### PR TITLE
add storageClass name to pvc

### DIFF
--- a/chart/templates/pvc.yaml
+++ b/chart/templates/pvc.yaml
@@ -4,6 +4,9 @@ apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-pvc
 spec:
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
   accessModes:
   {{- range .Values.persistence.accessModes }}
     - {{ . | quote }}


### PR DESCRIPTION
This PR simply adds the use of the persistence.storageClass value to set the storageClassName on the pvc if it is provided.