### PR TITLE
fix: show model name and ID in permission error message

### DIFF
--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -131,7 +131,7 @@ func (s *Server) dispatchLLMProxy(req api.Context) error {
 			return fmt.Errorf("failed to check model permission: %w", err)
 		}
 		if !hasAccess {
-			return types2.NewErrForbidden("user does not have permission to use model %q", modelID)
+			return types2.NewErrForbidden("user does not have permission to use model %q (%s)", model, modelID)
 		}
 	}
 


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/5433

