### PR TITLE
enhance: file upload UX and resource link preview modal

### DIFF
--- a/ui/user/src/lib/components/nanobot/Message.svelte
+++ b/ui/user/src/lib/components/nanobot/Message.svelte
@@ -4,7 +4,8 @@
 		Attachment,
 		ChatMessage,
 		ChatMessageItem,
-		ChatResult
+		ChatResult,
+		ResourceContents
 	} from '$lib/services/nanobot/types';
 	import MessageItemText from './MessageItemText.svelte';
 	import { CANCELLATION_PHRASE_CLIENT, isCancellationError } from '$lib/services/nanobot/utils';
@@ -15,9 +16,10 @@
 		timestamp?: Date;
 		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
 		onFileOpen?: (filename: string) => void;
+		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
 	}
 
-	let { message, timestamp, onSend, onFileOpen }: Props = $props();
+	let { message, timestamp, onSend, onFileOpen, onReadResource }: Props = $props();
 
 	let openToolGroups = new SvelteSet<string>();
 
@@ -113,9 +115,13 @@
 	const hasCompactionSummary = $derived(
 		message.items?.[0]?._meta?.['ai.nanobot.meta/compaction-summary']
 	);
+
+	const isAttachmentContext = $derived(message.items?.[0]?._meta?.['ai.nanobot.meta/attachment']);
 </script>
 
