### PR TITLE
fix: allow chatting when MCP servers are not configured

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -2,8 +2,9 @@ package types
 
 type MCPServerCatalogEntry struct {
 	Metadata
-	CommandManifest MCPServerCatalogEntryManifest `json:"commandManifest,omitzero"`
-	URLManifest     MCPServerCatalogEntryManifest `json:"urlManifest,omitzero"`
+	CommandManifest   MCPServerCatalogEntryManifest `json:"commandManifest,omitzero"`
+	URLManifest       MCPServerCatalogEntryManifest `json:"urlManifest,omitzero"`
+	ToolReferenceName string                        `json:"toolReferenceName,omitzero"`
 }
 
 type MCPServerCatalogEntryManifest struct {

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -59,9 +59,10 @@ func (m *MCPHandler) ListCatalog(req api.Context) error {
 
 func convertMCPServerCatalogEntry(entry v1.MCPServerCatalogEntry) types.MCPServerCatalogEntry {
 	return types.MCPServerCatalogEntry{
-		Metadata:        MetadataFrom(&entry),
-		CommandManifest: entry.Spec.CommandManifest,
-		URLManifest:     entry.Spec.URLManifest,
+		Metadata:          MetadataFrom(&entry),
+		CommandManifest:   entry.Spec.CommandManifest,
+		URLManifest:       entry.Spec.URLManifest,
+		ToolReferenceName: entry.Spec.ToolReferenceName,
 	}
 }
 
@@ -114,6 +115,10 @@ func (m *MCPHandler) ListServer(req api.Context) error {
 
 			tools, err = m.toolsForServer(req.Context(), req.Storage, server, thread.Spec.Manifest.AllowedMCPTools[server.Name], c.Env)
 			if err != nil {
+				if uc := (*render.UnconfiguredMCPError)(nil); errors.As(err, &uc) {
+					// Leave out tools for un-configured MCP servers
+					continue
+				}
 				return fmt.Errorf("failed to render tools: %w", err)
 			}
 		}

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -392,7 +392,7 @@ func Router(services *services.Services) (http.Handler, error) {
 
 	// MCP Catalog
 	mux.HandleFunc("GET /api/mcp/catalog", mcp.ListCatalog)
-	mux.HandleFunc("GET /api/mcp/catalog/{id}", mcp.GetCatalogEntry)
+	mux.HandleFunc("GET /api/mcp/catalog/{mcp_server_id}", mcp.GetCatalogEntry)
 
 	// MCP Servers
 	mux.HandleFunc("GET /api/assistants/{assistant_id}/projects/{project_id}/mcpservers", mcp.ListServer)

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -3,6 +3,7 @@ package render
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -167,6 +168,10 @@ func Agent(ctx context.Context, db kclient.Client, gptClient *gptscript.GPTScrip
 
 			toolDef, err := mcpServerTool(ctx, gptClient, mcpServer, allowedTools)
 			if err != nil {
+				if uc := (*UnconfiguredMCPError)(nil); errors.As(err, &uc) {
+					// Leave out un-configured MCP servers.
+					continue
+				}
 				return nil, nil, err
 			}
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2541,8 +2541,15 @@ func schema_obot_platform_obot_apiclient_types_MCPServerCatalogEntry(ref common.
 							Ref:     ref("github.com/obot-platform/obot/apiclient/types.MCPServerCatalogEntryManifest"),
 						},
 					},
+					"toolReferenceName": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 				},
-				Required: []string{"Metadata", "commandManifest", "urlManifest"},
+				Required: []string{"Metadata", "commandManifest", "urlManifest", "toolReferenceName"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
This change also returns a tool reference name for an MCP catalog entry if it is really from one of our tool bundles.