### PR TITLE
fix: set non-agent env vars to empty string for agents

### DIFF
--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -480,6 +480,23 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 		secretEnvStringData["NANOBOT_RUN_AUDIT_LOG_BATCH_SIZE"] = strconv.Itoa(k.auditLogsBatchSize)
 		secretEnvStringData["NANOBOT_RUN_AUDIT_LOG_FLUSH_INTERVAL_SECONDS"] = strconv.Itoa(k.auditLogsFlushIntervalSeconds)
 		secretEnvStringData["NANOBOT_RUN_AUDIT_LOG_METADATA"] = server.AuditLogMetadata
+	} else {
+		secretEnvStringData["NANOBOT_RUN_OAUTH_SCOPES"] = ""
+		secretEnvStringData["NANOBOT_RUN_TRUSTED_ISSUER"] = ""
+		secretEnvStringData["NANOBOT_RUN_OAUTH_JWKSURL"] = ""
+		secretEnvStringData["NANOBOT_RUN_TRUSTED_AUDIENCES"] = ""
+		secretEnvStringData["NANOBOT_RUN_OAUTH_CLIENT_ID"] = ""
+		secretEnvStringData["NANOBOT_RUN_OAUTH_CLIENT_SECRET"] = ""
+		secretEnvStringData["NANOBOT_RUN_OAUTH_TOKEN_URL"] = ""
+		secretEnvStringData["NANOBOT_RUN_OAUTH_AUTHORIZE_URL"] = ""
+		secretEnvStringData["NANOBOT_DISABLE_HEALTH_CHECKER"] = ""
+		secretEnvStringData["NANOBOT_RUN_APIKEY_AUTH_WEBHOOK_URL"] = ""
+		secretEnvStringData["NANOBOT_RUN_MCPSERVER_ID"] = ""
+		secretEnvStringData["NANOBOT_RUN_AUDIT_LOG_TOKEN"] = ""
+		secretEnvStringData["NANOBOT_RUN_AUDIT_LOG_SEND_URL"] = ""
+		secretEnvStringData["NANOBOT_RUN_AUDIT_LOG_BATCH_SIZE"] = ""
+		secretEnvStringData["NANOBOT_RUN_AUDIT_LOG_FLUSH_INTERVAL_SECONDS"] = ""
+		secretEnvStringData["NANOBOT_RUN_AUDIT_LOG_METADATA"] = ""
 	}
 
 	if server.NanobotAgentName != "" {

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -178,6 +178,60 @@ func TestK8sObjects_NanobotAgentExcludesAuditLogConfig(t *testing.T) {
 	assertNoAuditLogEnv(t, configSecret.StringData)
 }
 
+func TestK8sObjects_NanobotAgentExplicitlyClearsOAuthEnv(t *testing.T) {
+	k := newTestKubernetesBackend(t)
+
+	objs, err := k.k8sObjects(context.Background(), ServerConfig{
+		Runtime:              types.RuntimeContainerized,
+		MCPServerName:        "nanobot-agent-server",
+		MCPServerDisplayName: "Nanobot Agent Server",
+		UserID:               "user-1",
+		OwnerUserID:          "user-2",
+		ContainerImage:       "ghcr.io/nanobot-ai/nanobot:latest",
+		ContainerPort:        8080,
+		ContainerPath:        "/mcp",
+		Command:              "nanobot",
+		Args:                 []string{"run"},
+		NanobotAgentName:     "agent-1",
+	}, nil)
+	if err != nil {
+		t.Fatalf("k8sObjects() error = %v", err)
+	}
+
+	configSecret := findSecret(t, objs, name.SafeConcatName("nanobot-agent-server", "config"))
+
+	// These keys must be present (so that a strategic merge patch will overwrite
+	// any stale values left in the Secret's Data field) but their values must be
+	// empty for nanobot-agent-backed servers.
+	mustBeEmpty := []string{
+		"NANOBOT_RUN_OAUTH_SCOPES",
+		"NANOBOT_RUN_TRUSTED_ISSUER",
+		"NANOBOT_RUN_OAUTH_JWKSURL",
+		"NANOBOT_RUN_TRUSTED_AUDIENCES",
+		"NANOBOT_RUN_OAUTH_CLIENT_ID",
+		"NANOBOT_RUN_OAUTH_CLIENT_SECRET",
+		"NANOBOT_RUN_OAUTH_TOKEN_URL",
+		"NANOBOT_RUN_OAUTH_AUTHORIZE_URL",
+		"NANOBOT_DISABLE_HEALTH_CHECKER",
+		"NANOBOT_RUN_APIKEY_AUTH_WEBHOOK_URL",
+		"NANOBOT_RUN_MCPSERVER_ID",
+		"NANOBOT_RUN_AUDIT_LOG_TOKEN",
+		"NANOBOT_RUN_AUDIT_LOG_SEND_URL",
+		"NANOBOT_RUN_AUDIT_LOG_BATCH_SIZE",
+		"NANOBOT_RUN_AUDIT_LOG_FLUSH_INTERVAL_SECONDS",
+		"NANOBOT_RUN_AUDIT_LOG_METADATA",
+	}
+
+	for _, key := range mustBeEmpty {
+		val, ok := configSecret.StringData[key]
+		if !ok {
+			t.Errorf("expected key %q to be present in config secret", key)
+		} else if val != "" {
+			t.Errorf("expected key %q to be empty for nanobot agent, got %q", key, val)
+		}
+	}
+}
+
 func TestK8sObjects_NonAgentShimKeepsAuditLogConfig(t *testing.T) {
 	k := newTestKubernetesBackend(t)
 
@@ -238,9 +292,9 @@ func findSecret(t *testing.T, objs []kclient.Object, secretName string) *corev1.
 func assertNoAuditLogEnv(t *testing.T, env map[string]string) {
 	t.Helper()
 
-	for key := range env {
-		if strings.HasPrefix(key, "NANOBOT_RUN_AUDIT_LOG_") {
-			t.Fatalf("unexpected audit log env %q present", key)
+	for key, value := range env {
+		if strings.HasPrefix(key, "NANOBOT_RUN_AUDIT_LOG_") && value != "" {
+			t.Fatalf("expected audit log env %q to be empty, got %q", key, value)
 		}
 	}
 }


### PR DESCRIPTION
When we first dropped audit logs from the Nanobot agent containers, we didn't provide a way to migrate the ones that already had them configured. The old environment variables were sticking around in the secret, due to the way we were patching it. This change explicitly sets them to the empty string.

This does mean that, in the Nanobot agent container, all of these env vars will be set to `""` (rather than being completely unset), but this should not cause any problems.

The way this bug manifested was that older Nanobot agents in Main were still sending audit logs back to Obot.