### PR TITLE
fix: show github handle instead of email for github auth provider

### DIFF
--- a/apiclient/types/user.go
+++ b/apiclient/types/user.go
@@ -22,7 +22,7 @@ type User struct {
 	Email         string `json:"email,omitempty"`
 	IconURL       string `json:"iconURL,omitempty"`
 	Timezone      string `json:"timezone,omitempty"`
-	AuthProvider  string `json:"authProvider,omitempty"`
+	CurrentAuthProvider  string `json:"currentAuthProvider,omitempty"`
 }
 
 type UserList List[User]

--- a/apiclient/types/user.go
+++ b/apiclient/types/user.go
@@ -22,6 +22,7 @@ type User struct {
 	Email         string `json:"email,omitempty"`
 	IconURL       string `json:"iconURL,omitempty"`
 	Timezone      string `json:"timezone,omitempty"`
+	AuthProvider  string `json:"authProvider,omitempty"`
 }
 
 type UserList List[User]

--- a/pkg/api/handlers/authorizations.go
+++ b/pkg/api/handlers/authorizations.go
@@ -104,7 +104,7 @@ func (a *AuthorizationHandler) ListAgentAuthorizations(req api.Context) error {
 		if err != nil {
 			log.Errorf("failed to get user for authorization list %s: %v", grant.Spec.UserID, err)
 		} else if user != nil {
-			auth.User = types2.ConvertUser(user, a.userClient.IsExplicitAdmin(user.Email))
+			auth.User = types2.ConvertUser(user, a.userClient.IsExplicitAdmin(user.Email), nil)
 		}
 
 		result.Items = append(result.Items, auth)

--- a/pkg/api/handlers/authorizations.go
+++ b/pkg/api/handlers/authorizations.go
@@ -104,7 +104,7 @@ func (a *AuthorizationHandler) ListAgentAuthorizations(req api.Context) error {
 		if err != nil {
 			log.Errorf("failed to get user for authorization list %s: %v", grant.Spec.UserID, err)
 		} else if user != nil {
-			auth.User = types2.ConvertUser(user, a.userClient.IsExplicitAdmin(user.Email), nil)
+			auth.User = types2.ConvertUser(user, a.userClient.IsExplicitAdmin(user.Email), "")
 		}
 
 		result.Items = append(result.Items, auth)

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -37,7 +37,7 @@ func (s *Server) getCurrentUser(apiContext api.Context) error {
 		}
 	}
 
-	return apiContext.Write(types.ConvertUser(user, s.client.IsExplicitAdmin(user.Email)))
+	return apiContext.Write(types.ConvertUser(user, s.client.IsExplicitAdmin(user.Email), &name))
 }
 
 func (s *Server) getUsers(apiContext api.Context) error {
@@ -49,7 +49,7 @@ func (s *Server) getUsers(apiContext api.Context) error {
 	items := make([]types2.User, 0, len(users))
 	for _, user := range users {
 		if user.Username != "bootstrap" && user.Email != "" { // Filter out the bootstrap admin
-			items = append(items, *types.ConvertUser(&user, s.client.IsExplicitAdmin(user.Email)))
+			items = append(items, *types.ConvertUser(&user, s.client.IsExplicitAdmin(user.Email), nil))
 		}
 	}
 
@@ -81,7 +81,7 @@ func (s *Server) getUser(apiContext api.Context) error {
 		return fmt.Errorf("failed to get user: %v", err)
 	}
 
-	return apiContext.Write(types.ConvertUser(user, s.client.IsExplicitAdmin(user.Email)))
+	return apiContext.Write(types.ConvertUser(user, s.client.IsExplicitAdmin(user.Email), nil))
 }
 
 func (s *Server) updateUser(apiContext api.Context) error {
@@ -123,7 +123,7 @@ func (s *Server) updateUser(apiContext api.Context) error {
 		return types2.NewErrHTTP(status, fmt.Sprintf("failed to update user: %v", err))
 	}
 
-	return apiContext.Write(types.ConvertUser(existingUser, s.client.IsExplicitAdmin(existingUser.Email)))
+	return apiContext.Write(types.ConvertUser(existingUser, s.client.IsExplicitAdmin(existingUser.Email), nil))
 }
 
 func (s *Server) deleteUser(apiContext api.Context) error {
@@ -143,5 +143,5 @@ func (s *Server) deleteUser(apiContext api.Context) error {
 		return types2.NewErrHTTP(status, fmt.Sprintf("failed to delete user: %v", err))
 	}
 
-	return apiContext.Write(types.ConvertUser(existingUser, s.client.IsExplicitAdmin(existingUser.Email)))
+	return apiContext.Write(types.ConvertUser(existingUser, s.client.IsExplicitAdmin(existingUser.Email), nil))
 }

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -37,7 +37,7 @@ func (s *Server) getCurrentUser(apiContext api.Context) error {
 		}
 	}
 
