### PR TITLE
fix: editors overflow & profile nav width

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -221,12 +221,6 @@
 		width: 1.25rem; /* w-5 */
 	}
 
-	.button-layout {
-		border-radius: 1.5rem; /* rounded-3xl */
-		border-width: 2px; /* border-2 */
-		padding: 0.5rem 1.25rem; /* px-5 py-2 */
-	}
-
 	.button-colors {
 		background-color: var(--surface3);
 		border-width: 0;
@@ -255,14 +249,30 @@
 	}
 
 	.button-small {
-		composes: button;
 		display: flex;
 		align-items: center;
 		gap: 0.25rem; /* gap-1 */
 		font-size: 0.875rem; /* text-sm */
+
+		border-radius: 1.5rem;
+		padding: 0.5rem 1.25rem;
+		background-color: var(--surface3);
+		border-width: 0;
+		transition-property: color;
+		transition-duration: 200ms;
+
+		&:hover {
+			background-color: rgb(229 231 235 / 0.5);
+		}
+		.dark &:hover {
+			background-color: var(--color-gray-700);
+		}
 	}
 
-	.button-secondary-colors {
+	.button-secondary {
+		border-radius: 1.5rem; /* rounded-3xl */
+		border-width: 2px; /* border-2 */
+		padding: 0.5rem 1.25rem; /* px-5 py-2 */
 		border-color: var(--color-gray-100);
 		&:hover {
 			border-color: var(--color-gray-200);
@@ -277,12 +287,10 @@
 		}
 	}
 
-	.button-secondary {
-		composes: button-layout;
-		composes: button-secondary-colors;
-	}
-
-	.button-primary-colors {
+	.button-primary {
+		border-radius: 1.5rem; /* rounded-3xl */
+		border-width: 2px; /* border-2 */
+		padding: 0.5rem 1.25rem; /* px-5 py-2 */
 		border-color: var(--color-blue);
 		background-color: var(--color-blue);
 		color: white;
@@ -293,11 +301,6 @@
 		.dark & {
 			color: var(--color-gray-50);
 		}
-	}
-
-	.button-primary {
-		composes: button-layout;
-		composes: button-primary-colors;
 	}
 
 	.button-icon-primary {
@@ -337,9 +340,20 @@
 	}
 
 	.list-button-primary {
-		composes: button-icon-primary;
-		padding: 0 !important;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 9999px; /* rounded-full */
+		color: var(--color-gray);
+		padding: 0;
+		&:focus {
+			outline: none;
+		}
+		.dark &:hover {
+			background-color: rgb(55 65 81 / 0.3); /* bg-gray-700/30 */
+		}
 		&:hover {
+			color: var(--color-blue);
 			background-color: transparent;
 		}
 	}

--- a/ui/user/src/lib/components/Editors.svelte
+++ b/ui/user/src/lib/components/Editors.svelte
@@ -85,16 +85,8 @@
 		</div>
 	{/if}
 
-	<div class="relative flex h-full flex-col">
-		<div class="default-scrollbar-thin relative flex-1">
-			<FileEditors
-				{project}
-				{currentThreadID}
-				{onFileChanged}
-				{onInvoke}
-				bind:items={layout.items}
-			/>
-		</div>
+	<div class="default-scrollbar-thin relative flex grow flex-col overflow-y-auto">
+		<FileEditors {project} {currentThreadID} {onFileChanged} {onInvoke} bind:items={layout.items} />
 
 		{#if downloadable}
 			<button

--- a/ui/user/src/lib/components/Obot.svelte
+++ b/ui/user/src/lib/components/Obot.svelte
@@ -101,14 +101,12 @@
 				{/if}
 				<div
 					class={twMerge(
-						'border-surface2 absolute right-0 float-right w-full translate-x-full transform border-4 border-r-0 pt-2 transition-transform duration-300 md:mb-8 md:w-3/5 md:max-w-[calc(100%-320px)] md:min-w-[320px] md:rounded-l-3xl md:ps-5 md:pt-5',
+						'border-surface2 colors-background absolute right-0 float-right w-full translate-x-full transform border-4 border-r-0 pt-2 transition-transform duration-300 md:mb-8 md:w-3/5 md:max-w-[calc(100%-320px)] md:min-w-[320px] md:rounded-l-3xl md:ps-5 md:pt-5',
 						layout.fileEditorOpen && 'relative w-full translate-x-0',
 						!layout.fileEditorOpen && 'w-0!'
 					)}
 				>
-					<div class="colors-background">
-						<Editor {project} {currentThreadID} />
-					</div>
+					<Editor {project} {currentThreadID} />
 				</div>
 			</div>
 		</main>

--- a/ui/user/src/lib/components/navbar/Profile.svelte
+++ b/ui/user/src/lib/components/navbar/Profile.svelte
@@ -13,7 +13,7 @@
 	fixed={responsive.isMobile}
 	classes={{
 		dialog: twMerge(
-			'p-0 md:w-72 overflow-hidden',
+			'p-0 md:w-fit overflow-hidden',
 			responsive.isMobile &&
 				'rounded-none h-[calc(100vh-64px)] left-0 top-[64px] !rounded-none w-full h-full'
 		)
@@ -23,7 +23,7 @@
 		<ProfileIcon />
 	{/snippet}
 	{#snippet header()}
-		<div class="flex w-full items-center justify-between p-4">
+		<div class="flex w-full items-center justify-between gap-8 p-4">
 			<div class="flex items-center gap-3">
 				<ProfileIcon class="size-12" />
 				<div class="flex grow flex-col">

--- a/ui/user/src/lib/components/sidebar/Threads.svelte
+++ b/ui/user/src/lib/components/sidebar/Threads.svelte
@@ -227,7 +227,7 @@
 										break;
 								}
 							}}
-							class="w-0 grow border-none bg-transparent ring-0 outline-hidden dark:text-white"
+							class="mx-2 w-0 grow border-none bg-transparent ring-0 outline-hidden dark:text-white"
 							placeholder="Enter name"
 							type="text"
 						/>
@@ -246,7 +246,7 @@
 							<CircleX class="h-4 w-4" />
 						</button>
 						<button class="list-button-primary" onclick={saveName}>
-							<Save class="h-4 w-4" />
+							<Save class="mr-2 h-4 w-4" />
 						</button>
 					{:else}
 						<DotDotDot


### PR DESCRIPTION
* fixes for the profile nav (md:w-72 not great for long emails, use w-fit instead)
* fix for file editors overflow
* remove `composes` (This is my b, having Cursor translate css for me to speed up converting 😓) (checked: button-primary list-button-primary button-secondary button-small) ex:
<img width="239" alt="Screenshot 2025-03-23 at 4 09 06 AM" src="https://github.com/user-attachments/assets/e280d3b2-301d-468f-9512-6a8484212c75" />
<img width="178" alt="Screenshot 2025-03-23 at 4 08 57 AM" src="https://github.com/user-attachments/assets/40733715-7b34-44e8-b378-f34f6e274b9d" />

