### PR TITLE
fix: propagate user timezone to tasks

### DIFF
--- a/pkg/controller/handlers/workflowexecution/workflowexecution.go
+++ b/pkg/controller/handlers/workflowexecution/workflowexecution.go
@@ -172,6 +172,7 @@ func (h *Handler) newThread(ctx context.Context, c kclient.Client, wf *v1.Workfl
 			WebhookName:           we.Spec.WebhookName,
 			EmailReceiverName:     we.Spec.EmailReceiverName,
 			CronJobName:           we.Spec.CronJobName,
+			UserID:                projectThread.Spec.UserID,
 			Env: []types.EnvVar{
 				{
 					Name:  "WORKFLOW_INPUT",


### PR DESCRIPTION
Copy user IDs from the project thread to workflowexecutions,
ensuring the user's preferred timezone is injected into the
resulting run. Before this, running tasks always thought the
user's preferred timezone was UTC.

https://github.com/obot-platform/obot/issues/1951
