### PR TITLE
fix: multiple config prompt sequence

### DIFF
--- a/ui/user/src/lib/components/edit/ProjectConfiguration.svelte
+++ b/ui/user/src/lib/components/edit/ProjectConfiguration.svelte
@@ -15,7 +15,7 @@
 	import { onMount } from 'svelte';
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
-	import { getProjectMCPs } from '$lib/context/projectMcps.svelte';
+	import PageLoading from '$lib/components/PageLoading.svelte';
 
 	interface Props {
 		project: Project;
@@ -29,7 +29,6 @@
 	let upgradeLoading = $state(false);
 
 	const projectTools = getProjectTools();
-	const projectMCPs = getProjectMCPs();
 	const layout = getLayout();
 
 	let copiedProject = $derived(!!project?.sourceProjectID && project.sourceProjectID.trim() !== '');
@@ -59,15 +58,11 @@
 			);
 
 			// The upgrade was successful
-			// Refresh the sidebar mcp servers, tasks, and config form data
-			// Knowledge files are refreshed when the project changes because we're using
-			// bind:project={modifiedProject} in the ProjectConfigurationKnowledge component below
-			modifiedProject = project;
-			layout.tasks = (await ChatService.listTasks(project.assistantID, project.id)).items;
-			projectMCPs.items = await ChatService.listProjectMCPs(project.assistantID, project.id);
+			// Hard refresh the page to ensure all components are updated and auth/config prompts
+			// are triggered
+			window.location.href = window.location.pathname + '?edit=true';
 		} catch (error) {
 			console.error('Failed to upgrade project from template:', error);
-		} finally {
 			upgradeLoading = false;
 		}
 	}
@@ -273,3 +268,5 @@
 	oncancel={() => (confirmDelete = false)}
 	loading={deleting}
 />
+
+<PageLoading show={upgradeLoading} />


### PR DESCRIPTION
- Add keys for config prompt elements
- Hard refresh page on project upgrade to ensure new config/auth dialogs are
  triggered

Addresses https://github.com/obot-platform/obot/issues/4372

Loom: https://www.loom.com/share/1c2ceed88d6643f0a39032232950930d?sid=6fa39560-5b32-4813-b352-65c1e62fc3a8
