### PR TITLE
fix: ui: fix delete button for API keys in the details view

### DIFF
--- a/ui/user/src/lib/components/api-keys/ApiKeyDetailsDialog.svelte
+++ b/ui/user/src/lib/components/api-keys/ApiKeyDetailsDialog.svelte
@@ -132,8 +132,8 @@
 				<button
 					class="button-destructive flex items-center gap-2"
 					onclick={() => {
-						handleClose();
 						onDelete(apiKey);
+						handleClose();
 					}}
 				>
 					<Trash2 class="size-4" />


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5535

Literally just calling functions in the wrong order.