### PR TITLE
fix: safari icons stretching, use flex-shrink-0 instead

### DIFF
--- a/ui/admin/app/components/agent/ToolEntry.tsx
+++ b/ui/admin/app/components/agent/ToolEntry.tsx
@@ -78,10 +78,10 @@ export function useToolReference(tool: string) {
 	const icon = useMemo(
 		() =>
 			isLoading ? (
-				<LoadingSpinner className="h-6 w-6 min-w-fit" />
+				<LoadingSpinner className="h-6 w-6 flex-shrink-0" />
 			) : (
 				<ToolIcon
-					className="h-6 w-6 min-w-fit"
+					className="h-6 w-6 flex-shrink-0"
 					name={toolReference?.name || tool}
 					icon={toolReference?.metadata?.icon}
 				/>

--- a/ui/admin/app/components/ui/select.tsx
+++ b/ui/admin/app/components/ui/select.tsx
@@ -29,7 +29,7 @@ const SelectTrigger = React.forwardRef<
 	>
 		{children}
 		<SelectPrimitive.Icon asChild>
-			<CaretSortIcon className="h-4 w-4 min-w-fit opacity-50" />
+			<CaretSortIcon className="h-4 w-4 flex-shrink-0 opacity-50" />
 		</SelectPrimitive.Icon>
 	</SelectPrimitive.Trigger>
 ));


### PR DESCRIPTION
* Safari doesn't play nice with min-width / `min-w-fit`
* Use flex-shrink-0 instead for icons that start shrinking if it's sibling is too wide or the parent container shrinking causes the icon to shrink.

Addresses #1393 