### PR TITLE
enhance: registry API: cache fetched mime types

### DIFF
--- a/pkg/api/handlers/registry/convert.go
+++ b/pkg/api/handlers/registry/convert.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -22,6 +21,7 @@ func ConvertMCPServerToRegistry(
 	slug string,
 	reverseDNS string,
 	userID string,
+	mimeFetcher *mimeFetcher,
 ) (obottypes.RegistryServerResponse, error) {
 	// Use existing conversion function to get types.MCPServer
 	convertedServer := handlers.ConvertMCPServer(server, credEnv, serverURL, slug)
@@ -52,7 +52,7 @@ func ConvertMCPServerToRegistry(
 		serverDetail.Icons = []obottypes.RegistryServerIcon{
 			{
 				Src:      convertedServer.MCPServerManifest.Icon,
-				MimeType: guessMimeType(ctx, convertedServer.MCPServerManifest.Icon),
+				MimeType: mimeFetcher.guessMimeType(ctx, convertedServer.MCPServerManifest.Icon),
 			},
 		}
 	}
@@ -109,6 +109,7 @@ func ConvertMCPServerCatalogEntryToRegistry(
 	entry v1.MCPServerCatalogEntry,
 	serverURL string,
 	reverseDNS string,
+	mimeFetcher *mimeFetcher,
 ) (obottypes.RegistryServerResponse, error) {
 	manifest := entry.Spec.Manifest
 
@@ -133,7 +134,7 @@ func ConvertMCPServerCatalogEntryToRegistry(
 		serverDetail.Icons = []obottypes.RegistryServerIcon{
 			{
 				Src:      manifest.Icon,
-				MimeType: guessMimeType(ctx, manifest.Icon),
+				MimeType: mimeFetcher.guessMimeType(ctx, manifest.Icon),
 			},
 		}
 	}
@@ -205,80 +206,6 @@ func ConvertMCPServerCatalogEntryToRegistry(
 }
 
 // Helper functions
-
-func guessMimeType(ctx context.Context, iconURL string) string {
-	// First, try to guess from the file extension
-	lower := strings.ToLower(iconURL)
-	if strings.HasSuffix(lower, ".png") {
-		return "image/png"
-	}
-	if strings.HasSuffix(lower, ".jpg") || strings.HasSuffix(lower, ".jpeg") {
-		return "image/jpeg"
-	}
-	if strings.HasSuffix(lower, ".svg") {
-		return "image/svg+xml"
-	}
-	if strings.HasSuffix(lower, ".webp") {
-		return "image/webp"
-	}
-
-	// If we couldn't guess from the extension, try to fetch the URL
-	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
-		return fetchAndDetectMimeType(ctx, iconURL)
-	}
-
-	return ""
-}
-
-func fetchAndDetectMimeType(ctx context.Context, url string) string {
-	// Create a context with timeout to prevent hanging
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	// Create request
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return ""
-	}
-
-	// Perform the request
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return ""
-	}
-	defer resp.Body.Close()
-
-	// First, check the Content-Type header
-	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
-		// Extract just the MIME type (before any semicolon/parameters)
-		if idx := strings.Index(contentType, ";"); idx > 0 {
-			contentType = contentType[:idx]
-		}
-		contentType = strings.TrimSpace(contentType)
-
-		// Validate it's an image MIME type
-		if strings.HasPrefix(contentType, "image/") {
-			return contentType
-		}
-	}
-
-	// If header wasn't useful, read first 512 bytes to detect content type
-	buffer := make([]byte, 512)
-	n, err := resp.Body.Read(buffer)
-	if err != nil && n == 0 {
-		return ""
-	}
-
-	// Detect content type from the actual data
-	detectedType := http.DetectContentType(buffer[:n])
-
-	// Only return if it's an image type
-	if strings.HasPrefix(detectedType, "image/") {
-		return detectedType
-	}
-
-	return ""
-}
 
 func guessRepoSource(repoURL string) string {
 	lower := strings.ToLower(repoURL)

--- a/pkg/api/handlers/registry/handler.go
+++ b/pkg/api/handlers/registry/handler.go
@@ -21,6 +21,7 @@ type Handler struct {
 	acrHelper      *accesscontrolrule.Helper
 	serverURL      string
 	registryNoAuth bool
+	mimeFetcher    *mimeFetcher
 }
 
 func NewHandler(acrHelper *accesscontrolrule.Helper, serverURL string, registryNoAuth bool) *Handler {
@@ -28,6 +29,7 @@ func NewHandler(acrHelper *accesscontrolrule.Helper, serverURL string, registryN
 		acrHelper:      acrHelper,
 		serverURL:      serverURL,
 		registryNoAuth: registryNoAuth,
+		mimeFetcher:    newMimeFetcher(),
 	}
 }
 
@@ -86,7 +88,7 @@ func (h *Handler) collectAccessibleServers(req api.Context, reverseDNS string) (
 			continue
 		}
 
-		converted, err := ConvertMCPServerToRegistry(req.Context(), server, credMap[server.Name], h.serverURL, slug, reverseDNS, userID)
+		converted, err := ConvertMCPServerToRegistry(req.Context(), server, credMap[server.Name], h.serverURL, slug, reverseDNS, userID, h.mimeFetcher)
 		if err != nil {
 			// Skip servers that can't be converted
 			continue
@@ -106,7 +108,7 @@ func (h *Handler) collectAccessibleServers(req api.Context, reverseDNS string) (
 	}
 
 	for _, entry := range catalogEntries {
-		converted, err := ConvertMCPServerCatalogEntryToRegistry(req.Context(), entry, h.serverURL, reverseDNS)
+		converted, err := ConvertMCPServerCatalogEntryToRegistry(req.Context(), entry, h.serverURL, reverseDNS, h.mimeFetcher)
 		if err != nil {
 			// If conversion fails, just skip the entry
 			continue
@@ -128,7 +130,7 @@ func (h *Handler) collectAccessibleServers(req api.Context, reverseDNS string) (
 			continue
 		}
 
-		converted, err := ConvertMCPServerToRegistry(req.Context(), server, credMap[server.Name], h.serverURL, slug, reverseDNS, userID)
+		converted, err := ConvertMCPServerToRegistry(req.Context(), server, credMap[server.Name], h.serverURL, slug, reverseDNS, userID, h.mimeFetcher)
 		if err != nil {
 			// If conversion fails, just skip the server
 			continue
@@ -143,7 +145,7 @@ func (h *Handler) collectAccessibleServers(req api.Context, reverseDNS string) (
 	}
 
 	for _, entry := range workspaceEntries {
-		converted, err := ConvertMCPServerCatalogEntryToRegistry(req.Context(), entry, h.serverURL, reverseDNS)
+		converted, err := ConvertMCPServerCatalogEntryToRegistry(req.Context(), entry, h.serverURL, reverseDNS, h.mimeFetcher)
 		if err != nil {
 			// If conversion fails, just skip the entry
 			continue
@@ -165,7 +167,7 @@ func (h *Handler) collectAccessibleServers(req api.Context, reverseDNS string) (
 			continue
 		}
 
-		converted, err := ConvertMCPServerToRegistry(req.Context(), server, credMap[server.Name], h.serverURL, slug, reverseDNS, userID)
+		converted, err := ConvertMCPServerToRegistry(req.Context(), server, credMap[server.Name], h.serverURL, slug, reverseDNS, userID, h.mimeFetcher)
 		if err != nil {
 			// If conversion fails, just skip the server
 			continue
@@ -201,7 +203,7 @@ func (h *Handler) collectAccessibleServersNoAuth(req api.Context, reverseDNS str
 			continue
 		}
 
-		converted, err := ConvertMCPServerCatalogEntryToRegistry(req.Context(), entry, h.serverURL, reverseDNS)
+		converted, err := ConvertMCPServerCatalogEntryToRegistry(req.Context(), entry, h.serverURL, reverseDNS, h.mimeFetcher)
 		if err != nil {
 			// If conversion fails, just skip the entry
 			continue
@@ -245,7 +247,7 @@ func (h *Handler) collectAccessibleServersNoAuth(req api.Context, reverseDNS str
 		// Get credentials
 		credEnv, _ := h.getCredentialsForServer(req, server, "", system.DefaultCatalog, "")
 
-		converted, err := ConvertMCPServerToRegistry(req.Context(), server, credEnv, h.serverURL, slug, reverseDNS, "")
+		converted, err := ConvertMCPServerToRegistry(req.Context(), server, credEnv, h.serverURL, slug, reverseDNS, "", h.mimeFetcher)
 		if err != nil {
 			// If conversion fails, just skip the server
 			continue
@@ -780,7 +782,7 @@ func (h *Handler) findMCPServer(req api.Context, serverName, reverseDNS string) 
 		return types.RegistryServerResponse{}, fmt.Errorf("server not found")
 	}
 
-	return ConvertMCPServerToRegistry(req.Context(), server, credEnv, h.serverURL, slug, reverseDNS, req.User.GetUID())
+	return ConvertMCPServerToRegistry(req.Context(), server, credEnv, h.serverURL, slug, reverseDNS, req.User.GetUID(), h.mimeFetcher)
 }
 
 // findMCPServerCatalogEntry looks up an MCPServerCatalogEntry and checks ACR permissions
@@ -817,7 +819,7 @@ func (h *Handler) findMCPServerCatalogEntry(req api.Context, entryName string, r
 		return types.RegistryServerResponse{}, fmt.Errorf("catalog entry not found")
 	}
 
-	return ConvertMCPServerCatalogEntryToRegistry(req.Context(), entry, h.serverURL, reverseDNS)
+	return ConvertMCPServerCatalogEntryToRegistry(req.Context(), entry, h.serverURL, reverseDNS, h.mimeFetcher)
 }
 
 // notFoundError returns a standard 404 error response in the format:

--- a/pkg/api/handlers/registry/mime.go
+++ b/pkg/api/handlers/registry/mime.go
@@ -1,0 +1,108 @@
+package registry
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type mimeFetcher struct {
+	lock  sync.RWMutex
+	cache map[string]string
+}
+
+func newMimeFetcher() *mimeFetcher {
+	return &mimeFetcher{
+		lock:  sync.RWMutex{},
+		cache: make(map[string]string),
+	}
+}
+
+func (m *mimeFetcher) guessMimeType(ctx context.Context, iconURL string) string {
+	// First, try to guess from the file extension
+	lower := strings.ToLower(iconURL)
+	if strings.HasSuffix(lower, ".png") {
+		return "image/png"
+	}
+	if strings.HasSuffix(lower, ".jpg") || strings.HasSuffix(lower, ".jpeg") {
+		return "image/jpeg"
+	}
+	if strings.HasSuffix(lower, ".svg") {
+		return "image/svg+xml"
+	}
+	if strings.HasSuffix(lower, ".webp") {
+		return "image/webp"
+	}
+
+	// If we couldn't guess from the extension, try to fetch the URL
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return m.fetchAndDetectMimeType(ctx, iconURL)
+	}
+
+	return ""
+}
+
+func (m *mimeFetcher) fetchAndDetectMimeType(ctx context.Context, url string) string {
+	m.lock.RLock()
+	mimeType, ok := m.cache[url]
+	m.lock.RUnlock()
+	if ok {
+		return mimeType
+	}
+
+	// Create a context with timeout to prevent hanging
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return ""
+	}
+
+	// Perform the request
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	// First, check the Content-Type header
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		// Extract just the MIME type (before any semicolon/parameters)
+		if idx := strings.Index(contentType, ";"); idx > 0 {
+			contentType = contentType[:idx]
+		}
+		contentType = strings.TrimSpace(contentType)
+
+		// Validate it's an image MIME type
+		if strings.HasPrefix(contentType, "image/") {
+			m.lock.Lock()
+			m.cache[url] = contentType
+			m.lock.Unlock()
+			return contentType
+		}
+	}
+
+	// If header wasn't useful, read first 512 bytes to detect content type
+	buffer := make([]byte, 512)
+	n, err := resp.Body.Read(buffer)
+	if err != nil && n == 0 {
+		return ""
+	}
+
+	// Detect content type from the actual data
+	detectedType := http.DetectContentType(buffer[:n])
+
+	// Only return if it's an image type
+	if strings.HasPrefix(detectedType, "image/") {
+		m.lock.Lock()
+		m.cache[url] = detectedType
+		m.lock.Unlock()
+		return detectedType
+	}
+
+	return ""
+}


### PR DESCRIPTION
This speeds up the performance of the registry API. Also this is compatible with HA, since the cache will contain the same thing across replicas.