### PR TITLE
fix: graph bucket band time frame fix

### DIFF
--- a/ui/user/src/lib/components/graph/StackedTimeline.svelte
+++ b/ui/user/src/lib/components/graph/StackedTimeline.svelte
@@ -350,7 +350,7 @@
 		const generated = union(generator(start, end, step).map((d) => d.toISOString()));
 		const fromData = union(data.map((d) => accessor(d)));
 		const combined = new Set<string>([...generated, ...fromData]);
-		return Array.from(combined).sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
+		return Array.from(combined).sort((a, b) => a.localeCompare(b));
 	});
 
 	const xRange = $derived([0, innerWidth]);


### PR DESCRIPTION
before: March 9 wasn't in time frame band and got placed incorrectly/overlapping over existing dataset
<img width="711" height="307" alt="Screenshot 2026-03-09 at 12 32 17 PM" src="https://github.com/user-attachments/assets/f1577827-1c44-4e1a-8201-ca2d1cecd5af" />

after: 
<img width="1182" height="302" alt="Screenshot 2026-03-09 at 12 32 22 PM" src="https://github.com/user-attachments/assets/5e6422ed-9279-49a0-be91-8a9068ba4cc8" />
