### PR TITLE
feat: allow admin to create MCPServers inside MCPCatalogs

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -52,6 +52,7 @@ type MCPServer struct {
 	MissingRequiredHeaders  []string `json:"missingRequiredHeader,omitempty"`
 	CatalogEntryID          string   `json:"catalogEntryID"`
 	SharedWithinCatalogName string   `json:"sharedWithinCatalogName,omitempty"`
+	ConnectURL              string   `json:"connectURL,omitempty"`
 }
 
 type MCPServerList List[MCPServer]

--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -47,10 +47,11 @@ type MCPEnv struct {
 type MCPServer struct {
 	Metadata
 	MCPServerManifest
-	Configured             bool     `json:"configured"`
-	MissingRequiredEnvVars []string `json:"missingRequiredEnvVars,omitempty"`
-	MissingRequiredHeaders []string `json:"missingRequiredHeader,omitempty"`
-	CatalogEntryID         string   `json:"catalogEntryID"`
+	Configured              bool     `json:"configured"`
+	MissingRequiredEnvVars  []string `json:"missingRequiredEnvVars,omitempty"`
+	MissingRequiredHeaders  []string `json:"missingRequiredHeader,omitempty"`
+	CatalogEntryID          string   `json:"catalogEntryID"`
+	SharedWithinCatalogName string   `json:"sharedWithinCatalogName,omitempty"`
 }
 
 type MCPServerList List[MCPServer]

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -81,9 +81,12 @@ var staticRules = map[string][]string{
 		"POST /api/projectinvitations/{code}",
 		"DELETE /api/projectinvitations/{code}",
 
-		// Allow authenticated users to read entries from MCP catalogs
+		// Allow authenticated users to read servers and entries from MCP catalogs.
+		// The authz logic is handled in the routes themselves, for now.
 		"GET /api/all-mcp-catalogs/entries",
 		"GET /api/all-mcp-catalogs/entries/{entry_id}",
+		"GET /api/all-mcp-catalogs/servers",
+		"GET /api/all-mcp-catalogs/servers/{mcp_server_id}",
 	},
 
 	MetricsGroup: {

--- a/pkg/api/authz/mcpserver.go
+++ b/pkg/api/authz/mcpserver.go
@@ -7,9 +7,10 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"k8s.io/apiserver/pkg/authentication/user"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, _ user.Info) (bool, error) {
+func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, u user.Info) (bool, error) {
 	if resources.MCPServerID == "" {
 		return true, nil
 	}
@@ -21,6 +22,28 @@ func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, _ u
 	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPServerID), &mcpServer); err != nil {
 		return false, err
 	}
