### PR TITLE
chore: remove resp.Objects from controller implementations

### DIFF
--- a/pkg/controller/handlers/cleanup/cleanup.go
+++ b/pkg/controller/handlers/cleanup/cleanup.go
@@ -32,9 +32,15 @@ func Cleanup(req router.Request, _ router.Response) error {
 				ref.ObjType = new(v1.Reference)
 			}
 		}
-		if err := req.Get(ref.ObjType, req.Namespace, ref.Name); apierrors.IsNotFound(err) {
-			if err := req.Get(uncached.Get(ref.ObjType), req.Namespace, ref.Name); apierrors.IsNotFound(err) {
-				log.Infof("Deleting %s/%s due to missing %s", req.Namespace, req.Name, ref.Name)
+
+		namespace := req.Namespace
+		if namespace == "" && ref.Namespace != "" {
+			namespace = ref.Namespace
+		}
+
+		if err := req.Get(ref.ObjType, namespace, ref.Name); apierrors.IsNotFound(err) {
+			if err := req.Get(uncached.Get(ref.ObjType), namespace, ref.Name); apierrors.IsNotFound(err) {
+				log.Infof("Deleting %s/%s due to missing %s", namespace, req.Name, ref.Name)
 				return req.Delete(req.Object)
 			}
 		}

--- a/pkg/controller/handlers/reference/oauthappreference.go
+++ b/pkg/controller/handlers/reference/oauthappreference.go
@@ -3,14 +3,16 @@ package reference
 import (
 	"github.com/otto8-ai/nah/pkg/router"
 	v1 "github.com/otto8-ai/otto8/pkg/storage/apis/otto.otto8.ai/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func CreateGlobalOAuthAppReference(req router.Request, resp router.Response) error {
 	oa := req.Object.(*v1.OAuthApp)
-	// Always create an oauth app reference for this webhook.
-	resp.Objects(
-		&v1.OAuthAppReference{
+	var existing v1.OAuthAppReference
+	if err := req.Get(&existing, oa.Namespace, oa.Spec.Manifest.Integration); apierrors.IsNotFound(err) {
+		return kclient.IgnoreAlreadyExists(req.Client.Create(req.Ctx, &v1.OAuthAppReference{
 			ObjectMeta: metav1.ObjectMeta{
 				// TODO: This will have to change when we figure out how we want to do multitenancy.
 				Name: oa.Spec.Manifest.Integration,
@@ -20,8 +22,10 @@ func CreateGlobalOAuthAppReference(req router.Request, resp router.Response) err
 				AppName:      req.Name,
 				AppNamespace: req.Namespace,
 			},
-		},
-	)
+		}))
+	} else if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -109,6 +109,9 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.OAuthApp{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.OAuthApp{}).HandlerFunc(reference.CreateGlobalOAuthAppReference)
 
+	// OAuthAppReferences
+	root.Type(&v1.OAuthAppReference{}).HandlerFunc(cleanup.Cleanup)
+
 	// OAuthAppLogins
 	root.Type(&v1.OAuthAppLogin{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.OAuthAppLogin{}).HandlerFunc(oauthLogins.RunTool)

--- a/pkg/storage/apis/otto.otto8.ai/v1/knowledgeset.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/knowledgeset.go
@@ -34,8 +34,8 @@ func (in *KnowledgeSet) GetColumns() [][]string {
 
 func (in *KnowledgeSet) DeleteRefs() []Ref {
 	return []Ref{
-		{&Agent{}, in.Spec.AgentName},
-		{&Thread{}, in.Spec.ThreadName},
+		{ObjType: &Agent{}, Name: in.Spec.AgentName},
+		{ObjType: &Thread{}, Name: in.Spec.ThreadName},
 	}
 }
 

--- a/pkg/storage/apis/otto.otto8.ai/v1/oauthapp.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/oauthapp.go
@@ -97,6 +97,12 @@ func (*OAuthAppReference) NamespaceScoped() bool {
 	return false
 }
 
+func (r *OAuthAppReference) DeleteRefs() []Ref {
+	return []Ref{
+		{ObjType: new(OAuthApp), Name: r.Spec.AppName, Namespace: r.Spec.AppNamespace},
+	}
+}
+
 func (r *OAuthAppReference) Has(field string) bool {
 	return r.Get(field) != ""
 }

--- a/pkg/storage/apis/otto.otto8.ai/v1/refs.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/refs.go
@@ -5,6 +5,7 @@ import kclient "sigs.k8s.io/controller-runtime/pkg/client"
 // +k8s:deepcopy-gen=false
 
 type Ref struct {
-	ObjType kclient.Object
-	Name    string
+	ObjType   kclient.Object
+	Namespace string
+	Name      string
 }

--- a/pkg/storage/apis/otto.otto8.ai/v1/thread.go
+++ b/pkg/storage/apis/otto.otto8.ai/v1/thread.go
@@ -54,18 +54,18 @@ type ThreadSpec struct {
 
 func (in *Thread) DeleteRefs() []Ref {
 	refs := []Ref{
-		{&WorkflowExecution{}, in.Spec.WorkflowExecutionName},
-		{&Workflow{}, in.Spec.WorkflowName},
-		{&CronJob{}, in.Spec.CronJobName},
-		{&Webhook{}, in.Spec.WebhookName},
-		{&Thread{}, in.Status.PreviousThreadName},
-		{&KnowledgeSource{}, in.Spec.KnowledgeSourceName},
-		{&KnowledgeSet{}, in.Spec.KnowledgeSetName},
-		{&Workspace{}, in.Spec.WorkspaceName},
-		{&OAuthAppLogin{}, in.Spec.OAuthAppLoginName},
+		{ObjType: &WorkflowExecution{}, Name: in.Spec.WorkflowExecutionName},
+		{ObjType: &Workflow{}, Name: in.Spec.WorkflowName},
+		{ObjType: &CronJob{}, Name: in.Spec.CronJobName},
+		{ObjType: &Webhook{}, Name: in.Spec.WebhookName},
+		{ObjType: &Thread{}, Name: in.Status.PreviousThreadName},
+		{ObjType: &KnowledgeSource{}, Name: in.Spec.KnowledgeSourceName},
+		{ObjType: &KnowledgeSet{}, Name: in.Spec.KnowledgeSetName},
+		{ObjType: &Workspace{}, Name: in.Spec.WorkspaceName},
+		{ObjType: &OAuthAppLogin{}, Name: in.Spec.OAuthAppLoginName},
 	}
 	for _, name := range in.Spec.FromWorkspaceNames {
-		refs = append(refs, Ref{&Workspace{}, name})
+		refs = append(refs, Ref{ObjType: &Workspace{}, Name: name})
 	}
 	return refs
 }

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -4261,6 +4261,13 @@ func schema_storage_apis_ottootto8ai_v1_Ref(ref common.ReferenceCallback) common
 							Ref: ref("sigs.k8s.io/controller-runtime/pkg/client.Object"),
 						},
 					},
+					"Namespace": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"Name": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -4269,7 +4276,7 @@ func schema_storage_apis_ottootto8ai_v1_Ref(ref common.ReferenceCallback) common
 						},
 					},
 				},
-				Required: []string{"ObjType", "Name"},
+				Required: []string{"ObjType", "Namespace", "Name"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
This adds a Namespace field to the Ref object so that non-namespaced objects can be deleted with the cleanup controller.