### PR TITLE
fix: remove support for editing mcp server descriptions from overview

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -23,10 +23,10 @@
 		readonly?: boolean;
 		onCancel?: () => void;
 		onSubmit?: (id: string, type: MCPType) => void;
-		onUpdate?: () => void;
 	}
 
-	let { entry, catalogId, type, readonly, onCancel, onSubmit, onUpdate }: Props = $props();
+	let { entry, catalogId, type, readonly, onCancel, onSubmit }: Props = $props();
+
 	const tabs = $derived(
 		entry
 			? [
@@ -164,7 +164,11 @@
 		{/if}
 
 		{#if view === 'overview' && entry}
-			<McpServerInfo editable={!readonly} {catalogId} {entry} {onUpdate} />
+			<McpServerInfo
+				{catalogId}
+				{entry}
+				descriptionPlaceholder="Add a description for this MCP server in the Configuration tab"
+			/>
 		{:else if view === 'configuration'}
 			{@render configurationView()}
 		{:else if view === 'access-control'}

--- a/ui/user/src/routes/v2/admin/mcp-servers/c/[id]/+page.svelte
+++ b/ui/user/src/routes/v2/admin/mcp-servers/c/[id]/+page.svelte
@@ -5,7 +5,6 @@
 	import { fly } from 'svelte/transition';
 	import { goto } from '$app/navigation';
 	import BackLink from '$lib/components/admin/BackLink.svelte';
-	import { AdminService } from '$lib/services/index.js';
 	const duration = PAGE_TRANSITION_DURATION;
 
 	let { data } = $props();
@@ -31,13 +30,6 @@
 			}}
 			onSubmit={async () => {
 				goto('/v2/admin/mcp-servers');
-			}}
-			onUpdate={async () => {
-				if (!catalogEntry) return;
-				catalogEntry = await AdminService.getMCPCatalogEntry(
-					DEFAULT_MCP_CATALOG_ID,
-					catalogEntry.id
-				);
 			}}
 		/>
 	</div>

--- a/ui/user/src/routes/v2/admin/mcp-servers/s/[id]/+page.svelte
+++ b/ui/user/src/routes/v2/admin/mcp-servers/s/[id]/+page.svelte
@@ -5,7 +5,6 @@
 	import { fly } from 'svelte/transition';
 	import { goto } from '$app/navigation';
 	import BackLink from '$lib/components/admin/BackLink.svelte';
-	import { AdminService } from '$lib/services/index.js';
 	const duration = PAGE_TRANSITION_DURATION;
 
 	let { data } = $props();
@@ -29,10 +28,6 @@
 			}}
 			onSubmit={async () => {
 				goto('/v2/admin/mcp-servers');
-			}}
-			onUpdate={async () => {
-				if (!mcpServer) return;
-				mcpServer = await AdminService.getMCPCatalogServer(DEFAULT_MCP_CATALOG_ID, mcpServer.id);
 			}}
 		/>
 	</div>


### PR DESCRIPTION
Simplify the admin UX for editing MCP server descriptions by:
- removing the ability to edit descriptions in the Overview tab
- make the Configuration tab the only place descriptions may be edited
- adding some text directing admins to use the Configuration tab when
  the description is empty

https://github.com/user-attachments/assets/e4c2e4ad-4257-4e5e-a4aa-fc950b42908c


https://github.com/user-attachments/assets/3b10173c-fca9-44f5-95f1-051e4b18f61e


Addresses https://github.com/obot-platform/obot/issues/3346

