### PR TITLE
fix: DeepSeek icon inverted in dark mode fix

### DIFF
--- a/ui/admin/app/components/model-providers/ModelProviderIcon.tsx
+++ b/ui/admin/app/components/model-providers/ModelProviderIcon.tsx
@@ -12,6 +12,11 @@ export function ModelProviderIcon({
 	modelProvider: ModelProvider;
 	size?: "md" | "lg";
 }) {
+	const ignoreDarkModeSet = new Set([
+		CommonModelProviderIds.AZURE_OPENAI,
+		CommonModelProviderIds.DEEPSEEK,
+	]);
+
 	return modelProvider.icon ? (
 		<img
 			src={modelProvider.icon}
@@ -19,7 +24,7 @@ export function ModelProviderIcon({
 			className={cn({
 				"h-6 w-6": size === "md",
 				"h-16 w-16": size === "lg",
-				"dark:invert": modelProvider.id !== CommonModelProviderIds.AZURE_OPENAI,
+				"dark:invert": !ignoreDarkModeSet.has(modelProvider.id),
 			})}
 		/>
 	) : (


### PR DESCRIPTION

<img width="379" alt="Screenshot 2025-01-09 at 12 56 29 PM" src="https://github.com/user-attachments/assets/c008aabf-4d25-45dd-b5f0-0b30bb576ac8" />

<img width="354" alt="Screenshot 2025-01-09 at 12 59 31 PM" src="https://github.com/user-attachments/assets/77aac628-9c15-4377-8e1d-120d153da413" />

* super small fix, down to very dehydrated whale icon