### PR TITLE
feat: mark finished runs as inactive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ package-tools:
 tidy:
 	go mod tidy
 
-GOLANGCI_LINT_VERSION ?= v1.64.5
+GOLANGCI_LINT_VERSION ?= v1.64.6
 setup-env:
 	if ! command -v golangci-lint &> /dev/null; then \
   		echo "Could not find golangci-lint, installing version $(GOLANGCI_LINT_VERSION)."; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/obot-platform/obot
 
-go 1.23.4
+go 1.24.0
 
 replace (
 	github.com/obot-platform/obot/apiclient => ./apiclient

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/mhale/smtpd v0.8.3
 	github.com/obot-platform/kinm v0.0.0-20250116162656-270198b40c6d
-	github.com/obot-platform/nah v0.0.0-20250227230402-c8ac47e1add7
+	github.com/obot-platform/nah v0.0.0-20250305151239-35a77e89a2eb
 	github.com/obot-platform/namegenerator v0.0.0-20241217121223-fc58bdb7dca2
 	github.com/obot-platform/obot/apiclient v0.0.0-00010101000000-000000000000
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349 h1:t05Ww3DxZutOqbMN+
 github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/obot-platform/kinm v0.0.0-20250116162656-270198b40c6d h1:GzMvRkssr4jAa2YvQiv9eXhjuNpaZVab3GajE7+cQ3s=
 github.com/obot-platform/kinm v0.0.0-20250116162656-270198b40c6d/go.mod h1:RzrH0geIlbiTHDGZ8bpCk5k1hwdU9uu3l4zJn9n0pZU=
-github.com/obot-platform/nah v0.0.0-20250227230402-c8ac47e1add7 h1:IuG8TZqqxz5P1ZHj2aCxEEn6LGgHXeUVhkG/ELh2a8U=
-github.com/obot-platform/nah v0.0.0-20250227230402-c8ac47e1add7/go.mod h1:KG1jLO9FeYvCPGI0iDqe5oqDqOFLd3/dt/iwuMianmI=
+github.com/obot-platform/nah v0.0.0-20250305151239-35a77e89a2eb h1:Cgf8prbkB2gwFAI2vsXRN1U7enKkFMYJjaUT+uNR7dc=
+github.com/obot-platform/nah v0.0.0-20250305151239-35a77e89a2eb/go.mod h1:be9DBO6pFx4yiKs9bm4GcuZgGX4OVpeRJclA9ojxzmo=
 github.com/obot-platform/namegenerator v0.0.0-20241217121223-fc58bdb7dca2 h1:jiyBM/TYxU6UNVS9ff8Y8n55DOKDYohKkIZjfHpjfTY=
 github.com/obot-platform/namegenerator v0.0.0-20241217121223-fc58bdb7dca2/go.mod h1:isbKX6EfvvG/ojjFB2ZLyz27+2xoG3yRmpTSE+ytWEs=
 github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77 h1:3bMMZ1f+GPXFQ1uNaYbO/uECWvSfqEA+ZEXn1rFAT88=

--- a/pkg/api/handlers/threads.go
+++ b/pkg/api/handlers/threads.go
@@ -158,7 +158,7 @@ func (a *ThreadHandler) Update(req api.Context) error {
 		return err
 	}
 
-	// Don't allow update of tools here, do it with the /tools endpoing
+	// Don't allow update of tools here, do it with the /tools endpoint
 	newThread.Tools = existing.Spec.Manifest.Tools
 
 	existing.Spec.Manifest = newThread

--- a/pkg/controller/handlers/inactive/inactive.go
+++ b/pkg/controller/handlers/inactive/inactive.go
@@ -1,0 +1,27 @@
+package inactive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obot-platform/nah/pkg/backend"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func RemoveFromCache(ctx context.Context, backend backend.Backend, obj kclient.Object) error {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Kind == "" {
+		var err error
+		gvk, err = backend.GVKForObject(obj, backend.Scheme())
+		if err != nil {
+			return fmt.Errorf("failed to get GVK for object: %w", err)
+		}
+	}
+
+	informer, err := backend.GetInformerForKind(ctx, gvk)
+	if err != nil {
+		return fmt.Errorf("failed to get informer for kind %s: %w", gvk.String(), err)
+	}
+
+	return informer.GetStore().Delete(obj)
+}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 	"sort"
 	"strings"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/gptscript-ai/gptscript/pkg/sdkserver"
 	"github.com/obot-platform/nah"
 	"github.com/obot-platform/nah/pkg/apply"
+	nfields "github.com/obot-platform/nah/pkg/fields"
 	"github.com/obot-platform/nah/pkg/leader"
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/nah/pkg/runtime"
@@ -43,9 +46,12 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/request/union"
+	kcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	// Setup nah logging
 	_ "github.com/obot-platform/nah/pkg/logrus"
