### PR TITLE
fix: use list tools to launch MCP servers instead of ping

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -321,7 +321,7 @@ func (m *MCPHandler) LaunchServer(req api.Context) error {
 	}
 
 	if server.Spec.Manifest.Runtime != types.RuntimeRemote {
-		if _, err = m.mcpSessionManager.PingServer(req.Context(), req.User.GetUID(), server, serverConfig); err != nil {
+		if _, err = m.mcpSessionManager.ListTools(req.Context(), req.User.GetUID(), server, serverConfig); err != nil {
 			if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
 				return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
 			}

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -231,7 +231,7 @@ func (p *ProjectMCPHandler) LaunchServer(req api.Context) error {
 	}
 
 	if server.Spec.Manifest.Runtime != types.RuntimeRemote {
-		if _, err = p.mcpSessionManager.PingServer(req.Context(), req.User.GetUID(), server, serverConfig); err != nil {
+		if _, err = p.mcpSessionManager.ListTools(req.Context(), req.User.GetUID(), server, serverConfig); err != nil {
 			if errors.Is(err, nmcp.ErrNoResult) || strings.HasSuffix(err.Error(), nmcp.ErrNoResult.Error()) {
 				return types.NewErrHTTP(http.StatusServiceUnavailable, "No response from MCP server, check configuration for errors")
 			}


### PR DESCRIPTION
In a Kubernetes setup, ping only pings the nanobot server and doesn't interact with the "real" MCP server at all. Therefore, we cannot detect launch failures with ping.

This change switches to listing tools because this does interact with the MCP server.

Issue: https://github.com/obot-platform/obot/issues/3767