### PR TITLE
fix: composite prefix warnings

### DIFF
--- a/pkg/validation/mcpvalidators.go
+++ b/pkg/validation/mcpvalidators.go
@@ -21,9 +21,14 @@ var (
 	hostnameRegex = regexp.MustCompile(`^(?:\*\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$`)
 )
 
-// maxToolNameLength is the max length of an MCP server tool.
-// It's used to validate effective tool names after tool overrides and prefixes are applied.
-const maxToolNameLength = 128
+const (
+	// maxToolNameLength is the max length of an MCP server tool.
+	// It's used to validate effective tool names after tool overrides and prefixes are applied.
+	maxToolNameLength = 128
+
+	// maxToolPrefixLength is the max length of a composite component tool prefix.
+	maxToolPrefixLength = 64
+)
 
 // RuntimeValidator defines the interface for validating runtime-specific configurations
 type RuntimeValidator interface {
@@ -596,6 +601,13 @@ func (v CompositeValidator) ValidateConfig(manifest types.MCPServerManifest) err
 					Message: "toolPrefix must match " + toolNameRegex.String(),
 				}
 			}
+			if len(prefix) > maxToolPrefixLength {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolPrefix", i),
+					Message: fmt.Sprintf("toolPrefix must be at most %d characters", maxToolPrefixLength),
+				}
+			}
 		}
 
 		// Validate tool overrides
@@ -741,6 +753,13 @@ func (v CompositeValidator) ValidateCatalogConfig(manifest types.MCPServerCatalo
 					Runtime: types.RuntimeComposite,
 					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolPrefix", i),
 					Message: "toolPrefix must match " + toolNameRegex.String(),
+				}
+			}
+			if len(prefix) > maxToolPrefixLength {
+				return types.RuntimeValidationError{
+					Runtime: types.RuntimeComposite,
+					Field:   fmt.Sprintf("compositeConfig.componentServers[%d].toolPrefix", i),
+					Message: fmt.Sprintf("toolPrefix must be at most %d characters", maxToolPrefixLength),
 				}
 			}
 		}

--- a/pkg/validation/mcpvalidators_test.go
+++ b/pkg/validation/mcpvalidators_test.go
@@ -1139,6 +1139,46 @@ func TestCompositeValidator_ValidateCatalogConfig(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "tool prefix at max length is allowed",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolPrefix: strings.Repeat("a", maxToolPrefixLength),
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "tool prefix exceeds max length",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolPrefix: strings.Repeat("a", maxToolPrefixLength+1),
+						},
+					},
+				},
+			},
+			expectedError: types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   "compositeConfig.componentServers[0].toolPrefix",
+				Message: "toolPrefix must be at most 64 characters",
+			},
+		},
+		{
 			name: "empty tool prefixes may repeat across components",
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeComposite,
@@ -1196,9 +1236,9 @@ func TestCompositeValidator_ValidateCatalogConfig(t *testing.T) {
 							Manifest: types.MCPServerCatalogEntryManifest{
 								Runtime: types.RuntimeRemote,
 							},
-							ToolPrefix: strings.Repeat("a", 120) + "_",
+							ToolPrefix: strings.Repeat("a", maxToolPrefixLength),
 							ToolOverrides: []types.ToolOverride{
-								{Name: "list_all_the_things", Enabled: true},
+								{Name: strings.Repeat("b", maxToolNameLength-maxToolPrefixLength+1), Enabled: true},
 							},
 						},
 					},
@@ -1209,7 +1249,7 @@ func TestCompositeValidator_ValidateCatalogConfig(t *testing.T) {
 				Field:   "compositeConfig.componentServers[0].toolOverrides[0]",
 				Message: fmt.Sprintf(
 					"effective tool name must be at most 128 characters: %q",
-					strings.Repeat("a", 120)+"_list_all_the_things",
+					strings.Repeat("a", maxToolPrefixLength)+strings.Repeat("b", maxToolNameLength-maxToolPrefixLength+1),
 				),
 			},
 		},
