### PR TITLE
fix: use bug icon for issue reporting in mobile view

### DIFF
--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -19,6 +19,8 @@
 	import Tools from '$lib/components/navbar/Tools.svelte';
 	import type { UIEventHandler } from 'svelte/elements';
 	import AssistantIcon from '$lib/icons/AssistantIcon.svelte';
+	import { responsive } from '$lib/stores';
+	import { Bug } from 'lucide-svelte';
 
 	interface Props {
 		id?: string;
@@ -218,9 +220,13 @@
 						href="https://github.com/obot-platform/obot/issues/new?template=bug_report.md"
 						target="_blank"
 						rel="noopener noreferrer"
-						class="whitespace-nowrap text-blue-500 hover:underline"
+						class="whitespace-nowrap text-blue-500/50 hover:underline"
 					>
-						Report issues here
+						{#if responsive.isMobile}
+							<Bug class="h-4 w-4" />
+						{:else}
+							Report issues here
+						{/if}
 					</a>
 				</div>
 			</div>


### PR DESCRIPTION
e.g. 412 wide:

<img width="409" alt="Screenshot 2025-03-17 at 12 02 08 PM" src="https://github.com/user-attachments/assets/f3e8304e-a015-4f0c-9dae-d98d492d1dab" />
