### PR TITLE
fix: inherit enabled connector name, description, categories from parent

### DIFF
--- a/ui/user/src/lib/components/mcp/McpCard.svelte
+++ b/ui/user/src/lib/components/mcp/McpCard.svelte
@@ -18,7 +18,8 @@
 
 	let icon = $derived(data.manifest.icon);
 	let name = $derived(data?.alias ?? parent?.manifest.name ?? data?.manifest?.name);
-	let categories = $derived('categories' in data ? data.categories! : parseCategories(data));
+	let description = $derived(parent?.manifest?.description ?? data?.manifest?.description);
+	let categories = $derived(parent?.categories ?? data.categories! ?? parseCategories(data));
 	let needsUpdate = $derived(!('isCatalogEntry' in data) ? !data.configured : false);
 </script>
 
@@ -50,7 +51,7 @@
 				categories.length > 0 ? 'line-clamp-2' : 'line-clamp-3'
 			)}
 		>
-			{stripMarkdownToText(data.manifest.description ?? '')}
+			{stripMarkdownToText(description ?? '')}
 		</span>
 		<div class="line-clamp-1 flex w-full gap-1 pt-2">
 			{#each categories as category (category)}

--- a/ui/user/src/lib/components/mcp/McpCard.svelte
+++ b/ui/user/src/lib/components/mcp/McpCard.svelte
@@ -8,19 +8,17 @@
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
-		data:
-			| MCPCatalogServer
-			| MCPCatalogEntry
-			| (MCPCatalogServer & { categories: string[] })
-			| (MCPCatalogEntry & { categories: string[] });
+		data: (MCPCatalogServer | MCPCatalogEntry) & { categories?: string[]; alias?: string };
+		parent?: Props['data'];
 		onClick: () => void;
 		action?: Snippet;
 	}
 
-	let { data, onClick, action }: Props = $props();
+	let { data, parent, onClick, action }: Props = $props();
+
 	let icon = $derived(data.manifest.icon);
-	let name = $derived('alias' in data ? data.alias : data.manifest.name);
-	let categories = $derived('categories' in data ? data.categories : parseCategories(data));
+	let name = $derived(data?.alias ?? parent?.manifest.name ?? data?.manifest?.name);
+	let categories = $derived('categories' in data ? data.categories! : parseCategories(data));
 	let needsUpdate = $derived(!('isCatalogEntry' in data) ? !data.configured : false);
 </script>
 

--- a/ui/user/src/lib/components/mcp/McpServerInfo.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerInfo.svelte
@@ -11,6 +11,7 @@
 
 	interface Props {
 		entry: MCPCatalogEntry | MCPCatalogServer | ProjectMCP;
+		parent?: Props['entry'];
 		descriptionPlaceholder?: string;
 		preContent?: Snippet;
 	}
@@ -111,15 +112,29 @@
 		return details.filter((d) => d);
 	}
 
-	let { entry, descriptionPlaceholder = 'No description available', preContent }: Props = $props();
+	let {
+		entry,
+		parent,
+		descriptionPlaceholder = 'No description available',
+		preContent
+	}: Props = $props();
 	let details = $derived(convertEntryDetails(entry));
-	let description = $derived(
-		('manifest' in entry
-			? entry.manifest.description
-			: 'description' in entry
-				? entry.description
-				: '') ?? ''
-	);
+	let description = $derived.by(() => {
+		const descriptions = [
+			() => ('description' in entry ? entry.description : undefined),
+			() => ('manifest' in entry ? entry.manifest.description : undefined),
+			() => (parent && 'manifest' in parent ? parent?.manifest?.description : undefined)
+		];
+
+		for (const fn of descriptions) {
+			const desc = fn();
+			if (desc) {
+				return desc;
+			}
+		}
+
+		return '';
+	});
 </script>
 
 {#if preContent}

--- a/ui/user/src/lib/components/mcp/McpServerInfoAndTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerInfoAndTools.svelte
@@ -7,6 +7,7 @@
 
 	interface Props {
 		entry?: MCPCatalogEntry | MCPCatalogServer | ProjectMCP;
+		parent?: Props['entry'];
 		catalogId?: string;
 		onAuthenticate?: () => void;
 		project?: Project;
@@ -16,6 +17,7 @@
 
 	let {
 		entry,
+		parent,
 		catalogId,
 		onAuthenticate,
 		project,
@@ -59,6 +61,7 @@
 			<div class="pb-8">
 				<McpServerInfo
 					{entry}
+					{parent}
 					descriptionPlaceholder="Add a description for this MCP server in the Configuration tab"
 				>
 					{#snippet preContent()}

--- a/ui/user/src/lib/components/mcp/MyMcpServers.svelte
+++ b/ui/user/src/lib/components/mcp/MyMcpServers.svelte
@@ -480,6 +480,7 @@
 							{#if connectedServer.server}
 								<McpCard
 									data={connectedServer.server}
+									parent={connectedServer.parent}
 									onClick={() => {
 										if (onConnectedServerCardClick) {
 											onConnectedServerCardClick(connectedServer);

--- a/ui/user/src/lib/components/mcp/MyMcpServers.svelte
+++ b/ui/user/src/lib/components/mcp/MyMcpServers.svelte
@@ -721,7 +721,12 @@
 		{/if}
 
 		{#if serverOrEntry}
-			<McpServerInfoAndTools entry={serverOrEntry} />
+			<McpServerInfoAndTools
+				entry={serverOrEntry}
+				parent={selectedEntryOrServer && 'parent' in selectedEntryOrServer
+					? selectedEntryOrServer.parent
+					: undefined}
+			/>
 		{/if}
 	</div>
 {/snippet}


### PR DESCRIPTION
Addresses #3953

- mcp card name is derived from the server alias or parent manifest's name.