### PR TITLE
fix: add browser check so markdown parser goes through dompurify

### DIFF
--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -33,6 +33,7 @@
 	import { HELPER_TEXTS } from '$lib/context/helperMode.svelte';
 	import { clickOutside } from '$lib/actions/clickoutside';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
+	import { browser } from '$app/environment';
 
 	interface Props {
 		id?: string;
@@ -569,7 +570,9 @@
 			<div class="w-full max-w-[1000px]">
 				{#if centerInput && assistant?.introductionMessage}
 					<div class="milkdown-content mb-5 max-w-full px-5" in:fade>
-						{@html toHTMLFromMarkdown(assistant?.introductionMessage)}
+						{#if browser}
+							{@html toHTMLFromMarkdown(assistant?.introductionMessage)}
+						{/if}
 					</div>
 				{/if}
 				<Input

--- a/ui/user/src/lib/components/mcp/McpServerInfo.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerInfo.svelte
@@ -6,6 +6,7 @@
 	import { responsive } from '$lib/stores';
 	import { toHTMLFromMarkdownWithNewTabLinks } from '$lib/markdown';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
+	import { browser } from '$app/environment';
 
 	interface Props {
 		entry: MCPCatalogEntry | MCPCatalogServer | ProjectMCP;
@@ -123,7 +124,7 @@
 	<div
 		class="dark:bg-surface1 dark:border-surface3 flex h-fit w-full flex-col gap-4 rounded-lg border border-transparent bg-white p-4 shadow-sm"
 	>
-		{#if description}
+		{#if description && browser}
 			<div class="milkdown-content">
 				{@html toHTMLFromMarkdownWithNewTabLinks(description)}
 			</div>

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -23,6 +23,7 @@
 	import { parseErrorContent } from '$lib/errors';
 	import { toHTMLFromMarkdownWithNewTabLinks } from '$lib/markdown';
 	import Search from '../Search.svelte';
+	import { browser } from '$app/environment';
 
 	interface Props {
 		entry: MCPCatalogEntry | MCPCatalogServer | ProjectMCP;
@@ -357,12 +358,14 @@
 							</div>
 						</div>
 						{#if expandedDescriptions[tool.id] || allDescriptionsEnabled}
-							<div
-								in:slide={{ axis: 'y' }}
-								class="milkdown-content max-w-none text-sm font-light text-gray-500"
-							>
-								{@html toHTMLFromMarkdownWithNewTabLinks(tool.description || '')}
-							</div>
+							{#if browser}
+								<div
+									in:slide={{ axis: 'y' }}
+									class="milkdown-content max-w-none text-sm font-light text-gray-500"
+								>
+									{@html toHTMLFromMarkdownWithNewTabLinks(tool.description || '')}
+								</div>
+							{/if}
 							{#if Object.keys(tool.params ?? {}).length > 0}
 								{#if expandedParams[tool.id] || allParamsEnabled}
 									<div


### PR DESCRIPTION
Addresses #3961 

For components that render on routes with SSR, we need to make sure it goes through DOMPurify to make sure the html gets sanitized -- just need a browser check in these areas! `<unknown>` and `<transcript>` are elements that are causing hydration mismatch. 

Loom showing fix: 
https://www.loom.com/share/add55a39a0ab41739bd687305190c32c