### PR TITLE
change: allow hiding provider parameters in the UI

### DIFF
--- a/apiclient/types/modelprovider.go
+++ b/apiclient/types/modelprovider.go
@@ -12,6 +12,7 @@ type ProviderConfigurationParameter struct {
 	FriendlyName string `json:"friendlyName,omitempty"`
 	Description  string `json:"description,omitempty"`
 	Sensitive    bool   `json:"sensitive,omitempty"`
+	Hidden       bool   `json:"hidden,omitempty"`
 }
 
 type ModelProvider struct {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2996,6 +2996,12 @@ func schema_obot_platform_obot_apiclient_types_ProviderConfigurationParameter(re
 							Format: "",
 						},
 					},
+					"hidden": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"name"},
 			},

--- a/ui/admin/app/components/auth-and-model-providers/ProviderForm.tsx
+++ b/ui/admin/app/components/auth-and-model-providers/ProviderForm.tsx
@@ -56,25 +56,30 @@ const getInitialRequiredParams = (
 	requiredParameters: ProviderConfigurationParameter[],
 	parameters: ProviderConfig
 ): ProviderFormValues["requiredConfigParams"] =>
-	requiredParameters.map((param) => ({
-		tooltip: param.description ?? "",
-		label: param.friendlyName ?? param.name,
-		name: param.name,
-		value: parameters[param.name] ?? "",
-		sensitive: param.sensitive ?? false,
-	}));
+	requiredParameters
+		.filter((param) => !param.hidden)
+		.map((param) => ({
+			tooltip: param.description ?? "",
+			label: param.friendlyName ?? param.name,
+			name: param.name,
+			value: parameters[param.name] ?? "",
+			sensitive: param.sensitive ?? false,
+		}));
 
 const getInitialOptionalParams = (
 	optionalParameters: ProviderConfigurationParameter[],
 	parameters: ProviderConfig
 ): ProviderFormValues["optionalConfigParams"] =>
-	optionalParameters.map((param) => ({
-		tooltip: param.description ?? "",
-		label: param.friendlyName ?? param.name,
-		name: param.name,
-		value: parameters[param.name] ?? "",
-		sensitive: param.sensitive ?? false,
-	}));
+	optionalParameters
+		.filter((param) => !param.hidden)
+		.map((param) => ({
+			tooltip: param.description ?? "",
+			label: param.friendlyName ?? param.name,
+			name: param.name,
+			value: parameters[param.name] ?? "",
+			sensitive: param.sensitive ?? false,
+			hidden: param.hidden ?? false,
+		}));
 
 export function ProviderForm({
 	provider,

--- a/ui/admin/app/lib/model/providers.ts
+++ b/ui/admin/app/lib/model/providers.ts
@@ -5,6 +5,7 @@ export type ProviderConfigurationParameter = {
 	friendlyName?: string;
 	description?: string;
 	sensitive?: boolean;
+	hidden?: boolean;
 };
 
 export type ProviderStatus = {


### PR DESCRIPTION
Before: see https://github.com/obot-platform/obot/issues/1638

After (Cookie Secret hidden for all auth providers): 
![Screenshot 2025-02-04 at 21-26-57 Obot • Auth Providers](https://github.com/user-attachments/assets/ebd2fbc3-4138-45b9-a870-7d5b2e7f2f50)


Related Tool PRs: https://github.com/obot-platform/tools/pull/405 & https://github.com/obot-platform/enterprise-tools/pull/24