### PR TITLE
fix: allow model provider definition to be updated

### DIFF
--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -98,8 +98,8 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.KnowledgeSource{}).HandlerFunc(knowledgesource.Sync)
 
 	// ToolReferences
-	root.Type(&v1.ToolReference{}).HandlerFunc(toolRef.BackPopulateModels)
 	root.Type(&v1.ToolReference{}).HandlerFunc(toolRef.Populate)
+	root.Type(&v1.ToolReference{}).HandlerFunc(toolRef.BackPopulateModels)
 	root.Type(&v1.ToolReference{}).IncludeFinalizing().HandlerFunc(removeOldFinalizers)
 	root.Type(&v1.ToolReference{}).FinalizeFunc(v1.ToolReferenceFinalizer, toolRef.CleanupModelProvider)
 


### PR DESCRIPTION
If the model provider tool reference definition is wrong, then it will never be fixed because returning an error means that the status will not be properly saved. Reversing the order of the controllers ensures that the definition can be updated before we try to deal with the model provider.