### PR TITLE
Fix: Add uploadID to knowledge file

### DIFF
--- a/apiclient/types/knowledge.go
+++ b/apiclient/types/knowledge.go
@@ -10,6 +10,7 @@ type KnowledgeFile struct {
 	RemoteKnowledgeSourceType RemoteKnowledgeSourceType `json:"remoteKnowledgeSourceType,omitempty"`
 	IngestionStatus           IngestionStatus           `json:"ingestionStatus,omitempty"`
 	FileDetails               FileDetails               `json:"fileDetails,omitempty"`
+	UploadID                  string                    `json:"uploadID,omitempty"`
 }
 
 type FileDetails struct {

--- a/pkg/api/handlers/files.go
+++ b/pkg/api/handlers/files.go
@@ -125,6 +125,7 @@ func convertKnowledgeFile(file v1.KnowledgeFile, ws v1.Workspace) types.Knowledg
 		FileDetails:               file.Status.FileDetails,
 		RemoteKnowledgeSourceID:   file.Spec.RemoteKnowledgeSourceName,
 		RemoteKnowledgeSourceType: file.Spec.RemoteKnowledgeSourceType,
+		UploadID:                  file.Status.UploadID,
 	}
 }
 


### PR DESCRIPTION
We need to include uploadID in api response so that we can use it to make as exclude list.