### PR TITLE
fix: address console errors for tool grid

### DIFF
--- a/ui/admin/app/components/tools/toolGrid/CategoryTools.tsx
+++ b/ui/admin/app/components/tools/toolGrid/CategoryTools.tsx
@@ -10,8 +10,12 @@ interface CategoryToolsProps {
 export function CategoryTools({ tools, onDelete }: CategoryToolsProps) {
     return (
         <div className="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {tools.map((tool) => (
-                <ToolCard key={tool.id} tool={tool} onDelete={onDelete} />
+            {tools.map((tool, index) => (
+                <ToolCard
+                    key={`${tool.id}-${index}`}
+                    tool={tool}
+                    onDelete={onDelete}
+                />
             ))}
         </div>
     );


### PR DESCRIPTION
The key for the tool card was not unique, so it was causing console errors.