### PR TITLE
feat: add copy and edit buttons to obot responses

### DIFF
--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -180,6 +180,7 @@
 				<Message
 					{project}
 					{msg}
+					currentThreadID={id}
 					{onLoadFile}
 					{onSendCredentials}
 					onSendCredentialsCancel={() => thread?.abort()}

--- a/ui/user/src/lib/components/messages/Message.svelte
+++ b/ui/user/src/lib/components/messages/Message.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import MessageIcon from '$lib/components/messages/MessageIcon.svelte';
-	import { FileText, Pencil } from 'lucide-svelte/icons';
+	import { FileText, Pencil, Copy, Edit } from 'lucide-svelte/icons';
 	import { Tween } from 'svelte/motion';
 	import { ChatService, type Message, type Project } from '$lib/services';
 	import highlight from 'highlight.js';
@@ -11,10 +11,12 @@
 	import Loading from '$lib/icons/Loading.svelte';
 	import { fade } from 'svelte/transition';
 	import { overflowToolTip } from '$lib/actions/overflow';
+	import popover from '$lib/actions/popover.svelte';
 
 	interface Props {
 		msg: Message;
 		project: Project;
+		currentThreadID?: string;
 		onLoadFile?: (filename: string) => void;
 		onSendCredentials?: (id: string, credentials: Record<string, string>) => void;
 		onSendCredentialsCancel?: (id: string) => void;
@@ -23,6 +25,7 @@
 	let {
 		msg,
 		project,
+		currentThreadID,
 		onLoadFile = () => {},
 		onSendCredentials = ChatService.sendCredentials,
 		onSendCredentialsCancel
@@ -48,6 +51,9 @@
 	let animating = $state(false);
 	let showToolInputDetails = $state(false);
 	let showToolOutputDetails = $state(false);
+
+	let copyTT = popover({ hover: true, placement: 'bottom' });
+	let editTT = popover({ hover: true, placement: 'bottom' });
 
 	$effect(() => {
 		if (!shouldAnimate) return;
@@ -183,6 +189,35 @@
 			return formatted;
 		} catch (_error) {
 			return jsonString;
+		}
+	}
+
+	async function copyContentToClipboard() {
+		try {
+			await navigator.clipboard.writeText(content);
+		} catch (err) {
+			console.error('Failed to copy message:', err);
+		}
+	}
+
+	async function openContentInEditor() {
+		try {
+			const filename = `obot-response-${msg.time?.getTime()}.md`;
+			const files = await ChatService.listFiles(project.assistantID, project.id, {
+				threadID: currentThreadID
+			});
+
+			const fileExists = files.items.some((file) => file.name === filename);
+			if (!fileExists) {
+				const file = new File([content], filename, { type: 'text/plain' });
+				await ChatService.saveFile(project.assistantID, project.id, file, {
+					threadID: currentThreadID
+				});
+			}
+
+			onLoadFile(filename);
+		} catch (err) {
+			console.error('Failed to create or open file:', err);
 		}
 	}
 </script>
@@ -470,8 +505,35 @@
 				{#if msg.sent}
 					{@render time()}
 				{/if}
+
+				{#if !msg.sent && msg.done && !msg.toolCall && msg.time && !animating}
+					<div class="ml-2 mt-2 flex gap-2">
+						<div>
+							<button
+								use:copyTT.ref
+								class="icon-button-small"
+								onclick={() => copyContentToClipboard()}
+							>
+								<Copy class="h-4 w-4" />
+							</button>
+							<p use:copyTT.tooltip class="tooltip">Copy message to clipboard</p>
+						</div>
+
+						<div>
+							<button
+								use:editTT.ref
+								class="icon-button-small"
+								onclick={() => openContentInEditor()}
+							>
+								<Edit class="h-4 w-4" />
+							</button>
+							<p use:editTT.tooltip class="tooltip">Open message in editor</p>
+						</div>
+					</div>
+				{/if}
 			{/if}
 		</div>
+
 		{#if msg.aborted}
 			<div
 				class="pointer-events-none absolute bottom-0 z-10 flex h-full w-full flex-col items-center justify-center bg-white bg-opacity-60 text-xl font-semibold text-black text-opacity-30 dark:bg-black dark:bg-opacity-60 dark:text-white dark:text-opacity-30"


### PR DESCRIPTION
Add copy and edit buttons to chat messages that allow users to copy Obot responses to the clipboard and edit them as a file.

Addresses https://github.com/obot-platform/obot/issues/2100


https://github.com/user-attachments/assets/96290daf-3b81-4fb1-a3ad-4a0c6dd18a39


