### PR TITLE
chore: update database tool names

### DIFF
--- a/pkg/api/handlers/tables.go
+++ b/pkg/api/handlers/tables.go
@@ -26,7 +26,7 @@ func (t *TableHandler) tables(req api.Context, workspaceID string) (string, erro
 	if err := req.Get(&toolRef, "database"); err != nil {
 		return "", err
 	}
-	run, err := t.gptScript.Run(req.Context(), "Tables from "+toolRef.Status.Reference, gptscript.Options{
+	run, err := t.gptScript.Run(req.Context(), "List Database Tables from "+toolRef.Status.Reference, gptscript.Options{
 		Workspace: workspaceID,
 	})
 	if err != nil {
@@ -47,7 +47,7 @@ func (t *TableHandler) rows(req api.Context, workspaceID, tableName string) (str
 	if err != nil {
 		return "", err
 	}
-	run, err := t.gptScript.Run(req.Context(), "Query from "+toolRef.Status.Reference, gptscript.Options{
+	run, err := t.gptScript.Run(req.Context(), "Run Database Query from "+toolRef.Status.Reference, gptscript.Options{
 		Input:     string(input),
 		Workspace: workspaceID,
 	})


### PR DESCRIPTION
Use the updated database tool names introduced by https://github.com/obot-platform/tools/pull/334

Addresses part of https://github.com/obot-platform/obot/issues/1208
