### PR TITLE
enhance: allow setting ANTHROPIC_API_KEY for model setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Then open your browser to [http://localhost:8080](http://localhost:8080) to acce
 > You need to replace `<API KEY>` with your [OpenAI API Key](https://platform.openai.com/api-keys).
 >
 > Setting this is optional, but you'll need to setup a model provider from the Admin UI before using chat.
+>
+> You can also set `ANTHROPIC_API_KEY` here as well, setting the value to your [Anthropic API Key](https://console.anthropic.com/settings/keys).
+>
+> Setting both is also supported, but OpenAI models will be set as the defaults.
 
 For more installation methods, see our [Installation Guide](https://docs.obot.ai/installation/general).
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -96,6 +96,8 @@ config:
   OBOT_SERVER_RETENTION_POLICY_HOURS: ""
   # config.OPENAI_API_KEY -- An OpenAI API Key used to configure access to OpenAI models, which are the default in Obot.
   OPENAI_API_KEY: ""
+  # config.ANTHROPIC_API_KEY -- An Anthropic API Key used to configure access to Anthropic models, which can be used as the default in Obot.
+  ANTHROPIC_API_KEY: ""
 
   # config.OBOT_SERVER_OTEL_BASE_EXPORT_ENDPOINT -- The base export endpoint for OpenTelemetry
   OBOT_SERVER_OTEL_BASE_EXPORT_ENDPOINT: ""

--- a/docs/docs/01-overview.md
+++ b/docs/docs/01-overview.md
@@ -22,6 +22,10 @@ Then open your browser to [http://localhost:8080](http://localhost:8080) to acce
 You need to replace `<API KEY>` with your [OpenAI API Key](https://platform.openai.com/api-keys).
 
 Setting this is optional, but you'll need to setup a model provider from the Admin UI before using chat.
+
+You can also set `ANTHROPIC_API_KEY` here as well, setting the value to your [Anthropic API Key](https://console.anthropic.com/settings/keys).
+
+Setting both is also supported, but OpenAI models will be set as the defaults.
 :::
 
 For more installation methods, see our [Installation Guide](/installation/general).

--- a/docs/docs/10-installation/00-general.md
+++ b/docs/docs/10-installation/00-general.md
@@ -84,9 +84,12 @@ config:
 
   # Point this to your postgres database
   OBOT_SERVER_DSN: postgres://<user>:<pass>@<host>/<db>
-  
+
   OBOT_SERVER_HOSTNAME: <your obot hostname>
+  # Setting these is optional, but you'll need to setup a model provider from the Admin UI before using chat.
+  # You can set either, neither or both.
   OPENAI_API_KEY: <openai api key>
+  ANTHROPIC_API_KEY: <anthropic api key>
 ```
 
 

--- a/docs/docs/50-configuration/01-server-configuration.md
+++ b/docs/docs/50-configuration/01-server-configuration.md
@@ -5,6 +5,7 @@ The Obot server is configured via environment variables. The following configura
 | Environment Variable | Description |
 |---------------------|-------------|
 | `OPENAI_API_KEY` | The foundation of Obot is a large language model that supports function-calling. The default is OpenAI and specifying an OpenAI key here will ensure none of the users need to worry about specifying their own API key. |
+| `ANTHROPIC_API_KEY` | You can also provide an Anthropic API key in place of or in addition to an OpenAI API key. |
 | `GITHUB_AUTH_TOKEN` | Obot and its underlying tool GPTScript make heavy use of tools hosted on GitHub. Care is taken to cache these tools and only re-check when necessary. However, rate-limiting can happen. Setting a read-only token here can alleviate many of these issues. |
 | `OBOT_SERVER_DSN` | Obot uses a database backend. By default, it will use a sqlite3 local database. This environment variable allows you to specify another database option. For example, you can use a postgres database with something like `OBOT_SERVER_DSN=postgres://user:password@host/database`. |
 | `OBOT_SERVER_HOSTNAME` | Tell Obot what its server URL is so that things like OAuth, LLM proxying, and invoke URLs are handled correctly. |

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,6 +73,10 @@ func (c *Controller) PostStart(ctx context.Context, client kclient.Client) {
 		panic(fmt.Errorf("failed to ensure openai env credential and defaults: %w", err))
 	}
 
+	if err = c.toolRefHandler.EnsureAnthropicCredentialAndDefaults(ctx, client); err != nil {
+		panic(fmt.Errorf("failed to ensure anthropic credential and defaults: %w", err))
+	}
+
 	if err := c.mcpCatalogHandler.SetUpDefaultMCPCatalog(ctx, client); err != nil {
 		panic(fmt.Errorf("failed to set up default mcp catalog: %w", err))
 	}


### PR DESCRIPTION
This adds the same functionality for an Anthropic API key as we support for an OpenAI API key.

Note that Anthropic doesn't have an image generation nor text-embedding model, so neither of these default model aliases will be set when using Anthropic API keys.