### PR TITLE
fix: gc template projects with missing source project

### DIFF
--- a/pkg/storage/apis/obot.obot.ai/v1/thread.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/thread.go
@@ -162,6 +162,14 @@ func (in *Thread) DeleteRefs() []Ref {
 		{ObjType: &OAuthAppLogin{}, Name: in.Spec.OAuthAppLoginName},
 		{ObjType: &Thread{}, Name: in.Spec.ParentThreadName},
 	}
+
+	if in.Spec.Template {
+		refs = append(refs, Ref{
+			ObjType: &Thread{},
+			Name:    in.Spec.SourceThreadName,
+		})
+	}
+
 	return refs
 }
 


### PR DESCRIPTION
Ensure template projects are deleted when the project they were copied from no longer exist.

Addresses https://github.com/obot-platform/obot/issues/2852

