### PR TITLE
fix: avoid gzip-encoded proxy bodies in LLM token parsing

### DIFF
--- a/pkg/gateway/server/llmproxy_test.go
+++ b/pkg/gateway/server/llmproxy_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -311,5 +312,20 @@ func TestExtractModelFromBody(t *testing.T) {
 				t.Errorf("extractModelFromBody() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLLMTransformRequest_RemovesAcceptEncoding(t *testing.T) {
+	u := mustParseURL("https://api.example.com/v1")
+	director := llmTransformRequest(*u, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "http://gateway.local/v1/chat/completions", nil)
+	req.SetPathValue("path", "chat/completions")
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	director(req)
+
+	if got := req.Header.Get("Accept-Encoding"); got != "" {
+		t.Fatalf("Accept-Encoding = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
## Summary
- strip `Accept-Encoding` in the LLM proxy request director so Go's transport can transparently decode provider responses before token-usage parsing
- use the new LLM-specific request transformer in both `/v1/llm-proxy` and provider proxy code paths
- add a regression test to verify `Accept-Encoding` is removed by the director

## Testing
- go test ./pkg/gateway/server -run 'Test(ResponseModifier|ModifyResponse|ExtractModelFromBody|LLMTransformRequest)'

https://pkg.go.dev/net/http#Transport
Relevant DisableCompression text:
- “If the Transport requests gzip on its own and gets a gzipped response, it's transparently decoded in the Response.Body.”
- “However, if the user explicitly requested gzip it is not automatically uncompressed.”
That’s why forwarding a client Accept-Encoding: gzip can break JSON token parsing in the proxy path.