### PR TITLE
docs: improve docker deployment auth and port conf

### DIFF
--- a/docs/docs/installation/docker-deployment.md
+++ b/docs/docs/installation/docker-deployment.md
@@ -49,6 +49,21 @@ docker run -d \
   ghcr.io/obot-platform/obot:latest
 ```
 
+#### Using a Custom Port
+
+If you want to expose Obot on a different port (e.g., `-p 9999:8080`), you must also set `OBOT_SERVER_HOSTNAME` so that authentication redirects and MCP server connection URLs work correctly:
+
+```bash
+docker run -d \
+  --name obot \
+  -v obot-data:/data \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -p 9999:8080 \
+  -e OPENAI_API_KEY=your-openai-key \
+  -e OBOT_SERVER_HOSTNAME=localhost:9999 \
+  ghcr.io/obot-platform/obot:latest
+```
+
 ## Accessing Obot
 
 Once started, access Obot at http://localhost:8080.
@@ -57,7 +72,7 @@ If you enabled authentication, use your bootstrap token to log in as the owner a
 
 ## Next Steps
 
-1. **Configure Authentication**: Set up [auth providers](../configuration/auth-providers) for secure access
+1. **Configure Authentication**: Set up [authentication](enabling-authentication) for secure access
 2. **Configure Model Providers**: Configure [model providers](../configuration/model-providers) (OpenAI, Anthropic, etc.)
 3. **Set Up MCP Servers**: Configure [MCP servers](../functionality/mcp-servers) for extended functionality
 


### PR DESCRIPTION
Fix "Configure Authentication" link to point to enabling-authentication
instead of auth-providers

Add "Using a Custom Port" section explaining OBOT_SERVER_HOSTNAME is
required when exposing Obot on a non-default port

Signed-off-by: Craig Jellick <craig@obot.ai>
