### PR TITLE
fix: exclude req/resp bodies from audit log log list api

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -60,6 +60,7 @@ var (
 		"/api/system-mcp-servers/",
 		"GET /api/mcp-audit-logs",
 		"GET /api/mcp-audit-logs/filter-options/{filter}",
+		"GET /api/mcp-audit-logs/detail/{audit_log_id}",
 		"GET /api/mcp-audit-logs/{mcp_id}",
 		"GET /api/mcp-stats",
 		"GET /api/mcp-stats/{mcp_id}",
@@ -125,6 +126,7 @@ var (
 		types.GroupAuditor: {
 			"GET /api/mcp-audit-logs",
 			"GET /api/mcp-audit-logs/filter-options/{filter}",
+			"GET /api/mcp-audit-logs/detail/{audit_log_id}",
 			"GET /api/mcp-audit-logs/{mcp_id}",
 			"GET /api/mcp-stats",
 			"GET /api/mcp-stats/{mcp_id}",

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -597,6 +597,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mux.HandleFunc("GET /api/mcp-audit-logs", mcpAuditLogs.ListAuditLogs)
 	mux.HandleFunc("POST /api/mcp-audit-logs", mcpAuditLogs.SubmitAuditLogs)
 	mux.HandleFunc("GET /api/mcp-audit-logs/filter-options/{filter}", mcpAuditLogs.ListAuditLogFilterOptions)
+	mux.HandleFunc("GET /api/mcp-audit-logs/detail/{audit_log_id}", mcpAuditLogs.GetAuditLog)
 	mux.HandleFunc("GET /api/mcp-audit-logs/{mcp_id}", mcpAuditLogs.ListAuditLogs)
 	mux.HandleFunc("GET /api/mcp-stats", mcpAuditLogs.GetUsageStats)
 	mux.HandleFunc("GET /api/mcp-stats/{mcp_id}", mcpAuditLogs.GetUsageStats)

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -593,10 +593,18 @@
 
 	<AuditLogsTable
 		data={remoteAuditLogs}
-		onSelectRow={(d: typeof selectedAuditLog) => {
-			selectedAuditLog = d;
+		onSelectRow={async (d: AuditLog & { user: string }) => {
 			showFilters = false;
 			rightSidebar?.show();
+			// Fetch full audit log details with request/response bodies
+			try {
+				const fullDetails = await AdminService.getAuditLog(d.id);
+				selectedAuditLog = { ...fullDetails, user: d.user };
+			} catch (error) {
+				console.error('Failed to fetch audit log details:', error);
+				// Fallback to the cached data if fetch fails
+				selectedAuditLog = d;
+			}
 		}}
 		getUserDisplayName={(userId: string, hasConflict?: () => boolean) =>
 			getUserDisplayName(users, userId, hasConflict)}

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -768,6 +768,11 @@ export async function listServerOrInstanceAuditLogs(
 	return response;
 }
 
+export async function getAuditLog(id: string | number, opts?: { fetch?: Fetcher }) {
+	const response = (await doGet(`/mcp-audit-logs/detail/${id}`, opts)) as AuditLog;
+	return response;
+}
+
 type AuditLogUsageFilters = {
 	mcp_id?: string;
 	mcp_server_catalog_entry_names?: string;


### PR DESCRIPTION
- Add new API to get the full details of a specific audit log by ID
- Drop request/response bodies from audit log list API for everyone (not
  just auditors)

Addresses https://github.com/obot-platform/obot/issues/5319

