### PR TITLE
fix: pass obot user id from mcp token auth in user info extra

### DIFF
--- a/pkg/gateway/client/auth.go
+++ b/pkg/gateway/client/auth.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strconv"
 
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api/authz"
@@ -39,6 +40,21 @@ func (u UserDecorator) AuthenticateRequest(req *http.Request) (*authenticator.Re
 		ProviderUsername:      resp.User.GetName(),
 		ProviderUserID:        resp.User.GetUID(),
 	}
+
+	// Attempt to extract the Obot user ID from the extra claims.
+	// If present, this indicates MCP token authentication is being used.
+	// It's important to set the user ID value before calling EnsureIdentity so that the token's
+	// identity can be matched to an existing user. Not setting this value will cause authentication
+	// to fail.
+	if userID := firstValue(resp.User.GetExtra(), "obot:userID"); userID != "" {
+		id, err := strconv.ParseUint(userID, 10, 64)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to parse user id: %w", err)
+		}
+
+		identity.UserID = uint(id)
+	}
+
 	gatewayUser, err := u.client.EnsureIdentity(req.Context(), identity, req.Header.Get("X-Obot-User-Timezone"))
 	if err != nil {
 		return nil, false, err

--- a/pkg/gateway/server/tokenreview.go
+++ b/pkg/gateway/server/tokenreview.go
@@ -58,6 +58,7 @@ func (g *gatewayTokenReview) AuthenticateRequest(req *http.Request) (*authentica
 				"auth_provider_namespace": {namespace},
 				"auth_provider_name":      {name},
 				"auth_provider_groups":    groupIDs,
+				"obot:userID":             {strconv.FormatUint(uint64(u.ID), 10)},
 			},
 		},
 	}, true, nil

--- a/pkg/jwt/persistent/persistent.go
+++ b/pkg/jwt/persistent/persistent.go
@@ -119,6 +119,7 @@ func (t *TokenService) AuthenticateRequest(req *http.Request) (*authenticator.Re
 				"email":                   {tokenContext.UserEmail},
 				"auth_provider_name":      {tokenContext.AuthProviderName},
 				"auth_provider_namespace": {tokenContext.AuthProviderNamespace},
+				"obot:userID":             {tokenContext.UserID},
 			},
 		},
 	}, true, nil


### PR DESCRIPTION
The `Identity` produced by MCP token auth has a `ProviderUserID` field that is set to the actual Obot user ID [at this point](https://github.com/obot-platform/obot/blob/82488e2aca7c1f700184db91b04de604afc920bd/pkg/gateway/client/identity.go#L115). This means it doesn't match the existing `Identity` in the database (since that has the real ID from the provider) on the first use and creates a new one for the token. The catch is that this doesn't have a `UserID` field set yet, which causes the user creation [logic here](https://github.com/obot-platform/obot/blob/82488e2aca7c1f700184db91b04de604afc920bd/pkg/gateway/client/identity.go#L258) to trigger and fail with `"ERROR: duplicate key value violates unique constraint \"uni_users_hashed_username\"` because a user already exists with the same hashed username.

To fix this, pass the Obot user ID from the mcp token authenticators to the user decorator authenticator in the user info's extra map. This makes the user ID available when ensuring the initial token identity.

Addresses https://github.com/obot-platform/obot/issues/4173

Note: I'm still not sure this is the _correct_ solution, but at first glance it does appear to fix the problem.
