### PR TITLE
enhance: add metadata information to authentication messages once auth is confirmed

### DIFF
--- a/ui/admin/app/components/chat/Message.tsx
+++ b/ui/admin/app/components/chat/Message.tsx
@@ -163,8 +163,30 @@ function PromptMessage({ prompt }: { prompt: AuthPrompt }) {
     };
 
     const getSubmittedText = () => {
-        if (prompt.metadata?.authURL || prompt.metadata?.authType)
-            return "Authenticated";
+        if (prompt.metadata?.authURL || prompt.metadata?.authType) {
+            let str = "Authenticated";
+
+            if (prompt.metadata.category) {
+                str += ` with ${prompt.metadata.category}`;
+            }
+
+            if (prompt.metadata.icon) {
+                return (
+                    <div className="flex items-center gap-2">
+                        <ToolIcon
+                            name={prompt.name}
+                            category={prompt.metadata.category}
+                            icon={prompt.metadata.icon}
+                            disableTooltip
+                            className="w-5 h-5"
+                        />
+                        {str}
+                    </div>
+                );
+            }
+
+            return str;
+        }
 
         return "Parameters Submitted";
     };


### PR DESCRIPTION
addresses #730 

pulls icon and category information from the prompt metadata and displays it in the message

<img width="686" alt="Screenshot 2024-12-30 at 5 15 13 PM" src="https://github.com/user-attachments/assets/f57bf7d3-bafe-4e2d-b040-1585341f3710" />

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>