### PR TITLE
Fix: Account profile disappears when exiting obot editor

### DIFF
--- a/ui/user/src/lib/components/Navbar.svelte
+++ b/ui/user/src/lib/components/Navbar.svelte
@@ -30,7 +30,9 @@
 				<EditorToggle />
 			{/if}
 			{#if !layout.projectEditorOpen}
-				<Profile />
+				<div>
+					<Profile />
+				</div>
 			{/if}
 		</div>
 	</div>


### PR DESCRIPTION
Account profile disappears when exiting obot editor.
Addresses [#2641](https://github.com/obot-platform/obot/issues/2641)