### PR TITLE
fix: dont strip nanobot meta env from real deployment

### DIFF
--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -510,7 +510,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 						if server.Runtime != types.RuntimeComposite {
 							delete(secretEnvStringData, k)
 						}
-					} else if strings.HasPrefix(k, "NANOBOT_") {
+					} else if strings.HasPrefix(k, "NANOBOT_RUN_") {
 						vars[k] = v
 						if strings.HasPrefix(k, "NANOBOT_RUN_AUDIT_LOG_") || k != "NANOBOT_RUN_HEALTHZ_PATH" && server.Runtime != types.RuntimeComposite {
 							delete(secretEnvStringData, k)


### PR DESCRIPTION
This was breaking nanobot wrapper images that expect `NANOBOT_META_ENV` to carry required env vars for the MCP server they wrap.

See https://github.com/obot-platform/mcp-images/blob/628eab173e6932a5bfe94d9fd677dd20c9c7a6ea/scripts/nanobot.sh#L36

Addresses http://github.com/obot-platform/obot/issues/5212

