### PR TITLE
Fix: properly updating username which switching provider, show displayname in UI

### DIFF
--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -220,6 +220,12 @@ func (c *Client) ensureIdentity(ctx context.Context, tx *gorm.DB, id *types.Iden
 				userChanged = true
 			}
 
+			if user.Username != id.ProviderUsername {
+				user.Username = id.ProviderUsername
+				user.HashedUsername = hash.String(user.Username)
+				userChanged = true
+			}
+
 			// Update the verified email status if needed.
 			// This can happen in two cases:
 			// 1. The user was created before we started tracking verified emails (user.VerifiedEmail is nil)

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -268,7 +268,6 @@ func (c *Client) UpdateProfileIfNeeded(ctx context.Context, user *types.User, au
 			user.DisplayName = displayName
 		}
 	}
-
 	identity.IconLastChecked = time.Now()
 
 	if err = c.encryptIdentity(ctx, &identity); err != nil {

--- a/ui/user/src/lib/components/navbar/Profile.svelte
+++ b/ui/user/src/lib/components/navbar/Profile.svelte
@@ -45,7 +45,7 @@
 </script>
 
 <Menu
-	title={profile.current.getDisplayName?.() || 'Anonymous'}
+	title={profile.current.displayName || 'Anonymous'}
 	slide={responsive.isMobile ? 'left' : undefined}
 	fixed={responsive.isMobile}
 	classes={{
@@ -65,7 +65,7 @@
 				<ProfileIcon class="size-12" />
 				<div class="flex grow flex-col">
 					<span>
-						{profile.current.getDisplayName?.() || 'Anonymous'}
+						{profile.current.displayName || 'Anonymous'}
 					</span>
 					<span class="text-sm text-gray-500">
 						{profile.current.role === 1 ? 'Admin' : 'User'}

--- a/ui/user/src/lib/services/chat/operations.ts
+++ b/ui/user/src/lib/services/chat/operations.ts
@@ -54,9 +54,6 @@ export async function getProfile(opts?: { fetch?: Fetcher }): Promise<Profile> {
 	obj.isAdmin = () => {
 		return obj.role === 1;
 	};
-	obj.getDisplayName = () => {
-		return obj?.currentAuthProvider === 'github-auth-provider' ? obj.username : obj?.email;
-	};
 	obj.loaded = true;
 	return obj;
 }

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -151,12 +151,12 @@ export interface Profile {
 	role: number;
 	loaded?: boolean;
 	isAdmin?: () => boolean;
-	getDisplayName?: () => string;
 	unauthorized?: boolean;
 	username: string;
 	currentAuthProvider?: string;
 	expired?: boolean;
 	created?: string;
+	displayName?: string;
 }
 
 export interface Files {

--- a/ui/user/src/routes/profile/+page.svelte
+++ b/ui/user/src/routes/profile/+page.svelte
@@ -63,7 +63,7 @@
 					/>
 					<div class="flex flex-row py-3">
 						<div class="w-1/2 max-w-[150px]">Display Name:</div>
-						<div class="w-1/2 break-words">{profile.current.getDisplayName?.()}</div>
+						<div class="w-1/2 break-words">{profile.current.displayName}</div>
 					</div>
 					<hr />
 					<div class="flex flex-row py-3">


### PR DESCRIPTION
We should be properly updating username when switching auth provider to sign in. Also since we have displayName support in backend, we should just use it to show it UI.

https://github.com/obot-platform/obot/issues/1783