### PR TITLE
chore: remove unneeded CreatedAt field from the Group type

### DIFF
--- a/pkg/gateway/types/group.go
+++ b/pkg/gateway/types/group.go
@@ -22,9 +22,6 @@ type Group struct {
 
 	// IconURL is the URL of the group's icon.
 	IconURL *string `json:"iconURL"`
-
-	// CreatedAt is the time the group was created.
-	CreatedAt time.Time `json:"createdAt" gorm:"autoCreateTime"`
 }
 
 // GroupMemberships represents a user's membership in a group.


### PR DESCRIPTION
Groups are only persisted in the database if a user belongs to them. There was no need for a `CreatedAt` field for them