### PR TITLE
Expand MCP environment variables in args/commands/urls

### DIFF
--- a/ui/user/src/lib/components/mcp/McpCatalog.svelte
+++ b/ui/user/src/lib/components/mcp/McpCatalog.svelte
@@ -386,11 +386,9 @@
 	bind:this={configDialog}
 	bind:project
 	manifest={selectedMcpManifest}
-	manifestType={
-		!selectedMcpManifest?.command || selectedMcpManifest?.command === ''
-			? 'url'
-			: 'command'
-	}
+	manifestType={!selectedMcpManifest?.command || selectedMcpManifest?.command === ''
+		? 'url'
+		: 'command'}
 	{legacyBundleId}
 	onUpdate={(mcpServerInfo) => {
 		if (selectedMcp) {

--- a/ui/user/src/lib/components/mcp/McpCatalog.svelte
+++ b/ui/user/src/lib/components/mcp/McpCatalog.svelte
@@ -386,7 +386,11 @@
 	bind:this={configDialog}
 	bind:project
 	manifest={selectedMcpManifest}
-	manifestType={selectedMcpManifest?.command ? 'command' : 'url'}
+	manifestType={
+		!selectedMcpManifest?.command || selectedMcpManifest?.command === ''
+			? 'url'
+			: 'command'
+	}
 	{legacyBundleId}
 	onUpdate={(mcpServerInfo) => {
 		if (selectedMcp) {

--- a/ui/user/src/lib/components/mcp/ProjectMcpConfig.svelte
+++ b/ui/user/src/lib/components/mcp/ProjectMcpConfig.svelte
@@ -43,9 +43,7 @@
 			return false;
 		}
 		// If neither command nor URL is present, fall back to checking other properties
-		return (
-			(projectMcp.args?.length ?? 0) > 0
-		);
+		return (projectMcp.args?.length ?? 0) > 0;
 	}
 
 	const initConfig: MCPServerInfo = projectMcp

--- a/ui/user/src/lib/components/mcp/ProjectMcpConfig.svelte
+++ b/ui/user/src/lib/components/mcp/ProjectMcpConfig.svelte
@@ -34,10 +34,17 @@
 	let savedProjectMcp = $state<ProjectMCP>();
 
 	function isObotHosted(projectMcp: ProjectMCP) {
+		// Prioritize command presence for determining if it's Obot-hosted
+		// If there's no command but there's a URL, it should be treated as remote
+		if (projectMcp.command && projectMcp.command !== '') {
+			return true;
+		}
+		if (projectMcp.url && projectMcp.url !== '') {
+			return false;
+		}
+		// If neither command nor URL is present, fall back to checking other properties
 		return (
-			(projectMcp.env?.length ?? 0) > 0 ||
-			(projectMcp.args?.length ?? 0) > 0 ||
-			!!projectMcp.command
+			(projectMcp.args?.length ?? 0) > 0
 		);
 	}
 


### PR DESCRIPTION
This change expands environment variables (in the form `${ENV_VAR}`) present in the command, args, and/or URL of an MCP server's config to be expanded at MCP-server "start time".