@@ -1387,6 +1427,63 @@ func TestCompositeValidator_ValidateConfig_StaticOAuth(t *testing.T) {
 				Runtime: types.RuntimeComposite,
 				Field:   "compositeConfig.componentServers[1]",
 				Message: "remote component with static OAuth cannot be included in a composite server",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateConfig(tt.manifest)
+			require.Equal(t, tt.expectedError, err)
+		})
+	}
+}
+
+func TestCompositeValidator_ValidateConfig_ToolPrefixLength(t *testing.T) {
+	validator := CompositeValidator{}
+
+	tests := []struct {
+		name          string
+		manifest      types.MCPServerManifest
+		expectedError error
+	}{
+		{
+			name: "tool prefix at max length is allowed",
+			manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeRuntimeConfig{
+					ComponentServers: []types.ComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolPrefix: strings.Repeat("a", maxToolPrefixLength),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "tool prefix exceeds max length",
+			manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeRuntimeConfig{
+					ComponentServers: []types.ComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerManifest{
+								Runtime: types.RuntimeRemote,
+							},
+							ToolPrefix: strings.Repeat("a", maxToolPrefixLength+1),
+						},
+					},
+				},
+			},
+			expectedError: types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   "compositeConfig.componentServers[0].toolPrefix",
+				Message: "toolPrefix must be at most 64 characters",
 			},
 		},
 	}

--- a/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
@@ -14,6 +14,7 @@
 		effectiveToolName,
 		MAX_TOOL_PREFIX_LENGTH,
 		TOOL_NAME_CHARSET_REGEX,
+		TOOL_NAME_SPECIAL_CHAR_WARNING,
 		toolNameIssue,
 		type ToolNameIssue
 	} from '$lib/services/chat/mcp';
@@ -139,17 +140,24 @@
 				message: `Another component already uses the prefix "${p}". Non-empty prefixes must be unique across components.`
 			};
 		}
+		if (/[./]/.test(entry.toolPrefix ?? '')) {
+			return {
+				severity: 'warning',
+				message: TOOL_NAME_SPECIAL_CHAR_WARNING
+			};
+		}
 		return undefined;
 	}
 
 	// Component-card aggregate: highest severity among all enabled tools and
