### PR TITLE
chore: disable populate tool previews button for composites

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -527,7 +527,7 @@
 								<button
 									class="button-primary flex items-center gap-1 text-sm"
 									onclick={handleInitTemporaryInstance}
-									disabled={saving}
+									disabled={saving || type === 'composite'}
 								>
 									{#if saving}
 										<LoaderCircle class="size-4 animate-spin" />
@@ -540,6 +540,9 @@
 										{#if type === 'remote'}
 											Click above to connect to the remote MCP server to populate capabilities and
 											tools.
+										{:else if type === 'composite'}
+											Support for populating composite MCP server capabilities and tools coming
+											soon.
 										{:else}
 											Click above to set up a temporary instance that will populate capabilities and
 											tools. Otherwise, tools will populate when the user first launches this


### PR DESCRIPTION
Populating tool previews for composite MCP servers isn't supported yet. Prevent users from clicking the `Populate Tool Previews` button until it is.

<img width="1461" height="630" alt="Screenshot 2025-11-07 at 11 51 16 AM" src="https://github.com/user-attachments/assets/24bbf40f-ef81-4c53-b51c-22c675925ab9" />

Related to: https://github.com/obot-platform/obot/issues/4796

