### PR TITLE
chore: ensure old finalizers are removed

### DIFF
--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -84,7 +84,7 @@ func (c *Controller) setupRoutes() error {
 
 	// Uploads
 	root.Type(&v1.KnowledgeSource{}).HandlerFunc(cleanup.Cleanup)
-	root.Type(&v1.KnowledgeSource{}).HandlerFunc(removeOldFinalizers)
+	root.Type(&v1.KnowledgeSource{}).IncludeFinalizing().HandlerFunc(removeOldFinalizers)
 	root.Type(&v1.KnowledgeSource{}).FinalizeFunc(v1.KnowledgeSourceFinalizer, knowledgesource.Cleanup)
 	root.Type(&v1.KnowledgeSource{}).HandlerFunc(knowledgesource.Reschedule)
 	root.Type(&v1.KnowledgeSource{}).HandlerFunc(knowledgesource.Sync)
@@ -92,7 +92,7 @@ func (c *Controller) setupRoutes() error {
 	// ToolReferences
 	root.Type(&v1.ToolReference{}).HandlerFunc(toolRef.BackPopulateModels)
 	root.Type(&v1.ToolReference{}).HandlerFunc(toolRef.Populate)
-	root.Type(&v1.ToolReference{}).HandlerFunc(removeOldFinalizers)
+	root.Type(&v1.ToolReference{}).IncludeFinalizing().HandlerFunc(removeOldFinalizers)
 	root.Type(&v1.ToolReference{}).FinalizeFunc(v1.ToolReferenceFinalizer, toolRef.CleanupModelProvider)
 
 	// EmailReceivers
@@ -110,20 +110,20 @@ func (c *Controller) setupRoutes() error {
 
 	// Knowledge files
 	root.Type(&v1.KnowledgeFile{}).HandlerFunc(cleanup.Cleanup)
-	root.Type(&v1.KnowledgeFile{}).HandlerFunc(removeOldFinalizers)
+	root.Type(&v1.KnowledgeFile{}).IncludeFinalizing().HandlerFunc(removeOldFinalizers)
 	root.Type(&v1.KnowledgeFile{}).FinalizeFunc(v1.KnowledgeFileFinalizer, knowledgefile.Cleanup)
 	root.Type(&v1.KnowledgeFile{}).HandlerFunc(knowledgefile.IngestFile)
 	root.Type(&v1.KnowledgeFile{}).HandlerFunc(knowledgefile.Unapproved)
 
 	// Workspaces
 	root.Type(&v1.Workspace{}).HandlerFunc(cleanup.Cleanup)
-	root.Type(&v1.Workspace{}).HandlerFunc(removeOldFinalizers)
+	root.Type(&v1.Workspace{}).IncludeFinalizing().HandlerFunc(removeOldFinalizers)
 	root.Type(&v1.Workspace{}).FinalizeFunc(v1.WorkspaceFinalizer, workspace.RemoveWorkspace)
 	root.Type(&v1.Workspace{}).HandlerFunc(workspace.CreateWorkspace)
 
 	// KnowledgeSets
 	root.Type(&v1.KnowledgeSet{}).HandlerFunc(cleanup.Cleanup)
-	root.Type(&v1.KnowledgeSet{}).HandlerFunc(removeOldFinalizers)
+	root.Type(&v1.KnowledgeSet{}).IncludeFinalizing().HandlerFunc(removeOldFinalizers)
 	root.Type(&v1.KnowledgeSet{}).FinalizeFunc(v1.KnowledgeSetFinalizer, knowledgeset.Cleanup)
 	// Also cleanup the dataset when there is no content.
 	// This will allow the user to switch the embedding model implicitly.


### PR DESCRIPTION
Adding the IncludeFinalizing will ensure they old finalizers are removed even when the object is deleting.