### PR TITLE
fix: propagate  container port for webhook containers

### DIFF
--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -777,6 +777,7 @@ func (d *dockerBackend) buildServerConfig(server ServerConfig, c *container.Summ
 
 	return ServerConfig{
 		URL:                       url,
+		ContainerPort:             containerPort,
 		MCPServerNamespace:        server.MCPServerNamespace,
 		MCPServerName:             server.MCPServerName,
 		MCPServerDisplayName:      server.MCPServerDisplayName,


### PR DESCRIPTION
By passing the container port when building the configuration, we ensure that the URL passed to the nanobot shim has the correct port when connecting to the webhook container.

Issue: https://github.com/obot-platform/obot/issues/5925