### PR TITLE
feat: add webhook authentication in the API

### DIFF
--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -201,10 +201,10 @@ func (r *Context) Update(obj client.Object) error {
 
 func (r *Context) Namespace() string {
 	if r.User.GetUID() != "" {
-		return r.User.GetUID()
+		return "u1" + r.User.GetUID()
 	}
 	if r.User.GetName() != "" {
-		return r.User.GetName()
+		return "u1" + r.User.GetName()
 	}
 	return "default"
 }

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -1,0 +1,39 @@
+package cookie
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+)
+
+type Auth struct {
+	next authenticator.Request
+}
+
+func New(next authenticator.Request) authenticator.Request {
+	return &Auth{
+		next: next,
+	}
+}
+
+func (c *Auth) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	if c.next == nil {
+		return nil, false, nil
+	}
+
+	token, ok := GetCookieToken(req)
+	if ok && token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	return c.next.AuthenticateRequest(req)
+}
+
+func GetCookieToken(req *http.Request) (string, bool) {
+	c, err := req.Cookie("A_SESS")
+	if err != nil {
+		return "", false
+	}
+
+	return c.Value, true
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,54 @@
+package webhook
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/acorn-io/baaah/pkg/ratelimit"
+	"github.com/acorn-io/baaah/pkg/restconfig"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
+	"k8s.io/apiserver/pkg/authentication/token/cache"
+	"k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/plugin/pkg/authenticator/token/webhook"
+	"k8s.io/client-go/rest"
+)
+
+func New(scheme *runtime.Scheme, webhookURL string) (authenticator.Request, error) {
+	restConfig, err := restCfg(webhookURL, scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	wh, err := webhook.New(restConfig, authenticationv1.SchemeGroupVersion.Version, nil, *options.DefaultAuthWebhookRetryBackoff())
+	if err != nil {
+		return nil, err
+	}
+
+	tokenCache := cache.New(wh, false, 10*time.Second, 10*time.Second)
+	return bearertoken.New(tokenCache), nil
+}
+
+func restCfg(serverURL string, scheme *runtime.Scheme) (*rest.Config, error) {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return nil, err
+	}
+	insecure := false
+	if u.Scheme == "https" && u.Host == "localhost" {
+		insecure = true
+	}
+
+	cfg := &rest.Config{
+		Host: serverURL,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: insecure,
+		},
+		RateLimiter: ratelimit.None,
+	}
+
+	restconfig.SetScheme(cfg, scheme)
+	return cfg, nil
+}


### PR DESCRIPTION
Authentication is off by default. Running with --token-webhook-url option will enable it. If enabled, unauthenticated requests are not allowed.