### PR TITLE
fix: improve multilines ux for sensitive textarea component

### DIFF
--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -220,6 +220,7 @@
 										name={env.name}
 										bind:value={form.envs[i].value}
 										textarea={env.file}
+										growable
 									/>
 								{:else if env.file}
 									<textarea


### PR DESCRIPTION
Addresses #4563 

- Preserves all whitespace characters so original text and masked text break at the same point.
- Sync scroll position