### PR TITLE
fix: stop failing if component server catalog entry is deleted

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1317,6 +1317,9 @@ func serverConfigForAction(req api.Context, server v1.MCPServer, jwks string) (m
 	}
 
 	catalogName := server.Spec.MCPCatalogID
+	if catalogName == "" {
+		catalogName = server.Status.MCPCatalogID
+	}
 	if catalogName == "" && server.Spec.MCPServerCatalogEntryName != "" {
 		var entry v1.MCPServerCatalogEntry
 		if err := req.Get(&entry, server.Spec.MCPServerCatalogEntryName); err != nil {

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -257,6 +257,7 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPServerCatalogEntry{}).HandlerFunc(mcpservercatalogentry.EnsureUserCount)
 
 	// MCPServer
+	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureMCPCatalogID)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.MigrateSharedWithinMCPCatalogName)
 	root.Type(&v1.MCPServer{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.DeleteServersWithoutRuntime)

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -120,6 +120,8 @@ type MCPServerSpec struct {
 }
 
 type MCPServerStatus struct {
+	// MCPCatalogID is the catalog ID of the catalog entry that this MCP server is based on.
+	MCPCatalogID string `json:"mcpCatalogID,omitempty"`
 	// NeedsUpdate indicates whether the configuration in this server's catalog entry has drift from this server's configuration.
 	NeedsUpdate bool `json:"needsUpdate,omitempty"`
 	// MCPServerInstanceUserCount contains the number of unique users with server instances pointing to this MCP server.

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -14331,6 +14331,13 @@ func schema_storage_apis_obotobotai_v1_MCPServerStatus(ref common.ReferenceCallb
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"mcpCatalogID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MCPCatalogID is the catalog ID of the catalog entry that this MCP server is based on.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"needsUpdate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NeedsUpdate indicates whether the configuration in this server's catalog entry has drift from this server's configuration.",


### PR DESCRIPTION
For composite servers, a user is allowed to delete the catalog entry for a component server and have the composite server still function properly. If the catalog entry no longer exists, then it is not possible to retrieve the catalog ID from the entry. This change adds a field to the status to track the catalog ID of the component server, which was previously pulled from the catalog entry.

Issue: https://github.com/obot-platform/obot/issues/5096