### PR TITLE
fix: use catalog ID instead of entry name

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -744,6 +744,9 @@ func (m *MCPHandler) SetTools(req api.Context) error {
 	}
 
 	catalogName := mcpServer.Spec.MCPCatalogID
+	if catalogName == "" {
+		catalogName = mcpServer.Status.MCPCatalogID
+	}
 	if catalogName == "" && mcpServer.Spec.MCPServerCatalogEntryName != "" {
 		var entry v1.MCPServerCatalogEntry
 		if err := req.Get(&entry, mcpServer.Spec.MCPServerCatalogEntryName); err != nil {
@@ -1233,6 +1236,9 @@ func serverFromMCPServerInstance(req api.Context, instance v1.MCPServerInstance,
 	}
 
 	catalogName := server.Spec.MCPCatalogID
+	if catalogName == "" {
+		catalogName = server.Status.MCPCatalogID
+	}
 	if catalogName == "" && server.Spec.MCPServerCatalogEntryName != "" {
 		var entry v1.MCPServerCatalogEntry
 		if err := req.Get(&entry, server.Spec.MCPServerCatalogEntryName); err != nil {

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -304,13 +304,13 @@ func (h *Handler) DeleteServersForAnonymousUser(req router.Request, _ router.Res
 func (h *Handler) EnsureMCPCatalogID(req router.Request, _ router.Response) error {
 	server := req.Object.(*v1.MCPServer)
 
-	if server.Status.MCPCatalogID == "" && server.Spec.MCPCatalogID == "" && server.Spec.MCPServerCatalogEntryName != "" {
+	if (server.Status.MCPCatalogID == "" || server.Status.MCPCatalogID == server.Spec.MCPServerCatalogEntryName) && server.Spec.MCPCatalogID == "" && server.Spec.MCPServerCatalogEntryName != "" {
 		var mcpCatalogEntry v1.MCPServerCatalogEntry
 		if err := req.Get(&mcpCatalogEntry, server.Namespace, server.Spec.MCPServerCatalogEntryName); err != nil {
 			return err
 		}
 
-		server.Status.MCPCatalogID = mcpCatalogEntry.Name
+		server.Status.MCPCatalogID = mcpCatalogEntry.Spec.MCPCatalogName
 		return req.Client.Status().Update(req.Ctx, server)
 	}
 


### PR DESCRIPTION
There were a few places where we were using the MCPServerCatalogEntryName instead of the MCPCatalogID. This change ensures that we are using the correct ID for the MCP catalog.