### PR TITLE
fix: stop redeploying multi-user for other users

### DIFF
--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -315,7 +315,8 @@ func (sm *SessionManager) ensureDeployment(ctx context.Context, server ServerCon
 }
 
 func clientID(server ServerConfig) string {
-	// The allowed tools aren't part of the client ID.
+	// The user ID and scope is not part of the client ID.
+	server.UserID = ""
 	return "mcp" + hash.Digest(server)
 }
 


### PR DESCRIPTION
Prior to this change, we would redeploy a multi-user server every time a different user used it. This change fixes that.