### PR TITLE
fix: sort audit filter options lexicographically

### DIFF
--- a/pkg/api/handlers/mcpgateway/auditlog.go
+++ b/pkg/api/handlers/mcpgateway/auditlog.go
@@ -1,6 +1,7 @@
 package mcpgateway
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -190,6 +191,9 @@ func (h *AuditLogHandler) ListAuditLogFilterOptions(req api.Context) error {
 			}
 		}
 	}
+
+	// Ensure final options are lexicographically sorted after merging defaults
+	sort.Strings(options)
 
 	return req.Write(map[string]any{
 		"options": options,


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/3807 for audit log options.

