### PR TITLE
fix: wait for all capabilities to load before displaying them 

### DIFF
--- a/ui/user/src/lib/components/mcp/McpServerInfo.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerInfo.svelte
@@ -354,15 +354,15 @@
 		<div class="flex flex-col gap-2">
 			<h4 class="text-md font-semibold">Capabilities</h4>
 			<ul class="flex flex-wrap items-center gap-2">
-				{@render capabiliity('Tool Catalog', displayTools.length > 0)}
-				{@render capabiliity('Prompts', prompts.length > 0)}
-				{@render capabiliity('Resources', resources.length > 0)}
+				{@render capability('Tool Catalog', displayTools.length > 0)}
+				{@render capability('Prompts', prompts.length > 0)}
+				{@render capability('Resources', resources.length > 0)}
 			</ul>
 		</div>
 	{/if}
 {/snippet}
 
-{#snippet capabiliity(name: string, enabled: boolean)}
+{#snippet capability(name: string, enabled: boolean)}
 	<li
 		class={twMerge(
 			'flex w-fit items-center justify-center gap-1 rounded-full px-4 py-1 text-xs font-light',


### PR DESCRIPTION
Wait for requests to get tools, prompts, and resources to finish before
displaying MCP server capabilities to a user.

This ensure that even if a 424 (Failed Dependency) is returned by one of
the requests, it doesn't prevent the UI from showing the results of the
others to user in the capabilities section.

Addresses https://github.com/obot-platform/obot/issues/3492