### PR TITLE
fix: github icon darkmode:invert

### DIFF
--- a/ui/admin/app/components/auth-and-model-providers/ProviderIcon.tsx
+++ b/ui/admin/app/components/auth-and-model-providers/ProviderIcon.tsx
@@ -25,7 +25,6 @@ export function ProviderIcon({
 				"dark:invert": ![
 					CommonModelProviderIds.AZURE_OPENAI,
 					CommonAuthProviderIds.GOOGLE,
-					CommonAuthProviderIds.GITHUB,
 				].includes(provider.id),
 			})}
 		/>


### PR DESCRIPTION
<img width="348" alt="Screenshot 2025-01-21 at 12 07 55 PM" src="https://github.com/user-attachments/assets/97f33895-87b3-422d-8cda-b95cf27365eb" /> to
<img width="348" alt="Screenshot 2025-01-21 at 12 07 49 PM" src="https://github.com/user-attachments/assets/b86d3764-861a-47a8-9567-d0f547d5b393" />
