### PR TITLE
fix: PUP w/ auditor role not able to create servers

### DIFF
--- a/ui/user/src/routes/admin/mcp-servers/+page.ts
+++ b/ui/user/src/routes/admin/mcp-servers/+page.ts
@@ -1,0 +1,17 @@
+import { ChatService } from '$lib/services';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, parent }) => {
+	const { profile } = await parent();
+	try {
+		const workspaceId = await ChatService.fetchWorkspaceIDForProfile(profile.id, { fetch });
+		return {
+			workspaceId
+		};
+	} catch (_err) {
+		// ex. may not have a workspaceId if basic user with auditor access
+		return {
+			workspaceId: undefined
+		};
+	}
+};

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/+page.svelte
@@ -12,7 +12,7 @@
 	const duration = PAGE_TRANSITION_DURATION;
 
 	let { data } = $props();
-	let { workspaceId, catalogEntry } = $derived(data);
+	let { workspaceId, catalogEntry, belongsToUser } = $derived(data);
 	let title = $derived(catalogEntry?.manifest?.name ?? 'MCP Server');
 
 	const hasExistingConfigured = $derived(
@@ -23,6 +23,8 @@
 				)
 		)
 	);
+
+	let readonly = $derived(belongsToUser ? false : profile.current.isAdminReadonly?.());
 </script>
 
 <Layout
@@ -49,7 +51,7 @@
 				onSubmit={async () => {
 					goto('/admin/mcp-servers');
 				}}
-				readonly={profile.current.isAdminReadonly?.()}
+				{readonly}
 				{hasExistingConfigured}
 			/>
 		{/if}

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/+page.ts
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/+page.ts
@@ -1,18 +1,29 @@
 import { handleRouteError } from '$lib/errors';
 import { ChatService } from '$lib/services';
