### PR TITLE
chore: remove useForm dependency from BasicToolForm

### DIFF
--- a/ui/admin/app/components/agent/ToolForm.tsx
+++ b/ui/admin/app/components/agent/ToolForm.tsx
@@ -168,13 +168,6 @@ export function ToolForm({
                 <div className="flex justify-end">
                     <ToolCatalogDialog
                         tools={allTools}
-                        onAddTool={(tool) =>
-                            toolFields.append({
-                                tool,
-                                variant: ToolVariant.FIXED,
-                            })
-                        }
-                        onRemoveTools={removeTools}
                         onUpdateTools={(tools) =>
                             updateTools(tools, ToolVariant.FIXED)
                         }
@@ -231,13 +224,6 @@ export function ToolForm({
                 <div className="flex justify-end">
                     <ToolCatalogDialog
                         tools={allTools}
-                        onAddTool={(tool) =>
-                            toolFields.append({
-                                tool,
-                                variant: ToolVariant.DEFAULT,
-                            })
-                        }
-                        onRemoveTools={removeTools}
                         onUpdateTools={(tools) =>
                             updateTools(tools, ToolVariant.DEFAULT)
                         }

--- a/ui/admin/app/components/agent/ToolForm.tsx
+++ b/ui/admin/app/components/agent/ToolForm.tsx
@@ -124,6 +124,22 @@ export function ToolForm({
             { tool, variant }
         );
 
+    const updateTools = (tools: string[], variant: ToolVariant) => {
+        const removedToolIndexes = toolFields.fields
+            .filter((field) => !tools.includes(field.tool))
+            .map((item) => toolFields.fields.indexOf(item));
+
+        const addedTools = tools.filter(
+            (tool) => !toolFields.fields.some((field) => field.tool === tool)
+        );
+
+        toolFields.remove(removedToolIndexes);
+
+        for (const tool of addedTools) {
+            toolFields.append({ tool, variant });
+        }
+    };
+
     return (
         <Form {...form}>
             <form
@@ -159,6 +175,9 @@ export function ToolForm({
                             })
                         }
                         onRemoveTools={removeTools}
+                        onUpdateTools={(tools) =>
+                            updateTools(tools, ToolVariant.FIXED)
+                        }
                     />
                 </div>
 
@@ -219,6 +238,9 @@ export function ToolForm({
                             })
                         }
                         onRemoveTools={removeTools}
+                        onUpdateTools={(tools) =>
+                            updateTools(tools, ToolVariant.DEFAULT)
+                        }
                         className="w-auto"
                     />
                 </div>

--- a/ui/admin/app/components/tools/BasicToolForm.tsx
+++ b/ui/admin/app/components/tools/BasicToolForm.tsx
@@ -1,105 +1,57 @@
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useMemo } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
-import { z } from "zod";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import { ToolEntry } from "~/components/agent/ToolEntry";
 import { ToolCatalogDialog } from "~/components/tools/ToolCatalog";
-import { Form } from "~/components/ui/form";
 
-const formSchema = z.object({
-    tools: z.array(z.object({ value: z.string() })),
-});
-
-type BasicToolFormValues = z.infer<typeof formSchema>;
-
-type Tools = { tools: string[] };
-
-export function BasicToolForm({
-    defaultValues: _defaultValues,
-    onChange,
-}: {
-    defaultValues?: Partial<Tools>;
-    onSubmit?: (values: Tools) => void;
-    onChange?: (values: Tools) => void;
+export const BasicToolForm = memo(function BasicToolFormComponent(props: {
+    value?: string[];
+    defaultValue?: string[];
+    onChange?: (values: string[]) => void;
 }) {
-    const defaultValues = useMemo(() => {
-        return {
-            tools:
-                _defaultValues?.tools?.map((tool) => ({ value: tool })) || [],
-        };
-    }, [_defaultValues]);
+    const { onChange } = props;
 
-    const form = useForm<BasicToolFormValues>({
-        resolver: zodResolver(formSchema),
-        defaultValues: { tools: defaultValues?.tools || [] },
-    });
-    const { getValues, reset } = form;
+    const [_value, _setValue] = useState(props.defaultValue);
+    const value = useMemo(
+        () => props.value ?? _value ?? [],
+        [props.value, _value]
+    );
 
-    useEffect(() => {
-        const unchanged = compareArrays(
-            defaultValues?.tools.map(({ value }) => value) || [],
-            getValues().tools.map(({ value }) => value)
-        );
-
-        if (unchanged) return;
-
-        reset({ tools: defaultValues?.tools || [] });
-    }, [defaultValues, getValues, reset]);
-
-    const toolArr = useFieldArray({ control: form.control, name: "tools" });
-
-    useEffect(() => {
-        return form.watch((values) => {
-            const { data, success } = formSchema.safeParse(values);
-
-            if (!success) return;
-
-            onChange?.({ tools: data.tools.map((t) => t.value) });
-        }).unsubscribe;
-    }, [form, onChange]);
+    const setValue = useCallback(
+        (newValue: string[]) => {
+            _setValue(newValue);
+            onChange?.(newValue);
+        },
+        [onChange]
+    );
 
     const removeTools = (toolsToRemove: string[]) => {
-        const indexes = toolsToRemove
-            .map((tool) => toolArr.fields.findIndex((t) => t.value === tool))
-            .filter((index) => index !== -1);
-
-        toolArr.remove(indexes);
+        setValue(value.filter((tool) => !toolsToRemove.includes(tool)));
     };
 
     const addTool = (tool: string) => {
-        toolArr.append({ value: tool });
+        setValue([...value, tool]);
     };
 
     return (
-        <Form {...form}>
-            <div className="flex flex-col gap-2">
-                <div className="flex flex-col gap-1 w-full overflow-y-auto">
-                    {toolArr.fields.map((field) => (
-                        <ToolEntry
-                            key={field.id}
-                            tool={field.value}
-                            onDelete={() => removeTools([field.value])}
-                        />
-                    ))}
-                </div>
-
-                <div className="flex justify-end">
-                    <ToolCatalogDialog
-                        tools={toolArr.fields.map((field) => field.value)}
-                        onAddTool={addTool}
-                        onRemoveTools={removeTools}
+        <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-1 w-full overflow-y-auto">
+                {value.map((tool) => (
+                    <ToolEntry
+                        key={tool}
+                        tool={tool}
+                        onDelete={() => removeTools([tool])}
                     />
-                </div>
+                ))}
             </div>
-        </Form>
+
+            <div className="flex justify-end">
+                <ToolCatalogDialog
+                    tools={value}
+                    onAddTool={addTool}
+                    onRemoveTools={removeTools}
+                    onUpdateTools={setValue}
+                />
+            </div>
+        </div>
     );
-}
-
-function compareArrays(a: string[], b: string[]) {
-    const aSet = new Set(a);
-
-    if (aSet.size !== b.length) return false;
-
-    return b.every((tool) => aSet.has(tool));
-}
+});

--- a/ui/admin/app/components/tools/BasicToolForm.tsx
+++ b/ui/admin/app/components/tools/BasicToolForm.tsx
@@ -28,10 +28,6 @@ export const BasicToolForm = memo(function BasicToolFormComponent(props: {
         setValue(value.filter((tool) => !toolsToRemove.includes(tool)));
     };
 
-    const addTool = (tool: string) => {
-        setValue([...value, tool]);
-    };
-
     return (
         <div className="flex flex-col gap-2">
             <div className="flex flex-col gap-1 w-full overflow-y-auto">
@@ -45,12 +41,7 @@ export const BasicToolForm = memo(function BasicToolFormComponent(props: {
             </div>
 
             <div className="flex justify-end">
-                <ToolCatalogDialog
-                    tools={value}
-                    onAddTool={addTool}
-                    onRemoveTools={removeTools}
-                    onUpdateTools={setValue}
-                />
+                <ToolCatalogDialog tools={value} onUpdateTools={setValue} />
             </div>
         </div>
     );

--- a/ui/admin/app/components/tools/ToolCatalog.tsx
+++ b/ui/admin/app/components/tools/ToolCatalog.tsx
@@ -27,8 +27,6 @@ import {
 
 type ToolCatalogProps = React.HTMLAttributes<HTMLDivElement> & {
     tools: string[];
-    onAddTool: (tools: string) => void;
-    onRemoveTools: (tools: string[]) => void;
     onUpdateTools: (tools: string[]) => void;
     invert?: boolean;
     classNames?: { list?: string };
@@ -38,8 +36,6 @@ export function ToolCatalog({
     className,
     tools,
     invert = false,
-    onAddTool,
-    onRemoveTools,
     onUpdateTools,
     classNames,
 }: ToolCatalogProps) {
@@ -52,16 +48,16 @@ export function ToolCatalog({
     const handleSelect = useCallback(
         (toolId: string) => {
             if (!tools.includes(toolId)) {
-                onAddTool(toolId);
+                onUpdateTools([...tools, toolId]);
             }
         },
-        [tools, onAddTool]
+        [tools, onUpdateTools]
     );
 
     const handleSelectBundle = useCallback(
         (bundleToolId: string, categoryTools: ToolReference[]) => {
             if (tools.includes(bundleToolId)) {
-                onRemoveTools([bundleToolId]);
+                onUpdateTools(tools.filter((tool) => tool !== bundleToolId));
                 return;
             }
 
@@ -74,7 +70,7 @@ export function ToolCatalog({
 
             onUpdateTools(newTools);
         },
-        [tools, onUpdateTools, onRemoveTools]
+        [tools, onUpdateTools]
     );
 
     if (isLoading) return <LoadingSpinner />;

--- a/ui/admin/app/components/tools/ToolCatalog.tsx
+++ b/ui/admin/app/components/tools/ToolCatalog.tsx
@@ -29,6 +29,7 @@ type ToolCatalogProps = React.HTMLAttributes<HTMLDivElement> & {
     tools: string[];
     onAddTool: (tools: string) => void;
     onRemoveTools: (tools: string[]) => void;
+    onUpdateTools: (tools: string[]) => void;
     invert?: boolean;
     classNames?: { list?: string };
 };
@@ -39,6 +40,7 @@ export function ToolCatalog({
     invert = false,
     onAddTool,
     onRemoveTools,
+    onUpdateTools,
     classNames,
 }: ToolCatalogProps) {
     const { data: toolCategories, isLoading } = useSWR(
@@ -63,12 +65,16 @@ export function ToolCatalog({
                 return;
             }
 
-            onAddTool(bundleToolId);
+            const toolsToRemove = new Set(categoryTools.map((tool) => tool.id));
 
-            // remove all tools in the bundle to remove redundancy
-            onRemoveTools(categoryTools.map((tool) => tool.id));
+            const newTools = [
+                ...tools.filter((tool) => !toolsToRemove.has(tool)),
+                bundleToolId,
+            ];
+
+            onUpdateTools(newTools);
         },
-        [tools, onAddTool, onRemoveTools]
+        [tools, onUpdateTools, onRemoveTools]
     );
 
     if (isLoading) return <LoadingSpinner />;

--- a/ui/admin/app/components/workflow/Workflow.tsx
+++ b/ui/admin/app/components/workflow/Workflow.tsx
@@ -78,8 +78,8 @@ function WorkflowContent({ className }: WorkflowProps) {
                     </CardDescription>
 
                     <BasicToolForm
-                        defaultValues={workflow}
-                        onChange={debouncedSetWorkflowInfo}
+                        value={workflow.tools}
+                        onChange={(tools) => partialSetWorkflow({ tools })}
                     />
                 </div>
 

--- a/ui/admin/app/components/workflow/steps/Step.tsx
+++ b/ui/admin/app/components/workflow/steps/Step.tsx
@@ -107,9 +107,9 @@ export function StepComponent({
 
                             <AccordionContent className="p-1 pb-6">
                                 <BasicToolForm
-                                    defaultValues={step}
-                                    onChange={(values) =>
-                                        onUpdate({ ...step, ...values })
+                                    value={step.tools}
+                                    onChange={(tools) =>
+                                        onUpdate({ ...step, tools })
                                     }
                                 />
                             </AccordionContent>


### PR DESCRIPTION
TLDR;
useForm returns `useRef().current` under the hood as a hack to optimize rendering. For the most part, this is totally fine, but it CAN cause some erratic behavior when certain conditions are met (I think it has to do with resetting the form's default values...????)

Either way, it added way more complexity than it was worth (at least for this component) so removing it was the best solution

More in-depth:
After mount, the first rerender (change event) of this specific usage of `BasicToolForm` was causing the `form.watch` method to change references (not only that but it was being treated as a NOOP??) as a result, the `onChange` prop was not getting triggered, but only for the first change. Subsequent rerenders **did not** reinitialize the `watch` method and it behaved as expected.

Looking into the code of `react-hook-form` there is __no reasonable explanation__ for the reference of `form.watch` to change between renders. 

Essentially what happens is `useForm` initializes a `useRef` object with the `watch` method and **never updates it again**. The only way that re-initialization could happen is if the parent component is remounted (tested and this is not the case). 

The only thing that seemed off from within the `useForm` code is that it returns the `current` property of the previously mentioned `useRef` object. This technically breaks the rules of `useRef` ([this one](https://arc.net/l/quote/chttzirx) specifically) which "makes your component's behavior unpredictable"

In the interest of spending another 3+ hours on this topic, I'm sticking with this as the working diagnosis