### PR TITLE
fix: chat threads, filter out threads with project threads

### DIFF
--- a/ui/admin/app/lib/model/threads.ts
+++ b/ui/admin/app/lib/model/threads.ts
@@ -14,6 +14,7 @@ export type Thread = EntityMeta &
 		parentThreadId?: string;
 		lastRunID?: string;
 		userID?: string;
+		project?: boolean;
 	} & (
 		| { agentID: string; workflowID?: never }
 		| { agentID?: never; workflowID: string }

--- a/ui/admin/app/routes/_auth.chat-threads._index.tsx
+++ b/ui/admin/app/routes/_auth.chat-threads._index.tsx
@@ -74,7 +74,7 @@ export default function TaskRuns() {
 		if (!getThreads.data) return [];
 
 		let filteredThreads = getThreads.data.filter(
-			(thread) => thread.agentID && !thread.deleted
+			(thread) => thread.agentID && !thread.deleted && !thread.project
 		);
 
 		if (agentId) {


### PR DESCRIPTION
* both agent thread and a project thread (project: true) gets made when chatting with an agent
* filter out project: true threads for now (until admin-ui project changes are made)
Addresses #1798 