### PR TITLE
style: adjust styling for oauth buttons in chat

### DIFF
--- a/ui/admin/app/components/chat/Message.tsx
+++ b/ui/admin/app/components/chat/Message.tsx
@@ -141,7 +141,7 @@ function PromptMessage({ prompt }: { prompt: OAuthPrompt }) {
                 Tool Call requires authentication
             </TypographyP>
 
-            <Button asChild>
+            <Button asChild variant="secondary">
                 <a
                     rel="noreferrer"
                     target="_blank"
@@ -152,7 +152,7 @@ function PromptMessage({ prompt }: { prompt: OAuthPrompt }) {
                         icon={prompt.metadata?.icon}
                         category={prompt.metadata?.category}
                         name={prompt.name}
-                        className="w-5 h-5 invert dark:invert-0"
+                        className="w-5 h-5"
                         disableTooltip
                     />
                     Authenticate with {prompt.metadata?.category}


### PR DESCRIPTION
From this:

![Screenshot 2024-11-08 at 11 10 10 AM](https://github.com/user-attachments/assets/ad3ceb58-22b3-4088-8f8b-04566e287862)

To this:

![Screenshot 2024-11-08 at 11 09 52 AM](https://github.com/user-attachments/assets/8c8e1173-8377-4e3f-b61d-767309e9735f)

We should probably make our secondary theme color be brighter than this on lightmode but it will make our theming consistent at least.