### PR TITLE
Chore: support OPENAI O1 model

### DIFF
--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -45,6 +45,20 @@ func Agent(ctx context.Context, db kclient.Client, agent *v1.Agent, oauthServerU
 		Credentials:  agent.Spec.Credentials,
 	}
 
+	if agent.Spec.Manifest.Model != "" {
+		var model v1.Model
+		if err := db.Get(ctx, kclient.ObjectKey{
+			Namespace: agent.Namespace,
+			Name:      agent.Spec.Manifest.Model,
+		}, &model); err != nil {
+			return nil, nil, err
+		}
+
+		if model.Spec.Manifest.Name == "o1" && model.Spec.Manifest.ModelProvider == "openai-model-provider" {
+			extraEnv = append(extraEnv, "OPENAI_MODEL_NAME=o1")
+		}
+	}
+
 	extraEnv = append(extraEnv, agent.Spec.Env...)
 
 	for _, env := range agent.Spec.Manifest.Env {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -55,7 +55,7 @@ func Agent(ctx context.Context, db kclient.Client, agent *v1.Agent, oauthServerU
 		}
 
 		if model.Spec.Manifest.Name == "o1" && model.Spec.Manifest.ModelProvider == "openai-model-provider" {
-			extraEnv = append(extraEnv, "OPENAI_MODEL_NAME=o1")
+			extraEnv = append(extraEnv, "GPTSCRIPT_INTERNAL_OPENAI_STREAMING=false")
 		}
 	}
 


### PR DESCRIPTION
Support openai o1 model. This is done by setting a special env in gptscript so that it will be recognized and tweak the api properly to accommate O1 model.

https://github.com/obot-platform/obot/issues/1131

require: https://github.com/gptscript-ai/gptscript/pull/937