### PR TITLE
enhance: hide BrowserView controls until the agent has a browser

### DIFF
--- a/ui/user/src/lib/components/nanobot/ProjectStartThread.svelte
+++ b/ui/user/src/lib/components/nanobot/ProjectStartThread.svelte
@@ -8,6 +8,7 @@
 		projectId: string;
 		chat: ChatSession;
 		browserBaseUrl?: string;
+		browserAvailable?: boolean;
 		browserViewerOpen?: boolean;
 		onFileOpen?: (filename: string) => void;
 		suppressEmptyState?: boolean;
@@ -17,6 +18,7 @@
 	let {
 		chat,
 		browserBaseUrl = '',
+		browserAvailable = false,
 		browserViewerOpen = $bindable(false),
 		onFileOpen,
 		suppressEmptyState,
@@ -49,6 +51,7 @@
 				}}
 				{onFileOpen}
 				{browserBaseUrl}
+				{browserAvailable}
 				bind:browserViewerOpen
 				onReadResource={chat.readResource}
 				{suppressEmptyState}

--- a/ui/user/src/lib/components/nanobot/QuickAccess.svelte
+++ b/ui/user/src/lib/components/nanobot/QuickAccess.svelte
@@ -25,6 +25,7 @@
 		onToggleBrowserViewer?: () => void;
 		open?: boolean;
 		browserViewerOpen?: boolean;
+		browserAvailable?: boolean;
 		sessionId?: string;
 		selectedFile?: string;
 		agentId?: string;
@@ -36,6 +37,7 @@
 		onToggleBrowserViewer,
 		open,
 		browserViewerOpen = false,
+		browserAvailable = false,
 		sessionId,
 		selectedFile,
 		agentId,
@@ -95,7 +97,7 @@
 			<Profile {agentId} {projectId} />
 		</div>
 
