### PR TITLE
fix(ui): improve thread menu width and clarify rename action

### DIFF
--- a/ui/user/src/lib/components/sidebar/Threads.svelte
+++ b/ui/user/src/lib/components/sidebar/Threads.svelte
@@ -246,9 +246,9 @@
 							</button>
 						{:else}
 							<DotDotDot class="p-0">
-								<div class="default-dialog flex min-w-40 flex-col p-2">
+								<div class="default-dialog flex min-w-max flex-col p-2">
 									<button class="menu-button" onclick={startEditName}>
-										<Pen class="h-4 w-4" /> Edit
+										<Pen class="h-4 w-4" /> Rename
 									</button>
 									<button class="menu-button" onclick={() => deleteThread(thread.id)}>
 										<Trash2 class="h-4 w-4" /> Delete


### PR DESCRIPTION
Replaced fixed-width constraint with auto-width to ensure full text visibility
in the thread menu. Also renamed "Edit" button to "Rename" for better clarity
of purpose.

Addresses https://github.com/obot-platform/obot/issues/2121


<img width="461" alt="Screenshot 2025-03-14 at 11 56 56 AM" src="https://github.com/user-attachments/assets/97429f27-ee43-425a-a218-f579b6a34e04" />
