### PR TITLE
docs: auth providers

### DIFF
--- a/docs/docs/05-configuration/03-auth-providers.md
+++ b/docs/docs/05-configuration/03-auth-providers.md
@@ -1,32 +1,45 @@
 # Auth Providers
 
-Authentication providers allow your Obot installation to authenticate users with the identity provider of your choice. All authentication providers are configured using environment variables.
+Authentication providers allow your Obot installation to authenticate users with the identity provider of your choice.
+Administrators must configure at least one authentication provider before users can log in.
+Multiple providers can be configured and available for login at the same time.
 
-## Common Environment Variables
+:::note
+In order for authentication to be enabled, the Obot server must be run with `--enable-authentication` or
+`OBOT_SERVER_ENABLE_AUTHENTICATION=true`.
+:::
 
-The following environment variables are required for all authentication providers.
-Setting the Client ID and Client Secret will mean that the authentication provider is enabled.
-The remaining configuration will be validated on startup.
+## Setting up
 
-- `OBOT_SERVER_AUTH_CLIENT_ID`: The client ID of the authentication provider.
-- `OBOT_SERVER_AUTH_CLIENT_SECRET`: The client secret of the authentication provider.
-- `OBOT_SERVER_AUTH_COOKIE_SECRET`: The secret used to encrypt the authentication cookie. Must be of size 16, 24, or 32 bytes.
-- `OBOT_SERVER_AUTH_ADMIN_EMAILS`: A comma-separated list of the email addresses of the admin users.
+When launching Obot for the first time, the server will print a randomly generated bootstrap token to the console.
+This token can be used to authenticate as an admin user in the UI.
+You will then be able to configure authentication providers.
 
-The following environment variables are optional for all authentication providers:
-- `OBOT_SERVER_AUTH_EMAIL_DOMAINS`: A comma-separated list of email domains allowed for authentication. Ignored if not set.
-- `OBOT_SERVER_AUTH_CONFIG_TYPE`: The type of the authentication provider. For example, `google` or `github`. Defaults to `google`.
+:::tip
+You can use the `OBOT_BOOTSTRAP_TOKEN` environment variable to provide a specific value for the token,
+rather than having the server generate one for you. If you do this, the value will **not** be printed to the console.
+:::
 
-## Google
+### Preconfiguring admin users
 
-Google is the default authentication provider. There are currently no additional environment variables required for Google authentication.
+If you want to preconfigure admin users, you can set the `OBOT_SERVER_AUTH_ADMIN_EMAILS` environment variable.
+This is a comma-separated list of email addresses that will be granted admin access when they log in,
+regardless of which auth provider they used.
 
-## GitHub
+Users can be given the administrator role by other admins in the Users section of the UI.
+Users whose email addresses are in the `OBOT_SERVER_AUTH_ADMIN_EMAILS` list will automatically have the administrator role,
+and the role cannot be revoked from them.
 
-GitHub authentication has the following optional configuration:
+## Restricting access to specific email domains
 
-- `OBOT_SERVER_AUTH_GITHUB_ORG`: The name of the organization allowed for authentication. Ignored if not set.
-- `OBOT_SERVER_AUTH_GITHUB_TEAM`: The name of the team allowed for authentication. Ignored if not set.
-- `OBOT_SERVER_AUTH_GITHUB_REPO`: Restrict logins to collaborators of this repository formatted as `orgname/repo`. Ignored if not set.
-- `OBOT_SERVER_AUTH_GITHUB_TOKEN`: The token to use when verifying repository collaborators (must have push access to the repository).
-- `OBOT_SERVER_AUTH_GITHUB_ALLOW_USERS`: A comma-separated list of users allowed to log in even if they don't belong to the organization or team.
+All authentication providers support restricting access to specific email domains, using the "Email Domains" field in the configuration UI.
+You can use the value `*` to allow all email domains, or a comma-separated list of domains to restrict access to those domains.
+For example, `example.com,example.org` would only allow users with email addresses ending in `example.com` or `example.org`.
+
+## Available Auth Providers
+
+Obot currently supports the following authentication providers (using OAuth2):
+- GitHub
+- Google
+
+The code for these providers is available in the [Obot tools repo](https://github.com/obot-platform/tools).


### PR DESCRIPTION
This is the user-facing documentation explaining how to use auth providers.