### PR TITLE
fix: use display names for usage user filters

### DIFF
--- a/ui/user/src/lib/components/admin/usage/UsageFilters.svelte
+++ b/ui/user/src/lib/components/admin/usage/UsageFilters.svelte
@@ -71,8 +71,10 @@
 		// Populate user filter values
 		for (const userId of userIds) {
 			const user = users.find((u) => u.id === userId);
+			const displayName = user?.displayName || 'Unknown';
+			const email = user?.email;
 			filterSets[0].values[userId] = {
-				label: user?.email || user?.displayName || 'Unknown',
+				label: email ? `${displayName} (${email})` : displayName,
 				id: userId
 			};
 		}


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/3755


<img width="405" height="235" alt="Screenshot 2025-08-05 at 5 57 19 PM" src="https://github.com/user-attachments/assets/7bbce913-01e1-4924-ac1c-0b6ea643447b" />
