### PR TITLE
fix: chat messages spilling over

### DIFF
--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -143,7 +143,7 @@
 		<div
 			in:fade|global
 			bind:this={messagesDiv}
-			class="flex h-fit w-full flex-col justify-start gap-8 p-5 transition-all"
+			class="flex h-fit w-full max-w-[900px] flex-col justify-start gap-8 p-5 transition-all"
 			class:justify-center={!thread}
 		>
 			{#if !isTaskRun}


### PR DESCRIPTION
addresses #2174

It looks like this change got lost/reverted somewhere along the way.

This prevents the chat contents from spilling over and filling the container when the viewport is larger

Before:
<img width="1840" alt="Screenshot 2025-03-15 at 10 24 53 AM" src="https://github.com/user-attachments/assets/234dd9c4-76ae-4a25-b3f8-73a0d3272f52" />

After:
<img width="1840" alt="Screenshot 2025-03-15 at 10 25 17 AM" src="https://github.com/user-attachments/assets/3669ba0a-3021-4798-81ac-9d3ce8d5c0ae" />


Signed-off-by: Ryan Hopper-Lowe <ryan@acorn.io>