### PR TITLE
fix: give auditors read-only access to group role assignments

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -148,6 +148,8 @@ var (
 			"GET /api/users/",
 			"GET /api/groups",
 			"GET /api/groups/",
+			"GET /api/group-role-assignments",
+			"GET /api/group-role-assignments/",
 			"GET /api/mcp-catalogs/",
 			"GET /api/mcp-webhook-validations",
 			"GET /api/mcp-webhook-validations/",


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5403