### PR TITLE
chore: refactor mcpserverinstances

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -68,6 +68,7 @@ type MCPServer struct {
 	MissingRequiredHeaders  []string          `json:"missingRequiredHeader,omitempty"`
 	CatalogEntryID          string            `json:"catalogEntryID"`
 	SharedWithinCatalogName string            `json:"sharedWithinCatalogName,omitempty"`
+	ConnectURL              string            `json:"connectURL,omitempty"`
 }
 
 type MCPServerList List[MCPServer]

--- a/apiclient/types/mcpserverinstance.go
+++ b/apiclient/types/mcpserverinstance.go
@@ -6,13 +6,12 @@ type MCPServerInstance struct {
 	UserID string `json:"userID,omitempty"`
 	// MCPServerID is the ID of the MCP server this instance is associated with.
 	MCPServerID string `json:"mcpServerID,omitempty"`
-	// MCPCatalogID is the ID of the MCP catalog that the server that this instance points to is shared within, if there is one.
-	// If this doesn't point to a shared server, then this will be the catalog that the catalog entry is in, if there is one.
+	// MCPCatalogID is the ID of the MCP catalog that the server that this instance points to is shared within.
 	MCPCatalogID string `json:"mcpCatalogID,omitempty"`
+	// MCPServerCatalogEntryID is the ID of the MCP server catalog entry that the server that this instance points to is based on, if there is one.
+	MCPServerCatalogEntryID string `json:"mcpServerCatalogEntryID,omitempty"`
 	// ConnectURL is the URL to connect to the MCP server.
 	ConnectURL string `json:"connectURL,omitempty"`
-	// MCPServerCatalogEntryID is the ID of the MCP server catalog entry that the server that this instance points to is based on.
-	MCPServerCatalogEntryID string `json:"mcpServerCatalogEntryID,omitempty"`
 }
 
 type MCPServerInstanceList List[MCPServerInstance]

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -62,9 +62,9 @@ var staticRules = map[string][]string{
 		"GET /api/tool-references",
 
 		"GET /.well-known/",
-		"POST /oauth/register/{mcp_server_instance_id}",
-		"GET /oauth/authorize/{mcp_server_instance_id}",
-		"POST /oauth/token/{mcp_server_instance_id}",
+		"POST /oauth/register/{mcp_id}",
+		"GET /oauth/authorize/{mcp_id}",
+		"POST /oauth/token/{mcp_id}",
 	},
 
 	AuthenticatedGroup: {

--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -1,0 +1,35 @@
+package authz
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/obot-platform/nah/pkg/router"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user user.Info) (bool, error) {
+	if resources.MCPID == "" {
+		return true, nil
+	}
+
+	if strings.HasPrefix(resources.MCPID, system.MCPServerInstancePrefix) {
+		var mcpServerInstance v1.MCPServerInstance
+		if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &mcpServerInstance); err != nil {
+			return false, err
+		}
+
+		return mcpServerInstance.Spec.UserID == user.GetUID(), nil
+	}
+
+	var mcpServer v1.MCPServer
+	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &mcpServer); err != nil {
+		return false, err
+	}
+
+	// For servers, we only allow it if the user owns the server.
+	// Shared servers should be interacted with using MCPServerInstances.
+	return mcpServer.Spec.UserID == user.GetUID(), nil
+}

--- a/pkg/api/handlers/mcpgateway/oauth/handler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/handler.go
@@ -30,12 +30,12 @@ func SetupHandlers(gptClient *gptscript.GPTScript, gatewayClient *client.Client,
 		tokenStore:        mcpgateway.NewGlobalTokenStore(gatewayClient),
 	}
 
-	mux.HandleFunc("POST /oauth/register/{mcp_server_instance_id}", h.register)
+	mux.HandleFunc("POST /oauth/register/{mcp_id}", h.register)
 	mux.HandleFunc("GET /oauth/register/{client}", h.readClient)
 	mux.HandleFunc("PUT /oauth/register/{client}", h.updateClient)
 	mux.HandleFunc("DELETE /oauth/register/{client}", h.deleteClient)
