### PR TITLE
feat: add description to prompt credentials in user UI

### DIFF
--- a/ui/user/src/lib/components/messages/Message.svelte
+++ b/ui/user/src/lib/components/messages/Message.svelte
@@ -269,6 +269,9 @@
 						name={field.name}
 						bind:value={promptCredentials[field.name]}
 					/>
+					{#if field.description}
+						<p class="text-sm text-gray-500">{field.description}</p>
+					{/if}
 				</div>
 			{/each}
 


### PR DESCRIPTION
addresses #1677 

![image](https://github.com/user-attachments/assets/a163ff0e-06c2-4f25-afde-fa267de05fb7)
