### PR TITLE
fix: return error when trying to use an unconfigured auth provider 

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -168,6 +168,14 @@ func (pm *Manager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !slices.Contains(configuredProviders, name) {
 			// The requested auth provider isn't configured. Return an error, unless the user is signing out, in which case, just redirect.
 			if r.URL.Path == "/oauth2/sign_out" {
+				// Clear the cookie if it's there too.
+				http.SetCookie(w, &http.Cookie{
+					Name:   ObotAccessTokenCookie,
+					Value:  "",
+					Path:   "/",
+					MaxAge: -1,
+				})
+
 				http.Redirect(w, r, rdParam, http.StatusFound)
 				return
 			}


### PR DESCRIPTION
If the user had an old access token with a now-deconfigured auth provider and went to `/oauth2/start`, they would end up getting a `credential not found` error. This makes the error message a bit clearer, and deletes their cookie, so that if they try again, they will just end up using whichever auth provider is available.

This is a minor fix and does not need to go in before the release.