### PR TITLE
Fix: only copy task from shared parent once

### DIFF
--- a/pkg/controller/handlers/threads/threads.go
+++ b/pkg/controller/handlers/threads/threads.go
@@ -481,6 +481,10 @@ func (t *Handler) CopyTasksFromParent(req router.Request, _ router.Response) err
 		return nil
 	}
 
+	if thread.Status.CopiedTasksFromParent {
+		return nil
+	}
+
 	var parentThread v1.Thread
 	if err := req.Get(&parentThread, thread.Namespace, thread.Spec.ParentThreadName); apierrors.IsNotFound(err) {
 		return nil
@@ -538,7 +542,8 @@ func (t *Handler) CopyTasksFromParent(req router.Request, _ router.Response) err
 		}
 	}
 
-	return nil
+	thread.Status.CopiedTasksFromParent = true
+	return req.Client.Status().Update(req.Ctx, thread)
 }
 
 func (t *Handler) RemoveOldFinalizers(req router.Request, _ router.Response) error {

--- a/pkg/storage/apis/obot.obot.ai/v1/thread.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/thread.go
@@ -149,10 +149,11 @@ type ThreadStatus struct {
 	KnowledgeSetNames      []string            `json:"knowledgeSetNames,omitempty"`
 	SharedKnowledgeSetName string              `json:"sharedKnowledgeSetName,omitempty"`
 	// SharedWorkspaceName is used primarily to store the database content and is scoped to the project and shared across threads
-	SharedWorkspaceName string `json:"sharedWorkspaceName,omitempty"`
-	CopiedTasks         bool   `json:"copiedTasks,omitempty"`
-	CopiedTools         bool   `json:"copiedTools,omitempty"`
-	Created             bool   `json:"created,omitempty"`
+	SharedWorkspaceName   string `json:"sharedWorkspaceName,omitempty"`
+	CopiedTasks           bool   `json:"copiedTasks,omitempty"`
+	CopiedTools           bool   `json:"copiedTools,omitempty"`
+	CopiedTasksFromParent bool   `json:"copiedTasksFromParent,omitempty"`
+	Created               bool   `json:"created,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -9286,6 +9286,12 @@ func schema_storage_apis_obotobotai_v1_ThreadStatus(ref common.ReferenceCallback
 							Format: "",
 						},
 					},
+					"copiedTasksFromParent": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"created": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},


### PR DESCRIPTION
This PR fixed an issue so that if a task is shared from a shared project, modification to the task will not be reverted.

https://github.com/obot-platform/obot/issues/2539