### PR TITLE
Fix: Re-enable images-bundle

### DIFF
--- a/pkg/controller/data/agent.yaml
+++ b/pkg/controller/data/agent.yaml
@@ -78,6 +78,7 @@ spec:
     - workspace-files
     - tasks
     defaultThreadTools:
+    - images-bundle
     - memory
     - time
     - knowledge


### PR DESCRIPTION
Bring back vision and image-gen capabilities.

Signed-off-by: Craig Jellick <craig@obot.ai>
