### PR TITLE
fix: remove in handler access checks for mcp-capacity

### DIFF
--- a/pkg/api/handlers/mcpcapacity.go
+++ b/pkg/api/handlers/mcpcapacity.go
@@ -21,10 +21,6 @@ func NewMCPCapacityHandler(mcpSessionManager *mcp.SessionManager) *MCPCapacityHa
 // GetCapacity returns capacity information for the MCP namespace.
 // This endpoint is admin/owner-only.
 func (h *MCPCapacityHandler) GetCapacity(req api.Context) error {
-	if !req.UserIsAdmin() && !req.UserIsOwner() {
-		return types.NewErrForbidden("admin access required")
-	}
-
 	info, err := h.mcpSessionManager.GetCapacityInfo(req.Context())
 	if err != nil {
 		// If backend doesn't support capacity info (e.g., Docker), return empty info


### PR DESCRIPTION
This check is being handled by `pkg/authz`

Addresses https://github.com/obot-platform/obot/issues/5515

