### PR TITLE
fix: k8s controller: use correct label on deployments

### DIFF
--- a/pkg/controller/handlers/deployment/deployment.go
+++ b/pkg/controller/handlers/deployment/deployment.go
@@ -30,12 +30,12 @@ func New(mcpNamespace string, storageClient kclient.Client) *Handler {
 }
 
 // UpdateMCPServerStatus watches for Deployment changes and copies status information
-// to the corresponding MCPServer object based on the "mcp-server-name" label
+// to the corresponding MCPServer object based on the "app" label
 func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) error {
 	deployment := req.Object.(*appsv1.Deployment)
 
 	// Get the MCP server name from the deployment label
-	mcpServerName, exists := deployment.Labels["mcp-server-name"]
+	mcpServerName, exists := deployment.Labels["app"]
 	if !exists {
 		// This deployment is not associated with an MCP server, skip it
 		return nil


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5342

The `mcp-server-name` label was replaced during the large refactor. Now, the `app` label contains the name of the MCPServer that corresponds to the k8s Deployment.