### PR TITLE
fix: tasks: fix how step IDs are matched when running a single step

### DIFF
--- a/pkg/controller/handlers/workflowstep/workflowstep.go
+++ b/pkg/controller/handlers/workflowstep/workflowstep.go
@@ -180,13 +180,8 @@ func (h *Handler) checkPreconditions(req router.Request, _ router.Response) (pro
 	return true, nil
 }
 
-func normalizeStepID(stepID string) string {
-	id, _, _ := strings.Cut(stepID, "{")
-	return id
-}
-
 func matchesStepID(step *v1.WorkflowStep, stepID string) bool {
-	return normalizeStepID(step.Spec.Step.ID) == normalizeStepID(stepID)
+	return step.Spec.Step.ID == stepID
 }
 
 func GetStateFromSteps[T kclient.Object](ctx context.Context, client kclient.Client, generation int64, steps ...T) (lastRun string, output string, _ types.WorkflowState, _ error) {


### PR DESCRIPTION
Normalizing the step ID like this was causing problems for running individual loop steps. After the `loopdata` step would run, the subsequent steps to run for each element would enter a `Blocked` state, because the WorkflowExecution said to stop after the root step ID, and we were cutting off the `{loopdata}` part from the loopdata step when comparing it here, causing it to match the root step ID, thus causing the element steps not to run at all, thinking we had already passed the point where we wanted to stop.