### PR TITLE
fix: user-ui agent logo in dropdown

### DIFF
--- a/ui/admin/app/components/agent/icon/AgentIcon.tsx
+++ b/ui/admin/app/components/agent/icon/AgentIcon.tsx
@@ -141,6 +141,6 @@ export function AgentIcon({ icons, onChange, name }: AgentIconProps) {
 	}
 
 	function generateIconUrl(icon: string) {
-		return `${window.location.protocol}//${window.location.host}/agent/images/${icon}`;
+		return `/agent/images/${icon}`;
 	}
 }

--- a/ui/user/src/lib/components/navbar/Logo.svelte
+++ b/ui/user/src/lib/components/navbar/Logo.svelte
@@ -69,7 +69,7 @@
 						data-sveltekit-reload
 						class="flex rounded-3xl p-2 hover:bg-gray-70 dark:hover:bg-gray-900"
 					>
-						<div class="flex h-5 items-center">
+						<div class="flex flex-shrink-0 h-5 items-center">
 							<AssistantIcon id={assistant.id} />
 						</div>
 						<div class="ms-2 text-sm">

--- a/ui/user/src/lib/icons/AssistantIcon.svelte
+++ b/ui/user/src/lib/icons/AssistantIcon.svelte
@@ -12,7 +12,7 @@
 	let { id, class: klass }: Props = $props();
 
 	let assistant = $derived(
-		$currentAssistant ?? $assistants.find((a) => {
+		$assistants.find((a) => {
 			if (id) {
 				return a.id === id;
 			}

--- a/ui/user/src/lib/icons/AssistantIcon.svelte
+++ b/ui/user/src/lib/icons/AssistantIcon.svelte
@@ -12,6 +12,7 @@
 	let { id, class: klass }: Props = $props();
 
 	let assistant = $derived(
+		$currentAssistant?.id === id ? $currentAssistant :
 		$assistants.find((a) => {
 			if (id) {
 				return a.id === id;


### PR DESCRIPTION
* fix -- wrong agent logo in dropdown of agents on user-ui

<img width="292" alt="Screenshot 2025-01-27 at 4 05 26 PM" src="https://github.com/user-attachments/assets/6ccd025a-2380-4e75-a341-e0dd0b4c2b51" />

flex-shrink-0 fixes logo shrinking with longer text:
<img width="229" alt="Screenshot 2025-01-27 at 4 21 59 PM" src="https://github.com/user-attachments/assets/b2755e4f-b0e1-4add-a7df-0aaf45cf066a" />

Addresses #1474 
