### PR TITLE
fix: stop storing OAuth client name on MCP server

### DIFF
--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -120,8 +120,6 @@ type MCPServerSpec struct {
 }
 
 type MCPServerStatus struct {
-	// OAuthClientName is the OAuth client for this MCP server for token exchange.
-	OAuthClientName string `json:"oauthClientName,omitempty"`
 	// NeedsUpdate indicates whether the configuration in this server's catalog entry has drift from this server's configuration.
 	NeedsUpdate bool `json:"needsUpdate,omitempty"`
 	// MCPServerInstanceUserCount contains the number of unique users with server instances pointing to this MCP server.

--- a/pkg/storage/apis/obot.obot.ai/v1/oauthclient.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/oauthclient.go
@@ -1,11 +1,17 @@
 package v1
 
 import (
+	"slices"
+
+	"github.com/obot-platform/nah/pkg/fields"
 	"github.com/obot-platform/obot/apiclient/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ DeleteRefs = (*OAuthClient)(nil)
+var (
+	_ DeleteRefs    = (*OAuthClient)(nil)
+	_ fields.Fields = (*OAuthClient)(nil)
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -23,6 +29,22 @@ func (o *OAuthClient) DeleteRefs() []Ref {
 			Name:    o.Spec.MCPServerName,
 		},
 	}
+}
+
+func (o *OAuthClient) Has(field string) bool {
+	return slices.Contains(o.FieldNames(), field)
+}
+
+func (o *OAuthClient) Get(field string) (value string) {
+	switch field {
+	case "spec.mcpServerName":
+		return o.Spec.MCPServerName
+	}
+	return ""
+}
+
+func (*OAuthClient) FieldNames() []string {
+	return []string{"spec.mcpServerName"}
 }
 
 type OAuthClientSpec struct {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -13978,13 +13978,6 @@ func schema_storage_apis_obotobotai_v1_MCPServerStatus(ref common.ReferenceCallb
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"oauthClientName": {
-						SchemaProps: spec.SchemaProps{
-							Description: "OAuthClientName is the OAuth client for this MCP server for token exchange.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"needsUpdate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NeedsUpdate indicates whether the configuration in this server's catalog entry has drift from this server's configuration.",


### PR DESCRIPTION
This could create 409s in the API. Just store the information on the OAuth client object. In this change, we do ensure that we use an uncached list to verify that we haven't created the OAuth client already.

Issue: https://github.com/obot-platform/obot/issues/5108