### PR TITLE
fix: public chatbot user ui

### DIFF
--- a/pkg/api/handlers/projectshare.go
+++ b/pkg/api/handlers/projectshare.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
@@ -279,12 +280,13 @@ func (h *ProjectShareHandler) GetShareFromShareID(req api.Context) error {
 	threadShare := threadShareList.Items[0]
 
 	// Checking if user has a project created from this share
-	if err := req.Get(&baseProject, id); err == nil {
+	if req.Get(&baseProject, id) == nil {
 		// User does have a project instance, include its ID in the response
 		threadShare.Spec.ProjectThreadName = id
+	} else if req.Get(&baseProject, threadShare.Spec.ProjectThreadName) != nil {
+		return apierrors.NewInternalError(fmt.Errorf("unable to find base project"))
 	}
 
-	// Set editor flag if user is the project owner
 	threadShare.Spec.Editor = baseProject.Spec.UserID == req.User.GetUID()
 
 	return req.Write(convertProjectShare(threadShare))

--- a/ui/user/src/routes/s/[id]/+page.svelte
+++ b/ui/user/src/routes/s/[id]/+page.svelte
@@ -43,22 +43,23 @@
 
 		projectTools.tools = tools.items;
 		projectTools.maxTools = assistant?.maxTools ?? 5;
+		showWarning = false;
 	}
 
 	onMount(async () => {
 		if (profile.current.unauthorized) {
 			// Redirect to the main page to log in.
 			window.location.href = `/?rd=${window.location.pathname}`;
-		} else if (data.projectID) {
-			// If the user received projectID containing the params.id / shareID,
-			// they're receiving their obot instance project ID
-			if (data.projectID.split('-').includes(data.id) || data.isOwner) {
-				project = await ChatService.getProject(data.projectID);
-				loadProject();
-			} else {
-				showWarning = true;
-			}
+			return;
 		}
+
+		if (data.projectID && data.isOwner) {
+			project = await ChatService.getProject(data.projectID);
+			loadProject();
+			return;
+		}
+
+		showWarning = true;
 	});
 
 	async function createProject() {


### PR DESCRIPTION
Ensure the editor field is set on project shares for owners of a chatbot so they can access the chatbot.
This also ensures owners never encounter the warning page and fixes a problem where the warning page doesn't close after clicking "accept" (note this applied to both users and
owners).