### PR TITLE
fix: prevent flash of setup banner while loading auth providers

### DIFF
--- a/ui/admin/app/hooks/auth/useAuthStatus.ts
+++ b/ui/admin/app/hooks/auth/useAuthStatus.ts
@@ -4,18 +4,11 @@ import { ForbiddenError } from "~/lib/service/api/apiErrors";
 import { BootstrapApiService } from "~/lib/service/api/bootstrapApiService";
 import { VersionApiService } from "~/lib/service/api/versionApiService";
 
-type UseAuthStatusProps = {
-	suspense?: boolean;
-};
-
-export function useAuthStatus(props: UseAuthStatusProps = {}) {
-	// use suspense = true to prevent flash of unauthed content
-	const { suspense = false } = props;
-
+export function useAuthStatus() {
 	const getBootstrapStatus = useSWR(
 		BootstrapApiService.bootstrapStatus.key(),
 		BootstrapApiService.bootstrapStatus,
-		{ revalidateIfStale: false, suspense }
+		{ revalidateIfStale: false }
 	);
 
 	const bootstrapEnabled =
@@ -24,7 +17,7 @@ export function useAuthStatus(props: UseAuthStatusProps = {}) {
 	const getVersion = useSWR(
 		VersionApiService.getVersion.key(),
 		VersionApiService.getVersion,
-		{ suspense, revalidateIfStale: false }
+		{ revalidateIfStale: false }
 	);
 
 	const authEnabled =

--- a/ui/admin/app/routes/_auth.tsx
+++ b/ui/admin/app/routes/_auth.tsx
@@ -3,6 +3,7 @@ import { Outlet, isRouteErrorResponse, useRouteError } from "react-router";
 import { preload } from "swr";
 
 import { ForbiddenError, UnauthorizedError } from "~/lib/service/api/apiErrors";
+import { AuthProviderApiService } from "~/lib/service/api/authProviderApiService";
 import { ModelProviderApiService } from "~/lib/service/api/modelProviderApiService";
 import { UserService } from "~/lib/service/api/userService";
 
@@ -19,6 +20,10 @@ export async function clientLoader() {
 		preload(
 			ModelProviderApiService.getModelProviders.key(),
 			ModelProviderApiService.getModelProviders
+		),
+		preload(
+			AuthProviderApiService.getAuthProviders.key(),
+			AuthProviderApiService.getAuthProviders
 		),
 	]);
 	const me = promises[0];


### PR DESCRIPTION
preload auth providers to prevent flash of banner when data is loading

@ivyjeong13 feel free to merge this after review. Thanks!