-	// the component's own prefix state. Prefix issues are always errors.
+	// the component's own prefix state.
 	function componentSeverity(entry: {
 		toolOverrides?: { name: string; overrideName?: string; enabled?: boolean }[];
 		toolPrefix?: string;
 	}): 'warning' | 'error' | undefined {
-		if (prefixIssue(entry)) return 'error';
-		let out: 'warning' | 'error' | undefined;
+		const prefix = prefixIssue(entry);
+		if (prefix?.severity === 'error') return 'error';
+		let out: 'warning' | 'error' | undefined = prefix?.severity;
 		for (const t of entry.toolOverrides ?? []) {
 			const s = toolRowSeverity(t.name, t.overrideName, entry.toolPrefix, t.enabled);
 			if (s === 'error') return 'error';
@@ -160,7 +168,7 @@
 
 	$effect(() => {
 		hasToolNameErrors = (config.componentServers || []).some((entry) => {
-			if (prefixIssue(entry)) return true;
+			if (prefixIssue(entry)?.severity === 'error') return true;
 			return (entry.toolOverrides ?? []).some(
 				(t) => toolRowSeverity(t.name, t.overrideName, entry.toolPrefix, t.enabled) === 'error'
 			);
@@ -435,7 +443,11 @@
 									{/if}
 								</div>
 								{#if issue}
-									<p class="text-xs text-red-500">{issue.message}</p>
+									<p
+										class={`text-xs ${issue.severity === 'error' ? 'text-red-500' : 'text-yellow-500'}`}
+									>
+										{issue.message}
+									</p>
 								{:else}
 									<p class="text-on-surface2 text-[11px]">
 										Prepended to every tool name exposed by this component. Clear to remove.

--- a/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
@@ -12,6 +12,7 @@
 		conflictIssue,
 		duplicateToolNames,
 		effectiveToolName,
+		MAX_TOOL_PREFIX_LENGTH,
 		TOOL_NAME_CHARSET_REGEX,
 		toolNameIssue,
 		type ToolNameIssue
@@ -124,6 +125,12 @@
 			return {
 				severity: 'error',
 				message: "Prefix may only contain letters, digits, '.', '/', '_', and '-'."
+			};
+		}
+		if ((entry.toolPrefix ?? '').length > MAX_TOOL_PREFIX_LENGTH) {
+			return {
+				severity: 'error',
+				message: `Prefix exceeds ${MAX_TOOL_PREFIX_LENGTH} character limit.`
 			};
 		}
 		if (p && duplicatePrefixes.has(p)) {
@@ -356,8 +363,10 @@
 						{:else}
 							<Server class="text-on-surface1 size-8" />
 						{/if}
-						<div class="flex flex-1 items-center gap-1.5">
-							<div class="font-medium">{entry.manifest?.name || 'Unnamed Server'}</div>
+						<div class="flex min-w-0 flex-1 items-center gap-1.5">
+							<div class="truncate font-medium" title={entry.manifest?.name || 'Unnamed Server'}>
+								{entry.manifest?.name || 'Unnamed Server'}
+							</div>
 							{#if headerSeverity}
 								<ToolNameIssueIcon
 									issue={{
@@ -486,9 +495,12 @@
 										>
 											<div class="flex min-w-0 grow flex-col gap-2">
 												<div class="flex items-start justify-between gap-2">
-													<div class="min-w-0">
-														<div class="flex items-center gap-1.5">
-															<div class="truncate text-sm font-medium" title={effectiveName}>
+													<div class="min-w-0 flex-1">
+														<div class="flex min-w-0 items-center gap-1.5">
+															<div
+																class="min-w-0 flex-1 truncate text-sm font-medium"
+																title={effectiveName}
+															>
 																{#if entry.toolPrefix}<span class="text-on-surface2"
 																		>{entry.toolPrefix}</span
 																	>{/if}{currentName}

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -250,14 +250,14 @@
 						class:pb-2={hasContentDisplayed}
 					>
 						<div class="flex items-center justify-between gap-2">
-							<p class="text-md flex items-center gap-1.5 font-semibold">
-								<span>{tool.name}</span>
+							<p class="text-md flex min-w-0 flex-1 items-center gap-1.5 font-semibold">
+								<span class="min-w-0 flex-1 truncate" title={tool.name}>{tool.name}</span>
 								{#if showToolNameIssues}
 									{@const conflict = conflictIssue(tool.name, toolNameDuplicates)}
 									<ToolNameIssueIcon issue={conflict ?? toolNameIssue(tool.name)} />
 								{/if}
 								{#if tool.unsupported}
-									<span class="text-on-surface1 ml-3 text-sm">
+									<span class="text-on-surface1 ml-3 flex-shrink-0 text-sm">
 										⚠️ Not yet fully supported in Obot
 									</span>
 								{/if}

--- a/ui/user/src/lib/components/mcp/ToolNameIssueIcon.svelte
+++ b/ui/user/src/lib/components/mcp/ToolNameIssueIcon.svelte
@@ -16,7 +16,7 @@
 
 {#if issue}
 	<span
-		class={`inline-flex items-center ${issue.severity === 'error' ? 'text-red-500' : 'text-yellow-500'}`}
+		class={`inline-flex flex-shrink-0 items-center ${issue.severity === 'error' ? 'text-red-500' : 'text-yellow-500'}`}
 		use:tooltip={{ text: issue.message, placement: 'top', disablePortal }}
 		aria-label={issue.message}
 	>

--- a/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
@@ -7,6 +7,7 @@
 		conflictIssue,
 		duplicateToolNames,
 		effectiveToolName,
+		MAX_TOOL_PREFIX_LENGTH,
 		TOOL_NAME_CHARSET_REGEX,
 		toolNameIssue
 	} from '$lib/services/chat/mcp';
@@ -46,6 +47,7 @@
 	);
 
 	let prefixInvalid = $derived(!TOOL_NAME_CHARSET_REGEX.test(toolPrefix ?? ''));
+	let prefixTooLong = $derived((toolPrefix ?? '').length > MAX_TOOL_PREFIX_LENGTH);
 	let duplicatePrefix = $derived.by(() => {
 		const prefix = (toolPrefix ?? '').trim();
 		if (!prefix) return false;
@@ -57,6 +59,11 @@
 					severity: 'error',
 					message: "Prefix may only contain letters, digits, '.', '/', '_', and '-'."
 				} as const)
+			: prefixTooLong
+				? ({
+						severity: 'error',
+						message: `Prefix must be at most ${MAX_TOOL_PREFIX_LENGTH} characters.`
+					} as const)
 			: duplicatePrefix
 				? ({
 						severity: 'error',
@@ -218,9 +225,9 @@
 			>
 				<div class="flex min-w-0 grow flex-col gap-2">
 					<div class="flex items-start justify-between gap-2">
-						<div class="min-w-0">
-							<div class="flex items-center gap-1.5">
-								<div class="truncate text-sm font-medium" title={effectiveName}>
+						<div class="min-w-0 flex-1">
+							<div class="flex min-w-0 items-center gap-1.5">
+								<div class="min-w-0 flex-1 truncate text-sm font-medium" title={effectiveName}>
 									{#if toolPrefix}<span class="text-on-surface2">{toolPrefix}</span
 										>{/if}{currentName}
 								</div>

--- a/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
@@ -9,6 +9,7 @@
 		effectiveToolName,
 		MAX_TOOL_PREFIX_LENGTH,
 		TOOL_NAME_CHARSET_REGEX,
+		TOOL_NAME_SPECIAL_CHAR_WARNING,
 		toolNameIssue
 	} from '$lib/services/chat/mcp';
 	import ToolNameIssueIcon from '../ToolNameIssueIcon.svelte';
@@ -48,6 +49,7 @@
 
 	let prefixInvalid = $derived(!TOOL_NAME_CHARSET_REGEX.test(toolPrefix ?? ''));
 	let prefixTooLong = $derived((toolPrefix ?? '').length > MAX_TOOL_PREFIX_LENGTH);
+	let prefixSpecialChar = $derived(/[./]/.test(toolPrefix ?? ''));
 	let duplicatePrefix = $derived.by(() => {
 		const prefix = (toolPrefix ?? '').trim();
 		if (!prefix) return false;
@@ -64,12 +66,17 @@
 						severity: 'error',
 						message: `Prefix must be at most ${MAX_TOOL_PREFIX_LENGTH} characters.`
 					} as const)
-			: duplicatePrefix
-				? ({
-						severity: 'error',
-						message: `Another component already uses the prefix "${(toolPrefix ?? '').trim()}". Non-empty prefixes must be unique across components.`
-					} as const)
-				: undefined
+				: duplicatePrefix
+					? ({
+							severity: 'error',
+							message: `Another component already uses the prefix "${(toolPrefix ?? '').trim()}". Non-empty prefixes must be unique across components.`
+						} as const)
+					: prefixSpecialChar
+						? ({
+								severity: 'warning',
+								message: TOOL_NAME_SPECIAL_CHAR_WARNING
+							} as const)
+						: undefined
 	);
 
 	// Only enabled tools contribute to blocking errors; disabled tools aren't exposed.
@@ -181,7 +188,11 @@
 				</button>
 			</div>
 			{#if prefixIssue}
-				<p class="text-xs text-red-500">{prefixIssue.message}</p>
+				<p
+					class={`text-xs ${prefixIssue.severity === 'error' ? 'text-red-500' : 'text-yellow-500'}`}
+				>
+					{prefixIssue.message}
+				</p>
 			{:else}
 				<p class="text-on-surface2 text-[11px]">
 					Prepended to every tool name exposed by this component. Clear to remove.
@@ -319,7 +330,7 @@
 		<button class="button" onclick={handleCancel}>Cancel</button>
 		<button
 			class="button-primary"
-			disabled={hasBlockingToolNameErrors || !!prefixIssue}
+			disabled={hasBlockingToolNameErrors || prefixIssue?.severity === 'error'}
 			onclick={() => {
 				onSuccess?.();
 				dialog?.close();

--- a/ui/user/src/lib/services/chat/mcp.ts
+++ b/ui/user/src/lib/services/chat/mcp.ts
@@ -654,6 +654,8 @@ export function deriveToolPrefix(name: string): string {
 export const TOOL_NAME_CHARSET_REGEX = /^[A-Za-z0-9._/-]*$/;
 export const MAX_TOOL_PREFIX_LENGTH = 64;
 export const MAX_TOOL_NAME_LENGTH = 128;
+export const TOOL_NAME_SPECIAL_CHAR_WARNING =
+	"'.' and '/' in MCP server tool names are not supported by some clients.";
 
 export type ToolNameIssue = { severity: 'warning' | 'error'; message: string };
 
@@ -691,7 +693,7 @@ export function toolNameIssue(effectiveName: string): ToolNameIssue | undefined 
 	if (/[./]/.test(effectiveName)) {
 		return {
 			severity: 'warning',
-			message: `'.' and '/' in MCP server tool names are not supported by some clients.`
+			message: TOOL_NAME_SPECIAL_CHAR_WARNING
 		};
 	}
 	return undefined;

--- a/ui/user/src/lib/services/chat/mcp.ts
+++ b/ui/user/src/lib/services/chat/mcp.ts
@@ -652,6 +652,8 @@ export function deriveToolPrefix(name: string): string {
 // toolNameRegex). '.' and '/' are permitted but trigger a soft warning on the
 // resulting effective tool names because some MCP clients don't support them.
 export const TOOL_NAME_CHARSET_REGEX = /^[A-Za-z0-9._/-]*$/;
+export const MAX_TOOL_PREFIX_LENGTH = 64;
+export const MAX_TOOL_NAME_LENGTH = 128;
 
 export type ToolNameIssue = { severity: 'warning' | 'error'; message: string };
 
@@ -674,10 +676,10 @@ export function toolNameIssue(effectiveName: string): ToolNameIssue | undefined 
 	if (!TOOL_NAME_CHARSET_REGEX.test(effectiveName)) {
 		return { severity: 'error', message: 'Tool name contains invalid characters.' };
 	}
-	if (effectiveName.length > 128) {
+	if (effectiveName.length > MAX_TOOL_NAME_LENGTH) {
 		return {
 			severity: 'error',
-			message: 'Tool name exceeds the maximum length of 128 characters.'
+			message: `Tool name exceeds the maximum length of ${MAX_TOOL_NAME_LENGTH} characters.`
 		};
 	}
 	if (effectiveName.length > 64) {


### PR DESCRIPTION
- Limit composite component tool prefixes to 64 characters in both UI validation and backend manifest validation, with test coverage for catalog and runtime configs
- Keep long tool names from pushing warning and error indicators out of tool rows by truncating the name area while preserving the icon and controls
- Show compatibility warnings when composite tool prefixes contain dots or slashes during configuration, including saved component configuration and tool setup flows


Addresses:
- https://github.com/obot-platform/obot/issues/6429
- https://github.com/obot-platform/obot/issues/6430