### PR TITLE
fix: 403 using share links

### DIFF
--- a/ui/user/src/routes/s/[id]/+page.ts
+++ b/ui/user/src/routes/s/[id]/+page.ts
@@ -17,20 +17,15 @@ export const load: PageLoad = async ({ params, fetch }) => {
 
 	try {
 		share = await ChatService.getProjectShareByPublicID(params.id, { fetch });
+		toolReferences = await ChatService.listAllTools({ fetch });
 
-		if (share?.projectID) {
+		if (share?.projectID && share.editor) {
 			// Get the project data
 			project = await ChatService.getProject(share.projectID, { fetch });
 
 			// Get tool references and MCPs in parallel
 			if (project && project.assistantID) {
-				const [toolRefsResponse, mcpsResponse] = await Promise.all([
-					ChatService.listAllTools({ fetch }),
-					ChatService.listProjectMCPs(project.assistantID, project.id, { fetch })
-				]);
-
-				toolReferences = toolRefsResponse;
-				mcps = mcpsResponse;
+				mcps = await ChatService.listProjectMCPs(project.assistantID, project.id, { fetch });
 			}
 		}
 	} catch (e) {


### PR DESCRIPTION
Update the `/s/` page route so it doesn't attempt to fetch the agent
project for a given share link on page load. This avoids a 403 the
prevents the page from loading when the user doesn't have direct access to the
agent.

Addresses https://github.com/obot-platform/obot/issues/3069
