### PR TITLE
chore: update the user API to be usable

### DIFF
--- a/apiclient/types/user.go
+++ b/apiclient/types/user.go
@@ -11,7 +11,7 @@ const (
 type Role int
 
 func (u Role) HasRole(role Role) bool {
-	return role >= u
+	return u != RoleUnknown && role >= u
 }
 
 type User struct {

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -50,6 +50,7 @@ var staticRules = map[string][]string{
 		"/api/oauth/redirect/{service}",
 		"/api/assistants/{path...}",
 		"GET /api/me",
+		"PATCH /api/users/{id}",
 		"POST /api/llm-proxy/",
 		"POST /api/prompt",
 		"GET /api/models",

--- a/pkg/gateway/client/auth.go
+++ b/pkg/gateway/client/auth.go
@@ -32,11 +32,15 @@ func (u UserDecorator) AuthenticateRequest(req *http.Request) (*authenticator.Re
 		return nil, false, nil
 	}
 
-	gatewayUser, err := u.client.EnsureIdentity(req.Context(), &types.Identity{
-		Email:            firstValue(resp.User.GetExtra(), "email"),
-		AuthProviderID:   uint(firstValueAsInt(resp.User.GetExtra(), "auth_provider_id")),
-		ProviderUsername: resp.User.GetName(),
-	}, req.Header.Get("X-Obot-User-Timezone"))
+	gatewayUser, err := u.client.EnsureIdentity(
+		req.Context(),
+		&types.Identity{
+			Email:            firstValue(resp.User.GetExtra(), "email"),
+			AuthProviderID:   uint(firstValueAsInt(resp.User.GetExtra(), "auth_provider_id")),
+			ProviderUsername: resp.User.GetName(),
+		},
+		req.Header.Get("X-Obot-User-Timezone"),
+	)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/gateway/client/error.go
+++ b/pkg/gateway/client/error.go
@@ -1,0 +1,15 @@
+package client
+
+type LastAdminError struct{}
+
+func (e *LastAdminError) Error() string {
+	return "last admin"
+}
+
+type AlreadyExistsError struct {
+	name string
+}
+
+func (e *AlreadyExistsError) Error() string {
+	return e.name + " already exists"
+}


### PR DESCRIPTION
The user API was migrated from the Gateway and wasn't used outside getting and listing. This change ensures that update and delete work, especially in regard to changing user roles.

One note: this change does make it possible to change the "nobody" user when authentication is turned off. However, the role will be switched back to admin automatically.