### PR TITLE
fix: update catalog entries when the tool changes

### DIFF
--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -593,7 +593,7 @@ func (h *Handler) createMCPServerCatalog(req router.Request, toolRef *v1.ToolRef
 			shouldUpdate = true
 		}
 
-		if equality.Semantic.DeepEqual(mcpCatalogEntry.Spec.CommandManifest.Server, serverManifest) &&
+		if !equality.Semantic.DeepEqual(mcpCatalogEntry.Spec.CommandManifest.Server, serverManifest) &&
 			mcpCatalogEntry.Spec.ToolReferenceName == toolRef.Name {
 			shouldUpdate = true
 		}


### PR DESCRIPTION
This fixes a bug that I sadly introduced in this PR: https://github.com/obot-platform/obot/pull/2906/files

I inverted the logic inadvertently.