### PR TITLE
fix: add redirects for broken referral links

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -30,6 +30,14 @@ const config: Config = {
             from: "/concepts/admin/mcp-server-catalogs",
             to: "/configuration/mcp-server-gitops",
           },
+          {
+            from: "/concepts/mcp-gateway/overview",
+            to: "/concepts/mcp-gateway",
+          },
+          {
+            from: "/installation/general",
+            to: "/installation/overview",
+          },
         ],
       },
     ],


### PR DESCRIPTION
Add redirects for URLs that external sites are linking to but no longer exist:
- /concepts/mcp-gateway/overview -> /concepts/mcp-gateway
- /installation/general -> /installation/overview

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
Signed-off-by: Craig Jellick <craig@obot.ai>
