### PR TITLE
fix: ignore events that have "waitingOnModel": true after more progress

### DIFF
--- a/ui/user/src/lib/services/chat/messages.ts
+++ b/ui/user/src/lib/services/chat/messages.ts
@@ -214,7 +214,7 @@ function toMessages(progresses: Progress[], opts?: AdditionalOptions): Messages 
 		}
 	}
 
-	for (const progress of progresses) {
+	for (const [i, progress] of progresses.entries()) {
 		if (progress.error) {
 			if (progress.runID) {
 				for (const message of messages) {
@@ -229,13 +229,13 @@ function toMessages(progresses: Progress[], opts?: AdditionalOptions): Messages 
 			lastStepID = progress.step.id;
 		}
 
-		if (progress.runID) {
-			lastRunID = progress.runID;
-			inProgress = true;
-		} else {
+		if (!progress.runID) {
 			// if it doesn't have a runID we don't know what do to with it, so ignore
 			continue;
 		}
+
+		lastRunID = progress.runID;
+		inProgress = true;
 
 		if (progress.parentRunID) {
 			parentRunID = progress.parentRunID;
@@ -276,7 +276,7 @@ function toMessages(progresses: Progress[], opts?: AdditionalOptions): Messages 
 			// delete the current runID, this is to avoid duplicate messages
 			messages = messages.filter((m) => m.runID !== progress.runID);
 			messages.push(newInputMessage(progress, parentRunID));
-		} else if (progress.content || progress.waitingOnModel) {
+		} else if (progress.content || (progress.waitingOnModel && i == progresses.length - 1)) {
 			const found = messages.findLast(
 				(m) => m.contentID === progress.contentID && progress.contentID
 			);


### PR DESCRIPTION
When more progress comes in, this event will be replaced by the next event.

Issue: https://github.com/obot-platform/obot/issues/3630

https://www.loom.com/share/70f1bcc0ce754ab18607bccfc70cd808