### PR TITLE
enhance: enable chatbot users to configure creds for mcp servers

### DIFF
--- a/pkg/api/handlers/projects.go
+++ b/pkg/api/handlers/projects.go
@@ -676,8 +676,13 @@ func (h *ProjectsHandler) listCredentials(req api.Context, local bool) error {
 		credContextID = thread.Name + "-local"
 	}
 
+	credContexts := []string{credContextID}
+	if thread.Spec.ParentThreadName != "" && !local {
+		credContexts = append(credContexts, thread.Spec.ParentThreadName)
+	}
+
 	creds, err := req.GPTClient.ListCredentials(req.Context(), gptscript.ListCredentialsOptions{
-		CredentialContexts: []string{credContextID},
+		CredentialContexts: credContexts,
 	})
 	if err != nil {
 		return err

--- a/ui/user/src/lib/components/Sidebar.svelte
+++ b/ui/user/src/lib/components/Sidebar.svelte
@@ -106,6 +106,7 @@
 			</div>
 		{:else}
 			<Threads {project} bind:currentThreadID />
+			<McpServers {project} chatbot={true} />
 			{#if hasTool(projectTools.tools, 'memory')}
 				<Memories {project} />
 			{/if}

--- a/ui/user/src/lib/components/edit/McpServers.svelte
+++ b/ui/user/src/lib/components/edit/McpServers.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
 	import { getProjectMCPs } from '$lib/context/projectMcps.svelte';
-	import { ChatService, type MCP, type Project, type ProjectMCP } from '$lib/services';
-	import { PencilLine, Plus, Server, Trash2, Wrench } from 'lucide-svelte/icons';
+	import {
+		ChatService,
+		type MCP,
+		type Project,
+		type ProjectMCP,
+		type ProjectCredential
+	} from '$lib/services';
+	import { type MCPServerInfo } from '$lib/services/chat/mcp';
+	import { PencilLine, Plus, Server, Trash2, Wrench, TriangleAlert } from 'lucide-svelte/icons';
+	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import McpInfoConfig from '$lib/components/mcp/McpInfoConfig.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import { onMount } from 'svelte';
@@ -14,18 +22,41 @@
 
 	interface Props {
 		project: Project;
+		chatbot?: boolean;
 	}
 
-	let { project }: Props = $props();
+	let { project, chatbot = false }: Props = $props();
 	let mcpToShow = $state<ProjectMCP>();
 	let toDelete = $state<ProjectMCP>();
 	let mcps = $state<MCP[]>([]);
+	let localCredentials = $state<ProjectCredential[]>([]);
+	let regularCredentials = $state<ProjectCredential[]>([]);
 
 	let mcpConfigDialog = $state<ReturnType<typeof McpInfoConfig>>();
 	let mcpSetupWizard = $state<ReturnType<typeof McpSetupWizard>>();
 
 	const projectMCPs = getProjectMCPs();
 	const toolBundleMap = getToolBundleMap();
+	const layout = getLayout();
+
+	export async function refreshMcpList() {
+		if (!project?.assistantID || !project.id) return;
+
+		projectMCPs.items = await ChatService.listProjectMCPs(project.assistantID, project.id);
+		if (chatbot) {
+			await fetchCredentials();
+		}
+	}
+
+	// Refresh MCP list whenever sidebar config changes (and we're not currently editing an MCP)
+	$effect(() => {
+		const currentConfig = layout.sidebarConfig;
+
+		if (currentConfig !== 'custom-mcp') {
+			setTimeout(() => refreshMcpList(), 100);
+		}
+	});
+
 	let legacyBundleId = $derived(
 		mcpToShow?.catalogID && toolBundleMap.get(mcpToShow.catalogID) ? mcpToShow.catalogID : undefined
 	);
@@ -36,17 +67,73 @@
 			return acc;
 		}, [])
 	);
