### PR TITLE
fix: save url params when clicking view audit logs from deployments/registries view

### DIFF
--- a/ui/user/src/routes/admin/mcp-servers/DeploymentsView.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/DeploymentsView.svelte
@@ -398,9 +398,17 @@
 								<Power class="size-4" /> Restart Server
 							</button>
 						{/if}
-						<a href={auditLogsUrl} class="menu-button">
+						<button
+							onclick={(e) => {
+								e.stopPropagation();
+								const isCtrlClick = e.ctrlKey || e.metaKey;
+								setSearchParamsToLocalStorage(page.url.pathname, page.url.search);
+								openUrl(auditLogsUrl, isCtrlClick);
+							}}
+							class="menu-button"
+						>
 							<Captions class="size-4" /> View Audit Logs
-						</a>
+						</button>
 						{#if !readonly}
 							<button
 								class="menu-button-destructive"

--- a/ui/user/src/routes/admin/mcp-servers/RegistriesView.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/RegistriesView.svelte
@@ -175,9 +175,17 @@
 					{/snippet}
 
 					<div class="default-dialog flex min-w-max flex-col gap-1 p-2">
-						<a href={url} class="menu-button">
+						<button
+							onclick={(e) => {
+								e.stopPropagation();
+								const isCtrlClick = e.ctrlKey || e.metaKey;
+								setSearchParamsToLocalStorage(page.url.pathname, page.url.search);
+								openUrl(url, isCtrlClick);
+							}}
+							class="menu-button"
+						>
 							<Captions class="size-4" /> View Audit Logs
-						</a>
+						</button>
 						{#if d.editable && !readonly}
 							<button
 								class="menu-button-destructive"


### PR DESCRIPTION
Addresses follow up in #4688