### PR TITLE
fix: do not clip absolute element and enhance scrollbar visibility

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -933,3 +933,8 @@ html {
 	--surface3: var(--color-gray-200);
 	--on-surface3: var(--color-black);
 }
+
+.scrollable {
+	scrollbar-color: var(--color-surface3) #f1f1f100;
+	scrollbar-width: auto;
+}

--- a/ui/user/src/lib/components/messages/Input.svelte
+++ b/ui/user/src/lib/components/messages/Input.svelte
@@ -136,7 +136,7 @@
 		class="button-colors text-blue rounded-full p-2 transition-all duration-100 hover:border-none"
 	>
 		{#if readonly}
-			<div class="m-1.5 h-3 w-3 place-self-center rounded-xs bg-white"></div>
+			<div class="rounded-xs m-1.5 h-3 w-3 place-self-center bg-white"></div>
 		{:else if pending}
 			<LoaderCircle class="animate-spin" />
 		{:else}
@@ -152,13 +152,18 @@
 	{/if}
 
 	<div
-		class=" focus-within:ring-blue bg-surface1 mt-4 flex h-fit max-h-[80svh] overflow-hidden rounded-2xl focus-within:shadow-md focus-within:ring-1"
+		class=" focus-within:ring-blue bg-surface1 mt-4 flex h-fit max-h-[80svh] rounded-2xl focus-within:shadow-md focus-within:ring-1"
 	>
 		<div class="flex min-h-full w-full flex-col" {id}>
 			<label for="chat" class="sr-only">Your messages</label>
-			<div class="chat-grid relative flex flex-1 flex-col items-center overflow-hidden">
-				<div class="flex h-full items-end overflow-hidden">
-					<div class="scrollable relative flex max-h-full w-full flex-1 gap-4 overflow-y-auto p-2">
+			<div class="chat-grid relative flex flex-1 flex-col items-center">
+				<div
+					class="flex h-full flex-1 items-end overflow-hidden pr-1"
+					style="max-height: calc(80svh - 48px);"
+				>
+					<div
+						class="scrollable relative flex max-h-full w-full flex-1 scroll-m-10 scroll-pb-20 gap-4 overflow-y-auto p-2"
+					>
 						<PlaintextEditor
 							bind:this={editor}
 							bind:value
@@ -174,7 +179,9 @@
 				</div>
 
 				{#if children}
-					<div class="chat-footer pointer-events-none z-1 flex w-full justify-between px-2 pb-2">
+					<div
+						class="chat-footer z-1 pointer-events-none flex w-full justify-between rounded-b-2xl px-2 pb-2"
+					>
 						<div class="pointer-events-auto flex flex-1">
 							{@render children?.()}
 							<div class="grow"></div>

--- a/ui/user/src/lib/components/messages/Input.svelte
+++ b/ui/user/src/lib/components/messages/Input.svelte
@@ -136,7 +136,7 @@
 		class="button-colors text-blue rounded-full p-2 transition-all duration-100 hover:border-none"
 	>
 		{#if readonly}
-			<div class="rounded-xs m-1.5 h-3 w-3 place-self-center bg-white"></div>
+			<div class="m-1.5 h-3 w-3 place-self-center rounded-xs bg-white"></div>
 		{:else if pending}
 			<LoaderCircle class="animate-spin" />
 		{:else}
@@ -180,7 +180,7 @@
 
 				{#if children}
 					<div
-						class="chat-footer z-1 pointer-events-none flex w-full justify-between rounded-b-2xl px-2 pb-2"
+						class="chat-footer pointer-events-none z-1 flex w-full justify-between rounded-b-2xl px-2 pb-2"
 					>
 						<div class="pointer-events-auto flex flex-1">
 							{@render children?.()}


### PR DESCRIPTION
Addresses #4320 

- Make sure absolute elements are not clipped.
- Improve scrollbar style for a better look.

<img width="967" height="345" alt="image" src="https://github.com/user-attachments/assets/166812b0-5896-40a5-8438-51468fe3d9e3" />
