### PR TITLE
enhance: add encryption to PII in users and identities

### DIFF
--- a/aws-encryption.yaml
+++ b/aws-encryption.yaml
@@ -4,6 +4,8 @@ resources:
   - resources:
       - credentials
       - runstates.obot.obot.ai
+      - users.obot.obot.ai
+      - identities.obot.obot.ai
     providers:
       - kms:
           apiVersion: v2

--- a/azure-encryption.yaml
+++ b/azure-encryption.yaml
@@ -4,6 +4,8 @@ resources:
   - resources:
       - credentials
       - runstates.obot.obot.ai
+      - users.obot.obot.ai
+      - identities.obot.obot.ai
     providers:
       - kms:
           apiVersion: v2

--- a/gcp-encryption.yaml
+++ b/gcp-encryption.yaml
@@ -4,6 +4,8 @@ resources:
   - resources:
       - credentials
       - runstates.obot.obot.ai
+      - users.obot.obot.ai
+      - identities.obot.obot.ai
     providers:
       - kms:
           apiVersion: v2

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -3,13 +3,12 @@ package client
 import (
 	"github.com/obot-platform/obot/pkg/gateway/db"
 	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
-	"k8s.io/apiserver/pkg/storage/value"
 )
 
 type Client struct {
-	db          *db.DB
-	transformer value.Transformer
-	adminEmails map[string]struct{}
+	db               *db.DB
+	encryptionConfig *encryptionconfig.EncryptionConfiguration
+	adminEmails      map[string]struct{}
 }
 
 func New(db *db.DB, encryptionConfig *encryptionconfig.EncryptionConfiguration, adminEmails []string) *Client {
@@ -17,14 +16,10 @@ func New(db *db.DB, encryptionConfig *encryptionconfig.EncryptionConfiguration, 
 	for _, email := range adminEmails {
 		adminEmailsSet[email] = struct{}{}
 	}
-	var transformer value.Transformer
-	if encryptionConfig != nil {
-		transformer = encryptionConfig.Transformers[gr]
-	}
 	return &Client{
-		db:          db,
-		transformer: transformer,
-		adminEmails: adminEmailsSet,
+		db:               db,
+		encryptionConfig: encryptionConfig,
+		adminEmails:      adminEmailsSet,
 	}
 }
 

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -2,36 +2,86 @@ package client
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/accesstoken"
 	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/hash"
 	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/storage/value"
 )
