### PR TITLE
fix: show email triggers in workflow triggers page

### DIFF
--- a/ui/admin/app/components/workflow/triggers/EmailReceiverEntry.tsx
+++ b/ui/admin/app/components/workflow/triggers/EmailReceiverEntry.tsx
@@ -17,7 +17,7 @@ export function EmailTriggerEntry({
 
 			<div className="flex gap-2">
 				<CopyText
-					text={receiver.emailAddress}
+					text={receiver.emailAddress ?? ""}
 					className="bg-transparent text-sm text-muted-foreground"
 					classNames={{
 						text: "p-0",

--- a/ui/admin/app/lib/model/email-receivers.ts
+++ b/ui/admin/app/lib/model/email-receivers.ts
@@ -11,7 +11,7 @@ type EmailReceiverBase = {
 export type EmailReceiver = EntityMeta &
 	EmailReceiverBase & {
 		aliasAssigned?: boolean;
-		emailAddress: string;
+		emailAddress?: string;
 	};
 
 export type CreateEmailReceiver = EmailReceiverBase;

--- a/ui/admin/app/lib/model/workflow-trigger.ts
+++ b/ui/admin/app/lib/model/workflow-trigger.ts
@@ -27,7 +27,10 @@ const objectHasAllKeys = <T extends object = object>(
 function isEmailReceiver(
 	entity: WorkFlowTriggerEntity
 ): entity is EmailReceiver {
-	return objectHasAllKeys<EmailReceiver>(entity, ["workflow", "emailAddress"]);
+	return (
+		entity.type === "emailreceiver" &&
+		objectHasAllKeys<EmailReceiver>(entity, ["workflow"])
+	);
 }
 
 function isWebhook(entity: WorkFlowTriggerEntity): entity is Webhook {


### PR DESCRIPTION
Addresses #1188 

Per Donnie: `If the SMTP server is not enabled, then the email address field will not be set.` so `emailAddress` may not be set. Slightly modified the `isEmailReceiver` check to get email trigger types to come through.