### PR TITLE
Fix image path typo in Installation doc

### DIFF
--- a/docs/docs/05-installation/00-Installation.md
+++ b/docs/docs/05-installation/00-Installation.md
@@ -48,9 +48,9 @@ There are several ways to install Obot.
 
 Docker is the easiest way to get started with Obot.
 
-The OSS version of Obot image is `ghrc.io/obot-platform/obot:latest`
+The OSS version of Obot image is `ghcr.io/obot-platform/obot:latest`
 
-The Enterprise version of Obot image is `ghrc.io/obot-platform/obot-enterprise:latest`
+The Enterprise version of Obot image is `ghcr.io/obot-platform/obot-enterprise:latest`
 
 For a local installation, you can run the following command:
 


### PR DESCRIPTION
Fix the typo for the image path where `ghcr` was typed as `ghrc`

Existing
`ghrc.io/obot-platform/obot:latest`

Fixed
`ghcr.io/obot-platform/obot:latest`