### PR TITLE
fix: add delete ref for model type

### DIFF
--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -162,6 +162,7 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.ToolReference{}).FinalizeFunc(v1.ToolReferenceFinalizer, toolRef.CleanupModelProvider)
 
 	// Models
+	root.Type(&v1.Model{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.Model{}).HandlerFunc(alias.AssignAlias)
 	root.Type(&v1.Model{}).HandlerFunc(generationed.UpdateObservedGeneration)
 

--- a/pkg/storage/apis/obot.obot.ai/v1/model.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/model.go
@@ -10,6 +10,7 @@ var (
 	_ fields.Fields = (*Model)(nil)
 	_ Aliasable     = (*Model)(nil)
 	_ Generationed  = (*Model)(nil)
+	_ DeleteRefs    = (*Model)(nil)
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -19,6 +20,12 @@ type Model struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              ModelSpec   `json:"spec,omitempty"`
 	Status            ModelStatus `json:"status,omitempty"`
+}
+
+func (m *Model) DeleteRefs() []Ref {
+	return []Ref{
+		{ObjType: &ToolReference{}, Name: m.Spec.Manifest.ModelProvider},
+	}
 }
 
 func (m *Model) Has(field string) (exists bool) {


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/6335

So, ToolReferences have a finalizer on them that is supposed to delete the corresponding Models. For some reason, this must not have fired on Voyage in Main when we deleted it from the tools repo. I'm not sure why, but adding this DeleteRef should knock out the models that were associated with it on the next controller startup.