### PR TITLE
enhance: lexicographically sort tool catalog

### DIFF
--- a/ui/user/src/lib/components/edit/ToolCatalog.svelte
+++ b/ui/user/src/lib/components/edit/ToolCatalog.svelte
@@ -139,11 +139,11 @@
 	</p>
 
 	<div class="default-scrollbar-thin flex max-h-[50vh] grow flex-col p-3">
-		{#each bundleMap.values() as { tool, bundleTools }}
+		{#each Array.from(bundleMap.values()).sort( (a, b) => a.tool.name.localeCompare(b.tool.name) ) as { tool, bundleTools }}
 			{@const hasBundle = tool.id in toolSelection}
-			{@const visibleBundleTools = bundleTools.filter(
-				(t) => t.id in toolSelection && shouldShowTool(toolSelection[t.id])
-			)}
+			{@const visibleBundleTools = bundleTools
+				.filter((t) => t.id in toolSelection && shouldShowTool(toolSelection[t.id]))
+				.sort((a, b) => a.name.localeCompare(b.name))}
 			{@const selectedSubtools = bundleTools.filter(
 				(t) => t.id in toolSelection && toolSelection[t.id].enabled
 			).length}


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/2120

e.g. before change (unsorted)

<img width="868" alt="Screenshot 2025-03-14 at 11 07 44 PM" src="https://github.com/user-attachments/assets/4088ffd1-8856-45df-9cd0-cabc17f1330f" />

e.g. after change (sorted)

Screenshot 2025-03-14 at 11.26.57 PM