### PR TITLE
Fix: use relative path correctly when it is not a remote source

### DIFF
--- a/pkg/tools/resolve.go
+++ b/pkg/tools/resolve.go
@@ -66,10 +66,9 @@ func ResolveToolReferences(ctx context.Context, gptClient *gptscript.GPTScript, 
 		}
 
 		peerTool := prg.ToolSet[peerToolID]
-		ref, _, _ := strings.Cut(peerToolID, ":")
 		toolRef := reference
-		if strings.HasPrefix(ref, "./") || strings.HasPrefix(ref, "../") {
-			relPath, err := filepath.Rel(peerTool.WorkingDir, ref)
+		if !strings.HasPrefix(peerTool.Source.Location, "http://") && !strings.HasPrefix(peerTool.Source.Location, "https://") {
+			relPath, err := filepath.Rel(peerTool.WorkingDir, peerTool.Source.Location)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
When looking for subpath from subtool, just check if path starts with http:// or https:// to see if it is a remote tool. If not, should be able to resolve the correct gptfile by calculating rel path.

This should fix the issue where hubspot subTool referenced in different gptfile not showing up. The previous fix didn't work out due to the path being absolute path. 