### PR TITLE
chore: bump obot-mcp-server image to v0.1.1

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -192,8 +192,8 @@ config:
   # config.OBOT_ARTIFACT_AZURE_CLIENT_SECRET -- Azure client secret for published workflow storage when using explicit Azure credentials.
   OBOT_ARTIFACT_AZURE_CLIENT_SECRET: ""
 
-  # config.OBOT_SERVER_MCPSERVER_SEARCH_IMAGE -- The container image to use for the MCP server search functionality. Defaults to ghcr.io/obot-platform/obot-mcp-server:v0.1.0
-  OBOT_SERVER_MCPSERVER_SEARCH_IMAGE: ghcr.io/obot-platform/obot-mcp-server:v0.1.0
+  # config.OBOT_SERVER_MCPSERVER_SEARCH_IMAGE -- The container image to use for the MCP server search functionality. Defaults to ghcr.io/obot-platform/obot-mcp-server:v0.1.1
+  OBOT_SERVER_MCPSERVER_SEARCH_IMAGE: ghcr.io/obot-platform/obot-mcp-server:v0.1.1
 
   # config.OBOT_DEFAULT_SKILL_REPO_URL -- The default skill repository URL. Must be a full HTTPS GitHub URL. Defaults to https://github.com/obot-platform/skills. Only used on first-time setup (before the first owner user is created). Set to an empty string to disable.
   # OBOT_DEFAULT_SKILL_REPO_URL: ""

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -124,7 +124,7 @@ type Config struct {
 	DisableLegacyChat       bool   `usage:"Disable legacy chat" default:"true"`
 	NanobotIntegration      bool   `usage:"Enable Nanobot integration" default:"true"`
 	EnableMessagePolicies   bool   `usage:"Enable message policies for LLM proxy content enforcement" default:"false"`
-	MCPServerSearchImage    string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.1.0"`
+	MCPServerSearchImage    string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.1.1"`
 	NanobotAgentImage       string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/nanobot-ai/nanobot-agent:v0.0.61"`
 
 	// Published artifact storage


### PR DESCRIPTION
This pickups a fix for connecting to multi-user MCP servers in the agent.

Issue: https://github.com/obot-platform/obot/issues/6189