### PR TITLE
fix: remove old credentials from when removing tools

### DIFF
--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -74,6 +74,7 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Workflow{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.Workflow{}).HandlerFunc(alias.AssignAlias)
 	root.Type(&v1.Workflow{}).HandlerFunc(toolInfo.SetToolInfoStatus)
+	root.Type(&v1.Workflow{}).HandlerFunc(toolInfo.RemoveUnneededCredentials)
 	root.Type(&v1.Workflow{}).HandlerFunc(generationed.UpdateObservedGeneration)
 	root.Type(&v1.Workflow{}).FinalizeFunc(v1.WorkflowFinalizer, credentialCleanup.Remove)
 
@@ -87,6 +88,7 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Agent{}).HandlerFunc(agents.BackPopulateAuthStatus)
 	root.Type(&v1.Agent{}).HandlerFunc(alias.AssignAlias)
 	root.Type(&v1.Agent{}).HandlerFunc(toolInfo.SetToolInfoStatus)
+	root.Type(&v1.Agent{}).HandlerFunc(toolInfo.RemoveUnneededCredentials)
 	root.Type(&v1.Agent{}).HandlerFunc(generationed.UpdateObservedGeneration)
 	root.Type(&v1.Agent{}).FinalizeFunc(v1.AgentFinalizer, credentialCleanup.Remove)
 


### PR DESCRIPTION
When removing the last tool that uses a credential, this change will remove the
old credential. The effect is that the user will have to authenticate the tool
again if a tool requiring that credential is added.

Issue: https://github.com/obot-platform/obot/issues/1570