### PR TITLE
fix: give auditors read-only access to token usage

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -204,6 +204,8 @@ var (
 			"GET /api/message-policy-violations/filter-options/{filter}",
 			"GET /api/message-policy-violations/{id}",
 			"GET /api/message-policy-violation-stats",
+			"GET /api/token-usage",
+			"GET /api/total-token-usage",
 			"GET /api/nanobot-agents",
 		},
 		anyGroup: {


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/6168