### PR TITLE
fix: consistency scrollbars ui

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -54,6 +54,14 @@ body {
 	@apply w-full rounded-lg bg-gray-100 p-2 outline-none focus:ring-2 focus:ring-blue dark:bg-gray-900;
 }
 
+.default-scrollbar-thin {
+	@apply overflow-auto scrollbar-thin scrollbar-track-surface2 scrollbar-thumb-surface3;
+}
+
+.default-scrollbar {
+	@apply scrollbar scrollbar-track-surface1 scrollbar-thumb-surface3;
+}
+
 dialog::backdrop {
 	@apply bg-black bg-opacity-60;
 }

--- a/ui/user/src/app.html
+++ b/ui/user/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="hidden">
+<html lang="en" class="default-scrollbar hidden">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/ui/user/src/lib/components/EditMode.svelte
+++ b/ui/user/src/lib/components/EditMode.svelte
@@ -96,9 +96,7 @@
 				class="inset-shadow-sm flex h-full w-1/4 min-w-[320px] flex-col overflow-hidden"
 				transition:slide={{ axis: 'x' }}
 			>
-				<div
-					class="flex grow flex-col default-scrollbar-thin"
-				>
+				<div class="default-scrollbar-thin flex grow flex-col">
 					<General bind:project />
 					<Instructions bind:project />
 					<Tools {tools} {onNewTools} />

--- a/ui/user/src/lib/components/EditMode.svelte
+++ b/ui/user/src/lib/components/EditMode.svelte
@@ -72,10 +72,13 @@
 	});
 </script>
 
