### PR TITLE
enhance: add composite tool prefixes

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -70,9 +70,11 @@ type CatalogComponentServer struct {
 	// MCPServerID if set, reference the multi-user MCP server the component server proxies to
 	MCPServerID string `json:"mcpServerID,omitempty"`
 	// Manifest is the catalog entry manifest of the component server
-	Manifest MCPServerCatalogEntryManifest `json:"manifest,omitempty"`
+	Manifest MCPServerCatalogEntryManifest `json:"manifest,omitzero"`
 	// ToolOverrides restrict the tools exposed by the component server
 	ToolOverrides []ToolOverride `json:"toolOverrides,omitempty"`
+	// ToolPrefix is an optional prefix applied to the final name of each tool exposed by the component server
+	ToolPrefix string `json:"toolPrefix,omitempty"`
 }
 
 // ComponentID returns the ID of the component server.
@@ -95,9 +97,11 @@ type ComponentServer struct {
 	// MCPServerID if set, reference the multi-user MCP server the component server proxies to
 	MCPServerID string `json:"mcpServerID,omitempty"`
 	// Manifest is the runtime manifest of the component server
-	Manifest MCPServerManifest `json:"manifest,omitempty"`
+	Manifest MCPServerManifest `json:"manifest,omitzero"`
 	// ToolOverrides restrict the tools exposed by the component server
 	ToolOverrides []ToolOverride `json:"toolOverrides,omitempty"`
+	// ToolPrefix is an optional prefix applied to the final name of each tool exposed by the component server
+	ToolPrefix string `json:"toolPrefix,omitempty"`
 	// Disabled indicates whether the component server should be included in the composite server at runtime
 	Disabled bool `json:"disabled,omitempty"`
 }

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1523,6 +1523,7 @@ func serverManifestFromCatalogEntryManifest(
 				MCPServerID:    entryComponent.MCPServerID,
 				CatalogEntryID: entryComponent.CatalogEntryID,
 				ToolOverrides:  entryComponent.ToolOverrides,
+				ToolPrefix:     entryComponent.ToolPrefix,
 				Disabled:       inputComponent.Disabled,
 				Manifest:       resultComponentManifest,
 			})

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -941,7 +941,7 @@ func (h *MCPCatalogHandler) generateCompositeToolPreviews(req api.Context, entry
 				return fmt.Errorf("failed to list tools for MCP server %q: %w", mcpServer.Name, err)
 			}
 
-			transformedTools := mcp.ApplyToolOverrides(tools, componentEntry.ToolOverrides)
+			transformedTools := mcp.ApplyToolOverrides(tools, componentEntry.ToolOverrides, componentEntry.ToolPrefix)
 			compositeToolPreviews = append(compositeToolPreviews, transformedTools...)
 			continue
 		}
@@ -1006,7 +1006,7 @@ func (h *MCPCatalogHandler) generateCompositeToolPreviews(req api.Context, entry
 		}
 
 		// Apply tool overrides before aggregating
-		transformedTools := mcp.ApplyToolOverrides(toolPreview, componentEntry.ToolOverrides)
+		transformedTools := mcp.ApplyToolOverrides(toolPreview, componentEntry.ToolOverrides, componentEntry.ToolPrefix)
 
 		compositeToolPreviews = append(compositeToolPreviews, transformedTools...)
 	}

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -238,6 +238,11 @@ func compositeConfigHasDrifted(serverConfig *types.CompositeRuntimeConfig, entry
 			return true, nil
 		}
 
