### PR TITLE
chore: dont convert uploaded images to webp

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -105,6 +105,9 @@ var (
 		"GET /api/eula",
 		"PUT /api/eula",
 
+		// Allow admins to upload custom images
+		"POST /api/image/upload",
+
 		// This rule allows admins without an ACR to fetch tools for MCP servers in the default
 		// catalog (all catalogs really) via the UI. It goes to the same handler as /api/mcp-servers/{mcpserver_id}/tools,
 		// which admins already have access to from the rules above, so it's not exposing anything that
@@ -196,6 +199,10 @@ var (
 			"GET /oauth/jwks.json",
 
 			"/mcp-connect/",
+
+			// Allow any user to read stored images.
+			// This allows the UI to display custom images to unauthenticated users.
+			"GET /api/image/{image_id}",
 		},
 
 		types.GroupBasic: {
@@ -205,7 +212,6 @@ var (
 			"GET /api/models",
 			"GET /api/model-providers",
 			"POST /api/image/generate",
-			"POST /api/image/upload",
 
 			// Allow authenticated users to read and accept/reject project invitations.
 			// The security depends on the code being an unguessable UUID string,

--- a/pkg/api/handlers/images.go
+++ b/pkg/api/handlers/images.go
@@ -14,9 +14,10 @@ import (
 )
 
 var allowedUploadedImageMIMETypes = map[string]bool{
-	"image/png":  true,
-	"image/jpeg": true,
-	"image/webp": true,
+	"image/svg+xml": true,
+	"image/png":     true,
+	"image/jpeg":    true,
+	"image/webp":    true,
 }
 
 const maxUploadSize = 2 * 1024 * 1024 // 2MB
@@ -96,14 +97,8 @@ func (h *ImageHandler) UploadImage(req api.Context) error {
 		return apierrors.NewInternalError(fmt.Errorf("failed to read image data: %w", err))
 	}
 
-	// Convert PNG/JPEG to WebP
-	data, err = convertToWebP(data)
-	if err != nil {
-		return apierrors.NewInternalError(fmt.Errorf("failed to convert image to WebP: %w", err))
-	}
-
 	// Store image in gateway
-	stored, err := req.GatewayClient.CreateImage(req.Context(), data, "image/webp")
+	stored, err := req.GatewayClient.CreateImage(req.Context(), data, mimeType)
 	if err != nil {
 		return apierrors.NewInternalError(fmt.Errorf("failed to store uploaded image: %w", err))
 	}


### PR DESCRIPTION
- Don't convert uploaded images to webp
- Make the image upload endpoint admin-only
- Allow unauthed users to read custom images
- Add svg to list of accepted upload mimetypes
