### PR TITLE
fix: allow revalidation with useOauthAppMap

### DIFF
--- a/ui/admin/app/hooks/oauthApps/useOAuthApps.ts
+++ b/ui/admin/app/hooks/oauthApps/useOAuthApps.ts
@@ -31,6 +31,6 @@ export function useOAuthAppInfo(type: OAuthProvider) {
 }
 
 export function useOauthAppMap() {
-	const list = useOAuthAppList({ revalidate: false });
+	const list = useOAuthAppList();
 	return new Map(list.map((app) => [app.alias ?? app.type, app]));
 }


### PR DESCRIPTION
* quick fix oauth apps not showing as configured on load, allowing revalidation on mount
* longer fix: looking into why cache is initially empty (though it should have the data from preload)