### PR TITLE
feat: add embedded browser viewer for launched nanobot agents

### DIFF
--- a/ui/user/package.json
+++ b/ui/user/package.json
@@ -82,6 +82,7 @@
 	"dependencies": {
 		"@codemirror/lang-markdown": "^6.3.3",
 		"@mcp-ui/client": "^6.0.0",
+		"@novnc/novnc": "1.4.0",
 		"@oddbird/popover-polyfill": "^0.6.1",
 		"d3": "^7.9.0",
 		"d3-time-format": "^4.1.0",
@@ -99,6 +100,11 @@
 			"glob": "10.5.0",
 			"cookie": "0.7.0",
 			"devalue": "5.6.2"
-		}
+		},
+		"onlyBuiltDependencies": [
+			"@modelcontextprotocol/ext-apps",
+			"@tailwindcss/oxide",
+			"esbuild"
+		]
 	}
 }

--- a/ui/user/pnpm-lock.yaml
+++ b/ui/user/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@mcp-ui/client':
         specifier: ^6.0.0
         version: 6.0.0(@preact/signals-core@1.12.2)(hono@4.11.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@novnc/novnc':
+        specifier: 1.4.0
+        version: 1.4.0
       '@oddbird/popover-polyfill':
         specifier: ^0.6.1
         version: 0.6.1
@@ -850,6 +853,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@novnc/novnc@1.4.0':
+    resolution: {integrity: sha512-kW6ALMc5BuH08e/ond/I1naYcfjc19JYMN1EdtmgjjjzPGCjW8fMtVM3MwM6q7YLRjPlQ3orEvoKMgSS7RkEVQ==}
 
   '@oddbird/popover-polyfill@0.6.1':
     resolution: {integrity: sha512-Papau51NPG+NajXvoEHCNT1CBJv4WIyvIGfH5gpJPLL8MZJt/4giC0jJ/mNZRtJmdzRuXWpUFB6QxkJa1RvMAQ==}
@@ -4534,6 +4540,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@novnc/novnc@1.4.0': {}
 
   '@oddbird/popover-polyfill@0.6.1': {}
 

--- a/ui/user/src/lib/components/nanobot/BrowserViewer.svelte
+++ b/ui/user/src/lib/components/nanobot/BrowserViewer.svelte
@@ -1,0 +1,418 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { Maximize2, Minimize2 } from 'lucide-svelte';
+	import RFB from '@novnc/novnc/lib/rfb.js';
+
+	interface Props {
+		browserBaseUrl?: string;
+		visible?: boolean;
+	}
+
+	function withProtocol(url: string, websocket: boolean) {
+		if (websocket) {
+			if (url.startsWith('https://')) return `wss://${url.slice('https://'.length)}`;
+			if (url.startsWith('http://')) return `ws://${url.slice('http://'.length)}`;
+			return url;
+		}
+
+		if (url.startsWith('wss://')) return `https://${url.slice('wss://'.length)}`;
+		if (url.startsWith('ws://')) return `http://${url.slice('ws://'.length)}`;
+		return url;
+	}
+
+	function browserUrl(browserBaseUrl = '', pathname = '/browser', websocket = true) {
+		if (typeof window === 'undefined') {
+			return websocket ? 'ws://localhost/browser' : 'http://localhost/browser/resize';
+		}
+
+		const trimmedBaseUrl = browserBaseUrl.replace(/\/$/, '');
+		const origin = window.location.origin.replace(/\/$/, '');
+		const base = trimmedBaseUrl
+			? /^(https?|wss?):\/\//.test(trimmedBaseUrl)
+				? trimmedBaseUrl
+				: `${origin}${trimmedBaseUrl.startsWith('/') ? '' : '/'}${trimmedBaseUrl}`
+			: origin;
+		return withProtocol(`${base}${pathname}`, websocket);
+	}
+
+	let { browserBaseUrl = '', visible = $bindable(true) }: Props = $props();
+
+	let container = $state<HTMLDivElement | undefined>(undefined);
+	let rfb = $state<RFB | null>(null);
+	let connected = $state(false);
+	let connecting = $state(false);
+	let error = $state<string | null>(null);
+	let isFullscreen = $state(false);
+	let activeVNCUrl = $state<string | null>(null);
+	let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+	let lastRequestedSize = $state<string | null>(null);
+	let viewerActive = $state(false);
+
+	function getVNCUrl() {
+		return browserUrl(browserBaseUrl);
+	}
+
+	function getResizeUrl() {
+		return browserUrl(browserBaseUrl, '/browser/resize', false);
+	}
+
+	async function connect() {
+		const nextVNCUrl = getVNCUrl();
+		if (!container || rfb || connecting) return;
+
+		connecting = true;
+		error = null;
+
+		try {
+			const nextRfb = new RFB(container, nextVNCUrl);
+			rfb = nextRfb;
+			activeVNCUrl = nextVNCUrl;
+
+			nextRfb.addEventListener('connect', () => {
+				if (rfb !== nextRfb) return;
+				connected = true;
+				connecting = false;
+				error = null;
+			});
+
+			nextRfb.addEventListener('disconnect', () => {
+				if (rfb === nextRfb) {
+					rfb = null;
+					activeVNCUrl = null;
+				}
+				connected = false;
+				connecting = false;
+			});
+
+			nextRfb.addEventListener('credentialsrequired', () => {
+				if (rfb !== nextRfb) return;
+				connecting = false;
+				error = 'Password required (but none configured)';
+			});
+
+			nextRfb.addEventListener('securityfailure', (e) => {
+				if (rfb !== nextRfb) return;
+				connecting = false;
+				error = `Security failure: ${e.detail.status}`;
+			});
+
+			nextRfb.scaleViewport = true;
+			nextRfb.resizeSession = true;
+			nextRfb.dragViewport = false;
+			nextRfb.clipViewport = false;
+		} catch (err) {
+			rfb = null;
+			activeVNCUrl = null;
+			connecting = false;
+			console.error('VNC connection error:', err);
+			error = err instanceof Error ? err.message : 'Connection failed';
+		}
+	}
+
+	function disconnect() {
+		if (rfb) {
+			rfb.disconnect();
+		}
+		rfb = null;
+		activeVNCUrl = null;
+		connected = false;
+		connecting = false;
+	}
+
+	async function syncRemoteClipboard(text: string) {
+		if (!text || !rfb) return;
+		rfb.focus();
+		rfb.clipboardPasteFrom(text);
+	}
+
+	function sendRemotePasteShortcut() {
+		if (!rfb) return;
+		rfb.focus();
+		rfb.sendKey(0xffe3, 'ControlLeft', true);
+		rfb.sendKey(0x0076, 'KeyV', true);
+		rfb.sendKey(0x0076, 'KeyV', false);
+		rfb.sendKey(0xffe3, 'ControlLeft', false);
+	}
+
+	async function handleLocalPaste() {
+		if (!viewerActive || !rfb || typeof navigator === 'undefined' || !navigator.clipboard) {
+			return;
+		}
+
+		try {
+			const text = await navigator.clipboard.readText();
+			await syncRemoteClipboard(text);
+			sendRemotePasteShortcut();
+		} catch (err) {
+			console.error('Browser clipboard read error:', err);
+		}
+	}
+
+	function toggleFullscreen() {
+		if (!container) return;
+
+		if (!document.fullscreenElement) {
+			container.requestFullscreen();
+			isFullscreen = true;
+		} else {
+			document.exitFullscreen();
+			isFullscreen = false;
+		}
+	}
+
+	function queueResize(width: number, height: number) {
+		const targetWidth = Math.max(640, Math.ceil(width * window.devicePixelRatio));
+		const targetHeight = Math.max(480, Math.ceil(height * window.devicePixelRatio));
+		const sizeKey = `${targetWidth}x${targetHeight}`;
+		if (sizeKey === lastRequestedSize) return;
+
+		if (resizeTimer) {
+			clearTimeout(resizeTimer);
+		}
+
+		resizeTimer = setTimeout(async () => {
+			try {
+				const response = await fetch(getResizeUrl(), {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify({
+						width: targetWidth,
+						height: targetHeight
+					})
+				});
+
+				if (!response.ok) {
+					throw new Error(`resize failed: ${response.status}`);
+				}
+
+				lastRequestedSize = sizeKey;
+			} catch (err) {
+				console.error('Browser resize error:', err);
+			}
+		}, 150);
+	}
+
+	onDestroy(() => {
+		if (resizeTimer) {
+			clearTimeout(resizeTimer);
+		}
+		disconnect();
+	});
+
+	$effect(() => {
+		if (!visible || !container || typeof ResizeObserver === 'undefined') {
+			return;
+		}
+
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			queueResize(entry.contentRect.width, entry.contentRect.height);
+		});
+
+		observer.observe(container);
+		const rect = container.getBoundingClientRect();
+		queueResize(rect.width, rect.height);
+
+		return () => {
+			observer.disconnect();
+		};
+	});
+
+	$effect(() => {
+		if (!visible || !container) {
+			viewerActive = false;
+			return;
+		}
+
+		const handlePointerDown = (event: PointerEvent) => {
+			if (!container) return;
+			viewerActive = container.contains(event.target as Node);
+		};
+
+		const handlePaste = async (event: ClipboardEvent) => {
+			if (!viewerActive || !rfb) return;
+
+			const text = event.clipboardData?.getData('text/plain') ?? '';
+			if (!text) return;
+
+			event.preventDefault();
+			await syncRemoteClipboard(text);
+		};
+
+		const handleKeyDown = async (event: KeyboardEvent) => {
+			const modifierPressed = event.metaKey || event.ctrlKey;
+			if (!viewerActive || !modifierPressed || event.key.toLowerCase() !== 'v') {
+				return;
+			}
+
+			event.preventDefault();
+			await handleLocalPaste();
+		};
+
+		document.addEventListener('pointerdown', handlePointerDown, true);
+		window.addEventListener('paste', handlePaste);
+		window.addEventListener('keydown', handleKeyDown, true);
+
+		return () => {
+			document.removeEventListener('pointerdown', handlePointerDown, true);
+			window.removeEventListener('paste', handlePaste);
+			window.removeEventListener('keydown', handleKeyDown, true);
+		};
+	});
+
+	$effect(() => {
+		const desiredVisible = visible;
+		const desiredUrl = getVNCUrl();
+		const hasContainer = !!container;
+
+		if (!desiredVisible || !hasContainer) {
+			disconnect();
+			return;
+		}
+
+		if (rfb && activeVNCUrl !== desiredUrl) {
+			disconnect();
+			return;
+		}
+
+		if (!rfb && !connecting) {
+			void connect();
+		}
+	});
+</script>
+
+{#if visible}
+	<div class="browser-viewer">
+		<div class="viewer-header">
+			<div class="viewer-status">
+				<span
+					class:error-dot={!!error}
+					class:connecting-dot={!error && !connected}
+					class:connected-dot={connected}
+					class="status-dot"
+				></span>
+				<span class="status-label">
+					{#if connected}
+						Connected
+					{:else if error}
+						Connection issue
+					{:else if connecting}
+						Connecting
+					{:else}
+						Idle
+					{/if}
+				</span>
+			</div>
+
+			<div class="header-actions">
+				<button
+					class="btn btn-ghost btn-sm btn-square"
+					onclick={toggleFullscreen}
+					title="Toggle fullscreen"
+				>
+					{#if isFullscreen}
+						<Minimize2 size={16} />
+					{:else}
+						<Maximize2 size={16} />
+					{/if}
+				</button>
+			</div>
+		</div>
+
+		{#if error}
+			<div class="error-message">
+				<p>{error}</p>
+				<button class="btn btn-primary btn-sm" onclick={connect}>Retry</button>
+			</div>
+		{/if}
+
+		<div class="viewer-container" bind:this={container}></div>
+	</div>
+{/if}
+
+<style>
+	.browser-viewer {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		overflow: hidden;
+		background: hsl(var(--b1));
+		border-left: 1px solid hsl(var(--b3) / 0.7);
+	}
+
+	.viewer-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.625rem 0.75rem;
+		background: hsl(var(--b1) / 0.92);
+		border-bottom: 1px solid hsl(var(--b3) / 0.7);
+		backdrop-filter: blur(8px);
+	}
+
+	.viewer-status {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		min-width: 0;
+	}
+
+	.header-actions {
+		display: flex;
+		gap: 0.125rem;
+	}
+
+	.status-dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		border-radius: 9999px;
+		flex-shrink: 0;
+		background: hsl(var(--bc) / 0.35);
+	}
+
+	.connected-dot {
+		background: #10b981;
+		box-shadow: 0 0 0 3px rgb(16 185 129 / 0.12);
+	}
+
+	.connecting-dot {
+		background: #f59e0b;
+		box-shadow: 0 0 0 3px rgb(245 158 11 / 0.12);
+	}
+
+	.error-dot {
+		background: #ef4444;
+		box-shadow: 0 0 0 3px rgb(239 68 68 / 0.12);
+	}
+
+	.status-label {
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: hsl(var(--bc) / 0.72);
+		white-space: nowrap;
+	}
+
+	.viewer-container {
+		flex: 1;
+		position: relative;
+		overflow: hidden;
+		background: #000;
+	}
+
+	.error-message {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 1rem;
+		padding: 2rem;
+		color: #ef4444;
+	}
+
+	.error-message p {
+		margin: 0;
+	}
+</style>

--- a/ui/user/src/lib/components/nanobot/ProjectStartThread.svelte
+++ b/ui/user/src/lib/components/nanobot/ProjectStartThread.svelte
@@ -7,12 +7,21 @@
 		agentId: string;
 		projectId: string;
 		chat: ChatSession;
+		browserBaseUrl?: string;
+		browserViewerOpen?: boolean;
 		onFileOpen?: (filename: string) => void;
 		suppressEmptyState?: boolean;
 		onThreadContentWidth?: (width: number) => void;
 	}
 
-	let { chat, onFileOpen, suppressEmptyState, onThreadContentWidth }: Props = $props();
+	let {
+		chat,
+		browserBaseUrl = '',
+		browserViewerOpen = $bindable(false),
+		onFileOpen,
+		suppressEmptyState,
+		onThreadContentWidth
+	}: Props = $props();
 </script>
 
 <div class="flex h-full w-full">
@@ -39,6 +48,8 @@
 					chat.refreshResources();
 				}}
 				{onFileOpen}
