### PR TITLE
fix: mcps in sidebar doesn't update on changing agents

### DIFF
--- a/ui/user/src/routes/o/[project]/+page.svelte
+++ b/ui/user/src/routes/o/[project]/+page.svelte
@@ -39,6 +39,12 @@
 	});
 
 	$effect(() => {
+		if (data.mcps) {
+			initProjectMCPs(data.mcps);
+		}
+	});
+
+	$effect(() => {
 		if (navigating) {
 			initialLayout();
 		}


### PR DESCRIPTION
Fixes:
1. Create an agent through MCP Servers
2. Click the 'New Agent' button on the far right, above the Advanced Editor button (below Profile pic)
3. See that the MCP Servers section doesn't update in the sidebar to empty