### PR TITLE
enhance: add ability to pre-configure auth and model providers

### DIFF
--- a/pkg/api/handlers/agent.go
+++ b/pkg/api/handlers/agent.go
@@ -993,7 +993,7 @@ func removeToolCredentials(ctx context.Context, client kclient.Client, gClient *
 		toolRef.Status.Tool = nil
 
 		for _, cred := range credentialNames {
-			if err := gClient.DeleteCredential(ctx, credCtx, cred); err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
+			if err := gClient.DeleteCredential(ctx, credCtx, cred); err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 				errs = append(errs, err)
 			}
 		}

--- a/pkg/api/handlers/availablemodels.go
+++ b/pkg/api/handlers/availablemodels.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -93,8 +94,8 @@ func (a *AvailableModelsHandler) ListForModelProvider(req api.Context) error {
 	var credEnvVars map[string]string
 	if modelProviderReference.Status.Tool != nil {
 		if envVars := modelProviderReference.Status.Tool.Metadata["envVars"]; envVars != "" {
-			cred, err := a.gptscript.RevealCredential(req.Context(), []string{string(modelProviderReference.UID)}, modelProviderReference.Name)
-			if err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
+			cred, err := a.gptscript.RevealCredential(req.Context(), []string{string(modelProviderReference.UID), system.GenericModelProviderCredentialContext}, modelProviderReference.Name)
+			if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 				return fmt.Errorf("failed to reveal credential for model provider %q: %w", modelProviderReference.Name, err)
 			} else if err == nil {
 				credEnvVars = cred.Env

--- a/pkg/api/handlers/env.go
+++ b/pkg/api/handlers/env.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/obot/apiclient/types"
@@ -28,8 +27,8 @@ func SetEnv(req api.Context) error {
 
 	var errs []error
 	for key, val := range envs {
-		if err := req.GPTClient.DeleteCredential(req.Context(), id, key); err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
-			errs = append(errs, fmt.Errorf("failed to remove existing credetial %q: %w", key, err))
+		if err := req.GPTClient.DeleteCredential(req.Context(), id, key); err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
+			errs = append(errs, fmt.Errorf("failed to remove existing credential %q: %w", key, err))
 			continue
 		}
 
@@ -55,8 +54,8 @@ func SetEnv(req api.Context) error {
 	for i := 0; i < len(*env); i++ {
 		if _, ok := envs[(*env)[i].Name]; !ok {
 			// Delete the credential for the store
-			if err := req.GPTClient.DeleteCredential(req.Context(), id, (*env)[i].Name); err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
-				errs = append(errs, fmt.Errorf("failed to remove existing credetial %q that is not longer needed: %w", (*env)[i].Name, err))
+			if err := req.GPTClient.DeleteCredential(req.Context(), id, (*env)[i].Name); err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
+				errs = append(errs, fmt.Errorf("failed to remove existing credential %q that is not longer needed: %w", (*env)[i].Name, err))
 				continue
 			}
 			// Remove the item from the slice
@@ -98,7 +97,7 @@ func RevealEnv(req api.Context) error {
 	resp := make(map[string]string, len(*env))
 	for _, e := range *env {
 		cred, err := req.GPTClient.RevealCredential(req.Context(), []string{id}, e.Name)
-		if err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
+		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return err
 		}
 

--- a/pkg/api/handlers/modelprovider.go
+++ b/pkg/api/handlers/modelprovider.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -48,8 +49,8 @@ func (mp *ModelProviderHandler) ByID(req api.Context) error {
 	var credEnvVars map[string]string
 	if ref.Status.Tool != nil {
 		if envVars := ref.Status.Tool.Metadata["envVars"]; envVars != "" {
-			cred, err := mp.gptscript.RevealCredential(req.Context(), []string{string(ref.UID)}, ref.Name)
-			if err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
+			cred, err := mp.gptscript.RevealCredential(req.Context(), []string{string(ref.UID), system.GenericModelProviderCredentialContext}, ref.Name)
+			if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 				return fmt.Errorf("failed to reveal credential for model provider %q: %w", ref.Name, err)
 			} else if err == nil {
 				credEnvVars = cred.Env
@@ -71,10 +72,11 @@ func (mp *ModelProviderHandler) List(req api.Context) error {
 		return err
 	}
 
-	credCtxs := make([]string, 0, len(refList.Items))
+	credCtxs := make([]string, 0, len(refList.Items)+1)
 	for _, ref := range refList.Items {
 		credCtxs = append(credCtxs, string(ref.UID))
 	}
+	credCtxs = append(credCtxs, system.GenericModelProviderCredentialContext)
 
 	creds, err := mp.gptscript.ListCredentials(req.Context(), gptscript.ListCredentialsOptions{
 		CredentialContexts: credCtxs,
@@ -90,7 +92,11 @@ func (mp *ModelProviderHandler) List(req api.Context) error {
 
 	resp := make([]types.ModelProvider, 0, len(refList.Items))
 	for _, ref := range refList.Items {
-		resp = append(resp, convertToolReferenceToModelProvider(ref, credMap[string(ref.UID)+ref.Name]))
+		env, ok := credMap[string(ref.UID)+ref.Name]
+		if !ok {
+			env = credMap[system.GenericModelProviderCredentialContext+ref.Name]
+		}
+		resp = append(resp, convertToolReferenceToModelProvider(ref, env))
 	}
 
 	return req.Write(types.ModelProviderList{Items: resp})
@@ -184,8 +190,13 @@ func (mp *ModelProviderHandler) Configure(req api.Context) error {
 	}
 
 	// Allow for updating credentials. The only way to update a credential is to delete the existing one and recreate it.
-	if err := mp.gptscript.DeleteCredential(req.Context(), string(ref.UID), ref.Name); err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
-		return fmt.Errorf("failed to update credential: %w", err)
+	cred, err := mp.gptscript.RevealCredential(req.Context(), []string{string(ref.UID), system.GenericModelProviderCredentialContext}, ref.Name)
+	if err != nil {
+		if !errors.As(err, &gptscript.ErrNotFound{}) {
+			return fmt.Errorf("failed to find credential: %w", err)
+		}
+	} else if err = mp.gptscript.DeleteCredential(req.Context(), cred.Context, ref.Name); err != nil {
+		return fmt.Errorf("failed to remove existing credential: %w", err)
 	}
 
 	for key, val := range envVars {
@@ -227,8 +238,13 @@ func (mp *ModelProviderHandler) Deconfigure(req api.Context) error {
 		return types.NewErrBadRequest("%q is not a model provider", ref.Name)
 	}
 
-	if err := mp.gptscript.DeleteCredential(req.Context(), string(ref.UID), ref.Name); err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
-		return fmt.Errorf("failed to update credential: %w", err)
+	cred, err := mp.gptscript.RevealCredential(req.Context(), []string{string(ref.UID), system.GenericModelProviderCredentialContext}, ref.Name)
+	if err != nil {
+		if !errors.As(err, &gptscript.ErrNotFound{}) {
+			return fmt.Errorf("failed to find credential: %w", err)
+		}
+	} else if err = mp.gptscript.DeleteCredential(req.Context(), cred.Context, ref.Name); err != nil {
+		return fmt.Errorf("failed to remove existing credential: %w", err)
 	}
 
 	// Stop the model provider so that the credential is completely removed from the system.
@@ -256,8 +272,8 @@ func (mp *ModelProviderHandler) Reveal(req api.Context) error {
 		return types.NewErrBadRequest("%q is not a model provider", ref.Name)
 	}
 
-	cred, err := mp.gptscript.RevealCredential(req.Context(), []string{string(ref.UID)}, ref.Name)
-	if err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
+	cred, err := mp.gptscript.RevealCredential(req.Context(), []string{string(ref.UID), system.GenericModelProviderCredentialContext}, ref.Name)
+	if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 		return fmt.Errorf("failed to reveal credential: %w", err)
 	} else if err == nil {
 		return req.Write(cred.Env)
@@ -279,8 +295,8 @@ func (mp *ModelProviderHandler) RefreshModels(req api.Context) error {
 	var credEnvVars map[string]string
 	if ref.Status.Tool != nil {
 		if envVars := ref.Status.Tool.Metadata["envVars"]; envVars != "" {
-			cred, err := mp.gptscript.RevealCredential(req.Context(), []string{string(ref.UID)}, ref.Name)
-			if err != nil && !strings.HasSuffix(err.Error(), "credential not found") {
+			cred, err := mp.gptscript.RevealCredential(req.Context(), []string{string(ref.UID), system.GenericModelProviderCredentialContext}, ref.Name)
+			if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 				return fmt.Errorf("failed to reveal credential for model provider %q: %w", ref.Name, err)
 			} else if err == nil {
 				credEnvVars = cred.Env

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -224,7 +224,7 @@ func (d *Dispatcher) startModelProvider(ctx context.Context, namespace, modelPro
 		return nil, fmt.Errorf("failed to get model provider: %w", err)
 	}
 
-	credCtx := []string{string(modelProvider.UID)}
+	credCtx := []string{string(modelProvider.UID), system.GenericModelProviderCredentialContext}
 	if modelProvider.Status.Tool == nil {
 		return nil, fmt.Errorf("model provider %q has not been resolved", modelProviderName)
 	}
@@ -324,7 +324,7 @@ func (d *Dispatcher) startAuthProvider(ctx context.Context, namespace, authProvi
 		return nil, fmt.Errorf("failed to get auth provider: %w", err)
 	}
 
-	credCtx := []string{string(authProvider.UID)}
+	credCtx := []string{string(authProvider.UID), system.GenericAuthProviderCredentialContext}
 	if authProvider.Status.Tool == nil {
 		return nil, fmt.Errorf("auth provider %q has not been resolved", authProviderName)
 	}
@@ -371,7 +371,7 @@ func (d *Dispatcher) ListConfiguredAuthProviders(ctx context.Context, namespace 
 
 	var result []string
 	for _, authProvider := range authProviders.Items {
-		if isConfigured, _, _ := d.isAuthProviderConfigured(ctx, []string{string(authProvider.UID)}, authProvider); isConfigured {
+		if isConfigured, _, _ := d.isAuthProviderConfigured(ctx, []string{string(authProvider.UID), system.GenericAuthProviderCredentialContext}, authProvider); isConfigured {
 			result = append(result, authProvider.Name)
 		}
 	}

--- a/pkg/system/tools.go
+++ b/pkg/system/tools.go
@@ -21,4 +21,7 @@ const (
 	DefaultNamespace = "default"
 
 	ModelProviderCredential = "sys.model.provider.credential"
+
+	GenericModelProviderCredentialContext = "model-provider"
+	GenericAuthProviderCredentialContext  = "auth-provider"
 )


### PR DESCRIPTION
The generic "auth-provider" and "model-provider" credential contexts will be used when looking for credentials for auth and model providers, respectively.

Additionally, use the ErrNotFound from the gptscript SDK instead of looking for "credential not found" in the error string.