### PR TITLE
fix: properly report kubernetes status of shutdown servers

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -653,20 +653,6 @@ func (m *MCPHandler) GetOAuthURL(req api.Context) error {
 		return fmt.Errorf("failed to get OAuth URL: %w", err)
 	}
 
-	// Best effort to update the last request time.
-	// Don't update on every request, only if it's been a while since the last update, to avoid excessive writes to storage.
-	if time.Since(server.Status.LastRequestTime.Time) > requestTimeUpdateInterval {
-		server.Status.LastRequestTime = metav1.Now()
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-
-			if err := req.Storage.Status().Update(ctx, &server); err != nil {
-				log.Warnf("failed to update mcp server status: %v", err)
-			}
-		}()
-	}
-
 	return req.Write(map[string]string{"oauthURL": u})
 }
 
@@ -1271,6 +1257,15 @@ func serverFromMCPServerInstance(req api.Context, instance v1.MCPServerInstance)
 		return server, mcp.ServerConfig{}, types.NewErrBadRequest("missing required config: %s", strings.Join(missingConfig, ", "))
 	}
 
+	// Best effort to update the last request time.
+	// Don't update on every request, only if it's been a while since the last update, to avoid excessive writes to storage.
+	if time.Since(server.Status.LastRequestTime.Time) > requestTimeUpdateInterval {
+		server.Status.LastRequestTime = metav1.Now()
+		if err := req.Storage.Status().Update(req.Context(), &server); err != nil {
+			log.Warnf("failed to update mcp server status: %v", err)
+		}
+	}
+
 	return server, serverConfig, nil
 }
 
