### PR TITLE
Fix: Don't show Configuration Needed in chat

### DIFF
--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -166,7 +166,6 @@ var apiResources = map[string][]string{
 		"DELETE /api/mcp-servers/{mcpserver_id}",
 		"DELETE /api/mcp-servers/{mcpserver_id}/oauth",
 		"PUT	/api/mcp-servers/{mcpserver_id}/alias",
-		"POST   /api/mcp-servers/{mcpserver_id}/trigger-update",
 		"POST   /api/mcp-servers/{mcpserver_id}/update-url",
 		"POST   /api/mcp-servers/{mcpserver_id}/configure",
 		"POST   /api/mcp-servers/{mcpserver_id}/deconfigure",

--- a/ui/user/src/lib/components/edit/McpServers.svelte
+++ b/ui/user/src/lib/components/edit/McpServers.svelte
@@ -58,7 +58,7 @@
 	}
 
 	function shouldShowWarning(mcp: (typeof projectMCPs.items)[0]) {
-		if (mcp.needsURL || mcp.needsUpdate) {
+		if (mcp.needsURL) {
 			return true;
 		}
 
@@ -74,7 +74,7 @@
 	}
 
 	function warningTooltip(mcp: (typeof projectMCPs.items)[0]) {
-		if (mcp.needsURL || mcp.needsUpdate) return 'Configuration Required';
+		if (mcp.needsURL) return 'Configuration Required';
 		if (typeof mcp.configured === 'boolean' && mcp.configured === false)
 			return 'Configuration Required';
 		if (typeof mcp.authenticated === 'boolean' && mcp.authenticated === false)


### PR DESCRIPTION
We have been incorrectly showing "Configuration Needed" for MCP servers
that have needsUpdate set to true. Users cannot update their own
servers. Only admins can, so this just drops the needsUpdate check.
Also, it drops the route for updating a server from the Basic user role.
They are not able to call that (and logic in the handler itself prevents
it).

Signed-off-by: Craig Jellick <craig@acorn.io>
