### PR TITLE
fix: show access control to power user plus

### DIFF
--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -74,7 +74,7 @@
 	let pathname = $state('');
 
 	let isBootStrapUser = $derived(profile.current.username === BOOTSTRAP_USER_ID);
-	let isAtLeastPowerUser = $derived(profile.current.groups.includes(Group.POWERUSER));
+	let isAtLeastPowerUserPlus = $derived(profile.current.groups.includes(Group.POWERUSER_PLUS));
 	let navLinks = $derived<NavLink[]>(
 		profile.current.hasAdminAccess?.() && !showUserLinks
 			? [
@@ -213,7 +213,7 @@
 						disabled: false,
 						collapsible: false
 					},
-					...(isAtLeastPowerUser
+					...(isAtLeastPowerUserPlus
 						? [
 								{
 									id: 'access-control',


### PR DESCRIPTION
Previously, power users were being shown a link to access control rules, but this should be reserved for power user plusses or above.

Issue: https://github.com/obot-platform/obot/issues/4467