### PR TITLE
fix: add missing return when updating mcp catalog entries

### DIFF
--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -603,6 +603,7 @@ func (h *Handler) createMCPServerCatalog(req router.Request, toolRef *v1.ToolRef
 			mcpCatalogEntry.Spec.ToolReferenceName = toolRef.Name
 			return req.Client.Update(req.Ctx, &mcpCatalogEntry)
 		}
+		return nil
 	}
 
 	return req.Client.Create(req.Ctx, &v1.MCPServerCatalogEntry{


### PR DESCRIPTION
I just noticed this when looking at a PR I made the other day. We are supposed to return nil here if we're not updating, rather than going through and calling `req.Create`.