### PR TITLE
fix: improve audit logs timelline ticks

### DIFF
--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsTimeline.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsTimeline.svelte
@@ -310,7 +310,7 @@
 			} else if (duration < 60) {
 				step = 2 * ticksRatio;
 			} else {
-				step = 5 * ticksRatio;
+				step = frameStep * ticksRatio;
 			}
 		}
 
@@ -498,10 +498,6 @@
 			<div class="text-2xl font-bold">{currentItem?.value}</div>
 		</div>
 	{/if}
-
-	<div class="absolute right-0 bottom-full text-xl">
-		{timeFrame[0]} | {timeFrame[1].toString().padStart(2, '0')}
-	</div>
 
 	<svg width={clientWidth} height={clientHeight} viewBox={`0 0 ${clientWidth} ${clientHeight}`}>
 		<g transform="translate({paddingLeft}, {paddingTop})">


### PR DESCRIPTION
Addresses #3841

- Define main & secondary ticks and differentiate them
- adjust tick ratio for better responsiveness
- fix ticks generation in `6h` interval

<img width="1434" height="293" alt="image" src="https://github.com/user-attachments/assets/751f4e39-7944-4758-8c1e-77cf1f59538e" />

<img width="1434" height="298" alt="image" src="https://github.com/user-attachments/assets/8df59d58-3867-4171-a288-f11db6965495" />

<img width="1430" height="294" alt="image" src="https://github.com/user-attachments/assets/18e6390d-1426-4b90-89d3-865ea1746723" />

