### PR TITLE
Fix: Don't auth the obot-search-bundle

### DIFF
--- a/ui/user/src/lib/components/mcp/McpInfoConfig.svelte
+++ b/ui/user/src/lib/components/mcp/McpInfoConfig.svelte
@@ -79,7 +79,7 @@
 			'google-search-bundle',
 			'images-bundle',
 			'memory',
-			'obot-search',
+			'obot-search-bundle',
 			'time',
 			'database',
 			'die-roller',


### PR DESCRIPTION
This whole bit of code is a hack but the idea is that these tools don't
need additional auth or configuration when added as an mcp-server.

Need to update to obot-search-bundle because we made this tool a bundle.

Signed-off-by: Craig Jellick <craig@acorn.io>
