### PR TITLE
fix: remove inactive models from model/default model alias dropdown options

### DIFF
--- a/ui/admin/app/components/agent/AgentForm.tsx
+++ b/ui/admin/app/components/agent/AgentForm.tsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 import useSWR from "swr";
 import { z } from "zod";
 
-import { Model, ModelUsage } from "~/lib/model/models";
+import { Model, ModelUsage, filterModelsByActive } from "~/lib/model/models";
 import { ModelApiService } from "~/lib/service/api/modelApiService";
 
 import { TypographyH4 } from "~/components/Typography";
@@ -136,7 +136,7 @@ export function AgentForm({ agent, onSubmit, onChange }: AgentFormProps) {
     );
 
     function getModelOptionsByModelProvider(models: Model[]) {
-        const byModelProviderGroups = models.reduce(
+        const byModelProviderGroups = filterModelsByActive(models).reduce(
             (acc, model) => {
                 acc[model.modelProvider] = acc[model.modelProvider] || [];
                 acc[model.modelProvider].push(model);

--- a/ui/admin/app/components/model/DefaultModelAliasForm.tsx
+++ b/ui/admin/app/components/model/DefaultModelAliasForm.tsx
@@ -8,6 +8,7 @@ import {
     Model,
     ModelAlias,
     ModelUsage,
+    filterModelsByActive,
     filterModelsByUsage,
     getModelAliasLabel,
     getModelUsageFromAlias,
@@ -166,9 +167,8 @@ export function DefaultModelAliasForm({
                                 getModelUsageFromAlias(alias) ??
                                 ModelUsage.Unknown;
 
-                            const modelOptions = filterModelsByUsage(
-                                models ?? [],
-                                usage
+                            const activeModelOptions = filterModelsByActive(
+                                filterModelsByUsage(models ?? [], usage)
                             );
 
                             return (
@@ -195,7 +195,7 @@ export function DefaultModelAliasForm({
 
                                                 <SelectContent>
                                                     {renderSelectContent(
-                                                        modelOptions,
+                                                        activeModelOptions,
                                                         defaultModel,
                                                         usage,
                                                         alias

--- a/ui/admin/app/lib/model/models.ts
+++ b/ui/admin/app/lib/model/models.ts
@@ -74,6 +74,10 @@ export function filterModelsByUsage(
     return models.filter((model) => _usages.includes(model.usage)).sort(sort);
 }
 
+export function filterModelsByActive(models: Model[]) {
+    return models.filter((model) => model.active);
+}
+
 export type ModelManifest = {
     name?: string;
     targetModel?: string;


### PR DESCRIPTION
* filter out models with `active: false` (inactive) from model dropdown options