### PR TITLE
fix: block deletion of multi-user servers with dependent composites

### DIFF
--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -138,6 +138,10 @@ func (r *Context) Write(obj any) error {
 	return r.write(obj, http.StatusOK)
 }
 
+func (r *Context) WriteCode(obj any, code int) error {
+	return r.write(obj, code)
+}
+
 func (r *Context) write(obj any, code int) error {
 	if data, ok := obj.([]byte); ok {
 		r.ResponseWriter.Header().Set("Content-Type", "application/octet-stream")

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -46,6 +46,8 @@ func (in *MCPServer) Get(field string) (value string) {
 		return strconv.FormatBool(in.Spec.Template)
 	case "spec.compositeName":
 		return in.Spec.CompositeName
+	case "spec.manifest.runtime":
+		return string(in.Spec.Manifest.Runtime)
 	}
 	return ""
 }
@@ -59,6 +61,7 @@ func (in *MCPServer) FieldNames() []string {
 		"spec.powerUserWorkspaceID",
 		"spec.template",
 		"spec.compositeName",
+		"spec.manifest.runtime",
 	}
 }
 

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
@@ -37,6 +37,8 @@ func (in *MCPServerCatalogEntry) Get(field string) string {
 		return in.Spec.MCPCatalogName
 	case "spec.powerUserWorkspaceID":
 		return in.Spec.PowerUserWorkspaceID
+	case "spec.manifest.runtime":
+		return string(in.Spec.Manifest.Runtime)
 	}
 	return ""
 }
@@ -45,6 +47,7 @@ func (in *MCPServerCatalogEntry) FieldNames() []string {
 	return []string{
 		"spec.mcpCatalogName",
 		"spec.powerUserWorkspaceID",
+		"spec.manifest.runtime",
 	}
 }
 


### PR DESCRIPTION
Return a `409 Conflict` error when a user tries to delete a multi-user server that is in use by any composite catalog entry or running server.
Include a list of reference to the dependents in the response to make it easier for the UI to construct actionable dialogs based on the error.

Addresses backend changes for: https://github.com/obot-platform/obot/issues/4967

