### PR TITLE
fix: message policies: only evaluate the last user message

### DIFF
--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -926,7 +926,7 @@ func (l *llmProviderProxy) proxy(req api.Context) error {
 					// last message in the conversation. If there are messages after it
 					// (assistant responses, tool results, etc.), this is a tool-calling
 					// continuation and the user text has already been evaluated.
-					if lastUserIdx >= 0 && lastUserIdx == len(rawMessages)-1 {
+					if lastUserIdx == len(rawMessages)-1 {
 						violations := l.messagePolicyHelper.EvaluateMessage(req.Context(), inputPolicies, history, lastUserMsg, types2.PolicyDirectionUserMessage)
 						if len(violations) > 0 {
 							var explanations []string


### PR DESCRIPTION
This fixes a bug. Prior to these changes, if the user sent one message that then resulted in a chain of tool calls, their initial message would be re-evaluated against the message policies on every single turn with the model. This is bad, as we only want it to be evaluated once, when the user first sends it. It's an oversight in the initial implementation, and this fixes it by only evaluating if the last user message is also the last message in the thread.