### PR TITLE
fix: do not invert tool icons from /admin/assets

### DIFF
--- a/ui/admin/app/components/agent/ToolEntry.tsx
+++ b/ui/admin/app/components/agent/ToolEntry.tsx
@@ -3,9 +3,9 @@ import useSWR from "swr";
 
 import { ToolReferenceService } from "~/lib/service/api/toolreferenceService";
 
-import { ToolIcon } from "../tools/ToolIcon";
-import { LoadingSpinner } from "../ui/LoadingSpinner";
-import { Button } from "../ui/button";
+import { ToolIcon } from "~/components/tools/ToolIcon";
+import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
+import { Button } from "~/components/ui/button";
 
 export function ToolEntry({
     tool,

--- a/ui/admin/app/components/tools/ToolIcon.tsx
+++ b/ui/admin/app/components/tools/ToolIcon.tsx
@@ -24,7 +24,10 @@ export function ToolIcon(props: ToolIconProps) {
         <img
             alt={name}
             src={icon}
-            className={cn("w-6 h-6 dark:invert", className)}
+            className={cn("w-6 h-6", className, {
+                // icons served from /admin/assets are colored, so we should not invert them.
+                "dark:invert": !icon.startsWith("/admin/assets"),
+            })}
         />
     ) : (
         <WrenchIcon className={cn("w-4 h-4 mr-2", className)} />

--- a/ui/admin/app/components/tools/toolGrid/CategoryHeader.tsx
+++ b/ui/admin/app/components/tools/toolGrid/CategoryHeader.tsx
@@ -19,7 +19,7 @@ export function CategoryHeader({
 }: CategoryHeaderProps) {
     return (
         <div className="flex items-center space-x-4">
-            <div className="w-10 h-10 flex items-center justify-center bg-muted rounded-full mb-2 border">
+            <div className="w-10 h-10 flex items-center justify-center rounded-full mb-2 border">
                 {tools[0]?.metadata?.icon ? (
                     <ToolIcon
                         className="w-6 h-6"

--- a/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
+++ b/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
@@ -10,6 +10,7 @@ import {
     TypographySmall,
 } from "~/components/Typography";
 import { ConfirmationDialog } from "~/components/composed/ConfirmationDialog";
+import { ToolIcon } from "~/components/tools/ToolIcon";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import {
@@ -24,8 +25,6 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/tooltip";
-
-import { ToolIcon } from "../ToolIcon";
 
 interface ToolCardProps {
     tool: ToolReference;


### PR DESCRIPTION
Prior to this dark mode would invert the new colored icons. Instead, I'm just forgoing inverting tool icons that are served from the `/admin/assets` path.