### PR TITLE
fix: hide user not found errors and make it possible to filter by user after user is deleted

### DIFF
--- a/ui/user/src/lib/components/admin/audit-logs/AuditDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditDetails.svelte
@@ -645,7 +645,7 @@
 				onClose={handleRightSidebarClose}
 				{filters}
 				getFilterDisplayLabel={(d) => d}
-				fetchUserById={(id) => Promise.resolve({ id: id, displayName: id } as OrgUser)}
+				users={usersMap}
 			/>
 		{/if}
 	</dialog>

--- a/ui/user/src/lib/components/admin/audit-logs/AuditDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditDetails.svelte
@@ -645,7 +645,7 @@
 				onClose={handleRightSidebarClose}
 				{filters}
 				getFilterDisplayLabel={(d) => d}
-				users={usersMap}
+				getUserDisplayName={(id) => usersMap.get(id)?.displayName ?? 'Unknown User'}
 			/>
 		{/if}
 	</dialog>

--- a/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
@@ -22,18 +22,23 @@
 	import { X } from 'lucide-svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import type { AuditLogURLFilters, OrgUser } from '$lib/services/admin/types';
+	import type { AuditLogURLFilters } from '$lib/services/admin/types';
 	import { AdminService } from '$lib/services';
 	import { untrack } from 'svelte';
 
 	interface Props {
 		filters?: AuditLogURLFilters;
-		users?: Map<string, OrgUser>;
 		onClose: () => void;
+		getUserDisplayName: (userId: string) => string;
 		getFilterDisplayLabel?: (key: keyof AuditLogURLFilters) => string;
 	}
 
-	let { filters: externFilters, onClose, users, getFilterDisplayLabel }: Props = $props();
+	let {
+		filters: externFilters,
+		onClose,
+		getUserDisplayName,
+		getFilterDisplayLabel
+	}: Props = $props();
 
 	let filters = $derived({ ...(externFilters ?? {}) });
 
@@ -81,13 +86,10 @@
 
 			if (filterId === 'user_id') {
 				return response.options
-					.map((d) => {
-						const user = users?.get(d);
-						return {
-							id: d,
-							label: user?.displayName ?? 'Unknown User'
-						};
-					})
+					.map((d) => ({
+						id: d,
+						label: getUserDisplayName(d)
+					}))
 					.filter(Boolean);
 			}
 

--- a/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
@@ -82,7 +82,12 @@
 			if (filterId === 'user_id') {
 				return await Promise.all(
 					response.options
-						.map((d) => fetchUserById(d).then((user) => ({ id: d, label: user?.displayName ?? d })))
+						.map((d) =>
+							fetchUserById(d).then((user) => ({
+								id: d,
+								label: user?.displayName ?? 'Unknown User'
+							}))
+						)
 						.filter(Boolean)
 				);
 			}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
@@ -28,12 +28,12 @@
 
 	interface Props {
 		filters?: AuditLogURLFilters;
+		users?: Map<string, OrgUser>;
 		onClose: () => void;
-		fetchUserById: (userId: string) => Promise<OrgUser | undefined>;
 		getFilterDisplayLabel?: (key: keyof AuditLogURLFilters) => string;
 	}
 
-	let { filters: externFilters, onClose, fetchUserById, getFilterDisplayLabel }: Props = $props();
+	let { filters: externFilters, onClose, users, getFilterDisplayLabel }: Props = $props();
 
 	let filters = $derived({ ...(externFilters ?? {}) });
 
@@ -80,16 +80,15 @@
 			const response = await AdminService.listAuditLogFilterOptions(filterId);
 
 			if (filterId === 'user_id') {
-				return await Promise.all(
-					response.options
-						.map((d) =>
-							fetchUserById(d).then((user) => ({
-								id: d,
-								label: user?.displayName ?? 'Unknown User'
-							}))
-						)
-						.filter(Boolean)
-				);
+				return response.options
+					.map((d) => {
+						const user = users?.get(d);
+						return {
+							id: d,
+							label: user?.displayName ?? 'Unknown User'
+						};
+					})
+					.filter(Boolean);
 			}
 
 			return response.options.map((d) => ({

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -295,7 +295,10 @@ export async function listUsers(opts?: { fetch?: Fetcher }): Promise<OrgUser[]> 
 	return response.items ?? [];
 }
 
-export async function getUser(userID: string, opts?: { fetch?: Fetcher }): Promise<OrgUser> {
+export async function getUser(
+	userID: string,
+	opts?: { fetch?: Fetcher; dontLogErrors?: boolean }
+): Promise<OrgUser> {
 	const response = (await doGet(`/users/${userID}`, opts)) as OrgUser;
 	return response;
 }

--- a/ui/user/src/routes/admin/audit-logs/+page.svelte
+++ b/ui/user/src/routes/admin/audit-logs/+page.svelte
@@ -176,8 +176,9 @@
 		}
 	}
 
-	async function fetchUserById(id: string): Promise<OrgUser | undefined> {
-		return users.get(id);
+	function getUserDisplayName(id: string): string {
+		const user = users.get(id);
+		return user?.displayName ?? 'Unknown User';
 	}
 
 	function getFilterDisplayLabel(key: keyof AuditLogURLFilters) {
@@ -212,9 +213,7 @@
 		}
 
 		if (label === 'user_id') {
-			const user = users.get(value + '');
-
-			return user?.displayName;
+			return getUserDisplayName(value + '');
 		}
 
 		return value + '';
@@ -357,7 +356,7 @@
 						showFilters = false;
 						rightSidebar?.show();
 					}}
