### PR TITLE
fix: correct secret trigger for nanobot cred sync

### DIFF
--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -134,6 +134,7 @@ func (k *kubernetesBackend) ensureServerDeployment(ctx context.Context, server S
 	}
 
 	if shouldDeploy {
+		olog.Infof("Triggering redeploy for MCP server %s", server.MCPServerName)
 		objs, err := k.k8sObjects(ctx, server, webhooks)
 		if err != nil {
 			return ServerConfig{}, fmt.Errorf("failed to generate kubernetes objects for server %s: %w", server.MCPServerName, err)


### PR DESCRIPTION
This addresses a lot of observed "stability" issues where the nanobot agent wasn't getting new credentials/api keys injected. The bugs manifest as problems connecting to either obot mcp server server (that helps you discover and configure MCPs) ore after that not being able to talk to servers you configured. 

The problem was that the trigger key was incorrectly concatenating the namespace with "files" instead of the server name, producing "namespace-files/server" rather than "namespace/server-files".

Also adds debug/info logging throughout the credential lifecycle and extracts token TTL into named constants.

..i extracted the times to constants because i just wanted to make them easier to modify locally. arguably they could be env vars, but that wasnt wiorth the extra hassle right now.

This was a somewhat inconsistent issue because there are other code paths that will sometimes trigger redeployments of a nanobot agent and thus fix cred issues. One of those is the other file (kuberenetes.go) that I edited here. Sometimes, when a user makes a request to an mcp server, based on the logic in that file, we will decied it needs refreshed. 

