### PR TITLE
Chore: Refactor tool indexing

### DIFF
--- a/apiclient/types/toolreference.go
+++ b/apiclient/types/toolreference.go
@@ -15,6 +15,7 @@ const (
 type ToolReferenceManifest struct {
 	Name      string            `json:"name"`
 	ToolType  ToolReferenceType `json:"toolType"`
+	Commit    string            `json:"commit,omitempty"`
 	Reference string            `json:"reference,omitempty"`
 	Active    bool              `json:"active,omitempty"`
 }
@@ -22,12 +23,14 @@ type ToolReferenceManifest struct {
 type ToolReference struct {
 	Metadata
 	ToolReferenceManifest
-	Resolved    bool              `json:"resolved,omitempty"`
-	Error       string            `json:"error,omitempty"`
-	Builtin     bool              `json:"builtin,omitempty"`
-	Description string            `json:"description,omitempty"`
-	Credentials []string          `json:"credentials,omitempty"`
-	Params      map[string]string `json:"params,omitempty"`
+	Resolved       bool              `json:"resolved,omitempty"`
+	Error          string            `json:"error,omitempty"`
+	Builtin        bool              `json:"builtin,omitempty"`
+	Description    string            `json:"description,omitempty"`
+	Credentials    []string          `json:"credentials,omitempty"`
+	Params         map[string]string `json:"params,omitempty"`
+	Bundle         bool              `json:"bundle,omitempty"`
+	BundleToolName string            `json:"bundleToolName,omitempty"`
 }
 
 type ToolReferenceList List[ToolReference]

--- a/pkg/api/handlers/toolreferences.go
+++ b/pkg/api/handlers/toolreferences.go
@@ -112,6 +112,8 @@ func (a *ToolReferenceHandler) Create(req api.Context) (err error) {
 		return apierrors.NewBadRequest("reference is required")
 	}
 
+	newToolReference.Reference = strings.TrimPrefix(strings.TrimPrefix(newToolReference.Reference, "https://"), "http://")
+
 	if newToolReference.Name == "" {
 		newToolReference.Name, err = a.pickNameForReference(req, newToolReference.Reference)
 		if err != nil {
@@ -138,11 +140,12 @@ func (a *ToolReferenceHandler) Create(req api.Context) (err error) {
 
 	for _, toolRef := range toolRefs {
 		if err := req.Create(toolRef); err != nil && !apierrors.IsAlreadyExists(err) {
-			return apierrors.NewInternalError(fmt.Errorf("failed to create tool reference %s: %w", toolRef.Name, err))
+			return apierrors.NewInternalError(fmt.Errorf("failed to create tool reference %s: %w", toolRef.GetName(), err))
 		}
 	}
 
-	return req.Write(convertToolReference(*toolRefs[0]))
+	toolRef := toolRefs[0].(*v1.ToolReference)
+	return req.Write(convertToolReference(*toolRef))
 }
 
 func (a *ToolReferenceHandler) Delete(req api.Context) error {

--- a/pkg/api/handlers/toolreferences.go
+++ b/pkg/api/handlers/toolreferences.go
@@ -12,6 +12,7 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/tools"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -33,10 +34,13 @@ func convertToolReference(toolRef v1.ToolReference) types.ToolReference {
 			Name:      toolRef.Name,
 			ToolType:  toolRef.Spec.Type,
 			Reference: toolRef.Spec.Reference,
+			Commit:    toolRef.Status.Commit,
 		},
-		Builtin:  toolRef.Spec.Builtin,
-		Error:    toolRef.Status.Error,
-		Resolved: toolRef.Generation == toolRef.Status.ObservedGeneration,
+		Builtin:        toolRef.Spec.Builtin,
+		Bundle:         toolRef.Spec.Bundle,
+		BundleToolName: toolRef.Spec.BundleToolName,
+		Error:          toolRef.Status.Error,
+		Resolved:       toolRef.Generation == toolRef.Status.ObservedGeneration,
 	}
 	if toolRef.Spec.Active == nil {
 		tf.Active = true
@@ -123,22 +127,22 @@ func (a *ToolReferenceHandler) Create(req api.Context) (err error) {
 		return apierrors.NewBadRequest(fmt.Sprintf("invalid tool type %s", newToolReference.ToolType))
 	}
 
-	toolRef := &v1.ToolReference{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      newToolReference.Name,
-			Namespace: req.Namespace(),
-		},
-		Spec: v1.ToolReferenceSpec{
-			Type:      newToolReference.ToolType,
-			Reference: newToolReference.Reference,
-		},
+	toolRefs, err := tools.ResolveToolReferences(req.Context(), a.gptscript, newToolReference.Name, newToolReference.Reference, false, newToolReference.ToolType)
+	if err != nil {
+		return apierrors.NewBadRequest(fmt.Sprintf("failed to resolve tool references for %s: %v", newToolReference.Reference, err))
 	}
 
-	if err = req.Create(toolRef); err != nil {
-		return err
+	if len(toolRefs) == 0 {
+		return apierrors.NewBadRequest(fmt.Sprintf("no tool references found for %s", newToolReference.Reference))
 	}
 
-	return req.Write(convertToolReference(*toolRef))
+	for _, toolRef := range toolRefs {
+		if err := req.Create(toolRef); err != nil && !apierrors.IsAlreadyExists(err) {
+			return apierrors.NewInternalError(fmt.Errorf("failed to create tool reference %s: %w", toolRef.Name, err))
+		}
+	}
+
+	return req.Write(convertToolReference(*toolRefs[0]))
 }
 
 func (a *ToolReferenceHandler) Delete(req api.Context) error {
@@ -164,6 +168,10 @@ func (a *ToolReferenceHandler) Delete(req api.Context) error {
 
 	if toolRef.Spec.Builtin {
 		return types.NewErrBadRequest("cannot delete builtin tool reference %s", id)
+	}
+
+	if !toolRef.Spec.Bundle {
+		return types.NewErrBadRequest("cannot delete child tool that belongs to a bundle tool")
 	}
 
 	return req.Delete(&v1.ToolReference{

--- a/pkg/api/handlers/toolreferences.go
+++ b/pkg/api/handlers/toolreferences.go
@@ -112,8 +112,6 @@ func (a *ToolReferenceHandler) Create(req api.Context) (err error) {
 		return apierrors.NewBadRequest("reference is required")
 	}
 
-	newToolReference.Reference = strings.TrimPrefix(strings.TrimPrefix(newToolReference.Reference, "https://"), "http://")
-
 	if newToolReference.Name == "" {
 		newToolReference.Name, err = a.pickNameForReference(req, newToolReference.Reference)
 		if err != nil {

--- a/pkg/api/handlers/toolreferences.go
+++ b/pkg/api/handlers/toolreferences.go
@@ -129,7 +129,7 @@ func (a *ToolReferenceHandler) Create(req api.Context) (err error) {
 		return apierrors.NewBadRequest(fmt.Sprintf("invalid tool type %s", newToolReference.ToolType))
 	}
 
-	toolRefs, err := tools.ResolveToolReferences(req.Context(), a.gptscript, newToolReference.Name, newToolReference.Reference, false, newToolReference.ToolType)
+	toolRefs, err := tools.ResolveToolReferences(req.Context(), a.gptscript, newToolReference.Name, newToolReference.Reference, "", false, newToolReference.ToolType)
 	if err != nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("failed to resolve tool references for %s: %v", newToolReference.Reference, err))
 	}

--- a/pkg/api/handlers/toolreferences.go
+++ b/pkg/api/handlers/toolreferences.go
@@ -142,8 +142,7 @@ func (a *ToolReferenceHandler) Create(req api.Context) (err error) {
 		}
 	}
 
-	toolRef := toolRefs[0].(*v1.ToolReference)
-	return req.Write(convertToolReference(*toolRef))
+	return req.Write(convertToolReference(*toolRefs[0]))
 }
 
 func (a *ToolReferenceHandler) Delete(req api.Context) error {
@@ -171,7 +170,7 @@ func (a *ToolReferenceHandler) Delete(req api.Context) error {
 		return types.NewErrBadRequest("cannot delete builtin tool reference %s", id)
 	}
 
-	if !toolRef.Spec.Bundle {
+	if !toolRef.Spec.Bundle && toolRef.Spec.BundleToolName != "" {
 		return types.NewErrBadRequest("cannot delete child tool that belongs to a bundle tool")
 	}
 

--- a/pkg/api/handlers/toolreferences.go
+++ b/pkg/api/handlers/toolreferences.go
@@ -129,7 +129,7 @@ func (a *ToolReferenceHandler) Create(req api.Context) (err error) {
 		return apierrors.NewBadRequest(fmt.Sprintf("invalid tool type %s", newToolReference.ToolType))
 	}
 
-	toolRefs, err := tools.ResolveToolReferences(req.Context(), a.gptscript, newToolReference.Name, newToolReference.Reference, "", false, newToolReference.ToolType)
+	toolRefs, err := tools.ResolveToolReferences(req.Context(), a.gptscript, newToolReference.Name, newToolReference.Reference, false, newToolReference.ToolType)
 	if err != nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("failed to resolve tool references for %s: %v", newToolReference.Reference, err))
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -40,6 +40,9 @@ func (c *Controller) PreStart(ctx context.Context) error {
 	if err := data.Data(ctx, c.services.StorageClient, c.services.AgentsDir); err != nil {
 		return fmt.Errorf("failed to apply data: %w", err)
 	}
+	if err := toolreference.MigrateToolNames(ctx, c.services.StorageClient); err != nil {
+		return fmt.Errorf("failed to migrate tool names: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/controller/handlers/toolreference/migrate.go
+++ b/pkg/controller/handlers/toolreference/migrate.go
@@ -1,46 +1,83 @@
 package toolreference
 
 import (
-	"github.com/obot-platform/nah/pkg/router"
+	"context"
+	"errors"
+
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var toolMigrations = map[string]string{
 	"file-summarizer-file-summarizer": "file-summarizer",
 }
 
-func (h *Handler) MigrateToolNames(req router.Request, _ router.Response) error {
+func MigrateToolNames(ctx context.Context, client kclient.Client) error {
 	if len(toolMigrations) == 0 {
 		return nil
 	}
 
+	var agents v1.AgentList
+	if err := client.List(ctx, &agents); err != nil {
+		return err
+	}
+
+	var workflows v1.WorkflowList
+	if err := client.List(ctx, &workflows); err != nil {
+		return err
+	}
+
+	var threads v1.ThreadList
+	if err := client.List(ctx, &threads); err != nil {
+		return err
+	}
+
+	var workflowSteps v1.WorkflowStepList
+	if err := client.List(ctx, &workflowSteps); err != nil {
+		return err
+	}
+
+	var objs []kclient.Object
+	for _, agent := range agents.Items {
+		objs = append(objs, &agent)
+	}
+	for _, workflow := range workflows.Items {
+		objs = append(objs, &workflow)
+	}
+	for _, thread := range threads.Items {
+		objs = append(objs, &thread)
+	}
+	for _, step := range workflowSteps.Items {
+		objs = append(objs, &step)
+	}
+
 	var tools []string
-
-	switch o := req.Object.(type) {
-	case *v1.Agent:
-		tools = o.Spec.Manifest.Tools
-	case *v1.Workflow:
-		tools = o.Spec.Manifest.Tools
-	case *v1.Thread:
-		tools = o.Spec.Manifest.Tools
-	case *v1.WorkflowStep:
-		tools = o.Spec.Step.Tools
-
-	default:
-		return nil
-	}
-
-	modified := false
-	for i, tool := range tools {
-		if newName, shouldMigrate := toolMigrations[tool]; shouldMigrate {
-			tools[i] = newName
-			modified = true
+	var errs []error
+	for _, obj := range objs {
+		switch o := obj.(type) {
+		case *v1.Agent:
+			tools = o.Spec.Manifest.Tools
+		case *v1.Workflow:
+			tools = o.Spec.Manifest.Tools
+		case *v1.Thread:
+			tools = o.Spec.Manifest.Tools
+		case *v1.WorkflowStep:
+			tools = o.Spec.Step.Tools
 		}
+		modified := false
+		for i, tool := range tools {
+			if newName, shouldMigrate := toolMigrations[tool]; shouldMigrate {
+				tools[i] = newName
+				modified = true
+			}
+		}
+
+		if !modified {
+			continue
+		}
+
+		errs = append(errs, client.Update(ctx, obj))
 	}
 
-	if !modified {
-		return nil
-	}
-
-	return req.Client.Update(req.Ctx, req.Object)
+	return errors.Join(errs...)
 }

--- a/pkg/controller/handlers/toolreference/migrate.go
+++ b/pkg/controller/handlers/toolreference/migrate.go
@@ -21,6 +21,11 @@ func (h *Handler) MigrateToolNames(req router.Request, _ router.Response) error 
 		tools = o.Spec.Manifest.Tools
 	case *v1.Workflow:
 		tools = o.Spec.Manifest.Tools
+	case *v1.Thread:
+		tools = o.Spec.Manifest.Tools
+	case *v1.WorkflowStep:
+		tools = o.Spec.Step.Tools
+
 	default:
 		return nil
 	}
@@ -42,6 +47,10 @@ func (h *Handler) MigrateToolNames(req router.Request, _ router.Response) error 
 		o.Spec.Manifest.Tools = tools
 	case *v1.Workflow:
 		o.Spec.Manifest.Tools = tools
+	case *v1.Thread:
+		o.Spec.Manifest.Tools = tools
+	case *v1.WorkflowStep:
+		o.Spec.Step.Tools = tools
 	}
 
 	return req.Client.Update(req.Ctx, req.Object)

--- a/pkg/controller/handlers/toolreference/migrate.go
+++ b/pkg/controller/handlers/toolreference/migrate.go
@@ -42,16 +42,5 @@ func (h *Handler) MigrateToolNames(req router.Request, _ router.Response) error 
 		return nil
 	}
 
-	switch o := req.Object.(type) {
-	case *v1.Agent:
-		o.Spec.Manifest.Tools = tools
-	case *v1.Workflow:
-		o.Spec.Manifest.Tools = tools
-	case *v1.Thread:
-		o.Spec.Manifest.Tools = tools
-	case *v1.WorkflowStep:
-		o.Spec.Step.Tools = tools
-	}
-
 	return req.Client.Update(req.Ctx, req.Object)
 }

--- a/pkg/controller/handlers/toolreference/migrate.go
+++ b/pkg/controller/handlers/toolreference/migrate.go
@@ -1,0 +1,48 @@
+package toolreference
+
+import (
+	"github.com/obot-platform/nah/pkg/router"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+)
+
+var toolMigrations = map[string]string{
+	"file-summarizer-file-summarizer": "file-summarizer",
+}
+
+func (h *Handler) MigrateToolNames(req router.Request, resp router.Response) error {
+	if len(toolMigrations) == 0 {
+		return nil
+	}
+
+	var tools []string
+
+	switch o := req.Object.(type) {
+	case *v1.Agent:
+		tools = o.Spec.Manifest.Tools
+	case *v1.Workflow:
+		tools = o.Spec.Manifest.Tools
+	default:
+		return nil
+	}
+
+	modified := false
+	for i, tool := range tools {
+		if newName, shouldMigrate := toolMigrations[tool]; shouldMigrate {
+			tools[i] = newName
+			modified = true
+		}
+	}
+
+	if !modified {
+		return nil
+	}
+
+	switch o := req.Object.(type) {
+	case *v1.Agent:
+		o.Spec.Manifest.Tools = tools
+	case *v1.Workflow:
+		o.Spec.Manifest.Tools = tools
+	}
+
+	return req.Client.Update(req.Ctx, req.Object)
+}

--- a/pkg/controller/handlers/toolreference/migrate.go
+++ b/pkg/controller/handlers/toolreference/migrate.go
@@ -9,7 +9,7 @@ var toolMigrations = map[string]string{
 	"file-summarizer-file-summarizer": "file-summarizer",
 }
 
-func (h *Handler) MigrateToolNames(req router.Request, resp router.Response) error {
+func (h *Handler) MigrateToolNames(req router.Request, _ router.Response) error {
 	if len(toolMigrations) == 0 {
 		return nil
 	}

--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -80,14 +80,10 @@ func (h *Handler) toolsToToolReferences(ctx context.Context, toolType types.Tool
 			continue
 		}
 
-		toolRefs, err := tools.ResolveToolReferences(ctx, h.gptClient, name, entry.Reference, true, toolType)
+		toolRefs, err := tools.ResolveToolReferences(ctx, h.gptClient, name, entry.Reference, entry.NameOverride, true, toolType)
 		if err != nil {
 			log.Errorf("Failed to resolve tool references for %s: %v", entry.Reference, err)
 			continue
-		}
-
-		if entry.NameOverride != "" {
-			toolRefs[0].SetName(entry.NameOverride)
 		}
 
 		result = append(result, toolRefs...)

--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -87,12 +87,10 @@ func (h *Handler) toolsToToolReferences(ctx context.Context, toolType types.Tool
 		}
 
 		if entry.NameOverride != "" {
-			toolRefs[0].Name = entry.NameOverride
+			toolRefs[0].SetName(entry.NameOverride)
 		}
 
-		for _, toolRef := range toolRefs {
-			result = append(result, toolRef)
-		}
+		result = append(result, toolRefs...)
 	}
 
 	return

--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -36,9 +36,6 @@ var jsonErrRegexp = regexp.MustCompile(`\{.*"error":.*}`)
 
 type indexEntry struct {
 	Reference string `json:"reference,omitempty"`
-
-	// NameOverride is used to override the name of the top-level tool reference.
-	NameOverride string `json:"nameOverride,omitempty"`
 }
 
 type index struct {
@@ -80,7 +77,7 @@ func (h *Handler) toolsToToolReferences(ctx context.Context, toolType types.Tool
 			continue
 		}
 
-		toolRefs, err := tools.ResolveToolReferences(ctx, h.gptClient, name, entry.Reference, entry.NameOverride, true, toolType)
+		toolRefs, err := tools.ResolveToolReferences(ctx, h.gptClient, name, entry.Reference, true, toolType)
 		if err != nil {
 			log.Errorf("Failed to resolve tool references for %s: %v", entry.Reference, err)
 			continue

--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -83,7 +83,9 @@ func (h *Handler) toolsToToolReferences(ctx context.Context, toolType types.Tool
 			continue
 		}
 
-		result = append(result, toolRefs...)
+		for _, toolRef := range toolRefs {
+			result = append(result, toolRef)
+		}
 	}
 
 	return

--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -23,6 +23,7 @@ import (
 	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	"github.com/obot-platform/obot/pkg/tools"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,7 +36,9 @@ var jsonErrRegexp = regexp.MustCompile(`\{.*"error":.*}`)
 
 type indexEntry struct {
 	Reference string `json:"reference,omitempty"`
-	All       bool   `json:"all,omitempty"`
+
+	// NameOverride is used to override the name of the top-level tool reference.
+	NameOverride string `json:"nameOverride,omitempty"`
 }
 
 type index struct {
@@ -68,93 +71,27 @@ func New(gptClient *gptscript.GPTScript,
 	}
 }
 
-func isValidTool(tool gptscript.Tool) bool {
-	if tool.MetaData["index"] == "false" {
-		return false
-	}
-	return tool.Name != "" && (tool.Type == "" || tool.Type == "tool")
-}
-
 func (h *Handler) toolsToToolReferences(ctx context.Context, toolType types.ToolReferenceType, registryURL string, entries map[string]indexEntry) (result []client.Object) {
-	annotations := map[string]string{
-		"obot.obot.ai/timestamp": time.Now().String(),
-	}
 	for name, entry := range entries {
 		if ref, ok := strings.CutPrefix(entry.Reference, "./"); ok {
 			entry.Reference = registryURL + "/" + ref
 		}
+		if !h.supportDocker && name == system.ShellTool {
+			continue
+		}
 
-		if entry.All {
-			prg, err := h.gptClient.LoadFile(ctx, "* from "+entry.Reference)
-			if err != nil {
-				log.Errorf("Failed to load tool %s: %v", entry.Reference, err)
-				continue
-			}
+		toolRefs, err := tools.ResolveToolReferences(ctx, h.gptClient, name, entry.Reference, true, toolType)
+		if err != nil {
+			log.Errorf("Failed to resolve tool references for %s: %v", entry.Reference, err)
+			continue
+		}
 
-			tool := prg.ToolSet[prg.EntryToolID]
-			if isValidTool(tool) {
-				toolName := tool.Name
-				if tool.MetaData["bundle"] == "true" {
-					toolName = "bundle"
-				}
-				result = append(result, &v1.ToolReference{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        normalize(name, toolName),
-						Namespace:   system.DefaultNamespace,
-						Finalizers:  []string{v1.ToolReferenceFinalizer},
-						Annotations: annotations,
-					},
-					Spec: v1.ToolReferenceSpec{
-						Type:      toolType,
-						Reference: entry.Reference,
-						Builtin:   true,
-					},
-				})
-			}
-			for _, peerToolID := range tool.LocalTools {
-				// If this is the entry tool, then we already added it or skipped it above.
-				if peerToolID == prg.EntryToolID {
-					continue
-				}
+		if entry.NameOverride != "" {
+			toolRefs[0].Name = entry.NameOverride
+		}
 
-				peerTool := prg.ToolSet[peerToolID]
-				if isValidTool(peerTool) {
-					toolName := peerTool.Name
-					if peerTool.MetaData["bundle"] == "true" {
-						toolName += "-bundle"
-					}
-					result = append(result, &v1.ToolReference{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:        normalize(name, toolName),
-							Namespace:   system.DefaultNamespace,
-							Finalizers:  []string{v1.ToolReferenceFinalizer},
-							Annotations: annotations,
-						},
-						Spec: v1.ToolReferenceSpec{
-							Type:      toolType,
-							Reference: fmt.Sprintf("%s from %s", peerTool.Name, entry.Reference),
-							Builtin:   true,
-						},
-					})
-				}
-			}
-		} else {
-			if !h.supportDocker && name == system.ShellTool {
-				continue
-			}
-			result = append(result, &v1.ToolReference{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        name,
-					Namespace:   system.DefaultNamespace,
-					Finalizers:  []string{v1.ToolReferenceFinalizer},
-					Annotations: annotations,
-				},
-				Spec: v1.ToolReferenceSpec{
-					Type:      toolType,
-					Reference: entry.Reference,
-					Builtin:   true,
-				},
-			})
+		for _, toolRef := range toolRefs {
+			result = append(result, toolRef)
 		}
 	}
 
@@ -215,10 +152,6 @@ func (h *Handler) readFromRegistry(ctx context.Context, c client.Client) error {
 	return apply.New(c).WithOwnerSubContext("toolreferences").Apply(ctx, nil, toAdd...)
 }
 
-func normalize(names ...string) string {
-	return strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(strings.Join(names, "-"), " ", "-"), "_", "-"))
-}
-
 func (h *Handler) PollRegistries(ctx context.Context, c client.Client) {
 	if len(h.registryURLs) < 1 {
 		return
@@ -251,6 +184,7 @@ func (h *Handler) Populate(req router.Request, resp router.Response) error {
 	toolRef.Status.LastReferenceCheck = metav1.Now()
 	toolRef.Status.ObservedGeneration = toolRef.Generation
 	toolRef.Status.Reference = toolRef.Spec.Reference
+	toolRef.Status.Commit = ""
 	toolRef.Status.Tool = nil
 	toolRef.Status.Error = ""
 
@@ -268,6 +202,9 @@ func (h *Handler) Populate(req router.Request, resp router.Response) error {
 		Description: tool.Description,
 		Metadata:    tool.MetaData,
 		Params:      map[string]string{},
+	}
+	if tool.Source.Repo != nil {
+		toolRef.Status.Commit = tool.Source.Repo.Revision
 	}
 	if tool.Arguments != nil {
 		for name, param := range tool.Arguments.Properties {

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -62,6 +62,7 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Thread{}).HandlerFunc(threads.CreateKnowledgeSet)
 	root.Type(&v1.Thread{}).HandlerFunc(threads.WorkflowState)
 	root.Type(&v1.Thread{}).HandlerFunc(knowledgesummary.Summarize)
+	root.Type(&v1.Thread{}).HandlerFunc(toolRef.MigrateToolNames)
 	root.Type(&v1.Thread{}).FinalizeFunc(v1.ThreadFinalizer, credentialCleanup.Remove)
 
 	// KnowledgeSummary
@@ -169,6 +170,7 @@ func (c *Controller) setupRoutes() error {
 	steps.HandlerFunc(changeWorkflowStepOwnerGVK)
 	steps.HandlerFunc(cleanup.Cleanup)
 	steps.HandlerFunc(handlers.GCOrphans)
+	steps.HandlerFunc(toolRef.MigrateToolNames)
 
 	running := steps.Middleware(workflowStep.Preconditions)
 	running.HandlerFunc(workflowStep.RunInvoke)

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -98,6 +98,7 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.KnowledgeSource{}).HandlerFunc(knowledgesource.Sync)
 
 	// ToolReferences
+	root.Type(&v1.ToolReference{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.ToolReference{}).HandlerFunc(toolRef.Populate)
 	root.Type(&v1.ToolReference{}).HandlerFunc(toolRef.BackPopulateModels)
 	root.Type(&v1.ToolReference{}).IncludeFinalizing().HandlerFunc(removeOldFinalizers)

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -75,6 +75,7 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Workflow{}).HandlerFunc(alias.AssignAlias)
 	root.Type(&v1.Workflow{}).HandlerFunc(toolInfo.SetToolInfoStatus)
 	root.Type(&v1.Workflow{}).HandlerFunc(generationed.UpdateObservedGeneration)
+	root.Type(&v1.Workflow{}).HandlerFunc(toolRef.MigrateToolNames)
 	root.Type(&v1.Workflow{}).FinalizeFunc(v1.WorkflowFinalizer, credentialCleanup.Remove)
 
 	// WorkflowExecutions
@@ -88,6 +89,7 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Agent{}).HandlerFunc(alias.AssignAlias)
 	root.Type(&v1.Agent{}).HandlerFunc(toolInfo.SetToolInfoStatus)
 	root.Type(&v1.Agent{}).HandlerFunc(generationed.UpdateObservedGeneration)
+	root.Type(&v1.Agent{}).HandlerFunc(toolRef.MigrateToolNames)
 	root.Type(&v1.Agent{}).FinalizeFunc(v1.AgentFinalizer, credentialCleanup.Remove)
 
 	// Uploads

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -62,7 +62,6 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Thread{}).HandlerFunc(threads.CreateKnowledgeSet)
 	root.Type(&v1.Thread{}).HandlerFunc(threads.WorkflowState)
 	root.Type(&v1.Thread{}).HandlerFunc(knowledgesummary.Summarize)
-	root.Type(&v1.Thread{}).HandlerFunc(toolRef.MigrateToolNames)
 	root.Type(&v1.Thread{}).FinalizeFunc(v1.ThreadFinalizer, credentialCleanup.Remove)
 
 	// KnowledgeSummary
@@ -76,7 +75,6 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Workflow{}).HandlerFunc(alias.AssignAlias)
 	root.Type(&v1.Workflow{}).HandlerFunc(toolInfo.SetToolInfoStatus)
 	root.Type(&v1.Workflow{}).HandlerFunc(generationed.UpdateObservedGeneration)
-	root.Type(&v1.Workflow{}).HandlerFunc(toolRef.MigrateToolNames)
 	root.Type(&v1.Workflow{}).FinalizeFunc(v1.WorkflowFinalizer, credentialCleanup.Remove)
 
 	// WorkflowExecutions
@@ -90,7 +88,6 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Agent{}).HandlerFunc(alias.AssignAlias)
 	root.Type(&v1.Agent{}).HandlerFunc(toolInfo.SetToolInfoStatus)
 	root.Type(&v1.Agent{}).HandlerFunc(generationed.UpdateObservedGeneration)
-	root.Type(&v1.Agent{}).HandlerFunc(toolRef.MigrateToolNames)
 	root.Type(&v1.Agent{}).FinalizeFunc(v1.AgentFinalizer, credentialCleanup.Remove)
 
 	// Uploads
@@ -170,7 +167,6 @@ func (c *Controller) setupRoutes() error {
 	steps.HandlerFunc(changeWorkflowStepOwnerGVK)
 	steps.HandlerFunc(cleanup.Cleanup)
 	steps.HandlerFunc(handlers.GCOrphans)
-	steps.HandlerFunc(toolRef.MigrateToolNames)
 
 	running := steps.Middleware(workflowStep.Preconditions)
 	running.HandlerFunc(workflowStep.RunInvoke)

--- a/pkg/storage/apis/obot.obot.ai/v1/toolreference.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/toolreference.go
@@ -48,6 +48,12 @@ func (in *ToolReference) GetColumns() [][]string {
 	}
 }
 
+func (in *ToolReference) DeleteRefs() []Ref {
+	return []Ref{
+		{ObjType: new(ToolReference), Name: in.Spec.BundleToolName},
+	}
+}
+
 type ToolReferenceSpec struct {
 	Type           types.ToolReferenceType `json:"type,omitempty"`
 	Builtin        bool                    `json:"builtin,omitempty"`

--- a/pkg/storage/apis/obot.obot.ai/v1/toolreference.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/toolreference.go
@@ -49,11 +49,13 @@ func (in *ToolReference) GetColumns() [][]string {
 }
 
 type ToolReferenceSpec struct {
-	Type         types.ToolReferenceType `json:"type,omitempty"`
-	Builtin      bool                    `json:"builtin,omitempty"`
-	Reference    string                  `json:"reference,omitempty"`
-	Active       *bool                   `json:"active,omitempty"`
-	ForceRefresh metav1.Time             `json:"forceRefresh,omitempty"`
+	Type           types.ToolReferenceType `json:"type,omitempty"`
+	Builtin        bool                    `json:"builtin,omitempty"`
+	Reference      string                  `json:"reference,omitempty"`
+	Active         *bool                   `json:"active,omitempty"`
+	Bundle         bool                    `json:"bundle,omitempty"`
+	BundleToolName string                  `json:"bundleToolName,omitempty"`
+	ForceRefresh   metav1.Time             `json:"forceRefresh,omitempty"`
 }
 
 type ToolShortDescription struct {
@@ -70,6 +72,7 @@ type ToolShortDescription struct {
 
 type ToolReferenceStatus struct {
 	Reference          string                `json:"reference,omitempty"`
+	Commit             string                `json:"commit,omitempty"`
 	ObservedGeneration int64                 `json:"observedGeneration,omitempty"`
 	LastReferenceCheck metav1.Time           `json:"lastReferenceCheck,omitempty"`
 	Tool               *ToolShortDescription `json:"tool,omitempty"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -4318,6 +4318,18 @@ func schema_obot_platform_obot_apiclient_types_ToolReference(ref common.Referenc
 							},
 						},
 					},
+					"bundle": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"bundleToolName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"Metadata", "ToolReferenceManifest"},
 			},
@@ -4373,6 +4385,12 @@ func schema_obot_platform_obot_apiclient_types_ToolReferenceManifest(ref common.
 							Default: "",
 							Type:    []string{"string"},
 							Format:  "",
+						},
+					},
+					"commit": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"reference": {
@@ -8534,6 +8552,18 @@ func schema_storage_apis_obotobotai_v1_ToolReferenceSpec(ref common.ReferenceCal
 							Format: "",
 						},
 					},
+					"bundle": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"bundleToolName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"forceRefresh": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
@@ -8554,6 +8584,12 @@ func schema_storage_apis_obotobotai_v1_ToolReferenceStatus(ref common.ReferenceC
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"reference": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"commit": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/pkg/tools/resolve.go
+++ b/pkg/tools/resolve.go
@@ -1,0 +1,103 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gptscript-ai/go-gptscript"
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ResolveToolReferences(ctx context.Context, gptClient *gptscript.GPTScript, name, reference string, builtin bool, toolType types.ToolReferenceType) ([]*v1.ToolReference, error) {
+	annotations := map[string]string{
+		"obot.obot.ai/timestamp": time.Now().String(),
+	}
+
+	var result []*v1.ToolReference
+
+	prg, err := gptClient.LoadFile(ctx, reference)
+	if err != nil {
+		return nil, err
+	}
+
+	tool := prg.ToolSet[prg.EntryToolID]
+	isCapability := tool.MetaData["category"] == "Capability"
+	isBundleTool := false
+	if len(tool.LocalTools) > 1 {
+		isBundleTool = true
+	}
+
+	toolName := resolveToolReferenceName(toolType, isBundleTool, isCapability, name, tool.Name)
+	entryTool := &v1.ToolReference{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        toolName,
+			Namespace:   system.DefaultNamespace,
+			Finalizers:  []string{v1.ToolReferenceFinalizer},
+			Annotations: annotations,
+		},
+		Spec: v1.ToolReferenceSpec{
+			Type:      toolType,
+			Reference: reference,
+			Builtin:   builtin,
+			Bundle:    isBundleTool,
+		},
+	}
+	result = append(result, entryTool)
+
+	for _, peerToolID := range tool.LocalTools {
+		if peerToolID == prg.EntryToolID {
+			continue
+		}
+
+		peerTool := prg.ToolSet[peerToolID]
+		if isValidTool(peerTool) {
+			toolName = resolveToolReferenceName(toolType, false, peerTool.MetaData["category"] == "Capability", name, peerTool.Name)
+			result = append(result, &v1.ToolReference{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        toolName,
+					Namespace:   system.DefaultNamespace,
+					Finalizers:  []string{v1.ToolReferenceFinalizer},
+					Annotations: annotations,
+				},
+				Spec: v1.ToolReferenceSpec{
+					Type:           toolType,
+					Reference:      fmt.Sprintf("%s from %s", peerTool.Name, reference),
+					Builtin:        builtin,
+					BundleToolName: entryTool.Name,
+				},
+			})
+		}
+	}
+
+	return result, nil
+}
+
+func resolveToolReferenceName(toolType types.ToolReferenceType, isBundle bool, isCapability bool, toolName, subToolName string) string {
+	if toolType == types.ToolReferenceTypeTool {
+		if isBundle {
+			if isCapability {
+				return toolName
+			}
+			return toolName + "-bundle"
+		}
+		return normalize(toolName, subToolName)
+	}
+
+	return toolName
+}
+
+func normalize(names ...string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(strings.Join(names, "-"), " ", "-"), "_", "-"))
+}
+
+func isValidTool(tool gptscript.Tool) bool {
+	if tool.MetaData["index"] == "false" {
+		return false
+	}
+	return tool.Name != "" && (tool.Type == "" || tool.Type == "tool")
+}

--- a/pkg/tools/resolve.go
+++ b/pkg/tools/resolve.go
@@ -11,15 +11,14 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ResolveToolReferences(ctx context.Context, gptClient *gptscript.GPTScript, name, reference string, builtin bool, toolType types.ToolReferenceType) ([]client.Object, error) {
+func ResolveToolReferences(ctx context.Context, gptClient *gptscript.GPTScript, name, reference string, builtin bool, toolType types.ToolReferenceType) ([]*v1.ToolReference, error) {
 	annotations := map[string]string{
 		"obot.obot.ai/timestamp": time.Now().String(),
 	}
 
-	var result []client.Object
+	var result []*v1.ToolReference
 
 	prg, err := gptClient.LoadFile(ctx, reference)
 	if err != nil {

--- a/ui/admin/app/components/tools/ToolItem.tsx
+++ b/ui/admin/app/components/tools/ToolItem.tsx
@@ -95,10 +95,10 @@ export function ToolItem({
 								<ToolIcon
 									icon={tool.metadata?.icon}
 									category={tool.metadata?.category}
-									name={tool.name}
+									name={tool.name || normalizeToolID(tool.id)}
 									className="mr-2 h-4 w-4"
 								/>
-								{tool.name}
+								{tool.name || normalizeToolID(tool.id)}
 							</span>
 						</span>
 
@@ -137,4 +137,8 @@ export function ToolItem({
 			)}
 		</>
 	);
+}
+
+function normalizeToolID(toolId: string) {
+	return toolId.replace(/-/g, " ");
 }

--- a/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
+++ b/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
@@ -1,3 +1,5 @@
+import { GitCommitIcon } from "lucide-react";
+
 import { ToolReference } from "~/lib/model/toolReferences";
 import { cn } from "~/lib/utils/cn";
 
@@ -5,7 +7,12 @@ import { Truncate } from "~/components/composed/typography";
 import { ToolIcon } from "~/components/tools/ToolIcon";
 import { ToolCardActions } from "~/components/tools/toolGrid/ToolCardActions";
 import { Button } from "~/components/ui/button";
-import { Card, CardContent, CardHeader } from "~/components/ui/card";
+import {
+	Card,
+	CardContent,
+	CardFooter,
+	CardHeader,
+} from "~/components/ui/card";
 import {
 	Popover,
 	PopoverContent,
@@ -82,6 +89,43 @@ export function ToolCard({
 					</Truncate>
 				)}
 			</CardContent>
+			{tool.commit && (
+				<CardFooter className="flex justify-end">
+					<Popover>
+						<PopoverTrigger asChild>
+							<Button size="icon" variant="ghost">
+								<GitCommitIcon className="h-4 w-4" />
+							</Button>
+						</PopoverTrigger>
+						<PopoverContent>
+							<div className="flex flex-col gap-2">
+								<p className="break-all text-sm text-muted-foreground">
+									Commit:{" "}
+									{tool.reference?.startsWith("github.com") ? (
+										<a
+											href={`https://${(() => {
+												const parts = tool.reference.split("/");
+												if (parts.length >= 3) {
+													const [org, repo, ...rest] = parts.slice(1);
+													return `github.com/${org}/${repo}/blob/${tool.commit}/${rest.join("/")}/tool.gpt`;
+												}
+												return tool.reference;
+											})()}`}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="text-blue-500 hover:underline"
+										>
+											{tool.commit}
+										</a>
+									) : (
+										tool.commit
+									)}
+								</p>
+							</div>
+						</PopoverContent>
+					</Popover>
+				</CardFooter>
+			)}
 		</Card>
 	);
 }

--- a/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
+++ b/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
@@ -18,6 +18,12 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "~/components/ui/popover";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "~/components/ui/tooltip";
 
 export function ToolCard({
 	tool,
@@ -26,6 +32,17 @@ export function ToolCard({
 	tool: ToolReference;
 	HeaderRightContent?: React.ReactNode;
 }) {
+	const getToolCommitURL = (tool: ToolReference) => {
+		if (tool.reference?.startsWith("github.com")) {
+			const parts = tool.reference.split("/");
+			const [org, repo, ...rest] = parts.slice(1);
+			const path = rest.join("/");
+			const pathWithGpt = path.endsWith(".gpt") ? path : `${path}/tool.gpt`;
+			return `https://github.com/${org}/${repo}/blob/${tool.commit}/${pathWithGpt}`;
+		}
+		return tool.reference;
+	};
+
 	return (
 		<Card
 			key={tool.id}
@@ -91,39 +108,28 @@ export function ToolCard({
 			</CardContent>
 			{tool.commit && (
 				<CardFooter className="flex justify-end">
-					<Popover>
-						<PopoverTrigger asChild>
-							<Button size="icon" variant="ghost">
-								<GitCommitIcon className="h-4 w-4" />
-							</Button>
-						</PopoverTrigger>
-						<PopoverContent>
-							<div className="flex flex-col gap-2">
-								<p className="break-all text-sm text-muted-foreground">
-									Commit:{" "}
-									{tool.reference?.startsWith("github.com") ? (
-										<a
-											href={`https://${(() => {
-												const parts = tool.reference.split("/");
-												if (parts.length >= 3) {
-													const [org, repo, ...rest] = parts.slice(1);
-													return `github.com/${org}/${repo}/blob/${tool.commit}/${rest.join("/")}/tool.gpt`;
-												}
-												return tool.reference;
-											})()}`}
-											target="_blank"
-											rel="noopener noreferrer"
-											className="text-blue-500 hover:underline"
-										>
-											{tool.commit}
-										</a>
-									) : (
-										tool.commit
-									)}
-								</p>
-							</div>
-						</PopoverContent>
-					</Popover>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									size="icon"
+									variant="ghost"
+									onClick={() => {
+										window.open(
+											getToolCommitURL(tool),
+											"_blank",
+											"noopener,noreferrer"
+										);
+									}}
+								>
+									<GitCommitIcon className="h-4 w-4" />
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent>
+								<p>View Commit</p>
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
 				</CardFooter>
 			)}
 		</Card>

--- a/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
+++ b/ui/admin/app/components/tools/toolGrid/ToolCard.tsx
@@ -21,7 +21,6 @@ import {
 import {
 	Tooltip,
 	TooltipContent,
-	TooltipProvider,
 	TooltipTrigger,
 } from "~/components/ui/tooltip";
 
@@ -108,28 +107,26 @@ export function ToolCard({
 			</CardContent>
 			{tool.commit && (
 				<CardFooter className="flex justify-end">
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="icon"
-									variant="ghost"
-									onClick={() => {
-										window.open(
-											getToolCommitURL(tool),
-											"_blank",
-											"noopener,noreferrer"
-										);
-									}}
-								>
-									<GitCommitIcon className="h-4 w-4" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>
-								<p>View Commit</p>
-							</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								size="icon"
+								variant="ghost"
+								onClick={() => {
+									window.open(
+										getToolCommitURL(tool),
+										"_blank",
+										"noopener,noreferrer"
+									);
+								}}
+							>
+								<GitCommitIcon className="h-4 w-4" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>
+							<p>View Commit</p>
+						</TooltipContent>
+					</Tooltip>
 				</CardFooter>
 			)}
 		</Card>

--- a/ui/admin/app/lib/model/toolReferences.ts
+++ b/ui/admin/app/lib/model/toolReferences.ts
@@ -83,7 +83,10 @@ export function convertToolReferencesToMap(toolReferences: ToolReference[]) {
 						tools: [toolReference],
 					};
 				} else {
-					result[toolReference.bundleToolName].tools!.push(toolReference);
+					if (!result[toolReference.bundleToolName].tools) {
+						throw new Error("This should never happen");
+					}
+					result[toolReference.bundleToolName].tools?.push(toolReference);
 				}
 			}
 		} else {

--- a/ui/admin/app/lib/model/toolReferences.ts
+++ b/ui/admin/app/lib/model/toolReferences.ts
@@ -13,12 +13,16 @@ export type ToolReferenceBase = {
 export type ToolReferenceType = "tool" | "stepTemplate" | "modelProvider";
 
 export type ToolReference = {
+	bundle: boolean;
+	bundleToolName?: string;
+	tools?: ToolReference[];
 	description: string;
 	builtin: boolean;
 	active: boolean;
 	credentials?: string[];
 	error?: string;
 	params?: Record<string, string>;
+	commit?: string;
 } & EntityMeta &
 	ToolReferenceBase;
 
@@ -32,15 +36,11 @@ export const toolReferenceToTemplate = (toolReference: ToolReference) => {
 	} as Template;
 };
 
-export type ToolCategory = {
-	bundleTool?: ToolReference;
-	tools: ToolReference[];
-};
 export const UncategorizedToolCategory = "Uncategorized";
 export const CustomToolsToolCategory = "Custom Tools";
 export const CapabilitiesToolCategory = "Capability";
 
-export type ToolCategoryMap = Record<string, ToolCategory>;
+export type ToolMap = Record<string, ToolReference>;
 
 export const CapabilityTool = {
 	Knowledge: "knowledge",
@@ -55,35 +55,43 @@ export function isCapabilityTool(toolReference: ToolReference) {
 	return toolReference.metadata?.category === CapabilitiesToolCategory;
 }
 
-export function convertToolReferencesToCategoryMap(
-	toolReferences: ToolReference[]
-) {
-	const result: ToolCategoryMap = {};
+export function convertToolReferencesToMap(toolReferences: ToolReference[]) {
+	// Convert array of tools to a map keyed by tool name
+	const toolMap = new Map(toolReferences.map((tool) => [tool.id, tool]));
+	const result: ToolMap = {};
 
 	for (const toolReference of toolReferences) {
-		if (toolReference.deleted) {
-			// skip tools if marked with deleted
+		if (toolReference.deleted || isCapabilityTool(toolReference)) {
 			continue;
 		}
 
-		// skip capabilities
-		if (isCapabilityTool(toolReference)) {
-			continue;
-		}
-
-		const category =
-			toolReference.metadata?.category || UncategorizedToolCategory;
-
-		if (!result[category]) {
-			result[category] = {
+		if (toolReference.bundle) {
+			// Handle bundle tool
+			if (!result[toolReference.id]) {
+				result[toolReference.id] = {
+					...toolReference,
+					tools: [],
+				};
+			}
+		} else if (toolReference.bundleToolName) {
+			// Handle tool that belongs to a bundle
+			const bundleTool = toolMap.get(toolReference.bundleToolName);
+			if (bundleTool && !isCapabilityTool(bundleTool)) {
+				if (!result[toolReference.bundleToolName]) {
+					result[toolReference.bundleToolName] = {
+						...bundleTool,
+						tools: [toolReference],
+					};
+				} else {
+					result[toolReference.bundleToolName].tools!.push(toolReference);
+				}
+			}
+		} else {
+			// Handle standalone tool
+			result[toolReference.id] = {
+				...toolReference,
 				tools: [],
 			};
-		}
-
-		if (toolReference.metadata?.bundle === "true") {
-			result[category].bundleTool = toolReference;
-		} else {
-			result[category].tools.push(toolReference);
 		}
 	}
 

--- a/ui/admin/app/routes/_auth.tools._index.tsx
+++ b/ui/admin/app/routes/_auth.tools._index.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import { MetaFunction } from "react-router";
 import useSWR, { preload } from "swr";
 
-import { convertToolReferencesToCategoryMap } from "~/lib/model/toolReferences";
+import { convertToolReferencesToMap } from "~/lib/model/toolReferences";
 import { OauthAppService } from "~/lib/service/api/oauthAppService";
 import { ToolReferenceService } from "~/lib/service/api/toolreferenceService";
 import { RouteHandle } from "~/lib/service/routeHandles";
@@ -33,8 +33,8 @@ export default function Tools() {
 		{ fallbackData: [] }
 	);
 
-	const toolCategories = useMemo(
-		() => Object.entries(convertToolReferencesToCategoryMap(getTools.data)),
+	const toolMap = useMemo(
+		() => convertToolReferencesToMap(getTools.data),
 		[getTools.data]
 	);
 
@@ -42,8 +42,8 @@ export default function Tools() {
 
 	const results =
 		searchQuery.length > 0
-			? filterToolCatalogBySearch(toolCategories, searchQuery)
-			: toolCategories;
+			? filterToolCatalogBySearch(Object.entries(toolMap), searchQuery)
+			: Object.entries(toolMap);
 
 	return (
 		<div>
@@ -65,7 +65,7 @@ export default function Tools() {
 			</div>
 
 			<ScrollArea className="flex h-[calc(100vh-8.5rem)] flex-col p-8">
-				<ToolGrid toolCategories={results} />
+				<ToolGrid toolMap={results} />
 			</ScrollArea>
 		</div>
 	);

--- a/ui/admin/test/mocks/models/toolReferences.ts
+++ b/ui/admin/test/mocks/models/toolReferences.ts
@@ -89,7 +89,6 @@ export const mockedImageToolBundle: ToolReference[] = [
 		revision: "1",
 		metadata: {
 			bundle: "true",
-			category: "Images",
 			icon: "https://www.mock.com/assets/images_icon.svg",
 		},
 		type: "toolreference",
@@ -101,14 +100,13 @@ export const mockedImageToolBundle: ToolReference[] = [
 		builtin: true,
 		description: "Tools for analyzing and generating images",
 		credentials: ["github.com/gptscript-ai/credentials/model-provider"],
-		bundle: false,
+		bundle: true,
 	},
 	{
 		id: "images-analyze-images",
 		created: "2025-01-29T11:10:12-05:00",
 		revision: "1",
 		metadata: {
-			category: "Images",
 			icon: "https://www.mock.com/assets/images_icon.svg",
 			noUserAuth: "sys.model.provider.credential",
 		},
@@ -139,7 +137,6 @@ export const mockedBrowserToolBundle: ToolReference[] = [
 		revision: "1",
 		metadata: {
 			bundle: "true",
-			category: "Browser",
 			icon: "https://www.mock.com/assets/browser_icon.svg",
 			noUserAuth: "sys.model.provider.credential",
 		},
@@ -152,14 +149,13 @@ export const mockedBrowserToolBundle: ToolReference[] = [
 		builtin: true,
 		description: "Tools to navigate websites using a browser.",
 		credentials: ["github.com/gptscript-ai/credentials/model-provider"],
-		bundle: false,
+		bundle: true,
 	},
 	{
 		id: "browser-download-file-from-url",
 		created: "2025-01-29T11:10:12-05:00",
 		revision: "1",
 		metadata: {
-			category: "Browser",
 			icon: "https://www.mock.com/assets/browser_icon.svg",
 		},
 		type: "toolreference",
@@ -178,6 +174,7 @@ export const mockedBrowserToolBundle: ToolReference[] = [
 			url: "(required) The URL of the file to download.",
 		},
 		bundle: false,
+		bundleToolName: "browser-bundle",
 	},
 ];
 
@@ -188,7 +185,6 @@ export const mockedBundleWithOauthReference: ToolReference[] = [
 		revision: "1",
 		metadata: {
 			bundle: "true",
-			category: "Gmail",
 			icon: "gmail_icon_small.png",
 			oauth: "google",
 		},
@@ -201,13 +197,13 @@ export const mockedBundleWithOauthReference: ToolReference[] = [
 		builtin: true,
 		description: "Tools for interacting with a user's Gmail account",
 		credentials: ["github.com/obot-platform/tools/google/credential"],
+		bundle: true,
 	},
 	{
 		id: "google-gmail-list-drafts",
 		created: "2025-02-05T13:54:26-05:00",
 		revision: "1",
 		metadata: {
-			category: "Gmail",
 			icon: "gmail_icon_small.png",
 			oauth: "google",
 		},
@@ -226,6 +222,8 @@ export const mockedBundleWithOauthReference: ToolReference[] = [
 			max_results:
 				"Maximum number of drafts to list (Optional: Default will list 100 drafts)",
 		},
+		bundle: false,
+		bundleToolName: "google-gmail-bundle",
 	},
 ];
 

--- a/ui/admin/test/mocks/models/toolReferences.ts
+++ b/ui/admin/test/mocks/models/toolReferences.ts
@@ -16,6 +16,7 @@ export const mockedDatabaseToolReference: ToolReference = {
 	resolved: true,
 	builtin: true,
 	description: "Tools for interacting with a database",
+	bundle: false,
 };
 
 export const mockedKnowledgeToolReference: ToolReference = {
@@ -39,6 +40,7 @@ export const mockedKnowledgeToolReference: ToolReference = {
 	params: {
 		Query: "A search query that will be evaluated against the knowledge set",
 	},
+	bundle: false,
 };
 
 export const mockedTasksToolReference: ToolReference = {
@@ -57,6 +59,7 @@ export const mockedTasksToolReference: ToolReference = {
 	resolved: true,
 	builtin: true,
 	description: "Manage and execute tasks",
+	bundle: false,
 };
 
 export const mockedWorkspaceFilesToolReference: ToolReference = {
@@ -76,6 +79,7 @@ export const mockedWorkspaceFilesToolReference: ToolReference = {
 	builtin: true,
 	description:
 		"Adds the capability for users to read and write workspace files",
+	bundle: false,
 };
 
 export const mockedImageToolBundle: ToolReference[] = [
@@ -97,6 +101,7 @@ export const mockedImageToolBundle: ToolReference[] = [
 		builtin: true,
 		description: "Tools for analyzing and generating images",
 		credentials: ["github.com/gptscript-ai/credentials/model-provider"],
+		bundle: false,
 	},
 	{
 		id: "images-analyze-images",
@@ -123,6 +128,7 @@ export const mockedImageToolBundle: ToolReference[] = [
 			prompt:
 				'(optional) A prompt to analyze the images with (defaults "Provide a brief description of each image")',
 		},
+		bundle: false,
 	},
 ];
 
@@ -146,6 +152,7 @@ export const mockedBrowserToolBundle: ToolReference[] = [
 		builtin: true,
 		description: "Tools to navigate websites using a browser.",
 		credentials: ["github.com/gptscript-ai/credentials/model-provider"],
+		bundle: false,
 	},
 	{
 		id: "browser-download-file-from-url",
@@ -170,6 +177,7 @@ export const mockedBrowserToolBundle: ToolReference[] = [
 				"(required) The name of the workspace file to save the content to.",
 			url: "(required) The URL of the file to download.",
 		},
+		bundle: false,
 	},
 ];
 


### PR DESCRIPTION
This PR implements the tool index refactoring logic defined at https://github.com/obot-platform/obot/issues/1026. It has both frontend and backend changes to support new indexing logic.

Backend:
- Dropping `all: true` and always import the first tool and its shared tools from gptfile. 
- Dropping bundle metadata and always relied on share tools
- Add api to support bundle tool and bundle child tools
- Apply same code to import both custom and built-in tools.
- Add tool commit

Frontend:
- Stop using category as a way to group bundle tool
- Group tool and bundle using new api fields.
- Add tool commit

Should fix
- https://github.com/obot-platform/obot/issues/1525
- https://github.com/obot-platform/obot/issues/1526
- https://github.com/obot-platform/obot/issues/1527