### PR TITLE
enhance: add rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/gptscript-ai/cmd v0.0.0-20250324222528-f16f18548238
 	github.com/gptscript-ai/go-gptscript v0.9.6-0.20250331192455-415de950d72d
 	github.com/gptscript-ai/gptscript v0.9.6-0.20250328194144-ce3b7262ed0e
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/mhale/smtpd v0.8.3
 	github.com/obot-platform/kinm v0.0.0-20250328185534-d9c9de49cc20
@@ -34,6 +35,7 @@ require (
 	github.com/pterm/pterm v0.12.80
 	github.com/rs/cors v1.11.1
 	github.com/sendgrid/sendgrid-go v3.16.0+incompatible
+	github.com/sethvargo/go-limiter v1.0.0
 	github.com/spf13/cobra v1.8.1
 	github.com/tidwall/gjson v1.18.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0
@@ -163,7 +165,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -557,6 +557,8 @@ github.com/sendgrid/sendgrid-go v3.16.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdR
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/sethvargo/go-limiter v1.0.0 h1:JqW13eWEMn0VFv86OKn8wiYJY/m250WoXdrjRV0kLe4=
+github.com/sethvargo/go-limiter v1.0.0/go.mod h1:01b6tW25Ap+MeLYBuD4aHunMrJoNO5PVUFdS9rac3II=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/pkg/api/ratelimit/authgroup.go
+++ b/pkg/api/ratelimit/authgroup.go
@@ -1,0 +1,214 @@
+// Package ratelimit implements HTTP middleware for rate limiting API requests
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/sethvargo/go-limiter/httplimit"
+	"github.com/sethvargo/go-limiter/memorystore"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// Config contains all configuration options for the rate limiter middleware.
+// These values can be set via environment variables or command-line flags.
+type Config struct {
+	// UnauthenticatedRateLimit is the number of requests allowed for unauthenticated users
+	UnauthenticatedRateLimit int `usage:"Rate limit for unauthenticated requests (req/sec)" default:"200"`
+
+	// AuthenticatedRateLimit is the number of requests allowed for authenticated non-admin users
+	AuthenticatedRateLimit int `usage:"Rate limit for authenticated non-admin requests (req/sec)" default:"400"`
+
+	// UserCacheTTL controls how long authenticated user information is cached
+	UserCacheTTL time.Duration `usage:"How long to cache authenticated user information" default:"1hr"`
+
+	// UserCacheCapacity limits the number of authenticated users to store in memory
+	UserCacheCapacity int `usage:"Maximum number of users to keep in the auth cache" default:"1000"`
+}
+
+// AuthGroupMiddleware implements the Middleware interface with full rate limiting
+// functionality for both authenticated and unauthenticated users.
+// It uses expirable LRU cache to efficiently track authenticated users
+// and different rate limits based on authentication status.
+type AuthGroupMiddleware struct {
+	// unauthenticatedMiddleware applies unauthenticated rate limits by IP address
+	unauthenticatedMiddleware *httplimit.Middleware
+
+	// authenticatedMiddleware applies authenticated rate limits by cached user ID
+	authenticatedMiddleware *httplimit.Middleware
+
+	// userCache maps recently used credential hashes to users.
+	userCache *expirable.LRU[string, *User]
+
+	// credSources is a set of previously known credential sources
+	// used to extract credentials from request headers and cookies.
+	credSources *sync.Map
+}
+
+// NewAuthGroupMiddleware creates a new rate limiting middleware based on the provided configuration.
+// It sets up separate limiters for authenticated and unauthenticated requests,
+// and initializes the expirable cache for tracking authenticated users.
+func NewAuthGroupMiddleware(config Config) (*AuthGroupMiddleware, error) {
+	unauthenticatedStore, err := memorystore.New(&memorystore.Config{
+		Tokens:   uint64(config.UnauthenticatedRateLimit),
+		Interval: time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create unauthenticated store: %w", err)
+	}
+	unauthenticatedMiddleware, err := httplimit.NewMiddleware(
+		unauthenticatedStore,
+		httplimit.IPKeyFunc(
+			"X-Forwarded-For",
+			"X-Real-IP",
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create unauthenticated middleware: %w", err)
+	}
+
+	authenticatedStore, err := memorystore.New(&memorystore.Config{
+		Tokens:   uint64(config.AuthenticatedRateLimit),
+		Interval: time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authenticated store: %w", err)
+	}
+	authenticatedMiddleware, err := httplimit.NewMiddleware(
+		authenticatedStore,
+		getAuthorizedIDKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authenticated middleware: %w", err)
+	}
+
+	return &AuthGroupMiddleware{
+		unauthenticatedMiddleware: unauthenticatedMiddleware,
+		authenticatedMiddleware:   authenticatedMiddleware,
+		userCache: expirable.NewLRU[string, *User](
+			config.UserCacheCapacity,
+			nil,
+			config.UserCacheTTL,
+		),
+		credSources: &sync.Map{},
+	}, nil
+}
+
+// registerCredSource registers a new credential source to check on requests.
+// This is an internal method called lazily when users are registered,
+// ensuring that credential sources are only tracked when actually used.
+func (m *AuthGroupMiddleware) registerCredSource(source CredSource) error {
+	switch source.Type {
+	case CredSourceTypeHeader, CredSourceTypeCookie:
+	default:
+		return fmt.Errorf("unsupported credential source type: %s", source.Type)
+	}
+
+	if source.Name == "" {
+		return fmt.Errorf("credential source name cannot be empty")
+	}
+
+	// Store this credential source for checking on future requests
+	m.credSources.LoadOrStore(source, nil)
+
+	return nil
+}
+
+// RegisterUser adds a user to the middleware's cache based on credential info.
+// It automatically registers the credential source that was used for authentication,
+// so future requests with the same credential can be properly identified.
+func (m *AuthGroupMiddleware) RegisterUser(u user.Info) error {
+	// Skip invalid or anonymous users
+	if u == nil ||
+		u.GetUID() == "" ||
+		u.GetUID() == "anonymous" {
+		return nil
+	}
+
+	// Extract credential info from user.Extra
+	credHash, source, ok := getUserCredInfo(u)
+	if !ok {
+		return nil
+	}
+
+	// Create and cache the user
+	user := &User{
+		ID:      u.GetUID(),
+		IsAdmin: slices.Contains(u.GetGroups(), authz.AdminGroup),
+	}
+
+	// Lazily register the credential source used to authenticate this user
+	if err := m.registerCredSource(source); err != nil {
+		return fmt.Errorf("failed to register credential source: %w", err)
+	}
+
+	// Add user to cache with configured TTL for automatic expiration
+	m.userCache.Add(credHash, user)
+
+	return nil
+}
+
+type authorizedIDCtxKey struct{}
+
+func contextWithAuthorizedID(ctx context.Context, authorizedID string) context.Context {
+	return context.WithValue(ctx, authorizedIDCtxKey{}, authorizedID)
+}
+
+func getAuthorizedIDKey(r *http.Request) (string, error) {
+	authorizedID, ok := r.Context().Value(authorizedIDCtxKey{}).(string)
+	if !ok || authorizedID == "" {
+		return "", fmt.Errorf("authorizedID not found in context")
+	}
+	return authorizedID, nil
+}
+
+func (m *AuthGroupMiddleware) Limit(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Find authenticated user from request credentials
+		cachedUser := m.getCachedUser(r)
+		if cachedUser == nil || cachedUser.ID == "" {
+			// Apply unauthenticated rate limits to the request by IP
+			m.unauthenticatedMiddleware.Handle(next).ServeHTTP(w, r)
+			return
+		}
+
+		if !cachedUser.IsAdmin {
+			// Apply authenticated rate limits to the request by user ID
+			r = r.WithContext(contextWithAuthorizedID(r.Context(), cachedUser.ID))
+			m.authenticatedMiddleware.Handle(next).ServeHTTP(w, r)
+			return
+		}
+
+		// Admin users bypass rate limiting completely
+		next.ServeHTTP(w, r)
+	})
+}
+
+// getCachedUser looks for credentials on the request using each registered credential source.
+// If it finds a credential, it looks up the user in the cache and returns it.
+// If it doesn't find a credential, or a user for that credential, it returns nil.
+func (m *AuthGroupMiddleware) getCachedUser(r *http.Request) *User {
+	var (
+		user  *User
+		found bool
+	)
+
+	m.credSources.Range(func(key, _ any) bool {
+		source := key.(CredSource)
+		cred := source.extractCred(r)
+		if cred == "" {
+			return true
+		}
+
+		user, found = m.userCache.Get(hashCred(cred))
+		return !found
+	})
+
+	return user
+}

--- a/pkg/api/ratelimit/noop.go
+++ b/pkg/api/ratelimit/noop.go
@@ -1,0 +1,24 @@
+package ratelimit
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// NoopMiddleware is a no-operation implementation of the Middleware interface.
+// It doesn't perform any actual rate limiting, making it useful for development
+// environments or when rate limiting needs to be temporarily disabled.
+type NoopMiddleware struct{}
+
+// Limit implements the Middleware interface for NoopMiddleware.
+// It simply passes requests through without any rate limiting.
+func (NoopMiddleware) Limit(next http.Handler) http.Handler {
+	return next
+}
+
+// RegisterUser implements the Middleware interface for NoopMiddleware.
+// It does nothing as no rate limiting is performed.
+func (NoopMiddleware) RegisterUser(_ user.Info) error {
+	return nil
+}

--- a/pkg/api/ratelimit/ratelimit.go
+++ b/pkg/api/ratelimit/ratelimit.go
@@ -1,0 +1,121 @@
+// Package ratelimiter implements HTTP middleware for rate limiting API requests
+// with different limits for authenticated and unauthenticated users.
+// It supports extracting credentials from HTTP headers or cookies,
+// caching authenticated users, and allowing admins to bypass rate limits entirely.
+package ratelimit
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// Middleware defines the interface for HTTP rate limiting middleware.
+// Implementations of this interface can be used to wrap HTTP handlers
+// with rate limiting functionality.
+type Middleware interface {
+	// Limit wraps an HTTP handler with rate limiting logic.
+	// It returns a new handler that enforces rate limits based on user authentication.
+	Limit(next http.Handler) http.Handler
+
+	// RegisterUser adds or updates a user in the rate limiter's cache.
+	// This makes subsequent requests with the same credentials use the authenticated rate.
+	RegisterUser(u user.Info) error
+}
+
+// CredSourceType defines where credentials are stored in the HTTP request.
+// Currently supports headers and cookies.
+type CredSourceType string
+
+// Supported credential source types
+const (
+	// CredSourceTypeHeader indicates credentials are in an HTTP header
+	CredSourceTypeHeader CredSourceType = "header"
+
+	// CredSourceTypeCookie indicates credentials are in an HTTP cookie
+	CredSourceTypeCookie CredSourceType = "cookie"
+
+	// Key used for storing credential info in user.Info.Extra map
+	credInfoKey = "rate_limit_cred_info"
+)
+
+// CredSource defines a specific location to extract credentials from HTTP requests.
+// It combines a type (header/cookie) with a name (e.g., "Authorization" or "session").
+type CredSource struct {
+	// Type specifies if the credential is in a header or cookie
+	Type CredSourceType
+
+	// Name is the specific header or cookie name containing the credential
+	Name string
+}
+
+func (c *CredSource) extractCred(r *http.Request) string {
+	var cred string
+
+	switch c.Type {
+	case CredSourceTypeHeader:
+		cred = r.Header.Get(c.Name)
+	case CredSourceTypeCookie:
+		if cookie, err := r.Cookie(c.Name); err == nil {
+			cred = cookie.Value
+		}
+	}
+
+	return cred
+}
+
+// User represents an authenticated user's rate limiting metadata.
+// It contains only the information needed for rate limiting decisions.
+type User struct {
+	// ID is the unique identifier for the user, used as the rate limit key
+	ID string
+
+	// IsAdmin determines if the user bypasses rate limits completely
+	IsAdmin bool
+}
+
+// EnableGroupRateLimit adds credential information to a user.DefaultInfo for later retrieval.
+// This should be called during the authentication process to store the credential
+// source information that was used to authenticate the user.
+func EnableAuthGroupRateLimit(sourceType CredSourceType, sourceName, cred string, u *user.DefaultInfo) {
+	if u.Extra == nil {
+		u.Extra = make(map[string][]string)
+	}
+
+	// Store the credential source type, name, and hashed token
+	// Format: "type:name:hash" (e.g. "header:Authorization:abc123...")
+	u.Extra[credInfoKey] = []string{
+		fmt.Sprintf("%s:%s:%s", sourceType, sourceName, hashCred(cred)),
+	}
+}
+
+// hashCred creates a cryptographic hash of a cred value.
+// This provides security by avoiding storage of the actual credentials
+// while still allowing lookups by credential.
+func hashCred(cred string) string {
+	h := sha256.New()
+	h.Write([]byte(cred))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// getUserCredInfo gets the credential source and token hash from user.Extra.
+// This information was previously stored during authentication via StoreCredInfo.
+func getUserCredInfo(u user.Info) (credHash string, source CredSource, ok bool) {
+	credInfos, exists := u.GetExtra()[credInfoKey]
+	if !exists || len(credInfos) == 0 {
+		return "", CredSource{}, false
+	}
+
+	parts := strings.Split(credInfos[0], ":")
+	if len(parts) != 3 {
+		return "", CredSource{}, false
+	}
+
+	return parts[2], CredSource{
+		Type: CredSourceType(parts[0]),
+		Name: parts[1],
+	}, true
+}


### PR DESCRIPTION
## Description

Implement middleware that applies rate limits to all HTTP endpoints exposed by Obot.

## Request Flow

1. A request is sent to any HTTP endpoint
2. The request immediately encounters the rate limiting middleware
3. The middleware inspects the request for any headers or cookies that appear
   in its recently authenticated users cache (LRU with entry TTL and automatic eviction)
4. The request is checked against the appropriate rate limiter based on
   the result of the cache lookup
   - If it contained a matching credential for an admin, no rate limits
     are applied to the request
   - If a non-admin entry was found, authenticated rate limits (200
     req/sec) are applied to the user ID associated with the cached
     credential
   - If the credential wasn't found in the cache, unauthenticated rate
     limits are applied to the client's IP address (100 req/sec)
   - If a limit is exceeded a 429 response code is returned with headers
     indicating when the client can make their next request
5. The request is sent through the authentication chain
   - If the request is successfully authenticated, the respective authenticator
     adds the hash of the credential and the info necessary to extract it from
     the request to the user info embedded in its response
6. After authentication is complete, the credential hash and lookup info
   are added to the rate limiting middleware's user cache
   - No entries are added to the cache if the request doesn't pass
     authentication
   - This step enables the middleware to roughly (and inexpensively)
     determine what limits should be applied to future requests with the
     same credential (steps 3 and 4)

## Justifying the Design

This approach should help reduce the amount of high-frequency traffic that can reach the more resource intensive operations performed by the authenticator chain (e.g. auth provider proxy and database token lookups) while still enabling higher rate limits for authenticated users and
admins.

Addresses: https://github.com/obot-platform/sensitive-issues/issues/18
