### PR TITLE
Fix: Drop introduction and starter messages from base agent

### DIFF
--- a/ui/admin/app/components/agent/Agent.tsx
+++ b/ui/admin/app/components/agent/Agent.tsx
@@ -8,7 +8,6 @@ import { AssistantNamespace } from "~/lib/model/assistants";
 import { AgentAlias } from "~/components/agent/AgentAlias";
 import { useAgent } from "~/components/agent/AgentContext";
 import { AgentForm } from "~/components/agent/AgentForm";
-import { AgentIntroForm } from "~/components/agent/AgentIntroForm";
 import { ToolForm } from "~/components/agent/ToolForm";
 import { AgentCapabilityForm } from "~/components/agent/shared/AgentCapabilityForm";
 import { AgentModelSelect } from "~/components/agent/shared/AgentModelSelect";
@@ -69,10 +68,6 @@ export function Agent() {
 
 			<div className="m-4 p-4">
 				<AgentForm agent={agentUpdates} onChange={partialSetAgent} />
-			</div>
-
-			<div className="m-4 p-4">
-				<AgentIntroForm agent={agentUpdates} onChange={partialSetAgent} />
 			</div>
 
 			<div className="m-4 space-y-4 p-4">

--- a/ui/admin/app/components/agent/AgentForm.tsx
+++ b/ui/admin/app/components/agent/AgentForm.tsx
@@ -100,7 +100,9 @@ export function AgentForm({
 						</h4>
 
 						<CardDescription>
-							Give the agent instructions on how to behave and respond to input.
+							Set the base instructions for how Obots created from this agent
+							should behave and respond. These instructions define the tone,
+							personality, and response style.
 						</CardDescription>
 
 						<ControlledAutosizeTextarea


### PR DESCRIPTION
Drop introduction and starter messages from base agent and clarify instructions field in Admin UI
Addresses [#2598](https://github.com/obot-platform/obot/issues/2598)