### PR TITLE
Fix: Don't tag any pre-releases as latest

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -38,7 +38,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
+        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -55,7 +55,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') && format('docker.io/obot/{0}:{1}', github.event.repository.name, github.ref_name) || '' }}
+            ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') && format('docker.io/obot/{0}:{1}', github.event.repository.name, github.ref_name) || '' }}
           build-args: |
             BASE_IMAGE=ghcr.io/obot-platform/obot/base:latest
 
@@ -69,7 +69,7 @@ jobs:
       - name: Sign Images
         env:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
-          TAGS: ghcr.io/${{ github.repository }}:${{ github.ref_name }} ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') && format('docker.io/obot/{0}:{1}', github.event.repository.name, github.ref_name) || '' }}
+          TAGS: ghcr.io/${{ github.repository }}:${{ github.ref_name }} ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') && format('docker.io/obot/{0}:{1}', github.event.repository.name, github.ref_name) || '' }}
         run: |
           images=""
           for tag in ${TAGS}; do
@@ -81,7 +81,7 @@ jobs:
         uses: imjasonh/setup-crane@v0.4
 
       - name: Copy OSS image to latest tag
-        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
+        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
         run: |
           crane tag ghcr.io/${{ github.repository }}:${{ github.ref_name }} latest
           crane tag docker.io/obot/${{ github.event.repository.name }}:${{ github.ref_name }} latest
@@ -135,7 +135,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Log in to Docker Hub
-        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
+        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -178,7 +178,7 @@ jobs:
         uses: imjasonh/setup-crane@v0.4
 
       - name: Copy Enterprise image to latest tag
-        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
+        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
         run: |
           crane tag ghcr.io/${{ github.repository }}-enterprise:${{ github.ref_name }} latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
   winget-release:
     needs: release-tag
-    if: "! contains(github.ref_name, '-rc')"
+    if: "! contains(github.ref_name, '-')"
     runs-on: windows-latest
     steps:
       - name: Install winget-create


### PR DESCRIPTION
When we released v0.16.0-alpha1 we realized that it was all tagged as
`latest`. We don't want that. We don't want any pre-releases getting
tagged as latest.

Signed-off-by: Craig Jellick <craig@acorn.io>
