### PR TITLE
fix: remove authentication requirement for file scanners

### DIFF
--- a/ui/admin/app/components/sidebar/Sidebar.tsx
+++ b/ui/admin/app/components/sidebar/Sidebar.tsx
@@ -94,7 +94,6 @@ const items = [
 		title: "File Scanners",
 		url: $path("/file-scanner-providers"),
 		icon: FileScanIcon,
-		requiresAuth: true,
 	},
 ];
 


### PR DESCRIPTION
File scanners should be available regardless of whether authentication is enabled.