### PR TITLE
fix: clears copied status on open close

### DIFF
--- a/ui/user/src/lib/components/CopyButton.svelte
+++ b/ui/user/src/lib/components/CopyButton.svelte
@@ -78,7 +78,7 @@
 		}
 	}
 
-	export function clearLabel() {
+	export function clearButtonText() {
 		buttonTextToShow = buttonText;
 	}
 </script>

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -76,7 +76,7 @@
 	let copyButtonController = $state<ReturnType<typeof CopyButton>>();
 
 	function handleOnClose() {
-		copyButtonController?.clearLabel();
+		copyButtonController?.clearButtonText();
 		onClose?.();
 	}
 


### PR DESCRIPTION
Addresses #5634

In this PR:
- clears copied state when dialog is closed
- truncate url to prevent layout shift