### PR TITLE
fix: use uncached gets in authorizer to avoid creation race

### DIFF
--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -17,7 +17,7 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user us
 
 	if strings.HasPrefix(resources.MCPID, system.MCPServerInstancePrefix) {
 		var mcpServerInstance v1.MCPServerInstance
-		if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &mcpServerInstance); err != nil {
+		if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &mcpServerInstance); err != nil {
 			return false, err
 		}
 
@@ -25,7 +25,7 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user us
 	}
 
 	var mcpServer v1.MCPServer
-	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &mcpServer); err != nil {
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &mcpServer); err != nil {
 		return false, err
 	}
 

--- a/pkg/api/authz/mcpserver.go
+++ b/pkg/api/authz/mcpserver.go
@@ -18,7 +18,7 @@ func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, u u
 		mcpServer v1.MCPServer
 	)
 
-	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPServerID), &mcpServer); err != nil {
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPServerID), &mcpServer); err != nil {
 		return false, err
 	}
 

--- a/pkg/api/authz/mcpserverinstance.go
+++ b/pkg/api/authz/mcpserverinstance.go
@@ -15,7 +15,7 @@ func (a *Authorizer) checkMCPServerInstance(req *http.Request, resources *Resour
 	}
 
 	var mcpServerInstance v1.MCPServerInstance
-	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPServerInstanceID), &mcpServerInstance); err != nil {
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPServerInstanceID), &mcpServerInstance); err != nil {
 		return false, err
 	}
 

--- a/pkg/api/authz/oauthclient.go
+++ b/pkg/api/authz/oauthclient.go
@@ -22,7 +22,7 @@ func (a *Authorizer) checkOAuthClient(r *http.Request) bool {
 	}
 
 	var oauthClient v1.OAuthClient
-	err := a.storage.Get(r.Context(), kclient.ObjectKey{Namespace: namespace, Name: name}, &oauthClient)
+	err := a.get(r.Context(), kclient.ObjectKey{Namespace: namespace, Name: name}, &oauthClient)
 
 	return err == nil && bcrypt.CompareHashAndPassword(oauthClient.Spec.RegistrationTokenHash, []byte(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))) == nil
 }
@@ -49,7 +49,7 @@ func (a *Authorizer) oauthClientBasicAuth(r *http.Request) bool {
 	}
 
 	var oauthClient v1.OAuthClient
-	if err = a.storage.Get(r.Context(), kclient.ObjectKey{Namespace: parts[0], Name: parts[1]}, &oauthClient); err != nil {
+	if err = a.get(r.Context(), kclient.ObjectKey{Namespace: parts[0], Name: parts[1]}, &oauthClient); err != nil {
 		return false
 	}
 

--- a/pkg/api/authz/project.go
+++ b/pkg/api/authz/project.go
@@ -25,7 +25,7 @@ func (a *Authorizer) checkProject(req *http.Request, resources *Resources, user 
 		projectThreadID = strings.Replace(resources.ProjectID, system.ProjectPrefix, system.ThreadPrefix, 1)
 	)
 
-	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, projectThreadID), &thread); err != nil {
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, projectThreadID), &thread); err != nil {
 		return false, err
 	}
 
@@ -59,7 +59,7 @@ func (a *Authorizer) projectIsAuthorized(ctx context.Context, agentID string, th
 
 	for _, userID := range validUserIDs {
 		var access v1.ThreadAuthorizationList
-		err := a.storage.List(ctx, &access, kclient.InNamespace(system.DefaultNamespace), kclient.MatchingFields{
+		err := a.cache.List(ctx, &access, kclient.InNamespace(system.DefaultNamespace), kclient.MatchingFields{
 			"spec.userID":   userID,
 			"spec.threadID": thread.Name,
 		})

--- a/pkg/api/authz/projectmcpserver.go
+++ b/pkg/api/authz/projectmcpserver.go
@@ -15,7 +15,7 @@ func (a *Authorizer) checkProjectMCPServer(req *http.Request, resources *Resourc
 	}
 
 	var projectMCPServer v1.ProjectMCPServer
-	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.ProjectMCPServerID), &projectMCPServer); err != nil {
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.ProjectMCPServerID), &projectMCPServer); err != nil {
 		return false, err
 	}
 

--- a/pkg/api/authz/run.go
+++ b/pkg/api/authz/run.go
@@ -22,7 +22,7 @@ func (a *Authorizer) checkRun(req *http.Request, resources *Resources, _ user.In
 		wfe v1.WorkflowExecution
 	)
 
-	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.RunID), &wfe); err != nil {
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.RunID), &wfe); err != nil {
 		return false, err
 	}
 

