### PR TITLE
fix: add MarkdownLink to CustomMarkdownComponents

### DIFF
--- a/ui/admin/app/components/react-markdown.tsx
+++ b/ui/admin/app/components/react-markdown.tsx
@@ -30,6 +30,17 @@ const MarkdownOrderedList = memo(
 
 MarkdownOrderedList.displayName = "MarkdownOrderedList";
 
+const MarkdownLink = memo(
+	({ node: _node, ...props }: MarkdownComponentProps<"a">) => (
+		<a {...props} target="_blank" rel="noopener noreferrer">
+			{props.children}
+		</a>
+	)
+);
+
+MarkdownLink.displayName = "MarkdownLink";
+
 export const CustomMarkdownComponents: Partial<Components> = {
 	ol: MarkdownOrderedList as Components["ol"],
+	a: MarkdownLink as Components["a"],
 };


### PR DESCRIPTION
* makes sure target="_blank" is added to embedded `<a href="">` components

Addresses #1344 