### PR TITLE
fix: hide error toast for reveal api during initial model provider configuration

### DIFF
--- a/ui/admin/app/components/chat/ChatActions.tsx
+++ b/ui/admin/app/components/chat/ChatActions.tsx
@@ -6,7 +6,7 @@ import { ToolsInfo } from "~/components/chat/chat-actions/ToolsInfo";
 import {
 	useOptimisticThread,
 	useThreadAgents as useThreadAgent,
-} from "~/components/chat/thread-helpers";
+} from "~/components/chat/shared/thread-helpers";
 
 export function ChatActions({ className }: { className?: string }) {
 	const { threadId } = useChat();

--- a/ui/admin/app/components/chat/chat-actions/KnowledgeInfo.tsx
+++ b/ui/admin/app/components/chat/chat-actions/KnowledgeInfo.tsx
@@ -5,7 +5,7 @@ import { KNOWLEDGE_TOOL } from "~/lib/model/agents";
 import { KnowledgeFileNamespace } from "~/lib/model/knowledge";
 import { cn } from "~/lib/utils";
 
-import { useThreadAgents } from "~/components/chat/thread-helpers";
+import { useThreadAgents } from "~/components/chat/shared/thread-helpers";
 import { KnowledgeFileItem } from "~/components/knowledge/KnowledgeFileItem";
 import { Button } from "~/components/ui/button";
 import {

--- a/ui/admin/app/components/chat/shared/thread-helpers.ts
+++ b/ui/admin/app/components/chat/shared/thread-helpers.ts
@@ -1,6 +1,7 @@
 import { toast } from "sonner";
 import useSWR from "swr";
 
+import { KnowledgeFileNamespace } from "~/lib/model/knowledge";
 import { UpdateThread } from "~/lib/model/threads";
 import { AgentService } from "~/lib/service/api/agentService";
 import { KnowledgeFileService } from "~/lib/service/api/knowledgeFileApiService";
@@ -45,9 +46,18 @@ export function useOptimisticThread(threadId?: Nullish<string>) {
 
 export function useThreadKnowledge(threadId?: Nullish<string>) {
 	return useSWR(
-		KnowledgeFileService.getKnowledgeFiles.key("threads", threadId),
-		({ agentId, namespace }) =>
-			KnowledgeFileService.getKnowledgeFiles(namespace, agentId)
+		KnowledgeFileService.getKnowledgeFiles.key(
+			KnowledgeFileNamespace.Threads,
+			threadId
+		),
+		({ entityId, namespace }) =>
+			KnowledgeFileService.getKnowledgeFiles(namespace, entityId)
+	);
+}
+
+export function useThreadFiles(threadId?: Nullish<string>) {
+	return useSWR(ThreadsService.getFiles.key(threadId), ({ threadId }) =>
+		ThreadsService.getFiles(threadId)
 	);
 }
 

--- a/ui/admin/app/components/thread/ThreadMeta.tsx
+++ b/ui/admin/app/components/thread/ThreadMeta.tsx
@@ -4,18 +4,21 @@ import {
 	ExternalLink,
 	FileIcon,
 	FilesIcon,
+	RotateCwIcon,
 } from "lucide-react";
 import { $path } from "safe-routes";
 
 import { Agent } from "~/lib/model/agents";
-import { KnowledgeFile } from "~/lib/model/knowledge";
 import { runStateToBadgeColor } from "~/lib/model/runs";
 import { Thread } from "~/lib/model/threads";
 import { Workflow } from "~/lib/model/workflows";
-import { WorkspaceFile } from "~/lib/model/workspace";
 import { ThreadsService } from "~/lib/service/api/threadsService";
 import { cn } from "~/lib/utils";
 
+import {
+	useThreadFiles,
+	useThreadKnowledge,
+} from "~/components/chat/shared/thread-helpers";
 import { Truncate } from "~/components/composed/typography";
 import {
 	Accordion,
@@ -35,26 +38,24 @@ import {
 } from "~/components/ui/tooltip";
 
 interface ThreadMetaProps {
-	for: Agent | Workflow;
+	entity: Agent | Workflow;
 	thread: Thread;
-	files: WorkspaceFile[];
-	knowledge: KnowledgeFile[];
 	className?: string;
 }
 
-export function ThreadMeta({
-	for: entity,
-	thread,
-	files,
-	className,
-	knowledge,
-}: ThreadMetaProps) {
+export function ThreadMeta({ entity, thread, className }: ThreadMetaProps) {
 	const from = $path("/threads/:id", { id: thread.id });
 	const isAgent = entity.id.startsWith("a");
 
 	const assistantLink = isAgent
 		? $path("/agents/:agent", { agent: entity.id }, { from })
 		: $path("/workflows/:workflow", { workflow: entity.id });
+
+	const getFiles = useThreadFiles(thread.id);
+	const { data: files = [] } = getFiles;
+
+	const getKnowledge = useThreadKnowledge(thread.id);
+	const { data: knowledge = [] } = getKnowledge;
 
 	return (
 		<Card className={cn("bg-0 h-full overflow-hidden", className)}>
@@ -131,10 +132,24 @@ export function ThreadMeta({
 					{files.length > 0 && (
 						<AccordionItem value="files">
 							<AccordionTrigger>
-								<span className="flex items-center">
-									<FilesIcon className="mr-2 h-4 w-4" />
-									Files
-								</span>
+								<div className="flex w-full items-center justify-between">
+									<span className="flex items-center">
+										<FilesIcon className="mr-2 h-4 w-4" />
+										Files
+									</span>
+
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										loading={getFiles.isValidating}
+										onClick={(e) => {
+											e.stopPropagation();
+											getFiles.mutate();
+										}}
+									>
+										<RotateCwIcon />
+									</Button>
+								</div>
 							</AccordionTrigger>
 							<AccordionContent className="mx-4">
 								<ul className="space-y-2">
@@ -171,10 +186,24 @@ export function ThreadMeta({
 					{knowledge.length > 0 && (
 						<AccordionItem value="knowledge">
 							<AccordionTrigger>
-								<span className="flex items-center text-base">
-									<FilesIcon className="mr-2 h-4 w-4" />
-									Knowledge Files
-								</span>
+								<div className="flex w-full items-center justify-between">
+									<span className="flex items-center">
+										<FilesIcon className="mr-2 h-4 w-4" />
+										Knowledge Files
+									</span>
+
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										loading={getKnowledge.isValidating}
+										onClick={(e) => {
+											e.stopPropagation();
+											getKnowledge.mutate();
+										}}
+									>
+										<RotateCwIcon />
+									</Button>
+								</div>
 							</AccordionTrigger>
 							<AccordionContent className="mx-4">
 								<ul className="space-y-2">

--- a/ui/admin/app/components/ui/button.tsx
+++ b/ui/admin/app/components/ui/button.tsx
@@ -90,7 +90,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 		);
 
 		function getContent() {
-			if (size === "icon" && loading)
+			if ((size === "icon" || size === "icon-sm") && loading)
 				return <Loader2 className="animate-spin" />;
 
 			return loading ? (

--- a/ui/admin/app/hooks/knowledge/useKnowledgeFiles.ts
+++ b/ui/admin/app/hooks/knowledge/useKnowledgeFiles.ts
@@ -20,8 +20,8 @@ export function useKnowledgeFiles(
 		...rest
 	} = useSWR(
 		KnowledgeFileService.getKnowledgeFiles.key(namespace, agentId),
-		({ namespace, agentId }) =>
-			KnowledgeFileService.getKnowledgeFiles(namespace, agentId),
+		({ namespace, entityId }) =>
+			KnowledgeFileService.getKnowledgeFiles(namespace, entityId),
 		{
 			revalidateOnFocus: false,
 			refreshInterval: blockPollingLocalFiles ? undefined : 5000,

--- a/ui/admin/app/lib/service/api/knowledgeFileApiService.ts
+++ b/ui/admin/app/lib/service/api/knowledgeFileApiService.ts
@@ -4,10 +4,10 @@ import { request } from "~/lib/service/api/primitives";
 
 async function getKnowledgeFiles(
 	namespace: KnowledgeFileNamespace,
-	agentId: string
+	entityId: string
 ) {
 	const res = await request<{ items: KnowledgeFile[] }>({
-		url: ApiRoutes.knowledgeFiles.getKnowledgeFiles(namespace, agentId).url,
+		url: ApiRoutes.knowledgeFiles.getKnowledgeFiles(namespace, entityId).url,
 		errorMessage: "Failed to fetch knowledge for agent",
 	});
 
@@ -15,13 +15,13 @@ async function getKnowledgeFiles(
 }
 getKnowledgeFiles.key = (
 	namespace?: Nullish<KnowledgeFileNamespace>,
-	agentId?: Nullish<string>
+	entityId?: Nullish<string>
 ) => {
-	if (!namespace || !agentId) return null;
+	if (!namespace || !entityId) return null;
 
 	return {
-		url: ApiRoutes.knowledgeFiles.getKnowledgeFiles(namespace, agentId).path,
-		agentId,
+		url: ApiRoutes.knowledgeFiles.getKnowledgeFiles(namespace, entityId).path,
+		entityId,
 		namespace,
 	};
 };

--- a/ui/admin/app/lib/service/api/modelProviderApiService.ts
+++ b/ui/admin/app/lib/service/api/modelProviderApiService.ts
@@ -68,7 +68,8 @@ const revealModelProviderById = async (providerKey: string) => {
 		url: ApiRoutes.modelProviders.revealModelProviderById(providerKey).url,
 		method: "POST",
 		errorMessage:
-			"Failed to reveal configuration values on the requested model provider.",
+			"Failed to reveal configuration values on the requested modal provider.",
+		toastError: false,
 	});
 
 	return res.data;

--- a/ui/admin/app/lib/service/api/primitives.ts
+++ b/ui/admin/app/lib/service/api/primitives.ts
@@ -29,12 +29,14 @@ interface ExtendedAxiosRequestConfig<D = unknown>
 	errorMessage?: string;
 	disableTokenRefresh?: boolean;
 	debugThrow?: Error;
+	toastError?: boolean;
 }
 
 export async function request<T, R = AxiosResponse<T>, D = unknown>({
 	errorMessage = "Something went wrong",
 	disableTokenRefresh,
 	debugThrow,
+	toastError = true,
 	...config
 }: ExtendedAxiosRequestConfig<D>): Promise<R> {
 	// Get the browser's default timezone
@@ -77,7 +79,7 @@ export async function request<T, R = AxiosResponse<T>, D = unknown>({
 			});
 		}
 
-		toast.error(errorMessage);
+		if (toastError) toast.error(errorMessage);
 
 		throw convertedError;
 	}

--- a/ui/admin/app/routes/_auth.threads.$id.tsx
+++ b/ui/admin/app/routes/_auth.threads.$id.tsx
@@ -8,6 +8,7 @@ import {
 	useNavigate,
 } from "react-router";
 import { $path } from "safe-routes";
+import { preload } from "swr";
 
 import { KnowledgeFileNamespace } from "~/lib/model/knowledge";
 import { AgentService } from "~/lib/service/api/agentService";
@@ -16,7 +17,6 @@ import { ThreadsService } from "~/lib/service/api/threadsService";
 import { WorkflowService } from "~/lib/service/api/workflowService";
 import { RouteHandle } from "~/lib/service/routeHandles";
 import { RouteService } from "~/lib/service/routeService";
-import { noop } from "~/lib/utils";
 
 import { Chat } from "~/components/chat";
 import { ChatProvider } from "~/components/chat/ChatContext";
@@ -50,29 +50,43 @@ export const clientLoader = async ({
 		throw redirect("/threads");
 	}
 
-	const thread = await ThreadsService.getThreadById(id);
+	const thread = await preload(ThreadsService.getThreadById.key(id), () =>
+		ThreadsService.getThreadById(id)
+	);
 	if (!thread) throw redirect("/threads");
 
-	const agent = thread.agentID
-		? await AgentService.getAgentById(thread.agentID).catch(noop)
-		: null;
+	const [agent, workflow] = await Promise.all([
+		thread.agentID
+			? preload(AgentService.getAgentById.key(thread.agentID), () =>
+					AgentService.getAgentById(thread.agentID)
+				)
+			: null,
+		thread.workflowID
+			? preload(WorkflowService.getWorkflowById.key(thread.workflowID), () =>
+					WorkflowService.getWorkflowById(thread.workflowID)
+				)
+			: null,
+		preload(ThreadsService.getFiles.key(thread.id), () =>
+			ThreadsService.getFiles(thread.id)
+		),
+		preload(
+			KnowledgeFileService.getKnowledgeFiles.key(
+				KnowledgeFileNamespace.Threads,
+				thread.id
+			),
+			() =>
+				KnowledgeFileService.getKnowledgeFiles(
+					KnowledgeFileNamespace.Threads,
+					thread.id
+				)
+		),
+	]);
 
-	const workflow = thread.workflowID
-		? await WorkflowService.getWorkflowById(thread.workflowID).catch(noop)
-		: null;
-
-	const files = await ThreadsService.getFiles(id);
-	const knowledge = await KnowledgeFileService.getKnowledgeFiles(
-		KnowledgeFileNamespace.Threads,
-		thread.id
-	);
-
-	return { thread, agent, workflow, files, knowledge };
+	return { thread, agent, workflow };
 };
 
 export default function ChatAgent() {
-	const { thread, agent, workflow, files, knowledge } =
-		useLoaderData<typeof clientLoader>();
+	const { thread, agent, workflow } = useLoaderData<typeof clientLoader>();
 
 	const getEntity = () => {
 		if (agent) return agent;
@@ -119,9 +133,7 @@ export default function ChatAgent() {
 						<ThreadMeta
 							className="rounded-none border-none"
 							thread={thread}
-							for={entity}
-							files={files}
-							knowledge={knowledge}
+							entity={entity}
 						/>
 					</ScrollArea>
 				</ResizablePanel>


### PR DESCRIPTION
- also add ability to refresh files/knowledge in thread sidebar

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>