### PR TITLE
fix: dont allow admins to connect to mcp servers they dont have access to

### DIFF
--- a/pkg/accesscontrolrule/helper.go
+++ b/pkg/accesscontrolrule/helper.go
@@ -154,10 +154,6 @@ func (h *Helper) GetAccessControlRulesForSelectorInCatalog(namespace, selector, 
 // UserHasAccessToMCPServerInCatalog checks if a user has access to a specific MCP server through AccessControlRules
 // This method now requires the catalog ID to ensure proper scoping
 func (h *Helper) UserHasAccessToMCPServerInCatalog(user kuser.Info, serverName, catalogID string) (bool, error) {
-	if userIsAdminOrOwner(user) {
-		return true, nil
-	}
-
 	// See if there is a selector that this user is included on in the specified catalog.
 	selectorRules, err := h.GetAccessControlRulesForSelectorInCatalog(system.DefaultNamespace, "*", catalogID)
 	if err != nil {
@@ -218,10 +214,6 @@ func (h *Helper) UserHasAccessToMCPServerInCatalog(user kuser.Info, serverName, 
 // UserHasAccessToMCPServerCatalogEntryInCatalog checks if a user has access to a specific catalog entry through AccessControlRules
 // This method now requires the catalog ID to ensure proper scoping
 func (h *Helper) UserHasAccessToMCPServerCatalogEntryInCatalog(user kuser.Info, entryName, catalogID string) (bool, error) {
-	if userIsAdminOrOwner(user) {
-		return true, nil
-	}
-
 	// See if there is a selector that this user is included on in the specified catalog.
 	selectorRules, err := h.GetAccessControlRulesForSelectorInCatalog(system.DefaultNamespace, "*", catalogID)
 	if err != nil {
@@ -409,10 +401,6 @@ func (h *Helper) GetAccessControlRulesForSelectorInWorkspace(namespace, selector
 
 // UserHasAccessToMCPServerInWorkspace checks if a user has access to a specific MCP server through workspace-scoped AccessControlRules
 func (h *Helper) UserHasAccessToMCPServerInWorkspace(user kuser.Info, serverName, workspaceID, serverUserID string) (bool, error) {
-	if userIsAdminOrOwner(user) {
-		return true, nil
-	}
-
 	var (
 		userID = user.GetUID()
 		groups = authGroupSet(user)
@@ -478,10 +466,6 @@ func (h *Helper) UserHasAccessToMCPServerInWorkspace(user kuser.Info, serverName
 
 // UserHasAccessToMCPServerCatalogEntryInWorkspace checks if a user has access to a specific catalog entry through workspace-scoped AccessControlRules
 func (h *Helper) UserHasAccessToMCPServerCatalogEntryInWorkspace(ctx context.Context, user kuser.Info, entryName, workspaceID string) (bool, error) {
-	if userIsAdminOrOwner(user) {
-		return true, nil
-	}
-
 	// See if there is a selector that this user is included on in the specified workspace.
 	selectorRules, err := h.GetAccessControlRulesForSelectorInWorkspace(system.DefaultNamespace, "*", workspaceID)
 	if err != nil {
@@ -557,15 +541,4 @@ func authGroupSet(user kuser.Info) map[string]struct{} {
 		set[group] = struct{}{}
 	}
 	return set
-}
-
-func userIsAdminOrOwner(user kuser.Info) bool {
-	for _, group := range user.GetGroups() {
-		switch group {
-		case types.GroupAdmin, types.GroupOwner:
-			return true
-		}
-	}
-
-	return false
 }

--- a/ui/user/src/lib/components/chat/ChatConnectorsView.svelte
+++ b/ui/user/src/lib/components/chat/ChatConnectorsView.svelte
@@ -70,9 +70,11 @@
 	);
 
 	let filteredTableData = $derived.by(() => {
-		const sorted = tableData.sort((a, b) => {
-			return a.name.localeCompare(b.name);
-		});
+		const sorted = tableData
+			.filter((d) => d.data.canConnect !== false)
+			.sort((a, b) => {
+				return a.name.localeCompare(b.name);
+			});
 		return query
 			? sorted.filter(
 					(d) =>

--- a/ui/user/src/lib/components/mcp/ConnectorsView.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectorsView.svelte
@@ -515,8 +515,14 @@
 	toggle: (value: boolean) => void,
 	isCreateFirst?: boolean
 )}
+	{@const canConnect = d.canConnect !== false}
 	<button
-		class="menu-button"
+		class="menu-button disabled:cursor-not-allowed disabled:opacity-50"
+		disabled={!canConnect}
+		use:tooltip={{
+			text: canConnect ? '' : 'See MCP Registries to grant connect access to this server',
+			disablePortal: true
+		}}
 		onclick={async (e) => {
 			e.stopPropagation();
 

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -82,6 +82,7 @@ export interface MCPCatalogEntry {
 	powerUserWorkspaceID?: string;
 	isCatalogEntry: boolean;
 	needsUpdate?: boolean;
+	canConnect?: boolean;
 }
 
 // Matches the backend compositeDeletionDependency struct used when preventing

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -762,6 +762,7 @@ export interface MCPCatalogServer {
 	powerUserWorkspaceID?: string;
 	deploymentStatus?: string;
 	compositeName?: string;
+	canConnect?: boolean;
 }
 
 export interface MCPServerInstance {


### PR DESCRIPTION
- Disable `Connect To Server` buttons when an admin hasn't been
  granted access to an MCP Server via an MCP Registry (Access Control
  Rule)
- Only show servers the admin has access to when adding MCP Servers to a
  project/chat

Loom: https://www.loom.com/share/c3af5b48ff86490e962745fd7c43eb0f

Addresses https://github.com/obot-platform/obot/issues/5429
