### PR TITLE
Fix: Clarify text for explaining MCP server config

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -721,17 +721,24 @@
 
 						<p class="text-xs font-light text-gray-400 dark:text-gray-600">
 							{#if formData.env[i].file}
-								The {type === 'single' ? 'user supplied' : 'specified'} value will be written to a file.
-								Its contents will be available as an environment variable that will be set to the specified
-								$KEY_NAME.
+								The value {type === 'single' ? 'the user supplies' : 'you provide'} will be written to
+								a file. An environment variable will be created using the name you specify in the Key
+								field and its value will be the path to that file. This environment variable will be
+								set inside your MCP server and you can reference it in the arguments section above using
+								the syntax ${'{KEY_NAME}'}.
 							{:else}
-								{type === 'single' ? 'User supplied config' : 'Config'} values will be available as environment
-								variables in the MCP server and can be referenced in the runtime configuration using
-								the syntax $KEY_NAME.
+								{type === 'single' ? 'The value the user supplies' : 'The value you provide'} will be
+								set as an environment variable using the name you specify in the Key field. This environment
+								variable will be set inside your MCP server and you can reference it in the arguments
+								section above using the syntax ${'{KEY_NAME}'}.
 							{/if}
 						</p>
 
 						{#if type === 'single'}
+							<p class="text-xs font-light text-gray-400 dark:text-gray-600">
+								The Name and Description fields will be displayed to the user when configuring this
+								server. The Key field will not.
+							</p>
 							<div class="flex w-full flex-col gap-1">
 								<label for={`env-name-${i}`} class="text-sm font-light">Name</label>
 								<input


### PR DESCRIPTION
Just updated the explanatory text for environment variable and file
based config options for MCP servers.


## Single user
<img width="1334" height="624" alt="Screenshot 2025-09-10 at 7 01 29 PM" src="https://github.com/user-attachments/assets/ebcc50e5-c8de-48e2-be55-077a1586b7e2" />
<img width="1332" height="625" alt="Screenshot 2025-09-10 at 7 01 34 PM" src="https://github.com/user-attachments/assets/4e245e2e-fb65-4b3b-acac-86f5877c6426" />

## Multi user

<img width="1333" height="513" alt="Screenshot 2025-09-10 at 7 01 46 PM" src="https://github.com/user-attachments/assets/c3fbb530-7d96-43bb-b052-888e7e27cf04" />

<img width="1324" height="519" alt="Screenshot 2025-09-10 at 7 01 53 PM" src="https://github.com/user-attachments/assets/a03d32f5-c0ed-46a6-924d-7a409b7dd182" />
