### PR TITLE
Enhance: Support slack bot token

### DIFF
--- a/pkg/gateway/server/oauth_apps.go
+++ b/pkg/gateway/server/oauth_apps.go
@@ -266,7 +266,13 @@ func (s *Server) authorizeOAuthApp(apiContext api.Context) error {
 	// Slack is annoying and makes us call this query parameter user_scope instead of scope.
 	// user_scope is used for delegated user permissions (which is what we want), while just scope is used for bot permissions.
 	if app.Spec.Manifest.Type == types2.OAuthAppTypeSlack {
-		q.Set("user_scope", scope)
+		if scope != "" {
+			q.Set("scope", scope)
+		}
+		userScope := apiContext.URL.Query().Get("user_scope")
+		if userScope != "" {
+			q.Set("user_scope", userScope)
+		}
 	} else {
 		q.Set("scope", scope)
 	}
@@ -430,12 +436,18 @@ func (s *Server) callbackOAuthApp(apiContext api.Context) error {
 		}
 
 		tokenResp = &types.OAuthTokenResponse{
-			State:       state,
-			Scope:       slackTokenResp.AuthedUser.Scope,
-			AccessToken: slackTokenResp.AuthedUser.AccessToken,
-			Ok:          slackTokenResp.Ok,
-			Error:       slackTokenResp.Error,
-			CreatedAt:   time.Now(),
+			State:     state,
+			Ok:        slackTokenResp.Ok,
+			Error:     slackTokenResp.Error,
+			CreatedAt: time.Now(),
+		}
+
+		if slackTokenResp.AuthedUser.AccessToken != "" {
+			tokenResp.AccessToken = slackTokenResp.AuthedUser.AccessToken
+			tokenResp.Scope = slackTokenResp.AuthedUser.Scope
+		} else if slackTokenResp.AccessToken != "" {
+			tokenResp.AccessToken = slackTokenResp.AccessToken
+			tokenResp.Scope = slackTokenResp.Scope
 		}
 	case types2.OAuthAppTypeGitHub:
 		// Read the response body

--- a/pkg/gateway/types/oauth_apps.go
+++ b/pkg/gateway/types/oauth_apps.go
@@ -225,6 +225,8 @@ type SlackOAuthTokenResponse struct {
 		Scope       string `json:"scope"`
 		AccessToken string `json:"access_token"`
 	} `json:"authed_user"`
+	AccessToken string `json:"access_token"`
+	Scope       string `json:"scope"`
 }
 
 type OAuthTokenRequestChallenge struct {


### PR DESCRIPTION
This PR supports pulling slack bot token from oauth process. This requires tools to specify `scope` instead of `user_scope` to get token from bot.

Require https://github.com/obot-platform/tools/pull/451.