### PR TITLE
fix: ui: display proper model for the thread

### DIFF
--- a/ui/user/src/lib/components/edit/ThreadModelSelector.svelte
+++ b/ui/user/src/lib/components/edit/ThreadModelSelector.svelte
@@ -87,10 +87,6 @@
 	}
 
 	onMount(() => {
-		if (threadId) {
-			fetchThreadDetails();
-		}
-
 		// Close model selector when clicking outside
 		const handleClickOutside = (event: MouseEvent) => {
 			if (
@@ -112,7 +108,7 @@
 	});
 
 	$effect(() => {
-		if (threadId && !threadDetails) {
+		if (threadId) {
 			fetchThreadDetails().then(() => {
 				if (threadDetails && threadDetails.model && threadDetails.modelProvider) {
 					// Make sure that the thread model is available on the project, and replace it with default if not.


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/2873

The issue here is simply that we were not re-fetching data in this component when the thread ID changed. This fixes that.