### PR TITLE
fix: use correct port for containerized runtime shims

### DIFF
--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -215,6 +215,8 @@ func (d *dockerBackend) ensureServerDeployment(ctx context.Context, server Serve
 		}
 
 		server.MCPServerName += "-shim"
+		// Set the container port to 0 for the shim so the default port is used.
+		server.ContainerPort = 0
 	} else {
 		server.URL = strings.Replace(server.URL, "http://localhost", d.hostBaseURL, 1)
 	}


### PR DESCRIPTION
The container port for the containerized MCP server was being used for the shim, which is incorrect. The shim should use the default port.