### PR TITLE
fix: nanobot files decode encoded names and stabilize table sorting

### DIFF
--- a/ui/user/src/lib/components/nanobot/FileEditor.svelte
+++ b/ui/user/src/lib/components/nanobot/FileEditor.svelte
@@ -4,6 +4,7 @@
 	import { X } from 'lucide-svelte';
 	import MarkdownEditor from './MarkdownEditor.svelte';
 	import { isSafeImageMimeType } from '$lib/services/nanobot/utils';
+	import { tryDecodeURIComponent } from '$lib/url';
 	import { getLayout } from '$lib/context/nanobotLayout.svelte';
 	import { twMerge } from 'tailwind-merge';
 	import RawEditor from '$lib/components/editor/RawEditor.svelte';
@@ -27,7 +28,7 @@
 		threadContentWidth = 0
 	}: Props = $props();
 
-	const name = $derived(filename.split('/').pop() || '');
+	const name = $derived(tryDecodeURIComponent(filename.split('/').pop() || ''));
 	let resource = $state<ResourceContents | null>(null);
 	let loading = $state(true);
 	let error = $state<string | null>(null);

--- a/ui/user/src/lib/components/nanobot/FileItem.svelte
+++ b/ui/user/src/lib/components/nanobot/FileItem.svelte
@@ -2,6 +2,7 @@
 	import { FileIcon, FileImage } from 'lucide-svelte';
 	import { fly } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
+	import { tryDecodeURIComponent } from '$lib/url';
 
 	interface Props {
 		uri?: string;
@@ -16,7 +17,7 @@
 
 	let { uri, classes, compact, type = 'label', isSelected, onClick }: Props = $props();
 
-	let name = $derived(uri ? uri.split('/').pop() : undefined);
+	let name = $derived(uri ? tryDecodeURIComponent(uri.split('/').pop() ?? '') : undefined);
 	let extension = $derived(
 		name && name.includes('.') ? name.split('.').pop()?.toLowerCase() : undefined
 	);

--- a/ui/user/src/lib/url.ts
+++ b/ui/user/src/lib/url.ts
@@ -109,3 +109,11 @@ export function setUrlParam(url: URL, key: string, value: string | null): void {
 		url.searchParams.delete(key);
 	}
 }
+
+export function tryDecodeURIComponent(value: string): string {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return value;
+	}
+}

--- a/ui/user/src/routes/nanobot/p/[projectId]/files/+page.svelte
+++ b/ui/user/src/routes/nanobot/p/[projectId]/files/+page.svelte
@@ -12,6 +12,7 @@
 	} from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 	import { getContext } from 'svelte';
+	import { tryDecodeURIComponent } from '$lib/url';
 	import type { ProjectLayoutContext } from '$lib/services/nanobot/types';
 	import { PROJECT_LAYOUT_CONTEXT } from '$lib/services/nanobot/types';
 	import FileItem from '$lib/components/nanobot/FileItem.svelte';
@@ -110,7 +111,7 @@
 			const path = f.uri.replace(/^file:\/\/+/, '');
 			const segments = path.split('/').filter(Boolean);
 			if (segments.length === 0) continue;
-			const fileName = segments.pop()!;
+			const fileName = tryDecodeURIComponent(segments.pop()!);
 			const parent = ensurePath(segments);
 			parent.children.push({
 				type: 'file',
@@ -142,14 +143,20 @@
 		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 	}
 
-	let hasLastModified = $derived(
-		resourceFiles.some((r) => !!formatFileTime(r.annotations?.lastModified).date)
-	);
-	let columnCount = $derived(3 + (hasLastModified ? 1 : 0));
+	function toNumberOrUndefined(value: unknown): number | undefined {
+		if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+		if (typeof value === 'string') {
+			const parsed = Number(value);
+			return Number.isFinite(parsed) ? parsed : undefined;
+		}
+		return undefined;
+	}
+
+	let columnCount = $derived(4);
 	let columnHeaders = $derived([
 		{ property: 'name', title: 'Name' },
 		{ property: 'size', title: 'Size' },
-		...(hasLastModified ? [{ property: 'lastModified', title: 'Last Modified' }] : []),
+		{ property: 'lastModified', title: 'Last Modified' },
 		{ property: 'uri', title: 'Location' }
 	]);
 
@@ -223,13 +230,15 @@
 		return flat.filter(({ path }) => toInclude.has(path));
 	});
 
-	const sortValueByProperty: Record<string, (item: FlatNode) => string | number> = {
+	const sortValueByProperty: Record<string, (item: FlatNode) => string | number | undefined> = {
 		name: (item) => item.node.name ?? '',
-		size: (item) => (item.node.type === 'file' ? (item.node.size ?? 0) : 0),
-		modifiedAt: (item) =>
-			item.node.type === 'file' ? (item.node.lastModified?.date?.getTime() ?? 0) : 0,
+		size: (item) => (item.node.type === 'file' ? toNumberOrUndefined(item.node.size) : undefined),
+		lastModified: (item) =>
+			item.node.type === 'file' ? item.node.lastModified?.date?.getTime() : undefined,
 		uri: (item) => (item.node.type === 'file' ? item.node.uri : item.path)
 	};
+
+	const numericSortProperties = new Set(['size', 'lastModified']);
 
 	let sortedFlatFileList = $derived.by(() => {
 		const list = [...filteredFlatFileList];
@@ -238,16 +247,21 @@
 		const getVal = sortValueByProperty[property] ?? sortValueByProperty.name;
 
 		list.sort((a, b) => {
-			if (property === 'size' || property === 'modifiedAt' || property === 'createdAt') {
+			if (numericSortProperties.has(property)) {
 				if (a.node.type === 'folder' && b.node.type === 'file') return -1;
 				if (a.node.type === 'file' && b.node.type === 'folder') return 1;
 			}
 			const aVal = getVal(a);
 			const bVal = getVal(b);
-			const cmp =
-				typeof aVal === 'string' && typeof bVal === 'string'
-					? (aVal || '').localeCompare(bVal || '')
-					: (aVal as number) - (bVal as number);
+			if (numericSortProperties.has(property)) {
+				const aNum = toNumberOrUndefined(aVal);
+				const bNum = toNumberOrUndefined(bVal);
+				if (aNum == undefined && bNum == undefined) return 0;
+				if (aNum == undefined) return 1;
+				if (bNum == undefined) return -1;
+				return mult * (aNum - bNum);
+			}
+			const cmp = (aVal as string).localeCompare(bVal as string);
 			return mult * cmp;
 		});
 		return list;
@@ -367,13 +381,11 @@
 									</div>
 								</td>
 								<td><p class="truncate text-nowrap break-all">{formatFileSize(node.size)}</p></td>
-								{#if hasLastModified}
-									<td
-										><p class="truncate text-nowrap break-all">
-											{node.lastModified?.formatted}
-										</p></td
-									>
-								{/if}
+								<td
+									><p class="truncate text-nowrap break-all">
+										{node.lastModified?.formatted || '-'}
+									</p></td
+								>
 								<td>
 									<div class="w-full min-w-0">
 										<p


### PR DESCRIPTION
- Ensure file names from URI segments are decoded before display in the file list and editor
- Normalize size/last-modified handling so columns are always present and numeric sorts are consistent when values are missing or string-typed

