### PR TITLE
fix: always call configure endpoint when launching composites

### DIFF
--- a/ui/user/src/lib/components/mcp/MyMcpServers.svelte
+++ b/ui/user/src/lib/components/mcp/MyMcpServers.svelte
@@ -433,12 +433,7 @@
 				manifest
 			});
 
-			const hasAnyConfig = Object.values(payload).some(
-				(v) => Object.keys(v.config || {}).length > 0
-			);
-			if (hasAnyConfig) {
-				await ChatService.configureCompositeMcpServer(created.id, payload);
-			}
+			await ChatService.configureCompositeMcpServer(created.id, payload);
 
 			const launchResponse = await ChatService.validateSingleOrRemoteMcpServerLaunched(created.id);
 			if (!launchResponse.success) {


### PR DESCRIPTION
When a component of a composite MCP server that requires config is disabled, but there are no other components that require configuration, the UI skips calling the configure endpoint for the composite. However, the configure endpoint is also used to disable MCP servers, so when this step is skipped, the server is never actually disabled and the subsequent call to the launch endpoint fails.

To fix this, always call the configure endpoint when launching composite MCP servers.

Addresses https://github.com/obot-platform/obot/issues/4872

