### PR TITLE
fix: show health and updates in separate columns

### DIFF
--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -475,7 +475,13 @@
 			bind:this={tableRef}
 			data={tableData}
 			fields={entity === 'workspace'
-				? ['displayName', 'type', 'deploymentStatus', 'updatesAvailable', 'created']
+				? [
+						'displayName',
+						'type',
+						...(doesSupportK8sUpdates ? ['deploymentStatus'] : []),
+						'updatesAvailable',
+						'created'
+					]
 				: [
 						'displayName',
 						'type',
@@ -489,7 +495,6 @@
 				'displayName',
 				'type',
 				'deploymentStatus',
-				...(doesSupportK8sUpdates ? ['deploymentStatus'] : []),
 				'updatesAvailable',
 				'userName',
 				'registry'


### PR DESCRIPTION
Addresses ##5560

- Add a 'Health' column to show server's availability status
- Show health column only on the Kubernetes platform