### PR TITLE
enhance: add no-reply email to server config

### DIFF
--- a/pkg/invoke/invoker.go
+++ b/pkg/invoke/invoker.go
@@ -35,24 +35,26 @@ import (
 var log = logger.Package()
 
 type Invoker struct {
-	gptClient     *gptscript.GPTScript
-	uncached      kclient.WithWatch
-	gatewayClient *client.Client
-	tokenService  *jwt.TokenService
-	events        *events.Emitter
-	serverURL     string
-	serverPort    int
+	gptClient           *gptscript.GPTScript
+	uncached            kclient.WithWatch
+	gatewayClient       *client.Client
+	tokenService        *jwt.TokenService
+	events              *events.Emitter
+	noReplyEmailAddress string
+	serverURL           string
+	serverPort          int
 }
 
-func NewInvoker(c kclient.WithWatch, gptClient *gptscript.GPTScript, gatewayClient *client.Client, serverURL string, serverPort int, tokenService *jwt.TokenService, events *events.Emitter) *Invoker {
+func NewInvoker(c kclient.WithWatch, gptClient *gptscript.GPTScript, gatewayClient *client.Client, noReplyEmailAddress, serverURL string, serverPort int, tokenService *jwt.TokenService, events *events.Emitter) *Invoker {
 	return &Invoker{
-		uncached:      c,
-		gptClient:     gptClient,
-		gatewayClient: gatewayClient,
-		tokenService:  tokenService,
-		events:        events,
-		serverURL:     serverURL,
-		serverPort:    serverPort,
+		uncached:            c,
+		gptClient:           gptClient,
+		gatewayClient:       gatewayClient,
+		tokenService:        tokenService,
+		events:              events,
+		serverURL:           serverURL,
+		serverPort:          serverPort,
+		noReplyEmailAddress: noReplyEmailAddress,
 	}
 }
 
@@ -515,7 +517,8 @@ func (i *Invoker) Resume(ctx context.Context, c kclient.WithWatch, thread *v1.Th
 				"OBOT_USER_ID="+userID,
 				"OBOT_USER_NAME="+userName,
 				"OBOT_USER_EMAIL="+userEmail,
-				"GPTSCRIPT_HTTP_ENV=OBOT_TOKEN,OBOT_RUN_ID,OBOT_THREAD_ID,OBOT_WORKFLOW_ID,OBOT_WORKFLOW_STEP_ID,OBOT_AGENT_ID",
+				"OBOT_NO_REPLY_EMAIL="+i.noReplyEmailAddress,
+				"GPTSCRIPT_HTTP_ENV=OBOT_TOKEN,OBOT_RUN_ID,OBOT_THREAD_ID,OBOT_WORKFLOW_ID,OBOT_WORKFLOW_STEP_ID,OBOT_AGENT_ID,OBOT_NO_REPLY_EMAIL",
 			),
 			DefaultModel:         run.Spec.DefaultModel,
 			DefaultModelProvider: modelProvider,

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	EncryptionConfigFile       string `usage:"The path to the encryption configuration file" default:"./encryption.yaml"`
 	KnowledgeSetIngestionLimit int    `usage:"The maximum number of files to ingest into a knowledge set" default:"1000" env:"OBOT_KNOWLEDGESET_INGESTION_LIMIT" name:"knowledge-set-ingestion-limit"`
 	EmailServerName            string `usage:"The name of the email server to display for email receivers (default: ui-hostname value)"`
+	NoReplyEmailAddress        string `usage:"The email to use for no-reply emails from obot"`
 
 	AuthConfig
 	GatewayConfig
@@ -217,7 +218,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		tokenServer             = &jwt.TokenService{}
 		events                  = events.NewEmitter(storageClient)
 		gatewayClient           = client.New(gatewayDB, config.AuthAdminEmails)
-		invoker                 = invoke.NewInvoker(storageClient, c, client.New(gatewayDB, config.AuthAdminEmails), config.Hostname, config.HTTPListenPort, tokenServer, events)
+		invoker                 = invoke.NewInvoker(storageClient, c, client.New(gatewayDB, config.AuthAdminEmails), config.NoReplyEmailAddress, config.Hostname, config.HTTPListenPort, tokenServer, events)
 		modelProviderDispatcher = dispatcher.New(invoker, storageClient, c)
 
 		proxyServer *proxy.Proxy


### PR DESCRIPTION
Add a no-reply email address option to the Obot server configuration. This setting is passed down to running tools so that the sendgrid tool can send emails using a pre-configured no-reply address.

