### PR TITLE
fix: retention: set last used time on a project when it is created

### DIFF
--- a/pkg/api/handlers/projects.go
+++ b/pkg/api/handlers/projects.go
@@ -358,6 +358,10 @@ func (h *ProjectsHandler) CreateProject(req api.Context) error {
 			DefaultModel:         project.DefaultModel,
 			Models:               project.Models,
 		},
+		// Set the last used time to now, so that the project will get cleaned up by retention, even if it is never used.
+		Status: v1.ThreadStatus{
+			LastUsedTime: metav1.Now(),
+		},
 	}
 
 	if err := req.Create(thread); err != nil {


### PR DESCRIPTION
for https://github.com/obot-platform/sensitive-issues/issues/26

Before this change, we only set the `Last Used Time` on a project when the user chats with one of its threads, which led to projects that never had a thread staying around perpetually and never getting cleaned up. This fixes that.