### PR TITLE
fix: cookie secret generation: actually generate it

### DIFF
--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -302,10 +302,14 @@ func convertAuthProviderToolRef(toolRef v1.ToolReference, cred map[string]string
 func generateCookieSecret() (string, error) {
 	const length = 32
 
-	var b = make([]byte, length)
-
 	// Generate a random token. Repeat until we have one that is 32 bytes long after trimming.
 	// This only takes one try in the vast majority of circumstances, but could occasionally take a second.
+	var b = make([]byte, length)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate random token: %w", err)
+	}
+
 	for len(bytes.TrimSpace(b)) != length {
 		_, err := rand.Read(b)
 		if err != nil {


### PR DESCRIPTION
Sorry, this was a big oversight on my part. The cookie secret was always ending up the same, since I wasn't doing the initial generation outside of the loop.