### PR TITLE
obot-platform/obot#5563 - Add model selection for task execution

### DIFF
--- a/apiclient/types/tasks.go
+++ b/apiclient/types/tasks.go
@@ -11,11 +11,13 @@ type Task struct {
 type TaskList List[Task]
 
 type TaskManifest struct {
-	Name        string        `json:"name"`
-	Description string        `json:"description"`
-	Steps       []TaskStep    `json:"steps"`
-	Schedule    *Schedule     `json:"schedule"`
-	OnDemand    *TaskOnDemand `json:"onDemand"`
+	Name          string        `json:"name"`
+	Description   string        `json:"description"`
+	Steps         []TaskStep    `json:"steps"`
+	Schedule      *Schedule     `json:"schedule"`
+	OnDemand      *TaskOnDemand `json:"onDemand"`
+	Model         string        `json:"model,omitempty"`
+	ModelProvider string        `json:"modelProvider,omitempty"`
 }
 
 type TaskOnDemand struct {

--- a/apiclient/types/workflow.go
+++ b/apiclient/types/workflow.go
@@ -11,12 +11,14 @@ type Workflow struct {
 type WorkflowList List[Workflow]
 
 type WorkflowManifest struct {
-	Alias       string            `json:"alias"`
-	Steps       []Step            `json:"steps"`
-	Params      map[string]string `json:"params,omitempty"`
-	Output      string            `json:"output"`
-	Name        string            `json:"name,omitempty"`
-	Description string            `json:"description,omitempty"`
+	Alias         string            `json:"alias"`
+	Steps         []Step            `json:"steps"`
+	Params        map[string]string `json:"params,omitempty"`
+	Output        string            `json:"output"`
+	Name          string            `json:"name,omitempty"`
+	Description   string            `json:"description,omitempty"`
+	Model         string            `json:"model,omitempty"`
+	ModelProvider string            `json:"modelProvider,omitempty"`
 }
 
 type EnvVar struct {

--- a/pkg/api/handlers/tasks.go
+++ b/pkg/api/handlers/tasks.go
@@ -621,10 +621,12 @@ func (t *TaskHandler) CreateFromScope(req api.Context) error {
 
 func ToWorkflowManifest(manifest types.TaskManifest) types.WorkflowManifest {
 	return types.WorkflowManifest{
-		Name:        manifest.Name,
-		Description: manifest.Description,
-		Steps:       toWorkflowSteps(manifest.Steps),
-		Params:      toParams(manifest),
+		Name:          manifest.Name,
+		Description:   manifest.Description,
+		Steps:         toWorkflowSteps(manifest.Steps),
+		Params:        toParams(manifest),
+		Model:         manifest.Model,
+		ModelProvider: manifest.ModelProvider,
 	}
 }
 
@@ -821,9 +823,11 @@ func ConvertTaskManifest(manifest *types.WorkflowManifest) types.TaskManifest {
 		return types.TaskManifest{}
 	}
 	return types.TaskManifest{
-		Name:        manifest.Name,
-		Description: manifest.Description,
-		Steps:       toTaskSteps(manifest.Steps),
+		Name:          manifest.Name,
+		Description:   manifest.Description,
+		Steps:         toTaskSteps(manifest.Steps),
+		Model:         manifest.Model,
+		ModelProvider: manifest.ModelProvider,
 	}
 }
 

--- a/pkg/api/handlers/tasks_test.go
+++ b/pkg/api/handlers/tasks_test.go
@@ -1,0 +1,155 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToWorkflowManifest_ModelFields(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            types.TaskManifest
+		expectedModel    string
+		expectedProvider string
+	}{
+		{
+			name: "preserves model fields when both are set",
+			input: types.TaskManifest{
+				Name:          "test-task",
+				Description:   "A test task",
+				Model:         "claude-3-opus",
+				ModelProvider: "anthropic-model-provider",
+				Steps:         []types.TaskStep{{Step: "Do something"}},
+			},
+			expectedModel:    "claude-3-opus",
+			expectedProvider: "anthropic-model-provider",
+		},
+		{
+			name: "handles empty model fields",
+			input: types.TaskManifest{
+				Name:        "task-no-model",
+				Description: "Task without model selection",
+				Steps:       []types.TaskStep{{Step: "Step 1"}},
+			},
+			expectedModel:    "",
+			expectedProvider: "",
+		},
+		{
+			name: "preserves model when provider is empty",
+			input: types.TaskManifest{
+				Name:  "task-model-only",
+				Model: "gpt-4",
+			},
+			expectedModel:    "gpt-4",
+			expectedProvider: "",
+		},
+		{
+			name: "preserves provider when model is empty",
+			input: types.TaskManifest{
+				Name:          "task-provider-only",
+				ModelProvider: "openai-model-provider",
+			},
+			expectedModel:    "",
+			expectedProvider: "openai-model-provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToWorkflowManifest(tt.input)
+
+			assert.Equal(t, tt.expectedModel, result.Model, "Model field mismatch")
+			assert.Equal(t, tt.expectedProvider, result.ModelProvider, "ModelProvider field mismatch")
+		})
+	}
+}
+
+func TestConvertTaskManifest_ModelFields(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            *types.WorkflowManifest
+		expectedModel    string
+		expectedProvider string
+	}{
+		{
+			name: "preserves model fields when both are set",
+			input: &types.WorkflowManifest{
+				Name:          "test-workflow",
+				Description:   "A test workflow",
+				Model:         "claude-3-sonnet",
+				ModelProvider: "anthropic-model-provider",
+				Steps:         []types.Step{{Step: "Do something"}},
+			},
+			expectedModel:    "claude-3-sonnet",
+			expectedProvider: "anthropic-model-provider",
+		},
+		{
+			name: "handles empty model fields",
+			input: &types.WorkflowManifest{
+				Name:        "workflow-no-model",
+				Description: "Workflow without model selection",
+			},
+			expectedModel:    "",
+			expectedProvider: "",
+		},
+		{
+			name:             "handles nil input gracefully",
+			input:            nil,
+			expectedModel:    "",
+			expectedProvider: "",
+		},
+		{
+			name: "preserves model fields with steps",
+			input: &types.WorkflowManifest{
+				Name:          "workflow-with-steps",
+				Model:         "llama3.2",
+				ModelProvider: "ollama-model-provider",
+				Steps: []types.Step{
+					{Step: "First step"},
+					{Step: "Second step"},
+				},
+			},
+			expectedModel:    "llama3.2",
+			expectedProvider: "ollama-model-provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertTaskManifest(tt.input)
+
+			assert.Equal(t, tt.expectedModel, result.Model, "Model field mismatch")
+			assert.Equal(t, tt.expectedProvider, result.ModelProvider, "ModelProvider field mismatch")
+		})
+	}
+}
+
+func TestTaskWorkflowConversion_RoundTrip(t *testing.T) {
+	// Test that converting Task -> Workflow -> Task preserves model fields
+	original := types.TaskManifest{
+		Name:          "roundtrip-task",
+		Description:   "Testing round trip conversion",
+		Model:         "claude-3-opus",
+		ModelProvider: "anthropic-model-provider",
+		Steps:         []types.TaskStep{{Step: "Do something"}},
+	}
+
+	// Convert to workflow
+	workflow := ToWorkflowManifest(original)
+
+	// Verify workflow has the model fields
+	require.Equal(t, original.Model, workflow.Model, "Workflow should have model from task")
+	require.Equal(t, original.ModelProvider, workflow.ModelProvider, "Workflow should have modelProvider from task")
+
+	// Convert back to task
+	result := ConvertTaskManifest(&workflow)
+
+	// Verify round-trip preserves model fields
+	assert.Equal(t, original.Model, result.Model, "Round-trip should preserve model")
+	assert.Equal(t, original.ModelProvider, result.ModelProvider, "Round-trip should preserve modelProvider")
+	assert.Equal(t, original.Name, result.Name, "Round-trip should preserve name")
+	assert.Equal(t, original.Description, result.Description, "Round-trip should preserve description")
+}

