### PR TITLE
Fix: Fix alias api when email receiver is first created

### DIFF
--- a/apiclient/types/emailreceiver.go
+++ b/apiclient/types/emailreceiver.go
@@ -3,8 +3,8 @@ package types
 type EmailReceiver struct {
 	Metadata
 	EmailReceiverManifest
-	AddressAssigned *bool  `json:"aliasAssigned,omitempty"`
-	EmailAddress    string `json:"emailAddress,omitempty"`
+	AliasAssigned *bool  `json:"aliasAssigned,omitempty"`
+	EmailAddress  string `json:"emailAddress,omitempty"`
 }
 
 type EmailReceiverManifest struct {

--- a/apiclient/types/zz_generated.deepcopy.go
+++ b/apiclient/types/zz_generated.deepcopy.go
@@ -561,8 +561,8 @@ func (in *EmailReceiver) DeepCopyInto(out *EmailReceiver) {
 	*out = *in
 	in.Metadata.DeepCopyInto(&out.Metadata)
 	in.EmailReceiverManifest.DeepCopyInto(&out.EmailReceiverManifest)
-	if in.AddressAssigned != nil {
-		in, out := &in.AddressAssigned, &out.AddressAssigned
+	if in.AliasAssigned != nil {
+		in, out := &in.AliasAssigned, &out.AliasAssigned
 		*out = new(bool)
 		**out = **in
 	}

--- a/ui/admin/app/components/webhooks/WebhookConfirmation.tsx
+++ b/ui/admin/app/components/webhooks/WebhookConfirmation.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { $path } from "safe-routes";
 import useSWR from "swr";
 
@@ -47,22 +47,24 @@ export const WebhookConfirmation = ({
 	//     !!token ||
 	//     tokenRemoved;
 
+	const [blockPollingWebhook, setBlockPollingWebhook] = useState(false);
 	const getWebhookData = useSWR(
 		WebhookApiService.getWebhookById.key(webhook.id),
-		() => WebhookApiService.getWebhookById(webhook.id)
+		() => WebhookApiService.getWebhookById(webhook.id),
+		{
+			refreshInterval: blockPollingWebhook ? undefined : 1000,
+		}
 	);
 
 	const webhookData = getWebhookData.data ?? webhook;
 
 	useEffect(() => {
 		if (webhookData?.alias && webhookData.aliasAssigned === undefined) {
-			const interval = setInterval(async () => {
-				await getWebhookData.mutate();
-			}, 1000);
-
-			return () => clearInterval(interval);
+			setBlockPollingWebhook(false);
+		} else {
+			setBlockPollingWebhook(true);
 		}
-	}, [getWebhookData, webhookData?.alias, webhookData?.aliasAssigned]);
+	}, [webhookData]);
 
 	return (
 		<Dialog open>

--- a/ui/admin/app/hooks/workflow-triggers/useWorkflowTriggers.ts
+++ b/ui/admin/app/hooks/workflow-triggers/useWorkflowTriggers.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import useSWR from "swr";
 
 import {
@@ -22,12 +23,23 @@ export function useWorkflowTriggers(props?: UseWorkflowTriggersProps) {
 
 	const types = new Set(Array.isArray(type) ? type : [type]);
 
-	const { data: emailReceivers } = useSWR(
+	const { data: emailReceivers, mutate: mutateEmailReceivers } = useSWR(
 		types.has("email") &&
 			EmailReceiverApiService.getEmailReceivers.key(filters),
 		({ filters }) => EmailReceiverApiService.getEmailReceivers(filters),
 		{ fallbackData: [] }
 	);
+
+	useEffect(() => {
+		if (
+			emailReceivers &&
+			emailReceivers.some(
+				(receiver) => receiver.aliasAssigned == null && receiver.alias
+			)
+		) {
+			mutateEmailReceivers();
+		}
+	}, [emailReceivers, mutateEmailReceivers]);
 
 	const { data: cronjobs } = useSWR(
 		types.has("schedule") && CronJobApiService.getCronJobs.key(filters),


### PR DESCRIPTION
When email receiver is first created in ui, the emailAddress will always return with random string at the start even if alias is set. This is problematic as it will change to use alias email on refresh once controller has set the alias. 

https://github.com/obot-platform/obot/issues/1412