### PR TITLE
docs: fix canonical URL issues with trailing slash

### DIFF
--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -16,7 +16,7 @@ Obot is designed to enable organizations to consume MCP servers in an enterprise
 
 - **MCP Registry**: An index of MCP servers with metadata about how to run them and where to find them.
 
-- **MCP Gateway**: A reverse-proxy that authenticates users, ensures servers are deployed, and forwards requests. See [MCP Gateway](mcp-gateway) for details.
+- **MCP Gateway**: A reverse-proxy that authenticates users, ensures servers are deployed, and forwards requests. See [MCP Gateway](/concepts/mcp-gateway/) for details.
 
 - **MCP Server Shim**: A protocol-aware sidecar that runs alongside each MCP server, handling authorization, audit logging, webhook filters, and token exchange.
 
@@ -42,8 +42,8 @@ Key security properties:
 
 ## Encryption
 
-Obot uses cloud KMS systems to encrypt data at rest. See [Encryption Providers](../configuration/encryption-providers/overview) for configuration options.
+Obot uses cloud KMS systems to encrypt data at rest. See [Encryption Providers](/configuration/encryption-providers/overview/) for configuration options.
 
 ## LLMs
 
-Obot operates with a bring-your-own-model philosophy. Multiple providers can be configured to meet organizational requirements. See [Model Providers](../configuration/model-providers) for details.
+Obot operates with a bring-your-own-model philosophy. Multiple providers can be configured to meet organizational requirements. See [Model Providers](/configuration/model-providers/) for details.

--- a/docs/docs/concepts/mcp-hosting.md
+++ b/docs/docs/concepts/mcp-hosting.md
@@ -8,16 +8,16 @@ The MCP Hosting layer runs and manages MCP servers directly within Obot. It hand
 
 ## Runtime Types
 
