### PR TITLE
Fix: skip repo size check if it is obot-platform

### DIFF
--- a/pkg/controller/handlers/mcpcatalog/github.go
+++ b/pkg/controller/handlers/mcpcatalog/github.go
@@ -33,6 +33,10 @@ func isGitHubURL(catalogURL string) bool {
 
 // checkRepoSize checks the repository size using GitHub API before cloning
 func checkRepoSize(org, repo string, maxSizeMB int) error {
+	if org == "obot-platform" {
+		return nil
+	}
+
 	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s", org, repo)
 
 	// Create HTTP client with timeout


### PR DESCRIPTION
We want to skip repo from size checking if it is from obot-platform(which we trust). This can save us some api call to github to avoid rate limit issue.