### PR TITLE
chore: revert change to return 404 status for thread knowledge

### DIFF
--- a/pkg/api/handlers/threads.go
+++ b/pkg/api/handlers/threads.go
@@ -261,7 +261,7 @@ func (a *ThreadHandler) Knowledge(req api.Context) error {
 		}
 	}
 
-	return types.NewErrHttp(http.StatusNotFound, fmt.Sprintf("no knowledge workspace found for thread %s", req.PathValue("id")))
+	return fmt.Errorf("no knowledge workspace found for thread %s", req.PathValue("id"))
 }
 
 func (a *ThreadHandler) UploadKnowledge(req api.Context) error {
@@ -281,7 +281,7 @@ func (a *ThreadHandler) UploadKnowledge(req api.Context) error {
 		}
 	}
 
-	return types.NewErrHttp(http.StatusBadRequest, fmt.Sprintf("no knowledge workspace found for thread %s", req.PathValue("id")))
+	return fmt.Errorf("no knowledge workspace found for thread %s", req.PathValue("id"))
 }
 
 func (a *ThreadHandler) DeleteKnowledge(req api.Context) error {
@@ -301,5 +301,5 @@ func (a *ThreadHandler) DeleteKnowledge(req api.Context) error {
 		}
 	}
 
-	return types.NewErrHttp(http.StatusBadRequest, fmt.Sprintf("no knowledge workspace found for thread %s", req.PathValue("id")))
+	return fmt.Errorf("no knowledge workspace found for thread %s", req.PathValue("id"))
 }


### PR DESCRIPTION
It turns out that the fact that threads didn't have knowledge was a bug. In which case, returning a 500 is the right thing because the lack of thread knowledge is a server-side issue.

This reverts commit af685f150d1db44a015219bc4f53e926776448fb.