### PR TITLE
fix: cancel correctly redirects for pup mcp-registries

### DIFF
--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -437,8 +437,10 @@
 						onclick={() => {
 							if (redirect) {
 								goto(redirect);
-							} else {
+							} else if (profile.current.hasAdminAccess?.()) {
 								goto('/admin/mcp-registries');
+							} else {
+								goto('/mcp-registries');
 							}
 						}}
 					>

--- a/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
+++ b/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
@@ -16,6 +16,7 @@
 	import { Circle, CircleCheck, LoaderCircle } from 'lucide-svelte';
 	import { goto } from '$lib/url';
 	import { ADMIN_SESSION_STORAGE } from '$lib/constants';
+	import { profile } from '$lib/stores';
 
 	interface Props {
 		entry?: MCPCatalogEntry | MCPCatalogServer;
@@ -107,7 +108,11 @@
 		if (entry) {
 			sessionStorage.setItem(ADMIN_SESSION_STORAGE.ACCESS_CONTROL_RULE_CREATION, entry.id);
 		}
-		goto('/admin/mcp-registries?new=true');
+		goto(
+			profile.current?.hasAdminAccess?.()
+				? '/admin/mcp-registries?new=true'
+				: '/mcp-registries?new=true'
+		);
 	}
 </script>
 
@@ -185,7 +190,7 @@
 	{/if}
 	{#if accessControlRules.length > 0}
 		<div class="mt-auto flex justify-between gap-4">
-			<button class="button-primary" onclick={handleCreateNewRule}> Create New Rule </button>
+			<button class="button-primary" onclick={handleCreateNewRule}> Create New Registry </button>
 			<div class="flex items-center gap-4">
 				<button
 					class="button-primary flex items-center gap-1"


### PR DESCRIPTION
* correct goto route for /mcp-registries depending if user has admin access
* for both canceling on creating new registry or for create new registry during catalog entry creation