### PR TITLE
fix: threads refresh fix & advanced options scroll to bottom

### DIFF
--- a/ui/admin/app/components/agent/Agent.tsx
+++ b/ui/admin/app/components/agent/Agent.tsx
@@ -40,6 +40,7 @@ export function Agent({ className, currentThreadId, onRefresh }: AgentProps) {
 		useAgent();
 
 	const [agentUpdates, setAgentUpdates] = useState(agent);
+	const [enableScrollStick, setEnableScrollStick] = useState(false);
 
 	useEffect(() => {
 		setAgentUpdates((prev) => {
@@ -83,9 +84,16 @@ export function Agent({ className, currentThreadId, onRefresh }: AgentProps) {
 		[onRefresh]
 	);
 
+	const handleAccordionValueChange = useCallback((value: string[]) => {
+		setEnableScrollStick(value.includes("model"));
+	}, []);
+
 	return (
 		<div className="flex h-full flex-col">
-			<ScrollArea className={cn("h-full", className)}>
+			<ScrollArea
+				className={cn("h-full", className)}
+				enableScrollStick={enableScrollStick ? "bottom" : undefined}
+			>
 				<AgentAlias agent={agentUpdates} onChange={partialSetAgent} />
 
 				<div className="m-4 p-4">
@@ -159,7 +167,11 @@ export function Agent({ className, currentThreadId, onRefresh }: AgentProps) {
 
 				<WorkspaceFilesSection entityId={agent.id} />
 
-				<Accordion type="multiple" className="m-4 p-4">
+				<Accordion
+					type="multiple"
+					className="m-4 p-4"
+					onValueChange={handleAccordionValueChange}
+				>
 					<AccordionItem value="model">
 						<AccordionTrigger className="border-b">
 							<h4 className="flex items-center gap-2">

--- a/ui/admin/app/routes/_auth.threads._index.tsx
+++ b/ui/admin/app/routes/_auth.threads._index.tsx
@@ -117,7 +117,7 @@ export default function Threads() {
 		if (!getThreads.data) return [];
 
 		let filteredThreads = getThreads.data.filter(
-			(thread) => thread.agentID || thread.workflowID
+			(thread) => (thread.agentID || thread.workflowID) && !thread.deleted
 		);
 
 		if (agentId) {


### PR DESCRIPTION
Addresses #1431 
Addresses #1355 

https://github.com/user-attachments/assets/18ffe479-76bb-4218-a608-4021e07d88d3

https://github.com/user-attachments/assets/41b1853d-ec13-4879-ab89-0dafd2ef32a0

* if user clicks Advanced, the section scrolls to bottom to bring contents into view
* filter out threads with `deleted` property as they're being deleted in the background 