@@ -76,6 +82,7 @@ type Config struct {
 	AuthAdminEmails            []string `usage:"Emails of admin users"`
 	AgentsDir                  string   `usage:"The directory to auto load agents on start (default $XDG_CONFIG_HOME/.obot/agents)"`
 	StaticDir                  string   `usage:"The directory to serve static files from"`
+	IgnoreInactive             bool     `usage:"Ignore inactive objects" default:"false"`
 
 	// Sendgrid webhook
 	SendgridWebhookUsername string `usage:"The username for the sendgrid webhook to authenticate with"`
@@ -279,17 +286,27 @@ func New(ctx context.Context, config Config) (*Services, error) {
 			return nil, err
 		}
 	} else {
-		var notFound gptscript.ErrNotFound
-		if err := c.DeleteCredential(ctx, system.DefaultNamespace, system.KnowledgeCredID); err != nil && !errors.As(err, &notFound) {
+		if err := c.DeleteCredential(ctx, system.DefaultNamespace, system.KnowledgeCredID); err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return nil, err
 		}
 	}
 
+	byObjectFieldSelectors := make(map[kclient.Object]kcache.ByObject)
+	if config.IgnoreInactive {
+		for _, t := range scheme.Scheme.AllKnownTypes() {
+			if v, ok := reflect.New(t).Interface().(nfields.Fields); ok && slices.Contains(v.FieldNames(), v1.LabelInactive) {
+				// Only add the field selector requirement to objects that support the field selector.
+				byObjectFieldSelectors[v.(kclient.Object)] = kcache.ByObject{Field: fields.OneTermEqualSelector(v1.LabelInactive, "")}
+			}
+		}
+	}
+
 	r, err := nah.NewRouter("obot-controller", &nah.Options{
-		DefaultRESTConfig: restConfig,
-		Scheme:            scheme.Scheme,
-		ElectionConfig:    leader.NewDefaultElectionConfig("", "obot-controller", restConfig),
-		HealthzPort:       -1,
+		RESTConfig:     restConfig,
+		Scheme:         scheme.Scheme,
+		ByObject:       byObjectFieldSelectors,
+		ElectionConfig: leader.NewDefaultElectionConfig("", "obot-controller", restConfig),
+		HealthzPort:    -1,
 		GVKThreadiness: map[schema.GroupVersionKind]int{
 			v1.SchemeGroupVersion.WithKind("KnowledgeFile"): config.KnowledgeFileWorkers,
 		},

--- a/pkg/storage/apis/obot.obot.ai/v1/inactive.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/inactive.go
@@ -1,0 +1,20 @@
+package v1
+
+import kclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+const LabelInactive = "obot_inactive_object"
+
+func SetInactive(o kclient.Object) {
+	if o.GetLabels() == nil {
+		o.SetLabels(make(map[string]string, 1))
+	}
+	o.GetLabels()[LabelInactive] = "true"
+}
+
+func SetActive(o kclient.Object) {
+	delete(o.GetLabels(), LabelInactive)
+}
+
+func IsActive(o kclient.Object) bool {
+	return o.GetLabels()[LabelInactive] != "true"
+}

--- a/pkg/storage/apis/obot.obot.ai/v1/run.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/run.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	gptscriptclient "github.com/gptscript-ai/go-gptscript"
+	"github.com/obot-platform/nah/pkg/fields"
 	"github.com/obot-platform/obot/apiclient/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -23,6 +24,11 @@ const (
 	AuthProviderSyncAnnotation  = "obot.ai/auth-provider-sync"
 )
 
+var (
+	_ fields.Fields = (*Run)(nil)
+	_ DeleteRefs    = (*Run)(nil)
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Run struct {
@@ -40,6 +46,8 @@ func (in *Run) Has(field string) bool {
 func (in *Run) Get(field string) string {
 	if in != nil {
 		switch field {
+		case LabelInactive:
+			return in.Labels[LabelInactive]
 		case "spec.threadName":
 			return in.Spec.ThreadName
 		case "spec.previousRunName":
@@ -51,7 +59,7 @@ func (in *Run) Get(field string) string {
 }
 
 func (in *Run) FieldNames() []string {
-	return []string{"spec.threadName", "spec.previousRunName"}
+	return []string{"spec.threadName", "spec.previousRunName", LabelInactive}
 }
 
 func (in *Run) GetColumns() [][]string {

--- a/pkg/storage/apis/obot.obot.ai/v1/thread.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/thread.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"slices"
+	"strconv"
 
 	gptscriptclient "github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/obot/apiclient/types"
@@ -38,19 +39,16 @@ func (in *Thread) Has(field string) (exists bool) {
 	return slices.Contains(in.FieldNames(), field)
 }
 
-func (in *Thread) Get(field string) (value string) {
-	switch field {
-	case "spec.agentName":
-		return in.Spec.AgentName
-	case "spec.userUID":
-		return in.Spec.UserID
-	case "spec.project":
-		if in.Spec.Project {
-			return "true"
+func (in *Thread) Get(field string) string {
+	if in != nil {
+		switch field {
+		case "spec.agentName":
+			return in.Spec.AgentName
+		case "spec.project":
+			return strconv.FormatBool(in.Spec.Project)
+		case "spec.parentThreadName":
+			return in.Spec.ParentThreadName
 		}
-		return "false"
-	case "spec.parentThreadName":
-		return in.Spec.ParentThreadName
 	}
 	return ""
 }


### PR DESCRIPTION
Inactive runs will not be processed by the controller and will be removed from
its cache. These runs will still be accessible from the API.

This logic is implemented such that other objects can be marked as inactive and
the controller will similarly ignore them.