### PR TITLE
Ui/feat/block-slack-oauth-app-config-when-using-http

### DIFF
--- a/ui/admin/app/components/oauth-apps/OAuthAppDetail.tsx
+++ b/ui/admin/app/components/oauth-apps/OAuthAppDetail.tsx
@@ -59,10 +59,16 @@ export function OAuthAppDetail({
                         <OAuthAppTypeIcon type={type} />
 
                         <span>{spec?.displayName}</span>
+
+                        {spec.disableConfiguration && (
+                            <span>is not configurable</span>
+                        )}
                     </DialogTitle>
                 </DialogHeader>
 
-                {spec?.customApp ? (
+                {spec.disableConfiguration ? (
+                    <DisabledContent spec={spec} />
+                ) : spec?.customApp ? (
                     <Content app={spec.customApp} spec={spec} />
                 ) : (
                     <EmptyContent spec={spec} />
@@ -70,6 +76,10 @@ export function OAuthAppDetail({
             </DialogContent>
         </Dialog>
     );
+}
+
+function DisabledContent({ spec }: { spec: OAuthAppSpec }) {
+    return <TypographyP>{spec.disabledReason}</TypographyP>;
 }
 
 function EmptyContent({ spec }: { spec: OAuthAppSpec }) {

--- a/ui/admin/app/components/oauth-apps/OAuthAppTile.tsx
+++ b/ui/admin/app/components/oauth-apps/OAuthAppTile.tsx
@@ -24,6 +24,10 @@ export function OAuthAppTile({
 
     const { displayName } = info;
 
+    if (info.type == "slack") {
+        console.log(info);
+    }
+
     const getSrc = () => {
         if (isDark) return info.darkLogo ?? info.logo;
         return info.logo;
@@ -44,12 +48,7 @@ export function OAuthAppTile({
                 })}
             />
 
-            {!info.disableConfiguration && (
-                <OAuthAppDetail
-                    type={type}
-                    className="absolute top-2 right-2"
-                />
-            )}
+            <OAuthAppDetail type={type} className="absolute top-2 right-2" />
         </Card>
     );
 }

--- a/ui/admin/app/lib/model/oauthApps/oauth-helpers.ts
+++ b/ui/admin/app/lib/model/oauthApps/oauth-helpers.ts
@@ -39,6 +39,7 @@ export type OAuthAppSpec = {
     darkLogo?: string;
     steps: OAuthFormStep[];
     disableConfiguration?: boolean;
+    disabledReason?: string;
     invertDark?: boolean;
 };
 

--- a/ui/admin/app/lib/model/oauthApps/providers/slack.ts
+++ b/ui/admin/app/lib/model/oauthApps/providers/slack.ts
@@ -26,7 +26,6 @@ const scopes = [
     "mpim:write",
     "im:write",
 ];
-// any changes to the OAuth & Permissions section will require the user to click `Reinstall to <Slack App Name>`
 
 const steps: OAuthFormStep<typeof schema.shape>[] = [
     {
@@ -116,6 +115,9 @@ const steps: OAuthFormStep<typeof schema.shape>[] = [
     },
 ];
 
+const disableConfiguration = !getOAuthLinks("slack")
+    .redirectURL.toLowerCase()
+    .startsWith("https");
 export const SlackOAuthApp = {
     schema,
     refName: "slack",
@@ -124,4 +126,8 @@ export const SlackOAuthApp = {
     logo: assetUrl("/assets/slack_logo_light.png"),
     darkLogo: assetUrl("/assets/slack_logo_dark.png"),
     steps,
+    disableConfiguration,
+    disabledReason: disableConfiguration
+        ? "Slack requires that redirect URLs start with `https`. Since this application is running on `http`, you will need to redeploy Otto using `https` in order to configure a custom Slack OAuth app."
+        : undefined,
 } satisfies OAuthAppSpec;


### PR DESCRIPTION
This PR prevents a user from configuring a slack OAuth app when the Api Base URL is using http

![Oct 29 Screenshot from Slack](https://github.com/user-attachments/assets/f613333f-706d-4485-b8b3-000bed0979c4)

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>