### PR TITLE
fix: dereference the user pointer when copying

### DIFF
--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -177,12 +177,12 @@ func (c *Client) UpdateUser(ctx context.Context, actingUserIsAdmin bool, updated
 		}
 
 		// Copy the user object that is returned to the caller so they don't get the encrypted values
-		u := existingUser
-		if err := c.encryptUser(ctx, u); err != nil {
+		u := *existingUser
+		if err := c.encryptUser(ctx, &u); err != nil {
 			return fmt.Errorf("failed to encrypt user: %w", err)
 		}
 
-		return tx.Updates(u).Error
+		return tx.Updates(&u).Error
 	})
 }
 


### PR DESCRIPTION
If we don't dereference, then there is no point in copying.