### PR TITLE
fix: report correct deployment status for Docker installs

### DIFF
--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -201,7 +201,10 @@
 				) {
 					updateStatus = SERVER_UPGRADES_AVAILABLE.NONE;
 					updatesAvailable = [SERVER_UPGRADES_AVAILABLE.NONE];
-				} else if (deployment.deploymentStatus?.toLocaleLowerCase().includes('available')) {
+				} else if (
+					deployment.deploymentStatus?.toLocaleLowerCase().includes('available') ||
+					version.current.engine !== 'kubernetes'
+				) {
 					if (needsUpdate && needsK8sUpdate) {
 						updateStatus = SERVER_UPGRADES_AVAILABLE.BOTH;
 						updatesAvailable = [SERVER_UPGRADES_AVAILABLE.SERVER, SERVER_UPGRADES_AVAILABLE.K8S];


### PR DESCRIPTION
If the MCP servers are deployed via Docker, then the deploymentStatus field will not be set. We should detect this and properly display the deployment status in the UI.

Issue: https://github.com/obot-platform/obot/issues/5531