### PR TITLE
fix: bootstrap redirect and side bar subsections

### DIFF
--- a/ui/handler.go
+++ b/ui/handler.go
@@ -70,6 +70,8 @@ func (s *uiServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if r.URL.Path == "/" {
 		http.ServeFileFS(w, r, embedded, "user/build/index.html")
+	} else if r.URL.Path == "/v2/admin" {
+		http.ServeFileFS(w, r, embedded, "user/build/v2/admin.html")
 	} else if _, err := fs.Stat(embedded, userPath); err == nil {
 		http.ServeFileFS(w, r, embedded, userPath)
 	} else if _, err := fs.Stat(embedded, adminPath); err == nil {

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -175,8 +175,8 @@
 													></div>
 													{#if item.disabled}
 														<div class="sidebar-link disabled">
-															<link.icon class="size-4" />
-															{link.label}
+															<item.icon class="size-4" />
+															{item.label}
 														</div>
 													{:else}
 														<a

--- a/ui/user/src/lib/stores/profile.svelte.ts
+++ b/ui/user/src/lib/stores/profile.svelte.ts
@@ -1,3 +1,4 @@
+import { BOOTSTRAP_USER_ID } from '$lib/constants';
 import { getProfile } from '$lib/services/chat/operations';
 import { type Profile } from '$lib/services/chat/types';
 
@@ -12,6 +13,9 @@ const store = $state({
 async function init() {
 	try {
 		store.current = await getProfile();
+		if (store.current.username === BOOTSTRAP_USER_ID) {
+			store.current.displayName = 'Bootstrap';
+		}
 	} catch (e) {
 		if (e instanceof Error && (e.message.startsWith('403') || e.message.startsWith('401'))) {
 			store.current = {

--- a/ui/user/src/routes/+page.ts
+++ b/ui/user/src/routes/+page.ts
@@ -1,16 +1,20 @@
-import { ChatService, getProfile, type AuthProvider } from '$lib/services';
-import { Role } from '$lib/services/admin/types';
+import { AdminService, ChatService, getProfile, type AuthProvider } from '$lib/services';
+import { Role, type BootstrapStatus } from '$lib/services/admin/types';
 import type { PageLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 
 export const load: PageLoad = async ({ fetch, url }) => {
+	let bootstrapStatus: BootstrapStatus | undefined;
 	let authProviders: AuthProvider[] = [];
 	let profile;
 
 	try {
 		profile = await getProfile({ fetch });
 	} catch (_err) {
-		authProviders = await ChatService.listAuthProviders({ fetch });
+		[bootstrapStatus, authProviders] = await Promise.all([
+			AdminService.getBootstrapStatus(),
+			ChatService.listAuthProviders({ fetch })
+		]);
 	}
 
 	const loggedIn = profile?.loaded ?? false;
@@ -23,8 +27,10 @@ export const load: PageLoad = async ({ fetch, url }) => {
 		}
 
 		// Redirect to appropriate dashboard
-		throw redirect(302, isAdmin ? '/v2/admin/mcp-servers' : '/mcp-servers');
-	} else if (authProviders.length === 0) {
+		throw redirect(302, isAdmin ? '/v2/admin' : '/mcp-servers');
+	}
+
+	if (bootstrapStatus?.enabled && authProviders.length === 0) {
 		// If no auth providers are configured, redirect to admin page for bootstrap login
 		throw redirect(302, '/v2/admin');
 	}


### PR DESCRIPTION
- Ensure bootstrap is enabled before redirecting for bootstrap login
- Redirect to `v2/admin` from `/` for admins and let that page redirect
  to the correct admin dashboard for the user (bootstrap should always
  go to `auth-providers`
- Serve correct build file for `/v2/admin` from UI handler in production
  mode
- Set profile display name to `Bootstrap` when authenticated as the
  bootstrap user
- Correct link name and image used for disabled subsection items in navbar

Addresses:
- https://github.com/obot-platform/obot/issues/3434
- https://github.com/obot-platform/obot/issues/3542