### PR TITLE
enhance: dont give admins implicit access to models

### DIFF
--- a/pkg/api/handlers/model.go
+++ b/pkg/api/handlers/model.go
@@ -33,9 +33,17 @@ func (a *ModelHandler) List(req api.Context) error {
 		return err
 	}
 
-	allowedModels, allowAll, err := a.mapHelper.GetUserAllowedModels(req.User)
-	if err != nil {
-		return err
+	var (
+		allowAll      = req.URL.Query().Get("all") == "true" && req.UserIsAdmin()
+		allowedModels map[string]bool
+		err           error
+	)
+
+	if !allowAll {
+		allowedModels, allowAll, err = a.mapHelper.GetUserAllowedModels(req.User)
+		if err != nil {
+			return err
+		}
 	}
 
 	var toolRefList v1.ToolReferenceList

--- a/pkg/api/handlers/modelprovider.go
+++ b/pkg/api/handlers/modelprovider.go
@@ -8,11 +8,10 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/obot-platform/obot/pkg/api/handlers/providers"
-
 	"github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/api/handlers/providers"
 	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
 	"github.com/obot-platform/obot/pkg/invoke"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"

--- a/pkg/modelaccesspolicy/helper.go
+++ b/pkg/modelaccesspolicy/helper.go
@@ -82,10 +82,6 @@ func (h *Helper) UserHasAccessToModel(user kuser.Info, modelID string) (bool, er
 // getUserAllowedModels returns a set of model IDs that a user can access.
 // If a user is an owner/admin or has been granted access to all models via a wildcard model selector, this method returns nil and true.
 func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, error) {
-	if userIsAdminOrOwner(user) {
-		return nil, true, nil
-	}
-
 	var (
 		allowedModels   = make(map[string]bool)
 		aliasModels     = h.getAliasModels()
@@ -253,9 +249,4 @@ func authGroupSet(user kuser.Info) map[string]struct{} {
 		set[group] = struct{}{}
 	}
 	return set
-}
-
-// userIsAdminOrOwner checks if the user is an admin or owner.
-func userIsAdminOrOwner(user kuser.Info) bool {
-	return slices.Contains(user.GetGroups(), types.GroupAdmin)
 }

--- a/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
@@ -67,7 +67,7 @@
 
 	onMount(async () => {
 		const [fetchedModels, fetchedAliases] = await Promise.all([
-			AdminService.listModels(),
+			AdminService.listModels({ all: true }),
 			AdminService.listDefaultModelAliases()
 		]);
 

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -585,8 +585,9 @@ export async function validateModelProvider(
 	});
 }
 
-export async function listModels(opts?: { fetch?: Fetcher }): Promise<Model[]> {
-	const response = (await doGet('/models', opts)) as ItemsResponse<Model>;
+export async function listModels(opts?: { fetch?: Fetcher; all?: boolean }): Promise<Model[]> {
+	const url = opts?.all ? '/models?all=true' : '/models';
+	const response = (await doGet(url, opts)) as ItemsResponse<Model>;
 	return response.items ?? [];
 }
 

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -45,7 +45,7 @@
 	const adminModels = getAdminModels();
 
 	onMount(async () => {
-		const models = await AdminService.listModels();
+		const models = await AdminService.listModels({ all: true });
 		adminModels.items = models;
 	});
 


### PR DESCRIPTION
Don't allow admins/owners explicit access to all models.

This aligns the behavior of ModelAccessPolicies with AccessControlRules.

Related to https://github.com/obot-platform/obot/issues/5283