### PR TITLE
fix: simplify the knowledge and onedrive api responses

### DIFF
--- a/pkg/api/types/types.go
+++ b/pkg/api/types/types.go
@@ -97,3 +97,29 @@ type InvokeResponse struct {
 }
 
 type Progress v1.Progress
+
+type KnowledgeFile struct {
+	FileName        string             `json:"fileName"`
+	AgentName       string             `json:"agentName,omitempty"`
+	WorkflowName    string             `json:"workflowName,omitempty"`
+	ThreadName      string             `json:"threadName,omitempty"`
+	UploadName      string             `json:"uploadName,omitempty"`
+	IngestionStatus v1.IngestionStatus `json:"ingestionStatus,omitempty"`
+	FileDetails     v1.FileDetails     `json:"fileDetails,omitempty"`
+	UploadID        string             `json:"uploadID,omitempty"`
+}
+
+type KnowledgeFileList List[KnowledgeFile]
+
+type OneDriveLinks struct {
+	AgentName    string       `json:"agentName,omitempty"`
+	WorkflowName string       `json:"workflowName,omitempty"`
+	SharedLinks  []string     `json:"sharedLinks,omitempty"`
+	ThreadName   string       `json:"threadName,omitempty"`
+	RunName      string       `json:"runName,omitempty"`
+	Status       string       `json:"output,omitempty"`
+	Error        string       `json:"error,omitempty"`
+	Folders      v1.FolderSet `json:"folders,omitempty"`
+}
+
+type OneDriveLinksList List[OneDriveLinks]

--- a/pkg/storage/apis/otto.gptscript.ai/v1/upload.go
+++ b/pkg/storage/apis/otto.gptscript.ai/v1/upload.go
@@ -52,9 +52,9 @@ type OneDriveLinksConnectorStatus struct {
 }
 
 type FileDetails struct {
-	FilePath  string `json:"filePath"`
-	URL       string `json:"url"`
-	UpdatedAt string `json:"updatedAt"`
+	FilePath  string `json:"filePath,omitempty"`
+	URL       string `json:"url,omitempty"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
 }
 
 type FolderSet map[string]Item


### PR DESCRIPTION
We shouldn't expose the Kubernetes stuff to the caller.