### PR TITLE
chore: update tool config for default agent

### DIFF
--- a/pkg/controller/data/agent.yaml
+++ b/pkg/controller/data/agent.yaml
@@ -25,9 +25,10 @@ spec:
     alias: obot
     tools:
     - workspace-files
-    - time
-    - knowledge
-    - database
     - tasks
     defaultThreadTools:
     - images-bundle
+    - time
+    - knowledge
+    availableThreadTools:
+    - database


### PR DESCRIPTION
This change updates the default Agent definition so that:
- The `time` and `knowledge` bundles are "Optional On"
- The `database` bundle is "Optional Off"

