### PR TITLE
chore: bump nanobot for mcp session init fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/gptscript-ai/gptscript v0.9.6-0.20250623175741-7a49337eef7b
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/mhale/smtpd v0.8.3
-	github.com/nanobot-ai/nanobot v0.0.6-0.20250708021654-6ff874bc6980
+	github.com/nanobot-ai/nanobot v0.0.6-0.20250708194048-f0a6fc56c15f
 	github.com/obot-platform/kinm v0.0.0-20250328185534-d9c9de49cc20
 	github.com/obot-platform/nah v0.0.0-20250418220644-1b9278409317
 	github.com/obot-platform/namegenerator v0.0.0-20241217121223-fc58bdb7dca2

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/nanobot-ai/nanobot v0.0.6-0.20250708021654-6ff874bc6980 h1:SVS0DlUVklefZ+qVvtlaw9ixUjdnfwPexazUSx2X6V8=
-github.com/nanobot-ai/nanobot v0.0.6-0.20250708021654-6ff874bc6980/go.mod h1:Kr1V82hwgbsw6cFy6/U8pskwjGFGMi2YQ4IAu4t4fg0=
+github.com/nanobot-ai/nanobot v0.0.6-0.20250708194048-f0a6fc56c15f h1:Q3R40Cu4c5lN4DZAFkaI+nuEH8Pj7YVDHW6ryBYu0ww=
+github.com/nanobot-ai/nanobot v0.0.6-0.20250708194048-f0a6fc56c15f/go.mod h1:Kr1V82hwgbsw6cFy6/U8pskwjGFGMi2YQ4IAu4t4fg0=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nwaples/rardecode/v2 v2.1.0 h1:JQl9ZoBPDy+nIZGb1mx8+anfHp/LV3NE2MjMiv0ct/U=


### PR DESCRIPTION
Bump the nanobot module to pick up the fix ensuring capabilities are saved to sessions.

Fixes https://github.com/obot-platform/obot/issues/3334

