### PR TITLE
feat: pass LLM proxy URL and token to MCP servers

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -126,6 +126,8 @@ config:
   OBOT_SERVER_MCPBASE_IMAGE: ""
   # config.OBOT_SERVER_MCPCLUSTER_DOMAIN -- The cluster domain to use for MCP services. Defaults to cluster.local. Only matters if the above image is set.
   OBOT_SERVER_MCPCLUSTER_DOMAIN: ""
+  # config.OBOT_SERVER_MCPOBOT_SERVICE_FQDN -- The FQDN MCP servers should use to call back to Obot. Defaults to localhost:8080
+  OBOT_SERVER_MCPOBOT_SERVICE_FQDN: ""
   # config.OBOT_SERVER_DISALLOW_LOCALHOST_MCP -- disallow MCP servers that try to connect to localhost. Defaults to false.
   OBOT_SERVER_DISALLOW_LOCALHOST_MCP: ""
 

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -28,7 +28,7 @@ import (
 const tokenUsageTimePeriod = 24 * time.Hour
 
 func (s *Server) llmProxy(req api.Context) error {
-	token, err := s.tokenService.DecodeToken(strings.TrimPrefix(req.Request.Header.Get("Authorization"), "Bearer "))
+	token, err := s.tokenService.DecodeToken(req.Context(), strings.TrimPrefix(req.Request.Header.Get("Authorization"), "Bearer "))
 	if err != nil {
 		return types2.NewErrHTTP(http.StatusUnauthorized, fmt.Sprintf("invalid token: %v", err))
 	}

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -1,15 +1,19 @@
 package jwt
 
 import (
+	"context"
+	"fmt"
 	"net/http"
-	"slices"
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/obot-platform/nah/pkg/randomtoken"
 	"github.com/obot-platform/obot/pkg/api/authz"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/thread"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var secret string
@@ -33,17 +37,31 @@ type TokenContext struct {
 	WorkflowID     string
 	WorkflowStepID string
 	Scope          string
+	MCPServerID    string
 	UserID         string
 	UserName       string
 	UserEmail      string
 	UserGroups     []string
 }
 
-type TokenService struct{}
+type TokenService struct {
+	client kclient.Client
+	token  string
+}
+
+func NewTokenService(client kclient.Client) *TokenService {
+	return &TokenService{
+		client: client,
+	}
+}
+
+func (t *TokenService) SetLongLivedSigningToken(token string) {
+	t.token = token
+}
 
 func (t *TokenService) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
 	token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
-	tokenContext, err := t.DecodeToken(token)
+	tokenContext, err := t.DecodeToken(req.Context(), token)
 	if err != nil {
 		return nil, false, nil
 	}
@@ -67,30 +85,60 @@ func (t *TokenService) AuthenticateRequest(req *http.Request) (*authenticator.Re
 	}, true, nil
 }
 
-func (t *TokenService) DecodeToken(token string) (*TokenContext, error) {
-	tk, err := jwt.Parse(token, func(*jwt.Token) (any, error) {
+func (t *TokenService) DecodeToken(ctx context.Context, token string) (*TokenContext, error) {
+	var mcpToken bool
+	tk, err := jwt.Parse(token, func(token *jwt.Token) (any, error) {
+		if t.token != "" {
+			if mcp, _ := token.Claims.(jwt.MapClaims)["MCPServerID"].(string); mcp != "" {
+				mcpToken = true
+				return []byte(t.token), nil
+			}
+		}
 		return []byte(secret), nil
 	})
 	if err != nil {
 		return nil, err
 	}
+
 	claims, ok := tk.Claims.(jwt.MapClaims)
 	if !ok {
 		return nil, err
 	}
 
-	groups := strings.Split(claims["UserGroups"].(string), ",")
-	groups = slices.DeleteFunc(groups, func(s string) bool { return s == "" })
+	var groups []string
+	if groupsClaim, ok := claims["UserGroups"].(string); ok && groupsClaim != "" {
+		groups = strings.Split(groupsClaim, ",")
+	}
+
+	modelProvider := claims["ModelProvider"].(string)
+	model := claims["Model"].(string)
+	projectID := claims["ProjectID"].(string)
+	namespace := claims["Namespace"].(string)
+
+	if mcpToken {
+		// MCP tokens are long-lived tokens. Therefore, we don't store some of the dynamic information like run ID, model provider and model.
+		// We need to get that information dynamically when the token is used.
+		var projectThread v1.Thread
+		if err = t.client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: projectID}, &projectThread); err != nil {
+			return nil, err
+		}
+
+		modelProvider, model, err = thread.GetModelAndModelProviderForThread(ctx, t.client, &projectThread)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get model and model provider for thread: %w", err)
+		}
+	}
 
 	context := &TokenContext{
-		Namespace:      claims["Namespace"].(string),
+		Namespace:      namespace,
 		RunID:          claims["RunID"].(string),
 		ThreadID:       claims["ThreadID"].(string),
-		ProjectID:      claims["ProjectID"].(string),
-		ModelProvider:  claims["ModelProvider"].(string),
-		Model:          claims["Model"].(string),
+		ProjectID:      projectID,
+		ModelProvider:  modelProvider,
+		Model:          model,
 		AgentID:        claims["AgentID"].(string),
 		Scope:          claims["Scope"].(string),
+		MCPServerID:    claims["MCPServerID"].(string),
 		WorkflowID:     claims["WorkflowID"].(string),
 		WorkflowStepID: claims["WorkflowStepID"].(string),
 		UserID:         claims["UserID"].(string),
@@ -112,6 +160,7 @@ func (t *TokenService) NewToken(context TokenContext) (string, error) {
 		"Model":          context.Model,
 		"AgentID":        context.AgentID,
 		"Scope":          context.Scope,
+		"MCPServerID":    context.MCPServerID,
 		"WorkflowID":     context.WorkflowID,
 		"WorkflowStepID": context.WorkflowStepID,
 		"UserID":         context.UserID,
@@ -121,5 +170,9 @@ func (t *TokenService) NewToken(context TokenContext) (string, error) {
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	if context.MCPServerID != "" {
+		return token.SignedString([]byte(t.token))
+	}
 	return token.SignedString([]byte(secret))
 }

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -29,7 +29,7 @@ func ToServerConfig(mcpServer v1.MCPServer, projectThreadName string, credEnv ma
 			Env:          make([]string, 0, len(mcpServer.Spec.Manifest.Env)),
 			URL:          mcpServer.Spec.Manifest.URL,
 			Headers:      make([]string, 0, len(mcpServer.Spec.Manifest.Headers)),
-			Scope:        projectThreadName,
+			Scope:        fmt.Sprintf("%s/%s", mcpServer.Namespace, projectThreadName),
 			AllowedTools: allowedTools,
 		},
 	}

--- a/pkg/system/tools.go
+++ b/pkg/system/tools.go
@@ -18,6 +18,7 @@ const (
 	ExistingCredTool        = "existing-credential"
 	KnowledgeCredID         = "knowledge"
 	TaskInvoke              = "task-invoke"
+	MCPJWTSigningCredID     = "mcp-jwt-signing"
 
 	DefaultNamespace = "default"
 


### PR DESCRIPTION
This change will give MCP servers access to the LLM proxy in Obot. Since MCP servers are scoped to the project, then so are their LLM requests. Meaning that, if the user has set a model at the thread level, LLM requests from MCP servers will not see this and will use the project-level configuration.