### PR TITLE
Fix: hide builtin tool actions

### DIFF
--- a/ui/admin/app/components/tools/toolGrid/ToolCardActions.tsx
+++ b/ui/admin/app/components/tools/toolGrid/ToolCardActions.tsx
@@ -28,6 +28,8 @@ export function ToolCardActions({ tool }: { tool: ToolReference }) {
 		}
 	);
 
+	if (tool.builtin) return null;
+
 	return (
 		<div className="flex items-center gap-2">
 			{(forceRefresh.isLoading || isPolling) && <LoadingSpinner />}


### PR DESCRIPTION
- hides builtin tool actions from the tools page
- prevents stale data from preemptively stopping tool polling after refresh