### PR TITLE
Chore: Rename docs build job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
       - "docs/**"
 
 jobs:
-  build-docs:
+  build:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Our pull request require a check called "build" to pass.

Signed-off-by: Craig Jellick <craig@acorn.io>
