### PR TITLE
fix: minor ui updates & fix model provider key updating on save/error

### DIFF
--- a/ui/admin/app/components/model-providers/ModelProviderForm.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderForm.tsx
@@ -119,11 +119,6 @@ export function ModelProviderForm({
         {
             onSuccess: () => {
                 mutate(ModelProviderApiService.getModelProviders.key());
-                mutate(
-                    ModelProviderApiService.revealModelProviderById.key(
-                        modelProvider.id
-                    )
-                );
                 onSuccess();
             },
         }
@@ -133,6 +128,11 @@ export function ModelProviderForm({
         ModelProviderApiService.configureModelProviderById,
         {
             onSuccess: async () => {
+                mutate(
+                    ModelProviderApiService.revealModelProviderById.key(
+                        modelProvider.id
+                    )
+                );
                 await fetchAvailableModels.execute(modelProvider.id);
             },
         }

--- a/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
+++ b/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
@@ -66,10 +66,12 @@ export function ToolCard({ tool, onDelete }: ToolCardProps) {
                 </TypographyH4>
             </CardHeader>
             <CardContent className="flex-grow">
-                <TruncatedText
-                    content={tool.reference}
-                    className="max-w-full"
-                />
+                {!tool.builtin && (
+                    <TruncatedText
+                        content={tool.reference}
+                        className="max-w-full"
+                    />
+                )}
                 <TypographyP className="mt-2 text-sm text-muted-foreground line-clamp-2">
                     {tool.description || "No description available"}
                 </TypographyP>

--- a/ui/admin/app/components/webhooks/WebhookConfirmation.tsx
+++ b/ui/admin/app/components/webhooks/WebhookConfirmation.tsx
@@ -61,7 +61,7 @@ export const WebhookConfirmation = ({
                     <TypographyP>Payload URL: </TypographyP>
                     <CopyText
                         text={getWebhookUrl(webhook, token)}
-                        className="min-w-fit"
+                        className="w-fit-content max-w-full"
                     />
                 </div>
 


### PR DESCRIPTION
Addresses #814 
Addresses #1042 
Addresses #901 

* minor adjustments for ui in tools, webhook, and model provider
* fixes overflow of webhook url in dialog
* removes tool.reference from displaying for built-in tools per request
* makes sure model provider revealed keys gets revalidated on success of configure rather than success of getting of models