### PR TITLE
fix: include one webhook status on failure

### DIFF
--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -524,13 +524,13 @@ func fireWebhooks(ctx context.Context, webhooks []mcp.Webhook, msg nmcp.Message,
 				Message: rpcError.Message,
 			})
 			rpcErrors = append(rpcErrors, rpcError)
+		} else {
+			auditLog.WebhookStatuses = append(auditLog.WebhookStatuses, gatewaytypes.MCPWebhookStatus{
+				Type:   webhookType,
+				URL:    webhook.URL,
+				Status: webhookStatus,
+			})
 		}
-
-		auditLog.WebhookStatuses = append(auditLog.WebhookStatuses, gatewaytypes.MCPWebhookStatus{
-			Type:   webhookType,
-			URL:    webhook.URL,
-			Status: webhookStatus,
-		})
 	}
 
 	switch len(rpcErrors) {


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/4800