### PR TITLE
fix: disable builtin agents in nanobot containers

### DIFF
--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -725,7 +725,7 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 		})
 
 		// Use nanobot command
-		cmd = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--config", "/run/nanobot.yaml"}
+		cmd = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/run/nanobot.yaml"}
 
 		// Set nanobot environment variables
 		env = append(env, "NANOBOT_RUN_HEALTHZ_PATH=/healthz", "OBOT_KUBERNETES_MODE=true")

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -297,7 +297,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 		command  []string
 		objs     = make([]kclient.Object, 0, 5)
 		image    = k.baseImage
-		args     = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--config", "/run/nanobot.yaml"}
+		args     = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/run/nanobot.yaml"}
 		port     = defaultContainerPort
 		portName = "http"
 
@@ -555,7 +555,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
 			},
-			Args: []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", port), "--config", "/run/nanobot.yaml"},
+			Args: []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", port), "--exclude-built-in-agents", "--config", "/run/nanobot.yaml"},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "run-shim-file",


### PR DESCRIPTION
The new images have default agents builtin that are exposed for all server configurations. We don't want those, so this change introduces a flag to disable them.

Issue: https://github.com/obot-platform/obot/issues/5726