### PR TITLE
Fix: fix an issue where aborted message is duplicated

### DIFF
--- a/ui/user/src/lib/services/chat/messages.ts
+++ b/ui/user/src/lib/services/chat/messages.ts
@@ -189,6 +189,11 @@ export function buildMessagesFromProgress(
 				item.message = [];
 			}
 		}
+
+		// Drop aborted message if previous message was also aborted
+		if (i > 0 && item.aborted && !item.ignore && messages.messages[i - 1].aborted) {
+			messages.messages[i - 1].ignore = true;
+		}
 	});
 
 	return messages;


### PR DESCRIPTION
This fixed an issue where aborted message is duplicated if you cancel the run. 

https://github.com/obot-platform/obot/issues/1982

