### PR TITLE
fix: do not show sensitive info automatically

### DIFF
--- a/ui/user/src/lib/components/SensitiveInput.svelte
+++ b/ui/user/src/lib/components/SensitiveInput.svelte
@@ -15,28 +15,10 @@
 	let { name, value = $bindable(''), error, oninput, textarea, disabled }: Props = $props();
 	let showSensitive = $state(false);
 	let textareaElement = $state<HTMLTextAreaElement>();
-	let isEditing = $state(false);
+	let isPulsing = $state(false);
 
 	function getMaskedValue(text: string): string {
 		return text.replace(/[^\n\r]/g, '•');
-	}
-
-	function handleTextareaFocus() {
-		if (!showSensitive) {
-			isEditing = true;
-		}
-	}
-
-	function handleTextareaBlur() {
-		if (!showSensitive) {
-			isEditing = false;
-		}
-	}
-
-	function handleTextareaInput(event: Event) {
-		const input = event.target as HTMLInputElement | HTMLTextAreaElement;
-		value = input.value;
-		oninput?.();
 	}
 
 	function handleInput(event: Event) {
@@ -48,6 +30,12 @@
 	function toggleVisibility(e: MouseEvent) {
 		e.preventDefault();
 		showSensitive = !showSensitive;
+
+		if (showSensitive) {
+			textareaElement?.focus();
+		}
+
+		isPulsing = false;
 	}
 </script>
 
@@ -58,16 +46,29 @@
 			data-1p-ignore
 			id={name}
 			{name}
+			{disabled}
 			class={twMerge(
 				'text-input-filled w-full pr-10',
 				error && 'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
 			)}
 			class:text-red-500={error}
-			value={showSensitive || isEditing ? value : getMaskedValue(value || '')}
-			onfocus={handleTextareaFocus}
-			onblur={handleTextareaBlur}
-			oninput={handleTextareaInput}
-			{disabled}
+			bind:value={
+				() => (showSensitive ? value : getMaskedValue(value || '')),
+				(v) => {
+					value = v;
+					oninput?.();
+				}
+			}
+			onkeydown={(ev) => {
+				if (!showSensitive) {
+					if (ev.key === 'v' && (ev.metaKey || ev.ctrlKey)) return true;
+
+					ev.preventDefault();
+					isPulsing = true;
+
+					return false;
+				}
+			}}
 		></textarea>
 	{:else}
 		<input
@@ -89,8 +90,9 @@
 
 	<button
 		type="button"
-		class="absolute top-1/2 right-4 z-10 -translate-y-1/2 cursor-pointer"
+		class="absolute top-1/2 right-4 z-10 -translate-y-1/2 cursor-pointer transition-colors duration-150"
 		class:text-red-500={error}
+		class:pulse={isPulsing}
 		onclick={toggleVisibility}
 		use:tooltip={{ disablePortal: true, text: showSensitive ? 'Hide' : 'Reveal' }}
 	>
@@ -101,3 +103,21 @@
 		{/if}
 	</button>
 </div>
+
+<style>
+	@keyframes pulse {
+		0% {
+			color: rgb(255, 255, 255);
+			transform: scale(1);
+		}
+
+		100% {
+			color: var(--color-blue);
+			transform: scale(1.2);
+		}
+	}
+
+	.pulse {
+		animation: pulse 0.2s ease-in-out alternate infinite;
+	}
+</style>

--- a/ui/user/src/lib/components/SensitiveInput.svelte
+++ b/ui/user/src/lib/components/SensitiveInput.svelte
@@ -88,20 +88,24 @@
 		/>
 	{/if}
 
-	<button
-		type="button"
-		class="absolute top-1/2 right-4 z-10 -translate-y-1/2 cursor-pointer transition-colors duration-150"
-		class:text-red-500={error}
-		class:pulse={isPulsing}
-		onclick={toggleVisibility}
+	<div
+		class="absolute top-1/2 right-4 z-10 grid -translate-y-1/2 grid-cols-1 grid-rows-1"
 		use:tooltip={{ disablePortal: true, text: showSensitive ? 'Hide' : 'Reveal' }}
 	>
-		{#if showSensitive}
-			<EyeOff class="size-4" />
-		{:else}
-			<Eye class="size-4" />
-		{/if}
-	</button>
+		<button
+			type="button"
+			class="cursor-pointer transition-colors duration-150"
+			class:text-red-500={error}
+			class:pulse={isPulsing}
+			onclick={toggleVisibility}
+		>
+			{#if showSensitive}
+				<EyeOff class="size-4" />
+			{:else}
+				<Eye class="size-4" />
+			{/if}
+		</button>
+	</div>
 </div>
 
 <style>

--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -57,12 +57,16 @@
 	let initialFormJson = $state<string>('');
 	let resizing = $state(false);
 
+	let isOpen = $state(false);
+
 	export function open() {
 		configDialog?.open();
 		if (!isNew) {
 			// store initial form data as jsonified string for comparison when not new
 			initialFormJson = JSON.stringify(form);
 		}
+
+		isOpen = true;
 	}
 
 	function clearHighlights() {
@@ -141,6 +145,7 @@
 	onClose={() => {
 		clearHighlights();
 		onClose?.();
+		isOpen = false;
 	}}
 	onClickOutside={() => {
 		if (resizing || disableOutsideClick) return;
@@ -148,6 +153,7 @@
 			showConfirmClose = true;
 		} else {
 			configDialog?.close();
+			isOpen = false;
 		}
 	}}
 >
@@ -163,122 +169,125 @@
 			{name}
 		</div>
 	{/snippet}
-	{#if error}
-		<div class="notification-error flex items-center gap-2">
-			<AlertCircle class="size-6 flex-shrink-0 text-red-500" />
-			<p class="flex flex-col text-sm font-light">
-				<span class="font-semibold">Error:</span>
-				<span>
-					{error}
-				</span>
-			</p>
-		</div>
-	{/if}
-	{#if form}
-		<form
-			onsubmit={(e) => {
-				e.preventDefault();
-			}}
-		>
-			<div class="my-4 flex flex-col gap-4">
-				{#if showAlias}
-					<div class="flex flex-col gap-1">
-						<span class="flex items-center gap-2">
-							<label for="name"> Server Alias </label>
-							<span class="text-gray-400 dark:text-gray-600">(optional)</span>
-							<InfoTooltip
-								text="Uses server name as default. Duplicate instances default to a number increment added at the end of name."
-							/>
-						</span>
-						<input type="text" id="name" bind:value={form.name} class="text-input-filled" />
-					</div>
-				{/if}
-				{#if form.envs && form.envs.length > 0}
-					{#each form.envs as env, i (env.key)}
-						{@const highlightRequired = highlightedFields.has(env.key) && !env.value}
-						<div class="flex flex-col gap-1">
-							<span class="flex items-center gap-2">
-								<label for={env.key} class={highlightRequired ? 'text-red-500' : ''}>
-									{env.name}
-									{#if !env.required}
-										<span class="text-gray-400 dark:text-gray-600">(optional)</span>
-									{/if}
-								</label>
-								<InfoTooltip text={env.description} />
-							</span>
-							{#if env.sensitive}
-								<SensitiveInput
-									error={highlightRequired}
-									name={env.name}
-									bind:value={form.envs[i].value}
-									textarea={env.file}
-								/>
-							{:else if env.file}
-								<textarea
-									id={env.key}
-									bind:value={form.envs[i].value}
-									class={twMerge(
-										'text-input-filled h-32 resize-y whitespace-pre-wrap',
-										highlightRequired && 'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
-									)}
-									onmousedown={() => (resizing = true)}
-									onmouseup={() => (resizing = false)}
-								></textarea>
-							{:else}
-								<input
-									type="text"
-									id={env.key}
-									bind:value={form.envs[i].value}
-									class={twMerge(
-										'text-input-filled',
-										highlightRequired && 'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
-									)}
-								/>
-							{/if}
-						</div>
-					{/each}
-				{/if}
-				{#if form.headers && form.headers.length > 0}
-					{#each form.headers as header, i (header.key)}
-						<div class="flex flex-col gap-1">
-							<span class="flex items-center gap-2">
-								<label for={header.key}>
-									{header.name}
-									{#if !header.required}
-										<span class="text-gray-400 dark:text-gray-600">(optional)</span>
-									{/if}
-								</label>
-								<InfoTooltip text={header.description} />
-							</span>
-							{#if header.sensitive}
-								<SensitiveInput name={header.name} bind:value={form.headers[i].value} />
-							{:else}
-								<input
-									type="text"
-									id={header.key}
-									bind:value={form.headers[i].value}
-									class="text-input-filled"
-								/>
-							{/if}
-						</div>
-					{/each}
-				{/if}
-				{#if form.hostname}
-					<label for="url-manifest-url"> URL </label>
-					<input
-						type="text"
-						id="url-manifest-url"
-						bind:value={form.url}
-						class="text-input-filled"
-					/>
-					<span class="font-light text-gray-400 dark:text-gray-600">
-						The URL must contain the hostname: <b class="font-semibold">
-							{form.hostname}
-						</b>
+
+	{#if isOpen}
+		{#if error}
+			<div class="notification-error flex items-center gap-2">
+				<AlertCircle class="size-6 flex-shrink-0 text-red-500" />
+				<p class="flex flex-col text-sm font-light">
+					<span class="font-semibold">Error:</span>
+					<span>
+						{error}
 					</span>
-				{/if}
+				</p>
 			</div>
-		</form>
+		{/if}
+		{#if form}
+			<form
+				onsubmit={(e) => {
+					e.preventDefault();
+				}}
+			>
+				<div class="my-4 flex flex-col gap-4">
+					{#if showAlias}
+						<div class="flex flex-col gap-1">
+							<span class="flex items-center gap-2">
+								<label for="name"> Server Alias </label>
+								<span class="text-gray-400 dark:text-gray-600">(optional)</span>
+								<InfoTooltip
+									text="Uses server name as default. Duplicate instances default to a number increment added at the end of name."
+								/>
+							</span>
+							<input type="text" id="name" bind:value={form.name} class="text-input-filled" />
+						</div>
+					{/if}
+					{#if form.envs && form.envs.length > 0}
+						{#each form.envs as env, i (env.key)}
+							{@const highlightRequired = highlightedFields.has(env.key) && !env.value}
+							<div class="flex flex-col gap-1">
+								<span class="flex items-center gap-2">
+									<label for={env.key} class={highlightRequired ? 'text-red-500' : ''}>
+										{env.name}
+										{#if !env.required}
+											<span class="text-gray-400 dark:text-gray-600">(optional)</span>
+										{/if}
+									</label>
+									<InfoTooltip text={env.description} />
+								</span>
+								{#if env.sensitive}
+									<SensitiveInput
+										error={highlightRequired}
+										name={env.name}
+										bind:value={form.envs[i].value}
+										textarea={env.file}
+									/>
+								{:else if env.file}
+									<textarea
+										id={env.key}
+										bind:value={form.envs[i].value}
+										class={twMerge(
+											'text-input-filled h-32 resize-y whitespace-pre-wrap',
+											highlightRequired && 'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
+										)}
+										onmousedown={() => (resizing = true)}
+										onmouseup={() => (resizing = false)}
+									></textarea>
+								{:else}
+									<input
+										type="text"
+										id={env.key}
+										bind:value={form.envs[i].value}
+										class={twMerge(
+											'text-input-filled',
+											highlightRequired && 'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
+										)}
+									/>
+								{/if}
+							</div>
+						{/each}
+					{/if}
+					{#if form.headers && form.headers.length > 0}
+						{#each form.headers as header, i (header.key)}
+							<div class="flex flex-col gap-1">
+								<span class="flex items-center gap-2">
+									<label for={header.key}>
+										{header.name}
+										{#if !header.required}
+											<span class="text-gray-400 dark:text-gray-600">(optional)</span>
+										{/if}
+									</label>
+									<InfoTooltip text={header.description} />
+								</span>
+								{#if header.sensitive}
+									<SensitiveInput name={header.name} bind:value={form.headers[i].value} />
+								{:else}
+									<input
+										type="text"
+										id={header.key}
+										bind:value={form.headers[i].value}
+										class="text-input-filled"
+									/>
+								{/if}
+							</div>
+						{/each}
+					{/if}
+					{#if form.hostname}
+						<label for="url-manifest-url"> URL </label>
+						<input
+							type="text"
+							id="url-manifest-url"
+							bind:value={form.url}
+							class="text-input-filled"
+						/>
+						<span class="font-light text-gray-400 dark:text-gray-600">
+							The URL must contain the hostname: <b class="font-semibold">
+								{form.hostname}
+							</b>
+						</span>
+					{/if}
+				</div>
+			</form>
+		{/if}
 	{/if}
 
 	<div class="flex justify-end gap-2">
@@ -302,6 +311,7 @@
 	onsuccess={async () => {
 		showConfirmClose = false;
 		configDialog?.close();
+		isOpen = false;
 	}}
 	oncancel={() => (showConfirmClose = false)}
 >


### PR DESCRIPTION
Addresses #4220

- The user has to click on the eye icon to show/edit sensitive info.
- If a user tries to edit hidden sensitive info, the eye icon will start pulsing to grab the user's attention.