### PR TITLE
fix: hide copy and edit buttons when message has no content

### DIFF
--- a/ui/user/src/lib/components/messages/Message.svelte
+++ b/ui/user/src/lib/components/messages/Message.svelte
@@ -503,7 +503,7 @@
 					{@render time()}
 				{/if}
 
-				{#if !msg.sent && msg.done && !msg.toolCall && msg.time && !animating}
+				{#if !msg.sent && msg.done && !msg.toolCall && msg.time && content && !animating}
 					<div class="mt-2 ml-2 flex gap-2">
 						<div>
 							<button


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/2292
