### PR TITLE
fix: allow non-admin access to a user's own thread files

### DIFF
--- a/pkg/api/authz/thread.go
+++ b/pkg/api/authz/thread.go
@@ -43,7 +43,7 @@ func (a *Authorizer) authorizeThreadFileDownload(req *http.Request, user user.In
 	if parts[0] != "" ||
 		parts[1] != "api" ||
 		parts[2] != "threads" ||
-		parts[4] != "file" {
+		parts[4] != "files" {
 		return false
 	}
 


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/1559