### PR TITLE
fix: unauthenticated agents & mcp section links

### DIFF
--- a/ui/user/src/lib/components/agents/AgentCatalog.svelte
+++ b/ui/user/src/lib/components/agents/AgentCatalog.svelte
@@ -8,13 +8,15 @@
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { responsive } from '$lib/stores';
 	import Search from '$lib/components/Search.svelte';
+	import { onMount } from 'svelte';
 
 	interface Props {
 		templates: ProjectTemplate[];
 		mcps: MCP[];
+		preselected?: string;
 	}
 
-	let { templates, mcps: referencedMcps }: Props = $props();
+	let { templates, mcps: referencedMcps, preselected }: Props = $props();
 	let dialog: HTMLDialogElement | undefined = $state();
 	let agentCopy: ReturnType<typeof AgentCopy> | undefined = $state();
 
@@ -71,6 +73,17 @@
 			currentPage--;
 		}
 	}
+
+	onMount(() => {
+		const preselectedTemplate = preselected && templates.find((t) => t.id === preselected);
+		if (preselectedTemplate) {
+			const templateMcps =
+				(preselectedTemplate?.mcpServers?.map((id) => mcps.get(id)).filter(Boolean) as MCP[]) || [];
+
+			dialog?.showModal();
+			agentCopy?.open(preselectedTemplate, templateMcps);
+		}
+	});
 
 	let mcps = $derived(new Map(referencedMcps.map((m) => [m.id, m])));
 </script>

--- a/ui/user/src/lib/components/agents/AgentCatalog.svelte
+++ b/ui/user/src/lib/components/agents/AgentCatalog.svelte
@@ -14,9 +14,10 @@
 		templates: ProjectTemplate[];
 		mcps: MCP[];
 		preselected?: string;
+		inline?: boolean;
 	}
 
-	let { templates, mcps: referencedMcps, preselected }: Props = $props();
+	let { templates, mcps: referencedMcps, preselected, inline }: Props = $props();
 	let dialog: HTMLDialogElement | undefined = $state();
 	let agentCopy: ReturnType<typeof AgentCopy> | undefined = $state();
 
@@ -88,32 +89,41 @@
 	let mcps = $derived(new Map(referencedMcps.map((m) => [m.id, m])));
 </script>
 
-<dialog
-	bind:this={dialog}
-	use:clickOutside={() => dialog?.close()}
-	class="default-dialog h-full w-full max-w-(--breakpoint-2xl) bg-white p-0 dark:bg-black"
-	class:mobile-screen-dialog={responsive.isMobile}
->
-	<div class="default-scrollbar-thin relative mx-auto h-full min-h-0 w-full overflow-y-auto">
-		<button
-			class="icon-button sticky top-3 right-2 z-40 float-right self-end"
-			onclick={() => dialog?.close()}
-			use:tooltip={{ disablePortal: true, text: 'Close Agent Catalog' }}
-		>
-			<X class="size-7" />
-		</button>
-		<div class="mt-4 flex w-full flex-col items-center justify-center gap-2 px-4 py-4">
-			<h2 class="text-3xl font-semibold md:text-4xl">Agent Catalog</h2>
-			<p class="mb-8 max-w-full text-center text-base font-light md:max-w-md">
-				Copy an existing agent to jumpstart your journey
-			</p>
+{#if inline}
+	{@render content()}
+{:else}
+	<dialog
+		bind:this={dialog}
+		use:clickOutside={() => dialog?.close()}
+		class="default-dialog h-full w-full max-w-(--breakpoint-2xl) bg-white p-0 dark:bg-black"
+		class:mobile-screen-dialog={responsive.isMobile}
+	>
+		<div class="default-scrollbar-thin relative mx-auto h-full min-h-0 w-full overflow-y-auto">
+			<button
+				class="icon-button sticky top-3 right-2 z-40 float-right self-end"
+				onclick={() => dialog?.close()}
+				use:tooltip={{ disablePortal: true, text: 'Close Agent Catalog' }}
+			>
+				<X class="size-7" />
+			</button>
+
+			{@render content()}
 		</div>
-		<div class="pr-12 pb-4">
-			{@render body()}
-		</div>
-		<AgentCopy bind:this={agentCopy} />
+	</dialog>
+{/if}
+
+{#snippet content()}
+	<div class="mt-4 flex w-full flex-col items-center justify-center gap-2 px-4 py-4">
+		<h2 class="text-3xl font-semibold md:text-4xl">Agent Catalog</h2>
+		<p class="mb-8 max-w-full text-center text-base font-light md:max-w-md">
+			Copy an existing agent to jumpstart your journey
+		</p>
 	</div>
-</dialog>
+	<div class="pr-12 pb-4">
+		{@render body()}
+	</div>
+	<AgentCopy bind:this={agentCopy} />
+{/snippet}
 
 {#snippet body()}
 	<div class="relative flex w-full max-w-(--breakpoint-2xl)">

--- a/ui/user/src/lib/components/mcp/McpCatalog.svelte
+++ b/ui/user/src/lib/components/mcp/McpCatalog.svelte
@@ -10,6 +10,7 @@
 	import McpInfoConfig from '$lib/components/mcp/McpInfoConfig.svelte';
 	import type { MCPServerInfo } from '$lib/services/chat/mcp';
 	import { getToolBundleMap } from '$lib/context/toolReferences.svelte';
+	import { onMount } from 'svelte';
 
 	const BROWSE_ALL_CATEGORY = 'Browse All';
 
@@ -21,6 +22,7 @@
 		selectedMcpIds?: string[];
 		subtitle?: string;
 		project?: Project;
+		preselectedMcp?: string;
 	}
 
 	type TransformedMcp = {
@@ -39,7 +41,8 @@
 		submitText,
 		selectedMcpIds,
 		subtitle,
-		project = $bindable()
+		project = $bindable(),
+		preselectedMcp
 	}: Props = $props();
 	let dialog: HTMLDialogElement | undefined = $state();
 	let configDialog = $state<ReturnType<typeof McpInfoConfig>>();
@@ -128,6 +131,16 @@
 			)
 		)
 	);
