### PR TITLE
feat: add streamlined tooltips to user ui

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -192,7 +192,7 @@ li:has(input[type='checkbox'])::marker {
 }
 
 .tooltip {
-	@apply rounded-lg bg-surface2 p-2 text-sm font-light;
+	@apply rounded-lg border border-surface3 bg-surface2 p-2 text-sm font-light shadow-sm;
 }
 
 .default-dialog,

--- a/ui/user/src/lib/actions/overflow.ts
+++ b/ui/user/src/lib/actions/overflow.ts
@@ -1,23 +1,27 @@
 import popover from './popover.svelte.js';
+import type { Placement } from '@floating-ui/dom';
 
 function hasOverflow(element: HTMLElement) {
 	return element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth;
 }
 
-export function overflowToolTip(node: HTMLElement) {
+export function overflowToolTip(
+	node: HTMLElement,
+	{ placement = 'top', tooltipClass }: { placement?: Placement; tooltipClass?: string } = {}
+) {
 	const { ref, tooltip } = popover({
-		placement: 'top',
+		placement,
 		offset: 4,
 		hover: true
 	});
 
-	node.classList.add('text-nowrap', 'overflow-hidden', 'text-ellipsis', 'w-full');
+	node.classList.add('line-clamp-1', 'break-all');
 
-	const span = document.createElement('p') as HTMLSpanElement;
-	span.classList.add('tooltip');
-	span.textContent = node.textContent;
+	const p = document.createElement('p');
+	p.classList.add('tooltip-text', 'break-all', ...(tooltipClass?.split(' ') ?? []));
+	p.textContent = node.textContent;
 
-	node.insertAdjacentElement('afterend', span);
+	node.insertAdjacentElement('afterend', p);
 	node.addEventListener('mouseenter', (e) => {
 		if (!hasOverflow(node)) {
 			e.stopImmediatePropagation();
@@ -25,6 +29,6 @@ export function overflowToolTip(node: HTMLElement) {
 	});
 
 	// Register after the above event listener to ensure we can stop propagation
-	tooltip(span);
+	tooltip(p);
 	ref(node);
 }

--- a/ui/user/src/lib/actions/overflow.ts
+++ b/ui/user/src/lib/actions/overflow.ts
@@ -1,5 +1,6 @@
 import popover from './popover.svelte.js';
 import type { Placement } from '@floating-ui/dom';
+import { twMerge } from 'tailwind-merge';
 
 function hasOverflow(element: HTMLElement) {
 	return element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth;
@@ -7,18 +8,20 @@ function hasOverflow(element: HTMLElement) {
 
 export function overflowToolTip(
 	node: HTMLElement,
-	{ placement = 'top', tooltipClass }: { placement?: Placement; tooltipClass?: string } = {}
+	{
+		placement = 'top',
+		tooltipClass,
+		offset = 4
+	}: { placement?: Placement; tooltipClass?: string; offset?: number } = {}
 ) {
-	const { ref, tooltip } = popover({
-		placement,
-		offset: 4,
-		hover: true
-	});
+	const { ref, tooltip } = popover({ placement, offset, hover: true });
 
 	node.classList.add('line-clamp-1', 'break-all');
 
 	const p = document.createElement('p');
-	p.classList.add('tooltip-text', 'break-all', ...(tooltipClass?.split(' ') ?? []));
+	p.classList.add(
+		...twMerge('tooltip', 'break-all', ...(tooltipClass?.split(' ') ?? [])).split(' ')
+	);
 	p.textContent = node.textContent;
 
 	node.insertAdjacentElement('afterend', p);

--- a/ui/user/src/lib/actions/popover.svelte.ts
+++ b/ui/user/src/lib/actions/popover.svelte.ts
@@ -33,7 +33,7 @@ export default function popover(opts?: PopoverOptions): Popover {
 	let ref: HTMLElement;
 	let tooltip: HTMLElement;
 	let open = $state(false);
-	const offsetSize = opts?.offset ?? 8;
+	const offsetSize = opts?.offset ?? 4;
 	let hoverTimeout: number | null = null;
 
 	function build(): ActionReturn | void {

--- a/ui/user/src/lib/components/Editors.svelte
+++ b/ui/user/src/lib/components/Editors.svelte
@@ -42,11 +42,11 @@
 <div class="relative flex h-full flex-col">
 	{#if layout.fileEditorOpen}
 		{#if layout.items.length > 1 || (!layout.items[0]?.table && !layout.items[0]?.generic)}
-			<div class="relative flex items-center border-b-2 border-surface2">
-				<ul class="relative flex flex-1 items-center gap-1 pb-2 text-center text-sm">
+			<div class="relative flex items-center border-b-2 border-surface2 pb-2">
+				<ul class="relative flex flex-1 items-center gap-1 text-center text-sm">
 					{#each layout.items as item (item.id)}
-						{@const tt = popover({ hover: true, placement: 'top' })}
-						<p use:tt.tooltip class="rounded-full bg-surface2 p-2">
+						{@const tt = popover({ hover: true, placement: 'top-start' })}
+						<p use:tt.tooltip class="tooltip-text">
 							{item.name}
 						</p>
 

--- a/ui/user/src/lib/components/Editors.svelte
+++ b/ui/user/src/lib/components/Editors.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { popover } from '$lib/actions';
+	import { overflowToolTip } from '$lib/actions/overflow';
 	import Controls from '$lib/components/editor/Controls.svelte';
 	import FileEditors from '$lib/components/editor/FileEditors.svelte';
 	import Terminal from '$lib/components/terminal/Terminal.svelte';
@@ -45,15 +45,9 @@
 			<div class="relative flex items-center border-b-2 border-surface2 pb-2">
 				<ul class="relative flex flex-1 items-center gap-1 text-center text-sm">
 					{#each layout.items as item (item.id)}
-						{@const tt = popover({ hover: true, placement: 'top-start' })}
-						<p use:tt.tooltip class="tooltip-text">
-							{item.name}
-						</p>
-
 						<li class="flex-1">
 							<!-- TODO: div with onclick is not accessible, we'll need to update this in the future -->
 							<div
-								use:tt.ref
 								role="none"
 								onclick={() => {
 									EditorService.select(layout.items, item.id);
@@ -66,7 +60,14 @@
 								<div
 									class="relative flex w-full items-center justify-between gap-1 [&_svg]:size-4 [&_svg]:min-w-fit"
 								>
-									<span class="line-clamp-1 break-all p-1">{item.name}</span>
+									<span
+										use:overflowToolTip={{
+											placement: 'top-start',
+											tooltipClass: 'min-w-fit break-words',
+											offset: 8
+										}}
+										class="line-clamp-1 break-all p-1">{item.name}</span
+									>
 
 									<button
 										class={twMerge(

--- a/ui/user/src/lib/components/Sidebar.svelte
+++ b/ui/user/src/lib/components/Sidebar.svelte
@@ -11,6 +11,7 @@
 	import Projects from './navbar/Projects.svelte';
 	import Logo from './navbar/Logo.svelte';
 	import Tables from '$lib/components/sidebar/Tables.svelte';
+	import { popover } from '$lib/actions';
 
 	interface Props {
 		project: Project;
@@ -22,6 +23,8 @@
 	let credentials = $state<ReturnType<typeof Credentials>>();
 	let projectsOpen = $state(false);
 	const layout = getLayout();
+
+	let credentialsTT = popover({ hover: true, placement: 'right' });
 </script>
 
 <div class="relative flex size-full flex-col bg-surface1">
@@ -66,9 +69,13 @@
 		{#if hasTool(tools, 'shell')}
 			<Term />
 		{/if}
-		<button class="icon-button" onclick={() => credentials?.show()}>
+
+		<p use:credentialsTT.tooltip class="tooltip-text">Credentials</p>
+
+		<button class="icon-button" onclick={() => credentials?.show()} use:credentialsTT.ref>
 			<KeyRound class="icon-default" />
 		</button>
+
 		<Credentials bind:this={credentials} {project} {tools} />
 		{#if !project.editor}
 			<Clone {project} />

--- a/ui/user/src/lib/components/Sidebar.svelte
+++ b/ui/user/src/lib/components/Sidebar.svelte
@@ -70,7 +70,7 @@
 			<Term />
 		{/if}
 
-		<p use:credentialsTT.tooltip class="tooltip-text">Credentials</p>
+		<p use:credentialsTT.tooltip class="tooltip">Credentials</p>
 
 		<button class="icon-button" onclick={() => credentials?.show()} use:credentialsTT.ref>
 			<KeyRound class="icon-default" />

--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -123,10 +123,10 @@
 <div class="relative w-full max-w-[900px] pb-32">
 	<!-- Fade text in/out on scroll -->
 	<div
-		class="absolute inset-x-0 top-0 z-30 h-14 w-full bg-gradient-to-b from-white dark:from-black"
+		class="absolute inset-x-0 top-0 z-10 h-14 w-full bg-gradient-to-b from-white dark:from-black"
 	></div>
 	<div
-		class="absolute inset-x-0 bottom-32 z-30 h-14 w-full bg-gradient-to-t from-white dark:from-black"
+		class="absolute inset-x-0 bottom-32 z-10 h-14 w-full bg-gradient-to-t from-white dark:from-black"
 	></div>
 
 	<div
@@ -188,7 +188,7 @@
 				<!-- Vertical Spacer -->
 			</div>
 		</div>
-		<div class="absolute inset-x-0 bottom-0 z-30 flex justify-center py-8">
+		<div class="absolute inset-x-0 bottom-0 z-30 flex flex-col justify-center py-8">
 			<Input
 				readonly={messages.inProgress}
 				pending={thread?.pending}
@@ -205,18 +205,18 @@
 			>
 				<div class="flex w-fit items-center gap-1">
 					<div use:fileTT.ref>
-						<p use:fileTT.tooltip class="tooltip-text">Open in Editor</p>
+						<p use:fileTT.tooltip class="tooltip">Files</p>
 						<Files thread {project} bind:currentThreadID={id} />
 					</div>
 
 					<div use:toolsTT.ref>
-						<p use:toolsTT.tooltip class="tooltip-text">Tools</p>
+						<p use:toolsTT.tooltip class="tooltip">Tools</p>
 						<Tools {project} {version} {tools} />
 					</div>
-				</Input>
-				<div class="mt-3 text-center text-xs font-light text-gray dark:text-gray-400">
-					Obots aren't perfect. Double check their work.
 				</div>
+			</Input>
+			<div class="mt-3 text-center text-xs font-light text-gray dark:text-gray-400">
+				Obots aren't perfect. Double check their work.
 			</div>
 		</div>
 	</div>

--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -19,6 +19,7 @@
 	import Tools from '$lib/components/navbar/Tools.svelte';
 	import type { UIEventHandler } from 'svelte/elements';
 	import AssistantIcon from '$lib/icons/AssistantIcon.svelte';
+	import { popover } from '$lib/actions';
 
 	interface Props {
 		id?: string;
@@ -55,6 +56,9 @@
 	});
 
 	let scrollControls = $state<StickToBottomControls>();
+
+	const fileTT = popover({ hover: true, placement: 'top' });
+	const toolsTT = popover({ hover: true, placement: 'top' });
 
 	onDestroy(() => {
 		thread?.close?.();
@@ -185,23 +189,28 @@
 			</div>
 		</div>
 		<div class="absolute inset-x-0 bottom-0 z-30 flex justify-center py-8">
-			<div class="w-full max-w-[1000px]">
-				<Input
-					readonly={messages.inProgress}
-					pending={thread?.pending}
-					onAbort={async () => {
-						await thread?.abort();
-					}}
-					onSubmit={async (i) => {
-						await ensureThread();
-						scrollSmooth = false;
-						scrollControls?.stickToBottom();
-						await thread?.invoke(i);
-					}}
-					bind:items={layout.items}
-				>
-					<div class="flex w-fit items-center gap-1">
+			<Input
+				readonly={messages.inProgress}
+				pending={thread?.pending}
+				onAbort={async () => {
+					await thread?.abort();
+				}}
+				onSubmit={async (i) => {
+					await ensureThread();
+					scrollSmooth = false;
+					scrollControls?.stickToBottom();
+					await thread?.invoke(i);
+				}}
+				bind:items={layout.items}
+			>
+				<div class="flex w-fit items-center gap-1">
+					<div use:fileTT.ref>
+						<p use:fileTT.tooltip class="tooltip-text">Open in Editor</p>
 						<Files thread {project} bind:currentThreadID={id} />
+					</div>
+
+					<div use:toolsTT.ref>
+						<p use:toolsTT.tooltip class="tooltip-text">Tools</p>
 						<Tools {project} {version} {tools} />
 					</div>
 				</Input>

--- a/ui/user/src/lib/components/edit/Files.svelte
+++ b/ui/user/src/lib/components/edit/Files.svelte
@@ -156,18 +156,22 @@
 							{:else}
 								<FileText class="size-5 min-w-fit" />
 							{/if}
-							<span use:overflowToolTip>{file.name}</span>
+							<span use:overflowToolTip={{ placement: 'top-start', tooltipClass: 'min-w-full' }}
+								>{file.name}</span
+							>
 						</button>
+
 						<button
-							class="ms-2 hidden group-hover:block"
+							class="icon-button-small invisible ms-2 group-hover:visible"
 							onclick={() => {
 								EditorService.download([], project, file.name, apiOpts);
 							}}
 						>
 							<Download class="h-5 w-5 text-gray" />
 						</button>
+
 						<button
-							class="ms-2 hidden group-hover:block"
+							class="icon-button-small invisible ms-2 group-hover:visible"
 							onclick={() => {
 								fileToDelete = file.name;
 							}}

--- a/ui/user/src/lib/components/edit/Files.svelte
+++ b/ui/user/src/lib/components/edit/Files.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
-	import { FileText, Trash, Upload, X } from 'lucide-svelte/icons';
+	import { overflowToolTip } from '$lib/actions/overflow';
+	import Confirm from '$lib/components/Confirm.svelte';
+	import CollapsePane from '$lib/components/edit/CollapsePane.svelte';
+	import FileEditors from '$lib/components/editor/FileEditors.svelte';
+	import Error from '$lib/components/Error.svelte';
+	import Menu from '$lib/components/navbar/Menu.svelte';
+	import { getLayout } from '$lib/context/layout.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
+	import { isImage } from '$lib/image';
+	import { newFileMonitor } from '$lib/save.js';
 	import {
 		ChatService,
 		EditorService,
@@ -8,19 +17,10 @@
 		type Project,
 		type Thread
 	} from '$lib/services';
-	import Confirm from '$lib/components/Confirm.svelte';
-	import { Download, Image } from 'lucide-svelte';
-	import { isImage } from '$lib/image';
-	import Error from '$lib/components/Error.svelte';
-	import Loading from '$lib/icons/Loading.svelte';
-	import CollapsePane from '$lib/components/edit/CollapsePane.svelte';
-	import { getLayout } from '$lib/context/layout.svelte';
 	import type { EditorItem } from '$lib/services/editor/index.svelte';
-	import FileEditors from '$lib/components/editor/FileEditors.svelte';
-	import { newFileMonitor } from '$lib/save.js';
+	import { Download, Image } from 'lucide-svelte';
+	import { FileText, Trash, Upload, X } from 'lucide-svelte/icons';
 	import { onMount } from 'svelte';
-	import { overflowToolTip } from '$lib/actions/overflow';
-	import Menu from '$lib/components/navbar/Menu.svelte';
 
 	interface Props {
 		project: Project;
@@ -143,7 +143,7 @@
 	{#if files.length === 0}
 		<p class="pb-3 pt-6 text-center text-sm text-gray dark:text-gray-300">No files</p>
 	{:else}
-		<ul class="max-h-[60vh] space-y-4 overflow-y-auto px-3 py-6 text-sm">
+		<ul class="max-h-[60vh] space-y-4 overflow-y-auto py-6 ps-3 text-sm">
 			{#each files as file}
 				<li class="group">
 					<div class="flex">
@@ -156,7 +156,7 @@
 							{:else}
 								<FileText class="size-5 min-w-fit" />
 							{/if}
-							<span use:overflowToolTip={{ placement: 'top-start', tooltipClass: 'min-w-full' }}
+							<span use:overflowToolTip={{ placement: 'top', tooltipClass: 'max-w-full' }}
 								>{file.name}</span
 							>
 						</button>

--- a/ui/user/src/lib/components/edit/ToolCatalog.svelte
+++ b/ui/user/src/lib/components/edit/ToolCatalog.svelte
@@ -200,7 +200,7 @@
 							{/if}
 						</label>
 
-						<p use:tt.tooltip class="w-64 rounded-xl bg-surface3 p-2 text-start">
+						<p use:tt.tooltip class="tooltip-text max-w-64">
 							{#if hasBundle}
 								{tool.description}
 							{:else}
@@ -242,7 +242,7 @@
 		</p>
 	</label>
 
-	<p use:tooltip class="w-64 rounded-xl bg-surface3 p-2 text-start">
+	<p use:tooltip class="tooltip-text max-w-64">
 		{toolReference.description}
 	</p>
 {/snippet}

--- a/ui/user/src/lib/components/edit/ToolCatalog.svelte
+++ b/ui/user/src/lib/components/edit/ToolCatalog.svelte
@@ -200,7 +200,7 @@
 							{/if}
 						</label>
 
-						<p use:tt.tooltip class="tooltip-text max-w-64">
+						<p use:tt.tooltip class="tooltip max-w-64">
 							{#if hasBundle}
 								{tool.description}
 							{:else}
@@ -242,7 +242,7 @@
 		</p>
 	</label>
 
-	<p use:tooltip class="tooltip-text max-w-64">
+	<p use:tooltip class="tooltip max-w-64">
 		{toolReference.description}
 	</p>
 {/snippet}

--- a/ui/user/src/lib/components/edit/Tools.svelte
+++ b/ui/user/src/lib/components/edit/Tools.svelte
@@ -54,7 +54,7 @@
 					<span class="line-clamp-2 text-xs text-gray-500">{tool.description}</span>
 				</div>
 
-				<p use:tt.tooltip class="tooltip-text max-w-64">{tool.description}</p>
+				<p use:tt.tooltip class="tooltip max-w-64">{tool.description}</p>
 			</div>
 		{/each}
 	</ul>

--- a/ui/user/src/lib/components/edit/Tools.svelte
+++ b/ui/user/src/lib/components/edit/Tools.svelte
@@ -54,7 +54,7 @@
 					<span class="line-clamp-2 text-xs text-gray-500">{tool.description}</span>
 				</div>
 
-				<p use:tt.tooltip class="tooltip max-w-64">{tool.description}</p>
+				<p use:tt.tooltip class="tooltip-text max-w-64">{tool.description}</p>
 			</div>
 		{/each}
 	</ul>

--- a/ui/user/src/lib/components/editor/Controls.svelte
+++ b/ui/user/src/lib/components/editor/Controls.svelte
@@ -26,7 +26,7 @@
 	<div class={twMerge('flex items-start', className)}>
 		{#if currentThreadID}
 			<div use:fileTT.ref>
-				<p use:fileTT.tooltip class="tooltip-text">Browse Files</p>
+				<p use:fileTT.tooltip class="tooltip">Browse Files</p>
 				<Files {project} thread {currentThreadID} primary={false} />
 			</div>
 		{/if}

--- a/ui/user/src/lib/components/editor/Controls.svelte
+++ b/ui/user/src/lib/components/editor/Controls.svelte
@@ -5,6 +5,7 @@
 	import { X } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 	import Files from '../edit/Files.svelte';
+	import { popover } from '$lib/actions';
 
 	interface Props {
 		navBar?: boolean;
@@ -17,12 +18,17 @@
 
 	const layout = getLayout();
 	let show = $derived(navBar || layout.items.length <= 1);
+
+	const fileTT = popover({ hover: true, placement: 'top' });
 </script>
 
 {#if show}
 	<div class={twMerge('flex items-start', className)}>
 		{#if currentThreadID}
-			<Files {project} thread {currentThreadID} primary={false} />
+			<div use:fileTT.ref>
+				<p use:fileTT.tooltip class="tooltip-text">Browse Files</p>
+				<Files {project} thread {currentThreadID} primary={false} />
+			</div>
 		{/if}
 
 		<button

--- a/ui/user/src/lib/components/messages/Message.svelte
+++ b/ui/user/src/lib/components/messages/Message.svelte
@@ -12,6 +12,7 @@
 	import { waitingOnModelMessage } from '$lib/services/chat/messages';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { fade } from 'svelte/transition';
+	import { overflowToolTip } from '$lib/actions/overflow';
 
 	interface Props {
 		msg: Message;
@@ -193,19 +194,13 @@
 {#snippet files()}
 	{#if msg.file?.filename}
 		<button
-			class="my-2 flex cursor-pointer flex-col divide-y
-		 divide-gray-300 rounded-3xl
-		 border border-gray-300
-		 bg-white text-start
-		 text-black shadow-lg
-		   dark:bg-black
-		    dark:text-gray-50"
+			class="my-2 flex cursor-pointer flex-col divide-y divide-gray-300 rounded-3xl border border-gray-300 bg-white text-start text-black shadow-lg dark:bg-black dark:text-gray-50"
 			onclick={fileLoad}
 		>
-			<div class="flex gap-2 px-5 py-4 text-md">
-				<div class="flex grow justify-start gap-2">
-					<FileText />
-					<span>{msg.file.filename}</span>
+			<div class="text-md flex gap-2 px-5 py-4">
+				<div class="flex items-center justify-start gap-2">
+					<FileText class="min-w-fit" />
+					<span use:overflowToolTip={{ placement: 'top' }}>{msg.file.filename}</span>
 				</div>
 				<div>
 					<Pencil />
@@ -213,7 +208,7 @@
 				</div>
 			</div>
 			<div class="relative">
-				<div class="whitespace-pre-wrap p-5 font-body text-md text-gray-700 dark:text-gray-300">
+				<div class="text-md whitespace-pre-wrap p-5 font-body text-gray-700 dark:text-gray-300">
 					{msg.file.content.split('\n').splice(0, 6).join('\n')}
 				</div>
 				<div
@@ -248,7 +243,7 @@
 					}}>{msg.explain.filename}</button
 				>
 			</div>
-			<div class="whitespace-pre-wrap p-5 font-body text-md text-gray-700 dark:text-gray-300">
+			<div class="text-md whitespace-pre-wrap p-5 font-body text-gray-700 dark:text-gray-300">
 				{msg.explain.selection}
 			</div>
 		</div>
@@ -465,7 +460,7 @@
 		}
 
 		.message-content p {
-			@apply mb-4 text-md text-gray-900 dark:text-gray-100;
+			@apply text-md mb-4 text-gray-900 dark:text-gray-100;
 		}
 
 		.message-content a {
@@ -481,7 +476,7 @@
 		}
 
 		.message-content ul li {
-			@apply ps-2 text-md;
+			@apply text-md ps-2;
 		}
 
 		.message-content code {

--- a/ui/user/src/lib/components/messages/Message.svelte
+++ b/ui/user/src/lib/components/messages/Message.svelte
@@ -197,7 +197,7 @@
 			class="my-2 flex cursor-pointer flex-col divide-y divide-gray-300 rounded-3xl border border-gray-300 bg-white text-start text-black shadow-lg dark:bg-black dark:text-gray-50"
 			onclick={fileLoad}
 		>
-			<div class="text-md flex gap-2 px-5 py-4">
+			<div class="flex gap-2 px-5 py-4 text-md">
 				<div class="flex items-center justify-start gap-2">
 					<FileText class="min-w-fit" />
 					<span use:overflowToolTip={{ placement: 'top' }}>{msg.file.filename}</span>
@@ -208,7 +208,7 @@
 				</div>
 			</div>
 			<div class="relative">
-				<div class="text-md whitespace-pre-wrap p-5 font-body text-gray-700 dark:text-gray-300">
+				<div class="whitespace-pre-wrap p-5 font-body text-md text-gray-700 dark:text-gray-300">
 					{msg.file.content.split('\n').splice(0, 6).join('\n')}
 				</div>
 				<div
@@ -243,7 +243,7 @@
 					}}>{msg.explain.filename}</button
 				>
 			</div>
-			<div class="text-md whitespace-pre-wrap p-5 font-body text-gray-700 dark:text-gray-300">
+			<div class="whitespace-pre-wrap p-5 font-body text-md text-gray-700 dark:text-gray-300">
 				{msg.explain.selection}
 			</div>
 		</div>
@@ -460,7 +460,7 @@
 		}
 
 		.message-content p {
-			@apply text-md mb-4 text-gray-900 dark:text-gray-100;
+			@apply mb-4 text-md text-gray-900 dark:text-gray-100;
 		}
 
 		.message-content a {
@@ -476,7 +476,7 @@
 		}
 
 		.message-content ul li {
-			@apply text-md ps-2;
+			@apply ps-2 text-md;
 		}
 
 		.message-content code {

--- a/ui/user/src/lib/components/sidebar/Tasks.svelte
+++ b/ui/user/src/lib/components/sidebar/Tasks.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { Plus } from 'lucide-svelte/icons';
-	import { ChatService, type Project, type Task } from '$lib/services';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import { getLayout, openTask } from '$lib/context/layout.svelte';
+	import { ChatService, type Project, type Task } from '$lib/services';
+	import { Plus } from 'lucide-svelte/icons';
 	import { onMount } from 'svelte';
 	import TaskItem from './TaskItem.svelte';
 


### PR DESCRIPTION
https://www.loom.com/share/48c459d6e51649cdb010fe84183b7daf?sid=3a1a28d1-395d-4f3b-8852-d57a946e6887

Additionally fixes issue where long file names completely break width of page when editor is open

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>