### PR TITLE
Chore: update eslint dep so linting works locally

### DIFF
--- a/ui/user/package.json
+++ b/ui/user/package.json
@@ -31,6 +31,7 @@
 		"@codemirror/search": "^6.5.10",
 		"@codemirror/state": "^6.5.2",
 		"@codemirror/view": "^6.36.3",
+		"@eslint/js": "^9.26.0",
 		"@faker-js/faker": "^9.7.0",
 		"@floating-ui/dom": "^1.6.13",
 		"@milkdown/crepe": "^7.6.3",

--- a/ui/user/pnpm-lock.yaml
+++ b/ui/user/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.36.3
         version: 6.36.3
+      '@eslint/js':
+        specifier: ^9.26.0
+        version: 9.26.0
       '@faker-js/faker':
         specifier: ^9.7.0
         version: 9.7.0
@@ -671,6 +674,10 @@ packages:
 
   '@eslint/js@9.21.0':
     resolution: {integrity: sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.26.0':
+    resolution: {integrity: sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.6':
@@ -3111,6 +3118,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@9.21.0': {}
+
+  '@eslint/js@9.26.0': {}
 
   '@eslint/object-schema@2.1.6': {}
 


### PR DESCRIPTION
if you ran our linting locally (on a mac at least) it would fail with:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js' imported from /Users/thedadams/code/obot/ui/user/eslint.config.js
Did you mean to import "@eslint/js/src/index.js"?
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:267:9)
    at packageResolve (node:internal/modules/esm/resolve:768:81)
    at moduleResolve (node:internal/modules/esm/resolve:854:18)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:780:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:704:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:687:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:305:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:137:49)
```

I fixed by running these commands:
```
pnpm install
pnpm install --save-dev @eslint/js
```
and verified with
```
pnpm run ci
```

Signed-off-by: Craig Jellick <craig@acorn.io>
