### PR TITLE
feat: add k8s info for servers in catalog entry/server admin tabs

### DIFF
--- a/ui/user/src/lib/components/admin/AuditDetails.svelte
+++ b/ui/user/src/lib/components/admin/AuditDetails.svelte
@@ -439,6 +439,8 @@
 						{:else}
 							{d.client.name}/{d.client.version}
 						{/if}
+					{:else if property === 'createdAt'}
+						{new Date(d.createdAt).toISOString()}
 					{:else}
 						{d[property as keyof typeof d]}
 					{/if}

--- a/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+	import { AdminService, type K8sServerDetail } from '$lib/services';
+	import { EventStreamService } from '$lib/services/admin/eventstream.svelte';
+	import { formatTimeAgo } from '$lib/time';
+	import { AlertTriangle, Info, LoaderCircle } from 'lucide-svelte';
+	import { onDestroy, onMount } from 'svelte';
+	import Table from '../Table.svelte';
+	import { fade } from 'svelte/transition';
+	import { tooltip } from '$lib/actions/tooltip.svelte';
+
+	interface Props {
+		mcpServerId: string;
+		name: string;
+		mcpServerInstanceId?: string;
+	}
+
+	const { mcpServerId, mcpServerInstanceId, name }: Props = $props();
+
+	let listK8sInfo = $state<Promise<K8sServerDetail>>();
+	let messages = $state<string[]>([]);
+	let error = $state<string>();
+	let logsContainer: HTMLDivElement;
+
+	const eventStream = new EventStreamService<string>();
+
+	function isScrolledToBottom(element: HTMLElement): boolean {
+		return Math.abs(element.scrollHeight - element.clientHeight - element.scrollTop) < 10;
+	}
+
+	function scrollToBottom(element: HTMLElement) {
+		element.scrollTop = element.scrollHeight;
+	}
+
+	function handleScroll() {
+		if (logsContainer) {
+			const wasAtBottom = isScrolledToBottom(logsContainer);
+			if (wasAtBottom) {
+				setTimeout(() => scrollToBottom(logsContainer), 0);
+			}
+		}
+	}
+
+	onMount(() => {
+		listK8sInfo = AdminService.getK8sServerDetail(mcpServerId);
+		eventStream.connect(`/api/mcp-servers/${mcpServerId}/logs`, {
+			onMessage: (data) => {
+				messages = [...messages, data];
+				// Trigger auto-scroll after adding new message
+				handleScroll();
+			},
+			onOpen: () => {
+				console.debug(`${mcpServerId} event stream opened`);
+				error = undefined;
+			},
+			onError: () => {
+				error = 'Connection failed';
+			},
+			onClose: () => {
+				console.debug(`${mcpServerId} event stream closed`);
+			}
+		});
+	});
+
+	onDestroy(() => {
+		eventStream.disconnect();
+	});
+
+	function compileK8sInfo(info?: K8sServerDetail) {
+		if (!info) return [];
+		const details = [
+			{
+				id: 'kubernetes_deployments',
+				label: 'Kubernetes Deployment',
+				value: `${info.namespace}/${info.deploymentName}`
+			},
+			{
+				id: 'last_restart',
+				label: 'Last Restart',
+				value: formatTimeAgo(info.lastRestart).relativeTime
+			},
+			{
+				id: 'status',
+				label: 'Status',
+				value: info.isAvailable ? 'Healthy' : 'Unhealthy'
+			}
+		];
+		return details;
+	}
+</script>
+
+<h1 class="text-2xl font-semibold">
+	{#if mcpServerInstanceId}
+		{name} | {mcpServerInstanceId}
+	{:else}
+		{name}
+	{/if}
+</h1>
+
+{#if mcpServerInstanceId}
+	<div class="notification-info p-3 text-sm font-light">
+		<div class="flex items-center gap-3">
+			<Info class="size-6" />
+			<p>
+				This is a multi-user server instance. The server information displayed here is the root
+				server that is shared between all server instances.
+			</p>
+		</div>
+	</div>
+{/if}
+
+{#await listK8sInfo}
+	<div class="flex w-full justify-center">
+		<LoaderCircle class="size-6 animate-spin" />
+	</div>
+{:then info}
+	{@const k8sInfo = compileK8sInfo(info)}
+	<div class="flex flex-col gap-2">
+		{#each k8sInfo as detail (detail.id)}
+			<div
+				class="dark:bg-surface1 dark:border-surface3 flex flex-col rounded-lg border border-transparent bg-white p-4 shadow-sm"
+			>
+				<div class="grid grid-cols-12 gap-4">
+					<p class="col-span-4 text-sm font-semibold">{detail.label}</p>
+					<p class="col-span-8 truncate text-sm font-light">{detail.value}</p>
+				</div>
+			</div>
+		{/each}
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-lg font-semibold">Events</h2>
+		{#if info?.events && info.events.length > 0}
+			{@const tableData = info.events.map((event) => ({
+				id: event.time,
+				...event
+			}))}
+			<Table
+				data={tableData}
+				fields={['time', 'eventType', 'message']}
+				headers={[{ title: 'Event Type', property: 'eventType' }]}
+			>
+				{#snippet onRenderColumn(property, d)}
+					{#if property === 'time'}
+						{formatTimeAgo(d.time).fullDate}
+					{:else}
+						{d[property as keyof typeof d]}
+					{/if}
+				{/snippet}
+			</Table>
+		{:else}
+			<span class="text-sm font-light text-gray-400 dark:text-gray-600">No events.</span>
+		{/if}
+	</div>
+{:catch error}
+	{@const isPending = error instanceof Error && error.message.includes('ContainerCreating')}
+	<div class="flex flex-col gap-2">
+		<div
+			class="dark:bg-surface1 dark:border-surface3 flex flex-col rounded-lg border border-transparent bg-white p-4 shadow-sm"
+		>
+			<div class="grid grid-cols-2 gap-4">
+				<p class="text-sm font-semibold">Status</p>
+				<p class="text-sm font-light">{isPending ? 'Pending' : 'Error'}</p>
+			</div>
+		</div>
+	</div>
+{/await}
+
+<div>
+	<div class="mb-2 flex items-center gap-2">
+		<h2 class=" text-lg font-semibold">Deployment Logs</h2>
+		{#if error}
+			<div
+				use:tooltip={`An error occurred in connecting to the event stream. This is normal if the server is still starting up.`}
+			>
+				<AlertTriangle class="size-4 text-yellow-500" />
+			</div>
+		{/if}
+	</div>
+	<div
+		bind:this={logsContainer}
+		class="dark:bg-surface1 dark:border-surface3 default-scrollbar-thin flex max-h-84 min-h-64 flex-col overflow-y-auto rounded-lg border border-transparent bg-white p-4 shadow-sm"
+	>
+		{#if messages.length > 0}
+			<div class="space-y-2">
+				{#each messages as message, i (i)}
+					<div class="font-mono text-sm" in:fade>
+						<span class="text-gray-600 dark:text-gray-400">{message}</span>
+					</div>
+				{/each}
+			</div>
+		{:else}
+			<span class="text-sm font-light text-gray-400 dark:text-gray-600">No deployment logs.</span>
+		{/if}
+	</div>
+</div>

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -121,11 +121,11 @@
 							<div class="flex flex-col px-2 pb-2 text-xs" in:slide={{ axis: 'y' }}>
 								<div class="flex flex-col gap-2">
 									{#each Object.keys(tool.params ?? {}) as paramKey (paramKey)}
-										<div class="flex flex-col items-center gap-2 md:flex-row">
+										<div class="flex flex-col items-center gap-2">
 											<p class="self-start font-semibold text-gray-500">
 												{paramKey}
 											</p>
-											<p class="self-start font-light text-gray-500">
+											<p class="self-start pl-4 font-light text-gray-500">
 												{tool.params?.[paramKey]}
 											</p>
 										</div>

--- a/ui/user/src/lib/services/admin/eventstream.svelte.ts
+++ b/ui/user/src/lib/services/admin/eventstream.svelte.ts
@@ -1,0 +1,55 @@
+export class EventStreamService<T> {
+	private eventSource: EventSource | null = null;
+
+	connect(
+		url: string,
+		options?: {
+			onMessage?: (data: T) => void;
+			onOpen?: () => void;
+			onError?: (error: Event) => void;
+			onClose?: () => void;
+		}
+	) {
+		this.eventSource = new EventSource(url);
+
+		this.eventSource.onmessage = (event) => {
+			try {
+				const data = JSON.parse(event.data);
+				options?.onMessage?.(data);
+			} catch (_error) {
+				options?.onMessage?.(event.data as T);
+			}
+		};
+
+		// Handle custom event types (like 'log', 'ping', etc.)
+		this.eventSource.addEventListener('log', (event) => {
+			try {
+				const data = JSON.parse(event.data);
+				options?.onMessage?.(data);
+			} catch (_error) {
+				options?.onMessage?.(event.data as T);
+			}
+		});
+
+		this.eventSource.onopen = () => {
+			console.log('SSE connection opened');
+			options?.onOpen?.();
+		};
+
+		this.eventSource.onerror = (error) => {
+			console.error('SSE connection error:', error);
+			options?.onError?.(error);
+		};
+
+		// Custom close event handling
+		this.eventSource.addEventListener('close', () => {
+			console.log('SSE connection closed by server');
+			options?.onClose?.();
+		});
+	}
+
+	disconnect() {
+		this.eventSource?.close();
+		this.eventSource = null;
+	}
+}

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -25,7 +25,9 @@ import type {
 	BootstrapStatus,
 	AuditLog,
 	AuditLogUsageStats,
-	AuditLogFilters
+	AuditLogFilters,
+	K8sServerLog,
+	K8sServerDetail
 } from './types';
 
 type ItemsResponse<T> = { items: T[] | null };
@@ -115,6 +117,18 @@ export async function updateMCPCatalogEntry(
 
 export async function deleteMCPCatalogEntry(catalogID: string, entryID: string): Promise<void> {
 	await doDelete(`/mcp-catalogs/${catalogID}/entries/${entryID}`);
+}
+
+export async function listMCPServersForEntry(
+	catalogID: string,
+	entryID: string,
+	opts?: { fetch?: Fetcher }
+): Promise<MCPCatalogServer[]> {
+	const response = (await doGet(
+		`/mcp-catalogs/${catalogID}/entries/${entryID}/servers`,
+		opts
+	)) as ItemsResponse<MCPCatalogServer>;
+	return response.items ?? [];
 }
 
 export async function createMCPCatalogServer(
@@ -509,5 +523,15 @@ export async function listServerOrInstanceAuditLogStats(
 		`/mcp-stats/${mcpId}${queryString ? `?${queryString}` : ''}`,
 		opts
 	)) as AuditLogUsageStats;
+	return response;
+}
+
+export async function getK8sServerDetail(mcpServerId: string, opts?: { fetch?: Fetcher }) {
+	const response = (await doGet(`/mcp-servers/${mcpServerId}/details`, opts)) as K8sServerDetail;
+	return response;
+}
+
+export async function listK8sServerLogs(mcpServerId: string, opts?: { fetch?: Fetcher }) {
+	const response = (await doGet(`/mcp-servers/${mcpServerId}/logs`, opts)) as K8sServerLog[];
 	return response;
 }

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -309,7 +309,7 @@ export interface K8sServerDetail {
 	lastRestart: string;
 	namespace: string;
 	readyReplicas: number;
-	repliaces: number;
+	replicas: number;
 }
 
 export interface K8sServerLog {

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -292,3 +292,26 @@ export type AuditLogFilters = {
 	limit?: number | null;
 	offset?: number | null;
 };
+
+export interface K8sServerEvent {
+	action: string;
+	count: number;
+	eventType: string;
+	message: string;
+	reason: string;
+	time: string;
+}
+
+export interface K8sServerDetail {
+	deploymentName: string;
+	events: K8sServerEvent[];
+	isAvailable: boolean;
+	lastRestart: string;
+	namespace: string;
+	readyReplicas: number;
+	repliaces: number;
+}
+
+export interface K8sServerLog {
+	message: string;
+}

--- a/ui/user/src/routes/v2/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/v2/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
@@ -1,80 +1,43 @@
 <script lang="ts">
 	import BackLink from '$lib/components/admin/BackLink.svelte';
+	import McpServerK8sInfo from '$lib/components/admin/McpServerK8sInfo.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { Info } from 'lucide-svelte';
 	import { fly } from 'svelte/transition';
 
 	let { data } = $props();
-	let { catalogEntry, catalogServer } = data;
+	let { catalogEntry, mcpServerId } = data;
 	const duration = PAGE_TRANSITION_DURATION;
-
-	const mockDetails = [
-		{
-			id: 'kubernetes_deployments',
-			label: 'Kubernetes Deployment',
-			value: '-'
-		},
-		{
-			id: 'last_restart',
-			label: 'Last Restart',
-			value: '-'
-		},
-		{
-			id: 'status',
-			label: 'Status',
-			value: 'Healthy'
-		}
-	];
 
 	let catalogEntryName =
 		catalogEntry?.urlManifest?.name ?? catalogEntry?.commandManifest?.name ?? 'Unknown';
-	let catalogServerId = catalogServer?.id ?? 'Unknown';
 </script>
 
 <Layout>
 	<div class="mt-6 flex flex-col gap-6 pb-8" in:fly={{ x: 100, delay: duration, duration }}>
-		{#if catalogServer}
-			{@const currentLabel = catalogServer.id ?? 'Server'}
+		{#if mcpServerId}
+			{@const currentLabel = mcpServerId ?? 'Server'}
 			<BackLink fromURL={`/mcp-servers/${catalogEntry?.id}`} {currentLabel} />
 		{/if}
 
-		<h1 class="text-2xl font-semibold">
-			{catalogEntryName} | {catalogServerId}
-		</h1>
+		{#if mcpServerId && catalogEntry?.commandManifest}
+			<McpServerK8sInfo {mcpServerId} name={catalogEntryName} />
+		{:else}
+			<h1 class="text-2xl font-semibold">
+				{catalogEntryName} | {mcpServerId}
+			</h1>
 
-		<div class="flex flex-col gap-2">
-			{#each mockDetails as detail (detail.id)}
-				<div
-					class="dark:bg-surface1 dark:border-surface3 flex flex-col rounded-lg border border-transparent bg-white p-4 shadow-sm"
-				>
-					<div class="grid grid-cols-2 gap-4">
-						<p class="text-sm font-semibold">{detail.label}</p>
-						<p class="text-sm font-light">{detail.value}</p>
-					</div>
+			<div class="notification-info p-3 text-sm font-light">
+				<div class="flex items-center gap-3">
+					<Info class="size-6" />
+					<p>Server information cannot be provided at this time.</p>
 				</div>
-			{/each}
-		</div>
-
-		<div>
-			<h2 class="mb-2 text-lg font-semibold">Events</h2>
-			<div
-				class="dark:bg-surface1 dark:border-surface3 flex min-h-10 flex-col rounded-lg border border-transparent bg-white p-4 shadow-sm"
-			>
-				<span class="text-sm font-light text-gray-400 dark:text-gray-600">No events.</span>
 			</div>
-		</div>
-
-		<div>
-			<h2 class="mb-2 text-lg font-semibold">Deployment Logs</h2>
-			<div
-				class="dark:bg-surface1 dark:border-surface3 flex min-h-64 flex-col rounded-lg border border-transparent bg-white p-4 shadow-sm"
-			>
-				<span class="text-sm font-light text-gray-400 dark:text-gray-600">No deployment logs.</span>
-			</div>
-		</div>
+		{/if}
 	</div>
 </Layout>
 
 <svelte:head>
-	<title>Obot | {catalogEntryName} | {catalogServerId}</title>
+	<title>Obot | {catalogEntryName} | {mcpServerId}</title>
 </svelte:head>

--- a/ui/user/src/routes/v2/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.ts
+++ b/ui/user/src/routes/v2/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.ts
@@ -1,36 +1,28 @@
 import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 import { handleRouteError } from '$lib/errors';
-import { AdminService, ChatService } from '$lib/services';
+import { AdminService } from '$lib/services';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
 
 export const load: PageLoad = async ({ params, fetch }) => {
 	const catalogEntryId = params.id;
-	const serverId = params.ms_id;
+	const mcpServerId = params.ms_id;
 
-	let catalogServer;
 	let catalogEntry;
 	try {
 		catalogEntry = await AdminService.getMCPCatalogEntry(DEFAULT_MCP_CATALOG_ID, catalogEntryId, {
 			fetch
 		});
-		catalogServer = await ChatService.getSingleOrRemoteMcpServer(serverId, {
-			fetch
-		});
-		if (!catalogServer || catalogServer.catalogEntryID !== catalogEntryId) {
-			throw error(404, 'MCP server for catalog not found');
-		}
 	} catch (err) {
 		handleRouteError(
 			err,
-			`/v2/admin/mcp-servers/c/${catalogEntryId}/instance/${serverId}`,
+			`/v2/admin/mcp-servers/c/${catalogEntryId}/instance/${mcpServerId}`,
 			profile.current
 		);
 	}
 
 	return {
 		catalogEntry,
-		catalogServer
+		mcpServerId
 	};
 };

--- a/ui/user/src/routes/v2/admin/mcp-servers/s/[id]/instance/[msi_id]/+page.svelte
+++ b/ui/user/src/routes/v2/admin/mcp-servers/s/[id]/instance/[msi_id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import BackLink from '$lib/components/admin/BackLink.svelte';
+	import McpServerK8sInfo from '$lib/components/admin/McpServerK8sInfo.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { fly } from 'svelte/transition';
@@ -7,24 +8,6 @@
 	let { data } = $props();
 	let { mcpServer, mcpServerInstance } = data;
 	const duration = PAGE_TRANSITION_DURATION;
-
-	const mockDetails = [
-		{
-			id: 'kubernetes_deployments',
-			label: 'Kubernetes Deployment',
-			value: '-'
-		},
-		{
-			id: 'last_restart',
-			label: 'Last Restart',
-			value: '-'
-		},
-		{
-			id: 'status',
-			label: 'Status',
-			value: 'Healthy'
-		}
-	];
 </script>
 
 <Layout>
@@ -34,40 +17,13 @@
 			<BackLink fromURL={`/mcp-servers/${mcpServer.id}`} {currentLabel} />
 		{/if}
 
-		<h1 class="text-2xl font-semibold">
-			{mcpServer?.manifest?.name} | {mcpServerInstance?.id}
-		</h1>
-
-		<div class="flex flex-col gap-2">
-			{#each mockDetails as detail (detail.id)}
-				<div
-					class="dark:bg-surface1 dark:border-surface3 flex flex-col rounded-lg border border-transparent bg-white p-4 shadow-sm"
-				>
-					<div class="grid grid-cols-2 gap-4">
-						<p class="text-sm font-semibold">{detail.label}</p>
-						<p class="text-sm font-light">{detail.value}</p>
-					</div>
-				</div>
-			{/each}
-		</div>
-
-		<div>
-			<h2 class="mb-2 text-lg font-semibold">Events</h2>
-			<div
-				class="dark:bg-surface1 dark:border-surface3 flex min-h-10 flex-col rounded-lg border border-transparent bg-white p-4 shadow-sm"
-			>
-				<span class="text-sm font-light text-gray-400 dark:text-gray-600">No events.</span>
-			</div>
-		</div>
-
-		<div>
-			<h2 class="mb-2 text-lg font-semibold">Deployment Logs</h2>
-			<div
-				class="dark:bg-surface1 dark:border-surface3 flex min-h-64 flex-col rounded-lg border border-transparent bg-white p-4 shadow-sm"
-			>
-				<span class="text-sm font-light text-gray-400 dark:text-gray-600">No deployment logs.</span>
-			</div>
-		</div>
+		{#if mcpServer}
+			<McpServerK8sInfo
+				mcpServerId={mcpServer.id}
+				name={mcpServer.manifest.name || 'Unknown'}
+				mcpServerInstanceId={mcpServerInstance?.id}
+			/>
+		{/if}
 	</div>
 </Layout>
 


### PR DESCRIPTION
* display k8s server info for catalog entry servers/server instances (server instances will show info about using a shared server)
Loom: https://www.loom.com/share/71471195af8746e581920d94c67c9c44 

Addresses #3381 
Merge after PR: https://github.com/obot-platform/obot/pull/3395/files#diff-d83b2475ac8bcad634d42b9cb4510b5cb92018d0e814e0234124e81162919bedR435 (Needs following endpoint)