### PR TITLE
fix: avoid error if user has already accepted agent invitation

### DIFF
--- a/ui/user/src/lib/services/chat/operations.ts
+++ b/ui/user/src/lib/services/chat/operations.ts
@@ -1240,7 +1240,11 @@ export async function getProjectInvitation(
 }
 
 export async function acceptProjectInvitation(code: string): Promise<ProjectInvitation> {
-	return (await doPost(`/projectinvitations/${code}`, {})) as ProjectInvitation;
+	return (await doPost(
+		`/projectinvitations/${code}`,
+		{},
+		{ dontLogErrors: true }
+	)) as ProjectInvitation;
 }
 
 export async function rejectProjectInvitation(code: string): Promise<void> {


### PR DESCRIPTION
Addresses #3007 

Related Loom: https://www.loom.com/share/2bb3043fedd642d5b71f2c9d45965ab7
* user gets a view of having already accepted the invitation instead of an error notification