### PR TITLE
fix: server name and chat auth fixes

### DIFF
--- a/ui/user/src/lib/components/chat/McpServerOauths.svelte
+++ b/ui/user/src/lib/components/chat/McpServerOauths.svelte
@@ -3,6 +3,7 @@
 	import { Server, X } from 'lucide-svelte';
 	import { dialogAnimation } from '$lib/actions/dialogAnimation';
 	import { onMount } from 'svelte';
+	import { getLayout } from '$lib/context/chatLayout.svelte';
 
 	interface Props {
 		assistantId: string;
@@ -17,9 +18,13 @@
 		projectMcps.items.filter((mcp) => !mcp.authenticated && mcp.oauthURL)
 	);
 	let dialogs = $state<HTMLDialogElement[]>([]);
+	const layout = getLayout();
+	const isInMcp = $derived(
+		layout.sidebarConfig === 'mcp-server-tools' || layout.sidebarConfig === 'mcp-server'
+	);
 
 	$effect(() => {
-		if (mcpServersThatRequireOauth.length > 0) {
+		if (mcpServersThatRequireOauth.length > 0 && !isInMcp) {
 			currentIndex = 0;
 			dialogs[currentIndex]?.showModal();
 		}
@@ -27,6 +32,7 @@
 
 	onMount(() => {
 		const handleVisibilityChange = () => {
+			if (isInMcp) return;
 			if (document.visibilityState === 'visible') {
 				checkMcpOauths();
 			}

--- a/ui/user/src/lib/components/edit/McpServers.svelte
+++ b/ui/user/src/lib/components/edit/McpServers.svelte
@@ -114,7 +114,7 @@
 										? 'Configuration Required'
 										: 'Authentication Required'}
 								>
-									<TriangleAlert class="size-4" stroke="currentColor" fill="none" color="orange" />
+									<TriangleAlert class="size-3" stroke="currentColor" fill="none" color="orange" />
 								</span>
 							{/if}
 						</p>

--- a/ui/user/src/lib/components/edit/McpServers.svelte
+++ b/ui/user/src/lib/components/edit/McpServers.svelte
@@ -58,9 +58,11 @@
 	}
 
 	function shouldShowWarning(mcp: (typeof projectMCPs.items)[0]) {
-		if (typeof mcp.authenticated === 'boolean' && !mcp.authenticated) {
-			return true;
+		if (typeof mcp.authenticated === 'boolean') {
+			return !mcp.authenticated;
 		}
+
+		return !!mcp.oauthURL;
 	}
 
 	async function handleRemoveMcp() {

--- a/ui/user/src/lib/components/mcp/McpOauth.svelte
+++ b/ui/user/src/lib/components/mcp/McpOauth.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import {
+		AdminService,
+		ChatService,
+		type MCPCatalogEntry,
+		type MCPCatalogServer,
+		type Project,
+		type ProjectMCP
+	} from '$lib/services';
+	import { parseErrorContent } from '$lib/errors';
+	import { Info, RefreshCcw } from 'lucide-svelte';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		entry: MCPCatalogEntry | MCPCatalogServer | ProjectMCP;
+		onAuthenticate?: () => void;
+		error?: string;
+		project?: Project;
+		text?: string;
+	}
+
+	let { onAuthenticate, error = $bindable(), project, entry, text }: Props = $props();
+
+	let oauthURL = $state<string>('');
+	let showRefresh = $state(false);
+	let loading = $state(false);
+	// Create AbortController for cancelling API calls
+	let abortController = $state<AbortController | null>(null);
+
+	async function loadOauthURL() {
+		// Cancel any existing requests
+		if (abortController) {
+			abortController.abort();
+		}
+
+		// Create new AbortController for this request
+		abortController = new AbortController();
+
+		loading = true;
+		oauthURL = '';
+		showRefresh = false;
+		error = '';
+
+		try {
+			if (project) {
+				oauthURL = await ChatService.getProjectMcpServerOauthURL(
+					project.assistantID,
+					project.id,
+					entry.id,
+					{
+						signal: abortController.signal
+					}
+				);
+			} else if ('sharedWithinCatalogName' in entry) {
+				oauthURL = await AdminService.getMCPCatalogServerOAuthURL(
+					entry.sharedWithinCatalogName,
+					entry.id,
+					{
+						signal: abortController.signal
+					}
+				);
+			} else {
+				oauthURL = await ChatService.getMcpServerOauthURL(entry.id, {
+					signal: abortController.signal
+				});
+			}
+		} catch (err: unknown) {
+			// Only handle errors if the request wasn't aborted
+			if (err instanceof Error && err.name !== 'AbortError') {
+				console.error(err);
+				const { message } = parseErrorContent(err);
+				error = message;
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(() => {
+		loadOauthURL();
+	});
+</script>
+
+{#if oauthURL}
+	<div class="notification-info flex w-full flex-row justify-between p-3 text-sm font-light">
+		<div class="flex items-center gap-3">
+			<Info class="size-6 flex-shrink-0" />
+			{#if text}
+				<p>{text}</p>
+			{:else}
+				<p>For detailed information about this MCP server, server authentication is required.</p>
+			{/if}
+		</div>
+		{#if showRefresh}
+			<button
+				class="button-primary flex items-center justify-center gap-1 text-center text-sm"
+				onclick={async () => {
+					await loadOauthURL();
+					onAuthenticate?.();
+				}}
+				disabled={loading}
+			>
+				<RefreshCcw class="size-4 text-white" /> Reload
+			</button>
+		{:else}
+			<a
+				target="_blank"
+				href={oauthURL}
+				class="button-primary text-center text-sm"
+				onclick={() => {
+					setTimeout(() => {
+						showRefresh = true;
+					}, 500);
+				}}
+			>
+				Authenticate
+			</a>
+		{/if}
+	</div>
+{/if}

--- a/ui/user/src/lib/components/mcp/McpServerInfo.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerInfo.svelte
@@ -7,10 +7,12 @@
 	import { toHTMLFromMarkdownWithNewTabLinks } from '$lib/markdown';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { browser } from '$app/environment';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
 		entry: MCPCatalogEntry | MCPCatalogServer | ProjectMCP;
 		descriptionPlaceholder?: string;
+		preContent?: Snippet;
 	}
 
 	type EntryDetail = {
@@ -109,7 +111,7 @@
 		return details.filter((d) => d);
 	}
 
-	let { entry, descriptionPlaceholder = 'No description available' }: Props = $props();
+	let { entry, descriptionPlaceholder = 'No description available', preContent }: Props = $props();
 	let details = $derived(convertEntryDetails(entry));
 	let description = $derived(
 		('manifest' in entry
@@ -119,6 +121,10 @@
 				: '') ?? ''
 	);
 </script>
+
+{#if preContent}
+	{@render preContent()}
+{/if}
 
 <div class="flex w-full flex-col gap-4 md:flex-row">
 	<div

--- a/ui/user/src/lib/components/mcp/McpServerInfoAndTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerInfoAndTools.svelte
@@ -3,6 +3,7 @@
 	import { twMerge } from 'tailwind-merge';
 	import McpServerInfo from './McpServerInfo.svelte';
 	import McpServerTools from './McpServerTools.svelte';
+	import McpOauth from './McpOauth.svelte';
 
 	interface Props {
 		entry?: MCPCatalogEntry | MCPCatalogServer | ProjectMCP;
@@ -59,7 +60,13 @@
 				<McpServerInfo
 					{entry}
 					descriptionPlaceholder="Add a description for this MCP server in the Configuration tab"
-				/>
+				>
+					{#snippet preContent()}
+						{#if project}
+							<McpOauth {entry} {onAuthenticate} {project} />
+						{/if}
+					{/snippet}
+				</McpServerInfo>
 			</div>
 		{:else if selected === 'tools' && entry}
 			<McpServerTools {entry} {catalogId} {onAuthenticate} {project} {onProjectToolsUpdate} />

--- a/ui/user/src/lib/components/mcp/MyMcpServers.svelte
+++ b/ui/user/src/lib/components/mcp/MyMcpServers.svelte
@@ -672,7 +672,7 @@
 						class="button-primary"
 						onclick={() => {
 							configureForm = undefined;
-							if ('isCatalogEntry' in item && hasEditableConfiguration(item)) {
+							if ('isCatalogEntry' in item) {
 								initConfigureForm(item);
 								configDialog?.open();
 							} else {

--- a/ui/user/src/lib/components/mcp/MyMcpServers.svelte
+++ b/ui/user/src/lib/components/mcp/MyMcpServers.svelte
@@ -566,7 +566,9 @@
 	bind:form={configureForm}
 	{error}
 	icon={selectedManifest?.icon}
-	name={selectedManifest?.name}
+	name={selectedEntryOrServer && 'server' in selectedEntryOrServer
+		? selectedEntryOrServer.server?.alias || selectedManifest?.name
+		: selectedManifest?.name}
 	onSave={handleConfigureForm}
 	submitText={selectedEntryOrServer && 'server' in selectedEntryOrServer ? 'Update' : 'Launch'}
 	loading={saving}

--- a/ui/user/src/routes/mcp-servers/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/+page.svelte
@@ -125,9 +125,10 @@
 		}, 10000);
 
 		const projects = await ChatService.listProjects();
-		const name = [connectedServer.server?.manifest.name ?? '', connectedServer.server.id].join(
-			' - '
-		);
+		const name = [
+			connectedServer.server?.alias || connectedServer.server?.manifest.name || '',
+			connectedServer.server.id
+		].join(' - ');
 		const match = projects.items.find((project) => project.name === name);
 
 		let project = match;


### PR DESCRIPTION
Addresses #3885
* moves the authenticate banner to also show in overview when mcp server in chat needs authentication
* provides another way to authenticate if user closes out the authentication dialog
* fixes warning not showing in sidebar when mcp server requires oauth
<img width="1447" height="628" alt="Screenshot 2025-08-21 at 11 12 27 AM" src="https://github.com/user-attachments/assets/0fb448e3-7d8e-4286-beb3-7d00030b4e62" />

Addresses #3925
Addresses #3926 
Addresses #3929 