### PR TITLE
Fix: Set Obot dark mode icon to blue

### DIFF
--- a/pkg/controller/data/agent.go
+++ b/pkg/controller/data/agent.go
@@ -149,6 +149,12 @@ func addDefaultAgent(ctx context.Context, k kclient.Client, agentDir string) err
 		modified = true
 	}
 
+	// set obot dark mode to blue
+	if existing.Spec.Manifest.Icons != nil && existing.Spec.Manifest.Icons.Icon == "/user/images/obot-icon-blue.svg" && existing.Spec.Manifest.Icons.IconDark == "" {
+		existing.Spec.Manifest.Icons = agent.Spec.Manifest.Icons
+		modified = true
+	}
+
 	if modified {
 		return k.Update(ctx, &existing)
 	}

--- a/pkg/controller/data/agent.yaml
+++ b/pkg/controller/data/agent.yaml
@@ -9,6 +9,7 @@ spec:
     description: Default Assistant
     icons:
       icon: /user/images/obot-icon-blue.svg
+      iconDark: /user/images/obot-icon-blue.svg
       collapsed: /user/images/obot-logo-blue-black-text.svg
       collapsedDark: /user/images/obot-logo-blue-white-text.svg
     prompt: |


### PR DESCRIPTION
We use invert logic when an agent doesn't have an explicit dark icon
set. Generally, this should be fine, but for obot, we want the dark mode
to be blue, not the orange, which is the inversion of blue.

Signed-off-by: Craig Jellick <craig@acorn.io>
