### PR TITLE
fix: use real provider id when ensuring identity for mcp client tokens

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -282,6 +282,7 @@ func (h *handler) callback(req api.Context) error {
 	code := strings.ToLower(rand.Text() + rand.Text())
 	oauthAppAuthRequest.Spec.HashedAuthCode = fmt.Sprintf("%x", sha256.Sum256([]byte(code)))
 	oauthAppAuthRequest.Spec.UserID = req.UserID()
+	oauthAppAuthRequest.Spec.AuthProviderUserID = auth.FirstExtraValue(req.User.GetExtra(), "auth_provider_user_id")
 	oauthAppAuthRequest.Spec.AuthProviderNamespace = authProviderNamespace
 	oauthAppAuthRequest.Spec.AuthProviderName = authProviderName
 	oauthAppAuthRequest.Spec.HashedSessionID = hashedSessionID

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -210,6 +210,7 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 		UserGroups:            groups,
 		AuthProviderName:      oauthAuthRequest.Spec.AuthProviderName,
 		AuthProviderNamespace: oauthAuthRequest.Spec.AuthProviderNamespace,
+		AuthProviderUserID:    oauthAuthRequest.Spec.AuthProviderUserID,
 		HashedSessionID:       oauthAuthRequest.Spec.HashedSessionID,
 	}
 	tkn, err := h.tokenService.NewToken(tknCtx)
@@ -231,6 +232,7 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 			HashedSessionID:       oauthAuthRequest.Spec.HashedSessionID,
 			AuthProviderNamespace: oauthAuthRequest.Spec.AuthProviderNamespace,
 			AuthProviderName:      oauthAuthRequest.Spec.AuthProviderName,
+			AuthProviderUserID:    oauthAuthRequest.Spec.AuthProviderUserID,
 		},
 	}
 
@@ -308,6 +310,7 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 		UserGroups:            groups,
 		AuthProviderName:      oauthToken.Spec.AuthProviderName,
 		AuthProviderNamespace: oauthToken.Spec.AuthProviderNamespace,
+		AuthProviderUserID:    oauthToken.Spec.AuthProviderUserID,
 		HashedSessionID:       oauthToken.Spec.HashedSessionID,
 	}
 	tkn, err := h.tokenService.NewToken(tknCtx)
@@ -329,6 +332,7 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 			HashedSessionID:       oauthToken.Spec.HashedSessionID,
 			AuthProviderNamespace: oauthToken.Spec.AuthProviderNamespace,
 			AuthProviderName:      oauthToken.Spec.AuthProviderName,
+			AuthProviderUserID:    oauthToken.Spec.AuthProviderUserID,
 		},
 	}
 

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/obot-platform/obot/pkg/auth"
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/storage"
 	"github.com/obot-platform/obot/pkg/system"
@@ -283,19 +284,13 @@ func (r *Context) UserID() uint {
 	return uint(userID)
 }
 
