### PR TITLE
fix: build: upgrade all packages to fix curl incompatibility

### DIFF
--- a/tools/package-chrome.sh
+++ b/tools/package-chrome.sh
@@ -2,6 +2,9 @@ set -e
 mkdir -p /opt/google/chrome
 
 if [ $(uname -m) = aarch64 ]; then
+	# This is a temporary fix until Chainguard rebuilds the postgres-dev image.
+	sed -i 's|=.*||' /etc/apk/world
+    apk upgrade --no-cache --all
     apk add --no-cache \
         curl \
         font-opensans \


### PR DESCRIPTION
`curl` was not working in the container, causing the image build to fail. We need to upgrade all the packages in the image in order to fix this.

More information: https://github.com/orgs/wolfi-dev/discussions/41391