### PR TITLE
fix: display user "created" field as relative to the day

### DIFF
--- a/ui/admin/app/lib/utils/time.ts
+++ b/ui/admin/app/lib/utils/time.ts
@@ -34,25 +34,22 @@ export const timeSince = (date: Date) => {
 };
 
 export const daysSince = (date: Date) => {
-	const seconds = Math.floor(
-		(new Date().getTime() - Math.floor(date.getTime() / 86400000) * 86400000) /
-			1000
-	);
+	const seconds =
+		(Math.floor(new Date().getTime() / 86400000) -
+			Math.floor(date.getTime() / 86400000)) *
+		86400;
 
-	let interval = seconds / 31536000;
+	let interval = Math.floor(seconds / 31536000);
 
-	if (interval > 1) {
-		interval = Math.floor(interval);
+	if (interval >= 1) {
 		return interval + " " + pluralize(interval, "year", "years") + " ago";
 	}
-	interval = seconds / 2592000;
-	if (interval > 1) {
-		interval = Math.floor(interval);
+	interval = Math.floor(seconds / 2592000);
+	if (interval >= 1) {
 		return interval + " " + pluralize(interval, "month", "months") + " ago";
 	}
-	interval = seconds / 86400;
-	if (interval > 1) {
-		interval = Math.floor(interval);
+	interval = Math.floor(seconds / 86400);
+	if (interval >= 1) {
 		return interval + " " + pluralize(interval, "day", "days") + " ago";
 	}
 	return "Today";

--- a/ui/admin/app/routes/_auth.users.tsx
+++ b/ui/admin/app/routes/_auth.users.tsx
@@ -17,7 +17,7 @@ import { UserService } from "~/lib/service/api/userService";
 import { VersionApiService } from "~/lib/service/api/versionApiService";
 import { RouteHandle } from "~/lib/service/routeHandles";
 import { RouteQueryParams, RouteService } from "~/lib/service/routeService";
-import { daysSince, pluralize, timeSince } from "~/lib/utils";
+import { daysSince, pluralize } from "~/lib/utils";
 
 import { DataTable, DataTableFilter } from "~/components/composed/DataTable";
 import { Filters } from "~/components/composed/Filters";
@@ -164,9 +164,7 @@ export default function Users() {
 			columnHelper.display({
 				id: "created",
 				header: "Created",
-				cell: ({ row }) => (
-					<p>{timeSince(new Date(row.original.created))} ago</p>
-				),
+				cell: ({ row }) => <p>{daysSince(new Date(row.original.created))}</p>,
 			}),
 			columnHelper.display({
 				id: "lastActiveDay",


### PR DESCRIPTION
Previously, depending on the time the user was created, it seemed like a user
was active before the user was created. This is because activity is at the day
granularity. This change makes the created field also displayed at the day
granularity.

Signed-off-by: Donnie Adams <donnie@acorn.io>