### PR TITLE
fix: do not create needless ACR for power users

### DIFF
--- a/pkg/controller/handlers/poweruserworkspace/poweruserworkspace.go
+++ b/pkg/controller/handlers/poweruserworkspace/poweruserworkspace.go
@@ -177,9 +177,11 @@ func (h *Handler) cleanupWorkspaceForDemotionToPowerUser(ctx context.Context, cl
 			}
 		}
 
-		workspace.Status.DefaultAccessControlRuleGenerated = false
-		if err := client.Status().Update(ctx, &workspace); err != nil {
-			return err
+		if workspace.Status.DefaultAccessControlRuleGenerated {
+			workspace.Status.DefaultAccessControlRuleGenerated = false
+			if err := client.Status().Update(ctx, &workspace); err != nil {
+				return err
+			}
 		}
 
 		// Delete all MCPServers in this workspace

--- a/pkg/controller/handlers/poweruserworkspace/poweruserworkspace.go
+++ b/pkg/controller/handlers/poweruserworkspace/poweruserworkspace.go
@@ -230,13 +230,7 @@ func (h *Handler) createDefaultAccessControlRule(ctx context.Context, client kcl
 		}
 	}
 
-	// For power user plus and admin, generate rules that give all users access
-	subject := types.Subject{
-		Type: types.SubjectTypeSelector,
-		ID:   "*",
-	}
-
-	// Create the default access control rule
+	// For power user plus and admin, generate a rule that gives all users access
 	defaultACR := &v1.AccessControlRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    namespace,
@@ -248,7 +242,10 @@ func (h *Handler) createDefaultAccessControlRule(ctx context.Context, client kcl
 			Manifest: types.AccessControlRuleManifest{
 				DisplayName: "Default Access Rule",
 				Subjects: []types.Subject{
-					subject,
+					{
+						Type: types.SubjectTypeSelector,
+						ID:   "*",
+					},
 				},
 				Resources: []types.Resource{
 					{


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/4409

There is separate logic that already gives PUs access to things in their own PUW, so we don't need to create this default ACR for them anymore.