### PR TITLE
fix: cleanup nobody user when enabling auth

### DIFF
--- a/docs/docs/installation/enabling-authentication.md
+++ b/docs/docs/installation/enabling-authentication.md
@@ -12,6 +12,10 @@ By default, Obot runs without authentication in development mode. For production
 1. Configure admins/owners
 1. Restart the system
 
+:::note
+If any MCP servers were created with authentication disabled, they will be deleted when authentication is enabled.
+:::
+
 ## Step 1: Enable Authentication
 
 ### Docker/Compose Deployment


### PR DESCRIPTION
If auth was disabled and the nobody user deployed MCP servers, for example, we need to clean those up when auth is enabled. The nobody user was already being deleted, but their stuff was left behind.