### PR TITLE
fix: show filter by server id/ catalog entry name in mcp audit logs

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -368,7 +368,7 @@
 
 		<div class="mt-4 flex min-h-full flex-col gap-8 pb-8">
 			<!-- temporary filter mcp server by name and catalog entry id-->
-			<AuditLogsPageContent mcpId={null} {mcpCatalogEntryId} mcpServerDisplayName={name}>
+			<AuditLogsPageContent {mcpId} {mcpCatalogEntryId} mcpServerDisplayName={name}>
 				{#snippet emptyContent()}
 					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
 						<Users class="size-24 text-gray-200 dark:text-gray-900" />

--- a/ui/user/src/lib/components/admin/audit-logs/AuditFilter.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditFilter.svelte
@@ -56,7 +56,12 @@
 	);
 </script>
 
-<div class={twMerge('mb-2 flex flex-col gap-1', !options.length && 'opacity-50')}>
+<div
+	class={twMerge(
+		'mb-2 flex flex-col gap-1',
+		(filter.disabled || !options.length) && 'pointer-events-none opacity-50'
+	)}
+>
 	<div class="flex items-center justify-between">
 		<label for={filter.property} class="text-md font-light">
 			By {filter.label}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
@@ -92,7 +92,7 @@
 
 			if (filterId === 'user_id') {
 				return (
-					response.options
+					response?.options
 						?.filter((d) => filterOptions?.(d, filterId) ?? true)
 						?.map((d) => ({
 							id: d,
@@ -101,19 +101,9 @@
 				);
 			}
 
-			if (filterId === 'mcp_id') {
-				const selectedMcpId = page.params?.id ?? '';
-
-				return (
-					response?.options
-						?.filter((d) => !selectedMcpId || d.endsWith(selectedMcpId))
-						.map((d) => ({ id: d, label: d })) ?? []
-				);
-			}
-
 			return (
 				response?.options
-					.filter((d) => filterOptions?.(d, filterId) ?? true)
+					?.filter((d) => filterOptions?.(d, filterId) ?? true)
 					?.map((d) => ({
 						id: d,
 						label: d

--- a/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditFilters.svelte
@@ -10,6 +10,7 @@
 		selected?: string | number | null;
 		default?: string | number | null;
 		options: { id: string; label: string }[];
+		readonly disabled: boolean;
 	};
 
 	export type FilterOption = {
@@ -29,6 +30,9 @@
 
 	interface Props {
 		filters?: AuditLogURLFilters;
+		isFilterDisabled?: (key: keyof AuditLogURLFilters) => boolean;
+		// Used to filter server ids when selecting a multi instance server
+		filterOptions?: (option: string, filterId?: keyof AuditLogURLFilters) => boolean;
 		onClose: () => void;
 		getUserDisplayName: (userId: string) => string;
 		getFilterDisplayLabel?: (key: keyof AuditLogURLFilters) => string;
@@ -37,10 +41,12 @@
 
 	let {
 		filters: externFilters,
+		isFilterDisabled,
 		onClose,
 		getUserDisplayName,
 		getFilterDisplayLabel,
-		getDefaultValue
+		getDefaultValue,
+		filterOptions
 	}: Props = $props();
 
 	const url = new URL(page.url);
@@ -69,6 +75,9 @@
 				},
 				get options() {
 					return filtersOptions[filterId];
+				},
+				get disabled() {
+					return isFilterDisabled?.(filterId) ?? false;
 				}
 			};
 			return acc;
@@ -78,25 +87,37 @@
 	const filterInputsAsArray = $derived(Object.values(filterInputs));
 
 	$effect(() => {
-		const processLog = async (filterId: string) => {
+		const processLog = async (filterId: keyof AuditLogURLFilters) => {
 			const response = await AdminService.listAuditLogFilterOptions(filterId);
 
 			if (filterId === 'user_id') {
 				return (
 					response.options
+						?.filter((d) => filterOptions?.(d, filterId) ?? true)
 						?.map((d) => ({
 							id: d,
 							label: getUserDisplayName(d)
-						}))
-						?.filter(Boolean) ?? []
+						})) ?? []
+				);
+			}
+
+			if (filterId === 'mcp_id') {
+				const selectedMcpId = page.params?.id ?? '';
+
+				return (
+					response?.options
+						?.filter((d) => !selectedMcpId || d.endsWith(selectedMcpId))
+						.map((d) => ({ id: d, label: d })) ?? []
 				);
 			}
 
 			return (
-				response?.options?.map((d) => ({
-					id: d,
-					label: d
-				})) ?? []
+				response?.options
+					.filter((d) => filterOptions?.(d, filterId) ?? true)
+					?.map((d) => ({
+						id: d,
+						label: d
+					})) ?? []
 			);
 		};
 

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -517,8 +517,6 @@
 			getDefaultValue={(filter) => defaultSearchParams[filter]}
 			filterOptions={(option, filterId) => {
 				if (filterId === 'mcp_id') {
-					console.log(page.url.pathname);
-
 					if (page.url.pathname.match(/[\w\d]+$/)) {
 						const selectedMcpId = page.params?.id ?? '';
 

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -168,11 +168,11 @@
 	const auditLogsSlideoverFilters = $derived.by(() => {
 		const clone = { ...searchParamFilters };
 
-		for (const key of ['mcp_server_display_name', 'start_time', 'end_time']) {
+		for (const key of ['start_time', 'end_time']) {
 			delete clone[key as keyof AuditLogURLFilters];
 		}
 
-		return { ...clone };
+		return { ...clone, ...propsFilters };
 	});
 
 	let timeRangeFilters = $derived.by(() => {

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -34,7 +34,7 @@
 		emptyContent?: Snippet;
 	}
 
-	let { mcpId, mcpCatalogEntryId, mcpServerDisplayName, emptyContent }: Props = $props();
+	let { mcpServerDisplayName, emptyContent }: Props = $props();
 
 	let auditLogsResponse = $state<PaginatedResponse<AuditLog>>();
 	const auditLogsTotalItems = $derived(auditLogsResponse?.total ?? 0);
@@ -152,8 +152,6 @@
 
 	const propsFilters = $derived.by(() => {
 		const entries: [key: string, value: string | null | undefined][] = [
-			['mcp_id', mcpId],
-			['mcp_server_catalog_entry_name', mcpCatalogEntryId],
 			['mcp_server_display_name', mcpServerDisplayName]
 		];
 
@@ -170,7 +168,7 @@
 	const auditLogsSlideoverFilters = $derived.by(() => {
 		const clone = { ...searchParamFilters };
 
-		for (const key of [...Object.keys(propsFilters), 'start_time', 'end_time']) {
+		for (const key of ['mcp_server_display_name', 'start_time', 'end_time']) {
 			delete clone[key as keyof AuditLogURLFilters];
 		}
 
@@ -506,9 +504,30 @@
 		<AuditFilters
 			onClose={handleRightSidebarClose}
 			filters={{ ...auditLogsSlideoverFilters }}
+			isFilterDisabled={(key) => {
+				if (!mcpServerDisplayName) return false;
+
+				if (key === 'mcp_server_display_name') return true;
+				if (key === 'mcp_server_catalog_entry_name') return true;
+
+				return false;
+			}}
 			{getUserDisplayName}
 			{getFilterDisplayLabel}
 			getDefaultValue={(filter) => defaultSearchParams[filter]}
+			filterOptions={(option, filterId) => {
+				if (filterId === 'mcp_id') {
+					console.log(page.url.pathname);
+
+					if (page.url.pathname.match(/[\w\d]+$/)) {
+						const selectedMcpId = page.params?.id ?? '';
+
+						return !selectedMcpId || option.endsWith(selectedMcpId);
+					}
+				}
+
+				return true;
+			}}
 		/>
 	{/if}
 </dialog>


### PR DESCRIPTION
Addresses #3898 

- Show server ID and server catalog entry name fields in the MCP server audit logs page.
- In case the user selects a single server, the server ID is disabled.
- In case the user selects a single server, the catalog entry name is disabled.
- In case the user selects a multi-user server, the server ID shows only the available instances of the selected server.
- The server name filter will be disabled in the MCP server audit logs tab.

Changes to Audit filter:
- Add disabled property
- When no option is available, make the filter disabled.