### PR TITLE
enhance: distinguish between verified and unverified email addresses

### DIFF
--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -69,6 +69,17 @@ func (s *Server) wrap(f api.HandlerFunc) http.HandlerFunc {
 		}
 
 		if !s.authorizer.Authorize(req, user) {
+			if _, err := req.Cookie("obot_access_token"); err == nil && req.URL.Path == "/api/me" {
+				// Tell the browser to delete the obot_access_token cookie.
+				// If the user tried to access this path and was unauthorized, then something is wrong with their token.
+				http.SetCookie(rw, &http.Cookie{
+					Name:   "obot_access_token",
+					Value:  "",
+					Path:   "/",
+					MaxAge: -1,
+				})
+			}
+
 			http.Error(rw, "forbidden", http.StatusForbidden)
 			return
 		}

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -11,13 +11,14 @@ import (
 )
 
 type User struct {
-	ID        uint        `json:"id" gorm:"primaryKey"`
-	CreatedAt time.Time   `json:"createdAt"`
-	Username  string      `json:"username" gorm:"unique"`
-	Email     string      `json:"email"`
-	Role      types2.Role `json:"role"`
-	IconURL   string      `json:"iconURL"`
-	Timezone  string      `json:"timezone"`
+	ID            uint        `json:"id" gorm:"primaryKey"`
+	CreatedAt     time.Time   `json:"createdAt"`
+	Username      string      `json:"username" gorm:"unique"`
+	Email         string      `json:"email"`
+	VerifiedEmail *bool       `json:"verifiedEmail,omitempty"`
+	Role          types2.Role `json:"role"`
+	IconURL       string      `json:"iconURL"`
+	Timezone      string      `json:"timezone"`
 }
 
 func ConvertUser(u *User, roleFixed bool, authProviderName string) *types2.User {


### PR DESCRIPTION
**Reviewers**: please double-check my logic in this, as well was my design choices surrounding migration that I outlined below.

for https://github.com/obot-platform/obot/issues/1807

This PR adds a distinction between users with a verified email address or an unverified email address. Google and GitHub verify email addresses, so we automatically treat those as verified, and everything else as unverified.

When checking to see if a new identity matches an existing user, we only look for an existing user if the new identity has a verified email address, and the existing user does too. This is the only way we can safely continue to match identities to users based on email addresses.

## Handling Migration

There is no automatic migration to do. The new `VerifiedEmail` field on the user starts out as null. We fill it in with either `true` or `false` depending on whether the first auth provider that the user uses to log in to it is verified or not.

All existing associations between an identity and a user are preserved.

If there is both a verified and an unverified identity associated with the user, the user's `VerifiedEmail` field will be marked `true` permanently as soon as they log in with the verified auth provider, but they will also still be able to log in with the unverified one, for the sake of backward compatibility. I don't know if this case actually exists anywhere out there, since the only unverified auth providers are enterprise only, but I wanted to account for this case anyway.