### PR TITLE
Add user-configurable MCP startup timeouts

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -167,6 +167,8 @@ type MCPServerCatalogEntryManifest struct {
 
 	Env []MCPEnv `json:"env,omitempty"`
 
+	// StartupTimeout configures the timeout to start and connect to an MCP Server. When unset, it defaults to 60s.
+	// The maximum allowed value is 600s (10 minutes). Attempting to set a higher value will cause an error.
 	StartupTimeoutSeconds int `json:"startupTimeoutSeconds,omitempty"`
 }
 
@@ -411,14 +413,14 @@ func (e RuntimeValidationError) Error() string {
 func MapCatalogEntryToServer(catalogEntry MCPServerCatalogEntryManifest, userURL string, disableHostnameValidation bool) (MCPServerManifest, error) {
 	serverManifest := MCPServerManifest{
 		// Copy common fields
-		Metadata:         catalogEntry.Metadata,
-		Name:             catalogEntry.Name,
-		ShortDescription: catalogEntry.ShortDescription,
-		Description:      catalogEntry.Description,
-		Icon:             catalogEntry.Icon,
-		ToolPreview:      catalogEntry.ToolPreview,
-		Runtime:          catalogEntry.Runtime,
-		Env:              catalogEntry.Env,
+		Metadata:              catalogEntry.Metadata,
+		Name:                  catalogEntry.Name,
+		ShortDescription:      catalogEntry.ShortDescription,
+		Description:           catalogEntry.Description,
+		Icon:                  catalogEntry.Icon,
+		ToolPreview:           catalogEntry.ToolPreview,
+		Runtime:               catalogEntry.Runtime,
+		Env:                   catalogEntry.Env,
 		StartupTimeoutSeconds: catalogEntry.StartupTimeoutSeconds,
 	}
 

--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -166,6 +166,8 @@ type MCPServerCatalogEntryManifest struct {
 	MultiUserConfig *MultiUserConfig `json:"multiUserConfig,omitempty"`
 
 	Env []MCPEnv `json:"env,omitempty"`
+
+	StartupTimeoutSeconds int `json:"startupTimeoutSeconds,omitempty"`
 }
 
 // ToolOverride defines how a single component tool is exposed by the composite server
@@ -245,6 +247,7 @@ type MCPServerManifest struct {
 	Headers []MCPHeader `json:"headers,omitempty"`
 
 	IdleShutdownIntervalHours int `json:"idleShutdownIntervalHours,omitempty"`
+	StartupTimeoutSeconds     int `json:"startupTimeoutSeconds,omitempty"`
 }
 
 type MCPServer struct {
@@ -416,6 +419,7 @@ func MapCatalogEntryToServer(catalogEntry MCPServerCatalogEntryManifest, userURL
 		ToolPreview:      catalogEntry.ToolPreview,
 		Runtime:          catalogEntry.Runtime,
 		Env:              catalogEntry.Env,
+		StartupTimeoutSeconds: catalogEntry.StartupTimeoutSeconds,
 	}
 
 	// Handle runtime-specific mapping

--- a/apiclient/types/systemmcpserver.go
+++ b/apiclient/types/systemmcpserver.go
@@ -20,6 +20,8 @@ type SystemMCPServerManifest struct {
 	RemoteConfig        *RemoteRuntimeConfig        `json:"remoteConfig,omitempty"`
 
 	Env []MCPEnv `json:"env,omitempty"`
+
+	StartupTimeoutSeconds int `json:"startupTimeoutSeconds,omitempty"`
 }
 
 type SystemMCPServer struct {

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2429,15 +2429,6 @@ func toolsForServer(ctx context.Context, mcpSessionManager *mcp.SessionManager, 
 	return mcp.ConvertTools(gTools, allowedTools, server.Spec.UnsupportedTools)
 }
 
-// contextWithDefaultTimeout adds a context timeout when one does not already exist
-func contextWithDefaultTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	if _, ok := ctx.Deadline(); ok {
-		return ctx, func() {}
-	}
-
-	return context.WithTimeout(ctx, timeout)
-}
-
 func (m *MCPHandler) removeMCPServer(ctx context.Context, mcpServer v1.MCPServer) error {
 	if err := m.mcpSessionManager.ShutdownServer(ctx, mcpServer.Name); err != nil {
 		return fmt.Errorf("failed to shutdown server: %w", err)

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2413,10 +2413,7 @@ func (m *MCPHandler) revealCompositeServer(req api.Context, compositeServer v1.M
 }
 
 func toolsForServer(ctx context.Context, mcpSessionManager *mcp.SessionManager, server v1.MCPServer, serverConfig mcp.ServerConfig, allowedTools []string) ([]types.MCPServerTool, error) {
-	listCtx, cancel := contextWithDefaultTimeout(ctx, time.Minute)
-	defer cancel()
-
-	gTools, err := mcpSessionManager.ListTools(listCtx, serverConfig)
+	gTools, err := mcpSessionManager.ListTools(ctx, serverConfig)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, nil

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2413,7 +2413,10 @@ func (m *MCPHandler) revealCompositeServer(req api.Context, compositeServer v1.M
 }
 
 func toolsForServer(ctx context.Context, mcpSessionManager *mcp.SessionManager, server v1.MCPServer, serverConfig mcp.ServerConfig, allowedTools []string) ([]types.MCPServerTool, error) {
-	gTools, err := mcpSessionManager.ListTools(ctx, serverConfig)
+	listCtx, cancel := contextWithDefaultTimeout(ctx, time.Minute)
+	defer cancel()
+
+	gTools, err := mcpSessionManager.ListTools(listCtx, serverConfig)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, nil
@@ -2427,6 +2430,15 @@ func toolsForServer(ctx context.Context, mcpSessionManager *mcp.SessionManager, 
 	}
 
 	return mcp.ConvertTools(gTools, allowedTools, server.Spec.UnsupportedTools)
+}
+
+// contextWithDefaultTimeout adds a context timeout when one does not already exist
+func contextWithDefaultTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, timeout)
 }
 
 func (m *MCPHandler) removeMCPServer(ctx context.Context, mcpServer v1.MCPServer) error {

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2413,9 +2413,6 @@ func (m *MCPHandler) revealCompositeServer(req api.Context, compositeServer v1.M
 }
 
 func toolsForServer(ctx context.Context, mcpSessionManager *mcp.SessionManager, server v1.MCPServer, serverConfig mcp.ServerConfig, allowedTools []string) ([]types.MCPServerTool, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
 	gTools, err := mcpSessionManager.ListTools(ctx, serverConfig)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -1,52 +1,10 @@
 package handlers
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 )
-
-func TestContextWithDefaultTimeout(t *testing.T) {
-	t.Run("adds timeout when missing", func(t *testing.T) {
-		ctx := context.Background()
-
-		withTimeout, cancel := contextWithDefaultTimeout(ctx, time.Minute)
-		defer cancel()
-
-		deadline, ok := withTimeout.Deadline()
-		if !ok {
-			t.Fatalf("expected deadline to be set")
-		}
-
-		remaining := time.Until(deadline)
-		if remaining <= 0 || remaining > time.Minute {
-			t.Fatalf("expected remaining timeout in (0, 1m], got %v", remaining)
-		}
-	})
-
-	t.Run("preserves existing timeout", func(t *testing.T) {
-		baseCtx, baseCancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer baseCancel()
-
-		originalDeadline, ok := baseCtx.Deadline()
-		if !ok {
-			t.Fatalf("expected base context deadline")
-		}
-
-		withTimeout, cancel := contextWithDefaultTimeout(baseCtx, time.Minute)
-		defer cancel()
-
-		newDeadline, ok := withTimeout.Deadline()
-		if !ok {
-			t.Fatalf("expected deadline to be preserved")
-		}
-
-		if !newDeadline.Equal(originalDeadline) {
-			t.Fatalf("expected deadline %v, got %v", originalDeadline, newDeadline)
-		}
-	})
-}
 
 // Test functions for applyURLTemplate
 func TestApplyURLTemplate(t *testing.T) {

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -1,10 +1,52 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 )
+
+func TestContextWithDefaultTimeout(t *testing.T) {
+	t.Run("adds timeout when missing", func(t *testing.T) {
+		ctx := context.Background()
+
+		withTimeout, cancel := contextWithDefaultTimeout(ctx, time.Minute)
+		defer cancel()
+
+		deadline, ok := withTimeout.Deadline()
+		if !ok {
+			t.Fatalf("expected deadline to be set")
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 || remaining > time.Minute {
+			t.Fatalf("expected remaining timeout in (0, 1m], got %v", remaining)
+		}
+	})
+
+	t.Run("preserves existing timeout", func(t *testing.T) {
+		baseCtx, baseCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer baseCancel()
+
+		originalDeadline, ok := baseCtx.Deadline()
+		if !ok {
+			t.Fatalf("expected base context deadline")
+		}
+
+		withTimeout, cancel := contextWithDefaultTimeout(baseCtx, time.Minute)
+		defer cancel()
+
+		newDeadline, ok := withTimeout.Deadline()
+		if !ok {
+			t.Fatalf("expected deadline to be preserved")
+		}
+
+		if !newDeadline.Equal(originalDeadline) {
+			t.Fatalf("expected deadline %v, got %v", originalDeadline, newDeadline)
+		}
+	})
+}
 
 // Test functions for applyURLTemplate
 func TestApplyURLTemplate(t *testing.T) {

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -18,7 +18,6 @@ const (
 	defaultContainerPort          = 8099
 	defaultWebhookToolName        = "fire-webhook"
 	serviceUnavailableGracePeriod = 10 * time.Second
-	imagePullTimeout              = 3 * time.Minute
 )
 
 type backend interface {

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -52,13 +52,6 @@ var (
 	ErrInsufficientCapacity   = errors.New("insufficient cluster capacity to deploy MCP server")
 )
 
-func startupTimeout(server ServerConfig) time.Duration {
-	if server.StartupTimeoutSeconds > 0 {
-		return time.Duration(server.StartupTimeoutSeconds) * time.Second
-	}
-	return time.Minute
-}
-
 func ensureServerReady(ctx context.Context, url string, server ServerConfig) error {
 	// Ensure we can actually hit the service URL.
 	client := &http.Client{

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -18,6 +18,7 @@ const (
 	defaultContainerPort          = 8099
 	defaultWebhookToolName        = "fire-webhook"
 	serviceUnavailableGracePeriod = 10 * time.Second
+	imagePullTimeout              = 3 * time.Minute
 )
 
 type backend interface {
@@ -51,10 +52,15 @@ var (
 	ErrInsufficientCapacity   = errors.New("insufficient cluster capacity to deploy MCP server")
 )
 
+func startupTimeout(server ServerConfig) time.Duration {
+	if server.StartupTimeoutSeconds > 0 {
+		return time.Duration(server.StartupTimeoutSeconds) * time.Second
+	}
+	return time.Minute
+}
+
 func ensureServerReady(ctx context.Context, url string, server ServerConfig) error {
 	// Ensure we can actually hit the service URL.
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
 	client := &http.Client{
 		Timeout: time.Second,
 	}

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -124,7 +124,7 @@ func ensureServerReady(ctx context.Context, url string, server ServerConfig) err
 		case <-time.After(100 * time.Millisecond):
 		}
 
-		req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(streamableHTTPHealthcheckBody))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(streamableHTTPHealthcheckBody))
 		if err != nil {
 			return fmt.Errorf("failed to create request: %w", err)
 		}
@@ -142,7 +142,7 @@ func ensureServerReady(ctx context.Context, url string, server ServerConfig) err
 			if sessionID := resp.Header.Get("Mcp-Session-Id"); sessionID != "" {
 				// Send a cancellation, since we don't need this session.
 				// If we get any errors, ignore them, because it doesn't matter for us.
-				req, err := http.NewRequest(http.MethodDelete, url, nil)
+				req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 				if err == nil {
 					req.Header.Set("Mcp-Session-Id", sessionID)
 					copyHeaders(req.Header, server.PassthroughHeaderNames, server.PassthroughHeaderValues)

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -158,7 +158,7 @@ func ensureServerReady(ctx context.Context, url string, server ServerConfig) err
 		}
 
 		if resp.StatusCode == http.StatusOK {
-			readCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 
 			// Start looking for an event with "endpoint".
 			scanner := bufio.NewScanner(resp.Body)

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -72,7 +72,12 @@ func ensureServerReady(ctx context.Context, url string, server ServerConfig) err
 		var firstServiceUnavailable time.Time
 
 		for {
-			resp, err := client.Get(url)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+			if err != nil {
+				return fmt.Errorf("failed to create request: %w", err)
+			}
+
+			resp, err := client.Do(req)
 			if err == nil {
 				resp.Body.Close()
 				switch resp.StatusCode {
@@ -148,7 +153,7 @@ func ensureServerReady(ctx context.Context, url string, server ServerConfig) err
 		}
 
 		// Fallback to trying SSE.
-		req, err = http.NewRequest(http.MethodGet, url, nil)
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create request: %w", err)
 		}
@@ -161,14 +166,14 @@ func ensureServerReady(ctx context.Context, url string, server ServerConfig) err
 		}
 
 		if resp.StatusCode == http.StatusOK {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			readCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 
 			// Start looking for an event with "endpoint".
 			scanner := bufio.NewScanner(resp.Body)
 		scannerLoop:
 			for scanner.Scan() {
 				select {
-				case <-ctx.Done():
+				case <-readCtx.Done():
 					break scannerLoop
 				default:
 					if strings.Contains(scanner.Text(), "endpoint") {

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -55,6 +55,9 @@ func (sm *SessionManager) clientForServerWithOptions(ctx context.Context, client
 		return nil, err
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
 	session, err := sm.loadSession(ctx, config, clientScope, opt)
 	if err != nil {
 		return nil, err

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -291,6 +291,9 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 			existing.State = ""
 		}
 
+		ctx, cancel := context.WithTimeout(ctx, startupTimeout(server))
+		defer cancel()
+
 		// Container exists, check state
 		switch existing.State {
 		case container.StateCreated:
@@ -769,6 +772,7 @@ func (d *dockerBackend) buildServerConfig(server ServerConfig, c *container.Summ
 		NanobotAgentName:          server.NanobotAgentName,
 		PassthroughHeaderNames:    server.PassthroughHeaderNames,
 		PassthroughHeaderValues:   server.PassthroughHeaderValues,
+		StartupTimeoutSeconds:     server.StartupTimeoutSeconds,
 	}, nil
 }
 
@@ -777,6 +781,10 @@ func (d *dockerBackend) createAndStartAndWaitForContainer(ctx context.Context, s
 	if err != nil {
 		return ServerConfig{}, err
 	}
+
+	// Use MCP Server startup timeout now that image is pulled and container is created
+	ctx, cancel := context.WithTimeout(ctx, startupTimeout(server))
+	defer cancel()
 
 	// Wait for container to be running and healthy
 	if err := d.waitForContainer(ctx, containerID); err != nil {
@@ -1041,6 +1049,8 @@ func (d *dockerBackend) waitForContainer(ctx context.Context, containerID string
 		select {
 		case <-timeout:
 			return fmt.Errorf("timeout waiting for container to start")
+		case <-ctx.Done():
+			return fmt.Errorf("%w: timeout waiting for container to start", ErrHealthCheckTimeout)
 		case <-ticker.C:
 			inspect, err := d.client.ContainerInspect(ctx, containerID)
 			if err != nil {
@@ -1324,6 +1334,9 @@ func (d *dockerBackend) populateFilesVolume(ctx context.Context, volumeName, con
 }
 
 func (d *dockerBackend) pullImage(ctx context.Context, imageName string, ifNotExists bool) error {
+	ctx, cancel := context.WithTimeout(ctx, imagePullTimeout)
+	defer cancel()
+
 	if ifNotExists {
 		// Check if image exists locally
 		_, err := d.client.ImageInspect(ctx, imageName)

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -291,22 +291,22 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 			existing.State = ""
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, startupTimeout(server))
+		readyCtx, cancel := context.WithTimeout(ctx, startupTimeout(server))
 		defer cancel()
 
 		// Container exists, check state
 		switch existing.State {
 		case container.StateCreated:
 			// Container exists and is created, start it and wait for it to be ready.
-			if err := d.client.ContainerStart(ctx, existing.ID, container.StartOptions{}); err != nil {
+			if err := d.client.ContainerStart(readyCtx, existing.ID, container.StartOptions{}); err != nil {
 				return ServerConfig{}, fmt.Errorf("failed to start container: %w", err)
 			}
 
-			if err := d.waitForContainer(ctx, existing.ID); err != nil {
+			if err := d.waitForContainer(readyCtx, existing.ID); err != nil {
 				return ServerConfig{}, fmt.Errorf("failed to wait for container: %w", err)
 			}
 
-			existing, err = d.getContainer(ctx, server.MCPServerName)
+			existing, err = d.getContainer(readyCtx, server.MCPServerName)
 			if err != nil {
 				return ServerConfig{}, fmt.Errorf("failed to get running container: %w", err)
 			}
@@ -314,7 +314,7 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 			// The container is ready now, so fallthrough to the next case.
 			fallthrough
 		case container.StateRunning:
-			if err := d.syncContainerFiles(ctx, server, existing); err != nil {
+			if err := d.syncContainerFiles(readyCtx, server, existing); err != nil {
 				return ServerConfig{}, fmt.Errorf("failed syncing container files: %w", err)
 			}
 
@@ -323,7 +323,7 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 				containerPort = server.ContainerPort
 			}
 
-			if err = d.ensureServerReady(ctx, existing, server, containerPort); err != nil {
+			if err = d.ensureServerReady(readyCtx, existing, server, containerPort); err != nil {
 				return ServerConfig{}, fmt.Errorf("server running, but readiness check failed: %w", err)
 			}
 

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -1026,6 +1026,9 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 		} else {
 			containerID = resp.ID
 		}
+		if containerID != "" {
+			break
+		}
 	}
 	if containerID == "" {
 		return "", 0, fmt.Errorf("failed to create container")

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -291,22 +291,19 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 			existing.State = ""
 		}
 
-		readyCtx, cancel := context.WithTimeout(ctx, server.StartupTimeout)
-		defer cancel()
-
 		// Container exists, check state
 		switch existing.State {
 		case container.StateCreated:
 			// Container exists and is created, start it and wait for it to be ready.
-			if err := d.client.ContainerStart(readyCtx, existing.ID, container.StartOptions{}); err != nil {
+			if err := d.client.ContainerStart(ctx, existing.ID, container.StartOptions{}); err != nil {
 				return ServerConfig{}, fmt.Errorf("failed to start container: %w", err)
 			}
 
-			if err := d.waitForContainer(readyCtx, existing.ID); err != nil {
+			if err := d.waitForContainer(ctx, existing.ID); err != nil {
 				return ServerConfig{}, fmt.Errorf("failed to wait for container: %w", err)
 			}
 
-			existing, err = d.getContainer(readyCtx, server.MCPServerName)
+			existing, err = d.getContainer(ctx, server.MCPServerName)
 			if err != nil {
 				return ServerConfig{}, fmt.Errorf("failed to get running container: %w", err)
 			}
@@ -314,7 +311,7 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 			// The container is ready now, so fallthrough to the next case.
 			fallthrough
 		case container.StateRunning:
-			if err := d.syncContainerFiles(readyCtx, server, existing); err != nil {
+			if err := d.syncContainerFiles(ctx, server, existing); err != nil {
 				return ServerConfig{}, fmt.Errorf("failed syncing container files: %w", err)
 			}
 
@@ -323,7 +320,7 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 				containerPort = server.ContainerPort
 			}
 
-			if err = d.ensureServerReady(readyCtx, existing, server, containerPort); err != nil {
+			if err = d.ensureServerReady(ctx, existing, server, containerPort); err != nil {
 				return ServerConfig{}, fmt.Errorf("server running, but readiness check failed: %w", err)
 			}
 
@@ -781,10 +778,6 @@ func (d *dockerBackend) createAndStartAndWaitForContainer(ctx context.Context, s
 	if err != nil {
 		return ServerConfig{}, err
 	}
-
-	// Use MCP Server startup timeout now that image is pulled and container is created
-	ctx, cancel := context.WithTimeout(ctx, server.StartupTimeout)
-	defer cancel()
 
 	// Wait for container to be running and healthy
 	if err := d.waitForContainer(ctx, containerID); err != nil {
@@ -1337,9 +1330,6 @@ func (d *dockerBackend) populateFilesVolume(ctx context.Context, volumeName, con
 }
 
 func (d *dockerBackend) pullImage(ctx context.Context, imageName string, ifNotExists bool) error {
-	ctx, cancel := context.WithTimeout(ctx, imagePullTimeout)
-	defer cancel()
-
 	if ifNotExists {
 		// Check if image exists locally
 		_, err := d.client.ImageInspect(ctx, imageName)

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -291,7 +291,7 @@ func (d *dockerBackend) ensureDeployment(ctx context.Context, server ServerConfi
 			existing.State = ""
 		}
 
-		readyCtx, cancel := context.WithTimeout(ctx, startupTimeout(server))
+		readyCtx, cancel := context.WithTimeout(ctx, server.StartupTimeout)
 		defer cancel()
 
 		// Container exists, check state
@@ -772,7 +772,7 @@ func (d *dockerBackend) buildServerConfig(server ServerConfig, c *container.Summ
 		NanobotAgentName:          server.NanobotAgentName,
 		PassthroughHeaderNames:    server.PassthroughHeaderNames,
 		PassthroughHeaderValues:   server.PassthroughHeaderValues,
-		StartupTimeoutSeconds:     server.StartupTimeoutSeconds,
+		StartupTimeout:            server.StartupTimeout,
 	}, nil
 }
 
@@ -783,7 +783,7 @@ func (d *dockerBackend) createAndStartAndWaitForContainer(ctx context.Context, s
 	}
 
 	// Use MCP Server startup timeout now that image is pulled and container is created
-	ctx, cancel := context.WithTimeout(ctx, startupTimeout(server))
+	ctx, cancel := context.WithTimeout(ctx, server.StartupTimeout)
 	defer cancel()
 
 	// Wait for container to be running and healthy

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -744,7 +744,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			ProgressDeadlineSeconds: new(int32(startupTimeout(server).Seconds())),
+			ProgressDeadlineSeconds: new(int32(startupTimeout(server).Seconds() + imagePullTimeout.Seconds())),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": server.MCPServerName,

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -937,7 +937,7 @@ func analyzePodStatus(pod *corev1.Pod) (bool, *time.Time, error) {
 	// while a cluster autoscaler reacts, so keep waiting until the overall deadline.
 	for _, cond := range pod.Status.Conditions {
 		if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse && cond.Reason == corev1.PodReasonUnschedulable {
-			return false, nil, nil
+			return true, nil, nil
 		}
 	}
 
@@ -1045,21 +1045,23 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 					return false, podErr
 				}
 
-				if pullingImage && time.Now().After(imagePullDeadline) {
-					return false, fmt.Errorf("%w: image pull exceeded %s timeout", ErrHealthCheckTimeout, imagePullTimeout)
+				if pullingImage {
+					if time.Now().After(imagePullDeadline) {
+						return false, fmt.Errorf("%w: image pull exceeded %s timeout", ErrHealthCheckTimeout, imagePullTimeout)
+					}
+					return false, nil // Retryable state, keep waiting
 				}
-				if !pullingImage {
-					// Pod is past image pulling (container creating/starting/running).
-					// Start the startup timeout from the MCP container's Kubernetes start time
-					// when available so a long watch interval doesn't grant extra startup time.
-					if mcpContainerStartedAt != nil {
-						startupDeadline = mcpContainerStartedAt.Add(timeout)
-					} else if startupDeadline.IsZero() {
-						startupDeadline = time.Now().Add(timeout)
-					}
-					if time.Now().After(startupDeadline) {
-						return false, fmt.Errorf("%w: container startup exceeded %s timeout", ErrHealthCheckTimeout, timeout)
-					}
+
+				// Pod is past image pulling (container creating/starting/running).
+				// Start the startup timeout from the MCP container's Kubernetes start time
+				// when available so a long watch interval doesn't grant extra startup time.
+				if mcpContainerStartedAt != nil {
+					startupDeadline = mcpContainerStartedAt.Add(timeout)
+				} else if startupDeadline.IsZero() {
+					startupDeadline = time.Now().Add(timeout)
+				}
+				if time.Now().After(startupDeadline) {
+					return false, fmt.Errorf("%w: container startup exceeded %s timeout", ErrHealthCheckTimeout, timeout)
 				}
 
 				return false, nil // Retryable state, keep waiting

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -37,6 +37,8 @@ import (
 
 var olog = logger.Package()
 
+const maxPodRestartsDuringSetup = 3
+
 type kubernetesBackend struct {
 	clientset                     *kubernetes.Clientset
 	client                        kclient.WithWatch
@@ -162,19 +164,20 @@ func (k *kubernetesBackend) ensureServerDeployment(ctx context.Context, server S
 	// For direct access to the real MCP server (when there's a shim), use a different port
 	if server.NanobotAgentName != "" {
 		return ServerConfig{
-			URL:                  fmt.Sprintf("%s/%s", u, strings.TrimPrefix(server.ContainerPath, "/")),
-			MCPServerName:        server.MCPServerName,
-			Audiences:            server.Audiences,
-			MCPServerNamespace:   server.MCPServerNamespace,
-			MCPServerDisplayName: server.MCPServerDisplayName,
-			Scope:                podName,
-			UserID:               server.UserID,
-			OwnerUserID:          server.OwnerUserID,
-			Runtime:              types.RuntimeRemote,
-			Issuer:               server.Issuer,
-			ContainerPort:        server.ContainerPort,
-			ContainerPath:        server.ContainerPath,
-			NanobotAgentName:     server.NanobotAgentName,
+			URL:                   fmt.Sprintf("%s/%s", u, strings.TrimPrefix(server.ContainerPath, "/")),
+			MCPServerName:         server.MCPServerName,
+			Audiences:             server.Audiences,
+			MCPServerNamespace:    server.MCPServerNamespace,
+			MCPServerDisplayName:  server.MCPServerDisplayName,
+			Scope:                 podName,
+			UserID:                server.UserID,
+			OwnerUserID:           server.OwnerUserID,
+			Runtime:               types.RuntimeRemote,
+			Issuer:                server.Issuer,
+			ContainerPort:         server.ContainerPort,
+			ContainerPath:         server.ContainerPath,
+			NanobotAgentName:      server.NanobotAgentName,
+			StartupTimeoutSeconds: server.StartupTimeoutSeconds,
 		}, nil
 	}
 
@@ -196,6 +199,7 @@ func (k *kubernetesBackend) ensureServerDeployment(ctx context.Context, server S
 		ContainerPath:           server.ContainerPath,
 		PassthroughHeaderNames:  server.PassthroughHeaderNames,
 		PassthroughHeaderValues: server.PassthroughHeaderValues,
+		StartupTimeoutSeconds:   server.StartupTimeoutSeconds,
 	}, nil
 }
 
@@ -736,7 +740,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			ProgressDeadlineSeconds: new(int32(60)),
+			ProgressDeadlineSeconds: new(int32(startupTimeout(server).Seconds())),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": server.MCPServerName,
@@ -908,62 +912,56 @@ func getNewestPod(pods []corev1.Pod) (*corev1.Pod, error) {
 	return newest, nil
 }
 
-// analyzePodStatus examines a pod's status to determine if we should retry waiting for it
-// or if we should fail immediately. Returns (shouldRetry, error).
-func analyzePodStatus(pod *corev1.Pod) (bool, error) {
+// analyzePodStatus examines a pod's status to detect permanent failures, image pull state,
+// and when the MCP container actually started. Returns (pullingImage, startedAt, error).
+// A non-nil error means the pod is in a non-recoverable state and we should stop retrying.
+// pullingImage is true when a container is actively pulling an image, which should not count
+// against the startup timeout.
+func analyzePodStatus(pod *corev1.Pod) (bool, *time.Time, error) {
 	// Check pod phase first
 	switch pod.Status.Phase {
 	case corev1.PodFailed:
-		return false, fmt.Errorf("%w: pod is in Failed phase: %s", ErrHealthCheckTimeout, pod.Status.Message)
+		return false, nil, fmt.Errorf("%w: pod is in Failed phase: %s", ErrHealthCheckTimeout, pod.Status.Message)
 	case corev1.PodSucceeded:
 		// This shouldn't happen for a long-running deployment, but if it does, it's an error
-		return false, fmt.Errorf("%w: pod succeeded and exited", ErrHealthCheckTimeout)
+		return false, nil, fmt.Errorf("%w: pod succeeded and exited", ErrHealthCheckTimeout)
 	case corev1.PodUnknown:
-		return false, fmt.Errorf("%w: pod is in Unknown phase", ErrHealthCheckTimeout)
+		return false, nil, fmt.Errorf("%w: pod is in Unknown phase", ErrHealthCheckTimeout)
 	}
 
-	// Check pod conditions for scheduling issues
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse {
-			// Pod can't be scheduled - check if it's a transient issue
-			if cond.Reason == corev1.PodReasonUnschedulable {
-				// Unschedulable could be transient (e.g., waiting for autoscaler)
-				return true, fmt.Errorf("%w: pod unschedulable: %s", ErrPodSchedulingFailed, cond.Message)
-			}
-		}
-	}
-
+	var mcpContainerStartedAt *time.Time
 	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == "mcp" && cs.State.Running != nil && !cs.State.Running.StartedAt.IsZero() {
+			startedAt := cs.State.Running.StartedAt.Time
+			mcpContainerStartedAt = &startedAt
+		}
+
 		// Check if container is waiting
 		if cs.State.Waiting != nil {
 			waiting := cs.State.Waiting
 			switch waiting.Reason {
-			// Transient/recoverable states - should retry
-			case "ContainerCreating", "PodInitializing":
-				return true, fmt.Errorf("container %s is %s", cs.Name, waiting.Reason)
-
-			// Image pull states - need to check if it's temporary or permanent
-			case "ImagePullBackOff", "ErrImagePull":
-				// ImagePullBackOff can be transient (network issues) but also permanent (bad image)
-				// We'll treat it as retryable for now, but it will eventually hit max retries
-				return true, fmt.Errorf("%w: container %s: %s - %s", ErrImagePullFailed, cs.Name, waiting.Reason, waiting.Message)
+			// Image pull states - retryable and should not count against startup timeout.
+			// ContainerCreating is included because the initial image pull happens during
+			// this phase
+			case "ContainerCreating", "ImagePullBackOff", "ErrImagePull":
+				return true, nil, nil
 
 			// Permanent failures - should not retry
 			case "CrashLoopBackOff":
-				return false, fmt.Errorf("%w: container %s is in CrashLoopBackOff: %s", ErrPodCrashLoopBackOff, cs.Name, waiting.Message)
+				return false, nil, fmt.Errorf("%w: container %s is in CrashLoopBackOff: %s", ErrPodCrashLoopBackOff, cs.Name, waiting.Message)
 			case "InvalidImageName":
-				return false, fmt.Errorf("%w: container %s has invalid image name: %s", ErrImagePullFailed, cs.Name, waiting.Message)
+				return false, nil, fmt.Errorf("%w: container %s has invalid image name: %s", ErrImagePullFailed, cs.Name, waiting.Message)
 			case "CreateContainerConfigError", "CreateContainerError":
-				return false, fmt.Errorf("%w: container %s failed to create: %s - %s", ErrPodConfigurationFailed, cs.Name, waiting.Reason, waiting.Message)
+				return false, nil, fmt.Errorf("%w: container %s failed to create: %s - %s", ErrPodConfigurationFailed, cs.Name, waiting.Reason, waiting.Message)
 			case "RunContainerError":
-				return false, fmt.Errorf("%w: container %s failed to run: %s", ErrPodConfigurationFailed, cs.Name, waiting.Message)
+				return false, nil, fmt.Errorf("%w: container %s failed to run: %s", ErrPodConfigurationFailed, cs.Name, waiting.Message)
 			}
 		}
 
 		// Check if container terminated with errors and has high restart count
 		if cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
-			if cs.RestartCount > 3 {
-				return false, fmt.Errorf("%w: container %s repeatedly crashing (exit code %d, %d restarts): %s",
+			if cs.RestartCount > maxPodRestartsDuringSetup {
+				return false, nil, fmt.Errorf("%w: container %s repeatedly crashing (exit code %d, %d restarts): %s",
 					ErrPodCrashLoopBackOff, cs.Name, cs.State.Terminated.ExitCode, cs.RestartCount, cs.State.Terminated.Reason)
 			}
 		}
@@ -971,118 +969,137 @@ func analyzePodStatus(pod *corev1.Pod) (bool, error) {
 
 	// Check if pod is being evicted
 	if pod.Status.Reason == "Evicted" {
-		return false, fmt.Errorf("%w: pod was evicted: %s", ErrPodSchedulingFailed, pod.Status.Message)
+		return false, nil, fmt.Errorf("%w: pod was evicted: %s", ErrPodSchedulingFailed, pod.Status.Message)
 	}
 
-	// Default: pod is in Pending or Running but not ready yet - should retry
-	return true, fmt.Errorf("pod in phase %s, waiting for containers to be ready", pod.Status.Phase)
+	// Default: pod is in Pending or Running but not ready yet - keep waiting
+	return false, mcpContainerStartedAt, nil
 }
 
 func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id string, server ServerConfig, previousPodName string) (string, error) {
-	const maxRetries = 5
-	var lastErr error
+	// Track separate deadlines for image pulling and container startup.
+	// Image pulling gets a fixed generous timeout; the configured timeout applies to container startup.
+	timeout := startupTimeout(server)
+	imagePullDeadline := time.Now().Add(imagePullTimeout)
+	var startupDeadline time.Time
 
-	// Retry loop with smart pod status checking
-	for attempt := range maxRetries {
-		// Wait for the deployment to be updated.
-		_, err := wait.For(ctx, k.client, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: id, Namespace: k.mcpNamespace}}, func(dep *appsv1.Deployment) (bool, error) {
-			return dep.Generation == dep.Status.ObservedGeneration && dep.Status.UpdatedReplicas == 1 && dep.Status.ReadyReplicas == 1 && dep.Status.AvailableReplicas == 1, nil
-		}, wait.Option{Timeout: time.Minute})
-		if err == nil {
-			// Get the pod name that is currently running.
-			var (
-				pods    corev1.PodList
-				podName string
-			)
-			if err = k.client.List(ctx, &pods, &kclient.ListOptions{
+	// Wait for the deployment to be ready, checking pod status on each update to fail fast on permanent errors.
+	// The watch timeout must cover both image pulling and container startup.
+	_, err := wait.For(ctx, k.client, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: id, Namespace: k.mcpNamespace}},
+		func(dep *appsv1.Deployment) (bool, error) {
+			if dep.Generation == dep.Status.ObservedGeneration && dep.Status.UpdatedReplicas == 1 && dep.Status.ReadyReplicas == 1 && dep.Status.AvailableReplicas == 1 {
+				return true, nil
+			}
+
+			// Deployment not ready yet — check pod status for early failure detection.
+			var pods corev1.PodList
+			if listErr := k.client.List(ctx, &pods, &kclient.ListOptions{
 				Namespace: k.mcpNamespace,
 				LabelSelector: labels.SelectorFromSet(map[string]string{
 					"app": id,
 				}),
-			}); err != nil {
-				return "", fmt.Errorf("failed to list MCP pods: %w", err)
+			}); listErr != nil {
+				olog.Warnf("failed to list MCP pods for status check: id=%s error=%v", id, listErr)
+				return false, nil // Keep waiting; listing failure is transient
 			}
 
-			var newestCreatedTime metav1.Time
-			for _, p := range pods.Items {
-				if p.DeletionTimestamp.IsZero() && p.CreationTimestamp.After(newestCreatedTime.Time) && p.Status.Phase == corev1.PodRunning {
-					podName = p.Name
-					newestCreatedTime = p.CreationTimestamp
+			if len(pods.Items) == 0 {
+				return false, nil // No pods yet, keep waiting
+			}
+
+			newestPod, err := getNewestPod(pods.Items)
+			if err != nil {
+				return false, nil // Keep waiting
+			}
+
+			pullingImage, mcpContainerStartedAt, podErr := analyzePodStatus(newestPod)
+			if podErr != nil {
+				// Permanent failure — abort immediately
+				olog.Warnf("pod in non-retryable state: id=%s error=%v", id, podErr)
+				return false, podErr
+			}
+
+			if pullingImage && time.Now().After(imagePullDeadline) {
+				return false, fmt.Errorf("%w: image pull exceeded %s timeout", ErrHealthCheckTimeout, imagePullTimeout)
+			}
+			if !pullingImage {
+				// Pod is past image pulling (container creating/starting/running).
+				// Start the startup timeout from the MCP container's Kubernetes start time
+				// when available so a long watch interval doesn't grant extra startup time.
+				if mcpContainerStartedAt != nil {
+					startupDeadline = mcpContainerStartedAt.Add(timeout)
+				} else if startupDeadline.IsZero() {
+					startupDeadline = time.Now().Add(timeout)
+				}
+				if time.Now().After(startupDeadline) {
+					return false, fmt.Errorf("%w: container startup exceeded %s timeout", ErrHealthCheckTimeout, timeout)
 				}
 			}
 
-			if podName != "" {
-				if podName == previousPodName {
-					return podName, nil
-				}
+			return false, nil // Retryable state, keep waiting
+		},
+		// wait.For will default to 2m timeout. Here we combine the configured timeouts + some wiggle room
+		wait.Option{Timeout: imagePullTimeout + timeout + 30*time.Second},
+	)
+	if err != nil {
+		return "", err
+	}
 
-				// For containerized runtimes, ensure that the server is healthy.
-				if server.Runtime == types.RuntimeContainerized {
-					if err = ensureServerReady(ctx, fmt.Sprintf("%s:%d", url, 8080), server); err != nil {
-						return "", fmt.Errorf("failed to ensure MCP server is ready: %w", err)
-					}
-				}
+	// Deployment is ready. Get the pod name that is currently running.
+	var (
+		pods    corev1.PodList
+		podName string
+	)
+	if err = k.client.List(ctx, &pods, &kclient.ListOptions{
+		Namespace: k.mcpNamespace,
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"app": id,
+		}),
+	}); err != nil {
+		return "", fmt.Errorf("failed to list MCP pods: %w", err)
+	}
 
-				// For non-agents, check that the shim is healthy and ready.
-				if server.NanobotAgentName == "" {
-					// We are checking the shim, so set the runtime accordingly.
-					server.Runtime = types.RuntimeRemote
-					if err = ensureServerReady(ctx, url, server); err != nil {
-						return "", fmt.Errorf("failed to ensure MCP server is ready: %w", err)
-					}
-				}
-
-				return podName, nil
-			}
-
-			lastErr = fmt.Errorf("no pods found")
-			continue
-		}
-
-		// Deployment wait timed out, check pod status to decide if we should retry
-		var pods corev1.PodList
-		if listErr := k.client.List(ctx, &pods, &kclient.ListOptions{
-			Namespace: k.mcpNamespace,
-			LabelSelector: labels.SelectorFromSet(map[string]string{
-				"app": id,
-			}),
-		}); listErr != nil {
-			olog.Debugf("failed to list MCP pods for status check: id=%s error=%v", id, listErr)
-			return "", fmt.Errorf("failed to list MCP pods: %w", listErr)
-		}
-
-		if len(pods.Items) == 0 {
-			olog.Debugf("no pods found for MCP server: id=%s attempt=%d", id, attempt+1)
-			lastErr = fmt.Errorf("no pods found")
-			if attempt < maxRetries {
-				continue
-			}
-			return "", fmt.Errorf("%w: %v", ErrHealthCheckTimeout, lastErr)
-		}
-
-		// Get the newest pod and analyze its status
-		newestPod, err := getNewestPod(pods.Items)
-		if err != nil {
-			olog.Debugf("failed to get newest pod: id=%s error=%v attempt=%d", id, err, attempt+1)
-			lastErr = err
-			if attempt < maxRetries {
-				continue
-			}
-			return "", fmt.Errorf("%w: %v", ErrHealthCheckTimeout, lastErr)
-		}
-
-		shouldRetry, podErr := analyzePodStatus(newestPod)
-		lastErr = podErr
-
-		if !shouldRetry {
-			// Permanent failure - return the error with the appropriate type already wrapped
-			olog.Debugf("pod in non-retryable state: id=%s error=%v attempt=%d", id, podErr, attempt+1)
-			return "", podErr
+	var newestCreatedTime metav1.Time
+	for _, p := range pods.Items {
+		if p.DeletionTimestamp.IsZero() && p.CreationTimestamp.After(newestCreatedTime.Time) && p.Status.Phase == corev1.PodRunning {
+			podName = p.Name
+			newestCreatedTime = p.CreationTimestamp
 		}
 	}
 
-	olog.Debugf("exceeded max retries waiting for pod: id=%s lastError=%v attempts=%d", id, lastErr, maxRetries)
-	return "", fmt.Errorf("%w after %d retries: %v", ErrHealthCheckTimeout, maxRetries, lastErr)
+	if podName == "" {
+		return "", fmt.Errorf("%w: deployment ready but no running pods found", ErrHealthCheckTimeout)
+	}
+
+	if podName == previousPodName {
+		return podName, nil
+	}
+
+	// Use the remaining startup deadline for ensureServerReady so it doesn't poll forever.
+	if startupDeadline.IsZero() {
+		startupDeadline = time.Now().Add(timeout)
+	}
+
+	healthCtx, healthCancel := context.WithDeadline(ctx, startupDeadline)
+	defer healthCancel()
+
+	// For containerized runtimes, ensure that the real MCP server is healthy.
+	if server.Runtime == types.RuntimeContainerized {
+		if err = ensureServerReady(healthCtx, fmt.Sprintf("%s:%d", url, 8080), server); err != nil {
+			return "", fmt.Errorf("failed to ensure MCP server is ready: %w", err)
+		}
+	}
+
+	// For non-agents, check that the shim is healthy and ready.
+	if server.NanobotAgentName == "" {
+		// We are checking the shim, so set the runtime accordingly.
+		server.Runtime = types.RuntimeRemote
+		if err = ensureServerReady(healthCtx, url, server); err != nil {
+			return "", fmt.Errorf("failed to ensure MCP server is ready: %w", err)
+		}
+	}
+
+	return podName, nil
 }
 
 func (k *kubernetesBackend) getDeploymentCache(mcpServerName string) *kubernetesDeploymentCacheEntry {

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -168,20 +168,20 @@ func (k *kubernetesBackend) ensureServerDeployment(ctx context.Context, server S
 	// For direct access to the real MCP server (when there's a shim), use a different port
 	if server.NanobotAgentName != "" {
 		return ServerConfig{
-			URL:                   fmt.Sprintf("%s/%s", u, strings.TrimPrefix(server.ContainerPath, "/")),
-			MCPServerName:         server.MCPServerName,
-			Audiences:             server.Audiences,
-			MCPServerNamespace:    server.MCPServerNamespace,
-			MCPServerDisplayName:  server.MCPServerDisplayName,
-			Scope:                 podName,
-			UserID:                server.UserID,
-			OwnerUserID:           server.OwnerUserID,
-			Runtime:               types.RuntimeRemote,
-			Issuer:                server.Issuer,
-			ContainerPort:         server.ContainerPort,
-			ContainerPath:         server.ContainerPath,
-			NanobotAgentName:      server.NanobotAgentName,
-			StartupTimeoutSeconds: server.StartupTimeoutSeconds,
+			URL:                  fmt.Sprintf("%s/%s", u, strings.TrimPrefix(server.ContainerPath, "/")),
+			MCPServerName:        server.MCPServerName,
+			Audiences:            server.Audiences,
+			MCPServerNamespace:   server.MCPServerNamespace,
+			MCPServerDisplayName: server.MCPServerDisplayName,
+			Scope:                podName,
+			UserID:               server.UserID,
+			OwnerUserID:          server.OwnerUserID,
+			Runtime:              types.RuntimeRemote,
+			Issuer:               server.Issuer,
+			ContainerPort:        server.ContainerPort,
+			ContainerPath:        server.ContainerPath,
+			NanobotAgentName:     server.NanobotAgentName,
+			StartupTimeout:       server.StartupTimeout,
 		}, nil
 	}
 
@@ -203,7 +203,7 @@ func (k *kubernetesBackend) ensureServerDeployment(ctx context.Context, server S
 		ContainerPath:           server.ContainerPath,
 		PassthroughHeaderNames:  server.PassthroughHeaderNames,
 		PassthroughHeaderValues: server.PassthroughHeaderValues,
-		StartupTimeoutSeconds:   server.StartupTimeoutSeconds,
+		StartupTimeout:          server.StartupTimeout,
 	}, nil
 }
 
@@ -744,7 +744,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			ProgressDeadlineSeconds: new(int32(startupTimeout(server).Seconds() + imagePullTimeout.Seconds())),
+			ProgressDeadlineSeconds: new(int32((server.StartupTimeout + imagePullTimeout).Seconds())),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": server.MCPServerName,
@@ -991,7 +991,7 @@ func analyzePodStatus(pod *corev1.Pod) (bool, *time.Time, error) {
 func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id string, server ServerConfig, previousPodName string) (string, error) {
 	// Track separate deadlines for image pulling and container startup.
 	// Image pulling gets a fixed generous timeout; the configured timeout applies to container startup.
-	timeout := startupTimeout(server)
+	timeout := server.StartupTimeout
 	imagePullDeadline := time.Now().Add(imagePullTimeout)
 	watchDeadline := time.Now().Add(imagePullTimeout + timeout + 30*time.Second)
 	var startupDeadline time.Time

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -933,6 +933,14 @@ func analyzePodStatus(pod *corev1.Pod) (bool, *time.Time, error) {
 		return false, nil, fmt.Errorf("%w: pod is in Unknown phase", ErrHealthCheckTimeout)
 	}
 
+	// Check pod conditions for scheduling issues. Unschedulable pods may be transient
+	// while a cluster autoscaler reacts, so keep waiting until the overall deadline.
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse && cond.Reason == corev1.PodReasonUnschedulable {
+			return false, nil, nil
+		}
+	}
+
 	var mcpContainerStartedAt *time.Time
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Name == "mcp" && cs.State.Running != nil && !cs.State.Running.StartedAt.IsZero() {

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -744,7 +744,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			ProgressDeadlineSeconds: new(int32((server.StartupTimeout + imagePullTimeout).Seconds())),
+			ProgressDeadlineSeconds: new(int32(server.StartupTimeout.Seconds())),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": server.MCPServerName,
@@ -916,64 +916,45 @@ func getNewestPod(pods []corev1.Pod) (*corev1.Pod, error) {
 	return newest, nil
 }
 
-// analyzePodStatus examines a pod's status to detect permanent failures, image pull state,
-// and when the MCP container actually started. Returns (pullingImage, startedAt, error).
-// A non-nil error means the pod is in a non-recoverable state and we should stop retrying.
-// pullingImage is true when a container is actively pulling an image, which should not count
-// against the startup timeout.
-func analyzePodStatus(pod *corev1.Pod) (bool, *time.Time, error) {
+// analyzePodStatus examines a pod's status to detect non-recoverable failures.
+// A non-nil error means the pod is in a state we should not retry.
+func analyzePodStatus(pod *corev1.Pod) error {
 	// Check pod phase first
 	switch pod.Status.Phase {
 	case corev1.PodFailed:
-		return false, nil, fmt.Errorf("%w: pod is in Failed phase: %s", ErrHealthCheckTimeout, pod.Status.Message)
+		return fmt.Errorf("%w: pod is in Failed phase: %s", ErrHealthCheckTimeout, pod.Status.Message)
 	case corev1.PodSucceeded:
 		// This shouldn't happen for a long-running deployment, but if it does, it's an error
-		return false, nil, fmt.Errorf("%w: pod succeeded and exited", ErrHealthCheckTimeout)
+		return fmt.Errorf("%w: pod succeeded and exited", ErrHealthCheckTimeout)
 	case corev1.PodUnknown:
-		return false, nil, fmt.Errorf("%w: pod is in Unknown phase", ErrHealthCheckTimeout)
+		return fmt.Errorf("%w: pod is in Unknown phase", ErrHealthCheckTimeout)
 	}
 
-	// Check pod conditions for scheduling issues. Unschedulable pods may be transient
-	// while a cluster autoscaler reacts, so keep waiting until the overall deadline.
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse && cond.Reason == corev1.PodReasonUnschedulable {
-			return true, nil, nil
-		}
-	}
-
-	var mcpContainerStartedAt *time.Time
 	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name == "mcp" && cs.State.Running != nil && !cs.State.Running.StartedAt.IsZero() {
-			startedAt := cs.State.Running.StartedAt.Time
-			mcpContainerStartedAt = &startedAt
-		}
-
 		// Check if container is waiting
 		if cs.State.Waiting != nil {
 			waiting := cs.State.Waiting
 			switch waiting.Reason {
-			// Image pull states - retryable and should not count against startup timeout.
-			// ContainerCreating is included because the initial image pull happens during
-			// this phase
+			// Retryable states.
 			case "ContainerCreating", "ImagePullBackOff", "ErrImagePull":
-				return true, nil, nil
+				continue
 
 			// Permanent failures - should not retry
 			case "CrashLoopBackOff":
-				return false, nil, fmt.Errorf("%w: container %s is in CrashLoopBackOff: %s", ErrPodCrashLoopBackOff, cs.Name, waiting.Message)
+				return fmt.Errorf("%w: container %s is in CrashLoopBackOff: %s", ErrPodCrashLoopBackOff, cs.Name, waiting.Message)
 			case "InvalidImageName":
-				return false, nil, fmt.Errorf("%w: container %s has invalid image name: %s", ErrImagePullFailed, cs.Name, waiting.Message)
+				return fmt.Errorf("%w: container %s has invalid image name: %s", ErrImagePullFailed, cs.Name, waiting.Message)
 			case "CreateContainerConfigError", "CreateContainerError":
-				return false, nil, fmt.Errorf("%w: container %s failed to create: %s - %s", ErrPodConfigurationFailed, cs.Name, waiting.Reason, waiting.Message)
+				return fmt.Errorf("%w: container %s failed to create: %s - %s", ErrPodConfigurationFailed, cs.Name, waiting.Reason, waiting.Message)
 			case "RunContainerError":
-				return false, nil, fmt.Errorf("%w: container %s failed to run: %s", ErrPodConfigurationFailed, cs.Name, waiting.Message)
+				return fmt.Errorf("%w: container %s failed to run: %s", ErrPodConfigurationFailed, cs.Name, waiting.Message)
 			}
 		}
 
 		// Check if container terminated with errors and has high restart count
 		if cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
 			if cs.RestartCount > maxPodRestartsDuringSetup {
-				return false, nil, fmt.Errorf("%w: container %s repeatedly crashing (exit code %d, %d restarts): %s",
+				return fmt.Errorf("%w: container %s repeatedly crashing (exit code %d, %d restarts): %s",
 					ErrPodCrashLoopBackOff, cs.Name, cs.State.Terminated.ExitCode, cs.RestartCount, cs.State.Terminated.Reason)
 			}
 		}
@@ -981,40 +962,29 @@ func analyzePodStatus(pod *corev1.Pod) (bool, *time.Time, error) {
 
 	// Check if pod is being evicted
 	if pod.Status.Reason == "Evicted" {
-		return false, nil, fmt.Errorf("%w: pod was evicted: %s", ErrPodSchedulingFailed, pod.Status.Message)
+		return fmt.Errorf("%w: pod was evicted: %s", ErrPodSchedulingFailed, pod.Status.Message)
 	}
 
-	// Default: pod is in Pending or Running but not ready yet - keep waiting
-	return false, mcpContainerStartedAt, nil
+	return nil
 }
 
 func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id string, server ServerConfig, previousPodName string) (string, error) {
-	// Track separate deadlines for image pulling and container startup.
-	// Image pulling gets a fixed generous timeout; the configured timeout applies to container startup.
-	timeout := server.StartupTimeout
-	imagePullDeadline := time.Now().Add(imagePullTimeout)
-	watchDeadline := time.Now().Add(imagePullTimeout + timeout + 30*time.Second)
-	var startupDeadline time.Time
-
 	// Wait for the deployment to be ready, checking pod status on each update to fail fast on permanent errors.
-	// The watch timeout must cover both image pulling and container startup.
 	var (
 		err     error
 		lastErr error
 	)
 	for attempt := range maxDeploymentWatchRetries {
-		remaining := time.Until(watchDeadline)
-		if remaining <= 0 {
-			if lastErr != nil {
-				return "", fmt.Errorf("%w: timeout waiting for deployment readiness: %v", ErrHealthCheckTimeout, lastErr)
-			}
-			return "", fmt.Errorf("%w: timeout waiting for deployment readiness", ErrHealthCheckTimeout)
-		}
-
 		_, err := wait.For(ctx, k.client, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: id, Namespace: k.mcpNamespace}},
 			func(dep *appsv1.Deployment) (bool, error) {
 				if dep.Generation == dep.Status.ObservedGeneration && dep.Status.UpdatedReplicas == 1 && dep.Status.ReadyReplicas == 1 && dep.Status.AvailableReplicas == 1 {
 					return true, nil
+				}
+
+				select {
+				case <-ctx.Done():
+					return false, ctx.Err()
+				default:
 				}
 
 				// Deployment not ready yet — check pod status for early failure detection.
@@ -1038,35 +1008,16 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 					return false, nil // Keep waiting
 				}
 
-				pullingImage, mcpContainerStartedAt, podErr := analyzePodStatus(newestPod)
+				podErr := analyzePodStatus(newestPod)
 				if podErr != nil {
 					// Permanent failure — abort immediately
 					olog.Warnf("pod in non-retryable state: id=%s error=%v", id, podErr)
 					return false, podErr
 				}
 
-				if pullingImage {
-					if time.Now().After(imagePullDeadline) {
-						return false, fmt.Errorf("%w: pod scheduling and image pull exceeded %s timeout", ErrHealthCheckTimeout, imagePullTimeout)
-					}
-					return false, nil // Retryable state, keep waiting
-				}
-
-				// Pod is past image pulling (container creating/starting/running).
-				// Start the startup timeout from the MCP container's Kubernetes start time
-				// when available so a long watch interval doesn't grant extra startup time.
-				if mcpContainerStartedAt != nil {
-					startupDeadline = mcpContainerStartedAt.Add(timeout)
-				} else if startupDeadline.IsZero() {
-					startupDeadline = time.Now().Add(timeout)
-				}
-				if time.Now().After(startupDeadline) {
-					return false, fmt.Errorf("%w: container startup exceeded %s timeout", ErrHealthCheckTimeout, timeout)
-				}
-
-				return false, nil // Retryable state, keep waiting
+				return false, nil // Keep waiting.
 			},
-			wait.Option{Timeout: remaining},
+			wait.Option{Timeout: server.StartupTimeout},
 		)
 		if err == nil {
 			break
@@ -1120,17 +1071,9 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 		return podName, nil
 	}
 
-	// Use the remaining startup deadline for ensureServerReady so it doesn't poll forever.
-	if startupDeadline.IsZero() {
-		startupDeadline = time.Now().Add(timeout)
-	}
-
-	healthCtx, healthCancel := context.WithDeadline(ctx, startupDeadline)
-	defer healthCancel()
-
 	// For containerized runtimes, ensure that the real MCP server is healthy.
 	if server.Runtime == types.RuntimeContainerized {
-		if err = ensureServerReady(healthCtx, fmt.Sprintf("%s:%d", url, 8080), server); err != nil {
+		if err = ensureServerReady(ctx, fmt.Sprintf("%s:%d", url, 8080), server); err != nil {
 			return "", fmt.Errorf("failed to ensure MCP server is ready: %w", err)
 		}
 	}
@@ -1139,7 +1082,7 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 	if server.NanobotAgentName == "" {
 		// We are checking the shim, so set the runtime accordingly.
 		server.Runtime = types.RuntimeRemote
-		if err = ensureServerReady(healthCtx, url, server); err != nil {
+		if err = ensureServerReady(ctx, url, server); err != nil {
 			return "", fmt.Errorf("failed to ensure MCP server is ready: %w", err)
 		}
 	}

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -37,7 +38,10 @@ import (
 
 var olog = logger.Package()
 
-const maxPodRestartsDuringSetup = 3
+const (
+	maxDeploymentWatchRetries = 5
+	maxPodRestartsDuringSetup = 3
+)
 
 type kubernetesBackend struct {
 	clientset                     *kubernetes.Clientset
@@ -981,68 +985,99 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 	// Image pulling gets a fixed generous timeout; the configured timeout applies to container startup.
 	timeout := startupTimeout(server)
 	imagePullDeadline := time.Now().Add(imagePullTimeout)
+	watchDeadline := time.Now().Add(imagePullTimeout + timeout + 30*time.Second)
 	var startupDeadline time.Time
 
 	// Wait for the deployment to be ready, checking pod status on each update to fail fast on permanent errors.
 	// The watch timeout must cover both image pulling and container startup.
-	_, err := wait.For(ctx, k.client, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: id, Namespace: k.mcpNamespace}},
-		func(dep *appsv1.Deployment) (bool, error) {
-			if dep.Generation == dep.Status.ObservedGeneration && dep.Status.UpdatedReplicas == 1 && dep.Status.ReadyReplicas == 1 && dep.Status.AvailableReplicas == 1 {
-				return true, nil
-			}
-
-			// Deployment not ready yet — check pod status for early failure detection.
-			var pods corev1.PodList
-			if listErr := k.client.List(ctx, &pods, &kclient.ListOptions{
-				Namespace: k.mcpNamespace,
-				LabelSelector: labels.SelectorFromSet(map[string]string{
-					"app": id,
-				}),
-			}); listErr != nil {
-				olog.Warnf("failed to list MCP pods for status check: id=%s error=%v", id, listErr)
-				return false, nil // Keep waiting; listing failure is transient
-			}
-
-			if len(pods.Items) == 0 {
-				return false, nil // No pods yet, keep waiting
-			}
-
-			newestPod, err := getNewestPod(pods.Items)
-			if err != nil {
-				return false, nil // Keep waiting
-			}
-
-			pullingImage, mcpContainerStartedAt, podErr := analyzePodStatus(newestPod)
-			if podErr != nil {
-				// Permanent failure — abort immediately
-				olog.Warnf("pod in non-retryable state: id=%s error=%v", id, podErr)
-				return false, podErr
-			}
-
-			if pullingImage && time.Now().After(imagePullDeadline) {
-				return false, fmt.Errorf("%w: image pull exceeded %s timeout", ErrHealthCheckTimeout, imagePullTimeout)
-			}
-			if !pullingImage {
-				// Pod is past image pulling (container creating/starting/running).
-				// Start the startup timeout from the MCP container's Kubernetes start time
-				// when available so a long watch interval doesn't grant extra startup time.
-				if mcpContainerStartedAt != nil {
-					startupDeadline = mcpContainerStartedAt.Add(timeout)
-				} else if startupDeadline.IsZero() {
-					startupDeadline = time.Now().Add(timeout)
-				}
-				if time.Now().After(startupDeadline) {
-					return false, fmt.Errorf("%w: container startup exceeded %s timeout", ErrHealthCheckTimeout, timeout)
-				}
-			}
-
-			return false, nil // Retryable state, keep waiting
-		},
-		// wait.For will default to 2m timeout. Here we combine the configured timeouts + some wiggle room
-		wait.Option{Timeout: imagePullTimeout + timeout + 30*time.Second},
+	var (
+		err     error
+		lastErr error
 	)
-	if err != nil {
-		return "", err
+	for attempt := range maxDeploymentWatchRetries {
+		remaining := time.Until(watchDeadline)
+		if remaining <= 0 {
+			if lastErr != nil {
+				return "", fmt.Errorf("%w: timeout waiting for deployment readiness: %v", ErrHealthCheckTimeout, lastErr)
+			}
+			return "", fmt.Errorf("%w: timeout waiting for deployment readiness", ErrHealthCheckTimeout)
+		}
+
+		_, err := wait.For(ctx, k.client, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: id, Namespace: k.mcpNamespace}},
+			func(dep *appsv1.Deployment) (bool, error) {
+				if dep.Generation == dep.Status.ObservedGeneration && dep.Status.UpdatedReplicas == 1 && dep.Status.ReadyReplicas == 1 && dep.Status.AvailableReplicas == 1 {
+					return true, nil
+				}
+
+				// Deployment not ready yet — check pod status for early failure detection.
+				var pods corev1.PodList
+				if listErr := k.client.List(ctx, &pods, &kclient.ListOptions{
+					Namespace: k.mcpNamespace,
+					LabelSelector: labels.SelectorFromSet(map[string]string{
+						"app": id,
+					}),
+				}); listErr != nil {
+					olog.Warnf("failed to list MCP pods for status check: id=%s error=%v", id, listErr)
+					return false, nil // Keep waiting; listing failure is transient
+				}
+
+				if len(pods.Items) == 0 {
+					return false, nil // No pods yet, keep waiting
+				}
+
+				newestPod, err := getNewestPod(pods.Items)
+				if err != nil {
+					return false, nil // Keep waiting
+				}
+
+				pullingImage, mcpContainerStartedAt, podErr := analyzePodStatus(newestPod)
+				if podErr != nil {
+					// Permanent failure — abort immediately
+					olog.Warnf("pod in non-retryable state: id=%s error=%v", id, podErr)
+					return false, podErr
+				}
+
+				if pullingImage && time.Now().After(imagePullDeadline) {
+					return false, fmt.Errorf("%w: image pull exceeded %s timeout", ErrHealthCheckTimeout, imagePullTimeout)
+				}
+				if !pullingImage {
+					// Pod is past image pulling (container creating/starting/running).
+					// Start the startup timeout from the MCP container's Kubernetes start time
+					// when available so a long watch interval doesn't grant extra startup time.
+					if mcpContainerStartedAt != nil {
+						startupDeadline = mcpContainerStartedAt.Add(timeout)
+					} else if startupDeadline.IsZero() {
+						startupDeadline = time.Now().Add(timeout)
+					}
+					if time.Now().After(startupDeadline) {
+						return false, fmt.Errorf("%w: container startup exceeded %s timeout", ErrHealthCheckTimeout, timeout)
+					}
+				}
+
+				return false, nil // Retryable state, keep waiting
+			},
+			wait.Option{Timeout: remaining},
+		)
+		if err == nil {
+			break
+		}
+
+		// Errors from pod analysis or explicit deadlines are authoritative; retry only watch-level failures.
+		if errors.Is(err, ErrHealthCheckTimeout) ||
+			errors.Is(err, ErrPodCrashLoopBackOff) ||
+			errors.Is(err, ErrImagePullFailed) ||
+			errors.Is(err, ErrPodSchedulingFailed) ||
+			errors.Is(err, ErrPodConfigurationFailed) ||
+			errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) {
+			return "", err
+		}
+
+		lastErr = err
+		olog.Debugf("retrying MCP deployment watch after error: id=%s attempt=%d maxAttempts=%d error=%v", id, attempt+1, maxDeploymentWatchRetries, err)
+		if attempt == maxDeploymentWatchRetries-1 {
+			return "", fmt.Errorf("%w after %d watch retries: %v", ErrHealthCheckTimeout, maxDeploymentWatchRetries, lastErr)
+		}
 	}
 
 	// Deployment is ready. Get the pod name that is currently running.

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -38,10 +38,7 @@ import (
 
 var olog = logger.Package()
 
-const (
-	maxDeploymentWatchRetries = 5
-	maxPodRestartsDuringSetup = 3
-)
+const maxDeploymentWatchRetries = 5
 
 type kubernetesBackend struct {
 	clientset                     *kubernetes.Clientset
@@ -916,18 +913,29 @@ func getNewestPod(pods []corev1.Pod) (*corev1.Pod, error) {
 	return newest, nil
 }
 
-// analyzePodStatus examines a pod's status to detect non-recoverable failures.
-// A non-nil error means the pod is in a state we should not retry.
-func analyzePodStatus(pod *corev1.Pod) error {
+// analyzePodStatus examines a pod's status to determine if we should retry waiting for it
+// or if we should fail immediately. Returns (shouldRetry, error).
+func analyzePodStatus(pod *corev1.Pod) (bool, error) {
 	// Check pod phase first
 	switch pod.Status.Phase {
 	case corev1.PodFailed:
-		return fmt.Errorf("%w: pod is in Failed phase: %s", ErrHealthCheckTimeout, pod.Status.Message)
+		return false, fmt.Errorf("%w: pod is in Failed phase: %s", ErrHealthCheckTimeout, pod.Status.Message)
 	case corev1.PodSucceeded:
 		// This shouldn't happen for a long-running deployment, but if it does, it's an error
-		return fmt.Errorf("%w: pod succeeded and exited", ErrHealthCheckTimeout)
+		return false, fmt.Errorf("%w: pod succeeded and exited", ErrHealthCheckTimeout)
 	case corev1.PodUnknown:
-		return fmt.Errorf("%w: pod is in Unknown phase", ErrHealthCheckTimeout)
+		return false, fmt.Errorf("%w: pod is in Unknown phase", ErrHealthCheckTimeout)
+	}
+
+	// Check pod conditions for scheduling issues
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse {
+			// Pod can't be scheduled - check if it's a transient issue
+			if cond.Reason == corev1.PodReasonUnschedulable {
+				// Unschedulable could be transient (e.g., waiting for autoscaler)
+				return true, fmt.Errorf("%w: pod unschedulable: %s", ErrPodSchedulingFailed, cond.Message)
+			}
+		}
 	}
 
 	for _, cs := range pod.Status.ContainerStatuses {
@@ -935,26 +943,32 @@ func analyzePodStatus(pod *corev1.Pod) error {
 		if cs.State.Waiting != nil {
 			waiting := cs.State.Waiting
 			switch waiting.Reason {
-			// Retryable states.
-			case "ContainerCreating", "ImagePullBackOff", "ErrImagePull":
-				continue
+			// Transient/recoverable states - should retry
+			case "ContainerCreating", "PodInitializing":
+				return true, fmt.Errorf("container %s is %s", cs.Name, waiting.Reason)
+
+			// Image pull states - need to check if it's temporary or permanent
+			case "ImagePullBackOff", "ErrImagePull":
+				// ImagePullBackOff can be transient (network issues) but also permanent (bad image)
+				// We'll treat it as retryable for now, but it will eventually hit max retries
+				return true, fmt.Errorf("%w: container %s: %s - %s", ErrImagePullFailed, cs.Name, waiting.Reason, waiting.Message)
 
 			// Permanent failures - should not retry
 			case "CrashLoopBackOff":
-				return fmt.Errorf("%w: container %s is in CrashLoopBackOff: %s", ErrPodCrashLoopBackOff, cs.Name, waiting.Message)
+				return false, fmt.Errorf("%w: container %s is in CrashLoopBackOff: %s", ErrPodCrashLoopBackOff, cs.Name, waiting.Message)
 			case "InvalidImageName":
-				return fmt.Errorf("%w: container %s has invalid image name: %s", ErrImagePullFailed, cs.Name, waiting.Message)
+				return false, fmt.Errorf("%w: container %s has invalid image name: %s", ErrImagePullFailed, cs.Name, waiting.Message)
 			case "CreateContainerConfigError", "CreateContainerError":
-				return fmt.Errorf("%w: container %s failed to create: %s - %s", ErrPodConfigurationFailed, cs.Name, waiting.Reason, waiting.Message)
+				return false, fmt.Errorf("%w: container %s failed to create: %s - %s", ErrPodConfigurationFailed, cs.Name, waiting.Reason, waiting.Message)
 			case "RunContainerError":
-				return fmt.Errorf("%w: container %s failed to run: %s", ErrPodConfigurationFailed, cs.Name, waiting.Message)
+				return false, fmt.Errorf("%w: container %s failed to run: %s", ErrPodConfigurationFailed, cs.Name, waiting.Message)
 			}
 		}
 
 		// Check if container terminated with errors and has high restart count
 		if cs.State.Terminated != nil && cs.State.Terminated.ExitCode != 0 {
-			if cs.RestartCount > maxPodRestartsDuringSetup {
-				return fmt.Errorf("%w: container %s repeatedly crashing (exit code %d, %d restarts): %s",
+			if cs.RestartCount > 3 {
+				return false, fmt.Errorf("%w: container %s repeatedly crashing (exit code %d, %d restarts): %s",
 					ErrPodCrashLoopBackOff, cs.Name, cs.State.Terminated.ExitCode, cs.RestartCount, cs.State.Terminated.Reason)
 			}
 		}
@@ -962,10 +976,11 @@ func analyzePodStatus(pod *corev1.Pod) error {
 
 	// Check if pod is being evicted
 	if pod.Status.Reason == "Evicted" {
-		return fmt.Errorf("%w: pod was evicted: %s", ErrPodSchedulingFailed, pod.Status.Message)
+		return false, fmt.Errorf("%w: pod was evicted: %s", ErrPodSchedulingFailed, pod.Status.Message)
 	}
 
-	return nil
+	// Default: pod is in Pending or Running but not ready yet - should retry
+	return true, fmt.Errorf("pod in phase %s, waiting for containers to be ready", pod.Status.Phase)
 }
 
 func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id string, server ServerConfig, previousPodName string) (string, error) {
@@ -1008,10 +1023,10 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 					return false, nil // Keep waiting
 				}
 
-				podErr := analyzePodStatus(newestPod)
-				if podErr != nil {
-					// Permanent failure — abort immediately
-					olog.Warnf("pod in non-retryable state: id=%s error=%v", id, podErr)
+				shouldRetry, podErr := analyzePodStatus(newestPod)
+				if !shouldRetry {
+					// Permanent failure - return the error with the appropriate type already wrapped
+					olog.Debugf("pod in non-retryable state: id=%s error=%v attempt=%d", id, podErr, attempt+1)
 					return false, podErr
 				}
 
@@ -1024,13 +1039,15 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 		}
 
 		// Errors from pod analysis or explicit deadlines are authoritative; retry only watch-level failures.
+		if errors.Is(err, context.DeadlineExceeded) {
+			return "", fmt.Errorf("%w: timeout waiting for deployment readiness", ErrHealthCheckTimeout)
+		}
 		if errors.Is(err, ErrHealthCheckTimeout) ||
 			errors.Is(err, ErrPodCrashLoopBackOff) ||
 			errors.Is(err, ErrImagePullFailed) ||
 			errors.Is(err, ErrPodSchedulingFailed) ||
 			errors.Is(err, ErrPodConfigurationFailed) ||
-			errors.Is(err, context.Canceled) ||
-			errors.Is(err, context.DeadlineExceeded) {
+			errors.Is(err, context.Canceled) {
 			return "", err
 		}
 

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -996,12 +996,6 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 					return true, nil
 				}
 
-				select {
-				case <-ctx.Done():
-					return false, ctx.Err()
-				default:
-				}
-
 				// Deployment not ready yet — check pod status for early failure detection.
 				var pods corev1.PodList
 				if listErr := k.client.List(ctx, &pods, &kclient.ListOptions{

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -1047,7 +1047,7 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 
 				if pullingImage {
 					if time.Now().After(imagePullDeadline) {
-						return false, fmt.Errorf("%w: image pull exceeded %s timeout", ErrHealthCheckTimeout, imagePullTimeout)
+						return false, fmt.Errorf("%w: pod scheduling and image pull exceeded %s timeout", ErrHealthCheckTimeout, imagePullTimeout)
 					}
 					return false, nil // Retryable state, keep waiting
 				}

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -442,7 +442,7 @@ func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 	}
 
 	_, err := k.updatedMCPPodName(context.Background(), "http://mcp.example.com", "test-server", ServerConfig{
-		Runtime:               types.RuntimeRemote,
+		Runtime:        types.RuntimeRemote,
 		StartupTimeout: time.Second,
 	}, "")
 	if !errors.Is(err, ErrHealthCheckTimeout) {

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -443,7 +443,7 @@ func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 
 	_, err := k.updatedMCPPodName(context.Background(), "http://mcp.example.com", "test-server", ServerConfig{
 		Runtime:               types.RuntimeRemote,
-		StartupTimeoutSeconds: 1,
+		StartupTimeout: time.Second,
 	}, "")
 	if !errors.Is(err, ErrHealthCheckTimeout) {
 		t.Fatalf("updatedMCPPodName() error = %v, want %v", err, ErrHealthCheckTimeout)

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -2,14 +2,17 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/obot-platform/nah/pkg/name"
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -254,6 +257,185 @@ func TestK8sObjects_ServicePorts(t *testing.T) {
 				t.Fatalf("deployment strategy = %q, want %q", dep.Spec.Strategy.Type, tt.expectedStrategy)
 			}
 		})
+	}
+}
+
+func TestAnalyzePodStatus(t *testing.T) {
+	startedAt := time.Now().Add(-10 * time.Second)
+
+	tests := []struct {
+		name             string
+		pod              corev1.Pod
+		wantPullingImage bool
+		wantStartedAt    *time.Time
+		wantErr          error
+		wantErrContains  string
+	}{
+		{
+			name: "running mcp container returns start time",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "mcp",
+						State: corev1.ContainerState{
+							Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(startedAt)},
+						},
+					}},
+				},
+			},
+			wantStartedAt: &startedAt,
+		},
+		{
+			name: "image pull backoff is retryable image pull",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "mcp",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+						},
+					}},
+				},
+			},
+			wantPullingImage: true,
+		},
+		{
+			name: "crash loop fails permanently",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name: "mcp",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff", Message: "back-off restarting failed container"},
+						},
+					}},
+				},
+			},
+			wantErr:         ErrPodCrashLoopBackOff,
+			wantErrContains: "back-off restarting failed container",
+		},
+		{
+			name: "failed phase fails health check timeout",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase:   corev1.PodFailed,
+					Message: "pod failed",
+				},
+			},
+			wantErr:         ErrHealthCheckTimeout,
+			wantErrContains: "pod failed",
+		},
+		{
+			name: "repeated terminated errors fail crash loop",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{{
+						Name:         "mcp",
+						RestartCount: maxPodRestartsDuringSetup + 1,
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+						},
+					}},
+				},
+			},
+			wantErr:         ErrPodCrashLoopBackOff,
+			wantErrContains: "repeatedly crashing",
+		},
+		{
+			name: "evicted pod fails scheduling",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase:   corev1.PodPending,
+					Reason:  "Evicted",
+					Message: "node had disk pressure",
+				},
+			},
+			wantErr:         ErrPodSchedulingFailed,
+			wantErrContains: "node had disk pressure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pullingImage, startedAt, err := analyzePodStatus(&tt.pod)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("analyzePodStatus() error = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Fatalf("analyzePodStatus() error = %q, want to contain %q", err, tt.wantErrContains)
+			}
+			if pullingImage != tt.wantPullingImage {
+				t.Fatalf("analyzePodStatus() pullingImage = %v, want %v", pullingImage, tt.wantPullingImage)
+			}
+			if tt.wantStartedAt == nil {
+				if startedAt != nil {
+					t.Fatalf("analyzePodStatus() startedAt = %v, want nil", startedAt)
+				}
+			} else if startedAt == nil || !startedAt.Equal(*tt.wantStartedAt) {
+				t.Fatalf("analyzePodStatus() startedAt = %v, want %v", startedAt, *tt.wantStartedAt)
+			}
+		})
+	}
+}
+
+func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(appsv1) error = %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(corev1) error = %v", err)
+	}
+
+	now := time.Now()
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-server",
+			Namespace: "obot-mcp",
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			UpdatedReplicas:    1,
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-server-pod",
+			Namespace:         "obot-mcp",
+			CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
+			Labels: map[string]string{
+				"app": "test-server",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "mcp",
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(now.Add(-2 * time.Second))},
+				},
+			}},
+		},
+	}
+
+	k := &kubernetesBackend{
+		client:       fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, pod).Build(),
+		mcpNamespace: "obot-mcp",
+	}
+
+	_, err := k.updatedMCPPodName(context.Background(), "http://mcp.example.com", "test-server", ServerConfig{
+		Runtime:               types.RuntimeRemote,
+		StartupTimeoutSeconds: 1,
+	}, "")
+	if !errors.Is(err, ErrHealthCheckTimeout) {
+		t.Fatalf("updatedMCPPodName() error = %v, want %v", err, ErrHealthCheckTimeout)
+	}
+	if !strings.Contains(err.Error(), "container startup exceeded 1s timeout") {
+		t.Fatalf("updatedMCPPodName() error = %q, want startup deadline message", err)
 	}
 }
 

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -264,6 +264,7 @@ func TestAnalyzePodStatus(t *testing.T) {
 	tests := []struct {
 		name            string
 		pod             corev1.Pod
+		wantRetryable   bool
 		wantErr         error
 		wantErrContains string
 	}{
@@ -271,10 +272,12 @@ func TestAnalyzePodStatus(t *testing.T) {
 			name: "running mcp container remains retryable",
 			pod: corev1.Pod{
 				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
+					Phase:             corev1.PodRunning,
 					ContainerStatuses: []corev1.ContainerStatus{{Name: "mcp"}},
 				},
 			},
+			wantRetryable:   true,
+			wantErrContains: "pod in phase Running",
 		},
 		{
 			name: "image pull backoff is retryable image pull",
@@ -289,6 +292,9 @@ func TestAnalyzePodStatus(t *testing.T) {
 					}},
 				},
 			},
+			wantRetryable:   true,
+			wantErr:         ErrImagePullFailed,
+			wantErrContains: "ImagePullBackOff",
 		},
 		{
 			name: "unschedulable pod remains retryable under pull/scheduling budget",
@@ -302,6 +308,9 @@ func TestAnalyzePodStatus(t *testing.T) {
 					}},
 				},
 			},
+			wantRetryable:   true,
+			wantErr:         ErrPodSchedulingFailed,
+			wantErrContains: "unschedulable",
 		},
 		{
 			name: "crash loop fails permanently",
@@ -337,7 +346,7 @@ func TestAnalyzePodStatus(t *testing.T) {
 					Phase: corev1.PodRunning,
 					ContainerStatuses: []corev1.ContainerStatus{{
 						Name:         "mcp",
-						RestartCount: maxPodRestartsDuringSetup + 1,
+						RestartCount: 4,
 						State: corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
 						},
@@ -363,9 +372,16 @@ func TestAnalyzePodStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := analyzePodStatus(&tt.pod)
-			if !errors.Is(err, tt.wantErr) {
-				t.Fatalf("analyzePodStatus() error = %v, want %v", err, tt.wantErr)
+			retryable, err := analyzePodStatus(&tt.pod)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("analyzePodStatus() error = %v, want %v", err, tt.wantErr)
+				}
+			} else if tt.wantErrContains == "" && err != nil {
+				t.Fatalf("analyzePodStatus() error = %v, want nil", err)
+			}
+			if retryable != tt.wantRetryable {
+				t.Fatalf("analyzePodStatus() retryable = %v, want %v", retryable, tt.wantRetryable)
 			}
 			if tt.wantErrContains != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErrContains)) {
 				t.Fatalf("analyzePodStatus() error = %q, want to contain %q", err, tt.wantErrContains)
@@ -419,7 +435,10 @@ func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 		mcpNamespace: "obot-mcp",
 	}
 
-	_, err := k.updatedMCPPodName(context.Background(), "http://mcp.example.com", "test-server", ServerConfig{
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := k.updatedMCPPodName(ctx, "http://mcp.example.com", "test-server", ServerConfig{
 		Runtime:        types.RuntimeRemote,
 		StartupTimeout: time.Second,
 	}, "")

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -261,30 +261,20 @@ func TestK8sObjects_ServicePorts(t *testing.T) {
 }
 
 func TestAnalyzePodStatus(t *testing.T) {
-	startedAt := time.Now().Add(-10 * time.Second)
-
 	tests := []struct {
-		name             string
-		pod              corev1.Pod
-		wantPullingImage bool
-		wantStartedAt    *time.Time
-		wantErr          error
-		wantErrContains  string
+		name            string
+		pod             corev1.Pod
+		wantErr         error
+		wantErrContains string
 	}{
 		{
-			name: "running mcp container returns start time",
+			name: "running mcp container remains retryable",
 			pod: corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
-					ContainerStatuses: []corev1.ContainerStatus{{
-						Name: "mcp",
-						State: corev1.ContainerState{
-							Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(startedAt)},
-						},
-					}},
+					ContainerStatuses: []corev1.ContainerStatus{{Name: "mcp"}},
 				},
 			},
-			wantStartedAt: &startedAt,
 		},
 		{
 			name: "image pull backoff is retryable image pull",
@@ -299,7 +289,6 @@ func TestAnalyzePodStatus(t *testing.T) {
 					}},
 				},
 			},
-			wantPullingImage: true,
 		},
 		{
 			name: "unschedulable pod remains retryable under pull/scheduling budget",
@@ -313,7 +302,6 @@ func TestAnalyzePodStatus(t *testing.T) {
 					}},
 				},
 			},
-			wantPullingImage: true,
 		},
 		{
 			name: "crash loop fails permanently",
@@ -375,22 +363,12 @@ func TestAnalyzePodStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pullingImage, startedAt, err := analyzePodStatus(&tt.pod)
+			err := analyzePodStatus(&tt.pod)
 			if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("analyzePodStatus() error = %v, want %v", err, tt.wantErr)
 			}
