### PR TITLE
fix: make mcp oauth callback URL static

### DIFF
--- a/apiclient/types/oauthapp.go
+++ b/apiclient/types/oauthapp.go
@@ -46,7 +46,8 @@ type OAuthAppManifest struct {
 	InstanceURL string `json:"instanceURL,omitempty"`
 	// This field is used for GitLab enterprise instances
 	GitLabBaseURL string `json:"gitlabBaseURL,omitempty"`
-	DefaultScope  string `json:"defaultScope,omitempty"`
+	// AuthorizationServerURL is the URL used in the MCP oauth flow
+	AuthorizationServerURL string `json:"authorizationServerURL,omitempty"`
 }
 
 type OAuthAppList List[OAuthApp]

--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -15,7 +15,7 @@ var apiResources = []string{
 	"GET    /api/all-mcp-catalogs/servers/{mcpserver_id}/prompts",
 	"GET    /api/all-mcp-catalogs/servers/{mcpserver_id}/prompts/{prompt_name}",
 	"GET    /oauth/callback/{oauth_request_id}/{mcp_id}",
-	"GET    /oauth/mcp/callback/{oauth_request_id}/{mcp_id}",
+	"GET    /oauth/mcp/callback",
 	"GET    /mcp-connect/{mcp_id}",
 	"POST   /mcp-connect/{mcp_id}",
 	"DELETE /mcp-connect/{mcp_id}",

--- a/pkg/api/handlers/mcpgateway/oauth/handler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/handler.go
@@ -32,5 +32,5 @@ func SetupHandlers(gatewayClient *client.Client, mcpSessionManager *mcp.SessionM
 	mux.HandleFunc("GET /oauth/authorize/{mcp_id}", h.authorize)
 	mux.HandleFunc("GET /oauth/callback/{oauth_auth_request}/{mcp_id}", h.callback)
 	mux.HandleFunc("POST /oauth/token/{mcp_id}", h.token)
-	mux.HandleFunc("GET /oauth/mcp/callback/{oauth_auth_request}/{mcp_id}", h.oauthCallback)
+	mux.HandleFunc("GET /oauth/mcp/callback", h.oauthCallback)
 }

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -17,11 +17,12 @@ import (
 )
 
 type mcpOAuthHandler struct {
-	client     kclient.Client
-	gptscript  *gptscript.GPTScript
-	stateCache *stateCache
-	mcpID      string
-	urlChan    chan string
+	client             kclient.Client
+	gptscript          *gptscript.GPTScript
+	stateCache         *stateCache
+	mcpID              string
+	oauthAuthRequestID string
+	urlChan            chan string
 }
 
 func (m *mcpOAuthHandler) HandleAuthURL(ctx context.Context, _ string, authURL string) (bool, error) {
@@ -39,14 +40,14 @@ func (m *mcpOAuthHandler) NewState(ctx context.Context, conf *oauth2.Config, ver
 	state := strings.ToLower(rand.Text())
 
 	ch := make(chan nmcp.CallbackPayload)
-	return state, ch, m.stateCache.store(ctx, m.mcpID, state, verifier, conf, ch)
+	return state, ch, m.stateCache.store(ctx, m.mcpID, m.oauthAuthRequestID, state, verifier, conf, ch)
 }
 
 func (m *mcpOAuthHandler) Lookup(ctx context.Context, authServerURL string) (string, string, error) {
 	var oauthApps v1.OAuthAppList
 	if err := m.client.List(ctx, &oauthApps, &kclient.ListOptions{
 		FieldSelector: fields.SelectorFromSet(map[string]string{
-			"spec.authorizationServerURL": authServerURL,
+			"spec.manifest.authorizationServerURL": authServerURL,
 		}),
 		Namespace: system.DefaultNamespace,
 	}); err != nil {

--- a/pkg/api/handlers/mcpgateway/tokenstore.go
+++ b/pkg/api/handlers/mcpgateway/tokenstore.go
@@ -69,5 +69,5 @@ func (t *tokenStore) GetTokenConfig(ctx context.Context, _ string) (*oauth2.Conf
 }
 
 func (t *tokenStore) SetTokenConfig(ctx context.Context, _ string, config *oauth2.Config, token *oauth2.Token) error {
-	return t.gatewayClient.ReplaceMCPOAuthToken(ctx, t.mcpID, "", "", config, token)
+	return t.gatewayClient.ReplaceMCPOAuthToken(ctx, t.mcpID, "", "", "", config, token)
 }

--- a/pkg/gateway/client/mcpoauthtoken.go
+++ b/pkg/gateway/client/mcpoauthtoken.go
@@ -48,21 +48,22 @@ func (c *Client) GetMCPOAuthTokenByState(ctx context.Context, state string) (*ty
 	return token, nil
 }
 
-func (c *Client) ReplaceMCPOAuthToken(ctx context.Context, mcpID, state, verifier string, oauthConf *oauth2.Config, token *oauth2.Token) error {
+func (c *Client) ReplaceMCPOAuthToken(ctx context.Context, mcpID, oauthAuthRequestID, state, verifier string, oauthConf *oauth2.Config, token *oauth2.Token) error {
 	t := &types.MCPOAuthToken{
-		MCPID:        mcpID,
-		State:        state,
-		Verifier:     verifier,
-		AccessToken:  token.AccessToken,
-		TokenType:    token.TokenType,
-		RefreshToken: token.RefreshToken,
-		Expiry:       token.Expiry,
-		ExpiresIn:    token.ExpiresIn,
-		ClientID:     oauthConf.ClientID,
-		ClientSecret: oauthConf.ClientSecret,
-		Endpoint:     oauthConf.Endpoint,
-		RedirectURL:  oauthConf.RedirectURL,
-		Scopes:       strings.Join(oauthConf.Scopes, " "),
+		MCPID:              mcpID,
+		OAuthAuthRequestID: oauthAuthRequestID,
+		State:              state,
+		Verifier:           verifier,
+		AccessToken:        token.AccessToken,
+		TokenType:          token.TokenType,
+		RefreshToken:       token.RefreshToken,
+		Expiry:             token.Expiry,
+		ExpiresIn:          token.ExpiresIn,
+		ClientID:           oauthConf.ClientID,
+		ClientSecret:       oauthConf.ClientSecret,
+		Endpoint:           oauthConf.Endpoint,
+		RedirectURL:        oauthConf.RedirectURL,
+		Scopes:             strings.Join(oauthConf.Scopes, " "),
 	}
 
 	if state != "" {

--- a/pkg/gateway/types/tokens.go
+++ b/pkg/gateway/types/tokens.go
@@ -40,12 +40,13 @@ type MCPOAuthToken struct {
 	HashedState *string `gorm:"unique"`
 	Verifier    string
 
-	MCPID        string `gorm:"primaryKey"`
-	AccessToken  string
-	TokenType    string
-	RefreshToken string
-	Expiry       time.Time
-	ExpiresIn    int64
+	MCPID              string `gorm:"primaryKey"`
+	OAuthAuthRequestID string `gorm:"index"`
+	AccessToken        string
+	TokenType          string
+	RefreshToken       string
+	Expiry             time.Time
+	ExpiresIn          int64
 
 	Encrypted bool
 }

--- a/pkg/storage/apis/obot.obot.ai/v1/oauthapp.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/oauthapp.go
@@ -58,6 +58,8 @@ func (r *OAuthApp) Get(field string) string {
 			return r.Spec.ThreadName
 		case "spec.slackReceiverName":
 			return r.Spec.SlackReceiverName
+		case "spec.manifest.authorizationServerURL":
+			return r.Spec.Manifest.AuthorizationServerURL
 		}
 	}
 
@@ -65,7 +67,7 @@ func (r *OAuthApp) Get(field string) string {
 }
 
 func (r *OAuthApp) FieldNames() []string {
-	return []string{"spec.manifest.alias", "spec.threadName", "spec.slackReceiverName"}
+	return []string{"spec.manifest.alias", "spec.threadName", "spec.slackReceiverName", "spec.manifest.authorizationServerURL"}
 }
 
 func (r *OAuthApp) RedirectURL(baseURL string) string {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -3910,10 +3910,11 @@ func schema_obot_platform_obot_apiclient_types_OAuthAppManifest(ref common.Refer
 							Format:      "",
 						},
 					},
-					"defaultScope": {
+					"authorizationServerURL": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "AuthorizationServerURL is the URL used in the MCP oauth flow",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},


### PR DESCRIPTION
This URL needs to be static for authorization servers that don't support dynamic client authorization. Clients for such servers need to be created in advance, and having a dynamic callback URL is not feasible.