### PR TITLE
enhance: give guided mcp configuration experience for chatbot/agent

### DIFF
--- a/ui/user/src/lib/components/Obot.svelte
+++ b/ui/user/src/lib/components/Obot.svelte
@@ -8,7 +8,7 @@
 	import type { EditorItem } from '$lib/services/editor/index.svelte';
 	import { errors, responsive } from '$lib/stores';
 	import { closeAll, getLayout } from '$lib/context/layout.svelte';
-	import { GripVertical, MessageCirclePlus, Plus, SidebarOpen } from 'lucide-svelte';
+	import { GripVertical, MessageCirclePlus, Plus, Server, SidebarOpen } from 'lucide-svelte';
 	import { fade, slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 	import Logo from './navbar/Logo.svelte';
@@ -24,6 +24,8 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { browser } from '$app/environment';
 	import Banner from './Banner.svelte';
+	import { getProjectMCPs } from '$lib/context/projectMcps.svelte';
+	import McpConfigMultiple from './mcp/McpConfigMultiple.svelte';
 
 	interface Props {
 		assistant?: Assistant;
@@ -40,7 +42,7 @@
 	let credentials = $state<ProjectCredential[]>([]);
 	let authDialog: ReturnType<typeof CredentialAuth> | undefined = $state();
 	let credToAuth = $state<ProjectCredential | undefined>();
-	let configDialog: HTMLDialogElement;
+	let slackConfigDialog: HTMLDialogElement;
 	let shortcutsDialog: HTMLDialogElement;
 	let nav = $state<HTMLDivElement>();
 	let bannerRef = $state<ReturnType<typeof Banner>>();
@@ -73,7 +75,7 @@
 				project.capabilities?.onSlackMessage &&
 				!credentials.find((c) => c.toolID === 'slack-bot-bundle')?.exists
 			) {
-				configDialog?.showModal();
+				slackConfigDialog?.showModal();
 				return;
 			}
 		});
@@ -270,12 +272,12 @@
 			</div>
 
 			<dialog
-				bind:this={configDialog}
+				bind:this={slackConfigDialog}
 				class="default-dialog"
-				use:clickOutside={() => configDialog?.close()}
+				use:clickOutside={() => slackConfigDialog?.close()}
 			>
 				<div class="p-6">
-					<button class="absolute top-0 right-0 p-3" onclick={() => configDialog?.close()}>
+					<button class="absolute top-0 right-0 p-3" onclick={() => slackConfigDialog?.close()}>
 						<X class="icon-default" />
 					</button>
 					<h3 class="mb-4 text-lg font-semibold">Configure Slack</h3>
@@ -286,7 +288,7 @@
 						<button
 							class="button"
 							onclick={() => {
-								configDialog?.close();
+								slackConfigDialog?.close();
 								authDialog?.show();
 							}}
 						>
@@ -295,6 +297,8 @@
 					</div>
 				</div>
 			</dialog>
+
+			<McpConfigMultiple {project} chatbot={shared} />
 
 			<CredentialAuth
 				bind:this={authDialog}

--- a/ui/user/src/lib/components/Obot.svelte
+++ b/ui/user/src/lib/components/Obot.svelte
@@ -8,7 +8,7 @@
 	import type { EditorItem } from '$lib/services/editor/index.svelte';
 	import { errors, responsive } from '$lib/stores';
 	import { closeAll, getLayout } from '$lib/context/layout.svelte';
