### PR TITLE
fix: update chat link visibility for additional mcp-publisher routes & hide publisher item

### DIFF
--- a/ui/user/src/lib/components/navbar/Profile.svelte
+++ b/ui/user/src/lib/components/navbar/Profile.svelte
@@ -54,11 +54,18 @@
 	}
 
 	afterNavigate(() => {
-		const routesToShowChatLink = ['/mcp-servers', '/profile', '/mcp-publisher'];
+		const routesToShowChatLink = [
+			'/mcp-servers',
+			'/profile',
+			'/mcp-publisher',
+			'/mcp-publisher/access-control',
+			'/mcp-publisher/audit-logs',
+			'/mcp-publisher/usage'
+		];
 		inAdminRoute = window.location.pathname.includes('/admin');
 		showChatLink = routesToShowChatLink.includes(window.location.pathname) || inAdminRoute;
 		showMyMcpServersLink = window.location.pathname !== '/mcp-servers';
-		showMcpPublisherLink = window.location.pathname !== '/mcp-publisher';
+		showMcpPublisherLink = !window.location.pathname.startsWith('/mcp-publisher');
 	});
 
 	function navigateTo(path: string, asNewTab?: boolean) {


### PR DESCRIPTION
Addresses #4744

- Add missing chat item in profile in `/mcp-publisher`
- remove `/mcp-publisher` from profile popover when user is in `/mcp-publisher` route