### PR TITLE
Fix: make sure only to load alias when aliaAssigned is true

### DIFF
--- a/pkg/api/handlers/agent.go
+++ b/pkg/api/handlers/agent.go
@@ -147,7 +147,7 @@ func (a *AgentHandler) Update(req api.Context) error {
 	if err != nil {
 		return err
 	}
-	return req.WriteCreated(resp)
+	return req.Write(resp)
 }
 
 func (a *AgentHandler) Delete(req api.Context) error {
@@ -273,7 +273,7 @@ func (a *AgentHandler) SetDefault(req api.Context) error {
 		return err
 	}
 
-	return req.WriteCreated(resp)
+	return req.Write(resp)
 }
 
 func (a *AgentHandler) ByID(req api.Context) error {
@@ -294,7 +294,7 @@ func (a *AgentHandler) ByID(req api.Context) error {
 		return err
 	}
 
-	return req.WriteCreated(resp)
+	return req.Write(resp)
 }
 
 func (a *AgentHandler) List(req api.Context) error {

--- a/ui/admin/app/components/agent/Agent.tsx
+++ b/ui/admin/app/components/agent/Agent.tsx
@@ -42,19 +42,6 @@ export function Agent({ className, currentThreadId, onRefresh }: AgentProps) {
 	const [agentUpdates, setAgentUpdates] = useState(agent);
 
 	useEffect(() => {
-		if (agent.aliasAssigned === undefined && agent.alias) {
-			const intervalId = setInterval(() => {
-				refreshAgent();
-				if (agent.aliasAssigned !== undefined) {
-					clearInterval(intervalId);
-				}
-			}, 1000);
-
-			return () => clearInterval(intervalId);
-		}
-	}, [agent, refreshAgent]);
-
-	useEffect(() => {
 		setAgentUpdates((prev) => {
 			return {
 				...agent,

--- a/ui/admin/app/components/agent/Agent.tsx
+++ b/ui/admin/app/components/agent/Agent.tsx
@@ -1,11 +1,9 @@
 import { GearIcon } from "@radix-ui/react-icons";
 import { BlocksIcon, LibraryIcon, PlusIcon, WrenchIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import useSWR from "swr";
 
 import { Agent as AgentType } from "~/lib/model/agents";
 import { AssistantNamespace } from "~/lib/model/assistants";
-import { AgentService } from "~/lib/service/api/agentService";
 import { cn } from "~/lib/utils";
 
 import { AgentAlias } from "~/components/agent/AgentAlias";
@@ -42,46 +40,31 @@ export function Agent({ className, currentThreadId, onRefresh }: AgentProps) {
 		useAgent();
 
 	const [agentUpdates, setAgentUpdates] = useState(agent);
-	const [loadingAgentId, setLoadingAgentId] = useState("");
+
+	useEffect(() => {
+		if (agent.aliasAssigned === undefined && agent.alias) {
+			const intervalId = setInterval(() => {
+				refreshAgent();
+				if (agent.aliasAssigned !== undefined) {
+					clearInterval(intervalId);
+				}
+			}, 1000);
+
+			return () => clearInterval(intervalId);
+		}
+	}, [agent, refreshAgent]);
 
 	useEffect(() => {
 		setAgentUpdates((prev) => {
-			if (agent.id === prev.id) {
-				return {
-					...prev,
-					aliasAssigned: agent.aliasAssigned,
-				};
-			}
-
-			return agent;
+			return {
+				...agent,
+				aliasAssigned:
+					agent.aliasAssigned !== undefined
+						? agent.aliasAssigned
+						: prev.aliasAssigned,
+			};
 		});
 	}, [agent]);
-
-	const getLoadingAgent = useSWR(
-		AgentService.getAgentById.key(loadingAgentId),
-		({ agentId }) => AgentService.getAgentById(agentId),
-		{
-			revalidateOnFocus: false,
-			refreshInterval: 2000,
-		}
-	);
-
-	useEffect(() => {
-		if (!loadingAgentId) return;
-
-		const { isLoading, data } = getLoadingAgent;
-		if (isLoading) return;
-
-		if (data?.aliasAssigned) {
-			setAgentUpdates((prev) => {
-				return {
-					...prev,
-					aliasAssigned: data.aliasAssigned,
-				};
-			});
-			setLoadingAgentId("");
-		}
-	}, [getLoadingAgent, loadingAgentId]);
 
 	const debouncedUpdateAgent = useDebounce(updateAgent, 1000);
 
@@ -93,7 +76,15 @@ export function Agent({ className, currentThreadId, onRefresh }: AgentProps) {
 
 			setAgentUpdates(updatedAgent);
 
-			if (changes.alias) setLoadingAgentId(changes.alias);
+			if (changes.alias) {
+				const updatedAgentWithAliasUndefined = {
+					...updatedAgent,
+					aliasAssigned: undefined,
+				};
+				setAgentUpdates(updatedAgentWithAliasUndefined);
+			} else {
+				setAgentUpdates(updatedAgent);
+			}
 		},
 		[agent, agentUpdates, debouncedUpdateAgent]
 	);

--- a/ui/admin/app/components/agent/AgentAlias.tsx
+++ b/ui/admin/app/components/agent/AgentAlias.tsx
@@ -34,8 +34,9 @@ export function AgentAlias({ agent, onChange }: AgentAliasProps) {
 	}, [getAssistants.data, agent.alias]);
 
 	const conflictingAlias = refAssistant && refAssistant.entityID !== agent.id;
+
 	const agentUrl = ConsumptionUrl(
-		`/${!conflictingAlias && agent.alias ? agent.alias : agent.id}`
+		`/${!conflictingAlias && agent.alias && agent.aliasAssigned ? agent.alias : agent.id}`
 	);
 
 	return (


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/1254

Changed the alias logic in the frontend to match the behavior in backend. The idea is that when agent.AliasAssigned is null it means that the agent needs controller reconcilation and UI should start polling until it reaches a final state.