### PR TITLE
fix: no loader circle when syncing data from interval calls in deployments view

### DIFF
--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -287,13 +287,13 @@
 			deployedWorkspaceCatalogEntryServers =
 				await AdminService.listAllWorkspaceDeployedSingleRemoteServers();
 			// Refresh multi-user servers too
-			mcpServersAndEntries.refreshAll();
+			await mcpServersAndEntries.refreshAll();
 			// Refresh capacity banner when server list changes
 			if (!isInitialLoad) {
 				capacityBanner?.refresh();
 			}
 		} else if (!isInitialLoad && entity === 'workspace') {
-			mcpServersAndEntries.refreshAll();
+			await mcpServersAndEntries.refreshAll();
 		}
 
 		if (isInitialLoad) {
@@ -535,7 +535,7 @@
 </script>
 
 <div class="flex flex-col gap-2">
-	{#if loading || mcpServersAndEntries.current.loading}
+	{#if loading}
 		<div class="my-2 flex items-center justify-center">
 			<LoaderCircle class="size-6 animate-spin" />
 		</div>

--- a/ui/user/src/lib/stores/mcpServersAndEntries.svelte.ts
+++ b/ui/user/src/lib/stores/mcpServersAndEntries.svelte.ts
@@ -133,12 +133,12 @@ async function fetchData(forceRefresh = false) {
 	}
 }
 
-function refreshAll() {
-	fetchData(true);
+async function refreshAll() {
+	await fetchData(true);
 }
 
-function initialize(forceRefresh = false) {
-	fetchData(forceRefresh);
+async function initialize(forceRefresh = false) {
+	await fetchData(forceRefresh);
 }
 
 async function refreshUserConfiguredServers() {


### PR DESCRIPTION
Addresses #6134

* makes showing of loader circle just dependent on the `loading` state and appear on initial mount