### PR TITLE
Fix: revert regenerate tool preview

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -456,21 +456,6 @@
 						{/if}
 					{/snippet}
 				</McpServerTools>
-				{#if entry && entry.manifest?.toolPreview && !readonly}
-					<div class="mt-4 flex justify-center">
-						<button
-							class="button-primary flex items-center gap-1 text-sm"
-							onclick={handleInitTemporaryInstance}
-							disabled={saving}
-						>
-							{#if saving}
-								<LoaderCircle class="size-4 animate-spin" />
-							{:else}
-								Regenerate Tool Preview
-							{/if}
-						</button>
-					</div>
-				{/if}
 			</div>
 		{:else if selected === 'access-control'}
 			{@render accessControlView()}


### PR DESCRIPTION
It looks like ivy already added this functionality and it will only show the regenerate tool button when server is updated but tools preview are not generated(which is better). So I am going to revert this change.

https://github.com/obot-platform/obot/issues/4120