### PR TITLE
fix: properly report credential info for tools with model provider cred

### DIFF
--- a/pkg/controller/handlers/toolinfo/toolinfo.go
+++ b/pkg/controller/handlers/toolinfo/toolinfo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/otto.otto8.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -39,10 +40,11 @@ func (h *Handler) SetToolInfoStatus(req router.Request, resp router.Response) (e
 	if err != nil {
 		return err
 	}
-	credsSet := make(sets.Set[string], len(creds))
+	credsSet := make(sets.Set[string], len(creds)+1)
 	for _, cred := range creds {
 		credsSet.Insert(cred.ToolName)
 	}
+	credsSet.Insert(system.ModelProviderCredential)
 
 	obj := req.Object.(v1.ToolUser)
 	tools := obj.GetTools()

--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -524,6 +524,10 @@ func modelName(modelProviderName, modelName string) string {
 }
 
 func determineCredentialNames(prg *gptscript.Program, tool gptscript.Tool, toolName string) ([]string, error) {
+	if toolName == system.ModelProviderCredential {
+		return []string{system.ModelProviderCredential}, nil
+	}
+
 	var subTool string
 	parsedToolName, alias, args, err := gtypes.ParseCredentialArgs(toolName, "")
 	if err != nil {

--- a/pkg/system/tools.go
+++ b/pkg/system/tools.go
@@ -16,4 +16,6 @@ const (
 	ExistingCredTool        = "existing-credential"
 
 	DefaultNamespace = "default"
+
+	ModelProviderCredential = "sys.model.provider.credential"
 )


### PR DESCRIPTION
The model provider credential is special and will always be set to point back to Obot. For tools that use this credential, we now properly detect it and report its status.