### PR TITLE
chore: switch to async agent/workflow invocations

### DIFF
--- a/ui/admin/app/components/chat/ChatContext.tsx
+++ b/ui/admin/app/components/chat/ChatContext.tsx
@@ -54,8 +54,8 @@ export function ChatProvider({
 			invokeAgent.execute({ slug: id, prompt, thread: threadId });
 	};
 
-	const invokeAgent = useAsync(InvokeService.invokeAgentWithStream, {
-		onSuccess: ({ threadId: responseThreadId }) => {
+	const invokeAgent = useAsync(InvokeService.invokeAgent, {
+		onSuccess: ({ threadID: responseThreadId }) => {
 			if (responseThreadId && responseThreadId !== threadId) {
 				// persist the threadId
 				onCreateThreadId?.(responseThreadId);

--- a/ui/admin/app/lib/routers/apiRoutes.ts
+++ b/ui/admin/app/lib/routers/apiRoutes.ts
@@ -231,10 +231,14 @@ export const ApiRoutes = {
 		updateUser: (username: string) => buildUrl(`/users/${username}`),
 	},
 	me: () => buildUrl("/me"),
-	invoke: (id: string, threadId?: Nullish<string>) => {
+	invoke: (
+		id: string,
+		threadId?: Nullish<string>,
+		params?: { async?: boolean }
+	) => {
 		return threadId
-			? buildUrl(`/invoke/${id}/threads/${threadId}`)
-			: buildUrl(`/invoke/${id}`);
+			? buildUrl(`/invoke/${id}/threads/${threadId}`, params)
+			: buildUrl(`/invoke/${id}`, params);
 	},
 	oauthApps: {
 		base: () => buildUrl("/oauth-apps"),


### PR DESCRIPTION
run agent invocations asynchronously to stop opening unnecessary event streams in the UI.