### PR TITLE
fix: display group names rather than IDs when creating new MCP server

### DIFF
--- a/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
+++ b/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
@@ -99,7 +99,6 @@
 			return group.name ?? group.id ?? subject.id;
 		}
 
-		// subject.type === 'selector
 		if (subject.id === '*') return 'All Obot Users';
 		return '';
 	}


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/4197