### PR TITLE
chore: provide generic MCP gateway OAuth endpoints

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -63,8 +63,12 @@ var staticRules = map[string][]string{
 
 		"GET /.well-known/",
 		"POST /oauth/register/{mcp_id}",
+		"POST /oauth/register",
 		"GET /oauth/authorize/{mcp_id}",
+		"GET /oauth/authorize",
 		"POST /oauth/token/{mcp_id}",
+		"POST /oauth/token",
+		"GET /oauth/callback/{oauth_request_id}",
 	},
 
 	AuthenticatedGroup: {

--- a/pkg/api/handlers/mcpgateway/oauth/handler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/handler.go
@@ -29,4 +29,13 @@ func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenService *jwt.Token
 	mux.HandleFunc("GET /oauth/callback/{oauth_auth_request}/{mcp_id}", h.callback)
 	mux.HandleFunc("POST /oauth/token/{mcp_id}", h.token)
 	mux.HandleFunc("GET /oauth/mcp/callback", h.oauthCallback)
+
+	// These endpoints allow clients that don't follow the spec to connect to Obot MCP servers.
+	// Such clients will not be able to do second-level OAuth because we aren't able to determine
+	// to which MCP server they're trying to connect. At least they will be able to connect to
+	// MCP servers that don't require second-level OAuth.
+	mux.HandleFunc("POST /oauth/register", h.register)
+	mux.HandleFunc("GET /oauth/authorize", h.authorize)
+	mux.HandleFunc("GET /oauth/callback/{oauth_auth_request}", h.callback)
+	mux.HandleFunc("POST /oauth/token", h.token)
 }

--- a/pkg/api/handlers/wellknown/handler.go
+++ b/pkg/api/handlers/wellknown/handler.go
@@ -19,7 +19,14 @@ func SetupHandlers(baseURL string, config services.OAuthAuthorizationServerConfi
 	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp-connect/{mcp_id}", h.oauthProtectedResource)
 	// Some clients choose the wrong URL for oauth-authorization-server. It doesn't harm anything to serve both.
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server/{mcp_id}", h.oauthAuthorization)
+	// This is the one we expect clients to hit.
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server/mcp-connect/{mcp_id}", h.oauthAuthorization)
+
+	// These will allow clients that don't follow the WWW-Authenticate header to connect to the MCP gateway.
+	// Such clients won't be able to do the second-level OAuth, but will be able to connect to all MCP servers
+	// that don't require second-level OAuth.
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource", h.oauthProtectedResource)
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server", h.oauthAuthorization)
 
 	return nil
 }

--- a/pkg/api/handlers/wellknown/oauth.go
+++ b/pkg/api/handlers/wellknown/oauth.go
@@ -8,19 +8,34 @@ import (
 
 // oauthAuthorization handles the /.well-known/oauth-authorization-server endpoint
 func (h *handler) oauthAuthorization(req api.Context) error {
+	mcpID := req.PathValue("mcp_id")
+	if mcpID != "" {
+		mcpID = "/" + mcpID
+	}
 	config := h.config
-	config.Issuer = fmt.Sprintf("%s/%s", h.baseURL, req.PathValue("mcp_id"))
-	config.AuthorizationEndpoint = fmt.Sprintf("%s/oauth/authorize/%s", h.baseURL, req.PathValue("mcp_id"))
-	config.TokenEndpoint = fmt.Sprintf("%s/oauth/token/%s", h.baseURL, req.PathValue("mcp_id"))
-	config.RegistrationEndpoint = fmt.Sprintf("%s/oauth/register/%s", h.baseURL, req.PathValue("mcp_id"))
+	config.Issuer = fmt.Sprintf("%s%s", h.baseURL, mcpID)
+	config.AuthorizationEndpoint = fmt.Sprintf("%s/oauth/authorize%s", h.baseURL, mcpID)
+	config.TokenEndpoint = fmt.Sprintf("%s/oauth/token%s", h.baseURL, mcpID)
+	config.RegistrationEndpoint = fmt.Sprintf("%s/oauth/register%s", h.baseURL, mcpID)
 	return req.Write(config)
 }
 
 func (h *handler) oauthProtectedResource(req api.Context) error {
-	return req.Write(fmt.Sprintf(`{
+	mcpID := req.PathValue("mcp_id")
+	if mcpID != "" {
+		return req.Write(fmt.Sprintf(`{
 	"resource_name": "Obot MCP Gateway",
 	"resource": "%s/mcp-connect/%s",
 	"authorization_servers": ["%[1]s/%[2]s"],
 	"bearer_methods_supported": ["header"]
-}`, h.baseURL, req.PathValue("mcp_id")))
+}`, h.baseURL, mcpID))
+	}
+
+	// The client is hitting the "generic" metadata endpoint and is not supplying an MCP ID. Server the generic metadata.
+	return req.Write(fmt.Sprintf(`{
+	"resource_name": "Obot MCP Gateway",
+	"resource": "%s/mcp-connect",
+	"authorization_servers": ["%[1]s"],
+	"bearer_methods_supported": ["header"]
+}`, h.baseURL))
 }


### PR DESCRIPTION
Clients that use these endpoints are not following the spec. However, exposing these generic endpoints will allow such clients to connect to Obot MCP gateway servers as long as the underlying MCP server doesn't require OAuth.

Issue: https://github.com/obot-platform/obot/issues/3406