### PR TITLE
perf: cache validated API keys

### DIFF
--- a/pkg/gateway/client/apikey.go
+++ b/pkg/gateway/client/apikey.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"time"
@@ -13,9 +14,131 @@ import (
 )
 
 const (
-	apiKeySecretLength = 32 // 32 bytes = 256 bits of entropy
-	apiKeyPrefix       = "ok1"
+	apiKeySecretLength       = 32 // 32 bytes = 256 bits of entropy
+	apiKeyPrefix             = "ok1"
+	apiKeyValidationCacheTTL = 15 * time.Second
+	apiKeyCacheCleanupPeriod = 5 * time.Minute
 )
+
+type apiKeyValidationCacheEntry struct {
+	apiKey    types.APIKey
+	expiresAt time.Time
+	keyID     uint
+}
+
+// cloneAPIKey creates a deep copy of the provided APIKey, so that it's safe to return without corrupting the cache
+func cloneAPIKey(apiKey types.APIKey) types.APIKey {
+	cloned := apiKey
+	if apiKey.MCPServerIDs != nil {
+		cloned.MCPServerIDs = append([]string(nil), apiKey.MCPServerIDs...)
+	}
+	if apiKey.LastUsedAt != nil {
+		cloned.LastUsedAt = new(*apiKey.LastUsedAt)
+	}
+	if apiKey.ExpiresAt != nil {
+		cloned.ExpiresAt = new(*apiKey.ExpiresAt)
+	}
+	return cloned
+}
+
+func apiKeyCacheFingerprint(key string) [32]byte {
+	return sha256.Sum256([]byte(key))
+}
+
+func (c *Client) getValidatedAPIKeyFromCache(key string, now time.Time) (*types.APIKey, bool) {
+	if c.apiKeyCacheTTL <= 0 {
+		return nil, false
+	}
+
+	fingerprint := apiKeyCacheFingerprint(key)
+
+	c.apiKeyCacheLock.RLock()
+	entry, ok := c.apiKeyCache[fingerprint]
+	if !ok {
+		c.apiKeyCacheLock.RUnlock()
+		return nil, false
+	}
+
+	// Fast path: entry appears valid under the read lock.
+	entryExpired := now.After(entry.expiresAt) || (entry.apiKey.ExpiresAt != nil && entry.apiKey.ExpiresAt.Before(now))
+	if !entryExpired {
+		cachedAPIKey := entry.apiKey
+		c.apiKeyCacheLock.RUnlock()
+		apiKey := cloneAPIKey(cachedAPIKey)
+		return &apiKey, true
+	}
+
+	// Slow path: entry appears expired; re-check under write lock before deleting
+	c.apiKeyCacheLock.RUnlock()
+
+	c.apiKeyCacheLock.Lock()
+	entry, ok = c.apiKeyCache[fingerprint]
+	if !ok {
+		c.apiKeyCacheLock.Unlock()
+		return nil, false
+	}
+
+	if now.After(entry.expiresAt) || (entry.apiKey.ExpiresAt != nil && entry.apiKey.ExpiresAt.Before(now)) {
+		delete(c.apiKeyCache, fingerprint)
+		c.apiKeyCacheLock.Unlock()
+		return nil, false
+	}
+
+	cachedAPIKey := entry.apiKey
+	c.apiKeyCacheLock.Unlock()
+	apiKey := cloneAPIKey(cachedAPIKey)
+	return &apiKey, true
+}
+
+func (c *Client) putValidatedAPIKeyInCache(key string, apiKey *types.APIKey, now time.Time) {
+	if c.apiKeyCacheTTL <= 0 || apiKey == nil {
+		return
+	}
+
+	c.apiKeyCacheLock.Lock()
+	c.apiKeyCache[apiKeyCacheFingerprint(key)] = apiKeyValidationCacheEntry{
+		apiKey:    cloneAPIKey(*apiKey),
+		expiresAt: now.Add(c.apiKeyCacheTTL),
+		keyID:     apiKey.ID,
+	}
+	c.apiKeyCacheLock.Unlock()
+}
+
+func (c *Client) pruneExpiredValidatedAPIKeys(now time.Time) {
+	c.apiKeyCacheLock.Lock()
+	defer c.apiKeyCacheLock.Unlock()
+
+	for fingerprint, entry := range c.apiKeyCache {
+		if now.After(entry.expiresAt) || (entry.apiKey.ExpiresAt != nil && entry.apiKey.ExpiresAt.Before(now)) {
+			delete(c.apiKeyCache, fingerprint)
+		}
+	}
+}
+
+func (c *Client) runAPIKeyCacheCleanup(ctx context.Context) {
+	ticker := time.NewTicker(apiKeyCacheCleanupPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			c.pruneExpiredValidatedAPIKeys(now)
+		}
+	}
+}
+
+func (c *Client) invalidateValidatedAPIKeysByID(keyID uint) {
+	c.apiKeyCacheLock.Lock()
+	defer c.apiKeyCacheLock.Unlock()
+
+	for fingerprint, entry := range c.apiKeyCache {
+		if entry.keyID == keyID {
+			delete(c.apiKeyCache, fingerprint)
+		}
+	}
+}
 
 // CreateAPIKey generates a new API key for the given user.
 // Returns the full key only once in the response.