-import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ params, fetch }) => {
+export const load: PageLoad = async ({ params, fetch, parent }) => {
 	const { id, wid } = params;
+	const { profile } = await parent();
+
+	let belongsToUser;
 	let catalogEntry;
 	try {
 		catalogEntry = await ChatService.getWorkspaceMCPCatalogEntry(wid, id, { fetch });
 	} catch (err) {
-		handleRouteError(err, `/admin/mcp-servers/w/${wid}/c/${id}`, profile.current);
+		handleRouteError(err, `/admin/mcp-servers/w/${wid}/c/${id}`, profile);
 	}
+
+	try {
+		const userWorkspaceId = await ChatService.fetchWorkspaceIDForProfile(profile.id, { fetch });
+		belongsToUser = userWorkspaceId === wid;
+	} catch (_err) {
+		belongsToUser = false;
+	}
+
 	return {
 		workspaceId: wid,
+		belongsToUser,
 		catalogEntry
 	};
 };

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/instance/[ms_id]/+page.svelte
@@ -13,7 +13,7 @@
 	const duration = PAGE_TRANSITION_DURATION;
 
 	let { data } = $props();
-	let { workspaceId, catalogEntry, mcpServer } = $derived(data);
+	let { workspaceId, catalogEntry, mcpServer, belongsToUser } = $derived(data);
 	let title = $derived(catalogEntry?.manifest?.name ?? 'MCP Server');
 
 	function navigateToMcpServers() {
@@ -42,7 +42,7 @@
 				entity="workspace"
 				onCancel={navigateToMcpServers}
 				onSubmit={navigateToMcpServers}
-				readonly={profile.current.isAdminReadonly?.()}
+				readonly={belongsToUser ? false : profile.current.isAdminReadonly?.()}
 			/>
 		{/if}
 	</div>

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/instance/[ms_id]/+page.ts
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/instance/[ms_id]/+page.ts
@@ -1,13 +1,14 @@
 import { handleRouteError } from '$lib/errors';
 import { ChatService } from '$lib/services';
-import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ params, fetch }) => {
+export const load: PageLoad = async ({ params, fetch, parent }) => {
+	const { profile } = await parent();
 	const workspaceId = params.wid;
 	const catalogEntryId = params.id;
 	const mcpServerId = params.ms_id;
 	let mcpServer;
+	let belongsToUser;
 
 	let catalogEntry;
 	try {
@@ -19,14 +20,22 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		handleRouteError(
 			err,
 			`/admin/mcp-servers/w/${workspaceId}/c/${catalogEntryId}/instance/${mcpServerId}`,
-			profile.current
+			profile
 		);
+	}
+
+	try {
+		const userWorkspaceId = await ChatService.fetchWorkspaceIDForProfile(profile.id, { fetch });
+		belongsToUser = userWorkspaceId === workspaceId;
+	} catch (_err) {
+		belongsToUser = false;
 	}
 
 	return {
 		workspaceId,
 		catalogEntry,
 		mcpServerId,
-		mcpServer
+		mcpServer,
+		belongsToUser
 	};
 };

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/+page.svelte
@@ -12,7 +12,7 @@
 	const duration = PAGE_TRANSITION_DURATION;
 
 	let { data } = $props();
-	let { mcpServer, workspaceId } = $derived(data);
+	let { mcpServer, workspaceId, belongsToUser } = $derived(data);
 	let title = $derived(mcpServer?.manifest?.name ?? 'MCP Server');
 </script>
 
@@ -40,7 +40,7 @@
 				onSubmit={async () => {
 					goto('/admin/mcp-servers');
 				}}
-				readonly={profile.current.isAdminReadonly?.()}
+				readonly={belongsToUser ? false : profile.current.isAdminReadonly?.()}
 			/>
 		{/if}
 	</div>

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/+page.ts
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/+page.ts
@@ -1,22 +1,31 @@
 import { handleRouteError } from '$lib/errors';
 import { ChatService } from '$lib/services';
-import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ params, fetch }) => {
+export const load: PageLoad = async ({ params, fetch, parent }) => {
 	const { id, wid } = params;
+	const { profile } = await parent();
 
+	let belongsToUser;
 	let mcpServer;
 	try {
 		mcpServer = await ChatService.getWorkspaceMCPCatalogServer(wid, id, {
 			fetch
 		});
 	} catch (err) {
-		handleRouteError(err, `/admin/mcp-servers/w/${wid}/s/${id}`, profile.current);
+		handleRouteError(err, `/admin/mcp-servers/w/${wid}/s/${id}`, profile);
+	}
+
+	try {
+		const userWorkspaceId = await ChatService.fetchWorkspaceIDForProfile(profile.id, { fetch });
+		belongsToUser = userWorkspaceId === wid;
+	} catch (_err) {
+		belongsToUser = false;
 	}
 
 	return {
 		mcpServer,
-		workspaceId: wid
+		workspaceId: wid,
+		belongsToUser
 	};
 };

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/details/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/details/+page.svelte
@@ -10,7 +10,7 @@
 	import { fly } from 'svelte/transition';
 
 	let { data } = $props();
-	let { mcpServer, workspaceId } = $derived(data);
+	let { mcpServer, workspaceId, belongsToUser } = $derived(data);
 	let loading = $state(false);
 	let users = $state<OrgUser[]>([]);
 	let instances = $state<MCPServerInstance[]>([]);
@@ -55,7 +55,7 @@
 						classes={{
 							title: 'text-lg font-semibold'
 						}}
-						readonly={profile.current.isAdminReadonly?.()}
+						readonly={belongsToUser ? false : profile.current.isAdminReadonly?.()}
 					/>
 				{/if}
 			</div>

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/details/+page.ts
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/details/+page.ts
@@ -1,20 +1,29 @@
 import { handleRouteError } from '$lib/errors';
 import { ChatService } from '$lib/services';
-import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ params, fetch }) => {
+export const load: PageLoad = async ({ params, fetch, parent }) => {
 	const { wid, id } = params;
+	const { profile } = await parent();
 
+	let belongsToUser;
 	let mcpServer;
 	try {
 		mcpServer = await ChatService.getWorkspaceMCPCatalogServer(wid, id, { fetch });
 	} catch (err) {
-		handleRouteError(err, `/admin/mcp-servers/w/${wid}/s/${id}/details`, profile.current);
+		handleRouteError(err, `/admin/mcp-servers/w/${wid}/s/${id}/details`, profile);
+	}
+
+	try {
+		const userWorkspaceId = await ChatService.fetchWorkspaceIDForProfile(profile.id, { fetch });
+		belongsToUser = userWorkspaceId === wid;
+	} catch (_err) {
+		belongsToUser = false;
 	}
 
 	return {
 		mcpServer,
-		workspaceId: wid
+		workspaceId: wid,
+		belongsToUser
 	};
 };


### PR DESCRIPTION
Addresses #5424 

This PR is to make sure poweruser/poweruser plus still have access to creating/editing servers in admin routes when they are auditors.