-			if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+			if tt.wantErrContains != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErrContains)) {
 				t.Fatalf("analyzePodStatus() error = %q, want to contain %q", err, tt.wantErrContains)
-			}
-			if pullingImage != tt.wantPullingImage {
-				t.Fatalf("analyzePodStatus() pullingImage = %v, want %v", pullingImage, tt.wantPullingImage)
-			}
-			if tt.wantStartedAt == nil {
-				if startedAt != nil {
-					t.Fatalf("analyzePodStatus() startedAt = %v, want nil", startedAt)
-				}
-			} else if startedAt == nil || !startedAt.Equal(*tt.wantStartedAt) {
-				t.Fatalf("analyzePodStatus() startedAt = %v, want %v", startedAt, *tt.wantStartedAt)
 			}
 		})
 	}
@@ -448,8 +426,8 @@ func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 	if !errors.Is(err, ErrHealthCheckTimeout) {
 		t.Fatalf("updatedMCPPodName() error = %v, want %v", err, ErrHealthCheckTimeout)
 	}
-	if !strings.Contains(err.Error(), "container startup exceeded 1s timeout") {
-		t.Fatalf("updatedMCPPodName() error = %q, want startup deadline message", err)
+	if !strings.Contains(err.Error(), "timeout waiting for deployment readiness") {
+		t.Fatalf("updatedMCPPodName() error = %q, want deployment timeout message", err)
 	}
 }
 

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -302,6 +302,20 @@ func TestAnalyzePodStatus(t *testing.T) {
 			wantPullingImage: true,
 		},
 		{
+			name: "unschedulable pod remains retryable under pull/scheduling budget",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+						Reason: corev1.PodReasonUnschedulable,
+					}},
+				},
+			},
+			wantPullingImage: true,
+		},
+		{
 			name: "crash loop fails permanently",
 			pod: corev1.Pod{
 				Status: corev1.PodStatus{

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -396,7 +396,7 @@ type fakeWithWatch struct {
 	watcher       *watch.FakeWatcher
 }
 
-func (f *fakeWithWatch) Watch(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+func (f *fakeWithWatch) Watch(_ context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
 	return f.watcher, nil
 }
 

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -15,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -390,6 +392,15 @@ func TestAnalyzePodStatus(t *testing.T) {
 	}
 }
 
+type fakeWithWatch struct {
+	client.Client // controller-runtime fake for Get/List/Create etc.
+	watcher       *watch.FakeWatcher
+}
+
+func (f *fakeWithWatch) Watch(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	return f.watcher, nil
+}
+
 func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := appsv1.AddToScheme(scheme); err != nil {
@@ -430,8 +441,22 @@ func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 		},
 	}
 
+	watcher := watch.NewFake()
+
+	go func() {
+		watcher.Add(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "obot-mcp"},
+		})
+		watcher.Stop()
+	}()
+
+	client := &fakeWithWatch{
+		Client:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, pod).Build(),
+		watcher: watcher,
+	}
+
 	k := &kubernetesBackend{
-		client:       fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, pod).Build(),
+		client:       client,
 		mcpNamespace: "obot-mcp",
 	}
 
