### PR TITLE
fix: use exposed port for connecting to component MCP servers in docker

### DIFF
--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -233,7 +233,7 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 	server.JWKSEndpoint = localhostURLRegexp.ReplaceAllString(server.JWKSEndpoint, d.hostBaseURLWithPort)
 
 	for i, component := range server.Components {
-		component.URL = strings.Replace(component.URL, "http://localhost", d.hostBaseURL, 1)
+		component.URL = localhostURLRegexp.ReplaceAllString(component.URL, d.hostBaseURLWithPort)
 		server.Components[i] = component
 	}
 


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/5493