### PR TITLE
fix: agent intro & markdown support

### DIFF
--- a/docs/docs/03-tools/02-integrating-oauth.md
+++ b/docs/docs/03-tools/02-integrating-oauth.md
@@ -35,7 +35,7 @@ https://cdn.jsdelivr.net/npm/@phosphor-icons/core@2/assets/duotone/gitlab-logo-d
 
 --
 !metadata:*:oauth
-gitlab
+gitlab-example
 ```
 
 This tool.gpt file just has a single tool name "List Projects" defined.
@@ -44,6 +44,8 @@ You can see that this tool defines a name, description, credential (we'll revisi
 If you review the repository, you'll notice that `projects.py` is one of the files in the repository.
 
 There are three metadata sections: one for category, one for icon and one for oauth. These will be used to display the tool in the Obot UI and tie oauth integration with the GitLab Oauth credentials we'll set up in the next step.
+
+The `oauth` metadata section is important. It tells Obot that this tool uses the `gitlab-example` OAuth integration. It should match with the `integration` field in the credential tool we'll create in the next step.
 
 ### Configure a credential tool that integrates our custom tool and OAuth app
 The credential tool can be found in our example repo at https://github.com/otto8-ai/gitlab-example-tool/blob/main/credential/tool.gpt. Here's the contents:

--- a/ui/admin/app/components/agent/Agent.tsx
+++ b/ui/admin/app/components/agent/Agent.tsx
@@ -105,6 +105,10 @@ export function Agent({ className, currentThreadId, onRefresh }: AgentProps) {
 					<AgentForm agent={agentUpdates} onChange={partialSetAgent} />
 				</div>
 
+				<div className="m-4 p-4">
+					<AgentIntroForm agent={agentUpdates} onChange={partialSetAgent} />
+				</div>
+
 				<div className="m-4 space-y-4 p-4">
 					<h4 className="flex items-center gap-2 border-b pb-2">
 						<BlocksIcon />
@@ -121,10 +125,6 @@ export function Agent({ className, currentThreadId, onRefresh }: AgentProps) {
 						entity={agentUpdates}
 						onChange={partialSetAgent}
 					/>
-				</div>
-
-				<div className="m-4 p-4">
-					<AgentIntroForm agent={agentUpdates} onChange={partialSetAgent} />
 				</div>
 
 				<div className="m-4 space-y-4 p-4">

--- a/ui/admin/app/components/agent/AgentIntroForm.tsx
+++ b/ui/admin/app/components/agent/AgentIntroForm.tsx
@@ -70,6 +70,7 @@ export function AgentIntroForm({
 
 				<CardDescription>
 					Start each conversation from the agent with a friendly introduction.
+					The introduction is <b>Markdown</b> syntax supported.
 				</CardDescription>
 
 				<ControlledAutosizeTextarea

--- a/ui/admin/app/components/chat/Message.tsx
+++ b/ui/admin/app/components/chat/Message.tsx
@@ -36,7 +36,7 @@ interface MessageProps {
 }
 
 // Allow links for file references in messages if it starts with file://, otherwise this will cause an empty href and cause app to reload when clicking on it
-const urlTransformAllowFiles = (u: string) => {
+export const urlTransformAllowFiles = (u: string) => {
 	if (u.startsWith("file://")) {
 		return u;
 	}

--- a/ui/admin/app/components/chat/NoMessages.tsx
+++ b/ui/admin/app/components/chat/NoMessages.tsx
@@ -1,6 +1,13 @@
 import { BrainCircuit, Compass, Wrench } from "lucide-react";
+import Markdown from "react-markdown";
+import rehypeExternalLinks from "rehype-external-links";
+import remarkGfm from "remark-gfm";
+
+import { cn } from "~/lib/utils";
 
 import { useChat } from "~/components/chat/ChatContext";
+import { urlTransformAllowFiles } from "~/components/chat/Message";
+import { CustomMarkdownComponents } from "~/components/react-markdown";
 import { Button } from "~/components/ui/button";
 
 export function NoMessages() {
@@ -15,8 +22,18 @@ export function NoMessages() {
 		<div className="flex h-full flex-col items-center justify-center space-y-4 p-4 text-center">
 			<h2 className="text-2xl font-semibold">Start the conversation!</h2>
 			<p className="text-gray-500">
-				{introductionMessage ||
-					"Looking for a starting point? Try one of these options."}
+				<Markdown
+					className={cn(
+						"prose max-w-full flex-auto overflow-x-auto break-words text-muted-foreground dark:prose-invert prose-pre:whitespace-pre-wrap prose-pre:break-words prose-thead:text-left prose-img:rounded-xl prose-img:shadow-lg"
+					)}
+					remarkPlugins={[remarkGfm]}
+					rehypePlugins={[[rehypeExternalLinks, { target: "_blank" }]]}
+					urlTransform={urlTransformAllowFiles}
+					components={CustomMarkdownComponents}
+				>
+					{introductionMessage ||
+						"Looking for a starting point? Try one of these options."}
+				</Markdown>
 			</p>
 			<div className="flex flex-wrap justify-center gap-2">
 				{starterMessages && starterMessages.length > 0


### PR DESCRIPTION
* moves introductions above capabilities
* add markdown support note & support to introduction message

<img width="1016" alt="Screenshot 2025-01-17 at 1 05 02 PM" src="https://github.com/user-attachments/assets/64b5abae-57ef-411e-a1e9-f331207341d6" />