-{#if !hasCompactionSummary}
+{#if isAttachmentContext}
+	<!-- Hidden attachment context message for model instructions -->
+{:else if !hasCompactionSummary}
 	{#if promptDisplayItem}
 		<MessageItemText item={promptDisplayItem} role="user" />
 	{:else if message.role === 'user' && toolCall?.type === 'tool' && toolCall.payload?.toolName}
@@ -127,7 +133,7 @@
 					<div class="rounded-box bg-base-200 mt-4 p-2">
 						{#if message.items && message.items.length > 0}
 							{#each message.items as item (item.id)}
-								<MessageItem {item} role={message.role} />
+								<MessageItem {item} role={message.role} {onFileOpen} {onReadResource} />
 							{/each}
 						{:else}
 							<!-- Fallback for messages without items -->
@@ -177,13 +183,25 @@
 									<div class="collapse-content">
 										<div>
 											{#each group.toolGroup as item (item.id)}
-												<MessageItem {item} role={message.role} {onSend} {onFileOpen} />
+												<MessageItem
+													{item}
+													role={message.role}
+													{onSend}
+													{onFileOpen}
+													{onReadResource}
+												/>
 											{/each}
 										</div>
 									</div>
 								</div>
 							{:else}
-								<MessageItem item={group.single} role={message.role} {onSend} {onFileOpen} />
+								<MessageItem
+									item={group.single}
+									role={message.role}
+									{onSend}
+									{onFileOpen}
+									{onReadResource}
+								/>
 							{/if}
 						{/each}
 					</div>

--- a/ui/user/src/lib/components/nanobot/MessageAttachments.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageAttachments.svelte
@@ -17,6 +17,7 @@
 
 <script lang="ts">
 	import { X } from 'lucide-svelte';
+	import FileItem from '$lib/components/nanobot/FileItem.svelte';
 
 	let {
 		uploadingFiles = [],
@@ -29,26 +30,26 @@
 
 {#snippet item<T>(
 	label: string,
-	type: string,
+	_type: string,
 	loading: boolean,
 	name: string,
 	id: T,
 	onClick?: (id: T) => void
 )}
-	<div class="bg-base-200 flex items-center gap-2 rounded-xl px-3 py-2 text-sm">
+	<div class="border-base-300 flex items-center gap-1.5 rounded-full border px-2 py-1 text-xs">
 		{#if loading}
 			<span class="loading loading-xs loading-spinner"></span>
 		{:else}
-			<span>{getFileIcon(type)}</span>
+			<FileItem uri={name} compact />
 		{/if}
-		<span class="max-w-32 truncate">{name}</span>
+		<span class="max-w-28 truncate">{name}</span>
 		<button
 			type="button"
 			onclick={() => onClick?.(id)}
-			class="btn btn-ghost btn-xs h-5 w-5 rounded-full p-0"
+			class="btn btn-ghost btn-xs h-4 w-4 rounded-full p-0"
 			aria-label={label}
 		>
-			<X class="h-3 w-3" />
+			<X class="h-2.5 w-2.5" />
 		</button>
 	</div>
 {/snippet}

--- a/ui/user/src/lib/components/nanobot/MessageInput.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageInput.svelte
@@ -170,6 +170,15 @@
 				bind:this={textareaRef}
 			></textarea>
 
+			<!-- Attachment chips row (left-aligned, only visible when files are present) -->
+			<MessageAttachments
+				{selectedResources}
+				{uploadedFiles}
+				{uploadingFiles}
+				{removeSelectedResource}
+				{cancelUpload}
+			/>
+
 			<!-- Bottom row: Agent select on left (if multiple agents), buttons on right -->
 			<div class="flex items-center justify-between">
 				<!-- Agent selector -->
@@ -198,14 +207,6 @@
 						</select>
 					{/if}
 				</div>
-
-				<MessageAttachments
-					{selectedResources}
-					{uploadedFiles}
-					{uploadingFiles}
-					{removeSelectedResource}
-					{cancelUpload}
-				/>
 
 				<!-- Action buttons -->
 				<div class="flex gap-2">

--- a/ui/user/src/lib/components/nanobot/MessageItem.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageItem.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-	import type { Attachment, ChatResult, ChatMessageItem } from '$lib/services/nanobot/types';
+	import type {
+		Attachment,
+		ChatResult,
+		ChatMessageItem,
+		ResourceContents
+	} from '$lib/services/nanobot/types';
 	import MessageItemText from './MessageItemText.svelte';
 	import MessageItemImage from './MessageItemImage.svelte';
 	import MessageItemAudio from './MessageItemAudio.svelte';
@@ -14,9 +19,10 @@
 		role: 'user' | 'assistant';
 		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
 		onFileOpen?: (filename: string) => void;
+		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
 	}
 
-	let { item, role, onSend, onFileOpen }: Props = $props();
+	let { item, role, onSend, onFileOpen, onReadResource }: Props = $props();
 </script>
 
 {#if item.type === 'text'}
@@ -26,7 +32,7 @@
 {:else if item.type === 'audio'}
 	<MessageItemAudio {item} />
 {:else if item.type === 'resource_link'}
-	<MessageItemResourceLink {item} />
+	<MessageItemResourceLink {item} {onReadResource} />
 {:else if item.type === 'resource'}
 	<MessageItemResource {item} />
 {:else if item.type === 'reasoning'}

--- a/ui/user/src/lib/components/nanobot/MessageItemResourceLink.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageItemResourceLink.svelte
@@ -1,20 +1,252 @@
 <script lang="ts">
-	import { ExternalLink } from 'lucide-svelte';
-	import type { ChatMessageItemResourceLink } from '$lib/services/nanobot/types';
+	import type { ChatMessageItemResourceLink, ResourceContents } from '$lib/services/nanobot/types';
+	import FileItem from '$lib/components/nanobot/FileItem.svelte';
+	import { isSafeImageMimeType } from '$lib/services/nanobot/utils';
+	import { toHTMLFromMarkdown } from '$lib/markdown';
 
 	interface Props {
 		item: ChatMessageItemResourceLink;
+		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
 	}
 
-	let { item }: Props = $props();
+	let { item, onReadResource }: Props = $props();
+
+	let modal = $state<HTMLDialogElement>();
+	let fetchedResource = $state<ResourceContents | null>(null);
+	let loading = $state(false);
+	let loadError = $state<string | null>(null);
+	let isMissing = $state(false);
+
+	const displayName = $derived(item.name || getNameFromURI(item.uri));
+	const inferredMimeType = $derived(inferMimeType(item.uri));
+	const previewMimeType = $derived(
+		inferredMimeType !== 'application/octet-stream'
+			? inferredMimeType
+			: fetchedResource?.mimeType || item.mimeType || inferredMimeType
+	);
+	const previewBlob = $derived(fetchedResource?.blob || '');
+	const previewText = $derived(fetchedResource?.text || '');
+
+	const extensionMimeTypes: Record<string, string> = {
+		txt: 'text/plain',
+		md: 'text/markdown',
+		markdown: 'text/markdown',
+		json: 'application/json',
+		yaml: 'application/yaml',
+		yml: 'application/yaml',
+		xml: 'application/xml',
+		html: 'text/html',
+		htm: 'text/html',
+		csv: 'text/csv',
+		js: 'application/javascript',
+		ts: 'application/typescript',
+		py: 'text/x-python',
+		go: 'text/x-go',
+		sh: 'application/x-sh',
+		log: 'text/plain',
+		pdf: 'application/pdf',
+		png: 'image/png',
+		jpg: 'image/jpeg',
+		jpeg: 'image/jpeg',
+		gif: 'image/gif',
+		webp: 'image/webp',
+		svg: 'image/svg+xml'
+	};
+
+	function handleClick() {
+		openModal();
+	}
+
+	async function openModal() {
+		modal?.showModal();
+		if (fetchedResource || loading) return;
+		if (!onReadResource) {
+			loadError = 'Resource reading is not available.';
+			return;
+		}
+
+		loading = true;
+		loadError = null;
+
+		try {
+			const result = await onReadResource(item.uri);
+			const content = result.contents?.find((c) => c.uri === item.uri) || result.contents?.[0];
+			if (!content) {
+				loadError = 'No content available for this resource.';
+				isMissing = true;
+				return;
+			}
+			fetchedResource = content;
+			isMissing = false;
+		} catch (e) {
+			const errorMessage = e instanceof Error ? e.message : String(e);
+			loadError = errorMessage;
+			if (isMissingResourceError(errorMessage)) {
+				isMissing = true;
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	function getNameFromURI(uri: string): string {
+		try {
+			const url = new URL(uri);
+			const decodedPath = decodeURIComponent(url.pathname || '');
+			const fromPath = decodedPath.split('/').filter(Boolean).pop();
+			if (fromPath) return fromPath;
+		} catch {
+			// ignore URL parse failures and fall back to raw URI parsing
+		}
+
+		const sanitized = uri.split('#')[0].split('?')[0];
+		const fromRaw = sanitized.split('/').filter(Boolean).pop();
+		return fromRaw || uri;
+	}
+
+	function inferMimeType(uri: string): string {
+		const name = getNameFromURI(uri).toLowerCase();
+		const ext = name.includes('.') ? name.split('.').pop() : '';
+		if (!ext) return 'application/octet-stream';
+		return extensionMimeTypes[ext] || 'application/octet-stream';
+	}
+
+	function isMissingResourceError(message: string): boolean {
+		const lower = message.toLowerCase();
+		return (
+			lower.includes('not found') ||
+			lower.includes('does not exist') ||
+			lower.includes('missing') ||
+			lower.includes('404')
+		);
+	}
+
+	function isTextType(mimeType: string): boolean {
+		return (
+			mimeType.startsWith('text/') ||
+			mimeType.includes('json') ||
+			mimeType.includes('xml') ||
+			mimeType.includes('yaml') ||
+			mimeType === 'application/javascript' ||
+			mimeType === 'application/typescript'
+		);
+	}
+
+	function isMarkdownType(mimeType: string): boolean {
+		return mimeType === 'text/markdown';
+	}
+
+	function isPdfType(mimeType: string): boolean {
+		return mimeType === 'application/pdf';
+	}
+
+	function getDecodedText(blob?: string, text?: string): string {
+		if (text) {
+			try {
+				return JSON.stringify(JSON.parse(text), null, 2);
+			} catch {
+				return text;
+			}
+		}
+		if (!blob) return '';
+		try {
+			const binaryString = atob(blob);
+			const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
+			const str = new TextDecoder('utf-8').decode(bytes);
+			try {
+				return JSON.stringify(JSON.parse(str), null, 2);
+			} catch {
+				return str;
+			}
+		} catch {
+			return 'Error decoding content';
+		}
+	}
 </script>
 
-<div class="bg-base-200 mb-3 rounded-lg p-3">
-	<div class="flex items-center gap-2 text-sm">
-		<ExternalLink class="text-primary h-4 w-4" />
-		<span>{item.name || item.uri}</span>
-	</div>
-	{#if item.description}
-		<p class="mt-1 text-xs opacity-70">{item.description}</p>
+<button
+	type="button"
+	class="mb-2 inline-flex max-w-full items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors {isMissing
+		? 'border-error/30 bg-error/10 text-error hover:bg-error/20'
+		: 'border-base-300 bg-base-200 hover:bg-base-300'}"
+	onclick={handleClick}
+	title={displayName}
+>
+	<FileItem uri={item.uri} compact />
+	<span class="truncate">{displayName}</span>
+	{#if isMissing}
+		<span class="badge badge-error badge-xs">Missing</span>
 	{/if}
-</div>
+</button>
+
+<!-- Preview modal -->
+<dialog bind:this={modal} class="modal modal-bottom sm:modal-middle">
+	<div class="modal-box max-h-[80vh] max-w-4xl overflow-hidden">
+		<div class="mb-4 flex items-center justify-between">
+			<h3 class="flex min-w-0 items-center gap-3 text-lg font-bold">
+				<div class="bg-primary/10 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
+					<FileItem uri={item.uri} compact />
+				</div>
+				<div class="min-w-0">
+					<div class="text-base-content truncate">{displayName}</div>
+					<div class="text-base-content/60 truncate text-sm font-normal">{item.uri}</div>
+				</div>
+			</h3>
+		</div>
+
+		<div class="mb-4 flex items-center gap-2">
+			<span class="badge badge-primary badge-sm">{previewMimeType}</span>
+		</div>
+
+		<div class="max-h-96 overflow-auto">
+			{#if loading}
+				<div class="flex items-center gap-2 py-8">
+					<span class="loading loading-sm loading-spinner"></span>
+					<span>Loading preview...</span>
+				</div>
+			{:else if loadError}
+				<div class="alert alert-error">
+					<span>{loadError}</span>
+				</div>
+			{:else if previewMimeType && isMarkdownType(previewMimeType) && (previewBlob || previewText)}
+				<div class="prose max-w-none">
+					{@html toHTMLFromMarkdown(getDecodedText(previewBlob, previewText))}
+				</div>
+			{:else if previewMimeType && isTextType(previewMimeType) && (previewBlob || previewText)}
+				<div class="mockup-code">
+					<pre><code>{getDecodedText(previewBlob, previewText)}</code></pre>
+				</div>
+			{:else if previewMimeType && isPdfType(previewMimeType) && (previewBlob || previewText)}
+				<div class="w-full">
+					<iframe
+						src="data:application/pdf;base64,{previewBlob || previewText}"
+						class="border-base-300 h-96 w-full rounded border"
+						title="PDF Viewer"
+					></iframe>
+				</div>
+			{:else if previewMimeType?.startsWith('image/') && isSafeImageMimeType(previewMimeType) && previewBlob}
+				<div class="flex justify-center">
+					<img
+						src="data:{previewMimeType};base64,{previewBlob}"
+						alt={displayName}
+						class="max-h-96 rounded"
+					/>
+				</div>
+			{:else}
+				<div class="py-8 text-center">
+					<p class="text-base-content/60">Preview not available for this resource type</p>
+					<p class="text-base-content/40 mt-2 text-sm break-all">{item.uri}</p>
+				</div>
+			{/if}
+		</div>
+
+		<div class="modal-action">
+			<form method="dialog">
+				<button class="btn">Close</button>
+			</form>
+		</div>
+	</div>
+	<form method="dialog" class="modal-backdrop">
+		<button>close</button>
+	</form>
+</dialog>

--- a/ui/user/src/lib/components/nanobot/Messages.svelte
+++ b/ui/user/src/lib/components/nanobot/Messages.svelte
@@ -5,7 +5,8 @@
 		ChatMessageItem,
 		ChatResult,
 		Agent,
-		Attachment
+		Attachment,
+		ResourceContents
 	} from '$lib/services/nanobot/types';
 	import AgentHeader from '$lib/components/nanobot/AgentHeader.svelte';
 
@@ -13,6 +14,7 @@
 		messages: ChatMessage[];
 		onSend?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
 		onFileOpen?: (filename: string) => void;
+		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
 		isLoading?: boolean;
 		agent?: Agent;
 		hideAgentHeader?: boolean;
@@ -21,6 +23,7 @@
 	let {
 		messages,
 		onFileOpen,
+		onReadResource,
 		onSend,
 		isLoading = false,
 		agent,
@@ -112,7 +115,7 @@
 				data-message-id={messageGroup?.[0]?.id}
 			>
 				{#each displayGroup as message (message.id)}
-					<Message {message} {onSend} {onFileOpen} />
+					<Message {message} {onSend} {onFileOpen} {onReadResource} />
 				{/each}
 				{#if isLast}
 					{#if showLoadingIndicator}

--- a/ui/user/src/lib/components/nanobot/ProjectStartThread.svelte
+++ b/ui/user/src/lib/components/nanobot/ProjectStartThread.svelte
@@ -64,6 +64,7 @@
 					chat.refreshResources();
 				}}
 				{onFileOpen}
+				onReadResource={chat.readResource}
 				{suppressEmptyState}
 				onContentWidthChange={onThreadContentWidth}
 			>

--- a/ui/user/src/lib/components/nanobot/Thread.svelte
+++ b/ui/user/src/lib/components/nanobot/Thread.svelte
@@ -11,13 +11,14 @@
 		ElicitationResult,
 		Elicitation as ElicitationType,
 		Prompt as PromptType,
+		ResourceContents,
 		UploadedFile,
 		UploadingFile
 	} from '$lib/services/nanobot/types';
 	import MessageInput from './MessageInput.svelte';
 	import Messages from './Messages.svelte';
 	import AgentHeader from './AgentHeader.svelte';
-	import { ChevronDown } from 'lucide-svelte';
+	import { ChevronDown, Upload } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { slide, fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -30,6 +31,7 @@
 		onSendMessage?: (message: string, attachments?: Attachment[]) => Promise<ChatResult | void>;
 		onFileUpload?: (file: File, opts?: { controller?: AbortController }) => Promise<Attachment>;
 		onFileOpen?: (filename: string) => void;
+		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
 		onRestart?: () => void;
 		onCancel?: () => void;
 		onContentWidthChange?: (width: number) => void;
@@ -56,6 +58,7 @@
 		onSendMessage,
 		onFileUpload,
 		onFileOpen,
+		onReadResource,
 		onRestart,
 		onCancel,
 		onContentWidthChange,
@@ -293,11 +296,65 @@
 			});
 		}
 	}
+
+	// Drag-and-drop file upload
+	let isDragging = $state(false);
+	let dragCounter = 0;
+
+	function handleDragEnter(e: DragEvent) {
+		e.preventDefault();
+		dragCounter++;
+		if (e.dataTransfer?.types.includes('Files')) {
+			isDragging = true;
+		}
+	}
+
+	function handleDragLeave(e: DragEvent) {
+		e.preventDefault();
+		dragCounter--;
+		if (dragCounter === 0) {
+			isDragging = false;
+		}
+	}
+
+	function handleDragOver(e: DragEvent) {
+		e.preventDefault();
+	}
+
+	async function handleDrop(e: DragEvent) {
+		e.preventDefault();
+		dragCounter = 0;
+		isDragging = false;
+
+		if (!onFileUpload || !e.dataTransfer?.files.length) return;
+
+		for (const file of e.dataTransfer.files) {
+			onFileUpload(file);
+		}
+	}
 </script>
 
 <div
 	class="flex h-[calc(100dvh-4rem)] w-full flex-col transition-transform md:relative peer-[.workspace]:md:w-1/4"
+	ondragenter={handleDragEnter}
+	ondragleave={handleDragLeave}
+	ondragover={handleDragOver}
+	ondrop={handleDrop}
 >
+	<!-- Drag-and-drop overlay -->
+	{#if isDragging}
+		<div
+			class="bg-base-300/60 pointer-events-none absolute inset-0 z-50 flex items-center justify-center backdrop-blur-sm"
+		>
+			<div
+				class="border-primary bg-base-100/90 flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed px-10 py-8 shadow-xl"
+			>
+				<Upload class="text-primary size-10" />
+				<p class="text-base-content text-lg font-semibold">Drop files to upload</p>
+			</div>
+		</div>
+	{/if}
+
 	<!-- Messages area - full height scrollable with bottom padding for floating input -->
 	<div
 		class="h-full w-full overflow-y-auto px-4"
@@ -336,6 +393,7 @@
 				{isLoading}
 				{agent}
 				{onFileOpen}
+				{onReadResource}
 				hideAgentHeader
 			/>
 		</div>

--- a/ui/user/src/lib/services/nanobot/chat/index.svelte.ts
+++ b/ui/user/src/lib/services/nanobot/chat/index.svelte.ts
@@ -23,7 +23,7 @@ import {
 	type UploadedFile,
 	type UploadingFile
 } from '../types';
-import { SvelteDate } from 'svelte/reactivity';
+import { SvelteDate, SvelteSet } from 'svelte/reactivity';
 
 export interface CallToolResult {
 	content?: ToolOutputItem[];
@@ -195,29 +195,29 @@ export class ChatAPI {
 		});
 	}
 
-	async createResource(
+	async uploadFile(
 		name: string,
 		mimeType: string,
 		blob: string,
 		opts?: {
-			description?: string;
 			sessionId?: string;
 			abort?: AbortController;
 		}
 	): Promise<Attachment> {
-		return await this.callMCPTool<Attachment>('create_resource', {
+		return await this.callMCPTool<Attachment>('uploadFile', {
 			payload: {
 				blob,
 				mimeType,
-				name,
-				...(opts?.description && { description: opts.description })
+				name
 			},
 			sessionId: opts?.sessionId,
 			abort: opts?.abort,
 			parseResponse: (resp: CallToolResult) => {
 				if (resp.content?.[0]?.type === 'resource_link') {
 					return {
-						uri: resp.content[0].uri
+						name: resp.content[0].name,
+						uri: resp.content[0].uri,
+						mimeType: mimeType
 					};
 				}
 				return {
@@ -264,7 +264,8 @@ export class ChatAPI {
 					id: request.id + '_0',
 					type: 'text',
 					text: request.message
-				}
+				},
+				...buildFileAttachmentPreviewItems(request.id, request.attachments || [])
 			]
 		};
 		return {
@@ -408,6 +409,45 @@ export function appendMessage(messages: ChatMessage[], newMessage: ChatMessage):
 		messages = [...messages, newMessage];
 	}
 	return messages;
+}
+
+function attachmentPreviewName(attachment: Attachment): string | undefined {
+	if (attachment.name) {
+		return attachment.name;
+	}
+
+	if (!attachment.uri.startsWith('file:///')) {
+		return undefined;
+	}
+
+	const rawPath = attachment.uri.replace(/^file:\/\/\//, '');
+	let decodedPath = rawPath;
+	try {
+		decodedPath = decodeURIComponent(rawPath);
+	} catch {
+		// keep raw path if decode fails
+	}
+	return decodedPath.split('/').filter(Boolean).pop() || decodedPath;
+}
+
+function buildFileAttachmentPreviewItems(messageID: string, attachments: Attachment[]) {
+	const seen = new SvelteSet<string>();
+	return attachments
+		.filter((attachment) => {
+			const uri = attachment.uri || '';
+			if (!uri.startsWith('file:///') || seen.has(uri)) {
+				return false;
+			}
+			seen.add(uri);
+			return true;
+		})
+		.map((attachment, index) => ({
+			id: `${messageID}_attachment_${index}`,
+			type: 'resource_link' as const,
+			uri: attachment.uri,
+			name: attachmentPreviewName(attachment),
+			mimeType: attachment.mimeType || 'application/octet-stream'
+		}));
 }
 
 export class ChatService {
@@ -691,6 +731,7 @@ export class ChatService {
 		const toolName = `chat-with-${effectiveAgentId}`;
 
 		this.currentRequestId = crypto.randomUUID();
+		const allAttachments = [...this.uploadedFiles, ...(attachments || [])];
 		const optimisticUserMessage: ChatMessage = {
 			id: this.currentRequestId,
 			role: 'user',
@@ -700,7 +741,8 @@ export class ChatService {
 					id: this.currentRequestId + '_0',
 					type: 'text',
 					text: message
-				}
+				},
+				...buildFileAttachmentPreviewItems(this.currentRequestId, allAttachments)
 			]
 		};
 		this.messages = appendMessage(this.messages, optimisticUserMessage);
@@ -716,7 +758,7 @@ export class ChatService {
 					id: this.currentRequestId,
 					threadId: this.chatId,
 					message: message,
-					attachments: [...this.uploadedFiles, ...(attachments || [])]
+					attachments: allAttachments
 				},
 				toolName
 			);
@@ -779,6 +821,18 @@ export class ChatService {
 			}
 			return false;
 		});
+
+		// Delete the uploaded file from disk
+		const uploaded = this.uploadedFiles.find((f) => f.id === fileId);
+		if (uploaded?.uri) {
+			this.api
+				.callMCPTool('deleteFile', {
+					payload: { uri: uploaded.uri },
+					sessionId: this.chatId
+				})
+				.catch((err) => console.error('Failed to delete uploaded file:', err));
+		}
+
 		this.uploadedFiles = this.uploadedFiles.filter((f) => f.id !== fileId);
 	};
 
@@ -831,8 +885,7 @@ export class ChatService {
 			throw new Error('Chat ID not set');
 		}
 
-		return await this.api.createResource(file.name, file.type, base64, {
-			description: file.name,
+		return await this.api.uploadFile(file.name, file.type, base64, {
 			sessionId: this.chatId,
 			abort: controller
 		});

--- a/ui/user/src/lib/services/nanobot/types.ts
+++ b/ui/user/src/lib/services/nanobot/types.ts
@@ -74,6 +74,7 @@ export interface ChatMessageItemResourceLink extends ChatMessageItemBase {
 	name?: string;
 	description?: string;
 	uri: string;
+	mimeType?: string;
 }
 
 export interface ChatMessageItemReasoning extends ChatMessageItemBase {

--- a/ui/user/src/routes/nanobot/p/[projectId]/files/+page.svelte
+++ b/ui/user/src/routes/nanobot/p/[projectId]/files/+page.svelte
@@ -76,8 +76,7 @@
 				name: string;
 				uri: string;
 				size?: number;
-				createdAt: FileTimeResult;
-				modifiedAt: FileTimeResult;
+				lastModified?: FileTimeResult;
 		  };
 
 	function onFileOpen(filename: string) {
@@ -85,7 +84,7 @@
 	}
 
 	function buildFileTreeSimple(
-		files: { uri: string; name?: string; size?: number; _meta?: { [key: string]: unknown } }[]
+		files: { uri: string; name?: string; size?: number; annotations?: { lastModified?: string } }[]
 	): FileTreeNode[] {
 		const root: Extract<FileTreeNode, { type: 'folder' }> = {
 			type: 'folder',
@@ -118,8 +117,7 @@
 				name: fileName,
 				uri: f.uri,
 				size: f.size,
-				createdAt: formatFileTime(f._meta?.createdAt),
-				modifiedAt: formatFileTime(f._meta?.modifiedAt)
+				lastModified: formatFileTime(f.annotations?.lastModified)
 			});
 		}
 		// Sort: folders first then files, both alphabetically
@@ -144,16 +142,14 @@
 		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 	}
 
-	let hasModifiedAt = $derived(
-		resourceFiles.some((r) => !!formatFileTime(r._meta?.modifiedAt).date)
+	let hasLastModified = $derived(
+		resourceFiles.some((r) => !!formatFileTime(r.annotations?.lastModified).date)
 	);
-	let hasCreatedAt = $derived(resourceFiles.some((r) => !!formatFileTime(r._meta?.createdAt).date));
-	let columnCount = $derived(3 + (hasModifiedAt ? 1 : 0) + (hasCreatedAt ? 1 : 0));
+	let columnCount = $derived(3 + (hasLastModified ? 1 : 0));
 	let columnHeaders = $derived([
 		{ property: 'name', title: 'Name' },
 		{ property: 'size', title: 'Size' },
-		...(hasModifiedAt ? [{ property: 'modifiedAt', title: 'Last Modified' }] : []),
-		...(hasCreatedAt ? [{ property: 'createdAt', title: 'Created' }] : []),
+		...(hasLastModified ? [{ property: 'lastModified', title: 'Last Modified' }] : []),
 		{ property: 'uri', title: 'Location' }
 	]);
 
@@ -231,9 +227,7 @@
 		name: (item) => item.node.name ?? '',
 		size: (item) => (item.node.type === 'file' ? (item.node.size ?? 0) : 0),
 		modifiedAt: (item) =>
-			item.node.type === 'file' ? (item.node.modifiedAt.date?.getTime() ?? 0) : 0,
-		createdAt: (item) =>
-			item.node.type === 'file' ? (item.node.createdAt.date?.getTime() ?? 0) : 0,
+			item.node.type === 'file' ? (item.node.lastModified?.date?.getTime() ?? 0) : 0,
 		uri: (item) => (item.node.type === 'file' ? item.node.uri : item.path)
 	};
 
@@ -373,11 +367,12 @@
 									</div>
 								</td>
 								<td><p class="truncate text-nowrap break-all">{formatFileSize(node.size)}</p></td>
-								{#if hasModifiedAt}
-									<td><p class="truncate text-nowrap break-all">{node.modifiedAt.formatted}</p></td>
-								{/if}
-								{#if hasCreatedAt}
-									<td><p class="truncate text-nowrap break-all">{node.createdAt.formatted}</p></td>
+								{#if hasLastModified}
+									<td
+										><p class="truncate text-nowrap break-all">
+											{node.lastModified?.formatted}
+										</p></td
+									>
 								{/if}
 								<td>
 									<div class="w-full min-w-0">


### PR DESCRIPTION
- Rewrite MessageItemResourceLink to show a file preview dialog modal when clicking uploaded file attachments in user messages (text, PDF, and image preview with lazy-fetch via MCP resources/read), while preserving sidebar open behavior for assistant message resource links.
- Style resource link pills as compact rounded chips with devicon/lucide icons via the FileItem component.
- Add drag-and-drop file upload to the Thread component with a visual overlay indicator. - Move MessageAttachments above the bottom action bar in MessageInput for better left-aligned layout.
- Restyle upload chips in MessageAttachments to use FileItem icons
instead of emoji, with smaller rounded-full border-only styling.
- Switch file upload API from create_resource to uploadFile/deleteFile tool calls and include mimeType in the returned Attachment. Build resource_link preview items for file attachments in both optimistic and server-confirmed user messages.
- Simplify file metadata in the files page from separate createdAt/modifiedAt fields to a single annotations.lastModified.
- Thread onReadResource prop through Message > Messages > MessageItem component chain.
- Hide attachment context messages from chat display.

Loom: https://www.loom.com/share/d8c79c76b24b419593cb6d033b684898

Additionally Addresses:
- https://github.com/obot-platform/obot/issues/5891

