### PR TITLE
Fix: Drop tools/list from audit log default

### DIFF
--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -99,14 +99,7 @@
 	];
 
 	const defaultSearchParams: Partial<AuditLogURLFilters> = {
-		call_type: [
-			'prompts/list',
-			'resources/read',
-			'tools/list',
-			'tools/call',
-			'prompts/get',
-			'resources/list'
-		].join(',')
+		call_type: ['resources/read', 'tools/call', 'prompts/get'].join(',')
 	};
 
 	const searchParamsAsArray: [SupportedFilter, string | undefined | null][] = $derived(


### PR DESCRIPTION
Our default API call for audit logs is too big. A big contributor to
this is the tools/list call which gets called a lot and is typically
pertty big. This just drops that callType from the default set of
callTypes we show on the audit log page.

Signed-off-by: Craig Jellick <craig@obot.ai>