-	mux.HandleFunc("GET /oauth/authorize/{mcp_server_instance_id}", h.authorize)
-	mux.HandleFunc("GET /oauth/callback/{oauth_auth_request}/{mcp_server_instance_id}", h.callback)
-	mux.HandleFunc("POST /oauth/token/{mcp_server_instance_id}", h.token)
-	mux.HandleFunc("GET /oauth/mcp/callback/{oauth_auth_request}/{mcp_server_instance_id}", h.oauthCallback)
+	mux.HandleFunc("GET /oauth/authorize/{mcp_id}", h.authorize)
+	mux.HandleFunc("GET /oauth/callback/{oauth_auth_request}/{mcp_id}", h.callback)
+	mux.HandleFunc("POST /oauth/token/{mcp_id}", h.token)
+	mux.HandleFunc("GET /oauth/mcp/callback/{oauth_auth_request}/{mcp_id}", h.oauthCallback)
 }

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -17,11 +17,11 @@ import (
 )
 
 type mcpOAuthHandler struct {
-	client                kclient.Client
-	gptscript             *gptscript.GPTScript
-	stateCache            *stateCache
-	mcpServerInstanceName string
-	urlChan               chan string
+	client     kclient.Client
+	gptscript  *gptscript.GPTScript
+	stateCache *stateCache
+	mcpID      string
+	urlChan    chan string
 }
 
 func (m *mcpOAuthHandler) HandleAuthURL(ctx context.Context, _ string, authURL string) (bool, error) {
@@ -39,7 +39,7 @@ func (m *mcpOAuthHandler) NewState(ctx context.Context, conf *oauth2.Config, ver
 	state := strings.ToLower(rand.Text())
 
 	ch := make(chan nmcp.CallbackPayload)
-	return state, ch, m.stateCache.store(ctx, m.mcpServerInstanceName, state, verifier, conf, ch)
+	return state, ch, m.stateCache.store(ctx, m.mcpID, state, verifier, conf, ch)
 }
 
 func (m *mcpOAuthHandler) Lookup(ctx context.Context, authServerURL string) (string, string, error) {

--- a/pkg/api/handlers/mcpgateway/tokenstore.go
+++ b/pkg/api/handlers/mcpgateway/tokenstore.go
@@ -12,7 +12,7 @@ import (
 )
 
 type GlobalTokenStore interface {
-	ForServerInstance(serverInstanceName string) nmcp.TokenStorage
+	ForMCPID(mcpID string) nmcp.TokenStorage
 }
 
 func NewGlobalTokenStore(gatewayClient *gateway.Client) GlobalTokenStore {
@@ -25,20 +25,20 @@ type globalTokenStore struct {
 	gatewayClient *gateway.Client
 }
 
-func (g *globalTokenStore) ForServerInstance(serverInstanceName string) nmcp.TokenStorage {
+func (g *globalTokenStore) ForMCPID(mcpID string) nmcp.TokenStorage {
 	return &tokenStore{
-		gatewayClient:         g.gatewayClient,
-		mcpServerInstanceName: serverInstanceName,
+		gatewayClient: g.gatewayClient,
+		mcpID:         mcpID,
 	}
 }
 
 type tokenStore struct {
-	gatewayClient         *gateway.Client
-	mcpServerInstanceName string
+	gatewayClient *gateway.Client
+	mcpID         string
 }
 
 func (t *tokenStore) GetTokenConfig(ctx context.Context, _ string) (*oauth2.Config, *oauth2.Token, error) {
-	mcpToken, err := t.gatewayClient.GetMCPOAuthToken(ctx, t.mcpServerInstanceName)
+	mcpToken, err := t.gatewayClient.GetMCPOAuthToken(ctx, t.mcpID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil, nil
@@ -69,5 +69,5 @@ func (t *tokenStore) GetTokenConfig(ctx context.Context, _ string) (*oauth2.Conf
 }
 
 func (t *tokenStore) SetTokenConfig(ctx context.Context, _ string, config *oauth2.Config, token *oauth2.Token) error {
-	return t.gatewayClient.ReplaceMCPOAuthToken(ctx, t.mcpServerInstanceName, "", "", config, token)
+	return t.gatewayClient.ReplaceMCPOAuthToken(ctx, t.mcpID, "", "", config, token)
 }

--- a/pkg/api/handlers/wellknown/handler.go
+++ b/pkg/api/handlers/wellknown/handler.go
@@ -16,8 +16,8 @@ func SetupHandlers(baseURL string, config services.OAuthAuthorizationServerConfi
 		config:  config,
 	}
 
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource/{mcp_server_instance_id}", h.oauthProtectedResource)
-	mux.HandleFunc("GET /.well-known/oauth-authorization-server/{mcp_server_instance_id}", h.oauthAuthorization)
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/{mcp_id}", h.oauthProtectedResource)
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server/{mcp_id}", h.oauthAuthorization)
 
 	return nil
 }

--- a/pkg/api/handlers/wellknown/oauth.go
+++ b/pkg/api/handlers/wellknown/oauth.go
@@ -9,10 +9,10 @@ import (
 // oauthAuthorization handles the /.well-known/oauth-authorization-server endpoint
 func (h *handler) oauthAuthorization(req api.Context) error {
 	config := h.config
-	config.Issuer = fmt.Sprintf("%s/%s", h.baseURL, req.PathValue("mcp_server_instance_id"))
-	config.AuthorizationEndpoint = fmt.Sprintf("%s/oauth/authorize/%s", h.baseURL, req.PathValue("mcp_server_instance_id"))
-	config.TokenEndpoint = fmt.Sprintf("%s/oauth/token/%s", h.baseURL, req.PathValue("mcp_server_instance_id"))
-	config.RegistrationEndpoint = fmt.Sprintf("%s/oauth/register/%s", h.baseURL, req.PathValue("mcp_server_instance_id"))
+	config.Issuer = fmt.Sprintf("%s/%s", h.baseURL, req.PathValue("mcp_id"))
+	config.AuthorizationEndpoint = fmt.Sprintf("%s/oauth/authorize/%s", h.baseURL, req.PathValue("mcp_id"))
+	config.TokenEndpoint = fmt.Sprintf("%s/oauth/token/%s", h.baseURL, req.PathValue("mcp_id"))
+	config.RegistrationEndpoint = fmt.Sprintf("%s/oauth/register/%s", h.baseURL, req.PathValue("mcp_id"))
 	return req.Write(config)
 }
 
@@ -22,5 +22,5 @@ func (h *handler) oauthProtectedResource(req api.Context) error {
 	"resource": "%s/mcp-connect/%s",
 	"authorization_servers": ["%[1]s/%[2]s"],
 	"bearer_methods_supported": ["header"]
-}`, h.baseURL, req.PathValue("mcp_server_instance_id")))
+}`, h.baseURL, req.PathValue("mcp_id")))
 }

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -142,7 +142,7 @@ func (s *Server) Wrap(f api.HandlerFunc) http.HandlerFunc {
 			}
 
 			if strings.HasPrefix(req.URL.Path, "/mcp-connect/") {
-				rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_request", error_description="Invalid access token", resource_metadata="%s/.well-known/oauth-protected-resource/%s"`, strings.TrimSuffix(s.baseURL, "/api"), req.PathValue("mcp_server_instance_id")))
+				rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_request", error_description="Invalid access token", resource_metadata="%s/.well-known/oauth-protected-resource/%s"`, strings.TrimSuffix(s.baseURL, "/api"), req.PathValue("mcp_id")))
 			}
 
 			if slices.Contains(user.GetGroups(), authz.UnauthenticatedGroup) {

--- a/pkg/controller/handlers/cleanup/credentials.go
+++ b/pkg/controller/handlers/cleanup/credentials.go
@@ -142,6 +142,10 @@ func (c *Credentials) removeMCPCredentialsForProject(req router.Request, _ route
 func (c *Credentials) RemoveMCPCredentials(req router.Request, resp router.Response) error {
 	mcpServer := req.Object.(*v1.MCPServer)
 
+	if err := c.gatewayClient.DeleteMCPOAuthToken(req.Ctx, req.Object.GetName()); err != nil {
+		return err
+	}
+
 	if mcpServer.Spec.ThreadName != "" {
 		return c.removeMCPCredentialsForProject(req, resp)
 	}

--- a/pkg/controller/handlers/mcpserverinstance/mcpserverinstance.go
+++ b/pkg/controller/handlers/mcpserverinstance/mcpserverinstance.go
@@ -4,7 +4,6 @@ import (
 	"github.com/obot-platform/nah/pkg/router"
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Handler struct {
@@ -17,43 +16,23 @@ func New(gatewayClient *gateway.Client) *Handler {
 	}
 }
 
-// Migrate makes sure that all spec fields are set properly.
-func (h *Handler) Migrate(req router.Request, _ router.Response) error {
+func (h *Handler) RemoveOAuthToken(req router.Request, _ router.Response) error {
+	return h.gatewayClient.DeleteMCPOAuthToken(req.Ctx, req.Object.GetName())
+}
+
+func (h *Handler) MigrationDeleteSingleUserInstances(req router.Request, _ router.Response) error {
 	instance := req.Object.(*v1.MCPServerInstance)
 
-	// Check to see if we need to update.
-	// Pre-migration, if there is a catalog name, it points to a shared server, and we don't need to add any new information.
-	if instance.Spec.MCPCatalogName != "" {
-		return nil
-	}
-
 	var server v1.MCPServer
-	if err := req.Client.Get(req.Ctx, client.ObjectKey{
-		Namespace: instance.Namespace,
-		Name:      instance.Spec.MCPServerName,
-	}, &server); err != nil {
+	if err := req.Get(&server, req.Namespace, instance.Spec.MCPServerName); err != nil {
 		return err
 	}
 
-	if server.Spec.MCPServerCatalogEntryName == "" {
-		instance.Spec.MCPServerCatalogEntryName = server.Spec.MCPServerCatalogEntryName
-
-		var entry v1.MCPServerCatalogEntry
-		if err := req.Client.Get(req.Ctx, client.ObjectKey{
-			Namespace: instance.Namespace,
-			Name:      instance.Spec.MCPServerCatalogEntryName,
-		}, &entry); err != nil {
-			return err
-		}
-
-		instance.Spec.MCPCatalogName = entry.Spec.MCPCatalogName
-
-		return req.Client.Update(req.Ctx, instance)
+	if server.Spec.SharedWithinMCPCatalogName == "" {
+		// This server is unshared, so it should not have any server instances.
+		// Delete this instance.
+		return req.Delete(instance)
 	}
 
 	return nil
-}
-
-func (h *Handler) RemoveOAuthToken(req router.Request, _ router.Response) error {
-	return h.gatewayClient.DeleteMCPOAuthToken(req.Ctx, req.Object.GetName())
 }

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -234,7 +234,7 @@ func (c *Controller) setupRoutes() error {
 
 	// MCPServerInstance
 	root.Type(&v1.MCPServerInstance{}).HandlerFunc(cleanup.Cleanup)
-	root.Type(&v1.MCPServerInstance{}).HandlerFunc(mcpserverinstance.Migrate)
+	root.Type(&v1.MCPServerInstance{}).HandlerFunc(mcpserverinstance.MigrationDeleteSingleUserInstances)
 	root.Type(&v1.MCPServerInstance{}).FinalizeFunc(v1.MCPServerInstanceFinalizer, mcpserverinstance.RemoveOAuthToken)
 
 	// ProjectInvitations

--- a/pkg/gateway/client/mcpoauthtoken.go
+++ b/pkg/gateway/client/mcpoauthtoken.go
@@ -20,9 +20,9 @@ var mcpOAuthTokenGroupResource = schema.GroupResource{
 	Resource: "mcpoauthtokens",
 }
 
-func (c *Client) GetMCPOAuthToken(ctx context.Context, mcpServerInstanceName string) (*types.MCPOAuthToken, error) {
+func (c *Client) GetMCPOAuthToken(ctx context.Context, mcpID string) (*types.MCPOAuthToken, error) {
 	token := new(types.MCPOAuthToken)
-	err := c.db.WithContext(ctx).Where("mcp_server_instance = ?", mcpServerInstanceName).First(token).Error
+	err := c.db.WithContext(ctx).Where("mcp_id = ?", mcpID).First(token).Error
 	if err != nil {
 		return nil, err
 	}
@@ -48,21 +48,21 @@ func (c *Client) GetMCPOAuthTokenByState(ctx context.Context, state string) (*ty
 	return token, nil
 }
 
-func (c *Client) ReplaceMCPOAuthToken(ctx context.Context, mcpServerInstanceName, state, verifier string, oauthConf *oauth2.Config, token *oauth2.Token) error {
+func (c *Client) ReplaceMCPOAuthToken(ctx context.Context, mcpID, state, verifier string, oauthConf *oauth2.Config, token *oauth2.Token) error {
 	t := &types.MCPOAuthToken{
-		MCPServerInstance: mcpServerInstanceName,
-		State:             state,
-		Verifier:          verifier,
-		AccessToken:       token.AccessToken,
-		TokenType:         token.TokenType,
-		RefreshToken:      token.RefreshToken,
-		Expiry:            token.Expiry,
-		ExpiresIn:         token.ExpiresIn,
-		ClientID:          oauthConf.ClientID,
-		ClientSecret:      oauthConf.ClientSecret,
-		Endpoint:          oauthConf.Endpoint,
-		RedirectURL:       oauthConf.RedirectURL,
-		Scopes:            strings.Join(oauthConf.Scopes, " "),
+		MCPID:        mcpID,
+		State:        state,
+		Verifier:     verifier,
+		AccessToken:  token.AccessToken,
+		TokenType:    token.TokenType,
+		RefreshToken: token.RefreshToken,
+		Expiry:       token.Expiry,
+		ExpiresIn:    token.ExpiresIn,
+		ClientID:     oauthConf.ClientID,
+		ClientSecret: oauthConf.ClientSecret,
+		Endpoint:     oauthConf.Endpoint,
+		RedirectURL:  oauthConf.RedirectURL,
+		Scopes:       strings.Join(oauthConf.Scopes, " "),
 	}
 
 	if state != "" {
@@ -76,8 +76,8 @@ func (c *Client) ReplaceMCPOAuthToken(ctx context.Context, mcpServerInstanceName
 	return c.db.WithContext(ctx).Save(t).Error
 }
 
-func (c *Client) DeleteMCPOAuthToken(ctx context.Context, mcpServerInstanceName string) error {
-	if err := c.db.WithContext(ctx).Delete(&types.MCPOAuthToken{MCPServerInstance: mcpServerInstanceName}).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+func (c *Client) DeleteMCPOAuthToken(ctx context.Context, mcpID string) error {
+	if err := c.db.WithContext(ctx).Delete(&types.MCPOAuthToken{MCPID: mcpID}).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
 		return err
 	}
 	return nil
@@ -231,5 +231,5 @@ func (c *Client) decryptMCPOAuthToken(ctx context.Context, token *types.MCPOAuth
 }
 
 func mcpOAuthTokenCtx(token *types.MCPOAuthToken) value.Context {
-	return value.DefaultContext(fmt.Sprintf("%s/%s", mcpOAuthTokenGroupResource.String(), token.MCPServerInstance))
+	return value.DefaultContext(fmt.Sprintf("%s/%s", mcpOAuthTokenGroupResource.String(), token.MCPID))
 }

--- a/pkg/gateway/types/tokens.go
+++ b/pkg/gateway/types/tokens.go
@@ -40,12 +40,12 @@ type MCPOAuthToken struct {
 	HashedState *string `gorm:"unique"`
 	Verifier    string
 
-	MCPServerInstance string `gorm:"primaryKey"`
-	AccessToken       string
-	TokenType         string
-	RefreshToken      string
-	Expiry            time.Time
-	ExpiresIn         int64
+	MCPID        string `gorm:"primaryKey"`
+	AccessToken  string
+	TokenType    string
+	RefreshToken string
+	Expiry       time.Time
+	ExpiresIn    int64
 
 	Encrypted bool
 }

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserverinstance.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserverinstance.go
@@ -59,10 +59,9 @@ type MCPServerInstanceSpec struct {
 	UserID string `json:"userID,omitempty"`
 	// MCPServerName is the name of the MCP server this instance is associated with.
 	MCPServerName string `json:"mcpServerName,omitempty"`
-	// MCPCatalogName is the name of the MCP catalog that the server that this instance points to is shared within, if there is one.
-	// If there is not one, then this field will be set to the catalog that the Spec.MCPServerCatalogEntryName is in.
+	// MCPCatalogName is the name of the MCP catalog that the server that this instance points to is shared within
 	MCPCatalogName string `json:"mcpCatalogName,omitempty"`
-	// MCPServerCatalogEntryName is the name of the MCP server catalog entry that the server that this instance points to is based on.
+	// MCPServerCatalogEntryName is the name of the MCP server catalog entry that the server that this instance points to is based on, if there is one.
 	MCPServerCatalogEntryName string `json:"mcpServerCatalogEntryName,omitempty"`
 }
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2778,6 +2778,12 @@ func schema_obot_platform_obot_apiclient_types_MCPServer(ref common.ReferenceCal
 							Format: "",
 						},
 					},
+					"connectURL": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"Metadata", "manifest", "configured", "catalogEntryID"},
 			},
@@ -3018,7 +3024,14 @@ func schema_obot_platform_obot_apiclient_types_MCPServerInstance(ref common.Refe
 					},
 					"mcpCatalogID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MCPCatalogID is the ID of the MCP catalog that the server that this instance points to is shared within, if there is one. If this doesn't point to a shared server, then this will be the catalog that the catalog entry is in, if there is one.",
+							Description: "MCPCatalogID is the ID of the MCP catalog that the server that this instance points to is shared within.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"mcpServerCatalogEntryID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MCPServerCatalogEntryID is the ID of the MCP server catalog entry that the server that this instance points to is based on, if there is one.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3026,13 +3039,6 @@ func schema_obot_platform_obot_apiclient_types_MCPServerInstance(ref common.Refe
 					"connectURL": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConnectURL is the URL to connect to the MCP server.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"mcpServerCatalogEntryID": {
-						SchemaProps: spec.SchemaProps{
-							Description: "MCPServerCatalogEntryID is the ID of the MCP server catalog entry that the server that this instance points to is based on.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -9944,14 +9950,14 @@ func schema_storage_apis_obotobotai_v1_MCPServerInstanceSpec(ref common.Referenc
 					},
 					"mcpCatalogName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MCPCatalogName is the name of the MCP catalog that the server that this instance points to is shared within, if there is one. If there is not one, then this field will be set to the catalog that the Spec.MCPServerCatalogEntryName is in.",
+							Description: "MCPCatalogName is the name of the MCP catalog that the server that this instance points to is shared within",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"mcpServerCatalogEntryName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MCPServerCatalogEntryName is the name of the MCP server catalog entry that the server that this instance points to is based on.",
+							Description: "MCPServerCatalogEntryName is the name of the MCP server catalog entry that the server that this instance points to is based on, if there is one.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
This refactors MCPServerInstances so that they are used **only** for shared (multi-user) servers, and for nothing else.

So now, for single-user/remote servers, the user only has to create an MCPServer, and that will have the connect URL on it immediately. There is no need (and in fact, you aren't allowed) to create an MCPServerInstance for it.