### PR TITLE
feat: add credentials api service to admin ui

### DIFF
--- a/ui/admin/app/lib/model/credentials.ts
+++ b/ui/admin/app/lib/model/credentials.ts
@@ -1,0 +1,14 @@
+export const CredentialNamespace = {
+    Threads: "threads",
+    Agents: "agents",
+    Workflows: "workflows",
+} as const;
+export type CredentialNamespace =
+    (typeof CredentialNamespace)[keyof typeof CredentialNamespace];
+
+export type Credential = {
+    contextID: string;
+    name: string;
+    envVars: string[];
+    expiresAt?: string; // date
+};

--- a/ui/admin/app/lib/model/primitives.ts
+++ b/ui/admin/app/lib/model/primitives.ts
@@ -12,3 +12,5 @@ export type EntityMeta<
     metadata?: TMetadata;
     type?: string;
 };
+
+export type EntityList<T> = { items: Nullish<T[]> };

--- a/ui/admin/app/lib/routers/apiRoutes.ts
+++ b/ui/admin/app/lib/routers/apiRoutes.ts
@@ -1,6 +1,7 @@
 import queryString from "query-string";
 import { mutate } from "swr";
 
+import { CredentialNamespace } from "~/lib/model/credentials";
 import {
     KnowledgeFileNamespace,
     KnowledgeSourceNamespace,
@@ -166,6 +167,17 @@ export const ApiRoutes = {
     env: {
         getEnv: (entityId: string) => buildUrl(`/agents/${entityId}/env`),
         updateEnv: (entityId: string) => buildUrl(`/agents/${entityId}/env`),
+    },
+    credentials: {
+        getCredentialsForEntity: (
+            namespace: CredentialNamespace,
+            entityId: string
+        ) => buildUrl(`/${namespace}/${entityId}/credentials`),
+        deleteCredential: (
+            namespace: CredentialNamespace,
+            entityId: string,
+            credentialId: string
+        ) => buildUrl(`/${namespace}/${entityId}/credentials/${credentialId}`),
     },
     threads: {
         base: () => buildUrl("/threads"),

--- a/ui/admin/app/lib/service/api/credentialApiService.ts
+++ b/ui/admin/app/lib/service/api/credentialApiService.ts
@@ -1,0 +1,48 @@
+import { Credential, CredentialNamespace } from "~/lib/model/credentials";
+import { EntityList } from "~/lib/model/primitives";
+import { ApiRoutes } from "~/lib/routers/apiRoutes";
+import { request } from "~/lib/service/api/primitives";
+
+async function getCredentials(
+    namespace: CredentialNamespace,
+    entityId: string
+) {
+    const { data } = await request<EntityList<Credential>>({
+        url: ApiRoutes.credentials.getCredentialsForEntity(namespace, entityId)
+            .url,
+    });
+
+    return data.items ?? [];
+}
+getCredentials.key = (
+    namespace: CredentialNamespace,
+    entityId?: Nullish<string>
+) => {
+    if (!entityId) return null;
+
+    return {
+        url: ApiRoutes.credentials.getCredentialsForEntity(namespace, entityId)
+            .path,
+        entityId,
+        namespace,
+    };
+};
+
+async function deleteCredential(
+    namespace: CredentialNamespace,
+    entityId: string,
+    credentialId: string
+) {
+    await request({
+        url: ApiRoutes.credentials.deleteCredential(
+            namespace,
+            entityId,
+            credentialId
+        ).url,
+    });
+}
+
+export const CredentialApiService = {
+    getCredentials,
+    deleteCredential,
+};


### PR DESCRIPTION
- adds api routes + credential api service
- apis and services are namespaced to allow for reused code between agents, workflows, and threads