### PR TITLE
Search user id response status

### DIFF
--- a/pkg/api/handlers/mcpgateway/auditlog.go
+++ b/pkg/api/handlers/mcpgateway/auditlog.go
@@ -118,7 +118,7 @@ func (h *AuditLogHandler) ListAuditLogs(req api.Context) error {
 	opts.SortOrder = query.Get("sort_order")
 
 	// Get audit logs
-	logs, err := req.GatewayClient.GetMCPAuditLogs(req.Context(), opts)
+	logs, total, err := req.GatewayClient.GetMCPAuditLogs(req.Context(), opts)
 	if err != nil {
 		return err
 	}
@@ -129,17 +129,11 @@ func (h *AuditLogHandler) ListAuditLogs(req api.Context) error {
 		result = append(result, gatewaytypes.ConvertMCPAuditLog(log))
 	}
 
-	// Get total count for pagination
-	totalCount, err := req.GatewayClient.CountMCPAuditLogs(req.Context(), opts)
-	if err != nil {
-		return err
-	}
-
 	return req.Write(types.MCPAuditLogResponse{
 		MCPAuditLogList: types.MCPAuditLogList{
 			Items: result,
 		},
-		Total:  totalCount,
+		Total:  total,
 		Limit:  opts.Limit,
 		Offset: opts.Offset,
 	})


### PR DESCRIPTION
Because we encrypt personally identifiable information like a user's display name, we have to list all users from the database and match the query in code.

This change also improves getting the total number of audit logs for a search. Instead of issuing a second search, the total count is processed at the same time as querying for audit logs.

There is a caveat here: when matching response_status against a search query, it only matches exactly. For example, no response_statuses will match if the query is "20"

I implemented both these fixes in the same PR to avoid conflicts.

Issues: https://github.com/obot-platform/obot/issues/3718, https://github.com/obot-platform/obot/issues/3720