### PR TITLE
fix: allow MCP servers with no tools allowed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/gptscript-ai/cmd v0.0.0-20250324222528-f16f18548238
 	github.com/gptscript-ai/datasets v0.0.0-20241125193827-31ce6c3c682b
 	github.com/gptscript-ai/go-gptscript v0.9.6-0.20250520154649-f1616a06f1b0
-	github.com/gptscript-ai/gptscript v0.9.6-0.20250528125227-ce6afe2a2323
+	github.com/gptscript-ai/gptscript v0.9.6-0.20250530145244-c810be4bf185
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/mark3labs/mcp-go v0.30.0
 	github.com/mhale/smtpd v0.8.3

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/gptscript-ai/datasets v0.0.0-20241125193827-31ce6c3c682b h1:IXgx6Y+g0
 github.com/gptscript-ai/datasets v0.0.0-20241125193827-31ce6c3c682b/go.mod h1:gMAaxAbeIvHtQoj/SKuqvoSGeywqc61/Yw9pusrT/R4=
 github.com/gptscript-ai/go-gptscript v0.9.6-0.20250520154649-f1616a06f1b0 h1:UXZRFAUPDWOgeTyjZd4M8YrEEgPc7XOfjgbm81w7x0w=
 github.com/gptscript-ai/go-gptscript v0.9.6-0.20250520154649-f1616a06f1b0/go.mod h1:t2TyiEa6rhd4reOcorAMUmd5MledmZuTmYrO7rV3Iy8=
-github.com/gptscript-ai/gptscript v0.9.6-0.20250528125227-ce6afe2a2323 h1:wylEg8wt0CHiRPgzjTSe8GgTHvfGrKfgHB+b2Lw2ZBY=
-github.com/gptscript-ai/gptscript v0.9.6-0.20250528125227-ce6afe2a2323/go.mod h1:fC34Lj8t/MJX7Yw+9PF7kSlqBK/yaY9T5OW4l5TzGFk=
+github.com/gptscript-ai/gptscript v0.9.6-0.20250530145244-c810be4bf185 h1:miNdaDyosDo9+dVgmJoKpLHFRirJZBGIYdNmycSZ6l8=
+github.com/gptscript-ai/gptscript v0.9.6-0.20250530145244-c810be4bf185/go.mod h1:fC34Lj8t/MJX7Yw+9PF7kSlqBK/yaY9T5OW4l5TzGFk=
 github.com/gptscript-ai/tui v0.0.0-20250419050840-5e79e16786c9 h1:wQC8sKyeGA50WnCEG+Jo5FNRIkuX3HX8d3ubyWCCoI8=
 github.com/gptscript-ai/tui v0.0.0-20250419050840-5e79e16786c9/go.mod h1:iwHxuueg2paOak7zIg0ESBWx7A0wIHGopAratbgaPNY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -142,7 +142,7 @@ func Agent(ctx context.Context, db kclient.Client, gptClient *gptscript.GPTScrip
 			allowedTools = allowedToolsPerMCP[mcpServer.Name]
 			if mcpServer.Spec.ToolReferenceName != "" {
 				// This is a "fake" MCP server really referencing our tools.
-				if len(allowedTools) == 0 || slices.Contains(allowedTools, "*") {
+				if allowedTools == nil || slices.Contains(allowedTools, "*") {
 					allowedTools = []string{mcpServer.Spec.ToolReferenceName}
 				}
 


### PR DESCRIPTION
Previously, this change would not distinguish between allowedTools being nil and having length zero, interpretting both to mean that all tools for the MCP server to be allowed.

Now, if the allowedTools is non-nil and length zero, then this will be treated as not allowing any tools from the MCP server.