### PR TITLE
fix: trim prefix to parse client credentials

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -50,7 +50,7 @@ func (h *handler) token(req api.Context) error {
 	var clientSecret string
 	clientID := req.FormValue("client_id")
 	if clientID == "" {
-		creds := strings.Trim(req.Request.Header.Get("Authorization"), "Basic ")
+		creds := strings.TrimPrefix(req.Request.Header.Get("Authorization"), "Basic ")
 		if creds == "" {
 			return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
 		}


### PR DESCRIPTION
Trimming "Basic" instead of trimming the prefix would mean we would remove characters and decoding the base64 encoded string would fail.

Issue: https://github.com/obot-platform/obot/issues/5093