### PR TITLE
fix: copy manifest in api handler during initial template copy

### DIFF
--- a/pkg/api/handlers/template.go
+++ b/pkg/api/handlers/template.go
@@ -145,6 +145,7 @@ func (h *TemplateHandler) CopyTemplate(req api.Context) error {
 		},
 		Spec: v1.ThreadSpec{
 			AgentName:        templateThread.Spec.AgentName,
+			Manifest:         templateThread.Spec.Manifest,
 			SourceThreadName: templateThread.Name,
 			UserID:           req.User.GetUID(),
 			Project:          true,


### PR DESCRIPTION
The project created by the "copy template" endpoint will now include
the template project's name in its manifest. This means the UI should
show the correct name when frontend routing to the new project completes
before the initial spec "upgrade".

Addresses https://github.com/obot-platform/obot/issues/4339

