### PR TITLE
chore: remove oauth-based apps from default agent

### DIFF
--- a/pkg/controller/data/agent.yaml
+++ b/pkg/controller/data/agent.yaml
@@ -26,14 +26,6 @@ spec:
     - knowledge
     - database
     - tasks
-    availableThreadTools:
-    - github-bundle
-    - google-docs-bundle
-    - google-gmail-bundle
-    - google-sheets-bundle
     defaultThreadTools:
     - images-bundle
     - google-search-bundle
-    oauthApps:
-    - github
-    - google


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/1528