### PR TITLE
fix: allow API call for servers that don't need new k8s settings

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -3024,16 +3024,17 @@ func (m *MCPHandler) RedeployWithK8sSettings(req api.Context) error {
 	currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec)
 	needsUpdate := deployedHash != currentHash
 
-	if !needsUpdate {
-		return types.NewErrBadRequest("Server is already using the current K8s settings")
-	}
-
-	// Trigger restart to force redeployment with new settings
-	if err := m.mcpSessionManager.RestartServerDeployment(req.Context(), serverConfig); err != nil {
-		if nse := (*mcp.ErrNotSupportedByBackend)(nil); errors.As(err, &nse) {
-			return types.NewErrBadRequest("Restart is not supported by the current backend")
+	if needsUpdate {
+		// Trigger restart to force redeployment with new settings
+		if err := m.mcpSessionManager.RestartServerDeployment(req.Context(), serverConfig); err != nil {
+			if nse := (*mcp.ErrNotSupportedByBackend)(nil); errors.As(err, &nse) {
+				return types.NewErrBadRequest("Restart is not supported by the current backend")
+			}
+			return fmt.Errorf("failed to redeploy server: %w", err)
 		}
-		return fmt.Errorf("failed to redeploy server: %w", err)
+
+		// We are assuming the redeployment will succeed, so we can clear the flag here.
+		server.Status.NeedsK8sUpdate = false
 	}
 
 	// Get credential for server


### PR DESCRIPTION
The API would send a 400 error if the server did not require new k8s settings. This change makes the API idempotent for such servers.

Issue: https://github.com/obot-platform/obot/issues/5548