### PR TITLE
fix: address race when restarting containers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3
-	github.com/MicahParks/jwkset v0.9.6
+	github.com/MicahParks/jwkset v0.11.0
 	github.com/adhocore/gronx v1.19.5
 	github.com/adrg/xdg v0.5.3
 	github.com/aws/aws-sdk-go-v2 v1.39.4
@@ -38,7 +38,7 @@ require (
 	github.com/moby/moby/api v1.52.0-alpha.1
 	github.com/moby/moby/client v0.1.0-alpha.0
 	github.com/modelcontextprotocol/go-sdk v0.2.0
-	github.com/nanobot-ai/nanobot v0.0.33-0.20251112194315-68a723817fb1
+	github.com/nanobot-ai/nanobot v0.0.37
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037
 	github.com/obot-platform/kinm v0.0.0-20250905213846-3c65d6845f83
 	github.com/obot-platform/nah v0.0.0-20250418220644-1b9278409317
@@ -102,6 +102,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.5.0 // indirect
 	github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
+	github.com/MicahParks/keyfunc/v3 v3.7.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,10 @@ github.com/MarvinJWendt/testza v0.5.2 h1:53KDo64C1z/h/d/stCYCPY69bt/OSwjq5KpFNwi
 github.com/MarvinJWendt/testza v0.5.2/go.mod h1:xu53QFE5sCdjtMCKk8YMQ2MnymimEctc4n3EjyIYvEY=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
-github.com/MicahParks/jwkset v0.9.6 h1:Tf8l2/MOby5Kh3IkrqzThPQKfLytMERoAsGZKlyYZxg=
-github.com/MicahParks/jwkset v0.9.6/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.7.0 h1:pdafUNyq+p3ZlvjJX1HWFP7MA3+cLpDtg69U3kITJGM=
+github.com/MicahParks/keyfunc/v3 v3.7.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
@@ -569,8 +571,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/nanobot-ai/nanobot v0.0.33-0.20251112194315-68a723817fb1 h1:qQ9xGllkWKzQNgypZxRrCPfNKZ7QxEJIfsnafmWj7wk=
-github.com/nanobot-ai/nanobot v0.0.33-0.20251112194315-68a723817fb1/go.mod h1:MZc8KYWTB982B3R9KFKKv4B5DWhGbs4Y7LKnXcBhDoc=
+github.com/nanobot-ai/nanobot v0.0.37 h1:b5LtTdfXsyqWogAeqlwv6L48haFwY9AUdkpcxwmZVRI=
+github.com/nanobot-ai/nanobot v0.0.37/go.mod h1:nA7TiHzmJUue6NFJkCEKFT6egyzz1HczdFM/fKxHEoE=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -107,12 +107,14 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(req api.Context, mcpServer v1.M
 	go func() {
 		defer close(errChan)
 		_, err := f.mcpSessionManager.ClientForMCPServerForOAuthCheck(req.Context(), "Obot OAuth Check", mcpServerConfig, nmcp.ClientOption{
-			ClientName:       "Obot MCP OAuth",
-			OAuthRedirectURL: fmt.Sprintf("%s/oauth/mcp/callback", f.baseURL),
-			OAuthClientName:  "Obot MCP Gateway",
-			CallbackHandler:  oauthHandler,
-			ClientCredLookup: oauthHandler,
-			TokenStorage:     f.tokenStore.ForUserAndMCP(oauthHandler.userID, oauthHandler.mcpID),
+			ClientName: "Obot MCP OAuth",
+			HTTPClientOptions: nmcp.HTTPClientOptions{
+				OAuthRedirectURL: fmt.Sprintf("%s/oauth/mcp/callback", f.baseURL),
+				OAuthClientName:  "Obot MCP Gateway",
+				CallbackHandler:  oauthHandler,
+				ClientCredLookup: oauthHandler,
+				TokenStorage:     f.tokenStore.ForUserAndMCP(oauthHandler.userID, oauthHandler.mcpID),
+			},
 		})
 		if err != nil {
 			errChan <- fmt.Errorf("failed to get client for server %s: %v", mcpServer.Name, err)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -16,6 +16,10 @@ import (
 )
 
 func (sm *SessionManager) GPTScriptTools(ctx context.Context, projectMCPServer v1.ProjectMCPServer, userID, mcpServerDisplayName, internalServerURL, serverURL string, allowedTools []string) ([]gptscript.ToolDef, error) {
+	return sm.gptScriptTools(ctx, projectMCPServer, userID, mcpServerDisplayName, internalServerURL, serverURL, allowedTools, true)
+}
+
+func (sm *SessionManager) gptScriptTools(ctx context.Context, projectMCPServer v1.ProjectMCPServer, userID, mcpServerDisplayName, internalServerURL, serverURL string, allowedTools []string, retry bool) ([]gptscript.ToolDef, error) {
 	if mcpServerDisplayName == "" {
 		mcpServerDisplayName = projectMCPServer.Name
 	}
@@ -37,6 +41,11 @@ func (sm *SessionManager) GPTScriptTools(ctx context.Context, projectMCPServer v
 
 	tools, err := client.ListTools(ctx)
 	if err != nil {
+		if retry {
+			sm.closeClient(serverConfig, "default")
+			return sm.gptScriptTools(ctx, projectMCPServer, userID, mcpServerDisplayName, internalServerURL, serverURL, allowedTools, false)
+		}
+
 		return nil, determineError(err, mcpServerDisplayName)
 	}
 


### PR DESCRIPTION
If the containers are restarted, there is a race condition in chat because we list resources and tools at the same time. This change, along with the bump in nanobot, will address this race.