### PR TITLE
feat: add support for credential auth for non-tool-references

### DIFF
--- a/pkg/controller/creds/creds.go
+++ b/pkg/controller/creds/creds.go
@@ -1,0 +1,185 @@
+package creds
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"slices"
+	"strings"
+
+	"github.com/gptscript-ai/go-gptscript"
+	gtypes "github.com/gptscript-ai/gptscript/pkg/types"
+	"github.com/obot-platform/obot/pkg/system"
+)
+
+func DetermineCredsAndCredNames(prg *gptscript.Program, tool gptscript.Tool, name string) ([]string, []string, error) {
+	seen := make(map[string]struct{})
+	// The available tool references from this tool are the tool itself and any tool this tool exports.
+	toolRefs := make([]toolRef, 0, len(tool.Export)+len(tool.Tools)+1)
+	toolRefs = append(toolRefs, toolRef{
+		ToolReference: gptscript.ToolReference{
+			Reference: name,
+			ToolID:    prg.EntryToolID,
+		},
+		name: name,
+	})
+	toolRefs = append(toolRefs, toolRefsFromTools(tool, toolRefs[0], tool.Tools, seen)...)
+
+	credentials := make([]string, 0, len(tool.Credentials)+len(tool.Export)+len(tool.Tools))
+	credentialNames := make([]string, 0, len(tool.Credentials)+len(tool.Export)+len(tool.Tools))
+	for len(toolRefs) > 0 {
+		ref := toolRefs[0]
+		toolRefs = toolRefs[1:]
+
+		if _, ok := seen[ref.ToolID]; ok {
+			continue
+		}
+		seen[ref.ToolID] = struct{}{}
+
+		t := prg.ToolSet[ref.ToolID]
+
+		// Add the tools that this tool exports if we haven't already seen them.
+		toolRefs = append(toolRefs, toolRefsFromTools(t, ref, t.Export, seen)...)
+
+		for _, cred := range append(t.Credentials, t.ExportCredentials...) {
+			if parsedCred := fullToolPathName(ref, cred); parsedCred != "" && !slices.Contains(credentials, parsedCred) {
+				credentials = append(credentials, parsedCred)
+			}
+
+			credNames, err := determineCredentialNames(prg, prg.ToolSet[ref.ToolID], cred)
+			if err != nil {
+				return credentials, credentialNames, err
+			}
+
+			for _, n := range credNames {
+				if !slices.Contains(credentialNames, n) {
+					credentialNames = append(credentialNames, n)
+				}
+			}
+		}
+	}
+
+	return credentials, credentialNames, nil
+}
+
+func determineCredentialNames(prg *gptscript.Program, tool gptscript.Tool, toolName string) ([]string, error) {
+	if toolName == system.ModelProviderCredential {
+		return []string{system.ModelProviderCredential}, nil
+	}
+
+	var subTool string
+	parsedToolName, alias, args, err := gtypes.ParseCredentialArgs(toolName, "")
+	if err != nil {
+		parsedToolName, subTool = gtypes.SplitToolRef(toolName)
+		parsedToolName, alias, args, err = gtypes.ParseCredentialArgs(parsedToolName, "")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if alias != "" {
+		return []string{alias}, nil
+	}
+
+	if args == nil {
+		// This is a tool and not the credential format. Parse the tool from the program to determine the alias
+		toolNames := make([]string, 0, len(tool.Credentials))
+		if subTool == "" {
+			toolName = parsedToolName
+		}
+		for _, cred := range tool.Credentials {
+			if cred == toolName {
+				if len(tool.ToolMapping[cred]) == 0 {
+					return nil, fmt.Errorf("cannot find credential name for tool %q", toolName)
+				}
+
+				for _, ref := range tool.ToolMapping[cred] {
+					for _, c := range prg.ToolSet[ref.ToolID].ExportCredentials {
+						names, err := determineCredentialNames(prg, prg.ToolSet[ref.ToolID], c)
+						if err != nil {
+							return nil, err
+						}
+
+						toolNames = append(toolNames, names...)
+					}
+				}
+			}
+		}
+
+		if len(toolNames) > 0 {
+			return toolNames, nil
+		}
+
+		return nil, fmt.Errorf("tool %q not found in program", toolName)
+	}
+
+	return []string{toolName}, nil
+}
+
+type toolRef struct {
+	gptscript.ToolReference
+	name string
+}
+
+func toolRefsFromTools(parentTool gptscript.Tool, parentRef toolRef, tools []string, seen map[string]struct{}) []toolRef {
+	var toolRefs []toolRef
+	for _, e := range tools {
+		name := e
+		if _, ok := parentTool.LocalTools[strings.ToLower(e)]; ok {
+			name, _ = gtypes.SplitToolRef(parentRef.name)
+			name = fmt.Sprintf("%s from %s", e, name)
+		}
+		name = fullToolPathName(parentRef, name)
+		if name == "" {
+			continue
+		}
+
+		for _, r := range parentTool.ToolMapping[e] {
+			if _, ok := seen[r.ToolID]; !ok {
+				toolRefs = append(toolRefs, toolRef{
+					ToolReference: r,
+					name:          name,
+				})
+			}
+		}
+	}
+
+	return toolRefs
+}
+
+func fullToolPathName(parentRef toolRef, name string) string {
+	toolName, subTool := gtypes.SplitToolRef(name)
+	if strings.HasPrefix(toolName, ".") {
+		parentToolName, _ := gtypes.SplitToolRef(parentRef.Reference)
+		if !path.IsAbs(parentToolName) {
+			if !strings.HasPrefix(parentToolName, ".") {
+				parentToolName, _ = gtypes.SplitToolRef(parentRef.name)
+			} else {
+				parentToolName = path.Join(parentRef.name, parentToolName)
+			}
+		}
+
+		refURL, err := url.Parse(parentToolName)
+		if err != nil {
+			return ""
+		}
+
+		if strings.HasSuffix(refURL.Path, ".gpt") {
+			refURL.Path = path.Dir(refURL.Path)
+		}
+
+		refURL.Path = path.Join(refURL.Path, toolName)
+		name = refURL.String()
+		if refURL.Host == "" {
+			// This is only a path, so url unescape it.
+			// No need to check the error here, we would have errored when parsing.
+			name, _ = url.PathUnescape(name)
+		}
+
+		if subTool != "" {
+			name = fmt.Sprintf("%s from %s", subTool, name)
+		}
+	}
+
+	return name
+}

--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -5,21 +5,18 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
-	"path"
-	"slices"
 	"strings"
 	"time"
 
 	"github.com/gptscript-ai/go-gptscript"
-	gtypes "github.com/gptscript-ai/gptscript/pkg/types"
 	"github.com/obot-platform/nah/pkg/apply"
 	"github.com/obot-platform/nah/pkg/name"
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/availablemodels"
+	"github.com/obot-platform/obot/pkg/controller/creds"
 	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
@@ -265,66 +262,9 @@ func (h *Handler) Populate(req router.Request, resp router.Response) error {
 		}
 	}
 