-<div class="colors-surface1 flex size-full flex-col">
+<div class="flex size-full flex-col bg-surface1">
 	{#if layout.projectEditorOpen}
 		<!-- Header -->
-		<div class="flex h-16 w-full items-center gap-2 p-5" transition:slide>
+		<div
+			class="z-10 flex h-16 w-full items-center gap-2 bg-surface1 p-5 shadow-md"
+			transition:slide
+		>
 			<img src="/user/images/obot-icon-blue.svg" class="h-8" alt="Obot icon" />
 			<h1 class="text-xl font-semibold">Obot Editor</h1>
 			<div class="grow"></div>
@@ -90,20 +93,24 @@
 			<!-- Left Nav -->
 			<div
 				bind:this={nav}
-				class="flex h-full w-1/4 min-w-[320px] flex-col overflow-auto pt-5"
+				class="inset-shadow-sm flex h-full w-1/4 min-w-[320px] flex-col overflow-hidden"
 				transition:slide={{ axis: 'x' }}
 			>
-				<General bind:project />
-				<Instructions bind:project />
-				<Tools {tools} {onNewTools} />
-				<Knowledge {project} />
-				<Files {project} />
-				<Tasks {project} />
-				<Interface bind:project />
-				<Credentials {project} {tools} />
-				<Share {project} />
-				<div class="grow"></div>
-				<div class="flex justify-end p-2">
+				<div
+					class="flex grow flex-col default-scrollbar-thin"
+				>
+					<General bind:project />
+					<Instructions bind:project />
+					<Tools {tools} {onNewTools} />
+					<Knowledge {project} />
+					<Files {project} />
+					<Tasks {project} />
+					<Interface bind:project />
+					<Credentials {project} {tools} />
+					<Share {project} />
+					<div class="grow"></div>
+				</div>
+				<div class="flex justify-end bg-surface1 p-2">
 					<button
 						class="button flex gap-1 text-gray"
 						onclick={() => {

--- a/ui/user/src/lib/components/Editors.svelte
+++ b/ui/user/src/lib/components/Editors.svelte
@@ -36,7 +36,7 @@
 <div class="flex h-full flex-col">
 	{#if layout.fileEditorOpen}
 		{#if layout.items.length > 1 || (!layout.items[0]?.table && !layout.items[0]?.generic)}
-			<div class="-mx-5 -mt-3 flex border-b-2 border-surface2 px-2 pb-2">
+			<div class="-ml-5 -mt-3 flex border-b-2 border-surface2 px-2 pb-2">
 				<ul class="flex flex-1 flex-wrap gap-2 text-center text-sm">
 					{#each layout.items as item}
 						<li>
@@ -88,7 +88,7 @@
 	{#if term.open}
 		<div
 			class={layout.fileEditorOpen
-				? '-mx-5 -mb-3 h-1/2 border-t-4 border-surface1 px-2 pt-2'
+				? '-mb-3 -ml-5 h-1/2 border-t-4 border-surface1 px-2 pt-2'
 				: 'h-full'}
 		>
 			<Terminal {project} />

--- a/ui/user/src/lib/components/Obot.svelte
+++ b/ui/user/src/lib/components/Obot.svelte
@@ -88,7 +88,7 @@
 			{#if editorVisible && mainInput}
 				<div class="w-4 translate-x-4 cursor-col-resize" use:columnResize={mainInput}></div>
 				<div
-					class="w-3/5 grow rounded-tl-3xl border-4 border-b-0 border-r-0 border-surface2 p-5 transition-all"
+					class="w-3/5 grow rounded-tl-3xl border-4 border-b-0 border-r-0 border-surface2 p-5 pb-0 pr-0 transition-all"
 				>
 					<Editor {project} {currentThreadID} />
 				</div>

--- a/ui/user/src/lib/components/Sidebar.svelte
+++ b/ui/user/src/lib/components/Sidebar.svelte
@@ -21,12 +21,12 @@
 	const layout = getLayout();
 </script>
 
-<div class="relative flex size-full flex-col gap-3 rounded-tl-3xl bg-surface1 p-3">
+<div class="relative flex size-full flex-col gap-3 rounded-tl-3xl bg-surface1">
 	<button class="icon-button absolute right-1 top-1" onclick={() => (layout.sidebarOpen = false)}>
 		<SidebarClose class="icon-default" />
 	</button>
 
-	<div class="mb-4 flex flex-col gap-2">
+	<div class="flex flex-col gap-2 p-3 pb-0">
 		<div class="flex items-center gap-2 rounded-lg">
 			<AssistantIcon {project} class="h-5 w-5" />
 			<span class="text-xl font-semibold text-on-background">{project.name || 'Untitled'}</span>
@@ -34,11 +34,12 @@
 		</div>
 	</div>
 
-	<Threads {project} bind:currentThreadID />
+	<div class="default-scrollbar-thin flex w-full grow flex-col gap-2 p-3">
+		<Threads {project} bind:currentThreadID />
+		<Tasks {project} />
+	</div>
 
-	<Tasks {project} />
-
-	<div class="absolute bottom-1 right-1 flex gap-1">
+	<div class="flex justify-end gap-1 px-3 pb-2">
 		{#if hasTool(tools, 'shell')}
 			<Term />
 		{/if}

--- a/ui/user/src/lib/components/editor/FileEditors.svelte
+++ b/ui/user/src/lib/components/editor/FileEditors.svelte
@@ -21,7 +21,11 @@
 </script>
 
 {#each items as file}
-	<div class:hidden={!file.selected} class="flex-1 overflow-auto" bind:clientHeight={height}>
+	<div
+		class:hidden={!file.selected}
+		class="default-scrollbar-thin flex-1"
+		bind:clientHeight={height}
+	>
 		{#if file.name.toLowerCase().endsWith('.md')}
 			<Milkdown {file} {onFileChanged} {onInvoke} {items} />
 		{:else if file.name.toLowerCase().endsWith('.pdf')}

--- a/ui/user/src/lib/components/sidebar/Tasks.svelte
+++ b/ui/user/src/lib/components/sidebar/Tasks.svelte
@@ -52,7 +52,7 @@
 </script>
 
 <div class="flex w-full flex-col">
-	<div class="flex items-center">
+	<div class="mb-2 flex items-center">
 		<CheckSquare class="me-2 h-5 w-5 text-gray" />
 		<h2 class="grow text-lg">Tasks</h2>
 		<button class="icon-button" onclick={() => newTask()}>
@@ -62,10 +62,10 @@
 	{#if !layout.tasks || layout.tasks.length === 0}
 		<p class="p-6 text-center text-sm text-gray dark:text-gray-300">No tasks</p>
 	{:else}
-		<ul class="space-y-4 py-6">
+		<ul class="space-y-4 px-3">
 			{#each layout.tasks as task}
 				<li class="flex flex-col">
-					<div class="flex items-center">
+					<div class="flex items-center gap-3">
 						<button
 							use:overflowToolTip
 							class="flex w-[50%] flex-1 items-center"

--- a/ui/user/src/lib/components/sidebar/Threads.svelte
+++ b/ui/user/src/lib/components/sidebar/Threads.svelte
@@ -132,7 +132,7 @@
 
 {#if isOpen}
 	<div bind:this={panel} class="flex flex-col">
-		<div class="mb-5 flex items-center gap-4">
+		<div class="mb-2 flex items-center gap-4">
 			<ScrollText class="icon-default text-gray" />
 			<h2 class="grow text-lg">Threads</h2>
 			<button class="text-gray" onclick={createThread}>


### PR DESCRIPTION
* get scrollbars consistent
* some minor styling updates for spacing cleanup, etc.

<img width="1285" alt="Screenshot 2025-03-10 at 3 20 15 PM" src="https://github.com/user-attachments/assets/a3d95996-a5dd-4e4d-a3e1-2e030b647073" />
<img width="1583" alt="Screenshot 2025-03-10 at 2 56 52 PM" src="https://github.com/user-attachments/assets/42e39253-a03b-4d96-884b-135fcc8a894d" />
<img width="1584" alt="Screenshot 2025-03-10 at 2 56 42 PM" src="https://github.com/user-attachments/assets/335104fd-cef9-4c41-84aa-04dff721f9cf" />

light mode:

<img width="1290" alt="Screenshot 2025-03-10 at 3 27 35 PM" src="https://github.com/user-attachments/assets/a8636eae-652a-44ca-ab73-b8e7eaa35c67" />
<img width="1292" alt="Screenshot 2025-03-10 at 3 27 25 PM" src="https://github.com/user-attachments/assets/29f9dc39-9160-4f98-aef4-f84d188e1eec" />
