### PR TITLE
fix: filter out the model provider credential when reporting tool info

### DIFF
--- a/pkg/controller/handlers/toolinfo/toolinfo.go
+++ b/pkg/controller/handlers/toolinfo/toolinfo.go
@@ -44,11 +44,10 @@ func (h *Handler) SetToolInfoStatus(req router.Request, resp router.Response) (e
 		return err
 	}
 
-	credsSet := make(sets.Set[string], len(creds)+1)
+	credsSet := make(sets.Set[string], len(creds))
 	for _, cred := range creds {
 		credsSet.Insert(cred.ToolName)
 	}
-	credsSet.Insert(system.ModelProviderCredential)
 
 	obj := req.Object.(v1.ToolUser)
 	tools := obj.GetTools()
@@ -76,6 +75,13 @@ func (h *Handler) SetToolInfoStatus(req router.Request, resp router.Response) (e
 			// This allows us to use the same variable for the whole loop
 			// while ensuring that the value we care about is loaded correctly.
 			toolRef.Status.Tool.CredentialNames = nil
+		}
+
+		for i := 0; i < len(credNames); i++ {
+			if credNames[i] == system.ModelProviderCredential {
+				credNames = append(credNames[:i], credNames[i+1:]...)
+				i--
+			}
 		}
 
 		toolInfos[tool] = types.ToolInfo{

--- a/pkg/storage/apis/obot.obot.ai/v1/file.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/file.go
@@ -9,6 +9,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	_ fields.Fields = (*KnowledgeFile)(nil)
+	_ DeleteRefs    = (*KnowledgeFile)(nil)
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type KnowledgeFile struct {
@@ -18,8 +23,6 @@ type KnowledgeFile struct {
 	Spec   KnowledgeFileSpec   `json:"spec,omitempty"`
 	Status KnowledgeFileStatus `json:"status,omitempty"`
 }
-
-var _ fields.Fields = (*KnowledgeFile)(nil)
 
 func (k *KnowledgeFile) GetColumns() [][]string {
 	return [][]string{
@@ -74,8 +77,6 @@ func (k *KnowledgeFile) Get(field string) string {
 func (*KnowledgeFile) FieldNames() []string {
 	return []string{"spec.knowledgeSourceName", "spec.knowledgeSetName"}
 }
-
-var _ fields.Fields = (*KnowledgeFile)(nil)
 
 type KnowledgeFileSpec struct {
 	KnowledgeSetName    string `json:"knowledgeSetName,omitempty"`


### PR DESCRIPTION
The model provider credential cannot be set by the user nor can it be deleted. Therefore, it doesn't make sense to include it when reporting tool infos on agents and workflows.

Issue: https://github.com/obot-platform/obot/issues/1159