### PR TITLE
fix: create PUWs for owners on startup

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,7 +73,7 @@ func (c *Controller) PreStart(ctx context.Context) error {
 	}
 
 	// Ensure PowerUserWorkspaces exist for all admin users on startup
-	if err := c.adminWorkspaceHandler.EnsureAllAdminWorkspaces(ctx, c.services.StorageClient, system.DefaultNamespace); err != nil {
+	if err := c.adminWorkspaceHandler.EnsureAllAdminAndOwnerWorkspaces(ctx, c.services.StorageClient, system.DefaultNamespace); err != nil {
 		return fmt.Errorf("failed to ensure admin workspaces: %w", err)
 	}
 


### PR DESCRIPTION
This is a little bug that I came across while testing and figured I should just fix. We create PowerUserWorkspaces for admins on startup, but we didn't add this functionality for owners when we introduced them, so this fixes that. That way, owners can use the MCP Publisher just like admins can.