### PR TITLE
feat: add and use ControlledAutosizeTextArea

### DIFF
--- a/ui/admin/app/components/agent/Agent.tsx
+++ b/ui/admin/app/components/agent/Agent.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from "react";
 import { Agent as AgentType } from "~/lib/model/agents";
 import { cn } from "~/lib/utils";
 
-import { TypographyP } from "~/components/Typography";
+import { TypographyH4, TypographyP } from "~/components/Typography";
 import { AgentProvider, useAgent } from "~/components/agent/AgentContext";
 import { AgentForm } from "~/components/agent/AgentForm";
 import { PastThreads } from "~/components/agent/PastThreads";
@@ -64,10 +64,10 @@ function AgentContent({ className, onRefresh }: AgentProps) {
                 </div>
 
                 <div className="p-4 flex-auto space-y-4">
-                    <span className="flex items-center gap-2 text-xl">
+                    <TypographyH4 className="flex items-center gap-2">
                         <WrenchIcon className="w-5 h-5" />
                         Tools
-                    </span>
+                    </TypographyH4>
                     <TypographyP className="text-muted-foreground flex items-center gap-2">
                         Add tools the allow the agent to perform useful actions
                         such as searching the web, reading files, or interacting
@@ -80,10 +80,10 @@ function AgentContent({ className, onRefresh }: AgentProps) {
                 </div>
 
                 <div className="p-4 flex-auto space-y-4">
-                    <span className="flex items-center gap-2 text-xl">
+                    <TypographyH4 className="flex items-center gap-2">
                         <LibraryIcon className="w-6 h-6" />
                         Knowledge
-                    </span>
+                    </TypographyH4>
                     <TypographyP className="text-muted-foreground flex items-center gap-2">
                         Provide knowledge to the agent in the form of files,
                         website, or external links in order to give it context

--- a/ui/admin/app/components/agent/AgentForm.tsx
+++ b/ui/admin/app/components/agent/AgentForm.tsx
@@ -1,13 +1,17 @@
 import { zodResolver } from "@hookform/resolvers/zod";
+import { BrainIcon } from "lucide-react";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { Agent } from "~/lib/model/agents";
 
+import { TypographyH4 } from "~/components/Typography";
+import {
+    ControlledAutosizeTextarea,
+    ControlledInput,
+} from "~/components/form/controlledInputs";
 import { Form } from "~/components/ui/form";
-
-import { ControlledInput, ControlledTextarea } from "../form/controlledInputs";
 
 const formSchema = z.object({
     name: z.string().min(1, {
@@ -74,11 +78,15 @@ export function AgentForm({ agent, onSubmit, onChange }: AgentFormProps) {
                     placeholder="Add a description..."
                     className="text-xl text-muted-foreground"
                 />
-                <ControlledTextarea
+                <TypographyH4 className="flex items-center gap-2">
+                    <BrainIcon className="w-5 h-5" />
+                    Instructions
+                </TypographyH4>
+                <ControlledAutosizeTextarea
                     control={form.control}
                     autoComplete="off"
                     name="prompt"
-                    label="Instructions"
+                    maxHeight={300}
                     placeholder="Give the agent instructions on how to behave and respond to input."
                 />
             </form>

--- a/ui/admin/app/components/form/controlledInputs.tsx
+++ b/ui/admin/app/components/form/controlledInputs.tsx
@@ -18,7 +18,12 @@ import {
     FormMessage,
 } from "~/components/ui/form";
 import { Input, InputProps } from "~/components/ui/input";
-import { Textarea, TextareaProps } from "~/components/ui/textarea";
+import {
+    AutosizeTextAreaProps,
+    AutosizeTextarea,
+    Textarea,
+    TextareaProps,
+} from "~/components/ui/textarea";
 
 type BaseProps<
     TValues extends FieldValues,
@@ -112,6 +117,53 @@ export function ControlledTextarea<
 
                     <FormControl>
                         <Textarea
+                            {...field}
+                            {...inputProps}
+                            className={cn(
+                                getFieldStateClasses(fieldState),
+                                className
+                            )}
+                        />
+                    </FormControl>
+
+                    <FormMessage />
+                </FormItem>
+            )}
+        />
+    );
+}
+
+export type ControlledAutosizeTextareaProps<
+    TValues extends FieldValues,
+    TName extends FieldPath<TValues>,
+> = Omit<AutosizeTextAreaProps, keyof ControllerRenderProps<TValues, TName>> &
+    BaseProps<TValues, TName>;
+
+export function ControlledAutosizeTextarea<
+    TValues extends FieldValues,
+    TName extends FieldPath<TValues>,
+>({
+    control,
+    name,
+    label,
+    description,
+    className,
+    ...inputProps
+}: ControlledAutosizeTextareaProps<TValues, TName>) {
+    return (
+        <FormField
+            control={control}
+            name={name}
+            render={({ field, fieldState }) => (
+                <FormItem>
+                    {label && <FormLabel>{label}</FormLabel>}
+
+                    {description && (
+                        <FormDescription>{description}</FormDescription>
+                    )}
+
+                    <FormControl>
+                        <AutosizeTextarea
                             {...field}
                             {...inputProps}
                             className={cn(

--- a/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
+++ b/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
@@ -15,7 +15,7 @@ import { Button } from "~/components/ui/button";
 
 import { Avatar } from "../ui/avatar";
 import { Label } from "../ui/label";
-import { Textarea } from "../ui/textarea";
+import { AutosizeTextarea } from "../ui/textarea";
 import FileModal from "./file/FileModal";
 import { NotionModal } from "./notion/NotionModal";
 import { OnedriveModal } from "./onedrive/OneDriveModal";
@@ -366,7 +366,8 @@ export default function AgentKnowledgePanel({
         <div className="flex flex-col gap-4 justify-center items-center">
             <div className="grid w-full gap-2">
                 <Label htmlFor="message">Knowledge Description</Label>
-                <Textarea
+                <AutosizeTextarea
+                    maxHeight={200}
                     placeholder="Provide a brief description of the information contained in this knowledge base. Example: A collection of documents about the human resources policies and procedures for Acme Corporation."
                     id="message"
                     value={knowledgeDescription ?? ""}

--- a/ui/admin/app/components/ui/textarea.tsx
+++ b/ui/admin/app/components/ui/textarea.tsx
@@ -68,7 +68,7 @@ export type AutosizeTextAreaRef = {
     minHeight: number;
 };
 
-type AutosizeTextAreaProps = {
+export type AutosizeTextAreaProps = {
     maxHeight?: number;
     minHeight?: number;
 } & React.TextareaHTMLAttributes<HTMLTextAreaElement>;


### PR DESCRIPTION
https://github.com/user-attachments/assets/2f619e03-f503-41f9-b8cd-b741e1501592

Adding and using a ControlledAutosizeTextArea for the agent form. Along with this, I am adding:
- Updated labels that use our existing typography components
- A new label for instructions to make it look more integrated
- The knowledge agent panel now uses the AutosizeTextArea for its description field