### PR TITLE
change: handle openaiAPI-style errors + expose modelProviderStatus.error to the UI

### DIFF
--- a/apiclient/types/modelprovider.go
+++ b/apiclient/types/modelprovider.go
@@ -28,6 +28,7 @@ type ModelProviderManifest struct {
 
 type ModelProviderStatus struct {
 	CommonProviderMetadata
+	Error                           string                           `json:"error,omitempty"`
 	Configured                      bool                             `json:"configured"`
 	ModelsBackPopulated             *bool                            `json:"modelsBackPopulated,omitempty"`
 	RequiredConfigurationParameters []ProviderConfigurationParameter `json:"requiredConfigurationParameters,omitempty"`

--- a/pkg/api/handlers/providers/modelproviders.go
+++ b/pkg/api/handlers/providers/modelproviders.go
@@ -42,6 +42,7 @@ func ConvertModelProviderToolRef(toolRef v1.ToolReference, cred map[string]strin
 
 	return &types.ModelProviderStatus{
 		CommonProviderMetadata:          providerMeta.CommonProviderMetadata,
+		Error:                           toolRef.Status.Error,
 		Configured:                      configured,
 		ModelsBackPopulated:             modelsPopulated,
 		RequiredConfigurationParameters: providerMeta.EnvVars,

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2323,6 +2323,12 @@ func schema_obot_platform_obot_apiclient_types_ModelProviderStatus(ref common.Re
 							Ref:     ref("github.com/obot-platform/obot/apiclient/types.CommonProviderMetadata"),
 						},
 					},
+					"error": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"configured": {
 						SchemaProps: spec.SchemaProps{
 							Default: false,

--- a/ui/admin/app/lib/model/providers.ts
+++ b/ui/admin/app/lib/model/providers.ts
@@ -10,6 +10,7 @@ export type ProviderConfigurationParameter = {
 
 export type ProviderStatus = {
 	configured: boolean;
+	error?: string;
 	icon?: string;
 	iconDark?: string;
 	link?: string;


### PR DESCRIPTION
Now we can use `modelProvider.error` [in the UI code](https://github.com/obot-platform/obot/blob/main/ui/admin/app/components/auth-and-model-providers/ModelProviderLists.tsx) to put some icon or whatever there.
I'm not sure if we should call it "Not configured" in case of an error, as we don't have error classes and it could as well be a network issue. Maybe a "Defunct" like message would be more appropriate.

Ugly example:
![Screenshot 2025-03-13 at 12-48-29 Obot • Model Providers](https://github.com/user-attachments/assets/5b61be15-910f-4cf4-8f00-7bfefccd9497)


Issue: https://github.com/obot-platform/obot/issues/819