### PR TITLE
fix: stop giving bootstrap user power user grups

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -173,6 +173,9 @@ func (b *Bootstrap) AuthenticateRequest(req *http.Request) (*authenticator.Respo
 			Name:   "bootstrap",
 			UID:    fmt.Sprintf("%d", gatewayUser.ID),
 			Groups: []string{types2.GroupOwner, types2.GroupAdmin, types2.GroupBasic, types2.GroupAuthenticated},
+			Extra: map[string][]string{
+				"auth_provider_name": {"bootstrap"},
+			},
 		},
 	}, true, nil
 }

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -41,6 +41,11 @@ func ConvertUser(u *User, roleFixed bool, authProviderName string) *types2.User 
 		return nil
 	}
 
+	groups := u.Role.Groups()
+	if authProviderName == "bootstrap" {
+		groups = []string{types2.GroupOwner, types2.GroupAdmin, types2.GroupBasic, types2.GroupAuthenticated}
+	}
+
 	user := &types2.User{
 		Metadata: types2.Metadata{
 			ID:      fmt.Sprint(u.ID),
@@ -50,7 +55,7 @@ func ConvertUser(u *User, roleFixed bool, authProviderName string) *types2.User 
 		Username:                   u.Username,
 		Email:                      u.Email,
 		Role:                       u.Role,
-		Groups:                     u.Role.Groups(),
+		Groups:                     groups,
 		ExplicitRole:               roleFixed,
 		IconURL:                    u.IconURL,
 		Timezone:                   u.Timezone,


### PR DESCRIPTION
This ensures that the MCP Publisher page doesn't show for the bootstrap user.

Issue: https://github.com/obot-platform/obot/issues/4430