+func (r *Context) AuthProviderUserID() string {
+	return auth.FirstExtraValue(r.User.GetExtra(), "auth_provider_user_id")
+}
+
 func (r *Context) AuthProviderNameAndNamespace() (string, string) {
-	extraName := r.User.GetExtra()["auth_provider_name"]
-	extraNamespace := r.User.GetExtra()["auth_provider_namespace"]
-
-	var name, namespace string
-	if len(extraName) > 0 {
-		name = extraName[0]
-	}
-	if len(extraNamespace) > 0 {
-		namespace = extraNamespace[0]
-	}
-
-	return name, namespace
+	return auth.FirstExtraValue(r.User.GetExtra(), "auth_provider_name"),
+		auth.FirstExtraValue(r.User.GetExtra(), "auth_provider_namespace")
 }
 
 func (r *Context) UserTimezone() string {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -112,3 +112,12 @@ func GetSessionInfoFromRequest(req *http.Request) (sessionID, sessionCookie stri
 	sessionCookie = cookie.Value
 	return
 }
+
+// FirstExtraValue returns the first value for the given key in the extra map.
+func FirstExtraValue(extra map[string][]string, key string) string {
+	values := extra[key]
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}

--- a/pkg/gateway/client/auth.go
+++ b/pkg/gateway/client/auth.go
@@ -7,6 +7,7 @@ import (
 
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/obot-platform/obot/pkg/auth"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -33,9 +34,9 @@ func (u UserDecorator) AuthenticateRequest(req *http.Request) (*authenticator.Re
 	}
 
 	identity := &types.Identity{
-		Email:                 firstValue(resp.User.GetExtra(), "email"),
-		AuthProviderName:      firstValue(resp.User.GetExtra(), "auth_provider_name"),
-		AuthProviderNamespace: firstValue(resp.User.GetExtra(), "auth_provider_namespace"),
+		Email:                 auth.FirstExtraValue(resp.User.GetExtra(), "email"),
+		AuthProviderName:      auth.FirstExtraValue(resp.User.GetExtra(), "auth_provider_name"),
+		AuthProviderNamespace: auth.FirstExtraValue(resp.User.GetExtra(), "auth_provider_namespace"),
 		ProviderUsername:      resp.User.GetName(),
 		ProviderUserID:        resp.User.GetUID(),
 	}

--- a/pkg/gateway/client/authtoken.go
+++ b/pkg/gateway/client/authtoken.go
@@ -17,7 +17,14 @@ const (
 	expirationDur     = 7 * 24 * time.Hour
 )
 
-func (c *Client) NewAuthToken(ctx context.Context, authProviderNamespace, authProviderName string, userID uint, tr *types.TokenRequest) (*types.AuthToken, error) {
+func (c *Client) NewAuthToken(
+	ctx context.Context,
+	authProviderNamespace,
+	authProviderName string,
+	authProviderUserID string,
+	userID uint,
+	tr *types.TokenRequest,
+) (*types.AuthToken, error) {
 	randBytes := make([]byte, tokenIDLength+randomTokenLength)
 	if _, err := rand.Read(randBytes); err != nil {
 		return nil, fmt.Errorf("could not generate token id: %w", err)
@@ -33,6 +40,7 @@ func (c *Client) NewAuthToken(ctx context.Context, authProviderNamespace, authPr
 		ExpiresAt:             time.Now().Add(expirationDur),
 		AuthProviderNamespace: authProviderNamespace,
 		AuthProviderName:      authProviderName,
+		AuthProviderUserID:    authProviderUserID,
 	}
 
 	return tkn, c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -54,11 +54,3 @@ func (c *Client) IsExplicitAdmin(email string) bool {
 	_, ok := c.adminEmails[email]
 	return ok
 }
-
-func firstValue(m map[string][]string, key string) string {
-	values := m[key]
-	if len(values) == 0 {
-		return ""
-	}
-	return values[0]
-}

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -26,14 +26,14 @@ var (
 	}
 )
 
-func (c *Client) UserFromToken(ctx context.Context, token string) (*types.User, string, string, string, []string, error) {
+func (c *Client) UserFromToken(ctx context.Context, token string) (*types.User, string, string, string, string, []string, error) {
 	// Extract the id and hashed token value from the bearer token.
 	id, token, _ := strings.Cut(token, ":")
 
 	var (
-		u                                = new(types.User)
-		namespace, name, hashedSessionID string
-		groupIDs                         []string
+		u                                                = new(types.User)
+		namespace, name, providerUserID, hashedSessionID string
+		groupIDs                                         []string
 	)
 	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		tkn := new(types.AuthToken)
@@ -43,6 +43,7 @@ func (c *Client) UserFromToken(ctx context.Context, token string) (*types.User, 
 
 		namespace = tkn.AuthProviderNamespace
 		name = tkn.AuthProviderName
+		providerUserID = tkn.AuthProviderUserID
 		hashedSessionID = tkn.HashedSessionID
 
 		// Get the user
@@ -63,10 +64,10 @@ func (c *Client) UserFromToken(ctx context.Context, token string) (*types.User, 
 
 		return nil
 	}); err != nil {
-		return nil, "", "", "", nil, err
+		return nil, "", "", "", "", nil, err
 	}
 
-	return u, namespace, name, hashedSessionID, groupIDs, c.decryptUser(ctx, u)
+	return u, namespace, name, providerUserID, hashedSessionID, groupIDs, c.decryptUser(ctx, u)
 }
 
 func (c *Client) Users(ctx context.Context, query types.UserQuery) ([]types.User, error) {

--- a/pkg/gateway/server/oauth.go
+++ b/pkg/gateway/server/oauth.go
@@ -75,7 +75,14 @@ func (s *Server) redirect(apiContext api.Context) error {
 		return types2.NewErrHTTP(http.StatusBadRequest, fmt.Sprintf("invalid state: %v", err))
 	}
 
-	if _, err = apiContext.GatewayClient.NewAuthToken(apiContext.Context(), namespace, name, apiContext.UserID(), tr); err != nil {
+	if _, err = apiContext.GatewayClient.NewAuthToken(
+		apiContext.Context(),
+		namespace,
+		name,
+		apiContext.AuthProviderUserID(),
+		apiContext.UserID(),
+		tr,
+	); err != nil {
 		return s.errorToken(apiContext.Context(), tr, http.StatusInternalServerError, err)
 	}
 

--- a/pkg/gateway/server/tokenreview.go
+++ b/pkg/gateway/server/tokenreview.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/nanobot-ai/nanobot/pkg/log"
@@ -37,7 +36,7 @@ func (g *gatewayTokenReview) AuthenticateRequest(req *http.Request) (*authentica
 		return nil, false, nil
 	}
 
-	u, namespace, name, hashedSessionID, groupIDs, err := g.gatewayClient.UserFromToken(req.Context(), bearer)
+	u, namespace, name, providerUserID, hashedSessionID, groupIDs, err := g.gatewayClient.UserFromToken(req.Context(), bearer)
 	if err != nil {
 		return nil, false, err
 	}
@@ -52,7 +51,7 @@ func (g *gatewayTokenReview) AuthenticateRequest(req *http.Request) (*authentica
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name: u.Username,
-			UID:  strconv.FormatUint(uint64(u.ID), 10),
+			UID:  providerUserID,
 			Extra: map[string][]string{
 				"email":                   {u.Email},
 				"auth_provider_namespace": {namespace},

--- a/pkg/gateway/types/tokens.go
+++ b/pkg/gateway/types/tokens.go
@@ -12,6 +12,7 @@ type AuthToken struct {
 	UserID                uint      `json:"-" gorm:"index"`
 	AuthProviderNamespace string    `json:"-" gorm:"index"`
 	AuthProviderName      string    `json:"-" gorm:"index"`
+	AuthProviderUserID    string    `json:"-"`
 	HashedToken           string    `json:"-" gorm:"index:idx_id_hashed_token"`
 	HashedSessionID       string    `json:"-" gorm:"index"`
 	CreatedAt             time.Time `json:"createdAt"`

--- a/pkg/jwt/persistent/persistent.go
+++ b/pkg/jwt/persistent/persistent.go
@@ -91,6 +91,7 @@ type TokenContext struct {
 	Picture               string
 	AuthProviderName      string
 	AuthProviderNamespace string
+	AuthProviderUserID    string
 	HashedSessionID       string
 }
 
@@ -114,7 +115,7 @@ func (t *TokenService) AuthenticateRequest(req *http.Request) (*authenticator.Re
 	groups := append([]string{authz.AuthenticatedGroup}, tokenContext.UserGroups...)
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
-			UID:    tokenContext.UserID,
+			UID:    tokenContext.AuthProviderUserID,
 			Name:   tokenContext.UserName,
 			Groups: groups,
 			Extra: map[string][]string{
@@ -176,6 +177,7 @@ func (t *TokenService) decodeToken(token string) (*TokenContext, error) {
 		Picture:               getStringClaim("picture"),
 		AuthProviderName:      getStringClaim("AuthProviderName"),
 		AuthProviderNamespace: getStringClaim("AuthProviderNamespace"),
+		AuthProviderUserID:    getStringClaim("AuthProviderUserID"),
 		HashedSessionID:       getStringClaim("HashedSessionID"),
 		// These two fields were the latter names and changed the former.
 		// This makes this backwards compatible with older tokens.
@@ -198,6 +200,7 @@ func (t *TokenService) NewToken(context TokenContext) (string, error) {
 		"UserGroups":            strings.Join(context.UserGroups, ","),
 		"AuthProviderName":      context.AuthProviderName,
 		"AuthProviderNamespace": context.AuthProviderNamespace,
+		"AuthProviderUserID":    context.AuthProviderUserID,
 		"HashedSessionID":       context.HashedSessionID,
 	}
 	if claims["aud"] == "" {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -353,6 +353,7 @@ func (p *Proxy) authenticateRequest(req *http.Request) (*authenticator.Response,
 			"email":                   {ss.Email},
 			"auth_provider_name":      {p.name},
 			"auth_provider_namespace": {p.namespace},
+			"auth_provider_user_id":   {ss.User},
 		},
 	}
 

--- a/pkg/storage/apis/obot.obot.ai/v1/oauthauthrequest.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/oauthauthrequest.go
@@ -55,6 +55,7 @@ type OAuthAuthRequestSpec struct {
 	HashedAuthCode        string `json:"hashedAuthCode"`
 	HashedSessionID       string `json:"hashedSessionID"`
 	UserID                uint   `json:"userID"`
+	AuthProviderUserID    string `json:"authProviderUserID"`
 	AuthProviderNamespace string `json:"authProviderNamespace"`
 	AuthProviderName      string `json:"authProviderName"`
 }

--- a/pkg/storage/apis/obot.obot.ai/v1/oauthtoken.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/oauthtoken.go
@@ -24,6 +24,7 @@ type OAuthTokenSpec struct {
 	ClientID              string `json:"clientID"`
 	UserID                uint   `json:"userID"`
 	HashedSessionID       string `json:"hashedSessionID"`
+	AuthProviderUserID    string `json:"authProviderUserID"`
 	AuthProviderName      string `json:"authProviderName"`
 	AuthProviderNamespace string `json:"authProviderNamespace"`
 }

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -13023,6 +13023,13 @@ func schema_storage_apis_obotobotai_v1_OAuthAuthRequestSpec(ref common.Reference
 							Format:  "int32",
 						},
 					},
+					"authProviderUserID": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"authProviderNamespace": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -13038,7 +13045,7 @@ func schema_storage_apis_obotobotai_v1_OAuthAuthRequestSpec(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"redirectURI", "state", "clientID", "codeChallenge", "codeChallengeMethod", "grantType", "resource", "hashedAuthCode", "hashedSessionID", "userID", "authProviderNamespace", "authProviderName"},
+				Required: []string{"redirectURI", "state", "clientID", "codeChallenge", "codeChallengeMethod", "grantType", "resource", "hashedAuthCode", "hashedSessionID", "userID", "authProviderUserID", "authProviderNamespace", "authProviderName"},
 			},
 		},
 	}
@@ -13372,6 +13379,13 @@ func schema_storage_apis_obotobotai_v1_OAuthTokenSpec(ref common.ReferenceCallba
 							Format:  "",
 						},
 					},
+					"authProviderUserID": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"authProviderName": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -13387,7 +13401,7 @@ func schema_storage_apis_obotobotai_v1_OAuthTokenSpec(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"resource", "clientID", "userID", "hashedSessionID", "authProviderName", "authProviderNamespace"},
+				Required: []string{"resource", "clientID", "userID", "hashedSessionID", "authProviderUserID", "authProviderName", "authProviderNamespace"},
 			},
 		},
 	}


### PR DESCRIPTION
The `Identity` produced by MCP token auth has a `ProviderUserID` field that is set to the actual Obot user ID [at this point](https://github.com/obot-platform/obot/blob/82488e2aca7c1f700184db91b04de604afc920bd/pkg/gateway/client/identity.go#L115). This means it doesn't match the existing `Identity` in the database (since that has the real ID from the provider) on the first use and creates a new one for the token. The catch is that this doesn't have a `UserID` field set yet, which causes the user creation [logic here](https://github.com/obot-platform/obot/blob/82488e2aca7c1f700184db91b04de604afc920bd/pkg/gateway/client/identity.go#L258) to trigger and fail with `"ERROR: duplicate key value violates unique constraint \"uni_users_hashed_username\"` because a user already exists with the same hashed username.

MCP client auth tokens for `GitHub` and `Google` currently don't encounter this issue because they are marked as "verified" providers, which allow the user to be looked up by email address. `Entra` and `Okta` are not verified providers, so they run into this issue.

To fix this, ensure the `Identity` produced by MCP token auth has a `ProviderUserID` set to the real user ID returned from provider. This will mean that the `ensureIdentity` call will find the existing `Identity` and `User` in the database, and avoid making the problematic create operation.

Addresses https://github.com/obot-platform/obot/issues/4173

