### PR TITLE
fix: clear stale search query on admin mcp-servers page when returning from external route

### DIFF
--- a/ui/user/src/routes/admin/mcp-servers/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/+page.svelte
@@ -105,6 +105,11 @@
 				return;
 			}
 
+			// If coming from outside /admin/mcp-servers, clear stale search queries
+			if (!from?.url?.pathname.startsWith('/admin/mcp-servers')) {
+				clearQueryFromLocalStorage();
+			}
+
 			const createNewType = page.url.searchParams.get('new') as LaunchServerType;
 			if (createNewType) {
 				selectServerType(createNewType, false);


### PR DESCRIPTION
Addresses #6157

## Summary

- When a user searches on `/admin/mcp-servers`, clicks into a detail page, navigates to a completely different route (e.g. `/agent`), then returns to `/admin/mcp-servers`, the search results were showing the previous search term even though the search bar appeared empty.
- The `beforeNavigate` hook that clears localStorage only fires from the `/admin/mcp-servers` page itself — it never fires when the user leaves via a detail sub-route (`/admin/mcp-servers/c/...`), so the stale query persisted.
- Fix: added a check in `afterNavigate` to clear saved search queries from localStorage when arriving from outside `/admin/mcp-servers`.

## Test plan

- [ ] Search for a term (e.g. "google") on `/admin/mcp-servers`
- [ ] Click into a server detail page
- [ ] Navigate to a different section (e.g. `/agent`)
- [ ] Navigate back to `/admin/mcp-servers`
- [ ] Verify the search bar is empty and default results are shown (not the previous search results)