### PR TITLE
fix: setup tooltip takes user to auth config directly

### DIFF
--- a/ui/admin/app/components/knowledge/AddKnowledgeButton.tsx
+++ b/ui/admin/app/components/knowledge/AddKnowledgeButton.tsx
@@ -18,7 +18,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu";
-import { useOAuthAppList } from "~/hooks/oauthApps/useOAuthApps";
+import { useOauthAppMap } from "~/hooks/oauthApps/useOAuthApps";
 
 interface AddKnowledgeButtonProps {
 	disabled?: boolean;
@@ -36,10 +36,7 @@ export function AddKnowledgeButton({
 	const [requiredConfiguration, setRequiredConfiguration] =
 		useState<OAuthAppSpec | null>(null);
 
-	const oauthApps = useOAuthAppList();
-	const oauthAppsMap = new Map(
-		oauthApps.map((app) => [app.alias ?? app.type, app])
-	);
+	const oauthAppsMap = useOauthAppMap();
 
 	const handleSelect = (knowledgeSourceType: KnowledgeSourceType) => {
 		const specType =

--- a/ui/admin/app/components/tools/ToolCatalog.tsx
+++ b/ui/admin/app/components/tools/ToolCatalog.tsx
@@ -2,7 +2,6 @@ import { AlertTriangleIcon, PlusIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import useSWR from "swr";
 
-import { OAuthProvider } from "~/lib/model/oauthApps/oauth-helpers";
 import {
 	ToolCategory,
 	convertToolReferencesToCategoryMap,
@@ -26,7 +25,7 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "~/components/ui/dialog";
-import { useOAuthAppList } from "~/hooks/oauthApps/useOAuthApps";
+import { useOauthAppMap } from "~/hooks/oauthApps/useOAuthApps";
 
 type ToolCatalogProps = React.HTMLAttributes<HTMLDivElement> & {
 	tools: string[];
@@ -61,11 +60,17 @@ export function ToolCatalog({
 	);
 
 	const [search, setSearch] = useState("");
-
-	const oauthApps = useOAuthAppList();
-	const configuredOauthApps = useMemo(() => {
-		return new Set(oauthApps.map((app) => app.alias ?? app.type));
-	}, [oauthApps]);
+	const configuredOauthApps = useOauthAppMap();
+	const configuredTools = useMemo(() => {
+		return new Set(
+			toolList
+				.filter((tool) => {
+					const oauth = tool.metadata?.oauth;
+					return oauth ? configuredOauthApps.has(oauth) : true;
+				})
+				.map((tool) => tool.id)
+		);
+	}, [toolList, configuredOauthApps]);
 
 	const sortedValidCategories = useMemo(() => {
 		return Object.entries(toolCategories).sort(
@@ -142,19 +147,13 @@ export function ToolCatalog({
 					<ToolCatalogGroup
 						key={category}
 						category={category}
-						configured={
-							categoryTools.bundleTool?.metadata?.oauth
-								? configuredOauthApps.has(
-										categoryTools.bundleTool.metadata.oauth as OAuthProvider
-									)
-								: true
-						}
 						tools={categoryTools}
 						selectedTools={selectedTools}
 						onAddTool={handleAddTool}
 						onRemoveTool={handleRemoveTool}
 						expandFor={search}
 						oauths={oauths}
+						configuredTools={configuredTools}
 					/>
 				))}
 			</CommandList>

--- a/ui/admin/app/components/tools/ToolCatalogGroup.tsx
+++ b/ui/admin/app/components/tools/ToolCatalogGroup.tsx
@@ -8,7 +8,7 @@ import { CommandGroup } from "~/components/ui/command";
 
 export function ToolCatalogGroup({
 	category,
-	configured,
+	configuredTools,
 	tools,
 	selectedTools,
 	onAddTool,
@@ -16,7 +16,7 @@ export function ToolCatalogGroup({
 	expandFor,
 }: {
 	category: string;
-	configured: boolean;
+	configuredTools: Set<string>;
 	tools: ToolCategory;
 	selectedTools: string[];
 	onAddTool: (
@@ -79,7 +79,7 @@ export function ToolCatalogGroup({
 			{tools.bundleTool && (
 				<ToolItem
 					tool={tools.bundleTool}
-					configured={configured}
+					configured={configuredTools.has(tools.bundleTool.id)}
 					isSelected={selectedTools.includes(tools.bundleTool.id)}
 					isBundleSelected={false}
 					onSelect={(toolOauthToAdd) =>
@@ -95,14 +95,15 @@ export function ToolCatalogGroup({
 				tools.tools.map((categoryTool) => (
 					<ToolItem
 						key={categoryTool.id}
-						configured={configured}
 						tool={categoryTool}
+						configured={configuredTools.has(categoryTool.id)}
 						isSelected={selectedTools.includes(categoryTool.id)}
 						isBundleSelected={
 							tools.bundleTool
 								? selectedTools.includes(tools.bundleTool.id)
 								: false
 						}
+						hideWarning={!!tools.bundleTool}
 						onSelect={(toolOauthToAdd) =>
 							handleSelect(categoryTool.id, toolOauthToAdd)
 						}

--- a/ui/admin/app/components/tools/ToolItem.tsx
+++ b/ui/admin/app/components/tools/ToolItem.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ToolReference } from "~/lib/model/toolReferences";
 import { cn } from "~/lib/utils";
 
+import { ToolOauthConfig } from "~/components/tools//ToolOauthConfig";
 import { SelectToolAuth } from "~/components/tools/SelectToolAuth";
 import { ToolIcon } from "~/components/tools/ToolIcon";
 import { ToolTooltip } from "~/components/tools/ToolTooltip";
@@ -14,6 +15,7 @@ import { CommandItem } from "~/components/ui/command";
 type ToolItemProps = {
 	tool: ToolReference;
 	configured: boolean;
+	hideWarning?: boolean;
 	isSelected: boolean;
 	isBundleSelected: boolean;
 	onSelect: (oAuthToAdd?: string) => void;
@@ -26,6 +28,7 @@ type ToolItemProps = {
 export function ToolItem({
 	tool,
 	configured,
+	hideWarning,
 	isSelected,
 	isBundleSelected,
 	onSelect,
@@ -66,7 +69,11 @@ export function ToolItem({
 				onSelect={available ? handleSelect : undefined}
 				disabled={isBundleSelected}
 			>
-				<ToolTooltip tool={tool} requiresConfiguration={!available}>
+				<ToolTooltip
+					tool={tool}
+					requiresConfiguration={!available}
+					onConfigureAuth={() => setToolOAuthDialogOpen(true)}
+				>
 					<div className={cn("flex w-full items-center justify-between gap-2")}>
 						<span
 							className={cn(
@@ -78,7 +85,7 @@ export function ToolItem({
 						>
 							{available ? (
 								<Checkbox checked={isSelected || isBundleSelected} />
-							) : isBundle ? (
+							) : !hideWarning ? (
 								<TriangleAlertIcon className="h-4 w-4 text-warning opacity-50" />
 							) : null}
 
@@ -118,6 +125,14 @@ export function ToolItem({
 					onOpenChange={setToolOAuthDialogOpen}
 					onOAuthSelect={handleOAuthSelect}
 					onPATSelect={handlePATSelect}
+				/>
+			)}
+			{oAuthMetadata && !isPATSupported && (
+				<ToolOauthConfig
+					tool={tool}
+					open={toolOAuthDialogOpen}
+					onOpenChange={setToolOAuthDialogOpen}
+					onSuccess={() => setToolOAuthDialogOpen(false)}
 				/>
 			)}
 		</>

--- a/ui/admin/app/components/tools/ToolOauthConfig.tsx
+++ b/ui/admin/app/components/tools/ToolOauthConfig.tsx
@@ -1,0 +1,45 @@
+import { OAuthProvider } from "~/lib/model/oauthApps/oauth-helpers";
+import { ToolReference } from "~/lib/model/toolReferences";
+
+import { CustomOauthAppDetail } from "~/components/oauth-apps/shared/CustomOauthAppDetail";
+import { OAuthAppDetail } from "~/components/oauth-apps/shared/OAuthAppDetail";
+import { useOauthAppMap } from "~/hooks/oauthApps/useOAuthApps";
+
+type ToolOauthConfigProps = {
+	tool?: ToolReference;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSuccess?: () => void;
+};
+
+export function ToolOauthConfig({
+	tool,
+	open,
+	onOpenChange,
+	onSuccess,
+}: ToolOauthConfigProps) {
+	const oauthAppsMap = useOauthAppMap();
+	const oauthMetadata = tool?.metadata?.oauth;
+	if (!oauthMetadata) return null;
+
+	const oauth = oauthAppsMap.get(tool?.metadata?.oauth ?? "");
+	const isSpecedOauth =
+		oauthMetadata &&
+		Object.values(OAuthProvider).includes(oauthMetadata as OAuthProvider);
+
+	return isSpecedOauth ? (
+		<OAuthAppDetail
+			open={open}
+			onOpenChange={onOpenChange}
+			onSuccess={onSuccess}
+			type={oauthMetadata as OAuthProvider}
+		/>
+	) : (
+		<CustomOauthAppDetail
+			open={open}
+			onOpenChange={onOpenChange}
+			app={oauth}
+			alias={oauthMetadata}
+		/>
+	);
+}

--- a/ui/admin/app/components/tools/ToolTooltip.tsx
+++ b/ui/admin/app/components/tools/ToolTooltip.tsx
@@ -1,10 +1,9 @@
 import { TriangleAlertIcon, WrenchIcon } from "lucide-react";
-import { $path } from "safe-routes";
 
 import { ToolReference } from "~/lib/model/toolReferences";
 
 import { ToolIcon } from "~/components/tools/ToolIcon";
-import { Link } from "~/components/ui/link";
+import { Button } from "~/components/ui/button";
 import {
 	Tooltip,
 	TooltipContent,
@@ -14,6 +13,7 @@ import {
 type ToolTooltipProps = {
 	tool: ToolReference;
 	children: React.ReactNode;
+	onConfigureAuth?: () => void;
 	requiresConfiguration?: boolean;
 	isBundle?: boolean;
 };
@@ -21,6 +21,7 @@ type ToolTooltipProps = {
 export function ToolTooltip({
 	tool,
 	children,
+	onConfigureAuth,
 	requiresConfiguration,
 	isBundle = false,
 }: ToolTooltipProps) {
@@ -50,16 +51,20 @@ export function ToolTooltip({
 					<p className="text-sm">
 						{tool.description || "No description provided."}
 					</p>
-					{requiresConfiguration && (
+					{requiresConfiguration && onConfigureAuth && (
 						<>
 							<div className="flex items-center gap-1 pt-2 text-xs text-warning">
 								<span>
 									<TriangleAlertIcon className="h-4 w-4 text-warning" />
 								</span>
 								<p>
-									<Link to={$path("/tools")} className="text-xs">
+									<Button
+										variant="link"
+										className="p-0 text-xs"
+										onClick={onConfigureAuth}
+									>
 										Setup
-									</Link>{" "}
+									</Button>{" "}
 									required to use this tool.
 								</p>
 							</div>

--- a/ui/admin/app/components/tools/__tests__/ToolCatalog.test.tsx
+++ b/ui/admin/app/components/tools/__tests__/ToolCatalog.test.tsx
@@ -1,0 +1,50 @@
+import {
+	overrideServer,
+	render,
+	screen,
+	userEvent,
+	waitFor,
+	within,
+} from "test";
+import { toolsHandlers } from "test/mocks/handlers/tools";
+
+import { noop } from "~/lib/utils/noop";
+
+import { ToolCatalog } from "~/components/tools/ToolCatalog";
+
+describe(ToolCatalog, () => {
+	beforeEach(() => {
+		overrideServer(toolsHandlers);
+
+		// Mock scrollIntoView
+		Element.prototype.scrollIntoView = vi.fn();
+	});
+	it("No setup option in tooltip if tool does not need oauth configuration", async () => {
+		render(<ToolCatalog tools={[]} oauths={[]} onUpdateTools={noop} />);
+
+		const tool = await screen.findByText("Browser");
+		await userEvent.hover(tool);
+		await waitFor(() =>
+			expect(screen.getByRole("tooltip")).toBeInTheDocument()
+		);
+
+		expect(screen.queryByText("Setup")).not.toBeInTheDocument();
+	});
+	it("Clicking setup for a tool that needs oauth configuration opens the setup dialog", async () => {
+		render(<ToolCatalog tools={[]} oauths={[]} onUpdateTools={noop} />);
+
+		const tool = await screen.findByText("Gmail");
+		await userEvent.hover(tool);
+		await waitFor(() =>
+			expect(screen.getByRole("tooltip")).toBeInTheDocument()
+		);
+
+		const setupButton = await within(screen.getByRole("tooltip")).findByText(
+			"Setup"
+		);
+		await userEvent.click(setupButton);
+		await waitFor(() =>
+			expect(screen.getByText("Configure Google OAuth App")).toBeInTheDocument()
+		);
+	});
+});

--- a/ui/admin/app/components/tools/toolGrid/ToolCardActions.tsx
+++ b/ui/admin/app/components/tools/toolGrid/ToolCardActions.tsx
@@ -3,14 +3,12 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { mutate } from "swr";
 
-import { OAuthProvider } from "~/lib/model/oauthApps/oauth-helpers";
 import { ToolReference } from "~/lib/model/toolReferences";
 import { ToolReferenceService } from "~/lib/service/api/toolreferenceService";
 import { cn } from "~/lib/utils";
 
 import { ConfirmationDialog } from "~/components/composed/ConfirmationDialog";
-import { CustomOauthAppDetail } from "~/components/oauth-apps/shared/CustomOauthAppDetail";
-import { OAuthAppDetail } from "~/components/oauth-apps/shared/OAuthAppDetail";
+import { ToolOauthConfig } from "~/components/tools/ToolOauthConfig";
 import { LoadingSpinner } from "~/components/ui/LoadingSpinner";
 import { Button } from "~/components/ui/button";
 import {
@@ -20,7 +18,7 @@ import {
 	DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu";
 import { useConfirmationDialog } from "~/hooks/component-helpers/useConfirmationDialog";
-import { useOAuthAppList } from "~/hooks/oauthApps/useOAuthApps";
+import { useOauthAppMap } from "~/hooks/oauthApps/useOAuthApps";
 import { useAsync } from "~/hooks/useAsync";
 import { usePollSingleTool } from "~/hooks/usePollSingleTool";
 
@@ -28,10 +26,7 @@ export function ToolCardActions({ tool }: { tool: ToolReference }) {
 	const [configureAuthOpen, setConfigureAuthOpen] = useState(false);
 	const { dialogProps, interceptAsync } = useConfirmationDialog();
 
-	const oauthApps = useOAuthAppList();
-	const oauthAppsMap = new Map(
-		oauthApps.map((app) => [app.alias ?? app.type, app])
-	);
+	const oauthAppsMap = useOauthAppMap();
 	const oauth = oauthAppsMap.get(tool?.metadata?.oauth ?? "");
 
 	const deleteTool = useAsync(ToolReferenceService.deleteToolReference, {
@@ -60,10 +55,6 @@ export function ToolCardActions({ tool }: { tool: ToolReference }) {
 		interceptAsync(() => deleteTool.executeAsync(tool.id));
 
 	const toolOauthMetadata = tool.metadata?.oauth;
-
-	const isSpecedOauth =
-		toolOauthMetadata &&
-		Object.values(OAuthProvider).includes(toolOauthMetadata as OAuthProvider);
 	const requiresConfiguration = toolOauthMetadata && !oauth;
 
 	if (tool.builtin && !toolOauthMetadata) return null;
@@ -87,9 +78,7 @@ export function ToolCardActions({ tool }: { tool: ToolReference }) {
 							className={cn("flex items-center gap-1", {
 								"text-warning": requiresConfiguration,
 							})}
-							onClick={() => {
-								setConfigureAuthOpen(true);
-							}}
+							onClick={() => setConfigureAuthOpen(true)}
 						>
 							{requiresConfiguration && (
 								<TriangleAlertIcon className="h-4 w-4 text-warning" />
@@ -122,22 +111,11 @@ export function ToolCardActions({ tool }: { tool: ToolReference }) {
 					disabled: deleteTool.isLoading,
 				}}
 			/>
-			{toolOauthMetadata ? (
-				isSpecedOauth ? (
-					<OAuthAppDetail
-						open={configureAuthOpen}
-						onOpenChange={setConfigureAuthOpen}
-						type={toolOauthMetadata as OAuthProvider}
-					/>
-				) : (
-					<CustomOauthAppDetail
-						open={configureAuthOpen}
-						onOpenChange={setConfigureAuthOpen}
-						app={oauth}
-						alias={toolOauthMetadata}
-					/>
-				)
-			) : null}
+			<ToolOauthConfig
+				tool={tool}
+				open={configureAuthOpen}
+				onOpenChange={setConfigureAuthOpen}
+			/>
 		</>
 	);
 }

--- a/ui/admin/app/hooks/oauthApps/useOAuthApps.ts
+++ b/ui/admin/app/hooks/oauthApps/useOAuthApps.ts
@@ -29,3 +29,8 @@ export function useOAuthAppInfo(type: OAuthProvider) {
 
 	return app;
 }
+
+export function useOauthAppMap() {
+	const list = useOAuthAppList({ revalidate: false });
+	return new Map(list.map((app) => [app.alias ?? app.type, app]));
+}

--- a/ui/admin/test/mocks/models/toolReferences.ts
+++ b/ui/admin/test/mocks/models/toolReferences.ts
@@ -173,6 +173,54 @@ export const mockedBrowserToolBundle: ToolReference[] = [
 	},
 ];
 
+export const mockedBundleWithOauthReference: ToolReference[] = [
+	{
+		id: "google-gmail-bundle",
+		created: "2025-02-05T13:54:26-05:00",
+		revision: "1",
+		metadata: {
+			bundle: "true",
+			category: "Gmail",
+			icon: "gmail_icon_small.png",
+			oauth: "google",
+		},
+		type: "toolreference",
+		name: "Gmail",
+		toolType: "tool",
+		reference: "github.com/obot-platform/tools/google/gmail",
+		active: true,
+		resolved: true,
+		builtin: true,
+		description: "Tools for interacting with a user's Gmail account",
+		credentials: ["github.com/obot-platform/tools/google/credential"],
+	},
+	{
+		id: "google-gmail-list-drafts",
+		created: "2025-02-05T13:54:26-05:00",
+		revision: "1",
+		metadata: {
+			category: "Gmail",
+			icon: "gmail_icon_small.png",
+			oauth: "google",
+		},
+		type: "toolreference",
+		name: "List Drafts",
+		toolType: "tool",
+		reference: "List Drafts from github.com/obot-platform/tools/google/gmail",
+		active: true,
+		resolved: true,
+		builtin: true,
+		description: "List drafts in a user's Gmail account",
+		credentials: ["github.com/obot-platform/tools/google/credential"],
+		params: {
+			attachments:
+				"A comma separated list of workspace file paths to attach to the email (Optional)",
+			max_results:
+				"Maximum number of drafts to list (Optional: Default will list 100 drafts)",
+		},
+	},
+];
+
 export const mockedToolReferences: ToolReference[] = [
 	mockedDatabaseToolReference,
 	mockedKnowledgeToolReference,
@@ -180,4 +228,5 @@ export const mockedToolReferences: ToolReference[] = [
 	mockedWorkspaceFilesToolReference,
 	...mockedImageToolBundle,
 	...mockedBrowserToolBundle,
+	...mockedBundleWithOauthReference,
 ];


### PR DESCRIPTION
https://github.com/user-attachments/assets/176bfbc2-5c6d-4a15-9c13-baef08adc513

* opens up the auth config instead when clicking 'Setup' in the Tool Tooltip
* fix for tool that doesn't have bundle but has oauth not showing it requires configuration

- [x] TODO: test cases

Addresses #1408 