### PR TITLE
chore: allow tools to hit Obot server internally

### DIFF
--- a/pkg/api/handlers/agent.go
+++ b/pkg/api/handlers/agent.go
@@ -34,12 +34,14 @@ type AgentHandler struct {
 	mcpSessionManager *mcp.SessionManager
 	invoker           *invoke.Invoker
 	dispatcher        *dispatcher.Dispatcher
+	internalServerURL string
 	serverURL         string
 }
 
-func NewAgentHandler(tokenService *ephemeral.TokenService, dispatcher *dispatcher.Dispatcher, mcpSessionManager *mcp.SessionManager, invoker *invoke.Invoker, serverURL string) *AgentHandler {
+func NewAgentHandler(tokenService *ephemeral.TokenService, dispatcher *dispatcher.Dispatcher, mcpSessionManager *mcp.SessionManager, invoker *invoke.Invoker, serverURL string, port int) *AgentHandler {
 	return &AgentHandler{
 		serverURL:         serverURL,
+		internalServerURL: fmt.Sprintf("http://localhost:%d", port),
 		invoker:           invoker,
 		dispatcher:        dispatcher,
 		tokenService:      tokenService,
@@ -819,7 +821,7 @@ func (a *AgentHandler) Script(req api.Context) error {
 		}
 	}
 
-	renderedAgent, err := render.Agent(req.Context(), a.tokenService, a.mcpSessionManager, req.Storage, &agent, a.serverURL, render.AgentOptions{
+	renderedAgent, err := render.Agent(req.Context(), a.tokenService, a.mcpSessionManager, req.Storage, &agent, a.serverURL, a.internalServerURL, render.AgentOptions{
 		Thread: thread,
 		UserID: req.User.GetUID(),
 	})

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -20,7 +20,7 @@ func Router(services *services.Services) (http.Handler, error) {
 
 	oauthChecker := oauth.NewMCPOAuthHandlerFactory(services.ServerURL, services.MCPLoader, services.StorageClient, services.GPTClient, services.GatewayClient, services.MCPOAuthTokenStorage)
 
-	agents := handlers.NewAgentHandler(services.EphemeralTokenServer, services.ProviderDispatcher, services.MCPLoader, services.Invoker, services.ServerURL)
+	agents := handlers.NewAgentHandler(services.EphemeralTokenServer, services.ProviderDispatcher, services.MCPLoader, services.Invoker, services.ServerURL, services.HTTPPort)
 	assistants := handlers.NewAssistantHandler(services.ProviderDispatcher, services.Invoker, services.Events, services.Router.Backend())
 	tools := handlers.NewToolHandler(services.Invoker)
 	tasks := handlers.NewTaskHandler(services.Invoker, services.Events)

--- a/pkg/invoke/system.go
+++ b/pkg/invoke/system.go
@@ -64,7 +64,7 @@ func (i *Invoker) EphemeralThreadTask(ctx context.Context, thread *v1.Thread, to
 					Env:    agent.Spec.Manifest.Env,
 				},
 			},
-		}, i.serverURL, render.AgentOptions{
+		}, i.serverURL, i.internalServerURL, render.AgentOptions{
 			Thread: thread,
 		})
 		if err != nil {

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -16,12 +16,12 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 )
 
-func (sm *SessionManager) GPTScriptTools(ctx context.Context, tokenService *ephemeral.TokenService, projectMCPServer v1.ProjectMCPServer, userID, mcpServerDisplayName, serverURL string, allowedTools []string) ([]gptscript.ToolDef, error) {
+func (sm *SessionManager) GPTScriptTools(ctx context.Context, tokenService *ephemeral.TokenService, projectMCPServer v1.ProjectMCPServer, userID, mcpServerDisplayName, internalServerURL string, allowedTools []string) ([]gptscript.ToolDef, error) {
 	if mcpServerDisplayName == "" {
 		mcpServerDisplayName = projectMCPServer.Name
 	}
 
-	serverConfig, err := ProjectServerToConfig(tokenService, projectMCPServer, serverURL, userID, allowedTools...)
+	serverConfig, err := ProjectServerToConfig(tokenService, projectMCPServer, internalServerURL, userID, allowedTools...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert MCP server %s to server config: %w", mcpServerDisplayName, err)
 	}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -55,7 +55,7 @@ func stringAppend(first string, second ...string) string {
 	return strings.Join(append([]string{first}, second...), "\n\n")
 }
 
-func Agent(ctx context.Context, tokenService *ephemeral.TokenService, mcpSessionManager *mcp.SessionManager, db kclient.Client, agent *v1.Agent, serverURL string, opts AgentOptions) (RenderedAgent, error) {
+func Agent(ctx context.Context, tokenService *ephemeral.TokenService, mcpSessionManager *mcp.SessionManager, db kclient.Client, agent *v1.Agent, serverURL, internalServerURL string, opts AgentOptions) (RenderedAgent, error) {
 	var renderedAgent RenderedAgent
 	defer func() {
 		sort.Strings(renderedAgent.Env)
@@ -173,7 +173,7 @@ func Agent(ctx context.Context, tokenService *ephemeral.TokenService, mcpSession
 				mcpDisplayName = mcpServer.Spec.Alias
 			}
 
-			toolDefs, err := mcpSessionManager.GPTScriptTools(ctx, tokenService, projectMCPServer, opts.UserID, mcpDisplayName, serverURL, allowedTools)
+			toolDefs, err := mcpSessionManager.GPTScriptTools(ctx, tokenService, projectMCPServer, opts.UserID, mcpDisplayName, internalServerURL, allowedTools)
 			if err != nil {
 				if !opts.IgnoreMCPErrors {
 					return renderedAgent, fmt.Errorf("failed to populate tools for MCP server %q: %w", mcpDisplayName, err)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -125,6 +125,7 @@ type Services struct {
 	ToolRegistryURLs           []string
 	WorkspaceProviderType      string
 	ServerURL                  string
+	HTTPPort                   int
 	EmailServerName            string
 	DevUIPort                  int
 	UserUIPort                 int
@@ -728,6 +729,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		EncryptionConfig:      encryptionConfig,
 		WorkspaceProviderType: config.WorkspaceProviderType,
 		ServerURL:             config.Hostname,
+		HTTPPort:              config.HTTPListenPort,
 		DevUIPort:             devPort,
 		UserUIPort:            config.UserUIPort,
 		ToolRegistryURLs:      config.ToolRegistries,


### PR DESCRIPTION
Before this change, tools would use the public Obot URL. This is inefficient and causes issues with certain load balancers.

This change will provide a localhost URL for tools to use.