+		// Compare tool prefix
+		if serverComponent.ToolPrefix != entryComponent.ToolPrefix {
+			return true, nil
+		}
+
 		// Compare tool overrides
 		if hash.Digest(serverComponent.ToolOverrides) != hash.Digest(entryComponent.ToolOverrides) {
 			return true, nil

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -195,6 +195,7 @@ func constructMCPServerNanobotYAMLForComposite(servers []ComponentServer) ([]byt
 		mcpServers[name] = nanobotConfigMCPServer{
 			BaseURL:       component.URL,
 			ToolOverrides: tools,
+			ToolPrefix:    component.ToolPrefix,
 		}
 
 		names = append(names, name)
@@ -289,6 +290,7 @@ type nanobotConfigMCPServer struct {
 	BaseURL string              `json:"url,omitempty"`
 
 	ToolOverrides map[string]toolOverride `json:"toolOverrides,omitempty"`
+	ToolPrefix    string                  `json:"toolPrefix,omitempty"`
 }
 
 type toolOverride struct {

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -67,38 +68,32 @@ func ConvertTools(tools []mcp.Tool, allowedTools, unsupportedTools []string) ([]
 // ApplyToolOverrides applies ToolOverrides to a component's tool array,
 // filtering out disabled tools and applying name/description overrides.
 // If overrides are present, they act as an allowlist - only tools explicitly listed are included.
-func ApplyToolOverrides(tools []otypes.MCPServerTool, toolOverrides []otypes.ToolOverride) []otypes.MCPServerTool {
+// toolPrefix, if non-empty, is prepended to every returned tool's Name so previews
+// match what the composite server will expose via nanobot at runtime.
+func ApplyToolOverrides(tools []otypes.MCPServerTool, toolOverrides []otypes.ToolOverride, toolPrefix string) []otypes.MCPServerTool {
 	// Build lookup map: toolName -> ToolOverride
 	overrideMap := make(map[string]otypes.ToolOverride, len(toolOverrides))
 	for _, override := range toolOverrides {
 		overrideMap[override.Name] = override
 	}
 
-	hasOverrides := len(toolOverrides) > 0
-
-	transformedTools := make([]otypes.MCPServerTool, 0, len(tools))
+	var (
+		hasOverrides     = len(toolOverrides) > 0
+		transformedTools = make([]otypes.MCPServerTool, 0, len(tools))
+	)
 	for _, tool := range tools {
 		override, hasOverride := overrideMap[tool.Name]
-
-		// If overrides are defined, only include tools that are explicitly listed
-		if hasOverrides && !hasOverride {
+		if hasOverrides && (!hasOverride || !override.Enabled) {
+			// Omit the tool from the final tool set.
+			// Overrides have been set for the component and the tool either:
+			// - isn't present in the component's overrides (is likely net-new and wasn't available when the overrides were generated)
+			// - is explicitly disabled
 			continue
 		}
 
-		// If there's an override and the tool is explicitly disabled, skip it
-		if hasOverride && !override.Enabled {
-			continue
-		}
-
-		// Apply overrides
-		if hasOverride {
-			if override.OverrideName != "" {
-				tool.Name = override.OverrideName
-			}
-			if override.OverrideDescription != "" {
-				tool.Description = override.OverrideDescription
-			}
-		}
+		// Apply overrides and tool prefix if provided
+		tool.Name = toolPrefix + cmp.Or(override.OverrideName, tool.Name)
+		tool.Description = cmp.Or(override.OverrideDescription, tool.Description)
 
 		transformedTools = append(transformedTools, tool)
 	}

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -13,6 +13,7 @@ func TestApplyToolOverrides(t *testing.T) {
 		name          string
 		tools         []types.MCPServerTool
 		toolOverrides []types.ToolOverride
+		toolPrefix    string
 		expected      []types.MCPServerTool
 	}{
 		{
@@ -151,11 +152,69 @@ func TestApplyToolOverrides(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "tool prefix with no overrides - prefix applied to all tools",
+			tools: []types.MCPServerTool{
+				{Name: "create-issue", Description: "Creates an issue"},
+				{Name: "list-repos", Description: "Lists repositories"},
+			},
+			toolOverrides: nil,
+			toolPrefix:    "gh_",
+			expected: []types.MCPServerTool{
+				{Name: "gh_create-issue", Description: "Creates an issue"},
+				{Name: "gh_list-repos", Description: "Lists repositories"},
+			},
+		},
+		{
+			name: "tool prefix combined with override name",
+			tools: []types.MCPServerTool{
+				{Name: "create-issue", Description: "Creates an issue"},
+			},
+			toolOverrides: []types.ToolOverride{
+				{Name: "create-issue", OverrideName: "new-issue", Enabled: true},
+			},
+			toolPrefix: "gh_",
+			expected: []types.MCPServerTool{
+				{Name: "gh_new-issue", Description: "Creates an issue"},
+			},
+		},
+		{
+			name: "tool prefix does not leak onto disabled tools",
+			tools: []types.MCPServerTool{
+				{Name: "create-issue", Description: "Creates an issue"},
+				{Name: "delete-repo", Description: "Deletes a repository"},
+			},
+			toolOverrides: []types.ToolOverride{
+				{Name: "create-issue", Enabled: true},
+				{Name: "delete-repo", Enabled: false},
+			},
+			toolPrefix: "gh_",
+			expected: []types.MCPServerTool{
+				{Name: "gh_create-issue", Description: "Creates an issue"},
+			},
+		},
+		{
+			name: "tool prefix on allowlist-only tools",
+			tools: []types.MCPServerTool{
+				{Name: "create-issue", Description: "Creates an issue"},
+				{Name: "list-repos", Description: "Lists repositories"},
+				{Name: "delete-repo", Description: "Deletes a repository"},
+			},
+			toolOverrides: []types.ToolOverride{
+				{Name: "create-issue", Enabled: true},
+				{Name: "list-repos", Enabled: true},
+			},
+			toolPrefix: "gh_",
+			expected: []types.MCPServerTool{
+				{Name: "gh_create-issue", Description: "Creates an issue"},
+				{Name: "gh_list-repos", Description: "Lists repositories"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ApplyToolOverrides(tt.tools, tt.toolOverrides)
+			result := ApplyToolOverrides(tt.tools, tt.toolOverrides, tt.toolPrefix)
 			require.Equal(t, len(tt.expected), len(result), "Tool count mismatch")
 			for i := range tt.expected {
 				assert.Equal(t, tt.expected[i].Name, result[i].Name, "Tool name mismatch at index %d", i)

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -81,9 +81,10 @@ type File struct {
 }
 
 type ComponentServer struct {
-	Name  string               `json:"name"`
-	URL   string               `json:"url"`
-	Tools []types.ToolOverride `json:"tools"`
+	Name       string               `json:"name"`
+	URL        string               `json:"url"`
+	Tools      []types.ToolOverride `json:"tools"`
+	ToolPrefix string               `json:"toolPrefix"`
 }
 
 var envVarRegex = regexp.MustCompile(`\${([^}]+)}`)
@@ -253,9 +254,10 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 		}
 
 		config.Components = append(config.Components, ComponentServer{
-			Name:  name,
-			URL:   system.MCPConnectURL(issuer, component.Name),
-			Tools: tools,
+			Name:       name,
+			URL:        system.MCPConnectURL(issuer, component.Name),
+			Tools:      tools,
+			ToolPrefix: override.ToolPrefix,
 		})
 	}
 
@@ -278,9 +280,10 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 		}
 
 		config.Components = append(config.Components, ComponentServer{
-			Name:  instance.Name,
-			URL:   system.MCPConnectURL(issuer, instance.Name),
-			Tools: tools,
+			Name:       instance.Name,
+			URL:        system.MCPConnectURL(issuer, instance.Name),
+			Tools:      tools,
+			ToolPrefix: override.ToolPrefix,
 		})
 	}
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2034,7 +2034,15 @@ func schema_obot_platform_obot_apiclient_types_CatalogComponentServer(ref common
 							},
 						},
 					},
+					"toolPrefix": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ToolPrefix is an optional prefix applied to the final name of each tool exposed by the component server",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
+				Required: []string{"manifest"},
 			},
 		},
 		Dependencies: []string{
@@ -2227,6 +2235,13 @@ func schema_obot_platform_obot_apiclient_types_ComponentServer(ref common.Refere
 							},
 						},
 					},
+					"toolPrefix": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ToolPrefix is an optional prefix applied to the final name of each tool exposed by the component server",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"disabled": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Disabled indicates whether the component server should be included in the composite server at runtime",
@@ -2235,6 +2250,7 @@ func schema_obot_platform_obot_apiclient_types_ComponentServer(ref common.Refere
 						},
 					},
 				},
+				Required: []string{"manifest"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/validation/mcpvalidators.go
+++ b/pkg/validation/mcpvalidators.go
@@ -1,7 +1,7 @@
 package validation
 
 import (
-	"errors"
+	"cmp"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -11,7 +11,19 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 )
 
-var hostnameRegex = regexp.MustCompile(`^(?:\*\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$`)
+var (
+	// toolNameRegex matches the character set allowed for composite
+	// component tools: ASCII letters, digits, underscore, hyphen, dot,
+	// and forward slash. Note that '.' and '/' produce a soft warning downstream
+	// (some MCP clients reject them) but are permitted here so admins who know
+	// their clients can use them.
+	toolNameRegex = regexp.MustCompile(`^[A-Za-z0-9._/-]*$`)
+	hostnameRegex = regexp.MustCompile(`^(?:\*\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$`)
+)
+
+// maxToolNameLength is the max length of an MCP server tool.
+// It's used to validate effective tool names after tool overrides and prefixes are applied.
+const maxToolNameLength = 128
 
 // RuntimeValidator defines the interface for validating runtime-specific configurations
 type RuntimeValidator interface {
@@ -518,7 +530,8 @@ func (v CompositeValidator) ValidateConfig(manifest types.MCPServerManifest) err
 		}
 	}
 
-	if len(manifest.CompositeConfig.ComponentServers) < 1 {
+	numComponents := len(manifest.CompositeConfig.ComponentServers)
+	if numComponents < 1 {
 		return types.RuntimeValidationError{
 			Runtime: types.RuntimeComposite,
 			Field:   "compositeConfig.componentServers",
@@ -526,8 +539,11 @@ func (v CompositeValidator) ValidateConfig(manifest types.MCPServerManifest) err
 		}
 	}
 
-	// Check for duplicate component servers
-	componentServerIDs := make(map[string]struct{}, len(manifest.CompositeConfig.ComponentServers))
+	var (
+		componentServerIDs = make(map[string]struct{}, numComponents)
+		toolPrefixes       = make(map[string]struct{}, numComponents)
+		effectiveToolNames = make(map[string]struct{})
+	)
 	for i, component := range manifest.CompositeConfig.ComponentServers {
 		// Ensure exactly one of CatalogEntryID or MCPServerID is set
 		hasCatalogEntry, hasServerID := component.CatalogEntryID != "", component.MCPServerID != ""
@@ -559,15 +575,77 @@ func (v CompositeValidator) ValidateConfig(manifest types.MCPServerManifest) err
 			}
 		}
 
-		// Validate tool overrides
-		if err := validateToolOverrides(component.ToolOverrides); err != nil {
-			return errors.Join(types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   fmt.Sprintf("compositeConfig.componentServers[%d]", i),
-				Message: "tool overrides invalid",
-			}, err)
+		// Validate the tool prefix
+		prefix := component.ToolPrefix
+		if prefix != "" {
+			// Prevent duplicates
+			if _, ok := toolPrefixes[prefix]; ok {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolPrefix", i),
+					Message: fmt.Sprintf("duplicate toolPrefix: %s", prefix),
+				}
+			}
+			toolPrefixes[prefix] = struct{}{}
+
+			// Ensure the prefix is valid separately
+			if !toolNameRegex.MatchString(prefix) {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolPrefix", i),
+					Message: "toolPrefix must match " + toolNameRegex.String(),
+				}
+			}
 		}
 