-	import { GripVertical, MessageCirclePlus, Plus, Server, SidebarOpen } from 'lucide-svelte';
+	import { GripVertical, MessageCirclePlus, Plus, SidebarOpen } from 'lucide-svelte';
 	import { fade, slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 	import Logo from './navbar/Logo.svelte';
@@ -24,7 +24,6 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { browser } from '$app/environment';
 	import Banner from './Banner.svelte';
-	import { getProjectMCPs } from '$lib/context/projectMcps.svelte';
 	import McpConfigMultiple from './mcp/McpConfigMultiple.svelte';
 
 	interface Props {

--- a/ui/user/src/lib/components/edit/McpServers.svelte
+++ b/ui/user/src/lib/components/edit/McpServers.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
 	import { getProjectMCPs } from '$lib/context/projectMcps.svelte';
-	import {
-		ChatService,
-		type Project,
-		type ProjectMCP,
-		type ProjectCredential
-	} from '$lib/services';
+	import { ChatService, type Project, type ProjectMCP } from '$lib/services';
 	import { fetchConfigurationStatuses, type MCPServerInfo } from '$lib/services/chat/mcp';
 	import { PencilLine, Plus, Server, Trash2, Wrench, TriangleAlert } from 'lucide-svelte/icons';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import McpInfoConfig from '$lib/components/mcp/McpInfoConfig.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
-	import { onMount } from 'svelte';
 	import CollapsePane from '$lib/components/edit/CollapsePane.svelte';
 	import { HELPER_TEXTS } from '$lib/context/helperMode.svelte';
 	import DotDotDot from '$lib/components/DotDotDot.svelte';

--- a/ui/user/src/lib/components/mcp/McpConfigMultiple.svelte
+++ b/ui/user/src/lib/components/mcp/McpConfigMultiple.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import { clickOutside } from '$lib/actions/clickoutside';
+	import { type ProjectMCP, type Project, ChatService } from '$lib/services';
+	import { fetchConfigurationStatuses, getKeyValuePairs } from '$lib/services/chat/mcp';
+	import { Server, X } from 'lucide-svelte';
+	import McpInfoConfig from './McpInfoConfig.svelte';
+	import { dialogAnimation } from '$lib/actions/dialogAnimation';
+	import { getProjectMCPs } from '$lib/context/projectMcps.svelte';
+	import { getToolBundleMap } from '$lib/context/toolReferences.svelte';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		project: Project;
+		chatbot?: boolean;
+	}
+
+	let { project, chatbot }: Props = $props();
+	let currentIndex = $state(0);
+	let view = $state<'start' | 'finish' | 'error' | undefined>();
+	let infoDialog = $state<HTMLDialogElement>();
+
+	const projectMcps = getProjectMCPs();
+	const toolBundleMap = getToolBundleMap();
+
+	let dialogs = $state<ReturnType<typeof McpInfoConfig>[]>();
+
+	async function initRequiresConfiguration(mcps: ProjectMCP[]) {
+		const response = await fetchConfigurationStatuses(
+			project,
+			projectMcps.items,
+			toolBundleMap,
+			chatbot ?? false
+		);
+		projectMcps.configured = response?.configured || {};
+		projectMcps.requiresConfiguration = response?.requiresConfiguration || {};
+
+		// if requires configuration
+		const numRequiresConfiguration = Object.keys(projectMcps.requiresConfiguration).length;
+		if (numRequiresConfiguration > 0) {
+			dialogs = Array(numRequiresConfiguration).fill(undefined); // mcps to how many require configuration
+			currentIndex = 0;
+			view = 'start';
+			infoDialog?.showModal();
+		}
+	}
+
+	onMount(() => {
+		initRequiresConfiguration(projectMcps.items);
+	});
+</script>
+
+<dialog
+	bind:this={infoDialog}
+	class="default-dialog p-6"
+	use:clickOutside={() => infoDialog?.close()}
+	use:dialogAnimation={{ type: 'fade' }}
+>
+	<button class="absolute top-0 right-0 p-3" onclick={() => infoDialog?.close()}>
+		<X class="icon-default" />
+	</button>
+	<h3 class="mb-4 text-lg font-semibold">Configure MCP Servers</h3>
+
+	{#if view === 'start'}
+		<p class="text-sm text-gray-600">
+			To use this agent, you'll need to configure the following MCP servers:
+		</p>
+		<ul class="mt-2 flex flex-col gap-2">
+			{#each Object.values(projectMcps.requiresConfiguration) as mcp}
+				<li class="text-md flex items-center gap-2">
+					{#if mcp.icon}
+						<img src={mcp.icon} alt={mcp.name} class="size-6" />
+					{:else}
+						<Server class="size-6" />
+					{/if}
+					{mcp.name}
+				</li>
+			{/each}
+		</ul>
+		<button
+			class="button-primary mt-6 w-full"
+			onclick={() => {
+				infoDialog?.close();
+				dialogs?.[currentIndex]?.open();
+			}}
+		>
+			Configure Now
+		</button>
+	{:else if view === 'finish' || view === 'error'}
+		<p class="max-w-md text-sm text-gray-600">
+			{#if view === 'finish'}
+				You're all set! You can now use this agent.
+			{:else}
+				Looks like there was an issue during configuration. Verify the MCP server configurations
+				under MCP Servers.
+			{/if}
+		</p>
+		<button
+			class="button-primary mt-6 w-full"
+			onclick={() => {
+				infoDialog?.close();
+			}}
+		>
+			{view === 'finish' ? "Let's Go!" : 'Continue'}
+		</button>
+	{/if}
+</dialog>
+
+{#if dialogs}
+	{@const numToConfigure = Object.keys(projectMcps.requiresConfiguration).length}
+	{#each Object.values(projectMcps.requiresConfiguration) as mcp, index (mcp.id)}
+		<McpInfoConfig
+			bind:this={dialogs[index]}
+			animation="slide"
+			manifest={mcp}
+			{project}
+			submitText={index === numToConfigure - 1 ? 'Configure & Finish' : 'Configure & Next'}
+			legacyBundleId={mcp.catalogID && toolBundleMap.get(mcp.catalogID) ? mcp.catalogID : undefined}
+			onUpdate={async (manifest) => {
+				if (!project?.assistantID || !project.id || !mcp) return;
+
+				const keyValuePairs = getKeyValuePairs(manifest);
+				await ChatService.configureProjectMCPEnvHeaders(
+					project.assistantID,
+					project.id,
+					mcp.id,
+					keyValuePairs
+				);
+
+				dialogs?.[currentIndex]?.close();
+				currentIndex = currentIndex + 1;
+
+				if (currentIndex < numToConfigure) {
+					dialogs?.[currentIndex]?.open();
+				} else {
+					const response = await fetchConfigurationStatuses(
+						project,
+						projectMcps.items,
+						toolBundleMap,
+						chatbot ?? false
+					);
+					projectMcps.configured = response?.configured || {};
+					projectMcps.requiresConfiguration = response?.requiresConfiguration || {};
+					if (Object.keys(projectMcps.requiresConfiguration).length > 0) {
+						view = 'error';
+						setTimeout(() => {
+							infoDialog?.showModal();
+						}, 200);
+					} else {
+						view = 'finish';
+						setTimeout(() => {
+							infoDialog?.showModal();
+						}, 200); // waiting for slideout animation to complete from last config dialog
+					}
+				}
+			}}
+		/>
+	{/each}
+{/if}

--- a/ui/user/src/lib/components/mcp/McpConfigMultiple.svelte
+++ b/ui/user/src/lib/components/mcp/McpConfigMultiple.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { clickOutside } from '$lib/actions/clickoutside';
-	import { type ProjectMCP, type Project, ChatService } from '$lib/services';
+	import { type Project, ChatService } from '$lib/services';
 	import { fetchConfigurationStatuses, getKeyValuePairs } from '$lib/services/chat/mcp';
 	import { Server, X } from 'lucide-svelte';
 	import McpInfoConfig from './McpInfoConfig.svelte';
@@ -24,7 +24,7 @@
 
 	let dialogs = $state<ReturnType<typeof McpInfoConfig>[]>();
 
-	async function initRequiresConfiguration(mcps: ProjectMCP[]) {
+	async function initRequiresConfiguration() {
 		const response = await fetchConfigurationStatuses(
 			project,
 			projectMcps.items,
@@ -45,7 +45,7 @@
 	}
 
 	onMount(() => {
-		initRequiresConfiguration(projectMcps.items);
+		initRequiresConfiguration();
 	});
 </script>
 

--- a/ui/user/src/lib/components/mcp/McpInfoConfig.svelte
+++ b/ui/user/src/lib/components/mcp/McpInfoConfig.svelte
@@ -52,6 +52,7 @@
 			githubStars?: number;
 			githubUrl?: string;
 		};
+		animation?: 'slide' | 'fade';
 	}
 	let {
 		manifest,
@@ -67,7 +68,8 @@
 		legacyAuthText,
 		project = $bindable(),
 		manifestType,
-		info
+		info,
+		animation
 	}: Props = $props();
 	let configDialog = $state<HTMLDialogElement>();
 	let authDialog = $state<HTMLDialogElement>();
@@ -146,7 +148,7 @@
 		if (disableOutsideClick) return;
 		close();
 	}}
-	use:dialogAnimation={{ type: 'fade' }}
+	use:dialogAnimation={{ type: animation || 'slide' }}
 >
 	<div class="grid h-fit max-h-[calc(100vh-4rem)] grid-rows-[auto_1fr_auto]">
 		{@render basicInfo()}

--- a/ui/user/src/lib/context/projectMcps.svelte.ts
+++ b/ui/user/src/lib/context/projectMcps.svelte.ts
@@ -5,6 +5,8 @@ const Key = Symbol('mcps');
 
 export interface ProjectMCPContext {
 	items: ProjectMCP[];
+	configured: Record<string, boolean>;
+	requiresConfiguration: Record<string, ProjectMCP>;
 }
 
 export function getProjectMCPs() {
@@ -15,6 +17,10 @@ export function getProjectMCPs() {
 }
 
 export function initProjectMCPs(mcps: ProjectMCP[]) {
-	const data = $state<ProjectMCPContext>({ items: mcps });
+	const data = $state<ProjectMCPContext>({
+		items: mcps,
+		configured: {},
+		requiresConfiguration: {}
+	});
 	setContext(Key, data);
 }

--- a/ui/user/src/lib/context/toolReferences.svelte.ts
+++ b/ui/user/src/lib/context/toolReferences.svelte.ts
@@ -24,7 +24,7 @@ export function getToolReferenceMap() {
 	return new Map(toolReferences.map((x) => [x.id, x]));
 }
 
-type ToolBundleItem = {
+export type ToolBundleItem = {
 	tool: ToolReference;
 	bundleTools: ToolReference[];
 };


### PR DESCRIPTION
* when opening chatbot or creating agent from template, if mcp servers are required to be configured, start a guided experience on opening the agent

* moved the fetching of configured / required configuration to higher level & context so it's shared by the modal and sidebar