### PR TITLE
chore: add linter rule for no relative imports and fix issues

### DIFF
--- a/ui/admin/.eslintrc.cjs
+++ b/ui/admin/.eslintrc.cjs
@@ -50,6 +50,18 @@ module.exports = {
             },
             rules: {
                 "react/prop-types": "off",
+                "no-restricted-imports": [
+                    "error",
+                    {
+                        patterns: [
+                            {
+                                group: [".*"],
+                                message:
+                                    "Please use absolute imports (~/component) instead of relative imports (../../component).",
+                            },
+                        ],
+                    },
+                ],
             },
         },
 

--- a/ui/admin/app/components/chat/Message.tsx
+++ b/ui/admin/app/components/chat/Message.tsx
@@ -9,15 +9,14 @@ import { OAuthPrompt } from "~/lib/model/chatEvents";
 import { Message as MessageType } from "~/lib/model/messages";
 import { cn } from "~/lib/utils";
 
+import { TypographyP } from "~/components/Typography";
 import { MessageDebug } from "~/components/chat/MessageDebug";
+import { ToolCallInfo } from "~/components/chat/ToolCallInfo";
 import { CustomMarkdownComponents } from "~/components/react-markdown";
 import { ToolIcon } from "~/components/tools/ToolIcon";
 import { Button } from "~/components/ui/button";
 import { Card } from "~/components/ui/card";
 import { TypingDots } from "~/components/ui/typing-spinner";
-
-import { TypographyP } from "../Typography";
-import { ToolCallInfo } from "./ToolCallInfo";
 
 interface MessageProps {
     message: MessageType;

--- a/ui/admin/app/components/chat/MessageDebug.tsx
+++ b/ui/admin/app/components/chat/MessageDebug.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Calls } from "~/lib/model/runs";
 import { RunsService } from "~/lib/service/api/runsService";
 
