### PR TITLE
Fix: fix admin ACR to view entries and servers

### DIFF
--- a/pkg/accesscontrolrule/helper.go
+++ b/pkg/accesscontrolrule/helper.go
@@ -1,6 +1,7 @@
 package accesscontrolrule
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/obot-platform/obot/apiclient/types"
@@ -8,15 +9,18 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	gocache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Helper struct {
 	acrIndexer gocache.Indexer
+	client     client.Client
 }
 
-func NewAccessControlRuleHelper(acrIndexer gocache.Indexer) *Helper {
+func NewAccessControlRuleHelper(acrIndexer gocache.Indexer, client client.Client) *Helper {
 	return &Helper{
 		acrIndexer: acrIndexer,
+		client:     client,
 	}
 }
 
@@ -326,7 +330,7 @@ func (h *Helper) GetAccessControlRulesForSelectorInWorkspace(namespace, selector
 }
 
 // UserHasAccessToMCPServerInWorkspace checks if a user has access to a specific MCP server through workspace-scoped AccessControlRules
-func (h *Helper) UserHasAccessToMCPServerInWorkspace(user kuser.Info, serverName, workspaceID string) (bool, error) {
+func (h *Helper) UserHasAccessToMCPServerInWorkspace(user kuser.Info, serverName, workspaceID, serverUserID string) (bool, error) {
 	// See if there is a selector that this user is included on in the specified workspace.
 	selectorRules, err := h.GetAccessControlRulesForSelectorInWorkspace(system.DefaultNamespace, "*", workspaceID)
 	if err != nil {
@@ -381,11 +385,16 @@ func (h *Helper) UserHasAccessToMCPServerInWorkspace(user kuser.Info, serverName
 		}
 	}
 
+	// If the server is owned by the current user, they have access to it to ignore the AccessControlRules
+	if serverUserID == userID {
+		return true, nil
+	}
+
 	return false, nil
 }
 
 // UserHasAccessToMCPServerCatalogEntryInWorkspace checks if a user has access to a specific catalog entry through workspace-scoped AccessControlRules
-func (h *Helper) UserHasAccessToMCPServerCatalogEntryInWorkspace(user kuser.Info, entryName, workspaceID string) (bool, error) {
+func (h *Helper) UserHasAccessToMCPServerCatalogEntryInWorkspace(ctx context.Context, user kuser.Info, entryName, workspaceID string) (bool, error) {
 	// See if there is a selector that this user is included on in the specified workspace.
 	selectorRules, err := h.GetAccessControlRulesForSelectorInWorkspace(system.DefaultNamespace, "*", workspaceID)
 	if err != nil {
@@ -437,6 +446,17 @@ func (h *Helper) UserHasAccessToMCPServerCatalogEntryInWorkspace(user kuser.Info
 					return true, nil
 				}
 			}
+		}
+	}
+
+	// If the workspace is owned by the current user, they have access to all entries in the workspace
+	if workspaceID != "" {
+		var workspace v1.PowerUserWorkspace
+		if err := h.client.Get(ctx, client.ObjectKey{Namespace: system.DefaultNamespace, Name: workspaceID}, &workspace); err != nil {
+			return false, err
+		}
+		if workspace.Spec.UserID == userID {
+			return true, nil
 		}
 	}
 

--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -32,7 +32,7 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user us
 		if mcpServer.Spec.MCPCatalogID != "" {
 			return a.acrHelper.UserHasAccessToMCPServerInCatalog(user, resources.MCPID, mcpServer.Spec.MCPCatalogID)
 		} else if mcpServer.Spec.PowerUserWorkspaceID != "" {
-			return a.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(user, resources.MCPID, mcpServer.Spec.PowerUserWorkspaceID)
+			return a.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.Context(), user, resources.MCPID, mcpServer.Spec.PowerUserWorkspaceID)
 		}
 
 		// For single-user MCP servers, ensure the user owns the server.
@@ -46,7 +46,7 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user us
 		if entry.Spec.MCPCatalogName != "" {
 			return a.acrHelper.UserHasAccessToMCPServerCatalogEntryInCatalog(user, resources.MCPID, entry.Spec.MCPCatalogName)
 		} else if entry.Spec.PowerUserWorkspaceID != "" {
-			return a.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(user, resources.MCPID, entry.Spec.PowerUserWorkspaceID)
+			return a.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.Context(), user, resources.MCPID, entry.Spec.PowerUserWorkspaceID)
 		}
 
 		return false, nil

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -204,24 +204,26 @@ func (m *MCPHandler) ListServer(req api.Context) error {
 			continue
 		}
 
