### PR TITLE
fix: expand agent name/description fields to take up full width

### DIFF
--- a/ui/admin/app/components/agent/AgentForm.tsx
+++ b/ui/admin/app/components/agent/AgentForm.tsx
@@ -90,7 +90,7 @@ export function AgentForm({
 							icons={agent.icons}
 							onChange={(icons) => form.setValue("icons", icons)}
 						/>
-						<div className="flex flex-col gap-2">
+						<div className="flex flex-1 flex-col gap-2">
 							{renderTitleDescription()}
 						</div>
 					</div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e092aecd-688a-4607-b15c-dfc8464af7fa)

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>