### PR TITLE
enhance: move the /debug/metrics endpoint behind authentication

### DIFF
--- a/pkg/api/authn/anonymous.go
+++ b/pkg/api/authn/anonymous.go
@@ -8,10 +8,9 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
-type Anonymous struct {
-}
+type Anonymous struct{}
 
-func (n Anonymous) AuthenticateRequest(*http.Request) (*authenticator.Response, bool, error) {
+func (Anonymous) AuthenticateRequest(*http.Request) (*authenticator.Response, bool, error) {
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
 			UID:    "anonymous",

--- a/pkg/api/authn/token.go
+++ b/pkg/api/authn/token.go
@@ -1,0 +1,35 @@
+package authn
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+type Token struct {
+	Token, Username string
+	Groups          []string
+}
+
+func NewToken(token, username string, groups ...string) *Token {
+	return &Token{
+		Token:    token,
+		Username: username,
+		Groups:   groups,
+	}
+}
+
+func (t *Token) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	if req.Header.Get("Authorization") == "Bearer "+t.Token {
+		return &authenticator.Response{
+			User: &user.DefaultInfo{
+				UID:    t.Username,
+				Name:   t.Username,
+				Groups: t.Groups,
+			},
+		}, true, nil
+	}
+
+	return nil, false, nil
+}

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -12,6 +12,7 @@ import (
 const (
 	AdminGroup           = "admin"
 	AuthenticatedGroup   = "authenticated"
+	MetricsGroup         = "metrics"
 	UnauthenticatedGroup = "unauthenticated"
 
 	// anyGroup is an internal group that allows access to any group
@@ -47,7 +48,6 @@ var staticRules = map[string][]string{
 		"POST /api/sendgrid",
 
 		"GET /api/healthz",
-		"GET /debug/metrics",
 
 		"GET /api/auth-providers",
 		"GET /api/auth-providers/{id}",
@@ -72,6 +72,9 @@ var staticRules = map[string][]string{
 		"POST /api/image/generate",
 		"POST /api/image/upload",
 		"POST /api/logout-all",
+	},
+	MetricsGroup: {
+		"/debug/metrics",
 	},
 }
 

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -408,6 +408,10 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		authenticators = union.New(authenticators, tokenServer)
 		// Add bootstrap auth
 		authenticators = union.New(authenticators, bootstrapper)
+		if config.BearerToken != "" {
+			// Add otel metrics auth
+			authenticators = union.New(authenticators, authn.NewToken(config.BearerToken, "metrics", authz.MetricsGroup))
+		}
 		// Add anonymous user authenticator
 		authenticators = union.New(authenticators, authn.Anonymous{})
 


### PR DESCRIPTION
Admins still have access to this endpoint. A new metrics group is added that also has access. The Otel bearer token is the only user in that group.