### PR TITLE
docs: document MCP connection URL stability behavior

### DIFF
--- a/docs/docs/concepts/mcp-gateway.md
+++ b/docs/docs/concepts/mcp-gateway.md
@@ -66,17 +66,3 @@ https://your-obot-instance/mcp-connect/{server-id}
 ```
 
 All servers are exposed via `streamable-http` transport, regardless of their underlying runtime.
-
-### Connection URL Stability
-
-Connection URLs are derived from catalog entry names, and their stability depends on how the catalog entry was created:
-
-**Git-synced catalog entries** have deterministic names based on the repository and file path. This means:
-- The connection URL remains the same even if you remove and re-add the Git repository
-- URLs are predictable and consistent across environments using the same Git source
-
-**Manually created catalog entries** receive partially random names. This means:
-- The connection URL stays constant as long as you don't delete the catalog entry
-- If you delete and recreate a manual entry, it will receive a new URL
-
-For organizations distributing connection URLs to users (e.g., configuring Claude Desktop for multiple team members), Git-synced catalog entries provide the most reliable URL stability.

--- a/docs/docs/concepts/mcp-gateway.md
+++ b/docs/docs/concepts/mcp-gateway.md
@@ -66,3 +66,17 @@ https://your-obot-instance/mcp-connect/{server-id}
 ```
 
 All servers are exposed via `streamable-http` transport, regardless of their underlying runtime.
+
+### Connection URL Stability
+
+Connection URLs are derived from catalog entry names, and their stability depends on how the catalog entry was created:
+
+**Git-synced catalog entries** have deterministic names based on the repository and file path. This means:
+- The connection URL remains the same even if you remove and re-add the Git repository
+- URLs are predictable and consistent across environments using the same Git source
+
+**Manually created catalog entries** receive partially random names. This means:
+- The connection URL stays constant as long as you don't delete the catalog entry
+- If you delete and recreate a manual entry, it will receive a new URL
+
+For organizations distributing connection URLs to users (e.g., configuring Claude Desktop for multiple team members), Git-synced catalog entries provide the most reliable URL stability.

--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -14,17 +14,6 @@ Obot supports managing MCP servers through Git repositories, enabling GitOps wor
 - **Automation**: Integration with existing DevOps workflows and automated deployment
 - **Stable Connection URLs**: Deterministic URLs that remain constant even if you remove and re-add the Git repository
 
-### Connection URL Stability
-
-Connection URLs for MCP servers are derived from catalog entry names. Git-synced catalog entries have deterministic names based on the repository and file path, which provides important stability guarantees:
-
-- The connection URL remains the same even if you remove and re-add the Git repository
-- URLs are predictable and consistent across environments using the same Git source
-
-In contrast, manually created catalog entries receive partially random names. Their connection URLs stay constant as long as the entry isn't deleted, but if you delete and recreate a manual entry, it will receive a new URL.
-
-For organizations distributing connection URLs to users (e.g., pre-configuring Claude Desktop for multiple team members), Git-synced catalog entries provide the most reliable URL stability.
-
 ## Getting Started
 
 1. **Create or Fork a Repository**: Start with the official [Obot MCP server repository](https://github.com/obot-platform/mcp-catalog) or create your own
@@ -36,6 +25,12 @@ For organizations distributing connection URLs to users (e.g., pre-configuring C
 ## Adding a Git Source URL
 
 Administrators can add Git repositories as catalog sources from the **Admin → MCP Servers → Git Source URLs** tab. Click **Add server(s) from Git** and enter the repository URL.
+
+:::note
+
+Connection URLs for MCP servers are derived from catalog entry names. Git-synced catalog entries have deterministic names based on the repository and file path, so the connection URL remains the same even if you remove and re-add the Git repository.
+
+:::
 
 ### Supported URL formats
 

--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -12,6 +12,18 @@ Obot supports managing MCP servers through Git repositories, enabling GitOps wor
 - **Collaborative Workflows**: PR-based reviews, team collaboration, and approval processes
 - **Validation & Quality Assurance**: Automated testing, CI/CD integration, and consistent formatting
 - **Automation**: Integration with existing DevOps workflows and automated deployment
+- **Stable Connection URLs**: Deterministic URLs that remain constant even if you remove and re-add the Git repository
+
+### Connection URL Stability
+
+Connection URLs for MCP servers are derived from catalog entry names. Git-synced catalog entries have deterministic names based on the repository and file path, which provides important stability guarantees:
+
+- The connection URL remains the same even if you remove and re-add the Git repository
+- URLs are predictable and consistent across environments using the same Git source
+
+In contrast, manually created catalog entries receive partially random names. Their connection URLs stay constant as long as the entry isn't deleted, but if you delete and recreate a manual entry, it will receive a new URL.
+
+For organizations distributing connection URLs to users (e.g., pre-configuring Claude Desktop for multiple team members), Git-synced catalog entries provide the most reliable URL stability.
 
 ## Getting Started
 

--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -12,7 +12,6 @@ Obot supports managing MCP servers through Git repositories, enabling GitOps wor
 - **Collaborative Workflows**: PR-based reviews, team collaboration, and approval processes
 - **Validation & Quality Assurance**: Automated testing, CI/CD integration, and consistent formatting
 - **Automation**: Integration with existing DevOps workflows and automated deployment
-- **Stable Connection URLs**: Deterministic URLs that remain constant even if you remove and re-add the Git repository
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- Documents how MCP connection URL stability differs between Git-synced and manually created catalog entries
- Explains that Git-synced entries have deterministic, stable URLs even across remove/re-add cycles
- Clarifies that manually created entries have stable URLs only as long as the entry isn't deleted

## Context

This addresses a customer question about whether connection URLs remain stable when distributing MCP connection strings to Claude users. The documentation helps users understand when they can rely on URL stability for enterprise deployments.

Slack thread: https://acorn-io.slack.com/archives/C04MZLPC8KC/p1777479961000839?thread_ts=1777453687.746929&cid=C04MZLPC8KC

## Test plan

- [ ] Verify docs build successfully
- [ ] Review content accuracy with the team

https://claude.ai/code/session_015ViHZtuzNQ5u2c8MZv5CmH

---
_Generated by [Claude Code](https://claude.ai/code/session_015ViHZtuzNQ5u2c8MZv5CmH)_