### PR TITLE
fix: prevent tooltips from overlaying popovers in input actions

### DIFF
--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -211,12 +211,12 @@
 			>
 				<div class="flex w-fit items-center gap-1">
 					<div use:fileTT.ref>
-						<p use:fileTT.tooltip class="tooltip">Files</p>
+						<p use:fileTT.tooltip class="tooltip z-10">Files</p>
 						<Files thread {project} bind:currentThreadID={id} />
 					</div>
 
 					<div use:toolsTT.ref>
-						<p use:toolsTT.tooltip class="tooltip">Tools</p>
+						<p use:toolsTT.tooltip class="tooltip z-10">Tools</p>
 						<Tools {project} {version} {tools} />
 					</div>
 				</div>


### PR DESCRIPTION
addresses #2171

https://www.loom.com/share/9b2be141e85b411a86c87e72ae73558e?sid=d44a1225-8b29-4e15-a280-07c708f6c9c0

Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>