### PR TITLE
fix: conditionally render input if header is required

### DIFF
--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -247,28 +247,30 @@
 						{/each}
 					{/if}
 					{#if form.headers && form.headers.length > 0}
-						{#each form.headers.filter((header) => header.required) as header, i (header.key)}
-							<div class="flex flex-col gap-1">
-								<span class="flex items-center gap-2">
-									<label for={header.key}>
-										{header.name}
-										{#if !header.required}
-											<span class="text-gray-400 dark:text-gray-600">(optional)</span>
-										{/if}
-									</label>
-									<InfoTooltip text={header.description} />
-								</span>
-								{#if header.sensitive}
-									<SensitiveInput name={header.name} bind:value={form.headers[i].value} />
-								{:else}
-									<input
-										type="text"
-										id={header.key}
-										bind:value={form.headers[i].value}
-										class="text-input-filled"
-									/>
-								{/if}
-							</div>
+						{#each form.headers as header, i (header.key)}
+							{#if header.required}
+								<div class="flex flex-col gap-1">
+									<span class="flex items-center gap-2">
+										<label for={header.key}>
+											{header.name}
+											{#if !header.required}
+												<span class="text-gray-400 dark:text-gray-600">(optional)</span>
+											{/if}
+										</label>
+										<InfoTooltip text={header.description} />
+									</span>
+									{#if header.sensitive}
+										<SensitiveInput name={header.name} bind:value={form.headers[i].value} />
+									{:else}
+										<input
+											type="text"
+											id={header.key}
+											bind:value={form.headers[i].value}
+											class="text-input-filled"
+										/>
+									{/if}
+								</div>
+							{/if}
 						{/each}
 					{/if}
 					{#if form.hostname}


### PR DESCRIPTION
* reverting the `.filter` on headers for configure form -- this is causing it to bind to the wrong headers[i].value on the form
* changed to just render the input if header.required is set (if not set, this is static header value and should not be supplied by the user)

Addresses bug in #3703 (https://acorn-io.slack.com/archives/C07P0EZR917/p1760038258907299)
Addresses #4592 