### PR TITLE
fix: bootstrap: disable bootstrap when another admin user exists

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -79,8 +79,6 @@ spec:
                   name: {{ include "obot.config.secretName" . }}
                   key: githubAuthToken
             {{- end }}
-            - name: "OBOT_SERVER_ENABLE_BOOTSTRAP_USER"
-              value: "{{ .Values.config.obotServerEnableBootstrapUser }}"
             {{- if .Values.config.obotServerAuthAdminEmails }}
             - name: "OBOT_SERVER_AUTH_ADMIN_EMAILS"
               valueFrom:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -61,7 +61,6 @@ config:
 
   githubAuthToken: ""
   obotServerEnableAuthentication: true
-  obotServerEnableBootstrapUser: true
   obotBootstrapToken: ""
   obotServerAuthAdminEmails: ""
   obotServerDSN: ""

--- a/docs/docs/05-configuration/03-auth-providers.md
+++ b/docs/docs/05-configuration/03-auth-providers.md
@@ -14,10 +14,16 @@ In order for authentication to be enabled, the Obot server must be run with `--e
 When launching Obot for the first time, the server will print a randomly generated bootstrap token to the console.
 This token can be used to authenticate as an admin user in the UI.
 You will then be able to configure authentication providers.
+Once you have configured at least one authentication provider, and have granted admin access to at least one user,
+the bootstrap token will no longer be valid.
 
 :::tip
 You can use the `OBOT_BOOTSTRAP_TOKEN` environment variable to provide a specific value for the token,
 rather than having the server generate one for you. If you do this, the value will **not** be printed to the console.
+
+Obot will persist the value of the bootstrap token on its first launch (whether randomly generated or
+supplied by `OBOT_BOOTSTRAP_TOKEN`), and all future server launches will use that same value.
+`OBOT_BOOTSTRAP_TOKEN` can always be used to override the stored value.
 :::
 
 ### Preconfiguring admin users
@@ -43,10 +49,3 @@ Obot currently supports the following authentication providers (using OAuth2):
 - Google
 
 The code for these providers is available in the [Obot tools repo](https://github.com/obot-platform/tools).
-
-## Disabling the Bootstrap User
-
-If you do not want to be able to log in as the bootstrap user, you can set the `OBOT_SERVER_ENABLE_BOOTSTRAP_USER` environment variable to `false`.
-This will prevent you from logging in as the bootstrap user.
-When you first run Obot, do not set this environment variable, because you need to be able to use the bootstrap user to set up the first auth provider.
-Once that is done, you can restart the server and set this environment variable if you would like.

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -41,6 +41,7 @@ var staticRules = map[string][]string{
 
 		"GET /api/oauth/start/{id}/{namespace}/{name}",
 
+		"GET /api/bootstrap",
 		"POST /api/bootstrap/login",
 		"POST /api/bootstrap/logout",
 

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -310,6 +310,7 @@ func Router(services *services.Services) (http.Handler, error) {
 	mux.HandleFunc("POST /api/auth-providers/{id}/reveal", authProviders.Reveal)
 
 	// Bootstrap
+	mux.HandleFunc("GET /api/bootstrap", services.Bootstrapper.IsEnabled)
 	mux.HandleFunc("POST /api/bootstrap/login", services.Bootstrapper.Login)
 	mux.HandleFunc("POST /api/bootstrap/logout", services.Bootstrapper.Logout)
 

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -3,61 +3,134 @@ package bootstrap
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"strings"
 
+	"github.com/gptscript-ai/go-gptscript"
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/api/authz"
 	"github.com/obot-platform/obot/pkg/gateway/client"
-	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
 	"github.com/obot-platform/obot/pkg/gateway/types"
-	"github.com/obot-platform/obot/pkg/system"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
-const bootstrapCookie = "obot-bootstrap"
+const (
+	bootstrapCookie            = "obot-bootstrap"
+	bootstrapCredential        = "obot-bootstrap"
+	bootstrapCredentialContext = "obot-bootstrap"
+)
 
 type Bootstrap struct {
-	enableBootstrapUser bool
-	token, serverURL    string
-	gatewayClient       *client.Client
+	token, serverURL                  string
+	authEnabled, forceEnableBootstrap bool
+	gatewayClient                     *client.Client
 }
 
-func New(ctx context.Context, enableBootstrapUser bool, serverURL string, c *client.Client, d *dispatcher.Dispatcher) (*Bootstrap, error) {
+func New(ctx context.Context, serverURL string, c *client.Client, g *gptscript.GPTScript, authEnabled, forceEnableBootstrap bool) (*Bootstrap, error) {
+	if !authEnabled {
+		// Auth is not enabled, so skip token generation.
+		return &Bootstrap{
+			serverURL:            serverURL,
+			authEnabled:          authEnabled,
+			forceEnableBootstrap: forceEnableBootstrap,
+			gatewayClient:        c,
+		}, nil
+	}
+
 	token := os.Getenv("OBOT_BOOTSTRAP_TOKEN")
+	tokenFromCredential, exists, err := getTokenFromCredential(ctx, g)
+	if err != nil {
+		return nil, err
+	}
 
-	if token == "" && enableBootstrapUser {
-		bytes := make([]byte, 32)
-		_, err := rand.Read(bytes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate random token: %w", err)
+	if token != "" && !exists {
+		// Save the token from the env var to the credential.
+		if err := saveTokenToCredential(ctx, token, g); err != nil {
+			return nil, err
 		}
+	} else if token == "" {
+		if exists {
+			// Just use the token from the credential, since it already exists.
+			token = tokenFromCredential
+		} else {
+			// Generate a new token, save it in the credential, and print it to the logs.
+			bytes := make([]byte, 32)
+			_, err := rand.Read(bytes)
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate random token: %w", err)
+			}
 
-		token = fmt.Sprintf("%x", bytes)
+			token = fmt.Sprintf("%x", bytes)
 
-		// We deliberately only print the token if it was not provided by the user.
-		fmt.Printf("Bootstrap token: %s\nUse this token to log in to the Admin UI.\n", token)
-	} else if !enableBootstrapUser {
-		configuredAuthProviders, err := d.ListConfiguredAuthProviders(ctx, system.DefaultNamespace)
-		if err == nil && len(configuredAuthProviders) == 0 {
-			fmt.Printf("WARNING: Bootstrap user is disabled, and no auth providers are configured. You will be unable to log in to Obot.\n")
+			if err := saveTokenToCredential(ctx, token, g); err != nil {
+				return nil, err
+			}
+
+			printToken(token)
 		}
 	}
 
+	if len(token) < 6 {
+		return nil, errors.New("error: bootstrap token must be at least 6 characters")
+	}
+
 	return &Bootstrap{
-		enableBootstrapUser: enableBootstrapUser,
-		token:               token,
-		serverURL:           serverURL,
-		gatewayClient:       c,
+		token:                token,
+		authEnabled:          authEnabled,
+		serverURL:            serverURL,
+		forceEnableBootstrap: forceEnableBootstrap,
+		gatewayClient:        c,
 	}, nil
 }
 
+func getTokenFromCredential(ctx context.Context, g *gptscript.GPTScript) (string, bool, error) {
+	tokenCredential, err := g.RevealCredential(ctx, []string{bootstrapCredentialContext}, bootstrapCredential)
+	if err != nil {
+		if errors.As(err, &gptscript.ErrNotFound{}) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("failed to get bootstrap token credential: %w", err)
+	}
+
+	value, ok := tokenCredential.Env["token"]
+	if !ok {
+		return "", false, nil
+	}
+	return value, true, nil
+}
+
+func saveTokenToCredential(ctx context.Context, token string, g *gptscript.GPTScript) error {
+	credential := gptscript.Credential{
+		ToolName: bootstrapCredential,
+		Context:  bootstrapCredentialContext,
+		Type:     gptscript.CredentialTypeTool,
+		Env: map[string]string{
+			"token": token,
+		},
+	}
+
+	if err := g.CreateCredential(ctx, credential); err != nil {
+		return fmt.Errorf("failed to store bootstrap token credential: %w", err)
+	}
+	return nil
+}
+
+func printToken(token string) {
+	message := "Bootstrap token: " + token
+	line := strings.Repeat("-", len(message)+4)
+
+	fmt.Println(line)
+	fmt.Println("| " + message + " |")
+	fmt.Println(line)
+}
+
 func (b *Bootstrap) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
-	if !b.enableBootstrapUser {
+	if !b.authEnabled {
 		return nil, false, nil
 	}
 
@@ -70,6 +143,11 @@ func (b *Bootstrap) AuthenticateRequest(req *http.Request) (*authenticator.Respo
 		}
 	} else if authHeader != fmt.Sprintf("Bearer %s", b.token) {
 		return nil, false, nil
+	}
+
+	// Deny authentication if bootstrap is not enabled.
+	if enabled, err := b.bootstrapEnabled(req.Context()); !enabled || err != nil {
+		return nil, false, err
 	}
 
 	gatewayUser, err := b.gatewayClient.EnsureIdentityWithRole(
@@ -94,8 +172,18 @@ func (b *Bootstrap) AuthenticateRequest(req *http.Request) (*authenticator.Respo
 }
 
 func (b *Bootstrap) Login(req api.Context) error {
-	if !b.enableBootstrapUser {
+	if !b.authEnabled {
+		http.Error(req.ResponseWriter, "auth is not enabled", http.StatusNotFound)
+		return nil
+	}
+
+	// Deny login attempts if bootstrap is not enabled.
+	if enabled, err := b.bootstrapEnabled(req.Context()); !enabled || err != nil {
 		http.Error(req.ResponseWriter, "invalid token", http.StatusUnauthorized)
+
+		if err != nil {
+			fmt.Printf("WARNING: bootstrap login failed: failed to check if admin user exists: %v\n", err)
+		}
 		return nil
 	}
 
@@ -122,7 +210,6 @@ func (b *Bootstrap) Login(req api.Context) error {
 }
 
 func (b *Bootstrap) Logout(req api.Context) error {
-	fmt.Printf("logging out bootstrap user\n")
 	http.SetCookie(req.ResponseWriter, &http.Cookie{
 		Name:     bootstrapCookie,
 		Value:    "",
@@ -133,4 +220,38 @@ func (b *Bootstrap) Logout(req api.Context) error {
 	})
 
 	return nil
+}
+
+func (b *Bootstrap) IsEnabled(req api.Context) error {
+	if !b.authEnabled {
+		return req.Write(map[string]bool{"enabled": false})
+	}
+
+	bootstrapEnabled, err := b.bootstrapEnabled(req.Context())
+	if err != nil {
+		return err
+	}
+
+	return req.Write(map[string]bool{"enabled": bootstrapEnabled})
+}
+
+func (b *Bootstrap) bootstrapEnabled(ctx context.Context) (bool, error) {
+	if b.forceEnableBootstrap {
+		return true, nil
+	}
+
+	adminUsers, err := b.gatewayClient.Users(ctx, types.UserQuery{
+		Role: types2.RoleAdmin,
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to get admin users: %w", err)
+	}
+
+	for _, u := range adminUsers {
+		if u.Username != "bootstrap" && u.Email != "" {
+			// A non-bootstrap admin user exists, so bootstrap is not enabled
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -20,9 +20,7 @@ import (
 )
 
 const (
-	bootstrapCookie            = "obot-bootstrap"
-	bootstrapCredential        = "obot-bootstrap"
-	bootstrapCredentialContext = "obot-bootstrap"
+	obotBootstrap = "obot-bootstrap"
 )
 
 type Bootstrap struct {
@@ -89,7 +87,7 @@ func New(ctx context.Context, serverURL string, c *client.Client, g *gptscript.G
 }
 
 func getTokenFromCredential(ctx context.Context, g *gptscript.GPTScript) (string, bool, error) {
-	tokenCredential, err := g.RevealCredential(ctx, []string{bootstrapCredentialContext}, bootstrapCredential)
+	tokenCredential, err := g.RevealCredential(ctx, []string{obotBootstrap}, obotBootstrap)
 	if err != nil {
 		if errors.As(err, &gptscript.ErrNotFound{}) {
 			return "", false, nil
@@ -106,8 +104,8 @@ func getTokenFromCredential(ctx context.Context, g *gptscript.GPTScript) (string
 
 func saveTokenToCredential(ctx context.Context, token string, g *gptscript.GPTScript) error {
 	credential := gptscript.Credential{
-		ToolName: bootstrapCredential,
-		Context:  bootstrapCredentialContext,
+		ToolName: obotBootstrap,
+		Context:  obotBootstrap,
 		Type:     gptscript.CredentialTypeTool,
 		Env: map[string]string{
 			"token": token,
@@ -137,7 +135,7 @@ func (b *Bootstrap) AuthenticateRequest(req *http.Request) (*authenticator.Respo
 	authHeader := req.Header.Get("Authorization")
 	if authHeader == "" {
 		// Check for the cookie.
-		c, err := req.Cookie(bootstrapCookie)
+		c, err := req.Cookie(obotBootstrap)
 		if err != nil || c.Value != b.token {
 			return nil, false, nil
 		}
@@ -197,7 +195,7 @@ func (b *Bootstrap) Login(req api.Context) error {
 	}
 
 	http.SetCookie(req.ResponseWriter, &http.Cookie{
-		Name:     bootstrapCookie,
+		Name:     obotBootstrap,
 		Value:    strings.TrimPrefix(auth, "Bearer "),
 		Path:     "/",
 		MaxAge:   60 * 60 * 24 * 7, // 1 week
@@ -211,7 +209,7 @@ func (b *Bootstrap) Login(req api.Context) error {
 
 func (b *Bootstrap) Logout(req api.Context) error {
 	http.SetCookie(req.ResponseWriter, &http.Cookie{
-		Name:     bootstrapCookie,
+		Name:     obotBootstrap,
 		Value:    "",
 		Path:     "/",
 		MaxAge:   -1,

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -66,7 +66,7 @@ type Config struct {
 	EnvKeys                    []string `usage:"The environment keys to pass through to the GPTScript server" env:"OBOT_ENV_KEYS"`
 	KnowledgeSetIngestionLimit int      `usage:"The maximum number of files to ingest into a knowledge set" default:"3000" env:"OBOT_KNOWLEDGESET_INGESTION_LIMIT" name:"knowledge-set-ingestion-limit"`
 	EnableAuthentication       bool     `usage:"Enable authentication" default:"false"`
-	EnableBootstrapUser        bool     `usage:"Enables the bootstrap user, regardless of configured auth providers" default:"true"`
+	ForceEnableBootstrap       bool     `usage:"Enables the bootstrap user even if other admin users have been created" default:"false"`
 	AuthAdminEmails            []string `usage:"Emails of admin users"`
 	AgentsDir                  string   `usage:"The directory to auto load agents on start (default $XDG_CONFIG_HOME/.obot/agents)"`
 	StaticDir                  string   `usage:"The directory to serve static files from"`
@@ -309,7 +309,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		proxyManager *proxy.Manager
 	)
 
-	bootstrapper, err := bootstrap.New(ctx, config.EnableBootstrapUser, config.Hostname, gatewayClient, providerDispatcher)
+	bootstrapper, err := bootstrap.New(ctx, config.Hostname, gatewayClient, c, config.EnableAuthentication, config.ForceEnableBootstrap)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes the following changes to how initial auth and bootstrap work:
- The bootstrap token is now stored as a credential, based on the very first value set for it: either randomly generated, or from OBOT_BOOTSTRAP_TOKEN
  - OBOT_BOOTSTRAP_TOKEN can always be used to override it
- The bootstrap user is only available until there is another admin user in the database, after which it is no longer available
  - It can be made available again by setting OBOT_SERVER_FORCE_ENABLE_BOOTSTRAP=true
- `/api/bootstrap` returns a JSON string `{"enabled":true}` if bootstrap login is enabled (auth is enabled and bootstrap is enabled), or `{"enabled":false}` if auth is disabled or bootstrap is disabled