### PR TITLE
fix: entra user display names

### DIFF
--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -315,6 +315,14 @@ func (c *Client) UpdateProfileIfNeeded(ctx context.Context, user *types.User, au
 		if displayName, ok := profile["name"].(string); ok {
 			user.DisplayName = displayName
 		}
+	case "entra-auth-provider":
+		if iconURL, ok := profile["icon_url"].(string); ok {
+			user.IconURL = iconURL
+			identity.IconURL = iconURL
+		}
+		if displayName, ok := profile["name"].(string); ok {
+			user.DisplayName = displayName
+		}
 	}
 	identity.IconLastChecked = time.Now()
 


### PR DESCRIPTION
Extract Entra display name field from `/obot-get-user-info` response.

Addresses part of https://github.com/obot-platform/obot/issues/4128

Depends on https://github.com/obot-platform/enterprise-tools/pull/68

