### PR TITLE
fix: return items:[] instead of items:null

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -114,7 +114,7 @@ func (m *MCPHandler) ListEntriesFromAllSources(req api.Context) error {
 	}
 
 	// Apply ACR filtering for regular users and for admins without ?all=true
-	var entries []types.MCPServerCatalogEntry
+	entries := make([]types.MCPServerCatalogEntry, 0)
 	for _, entry := range list.Items {
 		var (
 			err       error

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -56,7 +56,7 @@ func (*MCPCatalogHandler) List(req api.Context) error {
 		return fmt.Errorf("failed to list catalogs: %w", err)
 	}
 
-	var items []types.MCPCatalog
+	items := make([]types.MCPCatalog, 0, len(list.Items))
 	for _, item := range list.Items {
 		items = append(items, convertMCPCatalog(item))
 	}
@@ -446,7 +446,7 @@ func (h *MCPCatalogHandler) AdminListServersForEntryInCatalog(req api.Context) e
 		return fmt.Errorf("failed to list servers: %w", err)
 	}
 
-	var items []types.MCPServer
+	items := make([]types.MCPServer, 0, len(list.Items))
 	for _, server := range list.Items {
 		if server.Spec.Template {
 			// Hide template servers
@@ -530,7 +530,7 @@ func (h *MCPCatalogHandler) AdminListServersForAllEntriesInCatalog(req api.Conte
 		filteredServers = append(filteredServers, server)
 	}
 
-	var items []types.MCPServer
+	items := make([]types.MCPServer, 0, len(filteredServers))
 	for _, server := range filteredServers {
 		var credCtx string
 		if server.Spec.MCPCatalogID != "" {
@@ -600,7 +600,7 @@ func (h *MCPCatalogHandler) ListServersForEntry(req api.Context) error {
 		return fmt.Errorf("failed to list servers: %w", err)
 	}
 
-	var items []types.MCPServer
+	items := make([]types.MCPServer, 0, len(list.Items))
 	for _, server := range list.Items {
 		if server.Spec.Template {
 			// Hide template servers


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/6048

If the user had no access control rules, then the list would come back as `null` instead of `[]`, which would cause an error in the Obot MCP Server when searching for MCP servers.