### PR TITLE
Fix: Make tool ref name check work

### DIFF
--- a/pkg/api/handlers/toolreferences.go
+++ b/pkg/api/handlers/toolreferences.go
@@ -1,8 +1,8 @@
 package handlers
 
 import (
-	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -83,8 +83,7 @@ func (a *ToolReferenceHandler) pickNameForReference(req api.Context, reference s
 		if i > 0 {
 			testName = name.SafeConcatName(newName, strconv.Itoa(i))
 		}
-		var errNotFound *types.ErrHTTP
-		if err := req.Get(&v1.ToolReference{}, testName); errors.As(err, &errNotFound) && errNotFound.Code == 404 {
+		if err := req.Get(&v1.ToolReference{}, testName); api.IsHTTPCode(err, http.StatusNotFound) {
 			return testName, nil
 		} else if err != nil {
 			return "", err


### PR DESCRIPTION
When creating a tool reference, we generate a name if one was not set.
We check for uniqueness of the name by doing a lookup and using the
first name where the lookup returns a 404. Our logic for checking the
404 was flawed. It was not matching the error type properly.

Addresses https://github.com/otto8-ai/otto8/issues/501

Signed-off-by: Craig Jellick <craig@acorn.io>
