### PR TITLE
fix: timeInput 1-12 format fix & 12/24hr preference

### DIFF
--- a/ui/user/src/lib/components/Calendar.svelte
+++ b/ui/user/src/lib/components/Calendar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import popover from '$lib/actions/popover.svelte';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
-	import { responsive } from '$lib/stores';
+	import { responsive, timePreference } from '$lib/stores';
 	import CalendarGrid, {
 		months,
 		isToday,
@@ -261,6 +261,8 @@
 						<div class="flex flex-col gap-1">
 							<div class="text-on-surface1 text-xs">{start.toDateString()}</div>
 							<TimeInput
+								format={timePreference.timeFormat}
+								clockAnchorPlacement="left"
 								date={start}
 								onChange={(date) => {
 									start = date;
@@ -281,6 +283,8 @@
 							{/if}
 
 							<TimeInput
+								format={timePreference.timeFormat}
+								clockAnchorPlacement="left"
 								date={end ?? endOfDay(start)}
 								onChange={(date) => {
 									end = date;

--- a/ui/user/src/lib/components/TimeClockPopover.svelte
+++ b/ui/user/src/lib/components/TimeClockPopover.svelte
@@ -1,0 +1,402 @@
+<script lang="ts">
+	import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
+	import { getHours, getMinutes, setHours, setMinutes } from 'date-fns';
+	import { twMerge } from 'tailwind-merge';
+
+	export type AnchorPlacement = 'top' | 'right' | 'bottom' | 'left';
+
+	type Props = {
+		open: boolean;
+		onOpenChange: (open: boolean) => void;
+		date: Date;
+		onApply: (date: Date) => void;
+		format: '12h' | '24h';
+		initialMode: 'hour' | 'minute';
+		/** When set, the popover is placed relative to the anchor (flip/shift) instead of centered */
+		anchor?: HTMLElement | null;
+		/** Preferred side of the anchor when `anchor` is set. Defaults to `bottom`. */
+		anchorPlacement?: AnchorPlacement;
+	};
+
+	let {
+		open,
+		onOpenChange,
+		date,
+		onApply,
+		format,
+		initialMode,
+		anchor = null,
+		anchorPlacement = 'bottom'
+	}: Props = $props();
+
+	const flipFallbacks: Record<AnchorPlacement, AnchorPlacement[]> = {
+		top: ['bottom', 'left', 'right'],
+		bottom: ['top', 'left', 'right'],
+		left: ['right', 'top', 'bottom'],
+		right: ['left', 'top', 'bottom']
+	};
+
+	const is24h = $derived(format === '24h');
+
+	let tempDate = $state(new Date());
+	let mode = $state<'hour' | 'minute'>('hour');
+	/** For minute: fine adjustment 0–4 added to the 5-minute bucket */
+	let minuteExtra = $state(0);
+	/** True only while `open` is true; reset when closed so the next open snapshots `date` again */
+	let sessionActive = $state(false);
+
+	let panelEl = $state<HTMLElement | null>(null);
+	let anchoredPositionReady = $state(false);
+
+	$effect(() => {
+		if (open) {
+			if (!sessionActive) {
+				tempDate = new Date(date.getTime());
+				minuteExtra = getMinutes(tempDate) % 5;
+			}
+			mode = initialMode;
+			sessionActive = true;
+		} else {
+			sessionActive = false;
+		}
+	});
+
+	$effect(() => {
+		if (!open) {
+			anchoredPositionReady = false;
+			return;
+		}
+		if (!anchor || !panelEl) {
+			anchoredPositionReady = true;
+			return;
+		}
+
+		anchoredPositionReady = false;
+
+		async function updatePosition() {
+			if (!anchor || !panelEl) return;
+			const { x, y } = await computePosition(anchor, panelEl, {
+				placement: anchorPlacement,
+				strategy: 'fixed',
+				middleware: [
+					offset(8),
+					flip({ fallbackPlacements: flipFallbacks[anchorPlacement] }),
+					shift({ padding: 8 })
+				]
+			});
+			Object.assign(panelEl.style, { left: `${x}px`, top: `${y}px` });
+			anchoredPositionReady = true;
+		}
+
+		void updatePosition();
+		return autoUpdate(anchor, panelEl, updatePosition);
+	});
+
+	$effect(() => {
+		if (!open || !panelEl || anchor) return;
+		panelEl.style.removeProperty('left');
+		panelEl.style.removeProperty('top');
+	});
+
+	const h24 = $derived(getHours(tempDate));
+	const m60 = $derived(getMinutes(tempDate));
+	const hour12 = $derived(h24 % 12 === 0 ? 12 : h24 % 12);
+	const isAm = $derived(h24 < 12);
+
+	const INNER_HOURS = [0, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23] as const;
+
+	function polarStyle(index1Based: number, n: number, radiusPct: number): string {
+		const angle = (index1Based / n) * 2 * Math.PI - Math.PI / 2;
+		const x = 50 + radiusPct * Math.cos(angle);
+		const y = 50 + radiusPct * Math.sin(angle);
+		return `left:${x}%;top:${y}%;transform:translate(-50%,-50%)`;
+	}
+
+	function polarStyleIndex(i: number, n: number, radiusPct: number): string {
+		const angle = (i / n) * 2 * Math.PI - Math.PI / 2;
+		const x = 50 + radiusPct * Math.cos(angle);
+		const y = 50 + radiusPct * Math.sin(angle);
+		return `left:${x}%;top:${y}%;transform:translate(-50%,-50%)`;
+	}
+
+	function setHour24(h: number) {
+		tempDate = setHours(tempDate, h);
+		mode = 'minute';
+	}
+
+	function setHour12(h12: number) {
+		if (isAm) {
+			tempDate = setHours(tempDate, h12 === 12 ? 0 : h12);
+		} else {
+			tempDate = setHours(tempDate, h12 === 12 ? 12 : h12 + 12);
+		}
+		mode = 'minute';
+	}
+
+	function toggleAmPm(nextAm: boolean) {
+		const ch = getHours(tempDate);
+		if (nextAm && ch >= 12) {
+			tempDate = setHours(tempDate, ch - 12);
+		} else if (!nextAm && ch < 12) {
+			tempDate = setHours(tempDate, ch + 12);
+		}
+	}
+
+	function setMinuteFromClock(fiveSlot: number) {
+		const base = fiveSlot * 5;
+		const next = Math.min(59, base + minuteExtra);
+		tempDate = setMinutes(tempDate, next);
+	}
+
+	function setMinuteExtra(extra: number) {
+		minuteExtra = extra;
+		const base = Math.floor(getMinutes(tempDate) / 5) * 5;
+		tempDate = setMinutes(tempDate, Math.min(59, base + extra));
+	}
+
+	function handAngleForHour24(selected: number): number {
+		if (selected >= 1 && selected <= 12) {
+			return (selected / 12) * 2 * Math.PI - Math.PI / 2;
+		}
+		const idx = INNER_HOURS.findIndex((v) => v === selected);
+		if (idx >= 0) {
+			return (idx / 12) * 2 * Math.PI - Math.PI / 2;
+		}
+		return -Math.PI / 2;
+	}
+
+	function handAngleForHour12(h12: number): number {
+		return (h12 / 12) * 2 * Math.PI - Math.PI / 2;
+	}
+
+	function handAngleForMinute(min: number): number {
+		return (min / 60) * 2 * Math.PI - Math.PI / 2;
+	}
+
+	function cancel() {
+		onOpenChange(false);
+	}
+
+	function ok() {
+		onApply(new Date(tempDate.getTime()));
+		onOpenChange(false);
+	}
+
+	$effect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onOpenChange(false);
+		};
+		document.addEventListener('keydown', onKey);
+		return () => document.removeEventListener('keydown', onKey);
+	});
+</script>
+
+{#if open}
+	<div class="fixed inset-0 z-80" onclick={() => onOpenChange(false)} role="presentation"></div>
+	<div
+		bind:this={panelEl}
+		class={twMerge(
+			'popover flex flex-col overflow-hidden max-h-[min(90vh,520px)] fixed z-90',
+			anchor
+				? twMerge(
+						'w-[min(340px,calc(100vw-16px))]',
+						!anchoredPositionReady && 'pointer-events-none opacity-0'
+					)
+				: 'left-1/2 top-1/2 w-[min(340px,calc(100%-2rem))] max-w-[340px] -translate-x-1/2 -translate-y-1/2'
+		)}
+		role="dialog"
+		aria-modal="true"
+		aria-label="Select time"
+		tabindex="0"
+	>
+		<!-- Header -->
+		<div
+			class={twMerge(
+				'flex shrink-0 items-center justify-center gap-1 px-4 py-5 text-4xl font-light tabular-nums',
+				'text-white bg-primary'
+			)}
+		>
+			{#if is24h}
+				<button
+					type="button"
+					class={twMerge(
+						'rounded px-1 transition-opacity',
+						mode === 'hour' ? 'opacity-100' : 'opacity-60 hover:opacity-90'
+					)}
+					onclick={() => (mode = 'hour')}>{String(h24).padStart(2, '0')}</button
+				>
+				<span class="opacity-90">:</span>
+				<button
+					type="button"
+					class={twMerge(
+						'rounded px-1 transition-opacity',
+						mode === 'minute' ? 'opacity-100' : 'opacity-60 hover:opacity-90'
+					)}
+					onclick={() => (mode = 'minute')}>{String(m60).padStart(2, '0')}</button
+				>
+			{:else}
+				<button
+					type="button"
+					class={twMerge(
+						'rounded px-1 transition-opacity',
+						mode === 'hour' ? 'opacity-100' : 'opacity-60 hover:opacity-90'
+					)}
+					onclick={() => (mode = 'hour')}>{String(hour12).padStart(2, '0')}</button
+				>
+				<span class="opacity-90">:</span>
+				<button
+					type="button"
+					class={twMerge(
+						'rounded px-1 transition-opacity',
+						mode === 'minute' ? 'opacity-100' : 'opacity-60 hover:opacity-90'
+					)}
+					onclick={() => (mode = 'minute')}>{String(m60).padStart(2, '0')}</button
+				>
+				<div class="ml-3 flex flex-col gap-0.5 text-sm font-medium">
+					<button
+						type="button"
+						class={twMerge('rounded px-2 py-0.5', isAm ? 'opacity-100' : 'opacity-50')}
+						onclick={() => toggleAmPm(true)}>AM</button
+					>
+					<button
+						type="button"
+						class={twMerge('rounded px-2 py-0.5', !isAm ? 'opacity-100' : 'opacity-50')}
+						onclick={() => toggleAmPm(false)}>PM</button
+					>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Clock face -->
+		<div class="relative flex flex-1 flex-col items-center justify-center px-3 pt-4 pb-6">
+			<div class="relative aspect-square w-full max-w-[280px] pb-4">
+				<!-- Dial background -->
+				<div class="bg-surface1 absolute inset-[0%] rounded-full"></div>
+
+				{#if mode === 'hour' && is24h}
+					{@const selAngle = handAngleForHour24(h24)}
+					<svg
+						class="pointer-events-none absolute inset-[8%] h-[84%] w-[84%]"
+						viewBox="0 0 100 100"
+					>
+						<line
+							x1="50"
+							y1="50"
+							x2={50 + 38 * Math.cos(selAngle)}
+							y2={50 + 38 * Math.sin(selAngle)}
+							stroke="currentColor"
+							stroke-width="1.5"
+							class="text-primary"
+						/>
+						<circle cx="50" cy="50" r="3" class="fill-primary" />
+					</svg>
+					{#each Array.from({ length: 12 }, (_, i) => i + 1) as h (h)}
+						<button
+							type="button"
+							style={polarStyle(h, 12, 40)}
+							class={twMerge(
+								'bg-surface1 hover:bg-surface3 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-sm',
+								h24 === h ? 'bg-primary text-white scale-110' : ''
+							)}
+							onclick={() => setHour24(h)}>{h}</button
+						>
+					{/each}
+					{#each INNER_HOURS as hv, i (hv)}
+						<button
+							type="button"
+							style={polarStyleIndex(i, 12, 24)}
+							class={twMerge(
+								'bg-surface1 hover:bg-surface3 absolute z-10 flex h-8 w-8 items-center justify-center rounded-full text-xs',
+								h24 === hv ? 'bg-primary text-white scale-110' : ''
+							)}
+							onclick={() => setHour24(hv)}>{String(hv).padStart(2, '0')}</button
+						>
+					{/each}
+				{:else if mode === 'hour' && !is24h}
+					{@const selAngle = handAngleForHour12(hour12)}
+					<svg
+						class="pointer-events-none absolute inset-[8%] h-[84%] w-[84%]"
+						viewBox="0 0 100 100"
+					>
+						<line
+							x1="50"
+							y1="50"
+							x2={50 + 40 * Math.cos(selAngle)}
+							y2={50 + 40 * Math.sin(selAngle)}
+							stroke="currentColor"
+							stroke-width="1.5"
+							class="text-primary"
+						/>
+						<circle cx="50" cy="50" r="3" class="fill-primary" />
+					</svg>
+					{#each Array.from({ length: 12 }, (_, i) => i + 1) as h (h)}
+						<button
+							type="button"
+							style={polarStyle(h, 12, 40)}
+							class={twMerge(
+								'bg-surface1 hover:bg-surface3 absolute z-10 flex h-10 w-10 items-center justify-center rounded-full text-base',
+								hour12 === h ? 'bg-primary text-white scale-110' : ''
+							)}
+							onclick={() => setHour12(h)}>{h}</button
+						>
+					{/each}
+				{:else}
+					{@const selMin = m60}
+					{@const selAngle = handAngleForMinute(selMin)}
+					<svg
+						class="pointer-events-none absolute inset-[8%] h-[84%] w-[84%]"
+						viewBox="0 0 100 100"
+					>
+						<line
+							x1="50"
+							y1="50"
+							x2={50 + 40 * Math.cos(selAngle)}
+							y2={50 + 40 * Math.sin(selAngle)}
+							stroke="currentColor"
+							stroke-width="1.5"
+							class="text-primary"
+						/>
+						<circle cx="50" cy="50" r="3" class="fill-primary" />
+					</svg>
+					{#each Array.from({ length: 12 }, (_, i) => i) as slot (slot)}
+						{@const label = slot * 5}
+						<button
+							type="button"
+							style={polarStyle(slot === 0 ? 12 : slot, 12, 38)}
+							class={twMerge(
+								'bg-surface1 hover:bg-surface3 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-xs',
+								Math.floor(selMin / 5) === slot ? 'bg-primary text-primary-content scale-110' : ''
+							)}
+							onclick={() => {
+								minuteExtra = 0;
+								setMinuteFromClock(slot);
+							}}>{String(label).padStart(2, '0')}</button
+						>
+					{/each}
+				{/if}
+			</div>
+
+			{#if mode === 'minute'}
+				<div class="w-full flex justify-center gap-1 pt-4 absolute bottom-2 left-0 right-0">
+					{#each [0, 1, 2, 3, 4] as e (e)}
+						<button
+							type="button"
+							class={twMerge(
+								'rounded px-2 py-1 text-xs',
+								minuteExtra === e ? 'bg-primary text-white' : 'bg-surface3/50 text-on-background'
+							)}
+							onclick={() => setMinuteExtra(e)}>+{e}</button
+						>
+					{/each}
+				</div>
+			{/if}
+		</div>
+
+		<!-- Footer -->
+		<div class="border-surface3 flex justify-end gap-2 border-t px-3 py-2">
+			<button type="button" class="button text-xs uppercase" onclick={cancel}>Cancel</button>
+			<button type="button" class="button-primary text-xs uppercase" onclick={ok}>OK</button>
+		</div>
+	</div>
+{/if}

--- a/ui/user/src/lib/components/TimeClockPopover.svelte
+++ b/ui/user/src/lib/components/TimeClockPopover.svelte
@@ -42,23 +42,27 @@
 	let mode = $state<'hour' | 'minute'>('hour');
 	/** For minute: fine adjustment 0–4 added to the 5-minute bucket */
 	let minuteExtra = $state(0);
-	/** True only while `open` is true; reset when closed so the next open snapshots `date` again */
-	let sessionActive = $state(false);
 
 	let panelEl = $state<HTMLElement | null>(null);
 	let anchoredPositionReady = $state(false);
 
+	let lastSyncedTime: number | null = null;
+
 	$effect(() => {
-		if (open) {
-			if (!sessionActive) {
-				tempDate = new Date(date.getTime());
-				minuteExtra = getMinutes(tempDate) % 5;
-			}
-			mode = initialMode;
-			sessionActive = true;
-		} else {
-			sessionActive = false;
+		if (!open) {
+			lastSyncedTime = null;
+			return;
 		}
+		const t = date.getTime();
+		if (lastSyncedTime === t) return;
+		lastSyncedTime = t;
+		tempDate = new Date(t);
+		minuteExtra = getMinutes(tempDate) % 5;
+	});
+
+	$effect(() => {
+		if (!open) return;
+		mode = initialMode;
 	});
 
 	$effect(() => {
@@ -296,8 +300,8 @@
 							type="button"
 							style={polarStyle(h, 12, 40)}
 							class={twMerge(
-								'bg-surface1 hover:bg-surface3 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-sm',
-								h24 === h ? 'bg-primary text-white scale-110' : ''
+								'bg-surface1 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-sm',
+								h24 === h ? 'bg-primary text-white scale-110' : 'hover:bg-surface3 '
 							)}
 							onclick={() => setHour24(h)}>{h}</button
 						>
@@ -307,8 +311,8 @@
 							type="button"
 							style={polarStyleIndex(i, 12, 24)}
 							class={twMerge(
-								'bg-surface1 hover:bg-surface3 absolute z-10 flex h-8 w-8 items-center justify-center rounded-full text-xs',
-								h24 === hv ? 'bg-primary text-white scale-110' : ''
+								'bg-surface1 absolute z-10 flex h-8 w-8 items-center justify-center rounded-full text-xs',
+								h24 === hv ? 'bg-primary text-white scale-110' : 'hover:bg-surface3 '
 							)}
 							onclick={() => setHour24(hv)}>{String(hv).padStart(2, '0')}</button
 						>
@@ -335,8 +339,8 @@
 							type="button"
 							style={polarStyle(h, 12, 40)}
 							class={twMerge(
-								'bg-surface1 hover:bg-surface3 absolute z-10 flex h-10 w-10 items-center justify-center rounded-full text-base',
-								hour12 === h ? 'bg-primary text-white scale-110' : ''
+								'bg-surface1 absolute z-10 flex h-10 w-10 items-center justify-center rounded-full text-base',
+								hour12 === h ? 'bg-primary text-white scale-110' : 'hover:bg-surface3 '
 							)}
 							onclick={() => setHour12(h)}>{h}</button
 						>
@@ -365,8 +369,10 @@
 							type="button"
 							style={polarStyle(slot === 0 ? 12 : slot, 12, 38)}
 							class={twMerge(
-								'bg-surface1 hover:bg-surface3 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-xs',
-								Math.floor(selMin / 5) === slot ? 'bg-primary text-primary-content scale-110' : ''
+								'bg-surface1 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-xs',
+								Math.floor(selMin / 5) === slot
+									? 'bg-primary text-primary-content scale-110'
+									: 'hover:bg-surface3 '
 							)}
 							onclick={() => {
 								minuteExtra = 0;

--- a/ui/user/src/lib/components/TimeInput.svelte
+++ b/ui/user/src/lib/components/TimeInput.svelte
@@ -163,6 +163,10 @@
 					ev.preventDefault();
 					return;
 				}
+
+				if (ev.key === 'Enter') {
+					commitHour();
+				}
 			}}
 			onkeyup={(ev) => {
 				if (ev.key === 'ArrowDown') {
@@ -195,6 +199,10 @@
 				if (['ArrowDown', 'ArrowUp'].includes(ev.key)) {
 					ev.preventDefault();
 					return;
+				}
+
+				if (ev.key === 'Enter') {
+					commitMinute();
 				}
 			}}
 			onkeyup={(ev) => {

--- a/ui/user/src/lib/components/TimeInput.svelte
+++ b/ui/user/src/lib/components/TimeInput.svelte
@@ -22,7 +22,7 @@
 	const hours = $derived(getHours(date));
 	const minutes = $derived(getMinutes(date));
 	const isAm = $derived(hours < 12);
-	const amPmAsNumber = $derived(+!isAm);
+	const hour12 = $derived(hours % 12 === 0 ? 12 : hours % 12);
 </script>
 
 <div class={twMerge('time-input bg-surface1 flex h-14 items-center gap-2 rounded-md', klass)}>
@@ -31,13 +31,21 @@
 			class="w-[3ch] flex-1 bg-transparent px-4 text-end"
 			type="number"
 			max="12"
-			min="0"
+			min="1"
 			bind:value={
-				() => (hours % 12).toString().padStart(2, '0'),
+				() => hour12.toString().padStart(2, '0'),
 				(v) => {
-					const valueAsNumber = parseInt(v, 10) || 0;
+					let h12 = parseInt(v, 10);
+					if (Number.isNaN(h12)) h12 = 12;
+					h12 = Math.min(12, Math.max(1, h12));
 
-					date = setHours(date, Math.min(valueAsNumber + amPmAsNumber * 12, 23));
+					let h24: number;
+					if (isAm) {
+						h24 = h12 === 12 ? 0 : h12;
+					} else {
+						h24 = h12 === 12 ? 12 : h12 + 12;
+					}
+					date = setHours(date, h24);
 					onChange?.(date);
 				}
 			}

--- a/ui/user/src/lib/components/TimeInput.svelte
+++ b/ui/user/src/lib/components/TimeInput.svelte
@@ -180,7 +180,7 @@
 		/>
 	</div>
 
-	<div class="text-4xl font-bold">:</div>
+	<div class="text-2xl font-bold">:</div>
 
 	<div class="flex h-full flex-1 rounded-md text-xl">
 		<input

--- a/ui/user/src/lib/components/TimeInput.svelte
+++ b/ui/user/src/lib/components/TimeInput.svelte
@@ -23,32 +23,96 @@
 	const minutes = $derived(getMinutes(date));
 	const isAm = $derived(hours < 12);
 	const hour12 = $derived(hours % 12 === 0 ? 12 : hours % 12);
+
+	let hourDraft = $state('');
+	let minuteDraft = $state('');
+
+	$effect(() => {
+		hourDraft = hour12.toString().padStart(2, '0');
+	});
+	$effect(() => {
+		minuteDraft = (minutes % 60).toString().padStart(2, '0');
+	});
+
+	function commitHour() {
+		const trimmed = hourDraft.trim();
+		if (trimmed === '') {
+			hourDraft = hour12.toString().padStart(2, '0');
+			return;
+		}
+		let h12 = parseInt(trimmed, 10);
+		if (Number.isNaN(h12)) {
+			hourDraft = hour12.toString().padStart(2, '0');
+			return;
+		}
+		if (trimmed === '00') {
+			h12 = 12;
+		} else {
+			h12 = Math.min(12, Math.max(1, h12));
+		}
+
+		let h24: number;
+		if (isAm) {
+			h24 = h12 === 12 ? 0 : h12;
+		} else {
+			h24 = h12 === 12 ? 12 : h12 + 12;
+		}
+		date = setHours(date, h24);
+		onChange?.(date);
+	}
+
+	function commitMinute() {
+		const trimmed = minuteDraft.trim();
+		if (trimmed === '') {
+			minuteDraft = (minutes % 60).toString().padStart(2, '0');
+			return;
+		}
+		const m = parseInt(trimmed, 10);
+		if (Number.isNaN(m)) {
+			minuteDraft = (minutes % 60).toString().padStart(2, '0');
+			return;
+		}
+		date = setMinutes(date, Math.min(59, Math.max(0, m)));
+		onChange?.(date);
+	}
+
+	function sanitizeHourDraft(raw: string): string {
+		const v = raw.replace(/\D/g, '').slice(0, 2);
+		if (v === '') return v;
+		if (v === '00') {
+			return '12';
+		}
+		const n = parseInt(v, 10);
+		if (!Number.isNaN(n) && n > 12) {
+			return '12';
+		}
+		return v;
+	}
+
+	function sanitizeMinuteDraft(raw: string): string {
+		const v = raw.replace(/\D/g, '').slice(0, 2);
+		if (v === '') return v;
+		const n = parseInt(v, 10);
+		if (!Number.isNaN(n) && n > 59) {
+			return '59';
+		}
+		return v;
+	}
 </script>
 
 <div class={twMerge('time-input bg-surface1 flex h-14 items-center gap-2 rounded-md', klass)}>
 	<div class="flex h-full flex-1 text-xl">
 		<input
 			class="w-[3ch] flex-1 bg-transparent px-4 text-end"
-			type="number"
-			max="12"
-			min="1"
-			bind:value={
-				() => hour12.toString().padStart(2, '0'),
-				(v) => {
-					let h12 = parseInt(v, 10);
-					if (Number.isNaN(h12)) h12 = 12;
-					h12 = Math.min(12, Math.max(1, h12));
-
-					let h24: number;
-					if (isAm) {
-						h24 = h12 === 12 ? 0 : h12;
-					} else {
-						h24 = h12 === 12 ? 12 : h12 + 12;
-					}
-					date = setHours(date, h24);
-					onChange?.(date);
-				}
-			}
+			type="text"
+			inputmode="numeric"
+			autocomplete="off"
+			maxlength="2"
+			bind:value={hourDraft}
+			oninput={(ev) => {
+				hourDraft = sanitizeHourDraft(ev.currentTarget.value);
+			}}
+			onblur={commitHour}
 			onkeydown={(ev) => {
 				if (['ArrowDown', 'ArrowUp'].includes(ev.key)) {
 					ev.preventDefault();
@@ -72,18 +136,15 @@
 	<div class="flex h-full flex-1 rounded-md text-xl">
 		<input
 			class="w-[3ch] flex-1 bg-transparent px-4"
-			type="number"
-			max="60"
-			min="0"
-			bind:value={
-				() => (minutes % 60).toString().padStart(2, '0'),
-				(v) => {
-					const valueAsNumber = parseInt(v, 10) || 0;
-
-					date = setMinutes(date, Math.min(valueAsNumber, 59));
-					onChange?.(date);
-				}
-			}
+			type="text"
+			inputmode="numeric"
+			autocomplete="off"
+			maxlength="2"
+			bind:value={minuteDraft}
+			oninput={(ev) => {
+				minuteDraft = sanitizeMinuteDraft(ev.currentTarget.value);
+			}}
+			onblur={commitMinute}
 			onkeydown={(ev) => {
 				if (['ArrowDown', 'ArrowUp'].includes(ev.key)) {
 					ev.preventDefault();
@@ -128,18 +189,3 @@
 		>
 	</div>
 </div>
-
-<style>
-	/* For WebKit-based browsers (Chrome, Safari, Edge, Opera) */
-	input::-webkit-outer-spin-button,
-	input::-webkit-inner-spin-button {
-		-webkit-appearance: none; /* Removes the default appearance */
-		margin: 0; /* Removes any default margin */
-	}
-
-	/* For Mozilla Firefox */
-	input[type='number'] {
-		appearance: textfield; /* Standard property for compatibility */
-		-moz-appearance: textfield; /* Hides the spin buttons in Firefox */
-	}
-</style>

--- a/ui/user/src/lib/components/TimeInput.svelte
+++ b/ui/user/src/lib/components/TimeInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import TimeClockPopover, { type AnchorPlacement } from './TimeClockPopover.svelte';
 	import {
 		addHours,
 		addMinutes,
@@ -15,20 +16,29 @@
 		date: Date;
 		onChange?: (date: Date) => void;
 		class?: string;
+		format?: '12h' | '24h';
+		clockAnchorPlacement?: AnchorPlacement;
 	};
 
-	let { date = $bindable(), onChange, class: klass }: Props = $props();
+	let {
+		date = $bindable(),
+		onChange,
+		class: klass,
+		format = '12h',
+		clockAnchorPlacement
+	}: Props = $props();
 
 	const hours = $derived(getHours(date));
 	const minutes = $derived(getMinutes(date));
 	const isAm = $derived(hours < 12);
 	const hour12 = $derived(hours % 12 === 0 ? 12 : hours % 12);
+	const displayHour = $derived(format === '24h' ? hours : hour12);
 
 	let hourDraft = $state('');
 	let minuteDraft = $state('');
 
 	$effect(() => {
-		hourDraft = hour12.toString().padStart(2, '0');
+		hourDraft = displayHour.toString().padStart(2, '0');
 	});
 	$effect(() => {
 		minuteDraft = (minutes % 60).toString().padStart(2, '0');
@@ -37,9 +47,21 @@
 	function commitHour() {
 		const trimmed = hourDraft.trim();
 		if (trimmed === '') {
-			hourDraft = hour12.toString().padStart(2, '0');
+			hourDraft = displayHour.toString().padStart(2, '0');
 			return;
 		}
+		if (format === '24h') {
+			let h24 = parseInt(trimmed, 10);
+			if (Number.isNaN(h24)) {
+				hourDraft = hours.toString().padStart(2, '0');
+				return;
+			}
+			h24 = Math.min(23, Math.max(0, h24));
+			date = setHours(date, h24);
+			onChange?.(date);
+			return;
+		}
+
 		let h12 = parseInt(trimmed, 10);
 		if (Number.isNaN(h12)) {
 			hourDraft = hour12.toString().padStart(2, '0');
@@ -79,6 +101,13 @@
 	function sanitizeHourDraft(raw: string): string {
 		const v = raw.replace(/\D/g, '').slice(0, 2);
 		if (v === '') return v;
+		if (format === '24h') {
+			const n = parseInt(v, 10);
+			if (!Number.isNaN(n) && n > 23) {
+				return '23';
+			}
+			return v;
+		}
 		if (v === '00') {
 			return '12';
 		}
@@ -98,6 +127,21 @@
 		}
 		return v;
 	}
+
+	let clockOpen = $state(false);
+	let clockAnchor = $state<HTMLElement | null>(null);
+	let clockInitialMode = $state<'hour' | 'minute'>('hour');
+
+	function openClockPicker(target: HTMLInputElement, mode: 'hour' | 'minute') {
+		clockAnchor = target;
+		clockInitialMode = mode;
+		clockOpen = true;
+	}
+
+	function onClockOpenChange(open: boolean) {
+		clockOpen = open;
+		if (!open) clockAnchor = null;
+	}
 </script>
 
 <div class={twMerge('time-input bg-surface1 flex h-14 items-center gap-2 rounded-md', klass)}>
@@ -109,6 +153,7 @@
 			autocomplete="off"
 			maxlength="2"
 			bind:value={hourDraft}
+			onfocus={(ev) => openClockPicker(ev.currentTarget, 'hour')}
 			oninput={(ev) => {
 				hourDraft = sanitizeHourDraft(ev.currentTarget.value);
 			}}
@@ -141,6 +186,7 @@
 			autocomplete="off"
 			maxlength="2"
 			bind:value={minuteDraft}
+			onfocus={(ev) => openClockPicker(ev.currentTarget, 'minute')}
 			oninput={(ev) => {
 				minuteDraft = sanitizeMinuteDraft(ev.currentTarget.value);
 			}}
@@ -163,29 +209,45 @@
 		/>
 	</div>
 
-	<div class="flex h-full flex-col gap-1 p-1 text-xs">
-		<button
-			class={twMerge(
-				'bg-surface3/30 flex-1 rounded-sm px-1',
-				isAm && 'bg-primary/10 border-primary/50 text-primary'
-			)}
-			onclick={() => {
-				if (isAm) return;
-				date = setHours(date, hours - 12);
-				onChange?.(date);
-			}}>AM</button
-		>
+	{#if format === '12h'}
+		<div class="flex h-full flex-col gap-1 p-1 text-xs">
+			<button
+				class={twMerge(
+					'bg-surface3/30 flex-1 rounded-sm px-1',
+					isAm && 'bg-primary/10 border-primary/50 text-primary'
+				)}
+				onclick={() => {
+					if (isAm) return;
+					date = setHours(date, hours - 12);
+					onChange?.(date);
+				}}>AM</button
+			>
 
-		<button
-			class={twMerge(
-				'bg-surface3/30 flex-1 rounded-sm px-1',
-				!isAm && 'text-primary bg-primary/10'
-			)}
-			onclick={() => {
-				if (!isAm) return;
-				date = setHours(date, (hours + 12) % 24);
-				onChange?.(date);
-			}}>PM</button
-		>
-	</div>
+			<button
+				class={twMerge(
+					'bg-surface3/30 flex-1 rounded-sm px-1',
+					!isAm && 'text-primary bg-primary/10'
+				)}
+				onclick={() => {
+					if (!isAm) return;
+					date = setHours(date, (hours + 12) % 24);
+					onChange?.(date);
+				}}>PM</button
+			>
+		</div>
+	{/if}
+
+	<TimeClockPopover
+		open={clockOpen}
+		onOpenChange={onClockOpenChange}
+		{date}
+		{format}
+		initialMode={clockInitialMode}
+		anchor={clockAnchor}
+		anchorPlacement={clockAnchorPlacement}
+		onApply={(d) => {
+			date = d;
+			onChange?.(d);
+		}}
+	/>
 </div>

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import { Group, type AuditLog } from '$lib/services/admin/types';
-	import { profile } from '$lib/stores';
+	import { profile, timePreference } from '$lib/stores';
+	import { formatLogTimestamp } from '$lib/time';
 	import { X } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -34,18 +35,7 @@
 			)}
 		></div>
 		<h3 class="text-lg font-semibold">
-			{new Date(auditLog.createdAt)
-				.toLocaleString(undefined, {
-					year: 'numeric',
-					month: 'short',
-					day: 'numeric',
-					hour: '2-digit',
-					minute: '2-digit',
-					second: '2-digit',
-					hour12: true,
-					timeZoneName: 'short'
-				})
-				.replace(/,/g, '')}
+			{formatLogTimestamp(auditLog.createdAt, timePreference.timeFormat)}
 		</h3>
 		<p class="text-on-surface1 text-xs font-light">
 			{auditLog.requestID}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogs.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogs.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { VirtualPageTable } from '$lib/components/ui';
-	import { mcpServersAndEntries } from '$lib/stores';
+	import { mcpServersAndEntries, timePreference } from '$lib/stores';
+	import { formatLogTimestamp } from '$lib/time';
 	import { throttle } from '$lib/utils';
 	import { GripVertical } from 'lucide-svelte';
 	import { tick } from 'svelte';
@@ -185,20 +186,7 @@
 						<td class="px-6 py-3">
 							{item.index + 1}
 						</td>
-						{@render td(
-							new Date(d.createdAt)
-								.toLocaleString(undefined, {
-									year: 'numeric',
-									month: 'short',
-									day: 'numeric',
-									hour: '2-digit',
-									minute: '2-digit',
-									second: '2-digit',
-									hour12: true,
-									timeZoneName: 'short'
-								})
-								.replace(/,/g, '')
-						)}
+						{@render td(formatLogTimestamp(d.createdAt, timePreference.timeFormat))}
 						{@render td(getUserDisplayName(d.userID))}
 						{@render td(
 							d.mcpID

--- a/ui/user/src/lib/components/edit/TaskItem.svelte
+++ b/ui/user/src/lib/components/edit/TaskItem.svelte
@@ -9,7 +9,7 @@
 	} from '$lib/context/chatLayout.svelte';
 	import { type Task, type Thread, type Project } from '$lib/services';
 	import { ChatService } from '$lib/services';
-	import { responsive } from '$lib/stores';
+	import { responsive, timePreference } from '$lib/stores';
 	import { formatTime } from '$lib/time.js';
 	import { ChevronDown, Trash2 } from 'lucide-svelte/icons';
 	import { untrack, type Snippet } from 'svelte';
@@ -138,7 +138,7 @@
 									}
 								}}
 							>
-								{formatTime(taskRun.created)}
+								{formatTime(taskRun.created, timePreference.timeFormat)}
 							</button>
 							<button
 								class={twMerge(

--- a/ui/user/src/lib/components/graph/StackedTimeline.svelte
+++ b/ui/user/src/lib/components/graph/StackedTimeline.svelte
@@ -1,7 +1,8 @@
 <script lang="ts" generics="T extends object">
 	import { tooltip as tooltipAction } from '$lib/actions/tooltip.svelte';
 	import { lightenHex } from '$lib/colors';
-	import { darkMode } from '$lib/stores';
+	import { darkMode, timePreference } from '$lib/stores';
+	import { formatLogTimestamp } from '$lib/time';
 	import { autoUpdate, computePosition, flip, offset } from '@floating-ui/dom';
 	import {
 		scaleBand,
@@ -904,7 +905,7 @@
 									currentItem = {
 										key: d.category,
 										value: `${(d.seg[1] as number) - (d.seg[0] as number)}`,
-										date: new Date(bucketKey).toLocaleString(),
+										date: formatLogTimestamp(bucketKey, timePreference.timeFormat),
 										count,
 										...(ps != null && {
 											primaryTotal: ps.primary,

--- a/ui/user/src/lib/components/graph/StackedTimeline.svelte
+++ b/ui/user/src/lib/components/graph/StackedTimeline.svelte
@@ -634,136 +634,139 @@
 
 			<svg width={clientWidth} height={clientHeight} viewBox={`0 0 ${clientWidth} ${clientHeight}`}>
 				<g transform="translate({paddingLeft}, {paddingTop})">
-					<g
-						class="x-axis text-on-surface3/20 dark:text-on-surface1/10"
-						transform="translate(0 {innerHeight})"
-						{@attach (node: SVGGElement) => {
-							const selection = select(node);
+					{#key timePreference.timeFormat}
+						<g
+							class="x-axis text-on-surface3/20 dark:text-on-surface1/10"
+							transform="translate(0 {innerHeight})"
+							{@attach (node: SVGGElement) => {
+								const selection = select(node);
 
-							const format = timeFormat;
+								const format = timeFormat;
+								const use24h = timePreference.timeFormat === '24h';
 
-							const formatMillisecond = format('.%L'),
-								formatSecond = format(':%S'),
-								formatMinute = format('%I:%M'),
-								formatHour = format('%I %p'),
-								formatDayOfWeek = format('%a %d'),
-								formatDayOfMonth = format('%d'),
-								formatMonth = format('%B'),
-								formatYear = format('%Y');
+								const formatMillisecond = format('.%L'),
+									formatSecond = format(':%S'),
+									formatMinute = format(use24h ? '%H:%M' : '%I:%M'),
+									formatHour = format(use24h ? '%H:00' : '%I %p'),
+									formatDayOfWeek = format('%a %d'),
+									formatDayOfMonth = format('%d'),
+									formatMonth = format('%B'),
+									formatYear = format('%Y');
 
-							function tickFormat(domainValue: Date | NumberValue) {
-								const date = domainValue as Date;
-								const fn = (() => {
-									if (startOfSecond(date) < date) return formatMillisecond;
+								function tickFormat(domainValue: Date | NumberValue) {
+									const date = domainValue as Date;
+									const fn = (() => {
+										if (startOfSecond(date) < date) return formatMillisecond;
 
-									if (startOfMinute(date) < date) return formatSecond;
+										if (startOfMinute(date) < date) return formatSecond;
 
-									if (startOfHour(date) < date) {
-										if (getHours(date) === 0) {
+										if (startOfHour(date) < date) {
+											if (getHours(date) === 0) {
+												return formatDayOfMonth;
+											}
+
+											return formatMinute;
+										}
+
+										if (startOfDay(date) < date) {
+											return formatHour;
+										}
+
+										if (startOfMonth(date) < date) {
+											if (getDate(date) === 15) {
+												return formatDayOfWeek;
+											}
+
+											if (timeFrame[0] === 'hour') {
+												return formatDayOfWeek;
+											}
+
+											if (timeFrame[0] === 'day' && timeFrame[2] <= 90 && getDay(date) === 1) {
+												return formatDayOfWeek;
+											}
+
 											return formatDayOfMonth;
 										}
 
-										return formatMinute;
-									}
+										if (startOfYear(date) < date) return formatMonth;
 
-									if (startOfDay(date) < date) {
-										return formatHour;
-									}
+										return formatYear;
+									})();
 
-									if (startOfMonth(date) < date) {
-										if (getDate(date) === 15) {
-											return formatDayOfWeek;
-										}
+									return fn(date);
+								}
 
-										if (timeFrame[0] === 'hour') {
-											return formatDayOfWeek;
-										}
+								const axis = axisBottom(timeScale)
+									.tickSizeOuter(0)
+									.tickValues(xAxisTicks)
+									.tickFormat(tickFormat);
 
-										if (timeFrame[0] === 'day' && timeFrame[2] <= 90 && getDay(date) === 1) {
-											return formatDayOfWeek;
-										}
+								selection
+									.transition()
+									.duration(100)
+									.call(axis)
+									.selectAll('.tick')
+									.attr(
+										'transform',
+										(d) => `translate(${timeScale(d as Date) + xScale.bandwidth() / 2}, 0)`
+									)
+									.selectAll('line, text')
+									.attr('class', function (d) {
+										const element = this as SVGElement;
 
-										return formatDayOfMonth;
-									}
-
-									if (startOfYear(date) < date) return formatMonth;
-
-									return formatYear;
-								})();
-
-								return fn(date);
-							}
-
-							const axis = axisBottom(timeScale)
-								.tickSizeOuter(0)
-								.tickValues(xAxisTicks)
-								.tickFormat(tickFormat);
-
-							selection
-								.transition()
-								.duration(100)
-								.call(axis)
-								.selectAll('.tick')
-								.attr(
-									'transform',
-									(d) => `translate(${timeScale(d as Date) + xScale.bandwidth() / 2}, 0)`
-								)
-								.selectAll('line, text')
-								.attr('class', function (d) {
-									const element = this as SVGElement;
-
-									const add = (...cn: string[]) => {
-										for (const name of cn) {
-											if (!classNames.includes(name)) {
-												classNames.push(name);
+										const add = (...cn: string[]) => {
+											for (const name of cn) {
+												if (!classNames.includes(name)) {
+													classNames.push(name);
+												}
 											}
-										}
-									};
+										};
 
-									const remove = (...cn: string[]) => {
-										for (const name of cn) {
-											classNames = classNames.filter((c) => c !== name);
-										}
-									};
+										const remove = (...cn: string[]) => {
+											for (const name of cn) {
+												classNames = classNames.filter((c) => c !== name);
+											}
+										};
 
-									const isActive = isWithinInterval(d as Date, {
-										start,
-										end
+										const isActive = isWithinInterval(d as Date, {
+											start,
+											end
+										});
+
+										let classNames = [...element.classList];
+										const baseClassName = ['duration-500', 'transition-all'];
+										add(...baseClassName);
+
+										const activeClassName = ['text-on-surface3', 'dark:text-on-surface1'];
+										const inactiveClassName = ['opacity-0', 'duration-500', 'transition-opacity'];
+
+										if (isActive) {
+											add(...activeClassName);
+											remove(...inactiveClassName);
+										} else {
+											add(...inactiveClassName);
+											remove(...activeClassName);
+										}
+
+										const mainTickClassName = ['opacity-100', 'font-medium'];
+										const secondaryTickClassName = ['opacity-50', 'font-normal'];
+
+										const isMain = isMainTick(d as Date);
+
+										if (isMain) {
+											add(...mainTickClassName);
+										} else {
+											remove(...mainTickClassName);
+											add(...secondaryTickClassName);
+										}
+
+										// Keep old class names
+										// Filter falsy values and join with a space
+										return classNames.join(' ');
 									});
-
-									let classNames = [...element.classList];
-									const baseClassName = ['duration-500', 'transition-all'];
-									add(...baseClassName);
-
-									const activeClassName = ['text-on-surface3', 'dark:text-on-surface1'];
-									const inactiveClassName = ['opacity-0', 'duration-500', 'transition-opacity'];
-
-									if (isActive) {
-										add(...activeClassName);
-										remove(...inactiveClassName);
-									} else {
-										add(...inactiveClassName);
-										remove(...activeClassName);
-									}
-
-									const mainTickClassName = ['opacity-100', 'font-medium'];
-									const secondaryTickClassName = ['opacity-50', 'font-normal'];
-
-									const isMain = isMainTick(d as Date);
-
-									if (isMain) {
-										add(...mainTickClassName);
-									} else {
-										remove(...mainTickClassName);
-										add(...secondaryTickClassName);
-									}
-
-									// Keep old class names
-									// Filter falsy values and join with a space
-									return classNames.join(' ');
-								});
-						}}
-					></g>
+							}}
+						></g>
+					{/key}
 
 					<g
 						class="y-axis text-on-surface3/20 dark:text-on-surface1/10"

--- a/ui/user/src/lib/components/messages/Message.svelte
+++ b/ui/user/src/lib/components/messages/Message.svelte
@@ -14,7 +14,7 @@
 		type Message,
 		type Project
 	} from '$lib/services';
-	import { profile } from '$lib/stores';
+	import { profile, timePreference } from '$lib/stores';
 	import { formatTime } from '$lib/time';
 	import { hasTool } from '$lib/tools';
 	import { isTextFile } from '$lib/utils';
@@ -352,7 +352,7 @@
 					<TriangleAlert class="size-3 text-yellow-500" />
 				</span>
 			{/if}
-			<span>{formatTime(msg.time)}</span>
+			<span>{formatTime(msg.time, timePreference.timeFormat)}</span>
 			{#if msg.username}
 				<span class="text-on-surface1">•</span>
 				<span class="max-w-[100px] truncate font-medium">by {msg.username?.split(' ')[0]}</span>
@@ -369,7 +369,7 @@
 			>
 		{/if}
 		{#if msg.time}
-			<span class="text-gray text-sm">{formatTime(msg.time)}</span>
+			<span class="text-gray text-sm">{formatTime(msg.time, timePreference.timeFormat)}</span>
 		{/if}
 		{#if !msg.done || animating}
 			<Loading class="size-4" />

--- a/ui/user/src/lib/components/nanobot/ScheduledTaskDialog.svelte
+++ b/ui/user/src/lib/components/nanobot/ScheduledTaskDialog.svelte
@@ -9,7 +9,7 @@
 		ScheduledTask,
 		UpdateScheduledTaskRequest
 	} from '$lib/services/nanobot/types';
-	import { errors } from '$lib/stores';
+	import { errors, timePreference } from '$lib/stores';
 	import {
 		buildCronSchedule,
 		defaultTaskScheduleForm,
@@ -396,6 +396,7 @@
 
 				<div class="flex flex-col gap-2">
 					<TimeInput
+						format={timePreference.timeFormat}
 						date={timeAsDate}
 						onChange={(d) => {
 							time = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;

--- a/ui/user/src/lib/components/nanobot/taskSchedule.ts
+++ b/ui/user/src/lib/components/nanobot/taskSchedule.ts
@@ -61,9 +61,9 @@ export function formatScheduleDateTime(value?: string | null): string {
 		year: 'numeric',
 		month: 'numeric',
 		day: 'numeric',
-		hour: 'numeric',
+		hour: '2-digit',
 		minute: '2-digit',
-		hour12: true
+		hour12: false
 	}).format(parsed);
 }
 
@@ -186,9 +186,9 @@ function formatTime(time: string): string {
 	const d = new Date();
 	d.setHours(hour, minute, 0, 0);
 	return new Intl.DateTimeFormat(undefined, {
-		hour: 'numeric',
+		hour: '2-digit',
 		minute: '2-digit',
-		hour12: true
+		hour12: false
 	}).format(d);
 }
 

--- a/ui/user/src/lib/components/nanobot/taskSchedule.ts
+++ b/ui/user/src/lib/components/nanobot/taskSchedule.ts
@@ -1,3 +1,5 @@
+import type { TimeDisplayFormat } from '$lib/time';
+
 export type TaskFrequency = 'daily' | 'weekly' | 'monthly' | 'no_repeat';
 
 export interface TaskScheduleForm {
@@ -49,7 +51,10 @@ export function formatScheduleDate(date: string): string {
 	}).format(parsed);
 }
 
-export function formatScheduleDateTime(value?: string | null): string {
+export function formatScheduleDateTime(
+	value: string | null | undefined,
+	format: TimeDisplayFormat
+): string {
 	if (!value) return 'Not available';
 
 	const parsed = new Date(value);
@@ -63,7 +68,7 @@ export function formatScheduleDateTime(value?: string | null): string {
 		day: 'numeric',
 		hour: '2-digit',
 		minute: '2-digit',
-		hour12: false
+		hour12: format === '12h'
 	}).format(parsed);
 }
 
@@ -168,7 +173,7 @@ export function buildCronSchedule(form: TaskScheduleForm): string {
 	}
 }
 
-function formatTime(time: string): string {
+function formatScheduleTime(time: string, format: TimeDisplayFormat): string {
 	const parts = time.split(':');
 	const hour = Number(parts[0]);
 	const minute = Number(parts[1] ?? 0);
@@ -188,11 +193,15 @@ function formatTime(time: string): string {
 	return new Intl.DateTimeFormat(undefined, {
 		hour: '2-digit',
 		minute: '2-digit',
-		hour12: false
+		hour12: format === '12h'
 	}).format(d);
 }
 
-export function scheduleSummary(schedule: string, expiration?: string): string {
+export function scheduleSummary(
+	schedule: string,
+	expiration: string | undefined,
+	format: TimeDisplayFormat
+): string {
 	if (!schedule?.trim()) return 'No schedule';
 
 	const fallback = defaultTaskScheduleForm();
@@ -205,7 +214,7 @@ export function scheduleSummary(schedule: string, expiration?: string): string {
 		return 'Schedule unavailable';
 	}
 
-	const time = formatTime(parsed.time);
+	const time = formatScheduleTime(parsed.time, format);
 	switch (parsed.frequency) {
 		case 'daily':
 			return `Daily at ${time}`;

--- a/ui/user/src/lib/components/nanobot/taskSchedule.ts
+++ b/ui/user/src/lib/components/nanobot/taskSchedule.ts
@@ -42,10 +42,11 @@ export function formatScheduleDate(date: string): string {
 		return date;
 	}
 
-	const month = String(parsed.getMonth() + 1).padStart(2, '0');
-	const day = String(parsed.getDate()).padStart(2, '0');
-	const year = parsed.getFullYear();
-	return `${month}-${day}-${year}`;
+	return new Intl.DateTimeFormat(undefined, {
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric'
+	}).format(parsed);
 }
 
 export function formatScheduleDateTime(value?: string | null): string {
@@ -56,9 +57,14 @@ export function formatScheduleDateTime(value?: string | null): string {
 		return value;
 	}
 
-	const date = `${String(parsed.getMonth() + 1).padStart(2, '0')}-${String(parsed.getDate()).padStart(2, '0')}-${parsed.getFullYear()}`;
-	const time = `${String(parsed.getHours()).padStart(2, '0')}:${String(parsed.getMinutes()).padStart(2, '0')}`;
-	return `${date} at ${time}`;
+	return new Intl.DateTimeFormat(undefined, {
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit',
+		hour12: true
+	}).format(parsed);
 }
 
 export function formatWeekdaySummary(daysOfWeek: string[]): string {
@@ -163,8 +169,27 @@ export function buildCronSchedule(form: TaskScheduleForm): string {
 }
 
 function formatTime(time: string): string {
-	const [hour, minute] = time.split(':');
-	return `${Number(hour)}:${minute}`;
+	const parts = time.split(':');
+	const hour = Number(parts[0]);
+	const minute = Number(parts[1] ?? 0);
+	if (
+		!Number.isInteger(hour) ||
+		!Number.isInteger(minute) ||
+		hour < 0 ||
+		hour > 23 ||
+		minute < 0 ||
+		minute > 59
+	) {
+		return time;
+	}
+
+	const d = new Date();
+	d.setHours(hour, minute, 0, 0);
+	return new Intl.DateTimeFormat(undefined, {
+		hour: 'numeric',
+		minute: '2-digit',
+		hour12: true
+	}).format(d);
 }
 
 export function scheduleSummary(schedule: string, expiration?: string): string {

--- a/ui/user/src/lib/components/profile/MyAccount.svelte
+++ b/ui/user/src/lib/components/profile/MyAccount.svelte
@@ -3,7 +3,7 @@
 	import ConfirmDeleteAccount from '$lib/components/ConfirmDeleteAccount.svelte';
 	import Toggle from '$lib/components/Toggle.svelte';
 	import { ChatService } from '$lib/services';
-	import { profile, errors, version } from '$lib/stores';
+	import { profile, errors, version, timePreference } from '$lib/stores';
 	import { success } from '$lib/stores/success';
 	import { goto } from '$lib/url';
 	import { getUserRoleLabel } from '$lib/utils';
@@ -68,6 +68,10 @@
 			savingPreferences = false;
 		}
 	}
+
+	function handleDisplay24HourFormatToggle(checked: boolean) {
+		timePreference.setTimeFormat(checked ? '24h' : '12h');
+	}
 </script>
 
 <button class="dropdown-link" onclick={() => dialog?.open()}>
@@ -87,21 +91,37 @@
 	/>
 	<div class="flex flex-row py-3">
 		<div class="w-1/2 max-w-[150px]">Display Name:</div>
-		<div class="w-1/2 break-words">{profile.current.displayName}</div>
+		<div class="w-1/2 wrap-break-word">{profile.current.displayName}</div>
 	</div>
 	<hr />
 	<div class="flex flex-row py-3">
 		<div class="w-1/2 max-w-[150px]">Email:</div>
-		<div class="w-1/2 break-words">{profile.current.email}</div>
+		<div class="w-1/2 wrap-break-word">{profile.current.email}</div>
 	</div>
 	<hr />
 	<div class="flex flex-row py-3">
 		<div class="w-1/2 max-w-[150px]">Role:</div>
-		<div class="w-1/2 break-words">
+		<div class="w-1/2 wrap-break-word">
 			{getUserRoleLabel(profile.current.effectiveRole)}
 		</div>
 	</div>
 	<hr />
+
+	<div class="flex flex-row items-center justify-between py-3">
+		<div class="flex flex-col gap-1">
+			<p>Display 24 Hour Format</p>
+			<span class="text-sm font-light opacity-70">
+				When enabled, time pickers and viewable times will be displayed in 24 hour format.
+			</span>
+		</div>
+		<Toggle
+			label=""
+			checked={timePreference.timeFormat === '24h'}
+			onChange={handleDisplay24HourFormatToggle}
+		/>
+	</div>
+	<hr />
+
 	{#if !version.current.autonomousToolUseEnabled}
 		<div class="flex flex-row items-center justify-between py-3">
 			<div class="flex flex-col gap-1">

--- a/ui/user/src/lib/format.ts
+++ b/ui/user/src/lib/format.ts
@@ -36,9 +36,9 @@ export function formatFileTime(timestamp: unknown): FileTimeResult {
 			year: 'numeric',
 			month: 'numeric',
 			day: 'numeric',
-			hour: 'numeric',
+			hour: '2-digit',
 			minute: '2-digit',
-			hour12: true
+			hour12: false
 		}).format(date);
 	} catch {
 		return { date: undefined, formatted: '' };

--- a/ui/user/src/lib/format.ts
+++ b/ui/user/src/lib/format.ts
@@ -1,4 +1,5 @@
 import type { FileTimeResult } from './services/nanobot/types';
+import type { TimeDisplayFormat } from './time';
 
 export function formatNumber(num: number): string {
 	if (num >= 1000) {
@@ -21,7 +22,7 @@ export function formatFileSize(bytes: number): string {
 	return `${size.toFixed(1)} ${units[unitIndex]}`;
 }
 
-export function formatFileTime(timestamp: unknown): FileTimeResult {
+export function formatFileTime(timestamp: unknown, format: TimeDisplayFormat): FileTimeResult {
 	if (typeof timestamp !== 'string') return { date: undefined, formatted: '' };
 
 	const value = timestamp.trim();
@@ -38,7 +39,7 @@ export function formatFileTime(timestamp: unknown): FileTimeResult {
 			day: 'numeric',
 			hour: '2-digit',
 			minute: '2-digit',
-			hour12: false
+			hour12: format === '12h'
 		}).format(date);
 	} catch {
 		return { date: undefined, formatted: '' };

--- a/ui/user/src/lib/format.ts
+++ b/ui/user/src/lib/format.ts
@@ -32,17 +32,14 @@ export function formatFileTime(timestamp: unknown): FileTimeResult {
 
 	let formatted = '';
 	try {
-		formatted = date
-			.toLocaleString(undefined, {
-				year: 'numeric',
-				month: 'numeric',
-				day: 'numeric',
-				hour: '2-digit',
-				minute: '2-digit',
-				hour12: false
-			})
-			.replace(/\//g, '-')
-			.replace(/,/g, '');
+		formatted = new Intl.DateTimeFormat(undefined, {
+			year: 'numeric',
+			month: 'numeric',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit',
+			hour12: true
+		}).format(date);
 	} catch {
 		return { date: undefined, formatted: '' };
 	}

--- a/ui/user/src/lib/stores/index.ts
+++ b/ui/user/src/lib/stores/index.ts
@@ -6,3 +6,4 @@ export { default as version } from './version.svelte';
 export { default as appPreferences } from './appPreferences.svelte';
 export { default as mcpServersAndEntries } from './mcpServersAndEntries.svelte';
 export { default as defaultModelAliases } from './defaultModelAliases.svelte';
+export { default as timePreference } from './timePreference.svelte';

--- a/ui/user/src/lib/stores/timePreference.svelte.ts
+++ b/ui/user/src/lib/stores/timePreference.svelte.ts
@@ -1,0 +1,34 @@
+import { browser } from '$app/environment';
+
+const store = $state({
+	timeFormat: getTimeFormat(),
+	setTimeFormat,
+	initialize
+});
+
+function initialize() {
+	if (!browser) {
+		return;
+	}
+	store.timeFormat = getTimeFormat();
+}
+
+function setTimeFormat(timeFormat: '12h' | '24h') {
+	if (browser) {
+		localStorage.setItem('timeFormat', timeFormat);
+	}
+	store.timeFormat = timeFormat;
+}
+
+function getTimeFormat(): '12h' | '24h' {
+	if (!browser) {
+		return '12h';
+	}
+	const timeFormat = localStorage.getItem('timeFormat') ?? '12h';
+	if (timeFormat === '24h') {
+		return '24h';
+	}
+	return '12h';
+}
+
+export default store;

--- a/ui/user/src/lib/time.ts
+++ b/ui/user/src/lib/time.ts
@@ -285,6 +285,21 @@ export function getTimeRangeShorthand(startTime: Date | string, endTime: Date | 
 	}
 }
 
+export function formatLogTimestamp(time: Date | string, format: TimeDisplayFormat) {
+	return new Date(time)
+		.toLocaleString(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit',
+			hour12: format === '12h',
+			timeZoneName: 'short'
+		})
+		.replace(/,/g, '');
+}
+
 export function isRecent(created: string, withinMinutes = 1): boolean {
 	const diff = Date.now() - new Date(created).getTime();
 	return diff < withinMinutes * 60 * 1000;

--- a/ui/user/src/lib/time.ts
+++ b/ui/user/src/lib/time.ts
@@ -1,8 +1,11 @@
-export function formatTime(time: Date | string) {
+export type TimeDisplayFormat = '12h' | '24h';
+
+export function formatTime(time: Date | string, format: TimeDisplayFormat) {
 	const now = new Date();
 	if (typeof time === 'string') {
 		time = new Date(time);
 	}
+	const hour12 = format === '12h';
 	if (
 		time.getDate() == now.getDate() &&
 		time.getMonth() == now.getMonth() &&
@@ -10,7 +13,8 @@ export function formatTime(time: Date | string) {
 	) {
 		return time.toLocaleTimeString(undefined, {
 			hour: 'numeric',
-			minute: 'numeric'
+			minute: 'numeric',
+			hour12
 		});
 	}
 	return time
@@ -20,7 +24,7 @@ export function formatTime(time: Date | string) {
 			day: '2-digit',
 			hour: 'numeric',
 			minute: '2-digit',
-			hour12: true
+			hour12
 		})
 		.replace(/\//g, '-')
 		.replace(/,/g, '');

--- a/ui/user/src/routes/+layout.svelte
+++ b/ui/user/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { page } from '$app/state';
 	import Notifications from '$lib/components/Notifications.svelte';
 	import ReLoginDialog from '$lib/components/ReLoginDialog.svelte';
@@ -9,7 +10,8 @@
 		appPreferences,
 		version,
 		mcpServersAndEntries,
-		defaultModelAliases
+		defaultModelAliases,
+		timePreference
 	} from '$lib/stores';
 	import '../app.css';
 	import type { PageData } from './$types';
@@ -43,6 +45,10 @@
 
 		if (data.defaultModelAliases) {
 			untrack(() => defaultModelAliases.initialize(data.defaultModelAliases));
+		}
+
+		if (browser) {
+			timePreference.initialize();
 		}
 	});
 

--- a/ui/user/src/routes/admin/policy-violations/+page.svelte
+++ b/ui/user/src/routes/admin/policy-violations/+page.svelte
@@ -15,7 +15,8 @@
 	} from '$lib/services/admin/types';
 	import { PolicyDirectionLabels } from '$lib/services/admin/types';
 	import type { PolicyDirection } from '$lib/services/admin/types';
-	import { responsive } from '$lib/stores';
+	import { responsive, timePreference } from '$lib/stores';
+	import { formatLogTimestamp } from '$lib/time';
 	import { getUserDisplayName } from '$lib/utils';
 	import { subDays, set } from 'date-fns';
 	import { ShieldAlert } from 'lucide-svelte';
@@ -533,18 +534,7 @@
 										<td class="px-6 py-3">{pageOffset + i + 1}</td>
 										<td class="whitespace-nowrap">
 											<div class="truncate px-6 py-4">
-												{new Date(v.createdAt)
-													.toLocaleString(undefined, {
-														year: 'numeric',
-														month: 'short',
-														day: 'numeric',
-														hour: '2-digit',
-														minute: '2-digit',
-														second: '2-digit',
-														hour12: true,
-														timeZoneName: 'short'
-													})
-													.replace(/,/g, '')}
+												{formatLogTimestamp(v.createdAt, timePreference.timeFormat)}
 											</div>
 										</td>
 										<td class="whitespace-nowrap">
@@ -668,7 +658,7 @@
 							<div class="flex flex-col gap-1 text-sm font-light">
 								<p>
 									<span class="font-medium">Timestamp</span>:
-									{new Date(detailedViolation.createdAt).toLocaleString()}
+									{formatLogTimestamp(detailedViolation.createdAt, timePreference.timeFormat)}
 								</p>
 								<p>
 									<span class="font-medium">User</span>:
@@ -716,11 +706,11 @@
 </Layout>
 
 <style lang="postcss">
-	.divider-horizontal {
-		width: 1px;
-		height: auto;
+	.divider {
+		height: 1px;
+		width: 100%;
 		background-color: var(--color-surface3);
-		margin-left: 1rem;
-		margin-right: 1rem;
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
 	}
 </style>

--- a/ui/user/src/routes/admin/token-usage/+page.svelte
+++ b/ui/user/src/routes/admin/token-usage/+page.svelte
@@ -696,7 +696,7 @@
 						<div class="flex shrink-0">
 							<button
 								class={twMerge(
-									'button-secondary rounded-r-none border-1 border-r-0 text-xs',
+									'button-secondary rounded-r-none border border-r-0 text-xs',
 									selectedTokenType === 'input' && 'bg-surface2 border-surface2'
 								)}
 								onclick={() => handleTokenTypeChange('input')}
@@ -705,7 +705,7 @@
 							</button>
 							<button
 								class={twMerge(
-									'button-secondary rounded-l-none border-1 text-xs',
+									'button-secondary rounded-l-none border text-xs',
 									selectedTokenType === 'output' && 'bg-surface2 border-surface2'
 								)}
 								onclick={() => handleTokenTypeChange('output')}

--- a/ui/user/src/routes/agent/p/[projectId]/files/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/files/+page.svelte
@@ -4,8 +4,9 @@
 	import { formatFileSize, formatFileTime } from '$lib/format';
 	import type { FileTimeResult, ProjectLayoutContext } from '$lib/services/nanobot/types';
 	import { PROJECT_LAYOUT_CONTEXT } from '$lib/services/nanobot/types';
-	import { responsive } from '$lib/stores';
+	import { responsive, timePreference } from '$lib/stores';
 	import { nanobotChat } from '$lib/stores/nanobotChat.svelte';
+	import type { TimeDisplayFormat } from '$lib/time';
 	import { tryDecodeURIComponent } from '$lib/url';
 	import {
 		ChevronDown,
@@ -53,7 +54,8 @@
 	}
 
 	function buildFileTreeSimple(
-		files: { uri: string; name?: string; size?: number; annotations?: { lastModified?: string } }[]
+		files: { uri: string; name?: string; size?: number; annotations?: { lastModified?: string } }[],
+		displayFormat: TimeDisplayFormat
 	): FileTreeNode[] {
 		const root: Extract<FileTreeNode, { type: 'folder' }> = {
 			type: 'folder',
@@ -86,7 +88,7 @@
 				name: fileName,
 				uri: f.uri,
 				size: f.size,
-				lastModified: formatFileTime(f.annotations?.lastModified)
+				lastModified: formatFileTime(f.annotations?.lastModified, displayFormat)
 			});
 		}
 		// Sort: folders first then files, both alphabetically
@@ -125,7 +127,7 @@
 				])
 	]);
 
-	let fileTree = $derived(buildFileTreeSimple(resourceFiles));
+	let fileTree = $derived(buildFileTreeSimple(resourceFiles, timePreference.timeFormat));
 
 	type FlatNode = { depth: number; path: string; node: FileTreeNode };
 	function flattenTree(

--- a/ui/user/src/routes/agent/p/[projectId]/files/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/files/+page.svelte
@@ -379,7 +379,7 @@
 								>
 								{#if !responsive.isMobile}
 									<td
-										><p class="truncate text-nowrap break-all">
+										><p class="text-nowrap">
 											{node.lastModified?.formatted || '-'}
 										</p></td
 									>

--- a/ui/user/src/routes/agent/p/[projectId]/scheduler/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/scheduler/+page.svelte
@@ -11,7 +11,7 @@
 		ScheduledTask
 	} from '$lib/services/nanobot/types';
 	import { PROJECT_LAYOUT_CONTEXT } from '$lib/services/nanobot/types';
-	import { errors } from '$lib/stores';
+	import { errors, timePreference } from '$lib/stores';
 	import { nanobotChat } from '$lib/stores/nanobotChat.svelte';
 	import { goto } from '$lib/url';
 	import ConfirmScheduleToggle from './ConfirmScheduleToggle.svelte';
@@ -95,7 +95,8 @@
 		return tasks.filter((task) => {
 			const summary = scheduleSummary(
 				String(taskMeta(task)?.schedule ?? ''),
-				taskMeta(task)?.expiration
+				taskMeta(task)?.expiration,
+				timePreference.timeFormat
 			).toLowerCase();
 			return (task.name ?? '').toLowerCase().includes(query) || summary.includes(query);
 		});
@@ -302,7 +303,11 @@
 					>
 						<td class="font-medium">{task.name}</td>
 						<td class="text-base-content/70">
-							{scheduleSummary(String(taskMeta(task)?.schedule ?? ''), taskMeta(task)?.expiration)}
+							{scheduleSummary(
+								String(taskMeta(task)?.schedule ?? ''),
+								taskMeta(task)?.expiration,
+								timePreference.timeFormat
+							)}
 						</td>
 						<td>
 							<span

--- a/ui/user/src/routes/agent/p/[projectId]/scheduler/ConfirmScheduleToggle.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/scheduler/ConfirmScheduleToggle.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Confirm from '$lib/components/Confirm.svelte';
 	import { estimateNextRun, formatScheduleDateTime } from '$lib/components/nanobot/taskSchedule';
+	import { timePreference } from '$lib/stores';
 
 	interface Props {
 		task?: {
@@ -40,7 +41,9 @@
 						<p class="mt-2">Are you sure you want to disable this schedule?</p>
 					{:else if !task.enabled && nextRun}
 						<p>The next run will be executed at:</p>
-						<p class="mt-2 font-semibold">{formatScheduleDateTime(nextRun.toISOString())}</p>
+						<p class="mt-2 font-semibold">
+							{formatScheduleDateTime(nextRun.toISOString(), timePreference.timeFormat)}
+						</p>
 						<p class="mt-2">Are you sure you want to enable this schedule?</p>
 					{/if}
 				{/if}

--- a/ui/user/src/routes/agent/p/[projectId]/scheduler/[scheduleId]/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/scheduler/[scheduleId]/+page.svelte
@@ -13,7 +13,7 @@
 		ScheduledTask
 	} from '$lib/services/nanobot/types';
 	import { PROJECT_LAYOUT_CONTEXT } from '$lib/services/nanobot/types';
-	import { errors } from '$lib/stores';
+	import { errors, timePreference } from '$lib/stores';
 	import { nanobotChat } from '$lib/stores/nanobotChat.svelte';
 	import { goto } from '$lib/url';
 	import ConfirmScheduleToggle from '../ConfirmScheduleToggle.svelte';
@@ -328,11 +328,15 @@
 			<div class="grid gap-0 md:grid-cols-2">
 				<div class="border-base-300 border-b px-5 py-4 md:border-r">
 					<div class="text-base-content/50 text-xs font-medium uppercase">Schedule</div>
-					<div class="mt-2 text-sm">{scheduleSummary(task.schedule, task.expiration)}</div>
+					<div class="mt-2 text-sm">
+						{scheduleSummary(task.schedule, task.expiration, timePreference.timeFormat)}
+					</div>
 				</div>
 				<div class="border-base-300 border-b px-5 py-4">
 					<div class="text-base-content/50 text-xs font-medium uppercase">Next run</div>
-					<div class="mt-2 text-sm">{formatScheduleDateTime(task.nextRunAt)}</div>
+					<div class="mt-2 text-sm">
+						{formatScheduleDateTime(task.nextRunAt, timePreference.timeFormat)}
+					</div>
 				</div>
 				<div class="border-base-300 px-5 py-4 md:border-r">
 					<div class="text-base-content/50 text-xs font-medium uppercase">Expiration</div>
@@ -342,7 +346,9 @@
 				</div>
 				<div class="px-5 py-4">
 					<div class="text-base-content/50 text-xs font-medium uppercase">Last run</div>
-					<div class="mt-2 text-sm">{formatScheduleDateTime(sortedSessions[0]?.created)}</div>
+					<div class="mt-2 text-sm">
+						{formatScheduleDateTime(sortedSessions[0]?.created, timePreference.timeFormat)}
+					</div>
 				</div>
 			</div>
 		</div>
@@ -403,7 +409,7 @@
 										<div class="truncate font-medium">{session.title || 'Untitled Session'}</div>
 									</td>
 									<td class="text-base-content/60 text-sm">
-										{formatScheduleDateTime(session.created)}
+										{formatScheduleDateTime(session.created, timePreference.timeFormat)}
 									</td>
 								</tr>
 							{/each}

--- a/ui/user/src/routes/agent/p/[projectId]/workflows/[workflowId]/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/workflows/[workflowId]/+page.svelte
@@ -14,7 +14,7 @@
 		PublishedArtifact
 	} from '$lib/services/nanobot/types';
 	import { PROJECT_LAYOUT_CONTEXT } from '$lib/services/nanobot/types';
-	import { profile, responsive } from '$lib/stores';
+	import { profile, responsive, timePreference } from '$lib/stores';
 	import { nanobotChat } from '$lib/stores/nanobotChat.svelte';
 	import { formatTimeAgo } from '$lib/time';
 	import { goto } from '$lib/url';
@@ -320,7 +320,8 @@
 							</td>
 							<td
 								><p class="truncate text-nowrap break-all">
-									{formatFileTime(resource.annotations?.lastModified).formatted || '-'}
+									{formatFileTime(resource.annotations?.lastModified, timePreference.timeFormat)
+										.formatted || '-'}
 								</p></td
 							>
 							<td>


### PR DESCRIPTION
Addresses #6248 

* also adjusts TimeInput so we can backspace (ex. hours "01" -> trying to backspace to delete "1" did nothing)
* also updates format for consistency (ex. we have TimeInput in 12hr format but time is displayed in 24hr format --> added localStorage user preference to display in 12 or 24hr preference in My Account. Time picker and display times will be appropriately displayed based on 12/24hr. Default is currently 12h.

<img width="533" height="648" alt="Screenshot 2026-04-13 at 3 20 16 PM" src="https://github.com/user-attachments/assets/5e3922f9-3879-4ed7-b5d8-bcda274fedd8" />


<img width="842" height="69" alt="Screenshot 2026-04-13 at 3 34 10 PM" src="https://github.com/user-attachments/assets/f8c7fbe5-7d42-4f06-b513-c68d5b1a7332" />
<img width="847" height="75" alt="Screenshot 2026-04-13 at 3 34 02 PM" src="https://github.com/user-attachments/assets/c484576e-ed35-4d54-9e0c-a22b4fcd4954" />
<img width="362" height="171" alt="Screenshot 2026-04-13 at 3 33 40 PM" src="https://github.com/user-attachments/assets/29527b42-c37b-4745-92d5-0f9538b37202" />
<img width="346" height="116" alt="Screenshot 2026-04-13 at 3 33 32 PM" src="https://github.com/user-attachments/assets/27c3cf8e-75a9-42d2-a40c-abbc9d86f5b5" />
<img width="1183" height="411" alt="Screenshot 2026-04-13 at 3 33 06 PM" src="https://github.com/user-attachments/assets/79c98d10-8406-4d01-b2cf-33163512772a" />
<img width="1171" height="422" alt="Screenshot 2026-04-13 at 3 32 51 PM" src="https://github.com/user-attachments/assets/442032bf-111b-4fc0-a452-c55b0e804e09" />

* also adds time picker option when focused on hour or minute of the TimeInput

<img width="402" height="560" alt="Screenshot 2026-04-13 at 3 37 50 PM" src="https://github.com/user-attachments/assets/106d9ca0-7263-4e62-b796-d42a8dd4a365" />
<img width="373" height="524" alt="Screenshot 2026-04-13 at 3 37 27 PM" src="https://github.com/user-attachments/assets/e21a17a3-ad13-4590-99b2-1917e39ef1b8" />
