### PR TITLE
fix: set created=true when creating a new identity

### DIFF
--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -285,6 +285,9 @@ func (c *Client) ensureIdentity(ctx context.Context, tx *gorm.DB, id *types.Iden
 			}
 		}
 	} else {
+		// Creating a new user
+		created = true
+
 		// Copy the user so we don't have to decrypt
 		u := *user
 		if err := c.encryptUser(ctx, &u); err != nil {


### PR DESCRIPTION
This bug was causing an issue where new users in Entra and Okta (who weren't given an explicit Owner role using the environment variables) were getting created with RoleUnknown instead of the proper default role.

for https://github.com/obot-platform/obot/issues/4469