### PR TITLE
Chore: support setting timezone for cronjob

### DIFF
--- a/apiclient/types/cronjob.go
+++ b/apiclient/types/cronjob.go
@@ -3,9 +3,10 @@ package types
 type CronJob struct {
 	Metadata
 	CronJobManifest
-	LastRunStartedAt           *Time `json:"lastRunStartedAt,omitempty"`
-	LastSuccessfulRunCompleted *Time `json:"lastSuccessfulRunCompleted,omitempty"`
-	NextRunAt                  *Time `json:"nextRunAt,omitempty"`
+	LastRunStartedAt           *Time  `json:"lastRunStartedAt,omitempty"`
+	LastSuccessfulRunCompleted *Time  `json:"lastSuccessfulRunCompleted,omitempty"`
+	NextRunAt                  *Time  `json:"nextRunAt,omitempty"`
+	Timezone                   string `json:"timezone,omitempty"`
 }
 
 type CronJobManifest struct {
@@ -14,6 +15,9 @@ type CronJobManifest struct {
 	Workflow     string    `json:"workflow,omitempty"`
 	Input        string    `json:"input,omitempty"`
 	TaskSchedule *Schedule `json:"taskSchedule,omitempty"`
+
+	// Timezone is the timezone to use for the cron job. If not set, the UTC timezone is used
+	Timezone string `json:"timezone,omitempty"`
 }
 
 type CronJobList List[CronJob]

--- a/apiclient/types/tasks.go
+++ b/apiclient/types/tasks.go
@@ -35,6 +35,7 @@ type Schedule struct {
 	Minute   int    `json:"minute"`
 	Day      int    `json:"day"`
 	Weekday  int    `json:"weekday"`
+	Timezone string `json:"timezone"`
 }
 
 type TaskStep struct {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -1217,6 +1217,12 @@ func schema_obot_platform_obot_apiclient_types_CronJob(ref common.ReferenceCallb
 							Ref: ref("github.com/obot-platform/obot/apiclient/types.Time"),
 						},
 					},
+					"timezone": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"Metadata", "CronJobManifest"},
 			},
@@ -1287,6 +1293,13 @@ func schema_obot_platform_obot_apiclient_types_CronJobManifest(ref common.Refere
 					"taskSchedule": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("github.com/obot-platform/obot/apiclient/types.Schedule"),
+						},
+					},
+					"timezone": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Timezone is the timezone to use for the cron job. If not set, the UTC timezone is used",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -3203,8 +3216,15 @@ func schema_obot_platform_obot_apiclient_types_Schedule(ref common.ReferenceCall
 							Format:  "int32",
 						},
 					},
+					"timezone": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 				},
-				Required: []string{"interval", "hour", "minute", "day", "weekday"},
+				Required: []string{"interval", "hour", "minute", "day", "weekday", "timezone"},
 			},
 		},
 	}
@@ -5804,6 +5824,13 @@ func schema_storage_apis_obotobotai_v1_CronJobSpec(ref common.ReferenceCallback)
 					"taskSchedule": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("github.com/obot-platform/obot/apiclient/types.Schedule"),
+						},
+					},
+					"timezone": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Timezone is the timezone to use for the cron job. If not set, the UTC timezone is used",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"threadName": {