@@ -82,14 +205,21 @@ func (c *Client) DeleteAPIKey(ctx context.Context, userID uint, keyID uint) erro
 	if result.Error != nil {
 		return fmt.Errorf("failed to delete API key: %w", result.Error)
 	}
+	c.invalidateValidatedAPIKeysByID(keyID)
 	return nil
 }
 
 // ValidateAPIKey validates an API key and returns the associated APIKey record.
 // The key format is: ok1-<user_id>-<key_id>-<secret>
 // Lookup is done by key ID, then bcrypt is used to verify the secret.
-// Also updates the last_used_at timestamp on successful validation.
+// Cache hits return a previously validated key without touching the database.
+// On cache misses, last_used_at is updated only if more than a minute has elapsed.
 func (c *Client) ValidateAPIKey(ctx context.Context, key string) (*types.APIKey, error) {
+	cacheNow := time.Now()
+	if cachedAPIKey, ok := c.getValidatedAPIKeyFromCache(key, cacheNow); ok {
+		return cachedAPIKey, nil
+	}
+
 	// Parse the key to extract components
 	_, userID, keyID, secret, err := ParseAPIKey(key)
 	if err != nil {
@@ -114,10 +244,10 @@ func (c *Client) ValidateAPIKey(ctx context.Context, key string) (*types.APIKey,
 		}
 
 		// Update last used timestamp if more than a minute has elapsed
-		now := time.Now()
-		if apiKey.LastUsedAt == nil || now.Sub(*apiKey.LastUsedAt) > time.Minute {
-			apiKey.LastUsedAt = &now
-			return tx.Model(&apiKey).Update("last_used_at", now).Error
+		lastUsedAtNow := time.Now()
+		if apiKey.LastUsedAt == nil || lastUsedAtNow.Sub(*apiKey.LastUsedAt) > time.Minute {
+			apiKey.LastUsedAt = &lastUsedAtNow
+			return tx.Model(&apiKey).Update("last_used_at", lastUsedAtNow).Error
 		}
 		return nil
 	})
@@ -125,6 +255,7 @@ func (c *Client) ValidateAPIKey(ctx context.Context, key string) (*types.APIKey,
 		return nil, err
 	}
 
+	c.putValidatedAPIKeyInCache(key, &apiKey, cacheNow)
 	return &apiKey, nil
 }
 
@@ -167,6 +298,7 @@ func (c *Client) DeleteAPIKeyByID(ctx context.Context, keyID uint) error {
 	if result.Error != nil {
 		return fmt.Errorf("failed to delete API key: %w", result.Error)
 	}
+	c.invalidateValidatedAPIKeysByID(keyID)
 	return nil
 }
 

