### PR TITLE
fix: store auth provider in the same cookie as the token

### DIFF
--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -39,7 +39,7 @@ func (c *Client) DeleteUser(ctx context.Context, username string) (*types.User, 
 		if existingUser.Role.HasRole(types2.RoleAdmin) {
 			var adminCount int64
 			// We filter out empty email users here, because that is the bootstrap user.
-			if err := tx.Model(new(types.User)).Where("role = ? and email != '' and ", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
+			if err := tx.Model(new(types.User)).Where("role = ? and email != ''", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
 				return err
 			}
 

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -38,7 +38,8 @@ func (c *Client) DeleteUser(ctx context.Context, username string) (*types.User, 
 
 		if existingUser.Role.HasRole(types2.RoleAdmin) {
 			var adminCount int64
-			if err := tx.Model(new(types.User)).Where("role = ?", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
+			// We filter out empty email users here, because that is the bootstrap user.
+			if err := tx.Model(new(types.User)).Where("role = ? and email != '' and ", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
 				return err
 			}
 
@@ -86,8 +87,9 @@ func (c *Client) UpdateUser(ctx context.Context, actingUserIsAdmin bool, updated
 					return &ExplicitAdminError{email: existingUser.Email}
 				}
 				// If the role is being changed from admin to non-admin, then ensure that this isn't the last admin.
+				// We filter out empty email users here, because that is the bootstrap user.
 				var adminCount int64
-				if err := tx.Model(new(types.User)).Where("role = ?", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
+				if err := tx.Model(new(types.User)).Where("role = ? and email != ''", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
 					return err
 				}
 

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -48,7 +48,9 @@ func (s *Server) getUsers(apiContext api.Context) error {
 
 	items := make([]types2.User, 0, len(users))
 	for _, user := range users {
-		items = append(items, *types.ConvertUser(&user, s.client.IsExplicitAdmin(user.Email)))
+		if user.Username != "bootstrap" && user.Email != "" { // Filter out the bootstrap admin
+			items = append(items, *types.ConvertUser(&user, s.client.IsExplicitAdmin(user.Email)))
+		}
 	}
 
 	return apiContext.Write(types2.UserList{Items: items})

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -21,7 +21,15 @@ import (
 
 var log = logger.Package()
 
-const AuthProviderCookie = "obot-auth-provider"
+const (
+	ObotAccessTokenCookie      = "obot_access_token"
+	ObotAuthProviderQueryParam = "obot-auth-provider"
+)
+
+type CookieContents struct {
+	AuthProvider string `json:"authProvider"`
+	Token        string `json:"token"`
+}
 
 type Manager struct {
 	dispatcher *dispatcher.Dispatcher
@@ -34,15 +42,38 @@ func NewProxyManager(dispatcher *dispatcher.Dispatcher) *Manager {
 }
 
 func (pm *Manager) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
-	c, err := req.Cookie(AuthProviderCookie)
+	cookie, err := req.Cookie(ObotAccessTokenCookie)
 	if err != nil {
 		return nil, false, nil
 	}
 
-	proxy, err := pm.createProxy(req.Context(), c.Value)
+	cookieOriginalValue := cookie.Value
+	cookieValue, err := url.QueryUnescape(cookie.Value)
+	if err != nil {
+		return nil, false, nil
+	}
+
+	var contents CookieContents
+	if err = json.Unmarshal([]byte(cookieValue), &contents); err != nil {
+		return nil, false, nil
+	}
+
+	proxy, err := pm.createProxy(req.Context(), contents.AuthProvider)
 	if err != nil {
 		return nil, false, err
 	}
+
+	// Overwrite the cookie with just the token.
+	cookie.Value = contents.Token
+	req.Header.Del("Cookie")
+	req.AddCookie(cookie)
+
+	// Reset the cookie value after authenticating.
+	defer func() {
+		cookie.Value = cookieOriginalValue
+		req.Header.Del("Cookie")
+		req.AddCookie(cookie)
+	}()
 
 	return proxy.authenticateRequest(req)
 }
@@ -53,6 +84,8 @@ func (pm *Manager) HandlerFunc(ctx api.Context) error {
 }
 
 func (pm *Manager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// If the proxy manager is not set up, just redirect the user.
+	// This can happen when auth is disabled.
 	if pm == nil {
 		rd := r.URL.Query().Get("rd")
 		if rd == "" || !strings.HasPrefix(rd, "/") {
@@ -62,19 +95,37 @@ func (pm *Manager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Determine which auth provider to use.
 	var provider string
+	if param := r.URL.Query().Get(ObotAuthProviderQueryParam); param != "" {
+		// If the provider is set in the query params, use that.
+		provider = param
+	} else if cookie, err := r.Cookie(ObotAccessTokenCookie); err == nil {
+		// Extract the provider from the cookie, if it's there.
+		cookieValue, err := url.QueryUnescape(cookie.Value)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to unescape cookie value: %v", err), http.StatusBadRequest)
+			return
+		}
 
-	if provider = r.URL.Query().Get(AuthProviderCookie); provider != "" {
-		// Set it as a cookie for the future.
-		http.SetCookie(w, &http.Cookie{
-			Name:  AuthProviderCookie,
-			Value: provider,
-			Path:  "/",
-		})
-	} else if c, err := r.Cookie(AuthProviderCookie); err == nil {
-		provider = c.Value
+		var contents CookieContents
+		if err = json.Unmarshal([]byte(cookieValue), &contents); err == nil {
+			provider = contents.AuthProvider
+
+			// Update the cookie to just be the token, which is what the auth provider expects.
+			cookie.Value = contents.Token
+			allCookies := r.Cookies()
+			r.Header.Del("Cookie")
+			for _, c := range allCookies {
+				if c.Name != ObotAccessTokenCookie {
+					r.AddCookie(c)
+				}
+			}
+			r.AddCookie(cookie)
+		}
 	}
 
+	// Save the redirect target for later.
 	rdParam := r.URL.Query().Get("rd")
 	if rdParam == "" {
 		rdParam = "/"
@@ -103,17 +154,13 @@ func (pm *Manager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		provider = "default/" + providers[0]
 	}
 
-	log.Infof("forwarding request for %s to provider %s", r.URL.Path, provider)
-
-	// If signing out, delete the auth provider cookie.
-	if r.URL.Path == "/oauth2/sign_out" {
-		http.SetCookie(w, &http.Cookie{
-			Name:   AuthProviderCookie,
-			Value:  "",
-			Path:   "/",
-			MaxAge: -1,
-		})
-	}
+	// If the legacy auth provider cookie exists, delete it.
+	http.SetCookie(w, &http.Cookie{
+		Name:   ObotAuthProviderQueryParam,
+		Value:  "",
+		Path:   "/",
+		MaxAge: -1,
+	})
 
 	proxy, err := pm.createProxy(r.Context(), provider)
 	if err != nil {
@@ -127,6 +174,8 @@ func (pm *Manager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	log.Infof("forwarding request for %s to provider %s", r.URL.Path, provider)
 
 	proxy.serveHTTP(w, r)
 }
@@ -156,8 +205,32 @@ func newProxy(providerNamespace, providerName, providerURL string) (*Proxy, erro
 		return nil, fmt.Errorf("failed to parse provider URL: %w", err)
 	}
 
+	proxy := httputil.NewSingleHostReverseProxy(u)
+	proxy.ModifyResponse = func(r *http.Response) error {
+		// See which cookies the auth provider is setting.
+		// We need to update the access token cookie to add information about the auth provider
+		if headers := r.Header.Values("Set-Cookie"); headers != nil {
+			for i, h := range headers {
+				parts := strings.Split(h, "; ")
+				for i, part := range parts {
+					if strings.HasPrefix(part, ObotAccessTokenCookie+"=") {
+						token := strings.TrimPrefix(part, ObotAccessTokenCookie+"=")
+
+						if token != "" {
+							newValue := fmt.Sprintf("{\"authProvider\":\"%s\",\"token\":\"%s\"}", providerNamespace+"/"+providerName, token)
+							parts[i] = fmt.Sprintf("%s=%s", ObotAccessTokenCookie, url.QueryEscape(newValue))
+						}
+						break
+					}
+				}
+				headers[i] = strings.Join(parts, "; ")
+			}
+		}
+		return nil
+	}
+
 	return &Proxy{
-		proxy:     httputil.NewSingleHostReverseProxy(u),
+		proxy:     proxy,
 		url:       providerURL,
 		name:      providerName,
 		namespace: providerNamespace,

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -314,7 +314,8 @@ func (p *Proxy) authenticateRequest(req *http.Request) (*authenticator.Response,
 	}
 
 	if ss.SetCookie != "" {
-		u.Extra["set-cookie"] = []string{ss.SetCookie}
+		// This is set if the auth provider needed to refresh the token.
+		u.Extra["set-cookie"] = []string{url.QueryEscape(fmt.Sprintf("{\"authProvider\":\"%s\",\"token\":\"%s\"}", p.namespace+"/"+p.name, ss.SetCookie))}
 	}
 
 	if req.URL.Path == "/api/me" {


### PR DESCRIPTION
Previously, after the user logs in, we would store which auth provider they used in a cookie. This was causing problems with otto8. This PR changes it so that the auth provider gets stored within the same cookie. The logic is a bit messy, but we basically just intercept and read/modify the cookie before we send it to the oauth2proxy, and when it sets the cookie in the browser, we also intercept it there to insert the info about which auth provider it is.

Because it needed to be taken care of, this PR also filters the bootstrap user out of `/api/users` and update the "last admin" error logic to exclude the bootstrap user there as well.