### PR TITLE
chore: drop default header options from webhook form

### DIFF
--- a/ui/admin/app/components/webhooks/WebhookFormContext.tsx
+++ b/ui/admin/app/components/webhooks/WebhookFormContext.tsx
@@ -54,7 +54,7 @@ export function WebhookFormContextProvider({
             description: webhook?.description ?? "",
             alias: webhook?.alias ?? "",
             workflow: webhook?.workflow ?? "",
-            headers: webhook?.headers ?? ["User-Agent", "X-GitHub-Event"],
+            headers: webhook?.headers ?? [],
             validationHeader: webhook?.validationHeader ?? "",
             secret: "",
             token: "",


### PR DESCRIPTION
Before:
<img width="799" alt="Screenshot 2025-01-06 at 3 51 33 PM" src="https://github.com/user-attachments/assets/84629450-2c31-4e01-b872-18633e4ffdc7" />

After:
<img width="799" alt="Screenshot 2025-01-06 at 3 51 20 PM" src="https://github.com/user-attachments/assets/902aff3e-6e84-4936-9121-8ef83bda3310" />
