### PR TITLE
enhance: include enterprise info in version API

### DIFF
--- a/pkg/api/handlers/version.go
+++ b/pkg/api/handlers/version.go
@@ -30,6 +30,7 @@ type VersionHandler struct {
 	supportDocker    bool
 	authEnabled      bool
 	sessionStore     SessionStore
+	enterprise       bool
 }
 
 func NewVersionHandler(emailDomain, postgresDSN string, supportDocker, authEnabled bool) *VersionHandler {
@@ -39,6 +40,7 @@ func NewVersionHandler(emailDomain, postgresDSN string, supportDocker, authEnabl
 		supportDocker:    supportDocker,
 		authEnabled:      authEnabled,
 		sessionStore:     sessionStoreFromPostgresDSN(postgresDSN),
+		enterprise:       os.Getenv("OBOT_ENTERPRISE") == "true",
 	}
 }
 
@@ -50,8 +52,7 @@ func (v *VersionHandler) getVersionResponse() map[string]any {
 	values := make(map[string]any)
 	versions := os.Getenv("OBOT_SERVER_VERSIONS")
 	if versions != "" {
-		pairs := strings.Split(versions, ",")
-		for _, pair := range pairs {
+		for pair := range strings.SplitSeq(versions, ",") {
 			if pair == "" {
 				continue
 			}
@@ -70,6 +71,8 @@ func (v *VersionHandler) getVersionResponse() map[string]any {
 	values["dockerSupported"] = v.supportDocker
 	values["authEnabled"] = v.authEnabled
 	values["sessionStore"] = v.sessionStore
+	values["enterprise"] = v.enterprise
+
 	return values
 }
 

--- a/tools/combine-envrc.sh
+++ b/tools/combine-envrc.sh
@@ -30,12 +30,20 @@ GPTSCRIPT_TOOL_REMAP="${remap_entries%,}"
 OBOT_SERVER_VERSIONS="${server_versions%,}"
 OBOT_SERVER_TOOL_REGISTRIES="${tool_registries%,}"
 
+# Check if enterprise tools are enabled
+if [[ "$OBOT_SERVER_TOOL_REGISTRIES" == *"github.com/obot-platform/enterprise-tools"* ]]; then
+  OBOT_ENTERPRISE=true
+else
+  OBOT_ENTERPRISE=false
+fi
+
 cat <<EOF >/obot-tools/.envrc.tools
 export GPTSCRIPT_SYSTEM_TOOLS_DIR=/obot-tools/
 export TOOLS_VENV_BIN=/obot-tools/venv/bin
 export GPTSCRIPT_TOOL_REMAP="${GPTSCRIPT_TOOL_REMAP}"
 export OBOT_SERVER_TOOL_REGISTRIES="${OBOT_SERVER_TOOL_REGISTRIES}"
 export OBOT_SERVER_VERSIONS="${OBOT_SERVER_VERSIONS}"
+export OBOT_ENTERPRISE="${OBOT_ENTERPRISE}"
 EOF
 
 rm -f /obot-tools/.envrc.tools.*


### PR DESCRIPTION
Whether the container is running the enterprise version is controlled via an environment variable that can only be set when building the image.

Issue: https://github.com/obot-platform/obot/issues/4090