### PR TITLE
fix: stop counting deleted server instances

### DIFF
--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -258,7 +258,7 @@ func (*Handler) EnsureMCPServerInstanceUserCount(req router.Request, _ router.Re
 
 	uniqueUsers := make(map[string]struct{}, len(mcpServerInstances.Items))
 	for _, instance := range mcpServerInstances.Items {
-		if userID := instance.Spec.UserID; userID != "" {
+		if userID := instance.Spec.UserID; userID != "" && instance.DeletionTimestamp.IsZero() {
 			uniqueUsers[userID] = struct{}{}
 		}
 	}


### PR DESCRIPTION
This ensures that server counts are correct when a server instance gets deleted.