### PR TITLE
Fix: disable client side sorting as server will return sorted order

### DIFF
--- a/ui/user/src/lib/components/navbar/Projects.svelte
+++ b/ui/user/src/lib/components/navbar/Projects.svelte
@@ -67,11 +67,7 @@
 				toggle(false);
 				return;
 			}
-			projects = (await ChatService.listProjects()).items.sort((a, b) => {
-				if (a.id === project.id) return -1;
-				if (b.id === project.id) return 1;
-				return b.created.localeCompare(a.created);
-			});
+			projects = (await ChatService.listProjects()).items;
 			toggle();
 		}}
 	>


### PR DESCRIPTION
The server now sorts project based on lastUsedTime so there is no need to sort project in client.

https://github.com/obot-platform/obot/issues/4032