### PR TITLE
fix: avoid excessive form resets

### DIFF
--- a/ui/admin/app/components/agent/AgentForm.tsx
+++ b/ui/admin/app/components/agent/AgentForm.tsx
@@ -59,10 +59,6 @@ export function AgentForm({
 	});
 
 	useEffect(() => {
-		if (agent) form.reset(agent);
-	}, [agent, form]);
-
-	useEffect(() => {
 		return form.watch((values) => {
 			if (!onChange) return;
 

--- a/ui/admin/app/components/agent/AgentIntroForm.tsx
+++ b/ui/admin/app/components/agent/AgentIntroForm.tsx
@@ -34,18 +34,10 @@ export function AgentIntroForm({
 		resolver: zodResolver(formSchema),
 		mode: "onChange",
 		defaultValues: {
-			introductionMessage: "",
-			starterMessages: [],
+			introductionMessage: agent.introductionMessage ?? "",
+			starterMessages: agent.starterMessages ?? [],
 		},
 	});
-
-	useEffect(() => {
-		if (agent)
-			form.reset({
-				introductionMessage: agent.introductionMessage ?? "",
-				starterMessages: agent.starterMessages ?? [],
-			});
-	}, [agent, form]);
 
 	useEffect(() => {
 		return form.watch((values) => {


### PR DESCRIPTION
To address: https://acorn-io.slack.com/archives/C07P0EZR917/p1740513904681939
* seems like these are firing every time with a key change which may be causing the lag and periodic loss of key input
Wondering should we be resetting whenever there's an update to agent? 