### PR TITLE
enhance: cleanup ephemeral threads after 12 hours

### DIFF
--- a/apiclient/types/thread.go
+++ b/apiclient/types/thread.go
@@ -33,6 +33,7 @@ type Thread struct {
 	UserID          string   `json:"userID,omitempty"`
 	Abort           bool     `json:"abort,omitempty"`
 	SystemTask      bool     `json:"systemTask,omitempty"`
+	Ephemeral       bool     `json:"ephemeral,omitempty"`
 	Env             []string `json:"env,omitempty"`
 }
 

--- a/pkg/api/handlers/agent.go
+++ b/pkg/api/handlers/agent.go
@@ -962,6 +962,7 @@ func runAuthForAgent(ctx context.Context, c kclient.WithWatch, invoker *invoke.I
 
 	return invoker.Agent(ctx, c, agent, "", invoke.Options{
 		Synchronous:           true,
+		EphemeralThread:       true,
 		ThreadCredentialScope: new(bool),
 	})
 }

--- a/pkg/api/handlers/assistants.go
+++ b/pkg/api/handlers/assistants.go
@@ -211,7 +211,7 @@ func getDefaultProjectThreadName(req api.Context, agentID string) (*v1.Thread, e
 		return nil, err
 	}
 
-	newThread, err := invoke.CreateThreadForAgent(req.Context(), req.Storage, agent, id, "", req.User.GetUID())
+	newThread, err := invoke.CreateThreadForAgent(req.Context(), req.Storage, agent, id, "", req.User.GetUID(), false)
 	if apierrors.IsAlreadyExists(err) {
 		return &thread, req.Get(&thread, id)
 	}

--- a/pkg/api/handlers/modelprovider.go
+++ b/pkg/api/handlers/modelprovider.go
@@ -156,14 +156,13 @@ func (mp *ModelProviderHandler) Validate(req api.Context) error {
 		},
 		Spec: v1.ThreadSpec{
 			SystemTask: true,
+			Ephemeral:  true,
 		},
 	}
 
 	if err := req.Create(thread); err != nil {
 		return fmt.Errorf("failed to create thread: %w", err)
 	}
-
-	defer func() { _ = req.Delete(thread) }()
 
 	task, err := mp.invoker.SystemTask(req.Context(), thread, "validate from "+ref.Spec.Reference, "", invoke.SystemTaskOptions{Env: envs})
 	if err != nil {

--- a/pkg/api/handlers/threads.go
+++ b/pkg/api/handlers/threads.go
@@ -57,6 +57,7 @@ func convertThread(thread v1.Thread) types.Thread {
 		UserID:          thread.Spec.UserUID,
 		Abort:           thread.Spec.Abort,
 		SystemTask:      thread.Spec.SystemTask,
+		Ephemeral:       thread.Spec.Ephemeral,
 		Env:             thread.Spec.Env,
 	}
 }

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -62,6 +62,7 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Thread{}).HandlerFunc(threads.CreateKnowledgeSet)
 	root.Type(&v1.Thread{}).HandlerFunc(threads.WorkflowState)
 	root.Type(&v1.Thread{}).HandlerFunc(knowledgesummary.Summarize)
+	root.Type(&v1.Thread{}).HandlerFunc(threads.CleanupEphemeralThreads)
 	root.Type(&v1.Thread{}).FinalizeFunc(v1.ThreadFinalizer, credentialCleanup.Remove)
 
 	// KnowledgeSummary

--- a/pkg/storage/apis/obot.obot.ai/v1/thread.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/thread.go
@@ -87,6 +87,8 @@ type ThreadSpec struct {
 	Project bool `json:"project,omitempty"`
 	// Env is the environment variable keys that expected to be set in the credential that matches the thread.Name
 	Env []string `json:"env,omitempty"`
+	// Ephemeral means that this thread is used once and then can be deleted
+	Ephemeral bool `json:"ephemeral,omitempty"`
 }
 
 func (in *Thread) DeleteRefs() []Ref {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -3881,6 +3881,12 @@ func schema_obot_platform_obot_apiclient_types_Thread(ref common.ReferenceCallba
 							Format: "",
 						},
 					},
+					"ephemeral": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"env": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
@@ -8256,6 +8262,13 @@ func schema_storage_apis_obotobotai_v1_ThreadSpec(ref common.ReferenceCallback) 
 									},
 								},
 							},
+						},
+					},
+					"ephemeral": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Ephemeral means that this thread is used once and then can be deleted",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},


### PR DESCRIPTION
This change introduces the concept of an ephemeral thread. These are threads
that are typically used for system-based or temporary tasks. Such threads will
be cleaned up 12 hours after their creation.

Issue: https://github.com/obot-platform/obot/issues/1723