### PR TITLE
fix: stop including deleted servers in user count

### DIFF
--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -26,8 +26,9 @@ func EnsureUserCount(req router.Request, _ router.Response) error {
 
 	uniqueUsers := make(map[string]struct{}, len(mcpServers.Items))
 	for _, server := range mcpServers.Items {
-		if server.Spec.UserID == "" {
+		if server.Spec.UserID == "" || !server.DeletionTimestamp.IsZero() {
 			// A server should always have a user ID, but if it doesn't, don't count it.
+			// Additionally, don't count servers that are being deleted.
 			continue
 		}
 

--- a/ui/user/src/routes/admin/mcp-servers/DeploymentsView.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/DeploymentsView.svelte
@@ -203,6 +203,9 @@
 	async function handleSingleDelete(server: MCPCatalogServer) {
 		if (server.catalogEntryID) {
 			await ChatService.deleteSingleOrRemoteMcpServer(server.id);
+			// Decrement the count of servers in the catalog
+			const entry = mcpServerAndEntries.entries.find((entry) => entry.id === server.catalogEntryID);
+			if (entry?.userCount) entry.userCount--;
 		} else {
 			// multi-user
 			if (server.powerUserWorkspaceID) {
@@ -210,6 +213,8 @@
 			} else {
 				await AdminService.deleteMCPCatalogServer(catalogId, server.id);
 			}
+			// Remove server from list
+			mcpServerAndEntries.servers = mcpServerAndEntries.servers.filter((s) => s.id !== server.id);
 		}
 	}
 


### PR DESCRIPTION
This also "refreshes" the UI so the content is up to date after deleting a server.

Issue: https://github.com/obot-platform/obot/issues/4790