### PR TITLE
chore: use primary styles for instance restart button

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
@@ -560,7 +560,7 @@
 				{#if id === 'status' && !readonly}
 					<button
 						onclick={() => (showRestartConfirm = true)}
-						class="bg-primary/50 hover:bg-primary/10 flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"
+						class="button-primary flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"
 						disabled={restarting}
 					>
 						<RotateCcw class="size-3" />


### PR DESCRIPTION
<img width="737" height="324" alt="restart-btn" src="https://github.com/user-attachments/assets/45b240c5-1efb-4cf8-8c92-13403dded4b0" />


