### PR TITLE
enhance: chat thread mcp server tool approval and fix bundle

### DIFF
--- a/apiclient/types/invoke.go
+++ b/apiclient/types/invoke.go
@@ -168,7 +168,8 @@ type ToolConfirmResponse struct {
 	Decision ToolConfirmDecision `json:"decision"`
 
 	// ToolName is the name of a tool to pre-approve for the duration of the thread.
-	// Set to the wildcard ("*") to pre-approve ALL tools.
+	// The wildcard "*" will allow all tools.
+	// A trailing wildcard will allow all tools with the matching prefix; e.g. "Everything Server ->*".
 	// This field is ignored when Decision is not ToolConfirmDecisionApproveThread.
 	ToolName string `json:"toolName,omitempty"`
 }

--- a/pkg/api/handlers/confirm.go
+++ b/pkg/api/handlers/confirm.go
@@ -39,7 +39,7 @@ func (c *ConfirmHandler) Confirm(req api.Context) error {
 		approved = false
 	case types.ToolConfirmDecisionApprove:
 	case types.ToolConfirmDecisionApproveThread:
-		// User is pre-approving a tool (or all tools with "*")
+		// User is pre-approving a tool (or all tools matching a wildcard suffix "*")
 		toolName = confirm.ToolName
 		if toolName == "" {
 			return types.NewErrBadRequest("tool name must be set for thread approval")

--- a/pkg/invoke/invoker_test.go
+++ b/pkg/invoke/invoker_test.go
@@ -1,0 +1,77 @@
+package invoke
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsApprovedTool(t *testing.T) {
+	tests := []struct {
+		name          string
+		toolName      string
+		approvedTools []string
+		expected      bool
+	}{
+		{
+			name:          "exact match",
+			toolName:      "myTool",
+			approvedTools: []string{"myTool"},
+			expected:      true,
+		},
+		{
+			name:          "no match",
+			toolName:      "myTool",
+			approvedTools: []string{"otherTool"},
+			expected:      false,
+		},
+		{
+			name:          "empty approved list",
+			toolName:      "myTool",
+			approvedTools: nil,
+			expected:      false,
+		},
+		{
+			name:          "wildcard matches all",
+			toolName:      "anything",
+			approvedTools: []string{"*"},
+			expected:      true,
+		},
+		{
+			name:          "prefix wildcard match",
+			toolName:      "fooBar",
+			approvedTools: []string{"foo*"},
+			expected:      true,
+		},
+		{
+			name:          "prefix wildcard no match",
+			toolName:      "barBaz",
+			approvedTools: []string{"foo*"},
+			expected:      false,
+		},
+		{
+			name:          "multiple entries match later",
+			toolName:      "baz",
+			approvedTools: []string{"foo", "bar", "baz"},
+			expected:      true,
+		},
+		{
+			name:          "empty tool name",
+			toolName:      "",
+			approvedTools: []string{"foo"},
+			expected:      false,
+		},
+		{
+			name:          "wildcard with empty tool name",
+			toolName:      "",
+			approvedTools: []string{"*"},
+			expected:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isApprovedTool(tt.toolName, tt.approvedTools))
+		})
+	}
+}

--- a/pkg/storage/apis/obot.obot.ai/v1/thread.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/thread.go
@@ -251,8 +251,8 @@ type ThreadSpec struct {
 	UpgradeApproved bool `json:"upgradeApproved,omitempty"`
 
 	// ApprovedTools is a list of tool names that are auto-approved in this thread.
-	// When a tool call matches a name in this list, it will be auto-approved.
-	// Use "*" as a wildcard to auto-approve all tools.
+	// The wildcard "*" will allow all tools.
+	// A trailing wildcard will allow all tools with the matching prefix; e.g. "Everything Server ->*".
 	ApprovedTools []string `json:"approvedTools,omitempty"`
 }
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -11058,7 +11058,7 @@ func schema_obot_platform_obot_apiclient_types_ToolConfirmResponse(ref common.Re
 					},
 					"toolName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ToolName is the name of a tool to pre-approve for the duration of the thread. Set to the wildcard (\"*\") to pre-approve ALL tools. This field is ignored when Decision is not ToolConfirmDecisionApproveThread.",
+							Description: "ToolName is the name of a tool to pre-approve for the duration of the thread. The wildcard \"*\" will allow all tools. A trailing wildcard will allow all tools with the matching prefix; e.g. \"Everything Server ->*\". This field is ignored when Decision is not ToolConfirmDecisionApproveThread.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -18926,7 +18926,7 @@ func schema_storage_apis_obotobotai_v1_ThreadSpec(ref common.ReferenceCallback) 
 					},
 					"approvedTools": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ApprovedTools is a list of tool names that are auto-approved in this thread. When a tool call matches a name in this list, it will be auto-approved. Use \"*\" as a wildcard to auto-approve all tools.",
