### PR TITLE
fix: filter blank selector identifiers when creating/updating filters

### DIFF
--- a/ui/user/src/lib/components/admin/FilterForm.svelte
+++ b/ui/user/src/lib/components/admin/FilterForm.svelte
@@ -435,9 +435,12 @@
 							secret: filter.secret || undefined,
 							selectors:
 								filter.selectors.length > 0
-									? filter.selectors.filter(
-											(s) => s.method || (s.identifiers && s.identifiers.some((id) => id.trim()))
-										)
+									? filter.selectors
+											.map((s) => ({
+												...s,
+												identifiers: s.identifiers?.filter((id) => id.trim()) || []
+											}))
+											.filter((s) => s.method || (s.identifiers && s.identifiers.length > 0))
 									: undefined
 						};
 


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/3672