### PR TITLE
Fix: Dont replace newlines with null character

### DIFF
--- a/ui/user/src/lib/components/messages/PlaintextEditor.svelte
+++ b/ui/user/src/lib/components/messages/PlaintextEditor.svelte
@@ -125,7 +125,7 @@
 		return new Plugin({
 			appendTransaction(transactions, oldState, newState) {
 				if (transactions.some((tr) => tr.docChanged)) {
-					_value = value = newState.doc.textBetween(1, newState.doc.content.size - 1, '\n', '\0');
+					_value = value = newState.doc.textBetween(1, newState.doc.content.size - 1, '\n');
 				}
 
 				return null;


### PR DESCRIPTION
The fourth parameter of this textBetween function call is causing us to
replaced newlines with the unicode null character. Here's the docs for
that function:

> Get all text between positions from and to. When blockSeparator is given,
> it will be inserted to separate text from different block nodes.
> If leafText is given, it'll be inserted for every non-text leaf node
> encountered, otherwise leafText will be used.

LeafText is the 4th param. The last sentence of that is confusing, but
regardless I don't think we need to set this 4th parameter.

Signed-off-by: Craig Jellick <craig@acorn.io>
