### PR TITLE
feat: add top level obot page to admin ui

### DIFF
--- a/apiclient/types/project.go
+++ b/apiclient/types/project.go
@@ -5,7 +5,7 @@ type Project struct {
 	ProjectManifest
 	AssistantID string `json:"assistantID,omitempty"`
 	Editor      bool   `json:"editor"`
-	ParentID    string `json:"parentID,omitempty`
+	ParentID    string `json:"parentID,omitempty"`
 }
 
 type ProjectManifest struct {

--- a/apiclient/types/project.go
+++ b/apiclient/types/project.go
@@ -5,6 +5,7 @@ type Project struct {
 	ProjectManifest
 	AssistantID string `json:"assistantID,omitempty"`
 	Editor      bool   `json:"editor"`
+	ParentID    string `json:"parentID,omitempty`
 }
 
 type ProjectManifest struct {

--- a/apiclient/types/project.go
+++ b/apiclient/types/project.go
@@ -6,6 +6,7 @@ type Project struct {
 	AssistantID string `json:"assistantID,omitempty"`
 	Editor      bool   `json:"editor"`
 	ParentID    string `json:"parentID,omitempty"`
+	UserID      string `json:"userID,omitempty"`
 }
 
 type ProjectManifest struct {

--- a/pkg/api/handlers/projects.go
+++ b/pkg/api/handlers/projects.go
@@ -281,10 +281,11 @@ func (h *ProjectsHandler) CopyProject(req api.Context) error {
 			Namespace:    req.Namespace(),
 		},
 		Spec: v1.ThreadSpec{
-			Manifest:  thread.Spec.Manifest,
-			AgentName: thread.Spec.AgentName,
-			Project:   true,
-			UserID:    req.User.GetUID(),
+			Manifest:         thread.Spec.Manifest,
+			AgentName:        thread.Spec.AgentName,
+			Project:          true,
+			UserID:           req.User.GetUID(),
+			ParentThreadName: thread.Name,
 		},
 	}
 
@@ -494,6 +495,7 @@ func convertProject(thread *v1.Thread) types.Project {
 		ProjectManifest: types.ProjectManifest{
 			ThreadManifest: thread.Spec.Manifest,
 		},
+		ParentID:    strings.Replace(thread.Spec.ParentThreadName, system.ThreadPrefix, system.ProjectPrefix, 1),
 		AssistantID: thread.Spec.AgentName,
 		Editor:      thread.IsEditor(),
 	}

--- a/pkg/api/handlers/projects.go
+++ b/pkg/api/handlers/projects.go
@@ -281,11 +281,10 @@ func (h *ProjectsHandler) CopyProject(req api.Context) error {
 			Namespace:    req.Namespace(),
 		},
 		Spec: v1.ThreadSpec{
-			Manifest:         thread.Spec.Manifest,
-			AgentName:        thread.Spec.AgentName,
-			Project:          true,
-			UserID:           req.User.GetUID(),
-			ParentThreadName: thread.Name,
+			Manifest:  thread.Spec.Manifest,
+			AgentName: thread.Spec.AgentName,
+			Project:   true,
+			UserID:    req.User.GetUID(),
 		},
 	}
 
@@ -498,6 +497,7 @@ func convertProject(thread *v1.Thread) types.Project {
 		ParentID:    strings.Replace(thread.Spec.ParentThreadName, system.ThreadPrefix, system.ProjectPrefix, 1),
 		AssistantID: thread.Spec.AgentName,
 		Editor:      thread.IsEditor(),
+		UserID:      thread.Spec.UserID,
 	}
 	p.Type = "project"
 	p.ID = strings.Replace(p.ID, system.ThreadPrefix, system.ProjectPrefix, 1)

--- a/pkg/api/handlers/threads.go
+++ b/pkg/api/handlers/threads.go
@@ -11,6 +11,7 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/events"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -49,7 +50,7 @@ func convertThread(thread v1.Thread) types.Thread {
 		LastRunID:       thread.Status.LastRunName,
 		CurrentRunID:    thread.Status.CurrentRunName,
 		State:           state,
-		ProjectID:       thread.Spec.ParentThreadName,
+		ProjectID:       strings.Replace(thread.Spec.ParentThreadName, system.ThreadPrefix, system.ProjectPrefix, 1),
 		UserID:          thread.Spec.UserID,
 		Abort:           thread.Spec.Abort,
 		SystemTask:      thread.Spec.SystemTask,

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2794,6 +2794,18 @@ func schema_obot_platform_obot_apiclient_types_Project(ref common.ReferenceCallb
 							Format:  "",
 						},
 					},
