### PR TITLE
feat: user impersonation

### DIFF
--- a/apiclient/types/user.go
+++ b/apiclient/types/user.go
@@ -9,8 +9,9 @@ package types
 //   - RolePowerUserPlus (64): Enhanced power user with ACL and MCP server management
 //   - RolePowerUser (128): Standard power user with workspace
 //
-// Orthogonal role:
+// Orthogonal roles:
 //   - RoleAuditor (32): Can view audit logs and sensitive data (can be combined with any base role)
+//   - RoleUserImpersonation (256): Can connect to other users' MCP servers (must be explicitly assigned)
 //
 // Examples of combined roles:
 //   - RoleAdmin | RoleAuditor (48): Admin with audit access
@@ -25,17 +26,19 @@ const (
 	RoleAuditor
 	RolePowerUserPlus
 	RolePowerUser
+	RoleUserImpersonation
 
 	RoleUnknown Role = 0
 
-	GroupOwner         = "owner"
-	GroupAdmin         = "admin"
-	GroupAuditor       = "auditor"
-	GroupPowerUserPlus = "power-user-plus"
-	GroupPowerUser     = "power-user"
-	GroupBasic         = "basic"
-	GroupAuthenticated = "authenticated"
-	GroupAPIKey        = "api-key" // API key users have restricted access to MCP-connect routes only
+	GroupOwner             = "owner"
+	GroupAdmin             = "admin"
+	GroupAuditor           = "auditor"
+	GroupUserImpersonation = "user-impersonation"
+	GroupPowerUserPlus     = "power-user-plus"
+	GroupPowerUser         = "power-user"
+	GroupBasic             = "basic"
+	GroupAuthenticated     = "authenticated"
+	GroupAPIKey            = "api-key" // API key users have restricted access to MCP-connect routes only
 )
 
 type Role int
@@ -64,17 +67,21 @@ func (u Role) IsExactBaseRole(role Role) bool {
 }
 
 func (u Role) SwitchBaseRole(role Role) Role {
-	return role | (u & RoleAuditor)
+	return role | (u & (RoleAuditor | RoleUserImpersonation))
 }
 
