### PR TITLE
fix: address styling of knowledge cards in dark mode

### DIFF
--- a/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
+++ b/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
@@ -238,8 +238,8 @@ export function AgentKnowledgePanel({ agentId }: { agentId: string }) {
 
     return (
         <div className="flex flex-col gap-4 justify-center items-center">
-            <div className="flex w-full items-center justify-between gap-3 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:ring-transparent">
-                <div className="flex items-center gap-2">
+            <div className="flex w-full items-center justify-between gap-3 rounded-md bg-background px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-muted-foreground/20 focus-visible:ring-transparent">
+                <div className="flex items-center gap-2 text-foreground">
                     <UploadIcon className="h-5 w-5" />
                     <span className="text-lg font-semibold">Files</span>
                 </div>
@@ -260,12 +260,12 @@ export function AgentKnowledgePanel({ agentId }: { agentId: string }) {
                         className="flex items-center gap-2"
                         variant="ghost"
                     >
-                        <SettingsIcon className="h-5 w-5" />
+                        <SettingsIcon className="h-5 w-5 text-foreground" />
                     </Button>
                 </div>
             </div>
-            <div className="flex w-full items-center justify-between gap-3 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:ring-transparent">
-                <div className="flex items-center gap-2">
+            <div className="flex w-full items-center justify-between gap-3 rounded-md bg-background px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-muted-foreground/20 focus-visible:ring-transparent">
+                <div className="flex items-center gap-2 text-foreground">
                     <Avatar className="h-5 w-5">
                         <img src={assetUrl("/notion.svg")} alt="Notion logo" />
                     </Avatar>
@@ -286,12 +286,12 @@ export function AgentKnowledgePanel({ agentId }: { agentId: string }) {
                         className="flex items-center gap-2"
                         variant="ghost"
                     >
-                        <SettingsIcon className="h-5 w-5" />
+                        <SettingsIcon className="h-5 w-5 text-foreground" />
                     </Button>
                 </div>
             </div>
-            <div className="flex w-full items-center justify-between gap-3 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:ring-transparent">
-                <div className="flex items-center gap-2">
+            <div className="flex w-full items-center justify-between gap-3 rounded-md bg-background px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-muted-foreground/20 focus-visible:ring-transparent">
+                <div className="flex items-center gap-2 text-foreground">
                     <Avatar className="h-5 w-5">
                         <img
                             src={assetUrl("/onedrive.svg")}
@@ -315,12 +315,12 @@ export function AgentKnowledgePanel({ agentId }: { agentId: string }) {
                         className="flex items-center gap-2"
                         variant="ghost"
                     >
-                        <SettingsIcon className="h-5 w-5" />
+                        <SettingsIcon className="h-5 w-5 text-foreground" />
                     </Button>
                 </div>
             </div>
-            <div className="flex w-full items-center justify-between gap-3 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:ring-transparent">
-                <div className="flex items-center gap-2">
+            <div className="flex w-full items-center justify-between gap-3 rounded-md bg-background px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-muted-foreground/20 focus-visible:ring-transparent">
+                <div className="flex items-center gap-2 text-foreground">
                     <Globe className="h-5 w-5" />
                     <span className="text-lg font-semibold">Website</span>
                 </div>
@@ -339,7 +339,7 @@ export function AgentKnowledgePanel({ agentId }: { agentId: string }) {
                         className="flex items-center gap-2"
                         variant="ghost"
                     >
-                        <SettingsIcon className="h-5 w-5" />
+                        <SettingsIcon className="h-5 w-5 text-foreground" />
                     </Button>
                 </div>
             </div>


### PR DESCRIPTION
This was annoying me too much, I had to fix it 😅 

<img width="1464" alt="Screenshot 2024-10-24 at 10 29 09 AM" src="https://github.com/user-attachments/assets/7025866c-eefd-4cfe-bcb6-cf9c3f8b91fa">
<img width="1464" alt="Screenshot 2024-10-24 at 10 29 06 AM" src="https://github.com/user-attachments/assets/cb53ef94-d41d-49aa-896b-7cdb552ddd88">
