### PR TITLE
fix: report errors for workflow executions

### DIFF
--- a/pkg/controller/handlers/workflowstep/invoke.go
+++ b/pkg/controller/handlers/workflowstep/invoke.go
@@ -54,15 +54,20 @@ func (h *Handler) RunInvoke(req router.Request, _ router.Response) error {
 		}
 	}
 
-	return h.setStepStateFromRun(step, &run)
+	h.setStepStateFromRun(step, &run)
+
+	return nil
 }
 
-func (h *Handler) setStepStateFromRun(step *v1.WorkflowStep, run *v1.Run) error {
+func (h *Handler) setStepStateFromRun(step *v1.WorkflowStep, run *v1.Run) {
 	switch run.Status.State {
 	case v1.Finished:
 		step.Status.State = types.WorkflowStateError
 		step.Status.LastRunName = step.Status.RunNames[0]
 		step.Status.Error = "Aborted"
+		if run.Status.Output != "" {
+			step.Status.Error += ": " + run.Status.Output
+		}
 	case v1.Continue:
 		step.Status.State = types.WorkflowStateComplete
 		step.Status.LastRunName = step.Status.RunNames[0]
@@ -72,5 +77,4 @@ func (h *Handler) setStepStateFromRun(step *v1.WorkflowStep, run *v1.Run) error 
 		step.Status.LastRunName = step.Status.RunNames[0]
 		step.Status.Error = run.Status.Error
 	}
-	return nil
 }


### PR DESCRIPTION
If a workflow execution failed for some reason, this was not being reported correctly in the external call information. It would look like the task would run forever.

This change will detect errors and report them on the external run output.