+		// Validate tool overrides
+		for j, override := range component.ToolOverrides {
+			if override.Name == "" {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolOverrides[%d].name", i, j),
+					Message: "original tool name is required",
+				}
+			}
+
+			// For disabled tools, we don't care about validating the effective tool names
+			if !override.Enabled {
+				continue
+			}
+
+			// Compute the effective tool name
+			effectiveToolName := prefix + cmp.Or(override.OverrideName, override.Name)
+
+			// Validate length
+			if len(effectiveToolName) > maxToolNameLength {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolOverrides[%d]", i, j),
+					Message: fmt.Sprintf("effective tool name must be at most %d characters: %q", maxToolNameLength, effectiveToolName),
+				}
+			}
+
+			// Validate character set
+			if !toolNameRegex.MatchString(effectiveToolName) {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolOverrides[%d]", i, j),
+					Message: "effective tool name must match " + toolNameRegex.String(),
+				}
+			}
+
+			// Prevent effective duplicates (across entire composite)
+			if _, ok := effectiveToolNames[effectiveToolName]; ok {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolOverrides[%d]", i, j),
+					Message: fmt.Sprintf("duplicate tool name: %s", effectiveToolName),
+				}
+			}
+			effectiveToolNames[effectiveToolName] = struct{}{}
+		}
+
+		// Prevent duplicate component servers
 		componentID := component.ComponentID()
 		if _, ok := componentServerIDs[componentID]; ok {
 			return types.RuntimeValidationError{
@@ -599,7 +677,8 @@ func (v CompositeValidator) ValidateCatalogConfig(manifest types.MCPServerCatalo
 		}
 	}
 
-	if len(manifest.CompositeConfig.ComponentServers) < 1 {
+	numComponents := len(manifest.CompositeConfig.ComponentServers)
+	if numComponents < 1 {
 		return types.RuntimeValidationError{
 			Runtime: types.RuntimeComposite,
 			Field:   "compositeConfig.componentServers",
@@ -607,8 +686,11 @@ func (v CompositeValidator) ValidateCatalogConfig(manifest types.MCPServerCatalo
 		}
 	}
 
-	// Check for duplicate component servers
-	componentServerIDs := make(map[string]struct{}, len(manifest.CompositeConfig.ComponentServers))
+	var (
+		componentServerIDs = make(map[string]struct{}, numComponents)
+		toolPrefixes       = make(map[string]struct{}, numComponents)
+		effectiveToolNames = make(map[string]struct{})
+	)
 	for i, component := range manifest.CompositeConfig.ComponentServers {
 		// Ensure exactly one of CatalogEntryID or MCPServerID is set
 		hasCatalogEntry, hasServerID := component.CatalogEntryID != "", component.MCPServerID != ""
@@ -640,15 +722,77 @@ func (v CompositeValidator) ValidateCatalogConfig(manifest types.MCPServerCatalo
 			}
 		}
 
-		// Validate tool overrides
-		if err := validateToolOverrides(component.ToolOverrides); err != nil {
-			return errors.Join(types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   fmt.Sprintf("compositeConfig.componentServers[%d]", i),
-				Message: "tool overrides invalid",
-			}, err)
+		// Validate the tool prefix
+		prefix := component.ToolPrefix
+		if prefix != "" {
+			// Prevent duplicates
+			if _, ok := toolPrefixes[prefix]; ok {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolPrefix", i),
+					Message: fmt.Sprintf("duplicate toolPrefix: %s", prefix),
+				}
+			}
+			toolPrefixes[prefix] = struct{}{}
+
+			// Ensure the prefix is valid separately
+			if !toolNameRegex.MatchString(prefix) {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolPrefix", i),
+					Message: "toolPrefix must match " + toolNameRegex.String(),
+				}
+			}
 		}
 
+		// Validate tool overrides
+		for j, override := range component.ToolOverrides {
+			if override.Name == "" {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolOverrides[%d].name", i, j),
+					Message: "original tool name is required",
+				}
+			}
+
+			// For disabled tools, we don't care about validating the effective tool names
+			if !override.Enabled {
+				continue
+			}
+
+			// Compute the effective tool name
+			effectiveToolName := prefix + cmp.Or(override.OverrideName, override.Name)
+
+			// Validate length
+			if len(effectiveToolName) > maxToolNameLength {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolOverrides[%d]", i, j),
+					Message: fmt.Sprintf("effective tool name must be at most %d characters: %q", maxToolNameLength, effectiveToolName),
+				}
+			}
+
+			// Validate character set
+			if !toolNameRegex.MatchString(effectiveToolName) {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolOverrides[%d]", i, j),
+					Message: "effective tool name must match " + toolNameRegex.String(),
+				}
+			}
+
+			// Prevent effective duplicates (across entire composite)
+			if _, ok := effectiveToolNames[effectiveToolName]; ok {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolOverrides[%d]", i, j),
+					Message: fmt.Sprintf("duplicate tool name: %s", effectiveToolName),
+				}
+			}
+			effectiveToolNames[effectiveToolName] = struct{}{}
+		}
+
+		// Prevent duplicate component servers
 		componentID := component.ComponentID()
 		if _, ok := componentServerIDs[componentID]; ok {
 			return types.RuntimeValidationError{
@@ -677,56 +821,6 @@ func (v CompositeValidator) ValidateSystemConfig(manifest types.SystemMCPServerM
 		Field:   "runtime",
 		Message: "composite runtime is not supported for system servers",
 	}
-}
-
-func validateToolOverrides(overrides []types.ToolOverride) error {
-	var (
-		toolNames    = make(map[string]struct{}, len(overrides))
-		exposedNames = make(map[string]struct{}, len(overrides))
-	)
-
-	for i, override := range overrides {
-		if override.Name == "" {
-			return types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   fmt.Sprintf("toolOverrides[%d].name", i),
-				Message: "original tool name is required",
-			}
-		}
-
-		// Check for duplicate original names
-		if _, ok := toolNames[override.Name]; ok {
-			return types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   fmt.Sprintf("toolOverrides[%d].name", i),
-				Message: fmt.Sprintf("duplicate tool name: %s", override.Name),
-			}
-		}
-		toolNames[override.Name] = struct{}{}
-
-		// For disabled tools, we don't care about exposed-name conflicts.
-		if !override.Enabled {
-			continue
-		}
-
-		// Compute the effective exposed name: override name if set, otherwise the original name.
-		effectiveName := override.OverrideName
-		if effectiveName == "" {
-			effectiveName = override.Name
-		}
-
-		// Check for duplicate exposed names among enabled tools.
-		if _, ok := exposedNames[effectiveName]; ok {
-			return types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   fmt.Sprintf("toolOverrides[%d].overrideName", i),
-				Message: fmt.Sprintf("duplicate override name: %s", effectiveName),
-			}
-		}
-		exposedNames[effectiveName] = struct{}{}
-	}
-
-	return nil
 }
 
 // getRuntimeValidators returns a map of all available runtime validators

