### PR TITLE
fix: get connection url on mcp card not working

### DIFF
--- a/ui/user/src/routes/mcp-servers/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/+page.svelte
@@ -447,6 +447,10 @@
 					<button
 						class="menu-button"
 						onclick={() => {
+							connectToEntry = undefined;
+							connectToServer = {
+								...connectedServer
+							};
 							connectDialog?.open();
 						}}
 					>


### PR DESCRIPTION
* apologies, fixes the 'Get Connection URL' on the mcp card '...' options to work again!