--- a/pkg/controller/handlers/workflowexecution/workflowexecution.go
+++ b/pkg/controller/handlers/workflowexecution/workflowexecution.go
@@ -220,6 +220,10 @@ func (h *Handler) newThread(ctx context.Context, c kclient.Client, wf *v1.Workfl
 				},
 			},
 			SystemTools: []string{system.WorkflowTool, system.TasksWorkflowTool},
+			Manifest: types.ThreadManifest{
+				Model:         wf.Spec.Manifest.Model,
+				ModelProvider: wf.Spec.Manifest.ModelProvider,
+			},
 		},
 	}
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -9976,6 +9976,18 @@ func schema_obot_platform_obot_apiclient_types_TaskManifest(ref common.Reference
 							Ref: ref("github.com/obot-platform/obot/apiclient/types.TaskOnDemand"),
 						},
 					},
+					"model": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"modelProvider": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"name", "description", "steps", "schedule", "onDemand"},
 			},
@@ -11948,6 +11960,18 @@ func schema_obot_platform_obot_apiclient_types_WorkflowManifest(ref common.Refer
 						},
 					},
 					"description": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"model": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"modelProvider": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/ui/user/src/lib/components/tasks/TaskModelSelector.svelte
+++ b/ui/user/src/lib/components/tasks/TaskModelSelector.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import { ChevronDown } from 'lucide-svelte/icons';
+	import type { Task, ModelProvider, Model } from '$lib/services/chat/types';
+	import { listGlobalModelProviders, listModels } from '$lib/services/chat/operations';
+	import { twMerge } from 'tailwind-merge';
+	import { SvelteMap } from 'svelte/reactivity';
+	import { darkMode } from '$lib/stores';
+	import { ModelUsage } from '$lib/services/admin/types';
+	import { popover } from '$lib/actions';
+
+	interface Props {
+		task: Task;
+		readOnly?: boolean;
+	}
+
+	let { task = $bindable(), readOnly = false }: Props = $props();
+
+	const { ref, tooltip, toggle } = popover({
+		placement: 'bottom-start'
+	});
+
+	let availableModels = $state<Model[]>([]);
+	let isLoadingModels = $state(true);
+	let modelsError = $state<string>();
+
+	let modelProvidersMap = new SvelteMap<string, ModelProvider>();
+	let modelsMap = new SvelteMap<string, Model>();
+
+	// Get current selected model info
+	let selectedModel = $derived(
+		task.model ? availableModels.find((m) => m.id === task.model || m.name === task.model) : null
+	);
+
+	$effect(() => {
+		loadModelProviders();
+		loadModels();
+	});
+
+	async function loadModels() {
+		try {
+			isLoadingModels = true;
+			const allModels = await listModels();
+
+			untrack(() => {
+				// Filter models: active=true AND usage='llm'
+				availableModels = (allModels ?? []).filter(
+					(model) => model.active && model.usage === ModelUsage.LLM
+				);
+
+				// Also populate modelsMap for display purposes
+				for (const model of allModels ?? []) {
+					modelsMap.set(model.id, model);
+				}
+			});
+
+			modelsError = undefined;
+		} catch (error) {
+			console.error('Failed to load models:', error);
+			modelsError = 'Failed to load models';
+			availableModels = [];
+		} finally {
+			isLoadingModels = false;
+		}
+	}
+
+	async function loadModelProviders() {
+		try {
+			listGlobalModelProviders().then((res) => {
+				untrack(() => {
+					for (const provider of res.items ?? []) {
+						modelProvidersMap.set(provider.id, provider);
+					}
+				});
+			});
+		} catch (error) {
+			console.error('Failed to load model providers:', error);
+		}
+	}
+
+	function selectModel(model: Model | null) {
+		if (model) {
+			task.model = model.id;
+			// Leave modelProvider empty - system resolves it from model ID
+			task.modelProvider = '';
+		} else {
+			// Clear to use project default
+			task.model = undefined;
+			task.modelProvider = undefined;
+		}
+		toggle(false);
+	}
+
+	// Group models by provider
+	let modelsByProvider = $derived.by(() => {
+		const grouped: Record<string, Model[]> = {};
+		availableModels.forEach((model) => {
+			const providerId = model.modelProvider;
+			if (!grouped[providerId]) {
+				grouped[providerId] = [];
+			}
+			grouped[providerId].push(model);
+		});
+		return Object.entries(grouped);
+	});
+</script>
+
+<div class="flex flex-col gap-2">
+	<label class="text-sm font-medium">Model</label>
+	<p class="text-gray text-sm">
+		Select a model for this task, or leave empty to use project default.
+	</p>
+
+	{#if readOnly}
+		<span
+			class="text-gray bg-surface2 flex items-center justify-between gap-2 rounded-3xl p-3 px-4"
+		>
+			{#if isLoadingModels}
+				Loading...
+			{:else if selectedModel}
+				{selectedModel.name || selectedModel.id}
+			{:else}
+				Use project default
+			{/if}
+			<ChevronDown class="text-gray" />
+		</span>
+	{:else}
+		<button
+			use:ref
+			type="button"
+			onclick={() => toggle()}
+			class="bg-surface2 hover:bg-surface2/80 flex items-center justify-between gap-2 rounded-3xl p-3 px-4"
+		>
+			{#if isLoadingModels}
+				Loading...
+			{:else if selectedModel}
+				{selectedModel.name || selectedModel.id}
+			{:else}
+				Use project default
+			{/if}
+			<ChevronDown />
+		</button>
+
+		<div
+			use:tooltip
+			class="bg-background default-scrollbar-thin max-h-60 min-w-[200px] overflow-y-auto rounded-xl shadow dark:bg-gray-900"
+		>
+			{#if isLoadingModels}
+				<div class="flex justify-center p-4">
+					<div
+						class="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+						aria-hidden="true"
+					></div>
+				</div>
+			{:else if modelsError}
+				<div class="text-on-surface1 p-4 text-sm">
+					{modelsError}
+				</div>
+			{:else}
+				<ul>
+					<!-- Project default option -->
+					<li>
+						<button
+							class={twMerge(
+								'w-full px-6 py-2.5 text-start hover:bg-gray-100 dark:hover:bg-gray-800',
+								!task.model && 'bg-gray-70 dark:bg-gray-800'
+							)}
+							onclick={() => selectModel(null)}
+						>
+							Use project default
+						</button>
+					</li>
+
+					<!-- Grouped models by provider -->
+					{#each modelsByProvider as [providerId, models] (providerId)}
+						{@const provider = modelProvidersMap.get(providerId)}
+						<li class="border-surface1 border-t px-4 py-2">
+							<div class="mb-1 flex items-center gap-1 text-xs text-gray-500">
+								{#if provider?.icon || provider?.iconDark}
+									<img
+										src={darkMode.isDark && provider.iconDark ? provider.iconDark : provider.icon}
+										alt={provider.name}
+										class={twMerge(
+											'size-4',
+											darkMode.isDark && !provider.iconDark ? 'dark:invert' : ''
+										)}
+									/>
+								{/if}
+								<span>{provider?.name ?? providerId}</span>
+							</div>
+						</li>
+						{#each models as model (model.id)}
+							<li>
+								<button
+									class={twMerge(
+										'w-full px-6 py-2 text-start text-sm hover:bg-gray-100 dark:hover:bg-gray-800',
+										task.model === model.id && 'bg-gray-70 dark:bg-gray-800'
+									)}
+									onclick={() => selectModel(model)}
+								>
+									{model.name || model.id}
+									{#if task.model === model.id}
+										<span class="text-primary ml-2">✓</span>
+									{/if}
+								</button>
+							</li>
+						{/each}
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/ui/user/src/lib/components/tasks/TaskOptions.svelte
+++ b/ui/user/src/lib/components/tasks/TaskOptions.svelte
@@ -2,6 +2,7 @@
 	import { type Task } from '$lib/services';
 	import Dropdown from '$lib/components/tasks/Dropdown.svelte';
 	import Trigger from './Trigger.svelte';
+	import TaskModelSelector from './TaskModelSelector.svelte';
 
 	interface Props {
 		task?: Task;
@@ -82,6 +83,13 @@
 
 		{#if task}
 			<Trigger bind:task {readOnly} />
+		{/if}
+
+		<!-- Model Selection -->
+		{#if task}
+			<div class="border-surface3 mt-4 border-t pt-4">
+				<TaskModelSelector bind:task {readOnly} />
+			</div>
 		{/if}
 	</div>
 {/if}

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -479,6 +479,8 @@ export interface Task {
 	alias?: string;
 	managed?: boolean;
 	projectID?: string;
+	model?: string;
+	modelProvider?: string;
 }
 
 export interface OnDemand {


### PR DESCRIPTION
## Summary

- Add ability for users to select a specific model when configuring a task, overriding the default Project → Agent → System hierarchy
- Implement TaskModelSelector component with dropdown grouped by model provider, following the existing ThreadModelSelector pattern
- Add unit tests for model field preservation through Task ↔ Workflow conversions

<img width="2104" height="1359" alt="Screenshot 2026-01-26 at 12 57 42 AM" src="https://github.com/user-attachments/assets/4533542c-5336-4518-8be2-43260aa036c9" />


Closes #5563