### PR TITLE
Fix: Don't show two dollar signs on placeholder

### DIFF
--- a/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
@@ -161,7 +161,7 @@
 							)}
 							bind:value={remoteConfig.urlTemplate}
 							disabled={readonly}
-							placeholder="e.g. https://${'${API_HOST}'}/api/${'${VERSION}'}/endpoint"
+							placeholder={`e.g. https://$${'{API_HOST}'}/api/$${'{VERSION}'}/endpoint`}
 							oninput={() => {
 								onFieldChange?.('urlTemplate');
 							}}


### PR DESCRIPTION
This was rendering as a double dollar sign.

Signed-off-by: Craig Jellick <craig@acorn.io>
