### PR TITLE
fix: stop redirect loop on fresh installs with auth enabled

### DIFF
--- a/ui/user/src/lib/services/chat/operations.ts
+++ b/ui/user/src/lib/services/chat/operations.ts
@@ -63,8 +63,8 @@ export async function deleteProfile() {
 	return doDelete(`/me`);
 }
 
-export async function getVersion(): Promise<Version> {
-	return (await doGet('/version')) as Version;
+export async function getVersion(opts?: { fetch?: Fetcher }): Promise<Version> {
+	return (await doGet('/version', opts)) as Version;
 }
 
 export async function getAssistant(id: string, opts?: { fetch?: Fetcher }): Promise<Assistant> {

--- a/ui/user/src/routes/admin/+page.ts
+++ b/ui/user/src/routes/admin/+page.ts
@@ -7,8 +7,10 @@ import { redirect } from '@sveltejs/kit';
 export const load: PageLoad = async ({ fetch }) => {
 	let authProviders: AuthProvider[] = [];
 	let profile;
+	let version;
 
 	try {
+		version = await ChatService.getVersion({ fetch });
 		profile = await getProfile({ fetch });
 	} catch (_err) {
 		authProviders = await ChatService.listAuthProviders({ fetch });
@@ -17,7 +19,9 @@ export const load: PageLoad = async ({ fetch }) => {
 	if (profile?.role === Role.ADMIN) {
 		throw redirect(
 			307,
-			profile.username === BOOTSTRAP_USER_ID ? '/admin/auth-providers' : '/admin/mcp-servers'
+			profile.username === BOOTSTRAP_USER_ID && version?.authEnabled
+				? '/admin/auth-providers'
+				: '/admin/mcp-servers'
 		);
 	}
 

--- a/ui/user/src/routes/admin/auth-providers/+page.ts
+++ b/ui/user/src/routes/admin/auth-providers/+page.ts
@@ -1,12 +1,13 @@
 import { handleRouteError } from '$lib/errors';
-import { AdminService } from '$lib/services';
+import { AdminService, ChatService } from '$lib/services';
 import type { AuthProvider } from '$lib/services/admin/types';
-import { profile, version } from '$lib/stores';
+import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 
 export const load: PageLoad = async ({ fetch }) => {
-	if (!version.current.authEnabled) {
+	const version = await ChatService.getVersion({ fetch });
+	if (!version.authEnabled) {
 		throw redirect(302, '/admin');
 	}
 


### PR DESCRIPTION
When authentication is enabled on a fresh install, a "too many redirects" error is presented to the user after they enter the bootstrap token. Checking whether the current user is admin seems to stop this.

I found that this redirect and [this one](https://github.com/obot-platform/obot/blob/main/ui/user/src/routes/admin/+page.ts#L20) contend with each other and redirect until the error occurs.