### PR TITLE
enhance: better error detection when migrating run states

### DIFF
--- a/pkg/controller/handlers/runs/runs.go
+++ b/pkg/controller/handlers/runs/runs.go
@@ -7,13 +7,11 @@ import (
 	"github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/nah/pkg/backend"
 	"github.com/obot-platform/nah/pkg/router"
-	"github.com/obot-platform/nah/pkg/untriggered"
 	"github.com/obot-platform/obot/pkg/controller/handlers/inactive"
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/invoke"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -32,16 +30,6 @@ func New(invoker *invoke.Invoker, backend backend.Backend, gatewayClient *gclien
 }
 
 func (h *Handler) DeleteRunState(req router.Request, _ router.Response) error {
-	if err := req.Delete(untriggered.Get(&v1.RunState{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.Object.GetName(),
-			Namespace: req.Object.GetNamespace(),
-		},
-	})); !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	// If the run state wasn't found in the Kubernetes database, then delete it from the gateway database.
 	return client.IgnoreNotFound(h.gatewayClient.DeleteRunState(req.Ctx, req.Object.GetNamespace(), req.Object.GetName()))
 }
 

--- a/pkg/controller/handlers/runstates/migrate.go
+++ b/pkg/controller/handlers/runstates/migrate.go
@@ -5,6 +5,7 @@ import (
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
 	gtypes "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -20,19 +21,26 @@ func NewHandler(gatewayClient *gclient.Client) *Handler {
 
 func (h *Handler) Migrate(req router.Request, _ router.Response) error {
 	rs := req.Object.(*v1.RunState)
-	if err := h.gatewayClient.CreateRunState(req.Ctx, &gtypes.RunState{
-		Namespace:  req.Object.GetNamespace(),
-		Name:       req.Object.GetName(),
-		ThreadName: rs.Spec.ThreadName,
-		Program:    rs.Spec.Program,
-		ChatState:  rs.Spec.ChatState,
-		CallFrame:  rs.Spec.CallFrame,
-		Output:     rs.Spec.Output,
-		Done:       rs.Spec.Done,
-		Error:      rs.Spec.Error,
-	}); err != nil {
+	var run v1.Run
+	if err := req.Get(&run, rs.Namespace, rs.Name); err == nil {
+		// If the run exists, then create the run state in the gateway database
+		if err := h.gatewayClient.CreateRunState(req.Ctx, &gtypes.RunState{
+			Namespace:  req.Object.GetNamespace(),
+			Name:       req.Object.GetName(),
+			ThreadName: rs.Spec.ThreadName,
+			Program:    rs.Spec.Program,
+			ChatState:  rs.Spec.ChatState,
+			CallFrame:  rs.Spec.CallFrame,
+			Output:     rs.Spec.Output,
+			Done:       rs.Spec.Done,
+			Error:      rs.Spec.Error,
+		}); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+	} else if !apierrors.IsNotFound(err) {
 		return err
 	}
 
+	// If all is successful, then delete the run state from the Kubernetes database.
 	return kclient.IgnoreNotFound(req.Delete(rs))
 }

--- a/pkg/gateway/client/runstate.go
+++ b/pkg/gateway/client/runstate.go
@@ -22,7 +22,7 @@ func (c *Client) RunState(ctx context.Context, namespace, name string) (*types.R
 }
 
 func (c *Client) CreateRunState(ctx context.Context, runState *types.RunState) error {
-	if err := c.db.WithContext(ctx).Create(runState).Error; !errors.Is(err, gorm.ErrCheckConstraintViolated) {
+	if err := c.db.WithContext(ctx).Create(runState).Error; !errors.Is(err, gorm.ErrDuplicatedKey) {
 		return err
 	}
 	return apierrors.NewAlreadyExists(schema.GroupResource{


### PR DESCRIPTION
The incorrect gorm error was used to detect "already exists" errors. That is
fixed here. Additionally, the old RunStates are now only cleaned up in one spot,
and the new RunStates are cleaned up when a run is deleted.

Signed-off-by: Donnie Adams <donnie@acorn.io>