### PR TITLE
fix: auth: catch another invalid session error

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -344,7 +344,7 @@ func (p *Proxy) authenticateRequest(req *http.Request) (*authenticator.Response,
 		return nil, false, err
 	}
 
-	if stateResponse.StatusCode == http.StatusInternalServerError && strings.Contains(string(body), "record not found") {
+	if stateResponse.StatusCode == http.StatusInternalServerError && (strings.Contains(string(body), "record not found") || strings.Contains(string(body), "session ticket cookie failed validation")) {
 		return nil, false, ErrInvalidSession
 	}
 


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5235

This catches another error that should result in invalid session.