### PR TITLE
fix: auth providers: remove postgres DSN from config and set dynamically

### DIFF
--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -149,10 +149,6 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 	}
 	envVars[providers.CookieSecretEnvVar] = cookieSecret
 
-	if ap.postgresDSN != "" {
-		envVars[providers.PostgresConnectionEnvVar] = ap.postgresDSN
-	}
-
 	// Allow for updating credentials. The only way to update a credential is to delete the existing one and recreate it.
 	cred, err := ap.gptscript.RevealCredential(req.Context(), []string{string(ref.UID), system.GenericAuthProviderCredentialContext}, ref.Name)
 	if err != nil {

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -349,7 +349,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 			tokenServer,
 			events,
 		)
-		providerDispatcher = dispatcher.New(ctx, invoker, storageClient, gptscriptClient)
+		providerDispatcher = dispatcher.New(ctx, invoker, storageClient, gptscriptClient, config.DSN)
 
 		proxyManager *proxy.Manager
 	)


### PR DESCRIPTION
Our current approach stores the postgres DSN in the credential that we configure for the auth provider. This is bad when we change the DSN in obot itself, because it doesn't automatically get updated for the auth provider, and things break.

This change makes it so that we no longer store the DSN in the credential, but instead just set it in the environment every time we set up the auth provider. That way, when Obot is restarted with a new DSN, the auth provider will get that new DSN as well.