### PR TITLE
enhance: support multiple auth providers

### DIFF
--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -132,19 +132,6 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 		return types.NewErrBadRequest("%q is not an auth provider", ref.Name)
 	}
 
-	// Check to see if there are any other configured auth providers.
-	// For now, we only support one auth provider at a time to be configured.
-	allAuthProviders, err := ap.listAuthProviders(req)
-	if err != nil {
-		return err
-	}
-
-	for _, ap := range allAuthProviders {
-		if ap.Configured && (ap.Name != authProviderNameFromToolRef(ref) || ap.Namespace != ref.Namespace) {
-			return types.NewErrBadRequest("another auth provider is already configured")
-		}
-	}
-
 	var envVars map[string]string
 	if err := req.Read(&envVars); err != nil {
 		return err

--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -63,7 +63,7 @@ func ensureIdentity(tx *gorm.DB, id *types.Identity, timezone string, role types
 	if user.ID != 0 {
 		userQuery = userQuery.Where("id = ?", user.ID)
 	} else {
-		userQuery = userQuery.Where("username = ?", user.Username)
+		userQuery = userQuery.Where("email = ?", user.Email)
 	}
 
 	if err := userQuery.First(&user).Error; errors.Is(err, gorm.ErrRecordNotFound) {

--- a/ui/admin/app/components/auth-and-model-providers/AuthProviderLists.tsx
+++ b/ui/admin/app/components/auth-and-model-providers/AuthProviderLists.tsx
@@ -1,4 +1,4 @@
-import { CircleCheckIcon, CircleHelpIcon, CircleSlashIcon } from "lucide-react";
+import { CircleCheckIcon, CircleSlashIcon } from "lucide-react";
 import { Link } from "react-router";
 
 import { AuthProvider } from "~/lib/model/providers";
@@ -7,23 +7,7 @@ import { ProviderConfigure } from "~/components/auth-and-model-providers/Provide
 import { ProviderIcon } from "~/components/auth-and-model-providers/ProviderIcon";
 import { ProviderMenu } from "~/components/auth-and-model-providers/ProviderMenu";
 import { Badge } from "~/components/ui/badge";
-import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader } from "~/components/ui/card";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "~/components/ui/tooltip";
-
-function isDisabled(
-	authProvider: AuthProvider,
-	authProviders: AuthProvider[]
-): boolean {
-	return (
-		!authProvider.configured &&
-		authProviders.filter((p) => p.configured).length > 0
-	);
-}
 
 export function AuthProviderList({
 	authProviders,
@@ -41,27 +25,9 @@ export function AuthProviderList({
 									<ProviderMenu provider={authProvider} />
 								</div>
 							)}
-							{isDisabled(authProvider, authProviders) && (
-								<div className="flex flex-row items-center gap-2">
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<Button variant="ghost" size="icon">
-												<CircleHelpIcon />
-											</Button>
-										</TooltipTrigger>
-										<TooltipContent>
-											<span>
-												You must deconfigure the existing provider before
-												configuring this one.
-											</span>
-										</TooltipContent>
-									</Tooltip>
-								</div>
+							{!authProvider.configured && (
+								<div className="flex flex-row items-center gap-2" />
 							)}
-							{!isDisabled(authProvider, authProviders) &&
-								!authProvider.configured && (
-									<div className="flex flex-row items-center gap-2" />
-								)}
 						</CardHeader>
 						<CardContent className="flex flex-col items-center gap-4">
 							<Link to={authProvider.link ?? ""}>
@@ -84,10 +50,7 @@ export function AuthProviderList({
 									</span>
 								)}
 							</Badge>
-							<ProviderConfigure
-								provider={authProvider}
-								disabled={isDisabled(authProvider, authProviders)}
-							/>
+							<ProviderConfigure provider={authProvider} />
 						</CardContent>
 					</Card>
 				))}

--- a/ui/admin/app/components/auth-and-model-providers/ModelProviderLists.tsx
+++ b/ui/admin/app/components/auth-and-model-providers/ModelProviderLists.tsx
@@ -57,7 +57,7 @@ export function ModelProviderList({
 									</span>
 								)}
 							</Badge>
-							<ProviderConfigure provider={modelProvider} disabled={false} />
+							<ProviderConfigure provider={modelProvider} />
 						</CardContent>
 					</Card>
 				))}

--- a/ui/admin/app/components/auth-and-model-providers/ProviderConfigure.tsx
+++ b/ui/admin/app/components/auth-and-model-providers/ProviderConfigure.tsx
@@ -29,13 +29,9 @@ import {
 
 type ProviderConfigureProps = {
 	provider: ModelProvider | AuthProvider;
-	disabled: boolean;
 };
 
-export function ProviderConfigure({
-	provider,
-	disabled,
-}: ProviderConfigureProps) {
+export function ProviderConfigure({ provider }: ProviderConfigureProps) {
 	const [dialogIsOpen, setDialogIsOpen] = useState(false);
 	const [showDefaultModelAliasForm, setShowDefaultModelAliasForm] =
 		useState(false);
@@ -77,7 +73,6 @@ export function ProviderConfigure({
 		<Dialog open={dialogIsOpen} onOpenChange={setDialogIsOpen}>
 			<DialogTrigger asChild>
 				<Button
-					disabled={disabled}
 					variant={provider.configured ? "secondary" : "accent"}
 					className="mt-0 w-full"
 				>


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/1719

This makes it so that a new identity will be mapped to an existing user, if the existing user has the same email address as the new identity. Previously we were doing this based on username, but while usernames in GitHub can be set by the user, the username in Google is just a random number, so this doesn't work.

I also removed the restrictions (in both the frontend and the backend) that prevent you from configuring more than one auth provider at once.

Google and GitHub both require you to verify that you have access to the email for your account, so this implementation is secure. It is important that future auth providers that we add also adhere to this constraint, and do not allow you to have an email address that you don't really own.