### PR TITLE
fix: use http 422 instead of 407 during model provider validation so that the error shows up properly

### DIFF
--- a/pkg/api/handlers/modelprovider.go
+++ b/pkg/api/handlers/modelprovider.go
@@ -180,12 +180,12 @@ func (mp *ModelProviderHandler) Validate(req api.Context) error {
 				ref.Name,
 			)
 		}
-		return types.NewErrHttp(http.StatusProxyAuthRequired, strings.Trim(err.Error(), "\"'"))
+		return types.NewErrHttp(http.StatusUnprocessableEntity, strings.Trim(err.Error(), "\"'"))
 	}
 
 	var validationError ValidationError
 	if json.Unmarshal([]byte(res.Output), &validationError) == nil && validationError.Err != "" {
-		return types.NewErrHttp(http.StatusProxyAuthRequired, validationError.Error())
+		return types.NewErrHttp(http.StatusUnprocessableEntity, validationError.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Issue https://github.com/obot-platform/obot/issues/1385

## Before

<img width="753" alt="405429558-042162d8-3f6c-4a1e-9725-750b7d89e767" src="https://github.com/user-attachments/assets/e38dcf38-2db5-4c2e-9b3f-b8ed28197079" />


## After

![Screenshot 2025-02-10 at 19-09-57 Obot • Model Providers](https://github.com/user-attachments/assets/eae09eee-987c-4d7b-aac0-16057aefeb4c)
