### PR TITLE
enhance: use just one auth cookie for Obot

### DIFF
--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -161,7 +162,7 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 	}
 
 	defer func() {
-		go ap.dispatcher.UpdateConfiguredAuthProviders()
+		go ap.dispatcher.UpdateConfiguredAuthProviders(context.Background())
 	}()
 
 	if err := ap.gptscript.CreateCredential(req.Context(), gptscript.Credential{
@@ -207,7 +208,7 @@ func (ap *AuthProviderHandler) Deconfigure(req api.Context) error {
 	}
 
 	defer func() {
-		go ap.dispatcher.UpdateConfiguredAuthProviders()
+		go ap.dispatcher.UpdateConfiguredAuthProviders(context.Background())
 	}()
 
 	// Stop the auth provider so that the credential is completely removed from the system.

--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -160,7 +160,6 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 		}
 	}
 
-	// Tell the dispatcher that it needs to update its list of configured auth providers.
 	defer func() {
 		go ap.dispatcher.UpdateConfiguredAuthProviders()
 	}()

--- a/pkg/gateway/server/oauth.go
+++ b/pkg/gateway/server/oauth.go
@@ -30,10 +30,7 @@ func (s *Server) oauth(apiContext api.Context) error {
 	}
 
 	// Check to make sure this auth provider exists.
-	list, err := s.dispatcher.ListConfiguredAuthProviders(apiContext.Context(), namespace)
-	if err != nil {
-		return fmt.Errorf("could not list configured auth providers: %w", err)
-	} else if !slices.Contains(list, name) {
+	if providerList := s.dispatcher.ListConfiguredAuthProviders(namespace); !slices.Contains(providerList, name) {
 		return types2.NewErrHttp(http.StatusNotFound, "auth provider not found")
 	}
 
@@ -71,10 +68,8 @@ func (s *Server) redirect(apiContext api.Context) error {
 	}
 
 	// Check to make sure this auth provider exists.
-	list, err := s.dispatcher.ListConfiguredAuthProviders(apiContext.Context(), namespace)
-	if err != nil {
-		return fmt.Errorf("could not list configured auth providers: %w", err)
-	} else if !slices.Contains(list, name) {
+
+	if providerList := s.dispatcher.ListConfiguredAuthProviders(namespace); !slices.Contains(providerList, name) {
 		return types2.NewErrHttp(http.StatusNotFound, "auth provider not found")
 	}
 

--- a/pkg/gateway/server/token.go
+++ b/pkg/gateway/server/token.go
@@ -111,10 +111,7 @@ func (s *Server) newToken(apiContext api.Context) error {
 	}
 
 	// Make sure the auth provider exists.
-	list, err := s.dispatcher.ListConfiguredAuthProviders(apiContext.Context(), namespace)
-	if err != nil {
-		return types2.NewErrHttp(http.StatusInternalServerError, fmt.Sprintf("error listing configured auth providers: %v", err))
-	} else if !slices.Contains(list, name) {
+	if providerList := s.dispatcher.ListConfiguredAuthProviders(namespace); !slices.Contains(providerList, name) {
 		return types2.NewErrHttp(http.StatusNotFound, "auth provider not found")
 	}
 
@@ -131,12 +128,7 @@ func (s *Server) tokenRequest(apiContext api.Context) error {
 	}
 
 	if reqObj.ProviderName != "" {
-		list, err := s.dispatcher.ListConfiguredAuthProviders(apiContext.Context(), reqObj.ProviderNamespace)
-		if err != nil {
-			return types2.NewErrHttp(http.StatusInternalServerError, err.Error())
-		}
-
-		if !slices.Contains(list, reqObj.ProviderName) {
+		if providerList := s.dispatcher.ListConfiguredAuthProviders(reqObj.ProviderNamespace); !slices.Contains(providerList, reqObj.ProviderName) {
 			return types2.NewErrHttp(http.StatusBadRequest, fmt.Sprintf("auth provider %q not found", reqObj.ProviderName))
 		}
 	}
@@ -165,12 +157,7 @@ func (s *Server) redirectForTokenRequest(apiContext api.Context) error {
 	name := apiContext.PathValue("name")
 
 	if namespace != "" && name != "" {
-		list, err := s.dispatcher.ListConfiguredAuthProviders(apiContext.Context(), namespace)
-		if err != nil {
-			return types2.NewErrHttp(http.StatusInternalServerError, err.Error())
-		}
-
-		if !slices.Contains(list, name) {
+		if providerList := s.dispatcher.ListConfiguredAuthProviders(namespace); !slices.Contains(providerList, name) {
 			return types2.NewErrHttp(http.StatusBadRequest, fmt.Sprintf("auth provider %q not found", name))
 		}
 	}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -331,7 +331,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 
 	var authenticators authenticator.Request = gatewayServer
 	if config.EnableAuthentication {
-		proxyManager = proxy.NewProxyManager(providerDispatcher)
+		proxyManager = proxy.NewProxyManager(ctx, providerDispatcher)
 
 		// Token Auth + OAuth auth
 		authenticators = union.New(authenticators, proxyManager)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -307,7 +307,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 			tokenServer,
 			events,
 		)
-		providerDispatcher = dispatcher.New(invoker, storageClient, c)
+		providerDispatcher = dispatcher.New(ctx, invoker, storageClient, c)
 
 		proxyManager *proxy.Manager
 	)


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/1630

This is (another) refactoring of how we handle auth cookies. Now, instead of doing one cookie per auth provider, we are just doing one cookie period. We figure out which auth provider is associated with it by storing its hash in a cache, but that only lasts for 24h before it gets removed. If it's not in the cache, we try it with each configured auth provider until we find one that recognizes it, and then we cache that auth provider in association with that token hash.