-- **[Node.js (npx)](../functionality/mcp-servers#npx-nodetypescript-based-mcp-servers)**: Run npm-packaged MCP servers via STDIO
-- **[Python (uvx)](../functionality/mcp-servers#uvx-for-python-based-packages)**: Run PyPI-packaged MCP servers via STDIO
-- **[Containerized](../functionality/mcp-servers#containerized-for-docker-based-deployments)**: Run Docker containers with HTTP/SSE transport
+- **[Node.js (npx)](/functionality/mcp-servers/#npx-nodetypescript-based-mcp-servers)**: Run npm-packaged MCP servers via STDIO
+- **[Python (uvx)](/functionality/mcp-servers/#uvx-for-python-based-packages)**: Run PyPI-packaged MCP servers via STDIO
+- **[Containerized](/functionality/mcp-servers/#containerized-for-docker-based-deployments)**: Run Docker containers with HTTP/SSE transport
 
 ## Server Types
 
-- **[Single-user](../functionality/mcp-servers#single-user-server)**: Each user gets their own isolated instance with separate credentials
-- **[Multi-user](../functionality/mcp-servers#multi-user-server)**: A shared instance serves multiple users with shared or per-user credentials
-- **[Remote](../functionality/mcp-servers#remote-server)**: External MCP servers accessed via HTTP, not hosted by Obot
-- **[Composite](../functionality/mcp-servers#composite-server)**: Combines multiple servers into a single virtual server with curated tools
+- **[Single-user](/functionality/mcp-servers/#single-user-server)**: Each user gets their own isolated instance with separate credentials
+- **[Multi-user](/functionality/mcp-servers/#multi-user-server)**: A shared instance serves multiple users with shared or per-user credentials
+- **[Remote](/functionality/mcp-servers/#remote-server)**: External MCP servers accessed via HTTP, not hosted by Obot
+- **[Composite](/functionality/mcp-servers/#composite-server)**: Combines multiple servers into a single virtual server with curated tools
 
 ## Deployment Environments
 
@@ -28,7 +28,7 @@ When running Obot with Docker, MCP servers are deployed as sibling containers:
 - Obot communicates with the Docker daemon to manage containers
 - Servers run alongside the Obot container
 - Suitable for development and small deployments
-- See [Docker Deployment](../installation/docker-deployment) for setup details
+- See [Docker Deployment](/installation/docker-deployment/) for setup details
 
 ### Kubernetes
 
@@ -36,7 +36,7 @@ For production deployments, Obot can deploy MCP servers to Kubernetes:
 
 - Servers run as pods in the cluster
 - Supports resource limits, network policies, and scaling
-- See [MCP Deployments in Kubernetes](../configuration/mcp-deployments-in-kubernetes) for configuration details
+- See [MCP Deployments in Kubernetes](/configuration/mcp-deployments-in-kubernetes/) for configuration details
 
 ## Authentication
 
@@ -47,9 +47,9 @@ Obot handles OAuth 2.1 flows for MCP servers that require authentication:
 - Per-user credential isolation
 - Supports custom OAuth configurations
 
-See [MCP Server OAuth Configuration](../configuration/mcp-server-oauth-configuration) for details on configuring OAuth for MCP servers.
+See [MCP Server OAuth Configuration](/configuration/mcp-server-oauth-configuration/) for details on configuring OAuth for MCP servers.
 
 ## Learn More
 
-- [MCP Servers](../functionality/mcp-servers) - Adding and configuring MCP servers
-- [Installation](../installation/overview) - Deployment environments and setup
+- [MCP Servers](/functionality/mcp-servers/) - Adding and configuring MCP servers
+- [Installation](/installation/overview/) - Deployment environments and setup

--- a/docs/docs/concepts/mcp-registry.md
+++ b/docs/docs/concepts/mcp-registry.md
@@ -13,7 +13,7 @@ The MCP Registry is a central place to list and discover MCP servers. It provide
 MCP server definitions can come from:
 
 - **Official Obot repository**: The default set from [obot-platform/mcp-catalog](https://github.com/obot-platform/mcp-catalog)
-- **Custom Git repositories**: Your own repositories containing server definitions (see [MCP Server GitOps](../configuration/mcp-server-gitops))
+- **Custom Git repositories**: Your own repositories containing server definitions (see [MCP Server GitOps](/configuration/mcp-server-gitops/))
 - **Direct entry**: Servers added manually through the UI
 
 ### Server Definitions
@@ -36,4 +36,4 @@ Obot implements the [MCP Registry specification](https://github.com/modelcontext
 
 ## Learn More
 
-- [MCP Registries](../functionality/mcp-registries) - Managing registries, API details, and contributing servers
+- [MCP Registries](/functionality/mcp-registries/) - Managing registries, API details, and contributing servers

--- a/docs/docs/concepts/obot-chat.md
+++ b/docs/docs/concepts/obot-chat.md
@@ -34,4 +34,4 @@ Projects can persist important information across all threads, capturing key det
 
 ## Learn More
 
-- [Obot Chat](../functionality/chat/overview) - Detailed configuration and usage
+- [Obot Chat](/functionality/chat/overview/) - Detailed configuration and usage

--- a/docs/docs/configuration/model-providers.md
+++ b/docs/docs/configuration/model-providers.md
@@ -19,7 +19,7 @@ Obot supports a variety of model providers, including:
 The UI will indicate whether each provider has been configured. If a provider is configured you will have the ability to modify or deconfigure it.
 
 :::note
-Our Enterprise release adds support for additional Enterprise-grade model providers. [See here](../enterprise/overview) for more details.
+Our Enterprise release adds support for additional Enterprise-grade model providers. [See here](/enterprise/overview/) for more details.
 :::
 
 #### Configuring and enabling a provider
@@ -56,12 +56,12 @@ The "Set Default Models" feature allows you to configure default models for vari
 - **Image Generation** - For creating images
 - **Vision** - For image analysis and processing
 
-These defaults determine which specific model is used when a [Model Access Policy](../functionality/model-access-policies) grants access to a default model alias (such as "Language Model (Chat)"). When you change a default here, any user with access to that alias automatically gains access to the new model.
+These defaults determine which specific model is used when a [Model Access Policy](../../functionality/model-access-policies/) grants access to a default model alias (such as "Language Model (Chat)"). When you change a default here, any user with access to that alias automatically gains access to the new model.
 
 After selecting the desired defaults, click "Save Changes" to confirm your configurations.
 
 :::note
-Setting a default model here does not automatically grant users access to it. Users must be included in a Model Access Policy that grants access to the corresponding alias. See [Model Access Policies](../functionality/model-access-policies) for details.
+Setting a default model here does not automatically grant users access to it. Users must be included in a Model Access Policy that grants access to the corresponding alias. See [Model Access Policies](../../functionality/model-access-policies/) for details.
 :::
 
 ### Instructions for configuring specific providers

--- a/docs/docs/configuration/user-roles.md
+++ b/docs/docs/configuration/user-roles.md
@@ -68,7 +68,7 @@ Configure the default role for new users on the **User Management > User Roles**
 
 ### Pre-Assigning Roles
 
-To grant admin or owner access to users before they log in, set these environment variables during deployment. See [Enabling Authentication](../installation/enabling-authentication) for details.
+To grant admin or owner access to users before they log in, set these environment variables during deployment. See [Enabling Authentication](/installation/enabling-authentication/) for details.
 
 ```bash
 OBOT_SERVER_AUTH_ADMIN_EMAILS=admin@example.com,admin2@example.com

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -8,7 +8,7 @@ Docker is suitable for local testing and small-scale deployments. For production
 
 ### Why can’t I see the User Management section?
 
-User Management is only visible when authentication is enabled. Make sure you start Obot with `OBOT_SERVER_ENABLE_AUTHENTICATION=true`. If you don't see the bootstrap token prompt, the environment variable may not be set correctly. Follow the [installation guide](installation/enabling-authentication).
+User Management is only visible when authentication is enabled. Make sure you start Obot with `OBOT_SERVER_ENABLE_AUTHENTICATION=true`. If you don't see the bootstrap token prompt, the environment variable may not be set correctly. Follow the [installation guide](/installation/enabling-authentication/).
 
 ### How do I assign roles to users before they log in?
 
@@ -50,12 +50,12 @@ Some clients do not support the required OAuth flows. As a workaround, use the `
 
 ### How do I pass user-specific parameters (e.g., Jira PAT tokens) to a remote MCP server?
 
-As an admin, you can configure the server in the MCP Servers section. See [MCP Servers](functionality/mcp-servers) for details.
+As an admin, you can configure the server in the MCP Servers section. See [MCP Servers](/functionality/mcp-servers/) for details.
 
 ### How do I get started with AKS/GKE/AWS deployment?
 
 See the reference architecture guide for your cloud provider, and follow the Kubernetes installation.
 
-- [AKS](installation/reference-architectures/azure-aks)
-- [GKE](installation/reference-architectures/gcp-gke)
-- [AWS](installation/reference-architectures/aws-eks)
+- [AKS](/installation/reference-architectures/azure-aks/)
+- [GKE](/installation/reference-architectures/gcp-gke/)
+- [AWS](/installation/reference-architectures/aws-eks/)

--- a/docs/docs/functionality/audit-logs-and-usage.md
+++ b/docs/docs/functionality/audit-logs-and-usage.md
@@ -7,7 +7,7 @@ title: Audit Logs & Usage
 The MCP Platform provides visibility into MCP activity through audit logs and usage tracking. These features help with monitoring, compliance, and understanding how MCP servers are being used.
 
 :::info Auditor Role
-Sensitive data (MCP request/response bodies, chat threads, and task runs) can **only** be viewed by users with the Auditor role. All other roles, including Owner and Admin, see only metadata for these resources. The Auditor role is an add-on permission that can be combined with any other role, granting read-only access to sensitive data across the platform. See [User Roles](../configuration/user-roles#auditor) for details.
+Sensitive data (MCP request/response bodies, chat threads, and task runs) can **only** be viewed by users with the Auditor role. All other roles, including Owner and Admin, see only metadata for these resources. The Auditor role is an add-on permission that can be combined with any other role, granting read-only access to sensitive data across the platform. See [User Roles](/configuration/user-roles/#auditor) for details.
 :::
 
 ## Audit Logs
@@ -51,7 +51,7 @@ Filter logs by:
 
 ### Exporting Audit Logs
 
-Audit logs can be exported for external analysis or compliance requirements. See [Audit Log Export](../configuration/audit-log-export) for configuration options.
+Audit logs can be exported for external analysis or compliance requirements. See [Audit Log Export](/configuration/audit-log-export/) for configuration options.
 
 ## Usage
 

--- a/docs/docs/functionality/chat-management.md
+++ b/docs/docs/functionality/chat-management.md
@@ -16,16 +16,16 @@ Configure default settings that apply to all new projects. Changes here affect t
 - **Instructions**: Default system prompt defining assistant behavior
 
 :::note Model Access
-Model availability for chat is now controlled through [Model Access Policies](model-access-policies). The previous "Allowed Models" setting has been replaced by policies that let you control which users and groups can access which models.
+Model availability for chat is now controlled through [Model Access Policies](../model-access-policies/). The previous "Allowed Models" setting has been replaced by policies that let you control which users and groups can access which models.
 :::
 
 ## Model Providers
 
-Configure LLM providers and their available models. See [Model Providers](../configuration/model-providers) for setup details.
+Configure LLM providers and their available models. See [Model Providers](/configuration/model-providers/) for setup details.
 
 ## Model Access Policies
 
-Control which users and groups can access which models for chat. See [Model Access Policies](model-access-policies) for details.
+Control which users and groups can access which models for chat. See [Model Access Policies](../model-access-policies/) for details.
 
 ## Chat Threads, Tasks, and Task Runs
 

--- a/docs/docs/functionality/chat/overview.md
+++ b/docs/docs/functionality/chat/overview.md
@@ -65,7 +65,7 @@ Connect to MCP servers through your projects:
 
 Admins and Owners configure which LLM providers and models are available to users. Users select from these configured models while chatting.
 
-See [Model Providers](../../configuration/model-providers) for configuration details.
+See [Model Providers](/configuration/model-providers/) for configuration details.
 
 ## Knowledge (RAG)
 

--- a/docs/docs/functionality/model-access-policies.md
+++ b/docs/docs/functionality/model-access-policies.md
@@ -44,7 +44,7 @@ Administrators do not have automatic access to all models. Like any other user, 
 
 Only models configured with the **Language Model (Chat)** usage type appear when creating policies. Models configured for other purposes—such as text embedding, image generation, or vision—do not appear as options.
 
-To change which models are available for chat or to configure new model providers, see [Model Providers](../configuration/model-providers).
+To change which models are available for chat or to configure new model providers, see [Model Providers](/configuration/model-providers).
 
 ## Default Model Aliases
 
@@ -53,7 +53,7 @@ When selecting models for a policy, you'll see options like:
 - **Language Model (Chat)** — The primary default model
 - **Language Model (Chat - Fast)** — A faster, typically smaller model
 
-These are aliases that automatically resolve to whichever model is currently configured as the default in [Model Providers](../configuration/model-providers).
+These are aliases that automatically resolve to whichever model is currently configured as the default in [Model Providers](/configuration/model-providers).
 
 Using aliases provides flexibility: if you later change which model serves as the default, users with access to the alias automatically gain access to the new default without needing to update any policies.
 
@@ -99,6 +99,6 @@ Deleting a policy removes model access for the affected subjects. If a user lose
 
 ## Related Topics
 
-- [Model Providers](../configuration/model-providers) — Configure language models and set defaults
-- [MCP Registries](mcp-registries) — Similar access control for MCP servers
-- [User Roles](../configuration/user-roles) — Understanding administrator and user permissions
+- [Model Providers](/configuration/model-providers) — Configure language models and set defaults
+- [MCP Registries](/functionality/mcp-registries/) — Similar access control for MCP servers
+- [User Roles](/configuration/user-roles) — Understanding administrator and user permissions

--- a/docs/docs/functionality/overview.md
+++ b/docs/docs/functionality/overview.md
@@ -6,7 +6,7 @@ title: Overview
 
 The MCP Platform is Obot's unified management interface for deploying, managing, and operating MCP servers. It provides role-based access to server management, registries, audit logs, usage tracking, and platform administration.
 
-For detailed permissions and role definitions, see [User Roles](../configuration/user-roles).
+For detailed permissions and role definitions, see [User Roles](/configuration/user-roles/).
 
 ## Roles and Capabilities
 
@@ -28,7 +28,7 @@ Power Users+ include all Power User capabilities and can additionally publish MC
 
 Admins and Owners have full administrative access to the platform, including system-wide configuration, user management, and chat administration.
 
-The only functional difference between Owners and Admins is that Owners can assign the **Auditor** role to users. For more information, see the [Auditor Role](../configuration/user-roles#auditor).
+The only functional difference between Owners and Admins is that Owners can assign the **Auditor** role to users. For more information, see the [Auditor Role](/configuration/user-roles/#auditor).
 
 ## Navigation by Role
 
@@ -52,14 +52,14 @@ The only functional difference between Owners and Admins is that Owners can assi
 
 ## Learn More
 
-- [MCP Servers](mcp-servers) - Deploy, configure, and manage MCP servers
-- [MCP Registries](mcp-registries) - Control which servers are available to which users and groups
-- [Audit Logs and Usage](audit-logs-and-usage) - Monitor activity and track consumption
-- [Filters](filters) - Inspect and control MCP traffic
-- [Server Scheduling](server-scheduling) - Define server availability windows
-- [Chat Management](chat-management) - Configure default chat settings and monitor activity
-- [User Management](user-management) - Manage users, roles, and authentication
-- [API Keys](api-keys) - Create and manage API keys for programmatic MCP server access
-- [Branding](branding) - Customize theme colors and branding
-- [Obot Chat](chat/overview) - Projects, threads, tasks, and chat features
-- [User Roles](../configuration/user-roles) - Detailed permissions and role definitions
+- [MCP Servers](../mcp-servers/) - Deploy, configure, and manage MCP servers
+- [MCP Registries](../mcp-registries/) - Control which servers are available to which users and groups
+- [Audit Logs and Usage](../audit-logs-and-usage/) - Monitor activity and track consumption
+- [Filters](../filters/) - Inspect and control MCP traffic
+- [Server Scheduling](../server-scheduling/) - Define server availability windows
+- [Chat Management](../chat-management/) - Configure default chat settings and monitor activity
+- [User Management](../user-management/) - Manage users, roles, and authentication
+- [API Keys](../api-keys/) - Create and manage API keys for programmatic MCP server access
+- [Branding](../branding/) - Customize theme colors and branding
+- [Obot Chat](../chat/overview/) - Projects, threads, tasks, and chat features
+- [User Roles](/configuration/user-roles/) - Detailed permissions and role definitions

--- a/docs/docs/functionality/user-management.md
+++ b/docs/docs/functionality/user-management.md
@@ -14,7 +14,7 @@ View and manage all users on the platform. From this page you can:
 - Update individual user roles
 - Monitor user activity
 
-For details on updating roles, see [User Roles](../configuration/user-roles#managing-roles).
+For details on updating roles, see [User Roles](/configuration/user-roles/#managing-roles).
 
 ## User Roles
 
@@ -25,12 +25,12 @@ Configure the default role assigned to new users when they first log in. Choose 
 - **Power User Plus**: Power User features plus share MCP servers through registries
 - **Admin**: Full platform management
 
-For detailed role descriptions and permissions, see [User Roles](../configuration/user-roles).
+For detailed role descriptions and permissions, see [User Roles](/configuration/user-roles/).
 
 ## API Keys
 
-View and manage API keys for all users. Administrators can see which users have created API keys and delete any key if necessary. For details on how API keys work, see [API Keys](api-keys).
+View and manage API keys for all users. Administrators can see which users have created API keys and delete any key if necessary. For details on how API keys work, see [API Keys](../api-keys/).
 
 ## Auth Providers
 
-Configure identity providers for user authentication. See [Auth Providers](../configuration/auth-providers) for setup details.
+Configure identity providers for user authentication. See [Auth Providers](/configuration/auth-providers/) for setup details.

--- a/docs/docs/installation/docker-deployment.md
+++ b/docs/docs/installation/docker-deployment.md
@@ -11,7 +11,7 @@ Docker deployment is the fastest way to get Obot running. It's ideal for:
 - Proof-of-concept and evaluation
 - Small team usage
 
-For production deployments, see [Kubernetes Deployment](kubernetes-deployment).
+For production deployments, see [Kubernetes Deployment](/installation/kubernetes-deployment/).
 
 ## Prerequisites
 
@@ -72,12 +72,12 @@ If you enabled authentication, use your bootstrap token to log in as the owner a
 
 ## Next Steps
 
-1. **Configure Authentication**: Set up [authentication](enabling-authentication) for secure access
-2. **Configure Model Providers**: Configure [model providers](../configuration/model-providers) (OpenAI, Anthropic, etc.)
-3. **Set Up MCP Servers**: Configure [MCP servers](../functionality/mcp-servers) for extended functionality
+1. **Configure Authentication**: Set up [auth providers](/installation/enabling-authentication/) for secure access
+2. **Configure Model Providers**: Configure [model providers](/configuration/model-providers/) (OpenAI, Anthropic, etc.)
+3. **Set Up MCP Servers**: Configure [MCP servers](/functionality/mcp-servers/) for extended functionality
 
 ## Related Documentation
 
-- [Installation Overview](overview)
-- [Kubernetes Deployment](kubernetes-deployment)
-- [Server Configuration](../configuration/server-configuration)
+- [Installation Overview](/installation/overview/)
+- [Kubernetes Deployment](/installation/kubernetes-deployment/)
+- [Server Configuration](/configuration/server-configuration/)

--- a/docs/docs/installation/enabling-authentication.md
+++ b/docs/docs/installation/enabling-authentication.md
@@ -11,7 +11,7 @@ If any MCP servers were created with authentication disabled, they will be delet
 
 ## Step 1: Set Environment Variables
 
-Enabling authentication begins with launching Obot with additional configuration options in the form of environment variables. See the [Docker](docker-deployment) or [Kubernetes](kubernetes-deployment) deployment guides for full setup details.
+Enabling authentication begins with launching Obot with additional configuration options in the form of environment variables. See the [Docker](/installation/docker-deployment/) or [Kubernetes](/installation/kubernetes-deployment/) deployment guides for full setup details.
 
 <Tabs>
   <TabItem value="docker" label="Docker" default>
@@ -63,7 +63,7 @@ Start (or restart) your Obot deployment with the new environment variables. Navi
 2. Click **Configure** on your desired provider (GitHub, Google, Entra, Okta)
 3. Follow the provider-specific configuration steps
 
-For detailed provider configuration, see the [Auth Providers](../configuration/auth-providers) documentation.
+For detailed provider configuration, see the [Auth Providers](/configuration/auth-providers/) documentation.
 
 ## Post-Setup
 
@@ -91,4 +91,4 @@ Note that you can always assign the owner or admin role to additional users thro
 
 ## Next Steps
 
-- Review [Auth Providers configuration](../configuration/auth-providers) for detailed provider setup
+- Review [Auth Providers configuration](/configuration/auth-providers/) for detailed provider setup

--- a/docs/docs/installation/kubernetes-deployment.md
+++ b/docs/docs/installation/kubernetes-deployment.md
@@ -86,28 +86,28 @@ To enable a high availability setup, uncomment the `replicaCount` line and set i
 
 For detailed configuration options, see:
 
-- **[Server Configuration](../configuration/server-configuration)** - All available environment variables
-- **[Workspace Provider](../configuration/workspace-provider)** - S3 storage configuration
-- **[Encryption Providers](../configuration/encryption-providers/aws-kms)** - KMS encryption setup
+- **[Server Configuration](/configuration/server-configuration/)** - All available environment variables
+- **[Workspace Provider](/configuration/workspace-provider/)** - S3 storage configuration
+- **[Encryption Providers](/configuration/encryption-providers/aws-kms/)** - KMS encryption setup
 
 ## Cloud-Specific Guides
 
 For detailed cloud-specific deployment instructions:
 
-- [Google Kubernetes Engine (GKE)](reference-architectures/gcp-gke)
-- [Amazon Elastic Kubernetes Service (EKS)](reference-architectures/aws-eks)
-- [Azure Kubernetes Service (AKS)](reference-architectures/azure-aks)
+- [Google Kubernetes Engine (GKE)](/installation/reference-architectures/gcp-gke/)
+- [Amazon Elastic Kubernetes Service (EKS)](/installation/reference-architectures/aws-eks/)
+- [Azure Kubernetes Service (AKS)](/installation/reference-architectures/azure-aks/)
 
 ## Next Steps
 
-1. **Configure Authentication**: Set up [auth providers](../configuration/auth-providers)
-2. **Add Model Providers**: Configure [model providers](../configuration/model-providers)
-3. **Set Up MCP Servers**: Configure [MCP servers](../functionality/mcp-servers)
+1. **Configure Authentication**: Set up [auth providers](/configuration/auth-providers/)
+2. **Add Model Providers**: Configure [model providers](/configuration/model-providers/)
+3. **Set Up MCP Servers**: Configure [MCP servers](/functionality/mcp-servers/)
 4. **Configure Monitoring**: Set up logging and metrics
 5. **Review Security**: Enable authentication and encryption
 
 ## Related Documentation
 
-- [Installation Overview](overview)
-- [Server Configuration](../configuration/server-configuration)
-- [Settings for Hosted MCP Server Deployments](../configuration/mcp-deployments-in-kubernetes)
+- [Installation Overview](/installation/overview/)
+- [Server Configuration](/configuration/server-configuration/)
+- [Settings for Hosted MCP Server Deployments](/configuration/mcp-deployments-in-kubernetes/)

--- a/docs/docs/installation/overview.md
+++ b/docs/docs/installation/overview.md
@@ -20,7 +20,7 @@ Docker provides the fastest way to get Obot running on your local machine or a s
 - Includes a built-in PostgreSQL database and local file storage
 - Deploys MCP servers as Docker containers using the host’s Docker socket
 
-For more details, see the [Docker Deployment Guide](docker-deployment).
+For more details, see the [Docker Deployment Guide](/installation/docker-deployment/).
 
 ## Kubernetes Deployment
 
@@ -30,7 +30,7 @@ Kubernetes provides the best way to run Obot reliably at scale in production env
 - Integrates with cloud-native services such as KMS and S3
 - Requires an external PostgreSQL database and external storage
 
-For more details, see the [Kubernetes Deployment Guide](kubernetes-deployment).
+For more details, see the [Kubernetes Deployment Guide](/installation/kubernetes-deployment/).
 
 ## Production System Requirements
 
@@ -40,7 +40,7 @@ For production deployments, the following components are required:
 - **External PostgreSQL database**: PostgreSQL 17 or later with the pgvector extension
 - **S3-compatible object storage**: For workspace files and persistent data
 - **Encryption provider**: AWS KMS, Google Cloud KMS, or Azure Key Vault
-- **Authentication provider**: See our supported [Authentication Providers](../configuration/auth-providers)
+- **Authentication provider**: See our supported [Authentication Providers](/configuration/auth-providers/)
 - **TLS/SSL certificates**: For secure HTTPS access
 - **Backup strategy**: Regular backups for both the database and object storage
 
@@ -48,18 +48,18 @@ For production deployments, the following components are required:
 
 If you plan to deploy Obot on a managed Kubernetes service, these reference architectures provide infrastructure guidance and best practices:
 
-- [GCP GKE Reference Architecture](reference-architectures/gcp-gke)
-- [AWS EKS Reference Architecture](reference-architectures/aws-eks)
-- [Azure AKS Reference Architecture](reference-architectures/azure-aks)
+- [GCP GKE Reference Architecture](/installation/reference-architectures/gcp-gke/)
+- [AWS EKS Reference Architecture](/installation/reference-architectures/aws-eks/)
+- [Azure AKS Reference Architecture](/installation/reference-architectures/azure-aks/)
 
 ## Next Steps
 
 1. Choose a deployment method above
 2. Follow the corresponding deployment guide
-3. [Configure authentication](../configuration/auth-providers)
-4. [Set up model providers](../configuration/model-providers)
-5. Review the [server configuration options](../configuration/server-configuration)
+3. [Configure authentication](/configuration/auth-providers/)
+4. [Set up model providers](/configuration/model-providers/)
+5. Review the [server configuration options](/configuration/server-configuration/)
 
 ## Getting Help
 
-- See the [FAQ](../faq)
+- See the [FAQ](/faq/)

--- a/docs/docs/installation/reference-architectures/01-gcp-gke.md
+++ b/docs/docs/installation/reference-architectures/01-gcp-gke.md
@@ -64,7 +64,7 @@ resource "google_kms_crypto_key_iam_binding" "this" {
 }
 ```
 
-More information on the Google Cloud KMS setup can be found [here](../../configuration/encryption-providers/google-cloud-kms).
+More information on the Google Cloud KMS setup can be found [here](/configuration/encryption-providers/google-cloud-kms/).
 
 
 Once you have these resources set up, install the Obot helm chart with:

--- a/docs/docs/installation/reference-architectures/02-aws-eks.md
+++ b/docs/docs/installation/reference-architectures/02-aws-eks.md
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "obot_kms" {
 }
 ```
 
-More information on the AWS KMS setup can be found [here](../../configuration/encryption-providers/aws-kms).
+More information on the AWS KMS setup can be found [here](/configuration/encryption-providers/aws-kms/).
 
 Once you have these resources set up, install the Obot helm chart with:
 

--- a/docs/docs/installation/reference-architectures/03-azure-aks.md
+++ b/docs/docs/installation/reference-architectures/03-azure-aks.md
@@ -73,7 +73,7 @@ resource "azurerm_federated_identity_credential" "obot" {
 }
 ```
 
-More information on the Azure Key Vault setup can be found [here](../../configuration/encryption-providers/azure-key-vault).
+More information on the Azure Key Vault setup can be found [here](/configuration/encryption-providers/azure-key-vault/).
 
 Once you have these resources set up, install the Obot helm chart with:
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -10,6 +10,7 @@ const config: Config = {
   favicon: "img/favicon.ico",
   url: "https://docs.obot.ai",
   baseUrl: "/",
+  trailingSlash: true,
   organizationName: "obot-platform",
   projectName: "obot",
   onBrokenLinks: "throw",
@@ -19,6 +20,20 @@ const config: Config = {
     defaultLocale: "en",
     locales: ["en"],
   },
+
+  plugins: [
+    [
+      "@docusaurus/plugin-client-redirects",
+      {
+        redirects: [
+          {
+            from: "/concepts/admin/mcp-server-catalogs",
+            to: "/configuration/mcp-server-gitops",
+          },
+        ],
+      },
+    ],
+  ],
 
   presets: [
     [

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
+        "@docusaurus/plugin-client-redirects": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",
         "@mdx-js/react": "^3.1.0",
         "axios": "^1.13.0",
@@ -3592,6 +3593,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.2.tgz",
+      "integrity": "sha512-lUgMArI9vyOYMzLRBUILcg9vcPTCyyI2aiuXq/4npcMVqOr6GfmwtmBYWSbNMlIUM0147smm4WhpXD0KFboffw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
+    "@docusaurus/plugin-client-redirects": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@mdx-js/react": "^3.1.0",
     "axios": "^1.13.0",

--- a/docs/versioned_docs/version-v0.13.0/concepts/chat/overview.md
+++ b/docs/versioned_docs/version-v0.13.0/concepts/chat/overview.md
@@ -55,4 +55,4 @@ Projects can interact with external systems through the Model Context Protocol. 
 
 ## Configuration
 
-For more information on configuring chat, visit the [chat configuration](../../configuration/chat-configuration) documentation.
+For more information on configuring chat, visit the [chat configuration](../../../configuration/chat-configuration/) documentation.

--- a/docs/versioned_docs/version-v0.13.0/configuration/server-configuration.md
+++ b/docs/versioned_docs/version-v0.13.0/configuration/server-configuration.md
@@ -40,10 +40,10 @@ The Obot server is configured via environment variables. The following configura
 
 ## Encryption Providers
 
-You can configure optional [encryption providers](encryption-providers/aws-kms) to ensure secrets are encrypted.
+You can configure optional [encryption providers](/configuration/encryption-providers/aws-kms/) to ensure secrets are encrypted.
 
 ## Model Providers
-You can configure additional models using [model providers](model-providers)
+You can configure additional models using [model providers](/configuration/model-providers/)
 
 ## Workspace Provider
-You can configure external storage for workspace files using a [workspace provider](workspace-provider)
+You can configure external storage for workspace files using a [workspace provider](/configuration/workspace-provider/)

--- a/docs/versioned_docs/version-v0.13.0/faq.md
+++ b/docs/versioned_docs/version-v0.13.0/faq.md
@@ -8,7 +8,7 @@ Docker is suitable for local testing and small-scale deployments. For production
 
 ### Why can’t I see the User Management section?
 
-User Management is only visible when authentication is enabled. Make sure you start Obot with `OBOT_SERVER_ENABLE_AUTHENTICATION=true`. If you don’t see the bootstrap token prompt, the environment variable may not be set correctly. Follow the [installation guide](installation/enabling-authentication)
+User Management is only visible when authentication is enabled. Make sure you start Obot with `OBOT_SERVER_ENABLE_AUTHENTICATION=true`. If you don’t see the bootstrap token prompt, the environment variable may not be set correctly. Follow the [installation guide](/installation/enabling-authentication/)
 
 ### How do I assign roles to users before they log in?
 
@@ -37,12 +37,12 @@ Both use the same core codebase, but the enterprise version includes additional 
 
 ### How do I pass user-specific parameters (e.g., Jira PAT tokens) to a remote MCP server?
 
-As an admin, you can configure the server in the catalog section of the mcp-servers page. See [here](concepts/admin/mcp-servers#configuration-parameters) for details.
+As an admin, you can configure the server in the catalog section of the mcp-servers page. See [here](../concepts/admin/mcp-servers/#configuration-parameters) for details.
 
 ### How do I get started with AKS/GKE/AWS deployment?
 
 See the reference architecture guide for your cloud provider, and follow the Kubernetes installation.
 
-- [AKS](installation/reference-architectures/azure-aks)
-- [GKE](installation/reference-architectures/gcp-gke)
-- [AWS](installation/reference-architectures/aws-eks)
+- [AKS](/installation/reference-architectures/azure-aks/)
+- [GKE](/installation/reference-architectures/gcp-gke/)
+- [AWS](/installation/reference-architectures/aws-eks/)

--- a/docs/versioned_docs/version-v0.13.0/installation/docker-deployment.md
+++ b/docs/versioned_docs/version-v0.13.0/installation/docker-deployment.md
@@ -11,7 +11,7 @@ Docker deployment is the fastest way to get Obot running. It's ideal for:
 - Proof-of-concept and evaluation
 - Small team usage
 
-For production deployments, see [Kubernetes Deployment](kubernetes-deployment).
+For production deployments, see [Kubernetes Deployment](/installation/kubernetes-deployment/).
 
 ## Prerequisites
 
@@ -72,12 +72,12 @@ You will need to look for an entry like:
 
 ## Next Steps
 
-1. **Configure Authentication**: Set up [auth providers](../configuration/auth-providers) for secure access
-2. **Configure Model Providers**: Configure [model providers](../configuration/model-providers) (OpenAI, Anthropic, etc.)
-3. **Set Up MCP Tools**: Deploy [MCP servers](../concepts/mcp-gateway/overview) for extended functionality
+1. **Configure Authentication**: Set up [auth providers](/configuration/auth-providers) for secure access
+2. **Configure Model Providers**: Configure [model providers](/configuration/model-providers) (OpenAI, Anthropic, etc.)
+3. **Set Up MCP Tools**: Deploy [MCP servers](../../concepts/mcp-gateway/overview/) for extended functionality
 
 ## Related Documentation
 
-- [Installation Overview](overview)
-- [Kubernetes Deployment](kubernetes-deployment)
-- [Server Configuration](../configuration/server-configuration)
+- [Installation Overview](/installation/overview/)
+- [Kubernetes Deployment](/installation/kubernetes-deployment/)
+- [Server Configuration](/configuration/server-configuration)

--- a/docs/versioned_docs/version-v0.13.0/installation/enabling-authentication.md
+++ b/docs/versioned_docs/version-v0.13.0/installation/enabling-authentication.md
@@ -70,7 +70,7 @@ Once logged in with the bootstrap token:
 3. Select your desired provider (GitHub, Google, Entra, Okta)
 4. Follow the provider-specific configuration steps
 
-For detailed provider configuration, see the [Auth Providers](../configuration/auth-providers) documentation.
+For detailed provider configuration, see the [Auth Providers](/configuration/auth-providers) documentation.
 
 ## Step 4: Set Admin/Owner Users and Restart
 
@@ -137,6 +137,6 @@ After restart:
 
 ## Next Steps
 
-- Review [Auth Providers configuration](../configuration/auth-providers) for detailed provider setup
-- Configure [OAuth settings](../configuration/oauth-configuration) for additional customization
-- Set up proper [access control](../configuration/auth-providers#access-control) with email domain restrictions
+- Review [Auth Providers configuration](/configuration/auth-providers) for detailed provider setup
+- Configure [OAuth settings](../../configuration/oauth-configuration/) for additional customization
+- Set up proper [access control](/configuration/auth-providers#access-control) with email domain restrictions

--- a/docs/versioned_docs/version-v0.13.0/installation/kubernetes-deployment.md
+++ b/docs/versioned_docs/version-v0.13.0/installation/kubernetes-deployment.md
@@ -75,28 +75,28 @@ config:
 
 For detailed configuration options, see:
 
-- **[Server Configuration](../configuration/server-configuration)** - All available environment variables
-- **[Workspace Provider](../configuration/workspace-provider)** - S3 storage configuration
-- **[Encryption Providers](../configuration/encryption-providers/aws-kms)** - KMS encryption setup
+- **[Server Configuration](/configuration/server-configuration)** - All available environment variables
+- **[Workspace Provider](/configuration/workspace-provider)** - S3 storage configuration
+- **[Encryption Providers](/configuration/encryption-providers/aws-kms)** - KMS encryption setup
 
 ## Cloud-Specific Guides
 
 For detailed cloud-specific deployment instructions:
 
-- [Google Kubernetes Engine (GKE)](reference-architectures/gcp-gke)
-- [Amazon Elastic Kubernetes Service (EKS)](reference-architectures/aws-eks)
-- [Azure Kubernetes Service (AKS)](reference-architectures/azure-aks)
+- [Google Kubernetes Engine (GKE)](/installation/reference-architectures/gcp-gke/)
+- [Amazon Elastic Kubernetes Service (EKS)](/installation/reference-architectures/aws-eks/)
+- [Azure Kubernetes Service (AKS)](/installation/reference-architectures/azure-aks/)
 
 ## Next Steps
 
-1. **Configure Authentication**: Set up [auth providers](../configuration/auth-providers)
-2. **Add Model Providers**: Configure [model providers](../configuration/model-providers)
-3. **Set Up MCP Servers**: Deploy [MCP tools](../concepts/mcp-gateway/overview)
+1. **Configure Authentication**: Set up [auth providers](/configuration/auth-providers)
+2. **Add Model Providers**: Configure [model providers](/configuration/model-providers)
+3. **Set Up MCP Servers**: Deploy [MCP tools](../../concepts/mcp-gateway/overview/)
 4. **Configure Monitoring**: Set up logging and metrics
 5. **Review Security**: Enable authentication and encryption
 
 ## Related Documentation
 
-- [Installation Overview](overview)
-- [Server Configuration](../configuration/server-configuration)
-- [Settings for Hosted MCP Server Deployments](../configuration/mcp-deployments-in-kubernetes)
+- [Installation Overview](/installation/overview/)
+- [Server Configuration](/configuration/server-configuration)
+- [Settings for Hosted MCP Server Deployments](/configuration/mcp-deployments-in-kubernetes)

--- a/docs/versioned_docs/version-v0.13.0/installation/overview.md
+++ b/docs/versioned_docs/version-v0.13.0/installation/overview.md
@@ -27,7 +27,7 @@ Docker provides the fastest way to get Obot running on your local machine or a s
 - Ideal for development and evaluation
 - Uses built-in PostgreSQL
 
-👉 [Docker Deployment Guide](docker-deployment)
+👉 [Docker Deployment Guide](/installation/docker-deployment/)
 
 ### Kubernetes Deployment
 
@@ -39,7 +39,7 @@ Deploy Obot on Kubernetes for production-grade reliability and scalability.
 - Integrates with cloud services (KMS, S3, etc.)
 - Requires external PostgreSQL database
 
-👉 [Kubernetes Deployment Guide](kubernetes-deployment)
+👉 [Kubernetes Deployment Guide](/installation/kubernetes-deployment/)
 
 ### Cloud Platform Reference Architectures
 
@@ -53,9 +53,9 @@ If you're planning to deploy Obot on cloud-managed Kubernetes services, these re
 
 Reference architectures for cloud-managed Kubernetes:
 
-- [GCP GKE Reference Architecture](reference-architectures/gcp-gke)
-- [AWS EKS Reference Architecture](reference-architectures/aws-eks)
-- [Azure AKS Reference Architecture](reference-architectures/azure-aks)
+- [GCP GKE Reference Architecture](/installation/reference-architectures/gcp-gke/)
+- [AWS EKS Reference Architecture](/installation/reference-architectures/aws-eks/)
+- [Azure AKS Reference Architecture](/installation/reference-architectures/azure-aks/)
 
 ## System Requirements
 
@@ -85,17 +85,17 @@ For production deployments, you should have:
 
 | Use Case | Recommended Deployment |
 |----------|----------------------|
-| Local development | [Docker](docker-deployment) |
-| Production | [Kubernetes](kubernetes-deployment) |
+| Local development | [Docker](/installation/docker-deployment/) |
+| Production | [Kubernetes](/installation/kubernetes-deployment/) |
 
 ## Next Steps
 
 1. Choose your deployment method above
 2. Follow the deployment guide
-3. [Configure authentication](../configuration/auth-providers)
-4. [Set up model providers](../configuration/model-providers)
-5. Review [server configuration](../configuration/server-configuration)
+3. [Configure authentication](/configuration/auth-providers)
+4. [Set up model providers](/configuration/model-providers)
+5. Review [server configuration](/configuration/server-configuration)
 
 ## Getting Help
 
-- Check [FAQ](../faq)
+- Check [FAQ](/faq/)

--- a/docs/versioned_docs/version-v0.13.0/installation/reference-architectures/01-gcp-gke.md
+++ b/docs/versioned_docs/version-v0.13.0/installation/reference-architectures/01-gcp-gke.md
@@ -64,7 +64,7 @@ resource "google_kms_crypto_key_iam_binding" "this" {
 }
 ```
 
-More information on the Google Cloud KMS setup can be found [here](../../configuration/encryption-providers/google-cloud-kms).
+More information on the Google Cloud KMS setup can be found [here](/configuration/encryption-providers/google-cloud-kms).
 
 
 Once you have these resources set up, install the Obot helm chart with:

--- a/docs/versioned_docs/version-v0.13.0/installation/reference-architectures/02-aws-eks.md
+++ b/docs/versioned_docs/version-v0.13.0/installation/reference-architectures/02-aws-eks.md
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "obot_kms" {
 }
 ```
 
-More information on the AWS KMS setup can be found [here](../../configuration/encryption-providers/aws-kms).
+More information on the AWS KMS setup can be found [here](/configuration/encryption-providers/aws-kms).
 
 Once you have these resources set up, install the Obot helm chart with:
 

--- a/docs/versioned_docs/version-v0.13.0/installation/reference-architectures/03-azure-aks.md
+++ b/docs/versioned_docs/version-v0.13.0/installation/reference-architectures/03-azure-aks.md
@@ -73,7 +73,7 @@ resource "azurerm_federated_identity_credential" "obot" {
 }
 ```
 
-More information on the Azure Key Vault setup can be found [here](../../configuration/encryption-providers/azure-key-vault).
+More information on the Azure Key Vault setup can be found [here](/configuration/encryption-providers/azure-key-vault).
 
 Once you have these resources set up, install the Obot helm chart with:
 

--- a/docs/versioned_docs/version-v0.14.0/concepts/chat/overview.md
+++ b/docs/versioned_docs/version-v0.14.0/concepts/chat/overview.md
@@ -55,4 +55,4 @@ Projects can interact with external systems through the Model Context Protocol. 
 
 ## Configuration
 
-For more information on configuring chat, visit the [chat configuration](../../configuration/chat-configuration) documentation.
+For more information on configuring chat, visit the [chat configuration](../../../configuration/chat-configuration/) documentation.

--- a/docs/versioned_docs/version-v0.14.0/configuration/server-configuration.md
+++ b/docs/versioned_docs/version-v0.14.0/configuration/server-configuration.md
@@ -40,10 +40,10 @@ The Obot server is configured via environment variables. The following configura
 
 ## Encryption Providers
 
-You can configure optional [encryption providers](encryption-providers/aws-kms) to ensure secrets are encrypted.
+You can configure optional [encryption providers](/configuration/encryption-providers/aws-kms/) to ensure secrets are encrypted.
 
 ## Model Providers
-You can configure additional models using [model providers](model-providers)
+You can configure additional models using [model providers](/configuration/model-providers/)
 
 ## Workspace Provider
-You can configure external storage for workspace files using a [workspace provider](workspace-provider)
+You can configure external storage for workspace files using a [workspace provider](/configuration/workspace-provider/)

--- a/docs/versioned_docs/version-v0.14.0/faq.md
+++ b/docs/versioned_docs/version-v0.14.0/faq.md
@@ -8,7 +8,7 @@ Docker is suitable for local testing and small-scale deployments. For production
 
 ### Why can’t I see the User Management section?
 
-User Management is only visible when authentication is enabled. Make sure you start Obot with `OBOT_SERVER_ENABLE_AUTHENTICATION=true`. If you don’t see the bootstrap token prompt, the environment variable may not be set correctly. Follow the [installation guide](installation/enabling-authentication)
+User Management is only visible when authentication is enabled. Make sure you start Obot with `OBOT_SERVER_ENABLE_AUTHENTICATION=true`. If you don’t see the bootstrap token prompt, the environment variable may not be set correctly. Follow the [installation guide](/installation/enabling-authentication/)
 
 ### How do I assign roles to users before they log in?
 
@@ -37,12 +37,12 @@ Both use the same core codebase, but the enterprise version includes additional 
 
 ### How do I pass user-specific parameters (e.g., Jira PAT tokens) to a remote MCP server?
 
-As an admin, you can configure the server in the catalog section of the mcp-servers page. See [here](concepts/admin/mcp-servers#configuration-parameters) for details.
+As an admin, you can configure the server in the catalog section of the mcp-servers page. See [here](../concepts/admin/mcp-servers/#configuration-parameters) for details.
 
 ### How do I get started with AKS/GKE/AWS deployment?
 
 See the reference architecture guide for your cloud provider, and follow the Kubernetes installation.
 
-- [AKS](installation/reference-architectures/azure-aks)
-- [GKE](installation/reference-architectures/gcp-gke)
-- [AWS](installation/reference-architectures/aws-eks)
+- [AKS](/installation/reference-architectures/azure-aks/)
+- [GKE](/installation/reference-architectures/gcp-gke/)
+- [AWS](/installation/reference-architectures/aws-eks/)

--- a/docs/versioned_docs/version-v0.14.0/installation/docker-deployment.md
+++ b/docs/versioned_docs/version-v0.14.0/installation/docker-deployment.md
@@ -11,7 +11,7 @@ Docker deployment is the fastest way to get Obot running. It's ideal for:
 - Proof-of-concept and evaluation
 - Small team usage
 
-For production deployments, see [Kubernetes Deployment](kubernetes-deployment).
+For production deployments, see [Kubernetes Deployment](/installation/kubernetes-deployment/).
 
 ## Prerequisites
 
@@ -72,12 +72,12 @@ You will need to look for an entry like:
 
 ## Next Steps
 
-1. **Configure Authentication**: Set up [auth providers](../configuration/auth-providers) for secure access
-2. **Configure Model Providers**: Configure [model providers](../configuration/model-providers) (OpenAI, Anthropic, etc.)
-3. **Set Up MCP Tools**: Deploy [MCP servers](../concepts/mcp-gateway/overview) for extended functionality
+1. **Configure Authentication**: Set up [auth providers](/configuration/auth-providers) for secure access
+2. **Configure Model Providers**: Configure [model providers](/configuration/model-providers) (OpenAI, Anthropic, etc.)
+3. **Set Up MCP Tools**: Deploy [MCP servers](../../concepts/mcp-gateway/overview/) for extended functionality
 
 ## Related Documentation
 
-- [Installation Overview](overview)
-- [Kubernetes Deployment](kubernetes-deployment)
-- [Server Configuration](../configuration/server-configuration)
+- [Installation Overview](/installation/overview/)
+- [Kubernetes Deployment](/installation/kubernetes-deployment/)
+- [Server Configuration](/configuration/server-configuration)

--- a/docs/versioned_docs/version-v0.14.0/installation/enabling-authentication.md
+++ b/docs/versioned_docs/version-v0.14.0/installation/enabling-authentication.md
@@ -70,7 +70,7 @@ Once logged in with the bootstrap token:
 3. Select your desired provider (GitHub, Google, Entra, Okta)
 4. Follow the provider-specific configuration steps
 
-For detailed provider configuration, see the [Auth Providers](../configuration/auth-providers) documentation.
+For detailed provider configuration, see the [Auth Providers](/configuration/auth-providers) documentation.
 
 ## Step 4: Set Admin/Owner Users and Restart
 
@@ -137,6 +137,6 @@ After restart:
 
 ## Next Steps
 
-- Review [Auth Providers configuration](../configuration/auth-providers) for detailed provider setup
-- Configure [OAuth settings](../configuration/oauth-configuration) for additional customization
-- Set up proper [access control](../configuration/auth-providers#access-control) with email domain restrictions
+- Review [Auth Providers configuration](/configuration/auth-providers) for detailed provider setup
+- Configure [OAuth settings](../../configuration/oauth-configuration/) for additional customization
+- Set up proper [access control](/configuration/auth-providers#access-control) with email domain restrictions

--- a/docs/versioned_docs/version-v0.14.0/installation/kubernetes-deployment.md
+++ b/docs/versioned_docs/version-v0.14.0/installation/kubernetes-deployment.md
@@ -75,28 +75,28 @@ config:
 
 For detailed configuration options, see:
 
-- **[Server Configuration](../configuration/server-configuration)** - All available environment variables
-- **[Workspace Provider](../configuration/workspace-provider)** - S3 storage configuration
-- **[Encryption Providers](../configuration/encryption-providers/aws-kms)** - KMS encryption setup
+- **[Server Configuration](/configuration/server-configuration)** - All available environment variables
+- **[Workspace Provider](/configuration/workspace-provider)** - S3 storage configuration
+- **[Encryption Providers](/configuration/encryption-providers/aws-kms)** - KMS encryption setup
 
 ## Cloud-Specific Guides
 
 For detailed cloud-specific deployment instructions:
 
-- [Google Kubernetes Engine (GKE)](reference-architectures/gcp-gke)
-- [Amazon Elastic Kubernetes Service (EKS)](reference-architectures/aws-eks)
-- [Azure Kubernetes Service (AKS)](reference-architectures/azure-aks)
+- [Google Kubernetes Engine (GKE)](/installation/reference-architectures/gcp-gke/)
+- [Amazon Elastic Kubernetes Service (EKS)](/installation/reference-architectures/aws-eks/)
+- [Azure Kubernetes Service (AKS)](/installation/reference-architectures/azure-aks/)
 
 ## Next Steps
 
-1. **Configure Authentication**: Set up [auth providers](../configuration/auth-providers)
-2. **Add Model Providers**: Configure [model providers](../configuration/model-providers)
-3. **Set Up MCP Servers**: Deploy [MCP tools](../concepts/mcp-gateway/overview)
+1. **Configure Authentication**: Set up [auth providers](/configuration/auth-providers)
+2. **Add Model Providers**: Configure [model providers](/configuration/model-providers)
+3. **Set Up MCP Servers**: Deploy [MCP tools](../../concepts/mcp-gateway/overview/)
 4. **Configure Monitoring**: Set up logging and metrics
 5. **Review Security**: Enable authentication and encryption
 
 ## Related Documentation
 
-- [Installation Overview](overview)
-- [Server Configuration](../configuration/server-configuration)
-- [Settings for Hosted MCP Server Deployments](../configuration/mcp-deployments-in-kubernetes)
+- [Installation Overview](/installation/overview/)
+- [Server Configuration](/configuration/server-configuration)
+- [Settings for Hosted MCP Server Deployments](/configuration/mcp-deployments-in-kubernetes)

--- a/docs/versioned_docs/version-v0.14.0/installation/overview.md
+++ b/docs/versioned_docs/version-v0.14.0/installation/overview.md
@@ -27,7 +27,7 @@ Docker provides the fastest way to get Obot running on your local machine or a s
 - Ideal for development and evaluation
 - Uses built-in PostgreSQL
 
-👉 [Docker Deployment Guide](docker-deployment)
+👉 [Docker Deployment Guide](/installation/docker-deployment/)
 
 ### Kubernetes Deployment
 
@@ -39,7 +39,7 @@ Deploy Obot on Kubernetes for production-grade reliability and scalability.
 - Integrates with cloud services (KMS, S3, etc.)
 - Requires external PostgreSQL database
 
-👉 [Kubernetes Deployment Guide](kubernetes-deployment)
+👉 [Kubernetes Deployment Guide](/installation/kubernetes-deployment/)
 
 ### Cloud Platform Reference Architectures
 
@@ -53,9 +53,9 @@ If you're planning to deploy Obot on cloud-managed Kubernetes services, these re
 
 Reference architectures for cloud-managed Kubernetes:
 
-- [GCP GKE Reference Architecture](reference-architectures/gcp-gke)
-- [AWS EKS Reference Architecture](reference-architectures/aws-eks)
-- [Azure AKS Reference Architecture](reference-architectures/azure-aks)
+- [GCP GKE Reference Architecture](/installation/reference-architectures/gcp-gke/)
+- [AWS EKS Reference Architecture](/installation/reference-architectures/aws-eks/)
+- [Azure AKS Reference Architecture](/installation/reference-architectures/azure-aks/)
 
 ## System Requirements
 
@@ -85,17 +85,17 @@ For production deployments, you should have:
 
 | Use Case | Recommended Deployment |
 |----------|----------------------|
-| Local development | [Docker](docker-deployment) |
-| Production | [Kubernetes](kubernetes-deployment) |
+| Local development | [Docker](/installation/docker-deployment/) |
+| Production | [Kubernetes](/installation/kubernetes-deployment/) |
 
 ## Next Steps
 
 1. Choose your deployment method above
 2. Follow the deployment guide
-3. [Configure authentication](../configuration/auth-providers)
-4. [Set up model providers](../configuration/model-providers)
-5. Review [server configuration](../configuration/server-configuration)
+3. [Configure authentication](/configuration/auth-providers)
+4. [Set up model providers](/configuration/model-providers)
+5. Review [server configuration](/configuration/server-configuration)
 
 ## Getting Help
 
-- Check [FAQ](../faq)
+- Check [FAQ](/faq/)

--- a/docs/versioned_docs/version-v0.14.0/installation/reference-architectures/01-gcp-gke.md
+++ b/docs/versioned_docs/version-v0.14.0/installation/reference-architectures/01-gcp-gke.md
@@ -64,7 +64,7 @@ resource "google_kms_crypto_key_iam_binding" "this" {
 }
 ```
 
-More information on the Google Cloud KMS setup can be found [here](../../configuration/encryption-providers/google-cloud-kms).
+More information on the Google Cloud KMS setup can be found [here](/configuration/encryption-providers/google-cloud-kms).
 
 
 Once you have these resources set up, install the Obot helm chart with:

--- a/docs/versioned_docs/version-v0.14.0/installation/reference-architectures/02-aws-eks.md
+++ b/docs/versioned_docs/version-v0.14.0/installation/reference-architectures/02-aws-eks.md
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "obot_kms" {
 }
 ```
 
-More information on the AWS KMS setup can be found [here](../../configuration/encryption-providers/aws-kms).
+More information on the AWS KMS setup can be found [here](/configuration/encryption-providers/aws-kms).
 
 Once you have these resources set up, install the Obot helm chart with:
 

--- a/docs/versioned_docs/version-v0.14.0/installation/reference-architectures/03-azure-aks.md
+++ b/docs/versioned_docs/version-v0.14.0/installation/reference-architectures/03-azure-aks.md
@@ -73,7 +73,7 @@ resource "azurerm_federated_identity_credential" "obot" {
 }
 ```
 
-More information on the Azure Key Vault setup can be found [here](../../configuration/encryption-providers/azure-key-vault).
+More information on the Azure Key Vault setup can be found [here](/configuration/encryption-providers/azure-key-vault).
 
 Once you have these resources set up, install the Obot helm chart with:
 

--- a/docs/versioned_docs/version-v0.15.0/concepts/architecture.md
+++ b/docs/versioned_docs/version-v0.15.0/concepts/architecture.md
@@ -16,7 +16,7 @@ Obot is designed to enable organizations to consume MCP servers in an enterprise
 
 - **MCP Registry**: An index of MCP servers with metadata about how to run them and where to find them.
 
-- **MCP Gateway**: A reverse-proxy that authenticates users, ensures servers are deployed, and forwards requests. See [MCP Gateway](mcp-gateway) for details.
+- **MCP Gateway**: A reverse-proxy that authenticates users, ensures servers are deployed, and forwards requests. See [MCP Gateway](/concepts/mcp-gateway/) for details.
 
 - **MCP Server Shim**: A protocol-aware sidecar that runs alongside each MCP server, handling authorization, audit logging, webhook filters, and token exchange.
 
@@ -42,8 +42,8 @@ Key security properties:
 
 ## Encryption
 
-Obot uses cloud KMS systems to encrypt data at rest. See [Encryption Providers](../configuration/encryption-providers/overview) for configuration options.
+Obot uses cloud KMS systems to encrypt data at rest. See [Encryption Providers](/configuration/encryption-providers/overview) for configuration options.
 
 ## LLMs
 
-Obot operates with a bring-your-own-model philosophy. Multiple providers can be configured to meet organizational requirements. See [Model Providers](../configuration/model-providers) for details.
+Obot operates with a bring-your-own-model philosophy. Multiple providers can be configured to meet organizational requirements. See [Model Providers](/configuration/model-providers) for details.

--- a/docs/versioned_docs/version-v0.15.0/concepts/mcp-hosting.md
+++ b/docs/versioned_docs/version-v0.15.0/concepts/mcp-hosting.md
@@ -8,16 +8,16 @@ The MCP Hosting layer runs and manages MCP servers directly within Obot. It hand
 
 ## Runtime Types
 
-- **[Node.js (npx)](../functionality/mcp-servers#npx-nodetypescript-based-mcp-servers)**: Run npm-packaged MCP servers via STDIO
-- **[Python (uvx)](../functionality/mcp-servers#uvx-for-python-based-packages)**: Run PyPI-packaged MCP servers via STDIO
-- **[Containerized](../functionality/mcp-servers#containerized-for-docker-based-deployments)**: Run Docker containers with HTTP/SSE transport
+- **[Node.js (npx)](/functionality/mcp-servers#npx-nodetypescript-based-mcp-servers)**: Run npm-packaged MCP servers via STDIO
+- **[Python (uvx)](/functionality/mcp-servers#uvx-for-python-based-packages)**: Run PyPI-packaged MCP servers via STDIO
+- **[Containerized](/functionality/mcp-servers#containerized-for-docker-based-deployments)**: Run Docker containers with HTTP/SSE transport
 
 ## Server Types
 
-- **[Single-user](../functionality/mcp-servers#single-user-server)**: Each user gets their own isolated instance with separate credentials
-- **[Multi-user](../functionality/mcp-servers#multi-user-server)**: A shared instance serves multiple users with shared or per-user credentials
-- **[Remote](../functionality/mcp-servers#remote-server)**: External MCP servers accessed via HTTP, not hosted by Obot
-- **[Composite](../functionality/mcp-servers#composite-server)**: Combines multiple servers into a single virtual server with curated tools
+- **[Single-user](/functionality/mcp-servers#single-user-server)**: Each user gets their own isolated instance with separate credentials
+- **[Multi-user](/functionality/mcp-servers#multi-user-server)**: A shared instance serves multiple users with shared or per-user credentials
+- **[Remote](/functionality/mcp-servers#remote-server)**: External MCP servers accessed via HTTP, not hosted by Obot
+- **[Composite](/functionality/mcp-servers#composite-server)**: Combines multiple servers into a single virtual server with curated tools
 
 ## Deployment Environments
 
@@ -28,7 +28,7 @@ When running Obot with Docker, MCP servers are deployed as sibling containers:
 - Obot communicates with the Docker daemon to manage containers
 - Servers run alongside the Obot container
 - Suitable for development and small deployments
-- See [Docker Deployment](../installation/docker-deployment) for setup details
+- See [Docker Deployment](/installation/docker-deployment) for setup details
 
 ### Kubernetes
 
@@ -36,7 +36,7 @@ For production deployments, Obot can deploy MCP servers to Kubernetes:
 
 - Servers run as pods in the cluster
 - Supports resource limits, network policies, and scaling
-- See [MCP Deployments in Kubernetes](../configuration/mcp-deployments-in-kubernetes) for configuration details
+- See [MCP Deployments in Kubernetes](/configuration/mcp-deployments-in-kubernetes) for configuration details
 
 ## Authentication
 
@@ -47,9 +47,9 @@ Obot handles OAuth 2.1 flows for MCP servers that require authentication:
 - Per-user credential isolation
 - Supports custom OAuth configurations
 
-See [MCP Server OAuth Configuration](../configuration/mcp-server-oauth-configuration) for details on configuring OAuth for MCP servers.
+See [MCP Server OAuth Configuration](/configuration/mcp-server-oauth-configuration) for details on configuring OAuth for MCP servers.
 
 ## Learn More
 
-- [MCP Servers](../functionality/mcp-servers) - Adding and configuring MCP servers
-- [Installation](../installation/overview) - Deployment environments and setup
+- [MCP Servers](/functionality/mcp-servers) - Adding and configuring MCP servers
+- [Installation](/installation/overview) - Deployment environments and setup

--- a/docs/versioned_docs/version-v0.15.0/concepts/mcp-registry.md
+++ b/docs/versioned_docs/version-v0.15.0/concepts/mcp-registry.md
@@ -13,7 +13,7 @@ The MCP Registry is a central place to list and discover MCP servers. It provide
 MCP server definitions can come from:
 
 - **Official Obot repository**: The default set from [obot-platform/mcp-catalog](https://github.com/obot-platform/mcp-catalog)
-- **Custom Git repositories**: Your own repositories containing server definitions (see [MCP Server GitOps](../configuration/mcp-server-gitops))
+- **Custom Git repositories**: Your own repositories containing server definitions (see [MCP Server GitOps](/configuration/mcp-server-gitops))
 - **Direct entry**: Servers added manually through the UI
 
 ### Server Definitions
@@ -36,4 +36,4 @@ Obot implements the [MCP Registry specification](https://github.com/modelcontext
 
 ## Learn More
 
-- [MCP Registries](../functionality/mcp-registries) - Managing registries, API details, and contributing servers
+- [MCP Registries](/functionality/mcp-registries) - Managing registries, API details, and contributing servers

--- a/docs/versioned_docs/version-v0.15.0/concepts/obot-chat.md
+++ b/docs/versioned_docs/version-v0.15.0/concepts/obot-chat.md
@@ -34,4 +34,4 @@ Projects can persist important information across all threads, capturing key det
 
 ## Learn More
 
-- [Obot Chat](../functionality/chat/overview) - Detailed configuration and usage
+- [Obot Chat](/functionality/chat/overview) - Detailed configuration and usage

--- a/docs/versioned_docs/version-v0.15.0/configuration/model-providers.md
+++ b/docs/versioned_docs/version-v0.15.0/configuration/model-providers.md
@@ -19,7 +19,7 @@ Obot supports a variety of model providers, including:
 The UI will indicate whether each provider has been configured. If a provider is configured you will have the ability to modify or deconfigure it.
 
 :::note
-Our Enterprise release adds support for additional Enterprise-grade model providers. [See here](../enterprise/overview) for more details.
+Our Enterprise release adds support for additional Enterprise-grade model providers. [See here](/enterprise/overview) for more details.
 :::
 
 ##### Configuring and enabling a provider

--- a/docs/versioned_docs/version-v0.15.0/configuration/user-roles.md
+++ b/docs/versioned_docs/version-v0.15.0/configuration/user-roles.md
@@ -68,7 +68,7 @@ Configure the default role for new users on the **User Management > User Roles**
 
 ### Pre-Assigning Roles
 
-To grant admin or owner access to users before they log in, set these environment variables during deployment. See [Enabling Authentication](../installation/enabling-authentication) for details.
+To grant admin or owner access to users before they log in, set these environment variables during deployment. See [Enabling Authentication](/installation/enabling-authentication) for details.
 
 ```bash
 OBOT_SERVER_AUTH_ADMIN_EMAILS=admin@example.com,admin2@example.com

--- a/docs/versioned_docs/version-v0.15.0/faq.md
+++ b/docs/versioned_docs/version-v0.15.0/faq.md
@@ -8,7 +8,7 @@ Docker is suitable for local testing and small-scale deployments. For production
 
 ### Why can’t I see the User Management section?
 
-User Management is only visible when authentication is enabled. Make sure you start Obot with `OBOT_SERVER_ENABLE_AUTHENTICATION=true`. If you don't see the bootstrap token prompt, the environment variable may not be set correctly. Follow the [installation guide](installation/enabling-authentication).
+User Management is only visible when authentication is enabled. Make sure you start Obot with `OBOT_SERVER_ENABLE_AUTHENTICATION=true`. If you don't see the bootstrap token prompt, the environment variable may not be set correctly. Follow the [installation guide](/installation/enabling-authentication/).
 
 ### How do I assign roles to users before they log in?
 
@@ -50,12 +50,12 @@ Some clients do not support the required OAuth flows. As a workaround, use the `
 
 ### How do I pass user-specific parameters (e.g., Jira PAT tokens) to a remote MCP server?
 
-As an admin, you can configure the server in the MCP Servers section. See [MCP Servers](functionality/mcp-servers) for details.
+As an admin, you can configure the server in the MCP Servers section. See [MCP Servers](/functionality/mcp-servers/) for details.
 
 ### How do I get started with AKS/GKE/AWS deployment?
 
 See the reference architecture guide for your cloud provider, and follow the Kubernetes installation.
 
-- [AKS](installation/reference-architectures/azure-aks)
-- [GKE](installation/reference-architectures/gcp-gke)
-- [AWS](installation/reference-architectures/aws-eks)
+- [AKS](/installation/reference-architectures/azure-aks/)
+- [GKE](/installation/reference-architectures/gcp-gke/)
+- [AWS](/installation/reference-architectures/aws-eks/)

--- a/docs/versioned_docs/version-v0.15.0/functionality/audit-logs-and-usage.md
+++ b/docs/versioned_docs/version-v0.15.0/functionality/audit-logs-and-usage.md
@@ -7,7 +7,7 @@ title: Audit Logs & Usage
 The MCP Platform provides visibility into MCP activity through audit logs and usage tracking. These features help with monitoring, compliance, and understanding how MCP servers are being used.
 
 :::info Auditor Role
-Sensitive data (MCP request/response bodies, chat threads, and task runs) can **only** be viewed by users with the Auditor role. All other roles, including Owner and Admin, see only metadata for these resources. The Auditor role is an add-on permission that can be combined with any other role, granting read-only access to sensitive data across the platform. See [User Roles](../configuration/user-roles#auditor) for details.
+Sensitive data (MCP request/response bodies, chat threads, and task runs) can **only** be viewed by users with the Auditor role. All other roles, including Owner and Admin, see only metadata for these resources. The Auditor role is an add-on permission that can be combined with any other role, granting read-only access to sensitive data across the platform. See [User Roles](/configuration/user-roles#auditor) for details.
 :::
 
 ## Audit Logs
@@ -51,7 +51,7 @@ Filter logs by:
 
 ### Exporting Audit Logs
 
-Audit logs can be exported for external analysis or compliance requirements. See [Audit Log Export](../configuration/audit-log-export) for configuration options.
+Audit logs can be exported for external analysis or compliance requirements. See [Audit Log Export](/configuration/audit-log-export) for configuration options.
 
 ## Usage
 

--- a/docs/versioned_docs/version-v0.15.0/functionality/chat-management.md
+++ b/docs/versioned_docs/version-v0.15.0/functionality/chat-management.md
@@ -26,7 +26,7 @@ Control which models users can select while chatting:
 
 ## Model Providers
 
-Configure LLM providers and their available models. See [Model Providers](../configuration/model-providers) for setup details.
+Configure LLM providers and their available models. See [Model Providers](/configuration/model-providers) for setup details.
 
 ## Chat Threads, Tasks, and Task Runs
 

--- a/docs/versioned_docs/version-v0.15.0/functionality/chat/overview.md
+++ b/docs/versioned_docs/version-v0.15.0/functionality/chat/overview.md
@@ -65,7 +65,7 @@ Connect to MCP servers through your projects:
 
 Admins and Owners configure which LLM providers and models are available to users. Users select from these configured models while chatting.
 
-See [Model Providers](../../configuration/model-providers) for configuration details.
+See [Model Providers](/configuration/model-providers) for configuration details.
 
 ## Knowledge (RAG)
 

--- a/docs/versioned_docs/version-v0.15.0/functionality/overview.md
+++ b/docs/versioned_docs/version-v0.15.0/functionality/overview.md
@@ -6,7 +6,7 @@ title: Overview
 
 The MCP Platform is Obot's unified management interface for deploying, managing, and operating MCP servers. It provides role-based access to server management, registries, audit logs, usage tracking, and platform administration.
 
-For detailed permissions and role definitions, see [User Roles](../configuration/user-roles).
+For detailed permissions and role definitions, see [User Roles](/configuration/user-roles).
 
 ## Roles and Capabilities
 
@@ -28,7 +28,7 @@ Power Users+ include all Power User capabilities and can additionally publish MC
 
 Admins and Owners have full administrative access to the platform, including system-wide configuration, user management, and chat administration.
 
-The only functional difference between Owners and Admins is that Owners can assign the **Auditor** role to users. For more information, see the [Auditor Role](../configuration/user-roles#auditor).
+The only functional difference between Owners and Admins is that Owners can assign the **Auditor** role to users. For more information, see the [Auditor Role](/configuration/user-roles#auditor).
 
 ## Navigation by Role
 
@@ -50,13 +50,13 @@ The only functional difference between Owners and Admins is that Owners can assi
 
 ## Learn More
 
-- [MCP Servers](mcp-servers) - Deploy, configure, and manage MCP servers
-- [MCP Registries](mcp-registries) - Control which servers are available to which users and groups
-- [Audit Logs and Usage](audit-logs-and-usage) - Monitor activity and track consumption
-- [Filters](filters) - Inspect and control MCP traffic
-- [Server Scheduling](server-scheduling) - Define server availability windows
-- [Chat Management](chat-management) - Configure default chat settings and monitor activity
-- [User Management](user-management) - Manage users, roles, and authentication
-- [Branding](branding) - Customize theme colors and branding
-- [Obot Chat](chat/overview) - Projects, threads, tasks, and chat features
-- [User Roles](../configuration/user-roles) - Detailed permissions and role definitions
+- [MCP Servers](/functionality/mcp-servers/) - Deploy, configure, and manage MCP servers
+- [MCP Registries](/functionality/mcp-registries/) - Control which servers are available to which users and groups
+- [Audit Logs and Usage](/functionality/audit-logs-and-usage/) - Monitor activity and track consumption
+- [Filters](/functionality/filters/) - Inspect and control MCP traffic
+- [Server Scheduling](/functionality/server-scheduling/) - Define server availability windows
+- [Chat Management](/functionality/chat-management/) - Configure default chat settings and monitor activity
+- [User Management](/functionality/user-management/) - Manage users, roles, and authentication
+- [Branding](/functionality/branding/) - Customize theme colors and branding
+- [Obot Chat](/functionality/chat/overview/) - Projects, threads, tasks, and chat features
+- [User Roles](/configuration/user-roles) - Detailed permissions and role definitions

--- a/docs/versioned_docs/version-v0.15.0/functionality/user-management.md
+++ b/docs/versioned_docs/version-v0.15.0/functionality/user-management.md
@@ -14,7 +14,7 @@ View and manage all users on the platform. From this page you can:
 - Update individual user roles
 - Monitor user activity
 
-For details on updating roles, see [User Roles](../configuration/user-roles#managing-roles).
+For details on updating roles, see [User Roles](/configuration/user-roles#managing-roles).
 
 ## User Roles
 
@@ -25,8 +25,8 @@ Configure the default role assigned to new users when they first log in. Choose 
 - **Power User Plus**: Power User features plus share MCP servers through registries
 - **Admin**: Full platform management
 
-For detailed role descriptions and permissions, see [User Roles](../configuration/user-roles).
+For detailed role descriptions and permissions, see [User Roles](/configuration/user-roles).
 
 ## Auth Providers
 
-Configure identity providers for user authentication. See [Auth Providers](../configuration/auth-providers) for setup details.
+Configure identity providers for user authentication. See [Auth Providers](/configuration/auth-providers) for setup details.

--- a/docs/versioned_docs/version-v0.15.0/installation/docker-deployment.md
+++ b/docs/versioned_docs/version-v0.15.0/installation/docker-deployment.md
@@ -11,7 +11,7 @@ Docker deployment is the fastest way to get Obot running. It's ideal for:
 - Proof-of-concept and evaluation
 - Small team usage
 
-For production deployments, see [Kubernetes Deployment](kubernetes-deployment).
+For production deployments, see [Kubernetes Deployment](/installation/kubernetes-deployment/).
 
 ## Prerequisites
 
@@ -57,12 +57,12 @@ If you enabled authentication, use your bootstrap token to log in as the owner a
 
 ## Next Steps
 
-1. **Configure Authentication**: Set up [auth providers](../configuration/auth-providers) for secure access
-2. **Configure Model Providers**: Configure [model providers](../configuration/model-providers) (OpenAI, Anthropic, etc.)
-3. **Set Up MCP Servers**: Configure [MCP servers](../functionality/mcp-servers) for extended functionality
+1. **Configure Authentication**: Set up [auth providers](/configuration/auth-providers) for secure access
+2. **Configure Model Providers**: Configure [model providers](/configuration/model-providers) (OpenAI, Anthropic, etc.)
+3. **Set Up MCP Servers**: Configure [MCP servers](/functionality/mcp-servers) for extended functionality
 
 ## Related Documentation
 
-- [Installation Overview](overview)
-- [Kubernetes Deployment](kubernetes-deployment)
-- [Server Configuration](../configuration/server-configuration)
+- [Installation Overview](/installation/overview/)
+- [Kubernetes Deployment](/installation/kubernetes-deployment/)
+- [Server Configuration](/configuration/server-configuration)

--- a/docs/versioned_docs/version-v0.15.0/installation/enabling-authentication.md
+++ b/docs/versioned_docs/version-v0.15.0/installation/enabling-authentication.md
@@ -11,7 +11,7 @@ If any MCP servers were created with authentication disabled, they will be delet
 
 ## Step 1: Set Environment Variables
 
-Enabling authentication begins with launching Obot with additional configuration options in the form of environment variables. See the [Docker](docker-deployment) or [Kubernetes](kubernetes-deployment) deployment guides for full setup details.
+Enabling authentication begins with launching Obot with additional configuration options in the form of environment variables. See the [Docker](/installation/docker-deployment/) or [Kubernetes](/installation/kubernetes-deployment/) deployment guides for full setup details.
 
 <Tabs>
   <TabItem value="docker" label="Docker" default>
@@ -63,7 +63,7 @@ Start (or restart) your Obot deployment with the new environment variables. Navi
 2. Click **Configure** on your desired provider (GitHub, Google, Entra, Okta)
 3. Follow the provider-specific configuration steps
 
-For detailed provider configuration, see the [Auth Providers](../configuration/auth-providers) documentation.
+For detailed provider configuration, see the [Auth Providers](/configuration/auth-providers) documentation.
 
 ## Post-Setup
 
@@ -91,4 +91,4 @@ Note that you can always assign the owner or admin role to additional users thro
 
 ## Next Steps
 
-- Review [Auth Providers configuration](../configuration/auth-providers) for detailed provider setup
+- Review [Auth Providers configuration](/configuration/auth-providers) for detailed provider setup

--- a/docs/versioned_docs/version-v0.15.0/installation/kubernetes-deployment.md
+++ b/docs/versioned_docs/version-v0.15.0/installation/kubernetes-deployment.md
@@ -86,28 +86,28 @@ To enable a high availability setup, uncomment the `replicaCount` line and set i
 
 For detailed configuration options, see:
 
-- **[Server Configuration](../configuration/server-configuration)** - All available environment variables
-- **[Workspace Provider](../configuration/workspace-provider)** - S3 storage configuration
-- **[Encryption Providers](../configuration/encryption-providers/aws-kms)** - KMS encryption setup
+- **[Server Configuration](/configuration/server-configuration)** - All available environment variables
+- **[Workspace Provider](/configuration/workspace-provider)** - S3 storage configuration
+- **[Encryption Providers](/configuration/encryption-providers/aws-kms)** - KMS encryption setup
 
 ## Cloud-Specific Guides
 
 For detailed cloud-specific deployment instructions:
 
-- [Google Kubernetes Engine (GKE)](reference-architectures/gcp-gke)
-- [Amazon Elastic Kubernetes Service (EKS)](reference-architectures/aws-eks)
-- [Azure Kubernetes Service (AKS)](reference-architectures/azure-aks)
+- [Google Kubernetes Engine (GKE)](/installation/reference-architectures/gcp-gke/)
+- [Amazon Elastic Kubernetes Service (EKS)](/installation/reference-architectures/aws-eks/)
+- [Azure Kubernetes Service (AKS)](/installation/reference-architectures/azure-aks/)
 
 ## Next Steps
 
-1. **Configure Authentication**: Set up [auth providers](../configuration/auth-providers)
-2. **Add Model Providers**: Configure [model providers](../configuration/model-providers)
-3. **Set Up MCP Servers**: Configure [MCP servers](../functionality/mcp-servers)
+1. **Configure Authentication**: Set up [auth providers](/configuration/auth-providers)
+2. **Add Model Providers**: Configure [model providers](/configuration/model-providers)
+3. **Set Up MCP Servers**: Configure [MCP servers](/functionality/mcp-servers)
 4. **Configure Monitoring**: Set up logging and metrics
 5. **Review Security**: Enable authentication and encryption
 
 ## Related Documentation
 
-- [Installation Overview](overview)
-- [Server Configuration](../configuration/server-configuration)
-- [Settings for Hosted MCP Server Deployments](../configuration/mcp-deployments-in-kubernetes)
+- [Installation Overview](/installation/overview/)
+- [Server Configuration](/configuration/server-configuration)
+- [Settings for Hosted MCP Server Deployments](/configuration/mcp-deployments-in-kubernetes)

--- a/docs/versioned_docs/version-v0.15.0/installation/overview.md
+++ b/docs/versioned_docs/version-v0.15.0/installation/overview.md
@@ -20,7 +20,7 @@ Docker provides the fastest way to get Obot running on your local machine or a s
 - Includes a built-in PostgreSQL database and local file storage
 - Deploys MCP servers as Docker containers using the host’s Docker socket
 
-For more details, see the [Docker Deployment Guide](docker-deployment).
+For more details, see the [Docker Deployment Guide](/installation/docker-deployment/).
 
 ## Kubernetes Deployment
 
@@ -30,7 +30,7 @@ Kubernetes provides the best way to run Obot reliably at scale in production env
 - Integrates with cloud-native services such as KMS and S3
 - Requires an external PostgreSQL database and external storage
 
-For more details, see the [Kubernetes Deployment Guide](kubernetes-deployment).
+For more details, see the [Kubernetes Deployment Guide](/installation/kubernetes-deployment/).
 
 ## Production System Requirements
 
@@ -40,7 +40,7 @@ For production deployments, the following components are required:
 - **External PostgreSQL database**: PostgreSQL 17 or later with the pgvector extension
 - **S3-compatible object storage**: For workspace files and persistent data
 - **Encryption provider**: AWS KMS, Google Cloud KMS, or Azure Key Vault
-- **Authentication provider**: See our supported [Authentication Providers](../configuration/auth-providers)
+- **Authentication provider**: See our supported [Authentication Providers](/configuration/auth-providers)
 - **TLS/SSL certificates**: For secure HTTPS access
 - **Backup strategy**: Regular backups for both the database and object storage
 
@@ -48,18 +48,18 @@ For production deployments, the following components are required:
 
 If you plan to deploy Obot on a managed Kubernetes service, these reference architectures provide infrastructure guidance and best practices:
 
-- [GCP GKE Reference Architecture](reference-architectures/gcp-gke)
-- [AWS EKS Reference Architecture](reference-architectures/aws-eks)
-- [Azure AKS Reference Architecture](reference-architectures/azure-aks)
+- [GCP GKE Reference Architecture](/installation/reference-architectures/gcp-gke/)
+- [AWS EKS Reference Architecture](/installation/reference-architectures/aws-eks/)
+- [Azure AKS Reference Architecture](/installation/reference-architectures/azure-aks/)
 
 ## Next Steps
 
 1. Choose a deployment method above
 2. Follow the corresponding deployment guide
-3. [Configure authentication](../configuration/auth-providers)
-4. [Set up model providers](../configuration/model-providers)
-5. Review the [server configuration options](../configuration/server-configuration)
+3. [Configure authentication](/configuration/auth-providers)
+4. [Set up model providers](/configuration/model-providers)
+5. Review the [server configuration options](/configuration/server-configuration)
 
 ## Getting Help
 
-- See the [FAQ](../faq)
+- See the [FAQ](/faq/)

--- a/docs/versioned_docs/version-v0.15.0/installation/reference-architectures/01-gcp-gke.md
+++ b/docs/versioned_docs/version-v0.15.0/installation/reference-architectures/01-gcp-gke.md
@@ -64,7 +64,7 @@ resource "google_kms_crypto_key_iam_binding" "this" {
 }
 ```
 
-More information on the Google Cloud KMS setup can be found [here](../../configuration/encryption-providers/google-cloud-kms).
+More information on the Google Cloud KMS setup can be found [here](/configuration/encryption-providers/google-cloud-kms).
 
 
 Once you have these resources set up, install the Obot helm chart with:

--- a/docs/versioned_docs/version-v0.15.0/installation/reference-architectures/02-aws-eks.md
+++ b/docs/versioned_docs/version-v0.15.0/installation/reference-architectures/02-aws-eks.md
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "obot_kms" {
 }
 ```
 
-More information on the AWS KMS setup can be found [here](../../configuration/encryption-providers/aws-kms).
+More information on the AWS KMS setup can be found [here](/configuration/encryption-providers/aws-kms).
 
 Once you have these resources set up, install the Obot helm chart with:
 

--- a/docs/versioned_docs/version-v0.15.0/installation/reference-architectures/03-azure-aks.md
+++ b/docs/versioned_docs/version-v0.15.0/installation/reference-architectures/03-azure-aks.md
@@ -73,7 +73,7 @@ resource "azurerm_federated_identity_credential" "obot" {
 }
 ```
 
-More information on the Azure Key Vault setup can be found [here](../../configuration/encryption-providers/azure-key-vault).
+More information on the Azure Key Vault setup can be found [here](/configuration/encryption-providers/azure-key-vault).
 
 Once you have these resources set up, install the Obot helm chart with:
 


### PR DESCRIPTION
- Add trailingSlash: true to Docusaurus config to ensure canonical URLs
  match the actual URLs that return 200 OK (fixes duplicate content issue)
- Add redirect from /concepts/admin/mcp-server-catalogs to
  /configuration/mcp-server-gitops for moved page
- Fix all relative links across docs to work with trailing slash URLs
- Update links in versioned docs (v0.13.0, v0.14.0, v0.15.0) to use
  proper relative paths within their version context

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
Signed-off-by: Craig Jellick <craig@obot.ai>
