### PR TITLE
fix: user correct endpoint for redeploying multi-user MCP servers

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -3036,6 +3036,9 @@ func (m *MCPHandler) RedeployWithK8sSettings(req api.Context) error {
 		return fmt.Errorf("failed to redeploy server: %w", err)
 	}
 
+	// We are assuming the redeployment will succeed, so we can clear the flag here.
+	server.Status.NeedsK8sUpdate = false
+
 	// Get credential for server
 	var credCtxs []string
 	if server.Spec.MCPCatalogID != "" {

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -885,7 +885,11 @@ export async function getK8sSettingsStatus(
 }
 
 export async function redeployWithK8sSettings(mcpServerId: string, opts?: { fetch?: Fetcher }) {
-	const response = await doPost(`/mcp-servers/${mcpServerId}/redeploy-with-k8s-settings`, {}, opts);
+	const response = await doPost(
+		`/mcp-catalogs/${DEFAULT_MCP_CATALOG_ID}/servers/${mcpServerId}/redeploy-with-k8s-settings`,
+		{},
+		opts
+	);
 	return response;
 }
 


### PR DESCRIPTION
The k8s redeployemnt for multi-user MCP servers was incorrect. This change uses the correct endpoint for redeploying MCP servers.

Issue: https://github.com/obot-platform/obot/issues/5546