### PR TITLE
Fix: remove existing cleanup method

### DIFF
--- a/pkg/controller/handlers/cronjob/cronjob.go
+++ b/pkg/controller/handlers/cronjob/cronjob.go
@@ -10,6 +10,7 @@ import (
 	"github.com/obot-platform/obot/pkg/alias"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,6 +61,9 @@ func (h *Handler) Run(req router.Request, resp router.Response) error {
 
 	var workflow v1.Workflow
 	if err := alias.Get(req.Ctx, req.Client, &workflow, cj.Namespace, cj.Spec.Workflow); err != nil {
+		if apierror.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -138,13 +138,11 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.KnowledgeSet{}).HandlerFunc(knowledgeset.SetEmbeddingModel)
 
 	// Webhooks
-	root.Type(&v1.Webhook{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.Webhook{}).HandlerFunc(alias.AssignAlias)
 	root.Type(&v1.Webhook{}).HandlerFunc(webHooks.SetSuccessRunTime)
 	root.Type(&v1.Webhook{}).HandlerFunc(generationed.UpdateObservedGeneration)
 
 	// Cronjobs
-	root.Type(&v1.CronJob{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.CronJob{}).HandlerFunc(cronJobs.SetSuccessRunTime)
 	root.Type(&v1.CronJob{}).HandlerFunc(cronJobs.Run)
 

--- a/pkg/storage/apis/obot.obot.ai/v1/cronjob.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/cronjob.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/obot-platform/nah/pkg/fields"
 	"github.com/obot-platform/obot/apiclient/types"
-	"github.com/obot-platform/obot/pkg/system"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -51,11 +50,6 @@ func (*CronJob) GetColumns() [][]string {
 }
 
 func (c *CronJob) DeleteRefs() []Ref {
-	if system.IsWorkflowID(c.Spec.Workflow) {
-		return []Ref{
-			{ObjType: new(Workflow), Name: c.Spec.Workflow},
-		}
-	}
 	return nil
 }
 

--- a/pkg/storage/apis/obot.obot.ai/v1/emailaddress.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/emailaddress.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/obot-platform/nah/pkg/fields"
 	"github.com/obot-platform/obot/apiclient/types"
-	"github.com/obot-platform/obot/pkg/system"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -74,11 +73,6 @@ func (*EmailReceiver) GetColumns() [][]string {
 }
 
 func (in *EmailReceiver) DeleteRefs() []Ref {
-	if system.IsWorkflowID(in.Spec.Workflow) {
-		return []Ref{
-			{ObjType: new(Workflow), Name: in.Spec.Workflow},
-		}
-	}
 	return nil
 }
 

--- a/pkg/storage/apis/obot.obot.ai/v1/webhook.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/webhook.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/obot-platform/nah/pkg/fields"
 	"github.com/obot-platform/obot/apiclient/types"
-	"github.com/obot-platform/obot/pkg/system"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -75,11 +74,6 @@ func (*Webhook) GetColumns() [][]string {
 }
 
 func (w *Webhook) DeleteRefs() []Ref {
-	if system.IsWebhookID(w.Spec.Workflow) {
-		return []Ref{
-			{ObjType: new(Workflow), Name: w.Spec.Workflow},
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
Removing existing cleanup method so that we can rely on client to decide when to remove triggers that are attached to a workflow.

https://github.com/obot-platform/obot/issues/1175