### PR TITLE
fix: need to use root instead of item in the loop

### DIFF
--- a/chart/templates/mcp.yaml
+++ b/chart/templates/mcp.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ .name }}
   namespace: {{ include "obot.config.mcpNamespace" $ }}
   labels:
-    {{- include "obot.labels" . | nindent 4 }}
+    {{- include "obot.labels" $ | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}


### PR DESCRIPTION
The loop was using `.` which represents the current item, not the root. The issue is the item doesn't have the Chart field needed for the template.