+							Description: "ApprovedTools is a list of tool names that are auto-approved in this thread. The wildcard \"*\" will allow all tools. A trailing wildcard will allow all tools with the matching prefix; e.g. \"Everything Server ->*\".",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/ui/user/src/lib/components/messages/ToolConfirmBar.svelte
+++ b/ui/user/src/lib/components/messages/ToolConfirmBar.svelte
@@ -18,24 +18,30 @@
 
 	let { messages, project, currentThreadID }: Props = $props();
 
-	// Only track the first pending toolConfirm and its message, avoiding full array scans
 	let current = $derived.by(() => {
-		for (const msg of messages) {
-			if (msg.toolConfirm && !msg.done) {
-				return { confirm: msg.toolConfirm, message: msg };
-			}
-		}
-		return undefined;
+		const msg = messages.find((m) => m.toolConfirm && !m.done);
+		if (!msg?.toolConfirm) return undefined;
+
+		const toolName = msg.toolConfirm.toolName ?? '';
+		const [serverName] = toolName.split(' -> ');
+		const hasServer = toolName.includes(' -> ');
+
+		return {
+			confirm: msg.toolConfirm,
+			displayName: msg.sourceName || toolName || '',
+			serverName: hasServer ? serverName : '',
+			serverPrefix: hasServer ? `${serverName} -> ` : ''
+		};
 	});
 
-	let displayName = $derived(current?.message.sourceName || current?.confirm.toolName || '');
-
+	let lastConfirmId = $state<string | undefined>(undefined);
 	let isSubmitted = $state(false);
 	let isExpanded = $state(false);
 
