### PR TITLE
chore: make server migrations easier

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2030,7 +2030,7 @@ func (m *MCPHandler) GetServerDetails(req api.Context) error {
 		mcpServerDisplayName = server.Name
 	}
 
-	details, err := m.mcpSessionManager.GetServerDetails(req.Context(), mcpServerDisplayName, server.Name, serverConfig)
+	details, err := m.mcpSessionManager.GetServerDetails(req.Context(), server.Spec.UserID, mcpServerDisplayName, server.Name, serverConfig)
 	if err != nil {
 		if nse := (*mcp.ErrNotSupportedByBackend)(nil); errors.As(err, &nse) {
 			return types.NewErrNotFound(nse.Error())
@@ -2123,7 +2123,7 @@ func (m *MCPHandler) StreamServerLogs(req api.Context) error {
 		mcpServerDisplayName = server.Name
 	}
 
-	logs, err := m.mcpSessionManager.StreamServerLogs(req.Context(), mcpServerDisplayName, server.Name, serverConfig)
+	logs, err := m.mcpSessionManager.StreamServerLogs(req.Context(), server.Spec.UserID, mcpServerDisplayName, server.Name, serverConfig)
 	if err != nil {
 		if nse := (*mcp.ErrNotSupportedByBackend)(nil); errors.As(err, &nse) {
 			return types.NewErrNotFound(nse.Error())

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -256,6 +256,7 @@ func (h *Handler) OnMessage(ctx context.Context, msg nmcp.Message) {
 
 	client, err = h.mcpSessionManager.ClientForMCPServerWithOptions(
 		ctx,
+		m.userID,
 		msg.Session.ID(),
 		m.mcpServer,
 		m.serverConfig,

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -49,7 +49,7 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(ctx context.Context, mcpServer 
 
 	go func() {
 		defer close(errChan)
-		_, err := f.mcpSessionManager.ClientForMCPServerWithOptions(ctx, "Obot OAuth Check", mcpServer, mcpServerConfig, nmcp.ClientOption{
+		_, err := f.mcpSessionManager.ClientForMCPServerWithOptions(ctx, userID, "Obot OAuth Check", mcpServer, mcpServerConfig, nmcp.ClientOption{
 			ClientName:       "Obot MCP OAuth",
 			OAuthRedirectURL: fmt.Sprintf("%s/oauth/mcp/callback", f.baseURL),
 			OAuthClientName:  "Obot MCP Gateway",

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -184,4 +184,5 @@ func (c *Controller) setupLocalK8sRoutes() {
 
 	deploymentHandler := deployment.New(c.services.MCPServerNamespace, c.services.Router.Backend())
 	c.localK8sRouter.Type(&appsv1.Deployment{}).HandlerFunc(deploymentHandler.UpdateMCPServerStatus)
+	c.localK8sRouter.Type(&appsv1.Deployment{}).HandlerFunc(deploymentHandler.CleanupOldIDs)
 }

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -16,8 +16,8 @@ import (
 const defaultContainerPort = 8099
 
 type backend interface {
-	ensureServerDeployment(ctx context.Context, server ServerConfig, id, mcpServerDisplayName, mcpServerName string) (ServerConfig, error)
-	transformConfig(ctx context.Context, id string, serverConfig ServerConfig) (*ServerConfig, error)
+	ensureServerDeployment(ctx context.Context, server ServerConfig, userID, mcpServerDisplayName, mcpServerName string) (ServerConfig, error)
+	transformConfig(ctx context.Context, serverConfig ServerConfig) (*ServerConfig, error)
 	streamServerLogs(ctx context.Context, id string) (io.ReadCloser, error)
 	getServerDetails(ctx context.Context, id string) (types.MCPServerDetails, error)
 	restartServer(ctx context.Context, id string) error

--- a/pkg/mcp/details.go
+++ b/pkg/mcp/details.go
@@ -11,35 +11,31 @@ import (
 // GetServerDetails will get the details of a specific MCP server based on its configuration, if the backend supports it.
 // If the server is remote, it will return an error as remote servers do not support this operation.
 // If the backend does not support the operation, it will return an [ErrNotSupportedByBackend] error.
-func (sm *SessionManager) GetServerDetails(ctx context.Context, mcpServerDisplayName, mcpServerName string, serverConfig ServerConfig) (types.MCPServerDetails, error) {
+func (sm *SessionManager) GetServerDetails(ctx context.Context, userID, mcpServerDisplayName, mcpServerName string, serverConfig ServerConfig) (types.MCPServerDetails, error) {
 	if serverConfig.Runtime == types.RuntimeRemote {
 		return types.MCPServerDetails{}, fmt.Errorf("getting server details is not supported for remote servers")
 	}
 
-	id := deploymentID(serverConfig)
-
-	_, err := sm.ensureDeployment(ctx, id, serverConfig, mcpServerDisplayName, mcpServerName)
+	_, err := sm.ensureDeployment(ctx, serverConfig, userID, mcpServerDisplayName, mcpServerName)
 	if err != nil {
 		return types.MCPServerDetails{}, err
 	}
 
-	return sm.backend.getServerDetails(ctx, id)
+	return sm.backend.getServerDetails(ctx, serverConfig.Scope)
 }
 
 // StreamServerLogs will stream the logs of a specific MCP server based on its configuration, if the backend supports it.
 // If the server is remote, it will return an error as remote servers do not support this operation.
 // If the backend does not support the operation, it will return an [ErrNotSupportedByBackend] error.
-func (sm *SessionManager) StreamServerLogs(ctx context.Context, mcpServerDisplayName, mcpServerName string, serverConfig ServerConfig) (io.ReadCloser, error) {
+func (sm *SessionManager) StreamServerLogs(ctx context.Context, userID, mcpServerDisplayName, mcpServerName string, serverConfig ServerConfig) (io.ReadCloser, error) {
 	if serverConfig.Runtime == types.RuntimeRemote {
 		return nil, fmt.Errorf("streaming logs is not supported for remote servers")
 	}
 
-	id := deploymentID(serverConfig)
-
-	_, err := sm.ensureDeployment(ctx, id, serverConfig, mcpServerDisplayName, mcpServerName)
+	_, err := sm.ensureDeployment(ctx, serverConfig, userID, mcpServerDisplayName, mcpServerName)
 	if err != nil {
 		return nil, err
 	}
 
-	return sm.backend.streamServerLogs(ctx, id)
+	return sm.backend.streamServerLogs(ctx, serverConfig.Scope)
 }

--- a/pkg/mcp/local.go
+++ b/pkg/mcp/local.go
@@ -18,17 +18,17 @@ func newLocalBackend() backend {
 	return &localBackend{}
 }
 
-func (*localBackend) ensureServerDeployment(_ context.Context, server ServerConfig, id, _, _ string) (ServerConfig, error) {
+func (*localBackend) ensureServerDeployment(_ context.Context, server ServerConfig, _, _, _ string) (ServerConfig, error) {
 	if server.Runtime == types.RuntimeContainerized {
 		// The containerized runtime is not supported when running servers locally.
 		return ServerConfig{}, &ErrNotSupportedByBackend{Feature: "containerized runtime", Backend: "local"}
 	}
 
-	return transformFileEnvVars(server, id)
+	return transformFileEnvVars(server, server.Scope)
 }
 
-func (*localBackend) transformConfig(_ context.Context, id string, server ServerConfig) (*ServerConfig, error) {
-	server, err := transformFileEnvVars(server, id)
+func (*localBackend) transformConfig(_ context.Context, server ServerConfig) (*ServerConfig, error) {
+	server, err := transformFileEnvVars(server, server.Scope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform file environment variables: %w", err)
 	}


### PR DESCRIPTION
Since we are using a hash of the server config for container and deployment names, it is possible to orphan these objects as the server configuration evolves.

This change will use a stable name for these objects so that they are updated rather than orphaned.