### PR TITLE
fix: prevent tool call info from overflowing

### DIFF
--- a/ui/admin/app/components/chat/ToolCallInfo.tsx
+++ b/ui/admin/app/components/chat/ToolCallInfo.tsx
@@ -18,7 +18,7 @@ export function ToolCallInfo({ tool, children }: ToolCallInfoProps) {
         <Popover>
             <PopoverTrigger asChild>{children}</PopoverTrigger>
             <PopoverContent className="w-80" side="left">
-                <div className="grid gap-4">
+                <div className="space-y-4">
                     <div className="space-y-2">
                         <h4 className="font-medium leading-none">
                             {tool.name}
@@ -27,7 +27,7 @@ export function ToolCallInfo({ tool, children }: ToolCallInfoProps) {
                             {tool.description}
                         </p>
                         <h3 className="text-sm font-medium">Input</h3>
-                        <p className="text-sm text-muted-foreground bg-gray-100 p-2 rounded-md">
+                        <p className="text-sm text-muted-foreground bg-gray-100 p-2 rounded-md text-wrap break-words">
                             {tool.input}
                         </p>
                     </div>


### PR DESCRIPTION
<img width="792" alt="Screenshot 2024-10-22 at 3 14 13 PM" src="https://github.com/user-attachments/assets/bf1ff8a3-9b2a-4ce8-b584-9c0a7c830549">
