### PR TITLE
chore: add additional scopes and apis to google oauth instructions

### DIFF
--- a/ui/admin/app/lib/model/oauthApps/providers/google.ts
+++ b/ui/admin/app/lib/model/oauthApps/providers/google.ts
@@ -23,9 +23,17 @@ const scopes = [
 	"https://www.googleapis.com/auth/gmail.readonly",
 	"https://www.googleapis.com/auth/gmail.compose",
 	"https://www.googleapis.com/auth/drive",
+	"https://www.googleapis.com/auth/webmasters",
+	"https://www.googleapis.com/auth/webmasters.readonly",
 ];
 
-const enabledApis = ["Google Drive", "Google Sheets", "Google Docs", "Gmail"];
+const enabledApis = [
+	"Google Drive",
+	"Google Sheets",
+	"Google Docs",
+	"Gmail",
+	"Google Search Console",
+];
 
 const steps: OAuthFormStep<typeof schema.shape>[] = [
 	{


### PR DESCRIPTION
Added webmaster and webmaster.readonly scopes for Google Search Console. Also added Google Search Console as an API to enable.

Follow up doc update for obot-platform/tools#430