### PR TITLE
fix: use different key for tool reference getters

### DIFF
--- a/ui/admin/app/lib/service/api/toolreferenceService.ts
+++ b/ui/admin/app/lib/service/api/toolreferenceService.ts
@@ -54,13 +54,8 @@ async function getToolReferencesCategoryMap(type?: ToolReferenceType) {
 }
 getToolReferencesCategoryMap.key = (type?: ToolReferenceType) =>
     ({
-        // tylerslaton: This is a workaround to make the SWR caching work
-        // nicely with the getToolReferences function. The reason we do this
-        // is because otherwise the SWR cache will not be invalidated between
-        // the two function calls and thus break type safety since types in
-        // TypeScript are erased at runtime. as-map=true does not exist in
-        // the API.
-        url: ApiRoutes.toolReferences.base({ type }).path + "?as-map=true",
+        url: ApiRoutes.toolReferences.base({ type }).path,
+        responseType: "map",
     }) as const;
 
 const getToolReferenceById = async (toolReferenceId: string) => {

--- a/ui/admin/app/routes/_auth.tools._index.tsx
+++ b/ui/admin/app/routes/_auth.tools._index.tsx
@@ -19,17 +19,19 @@ import { Input } from "~/components/ui/input";
 
 export async function clientLoader() {
     await Promise.all([
-        preload(ToolReferenceService.getToolReferences.key("tool"), () =>
-            ToolReferenceService.getToolReferences("tool")
+        preload(
+            ToolReferenceService.getToolReferencesCategoryMap.key("tool"),
+            () => ToolReferenceService.getToolReferencesCategoryMap("tool")
         ),
     ]);
     return null;
 }
 
 export default function Tools() {
-    const { data: tools, mutate } = useSWR(
-        ToolReferenceService.getToolReferences.key("tool"),
-        () => ToolReferenceService.getToolReferences("tool")
+    const { data: toolCategories, mutate } = useSWR(
+        ToolReferenceService.getToolReferencesCategoryMap.key("tool"),
+        () => ToolReferenceService.getToolReferencesCategoryMap("tool"),
+        { fallbackData: {} }
     );
 
     const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -79,9 +81,9 @@ export default function Tools() {
                 </div>
             </div>
 
-            {tools && (
+            {toolCategories && (
                 <ToolGrid
-                    tools={tools}
+                    toolCategories={toolCategories}
                     filter={searchQuery}
                     onDelete={handleDelete}
                 />


### PR DESCRIPTION
This is a workaround to make the SWR caching work nicely with the getToolReferences function. The reason we do this is because otherwise the SWR cache will not be invalidated between the two function calls and thus break type safety since types in TypeScript are erased at runtime. as-map=true does not exist in the API.

In addition, this PR also updates the ToolGrid to use the same getter as the ToolCatalog.

#292 