### PR TITLE
fix: grant auditors read-only access to API keys

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -134,6 +134,8 @@ var (
 		types.GroupAdmin: adminAndOwnerRules,
 		types.GroupOwner: adminAndOwnerRules,
 		types.GroupAuditor: {
+			"GET /api/admin-api-keys",
+			"GET /api/admin-api-keys/{id}",
 			"GET /api/mcp-audit-logs",
 			"GET /api/mcp-audit-logs/filter-options/{filter}",
 			"GET /api/mcp-audit-logs/detail/{audit_log_id}",

--- a/ui/user/src/routes/admin/api-keys/+page.svelte
+++ b/ui/user/src/routes/admin/api-keys/+page.svelte
@@ -64,13 +64,15 @@
 	<div class="flex flex-col gap-4">
 		<div class="flex items-center justify-between">
 			<p class="text-muted text-sm">View and manage all API keys across all users.</p>
-			<button
-				class="button-primary flex items-center gap-2"
-				onclick={() => (showCreateDialog = true)}
-			>
-				<Plus class="size-4" />
-				Create API Key
-			</button>
+			{#if !isAdminReadonly}
+				<button
+					class="button-primary flex items-center gap-2"
+					onclick={() => (showCreateDialog = true)}
+				>
+					<Plus class="size-4" />
+					Create API Key
+				</button>
+			{/if}
 		</div>
 
 		{#if allApiKeys.length === 0}


### PR DESCRIPTION
Auditors can now view all API keys in the system without the ability
to create or delete them. The UI hides create/delete buttons for
auditors, matching the existing pattern used for other admin resources.

Addresses https://github.com/obot-platform/obot/issues/5486

Signed-off-by: Nick Hale <4175918+njhale@users.noreply.github.com>
