### PR TITLE
chore: add oauthApps field to the default Obot agent

### DIFF
--- a/pkg/controller/data/agent.yaml
+++ b/pkg/controller/data/agent.yaml
@@ -33,3 +33,6 @@ spec:
     defaultThreadTools:
     - images-bundle
     - google-search-bundle
+    oauthApps:
+    - github
+    - google


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/1528