### PR TITLE
feat: allow images in markdown

### DIFF
--- a/ui/admin/app/components/ui/markdown.tsx
+++ b/ui/admin/app/components/ui/markdown.tsx
@@ -25,6 +25,7 @@ export function Markdown({
 }) {
 	const allowedAttributes = {
 		a: ["href", "target", "rel", "name", "title"],
+		img: ["src", "alt", "title"],
 	};
 	return (
 		<ReactMarkdown


### PR DESCRIPTION
addresses #432 

![image](https://github.com/user-attachments/assets/ffb8d531-4d7d-4dfe-b9aa-e0c3faff0607)

![image](https://github.com/user-attachments/assets/edf851d5-40b3-4642-a838-cffb2e18045e)
