### PR TITLE
chore: allow log access for user's MCP servers

### DIFF
--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -165,6 +165,7 @@ var apiResources = map[string][]string{
 		"POST   /api/mcp-servers",
 		"DELETE /api/mcp-servers/{mcpserver_id}",
 		"DELETE /api/mcp-servers/{mcpserver_id}/oauth",
+		"GET    /api/mcp-servers/{mcpserver_id}/logs",
 		"PUT	/api/mcp-servers/{mcpserver_id}/alias",
 		"POST   /api/mcp-servers/{mcpserver_id}/update-url",
 		"POST   /api/mcp-servers/{mcpserver_id}/configure",


### PR DESCRIPTION
If a user owns a single-user MCP server, then this change will allow them to access the logs. This helps for debugging purposes.

Issue: https://github.com/obot-platform/obot/issues/4182