### PR TITLE
Revert "chore: hide atlassian oauth config from admins"

### DIFF
--- a/ui/admin/app/lib/model/oauthApps/index.ts
+++ b/ui/admin/app/lib/model/oauthApps/index.ts
@@ -2,6 +2,7 @@ import {
     OAuthAppSpec,
     OAuthProvider,
 } from "~/lib/model/oauthApps/oauth-helpers";
+import { AtlassianOAuthApp } from "~/lib/model/oauthApps/providers/atlassian";
 import { GitHubOAuthApp } from "~/lib/model/oauthApps/providers/github";
 import { GoogleOAuthApp } from "~/lib/model/oauthApps/providers/google";
 import { Microsoft365OAuthApp } from "~/lib/model/oauthApps/providers/microsoft365";
@@ -10,6 +11,7 @@ import { SlackOAuthApp } from "~/lib/model/oauthApps/providers/slack";
 import { EntityMeta } from "~/lib/model/primitives";
 
 export const OAuthAppSpecMap = {
+    [OAuthProvider.Atlassian]: AtlassianOAuthApp,
     [OAuthProvider.GitHub]: GitHubOAuthApp,
     [OAuthProvider.Google]: GoogleOAuthApp,
     [OAuthProvider.Microsoft365]: Microsoft365OAuthApp,


### PR DESCRIPTION
Reverts obot-platform/obot#969. Required by https://github.com/obot-platform/tools/pull/291.