### PR TITLE
fix: api keys: access should always be allowed for *

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -576,7 +576,7 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 // For component servers (servers that belong to a composite), it instead checks whether
 // the corresponding composite server is in the allowed list.
 func validateAPIKeyAccess(ctx api.Context, apiKey *gwtypes.APIKey, mcpID string) error {
-	if slices.Contains(apiKey.MCPServerIDs, mcpID) {
+	if slices.Contains(apiKey.MCPServerIDs, "*") || slices.Contains(apiKey.MCPServerIDs, mcpID) {
 		return nil
 	}
 


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5480