### PR TITLE
fix: make Kubernetes backend work on localhost

### DIFF
--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -18,6 +18,8 @@ data:
   {{- end }}
   {{- if eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes" }}
   OBOT_SERVER_MCPNAMESPACE: {{ include "obot.config.mcpNamespace" . | b64enc }}
+  OBOT_SERVER_SERVICE_NAME: {{ include "obot.fullname" . | b64enc }}
+  OBOT_SERVER_SERVICE_NAMESPACE: {{ .Release.Namespace | b64enc }}
   {{- if gt (len .Values.mcpImagePullSecrets) 0 }}
   OBOT_SERVER_MCPIMAGE_PULL_SECRETS: {{ include "obot.config.mcpImagePullSecrets" . | b64enc }}
   {{- end }}

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -37,6 +37,8 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-converter:main` |
 | `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker, kubernetes, or local. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |
+| `OBOT_SERVER_SERVICE_NAME` | The Kubernetes service name for the obot server. Automatically set by the helm chart when using kubernetes backend. Used to construct the internal service FQDN for token exchange endpoints. | - |
+| `OBOT_SERVER_SERVICE_NAMESPACE` | The Kubernetes namespace where the obot server runs. Automatically set by the helm chart when using kubernetes backend. Used to construct the internal service FQDN for token exchange endpoints. | - |
 | `OBOT_SERVER_DISALLOW_LOCALHOST_MCP` | Disallow MCP servers that try to connect to localhost. | `false` |
 | `OBOT_SERVER_UPDATE_CHECK_INTERVAL_MINS` | The interval in minutes to check for Obot server updates. Set to 0 to disable. (Deprecated, will be removed in v0.14.0) | `1440` minutes (1 day) |
 | `OBOT_SERVER_DISABLE_UPDATE_CHECK` | Disable the Obot server update check. (v0.14.0+) | `false ` |

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -1,0 +1,137 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestReplaceHostWithServiceFQDN(t *testing.T) {
+	tests := []struct {
+		name        string
+		serviceFQDN string
+		inputURL    string
+		expectedURL string
+	}{
+		{
+			name:        "replace localhost with service FQDN",
+			serviceFQDN: "obot.obot-system.svc.cluster.local",
+			inputURL:    "http://localhost:8080/oauth/token",
+			expectedURL: "http://obot.obot-system.svc.cluster.local/oauth/token",
+		},
+		{
+			name:        "replace external domain with service FQDN",
+			serviceFQDN: "obot.obot-system.svc.cluster.local",
+			inputURL:    "https://obot.example.com/oauth/token",
+			expectedURL: "https://obot.obot-system.svc.cluster.local/oauth/token",
+		},
+		{
+			name:        "preserve path with multiple segments",
+			serviceFQDN: "obot.obot-system.svc.cluster.local",
+			inputURL:    "http://localhost:8080/api/v1/oauth/token",
+			expectedURL: "http://obot.obot-system.svc.cluster.local/api/v1/oauth/token",
+		},
+		{
+			name:        "handle URL with no path",
+			serviceFQDN: "obot.obot-system.svc.cluster.local",
+			inputURL:    "http://localhost:8080",
+			expectedURL: "http://obot.obot-system.svc.cluster.local",
+		},
+		{
+			name:        "handle URL with query string",
+			serviceFQDN: "obot.obot-system.svc.cluster.local",
+			inputURL:    "http://localhost:8080/oauth/token?foo=bar",
+			expectedURL: "http://obot.obot-system.svc.cluster.local/oauth/token?foo=bar",
+		},
+		{
+			name:        "empty service FQDN returns original URL",
+			serviceFQDN: "",
+			inputURL:    "http://localhost:8080/oauth/token",
+			expectedURL: "http://localhost:8080/oauth/token",
+		},
+		{
+			name:        "malformed URL without scheme returns original",
+			serviceFQDN: "obot.obot-system.svc.cluster.local",
+			inputURL:    "localhost:8080/oauth/token",
+			expectedURL: "localhost:8080/oauth/token",
+		},
+		{
+			name:        "custom cluster domain",
+			serviceFQDN: "obot.obot-system.svc.custom.domain",
+			inputURL:    "http://localhost:8080/oauth/token",
+			expectedURL: "http://obot.obot-system.svc.custom.domain/oauth/token",
+		},
+		{
+			name:        "handle root path",
+			serviceFQDN: "obot.obot-system.svc.cluster.local",
+			inputURL:    "http://localhost:8080/",
+			expectedURL: "http://obot.obot-system.svc.cluster.local/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &kubernetesBackend{
+				serviceFQDN: tt.serviceFQDN,
+			}
+			result := k.replaceHostWithServiceFQDN(tt.inputURL)
+			if result != tt.expectedURL {
+				t.Errorf("replaceHostWithServiceFQDN() = %v, want %v", result, tt.expectedURL)
+			}
+		})
+	}
+}
+
+func TestNewKubernetesBackend_ServiceFQDN(t *testing.T) {
+	tests := []struct {
+		name             string
+		serviceName      string
+		serviceNamespace string
+		clusterDomain    string
+		expectedFQDN     string
+	}{
+		{
+			name:             "constructs FQDN with all values",
+			serviceName:      "obot",
+			serviceNamespace: "obot-system",
+			clusterDomain:    "cluster.local",
+			expectedFQDN:     "obot.obot-system.svc.cluster.local",
+		},
+		{
+			name:             "custom cluster domain",
+			serviceName:      "obot",
+			serviceNamespace: "default",
+			clusterDomain:    "my-cluster.local",
+			expectedFQDN:     "obot.default.svc.my-cluster.local",
+		},
+		{
+			name:             "empty service name results in empty FQDN",
+			serviceName:      "",
+			serviceNamespace: "obot-system",
+			clusterDomain:    "cluster.local",
+			expectedFQDN:     "",
+		},
+		{
+			name:             "empty service namespace results in empty FQDN",
+			serviceName:      "obot",
+			serviceNamespace: "",
+			clusterDomain:    "cluster.local",
+			expectedFQDN:     "",
+		},
+		{
+			name:             "both empty results in empty FQDN",
+			serviceName:      "",
+			serviceNamespace: "",
+			clusterDomain:    "cluster.local",
+			expectedFQDN:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := newKubernetesBackend(nil, nil, "", "", "", "", tt.clusterDomain, tt.serviceName, tt.serviceNamespace, nil, nil)
+			k := backend.(*kubernetesBackend)
+			if k.serviceFQDN != tt.expectedFQDN {
+				t.Errorf("newKubernetesBackend() serviceFQDN = %v, want %v", k.serviceFQDN, tt.expectedFQDN)
+			}
+		})
+	}
+}

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -39,6 +39,10 @@ type Options struct {
 	MCPK8sSettingsAffinity    string `usage:"Affinity rules for MCP server pods (JSON)" env:"OBOT_SERVER_MCPK8S_SETTINGS_AFFINITY"`
 	MCPK8sSettingsTolerations string `usage:"Tolerations for MCP server pods (JSON)" env:"OBOT_SERVER_MCPK8S_SETTINGS_TOLERATIONS"`
 	MCPK8sSettingsResources   string `usage:"Resource requests/limits for MCP server pods (JSON)" env:"OBOT_SERVER_MCPK8S_SETTINGS_RESOURCES"`
+
+	// Obot service configuration for constructing internal service FQDN
+	ServiceName      string `usage:"The Kubernetes service name for the obot server" env:"OBOT_SERVER_SERVICE_NAME"`
+	ServiceNamespace string `usage:"The Kubernetes namespace where the obot server runs" env:"OBOT_SERVER_SERVICE_NAMESPACE"`
 }
 
 type SessionManager struct {
@@ -103,7 +107,7 @@ func NewSessionManager(ctx context.Context, tokenService TokenService, baseURL s
 			return nil, err
 		}
 
-		backend = newKubernetesBackend(clientset, client, opts.MCPBaseImage, opts.MCPHTTPWebhookBaseImage, opts.MCPRemoteShimBaseImage, opts.MCPNamespace, opts.MCPClusterDomain, opts.MCPImagePullSecrets, obotStorageClient)
+		backend = newKubernetesBackend(clientset, client, opts.MCPBaseImage, opts.MCPHTTPWebhookBaseImage, opts.MCPRemoteShimBaseImage, opts.MCPNamespace, opts.MCPClusterDomain, opts.ServiceName, opts.ServiceNamespace, opts.MCPImagePullSecrets, obotStorageClient)
 	default:
 		return nil, fmt.Errorf("unknown runtime backend: %s", opts.MCPRuntimeBackend)
 	}


### PR DESCRIPTION
The MCP containers now need to communicate with Obot for token exchange. This doesn't work when running on localhost. This change will pass the service FQDN as the token exchange endpoint.

Issue: https://github.com/obot-platform/obot/issues/5135