### PR TITLE
Encrypt-run-states

### DIFF
--- a/aws-encryption.yaml
+++ b/aws-encryption.yaml
@@ -3,9 +3,12 @@ kind: EncryptionConfiguration
 resources:
   - resources:
       - credentials
+      - runstates.obot.obot.ai
     providers:
       - kms:
           apiVersion: v2
           name: aws-kms
           endpoint: unix:///tmp/aws-cred-socket.sock
           timeout: 3s
+      - identity: {} # this fallback allows reading unencrypted secrets;
+        # for example, during initial migration

--- a/azure-encryption.yaml
+++ b/azure-encryption.yaml
@@ -3,8 +3,11 @@ kind: EncryptionConfiguration
 resources:
   - resources:
       - credentials
+      - runstates.obot.obot.ai
     providers:
       - kms:
           apiVersion: v2
           name: azure-kms
           endpoint: unix:///tmp/azure-cred-socket.sock
+      - identity: {} # this fallback allows reading unencrypted secrets;
+        # for example, during initial migration

--- a/gcp-encryption.yaml
+++ b/gcp-encryption.yaml
@@ -3,8 +3,11 @@ kind: EncryptionConfiguration
 resources:
   - resources:
       - credentials
+      - runstates.obot.obot.ai
     providers:
       - kms:
           apiVersion: v2
           name: google-cloud-kms
           endpoint: unix:///tmp/gcp-cred-socket.sock
+      - identity: {} # this fallback allows reading unencrypted secrets;
+        # for example, during initial migration

--- a/pkg/credstores/credstore.go
+++ b/pkg/credstores/credstore.go
@@ -1,226 +1,23 @@
 package credstores
 
 import (
-	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/gptscript-ai/gptscript/pkg/input"
 	"github.com/gptscript-ai/gptscript/pkg/loader"
-	"github.com/obot-platform/obot/logger"
 )
 
