### PR TITLE
Enhance: Add URL templating

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -41,15 +41,17 @@ type ContainerizedRuntimeConfig struct {
 
 // RemoteRuntimeConfig represents configuration for remote runtime (External MCP servers)
 type RemoteRuntimeConfig struct {
-	URL     string      `json:"url"`               // Required: Full URL to remote MCP server
-	Headers []MCPHeader `json:"headers,omitempty"` // Optional
+	URL        string      `json:"url"`               // Required: Full URL to remote MCP server
+	Headers    []MCPHeader `json:"headers,omitempty"` // Optional
+	IsTemplate bool        `json:"isTemplate"`        // Optional: Whether the URL is a template
 }
 
 // RemoteCatalogConfig represents template configuration for remote servers in catalog entries
 type RemoteCatalogConfig struct {
-	FixedURL string      `json:"fixedURL,omitempty"` // Fixed URL for all instances
-	Hostname string      `json:"hostname,omitempty"` // Required hostname for user URLs
-	Headers  []MCPHeader `json:"headers,omitempty"`  // Optional
+	FixedURL    string      `json:"fixedURL,omitempty"`    // Fixed URL for all instances
+	URLTemplate string      `json:"urlTemplate,omitempty"` // URL template for user URLs
+	Hostname    string      `json:"hostname,omitempty"`    // Required hostname for user URLs
+	Headers     []MCPHeader `json:"headers,omitempty"`     // Optional
 }
 
 type MCPServerCatalogEntry struct {
@@ -313,11 +315,13 @@ func MapCatalogEntryToServer(catalogEntry MCPServerCatalogEntryManifest, userURL
 				return serverManifest, err
 			}
 			remoteConfig.URL = userURL
+		} else if catalogEntry.RemoteConfig.URLTemplate != "" {
+			remoteConfig.IsTemplate = true
 		} else {
 			return serverManifest, RuntimeValidationError{
 				Runtime: RuntimeRemote,
 				Field:   "remoteConfig",
-				Message: "either fixedURL or hostname must be specified in catalog entry",
+				Message: "either fixedURL, hostname, or urlTemplate must be specified in catalog entry",
 			}
 		}
 

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -1,0 +1,279 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Test functions for applyURLTemplate
+func TestApplyURLTemplate(t *testing.T) {
+	tests := []struct {
+		name        string
+		template    string
+		envVars     map[string]string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "basic substitution",
+			template: "https://${DATABRICKS_WORKSPACE_URL}/api/2.0/mcp/genie/${DATABRICKS_GENIE_SPACE_ID}",
+			envVars: map[string]string{
+				"DATABRICKS_WORKSPACE_URL":  "workspace.cloud.databricks.com",
+				"DATABRICKS_GENIE_SPACE_ID": "12345",
+			},
+			expected:    "https://workspace.cloud.databricks.com/api/2.0/mcp/genie/12345",
+			expectError: false,
+		},
+		{
+			name:     "single variable",
+			template: "https://${API_HOST}/v1/endpoint",
+			envVars: map[string]string{
+				"API_HOST": "api.example.com",
+			},
+			expected:    "https://api.example.com/v1/endpoint",
+			expectError: false,
+		},
+		{
+			name:        "no variables",
+			template:    "https://example.com/api",
+			envVars:     map[string]string{},
+			expected:    "https://example.com/api",
+			expectError: false,
+		},
+		{
+			name:        "empty template",
+			template:    "",
+			envVars:     map[string]string{},
+			expected:    "",
+			expectError: false,
+		},
+		{
+			name:     "variable with special characters",
+			template: "https://${API_HOST}/path/${USER_ID}/data",
+			envVars: map[string]string{
+				"API_HOST": "api.example.com",
+				"USER_ID":  "user-123_456",
+			},
+			expected:    "https://api.example.com/path/user-123_456/data",
+			expectError: false,
+		},
+		{
+			name:     "multiple same variable",
+			template: "https://${API_HOST}/api/${API_HOST}/status",
+			envVars: map[string]string{
+				"API_HOST": "api.example.com",
+			},
+			expected:    "https://api.example.com/api/api.example.com/status",
+			expectError: false,
+		},
+		{
+			name:     "variable in query string",
+			template: "https://${API_HOST}/api?token=${API_TOKEN}&user=${USER_ID}",
+			envVars: map[string]string{
+				"API_HOST":  "api.example.com",
+				"API_TOKEN": "abc123",
+				"USER_ID":   "user456",
+			},
+			expected:    "https://api.example.com/api?token=abc123&user=user456",
+			expectError: false,
+		},
+		{
+			name:     "variable with empty value",
+			template: "https://${API_HOST}/api/${EMPTY_VAR}/data",
+			envVars: map[string]string{
+				"API_HOST":  "api.example.com",
+				"EMPTY_VAR": "",
+			},
+			expected:    "https://api.example.com/api//data",
+			expectError: false,
+		},
+		{
+			name:     "variable with spaces",
+			template: "https://${API_HOST}/api/${USER_NAME}/profile",
+			envVars: map[string]string{
+				"API_HOST":  "api.example.com",
+				"USER_NAME": "John Doe",
+			},
+			expected:    "https://api.example.com/api/John Doe/profile",
+			expectError: false,
+		},
+		{
+			name:     "complex path with variables",
+			template: "https://${REGION}.${SERVICE}.${PROVIDER}.com/${VERSION}/${RESOURCE}/${ID}",
+			envVars: map[string]string{
+				"REGION":   "us-west-2",
+				"SERVICE":  "compute",
+				"PROVIDER": "aws",
+				"VERSION":  "v1",
+				"RESOURCE": "instances",
+				"ID":       "i-1234567890abcdef0",
+			},
+			expected:    "https://us-west-2.compute.aws.com/v1/instances/i-1234567890abcdef0",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := applyURLTemplate(tt.template, tt.envVars)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestApplyURLTemplateEdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		template    string
+		envVars     map[string]string
+		description string
+		expected    string
+	}{
+		{
+			name:        "unmatched variable remains",
+			template:    "https://${API_HOST}/api/${MISSING_VAR}/data",
+			envVars:     map[string]string{"API_HOST": "api.example.com"},
+			description: "Variables not in envVars should remain unchanged in the result",
+			expected:    "https://api.example.com/api/${MISSING_VAR}/data",
+		},
+		{
+			name:        "case sensitive variables",
+			template:    "https://${API_HOST}/api/${api_host}/data",
+			envVars:     map[string]string{"API_HOST": "api.example.com", "api_host": "different.example.com"},
+			description: "Variable names are case sensitive",
+			expected:    "https://api.example.com/api/different.example.com/data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := applyURLTemplate(tt.template, tt.envVars)
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestApplyURLTemplatePerformance(t *testing.T) {
+	// Test with a large number of variables
+	largeEnvVars := make(map[string]string, 1000)
+	for i := 0; i < 1000; i++ {
+		key := fmt.Sprintf("VAR_%d", i)
+		value := fmt.Sprintf("value_%d", i)
+		largeEnvVars[key] = value
+	}
+
+	template := "https://example.com/api"
+	for i := 0; i < 100; i++ {
+		template += fmt.Sprintf("/${VAR_%d}", i)
+	}
+
+	start := time.Now()
+	result, err := applyURLTemplate(template, largeEnvVars)
+	duration := time.Since(start)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+
+	if result == "" {
+		t.Errorf("expected non-empty result")
+		return
+	}
+
+	// Performance should be reasonable (less than 100ms for 100 variables)
+	if duration > 100*time.Millisecond {
+		t.Errorf("performance test took too long: %v", duration)
+	}
+
+	t.Logf("Processed template with 100 variables in %v", duration)
+}
+
+func TestApplyURLTemplateRealWorldExamples(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		envVars  map[string]string
+		expected string
+	}{
+		{
+			name:     "Databricks example",
+			template: "https://${DATABRICKS_WORKSPACE_URL}/api/2.0/mcp/genie/${DATABRICKS_GENIE_SPACE_ID}",
+			envVars: map[string]string{
+				"DATABRICKS_WORKSPACE_URL":  "workspace.cloud.databricks.com",
+				"DATABRICKS_GENIE_SPACE_ID": "12345",
+			},
+			expected: "https://workspace.cloud.databricks.com/api/2.0/mcp/genie/12345",
+		},
+		{
+			name:     "AWS API Gateway",
+			template: "https://${API_ID}.execute-api.${REGION}.amazonaws.com/${STAGE}/${RESOURCE}",
+			envVars: map[string]string{
+				"API_ID":   "abc123def4",
+				"REGION":   "us-east-1",
+				"STAGE":    "prod",
+				"RESOURCE": "users",
+			},
+			expected: "https://abc123def4.execute-api.us-east-1.amazonaws.com/prod/users",
+		},
+		{
+			name:     "Google Cloud",
+			template: "https://${PROJECT_ID}.${REGION}.run.app/${SERVICE_NAME}",
+			envVars: map[string]string{
+				"PROJECT_ID":   "my-project-123",
+				"REGION":       "us-central1",
+				"SERVICE_NAME": "api-service",
+			},
+			expected: "https://my-project-123.us-central1.run.app/api-service",
+		},
+		{
+			name:     "Azure Functions",
+			template: "https://${FUNCTION_APP}.azurewebsites.net/api/${FUNCTION_NAME}?code=${FUNCTION_KEY}",
+			envVars: map[string]string{
+				"FUNCTION_APP":  "my-function-app",
+				"FUNCTION_NAME": "process-data",
+				"FUNCTION_KEY":  "abc123def456",
+			},
+			expected: "https://my-function-app.azurewebsites.net/api/process-data?code=abc123def456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := applyURLTemplate(tt.template, tt.envVars)
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -6757,9 +6757,16 @@ func schema_obot_platform_obot_apiclient_types_RemoteCatalogConfig(ref common.Re
 							Format: "",
 						},
 					},
-					"hostname": {
+					"urlTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Fixed URL for all instances",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"hostname": {
+						SchemaProps: spec.SchemaProps{
+							Description: "URL template for user URLs",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6814,8 +6821,16 @@ func schema_obot_platform_obot_apiclient_types_RemoteRuntimeConfig(ref common.Re
 							},
 						},
 					},
+					"isTemplate": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"url"},
+				Required: []string{"url", "isTemplate"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
Add URL template substitution. For now, it just does simpler substitution with ${ENV_NAME} where env_name is the env variable you defined when supplying to the mcp server. 

The catalog entry will have to define urlTemplate field instead of fixedUrl, as we introduced separate logic for validating url Template. 

The final connection url will be updated to mcp server once user configures the env variables that are defined in catalog.

Disclosure: Tests file are added by AI.

https://github.com/obot-platform/obot/issues/4016

