### PR TITLE
fix: tools thread dialog configure option

### DIFF
--- a/ui/user/src/lib/components/ModelProviders.svelte
+++ b/ui/user/src/lib/components/ModelProviders.svelte
@@ -132,7 +132,7 @@
 	});
 </script>
 
-<div class="flex w-full flex-col pt-10 pb-10">
+<div class="flex w-full flex-col px-4 pt-10 pb-10 lg:px-32">
 	<div class="mb-4 flex items-center justify-between">
 		<div class="flex flex-col">
 			<h3 class="text-lg font-semibold">Model Providers</h3>

--- a/ui/user/src/lib/components/SidebarConfig.svelte
+++ b/ui/user/src/lib/components/SidebarConfig.svelte
@@ -39,10 +39,7 @@
 	});
 </script>
 
-<div
-	class="default-scrollbar-thin relative flex w-full justify-center overflow-y-auto px-4 lg:px-32"
-	in:fade
->
+<div class="default-scrollbar-thin relative flex w-full justify-center overflow-y-auto" in:fade>
 	{#if layout.sidebarConfig === 'slack'}
 		<Slack {project} />
 	{:else if layout.sidebarConfig === 'invitations'}

--- a/ui/user/src/lib/services/chat/operations.ts
+++ b/ui/user/src/lib/services/chat/operations.ts
@@ -1161,7 +1161,10 @@ export async function listProjectThreadMcpServerTools(
 	threadID: string
 ): Promise<MCPServerTool[]> {
 	const response = (await doGet(
-		`/assistants/${assistantID}/projects/${projectID}/mcpservers/${projectMcpServerId}/tools/${threadID}`
+		`/assistants/${assistantID}/projects/${projectID}/mcpservers/${projectMcpServerId}/tools/${threadID}`,
+		{
+			dontLogErrors: true
+		}
 	)) as { tools: MCPServerTool[] };
 	return response.tools;
 }


### PR DESCRIPTION
Addresses request in #3093 

* if tools call returns with 400, display option to go and configure the MCP server
* also fixes styling padding that is messing up other sidebar config views (md:px-4 lg:px-32 padding)

<img width="1038" alt="Screenshot 2025-05-22 at 2 58 13 PM" src="https://github.com/user-attachments/assets/7ed81a17-7c93-4a8b-a7d9-36dfde27b7df" />
