### PR TITLE
enhance: bump default openAI model from gpt-4o to gpt-4.1

### DIFF
--- a/pkg/controller/data/default-models.yaml
+++ b/pkg/controller/data/default-models.yaml
@@ -2,11 +2,11 @@ items:
   - apiVersion: obot.obot.ai/v1
     kind: Model
     metadata:
-      name: gpt-4o
+      name: gpt-4.1
       namespace: default
     spec:
       manifest:
-        targetModel: gpt-4o
+        targetModel: gpt-4.1
         modelProvider: openai-model-provider
         active: true
         usage: llm
@@ -57,11 +57,11 @@ items:
   - apiVersion: obot.obot.ai/v1
     kind: Model
     metadata:
-      name: gpt-4o-mini
+      name: gpt-4.1-mini
       namespace: default
     spec:
       manifest:
-        targetModel: gpt-4o-mini
+        targetModel: gpt-4.1-mini
         modelProvider: openai-model-provider
         active: true
         usage: llm

--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -293,9 +293,9 @@ func (h *Handler) EnsureOpenAIEnvCredentialAndDefaults(ctx context.Context, c cl
 
 	// Since the user is setting up the OpenAI model provider with an environment variable, we should set the default model aliases to something reasonable.
 	openAIDefaultModelAliasMapping := map[types.DefaultModelAliasType]string{
-		types.DefaultModelAliasTypeLLM:             "gpt-4o",
-		types.DefaultModelAliasTypeLLMMini:         "gpt-4o-mini",
-		types.DefaultModelAliasTypeVision:          "gpt-4o",
+		types.DefaultModelAliasTypeLLM:             "gpt-4.1",
+		types.DefaultModelAliasTypeLLMMini:         "gpt-4.1-mini",
+		types.DefaultModelAliasTypeVision:          "gpt-4.1",
 		types.DefaultModelAliasTypeImageGeneration: "dall-e-3",
 		types.DefaultModelAliasTypeTextEmbedding:   "text-embedding-3-large",
 	}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -73,7 +73,7 @@ type Config struct {
 	AllowedOrigin              string   `usage:"Allowed origin for CORS"`
 	ToolRegistries             []string `usage:"The remote tool references to the set of tool registries to use" default:"github.com/obot-platform/tools" split:"true"`
 	WorkspaceProviderType      string   `usage:"The type of workspace provider to use for non-knowledge workspaces" default:"directory" env:"OBOT_WORKSPACE_PROVIDER_TYPE"`
-	HelperModel                string   `usage:"The model used to generate names and descriptions" default:"gpt-4o-mini"`
+	HelperModel                string   `usage:"The model used to generate names and descriptions" default:"gpt-4.1-mini"`
 	EmailServerName            string   `usage:"The name of the email server to display for email receivers"`
 	EnableSMTPServer           bool     `usage:"Enable SMTP server to receive emails" default:"false" env:"OBOT_ENABLE_SMTP_SERVER"`
 	Docker                     bool     `usage:"Enable Docker support" default:"false" env:"OBOT_DOCKER"`

--- a/ui/admin/app/components/model/constants.ts
+++ b/ui/admin/app/components/model/constants.ts
@@ -4,9 +4,9 @@ export const SUGGESTED_MODEL_SELECTIONS: Record<
 	ModelAlias,
 	string | undefined
 > = {
-	[ModelAlias.Llm]: "gpt-4o",
-	[ModelAlias.LlmMini]: "gpt-4o-mini",
+	[ModelAlias.Llm]: "gpt-4.1",
+	[ModelAlias.LlmMini]: "gpt-4.1-mini",
 	[ModelAlias.TextEmbedding]: "text-embedding-3-large",
 	[ModelAlias.ImageGeneration]: "dall-e-3",
-	[ModelAlias.Vision]: "gpt-4o",
+	[ModelAlias.Vision]: "gpt-4.1",
 };


### PR DESCRIPTION
As discussed in Slack, bump default OAI model from `gpt-4o` to `gpt-4.1`