### PR TITLE
fix: broken chat thread and task run lists in admin ui

### DIFF
--- a/ui/admin/app/components/chat/shared/thread-helpers.ts
+++ b/ui/admin/app/components/chat/shared/thread-helpers.ts
@@ -77,7 +77,9 @@ export function useThreadFiles(
 export function useThreadAgents(threadId?: Nullish<string>) {
 	const { data: thread } = useThread(threadId);
 
-	return useSWR(...AgentService.getAgentById.swr({ agentId: thread?.agentID }));
+	return useSWR(
+		...AgentService.getAgentById.swr({ agentId: thread?.assistantID })
+	);
 }
 
 export function useThreadCredentials(threadId: Nullish<string>) {
@@ -146,9 +148,9 @@ export const useThreadTasks = (agentThreadId?: string) => {
 
 	const runCounts = getThreads.data?.reduce<Record<string, number>>(
 		(acc, thread) => {
-			if (!thread.workflowID) return acc;
+			if (!thread.taskID) return acc;
 
-			acc[thread.workflowID] = (acc[thread.workflowID] || 0) + 1;
+			acc[thread.taskID] = (acc[thread.taskID] || 0) + 1;
 			return acc;
 		},
 		{}

--- a/ui/admin/app/lib/model/threads.ts
+++ b/ui/admin/app/lib/model/threads.ts
@@ -24,8 +24,8 @@ export type Thread = EntityMeta &
 		userID?: string;
 		project?: boolean;
 	} & (
-		| { agentID: string; workflowID?: never }
-		| { agentID?: never; workflowID: string }
+		| { assistantID: string; taskID?: never }
+		| { assistantID?: never; taskID: string }
 	);
 
 export type UpdateThread = ThreadManifest;

--- a/ui/admin/app/routes/_auth.chat-threads.$id.tsx
+++ b/ui/admin/app/routes/_auth.chat-threads.$id.tsx
@@ -54,7 +54,7 @@ export const clientLoader = async ({
 	if (!thread) throw redirect("/threads");
 
 	const [agent, project] = await Promise.all([
-		preload(...AgentService.getAgentById.swr({ agentId: thread.agentID })),
+		preload(...AgentService.getAgentById.swr({ agentId: thread.assistantID })),
 		preload(...ProjectApiService.getById.swr({ id: thread.projectID })),
 		preload(
 			KnowledgeFileService.getKnowledgeFiles.key(

--- a/ui/admin/app/routes/_auth.chat-threads._index.tsx
+++ b/ui/admin/app/routes/_auth.chat-threads._index.tsx
@@ -82,12 +82,12 @@ export default function TaskRuns() {
 		if (!getThreads.data) return [];
 
 		let filteredThreads = getThreads.data.filter(
-			(thread) => thread.agentID && !thread.deleted && !thread.project
+			(thread) => thread.assistantID && !thread.deleted && !thread.project
 		);
 
 		if (agentId) {
 			filteredThreads = filteredThreads.filter(
-				(thread) => thread.agentID === agentId
+				(thread) => thread.assistantID === agentId
 			);
 		}
 

--- a/ui/admin/app/routes/_auth.task-runs.$id.tsx
+++ b/ui/admin/app/routes/_auth.task-runs.$id.tsx
@@ -54,8 +54,8 @@ export const clientLoader = async ({
 	if (!thread) throw redirect("/threads");
 
 	const [task, project] = await Promise.all([
-		thread.workflowID
-			? preload(...TaskService.getTaskById.swr({ taskId: thread.workflowID }))
+		thread.taskID
+			? preload(...TaskService.getTaskById.swr({ taskId: thread.taskID }))
 			: null,
 		preload(...ProjectApiService.getById.swr({ id: thread.projectID })),
 		preload(

--- a/ui/admin/app/routes/_auth.task-runs._index.tsx
+++ b/ui/admin/app/routes/_auth.task-runs._index.tsx
@@ -76,9 +76,9 @@ export default function TaskRuns() {
 		const agentMap = new Map(getAgents.data?.map((agent) => [agent.id, agent]));
 		return new Map(
 			getThreads?.data
-				?.filter((thread) => thread.agentID)
+				?.filter((thread) => thread.assistantID)
 				.map((thread) => {
-					const agent = agentMap.get(thread.agentID!);
+					const agent = agentMap.get(thread.assistantID!);
 					return [thread.id, agent?.name ?? "-"];
 				})
 		);
@@ -104,9 +104,9 @@ export default function TaskRuns() {
 	})[] = useMemo(() => {
 		return (
 			getThreads.data
-				?.filter((thread) => thread.workflowID && !thread.deleted)
+				?.filter((thread) => thread.taskID && !thread.deleted)
 				.map((thread) => {
-					const task = taskMap.get(thread.workflowID!);
+					const task = taskMap.get(thread.taskID!);
 					const taskThread = threadMap.get(task?.projectID ?? "");
 					return {
 						...thread,
@@ -122,9 +122,7 @@ export default function TaskRuns() {
 		let filteredThreads = threads;
 
 		if (taskId) {
-			filteredThreads = threads.filter(
-				(thread) => thread.workflowID === taskId
-			);
+			filteredThreads = threads.filter((thread) => thread.taskID === taskId);
 		}
 
 		if (userId) {
@@ -215,7 +213,7 @@ export default function TaskRuns() {
 						<Link
 							onClick={(event) => event.stopPropagation()}
 							to={$path("/tasks/:id", {
-								id: info.row.original.workflowID!,
+								id: info.row.original.taskID!,
 							})}
 							className="px-0"
 						>

--- a/ui/admin/app/routes/_auth.tasks.$id.tsx
+++ b/ui/admin/app/routes/_auth.tasks.$id.tsx
@@ -60,7 +60,7 @@ export const clientLoader = async ({
 	const agent = await preload(
 		...AgentService.getAgentById.swr({ agentId: project.assistantID })
 	);
-	const taskRuns = threads.filter((t) => t.workflowID === task.id).length;
+	const taskRuns = threads.filter((t) => t.taskID === task.id).length;
 
 	return { task, agent, taskRuns, project };
 };

--- a/ui/admin/app/routes/_auth.tasks._index.tsx
+++ b/ui/admin/app/routes/_auth.tasks._index.tsx
@@ -90,9 +90,9 @@ export default function Tasks() {
 	const tasks: TableTask[] = useMemo(() => {
 		const threadCounts = getThreads.data?.reduce<Record<string, number>>(
 			(acc, thread) => {
-				if (!thread.workflowID) return acc;
+				if (!thread.taskID) return acc;
 
-				acc[thread.workflowID] = (acc[thread.workflowID] || 0) + 1;
+				acc[thread.taskID] = (acc[thread.taskID] || 0) + 1;
 				return acc;
 			},
 			{}

--- a/ui/admin/test/mocks/models/threads.ts
+++ b/ui/admin/test/mocks/models/threads.ts
@@ -9,7 +9,7 @@ export const mockedThreads: Thread[] = [
 		id: "t1bm2kn",
 		created: "2025-02-04T10:53:11-05:00",
 		type: "thread",
-		agentID: mockedAgent.id,
+		assistantID: mockedAgent.id,
 		state: RunState.Continue,
 		lastRunID: "r1g9hw7",
 		userID: mockedUser.id,


### PR DESCRIPTION
`Thread.agentId` and `Thread.workflowID` were renamed respectively to `Thread.assistantID`, and `Thread.taskID` in the backend, but were not updated in the admin UI models.

The solution: update the models in the admin ui to reflect the backend changes

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>