-					{fetchUserById}
+					{getUserDisplayName}
 				>
 					{#snippet emptyContent()}
 						<!-- Just to skip ts checker, have to added later -->
@@ -390,7 +389,7 @@
 		<AuditFilters
 			onClose={handleRightSidebarClose}
 			filters={{ ...searchParamFilters }}
-			{users}
+			{getUserDisplayName}
 			{getFilterDisplayLabel}
 		/>
 	{/if}

--- a/ui/user/src/routes/admin/audit-logs/+page.svelte
+++ b/ui/user/src/routes/admin/audit-logs/+page.svelte
@@ -112,7 +112,6 @@
 
 	afterNavigate(() => {
 		AdminService.listUsers().then((userData) => {
-			console.log(userData);
 			for (const user of userData) {
 				users.set(user.id, user);
 			}
@@ -198,27 +197,27 @@
 		return key.replace(/_(\w)/g, ' $1');
 	}
 
-	async function getFilterValue(label: keyof AuditLogURLFilters, value: string | number) {
+	function getFilterValue(label: keyof AuditLogURLFilters, value: string | number) {
 		if (label === 'start_time' || label === 'end_time') {
-			return Promise.resolve(
-				new Date(value).toLocaleString(undefined, {
-					year: 'numeric',
-					month: 'short',
-					day: 'numeric',
-					hour: '2-digit',
-					minute: '2-digit',
-					second: '2-digit',
-					hour12: true,
-					timeZoneName: 'short'
-				})
-			);
+			return new Date(value).toLocaleString(undefined, {
+				year: 'numeric',
+				month: 'short',
+				day: 'numeric',
+				hour: '2-digit',
+				minute: '2-digit',
+				second: '2-digit',
+				hour12: true,
+				timeZoneName: 'short'
+			});
 		}
 
 		if (label === 'user_id') {
-			return (await fetchUserById(value + ''))?.displayName;
+			const user = users.get(value + '');
+
+			return user?.displayName;
 		}
 
-		return Promise.resolve(value + '');
+		return value + '';
 	}
 
 	function handleRightSidebarClose() {
@@ -391,7 +390,7 @@
 		<AuditFilters
 			onClose={handleRightSidebarClose}
 			filters={{ ...searchParamFilters }}
-			{fetchUserById}
+			{users}
 			{getFilterDisplayLabel}
 		/>
 	{/if}
@@ -424,17 +423,15 @@
 						{#each values as value (value)}
 							{@const isMultiple = values.length > 1}
 
-							{#await getFilterValue(key, value) then response}
-								{#if isMultiple}
-									<span class="font-light">
-										<span>{response}</span>
-									</span>
+							{#if isMultiple}
+								<span class="font-light">
+									<span>{getFilterValue(key, value)}</span>
+								</span>
 
-									<span class="mx-1 font-bold last:hidden">OR</span>
-								{:else}
-									<span class="font-light">{response}</span>
-								{/if}
-							{/await}
+								<span class="mx-1 font-bold last:hidden">OR</span>
+							{:else}
+								<span class="font-light">{getFilterValue(key, value)}</span>
+							{/if}
 						{/each}
 					</div>
 

--- a/ui/user/src/routes/admin/audit-logs/+page.svelte
+++ b/ui/user/src/routes/admin/audit-logs/+page.svelte
@@ -365,7 +365,7 @@
 					{/snippet}
 				</AuditLogsTable>
 			{:else}
-				<div class="w-md mt-12 flex flex-col items-center gap-4 self-center text-center">
+				<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
 					<Captions class="size-24 text-gray-200 dark:text-gray-900" />
 					<h4 class="text-lg font-semibold text-gray-400 dark:text-gray-600">No audit logs</h4>
 					<p class="text-sm font-light text-gray-400 dark:text-gray-600">
@@ -382,7 +382,7 @@
 	bind:this={rightSidebar}
 	use:clickOutside={[handleRightSidebarClose, true]}
 	use:dialogAnimation={{ type: 'drawer' }}
-	class="dark:border-surface1 dark:bg-surface1 fixed! top-0! right-0! bottom-0! left-auto! outline-none! z-40 h-screen w-auto max-w-none rounded-none border-0 bg-white shadow-lg"
+	class="dark:border-surface1 dark:bg-surface1 fixed! top-0! right-0! bottom-0! left-auto! z-40 h-screen w-auto max-w-none rounded-none border-0 bg-white shadow-lg outline-none!"
 >
 	{#if selectedAuditLog}
 		<AuditLogDetails onClose={handleRightSidebarClose} auditLog={selectedAuditLog} />

--- a/ui/user/src/routes/admin/audit-logs/+page.svelte
+++ b/ui/user/src/routes/admin/audit-logs/+page.svelte
@@ -178,7 +178,7 @@
 
 	function getUserDisplayName(id: string): string {
 		const user = users.get(id);
-		return user?.displayName ?? 'Unknown User';
+		return user?.displayName ?? user?.username ?? user?.email ?? 'Unknown User';
 	}
 
 	function getFilterDisplayLabel(key: keyof AuditLogURLFilters) {

--- a/ui/user/src/routes/admin/audit-logs/+page.svelte
+++ b/ui/user/src/routes/admin/audit-logs/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { fade, slide } from 'svelte/transition';
-	import { X, ChevronLeft, ChevronRight } from 'lucide-svelte';
+	import { X, ChevronLeft, ChevronRight, Funnel, Captions } from 'lucide-svelte';
 	import { delay, throttle } from 'es-toolkit';
 	import { page } from '$app/state';
 	import { afterNavigate, goto } from '$app/navigation';

--- a/ui/user/src/routes/admin/audit-logs/AuditLogs.svelte
+++ b/ui/user/src/routes/admin/audit-logs/AuditLogs.svelte
@@ -1,23 +1,17 @@
 <script lang="ts">
 	import { twMerge } from 'tailwind-merge';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
-	import type { OrgUser } from '$lib/services';
 
 	let {
 		data = [],
 		onSelectRow,
 		emptyContent,
-		fetchUserById,
+		getUserDisplayName,
 		currentFragmentIndex = 0,
 		getFragmentIndex,
 		getFragmentRowIndex,
 		onLoadNextFragment
 	} = $props();
-
-	function getUserDisplayName(userId: string): Promise<string> {
-		const trimmedId = userId.trim();
-		return fetchUserById(trimmedId)!.then((user: OrgUser) => user?.displayName || 'Unknown User');
-	}
 </script>
 
 <!-- Data Table -->
@@ -133,11 +127,7 @@
 								.replace(/,/g, '')}</td
 						>
 						<td class="px-6 py-4 text-sm whitespace-nowrap">
-							{#await getUserDisplayName(item.userID)}
-								<span class="text-gray-500">Loading...</span>
-							{:then displayName}
-								{displayName}
-							{/await}
+							{getUserDisplayName(item.userID)}
 						</td>
 						<td class="px-6 py-4 text-sm whitespace-nowrap">{item.mcpServerDisplayName}</td>
 						<td class="px-6 py-4 text-sm whitespace-nowrap">{item.callType}</td>

--- a/ui/user/src/routes/admin/audit-logs/AuditLogs.svelte
+++ b/ui/user/src/routes/admin/audit-logs/AuditLogs.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { twMerge } from 'tailwind-merge';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
+	import type { OrgUser } from '$lib/services';
 
 	let {
 		data = [],
@@ -12,6 +13,11 @@
 		getFragmentRowIndex,
 		onLoadNextFragment
 	} = $props();
+
+	function getUserDisplayName(userId: string): Promise<string> {
+		const trimmedId = userId.trim();
+		return fetchUserById(trimmedId)!.then((user: OrgUser) => user?.displayName || 'Unknown User');
+	}
 </script>
 
 <!-- Data Table -->
@@ -127,10 +133,10 @@
 								.replace(/,/g, '')}</td
 						>
 						<td class="px-6 py-4 text-sm whitespace-nowrap">
-							{#await fetchUserById(item.userID)}
+							{#await getUserDisplayName(item.userID)}
 								<span class="text-gray-500">Loading...</span>
-							{:then user}
-								{user?.displayName || 'Unknown User'}
+							{:then displayName}
+								{displayName}
 							{/await}
 						</td>
 						<td class="px-6 py-4 text-sm whitespace-nowrap">{item.mcpServerDisplayName}</td>


### PR DESCRIPTION
Addresses #3711 

- Add the ability to disable logging errors when fetching by user ID.
- trim user ID
- Cache the fetch user promise for 1 minute