### PR TITLE
fix: disable save button when composite has no mcp servers

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -946,7 +946,14 @@
 			<span class="text-sm font-medium text-red-500">Fill out all required fields</span>
 		{/if}
 		<button class="button flex items-center gap-1" onclick={() => onCancel?.()}> Cancel </button>
-		<button class="button-primary flex items-center gap-1" onclick={handleSubmit}>
+		<button
+			class="button-primary flex items-center gap-1"
+			onclick={handleSubmit}
+			disabled={loading ||
+				(formData.runtime === 'composite' &&
+					(!formData.compositeConfig?.componentServers ||
+						formData.compositeConfig.componentServers.length === 0))}
+		>
 			{#if loading}
 				<LoaderCircle class="size-4 animate-spin" />
 			{:else}


### PR DESCRIPTION
Disable the save/update button when configuring composite catalog entries until at least one MCP server is present in the form.

Addresses:
- https://github.com/obot-platform/obot/issues/4974
- https://github.com/obot-platform/obot/issues/4965
- https://github.com/obot-platform/obot/issues/4964
