### PR TITLE
chore: add github workflow to announce releases to discord

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -1,0 +1,21 @@
+name: Announce Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  announce-release-discord:
+    runs-on: ubuntu-latest
+    if: github.event.release.prerelease == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Send Discord Notification
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          webhook_url: ${{ secrets.DISCORD_ANNOUNCE_WEBHOOK_URL }}
+          color: "2105893"
+          footer_title: "Obot Release"
+          footer_timestamp: true


### PR DESCRIPTION
Add a new workflow to announce new releases to discord.

Prerequisites:
1. Set up a webhook in the target discord channel (optional: set the webhook display name and image to make it look nice)
2. Create a secret named `DISCORD_ANNOUNCE_WEBHOOK_URL` containing the webhook URL generated in step 1
   
Here's a sample from my fork and burner discord server:

<img width="601" height="525" alt="Screenshot 2026-01-08 at 1 02 30 PM" src="https://github.com/user-attachments/assets/527d1b6d-6c03-4e2d-b478-2631c57531c3" />
