### PR TITLE
fix: ui: make the k8s settings less confusing

### DIFF
--- a/ui/user/src/routes/admin/server-scheduling/+page.svelte
+++ b/ui/user/src/routes/admin/server-scheduling/+page.svelte
@@ -271,7 +271,7 @@
 								bind:value={resourceInfo.requests.cpu}
 								class="text-input-filled dark:bg-black"
 								disabled={readonly}
-								placeholder="Default: Unset"
+								placeholder="example: 500m"
 							/>
 						</div>
 						<div class="flex flex-1 flex-col gap-1">
@@ -282,7 +282,7 @@
 								bind:value={resourceInfo.limits.cpu}
 								class="text-input-filled dark:bg-black"
 								disabled={readonly}
-								placeholder="Default: Unset"
+								placeholder="example: 1"
 							/>
 						</div>
 					</div>
@@ -296,7 +296,7 @@
 								bind:value={resourceInfo.requests.memory}
 								class="text-input-filled dark:bg-black"
 								disabled={readonly}
-								placeholder="Default: 400Mi"
+								placeholder="example: 512Mi"
 							/>
 						</div>
 						<div class="flex flex-1 flex-col gap-1">
@@ -307,7 +307,7 @@
 								bind:value={resourceInfo.limits.memory}
 								class="text-input-filled dark:bg-black"
 								disabled={readonly}
-								placeholder="Default: Unset"
+								placeholder="example: 1Gi"
 							/>
 						</div>
 					</div>


### PR DESCRIPTION
Here is what this change looks like:

<img width="1304" height="372" alt="image" src="https://github.com/user-attachments/assets/3a81f5b7-16b0-495c-84b8-50e67186b3b0" />


I believe the current state of the UI, with `default: 400Mi` in the memory request, is confusing. This default is only set if there are no k8s settings at all. It could confuse the user into thinking that, if they set CPU settings, the 400Mi memory request will still be there, even though that would actually get dropped, and there would be no memory request. So instead, I just provided examples in each box. This will also help the user use the correct unit suffixes.

Related to https://github.com/obot-platform/obot/issues/4999