### PR TITLE
fix: basic user audit logs table is hidden unless filter sidebar is open

### DIFF
--- a/ui/user/src/routes/audit-logs/+page.svelte
+++ b/ui/user/src/routes/audit-logs/+page.svelte
@@ -27,3 +27,7 @@
 		</div>
 	</div>
 </Layout>
+
+<svelte:head>
+	<title>Obot | Audit Logs</title>
+</svelte:head>


### PR DESCRIPTION
Addresses #6104