### PR TITLE
fix: check live state events first when watching events

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -278,8 +278,6 @@ func (e *Emitter) printRun(ctx context.Context, state *printState, run v1.Run, r
 		e.liveStateLock.Lock()
 		defer e.liveStateLock.Unlock()
 		for {
-			e.liveBroadcast.Wait()
-
 			select {
 			case broadcast <- struct{}{}:
 			default:
@@ -290,6 +288,8 @@ func (e *Emitter) printRun(ctx context.Context, state *printState, run v1.Run, r
 				return
 			default:
 			}
+
+			e.liveBroadcast.Wait()
 		}
 	}()
 


### PR DESCRIPTION
Checking the live state events initially will ensure that the events watcher will see any prompts that happen before other call events.

Issue: https://github.com/obot-platform/obot/issues/1290