### PR TITLE
fix: put bootstrap user in basic user group

### DIFF
--- a/pkg/api/authz/ui_test.go
+++ b/pkg/api/authz/ui_test.go
@@ -39,7 +39,7 @@ func TestCheckUI_V2AdminAccess(t *testing.T) {
 			path: "/admin/auth-providers",
 			user: &user.DefaultInfo{
 				Name:   "bootstrap",
-				Groups: []string{types.GroupOwner, types.GroupAdmin, types.GroupAuthenticated},
+				Groups: []string{types.GroupOwner, types.GroupAdmin, types.GroupBasic, types.GroupAuthenticated},
 			},
 			expected: true,
 		},

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -172,7 +172,7 @@ func (b *Bootstrap) AuthenticateRequest(req *http.Request) (*authenticator.Respo
 		User: &user.DefaultInfo{
 			Name:   "bootstrap",
 			UID:    fmt.Sprintf("%d", gatewayUser.ID),
-			Groups: []string{types2.GroupOwner, types2.GroupAdmin, types2.GroupAuthenticated},
+			Groups: []string{types2.GroupOwner, types2.GroupAdmin, types2.GroupBasic, types2.GroupAuthenticated},
 		},
 	}, true, nil
 }


### PR DESCRIPTION
This will give the bootstrap user access to My Connectors and Chat pages.

Issue: https://github.com/obot-platform/obot/issues/4428