-		var hasAccess bool
-		var err error
-
-		if server.Spec.MCPCatalogID != "" {
-			hasAccess, err = m.acrHelper.UserHasAccessToMCPServerCatalogEntryInCatalog(req.User, server.Name, server.Spec.MCPCatalogID)
-			if err != nil {
-				return fmt.Errorf("failed to check access: %w", err)
-			}
-		} else if server.Spec.PowerUserWorkspaceID != "" {
-			hasAccess, err = m.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.Context(), req.User, server.Name, server.Spec.PowerUserWorkspaceID)
-			if err != nil {
-				return fmt.Errorf("failed to check access: %w", err)
-			}
-		}
+		var (
+			hasAccess bool
+			err       error
+		)
 
 		// if the server is owned by the current user, they have access to it
 		if server.Spec.UserID == req.User.GetUID() {
 			hasAccess = true
+		} else {
+			if server.Spec.MCPCatalogID != "" {
+				hasAccess, err = m.acrHelper.UserHasAccessToMCPServerCatalogEntryInCatalog(req.User, server.Name, server.Spec.MCPCatalogID)
+				if err != nil {
+					return fmt.Errorf("failed to check access: %w", err)
+				}
+			} else if server.Spec.PowerUserWorkspaceID != "" {
+				hasAccess, err = m.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.Context(), req.User, server.Name, server.Spec.PowerUserWorkspaceID)
+				if err != nil {
+					return fmt.Errorf("failed to check access: %w", err)
+				}
+			}
 		}
 
 		if !hasAccess {

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -184,11 +184,12 @@ func (h *MCPCatalogHandler) ListEntries(req api.Context) error {
 			hasAccess, err = h.acrHelper.UserHasAccessToMCPServerCatalogEntryInCatalog(req.User, entry.Name, entry.Spec.MCPCatalogName)
 		} else if entry.Spec.PowerUserWorkspaceID != "" {
 			// Check workspace-scoped entries
-			hasAccess, err = h.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.User, entry.Name, entry.Spec.PowerUserWorkspaceID)
+			hasAccess, err = h.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.Context(), req.User, entry.Name, entry.Spec.PowerUserWorkspaceID)
 		}
 		if err != nil {
 			return err
 		}
+
 		if hasAccess {
 			entries = append(entries, convertMCPServerCatalogEntry(entry))
 		}

--- a/pkg/api/handlers/poweruserworkspace.go
+++ b/pkg/api/handlers/poweruserworkspace.go
@@ -80,24 +80,7 @@ func (p *PowerUserWorkspaceHandler) ListAllEntries(req api.Context) error {
 		}
 
 		for _, entry := range list2.Items {
-			var (
-				err       error
-				hasAccess bool
-			)
-
-			// Check default catalog entries
-			if entry.Spec.MCPCatalogName != "" {
-				hasAccess, err = p.acrHelper.UserHasAccessToMCPServerCatalogEntryInCatalog(req.User, entry.Name, entry.Spec.MCPCatalogName)
-			} else if entry.Spec.PowerUserWorkspaceID != "" {
-				// Check workspace-scoped entries
-				hasAccess, err = p.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.User, entry.Name, entry.Spec.PowerUserWorkspaceID)
-			}
-			if err != nil {
-				return err
-			}
-			if hasAccess {
-				catalogEntries = append(catalogEntries, convertMCPServerCatalogEntry(entry))
-			}
+			catalogEntries = append(catalogEntries, convertMCPServerCatalogEntryWithWorkspace(entry, item.Name, item.Spec.UserID))
 		}
 	}
 
