### PR TITLE
fix: use darker gray bg for homepage tool pills

### DIFF
--- a/ui/user/src/lib/components/ToolPill.svelte
+++ b/ui/user/src/lib/components/ToolPill.svelte
@@ -18,7 +18,7 @@
 
 <div
 	use:ref
-	class="flex w-fit cursor-help items-center gap-1 rounded-2xl bg-surface2 p-2 dark:bg-gray-100 dark:text-black"
+	class="flex w-fit cursor-help items-center gap-1 rounded-2xl bg-surface2 p-2 dark:bg-gray-600 dark:text-black"
 >
 	{#if tool}
 		{#if tool?.metadata?.icon}


### PR DESCRIPTION
Addresses #2155 

Before:
<img width="320" alt="Screenshot 2025-03-15 at 3 14 14 PM" src="https://github.com/user-attachments/assets/52098292-7b9d-49a4-8079-6ef82a4e6dfd" />

After:
<img width="323" alt="Screenshot 2025-03-15 at 3 14 08 PM" src="https://github.com/user-attachments/assets/5bac535c-54e5-4f91-8edb-c5826898ca9c" />