@@ -445,7 +470,7 @@ func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 	if !errors.Is(err, ErrHealthCheckTimeout) {
 		t.Fatalf("updatedMCPPodName() error = %v, want %v", err, ErrHealthCheckTimeout)
 	}
-	if !strings.Contains(err.Error(), "timeout waiting for deployment readiness") {
+	if err.Error() != "timed out waiting for MCP server to be ready after 5 watch retries: timeout waiting for Deployment test-server to meet condition" {
 		t.Fatalf("updatedMCPPodName() error = %q, want deployment timeout message", err)
 	}
 }

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -491,7 +490,7 @@ func newTestKubernetesBackend(t *testing.T) *kubernetesBackend {
 	}
 }
 
-func findSecret(t *testing.T, objs []kclient.Object, secretName string) *corev1.Secret {
+func findSecret(t *testing.T, objs []client.Object, secretName string) *corev1.Secret {
 	t.Helper()
 
 	for _, obj := range objs {
@@ -505,7 +504,7 @@ func findSecret(t *testing.T, objs []kclient.Object, secretName string) *corev1.
 	return nil
 }
 
-func findService(t *testing.T, objs []kclient.Object, serviceName string) *corev1.Service {
+func findService(t *testing.T, objs []client.Object, serviceName string) *corev1.Service {
 	t.Helper()
 
 	for _, obj := range objs {
@@ -519,7 +518,7 @@ func findService(t *testing.T, objs []kclient.Object, serviceName string) *corev
 	return nil
 }
 
-func findDeployment(t *testing.T, objs []kclient.Object, deploymentName string) *appsv1.Deployment {
+func findDeployment(t *testing.T, objs []client.Object, deploymentName string) *appsv1.Deployment {
 	t.Helper()
 
 	for _, obj := range objs {

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -356,6 +356,9 @@ func (sm *SessionManager) ensureDeployment(ctx context.Context, server ServerCon
 		}
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, server.StartupTimeout)
+	defer cancel()
+
 	return sm.backend.ensureServerDeployment(ctx, server, webhooks)
 }
 

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/nanobot-ai/nanobot/pkg/mcp"
@@ -17,6 +18,9 @@ func (sm *SessionManager) ListTools(ctx context.Context, serverConfig ServerConf
 	if err != nil {
 		return nil, err
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
 
 	resp, err := client.ListTools(ctx)
 	if err != nil {

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -15,7 +15,12 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 )
 
-const MaxMCPServerStartupTimeout = 10 * time.Minute
+const (
+	// MaxMCPServerStartupTimeout is the maximum value allowed to be used in ServerConfig.StartupTimeout
+	MaxMCPServerStartupTimeout = 10 * time.Minute
+	// defaultStartupTimeout is the default value used when ServerConfig.StartupTimeout is not set
+	defaultStartupTimeout = 60 * time.Second
+)
 
 type GlobalTokenStore interface {
 	ForUserAndMCP(userID, mcpID string) nmcp.TokenStorage
@@ -93,8 +98,6 @@ type ComponentServer struct {
 	Tools      []types.ToolOverride `json:"tools"`
 	ToolPrefix string               `json:"toolPrefix"`
 }
-
-const defaultStartupTimeout = 60 * time.Second
 
 var envVarRegex = regexp.MustCompile(`\${([^}]+)}`)
 

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -15,6 +15,8 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 )
 
+const MaxMCPServerStartupTimeout = 10 * time.Minute
+
 type GlobalTokenStore interface {
 	ForUserAndMCP(userID, mcpID string) nmcp.TokenStorage
 }
@@ -319,6 +321,9 @@ func ServerToServerConfig(mcpServer v1.MCPServer, audiences []string, issuer, us
 	if startupTimeout == 0 {
 		startupTimeout = defaultStartupTimeout
 	}
+	if startupTimeout > MaxMCPServerStartupTimeout {
+		return ServerConfig{}, nil, fmt.Errorf("input %d exceeds the max of %s", mcpServer.Spec.Manifest.StartupTimeoutSeconds, MaxMCPServerStartupTimeout)
+	}
 
 	serverConfig := ServerConfig{
 		Env:                       make([]string, 0, len(mcpServer.Spec.Manifest.Env)),
@@ -437,6 +442,9 @@ func SystemServerToServerConfig(systemServer v1.SystemMCPServer, audiences []str
 	startupTimeout := time.Duration(systemServer.Spec.Manifest.StartupTimeoutSeconds) * time.Second
 	if startupTimeout == 0 {
 		startupTimeout = defaultStartupTimeout
+	}
+	if startupTimeout > MaxMCPServerStartupTimeout {
+		return ServerConfig{}, nil, fmt.Errorf("input %d exceeds the max of %s", systemServer.Spec.Manifest.StartupTimeoutSeconds, MaxMCPServerStartupTimeout)
 	}
 
 	serverConfig := ServerConfig{

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	nmcp "github.com/nanobot-ai/nanobot/pkg/mcp"
@@ -75,7 +76,7 @@ type ServerConfig struct {
 	AuditLogEndpoint string `json:"auditLogEndpoint"`
 	AuditLogMetadata string `json:"auditLogMetadata"`
 
-	StartupTimeoutSeconds int `json:"startupTimeoutSeconds,omitempty"`
+	StartupTimeout time.Duration `json:"startupTimeout,omitempty"`
 }
 
 type File struct {
@@ -90,6 +91,8 @@ type ComponentServer struct {
 	Tools      []types.ToolOverride `json:"tools"`
 	ToolPrefix string               `json:"toolPrefix"`
 }
+
+const defaultStartupTimeout = 60 * time.Second
 
 var envVarRegex = regexp.MustCompile(`\${([^}]+)}`)
 
@@ -312,6 +315,11 @@ func ServerToServerConfig(mcpServer v1.MCPServer, audiences []string, issuer, us
 		powerUserWorkspaceID = mcpCatalogName
 	}
 
+	startupTimeout := time.Duration(mcpServer.Spec.Manifest.StartupTimeoutSeconds) * time.Second
+	if startupTimeout == 0 {
+		startupTimeout = defaultStartupTimeout
+	}
+
 	serverConfig := ServerConfig{
 		Env:                       make([]string, 0, len(mcpServer.Spec.Manifest.Env)),
 		UserID:                    userID,
@@ -332,7 +340,7 @@ func ServerToServerConfig(mcpServer v1.MCPServer, audiences []string, issuer, us
 		AuthorizeEndpoint:         fmt.Sprintf("%s/oauth/authorize", issuer),
 		ComponentMCPServer:        mcpServer.Spec.CompositeName != "",
 		NanobotAgentName:          mcpServer.Spec.NanobotAgentID,
-		StartupTimeoutSeconds:     mcpServer.Spec.Manifest.StartupTimeoutSeconds,
+		StartupTimeout:            startupTimeout,
 	}
 
 	if mcpServer.Spec.CompositeName == "" {
@@ -426,6 +434,11 @@ func SystemServerToServerConfig(systemServer v1.SystemMCPServer, audiences []str
 		displayName = systemServer.Name
 	}
 
+	startupTimeout := time.Duration(systemServer.Spec.Manifest.StartupTimeoutSeconds) * time.Second
+	if startupTimeout == 0 {
+		startupTimeout = defaultStartupTimeout
+	}
+
 	serverConfig := ServerConfig{
 		Env:                       make([]string, 0, len(systemServer.Spec.Manifest.Env)),
 		MCPServerNamespace:        systemServer.Namespace,
@@ -444,7 +457,7 @@ func SystemServerToServerConfig(systemServer v1.SystemMCPServer, audiences []str
 		AuditLogToken:             secretsCred["AUDIT_LOG_TOKEN"],
 		AuditLogMetadata:          fmt.Sprintf("mcpID=%s,mcpServerDisplayName=%s", systemServer.Name, displayName),
 		SystemMCPServer:           true,
-		StartupTimeoutSeconds:     systemServer.Spec.Manifest.StartupTimeoutSeconds,
+		StartupTimeout:            startupTimeout,
 	}
 
 	var missingRequiredNames []string

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -74,6 +74,8 @@ type ServerConfig struct {
 	AuditLogToken    string `json:"auditLogToken"`
 	AuditLogEndpoint string `json:"auditLogEndpoint"`
 	AuditLogMetadata string `json:"auditLogMetadata"`
+
+	StartupTimeoutSeconds int `json:"startupTimeoutSeconds,omitempty"`
 }
 
 type File struct {
@@ -330,6 +332,7 @@ func ServerToServerConfig(mcpServer v1.MCPServer, audiences []string, issuer, us
 		AuthorizeEndpoint:         fmt.Sprintf("%s/oauth/authorize", issuer),
 		ComponentMCPServer:        mcpServer.Spec.CompositeName != "",
 		NanobotAgentName:          mcpServer.Spec.NanobotAgentID,
+		StartupTimeoutSeconds:     mcpServer.Spec.Manifest.StartupTimeoutSeconds,
 	}
 
 	if mcpServer.Spec.CompositeName == "" {
@@ -441,6 +444,7 @@ func SystemServerToServerConfig(systemServer v1.SystemMCPServer, audiences []str
 		AuditLogToken:             secretsCred["AUDIT_LOG_TOKEN"],
 		AuditLogMetadata:          fmt.Sprintf("mcpID=%s,mcpServerDisplayName=%s", systemServer.Name, displayName),
 		SystemMCPServer:           true,
+		StartupTimeoutSeconds:     systemServer.Spec.Manifest.StartupTimeoutSeconds,
 	}
 
 	var missingRequiredNames []string

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -323,8 +323,7 @@ func ServerToServerConfig(mcpServer v1.MCPServer, audiences []string, issuer, us
 	startupTimeout := time.Duration(mcpServer.Spec.Manifest.StartupTimeoutSeconds) * time.Second
 	if startupTimeout == 0 {
 		startupTimeout = defaultStartupTimeout
-	}
-	if startupTimeout > MaxMCPServerStartupTimeout {
+	} else if startupTimeout > MaxMCPServerStartupTimeout {
 		return ServerConfig{}, nil, fmt.Errorf("input %d exceeds the max of %s", mcpServer.Spec.Manifest.StartupTimeoutSeconds, MaxMCPServerStartupTimeout)
 	}
 
@@ -445,8 +444,7 @@ func SystemServerToServerConfig(systemServer v1.SystemMCPServer, audiences []str
 	startupTimeout := time.Duration(systemServer.Spec.Manifest.StartupTimeoutSeconds) * time.Second
 	if startupTimeout == 0 {
 		startupTimeout = defaultStartupTimeout
-	}
-	if startupTimeout > MaxMCPServerStartupTimeout {
+	} else if startupTimeout > MaxMCPServerStartupTimeout {
 		return ServerConfig{}, nil, fmt.Errorf("input %d exceeds the max of %s", systemServer.Spec.Manifest.StartupTimeoutSeconds, MaxMCPServerStartupTimeout)
 	}
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -5049,8 +5049,9 @@ func schema_obot_platform_obot_apiclient_types_MCPServerCatalogEntryManifest(ref
 					},
 					"startupTimeoutSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "StartupTimeout configures the timeout to start and connect to an MCP Server. When unset, it defaults to 60s. The maximum allowed value is 600s (10 minutes). Attempting to set a higher value will cause an error.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 				},

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -5047,6 +5047,12 @@ func schema_obot_platform_obot_apiclient_types_MCPServerCatalogEntryManifest(ref
 							},
 						},
 					},
+					"startupTimeoutSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 				},
 				Required: []string{"name", "shortDescription", "description", "icon", "runtime"},
 			},
@@ -5497,6 +5503,12 @@ func schema_obot_platform_obot_apiclient_types_MCPServerManifest(ref common.Refe
 						},
 					},
 					"idleShutdownIntervalHours": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
+					"startupTimeoutSeconds": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},
 							Format: "int32",
@@ -12173,6 +12185,12 @@ func schema_obot_platform_obot_apiclient_types_SystemMCPServerManifest(ref commo
 									},
 								},
 							},
+						},
+					},
+					"startupTimeoutSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 				},

--- a/pkg/validation/mcpvalidators.go
+++ b/pkg/validation/mcpvalidators.go
@@ -969,6 +969,10 @@ func ValidateServerManifest(manifest types.MCPServerManifest, isMultiUser bool) 
 		}
 	}
 
+	if err := validateStartupTimeout(manifest.Runtime, manifest.StartupTimeoutSeconds); err != nil {
+		return err
+	}
+
 	if validator, ok := getRuntimeValidators()[manifest.Runtime]; ok {
 		return validator.ValidateConfig(manifest)
 	}
@@ -981,6 +985,10 @@ func ValidateServerManifest(manifest types.MCPServerManifest, isMultiUser bool) 
 }
 
 func ValidateCatalogEntryManifest(manifest types.MCPServerCatalogEntryManifest) error {
+	if err := validateStartupTimeout(manifest.Runtime, manifest.StartupTimeoutSeconds); err != nil {
+		return err
+	}
+
 	if validator, ok := getRuntimeValidators()[manifest.Runtime]; ok {
 		return validator.ValidateCatalogConfig(manifest)
 	}
@@ -1028,6 +1036,10 @@ func ValidateSystemMCPServerCatalogEntryManifest(manifest types.SystemMCPServerC
 }
 
 func ValidateSystemMCPServerManifest(manifest types.SystemMCPServerManifest) error {
+	if err := validateStartupTimeout(manifest.Runtime, manifest.StartupTimeoutSeconds); err != nil {
+		return err
+	}
+
 	if validator, ok := getRuntimeValidators()[manifest.Runtime]; ok {
 		return validator.ValidateSystemConfig(manifest)
 	}
@@ -1037,4 +1049,16 @@ func ValidateSystemMCPServerManifest(manifest types.SystemMCPServerManifest) err
 		Field:   "runtime",
 		Message: "unsupported runtime",
 	}
+}
+
+func validateStartupTimeout(runtime types.Runtime, startupTimeoutSeconds int) error {
+	if startupTimeoutSeconds < 0 {
+		return types.RuntimeValidationError{
+			Runtime: runtime,
+			Field:   "startupTimeoutSeconds",
+			Message: "must be greater than or equal to 0",
+		}
+	}
+
+	return nil
 }

--- a/pkg/validation/mcpvalidators.go
+++ b/pkg/validation/mcpvalidators.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/mcp"
 )
 
 var (
@@ -1057,6 +1058,13 @@ func validateStartupTimeout(runtime types.Runtime, startupTimeoutSeconds int) er
 			Runtime: runtime,
 			Field:   "startupTimeoutSeconds",
 			Message: "must be greater than or equal to 0",
+		}
+	}
+	if startupTimeoutSeconds > int(mcp.MaxMCPServerStartupTimeout.Seconds()) {
+		return types.RuntimeValidationError{
+			Runtime: runtime,
+			Field:   "startupTimeoutSeconds",
+			Message: fmt.Sprintf("must be less than %d", int(mcp.MaxMCPServerStartupTimeout.Seconds())),
 		}
 	}
 

--- a/pkg/validation/mcpvalidators_test.go
+++ b/pkg/validation/mcpvalidators_test.go
@@ -1644,7 +1644,7 @@ func TestValidateManifestStartupTimeoutNonNegative(t *testing.T) {
 			RemoteConfig: &types.RemoteRuntimeConfig{
 				URL: "https://example.com/mcp",
 			},
-		})
+		}, false)
 
 		require.Equal(t, types.RuntimeValidationError{
 			Runtime: types.RuntimeRemote,
@@ -1677,7 +1677,7 @@ func TestValidateManifestStartupTimeoutNonNegative(t *testing.T) {
 			RemoteConfig: &types.RemoteRuntimeConfig{
 				URL: "https://example.com/mcp",
 			},
-		})
+		}, false)
 
 		require.Equal(t, types.RuntimeValidationError{
 			Runtime: types.RuntimeRemote,

--- a/pkg/validation/mcpvalidators_test.go
+++ b/pkg/validation/mcpvalidators_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1665,6 +1666,40 @@ func TestValidateManifestStartupTimeoutNonNegative(t *testing.T) {
 			Runtime: types.RuntimeRemote,
 			Field:   "startupTimeoutSeconds",
 			Message: "must be greater than or equal to 0",
+		}, err)
+	})
+
+	t.Run("server manifest rejects startup timeout above maximum", func(t *testing.T) {
+		maxStartupTimeoutSeconds := int(mcp.MaxMCPServerStartupTimeout.Seconds())
+		err := ValidateServerManifest(types.MCPServerManifest{
+			Runtime:               types.RuntimeRemote,
+			StartupTimeoutSeconds: maxStartupTimeoutSeconds + 1,
+			RemoteConfig: &types.RemoteRuntimeConfig{
+				URL: "https://example.com/mcp",
+			},
+		})
+
+		require.Equal(t, types.RuntimeValidationError{
+			Runtime: types.RuntimeRemote,
+			Field:   "startupTimeoutSeconds",
+			Message: fmt.Sprintf("must be less than %d", maxStartupTimeoutSeconds),
+		}, err)
+	})
+
+	t.Run("catalog manifest rejects startup timeout above maximum", func(t *testing.T) {
+		maxStartupTimeoutSeconds := int(mcp.MaxMCPServerStartupTimeout.Seconds())
+		err := ValidateCatalogEntryManifest(types.MCPServerCatalogEntryManifest{
+			Runtime:               types.RuntimeRemote,
+			StartupTimeoutSeconds: maxStartupTimeoutSeconds + 1,
+			RemoteConfig: &types.RemoteCatalogConfig{
+				FixedURL: "https://example.com/mcp",
+			},
+		})
+
+		require.Equal(t, types.RuntimeValidationError{
+			Runtime: types.RuntimeRemote,
+			Field:   "startupTimeoutSeconds",
+			Message: fmt.Sprintf("must be less than %d", maxStartupTimeoutSeconds),
 		}, err)
 	})
 }

