### PR TITLE
chore: make the scope slightly more narrowly scoped

### DIFF
--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -187,7 +187,7 @@ func (sm *SessionManager) Load(ctx context.Context, tool types.Tool) (result []t
 		annotations := map[string]string{
 			"mcp-server-tool-name":   tool.Name,
 			"mcp-server-config-name": key,
-			"mcp-server-project":     server.Scope,
+			"mcp-server-scope":       server.Scope,
 		}
 		id := sessionID(server)
 

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -29,7 +29,7 @@ func ToServerConfig(mcpServer v1.MCPServer, projectThreadName string, credEnv ma
 			Env:          make([]string, 0, len(mcpServer.Spec.Manifest.Env)),
 			URL:          mcpServer.Spec.Manifest.URL,
 			Headers:      make([]string, 0, len(mcpServer.Spec.Manifest.Headers)),
-			Scope:        projectThreadName,
+			Scope:        fmt.Sprintf("%s-%s", mcpServer.Name, projectThreadName),
 			AllowedTools: allowedTools,
 		},
 	}


### PR DESCRIPTION
It is possible to add the same MCP server configuration twice, but this won't create a new MCP server instance. This change will ensure that a separate server instance is created.

This does create a new problem: conflicting tool names. However, that is easier to fix on the fly because the tools are dynamically generated.