### PR TITLE
fix: re-enable event propagation for workflow edit icon on the workflows page

### DIFF
--- a/ui/admin/app/routes/_auth.workflows._index.tsx
+++ b/ui/admin/app/routes/_auth.workflows._index.tsx
@@ -88,9 +88,6 @@ export default function Workflows() {
                         columns={getColumns()}
                         data={getWorkflows.data || []}
                         sort={[{ id: "created", desc: true }]}
-                        disableClickPropagation={(cell) =>
-                            cell.id.includes("action")
-                        }
                         onRowClick={navigateToWorkflow}
                     />
                 </div>


### PR DESCRIPTION
Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>