### PR TITLE
fix: address various oauth client validation issues

### DIFF
--- a/pkg/api/handlers/oauth/client.go
+++ b/pkg/api/handlers/oauth/client.go
@@ -183,31 +183,6 @@ func (h *handler) validateClientConfig(oauthClient *v1.OAuthClient) error {
 		})
 	}
 
-	var unsupported []string
-	for _, grantType := range oauthClient.Spec.Manifest.GrantTypes {
-		if !slices.Contains(h.oauthConfig.GrantTypesSupported, grantType) {
-			unsupported = append(unsupported, grantType)
-		}
-	}
-	if len(unsupported) > 0 {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidClientMetadata,
-			Description: "unsupported grant types: " + strings.Join(unsupported, ", "),
-		})
-	}
-
-	for _, responseType := range oauthClient.Spec.Manifest.ResponseTypes {
-		if !slices.Contains(h.oauthConfig.ResponseTypesSupported, responseType) {
-			unsupported = append(unsupported, responseType)
-		}
-	}
-	if len(unsupported) > 0 {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidClientMetadata,
-			Description: "unsupported response types: " + strings.Join(unsupported, ", "),
-		})
-	}
-
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,7 +50,7 @@ func Run(ctx context.Context, c services.Config) error {
 		}
 	}
 
-	if c.DevMode && c.AllowedOrigin == "" {
+	if c.AllowedOrigin == "" {
 		c.AllowedOrigin = "*"
 	}
 

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -551,7 +551,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 			ResponseTypesSupported:            []string{"code"},
 			GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
 			CodeChallengeMethodsSupported:     []string{"S256", "plain"},
-			TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "none"},
+			TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post", "none"},
 		},
 	}, nil
 }


### PR DESCRIPTION
This change will no longer validate grant and response types when registering an oauth client. It seems that oauth clients don't respect the supported fields on the oauth-authorization-server endpoint.

Support for oauth_client_basic token authentication type is added.

A change is made such that if the client uses a token authentication type of none, then they must use PKCE when doing the authorization_code flow.

A bug is addressed where the state was not being properly saved.

Finally, we allow all origins in CORS to allow oauth clients running in the user's browser (like inspector) to work properly.

Issue: https://github.com/obot-platform/obot/issues/3268