### PR TITLE
Fix: add tzdata

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	_ "time/tzdata"
 
 	"github.com/gptscript-ai/cmd"
 	"github.com/gptscript-ai/gptscript/pkg/embedded"


### PR DESCRIPTION
Add tzdata so that we can use time.LoadLocation to calculate time for cronjob to run in correct timzone. The image we use don't have it.

https://github.com/obot-platform/obot/issues/1480