### PR TITLE
Fix: don't show user, user profile and mcp publisher when auth is disabled

### DIFF
--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -182,7 +182,7 @@
 								icon: Users,
 								label: 'Users',
 								collapsible: false,
-								disabled: false
+								disabled: !version.current.authEnabled
 							},
 							{
 								id: 'user-roles',
@@ -190,7 +190,7 @@
 								icon: UserCog,
 								label: 'User Roles',
 								collapsible: false,
-								disabled: false
+								disabled: !version.current.authEnabled
 							},
 							{
 								id: 'auth-providers',

--- a/ui/user/src/lib/components/navbar/Profile.svelte
+++ b/ui/user/src/lib/components/navbar/Profile.svelte
@@ -179,7 +179,7 @@
 					Chat
 				</button>
 			{/if}
-			{#if (profile.current.role === Role.POWERUSER || profile.current.role === Role.POWERUSER_PLUS || profile.current.role === Role.ADMIN) && showMcpPublisherLink}
+			{#if (profile.current.role === Role.POWERUSER || profile.current.role === Role.POWERUSER_PLUS || profile.current.role === Role.ADMIN) && showMcpPublisherLink && version.current.authEnabled}
 				<a href="/mcp-publisher" rel="external" class="link">
 					<ServerCog class="size-4" /> MCP Publisher
 				</a>


### PR DESCRIPTION
We don't need to show users, user profile and mcp publisher page when auth is disabled.

https://github.com/obot-platform/obot/issues/4376