### PR TITLE
Fix: support setting timezone in user ui

### DIFF
--- a/apiclient/types/tasks.go
+++ b/apiclient/types/tasks.go
@@ -41,6 +41,7 @@ type Schedule struct {
 	Minute   int    `json:"minute"`
 	Day      int    `json:"day"`
 	Weekday  int    `json:"weekday"`
+	TimeZone string `json:"timezone"`
 }
 
 type TaskStep struct {

--- a/pkg/api/handlers/cronjob.go
+++ b/pkg/api/handlers/cronjob.go
@@ -133,7 +133,16 @@ func (a *CronJobHandler) Execute(req api.Context) error {
 
 func convertCronJob(cronJob v1.CronJob) types.CronJob {
 	var nextRunAt *time.Time
-	if next, err := gronx.NextTick(cronjob.GetSchedule(cronJob), false); err == nil {
+	schedule, timezone := cronjob.GetScheduleAndTimezone(cronJob)
+	t := time.Now()
+	if timezone != "" {
+		loc, err := time.LoadLocation(timezone)
+		if err == nil {
+			t = t.In(loc)
+		}
+	}
+
+	if next, err := gronx.NextTickAfter(schedule, t, false); err == nil {
 		nextRunAt = &next
 	}
 

--- a/pkg/storage/apis/obot.obot.ai/v1/cronjob.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/cronjob.go
@@ -43,7 +43,7 @@ func (c *CronJob) FieldNames() []string {
 func (*CronJob) GetColumns() [][]string {
 	return [][]string{
 		{"Name", "Name"},
-		{"Workflow", "Spec.Workflow"},
+		{"Workflow", "Spec.WorkflowName"},
 		{"Schedule", "Spec.Schedule"},
 		{"Last Success", "{{ago .Status.LastSuccessfulRunCompleted}}"},
 		{"Last Run", "{{ago .Status.LastRunStartedAt}}"},

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -3630,8 +3630,15 @@ func schema_obot_platform_obot_apiclient_types_Schedule(ref common.ReferenceCall
 							Format:  "int32",
 						},
 					},
+					"timezone": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 				},
-				Required: []string{"interval", "hour", "minute", "day", "weekday"},
+				Required: []string{"interval", "hour", "minute", "day", "weekday", "timezone"},
 			},
 		},
 	}

--- a/ui/user/src/lib/components/tasks/Schedule.svelte
+++ b/ui/user/src/lib/components/tasks/Schedule.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Schedule } from '$lib/services';
 	import Dropdown from '$lib/components/tasks/Dropdown.svelte';
+	import { GlobeIcon } from 'lucide-svelte';
 
 	interface Props {
 		schedule?: Schedule;
@@ -8,6 +9,8 @@
 	}
 
 	let { schedule = $bindable(), readOnly }: Props = $props();
+
+	let defaultTimezone = $state(Intl.DateTimeFormat().resolvedOptions().timeZone);
 </script>
 
 <h4 class="text-base font-medium">Schedule</h4>
@@ -68,6 +71,12 @@
 			}}
 			disabled={readOnly}
 		/>
+		{#if schedule?.timezone && schedule.timezone !== defaultTimezone}
+			<div class="flex items-center gap-1">
+				<GlobeIcon class="text-muted-foreground mr-1 h-4 w-4" />
+				<span class="text-muted-foreground text-sm">{schedule.timezone}</span>
+			</div>
+		{/if}
 	{/if}
 
 	{#if schedule?.interval === 'weekly'}
@@ -89,6 +98,12 @@
 			}}
 			disabled={readOnly}
 		/>
+		{#if schedule?.timezone && schedule.timezone !== defaultTimezone}
+			<div class="flex items-center gap-1">
+				<GlobeIcon class="text-muted-foreground mr-1 h-4 w-4" />
+				<span class="text-muted-foreground text-sm">{schedule.timezone}</span>
+			</div>
+		{/if}
 	{/if}
 
 	{#if schedule?.interval === 'monthly'}
@@ -111,5 +126,11 @@
 			}}
 			disabled={readOnly}
 		/>
+		{#if schedule?.timezone && schedule.timezone !== defaultTimezone}
+			<div class="flex items-center gap-1">
+				<GlobeIcon class="text-muted-foreground mr-1 h-4 w-4" />
+				<span class="text-muted-foreground text-sm">{schedule.timezone}</span>
+			</div>
+		{/if}
 	{/if}
 </div>

--- a/ui/user/src/lib/components/tasks/Type.svelte
+++ b/ui/user/src/lib/components/tasks/Type.svelte
@@ -47,7 +47,8 @@
 				hour: 0,
 				minute: 0,
 				day: 0,
-				weekday: 0
+				weekday: 0,
+				timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
 			};
 			task.webhook = undefined;
 			task.email = undefined;

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -282,6 +282,7 @@ export interface Schedule {
 	minute: number;
 	day: number;
 	weekday: number;
+	timezone: string;
 }
 
 export interface TaskList {


### PR DESCRIPTION
This PR added support to set timezone to current browser's timezone in scheduled task. This is so that the cron schedule runs the task per user's timezone. If user is in the different time zone when viewing the task, ui will display the timezone in order to show the difference. The timezone will be reset once user change the selection. 

https://github.com/obot-platform/obot/issues/1480