### PR TITLE
chore: disable project files configuration

### DIFF
--- a/ui/user/src/lib/components/edit/ProjectConfiguration.svelte
+++ b/ui/user/src/lib/components/edit/ProjectConfiguration.svelte
@@ -5,7 +5,6 @@
 	import EditIcon from './EditIcon.svelte';
 	import { HELPER_TEXTS } from '$lib/context/helperMode.svelte';
 	import ProjectConfigurationKnowledge from './ProjectConfigurationKnowledge.svelte';
-	import ProjectConfigurationFiles from './ProjectConfigurationFiles.svelte';
 	import Confirm from '../Confirm.svelte';
 	import { goto } from '$app/navigation';
 
@@ -87,7 +86,6 @@
 			</div>
 
 			<ProjectConfigurationKnowledge {project} />
-			<ProjectConfigurationFiles {project} />
 
 			<div class="mb-8 flex flex-col gap-2">
 				<h2 class="text-xl font-semibold">Danger Zone</h2>


### PR DESCRIPTION
Remove project scoped files from project configuration in the user UI.
Leave the components to make it easier to revive the feature should we
decide to down the road.

Depends on https://github.com/obot-platform/tools/pull/717
Addresses https://github.com/obot-platform/obot/issues/3555

