### PR TITLE
docs: fetch updated tool authoring readme snippets

### DIFF
--- a/docs/snippets/go-hash-tool-readme.md.mdx
+++ b/docs/snippets/go-hash-tool-readme.md.mdx
@@ -1,4 +1,4 @@
-## Writing your first tool in Go {#writing-your-first-tool-in-go-eb5bb8c4}
+## Writing your first tool in Go {#writing-your-first-tool-in-go-39365861}
 
 [go-hash-tool](https://github.com/obot-platform/go-hash-tool) contains a reference `Go` implementation of the `Hash` tool.
 
@@ -12,7 +12,7 @@ git clone git@github.com:obot-platform/go-hash-tool
 
 <br/>
 
-## Tool Repo Structure {#tool-repo-structure-eb5bb8c4}
+## Tool Repo Structure {#tool-repo-structure-39365861}
 
 The directory tree below highlights the files required to implement `Hash` in Go and package it for Obot.
 
@@ -30,7 +30,7 @@ go-hash-tool
 
 <br/>
 
-## Defining the `Hash` Tool {#defining-the-hash-tool-eb5bb8c4}
+## Defining the `Hash` Tool {#defining-the-hash-tool-39365861}
 
 The `tool.gpt` file contains [GPTScript Tool Definitions](https://docs.gptscript.ai/tools/gpt-file-reference) which describe a set of tools that can be used by agents in Obot.
 Every tool repository must have a `tool.gpt` file in its root directory.
@@ -89,12 +89,12 @@ Param: algo: The algorithm to generate a hash with. Default is "sha256". Support
 
 <br/>
 
-## Tool Metadata {#tool-metadata-eb5bb8c4}
+## Tool Metadata {#tool-metadata-39365861}
 
-The `tool.gpt` file also provides the following metadata for use in Obot:
+The snippet below (from the `tool.gpt` file) also provides the following metadata for use in Obot:
 
-- `!metadata:*:category` which tags tools with the `Crypto` category to promote organization and discovery
-- `!metadata:*:icon` which assigns `https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-duotone.svg` as the tool icon
+- `!metadata:*:category` which tags all tools in the `tool.gpt` file with the `Crypto` category to promote organization and discovery
+- `!metadata:*:icon` which assigns `https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-duotone.svg` as the tool icon to all tools in the `tool.gpt` file
 
 <br/>
 
@@ -150,7 +150,7 @@ https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-d
 
 <br/>
 
-## Implementing Business Logic {#implementing-business-logic-eb5bb8c4}
+## Implementing Business Logic {#implementing-business-logic-39365861}
 
 The `main.go` file is the entry point of the `gptscript-go-tool` binary that is executed by Obot when the `Hash` tool is called.
 
@@ -202,7 +202,7 @@ The Body of the `Verify` tool definition would then simply pass `verify` to `gpt
 
 ```yaml
 Name: Verify
-# ... {#-eb5bb8c4}
+# ... {#-39365861}
 
 #!{GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool verify
 ```
@@ -371,7 +371,7 @@ func keys[V any](m map[string]V) []string {
 
 <br/>
 
-## Testing `main.go` Locally {#testing-main-go-locally-eb5bb8c4}
+## Testing `main.go` Locally {#testing-main-go-locally-39365861}
 
 Before adding a tool to Obot, verify that the Go business logic works on your machine.
 
@@ -394,7 +394,7 @@ To do this, run through the following steps in the root of your local fork:
 
 <br/>
 
-## Adding the `Hash` tool to Obot {#adding-the-hash-tool-to-obot-eb5bb8c4}
+## Adding the `Hash` tool to Obot {#adding-the-hash-tool-to-obot-39365861}
 
 Before a tool can be used by an agent, an admin must first add the tool to Obot by performing the steps below:
 
@@ -432,7 +432,7 @@ Before a tool can be used by an agent, an admin must first add the tool to Obot 
     </div>
 </details>
 
-## Using The `Hash` tool in an agent {#using-the-hash-tool-in-an-agent-eb5bb8c4}
+## Using The `Hash` tool in an agent {#using-the-hash-tool-in-an-agent-39365861}
 
 To use the `Hash` tool in an agent, open the agent's Edit page, then:
 

--- a/docs/snippets/node-hash-tool-readme.md.mdx
+++ b/docs/snippets/node-hash-tool-readme.md.mdx
@@ -1,4 +1,4 @@
-## Writing your first tool in Node.js (with Typescript) {#writing-your-first-tool-in-node-js-with-typescript-aeed7f15}
+## Writing your first tool in Node.js (with Typescript) {#writing-your-first-tool-in-node-js-with-typescript-ac3b80a2}
 
 [node-hash-tool](https://github.com/obot-platform/node-hash-tool) contains a reference TypeScript Node.js implementation of the `Hash` tool.
 
@@ -11,7 +11,7 @@ git clone git@github.com:obot-platform/node-hash-tool
 ```
 <br/>
 
-## Tool Repo Structure {#tool-repo-structure-aeed7f15}
+## Tool Repo Structure {#tool-repo-structure-ac3b80a2}
 
 The directory tree below highlights the files required to implement `Hash` in TypeScript and package it for Obot.
 
@@ -31,7 +31,7 @@ node-hash-tool
 
 <br/>
 
-## Defining the `Hash` tool {#defining-the-hash-tool-aeed7f15}
+## Defining the `Hash` tool {#defining-the-hash-tool-ac3b80a2}
 
 The `tool.gpt` file contains [GPTScript Tool Definitions](https://docs.gptscript.ai/tools/gpt-file-reference) which describe a set of tools that can be used by agents in Obot.
 Every Tool repository must have a `tool.gpt` file in its root directory.
@@ -90,12 +90,12 @@ Param: algo: The algorithm to generate a hash with. Default is "sha256". Support
 
 <br/>
 
-## Tool Metadata {#tool-metadata-aeed7f15}
+## Tool Metadata {#tool-metadata-ac3b80a2}
 
-The `tool.gpt` file also provides the following metadata for use in Obot:
+The snippet below (from the `tool.gpt` file) also provides the following metadata for use in Obot:
 
-- `!metadata:*:category` which tags tools with the `Crypto` category to promote organization and discovery
-- `!metadata:*:icon` which assigns `https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-duotone.svg` as the tool icon
+- `!metadata:*:category` which tags all tools in the `tool.gpt` file with the `Crypto` category to promote organization and discovery
+- `!metadata:*:icon` which assigns `https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-duotone.svg` as the tool icon to all tools in the `tool.gpt` file
 
 <br/>
 
@@ -151,7 +151,7 @@ https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-d
 
 <br/>
 
-## Implementing Business Logic {#implementing-business-logic-aeed7f15}
+## Implementing Business Logic {#implementing-business-logic-ac3b80a2}
 
 As we saw earlier, the `npm` command invoked by the `Tool Body` passes `hash` as an argument to the `tool` script.
 
@@ -227,7 +227,7 @@ And the body of the `Verify` tool would pass `verify` to the `tool` script inste
 
 ```yaml
 Name: Verify
-# ... {#-aeed7f15}
+# ... {#-ac3b80a2}
 
 #!/usr/bin/env npm --silent --prefix ${GPTSCRIPT_TOOL_DIR} run tool -- verify
 ```
@@ -352,7 +352,7 @@ export function hash(data: string = '', algo = 'sha256'): string {
 
 <br/>
 
-## Testing `src/tools.ts` and `src/hash.ts` Locally {#testing-src-tools-ts-and-src-hash-ts-locally-aeed7f15}
+## Testing `src/tools.ts` and `src/hash.ts` Locally {#testing-src-tools-ts-and-src-hash-ts-locally-ac3b80a2}
 
 Before adding a tool to Obot, verify that the TypeScript business logic works on your machine.
 
@@ -375,7 +375,7 @@ To do this, run through the following steps in the root of your local fork:
 
 <br/>
 
-## Adding The `Hash` tool to Obot {#adding-the-hash-tool-to-obot-aeed7f15}
+## Adding The `Hash` tool to Obot {#adding-the-hash-tool-to-obot-ac3b80a2}
 
 Before a tool can be used by an agent, an admin must first add the tool to Obot by performing the steps below:
 
@@ -413,7 +413,7 @@ Before a tool can be used by an agent, an admin must first add the tool to Obot 
     </div>
 </details>
 
-## Using The `Hash` tool in an agent {#using-the-hash-tool-in-an-agent-aeed7f15}
+## Using The `Hash` tool in an agent {#using-the-hash-tool-in-an-agent-ac3b80a2}
 
 To use the `Hash` tool in an agent, open the agent's Edit page, then:
 

--- a/docs/snippets/python-hash-tool-readme.md.mdx
+++ b/docs/snippets/python-hash-tool-readme.md.mdx
@@ -1,4 +1,4 @@
-## Writing your first tool in Python {#writing-your-first-tool-in-python-28572835}
+## Writing your first tool in Python {#writing-your-first-tool-in-python-23674f98}
 
 [python-hash-tool](https://github.com/obot-platform/python-hash-tool) contains a reference `Python` implementation of the `Hash` tool.
 
@@ -12,7 +12,7 @@ git clone git@github.com:obot-platform/python-hash-tool
 
 <br/>
 
-## Tool Repo Structure {#tool-repo-structure-28572835}
+## Tool Repo Structure {#tool-repo-structure-23674f98}
 
 The directory tree below highlights the files required to implement `Hash` in Python and package it for Obot.
 
@@ -24,7 +24,7 @@ python-hash-tool
 ```
 <br/>
 
-## Defining the `Hash` Tool {#defining-the-hash-tool-28572835}
+## Defining the `Hash` Tool {#defining-the-hash-tool-23674f98}
 
 The `tool.gpt` file contains [GPTScript Tool Definitions](https://docs.gptscript.ai/tools/gpt-file-reference) which describe a set of tools that can be used by agents in Obot.
 Every tool repository must have a `tool.gpt` file in its root directory.
@@ -84,12 +84,12 @@ Param: algo: The algorithm to generate a hash with. Default is "sha256". Support
 
 <br/>
 
-## Tool Metadata {#tool-metadata-28572835}
+## Tool Metadata {#tool-metadata-23674f98}
 
-The `tool.gpt` file also provides the following metadata for use in Obot:
+The snippet below (from the `tool.gpt` file) also provides the following metadata for use in Obot:
 
-- `!metadata:*:category` which tags tools with the `Crypto` category to promote organization and discovery
-- `!metadata:*:icon` which assigns `https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-duotone.svg` as the tool icon
+- `!metadata:*:category` which tags all tools in the `tool.gpt` file with the `Crypto` category to promote organization and discovery
+- `!metadata:*:icon` which assigns `https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-duotone.svg` as the tool icon to all tools in the `tool.gpt` file
 
 <br/>
 
@@ -144,7 +144,7 @@ https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/fingerprint-d
 
 <br/>
 
-## Implementing Business Logic {#implementing-business-logic-28572835}
+## Implementing Business Logic {#implementing-business-logic-23674f98}
 
 The `hash.py` file executed by the `Tool Body` is the concrete implementation of the tool's business logic.
 
@@ -261,7 +261,7 @@ if __name__ == '__main__':
 
 <br/>
 
-## Testing `hash.py` Locally {#testing-hash-py-locally-28572835}
+## Testing `hash.py` Locally {#testing-hash-py-locally-23674f98}
 
 Before adding a tool to Obot, verify that the Python business logic works on your machine.
 
@@ -298,7 +298,7 @@ To do this, run through the following steps in the root of your local fork:
 
 <br/>
 
-## Adding The `Hash` tool to Obot {#adding-the-hash-tool-to-obot-28572835}
+## Adding The `Hash` tool to Obot {#adding-the-hash-tool-to-obot-23674f98}
 
 Before a tool can be used by an agent, an admin must first add the tool to Obot by performing the steps below:
 
@@ -336,7 +336,7 @@ Before a tool can be used by an agent, an admin must first add the tool to Obot 
     </div>
 </details>
 
-## Using The `Hash` tool in an agent {#using-the-hash-tool-in-an-agent-28572835}
+## Using The `Hash` tool in an agent {#using-the-hash-tool-in-an-agent-23674f98}
 
 To use the `Hash` tool in an agent, open the agent's Edit page, then:
 


### PR DESCRIPTION
Fetch the latest tool authoring README.md snippets from the respective example tool repos to include the doc updates initially authored by https://github.com/oskapt in https://github.com/obot-platform/obot/pull/1217.

This is change depends on the following PRs, which must merge before this:
- https://github.com/obot-platform/go-hash-tool/pull/2
- https://github.com/obot-platform/python-hash-tool/pull/3
- https://github.com/obot-platform/node-hash-tool/pull/2

Note: The docs snippet plugin is too complex and [is slated to be removed](https://github.com/obot-platform/obot/issues/1236) in the medium to long-term. This should be the last time we use this flow for updating the docs.
