### PR TITLE
Hide template resources from admin views

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1967,6 +1967,10 @@ func (m *MCPHandler) GetServerDetails(req api.Context) error {
 		return err
 	}
 
+	if server.Spec.Template {
+		return types.NewErrNotFound("MCP server not found")
+	}
+
 	if serverConfig.Runtime == types.RuntimeRemote {
 		return types.NewErrBadRequest("cannot get details for remote MCP server")
 	}

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -400,6 +400,11 @@ func (h *MCPCatalogHandler) AdminListServersForEntryInCatalog(req api.Context) e
 
 	var items []types.MCPServer
 	for _, server := range list.Items {
+		if server.Spec.Template {
+			// Hide template servers
+			continue
+		}
+
 		var credCtx string
 		if server.Spec.MCPCatalogID != "" {
 			credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)

--- a/pkg/api/handlers/tasks.go
+++ b/pkg/api/handlers/tasks.go
@@ -914,13 +914,24 @@ func (t *TaskHandler) ListFromScope(req api.Context) error {
 }
 
 func (t *TaskHandler) list(req api.Context, thread *v1.Thread) error {
-	selector := kclient.MatchingFields{}
+	var (
+		selector    = kclient.MatchingFields{}
+		templateSet map[string]struct{}
+		err         error
+	)
 
 	if thread != nil && thread.Name != "" {
 		if !thread.Spec.Project && thread.Spec.ParentThreadName != "" {
 			selector["spec.threadName"] = thread.Spec.ParentThreadName
 		} else {
 			selector["spec.threadName"] = thread.Name
+		}
+	} else {
+		// We're listing all tasks in the system, get the set of template thread names so we can
+		// omit template tasks from the results
+		templateSet, err = getTemplateSet(req.Context(), req.Storage)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -962,9 +973,11 @@ func (t *TaskHandler) list(req api.Context, thread *v1.Thread) error {
 	taskList := types.TaskList{Items: make([]types.Task, 0, len(workflows.Items))}
 
 	for _, workflow := range workflows.Items {
-		if !workflow.DeletionTimestamp.IsZero() {
+		if _, isTemplate := templateSet[workflow.Spec.ThreadName]; isTemplate ||
+			!workflow.DeletionTimestamp.IsZero() {
 			continue
 		}
+
 		taskList.Items = append(taskList.Items, convertTask(workflow, &triggers{
 			CronJob: cronMap[name.SafeHashConcatName(system.CronJobPrefix, workflow.Name)],
 			Webhook: webhookMap[name.SafeHashConcatName(system.WebhookPrefix, workflow.Name)],

--- a/pkg/api/handlers/template.go
+++ b/pkg/api/handlers/template.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"strings"
 
 	"github.com/obot-platform/obot/apiclient/types"
@@ -223,4 +224,21 @@ func (h *TemplateHandler) GetTemplate(req api.Context) error {
 	}
 
 	return req.Write(convertTemplateThread(templateThread, &templateShareList.Items[0]))
+}
+
+// getTemplateSet returns a set of template thread names for all templates
+func getTemplateSet(ctx context.Context, c kclient.Client) (map[string]struct{}, error) {
+	var templateThreadList v1.ThreadList
+	if err := c.List(ctx, &templateThreadList, kclient.MatchingFields{
+		"spec.template": "true",
+	}); err != nil {
+		return nil, err
+	}
+
+	templateSet := make(map[string]struct{}, len(templateThreadList.Items))
+	for _, thread := range templateThreadList.Items {
+		templateSet[thread.Name] = struct{}{}
+	}
+
+	return templateSet, nil
 }


### PR DESCRIPTION
Filter out resources in the API such that:
- template MCP servers are hidefrom the server details page
- Hide template tasks from the tasks view

Addresses https://github.com/obot-platform/obot/issues/4287