### PR TITLE
Fix: change task's alias, matching alias from email

### DIFF
--- a/pkg/api/handlers/tasks.go
+++ b/pkg/api/handlers/tasks.go
@@ -704,6 +704,10 @@ func (t *TaskHandler) CreateFromScope(req api.Context) error {
 		return fmt.Errorf("failed to generate alias: %w", err)
 	}
 
+	if len(workflowManifest.Alias) > 12 {
+		workflowManifest.Alias = workflowManifest.Alias[:12]
+	}
+
 	workflow := v1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: system.WorkflowPrefix,

--- a/pkg/emailtrigger/emailtrigger.go
+++ b/pkg/emailtrigger/emailtrigger.go
@@ -54,8 +54,14 @@ func (h *EmailHandler) Handler(ctx context.Context, from string, to []string, su
 			ns = system.DefaultNamespace
 		}
 
+		aliasName := ""
+		parts := strings.Split(name, "-")
+		if len(parts) > 1 {
+			aliasName = parts[len(parts)-1]
+		}
+
 		var emailReceiver v1.EmailReceiver
-		if err = alias.Get(ctx, h.c, &emailReceiver, ns, name); apierror.IsNotFound(err) {
+		if err = alias.Get(ctx, h.c, &emailReceiver, ns, aliasName); apierror.IsNotFound(err) {
 			log.Infof("Skipping mail for %s: no receiver found", toAddr.Address)
 			continue
 		} else if err != nil {

--- a/pkg/storage/apis/obot.obot.ai/v1/emailaddress.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/emailaddress.go
@@ -67,7 +67,7 @@ func (*EmailReceiver) GetColumns() [][]string {
 	return [][]string{
 		{"Name", "Name"},
 		{"Alias", "Spec.Alias"},
-		{"Workflow", "Spec.Workflow"},
+		{"Workflow", "Spec.WorkflowName"},
 		{"Created", "{{ago .CreationTimestamp}}"},
 		{"Description", "Spec.Description"},
 	}

--- a/ui/user/src/lib/components/tasks/Trigger.svelte
+++ b/ui/user/src/lib/components/tasks/Trigger.svelte
@@ -14,8 +14,9 @@
 	let version: Version = $state({});
 	let email = $derived.by(() => {
 		if (version.emailDomain && task.alias) {
-			return `${task.alias.replace('/', '.')}@${version.emailDomain}`;
+			return `${task.name ? task.name.toLocaleLowerCase().replace(' ', '-') + '-' : ''}${task.alias.replace('/', '.')}@${version.emailDomain}`;
 		}
+
 		return '';
 	});
 	let webhook = $derived.by(() => {
@@ -86,9 +87,12 @@
 			</div>
 		{/if}
 		{#if selectedTrigger() === 'email' && email}
-			<div class="flex justify-between pr-5">
+			<div class="flex flex-col justify-between gap-2 pr-5">
 				<h3 class="text-lg font-semibold">Email Address</h3>
-				{email}
+				<div class="flex gap-2">
+					<CopyButton text={email} />
+					{email}
+				</div>
 			</div>
 		{/if}
 		{#if selectedTrigger() === 'onDemand'}


### PR DESCRIPTION
I changed the task.alias to be a short version of 12 character, this will be used for webhook and email trigger. 

Make the email address from task prefixed with task name to be more user friendly, and in the backend we will only match the receiver that match the alias in the last part.

demo: https://www.loom.com/share/071ea961f7d74e34bf99de4f6dadf0b9