### PR TITLE
Enhance: Add integratin test and framework

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,45 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24"
+
+      - name: Wait for PostgreSQL
+        run: sleep 5
+
+      - name: Build obot
+        run: |
+          make build
+
+      - name: Run integration setup
+        run: |
+          OBOT_SERVER_DSN=postgres://testuser:testpass@localhost:5432/testdb?sslmode=disable make test-integration

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,10 @@ generate:
 	go generate
 
 test:
-	go test -v -cover ./...
+	go test -v -cover $$(go list ./... | grep -v github.com/obot-platform/obot/tests/integration)
+
+test-integration:
+	./tests/integration/setup.sh
 
 # Runs Go linters and validates that all generated code is committed.
 validate-go-code: tidy generate lint-go no-changes

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/obot-platform/namegenerator v0.0.0-20241217121223-fc58bdb7dca2
 	github.com/obot-platform/obot/apiclient v0.0.0-00010101000000-000000000000
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32
+	github.com/onsi/gomega v1.34.2
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/prometheus/client_golang v1.20.5
 	github.com/pterm/pterm v0.12.80
@@ -68,6 +69,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/yaml v1.4.0
 )
+
+require github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 
 require (
 	atomicgo.dev/cursor v0.2.0 // indirect
@@ -225,7 +228,7 @@ require (
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77 // indirect
-	github.com/onsi/ginkgo/v2 v2.20.2 // indirect
+	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -268,7 +268,6 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
-github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=

--- a/tests/integration/client.go
+++ b/tests/integration/client.go
@@ -1,11 +1,13 @@
 package integration
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	apiclient "github.com/obot-platform/obot/apiclient/types"
 )
@@ -76,6 +78,158 @@ func (c *Client) GetProject(id string) (*apiclient.Project, error) {
 	return &project, nil
 }
 
+func (c *Client) CreateThread(projectID string) (*apiclient.Thread, error) {
+	resp, err := c.HTTPClient.Post(c.ServerURL+"/api/assistants/a1-obot/projects/"+projectID+"/threads", "application/json", bytes.NewBuffer([]byte{}))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create thread: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var thread apiclient.Thread
+	err = json.Unmarshal(body, &thread)
+	if err != nil {
+		return nil, err
+	}
+
+	return &thread, nil
+}
+
+func (c *Client) GetProjectThread(projectID, threadID string) (*apiclient.Thread, error) {
+	resp, err := c.HTTPClient.Get(c.ServerURL + "/api/assistants/a1-obot/projects/" + projectID + "/threads/" + threadID)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get project thread: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var thread apiclient.Thread
+	err = json.Unmarshal(body, &thread)
+	if err != nil {
+		return nil, err
+	}
+
+	return &thread, nil
+}
+
+func (c *Client) InvokeProjectThread(projectID, threadID, message string) error {
+	resp, err := c.HTTPClient.Post(c.ServerURL+"/api/assistants/a1-obot/projects/"+projectID+"/threads/"+threadID+"/invoke", "application/json", bytes.NewBuffer([]byte(message)))
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	result, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("failed to invoke project thread: %s, %s", resp.Status, string(result))
+	}
+
+	return nil
+}
+
+type Event struct {
+	ID   string
+	Data apiclient.Progress
+}
+
+func (c *Client) GetProjectThreadEventsStream(projectID, threadID string) (<-chan Event, <-chan error) {
+	eventCh := make(chan Event)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(eventCh)
+		defer close(errCh)
+
+		url := fmt.Sprintf("%s/api/assistants/a1-obot/projects/%s/threads/%s/events?follow=true&history=true",
+			c.ServerURL, projectID, threadID)
+
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		req.Header.Set("Accept", "text/event-stream")
+
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			errCh <- fmt.Errorf("failed to get project thread events: %s", resp.Status)
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		var currentEvent, currentID, currentData strings.Builder
+
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			if line == "" {
+				if currentEvent.Len() > 0 || currentID.Len() > 0 || currentData.Len() > 0 {
+					var data apiclient.Progress
+					err := json.Unmarshal([]byte(currentData.String()), &data)
+					if err != nil {
+						errCh <- fmt.Errorf("failed to unmarshal event data: %v", err)
+						return
+					}
+
+					eventCh <- Event{
+						ID:   currentID.String(),
+						Data: data,
+					}
+				}
+				currentEvent.Reset()
+				currentID.Reset()
+				currentData.Reset()
+				continue
+			}
+
+			switch {
+			case strings.HasPrefix(line, "id:"):
+				currentID.WriteString(strings.TrimSpace(line[len("id:"):]))
+			case strings.HasPrefix(line, "data:"):
+				if currentData.Len() > 0 {
+					currentData.WriteString("\n")
+				}
+				currentData.WriteString(strings.TrimSpace(line[len("data:"):]))
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			errCh <- fmt.Errorf("error reading SSE: %v", err)
+		}
+	}()
+
+	return eventCh, errCh
+}
+
 func (c *Client) GetProjectTask(projectID, taskID string) (*apiclient.Task, error) {
 	resp, err := c.HTTPClient.Get(c.ServerURL + "/api/assistants/a1-obot/projects/" + projectID + "/tasks/" + taskID)
 	if err != nil {
@@ -131,4 +285,117 @@ func (c *Client) ConfigureProjectSlack(projectID string, payload map[string]inte
 	}
 
 	return &slackReceiver, nil
+}
+
+func (c *Client) GetModels() ([]apiclient.Model, error) {
+	resp, err := c.HTTPClient.Get(c.ServerURL + "/api/models")
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get models: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var modelList apiclient.ModelList
+	err = json.Unmarshal(body, &modelList)
+	if err != nil {
+		return nil, err
+	}
+
+	return modelList.Items, nil
+}
+
+func (c *Client) SetUpDefaultModelAlias(modelID, usage string) error {
+	payload := map[string]interface{}{
+		"model_id": modelID,
+		"usage":    usage,
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.HTTPClient.Post(c.ServerURL+"/api/default-model-aliases", "application/json", bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("failed to set up default model alias: %s", resp.Status)
+	}
+
+	return nil
+}
+
+func (c *Client) GetAgent(id string) (*apiclient.Agent, error) {
+	resp, err := c.HTTPClient.Get(c.ServerURL + "/api/agents/" + id)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get assistant: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var agent apiclient.Agent
+	err = json.Unmarshal(body, &agent)
+	if err != nil {
+		return nil, err
+	}
+
+	return &agent, nil
+}
+
+func (c *Client) UpdateAgent(id string, agent apiclient.Agent) (*apiclient.Agent, error) {
+	payloadBytes, err := json.Marshal(agent)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", c.ServerURL+"/api/agents/"+id, bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to update assistant: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	var updatedAgent apiclient.Agent
+	err = json.Unmarshal(body, &updatedAgent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %v", err)
+	}
+
+	return &updatedAgent, nil
 }

--- a/tests/integration/client.go
+++ b/tests/integration/client.go
@@ -1,0 +1,134 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	apiclient "github.com/obot-platform/obot/apiclient/types"
+)
+
+type Client struct {
+	ServerURL  string
+	HTTPClient *http.Client
+}
+
+func NewClient(serverURL string) *Client {
+	return &Client{
+		ServerURL:  serverURL,
+		HTTPClient: &http.Client{},
+	}
+}
+
+func (c *Client) CreateProject() (*apiclient.Project, error) {
+	payload := []byte(`{}`)
+
+	resp, err := c.HTTPClient.Post(c.ServerURL+"/api/assistants/a1-obot/projects", "application/json", bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create project: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var project apiclient.Project
+	err = json.Unmarshal(body, &project)
+	if err != nil {
+		return nil, err
+	}
+
+	return &project, nil
+}
+
+func (c *Client) GetProject(id string) (*apiclient.Project, error) {
+	resp, err := c.HTTPClient.Get(c.ServerURL + "/api/assistants/a1-obot/projects/" + id)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get project: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var project apiclient.Project
+	err = json.Unmarshal(body, &project)
+	if err != nil {
+		return nil, err
+	}
+
+	return &project, nil
+}
+
+func (c *Client) GetProjectTask(projectID, taskID string) (*apiclient.Task, error) {
+	resp, err := c.HTTPClient.Get(c.ServerURL + "/api/assistants/a1-obot/projects/" + projectID + "/tasks/" + taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get project task: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var task apiclient.Task
+	err = json.Unmarshal(body, &task)
+	if err != nil {
+		return nil, err
+	}
+
+	return &task, nil
+}
+
+func (c *Client) ConfigureProjectSlack(projectID string, payload map[string]interface{}) (*apiclient.SlackReceiver, error) {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.HTTPClient.Post(c.ServerURL+"/api/assistants/a1-obot/projects/"+projectID+"/slack", "application/json", bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to configure project slack: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	slackReceiver := apiclient.SlackReceiver{}
+	err = json.Unmarshal(body, &slackReceiver)
+	if err != nil {
+		return nil, err
+	}
+
+	return &slackReceiver, nil
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,11 +1,11 @@
+// revive:disable:dot-imports
+
 package integration_test
 
 import (
 	"testing"
 
-	//revive:disable
 	. "github.com/onsi/ginkgo/v2"
-	//revive:disable
 	. "github.com/onsi/gomega"
 )
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,0 +1,15 @@
+package integration_test
+
+import (
+	"testing"
+
+	//revive:disable
+	. "github.com/onsi/ginkgo/v2"
+	//revive:disable
+	. "github.com/onsi/gomega"
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Integration Suite")
+}

--- a/tests/integration/project_api_test.go
+++ b/tests/integration/project_api_test.go
@@ -1,0 +1,75 @@
+package integration
+
+import (
+	"time"
+
+	//revive:disable
+	. "github.com/onsi/ginkgo/v2"
+	//revive:disable
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Project API", func() {
+	var client *Client
+	var createdID string
+
+	BeforeEach(func() {
+		client = NewClient("http://localhost:8080")
+	})
+
+	Context("When creating a new project", func() {
+		It("should return 201 Created with a valid ID", func() {
+			project, err := client.CreateProject()
+			Expect(err).To(BeNil())
+
+			Expect(project.ID).NotTo(BeEmpty())
+			createdID = project.ID
+		})
+
+		It("should return 200 OK with correct project data", func() {
+			// Ensure that a project was created
+			Expect(createdID).NotTo(BeEmpty())
+
+			project, err := client.GetProject(createdID)
+			Expect(err).To(BeNil())
+
+			Expect(project.ID).To(Equal(createdID))
+		})
+	})
+
+	Context("When configuring Slack Integration	for the created project", func() {
+		It("should return 200 OK when Slack config is valid", func() {
+			Expect(createdID).NotTo(BeEmpty())
+
+			slackReceiver, err := client.ConfigureProjectSlack(createdID, map[string]interface{}{
+				"appId":         "foo",
+				"clientId":      "foo",
+				"clientSecret":  "foo",
+				"signingSecret": "foo",
+			})
+			Expect(err).To(BeNil())
+
+			Expect(slackReceiver.AppID).To(Equal("foo"))
+			Expect(slackReceiver.ClientID).To(Equal("foo"))
+		})
+
+		It("should eventually set task name into project", func() {
+			Expect(createdID).NotTo(BeEmpty())
+
+			Eventually(func(g Gomega) {
+				project, err := client.GetProject(createdID)
+				g.Expect(err).To(BeNil())
+
+				g.Expect(project.Capabilities.OnSlackMessage).To(BeTrue())
+				g.Expect(project.WorkflowNamesFromIntegration.SlackWorkflowName).NotTo(BeEmpty())
+
+				slackWorkflowName := project.WorkflowNamesFromIntegration.SlackWorkflowName
+				task, err := client.GetProjectTask(createdID, slackWorkflowName)
+				Expect(err).To(BeNil())
+
+				Expect(task.ID).To(Equal(slackWorkflowName))
+				Expect(task.ProjectID).To(Equal(createdID))
+			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond)
+		})
+	})
+})

--- a/tests/integration/project_api_test.go
+++ b/tests/integration/project_api_test.go
@@ -1,22 +1,41 @@
+// revive:disable:dot-imports
+
 package integration
 
 import (
 	"time"
 
-	//revive:disable
 	. "github.com/onsi/ginkgo/v2"
-	//revive:disable
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Project API", func() {
-	var client *Client
-	var createdID string
+var (
+	client    *Client
+	createdID string
+)
 
-	BeforeEach(func() {
-		client = NewClient("http://localhost:8080")
-	})
+var _ = BeforeSuite(func() {
+	client = NewClient("http://localhost:8080")
 
+	agent, err := client.GetAgent("a1-obot")
+	Expect(err).To(BeNil())
+
+	models, err := client.GetModels()
+	Expect(err).To(BeNil())
+
+	for _, model := range models {
+		if model.ModelProvider == "mock-model-provider" {
+			err = client.SetUpDefaultModelAlias(model.ID, "llm")
+			Expect(err).To(BeNil())
+
+			agent.Model = model.ID
+			agent, err = client.UpdateAgent(agent.ID, *agent)
+			Expect(err).To(BeNil())
+		}
+	}
+})
+
+var _ = Describe("Project API", Ordered, func() {
 	Context("When creating a new project", func() {
 		It("should return 201 Created with a valid ID", func() {
 			project, err := client.CreateProject()
@@ -27,7 +46,6 @@ var _ = Describe("Project API", func() {
 		})
 
 		It("should return 200 OK with correct project data", func() {
-			// Ensure that a project was created
 			Expect(createdID).NotTo(BeEmpty())
 
 			project, err := client.GetProject(createdID)
@@ -71,5 +89,44 @@ var _ = Describe("Project API", func() {
 				Expect(task.ProjectID).To(Equal(createdID))
 			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond)
 		})
+	})
+
+	Context("When creating a new thread", func() {
+		var threadID string
+		It("should return 201 Created with a valid ID", func() {
+			Expect(createdID).NotTo(BeEmpty())
+
+			thread, err := client.CreateThread(createdID)
+			Expect(err).To(BeNil())
+
+			Expect(thread.ID).NotTo(BeEmpty())
+			Expect(thread.ProjectID).To(Equal(createdID))
+
+			thread, err = client.GetProjectThread(createdID, thread.ID)
+			Expect(err).To(BeNil())
+
+			threadID = thread.ID
+		})
+
+		It("can invoke the thread and get the result", func() {
+			Expect(threadID).NotTo(BeEmpty())
+
+			err := client.InvokeProjectThread(createdID, threadID, "Hello, world!")
+			Expect(err).To(BeNil())
+
+			messages, _ := client.GetProjectThreadEventsStream(createdID, threadID)
+
+			for message := range messages {
+				if message.Data.Input != "" {
+					Expect(message.Data.Input).To(Equal("Hello, world!"))
+				} else if message.Data.Content != "" {
+					Expect(message.Data.Content).To(Equal("This is a fake response for testing."))
+				}
+				if message.Data.RunComplete {
+					break
+				}
+			}
+		})
+
 	})
 })

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -1,8 +1,10 @@
 #! /bin/bash
 
-export OBOT_SERVER_TOOL_REGISTRIES="github.com/obot-platform/tools"
+export OBOT_SERVER_TOOL_REGISTRIES="github.com/obot-platform/tools,test-tools"
+export GPTSCRIPT_TOOL_REMAP="test-tools=./tests/integration/tools/"
+export GPTSCRIPT_INTERNAL_OPENAI_STREAMING=false
 echo "Starting obot server..."
-./bin/obot server > ./obot.log 2>&1 &
+./bin/obot server --dev-mode > ./obot.log 2>&1 &
 
 URL="http://localhost:8080/api/healthz"
 TIMEOUT=300

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+export OBOT_SERVER_TOOL_REGISTRIES="github.com/obot-platform/tools"
+echo "Starting obot server..."
+./bin/obot server > ./obot.log 2>&1 &
+
+URL="http://localhost:8080/api/healthz"
+TIMEOUT=300
+INTERVAL=5
+MAX_RETRIES=$((TIMEOUT / INTERVAL))
+
+echo "Waiting for $URL to return OK..."
+
+for ((i=1; i<=MAX_RETRIES; i++)); do
+  response=$(curl -s -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null)
+  
+  if [ "$response" = "200" ]; then
+    health_content=$(curl -s "$URL")
+    if [[ "$health_content" == *"ok"* ]]; then
+      echo "✅ Health check passed! Response: $health_content"
+      go test ./tests/integration/... -v
+      exit 0
+    else
+      echo "⚠️  Got HTTP 200 but unexpected response: $health_content"
+    fi
+  fi
+
+  echo "Attempt $i/$MAX_RETRIES: Service not ready (HTTP $response). Retrying in $INTERVAL seconds..."
+  sleep "$INTERVAL"
+done
+
+echo "❌ Timeout reached! Service at $URL did not return OK within $TIMEOUT seconds"
+tail -n 100 ./obot.log
+exit 1
+

--- a/tests/integration/tools/index.yaml
+++ b/tests/integration/tools/index.yaml
@@ -1,0 +1,3 @@
+modelProviders:
+  mock-model-provider:
+    reference: ./mock-model-provider

--- a/tests/integration/tools/mock-model-provider/main.go
+++ b/tests/integration/tools/mock-model-provider/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+)
+
+// Fake model list response
+type Model struct {
+	ID       string            `json:"id"`
+	Object   string            `json:"object"`
+	Created  int               `json:"created"`
+	OwnedBy  string            `json:"owned_by"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+type ModelsResponse struct {
+	Object string  `json:"object"`
+	Data   []Model `json:"data"`
+}
+
+// Fake chat completion request/response
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatRequest struct {
+	Model    string        `json:"model"`
+	Messages []ChatMessage `json:"messages"`
+}
+
+type ChatChoice struct {
+	Index        int         `json:"index"`
+	Message      ChatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type ChatResponse struct {
+	ID      string       `json:"id"`
+	Object  string       `json:"object"`
+	Created int64        `json:"created"`
+	Model   string       `json:"model"`
+	Choices []ChatChoice `json:"choices"`
+}
+
+// Handler for /v1/models
+func handleModels(w http.ResponseWriter, _ *http.Request) {
+	models := ModelsResponse{
+		Object: "list",
+		Data: []Model{
+			{
+				ID:      "gpt-4o",
+				Object:  "model",
+				Created: 1687610602,
+				OwnedBy: "openai",
+				Metadata: map[string]string{
+					"usage": "llm",
+				},
+			},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(models); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+}
+
+// Handler for /v1/chat/completions
+func handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	var req ChatRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
+	resp := ChatResponse{
+		ID:      "chatcmpl-fakeid123",
+		Object:  "chat.completion",
+		Created: 1234567890,
+		Model:   req.Model,
+		Choices: []ChatChoice{
+			{
+				Index: 0,
+				Message: ChatMessage{
+					Role:    "assistant",
+					Content: "This is a fake response for testing.",
+				},
+				FinishReason: "stop",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+}
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "validate" {
+		return
+	}
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	http.HandleFunc("/v1/models", handleModels)
+	http.HandleFunc("/v1/chat/completions", handleChatCompletions)
+	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("http://127.0.0.1:" + port)); err != nil {
+			http.Error(w, "Failed to write response", http.StatusInternalServerError)
+			return
+		}
+	})
+	log.Println("Fake OpenAI proxy server listening on :" + port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}

--- a/tests/integration/tools/mock-model-provider/tool.gpt
+++ b/tests/integration/tools/mock-model-provider/tool.gpt
@@ -1,0 +1,10 @@
+Name: MockModelProvider
+Description: Mock Model Provider
+Model Provider: true
+
+#!sys.daemon ${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool
+---
+Name: validate
+Description: Validate the OpenAI API key
+
+#!${GPTSCRIPT_TOOL_DIR}/bin/gptscript-go-tool validate

--- a/tests/integration/tools/tool.gpt
+++ b/tests/integration/tools/tool.gpt
@@ -1,0 +1,5 @@
+name: Tool Index
+description: The upstream Obot tool registry
+
+outputfilter: index.yaml
+#!sys.echo


### PR DESCRIPTION
This PR added basic integration test framework to obot. It launch a obot server with controller running, setting up mock model provider so that developer can write tests against api/controller code against full api.


Still actively adding more tests, this PR serves as a baseline for setting up groundwork and and test suite examples.