### PR TITLE
chore: make auto-open in browser optional for dev rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,12 @@ clean:
 build:
 	CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/otto8 .
 
+
 dev:
-	./tools/dev.sh
+	./tools/dev.sh $(ARGS)
+
+dev-open: ARGS=--open-uis
+dev-open: dev
 
 # Lint the project
 lint: lint-admin
@@ -52,4 +56,4 @@ no-changes:
 		exit 1; \
 	fi
 
-.PHONY: ui ui-admin ui-user build all clean dev lint lint-admin lint-api no-changes fmt tidy
+.PHONY: ui ui-admin ui-user build all clean dev dev-open lint lint-admin lint-api no-changes fmt tidy

--- a/tools/dev.sh
+++ b/tools/dev.sh
@@ -2,6 +2,17 @@
 
 set -e # Exit on any command failure
 
+# Parse arguments for opening the user and admin UIs
+open_uis=false
+
+for arg in "$@"; do
+  case $arg in
+    --open-uis)
+      open_uis=true
+      ;;
+  esac
+done
+
 print_with_color() {
   local color_code=$1
   local color_message=$2
@@ -21,16 +32,15 @@ print_section_header() {
 }
 
 open_browser_tabs() {
-  if command -v open >/dev/null; then
-    echo "$@" | xargs -n 1 open
-  elif command -v xdg-open >/dev/null; then
-    echo "$@" | xargs -n 1 xdg-open
-  else
-    print_with_color 120 "Please open your browser to the following URLs: $(printf '%s ' "$@")"
-    return
+  if $open_uis; then
+    if command -v open >/dev/null; then
+      echo "$@" | xargs -n 1 open
+    elif command -v xdg-open >/dev/null; then
+      echo "$@" | xargs -n 1 xdg-open
+    fi
   fi
 
-  print_with_color 120 "The following URLs have been opened in your browser: [$(printf '%s ' "$@")]"
+  print_with_color 120 "UIs are accessible at: $(printf '%s ' "$@")"
 }
 
 cleanup() {


### PR DESCRIPTION
Add a new `dev-open` make rule that opens the admin/user UI in the
browser automatically. After this change `make dev` will no longer
open the browser.
