### PR TITLE
fix: ensure webhook credential is available before update

### DIFF
--- a/pkg/api/handlers/mcpwebhookvalidation.go
+++ b/pkg/api/handlers/mcpwebhookvalidation.go
@@ -131,16 +131,7 @@ func (m *MCPWebhookValidationHandler) Update(req api.Context) error {
 
 	validation.Spec.Manifest = manifest
 
-	if err := req.Update(&validation); err != nil {
-		return fmt.Errorf("failed to update mcp webhook validation: %w", err)
-	}
-
 	if secretCred != nil {
-		// The only way to update a credential is to delete it and recreate it.
-		if err := req.GPTClient.DeleteCredential(req.Context(), system.MCPWebhookValidationCredentialContext, validation.Name); err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
-			return fmt.Errorf("failed to delete credential: %w", err)
-		}
-
 		if err := req.GPTClient.CreateCredential(req.Context(), gptscript.Credential{
 			Context:  system.MCPWebhookValidationCredentialContext,
 			ToolName: validation.Name,
@@ -156,6 +147,10 @@ func (m *MCPWebhookValidationHandler) Update(req api.Context) error {
 		}
 
 		secretCred = cred.Env
+	}
+
+	if err := req.Update(&validation); err != nil {
+		return fmt.Errorf("failed to update mcp webhook validation: %w", err)
 	}
 
 	return req.Write(convertMCPWebhookValidation(validation, secretCred != nil))


### PR DESCRIPTION
Before this change, the webhook validation was being saved before the credential was updated. The controller to setup the system MCP server could run before the credential was available.

This change ensures the credential is created or updated before the webhook is updated.

Issue: https://github.com/obot-platform/obot/issues/6369