### PR TITLE
fix: remove id from event stream messages

### DIFF
--- a/ui/admin/app/lib/stream.ts
+++ b/ui/admin/app/lib/stream.ts
@@ -39,7 +39,10 @@ export async function readStream<T>({
 
             // Process complete messages
             for (const message of messages) {
-                const dataString = message.replace(/^data: /, "").trim();
+                const dataString = message
+                    .replace(/^id:.*\n/, "")
+                    .replace(/^data: /, "")
+                    .trim();
                 if (dataString) {
                     try {
                         const data = JSON.parse(dataString) as T;


### PR DESCRIPTION
This is a fix for issue #223. The event stream for messages included a new id entry that was not
expected by the client.