### PR TITLE
fix: only show log out all button if using db for session storage

### DIFF
--- a/pkg/api/handlers/version.go
+++ b/pkg/api/handlers/version.go
@@ -11,19 +11,35 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+type SessionStore string
+
+const (
+	SessionStoreDB     SessionStore = "db"
+	SessionStoreCookie SessionStore = "cookie"
+)
+
+func sessionStoreFromPostgresDSN(postgresDSN string) SessionStore {
+	if postgresDSN != "" {
+		return SessionStoreDB
+	}
+	return SessionStoreCookie
+}
+
 type VersionHandler struct {
 	gptscriptVersion string
 	emailDomain      string
 	supportDocker    bool
 	authEnabled      bool
+	sessionStore     SessionStore
 }
 
-func NewVersionHandler(emailDomain string, supportDocker, authEnabled bool) *VersionHandler {
+func NewVersionHandler(emailDomain, postgresDSN string, supportDocker, authEnabled bool) *VersionHandler {
 	return &VersionHandler{
 		emailDomain:      emailDomain,
 		gptscriptVersion: getGPTScriptVersion(),
 		supportDocker:    supportDocker,
 		authEnabled:      authEnabled,
+		sessionStore:     sessionStoreFromPostgresDSN(postgresDSN),
 	}
 }
 
@@ -44,6 +60,7 @@ func (v *VersionHandler) getVersionResponse() map[string]any {
 	values["emailDomain"] = v.emailDomain
 	values["dockerSupported"] = v.supportDocker
 	values["authEnabled"] = v.authEnabled
+	values["sessionStore"] = v.sessionStore
 	return values
 }
 

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -32,7 +32,7 @@ func Router(services *services.Services) (http.Handler, error) {
 	prompt := handlers.NewPromptHandler(services.GPTClient)
 	emailReceiver := handlers.NewEmailReceiverHandler(services.EmailServerName)
 	defaultModelAliases := handlers.NewDefaultModelAliasHandler()
-	version := handlers.NewVersionHandler(services.EmailServerName, services.SupportDocker, services.AuthEnabled)
+	version := handlers.NewVersionHandler(services.EmailServerName, services.PostgresDSN, services.SupportDocker, services.AuthEnabled)
 	tables := handlers.NewTableHandler(services.GPTClient)
 	projects := handlers.NewProjectsHandler(services.Router.Backend(), services.Invoker, services.GPTClient)
 	projectShare := handlers.NewProjectShareHandler()

--- a/ui/admin/app/lib/model/version.ts
+++ b/ui/admin/app/lib/model/version.ts
@@ -4,4 +4,5 @@ export type Version = {
 	dockerSupported?: boolean;
 	emailDomain: string;
 	gptscript: string;
+	sessionStore: string;
 };

--- a/ui/admin/test/mocks/models/version.ts
+++ b/ui/admin/test/mocks/models/version.ts
@@ -6,4 +6,5 @@ export const mockedVersion: Version = {
 	emailDomain: "",
 	gptscript: "v0.9.5",
 	obot: "v0.0.0-dev",
+	sessionStore: "db",
 };

--- a/ui/user/src/lib/components/navbar/Profile.svelte
+++ b/ui/user/src/lib/components/navbar/Profile.svelte
@@ -7,6 +7,7 @@
 	import { twMerge } from 'tailwind-merge';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import { success } from '$lib/stores/success';
+	import { version } from '$lib/stores';
 
 	let showLogoutAllConfirm = $state(false);
 
@@ -108,9 +109,11 @@
 				<a href="/oauth2/sign_out?rd=/" rel="external" role="menuitem" class="link"
 					><LogOut class="size-4" /> Log out</a
 				>
-				<button onclick={() => (showLogoutAllConfirm = true)} class="link text-red-500">
-					<LogOut class="size-4" /> Log out all other sessions
-				</button>
+				{#if version.current.sessionStore === 'db'}
+					<button onclick={() => (showLogoutAllConfirm = true)} class="link text-red-500">
+						<LogOut class="size-4" /> Log out all other sessions
+					</button>
+				{/if}
 			{/if}
 		</div>
 	{/snippet}

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -137,6 +137,7 @@ export interface Messages {
 export interface Version {
 	emailDomain?: string;
 	dockerSupported?: boolean;
+	sessionStore?: string;
 }
 
 export interface Profile {


### PR DESCRIPTION
I think we plan on changing this in another follow-up to put the button somewhere else, but we might as well now hide it when it's not needed.