### PR TITLE
fix: correctly determine MCP server ID for users that have yet to login

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -133,7 +133,7 @@ config:
   # config.OBOT_SERVER_MCPBASE_IMAGE -- Deploy MCP servers in the cluster using this base image. OBOT_SERVER_MCPNAMESPACE is automatically added to the secret if config.OBOT_SERVER_MCPBASE_IMAGE is set.
   OBOT_SERVER_MCPBASE_IMAGE: "ghcr.io/obot-platform/mcp-images/phat:main"
   # config.OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE -- Deploy MCP remote shim servers in the cluster using this base image.
-  OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE: "ghcr.io/nanobot-ai/nanobot:v0.0.39"
+  OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE: "ghcr.io/nanobot-ai/nanobot:v0.0.41"
   # config.OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE -- Deploy MCP HTTP webhook servers in the cluster using this base image.
   OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE: "ghcr.io/obot-platform/mcp-images/http-webhook-converter:main"
   # config.OBOT_SERVER_MCPCLUSTER_DOMAIN -- The cluster domain to use for MCP services. Defaults to cluster.local. Only matters if the above image is set.

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -33,7 +33,7 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_AUDIT_LOGS_COMPRESS_FILE` | Controls whether or not to compress audit log files | `true` |
 | `OBOT_SERVER_AUDIT_LOGS_USE_PATH_STYLE` | Whether to use path style for S3 | - |
 | `OBOT_SERVER_MCPBASE_IMAGE` | Deploy MCP servers in the kubernetes cluster or using docker with this base image. | `ghcr.io/obot-platform/mcp-images/phat:main` |
-| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.39` |
+| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.41` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-converter:main` |
 | `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker, kubernetes, or local. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -198,7 +198,6 @@ var (
 			"GET /oauth/authorize",
 			"POST /oauth/token/{mcp_id}",
 			"POST /oauth/token",
-			"GET /oauth/callback/{oauth_request_id}",
 			"GET /oauth/jwks.json",
 
 			"/mcp-connect/",

--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -314,7 +314,7 @@ func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user user
 		MCPServerID:            vars("mcpserver_id"),
 		MCPServerInstanceID:    vars("mcp_server_instance_id"),
 		ProjectMCPServerID:     vars("project_mcp_server_id"),
-		MCPID:                  vars("mcp_id"), // this will be either a server ID or a server instance ID
+		MCPID:                  vars("mcp_id"), // this can be a server ID, server instance ID, or a catalog entry ID
 		PendingAuthorizationID: vars("pending_authorization_id"),
 		ThreadShareID:          vars("share_public_id"),
 		TemplateID:             vars("template_public_id"),

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1167,19 +1167,21 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 	}
 }
 
-func MCPIDAndAudienceFromConnectURL(req api.Context, id string) (string, string, error) {
+// MCPServerIDFromConnectURL returns the MCP server name based on the provided connect URL.
+// The connect URL could have an MCP server ID, server instance ID, or MCP catalog entry ID.
+func MCPServerIDFromConnectURL(req api.Context, id string) (string, error) {
 	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	switch {
 	case instance.Name != "":
-		return instance.Name, instance.Spec.MCPServerName, nil
+		return instance.Spec.MCPServerName, nil
 	case server.Name != "":
-		return server.Name, server.Name, nil
+		return server.Name, nil
 	default:
-		return "", "", fmt.Errorf("unknown MCP server ID %s", id)
+		return "", fmt.Errorf("unknown MCP server ID %s", id)
 	}
 }
 

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -468,9 +468,8 @@ func (h *Handler) DeleteUnauthorizedMCPServersForCatalog(req router.Request, _ r
 		}
 		// Iterate through each MCPServer and make sure it is still allowed to exist.
 		for _, server := range mcpServers.Items {
-			if server.Spec.ThreadName != "" || server.Spec.MCPCatalogID != "" || server.Spec.UserID == "anonymous" {
+			if server.Spec.ThreadName != "" || server.Spec.MCPCatalogID != "" {
 				// For legacy project-scoped servers and multi-user servers created by the admin, we don't need to check them.
-				// For anonymous users, we don't need to check access. These servers are used for OAuth.
 				continue
 			}
 

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -287,6 +287,15 @@ func (h *Handler) DeleteServersWithoutRuntime(req router.Request, _ router.Respo
 	return nil
 }
 
+func (h *Handler) DeleteServersForAnonymousUser(req router.Request, _ router.Response) error {
+	server := req.Object.(*v1.MCPServer)
+	if server.Spec.UserID == "anonymous" {
+		return req.Client.Delete(req.Ctx, server)
+	}
+
+	return nil
+}
+
 func (h *Handler) MigrateSharedWithinMCPCatalogName(req router.Request, _ router.Response) error {
 	server := req.Object.(*v1.MCPServer)
 

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -260,6 +260,7 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.MigrateSharedWithinMCPCatalogName)
 	root.Type(&v1.MCPServer{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.DeleteServersWithoutRuntime)
+	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.DeleteServersForAnonymousUser)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.CleanupNestedCompositeServers)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.DetectDrift)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureMCPServerInstanceUserCount)

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -28,7 +28,7 @@ var log = logger.Package()
 type Options struct {
 	MCPBaseImage            string   `usage:"The base image to use for MCP containers" default:"ghcr.io/obot-platform/mcp-images/phat:main"`
 	MCPHTTPWebhookBaseImage string   `usage:"The base image to use for HTTP-based MCP webhook containers" default:"ghcr.io/obot-platform/mcp-images/http-webhook-converter:main"`
-	MCPRemoteShimBaseImage  string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.39"`
+	MCPRemoteShimBaseImage  string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.41"`
 	MCPNamespace            string   `usage:"The namespace to use for MCP containers" default:"obot-mcp"`
 	MCPClusterDomain        string   `usage:"The cluster domain to use for MCP containers" default:"cluster.local"`
 	DisallowLocalhostMCP    bool     `usage:"Allow MCP containers to run on localhost"`


### PR DESCRIPTION
If a user was logged out when they attempted to use a connect URL, there were two things that would go wrong:
1. An MCP server for the "anonymous" user was created.
2. The user would not be able to connect to the MCP server (because it belonged to the "anonymous" user).

This change addresses both of these by checking the for the MCP server ID only after we know the user has been authenticated (in the callback handler). The erroneously created servers for the anonymous user are now deleted.

There is a corresponding bug fixed here where the connect ID having 5 parts would cause 404 errors in nanobot.

Related issues: https://github.com/obot-platform/obot/issues/5111, https://github.com/obot-platform/obot/issues/5115