### PR TITLE
feat: model provider configuration validation

### DIFF
--- a/pkg/api/handlers/modelprovider.go
+++ b/pkg/api/handlers/modelprovider.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,10 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
+	"github.com/obot-platform/obot/pkg/invoke"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -16,12 +20,14 @@ import (
 type ModelProviderHandler struct {
 	gptscript  *gptscript.GPTScript
 	dispatcher *dispatcher.Dispatcher
+	invoker    *invoke.Invoker
 }
 
-func NewModelProviderHandler(gClient *gptscript.GPTScript, dispatcher *dispatcher.Dispatcher) *ModelProviderHandler {
+func NewModelProviderHandler(gClient *gptscript.GPTScript, dispatcher *dispatcher.Dispatcher, invoker *invoke.Invoker) *ModelProviderHandler {
 	return &ModelProviderHandler{
 		gptscript:  gClient,
 		dispatcher: dispatcher,
+		invoker:    invoker,
 	}
 }
 
@@ -87,6 +93,78 @@ func (mp *ModelProviderHandler) List(req api.Context) error {
 	}
 
 	return req.Write(types.ModelProviderList{Items: resp})
+}
+
+type ValidationError struct {
+	Err string `json:"error"`
+}
+
+func (ve *ValidationError) Error() string {
+	return fmt.Sprintf("model-provider credentials validation failed: {\"error\": \"%s\"}", ve.Err)
+}
+
+func (mp *ModelProviderHandler) Validate(req api.Context) error {
+	var ref v1.ToolReference
+	if err := req.Get(&ref, req.PathValue("id")); err != nil {
+		return err
+	}
+
+	if ref.Spec.Type != types.ToolReferenceTypeModelProvider {
+		return types.NewErrBadRequest("%q is not a model provider", ref.Name)
+	}
+
+	log.Debugf("Validating model provider %q", ref.Name)
+
+	var envVars map[string]string
+	if err := req.Read(&envVars); err != nil {
+		return err
+	}
+
+	envs := make([]string, 0, len(envVars))
+	for key, val := range envVars {
+		envs = append(envs, key+"="+val)
+	}
+
+	thread := &v1.Thread{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.ThreadPrefix + "-" + ref.Name + "-validate-",
+			Namespace:    ref.Namespace,
+		},
+		Spec: v1.ThreadSpec{
+			SystemTask: true,
+		},
+	}
+
+	if err := req.Create(thread); err != nil {
+		return fmt.Errorf("failed to create thread: %w", err)
+	}
+
+	defer func() { _ = req.Delete(thread) }()
+
+	task, err := mp.invoker.SystemTask(req.Context(), thread, "validate from "+ref.Spec.Reference, "", invoke.SystemTaskOptions{Env: envs})
+	if err != nil {
+		return err
+	}
+	defer task.Close()
+
+	res, err := task.Result(req.Context())
+	if err != nil {
+		if strings.Contains(err.Error(), "tool not found: validate from "+ref.Spec.Reference) { // there's no simple way to do errors.As/.Is at this point unfortunately
+			log.Errorf("Model provider %q does not provide a validate tool. Looking for 'validate from %s'", ref.Name, ref.Spec.Reference)
+			return types.NewErrNotFound(
+				fmt.Sprintf("`validate from %s` tool not found", ref.Spec.Reference),
+				ref.Name,
+			)
+		}
+		return &ValidationError{Err: strings.Trim(err.Error(), "\"'")}
+	}
+
+	var validationError ValidationError
+	if json.Unmarshal([]byte(res.Output), &validationError) == nil && validationError.Err != "" {
+		return &validationError
+	}
+
+	return nil
 }
 
 func (mp *ModelProviderHandler) Configure(req api.Context) error {

--- a/pkg/api/handlers/modelprovider.go
+++ b/pkg/api/handlers/modelprovider.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/gptscript-ai/go-gptscript"
@@ -156,12 +157,12 @@ func (mp *ModelProviderHandler) Validate(req api.Context) error {
 				ref.Name,
 			)
 		}