@@ -144,23 +127,6 @@ func (p *PowerUserWorkspaceHandler) ListAllServers(req api.Context) error {
 		}
 
 		for _, server := range serverList.Items {
-			if server.Spec.MCPCatalogID != "" {
-				hasAccess, err := p.acrHelper.UserHasAccessToMCPServerCatalogEntryInCatalog(req.User, server.Name, server.Spec.MCPCatalogID)
-				if err != nil {
-					return fmt.Errorf("failed to check access: %w", err)
-				}
-				if !hasAccess {
-					continue
-				}
-			} else if server.Spec.PowerUserWorkspaceID != "" {
-				hasAccess, err := p.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.User, server.Name, server.Spec.PowerUserWorkspaceID)
-				if err != nil {
-					return fmt.Errorf("failed to check access: %w", err)
-				}
-				if !hasAccess {
-					continue
-				}
-			}
 			// Add extracted env vars to the server definition
 			addExtractedEnvVars(&server)
 

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -193,7 +193,7 @@ func (p *ProjectMCPHandler) CreateServer(req api.Context) error {
 		if mcpServer.Spec.MCPCatalogID != "" {
 			hasAccess, err = p.acrHelper.UserHasAccessToMCPServerInCatalog(req.User, mcpServer.Name, mcpServer.Spec.MCPCatalogID)
 		} else if mcpServer.Spec.PowerUserWorkspaceID != "" {
-			hasAccess, err = p.acrHelper.UserHasAccessToMCPServerInWorkspace(req.User, mcpServer.Name, mcpServer.Spec.PowerUserWorkspaceID)
+			hasAccess, err = p.acrHelper.UserHasAccessToMCPServerInWorkspace(req.User, mcpServer.Name, mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Spec.UserID)
 		}
 
 		if err != nil {

--- a/pkg/api/handlers/serverinstances.go
+++ b/pkg/api/handlers/serverinstances.go
@@ -105,7 +105,7 @@ func (h *ServerInstancesHandler) CreateServerInstance(req api.Context) error {
 		if server.Spec.MCPCatalogID != "" {
 			hasAccess, err = h.acrHelper.UserHasAccessToMCPServerInCatalog(req.User, server.Name, server.Spec.MCPCatalogID)
 		} else if server.Spec.PowerUserWorkspaceID != "" {
-			hasAccess, err = h.acrHelper.UserHasAccessToMCPServerInWorkspace(req.User, server.Name, server.Spec.PowerUserWorkspaceID)
+			hasAccess, err = h.acrHelper.UserHasAccessToMCPServerInWorkspace(req.User, server.Name, server.Spec.PowerUserWorkspaceID, server.Spec.UserID)
 		}
 
 		if err != nil {

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -580,7 +580,7 @@ func (h *Handler) DeleteUnauthorizedMCPServerInstances(req router.Request, _ rou
 				return fmt.Errorf("failed to check if user %s has access to MCP server %s: %w", instance.Spec.UserID, instance.Spec.MCPServerName, err)
 			}
 		} else if mcpServer.Spec.PowerUserWorkspaceID != "" {
-			hasAccess, err = h.accessControlRuleHelper.UserHasAccessToMCPServerInWorkspace(user, instance.Spec.MCPServerName, mcpServer.Spec.PowerUserWorkspaceID)
+			hasAccess, err = h.accessControlRuleHelper.UserHasAccessToMCPServerInWorkspace(user, instance.Spec.MCPServerName, mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Spec.UserID)
 			if err != nil {
 				return fmt.Errorf("failed to check if user %s has access to MCP server %s: %w", instance.Spec.UserID, instance.Spec.MCPServerName, err)
 			}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -467,7 +467,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		return nil, err
 	}
 
-	acrHelper := accesscontrolrule.NewAccessControlRuleHelper(acrInformer.GetIndexer())
+	acrHelper := accesscontrolrule.NewAccessControlRuleHelper(acrInformer.GetIndexer(), r.Backend())
 
 	// Set up MCPWebhookValidation indexer
 	mcpWebhookValidationGVK, err := r.Backend().GroupVersionKindFor(&v1.MCPWebhookValidation{})


### PR DESCRIPTION
This PR fixes a couple of issue regarding to admin and ACR

- Admin by default still see all entries and servers from all users, be able to view logs/server details
- Admin should not see mcp server from connector page from PU/PUP users unless a ACR is granted to admin
- PU/PUP user should see their mcp servers and use them without having a ACR if they are the owner.

https://github.com/obot-platform/obot/issues/4382
https://github.com/obot-platform/obot/issues/4341