### PR TITLE
fix: prevent Time Range picker from overlapping in Audit Log Export form (#5394)

### DIFF
--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogCalendar.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogCalendar.svelte
@@ -111,7 +111,7 @@
 <div class="flex w-full md:max-w-fit">
 	<button
 		type="button"
-		class="dark:border-surface3 dark:hover:bg-surface2/70 dark:active:bg-surface2 dark:bg-surface1 hover:bg-surface1/70 active:bg-surface1 bg-background relative z-40 flex min-h-12.5 flex-1 flex-shrink-0 items-center gap-2 truncate rounded-l-lg border border-r-0 border-transparent px-2 text-sm shadow-sm transition-colors duration-200 disabled:opacity-50"
+		class="dark:border-surface3 dark:hover:bg-surface2/70 dark:active:bg-surface2 dark:bg-surface1 hover:bg-surface1/70 active:bg-surface1 bg-background relative flex min-h-12.5 flex-1 flex-shrink-0 items-center gap-2 truncate rounded-l-lg border border-r-0 border-transparent px-2 text-sm shadow-sm transition-colors duration-200 disabled:opacity-50"
 		{disabled}
 		use:refAction
 		onclick={() => {
@@ -180,7 +180,7 @@
 
 	<Calendar
 		compact
-		class="dark:border-surface3 hover:bg-surface1 dark:hover:bg-surface3 dark:bg-surface1 bg-background relative z-40 flex min-h-12.5 flex-shrink-0 items-center gap-2 truncate rounded-none rounded-r-lg border border-transparent px-4 text-sm shadow-sm"
+		class="dark:border-surface3 hover:bg-surface1 dark:hover:bg-surface3 dark:bg-surface1 bg-background relative flex min-h-12.5 flex-shrink-0 items-center gap-2 truncate rounded-none rounded-r-lg border border-transparent px-4 text-sm shadow-sm"
 		initialValue={{
 			start: new Date(start),
 			end: end ? new Date(end) : null


### PR DESCRIPTION
## Summary
Fixes #5394

The Time Range selector in the Audit Log Export form was detaching from its original position and floating at the top of the screen when scrolling down to Advanced Options, causing UI overlap issues.

## Changes
- Removed `z-40` from the quick actions button in `AuditLogCalendar.svelte`
- Removed `z-40` from the Calendar component in `AuditLogCalendar.svelte`

## Root Cause
The `z-40` (z-index: 40) on these elements caused them to render above other content during scroll, making the Time Range picker appear to "stick" at the top of the viewport.

## Testing
1. Go to Admin → Audit Logs
2. Click "Create Export" → "Create One-time Export"
3. Scroll down to Advanced Options
4. Verify the Time Range picker stays in its designated section

## Screenshots
Before: Time Range picker floats to top when scrolling
After: Time Range picker stays in place within the form