### PR TITLE
feat: add audit log endpoints

### DIFF
--- a/apiclient/types/mcpauditlog.go
+++ b/apiclient/types/mcpauditlog.go
@@ -43,8 +43,11 @@ type ClientInfo struct {
 }
 
 type WebhookStatus struct {
-	URL     string `json:"url"`
-	Status  string `json:"status"`
+	Type    string `json:"type,omitempty"`
+	Method  string `json:"method,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Status  string `json:"status,omitempty"`
 	Message string `json:"message"`
 }
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -135,7 +135,7 @@ config:
   # config.OBOT_SERVER_MCPBASE_IMAGE -- Deploy MCP servers in the cluster using this base image. OBOT_SERVER_MCPNAMESPACE is automatically added to the secret if config.OBOT_SERVER_MCPBASE_IMAGE is set.
   OBOT_SERVER_MCPBASE_IMAGE: "ghcr.io/obot-platform/mcp-images/phat:main"
   # config.OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE -- Deploy MCP remote shim servers in the cluster using this base image.
-  OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE: "ghcr.io/nanobot-ai/nanobot:v0.0.41"
+  OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE: "ghcr.io/nanobot-ai/nanobot:v0.0.42"
   # config.OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE -- Deploy MCP HTTP webhook servers in the cluster using this base image.
   OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE: "ghcr.io/obot-platform/mcp-images/http-webhook-converter:main"
   # config.OBOT_SERVER_MCPCLUSTER_DOMAIN -- The cluster domain to use for MCP services. Defaults to cluster.local. Only matters if the above image is set.

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -33,7 +33,7 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_AUDIT_LOGS_COMPRESS_FILE` | Controls whether or not to compress audit log files | `true` |
 | `OBOT_SERVER_AUDIT_LOGS_USE_PATH_STYLE` | Whether to use path style for S3 | - |
 | `OBOT_SERVER_MCPBASE_IMAGE` | Deploy MCP servers in the kubernetes cluster or using docker with this base image. | `ghcr.io/obot-platform/mcp-images/phat:main` |
-| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.41` |
+| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.42` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-converter:main` |
 | `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker, kubernetes, or local. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -205,6 +205,9 @@ var (
 			// Allow any user to read stored images.
 			// This allows the UI to display custom images to unauthenticated users.
 			"GET /api/image/{image_id}",
+
+			// The auth for this is handled in the HTTP handler
+			"POST /api/mcp-audit-logs",
 		},
 
 		types.GroupBasic: {

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -580,6 +580,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 
 	// MCP Audit Logs
 	mux.HandleFunc("GET /api/mcp-audit-logs", mcpAuditLogs.ListAuditLogs)
+	mux.HandleFunc("POST /api/mcp-audit-logs", mcpAuditLogs.SubmitAuditLogs)
 	mux.HandleFunc("GET /api/mcp-audit-logs/filter-options/{filter}", mcpAuditLogs.ListAuditLogFilterOptions)
 	mux.HandleFunc("GET /api/mcp-audit-logs/{mcp_id}", mcpAuditLogs.ListAuditLogs)
 	mux.HandleFunc("GET /api/mcp-stats", mcpAuditLogs.GetUsageStats)

--- a/pkg/controller/handlers/cleanup/credentials.go
+++ b/pkg/controller/handlers/cleanup/credentials.go
@@ -138,6 +138,11 @@ func (c *Credentials) RemoveMCPCredentials(req router.Request, _ router.Response
 		return c.removeMCPCredentialsForProject(req, mcpServer)
 	}
 
+	// Cleanup the audit log token.
+	if err := c.gClient.DeleteCredential(req.Ctx, mcpServer.Name, mcpServer.Name+"-audit-log-token"); err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
+		return err
+	}
+
 	var credCtx string
 	if mcpServer.Spec.MCPCatalogID != "" {
 		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.MCPCatalogID, mcpServer.Name)

--- a/pkg/controller/handlers/oauthclients/oauthclients.go
+++ b/pkg/controller/handlers/oauthclients/oauthclients.go
@@ -1,6 +1,8 @@
 package oauthclients
 
 import (
+	"errors"
+
 	"github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/nah/pkg/router"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -23,5 +25,9 @@ func (h *Handler) CleanupOAuthClientCred(req router.Request, _ router.Response) 
 		return nil
 	}
 
-	return h.gptClient.DeleteCredential(req.Ctx, o.Spec.MCPServerName, o.Spec.MCPServerName)
+	if err := h.gptClient.DeleteCredential(req.Ctx, o.Spec.MCPServerName, o.Spec.MCPServerName); !errors.As(err, &gptscript.ErrNotFound{}) {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -265,7 +265,7 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.CleanupNestedCompositeServers)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.DetectDrift)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureMCPServerInstanceUserCount)
-	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureOAuthClient)
+	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureMCPServerSecretInfo)
 	root.Type(&v1.MCPServer{}).FinalizeFunc(v1.MCPServerFinalizer, credentialCleanup.RemoveMCPCredentials)
 
 	// MCPServerInstance

