### PR TITLE
Enhance: fallback to github username, return displayName in api

### DIFF
--- a/apiclient/types/user.go
+++ b/apiclient/types/user.go
@@ -27,6 +27,7 @@ type User struct {
 	Internal                   bool   `json:"internal,omitempty"`
 	DailyPromptTokensLimit     int    `json:"dailyPromptTokensLimit,omitempty"`
 	DailyCompletionTokensLimit int    `json:"dailyCompletionTokensLimit,omitempty"`
+	DisplayName                string `json:"displayName,omitempty"`
 }
 
 type UserList List[User]

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -253,6 +253,11 @@ func (c *Client) UpdateProfileIfNeeded(ctx context.Context, user *types.User, au
 		}
 		if displayName, ok := profile["name"].(string); ok {
 			user.DisplayName = displayName
+			if user.DisplayName == "" {
+				if login, ok := profile["login"].(string); ok {
+					user.DisplayName = login
+				}
+			}
 		}
 	case "google-auth-provider":
 		if iconURL, ok := profile["picture"].(string); ok {

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -41,6 +41,7 @@ func ConvertUser(u *User, roleFixed bool, authProviderName string) *types2.User 
 			ID:      fmt.Sprint(u.ID),
 			Created: *types2.NewTime(u.CreatedAt),
 		},
+		DisplayName:                u.DisplayName,
 		Username:                   u.Username,
 		Email:                      u.Email,
 		Role:                       u.Role,

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -6397,6 +6397,12 @@ func schema_obot_platform_obot_apiclient_types_User(ref common.ReferenceCallback
 							Format: "int32",
 						},
 					},
+					"displayName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"Metadata", "lastActiveDay"},
 			},


### PR DESCRIPTION
Fixed an issue in case github name is not set, we use github username as displayName

https://github.com/obot-platform/obot/issues/3232