### PR TITLE
chore: simplify the server router paths

### DIFF
--- a/pkg/gateway/server/routes.go
+++ b/pkg/gateway/server/routes.go
@@ -12,52 +12,51 @@ import (
 
 func (s *Server) AddRoutes(authed func(api.HandlerFunc) http.Handler, mux *http.ServeMux) {
 	// All the routes served by the API will start with `/api`
-	apiMux := http.NewServeMux()
-	apiMux.Handle("GET /me", authed(s.authFunc(types.RoleBasic)(s.getCurrentUser)))
-	apiMux.Handle("GET /users", authed(s.authFunc(types.RoleAdmin)(s.getUsers)))
-	apiMux.Handle("GET /users/{username}", authed(s.authFunc(types.RoleAdmin)(s.getUser)))
+	mux.Handle("GET /me", authed(s.authFunc(types.RoleBasic)(s.getCurrentUser)))
+	mux.Handle("GET /users", authed(s.authFunc(types.RoleAdmin)(s.getUsers)))
+	mux.Handle("GET /users/{username}", authed(s.authFunc(types.RoleAdmin)(s.getUser)))
 	// Any user can update their own username, admins can update any user
-	apiMux.Handle("PATCH /users/{username}", authed(s.authFunc(types.RoleBasic)(s.updateUser)))
-	apiMux.Handle("DELETE /users/{username}", authed(s.authFunc(types.RoleAdmin)(s.deleteUser)))
+	mux.Handle("PATCH /users/{username}", authed(s.authFunc(types.RoleBasic)(s.updateUser)))
+	mux.Handle("DELETE /users/{username}", authed(s.authFunc(types.RoleAdmin)(s.deleteUser)))
 
-	apiMux.HandleFunc("POST /token-request", s.tokenRequest)
-	apiMux.HandleFunc("GET /token-request/{id}", s.checkForToken)
-	apiMux.HandleFunc("GET /token-request/{id}/{service}", s.redirectForTokenRequest)
+	mux.HandleFunc("POST /token-request", s.tokenRequest)
+	mux.HandleFunc("GET /token-request/{id}", s.checkForToken)
+	mux.HandleFunc("GET /token-request/{id}/{service}", s.redirectForTokenRequest)
 
-	apiMux.Handle("GET /tokens", authed(s.authFunc(types.RoleBasic)(s.getTokens)))
-	apiMux.Handle("DELETE /tokens/{id}", authed(s.authFunc(types.RoleBasic)(s.deleteToken)))
-	apiMux.Handle("POST /tokens", authed(s.authFunc(types.RoleBasic)(s.newToken)))
+	mux.Handle("GET /tokens", authed(s.authFunc(types.RoleBasic)(s.getTokens)))
+	mux.Handle("DELETE /tokens/{id}", authed(s.authFunc(types.RoleBasic)(s.deleteToken)))
+	mux.Handle("POST /tokens", authed(s.authFunc(types.RoleBasic)(s.newToken)))
 
-	apiMux.HandleFunc("GET /supported-auth-types", func(writer http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /supported-auth-types", func(writer http.ResponseWriter, r *http.Request) {
 		writeResponse(r.Context(), kcontext.GetLogger(r.Context()), writer, types.SupportedAuthTypeConfigs())
 	})
-	apiMux.HandleFunc("GET /supported-oauth-app-types", func(writer http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /supported-oauth-app-types", func(writer http.ResponseWriter, r *http.Request) {
 		writeResponse(r.Context(), kcontext.GetLogger(r.Context()), writer, types.SupportedOAuthAppTypeConfigs())
 	})
 
-	apiMux.Handle("POST /auth-providers", authed(s.authFunc(types.RoleAdmin)(s.createAuthProvider)))
-	apiMux.Handle("PATCH /auth-providers/{slug}", authed(s.authFunc(types.RoleAdmin)(s.updateAuthProvider)))
-	apiMux.Handle("DELETE /auth-providers/{slug}", authed(s.authFunc(types.RoleAdmin)(s.deleteAuthProvider)))
-	apiMux.HandleFunc("GET /auth-providers", s.getAuthProviders)
-	apiMux.HandleFunc("GET /auth-providers/{slug}", s.getAuthProvider)
-	apiMux.Handle("POST /auth-providers/{slug}/disable", authed(s.authFunc(types.RoleAdmin)(s.disableAuthProvider)))
-	apiMux.Handle("POST /auth-providers/{slug}/enable", authed(s.authFunc(types.RoleAdmin)(s.enableAuthProvider)))
+	mux.Handle("POST /auth-providers", authed(s.authFunc(types.RoleAdmin)(s.createAuthProvider)))
+	mux.Handle("PATCH /auth-providers/{slug}", authed(s.authFunc(types.RoleAdmin)(s.updateAuthProvider)))
+	mux.Handle("DELETE /auth-providers/{slug}", authed(s.authFunc(types.RoleAdmin)(s.deleteAuthProvider)))
+	mux.HandleFunc("GET /auth-providers", s.getAuthProviders)
+	mux.HandleFunc("GET /auth-providers/{slug}", s.getAuthProvider)
+	mux.Handle("POST /auth-providers/{slug}/disable", authed(s.authFunc(types.RoleAdmin)(s.disableAuthProvider)))
+	mux.Handle("POST /auth-providers/{slug}/enable", authed(s.authFunc(types.RoleAdmin)(s.enableAuthProvider)))
 
-	apiMux.Handle("POST /llm-providers", authed(s.authFunc(types.RoleAdmin)(s.createLLMProvider)))
-	apiMux.Handle("PATCH /llm-providers/{slug}", authed(s.authFunc(types.RoleAdmin)(s.updateLLMProvider)))
-	apiMux.Handle("DELETE /llm-providers/{slug}", authed(s.authFunc(types.RoleAdmin)(s.deleteLLMProvider)))
-	apiMux.Handle("GET /llm-providers", authed(s.authFunc(types.RoleBasic)(s.getLLMProviders)))
-	apiMux.Handle("GET /llm-providers/{slug}", authed(s.authFunc(types.RoleBasic)(s.getLLMProvider)))
-	apiMux.Handle("POST /llm-providers/{slug}/disable", authed(s.authFunc(types.RoleAdmin)(s.disableLLMProvider)))
-	apiMux.Handle("POST /llm-providers/{slug}/enable", authed(s.authFunc(types.RoleAdmin)(s.enableLLMProvider)))
+	mux.Handle("POST /llm-providers", authed(s.authFunc(types.RoleAdmin)(s.createLLMProvider)))
+	mux.Handle("PATCH /llm-providers/{slug}", authed(s.authFunc(types.RoleAdmin)(s.updateLLMProvider)))
+	mux.Handle("DELETE /llm-providers/{slug}", authed(s.authFunc(types.RoleAdmin)(s.deleteLLMProvider)))
+	mux.Handle("GET /llm-providers", authed(s.authFunc(types.RoleBasic)(s.getLLMProviders)))
+	mux.Handle("GET /llm-providers/{slug}", authed(s.authFunc(types.RoleBasic)(s.getLLMProvider)))
+	mux.Handle("POST /llm-providers/{slug}/disable", authed(s.authFunc(types.RoleAdmin)(s.disableLLMProvider)))
+	mux.Handle("POST /llm-providers/{slug}/enable", authed(s.authFunc(types.RoleAdmin)(s.enableLLMProvider)))
 
-	apiMux.Handle("POST /models", authed(s.authFunc(types.RoleAdmin)(s.createModel)))
-	apiMux.Handle("PATCH /models/{id}", authed(s.authFunc(types.RoleAdmin)(s.updateModel)))
-	apiMux.Handle("DELETE /models/{id}", authed(s.authFunc(types.RoleAdmin)(s.deleteModel)))
-	apiMux.Handle("GET /models", authed(s.authFunc(types.RoleBasic)(s.getModels)))
-	apiMux.Handle("GET /models/{id}", authed(s.authFunc(types.RoleBasic)(s.getModel)))
-	apiMux.Handle("POST /models/{id}/disable", authed(s.authFunc(types.RoleAdmin)(s.disableModel)))
-	apiMux.Handle("POST /models/{id}/enable", authed(s.authFunc(types.RoleAdmin)(s.enableModel)))
+	mux.Handle("POST /models", authed(s.authFunc(types.RoleAdmin)(s.createModel)))
+	mux.Handle("PATCH /models/{id}", authed(s.authFunc(types.RoleAdmin)(s.updateModel)))
+	mux.Handle("DELETE /models/{id}", authed(s.authFunc(types.RoleAdmin)(s.deleteModel)))
+	mux.Handle("GET /models", authed(s.authFunc(types.RoleBasic)(s.getModels)))
+	mux.Handle("GET /models/{id}", authed(s.authFunc(types.RoleBasic)(s.getModel)))
+	mux.Handle("POST /models/{id}/disable", authed(s.authFunc(types.RoleAdmin)(s.disableModel)))
+	mux.Handle("POST /models/{id}/enable", authed(s.authFunc(types.RoleAdmin)(s.enableModel)))
 
 	oauthMux := http.NewServeMux()
 	oauthMux.HandleFunc("GET /start/{id}/{service}", s.oauth)
@@ -65,23 +64,21 @@ func (s *Server) AddRoutes(authed func(api.HandlerFunc) http.Handler, mux *http.
 	mux.Handle("/oauth/", http.StripPrefix("/oauth", apply(oauthMux, addRequestID, addLogger, logRequest, contentType("application/json"))))
 
 	// CRUD routes for OAuth Apps (integrations with other service such as Microsoft 365)
-	apiMux.Handle("GET /oauth-apps", authed(s.authFunc(types.RoleBasic)(s.listOAuthApps)))
-	apiMux.Handle("GET /oauth-apps/{id}", authed(s.authFunc(types.RoleBasic)(s.oauthAppByID)))
-	apiMux.Handle("POST /oauth-apps", authed(s.authFunc(types.RoleAdmin)(s.createOAuthApp)))
-	apiMux.Handle("PATCH /oauth-apps", authed(s.authFunc(types.RoleAdmin)(s.updateOAuthApp)))
-	apiMux.Handle("DELETE /oauth-apps/{id}", authed(s.authFunc(types.RoleAdmin)(s.deleteOAuthApp)))
+	mux.Handle("GET /oauth-apps", authed(s.authFunc(types.RoleBasic)(s.listOAuthApps)))
+	mux.Handle("GET /oauth-apps/{id}", authed(s.authFunc(types.RoleBasic)(s.oauthAppByID)))
+	mux.Handle("POST /oauth-apps", authed(s.authFunc(types.RoleAdmin)(s.createOAuthApp)))
+	mux.Handle("PATCH /oauth-apps", authed(s.authFunc(types.RoleAdmin)(s.updateOAuthApp)))
+	mux.Handle("DELETE /oauth-apps/{id}", authed(s.authFunc(types.RoleAdmin)(s.deleteOAuthApp)))
 
 	// Routes for OAuth authorization code flow
 	oauthAppsMux := http.NewServeMux()
-	oauthAppsMux.Handle("GET /{id}/authorize", authed(s.authorizeOAuthApp))
-	oauthAppsMux.Handle("GET /{id}/refresh", authed(s.refreshOAuthApp))
-	oauthAppsMux.Handle("GET /{id}/callback", authed(s.callbackOAuthApp))
-	mux.Handle("/oauth-apps/", http.StripPrefix("/oauth-apps", apply(oauthAppsMux, addRequestID, addLogger, logRequest, contentType("application/json"))))
+	oauthAppsMux.Handle("GET /authorize/{id}", authed(s.authorizeOAuthApp))
+	oauthAppsMux.Handle("GET /refresh/{id}", authed(s.refreshOAuthApp))
+	oauthAppsMux.Handle("GET /callback/{id}", authed(s.callbackOAuthApp))
+	mux.Handle("/app-oauth/", http.StripPrefix("/app-oauth", apply(oauthAppsMux, addRequestID, addLogger, logRequest, contentType("application/json"))))
 
 	// Route for credential tools to get their OAuth tokens
-	apiMux.Handle("GET /oauth-apps/get-token", authed(s.getTokenOAuthApp))
-
-	mux.Handle("/api/", http.StripPrefix("/api", apply(apiMux, addRequestID, addLogger, logRequest, contentType("application/json"))))
+	mux.Handle("GET /app-oauth/get-token", authed(s.getTokenOAuthApp))
 
 	// Handle the proxy to the LLM provider.
 	llmMux := http.NewServeMux()

--- a/pkg/storage/apis/otto.gptscript.ai/v1/oauthapp.go
+++ b/pkg/storage/apis/otto.gptscript.ai/v1/oauthapp.go
@@ -28,21 +28,21 @@ func (r *OAuthApp) RedirectURL(baseURL string) string {
 	if r.Status.External.RefName == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s/oauth-apps/%s/callback", baseURL, r.Status.External.RefName)
+	return fmt.Sprintf("%s/app-oauth/callback/%s", baseURL, r.Status.External.RefName)
 }
 
 func (r *OAuthApp) AuthorizeURL(baseURL string) string {
 	if r.Status.External.RefName == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s/oauth-apps/%s/authorize", baseURL, r.Status.External.RefName)
+	return fmt.Sprintf("%s/app-oauth/authorize/%s", baseURL, r.Status.External.RefName)
 }
 
 func (r *OAuthApp) RefreshURL(baseURL string) string {
 	if r.Status.External.RefName == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s/oauth-apps/%s/refresh", baseURL, r.Status.External.RefName)
+	return fmt.Sprintf("%s/app-oauth/refresh/%s", baseURL, r.Status.External.RefName)
 }
 
 func (r *OAuthApp) GetConditions() *[]metav1.Condition {


### PR DESCRIPTION
The two most important changes are:
- the gateway APIs is no longer served at /api
- the oauth app links are now /app-oauth/ACTION/{id}
- the oauth-apps flow is now /app-oauth