### PR TITLE
fix: config banner still showing model provider needs configuring even if configured

### DIFF
--- a/ui/admin/app/components/composed/SetupBanner.tsx
+++ b/ui/admin/app/components/composed/SetupBanner.tsx
@@ -35,9 +35,9 @@ export function SetupBanner() {
 	const isSetupPage = steps.some((step) =>
 		location.pathname.includes(step.path)
 	);
-	const isConfigured = steps.every((step) => step.configured);
+	const stepsToConfigure = steps.filter((step) => !step.configured);
 
-	if (isConfigured || isSetupPage) return null;
+	if (stepsToConfigure.length === 0 || isSetupPage) return null;
 
 	return (
 		<div className="w-full">
@@ -57,18 +57,20 @@ export function SetupBanner() {
 						</h3>
 
 						<ul>
-							{steps.map((step) => (
-								<li key={step.step}>
-									<p className="mb-2 text-sm font-light">
-										<b className="font-semibold">{step.label}: </b>
-										{step.description}
-									</p>
-								</li>
-							))}
+							{stepsToConfigure
+								.filter((step) => !step.configured)
+								.map((step) => (
+									<li key={step.step}>
+										<p className="mb-2 text-sm font-light">
+											<b className="font-semibold">{step.label}: </b>
+											{step.description}
+										</p>
+									</li>
+								))}
 						</ul>
 
 						<div className="flex flex-row flex-wrap gap-2">
-							{steps.map((step) => (
+							{stepsToConfigure.map((step) => (
 								<Button
 									className={cn("mt-0 w-fit px-10", {
 										"flex-1": steps.length > 1,

--- a/ui/admin/app/components/composed/__tests__/SetupBanner.test.tsx
+++ b/ui/admin/app/components/composed/__tests__/SetupBanner.test.tsx
@@ -46,50 +46,37 @@ describe(SetupBanner, () => {
 		]);
 	};
 
-	it("Renders both steps when neither are configured", async () => {
-		setupServer(false, false);
-		render(<SetupBanner />);
+	it.each([
+		["Both Options", false, false],
+		["Only Model Provider Option", false, true],
+		["OnlyAuth Provider Option", true, false],
+		["Does Not Render Banner", true, true],
+	])(
+		"Renders: %s",
+		async (_, modelProviderConfigured, authProviderConfigured) => {
+			setupServer(modelProviderConfigured, authProviderConfigured);
+			render(<SetupBanner />);
 
-		await waitFor(() => {
-			expect(screen.getByText("Configure Model Provider")).toBeInTheDocument();
-			expect(screen.getByText("Configure Auth Provider")).toBeInTheDocument();
-		});
-	});
-
-	it("Renders model provider step when auth provider is configured", async () => {
-		setupServer(false, true);
-		render(<SetupBanner />);
-
-		await waitFor(() => {
-			expect(screen.getByText("Configure Model Provider")).toBeInTheDocument();
-			expect(
-				screen.queryByText("Configure Auth Provider")
-			).not.toBeInTheDocument();
-		});
-	});
-
-	it("Renders auth provider step when model provider is configured", async () => {
-		setupServer(true, false);
-		render(<SetupBanner />);
-
-		await waitFor(() => {
-			expect(screen.getByText("Configure Auth Provider")).toBeInTheDocument();
-			expect(
-				screen.queryByText("Configure Model Provider")
-			).not.toBeInTheDocument();
-		});
-	});
-
-	it("Does not render banner when both are configured", async () => {
-		setupServer(true, true);
-		render(<SetupBanner />);
-		await waitFor(() => {
-			expect(
-				screen.queryByText("Configure Model Provider")
-			).not.toBeInTheDocument();
-			expect(
-				screen.queryByText("Configure Auth Provider")
-			).not.toBeInTheDocument();
-		});
-	});
+			await waitFor(() => {
+				if (modelProviderConfigured) {
+					expect(
+						screen.queryByText("Configure Model Provider")
+					).not.toBeInTheDocument();
+				} else {
+					expect(
+						screen.getByText("Configure Model Provider")
+					).toBeInTheDocument();
+				}
+				if (authProviderConfigured) {
+					expect(
+						screen.queryByText("Configure Auth Provider")
+					).not.toBeInTheDocument();
+				} else {
+					expect(
+						screen.getByText("Configure Auth Provider")
+					).toBeInTheDocument();
+				}
+			});
+		}
+	);
 });

--- a/ui/admin/app/components/composed/__tests__/SetupBanner.test.tsx
+++ b/ui/admin/app/components/composed/__tests__/SetupBanner.test.tsx
@@ -17,6 +17,9 @@ import { ApiRoutes } from "~/lib/routers/apiRoutes";
 import { SetupBanner } from "~/components/composed/SetupBanner";
 
 describe(SetupBanner, () => {
+	const modelProviderButtonText = "Configure Model Provider";
+	const authProviderButtonText = "Configure Auth Provider";
+
 	const setupServer = (
 		modelProviderConfigured: boolean,
 		authProviderConfigured: boolean
@@ -60,21 +63,17 @@ describe(SetupBanner, () => {
 			await waitFor(() => {
 				if (modelProviderConfigured) {
 					expect(
-						screen.queryByText("Configure Model Provider")
+						screen.queryByText(modelProviderButtonText)
 					).not.toBeInTheDocument();
 				} else {
-					expect(
-						screen.getByText("Configure Model Provider")
-					).toBeInTheDocument();
+					expect(screen.getByText(modelProviderButtonText)).toBeInTheDocument();
 				}
 				if (authProviderConfigured) {
 					expect(
-						screen.queryByText("Configure Auth Provider")
+						screen.queryByText(authProviderButtonText)
 					).not.toBeInTheDocument();
 				} else {
-					expect(
-						screen.getByText("Configure Auth Provider")
-					).toBeInTheDocument();
+					expect(screen.getByText(authProviderButtonText)).toBeInTheDocument();
 				}
 			});
 		}

--- a/ui/admin/app/components/composed/__tests__/SetupBanner.test.tsx
+++ b/ui/admin/app/components/composed/__tests__/SetupBanner.test.tsx
@@ -1,0 +1,95 @@
+import {
+	HttpResponse,
+	http,
+	overrideServer,
+	render,
+	screen,
+	waitFor,
+} from "test";
+import { defaultBootstrappedMockHandlers } from "test/mocks/handlers/default";
+import { mockedAuthProvider } from "test/mocks/models/authProvider";
+import { mockedModelProvider } from "test/mocks/models/modelProvider";
+
+import { EntityList } from "~/lib/model/primitives";
+import { AuthProvider, ModelProvider } from "~/lib/model/providers";
+import { ApiRoutes } from "~/lib/routers/apiRoutes";
+
+import { SetupBanner } from "~/components/composed/SetupBanner";
+
+describe(SetupBanner, () => {
+	const setupServer = (
+		modelProviderConfigured: boolean,
+		authProviderConfigured: boolean
+	) => {
+		overrideServer([
+			...defaultBootstrappedMockHandlers,
+			http.get(ApiRoutes.modelProviders.getModelProviders().url, () => {
+				return HttpResponse.json<EntityList<ModelProvider>>({
+					items: [
+						{
+							...mockedModelProvider,
+							configured: modelProviderConfigured,
+						},
+					],
+				});
+			}),
+			http.get(ApiRoutes.authProviders.getAuthProviders().url, () => {
+				return HttpResponse.json<EntityList<AuthProvider>>({
+					items: [
+						{
+							...mockedAuthProvider,
+							configured: authProviderConfigured,
+						},
+					],
+				});
+			}),
+		]);
+	};
+
+	it("Renders both steps when neither are configured", async () => {
+		setupServer(false, false);
+		render(<SetupBanner />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Configure Model Provider")).toBeInTheDocument();
+			expect(screen.getByText("Configure Auth Provider")).toBeInTheDocument();
+		});
+	});
+
+	it("Renders model provider step when auth provider is configured", async () => {
+		setupServer(false, true);
+		render(<SetupBanner />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Configure Model Provider")).toBeInTheDocument();
+			expect(
+				screen.queryByText("Configure Auth Provider")
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it("Renders auth provider step when model provider is configured", async () => {
+		setupServer(true, false);
+		render(<SetupBanner />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Configure Auth Provider")).toBeInTheDocument();
+			expect(
+				screen.queryByText("Configure Model Provider")
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it("Does not render banner when both are configured", async () => {
+		setupServer(true, true);
+		render(<SetupBanner />);
+		await waitFor(() => {
+			expect(
+				screen.queryByText("Configure Model Provider")
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText("Configure Auth Provider")
+			).not.toBeInTheDocument();
+		});
+	});
+});

--- a/ui/admin/test/mocks/handlers/default.ts
+++ b/ui/admin/test/mocks/handlers/default.ts
@@ -1,5 +1,5 @@
 import { HttpResponse, http } from "msw";
-import { mockedUser } from "test/mocks/models/users";
+import { mockedBootstrappedUser, mockedUser } from "test/mocks/models/users";
 import { mockedVersion } from "test/mocks/models/version";
 
 import { User } from "~/lib/model/users";
@@ -13,13 +13,27 @@ export const defaultMockedHandlers = [
 		});
 	}),
 	http.get(ApiRoutes.version().path, () => {
-		return HttpResponse.json<{ data: Version }>({
-			data: mockedVersion,
-		});
+		return HttpResponse.json<Version>(mockedVersion);
 	}),
 	http.get(ApiRoutes.me().path, () => {
 		return HttpResponse.json<{ data: User }>({
 			data: mockedUser,
+		});
+	}),
+];
+
+export const defaultBootstrappedMockHandlers = [
+	http.get(ApiRoutes.bootstrap.status().path, () => {
+		return HttpResponse.json<{ data: { enabled: boolean } }>({
+			data: { enabled: true },
+		});
+	}),
+	http.get(ApiRoutes.version().path, () => {
+		return HttpResponse.json<Version>(mockedVersion);
+	}),
+	http.get(ApiRoutes.me().path, () => {
+		return HttpResponse.json<{ data: User }>({
+			data: mockedBootstrappedUser,
 		});
 	}),
 ];

--- a/ui/admin/test/mocks/models/authProvider.ts
+++ b/ui/admin/test/mocks/models/authProvider.ts
@@ -1,0 +1,42 @@
+import { AuthProvider } from "~/lib/model/providers";
+
+export const mockedAuthProvider: AuthProvider = {
+	id: "google-auth-provider",
+	created: "2025-02-04T16:04:02-05:00",
+	revision: "1",
+	type: "authprovider",
+	name: "Google",
+	toolReference: "github.com/obot-platform/tools/google-auth-provider",
+	icon: "google_icon_small.png",
+	iconDark: "google_icon_small.png",
+	link: "https://google.com/",
+	configured: true,
+	requiredConfigurationParameters: [
+		{
+			name: "OBOT_GOOGLE_AUTH_PROVIDER_CLIENT_ID",
+			friendlyName: "Client ID",
+			description:
+				"Unique identifier for the application when using Google's OAuth. Can typically be found in Google Cloud Console > Credentials",
+		},
+		{
+			name: "OBOT_GOOGLE_AUTH_PROVIDER_CLIENT_SECRET",
+			friendlyName: "Client Secret",
+			description:
+				"Password or key that app uses to authenticate with Google's OAuth. Can typically be found in Google Cloud Console > Credentials",
+			sensitive: true,
+		},
+		{
+			name: "OBOT_AUTH_PROVIDER_COOKIE_SECRET",
+			friendlyName: "Cookie Secret",
+			description:
+				"Secret used to encrypt cookies. Must be a random string of length 16, 24, or 32.",
+			sensitive: true,
+		},
+		{
+			name: "OBOT_AUTH_PROVIDER_EMAIL_DOMAINS",
+			friendlyName: "Allowed E-Mail Domains",
+			description:
+				"Comma separated list of email domains that are allowed to authenticate with this provider. * is a special value that allows all domains.",
+		},
+	],
+};

--- a/ui/admin/test/mocks/models/modelProvider.ts
+++ b/ui/admin/test/mocks/models/modelProvider.ts
@@ -1,0 +1,23 @@
+import { ModelProvider } from "~/lib/model/providers";
+
+export const mockedModelProvider: ModelProvider = {
+	id: "openai-model-provider",
+	created: "2025-02-04T16:04:02-05:00",
+	revision: "1",
+	type: "modelprovider",
+	name: "OpenAI",
+	toolReference: "github.com/obot-platform/tools/openai-model-provider",
+	icon: "open-ai-logo-duotone.svg",
+	link: "https://openai.com/",
+	configured: true,
+	requiredConfigurationParameters: [
+		{
+			name: "OBOT_OPENAI_MODEL_PROVIDER_API_KEY",
+			friendlyName: "API Key",
+			description:
+				"OpenAI API Key. Can be created and fetched from https://platform.openai.com/settings/organization/api-keys or https://platform.openai.com/api-keys",
+			sensitive: true,
+		},
+	],
+	missingConfigurationParameters: ["OBOT_OPENAI_MODEL_PROVIDER_API_KEY"],
+};

--- a/ui/admin/test/mocks/models/users.ts
+++ b/ui/admin/test/mocks/models/users.ts
@@ -1,5 +1,16 @@
 import { User } from "~/lib/model/users";
 
+export const mockedBootstrappedUser: User = {
+	id: "1",
+	created: "2025-02-04T16:08:24.074959-05:00",
+	username: "bootstrap",
+	role: 1,
+	timezone: "America/New_York",
+	email: "",
+	iconURL: "",
+	explicitAdmin: false,
+};
+
 // Admin User
 export const mockedUser: User = {
 	id: "1",

--- a/ui/admin/test/setup.ts
+++ b/ui/admin/test/setup.ts
@@ -29,7 +29,7 @@ beforeAll(() => server.listen());
 
 beforeEach(() => {
 	// Clear the SWR cache before each test
-	mutate(() => true, undefined, { revalidate: false });
+	mutate(() => true, undefined, { revalidate: true });
 });
 
 // Reset any request handlers that we may add during the tests,


### PR DESCRIPTION
* fix for configure banner still showing model provider needs configuring even though it has been configured
* adds back in the filter instead of every check at checking isSetupPage 
* adds test cases for checking!

Addresses #1639 