-	return apiContext.Write(types.ConvertUser(user, s.client.IsExplicitAdmin(user.Email), &name))
+	return apiContext.Write(types.ConvertUser(user, s.client.IsExplicitAdmin(user.Email), name))
 }
 
 func (s *Server) getUsers(apiContext api.Context) error {
@@ -49,7 +49,7 @@ func (s *Server) getUsers(apiContext api.Context) error {
 	items := make([]types2.User, 0, len(users))
 	for _, user := range users {
 		if user.Username != "bootstrap" && user.Email != "" { // Filter out the bootstrap admin
-			items = append(items, *types.ConvertUser(&user, s.client.IsExplicitAdmin(user.Email), nil))
+			items = append(items, *types.ConvertUser(&user, s.client.IsExplicitAdmin(user.Email), ""))
 		}
 	}
 
@@ -81,7 +81,7 @@ func (s *Server) getUser(apiContext api.Context) error {
 		return fmt.Errorf("failed to get user: %v", err)
 	}
 
-	return apiContext.Write(types.ConvertUser(user, s.client.IsExplicitAdmin(user.Email), nil))
+	return apiContext.Write(types.ConvertUser(user, s.client.IsExplicitAdmin(user.Email), ""))
 }
 
 func (s *Server) updateUser(apiContext api.Context) error {
@@ -123,7 +123,7 @@ func (s *Server) updateUser(apiContext api.Context) error {
 		return types2.NewErrHTTP(status, fmt.Sprintf("failed to update user: %v", err))
 	}
 
-	return apiContext.Write(types.ConvertUser(existingUser, s.client.IsExplicitAdmin(existingUser.Email), nil))
+	return apiContext.Write(types.ConvertUser(existingUser, s.client.IsExplicitAdmin(existingUser.Email), ""))
 }
 
 func (s *Server) deleteUser(apiContext api.Context) error {
@@ -143,5 +143,5 @@ func (s *Server) deleteUser(apiContext api.Context) error {
 		return types2.NewErrHTTP(status, fmt.Sprintf("failed to delete user: %v", err))
 	}
 
-	return apiContext.Write(types.ConvertUser(existingUser, s.client.IsExplicitAdmin(existingUser.Email), nil))
+	return apiContext.Write(types.ConvertUser(existingUser, s.client.IsExplicitAdmin(existingUser.Email), ""))
 }

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -25,7 +25,7 @@ func ConvertUser(u *User, roleFixed bool, authProviderName string) *types2.User 
 		return nil
 	}
 
