### PR TITLE
fix: registry API: return an empty, rather than null, list

### DIFF
--- a/pkg/api/handlers/registry/handler.go
+++ b/pkg/api/handlers/registry/handler.go
@@ -618,6 +618,10 @@ func paginateServers(servers []types.RegistryServerResponse, cursor string, limi
 	}
 
 	page := servers[startIdx:endIdx]
+	if page == nil {
+		// This prevents an error from showing up in VSCode when the result is empty.
+		page = []types.RegistryServerResponse{}
+	}
 
 	// Build response
 	response := types.RegistryServerList{


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5194