### PR TITLE
Fix: Delete workfile confirmation popup style issue

### DIFF
--- a/ui/user/src/lib/components/edit/Files.svelte
+++ b/ui/user/src/lib/components/edit/Files.svelte
@@ -173,10 +173,7 @@
 							class="icon-button-small invisible ms-2 group-hover:visible"
 							onclick={() => {
 								fileToDelete = file.name;
-								const element = document.querySelector('#click-catch');
-								if (element instanceof HTMLElement) {
-									element.click();
-								}
+								menu?.toggle(false);
 							}}
 						>
 							<Trash class="text-gray h-5 w-5" />


### PR DESCRIPTION
Delete workfile confirmation popup window gets hidden behind the file list
Addresses [#2439](https://github.com/obot-platform/obot/issues/2439)