### PR TITLE
fix: model-providers configured empty placeholder & combobox max height

### DIFF
--- a/ui/admin/app/components/composed/ComboBox.tsx
+++ b/ui/admin/app/components/composed/ComboBox.tsx
@@ -164,7 +164,7 @@ function ComboBoxList<T extends BaseOption>({
     return (
         <Command
             shouldFilter={false}
-            className="w-[var(--radix-popper-anchor-width)]"
+            className="w-[var(--radix-popper-anchor-width)] max-h-[50vh]"
         >
             <CommandInput
                 placeholder={placeholder}

--- a/ui/admin/app/routes/_auth.model-providers.tsx
+++ b/ui/admin/app/routes/_auth.model-providers.tsx
@@ -69,7 +69,9 @@ export default function ModelProviders() {
                             disabled={!modelProviderConfigured}
                         />
                     </div>
-                    {modelProviderConfigured ? null : (
+                    {modelProviderConfigured ? (
+                        <div className="w-full h-16" />
+                    ) : (
                         <WarningAlert
                             title="No Model Providers Configured!"
                             description="To use Obot's features, you'll need to


### PR DESCRIPTION
Addresses #827 and #841 

* set max height to avoid command dropdown being cut off due to smaller browser height screens
* set empty placeholder in model providers page to avoid jumping around from not configured -> configured