### PR TITLE
chore: remove the initial delay for speedier startup

### DIFF
--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -288,7 +288,6 @@ func (sm *SessionManager) Load(ctx context.Context, tool types.Tool) (result []t
 										Port: intstr.FromInt32(8080),
 									},
 								},
-								InitialDelaySeconds: 3,
 							},
 							Args: args,
 							EnvFrom: []corev1.EnvFromSource{{


### PR DESCRIPTION
We are manually checking the healthz endpoint to ensure the pod is ready, so we don't need any delay here.