### PR TITLE
Fix: don't assign slack receiver to triggers

### DIFF
--- a/pkg/gateway/server/oauth_apps.go
+++ b/pkg/gateway/server/oauth_apps.go
@@ -654,15 +654,6 @@ func (s *Server) storeSlackTrigger(apiContext api.Context, tokenResp types.OAuth
 		return nil
 	}
 
-	slackReceiverName := system.SlackReceiverPrefix + thread.Spec.ParentThreadName
-
-	var slackReceiver v1.SlackReceiver
-	if err := apiContext.Get(&slackReceiver, slackReceiverName); apierrors.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		return err
-	}
-
 	id := name.SafeHashConcatName(slackAppID, slackTeamID, thread.Spec.ParentThreadName)
 	name := system.SlackTriggerPrefix + hash2.String(id)[:12]
 	err := apiContext.Create(&v1.SlackTrigger{
@@ -671,10 +662,9 @@ func (s *Server) storeSlackTrigger(apiContext api.Context, tokenResp types.OAuth
 			Namespace: apiContext.Namespace(),
 		},
 		Spec: v1.SlackTriggerSpec{
-			AppID:             slackAppID,
-			TeamID:            slackTeamID,
-			ThreadName:        thread.Spec.ParentThreadName,
-			SlackReceiverName: slackReceiverName,
+			AppID:      slackAppID,
+			TeamID:     slackTeamID,
+			ThreadName: thread.Spec.ParentThreadName,
 		},
 		Status: v1.SlackTriggerStatus{},
 	})

--- a/pkg/storage/apis/obot.obot.ai/v1/slacktrigger.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/slacktrigger.go
@@ -25,7 +25,6 @@ type SlackTrigger struct {
 func (in *SlackTrigger) DeleteRefs() []Ref {
 	return []Ref{
 		{ObjType: new(Thread), Name: in.Spec.ThreadName},
-		{ObjType: new(SlackReceiver), Name: in.Spec.SlackReceiverName},
 	}
 }
 
@@ -48,10 +47,9 @@ func (in *SlackTrigger) FieldNames() []string {
 }
 
 type SlackTriggerSpec struct {
-	AppID             string `json:"appID,omitempty"`
-	TeamID            string `json:"teamID,omitempty"`
-	ThreadName        string `json:"threadName,omitempty"`
-	SlackReceiverName string `json:"slackReceiverName,omitempty"`
+	AppID      string `json:"appID,omitempty"`
+	TeamID     string `json:"teamID,omitempty"`
+	ThreadName string `json:"threadName,omitempty"`
 }
 
 type SlackTriggerStatus struct {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -8573,12 +8573,6 @@ func schema_storage_apis_obotobotai_v1_SlackTriggerSpec(ref common.ReferenceCall
 							Format: "",
 						},
 					},
-					"slackReceiverName": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
It turns out that assigning slack receiver name to trigger doesn't work well in copied obot, it is hard to trace the original slack receiver. Just relying on parent thread to delete should be fine for now.