### PR TITLE
fix: default first char of assistant if project name & icon is not available

### DIFF
--- a/ui/user/src/lib/icons/AssistantIcon.svelte
+++ b/ui/user/src/lib/icons/AssistantIcon.svelte
@@ -73,6 +73,6 @@
 			klass
 		)}
 	>
-		{project?.name ? project.name[0].toUpperCase() : '?'}
+		{project?.name ? project.name[0].toUpperCase() : assistant?.name ? assistant.name[0].toUpperCase() : '?'}
 	</div>
 {/if}


### PR DESCRIPTION
* default to first char of agent name if project name and icon is not available
* Addresses #1802

<img width="904" alt="Screenshot 2025-02-21 at 3 46 53 PM" src="https://github.com/user-attachments/assets/efdb1921-e643-459e-8ceb-58d4f07ec080" />

user-ui:
<img width="1295" alt="Screenshot 2025-02-21 at 3 46 49 PM" src="https://github.com/user-attachments/assets/5cf78a35-6a09-4f21-936d-9d7eba39fe5f" />
