### PR TITLE
Fix: remove slash prefix when comparing with match pattern

### DIFF
--- a/pkg/controller/handlers/knowledgefile/knowledgefile.go
+++ b/pkg/controller/handlers/knowledgefile/knowledgefile.go
@@ -404,7 +404,7 @@ func (h *Handler) Cleanup(req router.Request, _ router.Response) error {
 
 func isFileMatchPrefixPattern(filePath string, patterns []string) bool {
 	for _, pattern := range patterns {
-		if strings.HasPrefix(filePath, pattern) {
+		if strings.HasPrefix(strings.TrimPrefix(filePath, "/"), pattern) {
 			return true
 		}
 	}


### PR DESCRIPTION
When comparing with prefix pattern, the onedrive file has filepath starting with "/". But when we are adding folder to the prefix path, we are only adding the name. This makes the folder prefix matching not working in onedrive. So removing the prefix slash before comparing.

https://github.com/acorn-io/acorn/issues/822