### PR TITLE
enhance: deployment backends: use new deployServer function to deploy without waiting

### DIFF
--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -16,7 +16,10 @@ import (
 const defaultContainerPort = 8099
 
 type backend interface {
+	// ensureServerDeployment will deploy a server if it is not already deployed, and return the updated ServerConfig
 	ensureServerDeployment(ctx context.Context, server ServerConfig, userID, mcpServerDisplayName, mcpServerName string) (ServerConfig, error)
+	// deployServer will deploy a server if it is not already deployed, and will not wait or do any readiness checks
+	deployServer(ctx context.Context, server ServerConfig, userID, mcpServerDisplayName, mcpServerName string) error
 	transformConfig(ctx context.Context, serverConfig ServerConfig) (*ServerConfig, error)
 	streamServerLogs(ctx context.Context, id string) (io.ReadCloser, error)
 	getServerDetails(ctx context.Context, id string) (types.MCPServerDetails, error)

--- a/pkg/mcp/local.go
+++ b/pkg/mcp/local.go
@@ -18,6 +18,12 @@ func newLocalBackend() backend {
 	return &localBackend{}
 }
 
+func (l *localBackend) deployServer(ctx context.Context, server ServerConfig, userID string, mcpServerDisplayName, mcpServerName string) error {
+	// The local backend's ensureServerDeployment function doesn't wait for readiness, so we can just return its result
+	_, err := l.ensureServerDeployment(ctx, server, userID, mcpServerDisplayName, mcpServerName)
+	return err
+}
+
 func (*localBackend) ensureServerDeployment(_ context.Context, server ServerConfig, _, _, _ string) (ServerConfig, error) {
 	if server.Runtime == types.RuntimeContainerized {
 		// The containerized runtime is not supported when running servers locally.


### PR DESCRIPTION
This will allow users to fetch logs and deployment details for their servers before they are ready, making debugging easier.