### PR TITLE
chore: expose workqueue metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/obot-platform/obot/apiclient v0.0.0-00010101000000-000000000000
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/prometheus/client_golang v1.20.5
 	github.com/pterm/pterm v0.12.80
 	github.com/rs/cors v1.11.1
 	github.com/sendgrid/sendgrid-go v3.16.0+incompatible
@@ -43,6 +44,7 @@ require (
 	k8s.io/apimachinery v0.31.1
 	k8s.io/apiserver v0.31.1
 	k8s.io/client-go v0.31.1
+	k8s.io/component-base v0.31.1
 	k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9
 	k8s.io/kube-openapi v0.0.0-20241009091222-67ed5848f094
 	k8s.io/kubectl v0.29.0
@@ -190,7 +192,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.60.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
@@ -256,7 +257,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gorm.io/driver/postgres v1.5.11 // indirect
 	k8s.io/cli-runtime v0.29.0 // indirect
-	k8s.io/component-base v0.31.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kms v0.31.1 // indirect
 	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6 // indirect

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -53,6 +53,7 @@ var staticRules = map[string][]string{
 		"POST /api/sendgrid",
 
 		"GET /api/healthz",
+		"GET /debug/metrics",
 
 		"GET /api/auth-providers",
 		"GET /api/auth-providers/{id}",

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -7,6 +7,8 @@ import (
 	"github.com/obot-platform/obot/pkg/api/handlers/sendgrid"
 	"github.com/obot-platform/obot/pkg/services"
 	"github.com/obot-platform/obot/ui"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 func Router(services *services.Services) (http.Handler, error) {
@@ -316,7 +318,7 @@ func Router(services *services.Services) (http.Handler, error) {
 	mux.HandleFunc("PUT /api/cronjobs/{id}", cronJobs.Update)
 	mux.HandleFunc("POST /api/cronjobs/{id}", cronJobs.Execute)
 
-	// debug
+	// Debug
 	mux.HTTPHandle("GET /debug/pprof/", http.DefaultServeMux)
 	mux.HTTPHandle("GET /debug/triggers", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		b, err := services.Router.DumpTriggers(true)
@@ -325,6 +327,11 @@ func Router(services *services.Services) (http.Handler, error) {
 		}
 
 		_, _ = w.Write(b)
+	}))
+
+	// Metrics
+	mux.HTTPHandle("GET /debug/metrics", promhttp.HandlerFor(legacyregistry.DefaultGatherer, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
 	}))
 
 	// Model providers


### PR DESCRIPTION
The /debug/metrics endpoint is exposed to any unauthenticated user so that the
prometheus service can access the metrics.

Signed-off-by: Donnie Adams <donnie@acorn.io>