### PR TITLE
fix: delete threads if the agent was deleted

### DIFF
--- a/pkg/storage/apis/obot.obot.ai/v1/thread.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/thread.go
@@ -95,6 +95,7 @@ type ThreadSpec struct {
 
 func (in *Thread) DeleteRefs() []Ref {
 	refs := []Ref{
+		{ObjType: &Agent{}, Name: in.Spec.AgentName},
 		{ObjType: &WorkflowExecution{}, Name: in.Spec.WorkflowExecutionName},
 		{ObjType: &Workflow{}, Name: in.Spec.WorkflowName},
 		{ObjType: &CronJob{}, Name: in.Spec.CronJobName},


### PR DESCRIPTION
When a thread's agent gets deleted, the thread itself should be deleted also. This fixes that.