### PR TITLE
feat: implement pagination for thread files

### DIFF
--- a/ui/admin/app/components/chat/shared/thread-helpers.ts
+++ b/ui/admin/app/components/chat/shared/thread-helpers.ts
@@ -8,6 +8,7 @@ import { AgentService } from "~/lib/service/api/agentService";
 import { CredentialApiService } from "~/lib/service/api/credentialApiService";
 import { KnowledgeFileService } from "~/lib/service/api/knowledgeFileApiService";
 import { ThreadsService } from "~/lib/service/api/threadsService";
+import { PaginationParams } from "~/lib/service/pagination";
 
 import { useAsync } from "~/hooks/useAsync";
 
@@ -57,10 +58,18 @@ export function useThreadKnowledge(threadId?: Nullish<string>) {
 	);
 }
 
-export function useThreadFiles(threadId?: Nullish<string>) {
-	return useSWR(ThreadsService.getFiles.key(threadId), ({ threadId }) =>
-		ThreadsService.getFiles(threadId)
+export function useThreadFiles(
+	threadId?: Nullish<string>,
+	pagination?: PaginationParams,
+	search?: string
+) {
+	const { data, ...rest } = useSWR(
+		ThreadsService.getFiles.key(threadId, pagination, search),
+		({ threadId, pagination, search }) =>
+			ThreadsService.getFiles(threadId, pagination, search)
 	);
+
+	return { data, ...rest };
 }
 
 export function useThreadAgents(threadId?: Nullish<string>) {

--- a/ui/admin/app/components/composed/PaginationActions.tsx
+++ b/ui/admin/app/components/composed/PaginationActions.tsx
@@ -1,0 +1,48 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+
+export type PaginationActionsProps = {
+	page: number;
+	nextPage?: number;
+	previousPage?: number;
+	totalPages: number;
+	onPageChange: (page: number) => void;
+};
+
+export function PaginationActions({
+	page,
+	nextPage,
+	previousPage,
+	totalPages,
+	onPageChange,
+}: PaginationActionsProps) {
+	const hasNextPage = nextPage != null;
+	const hasPreviousPage = previousPage != null;
+
+	return (
+		<div className="flex flex-nowrap items-center justify-center gap-2">
+			<Button
+				variant="ghost"
+				size="icon-sm"
+				disabled={!hasPreviousPage}
+				onClick={() => hasPreviousPage && onPageChange(previousPage)}
+			>
+				<ChevronLeft />
+			</Button>
+
+			<p className="min-w-fit">
+				{page + 1} / {totalPages}
+			</p>
+
+			<Button
+				variant="ghost"
+				size="icon-sm"
+				disabled={!hasNextPage}
+				onClick={() => hasNextPage && onPageChange(nextPage)}
+			>
+				<ChevronRight />
+			</Button>
+		</div>
+	);
+}

--- a/ui/admin/app/components/ui/input.tsx
+++ b/ui/admin/app/components/ui/input.tsx
@@ -11,7 +11,7 @@ const InputReset =
 
 const inputVariants = cva(
 	cn(
-		"flex h-9 w-full items-center rounded-md border border-input bg-background text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50 has-[:focus-visible]:ring-1 has-[:focus-visible]:ring-ring"
+		"flex h-9 w-full items-center rounded-md border border-input bg-background text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50 has-[:focus-visible]:ring-1 has-[:focus-visible]:ring-ring [&_svg]:size-[1.375rem]"
 	),
 	{
 		variants: {
@@ -31,10 +31,14 @@ export interface InputProps
 	extends React.InputHTMLAttributes<HTMLInputElement>,
 		VariantProps<typeof inputVariants> {
 	disableToggle?: boolean;
+	startContent?: React.ReactNode;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-	({ className, variant, type, disableToggle = false, ...props }, ref) => {
+	(
+		{ className, variant, type, disableToggle = false, startContent, ...props },
+		ref
+	) => {
 		const isPassword = type === "password";
 		const [isVisible, setIsVisible] = React.useState(false);
 
@@ -51,6 +55,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
 		return (
 			<div className={cn(inputVariants({ variant, className }))}>
+				{startContent && (
+					<div className="flex h-full items-center pl-2">{startContent}</div>
+				)}
+
 				<input
 					type={internalType}
 					data-1p-ignore={!isPassword}

--- a/ui/admin/app/components/ui/skeleton.tsx
+++ b/ui/admin/app/components/ui/skeleton.tsx
@@ -2,13 +2,16 @@ import { cn } from "~/lib/utils";
 
 function Skeleton({
 	className,
+	children,
 	...props
 }: React.HTMLAttributes<HTMLDivElement>) {
 	return (
 		<div
 			className={cn("animate-pulse rounded-md bg-primary/10", className)}
 			{...props}
-		/>
+		>
+			{children && <div className="opacity-0">{children}</div>}
+		</div>
 	);
 }
 

--- a/ui/admin/app/hooks/pagination/usePagination.tsx
+++ b/ui/admin/app/hooks/pagination/usePagination.tsx
@@ -1,0 +1,57 @@
+import { useCallback, useState } from "react";
+
+import { PaginationParams, PaginationService } from "~/lib/service/pagination";
+
+import { useDebounce } from "~/hooks/useDebounce";
+
+type PaginationStoreProps = {
+	initialPage?: number;
+	initialSearch?: string;
+	pageSize: number;
+};
+
+export function usePagination({
+	initialPage = 0,
+	initialSearch,
+	pageSize,
+}: PaginationStoreProps) {
+	const [page, setPage] = useState(initialPage);
+	const [search, setSearch] = useState(initialSearch);
+	const [total, setTotal] = useState(pageSize);
+
+	const updateSearch = useCallback((search: string) => {
+		setSearch(search);
+		setPage(0);
+	}, []);
+
+	const debouncedSearch = useDebounce(updateSearch, 500);
+
+	const pagination = PaginationService.getPaginationInfo({
+		page,
+		pageSize,
+		total,
+	});
+
+	const updateTotal = useCallback(
+		(newTotal?: number) => {
+			if (newTotal != null && newTotal !== total) setTotal(newTotal);
+		},
+		[total]
+	);
+
+	const paginationParams: PaginationParams = {
+		page,
+		pageSize,
+	};
+
+	return {
+		...pagination,
+		paginationParams,
+		search,
+		setPage,
+		setSearch: updateSearch,
+		debouncedSearch,
+		total,
+		updateTotal,
+	};
+}

--- a/ui/admin/app/lib/service/api/invokeService.ts
+++ b/ui/admin/app/lib/service/api/invokeService.ts
@@ -10,8 +10,6 @@ async function invokeAsync({
 	prompt?: Nullish<string>;
 	thread?: Nullish<string>;
 }) {
-	console.log("invokeAsync", slug, prompt, thread);
-
 	const { data } = await request<{ threadID: string }>({
 		url: ApiRoutes.invoke(slug, thread, { async: true }).url,
 		method: "POST",

--- a/ui/admin/app/lib/service/pagination.ts
+++ b/ui/admin/app/lib/service/pagination.ts
@@ -1,0 +1,45 @@
+export type PaginationParams = {
+	page: number;
+	pageSize: number;
+};
+
+export type PaginationInfo = PaginationParams & {
+	totalPages: number;
+	total: number;
+	nextPage?: number;
+	previousPage?: number;
+};
+
+export type Paginated<T> = {
+	items: T[];
+	total: number;
+};
+
+function paginate<T>(items: T[], pagination?: PaginationParams): Paginated<T> {
+	if (!pagination) {
+		return { items, total: items.length };
+	}
+
+	const start = pagination.page * pagination.pageSize;
+	const end = start + pagination.pageSize;
+
+	return { items: items.slice(start, end), total: items.length };
+}
+
+export function getPaginationInfo(
+	pagination: PaginationParams & { total: number }
+): PaginationInfo {
+	const totalPages = Math.ceil(pagination.total / pagination.pageSize);
+
+	const nextPage =
+		pagination.page + 1 >= totalPages ? undefined : pagination.page + 1;
+	const previousPage =
+		pagination.page - 1 >= 0 ? pagination.page - 1 : undefined;
+
+	return { ...pagination, totalPages, nextPage, previousPage };
+}
+
+export const PaginationService = {
+	paginate,
+	getPaginationInfo,
+};


### PR DESCRIPTION
Addresses #1580 
- creates some rough abstractions for client side pagination (used to mock server side pagination until we suport it in backend)
- hooks up pagination to thread files view
- updates skeletons to take children

https://www.loom.com/share/781c47583175404cbef1f5a15adafacd?sid=e0d3edb6-a5d9-4567-97af-f7ff228a70e5