### PR TITLE
fix: calendar dialog cut off, tools dialog overflow & search not resetting in search mcps

### DIFF
--- a/ui/user/src/lib/components/Calendar.svelte
+++ b/ui/user/src/lib/components/Calendar.svelte
@@ -251,7 +251,10 @@
 	<dialog
 		use:clickOutside={[() => calendarPopover?.close(), true]}
 		bind:this={calendarPopover}
-		class={twMerge('default-dialog absolute z-50 min-w-[320px] p-4', classes?.calendar)}
+		class={twMerge(
+			'default-dialog absolute left-13 z-50 min-w-[320px] -translate-x-full p-4',
+			classes?.calendar
+		)}
 	>
 		<!-- Calendar Header -->
 		<div class={twMerge('mb-4 flex items-center justify-between', classes?.header)}>

--- a/ui/user/src/lib/components/admin/SearchMcpServers.svelte
+++ b/ui/user/src/lib/components/admin/SearchMcpServers.svelte
@@ -169,6 +169,7 @@
 					<Search
 						class="dark:bg-surface1 dark:border-surface3 shadow-inner dark:border"
 						onChange={(val) => (search = val)}
+						value={search}
 						placeholder="Search by name..."
 					/>
 				</div>

--- a/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
@@ -48,7 +48,7 @@
 		server. It may affect the LLM's ability to understand the tool so be careful when adjusting
 		these values.
 	</p>
-	<div class="relative flex flex-col gap-2 px-0.5">
+	<div class="relative flex flex-col gap-2 overflow-x-hidden px-0.5">
 		<div class="flex w-full justify-end">
 			<Toggle
 				checked={allToolsEnabled}


### PR DESCRIPTION
Some minor ui fixes as I was going through:

* fix calendar dialog being cut off at end of browser
<img width="698" height="908" alt="Screenshot 2025-11-07 at 10 52 33 AM" src="https://github.com/user-attachments/assets/ba9db4d4-1e77-405b-8b90-acbb6b601e56" />

* overflow horizontal scroll on composite tools dialog 
<img width="680" height="877" alt="Screenshot 2025-11-07 at 10 54 08 AM" src="https://github.com/user-attachments/assets/8c2e2fb3-0c42-4692-b79d-cf8695505f98" />

* searchbar in Search MCP servers not resetting after applying or closing
<img width="500" height="531" alt="Screenshot 2025-11-07 at 10 54 38 AM" src="https://github.com/user-attachments/assets/6c5013d9-c64f-406e-9e4a-ab13ed4f5865" />

