### PR TITLE
fix: ensure tool overrides are properly applied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ catalog.json
 
 # Ignore zed files
 .zed/
+__debug_*
 
 .claude/
 CLAUDE.md

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -133,7 +133,7 @@ config:
   # config.OBOT_SERVER_MCPBASE_IMAGE -- Deploy MCP servers in the cluster using this base image. OBOT_SERVER_MCPNAMESPACE is automatically added to the secret if config.OBOT_SERVER_MCPBASE_IMAGE is set.
   OBOT_SERVER_MCPBASE_IMAGE: "ghcr.io/obot-platform/mcp-images/phat:main"
   # config.OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE -- Deploy MCP remote shim servers in the cluster using this base image.
-  OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE: "ghcr.io/nanobot-ai/nanobot:v0.0.34"
+  OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE: "ghcr.io/nanobot-ai/nanobot:v0.0.35"
   # config.OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE -- Deploy MCP HTTP webhook servers in the cluster using this base image.
   OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE: "ghcr.io/obot-platform/mcp-images/http-webhook-converter:main"
   # config.OBOT_SERVER_MCPCLUSTER_DOMAIN -- The cluster domain to use for MCP services. Defaults to cluster.local. Only matters if the above image is set.

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -33,7 +33,7 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_AUDIT_LOGS_COMPRESS_FILE` | Controls whether or not to compress audit log files | `true` |
 | `OBOT_SERVER_AUDIT_LOGS_USE_PATH_STYLE` | Whether to use path style for S3 | - |
 | `OBOT_SERVER_MCPBASE_IMAGE` | Deploy MCP servers in the kubernetes cluster or using docker with this base image. | `ghcr.io/obot-platform/mcp-images/phat:main` |
-| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.34` |
+| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.35` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-converter:main` |
 | `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker, kubernetes, or local. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -176,16 +176,18 @@ func webhookToServerConfig(webhook Webhook, baseImage, mcpServerName, userID, sc
 
 func constructNanobotYAMLForCompositeServer(servers []ComponentServer) (string, error) {
 	mcpServers := make(map[string]nanobotConfigMCPServer, len(servers))
-	tools := make(map[string]toolOverride, len(servers))
 	names := make([]string, 0, len(servers))
 	replacer := strings.NewReplacer("/", "-", ":", "-", "?", "-")
 
 	for _, component := range servers {
+		tools := make(map[string]toolOverride, len(component.Tools))
 		for _, tool := range component.Tools {
+			if !tool.Enabled {
+				continue
+			}
 			tools[tool.Name] = toolOverride{
 				Name:        tool.OverrideName,
 				Description: tool.OverrideDescription,
-				Disabled:    !tool.Enabled,
 			}
 		}
 
@@ -276,5 +278,4 @@ type nanobotConfigMCPServer struct {
 type toolOverride struct {
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	Disabled    bool   `json:"disabled,omitempty"`
 }

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -208,7 +208,10 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 	// Check if container already exists
 	existing, err := d.getContainer(ctx, server.MCPServerName)
 	if err == nil && existing != nil {
-		if existing.Labels["mcp.config.hash"] != configHash || existing.NetworkSettings == nil || existing.NetworkSettings.Networks[d.network] == nil {
+		if existing.Labels["mcp.config.hash"] != configHash ||
+			existing.NetworkSettings == nil ||
+			existing.NetworkSettings.Networks[d.network] == nil ||
+			(server.Runtime == otypes.RuntimeRemote || server.Runtime == otypes.RuntimeComposite) && existing.Image != d.remoteShimBaseImage {
 			// Clear the state. The below logic will remove and recreate the container.
 			existing.State = ""
 		}

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -28,7 +28,7 @@ var log = logger.Package()
 type Options struct {
 	MCPBaseImage            string   `usage:"The base image to use for MCP containers" default:"ghcr.io/obot-platform/mcp-images/phat:main"`
 	MCPHTTPWebhookBaseImage string   `usage:"The base image to use for HTTP-based MCP webhook containers" default:"ghcr.io/obot-platform/mcp-images/http-webhook-converter:main"`
-	MCPRemoteShimBaseImage  string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.34"`
+	MCPRemoteShimBaseImage  string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.35"`
 	MCPNamespace            string   `usage:"The namespace to use for MCP containers" default:"obot-mcp"`
 	MCPClusterDomain        string   `usage:"The cluster domain to use for MCP containers" default:"cluster.local"`
 	DisallowLocalhostMCP    bool     `usage:"Allow MCP containers to run on localhost"`


### PR DESCRIPTION
This change also includes an image bump for the remote shim that makes tool overrides static. Meaning, only tools specified in the tool overrides are enabled for a sever. Empty overrides means all tools, including any new tools that are added by the server, are enabled.

Issue: https://github.com/obot-platform/obot/issues/5088