### PR TITLE
fix: condition for group info update

### DIFF
--- a/pkg/gateway/client/group.go
+++ b/pkg/gateway/client/group.go
@@ -175,7 +175,7 @@ func (c *Client) ensureGroups(ctx context.Context, tx *gorm.DB, identity *types.
 
 	var toUpsert []types.Group
 	for _, group := range identity.AuthProviderGroups {
-		if existing, ok := existingGroups[group.ID]; ok && (existing.Name != group.Name || existing.IconURL != group.IconURL) {
+		if existing, ok := existingGroups[group.ID]; ok && existing.Name == group.Name && existing.IconURL == group.IconURL {
 			// The group already exists and is up to date, skip
 			continue
 		}


### PR DESCRIPTION
Fix the condition that detects when user group name and icon info has changed from what's cached. This will ensure informational changes to cached groups are kept up to date.

Part of https://github.com/obot-platform/obot/issues/4012