--- a/pkg/api/authz/task.go
+++ b/pkg/api/authz/task.go
@@ -18,7 +18,7 @@ func (a *Authorizer) checkTask(req *http.Request, resources *Resources, _ user.I
 		workflow v1.Workflow
 	)
 
-	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.TaskID), &workflow); err != nil {
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.TaskID), &workflow); err != nil {
 		return false, err
 	}
 

--- a/pkg/api/authz/template.go
+++ b/pkg/api/authz/template.go
@@ -14,7 +14,7 @@ func (a *Authorizer) checkTemplate(req *http.Request, resources *Resources) (boo
 	}
 
 	var templateShareList v1.ThreadShareList
-	err := a.storage.List(req.Context(), &templateShareList, kclient.InNamespace(system.DefaultNamespace), kclient.MatchingFields{
+	err := a.cache.List(req.Context(), &templateShareList, kclient.InNamespace(system.DefaultNamespace), kclient.MatchingFields{
 		"spec.publicID": resources.TemplateID,
 	})
 

--- a/pkg/api/authz/thread.go
+++ b/pkg/api/authz/thread.go
@@ -19,7 +19,7 @@ func (a *Authorizer) checkThread(req *http.Request, resources *Resources, user u
 		thread v1.Thread
 	)
 
-	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.ThreadID), &thread); err != nil {
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.ThreadID), &thread); err != nil {
 		return false, err
 	}
 

--- a/pkg/api/authz/threadshare.go
+++ b/pkg/api/authz/threadshare.go
@@ -19,7 +19,7 @@ func (a *Authorizer) checkThreadShare(req *http.Request, resources *Resources, u
 		threadShareList v1.ThreadShareList
 	)
 
-	err := a.storage.List(req.Context(), &threadShareList, kclient.InNamespace(system.DefaultNamespace), kclient.MatchingFields{
+	err := a.cache.List(req.Context(), &threadShareList, kclient.InNamespace(system.DefaultNamespace), kclient.MatchingFields{
 		"spec.publicID": resources.ThreadShareID,
 	})
 	if err != nil {

--- a/pkg/api/authz/tool.go
+++ b/pkg/api/authz/tool.go
@@ -21,7 +21,7 @@ func (a *Authorizer) checkTools(req *http.Request, resources *Resources, _ user.
 	}
 
 	var tool v1.Tool
-	if err := a.storage.Get(req.Context(), router.Key(resources.Authorizated.Project.Namespace,
+	if err := a.get(req.Context(), router.Key(resources.Authorizated.Project.Namespace,
 		resources.ToolID), &tool); err != nil {
 		return false, err
 	}

--- a/pkg/api/authz/workflow.go
+++ b/pkg/api/authz/workflow.go
@@ -22,7 +22,7 @@ func (a *Authorizer) checkWorkflow(req *http.Request, resources *Resources, _ us
 		workflow v1.Workflow
 	)
 
-	if err := a.storage.Get(req.Context(), router.Key(system.DefaultNamespace, resources.WorkflowID), &workflow); err != nil {
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.WorkflowID), &workflow); err != nil {
 		return false, err
 	}
 

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -621,7 +621,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 			gatewayClient,
 			gptscriptClient,
 			authn.NewAuthenticator(authenticators),
-			authz.NewAuthorizer(r.Backend(), config.DevMode, acrHelper),
+			authz.NewAuthorizer(r.Backend(), storageClient, config.DevMode, acrHelper),
 			proxyManager,
 			auditLogger,
 			rateLimiter,


### PR DESCRIPTION
If an object was just created, then the cached get may fail for a short time. Use an uncached get when the cached get returns a not-found error to avoid unnecessary errors.

Issue: https://github.com/obot-platform/obot/issues/3670