### PR TITLE
fix: ensure agent credential is properly cleaned up on user delete

### DIFF
--- a/pkg/controller/handlers/cleanup/user.go
+++ b/pkg/controller/handlers/cleanup/user.go
@@ -104,7 +104,9 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 	var deletedServers int
 	for _, server := range servers.Items {
 		// Skip multi-user servers in the default MCPCatalog — they should persist after user deletion.
-		if server.Spec.MCPCatalogID == system.DefaultCatalog {
+		// Also skip servers that are associated with an agent because we need the credential to stick
+		// around so we can delete the API key.
+		if server.Spec.MCPCatalogID == system.DefaultCatalog || server.Spec.NanobotAgentID != "" {
 			continue
 		}
 		if err := kclient.IgnoreNotFound(req.Delete(&server)); err != nil {

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -510,7 +510,7 @@ func (h *Handler) deleteTokens(ctx context.Context, agent *v1.NanobotAgent, mcpS
 		}
 
 		// Look up the gateway user to get the uint ID needed for API key deletion
-		gatewayUser, err := h.gatewayClient.UserByID(ctx, agent.Spec.UserID)
+		gatewayUser, err := h.gatewayClient.UserByIDIncludeDeleted(ctx, agent.Spec.UserID)
 		if err != nil {
 			return fmt.Errorf("failed to get user: %w", err)
 		}


### PR DESCRIPTION
When the user is deleted, we should skip the MCP servers associated to the agents because they will be cleaned up elsewhere. And we need them to exist so that the credential and API keys can be properly deleted.

Issue: https://github.com/obot-platform/obot/issues/5936