### PR TITLE
chore: work with mcp-remote

### DIFF
--- a/pkg/api/handlers/wellknown/handler.go
+++ b/pkg/api/handlers/wellknown/handler.go
@@ -17,7 +17,9 @@ func SetupHandlers(baseURL string, config services.OAuthAuthorizationServerConfi
 	}
 
 	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp-connect/{mcp_id}", h.oauthProtectedResource)
+	// Some clients choose the wrong URL for oauth-authorization-server. It doesn't harm anything to serve both.
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server/{mcp_id}", h.oauthAuthorization)
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server/mcp-connect/{mcp_id}", h.oauthAuthorization)
 
 	return nil
 }


### PR DESCRIPTION
For some reason, after going through the OAuth process, mcp-remote is re-requesting the oauth-authorization-server metadata, but using the wrong URL. This change serves the same metadata from a different path to make mcp-remote happy.