### PR TITLE
fix: disable copy button when clipboard is unavailable

### DIFF
--- a/ui/user/src/lib/components/CopyButton.svelte
+++ b/ui/user/src/lib/components/CopyButton.svelte
@@ -28,6 +28,12 @@
 	let buttonTextToShow = $state(buttonText);
 	const COPIED_TEXT = 'Copied!';
 
+	// Check if clipboard is available
+	let clipboardUnavailable = $derived(typeof navigator === 'undefined' || !navigator.clipboard);
+
+	// Combine explicit disabled prop with clipboard availability
+	let isDisabled = $derived(disabled || clipboardUnavailable);
+
 	function copy() {
 		if (!text) return;
 		if (!navigator.clipboard) return;
@@ -45,7 +51,7 @@
 	<button
 		use:tooltip={message}
 		onclick={() => copy()}
-		{disabled}
+		disabled={isDisabled}
 		onmouseenter={() => (buttonTextToShow = buttonText)}
 		class={twMerge(
 			buttonText &&


### PR DESCRIPTION
`navigator.clipboard` is unavailable in insecure contexts (like
non-localhost http). This results in the copy button not working.

Detect this scenario and disable the copy button.

Addresses https://github.com/obot-platform/obot/issues/3433

Note: I'm not sure this is actually how we want to handle this. I can
try another method to make this work in these contexts, but wanted to
gather feedback on this approach first.
