### PR TITLE
Fix: fix helm install command to fetch token

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -8,4 +8,4 @@ To learn more about the release, try:
   $ helm get all {{ .Release.Name }}
 
 You can retrieve the bootstrap token by running:
-  $ kubectl get secret -n {{ .Release.Namespace }} {{ include "obot.config.secretName" . }} -ojson | jq -r .data.OBOT_BOOTSTRAP_TOKEN | base64 -d
+  $ kubectl get secret -n {{ .Release.Namespace }} {{ include "obot.config.secretName" . }} -ojson | jq -r .data.OBOT_BOOTSTRAP_TOKEN | base64 -d; echo


### PR DESCRIPTION
The previous helm command doesn't add new line at the end. this will produce weird output when user is using zsh. So add a new line to improve user experience.

https://github.com/obot-platform/obot/issues/3582