### PR TITLE
fix: use correct logic for needsURL and checking for hostname drift

### DIFF
--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -2,7 +2,6 @@ package mcpserver
 
 import (
 	"fmt"
-	"net/url"
 	"slices"
 	"strings"
 
@@ -65,17 +64,10 @@ func configurationHasDrifted(serverManifest types.MCPServerManifest, entryManife
 		return true, nil
 	}
 
-	if entryManifest.Hostname != "" {
-		u, err := url.Parse(serverManifest.URL)
-		if err != nil {
-			// Shouldn't ever happen.
-			return true, err
-		}
-
-		if u.Hostname() != entryManifest.Hostname {
-			return true, nil
-		}
-	}
+	// We are deliberately ignoring the hostname here, even if there is one.
+	// If there is drift between the server's URL and the catalog entry's hostname,
+	// that's the user's responsibility to fix, and triggering an update will not fix it,
+	// so there is no need to make needsUpdate as true for that.
 
 	// Check the rest of the fields to see if anything has changed.
 	drifted := serverManifest.Command != entryManifest.Command ||


### PR DESCRIPTION
~~I thought these used to be mutually exclusive, but apparently they never were.~~

I updated the logic for this. We want to check for hostname drift if the server hasn't yet been marked with `needsURL`, because that would mean that there was a real change in the catalog that the admin has not yet applied. If `needsURL` is true, then there is no need to check for hostname drift, because we are waiting for the user to supply the new URL already.