### PR TITLE
fix: use backend configuration to determine if redeploy is allowed

### DIFF
--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -61,7 +61,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	memories := handlers.NewMemoryHandler()
 	workflows := handlers.NewWorkflowHandler()
 	images := handlers.NewImageHandler(services.GeminiClient)
-	mcp := handlers.NewMCPHandler(services.MCPLoader, services.AccessControlRuleHelper, oauthChecker, services.ServerURL)
+	mcp := handlers.NewMCPHandler(services.MCPLoader, services.AccessControlRuleHelper, oauthChecker, services.MCPRuntimeBackend, services.ServerURL)
 	projectMCP := handlers.NewProjectMCPHandler(services.MCPLoader, services.AccessControlRuleHelper, oauthChecker, services.ServerURL, services.InternalServerURL)
 	projectInvitations := handlers.NewProjectInvitationHandler()
 	mcpGateway := mcpgateway.NewHandler(services.StorageClient, services.MCPLoader, services.WebhookHelper, services.OAuthServerConfig.ScopesSupported)

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -958,7 +958,10 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 
 func (k *kubernetesBackend) restartServer(ctx context.Context, id string) error {
 	var deployment appsv1.Deployment
-	if err := k.client.Get(ctx, kclient.ObjectKey{Name: id, Namespace: k.mcpNamespace}, &deployment); err != nil {
+	if err := k.client.Get(ctx, kclient.ObjectKey{Name: id, Namespace: k.mcpNamespace}, &deployment); apierrors.IsNotFound(err) {
+		// If the deployment isn't found, then just return and it will be created when needed.
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("failed to get deployment %s: %w", id, err)
 	}
 


### PR DESCRIPTION
Prior to this change, if the deployed kubernetes configuration hash was empty, we would assume that the we were not deploymen MCP servers into Kubernetes. It turned out that it may have been possible that the server hadn't been deployed yet.

This change uses the backend configuration to determine if redeploys are allowed instead, and doesn't error if the status field isn't set or the server has yet to be deployed.

Issue: https://github.com/obot-platform/obot/issues/5547