-		{#if onToggleBrowserViewer}
+		{#if onToggleBrowserViewer && browserAvailable}
 			{#if open}
 				<button
 					class={twMerge(

--- a/ui/user/src/lib/components/nanobot/Thread.svelte
+++ b/ui/user/src/lib/components/nanobot/Thread.svelte
@@ -36,6 +36,7 @@
 		onCancel?: () => void;
 		onContentWidthChange?: (width: number) => void;
 		browserBaseUrl?: string;
+		browserAvailable?: boolean;
 		browserViewerOpen?: boolean;
 		cancelUpload?: (fileId: string) => void;
 		uploadingFiles?: UploadingFile[];
@@ -64,6 +65,7 @@
 		onCancel,
 		onContentWidthChange,
 		browserBaseUrl = '',
+		browserAvailable = false,
 		browserViewerOpen = $bindable(false),
 		cancelUpload,
 		uploadingFiles,
@@ -130,6 +132,12 @@
 		if (isResizing) {
 			window.addEventListener('mouseup', stopResize);
 			return () => window.removeEventListener('mouseup', stopResize);
+		}
+	});
+
+	$effect(() => {
+		if (!browserAvailable && browserViewerOpen) {
+			browserViewerOpen = false;
 		}
 	});
 
@@ -522,7 +530,7 @@
 		</div>
 	</div>
 
-	{#if browserViewerOpen}
+	{#if browserViewerOpen && browserAvailable}
 		<div
 			class="bg-base-300 hover:bg-primary w-1 cursor-col-resize transition-colors"
 			onmousedown={startResize}
@@ -531,7 +539,7 @@
 		></div>
 	{/if}
 
-	{#if browserViewerOpen}
+	{#if browserViewerOpen && browserAvailable}
 		<div class="flex flex-col" style="width: {browserViewerWidth}%">
 			<BrowserViewer bind:visible={browserViewerOpen} {browserBaseUrl} />
 		</div>

--- a/ui/user/src/lib/services/nanobot/types.ts
+++ b/ui/user/src/lib/services/nanobot/types.ts
@@ -446,6 +446,8 @@ export interface ProjectLayoutContext {
 	setThreadContentWidth: (w: number) => void;
 	setLayoutName: (name: string) => void;
 	setShowBackButton: (show: boolean) => void;
+	browserAvailable: boolean;
+	setBrowserAvailable: (show: boolean) => void;
 	browserViewerOpen: boolean;
 	setBrowserViewerOpen: (show: boolean) => void;
 }

--- a/ui/user/src/routes/agent/+page.svelte
+++ b/ui/user/src/routes/agent/+page.svelte
@@ -17,6 +17,13 @@
 	let initialMessage = $state<string | undefined>(undefined);
 	let pendingFiles = $state<UploadedFile[]>([]);
 	let browserViewerOpen = $state(false);
+	let browserAvailable = $state(false);
+
+	function browserStatusUrl(baseUrl: string) {
+		const trimmedBaseUrl = baseUrl.replace(/\/$/, '');
+		const url = new URL(`${trimmedBaseUrl}/browser/status`);
+		return url.toString();
+	}
 
 	function cancelPendingUpload(fileId: string) {
 		const entry = pendingFiles.find((f) => f.id === fileId);
@@ -35,6 +42,32 @@
 		pendingFiles = [...pendingFiles, { id, file, uri, mimeType: file.type || undefined }];
 		return { name: file.name, uri, mimeType: file.type || undefined };
 	}
+
+	$effect(() => {
+		if (!agent.connectURL || typeof EventSource === 'undefined') {
+			return;
+		}
+
+		const eventSource = new EventSource(browserStatusUrl(agent.connectURL));
+		const handleStatus = (event: Event) => {
+			try {
+				const data = JSON.parse((event as MessageEvent<string>).data) as { available?: boolean };
+				browserAvailable = !!data.available;
+				if (!browserAvailable) {
+					browserViewerOpen = false;
+				}
+			} catch {
+				// Ignore malformed status events and keep the last known state.
+			}
+		};
+
+		eventSource.addEventListener('status', handleStatus);
+
+		return () => {
+			eventSource.removeEventListener('status', handleStatus);
+			eventSource.close();
+		};
+	});
 </script>
 
 <Layout
@@ -63,6 +96,7 @@
 			agentId={agent.id}
 			{projectId}
 			browserBaseUrl={agent.connectURL}
+			{browserAvailable}
 			bind:browserViewerOpen
 			chat={{
 				sendMessage: async (message: string, attachments?: Attachment[]) => {
@@ -139,6 +173,7 @@
 		<ThreadQuickAccess
 			{projectId}
 			agentId={agent.id}
+			{browserAvailable}
 			{browserViewerOpen}
 			onToggleBrowserViewer={() => (browserViewerOpen = !browserViewerOpen)}
 		/>

--- a/ui/user/src/routes/agent/p/[projectId]/+layout.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/+layout.svelte
@@ -31,6 +31,7 @@
 	let layoutName = $state('');
 	let showBackButton = $state(false);
 	let browserViewerOpen = $state(false);
+	let browserAvailable = $state(false);
 	/** Session ID we already tried to refresh for when it was missing (avoids loop if listSessions never returns it). */
 	let refreshedForMissingSessionId: string | null = null;
 	let titleInterval: ReturnType<typeof setInterval> | null = null;
@@ -43,6 +44,10 @@
 		setThreadContentWidth: (w: number) => (threadContentWidth = w),
 		setLayoutName: (name: string) => (layoutName = name),
 		setShowBackButton: (show: boolean) => (showBackButton = show),
+		get browserAvailable() {
+			return browserAvailable;
+		},
+		setBrowserAvailable: (show: boolean) => (browserAvailable = show),
 		get browserViewerOpen() {
 			return browserViewerOpen;
 		},
@@ -70,6 +75,38 @@
 		layout.quickBarAccessOpen = false;
 		selectedFile = filename;
 	}
+
+	function browserStatusUrl(baseUrl: string) {
+		const trimmedBaseUrl = baseUrl.replace(/\/$/, '');
+		const url = new URL(`${trimmedBaseUrl}/browser/status`);
+		return url.toString();
+	}
+
+	$effect(() => {
+		if (!data.agent.connectURL || typeof EventSource === 'undefined') {
+			return;
+		}
+
+		const eventSource = new EventSource(browserStatusUrl(data.agent.connectURL));
+		const handleStatus = (event: Event) => {
+			try {
+				const payload = JSON.parse((event as MessageEvent<string>).data) as { available?: boolean };
+				browserAvailable = !!payload.available;
+				if (!browserAvailable) {
+					browserViewerOpen = false;
+				}
+			} catch {
+				// Ignore malformed status events and keep the last known state.
+			}
+		};
+
+		eventSource.addEventListener('status', handleStatus);
+
+		return () => {
+			eventSource.removeEventListener('status', handleStatus);
+			eventSource.close();
+		};
+	});
 
 	$effect(() => {
 		if (parentWorkflowId || workflowId) {
@@ -287,6 +324,7 @@
 			onToggle={() => (layout.quickBarAccessOpen = !layout.quickBarAccessOpen)}
 			onToggleBrowserViewer={() => (browserViewerOpen = !browserViewerOpen)}
 			open={layout.quickBarAccessOpen}
+			{browserAvailable}
 			{browserViewerOpen}
 			{sessionId}
 			{selectedFile}

--- a/ui/user/src/routes/agent/p/[projectId]/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/+page.svelte
@@ -24,6 +24,7 @@
 			agentId={agent.id}
 			{projectId}
 			{browserBaseUrl}
+			browserAvailable={projectLayout.browserAvailable}
 			bind:browserViewerOpen={projectLayout.browserViewerOpen}
 			chat={displayChat}
 			onFileOpen={projectLayout.handleFileOpen}


### PR DESCRIPTION
Subscribe to the agent's browser availability stream from the Obot UI and use it to gate BrowserView controls.

The Browser button is now hidden until the launched agent reports an active Chrome or Chromium window, and the viewer is closed again if that browser disappears. This keeps the BrowserView affordance out of the way until there is real browser state to show.

Depends on https://github.com/nanobot-ai/nanobot/pull/235
