### PR TITLE
fix: stop filtering agent level tools from the tools dropdown

### DIFF
--- a/ui/admin/app/components/agent/shared/constants.ts
+++ b/ui/admin/app/components/agent/shared/constants.ts
@@ -6,6 +6,8 @@ const CapabilityToolOrder = {
 	[CapabilityTool.WorkspaceFiles]: 1,
 	[CapabilityTool.Database]: 2,
 	[CapabilityTool.Tasks]: 3,
+	[CapabilityTool.Projects]: 4,
+	[CapabilityTool.Threads]: 5,
 } satisfies Record<CapabilityTool, number>;
 
 export const getCapabilityToolOrder = (tool: string) => {

--- a/ui/admin/app/lib/model/toolReferences.ts
+++ b/ui/admin/app/lib/model/toolReferences.ts
@@ -51,6 +51,8 @@ export const CapabilityTool = {
 	WorkspaceFiles: "workspace-files",
 	Database: "database",
 	Tasks: "tasks",
+	Projects: "projects",
+	Threads: "threads",
 } as const;
 export type CapabilityTool =
 	(typeof CapabilityTool)[keyof typeof CapabilityTool];

--- a/ui/user/src/lib/components/navbar/Tools.svelte
+++ b/ui/user/src/lib/components/navbar/Tools.svelte
@@ -5,6 +5,7 @@
 	import { newTool } from '$lib/components/tool/Tool.svelte';
 	import Menu from '$lib/components/navbar/Menu.svelte';
 	import { PenBox } from 'lucide-svelte';
+	import { isCapabilityTool } from '$lib/model/tools';
 
 	let menu = $state<ReturnType<typeof Menu>>();
 
@@ -42,7 +43,7 @@
 	{#snippet body()}
 		<ul class="space-y-4 py-6 text-sm">
 			{#each tools.items as tool, i}
-				{#if !tool.builtin}
+				{#if !isCapabilityTool(tool.id)}
 					<li>
 						<div class="flex">
 							{#if tool.icon}

--- a/ui/user/src/lib/model/tools.ts
+++ b/ui/user/src/lib/model/tools.ts
@@ -1,0 +1,12 @@
+export const CapabilityTool = {
+	Knowledge: 'knowledge',
+	WorkspaceFiles: 'workspace-files',
+	Database: 'database',
+	Tasks: 'tasks',
+	Projects: 'projects',
+	Threads: 'threads'
+} as const;
+export type CapabilityTool = (typeof CapabilityTool)[keyof typeof CapabilityTool];
+
+export const isCapabilityTool = (value: string): value is CapabilityTool =>
+	Object.values(CapabilityTool).includes(value as CapabilityTool);


### PR DESCRIPTION
Addresses #527

- ensures that agent required tools are disabled so the user cannot remove them

<img width="426" alt="Screenshot 2025-03-03 at 5 46 18 PM" src="https://github.com/user-attachments/assets/5ed89ec4-bd80-430e-8c9e-a5f152efcc59" />
