### PR TITLE
enhance: server side usage filtering and multiple values filter

### DIFF
--- a/pkg/api/handlers/mcpgateway/auditlog.go
+++ b/pkg/api/handlers/mcpgateway/auditlog.go
@@ -186,20 +186,21 @@ func (h *AuditLogHandler) ListAuditLogFilterOptions(req api.Context) error {
 func (h *AuditLogHandler) GetUsageStats(req api.Context) error {
 	query := req.URL.Query()
 
-	var mcpServerDisplayName, mcpServerCatalogEntryName string
+	var mcpServerDisplayNames, mcpServerCatalogEntryNames, userIDs []string
 	mcpID := req.PathValue("mcp_id")
 	if mcpID == "" {
 		mcpID = query.Get("mcp_id")
 		// Only look at these query parameters if the MCP ID is not provided.
-		mcpServerDisplayName = query.Get("mcp_server_display_name")
-		mcpServerCatalogEntryName = query.Get("mcp_server_catalog_entry_name")
+		mcpServerDisplayNames = parseMultiValueParam(query, "mcp_server_display_names")
+		mcpServerCatalogEntryNames = parseMultiValueParam(query, "mcp_server_catalog_entry_names")
+		userIDs = parseMultiValueParam(query, "user_ids")
 	}
 
-	// Parse query parameters
 	opts := gateway.MCPUsageStatsOptions{
-		MCPID:                     mcpID,
-		MCPServerDisplayName:      mcpServerDisplayName,
-		MCPServerCatalogEntryName: mcpServerCatalogEntryName,
+		MCPID:                      mcpID,
+		MCPServerDisplayNames:      mcpServerDisplayNames,
+		MCPServerCatalogEntryNames: mcpServerCatalogEntryNames,
+		UserIDs:                    userIDs,
 	}
 
 	var (

--- a/pkg/gateway/client/mcpauditlog.go
+++ b/pkg/gateway/client/mcpauditlog.go
@@ -154,11 +154,14 @@ func (c *Client) GetMCPUsageStats(ctx context.Context, opts MCPUsageStatsOptions
 		if opts.MCPID != "" {
 			tx = tx.Where("mcp_id = ?", opts.MCPID)
 		}
-		if opts.MCPServerDisplayName != "" {
-			tx = tx.Where("mcp_server_display_name = ?", opts.MCPServerDisplayName)
+		if len(opts.UserIDs) > 0 {
+			tx = tx.Where("user_id IN (?)", opts.UserIDs)
 		}
-		if opts.MCPServerCatalogEntryName != "" {
-			tx = tx.Where("mcp_server_catalog_entry_name = ?", opts.MCPServerCatalogEntryName)
+		if len(opts.MCPServerDisplayNames) > 0 {
+			tx = tx.Where("mcp_server_display_name IN (?)", opts.MCPServerDisplayNames)
+		}
+		if len(opts.MCPServerCatalogEntryNames) > 0 {
+			tx = tx.Where("mcp_server_catalog_entry_name IN (?)", opts.MCPServerCatalogEntryNames)
 		}
 
 		type basicStats struct {
@@ -352,9 +355,10 @@ type MCPAuditLogOptions struct {
 
 // MCPUsageStatsOptions represents options for querying MCP usage statistics
 type MCPUsageStatsOptions struct {
-	MCPID                     string
-	MCPServerDisplayName      string
-	MCPServerCatalogEntryName string
-	StartTime                 time.Time
-	EndTime                   time.Time
+	MCPID                      string
+	UserIDs                    []string
+	MCPServerDisplayNames      []string
+	MCPServerCatalogEntryNames []string
+	StartTime                  time.Time
+	EndTime                    time.Time
 }

--- a/ui/user/src/lib/components/admin/audit-logs/AuditDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditDetails.svelte
@@ -110,7 +110,7 @@
 				startTime: filters?.startTime ?? '',
 				endTime: filters?.endTime ?? '',
 				mcpServerCatalogEntryName: mcpCatalogEntryId,
-				mcpServerDisplayName
+				mcpServerDisplayNames: mcpServerDisplayName ? [mcpServerDisplayName] : undefined
 			});
 		}
 	}

--- a/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
+++ b/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
@@ -285,44 +285,16 @@
 	});
 
 	async function reload() {
-		const statsPromise = mcpId
+		listUsageStats = mcpId
 			? AdminService.listServerOrInstanceAuditLogStats(mcpId, {
 					startTime: filters?.startTime ?? '',
 					endTime: filters?.endTime ?? ''
 				})
 			: AdminService.listAuditLogUsageStats({
-					startTime: filters?.startTime ?? '',
-					endTime: filters?.endTime ?? '',
-					mcpServerCatalogEntryName: mcpCatalogEntryId,
-					mcpServerDisplayName
+					...filters,
+					...(mcpCatalogEntryId && { mcpServerCatalogEntryName: mcpCatalogEntryId }),
+					...(mcpServerDisplayName && { mcpServerDisplayNames: [mcpServerDisplayName] })
 				});
-
-		// Apply client-side user filtering if userId filter is set
-		listUsageStats = statsPromise.then((stats) => {
-			if (!filters?.userId || !stats?.items) {
-				return stats;
-			}
-
-			// Filter the items to only include data for the specified user
-			const filteredItems = stats.items
-				.map((item) => ({
-					...item,
-					toolCalls:
-						item.toolCalls
-							?.map((toolCall) => ({
-								...toolCall,
-								items:
-									toolCall.items?.filter((callItem) => callItem.userID === filters.userId) ?? []
-							}))
-							?.filter((toolCall) => (toolCall.items?.length ?? 0) > 0) ?? []
-				}))
-				.filter((item) => (item.toolCalls?.length ?? 0) > 0);
-
-			return {
-				...stats,
-				items: filteredItems
-			};
-		});
 	}
 
 	$effect(() => {

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -374,9 +374,9 @@ export type AuditLogURLFilters = {
 };
 
 export type UsageStatsFilters = {
-	userId?: string | null;
-	mcpServerDisplayName?: string | null;
-	startTime?: string | null; // RFC3339 format (e.g., "2024-01-01T00:00:00Z"
+	userIds?: string[];
+	mcpServerDisplayNames?: string[];
+	startTime?: string | null;
 	endTime?: string | null;
 };
 

--- a/ui/user/src/routes/admin/usage/+page.svelte
+++ b/ui/user/src/routes/admin/usage/+page.svelte
@@ -50,24 +50,34 @@
 		const endTime = url.searchParams.get('endTime')
 			? decodeURIComponent(url.searchParams.get('endTime')!)
 			: null;
-		const userId = url.searchParams.get('userId');
-		const mcpServerDisplayName = url.searchParams.get('name')
-			? decodeURIComponent(url.searchParams.get('name')!)
-			: null;
+		// Handle both single and array-based parameters for backward compatibility
+		const userIds = url.searchParams.get('userIds')
+			? decodeURIComponent(url.searchParams.get('userIds')!)
+					.split(',')
+					.map((s) => s.trim())
+					.filter(Boolean)
+			: undefined;
+
+		const mcpServerDisplayNames = url.searchParams.get('mcpServerDisplayNames')
+			? decodeURIComponent(url.searchParams.get('mcpServerDisplayNames')!)
+					.split(',')
+					.map((s) => s.trim())
+					.filter(Boolean)
+			: undefined;
 
 		return {
 			startTime,
 			endTime,
-			userId,
-			mcpServerDisplayName
+			userIds,
+			mcpServerDisplayNames
 		};
 	}
 
 	function convertFilterDisplayLabel(key: string) {
-		if (key === 'mcpServerDisplayName') return 'Server';
+		if (key === 'mcpServerDisplayNames') return 'Servers';
 		if (key === 'startTime') return 'Start Time';
 		if (key === 'endTime') return 'End Time';
-		if (key === 'userId') return 'User ID';
+		if (key === 'userIds') return 'Users';
 		return key;
 	}
 
@@ -77,11 +87,13 @@
 		// make sure to preserve existing filters
 		Object.entries(currentFilters).forEach(([key, filterValue]) => {
 			if (filterValue && key !== 'startTime' && key !== 'endTime') {
-				let urlKey = key;
-				if (key === 'mcpServerDisplayName') {
-					urlKey = 'name';
+				if (Array.isArray(filterValue)) {
+					// Handle array values (join with commas)
+					url.searchParams.set(key, filterValue.join(','));
+				} else {
+					// Handle string values
+					url.searchParams.set(key, String(filterValue));
 				}
-				url.searchParams.set(urlKey, String(filterValue));
 			}
 		});
 
@@ -153,10 +165,8 @@
 {/snippet}
 
 {#snippet usageContent()}
-	{@const { mcpServerDisplayName } = currentFilters}
 	<div class="flex flex-col gap-8" in:fade={{ duration }}>
 		<UsageGraphs
-			mcpServerDisplayName={mcpServerDisplayName ?? undefined}
 			{users}
 			filters={{
 				...currentFilters,


### PR DESCRIPTION
- Add server-side support for filtering by multiple user IDs and MCP
server display names to `/api/mcp-stats`
- User server side filtering to filter usage stats
- Enable filtering usage by multiple users and mcp server names

Follow up for https://github.com/obot-platform/obot/issues/3579

Loom: https://www.loom.com/share/031530f2016c4bc39bcf87f8b83dcdfe?sid=d7f448f7-1e98-4e19-8f64-da4cbd6c4f42