### PR TITLE
fix: don't error when tool call has no metadata

### DIFF
--- a/ui/admin/app/components/chat/Message.tsx
+++ b/ui/admin/app/components/chat/Message.tsx
@@ -67,7 +67,7 @@ export function Message({ message }: MessageProps) {
                         )}
                     >
                         <div className="max-w-full overflow-hidden p-4 flex gap-2 items-center pl-[20px]">
-                            {toolCall?.metadata.icon && (
+                            {toolCall?.metadata?.icon && (
                                 <ToolIcon
                                     icon={toolCall.metadata.icon}
                                     category={toolCall.metadata.category}

--- a/ui/admin/app/lib/model/chatEvents.ts
+++ b/ui/admin/app/lib/model/chatEvents.ts
@@ -7,7 +7,7 @@ export type ToolCall = {
     name: string;
     description: string;
     input: string;
-    metadata: {
+    metadata?: {
         category?: string;
         icon?: string;
     };

--- a/ui/admin/app/lib/model/messages.ts
+++ b/ui/admin/app/lib/model/messages.ts
@@ -35,7 +35,7 @@ export const runsToMessages = (runs: Run[]) => {
 export const toolCallMessage = (toolCall: ToolCall) => {
     return {
         sender: "agent",
-        text: `Tool call: ${[toolCall.metadata.category, toolCall.name].filter((x) => !!x).join(" - ")}`,
+        text: `Tool call: ${[toolCall.metadata?.category, toolCall.name].filter((x) => !!x).join(" - ")}`,
         tools: [toolCall],
     } as Message;
 };

--- a/ui/admin/app/lib/model/toolReferences.ts
+++ b/ui/admin/app/lib/model/toolReferences.ts
@@ -5,7 +5,7 @@ export type ToolReferenceBase = {
     name: string;
     toolType: ToolReferenceType;
     reference: string;
-    metadata: Record<string, string>;
+    metadata?: Record<string, string>;
 };
 
 export type ToolReferenceType = "tool" | "stepTemplate";


### PR DESCRIPTION
This resolves an issue defined in #183 where tool calls with no metadata would cause an error when loading thread history. I am also updating the types to reflect metadata being potentially missing.