### PR TITLE
enhance: mark users that have been made explicit admins via config

### DIFF
--- a/apiclient/types/user.go
+++ b/apiclient/types/user.go
@@ -16,11 +16,12 @@ func (u Role) HasRole(role Role) bool {
 
 type User struct {
 	Metadata
-	Username string `json:"username,omitempty"`
-	Role     Role   `json:"role,omitempty"`
-	Email    string `json:"email,omitempty"`
-	IconURL  string `json:"iconURL,omitempty"`
-	Timezone string `json:"timezone,omitempty"`
+	Username      string `json:"username,omitempty"`
+	Role          Role   `json:"role,omitempty"`
+	ExplicitAdmin bool   `json:"explicitAdmin,omitempty"`
+	Email         string `json:"email,omitempty"`
+	IconURL       string `json:"iconURL,omitempty"`
+	Timezone      string `json:"timezone,omitempty"`
 }
 
 type UserList List[User]

--- a/pkg/api/handlers/authorizations.go
+++ b/pkg/api/handlers/authorizations.go
@@ -104,7 +104,7 @@ func (a *AuthorizationHandler) ListAgentAuthorizations(req api.Context) error {
 		if err != nil {
 			log.Errorf("failed to get user for authorization list %s: %v", grant.Spec.UserID, err)
 		} else if user != nil {
-			auth.User = types2.ConvertUser(user)
+			auth.User = types2.ConvertUser(user, a.userClient.IsExplicitAdmin(user.Email))
 		}
 
 		result.Items = append(result.Items, auth)

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -26,6 +26,11 @@ func (c *Client) Close() error {
 	return c.db.Close()
 }
 
+func (c *Client) IsExplicitAdmin(email string) bool {
+	_, ok := c.adminEmails[email]
+	return ok
+}
+
 func firstValue(m map[string][]string, key string) string {
 	values := m[key]
 	if len(values) == 0 {

--- a/pkg/gateway/client/error.go
+++ b/pkg/gateway/client/error.go
@@ -13,3 +13,11 @@ type AlreadyExistsError struct {
 func (e *AlreadyExistsError) Error() string {
 	return e.name + " already exists"
 }
+
+type ExplicitAdminError struct {
+	email string
+}
+
+func (e *ExplicitAdminError) Error() string {
+	return e.email + " has been marked explicitly as an admin"
+}

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -20,7 +20,7 @@ type User struct {
 	Timezone  string      `json:"timezone"`
 }
 
-func ConvertUser(u *User) *types2.User {
+func ConvertUser(u *User, roleFixed bool) *types2.User {
 	if u == nil {
 		return nil
 	}
@@ -30,11 +30,12 @@ func ConvertUser(u *User) *types2.User {
 			ID:      fmt.Sprint(u.ID),
 			Created: *types2.NewTime(u.CreatedAt),
 		},
-		Username: u.Username,
-		Email:    u.Email,
-		Role:     u.Role,
-		IconURL:  u.IconURL,
-		Timezone: u.Timezone,
+		Username:      u.Username,
+		Email:         u.Email,
+		Role:          u.Role,
+		ExplicitAdmin: roleFixed,
+		IconURL:       u.IconURL,
+		Timezone:      u.Timezone,
 	}
 }
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -3910,6 +3910,12 @@ func schema_obot_platform_obot_apiclient_types_User(ref common.ReferenceCallback
 							Format: "int32",
 						},
 					},
+					"explicitAdmin": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"email": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},


### PR DESCRIPTION
Users that were made admins by the config when deploying Obot are now marked. Additionally, it is an error to change their role to be different from an admin.