### PR TITLE
Fix: allow authed group to get model providers

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -79,6 +79,7 @@ var staticRules = map[string][]string{
 		"POST /api/llm-proxy/",
 		"POST /api/prompt",
 		"GET /api/models",
+		"GET /api/model-providers",
 		"GET /api/version",
 		"POST /api/image/generate",
 		"POST /api/image/upload",


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/3562

We need to get model provider in order to show properly model dropdown from chat views. I scanned through the model provider api list and there is no sensetive information, so we should be fine to expose that to regular users.