### PR TITLE
fix: continue showing tool calls in revisiting thread

### DIFF
--- a/ui/admin/app/routes/_auth.workflows._index.tsx
+++ b/ui/admin/app/routes/_auth.workflows._index.tsx
@@ -111,6 +111,7 @@ export default function Workflows() {
                     cell: (info) => (
                         <div className="flex gap-2 items-center">
                             <Link
+                                onClick={(event) => event.stopPropagation()}
                                 to={$path("/threads", {
                                     workflowId: info.row.original.id,
                                     from: "workflows",


### PR DESCRIPTION
* instead of skipping events with toolCall.output, update the previous toolCall without an output with it during event phase
* allow showing of messages with toolCall.output

* tested with while running with a workflow, newly created agent 
* tested with going to Threads and visiting a pre-existing thread where a tool was used