### PR TITLE
Fix: fix permission related issue for power users

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -104,40 +104,8 @@ var staticRules = map[string][]string{
 		"GET /api/all-mcps/servers",
 		"GET /api/all-mcps/servers/{mcp_server_id}",
 	},
-	PowerUserGroup: {
-		// Workspace-scoped MCP Server Catalog Entries
-		"GET /api/workspaces/{workspace_id}/entries",
-		"GET /api/workspaces/{workspace_id}/entries/{entry_id}",
-		"POST /api/workspaces/{workspace_id}/entries",
-		"PUT /api/workspaces/{workspace_id}/entries/{entry_id}",
-		"DELETE /api/workspaces/{workspace_id}/entries/{entry_id}",
-		"POST /api/workspaces/{workspace_id}/entries/{entry_id}/generate-tool-previews",
-		"POST /api/workspaces/{workspace_id}/entries/{entry_id}/generate-tool-previews/oauth-url",
-
-		// Workspace-scoped MCP Servers
-		"GET /api/workspaces/{workspace_id}/servers",
-		"GET /api/workspaces/{workspace_id}/servers/{mcp_server_id}",
-		"POST /api/workspaces/{workspace_id}/servers",
-		"PUT /api/workspaces/{workspace_id}/servers/{mcp_server_id}",
-		"DELETE /api/workspaces/{workspace_id}/servers/{mcp_server_id}",
-		"POST /api/workspaces/{workspace_id}/servers/{mcp_server_id}/launch",
-		"POST /api/workspaces/{workspace_id}/servers/{mcp_server_id}/check-oauth",
-		"GET /api/workspaces/{workspace_id}/servers/{mcp_server_id}/oauth-url",
-		"DELETE /api/workspaces/{workspace_id}/servers/{mcp_server_id}/oauth",
-		"POST /api/workspaces/{workspace_id}/servers/{mcp_server_id}/configure",
-		"POST /api/workspaces/{workspace_id}/servers/{mcp_server_id}/deconfigure",
-		"POST /api/workspaces/{workspace_id}/servers/{mcp_server_id}/reveal",
-		"GET /api/workspaces/{workspace_id}/servers/{mcp_server_id}/instances",
-	},
 
 	PowerUserPlusGroup: {
-		// Access Control Rules
-		"GET /api/workspaces/{workspace_id}/access-control-rules",
-		"GET /api/workspaces/{workspace_id}/access-control-rules/{access_control_rule_id}",
-		"POST /api/workspaces/{workspace_id}/access-control-rules",
-		"PUT /api/workspaces/{workspace_id}/access-control-rules/{access_control_rule_id}",
-		"DELETE /api/workspaces/{workspace_id}/access-control-rules/{access_control_rule_id}",
-
 		"GET /api/users",
 		"GET /api/users/{user_id}",
 		"GET /api/groups",

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -493,7 +493,7 @@ func Router(services *services.Services) (http.Handler, error) {
 	mux.HandleFunc("POST /api/workspaces/{workspace_id}/entries/{entry_id}/generate-tool-previews", mcpCatalogs.GenerateToolPreviews)
 	mux.HandleFunc("POST /api/workspaces/{workspace_id}/entries/{entry_id}/generate-tool-previews/oauth-url", mcpCatalogs.GenerateToolPreviewsOAuthURL)
 
-	// Workspace-scoped MCP Servers (PowerUser and higher only)
+	// Workspace-scoped MCP Servers (PowerUserPlus and higher only)
 	mux.HandleFunc("GET /api/workspaces/{workspace_id}/servers", mcp.ListServer)
 	mux.HandleFunc("GET /api/workspaces/{workspace_id}/servers/{mcp_server_id}", mcp.GetServer)
 	mux.HandleFunc("POST /api/workspaces/{workspace_id}/servers", mcp.CreateServer)

--- a/ui/user/src/lib/context/poweruserWorkspace.svelte.ts
+++ b/ui/user/src/lib/context/poweruserWorkspace.svelte.ts
@@ -36,7 +36,7 @@ export async function fetchMcpServerAndEntries(
 	const context = mcpServerAndEntries || getPoweruserWorkspace();
 	context.loading = true;
 	const entries = await ChatService.listWorkspaceMCPCatalogEntries(workspaceID);
-	const servers = await ChatService.listWorkspaceMCPCatalogServers(workspaceID);
+	const servers = await ChatService.listMCPCatalogServers();
 	context.entries = entries;
 	context.servers = servers;
 	context.loading = false;

--- a/ui/user/src/lib/context/poweruserWorkspace.svelte.ts
+++ b/ui/user/src/lib/context/poweruserWorkspace.svelte.ts
@@ -1,5 +1,6 @@
-import { ChatService, type MCPCatalogServer } from '$lib/services';
+import { ChatService, Role, type MCPCatalogServer } from '$lib/services';
 import type { MCPCatalogEntry } from '$lib/services/admin/types';
+import { profile } from '$lib/stores';
 import { getContext, hasContext, setContext } from 'svelte';
 
 const Key = Symbol('poweruser-workspace');
@@ -35,8 +36,13 @@ export async function fetchMcpServerAndEntries(
 ) {
 	const context = mcpServerAndEntries || getPoweruserWorkspace();
 	context.loading = true;
+	const hasMultiUserAccess =
+		profile.current.role === Role.POWERUSER_PLUS || profile.current.role === Role.ADMIN;
 	const entries = await ChatService.listWorkspaceMCPCatalogEntries(workspaceID);
-	const servers = await ChatService.listMCPCatalogServers();
+	// if not power user plus/admin, skip multi-users servers call
+	const servers = hasMultiUserAccess
+		? await ChatService.listWorkspaceMCPCatalogServers(workspaceID)
+		: [];
 	context.entries = entries;
 	context.servers = servers;
 	context.loading = false;


### PR DESCRIPTION
This PR reverts the changes to allow power user and plus to have more route access, as it should be granted based on workspace and permission in another handler. Also change the UI to use a differente endpoint to list servers for the current users.