### PR TITLE
fix: mount nanobot config to /config instead of /run to avoid read-only filesystem crash

### DIFF
--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -810,11 +810,11 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 		volumeMounts = append(volumeMounts, mount.Mount{
 			Type:   mount.TypeVolume,
 			Source: nanobotVolumeName,
-			Target: "/run",
+			Target: "/config",
 		})
 
 		// Use nanobot command
-		cmd = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/run/nanobot.yaml"}
+		cmd = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
 
 		// Set nanobot environment variables
 		env = append(env, "NANOBOT_RUN_HEALTHZ_PATH=/healthz", "OBOT_KUBERNETES_MODE=true")
@@ -1302,7 +1302,7 @@ func (d *dockerBackend) prepareNanobotConfig(ctx context.Context, server ServerC
 	}
 
 	// Create script to write nanobot config
-	script := fmt.Sprintf("cat > /run/nanobot.yaml << 'EOF'\n%s\nEOF\n", nanobotYAML)
+	script := fmt.Sprintf("cat > /config/nanobot.yaml << 'EOF'\n%s\nEOF\n", nanobotYAML)
 
 	// Create and run init container
 	initConfig := &container.Config{
@@ -1316,7 +1316,7 @@ func (d *dockerBackend) prepareNanobotConfig(ctx context.Context, server ServerC
 			{
 				Type:   mount.TypeVolume,
 				Source: volumeName,
-				Target: "/run",
+				Target: "/config",
 			},
 		},
 		AutoRemove: true,

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -374,7 +374,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 		command  []string
 		objs     = make([]kclient.Object, 0, 5)
 		image    = k.baseImage
-		args     = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/run/nanobot.yaml"}
+		args     = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
 		port     = defaultContainerPort
 		portName = "http"
 
@@ -659,11 +659,11 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 					ContainerPort: int32(port),
 				}},
 				SecurityContext: getContainerSecurityContext(psaLevel),
-				Args:            []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", port), "--exclude-built-in-agents", "--config", "/run/nanobot.yaml"},
+				Args:            []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", port), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"},
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "run-shim-file",
-						MountPath: "/run",
+						MountPath: "/config",
 						ReadOnly:  true,
 					},
 				},
@@ -866,7 +866,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 
 		dep.Spec.Template.Spec.Containers[len(containers)-1].VolumeMounts = append(dep.Spec.Template.Spec.Containers[len(containers)-1].VolumeMounts, corev1.VolumeMount{
 			Name:      "run-file",
-			MountPath: "/run",
+			MountPath: "/config",
 			ReadOnly:  true,
 		})
 


### PR DESCRIPTION
A recent wolfi base image update introduced a /var/run -> /run symlink,
which causes the nanobot shim container to CrashLoopBackOff on Docker
Desktop Kubernetes. The shim mounts its config volume read-only at /run,
and when the container runtime (runc) tries to create the service account
mountpoint at /var/run/secrets/kubernetes.io/serviceaccount, it follows
the symlink into /run/secrets/ and fails with:

  mkdirat .../run/secrets: read-only file system

This doesn't affect clusters using gvisor (e.g. GKE sandboxed nodes)
because gvisor constructs the entire mount tree in its in-memory virtual
filesystem before enforcing read-only constraints, so mountpoint creation
succeeds regardless of the read-only flag.

Move the nanobot config volume mount from /run to /config in both the
Kubernetes and Docker backends to avoid the path conflict entirely.

