### PR TITLE
fix: ensure project MCP server requests go through the gateway

### DIFF
--- a/pkg/api/handlers/agent.go
+++ b/pkg/api/handlers/agent.go
@@ -819,8 +819,10 @@ func (a *AgentHandler) Script(req api.Context) error {
 		}
 	}
 
-	tools, extraEnv, err := render.Agent(req.Context(), a.tokenService, a.mcpSessionManager, req.Storage, &agent, req.User.GetUID(), a.serverURL, render.AgentOptions{
-		Thread: thread,
+	tools, extraEnv, err := render.Agent(req.Context(), a.tokenService, a.mcpSessionManager, req.Storage, &agent, a.serverURL, render.AgentOptions{
+		Thread:      thread,
+		UserID:      req.User.GetUID(),
+		UserIsAdmin: req.UserIsAdmin(),
 	})
 	if err != nil {
 		return err

--- a/pkg/api/handlers/assistants.go
+++ b/pkg/api/handlers/assistants.go
@@ -93,6 +93,7 @@ func (a *AssistantHandler) Invoke(req api.Context) error {
 	resp, err := a.invoker.Thread(req.Context(), a.cachedClient, &thread, string(input), invoke.Options{
 		GenerateName: system.ChatRunPrefix,
 		UserUID:      req.User.GetUID(),
+		UserIsAdmin:  req.UserIsAdmin(),
 	})
 	if err != nil {
 		return err

--- a/pkg/api/handlers/invoke.go
+++ b/pkg/api/handlers/invoke.go
@@ -64,6 +64,7 @@ func (i *InvokeHandler) Invoke(req api.Context) error {
 		Synchronous:  synchronous,
 		CreateThread: true,
 		UserUID:      req.User.GetUID(),
+		UserIsAdmin:  req.UserIsAdmin(),
 	})
 	if err != nil {
 		return err

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -53,7 +53,7 @@ func Router(services *services.Services) (http.Handler, error) {
 	images := handlers.NewImageHandler(services.GeminiClient)
 	slackHandler := handlers.NewSlackHandler()
 	mcp := handlers.NewMCPHandler(services.MCPLoader, services.AccessControlRuleHelper, oauthChecker, services.ServerURL)
-	projectMCP := handlers.NewProjectMCPHandler(services.MCPLoader, services.AccessControlRuleHelper, oauthChecker, services.ServerURL)
+	projectMCP := handlers.NewProjectMCPHandler(services.MCPLoader, services.AccessControlRuleHelper, services.TokenServer, oauthChecker, services.ServerURL)
 	projectInvitations := handlers.NewProjectInvitationHandler()
 	mcpGateway := mcpgateway.NewHandler(services.TokenServer, services.StorageClient, services.MCPLoader, services.WebhookHelper, services.MCPOAuthTokenStorage, services.ServerURL)
 	mcpAuditLogs := mcpgateway.NewAuditLogHandler()

--- a/pkg/controller/handlers/cleanup/projectmcp.go
+++ b/pkg/controller/handlers/cleanup/projectmcp.go
@@ -11,7 +11,7 @@ import (
 func (c *Credentials) ShutdownProjectMCP(req router.Request, _ router.Response) error {
 	projectServer := req.Object.(*v1.ProjectMCPServer)
 
-	config, err := mcp.ProjectServerToConfig(c.tokenService, *projectServer, c.serverURL, projectServer.Spec.UserID)
+	config, err := mcp.ProjectServerToConfig(c.tokenService, *projectServer, c.serverURL, projectServer.Spec.UserID, false)
 	if err != nil {
 		return fmt.Errorf("failed to convert project server to config: %w", err)
 	}

--- a/pkg/invoke/invoker.go
+++ b/pkg/invoke/invoker.go
@@ -191,6 +191,7 @@ type Options struct {
 	CreateThread          bool
 	CredentialContextIDs  []string
 	UserUID               string
+	UserIsAdmin           bool
 	GenerateName          string
 	ExtraEnv              []string
 }
@@ -367,9 +368,10 @@ func (i *Invoker) Agent(ctx context.Context, c kclient.WithWatch, agent *v1.Agen
 		}
 	}
 
-	tools, extraEnv, err := render.Agent(ctx, i.tokenService, i.mcpSessionManager, c, agent, opt.UserUID, i.serverURL, render.AgentOptions{
+	tools, extraEnv, err := render.Agent(ctx, i.tokenService, i.mcpSessionManager, c, agent, i.serverURL, render.AgentOptions{
 		Thread:         thread,
 		WorkflowStepID: opt.WorkflowStepID,
+		UserID:         opt.UserUID,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/invoke/system.go
+++ b/pkg/invoke/system.go
@@ -64,7 +64,7 @@ func (i *Invoker) EphemeralThreadTask(ctx context.Context, thread *v1.Thread, to
 					Env:    agent.Spec.Manifest.Env,
 				},
 			},
-		}, "", i.serverURL, render.AgentOptions{
+		}, i.serverURL, render.AgentOptions{
 			Thread: thread,
 		})
 		if err != nil {

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -16,12 +16,12 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 )
 
-func (sm *SessionManager) GPTScriptTools(ctx context.Context, tokenService *jwt.TokenService, projectMCPServer v1.ProjectMCPServer, userID, mcpServerDisplayName, serverURL string, allowedTools []string) ([]gptscript.ToolDef, error) {
+func (sm *SessionManager) GPTScriptTools(ctx context.Context, tokenService *jwt.TokenService, projectMCPServer v1.ProjectMCPServer, userID, mcpServerDisplayName, serverURL string, userIsAdmin bool, allowedTools []string) ([]gptscript.ToolDef, error) {
 	if mcpServerDisplayName == "" {
 		mcpServerDisplayName = projectMCPServer.Name
 	}
 
-	serverConfig, err := ProjectServerToConfig(tokenService, projectMCPServer, serverURL, userID, allowedTools...)
+	serverConfig, err := ProjectServerToConfig(tokenService, projectMCPServer, serverURL, userID, userIsAdmin, allowedTools...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert MCP server %s to server config: %w", mcpServerDisplayName, err)
 	}

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -6,6 +6,7 @@ import (
 
 	gmcp "github.com/gptscript-ai/gptscript/pkg/mcp"
 	nmcp "github.com/nanobot-ai/nanobot/pkg/mcp"
+	"github.com/obot-platform/obot/pkg/api/authz"
 	"github.com/obot-platform/obot/pkg/jwt"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 )
@@ -99,10 +100,14 @@ func ServerToServerConfig(mcpServer v1.MCPServer, scope string, credEnv map[stri
 	return serverConfig, missingRequiredNames, nil
 }
 
-func ProjectServerToConfig(tokenService *jwt.TokenService, projectMCPServer v1.ProjectMCPServer, baseURL, userID string, allowedTools ...string) (ServerConfig, error) {
-	token, err := tokenService.NewToken(jwt.TokenContext{
+func ProjectServerToConfig(tokenService *jwt.TokenService, projectMCPServer v1.ProjectMCPServer, baseURL, userID string, userIsAdmin bool, allowedTools ...string) (ServerConfig, error) {
+	tokenContext := jwt.TokenContext{
 		UserID: userID,
-	})
+	}
+	if userIsAdmin {
+		tokenContext.UserGroups = []string{authz.AdminGroup}
+	}
+	token, err := tokenService.NewToken(tokenContext)
 	if err != nil {
 		return ServerConfig{}, fmt.Errorf("failed to create token: %w", err)
 	}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -35,6 +35,8 @@ var DefaultAgentParams = []string{
 type AgentOptions struct {
 	Thread         *v1.Thread
 	WorkflowStepID string
+	UserID         string
+	UserIsAdmin    bool
 }
 
 func stringAppend(first string, second ...string) string {
@@ -47,7 +49,7 @@ func stringAppend(first string, second ...string) string {
 	return strings.Join(append([]string{first}, second...), "\n\n")
 }
 
-func Agent(ctx context.Context, tokenService *jwt.TokenService, mcpSessionManager *mcp.SessionManager, db kclient.Client, agent *v1.Agent, userID, serverURL string, opts AgentOptions) (_ []gptscript.ToolDef, extraEnv []string, _ error) {
+func Agent(ctx context.Context, tokenService *jwt.TokenService, mcpSessionManager *mcp.SessionManager, db kclient.Client, agent *v1.Agent, serverURL string, opts AgentOptions) (_ []gptscript.ToolDef, extraEnv []string, _ error) {
 	defer func() {
 		sort.Strings(extraEnv)
 	}()
@@ -162,7 +164,7 @@ func Agent(ctx context.Context, tokenService *jwt.TokenService, mcpSessionManage
 			}
 			mcpDisplayName = mcpServer.Spec.Manifest.Name
 
-			toolDefs, err := mcpSessionManager.GPTScriptTools(ctx, tokenService, projectMCPServer, userID, mcpDisplayName, serverURL, allowedTools)
+			toolDefs, err := mcpSessionManager.GPTScriptTools(ctx, tokenService, projectMCPServer, opts.UserID, mcpDisplayName, serverURL, opts.UserIsAdmin, allowedTools)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
This change will ensure that every MCP request made through chat will go through the MCP gateway. Additionally, a change is made so that admins can make these requests.

Issues: https://github.com/obot-platform/obot/issues/3668, https://github.com/obot-platform/obot/issues/3673