### PR TITLE
enhance: catalog source URLs: use go-git to clone

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/gen2brain/webp v0.5.4
+	github.com/go-git/go-git/v5 v5.13.2
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/gptscript-ai/chat-completion-client v0.0.0-20250224164718-139cb4507b1d
@@ -150,7 +151,6 @@ require (
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
-	github.com/go-git/go-git/v5 v5.13.2 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/pkg/controller/handlers/mcpcatalog/github.go
+++ b/pkg/controller/handlers/mcpcatalog/github.go
@@ -127,7 +127,7 @@ func readGitHubCatalog(catalogURL string) ([]types.MCPServerCatalogEntryManifest
 	// Set up git credentials if token is available
 	if githubToken != "" {
 		cloneOptions.Auth = &http.BasicAuth{
-			Username: "obot", // Use a dummy username
+			Username: "obot", // Use a dummy username. The username is ignored, but required to be non-empty.
 			Password: githubToken,
 		}
 	}

--- a/pkg/controller/handlers/mcpcatalog/github.go
+++ b/pkg/controller/handlers/mcpcatalog/github.go
@@ -60,12 +60,24 @@ func checkRepoSize(org, repo string, maxSizeMB int) error {
 
 	// Check response status
 	if resp.StatusCode == 404 {
+		body, _ := io.ReadAll(resp.Body)
+		if len(body) > 0 {
+			return fmt.Errorf("repository not found: %s/%s - %s", org, repo, string(body))
+		}
 		return fmt.Errorf("repository not found: %s/%s", org, repo)
 	}
 	if resp.StatusCode == 403 {
+		body, _ := io.ReadAll(resp.Body)
+		if len(body) > 0 {
+			return fmt.Errorf("access denied to repository: %s/%s - %s", org, repo, string(body))
+		}
 		return fmt.Errorf("access denied to repository: %s/%s (may be private or rate limited)", org, repo)
 	}
 	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		if len(body) > 0 {
+			return fmt.Errorf("GitHub API returned status %d for repository %s/%s - %s", resp.StatusCode, org, repo, string(body))
+		}
 		return fmt.Errorf("GitHub API returned status %d for repository %s/%s", resp.StatusCode, org, repo)
 	}
 

--- a/pkg/controller/handlers/mcpcatalog/github.go
+++ b/pkg/controller/handlers/mcpcatalog/github.go
@@ -2,15 +2,16 @@ package mcpcatalog
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/obot-platform/obot/apiclient/types"
 	"sigs.k8s.io/yaml"
 )
@@ -20,6 +21,54 @@ var githubToken = os.Getenv("GITHUB_AUTH_TOKEN")
 func isGitHubURL(catalogURL string) bool {
 	u, err := url.Parse(catalogURL)
 	return err == nil && u.Host == "github.com"
+}
+
+// validateBranchName validates that the branch name doesn't contain suspicious characters
+func validateBranchName(branch string) error {
+	if branch == "" {
+		return fmt.Errorf("branch name cannot be empty")
+	}
+
+	// Check for path traversal attempts and other suspicious characters
+	if strings.Contains(branch, "..") || strings.Contains(branch, "/") ||
+		strings.Contains(branch, "\\") || strings.Contains(branch, ":") ||
+		strings.HasPrefix(branch, "-") {
+		return fmt.Errorf("invalid branch name: %s", branch)
+	}
+
+	return nil
+}
+
+// isPathSafe checks if a file path is safe to read (not a symlink and within bounds)
+func isPathSafe(path, baseDir string) error {
+	// Check if it's a symbolic link
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	// Skip symbolic links to prevent path traversal
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("symbolic links are not allowed for security reasons")
+	}
+
+	// Resolve the absolute path and ensure it's within the base directory
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	absBaseDir, err := filepath.Abs(baseDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute base directory: %w", err)
+	}
+
+	// Ensure the file is within the base directory
+	if !strings.HasPrefix(absPath, absBaseDir+string(filepath.Separator)) {
+		return fmt.Errorf("file path is outside the allowed directory")
+	}
+
+	return nil
 }
 
 func readGitHubCatalog(catalogURL string) ([]types.MCPServerCatalogEntryManifest, error) {
@@ -44,7 +93,7 @@ func readGitHubCatalog(catalogURL string) ([]types.MCPServerCatalogEntryManifest
 		return nil, fmt.Errorf("not a GitHub URL: %s", catalogURL)
 	}
 
-	// Convert github.com URL to raw.githubusercontent.com
+	// Convert github.com URL to clone URL
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("invalid GitHub URL format, expected github.com/org/repo")
@@ -53,29 +102,53 @@ func readGitHubCatalog(catalogURL string) ([]types.MCPServerCatalogEntryManifest
 	branch := "main"
 	if len(parts) > 2 {
 		branch = parts[2]
+		// Validate branch name for security
+		if err := validateBranchName(branch); err != nil {
+			return nil, fmt.Errorf("invalid branch name: %w", err)
+		}
+	}
+
+	// Create temporary directory for cloning
+	tempDir, err := os.MkdirTemp("", "catalog-clone-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Clone the repository
+	cloneURL := fmt.Sprintf("https://github.com/%s/%s.git", org, repo)
+
+	// Set up clone options
+	cloneOptions := &git.CloneOptions{
+		URL:           cloneURL,
+		Depth:         1,
+		ReferenceName: plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", branch)),
+	}
+
+	// Set up git credentials if token is available
+	if githubToken != "" {
+		cloneOptions.Auth = &http.BasicAuth{
+			Username: "obot", // Use a dummy username
+			Password: githubToken,
+		}
+	}
+
+	// Use go-git to clone the repository
+	_, err = git.PlainClone(tempDir, false, cloneOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone repository: %w", err)
 	}
 
 	var (
-		rawBaseURL            = fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s", org, repo, branch)
 		catalogPatterns       = []string{"*.json", "*.yaml", "*.yml"} // Default to all JSON and YAML files
 		usingObotCatalogsFile bool
 	)
 
 	// First try to get .obotcatalogs file
-	req, err := http.NewRequest(http.MethodGet, rawBaseURL+"/.obotcatalogs", nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	if githubToken != "" {
-		req.Header.Set("Authorization", "Bearer "+githubToken)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err == nil && resp.StatusCode == http.StatusOK {
+	obotCatalogsPath := filepath.Join(tempDir, ".obotcatalogs")
+	if content, err := os.ReadFile(obotCatalogsPath); err == nil {
 		usingObotCatalogsFile = true
-		defer resp.Body.Close()
-
-		scanner := bufio.NewScanner(resp.Body)
+		scanner := bufio.NewScanner(strings.NewReader(string(content)))
 		var patterns []string
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -91,78 +164,63 @@ func readGitHubCatalog(catalogURL string) ([]types.MCPServerCatalogEntryManifest
 		}
 	}
 
-	// Get repository file listing using GitHub API
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/git/trees/%s?recursive=1", org, repo, branch)
-	req, err = http.NewRequest(http.MethodGet, apiURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	if githubToken != "" {
-		req.Header.Set("Authorization", "Bearer "+githubToken)
-	}
+	// Walk through the cloned repository to find matching files
+	var (
+		entries   []types.MCPServerCatalogEntryManifest
+		fileCount int
+	)
+	const maxFiles = 1000 // Limit the number of files processed to prevent resource exhaustion
 
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list repository contents: %w", err)
-	}
-	defer resp.Body.Close()
+	err = filepath.WalkDir(tempDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to list repository contents: %s %s", resp.Status, string(body))
-	}
+		// Get relative path from repository root
+		relPath, err := filepath.Rel(tempDir, path)
+		if err != nil {
+			return err
+		}
 
-	var tree struct {
-		Tree []struct {
-			Path string `json:"path"`
-			Type string `json:"type"`
-		} `json:"tree"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
-		return nil, fmt.Errorf("failed to decode repository listing: %w", err)
-	}
+		// Skip the .git directory specifically
+		if d.IsDir() && (relPath == ".git" || strings.HasPrefix(relPath, ".git/")) {
+			return filepath.SkipDir
+		}
 
-	var entries []types.MCPServerCatalogEntryManifest
-	for _, item := range tree.Tree {
-		if item.Type != "blob" {
-			continue
+		// Skip directories (but continue walking into them)
+		if d.IsDir() {
+			return nil
+		}
+
+		// Check file count limit
+		fileCount++
+		if fileCount > maxFiles {
+			return fmt.Errorf("too many files to process (limit: %d)", maxFiles)
 		}
 
 		// Check if file matches any pattern
 		var matches bool
 		for _, pattern := range catalogPatterns {
-			if matched, _ := filepath.Match(pattern, filepath.Base(item.Path)); matched {
+			if matched, _ := filepath.Match(pattern, filepath.Base(relPath)); matched {
 				matches = true
 				break
 			}
 		}
 		if !matches {
-			continue
+			return nil
 		}
 
-		// Get file contents
-		req, err := http.NewRequest(http.MethodGet, rawBaseURL+"/"+item.Path, nil)
-		if err != nil {
-			log.Warnf("Failed to get contents of %s: %v", item.Path, err)
-			continue
-		}
-		if githubToken != "" {
-			req.Header.Set("Authorization", "Bearer "+githubToken)
+		// Security check: ensure the file is safe to read
+		if err := isPathSafe(path, tempDir); err != nil {
+			log.Warnf("Skipping unsafe file %s: %v", relPath, err)
+			return nil
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		// Read file contents
+		content, err := os.ReadFile(path)
 		if err != nil {
-			log.Warnf("Failed to get contents of %s: %v", item.Path, err)
-			continue
-		}
-		content, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			log.Warnf("Failed to read contents of %s: %v", item.Path, err)
-			continue
-		} else if resp.StatusCode != http.StatusOK {
-			log.Warnf("Failed to get contents of %s: (status: %s) (response body: %s)", item.Path, resp.Status, string(content))
-			continue
+			log.Warnf("Failed to read contents of %s: %v", relPath, err)
+			return nil
 		}
 
 		// Try to unmarshal as array first
@@ -172,16 +230,21 @@ func readGitHubCatalog(catalogURL string) ([]types.MCPServerCatalogEntryManifest
 			var entry types.MCPServerCatalogEntryManifest
 			if err := yaml.Unmarshal(content, &entry); err != nil {
 				if usingObotCatalogsFile {
-					log.Warnf("Failed to parse %s as catalog entry: %v", item.Path, err)
+					log.Warnf("Failed to parse %s as catalog entry: %v", relPath, err)
 				} else {
-					log.Debugf("Failed to parse %s as catalog entry: %v", item.Path, err)
+					log.Debugf("Failed to parse %s as catalog entry: %v", relPath, err)
 				}
-				continue
+				return nil
 			}
 			fileEntries = []types.MCPServerCatalogEntryManifest{entry}
 		}
 
 		entries = append(entries, fileEntries...)
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk repository files: %w", err)
 	}
 
 	return entries, nil

--- a/pkg/controller/handlers/mcpcatalog/github.go
+++ b/pkg/controller/handlers/mcpcatalog/github.go
@@ -37,7 +37,7 @@ func checkRepoSize(org, repo string, maxSizeMB int) error {
 
 	// Create HTTP client with timeout
 	client := &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: 5 * time.Second,
 	}
 
 	// Create request
@@ -59,21 +59,7 @@ func checkRepoSize(org, repo string, maxSizeMB int) error {
 	defer resp.Body.Close()
 
 	// Check response status
-	if resp.StatusCode == 404 {
-		body, _ := io.ReadAll(resp.Body)
-		if len(body) > 0 {
-			return fmt.Errorf("repository not found: %s/%s - %s", org, repo, string(body))
-		}
-		return fmt.Errorf("repository not found: %s/%s", org, repo)
-	}
-	if resp.StatusCode == 403 {
-		body, _ := io.ReadAll(resp.Body)
-		if len(body) > 0 {
-			return fmt.Errorf("access denied to repository: %s/%s - %s", org, repo, string(body))
-		}
-		return fmt.Errorf("access denied to repository: %s/%s (may be private or rate limited)", org, repo)
-	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		if len(body) > 0 {
 			return fmt.Errorf("GitHub API returned status %d for repository %s/%s - %s", resp.StatusCode, org, repo, string(body))
@@ -103,9 +89,8 @@ func validateBranchName(branch string) error {
 	}
 
 	// Check for path traversal attempts and other suspicious characters
-	if strings.Contains(branch, "..") || strings.Contains(branch, "/") ||
-		strings.Contains(branch, "\\") || strings.Contains(branch, ":") ||
-		strings.HasPrefix(branch, "-") {
+	if strings.Contains(branch, "..") || strings.Contains(branch, "\\") ||
+		strings.Contains(branch, ":") || strings.HasPrefix(branch, "-") {
 		return fmt.Errorf("invalid branch name: %s", branch)
 	}
 

--- a/pkg/controller/handlers/mcpcatalog/github.go
+++ b/pkg/controller/handlers/mcpcatalog/github.go
@@ -158,7 +158,7 @@ func readGitHubCatalog(catalogURL string) ([]types.MCPServerCatalogEntryManifest
 	org, repo := parts[0], parts[1]
 	branch := "main"
 	if len(parts) > 2 {
-		branch = parts[2]
+		branch = strings.Join(parts[2:], "/")
 		// Validate branch name for security
 		if err := validateBranchName(branch); err != nil {
 			return nil, fmt.Errorf("invalid branch name: %w", err)

--- a/pkg/controller/handlers/mcpcatalog/github.go
+++ b/pkg/controller/handlers/mcpcatalog/github.go
@@ -93,7 +93,6 @@ func readGitHubCatalog(catalogURL string) ([]types.MCPServerCatalogEntryManifest
 		return nil, fmt.Errorf("not a GitHub URL: %s", catalogURL)
 	}
 
-	// Convert github.com URL to clone URL
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("invalid GitHub URL format, expected github.com/org/repo")


### PR DESCRIPTION
This will hopefully help us to process catalog repos faster, compared to making tons of HTTP requests. Hopefully the rate limiting will be less severe, too.

This should help with https://github.com/obot-platform/obot/issues/3272