### PR TITLE
Fix: Rename everyone to 'All Obot Users'

### DIFF
--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -211,7 +211,7 @@
 
 					return {
 						id: subject.id,
-						displayName: subject.id === '*' ? 'Everyone' : subject.id,
+						displayName: subject.id === '*' ? 'All Obot Users' : subject.id,
 						type: 'Group'
 					};
 				})

--- a/ui/user/src/lib/components/admin/SearchUsers.svelte
+++ b/ui/user/src/lib/components/admin/SearchUsers.svelte
@@ -25,7 +25,7 @@
 	let filteredGroups = $state<OrgGroup[]>([]);
 
 	let filteredData = $derived.by(() => {
-		const everyoneGroup: OrgGroup = { id: '*', name: 'Everyone' };
+		const everyoneGroup: OrgGroup = { id: '*', name: 'All Obot Users' };
 		const shouldIncludeEveryone =
 			!searchNames.length || everyoneGroup.name.toLowerCase().includes(searchNames.toLowerCase());
 

--- a/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
+++ b/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
@@ -82,7 +82,7 @@
 	}
 
 	function convertToUserDisplayName(id: string) {
-		if (id === '*') return 'Everyone';
+		if (id === '*') return 'All Obot Users';
 		const user = userMap.get(id);
 		if (!user) return id;
 		return user.email ?? user.username ?? id;


### PR DESCRIPTION
Okta has a built-in group called "Everyone". So, our everyone and their
everyone appeared to be a dupe. Easiest fix is just to rename ours.

Signed-off-by: Craig Jellick <craig@acorn.io>
