### PR TITLE
Support multiple tool registries

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,7 +50,7 @@ Obot has a set of packaged tools. These tools are in the repo `github.com/obot-p
 
 1. Clone `github.com/obot-platform/tools` to your local machine.
 2. In the root directory of the tools repo on your local machine, run `make build`.
-3. Run the Obot server, either with `make dev` or in your IDE, with the `OBOT_SERVER_TOOL_REGISTRY` environment variable set to the root directory of the tools repo.
+3. Run the Obot server, either with `make dev` or in your IDE, with the `GPTSCRIPT_TOOL_REMAP` environment variable set to `github.com/obot-platform/tools=<local-tools-fork-root-directory>`; e.g. If you cloned the tools repo to the directory "above" the Obot repo, you'd use `GPTSCRIPT_TOOL_REMAP='github.com/obot-platform/tools=../tools' make dev`.
 
 Now, any time one of these tools is run, your local copy will be used.
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -41,7 +41,7 @@ func (c *Controller) PreStart(ctx context.Context) error {
 }
 
 func (c *Controller) PostStart(ctx context.Context) error {
-	go c.toolRefHandler.PollRegistry(ctx, c.services.Router.Backend())
+	go c.toolRefHandler.PollRegistries(ctx, c.services.Router.Backend())
 	return c.toolRefHandler.EnsureOpenAIEnvCredentialAndDefaults(ctx, c.services.Router.Backend())
 }
 

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -29,8 +29,12 @@ func (c *Controller) setupRoutes() error {
 
 	workflowExecution := workflowexecution.New(c.services.Invoker)
 	workflowStep := workflowstep.New(c.services.Invoker)
-	toolRef := toolreference.New(c.services.GPTClient, c.services.ModelProviderDispatcher,
-		c.services.ToolRegistryURL, c.services.SupportDocker)
+	toolRef := toolreference.New(
+		c.services.GPTClient,
+		c.services.ModelProviderDispatcher,
+		c.services.ToolRegistryURLs,
+		c.services.SupportDocker,
+	)
 	workspace := workspace.New(c.services.GPTClient, c.services.WorkspaceProviderType)
 	knowledgeset := knowledgeset.New(c.services.Invoker)
 	knowledgesource := knowledgesource.NewHandler(c.services.Invoker, c.services.GPTClient)

--- a/pkg/storage/server.go
+++ b/pkg/storage/server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/obot-platform/obot/pkg/storage/openapi/generated"
 	"github.com/obot-platform/obot/pkg/storage/registry/apigroups/agent"
 	"github.com/obot-platform/obot/pkg/storage/scheme"
-	"github.com/obot-platform/obot/pkg/storage/services"
+	sservices "github.com/obot-platform/obot/pkg/storage/services"
 	"github.com/obot-platform/obot/pkg/version"
 	k8sversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/server/healthz"
@@ -21,8 +21,8 @@ import (
 
 type Client client.WithWatch
 
-func Start(ctx context.Context, config services.Config) (Client, *rest.Config, *db.Factory, error) {
-	services, err := services.New(config)
+func Start(ctx context.Context, config sservices.Config) (Client, *rest.Config, *db.Factory, error) {
+	services, err := sservices.New(config)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -34,7 +34,7 @@ func Start(ctx context.Context, config services.Config) (Client, *rest.Config, *
 	return c, cfg, services.DB, nil
 }
 
-func startMinkServer(ctx context.Context, config services.Config, services *services.Services) (Client, *rest.Config, error) {
+func startMinkServer(ctx context.Context, config sservices.Config, services *sservices.Services) (Client, *rest.Config, error) {
 	apiGroups, err := mserver.BuildAPIGroups(services, agent.APIGroup, agent.LeasesAPIGroup)
 	if err != nil {
 		return nil, nil, err

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,16 @@ check_postgres_active() {
   exit 1
 }
 
+source /obot-tools/.envrc.tools
+export PATH=$TOOLS_VENV_BIN:$PATH
+
+# double echo to remove trailing whitespace
+export OBOT_SERVER_VERSIONS="$(cat <<VERSIONS
+"chrome": "$(echo $(/opt/google/chrome/chrome --version))"
+${OBOT_SERVER_VERSIONS}
+VERSIONS
+)"
+
 # Only enable sshd in Render. Remove sshd entirely once we have migrated out of Render.
 if [[ -v ENABLE_SSHD ]]; then
   mkdir -p /run/sshd
@@ -21,16 +31,6 @@ if [[ -v ENABLE_SSHD ]]; then
 fi
 
 mkdir -p /data/cache
-# This is YAML
-export OBOT_SERVER_VERSIONS="$(cat <<VERSIONS
-"github.com/obot-platform/tools": "$(cd /obot-tools && git rev-parse HEAD)"
-"github.com/gptscript-ai/workspace-provider": "$(cd /obot-tools/workspace-provider && git rev-parse HEAD)"
-"github.com/gptscript-ai/datasets": "$(cd /obot-tools/datasets && git rev-parse HEAD)"
-"github.com/kubernetes-sigs/aws-encryption-provider": "$(cd /obot-tools/aws-encryption-provider && git rev-parse HEAD)"
-# double echo to remove trailing whitespace
-"chrome": "$(echo $(/opt/google/chrome/chrome --version))"
-VERSIONS
-)"
 
 if [ -z "$OBOT_SERVER_DSN" ]; then
   echo "OBOT_SERVER_DSN is not set. Starting PostgreSQL process..."

--- a/tools/package-tools.sh
+++ b/tools/package-tools.sh
@@ -3,51 +3,117 @@ set -e -x -o pipefail
 
 BIN_DIR=${BIN_DIR:-./bin}
 
+# Check if TOOL_REGISTRY_REPOS is set and non-empty
+if [[ -z "${TOOL_REGISTRY_REPOS}" ]]; then
+    echo "Error: TOOL_REGISTRY_REPOS environment variable is not set or is empty."
+    exit 1
+fi
+
+if [[ -n "${GITHUB_TOKEN}" ]]; then
+    set +x
+    git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/" 2>/dev/null
+    set -x
+fi
+
 cd $(dirname $0)/..
 
 if [ ! -e obot-tools ]; then
-    git clone --depth=1 https://github.com/obot-platform/tools obot-tools
+    mkdir obot-tools
 fi
+cd obot-tools
 
-./obot-tools/scripts/build.sh
+# Convert TOOL_REGISTRY_REPOS into an array by replacing commas with spaces
+read -r -a TOOL_REPOS <<< "${TOOL_REGISTRY_REPOS//,/ }"
+REGISTRY_REMAP=()
+LOCAL_REGISTRIES=()
+OBOT_SERVER_VERSIONS=""
 
-for pj in $(find obot-tools -name package.json | grep -v node_modules); do
-    if [ $(basename $(dirname $pj)) == common ]; then
-        continue
+# Iterate over the repositories
+for REPO in "${TOOL_REPOS[@]}"; do
+    # Extract the repo name (e.g., tools, enterprise-tools)
+    REPO_NAME=$(basename "${REPO}")
+    REPO_DIR="obot-tools/${REPO_NAME}"
+
+    # Clone the repository into the target directory
+    echo "Cloning ${REPO} into ${REPO_DIR}..."
+    if git clone --depth=1 "https://${REPO}" "${REPO_NAME}"; then
+        # Change to the repository directory
+        # Check if the build script exists and is executable
+        if [[ -x "./${REPO_NAME}/scripts/build.sh" ]]; then
+          (
+            echo "Running build script for ${REPO}..."
+            cd "${REPO_NAME}"
+            ./scripts/build.sh
+            echo "Build script for ${REPO} complete!"
+          )
+        else
+            echo "No build script found in ${REPO}"
+        fi
+
+        OBOT_SERVER_VERSIONS="$(cat <<VERSIONS
+"${REPO}": "$(cd "${REPO_NAME}" && git rev-parse --short HEAD)"
+${OBOT_SERVER_VERSIONS}
+VERSIONS
+)"
+
+    else
+        echo "Failed to clone $REPO. Aborting..."
+        exit 1
     fi
-    (
-        cd $(dirname $pj)
-        echo Building $PWD
-        pnpm i
-    )
+
+    REGISTRY_REMAP+=("${REPO}=/${REPO_DIR}")
+    LOCAL_REGISTRIES+=("/${REPO_DIR}")
 done
 
+cd ..
+for pj in $(find obot-tools -name package.json | grep -v node_modules); do
+  if [ $(basename $(dirname $pj)) == common ]; then
+    continue
+  fi
+  (
+    cd $(dirname $pj)
+    echo Building $PWD
+    pnpm i
+  )
+done
 cd obot-tools
+
 if [ ! -e workspace-provider ]; then
     git clone --depth=1 https://github.com/gptscript-ai/workspace-provider
 fi
-
 cd workspace-provider
 go build -ldflags="-s -w" -o bin/gptscript-go-tool .
-
+REGISTRY_REMAP+=('github.com/gptscript-ai/workspace-provider=/obot-tools/workspace-provider')
+OBOT_SERVER_VERSIONS="$(cat <<VERSIONS
+"github.com/gptscript-ai/workspace-provider": "$(git rev-parse --short HEAD)"
+${OBOT_SERVER_VERSIONS}
+VERSIONS
+)"
 cd ..
 
 if [ ! -e datasets ]; then
     git clone --depth=1 https://github.com/gptscript-ai/datasets
 fi
-
 cd datasets
 go build -ldflags="-s -w" -o bin/gptscript-go-tool .
-
+REGISTRY_REMAP+=('github.com/gptscript-ai/datasets=/obot-tools/datasets')
+OBOT_SERVER_VERSIONS="$(cat <<VERSIONS
+"github.com/gptscript-ai/datasets": "$(git rev-parse --short HEAD)"
+${OBOT_SERVER_VERSIONS}
+VERSIONS
+)"
 cd ..
 
 if [ ! -e aws-encryption-provider ]; then
     git clone --depth=1 https://github.com/kubernetes-sigs/aws-encryption-provider
 fi
-
 cd aws-encryption-provider
-go build -o ${BIN_DIR}/aws-encryption-provider cmd/server/main.go
-
+go build -o "${BIN_DIR}/aws-encryption-provider" cmd/server/main.go
+OBOT_SERVER_VERSIONS="$(cat <<VERSIONS
+"github.com/kubernetes-sigs/aws-encryption-provider": "$(git rev-parse --short HEAD)"
+${OBOT_SERVER_VERSIONS}
+VERSIONS
+)"
 cd ../..
 
 if ! command -v uv; then
@@ -59,6 +125,14 @@ if [ ! -e obot-tools/venv ]; then
 fi
 
 source obot-tools/venv/bin/activate
-
 find obot-tools -name requirements.txt -exec cat {} \; -exec echo \; | sort -u > requirements.txt
 uv pip install -r requirements.txt
+
+cd obot-tools
+cat <<EOF > .envrc.tools
+export GPTSCRIPT_SYSTEM_TOOLS_DIR=/obot-tools/
+export GPTSCRIPT_TOOL_REMAP="$(IFS=','; echo "${REGISTRY_REMAP[*]}")"
+export OBOT_SERVER_TOOL_REGISTRIES="${TOOL_REGISTRY_REPOS}"
+export OBOT_SERVER_VERSIONS="${OBOT_SERVER_VERSIONS}"
+export TOOLS_VENV_BIN=/obot-tools/venv/bin
+EOF


### PR DESCRIPTION
This change adds support for consuming tools from more than one tool registry at a time.

It replaces the `OBOT_SERVER_TOOL_REGISTRY` option with `OBOT_SERVER_TOOL_REGISTRIES`. The new option accepts a comma-delimited string of registry URIs.

e.g.

```bash
export OBOT_SERVER_TOOL_REGISTRIES='github.com/obot-platform/tools,github.com/obot-platform/enterprise-tools'`
```

