### PR TITLE
fix: cookie secrets: check length after trimming spaces

### DIFF
--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -301,11 +302,16 @@ func convertAuthProviderToolRef(toolRef v1.ToolReference, cred map[string]string
 func generateCookieSecret() (string, error) {
 	const length = 32
 
-	var bytes = make([]byte, length)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate random token: %w", err)
+	var b = make([]byte, length)
+
+	// Generate a random token. Repeat until we have one that is 32 bytes long after trimming.
+	// This only takes one try in the vast majority of circumstances, but could occasionally take a second.
+	for len(bytes.TrimSpace(b)) != length {
+		_, err := rand.Read(b)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate random token: %w", err)
+		}
 	}
 
-	return base64.StdEncoding.EncodeToString(bytes), nil
+	return base64.StdEncoding.EncodeToString(b), nil
 }


### PR DESCRIPTION
This fixes a bug that occurs when the generated cookie secret has space on either end. The auth provider was trimming this space off, resulting in a secret that is too short, since it needs to be exactly 32 bytes.