### PR TITLE
enhance: show memory for chatbots

### DIFF
--- a/ui/user/src/lib/components/Sidebar.svelte
+++ b/ui/user/src/lib/components/Sidebar.svelte
@@ -112,6 +112,9 @@
 			</div>
 		{:else}
 			<Threads {project} bind:currentThreadID />
+			{#if hasTool(projectTools.tools, 'memory')}
+				<Memories {project} />
+			{/if}
 		{/if}
 	</div>
 


### PR DESCRIPTION
Show chatbot memories in the sidebar.

Addresses https://github.com/obot-platform/obot/issues/2810

https://github.com/user-attachments/assets/8812c7cb-b6ef-42b9-97b9-b8e067453ee7

