### PR TITLE
enhance: show mutated request and original response in audit logs

### DIFF
--- a/apiclient/types/mcpauditlog.go
+++ b/apiclient/types/mcpauditlog.go
@@ -18,8 +18,12 @@ type MCPAuditLog struct {
 	ClientIP                  string          `json:"clientIP"`
 	CallType                  string          `json:"callType"`
 	CallIdentifier            string          `json:"callIdentifier,omitempty"`
+	RequestMutated            bool            `json:"requestMutated"`
 	RequestBody               json.RawMessage `json:"requestBody,omitempty"`
+	MutatedRequestBody        json.RawMessage `json:"mutatedRequestBody,omitempty"`
+	ResponseMutated           bool            `json:"responseMutated"`
 	ResponseBody              json.RawMessage `json:"responseBody,omitempty"`
+	OriginalResponseBody      json.RawMessage `json:"originalResponseBody,omitempty"`
 	ResponseStatus            int             `json:"responseStatus"`
 	WebhookStatuses           []WebhookStatus `json:"webhookStatuses,omitempty"`
 	Error                     string          `json:"error,omitempty"`

--- a/apiclient/types/zz_generated.deepcopy.go
+++ b/apiclient/types/zz_generated.deepcopy.go
@@ -1566,8 +1566,18 @@ func (in *MCPAuditLog) DeepCopyInto(out *MCPAuditLog) {
 		*out = make(json.RawMessage, len(*in))
 		copy(*out, *in)
 	}
+	if in.MutatedRequestBody != nil {
+		in, out := &in.MutatedRequestBody, &out.MutatedRequestBody
+		*out = make(json.RawMessage, len(*in))
+		copy(*out, *in)
+	}
 	if in.ResponseBody != nil {
 		in, out := &in.ResponseBody, &out.ResponseBody
+		*out = make(json.RawMessage, len(*in))
+		copy(*out, *in)
+	}
+	if in.OriginalResponseBody != nil {
+		in, out := &in.OriginalResponseBody, &out.OriginalResponseBody
 		*out = make(json.RawMessage, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/gateway/client/auditlogpersister.go
+++ b/pkg/gateway/client/auditlogpersister.go
@@ -16,6 +16,9 @@ func (c *Client) LogMCPAuditEntry(entry types.MCPAuditLog) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	entry.RequestMutated = len(entry.MutatedRequestBody) > 0
+	entry.ResponseMutated = len(entry.OriginalResponseBody) > 0
+
 	if err := c.encryptMCPAuditLog(ctx, &entry); err != nil {
 		log.Errorf("Failed to encrypt MCP audit log: %v", err)
 	}

--- a/pkg/gateway/client/mcpauditlog.go
+++ b/pkg/gateway/client/mcpauditlog.go
@@ -72,8 +72,16 @@ func (c *Client) insertMCPAuditLogs(ctx context.Context, logs []types.MCPAuditLo
 				}
 
 				// Update response-specific fields if they have values
+				if len(responseLog.MutatedRequestBody) > 0 {
+					updates["mutated_request_body"] = responseLog.MutatedRequestBody
+					updates["request_mutated"] = true
+				}
 				if len(responseLog.ResponseBody) > 0 {
 					updates["response_body"] = responseLog.ResponseBody
+				}
+				if len(responseLog.OriginalResponseBody) > 0 {
+					updates["original_response_body"] = responseLog.OriginalResponseBody
+					updates["response_mutated"] = true
 				}
 				if len(responseLog.ResponseHeaders) > 0 {
 					updates["response_headers"] = responseLog.ResponseHeaders
@@ -289,7 +297,9 @@ session_id %[1]s ? OR request_id %[1]s ? OR user_agent %[1]s ?`
 			// These are the only fields that are encrypted right now.
 			// So, just blank them out and skip decryption.
 			logs[i].RequestBody = nil
+			logs[i].MutatedRequestBody = nil
 			logs[i].ResponseBody = nil
+			logs[i].OriginalResponseBody = nil
 			logs[i].RequestHeaders = nil
 			logs[i].ResponseHeaders = nil
 		} else {
@@ -319,7 +329,9 @@ func (c *Client) GetMCPAuditLog(ctx context.Context, id uint, withRequestAndResp
 	if !withRequestAndResponse {
 		// Blank out encrypted fields
 		log.RequestBody = nil
+		log.MutatedRequestBody = nil
 		log.ResponseBody = nil
+		log.OriginalResponseBody = nil
 	}
 
 	return &log, nil
@@ -607,11 +619,27 @@ func (c *Client) encryptMCPAuditLog(ctx context.Context, log *types.MCPAuditLog)
 		}
 	}
 
+	if len(log.MutatedRequestBody) > 0 {
+		if b, err = transformer.TransformToStorage(ctx, log.MutatedRequestBody, dataCtx); err != nil {
+			errs = append(errs, err)
+		} else {
+			log.MutatedRequestBody = json.RawMessage(base64.StdEncoding.EncodeToString(b))
+		}
+	}
+
 	if len(log.ResponseBody) > 0 {
 		if b, err = transformer.TransformToStorage(ctx, log.ResponseBody, dataCtx); err != nil {
 			errs = append(errs, err)
 		} else {
 			log.ResponseBody = json.RawMessage(base64.StdEncoding.EncodeToString(b))
+		}
+	}
+
+	if len(log.OriginalResponseBody) > 0 {
+		if b, err = transformer.TransformToStorage(ctx, log.OriginalResponseBody, dataCtx); err != nil {
+			errs = append(errs, err)
+		} else {
+			log.OriginalResponseBody = json.RawMessage(base64.StdEncoding.EncodeToString(b))
 		}
 	}
 
@@ -669,6 +697,20 @@ func (c *Client) decryptMCPAuditLog(ctx context.Context, log *types.MCPAuditLog)
 		}
 	}
 
+	if len(log.MutatedRequestBody) > 0 {
+		decoded = make([]byte, base64.StdEncoding.DecodedLen(len(log.MutatedRequestBody)))
+		n, err = base64.StdEncoding.Decode(decoded, log.MutatedRequestBody)
+		if err == nil {
+			if out, _, err = transformer.TransformFromStorage(ctx, decoded[:n], dataCtx); err != nil {
+				errs = append(errs, err)
+			} else {
+				log.MutatedRequestBody = json.RawMessage(out)
+			}
+		} else {
+			errs = append(errs, err)
+		}
+	}
+
 	if len(log.ResponseBody) > 0 {
 		decoded = make([]byte, base64.StdEncoding.DecodedLen(len(log.ResponseBody)))
 		n, err = base64.StdEncoding.Decode(decoded, log.ResponseBody)
@@ -677,6 +719,20 @@ func (c *Client) decryptMCPAuditLog(ctx context.Context, log *types.MCPAuditLog)
 				errs = append(errs, err)
 			} else {
 				log.ResponseBody = json.RawMessage(out)
+			}
+		} else {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(log.OriginalResponseBody) > 0 {
+		decoded = make([]byte, base64.StdEncoding.DecodedLen(len(log.OriginalResponseBody)))
+		n, err = base64.StdEncoding.Decode(decoded, log.OriginalResponseBody)
+		if err == nil {
+			if out, _, err = transformer.TransformFromStorage(ctx, decoded[:n], dataCtx); err != nil {
+				errs = append(errs, err)
+			} else {
+				log.OriginalResponseBody = json.RawMessage(out)
 			}
 		} else {
 			errs = append(errs, err)

--- a/pkg/gateway/types/mcpauditlog.go
+++ b/pkg/gateway/types/mcpauditlog.go
@@ -24,8 +24,12 @@ type MCPAuditLog struct {
 	ClientIP                  string                                `json:"clientIP" gorm:"index"`
 	CallType                  string                                `json:"callType" gorm:"index"`
 	CallIdentifier            string                                `json:"callIdentifier,omitempty" gorm:"index"`
+	RequestMutated            bool                                  `json:"requestMutated"`
 	RequestBody               json.RawMessage                       `json:"requestBody,omitempty"`
+	MutatedRequestBody        json.RawMessage                       `json:"mutatedRequestBody,omitempty"`
+	ResponseMutated           bool                                  `json:"responseMutated"`
 	ResponseBody              json.RawMessage                       `json:"responseBody,omitempty"`
+	OriginalResponseBody      json.RawMessage                       `json:"originalResponseBody,omitempty"`
 	ResponseStatus            int                                   `json:"responseStatus" gorm:"index"`
 	Error                     string                                `json:"error,omitempty"`
 	ProcessingTimeMs          int64                                 `json:"processingTimeMs" gorm:"index"`
@@ -123,20 +127,24 @@ func ConvertMCPAuditLog(a MCPAuditLog) types2.MCPAuditLog {
 			Name:    a.ClientName,
 			Version: a.ClientVersion,
 		},
-		ClientIP:         a.ClientIP,
-		CallType:         a.CallType,
-		CallIdentifier:   a.CallIdentifier,
-		RequestBody:      a.RequestBody,
-		ResponseBody:     a.ResponseBody,
-		ResponseStatus:   a.ResponseStatus,
-		Error:            a.Error,
-		WebhookStatuses:  webhookStatus,
-		ProcessingTimeMs: a.ProcessingTimeMs,
-		SessionID:        a.SessionID,
-		RequestID:        a.RequestID,
-		UserAgent:        a.UserAgent,
-		RequestHeaders:   a.RequestHeaders,
-		ResponseHeaders:  a.ResponseHeaders,
+		ClientIP:             a.ClientIP,
+		CallType:             a.CallType,
+		CallIdentifier:       a.CallIdentifier,
+		RequestMutated:       a.RequestMutated,
+		RequestBody:          a.RequestBody,
+		MutatedRequestBody:   a.MutatedRequestBody,
+		ResponseMutated:      a.ResponseMutated,
+		ResponseBody:         a.ResponseBody,
+		OriginalResponseBody: a.OriginalResponseBody,
+		ResponseStatus:       a.ResponseStatus,
+		Error:                a.Error,
+		WebhookStatuses:      webhookStatus,
+		ProcessingTimeMs:     a.ProcessingTimeMs,
+		SessionID:            a.SessionID,
+		RequestID:            a.RequestID,
+		UserAgent:            a.UserAgent,
+		RequestHeaders:       a.RequestHeaders,
+		ResponseHeaders:      a.ResponseHeaders,
 	}
 }
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -3903,13 +3903,39 @@ func schema_obot_platform_obot_apiclient_types_MCPAuditLog(ref common.ReferenceC
 							Format: "",
 						},
 					},
+					"requestMutated": {
+						SchemaProps: spec.SchemaProps{
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
+						},
+					},
 					"requestBody": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "byte",
 						},
 					},
+					"mutatedRequestBody": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "byte",
+						},
+					},
+					"responseMutated": {
+						SchemaProps: spec.SchemaProps{
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
+						},
+					},
 					"responseBody": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "byte",
+						},
+					},
+					"originalResponseBody": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "byte",
@@ -3979,7 +4005,7 @@ func schema_obot_platform_obot_apiclient_types_MCPAuditLog(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"id", "createdAt", "userID", "mcpID", "mcpServerDisplayName", "mcpServerCatalogEntryName", "client", "clientIP", "callType", "responseStatus", "processingTimeMs"},
+				Required: []string{"id", "createdAt", "userID", "mcpID", "mcpServerDisplayName", "mcpServerCatalogEntryName", "client", "clientIP", "callType", "requestMutated", "responseMutated", "responseStatus", "processingTimeMs"},
 			},
 		},
 		Dependencies: []string{

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
@@ -22,6 +22,14 @@
 		profile?.current?.hasAdminAccess?.() ||
 			(auditLog.userID === profile.current.id && !auditLog.powerUserWorkspaceID)
 	);
+
+	function hasBody(body: unknown) {
+		if (body == null) return false;
+		if (typeof body === 'object' && !Array.isArray(body)) {
+			return Object.keys(body).length > 0;
+		}
+		return true;
+	}
 </script>
 
 <div
@@ -122,22 +130,14 @@
 			{/if}
 
 			{#if shouldShowPayload}
-				{#if Object.keys(auditLog.requestBody ?? {}).length > 0}
-					{@const body = JSON.stringify(auditLog.requestBody, null, 2)}
-
-					<p class="translate-y-2 pt-4 text-base font-semibold">Request Body</p>
-					<div class="relative text-white">
-						<pre class="default-scrollbar-thin max-h-96 overflow-y-auto p-4">
-						<code class="language-json">{body}</code>
-					</pre>
-
-						<CopyButton
-							classes={{ button: 'absolute right-4 top-4 flex flex-col items-end' }}
-							text={body}
-						/>
-					</div>
+				{#if hasBody(auditLog.requestBody)}
+					{@render jsonBody('Request Body', auditLog.requestBody)}
 				{:else if !hasAuditorAccess}
 					{@render noAuditorAccessInfo('Request Body')}
+				{/if}
+
+				{#if hasBody(auditLog.mutatedRequestBody)}
+					{@render jsonBody('Mutated Request Body', auditLog.mutatedRequestBody)}
 				{/if}
 			{/if}
 		</div>
@@ -185,20 +185,12 @@
 			{/if}
 
 			{#if shouldShowPayload}
-				{#if Object.keys(auditLog.responseBody ?? {}).length > 0}
-					{@const body = JSON.stringify(auditLog.responseBody, null, 2)}
+				{#if hasBody(auditLog.originalResponseBody)}
+					{@render jsonBody('Original Response Body', auditLog.originalResponseBody)}
+				{/if}
 
-					<p class="translate-y-2 pt-4 text-base font-semibold">Response Body</p>
-					<div class="relative text-white">
-						<pre class="default-scrollbar-thin max-h-96 overflow-y-auto p-4">
-						<code class="language-json">{body}</code>
-					</pre>
-
-						<CopyButton
-							classes={{ button: 'absolute right-4 top-4 flex flex-col items-end text-current' }}
-							text={body}
-						/>
-					</div>
+				{#if hasBody(auditLog.responseBody)}
+					{@render jsonBody('Response Body', auditLog.responseBody)}
 				{:else if !hasAuditorAccess}
 					{@render noAuditorAccessInfo('Response Body')}
 				{/if}
@@ -224,6 +216,22 @@
 		</div>
 	</div>
 </div>
+
+{#snippet jsonBody(name: string, value: unknown)}
+	{@const body = JSON.stringify(value, null, 2)}
+
+	<p class="translate-y-2 pt-4 text-base font-semibold">{name}</p>
+	<div class="relative text-white">
+		<pre class="default-scrollbar-thin max-h-96 overflow-y-auto p-4">
+			<code class="language-json">{body}</code>
+		</pre>
+
+		<CopyButton
+			classes={{ button: 'absolute right-4 top-4 flex flex-col items-end text-current' }}
+			text={body}
+		/>
+	</div>
+{/snippet}
 
 {#snippet noAuditorAccessInfo(name: string)}
 	<p class="mt-4 mb-2 text-base font-semibold">{name}</p>

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogs.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogs.svelte
@@ -135,6 +135,32 @@
 	</td>
 {/snippet}
 
+{#snippet mutationIndicators(requestMutated: boolean, responseMutated: boolean)}
+	<td class="text-sm whitespace-nowrap">
+		<div class="box-content flex h-full px-6">
+			<div class="flex flex-1 items-center gap-1 py-4">
+				{#if requestMutated}
+					<span
+						class="rounded-full bg-orange-500/15 px-2 py-0.5 text-[11px] font-medium text-orange-600 dark:text-orange-400"
+						title="Request was mutated"
+					>
+						Req
+					</span>
+				{/if}
+				{#if responseMutated}
+					<span
+						class="rounded-full bg-orange-500/15 px-2 py-0.5 text-[11px] font-medium text-orange-600 dark:text-orange-400"
+						title="Response was mutated"
+					>
+						Res
+					</span>
+				{/if}
+			</div>
+			{@render tdResizeHandler()}
+		</div>
+	</td>
+{/snippet}
+
 <!-- Data Table -->
 <div
 	bind:this={tableContainer}
@@ -164,6 +190,8 @@
 						{@render th('Response Code', { class: 'w-[22ch]', minWidth: '22ch' })}
 
 						{@render th('Response Time (ms)', { class: 'w-[26ch]', minWidth: '26ch' })}
+
+						{@render th('Mutated', { class: 'w-[16ch]', minWidth: '16ch' })}
 
 						{@render th('Client', { class: 'w-[19ch]', minWidth: '19ch' })}
 
@@ -197,6 +225,7 @@
 						{@render td(d.callIdentifier)}
 						{@render td(d.responseStatus)}
 						{@render td(d.processingTimeMs)}
+						{@render mutationIndicators(d.requestMutated, d.responseMutated)}
 						{@render td(d.client?.name)}
 						{@render td(d.clientIP)}
 					</tr>

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -440,17 +440,13 @@ export interface AuditLog {
 	responseStatus: number;
 	processingTimeMs: number;
 	requestHeaders?: Record<string, string | string[]>;
-	requestBody?: {
-		capabilities?: Record<string, unknown>;
-		clientInfo?: Record<string, string>;
-		protocolVersion?: string;
-	};
+	requestMutated: boolean;
+	requestBody?: unknown;
+	mutatedRequestBody?: unknown;
 	responseHeaders?: Record<string, string | string[]>;
-	responseBody?: {
-		tools?: Record<string, unknown>[];
-		prompts?: Record<string, unknown>[];
-		resources?: Record<string, unknown>[];
-	};
+	responseMutated: boolean;
+	responseBody?: unknown;
+	originalResponseBody?: unknown;
 	webhookStatuses?: {
 		type?: string;
 		method?: string;


### PR DESCRIPTION
Before this change, the audit logs would show the original request body and the mutated response body. Both the mutated request and the original response body would not be shown so it would be difficult to see what changed and why.

After this change, all such request and response bodies will be saved to the audit logs if they exist.

Part of https://github.com/obot-platform/obot/issues/6426