### PR TITLE
fix: shorten copied project share resource names

### DIFF
--- a/pkg/controller/handlers/threads/template.go
+++ b/pkg/controller/handlers/threads/template.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/gptscript-ai/gptscript/pkg/hash"
-	"github.com/obot-platform/nah/pkg/name"
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -155,7 +155,7 @@ func remapCopiedAllowedMCPTools(copiedThread *v1.Thread) *v1.Thread {
 	for pmsName, toolNames := range allowedMCPTools {
 		// Copied ProjectMCPServers names are always constructed by concatenating the source MCP
 		// server name with the copied thread name.
-		remapped[name.SafeHashConcatName(pmsName, copiedThread.Name)] = toolNames
+		remapped[copiedName(system.ProjectMCPServerPrefix, pmsName, copiedThread.Name)] = toolNames
 	}
 	copiedThread.Spec.Manifest.AllowedMCPTools = remapped
 


### PR DESCRIPTION
Shorten the names of API objects copied when:
- creating project share snapshots
- copying project share snapshots

Note:
- Resources with the old long names should be deleted on upgrade
- Not sure how collision resistant this is; may want to switch to hashing/truncating the current name (just to normalize the length to the standard type prefix + 5 characters), then appending the project thread name as a hyphenated suffix. That should give us MCP server names like `ms1mcrprp-t1pw77s`.
