### PR TITLE
enhance: enable optional capabilities in project scoped tool picker

### DIFF
--- a/ui/admin/app/components/agent/shared/constants.ts
+++ b/ui/admin/app/components/agent/shared/constants.ts
@@ -8,6 +8,7 @@ const CapabilityToolOrder = {
 	[CapabilityTool.Tasks]: 3,
 	[CapabilityTool.Projects]: 4,
 	[CapabilityTool.Threads]: 5,
+	[CapabilityTool.Memory]: 6,
 } satisfies Record<CapabilityTool, number>;
 
 export const getCapabilityToolOrder = (tool: string) => {

--- a/ui/admin/app/lib/model/toolReferences.ts
+++ b/ui/admin/app/lib/model/toolReferences.ts
@@ -53,6 +53,7 @@ export const CapabilityTool = {
 	Tasks: "tasks",
 	Projects: "projects",
 	Threads: "threads",
+	Memory: "memory",
 } as const;
 export type CapabilityTool =
 	(typeof CapabilityTool)[keyof typeof CapabilityTool];

--- a/ui/user/src/lib/components/edit/ToolCatalog.svelte
+++ b/ui/user/src/lib/components/edit/ToolCatalog.svelte
@@ -16,6 +16,7 @@
 		tools: AssistantTool[];
 		maxTools: number;
 		title?: string;
+		isThreadScoped?: boolean;
 	}
 
 	type ToolCatalog = {
@@ -24,7 +25,14 @@
 		total?: number;
 	}[];
 
-	let { onSelectTools, onSubmit, tools, maxTools, title = 'Tool Catalog' }: Props = $props();
+	let {
+		onSelectTools,
+		onSubmit,
+		tools,
+		maxTools,
+		title = 'Tool Catalog',
+		isThreadScoped
+	}: Props = $props();
 
 	let searchPopover = $state<HTMLDialogElement>();
 	let search = $state('');
@@ -34,13 +42,30 @@
 	let maxExceeded = $state(false);
 
 	function getSelectionMap() {
+		const toolBundleMap = getToolBundleMap();
 		return tools
 			.filter((t) => !t.builtin)
 			.reduce<Record<string, AssistantTool>>((acc, tool) => {
-				acc[tool.id] = { ...tool };
+				// Find the corresponding ToolReference for this AssistantTool
+				const toolRef = toolBundleMap.get(tool.id)?.tool;
+
+				// Set capability flag based on ToolReference metadata category
+				const isCapability = toolRef?.metadata?.category === 'Capability';
+
+				// Skip capability tools in thread-scoped pickers
+				if (isThreadScoped && isCapability) {
+					return acc;
+				}
+
+				acc[tool.id] = {
+					...tool,
+					capability: isCapability
+				};
 				return acc;
 			}, {});
 	}
+
+	// Ensure we update tool selection when tools or thread scope changes
 	$effect(() => {
 		toolSelection = getSelectionMap();
 	});
@@ -81,11 +106,12 @@
 		};
 	});
 
