### PR TITLE
Fix: Don't call update-url when mcp is remote and use fixedUrl

### DIFF
--- a/ui/user/src/lib/components/chat/McpServerRequirements.svelte
+++ b/ui/user/src/lib/components/chat/McpServerRequirements.svelte
@@ -213,7 +213,8 @@
 			if (
 				parent?.manifest.runtime === 'remote' &&
 				configureForm.url &&
-				parent.manifest.remoteConfig?.urlTemplate === undefined
+				parent.manifest.remoteConfig?.urlTemplate === undefined &&
+				server.manifest.remoteConfig?.fixedURL !== undefined
 			) {
 				await ChatService.updateRemoteMcpServerUrl(server.id, configureForm.url.trim());
 			}

--- a/ui/user/src/lib/components/mcp/MyMcpServers.svelte
+++ b/ui/user/src/lib/components/mcp/MyMcpServers.svelte
@@ -407,6 +407,7 @@
 					selectedEntryOrServer.parent &&
 					selectedEntryOrServer.parent.manifest.runtime === 'remote' &&
 					selectedEntryOrServer.parent.manifest.remoteConfig?.urlTemplate === undefined &&
+					selectedEntryOrServer.server.manifest.remoteConfig?.fixedURL !== undefined &&
 					configureForm.url
 				) {
 					await ChatService.updateRemoteMcpServerUrl(

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -292,6 +292,7 @@ export interface ContainerizedRuntimeConfig {
 export interface RemoteRuntimeConfig {
 	url: string;
 	headers?: MCPSubField[];
+	fixedURL?: string;
 	isTemplate?: boolean;
 }
 


### PR DESCRIPTION
We should not call update-url api when mcpServer is remote and use fixedUrl. This will cause backend to reject the request. 

https://github.com/obot-platform/obot/issues/4615