### PR TITLE
enhance: admin dashboard page

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -1516,6 +1516,14 @@
 			}
 		}
 	}
+
+	.tooltip-divider {
+		height: 1px;
+		width: 100%;
+		background-color: var(--color-surface3);
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
+	}
 }
 
 .nanobot .prose,

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -239,7 +239,6 @@
 						id: 'agent-management',
 						icon: Bot,
 						label: 'Obot Agent Management',
-						disabled: isBootStrapUser,
 						collapsible: true,
 						items: [
 							{

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -55,7 +55,8 @@
 		CircleQuestionMark,
 		ShieldAlert,
 		ShieldX,
-		Bot
+		Bot,
+		LayoutDashboard
 	} from 'lucide-svelte';
 	import { type Component, type Snippet, untrack } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
@@ -172,6 +173,12 @@
 	let navLinks = $derived<NavLink[]>(
 		profile.current.hasAdminAccess?.()
 			? [
+					{
+						id: 'mcp-dashboard',
+						icon: LayoutDashboard,
+						label: 'Dashboard',
+						href: '/admin/dashboard'
+					},
 					{
 						id: 'mcp-server-management',
 						icon: RadioTower,

--- a/ui/user/src/lib/components/TweenedMetric.svelte
+++ b/ui/user/src/lib/components/TweenedMetric.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { cubicOut } from 'svelte/easing';
+	import { Tween } from 'svelte/motion';
+
+	interface Props {
+		target: number;
+		/** When true, the displayed value stays at 0 (e.g. while loading). */
+		holdAtZero?: boolean;
+		duration?: number;
+		/** Format the animated value for display; defaults to rounded integer string. */
+		format?: (n: number) => string;
+	}
+
+	let {
+		target,
+		holdAtZero = false,
+		duration = 650,
+		format = (n) => String(Math.round(n))
+	}: Props = $props();
+
+	const tween = new Tween(0, { easing: cubicOut });
+
+	$effect(() => {
+		if (holdAtZero) {
+			void tween.set(0, { duration: 0 });
+			return;
+		}
+		void tween.set(target, { duration });
+	});
+</script>
+
+{format(tween.current)}

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+	import { AdminService, type MCPCatalog } from '$lib/services';
+	import { TriangleAlert, X } from 'lucide-svelte';
+
+	interface Props {
+		defaultCatalog?: MCPCatalog;
+		defaultCatalogId?: string;
+		onSync?: () => void;
+	}
+
+	let { defaultCatalog, onSync, defaultCatalogId }: Props = $props();
+
+	let saving = $state(false);
+	let sourceError = $state<string>();
+	let editingSource = $state<{ index: number; value: string }>();
+	let sourceDialog = $state<HTMLDialogElement>();
+
+	export function open() {
+		editingSource = {
+			index: -1,
+			value: ''
+		};
+		sourceDialog?.showModal();
+	}
+
+	function closeSourceDialog() {
+		editingSource = undefined;
+		sourceError = undefined;
+		sourceDialog?.close();
+	}
+</script>
+
+<dialog bind:this={sourceDialog} class="dialog">
+	<div class="dialog-container w-full max-w-md p-4">
+		{#if editingSource}
+			<h3 class="dialog-title">
+				{editingSource.index === -1 ? 'Add Source URL' : 'Edit Source URL'}
+				<button onclick={() => closeSourceDialog()} class="icon-button dialog-close-btn">
+					<X class="size-5" />
+				</button>
+			</h3>
+
+			<div class="my-4 flex flex-col gap-1">
+				<label for="catalog-source-name" class="flex-1 text-sm font-light capitalize"
+					>Source URL
+				</label>
+				<input
+					id="catalog-source-name"
+					bind:value={editingSource.value}
+					class="text-input-filled"
+				/>
+			</div>
+
+			{#if sourceError}
+				<div class="mb-4 flex flex-col gap-2 text-red-500 dark:text-red-400">
+					<div class="flex items-center gap-2">
+						<TriangleAlert class="size-6 shrink-0 self-start" />
+						<p class="my-0.5 flex flex-col text-sm font-semibold">Error adding source URL:</p>
+					</div>
+					<span class="font-sm font-light break-all">{sourceError}</span>
+				</div>
+			{/if}
+
+			<div class="flex w-full justify-end gap-2">
+				<button class="button" disabled={saving} onclick={() => closeSourceDialog()}>Cancel</button>
+				<button
+					class="button-primary"
+					disabled={saving}
+					onclick={async () => {
+						if (!editingSource || (!defaultCatalog && !defaultCatalogId)) {
+							return;
+						}
+
+						let catalogToUse = defaultCatalog;
+						if (!catalogToUse && defaultCatalogId) {
+							catalogToUse = await AdminService.getMCPCatalog(defaultCatalogId);
+						}
+
+						if (!catalogToUse) {
+							sourceError = 'Failed to fetch catalog';
+							return;
+						}
+
+						saving = true;
+						sourceError = undefined;
+
+						try {
+							const updatingCatalog = { ...catalogToUse };
+
+							if (editingSource.index === -1) {
+								updatingCatalog.sourceURLs = [
+									...(updatingCatalog.sourceURLs ?? []),
+									editingSource.value
+								];
+							} else {
+								updatingCatalog.sourceURLs[editingSource.index] = editingSource.value;
+							}
+
+							const response = await AdminService.updateMCPCatalog(
+								catalogToUse.id,
+								updatingCatalog,
+								{
+									dontLogErrors: true
+								}
+							);
+							defaultCatalog = response;
+							await onSync?.();
+							closeSourceDialog();
+						} catch (error) {
+							sourceError = error instanceof Error ? error.message : 'An unexpected error occurred';
+						} finally {
+							saving = false;
+						}
+					}}
+				>
+					Add
+				</button>
+			</div>
+		{/if}
+	</div>
+	<form class="dialog-backdrop">
+		<button type="button" onclick={() => sourceDialog?.close()}>close</button>
+	</form>
+</dialog>

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -16,6 +16,7 @@
 	let sourceDialog = $state<HTMLDialogElement>();
 
 	export function open() {
+		sourceError = undefined;
 		editingSource = {
 			index: -1,
 			value: ''
@@ -35,7 +36,7 @@
 		{#if editingSource}
 			<h3 class="dialog-title">
 				{editingSource.index === -1 ? 'Add Source URL' : 'Edit Source URL'}
-				<button onclick={() => closeSourceDialog()} class="icon-button dialog-close-btn">
+				<button onclick={closeSourceDialog} class="icon-button dialog-close-btn">
 					<X class="size-5" />
 				</button>
 			</h3>
@@ -62,7 +63,7 @@
 			{/if}
 
 			<div class="flex w-full justify-end gap-2">
-				<button class="button" disabled={saving} onclick={() => closeSourceDialog()}>Cancel</button>
+				<button class="button" disabled={saving} onclick={closeSourceDialog}>Cancel</button>
 				<button
 					class="button-primary"
 					disabled={saving}
@@ -119,6 +120,6 @@
 		{/if}
 	</div>
 	<form class="dialog-backdrop">
-		<button type="button" onclick={() => sourceDialog?.close()}>close</button>
+		<button type="button" onclick={closeSourceDialog}>close</button>
 	</form>
 </dialog>

--- a/ui/user/src/lib/components/admin/SearchMcpServers.svelte
+++ b/ui/user/src/lib/components/admin/SearchMcpServers.svelte
@@ -230,7 +230,7 @@
 										{/if}
 									</div>
 									<span class="text-on-surface1 line-clamp-2 text-xs">
-										{@html stripMarkdownToText(item.description ?? '')}
+										{stripMarkdownToText(item.description ?? '')}
 									</span>
 								</div>
 							</div>

--- a/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
+++ b/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
@@ -19,6 +19,11 @@
 	import AuditLogCalendar from '../audit-logs/AuditLogCalendar.svelte';
 	import FiltersDrawer from '../filters-drawer/FiltersDrawer.svelte';
 	import type { SupportedStateFilter } from './types';
+	import {
+		transformAvgToolCallResponseTime,
+		transformTopServerUsage,
+		transformTopToolCalls
+	} from './utils';
 	import { endOfDay, isBefore, set, subDays } from 'date-fns';
 	import { ChevronsLeft, ChevronsRight, Funnel, ChartBarDecreasing, X } from 'lucide-svelte';
 	import { flip } from 'svelte/animate';
@@ -231,28 +236,7 @@
 			tooltip: 'calls',
 			formatXLabel: (d) => String(d).split('.').slice(1).join('.'),
 			formatTooltipText: (data) => `${data.count} calls • ${data.serverDisplayName}`,
-			transform: (stats) => {
-				// eslint-disable-next-line svelte/prefer-svelte-reactivity
-				const counts = new Map<string, { count: number; serverDisplayName: string }>();
-				for (const s of stats?.items ?? []) {
-					for (const call of s.toolCalls ?? []) {
-						const key = `${s.mcpServerDisplayName}.${call.toolName}`;
-						const existing = counts.get(key) ?? {
-							count: 0,
-							serverDisplayName: s.mcpServerDisplayName
-						};
-						existing.count += call.callCount;
-						counts.set(key, existing);
-					}
-				}
-				return Array.from(counts.entries())
-					.map(([toolName, { count, serverDisplayName }]) => ({
-						toolName,
-						count,
-						serverDisplayName
-					}))
-					.sort((a, b) => b.count - a.count);
-			}
+			transform: transformTopToolCalls
 		},
 		{
 			id: 'most-frequently-used-servers',
@@ -260,19 +244,7 @@
 			xKey: 'serverName',
 			yKey: 'count',
 			tooltip: 'calls',
-			transform: (stats) => {
-				// eslint-disable-next-line svelte/prefer-svelte-reactivity
-				const counts = new Map<string, number>();
-				for (const s of stats?.items ?? []) {
-					const total = (s.toolCalls ?? []).reduce((sum, t) => sum + t.callCount, 0);
-					if (total > 0) {
-						counts.set(s.mcpServerDisplayName, (counts.get(s.mcpServerDisplayName) ?? 0) + total);
-					}
-				}
-				return Array.from(counts.entries())
-					.map(([serverName, count]) => ({ serverName, count }))
-					.sort((a, b) => b.count - a.count);
-			}
+			transform: transformTopServerUsage
 		},
 		{
 			id: 'tool-call-average-response-time',
@@ -283,37 +255,7 @@
 			formatXLabel: (d) => String(d).split('.').slice(1).join('.'),
 			formatTooltipText: (data) =>
 				`${(data.averageResponseTimeMs as number).toFixed(2)}ms avg • ${data.serverDisplayName}`,
-			transform: (stats) => {
-				// eslint-disable-next-line svelte/prefer-svelte-reactivity
-				const responseTimes = new Map<
-					string,
-					{ total: number; count: number; serverDisplayName: string }
-				>();
-
-				for (const s of stats?.items ?? []) {
-					for (const call of s.toolCalls ?? []) {
-						const key = `${s.mcpServerDisplayName}.${call.toolName}`;
-						for (const item of call.items ?? []) {
-							const entry = responseTimes.get(key) ?? {
-								total: 0,
-								count: 0,
-								serverDisplayName: s.mcpServerDisplayName
-							};
-							entry.total += item.processingTimeMs;
-							entry.count += 1;
-							responseTimes.set(key, entry);
-						}
-					}
-				}
-
-				return Array.from(responseTimes.entries())
-					.map(([toolName, { total, count, serverDisplayName }]) => ({
-						toolName,
-						averageResponseTimeMs: count > 0 ? total / count : 0,
-						serverDisplayName
-					}))
-					.sort((a, b) => b.averageResponseTimeMs - a.averageResponseTimeMs);
-			}
+			transform: transformAvgToolCallResponseTime
 		},
 		{
 			id: 'tool-call-individual-response-time',

--- a/ui/user/src/lib/components/admin/usage/utils.ts
+++ b/ui/user/src/lib/components/admin/usage/utils.ts
@@ -1,0 +1,67 @@
+import type { AuditLogUsageStats } from '$lib/services';
+
+export function transformTopToolCalls(stats: AuditLogUsageStats | undefined) {
+	const counts = new Map<string, { count: number; serverDisplayName: string }>();
+	for (const s of stats?.items ?? []) {
+		for (const call of s.toolCalls ?? []) {
+			const key = `${s.mcpServerDisplayName}.${call.toolName}`;
+			const existing = counts.get(key) ?? {
+				count: 0,
+				serverDisplayName: s.mcpServerDisplayName
+			};
+			existing.count += call.callCount;
+			counts.set(key, existing);
+		}
+	}
+	return Array.from(counts.entries())
+		.map(([toolName, { count, serverDisplayName }]) => ({
+			toolName,
+			count,
+			serverDisplayName
+		}))
+		.sort((a, b) => b.count - a.count);
+}
+
+export function transformTopServerUsage(stats: AuditLogUsageStats | undefined) {
+	const counts = new Map<string, number>();
+	for (const s of stats?.items ?? []) {
+		const total = (s.toolCalls ?? []).reduce((sum, t) => sum + t.callCount, 0);
+		if (total > 0) {
+			counts.set(s.mcpServerDisplayName, (counts.get(s.mcpServerDisplayName) ?? 0) + total);
+		}
+	}
+	return Array.from(counts.entries())
+		.map(([serverName, count]) => ({ serverName, count }))
+		.sort((a, b) => b.count - a.count);
+}
+
+export function transformAvgToolCallResponseTime(stats: AuditLogUsageStats | undefined) {
+	const responseTimes = new Map<
+		string,
+		{ total: number; count: number; serverDisplayName: string }
+	>();
+
+	for (const s of stats?.items ?? []) {
+		for (const call of s.toolCalls ?? []) {
+			const key = `${s.mcpServerDisplayName}.${call.toolName}`;
+			for (const item of call.items ?? []) {
+				const entry = responseTimes.get(key) ?? {
+					total: 0,
+					count: 0,
+					serverDisplayName: s.mcpServerDisplayName
+				};
+				entry.total += item.processingTimeMs;
+				entry.count += 1;
+				responseTimes.set(key, entry);
+			}
+		}
+	}
+
+	return Array.from(responseTimes.entries())
+		.map(([toolName, { total, count, serverDisplayName }]) => ({
+			toolName,
+			averageResponseTimeMs: count > 0 ? total / count : 0,
+			serverDisplayName
+		}))
+		.sort((a, b) => b.averageResponseTimeMs - a.averageResponseTimeMs);
+}

--- a/ui/user/src/lib/components/api-keys/ApiKeyDetails.svelte
+++ b/ui/user/src/lib/components/api-keys/ApiKeyDetails.svelte
@@ -191,7 +191,7 @@
 										</p>
 										{#if d.description}
 											<span class="text-on-surface1 line-clamp-1 text-xs">
-												{@html stripMarkdownToText(d.description)}
+												{stripMarkdownToText(d.description)}
 											</span>
 										{/if}
 									</div>

--- a/ui/user/src/lib/components/graph/DonutGraph.svelte
+++ b/ui/user/src/lib/components/graph/DonutGraph.svelte
@@ -1,11 +1,24 @@
 <script lang="ts">
 	import { darkMode } from '$lib/stores';
-	import { arc, pie, type PieArcDatum } from 'd3';
+	import { autoUpdate, computePosition, flip, offset } from '@floating-ui/dom';
+	import { arc, pie, select, type PieArcDatum } from 'd3';
+	import type { Snippet } from 'svelte';
+	import { cubicOut } from 'svelte/easing';
+	import { tweened } from 'svelte/motion';
+	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 
 	export type DonutDatum = {
 		label: string;
 		value: number;
+	};
+
+	/** Tooltip payload for a slice (passed to `tooltipContent` snippet). */
+	export type DonutTooltipItem = {
+		label: string;
+		value: number;
+		/** Share of total in [0, 100]. */
+		percentOfTotal: number;
 	};
 
 	interface Props {
@@ -14,13 +27,15 @@
 		/** Inner radius as a fraction of the outer radius (0 = pie, 1 = invisible). */
 		donutRatio?: number;
 		formatValue?: (value: number) => string;
+		tooltipContent?: Snippet<[DonutTooltipItem]>;
 	}
 
 	let {
 		data,
 		class: klass = '',
 		donutRatio = 0.58,
-		formatValue = (v) => String(v)
+		formatValue = (v) => String(v),
+		tooltipContent
 	}: Props = $props();
 
 	const defaultPalette = [
@@ -53,28 +68,105 @@
 
 	const total = $derived(data.reduce((sum, d) => sum + Math.max(0, Number(d.value) || 0), 0));
 
-	const slices = $derived.by(() => {
+	const dataKey = $derived(data.map((d) => `${d.label}:${d.value}`).join('|'));
+
+	const progress = tweened(0, { duration: 550, easing: cubicOut });
+
+	function scheduleDonutEntryAnimation(_seriesKey: string) {
+		void progress.set(0, { duration: 0 }).then(() => void progress.set(1));
+	}
+
+	$effect(() => {
+		if (total <= 0) {
+			void progress.set(0, { duration: 0 });
+			return;
+		}
+		scheduleDonutEntryAnimation(dataKey);
+	});
+
+	let highlightedArcElement = $state<SVGGraphicsElement>();
+	let currentItem = $state<DonutTooltipItem>();
+
+	function tooltip(reference: Element, floating: HTMLElement) {
+		const compute = async () => {
+			const position = await computePosition(reference, floating, {
+				placement: 'top',
+				middleware: [
+					offset(8),
+					flip({
+						padding: {
+							top: 0,
+							right: 40,
+							left: 40,
+							bottom: 0
+						},
+						boundary: document.documentElement,
+						fallbackPlacements: ['top', 'top-end', 'top-start', 'left-start', 'right-start']
+					})
+				]
+			});
+
+			const { x, y } = position;
+
+			floating.style.transform = `translate(${x}px, ${y}px)`;
+		};
+
+		return autoUpdate(reference, floating, compute, {
+			animationFrame: true,
+			ancestorScroll: true,
+			ancestorResize: true
+		});
+	}
+
+	function computeSlices(p: number) {
 		if (outerRadius <= 0 || total <= 0) return [];
 		const snapshot = $state.snapshot(data);
 		const arcGen = arc<PieArcDatum<DonutDatum>>()
 			.innerRadius(innerRadius)
 			.outerRadius(outerRadius)
 			.cornerRadius(0.5);
-		return pieGenerator(snapshot).map((d, i) => ({
-			path: arcGen(d) ?? '',
-			color: colorAt(i),
-			label: d.data.label,
-			value: d.data.value
-		}));
-	});
+		return pieGenerator(snapshot).map((d, i) => {
+			const scaled: PieArcDatum<DonutDatum> = {
+				...d,
+				endAngle: d.startAngle + (d.endAngle - d.startAngle) * p
+			};
+			return {
+				path: arcGen(scaled) ?? '',
+				color: colorAt(i),
+				label: d.data.label,
+				value: d.data.value
+			};
+		});
+	}
 </script>
 
-<div class={twMerge('flex min-h-0 min-w-0 flex-col gap-3', klass)}>
+<div class={twMerge('group relative flex min-h-0 min-w-0 flex-col gap-3', klass)}>
 	<div
 		bind:clientWidth
 		bind:clientHeight
 		class="relative flex min-h-[160px] w-full flex-1 items-center justify-center"
 	>
+		{#if highlightedArcElement && currentItem}
+			<div
+				class="tooltip bg-background dark:bg-surface2 pointer-events-none fixed top-0 left-0 z-50 flex flex-col shadow-md min-w-32"
+				{@attach (node) => tooltip(highlightedArcElement!, node)}
+				in:fade={{ duration: 100, delay: 10 }}
+				out:fade={{ duration: 100 }}
+			>
+				{#if tooltipContent}
+					{@render tooltipContent(currentItem)}
+				{:else}
+					<div class="flex flex-col gap-0 text-xs">
+						<div class="text-on-background text-sm">{currentItem.label}</div>
+						<div class="border-on-surface1 mb-2 border-b pb-2">
+							{currentItem.percentOfTotal.toFixed(1)}% of total
+						</div>
+					</div>
+					<div class="text-on-background text-2xl font-bold">{formatValue(currentItem.value)}</div>
+				{/if}
+			</div>
+		{/if}
+
 		{#if total <= 0}
 			<p class="text-muted-foreground text-sm">No data</p>
 		{:else}
@@ -87,23 +179,42 @@
 				aria-label="Donut chart"
 			>
 				<g>
-					{#each slices as slice, i (i)}
-						<path d={slice.path} fill={slice.color} class="stroke-background stroke-1" />
+					{#each computeSlices($progress) as slice, i (i)}
+						<path
+							role="graphics-symbol"
+							aria-label="{slice.label}, {formatValue(Math.max(0, Number(slice.value) || 0))}"
+							d={slice.path}
+							fill={slice.color}
+							class="cursor-pointer stroke-background stroke-1"
+							onpointerenter={(e) => {
+								const el = e.currentTarget as SVGGraphicsElement;
+								highlightedArcElement = el;
+								const raw = Math.max(0, Number(slice.value) || 0);
+								currentItem = {
+									label: slice.label,
+									value: raw,
+									percentOfTotal: total > 0 ? (raw / total) * 100 : 0
+								};
+								select(el).attr('stroke', 'currentColor').attr('stroke-width', 2);
+							}}
+							onpointerleave={(e) => {
+								if (e.currentTarget === highlightedArcElement) {
+									highlightedArcElement = undefined;
+									currentItem = undefined;
+								}
+								select(e.currentTarget as SVGGraphicsElement)
+									.attr('stroke-width', 0)
+									.attr('stroke', null);
+							}}
+						/>
 					{/each}
 				</g>
-				<text
-					text-anchor="middle"
-					dominant-baseline="central"
-					class="fill-foreground pointer-events-none text-sm font-medium tabular-nums"
-				>
-					{formatValue(total)}
-				</text>
 			</svg>
 		{/if}
 	</div>
 
 	{#if total > 0 && data.length > 0}
-		<ul class="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+		<ul class="flex flex-wrap gap-x-4 gap-y-1 text-xs justify-center">
 			{#each data as row, i (i)}
 				<li class="flex items-center gap-1.5">
 					<span
@@ -112,9 +223,6 @@
 						aria-hidden="true"
 					></span>
 					<span class="text-foreground">{row.label}</span>
-					<span class="text-muted-foreground tabular-nums"
-						>{formatValue(Number(row.value) || 0)}</span
-					>
 				</li>
 			{/each}
 		</ul>

--- a/ui/user/src/lib/components/graph/DonutGraph.svelte
+++ b/ui/user/src/lib/components/graph/DonutGraph.svelte
@@ -4,7 +4,7 @@
 	import { arc, pie, select, type PieArcDatum } from 'd3';
 	import type { Snippet } from 'svelte';
 	import { cubicOut } from 'svelte/easing';
-	import { tweened } from 'svelte/motion';
+	import { Tween } from 'svelte/motion';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 
@@ -70,7 +70,7 @@
 
 	const dataKey = $derived(data.map((d) => `${d.label}:${d.value}`).join('|'));
 
-	const progress = tweened(0, { duration: 550, easing: cubicOut });
+	const progress = new Tween(0, { duration: 550, easing: cubicOut });
 
 	function scheduleDonutEntryAnimation(_seriesKey: string) {
 		void progress.set(0, { duration: 0 }).then(() => void progress.set(1));
@@ -168,7 +168,7 @@
 		{/if}
 
 		{#if total <= 0}
-			<p class="text-muted-foreground text-sm">No data</p>
+			<p class="text-on-surface1 font-light text-sm">No data</p>
 		{:else}
 			<svg
 				class="max-h-full max-w-full"
@@ -179,7 +179,7 @@
 				aria-label="Donut chart"
 			>
 				<g>
-					{#each computeSlices($progress) as slice, i (i)}
+					{#each computeSlices(progress.current) as slice, i (i)}
 						<path
 							role="graphics-symbol"
 							aria-label="{slice.label}, {formatValue(Math.max(0, Number(slice.value) || 0))}"

--- a/ui/user/src/lib/components/graph/DonutGraph.svelte
+++ b/ui/user/src/lib/components/graph/DonutGraph.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import { darkMode } from '$lib/stores';
+	import { arc, pie, type PieArcDatum } from 'd3';
+	import { twMerge } from 'tailwind-merge';
+
+	export type DonutDatum = {
+		label: string;
+		value: number;
+	};
+
+	interface Props {
+		data: DonutDatum[];
+		class?: string;
+		/** Inner radius as a fraction of the outer radius (0 = pie, 1 = invisible). */
+		donutRatio?: number;
+		formatValue?: (value: number) => string;
+	}
+
+	let {
+		data,
+		class: klass = '',
+		donutRatio = 0.58,
+		formatValue = (v) => String(v)
+	}: Props = $props();
+
+	const defaultPalette = [
+		'#4575b4',
+		'#fee090',
+		'#fdae61',
+		'#f46d43',
+		'#d73027',
+		'#e0f3f8',
+		'#abd9e9',
+		'#74add1'
+	];
+
+	const grayColor = $derived(darkMode.isDark ? '#999999' : '#cccccc');
+
+	function colorAt(i: number) {
+		return i < defaultPalette.length ? (defaultPalette[i] ?? grayColor) : grayColor;
+	}
+
+	const pieGenerator = pie<DonutDatum>()
+		.sort(null)
+		.value((d) => Math.max(0, Number(d.value) || 0));
+
+	let clientWidth = $state(0);
+	let clientHeight = $state(0);
+
+	const size = $derived(Math.min(Math.max(clientWidth, 1), Math.max(clientHeight, 1), 320));
+	const outerRadius = $derived(Math.max(0, size / 2 - 2));
+	const innerRadius = $derived(outerRadius * donutRatio);
+
+	const total = $derived(data.reduce((sum, d) => sum + Math.max(0, Number(d.value) || 0), 0));
+
+	const slices = $derived.by(() => {
+		if (outerRadius <= 0 || total <= 0) return [];
+		const snapshot = $state.snapshot(data);
+		const arcGen = arc<PieArcDatum<DonutDatum>>()
+			.innerRadius(innerRadius)
+			.outerRadius(outerRadius)
+			.cornerRadius(0.5);
+		return pieGenerator(snapshot).map((d, i) => ({
+			path: arcGen(d) ?? '',
+			color: colorAt(i),
+			label: d.data.label,
+			value: d.data.value
+		}));
+	});
+</script>
+
+<div class={twMerge('flex min-h-0 min-w-0 flex-col gap-3', klass)}>
+	<div
+		bind:clientWidth
+		bind:clientHeight
+		class="relative flex min-h-[160px] w-full flex-1 items-center justify-center"
+	>
+		{#if total <= 0}
+			<p class="text-muted-foreground text-sm">No data</p>
+		{:else}
+			<svg
+				class="max-h-full max-w-full"
+				width={size}
+				height={size}
+				viewBox="{-size / 2} {-size / 2} {size} {size}"
+				role="img"
+				aria-label="Donut chart"
+			>
+				<g>
+					{#each slices as slice, i (i)}
+						<path d={slice.path} fill={slice.color} class="stroke-background stroke-1" />
+					{/each}
+				</g>
+				<text
+					text-anchor="middle"
+					dominant-baseline="central"
+					class="fill-foreground pointer-events-none text-sm font-medium tabular-nums"
+				>
+					{formatValue(total)}
+				</text>
+			</svg>
+		{/if}
+	</div>
+
+	{#if total > 0 && data.length > 0}
+		<ul class="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+			{#each data as row, i (i)}
+				<li class="flex items-center gap-1.5">
+					<span
+						class="inline-block size-2.5 shrink-0 rounded-sm"
+						style:background-color={colorAt(i)}
+						aria-hidden="true"
+					></span>
+					<span class="text-foreground">{row.label}</span>
+					<span class="text-muted-foreground tabular-nums"
+						>{formatValue(Number(row.value) || 0)}</span
+					>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/ui/user/src/lib/components/graph/HorizontalBarRow.svelte
+++ b/ui/user/src/lib/components/graph/HorizontalBarRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { cubicOut } from 'svelte/easing';
-	import { tweened } from 'svelte/motion';
+	import { Tween } from 'svelte/motion';
 
 	interface Props {
 		targetWidth: number;
@@ -24,7 +24,7 @@
 		onpointerleave
 	}: Props = $props();
 
-	const width = tweened(0, { duration: 400, easing: cubicOut });
+	const width = new Tween(0, { duration: 400, easing: cubicOut });
 
 	$effect(() => {
 		width.set(targetWidth);
@@ -34,7 +34,7 @@
 <rect
 	x={0}
 	{y}
-	width={$width}
+	width={width.current}
 	{height}
 	{rx}
 	ry={rx}

--- a/ui/user/src/lib/format.ts
+++ b/ui/user/src/lib/format.ts
@@ -1,11 +1,20 @@
 import type { FileTimeResult } from './services/nanobot/types';
 
+function formatWithSuffix(value: number, suffix: string): string {
+	return value % 1 === 0 ? `${value}${suffix}` : `${value.toFixed(1)}${suffix}`;
+}
+
 export function formatNumber(num: number): string {
-	if (num >= 1000) {
-		const thousands = num / 1000;
-		return thousands % 1 === 0 ? `${thousands}k` : `${thousands.toFixed(1)}k`;
+	if (num < 1000) {
+		return num.toString();
 	}
-	return num.toString();
+	if (num >= 1_000_000_000) {
+		return formatWithSuffix(num / 1_000_000_000, 'B');
+	}
+	if (num >= 1_000_000) {
+		return formatWithSuffix(num / 1_000_000, 'M');
+	}
+	return formatWithSuffix(num / 1000, 'k');
 }
 
 export function formatFileSize(bytes: number): string {

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -832,6 +832,8 @@ export interface TokenUsage {
 	date: string;
 }
 
+export type TokenUsageWithCategory = TokenUsage & { category: string };
+
 export interface TokenUsageTimeRange {
 	start: Date | string;
 	end: Date | string;

--- a/ui/user/src/routes/+page.ts
+++ b/ui/user/src/routes/+page.ts
@@ -27,7 +27,7 @@ export const load: PageLoad = async ({ fetch, url, parent }) => {
 
 		const agentLinkEnabled = isAgentEnabled(defaultModelAliases);
 		const defaultRoute = isAdminOrOwner
-			? '/admin/mcp-servers'
+			? '/admin/dashboard'
 			: version?.nanobotIntegration && agentLinkEnabled
 				? '/agent'
 				: '/mcp-servers';

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -3,6 +3,7 @@
 	import DotDotDot from '$lib/components/DotDotDot.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import TweenedMetric from '$lib/components/TweenedMetric.svelte';
+	import McpServerGitSync from '$lib/components/admin/McpServerGitSync.svelte';
 	import {
 		transformTopToolCalls,
 		transformTopServerUsage,
@@ -41,6 +42,7 @@
 	let totalTokensData = $state<TotalTokenUsage>();
 
 	let selectServerTypeDialog = $state<ReturnType<typeof SelectServerType>>();
+	let sourceDialog = $state<ReturnType<typeof McpServerGitSync>>();
 
 	type TopToolCallRow = {
 		compositeKey: string;
@@ -541,11 +543,7 @@
 								<button
 									class="menu-button"
 									onclick={() => {
-										// editingSource = {
-										// 	index: -1,
-										// 	value: ''
-										// };
-										// sourceDialog?.showModal();
+										sourceDialog?.open();
 									}}
 								>
 									Add server(s) from Git
@@ -634,6 +632,14 @@
 	</div>
 </Layout>
 
+<McpServerGitSync
+	bind:this={sourceDialog}
+	onSync={async () => {
+		await AdminService.refreshMCPCatalog(DEFAULT_MCP_CATALOG_ID);
+		goto('/admin/mcp-servers');
+	}}
+	defaultCatalogId={DEFAULT_MCP_CATALOG_ID}
+/>
 <SelectServerType bind:this={selectServerTypeDialog} onSelectServerType={handleSelectServerType} />
 
 <svelte:head>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -309,7 +309,7 @@
 					</div>
 				</div>
 			</div>
-			{#if loading}
+			{#if loadingToolUsage}
 				<div class="bg-surface3 h-[400px] animate-pulse rounded-md"></div>
 			{:else}
 				<div in:fade={{ duration: 150 }} class="paper gap-1 w-full min-h-72">
@@ -403,7 +403,6 @@
 						<div class="pt-2 flex flex-col gap-4 w-full">
 							{#each Array.from({ length: TOP_TOOLS_LIMIT }) as _, i (i)}
 								<div class="flex gap-2 items-center animate-pulse w-full">
-									<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
 									<div class="flex flex-col gap-2 flex-1">
 										<div class="h-4 w-full rounded bg-surface3"></div>
 										<div class="h-3 w-full rounded bg-surface3"></div>
@@ -451,7 +450,7 @@
 			</div>
 		</div>
 		<div class="col-span-12 @min-[768px]:col-span-4 flex flex-col gap-4">
-			{#if serverAndEntries.loading}
+			{#if serverAndEntries.loading || loading}
 				<div class="bg-surface3 h-[530px] animate-pulse rounded-md"></div>
 				<div class="paper gap-1 flex grow">
 					<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -98,10 +98,10 @@
 	function topServersFromStats(stats: AuditLogUsageStats | undefined): TopServerUsageRow[] {
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
 		const counts = new Map<string, number>();
-		for (const s of stats?.items.filter(
+		for (const s of (stats?.items ?? []).filter(
 			(s) =>
 				!s.mcpServerDisplayName.startsWith('nba1') && !s.mcpServerDisplayName.startsWith('Obot ')
-		) ?? []) {
+		)) {
 			const total = (s.toolCalls ?? []).reduce((sum, t) => sum + t.callCount, 0);
 			if (total > 0) {
 				counts.set(s.mcpServerDisplayName, (counts.get(s.mcpServerDisplayName) ?? 0) + total);

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -4,14 +4,17 @@
 	import DonutGraph from '$lib/components/graph/DonutGraph.svelte';
 	import StackedTimeline from '$lib/components/graph/StackedTimeline.svelte';
 	import { formatNumber } from '$lib/format';
+	import { stripMarkdownToText } from '$lib/markdown';
 	import {
 		AdminService,
+		type MCPCatalogEntry,
+		type MCPCatalogServer,
 		type OrgUser,
 		type TokenUsage,
 		type TokenUsageWithCategory,
 		type TotalTokenUsage
 	} from '$lib/services';
-	import { errors } from '$lib/stores';
+	import { errors, mcpServersAndEntries } from '$lib/stores';
 	import { aggregateTimelineDataByBucket, getUserLabels } from '../token-usage/utils';
 	import { isWithinInterval, subMonths } from 'date-fns';
 	import { Activity, ChevronRight, Coins, PencilRuler, Server, Users, Wrench } from 'lucide-svelte';
@@ -43,6 +46,89 @@
 		usersData.filter(
 			(user) => user.lastActiveDay && isWithinInterval(user.lastActiveDay, { start, end })
 		).length
+	);
+
+	function compileServerAndEntries(data: typeof mcpServersAndEntries.current) {
+		const serversMap = new Map(data.servers.map((s) => [s.id, s]));
+		const entriesMap = new Map(data.entries.map((e) => [e.id, e]));
+		const instancesCount = data.userInstances.reduce<
+			Record<string, { server: MCPCatalogServer | undefined; count: number; id: string }>
+		>((acc, instance) => {
+			if (!instance.mcpServerID) return acc;
+			if (!acc[instance.mcpServerID]) {
+				const server = serversMap.get(instance.mcpServerID);
+				if (!server) return acc;
+				acc[instance.mcpServerID] = {
+					server,
+					count: 0,
+					id: server.id
+				};
+			}
+			acc[instance.mcpServerID].count++;
+			return acc;
+		}, {});
+		const catalogEntriesCount = data.userConfiguredServers.reduce<
+			Record<string, { entry: MCPCatalogEntry | undefined; count: number; id: string }>
+		>((acc, server) => {
+			if (!server.catalogEntryID) return acc;
+			if (!acc[server.catalogEntryID]) {
+				const entry = entriesMap.get(server.catalogEntryID);
+				if (!entry) return acc;
+				acc[server.catalogEntryID] = {
+					entry,
+					count: 0,
+					id: entry.id
+				};
+			}
+			acc[server.catalogEntryID].count++;
+			return acc;
+		}, {});
+		const combine = [...Object.values(instancesCount), ...Object.values(catalogEntriesCount)];
+		// sort by count descending
+		combine.sort((a, b) => b.count - a.count);
+
+		const entrieTypes = Object.values(catalogEntriesCount).reduce(
+			(acc, info) => {
+				if (!info.entry) return acc;
+				if (info.entry.manifest.runtime === 'composite') acc.composite++;
+				else if (info.entry.manifest.runtime === 'remote') acc.remote++;
+				else acc.single++;
+				return acc;
+			},
+			{
+				single: 0,
+				remote: 0,
+				composite: 0
+			}
+		);
+
+		return {
+			graphData: [
+				{
+					label: 'Multi-User',
+					value: Object.keys(instancesCount).length
+				},
+				{
+					label: 'Single-User',
+					value: entrieTypes.single
+				},
+				{
+					label: 'Remote',
+					value: entrieTypes.remote
+				},
+				{
+					label: 'Composite',
+					value: entrieTypes.composite
+				}
+			],
+			popularServers: combine.slice(0, 5),
+			totalServers: data.userConfiguredServers.length + data.userInstances.length
+		};
+	}
+
+	const serverAndEntries = $derived(mcpServersAndEntries.current);
+	const { graphData, popularServers, totalServers } = $derived(
+		compileServerAndEntries(serverAndEntries)
 	);
 
 	onMount(async () => {
@@ -334,92 +420,70 @@
 			</div>
 		</div>
 		<div class="md:col-span-4 col-span-12 flex flex-col gap-4">
-			<div class="paper gap-2 justify-center items-center">
-				<div class="text-xs text-on-surface1">Total Active Server Connections</div>
-				<div class="flex w-full gap-2 items-center justify-center">
-					<div class="text-3xl font-semibold">100</div>
-					<Server class="size-8 text-primary" />
+			{#if serverAndEntries.loading}
+				<div class="bg-surface3 h-[138.5px] animate-pulse rounded-md"></div>
+				<div class="bg-surface3 h-[380px] animate-pulse rounded-md"></div>
+				<div class="bg-surface3 h-[380px] animate-pulse rounded-md"></div>
+			{:else}
+				<div in:fade={{ duration: 150 }} class="paper gap-2 justify-center items-center">
+					<div class="text-xs text-on-surface1">Total Active Server Connections</div>
+					<div class="flex w-full gap-2 items-center justify-center">
+						<div class="text-3xl font-semibold">{totalServers}</div>
+						<Server class="size-8 text-primary" />
+					</div>
+					<a
+						href={resolve('/admin/mcp-servers?view=deployments')}
+						class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+					>
+						See All <ChevronRight class="size-3" />
+					</a>
 				</div>
-				<a
-					href={resolve('/admin/mcp-servers?view=deployments')}
-					class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-				>
-					See All <ChevronRight class="size-3" />
-				</a>
-			</div>
-			<div class="paper gap-1 flex grow">
-				<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>
-				<ul class="pt-2 flex flex-col gap-2">
-					<li class="flex gap-2 items-center">
-						<Server class="size-8 opacity-65" />
-						<div class="flex flex-col gap-1">
-							<p class="text-sm font-medium">Server Name</p>
-							<p class="text-xs text-on-surface1">100 calls</p>
-						</div>
-					</li>
-					<li class="flex gap-2 items-center">
-						<Server class="size-8 opacity-65" />
-						<div class="flex flex-col gap-1">
-							<p class="text-sm font-medium">Server Name</p>
-							<p class="text-xs text-on-surface1">100 calls</p>
-						</div>
-					</li>
-					<li class="flex gap-2 items-center">
-						<Server class="size-8 opacity-65" />
-						<div class="flex flex-col gap-1">
-							<p class="text-sm font-medium">Server Name</p>
-							<p class="text-xs text-on-surface1">100 calls</p>
-						</div>
-					</li>
-					<li class="flex gap-2 items-center">
-						<Server class="size-8 opacity-65" />
-						<div class="flex flex-col gap-1">
-							<p class="text-sm font-medium">Server Name</p>
-							<p class="text-xs text-on-surface1">100 calls</p>
-						</div>
-					</li>
-					<li class="flex gap-2 items-center">
-						<Server class="size-8 opacity-65" />
-						<div class="flex flex-col gap-1">
-							<p class="text-sm font-medium">Server Name</p>
-							<p class="text-xs text-on-surface1">100 calls</p>
-						</div>
-					</li>
-				</ul>
-				<div class="flex grow"></div>
-				<a
-					href={resolve('/admin/mcp-servers')}
-					class="justify-end self-end text-[11px] translate-x-2 transition-colors duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-				>
-					See All <ChevronRight class="size-3" />
-				</a>
-			</div>
-			<div class="paper">
-				<h4 class="font-semibold mb-1">Deployed Servers by Type</h4>
+				<div in:fade={{ duration: 150 }} class="paper gap-1 flex grow">
+					<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>
+					<ul class="pt-2 flex flex-col gap-2">
+						{#each popularServers as info (info.id)}
+							{@const icon =
+								'server' in info ? info.server?.manifest.icon : info.entry?.manifest.icon}
+							{@const displayName =
+								'server' in info
+									? (info.server?.alias ?? info.server?.manifest.name)
+									: info.entry?.manifest.name}
+							{@const description =
+								'server' in info
+									? info.server?.manifest.description
+									: info.entry?.manifest.description}
+							<li class="flex gap-2 items-center">
+								{#if icon}
+									<img src={icon} alt={info.id} class="size-9 bg-surface1 rounded-md p-1" />
+								{:else}
+									<Server class="size-9 opacity-65 bg-surface1 rounded-md p-1" />
+								{/if}
+								<div class="flex flex-col gap-1 max-w-[calc(100%-2.5rem)]">
+									<p class="text-sm font-medium">{displayName}</p>
+									{#if description}
+										<p class="text-xs truncate line-clamp-1 break-all font-light">
+											{@html stripMarkdownToText(description ?? '')}
+										</p>
+									{/if}
+									<p class="text-xs text-on-surface1 italic">Deployed {info.count} times</p>
+								</div>
+							</li>
+						{/each}
+					</ul>
+					<div class="flex grow"></div>
+					<a
+						href={resolve('/admin/mcp-servers')}
+						class="justify-end self-end text-[11px] translate-x-2 transition-colors duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+					>
+						See All <ChevronRight class="size-3" />
+					</a>
+				</div>
+				<div in:fade={{ duration: 150 }} class="paper">
+					<h4 class="font-semibold mb-1">Deployed Servers by Type</h4>
 
-				<DonutGraph
-					class="h-72"
-					donutRatio={0.65}
-					data={[
-						{
-							label: 'Remote',
-							value: 25
-						},
-						{
-							label: 'Single-User',
-							value: 37
-						},
-						{
-							label: 'Multi-User',
-							value: 8
-						},
-						{
-							label: 'Composite',
-							value: 1
-						}
-					]}
-				/>
-			</div>
+					<DonutGraph class="h-72" donutRatio={0.65} data={graphData} />
+				</div>
+			{/if}
 		</div>
 	</div>
 </Layout>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -373,7 +373,9 @@
 										<Wrench class="size-6 opacity-65 shrink-0" />
 									</div>
 									<div class="flex flex-col gap-1 min-w-0">
-										<p class="text-sm font-medium truncate">{row.toolLabel || row.compositeKey}</p>
+										<p class="text-sm font-medium truncate">
+											{row.toolLabel.split('.').slice(1).join('.') || row.compositeKey}
+										</p>
 										<p class="text-xs text-on-surface1">
 											{formatNumber(row.count)} calls · {row.serverDisplayName}
 										</p>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -465,7 +465,9 @@
 							{/each}
 						</div>
 					{:else if topToolCalls.length === 0}
-						<p class="text-xs text-on-surface1 pt-2 font-light text-center">
+						<p
+							class="text-xs text-on-surface1 pt-2 font-light grow flex items-center justify-center h-full text-center"
+						>
 							No recent tool calls.
 						</p>
 					{:else}
@@ -502,8 +504,8 @@
 						Frequently Used Servers
 						<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
 					</h4>
-					<div class="pt-2 flex flex-col gap-4 w-full">
-						{#if loadingToolUsage}
+					{#if loadingToolUsage}
+						<div class="pt-2 flex flex-col gap-4 w-full">
 							{#each Array.from({ length: TOP_TOOLS_LIMIT }) as _, i (i)}
 								<div class="flex gap-2 items-center animate-pulse w-full">
 									<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
@@ -513,11 +515,15 @@
 									</div>
 								</div>
 							{/each}
-						{:else if topServerUsage.length === 0}
-							<p class="text-xs text-on-surface1 pt-2 font-light text-center">
-								No recent server calls.
-							</p>
-						{:else}
+						</div>
+					{:else if topServerUsage.length === 0}
+						<p
+							class="text-xs text-on-surface1 pt-2 font-light grow flex items-center justify-center h-full text-center"
+						>
+							No recent server calls.
+						</p>
+					{:else}
+						<div class="pt-2 flex flex-col gap-4 w-full">
 							<ul class="pt-2 flex flex-col gap-2">
 								{#each topServerUsage as row (row.serverName)}
 									<li class="flex gap-2 items-center">
@@ -533,8 +539,8 @@
 									</li>
 								{/each}
 							</ul>
-						{/if}
-					</div>
+						</div>
+					{/if}
 					<div class="flex grow min-h-0"></div>
 					{#if topServerUsage.length > 0}
 						<a
@@ -698,7 +704,9 @@
 							{/each}
 						</div>
 					{:else}
-						<p class="text-xs text-on-surface1 pt-2 font-light text-center">
+						<p
+							class="text-xs text-on-surface1 pt-2 font-light text-center h-full flex items-center justify-center"
+						>
 							No servers have been deployed yet.
 						</p>
 					{/if}

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -3,8 +3,13 @@
 	import DotDotDot from '$lib/components/DotDotDot.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import TweenedMetric from '$lib/components/TweenedMetric.svelte';
+	import {
+		transformTopToolCalls,
+		transformTopServerUsage,
+		transformAvgToolCallResponseTime
+	} from '$lib/components/admin/usage/utils';
 	import DonutGraph from '$lib/components/graph/DonutGraph.svelte';
-	import StackedTimeline from '$lib/components/graph/StackedTimeline.svelte';
+	import HorizontalBarGraph from '$lib/components/graph/HorizontalBarGraph.svelte';
 	import SelectServerType from '$lib/components/mcp/SelectServerType.svelte';
 	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 	import { formatNumber } from '$lib/format';
@@ -17,43 +22,25 @@
 		type MCPCatalogEntry,
 		type MCPCatalogServer,
 		type OrgUser,
-		type TokenUsage,
-		type TokenUsageWithCategory,
 		type TotalTokenUsage
 	} from '$lib/services';
 	import { errors, mcpServersAndEntries } from '$lib/stores';
 	import { goto } from '$lib/url';
-	import { aggregateTimelineDataByBucket, getUserLabels } from '../token-usage/utils';
 	import { isWithinInterval, set, subMonths } from 'date-fns';
 	import { Activity, ChevronRight, Coins, Plus, Server, Users, Wrench } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
-	import { twMerge } from 'tailwind-merge';
+
+	const TOP_TOOLS_LIMIT = 5;
+	const TOP_SERVERS_LIMIT = 12;
 
 	let loading = $state(true);
-	let loadingTokensUsage = $state(true);
 	let loadingToolUsage = $state(true);
 
 	let usersData = $state<OrgUser[]>([]);
-	let selectedTokenType = $derived<'input' | 'output'>('input');
-	let tokenUsageData = $state<TokenUsage[]>([]);
 	let totalTokensData = $state<TotalTokenUsage>();
-	const end = new Date();
-	const start = subMonths(end, 1);
-
-	let mainChartData = $state<TokenUsageWithCategory[]>([]);
-	let usersMap = $derived(new Map(usersData.map((user) => [user.id, user])));
 
 	let selectServerTypeDialog = $state<ReturnType<typeof SelectServerType>>();
-
-	function handleSelectServerType(type: LaunchServerType) {
-		selectServerTypeDialog?.close();
-		goto(resolve(`/admin/mcp-servers?new=${type}`));
-	}
-
-	const DEFER_DATA_THRESHOLD = 400;
-	const TIMELINE_AGGREGATE_THRESHOLD = 500;
-	const TOP_TOOLS_LIMIT = 5;
 
 	type TopToolCallRow = {
 		compositeKey: string;
@@ -62,54 +49,44 @@
 		serverDisplayName: string;
 	};
 
-	let topToolCalls = $state<TopToolCallRow[]>([]);
-
 	type TopServerUsageRow = { serverName: string; count: number };
 
+	type AvgToolCallResponseTimeRow = {
+		toolName: string;
+		averageResponseTimeMs: number;
+		serverDisplayName: string;
+	};
+
+	let topToolCalls = $state<TopToolCallRow[]>([]);
 	let topServerUsage = $state<TopServerUsageRow[]>([]);
+	let avgToolCallResponseTime = $state<AvgToolCallResponseTimeRow[]>([]);
+
+	const end = new Date();
+	const start = subMonths(end, 1);
 
 	function topToolCallsFromStats(stats: AuditLogUsageStats | undefined): TopToolCallRow[] {
-		// eslint-disable-next-line svelte/prefer-svelte-reactivity
-		const counts = new Map<string, { count: number; serverDisplayName: string }>();
-		for (const s of stats?.items ?? []) {
-			for (const call of s.toolCalls ?? []) {
-				const key = `${s.mcpServerDisplayName}.${call.toolName}`;
-				const existing = counts.get(key) ?? {
-					count: 0,
-					serverDisplayName: s.mcpServerDisplayName
-				};
-				existing.count += call.callCount;
-				counts.set(key, existing);
-			}
-		}
-		return Array.from(counts.entries())
-			.map(([compositeKey, { count, serverDisplayName }]) => ({
-				compositeKey,
-				toolLabel: String(compositeKey).split('.').slice(1).join('.'),
-				count,
-				serverDisplayName
+		return transformTopToolCalls(stats)
+			.map((t) => ({
+				compositeKey: t.toolName,
+				toolLabel: t.toolName,
+				count: t.count,
+				serverDisplayName: t.serverDisplayName
 			}))
 			.filter(
 				(t) => !t.serverDisplayName.startsWith('nba1') && !t.serverDisplayName.startsWith('Obot ')
-			)
-			.sort((a, b) => b.count - a.count);
+			);
 	}
 
 	function topServersFromStats(stats: AuditLogUsageStats | undefined): TopServerUsageRow[] {
-		// eslint-disable-next-line svelte/prefer-svelte-reactivity
-		const counts = new Map<string, number>();
-		for (const s of (stats?.items ?? []).filter(
-			(s) =>
-				!s.mcpServerDisplayName.startsWith('nba1') && !s.mcpServerDisplayName.startsWith('Obot ')
-		)) {
-			const total = (s.toolCalls ?? []).reduce((sum, t) => sum + t.callCount, 0);
-			if (total > 0) {
-				counts.set(s.mcpServerDisplayName, (counts.get(s.mcpServerDisplayName) ?? 0) + total);
-			}
-		}
-		return Array.from(counts.entries())
-			.map(([serverName, count]) => ({ serverName, count }))
-			.sort((a, b) => b.count - a.count);
+		return transformTopServerUsage(stats).filter(
+			(s) => !s.serverName.startsWith('nba1') && !s.serverName.startsWith('Obot ')
+		);
+	}
+
+	function avgToolCallResponseTimeFromStats(stats: AuditLogUsageStats | undefined) {
+		return transformAvgToolCallResponseTime(stats).filter(
+			(t) => !t.serverDisplayName.startsWith('nba1') && !t.serverDisplayName.startsWith('Obot ')
+		);
 	}
 
 	let monthlyActiveUsers = $derived(
@@ -229,7 +206,8 @@
 		})
 			.then((stats) => {
 				topToolCalls = topToolCallsFromStats(stats).slice(0, TOP_TOOLS_LIMIT);
-				topServerUsage = topServersFromStats(stats).slice(0, TOP_TOOLS_LIMIT);
+				topServerUsage = topServersFromStats(stats).slice(0, TOP_SERVERS_LIMIT);
+				avgToolCallResponseTime = avgToolCallResponseTimeFromStats(stats).slice(0, TOP_TOOLS_LIMIT);
 			})
 			.catch((error) => {
 				if (error?.name === 'AbortError') return;
@@ -238,83 +216,26 @@
 			.finally(() => {
 				loadingToolUsage = false;
 			});
-
-		const timeRange = { start, end };
-		AdminService.listTokenUsage(timeRange)
-			.then((tokenUsage) => {
-				if (tokenUsage.length <= DEFER_DATA_THRESHOLD) {
-					tokenUsageData = tokenUsage;
-					return;
-				}
-				// Defer so the UI can paint (200, loading off) before heavy derivation. Safari lacks requestIdleCallback.
-				const schedule =
-					typeof requestIdleCallback !== 'undefined'
-						? (fn: () => void) => requestIdleCallback(fn, { timeout: 120 })
-						: (fn: () => void) => setTimeout(fn, 0);
-				schedule(() => {
-					tokenUsageData = tokenUsage;
-				});
-			})
-			.finally(() => {
-				loadingTokensUsage = false;
-			})
-			.catch((error) => {
-				if (error?.name === 'AbortError') return;
-				errors.append(error);
-			});
 	});
 
-	function computeMainTimelineData(
-		filtered: TokenUsage[],
-		group: string,
-		users: Map<string, OrgUser>
-	): TokenUsageWithCategory[] {
-		const userKeys = [...new Set(filtered.map((r) => r.userID ?? r.runName ?? 'Unknown'))].sort();
-		const userKeyToLabel = getUserLabels(users, userKeys);
-		return filtered.map((r) => ({
-			...r,
-			date: r.date,
-			promptTokens: r.promptTokens ?? 0,
-			completionTokens: r.completionTokens ?? 0,
-			totalTokens: r.totalTokens ?? (r.promptTokens ?? 0) + (r.completionTokens ?? 0),
-			category:
-				userKeyToLabel.get(r.userID ?? r.runName ?? 'Unknown') ?? r.userID ?? r.runName ?? 'Unknown'
-		}));
+	function handleSelectServerType(type: LaunchServerType) {
+		selectServerTypeDialog?.close();
+		goto(resolve(`/admin/mcp-servers?new=${type}`));
 	}
 
 	function getServerUrl(server: MCPCatalogServer) {
 		if (server.powerUserWorkspaceID) {
-			return `/admin/mcp-servers/w/${server.powerUserWorkspaceID}/s/${server.id}`;
+			return `/admin/mcp-servers/w/${server.powerUserWorkspaceID}/s/${server.id}?view=audit-logs`;
 		}
-		return `/admin/mcp-servers/s/${server.id}`;
+		return `/admin/mcp-servers/s/${server.id}?view=audit-logs`;
 	}
 
 	function getEntryUrl(entry: MCPCatalogEntry) {
 		if (entry.powerUserWorkspaceID) {
-			return `/admin/mcp-servers/w/${entry.powerUserWorkspaceID}/c/${entry.id}`;
+			return `/admin/mcp-servers/w/${entry.powerUserWorkspaceID}/c/${entry.id}?view=audit-logs`;
 		}
-		return `/admin/mcp-servers/c/${entry.id}`;
+		return `/admin/mcp-servers/c/${entry.id}?view=audit-logs`;
 	}
-
-	$effect(() => {
-		if (tokenUsageData.length <= TIMELINE_AGGREGATE_THRESHOLD) {
-			const timeline = computeMainTimelineData(tokenUsageData, 'group_by_users', usersMap);
-			mainChartData = timeline;
-			return;
-		}
-
-		const schedule =
-			typeof requestIdleCallback !== 'undefined'
-				? (fn: () => void) => requestIdleCallback(fn, { timeout: 150 })
-				: (fn: () => void) => setTimeout(fn, 0);
-		schedule(() => {
-			const timeline = computeMainTimelineData(tokenUsageData, 'group_by_users', usersMap);
-			mainChartData =
-				timeline.length <= TIMELINE_AGGREGATE_THRESHOLD
-					? timeline
-					: (aggregateTimelineDataByBucket(timeline, start, end) as TokenUsageWithCategory[]);
-		});
-	});
 </script>
 
 <Layout title="Dashboard" classes={{ childrenContainer: 'max-w-none', container: '' }}>
@@ -340,7 +261,7 @@
 							href={resolve('/admin/users')}
 							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
 						>
-							See All <ChevronRight class="size-3" />
+							See More <ChevronRight class="size-3" />
 						</a>
 					</div>
 				</div>
@@ -383,66 +304,38 @@
 							href={resolve('/admin/token-usage')}
 							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
 						>
-							See All <ChevronRight class="size-3" />
+							See More <ChevronRight class="size-3" />
 						</a>
 					</div>
 				</div>
 			</div>
-			{#if loadingTokensUsage}
+			{#if loading}
 				<div class="bg-surface3 h-[400px] animate-pulse rounded-md"></div>
 			{:else}
-				<div in:fade={{ duration: 150 }} class="paper w-full min-h-72">
+				<div in:fade={{ duration: 150 }} class="paper gap-1 w-full min-h-72">
 					<div class="flex flex-wrap items-center justify-between gap-4">
 						<h4 class="flex items-center gap-1 font-semibold">
-							Token Usage <span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
+							Top Servers Used <span class="text-on-surface1 text-xs font-light"
+								>(Last 30 Days)</span
+							>
 						</h4>
-						<div class="flex shrink-0">
-							<button
-								class={twMerge(
-									'button-secondary rounded-r-none border border-r-0 text-xs',
-									selectedTokenType === 'input' && 'bg-surface2 border-surface2'
-								)}
-								onclick={() => (selectedTokenType = 'input')}
-							>
-								Input Tokens
-							</button>
-							<button
-								class={twMerge(
-									'button-secondary rounded-l-none border text-xs',
-									selectedTokenType === 'output' && 'bg-surface2 border-surface2'
-								)}
-								onclick={() => (selectedTokenType = 'output')}
-							>
-								Output Tokens
-							</button>
-						</div>
 					</div>
-					<StackedTimeline
-						{start}
-						{end}
-						data={mainChartData}
-						dateKey="date"
-						primaryValueKey={selectedTokenType === 'input' ? 'promptTokens' : 'completionTokens'}
-						categoryKey="category"
-						class="h-72"
-						legend={{
-							showSecondaryLabel: false
-						}}
+					<HorizontalBarGraph
+						data={topServerUsage}
+						labelKey="serverName"
+						valueKey="count"
+						formatValue={(value) => Math.round(value).toString()}
+						class="h-[400px]"
 					>
 						{#snippet tooltipContent(item)}
-							{@const value = item.primaryTotal ?? 0}
 							<div class="flex flex-col gap-0 text-xs">
-								<div class="text-sm font-light">{item.key}</div>
-								<div class="text-on-surface1">{item.date}</div>
-								<div class="tooltip-divider"></div>
+								<div class="text-on-surface1 text-xs">{item.label}</div>
 							</div>
-							<div class="flex flex-col gap-1">
-								<div class="text-on-background flex flex-col">
-									<div class="text-xl font-bold">{value.toLocaleString()}</div>
-								</div>
+							<div class="text-on-background font-semibold">
+								{item.value} calls
 							</div>
 						{/snippet}
-					</StackedTimeline>
+					</HorizontalBarGraph>
 				</div>
 			{/if}
 
@@ -495,13 +388,13 @@
 							href={resolve('/admin/usage')}
 							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
 						>
-							See All <ChevronRight class="size-3" />
+							See More <ChevronRight class="size-3" />
 						</a>
 					{/if}
 				</div>
 				<div class="paper h-full gap-1 col-span-12 @min-[768px]:col-span-6 flex flex-col min-h-72">
 					<h4 class="flex items-center gap-2 font-semibold mb-1">
-						Frequently Used Servers
+						Tool Call Average Response Time
 						<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
 					</h4>
 					{#if loadingToolUsage}
@@ -516,25 +409,27 @@
 								</div>
 							{/each}
 						</div>
-					{:else if topServerUsage.length === 0}
+					{:else if avgToolCallResponseTime.length === 0}
 						<p
 							class="text-xs text-on-surface1 pt-2 font-light grow flex items-center justify-center h-full text-center"
 						>
-							No recent server calls.
+							No recent tool calls.
 						</p>
 					{:else}
 						<div class="pt-2 flex flex-col gap-4 w-full">
-							<ul class="pt-2 flex flex-col gap-2">
-								{#each topServerUsage as row (row.serverName)}
+							<ul class="flex flex-col gap-2">
+								{#each avgToolCallResponseTime as row (row.toolName)}
 									<li class="flex gap-2 items-center">
-										<div
-											class="size-8 items-center justify-center shrink-0 bg-surface1 dark:bg-surface2 rounded-md p-1 flex"
-										>
-											<Server class="size-6 opacity-65 shrink-0" />
+										<div class="flex flex-col gap-1 min-w-0 grow pr-4">
+											<p class="text-sm font-medium truncate">
+												{row.toolName.split('.').slice(1).join('.')}
+											</p>
+											<p class="text-xs text-on-surface1">
+												{row.serverDisplayName}
+											</p>
 										</div>
-										<div class="flex flex-col gap-1 min-w-0">
-											<p class="text-sm font-medium truncate">{row.serverName}</p>
-											<p class="text-xs text-on-surface1">{formatNumber(row.count)} calls</p>
+										<div class="text-sm">
+											{row.averageResponseTimeMs}ms
 										</div>
 									</li>
 								{/each}
@@ -542,12 +437,12 @@
 						</div>
 					{/if}
 					<div class="flex grow min-h-0"></div>
-					{#if topServerUsage.length > 0}
+					{#if avgToolCallResponseTime.length > 0}
 						<a
 							href={resolve('/admin/usage')}
 							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
 						>
-							See All <ChevronRight class="size-3" />
+							See More <ChevronRight class="size-3" />
 						</a>
 					{/if}
 				</div>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -458,7 +458,7 @@
 								{:else}
 									<Server class="size-9 opacity-65 bg-surface1 rounded-md p-1" />
 								{/if}
-								<div class="flex flex-col gap-1 max-w-[calc(100%-2.5rem)]">
+								<div class="flex flex-col gap-0.5 max-w-[calc(100%-2.5rem)]">
 									<p class="text-sm font-medium">{displayName}</p>
 									{#if description}
 										<p class="text-xs truncate line-clamp-1 break-all font-light">

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -454,7 +454,7 @@
 							{#each topToolCalls as row (row.compositeKey)}
 								<li class="flex gap-2 items-center">
 									<div
-										class="size-8 items-center justify-center shrink-0 bg-surface1 rounded-md p-1"
+										class="size-8 items-center justify-center shrink-0 bg-surface1 dark:bg-surface2 rounded-md p-1"
 									>
 										<Wrench class="size-6 opacity-65 shrink-0" />
 									</div>
@@ -500,7 +500,7 @@
 							{#each topServerUsage as row (row.serverName)}
 								<li class="flex gap-2 items-center">
 									<div
-										class="size-8 items-center justify-center shrink-0 bg-surface1 rounded-md p-1 flex"
+										class="size-8 items-center justify-center shrink-0 bg-surface1 dark:bg-surface2 rounded-md p-1 flex"
 									>
 										<Server class="size-6 opacity-65 shrink-0" />
 									</div>
@@ -599,11 +599,15 @@
 										? getEntryUrl(info.entry)
 										: undefined}
 								<a
-									class="flex gap-2 items-center hover:bg-surface1 -mx-2 px-2 py-1 rounded-md"
+									class="flex gap-2 items-center dark:hover:bg-surface2 hover:bg-surface1 transition-colors duration-150 -mx-2 px-2 py-1 rounded-md"
 									href={url ? resolve(url as `/${string}`) : undefined}
 								>
 									{#if icon}
-										<img src={icon} alt={info.id} class="size-9 bg-surface1 rounded-md p-1" />
+										<img
+											src={icon}
+											alt={info.id}
+											class="size-9 bg-surface1 dark:bg-surface2 rounded-md p-1"
+										/>
 									{:else}
 										<Server class="size-9 opacity-65 bg-surface1 rounded-md p-1" />
 									{/if}

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -318,11 +318,11 @@
 </script>
 
 <Layout title="Dashboard" classes={{ childrenContainer: 'max-w-none', container: '' }}>
-	<div class="grid grid-cols-12 gap-4">
-		<div class="flex flex-col md:col-span-8 col-span-12 gap-4">
+	<div class="@container grid grid-cols-12 gap-4">
+		<div class="flex flex-col col-span-12 @min-[768px]:col-span-8 gap-4">
 			<!-- this token usage graph-->
 			<div class="grid grid-cols-12 gap-4">
-				<div class="md:col-span-4 col-span-12">
+				<div class="col-span-12 @min-[768px]:col-span-4">
 					<div class="paper gap-2">
 						<div class="text-xs text-on-surface1 flex items-center gap-1">
 							Total Users
@@ -344,7 +344,7 @@
 						</a>
 					</div>
 				</div>
-				<div class="md:col-span-4 col-span-12">
+				<div class="col-span-12 @min-[768px]:col-span-4">
 					<div class="paper gap-2">
 						<div class="text-xs text-on-surface1 flex items-center gap-1">
 							Monthly Active Users
@@ -361,7 +361,7 @@
 						<div class="text-xs text-on-surface1">Last 30 Days</div>
 					</div>
 				</div>
-				<div class="md:col-span-4 col-span-12">
+				<div class="col-span-12 @min-[768px]:col-span-4">
 					<div class="paper gap-2">
 						<div class="text-xs text-on-surface1 flex items-center gap-1">
 							Total Tokens
@@ -447,7 +447,7 @@
 			{/if}
 
 			<div class="grid grid-cols-12 gap-4 grow">
-				<div class="paper h-full gap-1 md:col-span-6 col-span-12 flex flex-col min-h-72">
+				<div class="paper h-full gap-1 col-span-12 @min-[768px]:col-span-6 flex flex-col min-h-72">
 					<h4 class="flex items-center gap-2 font-semibold mb-1">
 						Recently Popular Tools
 						<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
@@ -499,7 +499,7 @@
 						</a>
 					{/if}
 				</div>
-				<div class="paper h-full gap-1 md:col-span-6 col-span-12 flex flex-col min-h-72">
+				<div class="paper h-full gap-1 col-span-12 @min-[768px]:col-span-6 flex flex-col min-h-72">
 					<h4 class="flex items-center gap-2 font-semibold mb-1">
 						Frequently Used Servers
 						<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
@@ -553,7 +553,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="md:col-span-4 col-span-12 flex flex-col gap-4">
+		<div class="col-span-12 @min-[768px]:col-span-4 flex flex-col gap-4">
 			{#if serverAndEntries.loading}
 				<div class="bg-surface3 h-[530px] animate-pulse rounded-md"></div>
 				<div class="paper gap-1 flex grow">

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -93,7 +93,7 @@
 
 	let monthlyActiveUsers = $derived(
 		usersData.filter(
-			(user) => user.lastActiveDay && isWithinInterval(user.lastActiveDay, { start, end })
+			(user) => user.lastActiveDay && isWithinInterval(new Date(user.lastActiveDay), { start, end })
 		).length
 	);
 
@@ -125,7 +125,7 @@
 			if (!server.catalogEntryID) {
 				acc[server.id] = {
 					server,
-					count: server.mcpServerInstanceUserCount ?? 0,
+					count: 1,
 					id: server.id
 				};
 				return acc;
@@ -146,7 +146,7 @@
 			(a, b) => b.count - a.count
 		);
 
-		const entrieTypes = data.reduce(
+		const entryTypes = data.reduce(
 			(acc, server) => {
 				if (!server.catalogEntryID) acc.multi++;
 				else if (server.manifest.runtime === 'composite') acc.composite++;
@@ -166,23 +166,23 @@
 			graphData: [
 				{
 					label: 'Multi-User',
-					value: entrieTypes.multi
+					value: entryTypes.multi
 				},
 				{
 					label: 'Single-User',
-					value: entrieTypes.single
+					value: entryTypes.single
 				},
 				{
 					label: 'Remote',
-					value: entrieTypes.remote
+					value: entryTypes.remote
 				},
 				{
 					label: 'Composite',
-					value: entrieTypes.composite
+					value: entryTypes.composite
 				}
 			],
 			popularServers: sortByCountDescending.filter((s) => s.count > 0).slice(0, 5),
-			totalServers: serversData.length
+			totalServers: data.length
 		};
 	}
 
@@ -598,7 +598,7 @@
 										<p class="text-sm font-medium">{displayName}</p>
 										{#if description}
 											<p class="text-xs truncate line-clamp-1 break-all font-light">
-												{@html stripMarkdownToText(description ?? '')}
+												{stripMarkdownToText(description ?? '')}
 											</p>
 										{/if}
 										<p class="text-xs text-on-surface1 italic">Deployed {info.count} times</p>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -3,7 +3,9 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import DonutGraph from '$lib/components/graph/DonutGraph.svelte';
 	import StackedTimeline from '$lib/components/graph/StackedTimeline.svelte';
+	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 	import { formatNumber } from '$lib/format';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
 	import {
 		AdminService,
@@ -19,16 +21,20 @@
 	import { isWithinInterval, subMonths } from 'date-fns';
 	import { Activity, ChevronRight, Coins, PencilRuler, Server, Users, Wrench } from 'lucide-svelte';
 	import { onMount } from 'svelte';
+	import { cubicOut } from 'svelte/easing';
+	import { Tween } from 'svelte/motion';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 
-	let loading = $state({
-		tokenUsage: true,
-		totalTokenUsage: true,
-		users: true,
-		tools: true,
-		skills: true
-	});
+	const STAT_COUNT_MS = 650;
+	const totalUsersAnimated = new Tween(0, { duration: STAT_COUNT_MS, easing: cubicOut });
+	const monthlyActiveAnimated = new Tween(0, { duration: STAT_COUNT_MS, easing: cubicOut });
+	const totalTokensAnimated = new Tween(0, { duration: STAT_COUNT_MS, easing: cubicOut });
+	const totalServersAnimated = new Tween(0, { duration: STAT_COUNT_MS, easing: cubicOut });
+
+	let loading = $state(true);
+	let loadingTokensUsage = $state(true);
+
 	let usersData = $state<OrgUser[]>([]);
 	let selectedTokenType = $derived<'input' | 'output'>('input');
 	let tokenUsageData = $state<TokenUsage[]>([]);
@@ -48,29 +54,35 @@
 		).length
 	);
 
-	function compileServerAndEntries(data: typeof mcpServersAndEntries.current) {
-		const serversMap = new Map(data.servers.map((s) => [s.id, s]));
-		const entriesMap = new Map(data.entries.map((e) => [e.id, e]));
-		const instancesCount = data.userInstances.reduce<
-			Record<string, { server: MCPCatalogServer | undefined; count: number; id: string }>
-		>((acc, instance) => {
-			if (!instance.mcpServerID) return acc;
-			if (!acc[instance.mcpServerID]) {
-				const server = serversMap.get(instance.mcpServerID);
-				if (!server) return acc;
-				acc[instance.mcpServerID] = {
+	let deployedCatalogEntryServers = $state<MCPCatalogServer[]>([]);
+	let deployedWorkspaceCatalogEntryServers = $state<MCPCatalogServer[]>([]);
+	let serversData = $derived([
+		...deployedCatalogEntryServers.filter((server) => !server.deleted),
+		...deployedWorkspaceCatalogEntryServers.filter((server) => !server.deleted),
+		...mcpServersAndEntries.current.servers.filter((server) => !server.deleted)
+	]);
+
+	function compileServerAndEntries(data: MCPCatalogServer[], entries: MCPCatalogEntry[]) {
+		const entriesMap = new Map(entries.map((e) => [e.id, e]));
+		const catalogEntriesCount = data.reduce<
+			Record<
+				string,
+				{
+					entry?: MCPCatalogEntry | undefined;
+					server?: MCPCatalogServer | undefined;
+					count: number;
+					id: string;
+				}
+			>
+		>((acc, server) => {
+			if (!server.catalogEntryID) {
+				acc[server.id] = {
 					server,
-					count: 0,
+					count: server.mcpServerInstanceUserCount ?? 0,
 					id: server.id
 				};
+				return acc;
 			}
-			acc[instance.mcpServerID].count++;
-			return acc;
-		}, {});
-		const catalogEntriesCount = data.userConfiguredServers.reduce<
-			Record<string, { entry: MCPCatalogEntry | undefined; count: number; id: string }>
-		>((acc, server) => {
-			if (!server.catalogEntryID) return acc;
 			if (!acc[server.catalogEntryID]) {
 				const entry = entriesMap.get(server.catalogEntryID);
 				if (!entry) return acc;
@@ -83,12 +95,13 @@
 			acc[server.catalogEntryID].count++;
 			return acc;
 		}, {});
-		const combine = [...Object.values(instancesCount), ...Object.values(catalogEntriesCount)];
-		// sort by count descending
-		combine.sort((a, b) => b.count - a.count);
+		const sortByCountDescending = Object.values(catalogEntriesCount).sort(
+			(a, b) => b.count - a.count
+		);
 
 		const entrieTypes = Object.values(catalogEntriesCount).reduce(
 			(acc, info) => {
+				if (info.server) acc.multi++;
 				if (!info.entry) return acc;
 				if (info.entry.manifest.runtime === 'composite') acc.composite++;
 				else if (info.entry.manifest.runtime === 'remote') acc.remote++;
@@ -96,6 +109,7 @@
 				return acc;
 			},
 			{
+				multi: 0,
 				single: 0,
 				remote: 0,
 				composite: 0
@@ -106,7 +120,7 @@
 			graphData: [
 				{
 					label: 'Multi-User',
-					value: Object.keys(instancesCount).length
+					value: entrieTypes.multi
 				},
 				{
 					label: 'Single-User',
@@ -121,27 +135,24 @@
 					value: entrieTypes.composite
 				}
 			],
-			popularServers: combine.slice(0, 5),
-			totalServers: data.userConfiguredServers.length + data.userInstances.length
+			popularServers: sortByCountDescending.filter((s) => s.count > 0).slice(0, 5),
+			totalServers: serversData.length
 		};
 	}
 
 	const serverAndEntries = $derived(mcpServersAndEntries.current);
 	const { graphData, popularServers, totalServers } = $derived(
-		compileServerAndEntries(serverAndEntries)
+		compileServerAndEntries(serversData, serverAndEntries.entries)
 	);
 
 	onMount(async () => {
-		AdminService.listUsersIncludeDeleted()
-			.then((users) => {
-				usersData = users;
-			})
-			.catch((error) => {
-				errors.append(error);
-			})
-			.finally(() => {
-				loading.users = false;
-			});
+		usersData = await AdminService.listUsersIncludeDeleted();
+		totalTokensData = await AdminService.listTotalTokenUsage();
+		deployedCatalogEntryServers =
+			await AdminService.listAllCatalogDeployedSingleRemoteServers(DEFAULT_MCP_CATALOG_ID);
+		deployedWorkspaceCatalogEntryServers =
+			await AdminService.listAllWorkspaceDeployedSingleRemoteServers();
+		loading = false;
 
 		const timeRange = { start, end };
 		AdminService.listTokenUsage(timeRange)
@@ -160,22 +171,11 @@
 				});
 			})
 			.finally(() => {
-				loading.tokenUsage = false;
+				loadingTokensUsage = false;
 			})
 			.catch((error) => {
 				if (error?.name === 'AbortError') return;
 				errors.append(error);
-			});
-
-		AdminService.listTotalTokenUsage()
-			.then((response) => {
-				totalTokensData = response;
-			})
-			.catch((error) => {
-				errors.append(error);
-			})
-			.finally(() => {
-				loading.totalTokenUsage = false;
 			});
 	});
 
@@ -197,6 +197,20 @@
 		}));
 	}
 
+	function getServerUrl(server: MCPCatalogServer) {
+		if (server.powerUserWorkspaceID) {
+			return resolve(`/admin/mcp-servers/w/${server.powerUserWorkspaceID}/s/${server.id}`);
+		}
+		return resolve(`/admin/mcp-servers/s/${server.id}`);
+	}
+
+	function getEntryUrl(entry: MCPCatalogEntry) {
+		if (entry.powerUserWorkspaceID) {
+			return resolve(`/admin/mcp-servers/w/${entry.powerUserWorkspaceID}/c/${entry.id}`);
+		}
+		return resolve(`/admin/mcp-servers/c/${entry.id}`);
+	}
+
 	$effect(() => {
 		if (tokenUsageData.length <= TIMELINE_AGGREGATE_THRESHOLD) {
 			const timeline = computeMainTimelineData(tokenUsageData, 'group_by_users', usersMap);
@@ -214,6 +228,38 @@
 			return aggregateTimelineDataByBucket(timeline, start, end) as TokenUsageWithCategory[];
 		});
 	});
+
+	$effect(() => {
+		if (loading) {
+			void totalUsersAnimated.set(0, { duration: 0 });
+			return;
+		}
+		void totalUsersAnimated.set(usersData.length);
+	});
+
+	$effect(() => {
+		if (loading) {
+			void monthlyActiveAnimated.set(0, { duration: 0 });
+			return;
+		}
+		void monthlyActiveAnimated.set(monthlyActiveUsers);
+	});
+
+	$effect(() => {
+		if (loading) {
+			void totalTokensAnimated.set(0, { duration: 0 });
+			return;
+		}
+		void totalTokensAnimated.set(totalTokensData?.totalTokens ?? 0);
+	});
+
+	$effect(() => {
+		if (serverAndEntries.loading) {
+			void totalServersAnimated.set(0, { duration: 0 });
+			return;
+		}
+		void totalServersAnimated.set(totalServers);
+	});
 </script>
 
 <Layout title="Dashboard" classes={{ childrenContainer: 'max-w-none', container: '' }}>
@@ -222,63 +268,66 @@
 			<!-- this token usage graph-->
 			<div class="grid grid-cols-12 gap-4">
 				<div class="md:col-span-4 col-span-12">
-					{#if loading.users}
-						<div class="bg-surface3 h-[138.5px] animate-pulse rounded-md"></div>
-					{:else}
-						<div class="paper gap-2">
-							<div class="text-xs text-on-surface1">Total Users</div>
-							<div class="flex w-full justify-between">
-								<div class="text-3xl font-semibold">{usersData.length}</div>
-								<Users class="size-8 text-primary" />
-							</div>
-							<a
-								href={resolve('/admin/users')}
-								class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-							>
-								See All <ChevronRight class="size-3" />
-							</a>
+					<div class="paper gap-2">
+						<div class="text-xs text-on-surface1 flex items-center gap-1">
+							Total Users
+							{#if loading}
+								<Loading class="size-3" />
+							{/if}
 						</div>
-					{/if}
+						<div class="flex w-full justify-between">
+							<div class="text-3xl font-semibold">{Math.round(totalUsersAnimated.current)}</div>
+							<Users class="size-8 text-primary" />
+						</div>
+						<a
+							href={resolve('/admin/users')}
+							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+						>
+							See All <ChevronRight class="size-3" />
+						</a>
+					</div>
 				</div>
 				<div class="md:col-span-4 col-span-12">
-					{#if loading.users}
-						<div class="bg-surface3 h-[138.5px] animate-pulse rounded-md"></div>
-					{:else}
-						<div class="paper gap-2">
-							<div class="text-xs text-on-surface1">Monthly Active Users</div>
-							<div class="flex w-full justify-between">
-								<div class="text-3xl font-semibold">
-									{monthlyActiveUsers}
-								</div>
-								<Activity class="size-8 text-primary" />
-							</div>
-							<div class="text-xs text-on-surface1">Last 30 Days</div>
+					<div class="paper gap-2">
+						<div class="text-xs text-on-surface1 flex items-center gap-1">
+							Monthly Active Users
+							{#if loading}
+								<Loading class="size-3" />
+							{/if}
 						</div>
-					{/if}
+						<div class="flex w-full justify-between">
+							<div class="text-3xl font-semibold">
+								{Math.round(monthlyActiveAnimated.current)}
+							</div>
+							<Activity class="size-8 text-primary" />
+						</div>
+						<div class="text-xs text-on-surface1">Last 30 Days</div>
+					</div>
 				</div>
 				<div class="md:col-span-4 col-span-12">
-					{#if loading.totalTokenUsage}
-						<div class="bg-surface3 h-[138.5px] animate-pulse rounded-md"></div>
-					{:else}
-						<div class="paper gap-2">
-							<div class="text-xs text-on-surface1">Total Tokens</div>
-							<div class="flex w-full justify-between">
-								<div class="text-3xl font-semibold">
-									{formatNumber(totalTokensData?.totalTokens ?? 0)}
-								</div>
-								<Coins class="size-8 text-primary" />
-							</div>
-							<a
-								href={resolve('/admin/token-usage')}
-								class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-							>
-								See All <ChevronRight class="size-3" />
-							</a>
+					<div class="paper gap-2">
+						<div class="text-xs text-on-surface1 flex items-center gap-1">
+							Total Tokens
+							{#if loading}
+								<Loading class="size-3" />
+							{/if}
 						</div>
-					{/if}
+						<div class="flex w-full justify-between">
+							<div class="text-3xl font-semibold">
+								{formatNumber(Math.max(0, Math.round(totalTokensAnimated.current)))}
+							</div>
+							<Coins class="size-8 text-primary" />
+						</div>
+						<a
+							href={resolve('/admin/token-usage')}
+							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+						>
+							See All <ChevronRight class="size-3" />
+						</a>
+					</div>
 				</div>
 			</div>
-			{#if loading.tokenUsage}
+			{#if loadingTokensUsage}
 				<div class="bg-surface3 h-[400px] animate-pulse rounded-md"></div>
 			{:else}
 				<div in:fade={{ duration: 150 }} class="paper w-full min-h-72">
@@ -421,26 +470,36 @@
 		</div>
 		<div class="md:col-span-4 col-span-12 flex flex-col gap-4">
 			{#if serverAndEntries.loading}
-				<div class="bg-surface3 h-[138.5px] animate-pulse rounded-md"></div>
 				<div class="bg-surface3 h-[380px] animate-pulse rounded-md"></div>
 				<div class="bg-surface3 h-[380px] animate-pulse rounded-md"></div>
 			{:else}
-				<div in:fade={{ duration: 150 }} class="paper gap-2 justify-center items-center">
-					<div class="text-xs text-on-surface1">Total Active Server Connections</div>
-					<div class="flex w-full gap-2 items-center justify-center">
-						<div class="text-3xl font-semibold">{totalServers}</div>
-						<Server class="size-8 text-primary" />
+				<div in:fade={{ duration: 150 }} class="paper">
+					<h4 class="font-semibold">Active Servers</h4>
+
+					<div class="mb-2 flex flex-col justify-center items-center gap-2">
+						<div class="text-xs">Total Currently Active</div>
+						<div class="flex w-full gap-2 items-center justify-center">
+							<div class="text-3xl font-semibold">{Math.round(totalServersAnimated.current)}</div>
+							<Server class="size-8 text-primary" />
+						</div>
 					</div>
-					<a
-						href={resolve('/admin/mcp-servers?view=deployments')}
-						class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-					>
-						See All <ChevronRight class="size-3" />
-					</a>
+
+					<div class="h-px w-full bg-surface2 mb-4"></div>
+
+					<DonutGraph class="h-72" donutRatio={0.65} data={graphData} />
+
+					<div class="flex justify-end">
+						<a
+							href={resolve('/admin/mcp-servers?view=deployments')}
+							class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+						>
+							See All <ChevronRight class="size-3" />
+						</a>
+					</div>
 				</div>
 				<div in:fade={{ duration: 150 }} class="paper gap-1 flex grow">
 					<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>
-					<ul class="pt-2 flex flex-col gap-2">
+					<div class="pt-2 flex flex-col gap-2">
 						{#each popularServers as info (info.id)}
 							{@const icon =
 								'server' in info ? info.server?.manifest.icon : info.entry?.manifest.icon}
@@ -452,13 +511,21 @@
 								'server' in info
 									? info.server?.manifest.description
 									: info.entry?.manifest.description}
-							<li class="flex gap-2 items-center">
+							{@const url = info.server
+								? getServerUrl(info.server)
+								: info.entry
+									? getEntryUrl(info.entry)
+									: undefined}
+							<a
+								class="flex gap-2 items-center hover:bg-surface1 -mx-2 px-2 py-1 rounded-md"
+								href={url}
+							>
 								{#if icon}
 									<img src={icon} alt={info.id} class="size-9 bg-surface1 rounded-md p-1" />
 								{:else}
 									<Server class="size-9 opacity-65 bg-surface1 rounded-md p-1" />
 								{/if}
-								<div class="flex flex-col gap-0.5 max-w-[calc(100%-2.5rem)]">
+								<div class="flex flex-col gap-0.5 max-w-[calc(100%-4.5rem)]">
 									<p class="text-sm font-medium">{displayName}</p>
 									{#if description}
 										<p class="text-xs truncate line-clamp-1 break-all font-light">
@@ -467,9 +534,10 @@
 									{/if}
 									<p class="text-xs text-on-surface1 italic">Deployed {info.count} times</p>
 								</div>
-							</li>
+								<ChevronRight class="size-5 shrink-0" />
+							</a>
 						{/each}
-					</ul>
+					</div>
 					<div class="flex grow"></div>
 					<a
 						href={resolve('/admin/mcp-servers')}
@@ -477,11 +545,6 @@
 					>
 						See All <ChevronRight class="size-3" />
 					</a>
-				</div>
-				<div in:fade={{ duration: 150 }} class="paper">
-					<h4 class="font-semibold mb-1">Deployed Servers by Type</h4>
-
-					<DonutGraph class="h-72" donutRatio={0.65} data={graphData} />
 				</div>
 			{/if}
 		</div>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -3,42 +3,65 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import DonutGraph from '$lib/components/graph/DonutGraph.svelte';
 	import StackedTimeline from '$lib/components/graph/StackedTimeline.svelte';
-	import Loading from '$lib/icons/Loading.svelte';
+	import { formatNumber } from '$lib/format';
 	import {
 		AdminService,
 		type OrgUser,
 		type TokenUsage,
-		type TokenUsageWithCategory
+		type TokenUsageWithCategory,
+		type TotalTokenUsage
 	} from '$lib/services';
 	import { errors } from '$lib/stores';
 	import { aggregateTimelineDataByBucket, getUserLabels } from '../token-usage/utils';
-	import { isWithinInterval, subDays } from 'date-fns';
-	import { Activity, ChevronRight, Server, Users, Wrench } from 'lucide-svelte';
+	import { isWithinInterval, subMonths } from 'date-fns';
+	import { Activity, ChevronRight, Coins, PencilRuler, Server, Users, Wrench } from 'lucide-svelte';
 	import { onMount } from 'svelte';
+	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 
-	let loadingTableData = $state(true);
+	let loading = $state({
+		tokenUsage: true,
+		totalTokenUsage: true,
+		users: true,
+		tools: true,
+		skills: true
+	});
 	let usersData = $state<OrgUser[]>([]);
 	let selectedTokenType = $derived<'input' | 'output'>('input');
-	let data = $state<TokenUsage[]>([]);
+	let tokenUsageData = $state<TokenUsage[]>([]);
+	let totalTokensData = $state<TotalTokenUsage>();
+	const end = new Date();
+	const start = subMonths(end, 1);
 
 	let mainChartData = $state<TokenUsageWithCategory[]>([]);
 	let usersMap = $derived(new Map(usersData.map((user) => [user.id, user])));
 
 	const DEFER_DATA_THRESHOLD = 400;
 	const TIMELINE_AGGREGATE_THRESHOLD = 500;
-	const end = new Date();
-	const start = subDays(end, 7);
+
+	let monthlyActiveUsers = $derived(
+		usersData.filter(
+			(user) => user.lastActiveDay && isWithinInterval(user.lastActiveDay, { start, end })
+		).length
+	);
 
 	onMount(async () => {
-		usersData = await AdminService.listUsersIncludeDeleted();
+		AdminService.listUsersIncludeDeleted()
+			.then((users) => {
+				usersData = users;
+			})
+			.catch((error) => {
+				errors.append(error);
+			})
+			.finally(() => {
+				loading.users = false;
+			});
 
 		const timeRange = { start, end };
-
 		AdminService.listTokenUsage(timeRange)
 			.then((tokenUsage) => {
 				if (tokenUsage.length <= DEFER_DATA_THRESHOLD) {
-					data = tokenUsage;
+					tokenUsageData = tokenUsage;
 					return;
 				}
 				// Defer so the UI can paint (200, loading off) before heavy derivation. Safari lacks requestIdleCallback.
@@ -47,15 +70,26 @@
 						? (fn: () => void) => requestIdleCallback(fn, { timeout: 120 })
 						: (fn: () => void) => setTimeout(fn, 0);
 				schedule(() => {
-					data = tokenUsage;
+					tokenUsageData = tokenUsage;
 				});
 			})
 			.finally(() => {
-				loadingTableData = false;
+				loading.tokenUsage = false;
 			})
 			.catch((error) => {
 				if (error?.name === 'AbortError') return;
 				errors.append(error);
+			});
+
+		AdminService.listTotalTokenUsage()
+			.then((response) => {
+				totalTokensData = response;
+			})
+			.catch((error) => {
+				errors.append(error);
+			})
+			.finally(() => {
+				loading.totalTokenUsage = false;
 			});
 	});
 
@@ -78,8 +112,8 @@
 	}
 
 	$effect(() => {
-		if (data.length <= TIMELINE_AGGREGATE_THRESHOLD) {
-			const timeline = computeMainTimelineData(data, 'group_by_users', usersMap);
+		if (tokenUsageData.length <= TIMELINE_AGGREGATE_THRESHOLD) {
+			const timeline = computeMainTimelineData(tokenUsageData, 'group_by_users', usersMap);
 			mainChartData = timeline;
 			return;
 		}
@@ -89,7 +123,7 @@
 				? (fn: () => void) => requestIdleCallback(fn, { timeout: 150 })
 				: (fn: () => void) => setTimeout(fn, 0);
 		schedule(() => {
-			const timeline = computeMainTimelineData(data, 'group_by_users', usersMap);
+			const timeline = computeMainTimelineData(tokenUsageData, 'group_by_users', usersMap);
 			if (timeline.length <= TIMELINE_AGGREGATE_THRESHOLD) return timeline;
 			return aggregateTimelineDataByBucket(timeline, start, end) as TokenUsageWithCategory[];
 		});
@@ -102,81 +136,91 @@
 			<!-- this token usage graph-->
 			<div class="grid grid-cols-12 gap-4">
 				<div class="md:col-span-4 col-span-12">
-					<div class="paper gap-2">
-						<div class="text-xs text-on-surface1">Total Users</div>
-						<div class="flex w-full justify-between">
-							<div class="text-3xl font-semibold">{usersData.length}</div>
-							<Users class="size-8 text-primary" />
-						</div>
-						<a
-							href={resolve('/admin/users')}
-							class="text-[11px] bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-						>
-							See All Users <ChevronRight class="size-3" />
-						</a>
-					</div>
-				</div>
-				<div class="md:col-span-4 col-span-12">
-					<div class="paper gap-2">
-						<div class="text-xs text-on-surface1">Monthly Active Users</div>
-						<div class="flex w-full justify-between">
-							<div class="text-3xl font-semibold">
-								{usersData.filter(
-									(user) =>
-										user.lastActiveDay && isWithinInterval(user.lastActiveDay, { start, end })
-								).length}
+					{#if loading.users}
+						<div class="bg-surface3 h-[138.5px] animate-pulse rounded-md"></div>
+					{:else}
+						<div class="paper gap-2">
+							<div class="text-xs text-on-surface1">Total Users</div>
+							<div class="flex w-full justify-between">
+								<div class="text-3xl font-semibold">{usersData.length}</div>
+								<Users class="size-8 text-primary" />
 							</div>
-							<Activity class="size-8 text-primary" />
+							<a
+								href={resolve('/admin/users')}
+								class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+							>
+								See All <ChevronRight class="size-3" />
+							</a>
 						</div>
-						<div class="text-xs text-on-surface1">Jan 1st - Feb 1st</div>
-					</div>
+					{/if}
 				</div>
 				<div class="md:col-span-4 col-span-12">
-					<div class="paper gap-2">
-						<div class="text-xs text-on-surface1">Active Server Connections</div>
-						<div class="flex w-full justify-between">
-							<div class="text-3xl font-semibold">100</div>
-							<Server class="size-8 text-primary" />
+					{#if loading.users}
+						<div class="bg-surface3 h-[138.5px] animate-pulse rounded-md"></div>
+					{:else}
+						<div class="paper gap-2">
+							<div class="text-xs text-on-surface1">Monthly Active Users</div>
+							<div class="flex w-full justify-between">
+								<div class="text-3xl font-semibold">
+									{monthlyActiveUsers}
+								</div>
+								<Activity class="size-8 text-primary" />
+							</div>
+							<div class="text-xs text-on-surface1">Last 30 Days</div>
 						</div>
-						<a
-							href={resolve('/admin/mcp-servers?view=deployments')}
-							class="text-[11px] bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-						>
-							See All Deployments <ChevronRight class="size-3" />
-						</a>
-					</div>
+					{/if}
+				</div>
+				<div class="md:col-span-4 col-span-12">
+					{#if loading.totalTokenUsage}
+						<div class="bg-surface3 h-[138.5px] animate-pulse rounded-md"></div>
+					{:else}
+						<div class="paper gap-2">
+							<div class="text-xs text-on-surface1">Total Tokens</div>
+							<div class="flex w-full justify-between">
+								<div class="text-3xl font-semibold">
+									{formatNumber(totalTokensData?.totalTokens ?? 0)}
+								</div>
+								<Coins class="size-8 text-primary" />
+							</div>
+							<a
+								href={resolve('/admin/token-usage')}
+								class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+							>
+								See All <ChevronRight class="size-3" />
+							</a>
+						</div>
+					{/if}
 				</div>
 			</div>
-			<div class="paper w-full min-h-72">
-				<div class="flex flex-wrap items-center justify-between gap-4">
-					<h4 class="flex items-center gap-2 font-semibold">
-						Token Usage <span class="text-on-surface1 text-xs font-light">(Last 7 Days)</span>
-						{#if loadingTableData}
-							<Loading class="size-4 animate-spin" />
-						{/if}
-					</h4>
-					<div class="flex shrink-0">
-						<button
-							class={twMerge(
-								'button-secondary rounded-r-none border border-r-0 text-xs',
-								selectedTokenType === 'input' && 'bg-surface2 border-surface2'
-							)}
-							onclick={() => (selectedTokenType = 'input')}
-						>
-							Input Tokens
-						</button>
-						<button
-							class={twMerge(
-								'button-secondary rounded-l-none border text-xs',
-								selectedTokenType === 'output' && 'bg-surface2 border-surface2'
-							)}
-							onclick={() => (selectedTokenType = 'output')}
-						>
-							Output Tokens
-						</button>
+			{#if loading.tokenUsage}
+				<div class="bg-surface3 h-[400px] animate-pulse rounded-md"></div>
+			{:else}
+				<div in:fade={{ duration: 150 }} class="paper w-full min-h-72">
+					<div class="flex flex-wrap items-center justify-between gap-4">
+						<h4 class="flex items-center gap-1 font-semibold">
+							Token Usage <span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
+						</h4>
+						<div class="flex shrink-0">
+							<button
+								class={twMerge(
+									'button-secondary rounded-r-none border border-r-0 text-xs',
+									selectedTokenType === 'input' && 'bg-surface2 border-surface2'
+								)}
+								onclick={() => (selectedTokenType = 'input')}
+							>
+								Input Tokens
+							</button>
+							<button
+								class={twMerge(
+									'button-secondary rounded-l-none border text-xs',
+									selectedTokenType === 'output' && 'bg-surface2 border-surface2'
+								)}
+								onclick={() => (selectedTokenType = 'output')}
+							>
+								Output Tokens
+							</button>
+						</div>
 					</div>
-				</div>
-				{#if !loadingTableData}
 					<StackedTimeline
 						{start}
 						{end}
@@ -186,8 +230,7 @@
 						categoryKey="category"
 						class="h-72"
 						legend={{
-							showSecondaryLabel: false,
-							primaryLabel: selectedTokenType === 'input' ? 'input tokens' : 'output tokens'
+							showSecondaryLabel: false
 						}}
 					>
 						{#snippet tooltipContent(item)}
@@ -195,7 +238,7 @@
 							<div class="flex flex-col gap-0 text-xs">
 								<div class="text-sm font-light">{item.key}</div>
 								<div class="text-on-surface1">{item.date}</div>
-								<div class="divider"></div>
+								<div class="tooltip-divider"></div>
 							</div>
 							<div class="flex flex-col gap-1">
 								<div class="text-on-background flex flex-col">
@@ -204,85 +247,85 @@
 							</div>
 						{/snippet}
 					</StackedTimeline>
-				{/if}
-			</div>
+				</div>
+			{/if}
 
 			<div class="grid grid-cols-12 gap-4">
 				<div class="paper gap-1 md:col-span-6 col-span-12">
-					<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>
-					<ul class="py-2 flex flex-col gap-2">
+					<h4 class="flex items-center gap-2 font-semibold">Most Popular Tools</h4>
+					<ul class="pt-2 flex flex-col gap-2">
 						<li class="flex gap-2 items-center">
-							<Server class="size-8 opacity-65" />
+							<Wrench class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-sm font-medium">Tool Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
 						<li class="flex gap-2 items-center">
-							<Server class="size-8 opacity-65" />
+							<Wrench class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-sm font-medium">Tool Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
 						<li class="flex gap-2 items-center">
-							<Server class="size-8 opacity-65" />
+							<Wrench class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-sm font-medium">Tool Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
 						<li class="flex gap-2 items-center">
-							<Server class="size-8 opacity-65" />
+							<Wrench class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-sm font-medium">Tool Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
 						<li class="flex gap-2 items-center">
-							<Server class="size-8 opacity-65" />
+							<Wrench class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-sm font-medium">Tool Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
 					</ul>
 				</div>
 				<div class="paper gap-1 md:col-span-6 col-span-12">
-					<h4 class="flex items-center gap-2 font-semibold">Most Popular Tools</h4>
-					<ul class="py-2 flex flex-col gap-2">
+					<h4 class="flex items-center gap-2 font-semibold">Most Popular Skills</h4>
+					<ul class="pt-2 flex flex-col gap-2">
 						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
+							<PencilRuler class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-sm font-medium">Skill Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
 						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
+							<PencilRuler class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-sm font-medium">Skill Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
 						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
+							<PencilRuler class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-sm font-medium">Skill Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
 						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
+							<PencilRuler class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-sm font-medium">Skill Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
 						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
+							<Server class="size-8 opacity-65" />
 							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-sm font-medium">Server Name</p>
 								<p class="text-xs text-on-surface1">100 calls</p>
 							</div>
 						</li>
@@ -290,7 +333,67 @@
 				</div>
 			</div>
 		</div>
-		<div class="md:col-span-4 col-span-12">
+		<div class="md:col-span-4 col-span-12 flex flex-col gap-4">
+			<div class="paper gap-2 justify-center items-center">
+				<div class="text-xs text-on-surface1">Total Active Server Connections</div>
+				<div class="flex w-full gap-2 items-center justify-center">
+					<div class="text-3xl font-semibold">100</div>
+					<Server class="size-8 text-primary" />
+				</div>
+				<a
+					href={resolve('/admin/mcp-servers?view=deployments')}
+					class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+				>
+					See All <ChevronRight class="size-3" />
+				</a>
+			</div>
+			<div class="paper gap-1 flex grow">
+				<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>
+				<ul class="pt-2 flex flex-col gap-2">
+					<li class="flex gap-2 items-center">
+						<Server class="size-8 opacity-65" />
+						<div class="flex flex-col gap-1">
+							<p class="text-sm font-medium">Server Name</p>
+							<p class="text-xs text-on-surface1">100 calls</p>
+						</div>
+					</li>
+					<li class="flex gap-2 items-center">
+						<Server class="size-8 opacity-65" />
+						<div class="flex flex-col gap-1">
+							<p class="text-sm font-medium">Server Name</p>
+							<p class="text-xs text-on-surface1">100 calls</p>
+						</div>
+					</li>
+					<li class="flex gap-2 items-center">
+						<Server class="size-8 opacity-65" />
+						<div class="flex flex-col gap-1">
+							<p class="text-sm font-medium">Server Name</p>
+							<p class="text-xs text-on-surface1">100 calls</p>
+						</div>
+					</li>
+					<li class="flex gap-2 items-center">
+						<Server class="size-8 opacity-65" />
+						<div class="flex flex-col gap-1">
+							<p class="text-sm font-medium">Server Name</p>
+							<p class="text-xs text-on-surface1">100 calls</p>
+						</div>
+					</li>
+					<li class="flex gap-2 items-center">
+						<Server class="size-8 opacity-65" />
+						<div class="flex flex-col gap-1">
+							<p class="text-sm font-medium">Server Name</p>
+							<p class="text-xs text-on-surface1">100 calls</p>
+						</div>
+					</li>
+				</ul>
+				<div class="flex grow"></div>
+				<a
+					href={resolve('/admin/mcp-servers')}
+					class="justify-end self-end text-[11px] translate-x-2 transition-colors duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+				>
+					See All <ChevronRight class="size-3" />
+				</a>
+			</div>
 			<div class="paper">
 				<h4 class="font-semibold mb-1">Deployed Servers by Type</h4>
 
@@ -309,6 +412,10 @@
 						{
 							label: 'Multi-User',
 							value: 8
+						},
+						{
+							label: 'Composite',
+							value: 1
 						}
 					]}
 				/>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -254,17 +254,16 @@
 			<div class="grid grid-cols-12 gap-4">
 				<div class="col-span-12 @min-[768px]:col-span-4">
 					<div class="paper gap-2 h-full">
-						<div class="text-xs text-on-surface1 flex items-center gap-1">
-							Total Users
-							{#if loading}
-								<Loading class="size-3" />
-							{/if}
-						</div>
+						<div class="text-xs text-on-surface1 flex items-center gap-1">Total Users</div>
 						<div class="flex w-full justify-between">
-							<div class="text-3xl font-semibold">
-								<TweenedMetric holdAtZero={loading} target={usersData.length} />
-							</div>
-							<Users class="size-8 text-primary" />
+							{#if loading}
+								<Loading class="size-8" />
+							{:else}
+								<div class="text-3xl font-semibold">
+									<TweenedMetric holdAtZero={loading} target={usersData.length} />
+								</div>
+								<Users class="size-8 text-primary" />
+							{/if}
 						</div>
 						{#if !isBootStrapUser}
 							<a
@@ -278,38 +277,36 @@
 				</div>
 				<div class="col-span-12 @min-[768px]:col-span-4">
 					<div class="paper gap-2 h-full">
-						<div class="text-xs text-on-surface1 flex items-center gap-1">
-							Monthly Active Users
-							{#if loading}
-								<Loading class="size-3" />
-							{/if}
-						</div>
+						<div class="text-xs text-on-surface1 flex items-center gap-1">Monthly Active Users</div>
 						<div class="flex w-full justify-between">
-							<div class="text-3xl font-semibold">
-								<TweenedMetric holdAtZero={loading} target={monthlyActiveUsers} />
-							</div>
-							<Activity class="size-8 text-primary" />
+							{#if loading}
+								<Loading class="size-8" />
+							{:else}
+								<div class="text-3xl font-semibold">
+									<TweenedMetric holdAtZero={loading} target={monthlyActiveUsers} />
+								</div>
+								<Activity class="size-8 text-primary" />
+							{/if}
 						</div>
 						<div class="text-xs text-on-surface1">Last 30 Days</div>
 					</div>
 				</div>
 				<div class="col-span-12 @min-[768px]:col-span-4">
 					<div class="paper gap-2 h-full">
-						<div class="text-xs text-on-surface1 flex items-center gap-1">
-							Total Tokens
-							{#if loading}
-								<Loading class="size-3" />
-							{/if}
-						</div>
+						<div class="text-xs text-on-surface1 flex items-center gap-1">Total Tokens</div>
 						<div class="flex w-full justify-between">
-							<div class="text-3xl font-semibold">
-								<TweenedMetric
-									holdAtZero={loading}
-									target={totalTokensData?.totalTokens ?? 0}
-									format={(n) => formatNumber(Math.max(0, Math.round(n)))}
-								/>
-							</div>
-							<Coins class="size-8 text-primary" />
+							{#if loading}
+								<Loading class="size-8" />
+							{:else}
+								<div class="text-3xl font-semibold">
+									<TweenedMetric
+										holdAtZero={loading}
+										target={totalTokensData?.totalTokens ?? 0}
+										format={(n) => formatNumber(Math.max(0, Math.round(n)))}
+									/>
+								</div>
+								<Coins class="size-8 text-primary" />
+							{/if}
 						</div>
 						{#if !isBootStrapUser}
 							<a

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import DotDotDot from '$lib/components/DotDotDot.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import TweenedMetric from '$lib/components/TweenedMetric.svelte';
 	import DonutGraph from '$lib/components/graph/DonutGraph.svelte';
 	import StackedTimeline from '$lib/components/graph/StackedTimeline.svelte';
+	import SelectServerType from '$lib/components/mcp/SelectServerType.svelte';
 	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 	import { formatNumber } from '$lib/format';
 	import Loading from '$lib/icons/Loading.svelte';
@@ -11,6 +13,7 @@
 	import {
 		AdminService,
 		type AuditLogUsageStats,
+		type LaunchServerType,
 		type MCPCatalogEntry,
 		type MCPCatalogServer,
 		type OrgUser,
@@ -19,9 +22,10 @@
 		type TotalTokenUsage
 	} from '$lib/services';
 	import { errors, mcpServersAndEntries } from '$lib/stores';
+	import { goto } from '$lib/url';
 	import { aggregateTimelineDataByBucket, getUserLabels } from '../token-usage/utils';
 	import { isWithinInterval, set, subMonths } from 'date-fns';
-	import { Activity, ChevronRight, Coins, Server, Users, Wrench } from 'lucide-svelte';
+	import { Activity, ChevronRight, Coins, Plus, Server, Users, Wrench } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -39,6 +43,13 @@
 
 	let mainChartData = $state<TokenUsageWithCategory[]>([]);
 	let usersMap = $derived(new Map(usersData.map((user) => [user.id, user])));
+
+	let selectServerTypeDialog = $state<ReturnType<typeof SelectServerType>>();
+
+	function handleSelectServerType(type: LaunchServerType) {
+		selectServerTypeDialog?.close();
+		goto(resolve(`/admin/mcp-servers?new=${type}`));
+	}
 
 	const DEFER_DATA_THRESHOLD = 400;
 	const TIMELINE_AGGREGATE_THRESHOLD = 500;
@@ -436,7 +447,7 @@
 			{/if}
 
 			<div class="grid grid-cols-12 gap-4 grow">
-				<div class="paper h-full gap-1 md:col-span-6 col-span-12 flex flex-col">
+				<div class="paper h-full gap-1 md:col-span-6 col-span-12 flex flex-col min-h-72">
 					<h4 class="flex items-center gap-2 font-semibold mb-1">
 						Recently Popular Tools
 						<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
@@ -454,7 +465,9 @@
 							{/each}
 						</div>
 					{:else if topToolCalls.length === 0}
-						<p class="text-xs text-on-surface1 pt-2">No tool calls in the last 7 days.</p>
+						<p class="text-xs text-on-surface1 pt-2 font-light text-center">
+							No recent tool calls.
+						</p>
 					{:else}
 						<ul class="pt-2 flex flex-col gap-2">
 							{#each topToolCalls as row (row.compositeKey)}
@@ -475,20 +488,22 @@
 						</ul>
 					{/if}
 					<div class="flex grow min-h-0"></div>
-					<a
-						href={resolve('/admin/usage')}
-						class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
-					>
-						See All <ChevronRight class="size-3" />
-					</a>
+					{#if topToolCalls.length > 0}
+						<a
+							href={resolve('/admin/usage')}
+							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
+						>
+							See All <ChevronRight class="size-3" />
+						</a>
+					{/if}
 				</div>
-				<div class="paper h-full gap-1 md:col-span-6 col-span-12 flex flex-col">
+				<div class="paper h-full gap-1 md:col-span-6 col-span-12 flex flex-col min-h-72">
 					<h4 class="flex items-center gap-2 font-semibold mb-1">
 						Frequently Used Servers
 						<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
 					</h4>
-					{#if loadingToolUsage}
-						<div class="pt-2 flex flex-col gap-4 w-full">
+					<div class="pt-2 flex flex-col gap-4 w-full">
+						{#if loadingToolUsage}
 							{#each Array.from({ length: TOP_TOOLS_LIMIT }) as _, i (i)}
 								<div class="flex gap-2 items-center animate-pulse w-full">
 									<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
@@ -498,33 +513,37 @@
 									</div>
 								</div>
 							{/each}
-						</div>
-					{:else if topServerUsage.length === 0}
-						<p class="text-xs text-on-surface1 pt-2">No server tool calls in the last 7 days.</p>
-					{:else}
-						<ul class="pt-2 flex flex-col gap-2">
-							{#each topServerUsage as row (row.serverName)}
-								<li class="flex gap-2 items-center">
-									<div
-										class="size-8 items-center justify-center shrink-0 bg-surface1 dark:bg-surface2 rounded-md p-1 flex"
-									>
-										<Server class="size-6 opacity-65 shrink-0" />
-									</div>
-									<div class="flex flex-col gap-1 min-w-0">
-										<p class="text-sm font-medium truncate">{row.serverName}</p>
-										<p class="text-xs text-on-surface1">{formatNumber(row.count)} calls</p>
-									</div>
-								</li>
-							{/each}
-						</ul>
-					{/if}
+						{:else if topServerUsage.length === 0}
+							<p class="text-xs text-on-surface1 pt-2 font-light text-center">
+								No recent server calls.
+							</p>
+						{:else}
+							<ul class="pt-2 flex flex-col gap-2">
+								{#each topServerUsage as row (row.serverName)}
+									<li class="flex gap-2 items-center">
+										<div
+											class="size-8 items-center justify-center shrink-0 bg-surface1 dark:bg-surface2 rounded-md p-1 flex"
+										>
+											<Server class="size-6 opacity-65 shrink-0" />
+										</div>
+										<div class="flex flex-col gap-1 min-w-0">
+											<p class="text-sm font-medium truncate">{row.serverName}</p>
+											<p class="text-xs text-on-surface1">{formatNumber(row.count)} calls</p>
+										</div>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					</div>
 					<div class="flex grow min-h-0"></div>
-					<a
-						href={resolve('/admin/usage')}
-						class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
-					>
-						See All <ChevronRight class="size-3" />
-					</a>
+					{#if topServerUsage.length > 0}
+						<a
+							href={resolve('/admin/usage')}
+							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
+						>
+							See All <ChevronRight class="size-3" />
+						</a>
+					{/if}
 				</div>
 			</div>
 		</div>
@@ -546,31 +565,79 @@
 					</div>
 				</div>
 			{:else}
-				<div in:fade={{ duration: 150 }} class="paper">
-					<h4 class="font-semibold">Active Servers</h4>
-
-					<div class="mb-2 flex flex-col justify-center items-center gap-2">
-						<div class="flex w-full gap-2 items-center justify-center">
-							<div class="text-3xl font-semibold">
-								<TweenedMetric holdAtZero={serverAndEntries.loading} target={totalServers} />
+				<div in:fade={{ duration: 150 }} class="paper min-h-96">
+					{#if deployedCatalogEntryServers.length > 0 || deployedWorkspaceCatalogEntryServers.length > 0}
+						<h4 class="font-semibold">Active Servers</h4>
+						<div class="mb-2 flex flex-col justify-center items-center gap-2">
+							<div class="flex w-full gap-2 items-center justify-center">
+								<div class="text-3xl font-semibold">
+									<TweenedMetric holdAtZero={serverAndEntries.loading} target={totalServers} />
+								</div>
+								<Server class="size-8 text-primary" />
 							</div>
-							<Server class="size-8 text-primary" />
+							<div class="text-xs">Total Currently Active</div>
 						</div>
-						<div class="text-xs">Total Currently Active</div>
-					</div>
 
-					<div class="h-px w-full bg-surface2 mb-4"></div>
+						<div class="h-px w-full bg-surface2 mb-4"></div>
 
-					<DonutGraph class="h-72" donutRatio={0.65} data={graphData} />
+						<div class="h-72 flex flex-col items-center justify-center">
+							{#if graphData.some((g) => g.value > 0)}
+								<DonutGraph class="h-72" donutRatio={0.65} data={graphData} />
+							{:else}
+								<p class="font-light text-xs text-on-surface1 pt-2 text-center">
+									No servers have been deployed yet.
+								</p>
+							{/if}
+						</div>
 
-					<div class="flex justify-end">
-						<a
-							href={resolve('/admin/mcp-servers?view=deployments')}
-							class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-						>
-							See All <ChevronRight class="size-3" />
-						</a>
-					</div>
+						<div class="flex justify-end">
+							<a
+								href={resolve('/admin/mcp-servers?view=deployments')}
+								class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+							>
+								See All <ChevronRight class="size-3" />
+							</a>
+						</div>
+					{:else}
+						<div class="grow flex flex-col items-center justify-center gap-4">
+							<div>
+								<p class="text-sm text-center mb-1">
+									Looks like you don't have any servers created yet.
+								</p>
+								<p class="text-sm text-center">Click below to get started!</p>
+							</div>
+							<DotDotDot
+								class="button-primary w-full text-sm md:w-fit self-center"
+								placement="bottom"
+							>
+								{#snippet icon()}
+									<span class="flex items-center justify-center gap-1">
+										<Plus class="size-4" /> Add MCP Server
+									</span>
+								{/snippet}
+								<button
+									class="menu-button"
+									onclick={() => {
+										selectServerTypeDialog?.open();
+									}}
+								>
+									Add server
+								</button>
+								<button
+									class="menu-button"
+									onclick={() => {
+										// editingSource = {
+										// 	index: -1,
+										// 	value: ''
+										// };
+										// sourceDialog?.showModal();
+									}}
+								>
+									Add server(s) from Git
+								</button>
+							</DotDotDot>
+						</div>
+					{/if}
 				</div>
 				<div in:fade={{ duration: 150 }} class="paper gap-1 flex grow">
 					<h4 class="flex items-center gap-2 font-semibold">Most Deployed Servers</h4>
@@ -586,7 +653,7 @@
 								</div>
 							{/each}
 						</div>
-					{:else}
+					{:else if popularServers.length > 0}
 						<div class="pt-2 flex flex-col gap-2">
 							{#each popularServers as info (info.id)}
 								{@const icon =
@@ -630,19 +697,27 @@
 								</a>
 							{/each}
 						</div>
+					{:else}
+						<p class="text-xs text-on-surface1 pt-2 font-light text-center">
+							No servers have been deployed yet.
+						</p>
 					{/if}
 					<div class="flex grow"></div>
-					<a
-						href={resolve('/admin/mcp-servers')}
-						class="justify-end self-end text-[11px] translate-x-2 transition-colors duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-					>
-						See All <ChevronRight class="size-3" />
-					</a>
+					{#if popularServers.length > 0}
+						<a
+							href={resolve('/admin/mcp-servers')}
+							class="justify-end self-end text-[11px] translate-x-2 transition-colors duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+						>
+							See All <ChevronRight class="size-3" />
+						</a>
+					{/if}
 				</div>
 			{/if}
 		</div>
 	</div>
 </Layout>
+
+<SelectServerType bind:this={selectServerTypeDialog} onSelectServerType={handleSelectServerType} />
 
 <svelte:head>
 	<title>Obot | Dashboard</title>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -1,0 +1,318 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import Layout from '$lib/components/Layout.svelte';
+	import DonutGraph from '$lib/components/graph/DonutGraph.svelte';
+	import StackedTimeline from '$lib/components/graph/StackedTimeline.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
+	import {
+		AdminService,
+		type OrgUser,
+		type TokenUsage,
+		type TokenUsageWithCategory
+	} from '$lib/services';
+	import { errors } from '$lib/stores';
+	import { aggregateTimelineDataByBucket, getUserLabels } from '../token-usage/utils';
+	import { isWithinInterval, subDays } from 'date-fns';
+	import { Activity, ChevronRight, Server, Users, Wrench } from 'lucide-svelte';
+	import { onMount } from 'svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	let loadingTableData = $state(true);
+	let usersData = $state<OrgUser[]>([]);
+	let selectedTokenType = $derived<'input' | 'output'>('input');
+	let data = $state<TokenUsage[]>([]);
+
+	let mainChartData = $state<TokenUsageWithCategory[]>([]);
+	let usersMap = $derived(new Map(usersData.map((user) => [user.id, user])));
+
+	const DEFER_DATA_THRESHOLD = 400;
+	const TIMELINE_AGGREGATE_THRESHOLD = 500;
+	const end = new Date();
+	const start = subDays(end, 7);
+
+	onMount(async () => {
+		usersData = await AdminService.listUsersIncludeDeleted();
+
+		const timeRange = { start, end };
+
+		AdminService.listTokenUsage(timeRange)
+			.then((tokenUsage) => {
+				if (tokenUsage.length <= DEFER_DATA_THRESHOLD) {
+					data = tokenUsage;
+					return;
+				}
+				// Defer so the UI can paint (200, loading off) before heavy derivation. Safari lacks requestIdleCallback.
+				const schedule =
+					typeof requestIdleCallback !== 'undefined'
+						? (fn: () => void) => requestIdleCallback(fn, { timeout: 120 })
+						: (fn: () => void) => setTimeout(fn, 0);
+				schedule(() => {
+					data = tokenUsage;
+				});
+			})
+			.finally(() => {
+				loadingTableData = false;
+			})
+			.catch((error) => {
+				if (error?.name === 'AbortError') return;
+				errors.append(error);
+			});
+	});
+
+	function computeMainTimelineData(
+		filtered: TokenUsage[],
+		group: string,
+		users: Map<string, OrgUser>
+	): TokenUsageWithCategory[] {
+		const userKeys = [...new Set(filtered.map((r) => r.userID ?? r.runName ?? 'Unknown'))].sort();
+		const userKeyToLabel = getUserLabels(users, userKeys);
+		return filtered.map((r) => ({
+			...r,
+			date: r.date,
+			promptTokens: r.promptTokens ?? 0,
+			completionTokens: r.completionTokens ?? 0,
+			totalTokens: r.totalTokens ?? (r.promptTokens ?? 0) + (r.completionTokens ?? 0),
+			category:
+				userKeyToLabel.get(r.userID ?? r.runName ?? 'Unknown') ?? r.userID ?? r.runName ?? 'Unknown'
+		}));
+	}
+
+	$effect(() => {
+		if (data.length <= TIMELINE_AGGREGATE_THRESHOLD) {
+			const timeline = computeMainTimelineData(data, 'group_by_users', usersMap);
+			mainChartData = timeline;
+			return;
+		}
+
+		const schedule =
+			typeof requestIdleCallback !== 'undefined'
+				? (fn: () => void) => requestIdleCallback(fn, { timeout: 150 })
+				: (fn: () => void) => setTimeout(fn, 0);
+		schedule(() => {
+			const timeline = computeMainTimelineData(data, 'group_by_users', usersMap);
+			if (timeline.length <= TIMELINE_AGGREGATE_THRESHOLD) return timeline;
+			return aggregateTimelineDataByBucket(timeline, start, end) as TokenUsageWithCategory[];
+		});
+	});
+</script>
+
+<Layout title="Dashboard" classes={{ childrenContainer: 'max-w-none', container: '' }}>
+	<div class="grid grid-cols-12 gap-4">
+		<div class="flex flex-col md:col-span-8 col-span-12 gap-4">
+			<!-- this token usage graph-->
+			<div class="grid grid-cols-12 gap-4">
+				<div class="md:col-span-4 col-span-12">
+					<div class="paper gap-2">
+						<div class="text-xs text-on-surface1">Total Users</div>
+						<div class="flex w-full justify-between">
+							<div class="text-3xl font-semibold">{usersData.length}</div>
+							<Users class="size-8 text-primary" />
+						</div>
+						<a
+							href={resolve('/admin/users')}
+							class="text-[11px] bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+						>
+							See All Users <ChevronRight class="size-3" />
+						</a>
+					</div>
+				</div>
+				<div class="md:col-span-4 col-span-12">
+					<div class="paper gap-2">
+						<div class="text-xs text-on-surface1">Monthly Active Users</div>
+						<div class="flex w-full justify-between">
+							<div class="text-3xl font-semibold">
+								{usersData.filter(
+									(user) =>
+										user.lastActiveDay && isWithinInterval(user.lastActiveDay, { start, end })
+								).length}
+							</div>
+							<Activity class="size-8 text-primary" />
+						</div>
+						<div class="text-xs text-on-surface1">Jan 1st - Feb 1st</div>
+					</div>
+				</div>
+				<div class="md:col-span-4 col-span-12">
+					<div class="paper gap-2">
+						<div class="text-xs text-on-surface1">Active Server Connections</div>
+						<div class="flex w-full justify-between">
+							<div class="text-3xl font-semibold">100</div>
+							<Server class="size-8 text-primary" />
+						</div>
+						<a
+							href={resolve('/admin/mcp-servers?view=deployments')}
+							class="text-[11px] bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+						>
+							See All Deployments <ChevronRight class="size-3" />
+						</a>
+					</div>
+				</div>
+			</div>
+			<div class="paper w-full min-h-72">
+				<div class="flex flex-wrap items-center justify-between gap-4">
+					<h4 class="flex items-center gap-2 font-semibold">
+						Token Usage <span class="text-on-surface1 text-xs font-light">(Last 7 Days)</span>
+						{#if loadingTableData}
+							<Loading class="size-4 animate-spin" />
+						{/if}
+					</h4>
+					<div class="flex shrink-0">
+						<button
+							class={twMerge(
+								'button-secondary rounded-r-none border border-r-0 text-xs',
+								selectedTokenType === 'input' && 'bg-surface2 border-surface2'
+							)}
+							onclick={() => (selectedTokenType = 'input')}
+						>
+							Input Tokens
+						</button>
+						<button
+							class={twMerge(
+								'button-secondary rounded-l-none border text-xs',
+								selectedTokenType === 'output' && 'bg-surface2 border-surface2'
+							)}
+							onclick={() => (selectedTokenType = 'output')}
+						>
+							Output Tokens
+						</button>
+					</div>
+				</div>
+				{#if !loadingTableData}
+					<StackedTimeline
+						{start}
+						{end}
+						data={mainChartData}
+						dateKey="date"
+						primaryValueKey={selectedTokenType === 'input' ? 'promptTokens' : 'completionTokens'}
+						categoryKey="category"
+						class="h-72"
+						legend={{
+							showSecondaryLabel: false,
+							primaryLabel: selectedTokenType === 'input' ? 'input tokens' : 'output tokens'
+						}}
+					>
+						{#snippet tooltipContent(item)}
+							{@const value = item.primaryTotal ?? 0}
+							<div class="flex flex-col gap-0 text-xs">
+								<div class="text-sm font-light">{item.key}</div>
+								<div class="text-on-surface1">{item.date}</div>
+								<div class="divider"></div>
+							</div>
+							<div class="flex flex-col gap-1">
+								<div class="text-on-background flex flex-col">
+									<div class="text-xl font-bold">{value.toLocaleString()}</div>
+								</div>
+							</div>
+						{/snippet}
+					</StackedTimeline>
+				{/if}
+			</div>
+
+			<div class="grid grid-cols-12 gap-4">
+				<div class="paper gap-1 md:col-span-6 col-span-12">
+					<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>
+					<ul class="py-2 flex flex-col gap-2">
+						<li class="flex gap-2 items-center">
+							<Server class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+						<li class="flex gap-2 items-center">
+							<Server class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+						<li class="flex gap-2 items-center">
+							<Server class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+						<li class="flex gap-2 items-center">
+							<Server class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+						<li class="flex gap-2 items-center">
+							<Server class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Server Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+					</ul>
+				</div>
+				<div class="paper gap-1 md:col-span-6 col-span-12">
+					<h4 class="flex items-center gap-2 font-semibold">Most Popular Tools</h4>
+					<ul class="py-2 flex flex-col gap-2">
+						<li class="flex gap-2 items-center">
+							<Wrench class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+						<li class="flex gap-2 items-center">
+							<Wrench class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+						<li class="flex gap-2 items-center">
+							<Wrench class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+						<li class="flex gap-2 items-center">
+							<Wrench class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+						<li class="flex gap-2 items-center">
+							<Wrench class="size-8 opacity-65" />
+							<div class="flex flex-col gap-1">
+								<p class="text-sm font-medium">Tool Name</p>
+								<p class="text-xs text-on-surface1">100 calls</p>
+							</div>
+						</li>
+					</ul>
+				</div>
+			</div>
+		</div>
+		<div class="md:col-span-4 col-span-12">
+			<div class="paper">
+				<h4 class="font-semibold mb-1">Deployed Servers by Type</h4>
+
+				<DonutGraph
+					class="h-72"
+					donutRatio={0.65}
+					data={[
+						{
+							label: 'Remote',
+							value: 25
+						},
+						{
+							label: 'Single-User',
+							value: 37
+						},
+						{
+							label: 'Multi-User',
+							value: 8
+						}
+					]}
+				/>
+			</div>
+		</div>
+	</div>
+</Layout>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -190,16 +190,9 @@
 	);
 
 	onMount(async () => {
-		usersData = await AdminService.listUsersIncludeDeleted();
-		totalTokensData = await AdminService.listTotalTokenUsage();
-		deployedCatalogEntryServers =
-			await AdminService.listAllCatalogDeployedSingleRemoteServers(DEFAULT_MCP_CATALOG_ID);
-		deployedWorkspaceCatalogEntryServers =
-			await AdminService.listAllWorkspaceDeployedSingleRemoteServers();
-		loading = false;
-
 		const endToolStats = set(new Date(), { milliseconds: 0, seconds: 59 });
 		const startToolStats = subMonths(endToolStats, 1);
+
 		AdminService.listAuditLogUsageStats({
 			start_time: startToolStats.toISOString(),
 			end_time: endToolStats.toISOString()
@@ -216,6 +209,19 @@
 			.finally(() => {
 				loadingToolUsage = false;
 			});
+
+		const [users, tokens, catalogServers, workspaceServers] = await Promise.all([
+			AdminService.listUsersIncludeDeleted(),
+			AdminService.listTotalTokenUsage(),
+			AdminService.listAllCatalogDeployedSingleRemoteServers(DEFAULT_MCP_CATALOG_ID),
+			AdminService.listAllWorkspaceDeployedSingleRemoteServers()
+		]);
+
+		usersData = users;
+		totalTokensData = tokens;
+		deployedCatalogEntryServers = catalogServers;
+		deployedWorkspaceCatalogEntryServers = workspaceServers;
+		loading = false;
 	});
 
 	function handleSelectServerType(type: LaunchServerType) {

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -78,13 +78,19 @@
 				count,
 				serverDisplayName
 			}))
+			.filter(
+				(t) => !t.serverDisplayName.startsWith('nba1') && !t.serverDisplayName.startsWith('Obot ')
+			)
 			.sort((a, b) => b.count - a.count);
 	}
 
 	function topServersFromStats(stats: AuditLogUsageStats | undefined): TopServerUsageRow[] {
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
 		const counts = new Map<string, number>();
-		for (const s of stats?.items.filter((s) => !s.mcpServerDisplayName.startsWith('nba1')) ?? []) {
+		for (const s of stats?.items.filter(
+			(s) =>
+				!s.mcpServerDisplayName.startsWith('nba1') && !s.mcpServerDisplayName.startsWith('Obot ')
+		) ?? []) {
 			const total = (s.toolCalls ?? []).reduce((sum, t) => sum + t.callCount, 0);
 			if (total > 0) {
 				counts.set(s.mcpServerDisplayName, (counts.get(s.mcpServerDisplayName) ?? 0) + total);
@@ -544,13 +550,13 @@
 					<h4 class="font-semibold">Active Servers</h4>
 
 					<div class="mb-2 flex flex-col justify-center items-center gap-2">
-						<div class="text-xs">Total Currently Active</div>
 						<div class="flex w-full gap-2 items-center justify-center">
 							<div class="text-3xl font-semibold">
 								<TweenedMetric holdAtZero={serverAndEntries.loading} target={totalServers} />
 							</div>
 							<Server class="size-8 text-primary" />
 						</div>
+						<div class="text-xs">Total Currently Active</div>
 					</div>
 
 					<div class="h-px w-full bg-surface2 mb-4"></div>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import Layout from '$lib/components/Layout.svelte';
+	import TweenedMetric from '$lib/components/TweenedMetric.svelte';
 	import DonutGraph from '$lib/components/graph/DonutGraph.svelte';
 	import StackedTimeline from '$lib/components/graph/StackedTimeline.svelte';
 	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
@@ -21,16 +22,8 @@
 	import { isWithinInterval, subMonths } from 'date-fns';
 	import { Activity, ChevronRight, Coins, PencilRuler, Server, Users, Wrench } from 'lucide-svelte';
 	import { onMount } from 'svelte';
-	import { cubicOut } from 'svelte/easing';
-	import { Tween } from 'svelte/motion';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
-
-	const STAT_COUNT_MS = 650;
-	const totalUsersAnimated = new Tween(0, { duration: STAT_COUNT_MS, easing: cubicOut });
-	const monthlyActiveAnimated = new Tween(0, { duration: STAT_COUNT_MS, easing: cubicOut });
-	const totalTokensAnimated = new Tween(0, { duration: STAT_COUNT_MS, easing: cubicOut });
-	const totalServersAnimated = new Tween(0, { duration: STAT_COUNT_MS, easing: cubicOut });
 
 	let loading = $state(true);
 	let loadingTokensUsage = $state(true);
@@ -199,16 +192,16 @@
 
 	function getServerUrl(server: MCPCatalogServer) {
 		if (server.powerUserWorkspaceID) {
-			return resolve(`/admin/mcp-servers/w/${server.powerUserWorkspaceID}/s/${server.id}`);
+			return `/admin/mcp-servers/w/${server.powerUserWorkspaceID}/s/${server.id}`;
 		}
-		return resolve(`/admin/mcp-servers/s/${server.id}`);
+		return `/admin/mcp-servers/s/${server.id}`;
 	}
 
 	function getEntryUrl(entry: MCPCatalogEntry) {
 		if (entry.powerUserWorkspaceID) {
-			return resolve(`/admin/mcp-servers/w/${entry.powerUserWorkspaceID}/c/${entry.id}`);
+			return `/admin/mcp-servers/w/${entry.powerUserWorkspaceID}/c/${entry.id}`;
 		}
-		return resolve(`/admin/mcp-servers/c/${entry.id}`);
+		return `/admin/mcp-servers/c/${entry.id}`;
 	}
 
 	$effect(() => {
@@ -224,42 +217,13 @@
 				: (fn: () => void) => setTimeout(fn, 0);
 		schedule(() => {
 			const timeline = computeMainTimelineData(tokenUsageData, 'group_by_users', usersMap);
-			if (timeline.length <= TIMELINE_AGGREGATE_THRESHOLD) return timeline;
-			return aggregateTimelineDataByBucket(timeline, start, end) as TokenUsageWithCategory[];
+			mainChartData =
+				timeline.length <= TIMELINE_AGGREGATE_THRESHOLD
+					? timeline
+					: (aggregateTimelineDataByBucket(timeline, start, end) as TokenUsageWithCategory[]);
 		});
 	});
 
-	$effect(() => {
-		if (loading) {
-			void totalUsersAnimated.set(0, { duration: 0 });
-			return;
-		}
-		void totalUsersAnimated.set(usersData.length);
-	});
-
-	$effect(() => {
-		if (loading) {
-			void monthlyActiveAnimated.set(0, { duration: 0 });
-			return;
-		}
-		void monthlyActiveAnimated.set(monthlyActiveUsers);
-	});
-
-	$effect(() => {
-		if (loading) {
-			void totalTokensAnimated.set(0, { duration: 0 });
-			return;
-		}
-		void totalTokensAnimated.set(totalTokensData?.totalTokens ?? 0);
-	});
-
-	$effect(() => {
-		if (serverAndEntries.loading) {
-			void totalServersAnimated.set(0, { duration: 0 });
-			return;
-		}
-		void totalServersAnimated.set(totalServers);
-	});
 </script>
 
 <Layout title="Dashboard" classes={{ childrenContainer: 'max-w-none', container: '' }}>
@@ -276,7 +240,9 @@
 							{/if}
 						</div>
 						<div class="flex w-full justify-between">
-							<div class="text-3xl font-semibold">{Math.round(totalUsersAnimated.current)}</div>
+							<div class="text-3xl font-semibold">
+								<TweenedMetric holdAtZero={loading} target={usersData.length} />
+							</div>
 							<Users class="size-8 text-primary" />
 						</div>
 						<a
@@ -297,7 +263,7 @@
 						</div>
 						<div class="flex w-full justify-between">
 							<div class="text-3xl font-semibold">
-								{Math.round(monthlyActiveAnimated.current)}
+								<TweenedMetric holdAtZero={loading} target={monthlyActiveUsers} />
 							</div>
 							<Activity class="size-8 text-primary" />
 						</div>
@@ -314,7 +280,11 @@
 						</div>
 						<div class="flex w-full justify-between">
 							<div class="text-3xl font-semibold">
-								{formatNumber(Math.max(0, Math.round(totalTokensAnimated.current)))}
+								<TweenedMetric
+									holdAtZero={loading}
+									target={totalTokensData?.totalTokens ?? 0}
+									format={(n) => formatNumber(Math.max(0, Math.round(n)))}
+								/>
 							</div>
 							<Coins class="size-8 text-primary" />
 						</div>
@@ -479,7 +449,12 @@
 					<div class="mb-2 flex flex-col justify-center items-center gap-2">
 						<div class="text-xs">Total Currently Active</div>
 						<div class="flex w-full gap-2 items-center justify-center">
-							<div class="text-3xl font-semibold">{Math.round(totalServersAnimated.current)}</div>
+							<div class="text-3xl font-semibold">
+								<TweenedMetric
+									holdAtZero={serverAndEntries.loading}
+									target={totalServers}
+								/>
+							</div>
 							<Server class="size-8 text-primary" />
 						</div>
 					</div>
@@ -518,7 +493,7 @@
 									: undefined}
 							<a
 								class="flex gap-2 items-center hover:bg-surface1 -mx-2 px-2 py-1 rounded-md"
-								href={url}
+								href={url ? resolve(url as `/${string}`) : undefined}
 							>
 								{#if icon}
 									<img src={icon} alt={info.id} class="size-9 bg-surface1 rounded-md p-1" />

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -10,6 +10,7 @@
 	import { stripMarkdownToText } from '$lib/markdown';
 	import {
 		AdminService,
+		type AuditLogUsageStats,
 		type MCPCatalogEntry,
 		type MCPCatalogServer,
 		type OrgUser,
@@ -19,7 +20,7 @@
 	} from '$lib/services';
 	import { errors, mcpServersAndEntries } from '$lib/stores';
 	import { aggregateTimelineDataByBucket, getUserLabels } from '../token-usage/utils';
-	import { isWithinInterval, subMonths } from 'date-fns';
+	import { isWithinInterval, set, subDays, subMonths } from 'date-fns';
 	import { Activity, ChevronRight, Coins, PencilRuler, Server, Users, Wrench } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -27,6 +28,7 @@
 
 	let loading = $state(true);
 	let loadingTokensUsage = $state(true);
+	let loadingToolUsage = $state(true);
 
 	let usersData = $state<OrgUser[]>([]);
 	let selectedTokenType = $derived<'input' | 'output'>('input');
@@ -40,6 +42,40 @@
 
 	const DEFER_DATA_THRESHOLD = 400;
 	const TIMELINE_AGGREGATE_THRESHOLD = 500;
+	const TOP_TOOLS_LIMIT = 5;
+
+	type TopToolCallRow = {
+		compositeKey: string;
+		toolLabel: string;
+		count: number;
+		serverDisplayName: string;
+	};
+
+	let topToolCalls = $state<TopToolCallRow[]>([]);
+
+	function topToolCallsFromStats(stats: AuditLogUsageStats | undefined): TopToolCallRow[] {
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const counts = new Map<string, { count: number; serverDisplayName: string }>();
+		for (const s of stats?.items ?? []) {
+			for (const call of s.toolCalls ?? []) {
+				const key = `${s.mcpServerDisplayName}.${call.toolName}`;
+				const existing = counts.get(key) ?? {
+					count: 0,
+					serverDisplayName: s.mcpServerDisplayName
+				};
+				existing.count += call.callCount;
+				counts.set(key, existing);
+			}
+		}
+		return Array.from(counts.entries())
+			.map(([compositeKey, { count, serverDisplayName }]) => ({
+				compositeKey,
+				toolLabel: String(compositeKey).split('.').slice(1).join('.'),
+				count,
+				serverDisplayName
+			}))
+			.sort((a, b) => b.count - a.count);
+	}
 
 	let monthlyActiveUsers = $derived(
 		usersData.filter(
@@ -49,11 +85,15 @@
 
 	let deployedCatalogEntryServers = $state<MCPCatalogServer[]>([]);
 	let deployedWorkspaceCatalogEntryServers = $state<MCPCatalogServer[]>([]);
-	let serversData = $derived([
-		...deployedCatalogEntryServers.filter((server) => !server.deleted),
-		...deployedWorkspaceCatalogEntryServers.filter((server) => !server.deleted),
-		...mcpServersAndEntries.current.servers.filter((server) => !server.deleted)
-	]);
+	let serversData = $derived(
+		mcpServersAndEntries.current.loading || loading
+			? []
+			: [
+					...deployedCatalogEntryServers.filter((server) => !server.deleted),
+					...deployedWorkspaceCatalogEntryServers.filter((server) => !server.deleted),
+					...mcpServersAndEntries.current.servers.filter((server) => !server.deleted)
+				]
+	);
 
 	function compileServerAndEntries(data: MCPCatalogServer[], entries: MCPCatalogEntry[]) {
 		const entriesMap = new Map(entries.map((e) => [e.id, e]));
@@ -92,12 +132,11 @@
 			(a, b) => b.count - a.count
 		);
 
-		const entrieTypes = Object.values(catalogEntriesCount).reduce(
-			(acc, info) => {
-				if (info.server) acc.multi++;
-				if (!info.entry) return acc;
-				if (info.entry.manifest.runtime === 'composite') acc.composite++;
-				else if (info.entry.manifest.runtime === 'remote') acc.remote++;
+		const entrieTypes = data.reduce(
+			(acc, server) => {
+				if (!server.catalogEntryID) acc.multi++;
+				else if (server.manifest.runtime === 'composite') acc.composite++;
+				else if (server.manifest.runtime === 'remote') acc.remote++;
 				else acc.single++;
 				return acc;
 			},
@@ -146,6 +185,23 @@
 		deployedWorkspaceCatalogEntryServers =
 			await AdminService.listAllWorkspaceDeployedSingleRemoteServers();
 		loading = false;
+
+		const endToolStats = set(new Date(), { milliseconds: 0, seconds: 59 });
+		const startToolStats = subDays(endToolStats, 7);
+		AdminService.listAuditLogUsageStats({
+			start_time: startToolStats.toISOString(),
+			end_time: endToolStats.toISOString()
+		})
+			.then((stats) => {
+				topToolCalls = topToolCallsFromStats(stats).slice(0, TOP_TOOLS_LIMIT);
+			})
+			.catch((error) => {
+				if (error?.name === 'AbortError') return;
+				errors.append(error);
+			})
+			.finally(() => {
+				loadingToolUsage = false;
+			});
 
 		const timeRange = { start, end };
 		AdminService.listTokenUsage(timeRange)
@@ -223,7 +279,6 @@
 					: (aggregateTimelineDataByBucket(timeline, start, end) as TokenUsageWithCategory[]);
 		});
 	});
-
 </script>
 
 <Layout title="Dashboard" classes={{ childrenContainer: 'max-w-none', container: '' }}>
@@ -355,49 +410,64 @@
 				</div>
 			{/if}
 
-			<div class="grid grid-cols-12 gap-4">
-				<div class="paper gap-1 md:col-span-6 col-span-12">
-					<h4 class="flex items-center gap-2 font-semibold">Most Popular Tools</h4>
-					<ul class="pt-2 flex flex-col gap-2">
-						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-						<li class="flex gap-2 items-center">
-							<Wrench class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Tool Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-					</ul>
+			<div class="grid grid-cols-12 gap-4 grow">
+				<div class="paper h-full gap-1 md:col-span-6 col-span-12 flex flex-col">
+					<h4 class="flex items-center gap-2 font-semibold">
+						Recently Popular Tools
+						<span class="text-on-surface1 text-xs font-light flex items-center gap-1">
+							(Last 7 Days)
+							{#if loadingToolUsage}
+								<Loading class="size-3" />
+							{/if}
+						</span>
+					</h4>
+					{#if loadingToolUsage}
+						<div class="pt-2 flex flex-col gap-4 w-full">
+							{#each Array.from({ length: TOP_TOOLS_LIMIT }) as _, i (i)}
+								<div class="flex gap-2 items-center animate-pulse w-full">
+									<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
+									<div class="flex flex-col gap-2 flex-1">
+										<div class="h-4 w-full rounded bg-surface3"></div>
+										<div class="h-3 w-full rounded bg-surface3"></div>
+									</div>
+								</div>
+							{/each}
+						</div>
+					{:else if topToolCalls.length === 0}
+						<p class="text-xs text-on-surface1 pt-2">No tool calls in the last 7 days.</p>
+					{:else}
+						<ul class="pt-2 flex flex-col gap-2">
+							{#each topToolCalls as row (row.compositeKey)}
+								<li class="flex gap-2 items-center">
+									<div
+										class="size-8 items-center justify-center shrink-0 bg-surface1 rounded-md p-1"
+									>
+										<Wrench class="size-6 opacity-65 shrink-0" />
+									</div>
+									<div class="flex flex-col gap-1 min-w-0">
+										<p class="text-sm font-medium truncate">{row.toolLabel || row.compositeKey}</p>
+										<p class="text-xs text-on-surface1">
+											{formatNumber(row.count)} calls · {row.serverDisplayName}
+										</p>
+									</div>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+					<div class="flex grow min-h-0"></div>
+					<a
+						href={resolve('/admin/usage')}
+						class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
+					>
+						See All <ChevronRight class="size-3" />
+					</a>
 				</div>
-				<div class="paper gap-1 md:col-span-6 col-span-12">
-					<h4 class="flex items-center gap-2 font-semibold">Most Popular Skills</h4>
+				<div class="paper h-full gap-1 md:col-span-6 col-span-12">
+					<h4 class="flex items-center gap-2 font-semibold">
+						Recently Popular Skills <span class="text-on-surface1 text-xs font-light">
+							(Last 7 Days)
+						</span>
+					</h4>
 					<ul class="pt-2 flex flex-col gap-2">
 						<li class="flex gap-2 items-center">
 							<PencilRuler class="size-8 opacity-65" />
@@ -440,8 +510,21 @@
 		</div>
 		<div class="md:col-span-4 col-span-12 flex flex-col gap-4">
 			{#if serverAndEntries.loading}
-				<div class="bg-surface3 h-[380px] animate-pulse rounded-md"></div>
-				<div class="bg-surface3 h-[380px] animate-pulse rounded-md"></div>
+				<div class="bg-surface3 h-[530px] animate-pulse rounded-md"></div>
+				<div class="paper gap-1 flex grow">
+					<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>
+					<div class="pt-2 flex flex-col gap-4">
+						{#each Array.from({ length: 5 }) as _, i (i)}
+							<div class="flex gap-2 items-center animate-pulse w-full">
+								<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
+								<div class="flex flex-col gap-2 flex-1">
+									<div class="h-4 w-full rounded bg-surface3"></div>
+									<div class="h-3 w-full rounded bg-surface3"></div>
+								</div>
+							</div>
+						{/each}
+					</div>
+				</div>
 			{:else}
 				<div in:fade={{ duration: 150 }} class="paper">
 					<h4 class="font-semibold">Active Servers</h4>
@@ -450,10 +533,7 @@
 						<div class="text-xs">Total Currently Active</div>
 						<div class="flex w-full gap-2 items-center justify-center">
 							<div class="text-3xl font-semibold">
-								<TweenedMetric
-									holdAtZero={serverAndEntries.loading}
-									target={totalServers}
-								/>
+								<TweenedMetric holdAtZero={serverAndEntries.loading} target={totalServers} />
 							</div>
 							<Server class="size-8 text-primary" />
 						</div>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -24,7 +24,7 @@
 		type OrgUser,
 		type TotalTokenUsage
 	} from '$lib/services';
-	import { errors, mcpServersAndEntries } from '$lib/stores';
+	import { errors, mcpServersAndEntries, profile } from '$lib/stores';
 	import { goto } from '$lib/url';
 	import { isWithinInterval, set, subMonths } from 'date-fns';
 	import { Activity, ChevronRight, Coins, Plus, Server, Users, Wrench } from 'lucide-svelte';
@@ -188,6 +188,7 @@
 	const { graphData, popularServers, totalServers } = $derived(
 		compileServerAndEntries(serversData, serverAndEntries.entries)
 	);
+	let isBootStrapUser = $derived(profile.current.isBootstrapUser?.() ?? false);
 
 	onMount(async () => {
 		const endToolStats = set(new Date(), { milliseconds: 0, seconds: 59 });
@@ -250,7 +251,7 @@
 			<!-- this token usage graph-->
 			<div class="grid grid-cols-12 gap-4">
 				<div class="col-span-12 @min-[768px]:col-span-4">
-					<div class="paper gap-2">
+					<div class="paper gap-2 h-full">
 						<div class="text-xs text-on-surface1 flex items-center gap-1">
 							Total Users
 							{#if loading}
@@ -263,16 +264,18 @@
 							</div>
 							<Users class="size-8 text-primary" />
 						</div>
-						<a
-							href={resolve('/admin/users')}
-							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-						>
-							See More <ChevronRight class="size-3" />
-						</a>
+						{#if !isBootStrapUser}
+							<a
+								href={resolve('/admin/users')}
+								class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+							>
+								See More <ChevronRight class="size-3" />
+							</a>
+						{/if}
 					</div>
 				</div>
 				<div class="col-span-12 @min-[768px]:col-span-4">
-					<div class="paper gap-2">
+					<div class="paper gap-2 h-full">
 						<div class="text-xs text-on-surface1 flex items-center gap-1">
 							Monthly Active Users
 							{#if loading}
@@ -289,7 +292,7 @@
 					</div>
 				</div>
 				<div class="col-span-12 @min-[768px]:col-span-4">
-					<div class="paper gap-2">
+					<div class="paper gap-2 h-full">
 						<div class="text-xs text-on-surface1 flex items-center gap-1">
 							Total Tokens
 							{#if loading}
@@ -306,12 +309,14 @@
 							</div>
 							<Coins class="size-8 text-primary" />
 						</div>
-						<a
-							href={resolve('/admin/token-usage')}
-							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-						>
-							See More <ChevronRight class="size-3" />
-						</a>
+						{#if !isBootStrapUser}
+							<a
+								href={resolve('/admin/token-usage')}
+								class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+							>
+								See More <ChevronRight class="size-3" />
+							</a>
+						{/if}
 					</div>
 				</div>
 			</div>
@@ -391,7 +396,7 @@
 						</ul>
 					{/if}
 					<div class="flex grow min-h-0"></div>
-					{#if topToolCalls.length > 0}
+					{#if topToolCalls.length > 0 && !isBootStrapUser}
 						<a
 							href={resolve('/admin/usage')}
 							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
@@ -444,7 +449,7 @@
 						</div>
 					{/if}
 					<div class="flex grow min-h-0"></div>
-					{#if avgToolCallResponseTime.length > 0}
+					{#if avgToolCallResponseTime.length > 0 && !isBootStrapUser}
 						<a
 							href={resolve('/admin/usage')}
 							class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
@@ -474,7 +479,7 @@
 				</div>
 			{:else}
 				<div in:fade={{ duration: 150 }} class="paper min-h-96">
-					{#if deployedCatalogEntryServers.length > 0 || deployedWorkspaceCatalogEntryServers.length > 0}
+					{#if deployedCatalogEntryServers.length > 0 || deployedWorkspaceCatalogEntryServers.length > 0 || isBootStrapUser}
 						<h4 class="font-semibold">Active Servers</h4>
 						<div class="mb-2 flex flex-col justify-center items-center gap-2">
 							<div class="flex w-full gap-2 items-center justify-center">
@@ -498,14 +503,16 @@
 							{/if}
 						</div>
 
-						<div class="flex justify-end">
-							<a
-								href={resolve('/admin/mcp-servers?view=deployments')}
-								class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
-							>
-								See All <ChevronRight class="size-3" />
-							</a>
-						</div>
+						{#if !isBootStrapUser}
+							<div class="flex justify-end">
+								<a
+									href={resolve('/admin/mcp-servers?view=deployments')}
+									class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+								>
+									See More <ChevronRight class="size-3" />
+								</a>
+							</div>
+						{/if}
 					{:else}
 						<div class="grow flex flex-col items-center justify-center gap-4">
 							<div>
@@ -613,12 +620,12 @@
 						</p>
 					{/if}
 					<div class="flex grow"></div>
-					{#if popularServers.length > 0}
+					{#if popularServers.length > 0 && !isBootStrapUser}
 						<a
 							href={resolve('/admin/mcp-servers')}
 							class="justify-end self-end text-[11px] translate-x-2 transition-colors duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
 						>
-							See All <ChevronRight class="size-3" />
+							See More <ChevronRight class="size-3" />
 						</a>
 					{/if}
 				</div>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -487,3 +487,7 @@
 		</div>
 	</div>
 </Layout>
+
+<svelte:head>
+	<title>Obot | Dashboard</title>
+</svelte:head>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -20,8 +20,8 @@
 	} from '$lib/services';
 	import { errors, mcpServersAndEntries } from '$lib/stores';
 	import { aggregateTimelineDataByBucket, getUserLabels } from '../token-usage/utils';
-	import { isWithinInterval, set, subDays, subMonths } from 'date-fns';
-	import { Activity, ChevronRight, Coins, PencilRuler, Server, Users, Wrench } from 'lucide-svelte';
+	import { isWithinInterval, set, subMonths } from 'date-fns';
+	import { Activity, ChevronRight, Coins, Server, Users, Wrench } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -53,6 +53,10 @@
 
 	let topToolCalls = $state<TopToolCallRow[]>([]);
 
+	type TopServerUsageRow = { serverName: string; count: number };
+
+	let topServerUsage = $state<TopServerUsageRow[]>([]);
+
 	function topToolCallsFromStats(stats: AuditLogUsageStats | undefined): TopToolCallRow[] {
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
 		const counts = new Map<string, { count: number; serverDisplayName: string }>();
@@ -74,6 +78,20 @@
 				count,
 				serverDisplayName
 			}))
+			.sort((a, b) => b.count - a.count);
+	}
+
+	function topServersFromStats(stats: AuditLogUsageStats | undefined): TopServerUsageRow[] {
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const counts = new Map<string, number>();
+		for (const s of stats?.items.filter((s) => !s.mcpServerDisplayName.startsWith('nba1')) ?? []) {
+			const total = (s.toolCalls ?? []).reduce((sum, t) => sum + t.callCount, 0);
+			if (total > 0) {
+				counts.set(s.mcpServerDisplayName, (counts.get(s.mcpServerDisplayName) ?? 0) + total);
+			}
+		}
+		return Array.from(counts.entries())
+			.map(([serverName, count]) => ({ serverName, count }))
 			.sort((a, b) => b.count - a.count);
 	}
 
@@ -187,13 +205,14 @@
 		loading = false;
 
 		const endToolStats = set(new Date(), { milliseconds: 0, seconds: 59 });
-		const startToolStats = subDays(endToolStats, 7);
+		const startToolStats = subMonths(endToolStats, 1);
 		AdminService.listAuditLogUsageStats({
 			start_time: startToolStats.toISOString(),
 			end_time: endToolStats.toISOString()
 		})
 			.then((stats) => {
 				topToolCalls = topToolCallsFromStats(stats).slice(0, TOP_TOOLS_LIMIT);
+				topServerUsage = topServersFromStats(stats).slice(0, TOP_TOOLS_LIMIT);
 			})
 			.catch((error) => {
 				if (error?.name === 'AbortError') return;
@@ -412,14 +431,9 @@
 
 			<div class="grid grid-cols-12 gap-4 grow">
 				<div class="paper h-full gap-1 md:col-span-6 col-span-12 flex flex-col">
-					<h4 class="flex items-center gap-2 font-semibold">
+					<h4 class="flex items-center gap-2 font-semibold mb-1">
 						Recently Popular Tools
-						<span class="text-on-surface1 text-xs font-light flex items-center gap-1">
-							(Last 7 Days)
-							{#if loadingToolUsage}
-								<Loading class="size-3" />
-							{/if}
-						</span>
+						<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
 					</h4>
 					{#if loadingToolUsage}
 						<div class="pt-2 flex flex-col gap-4 w-full">
@@ -462,49 +476,49 @@
 						See All <ChevronRight class="size-3" />
 					</a>
 				</div>
-				<div class="paper h-full gap-1 md:col-span-6 col-span-12">
-					<h4 class="flex items-center gap-2 font-semibold">
-						Recently Popular Skills <span class="text-on-surface1 text-xs font-light">
-							(Last 7 Days)
-						</span>
+				<div class="paper h-full gap-1 md:col-span-6 col-span-12 flex flex-col">
+					<h4 class="flex items-center gap-2 font-semibold mb-1">
+						Frequently Used Servers
+						<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
 					</h4>
-					<ul class="pt-2 flex flex-col gap-2">
-						<li class="flex gap-2 items-center">
-							<PencilRuler class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Skill Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-						<li class="flex gap-2 items-center">
-							<PencilRuler class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Skill Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-						<li class="flex gap-2 items-center">
-							<PencilRuler class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Skill Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-						<li class="flex gap-2 items-center">
-							<PencilRuler class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Skill Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-						<li class="flex gap-2 items-center">
-							<Server class="size-8 opacity-65" />
-							<div class="flex flex-col gap-1">
-								<p class="text-sm font-medium">Server Name</p>
-								<p class="text-xs text-on-surface1">100 calls</p>
-							</div>
-						</li>
-					</ul>
+					{#if loadingToolUsage}
+						<div class="pt-2 flex flex-col gap-4 w-full">
+							{#each Array.from({ length: TOP_TOOLS_LIMIT }) as _, i (i)}
+								<div class="flex gap-2 items-center animate-pulse w-full">
+									<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
+									<div class="flex flex-col gap-2 flex-1">
+										<div class="h-4 w-full rounded bg-surface3"></div>
+										<div class="h-3 w-full rounded bg-surface3"></div>
+									</div>
+								</div>
+							{/each}
+						</div>
+					{:else if topServerUsage.length === 0}
+						<p class="text-xs text-on-surface1 pt-2">No server tool calls in the last 7 days.</p>
+					{:else}
+						<ul class="pt-2 flex flex-col gap-2">
+							{#each topServerUsage as row (row.serverName)}
+								<li class="flex gap-2 items-center">
+									<div
+										class="size-8 items-center justify-center shrink-0 bg-surface1 rounded-md p-1 flex"
+									>
+										<Server class="size-6 opacity-65 shrink-0" />
+									</div>
+									<div class="flex flex-col gap-1 min-w-0">
+										<p class="text-sm font-medium truncate">{row.serverName}</p>
+										<p class="text-xs text-on-surface1">{formatNumber(row.count)} calls</p>
+									</div>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+					<div class="flex grow min-h-0"></div>
+					<a
+						href={resolve('/admin/usage')}
+						class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
+					>
+						See All <ChevronRight class="size-3" />
+					</a>
 				</div>
 			</div>
 		</div>
@@ -553,46 +567,60 @@
 					</div>
 				</div>
 				<div in:fade={{ duration: 150 }} class="paper gap-1 flex grow">
-					<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>
-					<div class="pt-2 flex flex-col gap-2">
-						{#each popularServers as info (info.id)}
-							{@const icon =
-								'server' in info ? info.server?.manifest.icon : info.entry?.manifest.icon}
-							{@const displayName =
-								'server' in info
-									? (info.server?.alias ?? info.server?.manifest.name)
-									: info.entry?.manifest.name}
-							{@const description =
-								'server' in info
-									? info.server?.manifest.description
-									: info.entry?.manifest.description}
-							{@const url = info.server
-								? getServerUrl(info.server)
-								: info.entry
-									? getEntryUrl(info.entry)
-									: undefined}
-							<a
-								class="flex gap-2 items-center hover:bg-surface1 -mx-2 px-2 py-1 rounded-md"
-								href={url ? resolve(url as `/${string}`) : undefined}
-							>
-								{#if icon}
-									<img src={icon} alt={info.id} class="size-9 bg-surface1 rounded-md p-1" />
-								{:else}
-									<Server class="size-9 opacity-65 bg-surface1 rounded-md p-1" />
-								{/if}
-								<div class="flex flex-col gap-0.5 max-w-[calc(100%-4.5rem)]">
-									<p class="text-sm font-medium">{displayName}</p>
-									{#if description}
-										<p class="text-xs truncate line-clamp-1 break-all font-light">
-											{@html stripMarkdownToText(description ?? '')}
-										</p>
-									{/if}
-									<p class="text-xs text-on-surface1 italic">Deployed {info.count} times</p>
+					<h4 class="flex items-center gap-2 font-semibold">Most Deployed Servers</h4>
+					{#if mcpServersAndEntries.current.loading || loading}
+						<div class="pt-2 flex flex-col gap-4">
+							{#each Array.from({ length: 5 }) as _, i (i)}
+								<div class="flex gap-2 items-center animate-pulse w-full">
+									<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
+									<div class="flex flex-col gap-2 flex-1">
+										<div class="h-4 w-full rounded bg-surface3"></div>
+										<div class="h-3 w-full rounded bg-surface3"></div>
+									</div>
 								</div>
-								<ChevronRight class="size-5 shrink-0" />
-							</a>
-						{/each}
-					</div>
+							{/each}
+						</div>
+					{:else}
+						<div class="pt-2 flex flex-col gap-2">
+							{#each popularServers as info (info.id)}
+								{@const icon =
+									'server' in info ? info.server?.manifest.icon : info.entry?.manifest.icon}
+								{@const displayName =
+									'server' in info
+										? (info.server?.alias ?? info.server?.manifest.name)
+										: info.entry?.manifest.name}
+								{@const description =
+									'server' in info
+										? info.server?.manifest.description
+										: info.entry?.manifest.description}
+								{@const url = info.server
+									? getServerUrl(info.server)
+									: info.entry
+										? getEntryUrl(info.entry)
+										: undefined}
+								<a
+									class="flex gap-2 items-center hover:bg-surface1 -mx-2 px-2 py-1 rounded-md"
+									href={url ? resolve(url as `/${string}`) : undefined}
+								>
+									{#if icon}
+										<img src={icon} alt={info.id} class="size-9 bg-surface1 rounded-md p-1" />
+									{:else}
+										<Server class="size-9 opacity-65 bg-surface1 rounded-md p-1" />
+									{/if}
+									<div class="flex flex-col gap-0.5 max-w-[calc(100%-4.5rem)]">
+										<p class="text-sm font-medium">{displayName}</p>
+										{#if description}
+											<p class="text-xs truncate line-clamp-1 break-all font-light">
+												{@html stripMarkdownToText(description ?? '')}
+											</p>
+										{/if}
+										<p class="text-xs text-on-surface1 italic">Deployed {info.count} times</p>
+									</div>
+									<ChevronRight class="size-5 shrink-0" />
+								</a>
+							{/each}
+						</div>
+					{/if}
 					<div class="flex grow"></div>
 					<a
 						href={resolve('/admin/mcp-servers')}

--- a/ui/user/src/routes/admin/mcp-servers/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/+page.svelte
@@ -5,6 +5,7 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import Search from '$lib/components/Search.svelte';
 	import McpServerEntryForm from '$lib/components/admin/McpServerEntryForm.svelte';
+	import McpServerGitSync from '$lib/components/admin/McpServerGitSync.svelte';
 	import ConnectorsView from '$lib/components/mcp/ConnectorsView.svelte';
 	import DeploymentsView from '$lib/components/mcp/DeploymentsView.svelte';
 	import SelectServerType from '$lib/components/mcp/SelectServerType.svelte';
@@ -25,7 +26,7 @@
 		replaceState
 	} from '$lib/url';
 	import SourceUrlsView from './SourceUrlsView.svelte';
-	import { AlertTriangle, Info, LoaderCircle, Plus, RefreshCcw, Server, X } from 'lucide-svelte';
+	import { Info, LoaderCircle, Plus, RefreshCcw, Server } from 'lucide-svelte';
 	import { onDestroy, onMount } from 'svelte';
 	import { fade, fly, slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -80,16 +81,13 @@
 	let usersMap = $derived(new Map(users.map((user) => [user.id, user])));
 
 	let defaultCatalog = $state<MCPCatalog>();
-	let editingSource = $state<{ index: number; value: string }>();
-	let sourceDialog = $state<HTMLDialogElement>();
+	let sourceDialog = $state<ReturnType<typeof McpServerGitSync>>();
 	let selectServerTypeDialog = $state<ReturnType<typeof SelectServerType>>();
 
 	let selectedServerType = $derived(page.url.searchParams.get('new') as LaunchServerType);
 	let showServerForm = $derived(page.url.searchParams.has('new'));
 
-	let saving = $state(false);
 	let syncing = $state(false);
-	let sourceError = $state<string>();
 	let syncInterval = $state<ReturnType<typeof setInterval>>();
 
 	let isAdminReadonly = $derived(profile.current.isAdminReadonly?.());
@@ -102,12 +100,6 @@
 		if (updateUrl) {
 			goto(resolve(`/admin/mcp-servers?new=${type}`));
 		}
-	}
-
-	function closeSourceDialog() {
-		editingSource = undefined;
-		sourceError = undefined;
-		sourceDialog?.close();
 	}
 
 	function pollTillSyncComplete() {
@@ -367,11 +359,7 @@
 		<button
 			class="menu-button"
 			onclick={() => {
-				editingSource = {
-					index: -1,
-					value: ''
-				};
-				sourceDialog?.showModal();
+				sourceDialog?.open();
 			}}
 		>
 			Add server(s) from Git
@@ -379,89 +367,7 @@
 	</DotDotDot>
 {/snippet}
 
-<dialog bind:this={sourceDialog} class="dialog">
-	<div class="dialog-container w-full max-w-md p-4">
-		{#if editingSource}
-			<h3 class="dialog-title">
-				{editingSource.index === -1 ? 'Add Source URL' : 'Edit Source URL'}
-				<button onclick={() => closeSourceDialog()} class="icon-button dialog-close-btn">
-					<X class="size-5" />
-				</button>
-			</h3>
-
-			<div class="my-4 flex flex-col gap-1">
-				<label for="catalog-source-name" class="flex-1 text-sm font-light capitalize"
-					>Source URL
-				</label>
-				<input
-					id="catalog-source-name"
-					bind:value={editingSource.value}
-					class="text-input-filled"
-				/>
-			</div>
-
-			{#if sourceError}
-				<div class="mb-4 flex flex-col gap-2 text-red-500 dark:text-red-400">
-					<div class="flex items-center gap-2">
-						<AlertTriangle class="size-6 flex-shrink-0 self-start" />
-						<p class="my-0.5 flex flex-col text-sm font-semibold">Error adding source URL:</p>
-					</div>
-					<span class="font-sm font-light break-all">{sourceError}</span>
-				</div>
-			{/if}
-
-			<div class="flex w-full justify-end gap-2">
-				<button class="button" disabled={saving} onclick={() => closeSourceDialog()}>Cancel</button>
-				<button
-					class="button-primary"
-					disabled={saving}
-					onclick={async () => {
-						if (!editingSource || !defaultCatalog) {
-							return;
-						}
-
-						saving = true;
-						sourceError = undefined;
-
-						try {
-							const updatingCatalog = { ...defaultCatalog };
-
-							if (editingSource.index === -1) {
-								updatingCatalog.sourceURLs = [
-									...(updatingCatalog.sourceURLs ?? []),
-									editingSource.value
-								];
-							} else {
-								updatingCatalog.sourceURLs[editingSource.index] = editingSource.value;
-							}
-
-							const response = await AdminService.updateMCPCatalog(
-								defaultCatalogId,
-								updatingCatalog,
-								{
-									dontLogErrors: true
-								}
-							);
-							defaultCatalog = response;
-							await sync();
-							closeSourceDialog();
-						} catch (error) {
-							sourceError = error instanceof Error ? error.message : 'An unexpected error occurred';
-						} finally {
-							saving = false;
-						}
-					}}
-				>
-					Add
-				</button>
-			</div>
-		{/if}
-	</div>
-	<form class="dialog-backdrop">
-		<button type="button" onclick={() => sourceDialog?.close()}>close</button>
-	</form>
-</dialog>
-
+<McpServerGitSync bind:this={sourceDialog} {defaultCatalog} onSync={sync} />
 <SelectServerType bind:this={selectServerTypeDialog} onSelectServerType={selectServerType} />
 
 <svelte:head>

--- a/ui/user/src/routes/admin/token-usage/+page.svelte
+++ b/ui/user/src/routes/admin/token-usage/+page.svelte
@@ -13,7 +13,8 @@
 		type Model,
 		type OrgUser,
 		type TokenUsage,
-		type TotalTokenUsage
+		type TotalTokenUsage,
+		type TokenUsageWithCategory
 	} from '$lib/services';
 	import { errors } from '$lib/stores';
 	import { goto } from '$lib/url';
@@ -165,8 +166,6 @@
 	const targetModelToDisplayName = $derived(
 		new Map(modelsData.map((m) => [m.targetModel, m.displayName || m.name]))
 	);
-
-	type TokenUsageWithCategory = TokenUsage & { category: string };
 
 	function toTimelineItem(r: TokenUsage, category: string): TokenUsageWithCategory {
 		return {
@@ -751,7 +750,7 @@
 								<div class="flex flex-col gap-0 text-xs">
 									<div class="text-sm font-light">{item.key}</div>
 									<div class="text-on-surface1">{item.date}</div>
-									<div class="divider"></div>
+									<div class="tooltip-divider"></div>
 								</div>
 								<div class="flex flex-col gap-1">
 									<div class="text-on-background flex flex-col">
@@ -867,7 +866,7 @@
 															{item.hoveredPart === 'primary' ? 'Input tokens' : 'Output tokens'}
 														</div>
 														<div class="text-on-surface1">{item.date}</div>
-														<div class="divider"></div>
+														<div class="tooltip-divider"></div>
 													</div>
 													<div class="flex flex-col gap-1">
 														<div class="text-on-background flex flex-col">
@@ -930,13 +929,5 @@
 		background-color: var(--color-surface3);
 		margin-left: 1rem;
 		margin-right: 1rem;
-	}
-
-	.divider {
-		height: 1px;
-		width: 100%;
-		background-color: var(--color-surface3);
-		margin-top: 0.5rem;
-		margin-bottom: 0.5rem;
 	}
 </style>

--- a/ui/user/src/routes/keys/CreateApiKeyForm.svelte
+++ b/ui/user/src/routes/keys/CreateApiKeyForm.svelte
@@ -210,7 +210,7 @@
 								<p class="truncate text-sm">{getServerDisplayName(server)}</p>
 								{#if server.manifest.description}
 									<span class="text-on-surface1 line-clamp-1 text-xs">
-										{@html stripMarkdownToText(server.manifest.description)}
+										{stripMarkdownToText(server.manifest.description)}
 									</span>
 								{/if}
 							</div>


### PR DESCRIPTION
Addresses #5783 

<img width="1728" height="937" alt="Screenshot 2026-04-20 at 1 21 03 PM" src="https://github.com/user-attachments/assets/18830615-e30d-4802-8b7d-c2f638cdd02f" />

- [x] Get feedback (is what's in there good/valuable?) -- edit: Changed the middle graph to be of top server usage, if Obot Agent comes to forefront, token usage may be valuable but currently it is not the case.
- [x] Responsive better when browser resizing & sidebar is open
- [x] slightly better empty states
<img width="1695" height="925" alt="Screenshot 2026-04-17 at 6 46 50 PM" src="https://github.com/user-attachments/assets/699dc218-7f37-4924-8668-c6ee939bffb6" />

- [x] Filter nanobot related calls/servers?
- [x] Change route redirect for admin (/admin/mcp-servers -> admin/dashboard)
- [x] Update flow/disable states if bootstrap user