### PR TITLE
fix: rearrange sidebar nav items & combobox multi-highlight name fix

### DIFF
--- a/ui/admin/app/components/composed/ComboBox.tsx
+++ b/ui/admin/app/components/composed/ComboBox.tsx
@@ -1,6 +1,8 @@
 import { CheckIcon, ChevronsUpDownIcon } from "lucide-react";
 import { ReactNode, useState } from "react";
 
+import { cn } from "~/lib/utils";
+
 import { Button, ButtonProps } from "~/components/ui/button";
 import {
 	Command,
@@ -20,7 +22,8 @@ import { useIsMobile } from "~/hooks/use-mobile";
 
 type BaseOption = {
 	id: string;
-	name?: string | undefined;
+	name?: string;
+	sublabel?: string;
 };
 
 type GroupedOption<T extends BaseOption> = {
@@ -42,6 +45,9 @@ type ComboBoxProps<T extends BaseOption> = {
 	renderOption?: (option: T) => ReactNode;
 	validateCreate?: (value: string) => boolean;
 	value?: T | null;
+	classNames?: {
+		command?: string;
+	};
 };
 
 export function ComboBox<T extends BaseOption>({
@@ -125,6 +131,7 @@ function ComboBoxList<T extends BaseOption>({
 	placeholder = "Filter...",
 	emptyLabel = "No results found.",
 	closeOnSelect = true,
+	classNames,
 }: { setOpen: (open: boolean) => void } & ComboBoxProps<T>) {
 	const [filteredOptions, setFilteredOptions] =
 		useState<typeof options>(options);
@@ -173,7 +180,10 @@ function ComboBoxList<T extends BaseOption>({
 	return (
 		<Command
 			shouldFilter={false}
-			className="max-h-[50vh] w-[var(--radix-popper-anchor-width)]"
+			className={cn(
+				"max-h-[50vh] w-[var(--radix-popper-anchor-width)]",
+				classNames?.command
+			)}
 		>
 			<CommandInput
 				placeholder={placeholder}
@@ -244,6 +254,12 @@ function ComboBoxList<T extends BaseOption>({
 			>
 				<span>
 					{renderOption ? renderOption(option) : (option.name ?? option.id)}
+					{option.sublabel && (
+						<span className="text-xs text-muted-foreground">
+							{" "}
+							({option.sublabel})
+						</span>
+					)}
 				</span>
 				{value?.id === option.id && <CheckIcon className="h-4 w-4" />}
 			</CommandItem>

--- a/ui/admin/app/components/composed/ComboBox.tsx
+++ b/ui/admin/app/components/composed/ComboBox.tsx
@@ -255,10 +255,10 @@ function ComboBoxList<T extends BaseOption>({
 				<span>
 					{renderOption ? renderOption(option) : (option.name ?? option.id)}
 					{option.sublabel && (
-						<span className="text-xs text-muted-foreground">
+						<small className="text-muted-foreground">
 							{" "}
 							({option.sublabel})
-						</span>
+						</small>
 					)}
 				</span>
 				{value?.id === option.id && <CheckIcon className="h-4 w-4" />}

--- a/ui/admin/app/components/composed/ComboBox.tsx
+++ b/ui/admin/app/components/composed/ComboBox.tsx
@@ -235,7 +235,7 @@ function ComboBoxList<T extends BaseOption>({
 		return (
 			<CommandItem
 				key={option.id}
-				value={option.name}
+				value={option.id}
 				onSelect={() => {
 					onChange(option);
 					if (closeOnSelect) setOpen(false);

--- a/ui/admin/app/components/composed/DataTable.tsx
+++ b/ui/admin/app/components/composed/DataTable.tsx
@@ -161,6 +161,9 @@ export const DataTableFilter = ({
 			placeholder={field}
 			onChange={(option) => onSelect(option?.id ?? "")}
 			options={values}
+			classNames={{
+				command: "min-w-64",
+			}}
 		/>
 	);
 };

--- a/ui/admin/app/components/sidebar/Sidebar.tsx
+++ b/ui/admin/app/components/sidebar/Sidebar.tsx
@@ -52,6 +52,16 @@ const items = [
 		icon: MessageSquare,
 	},
 	{
+		title: "Tasks",
+		url: $path("/tasks"),
+		icon: PuzzleIcon,
+	},
+	{
+		title: "Task Runs",
+		url: $path("/task-runs"),
+		icon: CpuIcon,
+	},
+	{
 		title: "Tools",
 		url: $path("/tools"),
 		icon: Wrench,
@@ -61,16 +71,6 @@ const items = [
 		url: $path("/users"),
 		icon: User,
 		requiresAuth: true,
-	},
-	{
-		title: "Tasks",
-		url: $path("/tasks"),
-		icon: PuzzleIcon,
-	},
-	{
-		title: "Task Runs",
-		url: $path("/task-runs"),
-		icon: CpuIcon,
 	},
 	{
 		title: "Model Providers",

--- a/ui/admin/app/routes/_auth.tasks._index.tsx
+++ b/ui/admin/app/routes/_auth.tasks._index.tsx
@@ -143,6 +143,13 @@ export default function Tasks() {
 		return filteredTasks;
 	}, [tasks, search, agentId, userId, taskId]);
 
+	const namesCount = useMemo(() => {
+		return data.reduce<Record<string, number>>((acc, task) => {
+			acc[task.name] = (acc[task.name] || 0) + 1;
+			return acc;
+		}, {});
+	}, [data]);
+
 	return (
 		<div>
 			<div className="flex h-full flex-col gap-4 p-6">
@@ -183,9 +190,10 @@ export default function Tasks() {
 						key={column.id}
 						field="Task"
 						values={
-							getWorkflows.data?.map((workflow) => ({
-								id: workflow.id,
-								name: workflow.name,
+							data?.map((task) => ({
+								id: task.id,
+								name: task.name,
+								sublabel: namesCount[task.name] > 1 ? task.agent : "",
 							})) ?? []
 						}
 						onSelect={(value) => {


### PR DESCRIPTION
* rearrange sidebar nav items per Craig's request
* fix combobox highlighting items with same name (but different id)

fixes:
<img width="261" alt="Screenshot 2025-02-12 at 1 49 54 PM" src="https://github.com/user-attachments/assets/5e424689-012f-4614-b704-133353627e2a" />

adds agent name if the workflow has a duplicate title with someone else:
<img width="299" alt="Screenshot 2025-02-12 at 3 16 40 PM" src="https://github.com/user-attachments/assets/6ce7d903-68ec-4ecd-a185-81362f91a8f3" />
