### PR TITLE
fix: mute reveal auth provider toast error

### DIFF
--- a/ui/admin/app/lib/service/api/authProviderApiService.ts
+++ b/ui/admin/app/lib/service/api/authProviderApiService.ts
@@ -57,6 +57,7 @@ const revealAuthProviderById = async (providerKey: string) => {
 		method: "POST",
 		errorMessage:
 			"Failed to reveal configuration values on the requested auth provider.",
+		toastError: false,
 	});
 
 	return res.data;


### PR DESCRIPTION
* mutes toast error when reveal auth provider 404 occurs

Uses `toastError` from #1347 