### PR TITLE
Fix: don't delete knowledge dataset when it is not being created

### DIFF
--- a/pkg/controller/handlers/knowledgeset/knowledgeset.go
+++ b/pkg/controller/handlers/knowledgeset/knowledgeset.go
@@ -108,7 +108,7 @@ func (h *Handler) CheckHasContent(req router.Request, _ router.Response) error {
 		ks.Status.ExistingFile = ""
 	} else {
 		ks.Status.ExistingFile = files.Items[0].Name
-		ks.Status.EmptyDatasetDeleted = false
+		ks.Status.DatasetCreated = true
 	}
 
 	return nil
@@ -149,7 +149,7 @@ func (h *Handler) CreateWorkspace(req router.Request, _ router.Response) error {
 
 func (h *Handler) Cleanup(req router.Request, _ router.Response) error {
 	ks := req.Object.(*v1.KnowledgeSet)
-	if ks.Status.ThreadName == "" || ks.Status.EmptyDatasetDeleted || (ks.DeletionTimestamp.IsZero() && ks.Status.HasContent) {
+	if ks.Status.ThreadName == "" || !ks.Status.DatasetCreated || (ks.DeletionTimestamp.IsZero() && ks.Status.HasContent) {
 		return nil
 	}
 
@@ -171,6 +171,6 @@ func (h *Handler) Cleanup(req router.Request, _ router.Response) error {
 		return fmt.Errorf("failed to delete knowledge set: %w", err)
 	}
 
-	ks.Status.EmptyDatasetDeleted = true
+	ks.Status.DatasetCreated = false
 	return nil
 }

--- a/pkg/storage/apis/obot.obot.ai/v1/knowledgeset.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/knowledgeset.go
@@ -72,7 +72,7 @@ type KnowledgeSetManifest struct {
 
 type KnowledgeSetStatus struct {
 	HasContent               bool   `json:"hasContent,omitempty"`
-	EmptyDatasetDeleted      bool   `json:"emptyDatasetDeleted,omitempty"`
+	DatasetCreated           bool   `json:"datasetCreated,omitempty"`
 	SuggestedDataDescription string `json:"suggestedDataDescription,omitempty"`
 	WorkspaceName            string `json:"workspaceName,omitempty"`
 	ThreadName               string `json:"threadName,omitempty"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -6098,7 +6098,7 @@ func schema_storage_apis_obotobotai_v1_KnowledgeSetStatus(ref common.ReferenceCa
 							Format: "",
 						},
 					},
-					"emptyDatasetDeleted": {
+					"datasetCreated": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",


### PR DESCRIPTION
We are issuing a  run to delete knowledge dataset when a thread and knowledge set has been created first but with no content on it. Seems unnecessary to do so that. What is happening today is that when user chats with an agent, a new thread with knowledge set created and we immediately run a `knowledge-delete` run with it even there is no dataset created with it. 