### PR TITLE
enhance: normalize chatbot ux across personas

### DIFF
--- a/ui/user/src/routes/s/[id]/+page.svelte
+++ b/ui/user/src/routes/s/[id]/+page.svelte
@@ -43,28 +43,29 @@
 
 		projectTools.tools = tools.items;
 		projectTools.maxTools = assistant?.maxTools ?? 5;
+
+		// Close out the warning if the project is successfully loaded
+		showWarning = false;
 	}
 
 	onMount(async () => {
 		if (profile.current.unauthorized) {
 			// Redirect to the main page to log in.
 			window.location.href = `/?rd=${window.location.pathname}`;
-		} else if (data.projectID) {
-			// If the user received projectID containing the params.id / shareID,
-			// they're receiving their obot instance project ID
-			if (data.projectID.split('-').includes(data.id) || data.isOwner) {
-				project = await ChatService.getProject(data.projectID);
-				loadProject();
-			} else {
-				showWarning = true;
-			}
 		}
+
+		if (data.projectID && data.isOwner) {
+			project = await ChatService.getProject(data.projectID);
+			loadProject();
+			return;
+		}
+
+		showWarning = true;
 	});
 
 	async function createProject() {
-		const urlParams = new URLSearchParams(window.location.search);
 		project = await ChatService.createProjectFromShare(data.id, {
-			create: urlParams.has('create')
+			create: true
 		});
 		loadProject();
 	}


### PR DESCRIPTION
Normalize ChatBot UX so that agent owners have the same experience as
consumers of their ChatBot. This means that when they access a share
link, they will now interact with a shared "copy" instead of directly
with the parent project.

This commit also includes changes to ensure the ChatBot user warning is
properly closed after the user accepts.

