### PR TITLE
fix: do not retry for reveal 404, will clear existing form entries

### DIFF
--- a/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
@@ -130,16 +130,12 @@ export function ModelProviderConfigureContent({
             ModelProviderApiService.revealModelProviderById(modelProviderId),
         {
             keepPreviousData: true,
-            // 404 -> no credential found, so don't retry
-            shouldRetryOnError: (error) => {
-                if (
-                    error instanceof NotFoundError &&
-                    error.message.toLowerCase().includes("no credential found")
-                ) {
-                    return false;
-                }
-                return true;
-            },
+            // 404: no credential found = no need to retry
+            shouldRetryOnError: (error) =>
+                error instanceof NotFoundError &&
+                error.message.toLowerCase().includes("no credential found")
+                    ? false
+                    : true,
         }
     );
 

--- a/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
@@ -127,7 +127,11 @@ export function ModelProviderConfigureContent({
         ModelProviderApiService.revealModelProviderById.key(modelProvider.id),
         ({ modelProviderId }) =>
             ModelProviderApiService.revealModelProviderById(modelProviderId),
-        { keepPreviousData: true }
+        {
+            keepPreviousData: true,
+            // 404 -> no credential found, so don't retry
+            shouldRetryOnError: (error) => error.status !== 404,
+        }
     );
 
     const requiredParameters = modelProvider.requiredConfigurationParameters;

--- a/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderConfigure.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import useSWR from "swr";
 
 import { ModelProvider } from "~/lib/model/modelProviders";
+import { NotFoundError } from "~/lib/service/api/apiErrors";
 import { ModelProviderApiService } from "~/lib/service/api/modelProviderApiService";
 
 import { ModelProviderForm } from "~/components/model-providers/ModelProviderForm";
@@ -130,7 +131,15 @@ export function ModelProviderConfigureContent({
         {
             keepPreviousData: true,
             // 404 -> no credential found, so don't retry
-            shouldRetryOnError: (error) => error.status !== 404,
+            shouldRetryOnError: (error) => {
+                if (
+                    error instanceof NotFoundError &&
+                    error.message.toLowerCase().includes("no credential found")
+                ) {
+                    return false;
+                }
+                return true;
+            },
         }
     );
 

--- a/ui/admin/app/lib/service/api/apiErrors.tsx
+++ b/ui/admin/app/lib/service/api/apiErrors.tsx
@@ -1,5 +1,6 @@
 export class ConflictError extends Error {}
 export class BadRequestError extends Error {}
+export class NotFoundError extends Error {}
 
 // Errors that should trigger the error boundary
 export class BoundaryError extends Error {}

--- a/ui/admin/app/lib/service/api/primitives.ts
+++ b/ui/admin/app/lib/service/api/primitives.ts
@@ -8,6 +8,7 @@ import {
     BadRequestError,
     ConflictError,
     ForbiddenError,
+    NotFoundError,
     UnauthorizedError,
 } from "~/lib/service/api/apiErrors";
 
@@ -62,6 +63,10 @@ export async function request<T, R = AxiosResponse<T>, D = unknown>({
                 ...config,
                 disableTokenRefresh: true,
             });
+        }
+
+        if (isAxiosError(error) && error.response?.status === 404) {
+            throw new NotFoundError(error.response.data);
         }
 
         if (isAxiosError(error) && error.response?.status === 409) {


### PR DESCRIPTION
* Addresses #843 
* useSWR continues to retry if it receives an error response but 404 response is valid for /reveal (means no credential found for that model provider)
* avoid retry for 404 (causing clear out of form and retry is unnecessary, we revalidate reveal after user submits form)