### PR TITLE
fix: autosize min-height on task steps & chatbar

### DIFF
--- a/ui/admin/app/components/chat/Chatbar.tsx
+++ b/ui/admin/app/components/chat/Chatbar.tsx
@@ -69,7 +69,7 @@ export function Chatbar({ className }: ChatbarProps) {
 						}
 					}}
 					maxHeight={200}
-					minHeight={32}
+					rows={1}
 					onChange={(e) => setInput(e.target.value)}
 					placeholder="Type your message..."
 					bottomContent={

--- a/ui/admin/app/components/chat/Chatbar.tsx
+++ b/ui/admin/app/components/chat/Chatbar.tsx
@@ -69,7 +69,7 @@ export function Chatbar({ className }: ChatbarProps) {
 						}
 					}}
 					maxHeight={200}
-					minHeight={0}
+					minHeight={32}
 					onChange={(e) => setInput(e.target.value)}
 					placeholder="Type your message..."
 					bottomContent={

--- a/ui/admin/app/components/task/steps/StepBase.tsx
+++ b/ui/admin/app/components/task/steps/StepBase.tsx
@@ -97,7 +97,7 @@ export const StepBase = memo(function StepBase({
 						onChange={(e) => fieldConfig.onChange(e.target.value)}
 						placeholder={fieldConfig.placeholder}
 						maxHeight={100}
-						minHeight={32}
+						rows={1}
 						className="flex-grow bg-background"
 						onClick={(e) => e.stopPropagation()}
 					/>

--- a/ui/admin/app/components/task/steps/StepBase.tsx
+++ b/ui/admin/app/components/task/steps/StepBase.tsx
@@ -97,7 +97,7 @@ export const StepBase = memo(function StepBase({
 						onChange={(e) => fieldConfig.onChange(e.target.value)}
 						placeholder={fieldConfig.placeholder}
 						maxHeight={100}
-						minHeight={0}
+						minHeight={32}
 						className="flex-grow bg-background"
 						onClick={(e) => e.stopPropagation()}
 					/>


### PR DESCRIPTION
* fixes min-height on chatbar & tasks steps looking like this:

<img width="568" alt="Screenshot 2025-02-21 at 11 17 49 AM" src="https://github.com/user-attachments/assets/3a5e7912-0ad3-4012-9fc6-24c2711d23c9" />
<img width="729" alt="Screenshot 2025-02-21 at 11 17 43 AM" src="https://github.com/user-attachments/assets/ea12f340-f90b-404c-b7ed-c01963091517" />

