### PR TITLE
fix: error boundary go back

### DIFF
--- a/ui/admin/app/components/errors/Error.tsx
+++ b/ui/admin/app/components/errors/Error.tsx
@@ -1,4 +1,5 @@
-import { ArrowLeft, HomeIcon } from "lucide-react";
+import { ArrowLeft, HomeIcon, RefreshCw } from "lucide-react";
+import { useNavigate } from "react-router";
 
 import { ObotLogo } from "~/components/branding/ObotLogo";
 import { Button } from "~/components/ui/button";
@@ -13,6 +14,8 @@ import {
 import { Link } from "~/components/ui/link";
 
 export function Error({ error }: { error: Error }) {
+    const navigate = useNavigate();
+
     return (
         <div className="flex min-h-screen w-full items-center justify-center p-4">
             <Card className="w-96">
@@ -27,23 +30,35 @@ export function Error({ error }: { error: Error }) {
                         persists.
                     </p>
                 </CardContent>
-                <CardFooter className="flex gap-4">
-                    <Link
-                        as="button"
-                        className="w-full"
-                        variant="secondary"
-                        to="/"
-                    >
-                        <HomeIcon /> Go home
-                    </Link>
+
+                <CardFooter className="flex flex-col gap-4">
                     <Button
                         className="w-full"
-                        variant="secondary"
-                        onClick={() => window.location.reload()}
-                        startContent={<ArrowLeft />}
+                        onClick={() => navigate(0)}
+                        startContent={<RefreshCw />}
                     >
-                        Go back
+                        Try again
                     </Button>
+
+                    <div className="flex items-center gap-4 w-full">
+                        <Link
+                            as="button"
+                            className="w-full"
+                            variant="secondary"
+                            to="/"
+                        >
+                            <HomeIcon /> Go home
+                        </Link>
+
+                        <Button
+                            className="w-full"
+                            variant="secondary"
+                            onClick={() => navigate(-1)}
+                            startContent={<ArrowLeft />}
+                        >
+                            Go back
+                        </Button>
+                    </div>
                 </CardFooter>
             </Card>
         </div>

--- a/ui/admin/app/components/errors/RouteError.tsx
+++ b/ui/admin/app/components/errors/RouteError.tsx
@@ -1,4 +1,4 @@
-import { ErrorResponse } from "react-router";
+import { ErrorResponse, useNavigate } from "react-router";
 
 import { ObotLogo } from "~/components/branding/ObotLogo";
 import { Button } from "~/components/ui/button";
@@ -12,6 +12,8 @@ import {
 } from "~/components/ui/card";
 
 export function RouteError({ error }: { error: ErrorResponse }) {
+    const navigate = useNavigate();
+
     return (
         <div className="flex min-h-screen w-full items-center justify-center p-4">
             <Card className="w-96">
@@ -29,7 +31,7 @@ export function RouteError({ error }: { error: ErrorResponse }) {
                     <Button
                         className="w-full"
                         variant="secondary"
-                        onClick={() => window.location.reload()}
+                        onClick={() => navigate(0)}
                     >
                         Try Again
                     </Button>

--- a/ui/admin/app/routes/_auth.workflows.$workflow.tsx
+++ b/ui/admin/app/routes/_auth.workflows.$workflow.tsx
@@ -39,7 +39,7 @@ export const clientLoader = async ({
 
     if (!pathParams.workflow) throw redirect($path("/workflows"));
 
-    const promises = await Promise.all([
+    const [workflow] = await Promise.all([
         preload(WorkflowService.getWorkflowById.key(pathParams.workflow), () =>
             WorkflowService.getWorkflowById(pathParams.workflow)
         ),
@@ -50,8 +50,6 @@ export const clientLoader = async ({
             WebhookApiService.getWebhooks()
         ),
     ]);
-
-    const workflow = promises[0];
 
     if (!workflow) throw redirect($path("/workflows"));
 


### PR DESCRIPTION
addresses #1114

- fixes the `go back` cta
- adds a third `try again` option that refreshes the page

![image](https://github.com/user-attachments/assets/ffb65785-f3a1-454a-b39e-681c79fd75df)


Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>