### PR TITLE
chore: gate github tests behind a check for the token

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,3 +25,5 @@ jobs:
       - name: Run Tests
         run: |
           make test
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/controller/handlers/mcpcatalog/github_test.go
+++ b/pkg/controller/handlers/mcpcatalog/github_test.go
@@ -1,17 +1,12 @@
 package mcpcatalog
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestReadGitHubCatalog(t *testing.T) {
-	if os.Getenv("GITHUB_AUTH_TOKEN") == "" {
-		t.Skip("GITHUB_AUTH_TOKEN is not set")
-	}
-
 	tests := []struct {
 		name       string
 		catalog    string


### PR DESCRIPTION
We get rate limited in our PRs way too much. ~~This section of the code is pretty isolated and hardly ever touched, so there's really not a need to run this test on every PR anyway.~~

I added the GitHub token to the environment when running tests in order to help prevent this.