### PR TITLE
fix: remove the reveal icon for secret when editing a filter

### DIFF
--- a/ui/user/src/lib/components/admin/FilterForm.svelte
+++ b/ui/user/src/lib/components/admin/FilterForm.svelte
@@ -226,10 +226,12 @@
 									placement: 'top-end'
 								}}
 							>
-								{#if showSecret}
-									<EyeOff class="size-4" />
-								{:else}
-									<Eye class="size-4" />
+								{#if !initialFilter}
+									{#if showSecret}
+										<EyeOff class="size-4" />
+									{:else}
+										<Eye class="size-4" />
+									{/if}
 								{/if}
 							</button>
 						{/if}


### PR DESCRIPTION
It is not possible to reveal the secret for an existing webhook filter, so this change removes the icon.

Issue: https://github.com/obot-platform/obot/issues/3662