When overriding a remote registry with a directory in the local filesystem, the `GPTSCRIPT_TOOL_REMAP` environment variable is used to provide tool reference remapping in GPTScript/Obot.

e.g. Replacing `github.com/obot-platform/tools` with `../tools`:

```bash
export GPTSCRIPT_TOOL_REMAP='github.com/obot-platform/tools=../tools'
```

e.g. Replacing `github.com/obot-platform/tools` with `../tools` and `github.com/obot-platform/enterprise-tools` with `../enterprise-tools`:

```bash
export GPTSCRIPT_TOOL_REMAP='github.com/obot-platform/tools=../tools,github.com/obot-platform/enterprise-tools=../enterprise-tools'
export OBOT_SERVER_TOOL_REGISTRIES='github.com/obot-platform/tools,github.com/obot-platform/enterprise-tools'`
```

Note:
- `OBOT_SERVER_TOOL_REGISTRIES` should always reference remote tool registry repos, never local file paths
- Only `GPTSCRIPT_TOOL_REMAP` needs to be set to swap the default tool registry (`github.com/obot-platform/tools`) with a local fork

This change also updates the container image build to support
- Pulling multiple tool registries into the image at build-time via the `TOOL_REGISTY_REPOS` build arg
- Cloning private tool registry repos via the `GITHUB_TOKEN` Docker secret

e.g. Building the "enterprise" Obot image

```bash
export GITHUB_TOKEN=$(gh auth token)
# Here `github.com/obot-platform/enterprise-tools` is a private repo
docker build --build-arg TOOL_REGISTRY_REPOS='github.com/obot-platform/enterprise-tools,github.com/obot-platform/tools' \
  --secret id=GITHUB_TOKEN \
  -t obot-enterprise:latest .
```

e.g. Building the "OSS" Obot image

```bash
# When no `TOOL_REGISTRY_REPOS` build arg is given, `github.com/obot-platform/obot` is pulled into the image by default
docker build -t obot:latest .
```

Part of #877 