+import CallFrames from "~/components/chat/CallFrames";
 import { Button, ButtonProps } from "~/components/ui/button";
 import {
     Dialog,
@@ -19,8 +20,6 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/tooltip";
-
-import CallFrames from "./CallFrames";
 
 type MessageDebugProps = {
     runId: string;

--- a/ui/admin/app/components/chat/MessagePane.tsx
+++ b/ui/admin/app/components/chat/MessagePane.tsx
@@ -2,12 +2,11 @@ import { ToolCall } from "~/lib/model/chatEvents";
 import { Message as MessageType } from "~/lib/model/messages";
 import { cn } from "~/lib/utils";
 
+import { useChat } from "~/components/chat/ChatContext";
 import { Message } from "~/components/chat/Message";
 import { NoMessages } from "~/components/chat/NoMessages";
+import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 import { ScrollArea } from "~/components/ui/scroll-area";
-
-import { LoadingSpinner } from "../ui/LoadingSpinner";
-import { useChat } from "./ChatContext";
 
 interface MessagePaneProps {
     messages: MessageType[];

--- a/ui/admin/app/components/chat/index.tsx
+++ b/ui/admin/app/components/chat/index.tsx
@@ -1,5 +1,5 @@
-export { Chat } from "./Chat";
-export { Chatbar } from "./Chatbar";
-export { MessagePane } from "./MessagePane";
-export { Message } from "./Message";
-export { ChatProvider, useChat } from "./ChatContext";
+export { Chat } from "~/components/chat/Chat";
+export { Chatbar } from "~/components/chat/Chatbar";
+export { MessagePane } from "~/components/chat/MessagePane";
+export { Message } from "~/components/chat/Message";
+export { ChatProvider, useChat } from "~/components/chat/ChatContext";

--- a/ui/admin/app/components/composed/DataTable.tsx
+++ b/ui/admin/app/components/composed/DataTable.tsx
@@ -17,7 +17,7 @@ import {
     TableHead,
     TableHeader,
     TableRow,
-} from "../ui/table";
+} from "~/components/ui/table";
 
 interface DataTableProps<TData, TValue> {
     columns: ColumnDef<TData, TValue>[];

--- a/ui/admin/app/components/header/HeaderNav.tsx
+++ b/ui/admin/app/components/header/HeaderNav.tsx
@@ -15,9 +15,8 @@ import {
     BreadcrumbPage,
     BreadcrumbSeparator,
 } from "~/components/ui/breadcrumb";
-
-import { SidebarTrigger } from "../ui/sidebar";
-import { UserMenu } from "../user/UserMenu";
+import { SidebarTrigger } from "~/components/ui/sidebar";
+import { UserMenu } from "~/components/user/UserMenu";
 
 export function HeaderNav() {
     const { pathname } = useLocation();

--- a/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
+++ b/ui/admin/app/components/knowledge/AgentKnowledgePanel.tsx
@@ -11,15 +11,14 @@ import {
 import { KnowledgeService } from "~/lib/service/api/knowledgeService";
 import { assetUrl } from "~/lib/utils";
 
+import FileModal from "~/components/knowledge/file/FileModal";
+import { NotionModal } from "~/components/knowledge/notion/NotionModal";
+import { OnedriveModal } from "~/components/knowledge/onedrive/OneDriveModal";
+import { WebsiteModal } from "~/components/knowledge/website/WebsiteModal";
+import { Avatar } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
-
-import { Avatar } from "../ui/avatar";
-import { Label } from "../ui/label";
-import { AutosizeTextarea } from "../ui/textarea";
-import FileModal from "./file/FileModal";
-import { NotionModal } from "./notion/NotionModal";
-import { OnedriveModal } from "./onedrive/OneDriveModal";
-import { WebsiteModal } from "./website/WebsiteModal";
+import { Label } from "~/components/ui/label";
+import { AutosizeTextarea } from "~/components/ui/textarea";
 
 type AgentKnowledgePanelProps = {
     agentId: string;

--- a/ui/admin/app/components/knowledge/FileItem.tsx
+++ b/ui/admin/app/components/knowledge/FileItem.tsx
@@ -5,15 +5,14 @@ import { KnowledgeService } from "~/lib/service/api/knowledgeService";
 import { cn } from "~/lib/utils";
 
 import { TypographyP } from "~/components/Typography";
+import FileStatusIcon from "~/components/knowledge/FileStatusIcon";
+import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 import { Button } from "~/components/ui/button";
 import {
     Tooltip,
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/tooltip";
-
-import { LoadingSpinner } from "../ui/LoadingSpinner";
-import FileStatusIcon from "./FileStatusIcon";
 
 type FileItemProps = {
     file: KnowledgeFile;

--- a/ui/admin/app/components/knowledge/FileStatusIcon.tsx
+++ b/ui/admin/app/components/knowledge/FileStatusIcon.tsx
@@ -7,14 +7,13 @@ import {
 } from "~/lib/model/knowledge";
 import { cn } from "~/lib/utils";
 
+import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 import {
     Tooltip,
     TooltipContent,
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/tooltip";
-
-import { LoadingSpinner } from "../ui/LoadingSpinner";
 
 const fileStateIcons: Record<KnowledgeFileState, [React.ElementType, string]> =
     {

--- a/ui/admin/app/components/knowledge/IngestionStatus.tsx
+++ b/ui/admin/app/components/knowledge/IngestionStatus.tsx
@@ -2,14 +2,13 @@ import { CheckIcon } from "lucide-react";
 
 import { KnowledgeFile, KnowledgeFileState } from "~/lib/model/knowledge";
 
+import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 import {
     Tooltip,
     TooltipContent,
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/tooltip";
-
-import { LoadingSpinner } from "../ui/LoadingSpinner";
 
 interface IngestionStatusProps {
     files: KnowledgeFile[];

--- a/ui/admin/app/components/knowledge/RemoteFileItemChip.tsx
+++ b/ui/admin/app/components/knowledge/RemoteFileItemChip.tsx
@@ -6,16 +6,15 @@ import {
 import { cn } from "~/lib/utils";
 
 import { TypographyP } from "~/components/Typography";
+import FileStatusIcon from "~/components/knowledge/FileStatusIcon";
+import RemoteFileAvatar from "~/components/knowledge/RemoteFileAvatar";
+import { Button } from "~/components/ui/button";
 import {
     Tooltip,
     TooltipContent,
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/tooltip";
-
-import { Button } from "../ui/button";
-import FileStatusIcon from "./FileStatusIcon";
-import RemoteFileAvatar from "./RemoteFileAvatar";
 
 type RemoteFileItemProps = {
     file: KnowledgeFile;

--- a/ui/admin/app/components/knowledge/RemoteKnowledgeSourceStatus.tsx
+++ b/ui/admin/app/components/knowledge/RemoteKnowledgeSourceStatus.tsx
@@ -6,9 +6,8 @@ import {
     RemoteKnowledgeSourceType,
 } from "~/lib/model/knowledge";
 
+import RemoteFileAvatar from "~/components/knowledge/RemoteFileAvatar";
 import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
-
-import RemoteFileAvatar from "./RemoteFileAvatar";
 
 interface RemoteKnowledgeSourceStatusProps {
     source: KnowledgeSource | undefined;

--- a/ui/admin/app/components/knowledge/file/FileModal.tsx
+++ b/ui/admin/app/components/knowledge/file/FileModal.tsx
@@ -5,6 +5,8 @@ import { KnowledgeFile } from "~/lib/model/knowledge";
 import { KnowledgeService } from "~/lib/service/api/knowledgeService";
 import { cn } from "~/lib/utils";
 
+import { FileChip } from "~/components/knowledge/FileItem";
+import IngestionStatusComponent from "~/components/knowledge/IngestionStatus";
 import { Button } from "~/components/ui/button";
 import {
     Dialog,
@@ -23,9 +25,6 @@ import {
 } from "~/components/ui/tooltip";
 import { useAsync } from "~/hooks/useAsync";
 import { useMultiAsync } from "~/hooks/useMultiAsync";
-
-import { FileChip } from "../FileItem";
-import IngestionStatusComponent from "../IngestionStatus";
 
 interface FileModalProps {
     agentId: string;

--- a/ui/admin/app/components/knowledge/index.ts
+++ b/ui/admin/app/components/knowledge/index.ts
@@ -1,3 +1,3 @@
-import AgentKnowledgePanel from "./AgentKnowledgePanel";
+import AgentKnowledgePanel from "~/components/knowledge/AgentKnowledgePanel";
 
 export { AgentKnowledgePanel };

--- a/ui/admin/app/components/knowledge/notion/NotionModal.tsx
+++ b/ui/admin/app/components/knowledge/notion/NotionModal.tsx
@@ -10,6 +10,7 @@ import {
 import { KnowledgeService } from "~/lib/service/api/knowledgeService";
 import { assetUrl } from "~/lib/utils";
 
+import IngestionStatusComponent from "~/components/knowledge/IngestionStatus";
 import RemoteFileItemChip from "~/components/knowledge/RemoteFileItemChip";
 import RemoteKnowledgeSourceStatus from "~/components/knowledge/RemoteKnowledgeSourceStatus";
 import RemoteSourceSettingModal from "~/components/knowledge/RemoteSourceSettingModal";
@@ -29,8 +30,6 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/tooltip";
-
-import IngestionStatusComponent from "../IngestionStatus";
 
 type NotionModalProps = {
     agentId: string;

--- a/ui/admin/app/components/knowledge/onedrive/OneDriveModal.tsx
+++ b/ui/admin/app/components/knowledge/onedrive/OneDriveModal.tsx
@@ -19,7 +19,11 @@ import {
 import { KnowledgeService } from "~/lib/service/api/knowledgeService";
 import { assetUrl } from "~/lib/utils";
 
+import IngestionStatusComponent from "~/components/knowledge/IngestionStatus";
+import RemoteFileItemChip from "~/components/knowledge/RemoteFileItemChip";
 import RemoteKnowledgeSourceStatus from "~/components/knowledge/RemoteKnowledgeSourceStatus";
+import RemoteSourceSettingModal from "~/components/knowledge/RemoteSourceSettingModal";
+import AddLinkModal from "~/components/knowledge/onedrive/AddLinkModal";
 import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 import { Avatar } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
@@ -31,11 +35,6 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/tooltip";
-
-import IngestionStatusComponent from "../IngestionStatus";
-import RemoteFileItemChip from "../RemoteFileItemChip";
-import RemoteSourceSettingModal from "../RemoteSourceSettingModal";
-import AddLinkModal from "./AddLinkModal";
 
 interface OnedriveModalProps {
     agentId: string;

--- a/ui/admin/app/components/knowledge/website/WebsiteModal.tsx
+++ b/ui/admin/app/components/knowledge/website/WebsiteModal.tsx
@@ -17,6 +17,11 @@ import {
 } from "~/lib/model/knowledge";
 import { KnowledgeService } from "~/lib/service/api/knowledgeService";
 
+import IngestionStatusComponent from "~/components/knowledge/IngestionStatus";
+import RemoteFileItemChip from "~/components/knowledge/RemoteFileItemChip";
+import RemoteKnowledgeSourceStatus from "~/components/knowledge/RemoteKnowledgeSourceStatus";
+import RemoteSourceSettingModal from "~/components/knowledge/RemoteSourceSettingModal";
+import AddWebsiteModal from "~/components/knowledge/website/AddWebsiteModal";
 import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 import { Avatar } from "~/components/ui/avatar";
 import { Button } from "~/components/ui/button";
@@ -27,12 +32,6 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "~/components/ui/tooltip";
-
-import IngestionStatusComponent from "../IngestionStatus";
-import RemoteFileItemChip from "../RemoteFileItemChip";
-import RemoteKnowledgeSourceStatus from "../RemoteKnowledgeSourceStatus";
-import RemoteSourceSettingModal from "../RemoteSourceSettingModal";
-import AddWebsiteModal from "./AddWebsiteModal";
 
 interface WebsiteModalProps {
     agentId: string;

--- a/ui/admin/app/components/oauth-apps/ConfigureOAuthApp.tsx
+++ b/ui/admin/app/components/oauth-apps/ConfigureOAuthApp.tsx
@@ -6,6 +6,8 @@ import { OAuthAppParams } from "~/lib/model/oauthApps";
 import { OAuthProvider } from "~/lib/model/oauthApps/oauth-helpers";
 import { OauthAppService } from "~/lib/service/api/oauthAppService";
 
+import { OAuthAppForm } from "~/components/oauth-apps/OAuthAppForm";
+import { OAuthAppTypeIcon } from "~/components/oauth-apps/OAuthAppTypeIcon";
 import { Button } from "~/components/ui/button";
 import {
     Dialog,
@@ -18,9 +20,6 @@ import { ScrollArea } from "~/components/ui/scroll-area";
 import { useOAuthAppInfo } from "~/hooks/oauthApps/useOAuthApps";
 import { useAsync } from "~/hooks/useAsync";
 import { useDisclosure } from "~/hooks/useDisclosure";
-
-import { OAuthAppForm } from "./OAuthAppForm";
-import { OAuthAppTypeIcon } from "./OAuthAppTypeIcon";
 
 export function ConfigureOAuthApp({
     type,

--- a/ui/admin/app/components/oauth-apps/OAuthAppDetail.tsx
+++ b/ui/admin/app/components/oauth-apps/OAuthAppDetail.tsx
@@ -9,6 +9,9 @@ import {
 import { cn } from "~/lib/utils";
 
 import { TypographyP } from "~/components/Typography";
+import { ConfigureOAuthApp } from "~/components/oauth-apps/ConfigureOAuthApp";
+import { DeleteOAuthApp } from "~/components/oauth-apps/DeleteOAuthApp";
+import { OAuthAppTypeIcon } from "~/components/oauth-apps/OAuthAppTypeIcon";
 import { Button } from "~/components/ui/button";
 import {
     Dialog,
@@ -20,17 +23,13 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "~/components/ui/dialog";
-import { useOAuthAppInfo } from "~/hooks/oauthApps/useOAuthApps";
-
 import {
     Tooltip,
     TooltipContent,
     TooltipProvider,
     TooltipTrigger,
-} from "../ui/tooltip";
-import { ConfigureOAuthApp } from "./ConfigureOAuthApp";
-import { DeleteOAuthApp } from "./DeleteOAuthApp";
-import { OAuthAppTypeIcon } from "./OAuthAppTypeIcon";
+} from "~/components/ui/tooltip";
+import { useOAuthAppInfo } from "~/hooks/oauthApps/useOAuthApps";
 
 export function OAuthAppDetail({
     type,

--- a/ui/admin/app/components/oauth-apps/OAuthAppForm.tsx
+++ b/ui/admin/app/components/oauth-apps/OAuthAppForm.tsx
@@ -15,16 +15,15 @@ import { CopyText } from "~/components/composed/CopyText";
 import { ControlledInput } from "~/components/form/controlledInputs";
 import { CustomMarkdownComponents } from "~/components/react-markdown";
 import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
-import { Button } from "~/components/ui/button";
-import { Form } from "~/components/ui/form";
-import { useOAuthAppInfo } from "~/hooks/oauthApps/useOAuthApps";
-
 import {
     Accordion,
     AccordionContent,
     AccordionItem,
     AccordionTrigger,
-} from "../ui/accordion";
+} from "~/components/ui/accordion";
+import { Button } from "~/components/ui/button";
+import { Form } from "~/components/ui/form";
+import { useOAuthAppInfo } from "~/hooks/oauthApps/useOAuthApps";
 
 type OAuthAppFormProps = {
     type: OAuthProvider;

--- a/ui/admin/app/components/oauth-apps/OAuthAppList.tsx
+++ b/ui/admin/app/components/oauth-apps/OAuthAppList.tsx
@@ -1,7 +1,6 @@
 import { TypographyH3 } from "~/components/Typography";
+import { OAuthAppTile } from "~/components/oauth-apps/OAuthAppTile";
 import { useOAuthAppList } from "~/hooks/oauthApps/useOAuthApps";
-
-import { OAuthAppTile } from "./OAuthAppTile";
 
 export function OAuthAppList() {
     const apps = useOAuthAppList();

--- a/ui/admin/app/components/oauth-apps/OAuthAppTile.tsx
+++ b/ui/admin/app/components/oauth-apps/OAuthAppTile.tsx
@@ -2,6 +2,7 @@ import { OAuthProvider } from "~/lib/model/oauthApps/oauth-helpers";
 import { cn } from "~/lib/utils";
 
 import { TypographyH3 } from "~/components/Typography";
+import { OAuthAppDetail } from "~/components/oauth-apps/OAuthAppDetail";
 import { useTheme } from "~/components/theme";
 import { Badge } from "~/components/ui/badge";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
@@ -12,8 +13,6 @@ import {
     TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { useOAuthAppInfo } from "~/hooks/oauthApps/useOAuthApps";
-
-import { OAuthAppDetail } from "./OAuthAppDetail";
 
 export function OAuthAppTile({
     type,

--- a/ui/admin/app/components/oauth-apps/custom/CreateCustomOAuthApp.tsx
+++ b/ui/admin/app/components/oauth-apps/custom/CreateCustomOAuthApp.tsx
@@ -1,6 +1,7 @@
 import { PlusIcon } from "lucide-react";
 import { useState } from "react";
 
+import { CustomOAuthAppForm } from "~/components/oauth-apps/custom/CustomOAuthAppForm";
 import { Button } from "~/components/ui/button";
 import {
     Dialog,
@@ -10,8 +11,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "~/components/ui/dialog";
-
-import { CustomOAuthAppForm } from "./CustomOAuthAppForm";
 
 export function CreateCustomOAuthApp() {
     const [isOpen, setIsOpen] = useState(false);

--- a/ui/admin/app/components/oauth-apps/custom/CustomOAuthAppTile.tsx
+++ b/ui/admin/app/components/oauth-apps/custom/CustomOAuthAppTile.tsx
@@ -11,6 +11,7 @@ import {
     TypographySmall,
 } from "~/components/Typography";
 import { ConfirmationDialog } from "~/components/composed/ConfirmationDialog";
+import { EditCustomOAuthApp } from "~/components/oauth-apps/custom/EditCustomOAuthApp";
 import { Button } from "~/components/ui/button";
 import {
     Card,
@@ -19,8 +20,6 @@ import {
     CardHeader,
 } from "~/components/ui/card";
 import { useAsync } from "~/hooks/useAsync";
-
-import { EditCustomOAuthApp } from "./EditCustomOAuthApp";
 
 type CustomOAuthAppTileProps = {
     app: OAuthApp;

--- a/ui/admin/app/components/oauth-apps/custom/CustomOAuthApps.tsx
+++ b/ui/admin/app/components/oauth-apps/custom/CustomOAuthApps.tsx
@@ -1,7 +1,6 @@
 import { TypographyH3 } from "~/components/Typography";
+import { CustomOAuthAppTile } from "~/components/oauth-apps/custom/CustomOAuthAppTile";
 import { useCustomOAuthAppInfo } from "~/hooks/oauthApps/useOAuthApps";
-
-import { CustomOAuthAppTile } from "./CustomOAuthAppTile";
 
 export function CustomOAuthApps() {
     const apps = useCustomOAuthAppInfo();

--- a/ui/admin/app/components/oauth-apps/custom/EditCustomOAuthApp.tsx
+++ b/ui/admin/app/components/oauth-apps/custom/EditCustomOAuthApp.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { OAuthApp } from "~/lib/model/oauthApps";
 
+import { CustomOAuthAppForm } from "~/components/oauth-apps/custom/CustomOAuthAppForm";
 import { Button } from "~/components/ui/button";
 import {
     Dialog,
@@ -11,8 +12,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "~/components/ui/dialog";
-
-import { CustomOAuthAppForm } from "./CustomOAuthAppForm";
 
 type EditCustomOAuthAppProps = {
     app: OAuthApp;

--- a/ui/admin/app/components/sidebar/Sidebar.tsx
+++ b/ui/admin/app/components/sidebar/Sidebar.tsx
@@ -11,6 +11,8 @@ import { $path } from "remix-routes";
 
 import { cn } from "~/lib/utils";
 
+import { OttoLogo } from "~/components/branding/OttoLogo";
+import { Button } from "~/components/ui/button";
 import {
     Popover,
     PopoverContent,
@@ -29,9 +31,6 @@ import {
     SidebarRail,
     useSidebar,
 } from "~/components/ui/sidebar";
-
-import { OttoLogo } from "../branding/OttoLogo";
-import { Button } from "../ui/button";
 
 // Menu items.
 const items = [

--- a/ui/admin/app/components/thread/ThreadMeta.tsx
+++ b/ui/admin/app/components/thread/ThreadMeta.tsx
@@ -9,16 +9,15 @@ import { Thread } from "~/lib/model/threads";
 import { WorkspaceFile } from "~/lib/model/workspace";
 import { cn } from "~/lib/utils";
 
-import { Badge } from "~/components/ui/badge";
-import { Card, CardContent } from "~/components/ui/card";
-
 import {
     Accordion,
     AccordionContent,
     AccordionItem,
     AccordionTrigger,
-} from "../ui/accordion";
-import { Button } from "../ui/button";
+} from "~/components/ui/accordion";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent } from "~/components/ui/card";
 
 interface ThreadMetaProps {
     thread: Thread;

--- a/ui/admin/app/components/tools/ToolCatalog.tsx
+++ b/ui/admin/app/components/tools/ToolCatalog.tsx
@@ -6,6 +6,7 @@ import { ToolReference } from "~/lib/model/toolReferences";
 import { ToolReferenceService } from "~/lib/service/api/toolreferenceService";
 import { cn } from "~/lib/utils";
 
+import { ToolCategoryHeader } from "~/components/tools/ToolCategoryHeader";
 import { ToolItem } from "~/components/tools/ToolItem";
 import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 import {
@@ -15,8 +16,6 @@ import {
     CommandInput,
     CommandList,
 } from "~/components/ui/command";
-
-import { ToolCategoryHeader } from "./ToolCategoryHeader";
 
 type ToolCatalogProps = React.HTMLAttributes<HTMLDivElement> & {
     tools: string[];

--- a/ui/admin/app/components/ui/scroll-area.tsx
+++ b/ui/admin/app/components/ui/scroll-area.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import { cn } from "~/lib/utils";
 
-import { ScrollToBottom } from "./scroll-to-bottom";
+import { ScrollToBottom } from "~/components/ui/scroll-to-bottom";
 
 // note: I opted not to guess how to implement other scroll directions (i.e. 'top', 'left', 'right')
 // because I don't think it's necessary for the current use case. If you do need it, feel free to

--- a/ui/admin/app/components/ui/scroll-to-bottom.tsx
+++ b/ui/admin/app/components/ui/scroll-to-bottom.tsx
@@ -1,15 +1,14 @@
 import { ArrowDown } from "lucide-react";
 import React from "react";
 
-import { useDebouncedValue } from "~/hooks/useDebounce";
-
-import { Button } from "./button";
+import { Button } from "~/components/ui/button";
 import {
     Tooltip,
     TooltipContent,
     TooltipProvider,
     TooltipTrigger,
-} from "./tooltip";
+} from "~/components/ui/tooltip";
+import { useDebouncedValue } from "~/hooks/useDebounce";
 
 type ScrollToBottomProps = {
     scrollContainerEl: HTMLDivElement | null;

--- a/ui/admin/app/components/workflow/StringArrayForm.tsx
+++ b/ui/admin/app/components/workflow/StringArrayForm.tsx
@@ -6,10 +6,9 @@ import { z } from "zod";
 
 import { noop } from "~/lib/utils";
 
+import { Button } from "~/components/ui/button";
 import { Form, FormField, FormItem, FormMessage } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
-
-import { Button } from "../ui/button";
 
 const formSchema = z.object({
     items: z.array(z.string()),

--- a/ui/admin/app/components/workflow/Workflow.tsx
+++ b/ui/admin/app/components/workflow/Workflow.tsx
@@ -21,6 +21,8 @@ import {
 } from "~/components/ui/accordion";
 import { Button } from "~/components/ui/button";
 import { ScrollArea } from "~/components/ui/scroll-area";
+import { ParamsForm } from "~/components/workflow/ParamsForm";
+import { StringArrayForm } from "~/components/workflow/StringArrayForm";
 import { WorkflowAdvancedForm } from "~/components/workflow/WorkflowAdvancedForm";
 import {
     WorkflowProvider,
@@ -29,9 +31,6 @@ import {
 import { WorkflowForm } from "~/components/workflow/WorkflowForm";
 import { StepsForm } from "~/components/workflow/steps/StepsForm";
 import { useDebounce } from "~/hooks/useDebounce";
-
-import { ParamsForm } from "./ParamsForm";
-import { StringArrayForm } from "./StringArrayForm";
 
 type WorkflowProps = {
     workflow: WorkflowType;

--- a/ui/admin/app/components/workflow/WorkflowAdvancedForm.tsx
+++ b/ui/admin/app/components/workflow/WorkflowAdvancedForm.tsx
@@ -13,8 +13,7 @@ import {
     FormLabel,
     FormMessage,
 } from "~/components/ui/form";
-
-import { Textarea } from "../ui/textarea";
+import { Textarea } from "~/components/ui/textarea";
 
 const formSchema = z.object({
     prompt: z.string().optional(),

--- a/ui/admin/app/components/workflow/WorkflowForm.tsx
+++ b/ui/admin/app/components/workflow/WorkflowForm.tsx
@@ -14,8 +14,7 @@ import {
     FormMessage,
 } from "~/components/ui/form";
 import { Input } from "~/components/ui/input";
-
-import { Textarea } from "../ui/textarea";
+import { Textarea } from "~/components/ui/textarea";
 
 const formSchema = z.object({
     name: z.string().min(1, {

--- a/ui/admin/app/components/workflow/steps/AddStep.tsx
+++ b/ui/admin/app/components/workflow/steps/AddStep.tsx
@@ -22,8 +22,7 @@ import {
     PopoverTrigger,
 } from "~/components/ui/popover";
 import { ScrollArea } from "~/components/ui/scroll-area";
-
-import { StepTemplateCard } from "./StepTemplateCard";
+import { StepTemplateCard } from "~/components/workflow/steps/StepTemplateCard";
 
 type StepType = "regular" | "if" | "while" | "template";
 

--- a/ui/admin/app/components/workflow/steps/If.tsx
+++ b/ui/admin/app/components/workflow/steps/If.tsx
@@ -6,8 +6,7 @@ import { cn } from "~/lib/utils";
 
 import { Button } from "~/components/ui/button";
 import { Textarea } from "~/components/ui/textarea";
-
-import { AddStepButton } from "./AddStep";
+import { AddStepButton } from "~/components/workflow/steps/AddStep";
 
 export function IfComponent({
     ifCondition,

--- a/ui/admin/app/components/workflow/steps/StepRenderer.tsx
+++ b/ui/admin/app/components/workflow/steps/StepRenderer.tsx
@@ -1,10 +1,9 @@
 import { Step } from "~/lib/model/workflows";
 
 import { IfComponent } from "~/components/workflow/steps/If";
+import { StepComponent } from "~/components/workflow/steps/Step";
+import { TemplateComponent } from "~/components/workflow/steps/Template";
 import { WhileComponent } from "~/components/workflow/steps/While";
-
-import { StepComponent } from "./Step";
-import { TemplateComponent } from "./Template";
 
 export function renderStep(
     step: Step,

--- a/ui/admin/app/components/workflow/steps/While.tsx
+++ b/ui/admin/app/components/workflow/steps/While.tsx
@@ -7,8 +7,7 @@ import { cn } from "~/lib/utils";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Textarea } from "~/components/ui/textarea";
-
-import { AddStepButton } from "./AddStep";
+import { AddStepButton } from "~/components/workflow/steps/AddStep";
 
 export function WhileComponent({
     whileCondition,

--- a/ui/admin/app/lib/model/messages.ts
+++ b/ui/admin/app/lib/model/messages.ts
@@ -1,5 +1,5 @@
-import { ChatEvent, OAuthPrompt, ToolCall } from "./chatEvents";
-import { Run } from "./runs";
+import { ChatEvent, OAuthPrompt, ToolCall } from "~/lib/model/chatEvents";
+import { Run } from "~/lib/model/runs";
 
 export interface Message {
     text: string;

--- a/ui/admin/app/lib/model/oauthApps/index.ts
+++ b/ui/admin/app/lib/model/oauthApps/index.ts
@@ -1,11 +1,13 @@
+import {
+    OAuthAppSpec,
+    OAuthProvider,
+} from "~/lib/model/oauthApps/oauth-helpers";
+import { GitHubOAuthApp } from "~/lib/model/oauthApps/providers/github";
+import { GoogleOAuthApp } from "~/lib/model/oauthApps/providers/google";
+import { Microsoft365OAuthApp } from "~/lib/model/oauthApps/providers/microsoft365";
+import { NotionOAuthApp } from "~/lib/model/oauthApps/providers/notion";
+import { SlackOAuthApp } from "~/lib/model/oauthApps/providers/slack";
 import { EntityMeta } from "~/lib/model/primitives";
-
-import { OAuthAppSpec, OAuthProvider } from "./oauth-helpers";
-import { GitHubOAuthApp } from "./providers/github";
-import { GoogleOAuthApp } from "./providers/google";
-import { Microsoft365OAuthApp } from "./providers/microsoft365";
-import { NotionOAuthApp } from "./providers/notion";
-import { SlackOAuthApp } from "./providers/slack";
 
 export const OAuthAppSpecMap = {
     [OAuthProvider.GitHub]: GitHubOAuthApp,

--- a/ui/admin/app/lib/model/oauthApps/providers/github.ts
+++ b/ui/admin/app/lib/model/oauthApps/providers/github.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
+import {
+    OAuthAppSpec,
+    OAuthFormStep,
+    getOAuthLinks,
+} from "~/lib/model/oauthApps/oauth-helpers";
 import { BaseUrl } from "~/lib/routers/baseRouter";
 import { assetUrl } from "~/lib/utils";
-
-import { OAuthAppSpec, OAuthFormStep, getOAuthLinks } from "../oauth-helpers";
 
 const schema = z.object({
     clientID: z.string().min(1, "Client ID is required"),

--- a/ui/admin/app/lib/model/oauthApps/providers/google.ts
+++ b/ui/admin/app/lib/model/oauthApps/providers/google.ts
@@ -1,9 +1,12 @@
 import { z } from "zod";
 
+import {
+    OAuthAppSpec,
+    OAuthFormStep,
+    getOAuthLinks,
+} from "~/lib/model/oauthApps/oauth-helpers";
 import { DomainUrl } from "~/lib/routers/baseRouter";
 import { assetUrl } from "~/lib/utils";
-
-import { OAuthAppSpec, OAuthFormStep, getOAuthLinks } from "../oauth-helpers";
 
 const schema = z.object({
     clientID: z.string().min(1, "Client ID is required"),

--- a/ui/admin/app/lib/model/oauthApps/providers/microsoft365.ts
+++ b/ui/admin/app/lib/model/oauthApps/providers/microsoft365.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 
+import {
+    OAuthAppSpec,
+    OAuthFormStep,
+    getOAuthLinks,
+} from "~/lib/model/oauthApps/oauth-helpers";
 import { assetUrl } from "~/lib/utils";
-
-import { OAuthAppSpec, OAuthFormStep, getOAuthLinks } from "../oauth-helpers";
 
 const schema = z.object({
     clientID: z.string().min(1, "Client ID is required"),

--- a/ui/admin/app/lib/model/oauthApps/providers/notion.ts
+++ b/ui/admin/app/lib/model/oauthApps/providers/notion.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 
+import {
+    OAuthAppSpec,
+    OAuthFormStep,
+    getOAuthLinks,
+} from "~/lib/model/oauthApps/oauth-helpers";
 import { assetUrl } from "~/lib/utils";
-
-import { OAuthAppSpec, OAuthFormStep, getOAuthLinks } from "../oauth-helpers";
 
 const schema = z.object({
     clientID: z.string().min(1, "Client ID is required"),

--- a/ui/admin/app/lib/model/oauthApps/providers/slack.ts
+++ b/ui/admin/app/lib/model/oauthApps/providers/slack.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 
+import {
+    OAuthAppSpec,
+    OAuthFormStep,
+    getOAuthLinks,
+} from "~/lib/model/oauthApps/oauth-helpers";
 import { assetUrl } from "~/lib/utils";
-
-import { OAuthAppSpec, OAuthFormStep, getOAuthLinks } from "../oauth-helpers";
 
 const schema = z.object({
     clientID: z.string().min(1, "Client ID is required"),

--- a/ui/admin/app/lib/model/runs.ts
+++ b/ui/admin/app/lib/model/runs.ts
@@ -1,6 +1,6 @@
 import { CallFrame, RunState } from "@gptscript-ai/gptscript";
 
-import { EntityMeta } from "./primitives";
+import { EntityMeta } from "~/lib/model/primitives";
 
 export type Run = EntityMeta & {
     threadID?: string;

--- a/ui/admin/app/lib/routers/apiRoutes.ts
+++ b/ui/admin/app/lib/routers/apiRoutes.ts
@@ -2,8 +2,7 @@ import queryString from "query-string";
 import { mutate } from "swr";
 
 import { ToolReferenceType } from "~/lib/model/toolReferences";
-
-import { ApiUrl } from "./baseRouter";
+import { ApiUrl } from "~/lib/routers/baseRouter";
 
 const prodBaseUrl = () => new URL(ApiUrl()).pathname;
 

--- a/ui/admin/app/lib/service/api/oauthAppService.ts
+++ b/ui/admin/app/lib/service/api/oauthAppService.ts
@@ -1,7 +1,6 @@
 import { CreateOAuthApp, OAuthApp, OAuthAppBase } from "~/lib/model/oauthApps";
 import { ApiRoutes } from "~/lib/routers/apiRoutes";
-
-import { request } from "./primitives";
+import { request } from "~/lib/service/api/primitives";
 
 const getOauthApps = async () => {
     const res = await request<{ items: OAuthApp[] }>({

--- a/ui/admin/app/lib/service/api/primitives.ts
+++ b/ui/admin/app/lib/service/api/primitives.ts
@@ -1,7 +1,7 @@
 // TODO: Add default configurations with auth tokens, etc. When ready
 import axios, { AxiosRequestConfig, AxiosResponse, isAxiosError } from "axios";
 
-import { ConflictError } from "./apiErrors";
+import { ConflictError } from "~/lib/service/api/apiErrors";
 
 export const ResponseHeaders = {
     ThreadId: "x-otto-thread-id",

--- a/ui/admin/app/lib/service/authService.ts
+++ b/ui/admin/app/lib/service/authService.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from "axios";
 
-import { UserService } from "./api/userService";
+import { UserService } from "~/lib/service/api/userService";
 
 export const signedIn = async () => {
     try {

--- a/ui/admin/app/root.tsx
+++ b/ui/admin/app/root.tsx
@@ -11,11 +11,10 @@ import { SWRConfig } from "swr";
 import { AuthProvider } from "~/components/auth/AuthContext";
 import { LayoutProvider } from "~/components/layout/LayoutProvider";
 import { ThemeProvider } from "~/components/theme";
+import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
+import { SidebarProvider } from "~/components/ui/sidebar";
 import { Toaster } from "~/components/ui/sonner";
-
-import { LoadingSpinner } from "./components/ui/LoadingSpinner";
-import { SidebarProvider } from "./components/ui/sidebar";
-import "./tailwind.css";
+import "~/tailwind.css";
 
 export const links: LinksFunction = () => [
     { rel: "preconnect", href: "https://fonts.googleapis.com" },


### PR DESCRIPTION
Adding a linting rule that forces us to import from `~`, this is specifically targeted so that we don't do relative imports like `../component` or `./component`. Instead we do `~/component`.

The rest of the changes here are fixing the portions of code that do not respect this.