### PR TITLE
fix: prevent infinite loading when clicking current project in selector

### DIFF
--- a/ui/user/src/lib/components/navbar/Projects.svelte
+++ b/ui/user/src/lib/components/navbar/Projects.svelte
@@ -130,7 +130,9 @@
 		<a
 			href={resolve(`/o/${p.id}`)}
 			class="flex min-h-14 w-full items-center gap-2 p-2"
-			onclick={() => (loading = true)}
+			onclick={() => {
+				if (!isActive) loading = true;
+			}}
 		>
 			<div class="flex grow flex-col">
 				<span class="text-on-background text-sm font-semibold"


### PR DESCRIPTION
Clicking the already-active project in the project selector would set loading=true, but since SvelteKit doesn't navigate when the URL is unchanged, the loading state was never reset.


This issue was reported by user.