### PR TITLE
chore: add the ability to create releases for tools repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Trigger tools repo tag workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.TOOLS_DISPATCH_PAT }}
+          repository: obot-platform/tools
+          event-type: release
+          client-payload: '{"tag": "${{ github.ref_name }}"}'
+
+      - name: Trigger enterprise-tool repo tag workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.ENTERPRISE_TOOLS_DISPATCH_PAT }}
+          repository: obot-platform/enterprise-tools
+          event-type: release
+          client-payload: '{"tag": "${{ github.ref_name }}"}'
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This will create tagged releases in the tools repos when we release Obot. This will make it easier to identify which commit of the tools repos are in which release.

If the tag already exists in a tools repo, then this won't change that release.

Requires: https://github.com/obot-platform/tools/pull/392 and https://github.com/obot-platform/enterprise-tools/pull/18