### PR TITLE
fix: use project's name for MCP scope to avoid launching too many MCPs

### DIFF
--- a/pkg/render/mcp.go
+++ b/pkg/render/mcp.go
@@ -22,23 +22,14 @@ func (e *UnconfiguredMCPError) Error() string {
 	return fmt.Sprintf("MCP server %s missing required configuration parameters: %s", e.MCPName, strings.Join(e.Missing, ", "))
 }
 
-func mcpServerTool(ctx context.Context, thread *v1.Thread, gptClient *gptscript.GPTScript, mcpServer v1.MCPServer, allowTools []string) (gptscript.ToolDef, error) {
+func mcpServerTool(ctx context.Context, gptClient *gptscript.GPTScript, mcpServer v1.MCPServer, projectName string, allowTools []string) (gptscript.ToolDef, error) {
 	var credEnv map[string]string
 	if len(mcpServer.Spec.Manifest.Env) != 0 || len(mcpServer.Spec.Manifest.Headers) != 0 {
-		var credCtxs []string
-		// Add any local MCP credentials from the thread scope.
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", thread.Name, mcpServer.Name))
-
-		if parent := thread.Spec.ParentThreadName; parent != "" {
-			// Add any local MCP credentials from the parent project scope.
-			// For non-project child threads of an agent project, this will include local credentials from the agent project.
-			// For non-project child threads of a chatbot project, this will include local credentials from the chatbot project.
-			credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", parent, mcpServer.Name))
-
-			if parent != mcpServer.Spec.ThreadName {
-				// Add shared MCP credentials from the agent project to chatbot threads.
-				credCtxs = append(credCtxs, fmt.Sprintf("%s-%s-shared", mcpServer.Spec.ThreadName, mcpServer.Name))
-			}
+		// Add the credential context for the direct parent to pick up credentials specifically for this project.
+		credCtxs := []string{fmt.Sprintf("%s-%s", projectName, mcpServer.Name)}
+		if projectName != mcpServer.Spec.ThreadName {
+			// Add shared MCP credentials from the agent project to chatbot threads.
+			credCtxs = append(credCtxs, fmt.Sprintf("%s-%s-shared", mcpServer.Spec.ThreadName, mcpServer.Name))
 		}
 
 		cred, err := gptClient.RevealCredential(ctx, credCtxs, mcpServer.Name)
@@ -49,7 +40,7 @@ func mcpServerTool(ctx context.Context, thread *v1.Thread, gptClient *gptscript.
 		credEnv = cred.Env
 	}
 
-	return MCPServerToolWithCreds(mcpServer, thread.Name, credEnv, allowTools...)
+	return MCPServerToolWithCreds(mcpServer, projectName, credEnv, allowTools...)
 }
 
 func MCPServerToolWithCreds(mcpServer v1.MCPServer, projectThreadName string, credEnv map[string]string, allowedTools ...string) (gptscript.ToolDef, error) {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -160,7 +160,7 @@ func Agent(ctx context.Context, db kclient.Client, gptClient *gptscript.GPTScrip
 				continue
 			}
 
-			toolDef, err := mcpServerTool(ctx, opts.Thread, gptClient, mcpServer, allowedTools)
+			toolDef, err := mcpServerTool(ctx, gptClient, mcpServer, opts.Thread.Spec.ParentThreadName, allowedTools)
 			if err != nil {
 				if uc := (*UnconfiguredMCPError)(nil); errors.As(err, &uc) {
 					// Leave out un-configured MCP servers.


### PR DESCRIPTION
When rendering the MCP servers, the thread is the chat thread and not the project thread. This change will use the project's thread name instead of the thread's name to avoid launching MCP servers for every chat thread.