### PR TITLE
fix: Include steps in the Atlassian Oauth App guide to guide users on how to set their apps to public.

### DIFF
--- a/ui/admin/app/lib/model/oauthApps/providers/atlassian.ts
+++ b/ui/admin/app/lib/model/oauthApps/providers/atlassian.ts
@@ -89,6 +89,17 @@ const steps: OAuthFormStep<typeof schema.shape>[] = [
         label: "Client Secret",
         inputType: "password",
     },
+    {
+        type: "markdown",
+        text:
+            "### (Optional): Make Your OAuth App Public\n" +
+            "By default, your OAuth App is private. When users authorize their account with your app, they will see a warning like: `Make sure you trust [Your App Name]`. To remove this warning, follow these steps to make your app public:\n" +
+            "- Navigate to the `Distribution` tab in the sidebar\n" +
+            "- Click on `Edit` button and change the `DISTRIBUTION STATUS` of your app to `Sharing`.\n" +
+            "- Fill in the required vendor and security details in the same window\n" +
+            "- Once you've completed the required details, click the **Save Changes** button\n" +
+            "Your app is now public, and users will no longer see the warning message.\n",
+    },
 ];
 
 export const AtlassianOAuthApp = {


### PR DESCRIPTION
- Add optional steps in the Atlassian Oauth App guide to guide users on `how to set their Atlassian apps to public` to get rid of the warning message. See https://github.com/obot-platform/obot/issues/1015


<img width="768" alt="Screenshot 2025-01-09 at 8 27 49 PM" src="https://github.com/user-attachments/assets/6916fa3b-4e62-42c2-91b1-ba8fbd944582" />

