### PR TITLE
enhance: add configure info banner for auth/model providers

### DIFF
--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -140,12 +140,6 @@
 
 	initLayout();
 	const layout = getLayout();
-
-	let configureBanner = $state<ReturnType<typeof ConfigureBanner>>();
-
-	export function refreshConfigureBanner() {
-		configureBanner?.refresh();
-	}
 </script>
 
 <div class="flex min-h-dvh flex-col items-center">
@@ -277,7 +271,7 @@
 					class={twMerge('h-full w-full max-w-(--breakpoint-xl)', classes?.childrenContainer ?? '')}
 				>
 					{#if pathname.includes('/admin') && !excludeConfigureBanner.includes(pathname)}
-						<ConfigureBanner bind:this={configureBanner} />
+						<ConfigureBanner />
 					{/if}
 					{@render children()}
 				</div>

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -26,6 +26,7 @@
 	import { twMerge } from 'tailwind-merge';
 	import { afterNavigate } from '$app/navigation';
 	import BetaLogo from './navbar/BetaLogo.svelte';
+	import ConfigureBanner from './admin/ConfigureBanner.svelte';
 
 	interface Props {
 		classes?: {
@@ -135,8 +136,16 @@
 		}
 	});
 
+	const excludeConfigureBanner = ['/admin/model-providers', '/admin/auth-providers'];
+
 	initLayout();
 	const layout = getLayout();
+
+	let configureBanner = $state<ReturnType<typeof ConfigureBanner>>();
+
+	export function refreshConfigureBanner() {
+		configureBanner?.refresh();
+	}
 </script>
 
 <div class="flex min-h-dvh flex-col items-center">
@@ -267,6 +276,9 @@
 				<div
 					class={twMerge('h-full w-full max-w-(--breakpoint-xl)', classes?.childrenContainer ?? '')}
 				>
