### PR TITLE
enhance: default generated obot icon prompt

### DIFF
--- a/ui/user/src/lib/components/edit/GenerateIcon.svelte
+++ b/ui/user/src/lib/components/edit/GenerateIcon.svelte
@@ -10,7 +10,7 @@
 	}
 
 	const DEFAULT_PROMPT =
-		'Based on the following character description: "{description}", draw an animated profile picture in a modern style with an upbeat and vibrant color palette.';
+		'Based on the following description of a mascot: "{description}", draw an animated profile picture in a modern style with an upbeat and vibrant color palette.';
 
 	let { project = $bindable() }: Props = $props();
 	let isGenerating = $state(false);


### PR DESCRIPTION
The current prompt for generating Obot icons results in generic humans being generated for most Obot descriptions. Tweak the prompt to generate more unique characters.
