### PR TITLE
fix: tool preview generation for gvisor enabled k8s clusters

### DIFF
--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1423,7 +1423,7 @@ func tempServerAndConfig(ctx context.Context, gptClient *gptscript.GPTScript, cl
 	}
 
 	// Create temporary MCPServer object to use existing conversion logic
-	tempName := "temp-preview-" + hash.Digest(serverManifest)[:32]
+	tempName := "tool-preview-" + hash.Digest(serverManifest)[:16]
 	tempMCPServer := v1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: tempName,


### PR DESCRIPTION
gVisor produces invalid pod annotations for temporary MCP servers used to generate tool previews. This prevents the pods from deploying and breaks preview generation.

e.g.

```
Pod "temp-preview-86e0181ca875e6f8c0a5d72da8a4b690-675d8d79b8-2dl65" is invalid: metadata.annotations: Invalid value: "dev.gvisor.internal.seccomp.temp-preview-86e0181ca875e6f8c0a5d72da8a4b690-shim": name part must be no more than 63 characters
```


Shorten the hash used in temporary server names to 16 characters to prevent the gVisor pod annotation keys from exceeding the limit. (Note: after this change, the annotations should always be exactly 62 characters in length).

