### PR TITLE
fix: user registry pill for basic/pup viewing a registry entry

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -88,13 +88,7 @@ func (m *MCPHandler) GetEntryFromAllSources(req api.Context) error {
 		return types.NewErrForbidden("user is not authorized to access this catalog entry")
 	}
 
-	// Only include powerUserWorkspaceID if it matches the user's workspace
-	var powerUserWorkspaceID string
-	if entry.Spec.PowerUserWorkspaceID == system.GetPowerUserWorkspaceID(req.User.GetUID()) {
-		powerUserWorkspaceID = entry.Spec.PowerUserWorkspaceID
-	}
-
-	return req.Write(ConvertMCPServerCatalogEntryWithWorkspace(entry, powerUserWorkspaceID, ""))
+	return req.Write(ConvertMCPServerCatalogEntryWithWorkspace(entry, entry.Spec.PowerUserWorkspaceID, ""))
 }
 
 func (m *MCPHandler) ListEntriesFromAllSources(req api.Context) error {

--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -24,8 +24,9 @@
 	import Confirm from '../Confirm.svelte';
 	import { goto } from '$lib/url';
 	import SearchMcpServers from './SearchMcpServers.svelte';
-	import { getRegistryLabel, getUserDisplayName } from '$lib/utils';
+	import { getUserDisplayName } from '$lib/utils';
 	import { profile } from '$lib/stores';
+	import { getUserRegistry } from '$lib/services/chat/mcp';
 
 	interface Props {
 		topContent?: Snippet;
@@ -289,11 +290,7 @@
 					</h1>
 					{#if !loadingUsersAndGroups}
 						{#if initialAccessControlRule}
-							{@const registry = getRegistryLabel(
-								initialAccessControlRule.powerUserID,
-								profile.current?.id,
-								usersAndGroups?.users
-							)}
+							{@const registry = getUserRegistry(initialAccessControlRule, usersMap)}
 							{#if registry}
 								<div class="dark:bg-surface2 bg-surface3 rounded-full px-3 py-1 text-xs">
 									{registry}

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -36,7 +36,7 @@
 	import McpServerTools from '../mcp/McpServerTools.svelte';
 	import AuditLogsPageContent from './audit-logs/AuditLogsPageContent.svelte';
 	import { page } from '$app/state';
-	import { getRegistryLabel, openUrl } from '$lib/utils';
+	import { openUrl } from '$lib/utils';
 	import CatalogConfigureForm, {
 		type LaunchFormData,
 		type CompositeLaunchFormData,
@@ -47,7 +47,7 @@
 	import { setVirtualPageDisabled } from '../ui/virtual-page/context';
 	import { profile } from '$lib/stores';
 	import OverflowContainer from '../OverflowContainer.svelte';
-	import { getServerTypeLabel } from '$lib/services/chat/mcp';
+	import { getServerTypeLabel, getUserRegistry } from '$lib/services/chat/mcp';
 	import { resolve } from '$app/paths';
 
 	interface Props {
@@ -76,7 +76,6 @@
 		isDialogView
 	}: Props = $props();
 	let isAtLeastPowerUserPlus = $derived(profile.current?.groups.includes(Group.POWERUSER_PLUS));
-	let isAuditor = $derived(profile.current?.groups.includes(Group.AUDITOR));
 	let belongsToUser = $derived(
 		(entity === 'workspace' && entry?.powerUserWorkspaceID && entry.powerUserWorkspaceID === id) ||
 			profile.current?.hasAdminAccess?.()
@@ -85,16 +84,8 @@
 	let listAccessControlRules = $state<Promise<AccessControlRule[]>>();
 	let listFilters = $state<Promise<MCPFilter[]>>();
 	let users = $state<OrgUser[]>([]);
-	let registry = $derived.by(() => {
-		if (!entry) return undefined;
-		const ownerUserId =
-			'isCatalogEntry' in entry
-				? entry.powerUserID
-				: entry.powerUserWorkspaceID
-					? entry.userID
-					: undefined;
-		return getRegistryLabel(ownerUserId, profile.current?.id, users);
-	});
+	let usersMap = $derived(new Map(users.map((user) => [user.id, user])));
+	let registry = $derived(entry ? getUserRegistry(entry, usersMap) : 'Global Registry');
 
 	let deleteServer = $state(false);
 	let deleteConflictError = $state<MCPCompositeDeletionDependencyError | undefined>();
@@ -190,11 +181,9 @@
 	});
 
 	onMount(() => {
-		if (isAtLeastPowerUserPlus || isAuditor) {
-			AdminService.listUsersIncludeDeleted().then((data) => {
-				users = data;
-			});
-		}
+		AdminService.listUsersIncludeDeleted().then((data) => {
+			users = data;
+		});
 
 		checkScrollPosition();
 		scrollContainer?.addEventListener('scroll', checkScrollPosition);
@@ -460,8 +449,7 @@
 			})),
 			headers: entry.manifest?.remoteConfig?.headers?.map((header) => ({
 				...header,
-				value: '',
-				isStatic: header.value !== ''
+				value: ''
 			})),
 			...(hostname ? { hostname, url: '' } : {})
 		};
@@ -972,7 +960,6 @@
 	submitText="Launch"
 	loading={saving}
 	isNew={false}
-	{type}
 />
 
 <ResponsiveDialog

--- a/ui/user/src/lib/services/chat/mcp.ts
+++ b/ui/user/src/lib/services/chat/mcp.ts
@@ -3,6 +3,7 @@ import { profile } from '$lib/stores';
 import { getUserDisplayName } from '$lib/utils';
 import {
 	ChatService,
+	type AccessControlRule,
 	type LaunchServerType,
 	type MCPCatalogEntry,
 	type MCPCatalogServer,
@@ -107,8 +108,8 @@ export function requiresUserUpdate(server?: MCPCatalogServer) {
 	return typeof server?.configured === 'boolean' ? server?.configured === false : false;
 }
 
-function getUserRegistry(
-	entity: MCPCatalogEntry | MCPCatalogServer,
+export function getUserRegistry(
+	entity: MCPCatalogEntry | MCPCatalogServer | AccessControlRule,
 	usersMap?: Map<string, OrgUser>
 ) {
 	let registry: string = 'Global Registry';

--- a/ui/user/src/lib/utils.ts
+++ b/ui/user/src/lib/utils.ts
@@ -246,13 +246,3 @@ export function getUserDisplayName(
 
 	return display;
 }
-
-export function getRegistryLabel(idToLookup?: string, myID?: string, users?: OrgUser[]) {
-	const usersMap = new Map(users?.map((user) => [user.id, user]));
-	const user = idToLookup ? usersMap.get(idToLookup) : undefined;
-	const ownerDisplayName = user && getUserDisplayName(usersMap, user.id);
-	const isMe = idToLookup === myID;
-	return idToLookup
-		? `${isMe ? 'My' : `${ownerDisplayName || 'Unknown'}'s`} Registry`
-		: 'Global Registry';
-}


### PR DESCRIPTION
Addresses follow up on #5314 
* use common util fn `getUserRegistry`
* removes restriction on getting back powerUserWorkspaceID in all-mcps-/entries/{entry_id}