### PR TITLE
enhance: sensitive input for mcp server config

### DIFF
--- a/ui/user/src/lib/components/SensitiveInput.svelte
+++ b/ui/user/src/lib/components/SensitiveInput.svelte
@@ -9,7 +9,6 @@
 
 	let { name, value = $bindable('') }: Props = $props();
 	let showSensitive = $state(false);
-	let focused = $state(false);
 
 	function handleInput(event: Event) {
 		const input = event.target as HTMLInputElement;
@@ -30,8 +29,6 @@
 		{value}
 		type={showSensitive ? 'text' : 'password'}
 		oninput={handleInput}
-		onfocus={() => (focused = true)}
-		onblur={() => (focused = false)}
 	/>
 
 	<button

--- a/ui/user/src/lib/components/SensitiveInput.svelte
+++ b/ui/user/src/lib/components/SensitiveInput.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { Eye, EyeOff } from 'lucide-svelte';
+
+	interface Props {
+		name: string;
+		value?: string;
+	}
+
+	let { name, value = $bindable('') }: Props = $props();
+	let showSensitive = $state(false);
+	let focused = $state(false);
+
+	function handleInput(event: Event) {
+		const input = event.target as HTMLInputElement;
+		value = input.value;
+	}
+
+	function toggleVisibility() {
+		showSensitive = !showSensitive;
+	}
+</script>
+
+<div class="relative flex grow items-center">
+	<input
+		data-1p-ignore
+		id={name}
+		{name}
+		class="text-input-filled w-full pr-10"
+		{value}
+		type={showSensitive ? 'text' : 'password'}
+		oninput={handleInput}
+		onfocus={() => (focused = true)}
+		onblur={() => (focused = false)}
+	/>
+
+	<button
+		class="absolute top-1/2 right-4 z-10 -translate-y-1/2 cursor-pointer"
+		onclick={toggleVisibility}
+	>
+		{#if showSensitive}
+			<EyeOff class="size-4" />
+		{:else}
+			<Eye class="size-4" />
+		{/if}
+	</button>
+</div>

--- a/ui/user/src/lib/components/SensitiveInput.svelte
+++ b/ui/user/src/lib/components/SensitiveInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { Eye, EyeOff } from 'lucide-svelte';
 
 	interface Props {
@@ -36,6 +37,7 @@
 	<button
 		class="absolute top-1/2 right-4 z-10 -translate-y-1/2 cursor-pointer"
 		onclick={toggleVisibility}
+		use:tooltip={{ disablePortal: true, text: showSensitive ? 'Hide' : 'Reveal' }}
 	>
 		{#if showSensitive}
 			<EyeOff class="size-4" />

--- a/ui/user/src/lib/components/mcp/HostedMcpForm.svelte
+++ b/ui/user/src/lib/components/mcp/HostedMcpForm.svelte
@@ -2,6 +2,7 @@
 	import type { MCPServerInfo } from '$lib/services/chat/mcp';
 	import { Plus, Trash2 } from 'lucide-svelte';
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
+	import SensitiveInput from '$lib/components/SensitiveInput.svelte';
 
 	interface Props {
 		config: MCPServerInfo;
@@ -35,15 +36,20 @@
 							<InfoTooltip text={env.description} />
 						</label>
 					{/if}
-					<input
-						data-1p-ignore
-						id={env.name}
-						name={env.name}
-						class="text-input-filled w-full"
-						class:error={showSubmitError && !env.value && env.required}
-						bind:value={env.value}
-						type={env.sensitive ? 'password' : 'text'}
-					/>
+					{#if env.sensitive}
+						<SensitiveInput name={env.name} bind:value={env.value} />
+					{:else}
+						<input
+							data-1p-ignore
+							id={env.name}
+							name={env.name}
+							class="text-input-filled w-full"
+							class:error={showSubmitError && !env.value && env.required}
+							bind:value={env.value}
+							type="text"
+						/>
+					{/if}
+
 					<div class="min-h-4 text-xs text-red-500">
 						{#if showSubmitError && !env.value && env.required}
 							This field is required.

--- a/ui/user/src/lib/components/mcp/ProjectMcpConfig.svelte
+++ b/ui/user/src/lib/components/mcp/ProjectMcpConfig.svelte
@@ -4,9 +4,10 @@
 	import { isValidMcpConfig, type MCPServerInfo } from '$lib/services/chat/mcp';
 	import { ChevronsRight, PencilLine, Plus, Server, Trash2, X } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
-	import HostedMcpForm from './HostedMcpForm.svelte';
 	import { onMount } from 'svelte';
 	import { errors } from '$lib/stores';
+	import HostedMcpForm from '$lib/components/mcp/HostedMcpForm.svelte';
+	import SensitiveInput from '$lib/components/SensitiveInput.svelte';
 
 	interface Props {
 		projectMcp?: ProjectMCP;
@@ -223,14 +224,18 @@
 							placeholder="Key (ex. API_KEY)"
 							use:focusOnAdd={i === config.headers.length - 1}
 						/>
-						<input
-							data-1p-ignore
-							id={header.name}
-							name={header.name}
-							class="text-input-filled w-full"
-							bind:value={header.value}
-							type={header.sensitive ? 'password' : 'text'}
-						/>
+						{#if header.sensitive}
+							<SensitiveInput name={header.name} bind:value={header.value} />
+						{:else}
+							<input
+								data-1p-ignore
+								id={header.name}
+								name={header.name}
+								class="text-input-filled w-full"
+								bind:value={header.value}
+								type="text"
+							/>
+						{/if}
 					</div>
 					<button class="icon-button" onclick={() => config.headers?.splice(i, 1)}>
 						<Trash2 class="size-4" />


### PR DESCRIPTION
* small QOL, adds sensistive input to allow option to reveal/hide value of an input (basically, eyeball thingy)
<img width="515" alt="Screenshot 2025-05-12 at 12 56 14 PM" src="https://github.com/user-attachments/assets/1faf3bc1-b366-448a-8c1b-72d0469a8c99" />

<img width="1003" alt="Screenshot 2025-05-12 at 12 57 40 PM" src="https://github.com/user-attachments/assets/b9d78ee0-19c8-4249-b623-aa725d3085d5" />


