### PR TITLE
fix: ensure new composite configuration is used on upgrades

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -135,7 +135,7 @@ config:
   # config.OBOT_SERVER_MCPBASE_IMAGE -- Deploy MCP servers in the cluster using this base image. OBOT_SERVER_MCPNAMESPACE is automatically added to the secret if config.OBOT_SERVER_MCPBASE_IMAGE is set.
   OBOT_SERVER_MCPBASE_IMAGE: "ghcr.io/obot-platform/mcp-images/phat:main"
   # config.OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE -- Deploy MCP remote shim servers in the cluster using this base image.
-  OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE: "ghcr.io/nanobot-ai/nanobot:v0.0.42"
+  OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE: "ghcr.io/nanobot-ai/nanobot:v0.0.43"
   # config.OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE -- Deploy MCP HTTP webhook servers in the cluster using this base image.
   OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE: "ghcr.io/obot-platform/mcp-images/http-webhook-converter:main"
   # config.OBOT_SERVER_MCPCLUSTER_DOMAIN -- The cluster domain to use for MCP services. Defaults to cluster.local. Only matters if the above image is set.

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -33,7 +33,7 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_AUDIT_LOGS_COMPRESS_FILE` | Controls whether or not to compress audit log files | `true` |
 | `OBOT_SERVER_AUDIT_LOGS_USE_PATH_STYLE` | Whether to use path style for S3 | - |
 | `OBOT_SERVER_MCPBASE_IMAGE` | Deploy MCP servers in the kubernetes cluster or using docker with this base image. | `ghcr.io/obot-platform/mcp-images/phat:main` |
-| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.42` |
+| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.43` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-converter:main` |
 | `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker, kubernetes, or local. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/moby/moby/api v1.52.0-alpha.1
 	github.com/moby/moby/client v0.1.0-alpha.0
 	github.com/modelcontextprotocol/go-sdk v0.2.0
-	github.com/nanobot-ai/nanobot v0.0.37
+	github.com/nanobot-ai/nanobot v0.0.43
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037
 	github.com/obot-platform/kinm v0.0.0-20250905213846-3c65d6845f83
 	github.com/obot-platform/nah v0.0.0-20250418220644-1b9278409317

--- a/go.sum
+++ b/go.sum
@@ -571,8 +571,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/nanobot-ai/nanobot v0.0.37 h1:b5LtTdfXsyqWogAeqlwv6L48haFwY9AUdkpcxwmZVRI=
-github.com/nanobot-ai/nanobot v0.0.37/go.mod h1:nA7TiHzmJUue6NFJkCEKFT6egyzz1HczdFM/fKxHEoE=
+github.com/nanobot-ai/nanobot v0.0.43 h1:J9EwR1dIFtJ8dYU+vj0QXFxrbPgqBT1sT7WsxeiQSHM=
+github.com/nanobot-ai/nanobot v0.0.43/go.mod h1:1OKH4u7G65z9xvh7N95yJxorecYD7J0p6q9yoiRPtBk=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package api
 
 import (

--- a/pkg/gateway/context/context.go
+++ b/pkg/gateway/context/context.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package context
 
 import (

--- a/pkg/gateway/time/duration_test.go
+++ b/pkg/gateway/time/duration_test.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package time
 
 import (

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package hash
 
 import (

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -485,6 +485,8 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 			return nil, fmt.Errorf("failed to construct nanobot.yaml: %w", err)
 		}
 
+		annotations["nanobot-file-rev"] = hash.Digest(nanobotFileString)
+
 		objs = append(objs, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        name.SafeConcatName(server.MCPServerName, "run", "shim"),
@@ -699,6 +701,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 		var nanobotFileString string
 		if server.Runtime == types.RuntimeComposite {
 			nanobotFileString, err = constructNanobotYAMLForCompositeServer(server.Components)
+			annotations["nanobot-composite-file-rev"] = hash.Digest(nanobotFileString)
 		} else {
 			nanobotFileString, err = constructNanobotYAMLForServer(server.MCPServerDisplayName, server.URL, server.Command, server.Args, secretEnvStringData, headerData, webhooks)
 		}

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -28,7 +28,7 @@ var log = logger.Package()
 type Options struct {
 	MCPBaseImage            string   `usage:"The base image to use for MCP containers" default:"ghcr.io/obot-platform/mcp-images/phat:main"`
 	MCPHTTPWebhookBaseImage string   `usage:"The base image to use for HTTP-based MCP webhook containers" default:"ghcr.io/obot-platform/mcp-images/http-webhook-converter:main"`
-	MCPRemoteShimBaseImage  string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.42"`
+	MCPRemoteShimBaseImage  string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.43"`
 	MCPNamespace            string   `usage:"The namespace to use for MCP containers" default:"obot-mcp"`
 	MCPClusterDomain        string   `usage:"The cluster domain to use for MCP containers" default:"cluster.local"`
 	DisallowLocalhostMCP    bool     `usage:"Allow MCP containers to run on localhost"`


### PR DESCRIPTION
This change fixes two issues in this area:
1. When new composite configuration is needed, we need to ensure the nanobot process is restarted to pick up the new configuration.
2. When nanobot client is created using an existing session, we need to ensure the client has the original initialization request.

Issues: https://github.com/obot-platform/obot/issues/5166, https://github.com/obot-platform/obot/issues/5170