### PR TITLE
feat: extraEnvFrom, extraVolumes, extraVolumeMounts

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -41,10 +41,15 @@ spec:
               port: http
             failureThreshold: 5
             periodSeconds: 10
-          {{- if and (eq .Values.config.OBOT_WORKSPACE_PROVIDER_TYPE "directory") .Values.persistence.enabled }}
+          {{- if or .Values.extraVolumeMounts (and (eq .Values.config.OBOT_WORKSPACE_PROVIDER_TYPE "directory") .Values.persistence.enabled) }}
           volumeMounts:
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if and (eq .Values.config.OBOT_WORKSPACE_PROVIDER_TYPE "directory") .Values.persistence.enabled }}
             - mountPath: {{ .Values.persistence.path }}
               name: data
+            {{- end }}
           {{- end }}
           {{- if .Values.extraEnv }}
           env:
@@ -61,9 +66,14 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if and (eq .Values.config.OBOT_WORKSPACE_PROVIDER_TYPE "directory") .Values.persistence.enabled }}
+      {{- if or .Values.extraVolumes (and (eq .Values.config.OBOT_WORKSPACE_PROVIDER_TYPE "directory") .Values.persistence.enabled) }}
       volumes:
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if and (eq .Values.config.OBOT_WORKSPACE_PROVIDER_TYPE "directory") .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ ternary .Values.persistence.existingClaim (print .Release.Name "-pvc") (ne .Values.persistence.existingClaim "") }}
+        {{- end }}
       {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ if .Values.config.existingSecret }}{{ .Values.config.existingSecret }}{{ else }}{{ include "obot.config.secretName" . }}{{- end }}
+          {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if and (eq .Values.config.OBOT_WORKSPACE_PROVIDER_TYPE "directory") .Values.persistence.enabled }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -148,6 +148,12 @@ persistence:
   size: 8Gi
   existingClaim: ""
 
+# extraVolumes -- A list of additional volumes to create
+extraVolumes: [ ]
+
+# extraVolumeMounts -- A list of additional volume mounts to create
+extraVolumeMounts: [ ]
+
 serviceAccount:
   # serviceAccount.create - Specifies whether a service account should be created
   create: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -125,6 +125,9 @@ config:
 # extraEnv -- A map of additional environment variables to set
 extraEnv: { }
 
+# extraEnvFrom -- A list of additional environment variables to set from a secret
+extraEnvFrom: [ ]
+
 # resources -- Resource requests and limits to use for Obot
 resources: { }
 


### PR DESCRIPTION
Currently, there is no way to specify extra env vars via secrets. The existing `extraEnv` option also does not support `valueFrom` references.

Additionally, this PR adds extraVolumes and extraVolumeMounts, which are useful e.g. to mount custom CA certificates.