--- a/pkg/validation/mcpvalidators_test.go
+++ b/pkg/validation/mcpvalidators_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -963,41 +964,6 @@ func TestCompositeValidator_ValidateCatalogConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "tool overrides invalid bubbles up in catalog",
-			manifest: types.MCPServerCatalogEntryManifest{
-				Runtime: types.RuntimeComposite,
-				CompositeConfig: &types.CompositeCatalogConfig{
-					ComponentServers: []types.CatalogComponentServer{
-						{
-							CatalogEntryID: "entry-1",
-							Manifest: types.MCPServerCatalogEntryManifest{
-								Runtime: types.RuntimeRemote,
-							},
-							ToolOverrides: []types.ToolOverride{
-								{
-									Name:         "",
-									OverrideName: "tool-1-override",
-									Enabled:      true,
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedError: errors.Join(
-				types.RuntimeValidationError{
-					Runtime: types.RuntimeComposite,
-					Field:   "compositeConfig.componentServers[0]",
-					Message: "tool overrides invalid",
-				},
-				types.RuntimeValidationError{
-					Runtime: types.RuntimeComposite,
-					Field:   "toolOverrides[0].name",
-					Message: "original tool name is required",
-				},
-			),
-		},
-		{
 			name: "valid catalog composite configuration passes",
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeComposite,
@@ -1073,132 +1039,242 @@ func TestCompositeValidator_ValidateCatalogConfig(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			name: "tool prefix with invalid character",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolOverrides: []types.ToolOverride{
+								{Name: "list", Enabled: true},
+							},
+							ToolPrefix: "gh space",
+						},
+					},
+				},
+			},
+			expectedError: types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   "compositeConfig.componentServers[0].toolPrefix",
+				Message: "toolPrefix must match ^[A-Za-z0-9._/-]*$",
+			},
+		},
+		{
+			name: "tool prefix is allowed without tool overrides",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolPrefix: "gh_",
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "duplicate non-empty tool prefix",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolOverrides: []types.ToolOverride{
+								{Name: "list", Enabled: true},
+							},
+							ToolPrefix: "gh_",
+						},
+						{
+							CatalogEntryID: "entry-2",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolOverrides: []types.ToolOverride{
+								{Name: "list", Enabled: true},
+							},
+							ToolPrefix: "gh_",
+						},
+					},
+				},
+			},
+			expectedError: types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   "compositeConfig.componentServers[1].toolPrefix",
+				Message: "duplicate toolPrefix: gh_",
+			},
+		},
+		{
+			name: "valid tool prefix with tool overrides",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolOverrides: []types.ToolOverride{
+								{Name: "list", Enabled: true},
+							},
+							ToolPrefix: "gh_",
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "empty tool prefixes may repeat across components",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+						},
+						{
+							CatalogEntryID: "entry-2",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "empty original tool name",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolOverrides: []types.ToolOverride{
+								{Name: "", Enabled: true},
+							},
+						},
+					},
+				},
+			},
+			expectedError: types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   "compositeConfig.componentServers[0].toolOverrides[0].name",
+				Message: "original tool name is required",
+			},
+		},
+		{
+			name: "effective tool name exceeds max length",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolPrefix: strings.Repeat("a", 120) + "_",
+							ToolOverrides: []types.ToolOverride{
+								{Name: "list_all_the_things", Enabled: true},
+							},
+						},
+					},
+				},
+			},
+			expectedError: types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   "compositeConfig.componentServers[0].toolOverrides[0]",
+				Message: fmt.Sprintf(
+					"effective tool name must be at most 128 characters: %q",
+					strings.Repeat("a", 120)+"_list_all_the_things",
+				),
+			},
+		},
+		{
+			name: "effective tool name has invalid character",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolOverrides: []types.ToolOverride{
+								{Name: "list things", Enabled: true},
+							},
+						},
+					},
+				},
+			},
+			expectedError: types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   "compositeConfig.componentServers[0].toolOverrides[0]",
+				Message: "effective tool name must match ^[A-Za-z0-9._/-]*$",
+			},
+		},
+		{
+			name: "duplicate effective tool name across components",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolOverrides: []types.ToolOverride{
+								{Name: "list", Enabled: true},
+							},
+						},
+						{
+							CatalogEntryID: "entry-2",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolOverrides: []types.ToolOverride{
+								{Name: "list", Enabled: true},
+							},
+						},
+					},
+				},
+			},
+			expectedError: types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   "compositeConfig.componentServers[1].toolOverrides[0]",
+				Message: "duplicate tool name: list",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validator.ValidateCatalogConfig(tt.manifest)
-			require.Equal(t, tt.expectedError, err)
-		})
-	}
-}
-
-func TestValidateToolOverrides(t *testing.T) {
-	tests := []struct {
-		name          string
-		overrides     []types.ToolOverride
-		expectedError error
-	}{
-		{
-			name: "valid overrides",
-			overrides: []types.ToolOverride{
-				{
-					Name:    "tool-1",
-					Enabled: true,
-				},
-				{
-					Name:         "tool-2",
-					OverrideName: "tool-2-alias",
-					Enabled:      true,
-				},
-			},
-			expectedError: nil,
-		},
-		{
-			name: "missing original tool name",
-			overrides: []types.ToolOverride{
-				{
-					Name:         "",
-					OverrideName: "tool-1",
-					Enabled:      true,
-				},
-			},
-			expectedError: types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   "toolOverrides[0].name",
-				Message: "original tool name is required",
-			},
-		},
-		{
-			name: "duplicate effective name when override uses original name",
-			overrides: []types.ToolOverride{
-				{
-					Name:    "tool-1",
-					Enabled: true,
-				},
-				{
-					Name:         "tool-2",
-					OverrideName: "tool-1",
-					Enabled:      true,
-				},
-			},
-			expectedError: types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   "toolOverrides[1].overrideName",
-				Message: "duplicate override name: tool-1",
-			},
-		},
-		{
-			name: "duplicate original tool name",
-			overrides: []types.ToolOverride{
-				{
-					Name:         "tool-1",
-					OverrideName: "tool-1",
-					Enabled:      true,
-				},
-				{
-					Name:         "tool-1",
-					OverrideName: "tool-1-alias",
-					Enabled:      true,
-				},
-			},
-			expectedError: types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   "toolOverrides[1].name",
-				Message: "duplicate tool name: tool-1",
-			},
-		},
-		{
-			name: "duplicate override name when enabled",
-			overrides: []types.ToolOverride{
-				{
-					Name:         "tool-1",
-					OverrideName: "shared-alias",
-					Enabled:      true,
-				},
-				{
-					Name:         "tool-2",
-					OverrideName: "shared-alias",
-					Enabled:      true,
-				},
-			},
-			expectedError: types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   "toolOverrides[1].overrideName",
-				Message: "duplicate override name: shared-alias",
-			},
-		},
-		{
-			name: "duplicate override name allowed when second is disabled",
-			overrides: []types.ToolOverride{
-				{
-					Name:         "tool-1",
-					OverrideName: "shared-alias",
-					Enabled:      true,
-				},
-				{
-					Name:         "tool-2",
-					OverrideName: "shared-alias",
-					Enabled:      false,
-				},
-			},
-			expectedError: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateToolOverrides(tt.overrides)
 			require.Equal(t, tt.expectedError, err)
 		})
 	}

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -71,6 +71,7 @@
 	let selectRulesDialog = $state<ReturnType<typeof SelectMcpAccessControlRules>>();
 	let showRequired = $state<Record<string, boolean>>({});
 	let loading = $state(false);
+	let compositeHasToolNameErrors = $state(false);
 
 	let formData = $state<RuntimeFormData>(untrack(() => convertToFormData(entry)));
 
@@ -582,6 +583,7 @@
 {:else if formData.runtime === 'composite' && formData.compositeConfig}
 	<CompositeRuntimeForm
 		bind:config={formData.compositeConfig}
+		bind:hasToolNameErrors={compositeHasToolNameErrors}
 		{readonly}
 		catalogId={id}
 		id={entry?.id}
