### PR TITLE
fix: mcpgateway: delete temporary client with background ctx

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -281,10 +281,12 @@ func (h *handler) callback(req api.Context) error {
 			ClientCredLookup: oauthHandler,
 			TokenStorage:     h.tokenStore.ForMCPID(oauthHandler.mcpID),
 		})
-		// We only need this client for checking for OAuth. Close it when we're done.
-		if shutdownErr := h.mcpSessionManager.ShutdownServer(ctx, mcpServerConfig); shutdownErr != nil {
-			log.Errorf("failed to shutdown server after authentication %s: %v", mcpServer.Name, shutdownErr)
-		}
+		// We only need this client for checking for OAuth. Close it, now that we're done.
+		go func() {
+			if shutdownErr := h.mcpSessionManager.ShutdownServer(context.Background(), mcpServerConfig); shutdownErr != nil {
+				log.Errorf("failed to shutdown server after authentication %s: %v", mcpServer.Name, shutdownErr)
+			}
+		}()
 		if err != nil {
 			errChan <- fmt.Errorf("failed to get client for server %s: %v", mcpServer.Name, err)
 			return


### PR DESCRIPTION
The ctx that we were using for this was getting cancelled, because the function that spawned this outer goroutine was canceling it before we were done removing the k8s objects. This fixes that.