### PR TITLE
feat: add storage service accounts

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -100,13 +100,17 @@ spec:
               port: http
             failureThreshold: 5
             periodSeconds: 10
-          {{- if .Values.extraEnv }}
           env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- if .Values.extraEnv }}
             {{- range $key, $value := .Values.extraEnv }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          {{- end }}
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ if .Values.config.existingSecret }}{{ .Values.config.existingSecret }}{{ else }}{{ include "obot.config.secretName" . }}{{- end }}

--- a/chart/templates/mcp.yaml
+++ b/chart/templates/mcp.yaml
@@ -72,4 +72,38 @@ roleRef:
   name: obot-mcp-role
   apiGroup: rbac.authorization.k8s.io
 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: obot-runtime-secret-role
+  labels:
+    {{- include "obot.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["obot-network-policy-provider"]
+    verbs: ["get", "update", "patch", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: obot-runtime-secret-rolebinding
+  labels:
+    {{- include "obot.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "obot.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: obot-runtime-secret-role
+  apiGroup: rbac.authorization.k8s.io
+
 {{- end }}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -55,8 +55,14 @@ func New(services *services.Services) (*Controller, error) {
 	if services.LocalK8sConfig != nil {
 		c.localK8sRouter, err = c.createLocalK8sRouter()
 		if err != nil {
-			// Log warning but don't fail - MCP deployment monitoring is optional
 			return nil, fmt.Errorf("failed to create local Kubernetes router: %w", err)
+		}
+
+		c.runtimeClient, err = kclient.New(services.LocalK8sConfig, kclient.Options{
+			Scheme: scheme.Scheme,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create runtime Kubernetes client: %w", err)
 		}
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -39,12 +39,15 @@ type Controller struct {
 	toolRefHandler        *toolreference.Handler
 	mcpCatalogHandler     *mcpcatalog.Handler
 	adminWorkspaceHandler *adminworkspace.Handler
+	runtimeClient         kclient.Client
+	now                   func() time.Time
 }
 
 func New(services *services.Services) (*Controller, error) {
 	c := &Controller{
 		router:   services.Router,
 		services: services,
+		now:      time.Now,
 	}
 
 	// Create local Kubernetes router if MCP is enabled and config is available
@@ -250,6 +253,8 @@ func (c *Controller) PostStart(ctx context.Context, client kclient.Client) {
 	// This fixes a race condition where catalog entry changes might not trigger MCPServer
 	// reconciliation if the server hadn't registered its watch yet.
 	go c.retriggerCatalogEntries(ctx, client)
+
+	go c.runServiceAccountKeyRotation(ctx)
 }
 
 // retriggerCatalogEntries touches all MCPServerCatalogEntries to trigger their handlers,

--- a/pkg/controller/serviceaccount.go
+++ b/pkg/controller/serviceaccount.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/serviceaccounts"
-	"github.com/obot-platform/obot/pkg/system"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -147,15 +146,20 @@ func (c *Controller) getServiceAccountSecretToken(ctx context.Context, account s
 		return "", nil, fmt.Errorf("failed to build runtime client: %w", err)
 	}
 
+	ns, err := c.runtimeNamespace()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get runtime namespace: %w", err)
+	}
+
 	secret := &corev1.Secret{}
 	if err := runtimeClient.Get(ctx, kclient.ObjectKey{
-		Namespace: c.runtimeNamespace(),
+		Namespace: ns,
 		Name:      account.SecretName,
 	}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			return "", secret, nil
 		}
-		return "", nil, fmt.Errorf("failed to read secret %s/%s: %w", c.runtimeNamespace(), account.SecretName, err)
+		return "", nil, fmt.Errorf("failed to read secret %s/%s: %w", ns, account.SecretName, err)
 	}
 
 	return string(secret.Data[account.SecretKey]), secret, nil
@@ -173,8 +177,13 @@ func (c *Controller) writeServiceAccountSecret(ctx context.Context, account serv
 		secret = &corev1.Secret{}
 	}
 
-	secret.ObjectMeta.Name = account.SecretName
-	secret.ObjectMeta.Namespace = c.runtimeNamespace()
+	ns, err := c.runtimeNamespace()
+	if err != nil {
+		return fmt.Errorf("failed to get runtime namespace: %w", err)
+	}
+
+	secret.Name = account.SecretName
+	secret.Namespace = ns
 	if secret.Labels == nil {
 		secret.Labels = map[string]string{}
 	}
@@ -202,28 +211,33 @@ func (c *Controller) deleteServiceAccountSecret(ctx context.Context, account ser
 		return fmt.Errorf("failed to build runtime client: %w", err)
 	}
 
+	ns, err := c.runtimeNamespace()
+	if err != nil {
+		return fmt.Errorf("failed to get runtime namespace: %w", err)
+	}
+
 	secret := &corev1.Secret{}
 	if err := runtimeClient.Get(ctx, kclient.ObjectKey{
-		Namespace: c.runtimeNamespace(),
+		Namespace: ns,
 		Name:      account.SecretName,
 	}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to read secret %s/%s for deletion: %w", c.runtimeNamespace(), account.SecretName, err)
+		return fmt.Errorf("failed to read secret %s/%s for deletion: %w", ns, account.SecretName, err)
 	}
 
 	if err := runtimeClient.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete secret %s/%s: %w", c.runtimeNamespace(), account.SecretName, err)
+		return fmt.Errorf("failed to delete secret %s/%s: %w", ns, account.SecretName, err)
 	}
 	return nil
 }
 
-func (c *Controller) runtimeNamespace() string {
+func (c *Controller) runtimeNamespace() (string, error) {
 	if namespace := os.Getenv("POD_NAMESPACE"); namespace != "" {
-		return namespace
+		return namespace, nil
 	}
-	return system.DefaultNamespace
+	return "", errors.New("could not determine runtime namespace: POD_NAMESPACE environment variable not set")
 }
 
 func (c *Controller) runtimeK8sClient() (kclient.Client, error) {

--- a/pkg/controller/serviceaccount.go
+++ b/pkg/controller/serviceaccount.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/serviceaccounts"
-	"github.com/obot-platform/obot/pkg/services"
 	"github.com/obot-platform/obot/pkg/system"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +21,8 @@ const (
 	serviceAccountOverlapWindow    = time.Hour
 	serviceAccountRotationPeriod   = time.Minute
 )
+
+var errRuntimeK8sConfigUnavailable = errors.New("runtime Kubernetes config is not configured")
 
 func (c *Controller) runServiceAccountKeyRotation(ctx context.Context) {
 	if err := c.reconcileServiceAccountKeys(ctx); err != nil {
@@ -141,7 +142,7 @@ func (c *Controller) getServiceAccountSecretToken(ctx context.Context, account s
 		return "", nil, nil
 	}
 
-	runtimeClient, err := c.runtimeK8sClient(ctx)
+	runtimeClient, err := c.runtimeK8sClient()
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to build runtime client: %w", err)
 	}
@@ -157,11 +158,11 @@ func (c *Controller) getServiceAccountSecretToken(ctx context.Context, account s
 		return "", nil, fmt.Errorf("failed to read secret %s/%s: %w", c.runtimeNamespace(), account.SecretName, err)
 	}
 
-	return string(secret.Data[serviceaccounts.NetworkPolicySecretKey]), secret, nil
+	return string(secret.Data[account.SecretKey]), secret, nil
 }
 
 func (c *Controller) writeServiceAccountSecret(ctx context.Context, account serviceaccounts.Account, existing *corev1.Secret, token string, rotatedAt, expiresAt time.Time) error {
-	runtimeClient, err := c.runtimeK8sClient(ctx)
+	runtimeClient, err := c.runtimeK8sClient()
 	if err != nil {
 		return fmt.Errorf("failed to build runtime client: %w", err)
 	}
@@ -180,10 +181,10 @@ func (c *Controller) writeServiceAccountSecret(ctx context.Context, account serv
 	secret.Labels["app.kubernetes.io/name"] = "obot"
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
-		serviceaccounts.NetworkPolicySecretKey: []byte(token),
-		serviceaccounts.ServiceAccountNameKey:  []byte(account.Name),
-		serviceaccounts.RotatedAtKey:           []byte(rotatedAt.UTC().Format(time.RFC3339)),
-		serviceaccounts.ExpiresAtKey:           []byte(expiresAt.UTC().Format(time.RFC3339)),
+		account.SecretKey:                     []byte(token),
+		serviceaccounts.ServiceAccountNameKey: []byte(account.Name),
+		serviceaccounts.RotatedAtKey:          []byte(rotatedAt.UTC().Format(time.RFC3339)),
+		serviceaccounts.ExpiresAtKey:          []byte(expiresAt.UTC().Format(time.RFC3339)),
 	}
 
 	if create {
@@ -193,7 +194,10 @@ func (c *Controller) writeServiceAccountSecret(ctx context.Context, account serv
 }
 
 func (c *Controller) deleteServiceAccountSecret(ctx context.Context, account serviceaccounts.Account) error {
-	runtimeClient, err := c.runtimeK8sClient(ctx)
+	runtimeClient, err := c.runtimeK8sClient()
+	if errors.Is(err, errRuntimeK8sConfigUnavailable) {
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to build runtime client: %w", err)
 	}
@@ -222,17 +226,16 @@ func (c *Controller) runtimeNamespace() string {
 	return system.DefaultNamespace
 }
 
-func (c *Controller) runtimeK8sClient(ctx context.Context) (kclient.Client, error) {
+func (c *Controller) runtimeK8sClient() (kclient.Client, error) {
 	if c.runtimeClient != nil {
 		return c.runtimeClient, nil
 	}
 
-	cfg, err := services.BuildLocalK8sConfig()
-	if err != nil {
-		return nil, err
+	if c.services.LocalK8sConfig == nil {
+		return nil, errRuntimeK8sConfigUnavailable
 	}
 
-	client, err := kclient.New(cfg, kclient.Options{
+	client, err := kclient.New(c.services.LocalK8sConfig, kclient.Options{
 		Scheme: scheme.Scheme,
 	})
 	if err != nil {

--- a/pkg/controller/serviceaccount.go
+++ b/pkg/controller/serviceaccount.go
@@ -1,0 +1,244 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/serviceaccounts"
+	"github.com/obot-platform/obot/pkg/services"
+	"github.com/obot-platform/obot/pkg/system"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes/scheme"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	serviceAccountRotationInterval = 10 * time.Hour
+	serviceAccountOverlapWindow    = time.Hour
+	serviceAccountRotationPeriod   = time.Minute
+)
+
+func (c *Controller) runServiceAccountKeyRotation(ctx context.Context) {
+	if err := c.reconcileServiceAccountKeys(ctx); err != nil {
+		log.Errorf("failed to reconcile service account keys: %v", err)
+	}
+
+	ticker := time.NewTicker(serviceAccountRotationPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := c.reconcileServiceAccountKeys(ctx); err != nil {
+				log.Errorf("failed to reconcile service account keys: %v", err)
+			}
+		}
+	}
+}
+
+func (c *Controller) reconcileServiceAccountKeys(ctx context.Context) error {
+	for _, account := range serviceaccounts.All() {
+		if !serviceaccounts.Enabled(account, c.services.MCPRuntimeBackend) {
+			if err := c.cleanupServiceAccountKey(ctx, account); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := c.reconcileServiceAccountKey(ctx, account); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) cleanupServiceAccountKey(ctx context.Context, account serviceaccounts.Account) error {
+	if err := c.services.GatewayClient.DeleteAllServiceAccountAPIKeys(ctx, account.Name); err != nil {
+		return fmt.Errorf("failed to delete disabled keys for %s: %w", account.Name, err)
+	}
+
+	if account.SecretManaged {
+		if err := c.deleteServiceAccountSecret(ctx, account); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) reconcileServiceAccountKey(ctx context.Context, account serviceaccounts.Account) error {
+	now := c.now().UTC()
+	if err := c.services.GatewayClient.DeleteExpiredServiceAccountAPIKeys(ctx, account.Name, now); err != nil {
+		return fmt.Errorf("failed to delete expired keys for %s: %w", account.Name, err)
+	}
+
+	keys, err := c.services.GatewayClient.ListServiceAccountAPIKeys(ctx, account.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list keys for %s: %w", account.Name, err)
+	}
+
+	var latestActive *types.ServiceAccountAPIKey
+	for i := range keys {
+		key := &keys[i]
+		if key.ValidAfter.After(now) {
+			continue
+		}
+		if key.RetireAfter != nil && key.RetireAfter.Before(now) {
+			continue
+		}
+		if latestActive == nil || key.CreatedAt.After(latestActive.CreatedAt) {
+			latestActive = key
+		}
+	}
+
+	secretToken, secretKey, err := c.getServiceAccountSecretToken(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	secretCurrent := false
+	if secretToken != "" {
+		existingKey, validateErr := c.services.GatewayClient.ValidateStorageServiceAccountToken(ctx, secretToken)
+		if validateErr == nil && existingKey.ServiceAccountName == account.Name && latestActive != nil && existingKey.ID == latestActive.ID {
+			secretCurrent = true
+		}
+	}
+
+	needsRotation := latestActive == nil || !secretCurrent || now.Sub(latestActive.CreatedAt) >= serviceAccountRotationInterval
+	if !needsRotation {
+		return nil
+	}
+
+	newKey, err := c.services.GatewayClient.CreateServiceAccountAPIKey(ctx, account.Name, now)
+	if err != nil {
+		return fmt.Errorf("failed to create key for %s: %w", account.Name, err)
+	}
+
+	if account.SecretManaged {
+		if err := c.writeServiceAccountSecret(ctx, account, secretKey, newKey.Token, newKey.CreatedAt, newKey.CreatedAt.Add(serviceAccountRotationInterval)); err != nil {
+			if deleteErr := c.services.GatewayClient.DeleteServiceAccountAPIKeyByID(ctx, newKey.ID); deleteErr != nil {
+				return errors.Join(err, fmt.Errorf("failed to roll back new key %d: %w", newKey.ID, deleteErr))
+			}
+			return err
+		}
+	}
+
+	if err := c.services.GatewayClient.RetireOtherServiceAccountAPIKeys(ctx, account.Name, newKey.ID, now.Add(serviceAccountOverlapWindow)); err != nil {
+		return fmt.Errorf("failed to retire older keys for %s: %w", account.Name, err)
+	}
+
+	return nil
+}
+
+func (c *Controller) getServiceAccountSecretToken(ctx context.Context, account serviceaccounts.Account) (string, *corev1.Secret, error) {
+	if !account.SecretManaged {
+		return "", nil, nil
+	}
+
+	runtimeClient, err := c.runtimeK8sClient(ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to build runtime client: %w", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := runtimeClient.Get(ctx, kclient.ObjectKey{
+		Namespace: c.runtimeNamespace(),
+		Name:      account.SecretName,
+	}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", secret, nil
+		}
+		return "", nil, fmt.Errorf("failed to read secret %s/%s: %w", c.runtimeNamespace(), account.SecretName, err)
+	}
+
+	return string(secret.Data[serviceaccounts.NetworkPolicySecretKey]), secret, nil
+}
+
+func (c *Controller) writeServiceAccountSecret(ctx context.Context, account serviceaccounts.Account, existing *corev1.Secret, token string, rotatedAt, expiresAt time.Time) error {
+	runtimeClient, err := c.runtimeK8sClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build runtime client: %w", err)
+	}
+
+	create := existing == nil || existing.Name == ""
+	secret := existing
+	if secret == nil {
+		secret = &corev1.Secret{}
+	}
+
+	secret.ObjectMeta.Name = account.SecretName
+	secret.ObjectMeta.Namespace = c.runtimeNamespace()
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels["app.kubernetes.io/name"] = "obot"
+	secret.Type = corev1.SecretTypeOpaque
+	secret.Data = map[string][]byte{
+		serviceaccounts.NetworkPolicySecretKey: []byte(token),
+		serviceaccounts.ServiceAccountNameKey:  []byte(account.Name),
+		serviceaccounts.RotatedAtKey:           []byte(rotatedAt.UTC().Format(time.RFC3339)),
+		serviceaccounts.ExpiresAtKey:           []byte(expiresAt.UTC().Format(time.RFC3339)),
+	}
+
+	if create {
+		return runtimeClient.Create(ctx, secret)
+	}
+	return runtimeClient.Update(ctx, secret)
+}
+
+func (c *Controller) deleteServiceAccountSecret(ctx context.Context, account serviceaccounts.Account) error {
+	runtimeClient, err := c.runtimeK8sClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build runtime client: %w", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := runtimeClient.Get(ctx, kclient.ObjectKey{
+		Namespace: c.runtimeNamespace(),
+		Name:      account.SecretName,
+	}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read secret %s/%s for deletion: %w", c.runtimeNamespace(), account.SecretName, err)
+	}
+
+	if err := runtimeClient.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete secret %s/%s: %w", c.runtimeNamespace(), account.SecretName, err)
+	}
+	return nil
+}
+
+func (c *Controller) runtimeNamespace() string {
+	if namespace := os.Getenv("POD_NAMESPACE"); namespace != "" {
+		return namespace
+	}
+	return system.DefaultNamespace
+}
+
+func (c *Controller) runtimeK8sClient(ctx context.Context) (kclient.Client, error) {
+	if c.runtimeClient != nil {
+		return c.runtimeClient, nil
+	}
+
+	cfg, err := services.BuildLocalK8sConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := kclient.New(cfg, kclient.Options{
+		Scheme: scheme.Scheme,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c.runtimeClient = client
+	return client, nil
+}

--- a/pkg/controller/serviceaccount.go
+++ b/pkg/controller/serviceaccount.go
@@ -97,7 +97,7 @@ func (c *Controller) reconcileServiceAccountKey(ctx context.Context, account ser
 		}
 	}
 
-	secretToken, secretKey, err := c.getServiceAccountSecretToken(ctx, account)
+	secretToken, existingSecret, err := c.getServiceAccountSecretToken(ctx, account)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (c *Controller) reconcileServiceAccountKey(ctx context.Context, account ser
 	}
 
 	if account.SecretManaged {
-		if err := c.writeServiceAccountSecret(ctx, account, secretKey, newKey.Token, newKey.CreatedAt, newKey.CreatedAt.Add(serviceAccountRotationInterval)); err != nil {
+		if err := c.writeServiceAccountSecret(ctx, account, existingSecret, newKey.Token, newKey.CreatedAt, newKey.CreatedAt.Add(serviceAccountRotationInterval)); err != nil {
 			if deleteErr := c.services.GatewayClient.DeleteServiceAccountAPIKeyByID(ctx, newKey.ID); deleteErr != nil {
 				return errors.Join(err, fmt.Errorf("failed to roll back new key %d: %w", newKey.ID, deleteErr))
 			}

--- a/pkg/controller/serviceaccount.go
+++ b/pkg/controller/serviceaccount.go
@@ -11,7 +11,6 @@ import (
 	"github.com/obot-platform/obot/pkg/serviceaccounts"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/kubernetes/scheme"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,18 +43,19 @@ func (c *Controller) runServiceAccountKeyRotation(ctx context.Context) {
 }
 
 func (c *Controller) reconcileServiceAccountKeys(ctx context.Context) error {
+	var errs []error
 	for _, account := range serviceaccounts.All() {
 		if !serviceaccounts.Enabled(account, c.services.MCPRuntimeBackend) {
 			if err := c.cleanupServiceAccountKey(ctx, account); err != nil {
-				return err
+				errs = append(errs, err)
 			}
 			continue
 		}
 		if err := c.reconcileServiceAccountKey(ctx, account); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func (c *Controller) cleanupServiceAccountKey(ctx context.Context, account serviceaccounts.Account) error {
@@ -241,21 +241,8 @@ func (c *Controller) runtimeNamespace() (string, error) {
 }
 
 func (c *Controller) runtimeK8sClient() (kclient.Client, error) {
-	if c.runtimeClient != nil {
-		return c.runtimeClient, nil
-	}
-
-	if c.services.LocalK8sConfig == nil {
+	if c.runtimeClient == nil {
 		return nil, errRuntimeK8sConfigUnavailable
 	}
-
-	client, err := kclient.New(c.services.LocalK8sConfig, kclient.Options{
-		Scheme: scheme.Scheme,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	c.runtimeClient = client
-	return client, nil
+	return c.runtimeClient, nil
 }

--- a/pkg/controller/serviceaccount_test.go
+++ b/pkg/controller/serviceaccount_test.go
@@ -85,7 +85,7 @@ func TestReconcileServiceAccountKeyBootstrapsSecret(t *testing.T) {
 	if string(secret.Data[serviceaccounts.ServiceAccountNameKey]) != account.Name {
 		t.Fatalf("expected secret serviceAccountName=%q, got %q", account.Name, secret.Data[serviceaccounts.ServiceAccountNameKey])
 	}
-	if _, err := gatewayClient.ValidateStorageServiceAccountToken(ctx, string(secret.Data[serviceaccounts.NetworkPolicySecretKey])); err != nil {
+	if _, err := gatewayClient.ValidateStorageServiceAccountToken(ctx, string(secret.Data[account.SecretKey])); err != nil {
 		t.Fatalf("expected secret token to validate, got %v", err)
 	}
 }
@@ -115,7 +115,7 @@ func TestReconcileServiceAccountKeyRotatesWithOverlap(t *testing.T) {
 	}, secret); err != nil {
 		t.Fatalf("failed to read service account secret: %v", err)
 	}
-	oldToken := string(secret.Data[serviceaccounts.NetworkPolicySecretKey])
+	oldToken := string(secret.Data[account.SecretKey])
 
 	controller.now = func() time.Time { return base.Add(11 * time.Hour) }
 	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
@@ -128,7 +128,7 @@ func TestReconcileServiceAccountKeyRotatesWithOverlap(t *testing.T) {
 	}, secret); err != nil {
 		t.Fatalf("failed to read rotated service account secret: %v", err)
 	}
-	newToken := string(secret.Data[serviceaccounts.NetworkPolicySecretKey])
+	newToken := string(secret.Data[account.SecretKey])
 	if newToken == oldToken {
 		t.Fatal("expected rotation to write a new token to the secret")
 	}
@@ -205,8 +205,7 @@ func TestReconcileServiceAccountKeysSkipsWhenBackendNotKubernetes(t *testing.T) 
 			GatewayClient:     gatewayClient,
 			MCPRuntimeBackend: "docker",
 		},
-		runtimeClient: newRuntimeSecretClient(),
-		now:           func() time.Time { return base },
+		now: func() time.Time { return base },
 	}
 
 	account, _ := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)
@@ -222,12 +221,8 @@ func TestReconcileServiceAccountKeysSkipsWhenBackendNotKubernetes(t *testing.T) 
 		t.Fatalf("expected no keys to be created for non-kubernetes backend, got %d", len(keys))
 	}
 
-	secret := &corev1.Secret{}
-	if err := controller.runtimeClient.Get(ctx, kclient.ObjectKey{
-		Namespace: controller.runtimeNamespace(),
-		Name:      account.SecretName,
-	}, secret); err == nil {
-		t.Fatal("expected no secret to be created for non-kubernetes backend")
+	if controller.runtimeClient != nil {
+		t.Fatal("expected no runtime client to be created for non-kubernetes backend")
 	}
 }
 
@@ -248,7 +243,7 @@ func TestReconcileServiceAccountKeysCleansUpWhenBackendDisabled(t *testing.T) {
 	secret.Namespace = system.DefaultNamespace
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
-		serviceaccounts.NetworkPolicySecretKey: []byte(created.Token),
+		account.SecretKey: []byte(created.Token),
 	}
 	if err := runtimeClient.Create(ctx, secret); err != nil {
 		t.Fatalf("failed to create secret fixture: %v", err)

--- a/pkg/controller/serviceaccount_test.go
+++ b/pkg/controller/serviceaccount_test.go
@@ -1,0 +1,284 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
+	"github.com/obot-platform/obot/pkg/serviceaccounts"
+	"github.com/obot-platform/obot/pkg/services"
+	sservices "github.com/obot-platform/obot/pkg/storage/services"
+	"github.com/obot-platform/obot/pkg/system"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestGatewayClient(t *testing.T) *gatewayclient.Client {
+	t.Helper()
+
+	storageServices, err := sservices.New(sservices.Config{
+		DSN: "sqlite://:memory:",
+	})
+	if err != nil {
+		t.Fatalf("failed to create storage services: %v", err)
+	}
+
+	db, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
+	if err != nil {
+		t.Fatalf("failed to create gateway db: %v", err)
+	}
+	if err := db.AutoMigrate(); err != nil {
+		t.Fatalf("failed to migrate gateway db: %v", err)
+	}
+
+	return gatewayclient.New(context.Background(), db, nil, nil, nil, nil, time.Minute, 10, 90)
+}
+
+func newRuntimeSecretClient() kclient.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		Build()
+}
+
+func TestReconcileServiceAccountKeyBootstrapsSecret(t *testing.T) {
+	ctx := context.Background()
+	gatewayClient := newTestGatewayClient(t)
+	base := time.Now().UTC().Add(-time.Hour)
+	controller := &Controller{
+		services: &services.Services{
+			GatewayClient:     gatewayClient,
+			MCPRuntimeBackend: "kubernetes",
+		},
+		runtimeClient: newRuntimeSecretClient(),
+		now:           func() time.Time { return base },
+	}
+
+	account, ok := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)
+	if !ok {
+		t.Fatal("expected hardcoded service account to exist")
+	}
+
+	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	keys, err := gatewayClient.ListServiceAccountAPIKeys(ctx, account.Name)
+	if err != nil {
+		t.Fatalf("failed to list service account keys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+
+	secret := &corev1.Secret{}
+	if err := controller.runtimeClient.Get(ctx, kclient.ObjectKey{
+		Namespace: controller.runtimeNamespace(),
+		Name:      account.SecretName,
+	}, secret); err != nil {
+		t.Fatalf("failed to read service account secret: %v", err)
+	}
+
+	if string(secret.Data[serviceaccounts.ServiceAccountNameKey]) != account.Name {
+		t.Fatalf("expected secret serviceAccountName=%q, got %q", account.Name, secret.Data[serviceaccounts.ServiceAccountNameKey])
+	}
+	if _, err := gatewayClient.ValidateStorageServiceAccountToken(ctx, string(secret.Data[serviceaccounts.NetworkPolicySecretKey])); err != nil {
+		t.Fatalf("expected secret token to validate, got %v", err)
+	}
+}
+
+func TestReconcileServiceAccountKeyRotatesWithOverlap(t *testing.T) {
+	ctx := context.Background()
+	gatewayClient := newTestGatewayClient(t)
+	base := time.Now().UTC().Add(-11 * time.Hour)
+	controller := &Controller{
+		services: &services.Services{
+			GatewayClient:     gatewayClient,
+			MCPRuntimeBackend: "kubernetes",
+		},
+		runtimeClient: newRuntimeSecretClient(),
+		now:           func() time.Time { return base },
+	}
+
+	account, _ := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)
+	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := controller.runtimeClient.Get(ctx, kclient.ObjectKey{
+		Namespace: controller.runtimeNamespace(),
+		Name:      account.SecretName,
+	}, secret); err != nil {
+		t.Fatalf("failed to read service account secret: %v", err)
+	}
+	oldToken := string(secret.Data[serviceaccounts.NetworkPolicySecretKey])
+
+	controller.now = func() time.Time { return base.Add(11 * time.Hour) }
+	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
+		t.Fatalf("unexpected reconcile error on rotation: %v", err)
+	}
+
+	if err := controller.runtimeClient.Get(ctx, kclient.ObjectKey{
+		Namespace: controller.runtimeNamespace(),
+		Name:      account.SecretName,
+	}, secret); err != nil {
+		t.Fatalf("failed to read rotated service account secret: %v", err)
+	}
+	newToken := string(secret.Data[serviceaccounts.NetworkPolicySecretKey])
+	if newToken == oldToken {
+		t.Fatal("expected rotation to write a new token to the secret")
+	}
+
+	keys, err := gatewayClient.ListServiceAccountAPIKeys(ctx, account.Name)
+	if err != nil {
+		t.Fatalf("failed to list service account keys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 overlapping keys after rotation, got %d", len(keys))
+	}
+
+	if _, err := gatewayClient.ValidateStorageServiceAccountToken(ctx, oldToken); err != nil {
+		t.Fatalf("expected previous token to remain valid during overlap, got %v", err)
+	}
+	if _, err := gatewayClient.ValidateStorageServiceAccountToken(ctx, newToken); err != nil {
+		t.Fatalf("expected new token to validate, got %v", err)
+	}
+
+	var retiredCount int
+	for _, key := range keys {
+		if key.RetireAfter != nil {
+			retiredCount++
+		}
+	}
+	if retiredCount != 1 {
+		t.Fatalf("expected 1 retired overlapping key, got %d", retiredCount)
+	}
+}
+
+func TestReconcileServiceAccountKeyDeletesExpiredOverlapKeys(t *testing.T) {
+	ctx := context.Background()
+	gatewayClient := newTestGatewayClient(t)
+	base := time.Now().UTC().Add(-11 * time.Hour)
+	controller := &Controller{
+		services: &services.Services{
+			GatewayClient:     gatewayClient,
+			MCPRuntimeBackend: "kubernetes",
+		},
+		runtimeClient: newRuntimeSecretClient(),
+		now:           func() time.Time { return base },
+	}
+
+	account, _ := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)
+	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	controller.now = func() time.Time { return base.Add(11 * time.Hour) }
+	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
+		t.Fatalf("unexpected reconcile error on rotation: %v", err)
+	}
+
+	controller.now = func() time.Time { return base.Add(12*time.Hour + time.Minute) }
+	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
+		t.Fatalf("unexpected reconcile error on cleanup: %v", err)
+	}
+
+	keys, err := gatewayClient.ListServiceAccountAPIKeys(ctx, account.Name)
+	if err != nil {
+		t.Fatalf("failed to list service account keys after cleanup: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected expired overlap keys to be removed, got %d keys", len(keys))
+	}
+}
+
+func TestReconcileServiceAccountKeysSkipsWhenBackendNotKubernetes(t *testing.T) {
+	ctx := context.Background()
+	gatewayClient := newTestGatewayClient(t)
+	base := time.Now().UTC()
+	controller := &Controller{
+		services: &services.Services{
+			GatewayClient:     gatewayClient,
+			MCPRuntimeBackend: "docker",
+		},
+		runtimeClient: newRuntimeSecretClient(),
+		now:           func() time.Time { return base },
+	}
+
+	account, _ := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)
+	if err := controller.reconcileServiceAccountKeys(ctx); err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	keys, err := gatewayClient.ListServiceAccountAPIKeys(ctx, account.Name)
+	if err != nil {
+		t.Fatalf("failed to list service account keys: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("expected no keys to be created for non-kubernetes backend, got %d", len(keys))
+	}
+
+	secret := &corev1.Secret{}
+	if err := controller.runtimeClient.Get(ctx, kclient.ObjectKey{
+		Namespace: controller.runtimeNamespace(),
+		Name:      account.SecretName,
+	}, secret); err == nil {
+		t.Fatal("expected no secret to be created for non-kubernetes backend")
+	}
+}
+
+func TestReconcileServiceAccountKeysCleansUpWhenBackendDisabled(t *testing.T) {
+	ctx := context.Background()
+	gatewayClient := newTestGatewayClient(t)
+	base := time.Now().UTC()
+	account, _ := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)
+	runtimeClient := newRuntimeSecretClient()
+
+	created, err := gatewayClient.CreateServiceAccountAPIKey(ctx, account.Name, base)
+	if err != nil {
+		t.Fatalf("failed to create service account key: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	secret.Name = account.SecretName
+	secret.Namespace = system.DefaultNamespace
+	secret.Type = corev1.SecretTypeOpaque
+	secret.Data = map[string][]byte{
+		serviceaccounts.NetworkPolicySecretKey: []byte(created.Token),
+	}
+	if err := runtimeClient.Create(ctx, secret); err != nil {
+		t.Fatalf("failed to create secret fixture: %v", err)
+	}
+
+	controller := &Controller{
+		services: &services.Services{
+			GatewayClient:     gatewayClient,
+			MCPRuntimeBackend: "docker",
+		},
+		runtimeClient: runtimeClient,
+		now:           func() time.Time { return base },
+	}
+
+	if err := controller.reconcileServiceAccountKeys(ctx); err != nil {
+		t.Fatalf("unexpected reconcile error: %v", err)
+	}
+
+	keys, err := gatewayClient.ListServiceAccountAPIKeys(ctx, account.Name)
+	if err != nil {
+		t.Fatalf("failed to list service account keys: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("expected disabled backend cleanup to remove keys, got %d", len(keys))
+	}
+
+	if err := runtimeClient.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      account.SecretName,
+	}, &corev1.Secret{}); err == nil {
+		t.Fatal("expected disabled backend cleanup to remove secret")
+	}
+}

--- a/pkg/controller/serviceaccount_test.go
+++ b/pkg/controller/serviceaccount_test.go
@@ -62,6 +62,7 @@ func TestReconcileServiceAccountKeyBootstrapsSecret(t *testing.T) {
 		t.Fatal("expected hardcoded service account to exist")
 	}
 
+	t.Setenv("POD_NAMESPACE", "obot")
 	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
 		t.Fatalf("unexpected reconcile error: %v", err)
 	}
@@ -74,9 +75,14 @@ func TestReconcileServiceAccountKeyBootstrapsSecret(t *testing.T) {
 		t.Fatalf("expected 1 key, got %d", len(keys))
 	}
 
+	ns, err := controller.runtimeNamespace()
+	if err != nil {
+		t.Fatalf("unexpected runtime namespace error: %v", err)
+	}
+
 	secret := &corev1.Secret{}
 	if err := controller.runtimeClient.Get(ctx, kclient.ObjectKey{
-		Namespace: controller.runtimeNamespace(),
+		Namespace: ns,
 		Name:      account.SecretName,
 	}, secret); err != nil {
 		t.Fatalf("failed to read service account secret: %v", err)
@@ -104,13 +110,19 @@ func TestReconcileServiceAccountKeyRotatesWithOverlap(t *testing.T) {
 	}
 
 	account, _ := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)
+	t.Setenv("POD_NAMESPACE", "obot")
 	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
 		t.Fatalf("unexpected reconcile error: %v", err)
 	}
 
+	ns, err := controller.runtimeNamespace()
+	if err != nil {
+		t.Fatalf("unexpected runtime namespace error: %v", err)
+	}
+
 	secret := &corev1.Secret{}
 	if err := controller.runtimeClient.Get(ctx, kclient.ObjectKey{
-		Namespace: controller.runtimeNamespace(),
+		Namespace: ns,
 		Name:      account.SecretName,
 	}, secret); err != nil {
 		t.Fatalf("failed to read service account secret: %v", err)
@@ -123,7 +135,7 @@ func TestReconcileServiceAccountKeyRotatesWithOverlap(t *testing.T) {
 	}
 
 	if err := controller.runtimeClient.Get(ctx, kclient.ObjectKey{
-		Namespace: controller.runtimeNamespace(),
+		Namespace: ns,
 		Name:      account.SecretName,
 	}, secret); err != nil {
 		t.Fatalf("failed to read rotated service account secret: %v", err)
@@ -173,6 +185,7 @@ func TestReconcileServiceAccountKeyDeletesExpiredOverlapKeys(t *testing.T) {
 	}
 
 	account, _ := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)
+	t.Setenv("POD_NAMESPACE", "obot")
 	if err := controller.reconcileServiceAccountKey(ctx, account); err != nil {
 		t.Fatalf("unexpected reconcile error: %v", err)
 	}
@@ -240,7 +253,7 @@ func TestReconcileServiceAccountKeysCleansUpWhenBackendDisabled(t *testing.T) {
 
 	secret := &corev1.Secret{}
 	secret.Name = account.SecretName
-	secret.Namespace = system.DefaultNamespace
+	secret.Namespace = "obot"
 	secret.Type = corev1.SecretTypeOpaque
 	secret.Data = map[string][]byte{
 		account.SecretKey: []byte(created.Token),
@@ -258,6 +271,7 @@ func TestReconcileServiceAccountKeysCleansUpWhenBackendDisabled(t *testing.T) {
 		now:           func() time.Time { return base },
 	}
 
+	t.Setenv("POD_NAMESPACE", "obot")
 	if err := controller.reconcileServiceAccountKeys(ctx); err != nil {
 		t.Fatalf("unexpected reconcile error: %v", err)
 	}

--- a/pkg/gateway/client/serviceaccountapikey.go
+++ b/pkg/gateway/client/serviceaccountapikey.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/serviceaccounts"
+)
+
+const (
+	serviceAccountTokenSecretLength = 32
+)
+
+func (c *Client) CreateServiceAccountAPIKey(ctx context.Context, serviceAccountName string, validAfter time.Time) (*types.ServiceAccountAPIKeyCreateResponse, error) {
+	if _, ok := serviceaccounts.Get(serviceAccountName); !ok {
+		return nil, fmt.Errorf("unknown service account %q", serviceAccountName)
+	}
+
+	secretBytes := make([]byte, serviceAccountTokenSecretLength)
+	_, _ = rand.Read(secretBytes) // rand.Read never returns an error and always fills the slice entirely
+
+	token := fmt.Sprintf("%s.%s.%s", serviceaccounts.TokenPrefix, serviceAccountName, base64.RawURLEncoding.EncodeToString(secretBytes))
+	apiKey := &types.ServiceAccountAPIKey{
+		ServiceAccountName: serviceAccountName,
+		HashedToken:        hash.String(token),
+		CreatedAt:          validAfter.UTC(),
+		ValidAfter:         validAfter.UTC(),
+	}
+
+	if err := c.db.WithContext(ctx).Create(apiKey).Error; err != nil {
+		return nil, fmt.Errorf("failed to create service account API key: %w", err)
+	}
+
+	return &types.ServiceAccountAPIKeyCreateResponse{
+		ServiceAccountAPIKey: *apiKey,
+		Token:                token,
+	}, nil
+}
+
+func (c *Client) ListServiceAccountAPIKeys(ctx context.Context, serviceAccountName string) ([]types.ServiceAccountAPIKey, error) {
+	var keys []types.ServiceAccountAPIKey
+	if err := c.db.WithContext(ctx).
+		Where("service_account_name = ?", serviceAccountName).
+		Order("created_at DESC").
+		Find(&keys).Error; err != nil {
+		return nil, fmt.Errorf("failed to list service account API keys: %w", err)
+	}
+	return keys, nil
+}
+
+func (c *Client) ValidateStorageServiceAccountToken(ctx context.Context, token string) (*types.ServiceAccountAPIKey, error) {
+	var apiKey types.ServiceAccountAPIKey
+	now := time.Now().UTC()
+	if err := c.db.WithContext(ctx).
+		Where("hashed_token = ?", hash.String(token)).
+		Where("valid_after <= ?", now).
+		Where("retire_after IS NULL OR retire_after > ?", now).
+		First(&apiKey).Error; err != nil {
+		return nil, err
+	}
+	return &apiKey, nil
+}
+
+func (c *Client) RetireOtherServiceAccountAPIKeys(ctx context.Context, serviceAccountName string, keepID uint, retireAfter time.Time) error {
+	return c.db.WithContext(ctx).
+		Model(&types.ServiceAccountAPIKey{}).
+		Where("service_account_name = ?", serviceAccountName).
+		Where("id <> ?", keepID).
+		Where("retire_after IS NULL OR retire_after > ?", retireAfter.UTC()).
+		Update("retire_after", retireAfter.UTC()).Error
+}
+
+func (c *Client) DeleteExpiredServiceAccountAPIKeys(ctx context.Context, serviceAccountName string, now time.Time) error {
+	return c.db.WithContext(ctx).
+		Where("service_account_name = ?", serviceAccountName).
+		Where("retire_after IS NOT NULL AND retire_after <= ?", now.UTC()).
+		Delete(&types.ServiceAccountAPIKey{}).Error
+}
+
+func (c *Client) DeleteServiceAccountAPIKeyByID(ctx context.Context, keyID uint) error {
+	return c.db.WithContext(ctx).
+		Where("id = ?", keyID).
+		Delete(&types.ServiceAccountAPIKey{}).Error
+}
+
+func (c *Client) DeleteAllServiceAccountAPIKeys(ctx context.Context, serviceAccountName string) error {
+	return c.db.WithContext(ctx).
+		Where("service_account_name = ?", serviceAccountName).
+		Delete(&types.ServiceAccountAPIKey{}).Error
+}

--- a/pkg/gateway/client/serviceaccountapikey_test.go
+++ b/pkg/gateway/client/serviceaccountapikey_test.go
@@ -1,0 +1,129 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/serviceaccounts"
+	"gorm.io/gorm"
+)
+
+func TestCreateAndValidateServiceAccountAPIKey(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	created, err := c.CreateServiceAccountAPIKey(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("failed to create service account key: %v", err)
+	}
+
+	got, err := c.ValidateStorageServiceAccountToken(ctx, created.Token)
+	if err != nil {
+		t.Fatalf("failed to validate service account key: %v", err)
+	}
+
+	if got.ServiceAccountName != serviceaccounts.NetworkPolicyProvider {
+		t.Fatalf("expected service account %q, got %q", serviceaccounts.NetworkPolicyProvider, got.ServiceAccountName)
+	}
+}
+
+func TestValidateServiceAccountAPIKeyRejectsRetiredKey(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	created, err := c.CreateServiceAccountAPIKey(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("failed to create service account key: %v", err)
+	}
+
+	retireAt := time.Now().UTC().Add(-time.Minute)
+	if err := c.db.WithContext(ctx).
+		Model(&types.ServiceAccountAPIKey{}).
+		Where("id = ?", created.ID).
+		Update("retire_after", retireAt).Error; err != nil {
+		t.Fatalf("failed to retire service account key: %v", err)
+	}
+
+	if _, err := c.ValidateStorageServiceAccountToken(ctx, created.Token); err == nil {
+		t.Fatal("expected retired key to be rejected")
+	}
+}
+
+func TestDeleteExpiredServiceAccountAPIKeys(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	created, err := c.CreateServiceAccountAPIKey(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("failed to create service account key: %v", err)
+	}
+
+	retireAt := time.Now().UTC().Add(-time.Minute)
+	if err := c.db.WithContext(ctx).
+		Model(&types.ServiceAccountAPIKey{}).
+		Where("id = ?", created.ID).
+		Update("retire_after", retireAt).Error; err != nil {
+		t.Fatalf("failed to retire service account key: %v", err)
+	}
+
+	if err := c.DeleteExpiredServiceAccountAPIKeys(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC()); err != nil {
+		t.Fatalf("failed to delete expired keys: %v", err)
+	}
+
+	var count int64
+	if err := c.db.WithContext(ctx).
+		Model(&types.ServiceAccountAPIKey{}).
+		Where("service_account_name = ?", serviceaccounts.NetworkPolicyProvider).
+		Count(&count).Error; err != nil {
+		t.Fatalf("failed to count service account keys: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected all expired keys to be deleted, got %d", count)
+	}
+}
+
+func TestRetireOtherServiceAccountAPIKeys(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	first, err := c.CreateServiceAccountAPIKey(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("failed to create first key: %v", err)
+	}
+	second, err := c.CreateServiceAccountAPIKey(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("failed to create second key: %v", err)
+	}
+
+	retireAt := time.Now().UTC().Add(time.Hour)
+	if err := c.RetireOtherServiceAccountAPIKeys(ctx, serviceaccounts.NetworkPolicyProvider, second.ID, retireAt); err != nil {
+		t.Fatalf("failed to retire older keys: %v", err)
+	}
+
+	var retired types.ServiceAccountAPIKey
+	if err := c.db.WithContext(ctx).Where("id = ?", first.ID).First(&retired).Error; err != nil {
+		t.Fatalf("failed to reload retired key: %v", err)
+	}
+	if retired.RetireAfter == nil || !retired.RetireAfter.Equal(retireAt) {
+		t.Fatalf("expected first key to retire at %v, got %v", retireAt, retired.RetireAfter)
+	}
+
+	var current types.ServiceAccountAPIKey
+	if err := c.db.WithContext(ctx).Where("id = ?", second.ID).First(&current).Error; err != nil {
+		t.Fatalf("failed to reload kept key: %v", err)
+	}
+	if current.RetireAfter != nil {
+		t.Fatalf("expected kept key to remain active, got retire_after %v", current.RetireAfter)
+	}
+}
+
+func TestValidateServiceAccountAPIKeyRejectsUnknownToken(t *testing.T) {
+	c := newTestClient(t)
+	if _, err := c.ValidateStorageServiceAccountToken(context.Background(), "osa1.bad.token"); err == nil {
+		t.Fatal("expected unknown token to be rejected")
+	} else if err != gorm.ErrRecordNotFound {
+		t.Fatalf("expected gorm.ErrRecordNotFound, got %v", err)
+	}
+}

--- a/pkg/gateway/db/db.go
+++ b/pkg/gateway/db/db.go
@@ -106,6 +106,7 @@ func (db *DB) AutoMigrate() (err error) {
 		types.TempSetupUser{},
 		types.Property{},
 		types.APIKey{},
+		types.ServiceAccountAPIKey{},
 		types.MessagePolicyViolation{},
 	); err != nil {
 		return fmt.Errorf("failed to auto migrate gateway types: %w", err)

--- a/pkg/gateway/types/serviceaccountapikey.go
+++ b/pkg/gateway/types/serviceaccountapikey.go
@@ -6,7 +6,7 @@ import "time"
 type ServiceAccountAPIKey struct {
 	ID                 uint       `json:"id" gorm:"primaryKey;autoIncrement"`
 	ServiceAccountName string     `json:"serviceAccountName" gorm:"index"`
-	HashedToken        string     `json:"-"`
+	HashedToken        string     `json:"-" gorm:"index"`
 	CreatedAt          time.Time  `json:"createdAt"`
 	ValidAfter         time.Time  `json:"validAfter" gorm:"index"`
 	RetireAfter        *time.Time `json:"retireAfter,omitempty" gorm:"index"`

--- a/pkg/gateway/types/serviceaccountapikey.go
+++ b/pkg/gateway/types/serviceaccountapikey.go
@@ -1,0 +1,18 @@
+//nolint:revive
+package types
+
+import "time"
+
+type ServiceAccountAPIKey struct {
+	ID                 uint       `json:"id" gorm:"primaryKey;autoIncrement"`
+	ServiceAccountName string     `json:"serviceAccountName" gorm:"index"`
+	HashedToken        string     `json:"-"`
+	CreatedAt          time.Time  `json:"createdAt"`
+	ValidAfter         time.Time  `json:"validAfter" gorm:"index"`
+	RetireAfter        *time.Time `json:"retireAfter,omitempty" gorm:"index"`
+}
+
+type ServiceAccountAPIKeyCreateResponse struct {
+	ServiceAccountAPIKey
+	Token string `json:"token"`
+}

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -104,7 +104,7 @@ func NewSessionManager(ctx context.Context, tokenService TokenService, baseURL s
 		backend = dockerBackend
 	case "kubernetes", "k8s":
 		if localK8sConfig == nil {
-			return nil, fmt.Errorf("use ofKubernetes backend requested but no local K8s config available")
+			return nil, fmt.Errorf("use of Kubernetes backend requested but no local K8s config available")
 		}
 
 		client, err := kclient.NewWithWatch(localK8sConfig, kclient.Options{})

--- a/pkg/serviceaccounts/serviceaccounts.go
+++ b/pkg/serviceaccounts/serviceaccounts.go
@@ -1,0 +1,56 @@
+package serviceaccounts
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+)
+
+const (
+	Group                   = "system:serviceaccounts"
+	TokenPrefix             = "osa1"
+	NetworkPolicyProvider   = "NetworkPolicyProvider"
+	NetworkPolicySecretName = "obot-network-policy-provider"
+	NetworkPolicySecretKey  = "apiKey"
+	ServiceAccountNameKey   = "serviceAccountName"
+	RotatedAtKey            = "rotatedAt"
+	ExpiresAtKey            = "expiresAt"
+)
+
+type Account struct {
+	Name               string
+	Username           string
+	UID                string
+	Group              string
+	SecretName         string
+	SecretManaged      bool
+	RequiredMCPBackend string
+}
+
+var accounts = map[string]Account{
+	NetworkPolicyProvider: {
+		Name:               NetworkPolicyProvider,
+		Username:           "system:serviceaccount:" + NetworkPolicyProvider,
+		UID:                "system:serviceaccount:" + NetworkPolicyProvider,
+		Group:              fmt.Sprintf("%s:%s", Group, NetworkPolicyProvider),
+		SecretName:         NetworkPolicySecretName,
+		SecretManaged:      true,
+		RequiredMCPBackend: "kubernetes",
+	},
+}
+
+func All() []Account {
+	return slices.Collect(maps.Values(accounts))
+}
+
+func Get(name string) (Account, bool) {
+	account, ok := accounts[name]
+	return account, ok
+}
+
+func Enabled(account Account, mcpRuntimeBackend string) bool {
+	if account.RequiredMCPBackend == "" {
+		return true
+	}
+	return account.RequiredMCPBackend == mcpRuntimeBackend
+}

--- a/pkg/serviceaccounts/serviceaccounts.go
+++ b/pkg/serviceaccounts/serviceaccounts.go
@@ -23,6 +23,7 @@ type Account struct {
 	UID                string
 	Group              string
 	SecretName         string
+	SecretKey          string
 	SecretManaged      bool
 	RequiredMCPBackend string
 }
@@ -34,6 +35,7 @@ var accounts = map[string]Account{
 		UID:                "system:serviceaccount:" + NetworkPolicyProvider,
 		Group:              fmt.Sprintf("%s:%s", Group, NetworkPolicyProvider),
 		SecretName:         NetworkPolicySecretName,
+		SecretKey:          NetworkPolicySecretKey,
 		SecretManaged:      true,
 		RequiredMCPBackend: "kubernetes",
 	},

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -51,6 +51,7 @@ import (
 	"github.com/obot-platform/obot/pkg/messagepolicy"
 	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
 	"github.com/obot-platform/obot/pkg/proxy"
+	"github.com/obot-platform/obot/pkg/serviceaccounts"
 	"github.com/obot-platform/obot/pkg/skillaccessrule"
 	"github.com/obot-platform/obot/pkg/storage"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -282,8 +283,8 @@ func copyKeys(envs []string) []string {
 	return newEnvs
 }
 
-// buildLocalK8sConfig creates a Kubernetes config for local cluster access
-func buildLocalK8sConfig() (*rest.Config, error) {
+// BuildLocalK8sConfig creates a Kubernetes config for local cluster access.
+func BuildLocalK8sConfig() (*rest.Config, error) {
 	cfg, err := rest.InClusterConfig()
 	if err == nil {
 		return cfg, nil
@@ -479,7 +480,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	// Sanitize DSN for logging (remove credentials)
 	sanitizedDSN := logutil.SanitizeDSN(config.DSN)
 	pkgLog.Infof("Connecting to database: dsn=%s", sanitizedDSN)
-	storageClient, restConfig, dbAccess, err := storage.Start(ctx, config.Config)
+	storageClient, restConfig, dbAccess, storageServices, err := storage.Start(ctx, config.Config)
 	if err != nil {
 		pkgLog.Errorf("Failed to connect to database: dsn=%s error=%v", sanitizedDSN, err)
 		return nil, err
@@ -550,12 +551,23 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		config.MCPAuditLogsPersistBatchSize,
 		config.MCPAuditLogRetentionDays,
 	)
+	storageServices.Authn.SetServiceAccountValidator(func(ctx context.Context, token string) (string, error) {
+		apiKey, err := gatewayClient.ValidateStorageServiceAccountToken(ctx, token)
+		if err != nil {
+			return "", err
+		}
+		account, ok := serviceaccounts.Get(apiKey.ServiceAccountName)
+		if !ok || !serviceaccounts.Enabled(account, config.MCPRuntimeBackend) {
+			return "", fmt.Errorf("service account %q disabled for backend %q", apiKey.ServiceAccountName, config.MCPRuntimeBackend)
+		}
+		return apiKey.ServiceAccountName, nil
+	})
 	mcpOAuthTokenStorage := mcpgateway.NewGlobalTokenStore(gatewayClient)
 
 	// Build local Kubernetes config for deployment monitoring (optional)
 	var localK8sConfig *rest.Config
 	if config.MCPRuntimeBackend == "kubernetes" {
-		localK8sConfig, err = buildLocalK8sConfig()
+		localK8sConfig, err = BuildLocalK8sConfig()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build local Kubernetes config: %w", err)
 		}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -55,10 +55,12 @@ import (
 	"github.com/obot-platform/obot/pkg/skillaccessrule"
 	"github.com/obot-platform/obot/pkg/storage"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storageauthn "github.com/obot-platform/obot/pkg/storage/authn"
 	"github.com/obot-platform/obot/pkg/storage/blob"
 	"github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/storage/services"
 	"github.com/obot-platform/obot/pkg/system"
+	"gorm.io/gorm"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -554,11 +556,14 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	storageServices.Authn.SetServiceAccountValidator(func(ctx context.Context, token string) (string, error) {
 		apiKey, err := gatewayClient.ValidateStorageServiceAccountToken(ctx, token)
 		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return "", storageauthn.ErrInvalidServiceAccountToken
+			}
 			return "", err
 		}
 		account, ok := serviceaccounts.Get(apiKey.ServiceAccountName)
 		if !ok || !serviceaccounts.Enabled(account, config.MCPRuntimeBackend) {
-			return "", fmt.Errorf("service account %q disabled for backend %q", apiKey.ServiceAccountName, config.MCPRuntimeBackend)
+			return "", fmt.Errorf("%w: service account %q disabled for backend %q", storageauthn.ErrInvalidServiceAccountToken, apiKey.ServiceAccountName, config.MCPRuntimeBackend)
 		}
 		return apiKey.ServiceAccountName, nil
 	})

--- a/pkg/storage/authn/authn.go
+++ b/pkg/storage/authn/authn.go
@@ -1,9 +1,12 @@
 package authn
 
 import (
+	"context"
 	"net/http"
 	"strings"
+	"sync"
 
+	"github.com/obot-platform/obot/pkg/serviceaccounts"
 	"github.com/obot-platform/obot/pkg/storage/authz"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -24,12 +27,42 @@ var (
 
 type Authenticator struct {
 	authToken string
+
+	lock                    sync.RWMutex
+	serviceAccountValidator ServiceAccountValidator
+}
+
+type ServiceAccountValidator func(context.Context, string) (string, error)
+
+func serviceAccountResponse(accountName string) (*authenticator.Response, bool) {
+	account, ok := serviceaccounts.Get(accountName)
+	if !ok {
+		return nil, false
+	}
+
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name: account.Username,
+			UID:  account.UID,
+			Groups: []string{
+				authz.AuthenticatedGroup,
+				serviceaccounts.Group,
+				account.Group,
+			},
+		},
+	}, true
 }
 
 func NewAuthenticator(authToken string) *Authenticator {
 	return &Authenticator{
 		authToken: authToken,
 	}
+}
+
+func (a *Authenticator) SetServiceAccountValidator(validator ServiceAccountValidator) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	a.serviceAccountValidator = validator
 }
 
 func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
@@ -41,6 +74,22 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 
 	if bearerToken == a.authToken {
 		return adminUserResponse, true, nil
+	}
+
+	a.lock.RLock()
+	validator := a.serviceAccountValidator
+	a.lock.RUnlock()
+	if validator == nil {
+		return nil, false, nil
+	}
+
+	serviceAccountName, err := validator(req.Context(), bearerToken)
+	if err != nil {
+		return nil, false, nil
+	}
+
+	if resp, ok := serviceAccountResponse(serviceAccountName); ok {
+		return resp, true, nil
 	}
 
 	return nil, false, nil

--- a/pkg/storage/authn/authn.go
+++ b/pkg/storage/authn/authn.go
@@ -2,6 +2,7 @@ package authn
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -13,6 +14,8 @@ import (
 )
 
 var (
+	ErrInvalidServiceAccountToken = errors.New("invalid service account token")
+
 	adminUserResponse = &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name: authz.AdminName,
@@ -84,8 +87,10 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 	}
 
 	serviceAccountName, err := validator(req.Context(), bearerToken)
-	if err != nil {
+	if errors.Is(err, ErrInvalidServiceAccountToken) {
 		return nil, false, nil
+	} else if err != nil {
+		return nil, false, err
 	}
 
 	if resp, ok := serviceAccountResponse(serviceAccountName); ok {

--- a/pkg/storage/authn/authn_test.go
+++ b/pkg/storage/authn/authn_test.go
@@ -35,7 +35,7 @@ func TestAuthenticateRequestServiceAccount(t *testing.T) {
 		if token == "service-account-token" {
 			return serviceaccounts.NetworkPolicyProvider, nil
 		}
-		return "", fmt.Errorf("invalid token")
+		return "", ErrInvalidServiceAccountToken
 	})
 
 	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
@@ -59,7 +59,7 @@ func TestAuthenticateRequestServiceAccount(t *testing.T) {
 func TestAuthenticateRequestRejectsInvalidServiceAccountToken(t *testing.T) {
 	authenticator := NewAuthenticator("admin-token")
 	authenticator.SetServiceAccountValidator(func(_ context.Context, token string) (string, error) {
-		return "", fmt.Errorf("invalid token %s", token)
+		return "", fmt.Errorf("%w %s", ErrInvalidServiceAccountToken, token)
 	})
 
 	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
@@ -70,5 +70,22 @@ func TestAuthenticateRequestRejectsInvalidServiceAccountToken(t *testing.T) {
 
 	if _, ok, err := authenticator.AuthenticateRequest(req); err != nil || ok {
 		t.Fatalf("expected invalid token to be rejected, ok=%v err=%v", ok, err)
+	}
+}
+
+func TestAuthenticateRequestPropagatesServiceAccountValidatorError(t *testing.T) {
+	authenticator := NewAuthenticator("admin-token")
+	authenticator.SetServiceAccountValidator(func(_ context.Context, token string) (string, error) {
+		return "", fmt.Errorf("validator unavailable for %s", token)
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer service-account-token")
+
+	if _, ok, err := authenticator.AuthenticateRequest(req); err == nil || ok {
+		t.Fatalf("expected validator error to propagate, ok=%v err=%v", ok, err)
 	}
 }

--- a/pkg/storage/authn/authn_test.go
+++ b/pkg/storage/authn/authn_test.go
@@ -1,0 +1,74 @@
+package authn
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/serviceaccounts"
+)
+
+func TestAuthenticateRequestAdminToken(t *testing.T) {
+	authenticator := NewAuthenticator("admin-token")
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer admin-token")
+
+	resp, ok, err := authenticator.AuthenticateRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected admin token to authenticate")
+	}
+	if resp.User.GetName() != "admin" {
+		t.Fatalf("expected admin user, got %q", resp.User.GetName())
+	}
+}
+
+func TestAuthenticateRequestServiceAccount(t *testing.T) {
+	authenticator := NewAuthenticator("admin-token")
+	authenticator.SetServiceAccountValidator(func(_ context.Context, token string) (string, error) {
+		if token == "service-account-token" {
+			return serviceaccounts.NetworkPolicyProvider, nil
+		}
+		return "", fmt.Errorf("invalid token")
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer service-account-token")
+
+	resp, ok, err := authenticator.AuthenticateRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected service account token to authenticate")
+	}
+	if resp.User.GetName() != "system:serviceaccount:"+serviceaccounts.NetworkPolicyProvider {
+		t.Fatalf("unexpected service account username %q", resp.User.GetName())
+	}
+}
+
+func TestAuthenticateRequestRejectsInvalidServiceAccountToken(t *testing.T) {
+	authenticator := NewAuthenticator("admin-token")
+	authenticator.SetServiceAccountValidator(func(_ context.Context, token string) (string, error) {
+		return "", fmt.Errorf("invalid token %s", token)
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "http://localhost", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer bad-token")
+
+	if _, ok, err := authenticator.AuthenticateRequest(req); err != nil || ok {
+		t.Fatalf("expected invalid token to be rejected, ok=%v err=%v", ok, err)
+	}
+}

--- a/pkg/storage/authz/authz_test.go
+++ b/pkg/storage/authz/authz_test.go
@@ -1,0 +1,28 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/serviceaccounts"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestServiceAccountsHaveNoImplicitAuthorization(t *testing.T) {
+	a := &Authorizer{}
+	decision, _, err := a.Authorize(t.Context(), authorizer.AttributesRecord{
+		User: &user.DefaultInfo{
+			Name: "system:serviceaccount:" + serviceaccounts.NetworkPolicyProvider,
+			Groups: []string{
+				AuthenticatedGroup,
+				serviceaccounts.Group,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if decision != authorizer.DecisionNoOpinion {
+		t.Fatalf("expected no opinion for service account, got %v", decision)
+	}
+}

--- a/pkg/storage/server.go
+++ b/pkg/storage/server.go
@@ -22,17 +22,17 @@ import (
 
 type Client client.WithWatch
 
-func Start(ctx context.Context, config sservices.Config) (Client, *rest.Config, *db.Factory, error) {
+func Start(ctx context.Context, config sservices.Config) (Client, *rest.Config, *db.Factory, *sservices.Services, error) {
 	services, err := sservices.New(config)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	c, cfg, err := startMinkServer(ctx, config, services)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return c, cfg, services.DB, nil
+	return c, cfg, services.DB, services, nil
 }
 
 func startMinkServer(ctx context.Context, config sservices.Config, services *sservices.Services) (Client, *rest.Config, error) {

--- a/pkg/storage/services/config.go
+++ b/pkg/storage/services/config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/obot-platform/obot/pkg/storage/authn"
 	"github.com/obot-platform/obot/pkg/storage/authz"
 	"github.com/obot-platform/obot/pkg/storage/scheme"
-	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
@@ -22,7 +21,7 @@ type Config struct {
 
 type Services struct {
 	DB    *db.Factory
-	Authn authenticator.Request
+	Authn *authn.Authenticator
 	Authz authorizer.Authorizer
 }
 


### PR DESCRIPTION
We reverted this because I merged it too soon.

Original description:

> This is the first change to support network policy providers. On its own, this doesn't do anything, as there is nothing that consumes the Kubernetes secret we are creating. The rest of the changes will come in a second PR.