### PR TITLE
enhance: display file metadata in nanobot files table

### DIFF
--- a/ui/user/src/lib/components/nanobot/MessageItemResource.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageItemResource.svelte
@@ -57,7 +57,7 @@
 	}
 
 	function formatFileSize(bytes?: number): string {
-		if (!bytes) return '';
+		if (bytes == undefined) return '0 B';
 		if (bytes < 1024) return `${bytes} B`;
 		if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
 		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;


### PR DESCRIPTION
Populate size, created, and modified columns with actual data from resource file metadata. Conditionally render date columns based on data availability and compute colspan dynamically for the empty state.

Depends on https://github.com/nanobot-ai/nanobot/pull/171

Addresses https://github.com/obot-platform/obot/issues/5861

