### PR TITLE
enhance: homepage & obot redirect/selector updates

### DIFF
--- a/ui/user/src/lib/components/FeaturedObotCard.svelte
+++ b/ui/user/src/lib/components/FeaturedObotCard.svelte
@@ -3,19 +3,26 @@
 	import { getProjectImage } from '$lib/image';
 	import type { Project, ProjectShare, ToolReference } from '$lib/services';
 	import { darkMode, responsive } from '$lib/stores';
+	import { twMerge } from 'tailwind-merge';
 	import ToolPill from './ToolPill.svelte';
 
 	interface Props {
 		project: Project | ProjectShare;
 		tools: Map<string, ToolReference>;
 		onclick?: () => void;
+		class?: string;
 	}
 
-	const { project, tools, onclick }: Props = $props();
+	const { project, tools, onclick, class: klass }: Props = $props();
 </script>
 
 {#snippet content()}
-	<div class="bg-surface1 z-10 flex w-full grow items-center rounded-xl p-4 shadow-md">
+	<div
+		class={twMerge(
+			'bg-surface1 z-10 flex w-full grow items-center rounded-xl p-4 shadow-md',
+			klass
+		)}
+	>
 		<img
 			alt="obot logo"
 			src={getProjectImage(project, darkMode.isDark)}

--- a/ui/user/src/lib/components/ObotCard.svelte
+++ b/ui/user/src/lib/components/ObotCard.svelte
@@ -10,15 +10,15 @@
 	interface Props {
 		project: Project | ProjectShare;
 		tools: Map<string, ToolReference>;
-		menu?: Snippet;
+		actionContent?: Snippet;
 	}
-	let { project, tools, menu }: Props = $props();
+	let { project, tools, actionContent }: Props = $props();
 </script>
 
 <a
 	href={'publicID' in project ? `/s/${project.publicID}` : `/o/${project.id}`}
 	data-sveltekit-preload-data={'publicID' in project ? 'off' : 'hover'}
-	class="card relative z-20 flex-col overflow-hidden shadow-md"
+	class="card group relative z-20 flex-col overflow-hidden shadow-md"
 >
 	<div class="flex h-fit w-full flex-col gap-2 p-4 md:h-auto md:grow">
 		<div class="flex w-full">
@@ -35,9 +35,9 @@
 					{project.description}
 				</p>
 			</div>
-			{#if !('publicID' in project) && menu}
+			{#if !('publicID' in project) && actionContent}
 				<div class="translate-x-2 -translate-y-2">
-					{@render menu()}
+					{@render actionContent()}
 				</div>
 			{/if}
 		</div>

--- a/ui/user/src/lib/components/Sidebar.svelte
+++ b/ui/user/src/lib/components/Sidebar.svelte
@@ -38,7 +38,7 @@
 				disabled={layout.projectEditorOpen}
 				classes={{
 					tooltip:
-						'md:w-[250px] md:w-1/6 md:-translate-x-14 -translate-x-1 border-t-[1px] border-surface3 bg-surface2 shadow-inner max-h-[calc(100vh-66px)] overflow-y-auto default-scrollbar-thin'
+						'md:min-w-[250px] md:w-1/6 md:-translate-x-14 -translate-x-1 border-t-[1px] border-surface3 bg-surface2 shadow-inner max-h-[calc(100vh-66px)] overflow-y-auto default-scrollbar-thin'
 				}}
 			/>
 		</div>

--- a/ui/user/src/lib/components/Sidebar.svelte
+++ b/ui/user/src/lib/components/Sidebar.svelte
@@ -38,7 +38,7 @@
 				disabled={layout.projectEditorOpen}
 				classes={{
 					tooltip:
-						'md:w-[250px] md:-translate-x-14 -translate-x-1 border-t-[1px] border-surface3 bg-surface2 shadow-inner max-h-[calc(100vh-66px)] overflow-y-auto default-scrollbar-thin'
+						'md:w-[250px] md:w-1/6 md:-translate-x-14 -translate-x-1 border-t-[1px] border-surface3 bg-surface2 shadow-inner max-h-[calc(100vh-66px)] overflow-y-auto default-scrollbar-thin'
 				}}
 			/>
 		</div>

--- a/ui/user/src/lib/components/navbar/Logo.svelte
+++ b/ui/user/src/lib/components/navbar/Logo.svelte
@@ -8,6 +8,6 @@
 	let { class: klass }: Props = $props();
 </script>
 
-<a href="/">
+<a href="/home">
 	<img src="/user/images/obot-icon-blue.svg" class={twMerge('mx-2 h-8', klass)} alt="Obot icon" />
 </a>

--- a/ui/user/src/lib/components/navbar/Projects.svelte
+++ b/ui/user/src/lib/components/navbar/Projects.svelte
@@ -26,30 +26,9 @@
 	}: Props = $props();
 
 	let projects = $state<Project[]>([]);
-	let recentlyUsedLimit = $state(10);
-	let myObotsLimit = $state(10);
+	let limit = $state(10);
 	let open = $state(false);
 	let buttonElement = $state<HTMLButtonElement>();
-
-	let recentlyUsed = $derived(
-		projects.length === 0
-			? []
-			: onlyEditable
-				? []
-				: projects
-						.filter((p) => p.editor === false)
-						.sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())
-	);
-
-	let myObots = $derived(
-		projects.length === 0
-			? []
-			: onlyEditable
-				? projects
-				: projects
-						.filter((p) => p.editor === true)
-						.sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())
-	);
 
 	let { ref, tooltip, toggle } = popover({
 		placement: 'bottom-start',
@@ -59,12 +38,8 @@
 		}
 	});
 
