### PR TITLE
fix: remove / from MCP server names for nanobot

### DIFF
--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/gptscript-ai/gptscript/pkg/hash"
@@ -303,6 +304,7 @@ func (sm *SessionManager) GenerateToolPreviews(ctx context.Context, tempMCPServe
 }
 
 func constructNanobotYAML(name, command string, args []string, env map[string]string) (string, error) {
+	name = strings.ReplaceAll(name, "/", "-")
 	config := nanobotConfig{
 		Publish: nanobotConfigPublish{
 			MCPServers: []string{name},
@@ -325,7 +327,7 @@ func constructNanobotYAML(name, command string, args []string, env map[string]st
 }
 
 type nanobotConfig struct {
-	Publish    nanobotConfigPublish              `json:"publish,omitempty"`
+	Publish    nanobotConfigPublish              `json:"publish,omitzero"`
 	MCPServers map[string]nanobotConfigMCPServer `json:"mcpServers,omitempty"`
 }
 


### PR DESCRIPTION
Nanobot expects the server name to not have any forward-slashes in it because it uses forward-slashes for tool mapping. So, if the server name is something like @modelcontextprotocol/server-sequential-thinking, then nanobot will parse this as a server with name @modelcontextprotocol and a tool with name server-sequential-thinking.

This change will replace / with - and nanobot will correctly parse the config.

Issue: https://github.com/obot-platform/obot/issues/4603