### PR TITLE
fix: ensure clients are created for tool calls

### DIFF
--- a/pkg/mcp/runner.go
+++ b/pkg/mcp/runner.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 
 	"github.com/gptscript-ai/gptscript/pkg/engine"
-	"github.com/gptscript-ai/gptscript/pkg/types"
+	gtypes "github.com/gptscript-ai/gptscript/pkg/types"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/jwt/ephemeral"
 )
 
 // Run is responsible for calling MCP tools when the LLM requests their execution. This method is called by GPTScript.
-func (sm *SessionManager) Run(ctx engine.Context, _ chan<- types.CompletionStatus, tool types.Tool, input string) (string, error) {
+func (sm *SessionManager) Run(ctx engine.Context, _ chan<- gtypes.CompletionStatus, tool gtypes.Tool, input string) (string, error) {
 	fields := strings.Fields(tool.Instructions)
 	if len(fields) < 2 {
 		return "", fmt.Errorf("invalid mcp call, invalid number of fields in %s", tool.Instructions)
@@ -18,7 +20,7 @@ func (sm *SessionManager) Run(ctx engine.Context, _ chan<- types.CompletionStatu
 
 	id := fields[1]
 	clientScope := fields[2]
-	toolName, ok := strings.CutPrefix(fields[0], types.MCPInvokePrefix)
+	toolName, ok := strings.CutPrefix(fields[0], gtypes.MCPInvokePrefix)
 	if !ok {
 		return "", fmt.Errorf("invalid mcp call, invalid tool name in %s", tool.Instructions)
 	}
@@ -33,7 +35,35 @@ func (sm *SessionManager) Run(ctx engine.Context, _ chan<- types.CompletionStatu
 
 	session := sm.getClient(id, clientScope)
 	if session == nil {
-		return "", fmt.Errorf("session not found for MCP server %s, %s", id, clientScope)
+		// The session being nil here means that we don't have a client for this MCP server.
+		// This likely means that Obot was restarted between starting the run and making the tool call.
+		// Luckily, we have the metadata on the tool and can create a new client.
+		var serverConfig ServerConfig
+		err := json.Unmarshal([]byte(tool.MetaData["obot-server-config"]), &serverConfig)
+		if err != nil {
+			log.Errorf("failed to unmarshal server config: %v", err)
+			return "", fmt.Errorf("session not found for MCP server %s, %s", id, clientScope)
+		}
+
+		userID := tool.MetaData["obot-user-id"]
+
+		// Ephemeral tokens "expire" every time Obot restarts. Create a new one.
+		token, err := sm.ephemeralTokenService.NewToken(ephemeral.TokenContext{
+			UserID:     userID,
+			UserGroups: []string{types.GroupBasic},
+		})
+		if err != nil {
+			log.Errorf("failed to create token: %v", err)
+			return "", fmt.Errorf("session not found for MCP server %s, %s", id, clientScope)
+		}
+
+		serverConfig.Headers = []string{fmt.Sprintf("Authorization=Bearer %s", token)}
+
+		session, err = sm.ClientForServer(ctx.Ctx, userID, tool.MetaData["obot-server-display-name"], tool.MetaData["obot-project-mcp-server-name"], serverConfig)
+		if err != nil {
+			log.Errorf("failed to create session for MCP server %s, %s: %v", id, clientScope, err)
+			return "", fmt.Errorf("session not found for MCP server %s, %s", id, clientScope)
+		}
 	}
 
 	result, err := session.Call(ctx.Ctx, toolName, arguments)

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -278,11 +278,10 @@ func ServerToServerConfig(mcpServer v1.MCPServer, scope string, credEnv map[stri
 }
 
 func ProjectServerToConfig(tokenService *ephemeral.TokenService, projectMCPServer v1.ProjectMCPServer, baseURL, userID string, allowedTools ...string) (ServerConfig, error) {
-	tokenContext := ephemeral.TokenContext{
+	token, err := tokenService.NewToken(ephemeral.TokenContext{
 		UserID:     userID,
 		UserGroups: []string{types.GroupBasic},
-	}
-	token, err := tokenService.NewToken(tokenContext)
+	})
 	if err != nil {
 		return ServerConfig{}, fmt.Errorf("failed to create token: %w", err)
 	}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -442,7 +442,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		return nil, err
 	}
 
-	mcpLoader, err := mcp.NewSessionManager(ctx, mcpOAuthTokenStorage, config.Hostname, mcp.Options(config.MCPConfig), localK8sConfig, storageClient)
+	ephemeralTokenServer := &ephemeral.TokenService{}
+	mcpLoader, err := mcp.NewSessionManager(ctx, ephemeralTokenServer, mcpOAuthTokenStorage, config.Hostname, mcp.Options(config.MCPConfig), localK8sConfig, storageClient)
 	if err != nil {
 		return nil, err
 	}
@@ -609,9 +610,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	}
 
 	var (
-		ephemeralTokenServer = &ephemeral.TokenService{}
-		events               = events.NewEmitter(storageClient, gatewayClient)
-		invoker              = invoke.NewInvoker(
+		events  = events.NewEmitter(storageClient, gatewayClient)
+		invoker = invoke.NewInvoker(
 			storageClient,
 			gptscriptClient,
 			gatewayClient,


### PR DESCRIPTION
If Obot restarts between starting the run and making a tool call, then it is likely that we won't have a constructed client for the server.

This change puts the information we need on the tool definition to construct a new client on the fly in this case.

Issue: https://github.com/obot-platform/obot/issues/4094