--- a/pkg/gateway/client/mcpauditlog.go
+++ b/pkg/gateway/client/mcpauditlog.go
@@ -82,7 +82,19 @@ func (c *Client) insertMCPAuditLogs(ctx context.Context, logs []types.MCPAuditLo
 					updates["error"] = responseLog.Error
 				}
 				if len(responseLog.WebhookStatuses) > 0 {
-					updates["webhook_statuses"] = responseLog.WebhookStatuses
+					updates["webhook_statuses"] = append(existingLog.WebhookStatuses, responseLog.WebhookStatuses...)
+				}
+				if existingLog.UserID == "" {
+					updates["user_id"] = responseLog.UserID
+				}
+				if existingLog.ClientIP == "" {
+					updates["client_ip"] = responseLog.ClientIP
+				}
+				if existingLog.ClientName == "" {
+					updates["client_name"] = responseLog.ClientName
+				}
+				if existingLog.ClientVersion == "" {
+					updates["client_version"] = responseLog.ClientVersion
 				}
 
 				// Calculate processing time as difference between response and request timestamps

--- a/pkg/gateway/types/mcpauditlog.go
+++ b/pkg/gateway/types/mcpauditlog.go
@@ -43,8 +43,10 @@ type MCPAuditLog struct {
 
 type MCPWebhookStatus struct {
 	Type    string `json:"type,omitempty"`
-	URL     string `json:"url"`
-	Status  string `json:"status"`
+	URL     string `json:"url,omitempty"`
+	Method  string `json:"method,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Status  string `json:"status,omitempty"`
 	Message string `json:"message,omitempty"`
 }
 
@@ -99,7 +101,10 @@ func ConvertMCPAuditLog(a MCPAuditLog) types2.MCPAuditLog {
 	webhookStatus := make([]types2.WebhookStatus, len(a.WebhookStatuses))
 	for i, ws := range a.WebhookStatuses {
 		webhookStatus[i] = types2.WebhookStatus{
+			Type:    ws.Type,
+			Method:  ws.Method,
 			URL:     ws.URL,
+			Name:    ws.Name,
 			Status:  ws.Status,
 			Message: ws.Message,
 		}

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -222,11 +222,15 @@ func constructNanobotYAMLForServer(name, url, command string, args []string, env
 	mcpServers := make(map[string]nanobotConfigMCPServer, len(webhooks)+1)
 
 	for _, webhook := range webhooks {
-		mcpServers[replacer.Replace(webhook.Name)] = nanobotConfigMCPServer{
+		name := replacer.Replace(webhook.DisplayName)
+		if name == "" {
+			name = replacer.Replace(webhook.Name)
+		}
+		mcpServers[name] = nanobotConfigMCPServer{
 			BaseURL: webhook.URL,
 		}
 		for _, def := range webhook.Definitions {
-			webhookDefinitions[def] = []string{fmt.Sprintf("%s/%s", webhook.Name, webhookToolName)}
+			webhookDefinitions[def] = []string{fmt.Sprintf("%s/%s", name, webhookToolName)}
 		}
 	}
 

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -48,6 +48,12 @@ func TestReplaceHostWithServiceFQDN(t *testing.T) {
 			expectedURL: "http://localhost:8080/oauth/token",
 		},
 		{
+			name:        "empty URL returns empty string",
+			serviceFQDN: "obot.obot-system.svc.cluster.local",
+			inputURL:    "",
+			expectedURL: "",
+		},
+		{
 			name:        "malformed URL without scheme returns original",
 			serviceFQDN: "obot.obot-system.svc.cluster.local",
 			inputURL:    "localhost:8080/oauth/token",
@@ -127,7 +133,7 @@ func TestNewKubernetesBackend_ServiceFQDN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			backend := newKubernetesBackend(nil, nil, "", "", "", "", tt.clusterDomain, tt.serviceName, tt.serviceNamespace, nil, nil)
+			backend := newKubernetesBackend(nil, nil, nil, Options{ServiceName: tt.serviceName, ServiceNamespace: tt.serviceNamespace, MCPClusterDomain: tt.clusterDomain})
 			k := backend.(*kubernetesBackend)
 			if k.serviceFQDN != tt.expectedFQDN {
 				t.Errorf("newKubernetesBackend() serviceFQDN = %v, want %v", k.serviceFQDN, tt.expectedFQDN)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -105,11 +105,9 @@ type Config struct {
 	DefaultMCPCatalogPath      string   `usage:"The path to the default MCP catalog (accessible to all users)" default:""`
 	DisableUpdateCheck         bool     `usage:"Disable Obot server update checks"`
 	// Sendgrid webhook
-	SendgridWebhookUsername           string `usage:"The username for the sendgrid webhook to authenticate with"`
-	SendgridWebhookPassword           string `usage:"The password for the sendgrid webhook to authenticate with"`
-	MCPAuditLogPersistIntervalSeconds int    `usage:"The interval in seconds to persist MCP audit logs to the database" default:"5"`
-	MCPAuditLogsPersistBatchSize      int    `usage:"The number of MCP audit logs to persist in a single batch" default:"1000"`
-	EnableRegistryAuth                bool   `usage:"Enable authentication for the MCP registry API" default:"false" env:"OBOT_SERVER_ENABLE_REGISTRY_AUTH"`
+	SendgridWebhookUsername string `usage:"The username for the sendgrid webhook to authenticate with"`
+	SendgridWebhookPassword string `usage:"The password for the sendgrid webhook to authenticate with"`
+	EnableRegistryAuth      bool   `usage:"Enable authentication for the MCP registry API" default:"false" env:"OBOT_SERVER_ENABLE_REGISTRY_AUTH"`
 
 	GeminiConfig
 	GatewayConfig

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -49,6 +49,8 @@ func (in *MCPServer) Get(field string) (value string) {
 		return in.Spec.CompositeName
 	case "spec.manifest.runtime":
 		return string(in.Spec.Manifest.Runtime)
+	case "auditLogTokenHash":
+		return in.Status.AuditLogTokenHash
 	}
 	return ""
 }
@@ -63,6 +65,7 @@ func (in *MCPServer) FieldNames() []string {
 		"spec.template",
 		"spec.compositeName",
 		"spec.manifest.runtime",
+		"auditLogTokenHash",
 	}
 }
 
@@ -140,6 +143,8 @@ type MCPServerStatus struct {
 	// This field is only populated for servers running in Kubernetes runtime.
 	// For Docker, local, or remote runtimes, this field is omitted entirely.
 	K8sSettingsHash string `json:"k8sSettingsHash,omitempty"`
+	// AuditLogTokenHash is the hash of the token used to submit audit logs.
+	AuditLogTokenHash string `json:"auditLogTokenHash,omitempty"`
 }
 
 type DeploymentCondition struct {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -11209,18 +11209,34 @@ func schema_obot_platform_obot_apiclient_types_WebhookStatus(ref common.Referenc
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"method": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"url": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Type:   []string{"string"},
+							Format: "",
 						},
 					},
 					"message": {
@@ -11231,7 +11247,7 @@ func schema_obot_platform_obot_apiclient_types_WebhookStatus(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"url", "status", "message"},
+				Required: []string{"message"},
 			},
 		},
 	}
@@ -14869,6 +14885,13 @@ func schema_storage_apis_obotobotai_v1_MCPServerStatus(ref common.ReferenceCallb
 					"k8sSettingsHash": {
 						SchemaProps: spec.SchemaProps{
 							Description: "K8sSettingsHash contains the hash of K8s settings (affinity, tolerations, resources) this server was deployed with. This field is only populated for servers running in Kubernetes runtime. For Docker, local, or remote runtimes, this field is omitted entirely.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"auditLogTokenHash": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AuditLogTokenHash is the hash of the token used to submit audit logs.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/system/ids.go
+++ b/pkg/system/ids.go
@@ -93,6 +93,10 @@ func IsMCPServerInstanceID(id string) bool {
 	return strings.HasPrefix(id, MCPServerInstancePrefix)
 }
 
+func IsPowerUserWorkspaceID(id string) bool {
+	return strings.HasPrefix(id, PowerUserWorkspacePrefix)
+}
+
 // GetProjectShareName returns the project share name for a given user ID and project ID.
 func GetProjectShareName(userID string, projectID string) string {
 	return name.SafeHashConcatName(ThreadSharePrefix, userID,

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -368,8 +368,10 @@ export interface AuditLog {
 	};
 	webhookStatuses?: {
 		type?: string;
-		url: string;
-		status: string;
+		method?: string;
+		name?: string;
+		url?: string;
+		status?: string;
 		message?: string;
 	}[];
 	error?: string;


### PR DESCRIPTION
Audit logs will now be pushed from a nanobot shim for all MCP servers. This change makes that possible by:
1. Adding a new endpoint to the MCP server API for pushing audit logs.
2. Adding tokens to the MCP servers to allow for authentication when pushing audit logs.