### PR TITLE
fix: error workflows.reduce fix due to Workflows clientLoader mutate

### DIFF
--- a/ui/admin/app/routes/_auth.workflows._index.tsx
+++ b/ui/admin/app/routes/_auth.workflows._index.tsx
@@ -3,7 +3,7 @@ import { PenSquareIcon } from "lucide-react";
 import { useMemo } from "react";
 import { MetaFunction, useNavigate } from "react-router";
 import { $path } from "safe-routes";
-import useSWR, { mutate, preload } from "swr";
+import useSWR, { preload } from "swr";
 
 import { Workflow } from "~/lib/model/workflows";
 import { ThreadsService } from "~/lib/service/api/threadsService";
@@ -23,7 +23,6 @@ import { DeleteWorkflowButton } from "~/components/workflow/DeleteWorkflow";
 import { WorkflowViewYaml } from "~/components/workflow/WorkflowView";
 
 export async function clientLoader() {
-	mutate(WorkflowService.getWorkflows.key(), ThreadsService.getThreads.key());
 	await Promise.all([
 		preload(WorkflowService.getWorkflows.key(), WorkflowService.getWorkflows),
 		preload(ThreadsService.getThreads.key(), ThreadsService.getThreads),


### PR DESCRIPTION
Addresses #1230 

<img width="981" alt="Screenshot 2025-01-15 at 1 14 38 PM" src="https://github.com/user-attachments/assets/7fefe0e6-9bc0-4241-8edf-8f28ce0136b0" />

* `mutate` was changing getWorkflows.data to object returned from `ThreadsService.getThreads.key()`
* don't believe this is needed? ClientLoader is calling preload on these two calls 