### PR TITLE
fix: stop refresh icon spinning after canceling tool override configuration

### DIFF
--- a/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
@@ -366,6 +366,10 @@
 	class="md:w-sm"
 	onClose={() => {
 		listeningOauthVisibility = false;
+		if (!ready) {
+			resetConfigureTool();
+			onCancel?.();
+		}
 	}}
 >
 	{#if configuringEntry}
@@ -436,10 +440,15 @@
 	{configuringEntry}
 	{tools}
 	onCancel={() => {
+		const hadConfiguringEntry = !!configuringEntry;
 		resetConfigureTool();
-		if (configuringEntry) {
+		if (hadConfiguringEntry) {
 			onCancel?.();
 		}
+	}}
+	onClose={() => {
+		resetConfigureTool();
+		onCancel?.();
 	}}
 	onSuccess={() => {
 		if (!componentConfig || !configuringEntry) return;


### PR DESCRIPTION
When clicking "Refresh Tool Overrides" for a Composite MCP Server component and then canceling the configuration modal, the refresh icon would continue spinning indefinitely.

Changes:
- Save configuringEntry state before resetting in onCancel handler
- Add onClose handler for CompositeEditTools to reset loading state
- Fix initConfigureToolsDialog onClose to properly clean up state

Addresses https://github.com/obot-platform/obot/issues/5374

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
