### PR TITLE
fix: reset nanobotChat store regardless if currentSessionId isn't set

### DIFF
--- a/ui/user/src/routes/agent/p/[projectId]/+layout.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/+layout.svelte
@@ -257,7 +257,7 @@
 					return data;
 				});
 			});
-		} else {
+		} else if (storedChat?.chat) {
 			nanobotChat.update((data) => {
 				if (data) {
 					data.chat = undefined;


### PR DESCRIPTION
Addresses #6131 

If currentSessionId isn't set, the clearing of chat from nanobotChat store should happen regardless if prevSessionId is defined or not 