### PR TITLE
fix: allow authz when public share id not found

### DIFF
--- a/pkg/api/authz/threadshare.go
+++ b/pkg/api/authz/threadshare.go
@@ -26,6 +26,12 @@ func (a *Authorizer) checkThreadShare(req *http.Request, resources *Resources, u
 		return false, err
 	}
 
+	if len(threadShareList.Items) < 1 {
+		// The user is referencing a thread share that doesn't exist, allow access so the user gets a
+		// 404 instead of 403 "unauthorized".
+		return true, nil
+	}
+
 	validUserIDs := getValidUserIDs(user)
 	for _, threadShare := range threadShareList.Items {
 		if threadShare.Spec.UserID == user.GetUID() {

--- a/ui/user/src/lib/errors.ts
+++ b/ui/user/src/lib/errors.ts
@@ -18,6 +18,10 @@ export function handleRouteError(e: unknown, path: string, profile?: Profile) {
 	}
 
 	if (e.message?.includes('404') || e.message?.includes('not found')) {
+		if (path.includes('/s/')) {
+			throw error(404, `The chatbot at ${path} does not exist`);
+		}
+
 		throw error(404, e.message);
 	}
 


### PR DESCRIPTION
Allow authz to succeed when the `public_share_id` is not found. This
allows API requests to proceed and return a 404 when users are trying to
access a chatbot from an inactive share link (e.g. the chatbot was
disabled) and causes the UI to load the generic "page not found" page
instead of the "403" page. This change also adds details to the "page
not found" page explaining that the chatbot at the given path does not
exist.

<img width="829" alt="Screenshot 2025-05-27 at 1 25 41 PM" src="https://github.com/user-attachments/assets/6f499752-ee0e-408d-8183-90643138c351" />

Note: The two routes affected by this change are `GET` and `POST` on `/api/shares/{public_share_id}`
which both respond with a 404 when no share exists with the given `public_share_id`.

Addresses: https://github.com/obot-platform/obot/issues/2792

