### PR TITLE
fix: auth: return invalid session when there is no configured provider

### DIFF
--- a/pkg/gateway/time/duration.go
+++ b/pkg/gateway/time/duration.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package time
 
 import (

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -34,17 +34,12 @@ const (
 
 var ErrInvalidSession = errors.New("invalid session")
 
-type cacheObject struct {
-	provider  string
-	createdAt time.Time
-}
-
 type Manager struct {
 	dispatcher *dispatcher.Dispatcher
 	gptClient  *gptscript.GPTScript
 }
 
-func NewProxyManager(ctx context.Context, dispatcher *dispatcher.Dispatcher, gptClient *gptscript.GPTScript) *Manager {
+func NewProxyManager(dispatcher *dispatcher.Dispatcher, gptClient *gptscript.GPTScript) *Manager {
 	m := &Manager{
 		dispatcher: dispatcher,
 		gptClient:  gptClient,

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -651,7 +651,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 
 	authenticators := gserver.NewGatewayTokenReviewer(gatewayClient, gptscriptClient, providerDispatcher)
 	if config.EnableAuthentication {
-		proxyManager = proxy.NewProxyManager(ctx, providerDispatcher, gptscriptClient)
+		proxyManager = proxy.NewProxyManager(providerDispatcher, gptscriptClient)
 
 		// Token Auth + OAuth auth
 		authenticators = union.NewFailOnError(authenticators, proxyManager)


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5244

This authenticator was using a cache of token hashes to auth providers, and wrongly assumed that auth providers would continue to be configured. This cache was only ever needed back when we supported multiple auth providers at once. Now that we don't anymore, I removed it, and simplified the logic (although there is more simplification we could do here later).

Now, we check for a session cookie first. If there isn't one, we return nil and it moves on to the next authenticator in the chain. If there is one, then we check for the configured auth provider. If there is no configured auth provider, we return `ErrInvalidSession`, which is the specific error that the authenticator checks for, to know when to tell the browser to delete the session cookie. This fixes the bug in the issue that I linked.