### PR TITLE
Fix: Don't ignore obot frame in debug view

### DIFF
--- a/ui/admin/app/components/chat/CallFrames.tsx
+++ b/ui/admin/app/components/chat/CallFrames.tsx
@@ -56,8 +56,9 @@ const CallFrames = ({ calls }: { calls: CallsType }) => {
 
 		sortedCalls.forEach(([id, call]) => {
 			if (
-				call.tool?.name === "GPTScript Gateway Provider" ||
-				call.tool?.name === "Obot"
+				call.tool?.modelProvider &&
+				(call.tool?.name === "GPTScript Gateway Provider" ||
+					call.tool?.name === "Obot")
 			) {
 				return;
 			}


### PR DESCRIPTION
When contructing the debug view, we would ignore certain frames, but it
seems we should not ignore frames where the tool is named obot, because
that is the name of the root frame for threads from the obot agent.

Signed-off-by: Craig Jellick <craig@acorn.io>
