### PR TITLE
fix: handle empty responses from MCP servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/mhale/smtpd v0.8.3
 	github.com/modelcontextprotocol/go-sdk v0.2.0
-	github.com/nanobot-ai/nanobot v0.0.6-0.20250723122733-7c0c65a44ace
+	github.com/nanobot-ai/nanobot v0.0.6-0.20250730144017-c1d3b81c73fb
 	github.com/obot-platform/kinm v0.0.0-20250328185534-d9c9de49cc20
 	github.com/obot-platform/nah v0.0.0-20250418220644-1b9278409317
 	github.com/obot-platform/namegenerator v0.0.0-20241217121223-fc58bdb7dca2

--- a/go.sum
+++ b/go.sum
@@ -519,8 +519,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/nanobot-ai/nanobot v0.0.6-0.20250723122733-7c0c65a44ace h1:0brFM/EIICR8LUkYCCV9HWvDE8PyRVKO5oRMXFHFeIk=
-github.com/nanobot-ai/nanobot v0.0.6-0.20250723122733-7c0c65a44ace/go.mod h1:vKoxU5Fro4DuvHq2AsxjhNYF3/KRlAuHLFT+NZ9ns5w=
+github.com/nanobot-ai/nanobot v0.0.6-0.20250730144017-c1d3b81c73fb h1:PKRqFTPdUsUIPo6kc/JDH9TLlwVr65sneTyzFbWqSvU=
+github.com/nanobot-ai/nanobot v0.0.6-0.20250730144017-c1d3b81c73fb/go.mod h1:vKoxU5Fro4DuvHq2AsxjhNYF3/KRlAuHLFT+NZ9ns5w=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nwaples/rardecode/v2 v2.1.0 h1:JQl9ZoBPDy+nIZGb1mx8+anfHp/LV3NE2MjMiv0ct/U=

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -362,6 +362,9 @@ func (m *MCPHandler) GetOAuthURL(req api.Context) error {
 func (m *MCPHandler) GetTools(req api.Context) error {
 	server, serverConfig, caps, err := serverForActionWithCapabilities(req, m.mcpSessionManager)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -388,6 +391,9 @@ func (m *MCPHandler) GetTools(req api.Context) error {
 
 	tools, err := toolsForServer(req.Context(), m.mcpSessionManager, req.User.GetUID(), server, serverConfig, allowedTools)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return fmt.Errorf("failed to list tools: %w", err)
 	}
 
@@ -438,6 +444,9 @@ func (m *MCPHandler) SetTools(req api.Context) error {
 
 	mcpTools, err := toolsForServer(req.Context(), m.mcpSessionManager, req.User.GetUID(), mcpServer, serverConfig, tools)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return fmt.Errorf("failed to render tools: %w", err)
 	}
 
@@ -469,6 +478,9 @@ func (m *MCPHandler) SetTools(req api.Context) error {
 func (m *MCPHandler) GetResources(req api.Context) error {
 	mcpServer, serverConfig, caps, err := serverForActionWithCapabilities(req, m.mcpSessionManager)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -479,7 +491,9 @@ func (m *MCPHandler) GetResources(req api.Context) error {
 	resources, err := m.mcpSessionManager.ListResources(req.Context(), req.User.GetUID(), mcpServer, serverConfig)
 	if err != nil {
 		var are nmcp.AuthRequiredErr
-		if strings.HasSuffix(err.Error(), "Method not found") {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		} else if strings.HasSuffix(err.Error(), "Method not found") {
 			return types.NewErrHTTP(http.StatusFailedDependency, "MCP server does not support resources")
 		} else if errors.As(err, &are) {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
@@ -493,6 +507,9 @@ func (m *MCPHandler) GetResources(req api.Context) error {
 func (m *MCPHandler) ReadResource(req api.Context) error {
 	mcpServer, serverConfig, caps, err := serverForActionWithCapabilities(req, m.mcpSessionManager)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -503,7 +520,9 @@ func (m *MCPHandler) ReadResource(req api.Context) error {
 	contents, err := m.mcpSessionManager.ReadResource(req.Context(), req.User.GetUID(), mcpServer, serverConfig, req.PathValue("resource_uri"))
 	if err != nil {
 		var are nmcp.AuthRequiredErr
-		if strings.HasSuffix(err.Error(), "Method not found") {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		} else if strings.HasSuffix(err.Error(), "Method not found") {
 			return types.NewErrHTTP(http.StatusFailedDependency, "MCP server does not support resources")
 		} else if errors.As(err, &are) {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
@@ -517,6 +536,9 @@ func (m *MCPHandler) ReadResource(req api.Context) error {
 func (m *MCPHandler) GetPrompts(req api.Context) error {
 	mcpServer, serverConfig, caps, err := serverForActionWithCapabilities(req, m.mcpSessionManager)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -527,7 +549,9 @@ func (m *MCPHandler) GetPrompts(req api.Context) error {
 	prompts, err := m.mcpSessionManager.ListPrompts(req.Context(), req.User.GetUID(), mcpServer, serverConfig)
 	if err != nil {
 		var are nmcp.AuthRequiredErr
-		if strings.HasSuffix(err.Error(), "Method not found") {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		} else if strings.HasSuffix(err.Error(), "Method not found") {
 			return types.NewErrHTTP(http.StatusFailedDependency, "MCP server does not support prompts")
 		} else if errors.As(err, &are) {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
@@ -541,6 +565,9 @@ func (m *MCPHandler) GetPrompts(req api.Context) error {
 func (m *MCPHandler) GetPrompt(req api.Context) error {
 	mcpServer, serverConfig, caps, err := serverForActionWithCapabilities(req, m.mcpSessionManager)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -556,7 +583,9 @@ func (m *MCPHandler) GetPrompt(req api.Context) error {
 	messages, description, err := m.mcpSessionManager.GetPrompt(req.Context(), req.User.GetUID(), mcpServer, serverConfig, req.PathValue("prompt_name"), args)
 	if err != nil {
 		var are nmcp.AuthRequiredErr
-		if strings.HasSuffix(err.Error(), "Method not found") {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		} else if strings.HasSuffix(err.Error(), "Method not found") {
 			return types.NewErrHTTP(http.StatusFailedDependency, "MCP server does not support prompts")
 		} else if errors.As(err, &are) {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -290,6 +290,9 @@ func (p *ProjectMCPHandler) GetTools(req api.Context) error {
 
 	caps, err := p.mcpSessionManager.ServerCapabilities(req.Context(), req.User.GetUID(), server, serverConfig)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -314,6 +317,9 @@ func (p *ProjectMCPHandler) GetTools(req api.Context) error {
 
 	tools, err := toolsForServer(req.Context(), p.mcpSessionManager, req.User.GetUID(), server, serverConfig, allowedTools)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return fmt.Errorf("failed to list tools: %w", err)
 	}
 
@@ -382,6 +388,9 @@ func (p *ProjectMCPHandler) SetTools(req api.Context) error {
 
 	mcpTools, err := toolsForServer(req.Context(), p.mcpSessionManager, req.User.GetUID(), mcpServer, serverConfig, tools)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return fmt.Errorf("failed to render tools: %w", err)
 	}
 
@@ -432,6 +441,9 @@ func (p *ProjectMCPHandler) GetResources(req api.Context) error {
 
 	caps, err := p.mcpSessionManager.ServerCapabilities(req.Context(), req.User.GetUID(), server, serverConfig)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -442,7 +454,9 @@ func (p *ProjectMCPHandler) GetResources(req api.Context) error {
 	resources, err := p.mcpSessionManager.ListResources(req.Context(), req.User.GetUID(), server, serverConfig)
 	if err != nil {
 		var are nmcp.AuthRequiredErr
-		if strings.HasSuffix(err.Error(), "Method not found") {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		} else if strings.HasSuffix(err.Error(), "Method not found") {
 			return types.NewErrHTTP(http.StatusFailedDependency, "MCP server does not support resources")
 		} else if errors.As(err, &are) {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
@@ -475,6 +489,9 @@ func (p *ProjectMCPHandler) ReadResource(req api.Context) error {
 
 	caps, err := p.mcpSessionManager.ServerCapabilities(req.Context(), req.User.GetUID(), server, serverConfig)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -485,7 +502,9 @@ func (p *ProjectMCPHandler) ReadResource(req api.Context) error {
 	contents, err := p.mcpSessionManager.ReadResource(req.Context(), req.User.GetUID(), server, serverConfig, req.PathValue("resource_uri"))
 	if err != nil {
 		var are nmcp.AuthRequiredErr
-		if strings.HasSuffix(err.Error(), "Method not found") {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		} else if strings.HasSuffix(err.Error(), "Method not found") {
 			return types.NewErrHTTP(http.StatusFailedDependency, "MCP server does not support resources")
 		} else if errors.As(err, &are) {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
@@ -518,6 +537,9 @@ func (p *ProjectMCPHandler) GetPrompts(req api.Context) error {
 
 	caps, err := p.mcpSessionManager.ServerCapabilities(req.Context(), req.User.GetUID(), server, serverConfig)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -528,7 +550,9 @@ func (p *ProjectMCPHandler) GetPrompts(req api.Context) error {
 	prompts, err := p.mcpSessionManager.ListPrompts(req.Context(), req.User.GetUID(), server, serverConfig)
 	if err != nil {
 		var are nmcp.AuthRequiredErr
-		if strings.HasSuffix(err.Error(), "Method not found") {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		} else if strings.HasSuffix(err.Error(), "Method not found") {
 			return types.NewErrHTTP(http.StatusFailedDependency, "MCP server does not support prompts")
 		} else if errors.As(err, &are) {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
@@ -561,6 +585,9 @@ func (p *ProjectMCPHandler) GetPrompt(req api.Context) error {
 
 	caps, err := p.mcpSessionManager.ServerCapabilities(req.Context(), req.User.GetUID(), server, serverConfig)
 	if err != nil {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		}
 		return err
 	}
 
@@ -576,7 +603,9 @@ func (p *ProjectMCPHandler) GetPrompt(req api.Context) error {
 	messages, description, err := p.mcpSessionManager.GetPrompt(req.Context(), req.User.GetUID(), server, serverConfig, req.PathValue("prompt_name"), args)
 	if err != nil {
 		var are nmcp.AuthRequiredErr
-		if strings.HasSuffix(err.Error(), "Method not found") {
+		if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
+			return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
+		} else if strings.HasSuffix(err.Error(), "Method not found") {
 			return types.NewErrHTTP(http.StatusFailedDependency, "MCP server does not support prompts")
 		} else if errors.As(err, &are) {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -16,7 +16,7 @@ func (sm *SessionManager) ListTools(ctx context.Context, userID string, mcpServe
 
 	resp, err := client.ListTools(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list MCP prompts: %w", err)
+		return nil, fmt.Errorf("failed to list MCP tools: %w", err)
 	}
 
 	return resp.Tools, nil

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
@@ -22,7 +22,6 @@ type MCPServerCatalogEntry struct {
 func (in *MCPServerCatalogEntry) GetColumns() [][]string {
 	return [][]string{
 		{"Name", "Name"},
-		{"Tool Reference", "Spec.ToolReferenceName"},
 		{"MCP Catalog", "Spec.MCPCatalogName"},
 		{"Created", "{{ago .CreationTimestamp}}"},
 	}

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -8,10 +8,19 @@
 		type Project,
 		type ProjectMCP
 	} from '$lib/services';
-	import { ChevronDown, ChevronUp, Info, LoaderCircle, RefreshCcw, Wrench } from 'lucide-svelte';
+	import {
+		AlertCircle,
+		ChevronDown,
+		ChevronUp,
+		Info,
+		LoaderCircle,
+		RefreshCcw,
+		Wrench
+	} from 'lucide-svelte';
 	import Toggle from '../Toggle.svelte';
 	import { slide } from 'svelte/transition';
 	import { responsive } from '$lib/stores';
+	import { parseErrorContent } from '$lib/errors';
 	import Search from '../Search.svelte';
 
 	interface Props {
@@ -29,6 +38,7 @@
 	let previousEntryId = $state<string | undefined>(undefined);
 	let oauthURL = $state<string>('');
 	let showRefresh = $state(false);
+	let error = $state('');
 	// Create AbortController for cancelling API calls
 	let abortController = $state<AbortController | null>(null);
 
@@ -109,6 +119,7 @@
 		loading = true;
 		oauthURL = '';
 		showRefresh = false;
+		error = '';
 
 		try {
 			if (project) {
@@ -150,6 +161,8 @@
 			// Only handle errors if the request wasn't aborted
 			if (err instanceof Error && err.name !== 'AbortError') {
 				console.error(err);
+				const { message } = parseErrorContent(err);
+				error = message;
 			}
 		} finally {
 			loading = false;
@@ -199,6 +212,17 @@
 						This is a preview of the tools that are available for this MCP server; the actual tools
 						may differ on user connection.
 					</div>
+				</div>
+			</div>
+		{/if}
+		{#if error}
+			<div class="notification-error flex w-full items-center gap-2 p-3">
+				<AlertCircle class="size-4" />
+				<div class="flex flex-col">
+					<p class="text-sm font-semibold">Unable to retrieve the server's tools</p>
+					<p class="text-sm font-light">
+						{error}
+					</p>
 				</div>
 			</div>
 		{/if}


### PR DESCRIPTION
An empty response most likely means that the MCP server failed to start or crashed for some reason. Report such errors to the user in the UI.

Part of: https://github.com/obot-platform/obot/issues/3280

<img width="2720" height="1950" alt="Screenshot 2025-07-30 at 10 08 20" src="https://github.com/user-attachments/assets/dfd77cc6-dadc-49cd-9fec-638fd108e1aa" />
