### PR TITLE
fix: specify .nanobot as the default config location

### DIFF
--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -44,8 +44,8 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_AUDIT_LOGS_COMPRESS_FILE` | Controls whether or not to compress audit log files | `true` |
 | `OBOT_SERVER_AUDIT_LOGS_USE_PATH_STYLE` | Whether to use path style for S3 | - |
 | `OBOT_SERVER_MCPBASE_IMAGE` | Deploy MCP servers in the kubernetes cluster or using docker with this base image. | `ghcr.io/obot-platform/mcp-images/phat:v0.20.2` |
-| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.70` |
-| `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/nanobot-ai/nanobot-agent:v0.0.70` |
+| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.72` |
+| `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/nanobot-ai/nanobot-agent:v0.0.72` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.20.2` |
 | `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker, kubernetes, or local. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/moby/moby/api v1.52.0-alpha.1
 	github.com/moby/moby/client v0.1.0-alpha.0
-	github.com/nanobot-ai/nanobot v0.0.69
+	github.com/nanobot-ai/nanobot v0.0.72
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037
 	github.com/obot-platform/kinm v0.0.0-20260420174234-eec2cd66c333
 	github.com/obot-platform/nah v0.0.0-20260420174246-bea1b9e01234

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nanobot-ai/nanobot v0.0.69 h1:vOmvcTXFlJkxAKDQvugTHPRLxn0LNbO/Mw9yLhh34DA=
-github.com/nanobot-ai/nanobot v0.0.69/go.mod h1:y9rGtxA+kJVmtj8RmoHSM6/P4KCwoEtjL6MpARPuJnQ=
+github.com/nanobot-ai/nanobot v0.0.72 h1:9jg5yVaL5c90aaQrJW055aN8qLj4YBmOCg6HbomuAXA=
+github.com/nanobot-ai/nanobot v0.0.72/go.mod h1:y9rGtxA+kJVmtj8RmoHSM6/P4KCwoEtjL6MpARPuJnQ=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=

--- a/pkg/api/handlers/nanobotagent.go
+++ b/pkg/api/handlers/nanobotagent.go
@@ -212,7 +212,7 @@ func (h *NanobotAgentHandler) Launch(req api.Context) error {
 		}
 		var errHTTP *types.ErrHTTP
 		if !errors.As(err, &errHTTP) || errHTTP.Code != http.StatusBadRequest ||
-			(!strings.Contains(errHTTP.Message, "NANOBOT_ENV_FILE") && !strings.Contains(errHTTP.Message, "NANOBOT_CONFIG")) {
+			(!strings.Contains(errHTTP.Message, "NANOBOT_ENV_FILE") && !strings.Contains(errHTTP.Message, "NANOBOT_CONFIG_FILE")) {
 			return err
 		}
 		select {

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -69,6 +69,11 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 
 	mcpServerName := system.MCPServerPrefix + agent.Name
 
+	expectedArgs := []string{"run", "--state", ".nanobot/state/nanobot.db", "--config", ".nanobot/", "--config", "${NANOBOT_CONFIG_FILE}"}
+	if agent.Spec.DefaultAgent != "" {
+		expectedArgs = append(expectedArgs, "--agent", agent.Spec.DefaultAgent)
+	}
+
 	// Check if MCPServer already exists
 	var existing v1.MCPServer
 	err := req.Get(&existing, agent.Namespace, mcpServerName)
@@ -94,12 +99,6 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 			needsUpdate = true
 		}
 
-		// Check if default agent changed
-		expectedArgs := []string{"run", "--state", ".nanobot/state/nanobot.db"}
-		if agent.Spec.DefaultAgent != "" {
-			expectedArgs = append(expectedArgs, "--agent", agent.Spec.DefaultAgent)
-		}
-
 		expectedEnv := []types.MCPEnv{
 			{
 				MCPHeader: types.MCPHeader{
@@ -114,9 +113,9 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 			},
 			{
 				MCPHeader: types.MCPHeader{
-					Name:        "NANOBOT_CONFIG",
+					Name:        "NANOBOT_CONFIG_FILE",
 					Description: "Provider config YAML for Nanobot",
-					Key:         "NANOBOT_CONFIG",
+					Key:         "NANOBOT_CONFIG_FILE",
 					Sensitive:   true,
 					Required:    true,
 				},
@@ -161,12 +160,6 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 		return fmt.Errorf("failed to check for existing MCPServer: %w", err)
 	}
 
-	// Create new MCPServer
-	args := []string{"run", "--state", ".nanobot/state/nanobot.db"}
-	if agent.Spec.DefaultAgent != "" {
-		args = append(args, "--agent", agent.Spec.DefaultAgent)
-	}
-
 	mcpServer := &v1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mcpServerName,
@@ -183,7 +176,7 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 				ContainerizedConfig: &types.ContainerizedRuntimeConfig{
 					Image:   h.nanobotImage,
 					Command: "nanobot",
-					Args:    args,
+					Args:    expectedArgs,
 					Port:    8080,
 					Path:    "/mcp",
 				},
@@ -201,9 +194,9 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 					},
 					{
 						MCPHeader: types.MCPHeader{
-							Name:        "NANOBOT_CONFIG",
+							Name:        "NANOBOT_CONFIG_FILE",
 							Description: "Provider config YAML for Nanobot",
-							Key:         "NANOBOT_CONFIG",
+							Key:         "NANOBOT_CONFIG_FILE",
 							Sensitive:   true,
 							Required:    true,
 						},
@@ -294,7 +287,7 @@ func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, res
 	if !needsRefresh &&
 		credEnvFileVars["NANOBOT_DEFAULT_MODEL"] == llmDefault &&
 		credEnvFileVars["NANOBOT_DEFAULT_MINI_MODEL"] == miniDefault &&
-		cred.Env["NANOBOT_CONFIG"] == providerYAML {
+		cred.Env["NANOBOT_CONFIG_FILE"] == providerYAML {
 		// Credentials are up to date
 		return nil
 	}
@@ -378,8 +371,8 @@ func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, res
 		ToolName: mcpServerName,
 		Type:     gptscript.CredentialTypeTool,
 		Env: map[string]string{
-			"NANOBOT_ENV_FILE": strings.Join(envFileLines, "\n"),
-			"NANOBOT_CONFIG":   providerYAML,
+			"NANOBOT_ENV_FILE":    strings.Join(envFileLines, "\n"),
+			"NANOBOT_CONFIG_FILE": providerYAML,
 		},
 	}); err != nil {
 		return fmt.Errorf("failed to create credential: %w", err)

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -27,7 +27,7 @@ var log = logger.Package()
 type Options struct {
 	MCPBaseImage                      string   `usage:"The base image to use for MCP containers" default:"ghcr.io/obot-platform/mcp-images/phat:v0.20.2"`
 	MCPHTTPWebhookBaseImage           string   `usage:"The base image to use for HTTP-based MCP webhook containers" default:"ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.20.2"`
-	MCPRemoteShimBaseImage            string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.70"`
+	MCPRemoteShimBaseImage            string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.72"`
 	MCPNamespace                      string   `usage:"The namespace to use for MCP containers" default:"obot-mcp"`
 	MCPClusterDomain                  string   `usage:"The cluster domain to use for MCP containers" default:"cluster.local"`
 	DisallowLocalhostMCP              bool     `usage:"Allow MCP containers to run on localhost"`

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -125,7 +125,7 @@ type Config struct {
 	NanobotIntegration      bool   `usage:"Enable Nanobot integration" default:"true"`
 	EnableMessagePolicies   bool   `usage:"Enable message policies for LLM proxy content enforcement" default:"false"`
 	MCPServerSearchImage    string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.1.1"`
-	NanobotAgentImage       string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/nanobot-ai/nanobot-agent:v0.0.70"`
+	NanobotAgentImage       string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/nanobot-ai/nanobot-agent:v0.0.72"`
 
 	// Published artifact storage
 	ArtifactStorageProvider       string `usage:"Storage provider for published artifacts (s3, gcs, azure, custom)" name:"artifact-storage-provider" env:"OBOT_ARTIFACT_STORAGE_PROVIDER"`


### PR DESCRIPTION
The model provider configuration was specified and nanobot would try to write other configuration to its directory. The problem is that that directory is read-only because it is backed by a secret.

This change incorporates the nanobot change that allows passing the --config flag multiple times, and .nanobot will be used for this special configuration location.

Issue: https://github.com/obot-platform/obot/issues/6400