### PR TITLE
fix: set the server defaults earlier

### DIFF
--- a/pkg/gateway/server/server.go
+++ b/pkg/gateway/server/server.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/otto8-ai/otto8/pkg/gateway/client"
@@ -31,26 +29,6 @@ type Server struct {
 func New(ctx context.Context, db *db.DB, adminEmails []string, opts Options) (*Server, error) {
 	if err := db.AutoMigrate(); err != nil {
 		return nil, fmt.Errorf("auto migrate failed: %w", err)
-	}
-
-	if opts.GatewayDebug {
-		slog.SetLogLoggerLevel(slog.LevelDebug)
-	}
-
-	if opts.Hostname == "" {
-		opts.Hostname = "http://localhost:8080"
-	}
-	if opts.UIHostname == "" {
-		opts.UIHostname = opts.Hostname
-	}
-
-	if strings.HasPrefix(opts.Hostname, "localhost") || strings.HasPrefix(opts.Hostname, "127.0.0.1") {
-		opts.Hostname = "http://" + opts.Hostname
-	} else if !strings.HasPrefix(opts.Hostname, "http") {
-		opts.Hostname = "https://" + opts.Hostname
-	}
-	if !strings.HasPrefix(opts.UIHostname, "http") {
-		opts.UIHostname = "https://" + opts.UIHostname
 	}
 
 	adminEmailsSet := make(map[string]struct{}, len(adminEmails))

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,6 +119,26 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	if config.DevMode {
 		startDevMode(ctx, storageClient)
 		config.GatewayDebug = true
+	}
+
+	if config.GatewayDebug {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+	}
+
+	if config.Hostname == "" {
+		config.Hostname = "http://localhost:8080"
+	}
+	if config.UIHostname == "" {
+		config.UIHostname = config.Hostname
+	}
+
+	if strings.HasPrefix(config.Hostname, "localhost") || strings.HasPrefix(config.Hostname, "127.0.0.1") {
+		config.Hostname = "http://" + config.Hostname
+	} else if !strings.HasPrefix(config.Hostname, "http") {
+		config.Hostname = "https://" + config.Hostname
+	}
+	if !strings.HasPrefix(config.UIHostname, "http") {
+		config.UIHostname = "https://" + config.UIHostname
 	}
 
 	c, err := newGPTScript(ctx, config.WorkspaceTool)


### PR DESCRIPTION
The server defaults were being set when constructing the server. However, the invoker needs some of the same settings. This change will set the defaults earlier, so that it can be used in the invoker.