### PR TITLE
fix: retain multi-user servers when an admin is deleted

### DIFF
--- a/pkg/controller/handlers/cleanup/user.go
+++ b/pkg/controller/handlers/cleanup/user.go
@@ -87,8 +87,7 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 	deletedServers := 0
 	for _, server := range servers.Items {
 		// Skip multi-user servers in the default MCPCatalog — they should persist after user deletion.
-		// Servers in a PowerUserWorkspace should still be deleted.
-		if server.Spec.MCPCatalogID == system.DefaultCatalog && server.Spec.PowerUserWorkspaceID == "" {
+		if server.Spec.MCPCatalogID == system.DefaultCatalog {
 			continue
 		}
 		if err := kclient.IgnoreNotFound(req.Delete(&server)); err != nil {


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5848

The user ID of the admin who creates a multi-user server in the default catalog gets put on the MCPServer for it, which was getting deleted if the admin ever got deleted. This fixes that by retaining it.

Multi-user servers created by PUPs in their PowerUserWorkspace are still deleted if they are deleted.