### PR TITLE
fix: composite tool override oauth dialog

### DIFF
--- a/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
@@ -105,7 +105,6 @@
 							toolOverrides: []
 						} as CatalogComponentServer);
 			initConfigureToolsDialog?.open();
-			handleConfigureToolsInit();
 		} else {
 			searchDialog?.open();
 		}
@@ -123,10 +122,6 @@
 
 	async function handleConfigureToolsInit() {
 		if (!configuringEntry) return;
-
-		if (presetConfiguringEntry) {
-			initConfigureToolsDialog?.close();
-		}
 
 		if ('isCatalogEntry' in configuringEntry && hasEditableConfiguration(configuringEntry)) {
 			choiceDialog?.close();
@@ -470,8 +465,8 @@
 		if (!configuringEntry) return;
 		const configValues = convertEnvHeadersToRecord(configureForm?.envs, configureForm?.headers);
 		await runPreview({ config: configValues, url: configureForm?.url });
-		// Only proceed if there was no error
 		if (!error) {
+			// Keep the dialog open to display the error
 			configDialog?.close();
 			modifyToolsDialog?.open();
 		}


### PR DESCRIPTION
- Fix a regression caused by https://github.com/obot-platform/obot/pull/5265
  that resulted in the `Configure Tools` dialog closing immediately for MCP servers
  requiring OAuth that were already in the component list.
- Fix a similar issue for multi-user components

Addresses: https://github.com/obot-platform/obot/issues/5273
