### PR TITLE
fix: ensure all webhook definitions are used in the backend

### DIFF
--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -230,7 +230,7 @@ func constructNanobotYAMLForServer(name, url, command string, args []string, env
 			BaseURL: webhook.URL,
 		}
 		for _, def := range webhook.Definitions {
-			webhookDefinitions[def] = []string{fmt.Sprintf("%s/%s", name, webhookToolName)}
+			webhookDefinitions[def] = append(webhookDefinitions[def], fmt.Sprintf("%s/%s", name, webhookToolName))
 		}
 	}
 


### PR DESCRIPTION
We were overwriting the webhookDefinitions map instead of appending to it.

Issue: https://github.com/obot-platform/obot/issues/5186