### PR TITLE
feat: add usage metadata to models

### DIFF
--- a/apiclient/types/model.go
+++ b/apiclient/types/model.go
@@ -7,11 +7,12 @@ type Model struct {
 }
 
 type ModelManifest struct {
-	Name          string `json:"name,omitempty"`
-	TargetModel   string `json:"targetModel,omitempty"`
-	ModelProvider string `json:"modelProvider,omitempty"`
-	Active        bool   `json:"active"`
-	Default       bool   `json:"default"`
+	Name          string     `json:"name,omitempty"`
+	TargetModel   string     `json:"targetModel,omitempty"`
+	ModelProvider string     `json:"modelProvider,omitempty"`
+	Active        bool       `json:"active"`
+	Default       bool       `json:"default"`
+	Usage         ModelUsage `json:"usage,omitempty"`
 }
 
 type ModelList List[Model]
@@ -20,3 +21,11 @@ type ModelProviderStatus struct {
 	Configured     bool     `json:"configured"`
 	MissingEnvVars []string `json:"missingEnvVars,omitempty"`
 }
+
+type ModelUsage string
+
+const (
+	ModelUsageAgent     ModelUsage = "agent"
+	ModelUsageEmbedding ModelUsage = "text-embedding"
+	ModelUsageImage     ModelUsage = "image-generation"
+)

--- a/pkg/api/handlers/model.go
+++ b/pkg/api/handlers/model.go
@@ -70,7 +70,7 @@ func (a *ModelHandler) Update(req api.Context) error {
 
 	existing.Spec.Manifest = model
 
-	if err := validateModelManifest(req.Context(), req.Storage, existing); err != nil {
+	if err := validateModelManifestAndSetDefaults(req.Context(), req.Storage, &existing); err != nil {
 		return err
 	}
 
@@ -115,7 +115,7 @@ func (a *ModelHandler) Create(req api.Context) error {
 		},
 	}
 
-	if err := validateModelManifest(req.Context(), req.Storage, model); err != nil {
+	if err := validateModelManifestAndSetDefaults(req.Context(), req.Storage, &model); err != nil {
 		return err
 	}
 
@@ -184,13 +184,17 @@ func convertModelProviderToolRef(toolRef v1.ToolReference) *types.ModelProviderS
 	}
 }
 
-func validateModelManifest(ctx context.Context, c kclient.Client, newModel v1.Model) error {
+func validateModelManifestAndSetDefaults(ctx context.Context, c kclient.Client, newModel *v1.Model) error {
 	var errs []error
 	if newModel.Spec.Manifest.TargetModel == "" {
 		errs = append(errs, fmt.Errorf("field targetModel is required"))
 	}
 	if newModel.Spec.Manifest.ModelProvider == "" {
 		errs = append(errs, fmt.Errorf("field modelProvider is required"))
+	}
+
+	if newModel.Spec.Manifest.Usage == "" {
+		newModel.Spec.Manifest.Usage = types.ModelUsageAgent
 	}
 
 	if newModel.Spec.Manifest.Default && newModel.Spec.Manifest.Active {

--- a/pkg/controller/data/default-models.yaml
+++ b/pkg/controller/data/default-models.yaml
@@ -10,6 +10,7 @@ items:
         modelProvider: openai-model-provider
         default: true
         active: true
+        usage: agent
   - apiVersion: otto.otto8.ai/v1
     kind: Model
     metadata:
@@ -20,6 +21,7 @@ items:
         targetModel: text-embedding-ada-002
         modelProvider: openai-model-provider
         active: true
+        usage: text-embedding
   - apiVersion: otto.otto8.ai/v1
     kind: Model
     metadata:
@@ -30,6 +32,7 @@ items:
         targetModel: text-embedding-3-small
         modelProvider: openai-model-provider
         active: true
+        usage: text-embedding
   - apiVersion: otto.otto8.ai/v1
     kind: Model
     metadata:
@@ -40,6 +43,7 @@ items:
         targetModel: dall-e-3
         modelProvider: openai-model-provider
         active: true
+        usage: image-generation
   - apiVersion: otto.otto8.ai/v1
     kind: Model
     metadata:
@@ -50,6 +54,7 @@ items:
         targetModel: gpt-4o-mini
         modelProvider: openai-model-provider
         active: true
+        usage: agent
   - apiVersion: otto.otto8.ai/v1
     kind: Model
     metadata:
@@ -60,3 +65,4 @@ items:
         targetModel: gpt-3.5-turbo
         modelProvider: openai-model-provider
         active: true
+        usage: agent

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -1500,6 +1500,12 @@ func schema_otto8_ai_otto8_apiclient_types_ModelManifest(ref common.ReferenceCal
 							Format:  "",
 						},
 					},
+					"usage": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"active", "default"},
 			},

--- a/ui/admin/app/components/agent/AgentForm.tsx
+++ b/ui/admin/app/components/agent/AgentForm.tsx
@@ -126,11 +126,15 @@ export function AgentForm({ agent, onSubmit, onChange }: AgentFormProps) {
                                 <SelectEmptyItem>
                                     Use System Default
                                 </SelectEmptyItem>
-                                {models?.map((m) => (
-                                    <SelectItem key={m.id} value={m.id}>
-                                        {m.name || m.id}
-                                    </SelectItem>
-                                ))}
+                                {models
+                                    ?.filter(
+                                        (m) => !m.usage || m.usage === "agent"
+                                    )
+                                    .map((m) => (
+                                        <SelectItem key={m.id} value={m.id}>
+                                            {m.name || m.id}
+                                        </SelectItem>
+                                    ))}
                             </SelectContent>
                         </Select>
                     )}

--- a/ui/admin/app/lib/model/models.ts
+++ b/ui/admin/app/lib/model/models.ts
@@ -8,6 +8,7 @@ export type ModelManifest = {
     modelProvider: string;
     active: boolean;
     default: boolean;
+    usage?: string;
 };
 
 export type ModelProviderStatus = {


### PR DESCRIPTION
The usage field indicates the general use of the model. For example, text-embedding or image-generation. If a model is fit for use as a general agent model, then the usage is agent.