-	const builtInToolMap = $derived(
-		new Map<string, AssistantTool>(
+	const builtInToolMap = $derived.by(() => {
+		return new Map<string, AssistantTool>(
 			tools.filter((t) => t.builtin && !IGNORED_BUILTIN_TOOLS.has(t.id)).map((t) => [t.id, t])
-		)
-	);
+		);
+	});
+
 	const builtInTools = $derived.by(() => {
 		return Array.from(getToolBundleMap().values()).reduce<ToolCatalog>(
 			(acc, { tool, bundleTools }) => {
@@ -174,10 +200,22 @@
 	function getEnabledTools() {
 		return bundles.reduce<ToolCatalog>((acc, { tool, bundleTools }) => {
 			if (!tool) return acc;
+
+			// Skip capability tools in thread-scoped pickers
+			if (isThreadScoped && toolSelection[tool.id]?.capability) {
+				return acc;
+			}
+
 			if (bundleTools) {
 				const bundleEnabled = toolSelection[tool.id]?.enabled;
 				const total = bundleTools.length;
-				const enabledSubtools = bundleTools.filter((t) => toolSelection[t.id].enabled);
+				const enabledSubtools = bundleTools.filter((t) => {
+					// Skip capability subtools in thread-scoped pickers
+					if (isThreadScoped && toolSelection[t.id]?.capability) {
+						return false;
+					}
+					return toolSelection[t.id].enabled;
+				});
 				if (!bundleEnabled && !enabledSubtools.length) return acc;
 
 				acc.push({
@@ -196,12 +234,24 @@
 	function getDisabledTools() {
 		return bundles.reduce<ToolCatalog>((acc, { tool, bundleTools }) => {
 			if (!tool) return acc;
+
+			// Skip capability tools in thread-scoped pickers
+			if (isThreadScoped && toolSelection[tool.id]?.capability) {
+				return acc;
+			}
+
 			if (bundleTools) {
 				const bundleEnabled = toolSelection[tool.id].enabled;
 				if (bundleEnabled) return acc;
 
 				const total = bundleTools.length;
-				const disabledSubtools = bundleTools.filter((t) => !toolSelection[t.id].enabled);
+				const disabledSubtools = bundleTools.filter((t) => {
+					// Skip capability subtools in thread-scoped pickers
+					if (isThreadScoped && toolSelection[t.id]?.capability) {
+						return false;
+					}
+					return !toolSelection[t.id].enabled;
+				});
 				acc.push({ tool, bundleTools: disabledSubtools, total });
 			} else if (!toolSelection[tool.id].enabled) {
 				acc.push({ tool, bundleTools: undefined });

--- a/ui/user/src/lib/components/navbar/Tools.svelte
+++ b/ui/user/src/lib/components/navbar/Tools.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
 	import { LoaderCircle, Wrench } from 'lucide-svelte/icons';
-	import { ChatService, type AssistantTool, type Project, type Thread } from '$lib/services';
+	import {
+		ChatService,
+		type AssistantTool,
+		type Project,
+		type Thread,
+		type ToolReference
+	} from '$lib/services';
 	import ToolCatalog from '../edit/ToolCatalog.svelte';
 	import { clickOutside } from '$lib/actions/clickoutside';
 	import { getProjectTools } from '$lib/context/projectTools.svelte';
+	import { getToolReferences } from '$lib/context/toolReferences.svelte';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 
 	interface Prop {
@@ -38,9 +45,26 @@
 
 	async function fetchThreadTools() {
 		if (!currentThreadID) return;
-		tools =
-			(await ChatService.listProjectThreadTools(project.assistantID, project.id, currentThreadID))
-				?.items ?? [];
+
+		// Get tool references from context and thread tools from API
+		const toolReferences = getToolReferences();
+		const threadTools = await ChatService.listProjectThreadTools(
+			project.assistantID,
+			project.id,
+			currentThreadID
+		);
+
+		// Create a map of tool references by ID for faster lookup
+		const toolReferenceMap = new Map<string, ToolReference>();
+		for (const reference of toolReferences) {
+			toolReferenceMap.set(reference.id, reference);
+		}
+
+		// Enhance each tool with capability information
+		tools = (threadTools?.items || []).map((tool) => ({
+			...tool,
+			capability: toolReferenceMap.get(tool.id)?.metadata?.category === 'Capability'
+		}));
 	}
 
 	async function sleep(ms: number): Promise<void> {
@@ -90,6 +114,7 @@
 			maxTools={projectTools.maxTools}
 			title="Thread Tool Catalog"
 			{tools}
+			isThreadScoped
 		/>
 	{/if}
 </dialog>

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -210,6 +210,7 @@ export interface AssistantTool {
 	icon?: string;
 	enabled?: boolean;
 	builtin?: boolean;
+	capability?: boolean;
 	toolType?: AssistantToolType;
 	image?: string;
 	instructions?: string;
@@ -240,6 +241,7 @@ export interface ToolReference {
 	metadata?: {
 		icon?: string;
 		oath: string;
+		category?: string;
 	};
 }
 

--- a/ui/user/src/routes/o/[project]/+page.ts
+++ b/ui/user/src/routes/o/[project]/+page.ts
@@ -1,8 +1,32 @@
 import { browser } from '$app/environment';
 import { handleRouteError } from '$lib/errors';
 import { ChatService } from '$lib/services';
+import type { AssistantTool, ToolReference } from '$lib/services/chat/types';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
+
+/**
+ * Enhances the tools array with capability information from toolReferences
+ */
+function enhanceToolsWithCapabilities(
+	tools: AssistantTool[],
+	toolReferences: ToolReference[]
+): AssistantTool[] {
+	// Create a map of tool references by ID for faster lookup
+	const toolReferenceMap = new Map<string, ToolReference>();
+	for (const reference of toolReferences) {
+		toolReferenceMap.set(reference.id, reference);
+	}
+
+	// Enhance each tool with capability information
+	return tools.map((tool) => {
+		const toolRef = toolReferenceMap.get(tool.id);
+		return {
+			...tool,
+			capability: toolRef?.metadata?.category === 'Capability'
+		};
+	});
+}
 
 export const load: PageLoad = async ({ params, fetch }) => {
 	try {
@@ -20,7 +44,15 @@ export const load: PageLoad = async ({ params, fetch }) => {
 			localStorage.setItem('lastVisitedObot', params.project);
 		}
 
-		return { project, tools: tools.items, toolReferences: toolReferences.items, assistant };
+		// Enhance tools with capability information
+		const enhancedTools = enhanceToolsWithCapabilities(tools.items, toolReferences.items);
+
+		return {
+			project,
+			tools: enhancedTools,
+			toolReferences: toolReferences.items,
+			assistant
+		};
 	} catch (e) {
 		handleRouteError(e, `/o/${params.project}`, profile.current);
 	}


### PR DESCRIPTION
- Allow users to enable/disable capabilities in the project (Obot)
  scoped tool picker in the user UI
- Mark memory bundle as a capability in the admin UI

Note: Explicitly hidden capabilities like threads and knowledge are still
hidden in both tool picker scopes.

Addresses https://github.com/obot-platform/obot/issues/2603
