### PR TITLE
fix: alleviate block when deleting users when using sqlite

### DIFF
--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -182,7 +182,7 @@ func (s *Server) deleteUser(apiContext api.Context) (err error) {
 	}
 
 	status := http.StatusInternalServerError
-	_, err = apiContext.GatewayClient.DeleteUser(apiContext.Context(), apiContext.Storage, userID)
+	_, err = apiContext.GatewayClient.DeleteUser(apiContext.Context(), userID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			status = http.StatusNotFound


### PR DESCRIPTION
When we use sqlite, we have a single database connection. Also, sqlite's locking is not as sophisticated as others. So, when we're deleting a user in a transaction, that locks the database. Then, we're blocked when we try to clean up other resources associated with the user from inside the transaction.

This change alleviates that blocking by cleaning up all user-based resources in the user-delete controller.