### PR TITLE
Chore: Allow UI to hit remote API for dev

### DIFF
--- a/ui/user/vite.config.ts
+++ b/ui/user/vite.config.ts
@@ -1,17 +1,37 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
-export default defineConfig({
-	server: {
-		port: 5174,
-		proxy: {
-			'/api': 'http://localhost:8080',
-			'/oauth2': 'http://localhost:8080'
-		}
-	},
-	optimizeDeps: {
-		// currently incompatible with dep optimizer
-		exclude: ['layerchart', 'layercake']
-	},
-	plugins: [sveltekit()]
+export default defineConfig(({ mode }) => {
+	const env = loadEnv(mode, '.', '');
+	const apiTarget = env.VITE_API_TARGET || 'http://localhost:8080';
+	const apiToken = env.VITE_API_TOKEN;
+
+	// Fail build if API token is set in production - it would be exposed in the bundle
+	if (mode === 'production' && apiToken) {
+		throw new Error('VITE_API_TOKEN must not be set for production builds');
+	}
+
+	// Configure proxy to add auth header when API token is set
+	// This is needed for EventSource requests which don't support custom headers
+	const proxyConfig = {
+		target: apiTarget,
+		changeOrigin: true,
+		secure: true,
+		headers: apiToken ? { Authorization: `Bearer ${apiToken}` } : undefined
+	};
+
+	return {
+		server: {
+			port: 5174,
+			proxy: {
+				'/api': proxyConfig,
+				'/oauth2': proxyConfig
+			}
+		},
+		optimizeDeps: {
+			// currently incompatible with dep optimizer
+			exclude: ['layerchart', 'layercake']
+		},
+		plugins: [sveltekit()]
+	};
 });


### PR DESCRIPTION
In local development it is useful to be able to hit a remote instance of
the Obot API, like hitting our "main" environment so that you can
development the frontend against a backend with a lot more data.

This change makes that possible. You need to set two environment
variables when running npm run dev:
- `VITE_API_TARGET=https://<hostname>`
- `VITE_API_TOKEN=<token>`

A few notes on those:
- Note that the API target does NOT include /api at the end, just the
  hostname
- The token will be set as the Authorization Bearer token and is used to
  bypass OAuth. You can obtain a token through the Obot CLI with:
`OBOT_BASE_URL=https://<hostname>/api obot token`
Note that you do include the /api when getting a token this way.

Signed-off-by: Craig Jellick <craig@obot.ai>