-	function loadMore(category: 'recent' | 'myObots') {
-		if (category === 'recent') {
-			recentlyUsedLimit += 10;
-		} else {
-			myObotsLimit += 10;
-		}
+	function loadMore() {
+		limit += 10;
 	}
 </script>
 
@@ -105,38 +80,17 @@
 		onclick={() => toggle(false)}
 		style={onlyEditable ? `width: ${buttonElement?.clientWidth}px` : ''}
 	>
-		{#if onlyEditable}
-			{#each myObots.slice(0, myObotsLimit) as p}
-				{@render ProjectItem(p, true)}
-			{/each}
-			{@render LoadMoreButton(myObots.length, myObotsLimit, 'myObots')}
-		{:else}
-			{#if recentlyUsed.length > 0}
-				<div class="flex flex-col">
-					<h3 class="mb-1 px-2 text-sm font-semibold">Recently Used</h3>
-					{#each recentlyUsed.slice(0, recentlyUsedLimit) as p}
-						{@render ProjectItem(p)}
-					{/each}
-					{@render LoadMoreButton(recentlyUsed.length, recentlyUsedLimit, 'recent')}
-				</div>
-			{/if}
-
-			<div class="mt-3 flex flex-col">
-				<h3 class="mb-1 px-2 text-sm font-semibold">My Obots</h3>
-				{#each myObots.slice(0, myObotsLimit) as p}
-					{@render ProjectItem(p)}
-				{/each}
-				{@render LoadMoreButton(myObots.length, myObotsLimit, 'myObots')}
-			</div>
-
-			<a
-				href="/home"
-				class="text-gray hover:bg-surface3 mt-3 flex items-center justify-center gap-2 rounded-xl px-2 py-4"
-			>
-				<img src="/user/images/obot-icon-blue.svg" class="h-5" alt="Obot icon" />
-				<span class="text-gray text-sm">See All Obots</span>
-			</a>
-		{/if}
+		{#each projects.slice(0, limit) as p}
+			{@render ProjectItem(p, true)}
+		{/each}
+		{@render LoadMoreButton(projects.length, limit)}
+		<a
+			href={`/catalog?from=${encodeURIComponent(window.location.pathname)}`}
+			class="text-gray hover:bg-surface3 mt-3 flex items-center justify-center gap-2 rounded-xl px-2 py-4"
+		>
+			<img src="/user/images/obot-icon-blue.svg" class="h-5" alt="Obot icon" />
+			<span class="text-gray text-sm">View Obot Catalog</span>
+		</a>
 	</div>
 {/if}
 
@@ -159,13 +113,13 @@
 	</a>
 {/snippet}
 
-{#snippet LoadMoreButton(totalLength: number, limit: number, category: 'recent' | 'myObots')}
+{#snippet LoadMoreButton(totalLength: number, limit: number)}
 	{#if totalLength > limit}
 		<button
 			class="hover:bg-surface2 mt-1 w-full rounded-sm py-1 text-sm text-blue-500"
 			onclick={(e) => {
 				e.stopPropagation();
-				loadMore(category);
+				loadMore();
 			}}
 		>
 			Load 10 more

--- a/ui/user/src/lib/components/navbar/Projects.svelte
+++ b/ui/user/src/lib/components/navbar/Projects.svelte
@@ -57,8 +57,7 @@
 			toggle(false);
 			return;
 		}
-		const results = (await ChatService.listProjects()).items;
-		projects = onlyEditable ? results.filter((p) => !!p.editor) : results;
+		projects = (await ChatService.listProjects()).items;
 		toggle();
 	}}
 >
@@ -81,7 +80,7 @@
 		style={onlyEditable ? `width: ${buttonElement?.clientWidth}px` : ''}
 	>
 		{#each projects.slice(0, limit) as p}
-			{@render ProjectItem(p, true)}
+			{@render ProjectItem(p, onlyEditable)}
 		{/each}
 		{@render LoadMoreButton(projects.length, limit)}
 		<a

--- a/ui/user/src/lib/url.ts
+++ b/ui/user/src/lib/url.ts
@@ -7,3 +7,10 @@ export function qIsSet(key: string): boolean {
 	}
 	return browser && new URL(window.location.href).searchParams.has(key);
 }
+
+export function q(key: string): string {
+	if (navigating?.to?.url.searchParams.has(key)) {
+		return navigating.to.url.searchParams.get(key) || '';
+	}
+	return browser ? new URL(window.location.href).searchParams.get(key) || '' : '';
+}

--- a/ui/user/src/routes/+page.svelte
+++ b/ui/user/src/routes/+page.svelte
@@ -10,21 +10,16 @@
 	import FeaturedObotCard from '$lib/components/FeaturedObotCard.svelte';
 
 	let { data }: PageProps = $props();
-	let { authProviders, assistants, assistantsLoaded, featuredProjectShares, tools } = data;
+	let { authProviders, featuredProjectShares, tools } = data;
 	let loginDialog = $state<HTMLDialogElement>();
 	let projectShareRedirect = $state<string | null>(null);
 
 	onMount(async () => {
-		if (!assistantsLoaded) {
-			show();
-		}
-
 		if (browser && new URL(window.location.href).searchParams.get('rd')) {
 			loginDialog?.showModal();
 		}
 	});
 
-	let div: HTMLElement;
 	let rd = $derived.by(() => {
 		if (browser) {
 			const rd = new URL(window.location.href).searchParams.get('rd');
@@ -39,24 +34,10 @@
 	});
 
 	$effect(() => {
-		let a = assistants.find((assistant) => assistant.default);
-		if (a || assistants.length === 1) {
+		if (profile.current.loaded) {
 			goto(`/home`, { replaceState: true });
-		} else if (assistantsLoaded) {
-			window.location.href = '/admin/';
 		}
 	});
-
-	$effect(() => {
-		if (profile.current.unauthorized) {
-			show();
-		}
-	});
-
-	function show() {
-		div.classList.remove('hidden');
-		div.classList.add('flex');
-	}
 </script>
 
 {#snippet navLinks()}
@@ -86,7 +67,7 @@
 	<title>Obot - Do more with AI</title>
 </svelte:head>
 
-<div bind:this={div} class="relative hidden h-dvh w-full flex-col text-black dark:text-white">
+<div class="relative h-dvh w-full flex-col text-black dark:text-white">
 	<!-- Header with logo and navigation -->
 	<div class="colors-background flex h-16 w-full items-center p-5">
 		<div class="relative flex items-end">

--- a/ui/user/src/routes/+page.ts
+++ b/ui/user/src/routes/+page.ts
@@ -1,3 +1,4 @@
+import { browser } from '$app/environment';
 import { ChatService, type Project } from '$lib/services';
 import { sortByFeaturedNameOrder } from '$lib/sort';
 import type { PageLoad } from './$types';
@@ -21,10 +22,12 @@ export const load: PageLoad = async ({ fetch }) => {
 		// do nothing
 	}
 
-	const lastVisitedObot = localStorage.getItem('lastVisitedObot');
-	const matchingProject = editorProjects.find((p) => p.id === lastVisitedObot);
-	if (lastVisitedObot && matchingProject) {
-		throw redirect(303, `/o/${matchingProject.id}`);
+	if (browser) {
+		const lastVisitedObot = localStorage.getItem('lastVisitedObot');
+		const matchingProject = editorProjects.find((p) => p.id === lastVisitedObot);
+		if (lastVisitedObot && matchingProject) {
+			throw redirect(303, `/o/${matchingProject.id}`);
+		}
 	}
 
 	return {

--- a/ui/user/src/routes/+page.ts
+++ b/ui/user/src/routes/+page.ts
@@ -1,6 +1,7 @@
-import { type Assistant, ChatService } from '$lib/services';
+import { ChatService, type Project } from '$lib/services';
 import { sortByFeaturedNameOrder } from '$lib/sort';
 import type { PageLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
 
 export const load: PageLoad = async ({ fetch }) => {
 	const authProviders = await ChatService.listAuthProviders({ fetch });
@@ -12,20 +13,23 @@ export const load: PageLoad = async ({ fetch }) => {
 		)
 		.sort(sortByFeaturedNameOrder);
 	const tools = new Map((await ChatService.listAllTools({ fetch })).items.map((t) => [t.id, t]));
-	let assistantsLoaded = false;
-	let assistants: Assistant[] = [];
+	let editorProjects: Project[] = [];
 
 	try {
-		assistants = (await ChatService.listAssistants({ fetch })).items;
-		assistantsLoaded = true;
+		editorProjects = (await ChatService.listProjects({ fetch })).items;
 	} catch {
 		// do nothing
 	}
 
+	if (editorProjects.length > 0) {
+		const sortedProjects = editorProjects.sort(
+			(a, b) => new Date(b.created).getTime() - new Date(a.created).getTime()
+		);
+		throw redirect(303, `/o/${sortedProjects[0].id}`);
+	}
+
 	return {
 		authProviders,
-		assistants,
-		assistantsLoaded,
 		featuredProjectShares,
 		tools
 	};

--- a/ui/user/src/routes/+page.ts
+++ b/ui/user/src/routes/+page.ts
@@ -21,11 +21,10 @@ export const load: PageLoad = async ({ fetch }) => {
 		// do nothing
 	}
 
-	if (editorProjects.length > 0) {
-		const sortedProjects = editorProjects.sort(
-			(a, b) => new Date(b.created).getTime() - new Date(a.created).getTime()
-		);
-		throw redirect(303, `/o/${sortedProjects[0].id}`);
+	const lastVisitedObot = localStorage.getItem('lastVisitedObot');
+	const matchingProject = editorProjects.find((p) => p.id === lastVisitedObot);
+	if (lastVisitedObot && matchingProject) {
+		throw redirect(303, `/o/${matchingProject.id}`);
 	}
 
 	return {

--- a/ui/user/src/routes/catalog/+page.svelte
+++ b/ui/user/src/routes/catalog/+page.svelte
@@ -83,14 +83,12 @@
 			</div>
 		{/if}
 		{#if featured.length > 0}
-			<div
-				class="bg-surface2 dark:bg-surface1 mb-4 flex w-full flex-col items-center justify-center"
-			>
+			<div class="mb-4 flex w-full flex-col items-center justify-center">
 				<div class="flex w-full max-w-(--breakpoint-xl) flex-col gap-4 px-4 md:px-12">
 					<h3 class="mt-8 text-2xl font-semibold md:text-3xl">Featured</h3>
 					<div class="featured-card-layout gap-x-4 gap-y-6 sm:gap-y-8">
 						{#each featured.slice(0, 4) as featuredShare}
-							<FeaturedObotCard class="dark:bg-black" project={featuredShare} {tools} />
+							<FeaturedObotCard project={featuredShare} {tools} />
 						{/each}
 					</div>
 				</div>

--- a/ui/user/src/routes/catalog/+page.svelte
+++ b/ui/user/src/routes/catalog/+page.svelte
@@ -7,7 +7,7 @@
 	import type { PageProps } from './$types';
 	import ObotCard from '$lib/components/ObotCard.svelte';
 	import { q, qIsSet } from '$lib/url';
-	import { ChevronsLeft } from 'lucide-svelte';
+	import { ChevronLeft } from 'lucide-svelte';
 	import FeaturedObotCard from '$lib/components/FeaturedObotCard.svelte';
 	import { sortByFeaturedNameOrder } from '$lib/sort';
 
@@ -65,10 +65,13 @@
 	<main class="colors-background relative flex w-full flex-col items-center justify-center pb-12">
 		{#if qIsSet('from')}
 			{@const from = decodeURIComponent(q('from'))}
-			<div class="flex w-full max-w-(--breakpoint-xl) flex-col justify-start md:px-8">
-				<a href={from} class="button-text flex items-center gap-2 text-sm md:text-base"
-					><ChevronsLeft class="size-4" />{from.includes('home') ? 'My Obots' : 'Go Back'}</a
+			<div class="mt-8 flex w-full max-w-(--breakpoint-xl) flex-col justify-start md:px-8">
+				<a
+					href={from}
+					class="button-text flex w-fit items-center gap-1 pb-0 text-base font-semibold text-black md:text-lg dark:text-white"
 				>
+					<ChevronLeft class="size-5" />{from.includes('home') ? 'My Obots' : 'Go Back'}
+				</a>
 			</div>
 		{/if}
 		{#if qIsSet('new')}

--- a/ui/user/src/routes/catalog/+page.svelte
+++ b/ui/user/src/routes/catalog/+page.svelte
@@ -6,7 +6,7 @@
 	import Notifications from '$lib/components/Notifications.svelte';
 	import type { PageProps } from './$types';
 	import ObotCard from '$lib/components/ObotCard.svelte';
-	import { qIsSet } from '$lib/url';
+	import { q, qIsSet } from '$lib/url';
 	import { ChevronsLeft } from 'lucide-svelte';
 	import FeaturedObotCard from '$lib/components/FeaturedObotCard.svelte';
 	import { sortByFeaturedNameOrder } from '$lib/sort';
@@ -64,9 +64,10 @@
 
 	<main class="colors-background relative flex w-full flex-col items-center justify-center pb-12">
 		{#if qIsSet('from')}
+			{@const from = decodeURIComponent(q('from'))}
 			<div class="flex w-full max-w-(--breakpoint-xl) flex-col justify-start md:px-8">
-				<a href="/home" class="button-text flex items-center gap-2 text-sm md:text-base"
-					><ChevronsLeft class="size-4" /> My Obots</a
+				<a href={from} class="button-text flex items-center gap-2 text-sm md:text-base"
+					><ChevronsLeft class="size-4" />{from.includes('home') ? 'My Obots' : 'Go Back'}</a
 				>
 			</div>
 		{/if}
@@ -82,12 +83,14 @@
 			</div>
 		{/if}
 		{#if featured.length > 0}
-			<div class="bg-surface2 mb-4 flex w-full flex-col items-center justify-center">
+			<div
+				class="bg-surface2 dark:bg-surface1 mb-4 flex w-full flex-col items-center justify-center"
+			>
 				<div class="flex w-full max-w-(--breakpoint-xl) flex-col gap-4 px-4 md:px-12">
 					<h3 class="mt-8 text-2xl font-semibold md:text-3xl">Featured</h3>
 					<div class="featured-card-layout gap-x-4 gap-y-6 sm:gap-y-8">
 						{#each featured.slice(0, 4) as featuredShare}
-							<FeaturedObotCard project={featuredShare} {tools} />
+							<FeaturedObotCard class="dark:bg-black" project={featuredShare} {tools} />
 						{/each}
 					</div>
 				</div>

--- a/ui/user/src/routes/home/+page.svelte
+++ b/ui/user/src/routes/home/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { darkMode } from '$lib/stores';
-	import { Copy, Pencil, Trash2 } from 'lucide-svelte';
+	import { Copy, Pencil, Trash2, UserPen, X } from 'lucide-svelte';
 	import { Plus } from 'lucide-svelte/icons';
 	import Profile from '$lib/components/navbar/Profile.svelte';
 	import { ChatService, EditorService } from '$lib/services';
@@ -8,11 +8,11 @@
 	import { goto } from '$app/navigation';
 	import Notifications from '$lib/components/Notifications.svelte';
 	import type { PageProps } from './$types';
-	import DotDotDot from '$lib/components/DotDotDot.svelte';
 	import { type Project } from '$lib/services';
 	import Confirm from '$lib/components/Confirm.svelte';
-	import { DEFAULT_PROJECT_NAME } from '$lib/constants';
+	import { DEFAULT_PROJECT_DESCRIPTION, DEFAULT_PROJECT_NAME } from '$lib/constants';
 	import ObotCard from '$lib/components/ObotCard.svelte';
+	import { tooltip } from '$lib/actions/tooltip.svelte';
 
 	let { data }: PageProps = $props();
 	let toDelete = $state<Project>();
@@ -20,6 +20,9 @@
 		data.editorProjects
 			.filter((p) => p.editor == false)
 			.sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())
+	);
+	let recentlyUsedProjectsMap = $derived.by(
+		() => new Map(recentlyUsedProjects.map((p) => [p.id, p]))
 	);
 	let userProjects = $state<Project[]>(
 		data.editorProjects.sort(
@@ -87,29 +90,8 @@
 		</div>
 	</div>
 
-	{#snippet actionMenu(project: Project)}
-		<DotDotDot class="icon-button min-h-10 min-w-10 p-2.5 text-sm">
-			<div class="default-dialog flex flex-col p-2">
-				{#if project.editor}
-					<button class="menu-button" onclick={() => goto(`/o/${project.id}?edit`)}>
-						<Pencil class="icon-default" />
-						<span>Edit</span>
-					</button>
-				{/if}
-				<button class="menu-button" onclick={() => copy(project)}>
-					<Copy class="icon-default" />
-					<span>Copy</span>
-				</button>
-				<button class="menu-button" onclick={() => (toDelete = project)}>
-					<Trash2 class="icon-default" />
-					<span>{recentlyUsedProjects.some((p) => p.id === project.id) ? 'Remove' : 'Delete'}</span>
-				</button>
-			</div>
-		</DotDotDot>
-	{/snippet}
-
 	<main
-		class="colors-background relative flex w-full max-w-(--breakpoint-2xl) flex-col justify-center pb-12"
+		class="colors-background relative flex w-full max-w-(--breakpoint-2xl) flex-col justify-center md:pb-12"
 	>
 		<div class="mt-8 flex w-full flex-col gap-8">
 			<div class="flex w-full flex-col gap-4">
@@ -126,35 +108,49 @@
 					</button>
 					{#if !responsive.isMobile}
 						<div class="flex grow items-center justify-end">
-							<a href="/catalog?from=home" class="button-text items-center text-xs underline"
+							<a href="/catalog?from=home" class="button-primary items-center text-xs"
 								>View Obot Catalog</a
 							>
 						</div>
 					{/if}
 				</div>
-				{#if responsive.isMobile}
-					<div class="flex grow items-center justify-end">
-						<a href="/catalog?from=home" class="button-text items-center py-0 text-sm underline"
-							>View Obot Catalog</a
-						>
-					</div>
-				{/if}
 				<div class="card-layout px-4 md:px-12">
 					{#each userProjects as project}
 						<ObotCard {project} {tools}>
-							{#snippet menu()}
-								{@render actionMenu(project)}
+							{#snippet actionContent()}
+								<button
+									class="icon-button opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+									onclick={(e) => {
+										e.preventDefault();
+										toDelete = project;
+									}}
+									use:tooltip={recentlyUsedProjectsMap.has(project.id)
+										? 'Remove From My Obots'
+										: 'Delete Obot'}
+								>
+									{#if recentlyUsedProjectsMap.has(project.id)}
+										<X class="size-5" />
+									{:else}
+										<Trash2 class="size-4" />
+									{/if}
+								</button>
 							{/snippet}
 						</ObotCard>
 					{/each}
-					<button
-						class="card flex min-h-36 flex-col items-center justify-center p-4 whitespace-nowrap shadow-md"
-						onclick={() => createNew()}
-					>
-						<Plus class="h-8 w-8" />
-						<span class="text-sm font-semibold md:text-base">Create New Obot</span>
-					</button>
+
+					{#if userProjects.length === 0}
+						{@render placeholderBtn()}
+					{/if}
 				</div>
+
+				{#if responsive.isMobile}
+					<div class="sticky bottom-0 z-30 flex grow items-center bg-white px-4 py-2 dark:bg-black">
+						<a
+							href="/catalog?from=home"
+							class="button-primary w-full items-center text-center text-xs">View Obot Catalog</a
+						>
+					</div>
+				{/if}
 			</div>
 		</div>
 	</main>
@@ -162,8 +158,34 @@
 	<Notifications />
 </div>
 
+{#snippet placeholderBtn()}
+	<button
+		class="card flex min-h-36 flex-col items-center justify-center p-4 whitespace-nowrap shadow-md"
+		onclick={() => createNew()}
+	>
+		<div class="flex w-full">
+			<img alt="obot logo" src="/agent/images/obot_placeholder.webp" class="size-18 rounded-full" />
+			<div class="flex grow flex-col justify-between gap-2 pl-3">
+				<h4 class="text-md text-left leading-4.5 font-semibold">
+					{DEFAULT_PROJECT_NAME}
+				</h4>
+				<p class="line-clamp-3 grow text-left text-xs font-light text-gray-500">
+					{DEFAULT_PROJECT_DESCRIPTION}
+				</p>
+			</div>
+		</div>
+		<div class="flex w-full justify-between">
+			<span
+				class="bg-surface2 mt-auto flex h-fit w-fit gap-1 rounded-full px-3 py-1 text-xs font-light text-gray-500"
+			>
+				<UserPen class="size-4" /> Owner
+			</span>
+		</div>
+	</button>
+{/snippet}
+
 <Confirm
-	msg={recentlyUsedProjects.some((p) => p.id === toDelete?.id)
+	msg={toDelete?.id && recentlyUsedProjectsMap.has(toDelete.id)
 		? `Remove recently used Obot ${toDelete?.name || DEFAULT_PROJECT_NAME}?`
 		: `Delete the Obot ${toDelete?.name || DEFAULT_PROJECT_NAME}?`}
 	show={!!toDelete}

--- a/ui/user/src/routes/home/+page.svelte
+++ b/ui/user/src/routes/home/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { darkMode } from '$lib/stores';
-	import { Copy, Pencil, Trash2, UserPen, X } from 'lucide-svelte';
+	import { Trash2, UserPen, X } from 'lucide-svelte';
 	import { Plus } from 'lucide-svelte/icons';
 	import Profile from '$lib/components/navbar/Profile.svelte';
 	import { ChatService, EditorService } from '$lib/services';
@@ -38,11 +38,6 @@
 		} catch (error) {
 			errors.append((error as Error).message);
 		}
-	}
-
-	async function copy(project: Project) {
-		const newProject = await ChatService.copyProject(project.assistantID, project.id);
-		await goto(`/o/${newProject.id}`);
 	}
 </script>
 

--- a/ui/user/src/routes/o/[project]/+page.ts
+++ b/ui/user/src/routes/o/[project]/+page.ts
@@ -1,3 +1,4 @@
+import { browser } from '$app/environment';
 import { handleRouteError } from '$lib/errors';
 import { ChatService } from '$lib/services';
 import { profile } from '$lib/stores';
@@ -14,6 +15,10 @@ export const load: PageLoad = async ({ params, fetch }) => {
 			ChatService.listTools(project.assistantID, project.id, { fetch }),
 			ChatService.getAssistant(project.assistantID, { fetch })
 		]);
+
+		if (browser) {
+			localStorage.setItem('lastVisitedObot', params.project);
+		}
 
 		return { project, tools: tools.items, toolReferences: toolReferences.items, assistant };
 	} catch (e) {


### PR DESCRIPTION
From Will's Feedback:

https://www.loom.com/share/3889568825ab41368cdfcfe76ae55071

Sidebar Obot Selector Dropdown:
- [x] No more Recently Used & My Obots, similar to homepage
- [x] See All Obots should be “View Obot Catalog” and go to to catalog

Log In & Visiting Root:
- [x] For current browser, save session of the last Obot and if they go to obot.ai, go to the last obot they were working with or if they logged in

Homepage: 
* Obot Card:
- [x] Drop Edit, Copy actions
- [x] Have Remove a X icon
- [x] Have Delete be trash can icon

- [x] Remove the Create New Obot 

* For new user:
- [x] On an empty page, they see a placeholder that looks like a new My Obot that will essentially Create New Obot when clicked

- [x] View Obot Catalog — make it a button, maybe different color

Obot Catalog:
- [x] In obot catalog, the dark mode featured background, try changing


