### PR TITLE
fix: mcpgateway: always delete temporary client

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -281,15 +281,15 @@ func (h *handler) callback(req api.Context) error {
 			ClientCredLookup: oauthHandler,
 			TokenStorage:     h.tokenStore.ForMCPID(oauthHandler.mcpID),
 		})
+		// We only need this client for checking for OAuth. Close it when we're done.
+		if shutdownErr := h.mcpSessionManager.ShutdownServer(ctx, mcpServerConfig); shutdownErr != nil {
+			log.Errorf("failed to shutdown server after authentication %s: %v", mcpServer.Name, shutdownErr)
+		}
 		if err != nil {
 			errChan <- fmt.Errorf("failed to get client for server %s: %v", mcpServer.Name, err)
 			return
 		}
 		errChan <- nil
-		// We only need this client for checking for OAuth. Close it when we're done.
-		if err = h.mcpSessionManager.ShutdownServer(ctx, mcpServerConfig); err != nil {
-			log.Errorf("failed to shutdown server after authentication %s: %v", mcpServer.Name, err)
-		}
 	}()
 
 	select {


### PR DESCRIPTION
I found this bug while testing https://github.com/obot-platform/obot/issues/3282, though I am not sure if that issue was actually related to this.