### PR TITLE
fix: use display name in most active users usage graph

### DIFF
--- a/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
+++ b/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
@@ -252,9 +252,13 @@
 			xKey: 'userId',
 			yKey: 'callCount',
 			tooltip: 'calls',
+			formatTooltipText: (data) => {
+				const user = users.find((u) => u.id === data.userId);
+				return `${data.callCount} calls • ${user ? user.email || user.id : String(data.userId)}`;
+			},
 			formatXLabel: (userId) => {
 				const user = users.find((u) => u.id === userId);
-				return user ? user.email : String(userId);
+				return user ? user.displayName || user.email || user.id : String(userId);
 			},
 			transform: (stats) => {
 				const userCounts = new Map<string, number>();


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/3755

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>

Loom: https://www.loom.com/share/210b1bd03af04c0b87403c86e91effe1?sid=bb773f1e-3b97-425d-a4e2-033e118e4613