### PR TITLE
enhance/post authn rate limits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/pterm/pterm v0.12.80
 	github.com/rs/cors v1.11.1
 	github.com/sendgrid/sendgrid-go v3.16.0+incompatible
+	github.com/sethvargo/go-limiter v1.0.0
 	github.com/spf13/cobra v1.8.1
 	github.com/tidwall/gjson v1.18.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0

--- a/go.sum
+++ b/go.sum
@@ -557,6 +557,8 @@ github.com/sendgrid/sendgrid-go v3.16.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdR
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
+github.com/sethvargo/go-limiter v1.0.0 h1:JqW13eWEMn0VFv86OKn8wiYJY/m250WoXdrjRV0kLe4=
+github.com/sethvargo/go-limiter v1.0.0/go.mod h1:01b6tW25Ap+MeLYBuD4aHunMrJoNO5PVUFdS9rac3II=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/pkg/api/server/ratelimiter/ratelimiter.go
+++ b/pkg/api/server/ratelimiter/ratelimiter.go
@@ -1,0 +1,121 @@
+package ratelimiter
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/obot-platform/obot/pkg/api/server/requestinfo"
+	"github.com/sethvargo/go-limiter"
+	"github.com/sethvargo/go-limiter/memorystore"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+const (
+	// HeaderRateLimitLimit, HeaderRateLimitRemaining, and HeaderRateLimitReset
+	// are the recommended return header values from IETF on rate limiting. Reset
+	// is in UTC time.
+	headerRateLimitLimit     = "X-RateLimit-Limit"
+	headerRateLimitRemaining = "X-RateLimit-Remaining"
+	headerRateLimitReset     = "X-RateLimit-Reset"
+
+	// HeaderRetryAfter is the header used to indicate when a client should retry
+	// requests (when the rate limit expires), in UTC time.
+	headerRetryAfter = "Retry-After"
+)
+
+var ErrRateLimitExceeded = errors.New("rate limit exceeded, please try again later")
+
+type Options struct {
+	UnauthenticatedRateLimit int `usage:"Rate limit for unauthenticated requests (req/sec)" default:"100"`
+	AuthenticatedRateLimit   int `usage:"Rate limit for authenticated non-admin requests (req/sec)" default:"200"`
+}
+
+// RateLimiter limits the number of HTTP requests per second a user can make.
+// It tracks limits for unauthenticated and authenticated users separately:
+// - Authenticated requests are tracked by user ID or name.
+// - Unauthenticated requests are tracked by IP address.
+// - Admins are exempt from rate limiting.
+type RateLimiter struct {
+	unauthenticatedStore limiter.Store
+	authenticatedStore   limiter.Store
+}
+
+func New(opts Options) (*RateLimiter, error) {
+	unauthenticatedStore, err := memorystore.New(&memorystore.Config{
+		Tokens:   uint64(opts.UnauthenticatedRateLimit),
+		Interval: time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create unauthenticated store: %w", err)
+	}
+
+	authenticatedStore, err := memorystore.New(&memorystore.Config{
+		Tokens:   uint64(opts.AuthenticatedRateLimit),
+		Interval: time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authenticated store: %w", err)
+	}
+
+	return &RateLimiter{
+		unauthenticatedStore: unauthenticatedStore,
+		authenticatedStore:   authenticatedStore,
+	}, nil
+}
+
+// ApplyLimit applies the user's rate limit to the request, sets the rate limit headers, and returns a ErrRateLimitExceeded error if the limit has been exceeded.
+// It returns nil if the user is exempt from rate limiting or if the user has not exceeded their limit.
+func (l *RateLimiter) ApplyLimit(u user.Info, rw http.ResponseWriter, req *http.Request) error {
+	groups := u.GetGroups()
+
+	if slices.Contains(groups, authz.AdminGroup) {
+		// Admins are exempt from rate limiting
+		return nil
+	}
+
+	var store limiter.Store
+	key := u.GetUID()
+	if key == "" {
+		key = u.GetName()
+	}
+
+	if slices.Contains(groups, authz.AuthenticatedGroup) && key != "" {
+		store = l.authenticatedStore
+	} else {
+		// Get the source IP address from the request.
+		key = requestinfo.GetSourceIP(req)
+
+		// Strip the port from the IP address if present.
+		if ip, _, err := net.SplitHostPort(key); err == nil {
+			key = ip
+		}
+
+		store = l.unauthenticatedStore
+	}
+
+	limit, remaining, reset, ok, err := store.Take(req.Context(), key)
+	if err != nil {
+		return fmt.Errorf("failed to take rate limit tokens: %w", err)
+	}
+
+	resetTime := time.Unix(0, int64(reset)).UTC().Format(time.RFC1123)
+
+	// Always set the rate limit response headers
+	rw.Header().Set(headerRateLimitLimit, strconv.FormatUint(limit, 10))
+	rw.Header().Set(headerRateLimitRemaining, strconv.FormatUint(remaining, 10))
+	rw.Header().Set(headerRateLimitReset, resetTime)
+
+	if !ok {
+		// Rate limit exceeded.
+		rw.Header().Set(headerRetryAfter, resetTime)
+		return ErrRateLimitExceeded
+	}
+
+	return nil
+}

--- a/pkg/api/server/requestinfo/requestinfo.go
+++ b/pkg/api/server/requestinfo/requestinfo.go
@@ -1,0 +1,27 @@
+package requestinfo
+
+import (
+	"net/http"
+	"strings"
+)
+
+// GetSourceIP extracts the real client IP address from the request.
+// It checks X-Forwarded-For and X-Real-IP headers before falling back to RemoteAddr.
+func GetSourceIP(req *http.Request) string {
+	// Check X-Forwarded-For header first
+	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
+		// X-Forwarded-For can contain multiple IPs (client, proxy1, proxy2, ...).
+		// A typical deployment of Obot will have a proxy in front of it that appends the request client's IP address (req.RemoteAddr) to the X-Forwarded-For header before forwarding the request to Obot.
+		// With that in mind, we choose the rightmost IP in the X-Forwarded-For header since it's the only IP address that is not spoofable by the client.
+		ips := strings.Split(xff, ",")
+		return strings.TrimSpace(ips[len(ips)-1])
+	}
+
+	// Check X-Real-IP header next
+	if xrip := req.Header.Get("X-Real-IP"); xrip != "" {
+		return xrip
+	}
+
+	// Fall back to RemoteAddr
+	return req.RemoteAddr
+}

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -14,6 +14,8 @@ import (
 	"github.com/obot-platform/obot/pkg/api/authn"
 	"github.com/obot-platform/obot/pkg/api/authz"
 	"github.com/obot-platform/obot/pkg/api/server/audit"
+	"github.com/obot-platform/obot/pkg/api/server/ratelimiter"
+	"github.com/obot-platform/obot/pkg/api/server/requestinfo"
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/proxy"
 	"github.com/obot-platform/obot/pkg/storage"
@@ -34,12 +36,13 @@ type Server struct {
 	authorizer    *authz.Authorizer
 	proxyManager  *proxy.Manager
 	auditLogger   audit.Logger
+	rateLimiter   *ratelimiter.RateLimiter
 	baseURL       string
 
 	mux *http.ServeMux
 }
 
-func NewServer(storageClient storage.Client, gatewayClient *gclient.Client, gptClient *gptscript.GPTScript, authn *authn.Authenticator, authz *authz.Authorizer, proxyManager *proxy.Manager, auditLogger audit.Logger, baseURL string) *Server {
+func NewServer(storageClient storage.Client, gatewayClient *gclient.Client, gptClient *gptscript.GPTScript, authn *authn.Authenticator, authz *authz.Authorizer, proxyManager *proxy.Manager, auditLogger audit.Logger, rateLimiter *ratelimiter.RateLimiter, baseURL string) *Server {
 	return &Server{
 		storageClient: storageClient,
 		gatewayClient: gatewayClient,
@@ -49,6 +52,7 @@ func NewServer(storageClient storage.Client, gatewayClient *gclient.Client, gptC
 		proxyManager:  proxyManager,
 		baseURL:       baseURL + "/api",
 		auditLogger:   auditLogger,
+		rateLimiter:   rateLimiter,
 		mux:           http.NewServeMux(),
 	}
 }
@@ -82,6 +86,18 @@ func (s *Server) wrap(f api.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
+		if err := s.rateLimiter.ApplyLimit(user, rw, req); err != nil {
+			if errors.Is(err, ratelimiter.ErrRateLimitExceeded) {
+				// The user has exceeded their rate limit.
+				http.Error(rw, err.Error(), http.StatusTooManyRequests)
+				return
+			}
+
+			// There was an error applying the rate limit.
+			// Log it and move on so that a failure to apply rate limits doesn't take down the entire API.
+			log.Warnf("Failed to apply rate limits: %v", err)
+		}
+
 		if strings.HasPrefix(req.URL.Path, "/api/") {
 			// Setup a new response writer for audit logging.
 			rw = &responseWriter{
@@ -92,7 +108,7 @@ func (s *Server) wrap(f api.HandlerFunc) http.HandlerFunc {
 					Method:    req.Method,
 					Path:      req.URL.Path,
 					UserAgent: req.UserAgent(),
-					SourceIP:  getSourceIP(req),
+					SourceIP:  requestinfo.GetSourceIP(req),
 					Host:      req.Host,
 				},
 				auditLogger: s.auditLogger,
@@ -176,27 +192,4 @@ func (rw *responseWriter) Flush() {
 	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
-}
-
-// getSourceIP extracts the real client IP address from the request.
-// It checks X-Forwarded-For and X-Real-IP headers before falling back to RemoteAddr.
-func getSourceIP(req *http.Request) string {
-	// Check X-Forwarded-For header first
-	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
-		// X-Forwarded-For can contain multiple IPs (client, proxy1, proxy2, ...).
-		// A typical deployment of Obot will have a proxy in front of it that appends the request client's IP address (req.RemoteAddr) to the X-Forwarded-For header before forwarding the request to Obot.
-		// With that in mind, we choose the rightmost IP in the X-Forwarded-For header since it's the only IP address that is not spoofable by the client.
-		ips := strings.Split(xff, ",")
-		if len(ips) > 0 {
-			return strings.TrimSpace(ips[len(ips)-1])
-		}
-	}
-
-	// Check X-Real-IP header next
-	if xrip := req.Header.Get("X-Real-IP"); xrip != "" {
-		return xrip
-	}
-
-	// Fall back to RemoteAddr
-	return req.RemoteAddr
 }

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -183,11 +183,12 @@ func (rw *responseWriter) Flush() {
 func getSourceIP(req *http.Request) string {
 	// Check X-Forwarded-For header first
 	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
-		// X-Forwarded-For can contain multiple IPs (client, proxy1, proxy2, ...)
-		// The leftmost one is the original client IP
+		// X-Forwarded-For can contain multiple IPs (client, proxy1, proxy2, ...).
+		// A typical deployment of Obot will have a proxy in front of it that appends the request client's IP address (req.RemoteAddr) to the X-Forwarded-For header before forwarding the request to Obot.
+		// With that in mind, we choose the rightmost IP in the X-Forwarded-For header since it's the only IP address that is not spoofable by the client.
 		ips := strings.Split(xff, ",")
 		if len(ips) > 0 {
-			return strings.TrimSpace(ips[0])
+			return strings.TrimSpace(ips[len(ips)-1])
 		}
 	}
 


### PR DESCRIPTION
Rate limit all HTTP requests after authentication completes. Authenticated users get a higher quota than unauthenticated users by default and, as a special case, admins are exempt from rate limits entirely.

Addresses https://github.com/obot-platform/sensitive-issues/issues/18