### PR TITLE
enhance: user ui ux for project scoped workspaces 

### DIFF
--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -93,6 +93,7 @@ var apiResources = []string{
 	"POST   /api/assistants/{assistant_id}/projects/{project_id}/tasks/{task_id}/runs/{run_id}/abort",
 	"GET    /api/assistants/{assistant_id}/projects/{project_id}/tasks/{task_id}/runs/{run_id}/events",
 	"POST   /api/assistants/{assistant_id}/projects/{project_id}/tasks/{task_id}/runs/{run_id}/events",
+	"DELETE /api/assistants/{assistant_id}/projects/{project_id}/tasks/{task_id}/runs/{run_id}/file/{file...}",
 	"GET    /api/assistants/{assistant_id}/projects/{project_id}/tasks/{task_id}/runs/{run_id}/file/{file...}",
 	"POST   /api/assistants/{assistant_id}/projects/{project_id}/tasks/{task_id}/runs/{run_id}/file/{file...}",
 	"GET    /api/assistants/{assistant_id}/projects/{project_id}/tasks/{task_id}/runs/{run_id}/files",

--- a/ui/user/src/lib/components/Editors.svelte
+++ b/ui/user/src/lib/components/Editors.svelte
@@ -45,8 +45,8 @@
 		}, 300);
 	};
 
-	function onFileChanged(name: string, contents: string) {
-		const item = layout.items.find((item) => item.name === name);
+	function onFileChanged(id: string, contents: string) {
+		const item = layout.items.find((item) => item.id === id);
 		if (item && item.file) {
 			item.file.buffer = contents;
 			item.file.modified = true;
@@ -90,6 +90,11 @@
 								class="group/file relative flex w-full items-center justify-between gap-1 [&_svg]:size-4 [&_svg]:min-w-fit"
 							>
 								<span use:overflowToolTip class="truncate p-1">{item.name}</span>
+								{#if item.file?.projectScoped === true}
+									<span class="inline-flex items-center rounded-full border px-1 py-0.5 text-[9px]">
+										Project
+									</span>
+								{/if}
 								<button
 									class="hover:bg-surface2 flex h-6 w-0 flex-shrink-0 items-center justify-center overflow-hidden rounded-full text-gray-500 transition-all duration-300 group-hover/file:w-6"
 									class:w-6={item.selected}

--- a/ui/user/src/lib/components/Sidebar.svelte
+++ b/ui/user/src/lib/components/Sidebar.svelte
@@ -104,6 +104,7 @@
 			{#if hasTool(projectTools.tools, 'memory')}
 				<Memories {project} />
 			{/if}
+			<Files {project} classes={{ list: 'text-sm flex flex-col gap-2' }} />
 		{/if}
 	</div>
 

--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -111,10 +111,9 @@
 	});
 
 	const layout = getLayout();
-	function onLoadFile(filename: string) {
-		EditorService.load(layout.items, project, filename, {
-			threadID: id
-		});
+	function onLoadFile(filename: string, projectScoped?: boolean) {
+		let opts = projectScoped === true ? {} : { threadID: id };
+		EditorService.load(layout.items, project, filename, opts);
 		layout.fileEditorOpen = true;
 	}
 

--- a/ui/user/src/lib/components/editor/Codemirror.svelte
+++ b/ui/user/src/lib/components/editor/Codemirror.svelte
@@ -61,7 +61,7 @@
 	interface Props {
 		file: EditorItem;
 		onInvoke?: (invoke: InvokeInput) => void | Promise<void>;
-		onFileChanged?: (name: string, contents: string) => void;
+		onFileChanged?: (id: string, contents: string) => void;
 		class?: string;
 		items: EditorItem[];
 	}
@@ -125,7 +125,8 @@
 				onInvoke?.({
 					explain: {
 						filename: file.name,
-						selection: ttState.sliceDoc(selection.from, selection.to).toString()
+						selection: ttState.sliceDoc(selection.from, selection.to).toString(),
+						projectScoped: file?.file?.projectScoped
 					}
 				});
 			}
@@ -144,7 +145,8 @@
 				filename: file.name,
 				selection: ttState
 					.sliceDoc(ttState.selection.ranges[0].from, ttState.selection.ranges[0].to)
-					.toString()
+					.toString(),
+				projectScoped: file?.file?.projectScoped
 			};
 			await onInvoke?.(input);
 		}
@@ -186,7 +188,7 @@
 
 		const updater = EditorView.updateListener.of((update) => {
 			if (update.docChanged && focused) {
-				onFileChanged?.(file.name, update.state.doc.toString());
+				onFileChanged?.(file?.id, update.state.doc.toString());
 			}
 		});
 

--- a/ui/user/src/lib/components/editor/FileEditors.svelte
+++ b/ui/user/src/lib/components/editor/FileEditors.svelte
@@ -8,7 +8,7 @@
 	import Codemirror from '$lib/components/editor/Codemirror.svelte';
 
 	interface Props {
-		onFileChanged: (name: string, contents: string) => void;
+		onFileChanged: (id: string, contents: string) => void;
 		onInvoke?: (invoke: InvokeInput) => void;
 		items: EditorItem[];
 	}

--- a/ui/user/src/lib/components/editor/Milkdown.svelte
+++ b/ui/user/src/lib/components/editor/Milkdown.svelte
@@ -23,7 +23,7 @@
 	interface Props {
 		file: EditorItem;
 		onInvoke?: (invoke: InvokeInput) => void | Promise<void>;
-		onFileChanged?: (name: string, contents: string) => void;
+		onFileChanged?: (id: string, contents: string) => void;
 		items: EditorItem[];
 		class?: string;
 	}
@@ -80,7 +80,8 @@
 	async function onSubmit(input: InvokeInput) {
 		input.improve = {
 			filename: file.name,
-			selection: getSelection()
+			selection: getSelection(),
+			projectScoped: file?.file?.projectScoped
 		};
 		await onInvoke?.(input);
 		hide();
@@ -101,7 +102,8 @@
 		onInvoke?.({
 			explain: {
 				filename: file.name,
-				selection: getSelection()
+				selection: getSelection(),
+				projectScoped: file?.file?.projectScoped
 			}
 		});
 	}
@@ -151,7 +153,7 @@
 					}
 
 					if (onFileChanged) {
-						onFileChanged(file.name, markdown);
+						onFileChanged(file.id, markdown);
 					}
 				});
 

