### PR TITLE
fix: layout.items updates on message file item changes

### DIFF
--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -92,7 +92,10 @@
 				// false means don't reconnect
 				return false;
 			},
-			items: layout.items
+			items: layout.items,
+			onItemsChanged: (items) => {
+				layout.items = items;
+			}
 		});
 
 		messages = {

--- a/ui/user/src/lib/components/editor/Milkdown.svelte
+++ b/ui/user/src/lib/components/editor/Milkdown.svelte
@@ -145,8 +145,8 @@
 				editorCtx = ctx;
 
 				const listener = ctx.get(listenerCtx);
-				listener.markdownUpdated((ctx, markdown, prevMarkdown) => {
-					if (markdown === prevMarkdown) {
+				listener.markdownUpdated((_ctx, markdown, prevMarkdown) => {
+					if (markdown === prevMarkdown || markdown === lastSetValue) {
 						return;
 					}
 

--- a/ui/user/src/lib/services/chat/messages.ts
+++ b/ui/user/src/lib/services/chat/messages.ts
@@ -2,6 +2,13 @@ import { ABORTED_BY_USER_MESSAGE, ABORTED_THREAD_MESSAGE } from '$lib/constants'
 import type { EditorItem } from '$lib/services/editor/index.svelte';
 import type { CitationSource, Explain, InputMessage, Message, Messages, Progress } from './types';
 
+type AdditionalOptions = {
+	threadID?: string;
+	taskID?: string;
+	runID?: string;
+	onItemsChanged?: (items: EditorItem[]) => void;
+};
+
 const errorIcon = 'Error';
 const assistantIcon = 'Assistant';
 const profileIcon = 'Profile';
@@ -23,13 +30,10 @@ function setFileContent(
 	name: string,
 	content: string,
 	full: boolean = false,
-	opts: {
-		threadID?: string;
-		taskID?: string;
-		runID?: string;
-	} = {}
+	opts: AdditionalOptions = {}
 ) {
 	const id = opts.runID ? `${opts.taskID}/${opts.runID}/${name}` : `${opts.threadID}/${name}`;
+
 	const existing = items.find((f) => f.id === id);
 	if (existing && existing.file) {
 		if (full) {
@@ -54,6 +58,10 @@ function setFileContent(
 	items.forEach((f) => {
 		f.selected = f.name === name;
 	});
+
+	if (opts.onItemsChanged) {
+		opts.onItemsChanged(items);
+	}
 }
 
 function reformatInputMessage(msg: Message) {
@@ -127,11 +135,7 @@ function reformatWriteMessage(
 	items: EditorItem[],
 	msg: Message,
 	last: boolean,
-	opts: {
-		threadID?: string;
-		taskID?: string;
-		runID?: string;
-	} = {}
+	opts: AdditionalOptions = {}
 ) {
 	msg.icon = 'Pencil';
 	msg.done = !last || msg.toolCall !== undefined;
@@ -161,11 +165,7 @@ function reformatWriteMessage(
 export function buildMessagesFromProgress(
 	items: EditorItem[],
 	progresses: Progress[],
-	opts: {
-		threadID?: string;
-		taskID?: string;
-		runID?: string;
-	}
+	opts: AdditionalOptions
 ): Messages {
 	const messages = toMessages(progresses);
 

--- a/ui/user/src/lib/services/chat/thread.svelte.ts
+++ b/ui/user/src/lib/services/chat/thread.svelte.ts
@@ -30,7 +30,7 @@ export class Thread {
 		tools?: string[];
 	};
 	readonly #items: EditorItem[] = [];
-
+	readonly #onItemsChanged?: (items: EditorItem[]) => void;
 	constructor(
 		project: Project,
 		opts?: {
@@ -46,6 +46,7 @@ export class Thread {
 			onError?: (error: Error) => void;
 			// Return true to reconnect, false to close
 			onClose?: () => boolean;
+			onItemsChanged?: (items: EditorItem[]) => void;
 			items?: EditorItem[];
 		}
 	) {
@@ -59,6 +60,9 @@ export class Thread {
 		this.#es = this.#reconnect();
 		if (opts?.items) {
 			this.#items = opts.items;
+		}
+		if (opts?.onItemsChanged) {
+			this.#onItemsChanged = opts.onItemsChanged;
 		}
 	}
 
@@ -168,7 +172,8 @@ export class Thread {
 				buildMessagesFromProgress(this.#items, msgs, {
 					taskID: this.#task?.id,
 					runID: this.runID,
-					threadID: this.threadID
+					threadID: this.threadID,
+					onItemsChanged: this.#onItemsChanged
 				})
 			);
 		}
@@ -181,7 +186,8 @@ export class Thread {
 				buildMessagesFromProgress(this.#items, this.#progresses, {
 					taskID: this.#task?.id,
 					runID: this.runID,
-					threadID: this.threadID
+					threadID: this.threadID,
+					onItemsChanged: this.#onItemsChanged
 				})
 			);
 			this.#handleSteps();


### PR DESCRIPTION
* added an onItemsChanged optional fn to pass into the instantiated Thread class

Addresses #2437 
Slack convo for reference: https://acorn-io.slack.com/archives/C07P0EZR917/p1744065127996349

I did try removing the `readonly` on `items` and fiddled with it to trigger reactivity but it looks like svelte triggers reactivity based on assignment so changing something on `this.#items` will not necessarily trigger a render like changing `layout.items` would. 