### PR TITLE
fix: ensure threads current and latest runs are active

### DIFF
--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -73,6 +73,7 @@ func (c *Controller) setupRoutes() error {
 	root.Type(&v1.Thread{}).HandlerFunc(projects.CopyProjectInfo)
 	root.Type(&v1.Thread{}).HandlerFunc(threads.CopyTasksFromSource)
 	root.Type(&v1.Thread{}).HandlerFunc(threads.CopyTasksFromParent)
+	root.Type(&v1.Thread{}).HandlerFunc(threads.EnsureLastAndCurrentRunActive)
 	root.Type(&v1.Thread{}).FinalizeFunc(v1.ThreadFinalizer, credentialCleanup.Remove)
 	root.Type(&v1.Thread{}).FinalizeFunc(v1.ThreadFinalizer+"-child-cleanup", threads.ActivateRuns)
 


### PR DESCRIPTION
A previous change made "old" runs inactive. Inactive runs are not cached nor
watched by the controllers.

This wasn't a problem until the cached GET behavior was changed to no longer do
an uncached get when a not-found error occurs. Now we need to ensure that every
thread's latest and current runs are active.