-	const layout = getLayout();
+
+	$effect(() => {
+		if (project?.assistantID && project.id && chatbot) {
+			fetchCredentials();
+		}
+	});
+
+	async function fetchCredentials() {
+		if (!project?.assistantID || !project.id) return;
+
+		try {
+			localCredentials = (
+				await ChatService.listProjectLocalCredentials(project.assistantID, project.id)
+			).items;
+
+			regularCredentials = (
+				await ChatService.listProjectCredentials(project.assistantID, project.id)
+			).items;
+		} catch (error) {
+			console.error('Failed to fetch credentials:', error);
+		}
+	}
+
+	function shouldShowWarning(mcp: ProjectMCP) {
+		if (!mcp.catalogID || !toolBundleMap.get(mcp.catalogID)) {
+			return mcp.configured !== true;
+		}
+
+		const hasLocalCredential = localCredentials.some(
+			(cred) => cred.toolID === mcp.catalogID && cred.exists === true
+		);
+
+		const hasRegularCredential = regularCredentials.some(
+			(cred) => cred.toolID === mcp.catalogID && cred.exists === true
+		);
+
+		return !(hasLocalCredential || hasRegularCredential);
+	}
+
 	onMount(() => {
 		ChatService.listMCPs().then((response) => {
 			mcps = response;
 		});
+
+		if (project?.assistantID && project.id && chatbot) {
+			fetchCredentials();
+		}
 	});
 
 	async function handleRemoveMcp() {
 		if (!project?.assistantID || !project.id || !toDelete) return;
-		await ChatService.deleteProjectMCP(project.assistantID, project.id, toDelete.id);
-		projectMCPs.items = projectMCPs.items.filter((mcp) => mcp.id !== toDelete?.id);
+
+		if (chatbot) {
+			if (toDelete.catalogID && toolBundleMap.get(toDelete.catalogID)) {
+				await ChatService.deleteProjectLocalCredential(
+					project.assistantID,
+					project.id,
+					toDelete.catalogID
+				);
+			} else if (toDelete.configured) {
+				await ChatService.deconfigureProjectMCP(project.assistantID, project.id, toDelete.id);
+			}
+		} else {
+			await ChatService.deleteProjectMCP(project.assistantID, project.id, toDelete.id);
+		}
+
+		await refreshMcpList();
 		toDelete = undefined;
 	}
 </script>
@@ -56,7 +143,7 @@
 	iconSize={5}
 	header="MCP Servers"
 	helpText={HELPER_TEXTS.mcpServers}
-	open={projectMCPs.items.length > 0}
+	open={chatbot ? projectMCPs.items.some(shouldShowWarning) : projectMCPs.items.length > 0}
 >
 	<div class="flex flex-col gap-2">
 		{#if projectMCPs.items.length > 0}
@@ -73,7 +160,7 @@
 									mcpToShow = mcp;
 									mcpConfigDialog?.open();
 								} else {
-									openEditProjectMcp(layout, mcp);
+									openEditProjectMcp(layout, mcp, chatbot);
 								}
 							}}
 						>
@@ -84,19 +171,37 @@
 									<Server class="size-4" />
 								{/if}
 							</div>
-							<p class="w-[calc(100%-24px)] truncate text-left text-xs font-light">
+							<p
+								class="flex w-[calc(100%-24px)] items-center truncate text-left text-xs font-light"
+							>
 								{mcp.name || 'My Custom Server'}
