### PR TITLE
fix: stop leaking goroutine during MCP OAuth process

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -255,9 +255,10 @@ func (h *handler) callback(req api.Context) error {
 		urlChan:               make(chan string),
 		mcpServerInstanceName: mcpServerConfig.Scope,
 	}
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 
 	go func() {
+		defer close(errChan)
 		_, err := h.mcpSessionManager.ClientForServer(ctx, mcpServer, mcpServerConfig, nmcp.ClientOption{
 			OAuthRedirectURL: fmt.Sprintf("%s/oauth/mcp/callback/%s/%s", h.baseURL, oauthAppAuthRequest.Name, req.PathValue("mcp_server_instance_id")),
 			CallbackHandler:  oauthHandler,


### PR DESCRIPTION
Getting a client during the OAuth process will certainly produce an error because, after we get the authorization URL, we are done with the client. If the channel is unbuffered and there is no reader, then the goroutine will leak.