### PR TITLE
fix: return correct resource_metadata URL

### DIFF
--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -165,7 +165,7 @@ func (m *messageHandler) OnMessage(ctx context.Context, msg nmcp.Message) {
 				auditLog.ResponseStatus = http.StatusUnauthorized
 				m.resp.Header().Set(
 					"WWW-Authenticate",
-					fmt.Sprintf(`Bearer error="invalid_token", error_description="The access token is invalid or expired. Please re-authenticate and try again.", resource_metadata="%s/.well-known/oauth-protected-resource/%s"`, m.handler.baseURL, m.mcpID),
+					fmt.Sprintf(`Bearer error="invalid_token", error_description="The access token is invalid or expired. Please re-authenticate and try again.", resource_metadata="%s/.well-known/oauth-protected-resource/mcp-connect/%s"`, m.handler.baseURL, m.mcpID),
 				)
 				http.Error(m.resp, fmt.Sprintf("Unauthorized: %v", oauthErr), http.StatusUnauthorized)
 				m.insertAuditLog(auditLog)

--- a/pkg/api/handlers/wellknown/handler.go
+++ b/pkg/api/handlers/wellknown/handler.go
@@ -16,7 +16,7 @@ func SetupHandlers(baseURL string, config services.OAuthAuthorizationServerConfi
 		config:  config,
 	}
 
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource/{mcp_id}", h.oauthProtectedResource)
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp-connect/{mcp_id}", h.oauthProtectedResource)
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server/{mcp_id}", h.oauthAuthorization)
 
 	return nil

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -142,7 +142,7 @@ func (s *Server) Wrap(f api.HandlerFunc) http.HandlerFunc {
 			}
 
 			if strings.HasPrefix(req.URL.Path, "/mcp-connect/") {
-				rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_request", error_description="Invalid access token", resource_metadata="%s/.well-known/oauth-protected-resource/%s"`, strings.TrimSuffix(s.baseURL, "/api"), req.PathValue("mcp_id")))
+				rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_request", error_description="Invalid access token", resource_metadata="%s/.well-known/oauth-protected-resource/mcp-connect/%s"`, strings.TrimSuffix(s.baseURL, "/api"), req.PathValue("mcp_id")))
 			}
 
 			if slices.Contains(user.GetGroups(), authz.UnauthenticatedGroup) {


### PR DESCRIPTION
Apparently, the resource_metadata URL has a prescribed format. This change conforms to that prescribed format.