### PR TITLE
fix: no "refresh tool" on built-in tool dropdown

### DIFF
--- a/ui/admin/app/components/tools/toolGrid/ToolCardActions.tsx
+++ b/ui/admin/app/components/tools/toolGrid/ToolCardActions.tsx
@@ -98,16 +98,18 @@ export function ToolCardActions({ tool }: { tool: ToolReference }) {
 							Configure OAuth
 						</DropdownMenuItem>
 					)}
-					<DropdownMenuItem onClick={() => forceRefresh.execute(tool.id)}>
-						Refresh Tool
-					</DropdownMenuItem>
 					{!tool.builtin && (
-						<DropdownMenuItem
-							className="text-destructive"
-							onClick={handleDelete}
-						>
-							Delete Tool
-						</DropdownMenuItem>
+						<>
+							<DropdownMenuItem onClick={() => forceRefresh.execute(tool.id)}>
+								Refresh Tool
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="text-destructive"
+								onClick={handleDelete}
+							>
+								Delete Tool
+							</DropdownMenuItem>
+						</>
 					)}
 				</DropdownMenuContent>
 			</DropdownMenu>


### PR DESCRIPTION
* built-in tools with oauth metadata will have the dropdown, need to make sure to exclude refresh tool along with delete tool option