--- a/ui/user/src/lib/components/messages/Input.svelte
+++ b/ui/user/src/lib/components/messages/Input.svelte
@@ -52,7 +52,7 @@
 				if (!input.changedFiles) {
 					input.changedFiles = {};
 				}
-				input.changedFiles[file.name] = file.file.buffer;
+				input.changedFiles[scopedFilename(file)] = file.file.buffer;
 			}
 		}
 
@@ -65,8 +65,9 @@
 
 		if (input.changedFiles) {
 			for (const file of items) {
-				if (input.changedFiles[file.name] && file.file) {
-					file.file.contents = input.changedFiles[file.name];
+				const name = scopedFilename(file);
+				if (input.changedFiles[name] && file.file) {
+					file.file.contents = input.changedFiles[name];
 					file.file.modified = false;
 					file.file.buffer = '';
 				}
@@ -97,6 +98,10 @@
 
 	export function setValue(newValue: string) {
 		value = newValue;
+	}
+
+	export function scopedFilename(file: EditorItem) {
+		return file.file?.projectScoped ? `project://${file.name}` : file.name;
 	}
 
 	onMount(() => {

--- a/ui/user/src/lib/components/messages/Message.svelte
+++ b/ui/user/src/lib/components/messages/Message.svelte
@@ -33,7 +33,7 @@
 		msg: Message;
 		project: Project;
 		currentThreadID?: string;
-		onLoadFile?: (filename: string) => void;
+		onLoadFile?: (filename: string, projectScoped?: boolean) => void;
 		onSendCredentials?: (id: string, credentials: Record<string, string>) => void;
 		onSendCredentialsCancel?: (id: string) => void;
 		disableMessageToEditor?: boolean;
@@ -144,7 +144,7 @@
 
 	function fileLoad() {
 		if (msg.file?.filename) {
-			onLoadFile(msg.file?.filename);
+			onLoadFile(msg.file?.filename, msg.file?.projectScoped);
 		}
 	}
 
@@ -251,7 +251,11 @@
 				threadID: currentThreadID
 			});
 
-			const fileExists = files.items.some((file) => file.name === filename);
+			const fileExists = files.items.some(
+				(file) =>
+					file.name === filename &&
+					(file.projectScoped === msg.file?.projectScoped || !msg.file?.projectScoped)
+			);
 			return fileExists;
 		} catch (err) {
 			console.error('Failed to check if file exists:', err);
@@ -288,7 +292,7 @@
 				});
 			}
 
