### PR TITLE
fix: add missing namespaces to helm templates

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: obot
 description: A Helm chart for Obot
-version: 0.1.0
-appVersion: 0.0.0-dev
+version: 0.17.1
+appVersion: 0.17.1

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "obot.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "obot.labels" . | nindent 4 }}
 spec:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: "networking.k8s.io/v1"
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "obot.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/chart/templates/pvc.yaml
+++ b/chart/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-pvc
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "obot.labels" . | nindent 4 }}
 spec:

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "obot.labels" . | nindent 4 }}
   name: {{ include "obot.config.secretName" . }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "obot.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "obot.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "obot.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Ensure that all Helm templates explicitly declare the release namespace in their metadata to prevent resources from being deployed into the default namespace. Without this the user can't deploy it to any other namespace even with the `--namespace` helm flag.

Also update the versions in `Chart.yaml`. There should be a process to update these values for every release though. 