### PR TITLE
chore: add X-Content-Type-Options: nosniff header to API responses

### DIFF
--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -170,10 +170,6 @@ func (s *Server) Wrap(f api.HandlerFunc) http.HandlerFunc {
 			rw.Header().Set("Pragma", "no-cache")
 			rw.Header().Set("Expires", "0")
 			rw.Header().Set("X-Content-Type-Options", "nosniff")
-
-			if rw.Header().Get("Content-Type") == "" {
-				rw.Header().Set("Content-Type", "application/json")
-			}
 		}
 
 		err = f(api.Context{


### PR DESCRIPTION
This works this time because I am not force-adding the application/json Content-Type to everything.