### PR TITLE
fix: add lazy loading and error handling for user icons in SearchUsers component

### DIFF
--- a/ui/user/src/lib/components/admin/SearchUsers.svelte
+++ b/ui/user/src/lib/components/admin/SearchUsers.svelte
@@ -141,6 +141,14 @@
 								src={item.iconURL}
 								alt={'username' in item ? item.username : item.name}
 								class="size-10 rounded-full"
+								loading="lazy"
+								onerror={(e) => {
+									const target = e.currentTarget as HTMLImageElement;
+									// Retry after delay or show fallback
+									setTimeout(() => {
+										target.src = item.iconURL ?? '';
+									}, 2000);
+								}}
 							/>
 						{:else if 'name' in item}
 							<div


### PR DESCRIPTION
Addresses #4808

- Lazy load images
- Retry after 2s if an error occurs.