### PR TITLE
fix: stop closing OAuth clients

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -373,12 +373,9 @@ func (m *MCPHandler) GetOAuthURL(req api.Context) error {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
-	var u string
-	if server.Spec.Manifest.Runtime == types.RuntimeRemote {
-		u, err = m.mcpOAuthChecker.CheckForMCPAuth(req.Context(), server, serverConfig, req.User.GetUID(), server.Name, "")
-		if err != nil {
-			return fmt.Errorf("failed to get OAuth URL: %w", err)
-		}
+	u, err := m.mcpOAuthChecker.CheckForMCPAuth(req.Context(), server, serverConfig, req.User.GetUID(), server.Name, "")
+	if err != nil {
+		return fmt.Errorf("failed to get OAuth URL: %w", err)
 	}
 
 	return req.Write(map[string]string{"oauthURL": u})

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -256,22 +256,18 @@ func (h *handler) callback(req api.Context) error {
 			return err
 		}
 
-		// For now, we only need to check for OAuth if the MCP server is remote.
-		// This may change in the future as the protocol matures, but, for now, this is an optimization for loading times for the redirects.
-		if mcpServerConfig.Command == "" {
-			u, err := h.oauthChecker.CheckForMCPAuth(req.Context(), mcpServer, mcpServerConfig, req.User.GetUID(), mcpID, oauthAppAuthRequest.Name)
-			if err != nil {
-				redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-					Code:        ErrServerError,
-					Description: err.Error(),
-				})
-				return nil
-			}
+		u, err := h.oauthChecker.CheckForMCPAuth(req.Context(), mcpServer, mcpServerConfig, req.User.GetUID(), mcpID, oauthAppAuthRequest.Name)
+		if err != nil {
+			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
+				Code:        ErrServerError,
+				Description: err.Error(),
+			})
+			return nil
+		}
 
-			if u != "" {
-				http.Redirect(req.ResponseWriter, req.Request, u, http.StatusFound)
-				return nil
-			}
+		if u != "" {
+			http.Redirect(req.ResponseWriter, req.Request, u, http.StatusFound)
+			return nil
 		}
 	}
 

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -292,12 +292,9 @@ func (p *ProjectMCPHandler) GetOAuthURL(req api.Context) error {
 		return err
 	}
 
-	var u string
-	if server.Spec.Manifest.Runtime == types.RuntimeRemote {
-		u, err = p.mcpOAuthChecker.CheckForMCPAuth(req.Context(), server, serverConfig, req.User.GetUID(), server.Name, "")
-		if err != nil {
-			return fmt.Errorf("failed to get OAuth URL: %w", err)
-		}
+	u, err := p.mcpOAuthChecker.CheckForMCPAuth(req.Context(), server, serverConfig, req.User.GetUID(), server.Name, "")
+	if err != nil {
+		return fmt.Errorf("failed to get OAuth URL: %w", err)
 	}
 
 	return req.Write(map[string]string{"oauthURL": u})


### PR DESCRIPTION
A previous implementation closed the client we used to check for OAuth because we didn't want this extra client lying around. It would cause problems down the road.

A recent change separated clients by session. The upshot is that we no longer need to close this OAuth client, and it can remain active to make future checks quicker.

There was a bug here as well: the ShutdownServer call was shutting down all clients for a given server instead of just the OAuth client.