### PR TITLE
Fix: fix two more places we could be orphaning mcp servers

### DIFF
--- a/pkg/controller/handlers/cleanup/credentials.go
+++ b/pkg/controller/handlers/cleanup/credentials.go
@@ -167,6 +167,9 @@ func (c *Credentials) RemoveMCPCredentials(req router.Request, resp router.Respo
 	if mcpServer.Spec.MCPCatalogID != "" {
 		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.MCPCatalogID, mcpServer.Name)
 		scope = mcpServer.Spec.MCPCatalogID
+	} else if mcpServer.Spec.PowerUserWorkspaceID != "" {
+		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Name)
+		scope = mcpServer.Spec.PowerUserWorkspaceID
 	} else {
 		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)
 		scope = mcpServer.Spec.UserID

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -281,18 +281,18 @@ func deploymentID(server ServerConfig) string {
 // GenerateToolPreviews creates a temporary MCP server from a catalog entry, lists its tools,
 // then shuts it down and returns the tool preview data.
 func (sm *SessionManager) GenerateToolPreviews(ctx context.Context, tempMCPServer v1.MCPServer, serverConfig ServerConfig) ([]otypes.MCPServerTool, error) {
-	// Create MCP client and list tools
-	client, err := sm.ClientForServer(ctx, "system", tempMCPServer.Spec.Manifest.Name, tempMCPServer.Name, serverConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	// Ensure cleanup happens regardless of success or failure
 	defer func() {
 		if cleanupErr := sm.ShutdownServer(ctx, serverConfig); cleanupErr != nil {
 			log.Errorf("failed to clean up temporary instance %s: %v", tempMCPServer.Name, cleanupErr)
 		}
 	}()
+
+	// Create MCP client and list tools
+	client, err := sm.ClientForServer(ctx, "system", tempMCPServer.Spec.Manifest.Name, tempMCPServer.Name, serverConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	tools, err := client.ListTools(ctx)
 	if err != nil {


### PR DESCRIPTION
Fix two more places where we orphans mcp server

1. When generating tool preview failed(mcp server failed to connect), we orphan the mcp server launched from temp instance. This is because the cleanup defer is not reached when connection fails.

2. When launching a multi-user server as power user plus, we don't pass down scopes correctly and will not clean up mcp server when it is deleted. 

https://github.com/obot-platform/obot/issues/4607