### PR TITLE
fix: preload agents and thread on agents screen

### DIFF
--- a/ui/admin/app/routes/_auth.agents._index.tsx
+++ b/ui/admin/app/routes/_auth.agents._index.tsx
@@ -4,7 +4,7 @@ import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
 import { SquarePen, Trash } from "lucide-react";
 import { useMemo } from "react";
 import { $path } from "remix-routes";
-import useSWR from "swr";
+import useSWR, { preload } from "swr";
 
 import { Agent } from "~/lib/model/agents";
 import { AgentService } from "~/lib/service/api/agentService";
@@ -22,6 +22,14 @@ import {
     TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { useAsync } from "~/hooks/useAsync";
+
+export async function clientLoader() {
+    await Promise.all([
+        preload(AgentService.getAgents.key(), AgentService.getAgents),
+        preload(ThreadsService.getThreads.key(), ThreadsService.getThreads),
+    ]);
+    return null;
+}
 
 export default function Threads() {
     const navigate = useNavigate();


### PR DESCRIPTION
This fixes an issue described in #202 where the agents that were listed would not always have the correct thread counts on the page. To fix this, we now preload the agents and threaads.