### PR TITLE
fix: display icon with server during elicitation if available

### DIFF
--- a/ui/user/src/lib/components/Confirm.svelte
+++ b/ui/user/src/lib/components/Confirm.svelte
@@ -116,8 +116,11 @@
 						{/if}
 					</button>
 				{/if}
-				<button onclick={oncancel} type="button" class="button w-full justify-center"
-					>{cancelText}</button
+				<button
+					onclick={oncancel}
+					type="button"
+					class="button w-full justify-center"
+					disabled={loading}>{cancelText}</button
 				>
 			</div>
 		</div>

--- a/ui/user/src/lib/components/nanobot/Elicitation.svelte
+++ b/ui/user/src/lib/components/nanobot/Elicitation.svelte
@@ -4,7 +4,7 @@
 		ElicitationResult,
 		PrimitiveSchemaDefinition
 	} from '$lib/services/nanobot/types';
-	import { ChevronLeft, ChevronRight, Pencil, Info, X } from 'lucide-svelte';
+	import { ChevronLeft, ChevronRight, Pencil, Info, X, ServerIcon } from 'lucide-svelte';
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 	import { twMerge } from 'tailwind-merge';
 
@@ -554,9 +554,7 @@
 
 			{#if isOAuthElicitation()}
 				<!-- OAuth Authentication Dialog -->
-				<h3 class="mb-4 text-lg font-bold">
-					{elicitation._meta?.['ai.nanobot.meta/server-name'] || 'Authentication Required'}
-				</h3>
+				{@render elicitationServerHeader('Authentication Required', elicitation._meta)}
 
 				<div class="mb-4">
 					<p class="text-base-content/80 mb-4 text-sm whitespace-pre-wrap">{elicitation.message}</p>
@@ -572,9 +570,7 @@
 				</div>
 			{:else}
 				<!-- Generic Elicitation Form -->
-				<h3 class="mb-4 text-lg font-bold">
-					{elicitation._meta?.['ai.nanobot.meta/server-name'] || 'Information Request'}
-				</h3>
+				{@render elicitationServerHeader('Information Request', elicitation._meta)}
 
 				<div class="mb-4">
 					<p class="text-base-content/80 text-sm whitespace-pre-wrap">{elicitation.message}</p>
@@ -748,3 +744,21 @@
 		</div>
 	</dialog>
 {/if}
+
+{#snippet elicitationServerHeader(
+	fallbackHeader: string,
+	elicitationMeta?: Record<string, unknown>
+)}
+	{@const serverIcon = elicitationMeta?.['ai.nanobot.meta/server-icon'] as string}
+	{@const serverName = elicitationMeta?.['ai.nanobot.meta/server-name'] as string}
+	<div class="flex gap-2 items-center mb-4">
+		{#if serverIcon}
+			<img src={serverIcon as string} alt={serverName || fallbackHeader} class="size-6" />
+		{:else}
+			<ServerIcon class="size-6" />
+		{/if}
+		<h3 class="text-lg font-bold">
+			{serverName || fallbackHeader}
+		</h3>
+	</div>
+{/snippet}


### PR DESCRIPTION
Addresses #5836 comment asking for icon to display along with elicitation

oauth elicitation:
<img width="758" height="592" alt="Screenshot 2026-04-16 at 1 07 20 PM" src="https://github.com/user-attachments/assets/34eabc9a-73e9-4e0d-98d7-3bf409b14ce6" />

catalog entry with params elicitation:
<img width="1120" height="669" alt="Screenshot 2026-04-16 at 1 19 57 PM" src="https://github.com/user-attachments/assets/920682d1-315b-4de2-b8b4-796da8b676dd" />