--- a/pkg/validation/mcpvalidators_test.go
+++ b/pkg/validation/mcpvalidators_test.go
@@ -1634,3 +1634,37 @@ func TestCompositeValidator_ValidateConfig_ToolPrefixLength(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateManifestStartupTimeoutNonNegative(t *testing.T) {
+	t.Run("server manifest rejects negative startup timeout", func(t *testing.T) {
+		err := ValidateServerManifest(types.MCPServerManifest{
+			Runtime:               types.RuntimeRemote,
+			StartupTimeoutSeconds: -1,
+			RemoteConfig: &types.RemoteRuntimeConfig{
+				URL: "https://example.com/mcp",
+			},
+		})
+
+		require.Equal(t, types.RuntimeValidationError{
+			Runtime: types.RuntimeRemote,
+			Field:   "startupTimeoutSeconds",
+			Message: "must be greater than or equal to 0",
+		}, err)
+	})
+
+	t.Run("catalog manifest rejects negative startup timeout", func(t *testing.T) {
+		err := ValidateCatalogEntryManifest(types.MCPServerCatalogEntryManifest{
+			Runtime:               types.RuntimeRemote,
+			StartupTimeoutSeconds: -1,
+			RemoteConfig: &types.RemoteCatalogConfig{
+				FixedURL: "https://example.com/mcp",
+			},
+		})
+
+		require.Equal(t, types.RuntimeValidationError{
+			Runtime: types.RuntimeRemote,
+			Field:   "startupTimeoutSeconds",
+			Message: "must be greater than or equal to 0",
+		}, err)
+	})
+}

--- a/pkg/validation/systemmcpvalidators_test.go
+++ b/pkg/validation/systemmcpvalidators_test.go
@@ -125,6 +125,18 @@ func TestValidateSystemMCPServerManifest(t *testing.T) {
 			expectError: true,
 			errorField:  "uvxConfig",
 		},
+		{
+			name: "invalid - negative startup timeout",
+			manifest: types.SystemMCPServerManifest{
+				Runtime:               types.RuntimeRemote,
+				StartupTimeoutSeconds: -1,
+				RemoteConfig: &types.RemoteRuntimeConfig{
+					URL: "https://example.com/mcp",
+				},
+			},
+			expectError: true,
+			errorField:  "startupTimeoutSeconds",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/validation/systemmcpvalidators_test.go
+++ b/pkg/validation/systemmcpvalidators_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -130,6 +131,18 @@ func TestValidateSystemMCPServerManifest(t *testing.T) {
 			manifest: types.SystemMCPServerManifest{
 				Runtime:               types.RuntimeRemote,
 				StartupTimeoutSeconds: -1,
+				RemoteConfig: &types.RemoteRuntimeConfig{
+					URL: "https://example.com/mcp",
+				},
+			},
+			expectError: true,
+			errorField:  "startupTimeoutSeconds",
+		},
+		{
+			name: "invalid - startup timeout above maximum",
+			manifest: types.SystemMCPServerManifest{
+				Runtime:               types.RuntimeRemote,
+				StartupTimeoutSeconds: int(mcp.MaxMCPServerStartupTimeout.Seconds()) + 1,
 				RemoteConfig: &types.RemoteRuntimeConfig{
 					URL: "https://example.com/mcp",
 				},

--- a/pkg/wait/waitfor.go
+++ b/pkg/wait/waitfor.go
@@ -108,25 +108,34 @@ func For[T kclient.Object](ctx context.Context, c kclient.WithWatch, obj T, cond
 		}
 	}()
 
-	for event := range w.ResultChan() {
-		if event.Type == watch.Deleted {
-			gvk, _ := c.GroupVersionKindFor(obj)
-			return def, apierrors.NewNotFound(schema.GroupResource{
-				Group:    gvk.Group,
-				Resource: gvk.Kind,
-			}, obj.GetName())
-		}
-		switch event.Type {
-		case watch.Added, watch.Modified:
-			if ok, err := condition(event.Object.(T)); err != nil {
-				return def, err
-			} else if ok {
-				return event.Object.(T), nil
+	for {
+		select {
+		case <-ctx.Done():
+			return def, ctx.Err()
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				return def, fmt.Errorf("timeout waiting for %s %s to meet condition", gvk.Kind, obj.GetName())
 			}
-		case watch.Error:
-			return def, apierrors.FromObject(event.Object)
+
+			if event.Type == watch.Deleted {
+				gvk, _ := c.GroupVersionKindFor(obj)
+				return def, apierrors.NewNotFound(schema.GroupResource{
+					Group:    gvk.Group,
+					Resource: gvk.Kind,
+				}, obj.GetName())
+			}
+			switch event.Type {
+			case watch.Added, watch.Modified:
+				if ok, err := condition(event.Object.(T)); err != nil {
+					return def, err
+				} else if ok {
+					return event.Object.(T), nil
+				}
+			case watch.Error:
+				return def, apierrors.FromObject(event.Object)
+			}
 		}
 	}
 
-	return def, fmt.Errorf("timeout waiting for %s %s to meet condition", gvk.Kind, obj.GetName())
+	// unreachable
 }

--- a/pkg/wait/waitfor.go
+++ b/pkg/wait/waitfor.go
@@ -108,34 +108,25 @@ func For[T kclient.Object](ctx context.Context, c kclient.WithWatch, obj T, cond
 		}
 	}()
 
-	for {
-		select {
-		case <-ctx.Done():
-			return def, ctx.Err()
-		case event, ok := <-w.ResultChan():
-			if !ok {
-				return def, fmt.Errorf("timeout waiting for %s %s to meet condition", gvk.Kind, obj.GetName())
+	for event := range w.ResultChan() {
+		if event.Type == watch.Deleted {
+			gvk, _ := c.GroupVersionKindFor(obj)
+			return def, apierrors.NewNotFound(schema.GroupResource{
+				Group:    gvk.Group,
+				Resource: gvk.Kind,
+			}, obj.GetName())
+		}
+		switch event.Type {
+		case watch.Added, watch.Modified:
+			if ok, err := condition(event.Object.(T)); err != nil {
+				return def, err
+			} else if ok {
+				return event.Object.(T), nil
 			}
-
-			if event.Type == watch.Deleted {
-				gvk, _ := c.GroupVersionKindFor(obj)
-				return def, apierrors.NewNotFound(schema.GroupResource{
-					Group:    gvk.Group,
-					Resource: gvk.Kind,
-				}, obj.GetName())
-			}
-			switch event.Type {
-			case watch.Added, watch.Modified:
-				if ok, err := condition(event.Object.(T)); err != nil {
-					return def, err
-				} else if ok {
-					return event.Object.(T), nil
-				}
-			case watch.Error:
-				return def, apierrors.FromObject(event.Object)
-			}
+		case watch.Error:
+			return def, apierrors.FromObject(event.Object)
 		}
 	}
 
-	// unreachable
+	return def, fmt.Errorf("timeout waiting for %s %s to meet condition", gvk.Kind, obj.GetName())
 }

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -311,6 +311,7 @@
 
 	function convertToEntryManifest(formData: RuntimeFormData): MCPCatalogEntryServerManifest {
 		const { categories, ...baseData } = formData;
+		const startupTimeoutSeconds = baseData.startupTimeoutSeconds;
 
 		// Build base manifest structure
 		const manifest: MCPCatalogEntryServerManifest = {
@@ -320,8 +321,10 @@
 			env: baseData.env,
 			runtime: baseData.runtime,
 			...convertCategoriesToMetadata(categories),
-			...(baseData.startupTimeoutSeconds
-				? { startupTimeoutSeconds: baseData.startupTimeoutSeconds }
+			...(typeof startupTimeoutSeconds === 'number' &&
+			Number.isInteger(startupTimeoutSeconds) &&
+			startupTimeoutSeconds > 0
+				? { startupTimeoutSeconds }
 				: {})
 		};
 

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -160,6 +160,8 @@
 				multiUserConfig: manifest.multiUserConfig ?? { userDefinedHeaders: [] }
 			};
 
+			formData.startupTimeoutSeconds = manifest.startupTimeoutSeconds;
+
 			// Initialize the appropriate runtime config based on the runtime type
 			switch (manifest.runtime) {
 				case 'npx':
@@ -200,6 +202,8 @@
 				remoteConfig: undefined,
 				remoteServerConfig: undefined
 			};
+
+			formData.startupTimeoutSeconds = manifest.startupTimeoutSeconds;
 
 			// Initialize the appropriate runtime config based on the runtime type
 			switch (manifest.runtime) {
@@ -315,7 +319,10 @@
 			icon: baseData.icon,
 			env: baseData.env,
 			runtime: baseData.runtime,
-			...convertCategoriesToMetadata(categories)
+			...convertCategoriesToMetadata(categories),
+			...(baseData.startupTimeoutSeconds
+				? { startupTimeoutSeconds: baseData.startupTimeoutSeconds }
+				: {})
 		};
 
 		// Add runtime-specific config based on the runtime type
@@ -605,6 +612,7 @@
 		bind:config={formData.npxConfig}
 		{showEgressDomains}
 		{defaultDenyAllEgress}
+		bind:startupTimeoutSeconds={formData.startupTimeoutSeconds}
 		{readonly}
 		{showRequired}
 		onFieldChange={updateRequired}
@@ -614,6 +622,7 @@
 		bind:config={formData.uvxConfig}
 		{showEgressDomains}
 		{defaultDenyAllEgress}
+		bind:startupTimeoutSeconds={formData.startupTimeoutSeconds}
 		{readonly}
 		{showRequired}
 		onFieldChange={updateRequired}
@@ -623,6 +632,7 @@
 		bind:config={formData.containerizedConfig}
 		{showEgressDomains}
 		{defaultDenyAllEgress}
+		bind:startupTimeoutSeconds={formData.startupTimeoutSeconds}
 		{readonly}
 		{showRequired}
 		onFieldChange={updateRequired}
@@ -645,7 +655,7 @@
 		id={entry?.id}
 	/>
 {/if}
-
+<!-- Environment Variables Section -->
 {#if !['remote', 'composite'].includes(formData.runtime)}
 	<CustomConfigurationForm bind:config={formData.env} {readonly} {type} />
 {/if}

--- a/ui/user/src/lib/components/mcp/ContainerizedRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/ContainerizedRuntimeForm.svelte
@@ -289,7 +289,9 @@
 
 	<!-- Startup Timeout -->
 	<div class="flex items-center gap-4">
-		<label for="containerized-startup-timeout" class="text-sm font-light"
+		<label
+			for="containerized-startup-timeout"
+			class={twMerge('text-sm font-light', showRequired?.startupTimeoutSeconds && 'error')}
 			>Startup Timeout (seconds)</label
 		>
 		<input
@@ -298,7 +300,10 @@
 			min="1"
 			placeholder="60"
 			bind:value={startupTimeoutSeconds}
-			class="text-input-filled dark:bg-background w-32"
+			class={twMerge(
+				'text-input-filled dark:bg-background w-32',
+				showRequired?.startupTimeoutSeconds && 'error'
+			)}
 			disabled={readonly}
 		/>
 	</div>

--- a/ui/user/src/lib/components/mcp/ContainerizedRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/ContainerizedRuntimeForm.svelte
@@ -9,6 +9,7 @@
 
 	interface Props {
 		config: ContainerizedRuntimeConfig;
+		startupTimeoutSeconds?: number;
 		readonly?: boolean;
 		showEgressDomains?: boolean;
 		defaultDenyAllEgress?: boolean;
@@ -18,6 +19,7 @@
 	}
 	let {
 		config = $bindable(),
+		startupTimeoutSeconds = $bindable(),
 		readonly,
 		showEgressDomains = false,
 		defaultDenyAllEgress = false,
@@ -284,6 +286,22 @@
 			</div>
 		</div>
 	{/if}
+
+	<!-- Startup Timeout -->
+	<div class="flex items-center gap-4">
+		<label for="containerized-startup-timeout" class="text-sm font-light"
+			>Startup Timeout (seconds)</label
+		>
+		<input
+			type="number"
+			id="containerized-startup-timeout"
+			min="1"
+			placeholder="60"
+			bind:value={startupTimeoutSeconds}
+			class="text-input-filled dark:bg-background w-32"
+			disabled={readonly}
+		/>
+	</div>
 
 	{@render children?.()}
 </div>

--- a/ui/user/src/lib/components/mcp/NpxRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/NpxRuntimeForm.svelte
@@ -9,6 +9,7 @@
 
 	interface Props {
 		config: NPXRuntimeConfig;
+		startupTimeoutSeconds?: number;
 		readonly?: boolean;
 		showEgressDomains?: boolean;
 		defaultDenyAllEgress?: boolean;
@@ -18,6 +19,7 @@
 	}
 	let {
 		config = $bindable(),
+		startupTimeoutSeconds = $bindable(),
 		readonly,
 		showEgressDomains = false,
 		defaultDenyAllEgress = false,
@@ -205,6 +207,20 @@
 			</div>
 		</div>
 	{/if}
+
+	<!-- Startup Timeout -->
+	<div class="flex items-center gap-4">
+		<label for="npx-startup-timeout" class="text-sm font-light">Startup Timeout (seconds)</label>
+		<input
+			type="number"
+			id="npx-startup-timeout"
+			min="1"
+			placeholder="60"
+			bind:value={startupTimeoutSeconds}
+			class="text-input-filled dark:bg-background w-32"
+			disabled={readonly}
+		/>
+	</div>
 
 	{@render children?.()}
 </div>

--- a/ui/user/src/lib/components/mcp/NpxRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/NpxRuntimeForm.svelte
@@ -210,14 +210,21 @@
 
 	<!-- Startup Timeout -->
 	<div class="flex items-center gap-4">
-		<label for="npx-startup-timeout" class="text-sm font-light">Startup Timeout (seconds)</label>
+		<label
+			for="npx-startup-timeout"
+			class={twMerge('text-sm font-light', showRequired?.startupTimeoutSeconds && 'error')}
+			>Startup Timeout (seconds)</label
+		>
 		<input
 			type="number"
 			id="npx-startup-timeout"
 			min="1"
 			placeholder="60"
 			bind:value={startupTimeoutSeconds}
-			class="text-input-filled dark:bg-background w-32"
+			class={twMerge(
+				'text-input-filled dark:bg-background w-32',
+				showRequired?.startupTimeoutSeconds && 'error'
+			)}
 			disabled={readonly}
 		/>
 	</div>

--- a/ui/user/src/lib/components/mcp/UvxRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/UvxRuntimeForm.svelte
@@ -9,6 +9,7 @@
 
 	interface Props {
 		config: UVXRuntimeConfig;
+		startupTimeoutSeconds?: number;
 		readonly?: boolean;
 		showEgressDomains?: boolean;
 		defaultDenyAllEgress?: boolean;
@@ -18,6 +19,7 @@
 	}
 	let {
 		config = $bindable(),
+		startupTimeoutSeconds = $bindable(),
 		readonly,
 		showEgressDomains = false,
 		defaultDenyAllEgress = false,
@@ -222,6 +224,20 @@
 			</div>
 		</div>
 	{/if}
+
+	<!-- Startup Timeout -->
+	<div class="flex items-center gap-4">
+		<label for="uvx-startup-timeout" class="text-sm font-light">Startup Timeout (seconds)</label>
+		<input
+			type="number"
+			id="uvx-startup-timeout"
+			min="1"
+			placeholder="60"
+			bind:value={startupTimeoutSeconds}
+			class="text-input-filled dark:bg-background w-32"
+			disabled={readonly}
+		/>
+	</div>
 
 	{@render children?.()}
 </div>

--- a/ui/user/src/lib/components/mcp/UvxRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/UvxRuntimeForm.svelte
@@ -227,14 +227,21 @@
 
 	<!-- Startup Timeout -->
 	<div class="flex items-center gap-4">
-		<label for="uvx-startup-timeout" class="text-sm font-light">Startup Timeout (seconds)</label>
+		<label
+			for="uvx-startup-timeout"
+			class={twMerge('text-sm font-light', showRequired?.startupTimeoutSeconds && 'error')}
+			>Startup Timeout (seconds)</label
+		>
 		<input
 			type="number"
 			id="uvx-startup-timeout"
 			min="1"
 			placeholder="60"
 			bind:value={startupTimeoutSeconds}
-			class="text-input-filled dark:bg-background w-32"
+			class={twMerge(
+				'text-input-filled dark:bg-background w-32',
+				showRequired?.startupTimeoutSeconds && 'error'
+			)}
 			disabled={readonly}
 		/>
 	</div>

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -75,6 +75,8 @@ export interface MCPCatalogEntryServerManifest {
 	remoteConfig?: RemoteCatalogConfigAdmin;
 	compositeConfig?: CompositeCatalogConfig;
 	multiUserConfig?: MultiUserConfig;
+
+	startupTimeoutSeconds?: number;
 }
 
 export interface MCPCatalogEntry {
@@ -140,6 +142,8 @@ export interface RuntimeFormData {
 	compositeConfig?: CompositeCatalogConfig; // For catalog entries
 	compositeServerConfig?: CompositeRuntimeConfig; // For servers
 	multiUserConfig?: MultiUserConfig; // For servers
+
+	startupTimeoutSeconds?: number;
 }
 
 export interface MCPCatalogServerManifest {

--- a/ui/user/src/lib/services/chat/mcp.ts
+++ b/ui/user/src/lib/services/chat/mcp.ts
@@ -516,6 +516,13 @@ export const validateRuntimeForm = (
 	nameNotRequired: boolean = false
 ): Record<string, boolean> => {
 	const missingFields: Record<string, boolean> = {};
+	if (
+		formData.startupTimeoutSeconds !== undefined &&
+		(!Number.isInteger(formData.startupTimeoutSeconds) || formData.startupTimeoutSeconds <= 0)
+	) {
+		missingFields.startupTimeoutSeconds = true;
+	}
+
 	// Basic validation - name is required
 	if (!nameNotRequired && !formData.name.trim()) {
 		missingFields.name = true;
@@ -591,6 +598,7 @@ export const convertServerRuntimeFormDataToManifest = (
 	formData: RuntimeFormData
 ): MCPCatalogServerManifest => {
 	const { categories, ...baseData } = formData;
+	const startupTimeoutSeconds = baseData.startupTimeoutSeconds;
 
 	// Build base manifest structure for server
 	const serverManifest: MCPCatalogServerManifest = {
@@ -602,8 +610,10 @@ export const convertServerRuntimeFormDataToManifest = (
 			multiUserConfig: baseData.multiUserConfig,
 			runtime: baseData.runtime,
 			...convertCategoriesToMetadata(categories),
-			...(baseData.startupTimeoutSeconds
-				? { startupTimeoutSeconds: baseData.startupTimeoutSeconds }
+			...(typeof startupTimeoutSeconds === 'number' &&
+			Number.isInteger(startupTimeoutSeconds) &&
+			startupTimeoutSeconds > 0
+				? { startupTimeoutSeconds }
 				: {})
 		}
 	};

--- a/ui/user/src/lib/services/chat/mcp.ts
+++ b/ui/user/src/lib/services/chat/mcp.ts
@@ -601,7 +601,10 @@ export const convertServerRuntimeFormDataToManifest = (
 			env: baseData.env,
 			multiUserConfig: baseData.multiUserConfig,
 			runtime: baseData.runtime,
-			...convertCategoriesToMetadata(categories)
+			...convertCategoriesToMetadata(categories),
+			...(baseData.startupTimeoutSeconds
+				? { startupTimeoutSeconds: baseData.startupTimeoutSeconds }
+				: {})
 		}
 	};
 

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -413,6 +413,8 @@ export interface MCPServer {
 	remoteConfig?: RemoteRuntimeConfig;
 	compositeConfig?: CompositeRuntimeConfig;
 	multiUserConfig?: MultiUserConfig;
+
+	startupTimeoutSeconds?: number;
 }
 
 export interface MCPServerTool {


### PR DESCRIPTION
## Summary
Addresses #6185

- Add a configurable MCP server startup timeout to catalog entry, MCP server, and system MCP server manifests
- Surface the timeout in the NPX, UVX, and containerized runtime configuration UI
- Apply the configured timeout in Docker and Kubernetes MCP backend startup/readiness paths
~~- Separate image-pull waiting from container startup waiting so slow image pulls do not consume the user-configured startup timeout~~
  - K8s will also do early-exits when it detects unrecoverable failures/states


## Testing

In order to test this, I created a simple npx MCP server with a configurable sleep before serving:
```
# sleep 30s before starting (default is 60)
npx github:calvinmclean/slow-npx-mcp 30
```

This screenshot shows how the configuration can be set. In this case, the server will have a slow startup which would have previously timed-out. Now it will still succeed due to the 90s timeout.
<img width="978" height="332" alt="Screenshot 2026-04-24 at 14 13 36" src="https://github.com/user-attachments/assets/e30f346d-a0fc-48f0-9b92-de81f5dea3e0" />