### PR TITLE
fix: track the source URL for MCPServerCatalogEntries

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -7,6 +7,7 @@ type MCPServerCatalogEntry struct {
 	ToolReferenceName string                        `json:"toolReferenceName,omitzero"`
 	Editable          bool                          `json:"editable,omitempty"`
 	CatalogName       string                        `json:"catalogName,omitempty"`
+	SourceURL         string                        `json:"sourceURL,omitempty"`
 }
 
 type MCPServerCatalogEntryManifest struct {

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -113,6 +113,7 @@ func convertMCPServerCatalogEntry(entry v1.MCPServerCatalogEntry) types.MCPServe
 		ToolReferenceName: entry.Spec.ToolReferenceName,
 		Editable:          entry.Spec.Editable,
 		CatalogName:       entry.Spec.MCPCatalogName,
+		SourceURL:         entry.Spec.SourceURL,
 	}
 }
 

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -145,6 +145,7 @@ func (h *Handler) readMCPCatalog(catalogName, sourceURL string) ([]client.Object
 			},
 			Spec: v1.MCPServerCatalogEntrySpec{
 				MCPCatalogName: catalogName,
+				SourceURL:      sourceURL,
 				Editable:       false, // entries from source URLs are not editable
 			},
 		}

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
@@ -60,6 +60,7 @@ type MCPServerCatalogEntrySpec struct {
 	UnsupportedTools  []string                            `json:"unsupportedTools,omitempty"`
 	MCPCatalogName    string                              `json:"mcpCatalogName,omitempty"`
 	Editable          bool                                `json:"editable,omitempty"`
+	SourceURL         string                              `json:"sourceURL,omitempty"`
 }
 
 type MCPServerCatalogEntryStatus struct {


### PR DESCRIPTION
The UI needs to be able to display which source URL each catalog entry came from.