### PR TITLE
fix: filter bulk K8s upgrades to only include servers needing updates

### DIFF
--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -296,7 +296,10 @@
 	}
 
 	async function handleK8sBulkUpdate(selections: typeof selected) {
-		return Promise.all(Object.values(selections).map((server) => updateK8sSettings(server)));
+		const serversToUpdate = Object.values(selections).filter(
+			(server) => server.needsK8sUpdate && !server.compositeName
+		);
+		return Promise.all(serversToUpdate.map((server) => updateK8sSettings(server)));
 	}
 
 	async function handleBulkRestart() {


### PR DESCRIPTION
Follow up for https://github.com/obot-platform/obot/issues/5548

