### PR TITLE
Fix: prevent catalog from refreshing within a hour

### DIFF
--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -66,14 +66,10 @@ func (h *MCPCatalogHandler) Refresh(req api.Context) error {
 		return fmt.Errorf("failed to get catalog: %w", err)
 	}
 
-	if catalog.Annotations[v1.MCPCatalogSyncAnnotation] != "" {
-		delete(catalog.Annotations, v1.MCPCatalogSyncAnnotation)
-	} else {
-		if catalog.Annotations == nil {
-			catalog.Annotations = make(map[string]string)
-		}
-		catalog.Annotations[v1.MCPCatalogSyncAnnotation] = "true"
+	if catalog.Annotations == nil {
+		catalog.Annotations = make(map[string]string)
 	}
+	catalog.Annotations[v1.MCPCatalogSyncAnnotation] = "true"
 
 	return req.Update(&catalog)
 }


### PR DESCRIPTION
We should prevent catalog from syncing within the same hour(unless there is a force resync event). Also, stop applying if we hit any error so we don't accidently delete all the catalogs.

https://github.com/obot-platform/obot/issues/3321