### PR TITLE
fix: mitigate thread-stuck state by reverting to-do list to parse todoWrite tool calls

### DIFF
--- a/ui/user/src/lib/components/nanobot/QuickAccess.svelte
+++ b/ui/user/src/lib/components/nanobot/QuickAccess.svelte
@@ -139,13 +139,6 @@
 
 	const hasSidebarContent = $derived(!!sessionId || !!workflowName || files.length > 0);
 
-	/** Todo item shape from todo:///list resource or todo_write tool (application/json) */
-	interface TodoItem {
-		content: string;
-		status: 'pending' | 'in_progress' | 'completed' | 'cancelled';
-		activeForm?: string;
-	}
-
 	const TODO_WRITE_NAMES = ['todo_write', 'todoWrite'];
 
 	function parseTodoItem(raw: unknown): TodoItem | null {


### PR DESCRIPTION
The call to subscribe to todo list resource updates can sometimes trigger a race condition at session creation that causes the chat progress messages to be lost. This results in the session appearing to be stuck until the page is refreshed (the "lost" messages are then correctly populated from the history).

The root cause of the race condition has yet to be identified, but it can be mitigated by not subscribing to the "todo:///list" resource at session start.

This change reverts todo list logic in the UI to parse the chat history for todoWrite tool calls instead of subscribing to the todo list.

