### PR TITLE
enhance: plumb tz from client-side uis to tools

### DIFF
--- a/apiclient/types/user.go
+++ b/apiclient/types/user.go
@@ -20,6 +20,7 @@ type User struct {
 	Role     Role   `json:"role,omitempty"`
 	Email    string `json:"email,omitempty"`
 	IconURL  string `json:"iconURL,omitempty"`
+	Timezone string `json:"timezone,omitempty"`
 }
 
 type UserList List[User]

--- a/pkg/api/authn/noauth.go
+++ b/pkg/api/authn/noauth.go
@@ -1,20 +1,44 @@
 package authn
 
 import (
+	"fmt"
 	"net/http"
 
+	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/gateway/types"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 type NoAuth struct {
+	client *client.Client
 }
 
-func (n NoAuth) AuthenticateRequest(*http.Request) (*authenticator.Response, bool, error) {
+func NewNoAuth(client *client.Client) *NoAuth {
+	return &NoAuth{
+		client: client,
+	}
+}
+
+func (n *NoAuth) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	gatewayUser, err := n.client.EnsureIdentityWithRole(
+		req.Context(),
+		&types.Identity{
+			ProviderUsername: "nobody",
+		},
+		req.Header.Get("X-Obot-User-Timezone"),
+		types2.RoleAdmin,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name:   "nobody",
+			UID:    fmt.Sprintf("%d", gatewayUser.ID),
 			Groups: []string{authz.AdminGroup, authz.AuthenticatedGroup},
 		},
 	}, true, nil

--- a/pkg/api/handlers/assistants.go
+++ b/pkg/api/handlers/assistants.go
@@ -91,6 +91,7 @@ func (a *AssistantHandler) Invoke(req api.Context) error {
 
 	resp, err := a.invoker.Agent(req.Context(), req.Storage, agent, string(input), invoke.Options{
 		ThreadName: thread.Name,
+		UserUID:    req.User.GetUID(),
 	})
 	if err != nil {
 		return err

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -286,3 +286,7 @@ func (r *Context) AuthProviderID() uint {
 
 	return uint(authProviderID)
 }
+
+func (r *Context) UserTimezone() string {
+	return r.Request.Header.Get("X-Obot-User-Timezone")
+}

--- a/pkg/controller/data/agent.yaml
+++ b/pkg/controller/data/agent.yaml
@@ -21,7 +21,7 @@ spec:
     alias: obot
     tools:
     - workspace-files
-    - time
+    - time-bundle
     - knowledge
     - database
     - tasks

--- a/pkg/gateway/client/auth.go
+++ b/pkg/gateway/client/auth.go
@@ -36,7 +36,7 @@ func (u UserDecorator) AuthenticateRequest(req *http.Request) (*authenticator.Re
 		Email:            firstValue(resp.User.GetExtra(), "email"),
 		AuthProviderID:   uint(firstValueAsInt(resp.User.GetExtra(), "auth_provider_id")),
 		ProviderUsername: resp.User.GetName(),
-	})
+	}, req.Header.Get("X-Obot-User-Timezone"))
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -10,16 +10,21 @@ import (
 )
 
 // EnsureIdentity ensures that the given identity exists in the database, and returns the user associated with it.
