### PR TITLE
Update python-hash-tool-readme.md.mdx

### DIFF
--- a/docs/snippets/python-hash-tool-readme.md.mdx
+++ b/docs/snippets/python-hash-tool-readme.md.mdx
@@ -86,9 +86,9 @@ Param: algo: The algorithm to generate a hash with. Default is "sha256". Support
 
 ## Tool Metadata {#tool-metadata-28572835}
 
-The `tool.gpt` file also provides the following metadata for use in Obot:
+The `tool.gpt` file also provides the following metadata for use in Obot (referencing the example below):
 
-- `!metadata:*:category` which tags tools with the `Crypto` category to promote organization and discovery
+- `!metadata:*:category` which tags the tool with the `Crypto` category to promote organization and discovery
 - `!metadata:*:icon` which assigns `https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-duotone.svg` as the tool icon
 
 <br/>


### PR DESCRIPTION
The text as written is ambiguous about if the directives _only_ tag things with Crypto or with the icon, and it's not until the reader scrolls down that they might figure out the reference is to the example below. Adding this small bit of text directs them to the example early on and adds clarity.

Also fixes a small typographical error.