### PR TITLE
feat: show confirmation modals when deleting or updating the type of a workflow step

### DIFF
--- a/ui/admin/app/components/agent/AgentDropdownActions.tsx
+++ b/ui/admin/app/components/agent/AgentDropdownActions.tsx
@@ -15,7 +15,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu";
-import { useConfirmationDialog } from "~/hooks/component-helpers/useConfirmationDropdown";
+import { useConfirmationDialog } from "~/hooks/component-helpers/useConfirmationDialog";
 import { useAsync } from "~/hooks/useAsync";
 
 export function AgentDropdownActions({ agent }: { agent: Agent }) {

--- a/ui/admin/app/components/composed/ConfirmationDialog.tsx
+++ b/ui/admin/app/components/composed/ConfirmationDialog.tsx
@@ -11,6 +11,16 @@ import {
     DialogTrigger,
 } from "~/components/ui/dialog";
 
+export type ConfirmationDialogProps = ComponentProps<typeof Dialog> & {
+    children?: ReactNode;
+    title: ReactNode;
+    description?: ReactNode;
+    onConfirm: (e: React.MouseEvent<HTMLButtonElement>) => void;
+    onCancel?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+    confirmProps?: Omit<Partial<ComponentProps<typeof Button>>, "onClick">;
+    closeOnConfirm?: boolean;
+};
+
 export function ConfirmationDialog({
     children,
     title,
@@ -20,15 +30,7 @@ export function ConfirmationDialog({
     confirmProps,
     closeOnConfirm = true,
     ...dialogProps
-}: ComponentProps<typeof Dialog> & {
-    children?: ReactNode;
-    title: ReactNode;
-    description?: ReactNode;
-    onConfirm: (e: React.MouseEvent<HTMLButtonElement>) => void;
-    onCancel?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-    confirmProps?: Omit<Partial<ComponentProps<typeof Button>>, "onClick">;
-    closeOnConfirm?: boolean;
-}) {
+}: ConfirmationDialogProps) {
     return (
         <Dialog {...dialogProps}>
             {children && <DialogTrigger asChild>{children}</DialogTrigger>}

--- a/ui/admin/app/hooks/component-helpers/useConfirmationDialog.tsx
+++ b/ui/admin/app/hooks/component-helpers/useConfirmationDialog.tsx
@@ -1,10 +1,9 @@
-import { ComponentProps, useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { noop } from "~/lib/utils";
 
-import { ConfirmationDialog } from "~/components/composed/ConfirmationDialog";
+import { ConfirmationDialogProps } from "~/components/composed/ConfirmationDialog";
 
-type ConfirmationDialogProps = ComponentProps<typeof ConfirmationDialog>;
 type Handler = (e: React.MouseEvent<HTMLButtonElement>) => void;
 type AsyncHandler = (
     e: React.MouseEvent<HTMLButtonElement>


### PR DESCRIPTION
Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>