### PR TITLE
chore: Makefile updates and .dockerignore node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-node_modules/
+**/node_modules/
 otto8-tools/

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 default: build
 
 # All target
-all:
-	$(MAKE) ui
+all: ui
 	$(MAKE) build
 
 ui: ui-admin ui-user
@@ -44,9 +43,7 @@ lint-admin:
 package-tools:
 	./tools/package-tools.sh
 
-in-docker-build:
-	$(MAKE) all
-	$(MAKE) package-tools
+in-docker-build: all package-tools
 
 no-changes:
 	@if [ -n "$$(git status --porcelain)" ]; then \


### PR DESCRIPTION
Makefile update uses the targets as Make dependencies. This allows `make -j X <target>` to work more effectively. 

I noticed when doing local docker builds the node_modules directories were getting copied in.