### PR TITLE
enhance: add server name input & display info about duplicate server config

### DIFF
--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -13,6 +13,7 @@
 		headers?: MCPServerInfo['headers'];
 		url?: string;
 		hostname?: string;
+		name?: string;
 	};
 
 	interface Props {
@@ -154,6 +155,16 @@
 			}}
 		>
 			<div class="my-4 flex flex-col gap-4">
+				<div class="flex flex-col gap-1">
+					<span class="flex items-center gap-2">
+						<label for="name"> Server Name </label>
+						<span class="text-gray-400 dark:text-gray-600">(optional)</span>
+						<InfoTooltip
+							text="Uses server name as default. Duplicate instances default to a number increment added at the end of name."
+						/>
+					</span>
+					<input type="text" id="name" bind:value={form.name} class="text-input-filled" />
+				</div>
 				{#if form.envs && form.envs.length > 0}
 					{#each form.envs as env, i (env.key)}
 						{@const highlightRequired = highlightedFields.has(env.key) && !env.value}

--- a/ui/user/src/lib/components/mcp/MyMcpServers.svelte
+++ b/ui/user/src/lib/components/mcp/MyMcpServers.svelte
@@ -13,7 +13,7 @@
 	import { fly } from 'svelte/transition';
 	import type { LaunchFormData } from './CatalogConfigureForm.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
-	import { ChevronLeft, ChevronRight, LoaderCircle, ServerIcon } from 'lucide-svelte';
+	import { ChevronLeft, ChevronRight, Info, LoaderCircle, ServerIcon } from 'lucide-svelte';
 	import { tick, type Snippet } from 'svelte';
 	import McpCard from './McpCard.svelte';
 	import Search from '../Search.svelte';
@@ -188,6 +188,9 @@
 			}))
 			.filter((item) => !selectedCategory || item.server?.categories?.includes(selectedCategory))
 	]);
+	let userServerConfigureMap = $derived(
+		new Set(userConfiguredServers.map((server) => server.catalogEntryID))
+	);
 	let filteredConnectedServers = $derived(
 		connectedServers
 			.filter((item) => {
@@ -270,7 +273,7 @@
 		const serverName = entry.manifest.name || '';
 
 		// Generate unique alias if there's a naming conflict
-		const aliasToUse = getUniqueAlias(serverName);
+		const aliasToUse = configureForm?.name || getUniqueAlias(serverName);
 
 		let response: MCPCatalogServer | undefined = undefined;
 		try {
@@ -376,6 +379,7 @@
 
 	function initConfigureForm(item: Entry) {
 		configureForm = {
+			name: '',
 			envs: item.manifest?.env?.map((env) => ({
 				...env,
 				value: ''
@@ -696,6 +700,19 @@
 				{/if}
 			</div>
 		</div>
+
+		{#if 'isCatalogEntry' in item && userServerConfigureMap.has(item.id)}
+			<div class="notification-info p-3 text-sm font-light">
+				<div class="flex items-center gap-3">
+					<Info class="size-6" />
+					<p>
+						It looks like you already have an existing server instance available. It is recommended
+						to only create another one if you need to instantiate another one with different
+						configurations.
+					</p>
+				</div>
+			</div>
+		{/if}
 
 		{#if serverOrEntry}
 			<McpServerInfoAndTools entry={serverOrEntry} />


### PR DESCRIPTION
* displays info if user already has a configured server for that catalog entry
<img width="1064" height="546" alt="Screenshot 2025-08-11 at 5 33 47 PM" src="https://github.com/user-attachments/assets/2e81afbf-ed20-48f6-9848-b677826d4bb4" />

* adds name input for changing server field alias if desired
<img width="1518" height="819" alt="Screenshot 2025-08-11 at 5 35 03 PM" src="https://github.com/user-attachments/assets/7778e321-b4bd-445d-8a47-bbe06309bced" />
