### PR TITLE
enhance: markdown support in description

### DIFF
--- a/ui/user/src/lib/components/mcp/McpInfoConfig.svelte
+++ b/ui/user/src/lib/components/mcp/McpInfoConfig.svelte
@@ -32,6 +32,7 @@
 	import CredentialAuth from '$lib/components/edit/CredentialAuth.svelte';
 	import RemoteMcpForm from './RemoteMcpForm.svelte';
 	import { DEFAULT_CUSTOM_SERVER_NAME } from '$lib/constants';
+	import { toHTMLFromMarkdown } from '$lib/markdown';
 
 	interface Props {
 		manifest?: MCPServer | ProjectMCP;
@@ -268,12 +269,32 @@
 					{/if}
 				</div>
 			</div>
-			<p class="text-sm font-light text-gray-500">
-				{manifest.description}
-			</p>
+			<div class="markdown-description-content message-content">
+				{@html toHTMLFromMarkdown(manifest.description)}
+			</div>
 			{#if children}
 				{@render children()}
 			{/if}
 		</div>
 	{/if}
 {/snippet}
+
+<style lang="postcss">
+	:global {
+		.markdown-description-content.message-content {
+			/** override some message-content styles that don't fit for description section */
+			& p {
+				color: var(--color-gray-500);
+				font-size: var(--text-sm);
+				font-weight: var(--font-weight-light);
+			}
+
+			& a {
+				color: var(--color-blue-600);
+				.dark & {
+					color: var(--color-blue-400);
+				}
+			}
+		}
+	}
+</style>


### PR DESCRIPTION
Addresses #3022 

<img width="525" alt="Screenshot 2025-05-20 at 3 34 26 PM" src="https://github.com/user-attachments/assets/d9d51f95-72a1-477f-a874-0c64b3c66206" />

Tested with changing `description` for Zapier entry to:
```
"Connect to Zapier MCP servers. Visit [Zapier's MCP Platform](https://mcp.zapier.com/) to generate your unique MCP server link and paste it below.\n\nWhen creating your MCP server, choose \"Other\" for MCP client and on the Connect page, select the \"Server URL\" option (OAuth is not yet supported)."
```