### PR TITLE
fix: can't scroll when there's too many files

### DIFF
--- a/ui/user/src/lib/components/navbar/Files.svelte
+++ b/ui/user/src/lib/components/navbar/Files.svelte
@@ -51,7 +51,7 @@
 		{#if files.items.length === 0}
 			<p class="pb-3 pt-6 text-center text-sm text-gray dark:text-gray-300">No files</p>
 		{:else}
-			<ul class="space-y-4 px-3 py-6 text-sm">
+			<ul class="space-y-4 px-3 py-6 text-sm overflow-y-auto max-h-[60vh]">
 				{#each files.items as file}
 					<li class="group">
 						<div class="flex">

--- a/ui/user/src/lib/components/navbar/Files.svelte
+++ b/ui/user/src/lib/components/navbar/Files.svelte
@@ -51,7 +51,7 @@
 		{#if files.items.length === 0}
 			<p class="pb-3 pt-6 text-center text-sm text-gray dark:text-gray-300">No files</p>
 		{:else}
-			<ul class="space-y-4 px-3 py-6 text-sm overflow-y-auto max-h-[60vh]">
+			<ul class="max-h-[60vh] space-y-4 overflow-y-auto px-3 py-6 text-sm">
 				{#each files.items as file}
 					<li class="group">
 						<div class="flex">


### PR DESCRIPTION
* adds overflow for files list
<img width="1728" alt="Screenshot 2025-02-21 at 3 31 32 PM" src="https://github.com/user-attachments/assets/bdd16819-52e6-4e49-be5e-2f3e9d3824c2" />

Addresses #1769 