### PR TITLE
fix: make webhooks work with authentication enabled

### DIFF
--- a/apiclient/types/webhook.go
+++ b/apiclient/types/webhook.go
@@ -18,7 +18,8 @@ type WebhookManifest struct {
 }
 
 type WebhookExternalStatus struct {
-	RefNameAssigned bool `json:"refNameAssigned,omitempty"`
+	RefName         string `json:"refName,omitempty"`
+	RefNameAssigned bool   `json:"refNameAssigned,omitempty"`
 }
 
 type WebhookList List[Webhook]

--- a/pkg/controller/handlers/reference/webhookreference.go
+++ b/pkg/controller/handlers/reference/webhookreference.go
@@ -8,20 +8,35 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func AssociateWebhookWithReference(req router.Request, _ router.Response) error {
+func AssociateWebhookWithReference(req router.Request, resp router.Response) error {
 	wh := req.Object.(*v1.Webhook)
+	// Always create a webhook reference for this webhook.
+	resp.Objects(
+		&v1.WebhookReference{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: wh.Namespace + "-" + wh.Name,
+			},
+
+			Spec: v1.WebhookReferenceSpec{
+				WebhookName:      wh.Name,
+				WebhookNamespace: wh.Namespace,
+			},
+		},
+	)
+
 	if wh.Spec.RefName == "" {
 		return nil
 	}
 
 	ref := v1.WebhookReference{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: req.Namespace,
-			Name:      wh.Spec.RefName,
+			Name: wh.Spec.RefName,
 		},
 
 		Spec: v1.WebhookReferenceSpec{
-			WebhookName: wh.Name,
+			WebhookName:      wh.Name,
+			WebhookNamespace: wh.Namespace,
+			Custom:           true,
 		},
 	}
 
@@ -35,23 +50,28 @@ func AssociateWebhookWithReference(req router.Request, _ router.Response) error 
 	}
 
 	wh.Status.External.RefNameAssigned = existingRef.Spec == ref.Spec
+	if wh.Status.External.RefNameAssigned {
+		wh.Status.External.RefName = existingRef.Name
+	}
 	return nil
 }
 
 func Cleanup(req router.Request, _ router.Response) error {
 	whr := req.Object.(*v1.WebhookReference)
-	if whr.Spec.WebhookName == "" {
+	if whr.Spec.WebhookName == "" || whr.Spec.WebhookNamespace == "" {
 		return kclient.IgnoreNotFound(req.Delete(whr))
 	}
 
 	var webhook v1.Webhook
-	if err := req.Get(&webhook, whr.Namespace, whr.Spec.WebhookName); apierrors.IsNotFound(err) {
+	if err := req.Get(&webhook, whr.Spec.WebhookNamespace, whr.Spec.WebhookName); apierrors.IsNotFound(err) {
 		return kclient.IgnoreNotFound(req.Delete(whr))
 	} else if err != nil {
 		return err
 	}
 
-	if webhook.Spec.RefName != whr.Name {
+	// If the GenerateName field is set, then this is the "standard" webhook reference is that is associated to every
+	// webhook. We don't want to delete it here because it will be deleted when the webhook is deleted.
+	if whr.Spec.Custom && webhook.Spec.RefName != whr.Name {
 		return kclient.IgnoreNotFound(req.Delete(whr))
 	}
 

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -103,8 +103,11 @@ func routes(root *router.Router, svcs *services.Services) error {
 	// Webhooks
 	root.Type(&v1.Webhook{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.Webhook{}).HandlerFunc(reference.AssociateWebhookWithReference)
-	root.Type(&v1.WebhookReference{}).HandlerFunc(reference.Cleanup)
+	root.Type(&v1.Webhook{}).HandlerFunc(webHooks.AssignRefName)
 	root.Type(&v1.Webhook{}).HandlerFunc(webHooks.SetSuccessRunTime)
+
+	// Webhook references
+	root.Type(&v1.WebhookReference{}).HandlerFunc(reference.Cleanup)
 
 	// Cronjobs
 	root.Type(&v1.CronJob{}).HandlerFunc(cleanup.Cleanup)

--- a/pkg/storage/apis/otto.gptscript.ai/v1/webhookreference.go
+++ b/pkg/storage/apis/otto.gptscript.ai/v1/webhookreference.go
@@ -2,11 +2,13 @@ package v1
 
 import (
 	"github.com/acorn-io/baaah/pkg/conditions"
+	"github.com/acorn-io/baaah/pkg/fields"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
 	_ conditions.Conditions = (*WebhookReference)(nil)
+	_ fields.Fields         = (*WebhookReference)(nil)
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -19,12 +21,36 @@ type WebhookReference struct {
 	Status ReferenceStatus      `json:"status,omitempty"`
 }
 
+func (in *WebhookReference) Has(field string) bool {
+	return in.Get(field) != ""
+}
+
+func (in *WebhookReference) Get(field string) string {
+	switch field {
+	case "webhookNamespace":
+		return in.Spec.WebhookNamespace
+	case "webhookName":
+		return in.Spec.WebhookName
+	}
+	return ""
+}
+
+func (*WebhookReference) FieldNames() []string {
+	return []string{"webhookNamespace", "webhookName"}
+}
+
+func (*WebhookReference) NamespaceScoped() bool {
+	return false
+}
+
 func (in *WebhookReference) GetConditions() *[]metav1.Condition {
 	return &in.Status.Conditions
 }
 
 type WebhookReferenceSpec struct {
-	WebhookName string `json:"webhookName,omitempty"`
+	WebhookNamespace string `json:"webhookNamespace,omitempty"`
+	WebhookName      string `json:"webhookName,omitempty"`
+	Custom           bool   `json:"custom,omitempty"`
 }
 
 func (in *WebhookReference) DeleteRefs() []Ref {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -1843,6 +1843,12 @@ func schema_gptscript_ai_otto_apiclient_types_WebhookExternalStatus(ref common.R
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"refName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"refNameAssigned": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
@@ -4432,9 +4438,21 @@ func schema_storage_apis_ottogptscriptai_v1_WebhookReferenceSpec(ref common.Refe
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"webhookNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"webhookName": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"custom": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},


### PR DESCRIPTION
In order for webhooks to work with authentication enabled, they have to be globally accessible when they are executed. This change creates a non-namespaced object associated to each webhook to enable this flow.