### PR TITLE
fix: revisiting share link shouldnt show warning again

### DIFF
--- a/pkg/api/handlers/projectshare.go
+++ b/pkg/api/handlers/projectshare.go
@@ -261,6 +261,8 @@ func (h *ProjectShareHandler) GetShareFromShareID(req api.Context) error {
 	var (
 		shareID         = req.PathValue("share_public_id")
 		threadShareList v1.ThreadShareList
+		baseProject     v1.Thread
+		id              = name.SafeHashConcatName(system.ThreadPrefix, req.User.GetUID(), shareID)
 	)
 
 	if err := req.List(&threadShareList, kclient.InNamespace(req.Namespace()), kclient.MatchingFields{
@@ -274,5 +276,12 @@ func (h *ProjectShareHandler) GetShareFromShareID(req api.Context) error {
 	}
 
 	threadShare := threadShareList.Items[0]
+
+	// Checking if user has a project created from this share
+	if err := req.Get(&baseProject, id); err == nil {
+		// User does have a project instance, include its ID in the response
+		threadShare.Spec.ProjectThreadName = id
+	}
+
 	return req.Write(convertProjectShare(threadShare))
 }

--- a/ui/user/src/routes/s/[id]/+page.ts
+++ b/ui/user/src/routes/s/[id]/+page.ts
@@ -2,6 +2,7 @@ import { handleRouteError } from '$lib/errors';
 import { ChatService, type Project, type ProjectShare } from '$lib/services';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
 
 export const load: PageLoad = async ({ params, fetch }) => {
 	let share: ProjectShare | null = null;
@@ -10,6 +11,14 @@ export const load: PageLoad = async ({ params, fetch }) => {
 	} catch (e) {
 		handleRouteError(e, `/s/${params.id}`, profile.current);
 	}
+
+	// If the user received projectID containing the params.id / shareID,
+	// they're receiving their obot instance project ID
+	if (share?.projectID.split('-').includes(params.id)) {
+		// redirect to their obot instance project
+		throw redirect(303, `/o/${share?.projectID}`);
+	}
+
 	let project: Project | null = null;
 	if (share?.projectID) {
 		try {


### PR DESCRIPTION
* updated `GetShareFromShareID` to return the obot instance project ID if the user has created a project from it
* will redirect the user to their obot instance instead of showing the shared obot warning again