### PR TITLE
fix: treat owners and admins separately when removing

### DIFF
--- a/pkg/gateway/client/error.go
+++ b/pkg/gateway/client/error.go
@@ -6,6 +6,12 @@ func (e *LastAdminError) Error() string {
 	return "last admin"
 }
 
+type LastOwnerError struct{}
+
+func (e *LastOwnerError) Error() string {
+	return "last owner"
+}
+
 type AlreadyExistsError struct {
 	name string
 }

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -136,6 +136,8 @@ func (s *Server) updateUser(apiContext api.Context) error {
 			status = http.StatusNotFound
 		} else if lae := (*client.LastAdminError)(nil); errors.As(err, &lae) {
 			status = http.StatusBadRequest
+		} else if loe := (*client.LastOwnerError)(nil); errors.As(err, &loe) {
+			status = http.StatusBadRequest
 		} else if ea := (*client.ExplicitRoleError)(nil); errors.As(err, &ea) {
 			status = http.StatusBadRequest
 		} else if ae := (*client.AlreadyExistsError)(nil); errors.As(err, &ae) {
@@ -218,6 +220,8 @@ func (s *Server) deleteUser(apiContext api.Context) (err error) {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			status = http.StatusNotFound
 		} else if lae := (*client.LastAdminError)(nil); errors.As(err, &lae) {
+			status = http.StatusBadRequest
+		} else if loe := (*client.LastOwnerError)(nil); errors.As(err, &loe) {
 			status = http.StatusBadRequest
 		}
 		return types2.NewErrHTTP(status, fmt.Sprintf("failed to delete user: %v", err))


### PR DESCRIPTION
We deleting or demoting a user that is an ownwer, we would allow it if there was another admin in the system. This is incorrect because it would be impossible for any users to be promoted to owner.

This change separates the owner check from the admin check to ensure there is always at least one owner.

Issue: https://github.com/obot-platform/obot/issues/4817