### PR TITLE
fix: stop sending URL if URL is not set

### DIFF
--- a/ui/user/src/lib/components/mcp/MyMcpServers.svelte
+++ b/ui/user/src/lib/components/mcp/MyMcpServers.svelte
@@ -279,7 +279,7 @@
 		try {
 			response = await ChatService.createSingleOrRemoteMcpServer({
 				catalogEntryID: entry.id,
-				manifest: { remoteConfig: { url } },
+				manifest: url ? { remoteConfig: { url } } : {},
 				alias: aliasToUse
 			});
 		} catch (err) {


### PR DESCRIPTION
When the UI sends the request to create an MCP server, the remote config section will be non-nil. This leads to MCP servers with `https://` as their URL when no such URL should be set.

This change fixes that by checking the runtime.