### PR TITLE
fix: drop prefix from env vars in mcp catalog configuration

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -21,7 +21,6 @@
 	import CategorySelectInput from './CategorySelectInput.svelte';
 	import Select from '../Select.svelte';
 	import { profile } from '$lib/stores';
-	import InfoTooltip from '../InfoTooltip.svelte';
 
 	interface Props {
 		id?: string;


### PR DESCRIPTION
Addresses follow up https://github.com/obot-platform/obot/issues/4698#issuecomment-3438935665 for #4698 