### PR TITLE
feat: add support for provider auth groups

### DIFF
--- a/apiclient/types/accesscontrolrule.go
+++ b/apiclient/types/accesscontrolrule.go
@@ -35,13 +35,14 @@ type Subject struct {
 type SubjectType string
 
 const (
+	SubjectTypeGroup    SubjectType = "group"
 	SubjectTypeUser     SubjectType = "user"
 	SubjectTypeSelector SubjectType = "selector"
 )
 
 func (s Subject) Validate() error {
 	switch s.Type {
-	case SubjectTypeUser:
+	case SubjectTypeUser, SubjectTypeGroup:
 		if s.ID == "" {
 			return fmt.Errorf("user ID is required")
 		}

--- a/pkg/accesscontrolrule/helper.go
+++ b/pkg/accesscontrolrule/helper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
 	gocache "k8s.io/client-go/tools/cache"
 )
 
@@ -91,17 +92,32 @@ func (h *Helper) GetAccessControlRulesForSelector(namespace, selector string) ([
 }
 
 // UserHasAccessToMCPServer checks if a user has access to a specific MCP server through AccessControlRules
-func (h *Helper) UserHasAccessToMCPServer(userID, serverName string) (bool, error) {
+func (h *Helper) UserHasAccessToMCPServer(user kuser.Info, serverName string) (bool, error) {
 	// See if there is a selector that this user is included on.
 	selectorRules, err := h.GetAccessControlRulesForSelector(system.DefaultNamespace, "*")
 	if err != nil {
 		return false, err
 	}
 
+	var (
+		userID = user.GetUID()
+		groups = authGroupSet(user)
+	)
 	for _, rule := range selectorRules {
 		for _, subject := range rule.Spec.Manifest.Subjects {
-			if (subject.Type == types.SubjectTypeUser && subject.ID == userID) || (subject.Type == types.SubjectTypeSelector && subject.ID == "*") {
-				return true, nil
+			switch subject.Type {
+			case types.SubjectTypeUser:
+				if subject.ID == userID {
+					return true, nil
+				}
+			case types.SubjectTypeGroup:
+				if _, ok := groups[subject.ID]; ok {
+					return true, nil
+				}
+			case types.SubjectTypeSelector:
+				if subject.ID == "*" {
+					return true, nil
+				}
 			}
 		}
 	}
@@ -114,8 +130,19 @@ func (h *Helper) UserHasAccessToMCPServer(userID, serverName string) (bool, erro
 
 	for _, rule := range rules {
 		for _, subject := range rule.Spec.Manifest.Subjects {
-			if (subject.Type == types.SubjectTypeUser && subject.ID == userID) || (subject.Type == types.SubjectTypeSelector && subject.ID == "*") {
-				return true, nil
+			switch subject.Type {
+			case types.SubjectTypeUser:
+				if subject.ID == userID {
+					return true, nil
+				}
+			case types.SubjectTypeGroup:
+				if _, ok := groups[subject.ID]; ok {
+					return true, nil
+				}
+			case types.SubjectTypeSelector:
+				if subject.ID == "*" {
+					return true, nil
+				}
 			}
 		}
 	}
@@ -124,17 +151,32 @@ func (h *Helper) UserHasAccessToMCPServer(userID, serverName string) (bool, erro
 }
 
 // UserHasAccessToMCPServerCatalogEntry checks if a user has access to a specific catalog entry through AccessControlRules
-func (h *Helper) UserHasAccessToMCPServerCatalogEntry(userID, entryName string) (bool, error) {
+func (h *Helper) UserHasAccessToMCPServerCatalogEntry(user kuser.Info, entryName string) (bool, error) {
 	// See if there is a selector that this user is included on.
 	selectorRules, err := h.GetAccessControlRulesForSelector(system.DefaultNamespace, "*")
 	if err != nil {
 		return false, err
 	}
 
+	var (
+		userID = user.GetUID()
+		groups = authGroupSet(user)
+	)
 	for _, rule := range selectorRules {
 		for _, subject := range rule.Spec.Manifest.Subjects {
-			if (subject.Type == types.SubjectTypeUser && subject.ID == userID) || (subject.Type == types.SubjectTypeSelector && subject.ID == "*") {
-				return true, nil
+			switch subject.Type {
+			case types.SubjectTypeUser:
+				if subject.ID == userID {
+					return true, nil
+				}
+			case types.SubjectTypeGroup:
+				if _, ok := groups[subject.ID]; ok {
+					return true, nil
+				}
+			case types.SubjectTypeSelector:
+				if subject.ID == "*" {
+					return true, nil
+				}
 			}
 		}
 	}
@@ -147,11 +189,31 @@ func (h *Helper) UserHasAccessToMCPServerCatalogEntry(userID, entryName string) 
 
 	for _, rule := range rules {
 		for _, subject := range rule.Spec.Manifest.Subjects {
-			if (subject.Type == types.SubjectTypeUser && subject.ID == userID) || (subject.Type == types.SubjectTypeSelector && subject.ID == "*") {
-				return true, nil
+			switch subject.Type {
+			case types.SubjectTypeUser:
+				if subject.ID == userID {
+					return true, nil
+				}
+			case types.SubjectTypeGroup:
+				if _, ok := groups[subject.ID]; ok {
+					return true, nil
+				}
+			case types.SubjectTypeSelector:
+				if subject.ID == "*" {
+					return true, nil
+				}
 			}
 		}
 	}
 
 	return false, nil
+}
+
+func authGroupSet(user kuser.Info) map[string]struct{} {
+	groups := user.GetExtra()["auth_provider_groups"]
+	set := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		set[group] = struct{}{}
+	}
+	return set
 }

--- a/pkg/api/authz/mcpserver.go
+++ b/pkg/api/authz/mcpserver.go
@@ -14,10 +14,7 @@ func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, u u
 		return true, nil
 	}
 
-	var (
-		mcpServer v1.MCPServer
-	)
-
+	var mcpServer v1.MCPServer
 	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPServerID), &mcpServer); err != nil {
 		return false, err
 	}
@@ -33,7 +30,7 @@ func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, u u
 	if mcpServer.Spec.SharedWithinMCPCatalogName != "" {
 		if mcpServer.Spec.SharedWithinMCPCatalogName == system.DefaultCatalog {
 			// Check AccessControlRule authorization for this specific MCP server
-			hasAccess, err := a.acrHelper.UserHasAccessToMCPServer(u.GetUID(), mcpServer.Name)
+			hasAccess, err := a.acrHelper.UserHasAccessToMCPServer(u, mcpServer.Name)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -65,7 +65,7 @@ func (m *MCPHandler) GetCatalogEntryFromDefaultCatalog(req api.Context) error {
 
 	// Authorization check.
 	if !req.UserIsAdmin() {
-		hasAccess, err := m.acrHelper.UserHasAccessToMCPServerCatalogEntry(req.User.GetUID(), entry.Name)
+		hasAccess, err := m.acrHelper.UserHasAccessToMCPServerCatalogEntry(req.User, entry.Name)
 		if err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ func (m *MCPHandler) ListEntriesInDefaultCatalog(req api.Context) error {
 	for _, entry := range list.Items {
 		// For default catalog entries, check AccessControlRule authorization
 		if entry.Spec.MCPCatalogName == system.DefaultCatalog {
-			hasAccess, err := m.acrHelper.UserHasAccessToMCPServerCatalogEntry(req.User.GetUID(), entry.Name)
+			hasAccess, err := m.acrHelper.UserHasAccessToMCPServerCatalogEntry(req.User, entry.Name)
 			if err != nil {
 				return err
 			}
@@ -835,7 +835,7 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 
 	if input.CatalogEntryID != "" {
 		if !req.UserIsAdmin() {
-			hasAccess, err := m.acrHelper.UserHasAccessToMCPServerCatalogEntry(req.User.GetUID(), input.CatalogEntryID)
+			hasAccess, err := m.acrHelper.UserHasAccessToMCPServerCatalogEntry(req.User, input.CatalogEntryID)
 			if err != nil {
 				return err
 			}
@@ -1366,7 +1366,7 @@ func (m *MCPHandler) ListServersInDefaultCatalog(req api.Context) error {
 		allowedServers = list.Items
 	} else {
 		for _, server := range list.Items {
-			hasAccess, err := m.acrHelper.UserHasAccessToMCPServer(req.User.GetUID(), server.Name)
+			hasAccess, err := m.acrHelper.UserHasAccessToMCPServer(req.User, server.Name)
 			if err != nil {
 				return err
 			}
@@ -1446,7 +1446,7 @@ func (m *MCPHandler) GetServerFromDefaultCatalog(req api.Context) error {
 
 	// Authorization check.
 	if !req.UserIsAdmin() {
-		hasAccess, err := m.acrHelper.UserHasAccessToMCPServer(req.User.GetUID(), server.Name)
+		hasAccess, err := m.acrHelper.UserHasAccessToMCPServer(req.User, server.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -162,7 +162,7 @@ func (p *ProjectMCPHandler) CreateServer(req api.Context) error {
 	}
 
 	if !req.UserIsAdmin() && mcpServer.Spec.UserID != req.User.GetUID() {
-		hasAccess, err := p.acrHelper.UserHasAccessToMCPServer(req.User.GetUID(), mcpServer.Name)
+		hasAccess, err := p.acrHelper.UserHasAccessToMCPServer(req.User, mcpServer.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/api/handlers/serverinstances.go
+++ b/pkg/api/handlers/serverinstances.go
@@ -83,7 +83,7 @@ func (h *ServerInstancesHandler) CreateServerInstance(req api.Context) error {
 			return types.NewErrNotFound("MCP server not found")
 		}
 
-		hasAccess, err := h.acrHelper.UserHasAccessToMCPServer(req.User.GetUID(), server.Name)
+		hasAccess, err := h.acrHelper.UserHasAccessToMCPServer(req.User, server.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"context"
+)
+
+// GroupInfo represents information about a user group from an authentication provider
+type GroupInfo struct {
+	ID      string  `json:"id"`
+	Name    string  `json:"name"`
+	IconURL *string `json:"iconURL"`
+}
+
+type authProviderURLKey struct{}
+
+// ContextWithProviderURL adds the auth provider URL to the context
+func ContextWithProviderURL(ctx context.Context, url string) context.Context {
+	return context.WithValue(ctx, authProviderURLKey{}, url)
+}
+
+// ProviderURLFromContext retrieves the auth provider URL from the context
+func ProviderURLFromContext(ctx context.Context) string {
+	url, _ := ctx.Value(authProviderURLKey{}).(string)
+	return url
+}

--- a/pkg/gateway/client/group.go
+++ b/pkg/gateway/client/group.go
@@ -1,0 +1,323 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/obot-platform/nah/pkg/log"
+	"github.com/obot-platform/obot/pkg/accesstoken"
+	"github.com/obot-platform/obot/pkg/auth"
+	"github.com/obot-platform/obot/pkg/gateway/types"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	// groupCheckPeriod defines how often the system checks for updates to group information from the auth provider.
+	groupCheckPeriod = time.Minute * 10
+)
+
+// ListAuthGroups lists the auth provider groups for the given auth provider.
+//
+// It supports fuzzy finding group names using on the given nameFilter.
+// It queries the auth provider for "live" group search from the auth provider, then combines the
+// results with cached groups from the database.
+// This allows admins to discover groups that authenticated users belong to for auth providers
+// limited group search capabilities; e.g. there's not an effective way to perform a fuzzy search for
+// GitHub teams or orgs by name.
+func (c *Client) ListAuthGroups(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName, nameFilter string) ([]types.Group, error) {
+	// Fetch groups from the auth provider
+	var providerGroups []auth.GroupInfo
+	if authProviderURL != "" {
+		u, err := url.Parse(authProviderURL + "/obot-list-auth-groups")
+		if err != nil {
+			log.Warnf("failed to parse auth provider URL for group search: %v", err)
+		} else {
+			// We ignore errors here so that clients can still search over cached groups where there
+			// are issues fetching them from the auth provider.
+			if nameFilter != "" {
+				q := u.Query()
+				q.Set("name", nameFilter)
+				u.RawQuery = q.Encode()
+			}
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+			if err == nil {
+				if accessToken := accesstoken.GetAccessToken(ctx); accessToken != "" {
+					req.Header.Set("Authorization", "Bearer "+accessToken)
+				}
+
+				resp, err := http.DefaultClient.Do(req)
+				if err == nil {
+					defer resp.Body.Close()
+					if resp.StatusCode == http.StatusOK {
+						_ = json.NewDecoder(resp.Body).Decode(&providerGroups)
+					}
+				}
+			}
+		}
+	}
+
+	// Fetch groups from the database if we have auth provider info
+	var dbGroups []types.Group
+	if authProviderNamespace != "" && authProviderName != "" {
+		query := c.db.WithContext(ctx).Where("auth_provider_namespace = ? AND auth_provider_name = ?",
+			authProviderNamespace, authProviderName)
+
+		// Apply name filter if provided (case-insensitive, compatible with SQLite and PostgreSQL)
+		if nameFilter != "" {
+			query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+nameFilter+"%")
+		}
+
+		if err := query.Find(&dbGroups).Error; err != nil {
+			return nil, fmt.Errorf("failed to fetch groups from database: %w", err)
+		}
+	}
+
+	groups := make(map[string]types.Group, len(dbGroups))
+	for _, group := range dbGroups {
+		groups[group.ID] = group
+	}
+
+	// Add/merge provider groups
+	for _, providerGroup := range providerGroups {
+		if providerGroup.ID == "" {
+			continue
+		}
+
+		if existing, ok := groups[providerGroup.ID]; ok {
+			// Keep database timestamps but update other fields from provider
+			if providerGroup.Name != "" {
+				existing.Name = providerGroup.Name
+			}
+			if providerGroup.IconURL != nil {
+				existing.IconURL = providerGroup.IconURL
+			}
+			groups[providerGroup.ID] = existing
+			continue
+		}
+
+		groups[providerGroup.ID] = types.Group{
+			ID:                    providerGroup.ID,
+			AuthProviderName:      authProviderName,
+			AuthProviderNamespace: authProviderNamespace,
+			Name:                  providerGroup.Name,
+			IconURL:               providerGroup.IconURL,
+		}
+	}
+
+	result := make([]types.Group, 0, len(groups))
+	for _, group := range groups {
+		result = append(result, group)
+	}
+
+	return result, nil
+}
+
+// ListGroupIDsForUser lists the group IDs that the given user is a member of.
+// This can include groups from multiple auth providers.
+func (c *Client) ListGroupIDsForUser(ctx context.Context, userID uint) ([]string, error) {
+	var groupIDs []string
+	if err := c.db.WithContext(ctx).Table("group_memberships").Where("user_id = ?", userID).Pluck("group_id", &groupIDs).Error; err != nil {
+		return nil, fmt.Errorf("failed to list user group IDs: %w", err)
+	}
+
+	return groupIDs, nil
+}
+
+// ensureGroups ensures the groups that the identity is a member of exist and are up to date.
+func (c *Client) ensureGroups(ctx context.Context, tx *gorm.DB, identity *types.Identity) error {
+	if identity.AuthProviderName == "" || identity.AuthProviderNamespace == "" {
+		// No auth provider info, so we can't fetch groups from the provider
+		return nil
+	}
+
+	var (
+		providerURL    = auth.ProviderURLFromContext(ctx)
+		token          = accesstoken.GetAccessToken(ctx)
+		now            = time.Now()
+		nextGroupCheck = identity.AuthProviderGroupsLastChecked.Add(groupCheckPeriod)
+	)
+	if nextGroupCheck.After(now) || providerURL == "" || token == "" {
+		groups, err := c.listUserGroups(ctx, tx, identity)
+		if err != nil {
+			return fmt.Errorf("failed to list user groups: %w", err)
+		}
+
+		identity.AuthProviderGroups = groups
+		return nil
+	}
+
+	// Fetch groups from the auth provider
+	providerGroups, err := c.fetchGroups(ctx, providerURL, token, identity.AuthProviderNamespace, identity.AuthProviderName)
+	if err != nil {
+		return fmt.Errorf("failed to list user groups from provider: %w", err)
+	}
+
+	identity.AuthProviderGroups = providerGroups
+	identity.AuthProviderGroupsLastChecked = now
+
+	// Get the groups from the database
+	var groups []types.Group
+	if err := tx.WithContext(ctx).Where("auth_provider_name = ? AND auth_provider_namespace = ?", identity.AuthProviderName, identity.AuthProviderNamespace).Find(&groups).Error; err != nil {
+		return fmt.Errorf("failed to list auth provider groups: %w", err)
+	}
+
+	existingGroups := make(map[string]types.Group, len(groups))
+	for _, group := range groups {
+		existingGroups[group.ID] = group
+	}
+
+	var toUpsert []types.Group
+	for _, group := range identity.AuthProviderGroups {
+		if existing, ok := existingGroups[group.ID]; ok && (existing.Name != group.Name || existing.IconURL != group.IconURL) {
+			// The group already exists and is up to date, skip
+			continue
+		}
+		toUpsert = append(toUpsert, group)
+	}
+
+	if len(toUpsert) > 0 {
+		if err := tx.WithContext(ctx).Clauses(clause.OnConflict{
+			Columns: []clause.Column{
+				{Name: "id"},
+			},
+			DoUpdates: clause.AssignmentColumns([]string{"name", "icon_url"}),
+		}).Create(&toUpsert).Error; err != nil {
+			return fmt.Errorf("failed to upsert groups: %w", err)
+		}
+	}
+
+	if err := c.ensureGroupMemberships(ctx, tx, identity); err != nil {
+		return fmt.Errorf("failed to update group memberships for identity: %w", err)
+	}
+
+	return nil
+}
+
+// ensureGroupMemberships ensures the Identity is a member of the groups it references.
+func (c *Client) ensureGroupMemberships(ctx context.Context, tx *gorm.DB, identity *types.Identity) error {
+	// Get the existing memberships for this identity
+	var memberships []types.GroupMemberships
+	if err := tx.WithContext(ctx).
+		Joins("JOIN groups ON group_memberships.group_id = groups.id").
+		Where("group_memberships.user_id = ?", identity.UserID).
+		Where("groups.auth_provider_namespace = ? AND groups.auth_provider_name = ?", identity.AuthProviderNamespace, identity.AuthProviderName).
+		Find(&memberships).Error; err != nil {
+		return fmt.Errorf("failed to get existing group memberships: %w", err)
+	}
+
+	existingMemberships := make(map[string]types.GroupMemberships, len(memberships))
+	for _, membership := range memberships {
+		existingMemberships[membership.GroupID] = membership
+	}
+
+	var toInsert []types.GroupMemberships
+	for _, group := range identity.AuthProviderGroups {
+		if _, ok := existingMemberships[group.ID]; ok {
+			// The membership already exists, skip
+			delete(existingMemberships, group.ID)
+			continue
+		}
+
+		toInsert = append(toInsert, types.GroupMemberships{
+			UserID:  identity.UserID,
+			GroupID: group.ID,
+		})
+	}
+
+	// Insert new memberships
+	if len(toInsert) > 0 {
+		if err := tx.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&toInsert).Error; err != nil {
+			return fmt.Errorf("failed to create group memberships: %w", err)
+		}
+	}
+
+	toDelete := make([]types.GroupMemberships, 0, len(existingMemberships))
+	for _, membership := range existingMemberships {
+		toDelete = append(toDelete, membership)
+	}
+
+	if len(toDelete) > 0 {
+		// Delete memberships that are no longer in the identity's auth provider groups
+		if err := tx.WithContext(ctx).Delete(&toDelete).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to delete group memberships: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// deleteGroupMembershipsForUser deletes all group memberships for the given user.
+func (c *Client) deleteGroupMembershipsForUser(ctx context.Context, tx *gorm.DB, userID uint) error {
+	if err := tx.WithContext(ctx).Where("user_id = ?", userID).Delete(&types.GroupMemberships{}).Error; err != nil {
+		return fmt.Errorf("failed to delete group memberships for user: %w", err)
+	}
+	return nil
+}
+
+// listUserGroups lists the groups that the user is a member of from the database.
+func (*Client) listUserGroups(ctx context.Context, tx *gorm.DB, identity *types.Identity) ([]types.Group, error) {
+	if identity == nil {
+		return nil, fmt.Errorf("identity is nil")
+	}
+	if identity.UserID == 0 {
+		return nil, fmt.Errorf("identity has no user id")
+	}
+	if identity.AuthProviderNamespace == "" || identity.AuthProviderName == "" {
+		return nil, fmt.Errorf("identity missing auth provider info")
+	}
+
+	var groups []types.Group
+	if err := tx.WithContext(ctx).
+		Table("groups").
+		Select("groups.*").
+		Joins("JOIN group_memberships ON group_memberships.group_id = groups.id").
+		Where("group_memberships.user_id = ?", identity.UserID).
+		Where("groups.auth_provider_namespace = ? AND groups.auth_provider_name = ?", identity.AuthProviderNamespace, identity.AuthProviderName).
+		Find(&groups).Error; err != nil {
+		return nil, fmt.Errorf("failed to list user groups: %w", err)
+	}
+
+	return groups, nil
+}
+
+// fetchGroups fetches the groups that the owner of the access token is a member of from the auth provider.
+func (*Client) fetchGroups(ctx context.Context, authProviderURL, accessToken, authProviderNamespace, authProviderName string) ([]types.Group, error) {
+	// Fetch groups from the auth provider, ignore errors so that auth providers that don't yet
+	// implement group support don't block the user from logging in.
+	providerGroups := []auth.GroupInfo{}
+	u, err := url.Parse(authProviderURL + "/obot-list-user-auth-groups")
+	if err == nil {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err == nil {
+			req.Header.Set("Authorization", "Bearer "+accessToken)
+
+			resp, err := http.DefaultClient.Do(req)
+			if err == nil {
+				defer resp.Body.Close()
+				if resp.StatusCode == http.StatusOK {
+					_ = json.NewDecoder(resp.Body).Decode(&providerGroups)
+				}
+			}
+		}
+	}
+
+	var userGroups []types.Group
+	for _, group := range providerGroups {
+		userGroups = append(userGroups, types.Group{
+			ID:                    group.ID,
+			AuthProviderName:      authProviderName,
+			AuthProviderNamespace: authProviderNamespace,
+			Name:                  group.Name,
+			IconURL:               group.IconURL,
+		})
+	}
+
+	return userGroups, nil
+}

--- a/pkg/gateway/db/db.go
+++ b/pkg/gateway/db/db.go
@@ -68,6 +68,8 @@ func (db *DB) AutoMigrate() (err error) {
 		types.OAuthTokenResponse{},
 		types.User{},
 		types.Identity{},
+		types.Group{},
+		types.GroupMemberships{},
 		types.APIActivity{},
 		types.Image{},
 		types.RunState{},

--- a/pkg/gateway/server/router.go
+++ b/pkg/gateway/server/router.go
@@ -28,6 +28,7 @@ func (s *Server) AddRoutes(mux *server.Server) {
 	mux.HandleFunc("DELETE /api/me", wrap(s.deleteUser))
 	mux.HandleFunc("POST /api/logout-all", wrap(s.logoutAll))
 	mux.HandleFunc("GET /api/users", wrap(s.getUsers))
+	mux.HandleFunc("GET /api/groups", wrap(s.listAuthGroups))
 	mux.HandleFunc("POST /api/encrypt-all-users", wrap(s.encryptAllUsersAndIdentities))
 	mux.HandleFunc("GET /api/users/{user_id}", wrap(s.getUser))
 	mux.HandleFunc("GET /api/users/{user_id}/activities", wrap(s.activitiesByUser))

--- a/pkg/gateway/server/tokenreview.go
+++ b/pkg/gateway/server/tokenreview.go
@@ -26,7 +26,7 @@ func (g *gatewayTokenReview) AuthenticateRequest(req *http.Request) (*authentica
 		return nil, false, nil
 	}
 
-	u, namespace, name, err := g.gatewayClient.UserFromToken(req.Context(), bearer)
+	u, namespace, name, groups, err := g.gatewayClient.UserFromToken(req.Context(), bearer)
 	if err != nil {
 		return nil, false, err
 	}
@@ -39,6 +39,7 @@ func (g *gatewayTokenReview) AuthenticateRequest(req *http.Request) (*authentica
 				"email":                   {u.Email},
 				"auth_provider_namespace": {namespace},
 				"auth_provider_name":      {name},
+				"auth_provider_groups":    groups,
 			},
 		},
 	}, true, nil

--- a/pkg/gateway/types/group.go
+++ b/pkg/gateway/types/group.go
@@ -1,0 +1,39 @@
+package types
+
+import "time"
+
+// Group represents a group that users can belong to in an auth provider.
+type Group struct {
+	// ID is the globally unique identifier for the group.
+	// Each auth provider should use a different prefix for their groups to avoid collisions with other providers.
+	ID string `json:"id" gorm:"primaryKey;unique"`
+
+	// AuthProviderName is the name of the auth provider that the group belongs to.
+	// This is used to identify the auth provider that the group belongs to.
+	AuthProviderName string `json:"authProviderName" gorm:"primaryKey;index:idx_group_auth_provider"`
+
+	// AuthProviderNamespace is the namespace of the auth provider that the group belongs to.
+	// Note: This is pretty much always "default", but we're keeping it here for parity with the Identity type.
+	AuthProviderNamespace string `json:"authProviderNamespace" gorm:"primaryKey;index:idx_group_auth_provider"`
+
+	// Name is the display name of the group.
+	Name string `json:"name"`
+
+	// IconURL is the URL of the group's icon.
+	IconURL *string `json:"iconURL"`
+
+	// CreatedAt is the time the group was created.
+	CreatedAt time.Time `json:"createdAt" gorm:"autoCreateTime"`
+}
+
+// GroupMemberships represents a user's membership in a group.
+type GroupMemberships struct {
+	// UserID is the ID of the user that is a member of the group.
+	UserID uint `json:"userID" gorm:"primaryKey"`
+
+	// GroupID is the globally unique identifier for the group.
+	GroupID string `json:"groupID" gorm:"primaryKey"`
+
+	// CreatedAt is when the group membership was created.
+	CreatedAt time.Time `json:"createdAt" gorm:"autoCreateTime"`
+}

--- a/pkg/gateway/types/identity.go
+++ b/pkg/gateway/types/identity.go
@@ -15,4 +15,19 @@ type Identity struct {
 	IconURL               string    `json:"iconURL"`
 	IconLastChecked       time.Time `json:"iconLastChecked"`
 	Encrypted             bool      `json:"encrypted"`
+
+	// AuthProviderGroupsLastChecked is the last time the identity's auth provider groups were checked.
+	AuthProviderGroupsLastChecked time.Time `json:"authProviderGroupsLastChecked"`
+
+	// AuthProviderGroups is the set of auth provider groups that the identity is a member of.
+	AuthProviderGroups []Group `json:"groups" gorm:"-"`
+}
+
+func (i Identity) GetAuthProviderGroupIDs() []string {
+	ids := make([]string, len(i.AuthProviderGroups))
+	for i, group := range i.AuthProviderGroups {
+		ids[i] = group.ID
+	}
+
+	return ids
 }

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -15,6 +15,7 @@ import type {
 	MCPCatalogEntryServerManifest,
 	MCPCatalogManifest,
 	OrgUser,
+	OrgGroup,
 	ProjectThread,
 	MCPCatalogServerManifest,
 	DefaultModelAlias,
@@ -306,6 +307,12 @@ export async function getUser(
 ): Promise<OrgUser> {
 	const response = (await doGet(`/users/${userID}`, opts)) as OrgUser;
 	return response;
+}
+
+export async function listGroups(opts?: { fetch?: Fetcher; query?: string }): Promise<OrgGroup[]> {
+	const queryParam = opts?.query ? `?name=${encodeURIComponent(opts.query)}` : '';
+	const response = (await doGet(`/groups${queryParam}`, opts)) as OrgGroup[];
+	return response ?? [];
 }
 
 export async function updateUserRole(

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -241,7 +241,7 @@ export interface AccessControlRuleResource {
 }
 
 export interface AccessControlRuleSubject {
-	type: 'user' | 'selector';
+	type: 'user' | 'group' | 'selector';
 	id: string;
 }
 


### PR DESCRIPTION
Add the ability for admins to use auth provider sourced groups to gate user access to MCP servers.

Addresses part of https://github.com/obot-platform/obot/issues/3484