@@ -606,7 +608,8 @@
 			disabled={loading ||
 				(formData.runtime === 'composite' &&
 					(!formData.compositeConfig?.componentServers ||
-						formData.compositeConfig.componentServers.length === 0))}
+						formData.compositeConfig.componentServers.length === 0 ||
+						compositeHasToolNameErrors))}
 		>
 			{#if loading}
 				<LoaderCircle class="size-4 animate-spin" />

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -659,7 +659,10 @@
 						Regenerate Tools & Capabilities
 					</button>
 				{/if}
-				<McpServerTools entry={'isCatalogEntry' in entry && server ? server : entry}>
+				<McpServerTools
+					entry={'isCatalogEntry' in entry && server ? server : entry}
+					showToolNameIssues={entry.manifest?.runtime === 'composite'}
+				>
 					{#snippet noToolsContent()}
 						<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
 							<Wrench class="text-on-surface1 size-24 opacity-50" />

--- a/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
@@ -7,7 +7,17 @@
 		type MCPCatalogServer,
 		type CompositeServerToolRow
 	} from '$lib/services';
+	import {
+		compositeEffectiveToolNames,
+		conflictIssue,
+		duplicateToolNames,
+		effectiveToolName,
+		TOOL_NAME_CHARSET_REGEX,
+		toolNameIssue,
+		type ToolNameIssue
+	} from '$lib/services/chat/mcp';
 	import Toggle from '../Toggle.svelte';
+	import ToolNameIssueIcon from './ToolNameIssueIcon.svelte';
 	import CompositeToolsSetup from './composite/CompositeSelectServerAndToolsSetup.svelte';
 	import {
 		Plus,
@@ -20,7 +30,7 @@
 		RefreshCcw
 	} from 'lucide-svelte';
 	import { onMount } from 'svelte';
-	import { SvelteMap } from 'svelte/reactivity';
+	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { slide } from 'svelte/transition';
 
 	interface Props {
@@ -28,9 +38,19 @@
 		config: CompositeCatalogConfig;
 		readonly?: boolean;
 		catalogId?: string;
+		// Bound true when any tool's effective name fails a blocking check
+		// (length > 128 or cross-component duplicate). Parent forms read this
+		// to gate the Save button.
+		hasToolNameErrors?: boolean;
 	}
 
-	let { config = $bindable(), readonly, catalogId, id }: Props = $props();
+	let {
+		config = $bindable(),
+		readonly,
+		catalogId,
+		id,
+		hasToolNameErrors = $bindable(false)
+	}: Props = $props();
 	let componentEntries = $state<MCPCatalogEntry[]>([]);
 	const componentServers = new SvelteMap<string, MCPCatalogServer>();
 	let expanded = $state<Record<string, boolean>>({});
@@ -48,6 +68,97 @@
 	let initialComponentIds = $state<Set<string>>(new Set());
 
 	let compositeToolsSetupDialog = $state<ReturnType<typeof CompositeToolsSetup>>();
+
+	// All enabled effective tool names across every component. Used to detect
+	// cross-component final-name duplicates and to seed `otherEffectiveNames`
+	// for the edit-tools modal.
+	let allEnabledEffectiveNames = $derived(compositeEffectiveToolNames(config.componentServers));
+	let effectiveNameDuplicates = $derived(duplicateToolNames(allEnabledEffectiveNames));
+
+	// Set of non-empty prefixes that appear on more than one component. Matches
+	// the backend cross-component uniqueness check in pkg/validation.
+	let duplicatePrefixes = $derived.by(() => {
+		const counts = new SvelteMap<string, number>();
+		for (const c of config.componentServers ?? []) {
+			const p = (c.toolPrefix ?? '').trim();
+			if (!p) continue;
+			counts.set(p, (counts.get(p) ?? 0) + 1);
+		}
+		const out = new SvelteSet<string>();
+		for (const [p, n] of counts) if (n > 1) out.add(p);
+		return out;
+	});
+
+	// Effective names from all components EXCEPT the one currently being
+	// configured in the tools-setup dialog. Passed into the dialog so it can
+	// flag cross-component conflicts while the admin is still editing.
+	let otherEffectiveNames = $derived.by(() => {
+		if (!configuringComponentId) return allEnabledEffectiveNames;
+		return compositeEffectiveToolNames(
+			(config.componentServers || []).filter((c) => getComponentId(c) !== configuringComponentId)
+		);
+	});
+	let otherToolPrefixes = $derived.by(() => {
+		return (config.componentServers || [])
+			.filter((c) => getComponentId(c) !== configuringComponentId)
+			.map((c) => (c.toolPrefix ?? '').trim())
+			.filter(Boolean);
+	});
+
+	// Highest severity issue on a single tool row (includes cross-component
+	// conflicts via the shared duplicate set).
+	function toolRowSeverity(
+		original: string,
+		overrideName: string | undefined,
+		prefix: string | undefined,
+		enabled: boolean | undefined
+	): 'warning' | 'error' | undefined {
+		if (enabled === false) return undefined;
+		const name = effectiveToolName(original, overrideName, prefix);
+		return (conflictIssue(name, effectiveNameDuplicates) ?? toolNameIssue(name))?.severity;
+	}
+
+	function prefixIssue(entry: { toolPrefix?: string }): ToolNameIssue | undefined {
+		const p = (entry.toolPrefix ?? '').trim();
+		if (!TOOL_NAME_CHARSET_REGEX.test(entry.toolPrefix ?? '')) {
+			return {
+				severity: 'error',
+				message: "Prefix may only contain letters, digits, '.', '/', '_', and '-'."
+			};
+		}
+		if (p && duplicatePrefixes.has(p)) {
+			return {
+				severity: 'error',
+				message: `Another component already uses the prefix "${p}". Non-empty prefixes must be unique across components.`
+			};
+		}
+		return undefined;
+	}
+
+	// Component-card aggregate: highest severity among all enabled tools and
+	// the component's own prefix state. Prefix issues are always errors.
+	function componentSeverity(entry: {
+		toolOverrides?: { name: string; overrideName?: string; enabled?: boolean }[];
+		toolPrefix?: string;
+	}): 'warning' | 'error' | undefined {
+		if (prefixIssue(entry)) return 'error';
+		let out: 'warning' | 'error' | undefined;
+		for (const t of entry.toolOverrides ?? []) {
+			const s = toolRowSeverity(t.name, t.overrideName, entry.toolPrefix, t.enabled);
+			if (s === 'error') return 'error';
+			if (s === 'warning') out = 'warning';
+		}
+		return out;
+	}
+
+	$effect(() => {
+		hasToolNameErrors = (config.componentServers || []).some((entry) => {
+			if (prefixIssue(entry)) return true;
+			return (entry.toolOverrides ?? []).some(
+				(t) => toolRowSeverity(t.name, t.overrideName, entry.toolPrefix, t.enabled) === 'error'
+			);
+		});
+	});
 
 	const excluded = $derived([
 		...(config?.componentServers ?? []).map((c) => getComponentId(c)),
@@ -235,6 +346,7 @@
 		{:else if config.componentServers.length > 0}
 			{#each config.componentServers as entry (getComponentId(entry))}
 				{@const componentId = getComponentId(entry)}
+				{@const headerSeverity = componentSeverity(entry)}
 				<div
 					class="dark:bg-surface2 dark:border-surface3 rounded-lg border border-gray-200 bg-gray-50"
 				>
@@ -244,8 +356,16 @@
 						{:else}
 							<Server class="text-on-surface1 size-8" />
 						{/if}
-						<div class="flex-1">
+						<div class="flex flex-1 items-center gap-1.5">
 							<div class="font-medium">{entry.manifest?.name || 'Unnamed Server'}</div>
+							{#if headerSeverity}
+								<ToolNameIssueIcon
+									issue={{
+										severity: headerSeverity,
+										message: 'This component needs attention — expand for details.'
+									}}
+								/>
+							{/if}
 						</div>
 						{#if entry.toolOverrides?.length && !readonly}
 							<button
@@ -277,7 +397,42 @@
 						{/if}
 					</div>
 					{#if expanded[componentId]}
+						{@const issue = prefixIssue(entry)}
 						<div class="border-t border-gray-200 p-3" in:slide={{ axis: 'y' }}>
+							<div class="mb-3 flex flex-col gap-1">
+								<p class="flex items-center gap-1.5 text-xs text-gray-500">
+									<span>Tool name prefix</span>
+									{#if issue}
+										<ToolNameIssueIcon {issue} />
+									{/if}
+								</p>
+								<div class="flex items-center gap-2">
+									<input
+										class="text-input-filled flex-1 text-sm"
+										placeholder="No prefix"
+										disabled={readonly}
+										bind:value={entry.toolPrefix}
+									/>
+									{#if !readonly}
+										<button
+											type="button"
+											class="button px-3 py-1 text-xs"
+											onclick={() => {
+												entry.toolPrefix = '';
+											}}
+										>
+											Clear
+										</button>
+									{/if}
+								</div>
+								{#if issue}
+									<p class="text-xs text-red-500">{issue.message}</p>
+								{:else}
+									<p class="text-on-surface2 text-[11px]">
+										Prepended to every tool name exposed by this component. Clear to remove.
+									</p>
+								{/if}
+							</div>
 							{#if !populatedByEntry[componentId]}
 								<div class="flex flex-col items-center justify-center pb-2">
 									<p class="text-on-surface1 text-sm font-light">
@@ -316,6 +471,15 @@
 											(tool.overrideDescription || '').trim() || tool.description}
 										{@const isCustomized =
 											currentName !== tool.name || currentDescription !== tool.description}
+										{@const effectiveName = effectiveToolName(
+											tool.name,
+											tool.overrideName,
+											entry.toolPrefix
+										)}
+										{@const conflict =
+											tool.enabled !== false
+												? conflictIssue(effectiveName, effectiveNameDuplicates)
+												: undefined}
 
 										<div
 											class="dark:bg-surface2 dark:border-surface3 flex items-start gap-2 rounded border border-transparent bg-white p-2 shadow-sm"
@@ -323,8 +487,17 @@
 											<div class="flex min-w-0 grow flex-col gap-2">
 												<div class="flex items-start justify-between gap-2">
 													<div class="min-w-0">
-														<div class="truncate text-sm font-medium" title={currentName}>
-															{currentName}
+														<div class="flex items-center gap-1.5">
+															<div class="truncate text-sm font-medium" title={effectiveName}>
+																{#if entry.toolPrefix}<span class="text-on-surface2"
+																		>{entry.toolPrefix}</span
+																	>{/if}{currentName}
+															</div>
+															{#if tool.enabled !== false}
+																<ToolNameIssueIcon
+																	issue={conflict ?? toolNameIssue(effectiveName)}
+																/>
+															{/if}
 														</div>
 														{#if currentDescription}
 															<p class="line-clamp-2 text-xs" title={currentDescription}>
@@ -450,6 +623,11 @@
 	componentId={configuringComponentId}
 	isNewComponent={configuringIsNewComponent}
 	existingTools={toolsToEdit}
+	existingToolPrefix={(config.componentServers || []).find(
+		(c) => getComponentId(c) === configuringComponentId
+	)?.toolPrefix}
+	{otherEffectiveNames}
+	{otherToolPrefixes}
 	onCancel={() => {
 		if (configuringEntry) {
 			loadingByEntry[configuringEntry.id] = false;

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -9,10 +9,12 @@
 		type Project,
 		type ProjectMCP
 	} from '$lib/services';
+	import { conflictIssue, duplicateToolNames, toolNameIssue } from '$lib/services/chat/mcp';
 	import { responsive } from '$lib/stores';
 	import Search from '../Search.svelte';
 	import Toggle from '../Toggle.svelte';
 	import McpOauth from './McpOauth.svelte';
+	import ToolNameIssueIcon from './ToolNameIssueIcon.svelte';
 	import { AlertCircle, ChevronDown, ChevronUp, Info, LoaderCircle, Wrench } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
@@ -27,10 +29,21 @@
 		classes?: {
 			root?: string;
 		};
+		// When true, surface inline warning/error indicators next to each tool
+		// name for names that may be problematic for MCP clients / inference
+		// APIs (length, disallowed chars, or duplicates in this list).
+		showToolNameIssues?: boolean;
 	}
 
-	let { entry, onAuthenticate, onProjectToolsUpdate, project, noToolsContent, classes }: Props =
-		$props();
+	let {
+		entry,
+		onAuthenticate,
+		onProjectToolsUpdate,
+		project,
+		noToolsContent,
+		classes,
+		showToolNameIssues = false
+	}: Props = $props();
 	let search = $state('');
 	let tools = $state<MCPServerTool[]>([]);
 	let previewTools = $derived(getToolPreview(entry));
@@ -63,6 +76,13 @@
 				tool.name.toLowerCase().includes(search.toLowerCase()) ||
 				tool.description?.toLowerCase().includes(search.toLowerCase())
 		)
+	);
+
+	// Detect duplicate effective names across the aggregated tool list (composite
+	// previews/live lists only). Disabled via showToolNameIssues=false for other
+	// contexts so the icons stay opt-in.
+	let toolNameDuplicates = $derived(
+		showToolNameIssues ? duplicateToolNames(displayTools.map((t) => t.name)) : new Set<string>()
 	);
 
 	// Extract tool previews from the appropriate manifest
@@ -230,8 +250,12 @@
 						class:pb-2={hasContentDisplayed}
 					>
 						<div class="flex items-center justify-between gap-2">
-							<p class="text-md font-semibold">
-								{tool.name}
+							<p class="text-md flex items-center gap-1.5 font-semibold">
+								<span>{tool.name}</span>
+								{#if showToolNameIssues}
+									{@const conflict = conflictIssue(tool.name, toolNameDuplicates)}
+									<ToolNameIssueIcon issue={conflict ?? toolNameIssue(tool.name)} />
+								{/if}
 								{#if tool.unsupported}
 									<span class="text-on-surface1 ml-3 text-sm">
 										⚠️ Not yet fully supported in Obot

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -243,7 +243,7 @@
 					<LoaderCircle class="size-6 animate-spin" />
 				</div>
 			{:else if displayTools.length > 0}
-				{#each displayTools as tool (tool.name)}
+				{#each displayTools as tool, index (`${tool.name}-${index}`)}
 					{@const hasContentDisplayed = allDescriptionsEnabled || expanded[tool.id]}
 					<div
 						class="border-surface2 dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-2 rounded-md border p-3 shadow-sm"

--- a/ui/user/src/lib/components/mcp/ToolNameIssueIcon.svelte
+++ b/ui/user/src/lib/components/mcp/ToolNameIssueIcon.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { tooltip } from '$lib/actions/tooltip.svelte';
+	import { type ToolNameIssue } from '$lib/services/chat/mcp';
+	import { AlertTriangle } from 'lucide-svelte';
+
+	interface Props {
+		issue: ToolNameIssue | undefined;
+		// Render the tooltip inline instead of portaling to document.body.
+		// Required when the icon lives inside a native <dialog> modal, whose
+		// top layer hides body-portaled tooltips behind the backdrop.
+		disablePortal?: boolean;
+	}
+
+	let { issue, disablePortal = false }: Props = $props();
+</script>
+
+{#if issue}
+	<span
+		class={`inline-flex items-center ${issue.severity === 'error' ? 'text-red-500' : 'text-yellow-500'}`}
+		use:tooltip={{ text: issue.message, placement: 'top', disablePortal }}
+		aria-label={issue.message}
+	>
+		<AlertTriangle class="size-4 flex-shrink-0" />
+	</span>
+{/if}

--- a/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
@@ -3,6 +3,14 @@
 	import Search from '$lib/components/Search.svelte';
 	import Toggle from '$lib/components/Toggle.svelte';
 	import type { CompositeServerToolRow, MCPCatalogEntry, MCPCatalogServer } from '$lib/services';
+	import {
+		conflictIssue,
+		duplicateToolNames,
+		effectiveToolName,
+		TOOL_NAME_CHARSET_REGEX,
+		toolNameIssue
+	} from '$lib/services/chat/mcp';
+	import ToolNameIssueIcon from '../ToolNameIssueIcon.svelte';
 	import { AlertTriangle } from 'lucide-svelte';
 
 	interface Props {
@@ -11,16 +19,68 @@
 		onCancel?: () => void;
 		onSuccess?: () => void;
 		tools?: CompositeServerToolRow[];
+		toolPrefix?: string;
+		// Effective names of enabled tools from OTHER components of the composite,
+		// so the modal can flag cross-component final-name conflicts live as the
+		// admin edits overrides or the prefix.
+		otherEffectiveNames?: string[];
+		otherToolPrefixes?: string[];
 	}
 
-	let { configuringEntry, tools = [], onClose, onCancel, onSuccess }: Props = $props();
+	let {
+		configuringEntry,
+		tools = [],
+		toolPrefix = $bindable(),
+		otherEffectiveNames,
+		otherToolPrefixes,
+		onClose,
+		onCancel,
+		onSuccess
+	}: Props = $props();
+
+	let ownEnabledEffectiveNames = $derived(
+		tools.filter((t) => t.enabled).map((t) => effectiveToolName(t.name, t.overrideName, toolPrefix))
+	);
+	let conflictSet = $derived(
+		duplicateToolNames([...(otherEffectiveNames ?? []), ...ownEnabledEffectiveNames])
+	);
+
+	let prefixInvalid = $derived(!TOOL_NAME_CHARSET_REGEX.test(toolPrefix ?? ''));
+	let duplicatePrefix = $derived.by(() => {
+		const prefix = (toolPrefix ?? '').trim();
+		if (!prefix) return false;
+		return (otherToolPrefixes ?? []).some((p) => p === prefix);
+	});
+	let prefixIssue = $derived(
+		prefixInvalid
+			? ({
+					severity: 'error',
+					message: "Prefix may only contain letters, digits, '.', '/', '_', and '-'."
+				} as const)
+			: duplicatePrefix
+				? ({
+						severity: 'error',
+						message: `Another component already uses the prefix "${(toolPrefix ?? '').trim()}". Non-empty prefixes must be unique across components.`
+					} as const)
+				: undefined
+	);
+
+	// Only enabled tools contribute to blocking errors; disabled tools aren't exposed.
+	let hasBlockingToolNameErrors = $derived(
+		tools.some((t) => {
+			if (!t.enabled) return false;
+			const name = effectiveToolName(t.name, t.overrideName, toolPrefix);
+			if (toolNameIssue(name)?.severity === 'error') return true;
+			return conflictSet.has(name);
+		})
+	);
 	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let confirmDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let search = $state('');
 	let expandedTools = $state<Record<string, boolean>>({});
 
 	// Track initial state to detect changes
-	let initialToolsState = $state<string>('');
+	let initialConfigState = $state<string>('');
 
 	let allToolsEnabled = $derived(tools.every((tool) => tool.enabled));
 
@@ -36,13 +96,13 @@
 
 	// Check if there are any changes compared to initial state
 	let hasChanges = $derived.by(() => {
-		const currentState = JSON.stringify(tools);
-		return initialToolsState !== currentState;
+		const currentState = JSON.stringify({ tools, toolPrefix: toolPrefix ?? '' });
+		return initialConfigState !== currentState;
 	});
 
 	export function open() {
 		// Capture initial state when dialog opens
-		initialToolsState = JSON.stringify(tools);
+		initialConfigState = JSON.stringify({ tools, toolPrefix: toolPrefix ?? '' });
 		dialog?.open();
 	}
 
@@ -90,6 +150,37 @@
 		these values.
 	</p>
 	<div class="relative flex flex-col gap-2 overflow-x-hidden p-4">
+		<div class="flex flex-col gap-1">
+			<p class="flex items-center gap-1.5 text-xs text-gray-500">
+				<span>Tool name prefix</span>
+				{#if prefixIssue}
+					<ToolNameIssueIcon issue={prefixIssue} disablePortal />
+				{/if}
+			</p>
+			<div class="flex items-center gap-2">
+				<input
+					class="text-input-filled flex-1 text-sm"
+					placeholder="No prefix"
+					bind:value={toolPrefix}
+				/>
+				<button
+					type="button"
+					class="button px-3 py-1 text-xs"
+					onclick={() => {
+						toolPrefix = '';
+					}}
+				>
+					Clear
+				</button>
+			</div>
+			{#if prefixIssue}
+				<p class="text-xs text-red-500">{prefixIssue.message}</p>
+			{:else}
+				<p class="text-on-surface2 text-[11px]">
+					Prepended to every tool name exposed by this component. Clear to remove.
+				</p>
+			{/if}
+		</div>
 		<div class="flex w-full justify-end">
 			<Toggle
 				checked={allToolsEnabled}
@@ -120,14 +211,25 @@
 				(overrideName !== '' && overrideName !== tool.name) ||
 				(overrideDescription !== '' && overrideDescription !== tool.description)}
 
+			{@const effectiveName = effectiveToolName(tool.name, tool.overrideName, toolPrefix)}
+			{@const conflict = tool.enabled ? conflictIssue(effectiveName, conflictSet) : undefined}
 			<div
 				class="dark:bg-surface2 dark:border-surface3 bg-background flex items-start gap-2 rounded border border-transparent p-2 shadow-sm"
 			>
 				<div class="flex min-w-0 grow flex-col gap-2">
 					<div class="flex items-start justify-between gap-2">
 						<div class="min-w-0">
-							<div class="truncate text-sm font-medium" title={currentName}>
-								{currentName}
+							<div class="flex items-center gap-1.5">
+								<div class="truncate text-sm font-medium" title={effectiveName}>
+									{#if toolPrefix}<span class="text-on-surface2">{toolPrefix}</span
+										>{/if}{currentName}
+								</div>
+								{#if tool.enabled}
+									<ToolNameIssueIcon
+										issue={conflict ?? toolNameIssue(effectiveName)}
+										disablePortal
+									/>
+								{/if}
 							</div>
 							{#if currentDescription}
 								<p class="line-clamp-2 text-xs" title={currentDescription}>
@@ -210,6 +312,7 @@
 		<button class="button" onclick={handleCancel}>Cancel</button>
 		<button
 			class="button-primary"
+			disabled={hasBlockingToolNameErrors || !!prefixIssue}
 			onclick={() => {
 				onSuccess?.();
 				dialog?.close();

--- a/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
@@ -9,7 +9,11 @@
 		type MCPCatalogEntry,
 		type MCPCatalogServer
 	} from '$lib/services';
-	import { convertEnvHeadersToRecord, hasEditableConfiguration } from '$lib/services/chat/mcp';
+	import {
+		convertEnvHeadersToRecord,
+		deriveToolPrefix,
+		hasEditableConfiguration
+	} from '$lib/services/chat/mcp';
 	import { mcpServersAndEntries } from '$lib/stores';
 	import CatalogConfigureForm, { type LaunchFormData } from '../CatalogConfigureForm.svelte';
 	import CompositeEditTools from './CompositeEditTools.svelte';
@@ -31,6 +35,13 @@
 		// Indicates if this is a newly added component (not yet persisted to the composite entry)
 		isNewComponent?: boolean;
 		existingTools?: CompositeServerToolRow[];
+		// Current toolPrefix on the component being edited (refresh flow). Seeded into
+		// componentConfig so the edit modal displays and binds against it.
+		existingToolPrefix?: string;
+		// Effective names of enabled tools from OTHER components of the composite,
+		// so the modal can flag cross-component final-name conflicts live.
+		otherEffectiveNames?: string[];
+		otherToolPrefixes?: string[];
 	}
 
 	let {
@@ -42,7 +53,10 @@
 		compositeEntryId,
 		componentId,
 		isNewComponent = false,
-		existingTools
+		existingTools,
+		existingToolPrefix,
+		otherEffectiveNames,
+		otherToolPrefixes
 	}: Props = $props();
 	let searchDialog = $state<ReturnType<typeof SearchMcpServers>>();
 	let choiceDialog = $state<ReturnType<typeof ResponsiveDialog>>();
@@ -97,12 +111,14 @@
 					? {
 							catalogEntryID: configuringEntry.id,
 							manifest: configuringEntry.manifest,
-							toolOverrides: []
+							toolOverrides: [],
+							toolPrefix: existingToolPrefix
 						}
 					: ({
 							mcpServerID: configuringEntry.id,
 							manifest: configuringEntry.manifest,
-							toolOverrides: []
+							toolOverrides: [],
+							toolPrefix: existingToolPrefix
 						} as CatalogComponentServer);
 			initConfigureToolsDialog?.open();
 		} else {
@@ -282,17 +298,20 @@
 			return;
 		}
 
+		const defaultPrefix = deriveToolPrefix(configuringEntry.manifest?.name ?? '');
 		componentConfig =
 			'isCatalogEntry' in configuringEntry
 				? {
 						catalogEntryID: configuringEntry.id,
 						manifest: configuringEntry.manifest,
-						toolOverrides: []
+						toolOverrides: [],
+						toolPrefix: defaultPrefix
 					}
 				: ({
 						mcpServerID: configuringEntry.id,
 						manifest: configuringEntry.manifest,
 						toolOverrides: [],
+						toolPrefix: defaultPrefix,
 						disabled: false
 					} as CatalogComponentServer);
 		choiceDialog?.open();
@@ -439,6 +458,14 @@
 	bind:this={modifyToolsDialog}
 	{configuringEntry}
 	{tools}
+	{otherEffectiveNames}
+	{otherToolPrefixes}
+	bind:toolPrefix={
+		() => componentConfig?.toolPrefix,
+		(v) => {
+			if (componentConfig) componentConfig.toolPrefix = v;
+		}
+	}
 	onCancel={() => {
 		const hadConfiguringEntry = !!configuringEntry;
 		resetConfigureTool();

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -51,6 +51,7 @@ export interface CatalogComponentServer {
 	mcpServerID?: string;
 	manifest?: MCPCatalogEntryServerManifest;
 	toolOverrides?: ToolOverride[];
+	toolPrefix?: string;
 }
 
 export interface MCPCatalogEntryServerManifest {

--- a/ui/user/src/lib/services/chat/mcp.ts
+++ b/ui/user/src/lib/services/chat/mcp.ts
@@ -634,3 +634,104 @@ export const convertServerRuntimeFormDataToManifest = (
 
 	return serverManifest;
 };
+
+// deriveToolPrefix turns a human-readable component name into a sensible
+// default MCP tool-name prefix — lower_snake_case with a trailing underscore.
+// Returns "" when name is empty or contains no alphanumerics.
+export function deriveToolPrefix(name: string): string {
+	if (!name) return '';
+	const base = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '_')
+		.replace(/^_+|_+$/g, '');
+	return base ? `${base}_` : '';
+}
+
+// TOOL_NAME_CHARSET_REGEX mirrors the server-side charset check for composite
+// component tool names and prefixes (see pkg/validation/mcpvalidators.go's
+// toolNameRegex). '.' and '/' are permitted but trigger a soft warning on the
+// resulting effective tool names because some MCP clients don't support them.
+export const TOOL_NAME_CHARSET_REGEX = /^[A-Za-z0-9._/-]*$/;
+
+export type ToolNameIssue = { severity: 'warning' | 'error'; message: string };
+
+// effectiveToolName reconstructs the final name an MCP client will see for a
+// composite-component tool: prefix + (override name if set, otherwise original).
+export function effectiveToolName(
+	originalName: string,
+	overrideName: string | undefined,
+	toolPrefix: string | undefined
+): string {
+	const base = (overrideName ?? '').trim() || originalName;
+	return (toolPrefix ?? '') + base;
+}
+
+// toolNameIssue returns the highest-priority interop issue with an effective
+// tool name, or undefined if the name is clean. Callers pass the FINAL name
+// (prefix + override || original). Errors are checked before warnings; within
+// the same severity, first match wins.
+export function toolNameIssue(effectiveName: string): ToolNameIssue | undefined {
+	if (!TOOL_NAME_CHARSET_REGEX.test(effectiveName)) {
+		return { severity: 'error', message: 'Tool name contains invalid characters.' };
+	}
+	if (effectiveName.length > 128) {
+		return {
+			severity: 'error',
+			message: 'Tool name exceeds the maximum length of 128 characters.'
+		};
+	}
+	if (effectiveName.length > 64) {
+		return {
+			severity: 'warning',
+			message: `Tool names exceeding 64 characters aren't supported by some MCP clients and inference APIs.`
+		};
+	}
+	if (/[./]/.test(effectiveName)) {
+		return {
+			severity: 'warning',
+			message: `'.' and '/' in MCP server tool names are not supported by some clients.`
+		};
+	}
+	return undefined;
+}
+
+type ToolOverrideLike = { name: string; overrideName?: string; enabled?: boolean };
+type ComponentLike = { toolPrefix?: string; toolOverrides?: ToolOverrideLike[] };
+
+// compositeEffectiveToolNames returns every enabled tool's effective name
+// across the composite. Disabled tools are excluded because nanobot does not
+// expose them at runtime.
+export function compositeEffectiveToolNames(components: ComponentLike[] | undefined): string[] {
+	const out: string[] = [];
+	for (const comp of components ?? []) {
+		for (const t of comp.toolOverrides ?? []) {
+			if (t.enabled === false) continue;
+			out.push(effectiveToolName(t.name, t.overrideName, comp.toolPrefix));
+		}
+	}
+	return out;
+}
+
+// duplicateToolNames returns the set of names that appear more than once in
+// the input. Used to highlight final-name collisions across components.
+export function duplicateToolNames(names: string[]): Set<string> {
+	const counts = new Map<string, number>();
+	for (const n of names) {
+		counts.set(n, (counts.get(n) ?? 0) + 1);
+	}
+	const dups = new Set<string>();
+	for (const [n, c] of counts) {
+		if (c > 1) dups.add(n);
+	}
+	return dups;
+}
+
+// conflictIssue returns an error-severity issue when effectiveName appears in
+// the supplied duplicate set, otherwise undefined.
+export function conflictIssue(
+	effectiveName: string,
+	duplicates: Set<string>
+): ToolNameIssue | undefined {
+	if (!duplicates.has(effectiveName)) return undefined;
+	return { severity: 'error', message: 'Tool name is not unique.' };
+}

--- a/ui/user/src/lib/services/chat/types.ts
+++ b/ui/user/src/lib/services/chat/types.ts
@@ -338,6 +338,7 @@ export interface ComponentServer {
 	mcpServerID?: string;
 	manifest?: MCPServer;
 	toolOverrides?: ToolOverride[];
+	toolPrefix?: string;
 	disabled?: boolean;
 }
 

--- a/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
@@ -15,7 +15,7 @@
 	import { AdminService } from '$lib/services/index.js';
 	import { mcpServersAndEntries, profile } from '$lib/stores/index.js';
 	import { CircleFadingArrowUp, Info, GitCompare } from 'lucide-svelte';
-	import { type Component } from 'svelte';
+	import { type Component, untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
 
 	const duration = PAGE_TRANSITION_DURATION;
@@ -163,7 +163,7 @@
 
 	$effect(() => {
 		if (catalogEntry?.manifest.runtime === 'composite') {
-			mcpServersAndEntries.refreshAll();
+			untrack(() => mcpServersAndEntries.refreshAll());
 		}
 	});
 


### PR DESCRIPTION
Composite MCP servers expose tools aggregated from multiple component servers behind one endpoint. When two components expose tools with the same name nanobot silently drops the duplicates, and LLMs struggle to disambiguate near-identical names across components.

This change adds an optional `toolPrefix` on each component of a composite server. Nanobot prepends the prefix to every tool that component exposes, so all of a component's tools share a namespace (e.g. `google_calendar_list_events`). Prefixes work standalone or
alongside the existing per-tool overrides; disabled tools are still never exposed. A change to a component's prefix is treated as drift and triggers MCPServer reconciliation.

The backend enforces the same character set across prefixes and effective tool names, cross-component prefix uniqueness, and unique/length-bounded effective names across the entire composite. The admin UI seeds a default prefix derived from each component's display name, renders the live effective name for every tool, and flags invalid characters, oversized names, or cross-component collisions inline with warning/error indicators that gate Save. Composite tool previews in the server detail views surface the same indicators read-only.

Addresses https://github.com/obot-platform/obot/issues/6405

