### PR TITLE
update vllm logo

### DIFF
--- a/ui/admin/public/assets/vllm-logo.svg
+++ b/ui/admin/public/assets/vllm-logo.svg
@@ -1,1 +1,77 @@
-<svg version="1.1" viewBox="0.0 0.0 384.0 192.0" fill="none" stroke="none" stroke-linecap="square" stroke-miterlimit="10" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg"><clipPath id="g31e21232314_0_0.0"><path d="m0 0l384.0 0l0 192.0l-384.0 0l0 -192.0z" clip-rule="nonzero"/></clipPath><g clip-path="url(#g31e21232314_0_0.0)"><path fill="#ffffff" d="m0 0l384.0 0l0 192.0l-384.0 0z" fill-rule="evenodd"/><path fill="#000000" fill-opacity="0.0" d="m99.7706 12.614173l253.41733 0l0 166.77167l-253.41733 0z" fill-rule="evenodd"/><path fill="#434343" d="m172.66676 136.49417l-58.875 0l0 -93.0625l12.375 0l0 82.0625l46.5 0l0 11.0zm71.25 0l-58.875 0l0 -93.0625l12.375 0l0 82.0625l46.5 0l0 11.0zm95.249985 0l-12.375 0l0 -80.1875l-25.875 54.5625l-7.375 0l-25.6875 -54.5625l0 80.1875l-11.5625 0l0 -93.0625l16.875 0l24.8125 51.8125l24.0 -51.8125l17.1875 0l0 93.0625z" fill-rule="nonzero"/><path fill="#d9d9d9" d="m58.466934 134.81989l1.8897629 0l0 2.3307037l-1.8897629 0z" fill-rule="evenodd"/><path fill="#d9d9d9" d="m59.639175 136.0l1.8897667 0l0 2.3307037l-1.8897667 0z" fill-rule="evenodd"/><g filter="url(#shadowFilter-g31e21232314_0_0.1)"><use xlink:href="#g31e21232314_0_0.1" transform="matrix(1.0 0.0 0.0 1.0 0.0 2.0)"/></g><defs><filter id="shadowFilter-g31e21232314_0_0.1" filterUnits="userSpaceOnUse"><feGaussianBlur in="SourceAlpha" stdDeviation="2.0" result="blur"/><feComponentTransfer in="blur" color-interpolation-filters="sRGB"><feFuncR type="linear" slope="0" intercept="0.0"/><feFuncG type="linear" slope="0" intercept="0.0"/><feFuncB type="linear" slope="0" intercept="0.0"/><feFuncA type="linear" slope="0.0" intercept="0"/></feComponentTransfer></filter></defs><g id="g31e21232314_0_0.1"><path fill="#d9d9d9" d="m59.641495 83.01899l0 55.30709l-27.653543 -55.30709z" fill-rule="evenodd"/></g><g filter="url(#shadowFilter-g31e21232314_0_0.2)"><use xlink:href="#g31e21232314_0_0.2" transform="matrix(1.0 0.0 0.0 1.0 0.0 2.0)"/></g><defs><filter id="shadowFilter-g31e21232314_0_0.2" filterUnits="userSpaceOnUse"><feGaussianBlur in="SourceAlpha" stdDeviation="2.0" result="blur"/><feComponentTransfer in="blur" color-interpolation-filters="sRGB"><feFuncR type="linear" slope="0" intercept="0.0"/><feFuncG type="linear" slope="0" intercept="0.0"/><feFuncB type="linear" slope="0" intercept="0.0"/><feFuncA type="linear" slope="0.0" intercept="0"/></feComponentTransfer></filter></defs><g id="g31e21232314_0_0.2"><path fill="#d9d9d9" d="m59.640358 138.32608l21.72966 0l18.653542 -70.38583l-25.574799 13.461945z" fill-rule="evenodd"/></g><g filter="url(#shadowFilter-g31e21232314_0_0.3)"><use xlink:href="#g31e21232314_0_0.3" transform="matrix(1.0 0.0 0.0 1.0 0.0 2.0)"/></g><defs><filter id="shadowFilter-g31e21232314_0_0.3" filterUnits="userSpaceOnUse"><feGaussianBlur in="SourceAlpha" stdDeviation="2.0" result="blur"/><feComponentTransfer in="blur" color-interpolation-filters="sRGB"><feFuncR type="linear" slope="0" intercept="0.0"/><feFuncG type="linear" slope="0" intercept="0.0"/><feFuncB type="linear" slope="0" intercept="0.0"/><feFuncA type="linear" slope="0.0" intercept="0"/></feComponentTransfer></filter></defs><g id="g31e21232314_0_0.3"><path fill="#fdb515" d="m58.465023 81.84252l0 55.30709l-27.653543 -55.30709z" fill-rule="evenodd"/></g><g filter="url(#shadowFilter-g31e21232314_0_0.4)"><use xlink:href="#g31e21232314_0_0.4" transform="matrix(1.0 0.0 0.0 1.0 0.0 2.0)"/></g><defs><filter id="shadowFilter-g31e21232314_0_0.4" filterUnits="userSpaceOnUse"><feGaussianBlur in="SourceAlpha" stdDeviation="2.0" result="blur"/><feComponentTransfer in="blur" color-interpolation-filters="sRGB"><feFuncR type="linear" slope="0" intercept="0.0"/><feFuncG type="linear" slope="0" intercept="0.0"/><feFuncB type="linear" slope="0" intercept="0.0"/><feFuncA type="linear" slope="0.0" intercept="0"/></feComponentTransfer></filter></defs><g id="g31e21232314_0_0.4"><path fill="#30a2ff" d="m58.46389 137.14961l21.72966 0l18.653542 -70.38583l-25.574806 13.461945z" fill-rule="evenodd"/></g></g></svg>
+<svg version="1.1" viewBox="0.0 0.0 96.0 96.0" fill="none" stroke="none" stroke-linecap="square" stroke-miterlimit="10" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
+  <clipPath id="g31e21232314_0_33.0">
+    <path d="m0 0l96.0 0l0 96.0l-96.0 0l0 -96.0z" clip-rule="nonzero"/>
+  </clipPath>
+  <g clip-path="url(#g31e21232314_0_33.0)">
+    <path fill="#d9d9d9" d="m41.04961 80.271324l1.8897629 0l0 2.3307114l-1.8897629 0z" fill-rule="evenodd"/>
+    <path fill="#d9d9d9" d="m42.221855 81.45145l1.8897629 0l0 2.3307037l-1.8897629 0z" fill-rule="evenodd"/>
+    <g filter="url(#shadowFilter-g31e21232314_0_33.1)">
+      <use xlink:href="#g31e21232314_0_33.1" transform="matrix(1.0 0.0 0.0 1.0 0.0 2.0)"/>
+    </g>
+    <defs>
+      <filter id="shadowFilter-g31e21232314_0_33.1" filterUnits="userSpaceOnUse">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="2.0" result="blur"/>
+        <feComponentTransfer in="blur" color-interpolation-filters="sRGB">
+          <feFuncR type="linear" slope="0" intercept="0.0"/>
+          <feFuncG type="linear" slope="0" intercept="0.0"/>
+          <feFuncB type="linear" slope="0" intercept="0.0"/>
+          <feFuncA type="linear" slope="0.0" intercept="0"/>
+        </feComponentTransfer>
+      </filter>
+    </defs>
+    <g id="g31e21232314_0_33.1">
+      <path fill="#d9d9d9" d="m42.22417 28.470434l0 55.307083l-27.653543 -55.307083z" fill-rule="evenodd"/>
+    </g>
+    <g filter="url(#shadowFilter-g31e21232314_0_33.2)">
+      <use xlink:href="#g31e21232314_0_33.2" transform="matrix(1.0 0.0 0.0 1.0 0.0 2.0)"/>
+    </g>
+    <defs>
+      <filter id="shadowFilter-g31e21232314_0_33.2" filterUnits="userSpaceOnUse">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="2.0" result="blur"/>
+        <feComponentTransfer in="blur" color-interpolation-filters="sRGB">
+          <feFuncR type="linear" slope="0" intercept="0.0"/>
+          <feFuncG type="linear" slope="0" intercept="0.0"/>
+          <feFuncB type="linear" slope="0" intercept="0.0"/>
+          <feFuncA type="linear" slope="0.0" intercept="0"/>
+        </feComponentTransfer>
+      </filter>
+    </defs>
+    <g id="g31e21232314_0_33.2">
+      <path fill="#d9d9d9" d="m42.223038 83.77752l21.729656 0l18.653545 -70.385826l-25.574802 13.461943z" fill-rule="evenodd"/>
+    </g>
+    <g filter="url(#shadowFilter-g31e21232314_0_33.3)">
+      <use xlink:href="#g31e21232314_0_33.3" transform="matrix(1.0 0.0 0.0 1.0 0.0 2.0)"/>
+    </g>
+    <defs>
+      <filter id="shadowFilter-g31e21232314_0_33.3" filterUnits="userSpaceOnUse">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="2.0" result="blur"/>
+        <feComponentTransfer in="blur" color-interpolation-filters="sRGB">
+          <feFuncR type="linear" slope="0" intercept="0.0"/>
+          <feFuncG type="linear" slope="0" intercept="0.0"/>
+          <feFuncB type="linear" slope="0" intercept="0.0"/>
+          <feFuncA type="linear" slope="0.0" intercept="0"/>
+        </feComponentTransfer>
+      </filter>
+    </defs>
+    <g id="g31e21232314_0_33.3">
+      <path fill="#fdb515" d="m41.0477 27.293962l0 55.30709l-27.653542 -55.30709z" fill-rule="evenodd"/>
+    </g>
+    <g filter="url(#shadowFilter-g31e21232314_0_33.4)">
+      <use xlink:href="#g31e21232314_0_33.4" transform="matrix(1.0 0.0 0.0 1.0 0.0 2.0)"/>
+    </g>
+    <defs>
+      <filter id="shadowFilter-g31e21232314_0_33.4" filterUnits="userSpaceOnUse">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="2.0" result="blur"/>
+        <feComponentTransfer in="blur" color-interpolation-filters="sRGB">
+          <feFuncR type="linear" slope="0" intercept="0.0"/>
+          <feFuncG type="linear" slope="0" intercept="0.0"/>
+          <feFuncB type="linear" slope="0" intercept="0.0"/>
+          <feFuncA type="linear" slope="0.0" intercept="0"/>
+        </feComponentTransfer>
+      </filter>
+    </defs>
+    <g id="g31e21232314_0_33.4">
+      <path fill="#30a2ff" d="m41.046566 82.60105l21.72966 0l18.653545 -70.385826l-25.574806 13.461943z" fill-rule="evenodd"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
previous vLLM logo had a white background - new logo is their just their logo without the text "vLLM"

addresses https://github.com/obot-platform/obot/issues/1104

Looks like this now:
<img width="2353" alt="image" src="https://github.com/user-attachments/assets/2efc1fb0-c440-4ed7-a8e3-afa3ee858154" />
