### PR TITLE
fix: sign out the temp user after auth completes

### DIFF
--- a/pkg/api/handlers/setup/oauth_complete.go
+++ b/pkg/api/handlers/setup/oauth_complete.go
@@ -54,7 +54,7 @@ func (h *Handler) OAuthComplete(req api.Context) error {
 	http.Redirect(
 		req.ResponseWriter,
 		req.Request,
-		"/admin?setup=complete",
+		"/oauth2/sign_out?rd=/admin?setup=complete",
 		http.StatusFound,
 	)
 


### PR DESCRIPTION
This is to prevent getting 403s during the improved setup process.