### PR TITLE
Fix: make sure include thread tools when listing credentials

### DIFF
--- a/ui/user/src/lib/components/Sidebar.svelte
+++ b/ui/user/src/lib/components/Sidebar.svelte
@@ -82,7 +82,7 @@
 			</button>
 		{/if}
 
-		<Credentials bind:this={credentials} {project} />
+		<Credentials bind:this={credentials} {project} {currentThreadID} />
 		<MemoriesDialog bind:this={memories} {project} />
 		{#if !project.editor}
 			<Clone {project} />

--- a/ui/user/src/lib/components/navbar/Credentials.svelte
+++ b/ui/user/src/lib/components/navbar/Credentials.svelte
@@ -6,9 +6,10 @@
 
 	interface Props {
 		project: Project;
+		currentThreadID?: string;
 	}
 
-	let { project }: Props = $props();
+	let { project, currentThreadID }: Props = $props();
 	let dialog = $state<HTMLDialogElement>();
 	let credentials = $state<ReturnType<typeof Credentials>>();
 
@@ -25,6 +26,12 @@
 	class:mobile-screen-dialog={responsive.isMobile}
 >
 	<div class="flex h-full grow flex-col gap-4 md:h-auto md:min-h-[300px]">
-		<Credentials bind:this={credentials} {project} local onClose={() => dialog?.close()} />
+		<Credentials
+			bind:this={credentials}
+			{project}
+			local
+			onClose={() => dialog?.close()}
+			{currentThreadID}
+		/>
 	</div>
 </dialog>


### PR DESCRIPTION
When adding tools into thread, the credential user added in the message will not be showing in credential dialog. This is because in frontend we only match the project tools, not thread tools. This pr changes to respect the thread tool if thread is is actively set in url.

https://www.loom.com/share/c6d1e6983fa54c5984a4e7f5b50a8f25

https://github.com/obot-platform/obot/issues/2403