### PR TITLE
fix: copy & paste listening only on markdown contentEditable

### DIFF
--- a/ui/admin/app/components/ui/markdown.tsx
+++ b/ui/admin/app/components/ui/markdown.tsx
@@ -104,6 +104,11 @@ export function MarkdownEditor({
 	}, [markdown]);
 
 	const handlePaste = (event: React.ClipboardEvent<HTMLDivElement>) => {
+		const target = event.target as HTMLElement;
+		if (!target.closest('[class^="_contentEditable"]')) {
+			return;
+		}
+
 		event.stopPropagation();
 		const text = event.clipboardData.getData("text/plain");
 		ref.current?.insertMarkdown(text);
@@ -179,7 +184,6 @@ export function MarkdownEditor({
 						readOnlyDiff: true,
 					}),
 				]}
-				suppressHtmlProcessing
 			/>
 		</div>
 	);

--- a/ui/admin/package.json
+++ b/ui/admin/package.json
@@ -22,7 +22,7 @@
 		"@dnd-kit/utilities": "^3.2.2",
 		"@gptscript-ai/gptscript": "^0.9.5-rc5",
 		"@hookform/resolvers": "^3.9.0",
-		"@mdxeditor/editor": "^3.23.2",
+		"@mdxeditor/editor": "^3.25.0",
 		"@monaco-editor/react": "^4.6.0",
 		"@radix-ui/react-accordion": "^1.2.0",
 		"@radix-ui/react-alert-dialog": "^1.1.2",

--- a/ui/admin/pnpm-lock.yaml
+++ b/ui/admin/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^3.9.0
         version: 3.9.1(react-hook-form@7.54.1(react@18.3.1))
       '@mdxeditor/editor':
-        specifier: ^3.23.2
-        version: 3.23.2(@codemirror/language@6.10.8)(@lezer/highlight@1.2.1)(@types/react-dom@18.3.5(@types/react@18.3.17))(@types/react@18.3.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.23)
+        specifier: ^3.25.0
+        version: 3.25.0(@codemirror/language@6.10.8)(@lezer/highlight@1.2.1)(@types/react-dom@18.3.5(@types/react@18.3.17))(@types/react@18.3.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.23)
       '@monaco-editor/react':
         specifier: ^4.6.0
         version: 4.6.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1343,8 +1343,8 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
-  '@mdxeditor/editor@3.23.2':
-    resolution: {integrity: sha512-sRc/V7at5+zCto4KQaarcQFAtAWRQFHwJm7B29iFGGax1q7mvrSBSMvedoy16vsyey8Nq27tETuewhTi5QSDNg==}
+  '@mdxeditor/editor@3.25.0':
+    resolution: {integrity: sha512-SGbCyqSRezWJ3JUrYVjjjl6wlUibMalumZ++58GGS2XEnOZGMb48FMhrYAkbqQmQgDj0GvnCIsYvxT3/uvt7Jw==}
     engines: {node: '>=16'}
     peerDependencies:
       react: '>= 18 || >= 19'
@@ -6770,7 +6770,7 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
-  '@mdxeditor/editor@3.23.2(@codemirror/language@6.10.8)(@lezer/highlight@1.2.1)(@types/react-dom@18.3.5(@types/react@18.3.17))(@types/react@18.3.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.23)':
+  '@mdxeditor/editor@3.25.0(@codemirror/language@6.10.8)(@lezer/highlight@1.2.1)(@types/react-dom@18.3.5(@types/react@18.3.17))(@types/react@18.3.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.23)':
     dependencies:
       '@codemirror/lang-markdown': 6.3.2
       '@codemirror/language-data': 6.5.1


### PR DESCRIPTION
* copy & paste event handler should only trigger when user is focused on _contentEditable class, otherwise copy & paste is being triggered on image/link dialog and link/image url is getting pasted into content
Addresses #1759 
Related to #1817