### PR TITLE
Fix: fix timezone for triggering tasks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,27 @@
+name: Run Tests on Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Install Dependencies
+        run: |
+          go mod download
+
+      - name: Run Tests
+        run: |
+          make test

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ lint-go: setup-env
 generate:
 	go generate
 
+test:
+	go test -v -cover ./...
+
 # Runs Go linters and validates that all generated code is committed.
 validate-go-code: tidy generate lint-go no-changes
 

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/sendgrid/sendgrid-go v3.16.0+incompatible
 	github.com/sethvargo/go-limiter v1.0.0
 	github.com/spf13/cobra v1.8.1
+	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0
 	go.opentelemetry.io/otel v1.35.0
@@ -71,6 +72,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.7 // indirect
 	github.com/pkoukk/tiktoken-go-loader v0.0.2-0.20240522064338-c17e8bc0f699 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 )
 
@@ -239,7 +241,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tetratelabs/wazero v1.9.0 // indirect
 	github.com/therootcompany/xz v1.0.1 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/pkg/controller/handlers/cronjob/cronjob_test.go
+++ b/pkg/controller/handlers/cronjob/cronjob_test.go
@@ -1,0 +1,72 @@
+package cronjob
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCalculateNextRunTime(t *testing.T) {
+	t.Run("cronjob with empty LastRunStartedAt", func(t *testing.T) {
+		creationTime := time.Date(2025, 4, 26, 9, 0, 0, 0, time.UTC)
+		cronJob := v1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: creationTime},
+			},
+			Status: v1.CronJobStatus{
+				LastRunStartedAt: &metav1.Time{},
+			},
+			Spec: v1.CronJobSpec{
+				CronJobManifest: types.CronJobManifest{
+					TaskSchedule: &types.Schedule{
+						Interval: "daily",
+						Hour:     10,
+						TimeZone: "America/Phoenix",
+					},
+				},
+			},
+		}
+
+		nextRun, err := calculateNextRunTime(cronJob)
+		require.NoError(t, err)
+		loc, err := time.LoadLocation("America/Phoenix")
+		require.NoError(t, err)
+		expectedNextRun := creationTime.In(loc).Add(8 * time.Hour)
+		require.Equal(t, expectedNextRun, nextRun)
+	})
+
+	t.Run("cronjob with timezone specified", func(t *testing.T) {
+		// Setup
+		creationTimeUTC := time.Date(2025, 4, 26, 9, 0, 0, 0, time.UTC)
+
+		cronJob := v1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: creationTimeUTC},
+			},
+			Status: v1.CronJobStatus{
+				LastRunStartedAt: &metav1.Time{Time: creationTimeUTC},
+			},
+			Spec: v1.CronJobSpec{
+				CronJobManifest: types.CronJobManifest{
+					TaskSchedule: &types.Schedule{
+						Interval: "daily",
+						Hour:     10,
+						TimeZone: "America/Phoenix",
+					},
+				},
+			},
+		}
+
+		nextRun, err := calculateNextRunTime(cronJob)
+		require.NoError(t, err)
+
+		loc, err := time.LoadLocation("America/Phoenix")
+		require.NoError(t, err)
+		expectedNextRun := cronJob.Status.LastRunStartedAt.In(loc).Add(8 * time.Hour)
+		require.Equal(t, expectedNextRun, nextRun)
+	})
+}


### PR DESCRIPTION
This fixed the timezone bug where it is not respecting the correct timezone when running for the second time. It also adds some tests for it.

---

**Tracking Issue:** #2732

See the tracking issue for details and context from the Slack thread. This PR aims to resolve the bug where only the first scheduled run respects the timezone, but subsequent runs do not.