### PR TITLE
chore: rename docker build github workflow

### DIFF
--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image
+name: Test Docker Build
 
 on:
   pull_request:


### PR DESCRIPTION
Rename the `Build Docker Image` GitHub workflow to `Test Docker Build` for clarity.


