### PR TITLE
fix: delete button showing incorrectly & incorrect delete call

### DIFF
--- a/ui/user/src/lib/components/chat/McpServerSetup.svelte
+++ b/ui/user/src/lib/components/chat/McpServerSetup.svelte
@@ -184,6 +184,7 @@
 				entity="workspace"
 				{hasExistingConfigured}
 				isDialogView
+				limitViews={['overview', 'tools']}
 			/>
 		</div>
 	{/if}


### PR DESCRIPTION
Addresses #5355 

* fixes delete button shouldn't show if it's a catalog
* delete button shouldn't show on chat connector view/also simplified it to show just overview & tools
* when navigating to server details, need to account for admin access to navigate to right path (/admin/mcp-servers instead of /mcp-servers)