### PR TITLE
enhance: support multiple instances of a catalog entry

### DIFF
--- a/ui/user/src/lib/components/chat/McpServerSetup.svelte
+++ b/ui/user/src/lib/components/chat/McpServerSetup.svelte
@@ -187,7 +187,7 @@
 							loadData(true);
 						}}
 					>
-						{#snippet connectedServerCardAction(d)}
+						{#snippet connectedServerCardAction(d: ConnectedServer)}
 							{@const requiresUpdate = requiresUserUpdate(d)}
 							<button
 								disabled={requiresUpdate}

--- a/ui/user/src/lib/components/mcp/CatalogEditNameForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogEditNameForm.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import { LoaderCircle, Server } from 'lucide-svelte';
+	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import { ChatService } from '$lib/services';
+	import type { ConnectedServer } from './MyMcpServers.svelte';
+	import { errors } from '$lib/stores';
+
+	interface Props {
+		editingServer?: ConnectedServer;
+		onUpdateConfigure?: () => void;
+	}
+
+	let { editingServer, onUpdateConfigure }: Props = $props();
+
+	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let newName = $state('');
+	let originalName = $state('');
+	let saving = $state(false);
+
+	export function open() {
+		const name = editingServer?.server?.manifest?.name || '';
+		newName = name;
+		originalName = name;
+		dialog?.open();
+	}
+
+	export function close() {
+		dialog?.close();
+	}
+
+	async function handleSave() {
+		const trimmedName = newName.trim();
+		if (!editingServer?.server?.id || !trimmedName || trimmedName === originalName) return;
+
+		try {
+			saving = true;
+			const updatedManifest = { ...editingServer.server.manifest, name: trimmedName };
+			await ChatService.updateSingleOrRemoteMcpServer(editingServer.server.id, updatedManifest);
+			dialog?.close();
+			onUpdateConfigure?.();
+		} catch (err) {
+			errors.append(`Failed to update server name: ${err}`);
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<ResponsiveDialog
+	bind:this={dialog}
+	animate="slide"
+	onClose={() => {
+		newName = originalName;
+		saving = false;
+	}}
+>
+	{#snippet titleContent()}
+		<div class="flex items-center gap-2">
+			<div class="bg-surface1 rounded-sm p-1 dark:bg-gray-600">
+				{#if editingServer?.server?.manifest?.icon}
+					<img
+						src={editingServer.server.manifest.icon}
+						alt={newName || editingServer?.server?.manifest?.name}
+						class="size-8"
+					/>
+				{:else}
+					<Server class="size-8" />
+				{/if}
+			</div>
+			{newName || editingServer?.server?.manifest?.name || 'Server'}
+		</div>
+	{/snippet}
+
+	<form
+		onsubmit={(e) => {
+			e.preventDefault();
+			handleSave();
+		}}
+	>
+		<div class="my-4 flex flex-col gap-4">
+			<div class="flex flex-col gap-1">
+				<label for="serverName" class="text-sm font-medium">Server Name</label>
+				<input
+					type="text"
+					id="serverName"
+					bind:value={newName}
+					class="text-input-filled"
+					placeholder="Enter server name..."
+				/>
+			</div>
+		</div>
+	</form>
+
+	<div class="flex justify-end gap-2">
+		<button
+			class="button-primary"
+			onclick={handleSave}
+			disabled={saving || !newName.trim() || newName.trim() === originalName}
+		>
+			{#if saving}
+				<LoaderCircle class="size-4 animate-spin" />
+			{:else}
+				Update
+			{/if}
+		</button>
+	</div>
+</ResponsiveDialog>

--- a/ui/user/src/lib/components/mcp/MyMcpServers.svelte
+++ b/ui/user/src/lib/components/mcp/MyMcpServers.svelte
@@ -20,6 +20,7 @@
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import McpServerInfo from './McpServerInfo.svelte';
 	import CatalogConfigureForm from './CatalogConfigureForm.svelte';
+	import CatalogEditNameForm from './CatalogEditNameForm.svelte';
 	import DotDotDot from '../DotDotDot.svelte';
 	import Confirm from '../Confirm.svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -83,6 +84,8 @@
 	let configDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let configureForm = $state<LaunchFormData>();
 	let showServerInfo = $state(false);
+	let editingServer = $state<ConnectedServer>();
+	let editNameDialog = $state<ReturnType<typeof CatalogEditNameForm>>();
 
 	let selectedEntryOrServer = $state<Entry | ConnectedServer | Server>();
 	let selectedManifest = $derived(getManifest(selectedEntryOrServer));
@@ -101,18 +104,10 @@
 			])
 		)
 	);
-	let userConfiguredServersMap = $derived(
-		new Map(userConfiguredServers.map((server) => [server.catalogEntryID, server]))
-	);
 
 	let filteredEntriesData = $derived(
 		entries.filter((item) => {
 			if (item.deleted) {
-				return false;
-			}
-
-			const userConfiguredServer = userConfiguredServersMap.get(item.id);
-			if (userConfiguredServer) {
 				return false;
 			}
 
@@ -128,6 +123,7 @@
 			return true;
 		})
 	);
+
 	let filteredServers = $derived(
 		servers.filter((item) => {
 			if (item.deleted) {
@@ -278,6 +274,10 @@
 		return (item as ConnectedServer).server?.manifest;
 	}
 
+	function isSingleOrRemote(connectedServer: ConnectedServer | undefined) {
+		return connectedServer?.server && !connectedServer.instance;
+	}
+
 	function initConfigureForm(item: Entry) {
 		const manifest = item.commandManifest ?? item.urlManifest;
 		configureForm = {
@@ -374,23 +374,23 @@
 									}}
 								>
 									{#snippet action()}
-										{#if connectedServerCardAction}
-											{@render connectedServerCardAction(connectedServer)}
-										{:else}
+										<div class="flex items-center gap-1">
+											{@render connectedServerCardAction?.(connectedServer)}
 											<DotDotDot
 												class="icon-button hover:bg-surface1 dark:hover:bg-surface2 size-6 min-h-auto min-w-auto flex-shrink-0 p-1 hover:text-blue-500"
 												{disablePortal}
 												el={container}
 											>
 												<div class="default-dialog flex min-w-48 flex-col p-2">
-													{@render prependedDefaultActions(connectedServer)}
-													{#if additConnectedServerCardActions}
-														{@render additConnectedServerCardActions(connectedServer)}
+													{#if isSingleOrRemote(connectedServer)}
+														{@render editConfigAction(connectedServer)}
+														{@render editNameAction(connectedServer)}
 													{/if}
-													{@render appendedDefaultActions(connectedServer)}
+													{@render additConnectedServerCardActions?.(connectedServer)}
+													{@render disconnectAction(connectedServer)}
 												</div>
 											</DotDotDot>
-										{/if}
+										</div>
 									{/snippet}
 								</McpCard>
 							{/if}
@@ -453,6 +453,8 @@
 	submitText={selectedEntryOrServer && 'server' in selectedEntryOrServer ? 'Update' : 'Launch'}
 	loading={saving}
 />
+
+<CatalogEditNameForm bind:this={editNameDialog} {editingServer} {onUpdateConfigure} />
 
 <Confirm
 	msg="Are you sure you want to delete this server?"
@@ -548,9 +550,11 @@
 						{disablePortal}
 					>
 						<div class="default-dialog flex min-w-48 flex-col p-2">
-							{@render prependedDefaultActions(connectedServer)}
+							{#if isSingleOrRemote(connectedServer)}
+								{@render editConfigAction(connectedServer)}
+							{/if}
 							{@render additConnectedServerViewActions?.(connectedServer)}
-							{@render appendedDefaultActions(connectedServer)}
+							{@render disconnectAction(connectedServer)}
 						</div>
 					</DotDotDot>
 				{/if}
@@ -563,7 +567,7 @@
 	</div>
 {/snippet}
 
-{#snippet prependedDefaultActions(connectedServer: ConnectedServer)}
+{#snippet editConfigAction(connectedServer: ConnectedServer)}
 	{@const requiresUpdate = requiresUserUpdate(connectedServer)}
 	<button
 		class={twMerge(
@@ -604,7 +608,19 @@
 	</button>
 {/snippet}
 
-{#snippet appendedDefaultActions(connectedServer: ConnectedServer)}
+{#snippet editNameAction(connectedServer: ConnectedServer)}
+	<button
+		class="menu-button"
+		onclick={() => {
+			editingServer = connectedServer;
+			editNameDialog?.open();
+		}}
+	>
+		Edit Name
+	</button>
+{/snippet}
+
+{#snippet disconnectAction(connectedServer: ConnectedServer)}
 	<button
 		class="menu-button text-red-500"
 		onclick={async () => {


### PR DESCRIPTION
Make the following changes to the UI:
- Support connecting to a single/remote catalog entry multiple times
- Support renaming a connected single/remote MCP server
- Drop support for editing the configuration of connected multi-user MCP server instances

Addresses https://github.com/obot-platform/obot/issues/3359

Loom: https://www.loom.com/share/3b61b564c9724520b3d328ebf7a620f3?sid=b55b516f-7731-4811-9a3f-3ef1aa1cccb6

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
