### PR TITLE
fix: prevent tasks from jittering

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -532,7 +532,7 @@ func (e *Emitter) getNextWorkflowRun(ctx context.Context, run v1.Run) (*v1.Run, 
 			runName = thread.Status.CurrentRunName
 			return true, nil
 		}
-		if thread.Status.LastRunName != "" && thread.Status.LastRunName != run.Name {
+		if thread.Status.LastRunName != "" && thread.Status.LastRunName != run.Name && thread.Status.LastRunName != run.Spec.PreviousRunName {
 			runName = thread.Status.LastRunName
 			return true, nil
 		}


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/2975

Without this part of the condition, this `wait.For` might end up selecting the previous (second-to-last) run in the workflow, which would then cause it to select the last one again, and get into a loop for a little while, causing some jitter to happen in the frontend. The next workflow run obviously cannot be the same one as the current run's `PreviousRunName`, so we make sure it isn't.