### PR TITLE
fix: markdown embedded html & agent intro not firing onChange

### DIFF
--- a/ui/admin/app/components/agent/AgentIntroForm.tsx
+++ b/ui/admin/app/components/agent/AgentIntroForm.tsx
@@ -40,7 +40,11 @@ export function AgentIntroForm({
 	});
 
 	useEffect(() => {
-		if (agent) form.reset(agent);
+		if (agent)
+			form.reset({
+				introductionMessage: agent.introductionMessage ?? "",
+				starterMessages: agent.starterMessages ?? [],
+			});
 	}, [agent, form]);
 
 	useEffect(() => {

--- a/ui/admin/app/components/chat/Message.tsx
+++ b/ui/admin/app/components/chat/Message.tsx
@@ -2,9 +2,6 @@ import "@radix-ui/react-tooltip";
 import { AlertCircleIcon, WrenchIcon } from "lucide-react";
 import React, { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
-import Markdown, { defaultUrlTransform } from "react-markdown";
-import rehypeExternalLinks from "rehype-external-links";
-import remarkGfm from "remark-gfm";
 
 import { AuthPrompt } from "~/lib/model/chatEvents";
 import { Message as MessageType } from "~/lib/model/messages";
@@ -14,7 +11,6 @@ import { cn } from "~/lib/utils";
 import { MessageDebug } from "~/components/chat/MessageDebug";
 import { ToolCallInfo } from "~/components/chat/ToolCallInfo";
 import { ControlledInput } from "~/components/form/controlledInputs";
-import { CustomMarkdownComponents } from "~/components/react-markdown";
 import { ToolIcon } from "~/components/tools/ToolIcon";
 import { Button } from "~/components/ui/button";
 import {
@@ -27,6 +23,7 @@ import {
 } from "~/components/ui/dialog";
 import { Form } from "~/components/ui/form";
 import { Link } from "~/components/ui/link";
+import { Markdown } from "~/components/ui/markdown";
 import { useAnimatedText } from "~/hooks/messages/useAnimatedText";
 import { useAsync } from "~/hooks/useAsync";
 
@@ -34,14 +31,6 @@ interface MessageProps {
 	message: MessageType;
 	isRunning?: boolean;
 }
-
-// Allow links for file references in messages if it starts with file://, otherwise this will cause an empty href and cause app to reload when clicking on it
-export const urlTransformAllowFiles = (u: string) => {
-	if (u.startsWith("file://")) {
-		return u;
-	}
-	return defaultUrlTransform(u);
-};
 
 const OpenMarkdownLinkRegex = new RegExp(/\[([^\]]+)\]\(https?:\/\/[^)]*$/);
 
@@ -97,17 +86,10 @@ export const Message = React.memo(({ message, isRunning }: MessageProps) => {
 							<PromptMessage prompt={message.prompt} isRunning={isRunning} />
 						) : (
 							<Markdown
-								className={cn(
-									"prose max-w-full flex-auto overflow-x-auto break-words dark:prose-invert prose-pre:whitespace-pre-wrap prose-pre:break-words prose-thead:text-left prose-img:rounded-xl prose-img:shadow-lg",
-									{
-										"prose-invert text-accent-foreground": isUser,
-										"text-muted-foreground": message.aborted,
-									}
-								)}
-								remarkPlugins={[remarkGfm]}
-								rehypePlugins={[[rehypeExternalLinks, { target: "_blank" }]]}
-								urlTransform={urlTransformAllowFiles}
-								components={CustomMarkdownComponents}
+								className={cn({
+									"prose-invert text-accent-foreground": isUser,
+									"text-muted-foreground": message.aborted,
+								})}
 							>
 								{parsedMessage || "Waiting for more information..."}
 							</Markdown>

--- a/ui/admin/app/components/chat/NoMessages.tsx
+++ b/ui/admin/app/components/chat/NoMessages.tsx
@@ -1,14 +1,8 @@
 import { BrainCircuit, Compass, Wrench } from "lucide-react";
-import Markdown from "react-markdown";
-import rehypeExternalLinks from "rehype-external-links";
-import remarkGfm from "remark-gfm";
-
-import { cn } from "~/lib/utils";
 
 import { useChat } from "~/components/chat/ChatContext";
-import { urlTransformAllowFiles } from "~/components/chat/Message";
-import { CustomMarkdownComponents } from "~/components/react-markdown";
 import { Button } from "~/components/ui/button";
+import { Markdown } from "~/components/ui/markdown";
 
 export function NoMessages() {
 	const {
@@ -21,20 +15,12 @@ export function NoMessages() {
 	return (
 		<div className="flex h-full flex-col items-center justify-center space-y-4 p-4 text-center">
 			<h2 className="text-2xl font-semibold">Start the conversation!</h2>
-			<p className="text-gray-500">
-				<Markdown
-					className={cn(
-						"prose max-w-full flex-auto overflow-x-auto break-words text-muted-foreground dark:prose-invert prose-pre:whitespace-pre-wrap prose-pre:break-words prose-thead:text-left prose-img:rounded-xl prose-img:shadow-lg"
-					)}
-					remarkPlugins={[remarkGfm]}
-					rehypePlugins={[[rehypeExternalLinks, { target: "_blank" }]]}
-					urlTransform={urlTransformAllowFiles}
-					components={CustomMarkdownComponents}
-				>
+			<div className="text-gray-500">
+				<Markdown>
 					{introductionMessage ||
 						"Looking for a starting point? Try one of these options."}
 				</Markdown>
-			</p>
+			</div>
 			<div className="flex flex-wrap justify-center gap-2">
 				{starterMessages && starterMessages.length > 0
 					? starterMessages.map((starterMessage, index) => (

--- a/ui/admin/app/components/oauth-apps/OAuthAppForm.tsx
+++ b/ui/admin/app/components/oauth-apps/OAuthAppForm.tsx
@@ -1,8 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Fragment, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
-import Markdown from "react-markdown";
-import rehypeExternalLinks from "rehype-external-links";
 
 import { OAuthAppParams } from "~/lib/model/oauthApps";
 import {
@@ -13,7 +11,6 @@ import { cn } from "~/lib/utils";
 
 import { CopyText } from "~/components/composed/CopyText";
 import { ControlledInput } from "~/components/form/controlledInputs";
-import { CustomMarkdownComponents } from "~/components/react-markdown";
 import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 import {
 	Accordion,
@@ -23,6 +20,7 @@ import {
 } from "~/components/ui/accordion";
 import { Button } from "~/components/ui/button";
 import { Form } from "~/components/ui/form";
+import { Markdown } from "~/components/ui/markdown";
 import { useOAuthAppInfo } from "~/hooks/oauthApps/useOAuthApps";
 
 type OAuthAppFormProps = {
@@ -75,17 +73,7 @@ export function OAuthAppForm({ type, onSubmit, isLoading }: OAuthAppFormProps) {
 	function renderStep(step: OAuthFormStep) {
 		switch (step.type) {
 			case "markdown":
-				return (
-					<Markdown
-						className={cn(
-							"prose max-w-full flex-auto overflow-x-auto break-words dark:prose-invert prose-pre:whitespace-pre-wrap prose-pre:break-words prose-thead:text-left prose-img:rounded-xl prose-img:shadow-lg"
-						)}
-						components={CustomMarkdownComponents}
-						rehypePlugins={[[rehypeExternalLinks, { target: "_blank" }]]}
-					>
-						{step.text}
-					</Markdown>
-				);
+				return <Markdown>{step.text}</Markdown>;
 			case "input": {
 				return (
 					<ControlledInput

--- a/ui/admin/app/components/ui/markdown.tsx
+++ b/ui/admin/app/components/ui/markdown.tsx
@@ -1,0 +1,44 @@
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import rehypeExternalLinks from "rehype-external-links";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
+import remarkGfm from "remark-gfm";
+
+import { cn } from "~/lib/utils/cn";
+
+import { CustomMarkdownComponents } from "~/components/react-markdown";
+
+// Allow links for file references in messages if it starts with file://, otherwise this will cause an empty href and cause app to reload when clicking on it
+export const urlTransformAllowFiles = (u: string) => {
+	if (u.startsWith("file://")) {
+		return u;
+	}
+	return defaultUrlTransform(u);
+};
+
+export function Markdown({
+	children,
+	className,
+}: {
+	children?: string | null;
+	className?: string;
+}) {
+	return (
+		<ReactMarkdown
+			className={cn(
+				"prose max-w-full flex-auto overflow-x-auto break-words dark:prose-invert prose-pre:whitespace-pre-wrap prose-pre:break-words prose-thead:text-left prose-img:rounded-xl prose-img:shadow-lg",
+				className
+			)}
+			remarkPlugins={[remarkGfm]}
+			rehypePlugins={[
+				[rehypeExternalLinks, { target: "_blank" }],
+				rehypeRaw,
+				rehypeSanitize,
+			]}
+			urlTransform={urlTransformAllowFiles}
+			components={CustomMarkdownComponents}
+		>
+			{children}
+		</ReactMarkdown>
+	);
+}

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -63,6 +63,8 @@
 		"react-resizable-panels": "^2.1.3",
 		"react-router": "^7.0.0",
 		"rehype-external-links": "^3.0.0",
+		"rehype-raw": "^7.0.0",
+		"rehype-sanitize": "^6.0.0",
 		"remark-gfm": "^4.0.0",
 		"safe-routes": "^1.0.2",
 		"sonner": "1.4.3",

--- a/ui/admin/pnpm-lock.yaml
+++ b/ui/admin/pnpm-lock.yaml
@@ -155,6 +155,12 @@ importers:
       rehype-external-links:
         specifier: ^3.0.0
         version: 3.0.0
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1954,6 +1960,10 @@ packages:
     resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
     engines: {node: '>=10.13.0'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
@@ -2349,14 +2359,32 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.2:
+    resolution: {integrity: sha512-SfMzfdAi/zAoZ1KkFEyyeXBn7u/ShQrfd675ZEE9M3qj+PMFX05xubzRyF76CCSJu8au9jgVxDV1+okFvgZU4A==}
+
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
   hast-util-to-jsx-runtime@2.3.2:
     resolution: {integrity: sha512-1ngXYb+V9UT5h+PxNRa1O1FYguZK/XL+gkeqvp7EdHlB9oHUG0eYRo/vY5inBdcqo3RkPMC58/H94HvkbfGdyg==}
 
+  hast-util-to-parse5@8.0.0:
+    resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.0:
+    resolution: {integrity: sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -2370,6 +2398,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3022,6 +3053,9 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse5@7.2.1:
+    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3358,6 +3392,12 @@ packages:
 
   rehype-external-links@3.0.0:
     resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-gfm@4.0.0:
     resolution: {integrity: sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==}
@@ -3836,6 +3876,9 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.2:
     resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
 
@@ -3893,6 +3936,9 @@ packages:
 
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5741,6 +5787,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.2.1
 
+  entities@4.5.0: {}
+
   err-code@2.0.3: {}
 
   es-abstract@1.23.6:
@@ -6285,9 +6333,46 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-parse5@8.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.0
+      property-information: 6.5.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
   hast-util-is-element@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.2.1
+      hast-util-from-parse5: 8.0.2
+      hast-util-to-parse5: 8.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.0
+      parse5: 7.2.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.2.1
+      unist-util-position: 5.0.0
 
   hast-util-to-jsx-runtime@2.3.2:
     dependencies:
@@ -6309,9 +6394,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-parse5@8.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 6.5.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 6.5.0
+      space-separated-tokens: 2.0.2
 
   hermes-estree@0.25.1: {}
 
@@ -6324,6 +6427,8 @@ snapshots:
       lru-cache: 7.18.3
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   ignore@5.3.2: {}
 
@@ -7145,6 +7250,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.2.1:
+    dependencies:
+      entities: 4.5.0
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -7431,6 +7540,17 @@ snapshots:
       is-absolute-url: 4.0.1
       space-separated-tokens: 2.0.2
       unist-util-visit: 5.0.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   remark-gfm@4.0.0:
     dependencies:
@@ -8051,6 +8171,11 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.2:
     dependencies:
       '@types/unist': 3.0.3
@@ -8120,6 +8245,8 @@ snapshots:
   warning@4.0.3:
     dependencies:
       loose-envify: 1.4.0
+
+  web-namespaces@2.0.1: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
* shared Markdown component that takes in repeated props
* tweak to AgentForm.reset (if one of the fields is not supplied from `agent`, it fails the safeSchema check)
* add rehype-raw & rehype-sanitize to allow embedded html rendering and sanitize html

<img width="934" alt="Screenshot 2025-01-20 at 1 47 24 PM" src="https://github.com/user-attachments/assets/48796d5a-7003-4d93-b4b8-f929983a0a94" />

