### PR TITLE
fix: load agent templates in catalog component

### DIFF
--- a/ui/user/src/routes/agents/+page.svelte
+++ b/ui/user/src/routes/agents/+page.svelte
@@ -276,7 +276,7 @@
 	oncancel={() => (toDelete = undefined)}
 />
 
-<AgentCatalog bind:this={agentCatalog} templates={data.templates} />
+<AgentCatalog bind:this={agentCatalog} />
 
 <McpSetupWizard
 	bind:this={mcpSetupWizard}

--- a/ui/user/src/routes/agents/+page.ts
+++ b/ui/user/src/routes/agents/+page.ts
@@ -4,20 +4,17 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ fetch }) => {
 	try {
 		const projects = (await ChatService.listProjects({ fetch })).items;
-		const templates = (await ChatService.listTemplates({ fetch })).items;
 		const shares = (await ChatService.listProjectShares({ fetch })).items;
 		const tools = (await ChatService.listAllTools({ fetch })).items;
 
 		return {
 			projects,
-			templates,
 			shares,
 			tools
 		};
 	} catch {
 		return {
 			projects: [],
-			templates: [],
 			shares: [],
 			tools: []
 		};

--- a/ui/user/src/routes/catalog/+page.svelte
+++ b/ui/user/src/routes/catalog/+page.svelte
@@ -3,7 +3,6 @@
 	import type { PageProps } from './$types';
 	import { q, qIsSet } from '$lib/url';
 	import { ChevronLeft } from 'lucide-svelte';
-	import { sortByCreatedDate, sortTemplatesByFeaturedNameOrder } from '$lib/sort';
 	import Navbar from '$lib/components/Navbar.svelte';
 	import AgentCatalog from '$lib/components/agents/AgentCatalog.svelte';
 	import McpSetupWizard from '$lib/components/mcp/McpSetupWizard.svelte';
@@ -12,9 +11,6 @@
 	let { data }: PageProps = $props();
 
 	initToolReferences(data.tools);
-	const templates = $derived(
-		data.templates?.sort(sortByCreatedDate).sort(sortTemplatesByFeaturedNameOrder)
-	);
 
 	const type = q('type');
 	const preselected = q('id');
@@ -25,7 +21,7 @@
 	{#if type === 'agents'}
 		<main class="colors-background relative flex w-full flex-col items-center justify-center py-12">
 			<div class="flex w-full max-w-(--breakpoint-2xl) flex-col items-center justify-center">
-				<AgentCatalog inline {templates} {preselected} />
+				<AgentCatalog inline {preselected} />
 			</div>
 		</main>
 	{:else}

--- a/ui/user/src/routes/catalog/+page.ts
+++ b/ui/user/src/routes/catalog/+page.ts
@@ -3,18 +3,15 @@ import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch }) => {
 	try {
-		const templates = (await ChatService.listTemplates({ fetch })).items;
 		const mcps = await ChatService.listMCPs({ fetch });
 		const tools = (await ChatService.listAllTools({ fetch })).items;
 
 		return {
-			templates,
 			mcps,
 			tools
 		};
 	} catch {
 		return {
-			templates: [],
 			mcps: [],
 			tools: []
 		};


### PR DESCRIPTION
Fetch agent templates in the `AgentCatalog` component instead of on page
load so that closing and reopening the dialog triggers the set of
templates to refresh (instead of requiring a hard page refresh).

Follow up to complete https://github.com/obot-platform/obot/issues/2852

