### PR TITLE
Fix: Resolve agent icon in chat

### DIFF
--- a/ui/user/src/lib/components/messages/MessageIcon.svelte
+++ b/ui/user/src/lib/components/messages/MessageIcon.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ProfileIcon from '$lib/components/profile/ProfileIcon.svelte';
 	import type { Message } from '$lib/services';
+	import { currentAssistant } from '$lib/stores';
 	import { Pencil } from '$lib/icons';
 	import AssistantIcon from '$lib/icons/AssistantIcon.svelte';
 	import { AlertCircle } from 'lucide-svelte';
@@ -17,7 +18,7 @@
 {:else if msg.icon === 'Pencil'}
 	<Pencil class="h-8 w-8" />
 {:else if msg.icon === 'Assistant'}
-	<AssistantIcon />
+	<AssistantIcon id={$currentAssistant?.id} />
 {:else if msg.icon === 'Profile'}
 	<ProfileIcon />
 {:else if msg.icon === 'Error'}


### PR DESCRIPTION
Agent icon was not showing up in chat because we weren't passing the
current agent id in properly.

Signed-off-by: Craig Jellick <craig@acorn.io>