+					"parentID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"userID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"Metadata", "ProjectManifest", "editor"},
 			},

--- a/ui/admin/app/components/composed/Filters.tsx
+++ b/ui/admin/app/components/composed/Filters.tsx
@@ -16,6 +16,7 @@ type QueryParams = {
 	userId?: string;
 	taskId?: string;
 	obotId?: string;
+	parentObotId?: string;
 	createdStart?: string;
 	createdEnd?: string;
 };
@@ -96,6 +97,15 @@ export function Filters({
 					label: "Obot",
 					value: projectMap.get(filters.obotId)?.name ?? filters.obotId,
 					onRemove: () => deleteFilters("obotId"),
+				},
+			"parentObotId" in filters &&
+				filters.parentObotId &&
+				projectMap && {
+					key: "parentObotId",
+					label: "Children of",
+					value:
+						projectMap.get(filters.parentObotId)?.name ?? filters.parentObotId,
+					onRemove: () => deleteFilters("parentObotId"),
 				},
 		].filter((x) => !!x);
 	}, [url, searchParams, agentMap, userMap, taskMap, projectMap, navigate]);

--- a/ui/admin/app/components/composed/Filters.tsx
+++ b/ui/admin/app/components/composed/Filters.tsx
@@ -102,7 +102,7 @@ export function Filters({
 				filters.parentObotId &&
 				projectMap && {
 					key: "parentObotId",
-					label: "Children of",
+					label: "Spawned from",
 					value:
 						projectMap.get(filters.parentObotId)?.name ?? filters.parentObotId,
 					onRemove: () => deleteFilters("parentObotId"),

--- a/ui/admin/app/components/composed/Filters.tsx
+++ b/ui/admin/app/components/composed/Filters.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { $path, Routes } from "safe-routes";
 
 import { Agent } from "~/lib/model/agents";
+import { Project } from "~/lib/model/project";
 import { Task } from "~/lib/model/tasks";
 import { User } from "~/lib/model/users";
 import { RouteService } from "~/lib/service/routeService";
@@ -14,6 +15,7 @@ type QueryParams = {
 	agentId?: string;
 	userId?: string;
 	taskId?: string;
+	obotId?: string;
 	createdStart?: string;
 	createdEnd?: string;
 };
@@ -22,11 +24,13 @@ export function Filters({
 	agentMap,
 	userMap,
 	taskMap,
+	projectMap,
 	url,
 }: {
 	agentMap?: Map<string, Agent>;
 	userMap?: Map<string, User>;
 	taskMap?: Map<string, Task>;
+	projectMap?: Map<string, Project>;
 	url: keyof Routes;
 }) {
 	const [searchParams] = useSearchParams();
@@ -85,8 +89,16 @@ export function Filters({
 					value: `${new Date(filters.createdStart).toLocaleDateString()} ${filters.createdEnd ? `- ${new Date(filters.createdEnd).toLocaleDateString()}` : ""}`,
 					onRemove: () => deleteFilters("createdStart", "createdEnd"),
 				},
+			"obotId" in filters &&
+				filters.obotId &&
+				projectMap && {
+					key: "obotId",
+					label: "Obot",
+					value: projectMap.get(filters.obotId)?.name ?? filters.obotId,
+					onRemove: () => deleteFilters("obotId"),
+				},
 		].filter((x) => !!x);
-	}, [navigate, searchParams, agentMap, userMap, taskMap, url]);
+	}, [url, searchParams, agentMap, userMap, taskMap, projectMap, navigate]);
 
 	return (
 		<div className="flex gap-2 pb-2">

--- a/ui/admin/app/components/composed/typography.tsx
+++ b/ui/admin/app/components/composed/typography.tsx
@@ -53,6 +53,7 @@ export function Truncate({
 					"line-clamp-2": clamp && clampLength === 2,
 					truncate: !clamp,
 				},
+				"break-all",
 				classNames?.content
 			)}
 		>

