### PR TITLE
fix: update credentials in user-ui

### DIFF
--- a/ui/user/src/lib/components/navbar/Profile.svelte
+++ b/ui/user/src/lib/components/navbar/Profile.svelte
@@ -26,14 +26,17 @@
 			{#if credentials && credentials?.items.length > 0}
 				<span class="mb-2">Credentials</span>
 				{#each credentials.items as cred}
-					{#if !cred.name.startsWith('tl1')}
+					{#if !cred.toolName.startsWith('tl1')}
 						<div class="flex justify-between">
-							<span>{cred.name}</span>
+							<div class="flex items-center gap-2">
+								<img alt={cred.toolName} src={cred.icon} class="h-5 w-5" />
+								<span>{cred.toolName}</span>
+							</div>
 							<button>
 								<Trash
 									class="h-5 w-5 text-gray"
 									onclick={() => {
-										deleteCred(cred.name);
+										deleteCred(cred.toolName);
 									}}
 								/>
 							</button>

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -213,7 +213,8 @@ export interface AssistantToolList {
 }
 
 export interface Credential {
-	name: string;
+	toolName: string;
+	icon: string;
 }
 
 export interface CredentialList {


### PR DESCRIPTION
Addresses #1823 

* slight update to credentials based on api call -- `toolName` instead of `name`
* `icon` was also available so threw that in too!
<img width="390" alt="Screenshot 2025-02-25 at 11 06 40 AM" src="https://github.com/user-attachments/assets/56410659-4bc9-4c55-a8a5-adf09c082710" />
