### PR TITLE
Fix: Use uncache run version

### DIFF
--- a/pkg/controller/handlers/uploads/remoteknowledgesource.go
+++ b/pkg/controller/handlers/uploads/remoteknowledgesource.go
@@ -180,7 +180,7 @@ func (u *UploadHandler) HandleUploadRun(req router.Request, resp router.Response
 	}
 
 	var run v1.Run
-	if err := req.Get(&run, remoteKnowledgeSource.Namespace, remoteKnowledgeSource.Status.RunName); err != nil {
+	if err := req.Get(uncached.Get(&run), remoteKnowledgeSource.Namespace, remoteKnowledgeSource.Status.RunName); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Possibly use uncached version of run to avoid cache not available.