### PR TITLE
Fix: don't check for server.command

### DIFF
--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -230,10 +230,9 @@ func (sm *SessionManager) closeClients(id string) {
 // RestartServerDeployment restarts the server in the currently used backend, if the backend supports it.
 // If the backend does not support restarts, then an [ErrNotSupportedByBackend] error is returned.
 func (sm *SessionManager) RestartServerDeployment(ctx context.Context, server ServerConfig) error {
-	if server.Command == "" {
-		return nil
+	if server.Runtime == otypes.RuntimeRemote {
+		return otypes.NewErrBadRequest("cannot restart deployment for remote MCP server")
 	}
-
 	return sm.backend.restartServer(ctx, deploymentID(server))
 }
 


### PR DESCRIPTION
For restart deployment, we don't need to check for server.command anymore. This is because for built-in images from mcp-image the command will be built-in. Checking for empty command will fail to restart these deployment.

https://github.com/obot-platform/obot/issues/4580