### PR TITLE
fix: disable project sharing when a composite mcp server is present

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -270,10 +270,11 @@ type ProjectMCPServerManifest struct {
 type ProjectMCPServer struct {
 	Metadata
 	ProjectMCPServerManifest
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Icon        string `json:"icon"`
-	UserID      string `json:"userID"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Icon        string  `json:"icon"`
+	UserID      string  `json:"userID"`
+	Runtime     Runtime `json:"runtime,omitempty"`
 
 	// The following status fields are always copied from the MCPServer that this points to.
 	Configured  bool `json:"configured"`

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -49,6 +49,7 @@ func convertProjectMCPServer(projectServer *v1.ProjectMCPServer, mcpServer *v1.M
 		Description:              mcpServer.Spec.Manifest.Description,
 		Icon:                     mcpServer.Spec.Manifest.Icon,
 		UserID:                   projectServer.Spec.UserID,
+		Runtime:                  mcpServer.Spec.Manifest.Runtime,
 
 		// Default values to show to the user for shared servers:
 		Configured:  true,

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -7094,6 +7094,12 @@ func schema_obot_platform_obot_apiclient_types_ProjectMCPServer(ref common.Refer
 							Format:  "",
 						},
 					},
+					"runtime": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"configured": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The following status fields are always copied from the MCPServer that this points to.",

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -430,6 +430,7 @@ export interface ProjectMCP {
 	configured?: boolean;
 	needsUpdate?: boolean;
 	needsURL?: boolean;
+	runtime?: Runtime;
 }
 
 export interface Credential {


### PR DESCRIPTION
- Disable the create project share and upgrade project snapshot buttons until the
  composite server is removed from the project
- When disabled, display a tooltip on hover that explains that the
  project cannot be shared until the composite server is removed

Note: This is a stop-gap and support for composites in project shares
should be implemented in subsequent releases.

Addresses https://github.com/obot-platform/obot/issues/4814

