### PR TITLE
Add support for any Git repository URL as MCP catalog

### DIFF
--- a/pkg/controller/handlers/mcpcatalog/github_test.go
+++ b/pkg/controller/handlers/mcpcatalog/github_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReadGitHubCatalog(t *testing.T) {
+func TestReadGitCatalog(t *testing.T) {
 	tests := []struct {
 		name       string
 		catalog    string
@@ -26,13 +26,19 @@ func TestReadGitHubCatalog(t *testing.T) {
 			numEntries: 3,
 		},
 		{
+			name:       "valid github url with .git suffix",
+			catalog:    "https://github.com/obot-platform/test-mcp-catalog.git",
+			wantErr:    false,
+			numEntries: 3,
+		},
+		{
 			name:       "invalid protocol",
 			catalog:    "http://github.com/obot-platform/test-mcp-catalog",
 			wantErr:    true,
 			numEntries: 0,
 		},
 		{
-			name:       "invalid url format",
+			name:       "invalid github url format",
 			catalog:    "github.com/invalid",
 			wantErr:    true,
 			numEntries: 0,
@@ -41,7 +47,7 @@ func TestReadGitHubCatalog(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			entries, err := readGitHubCatalog(tt.catalog)
+			entries, err := readGitCatalog(tt.catalog)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -21,6 +21,7 @@ import (
 	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/logutil"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/validation"
@@ -138,11 +139,11 @@ func (h *Handler) readMCPCatalog(catalogName, sourceURL string) ([]client.Object
 	var entries []types.MCPServerCatalogEntryManifest
 
 	if strings.HasPrefix(sourceURL, "http://") || strings.HasPrefix(sourceURL, "https://") {
-		if isGitHubURL(sourceURL) {
+		if isGitURL(sourceURL) {
 			var err error
-			entries, err = readGitHubCatalog(sourceURL)
+			entries, err = readGitCatalog(sourceURL)
 			if err != nil {
-				return nil, fmt.Errorf("failed to read GitHub catalog %s: %w", sourceURL, err)
+				return nil, fmt.Errorf("failed to read Git catalog %s: %w", logutil.SanitizeURL(sourceURL), err)
 			}
 		} else {
 			// If it wasn't a GitHub repo, treat it as a raw file.

--- a/pkg/logutil/url.go
+++ b/pkg/logutil/url.go
@@ -1,0 +1,25 @@
+package logutil
+
+import "net/url"
+
+// SanitizeURL masks credentials in a URL for safe display/logging.
+// Returns the URL with password replaced by [REDACTED].
+// Example: https://user:pass@gitlab.com/repo.git -> https://user:[REDACTED]@gitlab.com/repo.git
+func SanitizeURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	if u.User == nil {
+		return rawURL
+	}
+
+	_, hasPassword := u.User.Password()
+	if !hasPassword {
+		return rawURL
+	}
+
+	result := u.Scheme + "://" + u.User.Username() + ":[REDACTED]@" + u.Host + u.RequestURI()
+	return result
+}


### PR DESCRIPTION
### Description:

Address issue https://github.com/obot-platform/obot/issues/5543

This PR add support for any Git HTTP repository URL (Not limited to github.com).

Those URLS contain the credentials directly in them, to avoid token leakage the back-end returns `[REDACTED]` insteadof the token value when displayed the configured repository URLs.


### Testing guide:
- Build and run obot
- Test that the default repository keeps working (https://github.com/obot-platform/mcp-catalog)
- Remove the default repository and add some others such as:
- Add some Git repositories and test that the sync continues to work:
  - [ ] https://github.com/obot-platform/mcp-catalog.git
  - [ ] https://gitlab.com/jjacobi/tmp-test.git
  - [ ] https://obot:${INSERT_PERSONAL_GITLAB_TOKEN}@gitlab.com/jjacobi/tmp-test.git
 
- [ ] Ensure that once you saved the URL you don't see the token secret value on the web application

