### PR TITLE
fix: show webhook statuses in the UI

### DIFF
--- a/apiclient/types/mcpauditlog.go
+++ b/apiclient/types/mcpauditlog.go
@@ -20,7 +20,7 @@ type MCPAuditLog struct {
 	RequestBody               json.RawMessage `json:"requestBody,omitempty"`
 	ResponseBody              json.RawMessage `json:"responseBody,omitempty"`
 	ResponseStatus            int             `json:"responseStatus"`
-	WebhookStatuses           []WebhookStatus `json:"webhookStatus,omitempty"`
+	WebhookStatuses           []WebhookStatus `json:"webhookStatuses,omitempty"`
 	Error                     string          `json:"error,omitempty"`
 	ProcessingTimeMs          int64           `json:"processingTimeMs"`
 	SessionID                 string          `json:"sessionID,omitempty"`

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -193,7 +193,9 @@ func (h *Handler) OnMessage(ctx context.Context, msg nmcp.Message) {
 
 		if err != nil {
 			auditLog.Error = err.Error()
-			auditLog.ResponseStatus = http.StatusInternalServerError
+			if auditLog.ResponseStatus < http.StatusBadRequest {
+				auditLog.ResponseStatus = http.StatusInternalServerError
+			}
 
 			var oauthErr nmcp.AuthRequiredErr
 			if errors.As(err, &oauthErr) {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2947,7 +2947,7 @@ func schema_obot_platform_obot_apiclient_types_MCPAuditLog(ref common.ReferenceC
 							Format:  "int32",
 						},
 					},
-					"webhookStatus": {
+					"webhookStatuses": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
@@ -213,6 +213,24 @@
 					{@render noAuditorAccessInfo('Response Body')}
 				{/if}
 			{/if}
+
+			{#if shouldShowPayload}
+				{#if auditLog.webhookStatuses && auditLog.webhookStatuses.length > 0}
+					{@const statuses = JSON.stringify(auditLog.webhookStatuses, null, 2)}
+
+					<p class="translate-y-2 pt-4 text-base font-semibold">Webhook Statuses</p>
+					<div class="relative text-white">
+						<pre class="default-scrollbar-thin max-h-96 overflow-y-auto p-4">
+						<code class="language-json">{statuses}</code>
+					</pre>
+
+						<CopyButton
+							classes={{ button: 'absolute right-4 top-4 flex flex-col items-end text-current' }}
+							text={statuses}
+						/>
+					</div>
+				{/if}
+			{/if}
 		</div>
 	</div>
 </div>

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -338,6 +338,12 @@ export interface AuditLog {
 		prompts?: Record<string, unknown>[];
 		resources?: Record<string, unknown>[];
 	};
+	webhookStatuses?: {
+		type?: string;
+		url: string;
+		status: string;
+		message?: string;
+	}[];
 	error?: string;
 	sessionID?: string;
 	requestID?: string;


### PR DESCRIPTION
The webhook statuses will be shown in the UI, if there are any. Even if they were successful. I think this is good so you can see that the webhooks were called.

Success:
<img width="493" height="793" alt="Screenshot 2025-10-23 at 15 52 52" src="https://github.com/user-attachments/assets/e7f17baa-ef2e-4973-8db8-e7f9a71ebcb9" />

Error:
<img width="504" height="1134" alt="Screenshot 2025-10-23 at 15 54 39" src="https://github.com/user-attachments/assets/1c8ae06a-70e7-4032-9924-f9cffbd26a46" />

Issue: https://github.com/obot-platform/obot/issues/3666