### PR TITLE
fix: credentials list popover blocked by dialog

### DIFF
--- a/ui/user/src/lib/actions/popover.svelte.ts
+++ b/ui/user/src/lib/actions/popover.svelte.ts
@@ -14,6 +14,7 @@ interface TooltipOptions {
 	slide?: 'left' | 'up';
 	fixed?: boolean;
 	hover?: boolean;
+	disablePortal?: boolean;
 }
 
 interface Popover {
@@ -139,8 +140,8 @@ export default function popover(initialOptions?: PopoverOptions): Popover {
 		tooltip.style.removeProperty('top');
 
 		tooltip.classList.add(options?.fixed ? 'fixed' : 'absolute');
-		// Always move tooltip to document.body
-		if (tooltip.parentElement !== document.body) {
+		// Always move tooltip to document.body unless disablePortal is enabled
+		if (tooltip.parentElement !== document.body && !options?.disablePortal) {
 			document.body.appendChild(tooltip);
 		}
 

--- a/ui/user/src/lib/components/Obot.svelte
+++ b/ui/user/src/lib/components/Obot.svelte
@@ -106,7 +106,7 @@
 				{/if}
 				<div
 					class={twMerge(
-						'border-surface2 absolute right-0 float-right w-full translate-x-full transform border-4 border-r-0 pt-2 transition-transform duration-300 md:mb-8 md:w-3/5 md:max-w-[calc(100%-320px)] md:min-w-[320px] md:rounded-l-3xl md:ps-5 md:pt-5',
+						'border-surface2 absolute right-0 z-30 float-right w-full translate-x-full transform border-4 border-r-0 pt-2 transition-transform duration-300 md:mb-8 md:w-3/5 md:max-w-[calc(100%-320px)] md:min-w-[320px] md:rounded-l-3xl md:ps-5 md:pt-5',
 						layout.fileEditorOpen && 'relative w-full translate-x-0',
 						!layout.fileEditorOpen && 'w-0'
 					)}

--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -183,7 +183,7 @@
 
 <div
 	id="main-input"
-	class="thread-container scrollbar-none flex w-full grow justify-center overflow-y-auto"
+	class="thread-container default-scrollbar-thin flex w-full grow justify-center overflow-y-auto"
 	bind:this={container}
 	class:scroll-smooth={scrollSmooth}
 	use:stickToBottom={{

--- a/ui/user/src/lib/components/edit/Credentials.svelte
+++ b/ui/user/src/lib/components/edit/Credentials.svelte
@@ -116,7 +116,7 @@
 			</div>
 		{/if}
 		<div
-			use:tooltip
+			use:tooltip={{ disablePortal: true }}
 			class="default-dialog scrollbar-thin z-20 hidden max-h-[500px] overflow-y-auto p-5"
 		>
 			{@render credentialList(credentialsAvailable ?? [], false)}


### PR DESCRIPTION
* add `disablePortal` option in popover action
* fixes credentials list popover being blocked by `dialog` ancestor natively moved to #top-level viewport layer