-	// The available tool references from this tool are the tool itself and any tool this tool exports.
-	toolRefs := make([]gptscript.ToolReference, 0, len(tool.Export)+1)
-	toolRefs = append(toolRefs, gptscript.ToolReference{
-		Reference: toolRef.Spec.Reference,
-		ToolID:    prg.EntryToolID,
-	})
-	for _, exportedTool := range tool.Export {
-		toolRefs = append(toolRefs, tool.ToolMapping[exportedTool]...)
-	}
-
-	toolRef.Status.Tool.Credentials = make([]string, 0, len(tool.Credentials)+len(tool.Export))
-	toolRef.Status.Tool.CredentialNames = make([]string, 0, len(tool.Credentials)+len(tool.Export))
-	for _, ref := range toolRefs {
-		t := prg.ToolSet[ref.ToolID]
-		for _, cred := range t.Credentials {
-			parsedCred := cred
-			credToolName, credSubTool := gtypes.SplitToolRef(cred)
-			if strings.HasPrefix(credToolName, ".") {
-				toolName, _ := gtypes.SplitToolRef(ref.Reference)
-				if !path.IsAbs(toolName) {
-					if !strings.HasPrefix(toolName, ".") {
-						toolName, _ = gtypes.SplitToolRef(toolRef.Spec.Reference)
-					} else {
-						toolName = path.Join(toolRef.Spec.Reference, toolName)
-					}
-				}
-
-				refURL, err := url.Parse(toolName)
-				if err != nil {
-					continue
-				}
-
-				refURL.Path = path.Join(refURL.Path, credToolName)
-				parsedCred = refURL.String()
-				if refURL.Host == "" {
-					// This is only a path, so url unescape it.
-					// No need to check the error here, we would have errored when parsing.
-					parsedCred, _ = url.PathUnescape(parsedCred)
-				}
-
-				if credSubTool != "" {
-					parsedCred = fmt.Sprintf("%s from %s", credSubTool, parsedCred)
-				}
-			}
-
-			if parsedCred != "" && !slices.Contains(toolRef.Status.Tool.Credentials, parsedCred) {
-				toolRef.Status.Tool.Credentials = append(toolRef.Status.Tool.Credentials, parsedCred)
-			}
-
-			credNames, err := determineCredentialNames(prg, prg.ToolSet[ref.ToolID], cred)
-			if err != nil {
-				toolRef.Status.Error = err.Error()
-			}
-
-			for _, n := range credNames {
-				if !slices.Contains(toolRef.Status.Tool.CredentialNames, n) {
-					toolRef.Status.Tool.CredentialNames = append(toolRef.Status.Tool.CredentialNames, n)
-				}
-			}
-		}
+	toolRef.Status.Tool.Credentials, toolRef.Status.Tool.CredentialNames, err = creds.DetermineCredsAndCredNames(prg, tool, toolRef.Spec.Reference)
+	if err != nil {
+		toolRef.Status.Error = err.Error()
 	}
 
 	return nil
@@ -521,58 +461,4 @@ func (h *Handler) CleanupModelProvider(req router.Request, _ router.Response) er
 
 func modelName(modelProviderName, modelName string) string {
 	return name.SafeConcatName(system.ModelPrefix, modelProviderName, fmt.Sprintf("%x", sha256.Sum256([]byte(modelName))))
-}
-
-func determineCredentialNames(prg *gptscript.Program, tool gptscript.Tool, toolName string) ([]string, error) {
-	if toolName == system.ModelProviderCredential {
-		return []string{system.ModelProviderCredential}, nil
-	}
-
-	var subTool string
-	parsedToolName, alias, args, err := gtypes.ParseCredentialArgs(toolName, "")
-	if err != nil {
-		parsedToolName, subTool = gtypes.SplitToolRef(toolName)
-		parsedToolName, alias, args, err = gtypes.ParseCredentialArgs(parsedToolName, "")
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if alias != "" {
-		return []string{alias}, nil
-	}
-
-	if args == nil {
-		// This is a tool and not the credential format. Parse the tool from the program to determine the alias
-		toolNames := make([]string, 0, len(tool.Credentials))
-		if subTool == "" {
-			toolName = parsedToolName
-		}
-		for _, cred := range tool.Credentials {
-			if cred == toolName {
-				if len(tool.ToolMapping[cred]) == 0 {
-					return nil, fmt.Errorf("cannot find credential name for tool %q", toolName)
-				}
-
-				for _, ref := range tool.ToolMapping[cred] {
-					for _, c := range prg.ToolSet[ref.ToolID].ExportCredentials {
-						names, err := determineCredentialNames(prg, prg.ToolSet[ref.ToolID], c)
-						if err != nil {
-							return nil, err
-						}
-
-						toolNames = append(toolNames, names...)
-					}
-				}
-			}
-		}
-
-		if len(toolNames) > 0 {
-			return toolNames, nil
-		}
-
-		return nil, fmt.Errorf("tool %q not found in program", toolName)
-	}
-
-	return []string{toolName}, nil
 }


### PR DESCRIPTION
Support authentication for agent and workflow tools that use non-tool-references in their definition. That is, a GitHub-hosted tool or a local tool.

During the implementation and testing for non-tool-references, I also spotted a gap: nested tools. That is, if an agent uses a tool that uses a tool that has a credential, then the authentication for that tool would not be processed. After this change, it will.