### PR TITLE
fix: stop using the user ID in the data context for encryption

### DIFF
--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -68,7 +68,7 @@ func (c *Client) EnsureIdentityWithRole(ctx context.Context, id *types.Identity,
 }
 
 // EncryptIdentities will pull all identities out of the database and ensure they are encrypted.
-func (c *Client) EncryptIdentities(ctx context.Context) error {
+func (c *Client) EncryptIdentities(ctx context.Context, force bool) error {
 	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var identities []types.Identity
 		if err := tx.Find(&identities).Error; err != nil {
@@ -76,7 +76,7 @@ func (c *Client) EncryptIdentities(ctx context.Context) error {
 		}
 
 		for i := range identities {
-			if identities[i].Encrypted {
+			if !force && identities[i].Encrypted {
 				continue
 			}
 

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -312,7 +312,18 @@ func (c *Client) decryptUser(ctx context.Context, user *types.User) error {
 	n, err = base64.StdEncoding.Decode(decoded, []byte(user.Username))
 	if err == nil {
 		if out, _, err = transformer.TransformFromStorage(ctx, decoded[:n], dataCtx); err != nil {
-			errs = append(errs, err)
+			if strings.Contains(err.Error(), "cipher: message authentication failed") {
+				// If we get this error, then that means that the user is encrypted with the old data context.
+				// Try with that context.
+				dataCtx = oldUserDataCtx(user)
+				if out, _, err = transformer.TransformFromStorage(ctx, decoded[:n], dataCtx); err != nil {
+					errs = append(errs, err)
+				} else {
+					user.Username = string(out)
+				}
+			} else {
+				errs = append(errs, err)
+			}
 		} else {
 			user.Username = string(out)
 		}
@@ -348,5 +359,9 @@ func (c *Client) decryptUser(ctx context.Context, user *types.User) error {
 }
 
 func userDataCtx(user *types.User) value.Context {
+	return value.DefaultContext(fmt.Sprintf("%s/%s", userGroupResource.String(), user.HashedUsername))
+}
+
+func oldUserDataCtx(user *types.User) value.Context {
 	return value.DefaultContext(fmt.Sprintf("%s/%s/%d", userGroupResource.String(), user.HashedUsername, user.ID))
 }

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -60,20 +60,22 @@ func (s *Server) getUsers(apiContext api.Context) error {
 }
 
 func (s *Server) encryptAllUsersAndIdentities(apiContext api.Context) error {
+	force := apiContext.URL.Query().Get("force") == "true"
+
 	users, err := apiContext.GatewayClient.Users(apiContext.Context(), types.NewUserQuery(apiContext.URL.Query()))
 	if err != nil {
 		return fmt.Errorf("failed to get users: %v", err)
 	}
 
 	for _, user := range users {
-		if !user.Encrypted {
+		if force || !user.Encrypted {
 			if _, err = apiContext.GatewayClient.UpdateUser(apiContext.Context(), apiContext.UserIsAdmin(), &user, user.Username); err != nil {
 				return fmt.Errorf("failed to encrypt user with id %d: %v", user.ID, err)
 			}
 		}
 	}
 
-	if err = apiContext.GatewayClient.EncryptIdentities(apiContext.Context()); err != nil {
+	if err = apiContext.GatewayClient.EncryptIdentities(apiContext.Context(), force); err != nil {
 		return fmt.Errorf("failed to encrypt identities: %v", err)
 	}
 


### PR DESCRIPTION
When a user is created, the ID is 0 until it is inserted into the database. Therefore, this field is not safe to use in the data context because it will be different when we try to decrypt it.

This change also includes a force query parameter for the encrypt-all-users API that will force re-encryption of all users regardless if those users are already encrypted.