### PR TITLE
fix: ensure identities aren't double-encrypted when encrypting all users

### DIFF
--- a/pkg/gateway/client/session.go
+++ b/pkg/gateway/client/session.go
@@ -57,7 +57,7 @@ func (c *Client) deleteSessionsForUser(ctx context.Context, db *gorm.DB, storage
 		emailHash := hash.String(identity.Email)
 		userHash := hash.String(user)
 
-		logger.Info("deleting sessions", "provider", identity.AuthProviderName, "emailHash", emailHash, "userHash", userHash, "user", user, "email", identity.Email)
+		logger.Debug("deleting sessions", "provider", identity.AuthProviderName, "emailHash", emailHash, "userHash", userHash)
 
 		if meta, ok := ref.Status.Tool.Metadata["providerMeta"]; ok {
 			tablePrefix := gjson.Get(meta, "postgresTablePrefix").String()

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gptscript-ai/gptscript/pkg/mvl"
@@ -69,7 +70,7 @@ func (s *Server) encryptAllUsersAndIdentities(apiContext api.Context) error {
 
 	for _, user := range users {
 		if force || !user.Encrypted {
-			if _, err = apiContext.GatewayClient.UpdateUser(apiContext.Context(), apiContext.UserIsAdmin(), &user, user.Username); err != nil {
+			if _, err = apiContext.GatewayClient.UpdateUser(apiContext.Context(), apiContext.UserIsAdmin(), &user, strconv.FormatUint(uint64(user.ID), 10)); err != nil {
 				return fmt.Errorf("failed to encrypt user with id %d: %v", user.ID, err)
 			}
 		}


### PR DESCRIPTION
This change also includes a migration to ensure that identities that do have their provider user ID double-encrypted are fixed.