### PR TITLE
fix: detection of project share changes

### DIFF
--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -14,6 +14,7 @@ import (
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/jwt/ephemeral"
+
 	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/obot-platform/obot/pkg/projects"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -267,6 +268,10 @@ func (p *ProjectMCPHandler) DeleteServer(req api.Context) error {
 
 	if err = req.Delete(&projectServer); err != nil {
 		return err
+	}
+
+	if err := kickThread(req.Context(), req.Storage, req.Namespace(), projectServer.Spec.ThreadName); err != nil {
+		log.Warnf("failed to kick thread %s after project MCP server %s was deleted: %v", projectServer.Spec.ThreadName, projectServer.Name, err)
 	}
 
 	return req.Write(convertProjectMCPServer(&projectServer, mcpServer, cred))

--- a/pkg/storage/apis/obot.obot.ai/v1/run.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/run.go
@@ -28,6 +28,7 @@ const (
 	AuthProviderSyncAnnotation        = "obot.ai/auth-provider-sync"
 	FileScannerProviderSyncAnnotation = "obot.ai/file-scanner-provider-sync"
 	MCPCatalogSyncAnnotation          = "obot.ai/mcp-catalog-sync"
+	ThreadSyncAnnotation              = "obot.ai/thread-sync"
 )
 
 var (


### PR DESCRIPTION
Fix the detection of changes between upstream projects, snapshots, and copied projects for:
- Disabling/enabling MCP server tools
- Removing MCP servers
- Removing tasks

Addresses https://github.com/obot-platform/obot/issues/4304

