### PR TITLE
Fix error handling for oauth not found

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -17,6 +17,7 @@ import (
 	"github.com/obot-platform/obot/pkg/auth"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,6 +34,7 @@ const (
 	ErrServerError             ErrorCode = "server_error"
 	ErrTemporarilyUnavailable  ErrorCode = "temporarily_unavailable"
 	ErrInvalidClientMetadata   ErrorCode = "invalid_client_metadata"
+	ErrInvalidClient           ErrorCode = "invalid_client"
 )
 
 // Error represents an OAuth 2.0 error response.
@@ -123,6 +125,13 @@ func (h *handler) authorize(req api.Context) error {
 
 	var oauthClient v1.OAuthClient
 	if err := req.Storage.Get(req.Context(), kclient.ObjectKey{Namespace: clientNamespace, Name: clientName}, &oauthClient); err != nil {
+		if apierrors.IsNotFound(err) {
+			return types.NewErrHTTP(http.StatusUnauthorized, Error{
+				Code:        ErrInvalidClient,
+				Description: "client not found, re-registration required",
+				State:       state,
+			}.Error())
+		}
 		return err
 	}
 

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -21,6 +21,7 @@ import (
 	"github.com/obot-platform/obot/pkg/storage/selectors"
 	"github.com/obot-platform/obot/pkg/system"
 	"golang.org/x/crypto/bcrypt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,6 +100,12 @@ func (h *handler) token(req api.Context) error {
 
 	var client v1.OAuthClient
 	if err := req.Storage.Get(req.Context(), kclient.ObjectKey{Namespace: clientNamespace, Name: clientName}, &client); err != nil {
+		if apierrors.IsNotFound(err) {
+			return types.NewErrHTTP(http.StatusUnauthorized, Error{
+				Code:        ErrInvalidClient,
+				Description: "client not found, re-registration required",
+			}.Error())
+		}
 		return err
 	}
 


### PR DESCRIPTION
## Summary

When an MCP OAuth client is not found in the authorize or token endpoints, the server previously propagated the raw storage error instead of returning a proper OAuth error response. This fix handles the not-found case explicitly in both endpoints.

Per [RFC 6749 §5.2](https://www.rfc-editor.org/rfc/rfc6749#section-5.2), when client authentication fails the server must respond with HTTP 401 and an `invalid_client` error. A missing client — which can occur when a previously registered client has been removed — is an authentication failure and should follow this same contract, with a description hinting that re-registration is required.

### Changes

- Added `ErrInvalidClient` error code constant to the OAuth error type set
- In `authorize`: detect `IsNotFound` on client lookup and return `HTTP 401 / invalid_client`
- In `token`: same fix for the token endpoint client lookup

## Testing/Reproducing
1. Run Obot and initialize an MCP server
2. Connect a client to this server and run some requests to make sure it works
3. Delete the `obot.db`
4. Restart Obot and re-create the MCP server
5. Rerun the MCP request from client
    - You should see an error like this open in web browser:
    ```
    OAuthClient.obot.obot.ai "oc1553gmyab6zeqbjuy2a5y542mg2" not found
    ```
6. Checkout this branch and re-run Obot
7. Try the client request again which will now re-register and succeed