### PR TITLE
fix: dont show populate tools option for configured server

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -124,6 +124,7 @@
 
 	let showRegenerateToolsButton = $derived(
 		entry &&
+			!server &&
 			entry.manifest?.toolPreview &&
 			'toolPreviewsLastGenerated' in entry &&
 			'lastUpdated' in entry &&
@@ -604,10 +605,10 @@
 					{#snippet noToolsContent()}
 						<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
 							<Wrench class="text-on-surface1 size-24 opacity-50" />
-							{#if !entry || (entry && readonly)}
+							{#if !entry || (entry && (readonly || server))}
 								<h4 class="text-on-surface1 text-lg font-semibold">No tools</h4>
 								<p class="text-on-surface1 text-sm font-light">
-									Looks like this MCP server doesn't have any tools available.
+									Looks like this MCP server doesn't have any tools available currently.
 								</p>
 							{:else if !readonly}
 								<h4 class="text-on-surface1 text-lg font-semibold">No tools</h4>


### PR DESCRIPTION
* don't show Populate Tool Preview options for a configured server of a catalog entry 