### PR TITLE
fix: correct nullish table column sort

### DIFF
--- a/ui/user/src/lib/components/table/Table.svelte
+++ b/ui/user/src/lib/components/table/Table.svelte
@@ -163,6 +163,11 @@
 				let aValue = a[sortedBy!.property as keyof T];
 				let bValue = b[sortedBy!.property as keyof T];
 
+				// Handle undefined/null values - treat as largest value (end for asc, beginning for desc)
+				if (aValue == null && bValue == null) return 0;
+				if (aValue == null) return sortedBy!.order === 'asc' ? 1 : -1;
+				if (bValue == null) return sortedBy!.order === 'asc' ? -1 : 1;
+
 				if (sortedBy?.property === 'created') {
 					const aDate = new Date(aValue as string);
 					const bDate = new Date(bValue as string);


### PR DESCRIPTION
Treat null values as the largest in table column sort comparison.
For `asc` sort order, this means null values are always placed in the bottom most rows (top-most for `desc`).

Addresses https://github.com/obot-platform/obot/issues/5467

