### PR TITLE
chore: update service method primitives

### DIFF
--- a/ui/admin/app/components/agent/AgentContext.tsx
+++ b/ui/admin/app/components/agent/AgentContext.tsx
@@ -6,7 +6,7 @@ import {
 	useEffect,
 	useState,
 } from "react";
-import useSWR, { mutate } from "swr";
+import useSWR from "swr";
 
 import { Agent } from "~/lib/model/agents";
 import { AgentService } from "~/lib/service/api/agentService";
@@ -36,14 +36,10 @@ export function AgentProvider({
 
 	const [blockPollingAgent, setBlockPollingAgent] = useState(false);
 
-	const getAgent = useSWR(
-		AgentService.getAgentById.key(agentId),
-		({ agentId }) => AgentService.getAgentById(agentId),
-		{
-			fallbackData: agent,
-			refreshInterval: blockPollingAgent ? undefined : 1000,
-		}
-	);
+	const getAgent = useSWR(...AgentService.getAgentById.swr({ agentId }), {
+		fallbackData: agent,
+		refreshInterval: blockPollingAgent ? undefined : 1000,
+	});
 
 	const agentData = getAgent.data ?? agent;
 
@@ -62,7 +58,7 @@ export function AgentProvider({
 			AgentService.updateAgent({ id: agentId, agent: updatedAgent })
 				.then((updatedAgent) => {
 					getAgent.mutate(updatedAgent);
-					mutate(AgentService.getAgents.key());
+					AgentService.getAgents.revalidate({});
 					setLastSaved(new Date());
 				})
 				.catch(console.error),

--- a/ui/admin/app/components/agent/AgentDropdownActions.tsx
+++ b/ui/admin/app/components/agent/AgentDropdownActions.tsx
@@ -2,7 +2,6 @@ import { EllipsisVerticalIcon } from "lucide-react";
 import { useNavigate } from "react-router";
 import { $path } from "safe-routes";
 import { toast } from "sonner";
-import { mutate } from "swr";
 
 import { Agent } from "~/lib/model/agents";
 import { AgentService } from "~/lib/service/api/agentService";
@@ -23,7 +22,7 @@ export function AgentDropdownActions({ agent }: { agent: Agent }) {
 
 	const deleteAgent = useAsync(AgentService.deleteAgent, {
 		onSuccess: () => {
-			mutate(AgentService.getAgents.key());
+			AgentService.getAgents.revalidate({});
 			toast.success("Agent deleted");
 			navigate($path("/agents"));
 		},
@@ -37,7 +36,7 @@ export function AgentDropdownActions({ agent }: { agent: Agent }) {
 	const { dialogProps, interceptAsync } = useConfirmationDialog();
 
 	const handleDelete = () =>
-		interceptAsync(() => deleteAgent.executeAsync(agent.id));
+		interceptAsync(() => deleteAgent.executeAsync({ id: agent.id }));
 
 	return (
 		<>

--- a/ui/admin/app/components/agent/DeleteAgent.tsx
+++ b/ui/admin/app/components/agent/DeleteAgent.tsx
@@ -1,6 +1,5 @@
 import { TrashIcon } from "lucide-react";
 import { toast } from "sonner";
-import { mutate } from "swr";
 
 import { AgentService } from "~/lib/service/api/agentService";
 
@@ -23,7 +22,7 @@ export function DeleteAgent({
 	const deleteAgent = useAsync(AgentService.deleteAgent, {
 		onSuccess: () => {
 			toast.success("Agent deleted");
-			mutate(AgentService.getAgents.key());
+			AgentService.getAgents.revalidate({});
 			onSuccess?.();
 		},
 		onError: () => toast.error("Failed to delete agent"),
@@ -36,7 +35,7 @@ export function DeleteAgent({
 			<ConfirmationDialog
 				title="Delete Agent?"
 				description="This action cannot be undone."
-				onConfirm={() => deleteAgent.execute(id)}
+				onConfirm={() => deleteAgent.execute({ id })}
 				confirmProps={{ variant: "destructive" }}
 			>
 				<TooltipTrigger asChild>

--- a/ui/admin/app/components/agent/shared/AgentSelect.tsx
+++ b/ui/admin/app/components/agent/shared/AgentSelect.tsx
@@ -16,10 +16,7 @@ type AgentSelectModuleProps = {
 };
 
 export function AgentSelectModule(props: AgentSelectModuleProps) {
-	const { data: agents } = useSWR(
-		AgentService.getAgents.key(),
-		AgentService.getAgents
-	);
+	const { data: agents } = useSWR(...AgentService.getAgents.swr({}));
 
 	return (
 		<SelectModule

--- a/ui/admin/app/components/agent/shared/WorkspaceFilesSection.tsx
+++ b/ui/admin/app/components/agent/shared/WorkspaceFilesSection.tsx
@@ -35,8 +35,7 @@ export function WorkspaceFilesSection({
 	const { dialogProps, interceptAsync } = useConfirmationDialog();
 
 	const { data: files, mutate: refresh } = useSWR(
-		AgentService.getWorkspaceFiles.key(entityId),
-		({ agentId }) => AgentService.getWorkspaceFiles(agentId)
+		...AgentService.getWorkspaceFiles.swr({ agentId: entityId })
 	);
 
 	const deleteFile = useAsync(AgentService.deleteWorkspaceFile, {
@@ -47,7 +46,7 @@ export function WorkspaceFilesSection({
 
 	const uploadFiles = useMultiAsync(
 		async (_index: number, file: File) =>
-			await AgentService.uploadWorkspaceFile(entityId, file),
+			await AgentService.uploadWorkspaceFile({ agentId: entityId, file }),
 		{
 			onSuccess: (data) =>
 				// optomistic update
@@ -118,7 +117,10 @@ export function WorkspaceFilesSection({
 										onClick={(e) => {
 											e.stopPropagation();
 											interceptAsync(() =>
-												deleteFile.executeAsync(entityId, file.name)
+												deleteFile.executeAsync({
+													agentId: entityId,
+													fileName: file.name,
+												})
 											);
 										}}
 										startContent={<TrashIcon className="size-5" />}

--- a/ui/admin/app/components/chat/shared/thread-helpers.ts
+++ b/ui/admin/app/components/chat/shared/thread-helpers.ts
@@ -66,9 +66,7 @@ export function useThreadFiles(threadId?: Nullish<string>) {
 export function useThreadAgents(threadId?: Nullish<string>) {
 	const { data: thread } = useThread(threadId);
 
-	return useSWR(AgentService.getAgentById.key(thread?.agentID), ({ agentId }) =>
-		AgentService.getAgentById(agentId)
-	);
+	return useSWR(...AgentService.getAgentById.swr({ agentId: thread?.agentID }));
 }
 
 export function useThreadCredentials(threadId: Nullish<string>) {

--- a/ui/admin/app/components/knowledge/OAuthSignDialog.tsx
+++ b/ui/admin/app/components/knowledge/OAuthSignDialog.tsx
@@ -51,10 +51,10 @@ const OauthSignDialog: FC<OauthSignDialogProps> = ({
 
 		const fetchOauthUrl = async () => {
 			const toolRef = getToolRefForKnowledgeSource(sourceType);
-			const authStatus = await AgentService.getAuthUrlForAgent(
+			const authStatus = await AgentService.getAuthUrlForAgent.handler({
 				agentId,
-				toolRef
-			);
+				toolRef,
+			});
 			if (authStatus?.required && authStatus?.url) {
 				setOauthUrl(authStatus.url);
 			} else {

--- a/ui/admin/app/hooks/toolAuth/useToolAuthPolling.ts
+++ b/ui/admin/app/hooks/toolAuth/useToolAuthPolling.ts
@@ -12,11 +12,11 @@ export function useToolAuthPolling(
 	const [isPolling, setIsPolling] = useState(false);
 	const refreshInterval = isPolling ? 1000 : undefined;
 
+	const [key, handler] = AgentService.getAgentById.swr({ agentId: entityId });
+
 	const { data: agent } = useSWR(
-		namespace === AssistantNamespace.Agents
-			? AgentService.getAgentById.key(entityId)
-			: null,
-		({ agentId }) => AgentService.getAgentById(agentId),
+		namespace === AssistantNamespace.Agents ? key : null,
+		handler,
 		{ refreshInterval }
 	);
 

--- a/ui/admin/app/lib/service/api/agentService.ts
+++ b/ui/admin/app/lib/service/api/agentService.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import {
 	Agent,
 	AgentAuthorization,
@@ -6,153 +8,195 @@ import {
 } from "~/lib/model/agents";
 import { EntityList } from "~/lib/model/primitives";
 import { WorkspaceFile } from "~/lib/model/workspace";
-import {
-	ApiRoutes,
-	createRevalidate,
-	revalidateWhere,
-} from "~/lib/routers/apiRoutes";
+import { ApiRoutes } from "~/lib/routers/apiRoutes";
 import { request } from "~/lib/service/api/primitives";
+import {
+	createFetcher,
+	createMutator,
+} from "~/lib/service/api/service-primitives";
 import { downloadUrl } from "~/lib/utils/downloadFile";
 
-async function getAgents() {
-	const res = await request<{ items: Agent[] }>({
-		url: ApiRoutes.agents.base().url,
-		errorMessage: "Failed to fetch agents",
-	});
+const getAgents = createFetcher(
+	z.object({}),
+	async (_, config = {}) => {
+		const res = await request<{ items: Agent[] }>({
+			url: ApiRoutes.agents.base().url,
+			errorMessage: "Failed to fetch agents",
+			...config,
+		});
 
-	return res.data.items ?? ([] as Agent[]);
-}
-getAgents.key = () => ({ url: ApiRoutes.agents.base().path }) as const;
-
-const getAgentById = async (agentId: string) => {
-	const res = await request<Agent>({
-		url: ApiRoutes.agents.getById(agentId).url,
-		errorMessage: "Failed to fetch agent",
-	});
-
-	if (!res.data) return null;
-
-	return res.data;
-};
-getAgentById.key = (agentId?: Nullish<string>) => {
-	if (!agentId) return null;
-
-	return { url: ApiRoutes.agents.getById(agentId).path, agentId };
-};
-
-async function createAgent({ agent }: { agent: CreateAgent }) {
-	const res = await request<Agent>({
-		url: ApiRoutes.agents.base().url,
-		method: "POST",
-		data: agent,
-		errorMessage: "Failed to create agent",
-	});
-
-	return res.data;
-}
-
-async function updateAgent({ id, agent }: { id: string; agent: UpdateAgent }) {
-	const res = await request<Agent>({
-		url: ApiRoutes.agents.getById(id).url,
-		method: "PUT",
-		data: agent,
-		errorMessage: "Failed to update agent",
-	});
-
-	return res.data;
-}
-
-async function deleteAgent(id: string) {
-	await request({
-		url: ApiRoutes.agents.getById(id).url,
-		method: "DELETE",
-		errorMessage: "Failed to delete agent",
-	});
-}
-
-async function getAuthUrlForAgent(agentId: string, toolRef: string) {
-	const res = await request<Agent>({
-		url: ApiRoutes.agents.getAuthUrlForAgent(agentId, toolRef).url,
-		errorMessage: "Failed to get auth url for agent",
-		method: "POST",
-	});
-
-	return res.data.authStatus?.[toolRef];
-}
-
-const revalidateAgents = () =>
-	revalidateWhere((url) => url.includes(ApiRoutes.agents.base().path));
-
-async function getAgentAuthorizations(agentId: string) {
-	const res = await request<{ items: AgentAuthorization[] }>({
-		url: ApiRoutes.agents.getAuthorizations(agentId).url,
-		errorMessage: "Failed to fetch agent authorizations",
-	});
-
-	return res.data.items;
-}
-getAgentAuthorizations.key = (agentId?: Nullish<string>) => {
-	if (!agentId) return null;
-
-	return { url: ApiRoutes.agents.getAuthorizations(agentId).path, agentId };
-};
-
-async function addAgentAuthorization(agentId: string, userId: string) {
-	await request({
-		url: ApiRoutes.agents.addAuthorization(agentId).url,
-		method: "POST",
-		data: { userId },
-		errorMessage: "Failed to add agent authorization",
-	});
-}
-
-async function removeAgentAuthorization(agentId: string, userId: string) {
-	await request({
-		url: ApiRoutes.agents.removeAuthorization(agentId).url,
-		method: "POST",
-		data: { userId },
-		errorMessage: "Failed to remove agent authorization",
-	});
-}
-
-async function getWorkspaceFiles(agentId: string) {
-	const res = await request<EntityList<WorkspaceFile>>({
-		url: ApiRoutes.agents.getWorkspaceFiles(agentId).url,
-		errorMessage: "Failed to fetch workspace files",
-	});
-
-	return res.data.items;
-}
-getWorkspaceFiles.key = (agentId?: Nullish<string>) => {
-	if (!agentId) return null;
-
-	return { url: ApiRoutes.agents.getWorkspaceFiles(agentId).path, agentId };
-};
-getWorkspaceFiles.revalidate = createRevalidate(
-	ApiRoutes.agents.getWorkspaceFiles
+		return res.data.items ?? ([] as Agent[]);
+	},
+	() => ["Agents"]
 );
 
-async function uploadWorkspaceFile(agentId: string, file: File) {
-	await request({
-		url: ApiRoutes.agents.uploadWorkspaceFile(agentId, file.name).url,
-		method: "POST",
-		data: await file.arrayBuffer(),
-		headers: { "Content-Type": "application/x-www-form-urlencoded" },
-		errorMessage: "Failed to add knowledge to agent",
-	});
+const getAgentById = createFetcher(
+	z.object({ agentId: z.string() }),
+	async ({ agentId }, config = {}) => {
+		const res = await request<Agent>({
+			url: ApiRoutes.agents.getById(agentId).url,
+			errorMessage: "Failed to fetch agent",
+			...config,
+		});
 
-	return file.name;
-}
+		return res.data;
+	},
+	({ agentId }) => ["Agents", agentId]
+);
 
-async function deleteWorkspaceFile(agentId: string, fileName: string) {
-	await request({
-		url: ApiRoutes.agents.removeWorkspaceFile(agentId, fileName).url,
-		method: "DELETE",
-		errorMessage: "Failed to delete workspace file",
-	});
+const createAgent = createMutator(
+	async ({ agent }: { agent: CreateAgent }, { signal }) => {
+		const res = await request<Agent>({
+			url: ApiRoutes.agents.base().url,
+			method: "POST",
+			data: agent,
+			errorMessage: "Failed to create agent",
+			signal,
+		});
 
-	return fileName;
-}
+		return res.data;
+	}
+);
+
+const updateAgent = createMutator(
+	async ({ id, agent }: { id: string; agent: UpdateAgent }, { signal }) => {
+		const res = await request<Agent>({
+			url: ApiRoutes.agents.getById(id).url,
+			method: "PUT",
+			data: agent,
+			errorMessage: "Failed to update agent",
+			signal,
+		});
+
+		return res.data;
+	}
+);
+
+const deleteAgent = createMutator(
+	async ({ id }: { id: string }, { signal }) => {
+		await request({
+			url: ApiRoutes.agents.getById(id).url,
+			method: "DELETE",
+			errorMessage: "Failed to delete agent",
+			signal,
+		});
+	}
+);
+
+const getAuthUrlForAgent = createFetcher(
+	z.object({ agentId: z.string(), toolRef: z.string() }),
+	async ({ agentId, toolRef }, config = {}) => {
+		const res = await request<Agent>({
+			url: ApiRoutes.agents.getAuthUrlForAgent(agentId, toolRef).url,
+			errorMessage: "Failed to get auth url for agent",
+			method: "POST",
+			...config,
+		});
+
+		return res.data.authStatus?.[toolRef];
+	},
+	({ agentId, toolRef }) => ["Agents", agentId, "AuthUrl", toolRef]
+);
+
+const getAgentAuthorizations = createFetcher(
+	z.object({ agentId: z.string() }),
+	async ({ agentId }, config = {}) => {
+		const res = await request<{ items: AgentAuthorization[] }>({
+			url: ApiRoutes.agents.getAuthorizations(agentId).url,
+			errorMessage: "Failed to fetch agent authorizations",
+			...config,
+		});
+
+		return res.data.items;
+	},
+	({ agentId }) => ["Agents", agentId, "Authorizations"]
+);
+
+type AddAgentAuthorizationParams = {
+	agentId: string;
+	userId: string;
+};
+
+const addAgentAuthorization = createMutator(
+	async ({ agentId, userId }: AddAgentAuthorizationParams, config) => {
+		await request({
+			url: ApiRoutes.agents.addAuthorization(agentId).url,
+			method: "POST",
+			data: { userId },
+			errorMessage: "Failed to add agent authorization",
+			...config,
+		});
+	}
+);
+
+type RemoveAgentAuthorizationParams = {
+	agentId: string;
+	userId: string;
+};
+
+const removeAgentAuthorization = createMutator(
+	async ({ agentId, userId }: RemoveAgentAuthorizationParams, config) => {
+		await request({
+			url: ApiRoutes.agents.removeAuthorization(agentId).url,
+			method: "POST",
+			data: { userId },
+			errorMessage: "Failed to remove agent authorization",
+			...config,
+		});
+	}
+);
+
+const getWorkspaceFiles = createFetcher(
+	z.object({ agentId: z.string() }),
+	async ({ agentId }, config = {}) => {
+		const res = await request<EntityList<WorkspaceFile>>({
+			url: ApiRoutes.agents.getWorkspaceFiles(agentId).url,
+			errorMessage: "Failed to fetch workspace files",
+			...config,
+		});
+
+		return res.data.items;
+	},
+	({ agentId }) => ["Agents", agentId, "WorkspaceFiles"]
+);
+
+type UploadWorkspaceFileParams = {
+	agentId: string;
+	file: File;
+};
+
+const uploadWorkspaceFile = createMutator(
+	async ({ agentId, file }: UploadWorkspaceFileParams, config = {}) => {
+		await request({
+			url: ApiRoutes.agents.uploadWorkspaceFile(agentId, file.name).url,
+			method: "POST",
+			data: await file.arrayBuffer(),
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			errorMessage: "Failed to add knowledge to agent",
+			...config,
+		});
+
+		return file.name;
+	}
+);
+
+type DeleteWorkspaceFileParams = {
+	agentId: string;
+	fileName: string;
+};
+
+const deleteWorkspaceFile = createMutator(
+	async ({ agentId, fileName }: DeleteWorkspaceFileParams, config) => {
+		await request({
+			url: ApiRoutes.agents.removeWorkspaceFile(agentId, fileName).url,
+			method: "DELETE",
+			errorMessage: "Failed to delete workspace file",
+			...config,
+		});
+
+		return fileName;
+	}
+);
 
 async function downloadWorkspaceFile(agentId: string, fileName: string) {
 	downloadUrl(
@@ -162,18 +206,17 @@ async function downloadWorkspaceFile(agentId: string, fileName: string) {
 }
 
 export const AgentService = {
-	getAgents,
-	getAgentById,
-	createAgent,
-	updateAgent,
-	deleteAgent,
-	getAuthUrlForAgent,
-	revalidateAgents,
-	getAgentAuthorizations,
-	addAgentAuthorization,
-	removeAgentAuthorization,
-	getWorkspaceFiles,
-	uploadWorkspaceFile,
-	deleteWorkspaceFile,
-	downloadWorkspaceFile,
+	getAgents: getAgents,
+	getAgentById: getAgentById,
+	createAgent: createAgent,
+	updateAgent: updateAgent,
+	deleteAgent: deleteAgent,
+	getAuthUrlForAgent: getAuthUrlForAgent,
+	getAgentAuthorizations: getAgentAuthorizations,
+	addAgentAuthorization: addAgentAuthorization,
+	removeAgentAuthorization: removeAgentAuthorization,
+	getWorkspaceFiles: getWorkspaceFiles,
+	uploadWorkspaceFile: uploadWorkspaceFile,
+	deleteWorkspaceFile: deleteWorkspaceFile,
+	downloadWorkspaceFile: downloadWorkspaceFile,
 };

--- a/ui/admin/app/lib/service/api/apiErrors.tsx
+++ b/ui/admin/app/lib/service/api/apiErrors.tsx
@@ -1,6 +1,7 @@
 export class ConflictError extends Error {}
 export class BadRequestError extends Error {}
 export class NotFoundError extends Error {}
+export class CanceledError extends Error {}
 
 // Errors that should trigger the error boundary
 export class BoundaryError extends Error {}

--- a/ui/admin/app/lib/service/api/primitives.ts
+++ b/ui/admin/app/lib/service/api/primitives.ts
@@ -1,5 +1,10 @@
 // TODO: Add default configurations with auth tokens, etc. When ready
-import axios, { AxiosRequestConfig, AxiosResponse, isAxiosError } from "axios";
+import axios, {
+	AxiosRequestConfig,
+	AxiosResponse,
+	CanceledError,
+	isAxiosError,
+} from "axios";
 import { toast } from "sonner";
 
 import { AuthDisabledUsername } from "~/lib/model/auth";
@@ -79,7 +84,8 @@ export async function request<T, R = AxiosResponse<T>, D = unknown>({
 			});
 		}
 
-		if (toastError) toast.error(errorMessage);
+		if (toastError && !(convertedError instanceof CanceledError))
+			toast.error(errorMessage);
 
 		throw convertedError;
 	}
@@ -106,6 +112,10 @@ function convertError(error: Error) {
 
 	if (isAxiosError(error) && error.response?.status === 409) {
 		return new ConflictError(error.response.data);
+	}
+
+	if (isAxiosError(error) && error.name === "ERR_CANCELED") {
+		return new CanceledError(error.name);
 	}
 
 	return error;

--- a/ui/admin/app/lib/service/api/service-primitives.ts
+++ b/ui/admin/app/lib/service/api/service-primitives.ts
@@ -1,0 +1,89 @@
+import { mutate } from "swr";
+import { ZodObject, ZodRawShape, z } from "zod";
+
+type FetcherConfig = {
+	signal?: AbortSignal;
+};
+
+export const RevalidateSkip = Symbol("RevalidateSkip");
+
+export const revalidateArray = <TKey extends unknown[]>(
+	key: TKey,
+	exact = true
+) =>
+	mutate((cacheKey) => {
+		if (!Array.isArray(cacheKey)) return false;
+
+		return (
+			key.every((k, i) => [cacheKey[i], RevalidateSkip].includes(k)) &&
+			(!exact || cacheKey.length === key.length)
+		);
+	});
+
+export const createFetcher = <
+	TInput extends ZodObject<ZodRawShape>,
+	TParams extends z.infer<TInput>,
+	TKey extends unknown[],
+	TResponse,
+>(
+	input: TInput,
+	handler: (params: TParams, config?: FetcherConfig) => Promise<TResponse>,
+	key: (params: TParams) => TKey
+) => {
+	type KeyParams = NullishPartial<TParams>;
+
+	const buildKey = (params: KeyParams) => {
+		const { data } = input.safeParse(params);
+		return data ? key(data as TParams) : null;
+	};
+
+	const skippedSchema = z.object(
+		Object.fromEntries(
+			Object.entries(input.shape).map(([key, schema]) => [
+				key,
+				schema.catch(RevalidateSkip),
+			])
+		)
+	);
+
+	const buildRevalidator = (params: KeyParams, exact?: boolean) => {
+		const data = skippedSchema.parse(params);
+		revalidateArray(key(data as TParams), exact);
+	};
+
+	// create a closure to trigger abort controller on consecutive requests
+	let abortController: AbortController;
+
+	const handleFetch = (params: TParams, config: FetcherConfig) => {
+		abortController?.abort();
+
+		abortController = new AbortController();
+		return handler(params, { signal: abortController.signal, ...config });
+	};
+
+	return {
+		handler,
+		key,
+		swr: (params: KeyParams, config: FetcherConfig = {}) => {
+			return [
+				buildKey(params),
+				() => handleFetch(params as TParams, config),
+			] as const;
+		},
+		revalidate: (params: KeyParams, exact?: boolean) =>
+			buildRevalidator(params, exact),
+	};
+};
+
+export const createMutator = <TInput extends object, TResponse>(
+	fn: (params: TInput, config: FetcherConfig) => Promise<TResponse>
+) => {
+	let abortController: AbortController;
+
+	return (params: TInput, config: FetcherConfig = {}) => {
+		abortController?.abort();
+
+		abortController = new AbortController();
+		return fn(params, { signal: abortController.signal, ...config });
+	};
+};

--- a/ui/admin/app/lib/service/api/service-primitives.ts
+++ b/ui/admin/app/lib/service/api/service-primitives.ts
@@ -5,8 +5,30 @@ type FetcherConfig = {
 	signal?: AbortSignal;
 };
 
-export const RevalidateSkip = Symbol("RevalidateSkip");
+/**
+ * Allows us to skip matching on specific key segments
+ * @example
+ * revalidateArray(["Agents", SkipKey])
+ * // will revalidate the following keys:
+ * ["Agents", "1234"]
+ * ["Agents", "5678"]
+ * // but not:
+ * ["Agents", "1234", "Threads"]
+ * ["Agents", "1234", "Threads", "5678"]
+ *
+ * // If exact is false:
+ * revalidateArray(["Agents", SkipKey], false)
+ * // will also revalidate the following keys:
+ * ["Agents", "1234", "Threads"]
+ * ["Agents", "1234", "Threads", "5678"]
+ */
+export const SkipKey = Symbol("SkipKey");
 
+/**
+ * Revalidates all keys that match the given key
+ * @param key - The key to match. Use SkipKey to skip matching on specific segments
+ * @param exact - Whether the key must match exactly
+ */
 export const revalidateArray = <TKey extends unknown[]>(
 	key: TKey,
 	exact = true
@@ -15,11 +37,18 @@ export const revalidateArray = <TKey extends unknown[]>(
 		if (!Array.isArray(cacheKey)) return false;
 
 		return (
-			key.every((k, i) => [cacheKey[i], RevalidateSkip].includes(k)) &&
+			key.every((k, i) => [cacheKey[i], SkipKey].includes(k)) &&
 			(!exact || cacheKey.length === key.length)
 		);
 	});
 
+/**
+ * Creates a fetcher for a given API function
+ * @param input - The input schema
+ * @param handler - The API function
+ * @param key - The function that generates the UNIQUE key for the given params. This should include all dependencies of the method
+ * @returns The fetcher
+ */
 export const createFetcher = <
 	TInput extends ZodObject<ZodRawShape>,
 	TParams extends z.infer<TInput>,
@@ -32,27 +61,31 @@ export const createFetcher = <
 ) => {
 	type KeyParams = NullishPartial<TParams>;
 
+	/** Creates a closure to trigger abort controller on consecutive requests */
+	let abortController: AbortController;
+
+	// this schema will skip any parameters that would cause an error
+	const skippedSchema = z.object(
+		Object.fromEntries(
+			Object.entries(input.shape).map(([key, schema]) => [
+				key,
+				// this means that if a parameter would cause an error, it will be skipped
+				schema.catch(SkipKey),
+			])
+		)
+	);
+
+	// this function will return null if the params are invalid
+	// SWR will not call the handler if the key is null
 	const buildKey = (params: KeyParams) => {
 		const { data } = input.safeParse(params);
 		return data ? key(data as TParams) : null;
 	};
 
-	const skippedSchema = z.object(
-		Object.fromEntries(
-			Object.entries(input.shape).map(([key, schema]) => [
-				key,
-				schema.catch(RevalidateSkip),
-			])
-		)
-	);
-
 	const buildRevalidator = (params: KeyParams, exact?: boolean) => {
 		const data = skippedSchema.parse(params);
 		revalidateArray(key(data as TParams), exact);
 	};
-
-	// create a closure to trigger abort controller on consecutive requests
-	let abortController: AbortController;
 
 	const handleFetch = (params: TParams, config: FetcherConfig) => {
 		abortController?.abort();
@@ -64,9 +97,11 @@ export const createFetcher = <
 	return {
 		handler,
 		key,
+		/** Creates a SWR key and fetcher for the given params. This works for both `useSWR` and `prefetch` from SWR */
 		swr: (params: KeyParams, config: FetcherConfig = {}) => {
 			return [
 				buildKey(params),
+				// casting (params as TParams) is safe here because handleFetch will never be called when params are invalid
 				() => handleFetch(params as TParams, config),
 			] as const;
 		},
@@ -75,9 +110,15 @@ export const createFetcher = <
 	};
 };
 
+/**
+ * Creates a mutator for a given API function
+ * @param fn - The API function
+ * @returns The mutator
+ */
 export const createMutator = <TInput extends object, TResponse>(
 	fn: (params: TInput, config: FetcherConfig) => Promise<TResponse>
 ) => {
+	/** Creates a closure to trigger abort controller on consecutive requests */
 	let abortController: AbortController;
 
 	return (params: TInput, config: FetcherConfig = {}) => {

--- a/ui/admin/app/routes/_auth.agents.$agent.tsx
+++ b/ui/admin/app/routes/_auth.agents.$agent.tsx
@@ -47,9 +47,7 @@ export const clientLoader = async ({
 			DefaultModelAliasApiService.getAliases.key(),
 			DefaultModelAliasApiService.getAliases
 		),
-		preload(AgentService.getAgentById.key(agentId), () =>
-			AgentService.getAgentById(agentId)
-		),
+		preload(...AgentService.getAgentById.swr({ agentId })),
 	]);
 
 	const agent = response[1];
@@ -66,11 +64,8 @@ export default function ChatAgent() {
 	// need to get updated starter messages and introduction message
 	// when agent updates happen for chat
 	const { data: updatedAgent } = useSWR(
-		AgentService.getAgentById.key(agent.id),
-		({ agentId }) => AgentService.getAgentById(agentId),
-		{
-			fallbackData: agent,
-		}
+		...AgentService.getAgentById.swr({ agentId: agent.id }),
+		{ fallbackData: agent }
 	);
 	const navigate = useNavigate();
 
@@ -122,8 +117,7 @@ const AgentBreadcrumb = () => {
 	const match = useMatch("/agents/:agent");
 
 	const { data: agent } = useSWR(
-		AgentService.getAgentById.key(match?.params.agent),
-		({ agentId }) => AgentService.getAgentById(agentId)
+		...AgentService.getAgentById.swr({ agentId: match?.params.agent })
 	);
 
 	return <>{agent?.name || "New Agent"}</>;

--- a/ui/admin/app/routes/_auth.agents._index.tsx
+++ b/ui/admin/app/routes/_auth.agents._index.tsx
@@ -4,7 +4,7 @@ import { SquarePen } from "lucide-react";
 import { useMemo } from "react";
 import { MetaFunction, useNavigate } from "react-router";
 import { $path } from "safe-routes";
-import useSWR, { mutate, preload } from "swr";
+import useSWR, { preload } from "swr";
 
 import { Agent } from "~/lib/model/agents";
 import { CapabilityTool } from "~/lib/model/toolReferences";
@@ -25,7 +25,7 @@ import {
 
 export async function clientLoader() {
 	await Promise.all([
-		preload(AgentService.getAgents.key(), AgentService.getAgents),
+		preload(...AgentService.getAgents.swr({})),
 		preload(ThreadsService.getThreads.key(), ThreadsService.getThreads),
 	]);
 	return null;
@@ -55,10 +55,7 @@ export default function Agents() {
 		);
 	}, [getThreads.data]);
 
-	const getAgents = useSWR(
-		AgentService.getAgents.key(),
-		AgentService.getAgents
-	);
+	const getAgents = useSWR(...AgentService.getAgents.swr({}));
 
 	const agents = getAgents.data || [];
 
@@ -78,7 +75,7 @@ export default function Agents() {
 										tools: CapabilityTools,
 									} as Agent,
 								}).then((agent) => {
-									mutate(AgentService.getAgents.key());
+									getAgents.mutate();
 									navigate(
 										$path("/agents/:agent", {
 											agent: agent.id,

--- a/ui/admin/app/routes/_auth.threads.$id.tsx
+++ b/ui/admin/app/routes/_auth.threads.$id.tsx
@@ -57,9 +57,7 @@ export const clientLoader = async ({
 
 	const [agent, workflow] = await Promise.all([
 		thread.agentID
-			? preload(AgentService.getAgentById.key(thread.agentID), () =>
-					AgentService.getAgentById(thread.agentID)
-				)
+			? preload(...AgentService.getAgentById.swr({ agentId: thread.agentID }))
 			: null,
 		thread.workflowID
 			? preload(WorkflowService.getWorkflowById.key(thread.workflowID), () =>

--- a/ui/admin/app/routes/_auth.threads._index.tsx
+++ b/ui/admin/app/routes/_auth.threads._index.tsx
@@ -42,7 +42,7 @@ export async function clientLoader({
 	request,
 }: ClientLoaderFunctionArgs) {
 	await Promise.all([
-		preload(AgentService.getAgents.key(), AgentService.getAgents),
+		preload(...AgentService.getAgents.swr({})),
 		preload(WorkflowService.getWorkflows.key(), WorkflowService.getWorkflows),
 		preload(ThreadsService.getThreads.key(), ThreadsService.getThreads),
 	]);
@@ -65,10 +65,7 @@ export default function Threads() {
 		ThreadsService.getThreads
 	);
 
-	const getAgents = useSWR(
-		AgentService.getAgents.key(),
-		AgentService.getAgents
-	);
+	const getAgents = useSWR(...AgentService.getAgents.swr({}));
 
 	const getWorkflows = useSWR(
 		WorkflowService.getWorkflows.key(),


### PR DESCRIPTION
Addresses #1581 

Refactor work performed only on agentService.ts (subsequent work can be done incrementally)

Improvements:

- provides a programatic way to create service methods with configurable capabilities
- abstracts a lot of the mess  useSWR
- loosens coupling with useSWR as a library (foreshadowing..?)
- provides builtin support for AbortControllers
- switches SWR keys to be arrays instead of objects. This allows us to meaningfully invalidate the api cache using partial keys

Things to Note:
- Going forward all service methods will only be able to take 1 parameter which must always be an object. It's a bit more restrictive, but it shouldn't prevent us from doing anything and I think it's worth it for the DX

Future work:
- we may want to improve the way keys are passed to `createFetcher`. Right now there's no way to know that a key is unique and won't collide with another service method.