-		return &ValidationError{Err: strings.Trim(err.Error(), "\"'")}
+		return types.NewErrHttp(http.StatusUnauthorized, strings.Trim(err.Error(), "\"'"))
 	}
 
 	var validationError ValidationError
 	if json.Unmarshal([]byte(res.Output), &validationError) == nil && validationError.Err != "" {
-		return &validationError
+		return types.NewErrHttp(http.StatusUnauthorized, validationError.Error())
 	}
 
 	return nil

--- a/pkg/api/handlers/modelprovider.go
+++ b/pkg/api/handlers/modelprovider.go
@@ -157,12 +157,12 @@ func (mp *ModelProviderHandler) Validate(req api.Context) error {
 				ref.Name,
 			)
 		}
-		return types.NewErrHttp(http.StatusUnauthorized, strings.Trim(err.Error(), "\"'"))
+		return types.NewErrHttp(http.StatusProxyAuthRequired, strings.Trim(err.Error(), "\"'"))
 	}
 
 	var validationError ValidationError
 	if json.Unmarshal([]byte(res.Output), &validationError) == nil && validationError.Err != "" {
-		return types.NewErrHttp(http.StatusUnauthorized, validationError.Error())
+		return types.NewErrHttp(http.StatusProxyAuthRequired, validationError.Error())
 	}
 
 	return nil

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -26,7 +26,7 @@ func Router(services *services.Services) (http.Handler, error) {
 	cronJobs := handlers.NewCronJobHandler()
 	models := handlers.NewModelHandler()
 	availableModels := handlers.NewAvailableModelsHandler(services.GPTClient, services.ModelProviderDispatcher)
-	modelProviders := handlers.NewModelProviderHandler(services.GPTClient, services.ModelProviderDispatcher)
+	modelProviders := handlers.NewModelProviderHandler(services.GPTClient, services.ModelProviderDispatcher, services.Invoker)
 	prompt := handlers.NewPromptHandler(services.GPTClient)
 	emailreceiver := handlers.NewEmailReceiverHandler(services.EmailServerName)
 	defaultModelAliases := handlers.NewDefaultModelAliasHandler()
@@ -295,6 +295,7 @@ func Router(services *services.Services) (http.Handler, error) {
 	// Model providers
 	mux.HandleFunc("GET /api/model-providers", modelProviders.List)
 	mux.HandleFunc("GET /api/model-providers/{id}", modelProviders.ByID)
+	mux.HandleFunc("POST /api/model-providers/{id}/validate", modelProviders.Validate)
 	mux.HandleFunc("POST /api/model-providers/{id}/configure", modelProviders.Configure)
 	mux.HandleFunc("POST /api/model-providers/{id}/deconfigure", modelProviders.Deconfigure)
 	mux.HandleFunc("POST /api/model-providers/{id}/reveal", modelProviders.Reveal)

--- a/pkg/availablemodels/availablemodels.go
+++ b/pkg/availablemodels/availablemodels.go
@@ -19,7 +19,7 @@ func ForProvider(ctx context.Context, dispatcher *dispatcher.Dispatcher, modelPr
 
 	r, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String()+"/v1/models", nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request to model provider %s: %w", modelProviderName, err)
+		return nil, fmt.Errorf("failed to create request to model provider %q: %w", modelProviderName, err)
 	}
 
 	if token != "" {
@@ -28,18 +28,18 @@ func ForProvider(ctx context.Context, dispatcher *dispatcher.Dispatcher, modelPr
 
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make request to model provider %s: %w", modelProviderName, err)
+		return nil, fmt.Errorf("failed to make request to model provider %q: %w", modelProviderName, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		message, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to get model list from model provider %s: %s", modelProviderName, message)
+		return nil, fmt.Errorf("failed to get model list from model provider %q: %s", modelProviderName, message)
 	}
 
 	var oModels openai.ModelsList
 	if err = json.NewDecoder(resp.Body).Decode(&oModels); err != nil {
-		return nil, fmt.Errorf("failed to decode model list from model provider %s: %w", modelProviderName, err)
+		return nil, fmt.Errorf("failed to decode model list from model provider %q: %w", modelProviderName, err)
 	}
 
 	return &oModels, nil

--- a/ui/admin/app/components/model-providers/ModelProviderForm.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderForm.tsx
@@ -126,37 +126,32 @@ export function ModelProviderForm({
 		}
 	);
 
-    const validateAndConfigureModelProvider = useAsync(
-        ModelProviderApiService.validateModelProviderById,
-        {
-            onSuccess: async (data, params) => {
-                // Only configure the model provider if validation was successful
-                const [modelProviderId, configParams] = params;
-                await configureModelProvider.execute(
-                    modelProviderId,
-                    configParams
-                );
-            },
-            onError: (error) => {
-                // Handle validation errors
-                console.error("Validation failed:", error);
-            },
-        }
-    );
+	const validateAndConfigureModelProvider = useAsync(
+		ModelProviderApiService.validateModelProviderById,
+		{
+			onSuccess: async (data, params) => {
+				// Only configure the model provider if validation was successful
+				const [modelProviderId, configParams] = params;
+				await configureModelProvider.execute(modelProviderId, configParams);
+			},
+			onError: (error) => {
+				// Handle validation errors
+				console.error("Validation failed:", error);
+			},
+		}
+	);
 
-    const configureModelProvider = useAsync(
-        ModelProviderApiService.configureModelProviderById,
-        {
-            onSuccess: async () => {
-                mutate(
-                    ModelProviderApiService.revealModelProviderById.key(
-                        modelProvider.id
-                    )
-                );
-                await fetchAvailableModels.execute(modelProvider.id);
-            },
-        }
-    );
+	const configureModelProvider = useAsync(
+		ModelProviderApiService.configureModelProviderById,
+		{
+			onSuccess: async () => {
+				mutate(
+					ModelProviderApiService.revealModelProviderById.key(modelProvider.id)
+				);
+				await fetchAvailableModels.execute(modelProvider.id);
+			},
+		}
+	);
 
 	const form = useForm<ModelProviderFormValues>({
 		resolver: zodResolver(formSchema),
@@ -205,87 +200,77 @@ export function ModelProviderForm({
 				}
 			);
 
-            await validateAndConfigureModelProvider.execute(
-                modelProvider.id,
-                allConfigParams
-            );
-        }
-    );
+			await validateAndConfigureModelProvider.execute(
+				modelProvider.id,
+				allConfigParams
+			);
+		}
+	);
 
 	const FORM_ID = "model-provider-form";
 	const showCustomConfiguration =
 		modelProvider.id === "azure-openai-model-provider";
 
-    const loading =
-        validateAndConfigureModelProvider.isLoading ||
-        fetchAvailableModels.isLoading ||
-        configureModelProvider.isLoading ||
-        isLoading;
+	const loading =
+		validateAndConfigureModelProvider.isLoading ||
+		fetchAvailableModels.isLoading ||
+		configureModelProvider.isLoading ||
+		isLoading;
 
-    return (
-        <div className="flex flex-col">
-            {validateAndConfigureModelProvider.error !== null && (
-                <div className="px-4">
-                    <Alert variant="destructive">
-                        <CircleAlertIcon className="w-4 h-4" />
-                        <AlertTitle>An error occurred!</AlertTitle>
-                        <AlertDescription>
-                            Your configuration could not be saved, because it
-                            failed validation:{" "}
-                            <strong>
-                                {(typeof validateAndConfigureModelProvider.error ===
-                                    "object" &&
-                                    "message" in
-                                        validateAndConfigureModelProvider.error &&
-                                    (validateAndConfigureModelProvider.error
-                                        .message as string)) ??
-                                    "Unknown error"}
-                            </strong>
-                        </AlertDescription>
-                    </Alert>
-                </div>
-            )}
-            {validateAndConfigureModelProvider.error === null &&
-                fetchAvailableModels.error !== null && (
-                    <div className="px-4">
-                        <Alert variant="destructive">
-                            <CircleAlertIcon className="w-4 h-4" />
-                            <AlertTitle>An error occurred!</AlertTitle>
-                            <AlertDescription>
-                                Your configuration was saved, but we were not
-                                able to connect to the model provider. Please
-                                check your configuration and try again:{" "}
-                                <strong>
-                                    {(typeof fetchAvailableModels.error ===
-                                        "object" &&
-                                        "message" in
-                                            fetchAvailableModels.error &&
-                                        (fetchAvailableModels.error
-                                            .message as string)) ??
-                                        "Unknown error"}
-                                </strong>
-                            </AlertDescription>
-                        </Alert>
-                    </div>
-                )}
-            <ScrollArea className="max-h-[50vh]">
-                <div className="flex flex-col gap-4 p-4">
-                    <h4 className="font-semibold text-md">
-                        Required Configuration
-                    </h4>
-                    <Form {...form}>
-                        <form
-                            id={FORM_ID}
-                            onSubmit={form.handleSubmit(onSubmit)}
-                            className="flex flex-col gap-4"
-                        >
-                            {requiredConfigParamFields.fields.map(
-                                (field, i) => {
-                                    const type = ModelProviderSensitiveFields[
-                                        field.name
-                                    ]
-                                        ? "password"
-                                        : "text";
+	return (
+		<div className="flex flex-col">
+			{validateAndConfigureModelProvider.error !== null && (
+				<div className="px-4">
+					<Alert variant="destructive">
+						<CircleAlertIcon className="h-4 w-4" />
+						<AlertTitle>An error occurred!</AlertTitle>
+						<AlertDescription>
+							Your configuration could not be saved, because it failed
+							validation:{" "}
+							<strong>
+								{(typeof validateAndConfigureModelProvider.error === "object" &&
+									"message" in validateAndConfigureModelProvider.error &&
+									(validateAndConfigureModelProvider.error
+										.message as string)) ??
+									"Unknown error"}
+							</strong>
+						</AlertDescription>
+					</Alert>
+				</div>
+			)}
+			{validateAndConfigureModelProvider.error === null &&
+				fetchAvailableModels.error !== null && (
+					<div className="px-4">
+						<Alert variant="destructive">
+							<CircleAlertIcon className="h-4 w-4" />
+							<AlertTitle>An error occurred!</AlertTitle>
+							<AlertDescription>
+								Your configuration was saved, but we were not able to connect to
+								the model provider. Please check your configuration and try
+								again:{" "}
+								<strong>
+									{(typeof fetchAvailableModels.error === "object" &&
+										"message" in fetchAvailableModels.error &&
+										(fetchAvailableModels.error.message as string)) ??
+										"Unknown error"}
+								</strong>
+							</AlertDescription>
+						</Alert>
+					</div>
+				)}
+			<ScrollArea className="max-h-[50vh]">
+				<div className="flex flex-col gap-4 p-4">
+					<h4 className="text-md font-semibold">Required Configuration</h4>
+					<Form {...form}>
+						<form
+							id={FORM_ID}
+							onSubmit={form.handleSubmit(onSubmit)}
+							className="flex flex-col gap-4"
+						>
+							{requiredConfigParamFields.fields.map((field, i) => {
+								const type = ModelProviderSensitiveFields[field.name]
+									? "password"
+									: "text";
 
 								return (
 									<div

--- a/ui/admin/app/components/model-providers/ModelProviderForm.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderForm.tsx
@@ -126,17 +126,37 @@ export function ModelProviderForm({
 		}
 	);
 
-	const configureModelProvider = useAsync(
-		ModelProviderApiService.configureModelProviderById,
-		{
-			onSuccess: async () => {
-				mutate(
-					ModelProviderApiService.revealModelProviderById.key(modelProvider.id)
-				);
-				await fetchAvailableModels.execute(modelProvider.id);
-			},
-		}
-	);
+    const validateAndConfigureModelProvider = useAsync(
+        ModelProviderApiService.validateModelProviderById,
+        {
+            onSuccess: async (data, params) => {
+                // Only configure the model provider if validation was successful
+                const [modelProviderId, configParams] = params;
+                await configureModelProvider.execute(
+                    modelProviderId,
+                    configParams
+                );
+            },
+            onError: (error) => {
+                // Handle validation errors
+                console.error("Validation failed:", error);
+            },
+        }
+    );
+
+    const configureModelProvider = useAsync(
+        ModelProviderApiService.configureModelProviderById,
+        {
+            onSuccess: async () => {
+                mutate(
+                    ModelProviderApiService.revealModelProviderById.key(
+                        modelProvider.id
+                    )
+                );
+                await fetchAvailableModels.execute(modelProvider.id);
+            },
+        }
+    );
 
 	const form = useForm<ModelProviderFormValues>({
 		resolver: zodResolver(formSchema),
@@ -185,45 +205,87 @@ export function ModelProviderForm({
 				}
 			);
 
-			await configureModelProvider.execute(modelProvider.id, allConfigParams);
-		}
-	);
+            await validateAndConfigureModelProvider.execute(
+                modelProvider.id,
+                allConfigParams
+            );
+        }
+    );
 
 	const FORM_ID = "model-provider-form";
 	const showCustomConfiguration =
 		modelProvider.id === "azure-openai-model-provider";
 
-	const loading =
-		fetchAvailableModels.isLoading ||
-		configureModelProvider.isLoading ||
-		isLoading;
-	return (
-		<div className="flex flex-col">
-			{fetchAvailableModels.error !== null && (
-				<div className="px-4">
-					<Alert variant="destructive">
-						<CircleAlertIcon className="h-4 w-4" />
-						<AlertTitle>An error occurred!</AlertTitle>
-						<AlertDescription>
-							Your configuration was saved, but we were not able to connect to
-							the model provider. Please check your configuration and try again.
-						</AlertDescription>
-					</Alert>
-				</div>
-			)}
-			<ScrollArea className="max-h-[50vh]">
-				<div className="flex flex-col gap-4 p-4">
-					<h4 className="text-md font-semibold">Required Configuration</h4>
-					<Form {...form}>
-						<form
-							id={FORM_ID}
-							onSubmit={form.handleSubmit(onSubmit)}
-							className="flex flex-col gap-4"
-						>
-							{requiredConfigParamFields.fields.map((field, i) => {
-								const type = ModelProviderSensitiveFields[field.name]
-									? "password"
-									: "text";
+    const loading =
+        validateAndConfigureModelProvider.isLoading ||
+        fetchAvailableModels.isLoading ||
+        configureModelProvider.isLoading ||
+        isLoading;
+
+    return (
+        <div className="flex flex-col">
+            {validateAndConfigureModelProvider.error !== null && (
+                <div className="px-4">
+                    <Alert variant="destructive">
+                        <CircleAlertIcon className="w-4 h-4" />
+                        <AlertTitle>An error occurred!</AlertTitle>
+                        <AlertDescription>
+                            Your configuration could not be saved, because it
+                            failed validation:{" "}
+                            <strong>
+                                {(typeof validateAndConfigureModelProvider.error ===
+                                    "object" &&
+                                    "message" in
+                                        validateAndConfigureModelProvider.error &&
+                                    (validateAndConfigureModelProvider.error
+                                        .message as string)) ??
+                                    "Unknown error"}
+                            </strong>
+                        </AlertDescription>
+                    </Alert>
+                </div>
+            )}
+            {validateAndConfigureModelProvider.error === null &&
+                fetchAvailableModels.error !== null && (
+                    <div className="px-4">
+                        <Alert variant="destructive">
+                            <CircleAlertIcon className="w-4 h-4" />
+                            <AlertTitle>An error occurred!</AlertTitle>
+                            <AlertDescription>
+                                Your configuration was saved, but we were not
+                                able to connect to the model provider. Please
+                                check your configuration and try again:{" "}
+                                <strong>
+                                    {(typeof fetchAvailableModels.error ===
+                                        "object" &&
+                                        "message" in
+                                            fetchAvailableModels.error &&
+                                        (fetchAvailableModels.error
+                                            .message as string)) ??
+                                        "Unknown error"}
+                                </strong>
+                            </AlertDescription>
+                        </Alert>
+                    </div>
+                )}
+            <ScrollArea className="max-h-[50vh]">
+                <div className="flex flex-col gap-4 p-4">
+                    <h4 className="font-semibold text-md">
+                        Required Configuration
+                    </h4>
+                    <Form {...form}>
+                        <form
+                            id={FORM_ID}
+                            onSubmit={form.handleSubmit(onSubmit)}
+                            className="flex flex-col gap-4"
+                        >
+                            {requiredConfigParamFields.fields.map(
+                                (field, i) => {
+                                    const type = ModelProviderSensitiveFields[
+                                        field.name
+                                    ]
+                                        ? "password"
+                                        : "text";
 
 								return (
 									<div

--- a/ui/admin/app/hooks/useAsync.tsx
+++ b/ui/admin/app/hooks/useAsync.tsx
@@ -47,35 +47,30 @@ export function useAsync<TData, TParams extends unknown[]>(
 			setLastCallParams(params);
 			const promise = callback(...params);
 
-            promise
-                .then((data) => {
-                    setData(data);
-                    onSuccess?.(data, params);
-                })
-                .catch((error) => {
-                    // If the response data is a JSON string with an error field
-                    // unpack that error field's value into the error message
-                    if (
-                        error.response &&
-                        typeof error.response.data === "string"
-                    ) {
-                        const errorMessageMatch =
-                            error.response.data.match(/{"error":\s+"(.*?)"}/);
-                        if (errorMessageMatch) {
-                            const errorMessage = JSON.parse(
-                                errorMessageMatch[0]
-                            ).error;
-                            console.log("Error: ", errorMessage);
-                            error.message = errorMessage;
-                        }
-                    }
-                    setError(error);
-                    onError?.(error, params);
-                })
-                .finally(() => {
-                    setIsLoading(false);
-                    onSettled?.({ params });
-                });
+			promise
+				.then((data) => {
+					setData(data);
+					onSuccess?.(data, params);
+				})
+				.catch((error) => {
+					// If the response data is a JSON string with an error field
+					// unpack that error field's value into the error message
+					if (error.response && typeof error.response.data === "string") {
+						const errorMessageMatch =
+							error.response.data.match(/{"error":\s+"(.*?)"}/);
+						if (errorMessageMatch) {
+							const errorMessage = JSON.parse(errorMessageMatch[0]).error;
+							console.log("Error: ", errorMessage);
+							error.message = errorMessage;
+						}
+					}
+					setError(error);
+					onError?.(error, params);
+				})
+				.finally(() => {
+					setIsLoading(false);
+					onSettled?.({ params });
+				});
 
 			return await handlePromise(promise);
 		},

--- a/ui/admin/app/lib/routers/apiRoutes.ts
+++ b/ui/admin/app/lib/routers/apiRoutes.ts
@@ -262,8 +262,8 @@ export const ApiRoutes = {
 		getModelProviders: () => buildUrl("/model-providers"),
 		getModelProviderById: (modelProviderKey: string) =>
 			buildUrl(`/model-providers/${modelProviderKey}`),
-        validateModelProviderById: (modelProviderKey: string) =>
-            buildUrl(`/model-providers/${modelProviderKey}/validate`),
+		validateModelProviderById: (modelProviderKey: string) =>
+			buildUrl(`/model-providers/${modelProviderKey}/validate`),
 		configureModelProviderById: (modelProviderKey: string) =>
 			buildUrl(`/model-providers/${modelProviderKey}/configure`),
 		revealModelProviderById: (modelProviderKey: string) =>

--- a/ui/admin/app/lib/routers/apiRoutes.ts
+++ b/ui/admin/app/lib/routers/apiRoutes.ts
@@ -262,6 +262,8 @@ export const ApiRoutes = {
 		getModelProviders: () => buildUrl("/model-providers"),
 		getModelProviderById: (modelProviderKey: string) =>
 			buildUrl(`/model-providers/${modelProviderKey}`),
+        validateModelProviderById: (modelProviderKey: string) =>
+            buildUrl(`/model-providers/${modelProviderKey}/validate`),
 		configureModelProviderById: (modelProviderKey: string) =>
 			buildUrl(`/model-providers/${modelProviderKey}/configure`),
 		revealModelProviderById: (modelProviderKey: string) =>

--- a/ui/admin/app/lib/service/api/modelProviderApiService.ts
+++ b/ui/admin/app/lib/service/api/modelProviderApiService.ts
@@ -32,6 +32,23 @@ getModelProviderById.key = (modelProviderId?: string) => {
 	};
 };
 
+const validateModelProviderById = async (
+    modelProviderKey: string,
+    modelProviderConfig: ModelProviderConfig
+) => {
+    const res = await request<ModelProvider>({
+        url: ApiRoutes.modelProviders.validateModelProviderById(
+            modelProviderKey
+        ).url,
+        method: "POST",
+        data: modelProviderConfig,
+        errorMessage:
+            "Failed to validate configuration values on the requested modal provider.",
+    });
+
+    return res.data;
+};
+
 const configureModelProviderById = async (
 	modelProviderKey: string,
 	modelProviderConfig: ModelProviderConfig
@@ -81,7 +98,8 @@ const deconfigureModelProviderById = async (modelProviderKey: string) => {
 export const ModelProviderApiService = {
 	getModelProviders,
 	getModelProviderById,
-	configureModelProviderById,
-	revealModelProviderById,
-	deconfigureModelProviderById,
+	validateModelProviderById,
+    configureModelProviderById,
+    revealModelProviderById,
+    deconfigureModelProviderById,
 };

--- a/ui/admin/app/lib/service/api/modelProviderApiService.ts
+++ b/ui/admin/app/lib/service/api/modelProviderApiService.ts
@@ -33,20 +33,19 @@ getModelProviderById.key = (modelProviderId?: string) => {
 };
 
 const validateModelProviderById = async (
-    modelProviderKey: string,
-    modelProviderConfig: ModelProviderConfig
+	modelProviderKey: string,
+	modelProviderConfig: ModelProviderConfig
 ) => {
-    const res = await request<ModelProvider>({
-        url: ApiRoutes.modelProviders.validateModelProviderById(
-            modelProviderKey
-        ).url,
-        method: "POST",
-        data: modelProviderConfig,
-        errorMessage:
-            "Failed to validate configuration values on the requested modal provider.",
-    });
+	const res = await request<ModelProvider>({
+		url: ApiRoutes.modelProviders.validateModelProviderById(modelProviderKey)
+			.url,
+		method: "POST",
+		data: modelProviderConfig,
+		errorMessage:
+			"Failed to validate configuration values on the requested modal provider.",
+	});
 
-    return res.data;
+	return res.data;
 };
 
 const configureModelProviderById = async (
@@ -99,7 +98,7 @@ export const ModelProviderApiService = {
 	getModelProviders,
 	getModelProviderById,
 	validateModelProviderById,
-    configureModelProviderById,
-    revealModelProviderById,
-    deconfigureModelProviderById,
+	configureModelProviderById,
+	revealModelProviderById,
+	deconfigureModelProviderById,
 };


### PR DESCRIPTION
Important: This draft PR contains a couple of changes.

1. Change to the handler to populate ToolReference.Status.Error with an error message if available models couldn't be fetched
	![Screenshot-20241223111504-1128x61](https://github.com/user-attachments/assets/4e336867-277c-4d69-be14-c68074321852)
2. Change to the UI when calling `/available-models/{model-provider-id}` so it shows the error message to the user
	![Screenshot 2024-12-23 at 10-45-22 ](https://github.com/user-attachments/assets/00d714d3-30b1-485a-b3ca-aef6f8def241)
3. Change to the UI to call /validate and only if that succeeds, save the config and call /available-models
	- If it fails, don't save the config and display an appropriate error
4. Add the /validate endpoint for model providers which calls the subtool `validate from <model-provider-tool>` to validate the config (if available)

Tested with the "reference implementation" which is the gemini-vertex provider: https://github.com/obot-platform/obot/pull/986 / https://github.com/obot-platform/tools/pull/297
	
	
Ref:
- https://github.com/obot-platform/obot/issues/842
- https://github.com/obot-platform/obot/issues/819
- https://github.com/obot-platform/obot/issues/993
- https://github.com/obot-platform/obot/issues/991
- https://github.com/obot-platform/obot/issues/974
