### PR TITLE
enhance: allow tools to indicate which credentials don't need auth

### DIFF
--- a/apiclient/types/toolreference.go
+++ b/apiclient/types/toolreference.go
@@ -25,7 +25,7 @@ type ToolReference struct {
 	Error       string            `json:"error,omitempty"`
 	Builtin     bool              `json:"builtin,omitempty"`
 	Description string            `json:"description,omitempty"`
-	Credentials []string          `json:"credential,omitempty"`
+	Credentials []string          `json:"credentials,omitempty"`
 	Params      map[string]string `json:"params,omitempty"`
 }
 

--- a/pkg/controller/handlers/toolinfo/toolinfo.go
+++ b/pkg/controller/handlers/toolinfo/toolinfo.go
@@ -10,7 +10,6 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/controller/creds"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
-	"github.com/obot-platform/obot/pkg/system"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -75,13 +74,6 @@ func (h *Handler) SetToolInfoStatus(req router.Request, resp router.Response) (e
 			// This allows us to use the same variable for the whole loop
 			// while ensuring that the value we care about is loaded correctly.
 			toolRef.Status.Tool.CredentialNames = nil
-		}
-
-		for i := 0; i < len(credNames); i++ {
-			if credNames[i] == system.ModelProviderCredential {
-				credNames = append(credNames[:i], credNames[i+1:]...)
-				i--
-			}
 		}
 
 		toolInfos[tool] = types.ToolInfo{

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -3824,7 +3824,7 @@ func schema_obot_platform_obot_apiclient_types_ToolReference(ref common.Referenc
 							Format: "",
 						},
 					},
-					"credential": {
+					"credentials": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{


### PR DESCRIPTION
Certain tools have credentials that don't require the use to authenticate them. For example, the sys.model.provider.credential is handled by the system and never needs user interaction.

This change introduces the processing of the noAuth metadata field to indicate which credentials don't need user auth. If a credential name is included in the noAuth metadata for a tool, then that credential name is disregarded for user auth. The sys.model.provider.credential is included by default for every tool.

This is more of a proposal. There have already been a couple of instances of us needing to exclude certain credentials from authentication. This will allow tools to tell us that a credential doesn't need authentication instead of us playing whack-a-mole as we go along.

Issue: https://github.com/obot-platform/obot/issues/1256

This PR should be merged first: https://github.com/obot-platform/tools/pull/346