### PR TITLE
fix: stop passing audit log credentials to composite MCP servers

### DIFF
--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -693,16 +693,21 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 				"NANOBOT_RUN_OAUTH_CLIENT_SECRET=" + server.TokenExchangeClientSecret,
 				"NANOBOT_RUN_OAUTH_TOKEN_URL=" + server.TokenExchangeEndpoint,
 				"NANOBOT_RUN_OAUTH_AUTHORIZE_URL=" + server.AuthorizeEndpoint,
-				"NANOBOT_RUN_AUDIT_LOG_TOKEN=" + server.AuditLogToken,
-				"NANOBOT_RUN_AUDIT_LOG_SEND_URL=" + server.AuditLogEndpoint,
-				"NANOBOT_RUN_AUDIT_LOG_BATCH_SIZE=" + strconv.Itoa(d.auditLogsBatchSize),
-				"NANOBOT_RUN_AUDIT_LOG_FLUSH_INTERVAL_SECONDS=" + strconv.Itoa(d.auditLogsFlushIntervalSeconds),
-				"NANOBOT_RUN_AUDIT_LOG_METADATA=" + server.AuditLogMetadata,
 				"NANOBOT_RUN_OAUTH_SCOPES=profile",
 				"NANOBOT_RUN_FORCE_FETCH_TOOL_LIST=true",
 				"NANOBOT_DISABLE_HEALTH_CHECKER=true",
 				"NANOBOT_RUN_APIKEY_AUTH_WEBHOOK_URL=" + localhostURLRegexp.ReplaceAllString(server.Issuer+"/api/api-keys/auth", d.hostBaseURLWithPort),
 				"NANOBOT_RUN_MCPSERVER_ID=" + strings.TrimSuffix(server.MCPServerName, "-shim"),
+			}
+
+			if server.Runtime == otypes.RuntimeRemote {
+				env = append(env, []string{
+					"NANOBOT_RUN_AUDIT_LOG_TOKEN=" + server.AuditLogToken,
+					"NANOBOT_RUN_AUDIT_LOG_SEND_URL=" + server.AuditLogEndpoint,
+					"NANOBOT_RUN_AUDIT_LOG_BATCH_SIZE=" + strconv.Itoa(d.auditLogsBatchSize),
+					"NANOBOT_RUN_AUDIT_LOG_FLUSH_INTERVAL_SECONDS=" + strconv.Itoa(d.auditLogsFlushIntervalSeconds),
+					"NANOBOT_RUN_AUDIT_LOG_METADATA=" + server.AuditLogMetadata,
+				}...)
 			}
 		}
 


### PR DESCRIPTION
These credentials should only be passed to the shims. Otherwise, we get extraneous audit logs from the internal clients.

Issue: https://github.com/obot-platform/obot/issues/5508