### PR TITLE
fix: return list of mcp id in audit logs page

### DIFF
--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -551,7 +551,7 @@
 				}
 
 				if (!catalogId || !mcpServerCatalogEntryName) {
-					return { options: [] };
+					return await AdminService.listAuditLogFilterOptions(filterId, ...args);
 				}
 
 				const items = await AdminService.listMCPServersForEntry(


### PR DESCRIPTION
Address #3898 

- Follow-up fix for fetching mcp ids options