### PR TITLE
bug: dialogs are not centered by default

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -121,6 +121,7 @@
 		font-size: 0.875rem; /* text-sm */
 		color: black;
 		box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1); /* shadow-lg */
+		margin: auto;
 		.dark & {
 			background-color: var(--surface2);
 			color: white;


### PR DESCRIPTION
Quick fix to make dialogs centered by default.  Maybe that's bad, but I'm guessing something changed between tailwind 3 and 4 regarding this.

![image](https://github.com/user-attachments/assets/56530c3e-14aa-40e8-8da0-f7c7f8343993)
