### PR TITLE
fix: auth providers: return correct error when sessions are missing from db

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -349,7 +349,7 @@ func (p *Proxy) authenticateRequest(req *http.Request) (*authenticator.Response,
 	}
 
 	var ss serializableState
-	if err = json.NewDecoder(stateResponse.Body).Decode(&ss); err != nil {
+	if err = json.Unmarshal(body, &ss); err != nil {
 		return nil, false, err
 	}
 


### PR DESCRIPTION
This is something I ran across when I was working on an auth provider issue. If the session was not found in the database (i.e. the user is using a cookie that doesn't map to an existing session, but is formatted correctly), they would receive a cryptic JSON parsing error attached to the 401. This fixes that by checking the body first before we attempt to decode it as JSON.