### PR TITLE
fix: show required tools for agents in the user ui

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 .icon-button-colors {
-	@apply text-gray hover:bg-gray-100 focus:outline-none dark:text-gray-400 dark:hover:bg-gray-700;
+	@apply text-gray hover:bg-gray-200 focus:outline-none disabled:opacity-50 disabled:hover:bg-transparent dark:text-gray-400 dark:hover:bg-gray-700;
 }
 
 .icon-button {

--- a/ui/user/src/lib/components/navbar/Tools.svelte
+++ b/ui/user/src/lib/components/navbar/Tools.svelte
@@ -12,6 +12,7 @@
 	import { PenBox } from 'lucide-svelte';
 	import type { EditorItem } from '$lib/services/editor/index.svelte';
 	import { getLayout } from '$lib/context/layout.svelte';
+	import { isCapabilityTool } from '$lib/model/tools';
 
 	interface Prop {
 		project: Project;
@@ -48,39 +49,33 @@
 	{/snippet}
 	{#snippet body()}
 		<ul class="space-y-4 py-6 text-sm">
-			{#each tools as tool, i}
-				{#if !tool.builtin}
-					<li>
-						<div class="flex">
-							{#if tool.icon}
-								<img
-									class="h-8 w-8 rounded-md bg-gray-100 p-1"
-									src={tool.icon}
-									alt="message icon"
-								/>
-							{:else}
-								<Wrench class="h-8 w-8 rounded-md bg-gray-100 p-1 text-black" />
-							{/if}
-							<div class="flex flex-1 px-2">
-								<div>
-									<label for="checkbox-item-{i}" class="text-sm font-medium dark:text-gray-100"
-										>{tool.name}</label
-									>
-									<p class="text-xs font-normal text-gray dark:text-gray-300">
-										{tool.description}
-									</p>
-								</div>
+			{#each tools.filter((t) => !isCapabilityTool(t.id)) as tool, i}
+				<li>
+					<div class="flex">
+						{#if tool.icon}
+							<img class="h-8 w-8 rounded-md bg-gray-100 p-1" src={tool.icon} alt="message icon" />
+						{:else}
+							<Wrench class="h-8 w-8 rounded-md bg-gray-100 p-1 text-black" />
+						{/if}
+						<div class="flex flex-1 px-2">
+							<div>
+								<label for="checkbox-item-{i}" class="text-sm font-medium dark:text-gray-100"
+									>{tool.name}</label
+								>
+								<p class="text-xs font-normal text-gray dark:text-gray-300">
+									{tool.description}
+								</p>
 							</div>
-							<button
-								class="p-1"
-								class:invisible={!tool.id.startsWith('tl1')}
-								onclick={() => editTool(tool.id)}
-							>
-								<PenBox class="h-4 w-4" />
-							</button>
 						</div>
-					</li>
-				{/if}
+						<button
+							class="p-1"
+							class:invisible={!tool.id.startsWith('tl1')}
+							onclick={() => editTool(tool.id)}
+						>
+							<PenBox class="h-4 w-4" />
+						</button>
+					</div>
+				</li>
 			{/each}
 		</ul>
 		{#if version.dockerSupported}

--- a/ui/user/src/lib/model/tools.ts
+++ b/ui/user/src/lib/model/tools.ts
@@ -1,0 +1,12 @@
+export const CapabilityTool = {
+	Knowledge: 'knowledge',
+	WorkspaceFiles: 'workspace-files',
+	Database: 'database',
+	Tasks: 'tasks',
+	Projects: 'projects',
+	Threads: 'threads'
+} as const;
+export type CapabilityTool = (typeof CapabilityTool)[keyof typeof CapabilityTool];
+
+export const isCapabilityTool = (tool: string) =>
+	Object.values(CapabilityTool).includes(tool as CapabilityTool);


### PR DESCRIPTION
addresses #572

- shows required agent tools in the project edit view
- removed background color from the tool items because they had wonky coloring in the tool dropdown

before:
<img width="611" alt="Screenshot 2025-03-06 at 11 50 08 AM" src="https://github.com/user-attachments/assets/d5385cbf-5644-4d67-bc32-91692cd13083" />


after:
<img width="682" alt="Screenshot 2025-03-06 at 11 49 00 AM" src="https://github.com/user-attachments/assets/f121cd33-35b6-46d3-af21-a08427caed65" />
