### PR TITLE
fix: normalize file resource URIs before reading

### DIFF
--- a/ui/user/src/lib/services/nanobot/chat/index.svelte.ts
+++ b/ui/user/src/lib/services/nanobot/chat/index.svelte.ts
@@ -180,9 +180,7 @@ export class ChatAPI {
 	}
 
 	async readResource(uri: string): Promise<{ contents: ResourceContents[] }> {
-		return (await this.mcpClient.exchange('resources/read', { uri })) as {
-			contents: ResourceContents[];
-		};
+		return this.mcpClient.readResource(uri);
 	}
 
 	async deleteWorkflow(workflowUri: string): Promise<void> {
@@ -469,9 +467,7 @@ export class ChatSession {
 	};
 
 	readResource = async (uri: string) => {
-		return (await this.sessionClient.exchange('resources/read', { uri })) as {
-			contents: ResourceContents[];
-		};
+		return this.sessionClient.readResource(uri);
 	};
 
 	register(

--- a/ui/user/src/lib/services/nanobot/mcpclient/index.svelte.ts
+++ b/ui/user/src/lib/services/nanobot/mcpclient/index.svelte.ts
@@ -1,4 +1,5 @@
 import { type InitializationResult, type ResourceContents, type Resources } from '../types';
+import { normalizeResourceReadURI } from '../utils';
 
 interface JSONRPCRequest {
 	jsonrpc: '2.0';
@@ -490,7 +491,11 @@ export class SimpleClient {
 		uri: string,
 		opts?: { abort?: AbortController }
 	): Promise<{ contents: ResourceContents[] }> {
-		const result = await this.exchange('resources/read', { uri }, { abort: opts?.abort });
+		const result = await this.exchange(
+			'resources/read',
+			{ uri: normalizeResourceReadURI(uri) },
+			{ abort: opts?.abort }
+		);
 		return result as { contents: ResourceContents[] };
 	}
 

--- a/ui/user/src/lib/services/nanobot/utils.ts
+++ b/ui/user/src/lib/services/nanobot/utils.ts
@@ -13,6 +13,33 @@ export function parseToolFilePath(item: ChatMessageItemToolCall) {
 	return parseJSON<{ file_path: string }>(item.arguments)?.file_path ?? null;
 }
 
+export function normalizeResourceReadURI(uri: string): string {
+	if (!uri) return uri;
+
+	const fileURIPrefix = 'file:///';
+	const homePrefix = '/home/nanobot/';
+	const isFileURI = uri.startsWith(fileURIPrefix);
+	const isWorkspacePath = uri.startsWith(homePrefix);
+
+	if (!isFileURI && !isWorkspacePath) {
+		return uri;
+	}
+
+	const rawPath = isFileURI ? uri.slice(fileURIPrefix.length) : uri.slice(homePrefix.length);
+	const normalizedPath = rawPath
+		.split('/')
+		.map((segment) => {
+			try {
+				return encodeURIComponent(decodeURIComponent(segment));
+			} catch {
+				return encodeURIComponent(segment);
+			}
+		})
+		.join('/');
+
+	return `${fileURIPrefix}${normalizedPath}`;
+}
+
 const SAFE_IMAGE_MIME_TYPES = new Set<string>([
 	'image/png',
 	'image/jpeg',


### PR DESCRIPTION
Normalize raw workspace file paths and unencoded file URIs before issuing resources/read so chat file previews work for names with spaces.

Route chat and session resource reads through SimpleClient.readResource so the normalization logic lives in one place.

Addresses https://github.com/obot-platform/obot/issues/5992

