### PR TITLE
fix: feedback updates for new ui/ux mcp servers flow

### DIFF
--- a/ui/user/src/lib/actions/tooltip.svelte.ts
+++ b/ui/user/src/lib/actions/tooltip.svelte.ts
@@ -14,6 +14,7 @@ export function tooltip(node: HTMLElement, opts: TooltipOptions | string | undef
 		'hidden',
 		'tooltip',
 		'text-left',
+		'break-all',
 		typeof opts === 'object' ? (opts.maxWidthClass ?? 'max-w-64') : 'max-w-64'
 	);
 

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -67,6 +67,12 @@
 				]
 	);
 
+	$effect(() => {
+		if (responsive.isMobile) {
+			layout.sidebarOpen = false;
+		}
+	});
+
 	initLayout();
 	const layout = getLayout();
 </script>

--- a/ui/user/src/lib/components/Table.svelte
+++ b/ui/user/src/lib/components/Table.svelte
@@ -117,7 +117,7 @@
 		onclick={() => onSelectRow?.(d)}
 	>
 		{#each fields as fieldName}
-			<td class="text-sm font-light">
+			<td class="overflow-hidden text-sm font-light">
 				<div class="flex h-full w-full px-4 py-2">
 					{#if onRenderColumn}
 						{@render onRenderColumn(fieldName, d)}

--- a/ui/user/src/lib/components/admin/BackLink.svelte
+++ b/ui/user/src/lib/components/admin/BackLink.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { getAdminMcpServerAndEntries } from '$lib/context/admin/mcpServerAndEntries.svelte';
+	import { ChevronLeft } from 'lucide-svelte';
+
+	interface Props {
+		fromURL?: string;
+		currentLabel: string;
+	}
+
+	let { fromURL, currentLabel }: Props = $props();
+
+	let links = $state<{ href: string; label: string }[]>([]);
+
+	function convertToHistory(href: string) {
+		const pathParts = href.split('/').filter(Boolean);
+		const [type, id] = pathParts;
+		if (type === 'mcp-servers') {
+			return [
+				{ href: '/v2/admin/mcp-servers', label: 'MCP Servers' },
+				...(id ? [{ href: `/v2/admin/mcp-servers?id=${id}`, label: convertToLabel(href) }] : [])
+			];
+		}
+
+		if (type === 'access-control') {
+			return [{ href: '/v2/admin/access-control', label: 'Access Control' }];
+		}
+
+		return [];
+	}
+
+	$effect(() => {
+		if (
+			fromURL &&
+			(mcpServerAndEntries.servers.length > 0 || mcpServerAndEntries.entries.length > 0)
+		) {
+			links = [...convertToHistory(fromURL)];
+		}
+	});
+
+	const mcpServerAndEntries = getAdminMcpServerAndEntries();
+
+	function convertToLabel(href: string) {
+		const pathParts = href.split('/').filter(Boolean);
+		const [type, id] = pathParts;
+		let label: string | undefined = undefined;
+		if (type === 'mcp-servers') {
+			const match =
+				mcpServerAndEntries.entries.find((e) => e.id === id) ||
+				mcpServerAndEntries.servers.find((s) => s.id === id);
+			if (match) {
+				if ('manifest' in match) {
+					label = match.manifest.name;
+				} else {
+					label = match.commandManifest?.name || match.urlManifest?.name || 'Unknown';
+				}
+			}
+		}
+
+		return label || 'Unknown';
+	}
+</script>
+
+<div class="flex flex-wrap items-center">
+	{#each links as link}
+		<ChevronLeft class="mx-2 size-4" />
+
+		<a href={link.href} class="button-text flex items-center gap-2 p-0 text-lg font-light">
+			{link.label}
+		</a>
+	{/each}
+	<ChevronLeft class="mx-2 size-4" />
+	<span class="text-lg font-light">{currentLabel}</span>
+</div>

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -5,11 +5,11 @@
 		type MCPCatalogEntryServerManifest,
 		type MCPCatalogServerManifest
 	} from '$lib/services/admin/types';
-	import { Plus, Trash2 } from 'lucide-svelte';
+	import { Info, Plus, Trash2 } from 'lucide-svelte';
 	import SingleMultiMcpForm from '../mcp/SingleMultiMcpForm.svelte';
 	import RemoteMcpForm from '../mcp/RemoteMcpForm.svelte';
 	import { AdminService, type MCPCatalogServer } from '$lib/services';
-	import { onMount } from 'svelte';
+	import { onMount, type Snippet } from 'svelte';
 
 	interface Props {
 		catalogId?: string;
@@ -19,6 +19,7 @@
 		onCancel?: () => void;
 		onSubmit?: () => void;
 		hideTitle?: boolean;
+		readonlyMessage?: Snippet;
 	}
 
 	function getType(entry?: MCPCatalogEntry | MCPCatalogServer) {
@@ -37,7 +38,8 @@
 		type: newType = 'single',
 		onCancel,
 		onSubmit,
-		hideTitle
+		hideTitle,
+		readonlyMessage
 	}: Props = $props();
 	let type = $derived(getType(entry) ?? newType);
 
@@ -230,6 +232,17 @@
 	class="dark:bg-surface1 dark:border-surface3 flex flex-col gap-8 rounded-lg border border-transparent bg-white p-4 shadow-sm"
 >
 	<div class="flex flex-col gap-8">
+		{#if readonly && readonlyMessage}
+			<div class="notification-info p-3 text-sm font-light">
+				<div class="flex items-center gap-3">
+					<Info class="size-6" />
+					<div>
+						{@render readonlyMessage()}
+					</div>
+				</div>
+			</div>
+		{/if}
+
 		<div class="flex flex-col gap-1">
 			<label for="name" class="text-sm font-light capitalize">Name</label>
 			<input

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -185,35 +185,16 @@
 				}}
 			>
 				{#snippet onRenderColumn(property, d)}
-					{#if property === 'resources'}
-						{@const referencedResource = d.resources?.find(
-							(r) => r.id === entry?.id || r.id === '*'
-						)}
-						{referencedResource?.id === '*' ? 'Everything' : 'Self'}
-					{:else}
-						{d[property as keyof typeof d]}
-					{/if}
-				{/snippet}
-				{#snippet actions(d)}
-					{@const referencedResource = d.resources?.find((r) => r.id === entry?.id || r.id === '*')}
-					<div class="min-h-9">
-						{#if referencedResource?.id !== '*'}
-							<button
-								class="icon-button hover:text-red-500"
-								use:tooltip={'Delete'}
-								onclick={(e) => {
-									e.stopPropagation();
-									if (!referencedResource) return;
-									deleteResourceFromRule = {
-										rule: d,
-										resourceId: referencedResource.id
-									};
-								}}
-							>
-								<Trash2 class="size-4" />
-							</button>
+					<span class="flex min-h-9 items-center">
+						{#if property === 'resources'}
+							{@const referencedResource = d.resources?.find(
+								(r) => r.id === entry?.id || r.id === '*'
+							)}
+							{referencedResource?.id === '*' ? 'Everything' : 'Self'}
+						{:else}
+							{d[property as keyof typeof d]}
 						{/if}
-					</div>
+					</span>
 				{/snippet}
 			</Table>
 		{:else}

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -273,7 +273,7 @@
 		if (!deleteResourceFromRule) {
 			return;
 		}
-		const updatedRule = await AdminService.updateAccessControlRule(deleteResourceFromRule.rule.id, {
+		await AdminService.updateAccessControlRule(deleteResourceFromRule.rule.id, {
 			...deleteResourceFromRule.rule,
 			resources: deleteResourceFromRule.rule.resources?.filter(
 				(r) => r.id !== deleteResourceFromRule!.resourceId

--- a/ui/user/src/lib/components/admin/SearchMcpServers.svelte
+++ b/ui/user/src/lib/components/admin/SearchMcpServers.svelte
@@ -7,27 +7,54 @@
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
-		onAdd: (mcpCatalogEntryIds: string[], mcpServerIds: string[]) => void;
+		onAdd: (mcpCatalogEntryIds: string[], mcpServerIds: string[], otherSelectors: string[]) => void;
 	}
+
+	type SearchItem = {
+		icon: string | undefined;
+		name: string;
+		description: string | undefined;
+		id: string;
+		type: 'mcpcatalogentry' | 'mcpserver' | 'all';
+	};
 
 	let { onAdd }: Props = $props();
 	let addMcpServerDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let search = $state('');
-	let selected = $state<(MCPCatalogEntry | MCPCatalogServer)[]>([]);
+	let selected = $state<SearchItem[]>([]);
 	let selectedMap = $derived(new Set(selected.map((i) => i.id)));
 	const mcpServerAndEntries = getAdminMcpServerAndEntries();
 
 	let loading = $state(false);
-	let allData = $derived(
+	let allData: SearchItem[] = $derived([
+		{
+			icon: undefined,
+			name: 'Everything',
+			description: 'All MCP servers and catalog entries',
+			id: '*',
+			type: 'all' as const
+		},
+		...mcpServerAndEntries.entries.map((entry) => ({
+			icon: entry.commandManifest?.icon || entry.urlManifest?.icon,
+			name: entry.commandManifest?.name || entry.urlManifest?.name || '',
+			description: entry.commandManifest?.description || entry.urlManifest?.description,
+			id: entry.id,
+			type: 'mcpcatalogentry' as const
+		})),
+		...mcpServerAndEntries.servers.map((server) => ({
+			icon: server.manifest.icon,
+			name: server.manifest.name || '',
+			description: server.manifest.description,
+			id: server.id,
+			type: 'mcpserver' as const
+		}))
+	]);
+	let filteredData = $derived(
 		search
-			? [...mcpServerAndEntries.entries, ...mcpServerAndEntries.servers].filter((item) => {
-					const name =
-						'manifest' in item
-							? item.manifest?.name
-							: item.commandManifest?.name || item.urlManifest?.name;
-					return name?.toLowerCase().includes(search.toLowerCase());
+			? allData.filter((item) => {
+					return item.name.toLowerCase().includes(search.toLowerCase());
 				})
-			: [...mcpServerAndEntries.entries, ...mcpServerAndEntries.servers]
+			: allData
 	);
 
 	export function open() {
@@ -42,14 +69,17 @@
 	function handleAdd() {
 		const mcpServerIds = [];
 		const mcpCatalogEntryIds = [];
+		const otherSelectors = [];
 		for (const item of selected) {
-			if ('manifest' in item) {
+			if (item.type === 'mcpserver') {
 				mcpServerIds.push(item.id);
-			} else {
+			} else if (item.type === 'mcpcatalogentry') {
 				mcpCatalogEntryIds.push(item.id);
+			} else {
+				otherSelectors.push(item.id);
 			}
 		}
-		onAdd(mcpCatalogEntryIds, mcpServerIds);
+		onAdd(mcpCatalogEntryIds, mcpServerIds, otherSelectors);
 		addMcpServerDialog?.close();
 	}
 </script>
@@ -77,7 +107,7 @@
 				</div>
 
 				<div class="flex flex-col">
-					{#each allData as item}
+					{#each filteredData as item}
 						<button
 							class={twMerge(
 								'dark:hover:bg-surface1 hover:bg-surface2 flex w-full items-center gap-2 px-4 py-2 text-left',
@@ -95,44 +125,21 @@
 							}}
 						>
 							<div class="flex w-full items-center gap-2 overflow-hidden">
-								{#if 'manifest' in item}
-									{#if item.manifest.icon}
-										<img
-											src={item.manifest.icon}
-											alt={item.manifest.name}
-											class="bg-surface1 size-8 flex-shrink-0 rounded-sm p-0.5 dark:bg-gray-600"
-										/>
-									{:else}
-										<Server
-											class="bg-surface1 size-8 flex-shrink-0 rounded-sm p-0.5 dark:bg-gray-600"
-										/>
-									{/if}
-									<div class="flex min-w-0 grow flex-col">
-										<p class="truncate">{item.manifest.name}</p>
-										<span class="truncate text-xs text-gray-500">{item.manifest.description}</span>
-									</div>
+								{#if item.icon}
+									<img
+										src={item.icon}
+										alt={item.name}
+										class="bg-surface1 size-8 flex-shrink-0 rounded-sm p-0.5 dark:bg-gray-600"
+									/>
 								{:else}
-									{@const icon = item.commandManifest?.icon || item.urlManifest?.icon}
-									{#if icon}
-										<img
-											src={icon}
-											alt={item.commandManifest?.name || item.urlManifest?.name}
-											class="bg-surface1 size-8 flex-shrink-0 rounded-sm p-0.5 dark:bg-gray-600"
-										/>
-									{:else}
-										<Server
-											class="bg-surface1 size-8 flex-shrink-0 rounded-sm p-0.5 dark:bg-gray-600"
-										/>
-									{/if}
-									<div class="flex min-w-0 grow flex-col">
-										<p class="truncate">
-											{item.commandManifest?.name || item.urlManifest?.name}
-										</p>
-										<span class="truncate text-xs font-light text-gray-500">
-											{item.commandManifest?.description || item.urlManifest?.description}
-										</span>
-									</div>
+									<Server
+										class="bg-surface1 size-8 flex-shrink-0 rounded-sm p-0.5 dark:bg-gray-600"
+									/>
 								{/if}
+								<div class="flex min-w-0 grow flex-col">
+									<p class="truncate">{item.name}</p>
+									<span class="truncate text-xs text-gray-500">{item.description}</span>
+								</div>
 							</div>
 							<div class="flex size-6 items-center justify-center">
 								{#if selectedMap.has(item.id)}

--- a/ui/user/src/lib/components/admin/SearchMcpServers.svelte
+++ b/ui/user/src/lib/components/admin/SearchMcpServers.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { type MCPCatalogEntry, type MCPCatalogServer } from '$lib/services';
 	import { Check, LoaderCircle, Server } from 'lucide-svelte';
 	import Search from '../Search.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';

--- a/ui/user/src/lib/components/mcp/HowToConnect.svelte
+++ b/ui/user/src/lib/components/mcp/HowToConnect.svelte
@@ -7,9 +7,10 @@
 
 	interface Props {
 		url: string;
+		name: string;
 	}
 
-	let { url }: Props = $props();
+	let { url, name }: Props = $props();
 	let scrollContainer: HTMLUListElement;
 	let showLeftChevron = $state(false);
 	let showRightChevron = $state(false);
@@ -30,14 +31,6 @@
 		cline: {
 			label: 'Cline',
 			icon: '/user/images/assistant/cline-mark.svg'
-		},
-		highlight: {
-			label: 'Highlight AI',
-			icon: '/user/images/assistant/highlightai-mark.svg'
-		},
-		augment: {
-			label: 'Augment Code',
-			icon: '/user/images/assistant/augmentcode-mark.svg'
 		}
 	};
 
@@ -179,7 +172,7 @@
 						{@render codeSnippet(`
     {
         "mcpServers": {
-            "obot": {
+            "${name}": {
                 "url": "${url}"
             }
         }
@@ -194,7 +187,7 @@
 						{@render codeSnippet(`
     {
         "mcpServers": {
-            "obot": {
+            "${name}": {
                 "command": "npx",
                 "args": [
                     "mcp-remote",
@@ -213,8 +206,7 @@
 						{@render codeSnippet(`
     {
         "servers": {
-            "obot": {
-                "type": "sse",
+            "${name}": {
                 "url": "${url}"
             }
         }
@@ -231,42 +223,12 @@
 						{@render codeSnippet(`
     {
         "mcpServers": {
-            "obot": {
+            "${name}": {
                 "url": "${url}",
                 "disabled": false,
                 "autoApprove": []
             }
         }
-    `)}
-					{:else if option.key === 'highlight'}
-						<p>
-							To add this MCP server to Highlight AI, click the plugins icon in the sidebar (@
-							symbol). Then proceed with the following:
-						</p>
-						<ul class="my-2 list-inside list-disc space-y-2">
-							<li>Click <b>Installed Plugins</b> at the top of the sidebar</li>
-							<li>Select <b>Custom Plugins</b></li>
-							<li>Click <b>Add a plugin using a custom SEE URL</b></li>
-							<li>Enter your plugin name: <span class="snippet">obot</span></li>
-							<li>Enter the URL as SSE URL: <span class="snippet">{url}</span></li>
-						</ul>
-					{:else if option.key === 'augment'}
-						<p>
-							To add this MCP server to Augment Code, go to Settings & MCP Section. Add the
-							following configuration:
-						</p>
-						{@render codeSnippet(`
-    {
-        "mcpServers": {
-            "git-mcp obot": {
-                "command": "npx",
-                "args": [
-                        "mcp-remote",
-                        "${url}"
-                ]
-            }
-        }
-    }
     `)}
 					{/if}
 				</div>

--- a/ui/user/src/lib/components/mcp/RemoteMcpForm.svelte
+++ b/ui/user/src/lib/components/mcp/RemoteMcpForm.svelte
@@ -132,6 +132,7 @@
 							<div class="flex gap-8">
 								<Toggle
 									classes={{ label: 'text-sm text-inherit' }}
+									disabled={readonly}
 									label="Sensitive"
 									labelInline
 									checked={!!header.sensitive}
@@ -143,6 +144,7 @@
 								/>
 								<Toggle
 									classes={{ label: 'text-sm text-inherit' }}
+									disabled={readonly}
 									label="Required"
 									labelInline
 									checked={!!header.required}

--- a/ui/user/src/lib/components/mcp/SingleMultiMcpForm.svelte
+++ b/ui/user/src/lib/components/mcp/SingleMultiMcpForm.svelte
@@ -180,6 +180,7 @@
 								onChange={(checked) => {
 									envs[i].sensitive = checked;
 								}}
+								disabled={readonly}
 							/>
 							<Toggle
 								classes={{ label: 'text-sm text-inherit' }}
@@ -189,6 +190,7 @@
 								onChange={(checked) => {
 									envs[i].required = checked;
 								}}
+								disabled={readonly}
 							/>
 						</div>
 					</div>
@@ -227,6 +229,7 @@
 								onChange={(checked) => {
 									envs[i].sensitive = checked;
 								}}
+								disabled={readonly}
 							/>
 						</div>
 					</div>

--- a/ui/user/src/lib/context/admin/mcpServerAndEntries.svelte.ts
+++ b/ui/user/src/lib/context/admin/mcpServerAndEntries.svelte.ts
@@ -30,7 +30,8 @@ export function initMcpServerAndEntries(mcpServerAndEntries?: AdminMcpServerAndE
 
 export async function fetchMcpServerAndEntries(
 	catalogId: string,
-	mcpServerAndEntries?: AdminMcpServerAndEntriesContext
+	mcpServerAndEntries?: AdminMcpServerAndEntriesContext,
+	onSuccess?: (entries: MCPCatalogEntry[], servers: MCPCatalogServer[]) => void
 ) {
 	const context = mcpServerAndEntries || getAdminMcpServerAndEntries();
 	context.loading = true;
@@ -39,4 +40,8 @@ export async function fetchMcpServerAndEntries(
 	context.entries = entries;
 	context.servers = servers;
 	context.loading = false;
+
+	if (onSuccess) {
+		onSuccess(entries, servers);
+	}
 }

--- a/ui/user/src/routes/mcp-servers/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/+page.svelte
@@ -475,7 +475,7 @@
 	</div>
 {/snippet}
 
-{#snippet connectUrlButton(url: string)}
+{#snippet connectUrlButton(url: string, name: string)}
 	<div class="mb-8 flex flex-col gap-1">
 		<label for="connectURL" class="font-light">Connection URL</label>
 		<div class="mock-input-btn flex w-full items-center justify-between gap-2 shadow-inner">
@@ -492,7 +492,7 @@
 		</div>
 	</div>
 
-	<HowToConnect {url} />
+	<HowToConnect {url} {name} />
 {/snippet}
 
 <ResponsiveDialog bind:this={serverInfoDialog}>
@@ -672,9 +672,15 @@
 	{/snippet}
 
 	{#if connectToEntry?.connectURL}
-		{@render connectUrlButton(connectToEntry.connectURL)}
+		{@render connectUrlButton(
+			connectToEntry.connectURL,
+			connectToEntry.entry.commandManifest?.name ?? connectToEntry.entry.urlManifest?.name ?? ''
+		)}
 	{:else if connectToServer?.connectURL}
-		{@render connectUrlButton(connectToServer.connectURL)}
+		{@render connectUrlButton(
+			connectToServer.connectURL,
+			connectToServer.server.manifest.name ?? ''
+		)}
 	{/if}
 </ResponsiveDialog>
 

--- a/ui/user/src/routes/v2/admin/access-control/+page.svelte
+++ b/ui/user/src/routes/v2/admin/access-control/+page.svelte
@@ -145,7 +145,7 @@
 					class="button-text flex -translate-x-1 items-center gap-2 p-0 text-lg font-light"
 				>
 					<ChevronLeft class="size-6" />
-					Back to Access Control
+					Access Control
 				</button>
 			{/snippet}
 		</AccessControlRuleForm>

--- a/ui/user/src/routes/v2/admin/access-control/[id]/+page.svelte
+++ b/ui/user/src/routes/v2/admin/access-control/[id]/+page.svelte
@@ -1,21 +1,31 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import AccessControlRuleForm from '$lib/components/admin/AccessControlRuleForm.svelte';
+	import BackLink from '$lib/components/admin/BackLink.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import {
 		fetchMcpServerAndEntries,
 		initMcpServerAndEntries
 	} from '$lib/context/admin/mcpServerAndEntries.svelte.js';
-	import { ChevronLeft } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
+	import { browser } from '$app/environment';
 
 	let { data } = $props();
 	const { accessControlRule: initialRule } = data;
 	let accessControlRule = $state(initialRule);
 	const duration = PAGE_TRANSITION_DURATION;
 	const defaultCatalogId = DEFAULT_MCP_CATALOG_ID;
+
+	let fromURL = $state('/v2/admin/access-control');
+
+	onMount(() => {
+		if (browser) {
+			const urlParams = new URLSearchParams(window.location.search);
+			fromURL = urlParams.get('from') || '/access-control';
+		}
+	});
 
 	initMcpServerAndEntries();
 
@@ -33,13 +43,10 @@
 			}}
 		>
 			{#snippet topContent()}
-				<a
-					href={`/v2/admin/access-control`}
-					class="button-text flex -translate-x-1 items-center gap-2 p-0 text-lg font-light"
-				>
-					<ChevronLeft class="size-6" />
-					Back to Access Control
-				</a>
+				<BackLink
+					currentLabel={accessControlRule?.displayName ?? 'Access Control Rule'}
+					{fromURL}
+				/>
 			{/snippet}
 		</AccessControlRuleForm>
 	</div>


### PR DESCRIPTION
Addresses feedback requests from @cjellick:

* when adding an MCP server, there should be an optional for "all" mcp servers similar to how you have the everyone option for users. they payload would be, like
"resources": [{type: "selector", id: "*"}]

* Can you add the MCP server’s icon to the table of mcp servers that the admin sees? I think this will just liven it up a bit

* For entries that are coming from a git source and thus their configuration is grey out, can you add an explanation somewhere on that page stating that the entry isnt editable because it comes from an external source

* For connection examples we have, make the following changes:
Just have cursor, claude, vscode, and cline. Drop the others.

* In the json snippets, you are setting the name to “obot” like { "servers": { "obot": {. That name should something more specific that reflects the server like “playwright”.

* For vs code, you are setting type to SSE. That’s wrong. Just drop type all together for vs code

* On the access control tab, can you make it possible to add and remove a server from existing rules? Dont need to make it possible to Create the rule or modify other parts of the rule, just add and remove.

* remove delete button from catalog entry created from git source URL

* updated/fixed navigation history link (ex > MCP Servers > Puppeteer instead of Back to 'X')

* various quick bugfixes

Addresses #3286 #3269 #3270 #3285 #3295 #3299