### PR TITLE
fix: use proper types when looking for audit log filter options

### DIFF
--- a/pkg/api/handlers/mcpgateway/auditlog.go
+++ b/pkg/api/handlers/mcpgateway/auditlog.go
@@ -145,17 +145,20 @@ func (h *AuditLogHandler) ListAuditLogs(req api.Context) error {
 	})
 }
 
-var filterOptions = map[string]struct{}{
-	"user_id":                       {},
-	"mcp_id":                        {},
-	"mcp_server_display_name":       {},
-	"mcp_server_catalog_entry_name": {},
-	"call_type":                     {},
-	"session_id":                    {},
-	"client_name":                   {},
-	"client_version":                {},
-	"response_status":               {},
-	"client_ip":                     {},
+// filterOptions represent the values that a user can use to filter audit logs.
+// The values of this map represent the "zero" values that are excluded when looking for options in the database.
+// For example, "" for strings and 0 for numbers.
+var filterOptions = map[string]any{
+	"user_id":                       "",
+	"mcp_id":                        "",
+	"mcp_server_display_name":       "",
+	"mcp_server_catalog_entry_name": "",
+	"call_type":                     "",
+	"session_id":                    "",
+	"client_name":                   "",
+	"client_version":                "",
+	"response_status":               0,
+	"client_ip":                     "",
 }
 
 func (h *AuditLogHandler) ListAuditLogFilterOptions(req api.Context) error {
@@ -164,11 +167,12 @@ func (h *AuditLogHandler) ListAuditLogFilterOptions(req api.Context) error {
 		return types.NewErrBadRequest("missing option")
 	}
 
-	if _, ok := filterOptions[filter]; !ok {
+	exclude, ok := filterOptions[filter]
+	if !ok {
 		return types.NewErrBadRequest("invalid option: %s", filter)
 	}
 
-	options, err := req.GatewayClient.GetAuditLogFilterOptions(req.Context(), filter)
+	options, err := req.GatewayClient.GetAuditLogFilterOptions(req.Context(), filter, exclude)
 	if err != nil {
 		return err
 	}

--- a/pkg/gateway/client/mcpauditlog.go
+++ b/pkg/gateway/client/mcpauditlog.go
@@ -125,9 +125,13 @@ func (c *Client) GetMCPAuditLogs(ctx context.Context, opts MCPAuditLogOptions) (
 	return logs, db.Find(&logs).Error
 }
 
-func (c *Client) GetAuditLogFilterOptions(ctx context.Context, option string) ([]string, error) {
+func (c *Client) GetAuditLogFilterOptions(ctx context.Context, option string, exclude ...any) ([]string, error) {
+	db := c.db.WithContext(ctx).Model(&types.MCPAuditLog{}).Distinct(option)
 	var result []string
-	return result, c.db.WithContext(ctx).Model(&types.MCPAuditLog{}).Distinct(option).Where(option + " != ''").Select(option).Scan(&result).Error
+	if len(exclude) != 0 {
+		db.Where(option+" NOT IN ?", exclude)
+	}
+	return result, db.Select(option).Scan(&result).Error
 }
 
 // GetMCPUsageStats retrieves usage statistics for MCP servers


### PR DESCRIPTION
The response_status field is an integer, so we can't compare it to an empty string. This change uses proper types so we get the right data out of the database for all filter options.