### PR TITLE
Fix: don't process to create threads when workspace name is not set

### DIFF
--- a/pkg/controller/handlers/knowledgeset/knowledgeset.go
+++ b/pkg/controller/handlers/knowledgeset/knowledgeset.go
@@ -3,6 +3,7 @@ package knowledgeset
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/obot-platform/nah/pkg/name"
 	"github.com/obot-platform/nah/pkg/router"
@@ -148,11 +149,16 @@ func (h *Handler) SetEmbeddingModel(req router.Request, _ router.Response) error
 	return nil
 }
 
-func (h *Handler) CreateWorkspace(req router.Request, _ router.Response) error {
+func (h *Handler) CreateWorkspace(req router.Request, resp router.Response) error {
 	ks := req.Object.(*v1.KnowledgeSet)
 
 	if err := createWorkspace(req.Ctx, req.Client, ks); err != nil {
 		return err
+	}
+
+	if ks.Status.WorkspaceName == "" {
+		resp.RetryAfter(time.Second * 5)
+		return nil
 	}
 
 	return h.createThread(req.Ctx, req.Client, ks)

--- a/pkg/controller/handlers/knowledgeset/knowledgeset.go
+++ b/pkg/controller/handlers/knowledgeset/knowledgeset.go
@@ -3,7 +3,6 @@ package knowledgeset
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/obot-platform/nah/pkg/name"
 	"github.com/obot-platform/nah/pkg/router"
@@ -149,7 +148,7 @@ func (h *Handler) SetEmbeddingModel(req router.Request, _ router.Response) error
 	return nil
 }
 
-func (h *Handler) CreateWorkspace(req router.Request, resp router.Response) error {
+func (h *Handler) CreateWorkspace(req router.Request, _ router.Response) error {
 	ks := req.Object.(*v1.KnowledgeSet)
 
 	if err := createWorkspace(req.Ctx, req.Client, ks); err != nil {
@@ -157,7 +156,6 @@ func (h *Handler) CreateWorkspace(req router.Request, resp router.Response) erro
 	}
 
 	if ks.Status.WorkspaceName == "" {
-		resp.RetryAfter(time.Second * 5)
 		return nil
 	}
 


### PR DESCRIPTION
We will need to wait for workspace name to be set, otherwise thread will have its own workspace created which will lose the file that user uploads too.