### PR TITLE
fix: hide composite component mcp server instances

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1927,6 +1927,20 @@ func (m *MCPHandler) deconfigureCompositeServer(req api.Context, compositeServer
 		}
 	}
 
+	// Delete any component MCPServerInstances created for this composite
+	var componentInstances v1.MCPServerInstanceList
+	if err := req.List(&componentInstances,
+		kclient.InNamespace(compositeServer.Namespace),
+		kclient.MatchingFields{"spec.compositeName": compositeServer.Name},
+	); err != nil {
+		return fmt.Errorf("failed to list component instances: %w", err)
+	}
+	for _, inst := range componentInstances.Items {
+		if err := req.Delete(&inst); err != nil {
+			return fmt.Errorf("failed to delete component instance %s: %w", inst.Name, err)
+		}
+	}
+
 	addExtractedEnvVars(&compositeServer)
 
 	var (

--- a/pkg/api/handlers/serverinstances.go
+++ b/pkg/api/handlers/serverinstances.go
@@ -47,8 +47,8 @@ func (h *ServerInstancesHandler) ListServerInstances(req api.Context) error {
 
 	convertedInstances := make([]types.MCPServerInstance, 0, len(instances.Items))
 	for _, instance := range instances.Items {
-		if instance.Spec.Template {
-			// Hide template instances from user list view
+		// Hide template and component instances from user list view
+		if instance.Spec.Template || instance.Spec.CompositeName != "" {
 			continue
 		}
 
@@ -218,6 +218,10 @@ func (h *ServerInstancesHandler) ListServerInstancesForServer(req api.Context) e
 
 	convertedInstances := make([]types.MCPServerInstance, 0, len(instances.Items))
 	for _, instance := range instances.Items {
+		// Hide component instances
+		if instance.Spec.CompositeName != "" {
+			continue
+		}
 		slug, err := slugForMCPServerInstance(req.Context(), req.Storage, instance)
 		if err != nil {
 			return fmt.Errorf("failed to determine slug for instance %s: %w", instance.Name, err)

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -625,7 +625,7 @@ func (h *Handler) DeleteUnauthorizedMCPServerInstancesForCatalog(req router.Requ
 				return fmt.Errorf("failed to check if user %s has access to MCP server %s: %w", instance.Spec.UserID, instance.Spec.MCPServerName, err)
 			}
 
-			if !hasAccess && server.Spec.CompositeName == "" {
+			if !hasAccess && instance.Spec.CompositeName == "" {
 				log.Infof("Deleting MCPServerInstance %q because it is no longer authorized to exist", instance.Name)
 				if err := req.Delete(&instance); err != nil {
 					return fmt.Errorf("failed to delete MCPServerInstance %s: %w", instance.Name, err)
@@ -690,7 +690,7 @@ func (h *Handler) DeleteUnauthorizedMCPServerInstancesForWorkspace(req router.Re
 				return fmt.Errorf("failed to check if user %s has access to MCP server %s: %w", instance.Spec.UserID, instance.Spec.MCPServerName, err)
 			}
 
-			if !hasAccess {
+			if !hasAccess && instance.Spec.CompositeName == "" {
 				log.Infof("Deleting MCPServerInstance %q because it is no longer authorized to exist", instance.Name)
 				if err := req.Delete(&instance); err != nil {
 					return fmt.Errorf("failed to delete MCPServerInstance %s: %w", instance.Name, err)

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserverinstance.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserverinstance.go
@@ -61,6 +61,7 @@ func (in *MCPServerInstance) FieldNames() []string {
 func (in *MCPServerInstance) DeleteRefs() []Ref {
 	return []Ref{
 		{ObjType: &MCPServer{}, Name: in.Spec.MCPServerName},
+		{ObjType: &MCPServer{}, Name: in.Spec.CompositeName},
 		{ObjType: &PowerUserWorkspace{}, Name: in.Spec.PowerUserWorkspaceID},
 	}
 }


### PR DESCRIPTION
For MCPServerInstances created as components of composite MCPServers:
- Add filters to remove them from API responses
- Add garbage collection for orphaned instances

Addresses https://github.com/obot-platform/obot/issues/4902

