### PR TITLE
Fix: use correct access rules for power users and power user plus

### DIFF
--- a/pkg/storage/apis/obot.obot.ai/v1/poweruserworkspace.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/poweruserworkspace.go
@@ -52,6 +52,7 @@ type PowerUserWorkspaceSpec struct {
 }
 
 type PowerUserWorkspaceStatus struct {
+	DefaultAccessControlRuleGenerated bool `json:"defaultAccessControlRuleGenerated,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -13609,6 +13609,14 @@ func schema_storage_apis_obotobotai_v1_PowerUserWorkspaceStatus(ref common.Refer
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"defaultAccessControlRuleGenerated": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/ui/user/src/routes/admin/access-control/+page.svelte
+++ b/ui/user/src/routes/admin/access-control/+page.svelte
@@ -15,7 +15,7 @@
 		getAdminMcpServerAndEntries,
 		initMcpServerAndEntries
 	} from '$lib/context/admin/mcpServerAndEntries.svelte';
-	import { AdminService } from '$lib/services/index.js';
+	import { AdminService, ChatService } from '$lib/services/index.js';
 	import { getUserDisplayName, openUrl } from '$lib/utils.js';
 
 	let { data } = $props();
@@ -250,7 +250,14 @@
 	show={Boolean(ruleToDelete)}
 	onsuccess={async () => {
 		if (!ruleToDelete) return;
-		await AdminService.deleteAccessControlRule(ruleToDelete.id);
+		if (ruleToDelete.powerUserWorkspaceID) {
+			await ChatService.deleteWorkspaceAccessControlRule(
+				ruleToDelete.powerUserWorkspaceID,
+				ruleToDelete.id
+			);
+		} else {
+			await AdminService.deleteAccessControlRule(ruleToDelete.id);
+		}
 		accessControlRules = await AdminService.listAccessControlRules();
 		ruleToDelete = undefined;
 	}}


### PR DESCRIPTION
- For power user we should create ACR that only allow current user access for its own registry. For plus, we will allow every user. 

- Also changed so that the generated rule can be deleted by user but won't be recreated again. 

- Fixed a bug in frontend to use the correct endpoint to delete ACR.

Note: this PR doesn't address migration issue for existing env. We will have to migrate manually.