### PR TITLE
fix: wysiwyg list styling & add source mode for markdown copy & paste

### DIFF
--- a/ui/admin/app/components/ui/markdown.css
+++ b/ui/admin/app/components/ui/markdown.css
@@ -1,13 +1,17 @@
-[class*="_selectTrigger"] {
-	@apply bg-transparent text-foreground;
+[class*="_selectTrigger"],
+.cm-gutters,
+.cm-gutterElement {
+	@apply bg-transparent text-muted-foreground;
 }
 [class*="_linkDialogPopoverContent"],
 [class*="_dialogContent"],
+.mdxeditor-diff-source-wrapper .cm-editor,
 .mdxeditor-select-content {
 	@apply bg-background;
 }
-.mdxeditor-toolbar {
-	@apply bg-background-secondary;
+.mdxeditor-toolbar,
+.cm-activeLineGutter {
+	@apply !bg-background-secondary;
 }
 .mdxeditor-popup-container input {
 	@apply bg-background;
@@ -17,4 +21,13 @@
 }
 [class*="_secondaryButton"] {
 	@apply relative inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-full border-0 bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground shadow-sm transition-colors hover:bg-secondary/80 hover:shadow-inner focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0;
+}
+.mdxeditor ul {
+	@apply list-disc px-4;
+}
+.mdxeditor ol {
+	@apply list-decimal px-4;
+}
+.mdxeditor-source-editor {
+	@apply overflow-auto max-h-[300px];
 }

--- a/ui/admin/app/components/ui/markdown.css
+++ b/ui/admin/app/components/ui/markdown.css
@@ -29,5 +29,5 @@
 	@apply list-decimal px-4;
 }
 .mdxeditor-source-editor {
-	@apply overflow-auto max-h-[300px];
+	@apply max-h-[300px] overflow-auto;
 }


### PR DESCRIPTION
* adds paste support to format to markdown
* adds source/diff in toolbar in case parsing errors
* fix ul/ol styling in mdx-editor
* add codeblock support
Addresses #1759 

<img width="930" alt="Screenshot 2025-02-21 at 1 48 31 PM" src="https://github.com/user-attachments/assets/84e63e99-f790-4fd9-967f-d73831532f5a" />
<img width="951" alt="Screenshot 2025-02-21 at 1 48 26 PM" src="https://github.com/user-attachments/assets/7100b6fd-4f84-4587-8e18-d6b0c4f5f451" />