### PR TITLE
Fix: bypass not found error

### DIFF
--- a/pkg/controller/handlers/uploads/remoteknowledgesource.go
+++ b/pkg/controller/handlers/uploads/remoteknowledgesource.go
@@ -201,10 +201,10 @@ func (u *UploadHandler) HandleUploadRun(req router.Request, resp router.Response
 
 	file, err := u.gptscript.ReadFileInWorkspace(req.Ctx, ".metadata.json", gptscript.ReadFileInWorkspaceOptions{WorkspaceID: thread.Spec.WorkspaceID})
 	if err != nil {
-		// Purposely ignore not found errors.
-		if !strings.HasPrefix(err.Error(), "not found") {
-			return err
+		if strings.HasPrefix(err.Error(), "not found") {
+			return nil
 		}
+		return err
 	} else {
 		if err = json.Unmarshal(file, &metadata); err != nil {
 			return err

--- a/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
+++ b/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
@@ -149,12 +149,6 @@ export function AgentKnowledgePanel({ agentId }: { agentId: string }) {
     let notionSource = remoteKnowledgeSources.find(
         (source) => source.sourceType === "notion"
     );
-    const onedriveSource = remoteKnowledgeSources.find(
-        (source) => source.sourceType === "onedrive"
-    );
-    const websiteSource = remoteKnowledgeSources.find(
-        (source) => source.sourceType === "website"
-    );
 
     const onClickNotion = async () => {
         if (!notionSource) {
@@ -178,21 +172,10 @@ export function AgentKnowledgePanel({ agentId }: { agentId: string }) {
     };
 
     const onClickOnedrive = async () => {
-        if (!onedriveSource) {
-            await KnowledgeService.createRemoteKnowledgeSource(agentId, {
-                sourceType: "onedrive",
-            });
-        }
         setIsOnedriveModalOpen(true);
     };
 
     const onClickWebsite = async () => {
-        if (!websiteSource) {
-            await KnowledgeService.createRemoteKnowledgeSource(agentId, {
-                sourceType: "website",
-            });
-            getRemoteKnowledgeSources.mutate();
-        }
         setIsWebsiteModalOpen(true);
     };
 

--- a/ui/admin/app/components/knowledge/onedrive/AddLinkModal.tsx
+++ b/ui/admin/app/components/knowledge/onedrive/AddLinkModal.tsx
@@ -32,21 +32,30 @@ const AddLinkModal: FC<AddLinkModalProps> = ({
     const [newLink, setNewLink] = useState("");
 
     const handleSave = async () => {
-        if (!onedriveSource) return;
-
-        await KnowledgeService.updateRemoteKnowledgeSource(
-            agentId,
-            onedriveSource!.id,
-            {
-                ...onedriveSource,
+        if (!onedriveSource) {
+            await KnowledgeService.createRemoteKnowledgeSource(agentId, {
+                sourceType: "onedrive",
                 onedriveConfig: {
-                    sharedLinks: [
-                        ...(onedriveSource.onedriveConfig?.sharedLinks || []),
-                        newLink,
-                    ],
+                    sharedLinks: [newLink],
                 },
-            }
-        );
+            });
+        } else {
+            await KnowledgeService.updateRemoteKnowledgeSource(
+                agentId,
+                onedriveSource!.id,
+                {
+                    ...onedriveSource,
+                    onedriveConfig: {
+                        sharedLinks: [
+                            ...(onedriveSource.onedriveConfig?.sharedLinks ||
+                                []),
+                            newLink,
+                        ],
+                    },
+                }
+            );
+        }
+
         setNewLink("");
         startPolling();
         onOpenChange(false);

--- a/ui/admin/app/components/knowledge/onedrive/OneDriveModal.tsx
+++ b/ui/admin/app/components/knowledge/onedrive/OneDriveModal.tsx
@@ -390,23 +390,19 @@ export const OnedriveModal: FC<OnedriveModalProps> = ({
                         Close
                     </Button>
                 </div>
-                {onedriveSource && (
-                    <>
-                        <RemoteSourceSettingModal
-                            agentId={agentId}
-                            isOpen={isSettingModalOpen}
-                            onOpenChange={setIsSettingModalOpen}
-                            remoteKnowledgeSource={onedriveSource}
-                        />
-                        <AddLinkModal
-                            agentId={agentId}
-                            onedriveSource={onedriveSource}
-                            startPolling={startPolling}
-                            isOpen={isAddLinkModalOpen}
-                            onOpenChange={setIsAddLinkModalOpen}
-                        />
-                    </>
-                )}
+                <RemoteSourceSettingModal
+                    agentId={agentId}
+                    isOpen={isSettingModalOpen}
+                    onOpenChange={setIsSettingModalOpen}
+                    remoteKnowledgeSource={onedriveSource!}
+                />
+                <AddLinkModal
+                    agentId={agentId}
+                    onedriveSource={onedriveSource!}
+                    startPolling={startPolling}
+                    isOpen={isAddLinkModalOpen}
+                    onOpenChange={setIsAddLinkModalOpen}
+                />
             </DialogContent>
         </Dialog>
     );

--- a/ui/admin/app/components/knowledge/website/AddWebsiteModal.tsx
+++ b/ui/admin/app/components/knowledge/website/AddWebsiteModal.tsx
@@ -32,20 +32,30 @@ const AddWebsiteModal: FC<AddWebsiteModalProps> = ({
                 newWebsite.startsWith("https://")
                     ? newWebsite
                     : `https://${newWebsite}`;
-            await KnowledgeService.updateRemoteKnowledgeSource(
-                agentId,
-                websiteSource.id!,
-                {
+
+            if (!websiteSource) {
+                await KnowledgeService.createRemoteKnowledgeSource(agentId, {
                     sourceType: "website",
                     websiteCrawlingConfig: {
-                        urls: [
-                            ...(websiteSource.websiteCrawlingConfig?.urls ||
-                                []),
-                            formattedWebsite,
-                        ],
+                        urls: [formattedWebsite],
                     },
-                }
-            );
+                });
+            } else {
+                await KnowledgeService.updateRemoteKnowledgeSource(
+                    agentId,
+                    websiteSource.id!,
+                    {
+                        sourceType: "website",
+                        websiteCrawlingConfig: {
+                            urls: [
+                                ...(websiteSource.websiteCrawlingConfig?.urls ||
+                                    []),
+                                formattedWebsite,
+                            ],
+                        },
+                    }
+                );
+            }
             const intervalId = setInterval(() => {
                 startPolling();
                 if (websiteSource?.runID) {

--- a/ui/admin/app/components/knowledge/website/WebsiteModal.tsx
+++ b/ui/admin/app/components/knowledge/website/WebsiteModal.tsx
@@ -301,23 +301,19 @@ export const WebsiteModal: FC<WebsiteModalProps> = ({
                         Close
                     </Button>
                 </div>
-                {websiteSource && (
-                    <>
-                        <RemoteSourceSettingModal
-                            agentId={agentId}
-                            isOpen={isSettingModalOpen}
-                            onOpenChange={setIsSettingModalOpen}
-                            remoteKnowledgeSource={websiteSource}
-                        />
-                        <AddWebsiteModal
-                            agentId={agentId}
-                            websiteSource={websiteSource}
-                            startPolling={startPolling}
-                            isOpen={isAddWebsiteModalOpen}
-                            onOpenChange={setIsAddWebsiteModalOpen}
-                        />
-                    </>
-                )}
+                <RemoteSourceSettingModal
+                    agentId={agentId}
+                    isOpen={isSettingModalOpen}
+                    onOpenChange={setIsSettingModalOpen}
+                    remoteKnowledgeSource={websiteSource!}
+                />
+                <AddWebsiteModal
+                    agentId={agentId}
+                    websiteSource={websiteSource!}
+                    startPolling={startPolling}
+                    isOpen={isAddWebsiteModalOpen}
+                    onOpenChange={setIsAddWebsiteModalOpen}
+                />
             </DialogContent>
         </Dialog>
     );


### PR DESCRIPTION
If we don't find .metadata.json, just return and don't process. We have seen a weird issue that could be caused when metadata.json is not found and it is processing, leaving some files being deleted immediately after syncing. It seems to be caused by another "ghost" run with a different metadata.json.

It also moved the frontend logic to create actual data source when onedrive link and website link are added to avoid `ghost` runs for empty config.