### PR TITLE
fix: eliminate 2GB pre-allocation in audit logger buffer

### DIFF
--- a/pkg/api/server/audit/logger.go
+++ b/pkg/api/server/audit/logger.go
@@ -157,11 +157,7 @@ func (l *persistentLogger) persist() error {
 	}
 
 	buf := l.buffer
-	if l.spare != nil {
-		l.buffer = l.spare[:0]
-	} else {
-		l.buffer = nil
-	}
+	l.buffer = l.spare[:0]
 	l.spare = nil
 	l.lock.Unlock()
 
@@ -173,10 +169,8 @@ func (l *persistentLogger) persist() error {
 	}
 
 	l.lock.Lock()
-	if cap(buf) <= l.maxSize {
+	if bufCap := cap(buf); bufCap <= l.maxSize && cap(l.spare) < bufCap {
 		l.spare = buf[:0]
-	} else {
-		l.spare = nil
 	}
 	l.lock.Unlock()
 


### PR DESCRIPTION
The audit logger pre-allocated a 2GB buffer (MaxFileSize*2) at startup and allocated a new 2GB buffer on every flush cycle, causing constant high memory usage regardless of actual audit log volume.

- Remove upfront 2GB buffer pre-allocation; let append grow as needed
- Reuse previous buffer via spare slice swap instead of allocating new
- Replace capacity-based flush trigger with explicit maxSize threshold

With the default 120s flush interval, the buffer usually contains only a few MB of audit logs. With spare buffer reuse, flush cycles no longer allocate new memory. Previously memory usage stayed around ~2GB even with small logs. Now it scales with actual audit log size (usually just a few MB).

Related Issues: #4985 