### PR TITLE
chore: ignore the thread not found error when ingesting

### DIFF
--- a/pkg/controller/handlers/knowledgefile/knowledgefile.go
+++ b/pkg/controller/handlers/knowledgefile/knowledgefile.go
@@ -90,7 +90,7 @@ func (h *Handler) IngestFile(req router.Request, _ router.Response) error {
 
 	thread, err := getThread(req.Ctx, req.Client, &ks, &source)
 	if err != nil {
-		return err
+		return kclient.IgnoreNotFound(err)
 	}
 
 	if file.Status.State == "" {


### PR DESCRIPTION
The ingestion will trigger when/if the thread exists.