-	user := &types2.User{
+	return &types2.User{
 		Metadata: types2.Metadata{
 			ID:      fmt.Sprint(u.ID),
 			Created: *types2.NewTime(u.CreatedAt),
@@ -38,8 +38,6 @@ func ConvertUser(u *User, roleFixed bool, authProviderName string) *types2.User 
 		Timezone:            u.Timezone,
 		CurrentAuthProvider: authProviderName,
 	}
-
-	return user
 }
 
 type UserQuery struct {

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -20,12 +20,12 @@ type User struct {
 	Timezone  string      `json:"timezone"`
 }
 
-func ConvertUser(u *User, roleFixed bool) *types2.User {
+func ConvertUser(u *User, roleFixed bool, authProviderName *string) *types2.User {
 	if u == nil {
 		return nil
 	}
 
-	return &types2.User{
+	user := &types2.User{
 		Metadata: types2.Metadata{
 			ID:      fmt.Sprint(u.ID),
 			Created: *types2.NewTime(u.CreatedAt),
@@ -37,6 +37,12 @@ func ConvertUser(u *User, roleFixed bool) *types2.User {
 		IconURL:       u.IconURL,
 		Timezone:      u.Timezone,
 	}
+
+	if authProviderName != nil {
+		user.AuthProvider = *authProviderName
+	}
+
+	return user
 }
 
 type UserQuery struct {

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -20,7 +20,7 @@ type User struct {
 	Timezone  string      `json:"timezone"`
 }
 
-func ConvertUser(u *User, roleFixed bool, authProviderName *string) *types2.User {
+func ConvertUser(u *User, roleFixed bool, authProviderName string) *types2.User {
 	if u == nil {
 		return nil
 	}
@@ -36,10 +36,7 @@ func ConvertUser(u *User, roleFixed bool, authProviderName *string) *types2.User
 		ExplicitAdmin: roleFixed,
 		IconURL:       u.IconURL,
 		Timezone:      u.Timezone,
-	}
-
-	if authProviderName != nil {
-		user.AuthProvider = *authProviderName
+		CurrentAuthProvider: authProviderName,
 	}
 
 	return user

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -30,12 +30,12 @@ func ConvertUser(u *User, roleFixed bool, authProviderName string) *types2.User 
 			ID:      fmt.Sprint(u.ID),
 			Created: *types2.NewTime(u.CreatedAt),
 		},
-		Username:      u.Username,
-		Email:         u.Email,
-		Role:          u.Role,
-		ExplicitAdmin: roleFixed,
-		IconURL:       u.IconURL,
-		Timezone:      u.Timezone,
+		Username:            u.Username,
+		Email:               u.Email,
+		Role:                u.Role,
+		ExplicitAdmin:       roleFixed,
+		IconURL:             u.IconURL,
+		Timezone:            u.Timezone,
 		CurrentAuthProvider: authProviderName,
 	}
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -4466,7 +4466,7 @@ func schema_obot_platform_obot_apiclient_types_User(ref common.ReferenceCallback
 							Format: "",
 						},
 					},
-					"authProvider": {
+					"currentAuthProvider": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -4466,6 +4466,12 @@ func schema_obot_platform_obot_apiclient_types_User(ref common.ReferenceCallback
 							Format: "",
 						},
 					},
+					"authProvider": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"Metadata"},
 			},

--- a/ui/admin/app/components/auth-and-model-providers/constants.ts
+++ b/ui/admin/app/components/auth-and-model-providers/constants.ts
@@ -17,10 +17,3 @@ export const RecommendedModelProviders = [
 	CommonModelProviderIds.OPENAI,
 	CommonModelProviderIds.AZURE_OPENAI,
 ];
-
-export const CommonAuthProviderIds = {
-	GOOGLE: "google-auth-provider",
-	GITHUB: "github-auth-provider",
-	OKTA: "okta-auth-provider",
-	ENTRA: "entra-auth-provider",
-};

--- a/ui/admin/app/components/user/UserMenu.tsx
+++ b/ui/admin/app/components/user/UserMenu.tsx
@@ -82,7 +82,7 @@ export const UserMenu: React.FC<UserMenuProps> = ({
 	);
 
 	function getDisplayName(user?: UserModel) {
-		if (user?.authProvider === CommonAuthProviderIds.GITHUB) {
+		if (user?.currentAuthProvider === CommonAuthProviderIds.GITHUB) {
 			return user.username;
 		}
 

--- a/ui/admin/app/components/user/UserMenu.tsx
+++ b/ui/admin/app/components/user/UserMenu.tsx
@@ -1,8 +1,8 @@
 import { LogOutIcon, User } from "lucide-react";
 import React from "react";
 
-import { AuthDisabledUsername } from "~/lib/model/auth";
-import { roleLabel } from "~/lib/model/users";
+import { AuthDisabledUsername, CommonAuthProviderIds } from "~/lib/model/auth";
+import { User as UserModel, roleLabel } from "~/lib/model/users";
 import { BootstrapApiService } from "~/lib/service/api/bootstrapApiService";
 import { cn } from "~/lib/utils";
 
@@ -32,6 +32,8 @@ export const UserMenu: React.FC<UserMenuProps> = ({
 		return null;
 	}
 
+	const displayName = getDisplayName(me);
+
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
@@ -49,7 +51,7 @@ export const UserMenu: React.FC<UserMenuProps> = ({
 					</Avatar>
 					{!avatarOnly && (
 						<div className="max-w-full truncate">
-							<p className="truncate text-sm font-medium">{me?.email}</p>
+							<p className="truncate text-sm font-medium">{displayName}</p>
 							<p className="truncate text-left text-xs text-muted-foreground">
 								{roleLabel(me?.role)}
 							</p>
@@ -78,4 +80,12 @@ export const UserMenu: React.FC<UserMenuProps> = ({
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);
+
+	function getDisplayName(user?: UserModel) {
+		if (user?.authProvider === CommonAuthProviderIds.GITHUB) {
+			return user.username;
+		}
+
+		return user?.email;
+	}
 };

--- a/ui/admin/app/components/user/__tests__/UserMenu.test.tsx
+++ b/ui/admin/app/components/user/__tests__/UserMenu.test.tsx
@@ -20,7 +20,7 @@ describe(UserMenu, () => {
 			http.get(ApiRoutes.me().path, () => {
 				return HttpResponse.json<User>({
 					...mockedUser,
-					authProvider: CommonAuthProviderIds.GITHUB,
+					currentAuthProvider: CommonAuthProviderIds.GITHUB,
 				});
 			}),
 		]);
@@ -35,7 +35,7 @@ describe(UserMenu, () => {
 			http.get(ApiRoutes.me().url, () => {
 				return HttpResponse.json<User>({
 					...mockedUser,
-					authProvider: CommonAuthProviderIds.GOOGLE,
+					currentAuthProvider: CommonAuthProviderIds.GOOGLE,
 				});
 			}),
 		]);

--- a/ui/admin/app/components/user/__tests__/UserMenu.test.tsx
+++ b/ui/admin/app/components/user/__tests__/UserMenu.test.tsx
@@ -1,0 +1,47 @@
+import { HttpResponse, http } from "msw";
+import { cleanup, render, screen } from "test";
+import { mockedUser } from "test/mocks/models/users";
+import { overrideServer } from "test/server";
+
+import { CommonAuthProviderIds } from "~/lib/model/auth";
+import { User } from "~/lib/model/users";
+import { ApiRoutes } from "~/lib/routers/apiRoutes";
+
+import { UserMenu } from "~/components/user/UserMenu";
+
+describe(UserMenu, () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("logging in with github oauth displays username", async () => {
+		overrideServer([
+			http.get(ApiRoutes.me().path, () => {
+				return HttpResponse.json<User>({
+					...mockedUser,
+					authProvider: CommonAuthProviderIds.GITHUB,
+				});
+			}),
+		]);
+
+		render(<UserMenu />);
+		const element = await screen.findByText(mockedUser.username);
+		expect(element).toBeInTheDocument();
+	});
+
+	it("logging in with other oauth displays email", async () => {
+		overrideServer([
+			http.get(ApiRoutes.me().url, () => {
+				return HttpResponse.json<User>({
+					...mockedUser,
+					authProvider: CommonAuthProviderIds.GOOGLE,
+				});
+			}),
+		]);
+
+		render(<UserMenu />);
+		const element = await screen.findByText(mockedUser.email);
+		expect(element).toBeInTheDocument();
+	});
+});

--- a/ui/admin/app/lib/model/auth.tsx
+++ b/ui/admin/app/lib/model/auth.tsx
@@ -1,2 +1,11 @@
 export const AuthDisabledUsername = "nobody";
 export const BootstrapUsername = "bootstrap";
+export const CommonAuthProviderIds = {
+	GOOGLE: "google-auth-provider",
+	GITHUB: "github-auth-provider",
+	OKTA: "okta-auth-provider",
+	ENTRA: "entra-auth-provider",
+} as const;
+
+export type CommonAuthProviderId =
+	(typeof CommonAuthProviderIds)[keyof typeof CommonAuthProviderIds];

--- a/ui/admin/app/lib/model/users.ts
+++ b/ui/admin/app/lib/model/users.ts
@@ -1,3 +1,4 @@
+import { CommonAuthProviderId } from "~/lib/model/auth";
 import { EntityMeta } from "~/lib/model/primitives";
 
 export type User = EntityMeta & {
@@ -7,6 +8,7 @@ export type User = EntityMeta & {
 	iconURL: string;
 	timezone: string;
 	explicitAdmin: boolean;
+	authProvider?: CommonAuthProviderId;
 };
 
 export const Role = {

--- a/ui/admin/app/lib/model/users.ts
+++ b/ui/admin/app/lib/model/users.ts
@@ -8,7 +8,7 @@ export type User = EntityMeta & {
 	iconURL: string;
 	timezone: string;
 	explicitAdmin: boolean;
-	authProvider?: CommonAuthProviderId;
+	currentAuthProvider?: CommonAuthProviderId;
 };
 
 export const Role = {

--- a/ui/admin/app/routes/_auth.auth-providers.tsx
+++ b/ui/admin/app/routes/_auth.auth-providers.tsx
@@ -1,11 +1,11 @@
 import { MetaFunction } from "react-router";
 
+import { CommonAuthProviderIds } from "~/lib/model/auth";
 import { AuthProvider } from "~/lib/model/providers";
 import { VersionApiService } from "~/lib/service/api/versionApiService";
 import { RouteHandle } from "~/lib/service/routeHandles";
 
 import { AuthProviderList } from "~/components/auth-and-model-providers/AuthProviderLists";
-import { CommonAuthProviderIds } from "~/components/auth-and-model-providers/constants";
 import { WarningAlert } from "~/components/composed/WarningAlert";
 import { useAuthProviders } from "~/hooks/auth-providers/useAuthProviders";
 
@@ -15,7 +15,7 @@ export async function clientLoader() {
 
 const sortAuthProviders = (authProviders: AuthProvider[]) => {
 	return [...authProviders].sort((a, b) => {
-		const preferredOrder = [
+		const preferredOrder: string[] = [
 			CommonAuthProviderIds.GOOGLE,
 			CommonAuthProviderIds.GITHUB,
 			CommonAuthProviderIds.OKTA,

--- a/ui/admin/test/mocks/handlers/default.ts
+++ b/ui/admin/test/mocks/handlers/default.ts
@@ -16,9 +16,7 @@ export const defaultMockedHandlers = [
 		return HttpResponse.json<Version>(mockedVersion);
 	}),
 	http.get(ApiRoutes.me().path, () => {
-		return HttpResponse.json<{ data: User }>({
-			data: mockedUser,
-		});
+		return HttpResponse.json<User>(mockedUser);
 	}),
 ];
 

--- a/ui/admin/test/server.ts
+++ b/ui/admin/test/server.ts
@@ -5,5 +5,5 @@ import { defaultMockedHandlers } from "test/mocks/handlers/default";
 // Setup requests interception using the given handlers
 export const server = setupServer(...defaultMockedHandlers);
 export const overrideServer = (handlers: RequestHandler[]) => {
-	server.use(...defaultMockedHandlers, ...handlers);
+	server.use(...handlers, ...defaultMockedHandlers);
 };


### PR DESCRIPTION
* uses username for github, otherwise defaults to email
* Addresses #1397 

github:
<img width="397" alt="Screenshot 2025-02-13 at 1 43 52 PM" src="https://github.com/user-attachments/assets/bb335101-c104-4856-ac2e-d86807f26fd2" />

google:
<img width="306" alt="Screenshot 2025-02-13 at 1 44 44 PM" src="https://github.com/user-attachments/assets/4122e999-a24a-4b5c-8c37-2925a6e1e024" />

TODO:
- [x] Test case
