### PR TITLE
refactor: hide threads that do not have an AgentID

### DIFF
--- a/ui/admin/app/routes/_auth.threads.tsx
+++ b/ui/admin/app/routes/_auth.threads.tsx
@@ -95,7 +95,7 @@ export default function Threads() {
                 <TypographyH2 className="mb-8">Threads</TypographyH2>
                 <DataTable
                     columns={getColumns()}
-                    data={threads}
+                    data={threads.filter((thread) => thread.agentID)}
                     sort={[{ id: "created", desc: true }]}
                     classNames={{
                         row: "!max-h-[200px] grow-0 height-[200px]",


### PR DESCRIPTION
If a thread does not have an agent associated to it then it is a system thread and we should not display it.