### PR TITLE
fix: add experimental tag option for provider card

### DIFF
--- a/ui/user/src/lib/components/admin/ProviderCard.svelte
+++ b/ui/user/src/lib/components/admin/ProviderCard.svelte
@@ -3,12 +3,13 @@
 	import type { BaseProvider } from '$lib/services/admin/types';
 	import { darkMode } from '$lib/stores';
 	import DotDotDot from '../DotDotDot.svelte';
-	import { CircleSlash, CircleCheck, Construction } from 'lucide-svelte';
+	import { CircleSlash, CircleCheck, Construction, FlaskConicalIcon } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
 		recommended?: boolean;
+		experimental?: boolean;
 		provider: BaseProvider;
 		onConfigure: () => void;
 		onDeconfigure: () => void;
@@ -21,6 +22,7 @@
 
 	const {
 		recommended,
+		experimental,
 		provider,
 		onConfigure,
 		onDeconfigure,
@@ -44,6 +46,13 @@
 				<span class="bg-primary rounded-md px-2 py-1 text-[11px] font-semibold text-white"
 					>Recommended</span
 				>
+			{/if}
+			{#if experimental}
+				<span
+					class="bg-yellow-500/15 text-yellow-500 rounded-md px-2 py-1 text-[10px] font-medium flex items-center gap-1"
+				>
+					<FlaskConicalIcon class="size-3 text-yellow-500" /> Experimental
+				</span>
 			{/if}
 		</div>
 

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -160,6 +160,7 @@
 		<div class="grid grid-cols-1 gap-4 px-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 			{#each sortedModelProviders as modelProvider (modelProvider.id)}
 				<ProviderCard
+					experimental={modelProvider.id === CommonModelProviderIds.OLLAMA}
 					provider={modelProvider}
 					deprecated={modelProvider.id === CommonModelProviderIds.ANTHROPIC_BEDROCK}
 					recommended={!isLegacyDisabled && RecommendedModelProviders.includes(modelProvider.id)}


### PR DESCRIPTION
* add experimental tag for provider card (ex. Ollama)

<img width="286" height="289" alt="Screenshot 2026-04-27 at 2 50 58 PM" src="https://github.com/user-attachments/assets/9c2e46c4-1556-408c-b67f-c5ddeee69fb7" />
<img width="308" height="294" alt="Screenshot 2026-04-27 at 2 52 25 PM" src="https://github.com/user-attachments/assets/7564c8a2-870c-4100-8785-fc4dd441537b" />