-type Options struct {
-	AWSKMSKeyARN         string
-	GCPKMSKeyURI         string
-	AzureKeyVaultName    string
-	AzureKeyName         string
-	AzureKeyVersion      string
-	EncryptionProvider   string
-	EncryptionConfigFile string
-}
-
-func (o *Options) Validate() error {
-	switch strings.ToLower(o.EncryptionProvider) {
-	case "aws":
-		if o.AWSKMSKeyARN == "" {
-			return fmt.Errorf("missing AWS KMS key ARN")
-		}
-		o.EncryptionConfigFile = "/aws-encryption.yaml"
-	case "gcp":
-		if o.GCPKMSKeyURI == "" {
-			return fmt.Errorf("missing GCP KMS key URI")
-		}
-		o.EncryptionConfigFile = "/gcp-encryption.yaml"
-	case "azure":
-		if o.AzureKeyVaultName == "" || o.AzureKeyName == "" || o.AzureKeyVersion == "" {
-			return fmt.Errorf("missing Azure Key Vault configuration")
-		}
-		o.EncryptionConfigFile = "/azure-encryption.yaml"
-	case "custom":
-		if o.EncryptionConfigFile == "" {
-			return fmt.Errorf("missing custom encryption config file")
-		}
-	case "none", "":
-	default:
-		return fmt.Errorf("invalid encryption provider %s", o.EncryptionProvider)
-	}
-
-	return nil
-}
-
-var log = logger.Package()
-
-func Init(ctx context.Context, toolRegistries []string, dsn string, opts Options) (string, []string, error) {
-	if err := opts.Validate(); err != nil {
-		return "", nil, err
-	}
-
-	// Set up encryption provider
-	switch strings.ToLower(opts.EncryptionProvider) {
-	case "aws":
-		if err := setUpAWSKMS(ctx, opts.AWSKMSKeyARN, opts.EncryptionConfigFile); err != nil {
-			return "", nil, fmt.Errorf("failed to setup AWS KMS: %w", err)
-		}
-	case "gcp":
-		if err := setUpGoogleKMS(ctx, opts.GCPKMSKeyURI, opts.EncryptionConfigFile); err != nil {
-			return "", nil, fmt.Errorf("failed to setup Google Cloud KMS: %w", err)
-		}
-	case "azure":
-		if err := setUpAzureKeyVault(ctx, opts.AzureKeyVaultName, opts.AzureKeyName, opts.AzureKeyVersion, opts.EncryptionConfigFile); err != nil {
-			return "", nil, fmt.Errorf("failed to setup Azure Key Vault: %w", err)
-		}
-	}
-
-	if opts.EncryptionConfigFile != "" {
-		log.Infof("Credstore: Using encryption config file: %s", opts.EncryptionConfigFile)
-	} else {
-		log.Warnf("Credstore: No encryption config file provided, using unencrypted storage")
-	}
-
+func Init(toolRegistries []string, dsn, encryptionConfigFile string) (string, []string, error) {
 	// Set up database
 	switch {
 	case strings.HasPrefix(dsn, "sqlite://"):
-		return setUpSQLite(toolRegistries, dsn, opts.EncryptionConfigFile)
+		return setUpSQLite(toolRegistries, dsn, encryptionConfigFile)
 	case strings.HasPrefix(dsn, "postgres://"):
-		return setUpPostgres(toolRegistries, dsn, opts.EncryptionConfigFile)
+		return setUpPostgres(toolRegistries, dsn, encryptionConfigFile)
 	default:
 		return "", nil, fmt.Errorf("unsupported database for credentials %s", strings.Split(dsn, "://")[0])
 	}
-}
-
-func setUpAzureKeyVault(ctx context.Context, keyvaultName, keyName, keyVersion, configFile string) error {
-	if keyvaultName == "" || keyName == "" || keyVersion == "" {
-		return fmt.Errorf("missing Azure Key Vault configuration")
-	}
-
-	if err := os.Setenv("GPTSCRIPT_ENCRYPTION_CONFIG_FILE", configFile); err != nil {
-		return fmt.Errorf("failed to set GPTSCRIPT_ENCRYPTION_CONFIG_FILE: %w", err)
-	}
-
-	if err := os.WriteFile("/tmp/azure.json", []byte(`{"useManagedIdentityExtension": true}`), 0600); err != nil {
-		return fmt.Errorf("failed to write Azure config file: %w", err)
-	}
-
-	cmd := exec.CommandContext(ctx,
-		"azure-encryption-provider",
-		"--config-file-path=/tmp/azure.json",
-		"--listen-addr=unix:///tmp/azure-cred-socket.sock",
-		"--keyvault-name="+keyvaultName,
-		"--key-name="+keyName,
-		"--key-version="+keyVersion,
-		"--healthz-port=22223")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	go func() {
-		err := cmd.Wait()
-		select {
-		case <-ctx.Done():
-			// ignore error if we are shutting down
-		default:
-			log.Fatalf("azure-encryption-provider exited: %v", err)
-		}
-	}()
-
-	return nil
-}
-
-func setUpGoogleKMS(ctx context.Context, kmsKeyURI, configFile string) error {
-	if kmsKeyURI == "" {
-		return fmt.Errorf("missing GCP KMS key URI")
-	}
-
-	if err := os.Setenv("GPTSCRIPT_ENCRYPTION_CONFIG_FILE", configFile); err != nil {
-		return fmt.Errorf("failed to set GPTSCRIPT_ENCRYPTION_CONFIG_FILE: %w", err)
-	}
-
-	cmd := exec.CommandContext(ctx,
-		"gcp-encryption-provider",
-		"--logtostderr",
-		"--path-to-unix-socket=/tmp/gcp-cred-socket.sock",
-		"--healthz-port=22222",
-		"--key-uri="+kmsKeyURI)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	go func() {
-		err := cmd.Wait()
-		select {
-		case <-ctx.Done():
-			// ignore error if we are shutting down
-		default:
-			log.Fatalf("gcp-encryption-provider exited: %v", err)
-		}
-	}()
-
-	// Wait for the encryption provider to be ready
-	var successful bool
-	for range 5 {
-		time.Sleep(time.Second)
-
-		resp, err := http.Get("http://localhost:22222/healthz")
-		if err == nil {
-			if resp.StatusCode == http.StatusOK {
-				successful = true
-				break
-			}
-			body, _ := io.ReadAll(resp.Body)
-			log.Errorf("gcp-encryption-provider health check failed: %s", body)
-			_ = resp.Body.Close()
-			return fmt.Errorf("gcp-encryption-provider health check failed: %d", resp.StatusCode)
-		}
-	}
-
-	if !successful {
-		return fmt.Errorf("timed out waiting for gcp-encryption-provider to be ready")
-	}
-
-	return nil
-}
-
-func setUpAWSKMS(ctx context.Context, arn, configFile string) error {
-	if arn == "" {
-		return fmt.Errorf("missing AWS KMS key ARN")
-	}
-
-	if err := os.Setenv("GPTSCRIPT_ENCRYPTION_CONFIG_FILE", configFile); err != nil {
-		return fmt.Errorf("failed to set GPTSCRIPT_ENCRYPTION_CONFIG_FILE: %w", err)
-	}
-
-	region := strings.Split(arn, ":")[3]
-
-	cmd := exec.CommandContext(ctx,
-		"aws-encryption-provider",
-		"--health-port=127.0.0.1:0",
-		"--region="+region,
-		"--key="+arn,
-		"--listen=/tmp/aws-cred-socket.sock")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	go func() {
-		err := cmd.Wait()
-		select {
-		case <-ctx.Done():
-			// ignore error if we are shutting down
-		default:
-			log.Fatalf("aws-encryption-provider exited: %v", err)
-		}
-	}()
-
-	return nil
 }
 
 func setUpPostgres(toolRegistries []string, dsn, encryptionConfigFile string) (string, []string, error) {

--- a/pkg/encryption/encryption.go
+++ b/pkg/encryption/encryption.go
@@ -1,0 +1,214 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/obot-platform/obot/logger"
+)
+
+var log = logger.Package()
+
+type Options struct {
+	AWSKMSKeyARN         string `usage:"The ARN of the AWS KMS key to use for encrypting credential storage. Only used with the AWS encryption provider." env:"OBOT_AWS_KMS_KEY_ARN" name:"aws-kms-key-arn"`
+	GCPKMSKeyURI         string `usage:"The URI of the Google Cloud KMS key to use for encrypting credential storage. Only used with the GCP encryption provider." env:"OBOT_GCP_KMS_KEY_URI" name:"gcp-kms-key-uri"`
+	AzureKeyVaultName    string `usage:"The name of the Azure Key Vault to use for encrypting credential storage. Only used with the Azure encryption provider." env:"OBOT_AZURE_KEY_VAULT_NAME" name:"azure-key-vault-name"`
+	AzureKeyName         string `usage:"The name of the Azure Key Vault key to use for encrypting credential storage. Only used with the Azure encryption provider." env:"OBOT_AZURE_KEY_NAME" name:"azure-key-vault-key-name"`
+	AzureKeyVersion      string `usage:"The version of the Azure Key Vault key to use for encrypting credential storage. Only used with the Azure encryption provider." env:"OBOT_AZURE_KEY_VERSION" name:"azure-key-vault-key-version"`
+	EncryptionProvider   string `usage:"The encryption provider to use. Options are AWS, GCP, None, or Custom. Default is None." default:"None"`
+	EncryptionConfigFile string `usage:"The path to the encryption configuration file. Only used with the Custom encryption provider."`
+}
+
+func (o *Options) Validate() error {
+	switch strings.ToLower(o.EncryptionProvider) {
+	case "aws":
+		if o.AWSKMSKeyARN == "" {
+			return fmt.Errorf("missing AWS KMS key ARN")
+		}
+		o.EncryptionConfigFile = "/aws-encryption.yaml"
+	case "gcp":
+		if o.GCPKMSKeyURI == "" {
+			return fmt.Errorf("missing GCP KMS key URI")
+		}
+		o.EncryptionConfigFile = "/gcp-encryption.yaml"
+	case "azure":
+		if o.AzureKeyVaultName == "" || o.AzureKeyName == "" || o.AzureKeyVersion == "" {
+			return fmt.Errorf("missing Azure Key Vault configuration")
+		}
+		o.EncryptionConfigFile = "/azure-encryption.yaml"
+	case "custom":
+		if o.EncryptionConfigFile == "" {
+			return fmt.Errorf("missing custom encryption config file")
+		}
+	case "none", "":
+	default:
+		return fmt.Errorf("invalid encryption provider %s", o.EncryptionProvider)
+	}
+
+	return nil
+}
+
+func Init(ctx context.Context, opts Options) error {
+	if err := opts.Validate(); err != nil {
+		return err
+	}
+
+	// Set up encryption provider
+	switch strings.ToLower(opts.EncryptionProvider) {
+	case "aws":
+		if err := setUpAWSKMS(ctx, opts.AWSKMSKeyARN, opts.EncryptionConfigFile); err != nil {
+			return fmt.Errorf("failed to setup AWS KMS: %w", err)
+		}
+	case "gcp":
+		if err := setUpGoogleKMS(ctx, opts.GCPKMSKeyURI, opts.EncryptionConfigFile); err != nil {
+			return fmt.Errorf("failed to setup Google Cloud KMS: %w", err)
+		}
+	case "azure":
+		if err := setUpAzureKeyVault(ctx, opts.AzureKeyVaultName, opts.AzureKeyName, opts.AzureKeyVersion, opts.EncryptionConfigFile); err != nil {
+			return fmt.Errorf("failed to setup Azure Key Vault: %w", err)
+		}
+	}
+
+	if opts.EncryptionConfigFile != "" {
+		log.Infof("Encryption: Using encryption config file: %s", opts.EncryptionConfigFile)
+	} else {
+		log.Warnf("Encryption: No encryption config file provided, using unencrypted storage")
+	}
+
+	return nil
+}
+
+func setUpAzureKeyVault(ctx context.Context, keyvaultName, keyName, keyVersion, configFile string) error {
+	if keyvaultName == "" || keyName == "" || keyVersion == "" {
+		return fmt.Errorf("missing Azure Key Vault configuration")
+	}
+
+	if err := os.Setenv("GPTSCRIPT_ENCRYPTION_CONFIG_FILE", configFile); err != nil {
+		return fmt.Errorf("failed to set GPTSCRIPT_ENCRYPTION_CONFIG_FILE: %w", err)
+	}
+
+	if err := os.WriteFile("/tmp/azure.json", []byte(`{"useManagedIdentityExtension": true}`), 0600); err != nil {
+		return fmt.Errorf("failed to write Azure config file: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx,
+		"azure-encryption-provider",
+		"--config-file-path=/tmp/azure.json",
+		"--listen-addr=unix:///tmp/azure-cred-socket.sock",
+		"--keyvault-name="+keyvaultName,
+		"--key-name="+keyName,
+		"--key-version="+keyVersion,
+		"--healthz-port=22223")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() {
+		err := cmd.Wait()
+		select {
+		case <-ctx.Done():
+			// ignore error if we are shutting down
+		default:
+			log.Fatalf("azure-encryption-provider exited: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+func setUpGoogleKMS(ctx context.Context, kmsKeyURI, configFile string) error {
+	if kmsKeyURI == "" {
+		return fmt.Errorf("missing GCP KMS key URI")
+	}
+
+	if err := os.Setenv("GPTSCRIPT_ENCRYPTION_CONFIG_FILE", configFile); err != nil {
+		return fmt.Errorf("failed to set GPTSCRIPT_ENCRYPTION_CONFIG_FILE: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx,
+		"gcp-encryption-provider",
+		"--logtostderr",
+		"--path-to-unix-socket=/tmp/gcp-cred-socket.sock",
+		"--healthz-port=22222",
+		"--key-uri="+kmsKeyURI)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() {
+		err := cmd.Wait()
+		select {
+		case <-ctx.Done():
+			// ignore error if we are shutting down
+		default:
+			log.Fatalf("gcp-encryption-provider exited: %v", err)
+		}
+	}()
+
+	// Wait for the encryption provider to be ready
+	var successful bool
+	for range 5 {
+		time.Sleep(time.Second)
+
+		resp, err := http.Get("http://localhost:22222/healthz")
+		if err == nil {
+			if resp.StatusCode == http.StatusOK {
+				successful = true
+				break
+			}
+			body, _ := io.ReadAll(resp.Body)
+			log.Errorf("gcp-encryption-provider health check failed: %s", body)
+			_ = resp.Body.Close()
+			return fmt.Errorf("gcp-encryption-provider health check failed: %d", resp.StatusCode)
+		}
+	}
+
+	if !successful {
+		return fmt.Errorf("timed out waiting for gcp-encryption-provider to be ready")
+	}
+
+	return nil
+}
+
+func setUpAWSKMS(ctx context.Context, arn, configFile string) error {
+	if arn == "" {
+		return fmt.Errorf("missing AWS KMS key ARN")
+	}
+
+	if err := os.Setenv("GPTSCRIPT_ENCRYPTION_CONFIG_FILE", configFile); err != nil {
+		return fmt.Errorf("failed to set GPTSCRIPT_ENCRYPTION_CONFIG_FILE: %w", err)
+	}
+
+	region := strings.Split(arn, ":")[3]
+
+	cmd := exec.CommandContext(ctx,
+		"aws-encryption-provider",
+		"--health-port=127.0.0.1:0",
+		"--region="+region,
+		"--key="+arn,
+		"--listen=/tmp/aws-cred-socket.sock")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() {
+		err := cmd.Wait()
+		select {
+		case <-ctx.Done():
+			// ignore error if we are shutting down
+		default:
+			log.Fatalf("aws-encryption-provider exited: %v", err)
+		}
+	}()
+
+	return nil
+}

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -2,21 +2,24 @@ package client
 
 import (
 	"github.com/obot-platform/obot/pkg/gateway/db"
+	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
 )
 
 type Client struct {
-	db          *db.DB
-	adminEmails map[string]struct{}
+	db               *db.DB
+	encryptionConfig *encryptionconfig.EncryptionConfiguration
+	adminEmails      map[string]struct{}
 }
 
-func New(db *db.DB, adminEmails []string) *Client {
+func New(db *db.DB, encryptionConfig *encryptionconfig.EncryptionConfiguration, adminEmails []string) *Client {
 	adminEmailsSet := make(map[string]struct{}, len(adminEmails))
 	for _, email := range adminEmails {
 		adminEmailsSet[email] = struct{}{}
 	}
 	return &Client{
-		db:          db,
-		adminEmails: adminEmailsSet,
+		db:               db,
+		encryptionConfig: encryptionConfig,
+		adminEmails:      adminEmailsSet,
 	}
 }
 

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -3,12 +3,13 @@ package client
 import (
 	"github.com/obot-platform/obot/pkg/gateway/db"
 	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
+	"k8s.io/apiserver/pkg/storage/value"
 )
 
 type Client struct {
-	db               *db.DB
-	encryptionConfig *encryptionconfig.EncryptionConfiguration
-	adminEmails      map[string]struct{}
+	db          *db.DB
+	transformer value.Transformer
+	adminEmails map[string]struct{}
 }
 
 func New(db *db.DB, encryptionConfig *encryptionconfig.EncryptionConfiguration, adminEmails []string) *Client {
@@ -16,10 +17,14 @@ func New(db *db.DB, encryptionConfig *encryptionconfig.EncryptionConfiguration, 
 	for _, email := range adminEmails {
 		adminEmailsSet[email] = struct{}{}
 	}
+	var transformer value.Transformer
+	if encryptionConfig != nil {
+		transformer = encryptionConfig.Transformers[gr]
+	}
 	return &Client{
-		db:               db,
-		encryptionConfig: encryptionConfig,
-		adminEmails:      adminEmailsSet,
+		db:          db,
+		transformer: transformer,
+		adminEmails: adminEmailsSet,
 	}
 }
 

--- a/pkg/gateway/client/runstate.go
+++ b/pkg/gateway/client/runstate.go
@@ -70,11 +70,7 @@ func (c *Client) DeleteRunState(ctx context.Context, namespace, name string) err
 }
 
 func (c *Client) encryptRunState(ctx context.Context, runState *types.RunState) error {
-	if c.encryptionConfig == nil {
-		return nil
-	}
-	transformer := c.encryptionConfig.Transformers[gr]
-	if transformer == nil {
+	if c.transformer == nil {
 		return nil
 	}
 
@@ -82,24 +78,20 @@ func (c *Client) encryptRunState(ctx context.Context, runState *types.RunState) 
 		err  error
 		errs []error
 	)
-	if runState.Output, err = transformer.TransformToStorage(ctx, runState.Output, nil); err != nil {
+	if runState.Output, err = c.transformer.TransformToStorage(ctx, runState.Output, nil); err != nil {
 		errs = append(errs, err)
 	}
-	if runState.CallFrame, err = transformer.TransformToStorage(ctx, runState.CallFrame, nil); err != nil {
+	if runState.CallFrame, err = c.transformer.TransformToStorage(ctx, runState.CallFrame, nil); err != nil {
 		errs = append(errs, err)
 	}
-	if runState.ChatState, err = transformer.TransformToStorage(ctx, runState.ChatState, nil); err != nil {
+	if runState.ChatState, err = c.transformer.TransformToStorage(ctx, runState.ChatState, nil); err != nil {
 		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
 }
 
 func (c *Client) decryptRunState(ctx context.Context, runState *types.RunState) error {
-	if c.encryptionConfig == nil {
-		return nil
-	}
-	transformer := c.encryptionConfig.Transformers[gr]
-	if transformer == nil {
+	if c.transformer == nil {
 		return nil
 	}
 
@@ -107,15 +99,15 @@ func (c *Client) decryptRunState(ctx context.Context, runState *types.RunState) 
 		errs []error
 		err  error
 	)
-	runState.Output, _, err = transformer.TransformFromStorage(ctx, runState.Output, nil)
+	runState.Output, _, err = c.transformer.TransformFromStorage(ctx, runState.Output, nil)
 	if err != nil {
 		errs = append(errs, err)
 	}
-	runState.CallFrame, _, err = transformer.TransformFromStorage(ctx, runState.CallFrame, nil)
+	runState.CallFrame, _, err = c.transformer.TransformFromStorage(ctx, runState.CallFrame, nil)
 	if err != nil {
 		errs = append(errs, err)
 	}
-	runState.ChatState, _, err = transformer.TransformFromStorage(ctx, runState.ChatState, nil)
+	runState.ChatState, _, err = c.transformer.TransformFromStorage(ctx, runState.ChatState, nil)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/pkg/gateway/client/runstate.go
+++ b/pkg/gateway/client/runstate.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"errors"
 
@@ -8,41 +9,62 @@ import (
 	"gorm.io/gorm"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/storage/value"
+)
+
+var (
+	encryptionSuffix = []byte(":OBOTENCRYPTED")
+	gr               = schema.GroupResource{
+		Group:    "obot.obot.ai",
+		Resource: "runstates",
+	}
 )
 
 func (c *Client) RunState(ctx context.Context, namespace, name string) (*types.RunState, error) {
 	r := new(types.RunState)
-	if err := c.db.WithContext(ctx).Where("name = ?", name).Where("namespace = ?", namespace).First(r).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
-		return r, err
+	if err := c.db.WithContext(ctx).Where("name = ?", name).Where("namespace = ?", namespace).First(r).Error; err == nil {
+		if transformer, ok := c.encryptionConfig.Transformers[gr]; ok {
+			if err := decryptRunState(ctx, r, transformer); err != nil {
+				return nil, err
+			}
+		}
+		return r, nil
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
 	}
-	return nil, apierrors.NewNotFound(schema.GroupResource{
-		Group:    "obot.obot.ai",
-		Resource: "runstates",
-	}, name)
+	return nil, apierrors.NewNotFound(gr, name)
 }
 
 func (c *Client) CreateRunState(ctx context.Context, runState *types.RunState) error {
+	// Copy the run state to avoid modifying the original
+	r := runState
+	if transformer, ok := c.encryptionConfig.Transformers[gr]; ok {
+		if err := encryptRunState(ctx, r, transformer); err != nil {
+			return err
+		}
+	}
 	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Get the run state. If it exists, return an already exists error, otherwise create it.
 		// We do this because trying to catch the gorm.ErrDuplicateKey doesn't work.
-		if err := tx.Where("name = ?", runState.Name).Where("namespace = ?", runState.Namespace).First(runState).Error; err == nil {
-			return apierrors.NewAlreadyExists(schema.GroupResource{
-				Group:    "obot.obot.ai",
-				Resource: "runstates",
-			}, runState.Name)
+		if err := tx.Where("name = ?", runState.Name).Where("namespace = ?", runState.Namespace).First(r).Error; err == nil {
+			return apierrors.NewAlreadyExists(gr, runState.Name)
 		}
-		return tx.Create(runState).Error
+		return tx.Create(r).Error
 	})
 }
 
 func (c *Client) UpdateRunState(ctx context.Context, runState *types.RunState) error {
-	if err := c.db.WithContext(ctx).Save(runState).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+	// Copy the run state to avoid modifying the original
+	r := runState
+	if transformer, ok := c.encryptionConfig.Transformers[gr]; ok {
+		if err := encryptRunState(ctx, r, transformer); err != nil {
+			return err
+		}
+	}
+	if err := c.db.WithContext(ctx).Save(r).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
 		return err
 	}
-	return apierrors.NewNotFound(schema.GroupResource{
-		Group:    "obot.obot.ai",
-		Resource: "runstates",
-	}, runState.Name)
+	return apierrors.NewNotFound(gr, runState.Name)
 }
 
 func (c *Client) DeleteRunState(ctx context.Context, namespace, name string) error {
@@ -50,4 +72,61 @@ func (c *Client) DeleteRunState(ctx context.Context, namespace, name string) err
 		return err
 	}
 	return nil
+}
+
+func encryptRunState(ctx context.Context, runState *types.RunState, transformer value.Transformer) error {
+	var (
+		b    []byte
+		err  error
+		errs []error
+	)
+	if transformer != nil {
+		if b, err = transformer.TransformToStorage(ctx, runState.Output, nil); err != nil {
+			errs = append(errs, err)
+		} else {
+			runState.Output = append(b, encryptionSuffix...)
+		}
+		if b, err = transformer.TransformToStorage(ctx, runState.CallFrame, nil); err != nil {
+			errs = append(errs, err)
+		} else {
+			runState.CallFrame = append(b, encryptionSuffix...)
+		}
+		if b, err = transformer.TransformToStorage(ctx, runState.ChatState, nil); err != nil {
+			errs = append(errs, err)
+		} else {
+			runState.ChatState = append(b, encryptionSuffix...)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func decryptRunState(ctx context.Context, runState *types.RunState, transformer value.Transformer) error {
+	var (
+		b    []byte
+		ok   bool
+		errs []error
+		err  error
+	)
+	if transformer != nil {
+		if b, ok = bytes.CutSuffix(runState.Output, encryptionSuffix); ok {
+			runState.Output, _, err = transformer.TransformFromStorage(ctx, b, nil)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+		if b, ok = bytes.CutSuffix(runState.CallFrame, encryptionSuffix); ok {
+			runState.CallFrame, _, err = transformer.TransformFromStorage(ctx, b, nil)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+		if b, ok = bytes.CutSuffix(runState.ChatState, encryptionSuffix); ok {
+			runState.ChatState, _, err = transformer.TransformFromStorage(ctx, b, nil)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	return errors.Join(errs...)
 }

--- a/pkg/gateway/client/runstate.go
+++ b/pkg/gateway/client/runstate.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"errors"
 
@@ -9,12 +8,10 @@ import (
 	"gorm.io/gorm"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apiserver/pkg/storage/value"
 )
 
 var (
-	encryptionSuffix = []byte(":OBOTENCRYPTED")
-	gr               = schema.GroupResource{
+	gr = schema.GroupResource{
 		Group:    "obot.obot.ai",
 		Resource: "runstates",
 	}
@@ -23,10 +20,8 @@ var (
 func (c *Client) RunState(ctx context.Context, namespace, name string) (*types.RunState, error) {
 	r := new(types.RunState)
 	if err := c.db.WithContext(ctx).Where("name = ?", name).Where("namespace = ?", namespace).First(r).Error; err == nil {
-		if transformer, ok := c.encryptionConfig.Transformers[gr]; ok {
-			if err := decryptRunState(ctx, r, transformer); err != nil {
-				return nil, err
-			}
+		if err := c.decryptRunState(ctx, r); err != nil {
+			return nil, err
 		}
 		return r, nil
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -38,11 +33,11 @@ func (c *Client) RunState(ctx context.Context, namespace, name string) (*types.R
 func (c *Client) CreateRunState(ctx context.Context, runState *types.RunState) error {
 	// Copy the run state to avoid modifying the original
 	r := runState
-	if transformer, ok := c.encryptionConfig.Transformers[gr]; ok {
-		if err := encryptRunState(ctx, r, transformer); err != nil {
-			return err
-		}
+
+	if err := c.encryptRunState(ctx, r); err != nil {
+		return err
 	}
+
 	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Get the run state. If it exists, return an already exists error, otherwise create it.
 		// We do this because trying to catch the gorm.ErrDuplicateKey doesn't work.
@@ -56,11 +51,11 @@ func (c *Client) CreateRunState(ctx context.Context, runState *types.RunState) e
 func (c *Client) UpdateRunState(ctx context.Context, runState *types.RunState) error {
 	// Copy the run state to avoid modifying the original
 	r := runState
-	if transformer, ok := c.encryptionConfig.Transformers[gr]; ok {
-		if err := encryptRunState(ctx, r, transformer); err != nil {
-			return err
-		}
+
+	if err := c.encryptRunState(ctx, r); err != nil {
+		return err
 	}
+
 	if err := c.db.WithContext(ctx).Save(r).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
 		return err
 	}
@@ -74,58 +69,55 @@ func (c *Client) DeleteRunState(ctx context.Context, namespace, name string) err
 	return nil
 }
 
-func encryptRunState(ctx context.Context, runState *types.RunState, transformer value.Transformer) error {
+func (c *Client) encryptRunState(ctx context.Context, runState *types.RunState) error {
+	if c.encryptionConfig == nil {
+		return nil
+	}
+	transformer := c.encryptionConfig.Transformers[gr]
+	if transformer == nil {
+		return nil
+	}
+
 	var (
-		b    []byte
 		err  error
 		errs []error
 	)
-	if transformer != nil {
-		if b, err = transformer.TransformToStorage(ctx, runState.Output, nil); err != nil {
-			errs = append(errs, err)
-		} else {
-			runState.Output = append(b, encryptionSuffix...)
-		}
-		if b, err = transformer.TransformToStorage(ctx, runState.CallFrame, nil); err != nil {
-			errs = append(errs, err)
-		} else {
-			runState.CallFrame = append(b, encryptionSuffix...)
-		}
-		if b, err = transformer.TransformToStorage(ctx, runState.ChatState, nil); err != nil {
-			errs = append(errs, err)
-		} else {
-			runState.ChatState = append(b, encryptionSuffix...)
-		}
+	if runState.Output, err = transformer.TransformToStorage(ctx, runState.Output, nil); err != nil {
+		errs = append(errs, err)
+	}
+	if runState.CallFrame, err = transformer.TransformToStorage(ctx, runState.CallFrame, nil); err != nil {
+		errs = append(errs, err)
+	}
+	if runState.ChatState, err = transformer.TransformToStorage(ctx, runState.ChatState, nil); err != nil {
+		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
 }
 
-func decryptRunState(ctx context.Context, runState *types.RunState, transformer value.Transformer) error {
+func (c *Client) decryptRunState(ctx context.Context, runState *types.RunState) error {
+	if c.encryptionConfig == nil {
+		return nil
+	}
+	transformer := c.encryptionConfig.Transformers[gr]
+	if transformer == nil {
+		return nil
+	}
+
 	var (
-		b    []byte
-		ok   bool
 		errs []error
 		err  error
 	)
-	if transformer != nil {
-		if b, ok = bytes.CutSuffix(runState.Output, encryptionSuffix); ok {
-			runState.Output, _, err = transformer.TransformFromStorage(ctx, b, nil)
-			if err != nil {
-				errs = append(errs, err)
-			}
-		}
-		if b, ok = bytes.CutSuffix(runState.CallFrame, encryptionSuffix); ok {
-			runState.CallFrame, _, err = transformer.TransformFromStorage(ctx, b, nil)
-			if err != nil {
-				errs = append(errs, err)
-			}
-		}
-		if b, ok = bytes.CutSuffix(runState.ChatState, encryptionSuffix); ok {
-			runState.ChatState, _, err = transformer.TransformFromStorage(ctx, b, nil)
-			if err != nil {
-				errs = append(errs, err)
-			}
-		}
+	runState.Output, _, err = transformer.TransformFromStorage(ctx, runState.Output, nil)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	runState.CallFrame, _, err = transformer.TransformFromStorage(ctx, runState.CallFrame, nil)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	runState.ChatState, _, err = transformer.TransformFromStorage(ctx, runState.ChatState, nil)
+	if err != nil {
+		errs = append(errs, err)
 	}
 
 	return errors.Join(errs...)

--- a/pkg/gateway/server/server.go
+++ b/pkg/gateway/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/obot-platform/obot/pkg/gateway/db"
 	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
 	"github.com/obot-platform/obot/pkg/jwt"
+	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
 )
 
 type Options struct {
@@ -25,10 +26,10 @@ type Server struct {
 	gptClient      *gptscript.GPTScript
 }
 
-func New(ctx context.Context, g *gptscript.GPTScript, db *db.DB, tokenService *jwt.TokenService, modelProviderDispatcher *dispatcher.Dispatcher, adminEmails []string, opts Options) (*Server, error) {
+func New(ctx context.Context, g *gptscript.GPTScript, db *db.DB, tokenService *jwt.TokenService, modelProviderDispatcher *dispatcher.Dispatcher, encryptionConfig *encryptionconfig.EncryptionConfiguration, adminEmails []string, opts Options) (*Server, error) {
 	s := &Server{
 		db:           db,
-		client:       client.New(db, adminEmails),
+		client:       client.New(db, encryptionConfig, adminEmails),
 		baseURL:      opts.Hostname,
 		uiURL:        opts.UIHostname,
 		tokenService: tokenService,

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -266,7 +266,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		return nil, err
 	}
 
-	if err := encryption.Init(ctx, encryption.Options(config.EncryptionConfig)); err != nil {
+	encryptionConfig, err := encryption.Init(ctx, encryption.Options(config.EncryptionConfig))
+	if err != nil {
 		return nil, err
 	}
 
@@ -354,7 +355,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 
 	var (
 		tokenServer   = &jwt.TokenService{}
-		gatewayClient = client.New(gatewayDB, config.AuthAdminEmails)
+		gatewayClient = client.New(gatewayDB, encryptionConfig, config.AuthAdminEmails)
 		events        = events.NewEmitter(storageClient, gatewayClient)
 		invoker       = invoke.NewInvoker(
 			storageClient,
@@ -381,6 +382,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		gatewayDB,
 		tokenServer,
 		providerDispatcher,
+		encryptionConfig,
 		config.AuthAdminEmails,
 		gserver.Options(config.GatewayConfig),
 	)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -61,9 +61,9 @@ import (
 )
 
 type (
-	GatewayConfig gserver.Options
-	GeminiConfig  gemini.Config
-	AuditConfig   audit.Options
+	GatewayConfig    gserver.Options
+	GeminiConfig     gemini.Config
+	AuditConfig      audit.Options
 	EncryptionConfig encryption.Options
 )
 
@@ -95,9 +95,9 @@ type Config struct {
 	GeminiConfig
 	GatewayConfig
 	EncryptionConfig
-	services.Config
 	OtelOptions
 	AuditConfig
+	services.Config
 }
 
 type Services struct {

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/obot-platform/obot/pkg/api/server/audit"
 	"github.com/obot-platform/obot/pkg/bootstrap"
 	"github.com/obot-platform/obot/pkg/credstores"
+	"github.com/obot-platform/obot/pkg/encryption"
 	"github.com/obot-platform/obot/pkg/events"
 	"github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/gateway/db"
@@ -63,6 +64,7 @@ type (
 	GatewayConfig gserver.Options
 	GeminiConfig  gemini.Config
 	AuditConfig   audit.Options
+	EncryptionConfig encryption.Options
 )
 
 type Config struct {
@@ -73,13 +75,6 @@ type Config struct {
 	ToolRegistries             []string `usage:"The remote tool references to the set of tool registries to use" default:"github.com/obot-platform/tools" split:"true"`
 	WorkspaceProviderType      string   `usage:"The type of workspace provider to use for non-knowledge workspaces" default:"directory" env:"OBOT_WORKSPACE_PROVIDER_TYPE"`
 	HelperModel                string   `usage:"The model used to generate names and descriptions" default:"gpt-4o-mini"`
-	AWSKMSKeyARN               string   `usage:"The ARN of the AWS KMS key to use for encrypting credential storage. Only used with the AWS encryption provider." env:"OBOT_AWS_KMS_KEY_ARN" name:"aws-kms-key-arn"`
-	GCPKMSKeyURI               string   `usage:"The URI of the Google Cloud KMS key to use for encrypting credential storage. Only used with the GCP encryption provider." env:"OBOT_GCP_KMS_KEY_URI" name:"gcp-kms-key-uri"`
-	AzureKeyVaultName          string   `usage:"The name of the Azure Key Vault to use for encrypting credential storage. Only used with the Azure encryption provider." env:"OBOT_AZURE_KEY_VAULT_NAME" name:"azure-key-vault-name"`
-	AzureKeyName               string   `usage:"The name of the Azure Key Vault key to use for encrypting credential storage. Only used with the Azure encryption provider." env:"OBOT_AZURE_KEY_NAME" name:"azure-key-vault-key-name"`
-	AzureKeyVersion            string   `usage:"The version of the Azure Key Vault key to use for encrypting credential storage. Only used with the Azure encryption provider." env:"OBOT_AZURE_KEY_VERSION" name:"azure-key-vault-key-version"`
-	EncryptionProvider         string   `usage:"The encryption provider to use. Options are AWS, GCP, None, or Custom. Default is None." default:"None"`
-	EncryptionConfigFile       string   `usage:"The path to the encryption configuration file. Only used with the Custom encryption provider."`
 	EmailServerName            string   `usage:"The name of the email server to display for email receivers"`
 	EnableSMTPServer           bool     `usage:"Enable SMTP server to receive emails" default:"false" env:"OBOT_ENABLE_SMTP_SERVER"`
 	Docker                     bool     `usage:"Enable Docker support" default:"false" env:"OBOT_DOCKER"`
@@ -99,6 +94,7 @@ type Config struct {
 
 	GeminiConfig
 	GatewayConfig
+	EncryptionConfig
 	services.Config
 	OtelOptions
 	AuditConfig
@@ -270,15 +266,11 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		return nil, err
 	}
 
-	credStore, credStoreEnv, err := credstores.Init(ctx, config.ToolRegistries, config.DSN, credstores.Options{
-		AWSKMSKeyARN:         config.AWSKMSKeyARN,
-		GCPKMSKeyURI:         config.GCPKMSKeyURI,
-		AzureKeyVaultName:    config.AzureKeyVaultName,
-		AzureKeyName:         config.AzureKeyName,
-		AzureKeyVersion:      config.AzureKeyVersion,
-		EncryptionProvider:   config.EncryptionProvider,
-		EncryptionConfigFile: config.EncryptionConfigFile,
-	})
+	if err := encryption.Init(ctx, encryption.Options(config.EncryptionConfig)); err != nil {
+		return nil, err
+	}
+
+	credStore, credStoreEnv, err := credstores.Init(config.ToolRegistries, config.DSN, config.EncryptionConfigFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
RunStates can have some personally identifiable information in them depending on
tool calls. This change encrypts the sensitive parts of the run state object.

Signed-off-by: Donnie Adams <donnie@acorn.io>