### PR TITLE
Fix: fix file not being able to download when created

### DIFF
--- a/ui/user/src/lib/services/chat/messages.ts
+++ b/ui/user/src/lib/services/chat/messages.ts
@@ -50,7 +50,10 @@ function setFileContent(
 			name: name,
 			file: {
 				contents: content,
-				buffer: ''
+				buffer: '',
+				threadID: opts.threadID,
+				taskID: opts.taskID,
+				runID: opts.runID
 			}
 		});
 	}


### PR DESCRIPTION
Fix https://github.com/obot-platform/obot/issues/3875

When files are first created it doesn't get assigned with thread id, this caused thread id to be missing when trying to download it and it will get an error.