### PR TITLE
fix: give auditors access to storage credentials

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -154,6 +154,8 @@ var (
 			"/api/audit-log-exports/{id}",
 			"/api/scheduled-audit-log-exports",
 			"/api/scheduled-audit-log-exports/{id}",
+			"/api/storage-credentials",
+			"/api/storage-credentials/",
 		},
 		anyGroup: {
 			// Allow access to the oauth2 endpoints


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/5249