--- a/ui/admin/app/components/sidebar/Sidebar.tsx
+++ b/ui/admin/app/components/sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import {
 	BotIcon,
+	BotMessageSquareIcon,
 	BoxesIcon,
 	CpuIcon,
 	InfoIcon,
@@ -49,7 +50,7 @@ const items = [
 	{
 		title: "Obots",
 		url: $path("/obots"),
-		icon: BotIcon,
+		icon: BotMessageSquareIcon,
 	},
 	{
 		title: "Chat Threads",

--- a/ui/admin/app/components/sidebar/Sidebar.tsx
+++ b/ui/admin/app/components/sidebar/Sidebar.tsx
@@ -47,6 +47,11 @@ const items = [
 		icon: BotIcon,
 	},
 	{
+		title: "Obots",
+		url: $path("/obots"),
+		icon: BotIcon,
+	},
+	{
 		title: "Chat Threads",
 		url: $path("/chat-threads"),
 		icon: MessageSquare,

--- a/ui/admin/app/components/thread/ThreadMeta.tsx
+++ b/ui/admin/app/components/thread/ThreadMeta.tsx
@@ -160,10 +160,10 @@ export function ThreadMeta({ entity, thread, className }: ThreadMetaProps) {
 									<td className="text-right">{thread.currentRunId}</td>
 								</tr>
 							)}
-							{thread.parentThreadId && (
+							{thread.projectID && (
 								<tr className="border-foreground/25">
 									<td className="py-2 pr-4 font-medium">Parent Thread ID</td>
-									<td className="text-right">{thread.parentThreadId}</td>
+									<td className="text-right">{thread.projectID}</td>
 								</tr>
 							)}
 							{thread.lastRunID && (

--- a/ui/admin/app/components/tools/ToolCatalogGroup.tsx
+++ b/ui/admin/app/components/tools/ToolCatalogGroup.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
 
 import {
 	ToolReference,
@@ -67,7 +67,7 @@ export function ToolCatalogGroup({
 				const configured = configuredTools.has(tool.id);
 
 				return (
-					<>
+					<Fragment key={tool.id}>
 						<ToolItem
 							key={tool.id}
 							tool={tool}
@@ -100,7 +100,7 @@ export function ToolCatalogGroup({
 									}
 								/>
 							))}
-					</>
+					</Fragment>
 				);
 			})}
 		</CommandGroup>

--- a/ui/admin/app/components/user/UserMenu.tsx
+++ b/ui/admin/app/components/user/UserMenu.tsx
@@ -1,8 +1,8 @@
 import { LogOutIcon, User } from "lucide-react";
 import React from "react";
 
-import { AuthDisabledUsername, CommonAuthProviderIds } from "~/lib/model/auth";
-import { User as UserModel, roleLabel } from "~/lib/model/users";
+import { AuthDisabledUsername } from "~/lib/model/auth";
+import { getUserDisplayName, roleLabel } from "~/lib/model/users";
 import { BootstrapApiService } from "~/lib/service/api/bootstrapApiService";
 import { cn } from "~/lib/utils";
 
@@ -32,7 +32,7 @@ export const UserMenu: React.FC<UserMenuProps> = ({
 		return null;
 	}
 
-	const displayName = getDisplayName(me);
+	const displayName = getUserDisplayName(me);
 
 	return (
 		<DropdownMenu>
@@ -80,12 +80,4 @@ export const UserMenu: React.FC<UserMenuProps> = ({
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);
-
-	function getDisplayName(user?: UserModel) {
-		if (user?.currentAuthProvider === CommonAuthProviderIds.GITHUB) {
-			return user.username;
-		}
-
-		return user?.email;
-	}
 };

--- a/ui/admin/app/hooks/useRouteInfo.ts
+++ b/ui/admin/app/hooks/useRouteInfo.ts
@@ -1,7 +1,13 @@
-import { useMemo } from "react";
-import { Location, useLocation, useParams } from "react-router";
+import { useCallback, useMemo } from "react";
+import {
+	Location,
+	useLocation,
+	useParams,
+	useSearchParams,
+} from "react-router";
+import { Routes } from "safe-routes";
 
-import { RouteService } from "~/lib/service/routeService";
+import { QueryInfo, RouteService } from "~/lib/service/routeService";
 
 const urlFromLocation = (location: Location) => {
 	const { pathname, search, hash } = location;
@@ -22,4 +28,38 @@ export function useUnknownPathParams() {
 		() => RouteService.getUnknownRouteInfo(url, params),
 		[url, params]
 	);
+}
+
+export function useQueryInfo<T extends keyof Routes>(route: T) {
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	const params = useMemo(
+		() => RouteService.getQueryParams(route, searchParams.toString()),
+		[route, searchParams]
+	);
+
+	const update = useCallback(
+		<TKey extends keyof QueryInfo<T>>(
+			param: TKey,
+			value: QueryInfo<T>[TKey]
+		) => {
+			setSearchParams((prev) => {
+				prev.set(param as string, String(value));
+				return prev;
+			});
+		},
+		[setSearchParams]
+	);
+
+	const remove = useCallback(
+		(param: keyof QueryInfo<T>) => {
+			setSearchParams((prev) => {
+				prev.delete(param as string);
+				return prev;
+			});
+		},
+		[setSearchParams]
+	);
+
+	return { params, update, remove };
 }

--- a/ui/admin/app/lib/model/project.ts
+++ b/ui/admin/app/lib/model/project.ts
@@ -1,0 +1,10 @@
+import { EntityMeta } from "~/lib/model/primitives";
+import { ThreadManifest } from "~/lib/model/threads";
+
+type ProjectManifest = ThreadManifest & {
+	parentID: string;
+	assistantID: string;
+	editor: boolean;
+};
+
+export type Project = EntityMeta & ProjectManifest;

--- a/ui/admin/app/lib/model/project.ts
+++ b/ui/admin/app/lib/model/project.ts
@@ -2,7 +2,7 @@ import { EntityMeta } from "~/lib/model/primitives";
 import { ThreadManifest } from "~/lib/model/threads";
 
 type ProjectManifest = ThreadManifest & {
-	parentID: string;
+	parentID?: Nullish<string>;
 	assistantID: string;
 	editor: boolean;
 	userID: string;

--- a/ui/admin/app/lib/model/project.ts
+++ b/ui/admin/app/lib/model/project.ts
@@ -5,6 +5,7 @@ type ProjectManifest = ThreadManifest & {
 	parentID: string;
 	assistantID: string;
 	editor: boolean;
+	userID: string;
 };
 
 export type Project = EntityMeta & ProjectManifest;

--- a/ui/admin/app/lib/model/threads.ts
+++ b/ui/admin/app/lib/model/threads.ts
@@ -1,17 +1,24 @@
 import { RunState } from "@gptscript-ai/gptscript";
 
+import { AgentIcons } from "~/lib/model/agents";
 import { EntityMeta } from "~/lib/model/primitives";
 
-export type ThreadBase = {
+export type ThreadManifest = {
+	name: string;
 	description?: string;
 	tools?: string[];
+	icons?: AgentIcons;
+	prompt: string;
+	knowledgeDescription: string;
+	introductionMessage: string;
+	starterMessages: string[];
 };
 
 export type Thread = EntityMeta &
-	ThreadBase & {
+	ThreadManifest & {
 		state?: RunState;
 		currentRunId?: string;
-		parentThreadId?: string;
+		projectID?: string;
 		lastRunID?: string;
 		userID?: string;
 		project?: boolean;
@@ -20,4 +27,4 @@ export type Thread = EntityMeta &
 		| { agentID?: never; workflowID: string }
 	);
 
-export type UpdateThread = ThreadBase;
+export type UpdateThread = ThreadManifest;

--- a/ui/admin/app/lib/model/threads.ts
+++ b/ui/admin/app/lib/model/threads.ts
@@ -7,11 +7,12 @@ export type ThreadManifest = {
 	name: string;
 	description?: string;
 	tools?: string[];
-	icons?: AgentIcons;
+	icons?: Nullish<AgentIcons>;
+	revision?: string;
 	prompt: string;
 	knowledgeDescription: string;
 	introductionMessage: string;
-	starterMessages: string[];
+	starterMessages: Nullish<string[]>;
 };
 
 export type Thread = EntityMeta &

--- a/ui/admin/app/lib/model/users.ts
+++ b/ui/admin/app/lib/model/users.ts
@@ -1,4 +1,4 @@
-import { CommonAuthProviderId } from "~/lib/model/auth";
+import { CommonAuthProviderId, CommonAuthProviderIds } from "~/lib/model/auth";
 import { EntityMeta } from "~/lib/model/primitives";
 
 export type User = EntityMeta & {
@@ -31,3 +31,11 @@ export const roleFromString = (role: string) => {
 
 export const ExplicitAdminDescription =
 	"This user is explicitly set as an admin at the system level and their role cannot be changed.";
+
+export function getUserDisplayName(user?: User) {
+	if (user?.currentAuthProvider === CommonAuthProviderIds.GITHUB) {
+		return user.username;
+	}
+
+	return user?.email;
+}

--- a/ui/admin/app/lib/routers/apiRoutes.ts
+++ b/ui/admin/app/lib/routers/apiRoutes.ts
@@ -202,6 +202,11 @@ export const ApiRoutes = {
 		base: () => buildUrl("/prompt"),
 		promptResponse: () => buildUrl("/prompt"),
 	},
+	projects: {
+		getAll: () => buildUrl("/projects", { all: true }),
+		deleteProject: (agentId: string, projectId: string) =>
+			buildUrl(`/assistants/${agentId}/projects/${projectId}`),
+	},
 	runs: {
 		base: () => buildUrl("/runs"),
 		getRunById: (runId: string) => buildUrl(`/runs/${runId}`),

--- a/ui/admin/app/lib/routers/baseRouter.ts
+++ b/ui/admin/app/lib/routers/baseRouter.ts
@@ -17,6 +17,6 @@ export const ApiUrl = () => {
 	return window.location.origin + "/api";
 };
 
-export const ConsumptionUrl = (route: string) => {
+export const ConsumptionUrl = (route: string = "") => {
 	return window.location.protocol + "//" + window.location.host + route;
 };

--- a/ui/admin/app/lib/routers/userRoutes.ts
+++ b/ui/admin/app/lib/routers/userRoutes.ts
@@ -1,0 +1,23 @@
+import queryString from "query-string";
+
+import { ConsumptionUrl } from "~/lib/routers/baseRouter";
+
+const buildUrl = (path: string, params?: Record<string, string>) => {
+	const url = new URL(ConsumptionUrl(path));
+
+	if (params) {
+		url.search = queryString.stringify(params, { skipNull: true });
+	}
+
+	return {
+		url: url.toString(),
+		path: url.pathname,
+	};
+};
+
+export const UserRoutes = {
+	root: () => buildUrl("/"),
+	obot: (projectId: string) => buildUrl(`/o/${projectId}`),
+	thread: (projectId: string, threadId: string) =>
+		buildUrl(`/o/${projectId}/t/${threadId}`),
+};

--- a/ui/admin/app/lib/service/api/projectApiService.ts
+++ b/ui/admin/app/lib/service/api/projectApiService.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+import { EntityList } from "~/lib/model/primitives";
+import { Project } from "~/lib/model/project";
+import { ApiRoutes } from "~/lib/routers/apiRoutes";
+import { request } from "~/lib/service/api/primitives";
+import {
+	createFetcher,
+	createMutator,
+} from "~/lib/service/api/service-primitives";
+
+const getAllFetcher = createFetcher(
+	z.object({}),
+	async (_, { signal }) => {
+		const { url } = ApiRoutes.projects.getAll();
+		const { data } = await request<EntityList<Project>>({ url, signal });
+		return data.items ?? [];
+	},
+	() => ApiRoutes.projects.getAll().path
+);
+
+const deleteProjectMutator = createMutator(
+	async ({ id, agentId }: { id: string; agentId: string }, { signal }) => {
+		const { url } = ApiRoutes.projects.deleteProject(agentId, id);
+		await request({ url, method: "DELETE", signal });
+	}
+);
+
+export const ProjectApiService = {
+	getAll: getAllFetcher,
+	delete: deleteProjectMutator,
+};

--- a/ui/admin/app/lib/service/routeService.ts
+++ b/ui/admin/app/lib/service/routeService.ts
@@ -35,6 +35,7 @@ const QuerySchemas = {
 	obotsSchema: z.object({
 		obotId: z.string().nullish(),
 		parentObotId: z.string().nullish(),
+		userId: z.string().nullish(),
 	}),
 } as const;
 

--- a/ui/admin/app/lib/service/routeService.ts
+++ b/ui/admin/app/lib/service/routeService.ts
@@ -36,6 +36,7 @@ const QuerySchemas = {
 		obotId: z.string().nullish(),
 		parentObotId: z.string().nullish(),
 		userId: z.string().nullish(),
+		agentId: z.string().nullish(),
 		showChildren: z
 			.boolean()
 			.nullish()

--- a/ui/admin/app/lib/service/routeService.ts
+++ b/ui/admin/app/lib/service/routeService.ts
@@ -36,6 +36,13 @@ const QuerySchemas = {
 		obotId: z.string().nullish(),
 		parentObotId: z.string().nullish(),
 		userId: z.string().nullish(),
+		showChildren: z
+			.boolean()
+			.nullish()
+			.catch((val) => {
+				if (typeof val.input === "string") return val.input === "true";
+				return undefined;
+			}),
 	}),
 } as const;
 
@@ -149,7 +156,7 @@ export const RouteHelperMap = {
 	},
 } satisfies Record<keyof Routes, RouteHelper>;
 
-type QueryInfo<T extends keyof Routes> = z.infer<
+export type QueryInfo<T extends keyof Routes> = z.infer<
 	(typeof RouteHelperMap)[T]["schema"]
 >;
 

--- a/ui/admin/app/lib/service/routeService.ts
+++ b/ui/admin/app/lib/service/routeService.ts
@@ -32,6 +32,10 @@ const QuerySchemas = {
 		createdEnd: z.string().nullish(),
 	}),
 	usersSchema: z.object({ userId: z.string().optional() }),
+	obotsSchema: z.object({
+		obotId: z.string().nullish(),
+		parentObotId: z.string().nullish(),
+	}),
 } as const;
 
 function parseQuery<T extends ZodType>(search: string, schema: T) {
@@ -80,7 +84,7 @@ export const RouteHelperMap = {
 	"/obots": {
 		regex: exactRegex($path("/obots")),
 		path: "/obots",
-		schema: z.null(),
+		schema: QuerySchemas.obotsSchema,
 	},
 	"/auth-providers": {
 		regex: exactRegex($path("/auth-providers")),

--- a/ui/admin/app/lib/service/routeService.ts
+++ b/ui/admin/app/lib/service/routeService.ts
@@ -16,7 +16,8 @@ const QuerySchemas = {
 		agentId: z.string().nullish(),
 		userId: z.string().nullish(),
 		taskId: z.string().nullish(),
-		from: z.enum(["tasks", "agents", "users"]).nullish().catch(null),
+		obotId: z.string().nullish(),
+		from: z.enum(["tasks", "agents", "users", "obots"]).nullish().catch(null),
 		createdStart: z.string().nullish(),
 		createdEnd: z.string().nullish(),
 	}),
@@ -75,6 +76,11 @@ export const RouteHelperMap = {
 		regex: exactRegex($path("/agents/:id", { id: "(.+)" })),
 		path: "/agents/:id",
 		schema: QuerySchemas.agentSchema,
+	},
+	"/obots": {
+		regex: exactRegex($path("/obots")),
+		path: "/obots",
+		schema: z.null(),
 	},
 	"/auth-providers": {
 		regex: exactRegex($path("/auth-providers")),

--- a/ui/admin/app/routes/__tests__/chat-threads._index.test.tsx
+++ b/ui/admin/app/routes/__tests__/chat-threads._index.test.tsx
@@ -7,11 +7,13 @@ import {
 	within,
 } from "test";
 import { mockedAgent } from "test/mocks/models/agents";
+import { mockedProject } from "test/mocks/models/projects";
 import { mockedThreads } from "test/mocks/models/threads";
 import { mockedUsers } from "test/mocks/models/users";
 
 import { Agent } from "~/lib/model/agents";
 import { EntityList } from "~/lib/model/primitives";
+import { Project } from "~/lib/model/project";
 import { Thread } from "~/lib/model/threads";
 import { User } from "~/lib/model/users";
 import { ApiRoutes } from "~/lib/routers/apiRoutes";
@@ -48,6 +50,11 @@ describe(ChatThreads, () => {
 			http.get(ApiRoutes.users.base().url, () => {
 				return HttpResponse.json<EntityList<User>>({
 					items: mockedUsers,
+				});
+			}),
+			http.get(ApiRoutes.projects.getAll().url, () => {
+				return HttpResponse.json<EntityList<Project>>({
+					items: [mockedProject],
 				});
 			}),
 		]);

--- a/ui/admin/app/routes/_auth.obots._index.tsx
+++ b/ui/admin/app/routes/_auth.obots._index.tsx
@@ -56,7 +56,8 @@ export default function ProjectsPage() {
 	const threadCounts = useMemo(
 		() =>
 			threads.reduce<Map<string, number>>((acc, thread) => {
-				if (!thread.projectID) return acc;
+				// filter out threads that don't have a parent project, or that are projects themselves
+				if (!thread.projectID || thread.project) return acc;
 
 				const count = acc.get(thread.projectID) ?? 0;
 				acc.set(thread.projectID, count + 1);
@@ -64,11 +65,6 @@ export default function ProjectsPage() {
 				return acc;
 			}, new Map()),
 		[threads]
-	);
-
-	console.log(
-		threads.filter((t) => !!t.projectID),
-		threadCounts
 	);
 
 	const { interceptAsync, dialogProps } = useConfirmationDialog();
@@ -119,7 +115,7 @@ export default function ProjectsPage() {
 				),
 			}),
 			columnHelper.accessor("parentID", {
-				header: "Copied From",
+				header: "Parent",
 				cell: ({ row }) => {
 					if (!row.original.parentID) return "-";
 
@@ -136,6 +132,22 @@ export default function ProjectsPage() {
 			}),
 			columnHelper.accessor((row) => String(threadCounts.get(row.id) ?? 0), {
 				header: "Threads",
+				cell: ({ row, getValue }) => {
+					const count = Number(getValue());
+
+					if (count === 0) return "-";
+
+					return (
+						<Link
+							to={$path("/chat-threads", {
+								obotId: row.original.id,
+								from: "obots",
+							})}
+						>
+							{count} Threads
+						</Link>
+					);
+				},
 			}),
 			columnHelper.display({
 				id: "actions",

--- a/ui/admin/app/routes/_auth.obots._index.tsx
+++ b/ui/admin/app/routes/_auth.obots._index.tsx
@@ -1,0 +1,181 @@
+import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
+import { EllipsisIcon } from "lucide-react";
+import { useMemo } from "react";
+import { ClientLoaderFunction, MetaFunction } from "react-router";
+import { $path } from "safe-routes";
+import useSWR, { preload } from "swr";
+
+import { Project } from "~/lib/model/project";
+import { UserRoutes } from "~/lib/routers/userRoutes";
+import { AgentService } from "~/lib/service/api/agentService";
+import { ProjectApiService } from "~/lib/service/api/projectApiService";
+import { ThreadsService } from "~/lib/service/api/threadsService";
+
+import { ConfirmationDialog } from "~/components/composed/ConfirmationDialog";
+import { DataTable } from "~/components/composed/DataTable";
+import { Button } from "~/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+import { Link } from "~/components/ui/link";
+import { useConfirmationDialog } from "~/hooks/component-helpers/useConfirmationDialog";
+import { useAsync } from "~/hooks/useAsync";
+
+export const clientLoader: ClientLoaderFunction = async () => {
+	await Promise.all([
+		preload(...ProjectApiService.getAll.swr({})),
+		preload(...AgentService.getAgents.swr({})),
+		preload(...ThreadsService.getThreads.swr({})),
+	]);
+};
+
+export default function ProjectsPage() {
+	const { data: projects, mutate: refresh } = useSWR(
+		...ProjectApiService.getAll.swr({}),
+		{ suspense: true }
+	);
+	const projectMap = useMemo(
+		() => new Map(projects.map((p) => [p.id, p])),
+		[projects]
+	);
+
+	const { data: agents } = useSWR(...AgentService.getAgents.swr({}), {
+		suspense: true,
+	});
+	const agentMap = useMemo(
+		() => new Map(agents?.map((a) => [a.id, a])),
+		[agents]
+	);
+
+	const { data: threads } = useSWR(...ThreadsService.getThreads.swr({}), {
+		suspense: true,
+	});
+	const threadCounts = useMemo(
+		() =>
+			threads.reduce<Map<string, number>>((acc, thread) => {
+				if (!thread.projectID) return acc;
+
+				const count = acc.get(thread.projectID) ?? 0;
+				acc.set(thread.projectID, count + 1);
+
+				return acc;
+			}, new Map()),
+		[threads]
+	);
+
+	console.log(
+		threads.filter((t) => !!t.projectID),
+		threadCounts
+	);
+
+	const { interceptAsync, dialogProps } = useConfirmationDialog();
+
+	const deleteProject = useAsync(ProjectApiService.delete, {
+		onSuccess: () => refresh(),
+	});
+
+	const handleDelete = (id: string, agentId: string) => {
+		interceptAsync(() => deleteProject.executeAsync({ id, agentId }));
+	};
+
+	return (
+		<div>
+			<div className="flex h-full flex-col gap-4 p-8">
+				<div className="flex-auto overflow-hidden">
+					<div className="width-full mb-8 flex justify-between space-x-2">
+						<h2>Obots</h2>
+					</div>
+
+					<DataTable columns={getColumns()} data={projects} />
+				</div>
+			</div>
+
+			<ConfirmationDialog
+				{...dialogProps}
+				title="Delete Project?"
+				description="Are you sure you want to delete this project? This action cannot be undone."
+				confirmProps={{
+					variant: "destructive",
+					children: "Delete",
+					loading: deleteProject.isLoading,
+					disabled: deleteProject.isLoading,
+				}}
+			/>
+		</div>
+	);
+
+	function getColumns(): ColumnDef<Project, string>[] {
+		return [
+			columnHelper.accessor("name", {
+				header: "Name",
+				cell: ({ row }) => (
+					<div>
+						<p>{row.original.name}</p>
+						<small className="text-muted-foreground">{row.original.id}</small>
+					</div>
+				),
+			}),
+			columnHelper.accessor("parentID", {
+				header: "Copied From",
+				cell: ({ row }) => {
+					if (!row.original.parentID) return "-";
+
+					return <p>{projectMap.get(row.original.parentID)?.name}</p>;
+				},
+			}),
+			columnHelper.accessor("assistantID", {
+				header: "Agent",
+				cell: ({ getValue }) => (
+					<Link to={$path("/agents/:id", { id: getValue() })}>
+						{agentMap.get(getValue())?.name}
+					</Link>
+				),
+			}),
+			columnHelper.accessor((row) => String(threadCounts.get(row.id) ?? 0), {
+				header: "Threads",
+			}),
+			columnHelper.display({
+				id: "actions",
+				cell: ({ row }) => (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild className="float-end">
+							<Button variant="ghost" size="icon">
+								<EllipsisIcon />
+							</Button>
+						</DropdownMenuTrigger>
+
+						<DropdownMenuContent side="top" align="end">
+							<DropdownMenuItem asChild>
+								<a
+									href={UserRoutes.obot(row.original.id).url}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									Try it out!
+								</a>
+							</DropdownMenuItem>
+
+							<DropdownMenuItem
+								variant="destructive"
+								onClick={() =>
+									handleDelete(row.original.id, row.original.assistantID)
+								}
+							>
+								Delete Project
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				),
+			}),
+		];
+	}
+}
+
+const columnHelper = createColumnHelper<Project>();
+
+export const meta: MetaFunction = () => {
+	return [{ title: "Obot • Obots" }];
+};

--- a/ui/admin/app/routes/_auth.obots.tsx
+++ b/ui/admin/app/routes/_auth.obots.tsx
@@ -1,0 +1,5 @@
+import { RouteHandle } from "~/lib/service/routeHandles";
+
+export const handle: RouteHandle = {
+	breadcrumb: () => [{ content: "Obots" }],
+};

--- a/ui/admin/test/mocks/models/projects.ts
+++ b/ui/admin/test/mocks/models/projects.ts
@@ -1,0 +1,19 @@
+import { Project } from "~/lib/model/project";
+
+export const mockedProject: Project = {
+	id: "p1d829q",
+	created: "2025-03-07T16:27:52-06:00",
+	revision: "47",
+	type: "project",
+	name: "Obot",
+	tools: ["images-bundle"],
+	description: "Default Assistant",
+	icons: null,
+	prompt: "",
+	knowledgeDescription: "",
+	introductionMessage: "",
+	starterMessages: null,
+	assistantID: "a1-obot",
+	editor: true,
+	userID: "2",
+};

--- a/ui/admin/test/mocks/models/threads.ts
+++ b/ui/admin/test/mocks/models/threads.ts
@@ -13,5 +13,10 @@ export const mockedThreads: Thread[] = [
 		state: RunState.Continue,
 		lastRunID: "r1g9hw7",
 		userID: mockedUser.id,
+		introductionMessage: "Hello, how are you?",
+		knowledgeDescription: "You have knowledge about the world.",
+		starterMessages: ["Hello, how are you?"],
+		name: "My Thread",
+		prompt: "You are a helpful assistant.",
 	},
 ];


### PR DESCRIPTION
addresses #1958

- adds top level obot page
- adds filters for `Spawned from`, `Agent`, `Created By`
- adds `Obot` filter for the `/chat-threads` page
- defaults to filtering out "spawned" obots
- provides actions for opening an obot in the User UI, and deleting the obot (with confirmation)

<img width="1796" alt="Screenshot 2025-03-07 at 5 33 05 PM" src="https://github.com/user-attachments/assets/9d2aaac8-69b3-432a-b2db-2bb46be61e01" />

<img width="305" alt="Screenshot 2025-03-07 at 5 35 17 PM" src="https://github.com/user-attachments/assets/16707fd9-6173-46c2-aac6-2ba551797a1f" />

<img width="1840" alt="Screenshot 2025-03-07 at 5 35 30 PM" src="https://github.com/user-attachments/assets/d246a5db-b710-4ded-8b4e-86e8a2d61677" />
