### PR TITLE
fix: calendar style adjustments

### DIFF
--- a/ui/admin/app/components/composed/DataTable.tsx
+++ b/ui/admin/app/components/composed/DataTable.tsx
@@ -227,6 +227,10 @@ export const DataTableTimeFilter = ({
 			</PopoverTrigger>
 			<PopoverContent>
 				<Calendar
+					classNames={{
+						caption: "flex items-center justify-between gap-4 pl-2",
+						nav: "flex gap-4",
+					}}
 					mode="range"
 					selected={range}
 					onSelect={(range) => {


### PR DESCRIPTION
* fixes calendar buttons colliding & month name not left-aligned

before:
<img width="235" alt="Screenshot 2025-02-24 at 10 12 59 AM" src="https://github.com/user-attachments/assets/ff914baf-9fec-4534-a246-6393e0a176cc" />


after:
<img width="290" alt="Screenshot 2025-02-24 at 10 13 08 AM" src="https://github.com/user-attachments/assets/1806b931-cd20-4d81-a448-2a848909d636" />