-func (c *Client) EnsureIdentity(ctx context.Context, id *types.Identity) (*types.User, error) {
+func (c *Client) EnsureIdentity(ctx context.Context, id *types.Identity, timezone string) (*types.User, error) {
 	role := types2.RoleBasic
 	if _, ok := c.adminEmails[id.Email]; ok {
 		role = types2.RoleAdmin
 	}
 
+	return c.EnsureIdentityWithRole(ctx, id, timezone, role)
+}
+
+// EnsureIdentityWithRole ensures the given identity exists in the database with the given role, and returns the user associated with it.
+func (c *Client) EnsureIdentityWithRole(ctx context.Context, id *types.Identity, timezone string, role types2.Role) (*types.User, error) {
 	var user *types.User
 	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var err error
-		user, err = EnsureIdentity(tx, id, role)
+		user, err = EnsureIdentity(tx, id, timezone, role)
 		return err
 	}); err != nil {
 		return nil, err
@@ -29,7 +34,7 @@ func (c *Client) EnsureIdentity(ctx context.Context, id *types.Identity) (*types
 }
 
 // EnsureIdentity ensures that the given identity exists in the database, and returns the user associated with it.
-func EnsureIdentity(tx *gorm.DB, id *types.Identity, role types2.Role) (*types.User, error) {
+func EnsureIdentity(tx *gorm.DB, id *types.Identity, timezone string, role types2.Role) (*types.User, error) {
 	email := id.Email
 	if err := tx.First(id).Error; errors.Is(err, gorm.ErrRecordNotFound) {
 		if err = tx.Create(id).Error; err != nil {
@@ -69,8 +74,18 @@ func EnsureIdentity(tx *gorm.DB, id *types.Identity, role types2.Role) (*types.U
 		return nil, err
 	}
 
+	var userChanged bool
 	if user.Role != role {
 		user.Role = role
+		userChanged = true
+	}
+
+	if user.Timezone == "" && timezone != "" {
+		user.Timezone = timezone
+		userChanged = true
+	}
+
+	if userChanged {
 		if err := tx.Updates(user).Error; err != nil {
 			return nil, err
 		}
@@ -84,4 +99,36 @@ func EnsureIdentity(tx *gorm.DB, id *types.Identity, role types2.Role) (*types.U
 	}
 
 	return user, nil
+}
+
+// RemoveIdentity deletes an identity and the associated user from the database.
+// The identity and user are deleted using UserID if set, otherwise ProviderUsername.
+// The method is idempotent and ignores not-found errors, returning only unexpected errors.
+func (c *Client) RemoveIdentity(ctx context.Context, id *types.Identity) error {
+	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var identityQuery, userQuery *gorm.DB
+
+		// Build queries based on UserID or ProviderUsername
+		if id.UserID != 0 {
+			// Use UserID if set
+			identityQuery = tx.Where("user_id = ?", id.UserID)
+			userQuery = tx.Where("id = ?", id.UserID)
+		} else {
+			// Fall back to ProviderUsername
+			identityQuery = tx.Where("provider_username = ?", id.ProviderUsername)
+			userQuery = tx.Where("username = ?", id.ProviderUsername)
+		}
+
+		// Attempt to delete the identity
+		if err := identityQuery.Delete(&types.Identity{}).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		// Attempt to delete the user
+		if err := userQuery.Delete(&types.User{}).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+
+		return nil
+	})
 }

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -17,6 +17,7 @@ type User struct {
 	Email     string      `json:"email"`
 	Role      types2.Role `json:"role"`
 	IconURL   string      `json:"iconURL"`
+	Timezone  string      `json:"timezone"`
 }
 
 func ConvertUser(u *User) *types2.User {
@@ -33,6 +34,7 @@ func ConvertUser(u *User) *types2.User {
 		Email:    u.Email,
 		Role:     u.Role,
 		IconURL:  u.IconURL,
+		Timezone: u.Timezone,
 	}
 }
 

--- a/pkg/invoke/invoker.go
+++ b/pkg/invoke/invoker.go
@@ -483,14 +483,14 @@ func (i *Invoker) Resume(ctx context.Context, c kclient.WithWatch, thread *v1.Th
 		return err
 	}
 
-	var userID, userName, userEmail string
-	if thread.Spec.UserUID != "" && thread.Spec.UserUID != "nobody" {
+	var userID, userName, userEmail, userTimezone string
+	if thread.Spec.UserUID != "" {
 		u, err := i.gatewayClient.UserByID(ctx, thread.Spec.UserUID)
 		if err != nil {
 			return fmt.Errorf("failed to get user: %w", err)
 		}
 
-		userID, userName, userEmail = thread.Spec.UserUID, u.Username, u.Email
+		userID, userName, userEmail, userTimezone = thread.Spec.UserUID, u.Username, u.Email, u.Timezone
 	}
 
 	token, err := i.tokenService.NewToken(jwt.TokenContext{
@@ -534,6 +534,7 @@ func (i *Invoker) Resume(ctx context.Context, c kclient.WithWatch, thread *v1.Th
 				"OBOT_USER_ID="+userID,
 				"OBOT_USER_NAME="+userName,
 				"OBOT_USER_EMAIL="+userEmail,
+				"OBOT_USER_TIMEZONE="+userTimezone,
 				"OBOT_NO_REPLY_EMAIL="+i.noReplyEmailAddress,
 				"GPTSCRIPT_HTTP_ENV=OBOT_TOKEN,OBOT_RUN_ID,OBOT_THREAD_ID,OBOT_WORKFLOW_ID,OBOT_WORKFLOW_STEP_ID,OBOT_AGENT_ID,OBOT_NO_REPLY_EMAIL",
 			),

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -3831,6 +3831,12 @@ func schema_obot_platform_obot_apiclient_types_User(ref common.ReferenceCallback
 							Format: "",
 						},
 					},
+					"timezone": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"Metadata"},
 			},

--- a/ui/admin/app/lib/model/users.ts
+++ b/ui/admin/app/lib/model/users.ts
@@ -5,6 +5,7 @@ export type User = EntityMeta & {
     email: string;
     role: Role;
     iconURL: string;
+    timezone: string;
 };
 
 export const Role = {

--- a/ui/user/src/lib/services/chat/http.ts
+++ b/ui/user/src/lib/services/chat/http.ts
@@ -12,7 +12,15 @@ interface GetOptions {
 }
 
 export async function doGet(path: string, opts?: GetOptions): Promise<unknown> {
-	const resp = await fetch(baseURL + path);
+	const resp = await fetch(baseURL + path, {
+		headers: {
+			// Pass the browser timezone as a request header.
+			// This is consumed during authentication to set the user's default timezone in Obot.
+			// The timezone is plumbed down to tools at runtime as an environment variable.
+			'x-obot-user-timezone': Intl.DateTimeFormat().resolvedOptions().timeZone
+		}
+	});
+
 	if (!resp.ok) {
 		const body = await resp.text();
 		const e = new Error(`${resp.status} ${path}: ${body}`);


### PR DESCRIPTION
Make the [tz database timezone ID](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for the default timezone of a user available to tools at runtime via the `OBOT_USER_TIMEZONE` environment variable.

e.g. `OBOT_USER_TIMEZONE=America/New_York`

TThe timezone ID is captured by the admin and user UIs from the browser and passed using the `X-Obot-User-Timezone` header on requests to Obot's APIs. The header is then unpacked in Obot's Authentication middleware and persisted in the respective `User` object. When a thread is invoked, its value is extracted from the `User` and passed to tool calls via the aforementioned environment variable.

The user's timezone can be customized independently of this defaulting mechanism by issuing a PATCH on `/api/users/{username}` with a body containing the desired timezone. Existing non-empty timezone fields on `User` objects take precedence over the timezone header.

Partially addresses https://github.com/obot-platform/obot/issues/1111
