### PR TITLE
enhance: make it easier to identify which filters are getting called

### DIFF
--- a/apiclient/types/mcpauditlog.go
+++ b/apiclient/types/mcpauditlog.go
@@ -52,6 +52,7 @@ type WebhookStatus struct {
 	Method  string `json:"method,omitempty"`
 	URL     string `json:"url,omitempty"`
 	Name    string `json:"name,omitempty"`
+	Tool    string `json:"tool,omitempty"`
 	Status  string `json:"status,omitempty"`
 	Message string `json:"message"`
 }

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -44,8 +44,8 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_AUDIT_LOGS_COMPRESS_FILE` | Controls whether or not to compress audit log files | `true` |
 | `OBOT_SERVER_AUDIT_LOGS_USE_PATH_STYLE` | Whether to use path style for S3 | - |
 | `OBOT_SERVER_MCPBASE_IMAGE` | Deploy MCP servers in the kubernetes cluster or using docker with this base image. | `ghcr.io/obot-platform/mcp-images/phat:v0.20.2` |
-| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.74` |
-| `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/nanobot-ai/nanobot-agent:v0.0.74` |
+| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/nanobot-ai/nanobot:v0.0.75` |
+| `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/nanobot-ai/nanobot-agent:v0.0.75` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.20.2` |
 | `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker, kubernetes, or local. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/moby/moby/api v1.52.0-alpha.1
 	github.com/moby/moby/client v0.1.0-alpha.0
-	github.com/nanobot-ai/nanobot v0.0.74
+	github.com/nanobot-ai/nanobot v0.0.75
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037
 	github.com/obot-platform/kinm v0.0.0-20260420174234-eec2cd66c333
 	github.com/obot-platform/nah v0.0.0-20260420174246-bea1b9e01234

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nanobot-ai/nanobot v0.0.74 h1:QmP/1qu05C9TRX0dCu/j3063VZGruZS2wfTRzYBZYl4=
-github.com/nanobot-ai/nanobot v0.0.74/go.mod h1:37GLiqal0HftteY5fV9brj0xvl+Om+fS4rpmWFClUKY=
+github.com/nanobot-ai/nanobot v0.0.75 h1:FxARu+f3JadwbFQDW+J5jnzGP/TOnecOvWMWxAmexnE=
+github.com/nanobot-ai/nanobot v0.0.75/go.mod h1:37GLiqal0HftteY5fV9brj0xvl+Om+fS4rpmWFClUKY=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=

--- a/pkg/controller/handlers/mcpwebhookvalidation/mcpwebhookvalidation.go
+++ b/pkg/controller/handlers/mcpwebhookvalidation/mcpwebhookvalidation.go
@@ -117,13 +117,7 @@ func desiredSystemServer(webhookValidation *v1.MCPWebhookValidation, image strin
 	if webhookValidation.Spec.Manifest.SystemMCPServerManifest != nil {
 		manifest = *webhookValidation.Spec.Manifest.SystemMCPServerManifest.DeepCopy()
 	} else {
-		displayName := webhookValidation.Spec.Manifest.Name
-		if displayName == "" {
-			displayName = webhookValidation.Name
-		}
-
 		manifest = types.SystemMCPServerManifest{
-			Name:             displayName,
 			ShortDescription: "Managed webhook validation server",
 			Enabled:          new(!webhookValidation.Spec.Manifest.Disabled),
 			Runtime:          types.RuntimeContainerized,
@@ -146,8 +140,12 @@ func desiredSystemServer(webhookValidation *v1.MCPWebhookValidation, image strin
 		}
 	}
 
+	manifest.Name = webhookValidation.Spec.Manifest.Name
 	if manifest.Name == "" {
-		manifest.Name = webhookValidation.Spec.Manifest.Name
+		manifest.Name = webhookValidation.Spec.Manifest.SystemMCPServerManifest.Name
+		if manifest.Name == "" {
+			manifest.Name = webhookValidation.Name
+		}
 	}
 
 	return v1.SystemMCPServer{

--- a/pkg/gateway/types/mcpauditlog.go
+++ b/pkg/gateway/types/mcpauditlog.go
@@ -51,6 +51,7 @@ type MCPWebhookStatus struct {
 	URL     string `json:"url,omitempty"`
 	Method  string `json:"method,omitempty"`
 	Name    string `json:"name,omitempty"`
+	Tool    string `json:"tool,omitempty"`
 	Status  string `json:"status,omitempty"`
 	Message string `json:"message,omitempty"`
 }
@@ -110,6 +111,7 @@ func ConvertMCPAuditLog(a MCPAuditLog) types2.MCPAuditLog {
 			Method:  ws.Method,
 			URL:     ws.URL,
 			Name:    ws.Name,
+			Tool:    ws.Tool,
 			Status:  ws.Status,
 			Message: ws.Message,
 		}

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -27,7 +27,7 @@ var log = logger.Package()
 type Options struct {
 	MCPBaseImage                      string   `usage:"The base image to use for MCP containers" default:"ghcr.io/obot-platform/mcp-images/phat:v0.20.2"`
 	MCPHTTPWebhookBaseImage           string   `usage:"The base image to use for HTTP-based MCP webhook containers" default:"ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.20.2"`
-	MCPRemoteShimBaseImage            string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.74"`
+	MCPRemoteShimBaseImage            string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/nanobot-ai/nanobot:v0.0.75"`
 	MCPNamespace                      string   `usage:"The namespace to use for MCP containers" default:"obot-mcp"`
 	MCPClusterDomain                  string   `usage:"The cluster domain to use for MCP containers" default:"cluster.local"`
 	DisallowLocalhostMCP              bool     `usage:"Allow MCP containers to run on localhost"`

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -126,7 +126,7 @@ type Config struct {
 	NanobotIntegration      bool   `usage:"Enable Nanobot integration" default:"true"`
 	EnableMessagePolicies   bool   `usage:"Enable message policies for LLM proxy content enforcement" default:"false"`
 	MCPServerSearchImage    string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.1.1"`
-	NanobotAgentImage       string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/nanobot-ai/nanobot-agent:v0.0.74"`
+	NanobotAgentImage       string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/nanobot-ai/nanobot-agent:v0.0.75"`
 
 	// Published artifact storage
 	ArtifactStorageProvider       string `usage:"Storage provider for published artifacts (s3, gcs, azure, custom)" name:"artifact-storage-provider" env:"OBOT_ARTIFACT_STORAGE_PROVIDER"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -13978,6 +13978,12 @@ func schema_obot_platform_obot_apiclient_types_WebhookStatus(ref common.Referenc
 							Format: "",
 						},
 					},
+					"tool": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -452,6 +452,7 @@ export interface AuditLog {
 		type?: string;
 		method?: string;
 		name?: string;
+		tool?: string;
 		url?: string;
 		status?: string;
 		message?: string;


### PR DESCRIPTION
This change fixes an issue where the name of the filter was not getting used. The name was defaulting to the system MCP server manifest name.

Additionally, this change adds a tool field to the webhook status to make it easier to identify which filter is doing what for a given request.