### PR TITLE
fix: user correct endpoint for redeploying multi-user MCP servers

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -3036,6 +3036,9 @@ func (m *MCPHandler) RedeployWithK8sSettings(req api.Context) error {
 		return fmt.Errorf("failed to redeploy server: %w", err)
 	}
 
+	// We are assuming the redeployment will succeed, so we can clear the flag here.
+	server.Status.NeedsK8sUpdate = false
+
 	// Get credential for server
 	var credCtxs []string
 	if server.Spec.MCPCatalogID != "" {

--- a/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
@@ -29,6 +29,7 @@
 	import { page } from '$app/state';
 	import SensitiveInput from '../SensitiveInput.svelte';
 	import { resolve } from '$app/paths';
+	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 
 	interface Props {
 		id?: string;
@@ -268,7 +269,10 @@
 					: ChatService.redeployWorkspaceK8sServerWithK8sSettings(entityId, mcpServerId)
 				: catalogEntry?.id
 					? AdminService.redeployMCPCatalogServerWithK8sSettings(catalogEntry.id, mcpServerId)
-					: AdminService.redeployWithK8sSettings(mcpServerId));
+					: AdminService.redeployWithK8sSettings(
+							mcpServerId,
+							mcpServer?.mcpCatalogID ?? DEFAULT_MCP_CATALOG_ID
+						));
 			listK8sSettingsStatus = getK8sSettingsStatus();
 		} catch (err) {
 			console.error('Failed to update Kubernetes settings:', err);

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -268,6 +268,8 @@
 				await AdminService.listAllCatalogDeployedSingleRemoteServers(id);
 			deployedWorkspaceCatalogEntryServers =
 				await AdminService.listAllWorkspaceDeployedSingleRemoteServers();
+			// Refresh multi-user servers too
+			mcpServersAndEntries.refreshAll();
 			// Refresh capacity banner when server list changes
 			if (!isInitialLoad) {
 				capacityBanner?.refresh();
@@ -371,7 +373,7 @@
 					: ChatService.redeployWorkspaceK8sServerWithK8sSettings(workspaceId, mcpServerId)
 				: catalogEntryId
 					? AdminService.redeployMCPCatalogServerWithK8sSettings(catalogEntryId, mcpServerId)
-					: AdminService.redeployWithK8sSettings(mcpServerId));
+					: AdminService.redeployWithK8sSettings(mcpServerId, server.mcpCatalogID));
 		} catch (err) {
 			updating[server.id] = {
 				inProgress: false,

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -884,8 +884,16 @@ export async function getK8sSettingsStatus(
 	return response;
 }
 
-export async function redeployWithK8sSettings(mcpServerId: string, opts?: { fetch?: Fetcher }) {
-	const response = await doPost(`/mcp-servers/${mcpServerId}/redeploy-with-k8s-settings`, {}, opts);
+export async function redeployWithK8sSettings(
+	mcpServerId: string,
+	catalogId: string,
+	opts?: { fetch?: Fetcher }
+) {
+	const response = await doPost(
+		`/mcp-catalogs/${catalogId}/servers/${mcpServerId}/redeploy-with-k8s-settings`,
+		{},
+		opts
+	);
 	return response;
 }
 


### PR DESCRIPTION
The k8s redeployemnt for multi-user MCP servers was incorrect. This change uses
the correct endpoint for redeploying MCP servers.

Addresses https://github.com/obot-platform/obot/issues/5546

Supersedes https://github.com/obot-platform/obot/pull/5561
