### PR TITLE
fix: revert broken events operation

### DIFF
--- a/ui/user/src/lib/services/chat/operations.ts
+++ b/ui/user/src/lib/services/chat/operations.ts
@@ -663,7 +663,7 @@ export async function listProjects(opts?: {
 }
 
 export function newMessageEventSource(
-	assistantID: string | undefined,
+	assistantID: string,
 	projectID: string,
 	opts?: {
 		authenticate?: {
@@ -702,13 +702,10 @@ export function newMessageEventSource(
 	}
 
 	const queryString = queryParams.length > 0 ? `?${queryParams.join('&')}` : '';
-	if (assistantID) {
-		return new EventSource(
-			baseURL +
-				`/assistants/${assistantID}/projects/${projectID}/threads/${opts?.threadID}/events${queryString}`
-		);
-	}
-	return new EventSource(baseURL + `/threads/${opts?.threadID}/events${queryString}`);
+	return new EventSource(
+		baseURL +
+			`/assistants/${assistantID}/projects/${projectID}/threads/${opts?.threadID}/events${queryString}`
+	);
 }
 
 export async function listTasks(assistantID: string, projectID: string): Promise<TaskList> {

--- a/ui/user/src/lib/services/chat/thread.svelte.ts
+++ b/ui/user/src/lib/services/chat/thread.svelte.ts
@@ -86,7 +86,7 @@ export class Thread {
 		const currentID = this.#count;
 		this.replayComplete = false;
 		let opened = false;
-		const es = newMessageEventSource(undefined, this.#project.id, {
+		const es = newMessageEventSource(this.#project.assistantID, this.#project.id, {
 			threadID: this.threadID,
 			task: this.#task,
 			runID: this.runID,


### PR DESCRIPTION
The fact that this was changed was a mistake. Reverting this back gives users access to their task events.

Issue: https://github.com/obot-platform/obot/issues/4432