--- a/pkg/gateway/client/apikey_cache_test.go
+++ b/pkg/gateway/client/apikey_cache_test.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+func TestValidatedAPIKeyCacheHit(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{
+		apiKeyCache:    make(map[[32]byte]apiKeyValidationCacheEntry),
+		apiKeyCacheTTL: time.Minute,
+	}
+
+	now := time.Now()
+	want := &types.APIKey{UserID: 7, Name: "cache-key"}
+
+	c.putValidatedAPIKeyInCache("ok1-7-1-secret", want, now)
+
+	got, ok := c.getValidatedAPIKeyFromCache("ok1-7-1-secret", now.Add(time.Second))
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if got.UserID != want.UserID || got.Name != want.Name {
+		t.Fatalf("unexpected cached value: %+v", got)
+	}
+}
+
+func TestValidatedAPIKeyCacheExpires(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{
+		apiKeyCache:    make(map[[32]byte]apiKeyValidationCacheEntry),
+		apiKeyCacheTTL: time.Second,
+	}
+
+	now := time.Now()
+	c.putValidatedAPIKeyInCache("ok1-7-1-secret", &types.APIKey{ID: 1, UserID: 7}, now)
+
+	if _, ok := c.getValidatedAPIKeyFromCache("ok1-7-1-secret", now.Add(2*time.Second)); ok {
+		t.Fatal("expected expired cache entry to miss")
+	}
+}
+
+func TestInvalidateValidatedAPIKeysByID(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{
+		apiKeyCache:    make(map[[32]byte]apiKeyValidationCacheEntry),
+		apiKeyCacheTTL: time.Minute,
+	}
+
+	now := time.Now()
+	c.putValidatedAPIKeyInCache("ok1-7-1-secret", &types.APIKey{ID: 1, UserID: 7}, now)
+	c.putValidatedAPIKeyInCache("ok1-7-2-secret", &types.APIKey{ID: 2, UserID: 7}, now)
+
+	c.invalidateValidatedAPIKeysByID(1)
+
+	if _, ok := c.getValidatedAPIKeyFromCache("ok1-7-1-secret", now); ok {
+		t.Fatal("expected keyID 1 cache entry to be invalidated")
+	}
+	if _, ok := c.getValidatedAPIKeyFromCache("ok1-7-2-secret", now); !ok {
+		t.Fatal("expected other cache entry to remain")
+	}
+}
+
+func TestPruneExpiredValidatedAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	c := &Client{
+		apiKeyCache:    make(map[[32]byte]apiKeyValidationCacheEntry),
+		apiKeyCacheTTL: time.Minute,
+	}
+
+	now := time.Now()
+	expiredKey := "ok1-7-1-secret"
+	activeKey := "ok1-7-2-secret"
+
+	c.apiKeyCache[apiKeyCacheFingerprint(expiredKey)] = apiKeyValidationCacheEntry{
+		apiKey:    types.APIKey{ID: 1, UserID: 7},
+		expiresAt: now.Add(-time.Second),
+		keyID:     1,
+	}
+
+	c.putValidatedAPIKeyInCache(activeKey, &types.APIKey{ID: 2, UserID: 7}, now)
+	c.pruneExpiredValidatedAPIKeys(now)
+
+	if _, ok := c.apiKeyCache[apiKeyCacheFingerprint(expiredKey)]; ok {
+		t.Fatal("expected expired cache entry to be pruned during cleanup")
+	}
+	if _, ok := c.apiKeyCache[apiKeyCacheFingerprint(activeKey)]; !ok {
+		t.Fatal("expected active cache entry to be inserted")
+	}
+}
+
+func TestValidatedAPIKeyCacheReturnsDeepCopy(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Now().Add(time.Hour)
+	lastUsedAt := time.Now()
+	c := &Client{
+		apiKeyCache:    make(map[[32]byte]apiKeyValidationCacheEntry),
+		apiKeyCacheTTL: time.Minute,
+	}
+
+	original := &types.APIKey{
+		ID:           1,
+		UserID:       7,
+		Name:         "cache-key",
+		MCPServerIDs: []string{"server-a"},
+		LastUsedAt:   &lastUsedAt,
+		ExpiresAt:    &expiresAt,
+	}
+
+	now := time.Now()
+	c.putValidatedAPIKeyInCache("ok1-7-1-secret", original, now)
+
+	got, ok := c.getValidatedAPIKeyFromCache("ok1-7-1-secret", now)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+
+	got.MCPServerIDs[0] = "mutated"
+	*got.LastUsedAt = got.LastUsedAt.Add(time.Minute)
+	*got.ExpiresAt = got.ExpiresAt.Add(time.Minute)
+
+	cached := c.apiKeyCache[apiKeyCacheFingerprint("ok1-7-1-secret")].apiKey
+	if cached.MCPServerIDs[0] != "server-a" {
+		t.Fatal("expected cached MCPServerIDs to be isolated from returned value")
+	}
+	if !cached.LastUsedAt.Equal(lastUsedAt) {
+		t.Fatal("expected cached LastUsedAt to be isolated from returned value")
+	}
+	if !cached.ExpiresAt.Equal(expiresAt) {
+		t.Fatal("expected cached ExpiresAt to be isolated from returned value")
+	}
+}

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -24,6 +24,9 @@ type Client struct {
 	auditBuffer            []types.MCPAuditLog
 	kickAuditPersist       chan struct{}
 	storageClient          kclient.Client
+	apiKeyCacheLock        sync.RWMutex
+	apiKeyCache            map[[32]byte]apiKeyValidationCacheEntry
+	apiKeyCacheTTL         time.Duration
 }
 
 func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptionConfig *encryptionconfig.EncryptionConfiguration, ownerEmails, adminEmails []string, auditLogPersistenceInterval time.Duration, auditLogBatchSize int) *Client {
@@ -42,10 +45,13 @@ func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptio
 		auditBuffer:            make([]types.MCPAuditLog, 0, 2*auditLogBatchSize),
 		kickAuditPersist:       make(chan struct{}),
 		storageClient:          storageClient,
+		apiKeyCache:            make(map[[32]byte]apiKeyValidationCacheEntry),
+		apiKeyCacheTTL:         apiKeyValidationCacheTTL,
 	}
 
 	go c.runPersistenceLoop(ctx, auditLogPersistenceInterval)
 	go c.runPendingStateCleanup(ctx)
+	go c.runAPIKeyCacheCleanup(ctx)
 	return c
 }
 


### PR DESCRIPTION
Add a short-lived in-memory cache for successful API key validations.

API key validation is on a hot path and was repeatedly paying the full bcrypt
verification cost for the same key across closely spaced requests. Cache hits
now return a previously validated API key record without redoing the database
lookup and bcrypt comparison.

The cache is intentionally narrow:
- only successful validations are cached
- entries expire quickly
- delete paths explicitly invalidate cached keys
- cache reads still enforce API key expiration

This reduces hot-path auth latency while keeping revocation and expiration
semantics bounded and predictable for a local in-memory cache

Signed-off-by: Craig Jellick <craig@obot.ai>
