### PR TITLE
fix: make search input sticky in connectors dialog (#5390)

### DIFF
--- a/ui/user/src/lib/components/chat/McpServerSetup.svelte
+++ b/ui/user/src/lib/components/chat/McpServerSetup.svelte
@@ -191,7 +191,7 @@
 {/snippet}
 
 {#snippet mainContent()}
-	<div class="w-full px-4 py-2">
+	<div class="bg-background sticky top-0 z-10 w-full px-4 py-2">
 		<div class="mb-2 flex items-center justify-between gap-4">
 			<h4 class="text-lg font-semibold">Add Connector</h4>
 			<button


### PR DESCRIPTION
## Summary
Fixes the search input scrolling out of view when scrolling through the connectors dialog.

## Problem
When opening the connectors dialog in the chat view, the search input at the top of the dialog would scroll away with the content, making it difficult for users to filter connectors after scrolling through the list.

## Solution
Added `sticky top-0 z-10 bg-background` CSS classes to the search header container in the `mainContent` snippet of `McpServerSetup.svelte`. This keeps the search input pinned to the top of the dialog while maintaining visual consistency with the background.

## Changes
- [McpServerSetup.svelte](ui/user/src/lib/components/chat/McpServerSetup.svelte): Modified the search header div to be sticky positioned

## Testing
- Verified the search input stays visible at the top while scrolling through the connectors list
- Confirmed the background color properly covers content scrolling behind it