### PR TITLE
fix: prevent scroll area from expanding with `code` tags

### DIFF
--- a/ui/admin/app/components/ui/scroll-area.tsx
+++ b/ui/admin/app/components/ui/scroll-area.tsx
@@ -73,7 +73,11 @@ const ScrollArea = React.forwardRef<
 		>
 			<ScrollAreaPrimitive.Viewport
 				className={cn(
-					"h-full max-h-[inherit] w-full scroll-smooth rounded-[inherit]",
+					// [&>div]:!block” is a workaround to fix width expansion issues caused by the viewport
+					// setting `display: table` in the `ScrollAreaPrimitive.Viewport` component.
+					// This is a known issue with Radix UI ScrollArea.
+					// https://github.com/radix-ui/primitives/issues/2722
+					"h-full max-h-[inherit] w-full scroll-smooth rounded-[inherit] [&>div]:!block",
 					classNames.viewport
 				)}
 				ref={initRef}

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -33,7 +33,7 @@
 		"@radix-ui/react-navigation-menu": "^1.2.0",
 		"@radix-ui/react-popover": "^1.1.1",
 		"@radix-ui/react-radio-group": "^1.2.1",
-		"@radix-ui/react-scroll-area": "^1.1.0",
+		"@radix-ui/react-scroll-area": "^1.2.2",
 		"@radix-ui/react-select": "^2.1.1",
 		"@radix-ui/react-separator": "^1.1.0",
 		"@radix-ui/react-slot": "^1.1.0",

--- a/ui/admin/pnpm-lock.yaml
+++ b/ui/admin/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         specifier: ^1.2.1
         version: 1.2.2(@types/react-dom@18.3.5(@types/react@18.3.17))(@types/react@18.3.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-scroll-area':
-        specifier: ^1.1.0
+        specifier: ^1.2.2
         version: 1.2.2(@types/react-dom@18.3.5(@types/react@18.3.17))(@types/react@18.3.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-select':
         specifier: ^2.1.1


### PR DESCRIPTION
addresses #1190

before:
![image](https://github.com/user-attachments/assets/5a4ec3d7-5706-42fc-8ecb-6ab2acbf4826)

after:
![image](https://github.com/user-attachments/assets/363dbf90-5934-48bf-af5c-cc1635c6f707)


Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>