### PR TITLE
fix: agent id briefly showing on breadcrumb in threads

### DIFF
--- a/ui/admin/app/routes/_auth.agents._index.tsx
+++ b/ui/admin/app/routes/_auth.agents._index.tsx
@@ -24,7 +24,6 @@ import {
 } from "~/components/ui/tooltip";
 
 export async function clientLoader() {
-    mutate(AgentService.getAgents.key(), ThreadsService.getThreads.key());
     await Promise.all([
         preload(AgentService.getAgents.key(), AgentService.getAgents),
         preload(ThreadsService.getThreads.key(), ThreadsService.getThreads),
@@ -72,6 +71,7 @@ export default function Agents() {
                                         name: generateRandomName(),
                                     } as Agent,
                                 }).then((agent) => {
+                                    mutate(AgentService.getAgents.key());
                                     navigate(
                                         $path("/agents/:agent", {
                                             agent: agent.id,

--- a/ui/admin/app/routes/_auth.threads.$id.tsx
+++ b/ui/admin/app/routes/_auth.threads.$id.tsx
@@ -74,7 +74,7 @@ export default function ChatAgent() {
         throw new Error("Trying to view a thread with an unsupported parent.");
     };
 
-    const [isAgent, entity] = [agent !== null, getEntity()];
+    const entity = getEntity();
 
     return (
         <div className="h-full flex flex-col overflow-hidden relative">


### PR DESCRIPTION
Addresses #816 and #815

* fixing showing of agent id instead of agent name in Threads page