### PR TITLE
enhance: round out tool borders in edit tool list and catalog (creates consistency with other tool icons)

### DIFF
--- a/ui/user/src/lib/components/edit/ToolCatalog.svelte
+++ b/ui/user/src/lib/components/edit/ToolCatalog.svelte
@@ -188,7 +188,7 @@
 								<img
 									src={tool.metadata?.icon}
 									alt={tool.name}
-									class="size-6 rounded-lg bg-white p-1"
+									class="size-6 rounded-full bg-white p-1"
 								/>
 								{tool.name}
 							</p>
@@ -237,7 +237,7 @@
 					(val) => handleSetSubtool(toolReference, val)
 				}
 			/>
-			<img src={tool.icon} alt={tool.name} class="size-6 rounded-lg bg-white p-1" />
+			<img src={tool.icon} alt={tool.name} class="size-6 rounded-full bg-white p-1" />
 			{toolReference.name}
 		</p>
 	</label>

--- a/ui/user/src/lib/components/edit/Tools.svelte
+++ b/ui/user/src/lib/components/edit/Tools.svelte
@@ -37,7 +37,7 @@
 							{#if tool.icon}
 								<img
 									src={tool.icon}
-									class="size-6 rounded-md bg-white p-1"
+									class="size-6 rounded-full bg-white p-1"
 									alt="tool {tool.name} icon"
 								/>
 							{/if}


### PR DESCRIPTION
<img width="1840" alt="Screenshot 2025-03-13 at 1 23 41 PM" src="https://github.com/user-attachments/assets/66ec0b99-e037-489f-bf22-3b3772f0ae48" />

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>