+				{browserBaseUrl}
+				bind:browserViewerOpen
 				onReadResource={chat.readResource}
 				{suppressEmptyState}
 				onContentWidthChange={onThreadContentWidth}

--- a/ui/user/src/lib/components/nanobot/QuickAccess.svelte
+++ b/ui/user/src/lib/components/nanobot/QuickAccess.svelte
@@ -5,6 +5,7 @@
 		Loader2,
 		ChevronUp,
 		ChevronDown,
+		Monitor,
 		SidebarOpen,
 		SidebarClose,
 		ListCheck
@@ -21,14 +22,25 @@
 
 	interface Props {
 		onToggle?: () => void;
+		onToggleBrowserViewer?: () => void;
 		open?: boolean;
+		browserViewerOpen?: boolean;
 		sessionId?: string;
 		selectedFile?: string;
 		agentId?: string;
 		projectId?: string;
 	}
 
-	let { onToggle, open, sessionId, selectedFile, agentId, projectId }: Props = $props();
+	let {
+		onToggle,
+		onToggleBrowserViewer,
+		open,
+		browserViewerOpen = false,
+		sessionId,
+		selectedFile,
+		agentId,
+		projectId
+	}: Props = $props();
 
 	/** Todo item shape from todo:///list resource or todo_write tool (application/json) */
 	interface TodoItem {
@@ -82,6 +94,33 @@
 		<div class={twMerge(open ? 'self-end' : 'w-14 self-center')}>
 			<Profile {agentId} {projectId} />
 		</div>
+
+		{#if onToggleBrowserViewer}
+			{#if open}
+				<button
+					class={twMerge(
+						'btn justify-start gap-2 self-stretch rounded-xl px-4',
+						browserViewerOpen ? 'btn-neutral' : 'btn-ghost border-base-300 border'
+					)}
+					onclick={onToggleBrowserViewer}
+				>
+					<Monitor class="size-4 shrink-0" />
+					Browser
+				</button>
+			{:else}
+				<button
+					class={twMerge(
+						'btn btn-circle tooltip tooltip-left size-10 self-center',
+						browserViewerOpen ? 'btn-neutral' : 'btn-ghost'
+					)}
+					onclick={onToggleBrowserViewer}
+					aria-label={browserViewerOpen ? 'Hide browser view' : 'Show browser view'}
+					data-tip={browserViewerOpen ? 'Hide browser view' : 'Show browser view'}
+				>
+					<Monitor class="size-5" />
+				</button>
+			{/if}
+		{/if}
 
 		{#if !!sessionId}
 			{#if open}

--- a/ui/user/src/lib/components/nanobot/Thread.svelte
+++ b/ui/user/src/lib/components/nanobot/Thread.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import BrowserViewer from '$lib/components/nanobot/BrowserViewer.svelte';
 	import Elicitation from '$lib/components/nanobot/Elicitation.svelte';
 	import Prompt from '$lib/components/nanobot/Prompt.svelte';
 	import type {
@@ -34,6 +35,8 @@
 		onReadResource?: (uri: string) => Promise<{ contents: ResourceContents[] }>;
 		onCancel?: () => void;
 		onContentWidthChange?: (width: number) => void;
+		browserBaseUrl?: string;
+		browserViewerOpen?: boolean;
 		cancelUpload?: (fileId: string) => void;
 		uploadingFiles?: UploadingFile[];
 		uploadedFiles?: UploadedFile[];
@@ -60,6 +63,8 @@
 		onReadResource,
 		onCancel,
 		onContentWidthChange,
+		browserBaseUrl = '',
+		browserViewerOpen = $bindable(false),
 		cancelUpload,
 		uploadingFiles,
 		uploadedFiles,
@@ -85,6 +90,8 @@
 	let pinInputToBottom = $derived(hasMessages || !!suppressEmptyState);
 	const showInlineAgentHeader = $derived(!emptyStateContent && !isLoading && !pinInputToBottom);
 	let selectedPrompt = $state<string | undefined>();
+	let browserViewerWidth = $state(50);
+	let isResizing = $state(false);
 
 	const selectedPromptData = $derived(
 		selectedPrompt && prompts?.length ? prompts.find((p) => p.name === selectedPrompt) : undefined
@@ -99,6 +106,32 @@
 	);
 
 	const SCROLL_THRESHOLD = 10;
+
+	function startResize(e: MouseEvent) {
+		isResizing = true;
+		e.preventDefault();
+	}
+
+	function stopResize() {
+		isResizing = false;
+	}
+
+	function resize(e: MouseEvent) {
+		if (!isResizing) return;
+		const container = e.currentTarget as HTMLElement;
+		if (!container) return;
+
+		const rect = container.getBoundingClientRect();
+		const newWidth = ((rect.right - e.clientX) / rect.width) * 100;
+		browserViewerWidth = Math.max(20, Math.min(80, newWidth));
+	}
+
+	$effect(() => {
+		if (isResizing) {
+			window.addEventListener('mouseup', stopResize);
+			return () => window.removeEventListener('mouseup', stopResize);
+		}
+	});
 
 	const isNearBottom = () => {
 		if (!messagesContainer) return false;
@@ -333,7 +366,8 @@
 </script>
 
 <div
-	class="flex h-[calc(100dvh-4rem)] w-full flex-col transition-transform md:relative peer-[.workspace]:md:w-1/4"
+	class="flex h-[calc(100dvh-4rem)] w-full flex-row transition-transform md:relative peer-[.workspace]:md:w-1/4"
+	onmousemove={resize}
 	ondragenter={handleDragEnter}
 	ondragleave={handleDragLeave}
 	ondragover={handleDragOver}
@@ -355,129 +389,153 @@
 		</div>
 	{/if}
 
-	<!-- Messages area - full height scrollable with bottom padding for floating input -->
 	<div
-		class="h-full w-full overflow-y-auto px-4"
-		bind:this={messagesContainer}
-		onscroll={handleScroll}
+		class="relative flex flex-col"
+		style="width: {browserViewerOpen ? `${100 - browserViewerWidth}%` : '100%'}"
 	>
-		<div class="mx-auto max-w-4xl" bind:this={messagesContentInner}>
-			<!-- Prompts section - show when prompts available and no messages -->
-			{#if prompts && prompts.length > 0}
-				<div class="mb-6">
-					<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-						{#if selectedPromptData}
-							<Prompt
-								prompt={selectedPromptData}
-								onSend={async (m) => {
-									selectedPrompt = undefined;
-									if (onSendMessage) {
-										pinInputToBottom = true;
-										return await onSendMessage(m);
-									}
-								}}
-								onCancel={() => (selectedPrompt = undefined)}
-								open
-							/>
-						{/if}
+		<!-- Messages area - full height scrollable with bottom padding for floating input -->
+		<div
+			class="h-full w-full flex-1 overflow-y-auto px-4"
+			bind:this={messagesContainer}
+			onscroll={handleScroll}
+		>
+			<div class="mx-auto max-w-4xl" bind:this={messagesContentInner}>
+				<!-- Prompts section - show when prompts available and no messages -->
+				{#if prompts && prompts.length > 0}
+					<div class="mb-6">
+						<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+							{#if selectedPromptData}
+								<Prompt
+									prompt={selectedPromptData}
+									onSend={async (m) => {
+										selectedPrompt = undefined;
+										if (onSendMessage) {
+											pinInputToBottom = true;
+											return await onSendMessage(m);
+										}
+									}}
+									onCancel={() => (selectedPrompt = undefined)}
+									open
+								/>
+							{/if}
+						</div>
 					</div>
-				</div>
-			{/if}
+				{/if}
 
-			<Messages
-				{messages}
-				onSend={async (m) => {
-					pinInputToBottom = true;
-					return await onSendMessage?.(m);
-				}}
-				{isLoading}
-				{agent}
-				{onFileOpen}
-				{onReadResource}
-				hideAgentHeader
-			/>
-		</div>
-	</div>
-
-	<!-- Message input - centered when no messages, bottom when messages exist or when empty state is suppressed -->
-	<div
-		class={twMerge(
-			'absolute top-auto right-0 bottom-0 left-0 flex flex-col transition-all duration-500 ease-in-out',
-			pinInputToBottom
-				? 'bg-base-100/80 ' + (questionElicitation ? 'h-full' : 'backdrop-blur-xs')
-				: 'top-1/2 -translate-y-1/2'
-		)}
-	>
-		{#if pinInputToBottom}
-			<!-- Overlay: always in DOM when pinned so opacity/blur can transition -->
-			<div
-				class={twMerge(
-					'bg-base-100/30 absolute inset-0 z-0 transition-[opacity,backdrop-filter] duration-500 ease-out',
-					questionElicitation
-						? 'bg-base-100 opacity-75 backdrop-blur-[1px]'
-						: 'pointer-events-none opacity-0 backdrop-blur-none'
-				)}
-				aria-hidden="true"
-			></div>
-		{/if}
-		{#if questionElicitation}
-			<div class="relative z-10 flex grow"></div>
-		{/if}
-		<!-- Scroll to bottom button -->
-		{#if showScrollButton && hasMessages}
-			<button
-				class="btn btn-circle border-base-300 bg-base-100 btn-md relative z-10 mx-auto shadow-lg active:translate-y-0.5"
-				onclick={scrollToBottom}
-				aria-label="Scroll to bottom"
-			>
-				<ChevronDown class="size-5" />
-			</button>
-		{/if}
-		{#if showInlineAgentHeader}
-			<div class="relative z-10 mx-auto w-full max-w-4xl" out:slide={{ axis: 'y', duration: 500 }}>
-				<div out:fade={{ duration: 500 }}>
-					<AgentHeader {agent} onSend={onSendMessage} />
-				</div>
-			</div>
-		{:else if emptyStateContent && !pinInputToBottom}
-			<div class="relative z-10 mx-auto w-full max-w-4xl" out:slide={{ axis: 'y', duration: 500 }}>
-				<div out:fade={{ duration: 500 }}>
-					{@render emptyStateContent()}
-				</div>
-			</div>
-		{/if}
-		<div class="relative z-10 mx-auto w-full max-w-4xl">
-			{#if questionElicitation}
-				{#key questionElicitation.id}
-					<div class="elicitation-slide-in mb-8">
-						<Elicitation
-							elicitation={questionElicitation}
-							open
-							onresult={(result) => {
-								onElicitationResult?.(questionElicitation, result);
-							}}
-						/>
-					</div>
-				{/key}
-			{:else}
-				<MessageInput
-					placeholder={`Type your message...${prompts && prompts.length > 0 ? ' or / for prompts' : ''}`}
-					onSend={onSendMessage}
-					{agents}
-					{selectedAgentId}
-					{onAgentChange}
-					onPrompt={(p) => (selectedPrompt = p)}
-					{onFileUpload}
-					disabled={isLoading}
-					{prompts}
-					{cancelUpload}
-					{uploadingFiles}
-					{uploadedFiles}
-					{onCancel}
+				<Messages
+					{messages}
+					onSend={async (m) => {
+						pinInputToBottom = true;
+						return await onSendMessage?.(m);
+					}}
+					{isLoading}
+					{agent}
+					{onFileOpen}
+					{onReadResource}
+					hideAgentHeader
 				/>
+			</div>
+		</div>
+
+		<!-- Message input - centered when no messages, bottom when messages exist or when empty state is suppressed -->
+		<div
+			class={twMerge(
+				'absolute top-auto right-0 bottom-0 left-0 flex flex-col transition-all duration-500 ease-in-out',
+				pinInputToBottom
+					? 'bg-base-100/80 ' + (questionElicitation ? 'h-full' : 'backdrop-blur-xs')
+					: 'top-1/2 -translate-y-1/2'
+			)}
+		>
+			{#if pinInputToBottom}
+				<div
+					class={twMerge(
+						'bg-base-100/30 absolute inset-0 z-0 transition-[opacity,backdrop-filter] duration-500 ease-out',
+						questionElicitation
+							? 'bg-base-100 opacity-75 backdrop-blur-[1px]'
+							: 'pointer-events-none opacity-0 backdrop-blur-none'
+					)}
+					aria-hidden="true"
+				></div>
 			{/if}
+			{#if questionElicitation}
+				<div class="relative z-10 flex grow"></div>
+			{/if}
+			{#if showScrollButton && hasMessages}
+				<button
+					class="btn btn-circle border-base-300 bg-base-100 btn-md relative z-10 mx-auto shadow-lg active:translate-y-0.5"
+					onclick={scrollToBottom}
+					aria-label="Scroll to bottom"
+				>
+					<ChevronDown class="size-5" />
+				</button>
+			{/if}
+			{#if showInlineAgentHeader}
+				<div
+					class="relative z-10 mx-auto w-full max-w-4xl"
+					out:slide={{ axis: 'y', duration: 500 }}
+				>
+					<div out:fade={{ duration: 500 }}>
+						<AgentHeader {agent} onSend={onSendMessage} />
+					</div>
+				</div>
+			{:else if emptyStateContent && !pinInputToBottom}
+				<div
+					class="relative z-10 mx-auto w-full max-w-4xl"
+					out:slide={{ axis: 'y', duration: 500 }}
+				>
+					<div out:fade={{ duration: 500 }}>
+						{@render emptyStateContent()}
+					</div>
+				</div>
+			{/if}
+			<div class="relative z-10 mx-auto w-full max-w-4xl">
+				{#if questionElicitation}
+					{#key questionElicitation.id}
+						<div class="elicitation-slide-in mb-8">
+							<Elicitation
+								elicitation={questionElicitation}
+								open
+								onresult={(result) => {
+									onElicitationResult?.(questionElicitation, result);
+								}}
+							/>
+						</div>
+					{/key}
+				{:else}
+					<MessageInput
+						placeholder={`Type your message...${prompts && prompts.length > 0 ? ' or / for prompts' : ''}`}
+						onSend={onSendMessage}
+						{agents}
+						{selectedAgentId}
+						{onAgentChange}
+						onPrompt={(p) => (selectedPrompt = p)}
+						{onFileUpload}
+						disabled={isLoading}
+						{prompts}
+						{cancelUpload}
+						{uploadingFiles}
+						{uploadedFiles}
+						{onCancel}
+					/>
+				{/if}
+			</div>
 		</div>
 	</div>
+
+	{#if browserViewerOpen}
+		<div
+			class="bg-base-300 hover:bg-primary w-1 cursor-col-resize transition-colors"
+			onmousedown={startResize}
+			role="separator"
+			aria-label="Resize browser viewer"
+		></div>
+	{/if}
+
+	{#if browserViewerOpen}
+		<div class="flex flex-col" style="width: {browserViewerWidth}%">
+			<BrowserViewer bind:visible={browserViewerOpen} {browserBaseUrl} />
+		</div>
+	{/if}
 
 	<!-- Modal elicitations (OAuth, generic form) -->
 	{#if modalElicitation}

--- a/ui/user/src/lib/services/nanobot/types.ts
+++ b/ui/user/src/lib/services/nanobot/types.ts
@@ -446,6 +446,8 @@ export interface ProjectLayoutContext {
 	setThreadContentWidth: (w: number) => void;
 	setLayoutName: (name: string) => void;
 	setShowBackButton: (show: boolean) => void;
+	browserViewerOpen: boolean;
+	setBrowserViewerOpen: (show: boolean) => void;
 }
 
 export const PROJECT_LAYOUT_CONTEXT = 'nanobot-project-layout';

--- a/ui/user/src/novnc.d.ts
+++ b/ui/user/src/novnc.d.ts
@@ -1,0 +1,35 @@
+declare module '@novnc/novnc/lib/rfb.js' {
+	interface RFBSecurityFailureDetail {
+		status: number | string;
+	}
+
+	interface RFBEventMap {
+		connect: Event;
+		disconnect: Event;
+		credentialsrequired: Event;
+		clipboard: CustomEvent<{ text: string }>;
+		securityfailure: CustomEvent<RFBSecurityFailureDetail>;
+	}
+
+	class RFB extends EventTarget {
+		constructor(target: Element, url: string);
+
+		scaleViewport: boolean;
+		resizeSession: boolean;
+		dragViewport: boolean;
+		clipViewport: boolean;
+
+		focus(options?: FocusOptions): void;
+		clipboardPasteFrom(text: string): void;
+		sendKey(keysym: number, code: string | null, down?: boolean): void;
+		disconnect(): void;
+
+		addEventListener<K extends keyof RFBEventMap>(
+			type: K,
+			listener: (this: RFB, event: RFBEventMap[K]) => void,
+			options?: boolean | AddEventListenerOptions
+		): void;
+	}
+
+	export default RFB;
+}

--- a/ui/user/src/routes/agent/+page.svelte
+++ b/ui/user/src/routes/agent/+page.svelte
@@ -16,6 +16,7 @@
 	let threadContentWidth = $state(0);
 	let initialMessage = $state<string | undefined>(undefined);
 	let pendingFiles = $state<UploadedFile[]>([]);
+	let browserViewerOpen = $state(false);
 
 	function cancelPendingUpload(fileId: string) {
 		const entry = pendingFiles.find((f) => f.id === fileId);
@@ -61,6 +62,8 @@
 		<ProjectStartThread
 			agentId={agent.id}
 			{projectId}
+			browserBaseUrl={agent.connectURL}
+			bind:browserViewerOpen
 			chat={{
 				sendMessage: async (message: string, attachments?: Attachment[]) => {
 					initialMessage = message;
@@ -133,7 +136,12 @@
 	</div>
 
 	{#snippet rightSidebar()}
-		<ThreadQuickAccess {projectId} agentId={agent.id} />
+		<ThreadQuickAccess
+			{projectId}
+			agentId={agent.id}
+			{browserViewerOpen}
+			onToggleBrowserViewer={() => (browserViewerOpen = !browserViewerOpen)}
+		/>
 	{/snippet}
 </Layout>
 

--- a/ui/user/src/routes/agent/p/[projectId]/+layout.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/+layout.svelte
@@ -30,6 +30,7 @@
 	let threadContentWidth = $state(0);
 	let layoutName = $state('');
 	let showBackButton = $state(false);
+	let browserViewerOpen = $state(false);
 	/** Session ID we already tried to refresh for when it was missing (avoids loop if listSessions never returns it). */
 	let refreshedForMissingSessionId: string | null = null;
 	let titleInterval: ReturnType<typeof setInterval> | null = null;
@@ -41,7 +42,11 @@
 		handleFileOpen,
 		setThreadContentWidth: (w: number) => (threadContentWidth = w),
 		setLayoutName: (name: string) => (layoutName = name),
-		setShowBackButton: (show: boolean) => (showBackButton = show)
+		setShowBackButton: (show: boolean) => (showBackButton = show),
+		get browserViewerOpen() {
+			return browserViewerOpen;
+		},
+		setBrowserViewerOpen: (show: boolean) => (browserViewerOpen = show)
 	});
 
 	setContext(PROJECT_LAYOUT_CONTEXT, projectLayoutContext);
@@ -280,7 +285,9 @@
 		{/if}
 		<QuickAccess
 			onToggle={() => (layout.quickBarAccessOpen = !layout.quickBarAccessOpen)}
+			onToggleBrowserViewer={() => (browserViewerOpen = !browserViewerOpen)}
 			open={layout.quickBarAccessOpen}
+			{browserViewerOpen}
 			{sessionId}
 			{selectedFile}
 			{agentId}

--- a/ui/user/src/routes/agent/p/[projectId]/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/+page.svelte
@@ -11,6 +11,7 @@
 	let projectId = $derived(data.projects[0].id);
 	let tid = $derived(page.url.searchParams.get('tid'));
 	let session = $derived($nanobotChat?.sessions?.find((s) => s.id === tid));
+	let browserBaseUrl = $derived(data.agent.connectURL);
 
 	const projectLayout = getContext<ProjectLayoutContext>(PROJECT_LAYOUT_CONTEXT);
 
@@ -22,6 +23,8 @@
 		<ProjectStartThread
 			agentId={agent.id}
 			{projectId}
+			{browserBaseUrl}
+			bind:browserViewerOpen={projectLayout.browserViewerOpen}
 			chat={displayChat}
 			onFileOpen={projectLayout.handleFileOpen}
 			suppressEmptyState


### PR DESCRIPTION
- add a bundled BrowserViewer for remote agent browser sessions
- connect BrowserView to /browser and /browser/resize via agent.connectURL
- wire browser panel state through nanobot thread and project layout routes
- expose the Browser toggle from Obot sidebar quick access
- add local noVNC typings for strict TS/lint compatibility

