### PR TITLE
chore: rm google-search bundle from agent definition

### DIFF
--- a/pkg/controller/data/agent.yaml
+++ b/pkg/controller/data/agent.yaml
@@ -31,4 +31,3 @@ spec:
     - tasks
     defaultThreadTools:
     - images-bundle
-    - google-search-bundle


### PR DESCRIPTION
The Google Search bundle has been removed from the tool index. Remove it from the `a1-obot` Agent definition.

