### PR TITLE
bug: move menu up one layer to not get overlap on the home page

### DIFF
--- a/ui/user/src/lib/components/navbar/Menu.svelte
+++ b/ui/user/src/lib/components/navbar/Menu.svelte
@@ -87,7 +87,7 @@
 <div
 	use:tooltip
 	class={twMerge(
-		'default-dialog z-30 flex w-screen flex-col divide-y divide-gray-200 p-6 md:w-96 dark:divide-gray-700',
+		'default-dialog z-40 flex w-screen flex-col divide-y divide-gray-200 p-6 md:w-96 dark:divide-gray-700',
 		classes?.dialog
 	)}
 >


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6718d237-9f00-471b-9b15-c10f971d9269)
