### PR TITLE
enhance: delete workflow from workflow form

### DIFF
--- a/ui/admin/app/components/agent/AgentAlias.tsx
+++ b/ui/admin/app/components/agent/AgentAlias.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { $path } from "safe-routes";
 import useSWR from "swr";
 
@@ -20,6 +20,8 @@ type AgentAliasProps = {
 };
 
 export function AgentAlias({ agent, onChange }: AgentAliasProps) {
+	const navigate = useNavigate();
+
 	const getAssistants = useSWR(
 		() => AssistantApiService.getAssistants.key(),
 		() => AssistantApiService.getAssistants()
@@ -73,7 +75,7 @@ export function AgentAlias({ agent, onChange }: AgentAliasProps) {
 
 				<div className="flex gap-2">
 					<AgentAccessControl agent={agent} />
-					<DeleteAgent id={agent.id} />
+					<DeleteAgent id={agent.id} onSuccess={() => navigate("/agents")} />
 				</div>
 			</div>
 			{conflictingAlias && (

--- a/ui/admin/app/components/agent/DeleteAgent.tsx
+++ b/ui/admin/app/components/agent/DeleteAgent.tsx
@@ -13,11 +13,18 @@ import {
 } from "~/components/ui/tooltip";
 import { useAsync } from "~/hooks/useAsync";
 
-export function DeleteAgent({ id }: { id: string }) {
+export function DeleteAgent({
+	id,
+	onSuccess,
+}: {
+	id: string;
+	onSuccess?: () => void;
+}) {
 	const deleteAgent = useAsync(AgentService.deleteAgent, {
 		onSuccess: () => {
 			toast.success("Agent deleted");
 			mutate(AgentService.getAgents.key());
+			onSuccess?.();
 		},
 		onError: () => toast.error("Failed to delete agent"),
 	});

--- a/ui/admin/app/components/workflow/DeleteWorkflow.tsx
+++ b/ui/admin/app/components/workflow/DeleteWorkflow.tsx
@@ -15,13 +15,18 @@ import { useAsync } from "~/hooks/useAsync";
 
 type DeleteWorkflowButtonProps = {
 	id: string;
+	onSuccess?: () => void;
 };
 
-export function DeleteWorkflowButton({ id }: DeleteWorkflowButtonProps) {
+export function DeleteWorkflowButton({
+	id,
+	onSuccess,
+}: DeleteWorkflowButtonProps) {
 	const deleteWorkflow = useAsync(WorkflowService.deleteWorkflow, {
 		onSuccess: () => {
 			mutate(WorkflowService.getWorkflows.key());
 			toast.success("Workflow deleted");
+			onSuccess?.();
 		},
 		onError: () => toast.error("Failed to delete workflow"),
 	});

--- a/ui/admin/app/components/workflow/Workflow.tsx
+++ b/ui/admin/app/components/workflow/Workflow.tsx
@@ -1,5 +1,7 @@
 import { Library, List, PuzzleIcon, WrenchIcon } from "lucide-react";
 import { useCallback, useState } from "react";
+import { useNavigate } from "react-router";
+import { $path } from "safe-routes";
 
 import { AssistantNamespace } from "~/lib/model/assistants";
 import { Workflow as WorkflowType } from "~/lib/model/workflows";
@@ -12,6 +14,7 @@ import { AgentKnowledgePanel } from "~/components/knowledge";
 import { BasicToolForm } from "~/components/tools/BasicToolForm";
 import { CardDescription } from "~/components/ui/card";
 import { ScrollArea } from "~/components/ui/scroll-area";
+import { DeleteWorkflowButton } from "~/components/workflow/DeleteWorkflow";
 import { ParamsForm } from "~/components/workflow/ParamsForm";
 import {
 	WorkflowProvider,
@@ -36,6 +39,7 @@ export function Workflow(props: WorkflowProps) {
 }
 
 function WorkflowContent({ className }: WorkflowProps) {
+	const navigate = useNavigate();
 	const { workflow, updateWorkflow, isUpdating, lastUpdated, refreshWorkflow } =
 		useWorkflow();
 
@@ -61,7 +65,13 @@ function WorkflowContent({ className }: WorkflowProps) {
 	return (
 		<div className="flex h-full flex-col">
 			<ScrollArea className={cn("h-full", className)}>
-				<div className="m-4 p-4">
+				<div className="flex justify-end px-8 pt-4">
+					<DeleteWorkflowButton
+						id={workflow.id}
+						onSuccess={() => navigate($path("/workflows"))}
+					/>
+				</div>
+				<div className="m-4 px-4 pb-4">
 					<AgentForm
 						agent={workflowUpdates}
 						onChange={debouncedSetWorkflowInfo}


### PR DESCRIPTION
* adds delete button in workflow form
* enhance: when deleting agent/workflow from their respective form, return to /agents or /workflows otherwise it's a bit odd to be staying on the page of a deleted agent/workflow

<img width="609" alt="Screenshot 2025-01-15 at 4 08 28 PM" src="https://github.com/user-attachments/assets/29291ec1-68b5-4104-88c7-755c1573dd2e" />
