### PR TITLE
fix: add entra to verified auth providers

### DIFF
--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -20,6 +20,7 @@ var (
 	verifiedAuthProviders = []string{
 		"default/google-auth-provider",
 		"default/github-auth-provider",
+		"default/entra-auth-provider",
 	}
 
 	identityGroupResource = schema.GroupResource{


### PR DESCRIPTION
Add `entra-auth-provider` to the set of verified providers.
This fixes MCP token auth when Entra is enabled.

Addresses https://github.com/obot-platform/obot/issues/4173
