### PR TITLE
fix: pass the encryption config var to tools

### DIFF
--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -118,6 +118,8 @@ var requiredEnvs = []string{
 	"PATH", "HOME", "USER", "PWD",
 	// Embedded env vars
 	"OBOT_BIN", "GPTSCRIPT_BIN", "GPTSCRIPT_EMBEDDED",
+	// Encryption,
+	"GPTSCRIPT_ENCRYPTION_CONFIG_FILE",
 	// XDG stuff
 	"XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME"}
 


### PR DESCRIPTION
This variable is not sensitive. It contains the path to a file that is also not sensitive. So it is safe to pass down to all tools. It is needed specifically by some of our credential helper tools.