### PR TITLE
fix: give auditor access to read all

### DIFF
--- a/pkg/api/handlers/projects.go
+++ b/pkg/api/handlers/projects.go
@@ -319,7 +319,7 @@ func (h *ProjectsHandler) ListProjects(req api.Context) error {
 		}
 	}
 
-	projects, err := h.getProjects(req, agent, req.UserIsAdmin() && req.URL.Query().Get("all") == "true")
+	projects, err := h.getProjects(req, agent, (req.UserIsAdmin() || req.UserIsAuditor()) && req.URL.Query().Get("all") == "true")
 	if err != nil {
 		return err
 	}

--- a/pkg/api/handlers/projectshare.go
+++ b/pkg/api/handlers/projectshare.go
@@ -93,7 +93,7 @@ func (h *ProjectShareHandler) ListShares(req api.Context) error {
 		fields          = kclient.MatchingFields{
 			"spec.template": "false",
 		}
-		all = req.UserIsAdmin() && req.URL.Query().Get("all") == "true"
+		all = (req.UserIsAdmin() || req.UserIsAuditor()) && req.URL.Query().Get("all") == "true"
 	)
 
 	if !all {

--- a/pkg/api/handlers/serverinstances.go
+++ b/pkg/api/handlers/serverinstances.go
@@ -34,7 +34,7 @@ func (h *ServerInstancesHandler) ListServerInstances(req api.Context) error {
 		instances v1.MCPServerInstanceList
 		err       error
 	)
-	if req.UserIsAdmin() && req.URL.Query().Get("all") == "true" {
+	if (req.UserIsAdmin() || req.UserIsAuditor()) && req.URL.Query().Get("all") == "true" {
 		err = req.List(&instances)
 	} else {
 		err = req.List(&instances, kclient.MatchingFields{


### PR DESCRIPTION
Auditor should have access to read all server instances, projects, and project shares.

Issue: https://github.com/obot-platform/obot/issues/4444