### PR TITLE
enhance: obot card owner tag & 401 handling

### DIFF
--- a/ui/user/src/lib/components/ObotCard.svelte
+++ b/ui/user/src/lib/components/ObotCard.svelte
@@ -5,6 +5,7 @@
 	import ToolPill from '$lib/components/ToolPill.svelte';
 	import { DEFAULT_PROJECT_NAME } from '$lib/constants';
 	import type { Snippet } from 'svelte';
+	import { UserPen } from 'lucide-svelte';
 
 	interface Props {
 		project: Project | ProjectShare;
@@ -40,27 +41,33 @@
 				</div>
 			{/if}
 		</div>
-		{#if 'tools' in project && project.tools}
-			{@const maxToolsToShow = responsive.isMobile ? 2 : 3}
-			<div class="mt-auto flex w-full flex-wrap justify-end gap-2">
-				{#each project.tools.slice(0, maxToolsToShow) as tool}
-					{@const toolData = tools.get(tool)}
-					{#if toolData}
-						<ToolPill tool={toolData} />
+		<div class="flex w-full justify-between">
+			{#if 'editor' in project && project.editor}
+				<span
+					class="bg-surface2 mt-auto flex h-fit w-fit gap-1 rounded-full px-3 py-1 text-xs font-light text-gray-500"
+				>
+					<UserPen class="size-4" /> Owner
+				</span>
+			{/if}
+			{#if 'tools' in project && project.tools}
+				{@const maxToolsToShow = responsive.isMobile ? 2 : 3}
+				<div class="mt-auto flex w-full flex-wrap justify-end gap-2">
+					{#each project.tools.slice(0, maxToolsToShow) as tool}
+						{@const toolData = tools.get(tool)}
+						{#if toolData}
+							<ToolPill tool={toolData} />
+						{/if}
+					{/each}
+					{#if project.tools.length > maxToolsToShow}
+						<ToolPill
+							tools={project.tools
+								.slice(maxToolsToShow)
+								.map((t) => tools.get(t))
+								.filter((t): t is ToolReference => !!t)}
+						/>
 					{/if}
-				{/each}
-				{#if project.tools.length > maxToolsToShow}
-					<ToolPill
-						tools={project.tools
-							.slice(maxToolsToShow)
-							.map((t) => tools.get(t))
-							.filter((t): t is ToolReference => !!t)}
-					/>
-				{/if}
-			</div>
-		{:else}
-			<div class="min-h-2"></div>
-			<!-- placeholder -->
-		{/if}
+				</div>
+			{/if}
+		</div>
 	</div>
 </a>

--- a/ui/user/src/lib/components/ReLoginDialog.svelte
+++ b/ui/user/src/lib/components/ReLoginDialog.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { profile } from '$lib/stores';
+
+	let dialog: HTMLDialogElement;
+
+	$effect(() => {
+		if (profile.current.loaded === true && profile.current.expired === true) {
+			dialog.showModal();
+		}
+	});
+
+	function handleLogin() {
+		window.location.href = `/?rd=${encodeURIComponent(window.location.pathname)}`;
+	}
+</script>
+
+<dialog
+	bind:this={dialog}
+	class="rounded-lg bg-white p-6 shadow-lg dark:bg-gray-900"
+	onclose={() => {
+		// Prevent closing by clicking outside
+		dialog.showModal();
+	}}
+>
+	<div class="flex flex-col items-center gap-4">
+		<h2 class="text-xl font-semibold">Session Expired</h2>
+		<p class="text-center text-gray-600 dark:text-gray-400">
+			Your session has expired. Please log in again to continue.
+		</p>
+		<button onclick={handleLogin} class="button-primary w-full"> Log In </button>
+	</div>
+</dialog>

--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -198,7 +198,7 @@
 		>
 			{#if editBasicDetails}
 				{@render editBasicSection()}
-			{:else if layout.projectEditorOpen}
+			{:else if layout.projectEditorOpen || !project.editor}
 				<div class="message-content mt-4 w-fit self-center border-2 border-transparent pt-4">
 					{@render basicSection()}
 				</div>

--- a/ui/user/src/lib/components/edit/ToolCatalog.svelte
+++ b/ui/user/src/lib/components/edit/ToolCatalog.svelte
@@ -40,7 +40,6 @@
 	let maxExceeded = $state(false);
 
 	function getSelectionMap() {
-		$inspect('tools', tools);
 		return tools
 			.filter((t) => !t.builtin)
 			.reduce<Record<string, AssistantTool>>((acc, tool) => {

--- a/ui/user/src/lib/components/navbar/Tools.svelte
+++ b/ui/user/src/lib/components/navbar/Tools.svelte
@@ -30,9 +30,9 @@
 			return;
 		}
 
-		tools = (
-			await ChatService.listProjectThreadTools(project.assistantID, project.id, currentThreadID)
-		).items;
+		tools =
+			(await ChatService.listProjectThreadTools(project.assistantID, project.id, currentThreadID))
+				?.items ?? [];
 	}
 
 	$effect(() => {

--- a/ui/user/src/lib/constants.ts
+++ b/ui/user/src/lib/constants.ts
@@ -3,3 +3,10 @@ export const DEFAULT_PROJECT_DESCRIPTION = 'Do more with AI';
 
 export const ABORTED_THREAD_MESSAGE = 'thread was aborted, cancelling run';
 export const ABORTED_BY_USER_MESSAGE = 'aborted by user';
+
+export const FEATURED_PROJECT_ORDER = [
+	'gmail unsubscriber',
+	'slack2github',
+	'job hunt helper',
+	'granite gains'
+];

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -149,6 +149,7 @@ export interface Profile {
 	unauthorized?: boolean;
 	username: string;
 	currentAuthProvider?: string;
+	expired?: boolean;
 }
 
 export interface Files {

--- a/ui/user/src/lib/sort.ts
+++ b/ui/user/src/lib/sort.ts
@@ -1,0 +1,12 @@
+import { FEATURED_PROJECT_ORDER } from './constants';
+import type { ProjectShare } from './services';
+
+export const sortByFeaturedNameOrder = (a: ProjectShare, b: ProjectShare) => {
+	const aName = (a.name?.toLowerCase() ?? '').trim();
+	const bName = (b.name?.toLowerCase() ?? '').trim();
+	const aIndex = FEATURED_PROJECT_ORDER.indexOf(aName);
+	const bIndex = FEATURED_PROJECT_ORDER.indexOf(bName);
+	if (aIndex === -1) return 1;
+	if (bIndex === -1) return -1;
+	return aIndex - bIndex;
+};

--- a/ui/user/src/routes/+layout.svelte
+++ b/ui/user/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '../app.css';
 	import { darkMode } from '$lib/stores';
 	import Notifications from '$lib/components/Notifications.svelte';
+	import ReLoginDialog from '$lib/components/ReLoginDialog.svelte';
 
 	interface Props {
 		children?: import('svelte').Snippet;
@@ -53,3 +54,4 @@
 </svelte:head>
 
 <Notifications />
+<ReLoginDialog />

--- a/ui/user/src/routes/+page.ts
+++ b/ui/user/src/routes/+page.ts
@@ -1,13 +1,16 @@
 import { type Assistant, ChatService } from '$lib/services';
+import { sortByFeaturedNameOrder } from '$lib/sort';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch }) => {
 	const authProviders = await ChatService.listAuthProviders({ fetch });
-	const featuredProjectShares = (await ChatService.listProjectShares({ fetch })).items.filter(
-		// Ensure the project has a name and description before showing it on the unauthenticated
-		// home page.
-		(projectShare) => projectShare.name && projectShare.description && projectShare.icons?.icon
-	);
+	const featuredProjectShares = (await ChatService.listProjectShares({ fetch })).items
+		.filter(
+			// Ensure the project has a name and description before showing it on the unauthenticated
+			// home page.
+			(projectShare) => projectShare.name && projectShare.description && projectShare.icons?.icon
+		)
+		.sort(sortByFeaturedNameOrder);
 	const tools = new Map((await ChatService.listAllTools({ fetch })).items.map((t) => [t.id, t]));
 	let assistantsLoaded = false;
 	let assistants: Assistant[] = [];

--- a/ui/user/src/routes/catalog/+page.svelte
+++ b/ui/user/src/routes/catalog/+page.svelte
@@ -9,9 +9,12 @@
 	import { qIsSet } from '$lib/url';
 	import { ChevronsLeft } from 'lucide-svelte';
 	import FeaturedObotCard from '$lib/components/FeaturedObotCard.svelte';
+	import { sortByFeaturedNameOrder } from '$lib/sort';
 
 	let { data }: PageProps = $props();
-	let featured = $state<ProjectShare[]>(data.shares.filter((s) => s.featured));
+	let featured = $state<ProjectShare[]>(
+		data.shares.filter((s) => s.featured).sort(sortByFeaturedNameOrder)
+	);
 	let tools = $state(new Map(data.tools.map((t) => [t.id, t])));
 </script>
 


### PR DESCRIPTION
https://www.loom.com/share/6aa8882575da44abb975bb9b469b94f3

* handling 401 when loading a page: prompts log-in with redirect
* handling 401 when user has already logged in: receives session expired dialog and log in button
* add owner tag to obot card
* also includes hardcoded sort based on obot name for featured: 
Gmail Unsubscriber      
Slack2GitHub
Job Hunt Helper           
Granite Gains