### PR TITLE
enhance: ui: show checkboxes for boolean auth provider params

### DIFF
--- a/ui/user/src/lib/components/admin/ProviderConfigure.svelte
+++ b/ui/user/src/lib/components/admin/ProviderConfigure.svelte
@@ -248,7 +248,7 @@
 			<span class="text-gray text-xs">{parameter.description}</span>
 		{/if}
 		<Toggle
-			label={parameter.friendlyName}
+			label={parameter.friendlyName ?? ''}
 			checked={form[parameter.name] === 'true'}
 			disabled={readonly ?? false}
 			onChange={(checked) => {


### PR DESCRIPTION
This is better UX for the new params to enable logging:

<img width="658" height="268" alt="image" src="https://github.com/user-attachments/assets/55302971-e88f-4fdb-9f6d-9620d05a9f3d" />