### PR TITLE
fix: account for deleted property on toolReference

### DIFF
--- a/ui/admin/app/lib/service/api/toolreferenceService.ts
+++ b/ui/admin/app/lib/service/api/toolreferenceService.ts
@@ -37,6 +37,11 @@ async function getToolReferencesCategoryMap(type?: ToolReferenceType) {
     const result: ToolCategoryMap = {};
 
     for (const toolReference of toolReferences) {
+        if (toolReference.deleted) {
+            // skip tools if marked with deleted
+            continue;
+        }
+
         const category = !toolReference.builtin
             ? YourToolsToolCategory
             : toolReference.metadata?.category || UncategorizedToolCategory;


### PR DESCRIPTION
* one-liner fix, if a toolReference is marked with deleted, it's being cleaned up  [Thread here](https://github.com/obot-platform/obot/issues/858#issuecomment-2557467363) Account for deleted and don't include it if it is set.