### PR TITLE
enhance: validate auth provider options before (re)configuring

### DIFF
--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -24,7 +24,7 @@ import (
 )
 
 type Dispatcher struct {
-	invoker                     *invoke.Invoker
+	Invoker                     *invoke.Invoker
 	gptscript                   *gptscript.GPTScript
 	client                      kclient.Client
 	gatewayClient               *client.Client
@@ -41,7 +41,7 @@ type Dispatcher struct {
 
 func New(ctx context.Context, invoker *invoke.Invoker, c kclient.Client, gClient *gptscript.GPTScript, gatewayClient *client.Client, postgresDSN string) *Dispatcher {
 	d := &Dispatcher{
-		invoker:                     invoker,
+		Invoker:                     invoker,
 		gptscript:                   gClient,
 		client:                      c,
 		gatewayClient:               gatewayClient,
@@ -148,7 +148,7 @@ func (d *Dispatcher) startProvider(ctx context.Context, providerType types.ToolR
 		return url.URL{}, fmt.Errorf("failed to get provider: %w", err)
 	}
 
-	task, err := d.invoker.SystemTask(ctx, thread, providerName, "", invoke.SystemTaskOptions{
+	task, err := d.Invoker.SystemTask(ctx, thread, providerName, "", invoke.SystemTaskOptions{
 		CredentialContextIDs: []string{string(providerToolRef.UID), providerTypeToGenericCredContext[providerType]},
 		Env:                  extraEnv,
 	})

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -445,3 +445,15 @@ export interface MCPFilter extends MCPFilterManifest {
 	type: string;
 	hasSecret: boolean;
 }
+
+// Field validation error types
+export interface FieldError {
+	envVar: string;
+	message: string;
+	value: string;
+	sensitive: boolean;
+}
+
+export interface ValidationError {
+	error: FieldError[] | string;
+}


### PR DESCRIPTION
- Validate auth provider options before (re)configuration using the target auth provider's `validate` tool (when present)
- Capture and display field-specific validation errors in auth provider config dialog

Loom: https://www.loom.com/share/09e93ef0c92f4113b6bb5cedb6c72641?sid=8e1455eb-7b5a-4d06-9ccf-f1104a07199e

Addresses part of https://github.com/obot-platform/obot/issues/4039