+								{#if chatbot && shouldShowWarning(mcp)}
+									<span class="ml-1" use:tooltip={'Configuration Required'}>
+										<TriangleAlert
+											class="size-4"
+											stroke="currentColor"
+											fill="none"
+											color="orange"
+										/>
+									</span>
+								{/if}
 							</p>
 						</button>
 						<DotDotDot
 							class="p-0 pr-2.5 transition-opacity duration-200 group-hover:opacity-100 md:opacity-0"
 						>
 							<div class="default-dialog flex min-w-max flex-col p-2">
-								<button class="menu-button" onclick={() => openMCPServerTools(layout, mcp)}>
-									<Wrench class="size-4" /> Manage Tools
-								</button>
+								{#if !chatbot}
+									<button class="menu-button" onclick={() => openMCPServerTools(layout, mcp)}>
+										<Wrench class="size-4" /> Manage Tools
+									</button>
+								{/if}
 								<button class="menu-button" onclick={() => (toDelete = mcp)}>
-									<Trash2 class="size-4" /> Delete
+									{#if !chatbot}
+										<Trash2 class="size-4" /> Delete
+									{:else}
+										<Trash2 class="size-4" /> Delete My Configuration
+									{/if}
 								</button>
 							</div>
 						</DotDotDot>
@@ -104,35 +209,37 @@
 				{/each}
 			</div>
 		{/if}
-		<div class="flex justify-end">
-			<DotDotDot class="button flex items-center gap-1 text-xs">
-				{#snippet icon()}
-					<Plus class="size-4" /> Add MCP Server
-				{/snippet}
-				<div class="default-dialog flex min-w-max flex-col p-2">
-					<button class="menu-button" onclick={() => mcpSetupWizard?.open()}>
-						<Server class="size-4" /> Browse Catalog
-					</button>
-					<button class="menu-button" onclick={() => openEditProjectMcp(layout)}>
-						<PencilLine class="size-4" /> Create Config
-					</button>
-				</div>
-			</DotDotDot>
-			<McpSetupWizard
-				bind:this={mcpSetupWizard}
-				catalogDescription="Extend your agent's capabilities by adding multiple MCP servers from our evergrowing catalog."
-				catalogSubmitText="Add to agent"
-				{selectedMcpIds}
-				{project}
-				{mcps}
-				onFinish={(newProjectMcp) => {
-					if (newProjectMcp) {
-						projectMCPs.items.push(newProjectMcp);
-					}
-					mcpSetupWizard?.close();
-				}}
-			/>
-		</div>
+		{#if !chatbot}
+			<div class="flex justify-end">
+				<DotDotDot class="button flex items-center gap-1 text-xs">
+					{#snippet icon()}
+						<Plus class="size-4" /> Add MCP Server
+					{/snippet}
+					<div class="default-dialog flex min-w-max flex-col p-2">
+						<button class="menu-button" onclick={() => mcpSetupWizard?.open()}>
+							<Server class="size-4" /> Browse Catalog
+						</button>
+						<button class="menu-button" onclick={() => openEditProjectMcp(layout)}>
+							<PencilLine class="size-4" /> Create Config
+						</button>
+					</div>
+				</DotDotDot>
+				<McpSetupWizard
+					bind:this={mcpSetupWizard}
+					catalogDescription="Extend your agent's capabilities by adding multiple MCP servers from our evergrowing catalog."
+					catalogSubmitText="Add to agent"
+					{selectedMcpIds}
+					{project}
+					{mcps}
+					onFinish={(newProjectMcp) => {
+						if (newProjectMcp) {
+							projectMCPs.items.push(newProjectMcp);
+						}
+						mcpSetupWizard?.close();
+					}}
+				/>
+			</div>
+		{/if}
 	</div>
 </CollapsePane>
 
@@ -143,10 +250,22 @@
 	{legacyBundleId}
 	submitText={legacyBundleId ? 'Reauthenticate' : 'Modify server'}
 	legacyAuthText="You will be prompted to login again to reauthenticate."
+	onUpdate={async (manifest: MCPServerInfo) => {
+		if (!project?.assistantID || !project.id || !mcpToShow) return;
+
+		if (!legacyBundleId) {
+			await ChatService.updateProjectMCP(project.assistantID, project.id, mcpToShow.id, manifest);
+		}
+
+		await refreshMcpList();
+		mcpConfigDialog?.close();
+	}}
 />
 
 <Confirm
-	msg={`Are you sure you want to delete MCP server: ${toDelete?.name}?`}
+	msg={chatbot
+		? `Are you sure you want to delete your MCP server configuration?`
+		: `Are you sure you want to delete MCP server: ${toDelete?.name}?`}
 	show={!!toDelete}
 	onsuccess={handleRemoveMcp}
 	oncancel={() => (toDelete = undefined)}

--- a/ui/user/src/lib/components/mcp/HostedMcpForm.svelte
+++ b/ui/user/src/lib/components/mcp/HostedMcpForm.svelte
@@ -8,8 +8,9 @@
 		config: MCPServerInfo;
 		showSubmitError: boolean;
 		custom?: boolean;
+		chatbot?: boolean;
 	}
-	let { config = $bindable(), showSubmitError, custom }: Props = $props();
+	let { config = $bindable(), showSubmitError, custom, chatbot = false }: Props = $props();
 
 	function focusOnAdd(node: HTMLInputElement, shouldFocus: boolean) {
 		if (shouldFocus) {
@@ -24,7 +25,7 @@
 		{#each config.env as env, i}
 			<div class="flex w-full items-center gap-2">
 				<div class="flex grow flex-col gap-1">
-					{#if !env.required}
+					{#if !env.required && !chatbot}
 						<input
 							class="ghost-input w-full py-0"
 							bind:value={env.key}
@@ -57,59 +58,79 @@
 						{/if}
 					</div>
 				</div>
-				{#if !env.required || custom}
+				{#if (!env.required || custom) && !chatbot}
 					<button class="icon-button" onclick={() => config.env?.splice(i, 1)}>
 						<Trash2 class="size-4" />
 					</button>
 				{/if}
 			</div>
 		{/each}
-		<div class="flex justify-end">
-			<button
-				class="button flex items-center gap-1 text-xs"
-				onclick={() =>
-					config.env?.push({
-						name: '',
-						key: '',
-						description: '',
-						sensitive: false,
-						required: false,
-						file: false,
-						value: ''
-					})}
-			>
-				<Plus class="size-4" /> Environment Variable
-			</button>
-		</div>
-	</div>
-{/if}
-
-<div class="flex items-center gap-4">
-	<h4 class="text-base font-semibold">Command</h4>
-	<input class="text-input-filled w-full" bind:value={config.command} />
-</div>
-
-{#if config.args}
-	<div class="flex gap-4">
-		<h4 class="mt-1.5 text-base font-semibold">Arguments</h4>
-		<div class="flex grow flex-col gap-4">
-			{#each config.args as _arg, i}
-				<div class="flex items-center gap-2">
-					<input class="text-input-filled w-full" bind:value={config.args[i]} />
-					<button class="icon-button" onclick={() => config.args?.splice(i, 1)}>
-						<Trash2 class="size-4" />
-					</button>
-				</div>
-			{/each}
-
+		{#if !chatbot}
 			<div class="flex justify-end">
 				<button
 					class="button flex items-center gap-1 text-xs"
-					onclick={() => config.args?.push('')}
+					onclick={() =>
+						config.env?.push({
+							name: '',
+							key: '',
+							description: '',
+							sensitive: false,
+							required: false,
+							file: false,
+							value: ''
+						})}
 				>
-					<Plus class="size-4" /> Argument
+					<Plus class="size-4" /> Environment Variable
 				</button>
 			</div>
-		</div>
+		{/if}
 	</div>
+{/if}
+
+{#if !chatbot}
+	<div class="flex items-center gap-4">
+		<h4 class="text-base font-semibold">Command</h4>
+		<input class="text-input-filled w-full" bind:value={config.command} />
+	</div>
+{:else if config.command}
+	<div class="flex items-center gap-4">
+		<h4 class="text-base font-semibold">Command</h4>
+		<div class="text-input-filled w-full opacity-75">{config.command}</div>
+	</div>
+{/if}
+
+{#if config.args}
+	{#if !chatbot}
+		<div class="flex gap-4">
+			<h4 class="mt-1.5 text-base font-semibold">Arguments</h4>
+			<div class="flex grow flex-col gap-4">
+				{#each config.args as _arg, i}
+					<div class="flex items-center gap-2">
+						<input class="text-input-filled w-full" bind:value={config.args[i]} />
+						<button class="icon-button" onclick={() => config.args?.splice(i, 1)}>
+							<Trash2 class="size-4" />
+						</button>
+					</div>
+				{/each}
+
+				<div class="flex justify-end">
+					<button
+						class="button flex items-center gap-1 text-xs"
+						onclick={() => config.args?.push('')}
+					>
+						<Plus class="size-4" /> Argument
+					</button>
+				</div>
+			</div>
+		</div>
+	{:else if config.args.length > 0}
+		<div class="flex gap-4">
+			<h4 class="mt-1.5 text-base font-semibold">Arguments</h4>
+			<div class="flex grow flex-col gap-4">
+				{#each config.args as arg}
+					<div class="text-input-filled w-full opacity-75">{arg}</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
 {/if}

--- a/ui/user/src/lib/components/mcp/ProjectMcpConfig.svelte
+++ b/ui/user/src/lib/components/mcp/ProjectMcpConfig.svelte
@@ -14,8 +14,9 @@
 		project?: Project;
 		onCreate?: (customMcpServerInfo: MCPServerInfo) => void;
 		onUpdate?: (customMcpServerInfo: MCPServerInfo) => void;
+		chatbot?: boolean;
 	}
-	let { projectMcp, project, onCreate, onUpdate }: Props = $props();
+	let { projectMcp, project, onCreate, onUpdate, chatbot = false }: Props = $props();
 
 	function isObotHosted(projectMcp: ProjectMCP) {
 		return (
@@ -148,7 +149,7 @@
 		</div>
 	</div>
 
-	{#if !projectMcp?.catalogID}
+	{#if !projectMcp?.catalogID && !chatbot}
 		<div
 			class="dark:bg-gray-980 mt-4 flex w-full flex-col gap-2 bg-gray-50 px-4 pt-4 pb-2 shadow-inner md:px-8"
 		>
@@ -187,9 +188,19 @@
 			class="dark:bg-surface2 dark:border-surface3 flex w-full grow flex-col gap-4 self-center rounded-lg bg-white px-4 pt-12 pb-8 shadow-sm md:max-w-[900px] md:px-8 dark:border"
 		>
 			{#if showObotHosted}
-				<HostedMcpForm bind:config {showSubmitError} custom={!projectMcp?.catalogID} />
+				<HostedMcpForm
+					bind:config
+					{showSubmitError}
+					custom={!projectMcp?.catalogID && !chatbot}
+					{chatbot}
+				/>
 			{:else}
-				<RemoteMcpForm bind:config {showSubmitError} custom={!projectMcp?.catalogID} />
+				<RemoteMcpForm
+					bind:config
+					{showSubmitError}
+					custom={!projectMcp?.catalogID && !chatbot}
+					{chatbot}
+				/>
 			{/if}
 		</div>
 

--- a/ui/user/src/lib/components/mcp/RemoteMcpForm.svelte
+++ b/ui/user/src/lib/components/mcp/RemoteMcpForm.svelte
@@ -7,8 +7,9 @@
 		config: MCPServerInfo;
 		showSubmitError: boolean;
 		custom?: boolean;
+		chatbot?: boolean;
 	}
-	let { config = $bindable(), showSubmitError, custom }: Props = $props();
+	let { config = $bindable(), showSubmitError, custom, chatbot = false }: Props = $props();
 
 	function focusOnAdd(node: HTMLInputElement, shouldFocus: boolean) {
 		if (shouldFocus) {
@@ -17,22 +18,34 @@
 	}
 </script>
 
-<div class="flex items-center gap-4">
-	<h4 class="w-24 text-base font-semibold">URL</h4>
-	<input class="text-input-filled flex grow" bind:value={config.url} />
-</div>
+{#if !chatbot}
+	<div class="flex items-center gap-4">
+		<h4 class="w-24 text-base font-semibold">URL</h4>
+		<input class="text-input-filled flex grow" bind:value={config.url} />
+	</div>
+{:else if config.url}
+	<div class="flex items-center gap-4">
+		<h4 class="w-24 text-base font-semibold">URL</h4>
+		<div class="text-input-filled flex grow opacity-75">{config.url}</div>
+	</div>
+{/if}
+
 <div class="flex flex-col gap-2">
 	<h4 class="text-base font-semibold">Headers</h4>
 	{#if config.headers && config.headers.length > 0}
 		{#each config.headers as header, i}
 			<div class="flex w-full items-center gap-2">
 				<div class="flex grow flex-col gap-1">
-					<input
-						class="ghost-input w-full py-0 pl-1"
-						bind:value={header.key}
-						placeholder="Key (ex. API_KEY)"
-						use:focusOnAdd={i === config.headers.length - 1}
-					/>
+					{#if !chatbot}
+						<input
+							class="ghost-input w-full py-0 pl-1"
+							bind:value={header.key}
+							placeholder="Key (ex. API_KEY)"
+							use:focusOnAdd={i === config.headers.length - 1}
+						/>
+					{:else}
+						<div class="ghost-input w-full py-0 pl-1">{header.key}</div>
+					{/if}
 					{#if header.sensitive}
 						<SensitiveInput name={header.name} bind:value={header.value} />
 					{:else}
@@ -51,7 +64,7 @@
 						{/if}
 					</div>
 				</div>
-				{#if !header.required || custom}
+				{#if (!header.required || custom) && !chatbot}
 					<button class="icon-button" onclick={() => config.headers?.splice(i, 1)}>
 						<Trash2 class="size-4" />
 					</button>
@@ -59,21 +72,23 @@
 			</div>
 		{/each}
 	{/if}
-	<div class="flex justify-end pt-2">
-		<button
-			class="button flex items-center gap-1 text-xs"
-			onclick={() =>
-				config.headers?.push({
-					name: '',
-					key: '',
-					description: '',
-					sensitive: false,
-					required: false,
-					file: false,
-					value: ''
-				})}
-		>
-			<Plus class="size-4" /> Header
-		</button>
-	</div>
+	{#if !chatbot}
+		<div class="flex justify-end">
+			<button
+				class="button flex items-center gap-1 text-xs"
+				onclick={() =>
+					config.headers?.push({
+						key: '',
+						name: '',
+						value: '',
+						description: '',
+						sensitive: false,
+						required: false,
+						file: false
+					})}
+			>
+				<Plus class="size-4" /> Header
+			</button>
+		</div>
+	{/if}
 </div>

--- a/ui/user/src/lib/context/layout.svelte.ts
+++ b/ui/user/src/lib/context/layout.svelte.ts
@@ -34,6 +34,7 @@ export interface Layout {
 	editProjectMcp?: ProjectMCP;
 	template?: ProjectTemplate;
 	mcpServer?: ProjectMCP;
+	chatbotMcpEdit?: boolean;
 }
 
 export function isSomethingSelected(layout: Layout) {
@@ -48,6 +49,7 @@ export function closeAll(layout: Layout) {
 	layout.editProjectMcp = undefined;
 	layout.template = undefined;
 	layout.mcpServer = undefined;
+	layout.chatbotMcpEdit = undefined;
 }
 
 export function openTask(layout: Layout, taskID?: string) {
@@ -92,11 +94,12 @@ export function openCustomTool(layout: Layout, customToolId: string) {
 	}
 }
 
-export function openEditProjectMcp(layout: Layout, projectMcp?: ProjectMCP) {
+export function openEditProjectMcp(layout: Layout, projectMcp?: ProjectMCP, chatbot?: boolean) {
 	closeAll(layout);
 	layout.fileEditorOpen = false;
 	layout.sidebarConfig = 'custom-mcp';
 	layout.editProjectMcp = projectMcp;
+	layout.chatbotMcpEdit = chatbot;
 	if (responsive.isMobile) {
 		layout.sidebarOpen = false;
 	}
@@ -108,6 +111,7 @@ export function closeSidebarConfig(layout: Layout) {
 	layout.editProjectMcp = undefined;
 	layout.template = undefined;
 	layout.mcpServer = undefined;
+	layout.chatbotMcpEdit = undefined;
 }
 
 export function initLayout(layout: Layout) {

--- a/ui/user/src/lib/services/chat/mcp.ts
+++ b/ui/user/src/lib/services/chat/mcp.ts
@@ -6,7 +6,7 @@ export interface MCPServerInfo extends Omit<ProjectMCP, 'id'> {
 	headers?: (MCPSubField & { value: string; custom?: boolean })[];
 }
 
-function getKeyValuePairs(customMcpConfig: MCPServerInfo) {
+export function getKeyValuePairs(customMcpConfig: MCPServerInfo) {
 	return [...(customMcpConfig.env ?? []), ...(customMcpConfig.headers ?? [])].reduce<
 		Record<string, string>
 	>(

--- a/ui/user/src/routes/s/[id]/+page.svelte
+++ b/ui/user/src/routes/s/[id]/+page.svelte
@@ -11,6 +11,8 @@
 	import { browser } from '$app/environment';
 	import { initProjectTools, getProjectTools } from '$lib/context/projectTools.svelte';
 	import { initHelperMode } from '$lib/context/helperMode.svelte';
+	import { initProjectMCPs } from '$lib/context/projectMcps.svelte';
+	import { initToolReferences } from '$lib/context/toolReferences.svelte';
 
 	let { data }: PageProps = $props();
 	let showWarning = $state(false);
@@ -25,6 +27,9 @@
 		projectEditorOpen: false,
 		items: []
 	});
+
+	initToolReferences(data.toolReferences || []);
+	initProjectMCPs(data.mcps || []);
 
 	initProjectTools({
 		tools: [],

--- a/ui/user/src/routes/s/[id]/+page.ts
+++ b/ui/user/src/routes/s/[id]/+page.ts
@@ -1,12 +1,38 @@
 import { handleRouteError } from '$lib/errors';
-import { ChatService, type ProjectShare } from '$lib/services';
+import {
+	ChatService,
+	type Project,
+	type ProjectMCP,
+	type ProjectShare,
+	type ToolReference
+} from '$lib/services';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params, fetch }) => {
 	let share: ProjectShare | null = null;
+	let project: Project | null = null;
+	let mcps: ProjectMCP[] = [];
+	let toolReferences = { items: [] as ToolReference[] };
+
 	try {
 		share = await ChatService.getProjectShareByPublicID(params.id, { fetch });
+
+		if (share?.projectID) {
+			// Get the project data
+			project = await ChatService.getProject(share.projectID, { fetch });
+
+			// Get tool references and MCPs in parallel
+			if (project && project.assistantID) {
+				const [toolRefsResponse, mcpsResponse] = await Promise.all([
+					ChatService.listAllTools({ fetch }),
+					ChatService.listProjectMCPs(project.assistantID, project.id, { fetch })
+				]);
+
+				toolReferences = toolRefsResponse;
+				mcps = mcpsResponse;
+			}
+		}
 	} catch (e) {
 		handleRouteError(e, `/s/${params.id}`, profile.current);
 	}
@@ -15,6 +41,9 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		id: params.id,
 		featured: share?.featured ?? false,
 		isOwner: share?.editor ?? false,
-		projectID: share?.projectID
+		projectID: share?.projectID,
+		project,
+		mcps,
+		toolReferences: toolReferences.items
 	};
 };


### PR DESCRIPTION
This change adds a modified MCP Servers section to the sidebar for chatbot users that allows them to:
- identify MCP servers that have _not_ been configured by them (or the
  author)
- manage local credentials for the chatbot's MCP servers


https://github.com/user-attachments/assets/d6a56794-b7a0-43af-b7b6-585c6dfa8aa1