--- a/ui/admin/app/components/workflow-triggers/shared/ScheduleSelection.tsx
+++ b/ui/admin/app/components/workflow-triggers/shared/ScheduleSelection.tsx
@@ -6,12 +6,14 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "~/components/ui/select";
+import { TimezoneSelection } from "~/components/workflow-triggers/shared/TimezoneSelection";
 
 type ScheduleSelectionProps = {
 	disabled?: boolean;
 	label?: string;
 	onChange: (schedule: string) => void;
 	value: string;
+	timezone: string;
 };
 
 export function ScheduleSelection({
@@ -19,6 +21,7 @@ export function ScheduleSelection({
 	label,
 	onChange,
 	value,
+	timezone,
 }: ScheduleSelectionProps) {
 	const cronFrequency = getCronFrequency(value ?? "");
 
@@ -73,6 +76,7 @@ export function ScheduleSelection({
 						))}
 					</SelectContent>
 				</Select>
+				<TimezoneSelection timezone={timezone} />
 			</div>
 		</fieldset>
 	);

--- a/ui/admin/app/components/workflow-triggers/shared/TimezoneSelection.tsx
+++ b/ui/admin/app/components/workflow-triggers/shared/TimezoneSelection.tsx
@@ -7,11 +7,9 @@ type TimezoneSelectionProps = {
 };
 
 export function TimezoneSelection({ timezone }: TimezoneSelectionProps) {
-	const defaultTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
 	return (
 		<div className="flex-r flex items-center">
-			{timezone && timezone !== defaultTimezone && (
+			{timezone && (
 				<>
 					<GlobeIcon className="mr-2 h-4 w-4 text-muted-foreground" />
 					<Label className="text-sm text-muted-foreground">{timezone}</Label>

--- a/ui/admin/app/components/workflow-triggers/shared/TimezoneSelection.tsx
+++ b/ui/admin/app/components/workflow-triggers/shared/TimezoneSelection.tsx
@@ -1,0 +1,22 @@
+import { GlobeIcon } from "lucide-react";
+
+import { Label } from "~/components/ui/label";
+
+type TimezoneSelectionProps = {
+	timezone: string;
+};
+
+export function TimezoneSelection({ timezone }: TimezoneSelectionProps) {
+	const defaultTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+	return (
+		<div className="flex-r flex items-center">
+			{timezone && timezone !== defaultTimezone && (
+				<>
+					<GlobeIcon className="mr-2 h-4 w-4 text-muted-foreground" />
+					<Label className="text-sm text-muted-foreground">{timezone}</Label>
+				</>
+			)}
+		</div>
+	);
+}

--- a/ui/admin/app/components/workflow/triggers/WorkflowScheduleTab.tsx
+++ b/ui/admin/app/components/workflow/triggers/WorkflowScheduleTab.tsx
@@ -54,7 +54,9 @@ export function WorkflowScheduleTab({ workflowId }: { workflowId: string }) {
 									? taskScheduleToCron(cronJob.taskSchedule)
 									: cronJob?.schedule) ?? ""
 							}
+							timezone={cronJob?.timezone ?? ""}
 						/>
+
 						<Button
 							size="icon"
 							variant="ghost"
@@ -76,6 +78,7 @@ export function WorkflowScheduleTab({ workflowId }: { workflowId: string }) {
 					createCronJob.execute({
 						...defaultSchedule,
 						workflow: workflowId,
+						timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 					})
 				}
 			>

--- a/ui/admin/app/components/workflow/triggers/WorkflowScheduleTab.tsx
+++ b/ui/admin/app/components/workflow/triggers/WorkflowScheduleTab.tsx
@@ -17,6 +17,7 @@ const defaultSchedule = {
 		hour: 0,
 		day: 0,
 		weekday: 0,
+		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 	},
 };
 
@@ -32,7 +33,7 @@ export function WorkflowScheduleTab({ workflowId }: { workflowId: string }) {
 		updateCronJob(cronJobId, {
 			...rest,
 			schedule: cronString,
-			taskSchedule: cronToTaskSchedule(cronString),
+			taskSchedule: cronToTaskSchedule(cronString, cronJob.timezone),
 		});
 	};
 
@@ -116,7 +117,8 @@ export function WorkflowScheduleTab({ workflowId }: { workflowId: string }) {
 	}
 
 	function cronToTaskSchedule(
-		cronString: string
+		cronString: string,
+		timezone: string
 	): CronJob["taskSchedule"] | undefined {
 		// Match groups: (minute) (hour) (day) (month) (weekday)
 		const matches = cronString.match(/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$/);
@@ -126,7 +128,14 @@ export function WorkflowScheduleTab({ workflowId }: { workflowId: string }) {
 
 		// Hourly patterns
 		if (minute === "0" && hour === "*") {
-			return { interval: "hourly", minute: 0, hour: 0, day: 0, weekday: 0 };
+			return {
+				interval: "hourly",
+				minute: 0,
+				hour: 0,
+				day: 0,
+				weekday: 0,
+				timezone,
+			};
 		}
 		const minuteInterval = minute.match(/^\*\/(\d+)$/);
 		if (minuteInterval && hour === "*") {
@@ -136,6 +145,7 @@ export function WorkflowScheduleTab({ workflowId }: { workflowId: string }) {
 				hour: 0,
 				day: 0,
 				weekday: 0,
+				timezone,
 			};
 		}
 
@@ -152,6 +162,7 @@ export function WorkflowScheduleTab({ workflowId }: { workflowId: string }) {
 				hour: parseInt(hour),
 				day: 0,
 				weekday: 0,
+				timezone,
 			};
 		}
 
@@ -163,6 +174,7 @@ export function WorkflowScheduleTab({ workflowId }: { workflowId: string }) {
 				hour: 0,
 				day: 0,
 				weekday: parseInt(weekday),
+				timezone,
 			};
 		}
 
@@ -179,6 +191,7 @@ export function WorkflowScheduleTab({ workflowId }: { workflowId: string }) {
 				hour: 0,
 				day: day === "L" ? -1 : parseInt(day) - 1, // day starts from 0 index
 				weekday: 0,
+				timezone,
 			};
 		}
 	}

--- a/ui/admin/app/lib/model/cronjobs.ts
+++ b/ui/admin/app/lib/model/cronjobs.ts
@@ -11,6 +11,7 @@ export type CronJobBase = {
 		minute: number;
 		weekday: number;
 	};
+	timezone: string;
 	input?: string;
 };
 

--- a/ui/admin/app/lib/model/cronjobs.ts
+++ b/ui/admin/app/lib/model/cronjobs.ts
@@ -10,6 +10,7 @@ export type CronJobBase = {
 		hour: number;
 		minute: number;
 		weekday: number;
+		timezone: string;
 	};
 	timezone: string;
 	input?: string;

--- a/ui/user/src/lib/components/tasks/Schedule.svelte
+++ b/ui/user/src/lib/components/tasks/Schedule.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Schedule } from '$lib/services';
 	import Dropdown from '$lib/components/tasks/Dropdown.svelte';
+	import { GlobeIcon } from 'lucide-svelte/icons';
 
 	interface Props {
 		schedule?: Schedule;
@@ -15,10 +16,13 @@
 			hour: 0,
 			minute: 0,
 			day: 0,
-			weekday: 0
+			weekday: 0,
+			timezone: ''
 		},
 		onChanged
 	}: Props = $props();
