### PR TITLE
fix: user deletion: delete more user-scoped resources

### DIFF
--- a/pkg/controller/handlers/accesscontrolrule/helper.go
+++ b/pkg/controller/handlers/accesscontrolrule/helper.go
@@ -19,6 +19,23 @@ func NewAccessControlRuleHelper(acrIndexer gocache.Indexer) *Helper {
 	}
 }
 
+func (h *Helper) GetAccessControlRulesForUser(namespace, userID string) ([]v1.AccessControlRule, error) {
+	acrs, err := h.acrIndexer.ByIndex("user-ids", userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access control rules for user: %w", err)
+	}
+
+	result := make([]v1.AccessControlRule, 0, len(acrs))
+	for _, acr := range acrs {
+		res, ok := acr.(*v1.AccessControlRule)
+		if ok && res.Namespace == namespace {
+			result = append(result, *res)
+		}
+	}
+
+	return result, nil
+}
+
 // GetAccessControlRulesForMCPServer returns all AccessControlRules that contain the specified MCP server name
 func (h *Helper) GetAccessControlRulesForMCPServer(namespace, serverName string) ([]v1.AccessControlRule, error) {
 	acrs, err := h.acrIndexer.ByIndex("server-names", serverName)

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -58,7 +58,7 @@ func (c *Controller) setupRoutes() error {
 	credentialCleanup := cleanup.NewCredentials(c.services.GPTClient, c.services.MCPLoader)
 	projects := projects.NewHandler()
 	runstates := runstates.NewHandler(c.services.GatewayClient)
-	userCleanup := cleanup.NewUserCleanup(c.services.GatewayClient)
+	userCleanup := cleanup.NewUserCleanup(c.services.GatewayClient, c.services.AccessControlRuleHelper)
 	discord := workflow.NewDiscordController(c.services.GPTClient)
 	taskHandler := task.NewHandler()
 	slackReceiverHandler := slackreceiver.NewHandler(c.services.GPTClient, c.services.StorageClient)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -390,6 +390,16 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	}
 
 	if err = informer.AddIndexers(map[string]gocache.IndexFunc{
+		"user-ids": func(obj any) ([]string, error) {
+			acr := obj.(*v1.AccessControlRule)
+			var results []string
+			for _, subject := range acr.Spec.Manifest.Subjects {
+				if subject.Type == apiclienttypes.SubjectTypeUser {
+					results = append(results, subject.ID)
+				}
+			}
+			return results, nil
+		},
 		"catalog-entry-names": func(obj any) ([]string, error) {
 			acr := obj.(*v1.AccessControlRule)
 			var results []string


### PR DESCRIPTION
addresses part of #3301

This PR fixes the user delete handler to delete MCPServerInstances and remove users from AccessControlRules when they are deleted.