### PR TITLE
chore: separate catalog and workspace cleanup

### DIFF
--- a/pkg/accesscontrolrule/helper.go
+++ b/pkg/accesscontrolrule/helper.go
@@ -33,7 +33,7 @@ func (h *Helper) GetAccessControlRulesForUser(namespace, userID string) ([]v1.Ac
 	result := make([]v1.AccessControlRule, 0, len(acrs))
 	for _, acr := range acrs {
 		res, ok := acr.(*v1.AccessControlRule)
-		if ok && res.Namespace == namespace {
+		if ok && res.Namespace == namespace && res.DeletionTimestamp.IsZero() {
 			result = append(result, *res)
 		}
 	}
@@ -51,7 +51,7 @@ func (h *Helper) GetAccessControlRulesForMCPServer(namespace, serverName string)
 	result := make([]v1.AccessControlRule, 0, len(acrs))
 	for _, acr := range acrs {
 		res, ok := acr.(*v1.AccessControlRule)
-		if ok && res.Namespace == namespace {
+		if ok && res.Namespace == namespace && res.DeletionTimestamp.IsZero() {
 			result = append(result, *res)
 		}
 	}
@@ -69,7 +69,7 @@ func (h *Helper) GetAccessControlRulesForMCPServerCatalogEntry(namespace, entryN
 	result := make([]v1.AccessControlRule, 0, len(acrs))
 	for _, acr := range acrs {
 		res, ok := acr.(*v1.AccessControlRule)
-		if ok && res.Namespace == namespace {
+		if ok && res.Namespace == namespace && res.DeletionTimestamp.IsZero() {
 			result = append(result, *res)
 		}
 	}
@@ -87,7 +87,7 @@ func (h *Helper) GetAccessControlRulesForSelector(namespace, selector string) ([
 	result := make([]v1.AccessControlRule, 0, len(acrs))
 	for _, acr := range acrs {
 		res, ok := acr.(*v1.AccessControlRule)
-		if ok && res.Namespace == namespace {
+		if ok && res.Namespace == namespace && res.DeletionTimestamp.IsZero() {
 			result = append(result, *res)
 		}
 	}

--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -32,7 +32,7 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user us
 		if mcpServer.Spec.MCPCatalogID != "" {
 			return a.acrHelper.UserHasAccessToMCPServerInCatalog(user, resources.MCPID, mcpServer.Spec.MCPCatalogID)
 		} else if mcpServer.Spec.PowerUserWorkspaceID != "" {
-			return a.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.Context(), user, resources.MCPID, mcpServer.Spec.PowerUserWorkspaceID)
+			return a.acrHelper.UserHasAccessToMCPServerInWorkspace(user, resources.MCPID, mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Spec.UserID)
 		}
 
 		// For single-user MCP servers, ensure the user owns the server.

--- a/pkg/api/handlers/accesscontrolrules.go
+++ b/pkg/api/handlers/accesscontrolrules.go
@@ -137,6 +137,7 @@ func (h *AccessControlRuleHandler) Create(req api.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: system.AccessControlRulePrefix,
 			Namespace:    req.Namespace(),
+			Finalizers:   []string{v1.AccessControlRuleFinalizer},
 		},
 		Spec: v1.AccessControlRuleSpec{
 			Manifest:             manifest,

--- a/pkg/storage/apis/obot.obot.ai/v1/run.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/run.go
@@ -21,6 +21,7 @@ const (
 	ProjectMCPServerFinalizer  = "obot.obot.ai/project-mcp-server"
 	SlackReceiverFinalizer     = "obot.obot.ai/slack-receiver"
 	MCPSessionFinalizer        = "obot.obot.ai/mcp-session"
+	AccessControlRuleFinalizer = "obot.obot.ai/access-control-rule"
 
 	ModelProviderSyncAnnotation       = "obot.ai/model-provider-sync"
 	WorkflowSyncAnnotation            = "obot.ai/workflow-sync"


### PR DESCRIPTION
The clean up of unauthorized MCP servers and instances was a universal handler. This could cause slowdown as we list the world every time an MCP server or instance is changed.

This change separates cleanup for catalogs and workspaces in an effort to be more efficient.