### PR TITLE
fix: stop show credential threads to users

### DIFF
--- a/pkg/api/handlers/agent.go
+++ b/pkg/api/handlers/agent.go
@@ -953,6 +953,8 @@ func runAuthForAgent(ctx context.Context, c kclient.WithWatch, invoker *invoke.I
 	agent.Spec.Manifest.AvailableThreadTools = nil
 	agent.Spec.Manifest.DefaultThreadTools = nil
 	agent.Spec.Credentials = credentials
+	agent.Spec.CredentialContextID = agent.Name
+	agent.Name = ""
 
 	return invoker.Agent(ctx, c, agent, "", invoke.Options{
 		Synchronous:           true,

--- a/pkg/controller/handlers/toolinfo/toolinfo.go
+++ b/pkg/controller/handlers/toolinfo/toolinfo.go
@@ -35,7 +35,7 @@ func (h *Handler) SetToolInfoStatus(req router.Request, resp router.Response) (e
 
 	// Get all the credentials that exist in the expected context.
 	creds, err := h.gptscript.ListCredentials(req.Ctx, gptscript.ListCredentialsOptions{
-		CredentialContexts: []string{req.Name},
+		CredentialContexts: []string{req.Name, req.Namespace},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
The threads used to authorize agents and workflows should not be shown to users. This change ensures that is the case.

Issue: https://github.com/obot-platform/obot/issues/1127