+					{#if pathname.includes('/admin') && !excludeConfigureBanner.includes(pathname)}
+						<ConfigureBanner bind:this={configureBanner} />
+					{/if}
 					{@render children()}
 				</div>
 			</div>

--- a/ui/user/src/lib/components/admin/ConfigureBanner.svelte
+++ b/ui/user/src/lib/components/admin/ConfigureBanner.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import { AdminService } from '$lib/services';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		modelProviderConfigured?: boolean;
+		authProviderConfigured?: boolean;
+	}
+
+	let { modelProviderConfigured, authProviderConfigured }: Props = $props();
+	let isModelProviderConfigured = $state(false);
+	let isAuthProviderConfigured = $state(false);
+	let loading = $state(true);
+
+	async function init() {
+		loading = true;
+		if (typeof modelProviderConfigured === 'boolean') {
+			isModelProviderConfigured = modelProviderConfigured;
+		} else {
+			const modelProviders = await AdminService.listModelProviders();
+			isModelProviderConfigured = modelProviders.some((provider) => provider.configured);
+		}
+
+		if (typeof authProviderConfigured === 'boolean') {
+			isAuthProviderConfigured = authProviderConfigured;
+		} else {
+			const authProviders = await AdminService.listAuthProviders();
+			isAuthProviderConfigured = authProviders.some((provider) => provider.configured);
+		}
+		loading = false;
+	}
+
+	onMount(() => {
+		init();
+	});
+
+	export function refresh() {
+		init();
+	}
+</script>
+
+{#if !loading && (!isModelProviderConfigured || !isAuthProviderConfigured)}
+	<div class="dark:bg-surface2 flex justify-center overflow-hidden rounded-xl bg-white py-4">
+		<div
+			class="relative flex min-h-36 w-[calc(100%-4rem)] max-w-screen-md flex-row items-center justify-between gap-4 rounded-sm"
+		>
+			<div class="absolute opacity-5 md:top-[-1.75rem] md:left-[-3.0rem] md:opacity-45">
+				<img
+					src="/user/images/obot-icon-surprised-yellow.svg"
+					alt="obot alert"
+					class="md:h-[17.5rem] md:w-[17.5rem]"
+				/>
+			</div>
+			<div class="relative z-10 flex flex-col gap-2 md:ml-64">
+				<h4 class="text-lg font-semibold">Wait! You've still got some setup to do!</h4>
+				{#if !isModelProviderConfigured}
+					<p class="text-sm font-light">
+						<b class="font-semibold">Model Provider:</b> To create Agents, configure a Model Provider.
+					</p>
+				{/if}
+				{#if !isAuthProviderConfigured}
+					<p class="text-sm font-light">
+						<b class="font-semibold">Auth Provider:</b> To support multiple users, configure an Auth
+						Provider.
+					</p>
+				{/if}
+				<div class="flex flex-row flex-wrap gap-2">
+					{#if !isModelProviderConfigured}
+						<a
+							href="/admin/model-providers"
+							class="button grow bg-yellow-500 text-center text-sm text-black hover:bg-yellow-500/70"
+						>
+							Configure Model Provider
+						</a>
+					{/if}
+					{#if !isAuthProviderConfigured}
+						<a
+							href="/admin/auth-providers"
+							class="button grow bg-yellow-500 text-center text-sm text-black hover:bg-yellow-500/70"
+						>
+							Configure Auth Provider
+						</a>
+					{/if}
+				</div>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/ui/user/src/lib/components/admin/ConfigureBanner.svelte
+++ b/ui/user/src/lib/components/admin/ConfigureBanner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { AdminService } from '$lib/services';
+	import { adminConfigStore } from '$lib/stores/adminConfig.svelte';
 	import { onMount } from 'svelte';
 
 	interface Props {
@@ -8,35 +8,29 @@
 	}
 
 	let { modelProviderConfigured, authProviderConfigured }: Props = $props();
-	let isModelProviderConfigured = $state(false);
-	let isAuthProviderConfigured = $state(false);
-	let loading = $state(true);
 
-	async function init() {
-		loading = true;
-		if (typeof modelProviderConfigured === 'boolean') {
-			isModelProviderConfigured = modelProviderConfigured;
-		} else {
-			const modelProviders = await AdminService.listModelProviders();
-			isModelProviderConfigured = modelProviders.some((provider) => provider.configured);
-		}
+	// Use the store for reactive data
+	const storeData = $derived($adminConfigStore);
 
-		if (typeof authProviderConfigured === 'boolean') {
-			isAuthProviderConfigured = authProviderConfigured;
-		} else {
-			const authProviders = await AdminService.listAuthProviders();
-			isAuthProviderConfigured = authProviders.some((provider) => provider.configured);
-		}
-		loading = false;
-	}
+	// Use props if provided, otherwise use store values
+	const isModelProviderConfigured = $derived(
+		typeof modelProviderConfigured === 'boolean'
+			? modelProviderConfigured
+			: storeData.modelProviderConfigured
+	);
+
+	const isAuthProviderConfigured = $derived(
+		typeof authProviderConfigured === 'boolean'
+			? authProviderConfigured
+			: storeData.authProviderConfigured
+	);
+
+	const loading = $derived(storeData.loading);
 
 	onMount(() => {
-		init();
+		// Initialize the store if it hasn't been initialized yet
+		adminConfigStore.initialize();
 	});
-
-	export function refresh() {
-		init();
-	}
 </script>
 
 {#if !loading && (!isModelProviderConfigured || !isAuthProviderConfigured)}

--- a/ui/user/src/lib/components/mcp/McpCard.svelte
+++ b/ui/user/src/lib/components/mcp/McpCard.svelte
@@ -48,7 +48,7 @@
 		</div>
 		<span
 			class={twMerge(
-				'mt-2 text-xs leading-4.5 font-light text-gray-400 dark:text-gray-600',
+				'mt-2 text-xs leading-4.5 font-light break-all text-gray-400 dark:text-gray-600',
 				categories.length > 0 ? 'line-clamp-2' : 'line-clamp-3'
 			)}
 		>

--- a/ui/user/src/lib/stores/adminConfig.svelte.ts
+++ b/ui/user/src/lib/stores/adminConfig.svelte.ts
@@ -1,0 +1,92 @@
+import { AdminService, type AuthProvider, type ModelProvider } from '$lib/services';
+import { writable, get } from 'svelte/store';
+
+interface AdminConfig {
+	modelProviderConfigured: boolean;
+	authProviderConfigured: boolean;
+	loading: boolean;
+	lastFetched: number | null;
+}
+
+const createAdminConfigStore = () => {
+	const { subscribe, set, update } = writable<AdminConfig>({
+		modelProviderConfigured: false,
+		authProviderConfigured: false,
+		loading: false,
+		lastFetched: null
+	});
+
+	let isInitialized = false;
+
+	const fetchData = async (forceRefresh = false) => {
+		const now = Date.now();
+		const cacheAge = 5 * 60 * 1000; // 5 minutes cache
+
+		// Return cached data if it's fresh and not forcing refresh
+		if (!forceRefresh && isInitialized && cacheAge > 0) {
+			const currentState = get({ subscribe });
+			if (currentState.lastFetched && now - currentState.lastFetched < cacheAge) {
+				return;
+			}
+		}
+
+		update((state) => ({ ...state, loading: true }));
+
+		try {
+			const [modelProviders, authProviders] = await Promise.all([
+				AdminService.listModelProviders(),
+				AdminService.listAuthProviders()
+			]);
+
+			const modelProviderConfigured = modelProviders.some((provider) => provider.configured);
+			const authProviderConfigured = authProviders.some((provider) => provider.configured);
+
+			set({
+				modelProviderConfigured,
+				authProviderConfigured,
+				loading: false,
+				lastFetched: now
+			});
+
+			isInitialized = true;
+		} catch (error) {
+			console.error('Failed to fetch admin config:', error);
+			update((state) => ({ ...state, loading: false }));
+		}
+	};
+
+	const refresh = () => fetchData(true);
+
+	const initialize = () => {
+		if (!isInitialized) {
+			fetchData();
+		}
+	};
+
+	const updateAuthProviders = (authProviders: AuthProvider[]) => {
+		update((state) => ({
+			...state,
+			authProviders,
+			authProviderConfigured: authProviders.some((provider) => provider.configured)
+		}));
+	};
+
+	const updateModelProviders = (modelProviders: ModelProvider[]) => {
+		update((state) => ({
+			...state,
+			modelProviders,
+			modelProviderConfigured: modelProviders.some((provider) => provider.configured)
+		}));
+	};
+
+	return {
+		subscribe,
+		refresh,
+		initialize,
+		fetchData,
+		updateAuthProviders,
+		updateModelProviders
+	};
+};
+
+export const adminConfigStore = createAdminConfigStore();

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -10,7 +10,7 @@
 	import ProviderConfigure from '$lib/components/admin/ProviderConfigure.svelte';
 	import type { AuthProvider } from '$lib/services/admin/types.js';
 	import { AdminService } from '$lib/services/index.js';
-	import { Info } from 'lucide-svelte';
+	import { AlertTriangle, Info } from 'lucide-svelte';
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -48,6 +48,7 @@
 	let providerConfigure = $state<ReturnType<typeof ProviderConfigure>>();
 	let configuringAuthProvider = $state<AuthProvider>();
 	let configuringAuthProviderValues = $state<Record<string, string>>();
+	let atLeastOneConfigured = $derived(authProviders.some((provider) => provider.configured));
 
 	let loading = $state(false);
 	let configureError = $state<string>();
@@ -85,6 +86,18 @@
 	<div class="my-4" in:fade={{ duration }} out:fade={{ duration }}>
 		<div class="flex flex-col gap-8">
 			<h1 class="text-2xl font-semibold">Auth Providers</h1>
+			{#if !atLeastOneConfigured}
+				<div class="notification-alert flex flex-col gap-2">
+					<div class="flex items-center gap-2">
+						<AlertTriangle class="size-6 flex-shrink-0 self-start text-yellow-500" />
+						<p class="my-0.5 flex flex-col text-sm font-semibold">No Auth Providers Configured!</p>
+					</div>
+					<span class="text-sm font-light break-all">
+						To finish setting up Obot, you'll need to configure an Auth Provider. Select one below
+						to get started!
+					</span>
+				</div>
+			{/if}
 		</div>
 		<div class="grid grid-cols-1 gap-4 py-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 			{#each sortedAuthProviders as authProvider (authProvider.id)}

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -15,6 +15,7 @@
 	import Confirm from '$lib/components/Confirm.svelte';
 	import { twMerge } from 'tailwind-merge';
 	import { darkMode } from '$lib/stores/index.js';
+	import { adminConfigStore } from '$lib/stores/adminConfig.svelte.js';
 
 	let { data } = $props();
 	let { authProviders: initialAuthProviders } = data;
@@ -64,6 +65,7 @@
 			try {
 				await AdminService.configureAuthProvider(configuringAuthProvider.id, form);
 				authProviders = await AdminService.listAuthProviders();
+				adminConfigStore.updateAuthProviders(authProviders);
 				providerConfigure?.close();
 			} catch (err: unknown) {
 				if (err instanceof Error) {
@@ -165,6 +167,7 @@
 			loading = true;
 			await AdminService.deconfigureAuthProvider(confirmDeconfigureAuthProvider.id);
 			authProviders = await AdminService.listAuthProviders();
+			adminConfigStore.updateAuthProviders(authProviders);
 			confirmDeconfigureAuthProvider = undefined;
 			loading = false;
 		}

--- a/ui/user/src/routes/admin/mcp-servers/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/+page.svelte
@@ -667,7 +667,7 @@
 					An issue occurred fetching this source URL:
 				</p>
 			</div>
-			<span class="font-sm font-light break-all">{syncError?.error}</span>
+			<span class="text-sm font-light break-all">{syncError?.error}</span>
 		</div>
 	</div>
 </ResponsiveDialog>

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -21,6 +21,7 @@
 	import DefaultModels from '$lib/components/admin/DefaultModels.svelte';
 	import { sortModelProviders } from '$lib/sort.js';
 	import { AlertTriangle } from 'lucide-svelte';
+	import { adminConfigStore } from '$lib/stores/adminConfig.svelte.js';
 
 	let { data } = $props();
 	let { modelProviders: initialModelProviders } = data;
@@ -133,6 +134,7 @@
 
 				// Fetch the updated model providers and available models
 				modelProviders = await AdminService.listModelProviders();
+				adminConfigStore.updateModelProviders(modelProviders);
 				adminModels.items = await AdminService.listModels();
 
 				// Close the provider configuration dialog
@@ -203,6 +205,7 @@
 					onDeconfigure={async () => {
 						await AdminService.deconfigureModelProvider(modelProvider.id);
 						modelProviders = await AdminService.listModelProviders();
+						adminConfigStore.updateModelProviders(modelProviders);
 					}}
 				>
 					{#snippet configuredActions(provider)}

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -20,6 +20,7 @@
 	import { onMount } from 'svelte';
 	import DefaultModels from '$lib/components/admin/DefaultModels.svelte';
 	import { sortModelProviders } from '$lib/sort.js';
+	import { AlertTriangle } from 'lucide-svelte';
 
 	let { data } = $props();
 	let { modelProviders: initialModelProviders } = data;
@@ -31,6 +32,7 @@
 	let configuringModelProviderValues = $state<Record<string, string>>();
 	let configureError = $state<string>();
 	let loading = $state(false);
+	let atLeastOneConfigured = $derived(modelProviders.some((provider) => provider.configured));
 
 	initModels([]);
 	const adminModels = getAdminModels();
@@ -165,6 +167,19 @@
 				Model Providers
 				<DefaultModels bind:this={defaultModelsDialog} availableModels={adminModels.items} />
 			</h1>
+
+			{#if !atLeastOneConfigured}
+				<div class="notification-alert flex flex-col gap-2">
+					<div class="flex items-center gap-2">
+						<AlertTriangle class="size-6 flex-shrink-0 self-start text-yellow-500" />
+						<p class="my-0.5 flex flex-col text-sm font-semibold">No Model Providers Configured!</p>
+					</div>
+					<span class="text-sm font-light break-all">
+						To use Obot's features, you'll need to set up a Model Provider. Select and configure one
+						below to get started!
+					</span>
+				</div>
+			{/if}
 		</div>
 		<div class="grid grid-cols-2 gap-4 py-8 md:grid-cols-3 lg:grid-cols-4">
 			{#each sortedModelProviders as modelProvider (modelProvider.id)}


### PR DESCRIPTION
* adds ConfigureBanner like legacy admin

Also addresses #3852 

<img width="1373" height="852" alt="Screenshot 2025-08-11 at 12 39 32 PM" src="https://github.com/user-attachments/assets/353770d2-86af-4904-a9ac-b7f513397dd0" />

<img width="1374" height="721" alt="Screenshot 2025-08-11 at 12 25 19 PM" src="https://github.com/user-attachments/assets/5098f0d5-840c-478c-a773-142f8b63a634" />

<img width="1381" height="642" alt="Screenshot 2025-08-11 at 12 40 07 PM" src="https://github.com/user-attachments/assets/9eb3d236-bc19-4947-9cec-51d376910e9b" />


* created adminConfigStore to reduce calls to auth-providers/model-providers between route navigation