### PR TITLE
fix: detect task calling cycles

### DIFF
--- a/apiclient/task.go
+++ b/apiclient/task.go
@@ -9,6 +9,8 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 )
 
+const TaskBreadCrumbHeader = "X-Obt-Task-Bread-Crumb"
+
 type ListTasksOptions struct {
 	ThreadID    string
 	AssistantID string
@@ -117,8 +119,9 @@ func (c *Client) ListTaskRuns(ctx context.Context, taskID string, opts ListTaskR
 }
 
 type TaskRunOptions struct {
-	ThreadID    string
-	AssistantID string
+	ThreadID       string
+	AssistantID    string
+	TaskBreadCrumb string
 }
 
 func (c *Client) RunTask(ctx context.Context, taskID string, input string, opts TaskRunOptions) (*types.TaskRun, error) {
@@ -129,7 +132,7 @@ func (c *Client) RunTask(ctx context.Context, taskID string, input string, opts 
 		url = fmt.Sprintf("/assistants/%s/tasks/%s/run", opts.AssistantID, taskID)
 	}
 
-	_, resp, err := c.postJSON(ctx, url, input)
+	_, resp, err := c.postJSON(ctx, url, input, TaskBreadCrumbHeader, opts.TaskBreadCrumb)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/handlers/tasks.go
+++ b/pkg/api/handlers/tasks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/nah/pkg/name"
 	"github.com/obot-platform/nah/pkg/randomtoken"
+	"github.com/obot-platform/obot/apiclient"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/events"
@@ -305,6 +306,7 @@ func (t *TaskHandler) RunFromScope(req api.Context) error {
 func (t *TaskHandler) run(req api.Context, workflow *v1.Workflow, threadName string) error {
 	stepID := req.PathValue("step_id")
 	runID := req.PathValue("run_id")
+	taskBreadCrumb := req.Request.Header.Get(apiclient.TaskBreadCrumbHeader)
 
 	input, err := req.Body()
 	if err != nil {
@@ -335,11 +337,12 @@ func (t *TaskHandler) run(req api.Context, workflow *v1.Workflow, threadName str
 				Namespace:    req.Namespace(),
 			},
 			Spec: v1.WorkflowExecutionSpec{
-				Input:        string(input),
-				ThreadName:   threadName,
-				WorkflowName: workflow.Name,
-				RunUntilStep: req.URL.Query().Get("stepID"),
-				RunName:      getRunIDFromUser(req),
+				Input:          string(input),
+				ThreadName:     threadName,
+				WorkflowName:   workflow.Name,
+				RunUntilStep:   req.URL.Query().Get("stepID"),
+				RunName:        getRunIDFromUser(req),
+				TaskBreakCrumb: taskBreadCrumb,
 			},
 		}
 		if err := req.Create(wfe); err != nil {

--- a/pkg/controller/handlers/workflowstep/invoke.go
+++ b/pkg/controller/handlers/workflowstep/invoke.go
@@ -60,7 +60,7 @@ func (h *Handler) RunInvoke(req router.Request, _ router.Response) error {
 func (h *Handler) setStepStateFromRun(step *v1.WorkflowStep, run *v1.Run) error {
 	switch run.Status.State {
 	case v1.Finished:
-		step.Status.State = types.WorkflowStateBlocked
+		step.Status.State = types.WorkflowStateError
 		step.Status.LastRunName = step.Status.RunNames[0]
 		step.Status.Error = "Aborted"
 	case v1.Continue:

--- a/pkg/invoke/invoker.go
+++ b/pkg/invoke/invoker.go
@@ -176,6 +176,7 @@ type Options struct {
 	EphemeralThread       bool
 	ThreadName            string
 	ParentThreadName      string
+	WorkflowName          string
 	WorkflowStepName      string
 	WorkflowStepID        string
 	WorkflowExecutionName string
@@ -185,6 +186,7 @@ type Options struct {
 	CredentialContextIDs  []string
 	UserUID               string
 	GenerateName          string
+	ExtraEnv              []string
 }
 
 func (i *Invoker) getChatState(ctx context.Context, c kclient.Client, run *v1.Run) (result string, _ error) {
@@ -377,8 +379,9 @@ func (i *Invoker) Agent(ctx context.Context, c kclient.WithWatch, agent *v1.Agen
 
 	return i.createRun(ctx, c, thread, tools, input, runOptions{
 		Synchronous:           opt.Synchronous,
+		WorkflowName:          opt.WorkflowName,
 		AgentName:             agent.Name,
-		Env:                   extraEnv,
+		Env:                   append(extraEnv, opt.ExtraEnv...),
 		CredentialContextIDs:  credContextIDs,
 		WorkflowStepName:      opt.WorkflowStepName,
 		WorkflowStepID:        opt.WorkflowStepID,

--- a/pkg/invoke/step.go
+++ b/pkg/invoke/step.go
@@ -28,12 +28,19 @@ func (i *Invoker) Step(ctx context.Context, c kclient.WithWatch, step *v1.Workfl
 		return nil, err
 	}
 
+	var extraEnv []string
+	if wfe.Spec.TaskBreakCrumb != "" {
+		extraEnv = []string{"OBOT_TASK_BREAD_CRUMB=" + wfe.Spec.TaskBreakCrumb}
+	}
+
 	return i.Thread(ctx, c, &thread, input, Options{
+		WorkflowName:          wfe.Spec.WorkflowName,
 		WorkflowStepName:      step.Name,
 		WorkflowStepID:        step.Spec.Step.ID,
 		WorkflowExecutionName: wfe.Name,
 		PreviousRunName:       opt.PreviousRunName,
 		ForceNoResume:         opt.PreviousRunName == "",
+		ExtraEnv:              extraEnv,
 	})
 }
 

--- a/pkg/storage/apis/obot.obot.ai/v1/workflowexecution.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/workflowexecution.go
@@ -73,6 +73,9 @@ type WorkflowExecutionSpec struct {
 	RunUntilStep       string `json:"runUntilStep,omitempty"`
 	// The Run that started this execution
 	RunName string `json:"runName,omitempty"`
+	// TaskBreadCrumb is a comma-delimited list of taskID calls made to execute this task.
+	// This helps to prevent cycles when tasks call tasks.
+	TaskBreakCrumb string `json:"taskBreakCrumb,omitempty"`
 }
 
 func (in *WorkflowExecution) DeleteRefs() []Ref {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -10118,6 +10118,13 @@ func schema_storage_apis_obotobotai_v1_WorkflowExecutionSpec(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"taskBreakCrumb": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TaskBreadCrumb is a comma-delimited list of taskID calls made to execute this task. This helps to prevent cycles when tasks call tasks.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
It is possible for users to construct tasks that call other tasks. A problem arises when a task call cycle is accidentally constructed because the task will never complete. This change tracks task breadcrumbs so the task invoke tool can detect cycles.