### PR TITLE
Fix: Don't show yellow text for unsupported files

### DIFF
--- a/ui/admin/app/components/knowledge/FileTree.tsx
+++ b/ui/admin/app/components/knowledge/FileTree.tsx
@@ -400,7 +400,7 @@ export default function FileTreeNode({
                                                         Unsupported
                                                     </Label>
                                                 </TooltipTrigger>
-                                                <TooltipContent className="text-warning">
+                                                <TooltipContent>
                                                     {node.file.error}
                                                 </TooltipContent>
                                             </Tooltip>


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/719