### PR TITLE
Fix: Similar admin and user UI authentication workflows for agents

### DIFF
--- a/ui/admin/app/components/chat/Message.tsx
+++ b/ui/admin/app/components/chat/Message.tsx
@@ -343,16 +343,40 @@ export function PromptAuthForm({
 	return (
 		<Form {...form}>
 			<form onSubmit={handleSubmit} className="flex flex-col gap-4">
-				{prompt.fields?.map((field) => (
-					<ControlledInput
-						key={field.name}
-						control={form.control}
-						name={field.name}
-						label={field.name}
-						description={field.description || ""}
-						type={prompt.sensitive || !!field.sensitive ? "password" : "text"}
-					/>
-				))}
+				{prompt.fields?.map((field) =>
+					field.options?.length ? (
+						<div className="flex flex-col gap-1" key={field.name}>
+							{field.options?.length > 1 ? (
+								<label
+									htmlFor={field.name}
+									className="mt-1 text-sm font-medium"
+								>
+									{field.name}
+								</label>
+							) : null}
+							{field.options?.map((option) => (
+								<Button
+									key={option}
+									className="button"
+									type="button"
+									variant="secondary"
+									onClick={() => form.setValue(field.name, option)}
+								>
+									{option}
+								</Button>
+							))}
+						</div>
+					) : (
+						<ControlledInput
+							key={field.name}
+							control={form.control}
+							name={field.name}
+							label={field.name}
+							description={field.description || ""}
+							type={prompt.sensitive || !!field.sensitive ? "password" : "text"}
+						/>
+					)
+				)}
 
 				<Button
 					disabled={authenticate.isLoading}

--- a/ui/admin/app/lib/model/chatEvents.ts
+++ b/ui/admin/app/lib/model/chatEvents.ts
@@ -60,6 +60,7 @@ export type AuthPrompt = {
 };
 
 export type PromptField = {
+	options?: string[];
 	name: string;
 	description?: string;
 	sensitive?: boolean;


### PR DESCRIPTION
Make the workflow relating to picking authentication mode in admin ui (when pre authenticating tools for agents) similar to user ui.
Addresses [#2371](https://github.com/obot-platform/obot/issues/2371)