### PR TITLE
fix: threads page, users initially showing empty

### DIFF
--- a/ui/admin/app/components/agent/__tests__/Agent.test.tsx
+++ b/ui/admin/app/components/agent/__tests__/Agent.test.tsx
@@ -22,6 +22,7 @@ import { overrideServer } from "test/server";
 
 import { Agent as AgentModel } from "~/lib/model/agents";
 import { Assistant } from "~/lib/model/assistants";
+import { OAuthApp } from "~/lib/model/oauthApps";
 import { EntityList } from "~/lib/model/primitives";
 import { Thread } from "~/lib/model/threads";
 import { User } from "~/lib/model/users";
@@ -61,6 +62,11 @@ describe(Agent, () => {
 			http.get(ApiRoutes.threads.getByAgent(agent.id).path, () => {
 				return HttpResponse.json<EntityList<Thread> | null>({
 					items: null,
+				});
+			}),
+			http.get(ApiRoutes.oauthApps.getOauthApps().url, () => {
+				return HttpResponse.json<EntityList<OAuthApp>>({
+					items: [],
 				});
 			}),
 			defaultModelAliasHandler,

--- a/ui/admin/app/components/thread/ThreadMeta.tsx
+++ b/ui/admin/app/components/thread/ThreadMeta.tsx
@@ -157,10 +157,10 @@ export function ThreadMeta({ entity, thread, className }: ThreadMetaProps) {
 									<td className="text-right">{thread.parentThreadId}</td>
 								</tr>
 							)}
-							{thread.lastRunId && (
+							{thread.lastRunID && (
 								<tr className="border-foreground/25">
 									<td className="py-2 pr-4 font-medium">Last Run ID</td>
-									<td className="text-right">{thread.lastRunId}</td>
+									<td className="text-right">{thread.lastRunID}</td>
 								</tr>
 							)}
 						</tbody>

--- a/ui/admin/app/components/workflow/__tests__/Workflow.test.tsx
+++ b/ui/admin/app/components/workflow/__tests__/Workflow.test.tsx
@@ -17,6 +17,7 @@ import { overrideServer } from "test/server";
 
 import { CronJob } from "~/lib/model/cronjobs";
 import { EmailReceiver } from "~/lib/model/email-receivers";
+import { OAuthApp } from "~/lib/model/oauthApps";
 import { EntityList } from "~/lib/model/primitives";
 import { Webhook } from "~/lib/model/webhooks";
 import { Workflow as WorkflowModel } from "~/lib/model/workflows";
@@ -58,6 +59,11 @@ describe(Workflow, () => {
 			}),
 			http.get(ApiRoutes.webhooks.getWebhooks().path, () => {
 				return HttpResponse.json<EntityList<Webhook>>({
+					items: [],
+				});
+			}),
+			http.get(ApiRoutes.oauthApps.getOauthApps().url, () => {
+				return HttpResponse.json<EntityList<OAuthApp>>({
 					items: [],
 				});
 			}),

--- a/ui/admin/app/lib/model/threads.ts
+++ b/ui/admin/app/lib/model/threads.ts
@@ -12,7 +12,7 @@ export type Thread = EntityMeta &
 		state?: RunState;
 		currentRunId?: string;
 		parentThreadId?: string;
-		lastRunId?: string;
+		lastRunID?: string;
 		userID?: string;
 	} & (
 		| { agentID: string; workflowID?: never }

--- a/ui/admin/app/routes/__tests__/threads._index.test.tsx
+++ b/ui/admin/app/routes/__tests__/threads._index.test.tsx
@@ -1,0 +1,70 @@
+import {
+	HttpResponse,
+	http,
+	overrideServer,
+	render,
+	screen,
+	within,
+} from "test";
+import { mockedAgent } from "test/mocks/models/agents";
+import { mockedThreads } from "test/mocks/models/threads";
+import { mockedUsers } from "test/mocks/models/users";
+
+import { Agent } from "~/lib/model/agents";
+import { EntityList } from "~/lib/model/primitives";
+import { Thread } from "~/lib/model/threads";
+import { User } from "~/lib/model/users";
+import { Workflow } from "~/lib/model/workflows";
+import { ApiRoutes } from "~/lib/routers/apiRoutes";
+
+import Threads from "~/routes/_auth.threads._index";
+
+vi.mock("react-router", async () => {
+	const actual = await vi.importActual("react-router");
+	return {
+		...actual,
+		useLoaderData: vi.fn(() => ({
+			// Mock the loader data that matches clientLoader return type
+			agentId: undefined,
+			workflowId: undefined,
+			userId: undefined,
+		})),
+		useNavigate: vi.fn(() => vi.fn()),
+		useSearchParams: vi.fn(() => [new URLSearchParams(), vi.fn()]),
+	};
+});
+
+describe(Threads, () => {
+	beforeEach(() => {
+		overrideServer([
+			http.get(ApiRoutes.threads.base().url, () => {
+				return HttpResponse.json<EntityList<Thread>>({
+					items: mockedThreads,
+				});
+			}),
+			http.get(ApiRoutes.agents.base().url, () => {
+				return HttpResponse.json<EntityList<Agent>>({
+					items: [mockedAgent],
+				});
+			}),
+			http.get(ApiRoutes.workflows.base().url, () => {
+				return HttpResponse.json<EntityList<Workflow>>({
+					items: [],
+				});
+			}),
+			http.get(ApiRoutes.users.base().url, () => {
+				return HttpResponse.json<EntityList<User>>({
+					items: mockedUsers,
+				});
+			}),
+		]);
+	});
+
+	it("Displays user email for an agent thread on initial render", async () => {
+		render(<Threads />);
+		const groups = await screen.findAllByRole("rowgroup");
+		const tableBody = groups[1]; // tbody
+		const cells = await within(tableBody).findAllByRole("cell"); // td
+		expect(cells[2]).toHaveTextContent(mockedUsers[0].email);
+	});
+});

--- a/ui/admin/test/mocks/models/threads.ts
+++ b/ui/admin/test/mocks/models/threads.ts
@@ -1,4 +1,6 @@
 import { RunState } from "@gptscript-ai/gptscript";
+import { mockedAgent } from "test/mocks/models/agents";
+import { mockedUser } from "test/mocks/models/users";
 
 import { Thread } from "~/lib/model/threads";
 
@@ -7,9 +9,9 @@ export const mockedThreads: Thread[] = [
 		id: "t1bm2kn",
 		created: "2025-02-04T10:53:11-05:00",
 		type: "thread",
-		agentID: "a17m9ht",
+		agentID: mockedAgent.id,
 		state: RunState.Continue,
 		lastRunID: "r1g9hw7",
-		userID: "1",
+		userID: mockedUser.id,
 	},
 ];

--- a/ui/admin/test/mocks/models/threads.ts
+++ b/ui/admin/test/mocks/models/threads.ts
@@ -1,0 +1,15 @@
+import { RunState } from "@gptscript-ai/gptscript";
+
+import { Thread } from "~/lib/model/threads";
+
+export const mockedThreads: Thread[] = [
+	{
+		id: "t1bm2kn",
+		created: "2025-02-04T10:53:11-05:00",
+		type: "thread",
+		agentID: "a17m9ht",
+		state: RunState.Continue,
+		lastRunID: "r1g9hw7",
+		userID: "1",
+	},
+];


### PR DESCRIPTION
What causes a rerender of `DataTable` is when `data` changes. Because `userMap` is not tied to that data, a rerender does not fire when getUsers.data is updated. Two solutions: Either preload to make sure the data is available before rendering or update `data` so it accounts for that information and does a rerender.
