### PR TITLE
Fix: Not able to filter obots using Created by

### DIFF
--- a/ui/admin/app/routes/_auth.obots._index.tsx
+++ b/ui/admin/app/routes/_auth.obots._index.tsx
@@ -95,6 +95,7 @@ export default function ProjectsPage() {
 			createdStart,
 			createdEnd,
 			agentId,
+			userId,
 		} = pageQuery.params ?? {};
 
 		if (createdStart) {
@@ -131,6 +132,10 @@ export default function ProjectsPage() {
 
 		if (!showChildren) {
 			filtered = filtered.filter((p) => !p.parentID);
+		}
+
+		if (userId) {
+			filtered = filtered.filter((p) => p.userID === userId);
 		}
 
 		return filtered;


### PR DESCRIPTION
Not able to filter obots using "Created by" filter
Addresses [#2344](https://github.com/obot-platform/obot/issues/2344)