+
+	// If this MCP server is shared within a catalog that the user has access to,
+	// then authorization is granted.
+	if mcpServer.Spec.SharedWithinMCPCatalogName != "" {
+		var userAuths v1.UserCatalogAuthorizationList
+		if err := a.storage.List(req.Context(), &userAuths, kclient.InNamespace(system.DefaultNamespace), kclient.MatchingFields{
+			"spec.mcpCatalogName": mcpServer.Spec.SharedWithinMCPCatalogName,
+		}); err != nil {
+			return false, err
+		}
+
+		for _, auth := range userAuths.Items {
+			if auth.Spec.UserID == u.GetUID() || auth.Spec.UserID == "*" {
+				resources.Authorizated.MCPServer = &mcpServer
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}
+
+	// Check to see if this MCP server is shared within a project that the user has access to.
 
 	if resources.Authorizated.Project == nil && resources.Authorizated.Thread != nil &&
 		resources.Authorizated.Thread.Spec.ParentThreadName != "" &&

--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -9,6 +9,11 @@ import (
 )
 
 var apiResources = []string{
+	"GET    /api/all-mcp-catalogs/servers/{mcpserver_id}/tools",
+	"GET    /api/all-mcp-catalogs/servers/{mcpserver_id}/resources",
+	"GET    /api/all-mcp-catalogs/servers/{mcpserver_id}/resources/{resource_uri}",
+	"GET    /api/all-mcp-catalogs/servers/{mcpserver_id}/prompts",
+	"GET    /api/all-mcp-catalogs/servers/{mcpserver_id}/prompts/{prompt_name}",
 	"GET    /api/assistants",
 	"GET    /api/assistants/{assistant_id}",
 	"GET    /api/assistants/{assistant_id}/projects",

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -205,7 +205,9 @@ func (m *MCPHandler) GetServer(req api.Context) error {
 		return err
 	}
 
-	if catalogID != "" && server.Spec.SharedWithinMCPCatalogName != catalogID {
+	// For servers that are in catalogs, this checks to make sure that a catalogID was provided and that it matches.
+	// For servers that are not in catalogs, this checks to make sure that no catalogID was provided. (Both are empty strings.)
+	if server.Spec.SharedWithinMCPCatalogName != catalogID {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
@@ -249,7 +251,9 @@ func (m *MCPHandler) DeleteServer(req api.Context) error {
 		return err
 	}
 
-	if catalogID != "" && server.Spec.SharedWithinMCPCatalogName != catalogID {
+	// For servers that are in catalogs, this checks to make sure that a catalogID was provided and that it matches.
+	// For servers that are not in catalogs, this checks to make sure that no catalogID was provided. (Both are empty strings.)
+	if server.Spec.SharedWithinMCPCatalogName != catalogID {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
@@ -658,7 +662,9 @@ func (m *MCPHandler) UpdateServer(req api.Context) error {
 		return err
 	}
 
-	if catalogID != "" && existing.Spec.SharedWithinMCPCatalogName != catalogID {
+	// For servers that are in catalogs, this checks to make sure that a catalogID was provided and that it matches.
+	// For servers that are not in catalogs, this checks to make sure that no catalogID was provided. (Both are empty strings.)
+	if existing.Spec.SharedWithinMCPCatalogName != catalogID {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
@@ -758,7 +764,9 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 		return err
 	}
 
-	if catalogID != "" && mcpServer.Spec.SharedWithinMCPCatalogName != catalogID {
+	// For servers that are in catalogs, this checks to make sure that a catalogID was provided and that it matches.
+	// For servers that are not in catalogs, this checks to make sure that no catalogID was provided. (Both are empty strings.)
+	if mcpServer.Spec.SharedWithinMCPCatalogName != catalogID {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
@@ -885,7 +893,9 @@ func (m *MCPHandler) DeconfigureServer(req api.Context) error {
 		return err
 	}
 
-	if catalogID != "" && mcpServer.Spec.SharedWithinMCPCatalogName != catalogID {
+	// For servers that are in catalogs, this checks to make sure that a catalogID was provided and that it matches.
+	// For servers that are not in catalogs, this checks to make sure that no catalogID was provided. (Both are empty strings.)
+	if mcpServer.Spec.SharedWithinMCPCatalogName != catalogID {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
@@ -971,7 +981,9 @@ func (m *MCPHandler) Reveal(req api.Context) error {
 		return err
 	}
 
-	if catalogID != "" && mcpServer.Spec.SharedWithinMCPCatalogName != catalogID {
+	// For servers that are in catalogs, this checks to make sure that a catalogID was provided and that it matches.
+	// For servers that are not in catalogs, this checks to make sure that no catalogID was provided. (Both are empty strings.)
+	if mcpServer.Spec.SharedWithinMCPCatalogName != catalogID {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
@@ -1361,6 +1373,10 @@ func (m *MCPHandler) GetServerFromCatalogs(req api.Context) error {
 
 	if err := req.Get(&server, id); err != nil {
 		return err
+	}
+
+	if server.Spec.SharedWithinMCPCatalogName == "" {
+		return types.NewErrNotFound("MCP server not found")
 	}
 
 	// Authorization check.

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -379,8 +379,6 @@ func Router(services *services.Services) (http.Handler, error) {
 	// MCP Shared Servers Within Catalogs
 	mux.HandleFunc("GET /api/all-mcp-catalogs/servers", mcp.ListServersForAllCatalogs)
 	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}", mcp.GetServerFromCatalogs)
-
-	// TODO: implement these next five routes
 	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}/tools", mcp.GetTools)
 	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}/resources", mcp.GetResources)
 	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}/resources/{resource_uri}", mcp.ReadResource)

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -377,8 +377,15 @@ func Router(services *services.Services) (http.Handler, error) {
 	mux.HandleFunc("GET /api/all-mcp-catalogs/entries/{entry_id}", mcp.GetCatalogEntry)
 
 	// MCP Shared Servers Within Catalogs
-	// mux.HandleFunc("GET /api/all-mcp-catalogs/servers", mcp.ListSharedServers)
-	// mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{server_id}", mcp.GetSharedServer)
+	mux.HandleFunc("GET /api/all-mcp-catalogs/servers", mcp.ListServersForAllCatalogs)
+	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}", mcp.GetServerFromCatalogs)
+
+	// TODO: implement these next five routes
+	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}/tools", mcp.GetTools)
+	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}/resources", mcp.GetResources)
+	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}/resources/{resource_uri}", mcp.ReadResource)
+	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}/prompts", mcp.GetPrompts)
+	mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{mcp_server_id}/prompts/{prompt_name}", mcp.GetPrompt)
 
 	// MCP Catalogs (admin only)
 	mux.HandleFunc("GET /api/mcp-catalogs", mcpCatalogs.List)
@@ -396,7 +403,6 @@ func Router(services *services.Services) (http.Handler, error) {
 	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/servers", mcp.CreateServer)
 	mux.HandleFunc("PUT /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}", mcp.UpdateServer)
 	mux.HandleFunc("DELETE /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}", mcp.DeleteServer)
-	// TODO: test these three routes below before moving on
 	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}/configure", mcp.ConfigureServer)
 	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}/deconfigure", mcp.DeconfigureServer)
 	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}/reveal", mcp.Reveal)

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -376,6 +376,10 @@ func Router(services *services.Services) (http.Handler, error) {
 	mux.HandleFunc("GET /api/all-mcp-catalogs/entries", mcp.ListEntriesForAllCatalogs)
 	mux.HandleFunc("GET /api/all-mcp-catalogs/entries/{entry_id}", mcp.GetCatalogEntry)
 
+	// MCP Shared Servers Within Catalogs
+	// mux.HandleFunc("GET /api/all-mcp-catalogs/servers", mcp.ListSharedServers)
+	// mux.HandleFunc("GET /api/all-mcp-catalogs/servers/{server_id}", mcp.GetSharedServer)
+
 	// MCP Catalogs (admin only)
 	mux.HandleFunc("GET /api/mcp-catalogs", mcpCatalogs.List)
 	mux.HandleFunc("GET /api/mcp-catalogs/{catalog_id}", mcpCatalogs.Get)
@@ -387,6 +391,15 @@ func Router(services *services.Services) (http.Handler, error) {
 	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/entries", mcpCatalogs.CreateEntry)
 	mux.HandleFunc("PUT /api/mcp-catalogs/{catalog_id}/entries/{entry_id}", mcpCatalogs.UpdateEntry)
 	mux.HandleFunc("DELETE /api/mcp-catalogs/{catalog_id}/entries/{entry_id}", mcpCatalogs.DeleteEntry)
+	mux.HandleFunc("GET /api/mcp-catalogs/{catalog_id}/servers", mcp.ListServer)
+	mux.HandleFunc("GET /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}", mcp.GetServer)
+	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/servers", mcp.CreateServer)
+	mux.HandleFunc("PUT /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}", mcp.UpdateServer)
+	mux.HandleFunc("DELETE /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}", mcp.DeleteServer)
+	// TODO: test these three routes below before moving on
+	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}/configure", mcp.ConfigureServer)
+	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}/deconfigure", mcp.DeconfigureServer)
+	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/servers/{mcp_server_id}/reveal", mcp.Reveal)
 
 	// MCP Servers
 	mux.HandleFunc("GET /api/assistants/{assistant_id}/projects/{project_id}/mcpservers", mcp.ListServer)

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -42,7 +42,7 @@ func expandEnvVars(text string, credEnv map[string]string) string {
 	})
 }
 
-func ToServerConfig(mcpServer v1.MCPServer, projectThreadName string, credEnv map[string]string, allowedTools ...string) (ServerConfig, []string) {
+func ToServerConfig(mcpServer v1.MCPServer, scope string, credEnv map[string]string, allowedTools ...string) (ServerConfig, []string) {
 	// Expand environment variables in command, args, and URL
 	command := expandEnvVars(mcpServer.Spec.Manifest.Command, credEnv)
 	url := expandEnvVars(mcpServer.Spec.Manifest.URL, credEnv)
@@ -59,7 +59,7 @@ func ToServerConfig(mcpServer v1.MCPServer, projectThreadName string, credEnv ma
 			Env:          make([]string, 0, len(mcpServer.Spec.Manifest.Env)),
 			URL:          url,
 			Headers:      make([]string, 0, len(mcpServer.Spec.Manifest.Headers)),
-			Scope:        fmt.Sprintf("%s-%s", mcpServer.Name, projectThreadName),
+			Scope:        fmt.Sprintf("%s-%s", mcpServer.Name, scope),
 			AllowedTools: allowedTools,
 		},
 	}

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -35,6 +35,8 @@ func (in *MCPServer) Get(field string) (value string) {
 		return in.Spec.UserID
 	case "spec.mcpServerCatalogEntryName":
 		return in.Spec.MCPServerCatalogEntryName
+	case "spec.sharedWithinMCPCatalogName":
+		return in.Spec.SharedWithinMCPCatalogName
 	}
 	return ""
 }
@@ -44,6 +46,7 @@ func (in *MCPServer) FieldNames() []string {
 		"spec.threadName",
 		"spec.userID",
 		"spec.mcpServerCatalogEntryName",
+		"spec.sharedWithinMCPCatalogName",
 	}
 }
 
@@ -52,6 +55,7 @@ func (in *MCPServer) DeleteRefs() []Ref {
 		{ObjType: &Thread{}, Name: in.Spec.ThreadName},
 		{ObjType: &ToolReference{}, Name: in.Spec.ToolReferenceName},
 		{ObjType: &MCPServerCatalogEntry{}, Name: in.Spec.MCPServerCatalogEntryName},
+		{ObjType: &MCPCatalog{}, Name: in.Spec.SharedWithinMCPCatalogName},
 	}
 }
 
@@ -59,11 +63,16 @@ type MCPServerSpec struct {
 	Manifest types.MCPServerManifest `json:"manifest,omitempty"`
 	// List of tool names that are known to not work well in Obot.
 	UnsupportedTools []string `json:"unsupportedTools,omitempty"`
-	// The project or thread that owns this server.
-	ThreadName                string `json:"threadName,omitempty"`
-	UserID                    string `json:"userID,omitempty"`
+	// ThreadName is the project or thread that owns this server, if there is one.
+	ThreadName string `json:"threadName,omitempty"`
+	// UserID is the user that created this server.
+	UserID string `json:"userID,omitempty"`
+	// SharedWithinMCPCatalogName contains the name of the MCPCatalog inside of which this server was directly created by the admin, if there is one.
+	SharedWithinMCPCatalogName string `json:"sharedWithinMCPCatalogName,omitempty"`
+	// MCPServerCatalogEntryName contains the name of the MCPServerCatalogEntry from which this MCP server was created, if there is one.
 	MCPServerCatalogEntryName string `json:"mcpServerCatalogEntryName,omitempty"`
-	ToolReferenceName         string `json:"toolReferenceName,omitempty"`
+	// ToolReferenceName contains the name of the legacy gptscript tool reference for this MCP server, if there is one.
+	ToolReferenceName string `json:"toolReferenceName,omitempty"`
 }
 
 type MCPServerStatus struct {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2591,6 +2591,12 @@ func schema_obot_platform_obot_apiclient_types_MCPServer(ref common.ReferenceCal
 							Format:  "",
 						},
 					},
+					"sharedWithinCatalogName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"Metadata", "MCPServerManifest", "configured", "catalogEntryID"},
 			},
@@ -9150,27 +9156,37 @@ func schema_storage_apis_obotobotai_v1_MCPServerSpec(ref common.ReferenceCallbac
 					},
 					"threadName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The project or thread that owns this server.",
+							Description: "ThreadName is the project or thread that owns this server, if there is one.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"userID": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "UserID is the user that created this server.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"sharedWithinMCPCatalogName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SharedWithinMCPCatalogName contains the name of the MCPCatalog inside of which this server was directly created by the admin, if there is one.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"mcpServerCatalogEntryName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "MCPServerCatalogEntryName contains the name of the MCPServerCatalogEntry from which this MCP server was created, if there is one.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"toolReferenceName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "ToolReferenceName contains the name of the legacy gptscript tool reference for this MCP server, if there is one.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2597,6 +2597,12 @@ func schema_obot_platform_obot_apiclient_types_MCPServer(ref common.ReferenceCal
 							Format: "",
 						},
 					},
+					"connectURL": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"Metadata", "MCPServerManifest", "configured", "catalogEntryID"},
 			},


### PR DESCRIPTION
This PR allows the admin to configure MCPServers directly within MCPCatalogs, to be used by the same users who are authorized in that catalog.

I have some questions and comments on my own PR that I would like reviewers to take a look at.