### PR TITLE
fix: decrypt identities when deleting a user

### DIFF
--- a/pkg/gateway/client/session.go
+++ b/pkg/gateway/client/session.go
@@ -68,7 +68,6 @@ func (c *Client) deleteSessionsForUser(ctx context.Context, db *gorm.DB, storage
 				} else {
 					err = c.deleteAllSessionsForUser(db, emailHash, userHash, tablePrefix)
 				}
-
 				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to delete sessions for provider %q: %w", identity.AuthProviderName, err))
 				} else {

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -104,6 +104,13 @@ func (c *Client) DeleteUser(ctx context.Context, storageClient kclient.Client, u
 			return err
 		}
 
+		for i, id := range identities {
+			if err := c.decryptIdentity(ctx, &id); err != nil {
+				return err
+			}
+			identities[i] = id
+		}
+
 		if err := c.deleteSessionsForUser(ctx, tx, storageClient, identities, ""); err != nil && !errors.Is(err, LogoutAllErr{}) {
 			return err
 		}


### PR DESCRIPTION
This ensures that the sessions are deleted successfully from the session storage.

Issues: https://github.com/obot-platform/sensitive-issues/issues/31, https://github.com/obot-platform/obot/issues/2581