-// ExtractBaseRole removes the Auditor flag from a role to get the base role
+// ExtractBaseRole removes orthogonal role flags to get the base role
 func (u Role) ExtractBaseRole() Role {
-	return u &^ RoleAuditor
+	return u &^ (RoleAuditor | RoleUserImpersonation)
 }
 
 // HasAuditorRole checks if the Auditor flag is set in the role
 func (u Role) HasAuditorRole() bool {
 	return u&RoleAuditor != 0
+}
+
+func (u Role) HasUserImpersonationRole() bool {
+	return u&RoleUserImpersonation != 0
 }
 
 func (u Role) Groups() []string {
@@ -96,6 +103,9 @@ func (u Role) Groups() []string {
 	}
 	if u.HasRole(RoleAuditor) {
 		groups = append(groups, GroupAuditor)
+	}
+	if u.HasRole(RoleUserImpersonation) {
+		groups = append(groups, GroupUserImpersonation)
 	}
 	if u != RoleUnknown {
 		groups = append(groups, GroupAuthenticated)

--- a/apiclient/types/user_test.go
+++ b/apiclient/types/user_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -18,6 +19,10 @@ func TestExtractBaseRole(t *testing.T) {
 		{"PowerUser with Auditor", RolePowerUser | RoleAuditor, RolePowerUser},
 		{"Owner and Admin", RoleOwner | RoleAdmin, RoleOwner | RoleAdmin},
 		{"Owner and Admin with Auditor", RoleOwner | RoleAdmin | RoleAuditor, RoleOwner | RoleAdmin},
+		{"Admin with User Impersonation", RoleAdmin | RoleUserImpersonation, RoleAdmin},
+		{"Owner with User Impersonation", RoleOwner | RoleUserImpersonation, RoleOwner},
+		{"User Impersonation only", RoleUserImpersonation, 0},
+		{"Owner and Admin with Auditor and User Impersonation", RoleOwner | RoleAdmin | RoleAuditor | RoleUserImpersonation, RoleOwner | RoleAdmin},
 	}
 
 	for _, tt := range tests {
@@ -25,6 +30,32 @@ func TestExtractBaseRole(t *testing.T) {
 			result := tt.role.ExtractBaseRole()
 			if result != tt.expected {
 				t.Errorf("extractBaseRole(%d) = %d, want %d", tt.role, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasUserImpersonationRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     Role
+		expected bool
+	}{
+		{"Admin only", RoleAdmin, false},
+		{"Admin with User Impersonation", RoleAdmin | RoleUserImpersonation, true},
+		{"User Impersonation only", RoleUserImpersonation, true},
+		{"Owner only", RoleOwner, false},
+		{"Owner with User Impersonation", RoleOwner | RoleUserImpersonation, true},
+		{"PowerUser only", RolePowerUser, false},
+		{"Owner and Admin", RoleOwner | RoleAdmin, false},
+		{"Owner and Admin with User Impersonation", RoleOwner | RoleAdmin | RoleUserImpersonation, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.role.HasUserImpersonationRole()
+			if result != tt.expected {
+				t.Errorf("hasUserImpersonationRole(%d) = %v, want %v", tt.role, result, tt.expected)
 			}
 		})
 	}
@@ -51,6 +82,153 @@ func TestHasAuditorRole(t *testing.T) {
 			result := tt.role.HasAuditorRole()
 			if result != tt.expected {
 				t.Errorf("hasAuditorRole(%d) = %v, want %v", tt.role, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSwitchBaseRole(t *testing.T) {
+	tests := []struct {
+		name        string
+		currentRole Role
+		newBaseRole Role
+		expected    Role
+	}{
+		{"Switch base role preserves Auditor", RoleAdmin | RoleAuditor, RolePowerUser, RolePowerUser | RoleAuditor},
+		{"Switch base role preserves User Impersonation", RoleOwner | RoleUserImpersonation, RoleAdmin, RoleAdmin | RoleUserImpersonation},
+		{"Switch base role preserves both add-ons", RoleOwner | RoleAuditor | RoleUserImpersonation, RoleAdmin, RoleAdmin | RoleAuditor | RoleUserImpersonation},
+		{"Switch base role with no add-ons", RoleOwner, RoleAdmin, RoleAdmin},
+		{"Switch from basic to admin no add-ons", RoleBasic, RoleAdmin, RoleAdmin},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.currentRole.SwitchBaseRole(tt.newBaseRole)
+			if result != tt.expected {
+				t.Errorf("SwitchBaseRole(%d, %d) = %d, want %d", tt.currentRole, tt.newBaseRole, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGroups(t *testing.T) {
+	tests := []struct {
+		name           string
+		role           Role
+		expectContains []string
+		expectMissing  []string
+	}{
+		{
+			"Owner gets owner, admin, power user groups",
+			RoleOwner,
+			[]string{GroupOwner, GroupAdmin, GroupPowerUserPlus, GroupPowerUser, GroupBasic, GroupAuthenticated},
+			[]string{GroupAuditor, GroupUserImpersonation},
+		},
+		{
+			"Admin with Auditor",
+			RoleAdmin | RoleAuditor,
+			[]string{GroupAdmin, GroupAuditor, GroupAuthenticated},
+			[]string{GroupOwner, GroupUserImpersonation},
+		},
+		{
+			"Admin with User Impersonation",
+			RoleAdmin | RoleUserImpersonation,
+			[]string{GroupAdmin, GroupUserImpersonation, GroupAuthenticated},
+			[]string{GroupOwner, GroupAuditor},
+		},
+		{
+			"Owner with all add-ons",
+			RoleOwner | RoleAuditor | RoleUserImpersonation,
+			[]string{GroupOwner, GroupAdmin, GroupAuditor, GroupUserImpersonation, GroupAuthenticated},
+			nil,
+		},
+		{
+			"Unknown role gets no groups",
+			RoleUnknown,
+			nil,
+			[]string{GroupOwner, GroupAdmin, GroupAuditor, GroupUserImpersonation, GroupAuthenticated},
+		},
+		{
+			"User Impersonation alone gets authenticated",
+			RoleUserImpersonation,
+			[]string{GroupUserImpersonation, GroupAuthenticated},
+			[]string{GroupOwner, GroupAdmin, GroupAuditor, GroupBasic},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups := tt.role.Groups()
+			for _, expected := range tt.expectContains {
+				if !slices.Contains(groups, expected) {
+					t.Errorf("Groups(%d) missing expected group %q, got %v", tt.role, expected, groups)
+				}
+			}
+			for _, unexpected := range tt.expectMissing {
+				if slices.Contains(groups, unexpected) {
+					t.Errorf("Groups(%d) unexpectedly contains group %q, got %v", tt.role, unexpected, groups)
+				}
+			}
+		})
+	}
+}
+
+func TestRoleValues(t *testing.T) {
+	// Verify role bit values are correct powers of 2 and don't overlap
+	roles := []struct {
+		name  string
+		role  Role
+		value int
+	}{
+		{"RoleBasic", RoleBasic, 4},
+		{"RoleOwner", RoleOwner, 8},
+		{"RoleAdmin", RoleAdmin, 16},
+		{"RoleAuditor", RoleAuditor, 32},
+		{"RolePowerUserPlus", RolePowerUserPlus, 64},
+		{"RolePowerUser", RolePowerUser, 128},
+		{"RoleUserImpersonation", RoleUserImpersonation, 256},
+	}
+
+	for _, r := range roles {
+		t.Run(r.name, func(t *testing.T) {
+			if int(r.role) != r.value {
+				t.Errorf("%s = %d, want %d", r.name, r.role, r.value)
+			}
+		})
+	}
+
+	// Verify no two roles share the same bit
+	seen := make(map[Role]string)
+	for _, r := range roles {
+		if existing, ok := seen[r.role]; ok {
+			t.Errorf("%s and %s have the same value %d", r.name, existing, r.role)
+		}
+		seen[r.role] = r.name
+	}
+}
+
+func TestHasRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     Role
+		check    Role
+		expected bool
+	}{
+		{"Owner has Admin", RoleOwner, RoleAdmin, true},
+		{"Owner has Basic", RoleOwner, RoleBasic, true},
+		{"Admin does not have Owner", RoleAdmin, RoleOwner, false},
+		{"Admin with UserImpersonation has Admin", RoleAdmin | RoleUserImpersonation, RoleAdmin, true},
+		{"Admin with UserImpersonation has UserImpersonation", RoleAdmin | RoleUserImpersonation, RoleUserImpersonation, true},
+		{"Admin with UserImpersonation does not have Owner", RoleAdmin | RoleUserImpersonation, RoleOwner, false},
+		{"Basic does not have UserImpersonation", RoleBasic, RoleUserImpersonation, false},
+		{"UserImpersonation alone does not have Admin", RoleUserImpersonation, RoleAdmin, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.role.HasRole(tt.check)
+			if result != tt.expected {
+				t.Errorf("Role(%d).HasRole(%d) = %v, want %v", tt.role, tt.check, result, tt.expected)
 			}
 		})
 	}

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -118,7 +118,7 @@ func (h *Handler) ensureServerIsDeployed(req api.Context) (string, bool, error) 
 		if err = req.Get(&agent, mcpServerConfig.NanobotAgentName); err != nil {
 			return "", false, fmt.Errorf("failed to get nanobot agent %q: %w", mcpServerConfig.NanobotAgentName, err)
 		}
-		if agent.Spec.UserID != req.User.GetUID() {
+		if agent.Spec.UserID != req.User.GetUID() && (!req.UserCanImpersonate() || !req.UserIsAdmin()) {
 			return "", false, types.NewErrForbidden("user is not authorized to access nanobot agent %q", mcpServerConfig.NanobotAgentName)
 		}
 	}

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -284,6 +284,10 @@ func (r *Context) UserIsAuditor() bool {
 	return slices.Contains(r.User.GetGroups(), types.GroupAuditor)
 }
 
+func (r *Context) UserCanImpersonate() bool {
+	return slices.Contains(r.User.GetGroups(), types.GroupUserImpersonation)
+}
+
 func (r *Context) UserIsPowerUser() bool {
 	return slices.Contains(r.User.GetGroups(), types.GroupPowerUser)
 }

--- a/pkg/gateway/client/grouproleassignment.go
+++ b/pkg/gateway/client/grouproleassignment.go
@@ -108,7 +108,7 @@ func (c *Client) GetGroupRoleAssignmentsForGroups(ctx context.Context, groupName
 // ResolveUserEffectiveRole computes the effective role for a user by combining:
 // 1. Individual role from users table
 // 2. Group-based roles from GroupRoleAssignments
-// Returns the highest base role plus Auditor (if present).
+// Returns the highest base role plus orthogonal add-on roles (if present).
 func (c *Client) ResolveUserEffectiveRole(ctx context.Context, user *types.User, authGroupIDs []string) (types2.Role, error) {
 	// Start with user's individual role
 	effectiveRole := user.Role
@@ -131,15 +131,16 @@ func (c *Client) ResolveUserEffectiveRole(ctx context.Context, user *types.User,
 		effectiveRole |= assignment.Role
 	}
 
-	// Normalize to keep only the highest base role + Auditor
+	// Normalize to keep only the highest base role + add-on roles
 	return normalizeToHighestRole(effectiveRole), nil
 }
 
 // normalizeToHighestRole takes a combined role bitmap and returns only the highest
-// base role (Owner > Admin > PowerUserPlus > PowerUser > Basic) plus the Auditor bit if present.
+// base role (Owner > Admin > PowerUserPlus > PowerUser > Basic) plus add-on bits if present.
 func normalizeToHighestRole(combinedRole types2.Role) types2.Role {
-	// Check if Auditor bit is set
+	// Check if add-on bits are set
 	hasAuditor := combinedRole.HasAuditorRole()
+	hasUserImpersonation := combinedRole.HasUserImpersonationRole()
 
 	// Find the highest base role in descending order of privilege
 	var highestRole types2.Role
@@ -155,9 +156,12 @@ func normalizeToHighestRole(combinedRole types2.Role) types2.Role {
 		highestRole = types2.RoleBasic
 	}
 
-	// Add Auditor bit back if it was present
+	// Add add-on bits back if they were present
 	if hasAuditor {
 		highestRole = highestRole | types2.RoleAuditor
+	}
+	if hasUserImpersonation {
+		highestRole = highestRole | types2.RoleUserImpersonation
 	}
 
 	return highestRole
@@ -231,7 +235,7 @@ func (c *Client) ResolveUserEffectiveRolesBulk(ctx context.Context, users []type
 			}
 		}
 
-		// Normalize to keep only the highest base role + Auditor
+		// Normalize to keep only the highest base role + add-on roles
 		effectiveRoles[user.ID] = normalizeToHighestRole(effectiveRole)
 	}
 

--- a/pkg/gateway/client/grouproleassignment_test.go
+++ b/pkg/gateway/client/grouproleassignment_test.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"testing"
+
+	types2 "github.com/obot-platform/obot/apiclient/types"
+)
+
+func TestNormalizeToHighestRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		combined types2.Role
+		expected types2.Role
+	}{
+		{
+			"Single Owner",
+			types2.RoleOwner,
+			types2.RoleOwner,
+		},
+		{
+			"Single Admin",
+			types2.RoleAdmin,
+			types2.RoleAdmin,
+		},
+		{
+			"Single Basic",
+			types2.RoleBasic,
+			types2.RoleBasic,
+		},
+		{
+			"Owner and Admin combined keeps Owner",
+			types2.RoleOwner | types2.RoleAdmin,
+			types2.RoleOwner,
+		},
+		{
+			"Admin and PowerUser combined keeps Admin",
+			types2.RoleAdmin | types2.RolePowerUser,
+			types2.RoleAdmin,
+		},
+		{
+			"PowerUserPlus and PowerUser keeps PowerUserPlus",
+			types2.RolePowerUserPlus | types2.RolePowerUser,
+			types2.RolePowerUserPlus,
+		},
+		{
+			"All base roles keeps Owner",
+			types2.RoleOwner | types2.RoleAdmin | types2.RolePowerUserPlus | types2.RolePowerUser | types2.RoleBasic,
+			types2.RoleOwner,
+		},
+		{
+			"Auditor preserved with Admin",
+			types2.RoleAdmin | types2.RoleAuditor,
+			types2.RoleAdmin | types2.RoleAuditor,
+		},
+		{
+			"Auditor preserved when merging Owner and Admin",
+			types2.RoleOwner | types2.RoleAdmin | types2.RoleAuditor,
+			types2.RoleOwner | types2.RoleAuditor,
+		},
+		{
+			"UserImpersonation preserved with Admin",
+			types2.RoleAdmin | types2.RoleUserImpersonation,
+			types2.RoleAdmin | types2.RoleUserImpersonation,
+		},
+		{
+			"UserImpersonation preserved when merging Owner and Admin",
+			types2.RoleOwner | types2.RoleAdmin | types2.RoleUserImpersonation,
+			types2.RoleOwner | types2.RoleUserImpersonation,
+		},
+		{
+			"Both Auditor and UserImpersonation preserved",
+			types2.RoleAdmin | types2.RoleAuditor | types2.RoleUserImpersonation,
+			types2.RoleAdmin | types2.RoleAuditor | types2.RoleUserImpersonation,
+		},
+		{
+			"All add-ons preserved when merging multiple base roles",
+			types2.RoleOwner | types2.RoleAdmin | types2.RolePowerUser | types2.RoleAuditor | types2.RoleUserImpersonation,
+			types2.RoleOwner | types2.RoleAuditor | types2.RoleUserImpersonation,
+		},
+		{
+			"Auditor alone normalizes to Basic with Auditor",
+			types2.RoleAuditor,
+			types2.RoleBasic | types2.RoleAuditor,
+		},
+		{
+			"UserImpersonation alone normalizes to Basic with UserImpersonation",
+			types2.RoleUserImpersonation,
+			types2.RoleBasic | types2.RoleUserImpersonation,
+		},
+		{
+			"Zero role normalizes to Basic",
+			0,
+			types2.RoleBasic,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeToHighestRole(tt.combined)
+			if result != tt.expected {
+				t.Errorf("normalizeToHighestRole(%d) = %d, want %d", tt.combined, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/gateway/server/grouproleassignment.go
+++ b/pkg/gateway/server/grouproleassignment.go
@@ -180,9 +180,10 @@ func (s *Server) triggerReconciliationForGroup(apiContext api.Context, groupName
 
 // validateRoleForUser checks if the requester is authorized to assign the given role
 func (s *Server) validateRoleForUser(apiContext api.Context, role types2.Role) error {
-	// Extract base role and auditor flag
+	// Extract base role and add-on role flags
 	baseRole := role.ExtractBaseRole()
 	hasAuditor := role.HasAuditorRole()
+	hasUserImpersonation := role.HasUserImpersonationRole()
 
 	// If role includes Owner, only Owners can assign it
 	if baseRole == types2.RoleOwner {
@@ -197,6 +198,22 @@ func (s *Server) validateRoleForUser(apiContext api.Context, role types2.Role) e
 		if !apiContext.UserIsOwner() {
 			pkgLog.Infof("Denied group role assignment request: requestedRole=%d reason=auditor_role_requires_owner", role)
 			return types2.NewErrHTTP(http.StatusForbidden, "only owners can assign the auditor role to groups")
+		}
+	}
+
+	// If role includes User Impersonation, only Owners can assign it and it must be combined with Owner or Admin
+	if hasUserImpersonation {
+		if !apiContext.UserIsOwner() {
+			pkgLog.Infof("Denied group role assignment request: requestedRole=%d reason=user_impersonation_role_requires_owner", role)
+			return types2.NewErrHTTP(http.StatusForbidden, "only owners can assign the user impersonation role to groups")
+		}
+
+		if baseRole != types2.RoleOwner && baseRole != types2.RoleAdmin {
+			pkgLog.Infof("Denied group role assignment request: requestedRole=%d reason=user_impersonation_can_only_be_combined_with_owner_or_admin", role)
+			return types2.NewErrBadRequest(
+				"user impersonation role can only be combined with owner (%d) or admin (%d)",
+				types2.RoleOwner, types2.RoleAdmin,
+			)
 		}
 	}
 

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -201,8 +201,16 @@ func (s *Server) updateUser(apiContext api.Context) error {
 		}
 		if originalUser.Role.HasRole(types2.RoleAuditor) != user.Role.HasRole(types2.RoleAuditor) {
 			pkgLog.Infof("Denied user role update: targetUserID=%s reason=auditor_role_change_requires_owner", userID)
-			return types2.NewErrHTTP(http.StatusForbidden, "only owner can remove admin role")
+			return types2.NewErrHTTP(http.StatusForbidden, "only owner can add or remove auditor role")
 		}
+		if originalUser.Role.HasRole(types2.RoleUserImpersonation) != user.Role.HasRole(types2.RoleUserImpersonation) {
+			pkgLog.Infof("Denied user role update: targetUserID=%s reason=user_impersonation_role_change_requires_owner", userID)
+			return types2.NewErrHTTP(http.StatusForbidden, "only owner can add or remove user impersonation role")
+		}
+	}
+
+	if user.Role.HasUserImpersonationRole() && !user.Role.HasRole(types2.RoleAdmin) && !user.Role.HasRole(types2.RoleOwner) {
+		return types2.NewErrHTTP(http.StatusBadRequest, "user impersonation role can only be combined with admin or owner")
 	}
 
 	status := http.StatusInternalServerError
@@ -290,6 +298,10 @@ func (s *Server) deleteUser(apiContext api.Context) (err error) {
 		if existingUser.Role.HasRole(types2.RoleAuditor) {
 			pkgLog.Infof("Denied user deletion: targetUserID=%s reason=auditor_delete_requires_owner", userID)
 			return types2.NewErrHTTP(http.StatusForbidden, "only owner can delete an auditor")
+		}
+		if existingUser.Role.HasRole(types2.RoleUserImpersonation) {
+			pkgLog.Infof("Denied user deletion: targetUserID=%s reason=user_impersonation_delete_requires_owner", userID)
+			return types2.NewErrHTTP(http.StatusForbidden, "only owner can delete a user with user impersonation role")
 		}
 	}
 
@@ -399,7 +411,7 @@ func (s *Server) restrictGroups(ctx context.Context, gptscriptClient *gptscript.
 func userIsBasicOrPower(u user.Info) bool {
 	for _, group := range u.GetGroups() {
 		switch group {
-		case types2.GroupPowerUserPlus, types2.GroupAuditor, types2.GroupAdmin, types2.GroupOwner:
+		case types2.GroupPowerUserPlus, types2.GroupAuditor, types2.GroupUserImpersonation, types2.GroupAdmin, types2.GroupOwner:
 			return false
 		}
 	}

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -183,7 +183,8 @@ export const Role = {
 	ADMIN: 16,
 	AUDITOR: 32,
 	POWERUSER_PLUS: 64,
-	POWERUSER: 128
+	POWERUSER: 128,
+	USER_IMPERSONATION: 256
 };
 
 export const Group = {
@@ -192,7 +193,8 @@ export const Group = {
 	POWERUSER_PLUS: 'power-user-plus',
 	POWERUSER: 'power-user',
 	USER: 'user',
-	AUDITOR: 'auditor'
+	AUDITOR: 'auditor',
+	USER_IMPERSONATION: 'user-impersonation'
 };
 
 export interface ProviderParameter {

--- a/ui/user/src/lib/utils.ts
+++ b/ui/user/src/lib/utils.ts
@@ -250,12 +250,13 @@ export function openUrl(url: string, isCtrlClick: boolean) {
 
 export const getUserRoleLabel = (role: number) => {
 	const withAuditor = role & Role.AUDITOR ? ', Auditor' : '';
-	if (role & Role.ADMIN) return 'Admin' + withAuditor;
-	if (role & Role.POWERUSER) return 'Power User' + withAuditor;
-	if (role & Role.POWERUSER_PLUS) return 'Power User Plus' + withAuditor;
-	if (role & Role.BASIC) return 'Basic User' + withAuditor;
-	if (role & Role.OWNER) return 'Owner' + withAuditor;
-	return 'Unknown' + withAuditor;
+	const withUserImpersonation = role & Role.USER_IMPERSONATION ? ', User Impersonation' : '';
+	if (role & Role.OWNER) return 'Owner' + withAuditor + withUserImpersonation;
+	if (role & Role.ADMIN) return 'Admin' + withAuditor + withUserImpersonation;
+	if (role & Role.POWERUSER) return 'Power User' + withAuditor + withUserImpersonation;
+	if (role & Role.POWERUSER_PLUS) return 'Power User Plus' + withAuditor + withUserImpersonation;
+	if (role & Role.BASIC) return 'Basic User' + withAuditor + withUserImpersonation;
+	return 'Unknown' + withAuditor + withUserImpersonation;
 };
 
 /**

--- a/ui/user/src/routes/admin/groups/+page.svelte
+++ b/ui/user/src/routes/admin/groups/+page.svelte
@@ -25,13 +25,14 @@
 	import AssignGroupRoleDialog from './AssignGroupRoleDialog.svelte';
 	import ConfirmAuditorRoleDialog from './ConfirmAuditorRoleDialog.svelte';
 	import ConfirmOwnerRoleDialog from './ConfirmOwnerRoleDialog.svelte';
+	import ConfirmUserImpersonationRoleDialog from './ConfirmUserImpersonationRoleDialog.svelte';
 	import type { GroupAssignment } from './types';
 
 	let { data } = $props();
 	let { groups, groupRoleAssignments } = $derived(data);
 
 	function getRoleId(role: number): number {
-		return role & ~Role.AUDITOR;
+		return role & ~(Role.AUDITOR | Role.USER_IMPERSONATION);
 	}
 
 	// Create a map for quick role lookups
@@ -75,6 +76,7 @@
 	let showAddAssignment = $state(false);
 	let showAssignGroupRoleDialog = $state(false);
 	let confirmAuditorAdditionToGroup = $state<GroupAssignment>();
+	let confirmUserImpersonationAdditionToGroup = $state<GroupAssignment>();
 	let confirmOwnerGroupAssignment = $state<GroupAssignment>();
 	let loading = $state(false);
 	let isAdminReadonly = $derived(profile.current.isAdminReadonly?.());
@@ -99,6 +101,7 @@
 
 			showAddAssignment = false;
 			confirmAuditorAdditionToGroup = undefined;
+			confirmUserImpersonationAdditionToGroup = undefined;
 			confirmOwnerGroupAssignment = undefined;
 
 			// Refresh data
@@ -246,6 +249,9 @@
 	onOwnerConfirm={(groupAssignment) => {
 		confirmOwnerGroupAssignment = groupAssignment;
 	}}
+	onUserImpersonationConfirm={(groupAssignment) => {
+		confirmUserImpersonationAdditionToGroup = groupAssignment;
+	}}
 	onAuditorConfirm={(groupAssignment) => {
 		confirmAuditorAdditionToGroup = groupAssignment;
 	}}
@@ -267,8 +273,41 @@
 	onOwnerConfirm={(groupAssignment) => {
 		confirmOwnerGroupAssignment = groupAssignment;
 	}}
+	onUserImpersonationConfirm={(groupAssignment) => {
+		confirmUserImpersonationAdditionToGroup = groupAssignment;
+	}}
 	onAuditorConfirm={(groupAssignment) => {
 		confirmAuditorAdditionToGroup = groupAssignment;
+	}}
+/>
+
+<ConfirmUserImpersonationRoleDialog
+	bind:groupAssignment={confirmUserImpersonationAdditionToGroup}
+	currentRole={confirmUserImpersonationAdditionToGroup
+		? (groupRoleMap[confirmUserImpersonationAdditionToGroup.group.id]?.role ?? 0)
+		: 0}
+	{loading}
+	onsuccess={(groupAssignment) => {
+		const originalRoleId = getRoleId(updatingRole?.assignment?.role || 0);
+		const newRoleId = getRoleId(groupAssignment.assignment.role);
+
+		if (newRoleId === Role.OWNER && originalRoleId !== Role.OWNER) {
+			confirmOwnerGroupAssignment = groupAssignment;
+			confirmUserImpersonationAdditionToGroup = undefined;
+			return;
+		}
+
+		updateGroupRole(groupAssignment);
+		confirmUserImpersonationAdditionToGroup = undefined;
+		updatingRole = undefined;
+	}}
+	oncancel={() => {
+		confirmUserImpersonationAdditionToGroup = undefined;
+		if (updatingRole) {
+			showAssignGroupRoleDialog = true;
+		} else {
+			showAddAssignment = true;
+		}
 	}}
 />
 

--- a/ui/user/src/routes/admin/groups/AddGroupAssignmentDialog.svelte
+++ b/ui/user/src/routes/admin/groups/AddGroupAssignmentDialog.svelte
@@ -18,6 +18,7 @@
 		onClose: () => void;
 		onConfirm: (groupAssignment: GroupAssignment) => void;
 		onAuditorConfirm: (groupAssignment: GroupAssignment) => void;
+		onUserImpersonationConfirm: (groupAssignment: GroupAssignment) => void;
 		onOwnerConfirm: (groupAssignment: GroupAssignment) => void;
 	}
 
@@ -29,6 +30,14 @@
 		return role | Role.AUDITOR;
 	}
 
+	function hasUserImpersonationFlag(role: number): boolean {
+		return (role & Role.USER_IMPERSONATION) !== 0;
+	}
+
+	function addUserImpersonationFlag(role: number): number {
+		return role | Role.USER_IMPERSONATION;
+	}
+
 	let {
 		open,
 		groups,
@@ -37,6 +46,7 @@
 		onClose,
 		onConfirm,
 		onAuditorConfirm,
+		onUserImpersonationConfirm,
 		onOwnerConfirm
 	}: Props = $props();
 
@@ -45,6 +55,7 @@
 	let selectedGroup = $state<OrgGroup | undefined>();
 	let draftRoleId = $state(0);
 	let draftHaveAuditorPrivilege = $state(false);
+	let draftHaveUserImpersonationPrivilege = $state(false);
 
 	let isSmallScreen = $derived(responsive.isMobile);
 
@@ -58,6 +69,7 @@
 		selectedGroup = undefined;
 		draftRoleId = 0;
 		draftHaveAuditorPrivilege = false;
+		draftHaveUserImpersonationPrivilege = false;
 	}
 
 	$effect(() => {
@@ -78,11 +90,13 @@
 		const existingAssignment = groupRoleMap[group.id];
 		if (existingAssignment) {
 			const role = existingAssignment.role || 0;
-			draftRoleId = role & ~Role.AUDITOR;
+			draftRoleId = role & ~(Role.AUDITOR | Role.USER_IMPERSONATION);
 			draftHaveAuditorPrivilege = hasAuditorFlag(role);
+			draftHaveUserImpersonationPrivilege = hasUserImpersonationFlag(role);
 		} else {
 			draftRoleId = 0;
 			draftHaveAuditorPrivilege = false;
+			draftHaveUserImpersonationPrivilege = false;
 		}
 	}
 
@@ -93,7 +107,13 @@
 	function handleConfirm() {
 		if (!selectedGroup) return;
 
-		const role = draftHaveAuditorPrivilege ? addAuditorFlag(draftRoleId) : draftRoleId;
+		let role = draftRoleId;
+		if (draftHaveAuditorPrivilege) {
+			role = addAuditorFlag(role);
+		}
+		if (draftHaveUserImpersonationPrivilege) {
+			role = addUserImpersonationFlag(role);
+		}
 		const result: GroupAssignment = {
 			group: selectedGroup,
 			assignment: {
@@ -107,9 +127,15 @@
 		const hadAuditorBefore = existingAssignment
 			? hasAuditorFlag(existingAssignment.role || 0)
 			: false;
+		const hadUserImpersonationBefore = existingAssignment
+			? hasUserImpersonationFlag(existingAssignment.role || 0)
+			: false;
 
-		// Auditor changed - show auditor confirmation only if they didn't have it before
-		if (draftHaveAuditorPrivilege && !hadAuditorBefore && draftRoleId !== 0) {
+		// User Impersonation changed - show confirmation only if they didn't have it before
+		if (draftHaveUserImpersonationPrivilege && !hadUserImpersonationBefore && draftRoleId !== 0) {
+			onUserImpersonationConfirm(result);
+		} else if (draftHaveAuditorPrivilege && !hadAuditorBefore && draftRoleId !== 0) {
+			// Auditor changed - show auditor confirmation only if they didn't have it before
 			onAuditorConfirm(result);
 		} else if (draftRoleId === Role.OWNER) {
 			// Changing to owner role - show owner confirmation
@@ -186,6 +212,7 @@
 			<GroupRoleForm
 				bind:roleId={draftRoleId}
 				bind:hasAuditorPrivilege={draftHaveAuditorPrivilege}
+				bind:hasUserImpersonationPrivilege={draftHaveUserImpersonationPrivilege}
 			/>
 		{:else}
 			<div class="text-on-surface1 flex h-full items-center justify-center py-12 text-sm">

--- a/ui/user/src/routes/admin/groups/AssignGroupRoleDialog.svelte
+++ b/ui/user/src/routes/admin/groups/AssignGroupRoleDialog.svelte
@@ -14,13 +14,14 @@
 		onClose: () => void;
 		onConfirm: (groupAssignment: GroupAssignment) => void;
 		onAuditorConfirm: (groupAssignment: GroupAssignment) => void;
+		onUserImpersonationConfirm: (groupAssignment: GroupAssignment) => void;
 		onOwnerConfirm: (groupAssignment: GroupAssignment) => void;
 		open?: boolean;
 	}
 
 	// Helper functions to work with roles
 	function getRoleId(role: number): number {
-		return role & ~Role.AUDITOR;
+		return role & ~(Role.AUDITOR | Role.USER_IMPERSONATION);
 	}
 
 	function hasAuditorFlag(role: number): boolean {
@@ -31,6 +32,14 @@
 		return role | Role.AUDITOR;
 	}
 
+	function hasUserImpersonationFlag(role: number): boolean {
+		return (role & Role.USER_IMPERSONATION) !== 0;
+	}
+
+	function addUserImpersonationFlag(role: number): number {
+		return role | Role.USER_IMPERSONATION;
+	}
+
 	let {
 		groupAssignment = $bindable(),
 		open,
@@ -38,6 +47,7 @@
 		onClose,
 		onConfirm,
 		onAuditorConfirm,
+		onUserImpersonationConfirm,
 		onOwnerConfirm
 	}: Props = $props();
 
@@ -45,6 +55,7 @@
 
 	let draftRoleId = $state(0);
 	let draftHaveAuditorPrivilege = $state(false);
+	let draftHaveUserImpersonationPrivilege = $state(false);
 
 	const hasRoleChanged = $derived(
 		draftRoleId !== getRoleId(groupAssignment ? groupAssignment.assignment.role : 0)
@@ -55,8 +66,13 @@
 			draftHaveAuditorPrivilege
 	);
 
+	const hasUserImpersonationChanged = $derived(
+		hasUserImpersonationFlag(groupAssignment ? groupAssignment.assignment.role : 0) !==
+			draftHaveUserImpersonationPrivilege
+	);
+
 	// Check if any changes were made
-	const hasChanges = $derived(hasRoleChanged || hasAuditorChanged);
+	const hasChanges = $derived(hasRoleChanged || hasAuditorChanged || hasUserImpersonationChanged);
 
 	$effect(() => {
 		if (groupAssignment) {
@@ -64,6 +80,7 @@
 			const role = groupAssignment.assignment.role || 0;
 			draftRoleId = getRoleId(role);
 			draftHaveAuditorPrivilege = hasAuditorFlag(role);
+			draftHaveUserImpersonationPrivilege = hasUserImpersonationFlag(role);
 		}
 	});
 
@@ -82,7 +99,13 @@
 	function handleConfirm() {
 		if (!groupAssignment) return;
 
-		const role = draftHaveAuditorPrivilege ? addAuditorFlag(draftRoleId) : draftRoleId;
+		let role = draftRoleId;
+		if (draftHaveAuditorPrivilege) {
+			role = addAuditorFlag(role);
+		}
+		if (draftHaveUserImpersonationPrivilege) {
+			role = addUserImpersonationFlag(role);
+		}
 		const result: GroupAssignment = {
 			group: groupAssignment.group,
 			assignment: {
@@ -92,7 +115,10 @@
 		};
 
 		const currentRoleId = getRoleId(groupAssignment.assignment.role || 0);
-		if (hasAuditorChanged && draftHaveAuditorPrivilege && draftRoleId !== 0) {
+		if (hasUserImpersonationChanged && draftHaveUserImpersonationPrivilege && draftRoleId !== 0) {
+			// User Impersonation changed - show confirmation
+			onUserImpersonationConfirm(result);
+		} else if (hasAuditorChanged && draftHaveAuditorPrivilege && draftRoleId !== 0) {
 			// Auditor changed - show auditor confirmation
 			onAuditorConfirm(result);
 		} else if (draftRoleId === Role.OWNER && currentRoleId !== Role.OWNER) {
@@ -144,6 +170,7 @@
 			<GroupRoleForm
 				bind:roleId={draftRoleId}
 				bind:hasAuditorPrivilege={draftHaveAuditorPrivilege}
+				bind:hasUserImpersonationPrivilege={draftHaveUserImpersonationPrivilege}
 			/>
 		</div>
 

--- a/ui/user/src/routes/admin/groups/ConfirmAuditorRoleDialog.svelte
+++ b/ui/user/src/routes/admin/groups/ConfirmAuditorRoleDialog.svelte
@@ -13,7 +13,11 @@
 	let { groupAssignment = $bindable(), loading = false, onsuccess, oncancel }: Props = $props();
 
 	const auditorReadonlyAdminRoles = [Role.BASIC, Role.POWERUSER, Role.POWERUSER_PLUS];
-	const roleId = $derived(groupAssignment ? groupAssignment.assignment.role & ~Role.AUDITOR : 0);
+	const roleId = $derived(
+		groupAssignment
+			? groupAssignment.assignment.role & ~(Role.AUDITOR | Role.USER_IMPERSONATION)
+			: 0
+	);
 </script>
 
 <Confirm

--- a/ui/user/src/routes/admin/groups/ConfirmUserImpersonationRoleDialog.svelte
+++ b/ui/user/src/routes/admin/groups/ConfirmUserImpersonationRoleDialog.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import Confirm from '$lib/components/Confirm.svelte';
+	import { Role } from '$lib/services/admin/types';
+	import type { GroupAssignment } from './types';
+
+	interface Props {
+		groupAssignment?: GroupAssignment;
+		currentRole?: number;
+		loading?: boolean;
+		onsuccess: (groupAssignment: GroupAssignment) => void;
+		oncancel: () => void;
+	}
+
+	let {
+		groupAssignment = $bindable(),
+		currentRole = 0,
+		loading = false,
+		onsuccess,
+		oncancel
+	}: Props = $props();
+
+	const addingAuditor = $derived(
+		Boolean(
+			groupAssignment &&
+				(groupAssignment.assignment.role & Role.AUDITOR) !== 0 &&
+				(currentRole & Role.AUDITOR) === 0
+		)
+	);
+	const removingAuditor = $derived(
+		Boolean(
+			groupAssignment &&
+				(groupAssignment.assignment.role & Role.AUDITOR) === 0 &&
+				(currentRole & Role.AUDITOR) !== 0
+		)
+	);
+</script>
+
+<Confirm
+	title="Confirm User Impersonation Role"
+	{loading}
+	show={Boolean(groupAssignment)}
+	onsuccess={async () => {
+		if (!groupAssignment) return;
+		onsuccess(groupAssignment);
+	}}
+	{oncancel}
+	type="info"
+	msg={`Grant ${groupAssignment?.group.name} the User Impersonation role?`}
+>
+	{#snippet note()}
+		<div class="mt-4 mb-8 flex flex-col gap-4 text-center">
+			<p>
+				User Impersonation grants elevated cross-user access so members of this group can connect to
+				other users' Obot Agents.
+			</p>
+			{#if addingAuditor}
+				<p>
+					This update will also grant Auditor, which adds expanded audit visibility (including
+					request/response/header details).
+				</p>
+			{:else if removingAuditor}
+				<p>This update will remove Auditor while granting User Impersonation access.</p>
+			{/if}
+			<p>
+				Are you sure you want to grant the <b>{groupAssignment?.group.name}</b> group this role?
+			</p>
+		</div>
+	{/snippet}
+</Confirm>

--- a/ui/user/src/routes/admin/groups/GroupRoleForm.svelte
+++ b/ui/user/src/routes/admin/groups/GroupRoleForm.svelte
@@ -7,8 +7,10 @@
 	interface Props {
 		roleId: number;
 		hasAuditorPrivilege?: boolean;
+		hasUserImpersonationPrivilege?: boolean;
 		onRoleChange?: (roleId: number) => void;
 		onAuditorChange?: (hasAuditor: boolean) => void;
+		onUserImpersonationChange?: (hasUserImpersonation: boolean) => void;
 	}
 
 	interface RoleOption {
@@ -19,8 +21,10 @@
 	let {
 		roleId = $bindable(),
 		hasAuditorPrivilege = $bindable(false),
+		hasUserImpersonationPrivilege = $bindable(false),
 		onRoleChange,
-		onAuditorChange
+		onAuditorChange,
+		onUserImpersonationChange
 	}: Props = $props();
 
 	const canAssignOwner = $derived(profile.current.groups.includes(Group.OWNER));
@@ -52,6 +56,17 @@
 	function handleAuditorChange() {
 		onAuditorChange?.(hasAuditorPrivilege);
 	}
+
+	function handleUserImpersonationChange() {
+		onUserImpersonationChange?.(hasUserImpersonationPrivilege);
+	}
+
+	// Auto-clear user impersonation when base role is not Admin or Owner
+	$effect(() => {
+		if (roleId !== Role.ADMIN && roleId !== Role.OWNER) {
+			hasUserImpersonationPrivilege = false;
+		}
+	});
 </script>
 
 {#snippet roleUi(role: RoleOption)}
@@ -113,6 +128,29 @@
 						All group members will gain access to additional details such as response, request, and
 						header information in the audit logs.
 					{/if}
+				</p>
+			</div>
+		</label>
+		{@const isUserImpersonationDisabled =
+			isDisabled || (roleId !== Role.ADMIN && roleId !== Role.OWNER)}
+		<label
+			class={twMerge(
+				'border-surface3 hover:bg-background/2 active:bg-background/5 my-4 flex cursor-pointer gap-4 rounded-lg border p-3',
+				isUserImpersonationDisabled ? 'pointer-events-none opacity-50' : ''
+			)}
+			aria-disabled={isUserImpersonationDisabled}
+		>
+			<input
+				type="checkbox"
+				bind:checked={hasUserImpersonationPrivilege}
+				onchange={handleUserImpersonationChange}
+				disabled={isUserImpersonationDisabled}
+			/>
+			<div class="flex flex-col">
+				<div class="w-28 flex-shrink-0 font-semibold">User Impersonation</div>
+				<p class="text-on-surface1 text-xs">
+					All group members will be able to connect to other users' Obot Agents. Must be combined
+					with Admin or Owner.
 				</p>
 			</div>
 		</label>

--- a/ui/user/src/routes/admin/users/+page.svelte
+++ b/ui/user/src/routes/admin/users/+page.svelte
@@ -37,11 +37,13 @@
 		users
 			.map((user) => ({
 				...user,
+				assignedRole: user.role,
 				name: getUserDisplayName(user),
 				role: getUserRoleLabel(user.role).split(','),
 				effectiveRole: getUserRoleLabel(user.effectiveRole).split(','),
-				roleId: user.role & ~Role.AUDITOR,
-				auditor: user.role & Role.AUDITOR ? true : false
+				roleId: user.role & ~(Role.AUDITOR | Role.USER_IMPERSONATION),
+				auditor: user.role & Role.AUDITOR ? true : false,
+				userImpersonation: user.role & Role.USER_IMPERSONATION ? true : false
 			}))
 			.filter(
 				(user) =>
@@ -57,7 +59,9 @@
 	let deletingUser = $state<TableItem>();
 	let confirmHandoffToUser = $state<TableItem>();
 	let confirmAuditorAdditionToUser = $state<TableItem>();
+	let confirmUserImpersonationAdditionToUser = $state<TableItem>();
 	let loading = $state(false);
+	let roleUpdateError = $state('');
 	let roleOptions = $derived([
 		...(profile.current.groups.includes(Group.OWNER) ? [{ label: 'Owner', id: Role.OWNER }] : []),
 		{ label: 'Admin', id: Role.ADMIN },
@@ -70,20 +74,52 @@
 	function closeUpdateRoleDialog() {
 		updateRoleDialog?.close();
 		updatingRole = undefined;
+		roleUpdateError = '';
 	}
 
-	async function updateUserRole(userID: string, role: number, refreshUsers = true) {
+	function getErrorMessage(error: unknown): string {
+		if (error instanceof Error && error.message) {
+			return error.message;
+		}
+		return 'Failed to update user role. Please try again.';
+	}
+
+	async function updateUserRole(
+		userID: string,
+		role: number,
+		refreshUsers = true
+	): Promise<boolean> {
 		loading = true;
-		await AdminService.updateUserRole(userID, role);
-		if (refreshUsers) {
-			users = await AdminService.listUsers();
+		roleUpdateError = '';
+		try {
+			await AdminService.updateUserRole(userID, role);
+			if (refreshUsers) {
+				users = await AdminService.listUsers();
+			}
+			if (profile.current.id === userID) {
+				// update with the role change
+				profile.current = await ChatService.getProfile();
+			}
+			closeUpdateRoleDialog();
+			return true;
+		} catch (error) {
+			roleUpdateError = getErrorMessage(error);
+			updateRoleDialog?.open();
+			return false;
+		} finally {
+			loading = false;
 		}
-		if (profile.current.id === userID) {
-			// update with the role change
-			profile.current = await ChatService.getProfile();
+	}
+
+	function composeRole(roleId: number, auditor: boolean, userImpersonation: boolean): number {
+		let role = roleId;
+		if (auditor) {
+			role |= Role.AUDITOR;
 		}
-		loading = false;
-		closeUpdateRoleDialog();
+		if (userImpersonation) {
+			role |= Role.USER_IMPERSONATION;
+		}
+		return role;
 	}
 
 	function getUserDisplayName(user: OrgUser): string {
@@ -116,6 +152,27 @@
 
 	const duration = PAGE_TRANSITION_DURATION;
 	const auditorReadonlyAdminRoles = [Role.BASIC, Role.POWERUSER, Role.POWERUSER_PLUS];
+	const isAddingAuditorWithUserImpersonation = $derived(
+		Boolean(
+			confirmUserImpersonationAdditionToUser &&
+				confirmUserImpersonationAdditionToUser.auditor &&
+				(confirmUserImpersonationAdditionToUser.assignedRole & Role.AUDITOR) === 0
+		)
+	);
+	const isRemovingAuditorWithUserImpersonation = $derived(
+		Boolean(
+			confirmUserImpersonationAdditionToUser &&
+				!confirmUserImpersonationAdditionToUser.auditor &&
+				(confirmUserImpersonationAdditionToUser.assignedRole & Role.AUDITOR) !== 0
+		)
+	);
+
+	// Auto-clear user impersonation when base role is not Admin or Owner
+	$effect(() => {
+		if (updatingRole && updatingRole.roleId !== Role.ADMIN && updatingRole.roleId !== Role.OWNER) {
+			updatingRole.userImpersonation = false;
+		}
+	});
 </script>
 
 <Layout title="Users">
@@ -231,6 +288,9 @@
 			{} as Record<number, string>
 		)}
 		<div class="m-4 flex flex-col gap-2 text-sm font-light">
+			{#if roleUpdateError}
+				<div class="notification-error mb-2 p-3 text-sm font-light">{roleUpdateError}</div>
+			{/if}
 			{#if updatingRole.explicitRole}
 				<div class="notification-info mb-2 p-3 text-sm font-light">
 					<div class="flex items-center gap-3">
@@ -264,7 +324,7 @@
 			{/each}
 
 			{#if profile.current.groups.includes(Group.OWNER)}
-				<label class="my-4 flex gap-4">
+				<label class="mt-4 flex gap-4">
 					<input type="checkbox" bind:checked={updatingRole.auditor} />
 					<span class="flex flex-col">
 						<p class="w-28 flex-shrink-0 font-semibold">Auditor</p>
@@ -281,6 +341,24 @@
 						{/if}
 					</span>
 				</label>
+				<label class="mt-2 flex gap-4">
+					<input
+						type="checkbox"
+						bind:checked={updatingRole.userImpersonation}
+						disabled={updatingRole.roleId !== Role.ADMIN && updatingRole.roleId !== Role.OWNER}
+					/>
+					<span
+						class="flex flex-col"
+						class:opacity-50={updatingRole.roleId !== Role.ADMIN &&
+							updatingRole.roleId !== Role.OWNER}
+					>
+						<p class="flex-shrink-0 font-semibold">User Impersonation</p>
+						<p class="text-on-surface1">
+							Will be able to connect to other users' Obot Agents. Requires Admin or Owner base
+							role.
+						</p>
+					</span>
+				</label>
 			{/if}
 		</div>
 		<div class="flex grow"></div>
@@ -290,13 +368,25 @@
 				class="button-primary"
 				onclick={async () => {
 					if (!updatingRole) return;
+					roleUpdateError = '';
+					const addingUserImpersonation =
+						updatingRole.userImpersonation &&
+						(updatingRole.assignedRole & Role.USER_IMPERSONATION) === 0;
+					const addingAuditor =
+						updatingRole.auditor && (updatingRole.assignedRole & Role.AUDITOR) === 0;
 					if (profile.current.isBootstrapUser?.() && updatingRole.roleId === Role.OWNER) {
 						updateRoleDialog?.close();
 						confirmHandoffToUser = updatingRole;
 						return;
 					}
 
-					if (updatingRole.auditor) {
+					if (addingUserImpersonation) {
+						updateRoleDialog?.close();
+						confirmUserImpersonationAdditionToUser = updatingRole;
+						return;
+					}
+
+					if (addingAuditor) {
 						updateRoleDialog?.close();
 						confirmAuditorAdditionToUser = updatingRole;
 						return;
@@ -304,7 +394,7 @@
 
 					updateUserRole(
 						updatingRole.id,
-						updatingRole.auditor ? updatingRole.roleId | Role.AUDITOR : updatingRole.roleId
+						composeRole(updatingRole.roleId, updatingRole.auditor, updatingRole.userImpersonation)
 					);
 				}}
 				disabled={loading}
@@ -324,13 +414,19 @@
 	{loading}
 	onsuccess={async () => {
 		if (!confirmHandoffToUser) return;
-		await updateUserRole(
+		const ok = await updateUserRole(
 			confirmHandoffToUser.id,
-			confirmHandoffToUser.auditor
-				? confirmHandoffToUser.roleId | Role.AUDITOR
-				: confirmHandoffToUser.roleId,
+			composeRole(
+				confirmHandoffToUser.roleId,
+				confirmHandoffToUser.auditor,
+				confirmHandoffToUser.userImpersonation
+			),
 			false
 		);
+		if (!ok) {
+			confirmHandoffToUser = undefined;
+			return;
+		}
 		await AdminService.bootstrapLogout();
 		window.location.href = '/oauth2/sign_out?rd=/admin';
 		confirmHandoffToUser = undefined;
@@ -359,6 +455,62 @@
 
 <Confirm
 	type="info"
+	title={isAddingAuditorWithUserImpersonation
+		? 'Confirm User Impersonation + Auditor Roles'
+		: 'Confirm User Impersonation Role'}
+	msg={isAddingAuditorWithUserImpersonation
+		? `Grant ${confirmUserImpersonationAdditionToUser?.email || confirmUserImpersonationAdditionToUser?.name} the User Impersonation and Auditor roles?`
+		: `Grant ${confirmUserImpersonationAdditionToUser?.email || confirmUserImpersonationAdditionToUser?.name} the User Impersonation role?`}
+	{loading}
+	show={Boolean(confirmUserImpersonationAdditionToUser)}
+	onsuccess={async () => {
+		if (!confirmUserImpersonationAdditionToUser) return;
+		await updateUserRole(
+			confirmUserImpersonationAdditionToUser.id,
+			composeRole(
+				confirmUserImpersonationAdditionToUser.roleId,
+				confirmUserImpersonationAdditionToUser.auditor,
+				true
+			)
+		);
+		confirmUserImpersonationAdditionToUser = undefined;
+	}}
+	oncancel={() => {
+		confirmUserImpersonationAdditionToUser = undefined;
+		updateRoleDialog?.open();
+	}}
+>
+	{#snippet note()}
+		<div class="flex flex-col gap-4">
+			<p class="text-left">
+				User Impersonation allows connecting to other users' Obot Agents. This is elevated
+				cross-user access and should be granted sparingly.
+			</p>
+			{#if isAddingAuditorWithUserImpersonation}
+				<p class="text-left">
+					This update will also grant Auditor, which adds expanded audit visibility (including
+					request/response/header details).
+				</p>
+			{:else if isRemovingAuditorWithUserImpersonation}
+				<p class="text-left">
+					This update will remove Auditor while granting User Impersonation access.
+				</p>
+			{:else}
+				<p class="text-left">This update does not modify the Auditor role.</p>
+			{/if}
+			<p>
+				Are you sure you want to grant <b
+					>{confirmUserImpersonationAdditionToUser?.email ||
+						confirmUserImpersonationAdditionToUser?.name}</b
+				>
+				{isAddingAuditorWithUserImpersonation ? 'these roles' : 'this role'}?
+			</p>
+		</div>
+	{/snippet}
+</Confirm>
+
+<Confirm
+	type="info"
 	title="Confirm Auditor Role"
 	msg={`Grant ${confirmAuditorAdditionToUser?.email || confirmAuditorAdditionToUser?.name} the Auditor role?`}
 	{loading}
@@ -367,11 +519,18 @@
 		if (!confirmAuditorAdditionToUser) return;
 		await updateUserRole(
 			confirmAuditorAdditionToUser.id,
-			confirmAuditorAdditionToUser.roleId | Role.AUDITOR
+			composeRole(
+				confirmAuditorAdditionToUser.roleId,
+				true,
+				confirmAuditorAdditionToUser.userImpersonation
+			)
 		);
 		confirmAuditorAdditionToUser = undefined;
 	}}
-	oncancel={() => (confirmAuditorAdditionToUser = undefined)}
+	oncancel={() => {
+		confirmAuditorAdditionToUser = undefined;
+		updateRoleDialog?.open();
+	}}
 >
 	{#snippet note()}
 		<div class="flex flex-col gap-4">


### PR DESCRIPTION
This adds a new User Impersonation orthogonal role that can be attached only to Admins and Owners, and allows them to connect to other users' Nanobot Agents.

This change does introduce the UI needed in order to add the role to users. It does not introduce the UI needed to allow users to easily view other users' Agents. That will come in a follow-up.