### PR TITLE
fix: give auditors access to view capacity

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -142,6 +142,7 @@ var (
 			"GET /api/mcp-audit-logs/{mcp_id}",
 			"GET /api/mcp-stats",
 			"GET /api/mcp-stats/{mcp_id}",
+			"GET /api/mcp-capacity",
 			"GET /api/threads",
 			"GET /api/threads/",
 			"GET /api/runs",


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/5515


