### PR TITLE
chore: create safer, fault tolerant method of cache key invalidation with service method primitives

### DIFF
--- a/ui/admin/app/components/agent/AgentContext.tsx
+++ b/ui/admin/app/components/agent/AgentContext.tsx
@@ -58,7 +58,7 @@ export function AgentProvider({
 			AgentService.updateAgent({ id: agentId, agent: updatedAgent })
 				.then((updatedAgent) => {
 					getAgent.mutate(updatedAgent);
-					AgentService.getAgents.revalidate({});
+					AgentService.getAgents.revalidate();
 					setLastSaved(new Date());
 				})
 				.catch(console.error),

--- a/ui/admin/app/components/chat/shared/thread-helpers.ts
+++ b/ui/admin/app/components/chat/shared/thread-helpers.ts
@@ -82,12 +82,10 @@ export function useThreadAgents(threadId?: Nullish<string>) {
 
 export function useThreadCredentials(threadId: Nullish<string>) {
 	const getCredentials = useSWR(
-		CredentialApiService.getCredentials.key(
-			CredentialNamespace.Threads,
-			threadId
-		),
-		({ namespace, entityId }) =>
-			CredentialApiService.getCredentials(namespace, entityId)
+		...CredentialApiService.getCredentials.swr({
+			namespace: CredentialNamespace.Threads,
+			entityId: threadId,
+		})
 	);
 
 	const handleDeleteCredential = async (credentialName: string) => {

--- a/ui/admin/app/components/workflow-triggers/ScheduleForm.tsx
+++ b/ui/admin/app/components/workflow-triggers/ScheduleForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
 import { $path } from "safe-routes";
 import { toast } from "sonner";
-import useSWR, { mutate } from "swr";
+import useSWR from "swr";
 import { z } from "zod";
 
 import { CronJob } from "~/lib/model/cronjobs";
@@ -44,9 +44,9 @@ export function ScheduleForm({ cronjob }: { cronjob?: CronJob }) {
 
 	const handleSubmitSuccess = () => {
 		if (cronjob) {
-			mutate(CronJobApiService.getCronJobById(cronjob.id));
+			CronJobApiService.getCronJobById.revalidate(cronjob);
 		}
-		mutate(CronJobApiService.getCronJobs.key());
+		CronJobApiService.getCronJobs.revalidate();
 		navigate($path("/workflow-triggers"));
 	};
 

--- a/ui/admin/app/hooks/cronjob/useCronjob.tsx
+++ b/ui/admin/app/hooks/cronjob/useCronjob.tsx
@@ -1,5 +1,5 @@
 import { toast } from "sonner";
-import useSWR, { mutate } from "swr";
+import useSWR from "swr";
 
 import { CronJobBase } from "~/lib/model/cronjobs";
 import { CronJobApiService } from "~/lib/service/api/cronjobApiService";
@@ -7,8 +7,8 @@ import { CronJobApiService } from "~/lib/service/api/cronjobApiService";
 import { useAsync } from "~/hooks/useAsync";
 
 export function useCronjob(workflowId?: string) {
-	const getCronJobs = useSWR(CronJobApiService.getCronJobs.key(), () =>
-		CronJobApiService.getCronJobs()
+	const getCronJobs = useSWR(
+		...CronJobApiService.getCronJobs.swr({ filters: { workflowId } })
 	);
 
 	const cronJobs = getCronJobs.data
@@ -20,7 +20,7 @@ export function useCronjob(workflowId?: string) {
 			if (error instanceof Error) toast.error("Something went wrong");
 		},
 		onSettled: () => {
-			mutate(CronJobApiService.getCronJobs.key());
+			getCronJobs.mutate();
 		},
 	});
 
@@ -29,7 +29,7 @@ export function useCronjob(workflowId?: string) {
 			if (error instanceof Error) toast.error("Something went wrong");
 		},
 		onSettled: () => {
-			mutate(CronJobApiService.getCronJobs.key());
+			getCronJobs.mutate();
 		},
 	});
 
@@ -38,7 +38,7 @@ export function useCronjob(workflowId?: string) {
 			if (error instanceof Error) toast.error("Something went wrong");
 		},
 		onSettled: () => {
-			mutate(CronJobApiService.getCronJobs.key());
+			getCronJobs.mutate();
 		},
 	});
 

--- a/ui/admin/app/hooks/workflow-triggers/useWorkflowTriggers.ts
+++ b/ui/admin/app/hooks/workflow-triggers/useWorkflowTriggers.ts
@@ -49,8 +49,10 @@ export function useWorkflowTriggers(props?: UseWorkflowTriggersProps) {
 	}, [emailReceivers]);
 
 	const { data: cronjobs } = useSWR(
-		types.has("schedule") && CronJobApiService.getCronJobs.key(filters),
-		({ filters }) => CronJobApiService.getCronJobs(filters),
+		...CronJobApiService.getCronJobs.swr(
+			{ filters },
+			{ enabled: types.has("schedule") }
+		),
 		{ fallbackData: [] }
 	);
 

--- a/ui/admin/app/lib/service/api/agentService.ts
+++ b/ui/admin/app/lib/service/api/agentService.ts
@@ -27,7 +27,7 @@ const getAgents = createFetcher(
 
 		return res.data.items ?? ([] as Agent[]);
 	},
-	() => ["agents"]
+	() => ApiRoutes.agents.base().path
 );
 
 const getAgentById = createFetcher(
@@ -41,7 +41,7 @@ const getAgentById = createFetcher(
 
 		return res.data;
 	},
-	({ agentId }) => ["agents", agentId]
+	() => ApiRoutes.agents.getById(":agentId").path
 );
 
 const createAgent = createMutator(
@@ -95,7 +95,7 @@ const getAuthUrlForAgent = createFetcher(
 
 		return res.data.authStatus?.[toolRef];
 	},
-	({ agentId, toolRef }) => ["agents", agentId, "AuthUrl", toolRef]
+	() => ApiRoutes.agents.getAuthUrlForAgent(":agentId", ":toolRef").path
 );
 
 const getAgentAuthorizations = createFetcher(
@@ -109,7 +109,7 @@ const getAgentAuthorizations = createFetcher(
 
 		return res.data.items;
 	},
-	({ agentId }) => ["agents", agentId, "Authorizations"]
+	() => ApiRoutes.agents.getAuthorizations(":agentId").path
 );
 
 type AddAgentAuthorizationParams = {
@@ -157,7 +157,7 @@ const getWorkspaceFiles = createFetcher(
 
 		return res.data.items;
 	},
-	({ agentId }) => ["agents", agentId, "WorkspaceFiles"]
+	() => ApiRoutes.agents.getWorkspaceFiles(":agentId").path
 );
 
 type UploadWorkspaceFileParams = {

--- a/ui/admin/app/lib/service/api/credentialApiService.ts
+++ b/ui/admin/app/lib/service/api/credentialApiService.ts
@@ -6,13 +6,7 @@ import { ApiRoutes } from "~/lib/routers/apiRoutes";
 import { request } from "~/lib/service/api/primitives";
 import { createFetcher } from "~/lib/service/api/service-primitives";
 
-const keys = {
-	byEntity: (namespace: CredentialNamespace, entityId: string) => [
-		namespace,
-		entityId,
-		"credentials",
-	],
-};
+const param = (x: string) => x as Todo;
 
 const getCredentialsFetcher = createFetcher(
 	z.object({
@@ -25,7 +19,8 @@ const getCredentialsFetcher = createFetcher(
 
 		return data.items ?? [];
 	},
-	({ namespace, entityId }) => keys.byEntity(namespace, entityId)
+	() =>
+		ApiRoutes.credentials.getCredentials(param(":namespace"), ":entityId").path
 );
 
 async function deleteCredential(

--- a/ui/admin/app/lib/service/api/cronjobApiService.ts
+++ b/ui/admin/app/lib/service/api/cronjobApiService.ts
@@ -6,11 +6,6 @@ import { ApiRoutes } from "~/lib/routers/apiRoutes";
 import { request } from "~/lib/service/api/primitives";
 import { createFetcher } from "~/lib/service/api/service-primitives";
 
-const keys = {
-	all: () => ["cronjobs"],
-	byId: (id: string) => ["cronjobs", id],
-};
-
 const getAll = createFetcher(
 	z.object({
 		filters: z
@@ -29,7 +24,7 @@ const getAll = createFetcher(
 
 		return data.items?.filter((item) => item.workflow === workflowId) ?? [];
 	},
-	({ filters }) => [...keys.all(), filters]
+	() => ApiRoutes.cronjobs.getCronJobs().path
 );
 
 const getById = createFetcher(
@@ -39,7 +34,7 @@ const getById = createFetcher(
 		const { data } = await request<CronJob>({ url, signal });
 		return data;
 	},
-	({ id }) => keys.byId(id)
+	() => ApiRoutes.cronjobs.getCronJobById(":id").path
 );
 
 async function createCronJob(cronJob: CronJobBase) {

--- a/ui/admin/app/lib/service/api/service-primitives.ts
+++ b/ui/admin/app/lib/service/api/service-primitives.ts
@@ -113,14 +113,19 @@ export const createFetcher = <
 			handleFetch(params, config),
 		key,
 		/** Creates a SWR key and fetcher for the given params. This works for both `useSWR` and `prefetch` from SWR */
-		swr: (params: KeyParams, config: FetcherConfig = {}) => {
+		swr: (
+			params: KeyParams,
+			config: FetcherConfig & { enabled?: boolean } = {}
+		) => {
+			const { enabled = true, ...restConfig } = config;
+
 			return [
-				buildKey(params),
+				enabled ? buildKey(params) : null,
 				// casting (params as TParams) is safe here because handleFetch will never be called when params are invalid
-				() => handleFetch(params as TParams, config),
+				() => handleFetch(params as TParams, restConfig),
 			] as const;
 		},
-		revalidate: (params: KeyParams, exact?: boolean) =>
+		revalidate: (params: KeyParams = {}, exact?: boolean) =>
 			buildRevalidator(params, exact),
 	};
 };

--- a/ui/admin/app/lib/service/api/service-primitives.ts
+++ b/ui/admin/app/lib/service/api/service-primitives.ts
@@ -1,47 +1,11 @@
-import { mutate } from "swr";
 import { ZodRawShape, z } from "zod";
+
+import { type KeyObj, revalidateObject } from "~/lib/service/revalidation";
 
 type FetcherConfig = {
 	signal?: AbortSignal;
 	cancellable?: boolean;
 };
-
-/**
- * Allows us to skip matching on specific key segments
- * @example
- * revalidateArray(["Agents", SkipKey])
- * // will revalidate the following keys:
- * ["Agents", "1234"]
- * ["Agents", "5678"]
- * // but not:
- * ["Agents", "1234", "Threads"]
- * ["Agents", "1234", "Threads", "5678"]
- *
- * // If exact is false:
- * revalidateArray(["Agents", SkipKey], false)
- * // will also revalidate the following keys:
- * ["Agents", "1234", "Threads"]
- * ["Agents", "1234", "Threads", "5678"]
- */
-export const SkipKey = Symbol("SkipKey");
-
-/**
- * Revalidates all keys that match the given key
- * @param key - The key to match. Use SkipKey to skip matching on specific segments
- * @param exact - Whether the key must match exactly
- */
-export const revalidateArray = <TKey extends unknown[]>(
-	key: TKey,
-	exact = true
-) =>
-	mutate((cacheKey) => {
-		if (!Array.isArray(cacheKey)) return false;
-
-		return (
-			key.every((k, i) => [cacheKey[i], SkipKey].includes(k)) &&
-			(!exact || cacheKey.length === key.length)
-		);
-	});
 
 /**
  * Creates a fetcher for a given API function
@@ -50,14 +14,10 @@ export const revalidateArray = <TKey extends unknown[]>(
  * @param key - The function that generates the UNIQUE key for the given params. This should include all dependencies of the method
  * @returns The fetcher
  */
-export const createFetcher = <
-	TParams extends object,
-	TKey extends unknown[],
-	TResponse,
->(
+export const createFetcher = <TParams extends object, TResponse>(
 	input: z.ZodSchema<TParams>,
 	handler: (params: TParams, config: FetcherConfig) => Promise<TResponse>,
-	key: (params: TParams) => TKey
+	key: () => string
 ) => {
 	type KeyParams = NullishPartial<TParams>;
 
@@ -80,21 +40,23 @@ export const createFetcher = <
 			Object.entries(getShape()).map(([key, schema]) => [
 				key,
 				// this means that if a parameter would cause an error, it will be skipped
-				schema.catch(SkipKey),
+				schema.optional().default(undefined).catch(undefined),
 			])
 		)
 	);
 
 	// this function will return null if the params are invalid
 	// SWR will not call the handler if the key is null
-	const buildKey = (params: KeyParams) => {
+	const buildKey = (params: KeyParams): Nullish<KeyObj<TParams>> => {
 		const { data } = input.safeParse(params);
-		return data ? key(data) : null;
+		return data ? { key: key(), params: data } : null;
 	};
 
-	const buildRevalidator = (params: KeyParams, exact?: boolean) => {
+	const revalidate = (params: KeyParams = {}) => {
 		const data = skippedSchema.parse(params);
-		revalidateArray(key(data as TParams), exact);
+
+		const keyObj = { key: key(), params: data };
+		revalidateObject(keyObj);
 	};
 
 	const handleFetch = (params: TParams, config: FetcherConfig) => {
@@ -125,8 +87,7 @@ export const createFetcher = <
 				() => handleFetch(params as TParams, restConfig),
 			] as const;
 		},
-		revalidate: (params: KeyParams = {}, exact?: boolean) =>
-			buildRevalidator(params, exact),
+		revalidate,
 	};
 };
 

--- a/ui/admin/app/lib/service/api/workspaceTableApiService.ts
+++ b/ui/admin/app/lib/service/api/workspaceTableApiService.ts
@@ -11,6 +11,8 @@ import {
 	WorkspaceTableRows,
 } from "~/components/model/tables";
 
+const param = (x: string) => x as Todo;
+
 const Keys = {
 	getTables: (namespace: TableNamespace, entityId: string) => [
 		namespace,
@@ -43,11 +45,7 @@ const getTables = createFetcher(
 
 		return QueryService.paginate(searched, query.pagination);
 	},
-	(params) => [
-		...Keys.getTables(params.namespace, params.entityId),
-		params.filters,
-		params.query,
-	]
+	() => ApiRoutes.workspace.getTables(param(":namespace"), ":entityId").path
 );
 
 const getTableRows = createFetcher(
@@ -80,11 +78,12 @@ const getTableRows = createFetcher(
 
 		return { ...data, ...rest };
 	},
-	({ namespace, entityId, tableName, filters, query }) => [
-		...Keys.getTableRows(namespace, entityId, tableName),
-		filters,
-		query,
-	]
+	() =>
+		ApiRoutes.workspace.getTableRows(
+			param(":namespace"),
+			":entityId",
+			":tableName"
+		).path
 );
 
 export const WorkspaceTableApiService = {

--- a/ui/admin/app/lib/service/revalidation.ts
+++ b/ui/admin/app/lib/service/revalidation.ts
@@ -1,0 +1,49 @@
+import { mutate } from "swr";
+
+export type KeyObj<TParams> = {
+	key: string;
+	params: TParams;
+};
+
+/**
+ * @description - Recusively compares two objects (`o1` and `o2`), returning true if all values from `o1` are equal to the same values for `o2`. Properties that are `undefined` in `o1` are ignored
+ * @example
+ * recursiveCompareKeys({ a: 1, b: 2 }, { a: 1, b: 2, c: 3 }) // true
+ * recursiveCompareKeys({ a: 1, b: 2 }, { a: 1, b: 3 }) // false
+ * recursiveCompareKeys({ a: 1, b: 2 }, { a: 1 }) // true
+ * recursiveCompareKeys({ a: 1, b: undefined }, { a: 1, b: 2 }) // true
+ * recursiveCompareKeys({ a: 1, b: 2 }, { a: 1, b: null }) // false
+ */
+export const recursiveCompareKeys = (
+	o1: object | null,
+	o2: object | null
+): boolean => {
+	// if either is null, they are equal if they are both null
+	if (o1 === null || o2 === null) return o1 === o2;
+
+	return Object.entries(o1).every(([key, value]) => {
+		// skip undefined values on o1
+		if (value === undefined) return true;
+
+		const o2Value: unknown = key in o2 ? o2[key as keyof typeof o2] : undefined;
+
+		// if o2Value is undefined, the keys are not equal
+		if (o2Value === undefined) return false;
+
+		// shallowly compare primitive values
+		if (typeof value !== "object" || typeof o2Value !== "object") {
+			return value === o2Value;
+		}
+
+		// recursively compare nested objects
+		return recursiveCompareKeys(value, o2Value);
+	});
+};
+
+export const revalidateObject = (keyObj: KeyObj<object>) => {
+	mutate((cacheKey) => {
+		if (typeof cacheKey !== "object") return false;
+
+		return recursiveCompareKeys(keyObj, cacheKey);
+	});
+};

--- a/ui/admin/app/routes/_auth.workflow-triggers._index.tsx
+++ b/ui/admin/app/routes/_auth.workflow-triggers._index.tsx
@@ -24,9 +24,7 @@ export async function clientLoader() {
 		preload(WorkflowService.getWorkflows.key(), () =>
 			WorkflowService.getWorkflows()
 		),
-		preload(CronJobApiService.getCronJobs.key(), () =>
-			CronJobApiService.getCronJobs()
-		),
+		preload(...CronJobApiService.getCronJobs.swr({})),
 		preload(EmailReceiverApiService.getEmailReceivers.key(), () =>
 			EmailReceiverApiService.getEmailReceivers()
 		),

--- a/ui/admin/app/routes/_auth.workflow-triggers.schedule.$trigger.tsx
+++ b/ui/admin/app/routes/_auth.workflow-triggers.schedule.$trigger.tsx
@@ -22,8 +22,8 @@ export async function clientLoader({
 		params
 	);
 
-	await preload(CronJobApiService.getCronJobById.key(pathParams.trigger), () =>
-		CronJobApiService.getCronJobById(pathParams.trigger)
+	await preload(
+		...CronJobApiService.getCronJobById.swr({ id: pathParams.trigger })
 	);
 
 	return { cronJobId: pathParams.trigger };
@@ -32,8 +32,7 @@ export async function clientLoader({
 export default function SchedulePage() {
 	const { cronJobId } = useLoaderData<typeof clientLoader>();
 	const { data: cronjob } = useSWR(
-		CronJobApiService.getCronJobById.key(cronJobId),
-		({ cronJobId }) => CronJobApiService.getCronJobById(cronJobId)
+		...CronJobApiService.getCronJobById.swr({ id: cronJobId })
 	);
 
 	return <ScheduleForm cronjob={cronjob} />;

--- a/ui/admin/app/routes/_auth.workflows.$workflow.tsx
+++ b/ui/admin/app/routes/_auth.workflows.$workflow.tsx
@@ -43,9 +43,7 @@ export const clientLoader = async ({
 		preload(WorkflowService.getWorkflowById.key(pathParams.workflow), () =>
 			WorkflowService.getWorkflowById(pathParams.workflow)
 		),
-		preload(CronJobApiService.getCronJobs.key(), () =>
-			CronJobApiService.getCronJobs()
-		),
+		preload(...CronJobApiService.getCronJobs.swr({})),
 		preload(WebhookApiService.getWebhooks.key(), () =>
 			WebhookApiService.getWebhooks()
 		),


### PR DESCRIPTION
- switches service method default cache keys back to an object structure
- service fetchers must now provide a key method that returns a UNIQUE string to be used as an identifier
- keys will be autogenerated as an object with the provided key, and parameters
- revalidation will invalidate cach keys that match the service method's key, AND partially match the provided revalidation params

- [ ] TODO: unit tests