### PR TITLE
fix: k8s: rename secrets and switch from StringData to Data

### DIFF
--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -340,7 +340,7 @@ func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, res
 
 	if h.localK8SBackend != nil {
 		// If local Kubernetes backend is available, trigger a sync to update the secret with the new credentials
-		triggerKey := fmt.Sprintf("%s/%s", h.mcpServerNamespace, name.SafeConcatName(mcpServerName, "files"))
+		triggerKey := fmt.Sprintf("%s/%s", h.mcpServerNamespace, name.SafeConcatName(mcpServerName, "mcp", "files"))
 		log.Debugf("Triggering local k8s secret sync: agent=%s mcpServer=%s key=%s", agent.Name, mcpServerName, triggerKey)
 		if err := h.localK8SBackend.Trigger(
 			ctx,

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -428,7 +428,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 
 	objs = append(objs, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name.SafeConcatName(server.MCPServerName, "files"),
+			Name:        name.SafeConcatName(server.MCPServerName, "mcp", "files"),
 			Namespace:   k.mcpNamespace,
 			Annotations: annotations,
 		},
@@ -591,7 +591,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: name.SafeConcatName(server.MCPServerName, "webhook", "secrets"),
+								Name: name.SafeConcatName(server.MCPServerName, "mcp", "webhook", "secrets"),
 							},
 							Key: secretKey,
 						},
@@ -618,7 +618,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 
 	objs = append(objs, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name.SafeConcatName(server.MCPServerName, "webhook", "secrets"),
+			Name:        name.SafeConcatName(server.MCPServerName, "mcp", "webhook", "secrets"),
 			Namespace:   k.mcpNamespace,
 			Annotations: annotations,
 		},
@@ -645,7 +645,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 
 			objs = append(objs, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        name.SafeConcatName(server.MCPServerName, "run", "shim"),
+					Name:        name.SafeConcatName(server.MCPServerName, "mcp", "run", "shim"),
 					Namespace:   k.mcpNamespace,
 					Annotations: annotations,
 				},
@@ -656,7 +656,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 
 			objs = append(objs, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        name.SafeConcatName(server.MCPServerName, "config", "shim"),
+					Name:        name.SafeConcatName(server.MCPServerName, "mcp", "config", "shim"),
 					Namespace:   k.mcpNamespace,
 					Annotations: annotations,
 				},
@@ -716,7 +716,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 				EnvFrom: []corev1.EnvFromSource{{
 					SecretRef: &corev1.SecretEnvSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: name.SafeConcatName(server.MCPServerName, "config", "shim"),
+							Name: name.SafeConcatName(server.MCPServerName, "mcp", "config", "shim"),
 						},
 					},
 				}},
@@ -748,7 +748,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 
 	objs = append(objs, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name.SafeConcatName(server.MCPServerName, "config"),
+			Name:        name.SafeConcatName(server.MCPServerName, "mcp", "config"),
 			Namespace:   k.mcpNamespace,
 			Annotations: annotations,
 		},
@@ -800,7 +800,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 		EnvFrom: []corev1.EnvFromSource{{
 			SecretRef: &corev1.SecretEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: name.SafeConcatName(server.MCPServerName, "config"),
+					Name: name.SafeConcatName(server.MCPServerName, "mcp", "config"),
 				},
 			},
 		}},
@@ -843,7 +843,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 								Name: "files",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName: name.SafeConcatName(server.MCPServerName, "files"),
+										SecretName: name.SafeConcatName(server.MCPServerName, "mcp", "files"),
 									},
 								},
 							},
@@ -851,7 +851,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 								Name: "run-file",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName: name.SafeConcatName(server.MCPServerName, "run"),
+										SecretName: name.SafeConcatName(server.MCPServerName, "mcp", "run"),
 									},
 								},
 							},
@@ -859,7 +859,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 								Name: "run-shim-file",
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
-										SecretName: name.SafeConcatName(server.MCPServerName, "run", "shim"),
+										SecretName: name.SafeConcatName(server.MCPServerName, "mcp", "run", "shim"),
 									},
 								},
 							},
@@ -901,7 +901,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 
 		objs = append(objs, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        name.SafeConcatName(server.MCPServerName, "run"),
+				Name:        name.SafeConcatName(server.MCPServerName, "mcp", "run"),
 				Namespace:   k.mcpNamespace,
 				Annotations: annotations,
 			},

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -174,7 +174,7 @@ func TestK8sObjects_NanobotAgentExcludesAuditLogConfig(t *testing.T) {
 		t.Fatalf("k8sObjects() error = %v", err)
 	}
 
-	configSecret := findSecret(t, objs, name.SafeConcatName("nanobot-agent-server", "config"))
+	configSecret := findSecret(t, objs, name.SafeConcatName("nanobot-agent-server", "mcp", "config"))
 	assertNoAuditLogEnv(t, configSecret.Data)
 }
 
@@ -200,7 +200,7 @@ func TestK8sObjects_NonAgentShimKeepsAuditLogConfig(t *testing.T) {
 		t.Fatalf("k8sObjects() error = %v", err)
 	}
 
-	shimConfigSecret := findSecret(t, objs, name.SafeConcatName("standard-server", "config", "shim"))
+	shimConfigSecret := findSecret(t, objs, name.SafeConcatName("standard-server", "mcp", "config", "shim"))
 	assertHasAuditLogEnv(t, shimConfigSecret.Data)
 }
 


### PR DESCRIPTION
When we were using StringData, it left us unable to remove env vars that were previously added to the secrets but should no longer be there.

This fixes that by switching from StringData to just Data. However, the old values are still unable to be removed, so we just slightly renamed the secrets so that they get fully recreated, without the old values.