@@ -1412,6 +1407,15 @@ func serverConfigForAction(req api.Context, server v1.MCPServer) (mcp.ServerConf
 
 	if len(missingConfig) > 0 {
 		return mcp.ServerConfig{}, types.NewErrBadRequest("missing required config: %s", strings.Join(missingConfig, ", "))
+	}
+
+	// Best effort to update the last request time.
+	// Don't update on every request, only if it's been a while since the last update, to avoid excessive writes to storage.
+	if time.Since(server.Status.LastRequestTime.Time) > requestTimeUpdateInterval {
+		server.Status.LastRequestTime = metav1.Now()
+		if err := req.Storage.Status().Update(req.Context(), &server); err != nil {
+			log.Warnf("failed to update mcp server status: %v", err)
+		}
 	}
 
 	return serverConfig, nil

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -1,18 +1,15 @@
 package mcpgateway
 
 import (
-	"context"
 	"fmt"
 	"maps"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/obot/apiclient/types"
-	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/api/handlers"
 	"github.com/obot-platform/obot/pkg/controller/handlers/systemmcpserver"
@@ -21,13 +18,8 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
-
-var log = logger.Package()
-
-const requestTimeUpdateInterval = 15 * time.Minute
 
 type Handler struct {
 	mcpSessionManager         *mcp.SessionManager
@@ -135,20 +127,6 @@ func (h *Handler) ensureServerIsDeployed(req api.Context) (string, bool, error) 
 	url, err := h.mcpSessionManager.LaunchServer(req.Context(), mcpServerConfig)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to launch mcp server: %w", err)
-	}
-
-	// Best effort to update the last request time.
-	// Don't update on every request, only if it's been a while since the last update, to avoid excessive writes to storage.
-	if time.Since(mcpServer.Status.LastRequestTime.Time) > requestTimeUpdateInterval {
-		mcpServer.Status.LastRequestTime = metav1.Now()
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
-
-			if err := req.Storage.Status().Update(ctx, &mcpServer); err != nil {
-				log.Warnf("failed to update mcp server status: %v", err)
-			}
-		}()
 	}
 
 	return url, h.nanobotIntegrationEnabled && mcpServerConfig.NanobotAgentName != "", nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -537,7 +537,7 @@ func (c *Controller) setupLocalK8sRoutes() {
 	}
 
 	deploymentHandler := deployment.New(c.services.MCPServerNamespace, c.services.Router.Backend())
-	c.localK8sRouter.Type(&appsv1.Deployment{}).HandlerFunc(deploymentHandler.UpdateMCPServerStatus)
+	c.localK8sRouter.Type(&appsv1.Deployment{}).IncludeRemoved().HandlerFunc(deploymentHandler.UpdateMCPServerStatus)
 	c.localK8sRouter.Type(&appsv1.Deployment{}).HandlerFunc(deploymentHandler.CleanupOldIDs)
 
 	secretHandler := secret.New(c.services.MCPServerNamespace, c.services.GPTClient)

--- a/pkg/controller/handlers/deployment/deployment.go
+++ b/pkg/controller/handlers/deployment/deployment.go
@@ -34,6 +34,28 @@ func New(mcpNamespace string, storageClient kclient.Client) *Handler {
 // UpdateMCPServerStatus watches for Deployment changes and copies status information
 // to the corresponding MCPServer object based on the "app" label
 func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) error {
+	if req.Object == nil {
+		// The deployment has been deleted, reset the status of the corresponding MCPServer
+		var mcpServer v1.MCPServer
+		if err := h.storageClient.Get(req.Ctx, kclient.ObjectKey{
+			Name:      req.Name,
+			Namespace: h.mcpNamespace,
+		}, &mcpServer); apierrors.IsNotFound(err) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to get MCPServer %s: %w", req.Name, err)
+		}
+
+		// Reset deployment-related status fields
+		mcpServer.Status.DeploymentStatus = "Shutdown"
+		mcpServer.Status.DeploymentAvailableReplicas = nil
+		mcpServer.Status.DeploymentReadyReplicas = nil
+		mcpServer.Status.DeploymentReplicas = nil
+		mcpServer.Status.DeploymentConditions = nil
+
+		return h.storageClient.Status().Update(req.Ctx, &mcpServer)
+	}
+
 	deployment := req.Object.(*appsv1.Deployment)
 
 	// Get the MCP server name from the deployment label

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -132,7 +132,7 @@ type MCPServerStatus struct {
 	NeedsUpdate bool `json:"needsUpdate,omitempty"`
 	// MCPServerInstanceUserCount contains the number of unique users with server instances pointing to this MCP server.
 	MCPServerInstanceUserCount *int `json:"mcpInstanceUserCount,omitempty"`
-	// DeploymentStatus indicates the overall status of the MCP server deployment (Available, Progressing, Unavailable, Needs Attention, Unknown).
+	// DeploymentStatus indicates the overall status of the MCP server deployment (Available, Progressing, Unavailable, Needs Attention, Shutdown, Unknown).
 	DeploymentStatus string `json:"deploymentStatus,omitempty"`
 	// DeploymentAvailableReplicas is the number of available replicas in the deployment.
 	DeploymentAvailableReplicas *int32 `json:"deploymentAvailableReplicas,omitempty"`

--- a/pkg/storage/apis/obot.obot.ai/v1/systemmcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/systemmcpserver.go
@@ -27,7 +27,7 @@ type SystemMCPServerSpec struct {
 }
 
 type SystemMCPServerStatus struct {
-	// DeploymentStatus indicates overall status (Available, Progressing, Unavailable, Needs Attention, Unknown)
+	// DeploymentStatus indicates overall status (Available, Progressing, Unavailable, Needs Attention, Shutdown, Unknown)
 	DeploymentStatus string `json:"deploymentStatus,omitempty"`
 	// DeploymentAvailableReplicas is the number of available replicas
 	DeploymentAvailableReplicas *int32 `json:"deploymentAvailableReplicas,omitempty"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -16877,7 +16877,7 @@ func schema_storage_apis_obotobotai_v1_MCPServerStatus(ref common.ReferenceCallb
 					},
 					"deploymentStatus": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DeploymentStatus indicates the overall status of the MCP server deployment (Available, Progressing, Unavailable, Needs Attention, Unknown).",
+							Description: "DeploymentStatus indicates the overall status of the MCP server deployment (Available, Progressing, Unavailable, Needs Attention, Shutdown, Unknown).",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -21102,7 +21102,7 @@ func schema_storage_apis_obotobotai_v1_SystemMCPServerStatus(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"deploymentStatus": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DeploymentStatus indicates overall status (Available, Progressing, Unavailable, Needs Attention, Unknown)",
+							Description: "DeploymentStatus indicates overall status (Available, Progressing, Unavailable, Needs Attention, Shutdown, Unknown)",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
This change also centralizes the "last request" logic for MCP servers by putting it in a location that is exercised in all of our MCP-based requests.

Issue: https://github.com/obot-platform/obot/issues/3505