-			onLoadFile(filename);
+			onLoadFile(filename, msg.file?.projectScoped);
 		} catch (err) {
 			console.error('Failed to create or open image file:', err);
 		}
@@ -394,6 +398,11 @@
 				<div class="flex items-center gap-2 truncate">
 					<FileText class="min-w-fit" />
 					<span use:overflowToolTip>{msg.file.filename}</span>
+					{#if msg.file.projectScoped}
+						<span class="inline-flex items-center rounded-full border px-1.5 py-0.5 text-[11px]">
+							Project File
+						</span>
+					{/if}
 				</div>
 				<div>
 					<Pencil />

--- a/ui/user/src/lib/context/helperMode.svelte.ts
+++ b/ui/user/src/lib/context/helperMode.svelte.ts
@@ -13,7 +13,8 @@ export const HELPER_TEXTS = {
 		'Begin every conversation with an introduction and default options that a user can choose from.',
 	knowledge:
 		'Add a collection of information (from documents to websites) that the agent can use to answer questions or perform tasks.',
-	projectFiles: 'Add files that are available to use/view by a user with every conversation.',
+	projectFiles: 'Files that all threads in the project can view and edit.',
+	threadFiles: 'Files that only this thread can view and edit.',
 	interfaces: 'Hook up an agent to third party services to automate tasks and workflows.',
 	sharing:
 		'Collaborate, share a simplified version to interact with, or make a template of the agent.',

--- a/ui/user/src/lib/services/chat/operations.ts
+++ b/ui/user/src/lib/services/chat/operations.ts
@@ -292,10 +292,13 @@ export async function listFiles(
 		)) as Files;
 	} else {
 		files = (await doGet(`/assistants/${assistantID}/projects/${projectID}/files`)) as Files;
+		files.items = files.items?.map((file) => ({ ...file, projectScoped: true }));
 	}
+
 	if (!files.items) {
 		files.items = [];
 	}
+
 	return files;
 }
 

--- a/ui/user/src/lib/services/chat/thread.svelte.ts
+++ b/ui/user/src/lib/services/chat/thread.svelte.ts
@@ -183,6 +183,7 @@ export class Thread {
 			this.onStepMessages(
 				stepID,
 				buildMessagesFromProgress(this.#items, msgs, {
+					projectID: this.#project.id,
 					taskID: this.#task?.id,
 					runID: this.runID,
 					threadID: this.threadID,
@@ -197,6 +198,7 @@ export class Thread {
 		if (this.replayComplete) {
 			this.onMessages(
 				buildMessagesFromProgress(this.#items, this.#progresses, {
+					projectID: this.#project.id,
 					taskID: this.#task?.id,
 					runID: this.runID,
 					threadID: this.threadID,

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -110,11 +110,13 @@ export interface InvokeInput {
 }
 
 export interface Explain {
+	projectScoped?: boolean;
 	filename: string;
 	selection: string;
 }
 
 export interface MessageFile {
+	projectScoped: boolean;
 	filename: string;
 	content: string;
 }
@@ -164,6 +166,7 @@ export interface Files {
 }
 
 export interface File {
+	projectScoped: boolean;
 	name: string;
 }
 


### PR DESCRIPTION
- Open project scoped files in the thread's file editor when accessed
  through in-chat preview card
- Enable explain/improve features for project scoped files opened in the
  thread's file editor (requires [this PR for the workspace-files input filter](https://github.com/obot-platform/tools/pull/707) to enable)
- Add a pill to file preview cards to inform users that a file is
  project scoped
  scoped
- Qualify file ids across user ui to improve consistent behavior with
  mixed file scopes
- Expose `Project Files` in chatbot sidenav
- Fix 403s by adding a singular task run file delete path to authz

Part of https://github.com/obot-platform/obot/issues/3242