+
+var (
+	userGroupResource = schema.GroupResource{
+		Group:    "obot.obot.ai",
+		Resource: "users",
+	}
+)
+
+func (c *Client) UserFromToken(ctx context.Context, token string) (*types.User, string, string, error) {
+	id, token, _ := strings.Cut(token, ":")
+	u := new(types.User)
+	var namespace, name string
+	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		tkn := new(types.AuthToken)
+		if err := tx.Where("id = ? AND hashed_token = ?", id, hash.String(token)).First(tkn).Error; err != nil {
+			return err
+		}
+
+		namespace = tkn.AuthProviderNamespace
+		name = tkn.AuthProviderName
+		return tx.Where("id = ?", tkn.UserID).First(u).Error
+	}); err != nil {
+		return nil, "", "", err
+	}
+
+	return u, namespace, name, c.decryptUser(ctx, u)
+}
 
 func (c *Client) Users(ctx context.Context, query types.UserQuery) ([]types.User, error) {
 	var users []types.User
-	return users, c.db.WithContext(ctx).Scopes(query.Scope).Find(&users).Error
+	if err := c.db.WithContext(ctx).Scopes(query.Scope).Find(&users).Error; err != nil {
+		return nil, err
+	}
+
+	for i := range users {
+		if err := c.decryptUser(ctx, &users[i]); err != nil {
+			return nil, err
+		}
+	}
+
+	return users, nil
 }
 
 func (c *Client) User(ctx context.Context, username string) (*types.User, error) {
 	u := new(types.User)
-	return u, c.db.WithContext(ctx).Where("username = ?", username).First(u).Error
+	if err := c.db.WithContext(ctx).Where("hashed_username = ?", hash.String(username)).First(u).Error; err != nil {
+		return nil, err
+	}
+
+	return u, c.decryptUser(ctx, u)
 }
 
 func (c *Client) UserByID(ctx context.Context, id string) (*types.User, error) {
 	u := new(types.User)
-	return u, c.db.WithContext(ctx).Where("id = ?", id).First(u).Error
+	if err := c.db.WithContext(ctx).Where("id = ?", id).First(u).Error; err != nil {
+		return nil, err
+	}
+
+	return u, c.decryptUser(ctx, u)
 }
 
 func (c *Client) DeleteUser(ctx context.Context, username string) (*types.User, error) {
 	existingUser := new(types.User)
-	return existingUser, c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("username = ?", username).First(existingUser).Error; err != nil {
 			return err
 		}
@@ -39,7 +89,7 @@ func (c *Client) DeleteUser(ctx context.Context, username string) (*types.User, 
 		if existingUser.Role.HasRole(types2.RoleAdmin) {
 			var adminCount int64
 			// We filter out empty email users here, because that is the bootstrap user.
-			if err := tx.Model(new(types.User)).Where("role = ? and email != ''", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
+			if err := tx.Model(new(types.User)).Where("role = ? and hashed_email != ''", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
 				return err
 			}
 
@@ -53,18 +103,26 @@ func (c *Client) DeleteUser(ctx context.Context, username string) (*types.User, 
 		}
 
 		return tx.Delete(existingUser).Error
-	})
+	}); err != nil {
+		return nil, err
+	}
+
+	return existingUser, c.decryptUser(ctx, existingUser)
 }
 
 func (c *Client) UpdateUser(ctx context.Context, actingUserIsAdmin bool, updatedUser *types.User, username string) (*types.User, error) {
 	existingUser := new(types.User)
 	return existingUser, c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("username = ?", username).First(existingUser).Error; err != nil {
+		if err := tx.Where("hashed_username = ?", hash.String(username)).First(existingUser).Error; err != nil {
 			return err
 		}
 
+		if err := c.decryptUser(ctx, existingUser); err != nil {
+			return fmt.Errorf("failed to decrypt user: %w", err)
+		}
+
 		// If the username is being changed, then ensure that a user with that name doesn't already exist.
-		if updatedUser.Username != "" && updatedUser.Username != username {
+		if len(updatedUser.Username) != 0 && updatedUser.Username != existingUser.Username {
 			if err := tx.Model(updatedUser).Where("username = ?", updatedUser.Username).First(new(types.User)).Error; err == nil {
 				return &AlreadyExistsError{name: fmt.Sprintf("user with username %q", updatedUser.Username)}
 			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -84,12 +142,12 @@ func (c *Client) UpdateUser(ctx context.Context, actingUserIsAdmin bool, updated
 			if updatedUser.Role > 0 && existingUser.Role.HasRole(types2.RoleAdmin) && !updatedUser.Role.HasRole(types2.RoleAdmin) {
 				// If this user has been explicitly marked as an admin, then don't allow changing the role.
 				if c.IsExplicitAdmin(existingUser.Email) {
-					return &ExplicitAdminError{email: existingUser.Email}
+					return &ExplicitAdminError{email: string(existingUser.Email)}
 				}
 				// If the role is being changed from admin to non-admin, then ensure that this isn't the last admin.
 				// We filter out empty email users here, because that is the bootstrap user.
 				var adminCount int64
-				if err := tx.Model(new(types.User)).Where("role = ? and email != ''", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
+				if err := tx.Model(new(types.User)).Where("role = ? and hashed_email != ''", types2.RoleAdmin).Count(&adminCount).Error; err != nil {
 					return err
 				}
 
@@ -101,7 +159,13 @@ func (c *Client) UpdateUser(ctx context.Context, actingUserIsAdmin bool, updated
 			existingUser.Role = updatedUser.Role
 		}
 
-		return tx.Updates(existingUser).Error
+		// Copy the user object that is returned to the caller so they don't get the encrypted values
+		u := existingUser
+		if err := c.encryptUser(ctx, u); err != nil {
+			return fmt.Errorf("failed to encrypt user: %w", err)
+		}
+
+		return tx.Updates(u).Error
 	})
 }
 
@@ -115,9 +179,7 @@ func (c *Client) UpdateProfileIconIfNeeded(ctx context.Context, user *types.User
 		return nil
 	}
 
-	var (
-		identity types.Identity
-	)
+	var identity types.Identity
 	if err := c.db.WithContext(ctx).Where("user_id = ?", user.ID).
 		Where("auth_provider_name = ?", authProviderName).
 		Where("auth_provider_namespace = ?", authProviderNamespace).
@@ -125,8 +187,12 @@ func (c *Client) UpdateProfileIconIfNeeded(ctx context.Context, user *types.User
 		return err
 	}
 
+	if err := c.decryptIdentity(ctx, &identity); err != nil {
+		return fmt.Errorf("failed to decrypt identity: %w", err)
+	}
+
 	if user.IconURL == identity.IconURL && time.Until(identity.IconLastChecked) > -7*24*time.Hour {
-		// Icon was checked less than 7 days ago and the user is still using the same auth provider.
+		// Icon was checked less than 7 days ago, and the user is still using the same auth provider.
 		return nil
 	}
 
@@ -139,8 +205,18 @@ func (c *Client) UpdateProfileIconIfNeeded(ctx context.Context, user *types.User
 	identity.IconURL = profileIconURL
 	identity.IconLastChecked = time.Now()
 
+	if err = c.encryptIdentity(ctx, &identity); err != nil {
+		return fmt.Errorf("failed to encrypt identity: %w", err)
+	}
+
+	// Copy user so that the caller's copy doesn't get encrypted.
+	u := *user
+	if err = c.encryptUser(ctx, &u); err != nil {
+		return fmt.Errorf("failed to encrypt user: %w", err)
+	}
+
 	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Updates(user).Error; err != nil {
+		if err := tx.Updates(u).Error; err != nil {
 			return err
 		}
 		return tx.Updates(&identity).Error
@@ -173,4 +249,104 @@ func (c *Client) fetchProfileIconURL(ctx context.Context, authProviderURL, acces
 	}
 
 	return body.IconURL, nil
+}
+
+func (c *Client) encryptUser(ctx context.Context, user *types.User) error {
+	if c.encryptionConfig == nil {
+		return nil
+	}
+
+	transformer := c.encryptionConfig.Transformers[userGroupResource]
+	if transformer == nil {
+		return nil
+	}
+
+	var (
+		b    []byte
+		err  error
+		errs []error
+
+		dataCtx = userDataCtx(user)
+	)
+	if b, err = transformer.TransformToStorage(ctx, []byte(user.Username), dataCtx); err != nil {
+		errs = append(errs, err)
+	} else {
+		user.Username = base64.StdEncoding.EncodeToString(b)
+	}
+	if b, err = transformer.TransformToStorage(ctx, []byte(user.Email), dataCtx); err != nil {
+		errs = append(errs, err)
+	} else {
+		user.Email = base64.StdEncoding.EncodeToString(b)
+	}
+	if b, err = transformer.TransformToStorage(ctx, []byte(user.IconURL), dataCtx); err != nil {
+		errs = append(errs, err)
+	} else {
+		user.IconURL = base64.StdEncoding.EncodeToString(b)
+	}
+
+	user.Encrypted = true
+
+	return errors.Join(errs...)
+}
+
+func (c *Client) decryptUser(ctx context.Context, user *types.User) error {
+	if !user.Encrypted || c.encryptionConfig == nil {
+		return nil
+	}
+
+	transformer := c.encryptionConfig.Transformers[userGroupResource]
+	if transformer == nil {
+		return nil
+	}
+
+	var (
+		out, decoded []byte
+		n            int
+		err          error
+		errs         []error
+
+		dataCtx = userDataCtx(user)
+	)
+
+	decoded = make([]byte, base64.StdEncoding.DecodedLen(len(user.Username)))
+	n, err = base64.StdEncoding.Decode(decoded, []byte(user.Username))
+	if err == nil {
+		if out, _, err = transformer.TransformFromStorage(ctx, decoded[:n], dataCtx); err != nil {
+			errs = append(errs, err)
+		} else {
+			user.Username = string(out)
+		}
+	} else {
+		errs = append(errs, err)
+	}
+
+	decoded = make([]byte, base64.StdEncoding.DecodedLen(len(user.Email)))
+	n, err = base64.StdEncoding.Decode(decoded, []byte(user.Email))
+	if err == nil {
+		if out, _, err = transformer.TransformFromStorage(ctx, decoded[:n], dataCtx); err != nil {
+			errs = append(errs, err)
+		} else {
+			user.Email = string(out)
+		}
+	} else {
+		errs = append(errs, err)
+	}
+
+	decoded = make([]byte, base64.StdEncoding.DecodedLen(len(user.IconURL)))
+	n, err = base64.StdEncoding.Decode(decoded, []byte(user.IconURL))
+	if err == nil {
+		if out, _, err = transformer.TransformFromStorage(ctx, decoded[:n], dataCtx); err != nil {
+			errs = append(errs, err)
+		} else {
+			user.IconURL = string(out)
+		}
+	} else {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+func userDataCtx(user *types.User) value.Context {
+	return value.DefaultContext(fmt.Sprintf("%s/%s/%d", userGroupResource.String(), user.Username, user.ID))
 }

--- a/pkg/gateway/db/db.go
+++ b/pkg/gateway/db/db.go
@@ -39,53 +39,13 @@ func (db *DB) AutoMigrate() (err error) {
 
 	// Only run PostgreSQL-specific migrations if using PostgreSQL
 	if db.gormDB.Dialector.Name() == "postgres" {
-		// Check if the identities table exists
-		var exists bool
-		if err := tx.Raw(`
-			SELECT EXISTS (
-				SELECT 1
-				FROM information_schema.tables
-				WHERE table_name = 'identities'
-			)
-		`).Scan(&exists).Error; err != nil {
-			return err
+		if err = addAuthProviderNameAndNamespace(tx); err != nil {
+			return fmt.Errorf("failed to add auth provider name and namespace: %w", err)
 		}
+	}
 
-		if exists {
-			// The identities table needs to have auth_provider_namespace,auth_provider_name,provider_user_id as a primary key.
-			// It used to have auth_provider_namespace,auth_provider_name,provider_username as a primary key.
-
-			// Check if the migration is needed.
-			var needsIdentityMigration bool
-			if err := tx.Raw(`
-				SELECT COUNT(*) = 0 as needs_migration
-				FROM information_schema.key_column_usage
-				WHERE table_name = 'identities'
-				AND constraint_name = 'identities_pkey'
-				AND column_name = 'provider_user_id'
-			`).Scan(&needsIdentityMigration).Error; err != nil {
-				return err
-			}
-
-			if needsIdentityMigration {
-				// Add provider_user_id to identities table and update primary key.
-				if err := tx.Exec(`
-				-- Drop existing primary key
-				ALTER TABLE identities DROP CONSTRAINT identities_pkey;
-
-				-- Add provider_user_id column
-				ALTER TABLE identities ADD COLUMN provider_user_id text NOT NULL DEFAULT '';
-
-				-- Set placeholder values for existing records
-				UPDATE identities SET provider_user_id = 'OBOT_PLACEHOLDER_' || provider_username WHERE provider_user_id = '';
-
-				-- Add new primary key
-					ALTER TABLE identities ADD PRIMARY KEY (auth_provider_name, auth_provider_namespace, provider_user_id);
-				`).Error; err != nil {
-					return err
-				}
-			}
-		}
+	if err = addIdentityAndUserHashedFields(tx); err != nil {
+		return fmt.Errorf("failed to add identity and user hashed fields: %w", err)
 	}
 
 	if err := tx.AutoMigrate(&GptscriptCredential{}); err != nil {

--- a/pkg/gateway/db/migrations.go
+++ b/pkg/gateway/db/migrations.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/hash"
+	"gorm.io/gorm"
+)
+
+func addAuthProviderNameAndNamespace(tx *gorm.DB) error {
+	// Check if the identities table exists
+	migrator := tx.Migrator()
+	// If the identities table exists and the hashed_provider_user_id column doesn't, then we need
+	// to migrate the old identities.
+	if migrator.HasTable(&types.Identity{}) && !migrator.HasColumn(&types.Identity{}, "hashed_provider_user_id") {
+		// The identities table needs to have auth_provider_namespace,auth_provider_name,provider_user_id as a primary key.
+		// It used to have auth_provider_namespace,auth_provider_name,provider_username as a primary key.
+
+		// Check if the migration is needed.
+		var needsIdentityMigration bool
+		if err := tx.Raw(`
+				SELECT COUNT(*) = 0 as needs_migration
+				FROM information_schema.key_column_usage
+				WHERE table_name = 'identities'
+				AND constraint_name = 'identities_pkey'
+				AND column_name = 'provider_user_id'
+			`).Scan(&needsIdentityMigration).Error; err != nil {
+			return err
+		}
+
+		if needsIdentityMigration {
+			// Add provider_user_id to identities table and update primary key.
+			if err := tx.Exec(`
+				-- Drop existing primary key
+				ALTER TABLE identities DROP CONSTRAINT identities_pkey;
+
+				-- Add provider_user_id column
+				ALTER TABLE identities ADD COLUMN provider_user_id text NOT NULL DEFAULT '';
+
+				-- Set placeholder values for existing records
+				UPDATE identities SET provider_user_id = 'OBOT_PLACEHOLDER_' || provider_username WHERE provider_user_id = '';
+
+				-- Add new primary key
+					ALTER TABLE identities ADD PRIMARY KEY (auth_provider_name, auth_provider_namespace, provider_user_id);
+				`).Error; err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func addIdentityAndUserHashedFields(tx *gorm.DB) error {
+	migrator := tx.Migrator()
+	u := new(types.User)
+	if migrator.HasTable(u) {
+		var usersNeedHashedFields bool
+		if !migrator.HasColumn(u, "hashed_username") {
+			if err := migrator.AddColumn(u, "hashed_username"); err != nil {
+				return err
+			}
+
+			usersNeedHashedFields = true
+		}
+
+		if !migrator.HasColumn(u, "hashed_email") {
+			if err := migrator.AddColumn(u, "hashed_email"); err != nil {
+				return err
+			}
+
+			usersNeedHashedFields = true
+		}
+
+		if usersNeedHashedFields {
+			var users []types.User
+			if err := tx.Find(&users).Error; err != nil {
+				return err
+			}
+
+			for _, user := range users {
+				if user.Username != "" {
+					user.HashedUsername = hash.String(user.Username)
+				}
+				if user.Email != "" {
+					user.HashedEmail = hash.String(user.Email)
+				}
+
+				if err := tx.Model(&user).Updates(user).Error; err != nil {
+					return fmt.Errorf("failed to migrate user ID %d: %w", user.ID, err)
+				}
+			}
+		}
+	}
+
+	id := new(types.Identity)
+	if migrator.HasTable(id) && !migrator.HasColumn(id, "hashed_provider_user_id") {
+		if err := migrator.AddColumn(id, "hashed_provider_user_id"); err != nil {
+			return err
+		}
+
+		if err := migrator.AddColumn(id, "hashed_email"); err != nil {
+			return err
+		}
+
+		if migrator.HasConstraint(id, "identities_pkey") {
+			if err := migrator.DropConstraint(id, "identities_pkey"); err != nil {
+				return err
+			}
+		}
+
+		var identities []types.Identity
+		if err := tx.Find(&identities).Error; err != nil {
+			return err
+		}
+
+		for _, i := range identities {
+			if i.ProviderUserID != "" {
+				if err := tx.Model(&i).Where("provider_user_id = ? AND auth_provider_name = ? AND auth_provider_namespace = ?", i.ProviderUserID, i.AuthProviderName, i.AuthProviderNamespace).Update("hashed_provider_user_id", hash.String(i.ProviderUserID)).Error; err != nil {
+					return fmt.Errorf("failed to migrate identity for user ID %d: %w", i.UserID, err)
+				}
+			}
+			if i.Email != "" {
+				i.HashedEmail = hash.String(i.Email)
+				if err := tx.Model(&i).Where("provider_user_id = ? AND auth_provider_name = ? AND auth_provider_namespace = ?", i.ProviderUserID, i.AuthProviderName, i.AuthProviderNamespace).Update("hashed_email", hash.String(i.Email)).Error; err != nil {
+					return fmt.Errorf("failed to migrate identity for user ID %d: %w", i.UserID, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/gateway/server/oauth.go
+++ b/pkg/gateway/server/oauth.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,6 +11,7 @@ import (
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/hash"
 	"gorm.io/gorm"
 )
 
@@ -91,7 +91,7 @@ func (s *Server) redirect(apiContext api.Context) error {
 	tkn := &types.AuthToken{
 		ID: fmt.Sprintf("%x", id),
 		// Hash the token again for long-term storage
-		HashedToken:           hashToken(fmt.Sprintf("%x", token)),
+		HashedToken:           hash.String(fmt.Sprintf("%x", token)),
 		ExpiresAt:             tr.ExpiresAt,
 		AuthProviderNamespace: namespace,
 		AuthProviderName:      name,
@@ -114,10 +114,6 @@ func (s *Server) redirect(apiContext api.Context) error {
 
 	http.Redirect(apiContext.ResponseWriter, apiContext.Request, tr.CompletionRedirectURL, http.StatusFound)
 	return nil
-}
-
-func hashToken(token string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(token)))
 }
 
 func publicToken(id, token []byte) string {

--- a/pkg/gateway/server/router.go
+++ b/pkg/gateway/server/router.go
@@ -28,6 +28,7 @@ func (s *Server) AddRoutes(mux *server.Server) {
 	mux.HandleFunc("DELETE /api/me", wrap(s.deleteUser))
 	mux.HandleFunc("POST /api/logout-all", wrap(s.logoutAll))
 	mux.HandleFunc("GET /api/users", wrap(s.getUsers))
+	mux.HandleFunc("POST /api/encrypt-all-users", wrap(s.encryptAllUsers))
 	mux.HandleFunc("GET /api/users/{username_or_id}", wrap(s.getUser))
 	mux.HandleFunc("GET /api/users/{user_id}/activities", wrap(s.activitiesByUser))
 	mux.HandleFunc("PATCH /api/users/{username}", wrap(s.updateUser))

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -59,6 +59,21 @@ func (s *Server) getUsers(apiContext api.Context) error {
 	return apiContext.Write(types2.UserList{Items: items})
 }
 
+func (s *Server) encryptAllUsers(apiContext api.Context) error {
+	users, err := apiContext.GatewayClient.Users(apiContext.Context(), types.NewUserQuery(apiContext.URL.Query()))
+	if err != nil {
+		return fmt.Errorf("failed to get users: %v", err)
+	}
+
+	for _, user := range users {
+		if _, err = s.client.UpdateUser(apiContext.Context(), apiContext.UserIsAdmin(), &user, user.Username); err != nil {
+			return fmt.Errorf("failed to encrypt user with id %d: %v", user.ID, err)
+		}
+	}
+
+	return apiContext.Write("done")
+}
+
 func (s *Server) getUser(apiContext api.Context) error {
 	var (
 		getByID      = apiContext.URL.Query().Get("by-id") == "true"

--- a/pkg/gateway/types/activity.go
+++ b/pkg/gateway/types/activity.go
@@ -14,7 +14,6 @@ type LLMProxyActivity struct {
 	AgentID        string
 	ThreadID       string
 	RunID          string
-	Username       string
 	Path           string
 }
 

--- a/pkg/gateway/types/identity.go
+++ b/pkg/gateway/types/identity.go
@@ -6,9 +6,12 @@ type Identity struct {
 	AuthProviderName      string    `json:"authProviderName" gorm:"primaryKey;index:idx_user_auth_id"`
 	AuthProviderNamespace string    `json:"authProviderNamespace" gorm:"primaryKey;index:idx_user_auth_id"`
 	ProviderUsername      string    `json:"providerUsername"`
-	ProviderUserID        string    `json:"providerUserID" gorm:"primaryKey"`
+	ProviderUserID        string    `json:"providerUserID"`
+	HashedProviderUserID  string    `json:"hashedProviderUserID" gorm:"primaryKey"`
 	Email                 string    `json:"email"`
+	HashedEmail           string    `json:"hashedEmail"`
 	UserID                uint      `json:"userID" gorm:"index:idx_user_auth_id"`
 	IconURL               string    `json:"iconURL"`
 	IconLastChecked       time.Time `json:"iconLastChecked"`
+	Encrypted             bool      `json:"encrypted"`
 }

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -7,20 +7,24 @@ import (
 	"time"
 
 	types2 "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/hash"
 	"gorm.io/gorm"
 )
 
 type User struct {
-	ID            uint        `json:"id" gorm:"primaryKey"`
-	CreatedAt     time.Time   `json:"createdAt"`
-	Username      string      `json:"username" gorm:"unique"`
-	Email         string      `json:"email"`
-	VerifiedEmail *bool       `json:"verifiedEmail,omitempty"`
-	Role          types2.Role `json:"role"`
-	IconURL       string      `json:"iconURL"`
-	Timezone      string      `json:"timezone"`
+	ID             uint        `json:"id" gorm:"primaryKey"`
+	CreatedAt      time.Time   `json:"createdAt"`
+	Username       string      `json:"username"`
+	HashedUsername string      `json:"-" gorm:"unique"`
+	Email          string      `json:"email"`
+	HashedEmail    string      `json:"-"`
+	VerifiedEmail  *bool       `json:"verifiedEmail,omitempty"`
+	Role           types2.Role `json:"role"`
+	IconURL        string      `json:"iconURL"`
+	Timezone       string      `json:"timezone"`
 	// LastActiveDay is the time of the last request made by this user, currently at the 24 hour granularity.
 	LastActiveDay time.Time `json:"lastActiveDay"`
+	Encrypted     bool      `json:"encrypted"`
 }
 
 func ConvertUser(u *User, roleFixed bool, authProviderName string) *types2.User {
@@ -65,10 +69,10 @@ func NewUserQuery(u url.Values) UserQuery {
 
 func (q UserQuery) Scope(db *gorm.DB) *gorm.DB {
 	if q.Username != "" {
-		db = db.Where("username LIKE ?", "%"+q.Username+"%")
+		db = db.Where("hashed_username = ?", "%"+hash.String(q.Username)+"%")
 	}
 	if q.Email != "" {
-		db = db.Where("email LIKE ?", "%"+q.Email+"%")
+		db = db.Where("hashed_email = ?", "%"+hash.String(q.Email)+"%")
 	}
 	if q.Role != 0 {
 		db = db.Where("role = ?", q.Role)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -35,6 +35,7 @@ import (
 	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/gemini"
+	"github.com/obot-platform/obot/pkg/hash"
 	"github.com/obot-platform/obot/pkg/invoke"
 	"github.com/obot-platform/obot/pkg/jwt"
 	"github.com/obot-platform/obot/pkg/proxy"
@@ -398,8 +399,9 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		// This reduces the chance that someone could authenticate as "nobody" and get admin access once authentication
 		// is enabled.
 		if err := gatewayClient.RemoveIdentity(ctx, &types.Identity{
-			ProviderUsername: "nobody",
-			ProviderUserID:   "nobody",
+			ProviderUsername:     "nobody",
+			ProviderUserID:       "nobody",
+			HashedProviderUserID: hash.String("nobody"),
 		}); err != nil {
 			return nil, fmt.Errorf(`failed to remove "nobody" user and identity from database: %w`, err)
 		}


### PR DESCRIPTION
To make this work, some hashed values are also added to the database to ensure that getting users and identities still works as expected. That is, we still need to get/update user by username. Therefore, we store a hash of the username in the database for selecting. Similar for some other fields.

Another field was added to users and identities: encrypted. This field tracks if a user or identity is encrypted in the database for migration and enabling encryption when it was off to begin with. This new field is really an implementation detail, which means that all gets/updates/creates for users and identities should be done through the client forever more.

Necessary migrations are also added for the hashed fields that are now required for users and identities.