### PR TITLE
fix: allow user to delete their account from the UI

### DIFF
--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -82,7 +82,7 @@ func (c *Client) UserByID(ctx context.Context, id string) (*types.User, error) {
 func (c *Client) DeleteUser(ctx context.Context, username string) (*types.User, error) {
 	existingUser := new(types.User)
 	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("username = ?", username).First(existingUser).Error; err != nil {
+		if err := tx.Where("hashed_username = ?", hash.String(username)).First(existingUser).Error; err != nil {
 			return err
 		}
 

--- a/pkg/gateway/server/activeusers.go
+++ b/pkg/gateway/server/activeusers.go
@@ -17,7 +17,7 @@ func (s *Server) activeUsers(apiContext api.Context) error {
 		return err
 	}
 
-	activeUsers, err := s.client.ActiveUsersByDate(apiContext.Context(), start, end)
+	activeUsers, err := apiContext.GatewayClient.ActiveUsersByDate(apiContext.Context(), start, end)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (s *Server) activitiesByUser(apiContext api.Context) error {
 		return err
 	}
 
-	activities, err := s.client.ActivitiesByUser(apiContext.Context(), userID, start, end)
+	activities, err := apiContext.GatewayClient.ActivitiesByUser(apiContext.Context(), userID, start, end)
 	if err != nil {
 		return err
 	}

--- a/pkg/gateway/server/logout_all.go
+++ b/pkg/gateway/server/logout_all.go
@@ -12,12 +12,12 @@ import (
 func (s *Server) logoutAll(apiContext api.Context) error {
 	sessionID := getSessionID(apiContext.Request)
 
-	identities, err := s.client.FindIdentitiesForUser(apiContext.Context(), apiContext.UserID())
+	identities, err := apiContext.GatewayClient.FindIdentitiesForUser(apiContext.Context(), apiContext.UserID())
 	if err != nil {
 		return err
 	}
 
-	return s.client.DeleteSessionsForUser(apiContext.Context(), s.storageClient, identities, sessionID)
+	return apiContext.GatewayClient.DeleteSessionsForUser(apiContext.Context(), s.storageClient, identities, sessionID)
 }
 
 func getSessionID(req *http.Request) string {


### PR DESCRIPTION
There were a couple issues keeping a user from being able to do this. First, when encryption is enabled, the user was not able to remove their account because it could not be found. This change switches the delete user method to use the hashed_username field.

Secondly, when the user successfully removed their account, the cookie they used to authenticate would still be valid. The UI would immediately called /api/me and the user would be authenticated and a new user created. This change tells the browser to remove the cookie so this does not happen.