### PR TITLE
Fix: Don't ignore obot frames

### DIFF
--- a/ui/admin/app/components/chat/CallFrames.tsx
+++ b/ui/admin/app/components/chat/CallFrames.tsx
@@ -56,8 +56,7 @@ const CallFrames = ({ calls }: { calls: CallsType }) => {
 
 		sortedCalls.forEach(([id, call]) => {
 			if (
-				call.tool?.name === "GPTScript Gateway Provider" ||
-				call.tool?.name === "Obot"
+				call.tool?.name === "GPTScript Gateway Provider"
 			) {
 				return;
 			}


### PR DESCRIPTION
In setting up the debug, we for some reason ignore a frame where the tool is named obot, but that causes us to actually show no output for user threads from the obot agent.