### PR TITLE
fix: remove 1password button for non-password inputs

### DIFF
--- a/ui/admin/app/components/ui/input.tsx
+++ b/ui/admin/app/components/ui/input.tsx
@@ -27,6 +27,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         return (
             <input
                 type={type}
+                data-1p-ignore={type !== "password"}
                 className={cn(inputVariants({ variant, className }))}
                 ref={ref}
                 {...props}


### PR DESCRIPTION
This automatically removes 1password button prompts for inputs that are not of type password.