### PR TITLE
chore: hide atlassian oauth config from admins

### DIFF
--- a/ui/admin/app/lib/model/oauthApps/index.ts
+++ b/ui/admin/app/lib/model/oauthApps/index.ts
@@ -2,7 +2,6 @@ import {
     OAuthAppSpec,
     OAuthProvider,
 } from "~/lib/model/oauthApps/oauth-helpers";
-import { AtlassianOAuthApp } from "~/lib/model/oauthApps/providers/atlassian";
 import { GitHubOAuthApp } from "~/lib/model/oauthApps/providers/github";
 import { GoogleOAuthApp } from "~/lib/model/oauthApps/providers/google";
 import { Microsoft365OAuthApp } from "~/lib/model/oauthApps/providers/microsoft365";
@@ -11,7 +10,6 @@ import { SlackOAuthApp } from "~/lib/model/oauthApps/providers/slack";
 import { EntityMeta } from "~/lib/model/primitives";
 
 export const OAuthAppSpecMap = {
-    [OAuthProvider.Atlassian]: AtlassianOAuthApp,
     [OAuthProvider.GitHub]: GitHubOAuthApp,
     [OAuthProvider.Google]: GoogleOAuthApp,
     [OAuthProvider.Microsoft365]: Microsoft365OAuthApp,


### PR DESCRIPTION
Hide the Atlassian OAuth integration from admins until we have tools that use it.
