### PR TITLE
fix: prevent text from overflowing in confirm dialog

### DIFF
--- a/ui/user/src/lib/components/Confirm.svelte
+++ b/ui/user/src/lib/components/Confirm.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { CircleAlert, X } from 'lucide-svelte/icons';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
 		show: boolean;
-		msg?: string;
+		msg?: string | Snippet;
 		onsuccess: () => void;
 		oncancel: () => void;
 	}
@@ -46,7 +47,13 @@
 			</button>
 			<div class="p-4 text-center md:p-5">
 				<CircleAlert class="mx-auto mb-4 h-12 w-12 text-gray-400 dark:text-gray-100" />
-				<h3 class="mb-5 text-lg font-normal text-black dark:text-gray-100">{msg}</h3>
+				<h3 class="mb-5 break-words text-lg font-normal text-black dark:text-gray-100">
+					{#if typeof msg === 'string'}
+						{msg}
+					{:else}
+						{@render msg()}
+					{/if}
+				</h3>
 				<button
 					onclick={onsuccess}
 					type="button"

--- a/ui/user/src/lib/components/edit/Files.svelte
+++ b/ui/user/src/lib/components/edit/Files.svelte
@@ -247,9 +247,13 @@
 	</div>
 </dialog>
 
+{#snippet msg()}
+	Are you sure you want to delete <span class="font-semibold">{fileToDelete}</span>?
+{/snippet}
+
 <Confirm
 	show={fileToDelete !== undefined}
-	msg={`Are you sure you want to delete ${fileToDelete}?`}
+	{msg}
 	onsuccess={deleteFile}
 	oncancel={() => (fileToDelete = undefined)}
 />


### PR DESCRIPTION
addresses comment in #1918

Before:
<img width="1796" alt="Screenshot 2025-03-19 at 11 27 46 AM" src="https://github.com/user-attachments/assets/d8dbef33-b4a0-4a14-93f0-754b1bce037d" />

After:
<img width="1840" alt="Screenshot 2025-03-19 at 11 27 27 AM" src="https://github.com/user-attachments/assets/bf56515f-134d-4d90-a5c4-3523e8e94aea" />
