### PR TITLE
fix: bootstrap access login/out workflow to /admin

### DIFF
--- a/ui/user/src/lib/components/navbar/Profile.svelte
+++ b/ui/user/src/lib/components/navbar/Profile.svelte
@@ -43,8 +43,9 @@
 
 	async function handleBootstrapLogout() {
 		try {
+			const isBootstrapUser = profile.current.username === BOOTSTRAP_USER_ID;
 			await AdminService.bootstrapLogout();
-			window.location.href = '/oauth2/sign_out?rd=/';
+			window.location.href = `/oauth2/sign_out?rd=${isBootstrapUser ? '/admin' : '/'}`;
 		} catch (err) {
 			console.error(err);
 		}


### PR DESCRIPTION
Related Loom: https://www.loom.com/share/83ec47b603804634baf5917cb43b8262
* quick fix to make bootstrap user always log out to /admin