### PR TITLE
fix: empty default model aliases dropdowns

### DIFF
--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -641,6 +641,7 @@ export interface ModelProvider {
 	icon?: string;
 	iconDark?: string;
 	configured: boolean;
+	modelsBackPopulated?: boolean;
 	requiredConfigurationParameters?: {
 		name: string;
 		friendlyName?: string;


### PR DESCRIPTION
Modify the `v2/admin/model-providers` UI route such that:
- The `DefaultModels` component is automatically opened after configuring a model provider IFF the provider adds models that can be used for unconfigured aliases
- Poll until the providers models are back-populated before checking if we should automatically open the default model aliases dialog (w/ a 10 second timeout)

Modify the `DefaultModels` component such that:
- The set of available providers is plumbed down as a property
- The `Set Default Models` button is disabled when no models are available
- The `Save` button is disabled until the selected models differ from the current default model aliases
- When the current default model alias for a usage isn't set, the suggested model is automatically selected from available models

Addresses https://github.com/obot-platform/obot/issues/3543

https://github.com/user-attachments/assets/6595f509-2723-4ab3-b669-668f0e0fb23d



