### PR TITLE
chore: remove tenant ID validation for microsoft365 oauth app

### DIFF
--- a/pkg/gateway/types/oauth_apps.go
+++ b/pkg/gateway/types/oauth_apps.go
@@ -135,8 +135,6 @@ func ValidateAndSetDefaultsOAuthAppManifest(r *types.OAuthAppManifest, create bo
 		}
 		if r.Type == types.OAuthAppTypeHubSpot && r.AppID == "" {
 			errs = append(errs, fmt.Errorf("missing appID"))
-		} else if r.Type == types.OAuthAppTypeMicrosoft365 && r.TenantID == "" {
-			errs = append(errs, fmt.Errorf("missing tenantID"))
 		}
 	}
 


### PR DESCRIPTION
If the tenant ID is blank, then it will default to "common"