### PR TITLE
fix: improve user and group loading logic

### DIFF
--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -88,7 +88,7 @@
 	});
 
 	$effect(() => {
-		// Prevent loading users and groups if we are in creation mode and onCreate callback is provided
+		// Prevent loading users and groups if acr has no subjects
 		if (!accessControlRule.subjects || accessControlRule.subjects?.length === 0) {
 			return;
 		}


### PR DESCRIPTION
Addresses #4160, #4558

- When ACR is empty, do not fetch users and groups data.