### PR TITLE
chore: add dev rule to start otto8 and the admin ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,8 @@ clean:
 build:
 	go build -o bin/otto -v
 
-.PHONY: ui build all clean
+dev: ui
+	@echo "Starting dev otto server and admin UI..."
+	./dev.sh
+
+.PHONY: ui build all clean dev

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+cleanup() {
+    echo "Terminating processes..."
+    kill 0
+}
+
+trap cleanup EXIT
+
+# Start the otto server
+go run main.go server --dev-mode 2>&1 | while IFS= read -r line; do
+    printf "\033[38;5;183m[server]\033[0m %s\n" "$line"
+done &
+otto_pid=$!
+
+# Start the admin UI
+cd ui/admin && VITE_API_IN_BROWSER=true npm run dev 2>&1 | while IFS= read -r line; do
+    printf "\033[38;5;153m[admin-ui]\033[0m %s\n" "$line"
+done &
+npm_pid=$!
+
+# Wait for both processes to finish
+wait "$otto_pid" "$npm_pid"


### PR DESCRIPTION
Add a make rule that starts the otto8 server and the admin UI in dev mode and interleaves their stdout/err.

<img width="1063" alt="Screenshot 2024-10-16 at 2 13 40 PM" src="https://github.com/user-attachments/assets/d52fb6d3-a0f6-424e-aafd-6141daef21b2">