+
+	let defaultTimezone = $state(Intl.DateTimeFormat().resolvedOptions().timeZone);
 </script>
 
 <h3 class="text-lg font-semibold">Schedule</h3>
@@ -63,29 +67,37 @@
 	{/if}
 
 	{#if schedule.interval === 'daily'}
-		<Dropdown
-			values={{
-				'0': 'midnight',
-				'3': '3 AM',
-				'6': '6 AM',
-				'9': '9 AM',
-				'12': 'noon',
-				'15': '3 PM',
-				'18': '6 PM',
-				'21': '9 PM'
-			}}
-			selected={schedule?.hour.toString()}
-			disabled={!editMode}
-			onSelected={(value) => {
-				onChanged?.({
-					...schedule,
-					minute: 0,
-					hour: parseInt(value),
-					day: 0,
-					weekday: 0
-				});
-			}}
-		/>
+		<div class="flex items-center gap-2">
+			<Dropdown
+				values={{
+					'0': 'midnight',
+					'3': '3 AM',
+					'6': '6 AM',
+					'9': '9 AM',
+					'12': 'noon',
+					'15': '3 PM',
+					'18': '6 PM',
+					'21': '9 PM'
+				}}
+				selected={schedule?.hour.toString()}
+				disabled={!editMode}
+				onSelected={(value) => {
+					onChanged?.({
+						...schedule,
+						minute: 0,
+						hour: parseInt(value),
+						day: 0,
+						weekday: 0
+					});
+				}}
+			/>
+			{#if schedule?.timezone && schedule.timezone !== defaultTimezone}
+				<div class="flex items-center gap-1">
+					<GlobeIcon class="text-muted-foreground mr-1 h-4 w-4" />
+					<span class="text-muted-foreground text-sm">{schedule.timezone}</span>
+				</div>
+			{/if}
+		</div>
 	{/if}
 
 	{#if schedule.interval === 'weekly'}
@@ -111,6 +123,10 @@
 				});
 			}}
 		/>
+		{#if schedule?.timezone && schedule.timezone !== defaultTimezone}
+			<GlobeIcon class="text-muted-foreground mr-1 h-4 w-4" />
+			<span class="text-muted-foreground text-sm">{schedule.timezone}</span>
+		{/if}
 	{/if}
 
 	{#if schedule.interval === 'monthly'}
@@ -137,5 +153,9 @@
 				});
 			}}
 		/>
+		{#if schedule?.timezone && schedule.timezone !== defaultTimezone}
+			<GlobeIcon class="text-muted-foreground mr-1 h-4 w-4" />
+			<span class="text-muted-foreground text-sm">{schedule.timezone}</span>
+		{/if}
 	{/if}
 </div>

--- a/ui/user/src/lib/components/tasks/Type.svelte
+++ b/ui/user/src/lib/components/tasks/Type.svelte
@@ -18,6 +18,7 @@
 		return Object.keys(task?.onDemand?.params ?? {}).length === 0;
 	});
 	let version: Version = $state({});
+	let defaultTimezone = $state(Intl.DateTimeFormat().resolvedOptions().timeZone);
 	let options = $derived.by(() => {
 		const options: Record<string, string> = {
 			onDemand: 'on demand',
@@ -61,7 +62,8 @@
 					hour: 0,
 					minute: 0,
 					day: 0,
-					weekday: 0
+					weekday: 0,
+					timezone: defaultTimezone
 				},
 				webhook: undefined,
 				email: undefined,

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -239,6 +239,7 @@ export interface Schedule {
 	minute: number;
 	day: number;
 	weekday: number;
+	timezone: string;
 }
 
 export interface TaskList {


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/1480

Adding support to run cronjob in a specific timezone. It will default to server's own timezone if it is not set in API. The browser will now set the user's own timezone as default but user will be able to change it.

https://www.loom.com/share/052bd151e46b4c1cb37e28b281687a50