+
+	onMount(() => {
+		const preselectedManifest =
+			preselectedMcp && transformedMcps.find((mcp) => mcp.catalogId === preselectedMcp);
+		if (preselectedManifest) {
+			selectedMcp = preselectedManifest;
+			selectedMcpManifest = preselectedManifest.manifest;
+			configDialog?.open();
+		}
+	});
 
 	export function open() {
 		searchInput?.clear();

--- a/ui/user/src/lib/components/mcp/McpSetupWizard.svelte
+++ b/ui/user/src/lib/components/mcp/McpSetupWizard.svelte
@@ -17,6 +17,7 @@
 	import { clickOutside } from '$lib/actions/clickoutside';
 	import { fade } from 'svelte/transition';
 	import { getToolBundleMap } from '$lib/context/toolReferences.svelte';
+	import { onMount } from 'svelte';
 
 	interface Props {
 		mcps: MCP[];
@@ -26,6 +27,7 @@
 		onFinish?: (projectMcp?: ProjectMCP, project?: Project) => void;
 		project?: Project;
 		selectedMcpIds?: string[];
+		preselected?: string;
 	}
 
 	let {
@@ -35,7 +37,8 @@
 		inline,
 		onFinish,
 		project: refProject,
-		selectedMcpIds
+		selectedMcpIds,
+		preselected
 	}: Props = $props();
 	let project = $state(refProject);
 	let projectMcp = $state<ProjectMCP>();
@@ -111,6 +114,7 @@
 	}}
 	{selectedMcpIds}
 	submitText={catalogSubmitText}
+	preselectedMcp={preselected}
 />
 
 {#if processing}

--- a/ui/user/src/lib/components/mcp/McpSetupWizard.svelte
+++ b/ui/user/src/lib/components/mcp/McpSetupWizard.svelte
@@ -17,7 +17,6 @@
 	import { clickOutside } from '$lib/actions/clickoutside';
 	import { fade } from 'svelte/transition';
 	import { getToolBundleMap } from '$lib/context/toolReferences.svelte';
-	import { onMount } from 'svelte';
 
 	interface Props {
 		mcps: MCP[];

--- a/ui/user/src/routes/+page.ts
+++ b/ui/user/src/routes/+page.ts
@@ -15,7 +15,9 @@ export const load: PageLoad = async ({ fetch }) => {
 	}
 
 	const authProviders = await ChatService.listAuthProviders({ fetch });
-	const templates = (await ChatService.listTemplates({ fetch })).items;
+	const templates = (await ChatService.listTemplates({ fetch })).items.filter(
+		(template) => template.featured
+	);
 	const mcps = await ChatService.listMCPs({ fetch });
 	let editorProjects: Project[] = [];
 

--- a/ui/user/src/routes/+page.ts
+++ b/ui/user/src/routes/+page.ts
@@ -10,12 +10,12 @@ export const load: PageLoad = async ({ fetch }) => {
 			authProviders: [],
 			tools: [],
 			mcps: [],
-			featuredAgents: []
+			templates: []
 		};
 	}
 
 	const authProviders = await ChatService.listAuthProviders({ fetch });
-	const featuredAgents = (await ChatService.listProjectShares({ fetch })).items;
+	const templates = (await ChatService.listTemplates({ fetch })).items;
 	const mcps = await ChatService.listMCPs({ fetch });
 	let editorProjects: Project[] = [];
 
@@ -38,6 +38,6 @@ export const load: PageLoad = async ({ fetch }) => {
 		isNew: editorProjects.length === 0,
 		authProviders,
 		mcps,
-		featuredAgents
+		templates
 	};
 };

--- a/ui/user/src/routes/catalog/+page.svelte
+++ b/ui/user/src/routes/catalog/+page.svelte
@@ -22,6 +22,7 @@
 	);
 
 	const type = q('type');
+	const preselected = q('id');
 </script>
 
 <div class="flex h-full flex-col items-center">
@@ -29,7 +30,7 @@
 	{#if type === 'agents'}
 		<main class="colors-background relative flex w-full flex-col items-center justify-center py-12">
 			<div class="flex w-full max-w-(--breakpoint-2xl) flex-col items-center justify-center">
-				<AgentCatalog {templates} {mcps} />
+				<AgentCatalog {templates} {mcps} {preselected} />
 			</div>
 		</main>
 	{:else}
@@ -65,6 +66,7 @@
 				{mcps}
 				inline
 				catalogDescription="Extend your agent's capabilities by adding multiple MCP servers from our evergrowing catalog."
+				{preselected}
 			/>
 		</main>
 	{/if}

--- a/ui/user/src/routes/catalog/+page.svelte
+++ b/ui/user/src/routes/catalog/+page.svelte
@@ -30,7 +30,7 @@
 	{#if type === 'agents'}
 		<main class="colors-background relative flex w-full flex-col items-center justify-center py-12">
 			<div class="flex w-full max-w-(--breakpoint-2xl) flex-col items-center justify-center">
-				<AgentCatalog {templates} {mcps} {preselected} />
+				<AgentCatalog inline {templates} {mcps} {preselected} />
 			</div>
 		</main>
 	{:else}


### PR DESCRIPTION
* fix clicking an agent template or mcp in the unauthenticated page
* reroutes to /catalog?type={type}&id={agentTemplateId or mcpCatalogId} to show the catalog and a preselected agent template or MCP Server to set up