### PR TITLE
Fix: Ignore not found error when deleting workspace files

### DIFF
--- a/pkg/controller/handlers/knowledge/knowledge.go
+++ b/pkg/controller/handlers/knowledge/knowledge.go
@@ -318,7 +318,8 @@ func (a *Handler) CleanupFile(req router.Request, resp router.Response) error {
 		return err
 	}
 
-	if err := a.gptscript.DeleteFileInWorkspace(req.Ctx, kFile.Spec.FileName, gptscript.DeleteFileInWorkspaceOptions{WorkspaceID: ws.Status.WorkspaceID}); err != nil {
+	var notFoundErr *gptscript.NotFoundInWorkspaceError
+	if err := a.gptscript.DeleteFileInWorkspace(req.Ctx, kFile.Spec.FileName, gptscript.DeleteFileInWorkspaceOptions{WorkspaceID: ws.Status.WorkspaceID}); err != nil && !errors.As(err, &notFoundErr) {
 		return err
 	}
 


### PR DESCRIPTION
When deleting file, we should ignore file not found error. Sometimes the file could already be deleted in workspace so this will make the file stuck at deleting.

https://github.com/otto8-ai/otto8/issues/290