-	// Reset state when the current confirm changes
 	$effect(() => {
-		if (current) {
+		const currentId = current?.confirm.id;
+		if (currentId !== lastConfirmId) {
+			lastConfirmId = currentId;
 			isSubmitted = false;
 			isExpanded = false;
 		}
@@ -46,18 +52,22 @@
 		decision: ToolConfirmDecision,
 		toolName?: string
 	) {
+		if (!current || confirm.id !== current.confirm.id) return;
 		if (isSubmitted) return;
 
-		// Only show loading spinner for approve actions, not deny
-		if (decision !== 'deny') {
-			isSubmitted = true;
-		}
+		if (decision !== 'deny') isSubmitted = true;
+		isExpanded = false;
 
-		await ChatService.sendToolConfirm(project.assistantID, project.id, currentThreadID, {
-			id: confirm.id,
-			decision,
-			toolName
-		});
+		try {
+			await ChatService.sendToolConfirm(project.assistantID, project.id, currentThreadID, {
+				id: confirm.id,
+				decision,
+				toolName
+			});
+		} catch (e) {
+			isSubmitted = false;
+			console.error('failed to send tool confirmation', e);
+		}
 	}
 
 	function formatJson(jsonString: string): string {
@@ -73,44 +83,39 @@
 {#if current}
 	{@const dropdown = popover({ placement: 'bottom-end' })}
 	<div
-		class="mb-2 w-full max-w-[900px] overflow-hidden rounded-xl bg-gray-900 px-5 shadow-lg dark:bg-gray-900"
-		transition:slide={{ duration: 150 }}
+		class="bg-surface1 text-on-background mb-2 w-full max-w-[900px] overflow-hidden rounded-xl px-5 shadow-lg"
 	>
 		{#key current.confirm.id}
 			<div class="flex min-h-[48px] items-center gap-3 px-4 py-2.5">
-				<!-- Tool name + details toggle -->
 				<div class="flex min-w-0 flex-1 items-center gap-2">
-					<span class="text-sm font-medium text-gray-100">{displayName}</span>
+					<span class="text-on-background text-sm font-medium">{current.displayName}</span>
+
 					{#if current.confirm.input}
 						<button
-							class="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-300"
+							class="text-on-surface1 hover:text-on-background flex items-center gap-1 text-xs"
 							onclick={() => (isExpanded = !isExpanded)}
 						>
-							{#if isExpanded}
-								Hide details
-							{:else}
-								Show details
-							{/if}
+							{#if isExpanded}Hide details{:else}Show details{/if}
 						</button>
 					{/if}
+
 					{#if isSubmitted}
-						<LoaderCircle class="size-5 animate-spin text-gray-400" />
+						<LoaderCircle class="text-on-surface1 size-5 animate-spin" />
 					{/if}
 				</div>
 
-				<!-- Buttons -->
 				<div class="flex flex-shrink-0 items-center gap-2">
 					{#if !isSubmitted}
 						<button
-							class="rounded px-3 py-1 text-xs text-gray-400 transition-colors hover:bg-gray-800 hover:text-gray-200"
+							class="text-on-surface1 hover:bg-surface2 hover:text-on-background rounded px-3 py-1 text-xs transition-colors"
 							onclick={() => handleConfirm(current.confirm, 'deny')}
 						>
 							Deny
 						</button>
 
-						<div class="flex rounded-lg border border-gray-700 bg-gray-700 shadow-sm">
+						<div class="bg-surface2 border-surface2 flex rounded-lg border">
 							<button
-								class="flex flex-1 items-center justify-center gap-1 rounded-l-lg rounded-r-none border-r border-gray-600 px-3 py-1 text-xs font-medium text-gray-100 transition-colors hover:bg-gray-600"
+								class="text-on-background hover:bg-surface3 border-surface3 flex flex-1 items-center justify-center gap-1 rounded-l-lg rounded-r-none border-r px-3 py-1 text-xs transition-colors hover:opacity-80"
 								onclick={() => handleConfirm(current.confirm, 'approve')}
 							>
 								Allow
@@ -118,31 +123,44 @@
 
 							<button
 								use:dropdown.ref
-								class="flex items-center justify-center rounded-l-none rounded-r-lg px-2 py-1 transition-colors hover:bg-gray-600"
+								class="hover:bg-surface3 flex items-center justify-center rounded-l-none rounded-r-lg px-2 py-1 transition-colors hover:opacity-80"
 								onclick={() => dropdown.toggle()}
 							>
-								<ChevronDown class="size-3 text-gray-100" />
+								<ChevronDown class="text-on-background size-3" />
 							</button>
 						</div>
 
 						<div
 							use:dropdown.tooltip
-							class="z-50 flex min-w-[180px] flex-col rounded-lg border border-gray-700 bg-gray-800 py-1 shadow-xl"
+							class="bg-surface2 border-surface3 z-50 flex min-w-[180px] flex-col rounded-lg border py-1 shadow-xl"
 						>
 							<button
-								class="px-3 py-1.5 text-left text-xs text-gray-200 transition-colors hover:bg-gray-700"
+								class="text-on-background hover:bg-surface3 px-3 py-1.5 text-left text-xs transition-colors"
 								onclick={() => {
-									handleConfirm(current.confirm, 'approve_thread', current.confirm.toolName);
 									dropdown.toggle(false);
+									handleConfirm(current.confirm, 'approve_thread', current.confirm.toolName);
 								}}
 							>
-								Allow {current.confirm.toolName} requests
+								Allow all {current.displayName} requests
 							</button>
+
+							{#if current.serverPrefix}
+								<button
+									class="text-on-background hover:bg-surface3 px-3 py-1.5 text-left text-xs transition-colors"
+									onclick={() => {
+										dropdown.toggle(false);
+										handleConfirm(current.confirm, 'approve_thread', current.serverPrefix + '*');
+									}}
+								>
+									Allow all {current.serverName} requests
+								</button>
+							{/if}
+
 							<button
-								class="px-3 py-1.5 text-left text-xs text-gray-200 transition-colors hover:bg-gray-700"
+								class="text-on-background hover:bg-surface3 px-3 py-1.5 text-left text-xs transition-colors"
 								onclick={() => {
-									handleConfirm(current.confirm, 'approve_thread', '*');
 									dropdown.toggle(false);
+									handleConfirm(current.confirm, 'approve_thread', '*');
 								}}
 							>
 								Allow all requests
@@ -152,13 +170,10 @@
 				</div>
 			</div>
 
-			<!-- Expanded input details -->
 			{#if isExpanded && current.confirm.input}
-				<div class="border-t border-gray-800 px-4 py-3" transition:slide={{ duration: 150 }}>
-					<pre
-						class="max-h-48 overflow-auto rounded bg-gray-950 p-3 text-xs text-gray-300">{formatJson(
-							current.confirm.input
-						)}</pre>
+				<div class="border-surface2 border-t px-4 py-3" transition:slide={{ duration: 150 }}>
+					<pre class="bg-background text-on-background max-h-48 overflow-auto rounded p-3 text-xs">
+{formatJson(current.confirm.input)}</pre>
 				</div>
 			{/if}
 		{/key}


### PR DESCRIPTION
Introduce prefix wildcard support for tool approvals, enabling users to approve all tools from a specific MCP server at once (e.g., "Allow all `Everything Server` requests"). The dropdown now shows three options:
- Allow all {toolName} requests (specific tool)
- Allow all {serverName} requests (all tools from server)
- Allow all requests (everything)

This change also bundles several fixes:
- fix light mode support for the tool confirmation bar
- Fetch latest thread state when checking approvals so multi-tool approval propagates immediately
- Remove 5-minute tool confirmation timeout
- Make thread abort more aggressive to clear pending confirmations

Addresses:
- https://github.com/obot-platform/obot/issues/5696
- https://github.com/obot-platform/obot/issues/5697
- https://github.com/obot-platform/obot/issues/5699

