### PR TITLE
Fix: fix thread model, use model id instead

### DIFF
--- a/pkg/thread/threadmodel.go
+++ b/pkg/thread/threadmodel.go
@@ -48,7 +48,7 @@ func GetModelAndModelProviderForThread(ctx context.Context, c kclient.Client, th
 	model := thread.Spec.Manifest.Model
 
 	// If it wasn't set on the thread, try to find a parent project that has it set.
-	if modelProvider == "" || model == "" {
+	if model == "" {
 		project, err := projects.GetFirst(ctx, c, thread, func(thread *v1.Thread) (bool, error) {
 			return thread.Spec.DefaultModelProvider != "" && thread.Spec.DefaultModel != "", nil
 		})

--- a/ui/user/src/lib/components/edit/ThreadModelSelector.svelte
+++ b/ui/user/src/lib/components/edit/ThreadModelSelector.svelte
@@ -336,20 +336,20 @@
 				<div class="flex flex-col">
 					{#each (() => {
 						const modelsByProvider = new Map<string, string[]>();
-						allowedModels.forEach((modelName) => {
-							// Find model by name since allowedModels contains model names
-							const model = Array.from(modelsMap.values()).find((m) => m.name === modelName);
+						allowedModels.forEach((modelId) => {
+							// Find model by ID since allowedModels contains model IDs
+							const model = modelsMap.get(modelId);
 							if (model) {
 								const providerId = model.modelProvider;
 								if (!modelsByProvider.has(providerId)) {
 									modelsByProvider.set(providerId, []);
 								}
-								modelsByProvider.get(providerId)!.push(modelName);
+								modelsByProvider.get(providerId)!.push(modelId);
 							}
 						});
 						return Array.from(modelsByProvider.entries());
-					})() as [providerId, modelNames] (providerId)}
-						{#if modelNames.length > 0}
+					})() as [providerId, modelIds] (providerId)}
+						{#if modelIds.length > 0}
 							{@const provider = modelProvidersMap.get(providerId)}
 							<div class="border-surface1 flex flex-col border-b py-2 last:border-transparent">
 								<div class="mb-2 flex gap-1 text-xs">
@@ -366,15 +366,13 @@
 									<div>{provider?.name ?? ''}</div>
 								</div>
 								<div class="provider-models flex flex-col gap-1">
-									{#each modelNames as modelName (modelName)}
-										{@const model = Array.from(modelsMap.values()).find(
-											(m) => m.name === modelName
-										)}
+									{#each modelIds as modelId (modelId)}
+										{@const model = modelsMap.get(modelId)}
 										{@const isModelSelected =
-											threadModelProvider === providerId && threadModel === modelName}
+											threadModelProvider === providerId && threadModel === modelId}
 
 										{@const isDefaultModel =
-											defaultModelProvider === providerId && defaultModel === modelName}
+											defaultModelProvider === providerId && defaultModel === model?.name}
 
 										{#if model}
 											<button
@@ -385,10 +383,10 @@
 													isModelSelected &&
 														'text-blue bg-blue/10 hover:bg-blue/15 active:bg-blue/20'
 												)}
-												onclick={() => setThreadModel(model.name, '')}
+												onclick={() => setThreadModel(model.id, '')}
 												tabindex="0"
 												data-provider={providerId}
-												data-model={modelName}
+												data-model={modelId}
 											>
 												<div>
 													{model.name}
@@ -403,7 +401,7 @@
 													/>
 												{/if}
 
-												{#if threadModelProvider === providerId && threadModel === modelName}
+												{#if threadModelProvider === providerId && threadModel === modelId}
 													<div class="ml-auto text-xs text-blue-500">✓</div>
 												{/if}
 											</button>

--- a/ui/user/src/routes/v2/admin/chat-configuration/+page.svelte
+++ b/ui/user/src/routes/v2/admin/chat-configuration/+page.svelte
@@ -40,7 +40,7 @@
 		new Map(modelsData.modelProviders.map((provider) => [provider.id, provider]))
 	);
 	let selectedModels = $derived(
-		modelsData.models.filter((model) => baseAgent?.allowedModels?.includes(model.name))
+		modelsData.models.filter((model) => baseAgent?.allowedModels?.includes(model.id))
 	);
 	let modelOptions = $derived(
 		modelsData.models.filter((model) => !model.usage || model.usage === ModelUsage.LLM)
@@ -264,17 +264,19 @@
 									>
 										Set as Default
 									</button>
-									<button
-										class="menu-button"
-										onclick={() => {
-											if (!baseAgent) return;
-											baseAgent.allowedModels = baseAgent.allowedModels?.filter(
-												(modelName) => modelName !== d.name
-											);
-										}}
-									>
-										Remove
-									</button>
+									{#if !d.isDefault}
+										<button
+											class="menu-button"
+											onclick={() => {
+												if (!baseAgent) return;
+												baseAgent.allowedModels = baseAgent.allowedModels?.filter(
+													(modelId) => modelId !== d.id
+												);
+											}}
+										>
+											Remove
+										</button>
+									{/if}
 								</div>
 							</DotDotDot>
 						{/snippet}
@@ -387,18 +389,18 @@
 							<button
 								class={twMerge(
 									'hover:bg-surface3 flex items-center justify-between gap-4 rounded-md bg-transparent p-2 font-light',
-									addModelsSelected[model.name] && 'bg-surface2'
+									addModelsSelected[model.id] && 'bg-surface2'
 								)}
 								onclick={() => {
-									if (addModelsSelected[model.name]) {
-										delete addModelsSelected[model.name];
+									if (addModelsSelected[model.id]) {
+										delete addModelsSelected[model.id];
 									} else {
-										addModelsSelected[model.name] = true;
+										addModelsSelected[model.id] = true;
 									}
 								}}
 							>
 								{model.name}
-								{#if addModelsSelected[model.name]}
+								{#if addModelsSelected[model.id]}
 									<Check class="size-4 text-blue-500" />
 								{/if}
 							</button>


### PR DESCRIPTION
We should use model id to set on the model allow list. We don't set alias anymore for models, so it has to use id to look up model correctly.


@ivyjeong13 Sorry I told you the wrong thing.. I realize there is a bug in backend that would prevent model name from working in backend. So switched to use id now :-)

https://github.com/obot-platform/obot/issues/3592
https://github.com/obot-platform/obot/issues/3593

