### PR TITLE
feat: Run Obot local with local K8s backend

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -118,3 +118,96 @@ The documentation for Obot is in the main repo. You can serve the documentation 
 ## Other Configuration
 
 Obot is configured via environment variables. You can see the relevant environment variables by building the binary (as above) and running `./bin/obot server --help`. There is also documentation available. You can serve the documentation locally as above.
+
+## Running Obot Locally with Kubernetes (Nanobot Agents)
+
+Nanobot agent containers run in Kubernetes and need to reach your local Obot process. This requires [Telepresence](https://www.telepresence.io/) to bridge the network between your Mac and the cluster.
+
+### Prerequisites
+
+- [Rancher Desktop](https://rancherdesktop.io/) (or another local Kubernetes setup)
+- [Telepresence](https://www.telepresence.io/docs/install/) v2.x
+- Local images loaded into containerd (see below)
+
+### 1. Load local images into containerd
+
+Rancher Desktop uses containerd, not Docker's image store. Load any locally built images with:
+
+```bash
+docker save nanobot:local | nerdctl --address /var/run/docker/containerd/containerd.sock load
+docker save nanobot-agent:local | nerdctl --address /var/run/docker/containerd/containerd.sock load
+```
+
+### 2. Configure the cluster namespaces
+
+The `obot-mcp` namespace is where MCP server pods run. It must exist with PSA set to `privileged` (required for Telepresence's network init container):
+
+```bash
+kubectl create namespace obot-mcp --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace obot-mcp \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/audit=restricted \
+  pod-security.kubernetes.io/warn=restricted \
+  --overwrite
+```
+
+The `default` namespace also needs PSA set to `privileged` for Telepresence:
+
+```bash
+kubectl label namespace default \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/audit=restricted \
+  pod-security.kubernetes.io/warn=restricted \
+  --overwrite
+```
+
+### 3. Set up Telepresence and intercept
+
+Use the Makefile target to create/update the intercept target, reconnect Telepresence, restart the target deployment, and create the intercept in one step:
+
+```bash
+make telepresence-setup
+```
+
+This target runs:
+
+```bash
+kubectl create deployment obot-upstream --image=alpine --dry-run=client -o yaml -- sleep infinity | kubectl apply -f -
+kubectl create service clusterip obot-upstream --tcp=8080:8080 --dry-run=client -o yaml | kubectl apply -f -
+kubectl patch svc obot-upstream --type='json' -p='[{"op":"replace","path":"/spec/ports/0/name","value":"http"}]'
+kubectl apply -f tools/obot-proxy.yaml
+telepresence quit -s
+telepresence connect
+kubectl rollout restart deployment/obot-upstream
+telepresence intercept obot-upstream -p 8080:8080
+```
+
+`obot-upstream` is the Telepresence intercept target — traffic to it routes to your local port 8080. `tools/obot-proxy.yaml` deploys an nginx pod as the `obot` Service (port 80). Pods reach Obot at `http://obot.default.svc.cluster.local` → nginx → `obot-upstream` (Telepresence) → your local process. nginx rewrites `http://localhost:8080` → `http://obot.default.svc.cluster.local` in response bodies so that OAuth metadata URLs are correct for pods, while your browser continues to use `http://localhost:8080` directly.
+
+Verify the intercept is `ACTIVE` with `telepresence list`.
+
+### 4. Configure Obot environment variables
+
+```bash
+export OBOT_SERVER_MCPRUNTIME_BACKEND='k8s'
+export OBOT_SERVER_SERVICE_NAME=obot
+export OBOT_SERVER_SERVICE_NAMESPACE=default
+
+# optional if using locally-built Nanobot images
+export OBOT_SERVER_NANOBOT_AGENT_IMAGE='nanobot-agent:local'
+export OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE='nanobot:local'
+```
+
+### Troubleshooting
+
+- **`ImagePullBackOff`**: Image isn't in containerd — re-run `nerdctl load`.
+- **`timed out waiting for MCP server to be ready: <url>`**: The URL in the error shows what Obot is trying to reach. If it's `*.svc.kubernetes` instead of `*.svc.cluster.local`, check `OBOT_SERVER_MCPCLUSTER_DOMAIN`.
+- **Telepresence `NO_AGENT`**: Pod was created before intercept — run `kubectl rollout restart deployment/obot-upstream`.
+- **PSA violations on `tel-agent-init`**: Namespace enforce level must be `privileged` (step 2 above).
+- **Stale intercept conflict** (`conflict with intercept ... on port 8080`): A previous intercept is stuck in the Traffic Manager. Reset it with:
+  ```bash
+  kubectl delete pod -n ambassador -l app=traffic-manager
+  kubectl rollout restart deployment/obot-upstream
+  telepresence connect --namespace default
+  telepresence intercept obot-upstream -p 8080:8080
+  ```

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,16 @@ otel-jaeger-down:
 otel-jaeger-logs:
 	docker compose -f tools/jaeger-compose.yaml logs -f
 
+telepresence-setup:
+	kubectl create deployment obot-upstream --image=alpine --dry-run=client -o yaml -- sleep infinity | kubectl apply -f -
+	kubectl create service clusterip obot-upstream --tcp=8080:8080 --dry-run=client -o yaml | kubectl apply -f -
+	kubectl patch svc obot-upstream --type='json' -p='[{"op":"replace","path":"/spec/ports/0/name","value":"http"}]'
+	kubectl apply -f tools/obot-proxy.yaml
+	telepresence quit -s
+	telepresence connect
+	kubectl rollout restart deployment/obot-upstream
+	telepresence intercept obot-upstream -p 8080:8080
+
 # Lint the project
 lint: lint-go
 
@@ -102,4 +112,4 @@ remove-docs-version:
 	jq 'del(.[] | select(. == "${version}"))' ./docs/versions.json > tmp.json && mv tmp.json ./docs/versions.json
 	grep -v '"${version}": {label: "${version}", banner: "none", path: "${version}"},' ./docs/docusaurus.config.ts  > tmp.config.ts && mv tmp.config.ts ./docs/docusaurus.config.ts
 
-.PHONY: ui ui-user build all clean dev dev-open otel-jaeger-up otel-jaeger-down otel-jaeger-logs lint lint-admin lint-api no-changes fmt tidy gen-docs-release deprecate-docs-release remove-docs-version
+.PHONY: ui ui-user build all clean dev dev-open otel-jaeger-up otel-jaeger-down otel-jaeger-logs telepresence-setup lint lint-admin lint-api no-changes fmt tidy gen-docs-release deprecate-docs-release remove-docs-version

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -50,7 +50,7 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/obot-platform/nanobot:v0.0.80` |
 | `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/obot-platform/nanobot-agent:v0.0.80` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.20.4` |
-| `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker, kubernetes, or local. | `kubernetes` in the helm chart, `docker` otherwise |
+| `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker or kubernetes. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |
 | `OBOT_SERVER_SERVICE_NAME` | The Kubernetes service name for the obot server. Automatically set by the helm chart when using kubernetes backend. Used to construct the internal service FQDN for token exchange endpoints. | - |
 | `OBOT_SERVER_SERVICE_NAMESPACE` | The Kubernetes namespace where the obot server runs. Automatically set by the helm chart when using kubernetes backend. Used to construct the internal service FQDN for token exchange endpoints. | - |

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -3407,10 +3407,7 @@ func (m *MCPHandler) CheckK8sSettingsStatus(req api.Context) error {
 
 // RedeployWithK8sSettings redeploys a server with the current K8s settings
 func (m *MCPHandler) RedeployWithK8sSettings(req api.Context) error {
-	switch m.mcpSessionManager.MCPRuntimeBackend() {
-	case "kubernetes", "k8s":
-		// Supported
-	default:
+	if !mcp.IsKubernetesBackend(m.mcpSessionManager.MCPRuntimeBackend()) {
 		return types.NewErrBadRequest("Redeployment with K8s settings is only supported for Kubernetes backend")
 	}
 

--- a/pkg/api/handlers/version.go
+++ b/pkg/api/handlers/version.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/obot-platform/obot/pkg/version"
 	"golang.org/x/mod/module"
 	"gorm.io/gorm"
@@ -139,7 +140,11 @@ func (v *VersionHandler) getVersionResponse() map[string]any {
 	values["disableLegacyChat"] = v.disableLegacyChat
 	values["sessionStore"] = v.sessionStore
 	values["enterprise"] = v.enterprise
-	values["engine"] = v.engine
+	engine := v.engine
+	if mcp.IsKubernetesBackend(engine) {
+		engine = mcp.RuntimeBackendKubernetes
+	}
+	values["engine"] = engine
 	values["mcpNetworkPolicyEnabled"] = v.mcpNetworkPolicyEnabled
 	values["mcpDefaultDenyAllEgress"] = v.mcpDefaultDenyAllEgress
 	values["autonomousToolUseEnabled"] = v.autonomousToolUseEnabled

--- a/pkg/controller/network_policy_provider.go
+++ b/pkg/controller/network_policy_provider.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/obot-platform/obot/pkg/serviceaccounts"
 	"github.com/obot-platform/obot/pkg/services"
 	"helm.sh/helm/v3/pkg/action"
@@ -76,8 +77,7 @@ func helmActionError(err error, capture *helmLogCapture) error {
 
 func (c *Controller) reconcileNetworkPolicyProvider(ctx context.Context) error {
 	if !c.services.MCPNetworkPolicyEnabled &&
-		c.services.MCPRuntimeBackend != "kubernetes" &&
-		c.services.MCPRuntimeBackend != "k8s" {
+		!mcp.IsKubernetesBackend(c.services.MCPRuntimeBackend) {
 		return nil
 	}
 

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -18,11 +18,15 @@ const (
 	defaultContainerPort          = 8099
 	defaultWebhookToolName        = "fire-webhook"
 	serviceUnavailableGracePeriod = 10 * time.Second
+
+	runtimeBackendDocker          = "docker"
+	RuntimeBackendKubernetes      = "kubernetes"
+	runtimeBackendKubernetesShort = "k8s"
 )
 
 func IsKubernetesBackend(backend string) bool {
 	switch strings.ToLower(strings.TrimSpace(backend)) {
-	case "kubernetes", "k8s":
+	case RuntimeBackendKubernetes, runtimeBackendKubernetesShort:
 		return true
 	default:
 		return false

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -31,7 +31,7 @@ type Options struct {
 	MCPNamespace                      string   `usage:"The namespace to use for MCP containers" default:"obot-mcp"`
 	MCPClusterDomain                  string   `usage:"The cluster domain to use for MCP containers" default:"cluster.local"`
 	DisallowLocalhostMCP              bool     `usage:"Allow MCP containers to run on localhost"`
-	MCPRuntimeBackend                 string   `usage:"The runtime backend to use for running MCP servers: docker, kubernetes, or local. Defaults to docker." default:"docker"`
+	MCPRuntimeBackend                 string   `usage:"The runtime backend to use for running MCP servers: docker, kubernetes, or k8s. Defaults to docker" default:"docker"`
 	MCPImagePullSecrets               []string `usage:"The name of the image pull secret to use for pulling MCP images"`
 	SingleUserIdleServerShutdownHours int      `usage:"The interval in hours to check for idle MCP servers designated to a single user and shut them down, set to -1 to disable shutdown" default:"24"`
 	MultiUserIdleServerShutdownHours  int      `usage:"The interval in hours to check for idle multi-user MCP servers and shut them down, set to -1 to disable" default:"168"`
@@ -100,14 +100,14 @@ func NewSessionManager(ctx context.Context, tokenService TokenService, baseURL s
 	var backend backend
 
 	switch opts.MCPRuntimeBackend {
-	case "docker":
+	case runtimeBackendDocker:
 		dockerBackend, err := newDockerBackend(ctx, httpListenPort, opts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize Docker backend: %w", err)
 		}
 
 		backend = dockerBackend
-	case "kubernetes", "k8s":
+	case RuntimeBackendKubernetes, runtimeBackendKubernetesShort:
 		if localK8sConfig == nil {
 			return nil, fmt.Errorf("use of Kubernetes backend requested but no local K8s config available")
 		}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -532,7 +532,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		return nil, fmt.Errorf("invalid MCP OAuth client expiration: must be at least 1 minute")
 	}
 
-	runtimeIsK8s := config.MCPRuntimeBackend == "kubernetes" || config.MCPRuntimeBackend == "k8s"
+	runtimeIsK8s := mcp.IsKubernetesBackend(config.MCPRuntimeBackend)
 	if runtimeIsK8s && config.StorageListenPort == 0 {
 		config.StorageListenPort = 8443
 	}

--- a/pkg/validation/mcpvalidators.go
+++ b/pkg/validation/mcpvalidators.go
@@ -1218,7 +1218,7 @@ func ValidateSecretBindings(manifest types.MCPServerManifest, gitManaged bool, m
 		if h.SecretBinding == nil {
 			return nil
 		}
-		if mcpBackend != "kubernetes" && mcpBackend != "k8s" {
+		if !mcp.IsKubernetesBackend(mcpBackend) {
 			return fmt.Errorf("%s %q: secretBinding requires the kubernetes MCP runtime backend", kind, key)
 		}
 		if !gitManaged {

--- a/tools/obot-proxy.yaml
+++ b/tools/obot-proxy.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: obot-proxy-config
+  namespace: default
+data:
+  nginx.conf: |
+    events {}
+    http {
+      server {
+        listen 80;
+        location / {
+          proxy_pass http://obot-upstream.default.svc.cluster.local:8080;
+          proxy_set_header Host $host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header Accept-Encoding "";
+
+          sub_filter 'http://localhost:8080' 'http://obot.default.svc.cluster.local';
+          sub_filter_once off;
+          sub_filter_types *;
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: obot-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: obot-proxy
+  template:
+    metadata:
+      labels:
+        app: obot-proxy
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
+        - name: config
+          configMap:
+            name: obot-proxy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: obot
+  namespace: default
+spec:
+  selector:
+    app: obot-proxy
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary
This PR enables running Obot locally while using a local Kubernetes cluster as the MCP runtime backend.

It works by using an nginx Deployment/Service that pods in the cluster use as Obot. Then, Telepresence is used to redirect this to Obot running locally (outside the cluster).

Also, unify/simplify the MCP backend detection.