### PR TITLE
fix: use standard OIDC claims for MCP JWT tokens

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -199,12 +199,14 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 
 	now := time.Now()
 	tknCtx := persistent.TokenContext{
+		Audience:              oauthAuthRequest.Spec.Resource,
 		IssuedAt:              now,
 		NotBefore:             now,
 		ExpiresAt:             now.Add(tokenExpiration),
 		UserID:                userID,
 		UserName:              user.Username,
 		UserEmail:             user.Email,
+		Picture:               user.IconURL,
 		UserGroups:            groups,
 		AuthProviderName:      oauthAuthRequest.Spec.AuthProviderName,
 		AuthProviderNamespace: oauthAuthRequest.Spec.AuthProviderNamespace,
@@ -224,6 +226,7 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 		},
 		Spec: v1.OAuthTokenSpec{
 			ClientID:              oauthClient.Name,
+			Resource:              oauthAuthRequest.Spec.Resource,
 			UserID:                oauthAuthRequest.Spec.UserID,
 			HashedSessionID:       oauthAuthRequest.Spec.HashedSessionID,
 			AuthProviderNamespace: oauthAuthRequest.Spec.AuthProviderNamespace,
@@ -294,12 +297,14 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 
 	now := time.Now()
 	tknCtx := persistent.TokenContext{
+		Audience:              oauthToken.Spec.Resource,
 		IssuedAt:              now,
 		NotBefore:             now,
 		ExpiresAt:             now.Add(tokenExpiration),
 		UserID:                userID,
 		UserName:              user.Username,
 		UserEmail:             user.Email,
+		Picture:               user.IconURL,
 		UserGroups:            groups,
 		AuthProviderName:      oauthToken.Spec.AuthProviderName,
 		AuthProviderNamespace: oauthToken.Spec.AuthProviderNamespace,
@@ -318,6 +323,7 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 			Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken))),
 		},
 		Spec: v1.OAuthTokenSpec{
+			Resource:              oauthToken.Spec.Resource,
 			ClientID:              oauthClient.Name,
 			UserID:                oauthToken.Spec.UserID,
 			HashedSessionID:       oauthToken.Spec.HashedSessionID,

--- a/pkg/storage/apis/obot.obot.ai/v1/oauthauthrequest.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/oauthauthrequest.go
@@ -51,6 +51,7 @@ type OAuthAuthRequestSpec struct {
 	CodeChallenge         string `json:"codeChallenge"`
 	CodeChallengeMethod   string `json:"codeChallengeMethod"`
 	GrantType             string `json:"grantType"`
+	Resource              string `json:"resource"`
 	HashedAuthCode        string `json:"hashedAuthCode"`
 	HashedSessionID       string `json:"hashedSessionID"`
 	UserID                uint   `json:"userID"`

--- a/pkg/storage/apis/obot.obot.ai/v1/oauthtoken.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/oauthtoken.go
@@ -20,6 +20,7 @@ func (in *OAuthToken) DeleteRefs() []Ref {
 }
 
 type OAuthTokenSpec struct {
+	Resource              string `json:"resource"`
 	ClientID              string `json:"clientID"`
 	UserID                uint   `json:"userID"`
 	HashedSessionID       string `json:"hashedSessionID"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -12857,6 +12857,13 @@ func schema_storage_apis_obotobotai_v1_OAuthAuthRequestSpec(ref common.Reference
 							Format:  "",
 						},
 					},
+					"resource": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"hashedAuthCode": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -12893,7 +12900,7 @@ func schema_storage_apis_obotobotai_v1_OAuthAuthRequestSpec(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"redirectURI", "state", "clientID", "codeChallenge", "codeChallengeMethod", "grantType", "hashedAuthCode", "hashedSessionID", "userID", "authProviderNamespace", "authProviderName"},
+				Required: []string{"redirectURI", "state", "clientID", "codeChallenge", "codeChallengeMethod", "grantType", "resource", "hashedAuthCode", "hashedSessionID", "userID", "authProviderNamespace", "authProviderName"},
 			},
 		},
 	}
@@ -13199,6 +13206,13 @@ func schema_storage_apis_obotobotai_v1_OAuthTokenSpec(ref common.ReferenceCallba
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"resource": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"clientID": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -13235,7 +13249,7 @@ func schema_storage_apis_obotobotai_v1_OAuthTokenSpec(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"clientID", "userID", "hashedSessionID", "authProviderName", "authProviderNamespace"},
+				Required: []string{"resource", "clientID", "userID", "hashedSessionID", "authProviderName", "authProviderNamespace"},
 			},
 		},
 	}


### PR DESCRIPTION
This change also uses the resource in the OAuth request as the audience.

Lastly, if the client doesn't follow the OAuth metadata, but includes a resource, then we will pull the mcp ID from the resource so the second-level OAuth can still happen.