### PR TITLE
fix: stop double-running system actions

### DIFF
--- a/pkg/controller/handlers/runs/runs.go
+++ b/pkg/controller/handlers/runs/runs.go
@@ -47,7 +47,7 @@ func (h *Handler) Resume(req router.Request, resp router.Response) error {
 	run := req.Object.(*v1.Run)
 	var thread v1.Thread
 
-	if run.Status.State.IsTerminal() || run.Status.State == gptscript.Continue {
+	if !run.Spec.Background || run.Status.State.IsTerminal() || run.Status.State == gptscript.Continue {
 		return nil
 	}
 

--- a/pkg/controller/handlers/uploads/onedrive.go
+++ b/pkg/controller/handlers/uploads/onedrive.go
@@ -113,6 +113,11 @@ func (u *UploadHandler) RunUpload(req router.Request, _ router.Response) error {
 		return err
 	}
 
+	go func() {
+		// Don't care about the events here, but we need to pull them out
+		r.Wait()
+	}()
+
 	oneDriveLinks.Status.RunName = r.Run.Name
 	return nil
 }

--- a/pkg/invoke/invoker.go
+++ b/pkg/invoke/invoker.go
@@ -544,7 +544,7 @@ func (i *Invoker) stream(ctx context.Context, c kclient.Client, events chan v1.P
 			select {
 			case <-saveCtx.Done():
 				return
-			case <-time.After(1 * time.Second):
+			case <-time.After(time.Second):
 				_ = i.saveState(ctx, c, thread, run, runResp, nil)
 			}
 		}

--- a/pkg/storage/services/config.go
+++ b/pkg/storage/services/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	//AuditLogPolicyFile string `usage:"Location of audit log policy file"`
 	DSN           string `usage:"Database dsn in driver://connection_string format" default:"sqlite://file:otto.db?_journal=WAL&cache=shared&_busy_timeout=30000"`
 	KnowledgeTool string `usage:"The knowledge tool to use" default:"github.com/gptscript-ai/knowledge" env:"KNOWLEDGE_TOOL"`
-	OneDriveTool  string `usage:"The OneDrive tool to use" default:"github.com/gptscript-ai/knowledge-onedrive-integration" env:"ONEDRIVE_TOOL"`
+	OneDriveTool  string `usage:"The OneDrive tool to use" default:"github.com/gptscript-ai/knowledge-onedrive-integration@otto" env:"ONEDRIVE_TOOL"`
 	HelperModel   string `usage:"The model used to generate names and descriptions" default:"gpt-4o-mini"`
 }
 


### PR DESCRIPTION
Additionally, this change updates the default onedrive tool to the otto-specific one.