### PR TITLE
fix: capabilities tools category and 403 oauth redirect

### DIFF
--- a/ui/admin/app/components/signin/SignIn.tsx
+++ b/ui/admin/app/components/signin/SignIn.tsx
@@ -54,6 +54,7 @@ export function SignIn({ className }: SignInProps) {
 						variant="secondary"
 						className="mb-4 w-full"
 						onClick={() => {
+							localStorage.setItem("preAuthRedirect", window.location.href);
 							window.location.href = `/oauth2/start?rd=${window.location.pathname}&obot-auth-provider=default/${provider.id}`;
 						}}
 					>

--- a/ui/admin/app/components/tools/toolGrid/ToolGrid.tsx
+++ b/ui/admin/app/components/tools/toolGrid/ToolGrid.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 
 import {
-	CapabilitiesToolCategory,
 	CustomToolsToolCategory,
 	ToolReference,
 	isCapabilityTool,
@@ -55,7 +54,7 @@ export function ToolGrid({ toolMap }: { toolMap: [string, ToolReference][] }) {
 
 			{capabilities.length > 0 && (
 				<div className="flex flex-col gap-4">
-					<h3>{CapabilitiesToolCategory}</h3>
+					<h3>Capabilities</h3>
 					<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
 						{capabilities.map(renderToolCard)}
 					</div>


### PR DESCRIPTION
Addresses #1557 -- clicking go back on 403 error.html should redirect to proper url
Note: Requires merge of 
Addresses #1273 -- "Capabilities" instead of "Capability"