### PR TITLE
fix: mcp servers: don't overwrite headers for admin

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -788,7 +788,17 @@ func mergeMCPServerManifests(existing, override types.MCPServerManifest) types.M
 		existing.ContainerizedConfig = override.ContainerizedConfig
 	}
 	if override.RemoteConfig != nil {
-		existing.RemoteConfig = override.RemoteConfig
+		if existing.RemoteConfig == nil {
+			existing.RemoteConfig = override.RemoteConfig
+		} else {
+			if override.RemoteConfig.URL != "" {
+				existing.RemoteConfig.URL = override.RemoteConfig.URL
+			}
+
+			if len(override.RemoteConfig.Headers) > 0 {
+				existing.RemoteConfig.Headers = override.RemoteConfig.Headers
+			}
+		}
 	}
 
 	return existing


### PR DESCRIPTION
There was a bug here where the headers would not get copied over from the catalog entry when an admin user instantiates it into a server, because we were overriding the entire `remoteConfig` with just the URL (without any headers), as that is what the UI passes in for this request.