### PR TITLE
fix: stop panicking when invoking workflows

### DIFF
--- a/pkg/api/handlers/invoke.go
+++ b/pkg/api/handlers/invoke.go
@@ -111,9 +111,14 @@ func (i *InvokeHandler) Invoke(req api.Context) error {
 		return req.WriteEvents(resp.Events)
 	}
 
+	var runID string
+	if resp.Run != nil {
+		runID = resp.Run.Name
+	}
+
 	req.ResponseWriter.Header().Set("Content-Type", "application/json")
 	return req.Write(map[string]string{
 		"threadID": resp.Thread.Name,
-		"runID":    resp.Run.Name,
+		"runID":    runID,
 	})
 }


### PR DESCRIPTION
The invoke repsonse doesn't have a run, so we should check for the run before
trying to get the run's Name.