### PR TITLE
chore: cleanup from nanobot ui to obot & branding page update

### DIFF
--- a/apiclient/types/apppreferences.go
+++ b/apiclient/types/apppreferences.go
@@ -20,18 +20,34 @@ type LogoPreferences struct {
 }
 
 type ThemePreferences struct {
-	BackgroundColor       string `json:"backgroundColor,omitempty"`
-	OnBackgroundColor     string `json:"onBackgroundColor,omitempty"`
-	OnSurfaceColor        string `json:"onSurfaceColor,omitempty"`
-	Surface1Color         string `json:"surface1Color,omitempty"`
-	Surface2Color         string `json:"surface2Color,omitempty"`
-	Surface3Color         string `json:"surface3Color,omitempty"`
-	PrimaryColor          string `json:"primaryColor,omitempty"`
+	BackgroundColor   string `json:"backgroundColor,omitempty"`
+	OnBackgroundColor string `json:"onBackgroundColor,omitempty"`
+	Surface1Color     string `json:"surface1Color,omitempty"`
+	Surface2Color     string `json:"surface2Color,omitempty"`
+	Surface3Color     string `json:"surface3Color,omitempty"`
+	SecondaryColor    string `json:"secondaryColor,omitempty"`
+	SuccessColor      string `json:"successColor,omitempty"`
+	WarningColor      string `json:"warningColor,omitempty"`
+	ErrorColor        string `json:"errorColor,omitempty"`
+	PrimaryColor      string `json:"primaryColor,omitempty"`
+	OnPrimaryColor    string `json:"onPrimaryColor,omitempty"`
+	OnSuccessColor    string `json:"onSuccessColor,omitempty"`
+	OnWarningColor    string `json:"onWarningColor,omitempty"`
+	OnErrorColor      string `json:"onErrorColor,omitempty"`
+	FontFamily        string `json:"fontFamily,omitempty"`
+
 	DarkBackgroundColor   string `json:"darkBackgroundColor,omitempty"`
 	DarkOnBackgroundColor string `json:"darkOnBackgroundColor,omitempty"`
-	DarkOnSurfaceColor    string `json:"darkOnSurfaceColor,omitempty"`
 	DarkSurface1Color     string `json:"darkSurface1Color,omitempty"`
 	DarkSurface2Color     string `json:"darkSurface2Color,omitempty"`
 	DarkSurface3Color     string `json:"darkSurface3Color,omitempty"`
+	DarkSecondaryColor    string `json:"darkSecondaryColor,omitempty"`
+	DarkSuccessColor      string `json:"darkSuccessColor,omitempty"`
+	DarkWarningColor      string `json:"darkWarningColor,omitempty"`
+	DarkErrorColor        string `json:"darkErrorColor,omitempty"`
 	DarkPrimaryColor      string `json:"darkPrimaryColor,omitempty"`
+	DarkOnPrimaryColor    string `json:"darkOnPrimaryColor,omitempty"`
+	DarkOnSuccessColor    string `json:"darkOnSuccessColor,omitempty"`
+	DarkOnWarningColor    string `json:"darkOnWarningColor,omitempty"`
+	DarkOnErrorColor      string `json:"darkOnErrorColor,omitempty"`
 }

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -14519,12 +14519,6 @@ func schema_obot_platform_obot_apiclient_types_ThemePreferences(ref common.Refer
 							Format: "",
 						},
 					},
-					"onSurfaceColor": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
 					"surface1Color": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -14543,7 +14537,61 @@ func schema_obot_platform_obot_apiclient_types_ThemePreferences(ref common.Refer
 							Format: "",
 						},
 					},
+					"secondaryColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"successColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"warningColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"errorColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"primaryColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"onPrimaryColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"onSuccessColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"onWarningColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"onErrorColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"fontFamily": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",
@@ -14556,12 +14604,6 @@ func schema_obot_platform_obot_apiclient_types_ThemePreferences(ref common.Refer
 						},
 					},
 					"darkOnBackgroundColor": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"darkOnSurfaceColor": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",
@@ -14585,7 +14627,55 @@ func schema_obot_platform_obot_apiclient_types_ThemePreferences(ref common.Refer
 							Format: "",
 						},
 					},
+					"darkSecondaryColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"darkSuccessColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"darkWarningColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"darkErrorColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"darkPrimaryColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"darkOnPrimaryColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"darkOnSuccessColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"darkOnWarningColor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"darkOnErrorColor": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -9,26 +9,12 @@
 
 @theme {
 	--font-*: initial;
-	--font-sans:
-		Poppins, ui-sans-serif, system-ui, -apple-system, system-ui, Segoe UI, Roboto, Helvetica Neue,
-		Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol,
-		Noto Color Emoji;
-	--font-body:
-		Poppins, ui-sans-serif, system-ui, -apple-system, system-ui, Segoe UI, Roboto, Helvetica Neue,
-		Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol,
-		Noto Color Emoji;
+	--font-sans: var(--theme-font-family);
+	--font-body: var(--theme-font-family);
 	--font-mono:
 		ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
 
 	--color-*: initial;
-	--color-background: var(--background);
-	--color-on-background: var(--on-background);
-	--color-surface1: var(--surface1);
-	--color-on-surface1: var(--on-surface1);
-	--color-surface2: var(--surface2);
-	--color-on-surface2: var(--on-surface2);
-	--color-surface3: var(--surface3);
-	--color-on-surface3: var(--on-surface3);
 	--color-transparent: transparent;
 	--color-current: currentColor;
 
@@ -93,7 +79,11 @@
 	--color-yellow-500: oklch(79.5% 0.184 86.047);
 	--color-green-500: oklch(72.3% 0.219 149.579);
 
+	--color-base-400: var(--theme-surface3-light, var(--color-gray-200));
+
 	--color-primary: var(--primary);
+
+	--color-muted-content: color-mix(in oklab, var(--color-base-content) 40%, transparent);
 }
 
 @plugin 'daisyui' {
@@ -107,26 +97,27 @@
 	default: true;
 	prefersdark: false;
 	color-scheme: light;
-	--color-base-100: hsl(0 0 100);
-	--color-base-200: hsl(0 0 95.5);
-	--color-base-300: hsl(0 0 92.5);
-	--color-base-content: hsl(0 0 0);
-	--color-primary: var(--primary);
-	--color-primary-content: hsl(0 0 100);
-	--color-secondary: hsl(0 0 82.5);
-	--color-secondary-content: hsl(0 0 0);
+	--color-base-100: var(--theme-background-light, var(--color-white));
+	--color-base-200: var(--theme-surface1-light, var(--color-gray-70));
+	--color-base-300: var(--theme-surface2-light, var(--color-gray-100));
+	--color-base-400: var(--theme-surface3-light, var(--color-gray-200));
+	--color-base-content: var(--theme-on-background-light, var(--color-black));
+	--color-primary: var(--theme-primary-light, var(--primary));
+	--color-primary-content: var(--theme-on-primary-light, var(--color-white));
+	--color-secondary: var(--theme-secondary-light, hsl(0 0 82.5));
+	--color-secondary-content: var(--theme-on-secondary-light, hsl(0 0 0));
 	--color-accent: #95bcfb;
 	--color-accent-content: hsl(0 0 0);
 	--color-neutral: hsl(0 0 82.5);
 	--color-neutral-content: hsl(0 0 0);
 	--color-info: var(--primary);
 	--color-info-content: hsl(0 0 100);
-	--color-success: oklch(67% 0.13 149);
-	--color-success-content: hsl(0 0 0);
-	--color-warning: oklch(79.5% 0.184 86.047);
-	--color-warning-content: hsl(0 0 100);
-	--color-error: #ef4444;
-	--color-error-content: hsl(0 0 100);
+	--color-success: var(--theme-success-light, oklch(67% 0.13 149));
+	--color-success-content: var(--theme-on-success-light, hsl(0 0 0));
+	--color-warning: var(--theme-warning-light, oklch(79.5% 0.184 86.047));
+	--color-warning-content: var(--theme-on-warning-light, hsl(0 0 100));
+	--color-error: var(--theme-error-light, #ef4444);
+	--color-error-content: var(--theme-on-error-light, hsl(0 0 100));
 	--radius-selector: 1rem;
 	--radius-field: 0.25rem;
 	--radius-box: 0.5rem;
@@ -143,26 +134,27 @@
 	prefersdark: true;
 	color-scheme: dark;
 
-	--color-base-100: hsl(0 0 0);
-	--color-base-200: hsl(0 0 5.5);
-	--color-base-300: hsl(0 0 12.5);
-	--color-base-content: hsl(0 0 97.5);
-	--color-primary: var(--primary);
-	--color-primary-content: hsl(0 0 97.5);
-	--color-secondary: hsl(0 0 22.5);
-	--color-secondary-content: hsl(0 0 97.5);
+	--color-base-100: var(--theme-background-dark, var(--color-black));
+	--color-base-200: var(--theme-surface1-dark, var(--color-gray-950));
+	--color-base-300: var(--theme-surface2-dark, var(--color-gray-900));
+	--color-base-400: var(--theme-surface3-dark, var(--color-gray-800));
+	--color-base-content: var(--theme-on-background-dark, var(--color-white));
+	--color-primary: var(--theme-primary-dark, var(--color-blue-500));
+	--color-primary-content: var(--theme-on-primary-dark, hsl(0 0 97.5));
+	--color-secondary: var(--theme-secondary-dark, hsl(0 0 22.5));
+	--color-secondary-content: var(--theme-on-secondary-dark, hsl(0 0 97.5));
 	--color-accent: #203188;
 	--color-accent-content: hsl(0 0 97.5);
 	--color-neutral: hsl(0 0 22.5);
 	--color-neutral-content: hsl(0 0 97.5);
 	--color-info: var(--primary);
 	--color-info-content: hsl(0 0 97.5);
-	--color-success: oklch(67% 0.13 149);
-	--color-success-content: hsl(0 0 97.5);
-	--color-warning: oklch(79.5% 0.184 86.047);
-	--color-warning-content: hsl(0 0 97.5);
-	--color-error: #ef4444;
-	--color-error-content: hsl(0 0 97.5);
+	--color-success: var(--theme-success-dark, oklch(67% 0.13 149));
+	--color-success-content: var(--theme-on-success-dark, hsl(0 0 97.5));
+	--color-warning: var(--theme-warning-dark, oklch(79.5% 0.184 86.047));
+	--color-warning-content: var(--theme-on-warning-dark, hsl(0 0 97.5));
+	--color-error: var(--theme-error-dark, #ef4444);
+	--color-error-content: var(--theme-on-error-dark, hsl(0 0 97.5));
 	--radius-selector: 1rem;
 	--radius-field: 0.25rem;
 	--radius-box: 0.5rem;
@@ -171,30 +163,6 @@
 	--border: 1px;
 	--depth: 0;
 	--noise: 0;
-}
-
-.nanobot[data-theme='nanobotlight'] {
-	--background: var(--theme-background-light, var(--color-white));
-	--on-background: var(--theme-on-background-light, var(--color-black));
-	--surface1: var(--theme-surface1-light, var(--color-gray-70));
-	--on-surface1: var(--theme-on-surface-light, var(--color-gray-400));
-	--surface2: var(--theme-surface2-light, var(--color-gray-100));
-	--on-surface2: var(--theme-on-surface-light, var(--color-black));
-	--surface3: var(--theme-surface3-light, var(--color-gray-200));
-	--on-surface3: var(--theme-on-surface-light, var(--color-black));
-	--primary: var(--theme-primary-light, var(--color-blue-500));
-}
-
-.nanobot[data-theme='nanobotdark'] {
-	--background: var(--theme-background-dark, var(--color-black));
-	--on-background: var(--theme-on-background-dark, var(--color-gray-50));
-	--surface1: var(--theme-surface1-dark, var(--color-gray-950));
-	--on-surface1: var(--theme-on-surface-dark, var(--color-gray-500));
-	--surface2: var(--theme-surface2-dark, var(--color-gray-900));
-	--on-surface2: var(--theme-on-surface-dark, var(--color-gray-50));
-	--surface3: var(--theme-surface3-dark, var(--color-gray-800));
-	--on-surface3: var(--theme-on-surface-dark, var(--color-gray-50));
-	--primary: var(--theme-primary-dark, var(--color-blue-500));
 }
 
 /*
@@ -215,27 +183,27 @@
 	}
 
 	body {
-		background-color: var(--background);
-		color: var(--on-background);
+		background-color: var(--color-base-100);
+		color: var(--color-base-content);
 	}
 
 	textarea,
 	input {
 		accent-color: var(--color-primary);
-		background-color: var(--background);
-		color: var(--on-background);
+		background-color: var(--color-base-100);
+		color: var(--color-base-content);
 		color-scheme: light;
 
 		&:disabled {
-			color: var(--color-gray-300);
+			color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 		}
 
 		.dark &:disabled {
-			color: var(--color-gray-500);
+			color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 		}
 
 		&::placeholder {
-			color: var(--color-gray-400);
+			color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 		}
 
 		.dark & {
@@ -243,13 +211,13 @@
 		}
 
 		.dark &::placeholder {
-			color: var(--color-gray-600);
+			color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 		}
 	}
 
 	blockquote {
 		border-left-width: 2px;
-		border-color: var(--color-gray-200);
+		border-color: color-mix(in oklab, var(--color-base-content) 70%, transparent);
 		padding-left: 1rem;
 		/* pl-4 */
 		font-style: italic;
@@ -442,381 +410,13 @@
 		transform-origin: center;
 	}
 
-	.icon-button-colors {
-		color: var(--color-gray-500);
-
-		&:hover {
-			background-color: var(--surface3);
-		}
-
-		&:focus {
-			outline: none;
-		}
-
-		.dark & {
-			color: var(--color-gray-400);
-		}
-	}
-
-	.icon-button {
-		display: flex;
-		min-height: 2.5rem;
-		/* min-h-10 */
-		min-width: 2.5rem;
-		/* min-w-10 */
-		align-items: center;
-		justify-content: center;
-		border-radius: 9999px;
-		/* rounded-full */
-		padding: 0.625rem;
-		/* p-2.5 */
-		font-size: 0.875rem;
-		/* text-sm */
-		transition-property: all;
-		transition-duration: 200ms;
-		color: var(--color-gray-500);
-
-		&:hover {
-			background-color: var(--surface3);
-		}
-
-		&:focus {
-			outline: none;
-		}
-
-		.dark & {
-			color: var(--color-gray-400);
-		}
-
-		&:disabled {
-			opacity: 0.5;
-		}
-
-		&:disabled:hover {
-			background-color: transparent;
-		}
-	}
-
-	.button-icon {
-		display: flex;
-		min-height: 2.5rem;
-		/* min-h-10 */
-		min-width: 2.5rem;
-		/* min-w-10 */
-		align-items: center;
-		justify-content: center;
-		border-radius: 9999px;
-		/* rounded-full */
-		padding: 0.625rem;
-		/* p-2.5 */
-		font-size: 0.875rem;
-		/* text-sm */
-		transition-property: all;
-		transition-duration: 200ms;
-		color: var(--color-gray-500);
-
-		&:hover {
-			background-color: var(--surface3);
-		}
-
-		&:focus {
-			outline: none;
-		}
-
-		.dark & {
-			color: var(--color-gray-400);
-		}
-
-		&:disabled {
-			opacity: 0.5;
-		}
-
-		&:disabled:hover {
-			background-color: transparent;
-		}
-	}
-
-	.icon-default {
-		height: 1.25rem;
-		/* h-5 */
-		width: 1.25rem;
-		/* w-5 */
-	}
-
-	.icon-button-small {
-		border-radius: 0.5rem;
-		/* rounded-lg */
-		padding: 0.25rem;
-		/* p-1 */
-		font-size: 0.875rem;
-		/* text-sm */
-		transition-property: all;
-		transition-duration: 200ms;
-		color: var(--color-gray-500);
-
-		&:hover {
-			background-color: var(--surface3);
-		}
-
-		&:focus {
-			outline: none;
-		}
-
-		.dark & {
-			color: var(--color-gray-400);
-		}
-	}
-
-	.icon-default-size {
-		height: 1.25rem;
-		/* h-5 */
-		width: 1.25rem;
-		/* w-5 */
-	}
-
-	.button-colors {
-		background-color: var(--surface3);
-		border-width: 0;
-
-		&:hover {
-			background-color: rgb(229 231 235 / 0.5);
-			/* bg-gray-200/50 */
-		}
-
-		.dark &:hover {
-			background-color: var(--color-gray-700);
-		}
-	}
-
-	.button {
-		border-radius: 1.5rem;
-		border-width: 2px;
-		padding: 0.5rem 1.25rem;
-		background-color: var(--surface3);
-		border-color: var(--surface3);
-		transition-property: all;
-		transition-duration: 200ms;
-
-		&:hover {
-			background-color: color-mix(in oklab, var(--surface3) 90%, var(--color-black));
-			border-color: color-mix(in oklab, var(--surface3) 90%, var(--color-black));
-		}
-
-		.dark &:hover {
-			background-color: color-mix(in oklab, var(--surface3) 90%, var(--color-white));
-			border-color: color-mix(in oklab, var(--surface3) 90%, var(--color-white));
-		}
-
-		&:disabled {
-			opacity: 0.5;
-		}
-
-		&:disabled:hover {
-			background-color: var(--surface3);
-			border-color: var(--surface3);
-		}
-	}
-
-	.button-small {
-		display: flex;
-		align-items: center;
-		gap: 0.25rem;
-		/* gap-1 */
-		font-size: 0.875rem;
-		/* text-sm */
-
-		border-radius: 1.5rem;
-		padding: 0.5rem 1.25rem;
-		background-color: var(--surface3);
-		border-width: 0;
-		transition-property: color, background-color;
-		transition-duration: 200ms;
-
-		&:hover {
-			background-color: color-mix(in oklab, var(--surface3) 90%, var(--color-black));
-			border-color: color-mix(in oklab, var(--surface3) 90%, var(--color-black));
-		}
-
-		.dark &:hover {
-			background-color: color-mix(in oklab, var(--surface3) 90%, var(--color-white));
-		}
-	}
-
-	.button-secondary {
-		border-radius: 1.5rem;
-		/* rounded-3xl */
-		border-width: 2px;
-		/* border-2 */
-		padding: 0.5rem 1.25rem;
-		/* px-5 py-2 */
-		border-color: var(--color-gray-100);
-		transition-property: all;
-		transition-duration: 300ms;
-
-		&:hover {
-			border-color: var(--color-gray-200);
-			background-color: var(--color-gray-200);
-		}
-
-		.dark & {
-			border-color: var(--color-gray-900);
-		}
-
-		.dark &:hover {
-			border-color: var(--color-gray-800);
-			background-color: var(--color-gray-800);
-		}
-	}
-
-	.button-primary {
-		border-radius: 1.5rem;
-		/* rounded-3xl */
-		border-width: 2px;
-		/* border-2 */
-		padding: 0.5rem 1.25rem;
-		/* px-5 py-2 */
-		border-color: var(--color-primary);
-		background-color: var(--color-primary);
-		color: white;
-		transition-property: all;
-		transition-duration: 300ms;
-
-		&:hover {
-			border-color: color-mix(in oklab, var(--color-primary) 75%, var(--color-background));
-		}
-
-		.dark & {
-			color: var(--color-gray-50);
-		}
-
-		&:disabled {
-			cursor: default;
-			opacity: 0.5;
-		}
-
-		&:disabled:hover {
-			border-color: var(--color-primary);
-			background-color: var(--color-primary);
-		}
-	}
-
-	.button-icon-primary {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		border-radius: 9999px;
-		/* rounded-full */
-		padding: 0.5rem;
-		/* p-2 */
-		color: var(--color-gray);
-
-		&:hover {
-			color: var(--color-primary);
-			background-color: var(--color-gray-100);
-		}
-
-		&:focus {
-			outline: none;
-		}
-
-		.dark &:hover {
-			background-color: var(--color-gray-950);
-		}
-
-		&:disabled:hover {
-			color: var(--color-gray);
-			background-color: transparent;
-		}
-	}
-
-	.button-text {
-		color: var(--color-gray);
-		width: fit-content;
-		justify-content: flex-start;
-		padding: 1rem;
-		text-align: left;
-		font-size: var(--text-sm);
-
-		&:hover {
-			text-decoration: underline;
-		}
-
-		&:disabled {
-			&:hover {
-				@media (hover: hover) {
-					text-decoration-line: none;
-				}
-			}
-
-			cursor: default;
-			opacity: 0.5;
-		}
-	}
-
-	.button-destructive {
-		display: flex;
-		align-items: center;
-		gap: 0.25rem;
-		border-radius: 9999px;
-		background-color: rgb(239 68 68 / 0.2);
-		/* bg-red-500/20 */
-		padding: 1rem 1rem;
-		/* px-4 py-2 */
-		font-size: 0.875rem;
-		color: var(--color-red-500);
-		transition-property: all;
-		transition-duration: 200ms;
-
-		&:hover {
-			background-color: var(--color-red-500);
-			color: white;
-		}
-
-		&:disabled {
-			cursor: default;
-			opacity: 0.5;
-		}
-	}
-
-	.button-auth {
-		display: flex;
-		width: 100%;
-		align-items: center;
-		justify-content: center;
-		gap: 0.375rem;
-		/* gap-1.5 */
-		border-radius: 9999px;
-		/* rounded-full */
-		padding: 0.5rem 2rem;
-		/* p-2 px-8 */
-		font-size: 1.125rem;
-		/* text-lg */
-		font-weight: 600;
-		/* font-semibold */
-		background-color: var(--surface1);
-		transition-property: background-color;
-		transition-duration: 200ms;
-
-		&:hover {
-			background-color: var(--surface2);
-		}
-
-		.dark & {
-			background-color: var(--surface1);
-		}
-
-		.dark &:hover {
-			background-color: var(--surface3);
-		}
-	}
-
 	.list-button-primary {
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		border-radius: 9999px;
 		/* rounded-full */
-		color: var(--color-gray);
+		color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 		padding: 0;
 
 		&:focus {
@@ -824,8 +424,7 @@
 		}
 
 		.dark &:hover {
-			background-color: rgb(55 65 81 / 0.3);
-			/* bg-gray-700/30 */
+			background-color: color-mix(in oklab, var(--color-base-400) 30%, transparent);
 		}
 
 		&:hover {
@@ -850,11 +449,11 @@
 		transition-duration: var(--tw-duration, var(--default-transition-duration));
 
 		&:hover {
-			background-color: color-mix(in oklab, var(--color-surface1) 50%, transparent);
+			background-color: color-mix(in oklab, var(--color-base-200) 50%, transparent);
 		}
 
 		.dark &:hover {
-			background-color: color-mix(in oklab, var(--color-surface3) 50%, transparent);
+			background-color: color-mix(in oklab, var(--color-base-400) 50%, transparent);
 		}
 
 		@media (max-width: 768px) {
@@ -867,7 +466,7 @@
 	}
 
 	label.error {
-		color: var(--color-red-500);
+		color: var(--color-error);
 	}
 
 	.text-input-filled,
@@ -875,7 +474,7 @@
 		width: 100%;
 		border-radius: 0.5rem;
 		border: 1px solid transparent;
-		background-color: var(--surface1);
+		background-color: var(--color-base-200);
 		padding: 0.5rem;
 		outline: none;
 		--tw-shadow: inset 0 2px 4px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.05));
@@ -890,16 +489,16 @@
 		}
 
 		.dark & {
-			background-color: var(--surface1);
-			border: 1px solid var(--surface3);
+			background-color: var(--color-base-200);
+			border: 1px solid var(--color-base-400);
 		}
 
 		&.error {
 			/* important to override default styles & precedence over dark mode */
-			border: 1px solid var(--color-red-500) !important;
-			background-color: rgb(239 68 68 / 0.2) !important;
-			color: var(--color-red-500) !important;
-			--tw-ring-color: var(--color-red-500);
+			border: 1px solid var(--color-error) !important;
+			background-color: color-mix(in oklab, var(--color-error) 20%, transparent) !important;
+			color: var(--color-error) !important;
+			--tw-ring-color: var(--color-error);
 
 			&:focus-within {
 				--tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width))
@@ -911,7 +510,7 @@
 	}
 
 	.input-description {
-		color: var(--color-gray-500);
+		color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 		font-size: var(--text-xs);
 		line-height: var(--text-xs--line-height);
 	}
@@ -922,10 +521,9 @@
 		font-weight: var(--font-weight-light);
 	}
 
-	.text-input,
 	.input-text {
 		border-bottom-width: 1px;
-		border-color: var(--surface3);
+		border-color: var(--color-base-400);
 		background-color: transparent;
 		padding-top: 0.5rem;
 		padding-bottom: 0.5rem;
@@ -942,11 +540,11 @@
 	.default-scrollbar-thin {
 		overflow: auto;
 		scrollbar-width: thin;
-		scrollbar-color: var(--surface3) var(--surface2);
+		scrollbar-color: var(--color-base-400) var(--color-base-300);
 	}
 
 	.default-scrollbar {
-		scrollbar-color: var(--surface3) var(--surface1);
+		scrollbar-color: var(--color-base-400) var(--color-base-200);
 	}
 
 	.scrollbar-stable-gutter {
@@ -996,7 +594,7 @@
 		position: relative;
 
 		&.mobile {
-			border-color: var(--surface3);
+			border-color: var(--color-base-400);
 			width: 100%;
 			border-bottom-width: 1px;
 			min-height: 3.5rem;
@@ -1010,10 +608,10 @@
 	.dialog-container {
 		border-radius: var(--radius-xl);
 		border-width: 1px;
-		border-color: var(--surface3);
-		background-color: var(--background);
+		border-color: var(--color-base-400);
+		background-color: var(--color-base-100);
 		font-size: 0.875rem;
-		color: var(--on-background);
+		color: var(--color-base-content);
 		box-shadow: var(--shadow-lg);
 		grid-row-start: 1;
 		grid-column-start: 1;
@@ -1022,7 +620,7 @@
 		max-height: 100dvh;
 
 		.dark & {
-			background-color: var(--surface2);
+			background-color: var(--color-base-300);
 		}
 
 		&.mobile {
@@ -1050,22 +648,6 @@
 	.dialog-close-btn {
 		position: relative;
 		padding: 0.625rem;
-		transition-property: all;
-		transition-duration: 200ms;
-		color: var(--color-gray-500);
-		border-radius: 9999px;
-
-		&:hover {
-			background-color: var(--surface3);
-		}
-
-		&:focus {
-			outline: none;
-		}
-
-		.dark & {
-			color: var(--color-gray-400);
-		}
 
 		.mobile & {
 			position: absolute;
@@ -1083,10 +665,10 @@
 	.popover {
 		border-radius: var(--radius-xl);
 		border-width: 1px;
-		border-color: var(--surface3);
-		background-color: var(--background);
+		border-color: var(--color-base-400);
+		background-color: var(--color-base-100);
 		font-size: 0.875rem;
-		color: var(--on-background);
+		color: var(--color-base-content);
 		box-shadow: var(--shadow-lg);
 		grid-row-start: 1;
 		grid-column-start: 1;
@@ -1094,7 +676,7 @@
 		overflow-y: auto;
 
 		.dark & {
-			background-color: var(--surface2);
+			background-color: var(--color-base-300);
 		}
 	}
 
@@ -1120,7 +702,7 @@
 		padding: 0.5rem;
 	}
 	.dropdown-link:hover {
-		background-color: var(--surface3);
+		background-color: var(--color-base-400);
 	}
 
 	.drawer-legacy[popover] {
@@ -1137,7 +719,7 @@
 		border-radius: 0;
 		border-width: 0;
 		outline: none;
-		background-color: var(--background);
+		background-color: var(--color-base-100);
 		box-shadow: var(--shadow-lg);
 		transition:
 			transform 0.2s ease-out,
@@ -1146,8 +728,8 @@
 			display 0.2s ease-out allow-discrete;
 
 		.dark & {
-			background-color: var(--surface1);
-			border-color: var(--surface1);
+			background-color: var(--color-base-200);
+			border-color: var(--color-base-200);
 		}
 	}
 
@@ -1169,23 +751,8 @@
 	}
 
 	.colors-background {
-		background-color: var(--background);
-		color: var(--on-background);
-	}
-
-	.colors-surface1 {
-		background-color: var(--surface1);
-		color: var(--on-surface1);
-	}
-
-	.colors-surface2 {
-		background-color: var(--surface2);
-		color: var(--on-surface2);
-	}
-
-	.colors-surface3 {
-		background-color: var(--surface3);
-		color: var(--on-surface3);
+		background-color: var(--color-base-100);
+		color: var(--color-base-content);
 	}
 
 	.card {
@@ -1198,7 +765,7 @@
 		border-radius: 0.375rem;
 		/* rounded-md */
 		border: 1px solid transparent;
-		background-color: white;
+		background-color: var(--color-base-100);
 		padding: 1rem;
 		/* p-4 */
 		box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
@@ -1210,15 +777,15 @@
 		}
 
 		.dark & {
-			background-color: var(--surface1);
-			border-color: var(--surface3);
+			background-color: var(--color-base-200);
+			border-color: var(--color-base-400);
 		}
 	}
 
 	.tooltip {
 		border-radius: 0.5rem;
-		border: 1px solid var(--surface3);
-		background-color: var(--surface2);
+		border: 1px solid var(--color-base-400);
+		background-color: var(--color-base-300);
 		padding: 0.5rem;
 		font-size: 0.875rem;
 		font-weight: 300;
@@ -1238,7 +805,7 @@
 		transition-duration: 200ms;
 
 		&:hover {
-			background-color: var(--surface2);
+			background-color: var(--color-base-300);
 		}
 
 		&:disabled {
@@ -1247,7 +814,7 @@
 		}
 
 		.dark &:hover {
-			background-color: var(--surface3);
+			background-color: var(--color-base-400);
 		}
 	}
 
@@ -1261,19 +828,19 @@
 		border-width: 1px;
 		border-style: solid;
 		border-color: transparent;
-		background-color: var(--background);
+		background-color: var(--color-base-100);
 		padding: 1.5rem;
 		box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 
 		.dark & {
-			background-color: var(--surface1, #f5f5f5);
-			border-color: var(--surface3, #d4d4d8);
+			background-color: var(--color-base-200, #f5f5f5);
+			border-color: var(--color-base-400, #d4d4d8);
 		}
 	}
 
 	.paper .text-input-filled {
 		.dark & {
-			background-color: var(--background);
+			background-color: var(--color-base-100);
 		}
 	}
 
@@ -1290,11 +857,11 @@
 		font-size: 0.875rem;
 		transition-property: all;
 		transition-duration: 200ms;
-		background-color: rgb(239 68 68 / 0.1);
-		color: var(--color-red-500);
+		background-color: color-mix(in oklab, var(--color-error) 10%, transparent);
+		color: var(--color-error);
 
 		&:hover {
-			background-color: rgb(239 68 68 / 0.2);
+			background-color: color-mix(in oklab, var(--color-error) 20%, transparent);
 		}
 
 		&:disabled {
@@ -1303,7 +870,7 @@
 		}
 
 		&:disabled:hover {
-			background-color: rgb(239 68 68 / 0.1);
+			background-color: color-mix(in oklab, var(--color-error) 10%, transparent);
 		}
 
 		@media (min-width: 768px) {
@@ -1358,22 +925,17 @@
 		transition-duration: 300ms;
 
 		&:hover {
-			border-color: var(--surface2);
+			border-color: var(--color-base-300);
 		}
 	}
 
 	.mock-input-btn {
-		background-color: var(--color-surface1);
+		background-color: var(--color-base-200);
 		padding: 0.5rem;
-		color: var(--color-gray-500);
+		color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 		width: 100%;
 		border-radius: 0.5rem;
 		text-align: left;
-
-		.dark {
-			background-color: var(--color-black);
-			color: var(--color-gray-300);
-		}
 	}
 
 	.nav-link {
@@ -1401,20 +963,20 @@
 
 	.notification-error {
 		border-radius: 0.5rem;
-		border: 1px solid var(--color-red-500);
-		background-color: rgb(239 68 68 / 0.15);
+		border: 1px solid var(--color-error);
+		background-color: color-mix(in oklab, var(--color-error) 10%, transparent);
 		padding: 0.5rem 1rem;
-		color: var(--color-red-500);
+		color: var(--color-error);
 	}
 
 	.notification-alert {
 		border-radius: 0.5rem;
-		border: 1px solid var(--color-yellow-500);
-		background-color: rgba(252, 199, 93, 0.15);
+		border: 1px solid var(--color-warning);
+		background-color: color-mix(in oklab, var(--color-warning) 10%, transparent);
 		padding: 0.5rem 1rem;
 
 		svg {
-			color: var(--color-yellow-500);
+			color: var(--color-warning);
 		}
 	}
 
@@ -1447,14 +1009,14 @@
 		align-items: center;
 		gap: 0.25rem;
 		width: fit-content;
-		background-color: var(--surface3);
+		background-color: var(--color-base-400);
 		border-radius: 9999px;
 		padding: 0.25rem 0.75rem;
 		font-size: 0.75rem;
 		line-height: 1rem;
 
 		.dark & {
-			background-color: var(--surface2);
+			background-color: var(--color-base-300);
 		}
 	}
 
@@ -1473,8 +1035,8 @@
 
 	.pill-warning {
 		border-radius: var(--radius-sm);
-		background-color: color-mix(in oklab, var(--color-yellow-500) 10%, transparent);
-		color: var(--color-yellow-500);
+		background-color: color-mix(in oklab, var(--color-warning) 10%, transparent);
+		color: var(--color-warning);
 		padding: 0.125rem 0.25rem;
 		font-size: 11px;
 		line-height: 1rem;
@@ -1484,12 +1046,12 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background-color: var(--color-surface1);
+		background-color: var(--color-base-200);
 		border-radius: var(--radius-sm);
 		padding: 0.125rem;
 
 		.dark & {
-			background-color: var(--color-gray-600);
+			background-color: var(--color-base-400);
 		}
 	}
 
@@ -1520,7 +1082,7 @@
 	.tooltip-divider {
 		height: 1px;
 		width: 100%;
-		background-color: var(--color-surface3);
+		background-color: var(--color-base-400);
 		margin-top: 0.5rem;
 		margin-bottom: 0.5rem;
 	}
@@ -1545,6 +1107,104 @@
 		color: inherit;
 		border-bottom-color: var(--primary);
 		font-weight: 500;
+	}
+}
+
+@layer utilities {
+	.toggle {
+		border-color: transparent;
+		background-color: var(--color-base-400);
+		--input-color: var(--color-base-100);
+	}
+
+	.dark .toggle {
+		--input-color: var(--color-base-300);
+	}
+
+	.toggle:checked,
+	.toggle[aria-checked='true'],
+	.toggle:has(> input:checked) {
+		background-color: var(--color-primary);
+		--input-color: var(--color-base-100);
+	}
+
+	.dark .toggle:checked,
+	.dark .toggle[aria-checked='true'],
+	.dark .toggle:has(> input:checked) {
+		--input-color: var(--color-base-300);
+	}
+
+	.btn {
+		font-weight: var(--font-weight-normal);
+	}
+
+	.btn-primary:not(.btn-circle):not(.btn-square),
+	.btn-secondary:not(.btn-circle):not(.btn-square),
+	.btn-error:not(.btn-circle):not(.btn-square),
+	.btn-warning:not(.btn-circle):not(.btn-square),
+	.btn-success:not(.btn-circle):not(.btn-square) {
+		border-radius: var(--radius-4xl);
+		padding-left: 1.25rem;
+		padding-right: 1.25rem;
+	}
+
+	.btn-link {
+		font-weight: var(--font-weight-light);
+		color: var(--color-base-content);
+		text-decoration: none;
+		&:hover {
+			color: var(--color-blue-500);
+			text-decoration: underline;
+		}
+	}
+
+	.btn-neutral {
+		color: var(--color-base-content);
+		background-color: var(--color-base-100);
+		border-color: transparent;
+		box-shadow: var(--shadow-sm);
+		font-size: var(--text-sm);
+
+		&:hover {
+			background-color: var(--color-base-200);
+		}
+
+		.dark & {
+			background-color: var(--color-base-100);
+			border-color: var(--color-base-400);
+
+			&:hover {
+				background-color: var(--color-base-400);
+			}
+		}
+	}
+
+	.btn-text {
+		@layer daisyui.l1 {
+			outline-color: currentcolor;
+			--btn-border: #0000;
+			--btn-bg: #0000;
+			--btn-noise: none;
+			--btn-shadow: '';
+			&:not(.btn-disabled, .btn:disabled, .btn[disabled]) {
+				--btn-fg: color-mix(in oklab, var(--color-base-content) 50%, transparent);
+			}
+			&:is(.btn-active, :hover, :active:focus, :focus-visible) {
+				--btn-fg: var(--color-base-content);
+				--btn-border: #0000;
+				--btn-bg: #0000;
+				text-decoration-line: underline;
+			}
+		}
+	}
+
+	html.dark .skeleton {
+		background-image: linear-gradient(
+			105deg,
+			var(--color-base-200) 0% 40%,
+			var(--color-base-300) 50%,
+			var(--color-base-200) 60% 100%
+		);
 	}
 }
 
@@ -1580,13 +1240,13 @@
 
 	& ol {
 		& ::marker {
-			color: var(--color-gray-500);
+			color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 		}
 	}
 
 	& ul {
 		& ::marker {
-			color: var(--color-gray-500);
+			color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 		}
 	}
 
@@ -1671,14 +1331,14 @@
 	}
 
 	& table {
-		border: 1px solid var(--surface3);
+		border: 1px solid var(--color-base-400);
 
 		& th {
 			padding: 0.5rem 1rem;
-			border-bottom: 1px solid var(--surface3);
+			border-bottom: 1px solid var(--color-base-400);
 
 			&:not(:last-child) {
-				border-right: 1px solid var(--surface3);
+				border-right: 1px solid var(--color-base-400);
 			}
 		}
 
@@ -1686,26 +1346,26 @@
 			padding: 0.5rem 1rem;
 
 			&:not(:last-child) {
-				border-right: 1px solid var(--surface3);
+				border-right: 1px solid var(--color-base-400);
 			}
 		}
 
 		& tr:not(:last-child) {
-			border-bottom: 1px solid var(--surface3);
+			border-bottom: 1px solid var(--color-base-400);
 		}
 	}
 
 	& code {
-		background-color: var(--surface1);
+		background-color: var(--color-base-200);
 		padding: 0.25rem 0.5rem;
 		border-radius: 0.25rem;
 		font-size: 0.875rem;
 		font-weight: 500;
-		color: var(--on-surface1);
+		color: var(--color-muted-content);
 
 		.dark & {
-			background-color: var(--surface2);
-			color: var(--on-surface2);
+			background-color: var(--color-base-300);
+			color: var(--color-base-400);
 		}
 	}
 
@@ -1815,14 +1475,14 @@
 	}
 
 	& table {
-		border: 1px solid var(--surface3);
+		border: 1px solid var(--color-base-400);
 
 		& th {
 			padding: 0.5rem 1rem;
-			border-bottom: 1px solid var(--surface3);
+			border-bottom: 1px solid var(--color-base-400);
 
 			&:not(:last-child) {
-				border-right: 1px solid var(--surface3);
+				border-right: 1px solid var(--color-base-400);
 			}
 		}
 
@@ -1830,26 +1490,26 @@
 			padding: 0.5rem 1rem;
 
 			&:not(:last-child) {
-				border-right: 1px solid var(--surface3);
+				border-right: 1px solid var(--color-base-400);
 			}
 		}
 
 		& tr:not(:last-child) {
-			border-bottom: 1px solid var(--surface3);
+			border-bottom: 1px solid var(--color-base-400);
 		}
 	}
 
 	& code {
-		background-color: var(--surface1);
+		background-color: var(--color-base-200);
 		padding: 0.25rem 0.5rem;
 		border-radius: 0.25rem;
 		font-size: 0.875rem;
 		font-weight: 500;
-		color: var(--on-surface1);
+		color: var(--color-muted-content);
 
 		.dark & {
-			background-color: var(--surface2);
-			color: var(--on-surface2);
+			background-color: var(--color-base-300);
+			color: var(--color-base-400);
 		}
 	}
 
@@ -1862,30 +1522,17 @@
 }
 
 .dark {
-	--background: var(--theme-background-dark, var(--color-black));
-	--on-background: var(--theme-on-background-dark, var(--color-gray-50));
-	--surface1: var(--theme-surface1-dark, var(--color-gray-950));
-	--on-surface1: var(--theme-on-surface-dark, var(--color-gray-500));
-	--surface2: var(--theme-surface2-dark, var(--color-gray-900));
-	--on-surface2: var(--theme-on-surface-dark, var(--color-gray-50));
-	--surface3: var(--theme-surface3-dark, var(--color-gray-800));
-	--on-surface3: var(--theme-on-surface-dark, var(--color-gray-50));
 	--primary: var(--theme-primary-dark, var(--color-blue-500));
 }
 
 html {
-	--background: var(--theme-background-light, var(--color-white));
-	--on-background: var(--theme-on-background-light, var(--color-black));
-	--surface1: var(--theme-surface1-light, var(--color-gray-70));
-	--on-surface1: var(--theme-on-surface-light, var(--color-gray-400));
-	--surface2: var(--theme-surface2-light, var(--color-gray-100));
-	--on-surface2: var(--theme-on-surface-light, var(--color-black));
-	--surface3: var(--theme-surface3-light, var(--color-gray-200));
-	--on-surface3: var(--theme-on-surface-light, var(--color-black));
+	--theme-font-family:
+		Poppins, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica Neue, Arial,
+		Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
 	--primary: var(--theme-primary-light, var(--color-blue-500));
 }
 
 .scrollable {
-	scrollbar-color: var(--color-surface3) #f1f1f100;
+	scrollbar-color: var(--color-base-400) #f1f1f100;
 	scrollbar-width: auto;
 }

--- a/ui/user/src/app.html
+++ b/ui/user/src/app.html
@@ -4,13 +4,20 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<script>
+			// Keep in sync with `getIsDark()` in `src/lib/stores/darkmode.svelte.ts`
 			(function () {
-				var dark = localStorage.getItem('theme');
-				if (
-					dark === 'true' ||
-					(dark === null && window.matchMedia('(prefers-color-scheme: dark)').matches)
-				) {
+				function getIsDark() {
+					var theme = localStorage.getItem('theme') ?? 'system';
+					if (theme === 'dark') return true;
+					if (theme === 'light') return false;
+					return window.matchMedia('(prefers-color-scheme: dark)').matches;
+				}
+				if (getIsDark()) {
 					document.documentElement.classList.add('dark');
+					document.documentElement.setAttribute('data-theme', 'nanobotdark');
+				} else {
+					document.documentElement.classList.remove('dark');
+					document.documentElement.setAttribute('data-theme', 'nanobotlight');
 				}
 			})();
 		</script>
@@ -21,25 +28,25 @@
 				display: flex;
 				align-items: center;
 				justify-content: center;
-				background: var(--background, #ffffff);
+				background: var(--color-base-100, #ffffff);
 				z-index: 9999;
 				transition: opacity 0.15s ease-out;
 			}
 			html.dark #initial-loader {
-				background: var(--background, #0a0a0a);
+				background: var(--color-base-100, #0a0a0a);
 			}
 			#initial-loader .spinner {
 				box-sizing: border-box;
 				width: 32px;
 				height: 32px;
-				border: 3px solid var(--surface1, #e5e7eb);
-				border-top-color: var(--primary, #4f7ef3);
+				border: 3px solid var(--color-base-200, #e5e7eb);
+				border-top-color: var(--color-primary, #4f7ef3);
 				border-radius: 50%;
 				animation: spin 0.8s linear infinite;
 			}
 			html.dark #initial-loader .spinner {
-				border-color: var(--surface1, #27272a);
-				border-top-color: var(--primary, #4f7ef3);
+				border-color: var(--color-base-200, #27272a);
+				border-top-color: var(--color-primary, #4f7ef3);
 			}
 			@keyframes spin {
 				to {

--- a/ui/user/src/lib/actions/tooltip.svelte.ts
+++ b/ui/user/src/lib/actions/tooltip.svelte.ts
@@ -3,7 +3,7 @@ import SnippetComponent from '$lib/components/primitives/Snippet.svelte';
 import type { Placement } from '@floating-ui/dom';
 import { mount, unmount, type Snippet } from 'svelte';
 
-const DEFAULT_LAYOUT_CLASSES = ['max-w-64', 'break-words', 'whitespace-pre-wrap'] as const;
+const DEFAULT_LAYOUT_CLASSES = ['max-w-64', 'wrap-break-word', 'whitespace-pre-wrap'] as const;
 
 export type TooltipVariant = 'default' | 'daisy';
 

--- a/ui/user/src/lib/actions/tutorial.svelte.ts
+++ b/ui/user/src/lib/actions/tutorial.svelte.ts
@@ -85,7 +85,7 @@ export function tutorial(opts: TutorialOptions) {
 		clone.style.top = `${rect.top}px`;
 		clone.style.width = `${rect.width}px`;
 		clone.style.height = `${rect.height}px`;
-		clone.classList.add('bg-background', 'px-2', 'rounded-md');
+		clone.classList.add('bg-base-100', 'px-2', 'rounded-md');
 
 		backdrop.appendChild(clone);
 

--- a/ui/user/src/lib/colors.ts
+++ b/ui/user/src/lib/colors.ts
@@ -1,101 +1,3 @@
-export function parseColorToHsl(css: string): { h: number; s: number; l: number } | null {
-	const s = css.trim();
-	const hexMatch = s.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
-	if (hexMatch) {
-		let hex = hexMatch[1];
-		if (hex.length === 3) hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-		const r = parseInt(hex.slice(0, 2), 16) / 255;
-		const g = parseInt(hex.slice(2, 4), 16) / 255;
-		const b = parseInt(hex.slice(4, 6), 16) / 255;
-		const max = Math.max(r, g, b);
-		const min = Math.min(r, g, b);
-		let h = 0;
-		let s_ = 0;
-		const l = (max + min) / 2;
-		if (max !== min) {
-			const d = max - min;
-			s_ = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-			switch (max) {
-				case r:
-					h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
-					break;
-				case g:
-					h = ((b - r) / d + 2) / 6;
-					break;
-				case b:
-					h = ((r - g) / d + 4) / 6;
-					break;
-			}
-		}
-		return { h: h * 360, s: s_ * 100, l: l * 100 };
-	}
-	const rgbMatch = s.match(/^rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
-	if (rgbMatch) {
-		const r = parseInt(rgbMatch[1], 10) / 255;
-		const g = parseInt(rgbMatch[2], 10) / 255;
-		const b = parseInt(rgbMatch[3], 10) / 255;
-		const max = Math.max(r, g, b);
-		const min = Math.min(r, g, b);
-		let h = 0;
-		let s_ = 0;
-		const l = (max + min) / 2;
-		if (max !== min) {
-			const d = max - min;
-			s_ = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-			switch (max) {
-				case r:
-					h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
-					break;
-				case g:
-					h = ((b - r) / d + 2) / 6;
-					break;
-				case b:
-					h = ((r - g) / d + 4) / 6;
-					break;
-			}
-		}
-		return { h: h * 360, s: s_ * 100, l: l * 100 };
-	}
-	const hslMatch = s.match(/^hsla?\s*\(\s*([\d.]+)\s*[, ]\s*([\d.]+)%?\s*[, ]\s*([\d.]+)%?\s*\)/);
-	if (hslMatch) {
-		return {
-			h: parseFloat(hslMatch[1]) % 360,
-			s: Math.min(100, Math.max(0, parseFloat(hslMatch[2]))),
-			l: Math.min(100, Math.max(0, parseFloat(hslMatch[3])))
-		};
-	}
-	return null;
-}
-
-export function hslToHex(h: number, s: number, l: number): string {
-	s /= 100;
-	l /= 100;
-	const a = s * Math.min(l, 1 - l);
-	const f = (n: number) => {
-		const k = (n + h / 30) % 12;
-		const v = l - a * Math.max(Math.min(k - 3, 9 - k, 1), -1);
-		return Math.round(v * 255)
-			.toString(16)
-			.padStart(2, '0');
-	};
-	return `#${f(0)}${f(8)}${f(4)}`;
-}
-
-const PALETTE_SIZE = 9;
-
-/** Build a contrasting palette from primary: primary first, then evenly spaced hues. */
-export function buildPaletteFromPrimary(primaryHsl: { h: number; s: number; l: number }): string[] {
-	const { h, s, l } = primaryHsl;
-	const sat = Math.max(50, Math.min(80, s));
-	const light = Math.max(42, Math.min(58, l));
-	const out: string[] = [];
-	for (let i = 0; i < PALETTE_SIZE; i++) {
-		const hue = (h + (360 / PALETTE_SIZE) * i) % 360;
-		out.push(hslToHex(hue, sat, light));
-	}
-	return out;
-}
-
 export function lightenHex(hex: string, amount: number): string {
 	const h = hex.replace(/^#/, '');
 	const r = parseInt(h.slice(0, 2), 16);
@@ -103,4 +5,298 @@ export function lightenHex(hex: string, amount: number): string {
 	const b = parseInt(h.slice(4, 6), 16);
 	const mix = (c: number) => Math.round(c + (255 - c) * amount);
 	return `#${[r, g, b].map((c) => mix(c).toString(16).padStart(2, '0')).join('')}`;
+}
+
+/**
+ * Converts a hue on the ROYGBIV spectrum (full saturation, mid lightness)
+ * to sRGB bytes. Hue is in degrees [0, 360].
+ */
+export function hueSpectrumToRgb(hue: number): { r: number; g: number; b: number } {
+	const h = ((hue % 360) + 360) % 360;
+	const s = 1;
+	const l = 0.5;
+	const c = (1 - Math.abs(2 * l - 1)) * s;
+	const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+	const m = l - c / 2;
+	let rp = 0;
+	let gp = 0;
+	let bp = 0;
+	if (h < 60) {
+		rp = c;
+		gp = x;
+	} else if (h < 120) {
+		rp = x;
+		gp = c;
+	} else if (h < 180) {
+		gp = c;
+		bp = x;
+	} else if (h < 240) {
+		gp = x;
+		bp = c;
+	} else if (h < 300) {
+		rp = x;
+		bp = c;
+	} else {
+		rp = c;
+		bp = x;
+	}
+	return {
+		r: Math.round((rp + m) * 255),
+		g: Math.round((gp + m) * 255),
+		b: Math.round((bp + m) * 255)
+	};
+}
+
+export function rgbToHex(r: number, g: number, b: number): string {
+	const clamp = (n: number) => Math.max(0, Math.min(255, n));
+	const toHex = (n: number) => clamp(n).toString(16).padStart(2, '0');
+	return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/** Max HSL saturation (0–1) applied when tint is 100%. Kept moderate for UI surfaces. */
+const TINT_MAX_SATURATION = 0.65;
+
+/** Soft HSL lightness bounds so tone/tint never land on pitch black or pure white. */
+const SOFT_L_MIN = 0.035;
+const SOFT_L_MAX = 0.972;
+
+/**
+ * Max change in HSL lightness (shade 0 vs 100 from center). Shade adjusts underlying tone, not an
+ * RGB overlay—whole surface ladder moves darker/lighter together.
+ */
+const SHADE_LIGHTNESS_DELTA_MAX = 0.19;
+
+/** Scales slider extremes so tone shifts stay gentle for UI. */
+const SHADE_TONE_ATTENUATION = 0.82;
+
+/** Discrete shade control: integer ticks with a neutral midpoint (UI slider). */
+export const SHADE_TICK_MIN = 0;
+export const SHADE_TICK_MAX = 6;
+export const SHADE_TICK_NEUTRAL = 3;
+
+/**
+ * In HSL, lightness at 0 or 1 collapses all hues to black or white—so a pure white background
+ * never shows tint. When applying chroma, clamp into (0, 1) so hue/saturation can surface while
+ * keeping relative lightness between background and surfaces.
+ */
+function clampLightnessForHslChroma(lightness: number): number {
+	return Math.min(Math.max(lightness, SOFT_L_MIN), SOFT_L_MAX);
+}
+
+/** Shift base lightness by discrete shade tick (`SHADE_TICK_NEUTRAL` = neutral). */
+function lightnessAfterShadeTone(baseLightness: number, shadeTick: number): number {
+	const tick = Math.round(Math.max(SHADE_TICK_MIN, Math.min(SHADE_TICK_MAX, shadeTick)));
+	const halfSpan = SHADE_TICK_NEUTRAL - SHADE_TICK_MIN;
+	const t = ((tick - SHADE_TICK_NEUTRAL) / halfSpan) * SHADE_TONE_ATTENUATION;
+	const delta = t * SHADE_LIGHTNESS_DELTA_MAX;
+	const l = baseLightness + delta;
+	return Math.min(Math.max(l, SOFT_L_MIN), SOFT_L_MAX);
+}
+
+/**
+ * Parses any CSS color string to sRGB using a canvas (browser only).
+ * Falls back to mid-gray when not in browser or parse fails.
+ */
+export function cssColorToRgb(css: string): { r: number; g: number; b: number } {
+	if (typeof document === 'undefined') {
+		return { r: 128, g: 128, b: 128 };
+	}
+	try {
+		const canvas = document.createElement('canvas');
+		canvas.width = 1;
+		canvas.height = 1;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) {
+			return { r: 128, g: 128, b: 128 };
+		}
+		ctx.fillStyle = css;
+		ctx.fillRect(0, 0, 1, 1);
+		const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+		return { r, g, b };
+	} catch {
+		return { r: 128, g: 128, b: 128 };
+	}
+}
+
+export function rgbToHsl(r: number, g: number, b: number): { h: number; s: number; l: number } {
+	r /= 255;
+	g /= 255;
+	b /= 255;
+	const max = Math.max(r, g, b);
+	const min = Math.min(r, g, b);
+	let h = 0;
+	let s = 0;
+	const l = (max + min) / 2;
+
+	if (max !== min) {
+		const d = max - min;
+		s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+		switch (max) {
+			case r:
+				h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+				break;
+			case g:
+				h = ((b - r) / d + 2) / 6;
+				break;
+			default:
+				h = ((r - g) / d + 4) / 6;
+		}
+	}
+
+	return { h: h * 360, s, l };
+}
+
+export function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+	let hh = ((h % 360) + 360) % 360;
+	hh /= 360;
+
+	if (s === 0) {
+		const v = Math.round(l * 255);
+		return { r: v, g: v, b: v };
+	}
+
+	const hue2rgb = (p: number, q: number, t: number) => {
+		let tt = t;
+		if (tt < 0) tt += 1;
+		if (tt > 1) tt -= 1;
+		if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+		if (tt < 1 / 2) return q;
+		if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+		return p;
+	};
+
+	const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+	const p = 2 * l - q;
+	const r = hue2rgb(p, q, hh + 1 / 3);
+	const g = hue2rgb(p, q, hh);
+	const b = hue2rgb(p, q, hh - 1 / 3);
+
+	return {
+		r: Math.round(r * 255),
+		g: Math.round(g * 255),
+		b: Math.round(b * 255)
+	};
+}
+
+function rgbToCssRgb(r: number, g: number, b: number): string {
+	const clamp = (n: number) => Math.max(0, Math.min(255, Math.round(n)));
+	return `rgb(${clamp(r)} ${clamp(g)} ${clamp(b)})`;
+}
+
+/**
+ * Computes one surface/background color from a base CSS color, hue (degrees), tint (0–100), and shade
+ * (integer ticks `SHADE_TICK_MIN`–`SHADE_TICK_MAX`, neutral `SHADE_TICK_NEUTRAL`).
+ * - Tint 0: preserves base hue/saturation (no chromatic tint); lightness uses the shade-toned base.
+ * - Tint > 0: hue/sat from tint; lightness follows the toned base, clamped so chroma shows on whites.
+ * - Shade neutral tick: no tone shift. Otherwise adjusts underlying HSL lightness (darker/lighter palette).
+ */
+export function applyHueTintShadeToSurface(
+	baseCss: string,
+	hueDeg: number,
+	tint0to100: number,
+	shadeTick: number
+): string {
+	const { r: br, g: bg, b: bb } = cssColorToRgb(baseCss);
+	const { h: bh, s: bs, l: bl } = rgbToHsl(br, bg, bb);
+
+	const blTone = lightnessAfterShadeTone(bl, shadeTick);
+
+	const tint = Math.max(0, Math.min(100, tint0to100));
+	let h = bh;
+	let s = bs;
+	let lForHsl = blTone;
+
+	if (tint > 0) {
+		h = ((hueDeg % 360) + 360) % 360;
+		s = (tint / 100) * TINT_MAX_SATURATION;
+		lForHsl = clampLightnessForHslChroma(blTone);
+	}
+
+	const { r, g, b } = hslToRgb(h, s, lForHsl);
+	return rgbToCssRgb(r, g, b);
+}
+
+export type TintedSurfaceSnapshot = {
+	light: {
+		backgroundColor: string;
+		surface1Color: string;
+		surface2Color: string;
+		surface3Color: string;
+	};
+	dark: {
+		darkBackgroundColor: string;
+		darkSurface1Color: string;
+		darkSurface2Color: string;
+		darkSurface3Color: string;
+	};
+};
+
+/** Hue / tint / shade for one color scheme’s tinted surfaces (light vs dark tracked separately). */
+export type TintedSliderSet = {
+	hueDeg: number;
+	tint0to100: number;
+	shadeTick: number;
+};
+
+/**
+ * Builds theme patch objects for light + dark surface keys from tinted snapshots and per-scheme sliders.
+ */
+export function computeTintedThemePatch(
+	snapshot: TintedSurfaceSnapshot,
+	lightSliders: TintedSliderSet,
+	darkSliders: TintedSliderSet
+): Record<string, string> {
+	const { light, dark } = snapshot;
+	const L = lightSliders;
+	const D = darkSliders;
+	return {
+		backgroundColor: applyHueTintShadeToSurface(
+			light.backgroundColor,
+			L.hueDeg,
+			L.tint0to100,
+			L.shadeTick
+		),
+		surface1Color: applyHueTintShadeToSurface(
+			light.surface1Color,
+			L.hueDeg,
+			L.tint0to100,
+			L.shadeTick
+		),
+		surface2Color: applyHueTintShadeToSurface(
+			light.surface2Color,
+			L.hueDeg,
+			L.tint0to100,
+			L.shadeTick
+		),
+		surface3Color: applyHueTintShadeToSurface(
+			light.surface3Color,
+			L.hueDeg,
+			L.tint0to100,
+			L.shadeTick
+		),
+		darkBackgroundColor: applyHueTintShadeToSurface(
+			dark.darkBackgroundColor,
+			D.hueDeg,
+			D.tint0to100,
+			D.shadeTick
+		),
+		darkSurface1Color: applyHueTintShadeToSurface(
+			dark.darkSurface1Color,
+			D.hueDeg,
+			D.tint0to100,
+			D.shadeTick
+		),
+		darkSurface2Color: applyHueTintShadeToSurface(
+			dark.darkSurface2Color,
+			D.hueDeg,
+			D.tint0to100,
+			D.shadeTick
+		),
+		darkSurface3Color: applyHueTintShadeToSurface(
+			dark.darkSurface3Color,
+			D.hueDeg,
+			D.tint0to100,
+			D.shadeTick
+		)
+	};
 }

--- a/ui/user/src/lib/components/Calendar.svelte
+++ b/ui/user/src/lib/components/Calendar.svelte
@@ -131,7 +131,7 @@
 			'w-8 h-8 flex items-center justify-center text-sm rounded-md transition-colors';
 
 		if (isDateDisabled(date, minDate, maxDate)) {
-			return twMerge(baseClasses, 'text-on-surface1 cursor-default');
+			return twMerge(baseClasses, 'text-muted-content cursor-default');
 		}
 
 		if (isStartDate(date) || isEndDate(date)) {
@@ -147,10 +147,10 @@
 		}
 
 		if (!isCurrentMonth(date, currentDate)) {
-			return twMerge(baseClasses, 'text-on-surface1');
+			return twMerge(baseClasses, 'text-muted-content');
 		}
 
-		return twMerge(baseClasses, 'hover:bg-surface3 cursor-pointer');
+		return twMerge(baseClasses, 'hover:bg-base-400 cursor-pointer');
 	}
 
 	const calendarPopover = popover({
@@ -185,11 +185,7 @@
 	{id}
 	{disabled}
 	type="button"
-	class={twMerge(
-		'dark:bg-surface1 text-md bg-background flex min-h-10 resize-none items-center justify-between rounded-lg px-4 py-2 text-left shadow-sm',
-		disabled && 'cursor-default opacity-50',
-		klass
-	)}
+	class={twMerge('btn btn-neutral h-12.5', disabled && 'cursor-default opacity-50', klass)}
 	use:popoverRef
 	onclick={() => !disabled && calendarPopover.toggle()}
 	{@attach (node: HTMLElement) => {
@@ -259,7 +255,7 @@
 						out:slide={{ duration: 100 }}
 					>
 						<div class="flex flex-col gap-1">
-							<div class="text-on-surface1 text-xs">{start.toDateString()}</div>
+							<div class="text-muted-content text-xs">{start.toDateString()}</div>
 							<TimeInput
 								format={timePreference.timeFormat}
 								clockAnchorPlacement="left"
@@ -274,7 +270,7 @@
 							<!-- In case start and end dates in the same day do not render the label -->
 							{#if !isSameDay(end ?? start, start)}
 								<div
-									class="text-on-surface1 text-xs"
+									class="text-muted-content text-xs"
 									in:slide={{ duration: 200 }}
 									out:slide={{ duration: 100 }}
 								>
@@ -295,8 +291,10 @@
 				{/if}
 
 				<div class="mt-4 flex justify-end gap-2">
-					<button type="button" class="button text-xs" onclick={handleCancel}>Cancel</button>
-					<button type="button" class="button-primary text-xs" onclick={handleApply}>Apply</button>
+					<button type="button" class="btn btn-sm btn-secondary" onclick={handleCancel}
+						>Cancel</button
+					>
+					<button type="button" class="btn btn-primary btn-sm" onclick={handleApply}>Apply</button>
 				</div>
 			</CalendarGrid>
 		</div>

--- a/ui/user/src/lib/components/CalendarGrid.svelte
+++ b/ui/user/src/lib/components/CalendarGrid.svelte
@@ -104,7 +104,7 @@
 <div class={twMerge('flex flex-col', klass)}>
 	<!-- Calendar Header -->
 	<div class="mb-4 flex items-center justify-between">
-		<button type="button" class="hover:bg-surface3 rounded p-1" onclick={previousMonth}>
+		<button type="button" class="hover:bg-base-400 rounded p-1" onclick={previousMonth}>
 			<ChevronLeft class="size-4" />
 		</button>
 
@@ -113,7 +113,7 @@
 			{currentDate.getFullYear()}
 		</h3>
 
-		<button type="button" class="hover:bg-surface3 rounded p-1" onclick={nextMonth}>
+		<button type="button" class="hover:bg-base-400 rounded p-1" onclick={nextMonth}>
 			<ChevronRight class="size-4" />
 		</button>
 	</div>
@@ -121,7 +121,7 @@
 	<!-- Weekday Headers -->
 	<div class="mb-2 grid grid-cols-7 gap-1">
 		{#each weekdays as day, i (i)}
-			<div class="text-on-surface1 flex h-8 w-8 items-center justify-center text-xs font-medium">
+			<div class="text-muted-content flex h-8 w-8 items-center justify-center text-xs font-medium">
 				{day}
 			</div>
 		{/each}

--- a/ui/user/src/lib/components/Confirm.svelte
+++ b/ui/user/src/lib/components/Confirm.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { CircleAlert, LoaderCircle, X } from 'lucide-svelte/icons';
+	import Loading from '$lib/icons/Loading.svelte';
+	import IconButton from './primitives/IconButton.svelte';
+	import { CircleAlert, X } from 'lucide-svelte/icons';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -58,9 +60,9 @@
 	<div class="dialog-container w-[calc(100dvw-2rem)] md:w-md">
 		<div class="dialog-title p-4 pb-0">
 			{title}
-			<button type="button" onclick={oncancel}>
+			<IconButton onclick={oncancel} class="btn-sm dialog-close-btn">
 				<X class="size-5" />
-			</button>
+			</IconButton>
 		</div>
 		<div class={twMerge('flex flex-col items-center justify-center gap-2 p-4 pt-0', classes?.body)}>
 			{#if msgContent}
@@ -69,14 +71,14 @@
 				<div
 					class={twMerge(
 						'rounded-full p-2',
-						type === 'delete' ? 'bg-red-500/10' : 'bg-primary/10',
+						type === 'delete' ? 'bg-error/10' : 'bg-primary/10',
 						classes?.iconContainer
 					)}
 				>
 					<CircleAlert
 						class={twMerge(
 							'size-8',
-							type === 'delete' ? 'text-red-500' : 'text-primary',
+							type === 'delete' ? 'text-error' : 'text-primary',
 							classes?.icon
 						)}
 					/>
@@ -103,14 +105,14 @@
 						onclick={onsuccess}
 						type="button"
 						class={twMerge(
-							'flex w-full justify-center p-3',
-							type === 'delete' ? 'button-destructive' : 'button-primary',
+							'flex flex-1 justify-center p-3 btn',
+							type === 'delete' ? 'btn-error' : 'btn-primary',
 							classes?.confirm
 						)}
 						disabled={loading || disabled}
 					>
 						{#if loading}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							{submitText}
 						{/if}
@@ -119,7 +121,7 @@
 				<button
 					onclick={oncancel}
 					type="button"
-					class="button w-full justify-center"
+					class="btn btn-secondary flex-1 flex justify-center"
 					disabled={loading}>{cancelText}</button
 				>
 			</div>

--- a/ui/user/src/lib/components/ConfirmDeleteAccount.svelte
+++ b/ui/user/src/lib/components/ConfirmDeleteAccount.svelte
@@ -36,11 +36,11 @@
 	disabled={username2 === '' || username2 !== username}
 >
 	{#snippet note()}
-		<p class="text-on-background mb-4 text-sm font-normal">
+		<p class="text-base-content mb-4 text-sm font-normal">
 			This will sign you out of all other devices and browsers, except for this one.
 		</p>
 
-		<p class="text-on-background mb-4 text-sm font-normal">
+		<p class="text-base-content mb-4 text-sm font-normal">
 			To confirm, type <strong>{username}</strong> in the box below
 		</p>
 

--- a/ui/user/src/lib/components/CopyButton.svelte
+++ b/ui/user/src/lib/components/CopyButton.svelte
@@ -89,18 +89,14 @@
 		onclick={() => copy()}
 		{disabled}
 		onmouseenter={() => (buttonTextToShow = buttonText)}
-		class={twMerge(
-			buttonText &&
-				'button-small border-primary text-primary hover:bg-primary disabled:text-primary flex items-center gap-1 rounded-full border bg-transparent px-4 py-2 hover:text-white disabled:bg-transparent disabled:opacity-50',
-			classes?.button
-		)}
+		class={twMerge(buttonText && 'btn btn-soft btn-primary', classes?.button)}
 		type="button"
 	>
 		{#if showTextLeft}
 			{buttonTextToShow}
-			<Copy class={twMerge('h-4 w-4', clazz)} />
+			<Copy class={twMerge('size-4', clazz)} />
 		{:else}
-			<Copy class={twMerge('h-4 w-4', clazz)} />
+			<Copy class={twMerge('size-4', clazz)} />
 			{buttonTextToShow}
 		{/if}
 	</button>

--- a/ui/user/src/lib/components/DatePicker.svelte
+++ b/ui/user/src/lib/components/DatePicker.svelte
@@ -83,7 +83,7 @@
 			'w-8 h-8 flex items-center justify-center text-sm rounded-md transition-colors';
 
 		if (isDateDisabled(date, minDate, maxDate)) {
-			return twMerge(baseClasses, 'text-on-surface1 cursor-default opacity-50');
+			return twMerge(baseClasses, 'text-muted-content cursor-default opacity-50');
 		}
 
 		if (isSelected(date)) {
@@ -95,10 +95,10 @@
 		}
 
 		if (!isCurrentMonth(date, currentDate)) {
-			return twMerge(baseClasses, 'text-on-surface1');
+			return twMerge(baseClasses, 'text-muted-content');
 		}
 
-		return twMerge(baseClasses, 'hover:bg-surface3 cursor-pointer');
+		return twMerge(baseClasses, 'hover:bg-base-400 cursor-pointer');
 	}
 </script>
 
@@ -116,8 +116,8 @@
 		style={`anchor-name: --${id}-anchor`}
 	>
 		<span class="flex grow items-center gap-2 truncate">
-			<Calendar class="text-on-surface1 size-4 flex-shrink-0" />
-			<span class={twMerge(!value && 'text-on-surface1')}>
+			<Calendar class="text-muted-content size-4 shrink-0" />
+			<span class={twMerge(!value && 'text-muted-content')}>
 				{value ? formatDate(value) : placeholder}
 			</span>
 		</span>
@@ -125,7 +125,7 @@
 			<span
 				role="button"
 				tabindex="0"
-				class="hover:bg-surface3 -mr-1 rounded p-1"
+				class="hover:bg-base-400 -mr-1 rounded p-1"
 				onclick={handleClear}
 				onkeydown={(e) => e.key === 'Enter' && handleClear(e as unknown as MouseEvent)}
 				{@attach (node: HTMLElement) => {
@@ -160,7 +160,7 @@
 					<div class="mt-4 flex justify-end">
 						<button
 							type="button"
-							class="button text-xs"
+							class="btn btn-secondary btn-sm"
 							onclick={() => {
 								value = null;
 								onChange(null);

--- a/ui/user/src/lib/components/DotDotDot.svelte
+++ b/ui/user/src/lib/components/DotDotDot.svelte
@@ -22,7 +22,7 @@
 
 	let {
 		children,
-		class: clazz = 'icon-button',
+		class: clazz,
 		classes,
 		placement = 'right-start',
 		icon,
@@ -39,7 +39,7 @@
 </script>
 
 <button
-	class={clazz}
+	class={twMerge('btn', !clazz?.includes('btn-block') && 'btn-ghost btn-square', clazz)}
 	use:ref
 	onclick={(e) => {
 		toggle();
@@ -51,7 +51,7 @@
 	{#if icon}
 		{@render icon()}
 	{:else}
-		<EllipsisVertical class="icon-default transition-colors duration-300" />
+		<EllipsisVertical class="size-5 transition-colors duration-300" />
 	{/if}
 </button>
 <div

--- a/ui/user/src/lib/components/Editors.svelte
+++ b/ui/user/src/lib/components/Editors.svelte
@@ -5,6 +5,7 @@
 	import { ChatService, EditorService, type InvokeInput, type Project } from '$lib/services';
 	import type { EditorItem } from '$lib/services/editor/index.svelte';
 	import { isTextFile } from '$lib/utils';
+	import IconButton from './primitives/IconButton.svelte';
 	import { Copy, Download, SquareChartGantt, SquareCode } from 'lucide-svelte';
 	import { X } from 'lucide-svelte/icons';
 
@@ -75,7 +76,7 @@
 			<div class="flex items-center gap-2">
 				{#if copyable}
 					<button
-						class="icon-button"
+						class="btn btn-square"
 						onclick={() => {
 							if (selected?.file?.contents) {
 								navigator.clipboard.writeText(selected.file.contents);
@@ -88,7 +89,7 @@
 				{/if}
 				{#if downloadable}
 					<button
-						class="icon-button"
+						class="btn btn-square"
 						onclick={() => {
 							if (selected) {
 								EditorService.download(layout.items, project, selected.name, {
@@ -104,7 +105,7 @@
 					</button>
 				{/if}
 				<button
-					class="icon-button"
+					class="btn btn-square btn-ghost"
 					onclick={() => {
 						layout.fileEditorOpen = false;
 					}}
@@ -122,22 +123,21 @@
 </div>
 
 {#snippet fileHeader(name?: string)}
-	<h4 class="text-on-surface1 flex items-center gap-1 px-2 text-base font-semibold">
+	<h4 class="text-muted-content flex items-center gap-1 px-2 text-base font-semibold">
 		{name}
 		{#if isMdFile}
-			<button
-				class="icon-button"
+			<IconButton
 				onclick={() => {
 					mdMode = mdMode === 'wysiwyg' ? 'raw' : 'wysiwyg';
 				}}
-				use:tooltip={mdMode === 'wysiwyg' ? 'Edit as raw markdown' : 'Use WYSIWYG editor'}
+				tooltip={{ text: mdMode === 'wysiwyg' ? 'Edit as raw markdown' : 'Use WYSIWYG editor' }}
 			>
 				{#if mdMode === 'wysiwyg'}
 					<SquareCode class="size-5" />
 				{:else}
 					<SquareChartGantt class="size-5" />
 				{/if}
-			</button>
+			</IconButton>
 		{/if}
 	</h4>
 {/snippet}

--- a/ui/user/src/lib/components/Error.svelte
+++ b/ui/user/src/lib/components/Error.svelte
@@ -12,10 +12,10 @@
 <!--error component-->
 <div in:fade class="flex items-center justify-center">
 	<div class="text-center">
-		<h3 class="text-on-background text-2xl font-semibold">Error</h3>
-		<p class="text-on-surface1">{error.message}</p>
+		<h3 class="text-base-content text-2xl font-semibold">Error</h3>
+		<p class="text-muted-content">{error.message}</p>
 		{#if onClick}
-			<button class="text-on-background mt-4 hover:underline" onclick={onClick}>Try again</button>
+			<button class="text-muted-content mt-4 hover:underline" onclick={onClick}>Try again</button>
 		{/if}
 	</div>
 </div>

--- a/ui/user/src/lib/components/JsonTreeView.svelte
+++ b/ui/user/src/lib/components/JsonTreeView.svelte
@@ -42,9 +42,9 @@
 				return 'text-[#6897bb] dark:text-[#d19a66] font-semibold'; // Boolean color
 			case 'null':
 			case 'undefined':
-				return 'text-on-surface1'; // Null/undefined color
+				return 'text-muted-content'; // Null/undefined color
 			default:
-				return 'text-on-background';
+				return 'text-base-content';
 		}
 	}
 

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -2,7 +2,6 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { columnResize } from '$lib/actions/resize';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Navbar from '$lib/components/Navbar.svelte';
 	import { ADMIN_AGENT_DISABLED_MESSAGE, USER_AGENT_DISABLED_MESSAGE } from '$lib/constants';
 	import {
@@ -21,6 +20,7 @@
 	import SetupSplashDialog from './admin/SetupSplashDialog.svelte';
 	import BetaLogo from './navbar/BetaLogo.svelte';
 	import Profile from './navbar/Profile.svelte';
+	import IconButton from './primitives/IconButton.svelte';
 	import { Render } from './ui/render';
 	import {
 		AlarmClock,
@@ -42,8 +42,6 @@
 		RadioTower,
 		Server,
 		Settings,
-		SidebarClose,
-		SidebarOpen,
 		SquareLibrary,
 		UserCog,
 		Users,
@@ -61,7 +59,9 @@
 		Notebook,
 		Laptop,
 		ScanLine,
-		MonitorCheck
+		MonitorCheck,
+		PanelRightClose,
+		PanelLeftOpen
 	} from 'lucide-svelte';
 	import { type Component, type Snippet, untrack } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
@@ -611,7 +611,7 @@
 		{:else if layout.sidebarOpen && !hideSidebar}
 			<div
 				class={twMerge(
-					'bg-background flex max-h-dvh w-full min-w-dvw shrink-0 flex-col md:w-1/6 md:max-w-xl md:min-w-[310px]',
+					'bg-base-100 dark:bg-base-200 flex max-h-dvh w-full min-w-dvw shrink-0 flex-col md:w-1/6 md:max-w-xl md:min-w-[310px]',
 					classes?.sidebarRoot
 				)}
 				transition:slide={{ axis: 'x' }}
@@ -641,7 +641,7 @@
 											href={resolve(link.href as `/${string}`)}
 											class={twMerge(
 												'sidebar-link',
-												link.href && link.href === pathname && 'bg-surface2'
+												link.href && link.href === pathname && 'bg-base-300'
 											)}
 										>
 											<link.icon class="size-5" />
@@ -663,9 +663,9 @@
 								{#if link.collapsible}
 									<button class="px-2" onclick={() => (collapsed[link.id] = !collapsed[link.id])}>
 										{#if collapsed[link.id]}
-											<ChevronUp class="size-5" />
-										{:else}
 											<ChevronDown class="size-5" />
+										{:else}
+											<ChevronUp class="size-5" />
 										{/if}
 									</button>
 								{/if}
@@ -681,7 +681,7 @@
 												<div class="relative flex items-center gap-2" id={item.id}>
 													<div
 														class={twMerge(
-															'bg-surface3 absolute top-1/2 left-0 h-full w-0.5 -translate-x-3 -translate-y-1/2',
+															'bg-base-400 absolute top-1/2 left-0 h-full w-0.5 -translate-x-3 -translate-y-1/2',
 															item.href === pathname && 'bg-primary'
 														)}
 													></div>
@@ -697,7 +697,7 @@
 															href={resolve(item.href as `/${string}`)}
 															class={twMerge(
 																'sidebar-link',
-																item.href === pathname && 'bg-surface2'
+																item.href === pathname && 'bg-base-300'
 															)}
 														>
 															<item.icon class="size-4" />
@@ -725,19 +725,18 @@
 				</div>
 
 				<div class="flex justify-end px-3 py-2">
-					<button
-						use:tooltip={'Close Sidebar'}
-						class="icon-button"
+					<IconButton
+						tooltip={{ text: 'Close Sidebar' }}
 						onclick={() => (layout.sidebarOpen = false)}
 					>
-						<SidebarClose class="size-6" />
-					</button>
+						<PanelRightClose class="size-6" />
+					</IconButton>
 				</div>
 			</div>
 			{#if !responsive.isMobile && !disableResize}
 				<div
 					role="none"
-					class="h-inherit border-r-surface2 dark:border-r-surface2 relative -ml-3 w-3 cursor-col-resize border-r"
+					class="h-inherit border-r-base-300 dark:border-r-base-300 relative -ml-3 w-3 cursor-col-resize border-r"
 					use:columnResize={{ column: nav }}
 				></div>
 			{/if}
@@ -746,7 +745,7 @@
 		<Render
 			class={twMerge(
 				'default-scrollbar-thin relative flex h-svh w-full min-w-0 grow flex-col overflow-y-auto',
-				whiteBackground ? 'bg-background' : 'bg-surface1 dark:bg-background'
+				whiteBackground ? 'bg-base-100' : 'bg-base-200 dark:bg-base-100'
 			)}
 			component={main?.component}
 			as="main"
@@ -756,7 +755,7 @@
 				{@render banner()}
 			{/if}
 			<Navbar
-				class={twMerge('dark:bg-background sticky top-0 left-0 z-50 w-full', classes?.navbar)}
+				class={twMerge('dark:bg-base-100 sticky top-0 left-0 z-50 w-full', classes?.navbar)}
 				{hideProfileButton}
 			>
 				{#snippet leftContent()}
@@ -787,7 +786,7 @@
 					{#if overrideRightMenu}
 						{@render overrideRightMenu()}
 					{:else if !hideProfileButton}
-						<div class="flex h-16 flex-shrink-0 items-center">
+						<div class="flex h-16 shrink-0 items-center">
 							<Profile />
 						</div>
 					{/if}
@@ -817,7 +816,7 @@
 							)}
 						>
 							{@render layoutHeaderContent()}
-							<div class="flex flex-shrink-0 items-center gap-2">
+							<div class="flex shrink-0 items-center gap-2">
 								{#if rightNavActions}
 									{@render rightNavActions()}
 								{/if}
@@ -840,13 +839,9 @@
 
 	{#if !layout.sidebarOpen && !hideSidebar && !leftSidebar}
 		<div class="absolute bottom-2 left-2 z-30" in:fade={{ delay: 300 }}>
-			<button
-				class="icon-button"
-				onclick={() => (layout.sidebarOpen = true)}
-				use:tooltip={'Open Sidebar'}
-			>
-				<SidebarOpen class="size-6" />
-			</button>
+			<IconButton onclick={() => (layout.sidebarOpen = true)} tooltip={{ text: 'Open Sidebar' }}>
+				<PanelLeftOpen class="size-6" />
+			</IconButton>
 		</div>
 	{/if}
 </div>
@@ -861,8 +856,8 @@
 
 {#snippet layoutHeaderContent()}
 	{#if showBackButton}
-		<button
-			class="icon-button flex-shrink-0"
+		<IconButton
+			class="btn btn-square btn-ghost shrink-0"
 			onclick={() => {
 				if (onBackButtonClick) {
 					onBackButtonClick();
@@ -872,7 +867,7 @@
 			}}
 		>
 			<ChevronLeft class="size-6" />
-		</button>
+		</IconButton>
 	{/if}
 	{#if title}
 		<h1
@@ -917,7 +912,7 @@
 		padding: 0.5rem;
 		transition: background-color 200ms;
 		&:hover {
-			background-color: var(--surface3);
+			background-color: var(--color-base-400);
 		}
 
 		&.disabled {

--- a/ui/user/src/lib/components/MarkdownInput.svelte
+++ b/ui/user/src/lib/components/MarkdownInput.svelte
@@ -185,7 +185,7 @@
 
 <div
 	class={twMerge(
-		'text-input-filled border-surface3 dark:bg-background flex flex-col gap-0 overflow-hidden border p-0 transition-colors',
+		'text-input-filled border-base-400 dark:bg-base-100 flex flex-col gap-0 overflow-hidden border p-0 transition-colors',
 		focused && !disabled && !disablePreview && 'ring-primary ring-2 outline-none',
 		disabled && 'disabled opacity-50',
 		klass
@@ -193,13 +193,13 @@
 >
 	{#if !disablePreview}
 		<div
-			class="dark:border-surface3 dark:bg-surface2 text-on-surface1 flex items-center border-b text-sm font-light"
+			class="dark:border-base-400 dark:bg-base-300 text-muted-content flex items-center border-b text-sm font-light"
 		>
 			<button
 				class={twMerge(
 					'px-4 py-2',
 					!showPreview &&
-						'dark:border-surface3 bg-background text-on-background relative z-10 translate-y-[1px] border-r font-medium'
+						'dark:border-base-400 bg-base-100 text-base-content relative z-10 translate-y-px border-r font-medium'
 				)}
 				onclick={() => {
 					showPreview = false;
@@ -215,7 +215,7 @@
 				class={twMerge(
 					'px-4 py-2',
 					showPreview &&
-						'dark:border-surface3 bg-background text-on-background relative z-10 translate-y-[1px] border-x font-medium'
+						'dark:border-base-400 bg-base-100 text-base-content relative z-10 translate-y-px border-x font-medium'
 				)}
 				onclick={() => (showPreview = true)}>Preview</button
 			>
@@ -223,14 +223,14 @@
 	{/if}
 	{#if !disablePreview && showPreview}
 		<div
-			class="milkdown-content default-scrollbar-thin bg-background max-h-[650px] min-h-48 overflow-y-auto p-4"
+			class="milkdown-content default-scrollbar-thin bg-base-100 max-h-[650px] min-h-48 overflow-y-auto p-4"
 		>
 			{@html toHTMLFromMarkdownWithNewTabLinks(value, true)}
 		</div>
 	{:else}
 		<div
 			class={twMerge(
-				'default-scrollbar-thin bg-background max-h-[650px] min-h-48 overflow-y-auto p-4 ',
+				'default-scrollbar-thin bg-base-100 max-h-[650px] min-h-48 overflow-y-auto p-4 ',
 				classes?.input
 			)}
 			use:cmEditor

--- a/ui/user/src/lib/components/MemoriesDialog.svelte
+++ b/ui/user/src/lib/components/MemoriesDialog.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { autoHeight } from '$lib/actions/textarea';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import {
 		type Project,
 		type Memory,
@@ -13,6 +12,7 @@
 	import Confirm from './Confirm.svelte';
 	import DotDotDot from './DotDotDot.svelte';
 	import ResponsiveDialog from './ResponsiveDialog.svelte';
+	import IconButton from './primitives/IconButton.svelte';
 	import Table from './table/Table.svelte';
 	import { Trash2, RefreshCcw, Edit, Check, X as XIcon, Pencil } from 'lucide-svelte/icons';
 	import { onMount, tick } from 'svelte';
@@ -180,15 +180,15 @@
 
 {#snippet content(preview = false)}
 	{#if error}
-		<div class="rounded bg-red-100 p-3 text-red-800">{error}</div>
+		<div class="rounded bg-error/10 p-3 text-error">{error}</div>
 	{/if}
 	{#if !preview}
 		<div class="flex items-center justify-between">
 			<span class="text-text2 text-sm">{memories.length} memories</span>
 			<div class="flex gap-2">
-				<button class="icon-button" onclick={() => loadMemories()} use:tooltip={'Refresh Memories'}>
+				<IconButton tooltip={{ text: 'Refresh Memories' }} onclick={() => loadMemories()}>
 					<RefreshCcw class="size-4" />
-				</button>
+				</IconButton>
 
 				{@render deleteAllButton(preview)}
 			</div>
@@ -203,7 +203,7 @@
 				></div>
 			</div>
 		{:else if memories.length === 0 && !preview}
-			<p in:fade class="text-on-surface1 pt-6 pb-3 text-center text-sm" class:text-xs={preview}>
+			<p in:fade class="text-muted-content pt-6 pb-3 text-center text-sm" class:text-xs={preview}>
 				No memories stored
 			</p>
 		{:else if !preview}
@@ -218,7 +218,7 @@
 					]}
 					data={memories}
 					classes={{
-						root: 'bg-surface1 dark:bg-background'
+						root: 'bg-base-200 dark:bg-base-100'
 					}}
 				>
 					{#snippet onRenderColumn(field, memory)}
@@ -237,7 +237,7 @@
 			<div class="flex w-full flex-col gap-4">
 				{#each memories as memory (memory.id)}
 					<div
-						class="text-md dark:bg-surface1 dark:border-surface3 bg-background flex items-center justify-between gap-4 rounded-md border border-transparent p-4 shadow-sm"
+						class="text-md dark:bg-base-200 dark:border-base-400 bg-base-100 flex items-center justify-between gap-4 rounded-md border border-transparent p-4 shadow-sm"
 					>
 						{#if editingMemoryId === memory.id}
 							<div class="flex w-full flex-col gap-4">
@@ -252,11 +252,11 @@
 										}
 									}}
 									bind:this={input}
-									class="default-scrollbar-thin text-on-background min-h-10 w-full border-none bg-transparent pr-0 ring-0 outline-hidden"
+									class="default-scrollbar-thin text-base-content min-h-10 w-full border-none bg-transparent pr-0 ring-0 outline-hidden"
 								></textarea>
 								<div class="flex justify-end gap-4">
-									<button class="button text-xs" onclick={cancelEdit}> Cancel </button>
-									<button class="button-primary text-xs" onclick={saveEdit}> Save </button>
+									<button class="btn btn-sm" onclick={cancelEdit}> Cancel </button>
+									<button class="btn btn-sm btn-primary" onclick={saveEdit}> Save </button>
 								</div>
 							</div>
 						{:else}
@@ -265,14 +265,11 @@
 							</p>
 						{/if}
 						{#if editingMemoryId !== memory.id}
-							<DotDotDot class="hover:text-on-background text-on-surface1  p-0">
+							<DotDotDot class="hover:text-muted-content text-muted-content  p-0">
 								<button class="menu-button" onclick={() => startEdit(memory, true)}>
 									<Pencil class="size-4" /> Edit
 								</button>
-								<button
-									class="menu-button text-red-500"
-									onclick={() => (deleteMemoryId = memory.id)}
-								>
+								<button class="menu-button text-error" onclick={() => (deleteMemoryId = memory.id)}>
 									<Trash2 class="size-4" /> Delete
 								</button>
 							</DotDotDot>
@@ -288,7 +285,7 @@
 	{#if editingMemoryId === memory.id && preview === editingPreview}
 		<textarea
 			bind:value={editContent}
-			class="text-input-filled border-surface1 bg-background min-h-[80px] w-full resize-none border"
+			class="text-input-filled border-base-400 bg-base-100 min-h-[80px] w-full resize-none border"
 			rows="3"
 		></textarea>
 	{:else}
@@ -300,43 +297,43 @@
 
 {#snippet options(memory: Memory, inline: boolean)}
 	{#if editingMemoryId === memory.id && inline === editingPreview}
-		<button
-			class={twMerge('icon-button text-green-500', inline && 'min-h-auto min-w-auto p-1.5')}
+		<IconButton
+			class={twMerge('text-success', inline && 'min-h-auto min-w-auto p-1.5')}
 			onclick={saveEdit}
-			use:tooltip={'Save changes'}
+			tooltip={{ text: 'Save changes' }}
 		>
 			<Check class="size-4" />
-		</button>
-		<button
-			class={twMerge('icon-button text-red-500', inline && 'min-h-auto min-w-auto p-1.5')}
+		</IconButton>
+		<IconButton
+			class={twMerge('text-error', inline && 'min-h-auto min-w-auto p-1.5')}
 			onclick={cancelEdit}
-			use:tooltip={'Cancel'}
+			tooltip={{ text: 'Cancel' }}
 		>
 			<XIcon class="size-4" />
-		</button>
+		</IconButton>
 	{:else}
-		<button
-			class={twMerge('icon-button', inline && 'min-h-auto min-w-auto p-1.5')}
+		<IconButton
+			class={twMerge(inline && 'min-h-auto min-w-auto p-1.5')}
 			onclick={() => startEdit(memory, inline)}
 			disabled={loading}
-			use:tooltip={'Edit memory'}
+			tooltip={{ text: 'Edit memory' }}
 		>
 			<Edit class="size-4" />
-		</button>
-		<button
-			class={twMerge('icon-button', inline && 'min-h-auto min-w-auto p-1.5')}
+		</IconButton>
+		<IconButton
+			class={twMerge(inline && 'min-h-auto min-w-auto p-1.5')}
 			onclick={() => (deleteMemoryId = memory.id)}
 			disabled={loading}
-			use:tooltip={'Delete memory'}
+			tooltip={{ text: 'Delete memory' }}
 		>
 			<Trash2 class="size-4" />
-		</button>
+		</IconButton>
 	{/if}
 {/snippet}
 
 {#snippet deleteAllButton(inline?: boolean)}
 	<button
-		class={twMerge('button-destructive', inline && 'py-2 text-xs')}
+		class={twMerge('btn btn-error btn-sm', inline && 'py-2')}
 		onclick={() => (toDeleteAll = true)}
 		disabled={loading || memories.length === 0}
 	>
@@ -378,12 +375,12 @@
 
 	:global(.dark) .memory {
 		color: white;
-		background-color: var(--color-surface2);
+		background-color: var(--color-base-300);
 	}
 
 	:global(.dark) .memory::before,
 	:global(.dark) .memory::after {
-		background-color: var(--color-surface2);
+		background-color: var(--color-base-300);
 	}
 
 	.memory::before {

--- a/ui/user/src/lib/components/ModelProviderCard.svelte
+++ b/ui/user/src/lib/components/ModelProviderCard.svelte
@@ -366,7 +366,7 @@
 </script>
 
 <div
-	class="model-provider-card border-surface2 flex max-h-[600px] min-h-fit w-full flex-col rounded-md border py-4 shadow-sm 2xl:mb-4 2xl:min-h-[514px] 2xl:last:mb-0"
+	class="model-provider-card border-base-300 flex max-h-[600px] min-h-fit w-full flex-col rounded-md border py-4 shadow-sm 2xl:mb-4 2xl:min-h-[514px] 2xl:last:mb-0"
 	data-provider-id={provider.id}
 >
 	<div class="flex flex-col px-4">
@@ -402,14 +402,14 @@
 			<!-- Models Selection Section -->
 			<div
 				class={twMerge(
-					'bg-surface1/0 flex flex-1 flex-col gap-2 rounded-md',
+					'bg-base-200 flex flex-1 flex-col gap-2 rounded-md',
 					isProviderConfigurationShown && 'pointer-events-none opacity-50'
 				)}
 				in:fade={{ duration: 200 }}
 				out:fade={{ duration: 0 }}
 			>
 				<div
-					class="model-provider-search-input bg-surface1 dark:bg-surface2 relative flex h-10 w-full items-center gap-2 rounded-md text-sm"
+					class="model-provider-search-input bg-base-200 dark:bg-base-300 relative flex h-10 w-full items-center gap-2 rounded-md text-sm"
 				>
 					<div class="absolute inset-x-0 left-2 aspect-square h-5 opacity-50">
 						<Search class="h-full" />
@@ -431,11 +431,11 @@
 					{/if}
 				</div>
 
-				<div class="border-surface1 flex flex-1 flex-col gap-2 rounded-md border">
+				<div class="border-base-300 flex flex-1 flex-col gap-2 rounded-md border">
 					<div class="flex items-center gap-2 px-4 py-2 text-sm font-medium">
 						<h5 class="flex items-center">
 							<input
-								class="bg-surface3 mr-2 h-4 w-4"
+								class="bg-base-400 mr-2 h-4 w-4"
 								type="checkbox"
 								id={`model-${provider.id}-toggle-all`}
 								bind:checked={
@@ -474,9 +474,9 @@
 							class="default-scrollbar-thin scrollbar-track-rounded-full absolute inset-0 flex h-full max-h-full flex-col overflow-y-auto px-2"
 						>
 							{#each filteredModels as model (model)}
-								<div class="hover:bg-surface1 bored flex items-center rounded px-2 py-2">
+								<div class="hover:bg-base-400 bored flex items-center rounded px-2 py-2">
 									<input
-										class="bg-surface3 mr-2 h-4 w-4"
+										class="bg-base-400 mr-2 h-4 w-4"
 										type="checkbox"
 										id={`model-${provider.id}-${model}`}
 										bind:checked={
@@ -494,7 +494,7 @@
 								</div>
 							{:else}
 								<div
-									class="w-full h-full flex items-center justify-center text-on-surface1 text-lg font-semibold rounded-lg absolute inset-0 p-8"
+									class="w-full h-full flex items-center justify-center text-muted-content text-lg font-semibold rounded-lg absolute inset-0 p-8"
 									transition:fade={{ duration: 100 }}
 								>
 									{#if isModelsLoading}
@@ -511,11 +511,11 @@
 		{:else}
 			<!-- TODO: this is an example placeholder, feel free to change if you have a better one -->
 			<div
-				class="bg-surface1 flex flex-1 flex-col items-center justify-center rounded-lg p-8"
+				class="bg-base-200 flex flex-1 flex-col items-center justify-center rounded-lg p-8"
 				in:fade={{ duration: 200 }}
 				out:fade={{ duration: 0 }}
 			>
-				<div class="text-on-surface1 mb-2 text-lg font-semibold">
+				<div class="text-muted-content mb-2 text-lg font-semibold">
 					Provider is not yet configured
 				</div>
 				<p class="text-center text-xs opacity-50">
@@ -531,7 +531,7 @@
 					<div class="flex items-center font-medium">
 						<span>Configurations</span>
 					</div>
-					<div class="border-surface2 flex-1 border-b"></div>
+					<div class="border-base-300 flex-1 border-b"></div>
 				</div>
 
 				<div class="flex flex-col gap-4">
@@ -558,7 +558,7 @@
 		{/if}
 	</div>
 
-	<div class="border-surface2 flex min-h-14 w-full justify-between gap-4 border-t px-4 pt-4">
+	<div class="border-base-300 flex min-h-14 w-full justify-between gap-4 border-t px-4 pt-4">
 		{#if isProviderConfigurationShown}
 			{@const isDirty =
 				JSON.stringify($state.snapshot(configuration)) !==
@@ -570,7 +570,7 @@
 						in:fade={{ duration: 100 }}
 						out:fade={{ duration: 0 }}
 						type="button"
-						class="button hover:bg-surface1 rounded-full px-4 py-2 text-sm transition-colors duration-100"
+						class="btn btn-secondary"
 						onclick={() => {
 							configuration = $state.snapshot(oldConfiguration);
 						}}
@@ -582,9 +582,7 @@
 						in:fade={{ duration: 100 }}
 						out:fade={{ duration: 0 }}
 						type="button"
-						class={twMerge(
-							'button hover:bg-surface1 rounded-full px-4 py-2 text-sm transition-colors duration-100'
-						)}
+						class="btn btn-secondary"
 						onclick={() => {
 							// Close configuration UI
 							isProviderConfigurationShown = false;
@@ -599,7 +597,7 @@
 						in:fade={{ duration: 100 }}
 						out:fade={{ duration: 0 }}
 						type="button"
-						class="button bg-primary/10 text-primary hover:bg-primary/15 active:bg-primary/20 rounded-full border-none px-4 py-2 text-sm transition-colors duration-100"
+						class="btn btn-primary"
 						disabled={!isDirty}
 						onclick={(ev) => saveHandler(ev)}
 					>
@@ -611,17 +609,14 @@
 
 		<div class="ml-auto flex gap-2">
 			{#if !isProviderConfigurationShown}
-				<button
-					class="button hover:bg-surface3/80 active:bg-surface3/100 bg-transparent text-sm font-medium"
-					onclick={onConfigureProviderClickHandler}
-				>
+				<button class="btn btn-secondary" onclick={onConfigureProviderClickHandler}>
 					{provider.configured ? 'Reconfigure' : 'Configure'}
 				</button>
 			{/if}
 
 			{#if provider.configured}
 				<button
-					class="button bg-red-500/5 text-sm font-medium text-red-500 transition-colors duration-100 hover:bg-red-500/10 active:bg-red-500/15"
+					class="btn btn-error"
 					onclick={() => {
 						isUnconfigureProviderDialogShown = true;
 					}}

--- a/ui/user/src/lib/components/ModelProviders.svelte
+++ b/ui/user/src/lib/components/ModelProviders.svelte
@@ -159,7 +159,7 @@
 	</div>
 
 	{#if error}
-		<div class="mb-4 text-red-500">{error}</div>
+		<div class="mb-4 text-error">{error}</div>
 		<button
 			class="bg-secondary text-secondary-foreground rounded-md px-4 py-2 text-sm font-medium"
 			onclick={loadModelProviders}
@@ -183,14 +183,14 @@
 			<!-- TODO: Use a 3rd-party UI library or create an internal custom component in the future -->
 			<div class="relative">
 				<select
-					class="border-surface2 dark:bg-surface1 w-full appearance-none rounded-md border px-4 py-4 text-sm"
+					class="border-base-300 dark:bg-base-200 w-full appearance-none rounded-md border px-4 py-4 text-sm"
 					value={defaultModelProvider && defaultModel
 						? `${defaultModel}|||${defaultModelProvider}`
 						: ''}
 					onchange={(e) => updateDefaultModel(e.currentTarget.value)}
 					onclick={() => (isDefaultModelSelectOpen = !isDefaultModelSelectOpen)}
 				>
-					<option class="dark:bg-surface3" value="" disabled
+					<option class="dark:bg-base-400" value="" disabled
 						>Select the default model for this project</option
 					>
 					{#if hasOneModelSelected}
@@ -200,7 +200,7 @@
 									{@const provider = modelProviders.find((p) => p.id === providerId)}
 
 									{#if provider}
-										<option class="dark:bg-surface3" value={`${model}|||${providerId}`}>
+										<option class="dark:bg-base-400" value={`${model}|||${providerId}`}>
 											{model} ({provider.name})
 										</option>
 									{/if}

--- a/ui/user/src/lib/components/Navbar.svelte
+++ b/ui/user/src/lib/components/Navbar.svelte
@@ -28,7 +28,7 @@
 	}: Props = $props();
 </script>
 
-<nav class={twMerge('bg-background flex h-16 w-full items-center px-3', klass)} in:fade|global>
+<nav class={twMerge('bg-base-100 flex h-16 w-full items-center px-3', klass)} in:fade|global>
 	<div class="flex w-full items-center justify-between">
 		{#if leftContent}
 			{@render leftContent()}
@@ -45,11 +45,11 @@
 				{@render rightContent()}
 			{/if}
 			{#if rightMenu}
-				<div class="flex h-16 flex-shrink-0 items-center">
+				<div class="flex h-16 shrink-0 items-center">
 					{@render rightMenu()}
 				</div>
 			{:else if !unauthorized && !hideProfileButton}
-				<div class="flex h-16 flex-shrink-0 items-center">
+				<div class="flex h-16 shrink-0 items-center">
 					<Profile />
 				</div>
 			{/if}

--- a/ui/user/src/lib/components/Notifications.svelte
+++ b/ui/user/src/lib/components/Notifications.svelte
@@ -49,7 +49,7 @@
 				</div>
 			</button>
 			{#if copied[error.message]}
-				<div class="text-on-surface1 self-end text-xs" in:fade={{ duration: 200 }}>
+				<div class="text-muted-content self-end text-xs" in:fade={{ duration: 200 }}>
 					Error copied to clipboard.
 				</div>
 			{/if}

--- a/ui/user/src/lib/components/Obot.svelte
+++ b/ui/user/src/lib/components/Obot.svelte
@@ -20,7 +20,8 @@
 	import McpServerRequirements from './chat/McpServerRequirements.svelte';
 	import McpServerActions from './mcp/McpServerActions.svelte';
 	import BetaLogo from './navbar/BetaLogo.svelte';
-	import { ChevronLeft, GripVertical, SidebarOpen } from 'lucide-svelte';
+	import IconButton from './primitives/IconButton.svelte';
+	import { ChevronLeft, GripVertical, PanelLeftOpen } from 'lucide-svelte';
 	import { X } from 'lucide-svelte';
 	import { onMount, onDestroy } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
@@ -95,7 +96,7 @@
 	<div class="relative flex h-full">
 		{#if layout.sidebarOpen && !layout.fileEditorOpen}
 			<div
-				class="bg-surface1 w-screen min-w-screen flex-shrink-0 md:w-1/6 md:min-w-[250px]"
+				class="bg-base-200 w-screen min-w-screen shrink-0 md:w-1/6 md:min-w-[250px]"
 				transition:slide={{ axis: 'x' }}
 				bind:this={nav}
 			>
@@ -203,9 +204,9 @@
 				<div class="dialog-container p-4">
 					<div class="dialog-title">
 						<h3 class="text-lg font-semibold">Keyboard Shortcuts</h3>
-						<button class="dialog-close-btn" onclick={() => shortcutsDialog?.close()}>
-							<X class="icon-default" />
-						</button>
+						<IconButton class="btn-sm dialog-close-btn" onclick={() => shortcutsDialog?.close()}>
+							<X class="size-5" />
+						</IconButton>
 					</div>
 					<div class="space-y-4">
 						<div class="grid grid-cols-2 gap-2">
@@ -232,15 +233,15 @@
 				class="relative h-full w-8 cursor-grab"
 				transition:slide={{ axis: 'x' }}
 			>
-				<div class="text-on-surface1 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-					<GripVertical class="text-surface3 size-3" />
+				<div class="text-muted-content absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+					<GripVertical class="text-base-400 size-3" />
 				</div>
 			</div>
 		{/if}
 		<div
 			bind:this={editor}
 			class={twMerge(
-				'border-surface2 bg-surface1 absolute right-0 z-30 float-right flex w-full flex-shrink-0 translate-x-full transform border border-r-0 transition-transform duration-300 md:w-3/5 md:max-w-[calc(100%-320px)] md:min-w-[320px]',
+				'border-base-300 bg-base-200 absolute right-0 z-30 float-right flex w-full shrink-0 translate-x-full transform border border-r-0 transition-transform duration-300 md:w-3/5 md:max-w-[calc(100%-320px)] md:min-w-[320px]',
 				layout.fileEditorOpen && 'relative w-full translate-x-0',
 				!layout.fileEditorOpen && 'w-0'
 			)}
@@ -253,20 +254,20 @@
 <McpServerRequirements assistantId={assistant?.id || ''} projectId={project.id} />
 
 {#snippet openSidebar()}
-	<button class="icon-button" onclick={() => (layout.sidebarOpen = true)}>
-		<SidebarOpen class="size-6" />
-	</button>
+	<IconButton onclick={() => (layout.sidebarOpen = true)}>
+		<PanelLeftOpen class="size-6" />
+	</IconButton>
 {/snippet}
 
 {#snippet projectMcpHeader(mcpServer: ProjectMCP)}
-	<button
-		class="icon-button mr-2 flex-shrink-0"
+	<IconButton
+		class="mr-2"
 		onclick={() => {
 			closeSidebarConfig(layout);
 		}}
 	>
 		<ChevronLeft class="size-6" />
-	</button>
+	</IconButton>
 	<h1 class="text-xl font-semibold">
 		{mcpServer.alias || mcpServer.name || 'MCP Server'}
 	</h1>

--- a/ui/user/src/lib/components/PageLoading.svelte
+++ b/ui/user/src/lib/components/PageLoading.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { AlertCircle, LoaderCircle, X } from 'lucide-svelte';
+	import Loading from '$lib/icons/Loading.svelte';
+	import IconButton from './primitives/IconButton.svelte';
+	import { CircleAlert, X } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { onDestroy } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -84,13 +86,13 @@
 		{#if error}
 			<div
 				class={twMerge(
-					'dark:bg-surface2 dark:border-surface3 bg-background relative flex w-full flex-col items-center gap-4 rounded-lg p-4 dark:border',
+					'dark:bg-base-300 dark:border-base-400 bg-base-100 relative flex w-full flex-col items-center gap-4 rounded-lg p-4 dark:border',
 					errorClasses?.root
 				)}
 			>
-				<button class="icon-button absolute top-2 right-2 self-end" onclick={() => onClose?.()}
-					><X class="size-5" /></button
-				>
+				<IconButton class="absolute top-2 right-2 self-end" onclick={() => onClose?.()}>
+					<X class="size-5" />
+				</IconButton>
 
 				{#if errorPreContent}
 					{@render errorPreContent()}
@@ -99,7 +101,7 @@
 				{/if}
 
 				<div class="notification-error flex w-full items-center gap-2">
-					<AlertCircle class="size-6 text-red-500" />
+					<CircleAlert class="size-6 text-error" />
 					<p class="flex flex-col text-sm font-light">
 						<span class="font-semibold">Error Details:</span>
 						<span class="break-all">
@@ -120,7 +122,7 @@
 					{Math.round(displayedProgress ?? 0)}%
 				</div>
 
-				<div class="bg-surface3 h-3 w-full overflow-hidden rounded-full">
+				<div class="bg-base-400 h-3 w-full overflow-hidden rounded-full">
 					<div
 						class={twMerge('bg-primary h-full rounded-full transition-all duration-500 ease-out')}
 						style="width: {progress ?? 0}%"
@@ -139,14 +141,14 @@
 			</div>
 		{:else}
 			<div
-				class="dark:bg-surface2 dark:border-surface3 bg-background flex flex-col items-center rounded-xl px-4 py-2 shadow-sm dark:border"
+				class="dark:bg-base-300 dark:border-base-400 bg-base-100 flex flex-col items-center rounded-xl px-4 py-2 shadow-sm dark:border"
 			>
 				<div class="flex items-center gap-2">
-					<LoaderCircle class="size-8 animate-spin " />
+					<Loading class="size-8" />
 					<p class="text-xl font-semibold">{text ?? 'Loading...'}</p>
 				</div>
 				{#if isLongLoad && longLoadMessage}
-					<p in:fade class="text-md text-on-surface1 mt-4 font-light">
+					<p in:fade class="text-md text-muted-content mt-4 font-light">
 						{longLoadMessage}
 					</p>
 				{/if}

--- a/ui/user/src/lib/components/ReLoginDialog.svelte
+++ b/ui/user/src/lib/components/ReLoginDialog.svelte
@@ -19,7 +19,7 @@
 		<div class="flex flex-col items-center gap-4">
 			<h2 class="text-xl font-semibold">Session Expired</h2>
 			<p class="text-center">Your session has expired. Please log in again to continue.</p>
-			<button onclick={handleLogin} class="button-primary w-full"> Log In </button>
+			<button onclick={handleLogin} class="btn btn-primary w-full"> Log In </button>
 		</div>
 	</div>
 </dialog>

--- a/ui/user/src/lib/components/ResponsiveDialog.svelte
+++ b/ui/user/src/lib/components/ResponsiveDialog.svelte
@@ -6,6 +6,7 @@
 	 */
 	import { dialogAnimation } from '$lib/actions/dialogAnimation';
 	import { responsive } from '$lib/stores';
+	import IconButton from './primitives/IconButton.svelte';
 	import { ChevronRight, X } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -90,9 +91,9 @@
 							{/if}
 						</span>
 						{#if !hideClose}
-							<button
+							<IconButton
 								class={twMerge(
-									'icon-button dialog-close-btn',
+									'btn-sm dialog-close-btn',
 									responsive.isMobile && 'mobile',
 									classes?.closeBtn
 								)}
@@ -106,7 +107,7 @@
 								{:else}
 									<X class="size-5" />
 								{/if}
-							</button>
+							</IconButton>
 						{/if}
 					</h3>
 				</div>

--- a/ui/user/src/lib/components/Search.svelte
+++ b/ui/user/src/lib/components/Search.svelte
@@ -52,7 +52,7 @@
 		type="text"
 		{placeholder}
 		class={twMerge(
-			'bg-surface1 peer hover:ring-primary focus:ring-primary w-full rounded-lg px-2.5 py-3 pl-12 ring-2 ring-transparent transition-all duration-200 hover:ring-2 focus:w-full focus:ring-2 focus:outline-hidden',
+			'bg-base-200 peer hover:ring-primary focus:ring-primary w-full rounded-sm px-2.5 py-3 pl-12 ring-2 ring-transparent transition-all duration-200 hover:ring-2 focus:w-full focus:ring-2 focus:outline-hidden',
 			compact && 'py-2 pl-8',
 			klass
 		)}

--- a/ui/user/src/lib/components/Select.svelte
+++ b/ui/user/src/lib/components/Select.svelte
@@ -146,6 +146,9 @@
 			});
 		}
 	}
+
+	const clearBtnClasses =
+		'btn btn-square border-transparent size-4 text-muted-content hover:text-base-content';
 </script>
 
 <div class={twMerge(classes?.root, (readonly || disabled) && 'pointer-events-none')}>
@@ -157,7 +160,7 @@
 			aria-expanded={popover?.matches(':popover-open') ?? false}
 			aria-controls={`${id}-popover`}
 			class={twMerge(
-				'dark:bg-surface1 text-md bg-background flex min-h-10 w-full grow cursor-pointer resize-none items-center gap-2 rounded-lg px-2 py-2 text-left shadow-sm',
+				'dark:bg-base-200 text-md bg-base-100 flex min-h-10 w-full grow cursor-pointer resize-none items-center gap-2 rounded-lg px-2 py-2 text-left shadow-sm',
 				disabled && 'pointer-events-none cursor-default opacity-50',
 				multiple && 'flex-wrap',
 				klass
@@ -199,7 +202,7 @@
 						{#each selectedOptions as selectedOption (selectedOption.id)}
 							<div
 								class={twMerge(
-									'text-md bg-surface3/50 dark:bg-surface2 inline-flex items-center gap-1 rounded-sm px-1',
+									'text-md bg-base-400/50 dark:bg-base-300 inline-flex items-center gap-1 rounded-sm px-1',
 									onClear && '',
 									classes?.buttonContent
 								)}
@@ -217,10 +220,7 @@
 
 								<div class="flex h-[22.5px] items-center place-self-start">
 									<button
-										class={twMerge(
-											'button rounded-xs p-0 transition-colors duration-300',
-											classes?.clear
-										)}
+										class={twMerge(clearBtnClasses, classes?.clear)}
 										{disabled}
 										onclick={(ev) => {
 											ev.preventDefault();
@@ -233,7 +233,7 @@
 											onClear?.(selectedOption, selected);
 										}}
 									>
-										<X class="size-4" />
+										<X class="size-3" />
 									</button>
 								</div>
 							</div>
@@ -266,7 +266,8 @@
 		{#if onClear && !multiple}
 			<button
 				class={twMerge(
-					'button absolute top-1/2 right-12 -translate-y-1/2 p-1 transition-colors duration-300',
+					clearBtnClasses,
+					'absolute top-1/2 right-12 -translate-y-1/2',
 					classes?.clear
 				)}
 				onclick={() => {
@@ -290,7 +291,7 @@
 	>
 		{#if searchInDropdown}
 			<div
-				class="border-surface3 flex h-12 items-center border-b p-2"
+				class="border-base-400 flex h-12 items-center border-b p-2"
 				role="presentation"
 				onclick={() => input?.focus()}
 			>
@@ -299,7 +300,7 @@
 			</div>
 		{/if}
 		{#if availableOptions.length === 0}
-			<div class="text-on-surface1 px-4 py-2 font-light">No options available</div>
+			<div class="text-muted-content px-4 py-2 font-light">No options available</div>
 		{:else}
 			{#each availableOptions as option, index (option.id)}
 				{@const isSelected = selectedValues.some((d) => d === option.id)}
@@ -307,10 +308,10 @@
 
 				<button
 					class={twMerge(
-						'dark:hover:bg-surface3/50 hover:bg-surface2/50 text-md flex w-full items-center px-4 py-2 text-left break-all transition-colors duration-100',
+						'dark:hover:bg-base-400/50 hover:bg-base-300/50 text-md flex w-full items-center px-4 py-2 text-left break-all transition-colors duration-100',
 						isSelected &&
-							'dark:bg-surface3/90 dark:hover:bg-surface3/50 bg-surface2/90 hover:bg-surface3/50',
-						isHighlighted && 'dark:bg-surface3 bg-surface3',
+							'dark:bg-base-400/90 dark:hover:bg-base-400/50 bg-base-300/90 hover:bg-base-400/50',
+						isHighlighted && 'dark:bg-base-400 bg-base-400',
 						classes?.option
 					)}
 					type="button"
@@ -335,7 +336,7 @@
 {#snippet clearAllButton()}
 	<button
 		class={twMerge(
-			'bg-surface3/50 dark:bg-surface2 hover:bg-surface3 dark:hover:bg-surface3 inline-flex rounded-sm px-1 text-xs transition-colors duration-300',
+			'bg-base-400/50 dark:bg-base-300 hover:bg-base-400 dark:hover:bg-base-400 inline-flex rounded-sm px-1 text-xs transition-colors duration-300',
 			classes?.buttonContent
 		)}
 		onclick={(ev) => {

--- a/ui/user/src/lib/components/SensitiveInput.svelte
+++ b/ui/user/src/lib/components/SensitiveInput.svelte
@@ -111,7 +111,7 @@
 				bind:this={maskedTextarea}
 				tabindex="-1"
 				class={twMerge(
-					'layer-1 black:text-white w-full bg-transparent font-mono break-words whitespace-pre-wrap text-black',
+					'layer-1 black:text-white w-full bg-transparent font-mono wrap-break-word whitespace-pre-wrap text-black',
 					klass
 				)}
 			>
@@ -125,7 +125,7 @@
 				bind:this={maskedTextarea}
 				tabindex="-1"
 				class={twMerge(
-					'layer-1 black:text-white w-full bg-transparent font-mono break-words whitespace-pre-wrap text-black',
+					'layer-1 black:text-white w-full bg-transparent font-mono wrap-break-word whitespace-pre-wrap text-black',
 					klass
 				)}
 			>
@@ -146,7 +146,7 @@
 						'text-input-filled base flex w-full flex-1 flex-col overflow-x-hidden overflow-y-auto font-mono',
 						klass,
 						classes?.wrapper,
-						error && 'border-red-500 bg-red-500/20 text-red-500 ring-red-500 focus:ring-1',
+						error && 'border-error bg-error/20 text-error ring-error focus:ring-1',
 						disabled && 'opacity-50',
 						!showSensitive ? 'hide' : ''
 					)}
@@ -202,7 +202,7 @@
 						aria-label="Resize"
 					>
 						<svg
-							class="h-full w-full text-gray-500 hover:text-gray-700"
+							class="h-full w-full text-muted-content hover:text-base-content"
 							viewBox="0 0 12 12"
 							fill="none"
 							stroke="currentColor"
@@ -220,7 +220,7 @@
 						'text-input-filled base flex min-h-full w-full flex-1 flex-col overflow-hidden rounded font-mono [box-shadow:none]',
 						klass,
 						classes?.wrapper,
-						error && 'border-red-500 bg-red-500/20 text-red-500 ring-red-500 focus:ring-1',
+						error && 'border-error bg-error/20 text-error ring-error focus:ring-1',
 						!showSensitive ? 'hide' : ''
 					)}
 				>
@@ -266,8 +266,7 @@
 				'text-input-filled w-full pr-10',
 				klass,
 				classes?.input,
-				error &&
-					'border-red-500 bg-red-500/20 [color:var(--color-red-500)] ring-red-500 focus:ring-1'
+				error && 'border-error bg-error/20 text-error ring-error focus:ring-1'
 			)}
 			{value}
 			type={showSensitive ? 'text' : 'password'}
@@ -289,7 +288,7 @@
 			<button
 				type="button"
 				class="cursor-pointer transition-colors duration-150"
-				class:text-red-500={error}
+				class:text-error={error}
 				onclick={toggleVisibility}
 			>
 				{#if showSensitive}
@@ -306,7 +305,7 @@
 	.text-input-filled.base.hide textarea,
 	.text-input-filled.base.hide [contenteditable] {
 		color: transparent;
-		caret-color: var(--color-on-background);
+		caret-color: var(--color-base-content);
 	}
 	.text-input-filled.base.hide::selection {
 		background: highlight;

--- a/ui/user/src/lib/components/SpectrumSlider.svelte
+++ b/ui/user/src/lib/components/SpectrumSlider.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import { twMerge } from 'tailwind-merge';
+
+	interface Props {
+		/** Hue in degrees along the visible spectrum (0–360). */
+		hue?: number;
+		id?: string;
+		disabled?: boolean;
+		/** Accessible name when no visible label is tied via `for`. */
+		'aria-label'?: string;
+		class?: string;
+	}
+
+	let {
+		hue = $bindable(0),
+		id,
+		disabled = false,
+		'aria-label': ariaLabel = 'Spectrum color',
+		class: className
+	}: Props = $props();
+</script>
+
+<div class={twMerge('spectrum-slider relative flex w-full min-w-48 items-center py-1', className)}>
+	<!-- Track: continuous hue gradient (ROYGBIV via HSL hues) -->
+	<div
+		class="pointer-events-none absolute inset-x-0 top-1/2 h-2 -translate-y-1/2 rounded-full border border-black/10 shadow-[inset_0_1px_2px_rgba(0,0,0,0.06)] dark:border-white/15 dark:shadow-[inset_0_1px_2px_rgba(0,0,0,0.25)]"
+		style="background: linear-gradient(
+			to right,
+			hsl(0, 100%, 50%),
+			hsl(60, 100%, 50%),
+			hsl(120, 100%, 50%),
+			hsl(180, 100%, 50%),
+			hsl(240, 100%, 50%),
+			hsl(300, 100%, 50%),
+			hsl(360, 100%, 50%)
+		);"
+		aria-hidden="true"
+	></div>
+
+	<input
+		{id}
+		type="range"
+		class="spectrum-slider-input relative z-10 h-8 w-full cursor-pointer bg-transparent disabled:cursor-not-allowed disabled:opacity-40"
+		min="0"
+		max="360"
+		step="1"
+		bind:value={hue}
+		{disabled}
+		aria-label={ariaLabel}
+		aria-valuemin={0}
+		aria-valuemax={360}
+		aria-valuenow={hue}
+	/>
+</div>
+
+<style lang="postcss">
+	/* Thumb: ring only so the spectrum shows through the center (matches ROYGBIV reference). */
+	.spectrum-slider-input {
+		-webkit-appearance: none;
+		appearance: none;
+	}
+
+	.spectrum-slider-input:focus {
+		outline: none;
+	}
+
+	.spectrum-slider-input:focus-visible {
+		outline: 2px solid var(--color-primary);
+		outline-offset: 4px;
+		border-radius: 9999px;
+	}
+
+	.spectrum-slider-input::-webkit-slider-runnable-track {
+		height: 0.5rem;
+		background: transparent;
+		border-radius: 9999px;
+	}
+
+	.spectrum-slider-input::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 1.25rem;
+		height: 1.25rem;
+		margin-top: -0.375rem;
+		border-radius: 9999px;
+		border: 3px solid white;
+		box-shadow:
+			0 0 0 1px rgb(0 0 0 / 0.25),
+			0 1px 3px rgb(0 0 0 / 0.2);
+		background: transparent;
+	}
+
+	.spectrum-slider-input::-moz-range-track {
+		height: 0.5rem;
+		background: transparent;
+		border-radius: 9999px;
+	}
+
+	.spectrum-slider-input::-moz-range-thumb {
+		width: 1.25rem;
+		height: 1.25rem;
+		border: 3px solid white;
+		border-radius: 9999px;
+		box-shadow:
+			0 0 0 1px rgb(0 0 0 / 0.25),
+			0 1px 3px rgb(0 0 0 / 0.2);
+		background: transparent;
+	}
+
+	.spectrum-slider-input:disabled::-webkit-slider-thumb {
+		box-shadow: 0 0 0 1px rgb(0 0 0 / 0.15);
+	}
+
+	.spectrum-slider-input:disabled::-moz-range-thumb {
+		box-shadow: 0 0 0 1px rgb(0 0 0 / 0.15);
+	}
+</style>

--- a/ui/user/src/lib/components/Success.svelte
+++ b/ui/user/src/lib/components/Success.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { CheckCircle2, X } from 'lucide-svelte/icons';
+	import { CircleCheckBig, X } from 'lucide-svelte/icons';
 	import { fade } from 'svelte/transition';
 
 	interface Props {
@@ -13,12 +13,12 @@
 <div
 	in:fade
 	out:fade={{ duration: 100 }}
-	class="relative flex max-w-sm items-center gap-2 rounded-xl bg-gray-50 p-5 pr-12 dark:bg-gray-950"
+	class="relative flex max-w-sm items-center gap-2 rounded-xl bg-base-200/50 p-5 pr-12"
 >
 	<div>
-		<CheckCircle2 class="h-5 w-5 text-green-500" />
+		<CircleCheckBig class="h-5 w-5 text-success" />
 	</div>
-	<div class="line-clamp-3 pr-5 text-sm font-normal break-words">
+	<div class="line-clamp-3 pr-5 text-sm font-normal wrap-break-word">
 		{message}
 	</div>
 	{#if onClose}

--- a/ui/user/src/lib/components/Success.svelte
+++ b/ui/user/src/lib/components/Success.svelte
@@ -10,20 +10,16 @@
 	let { message, onClose }: Props = $props();
 </script>
 
-<div
-	in:fade
-	out:fade={{ duration: 100 }}
-	class="relative flex max-w-sm items-center gap-2 rounded-xl bg-base-200/50 p-5 pr-12"
->
+<div in:fade out:fade={{ duration: 100 }} class="alert alert-horizontal alert-success alert-soft">
 	<div>
-		<CircleCheckBig class="h-5 w-5 text-success" />
+		<CircleCheckBig class="size-5 text-success" />
 	</div>
-	<div class="line-clamp-3 pr-5 text-sm font-normal wrap-break-word">
+	<div class="line-clamp-3 text-sm font-normal wrap-break-word">
 		{message}
 	</div>
 	{#if onClose}
-		<button type="button" onclick={onClose} class="absolute top-0 right-0 p-4">
-			<X class="h-5 w-5" />
+		<button type="button" onclick={onClose}>
+			<X class="size-4" />
 		</button>
 	{/if}
 </div>

--- a/ui/user/src/lib/components/SuccessNotifications.svelte
+++ b/ui/user/src/lib/components/SuccessNotifications.svelte
@@ -19,7 +19,7 @@
 	});
 </script>
 
-<div bind:this={div} class="absolute right-0 bottom-0 z-50 hidden flex-col gap-2 pr-5 pb-5">
+<div bind:this={div} class="toast toast-bottom toast-end z-50">
 	{#each $success as message (message.id)}
 		<Success message={message.message} onClose={() => success.remove(message.id)} />
 	{/each}

--- a/ui/user/src/lib/components/Thread.svelte
+++ b/ui/user/src/lib/components/Thread.svelte
@@ -9,6 +9,7 @@
 	import ToolConfirmBar from '$lib/components/messages/ToolConfirmBar.svelte';
 	import { closeAll, getLayout } from '$lib/context/chatLayout.svelte';
 	import { HELPER_TEXTS } from '$lib/context/helperMode.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { toHTMLFromMarkdown } from '$lib/markdown';
 	import {
 		ChatService,
@@ -29,7 +30,8 @@
 	import { goto } from '$lib/url';
 	import ResponsiveDialog from './ResponsiveDialog.svelte';
 	import McpPrompts from './mcp/McpPrompts.svelte';
-	import { Bug, LoaderCircle, X } from 'lucide-svelte';
+	import IconButton from './primitives/IconButton.svelte';
+	import { Bug, X } from 'lucide-svelte';
 	import { onDestroy, onMount, tick } from 'svelte';
 	import type { UIEventHandler } from 'svelte/elements';
 	import { fade } from 'svelte/transition';
@@ -437,13 +439,13 @@
 					id="project-name"
 					type="text"
 					placeholder="Project Name"
-					class="ghost-input border-b-surface1 mb-2 w-full pt-0 pb-0 text-center text-base font-bold"
+					class="ghost-input border-b-base-200 mb-2 w-full pt-0 pb-0 text-center text-base font-bold"
 					bind:value={createProject.name}
 					bind:this={nameInput}
 				/>
 				<textarea
 					id="project-desc"
-					class="ghost-input border-b-surface1 text-md scrollbar-none mb-4 w-full grow resize-none pt-0.5 pb-0 text-center font-light"
+					class="ghost-input border-b-base-200 text-md scrollbar-none mb-4 w-full grow resize-none pt-0.5 pb-0 text-center font-light"
 					rows="1"
 					placeholder="A short description of your project"
 					use:autoHeight
@@ -451,12 +453,12 @@
 				></textarea>
 
 				<div class="mt-2 flex w-full flex-col justify-start text-left">
-					<label for="project-prompt" class="text-on-surface1 mb-1 text-sm font-semibold"
+					<label for="project-prompt" class="text-muted-content mb-1 text-sm font-semibold"
 						>Instructions</label
 					>
 					<textarea
 						id="project-prompt"
-						class="ghost-input bg-surface1 text-md scrollbar-none mb-4 w-full grow resize-none rounded-md p-4 text-left font-light shadow-inner"
+						class="ghost-input bg-base-200 text-md scrollbar-none mb-4 w-full grow resize-none rounded-md p-4 text-left font-light shadow-inner"
 						rows="4"
 						placeholder={HELPER_TEXTS.prompt}
 						use:autoHeight
@@ -464,12 +466,12 @@
 					></textarea>
 				</div>
 				<button
-					class="button-primary w-full text-sm"
+					class="btn btn-primary btn-sm w-full"
 					disabled={savingNewProject}
 					onclick={handleSaveNewProject}
 				>
 					{#if savingNewProject}
-						<LoaderCircle class="size-4" />
+						<Loading class="size-4" />
 					{:else}
 						Save
 					{/if}
@@ -477,17 +479,17 @@
 			{/if}
 		</div>
 
-		<button
-			class="icon-button absolute top-2 right-2"
+		<IconButton
+			class="absolute top-2 right-2"
 			onclick={() => {
 				createProject = undefined;
 			}}
 		>
 			<X class="size-6" />
-		</button>
+		</IconButton>
 
 		<div
-			class="bg-surface1 dark:bg-surface2 m-auto mt-4 h-[1px] w-96 max-w-sm self-center rounded-full"
+			class="bg-base-200 dark:bg-base-300 m-auto mt-4 h-px w-96 max-w-sm self-center rounded-full"
 		></div>
 	</div>
 {/snippet}
@@ -526,7 +528,7 @@
 				{#if showLoadOlderButton}
 					<div class="mb-4 flex justify-center">
 						<button
-							class="border-surface3 hover:bg-surface2 bg-background rounded-full border px-4 py-2 text-sm font-light transition-all duration-300"
+							class="border-base-400 hover:bg-base-300 bg-base-100 rounded-full border px-4 py-2 text-sm font-light transition-all duration-300"
 							onclick={loadOlderMessages}
 							disabled={loadingOlderMessages}
 						>
@@ -568,8 +570,8 @@
 
 		<div
 			class={twMerge(
-				'bg-background sticky z-30 flex w-full flex-col items-center pb-2 transition-transform duration-300',
-				centerInput ? 'absolute top-1/2 -translate-y-[50%]' : 'bottom-0 -translate-y-[0%]'
+				'bg-base-100 sticky z-30 flex w-full flex-col items-center pb-2 transition-transform duration-300',
+				centerInput ? 'absolute top-1/2 -translate-y-[50%]' : 'bottom-0 translate-y-[0%]'
 			)}
 		>
 			{#if !centerInput && messages.messages.length > 0 && id}
@@ -673,7 +675,7 @@
 					<div
 						class="mt-3 grid grid-cols-[auto_auto] items-center justify-center gap-x-2 px-5 text-xs font-light"
 					>
-						<span class="text-on-surface1">Obot isn't perfect. Double check its work.</span>
+						<span class="text-muted-content">Obot isn't perfect. Double check its work.</span>
 						<a
 							href="https://github.com/obot-platform/obot/issues/new?template=bug_report.md"
 							target="_blank"
@@ -706,7 +708,7 @@
 		bottom: 9rem;
 		height: 3.5rem;
 		max-width: 900px;
-		background: linear-gradient(to bottom, transparent, var(--background));
+		background: linear-gradient(to bottom, transparent, var(--color-base-100));
 	}
 
 	.top-fade-bar {
@@ -715,6 +717,6 @@
 		top: 0;
 		height: 3.5rem;
 		max-width: 900px;
-		background: linear-gradient(to top, transparent, var(--background));
+		background: linear-gradient(to top, transparent, var(--color-base-100));
 	}
 </style>

--- a/ui/user/src/lib/components/TimeClockPopover.svelte
+++ b/ui/user/src/lib/components/TimeClockPopover.svelte
@@ -276,7 +276,7 @@
 		<div class="relative flex flex-1 flex-col items-center justify-center px-3 pt-4 pb-6">
 			<div class="relative aspect-square w-full max-w-[280px] pb-4">
 				<!-- Dial background -->
-				<div class="bg-surface1 absolute inset-[0%] rounded-full"></div>
+				<div class="bg-base-200 absolute inset-[0%] rounded-full"></div>
 
 				{#if mode === 'hour' && is24h}
 					{@const selAngle = handAngleForHour24(h24)}
@@ -300,8 +300,8 @@
 							type="button"
 							style={polarStyle(h, 12, 40)}
 							class={twMerge(
-								'bg-surface1 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-sm',
-								h24 === h ? 'bg-primary text-white scale-110' : 'hover:bg-surface3 '
+								'bg-base-200 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-sm',
+								h24 === h ? 'bg-primary text-white scale-110' : 'hover:bg-base-400 '
 							)}
 							onclick={() => setHour24(h)}>{h}</button
 						>
@@ -311,8 +311,8 @@
 							type="button"
 							style={polarStyleIndex(i, 12, 24)}
 							class={twMerge(
-								'bg-surface1 absolute z-10 flex h-8 w-8 items-center justify-center rounded-full text-xs',
-								h24 === hv ? 'bg-primary text-white scale-110' : 'hover:bg-surface3 '
+								'bg-base-200 absolute z-10 flex h-8 w-8 items-center justify-center rounded-full text-xs',
+								h24 === hv ? 'bg-primary text-white scale-110' : 'hover:bg-base-400 '
 							)}
 							onclick={() => setHour24(hv)}>{String(hv).padStart(2, '0')}</button
 						>
@@ -339,8 +339,8 @@
 							type="button"
 							style={polarStyle(h, 12, 40)}
 							class={twMerge(
-								'bg-surface1 absolute z-10 flex h-10 w-10 items-center justify-center rounded-full text-base',
-								hour12 === h ? 'bg-primary text-white scale-110' : 'hover:bg-surface3 '
+								'bg-base-200 absolute z-10 flex h-10 w-10 items-center justify-center rounded-full text-base',
+								hour12 === h ? 'bg-primary text-white scale-110' : 'hover:bg-base-400 '
 							)}
 							onclick={() => setHour12(h)}>{h}</button
 						>
@@ -369,10 +369,10 @@
 							type="button"
 							style={polarStyle(slot === 0 ? 12 : slot, 12, 38)}
 							class={twMerge(
-								'bg-surface1 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-xs',
+								'bg-base-200 absolute z-10 flex h-9 w-9 items-center justify-center rounded-full text-xs',
 								Math.floor(selMin / 5) === slot
 									? 'bg-primary text-primary-content scale-110'
-									: 'hover:bg-surface3 '
+									: 'hover:bg-base-400 '
 							)}
 							onclick={() => {
 								minuteExtra = 0;
@@ -390,7 +390,7 @@
 							type="button"
 							class={twMerge(
 								'rounded px-2 py-1 text-xs',
-								minuteExtra === e ? 'bg-primary text-white' : 'bg-surface3/50 text-on-background'
+								minuteExtra === e ? 'bg-primary text-white' : 'bg-base-400/50 text-muted-content'
 							)}
 							onclick={() => setMinuteExtra(e)}>+{e}</button
 						>
@@ -400,9 +400,9 @@
 		</div>
 
 		<!-- Footer -->
-		<div class="border-surface3 flex justify-end gap-2 border-t px-3 py-2">
-			<button type="button" class="button text-xs uppercase" onclick={cancel}>Cancel</button>
-			<button type="button" class="button-primary text-xs uppercase" onclick={ok}>OK</button>
+		<div class="border-base-400 flex justify-end gap-2 border-t px-3 py-2">
+			<button type="button" class="btn btn-secondary btn-sm" onclick={cancel}>Cancel</button>
+			<button type="button" class="btn btn-primary btn-sm" onclick={ok}>OK</button>
 		</div>
 	</div>
 {/if}

--- a/ui/user/src/lib/components/TimeInput.svelte
+++ b/ui/user/src/lib/components/TimeInput.svelte
@@ -144,7 +144,7 @@
 	}
 </script>
 
-<div class={twMerge('time-input bg-surface1 flex h-14 items-center gap-2 rounded-md', klass)}>
+<div class={twMerge('time-input bg-base-200 flex h-14 items-center gap-2 rounded-md', klass)}>
 	<div class="flex h-full flex-1 text-xl">
 		<input
 			class="w-[3ch] flex-1 bg-transparent px-4 text-end"
@@ -221,7 +221,7 @@
 		<div class="flex h-full flex-col gap-1 p-1 text-xs">
 			<button
 				class={twMerge(
-					'bg-surface3/30 flex-1 rounded-sm px-1',
+					'bg-base-400/30 flex-1 rounded-sm px-1',
 					isAm && 'bg-primary/10 border-primary/50 text-primary'
 				)}
 				onclick={() => {
@@ -233,7 +233,7 @@
 
 			<button
 				class={twMerge(
-					'bg-surface3/30 flex-1 rounded-sm px-1',
+					'bg-base-400/30 flex-1 rounded-sm px-1',
 					!isAm && 'text-primary bg-primary/10'
 				)}
 				onclick={() => {

--- a/ui/user/src/lib/components/Toggle.svelte
+++ b/ui/user/src/lib/components/Toggle.svelte
@@ -35,7 +35,7 @@
 		{@render input()}
 	</label>
 {:else}
-	<label class={twMerge('text-on-surface1 flex items-center gap-1 text-xs', classes?.label)}>
+	<label class={twMerge('text-muted-content flex items-center gap-1 text-xs', classes?.label)}>
 		<span>{label}</span>
 		<div class="relative flex h-4.5 w-8.25">
 			{@render input()}
@@ -48,8 +48,7 @@
 		type="checkbox"
 		{checked}
 		{disabled}
-		class={twMerge('opacity-0', classes?.input)}
-		readonly
+		class={twMerge('toggle toggle-sm', classes?.input)}
 		onchange={(e) => {
 			e.preventDefault();
 			if (!disabled) {
@@ -57,60 +56,4 @@
 			}
 		}}
 	/>
-	<span class="slider rounded-2xl" class:checked class:disabled></span>
 {/snippet}
-
-<style lang="postcss">
-	/* The slider */
-	:global {
-		.slider {
-			position: absolute;
-			cursor: pointer;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			background-color: var(--color-surface3);
-			-webkit-transition: 0.4s;
-			transition: 0.4s;
-
-			.dark & {
-				&::before {
-					background-color: var(--color-surface1);
-				}
-			}
-		}
-
-		.slider.disabled {
-			cursor: default;
-			opacity: 0.6;
-		}
-
-		.slider:before {
-			position: absolute;
-			content: '';
-			height: 0.825rem;
-			width: 0.825rem;
-			left: 0.145rem;
-			bottom: 0.145rem;
-			background-color: var(--color-white);
-			-webkit-transition: 0.4s;
-			transition: 0.4s;
-			border-radius: 50%;
-		}
-
-		.slider.checked {
-			background-color: var(--color-primary);
-		}
-
-		.slider.checked:before {
-			-webkit-transform: translateX(0.925rem);
-			-ms-transform: translateX(0.925rem);
-			transform: translateX(0.925rem);
-		}
-
-		input:focus + .slider {
-			box-shadow: 0 0 1px var(--color-primary);
-		}
-	}
-</style>

--- a/ui/user/src/lib/components/ToolPill.svelte
+++ b/ui/user/src/lib/components/ToolPill.svelte
@@ -17,7 +17,7 @@
 
 <div
 	use:ref
-	class="bg-surface2 flex size-8 cursor-help items-center gap-1 rounded-full p-2 dark:bg-gray-500 dark:text-black"
+	class="bg-base-300 flex size-8 cursor-help items-center gap-1 rounded-full p-2 dark:bg-base-200 dark:text-base-content"
 >
 	{#if tool}
 		{#if tool?.metadata?.icon}
@@ -46,7 +46,7 @@
 			{#each tools as tool (tool.id)}
 				<li class="flex items-center gap-2">
 					{#if tool?.metadata?.icon}
-						<div class="bg-surface2 rounded-full p-2 dark:bg-gray-100">
+						<div class="bg-base-300 rounded-full p-2 dark:bg-base-200">
 							<img alt={tool.name || 'Unknown'} src={tool.metadata.icon} class="h-4 w-4" />
 						</div>
 					{:else}

--- a/ui/user/src/lib/components/Tour.svelte
+++ b/ui/user/src/lib/components/Tour.svelte
@@ -302,13 +302,13 @@
 		.driver-popover {
 			box-shadow: var(--shadow-md);
 			border: 1px solid transparent;
-			background-color: var(--color-background);
+			background-color: var(--color-base-100);
 			color: var(--color-black);
 			border-radius: var(--radius-md);
 
 			.dark & {
-				border: 1px solid var(--surface3);
-				background-color: var(--surface2);
+				border: 1px solid var(--color-base-400);
+				background-color: var(--color-base-300);
 				color: var(--color-white);
 			}
 		}
@@ -329,7 +329,7 @@
 
 			border-radius: 1.5rem;
 			padding: 0.5rem 1.25rem;
-			background-color: var(--surface3);
+			background-color: var(--color-base-400);
 			border-width: 0;
 			transition-property: color, background-color;
 			transition-duration: 200ms;
@@ -339,12 +339,12 @@
 			}
 
 			&:hover {
-				background-color: color-mix(in oklab, var(--surface3) 90%, var(--color-black));
-				border-color: color-mix(in oklab, var(--surface3) 90%, var(--color-black));
+				background-color: color-mix(in oklab, var(--color-base-400) 90%, var(--color-black));
+				border-color: color-mix(in oklab, var(--color-base-400) 90%, var(--color-black));
 			}
 
 			.dark &:hover {
-				background-color: color-mix(in oklab, var(--surface3) 90%, var(--color-white));
+				background-color: color-mix(in oklab, var(--color-base-400) 90%, var(--color-white));
 			}
 		}
 
@@ -363,22 +363,22 @@
 		}
 
 		.driver-popover-arrow {
-			border: 5px solid var(--color-background);
+			border: 5px solid var(--color-base-100);
 			.dark & {
-				border: 5px solid var(--surface3);
+				border: 5px solid var(--color-base-400);
 			}
 		}
 
 		.driver-popover-close-btn {
-			color: color-mix(in oklab, var(--color-on-background) 75%, var(--color-white));
+			color: color-mix(in oklab, var(--color-base-content) 75%, var(--color-white));
 			&:hover {
-				color: var(--color-on-background);
+				color: var(--color-base-content);
 			}
 
 			.dark & {
-				color: color-mix(in oklab, var(--color-on-background) 75%, var(--color-black));
+				color: color-mix(in oklab, var(--color-base-content) 75%, var(--color-black));
 				&:hover {
-					color: var(--color-on-background);
+					color: var(--color-base-content);
 				}
 			}
 		}

--- a/ui/user/src/lib/components/UploadImage.svelte
+++ b/ui/user/src/lib/components/UploadImage.svelte
@@ -46,7 +46,9 @@
 <label
 	class={twMerge(
 		'flex cursor-pointer items-center justify-center gap-2 px-4 py-2',
-		variant === 'icon' ? 'icon-button' : 'border-surface3 min-h-72 border-2 border-dashed p-4'
+		variant === 'icon'
+			? 'btn btn-square btn-ghost'
+			: 'border-base-400 min-h-72 border-2 border-dashed p-4'
 	)}
 >
 	{#await uploadInProgress}
@@ -58,7 +60,7 @@
 	{#if !uploadInProgress}
 		{#if variant !== 'preview' || (variant === 'preview' && !previewUrl)}
 			<Upload class="h-5 w-5" />
-			<span class="text-on-surface">{label}</span>
+			<span class="text-muted-content">{label}</span>
 		{:else if variant === 'preview' && previewUrl}
 			{#key previewUrl}
 				<img src={previewUrl} alt={label} class="max-h-72 object-contain" />

--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import {
 		PAGE_TRANSITION_DURATION,
 		ADMIN_SESSION_STORAGE,
 		DEFAULT_MCP_CATALOG_ID,
 		ADMIN_ALL_OPTION
 	} from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, ChatService, type MCPCatalogServer } from '$lib/services';
 	import {
 		type AccessControlRule,
@@ -21,10 +21,11 @@
 	import { goto } from '$lib/url';
 	import { getUserDisplayName } from '$lib/utils';
 	import Confirm from '../Confirm.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import SearchMcpServers from './SearchMcpServers.svelte';
 	import SearchUsers from './SearchUsers.svelte';
-	import { LoaderCircle, Plus, Trash2 } from 'lucide-svelte';
+	import { Plus, Trash2 } from 'lucide-svelte';
 	import { untrack, type Snippet } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -290,7 +291,7 @@
 						{#if initialAccessControlRule}
 							{@const registry = getUserRegistry(initialAccessControlRule, usersMap)}
 							{#if registry}
-								<div class="dark:bg-surface2 bg-surface3 rounded-full px-3 py-1 text-xs">
+								<div class="dark:bg-base-300 bg-base-400 rounded-full px-3 py-1 text-xs">
 									{registry}
 								</div>
 							{/if}
@@ -298,22 +299,22 @@
 					{/if}
 				</div>
 				{#if !readonly}
-					<button
-						class="button-destructive flex items-center gap-1 text-xs font-normal"
-						use:tooltip={'Delete Catalog'}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete Catalog' }}
 						onclick={() => {
 							deletingRule = true;
 						}}
 					>
 						<Trash2 class="size-4" />
-					</button>
+					</IconButton>
 				{/if}
 			</div>
 		{/if}
 
 		{#if !accessControlRule.id}
 			<div
-				class="dark:bg-surface2 dark:border-surface3 bg-background rounded-lg border border-transparent p-4"
+				class="dark:bg-base-300 dark:border-base-400 bg-base-100 rounded-lg border border-transparent p-4"
 			>
 				<div class="flex flex-col gap-6">
 					<div class="flex flex-col gap-2">
@@ -337,12 +338,12 @@
 				{#if !readonly}
 					<div class="relative flex items-center gap-4">
 						{#if loadingUsersAndGroups}
-							<button class="button-primary flex items-center gap-1 text-sm" disabled>
+							<button class="btn btn-primary flex items-center gap-1 text-sm" disabled>
 								<Plus class="size-4" /> Add User/Group
 							</button>
 						{:else}
 							<button
-								class="button-primary flex items-center gap-1 text-sm"
+								class="btn btn-primary flex items-center gap-1 text-sm"
 								onclick={() => {
 									addUserGroupDialog?.open();
 								}}
@@ -355,7 +356,7 @@
 			</div>
 			{#if loadingUsersAndGroups}
 				<div class="my-2 flex items-center justify-center">
-					<LoaderCircle class="size-6 animate-spin" />
+					<Loading class="size-6" />
 				</div>
 			{:else}
 				{@const tableData = convertSubjectsToTableData(
@@ -371,17 +372,17 @@
 				>
 					{#snippet actions(d)}
 						{#if !readonly}
-							<button
-								class="icon-button hover:text-red-500"
+							<IconButton
+								variant="danger"
 								onclick={() => {
 									accessControlRule.subjects = accessControlRule.subjects?.filter(
 										(subject) => subject.id !== d.id
 									);
 								}}
-								use:tooltip={'Delete User/Group'}
+								tooltip={{ text: 'Delete User/Group' }}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					{/snippet}
 				</Table>
@@ -394,7 +395,7 @@
 				{#if !readonly}
 					<div class="relative flex items-center gap-4">
 						<button
-							class="button-primary flex items-center gap-1 text-sm"
+							class="btn btn-primary flex items-center gap-1 text-sm"
 							onclick={() => {
 								addMcpServerDialog?.open();
 							}}
@@ -407,16 +408,16 @@
 			<Table data={mcpServersTableData} fields={['name']} noDataMessage="No MCP servers added.">
 				{#snippet actions(d)}
 					{#if !readonly}
-						<button
-							class="icon-button hover:text-red-500"
+						<IconButton
+							variant="danger"
 							onclick={() => {
 								accessControlRule.resources =
 									accessControlRule.resources?.filter((resource) => resource.id !== d.id) ?? [];
 							}}
-							use:tooltip={'Remove MCP Server'}
+							tooltip={{ text: 'Remove MCP Server' }}
 						>
 							<Trash2 class="size-4" />
-						</button>
+						</IconButton>
 					{/if}
 				{/snippet}
 			</Table>
@@ -424,14 +425,14 @@
 	</div>
 	{#if !readonly}
 		<div
-			class="bg-surface1 text-on-surface1 dark:bg-background sticky bottom-0 left-0 flex w-full justify-end gap-2 py-4"
+			class="bg-base-200 text-muted-content dark:bg-base-100 sticky bottom-0 left-0 flex w-full justify-end gap-2 py-4"
 			out:fly={{ x: -100, duration }}
 			in:fly={{ x: -100 }}
 		>
 			<div class="flex w-full justify-end gap-2">
 				{#if !accessControlRule.id}
 					<button
-						class="button text-sm"
+						class="btn btn-secondary btn-sm"
 						onclick={() => {
 							if (redirect) {
 								goto(redirect);
@@ -445,7 +446,7 @@
 						Cancel
 					</button>
 					<button
-						class="button-primary text-sm"
+						class="btn btn-primary btn-sm"
 						disabled={!validate(accessControlRule) || saving}
 						onclick={async () => {
 							if (!id) return;
@@ -464,14 +465,14 @@
 						}}
 					>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Save
 						{/if}
 					</button>
 				{:else}
 					<button
-						class="button text-sm"
+						class="btn btn-secondary"
 						disabled={saving}
 						onclick={async () => {
 							if (!accessControlRule.id || !id) return;
@@ -486,7 +487,7 @@
 						Reset
 					</button>
 					<button
-						class="button-primary text-sm"
+						class="btn btn-primary"
 						disabled={!validate(accessControlRule) || saving}
 						onclick={async () => {
 							if (!accessControlRule.id || !id) return;
@@ -508,7 +509,7 @@
 						}}
 					>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Update
 						{/if}

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, ChatService, type MCPCatalogServer } from '$lib/services';
 	import {
 		type MCPCatalogEntry,
@@ -25,7 +26,7 @@
 	import RuntimeSelector from '../mcp/RuntimeSelector.svelte';
 	import UvxRuntimeForm from '../mcp/UvxRuntimeForm.svelte';
 	import SelectMcpAccessControlRules from './SelectMcpAccessControlRules.svelte';
-	import { Info, LoaderCircle } from 'lucide-svelte';
+	import { Info } from 'lucide-svelte';
 	import { onMount, untrack, type Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -549,7 +550,7 @@
 </script>
 
 <div
-	class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-8 rounded-lg border border-transparent p-4 shadow-sm"
+	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-8 rounded-lg border border-transparent p-4 shadow-sm"
 >
 	<div class="flex flex-col gap-8">
 		{#if readonly && readonlyMessage}
@@ -572,7 +573,7 @@
 				type="text"
 				id="name"
 				bind:value={formData.name}
-				class={twMerge('text-input-filled dark:bg-background', showRequired.name && 'error')}
+				class={twMerge('text-input-filled dark:bg-base-100', showRequired.name && 'error')}
 				disabled={readonly}
 				oninput={() => {
 					updateRequired('name');
@@ -582,7 +583,7 @@
 
 		<div class="flex flex-col gap-1">
 			<label for="name" class="text-sm font-light capitalize"
-				>Description <span class="text-on-surface1 text-xs">(Markdown syntax supported)</span
+				>Description <span class="text-muted-content text-xs">(Markdown syntax supported)</span
 				></label
 			>
 			<MarkdownInput
@@ -598,7 +599,7 @@
 				type="text"
 				id="icon"
 				bind:value={formData.icon}
-				class="text-input-filled dark:bg-background"
+				class="text-input-filled dark:bg-base-100"
 				disabled={readonly}
 			/>
 		</div>
@@ -684,14 +685,16 @@
 
 {#if !readonly}
 	<div
-		class="bg-surface1 dark:bg-background sticky bottom-0 left-0 flex w-[calc(100%+2em)] -translate-x-4 items-center justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
+		class="bg-base-200 dark:bg-base-100 sticky bottom-0 left-0 flex w-[calc(100%+2em)] -translate-x-4 items-center justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
 	>
 		{#if Object.keys(showRequired).length > 0}
-			<span class="text-sm font-medium text-red-500">Fill out all required fields</span>
+			<span class="text-sm font-medium text-error">Fill out all required fields</span>
 		{/if}
-		<button class="button flex items-center gap-1" onclick={() => onCancel?.()}> Cancel </button>
+		<button class="btn btn-secondary flex items-center gap-1" onclick={() => onCancel?.()}>
+			Cancel
+		</button>
 		<button
-			class="button-primary flex items-center gap-1"
+			class="btn btn-primary flex items-center gap-1"
 			onclick={handleSubmit}
 			disabled={loading ||
 				(formData.runtime === 'composite' &&
@@ -700,7 +703,7 @@
 						compositeHasToolNameErrors))}
 		>
 			{#if loading}
-				<LoaderCircle class="size-4 animate-spin" />
+				<Loading class="size-4" />
 			{:else}
 				{entry ? 'Update' : 'Save'}
 			{/if}

--- a/ui/user/src/lib/components/admin/CategorySelectInput.svelte
+++ b/ui/user/src/lib/components/admin/CategorySelectInput.svelte
@@ -33,10 +33,10 @@
 
 <div class="category-select-input flex w-full items-center gap-2">
 	<Select
-		class="dark:border-surface3 bg-surface1 text-input-filled dark:bg-background border border-transparent shadow-inner"
+		class="dark:border-base-400 bg-base-200 text-input-filled dark:bg-base-100 border border-transparent shadow-inner"
 		classes={{
 			root: 'w-full',
-			clear: 'hover:bg-surface3 bg-transparent'
+			clear: 'hover:bg-base-400 bg-transparent'
 		}}
 		options={localOptions}
 		disabled={readonly}

--- a/ui/user/src/lib/components/admin/ConfigureBanner.svelte
+++ b/ui/user/src/lib/components/admin/ConfigureBanner.svelte
@@ -34,13 +34,13 @@
 
 {#if !loading && (!isModelProviderConfigured || !isAuthProviderConfigured) && profile.current?.isAdmin?.()}
 	<div
-		class="dark:bg-surface2 bg-background mb-4 flex min-h-44 justify-center overflow-hidden rounded-xl py-4"
+		class="dark:bg-base-300 bg-base-100 mb-4 flex min-h-44 justify-center overflow-hidden rounded-xl py-4"
 	>
 		<div
-			class="relative flex min-h-36 w-[calc(100%-4rem)] max-w-screen-md flex-row items-center justify-between gap-4 rounded-sm"
+			class="relative flex min-h-36 w-[calc(100%-4rem)] max-w-3xl flex-row items-center justify-between gap-4 rounded-sm"
 		>
-			<div class="absolute opacity-5 md:top-[-1.75rem] md:left-[-3.0rem] md:opacity-45">
-				<Logo variant="warning" class="md:h-[17.5rem] md:w-[17.5rem]" />
+			<div class="absolute opacity-5 md:-top-7 md:left-[-3.0rem] md:opacity-45">
+				<Logo variant="warning" class="md:h-70 md:w-70" />
 			</div>
 			<div class="relative z-10 flex flex-col gap-2 md:ml-64">
 				<h4 class="text-lg font-semibold">Wait! You've still got some setup to do!</h4>
@@ -57,18 +57,12 @@
 				{/if}
 				<div class="flex flex-row flex-wrap gap-2">
 					{#if !isModelProviderConfigured}
-						<a
-							href={resolve('/admin/model-providers')}
-							class="button grow bg-yellow-500 text-center text-sm text-black hover:bg-yellow-500/70"
-						>
+						<a href={resolve('/admin/model-providers')} class="btn btn-warning">
 							Configure Model Provider
 						</a>
 					{/if}
 					{#if !isAuthProviderConfigured}
-						<a
-							href={resolve('/admin/auth-providers')}
-							class="button grow bg-yellow-500 text-center text-sm text-black hover:bg-yellow-500/70"
-						>
+						<a href={resolve('/admin/auth-providers')} class="btn btn-warning">
 							Configure Auth Provider
 						</a>
 					{/if}

--- a/ui/user/src/lib/components/admin/DefaultModels.svelte
+++ b/ui/user/src/lib/components/admin/DefaultModels.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		ModelAliasLabels,
 		ModelUsage,
@@ -13,7 +14,6 @@
 	import { version, defaultModelAliases as defaultModelAliasesStore } from '$lib/stores';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import Select from '../Select.svelte';
-	import { LoaderCircle } from 'lucide-svelte';
 
 	let { availableModels, readonly }: { availableModels: Model[]; readonly?: boolean } = $props();
 	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
@@ -168,7 +168,7 @@
 </script>
 
 <button
-	class="button-primary text-sm font-normal"
+	class="btn btn-primary"
 	disabled={availableModels.length === 0 || loading}
 	onclick={() => open()}
 >
@@ -187,7 +187,7 @@
 	}}
 	hideClose={required}
 >
-	<p class="text-on-surface1 pb-4 font-light">
+	<p class="text-muted-content pb-4 font-light">
 		When no model is specified, a default model is used for creating a new project, running user
 		tasks, or working with some tools, etc. Select your default models for the usage types below.
 	</p>
@@ -202,7 +202,7 @@
 				<Select
 					id={modelAlias.alias}
 					classes={{ root: 'w-1/2' }}
-					class="bg-surface1 dark:bg-surface2 dark:border-surface3 flex-1 border border-transparent shadow-inner"
+					class="bg-base-200 dark:bg-base-300 dark:border-base-400 flex-1 border border-transparent shadow-inner"
 					options={activeModelOptions
 						.map((model) => ({
 							label: (SUGGESTED_MODEL_SELECTIONS[modelAlias.alias] ?? []).includes(model.name ?? '')
@@ -234,22 +234,20 @@
 		{/each}
 	</div>
 	{#if !readonly}
-		<div class="flex flex-col gap-4 pt-4">
+		<div class="flex flex-col gap-2 pt-4">
 			<button
-				class="button-primary w-full text-sm font-normal"
+				class="btn btn-primary w-full"
 				onclick={handleSaveChanges}
 				disabled={loading || !changed}
 			>
 				{#if loading}
-					<LoaderCircle class="size-4 animate-spin inline-block" />
+					<Loading class="size-4 inline-block" />
 				{:else}
 					Save Changes
 				{/if}
 			</button>
 			{#if !required}
-				<button class="button w-full text-sm font-normal" onclick={() => dialog?.close()}>
-					Skip
-				</button>
+				<button class="btn btn-secondary w-full" onclick={() => dialog?.close()}> Skip </button>
 			{/if}
 		</div>
 	{/if}

--- a/ui/user/src/lib/components/admin/DeploymentLogs.svelte
+++ b/ui/user/src/lib/components/admin/DeploymentLogs.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import {
-		AlertTriangle,
 		ChevronDown,
 		ChevronUp,
 		Maximize,
 		Minimize,
 		RefreshCw,
 		Search,
+		TriangleAlert,
 		X
 	} from 'lucide-svelte';
 	import { fade } from 'svelte/transition';
@@ -180,9 +180,7 @@
 
 		return parts
 			.map((part, index) =>
-				index % 2 === 1
-					? `<mark class="bg-yellow-300 dark:bg-yellow-600">${escapeHtml(part)}</mark>`
-					: escapeHtml(part)
+				index % 2 === 1 ? `<mark class="bg-warning">${escapeHtml(part)}</mark>` : escapeHtml(part)
 			)
 			.join('');
 	}
@@ -233,7 +231,7 @@
 			<button
 				onclick={onRefresh}
 				use:tooltip={'Refresh logs'}
-				class="text-on-surface1/60 hover:bg-surface2 hover:text-on-surface1 rounded-md p-1 disabled:opacity-50"
+				class="text-muted-content hover:bg-base-300 hover:text-base-content rounded-md p-1 disabled:opacity-50"
 				disabled={refreshing}
 				aria-label="Refresh logs"
 			>
@@ -244,7 +242,7 @@
 			<div
 				use:tooltip={`An error occurred in connecting to the event stream. This is normal if the server is still starting up.`}
 			>
-				<AlertTriangle class="size-4 text-yellow-500" />
+				<TriangleAlert class="size-4 text-warning" />
 			</div>
 		{/if}
 
@@ -252,7 +250,7 @@
 			<button
 				onclick={clearLogs}
 				use:tooltip={'Clear logs'}
-				class="text-on-surface1/60 hover:bg-surface2 hover:text-on-surface1 rounded-md p-1 disabled:opacity-50"
+				class="text-muted-content hover:bg-base-300 hover:text-base-content rounded-md p-1 disabled:opacity-50"
 				disabled={!hasMessages || refreshing}
 				aria-label="Clear logs"
 			>
@@ -264,7 +262,7 @@
 					isMaximized = true;
 				}}
 				use:tooltip={'Maximize (Esc to close)'}
-				class="text-on-surface1/60 hover:bg-surface2 hover:text-on-surface1 rounded-md p-1 disabled:opacity-50"
+				class="text-muted-content hover:bg-base-300 hover:text-base-content rounded-md p-1 disabled:opacity-50"
 				disabled={!hasMessages}
 				aria-label="Maximize logs"
 			>
@@ -278,7 +276,7 @@
 		onclick={handleModalClick}
 		class={twMerge(
 			isMaximized
-				? 'bg-background/50 fixed inset-0 z-50 flex flex-col items-center justify-center p-4 md:p-8 lg:p-10'
+				? 'bg-base-100/50 fixed inset-0 z-50 flex flex-col items-center justify-center p-4 md:p-8 lg:p-10'
 				: 'contents'
 		)}
 		role={isMaximized ? 'dialog' : undefined}
@@ -289,15 +287,15 @@
 			onscroll={handleUserScroll}
 			bind:this={logsContainer}
 			class={twMerge(
-				'dark:bg-surface1 dark:border-surface3 default-scrollbar-thin bg-background flex min-h-64 flex-col overflow-y-auto rounded-lg border border-transparent shadow-sm',
+				'dark:bg-base-200 dark:border-base-400 default-scrollbar-thin bg-base-100 flex min-h-64 flex-col overflow-y-auto rounded-lg border border-transparent shadow-sm',
 				isMaximized ? 'h-full max-h-full w-full' : 'max-h-84 '
 			)}
 		>
 			{#if hasMessages}
-				<div class="dark:bg-surface1 bg-background border-surface3 sticky top-0 z-10 border-b p-4">
+				<div class="dark:bg-base-200 bg-base-100 border-base-400 sticky top-0 z-10 border-b p-4">
 					<div
 						class={twMerge(
-							'border-surface2 bg-surface1/50 focus-within:outline-primary flex h-10 w-full items-center gap-2 rounded-sm border pr-2 pl-2 text-xs focus-within:outline-2',
+							'border-base-300 bg-base-200/50 focus-within:outline-primary flex h-10 w-full items-center gap-2 rounded-sm border pr-2 pl-2 text-xs focus-within:outline-2',
 							isMaximized && 'text-md h-12'
 						)}
 					>
@@ -307,7 +305,7 @@
 
 						<input
 							bind:this={searchInput}
-							class="placeholder:text-on-surface1/40 flex-1 bg-transparent py-3 outline-none"
+							class="placeholder:text-muted-content flex-1 bg-transparent py-3 outline-none"
 							type="text"
 							placeholder="Search logs... (Ctrl/Cmd+F)"
 							bind:value={query}
@@ -317,7 +315,7 @@
 
 						<div class="flex h-full items-center gap-1 p-0.5">
 							{#if query}
-								<span class="text-on-surface1/60 text-xs">
+								<span class="text-muted-content text-xs">
 									{#if hasMatches}
 										{currentMatchIndex + 1} / {matchingIndices.length}
 									{:else}
@@ -325,7 +323,7 @@
 									{/if}
 								</span>
 								<button
-									class="hover:bg-surface2/80 active:bg-surface2/100 flex h-full max-h-8 items-center justify-center rounded-md p-1.5 opacity-30 hover:opacity-60 disabled:opacity-20"
+									class="hover:bg-base-300/80 active:bg-base-300 flex h-full max-h-8 items-center justify-center rounded-md p-1.5 opacity-30 hover:opacity-60 disabled:opacity-20"
 									onclick={navigateToPreviousMatch}
 									disabled={!hasMatches}
 									use:tooltip={'Previous match (↑ or Shift+Enter)'}
@@ -334,7 +332,7 @@
 									<ChevronUp class="size-full text-current" />
 								</button>
 								<button
-									class="hover:bg-surface2/80 active:bg-surface2/100 flex h-full max-h-8 items-center justify-center rounded-md p-1.5 opacity-30 hover:opacity-60 disabled:opacity-20"
+									class="hover:bg-base-300/80 active:bg-base-300 flex h-full max-h-8 items-center justify-center rounded-md p-1.5 opacity-30 hover:opacity-60 disabled:opacity-20"
 									onclick={navigateToNextMatch}
 									disabled={!hasMatches}
 									use:tooltip={'Next match (↓ or Enter)'}
@@ -343,7 +341,7 @@
 									<ChevronDown class="size-full text-current" />
 								</button>
 								<button
-									class="hover:bg-surface2/80 active:bg-surface2/100 flex h-full max-h-8 items-center justify-center rounded-md p-1.5 opacity-30 hover:opacity-60"
+									class="hover:bg-base-300/80 active:bg-base-300 flex h-full max-h-8 items-center justify-center rounded-md p-1.5 opacity-30 hover:opacity-60"
 									onclick={() => {
 										query = '';
 									}}
@@ -355,7 +353,7 @@
 
 							{#if isMaximized}
 								<button
-									class="hover:bg-surface2/80 active:bg-surface2/100 flex h-full max-h-8 items-center justify-center rounded-md p-1.5 opacity-30 hover:opacity-60"
+									class="hover:bg-base-300/80 active:bg-base-300 flex h-full max-h-8 items-center justify-center rounded-md p-1.5 opacity-30 hover:opacity-60"
 									onclick={() => {
 										isMaximized = false;
 									}}
@@ -381,16 +379,16 @@
 								'group grid gap-2 rounded px-2 py-1 font-mono text-sm transition-all',
 								isMaximized && 'text-base',
 								!isMatchingLine && 'opacity-50',
-								isMatchingLine && 'hover:bg-surface2',
+								isMatchingLine && 'hover:bg-base-300',
 								isCurrentMatchLine && 'outline-primary outline-2 outline-offset-2'
 							)}
 							style="grid-template-columns: auto 1fr;"
 							in:fade
 						>
-							<div class="border-surface3 border-r pr-1 text-right">
-								<span class="text-on-surface1/40 select-none">{i + 1}</span>
+							<div class="border-base-400 border-r pr-1 text-right">
+								<span class="text-muted-content select-none">{i + 1}</span>
 							</div>
-							<span class="text-on-surface1 flex-1">
+							<span class="text-muted-content flex-1">
 								{@html highlightText(message, query)}
 							</span>
 						</div>
@@ -399,8 +397,8 @@
 			{:else}
 				<div class="flex w-full flex-1 items-center justify-center p-6">
 					<div class="text-center">
-						<div class="text-on-surface1/80 font-medium">No deployment logs.</div>
-						<p class="text-on-surface1/60 mt-1 text-sm">Try refreshing the logs.</p>
+						<div class="text-muted-content font-medium">No deployment logs.</div>
+						<p class="text-muted-content mt-1 text-sm">Try refreshing the logs.</p>
 					</div>
 				</div>
 			{/if}

--- a/ui/user/src/lib/components/admin/DiffDialog.svelte
+++ b/ui/user/src/lib/components/admin/DiffDialog.svelte
@@ -30,7 +30,7 @@
 	{#snippet titleContent()}
 		{#if fromServer?.manifest}
 			<div class="flex items-center gap-2 md:p-4 md:pb-0">
-				<div class="bg-surface1 rounded-sm p-1 dark:bg-gray-600">
+				<div class="bg-base-200 rounded-sm p-1 dark:bg-base-300">
 					{#if fromServer?.manifest?.icon}
 						<img src={fromServer.manifest.icon} alt={fromServer.manifest.name} class="size-5" />
 					{:else}
@@ -49,9 +49,9 @@
 			{#if !responsive.isMobile}
 				<div class="grid h-full grid-cols-2">
 					<div class="h-full">
-						<h3 class="text-on-surface1 mb-2 px-4 text-sm font-semibold">Current Version</h3>
+						<h3 class="text-muted-content mb-2 px-4 text-sm font-semibold">Current Version</h3>
 						<div
-							class="default-scrollbar-thin dark:border-surface3 dark:bg-surface1 h-full overflow-x-auto border-r border-gray-200 bg-gray-50 p-4"
+							class="default-scrollbar-thin dark:border-base-400 dark:bg-base-200 h-full overflow-x-auto border-r border-gray-200 bg-gray-50 p-4"
 						>
 							<div class="font-mono text-sm whitespace-pre">
 								{@html formatJsonWithDiffHighlighting(diffManifest, diff, true)}
@@ -59,9 +59,9 @@
 						</div>
 					</div>
 					<div class="h-full">
-						<h3 class="text-on-surface1 mb-2 px-4 text-sm font-semibold">New Version</h3>
+						<h3 class="text-muted-content mb-2 px-4 text-sm font-semibold">New Version</h3>
 						<div
-							class="default-scrollbar-thin dark:border-surface3 dark:bg-surface1 h-full overflow-x-auto bg-gray-50 p-4"
+							class="default-scrollbar-thin dark:border-base-400 dark:bg-base-200 h-full overflow-x-auto bg-gray-50 p-4"
 						>
 							<div class="font-mono text-sm whitespace-pre">
 								{@html formatJsonWithDiffHighlighting(newServerManifest, diff, false)}
@@ -71,9 +71,9 @@
 				</div>
 			{:else}
 				<div class="h-full w-full pl-2">
-					<h3 class="text-on-surface1 mb-2 text-sm font-semibold">Source Diff</h3>
+					<h3 class="text-on-surfa ce1 mb-2 text-sm font-semibold">Source Diff</h3>
 					<div
-						class="default-scrollbar-thin dark:bg-surface1 h-full overflow-auto rounded-sm bg-gray-50 pt-4"
+						class="default-scrollbar-thin dark:bg-base-200 h-full overflow-auto rounded-sm bg-gray-50 pt-4"
 					>
 						{#each diff.unifiedLines as line, i (i)}
 							{@const type = line.startsWith('+')
@@ -87,10 +87,10 @@
 								class={twMerge(
 									'font-mono text-sm whitespace-pre',
 									type === 'added'
-										? 'bg-green-500/10 text-green-500 dark:bg-green-900/30'
+										? 'bg-success/10 text-success'
 										: type === 'removed'
-											? 'bg-red-500/10 text-red-500'
-											: 'text-gray-700 dark:text-gray-300'
+											? 'bg-error/10 text-error'
+											: 'text-muted-content'
 								)}
 							>
 								{prefix}{content}
@@ -102,7 +102,7 @@
 		{/if}
 	{:else}
 		<div class="flex items-center justify-center py-8">
-			<p class="text-on-surface1">Unable to compare manifests. Missing manifest data.</p>
+			<p class="text-muted-content">Unable to compare manifests. Missing manifest data.</p>
 		</div>
 	{/if}
 </ResponsiveDialog>

--- a/ui/user/src/lib/components/admin/FilterForm.svelte
+++ b/ui/user/src/lib/components/admin/FilterForm.svelte
@@ -2,6 +2,7 @@
 	import { beforeNavigate } from '$app/navigation';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { PAGE_TRANSITION_DURATION, PII_REDACT_TYPES, PII_BLOCK_TYPES } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		type MCPFilter,
@@ -27,7 +28,7 @@
 	import UvxRuntimeForm from '../mcp/UvxRuntimeForm.svelte';
 	import FilterFormTypeSelection from './FilterFormTypeSelection.svelte';
 	import SelectorsAndResourcesFormSegment from './SelectorsAndResourcesFormSegment.svelte';
-	import { Eye, EyeOff, LoaderCircle } from 'lucide-svelte';
+	import { Eye, EyeOff } from 'lucide-svelte';
 	import { onMount, untrack, type Snippet } from 'svelte';
 	import { fly } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -535,7 +536,7 @@
 		{/if}
 
 		<div
-			class="dark:bg-surface1 dark:border-surface3 bg-background rounded-lg border border-transparent p-4"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 rounded-lg border border-transparent p-4"
 		>
 			<div class="flex flex-col gap-6">
 				<div class="flex flex-col gap-2">
@@ -544,13 +545,13 @@
 						<input
 							id="filter-name"
 							bind:value={filter.name}
-							class="text-input-filled dark:bg-background mt-0.5 {nameError
-								? 'border-red-500 focus:border-red-500 focus:ring-red-500'
+							class="text-input-filled dark:bg-base-100 mt-0.5 {nameError
+								? 'border-error focus:border-error focus:ring-error'
 								: ''}"
 							disabled={readonly}
 						/>
 						{#if nameError}
-							<p class="text-xs text-red-600 dark:text-red-400">Name is required</p>
+							<p class="text-xs text-error">Name is required</p>
 						{/if}
 					</div>
 				</div>
@@ -561,7 +562,7 @@
 						<div class="w-full">
 							<Select
 								id="runtime-selector"
-								class="bg-surface1 dark:bg-surface1 dark:border-surface3 flex-1 border border-transparent shadow-inner"
+								class="bg-base-200 dark:bg-base-200 dark:border-base-400 flex-1 border border-transparent shadow-inner"
 								options={runtimeOptions}
 								bind:selected={runtimeTypeSelect}
 								onSelect={handleRuntimeChange}
@@ -575,7 +576,7 @@
 
 		{#if !runtimeFormData}
 			<div
-				class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-8 rounded-lg border border-transparent p-4 shadow-sm"
+				class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-8 rounded-lg border border-transparent p-4 shadow-sm"
 			>
 				<div class="flex flex-col gap-2">
 					<label for="webhook-url" class="flex-1 text-sm font-light capitalize">
@@ -584,14 +585,14 @@
 					<input
 						id="webhook-url"
 						bind:value={filter.url}
-						class="text-input-filled dark:bg-background mt-0.5 {urlError
-							? 'border-red-500 focus:border-red-500 focus:ring-red-500'
+						class="text-input-filled dark:bg-base-100 mt-0.5 {urlError
+							? 'border-error focus:border-error focus:ring-error'
 							: ''}"
 						required
 						disabled={readonly || isPrebuiltEntry}
 					/>
 					{#if urlError}
-						<p class="text-xs text-red-600 dark:text-red-400">Webhook URL is required</p>
+						<p class="text-xs text-error">Webhook URL is required</p>
 					{/if}
 				</div>
 
@@ -603,7 +604,7 @@
 						<input
 							id="webhook-secret"
 							bind:value={filter.secret}
-							class="text-input-filled pr-10 dark:bg-background"
+							class="text-input-filled pr-10 dark:bg-base-100"
 							type={showSecret ? 'text' : 'password'}
 							placeholder={initialFilter?.hasSecret && !filter.secret ? '*****' : ''}
 							disabled={readonly || isPrebuiltEntry}
@@ -611,7 +612,7 @@
 						{#if filter.secret || (initialFilter?.hasSecret && !filter.secret)}
 							<button
 								type="button"
-								class="absolute top-1/2 right-2 -translate-y-1/2 p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+								class="absolute top-1/2 right-2 -translate-y-1/2 p-1 text-muted-content hover:text-base-content dark:text-muted-content dark:hover:text-base-content"
 								onclick={() => (showSecret = !showSecret)}
 								use:tooltip={{
 									text: showSecret ? 'Hide secret' : 'Show secret',
@@ -639,12 +640,12 @@
 							{#if !readonly}
 								<button
 									type="button"
-									class="button-destructive shrink-0 text-xs"
+									class="btn btn-error btn-sm shrink-0"
 									disabled={removingSecret || saving || isPrebuiltEntry}
 									onclick={handleRemoveSecret}
 								>
 									{#if removingSecret}
-										<LoaderCircle class="size-3 animate-spin" />
+										<Loading class="size-3 inline-block" />
 										Removing...
 									{:else}
 										Remove Secret
@@ -653,7 +654,7 @@
 							{/if}
 						</div>
 					{:else}
-						<p class="text-on-surface1 text-xs">
+						<p class="text-muted-content text-xs">
 							A shared secret used to sign the payload for webhook verification.
 						</p>
 					{/if}
@@ -721,13 +722,13 @@
 			{/if}
 		{/if}
 
-		<div class="h-px bg-surface3 w-full my-4"></div>
+		<div class="h-px bg-base-400 w-full my-4"></div>
 
 		<SelectorsAndResourcesFormSegment bind:form={filter} {readonly} />
 	</div>
 	{#if !readonly}
 		<div
-			class="bg-surface1 dark:bg-background dark:text-on-surface1 sticky bottom-0 left-0 flex w-full justify-end gap-2 py-4 text-gray-400 z-50"
+			class="bg-base-200 dark:bg-base-100 dark:text-muted-content sticky bottom-0 left-0 flex w-full justify-end gap-2 py-4 text-gray-400 z-50"
 			out:fly={{ x: -100, duration }}
 			in:fly={{ x: -100 }}
 		>
@@ -735,10 +736,7 @@
 				<div>
 					{#if initialFilter?.id}
 						<button
-							class={twMerge(
-								'text-sm',
-								filter.disabled ? 'button-primary' : 'button-destructive py-2'
-							)}
+							class={twMerge('text-sm btn btn-soft', filter.disabled ? 'btn-primary' : 'btn-error')}
 							disabled={saving}
 							onclick={() => {
 								filter.disabled = !filter.disabled;
@@ -746,7 +744,7 @@
 							}}
 						>
 							{#if saving}
-								<LoaderCircle class="size-4 animate-spin" />
+								<Loading class="size-4" />
 							{:else}
 								{filter.disabled ? 'Enable' : 'Disable'} Filter
 							{/if}
@@ -755,7 +753,7 @@
 				</div>
 				<div class="flex gap-2">
 					<button
-						class="button text-sm"
+						class="btn btn-secondary"
 						onclick={() => {
 							if (initialFilterId) {
 								onUpdate?.(undefined);
@@ -766,9 +764,9 @@
 					>
 						Cancel
 					</button>
-					<button class="button-primary text-sm" disabled={saving} onclick={handleSave}>
+					<button class="btn btn-primary text-sm" disabled={saving} onclick={handleSave}>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Save
 						{/if}
@@ -797,11 +795,11 @@
 	{#snippet errorPostContent()}
 		{#if launchLogs.length > 0}
 			<div
-				class="default-scrollbar-thin bg-surface1 max-h-[50vh] w-full overflow-y-auto rounded-lg p-4 shadow-inner"
+				class="default-scrollbar-thin bg-base-200 max-h-[50vh] w-full overflow-y-auto rounded-lg p-4 shadow-inner"
 			>
 				{#each launchLogs as log, i (i)}
 					<div class="font-mono text-sm">
-						<span class="text-on-surface1">{log}</span>
+						<span class="text-muted-content">{log}</span>
 					</div>
 				{/each}
 			</div>
@@ -810,7 +808,9 @@
 		{/if}
 
 		<div class="flex w-full flex-col items-center gap-2 md:flex-row">
-			<button class="button w-full md:w-1/2 md:flex-1" onclick={handleCloseLaunch}>Close</button>
+			<button class="btn btn-secondary w-full md:w-1/2 md:flex-1" onclick={handleCloseLaunch}
+				>Close</button
+			>
 		</div>
 	{/snippet}
 </PageLoading>
@@ -835,16 +835,14 @@
 			<input
 				id="tool-name"
 				bind:value={filter.toolName}
-				class="text-input-filled dark:bg-background mt-0.5 {toolNameError
-					? 'border-red-500 focus:border-red-500 focus:ring-red-500'
+				class="text-input-filled dark:bg-base-100 mt-0.5 {toolNameError
+					? 'border-error focus:border-error focus:ring-error'
 					: ''}"
 				required
 				disabled={readonly || isPrebuiltEntry}
 			/>
 			{#if toolNameError}
-				<p class="text-xs text-red-600 dark:text-red-400">
-					The name of tool to be called for the filter is required.
-				</p>
+				<p class="text-xs text-error">The name of tool to be called for the filter is required.</p>
 			{/if}
 		</div>
 	</div>
@@ -852,7 +850,7 @@
 		<div class="flex items-center gap-4">
 			<Toggle
 				classes={{
-					label: 'text-sm gap-2 font-light text-on-background'
+					label: 'text-sm gap-2 font-light text-base-content'
 				}}
 				checked={filter.allowedToMutate ?? false}
 				onChange={(checked) => {
@@ -864,7 +862,7 @@
 			/>
 		</div>
 
-		<p class="text-on-surface1 text-xs font-light">
+		<p class="text-muted-content text-xs font-light">
 			Enable this if the filter tool call is allowed to mutate the response. By default, the filter
 			will only accept or reject the call based on validation.
 		</p>

--- a/ui/user/src/lib/components/admin/FilterFormTypeSelection.svelte
+++ b/ui/user/src/lib/components/admin/FilterFormTypeSelection.svelte
@@ -9,6 +9,7 @@
 	import type { MCPCatalogEntryFieldManifest } from '$lib/services';
 	import { randomUUID } from '$lib/utils';
 	import Select from '../Select.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2 } from 'lucide-svelte';
 
 	interface Props {
@@ -88,7 +89,7 @@
 				classes={{
 					root: 'w-full md:w-96'
 				}}
-				class="bg-surface1 shadow-inner! dark:bg-background dark:border-surface3 border border-transparent"
+				class="bg-base-200 shadow-inner! dark:bg-base-100 dark:border-base-400 border border-transparent"
 				options={PII_FILTER_OPTION_VALUES}
 				selected={isBlocked ? 'block' : isRedacted ? 'redact' : 'none'}
 				id={`pii-filter-type-${option.id}`}
@@ -107,7 +108,7 @@
 		<div class="w-full flex-col md:flex-row flex md:items-center md:justify-between md:gap-4 gap-1">
 			<Select
 				classes={{ root: 'flex grow' }}
-				class="bg-surface1 shadow-inner! dark:bg-background dark:border-surface3 border border-transparent"
+				class="bg-base-200 shadow-inner! dark:bg-base-100 dark:border-base-400 border border-transparent"
 				options={PII_FILTER_OPTIONAL_OPTIONS}
 				selected={option}
 				id={`pii-filter-type-${option}-selector`}
@@ -118,7 +119,7 @@
 				classes={{
 					root: 'w-full md:w-82'
 				}}
-				class="bg-surface1 shadow-inner! dark:bg-background dark:border-surface3 border border-transparent"
+				class="bg-base-200 shadow-inner! dark:bg-base-100 dark:border-base-400 border border-transparent"
 				options={PII_FILTER_OPTION_VALUES}
 				selected={isBlocked ? 'block' : isRedacted ? 'redact' : 'none'}
 				id={`pii-filter-type-${option}`}
@@ -132,22 +133,22 @@
 					}
 				}}
 			/>
-			<button
-				class="icon-button hover:text-red-500"
+			<IconButton
+				variant="danger"
 				onclick={() => {
 					if (isBlocked) removeTypeFromOneList(option, 'block');
 					else if (isRedacted) removeTypeFromOneList(option, 'mutate');
 				}}
 			>
 				<Trash2 class="size-4" />
-			</button>
+			</IconButton>
 		</div>
 	{/each}
 	{#each unassignedCustomOptions as option, i (option.id)}
 		<div class="w-full flex-col md:flex-row flex md:items-center md:justify-between md:gap-4 gap-1">
 			<Select
 				classes={{ root: 'flex grow' }}
-				class="bg-surface1 shadow-inner! dark:bg-background dark:border-surface3 border border-transparent"
+				class="bg-base-200 shadow-inner! dark:bg-base-100 dark:border-base-400 border border-transparent"
 				options={PII_FILTER_OPTIONAL_OPTIONS}
 				id={`pii-filter-type-${option.id}-selector`}
 				placeholder="Select filter type..."
@@ -161,7 +162,7 @@
 				classes={{
 					root: 'w-full md:w-82'
 				}}
-				class="bg-surface1 shadow-inner! dark:bg-background dark:border-surface3 border border-transparent"
+				class="bg-base-200 shadow-inner! dark:bg-base-100 dark:border-base-400 border border-transparent"
 				options={PII_FILTER_OPTION_VALUES}
 				selected={option.value}
 				id={`pii-filter-type-${option.id}`}
@@ -170,20 +171,20 @@
 					tryCommitUnassignedRow(i);
 				}}
 			/>
-			<button
-				class="icon-button hover:text-red-500"
+			<IconButton
+				variant="danger"
 				onclick={() => {
 					unassignedCustomOptions.splice(i, 1);
 				}}
 			>
 				<Trash2 class="size-4" />
-			</button>
+			</IconButton>
 		</div>
 	{/each}
 </div>
 <div class="flex justify-end">
 	<button
-		class="button flex items-center gap-1 text-xs"
+		class="btn btn-secondary flex items-center gap-1 btn-sm"
 		onclick={() => {
 			unassignedCustomOptions.push({ id: randomUUID(), key: '', value: 'none' });
 		}}

--- a/ui/user/src/lib/components/admin/ListModels.svelte
+++ b/ui/user/src/lib/components/admin/ListModels.svelte
@@ -6,6 +6,7 @@
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import Select from '../Select.svelte';
 	import Toggle from '../Toggle.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import { PictureInPicture2 } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -32,18 +33,17 @@
 	}));
 </script>
 
-<button
-	class="icon-button"
+<IconButton
 	onclick={() => {
 		modelsDialog?.open();
 	}}
 >
 	<PictureInPicture2 class="size-5" />
-</button>
+</IconButton>
 
 <ResponsiveDialog
 	bind:this={modelsDialog}
-	class="bg-surface1 dark:bg-background max-w-4xl"
+	class="bg-base-200 dark:bg-base-100 max-w-4xl"
 	classes={{ header: 'p-4 pb-0', content: 'p-0 pb-4' }}
 >
 	{#snippet titleContent()}
@@ -52,10 +52,10 @@
 			<img
 				src={url}
 				alt={provider.name}
-				class={twMerge('size-9 rounded-md p-1', !provider.iconDark && 'bg-gray-600')}
+				class={twMerge('size-9 rounded-md p-1', !provider.iconDark && 'bg-base-300')}
 			/>
 		{:else}
-			<img src={provider.icon} alt={provider.name} class="bg-surface1 size-9 rounded-md p-1" />
+			<img src={provider.icon} alt={provider.name} class="bg-base-200 size-9 rounded-md p-1" />
 		{/if}
 		{provider.name} Models
 	{/snippet}
@@ -73,7 +73,7 @@
 				<Table
 					data={modelsByProvider}
 					fields={['name', 'usage', 'active']}
-					classes={{ root: 'dark:bg-surface1' }}
+					classes={{ root: 'dark:bg-base-200' }}
 				>
 					{#snippet onRenderColumn(field, columnData)}
 						{#if field === 'active'}
@@ -95,7 +95,7 @@
 						{:else if field === 'usage'}
 							<Select
 								classes={{ root: 'w-full' }}
-								class="bg-surface1 dark:bg-surface2 dark:border-surface3 border border-transparent shadow-inner"
+								class="bg-base-200 dark:bg-base-200 dark:border-base-400 border border-transparent shadow-inner"
 								options={usageOptions}
 								selected={columnData.usage}
 								onSelect={(option) => {

--- a/ui/user/src/lib/components/admin/MarkdownTextEditor.svelte
+++ b/ui/user/src/lib/components/admin/MarkdownTextEditor.svelte
@@ -141,7 +141,7 @@
 ></div>
 
 <div
-	class="bg-surface1 absolute flex overflow-hidden rounded-3xl shadow-lg"
+	class="bg-base-200 absolute flex overflow-hidden rounded-3xl shadow-lg"
 	bind:this={ttDiv}
 	class:hidden={!ttVisible}
 >
@@ -274,7 +274,7 @@
 				}
 
 				& ::marker {
-					color: var(--color-gray-500);
+					color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 				}
 			}
 
@@ -294,7 +294,7 @@
 				}
 
 				& ::marker {
-					color: var(--color-gray-500);
+					color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
 				}
 			}
 
@@ -303,39 +303,39 @@
 			}
 
 			& table {
-				border: 1px solid var(--surface3);
+				border: 1px solid var(--color-base-400);
 
 				& th {
 					padding: 0.5rem 1rem;
-					border-bottom: 1px solid var(--surface3);
+					border-bottom: 1px solid var(--color-base-400);
 					&:not(:last-child) {
-						border-right: 1px solid var(--surface3);
+						border-right: 1px solid var(--color-base-400);
 					}
 				}
 
 				& td {
 					padding: 0.5rem 1rem;
 					&:not(:last-child) {
-						border-right: 1px solid var(--surface3);
+						border-right: 1px solid var(--color-base-400);
 					}
 				}
 
 				& tr:not(:last-child) {
-					border-bottom: 1px solid var(--surface3);
+					border-bottom: 1px solid var(--color-base-400);
 				}
 			}
 
 			& code {
-				background-color: var(--surface1);
+				background-color: var(--color-base-200);
 				padding: 0.25rem 0.5rem;
 				border-radius: 0.25rem;
 				font-size: 0.875rem;
 				font-weight: 500;
-				color: var(--on-surface1);
+				color: color-mix(in oklch, var(--color-base-content) 40%, transparent);
 
 				.dark & {
-					background-color: var(--surface2);
-					color: var(--on-surface2);
+					background-color: var(--color-base-200);
+					color: color-mix(in oklch, var(--color-base-content) 40%, transparent);
 				}
 			}
 		}

--- a/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
@@ -10,8 +10,9 @@
 	} from '$lib/services';
 	import { profile } from '$lib/stores';
 	import { openUrl } from '$lib/utils';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
-	import { AlertCircle, ChevronRight, Server } from 'lucide-svelte';
+	import { CircleAlert, ChevronRight, Server } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -94,7 +95,7 @@
 
 							openUrl(url, isCtrlClick);
 						}}
-						class="dark:bg-surface1 dark:border-surface3 dark:hover:bg-surface2 bg-background flex items-center justify-between gap-2 rounded-lg border border-transparent p-2 pl-4 shadow-sm hover:bg-gray-50"
+						class="dark:bg-base-200 dark:border-base-400 dark:hover:bg-base-200 bg-base-100 flex items-center justify-between gap-2 rounded-lg border border-transparent p-2 pl-4 shadow-sm hover:bg-gray-50"
 					>
 						<div class="flex items-center gap-2">
 							<div class="icon">
@@ -110,16 +111,16 @@
 							</div>
 							<p class="text-sm">{componentServer.manifest?.name}</p>
 							{#if catalogEntryServerId}
-								<span class="text-on-surface1 text-sm">({catalogEntryServerId})</span>
+								<span class="text-muted-content text-sm">({catalogEntryServerId})</span>
 							{/if}
 						</div>
-						<div class="icon-button">
+						<IconButton>
 							<ChevronRight class="size-6" />
-						</div>
+						</IconButton>
 					</button>
 				{:else}
 					<div
-						class="dark:bg-surface1 dark:border-surface3 bg-background flex items-center justify-between gap-2 rounded-lg border border-transparent p-2 pl-4 opacity-60 shadow-sm"
+						class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex items-center justify-between gap-2 rounded-lg border border-transparent p-2 pl-4 opacity-60 shadow-sm"
 					>
 						<div class="flex items-center gap-2">
 							<div class="icon">
@@ -135,10 +136,10 @@
 							</div>
 							<p class="text-sm">{componentServer.manifest?.name}</p>
 							<span
-								class="text-on-surface1 flex items-center gap-1 text-xs"
+								class="text-muted-content flex items-center gap-1 text-xs"
 								title="This component server no longer exists"
 							>
-								<AlertCircle class="size-4" />
+								<CircleAlert class="size-4" />
 								<span>Deleted</span>
 							</span>
 						</div>
@@ -165,7 +166,7 @@
 		{#snippet actions(d)}
 			{@const auditLogsUrl = getAuditLogUrl(d)}
 			{#if auditLogsUrl}
-				<a href={resolve(auditLogsUrl as `/${string}`)} class="button-text"> View Audit Logs </a>
+				<a href={resolve(auditLogsUrl as `/${string}`)} class="btn btn-link"> View Audit Logs </a>
 			{/if}
 		{/snippet}
 	</Table>

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { ADMIN_SESSION_STORAGE } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		type MCPFilter,
@@ -31,6 +31,7 @@
 	import McpServerInfo from '../mcp/McpServerInfo.svelte';
 	import McpServerTools from '../mcp/McpServerTools.svelte';
 	import StaticOAuthConfigureModal from '../mcp/StaticOAuthConfigureModal.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import { setVirtualPageDisabled } from '../ui/virtual-page/context';
 	import CatalogServerForm from './CatalogServerForm.svelte';
@@ -38,13 +39,12 @@
 	import AuditLogsPageContent from './audit-logs/AuditLogsPageContent.svelte';
 	import UsageGraphs from './usage/UsageGraphs.svelte';
 	import {
-		AlertCircle,
+		CircleAlert,
 		ChevronLeft,
 		ChevronRight,
 		GlobeLock,
 		Info,
 		ListFilter,
-		LoaderCircle,
 		Server,
 		Settings,
 		Trash2,
@@ -586,22 +586,22 @@
 				{/if}
 			</div>
 			{#if belongsToUser && !readonly}
-				<button
-					class="button-destructive flex items-center gap-1 text-xs font-normal"
-					use:tooltip={'Delete Server'}
+				<IconButton
+					variant="danger2"
+					tooltip={{ text: 'Delete Server' }}
 					onclick={() => {
 						deleteServer = true;
 					}}
 				>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 			{/if}
 		</div>
 	{/if}
 
 	{#if requiresStaticOauth}
-		<div class="flex items-center gap-3 rounded-lg border border-yellow-500 bg-yellow-500/10 p-4">
-			<Info class="size-5 flex-shrink-0 text-yellow-500" />
+		<div class="flex items-center gap-3 rounded-lg border border-warning bg-warning/10 p-4">
+			<Info class="size-5 shrink-0 text-warning" />
 			<div class="flex-1">
 				<p class="text-sm font-medium">Requires Oauth Config</p>
 				<p class="text-muted-foreground mt-1 text-xs">
@@ -610,7 +610,7 @@
 				</p>
 			</div>
 			<button
-				class="button flex items-center gap-1.5 text-sm font-normal"
+				class="btn btn-secondary flex items-center gap-1.5 font-normal"
 				onclick={handleConfigureOAuth}
 			>
 				<Settings class="size-4" />
@@ -620,53 +620,55 @@
 	{/if}
 
 	<div class="flex grow flex-col gap-2">
-		<OverflowContainer
-			class="scrollbar-none flex min-h-12 w-full items-center gap-2 overflow-x-auto"
-			style="scroll-behavior: smooth;"
-			{@attach (node: HTMLDivElement) => (scrollContainer = node)}
-		>
-			{#snippet children({ x })}
-				{#if tabs.length > 0 && (entry?.id || server?.id)}
-					{#if x}
-						<button
-							disabled={!showLeftChevron}
-							onclick={scrollLeft}
-							class="bg-surface1 dark:bg-background sticky left-0 flex aspect-square h-full items-center justify-center rounded-l-md p-2.5 opacity-100 transition-all duration-200 disabled:opacity-30"
-						>
-							<ChevronLeft class="size-full" />
-						</button>
-					{/if}
-
-					<div class="flex flex-1 gap-2 py-1 text-sm font-light">
-						{#each tabs as tab (tab.view)}
+		{#if tabs.length > 0 && (entry?.id || server?.id)}
+			<OverflowContainer
+				class="scrollbar-none flex min-h-12 w-full items-center gap-2 overflow-x-auto"
+				style="scroll-behavior: smooth;"
+				{@attach (node: HTMLDivElement) => (scrollContainer = node)}
+			>
+				{#snippet children({ x })}
+					{#if tabs.length > 0 && (entry?.id || server?.id)}
+						{#if x}
 							<button
-								onclick={() => {
-									handleSelectionChange(tab.view);
-								}}
-								class={twMerge(
-									'min-w-fit flex-1 rounded-md border border-transparent px-3 py-2 text-center whitespace-nowrap transition-colors duration-300',
-									selected === tab.view &&
-										'dark:bg-surface1 dark:border-surface3 bg-background shadow-sm',
-									selected !== tab.view && 'hover:bg-surface3'
-								)}
+								disabled={!showLeftChevron}
+								onclick={scrollLeft}
+								class="bg-base-200 dark:bg-base-100 sticky left-0 flex aspect-square h-full items-center justify-center rounded-l-md p-2.5 opacity-100 transition-all duration-200 disabled:opacity-30"
 							>
-								{tab.label}
+								<ChevronLeft class="size-full" />
 							</button>
-						{/each}
-					</div>
+						{/if}
 
-					{#if x}
-						<button
-							disabled={!showRightChevron}
-							onclick={scrollRight}
-							class="bg-surface1 dark:bg-background sticky right-0 flex aspect-square h-full items-center justify-center rounded-r-md p-2.5 opacity-100 transition-all duration-200 disabled:opacity-30"
-						>
-							<ChevronRight class="size-full" />
-						</button>
+						<div class="flex flex-1 gap-2 py-1 text-sm font-light">
+							{#each tabs as tab (tab.view)}
+								<button
+									onclick={() => {
+										handleSelectionChange(tab.view);
+									}}
+									class={twMerge(
+										'min-w-fit flex-1 rounded-md border border-transparent px-3 py-2 text-center whitespace-nowrap transition-colors duration-300',
+										selected === tab.view &&
+											'dark:bg-base-200 dark:border-base-400 bg-base-100 shadow-sm',
+										selected !== tab.view && 'hover:bg-base-400'
+									)}
+								>
+									{tab.label}
+								</button>
+							{/each}
+						</div>
+
+						{#if x}
+							<button
+								disabled={!showRightChevron}
+								onclick={scrollRight}
+								class="bg-base-200 dark:bg-base-100 sticky right-0 flex aspect-square h-full items-center justify-center rounded-r-md p-2.5 opacity-100 transition-all duration-200 disabled:opacity-30"
+							>
+								<ChevronRight class="size-full" />
+							</button>
+						{/if}
 					{/if}
-				{/if}
-			{/snippet}
-		</OverflowContainer>
+				{/snippet}
+			</OverflowContainer>
+		{/if}
 
 		{#if selected === 'overview' && entry}
 			<div class="pb-8">
@@ -692,7 +694,7 @@
 		{:else if selected === 'tools' && entry}
 			<div class="pb-8">
 				{#if showRegenerateToolsButton}
-					<button class="button-primary mb-4 text-sm" onclick={handleInitTemporaryInstance}>
+					<button class="btn btn-primary mb-4 text-sm" onclick={handleInitTemporaryInstance}>
 						Regenerate Tools & Capabilities
 					</button>
 				{/if}
@@ -702,27 +704,27 @@
 				>
 					{#snippet noToolsContent()}
 						<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-							<Wrench class="text-on-surface1 size-24 opacity-50" />
+							<Wrench class="text-muted-content size-24 opacity-50" />
 							{#if !entry || (entry && (readonly || server))}
-								<h4 class="text-on-surface1 text-lg font-semibold">No tools</h4>
-								<p class="text-on-surface1 text-sm font-light">
+								<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
+								<p class="text-muted-content text-sm font-light">
 									Looks like this MCP server doesn't have any tools available currently.
 								</p>
 							{:else if !readonly}
-								<h4 class="text-on-surface1 text-lg font-semibold">No tools</h4>
+								<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
 								<button
-									class="button-primary flex items-center gap-1 text-sm"
+									class="btn btn-primary flex items-center gap-1 text-sm"
 									onclick={handleInitTemporaryInstance}
 									disabled={saving}
 								>
 									{#if saving}
-										<LoaderCircle class="size-4 animate-spin" />
+										<Loading class="size-4" />
 									{:else}
 										Populate Tool Preview
 									{/if}
 								</button>
 								{#if !error}
-									<p class="text-on-surface1 text-sm font-light">
+									<p class="text-muted-content text-sm font-light">
 										{#if type === 'remote'}
 											Click above to connect to the remote MCP server to populate capabilities and
 											tools.
@@ -781,7 +783,7 @@
 				{#if entry && 'sourceURL' in entry && !!entry.sourceURL}
 					<p>
 						This MCP Server comes from an external Git Source URL <span
-							class="text-no-surface1 text-xs">({entry.sourceURL.split('/').pop()})</span
+							class="text-muted-content text-xs">({entry.sourceURL.split('/').pop()})</span
 						> and cannot be edited.
 					</p>
 				{:else}
@@ -795,7 +797,7 @@
 {#snippet accessControlView()}
 	{#await listAccessControlRules}
 		<div class="flex w-full justify-center">
-			<LoaderCircle class="size-6 animate-spin" />
+			<Loading class="size-6" />
 		</div>
 	{:then rules}
 		{@const serverRules = entry ? filterRulesByEntry(rules) : []}
@@ -858,9 +860,9 @@
 			</Table>
 		{:else}
 			<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-				<GlobeLock class="text-on-surface1 size-24 opacity-50" />
-				<h4 class="text-on-surface1 text-lg font-semibold">No MCP registries</h4>
-				<p class="text-on-surface1 text-sm font-light">
+				<GlobeLock class="text-muted-content size-24 opacity-50" />
+				<h4 class="text-muted-content text-lg font-semibold">No MCP registries</h4>
+				<p class="text-muted-content text-sm font-light">
 					This server is not tied to any registries.
 				</p>
 			</div>
@@ -909,14 +911,14 @@
 			>
 				{#snippet emptyContent()}
 					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-						<Users class="text-on-surface1 size-24 opacity-50" />
-						<h4 class="text-on-surface1 text-lg font-semibold">No recent audit logs</h4>
-						<p class="text-on-surface1 text-sm font-light">
+						<Users class="text-muted-content size-24 opacity-50" />
+						<h4 class="text-muted-content text-lg font-semibold">No recent audit logs</h4>
+						<p class="text-muted-content text-sm font-light">
 							This server has not had any active usage in the last 7 days.
 						</p>
 						{#if entryId || mcpCatalogEntryId}
 							{@const param = entryId ? 'mcpId=' + entryId : 'entryId=' + mcpCatalogEntryId}
-							<p class="text-on-surface1 text-sm font-light">
+							<p class="text-muted-content text-sm font-light">
 								See more usage details in the server's <a
 									href={resolve(`/admin/audit-logs?${param}`)}
 									class="text-link"
@@ -936,7 +938,7 @@
 	{#if listFilters}
 		{#await listFilters}
 			<div class="flex w-full justify-center">
-				<LoaderCircle class="size-6 animate-spin" />
+				<Loading class="size-6" />
 			</div>
 		{:then filters}
 			{@const serverFilters = entry ? filterFiltersByEntry(filters) : []}
@@ -970,9 +972,9 @@
 				</Table>
 			{:else}
 				<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-					<ListFilter class="text-on-surface1 size-24 opacity-50" />
-					<h4 class="text-on-surface1 text-lg font-semibold">No filters configured</h4>
-					<p class="text-on-surface1 text-sm font-light">
+					<ListFilter class="text-muted-content size-24 opacity-50" />
+					<h4 class="text-muted-content text-lg font-semibold">No filters configured</h4>
+					<p class="text-muted-content text-sm font-light">
 						This server is not referenced by any filters.
 					</p>
 				</div>
@@ -980,9 +982,9 @@
 		{/await}
 	{:else}
 		<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-			<ListFilter class="text-on-surface1 size-24 opacity-50" />
-			<h4 class="text-on-surface1 text-lg font-semibold">No filters available</h4>
-			<p class="text-on-surface1 text-sm font-light">
+			<ListFilter class="text-muted-content size-24 opacity-50" />
+			<h4 class="text-muted-content text-lg font-semibold">No filters available</h4>
+			<p class="text-muted-content text-sm font-light">
 				No filters have been configured in the system.
 			</p>
 		</div>
@@ -1086,18 +1088,18 @@
 	{/if}
 	{#if saving}
 		<div class="flex w-full justify-center">
-			<LoaderCircle class="size-6 animate-spin" />
+			<Loading class="size-6" />
 		</div>
 	{:else if oauthURL}
 		<!-- Single server OAuth -->
 		<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external OAuth URL -->
-		<a href={oauthURL} rel="external" target="_blank" class="button-primary text-center"
+		<a href={oauthURL} rel="external" target="_blank" class="btn btn-primary text-center"
 			>Authenticate</a
 		>
 	{:else if oauthURLs && Object.keys(oauthURLs).length > 0}
 		<!-- Composite server OAuth - multiple components -->
 		<div class="flex flex-col gap-3">
-			<p class="text-on-surface1 text-sm">
+			<p class="text-muted-content text-sm">
 				Multiple components require authentication. Please authenticate each component below:
 			</p>
 			{#each Object.entries(oauthURLs).filter(([id]) => !authenticatedComponents.has(id)) as [componentId, url] (componentId)}
@@ -1105,18 +1107,16 @@
 					(c) => c.catalogEntryID === componentId || c.mcpServerID === componentId
 				)}
 				{@const componentName = component?.manifest?.name || componentId}
-				<div
-					class="flex items-center justify-between gap-2 rounded border border-gray-200 p-3 dark:border-gray-700"
-				>
+				<div class="flex items-center justify-between gap-2 rounded border border-base-400 p-3">
 					<div class="flex items-center gap-2">
 						{#if component?.manifest?.icon}
-							<img src={component.manifest.icon} alt={componentName} class="size-6 flex-shrink-0" />
+							<img src={component.manifest.icon} alt={componentName} class="size-6 shrink-0" />
 						{/if}
 						<span class="text-sm font-medium">{componentName}</span>
 					</div>
 					<button
 						type="button"
-						class="button-primary text-sm"
+						class="btn btn-primary text-sm"
 						onclick={() => {
 							markComponentAuthenticated(componentId);
 							const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
@@ -1164,7 +1164,7 @@
 
 {#snippet errorSnippet()}
 	<div class="notification-error flex items-center gap-2">
-		<AlertCircle class="size-6 flex-shrink-0 text-red-500" />
+		<CircleAlert class="size-6 shrink-0 text-error" />
 		<p class="flex flex-col text-left text-sm font-light">
 			<span class="font-semibold">Error with launching temporary instance:</span>
 			<span>

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -2,6 +2,7 @@
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import SensitiveInput from '$lib/components/SensitiveInput.svelte';
 	import { AdminService, type MCPCatalog } from '$lib/services';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Info, TriangleAlert, X } from 'lucide-svelte';
 
 	interface Props {
@@ -54,9 +55,9 @@
 		{#if editingSource}
 			<h3 class="dialog-title">
 				{editingSource.index === -1 ? 'Add Source URL' : 'Edit Source URL'}
-				<button onclick={closeSourceDialog} class="icon-button dialog-close-btn">
+				<IconButton onclick={closeSourceDialog} class="btn-sm dialog-close-btn">
 					<X class="size-5" />
-				</button>
+				</IconButton>
 			</h3>
 
 			<div class="my-4 flex flex-col gap-1">
@@ -69,7 +70,7 @@
 							disablePortal: true
 						}}
 					>
-						<Info class="text-surface3 size-3.5" />
+						<Info class="text-muted-content size-3.5" />
 					</span>
 				</label>
 				<input
@@ -90,12 +91,12 @@
 								disablePortal: true
 							}}
 						>
-							<Info class="text-surface3 size-3.5" />
+							<Info class="text-base-content size-3.5" />
 						</span>
 					</label>
 					{#if editingSource.index >= 0 && defaultCatalog?.sourceURLCredentials?.[defaultCatalog?.sourceURLs?.[editingSource.index]] === '*' && !editingSource.clearToken}
 						<button
-							class="text-xs text-red-500 hover:underline dark:text-red-400"
+							class="text-xs text-error hover:underline"
 							onclick={() => {
 								if (editingSource) editingSource.clearToken = true;
 							}}
@@ -105,7 +106,7 @@
 					{/if}
 				</div>
 				{#if editingSource.clearToken}
-					<p class="text-surface3 text-xs">Token will be removed on save.</p>
+					<p class="text-muted-content text-xs">Token will be removed on save.</p>
 				{:else}
 					<SensitiveInput
 						name="catalog-source-token"
@@ -121,7 +122,7 @@
 			</div>
 
 			{#if sourceError}
-				<div class="mb-4 flex flex-col gap-2 text-red-500 dark:text-red-400">
+				<div class="mb-4 flex flex-col gap-2 text-error">
 					<div class="flex items-center gap-2">
 						<TriangleAlert class="size-6 shrink-0 self-start" />
 						<p class="my-0.5 flex flex-col text-sm font-semibold">Error adding source URL:</p>
@@ -131,9 +132,11 @@
 			{/if}
 
 			<div class="flex w-full justify-end gap-2">
-				<button class="button" disabled={saving} onclick={closeSourceDialog}>Cancel</button>
+				<button class="btn btn-secondary" disabled={saving} onclick={closeSourceDialog}
+					>Cancel</button
+				>
 				<button
-					class="button-primary"
+					class="btn btn-primary"
 					disabled={saving}
 					onclick={async () => {
 						if (!editingSource || (!defaultCatalog && !defaultCatalogId)) {

--- a/ui/user/src/lib/components/admin/McpServerInstances.svelte
+++ b/ui/user/src/lib/components/admin/McpServerInstances.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { ADMIN_SESSION_STORAGE } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		ChatService,
@@ -25,7 +26,6 @@
 		CircleFadingArrowUp,
 		Ellipsis,
 		GitCompare,
-		LoaderCircle,
 		Router,
 		Square,
 		SquareCheck
@@ -213,7 +213,7 @@
 
 {#if loading}
 	<div class="flex w-full justify-center">
-		<LoaderCircle class="size-6 animate-spin" />
+		<Loading class="size-6" />
 	</div>
 {:else if entry && !('isCatalogEntry' in entry) && id}
 	{#if entry && (type === 'multi' || instances.length > 0)}
@@ -246,7 +246,7 @@
 	{#if servers.length > 0}
 		{#if numServerUpdatesNeeded}
 			<button
-				class="group bg-background mb-2 w-fit rounded-md"
+				class="group bg-base-100 mb-2 w-fit rounded-md"
 				onclick={() => {
 					// TODO: show all servers with upgrade & update all option
 				}}
@@ -296,7 +296,7 @@
 							<div
 								use:tooltip={{
 									text: 'This server needs an update. View Diff to see the changes.',
-									classes: ['break-words', 'w-58']
+									classes: ['wrap-break-word', 'w-58']
 								}}
 							>
 								<CircleFadingArrowUp class="text-primary size-4" />
@@ -311,7 +311,7 @@
 								<div
 									use:tooltip={{
 										text: 'This server needs an update. View Diff to see the changes.',
-										classes: ['break-words', 'w-58']
+										classes: ['wrap-break-word', 'w-58']
 									}}
 								>
 									<CircleFadingArrowUp class="text-primary size-4" />
@@ -328,15 +328,15 @@
 
 			{#snippet actions(d)}
 				{@const auditLogsUrl = getAuditLogUrl(d)}
-				<div class="flex flex-shrink-0 items-center gap-1">
+				<div class="flex shrink-0 items-center gap-1">
 					{#if auditLogsUrl}
-						<a class="button-text" href={resolve(auditLogsUrl as `/${string}`)}>
+						<a class="btn btn-link" href={resolve(auditLogsUrl as `/${string}`)}>
 							View Audit Logs
 						</a>
 					{/if}
 
 					{#if d.needsUpdate}
-						<DotDotDot class="icon-button hover:dark:bg-background/50">
+						<DotDotDot class="hover:dark:bg-base-100/50">
 							{#snippet icon()}
 								<Ellipsis class="size-4" />
 							{/snippet}
@@ -369,7 +369,7 @@
 									: undefined}
 							>
 								{#if updating[d.id]?.inProgress}
-									<LoaderCircle class="size-4 animate-spin" />
+									<Loading class="size-4" />
 								{:else}
 									<CircleFadingArrowUp class="size-4" />
 								{/if}
@@ -377,7 +377,7 @@
 							</button>
 						</DotDotDot>
 						<button
-							class="icon-button hover:bg-black/50"
+							class="hover:bg-black/50"
 							onclick={(e) => {
 								e.stopPropagation();
 								if (selected[d.id]) {
@@ -405,7 +405,7 @@
 			{@const numSelected = Object.keys(selected).length}
 			{@const updatingInProgress = Object.values(updating).some((u) => u.inProgress)}
 			<div
-				class="bg-surface1 dark:bg-background sticky bottom-0 left-0 mt-auto flex w-[calc(100%+2em)] -translate-x-4 justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
+				class="bg-base-200 dark:bg-base-100 sticky bottom-0 left-0 mt-auto flex w-[calc(100%+2em)] -translate-x-4 justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
 			>
 				<div class="flex w-full items-center justify-between">
 					<p class="text-sm font-medium">
@@ -413,7 +413,7 @@
 					</p>
 					<div class="flex items-center gap-4">
 						<button
-							class="button flex items-center gap-1"
+							class="btn btn-secondary flex items-center gap-1"
 							onclick={() => {
 								selected = {};
 								updating = {};
@@ -422,7 +422,7 @@
 							Cancel
 						</button>
 						<button
-							class="button-primary flex items-center gap-1"
+							class="btn btn-primary flex items-center gap-1"
 							onclick={() => {
 								showConfirm = {
 									type: 'multi'
@@ -431,7 +431,7 @@
 							disabled={updatingInProgress}
 						>
 							{#if updatingInProgress}
-								<LoaderCircle class="size-5" />
+								<Loading class="size-5" />
 							{:else}
 								Update Servers
 							{/if}
@@ -449,9 +449,9 @@
 
 {#snippet emptyInstancesContent()}
 	<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-		<Router class="text-on-surface1 size-24 opacity-50" />
-		<h4 class="text-on-surface1 text-lg font-semibold">No server details</h4>
-		<p class="text-on-surface1 text-sm font-light">No details available yet for this server.</p>
+		<Router class="text-muted-content size-24 opacity-50" />
+		<h4 class="text-muted-content text-lg font-semibold">No server details</h4>
+		<p class="text-muted-content text-sm font-light">No details available yet for this server.</p>
 	</div>
 {/snippet}
 

--- a/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		ChatService,
@@ -21,14 +22,7 @@
 	import SensitiveInput from '../SensitiveInput.svelte';
 	import Table from '../table/Table.svelte';
 	import DeploymentLogs from './DeploymentLogs.svelte';
-	import {
-		AlertTriangle,
-		Info,
-		LoaderCircle,
-		RotateCcw,
-		RefreshCw,
-		CircleFadingArrowUp
-	} from 'lucide-svelte';
+	import { TriangleAlert, Info, RotateCcw, RefreshCw, CircleFadingArrowUp } from 'lucide-svelte';
 	import { onDestroy, onMount } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -449,7 +443,7 @@
 	{#if hasAdminAccess}
 		<button
 			onclick={handleRefreshEvents}
-			class="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+			class="rounded-md p-1 text-muted-content hover:bg-base-200 hover:text-base-content disabled:opacity-50 dark:text-muted-content dark:hover:bg-base-200 dark:hover:text-base-content"
 			disabled={refreshingEvents}
 		>
 			<RefreshCw class="size-4 {refreshingEvents ? 'animate-spin' : ''}" />
@@ -473,7 +467,7 @@
 	<div class="notification-alert">
 		<div class="flex grow flex-col gap-2">
 			<div class="flex items-center gap-2">
-				<AlertTriangle class="size-6 flex-shrink-0 self-start text-yellow-500" />
+				<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
 				<p class="my-0.5 flex flex-col text-sm font-semibold">
 					Missing Kubernetes Secret{missingSecretBindings.length > 1 ? 's' : ''}
 				</p>
@@ -496,7 +490,7 @@
 {#await listK8sInfo}
 	{#if hasAdminAccess}
 		<div class="flex w-full justify-center">
-			<LoaderCircle class="size-6 animate-spin" />
+			<Loading class="size-6" />
 		</div>
 	{/if}
 {:then info}
@@ -514,7 +508,7 @@
 		{#if hasAdminAccess}
 			{#await revealServerValues}
 				<div class="flex w-full justify-center">
-					<LoaderCircle class="size-6 animate-spin" />
+					<Loading class="size-6" />
 				</div>
 			{:then revealedValues}
 				{@const { headers, envs } = compileRevealedValues(revealedValues, catalogEntry)}
@@ -528,7 +522,7 @@
 								{/each}
 							</div>
 						{:else}
-							<span class="text-on-surface1 text-sm font-light">No configured headers.</span>
+							<span class="text-muted-content text-sm font-light">No configured headers.</span>
 						{/if}
 					</div>
 				{/if}
@@ -549,7 +543,7 @@
 							{/each}
 						</div>
 					{:else}
-						<span class="text-on-surface1 text-sm font-light"
+						<span class="text-muted-content text-sm font-light"
 							>No configured environment or file variables set.</span
 						>
 					{/if}
@@ -578,7 +572,7 @@
 					{/snippet}
 				</Table>
 			{:else}
-				<span class="text-on-surface1 text-sm font-light">No events.</span>
+				<span class="text-muted-content text-sm font-light">No events.</span>
 			{/if}
 		</div>
 	{/if}
@@ -590,7 +584,7 @@
 		<div class="notification-alert">
 			<div class="flex grow flex-col gap-2">
 				<div class="flex items-center gap-2">
-					<AlertTriangle class="size-6 flex-shrink-0 self-start text-yellow-500" />
+					<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
 					<p class="my-0.5 flex flex-col text-sm font-semibold">
 						User Configuration Update Required
 					</p>
@@ -606,7 +600,7 @@
 	{#if hasAdminAccess}
 		<div class="flex flex-col gap-2">
 			<div
-				class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col rounded-lg border border-transparent p-4 shadow-sm"
+				class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col rounded-lg border border-transparent p-4 shadow-sm"
 			>
 				<div class="grid grid-cols-2 gap-4">
 					<p class="text-sm font-semibold">Status</p>
@@ -649,7 +643,7 @@
 			{#snippet actions(d)}
 				{@const auditLogsUrl = getAuditLogUrl(d)}
 				{#if auditLogsUrl}
-					<a href={resolve(auditLogsUrl as `/${string}`)} class="button-text"> View Audit Logs </a>
+					<a href={resolve(auditLogsUrl as `/${string}`)} class="btn btn-link"> View Audit Logs </a>
 				{/if}
 			{/snippet}
 		</Table>
@@ -658,7 +652,7 @@
 
 {#snippet detailRow(label: string, value: string, id: string)}
 	<div
-		class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col rounded-lg border border-transparent p-4 shadow-sm"
+		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col rounded-lg border border-transparent p-4 shadow-sm"
 	>
 		<div class="grid grid-cols-12 gap-4">
 			<p class="col-span-4 text-sm font-semibold">{label}</p>
@@ -667,7 +661,7 @@
 				{#if id === 'status' && !readonly}
 					<button
 						onclick={() => (showRestartConfirm = true)}
-						class="button-primary flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"
+						class="btn btn-primary flex items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium text-white disabled:opacity-50"
 						disabled={restarting}
 					>
 						<RotateCcw class="size-3" />
@@ -676,12 +670,12 @@
 				{:else if id === 'kubernetes_deployments' && !readonly}
 					{#await listK8sSettingsStatus}
 						<div class="flex w-full justify-center">
-							<LoaderCircle class="size-6 animate-spin" />
+							<Loading class="size-6" />
 						</div>
 					{:then k8sSettingsStatus}
 						{#if k8sSettingsStatus?.needsK8sUpdate || mcpServer?.needsK8sUpdate}
 							<button
-								class="flex items-center gap-2 rounded-md bg-yellow-500/75 px-3 py-1.5 text-xs font-medium text-white hover:bg-yellow-500 disabled:opacity-50"
+								class="flex items-center gap-2 rounded-md bg-warning/75 px-3 py-1.5 text-xs font-medium text-warning-content hover:bg-warning disabled:opacity-50"
 								disabled={readonly}
 								onclick={() => (showUpdateK8sSettingsConfirm = true)}
 							>
@@ -705,13 +699,13 @@
 	dynamicFile?: boolean
 )}
 	<div
-		class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col rounded-lg border border-transparent px-4 py-1.5 shadow-sm"
+		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col rounded-lg border border-transparent px-4 py-1.5 shadow-sm"
 	>
 		<div class="grid grid-cols-12 items-center gap-4">
 			<p class="col-span-4 text-sm font-semibold">{label}</p>
 			<div class="col-span-8 flex items-center justify-between">
 				{#if secretBinding}
-					<span class="text-on-surface1 flex flex-wrap items-center gap-2 text-sm">
+					<span class="text-muted-content flex flex-wrap items-center gap-2 text-sm">
 						<span>
 							Kubernetes Secret: <code class="font-mono">{secretBinding.name}</code> /
 							<code class="font-mono">{secretBinding.key}</code>

--- a/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import {
 		type MessagePolicy,
@@ -15,9 +16,10 @@
 	import { getUserDisplayName } from '$lib/utils';
 	import Confirm from '../Confirm.svelte';
 	import Select from '../Select.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import SearchUsers from './SearchUsers.svelte';
-	import { CircleHelp, LoaderCircle, Plus, Trash2 } from 'lucide-svelte';
+	import { CircleQuestionMark, Plus, Trash2 } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -186,21 +188,21 @@
 					</h1>
 				</div>
 				{#if !readonly}
-					<button
-						class="button-destructive flex items-center gap-1 text-xs font-normal"
-						use:tooltip={'Delete Policy'}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete Policy' }}
 						onclick={() => {
 							deletingPolicy = true;
 						}}
 					>
 						<Trash2 class="size-4" />
-					</button>
+					</IconButton>
 				{/if}
 			</div>
 		{/if}
 
 		<div
-			class="dark:bg-surface2 dark:border-surface3 bg-background rounded-lg border border-transparent p-4"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 rounded-lg border border-transparent p-4"
 		>
 			<div class="flex flex-col gap-6">
 				{#if !messagePolicy.id}
@@ -229,7 +231,7 @@
 								classes: ['w-72', 'break-normal', 'whitespace-pre-wrap', 'z-[60]']
 							}}
 						>
-							<CircleHelp class="text-on-surface1 size-3.5" />
+							<CircleQuestionMark class="text-muted-content size-3.5" />
 						</div>
 					</label>
 					<textarea
@@ -266,12 +268,12 @@
 				{#if !readonly}
 					<div class="relative flex items-center gap-4">
 						{#if loadingUsersAndGroups}
-							<button class="button-primary flex items-center gap-1 text-sm" disabled>
+							<button class="btn btn-primary flex items-center gap-1 text-sm" disabled>
 								<Plus class="size-4" /> Add User/Group
 							</button>
 						{:else}
 							<button
-								class="button-primary flex items-center gap-1 text-sm"
+								class="btn btn-primary flex items-center gap-1 text-sm"
 								onclick={() => {
 									addUserGroupDialog?.open();
 								}}
@@ -284,7 +286,7 @@
 			</div>
 			{#if loadingUsersAndGroups}
 				<div class="my-2 flex items-center justify-center">
-					<LoaderCircle class="size-6 animate-spin" />
+					<Loading class="size-6" />
 				</div>
 			{:else}
 				{@const tableData = convertSubjectsToTableData(
@@ -300,17 +302,17 @@
 				>
 					{#snippet actions(d)}
 						{#if !readonly}
-							<button
-								class="icon-button hover:text-red-500"
+							<IconButton
+								variant="danger"
 								onclick={() => {
 									messagePolicy.subjects = messagePolicy.subjects?.filter(
 										(subject) => subject.id !== d.id
 									);
 								}}
-								use:tooltip={'Delete User/Group'}
+								tooltip={{ text: 'Delete User/Group' }}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					{/snippet}
 				</Table>
@@ -319,14 +321,14 @@
 	</div>
 	{#if !readonly}
 		<div
-			class="bg-surface1 text-on-surface1 dark:bg-background sticky bottom-0 left-0 z-50 flex w-full justify-end gap-2 py-4"
+			class="bg-base-200 text-muted-content dark:bg-base-100 sticky bottom-0 left-0 z-50 flex w-full justify-end gap-2 py-4"
 			out:fly={{ x: -100, duration }}
 			in:fly={{ x: -100 }}
 		>
 			<div class="flex w-full justify-end gap-2">
 				{#if !messagePolicy.id}
 					<button
-						class="button text-sm"
+						class="btn btn-secondary text-sm"
 						onclick={() => {
 							goto('/admin/message-policies');
 						}}
@@ -334,7 +336,7 @@
 						Cancel
 					</button>
 					<button
-						class="button-primary text-sm"
+						class="btn btn-primary text-sm"
 						disabled={!validate(messagePolicy) || saving}
 						onclick={async () => {
 							saving = true;
@@ -348,14 +350,14 @@
 						}}
 					>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Save
 						{/if}
 					</button>
 				{:else}
 					<button
-						class="button-primary text-sm"
+						class="btn btn-primary text-sm"
 						disabled={!validate(messagePolicy) || !hasChanges || saving}
 						onclick={async () => {
 							if (!messagePolicy.id) return;
@@ -373,7 +375,7 @@
 						}}
 					>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Update
 						{/if}

--- a/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import {
 		type ModelAccessPolicy,
@@ -18,10 +18,11 @@
 	import { goto } from '$lib/url';
 	import { getUserDisplayName } from '$lib/utils';
 	import Confirm from '../Confirm.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import SearchModels from './SearchModels.svelte';
 	import SearchUsers from './SearchUsers.svelte';
-	import { LoaderCircle, Plus, Trash2 } from 'lucide-svelte';
+	import { Plus, Trash2 } from 'lucide-svelte';
 	import { onMount, untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -298,22 +299,22 @@
 					</h1>
 				</div>
 				{#if !readonly}
-					<button
-						class="button-destructive flex items-center gap-1 text-xs font-normal"
-						use:tooltip={'Delete Policy'}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete Policy' }}
 						onclick={() => {
 							deletingPolicy = true;
 						}}
 					>
 						<Trash2 class="size-4" />
-					</button>
+					</IconButton>
 				{/if}
 			</div>
 		{/if}
 
 		{#if !modelAccessPolicy.id}
 			<div
-				class="dark:bg-surface2 dark:border-surface3 bg-background rounded-lg border border-transparent p-4"
+				class="dark:bg-base-200 dark:border-base-400 bg-base-100 rounded-lg border border-transparent p-4"
 			>
 				<div class="flex flex-col gap-6">
 					<div class="flex flex-col gap-2">
@@ -337,12 +338,12 @@
 				{#if !readonly}
 					<div class="relative flex items-center gap-4">
 						{#if loadingUsersAndGroups}
-							<button class="button-primary flex items-center gap-1 text-sm" disabled>
+							<button class="btn btn-primary flex items-center gap-1 text-sm" disabled>
 								<Plus class="size-4" /> Add User/Group
 							</button>
 						{:else}
 							<button
-								class="button-primary flex items-center gap-1 text-sm"
+								class="btn btn-primary flex items-center gap-1 text-sm"
 								onclick={() => {
 									addUserGroupDialog?.open();
 								}}
@@ -355,7 +356,7 @@
 			</div>
 			{#if loadingUsersAndGroups}
 				<div class="my-2 flex items-center justify-center">
-					<LoaderCircle class="size-6 animate-spin" />
+					<Loading class="size-6" />
 				</div>
 			{:else}
 				{@const tableData = convertSubjectsToTableData(
@@ -371,17 +372,17 @@
 				>
 					{#snippet actions(d)}
 						{#if !readonly}
-							<button
-								class="icon-button hover:text-red-500"
+							<IconButton
+								variant="danger"
 								onclick={() => {
 									modelAccessPolicy.subjects = modelAccessPolicy.subjects?.filter(
 										(subject) => subject.id !== d.id
 									);
 								}}
-								use:tooltip={'Delete User/Group'}
+								tooltip={{ text: 'Delete User/Group' }}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					{/snippet}
 				</Table>
@@ -393,7 +394,7 @@
 				<h2 class="text-lg font-semibold">Models</h2>
 				{#if !readonly}
 					<button
-						class="button-primary flex items-center gap-1 text-sm"
+						class="btn btn-primary flex items-center gap-1 text-sm"
 						onclick={() => {
 							addModelDialog?.open();
 						}}
@@ -404,7 +405,7 @@
 			</div>
 			{#if loadingModels}
 				<div class="my-2 flex items-center justify-center">
-					<LoaderCircle class="size-6 animate-spin" />
+					<Loading class="size-6" />
 				</div>
 			{:else}
 				<Table
@@ -422,17 +423,17 @@
 								<div class="flex flex-col">
 									<div class="flex items-center gap-2">
 										<span class="font-medium">{d.aliasName}</span>
-										<span class="text-on-surface1 text-xs" class:text-yellow-500={!d.isConfigured}>
+										<span class="text-muted-content text-xs" class:text-warning={!d.isConfigured}>
 											{d.effectiveModel}
 										</span>
 									</div>
-									<span class="text-on-surface1 text-xs">{d.name}</span>
+									<span class="text-muted-content text-xs">{d.name}</span>
 								</div>
 							{:else}
 								<div class="flex flex-col">
 									<span class="font-medium">{d.name}</span>
 									{#if d.usage}
-										<span class="text-on-surface1 text-xs">
+										<span class="text-muted-content text-xs">
 											{ModelUsageLabels[d.usage as ModelUsage] || d.usage}
 										</span>
 									{/if}
@@ -444,16 +445,16 @@
 					{/snippet}
 					{#snippet actions(d)}
 						{#if !readonly}
-							<button
-								class="icon-button hover:text-red-500"
+							<IconButton
+								variant="danger"
 								onclick={() => {
 									modelAccessPolicy.models =
 										modelAccessPolicy.models?.filter((m) => m.id !== d.id) ?? [];
 								}}
-								use:tooltip={'Remove Model'}
+								tooltip={{ text: 'Remove Model' }}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					{/snippet}
 				</Table>
@@ -462,14 +463,14 @@
 	</div>
 	{#if !readonly}
 		<div
-			class="bg-surface1 text-on-surface1 dark:bg-background sticky bottom-0 left-0 flex w-full justify-end gap-2 py-4"
+			class="bg-base-200 text-muted-content dark:bg-base-100 sticky bottom-0 left-0 flex w-full justify-end gap-2 py-4"
 			out:fly={{ x: -100, duration }}
 			in:fly={{ x: -100 }}
 		>
 			<div class="flex w-full justify-end gap-2">
 				{#if !modelAccessPolicy.id}
 					<button
-						class="button text-sm"
+						class="btn btn-secondary text-sm"
 						onclick={() => {
 							goto('/admin/model-access-policies');
 						}}
@@ -477,7 +478,7 @@
 						Cancel
 					</button>
 					<button
-						class="button-primary text-sm"
+						class="btn btn-primary text-sm"
 						disabled={!validate(modelAccessPolicy) || saving}
 						onclick={async () => {
 							saving = true;
@@ -491,14 +492,14 @@
 						}}
 					>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Save
 						{/if}
 					</button>
 				{:else}
 					<button
-						class="button-primary text-sm"
+						class="btn btn-primary text-sm"
 						disabled={!validate(modelAccessPolicy) || !hasChanges || saving}
 						onclick={async () => {
 							if (!modelAccessPolicy.id) return;
@@ -516,7 +517,7 @@
 						}}
 					>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Update
 						{/if}

--- a/ui/user/src/lib/components/admin/ProviderCard.svelte
+++ b/ui/user/src/lib/components/admin/ProviderCard.svelte
@@ -36,7 +36,7 @@
 
 <div
 	class={twMerge(
-		'dark:bg-surface1 dark:border-surface3 bg-background flex w-full flex-col items-center justify-center gap-4 rounded-lg border border-transparent p-4 pt-2 shadow-sm',
+		'dark:bg-base-200 dark:border-base-400 bg-base-100 flex w-full flex-col items-center justify-center gap-4 rounded-lg border border-transparent p-4 pt-2 shadow-sm',
 		isComingSoon && 'opacity-50'
 	)}
 >
@@ -49,9 +49,9 @@
 			{/if}
 			{#if experimental}
 				<span
-					class="bg-yellow-500/15 text-yellow-500 rounded-md px-2 py-1 text-[10px] font-medium flex items-center gap-1"
+					class="bg-warning/15 text-warning rounded-md px-2 py-1 text-[10px] font-medium flex items-center gap-1"
 				>
-					<FlaskConicalIcon class="size-3 text-yellow-500" /> Experimental
+					<FlaskConicalIcon class="size-3 text-warning" /> Experimental
 				</span>
 			{/if}
 		</div>
@@ -64,7 +64,7 @@
 				<DotDotDot>
 					<button
 						disabled={readonly}
-						class="menu-button text-red-500"
+						class="menu-button text-error"
 						onclick={() => onDeconfigure()}
 					>
 						Deconfigure Provider
@@ -78,17 +78,17 @@
 		<img
 			src={url}
 			alt={provider.name}
-			class={twMerge('size-16 rounded-md p-1', !provider.iconDark && 'bg-gray-600')}
+			class={twMerge('size-16 rounded-md p-1', !provider.iconDark && 'bg-base-400')}
 		/>
 	{:else}
 		<img src={provider.icon} alt={provider.name} class="size-16 rounded-md p-1" />
 	{/if}
 	<h4 class="text-center text-lg font-semibold">{provider.name}</h4>
-	<div class="border-surface2 rounded-md border px-2 py-1">
+	<div class="border-base-400 rounded-md border px-2 py-1">
 		<span class="flex items-center gap-2 text-xs font-light">
 			{#if deprecated}
 				<div
-					class="rounded-md bg-yellow-500 px-2 py-1 text-[10px] font-medium"
+					class="rounded-md bg-warning px-2 py-1 text-[10px] font-medium"
 					use:tooltip={{
 						classes: ['w-fit'],
 						text: 'Deprecated – use Amazon Bedrock instead.'
@@ -98,9 +98,9 @@
 				</div>
 			{/if}
 			{#if provider.configured}
-				<CircleCheck class="size-4 text-green-500" /> Configured
+				<CircleCheck class="size-4 text-success" /> Configured
 			{:else}
-				<CircleSlash class="size-4 text-red-500" /> Not Configured
+				<CircleSlash class="size-4 text-error" /> Not Configured
 			{/if}
 		</span>
 	</div>
@@ -108,7 +108,7 @@
 	<div class="mt-auto w-full">
 		{#if isComingSoon}
 			<div
-				class="bg-surface1 dark:bg-surface2/50 text-on-surface1 flex items-center justify-center gap-1 rounded-xs px-4 py-2 text-sm"
+				class="bg-base-200 dark:bg-base-400 text-muted-content flex items-center justify-center gap-1 rounded-xs px-4 py-2 text-sm"
 			>
 				<Construction class="size-4" /> Coming Soon
 			</div>
@@ -116,8 +116,8 @@
 			<button
 				onclick={onConfigure}
 				class={twMerge(
-					'w-full border-0 text-sm',
-					provider.configured ? 'button' : 'button-primary'
+					'w-full border-0 text-sm btn',
+					provider.configured ? 'btn-secondary' : 'btn-primary'
 				)}
 				disabled={disableConfigure}
 			>

--- a/ui/user/src/lib/components/admin/ProviderConfigure.svelte
+++ b/ui/user/src/lib/components/admin/ProviderConfigure.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import Toggle from '$lib/components/Toggle.svelte';
 	import { MultiValueInput } from '$lib/components/ui/multi-value-input';
+	import Loading from '$lib/icons/Loading.svelte';
 	import type { BaseProvider, ProviderParameter } from '$lib/services/admin/types';
 	import { darkMode, profile } from '$lib/stores';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import SensitiveInput from '../SensitiveInput.svelte';
-	import { AlertCircle, LoaderCircle } from 'lucide-svelte';
+	import { CircleAlert } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -271,10 +272,10 @@
 				<img
 					src={url}
 					alt={provider?.name}
-					class={twMerge('size-9 rounded-md p-1', !provider?.iconDark && 'bg-gray-600')}
+					class={twMerge('size-9 rounded-md p-1', !provider?.iconDark && 'bg-base-300')}
 				/>
 			{:else}
-				<img src={provider?.icon} alt={provider?.name} class="bg-surface1 size-9 rounded-md p-1" />
+				<img src={provider?.icon} alt={provider?.name} class="bg-base-200 size-9 rounded-md p-1" />
 			{/if}
 			Set Up {provider?.name}
 		</div>
@@ -294,10 +295,10 @@
 			/>
 			{#if error}
 				<div class="notification-error flex min-w-0 items-start gap-2 overflow-hidden">
-					<AlertCircle class="mt-0.5 size-6 shrink-0 text-red-500" />
+					<CircleAlert class="mt-0.5 size-6 shrink-0 text-error" />
 					<p class="min-w-0 flex flex-col text-sm font-light">
 						<span class="font-semibold">An error occurred!</span>
-						<span class="max-h-28 overflow-auto break-words pr-1">
+						<span class="max-h-28 overflow-auto wrap-break-word pr-1">
 							Your configuration could not be saved because it failed validation: <b
 								class="break-all font-semibold">{error}</b
 							>
@@ -320,7 +321,7 @@
 									<li>
 										<button
 											class={twMerge(
-												'bg-surface1 hover:bg-surface2 text-gray rounded-md px-4 py-2 text-sm font-medium transition-all duration-200',
+												'bg-base-200 hover:bg-base-400 text-gray rounded-md px-4 py-2 text-sm font-medium transition-all duration-200',
 												isSelected &&
 													'bg-primary hover:bg-primary/90 active:bg-primary text-white shadow-sm'
 											)}
@@ -347,7 +348,7 @@
 									{@render booleanToggle(parameter)}
 								{:else}
 									<li class="flex flex-col gap-1">
-										<label for={parameter.name} class:text-red-500={error}
+										<label for={parameter.name} class:text-error={error}
 											>{parameter.friendlyName}</label
 										>
 										{#if parameter.description}
@@ -457,9 +458,14 @@
 		</form>
 		{#if !readonly}
 			<div class="mt-4 flex justify-end gap-2 p-4 pt-0">
-				<button class="button-primary" type="button" onclick={() => configure()} disabled={loading}>
+				<button
+					class="btn btn-primary"
+					type="button"
+					onclick={() => configure()}
+					disabled={loading}
+				>
 					{#if loading}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 					{:else}
 						Confirm
 					{/if}

--- a/ui/user/src/lib/components/admin/SearchMcpServers.svelte
+++ b/ui/user/src/lib/components/admin/SearchMcpServers.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { ADMIN_ALL_OPTION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
 	import {
 		AdminService,
@@ -10,7 +11,7 @@
 	import { getUserDisplayName } from '$lib/utils';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import Search from '../Search.svelte';
-	import { Check, LoaderCircle, Server } from 'lucide-svelte';
+	import { Check, Server } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -176,12 +177,12 @@
 		<div class="flex flex-col gap-2">
 			{#if loading}
 				<div class="flex items-center justify-center">
-					<LoaderCircle class="size-6 animate-spin" />
+					<Loading class="size-6" />
 				</div>
 			{:else}
 				<div class="px-4">
 					<Search
-						class="dark:bg-surface1 dark:border-surface3 shadow-inner dark:border"
+						class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
 						onChange={(val) => (search = val)}
 						value={search}
 						placeholder="Search by name..."
@@ -192,8 +193,8 @@
 					{#each filteredData as item (item.id)}
 						<button
 							class={twMerge(
-								'dark:hover:bg-surface1 hover:bg-surface2 flex w-full items-center gap-2 px-4 py-2 text-left',
-								selectedMap.has(item.id) && 'dark:bg-gray-920 bg-gray-50'
+								'dark:hover:bg-base-200 hover:bg-base-400 flex w-full items-center gap-2 px-4 py-2 text-left',
+								selectedMap.has(item.id) && 'bg-base-200/50'
 							)}
 							onclick={() => {
 								if (singleSelect) {
@@ -215,21 +216,21 @@
 							<div class="flex w-full items-center gap-2 overflow-hidden">
 								<div class="icon">
 									{#if item.icon}
-										<img src={item.icon} alt={item.name} class="size-8 flex-shrink-0" />
+										<img src={item.icon} alt={item.name} class="size-8 shrink-0" />
 									{:else}
-										<Server class="size-8 flex-shrink-0" />
+										<Server class="size-8 shrink-0" />
 									{/if}
 								</div>
 								<div class="flex min-w-0 grow flex-col">
 									<div class="flex items-center gap-2">
 										<p class="truncate">{item.name}</p>
 										{#if item.registry}
-											<div class="dark:bg-surface2 bg-surface3 rounded-full px-3 py-1 text-[10px]">
+											<div class="dark:bg-base-400 bg-base-300 rounded-full px-3 py-1 text-[10px]">
 												{item.registry}
 											</div>
 										{/if}
 									</div>
-									<span class="text-on-surface1 line-clamp-2 text-xs">
+									<span class="text-muted-content line-clamp-2 text-xs">
 										{stripMarkdownToText(item.description ?? '')}
 									</span>
 								</div>
@@ -254,10 +255,13 @@
 				{/if}
 			</div>
 			<div class="flex items-center gap-2">
-				<button class="button w-full md:w-fit" onclick={() => addMcpServerDialog?.close()}>
+				<button
+					class="btn btn-secondary w-full md:w-fit"
+					onclick={() => addMcpServerDialog?.close()}
+				>
 					Cancel
 				</button>
-				<button class="button-primary w-full md:w-fit" onclick={handleAdd}> Confirm </button>
+				<button class="btn btn-primary w-full md:w-fit" onclick={handleAdd}> Confirm </button>
 			</div>
 		{/if}
 	</div>

--- a/ui/user/src/lib/components/admin/SearchModels.svelte
+++ b/ui/user/src/lib/components/admin/SearchModels.svelte
@@ -156,7 +156,7 @@
 		<div class="flex flex-col gap-2">
 			<div class="px-4">
 				<Search
-					class="dark:bg-surface1 dark:border-surface3 shadow-inner dark:border"
+					class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
 					onChange={(val) => (search = val)}
 					value={search}
 					placeholder="Search models..."
@@ -167,16 +167,16 @@
 				{#if wildcardAvailable}
 					<button
 						class={twMerge(
-							'hover:bg-surface3 dark:hover:bg-surface1 flex items-center justify-between gap-4 px-4 py-3 text-left',
-							selectedSet.has('*') && 'dark:bg-gray-920 bg-gray-50'
+							'hover:bg-base-300 dark:hover:bg-base-200 flex items-center justify-between gap-4 px-4 py-3 text-left',
+							selectedSet.has('*') && 'bg-base-200/50'
 						)}
 						onclick={() => toggleSelection('*')}
 					>
 						<div class="flex items-center gap-2">
-							<Cpu class="size-8 flex-shrink-0" />
+							<Cpu class="size-8 shrink-0" />
 							<div class="flex flex-col">
 								<p class="font-medium">All Models</p>
-								<span class="text-on-surface1 text-xs">
+								<span class="text-muted-content text-xs">
 									Grants access to all current and future models
 								</span>
 							</div>
@@ -200,8 +200,8 @@
 						{#each filteredAliases as alias (alias.id)}
 							<button
 								class={twMerge(
-									'hover:bg-surface3 flex items-center justify-between gap-4 rounded-md bg-transparent p-2 font-light',
-									selectedSet.has(alias.id) && 'bg-surface2'
+									'hover:bg-base-300 flex items-center justify-between gap-4 rounded-md bg-transparent p-2 font-light',
+									selectedSet.has(alias.id) && 'bg-base-400'
 								)}
 								onclick={() => toggleSelection(alias.id)}
 							>
@@ -209,13 +209,13 @@
 									<div class="flex items-center gap-2">
 										<span>{alias.aliasName}</span>
 										<span
-											class="text-on-surface1 text-xs"
-											class:text-yellow-500={!alias.isConfigured}
+											class="text-muted-content text-xs"
+											class:text-warning={!alias.isConfigured}
 										>
 											{alias.effectiveModelName}
 										</span>
 									</div>
-									<span class="text-on-surface1 text-xs">{alias.label}</span>
+									<span class="text-muted-content text-xs">{alias.label}</span>
 								</div>
 								{#if selectedSet.has(alias.id)}
 									<Check class="text-primary size-4" />
@@ -237,15 +237,15 @@
 							{#each models as model (model.id)}
 								<button
 									class={twMerge(
-										'hover:bg-surface3 flex items-center justify-between gap-4 rounded-md bg-transparent p-2 font-light',
-										selectedSet.has(model.id) && 'bg-surface2'
+										'hover:bg-base-300 flex items-center justify-between gap-4 rounded-md bg-transparent p-2 font-light',
+										selectedSet.has(model.id) && 'bg-base-400'
 									)}
 									onclick={() => toggleSelection(model.id)}
 								>
 									<div class="flex flex-col text-left">
 										<span>{model.displayName || model.name}</span>
 										{#if model.usage}
-											<span class="text-on-surface1 text-xs">
+											<span class="text-muted-content text-xs">
 												{ModelUsageLabels[model.usage as ModelUsage] || model.usage}
 											</span>
 										{/if}
@@ -269,10 +269,10 @@
 			{/if}
 		</div>
 		<div class="flex items-center gap-2">
-			<button class="button w-full md:w-fit" onclick={() => addModelDialog?.close()}>
+			<button class="btn btn-secondary w-full md:w-fit" onclick={() => addModelDialog?.close()}>
 				Cancel
 			</button>
-			<button class="button-primary w-full md:w-fit" onclick={handleAdd}> Confirm </button>
+			<button class="btn btn-primary w-full md:w-fit" onclick={handleAdd}> Confirm </button>
 		</div>
 	</div>
 </ResponsiveDialog>

--- a/ui/user/src/lib/components/admin/SearchSkills.svelte
+++ b/ui/user/src/lib/components/admin/SearchSkills.svelte
@@ -107,7 +107,7 @@
 		<div class="flex flex-col gap-2">
 			<div class="px-4">
 				<Search
-					class="dark:bg-surface1 dark:border-surface3 shadow-inner dark:border"
+					class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
 					onChange={(val) => (query = val)}
 					value={query}
 					placeholder="Search repositories & skills..."
@@ -118,15 +118,15 @@
 				{#if wildcardAvailable && !exclude?.includes('*')}
 					<button
 						class={twMerge(
-							'hover:bg-surface3 dark:hover:bg-surface1 flex items-center justify-between gap-4 px-4 py-3 text-left',
-							selectedSet.has('*') && 'dark:bg-gray-920 bg-gray-50'
+							'hover:bg-base-300 dark:hover:bg-base-200 flex items-center justify-between gap-4 px-4 py-3 text-left',
+							selectedSet.has('*') && 'bg-base-200/50'
 						)}
 						onclick={() => toggleSelection({ type: 'selector', id: '*' })}
 					>
 						<div class="flex items-center gap-2">
 							<div class="flex flex-col">
 								<p class="font-medium">All Skills</p>
-								<span class="text-on-surface1 text-xs">
+								<span class="text-muted-content text-xs">
 									Grants access to all current and future skills
 								</span>
 							</div>
@@ -142,8 +142,8 @@
 				{#each sortedRepositoriesAndSkills as item (item.id)}
 					<button
 						class={twMerge(
-							'hover:bg-surface3 dark:hover:bg-surface1 flex items-center justify-between gap-4 px-4 py-3 text-left',
-							selectedSet.has(item.id) && 'dark:bg-gray-920 bg-gray-50'
+							'hover:bg-base-300 dark:hover:bg-base-200 flex items-center justify-between gap-4 px-4 py-3 text-left',
+							selectedSet.has(item.id) && 'bg-base-200/50'
 						)}
 						onclick={() => {
 							if (item.id === '*') {
@@ -159,7 +159,7 @@
 						<div class="flex items-center gap-2">
 							<div class="flex flex-col">
 								<p class="font-medium">{item.name}</p>
-								<span class="text-on-surface1 line-clamp-1 text-xs">
+								<span class="text-muted-content line-clamp-1 text-xs">
 									{#if item.type === 'skillRepository'}
 										Grants access to all skills in this repository
 									{:else}
@@ -186,10 +186,10 @@
 			{/if}
 		</div>
 		<div class="flex items-center gap-2">
-			<button class="button w-full md:w-fit" onclick={() => addSkillDialog?.close()}>
+			<button class="btn btn-secondary w-full md:w-fit" onclick={() => addSkillDialog?.close()}>
 				Cancel
 			</button>
-			<button class="button-primary w-full md:w-fit" onclick={handleAdd}> Confirm </button>
+			<button class="btn btn-primary w-full md:w-fit" onclick={handleAdd}> Confirm </button>
 		</div>
 	</div>
 </ResponsiveDialog>

--- a/ui/user/src/lib/components/admin/SearchUsers.svelte
+++ b/ui/user/src/lib/components/admin/SearchUsers.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import { type OrgGroup, type OrgUser } from '$lib/services/admin/types';
 	import { getUserRoleLabel } from '$lib/utils';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import Search from '../Search.svelte';
 	import { debounce } from 'es-toolkit';
-	import { Check, LoaderCircle, User, Users } from 'lucide-svelte';
+	import { Check, User, Users } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -132,7 +133,7 @@
 	<div class="default-scrollbar-thin flex grow flex-col gap-4 overflow-y-auto pt-1">
 		<div class="px-4">
 			<Search
-				class="dark:bg-surface1 dark:border-surface3 shadow-inner dark:border"
+				class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
 				value={searchNames}
 				onChange={(val) => {
 					searchNames = val;
@@ -143,15 +144,15 @@
 		</div>
 		{#if loading}
 			<div class="flex grow items-center justify-center">
-				<LoaderCircle class="size-6 animate-spin" />
+				<Loading class="size-6" />
 			</div>
 		{:else}
 			<div class="flex flex-col">
 				{#each filteredData ?? [] as item (item.id)}
 					<button
 						class={twMerge(
-							'dark:hover:bg-surface1 hover:bg-surface2 flex items-center gap-2 px-4 py-2 text-left',
-							selectedUsersMap.has(item.id) && 'dark:bg-gray-920 bg-gray-50'
+							'dark:hover:bg-base-200 hover:bg-base-400 flex items-center gap-2 px-4 py-2 text-left',
+							selectedUsersMap.has(item.id) && 'bg-base-200/50'
 						)}
 						onclick={() => {
 							if (selectedUsersMap.has(item.id)) {
@@ -168,12 +169,12 @@
 						<div class="flex grow flex-col">
 							{#if !isGroup(item)}
 								<p>{item.displayName ?? item.email ?? item.username ?? item.id}</p>
-								<p class="text-on-surface1 font-light">
+								<p class="text-muted-content font-light">
 									{item.effectiveRole ? getUserRoleLabel(item.effectiveRole) : 'User'}
 								</p>
 							{:else}
 								<p>{item.name}</p>
-								<p class="text-on-surface1 font-light">Group</p>
+								<p class="text-muted-content font-light">Group</p>
 							{/if}
 						</div>
 						<div class="flex items-center justify-center">
@@ -198,11 +199,11 @@
 			{/if}
 		</div>
 		<div class="flex items-center gap-2">
-			<button class="button w-full md:w-fit" onclick={() => addUserGroupDialog?.close()}>
+			<button class="btn btn-secondary w-full md:w-fit" onclick={() => addUserGroupDialog?.close()}>
 				Cancel
 			</button>
 			<button
-				class="button-primary w-full md:w-fit"
+				class="btn btn-primary w-full md:w-fit"
 				onclick={() => {
 					const users = selectedUsers.filter((user) => !isGroup(user)) as OrgUser[];
 					const groups = selectedUsers.filter((user) => isGroup(user)) as OrgGroup[];

--- a/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
+++ b/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { ADMIN_SESSION_STORAGE } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		ChatService,
@@ -15,7 +16,7 @@
 	import { goto } from '$lib/url';
 	import InfoTooltip from '../InfoTooltip.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
-	import { Circle, CircleCheck, LoaderCircle } from 'lucide-svelte';
+	import { Circle, CircleCheck } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -143,7 +144,7 @@
 							class={twMerge(
 								'flex w-full items-center gap-2 rounded-md border border-transparent p-2 text-left transition-colors duration-200',
 								selectedRules.includes(rule.id) && 'border-primary',
-								!hasEverything && 'dark:hover:bg-surface1 hover:bg-surface2'
+								!hasEverything && 'dark:hover:bg-base-200 hover:bg-base-400'
 							)}
 							onclick={() => {
 								if (hasEverything) return;
@@ -155,18 +156,18 @@
 							}}
 						>
 							<div class="grid w-full grid-cols-2 items-center gap-2">
-								<p class={twMerge('truncate', hasEverything && 'text-on-surface1')}>
+								<p class={twMerge('truncate', hasEverything && 'text-muted-content')}>
 									{rule.displayName}
 								</p>
 								<div class="flex grow items-center justify-between">
-									<p class={twMerge('line-clamp-2 text-xs', hasEverything && 'text-on-surface1')}>
+									<p class={twMerge('line-clamp-2 text-xs', hasEverything && 'text-muted-content')}>
 										{#if rule.subjects && rule.subjects.length > 0}
 											{rule.subjects?.map((s) => convertSubjectToDisplayName(s)).join(', ')}
 										{:else}
-											<i class="text-on-surface1">(Empty)</i>
+											<i class="text-muted-content">(Empty)</i>
 										{/if}
 									</p>
-									<div class="flex-shrink-0">
+									<div class="shrink-0">
 										{#if hasEverything}
 											<InfoTooltip
 												class="size-4"
@@ -177,7 +178,7 @@
 										{:else if selectedRules.includes(rule.id)}
 											<CircleCheck class="text-primary size-4" />
 										{:else}
-											<Circle class="text-on-surface1 size-4" />
+											<Circle class="text-muted-content size-4" />
 										{/if}
 									</div>
 								</div>
@@ -190,15 +191,15 @@
 	{/if}
 	{#if accessControlRules.length > 0}
 		<div class="mt-auto flex justify-between gap-4">
-			<button class="button-primary" onclick={handleCreateNewRule}> Create New Registry </button>
+			<button class="btn btn-primary" onclick={handleCreateNewRule}> Create New Registry </button>
 			<div class="flex items-center gap-4">
 				<button
-					class="button-primary flex items-center gap-1"
+					class="btn btn-primary flex items-center gap-1"
 					onclick={handleAddToRules}
 					disabled={savingRules}
 				>
 					{#if savingRules}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 					{:else}
 						Continue
 					{/if}
@@ -207,8 +208,8 @@
 		</div>
 	{:else}
 		<div class="mt-auto flex justify-end gap-4">
-			<button class="button" onclick={close}> Skip Step </button>
-			<button class="button-primary" onclick={handleCreateNewRule}> Create MCP Registry </button>
+			<button class="btn btn-secondary" onclick={close}> Skip Step </button>
+			<button class="btn btn-primary" onclick={handleCreateNewRule}> Create MCP Registry </button>
 		</div>
 	{/if}
 </ResponsiveDialog>

--- a/ui/user/src/lib/components/admin/SelectorsAndResourcesFormSegment.svelte
+++ b/ui/user/src/lib/components/admin/SelectorsAndResourcesFormSegment.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import type { MCPFilterResource, MCPFilterWebhookSelector } from '$lib/services';
 	import { mcpServersAndEntries } from '$lib/stores';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import SearchMcpServers from './SearchMcpServers.svelte';
 	import { Plus, Trash2, X } from 'lucide-svelte';
@@ -92,13 +92,13 @@
 	<div class="mb-2 flex items-center justify-between">
 		<div class="flex flex-col gap-1">
 			<h2 class="text-lg font-semibold">Selectors</h2>
-			<p class="text-on-surface1 text-sm">
+			<p class="text-muted-content text-sm">
 				Specify which requests should be matched by this filter.
 			</p>
 		</div>
 		{#if !readonly}
 			<div class="relative flex items-center gap-4">
-				<button class="button-primary flex items-center gap-1 text-sm" onclick={addSelector}>
+				<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={addSelector}>
 					<Plus class="size-4" /> Add Selector
 				</button>
 			</div>
@@ -106,14 +106,14 @@
 	</div>
 
 	{#if form.selectors.length === 0}
-		<div class="text-on-surface1 p-4 text-center font-light text-sm">
+		<div class="text-muted-content p-4 text-center font-light text-sm">
 			No selectors added. This filter will match all MCP requests.<br />Click "Add Selector" to
 			specify filter criteria.
 		</div>
 	{:else}
 		{#each form.selectors as selector, selectorIndex (selectorIndex)}
 			{#if inDialog}
-				<div class="bg-surface1 dark:bg-background rounded-lg p-2 shadow-inner">
+				<div class="bg-base-200 dark:bg-base-100 rounded-lg p-2 shadow-inner">
 					{@render selectorView(selector, selectorIndex)}
 				</div>
 			{:else}
@@ -127,14 +127,14 @@
 	<div class="mb-2 flex items-center justify-between">
 		<div class="flex flex-col gap-1">
 			<h2 class="text-lg font-semibold">MCP Servers</h2>
-			<p class="text-on-surface1 text-sm">
+			<p class="text-muted-content text-sm">
 				Specify which MCP servers this filter should be applied to.
 			</p>
 		</div>
 		{#if !readonly}
 			<div class="relative flex items-center gap-4">
 				<button
-					class="button-primary flex items-center gap-1 text-sm"
+					class="btn btn-primary flex items-center gap-1 text-sm"
 					onclick={() => {
 						addMcpServerDialog?.open();
 					}}
@@ -145,7 +145,7 @@
 		{/if}
 	</div>
 	{#if inDialog}
-		<div class="bg-surface1 dark:bg-background rounded-lg p-2 shadow-inner">
+		<div class="bg-base-200 dark:bg-base-100 rounded-lg p-2 shadow-inner">
 			{@render mcpServersTable()}
 		</div>
 	{:else}
@@ -186,23 +186,23 @@
 {#snippet selectorView(selector: MCPFilterWebhookSelector, selectorIndex: number)}
 	<div
 		class={twMerge(
-			'dark:border-surface3 bg-background rounded-lg border border-transparent p-4',
-			inDialog ? 'dark:bg-surface2' : 'dark:bg-surface1 '
+			'dark:border-base-400 bg-base-100 rounded-lg border border-transparent p-4',
+			inDialog ? 'dark:bg-base-400' : 'dark:bg-base-100 '
 		)}
 		in:slide|global={{ axis: 'y', duration: 150 }}
 	>
 		<div class="mb-1 flex items-center justify-between">
-			<h3 class="text-sm font-medium text-gray-700 dark:text-gray-300">
+			<h3 class="text-sm font-medium text-muted-content dark:text-muted-content">
 				Selector {selectorIndex + 1}
 			</h3>
 			{#if !readonly}
-				<button
-					class="icon-button text-red-500 hover:text-red-600"
+				<IconButton
+					variant="danger"
 					onclick={() => removeSelector(selectorIndex)}
-					use:tooltip={'Remove Selector'}
+					tooltip={{ text: 'Remove Selector' }}
 				>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 			{/if}
 		</div>
 
@@ -225,7 +225,7 @@
 						<button
 							id="identifier-btn"
 							type="button"
-							class="button-text flex items-center gap-1 text-xs"
+							class="btn btn-secondary btn-sm flex items-center gap-1"
 							onclick={() => addIdentifier(selectorIndex)}
 						>
 							<Plus class="size-3" /> Add Identifier
@@ -234,7 +234,7 @@
 				</div>
 
 				{#if !selector.identifiers || selector.identifiers.length === 0}
-					<div class="text-on-surface1 p-3 text-center text-sm">
+					<div class="text-muted-content p-3 text-center text-sm">
 						{#if !readonly}
 							No identifiers added. Click "Add Identifier" to specify filter criteria.
 						{:else}
@@ -252,14 +252,13 @@
 								disabled={readonly}
 							/>
 							{#if !readonly}
-								<button
-									type="button"
-									class="icon-button text-red-500 hover:text-red-600"
+								<IconButton
+									variant="danger"
 									onclick={() => removeIdentifier(selectorIndex, identifierIndex)}
-									use:tooltip={'Remove Identifier'}
+									tooltip={{ text: 'Remove Identifier' }}
 								>
 									<X class="size-4" />
-								</button>
+								</IconButton>
 							{/if}
 						</div>
 					{/each}
@@ -273,15 +272,15 @@
 	<Table data={mcpServersTableData} fields={['name']} noDataMessage="No MCP servers added.">
 		{#snippet actions(d)}
 			{#if !readonly}
-				<button
-					class="icon-button hover:text-red-500"
+				<IconButton
+					variant="danger"
 					onclick={() => {
 						form.resources = form.resources.filter((resource) => resource.id !== d.id);
 					}}
-					use:tooltip={'Remove MCP Server'}
+					tooltip={{ text: 'Remove MCP Server' }}
 				>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 			{/if}
 		{/snippet}
 	</Table>

--- a/ui/user/src/lib/components/admin/SetupSplashDialog.svelte
+++ b/ui/user/src/lib/components/admin/SetupSplashDialog.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, Group } from '$lib/services';
 	import { profile, version } from '$lib/stores';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte';
 	import { goto } from '$lib/url';
 	import Logo from '../Logo.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
-	import { CircleCheckBig, LoaderCircle } from 'lucide-svelte';
+	import { CircleCheckBig } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -92,7 +93,7 @@
 
 	{#if isBootstrapUser}
 		<button
-			class="button-primary mt-8 flex justify-center text-center"
+			class="btn btn-primary mt-8 flex justify-center text-center"
 			disabled={loading}
 			onclick={async () => {
 				handleAcceptEula();
@@ -112,14 +113,14 @@
 			}}
 		>
 			{#if loading}
-				<LoaderCircle class="size-4 animate-spin" />
+				<Loading class="size-4" />
 			{:else}
 				Get Started
 			{/if}
 		</button>
 	{:else}
 		<button
-			class="button-primary mt-8 flex justify-center text-center"
+			class="btn btn-primary mt-8 flex justify-center text-center"
 			onclick={() => {
 				handleAcceptEula();
 				localStorage.setItem('seenSplashDialog', new Date().toISOString());
@@ -138,7 +139,7 @@
 {#snippet authDisabledNote()}
 	{#if !version.current.authEnabled}
 		<p class="mt-1 text-sm">
-			<span class="text-on-surface1">Auth is disabled.</span>
+			<span class="text-muted-content">Auth is disabled.</span>
 			<a
 				href="https://docs.obot.ai/installation/enabling-authentication"
 				rel="external noopener noreferrer"
@@ -152,11 +153,11 @@
 {#snippet renderChecklistItem(label: string, isChecked: boolean, note?: Snippet)}
 	<li>
 		<span
-			class={twMerge('flex items-center gap-1', isChecked ? 'text-on-surface1 line-through' : '')}
+			class={twMerge('flex items-center gap-1', isChecked ? 'text-muted-content line-through' : '')}
 		>
 			{label}
 			{#if isChecked}
-				<CircleCheckBig class="size-5 text-green-500" />
+				<CircleCheckBig class="size-5 text-success" />
 			{/if}
 		</span>
 		{#if note}

--- a/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import {
 		type AccessControlRuleSubject,
@@ -15,10 +15,11 @@
 	import { goto } from '$lib/url';
 	import { getUserDisplayName } from '$lib/utils';
 	import Confirm from '../Confirm.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import SearchSkills from './SearchSkills.svelte';
 	import SearchUsers from './SearchUsers.svelte';
-	import { LoaderCircle, Plus, Trash2 } from 'lucide-svelte';
+	import { Plus, Trash2 } from 'lucide-svelte';
 	import { onMount, untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -247,22 +248,22 @@
 					</h1>
 				</div>
 				{#if !readonly}
-					<button
-						class="button-destructive flex items-center gap-1 text-xs font-normal"
-						use:tooltip={'Delete Policy'}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete Policy' }}
 						onclick={() => {
 							deletingPolicy = true;
 						}}
 					>
 						<Trash2 class="size-4" />
-					</button>
+					</IconButton>
 				{/if}
 			</div>
 		{/if}
 
 		{#if !skillAccessPolicy.id}
 			<div
-				class="dark:bg-surface2 dark:border-surface3 bg-background rounded-lg border border-transparent p-4"
+				class="dark:bg-base-400 dark:border-base-400 bg-base-100 rounded-lg border border-transparent p-4"
 			>
 				<div class="flex flex-col gap-6">
 					<div class="flex flex-col gap-2">
@@ -286,12 +287,12 @@
 				{#if !readonly}
 					<div class="relative flex items-center gap-4">
 						{#if loadingUsersAndGroups}
-							<button class="button-primary flex items-center gap-1 text-sm" disabled>
+							<button class="btn btn-primary flex items-center gap-1 text-sm" disabled>
 								<Plus class="size-4" /> Add User/Group
 							</button>
 						{:else}
 							<button
-								class="button-primary flex items-center gap-1 text-sm"
+								class="btn btn-primary flex items-center gap-1 text-sm"
 								onclick={() => {
 									addUserGroupDialog?.open();
 								}}
@@ -304,7 +305,7 @@
 			</div>
 			{#if loadingUsersAndGroups}
 				<div class="my-2 flex items-center justify-center">
-					<LoaderCircle class="size-6 animate-spin" />
+					<Loading class="size-6" />
 				</div>
 			{:else}
 				<Table
@@ -315,17 +316,17 @@
 				>
 					{#snippet actions(d)}
 						{#if !readonly}
-							<button
-								class="icon-button hover:text-red-500"
+							<IconButton
+								variant="danger"
 								onclick={() => {
 									skillAccessPolicy.subjects = skillAccessPolicy.subjects?.filter(
 										(subject) => subject.id !== d.id
 									);
 								}}
-								use:tooltip={'Delete User/Group'}
+								tooltip={{ text: 'Delete User/Group' }}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					{/snippet}
 				</Table>
@@ -337,7 +338,7 @@
 				<h2 class="text-lg font-semibold">Skills</h2>
 				{#if !readonly}
 					<button
-						class="button-primary flex items-center gap-1 text-sm"
+						class="btn btn-primary flex items-center gap-1 text-sm"
 						onclick={() => {
 							addSkillDialog?.open();
 						}}
@@ -348,7 +349,7 @@
 			</div>
 			{#if loadingSkills}
 				<div class="my-2 flex items-center justify-center">
-					<LoaderCircle class="size-6 animate-spin" />
+					<Loading class="size-6" />
 				</div>
 			{:else}
 				<Table
@@ -369,16 +370,16 @@
 					{/snippet}
 					{#snippet actions(d)}
 						{#if !readonly}
-							<button
-								class="icon-button hover:text-red-500"
+							<IconButton
+								variant="danger"
 								onclick={() => {
 									skillAccessPolicy.resources =
 										skillAccessPolicy.resources?.filter((r) => r.id !== d.id) ?? [];
 								}}
-								use:tooltip={'Remove Skill'}
+								tooltip={{ text: 'Remove Skill' }}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					{/snippet}
 				</Table>
@@ -387,14 +388,14 @@
 	</div>
 	{#if !readonly}
 		<div
-			class="bg-surface1 text-on-surface1 dark:bg-background sticky bottom-0 left-0 z-50 flex w-full justify-end gap-2 py-4"
+			class="bg-base-200 text-muted-content dark:bg-base-100 sticky bottom-0 left-0 z-50 flex w-full justify-end gap-2 py-4"
 			out:fly={{ x: -100, duration }}
 			in:fly={{ x: -100 }}
 		>
 			<div class="flex w-full justify-end gap-2">
 				{#if !skillAccessPolicy.id}
 					<button
-						class="button text-sm"
+						class="btn btn-secondary text-sm"
 						onclick={() => {
 							goto('/admin/skill-access-policies');
 						}}
@@ -402,7 +403,7 @@
 						Cancel
 					</button>
 					<button
-						class="button-primary text-sm"
+						class="btn btn-primary text-sm"
 						disabled={!validate(skillAccessPolicy) || saving}
 						onclick={async () => {
 							saving = true;
@@ -416,14 +417,14 @@
 						}}
 					>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Save
 						{/if}
 					</button>
 				{:else}
 					<button
-						class="button-primary text-sm"
+						class="btn btn-primary text-sm"
 						disabled={!validate(skillAccessPolicy) || !hasChanges || saving}
 						onclick={async () => {
 							if (!skillAccessPolicy.id) return;
@@ -441,7 +442,7 @@
 						}}
 					>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Update
 						{/if}

--- a/ui/user/src/lib/components/admin/StatBar.svelte
+++ b/ui/user/src/lib/components/admin/StatBar.svelte
@@ -13,7 +13,7 @@
 
 {#if startTime && endTime}
 	<div
-		class="dark:bg-surface2 dark:border-surface3 bg-background text-on-background flex h-12 w-fit flex-wrap gap-4 rounded-md border border-transparent px-6 py-2 shadow-sm"
+		class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex h-12 w-fit flex-wrap gap-4 rounded-md border border-transparent px-6 py-2 shadow-sm"
 	>
 		<p class="flex items-center text-sm font-semibold">
 			{formatTimeRange(startTime, endTime)}
@@ -23,7 +23,7 @@
 
 {#if totalCalls || uniqueUsers}
 	<div
-		class="dark:bg-surface2 dark:border-surface3 bg-background text-on-background flex h-12 w-fit flex-wrap gap-4 rounded-md border border-transparent px-6 py-2 shadow-sm"
+		class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex h-12 w-fit flex-wrap gap-4 rounded-md border border-transparent px-6 py-2 shadow-sm"
 	>
 		{#if totalCalls}
 			<div class="flex items-center justify-between gap-4 text-sm">
@@ -34,7 +34,7 @@
 			</div>
 		{/if}
 		{#if totalCalls && uniqueUsers}
-			<div class="bg-surface3 h-8 w-0.5"></div>
+			<div class="bg-base-400 h-8 w-0.5"></div>
 		{/if}
 		{#if uniqueUsers}
 			<div class="flex items-center justify-between gap-4 text-sm">

--- a/ui/user/src/lib/components/admin/YamlEditor.svelte
+++ b/ui/user/src/lib/components/admin/YamlEditor.svelte
@@ -177,7 +177,7 @@
 
 <div
 	class={twMerge(
-		'text-input-filled border-surface3 dark:bg-background overflow-hidden p-0 transition-colors',
+		'text-input-filled border-base-400 dark:bg-base-100 overflow-hidden p-0 transition-colors',
 		focused && !disabled && 'ring-primary ring-2 outline-none',
 		disabled && 'disabled opacity-60',
 		klass

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte
@@ -3,15 +3,107 @@
 	import type { DateRange } from '$lib/components/Calendar.svelte';
 	import Select from '$lib/components/Select.svelte';
 	import AuditLogCalendar from '$lib/components/admin/audit-logs/AuditLogCalendar.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, Group, type AuditLogURLFilters } from '$lib/services';
 	import type { AuditLogExport, OrgUser } from '$lib/services/admin/types';
 	import { profile } from '$lib/stores';
 	import { subDays, set } from 'date-fns';
-	import { AlertTriangle, LoaderCircle, ChevronDown, ChevronUp } from 'lucide-svelte';
+	import { TriangleAlert, ChevronDown, ChevronUp } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
+
+	type AuditLogExportMultiSelectFilterKey =
+		| 'user_id'
+		| 'mcp_id'
+		| 'mcp_server_display_name'
+		| 'mcp_server_catalog_entry_name'
+		| 'call_type'
+		| 'call_identifier'
+		| 'client_name'
+		| 'client_version'
+		| 'client_ip'
+		| 'response_status'
+		| 'session_id';
+
+	type AuditLogExportFilterFieldConfig = {
+		filterKey: AuditLogExportMultiSelectFilterKey;
+		title: string;
+		description: string;
+		placeholder: string;
+		useUserDisplayNames?: boolean;
+	};
+
+	const AUDIT_LOG_EXPORT_FILTER_FIELDS: AuditLogExportFilterFieldConfig[] = [
+		{
+			filterKey: 'user_id',
+			title: 'Users',
+			description: 'List of users',
+			placeholder: 'user1,user2',
+			useUserDisplayNames: true
+		},
+		{
+			filterKey: 'mcp_id',
+			title: 'Server IDs',
+			description: 'List of server IDs',
+			placeholder: 'server1,server2'
+		},
+		{
+			filterKey: 'mcp_server_display_name',
+			title: 'Server Names',
+			description: 'List of server display names',
+			placeholder: 'server-name-1,server-name-2'
+		},
+		{
+			filterKey: 'call_type',
+			title: 'Call Types',
+			description: 'List of call types',
+			placeholder: 'tools/call,resources/read'
+		},
+		{
+			filterKey: 'client_name',
+			title: 'Client Names',
+			description: 'List of client names',
+			placeholder: 'client1,client2'
+		},
+		{
+			filterKey: 'response_status',
+			title: 'Response Status',
+			description: 'List of HTTP status codes',
+			placeholder: '200,400,500'
+		},
+		{
+			filterKey: 'session_id',
+			title: 'Session IDs',
+			description: 'List of session IDs',
+			placeholder: 'session1,session2'
+		},
+		{
+			filterKey: 'client_ip',
+			title: 'Client IPs',
+			description: 'List of IP addresses',
+			placeholder: '192.168.1.1,10.0.0.1'
+		},
+		{
+			filterKey: 'call_identifier',
+			title: 'Call Identifier',
+			description: 'List of call identifiers',
+			placeholder: 'call-identifier-1,call-identifier-2'
+		},
+		{
+			filterKey: 'client_version',
+			title: 'Client Versions',
+			description: 'List of client versions',
+			placeholder: 'client-version-1,client-version-2'
+		},
+		{
+			filterKey: 'mcp_server_catalog_entry_name',
+			title: 'Catalog Entry Names',
+			description: 'List of catalog entry names',
+			placeholder: 'workspace-id-1,workspace-id-2'
+		}
+	];
 
 	interface Props {
 		onCancel: () => void;
@@ -216,9 +308,20 @@
 			form.endTime = end;
 		}
 	}
+
+	function selectOptionsForField(
+		field: AuditLogExportFilterFieldConfig
+	): { id: string; label: string }[] {
+		const opts = filtersOptions[field.filterKey];
+		if (!opts?.map) return [];
+		if (field.useUserDisplayNames) {
+			return opts.map((d) => ({ id: d, label: usersMap.get(d)?.displayName ?? d }));
+		}
+		return opts.map((d) => ({ id: d, label: d }));
+	}
 </script>
 
-<div class="dark:bg-surface2 bg-background rounded-md p-6 shadow-sm">
+<div class="paper">
 	<form
 		class="space-y-8"
 		onsubmit={(e) => {
@@ -227,10 +330,8 @@
 		}}
 	>
 		{#if !hasAuditorPermissions}
-			<div
-				class="flex items-start gap-3 rounded-md border border-yellow-500 bg-yellow-500/10 p-4 dark:bg-yellow-500/10"
-			>
-				<AlertTriangle class="size-5 text-yellow-500 dark:text-yellow-500" />
+			<div class="flex items-start gap-3 rounded-md border border-warning bg-warning/10 p-4">
+				<TriangleAlert class="size-5 text-warning" />
 				<div class="text-sm">
 					Exported logs will not include request/response headers and body information. Auditor role
 					is required to access this data.
@@ -254,7 +355,7 @@
 					<input
 						class={twMerge(
 							'text-input-filled',
-							isViewMode && '[color:currentColor] disabled:opacity-100'
+							isViewMode && 'text-[currentColor] disabled:opacity-100'
 						)}
 						id="name"
 						bind:value={form.name}
@@ -264,7 +365,7 @@
 						disabled={isViewMode}
 					/>
 					{#if (isViewMode && form.name) || !isViewMode}
-						<p class="text-on-surface1 text-xs">Unique name for this export</p>
+						<p class="text-muted-content text-xs">Unique name for this export</p>
 					{/if}
 				</div>
 				<div class="flex flex-col gap-1">
@@ -272,7 +373,7 @@
 					<input
 						class={twMerge(
 							'text-input-filled',
-							isViewMode && '[color:currentColor] disabled:opacity-100'
+							isViewMode && 'text-[currentColor] disabled:opacity-100'
 						)}
 						id="bucket"
 						bind:value={form.bucket}
@@ -282,7 +383,9 @@
 						disabled={isViewMode}
 					/>
 					{#if (isViewMode && form.bucket) || !isViewMode}
-						<p class="text-on-surface1 text-xs">Storage bucket name where exports will be saved</p>
+						<p class="text-muted-content text-xs">
+							Storage bucket name where exports will be saved
+						</p>
 					{/if}
 				</div>
 			</div>
@@ -292,7 +395,7 @@
 				<input
 					class={twMerge(
 						'text-input-filled',
-						isViewMode && '[color:currentColor] disabled:opacity-100'
+						isViewMode && 'text-[currentColor] disabled:opacity-100'
 					)}
 					id="keyPrefix"
 					bind:value={form.keyPrefix}
@@ -301,7 +404,7 @@
 					disabled={isViewMode}
 				/>
 				{#if (isViewMode && form.keyPrefix) || !isViewMode}
-					<p class="text-on-surface1 text-xs">
+					<p class="text-muted-content text-xs">
 						Path prefix within the bucket. If empty, defaults to "mcp-audit-logs/YYYY/MM/DD/" format
 						based on current date.
 					</p>
@@ -342,298 +445,50 @@
 						Leave filters empty to export all logs in the selected time range
 					</p>
 
+					{#snippet auditLogExportFilterSelect(
+						filterKey: AuditLogExportMultiSelectFilterKey,
+						title: string,
+						description: string,
+						placeholder: string,
+						selectOptions: { id: string; label: string }[]
+					)}
+						<div class="flex flex-col gap-1">
+							<label class="text-sm font-medium" for={filterKey}>{title}</label>
+							<Select
+								id={filterKey}
+								class={twMerge(
+									'dark:border-base-400 bg-base-100 dark:bg-base-100 border border-transparent shadow-inner',
+									isViewMode && 'text-[currentColor] disabled:opacity-100'
+								)}
+								classes={{
+									root: 'w-full',
+									clear: 'hover:bg-base-400 bg-transparent'
+								}}
+								options={selectOptions}
+								bind:selected={
+									() => form.filters[filterKey] ?? '', (v) => (form.filters[filterKey] = v ?? '')
+								}
+								{placeholder}
+								disabled={isViewMode}
+								readonly={isViewMode}
+								multiple
+							/>
+							{#if (isViewMode && form.filters[filterKey]) || !isViewMode}
+								<p class="text-muted-content text-xs">{description}</p>
+							{/if}
+						</div>
+					{/snippet}
+
 					<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="user_id">Users</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['user_id']?.map?.((d) => ({
-									id: d,
-									label: usersMap.get(d)?.displayName ?? d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.user_id ?? '', (v) => (form.filters.user_id = v ?? '')
-								}
-								placeholder="user1,user2"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-
-							{#if (isViewMode && form.filters.user_id) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of users</p>
-							{/if}
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="mcp_id">Server IDs</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['mcp_id']?.map?.((d) => ({ id: d, label: d })) ?? []}
-								bind:selected={
-									() => form.filters.mcp_id ?? '', (v) => (form.filters.mcp_id = v ?? '')
-								}
-								placeholder="server1,server2"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.mcp_id) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of server IDs</p>
-							{/if}
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="mcp_server_display_name">Server Names</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['mcp_server_display_name']?.map?.((d) => ({
-									id: d,
-									label: d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.mcp_server_display_name ?? '',
-									(v) => (form.filters.mcp_server_display_name = v ?? '')
-								}
-								placeholder="server-name-1,server-name-2"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.mcp_server_display_name) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of server display names</p>
-							{/if}
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="call_type">Call Types</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['call_type']?.map?.((d) => ({ id: d, label: d })) ?? []}
-								bind:selected={
-									() => form.filters.call_type ?? '', (v) => (form.filters.call_type = v ?? '')
-								}
-								placeholder="tools/call,resources/read"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.call_type) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of call types</p>
-							{/if}
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="client_name">Client Names</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['client_name']?.map?.((d) => ({ id: d, label: d })) ?? []}
-								bind:selected={
-									() => form.filters.client_name ?? '', (v) => (form.filters.client_name = v ?? '')
-								}
-								placeholder="client1,client2"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.client_name) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of client names</p>
-							{/if}
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="response_status">Response Status</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['response_status']?.map?.((d) => ({ id: d, label: d })) ??
-									[]}
-								bind:selected={
-									() => form.filters.response_status ?? '',
-									(v) => (form.filters.response_status = v ?? '')
-								}
-								placeholder="200,400,500"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.response_status) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of HTTP status codes</p>
-							{/if}
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="session_id">Session IDs</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['session_id']?.map?.((d) => ({ id: d, label: d })) ?? []}
-								bind:selected={
-									() => form.filters.session_id ?? '', (v) => (form.filters.session_id = v ?? '')
-								}
-								placeholder="session1,session2"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.session_id) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of session IDs</p>
-							{/if}
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="client_ip">Client IPs</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['client_ip']?.map?.((d) => ({ id: d, label: d })) ?? []}
-								bind:selected={
-									() => form.filters.client_ip ?? '', (v) => (form.filters.client_ip = v ?? '')
-								}
-								placeholder="192.168.1.1,10.0.0.1"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.client_ip) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of IP addresses</p>
-							{/if}
-						</div>
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="call_identifier">Call Identifier</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['call_identifier']?.map?.((d) => ({ id: d, label: d })) ??
-									[]}
-								bind:selected={
-									() => form.filters.call_identifier ?? '',
-									(v) => (form.filters.call_identifier = v ?? '')
-								}
-								placeholder="call-identifier-1,call-identifier-2"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.call_identifier) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of call identifiers</p>
-							{/if}
-						</div>
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="client_version">Client Versions</label>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['client_version']?.map?.((d) => ({ id: d, label: d })) ??
-									[]}
-								bind:selected={
-									() => form.filters.client_version ?? '',
-									(v) => (form.filters.client_version = v ?? '')
-								}
-								placeholder="client-version-1,client-version-2"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.client_version) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of client versions</p>
-							{/if}
-						</div>
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="power_user_workspace_id"
-								>Catalog Entry Names</label
-							>
-							<Select
-								class={twMerge(
-									'dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner',
-									isViewMode && '[color:currentColor] disabled:opacity-100'
-								)}
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['mcp_server_catalog_entry_name']?.map?.((d) => ({
-									id: d,
-									label: d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.mcp_server_catalog_entry_name ?? '',
-									(v) => (form.filters.mcp_server_catalog_entry_name = v ?? '')
-								}
-								placeholder="workspace-id-1,workspace-id-2"
-								disabled={isViewMode}
-								readonly={isViewMode}
-								multiple
-							/>
-							{#if (isViewMode && form.filters.mcp_server_catalog_entry_name) || !isViewMode}
-								<p class="text-on-surface1 text-xs">List of catalog entry names</p>
-							{/if}
-						</div>
+						{#each AUDIT_LOG_EXPORT_FILTER_FIELDS as field (field.filterKey)}
+							{@render auditLogExportFilterSelect(
+								field.filterKey,
+								field.title,
+								field.description,
+								field.placeholder,
+								selectOptionsForField(field)
+							)}
+						{/each}
 					</div>
 				</div>
 			{/if}
@@ -641,9 +496,9 @@
 
 		<!-- Error Display -->
 		{#if error}
-			<div class="flex items-start gap-3 rounded-md bg-red-50 p-4 dark:bg-red-950/50">
-				<AlertTriangle class="size-5 text-red-600 dark:text-red-400" />
-				<div class="text-sm text-red-700 dark:text-red-300">
+			<div class="flex items-start gap-3 rounded-md bg-error/10 p-4">
+				<TriangleAlert class="size-5 text-error" />
+				<div class="text-sm text-error">
 					{error}
 				</div>
 			</div>
@@ -653,16 +508,16 @@
 		<div class="flex justify-end gap-3 pt-6">
 			<button
 				type="button"
-				class="button"
+				class="btn btn-secondary"
 				onclick={onCancel}
 				disabled={creating && mode !== 'view'}
 			>
 				{mode === 'view' ? 'Back' : 'Cancel'}
 			</button>
 			{#if mode !== 'view'}
-				<button type="submit" class="button-primary" disabled={creating}>
+				<button type="submit" class="btn btn-primary" disabled={creating}>
 					{#if creating}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 						{mode === 'edit' ? 'Saving Changes...' : 'Creating Export...'}
 					{:else}
 						{mode === 'edit' ? 'Save Changes' : 'Create Export'}

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte
@@ -2,10 +2,11 @@
 	import { page } from '$app/state';
 	import Select from '$lib/components/Select.svelte';
 	import Dropdown from '$lib/components/tasks/Dropdown.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, Group, type AuditLogURLFilters } from '$lib/services';
 	import type { OrgUser, ScheduledAuditLogExport } from '$lib/services/admin/types';
 	import { profile } from '$lib/stores';
-	import { AlertTriangle, LoaderCircle, GlobeIcon, ChevronDown, ChevronUp } from 'lucide-svelte';
+	import { TriangleAlert, GlobeIcon, ChevronDown, ChevronUp } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { slide } from 'svelte/transition';
@@ -179,6 +180,96 @@
 		});
 	});
 
+	type AuditScheduleAdvancedFilterRow = {
+		fieldId: string;
+		filterKey:
+			| 'user_id'
+			| 'mcp_id'
+			| 'mcp_server_display_name'
+			| 'call_type'
+			| 'client_name'
+			| 'response_status'
+			| 'session_id'
+			| 'client_ip'
+			| 'mcp_server_catalog_entry_name';
+		label: string;
+		description: string;
+		options: { id: string; label: string }[];
+	};
+
+	let auditScheduleAdvancedFilterRows = $derived.by((): AuditScheduleAdvancedFilterRow[] => {
+		const sameLabel = (d: string) => ({ id: d, label: d });
+		return [
+			{
+				fieldId: 'user_id',
+				filterKey: 'user_id',
+				label: 'User IDs',
+				description: 'Comma-separated user IDs',
+				options:
+					filtersOptions['user_id']?.map?.((d) => ({
+						id: d,
+						label: usersMap.get(d)?.displayName ?? d
+					})) ?? []
+			},
+			{
+				fieldId: 'mcp_id',
+				filterKey: 'mcp_id',
+				label: 'Server IDs',
+				description: 'Comma-separated server IDs',
+				options: filtersOptions['mcp_id']?.map?.(sameLabel) ?? []
+			},
+			{
+				fieldId: 'mcp_server_display_name',
+				filterKey: 'mcp_server_display_name',
+				label: 'Server Names',
+				description: 'Comma-separated server display names',
+				options: filtersOptions['mcp_server_display_name']?.map?.(sameLabel) ?? []
+			},
+			{
+				fieldId: 'call_type',
+				filterKey: 'call_type',
+				label: 'Call Types',
+				description: 'Comma-separated call types',
+				options: filtersOptions['call_type']?.map?.(sameLabel) ?? []
+			},
+			{
+				fieldId: 'client_name',
+				filterKey: 'client_name',
+				label: 'Client Names',
+				description: 'Comma-separated client names',
+				options: filtersOptions['client_name']?.map?.(sameLabel) ?? []
+			},
+			{
+				fieldId: 'response_status',
+				filterKey: 'response_status',
+				label: 'Response Status',
+				description: 'Comma-separated HTTP status codes',
+				options: filtersOptions['response_status']?.map?.(sameLabel) ?? []
+			},
+			{
+				fieldId: 'session_id',
+				filterKey: 'session_id',
+				label: 'Session IDs',
+				description: 'Comma-separated session IDs',
+				options: filtersOptions['session_id']?.map?.(sameLabel) ?? []
+			},
+			{
+				fieldId: 'client_ip',
+				filterKey: 'client_ip',
+				label: 'Client IPs',
+				description: 'Comma-separated IP addresses',
+				options: filtersOptions['client_ip']?.map?.(sameLabel) ?? []
+			},
+			{
+				fieldId: 'mcp_server_catalog_entry_name',
+				filterKey: 'mcp_server_catalog_entry_name',
+				label: 'Catalog Entry Names',
+				description: 'Comma-separated catalog entry names',
+				options: filtersOptions['mcp_server_catalog_entry_name']?.map?.(sameLabel) ?? []
+			}
+		];
+	});
+
 	async function handleSubmit() {
 		try {
 			creating = true;
@@ -258,7 +349,7 @@
 	}
 </script>
 
-<div class="dark:bg-surface2 bg-background rounded-md p-6 shadow-sm">
+<div class="paper">
 	<form
 		class="space-y-8"
 		onsubmit={(e) => {
@@ -267,10 +358,8 @@
 		}}
 	>
 		{#if !hasAuditorPermissions}
-			<div
-				class="flex items-start gap-3 rounded-md border border-yellow-500 bg-yellow-500/10 p-4 dark:bg-yellow-500/10"
-			>
-				<AlertTriangle class="size-5 text-yellow-500 dark:text-yellow-500" />
+			<div class="flex items-start gap-3 rounded-md border border-warning bg-warning/10 p-4">
+				<TriangleAlert class="size-5 text-warning" />
 				<div class="text-sm">
 					Exported logs will not include request/response headers and body information. Auditor role
 					is required to access this data.
@@ -301,7 +390,7 @@
 						required={mode !== 'view'}
 						readonly={mode === 'view'}
 					/>
-					<p class="text-on-surface1 text-xs">Unique name for this export schedule</p>
+					<p class="text-muted-content text-xs">Unique name for this export schedule</p>
 				</div>
 				<div class="flex flex-col gap-1">
 					<label class="text-sm font-medium" for="bucket">Bucket Name</label>
@@ -313,7 +402,7 @@
 						required={mode !== 'view'}
 						readonly={mode === 'view'}
 					/>
-					<p class="text-on-surface1 text-xs">Storage bucket name where exports will be saved</p>
+					<p class="text-muted-content text-xs">Storage bucket name where exports will be saved</p>
 				</div>
 			</div>
 
@@ -326,7 +415,7 @@
 					placeholder="Leave empty for default: mcp-audit-logs/YYYY/MM/DD/"
 					readonly={mode === 'view'}
 				/>
-				<p class="text-on-surface1 text-xs">
+				<p class="text-muted-content text-xs">
 					Path prefix within the bucket. If empty, defaults to "mcp-audit-logs/YYYY/MM/DD/" format
 					based on current date.
 				</p>
@@ -339,7 +428,7 @@
 
 			<div class="flex w-[50%] flex-wrap gap-4">
 				<Dropdown
-					class="schedule-dropdown"
+					class="text-input-filled"
 					values={{
 						hourly: 'hourly',
 						daily: 'daily',
@@ -357,7 +446,7 @@
 
 				{#if form.schedule.interval === 'hourly'}
 					<Dropdown
-						class="schedule-dropdown"
+						class="text-input-filled"
 						values={{
 							'0': 'on the hour',
 							'15': '15 minutes past',
@@ -373,7 +462,7 @@
 
 				{#if form.schedule.interval === 'daily'}
 					<Dropdown
-						class="schedule-dropdown"
+						class="text-input-filled"
 						values={{
 							'0': 'midnight',
 							'3': '3 AM',
@@ -399,7 +488,7 @@
 
 				{#if form.schedule.interval === 'weekly'}
 					<Dropdown
-						class="schedule-dropdown"
+						class="text-input-filled"
 						values={{
 							'0': 'Sunday',
 							'1': 'Monday',
@@ -415,7 +504,7 @@
 						}}
 					/>
 					<Dropdown
-						class="schedule-dropdown"
+						class="text-input-filled"
 						values={{
 							'0': 'midnight',
 							'3': '3 AM',
@@ -441,7 +530,7 @@
 
 				{#if form.schedule.interval === 'monthly'}
 					<Dropdown
-						class="schedule-dropdown"
+						class="text-input-filled"
 						values={{
 							'0': '1st',
 							'1': '2nd',
@@ -458,7 +547,7 @@
 						}}
 					/>
 					<Dropdown
-						class="schedule-dropdown"
+						class="text-input-filled"
 						values={{
 							'0': 'midnight',
 							'3': '3 AM',
@@ -492,7 +581,7 @@
 			</p>
 			<div class="flex flex-col gap-1">
 				<Dropdown
-					class="schedule-dropdown w-full max-w-xs"
+					class="text-input-filled w-full max-w-xs"
 					values={{
 						'1': 'Last 1 day',
 						'3': 'Last 3 days',
@@ -533,197 +622,34 @@
 						Leave filters empty to export all logs in each scheduled period
 					</p>
 
+					{#snippet auditScheduleAdvancedFilterField(row: AuditScheduleAdvancedFilterRow)}
+						<div class="flex flex-col gap-1">
+							<label class="text-sm font-medium" for={row.fieldId}>{row.label}</label>
+							<Select
+								id={row.fieldId}
+								class="text-input-filled bg-base-200 dark:bg-base-100"
+								classes={{
+									root: 'w-full',
+									clear: 'hover:bg-base-400 bg-transparent'
+								}}
+								options={row.options}
+								bind:selected={
+									() => form.filters[row.filterKey] ?? '',
+									(v) => {
+										form.filters[row.filterKey] = v ?? '';
+									}
+								}
+								disabled={isViewMode}
+								multiple
+							/>
+							<p class="text-muted-content text-xs">{row.description}</p>
+						</div>
+					{/snippet}
+
 					<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="user_id">User IDs</label>
-							<Select
-								class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['user_id']?.map?.((d) => ({
-									id: d,
-									label: usersMap.get(d)?.displayName ?? d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.user_id ?? '', (v) => (form.filters.user_id = v ?? '')
-								}
-								disabled={isViewMode}
-								multiple
-							/>
-							<p class="text-on-surface1 text-xs">Comma-separated user IDs</p>
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="mcp_id">Server IDs</label>
-							<Select
-								class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['mcp_id']?.map?.((d) => ({ id: d, label: d })) ?? []}
-								bind:selected={
-									() => form.filters.mcp_id ?? '', (v) => (form.filters.mcp_id = v ?? '')
-								}
-								disabled={isViewMode}
-								multiple
-							/>
-							<p class="text-on-surface1 text-xs">Comma-separated server IDs</p>
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="mcp_server_display_name">Server Names</label>
-							<Select
-								class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['mcp_server_display_name']?.map?.((d) => ({
-									id: d,
-									label: d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.mcp_server_display_name ?? '',
-									(v) => (form.filters.mcp_server_display_name = v ?? '')
-								}
-								disabled={isViewMode}
-								multiple
-							/>
-							<p class="text-on-surface1 text-xs">Comma-separated server display names</p>
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="call_type">Call Types</label>
-							<Select
-								class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['call_type']?.map?.((d) => ({
-									id: d,
-									label: d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.call_type ?? '', (v) => (form.filters.call_type = v ?? '')
-								}
-								disabled={isViewMode}
-								multiple
-							/>
-							<p class="text-on-surface1 text-xs">Comma-separated call types</p>
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="client_name">Client Names</label>
-							<Select
-								class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['client_name']?.map?.((d) => ({
-									id: d,
-									label: d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.client_name ?? '', (v) => (form.filters.client_name = v ?? '')
-								}
-								disabled={isViewMode}
-								multiple
-							/>
-							<p class="text-on-surface1 text-xs">Comma-separated client names</p>
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="response_status">Response Status</label>
-							<Select
-								class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['response_status']?.map?.((d) => ({
-									id: d,
-									label: d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.response_status ?? '',
-									(v) => (form.filters.response_status = v ?? '')
-								}
-								disabled={isViewMode}
-								multiple
-							/>
-							<p class="text-on-surface1 text-xs">Comma-separated HTTP status codes</p>
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="session_id">Session IDs</label>
-							<Select
-								class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['session_id']?.map?.((d) => ({
-									id: d,
-									label: d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.session_id ?? '', (v) => (form.filters.session_id = v ?? '')
-								}
-								disabled={isViewMode}
-								multiple
-							/>
-							<p class="text-on-surface1 text-xs">Comma-separated session IDs</p>
-						</div>
-
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="client_ip">Client IPs</label>
-							<Select
-								class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['client_ip']?.map?.((d) => ({
-									id: d,
-									label: d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.client_ip ?? '', (v) => (form.filters.client_ip = v ?? '')
-								}
-								disabled={isViewMode}
-								multiple
-							/>
-							<p class="text-on-surface1 text-xs">Comma-separated IP addresses</p>
-						</div>
-						<div class="flex flex-col gap-1">
-							<label class="text-sm font-medium" for="power_user_workspace_id"
-								>Catalog Entry Names</label
-							>
-							<Select
-								class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
-								classes={{
-									root: 'w-full',
-									clear: 'hover:bg-surface3 bg-transparent'
-								}}
-								options={filtersOptions['mcp_server_catalog_entry_name']?.map?.((d) => ({
-									id: d,
-									label: d
-								})) ?? []}
-								bind:selected={
-									() => form.filters.mcp_server_catalog_entry_name ?? '',
-									(v) => (form.filters.mcp_server_catalog_entry_name = v ?? '')
-								}
-								disabled={isViewMode}
-								multiple
-							/>
-
-							<p class="text-on-surface1 text-xs">Comma-separated catalog entry names</p>
-						</div>
+						{#each auditScheduleAdvancedFilterRows as row (row.fieldId)}
+							{@render auditScheduleAdvancedFilterField(row)}
+						{/each}
 					</div>
 				</div>
 			{/if}
@@ -731,9 +657,9 @@
 
 		<!-- Error Display -->
 		{#if error}
-			<div class="flex items-start gap-3 rounded-md bg-red-50 p-4 dark:bg-red-950/50">
-				<AlertTriangle class="size-5 text-red-600 dark:text-red-400" />
-				<div class="text-sm text-red-700 dark:text-red-300">
+			<div class="flex items-start gap-3 rounded-md bg-error/10 p-4">
+				<TriangleAlert class="size-5 text-error" />
+				<div class="text-sm text-error">
 					{error}
 				</div>
 			</div>
@@ -743,16 +669,16 @@
 		<div class="flex justify-end gap-3 pt-6">
 			<button
 				type="button"
-				class="button"
+				class="btn btn-secondary"
 				onclick={onCancel}
 				disabled={creating && mode !== 'view'}
 			>
 				{mode === 'view' ? 'Back' : 'Cancel'}
 			</button>
 			{#if mode !== 'view'}
-				<button type="submit" class="button-primary" disabled={creating}>
+				<button type="submit" class="btn btn-primary" disabled={creating}>
 					{#if creating}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 						{mode === 'edit' ? 'Saving Changes...' : 'Creating Schedule...'}
 					{:else}
 						{mode === 'edit' ? 'Save Changes' : 'Create Schedule'}
@@ -762,12 +688,3 @@
 		</div>
 	</form>
 </div>
-
-<style lang="postcss">
-	:global(.schedule-dropdown) {
-		background-color: var(--surface2);
-		font-size: var(--text-md);
-		display: flex;
-		flex-grow: 1;
-	}
-</style>

--- a/ui/user/src/lib/components/admin/audit-log-exports/StorageCredentialsForm.svelte
+++ b/ui/user/src/lib/components/admin/audit-log-exports/StorageCredentialsForm.svelte
@@ -4,9 +4,10 @@
 	import Success from '$lib/components/Success.svelte';
 	import Toggle from '$lib/components/Toggle.svelte';
 	import Dropdown from '$lib/components/tasks/Dropdown.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import type { StorageCredentials } from '$lib/services/admin/types';
-	import { AlertTriangle, LoaderCircle, Trash } from 'lucide-svelte';
+	import { TriangleAlert, Trash } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -307,14 +308,14 @@
 </script>
 
 {#if loading}
-	<div class="dark:bg-surface2 bg-background rounded-md p-6 shadow-sm">
+	<div class="dark:bg-base-300 bg-base-100 rounded-md p-6 shadow-sm">
 		<div class="flex items-center justify-center py-8">
-			<LoaderCircle class="text-primary size-6 animate-spin" />
+			<Loading class="size-6" />
 			<span class="ml-2 text-sm text-gray-600">Loading storage credentials...</span>
 		</div>
 	</div>
 {:else}
-	<div class="dark:bg-surface2 bg-background rounded-md p-6 shadow-sm">
+	<div class="paper">
 		<form
 			class="gap-8"
 			onsubmit={(e) => {
@@ -323,10 +324,8 @@
 			}}
 		>
 			{#if existingCredentials}
-				<div
-					class="mb-6 flex items-start gap-3 rounded-md border border-yellow-500 bg-yellow-500/10 p-4"
-				>
-					<AlertTriangle class="size-5 flex-shrink-0 text-yellow-500" />
+				<div class="mb-6 flex items-start gap-3 rounded-md border border-warning bg-warning/10 p-4">
+					<TriangleAlert class="size-5 shrink-0 text-warning" />
 					<div class="flex-1 text-sm">
 						<p class="font-medium">Storage provider already configured</p>
 						<p class="mt-1 opacity-80">
@@ -346,7 +345,7 @@
 						<label class="text-sm font-medium" for="storage-provider">Provider</label>
 						<div class={[!!existingCredentials && 'pointer-events-none opacity-50']}>
 							<Dropdown
-								class="w-full md:w-1/3"
+								class="w-full md:w-1/3 text-input-filled"
 								values={{
 									s3: 'Amazon S3',
 									gcs: 'Google Cloud Storage',
@@ -507,7 +506,7 @@
 									growable
 									hideReveal
 								/>
-								<p class="text-on-surface1 text-xs">
+								<p class="text-muted-content text-xs">
 									Complete JSON key file for the service account
 								</p>
 							</div>
@@ -590,13 +589,13 @@
 				<!-- Test Result -->
 				{#if testResult}
 					<div
-						class={`flex items-start gap-3 rounded-md p-4 ${testResult.success ? 'bg-green-50 dark:bg-green-950/50' : 'bg-red-50 dark:bg-red-950/50'}`}
+						class={`flex items-start gap-3 rounded-md p-4 ${testResult.success ? 'bg-success/10 text-success' : 'bg-error/10 text-error'}`}
 					>
 						{#if testResult.success}
 							<Success message={testResult.message} />
 						{:else}
-							<AlertTriangle class="size-5 text-red-600 dark:text-red-400" />
-							<div class="text-sm text-red-700 dark:text-red-300">
+							<TriangleAlert class="size-5 text-error" />
+							<div class="text-sm text-error">
 								{testResult.message}
 							</div>
 						{/if}
@@ -605,9 +604,9 @@
 
 				<!-- Error Display -->
 				{#if error}
-					<div class="flex items-start gap-3 rounded-md bg-red-50 p-4 dark:bg-red-950/50">
-						<AlertTriangle class="size-5 text-red-600 dark:text-red-400" />
-						<div class="text-sm text-red-700 dark:text-red-300">
+					<div class="flex items-start gap-3 rounded-md bg-error/10 p-4">
+						<TriangleAlert class="size-5 text-error" />
+						<div class="text-sm text-error">
 							{error}
 						</div>
 					</div>
@@ -619,12 +618,12 @@
 				{#if form.provider !== 'custom'}
 					<button
 						type="button"
-						class="button-secondary"
+						class="btn btn-secondary"
 						onclick={handleTest}
 						disabled={testing || saving}
 					>
 						{#if testing}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 							Testing...
 						{:else}
 							Test Connection
@@ -635,12 +634,12 @@
 				{#if !!existingCredentials}
 					<button
 						type="button"
-						class="button-destructive"
+						class="btn btn-error"
 						onclick={confirmDeleteCredentials}
 						disabled={testing || saving || deleting}
 					>
 						{#if deleting}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 							Deleting...
 						{:else}
 							<Trash class="size-4" />
@@ -650,12 +649,17 @@
 				{/if}
 
 				<div class="ml-auto flex gap-3">
-					<button type="button" class="button" onclick={onCancel} disabled={saving || testing}>
+					<button
+						type="button"
+						class="btn btn-secondary"
+						onclick={onCancel}
+						disabled={saving || testing}
+					>
 						Cancel
 					</button>
-					<button type="submit" class="button-primary" disabled={saving || testing}>
+					<button type="submit" class="btn btn-primary" disabled={saving || testing}>
 						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 							Saving...
 						{:else}
 							Save Credentials

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogCalendar.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogCalendar.svelte
@@ -111,7 +111,7 @@
 <div class="flex w-full md:max-w-fit">
 	<button
 		type="button"
-		class="dark:border-surface3 dark:hover:bg-surface2/70 dark:active:bg-surface2 dark:bg-surface1 hover:bg-surface1/70 active:bg-surface1 bg-background relative z-40 flex min-h-12.5 flex-1 flex-shrink-0 items-center gap-2 truncate rounded-l-lg border border-r-0 border-transparent px-2 text-sm shadow-sm transition-colors duration-200 disabled:opacity-50"
+		class="dark:border-base-400 dark:hover:bg-base-300/70 dark:active:bg-base-300 dark:bg-base-100 hover:bg-base-100/70 active:bg-base-100 bg-base-100 relative z-40 flex min-h-12.5 flex-1 shrink-0 items-center gap-2 truncate rounded-l-sm border border-r-0 border-transparent px-4 text-sm shadow-sm transition-colors duration-200 disabled:opacity-50"
 		{disabled}
 		use:refAction
 		onclick={() => {
@@ -129,7 +129,7 @@
 			return () => response.destroy();
 		}}
 	>
-		<span class="bg-surface3 rounded-md px-3 py-1 text-xs">
+		<span class="bg-base-400 rounded-sm px-3 py-1 text-xs">
 			{getTimeRangeShorthand(start, end)}
 		</span>
 		<span>
@@ -168,7 +168,7 @@
 					{#each actions as action (action.label)}
 						<button
 							type="button"
-							class="hover:bg-surface3/25 h-12 w-full min-w-max px-4 py-2 text-center last:border-b-transparent md:h-10 md:text-start"
+							class="hover:bg-base-400/25 h-12 w-full min-w-max px-4 py-2 text-center last:border-b-transparent md:h-10 md:text-start"
 							onclick={action.onpointerdown}
 						>
 							{action.label}
@@ -181,7 +181,7 @@
 
 	<Calendar
 		compact
-		class="dark:border-surface3 hover:bg-surface1 dark:hover:bg-surface3 dark:bg-surface1 bg-background relative z-40 flex min-h-12.5 flex-shrink-0 items-center gap-2 truncate rounded-none rounded-r-lg border border-transparent px-4 text-sm shadow-sm"
+		class="dark:border-base-400 hover:bg-base-100 dark:hover:bg-base-400 dark:bg-base-100 bg-base-100 relative z-40 flex min-h-12.5 shrink-0 items-center gap-2 truncate rounded-none rounded-r-sm border border-transparent px-4 text-sm shadow-sm"
 		initialValue={{
 			start: new Date(start),
 			end: end ? new Date(end) : null

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import CopyButton from '$lib/components/CopyButton.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import { Group, type AuditLog } from '$lib/services/admin/types';
 	import { profile, timePreference } from '$lib/stores';
 	import { formatLogTimestamp } from '$lib/time';
@@ -32,50 +33,48 @@
 	}
 </script>
 
-<div
-	class="dark:bg-gray-990 text-on-background flex h-full w-[inherit] min-w-[inherit] flex-col bg-gray-50"
->
-	<div class="dark:bg-surface1 bg-background relative flex w-full flex-col p-4 pl-5 shadow-xs">
+<div class="bg-base-200 text-base-content flex h-full w-[inherit] min-w-[inherit] flex-col">
+	<div class="dark:bg-base-300 bg-base-100 relative flex w-full flex-col p-4 pl-5 shadow-xs">
 		<div
 			class={twMerge(
 				'absolute top-0 left-0 h-full w-1',
-				auditLog.responseStatus >= 400 ? 'bg-red-500' : 'bg-primary'
+				auditLog.responseStatus >= 400 ? 'bg-error' : 'bg-primary'
 			)}
 		></div>
 		<h3 class="text-lg font-semibold">
 			{formatLogTimestamp(auditLog.createdAt, timePreference.timeFormat)}
 		</h3>
-		<p class="text-on-surface1 text-xs font-light">
+		<p class="text-muted-content text-xs font-light">
 			{auditLog.requestID}
 		</p>
-		<button onclick={onClose} class="icon-button absolute top-1/2 right-4 -translate-y-1/2">
+		<IconButton onclick={onClose} class="absolute top-1/2 right-4 -translate-y-1/2">
 			<X class="size-5" />
-		</button>
+		</IconButton>
 	</div>
 	<div class="default-scrollbar-thin relative h-[calc(100%-60px)] overflow-y-auto pb-4">
-		<div class="bg-surface2 absolute top-0 left-0 h-full w-1"></div>
+		<div class="bg-base-300 absolute top-0 left-0 h-full w-1"></div>
 
 		<div class="flex flex-wrap gap-2 p-4 pl-5">
 			{#if auditLog.callType}
-				<div class="dark:bg-surface3 bg-surface2 rounded-full px-3 py-1 text-[11px] font-light">
+				<div class="bg-base-400 rounded-full px-3 py-1 text-[11px] font-light">
 					<span class="font-medium">Call Type:</span>
 					{auditLog.callType}
 				</div>
 			{/if}
 			{#if auditLog.sessionID}
-				<div class="dark:bg-surface3 bg-surface2 rounded-full px-3 py-1 text-[11px] font-light">
+				<div class="bg-base-400 rounded-full px-3 py-1 text-[11px] font-light">
 					<span class="font-medium">Session ID:</span>
 					{auditLog.sessionID}
 				</div>
 			{/if}
 			{#if auditLog.mcpID}
-				<div class="dark:bg-surface3 bg-surface2 rounded-full px-3 py-1 text-[11px] font-light">
+				<div class="bg-base-400 rounded-full px-3 py-1 text-[11px] font-light">
 					<span class="font-medium">Server:</span>
 					{auditLog.mcpServerDisplayName} ({auditLog.mcpID})
 				</div>
 			{/if}
 			{#if auditLog.mcpServerCatalogEntryName}
-				<div class="dark:bg-surface3 bg-surface2 rounded-full px-3 py-1 text-[11px] font-light">
+				<div class="bg-base-400 rounded-full px-3 py-1 text-[11px] font-light">
 					<span class="font-medium">Parent Entry ID:</span>
 					{auditLog.mcpServerCatalogEntryName}
 				</div>
@@ -91,7 +90,7 @@
 				{#if auditLog.apiKey}
 					<p>
 						<span class="font-medium">API Key</span>: {auditLog.apiKey}***
-						<span class="text-on-surface1 text-xs italic">(redacted)</span>
+						<span class="text-muted-content text-xs italic">(redacted)</span>
 					</p>
 				{/if}
 				{#if auditLog.userAgent}
@@ -113,7 +112,7 @@
 					<p class="my-2 text-base font-semibold">Request Headers</p>
 
 					<div
-						class="dark:bg-surface2 bg-background relative flex flex-col gap-2 overflow-hidden rounded-md p-4 pl-5"
+						class="dark:bg-base-300 bg-base-100 relative flex flex-col gap-2 overflow-hidden rounded-md p-4 pl-5"
 					>
 						<div class="bg-primary/50 absolute top-0 left-0 h-full w-1"></div>
 						<div class="flex flex-col gap-1">
@@ -149,7 +148,7 @@
 					<p
 						class={twMerge(
 							'w-fit rounded-full px-3 py-1 text-xs font-semibold text-white',
-							auditLog.responseStatus >= 400 ? 'bg-red-500' : 'bg-primary'
+							auditLog.responseStatus >= 400 ? 'bg-error' : 'bg-primary'
 						)}
 					>
 						{auditLog.responseStatus}
@@ -161,7 +160,7 @@
 				{#if auditLog.responseHeaders}
 					<p class="mt-4 mb-2 text-base font-semibold">Response Headers</p>
 					<div
-						class="dark:bg-surface2 bg-background relative flex flex-col gap-2 overflow-hidden rounded-md p-4 pl-5"
+						class="dark:bg-base-300 bg-base-100 relative flex flex-col gap-2 overflow-hidden rounded-md p-4 pl-5"
 					>
 						<div class="bg-primary/50 absolute top-0 left-0 h-full w-1"></div>
 						<div class="flex flex-col gap-1">
@@ -180,7 +179,7 @@
 			{#if auditLog.error}
 				<div class="mt-4 flex flex-col">
 					<div class="mb-2 text-base font-semibold">Response Error</div>
-					<p class="text-red-500">{auditLog.error}</p>
+					<p class="text-error">{auditLog.error}</p>
 				</div>
 			{/if}
 
@@ -235,7 +234,7 @@
 
 {#snippet noAuditorAccessInfo(name: string)}
 	<p class="mt-4 mb-2 text-base font-semibold">{name}</p>
-	<div class="text-on-surface1 text-xs">
+	<div class="text-muted-content text-xs">
 		<i>Details are hidden; auditor role is required to access this information.</i>
 	</div>
 {/snippet}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogs.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogs.svelte
@@ -112,7 +112,7 @@
 {#snippet th(content: string, { class: klass = '', minWidth = '0ch' } = {})}
 	<th
 		class={twMerge(
-			'dark:bg-surface1 text-on-surface1 sticky top-0 box-content w-[24ch] truncate text-left text-xs font-medium tracking-wider uppercase',
+			'dark:bg-base-200 bg-base-300 text-muted-content sticky top-0 box-content w-[24ch] truncate text-left text-xs font-medium tracking-wider uppercase',
 			klass
 		)}
 		data-min-width={minWidth}
@@ -164,7 +164,7 @@
 <!-- Data Table -->
 <div
 	bind:this={tableContainer}
-	class="dark:bg-surface2 bg-background flex w-full min-w-full flex-1 divide-y divide-gray-200 overflow-x-auto overflow-y-visible rounded-lg border border-transparent shadow-sm"
+	class="dark:bg-base-300 bg-base-100 flex w-full min-w-full flex-1 divide-y divide-gray-200 overflow-x-auto overflow-y-visible rounded-lg border border-transparent shadow-sm"
 >
 	{#if data.length}
 		<VirtualPageTable class={twMerge('w-full flex-1 table-fixed border-collapse border-spacing-0')}>
@@ -172,7 +172,7 @@
 				<thead>
 					<tr bind:this={headerRowElement}>
 						<th
-							class="dark:bg-surface1 bg-surface2 text-on-surface1 sticky top-0 box-content w-[4ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
+							class="bg-base-300 dark:bg-base-200 text-muted-content sticky top-0 box-content w-[4ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
 						>
 							<div>#</div>
 						</th>
@@ -207,7 +207,7 @@
 					<tr
 						class={twMerge(
 							'group m-0 h-14 text-sm leading-0 text-[0] transition-colors duration-300',
-							onSelectRow && 'hover:bg-surface1 dark:hover:bg-surface3 cursor-pointer'
+							onSelectRow && 'hover:bg-base-200 dark:hover:bg-base-400 cursor-pointer'
 						)}
 						onclick={() => onSelectRow?.(d)}
 					>

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -254,6 +254,12 @@
 		);
 	});
 
+	const hasFilterPills = $derived(Object.keys(pillsSearchParamFilters).length > 0);
+
+	const showAuditExportActions = $derived(
+		profile.current.groups.includes(Group.ADMIN) || profile.current.groups.includes(Group.OWNER)
+	);
+
 	// Filters to be used in the audit logs slideover
 	// Exclude filters that are set via props and not undefined
 	const auditLogsSlideoverFilters = $derived.by(() => {
@@ -536,7 +542,7 @@
 		out:fade|global={{ duration: 300, delay: 500 }}
 	>
 		<div
-			class="bg-surface3/50 border-surface3 text-primary dark:text-primary flex flex-col items-center gap-4 rounded-2xl border px-16 py-8 shadow-md backdrop-blur-[1px]"
+			class="bg-base-400/50 border-base-400 text-primary dark:text-primary flex flex-col items-center gap-4 rounded-2xl border px-16 py-8 shadow-md backdrop-blur-[1px]"
 		>
 			<Loading class="size-32 stroke-1" />
 			<div class="text-2xl font-semibold">Loading logs...</div>
@@ -544,16 +550,16 @@
 	</div>
 {/if}
 
-<div class="flex flex-col justify-end gap-2">
-	<div class="flex flex-col gap-4 md:flex-row">
+<div class="flex flex-col justify-end gap-2 @container">
+	<div class="flex flex-col gap-4 @min-[768px]:flex-row">
 		<Search
-			class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 			onChange={handleQueryChange}
 			placeholder="Search..."
 			value={query}
 		/>
 
-		<div class="flex flex-col gap-2 self-start md:self-end">
+		<div class="flex flex-col gap-2 self-start @min-[768px]:self-end">
 			<div class="flex gap-4">
 				<AuditLogCalendar
 					start={timeRangeFilters.startTime}
@@ -562,7 +568,7 @@
 				/>
 
 				<button
-					class="hover:bg-surface1 dark:bg-surface1 dark:hover:bg-surface3 dark:border-surface3 button bg-background flex w-fit items-center justify-center gap-1 rounded-lg border border-transparent shadow-sm"
+					class="btn btn-neutral h-12.5"
 					onclick={() => {
 						showFilters = true;
 						selectedAuditLog = undefined;
@@ -575,46 +581,58 @@
 			</div>
 		</div>
 	</div>
-	{#if profile.current.groups.includes(Group.ADMIN) || profile.current.groups.includes(Group.OWNER)}
-		<div class="mt-4 flex justify-end gap-2">
-			<DotDotDot class="button-primary w-fit text-sm" placement="bottom">
-				{#snippet icon()}
-					<span class="flex items-center justify-center gap-1">
-						<Plus class="size-4" /> Create Export
-					</span>
-				{/snippet}
-				<button class="menu-button" onclick={() => handleExportRequest('export')}>
-					Create One-time Export
-				</button>
-				<button class="menu-button" onclick={() => handleExportRequest('scheduled')}>
-					Create Export Schedule
-				</button>
-			</DotDotDot>
+	{#if hasFilterPills || showAuditExportActions}
+		<div
+			class="{showAuditExportActions
+				? 'mt-4'
+				: ''} flex flex-col flex-nowrap gap-4 @min-[768px]:flex-row"
+		>
+			<div class="min-w-0 grow hidden @min-[768px]:block">
+				{@render filters()}
+			</div>
+			{#if showAuditExportActions}
+				<div class="@min-[768px]:ml-auto flex shrink-0 gap-4">
+					<DotDotDot class="btn btn-block btn-primary w-fit text-sm" placement="bottom">
+						{#snippet icon()}
+							<span class="flex items-center justify-center gap-1">
+								<Plus class="size-4" /> Create Export
+							</span>
+						{/snippet}
+						<button class="menu-button" onclick={() => handleExportRequest('export')}>
+							Create One-time Export
+						</button>
+						<button class="menu-button" onclick={() => handleExportRequest('scheduled')}>
+							Create Export Schedule
+						</button>
+					</DotDotDot>
 
-			<button
-				class="hover:bg-surface1 dark:bg-surface1 dark:hover:bg-surface3 dark:border-surface3 button bg-background flex w-fit items-center justify-center gap-1 rounded-lg border border-transparent shadow-sm"
-				onclick={() => {
-					goto('/admin/audit-logs/exports');
-				}}
-			>
-				<Settings class="size-4" />
-				Manage Exports
-			</button>
+					<button
+						class="btn btn-neutral rounded-4xl"
+						onclick={() => {
+							goto('/admin/audit-logs/exports');
+						}}
+					>
+						<Settings class="size-4" />
+						Manage Exports
+					</button>
+				</div>
+			{/if}
+			<div class="min-w-0 grow block @min-[768px]:hidden">
+				{@render filters()}
+			</div>
 		</div>
 	{/if}
 </div>
 
-{@render filters()}
-
 {#if auditLogsTotalItems > 0}
 	<!-- Timeline Graph (Placeholder) -->
 	<div
-		class="dark:bg-surface2 dark:border-surface3 bg-background text-on-background rounded-lg border border-transparent shadow-sm"
+		class="dark:bg-base-300 dark:border-base-400 bg-base-100 text-muted-content rounded-lg border border-transparent shadow-sm"
 	>
-		<h3 class="mb-2 px-4 pt-4 text-lg font-medium">Timeline</h3>
+		<h3 class="mb-6 px-4 pt-4 text-xs uppercase font-medium">Timeline</h3>
 		<div class="px-4">
 			{#if displayTimelineData.length > 0}
-				<div class="text-on-surface1 flex h-40 items-center justify-center rounded-md">
+				<div class="text-muted-content flex h-40 items-center justify-center rounded-md">
 					<StackedTimeline
 						start={timeRangeFilters.startTime}
 						end={timeRangeFilters.endTime}
@@ -627,14 +645,14 @@
 				</div>
 			{:else}
 				<div
-					class="text-on-surface1 flex h-40 items-center justify-center gap-2 rounded-md text-sm"
+					class="text-muted-content flex h-40 items-center justify-center gap-2 rounded-md text-sm"
 				>
 					<Loading class="size-5 animate-spin" />
 					<span>Preparing timeline…</span>
 				</div>
 			{/if}
 		</div>
-		<hr class="dark:border-surface3 my-4 border" />
+		<hr class="dark:border-base-400 my-4 border" />
 		<div class="flex items-center justify-between gap-2 px-4 pb-4 text-xs text-gray-600">
 			<div class="flex gap-4">
 				<div>{Intl.NumberFormat().format(remoteAuditLogs.length)} results</div>
@@ -652,7 +670,7 @@
 
 			<div class="flex gap-4">
 				<button
-					class="hover:text-on-surface1/80 active:text-on-surface1/100 flex items-center text-xs transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50"
+					class="hover:text-muted-content active:text-base-content/80 flex items-center text-xs transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50"
 					disabled={isReachedMin}
 					onclick={prevPage}
 				>
@@ -661,7 +679,7 @@
 				</button>
 
 				<button
-					class="hover:text-on-surface1/80 active:text-on-surface1/100 flex items-center text-xs transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50"
+					class="hover:text-muted-content active:text-base-content/80 flex items-center text-xs transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50"
 					disabled={isReachedMax}
 					onclick={nextPage}
 				>
@@ -692,16 +710,16 @@
 			{emptyContent}
 		></AuditLogsTable>
 	{:else if remoteAuditLogs.length > 0}
-		<div class="text-on-surface1 flex items-center justify-center gap-2 py-12 text-sm font-light">
+		<div class="text-muted-content flex items-center justify-center gap-2 py-12 text-sm font-light">
 			<Loading class="size-5 animate-spin" />
 			<span>Preparing results…</span>
 		</div>
 	{/if}
 {:else if !showLoadingSpinner}
 	<div class="mt-12 flex w-md max-w-full flex-col items-center gap-4 self-center text-center">
-		<Captions class="text-on-surface1 size-24 opacity-50" />
-		<h4 class="text-on-surface1 text-lg font-semibold">No audit logs</h4>
-		<p class="text-on-surface1 text-sm font-light">
+		<Captions class="text-muted-content size-24 opacity-50" />
+		<h4 class="text-muted-content text-lg font-semibold">No audit logs</h4>
+		<p class="text-muted-content text-sm font-light">
 			Currently, there are no audit logs for selected range or filters. Try modifying your search
 			criteria or try again later.
 		</p>
@@ -833,9 +851,9 @@
 <!-- Filter Confirmation Dialog -->
 {#if showFilterConfirmDialog}
 	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-		<div class="dark:bg-surface2 bg-background w-full max-w-2xl rounded-lg p-6 shadow-xl">
+		<div class="dark:bg-base-300 bg-base-100 w-full max-w-2xl rounded-lg p-6 shadow-xl">
 			<h3 class="mb-4 text-lg font-semibold">Apply Current Filters to Export?</h3>
-			<p class="text-on-surface1 mb-4 text-sm">
+			<p class="text-muted-content mb-4 text-sm">
 				You have active filters applied to the audit logs. Would you like to include these filters
 				in the export?
 			</p>
@@ -847,13 +865,13 @@
 					string
 				][]}
 				<div class="mb-4 rounded-md bg-gray-50 p-3 dark:bg-gray-800">
-					<h4 class="mb-2 text-xs font-medium text-gray-700 dark:text-gray-300">Active Filters:</h4>
-					<div class="text-on-surface1 space-y-1 text-xs">
+					<h4 class="mb-2 text-xs font-medium text-muted-content">Active Filters:</h4>
+					<div class="text-muted-content space-y-1 text-xs">
 						{#if query}
-							<div class="break-words"><strong>Search:</strong> {query}</div>
+							<div class="wrap-break-word"><strong>Search:</strong> {query}</div>
 						{/if}
 						{#each entries as [key, value] (key)}
-							<div class="break-words">
+							<div class="wrap-break-word">
 								<strong>{getFilterDisplayLabel(key)}:</strong>
 								{getFilterDisplayValue(key, value)}
 							</div>
@@ -863,8 +881,10 @@
 			{/if}
 
 			<div class="flex justify-end gap-3">
-				<button class="button" onclick={() => handleFilterConfirmation(false)}> No </button>
-				<button class="button-primary" onclick={() => handleFilterConfirmation(true)}>
+				<button class="btn btn-secondary" onclick={() => handleFilterConfirmation(false)}>
+					No
+				</button>
+				<button class="btn btn-primary" onclick={() => handleFilterConfirmation(true)}>
 					Yes, Include Filters
 				</button>
 			</div>

--- a/ui/user/src/lib/components/admin/device-scan/DeviceScanDonutCard.svelte
+++ b/ui/user/src/lib/components/admin/device-scan/DeviceScanDonutCard.svelte
@@ -40,11 +40,11 @@
 	<div class="flex items-baseline justify-between gap-2">
 		<h4 class="font-semibold">{title}</h4>
 		{#if totalGroups > topN}
-			<span class="text-on-surface1 text-xs">
+			<span class="text-muted-content text-xs">
 				top {topN} of {totalGroups}
 			</span>
 		{:else if totalGroups > 0}
-			<span class="text-on-surface1 text-xs">
+			<span class="text-muted-content text-xs">
 				{totalGroups}
 				{totalGroups === 1 ? 'entry' : 'entries'}
 			</span>
@@ -52,7 +52,7 @@
 	</div>
 
 	{#if buckets.length === 0}
-		<p class="text-on-surface1 py-8 text-center text-sm font-light">{emptyMsg}</p>
+		<p class="text-muted-content py-8 text-center text-sm font-light">{emptyMsg}</p>
 	{:else}
 		<div class={twMerge('flex flex-col items-center gap-4', !legendOnBottom && 'sm:flex-row')}>
 			<div class={twMerge('h-56 w-56 shrink-0', classes?.graphContainer)}>
@@ -75,13 +75,13 @@
 										e.ctrlKey || e.metaKey
 									);
 								}}
-								class="hover:bg-surface1 dark:hover:bg-surface2 group -mx-1 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
+								class="hover:bg-base-200 dark:hover:bg-base-300 group -mx-1 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
 							>
 								<span class="size-3 shrink-0 rounded-full" style="background-color: {bucket.color}"
 								></span>
 								<span class="flex-1 truncate">{bucket.label}</span>
-								<span class="text-on-surface1 tabular-nums">{bucket.value}</span>
-								<ChevronRight class="text-on-surface1 size-3 opacity-0 group-hover:opacity-100" />
+								<span class="text-muted-content tabular-nums">{bucket.value}</span>
+								<ChevronRight class="text-muted-content size-3 opacity-0 group-hover:opacity-100" />
 							</a>
 						</li>
 					{:else if bucket.drilldown === 'skill' && !bucket.isOther}
@@ -95,29 +95,29 @@
 										e.ctrlKey || e.metaKey
 									);
 								}}
-								class="hover:bg-surface1 dark:hover:bg-surface2 group -mx-1 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
+								class="hover:bg-base-200 dark:hover:bg-base-300 group -mx-1 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
 							>
 								<span class="size-3 shrink-0 rounded-full" style="background-color: {bucket.color}"
 								></span>
 								<span class="flex-1 truncate">{bucket.label}</span>
-								<span class="text-on-surface1 tabular-nums">{bucket.value}</span>
-								<ChevronRight class="text-on-surface1 size-3 opacity-0 group-hover:opacity-100" />
+								<span class="text-muted-content tabular-nums">{bucket.value}</span>
+								<ChevronRight class="text-muted-content size-3 opacity-0 group-hover:opacity-100" />
 							</a>
 						</li>
 					{:else}
 						<li
 							class="-mx-1 flex items-center gap-2 rounded-md px-1 py-0.5"
-							class:text-on-surface1={bucket.isOther}
+							class:text-muted-content={bucket.isOther}
 						>
 							<span class="size-3 shrink-0 rounded-full" style="background-color: {bucket.color}"
 							></span>
 							<span class="flex-1 truncate" class:italic={bucket.isOther}>
 								{bucket.label}
 								{#if bucket.isOther && bucket.otherCount !== undefined}
-									<span class="text-on-surface1 ml-1 not-italic">({bucket.otherCount} more)</span>
+									<span class="text-muted-content ml-1 not-italic">({bucket.otherCount} more)</span>
 								{/if}
 							</span>
-							<span class="text-on-surface1 tabular-nums">{bucket.value}</span>
+							<span class="text-muted-content tabular-nums">{bucket.value}</span>
 						</li>
 					{/if}
 				{/each}

--- a/ui/user/src/lib/components/admin/device-scan/DeviceScanTimelineCard.svelte
+++ b/ui/user/src/lib/components/admin/device-scan/DeviceScanTimelineCard.svelte
@@ -22,7 +22,7 @@
 	<div class="flex items-baseline justify-between gap-2">
 		<h4 class="font-semibold">Scan Timeline</h4>
 		{#if totalSubmissions > 0}
-			<span class="text-on-surface1 text-xs">
+			<span class="text-muted-content text-xs">
 				{totalSubmissions}
 				{totalSubmissions === 1 ? 'submission' : 'submissions'}
 			</span>
@@ -30,11 +30,13 @@
 	</div>
 
 	{#if timelineRows.length === 0}
-		<p class="text-on-surface1 flex min-h-56 flex-1 items-center justify-center text-sm font-light">
+		<p
+			class="text-muted-content flex min-h-56 flex-1 items-center justify-center text-sm font-light"
+		>
 			{emptyMsg}
 		</p>
 	{:else}
-		<div class="text-on-surface1 flex min-h-56 flex-1 items-center justify-center">
+		<div class="text-muted-content flex min-h-56 flex-1 items-center justify-center">
 			<StackedTimeline
 				start={new Date(rangeStart)}
 				end={new Date(rangeEnd)}

--- a/ui/user/src/lib/components/admin/device-scan/deviceScanTopBuckets.ts
+++ b/ui/user/src/lib/components/admin/device-scan/deviceScanTopBuckets.ts
@@ -15,7 +15,7 @@ export const DEVICE_SCAN_PALETTE = [
 	'#7f3b08'
 ];
 
-export const DEVICE_SCAN_OTHER_COLOR = 'var(--surface3, #6b7280)';
+export const DEVICE_SCAN_OTHER_COLOR = 'var(--color-base-400, #6b7280)';
 
 export type DeviceScanDrilldown = 'mcp' | 'skill' | undefined;
 

--- a/ui/user/src/lib/components/admin/filters-drawer/FilterField.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FilterField.svelte
@@ -114,10 +114,10 @@
 
 	<Select
 		id={`filter-${filter.property}`}
-		class="dark:border-surface3 bg-surface1 dark:bg-background border border-transparent shadow-inner"
+		class="dark:border-base-400 bg-base-200 dark:bg-base-100 border border-transparent shadow-inner"
 		classes={{
 			root: 'w-full',
-			clear: 'hover:bg-surface3 bg-transparent'
+			clear: 'hover:bg-base-400 bg-transparent'
 		}}
 		{options}
 		bind:selected={

--- a/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
@@ -7,6 +7,7 @@
 
 <script lang="ts">
 	import { page } from '$app/state';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import { AdminService } from '$lib/services';
 	import { AUDIT_LOG_FILTER_OPTIONS_LIMIT } from '$lib/services/admin/operations';
 	import type { AuditLogURLFilters } from '$lib/services/admin/types';
@@ -159,13 +160,13 @@
 </script>
 
 <div
-	class="dark:border-surface3 text-on-background h-dvh w-screen border-l border-transparent md:w-lg lg:w-xl"
+	class="dark:border-base-400 text-base-content h-dvh w-screen border-l border-transparent md:w-lg lg:w-xl"
 >
 	<div class="relative w-full text-center">
 		<h4 class="p-4 text-xl font-semibold">Filters</h4>
-		<button class="icon-button absolute top-1/2 right-4 -translate-y-1/2" onclick={onClose}>
+		<IconButton class="absolute top-1/2 right-4 -translate-y-1/2" onclick={onClose}>
 			<X class="size-5" />
-		</button>
+		</IconButton>
 	</div>
 	<div
 		class="default-scrollbar-thin flex h-[calc(100%-60px)] w-full flex-col gap-4 overflow-y-auto p-4 pt-0"
@@ -189,11 +190,11 @@
 		{/each}
 		<div class="mt-auto flex flex-col gap-2">
 			<button
-				class="button-secondary text-md w-full rounded-lg px-4 py-2"
+				class="btn btn-secondary text-md w-full rounded-lg px-4 py-2"
 				onclick={handleClearAllFilters}>Clear All</button
 			>
 			<button
-				class="button-primary text-md w-full rounded-lg px-4 py-2"
+				class="btn btn-primary text-md w-full rounded-lg px-4 py-2"
 				onclick={handleApplyFilters}>Apply Filters</button
 			>
 		</div>

--- a/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
+++ b/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { afterNavigate } from '$app/navigation';
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import type { DateRange } from '$lib/components/Calendar.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
@@ -545,7 +545,7 @@
 		out:fade|global={{ duration: 300, delay: 500 }}
 	>
 		<div
-			class="bg-surface3/50 border-surface3 text-primary flex flex-col items-center gap-4 rounded-2xl border px-16 py-8 shadow-md backdrop-blur-[1px]"
+			class="bg-base-400/50 border-base-400 text-primary flex flex-col items-center gap-4 rounded-2xl border px-16 py-8 shadow-md backdrop-blur-[1px]"
 		>
 			<Loading class="size-32 stroke-1" />
 			<div class="text-2xl font-semibold">Loading stats...</div>
@@ -554,7 +554,14 @@
 {/if}
 
 <div class="flex flex-col gap-8">
-	<div class="flex flex-col">
+	<div class="flex gap-4 justify-between">
+		<!-- Summary with filter button -->
+		<div class="flex shrink-0 items-center justify-between gap-4">
+			<div class="flex-1">
+				<StatBar startTime={filters?.start_time ?? ''} endTime={filters?.end_time ?? ''} />
+			</div>
+		</div>
+
 		<div class="flex w-full justify-end gap-4">
 			<AuditLogCalendar
 				start={timeRangeFilters.startTime}
@@ -564,7 +571,7 @@
 
 			{#if !mcpId}
 				<button
-					class="hover:bg-surface1 dark:bg-surface1 dark:hover:bg-surface3 dark:border-surface3 button bg-background flex h-12 w-fit items-center justify-center gap-1 rounded-lg border border-transparent shadow-sm"
+					class="btn btn-neutral h-12.5"
 					onclick={() => {
 						showFilters = true;
 						rightSidebar?.showPopover();
@@ -579,18 +586,11 @@
 
 	{@render filtersPill()}
 
-	<!-- Summary with filter button -->
-	<div class="flex items-center justify-between gap-4">
-		<div class="flex-1">
-			<StatBar startTime={filters?.start_time ?? ''} endTime={filters?.end_time ?? ''} />
-		</div>
-	</div>
-
 	{#if !showLoadingSpinner && !hasData(filteredGraphConfigs)}
 		<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-			<ChartBarDecreasing class="text-on-surface1 size-24 opacity-50" />
-			<h4 class="text-on-surface1 text-lg font-semibold">No usage stats</h4>
-			<p class="text-on-surface1 w-sm text-sm font-light">
+			<ChartBarDecreasing class="text-muted-content size-24 opacity-50" />
+			<h4 class="text-muted-content text-lg font-semibold">No usage stats</h4>
+			<p class="text-muted-content w-sm text-sm font-light">
 				Currently, there are no usage stats for the range or selected filters. Try modifying your
 				search criteria or try again later.
 			</p>
@@ -604,66 +604,68 @@
 				{@const maxPage = Math.max(0, Math.ceil(total / graphPageSize) - 1)}
 				{@const paginated = full.slice(page * graphPageSize, (page + 1) * graphPageSize)}
 
-				<div
-					class="dark:bg-surface1 dark:border-surface3 bg-background rounded-md border border-transparent p-6 shadow-sm"
-				>
-					<h3 class="text-lg font-semibold">{cfg.label}</h3>
+				<div class="paper p-0">
+					<h3
+						class="text-xs uppercase font-medium tracking-wider border-b dark:border-base-400 border-base-300 px-4 py-2 rounded-t-md"
+					>
+						{cfg.label}
+					</h3>
 
-					<div class="text-on-surface1 h-[300px] min-h-[300px]">
-						{#if paginated.length > 0}
-							<HorizontalBarGraph
-								data={paginated}
-								labelKey={cfg.xKey}
-								valueKey={cfg.yKey}
-								formatLabel={cfg.formatXLabel}
-								formatValue={(value) => Math.round(value).toString()}
-							>
-								{#snippet tooltipContent(item)}
-									<div class="flex flex-col gap-0 text-xs">
-										<div class="text-on-surface1 text-xs">{item.label}</div>
-									</div>
-									<div class="text-on-background font-semibold">
-										{cfg.formatTooltipText
-											? cfg.formatTooltipText(item.row as Record<string, string | number>)
-											: `${item.value} ${cfg.tooltip}`}
-									</div>
-								{/snippet}
-							</HorizontalBarGraph>
-						{:else if !showLoadingSpinner}
+					<div class="p-4">
+						<div class="text-muted-content h-[300px] min-h-[300px]">
+							{#if paginated.length > 0}
+								<HorizontalBarGraph
+									data={paginated}
+									labelKey={cfg.xKey}
+									valueKey={cfg.yKey}
+									formatLabel={cfg.formatXLabel}
+									formatValue={(value) => Math.round(value).toString()}
+								>
+									{#snippet tooltipContent(item)}
+										<div class="flex flex-col gap-0 text-xs">
+											<div class="text-muted-content text-xs">{item.label}</div>
+										</div>
+										<div class="text-base-content font-semibold">
+											{cfg.formatTooltipText
+												? cfg.formatTooltipText(item.row as Record<string, string | number>)
+												: `${item.value} ${cfg.tooltip}`}
+										</div>
+									{/snippet}
+								</HorizontalBarGraph>
+							{:else if !showLoadingSpinner}
+								<div
+									class="text-muted-content flex h-[300px] items-center justify-center text-sm font-light"
+								>
+									No data available
+								</div>
+							{/if}
+						</div>
+
+						{#if maxPage > 0}
 							<div
-								class="text-on-surface1 flex h-[300px] items-center justify-center text-sm font-light"
+								class="mt-4 flex items-center justify-center gap-4 border-t border-base-400 p-4 pb-0"
 							>
-								No data available
+								<IconButton
+									onclick={() => setGraphPage(cfg.id, Math.max(0, page - 1))}
+									disabled={page === 0}
+									tooltip={{ text: 'Previous Page' }}
+								>
+									<ChevronsLeft class="size-5" />
+								</IconButton>
+								<span class="text-sm">
+									Page {page + 1} of {maxPage + 1}
+									(showing {Math.min(graphPageSize, total - page * graphPageSize)} of {total} items)
+								</span>
+								<IconButton
+									onclick={() => setGraphPage(cfg.id, Math.min(maxPage, page + 1))}
+									disabled={page >= maxPage}
+									tooltip={{ text: 'Next Page' }}
+								>
+									<ChevronsRight class="size-5" />
+								</IconButton>
 							</div>
 						{/if}
 					</div>
-
-					{#if maxPage > 0}
-						<div
-							class="mt-4 flex items-center justify-center gap-4 border-t border-gray-200 p-4 pb-0 dark:border-gray-700"
-						>
-							<button
-								class="icon-button"
-								onclick={() => setGraphPage(cfg.id, Math.max(0, page - 1))}
-								disabled={page === 0}
-								use:tooltip={'Previous Page'}
-							>
-								<ChevronsLeft class="size-5" />
-							</button>
-							<span class="text-sm">
-								Page {page + 1} of {maxPage + 1}
-								(showing {Math.min(graphPageSize, total - page * graphPageSize)} of {total} items)
-							</span>
-							<button
-								class="icon-button"
-								onclick={() => setGraphPage(cfg.id, Math.min(maxPage, page + 1))}
-								disabled={page >= maxPage}
-								use:tooltip={'Next Page'}
-							>
-								<ChevronsRight class="size-5" />
-							</button>
-						</div>
-					{/if}
 				</div>
 			{/each}
 		</div>

--- a/ui/user/src/lib/components/agents/AgentCopy.svelte
+++ b/ui/user/src/lib/components/agents/AgentCopy.svelte
@@ -30,7 +30,7 @@
 				{template.projectSnapshot.name || 'Unnamed Project'}
 			</h3>
 			{#if template.projectSnapshotLastUpgraded}
-				<div class="text-on-surface1 mt-0.5 text-[12px]">
+				<div class="text-muted-content mt-0.5 text-[12px]">
 					Last Updated: {new Date(template.projectSnapshotLastUpgraded).toLocaleString(undefined, {
 						year: 'numeric',
 						month: 'short',
@@ -50,8 +50,8 @@
 			</div>
 		{/if}
 
-		<div class="mt-2 flex flex-col gap-4 border-t border-gray-100 pt-4 dark:border-gray-700">
-			<p class="text-on-surface1 px-2 text-sm font-light">
+		<div class="mt-2 flex flex-col gap-4 border-t border-base-400 pt-4">
+			<p class="text-muted-content px-2 text-sm font-light">
 				This project was shared by a user and may include instructions, MCP servers, knowledge
 				files, and task definitions that were not reviewed or verified by our team. It could
 				interact with external systems, access additional data sources, or behave in unexpected
@@ -59,11 +59,11 @@
 				to proceed at your own discretion.
 			</p>
 			<div class="flex flex-col items-center gap-3">
-				<button onclick={launchProject} class="button-primary w-full max-w-xs">
+				<button onclick={launchProject} class="btn btn-primary w-full max-w-xs">
 					Launch Project
 				</button>
 				{#if onBack}
-					<button onclick={onBack} class="button w-full max-w-xs"> Go Back </button>
+					<button onclick={onBack} class="btn btn-secondary w-full max-w-xs"> Go Back </button>
 				{/if}
 			</div>
 		</div>

--- a/ui/user/src/lib/components/api-keys/ApiKeyDetails.svelte
+++ b/ui/user/src/lib/components/api-keys/ApiKeyDetails.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { stripMarkdownToText } from '$lib/markdown';
@@ -8,6 +7,7 @@
 	import { mcpServersAndEntries, profile } from '$lib/stores';
 	import { formatTimeAgo, formatTimeUntil } from '$lib/time';
 	import Confirm from '../Confirm.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Server, Trash2 } from 'lucide-svelte';
 	import { fly } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -69,19 +69,19 @@
 					{apiKey.name || 'API Key'}
 				</h1>
 				{#if apiKey.userId.toString() === profile.current.id}
-					<button
-						class="button-destructive flex items-center gap-1 text-xs font-normal"
-						use:tooltip={'Delete API Key'}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete API Key' }}
 						disabled={saving}
 						onclick={() => (deletingApiKey = true)}
 					>
 						<Trash2 class="size-4" />
-					</button>
+					</IconButton>
 				{/if}
 			</div>
 
 			<div
-				class="dark:bg-surface2 dark:border-surface3 bg-background rounded-lg border border-transparent p-4"
+				class="dark:bg-base-300 dark:border-base-400 bg-base-100 rounded-lg border border-transparent p-4"
 			>
 				<div class="flex flex-col gap-6">
 					<div class="flex flex-col gap-2">
@@ -182,27 +182,27 @@
 								<div
 									class={twMerge(
 										'flex w-full items-center gap-3 px-4 py-3',
-										!d.exists && 'bg-yellow-500/5'
+										!d.exists && 'bg-warning/5'
 									)}
 								>
-									<div class="flex-shrink-0">
+									<div class="shrink-0">
 										{#if d.icon}
 											<img src={d.icon} alt={d.name} class="size-6" />
 										{:else}
-											<Server class="text-on-surface1 size-6" />
+											<Server class="text-muted-content size-6" />
 										{/if}
 									</div>
 									<div class="flex min-w-0 grow flex-col">
 										<p
 											class={twMerge(
 												'truncate text-sm',
-												!d.exists && 'text-on-surface1 font-light italic'
+												!d.exists && 'text-muted-content font-light italic'
 											)}
 										>
 											{d.name}
 										</p>
 										{#if d.description}
-											<span class="text-on-surface1 line-clamp-1 text-xs">
+											<span class="text-muted-content line-clamp-1 text-xs">
 												{stripMarkdownToText(d.description)}
 											</span>
 										{/if}

--- a/ui/user/src/lib/components/api-keys/ServersLabel.svelte
+++ b/ui/user/src/lib/components/api-keys/ServersLabel.svelte
@@ -46,7 +46,7 @@
 </script>
 
 {#snippet serverName(item: DisplayItem)}
-	{#if item.deleted}<i class="text-on-surface1 font-light italic">({item.name})</i
+	{#if item.deleted}<i class="text-muted-content font-light italic">({item.name})</i
 		>{:else}{item.name}{/if}
 {/snippet}
 
@@ -70,7 +70,7 @@
 			class="inline-block"
 			use:tooltip={`Includes ${deletedServersCount} deleted server${deletedServersCount === 1 ? '' : 's'}.`}
 		>
-			<TriangleAlert class="size-3 text-yellow-500" />
+			<TriangleAlert class="size-3 text-warning" />
 		</span>
 	{/if}
 </div>

--- a/ui/user/src/lib/components/chat/ChatConnectorsView.svelte
+++ b/ui/user/src/lib/components/chat/ChatConnectorsView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Table from '$lib/components/table/Table.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		type MCPCatalogEntry,
 		type MCPCatalogServer,
@@ -15,13 +16,8 @@
 	import { mcpServersAndEntries } from '$lib/stores';
 	import { formatTimeAgo } from '$lib/time';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
-	import {
-		CircleFadingArrowUp,
-		LoaderCircle,
-		Server,
-		StepForward,
-		TriangleAlert
-	} from 'lucide-svelte';
+	import IconButton from '../primitives/IconButton.svelte';
+	import { CircleFadingArrowUp, Server, StepForward, TriangleAlert } from 'lucide-svelte';
 
 	interface Props {
 		usersMap?: Map<string, OrgUser>;
@@ -88,7 +84,7 @@
 <div class="flex flex-col gap-2">
 	{#if mcpServersAndEntries.current.loading}
 		<div class="my-2 flex items-center justify-center">
-			<LoaderCircle class="size-6 animate-spin" />
+			<Loading class="size-6" />
 		</div>
 	{:else}
 		<Table
@@ -123,7 +119,7 @@
 							)
 						: d.data}
 				{#if property === 'name'}
-					<div class="flex flex-shrink-0 items-center gap-2">
+					<div class="flex shrink-0 items-center gap-2">
 						<div class="icon">
 							{#if d.icon}
 								<img src={d.icon} alt={d.name} class="size-6" />
@@ -135,7 +131,7 @@
 							{d.name}
 							{#if server && requiresUserUpdate(server)}
 								<span
-									class="text-yellow-500"
+									class="text-warning"
 									use:tooltip={{
 										text: 'Server requires an update.',
 										disablePortal: true
@@ -170,10 +166,10 @@
 					d.data.manifest?.runtime === 'remote' &&
 					d.data.manifest?.remoteConfig?.staticOAuthRequired &&
 					!d.data.oauthCredentialConfigured}
-				<button
-					class="icon-button hover:dark:bg-background/50 disabled:cursor-not-allowed disabled:opacity-50"
+				<IconButton
+					class="hover:dark:bg-base-100/50"
 					disabled={requiresOAuthConfig}
-					use:tooltip={{
+					tooltip={{
 						text: requiresOAuthConfig ? 'OAuth configuration required' : '',
 						disablePortal: true
 					}}
@@ -209,7 +205,7 @@
 					}}
 				>
 					<StepForward class="size-4" />
-				</button>
+				</IconButton>
 			{/snippet}
 		</Table>
 	{/if}
@@ -230,7 +226,7 @@
 	>
 		{#snippet onRenderColumn(property, d)}
 			{#if property === 'name'}
-				<div class="flex flex-shrink-0 items-center gap-2">
+				<div class="flex shrink-0 items-center gap-2">
 					<div class="icon">
 						{#if d.manifest.icon}
 							<img src={d.manifest.icon} alt={d.manifest.name} class="size-6" />
@@ -257,9 +253,9 @@
 			{/if}
 		{/snippet}
 		{#snippet actions()}
-			<button class="icon-button hover:dark:bg-background/50">
+			<IconButton class="hover:dark:bg-base-100/50">
 				<StepForward class="size-4" />
-			</button>
+			</IconButton>
 		{/snippet}
 	</Table>
 </ResponsiveDialog>

--- a/ui/user/src/lib/components/chat/ChatSidebar.svelte
+++ b/ui/user/src/lib/components/chat/ChatSidebar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { scrollFocus } from '$lib/actions/scrollFocus.svelte';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Threads from '$lib/components/chat/sidebar/Threads.svelte';
 	import McpServers from '$lib/components/edit/McpServers.svelte';
 	import Tasks from '$lib/components/edit/Tasks.svelte';
@@ -10,7 +9,8 @@
 	import { responsive } from '$lib/stores';
 	import BetaLogo from '../navbar/BetaLogo.svelte';
 	import Projects from '../navbar/Projects.svelte';
-	import { Settings, SidebarClose, Share, CircleFadingArrowUp } from 'lucide-svelte';
+	import IconButton from '../primitives/IconButton.svelte';
+	import { Settings, Share, CircleFadingArrowUp, PanelLeftClose } from 'lucide-svelte';
 	import { onDestroy } from 'svelte';
 
 	interface Props {
@@ -74,10 +74,8 @@
 	}
 </script>
 
-<div
-	class="border-surface2 dark:bg-gray-990 bg-background relative flex size-full flex-col border-r"
->
-	<div class="flex h-16 w-full flex-shrink-0 items-center justify-between px-2 md:justify-start">
+<div class="border-base-400 dark:bg-base-200 bg-base-100 relative flex size-full flex-col border-r">
+	<div class="flex h-16 w-full shrink-0 items-center justify-between px-2 md:justify-start">
 		<BetaLogo chat />
 		{#if responsive.isMobile}
 			{@render closeSidebar()}
@@ -100,12 +98,12 @@
 	<div class="flex w-full items-center justify-between gap-2 px-2 py-2">
 		<div class="flex items-center gap-1">
 			<div class="relative">
-				<button
-					class="icon-button relative"
+				<IconButton
+					class="relative"
 					onclick={() => (layout.sidebarConfig = 'project-configuration')}
-					use:tooltip={upgradeAvailable ? 'Upgrade available' : 'Configure Project'}
+					tooltip={{ text: upgradeAvailable ? 'Upgrade available' : 'Configure Project' }}
 				>
-					<Settings class="text-on-surface1 size-6" />
+					<Settings class="text-muted-content size-6" />
 					{#if upgradeAvailable}
 						<span
 							class="absolute top-0 right-0 flex h-4 w-4 animate-[pulse_2s_ease-in-out_5] items-center
@@ -114,12 +112,12 @@
 							<CircleFadingArrowUp class="text-primary size-4" />
 						</span>
 					{/if}
-				</button>
+				</IconButton>
 			</div>
 			{#if !shared}
-				<button class="icon-button" onclick={openTemplatePanel} use:tooltip={'Project Sharing'}>
-					<Share class="text-on-surface1 size-6" />
-				</button>
+				<IconButton onclick={openTemplatePanel} tooltip={{ text: 'Project Sharing' }}>
+					<Share class="text-muted-content size-6" />
+				</IconButton>
 			{/if}
 		</div>
 		{#if !responsive.isMobile}
@@ -129,7 +127,7 @@
 </div>
 
 {#snippet closeSidebar()}
-	<button class="icon-button" onclick={() => (layout.sidebarOpen = false)}>
-		<SidebarClose class="size-6" />
-	</button>
+	<IconButton onclick={() => (layout.sidebarOpen = false)}>
+		<PanelLeftClose class="size-6" />
+	</IconButton>
 {/snippet}

--- a/ui/user/src/lib/components/chat/ChatSidebarConfig.svelte
+++ b/ui/user/src/lib/components/chat/ChatSidebarConfig.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <div
-	class="default-scrollbar-thin bg-surface1 dark:bg-background relative flex w-full justify-center overflow-y-auto"
+	class="default-scrollbar-thin bg-base-200 dark:bg-base-100 relative flex w-full justify-center overflow-y-auto"
 	in:fade
 >
 	{#if layout.sidebarConfig === 'project-configuration'}
@@ -48,7 +48,7 @@
 {#snippet underConstruction()}
 	<div class="flex w-full flex-col items-center justify-center font-light">
 		<img src="/user/images/under-construction.webp" alt="under construction" class="size-32" />
-		<p class="text-on-surface1 text-sm font-light">
+		<p class="text-muted-content text-sm font-light">
 			This section is under construction. Please check back later.
 		</p>
 	</div>

--- a/ui/user/src/lib/components/chat/ChatSidebarMcpServer.svelte
+++ b/ui/user/src/lib/components/chat/ChatSidebarMcpServer.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { closeAll, closeSidebarConfig, getLayout } from '$lib/context/chatLayout.svelte';
 	import { getProjectMCPs, validateOauthProjectMcps } from '$lib/context/projectMcps.svelte';
 	import { ChatService, type Project, type ProjectMCP } from '$lib/services';
@@ -9,6 +8,7 @@
 	import EditExistingDeployment from '../mcp/EditExistingDeployment.svelte';
 	import McpServerActions from '../mcp/McpServerActions.svelte';
 	import McpServerInfoAndTools from '../mcp/McpServerInfoAndTools.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { ChevronLeft, Server, Trash2 } from 'lucide-svelte';
 
 	interface Props {
@@ -42,17 +42,17 @@
 	}
 </script>
 
-<div class="bg-surface1 dark:bg-background flex w-full justify-center">
+<div class="bg-base-200 dark:bg-base-100 flex w-full justify-center">
 	<div class="w-full md:max-w-[1200px]">
 		{#if !layout.sidebarOpen || responsive.isMobile}
 			<div class="flex w-full items-center justify-between gap-2 px-4 pt-4">
-				<div class="flex flex-shrink-0 items-center gap-2">
-					<button class="icon-button" onclick={() => closeSidebarConfig(layout)}>
+				<div class="flex shrink-0 items-center gap-2">
+					<IconButton onclick={() => closeSidebarConfig(layout)}>
 						<ChevronLeft class="size-6" />
-					</button>
+					</IconButton>
 					<h1 class="text-xl font-semibold capitalize">{mcpServer.alias || mcpServer.name}</h1>
 				</div>
-				<div class="flex flex-shrink-0 items-center gap-2">
+				<div class="flex shrink-0 items-center gap-2">
 					<McpServerActions entry={matchingEntry} server={matchingConfiguredServer} isProjectMcp />
 				</div>
 			</div>
@@ -63,22 +63,22 @@
 				<img
 					src={mcpServer.icon}
 					alt={mcpServer.name}
-					class="bg-surface1 size-10 rounded-md p-1 dark:bg-gray-600"
+					class="bg-base-200 size-10 rounded-md p-1 dark:bg-base-300"
 				/>
 			{:else}
-				<Server class="bg-surface1 size-10 rounded-md p-1 dark:bg-gray-600" />
+				<Server class="bg-base-200 size-10 rounded-md p-1 dark:bg-base-300" />
 			{/if}
 			<h1 class="text-2xl font-semibold capitalize">
 				{mcpServer.alias || mcpServer.name}
 			</h1>
 			<div class="flex grow justify-end gap-2">
-				<button
-					class="button-destructive"
-					use:tooltip={'Delete'}
+				<IconButton
+					variant="danger2"
+					tooltip={{ text: 'Delete' }}
 					onclick={() => (showDeleteConfirm = true)}
 				>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 			</div>
 		</div>
 		<McpServerInfoAndTools

--- a/ui/user/src/lib/components/chat/DebugCallFrames.svelte
+++ b/ui/user/src/lib/components/chat/DebugCallFrames.svelte
@@ -3,6 +3,7 @@
 	import type { CallFrame, ToolReference } from '$lib/services';
 	import JsonTreeView from '../JsonTreeView.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { ChevronDown, ChevronUp, Code, Download, Maximize2, Minimize2 } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -81,7 +82,7 @@
 <ResponsiveDialog
 	bind:this={dialog}
 	class={twMerge(
-		'bg-surface1 dark:bg-surface2 h-full transition-all',
+		'bg-base-200 dark:bg-base-300 h-full transition-all',
 		maximized ? 'h-dvh max-h-dvh w-full max-w-dvw' : 'max-h-[75vh] w-full max-w-2xl'
 	)}
 	classes={{ title: 'w-full justify-between', header: 'px-4', content: 'px-0 pb-0' }}
@@ -92,7 +93,7 @@
 			<p class="text-xl font-semibold">Run ID: {runId}</p>
 		</div>
 		<button
-			class="button-icon"
+			class="btn btn-square btn-ghost"
 			onclick={() => (maximized = !maximized)}
 			use:tooltip={maximized ? 'Minimize' : 'Maximize'}
 		>
@@ -103,34 +104,28 @@
 			{/if}
 		</button>
 	{/snippet}
-	<div class="bg-background flex max-h-[calc(100%-4rem)] grow flex-col rounded-md">
+	<div class="bg-base-100 flex max-h-[calc(100%-4rem)] grow flex-col rounded-md">
 		<div class="flex items-center justify-between gap-4 px-4 pt-2 pb-4">
 			<h4 class="text-lg font-semibold">Call Frames</h4>
 			<div class="flex items-center gap-2">
-				<button
-					class="button-icon"
+				<IconButton
 					onclick={handleDownload}
-					use:tooltip={{
-						disablePortal: true,
-						text: 'Download JSON'
-					}}
+					class="btn-sm"
+					tooltip={{ disablePortal: true, text: 'Download JSON' }}
 				>
 					<Download class="size-5" />
-				</button>
-				<button
-					class="button-icon"
+				</IconButton>
+				<IconButton
 					onclick={() => (expandAll = !expandAll)}
-					use:tooltip={{
-						disablePortal: true,
-						text: expandAll ? 'Collapse All' : 'Expand All'
-					}}
+					class="btn-sm"
+					tooltip={{ disablePortal: true, text: expandAll ? 'Collapse All' : 'Expand All' }}
 				>
 					{#if expandAll}
 						<ChevronUp class="size-5" />
 					{:else}
 						<ChevronDown class="size-5" />
 					{/if}
-				</button>
+				</IconButton>
 			</div>
 		</div>
 
@@ -155,7 +150,7 @@
 		</summary>
 		<div class="my-2 ml-5">
 			{#if call?.tool?.source?.location && call.tool.source.location !== 'inline'}
-				<div class="text-on-surface1 mb-2 text-sm">
+				<div class="text-muted-content mb-2 text-sm">
 					Source:
 					<!-- eslint-disable svelte/no-navigation-without-resolve -- external URL -->
 					<a
@@ -178,7 +173,7 @@
 						{@render inputContent(call.input)}
 					</div>
 				{:else}
-					<p class="text-on-surface1 ml-5">No input available</p>
+					<p class="text-muted-content ml-5">No input available</p>
 				{/if}
 			</details>
 			<details open={expandAll}>
@@ -294,7 +289,7 @@
 		<span class="mr-2 text-base font-semibold">
 			{typeof name === 'string' ? name : name.Name}
 		</span>
-		<span class="text-on-surface1 text-sm font-light">{info}</span>
+		<span class="text-muted-content text-sm font-light">{info}</span>
 	</p>
 {/snippet}
 

--- a/ui/user/src/lib/components/chat/McpServerRequirements.svelte
+++ b/ui/user/src/lib/components/chat/McpServerRequirements.svelte
@@ -18,7 +18,8 @@
 		requiresUserConfiguration,
 		requiresAdminOAuthConfig
 	} from '$lib/services/chat/mcp';
-	import { Server, X, AlertTriangle } from 'lucide-svelte';
+	import IconButton from '../primitives/IconButton.svelte';
+	import { Server, X, TriangleAlert } from 'lucide-svelte';
 	import { onMount, tick } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 
@@ -339,12 +340,12 @@
 		<dialog bind:this={oauthDialog} class="dialog" use:dialogAnimation={{ type: 'fade' }}>
 			<div class="dialog-container relative flex w-full flex-col gap-4 p-4 md:w-sm">
 				<div class="absolute top-2 right-2">
-					<button class="icon-button" onclick={dismissCurrent}>
+					<IconButton onclick={dismissCurrent}>
 						<X class="size-4" />
-					</button>
+					</IconButton>
 				</div>
 				<div class="flex items-center gap-2">
-					<div class="h-fit flex-shrink-0 self-start rounded-md bg-gray-50 p-1 dark:bg-gray-600">
+					<div class="h-fit shrink-0 self-start rounded-md bg-gray-50 p-1 dark:bg-base-300">
 						{#if oauth.icon}
 							<img src={oauth.icon} alt={oauth.name} class="size-6" />
 						{:else}
@@ -367,7 +368,7 @@
 					href={oauth.oauthURL}
 					rel="external"
 					target="_blank"
-					class="button-primary text-center text-sm outline-none"
+					class="btn btn-primary text-center text-sm outline-none"
 					onclick={() => {
 						if (currentOauthId) return;
 						currentOauthId = oauth.id;
@@ -389,12 +390,12 @@
 		<dialog bind:this={oauthDialog} class="dialog" use:dialogAnimation={{ type: 'fade' }}>
 			<div class="dialog-container relative flex w-full flex-col gap-4 p-4 md:w-sm">
 				<div class="absolute top-2 right-2">
-					<button class="icon-button" onclick={dismissCurrent}>
+					<IconButton onclick={dismissCurrent}>
 						<X class="size-4" />
-					</button>
+					</IconButton>
 				</div>
 				<div class="flex items-center gap-2">
-					<div class="h-fit flex-shrink-0 self-start rounded-md bg-gray-50 p-1 dark:bg-gray-600">
+					<div class="h-fit shrink-0 self-start rounded-md bg-base-200 p-1 dark:bg-base-300">
 						{#if adminOauth.icon}
 							<img src={adminOauth.icon} alt={adminOauth.name} class="size-6" />
 						{:else}
@@ -407,7 +408,7 @@
 				</div>
 
 				<div class="notification-warning flex items-start gap-2 p-3">
-					<AlertTriangle class="size-5 flex-shrink-0 text-yellow-500" />
+					<TriangleAlert class="size-5 shrink-0 text-warning" />
 					<p class="text-sm">
 						This MCP server requires OAuth credentials to be configured by an administrator.
 					</p>
@@ -417,7 +418,7 @@
 					Please contact your administrator to configure the OAuth credentials for this server.
 				</p>
 
-				<button class="button" onclick={dismissCurrent}> Dismiss </button>
+				<button class="btn btn-secondary" onclick={dismissCurrent}> Dismiss </button>
 			</div>
 			<form class="dialog-backdrop">
 				<button type="button" aria-label="Close dialog" onclick={dismissCurrent}>close</button>

--- a/ui/user/src/lib/components/chat/McpServerSetup.svelte
+++ b/ui/user/src/lib/components/chat/McpServerSetup.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { getProjectMCPs } from '$lib/context/projectMcps.svelte';
 	import {
@@ -16,6 +15,7 @@
 	import McpServerEntryForm from '../admin/McpServerEntryForm.svelte';
 	import ConnectToServer from '../mcp/ConnectToServer.svelte';
 	import McpServerActions from '../mcp/McpServerActions.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import ChatConnectorsView from './ChatConnectorsView.svelte';
 	import { ChevronLeft, X } from 'lucide-svelte';
 	import { fly } from 'svelte/transition';
@@ -144,9 +144,9 @@
 	{#if selected}
 		<div class="flex items-center justify-between gap-4 py-2 pr-4 pl-2">
 			<div class="flex items-center gap-2">
-				<button class="icon-button" onclick={() => (selected = undefined)}>
+				<IconButton onclick={() => (selected = undefined)}>
 					<ChevronLeft class="size-6" />
-				</button>
+				</IconButton>
 				<h4 class="text-lg font-semibold">
 					{selected.server?.alias ||
 						selected.server?.manifest.name ||
@@ -172,7 +172,7 @@
 			</div>
 		</div>
 		<div
-			class="bg-surface1 dark:bg-background flex h-full flex-col gap-6 p-4"
+			class="bg-base-200 dark:bg-base-100 flex h-full flex-col gap-6 p-4"
 			in:fly={{ x: 100, delay: duration, duration }}
 		>
 			<McpServerEntryForm
@@ -192,16 +192,15 @@
 	<div class="w-full px-4 py-2">
 		<div class="mb-2 flex items-center justify-between gap-4">
 			<h4 class="text-lg font-semibold">Add MCP Server</h4>
-			<button
-				class="icon-button"
+			<IconButton
 				onclick={() => closeCatalogDialog()}
-				use:tooltip={{ disablePortal: true, text: 'Close' }}
+				tooltip={{ disablePortal: true, text: 'Close' }}
 			>
 				<X class="size-6" />
-			</button>
+			</IconButton>
 		</div>
 		<Search
-			class="bg-surface1 dark:border-surface3 border border-transparent shadow-inner"
+			class="bg-base-200 dark:border-base-400 border border-transparent shadow-inner"
 			value={query}
 			onChange={(value) => (query = value)}
 			placeholder="Search servers..."

--- a/ui/user/src/lib/components/chat/sidebar/ModelProviders.svelte
+++ b/ui/user/src/lib/components/chat/sidebar/ModelProviders.svelte
@@ -68,7 +68,7 @@
 >
 	<div class="flex flex-col gap-8 p-2">
 		<div class="flex flex-col gap-4">
-			<p class="text-on-surface1 text-xs font-light">
+			<p class="text-muted-content text-xs font-light">
 				Projects use our included LLM by default. Connect other model providers to unlock more LLMs
 				you can chat with.
 			</p>
@@ -84,7 +84,7 @@
 
 							<li class="model-provider w-full">
 								<button
-									class="hover:bg-surface3 flex w-full items-center gap-1 rounded-md p-2 transition-colors duration-200"
+									class="hover:bg-base-400 flex w-full items-center gap-1 rounded-md p-2 transition-colors duration-200"
 									onclick={async () => {
 										openModelProvidersConfig();
 
@@ -139,7 +139,7 @@
 		</div>
 
 		<div class="flex justify-end">
-			<button class="button flex items-center gap-1" onclick={openModelProvidersConfig}>
+			<button class="btn btn-secondary flex items-center gap-1" onclick={openModelProvidersConfig}>
 				<span class="text-xs">Manage Model Providers</span>
 			</button>
 		</div>

--- a/ui/user/src/lib/components/chat/sidebar/Threads.svelte
+++ b/ui/user/src/lib/components/chat/sidebar/Threads.svelte
@@ -310,7 +310,10 @@
 			</div>
 			{#if (layout.threads?.length ?? 0) === 0}
 				<div class="flex justify-end" in:fade>
-					<button class="button flex items-center gap-1 text-xs" onclick={() => createThread()}>
+					<button
+						class="btn btn-sm btn-secondary flex items-center gap-1 text-xs"
+						onclick={() => createThread()}
+					>
 						<Plus class="size-4" /> Start New Chat
 					</button>
 				</div>
@@ -321,7 +324,7 @@
 			<div class="flex items-center justify-between">
 				<p class="text-md grow font-medium">Chats</p>
 				<button
-					class="hover:text-on-background text-on-surface1 p-2 transition-colors duration-200"
+					class="hover:text-base-content text-muted-content p-2 transition-colors duration-200"
 					onclick={createThread}
 					use:tooltip={'Start New Chat'}
 				>
@@ -337,8 +340,8 @@
 	<ul transition:fade>
 		{#each sortedThreads.slice(0, displayCount) as thread (thread.id)}
 			<li
-				class:bg-surface2={isCurrentThread(thread)}
-				class="hover:bg-surface3 group flex min-h-9 items-center gap-3 rounded-md font-light"
+				class:bg-base-300={isCurrentThread(thread)}
+				class="hover:bg-base-400 group flex min-h-9 items-center gap-3 rounded-md font-light"
 				animate:flip={{ duration: 200 }}
 			>
 				{#if editMode === thread.id}
@@ -355,7 +358,7 @@
 									break;
 							}
 						}}
-						class="text-on-background mx-2 w-0 flex-1 grow border-none bg-transparent ring-0 outline-hidden"
+						class="text-base-content mx-2 w-0 flex-1 grow border-none bg-transparent ring-0 outline-hidden"
 						placeholder="Enter name"
 						type="text"
 					/>
@@ -382,7 +385,7 @@
 					</button>
 
 					<DotDotDot
-						class="p-0 pr-2.5 transition-opacity duration-200 group-hover:opacity-100 md:opacity-0"
+						class="p-0 transition-opacity duration-200 group-hover:opacity-100 md:opacity-0 dark:hover:bg-base-300 dark:hover:border-base-300"
 					>
 						<button class="menu-button" onclick={() => toggleThreadPin(thread.id)}>
 							{#if isThreadPinned(thread.id)}
@@ -408,7 +411,7 @@
 			</li>
 		{/each}
 		{#if layout.threads?.length && layout.threads?.length > displayCount}
-			<li class="hover:bg-surface3 flex w-full justify-center rounded-md p-2">
+			<li class="hover:bg-base-400 flex w-full justify-center rounded-md p-2">
 				<button class="w-full text-xs" onclick={loadMore}> Show More </button>
 			</li>
 		{/if}

--- a/ui/user/src/lib/components/edit/CollapsePane.svelte
+++ b/ui/user/src/lib/components/edit/CollapsePane.svelte
@@ -80,7 +80,7 @@
 		<div
 			transition:slide
 			class={twMerge(
-				'border-surface1 bg-surface2 dark:bg-surface1 flex flex-col p-5 shadow-inner',
+				'border-base-400 bg-base-200 dark:bg-base-100 flex flex-col p-5 shadow-inner',
 				classes.content
 			)}
 		>

--- a/ui/user/src/lib/components/edit/EditIcon.svelte
+++ b/ui/user/src/lib/components/edit/EditIcon.svelte
@@ -5,6 +5,7 @@
 	import AssistantIcon from '$lib/icons/AssistantIcon.svelte';
 	import type { Project } from '$lib/services';
 	import { responsive } from '$lib/stores';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { ChevronRight, CircleX, Pencil } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -45,7 +46,7 @@
 {:else}
 	<div class="flex w-full items-center justify-center">
 		<button
-			class="icon-button group relative flex items-center gap-2 p-0 shadow-md"
+			class="btn btn-square btn-ghost group relative flex items-center gap-2 p-0 shadow-md"
 			class:cursor-default={!canEdit}
 			use:ref
 			onclick={() => toggle()}
@@ -55,7 +56,7 @@
 
 			{#if canEdit}
 				<div
-					class="bg-surface1 group-hover:bg-surface3 absolute -right-1 bottom-0 rounded-full p-2 shadow-md transition-all duration-200"
+					class="bg-base-200 group-hover:bg-base-400 absolute -right-1 bottom-0 rounded-full p-2 shadow-md transition-all duration-200"
 				>
 					<Pencil class="size-4" />
 				</div>
@@ -68,7 +69,7 @@
 			fixed: responsive.isMobile ? true : false,
 			disablePortal: true
 		}}
-		class="popover bg-surface1 dark:bg-background top-16 left-0 z-40 flex h-[calc(100vh-64px)] w-screen flex-col px-4 md:top-auto md:left-auto md:h-auto md:w-[350px] md:py-6"
+		class="popover bg-base-200 dark:bg-base-100 top-16 left-0 z-40 flex h-[calc(100vh-64px)] w-screen flex-col px-4 md:top-auto md:left-auto md:h-auto md:w-[350px] md:py-6"
 	>
 		{@render content()}
 	</div>
@@ -76,14 +77,11 @@
 
 {#snippet content()}
 	{#if responsive.isMobile}
-		<div class="border-surface3 relative mb-6 flex items-center justify-center border-b py-4">
+		<div class="border-base-400 relative mb-6 flex items-center justify-center border-b py-4">
 			<h4 class="text-lg font-medium">Edit Icon</h4>
-			<button
-				class="icon-button absolute top-1/2 right-0 -translate-y-1/2"
-				onclick={() => toggle()}
-			>
+			<IconButton class="absolute top-1/2 right-0 -translate-y-1/2" onclick={() => toggle()}>
 				<ChevronRight class="size-6" />
-			</button>
+			</IconButton>
 		</div>
 	{/if}
 	{#if urlIcon}
@@ -93,7 +91,7 @@
 				<input
 					id="project-name"
 					type="text"
-					class="bg-surface grow rounded-lg p-2"
+					class="bg-base-200 grow rounded-lg p-2"
 					bind:value={urlIcon.icon}
 				/>
 			</div>
@@ -102,12 +100,12 @@
 				<input
 					id="project-name"
 					type="text"
-					class="bg-surface grow rounded-lg p-2"
+					class="bg-base-200 grow rounded-lg p-2"
 					bind:value={urlIcon.iconDark}
 				/>
 			</div>
 			<button
-				class="button self-end"
+				class="btn btn-secondary self-end"
 				onclick={() => {
 					project.icons = urlIcon;
 					urlIcon = undefined;
@@ -138,7 +136,7 @@
 				/>
 
 				<button
-					class="icon-button flex items-center justify-center gap-2 px-4 py-2"
+					class="btn btn-secondary flex items-center justify-center gap-2 px-4 py-2"
 					onclick={() => {
 						project.icons = undefined;
 						onSubmit?.();

--- a/ui/user/src/lib/components/edit/Files.svelte
+++ b/ui/user/src/lib/components/edit/Files.svelte
@@ -20,6 +20,7 @@
 	} from '$lib/services';
 	import type { EditorItem } from '$lib/services/editor/index.svelte';
 	import { responsive } from '$lib/stores';
+	import IconButton from '../primitives/IconButton.svelte';
 	import CollapsePane from './CollapsePane.svelte';
 	import { Download, Image, Plus } from 'lucide-svelte';
 	import { FileText, Trash2, Upload } from 'lucide-svelte/icons';
@@ -170,24 +171,24 @@
 							<span use:overflowToolTip>{file.name}</span>
 						</button>
 
-						<button
-							class="icon-button-small ms-2 opacity-0 transition-all duration-200 group-hover:opacity-100"
+						<IconButton
+							class="btn-sm ms-2 opacity-0 transition-all duration-200 group-hover:opacity-100"
 							onclick={() => {
 								EditorService.download([], project, file.name, apiOpts);
 							}}
 						>
 							<Download class="text-gray size-4" />
-						</button>
+						</IconButton>
 
-						<button
-							class="icon-button-small ms-2 opacity-0 transition-all duration-200 group-hover:opacity-100"
+						<IconButton
+							class="btn-sm ms-2 opacity-0 transition-all duration-200 group-hover:opacity-100"
 							onclick={() => {
 								fileToDelete = file.name;
 								menu?.toggle(false);
 							}}
 						>
 							<Trash2 class="text-gray size-4" />
-						</button>
+						</IconButton>
 					</div>
 				</li>
 			{/each}
@@ -196,7 +197,7 @@
 	{#if thread}
 		<div class="flex items-center justify-end gap-4">
 			<McpResources {project} bind:threadID={currentThreadID} bind:currentThreadFiles={files} />
-			<label class="button mt-3 flex items-center justify-end gap-1 text-sm">
+			<label class="btn btn-secondary mt-3 flex items-center justify-end gap-1 text-sm">
 				{#await uploadInProgress}
 					<Loading class="size-4" />
 				{:catch error}
@@ -220,7 +221,7 @@
 			description="Content available to AI."
 			onLoad={loadFiles}
 			classes={{
-				button: primary ? 'button-icon-primary' : '',
+				button: primary ? 'btn btn-square btn-ghost btn-primary' : '',
 				menu: responsive.isMobile
 					? 'rounded-none max-h-[calc(100vh-64px)] left-0 bottom-0 w-full'
 					: ''
@@ -246,7 +247,7 @@
 			<div class="flex flex-col gap-4">
 				{@render content()}
 				<div class="flex justify-end">
-					<label class="button flex cursor-pointer items-center justify-end gap-1 text-xs">
+					<label class="btn btn-sm flex cursor-pointer items-center justify-end gap-1 text-xs">
 						{#await uploadInProgress}
 							<Loading class="size-4" />
 						{:catch error}

--- a/ui/user/src/lib/components/edit/GenerateIcon.svelte
+++ b/ui/user/src/lib/components/edit/GenerateIcon.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { autoHeight } from '$lib/actions/textarea';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { EditorService } from '$lib/services';
 	import type { Project } from '$lib/services';
 	import { errors } from '$lib/stores';
-	import { Wand, LoaderCircle, ChevronDown, ChevronUp } from 'lucide-svelte/icons';
+	import { Wand, ChevronDown, ChevronUp } from 'lucide-svelte/icons';
 	import { fade } from 'svelte/transition';
 
 	interface Props {
@@ -79,24 +80,24 @@
 </script>
 
 <div class="relative mt-2 flex flex-col gap-2">
-	<div class="border-surface3 flex rounded-lg border">
+	<div class="border-base-400 flex rounded-lg border">
 		<button
-			class="icon-button border-surface3 dark:border-surface3 hover:bg-surface2 bg-background flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-l-lg rounded-r-none border-r"
+			class="btn btn-secondary border-base-400 dark:border-base-400 hover:bg-base-300 bg-base-100 flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-l-lg rounded-r-none border-r"
 			onclick={() => (isCustomPrompt ? generateIcon(true) : generateIcon())}
 			disabled={isGenerating || (!project.description && !isCustomPrompt)}
 		>
 			{#if isGenerating}
-				<LoaderCircle class="h-5 w-5 animate-spin" />
-				<span class="text-on-surface">Generating icon...</span>
+				<Loading />
+				<span class="text-muted-content">Generating icon...</span>
 			{:else}
 				<Wand class="h-5 w-5" />
-				<span class="text-on-surface"
+				<span class="text-muted-content"
 					>{isCustomPrompt ? 'Generate from custom prompt' : 'Generate from description'}</span
 				>
 			{/if}
 		</button>
 		<button
-			class="icon-button hover:bg-surface2 dark:border-surface3 bg-background flex items-center rounded-l-none rounded-r-lg px-2 hover:shadow-inner"
+			class="btn btn-secondary hover:bg-base-300 dark:border-base-400 bg-base-100 flex items-center rounded-l-none rounded-r-lg px-2 hover:shadow-inner"
 			onclick={() => (isCustomPrompt = !isCustomPrompt)}
 			disabled={isGenerating}
 		>
@@ -108,13 +109,13 @@
 		</button>
 	</div>
 	{#if isCustomPrompt}
-		<div in:fade class="border-surface3 flex flex-col gap-2 border-b pt-2 pb-4">
+		<div in:fade class="border-base-400 flex flex-col gap-2 border-b pt-2 pb-4">
 			<textarea
 				bind:value={customPrompt}
 				use:autoHeight
 				use:focusTextarea
 				placeholder="Enter custom prompt for image generation..."
-				class="dark:border-surface3 bg-background w-full resize-none rounded-lg p-2 text-sm outline-hidden dark:border dark:text-gray-50"
+				class="dark:border-base-400 bg-base-100 text-base-content w-full resize-none rounded-lg p-2 text-sm outline-hidden dark:border"
 				rows="3"
 			></textarea>
 		</div>

--- a/ui/user/src/lib/components/edit/Knowledge.svelte
+++ b/ui/user/src/lib/components/edit/Knowledge.svelte
@@ -10,6 +10,7 @@
 	import { type KnowledgeFile as KnowledgeFileType } from '$lib/services';
 	import { hasTool } from '$lib/tools';
 	import InfoTooltip from '../InfoTooltip.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2, TriangleAlert } from 'lucide-svelte';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -60,7 +61,7 @@
 		<span
 			class={twMerge(
 				'flex grow items-center gap-1 text-sm',
-				!hasKnowledgeCapability && 'text-on-surface1 justify-between'
+				!hasKnowledgeCapability && 'text-muted-content justify-between'
 			)}
 		>
 			Knowledge
@@ -77,7 +78,7 @@
 	{/snippet}
 	<div class="flex flex-col gap-2">
 		{#if !hasKnowledgeCapability}
-			<p class="text-on-surface1 flex items-center gap-1 text-xs font-light">
+			<p class="text-muted-content flex items-center gap-1 text-xs font-light">
 				<span> Enable Knowledge in "Built-In Capabilities" to add knowledge to your project. </span>
 			</p>
 		{/if}
@@ -122,7 +123,7 @@
 			<div class="flex flex-col gap-2">
 				{#each project.websiteKnowledge.sites as _, i (i)}
 					<div
-						class="group dark:border-surface3 bg-background flex gap-2 rounded-md p-2 text-xs shadow-sm dark:border"
+						class="group dark:border-base-400 bg-base-100 flex gap-2 rounded-md p-2 text-xs shadow-sm dark:border"
 					>
 						<div class="flex grow flex-col gap-2">
 							<div>
@@ -133,7 +134,7 @@
 									id={`website-address-${i}`}
 									bind:value={project.websiteKnowledge.sites[i].site}
 									placeholder="example.com"
-									class="ghost-input border-surface2 w-full"
+									class="ghost-input border-base-300 w-full"
 								/>
 							</div>
 							<div>
@@ -142,7 +143,7 @@
 								>
 								<textarea
 									id={`website-description-${i}`}
-									class="ghost-input border-surface2 w-full resize-none"
+									class="ghost-input border-base-300 w-full resize-none"
 									bind:value={project.websiteKnowledge.sites[i].description}
 									rows="1"
 									placeholder="Description"
@@ -151,14 +152,13 @@
 							</div>
 						</div>
 						<div class="flex items-center justify-end">
-							<button
-								class="icon-button size-fit"
+							<IconButton
 								onclick={() => {
 									project.websiteKnowledge?.sites?.splice(i, 1);
 								}}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						</div>
 					</div>
 				{/each}
@@ -166,7 +166,7 @@
 		{/if}
 		<div class="self-end">
 			<button
-				class="button-small text-xs"
+				class="btn btn-secondary btn-sm"
 				onclick={() => {
 					if (!project.websiteKnowledge) {
 						project.websiteKnowledge = {

--- a/ui/user/src/lib/components/edit/McpServers.svelte
+++ b/ui/user/src/lib/components/edit/McpServers.svelte
@@ -119,7 +119,7 @@
 	<div class="flex items-center justify-between">
 		<p class="text-md grow font-medium">MCP Servers</p>
 		<button
-			class="hover:text-on-background text-on-surface1 p-2 transition-colors duration-200"
+			class="hover:text-base-content text-muted-content p-2 transition-colors duration-200"
 			onclick={() => mcpServerSetup?.open()}
 			use:tooltip={'Add MCP Server'}
 		>
@@ -134,7 +134,7 @@
 					? entriesMap.get(matchingConfiguredServer?.catalogEntryID)
 					: undefined}
 				<div
-					class="group hover:bg-surface3 flex w-full items-center rounded-md transition-colors duration-200"
+					class="group hover:bg-base-400 flex w-full items-center rounded-md transition-colors duration-200"
 				>
 					<button
 						class="flex grow items-center gap-1 py-2 pl-1.5"
@@ -142,7 +142,7 @@
 							openMCPServer(layout, mcpServer);
 						}}
 					>
-						<div class="rounded-md bg-gray-50 p-1 dark:bg-gray-600">
+						<div class="rounded-md bg-base-200 p-1 dark:bg-base-300">
 							{#if mcpServer.icon}
 								<img src={mcpServer.icon} class="size-4" alt={mcpServer.alias || mcpServer.name} />
 							{:else}
@@ -162,7 +162,7 @@
 					</button>
 
 					<DotDotDot
-						class="p-0 pr-2.5 transition-opacity duration-200 group-hover:opacity-100 md:opacity-0"
+						class="p-0 transition-opacity duration-200 group-hover:opacity-100 md:opacity-0 dark:hover:bg-base-300 dark:hover:border-base-300"
 					>
 						{#if matchingEntry && matchingConfiguredServer && hasEditableConfiguration(matchingEntry)}
 							<button

--- a/ui/user/src/lib/components/edit/ProjectConfiguration.svelte
+++ b/ui/user/src/lib/components/edit/ProjectConfiguration.svelte
@@ -7,14 +7,16 @@
 	import { closeAll, getLayout } from '$lib/context/chatLayout.svelte';
 	import { HELPER_TEXTS } from '$lib/context/helperMode.svelte';
 	import { getProjectTools } from '$lib/context/projectTools.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { ChatService, type Project } from '$lib/services';
 	import { hasTool } from '$lib/tools';
 	import { goto } from '$lib/url';
 	import { poll } from '$lib/utils';
 	import Confirm from '../Confirm.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import ProjectConfigurationKnowledge from './ProjectConfigurationKnowledge.svelte';
-	import { LoaderCircle, X, AlertCircle, CircleFadingArrowUp } from 'lucide-svelte';
-	import { AlertTriangle } from 'lucide-svelte';
+	import { X, CircleAlert, CircleFadingArrowUp } from 'lucide-svelte';
+	import { TriangleAlert } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
 	interface Props {
@@ -97,14 +99,14 @@
 	});
 </script>
 
-<div class="dark:bg-background bg-surface1 min-h-full w-full flex-col">
+<div class="dark:bg-base-100 bg-base-200 min-h-full w-full flex-col">
 	<div class="mx-auto min-h-full w-full px-4 py-4 md:max-w-[1200px] md:px-8">
 		<div class="mb-4 flex items-center gap-2">
 			<h1 class="text-2xl font-semibold capitalize">Project Configuration</h1>
 			<div class="flex grow justify-end">
-				<button class="icon-button" onclick={() => closeAll(layout)}>
+				<IconButton onclick={() => closeAll(layout)}>
 					<X class="size-6" />
-				</button>
+				</IconButton>
 			</div>
 		</div>
 		<div class="flex flex-col gap-6">
@@ -124,7 +126,7 @@
 								<div class="flex items-center gap-2">
 									<p class="font-semibold">Public Share URL</p>
 									{#if !shareUrl}
-										<AlertTriangle class="size-4 text-yellow-500" />
+										<TriangleAlert class="size-4 text-warning" />
 									{/if}
 								</div>
 								{#if shareUrl}
@@ -135,7 +137,7 @@
 											buttonText={shareUrl}
 											classes={{
 												button:
-													'button-small flex items-center gap-1 rounded-full border border-gray-500 bg-transparent px-4 py-2 text-gray-600 hover:bg-gray-500 hover:text-white disabled:bg-transparent'
+													'btn btn-sm flex items-center gap-1 rounded-full border border-base-300 bg-transparent px-4 py-2 text-muted-content hover:bg-base-200 hover:text-white disabled:bg-transparent'
 											}}
 										/>
 									</div>
@@ -153,15 +155,15 @@
 										>
 										{#if showUpgradeButton}
 											<button
-												class="button flex gap-1"
+												class="btn btn-primary btn-soft flex gap-1"
 												onclick={upgradeFromTemplate}
 												disabled={upgradeLoading}
 											>
 												{#if upgradeLoading}
-													<LoaderCircle class="size-4 animate-spin" />
+													<Loading class="size-4" />
 												{:else}
 													Upgrade
-													<CircleFadingArrowUp class="relative top-[1px] size-4 shrink-0" />
+													<CircleFadingArrowUp class="relative top-px size-4 shrink-0" />
 												{/if}
 											</button>
 										{/if}
@@ -172,7 +174,7 @@
 							<p
 								class="mt-1 flex w-full items-center justify-center gap-1 text-center text-xs font-light text-gray-600"
 							>
-								<AlertCircle class="max-h-3.5 min-h-3.5" />
+								<CircleAlert class="max-h-3.5 min-h-3.5" />
 								<span>
 									Changing fields such as instructions, MCP servers, tasks, or knowledge will make
 									this project ineligible to receive updates from the shared project snapshot
@@ -193,7 +195,7 @@
 								type="text"
 								id="name"
 								bind:value={modifiedProject.name}
-								class="text-input-filled dark:bg-background"
+								class="text-input-filled dark:bg-base-100"
 							/>
 						</div>
 						<div class="flex flex-col gap-1">
@@ -202,7 +204,7 @@
 								type="text"
 								id="description"
 								bind:value={modifiedProject.description}
-								class="text-input-filled dark:bg-background"
+								class="text-input-filled dark:bg-base-100"
 							/>
 						</div>
 					</div>
@@ -214,7 +216,7 @@
 						rows={6}
 						id="prompt"
 						bind:value={modifiedProject.prompt}
-						class="text-input-filled dark:bg-background"
+						class="text-input-filled dark:bg-base-100"
 						placeholder={HELPER_TEXTS.prompt}
 						use:autoHeight
 					></textarea>
@@ -229,13 +231,13 @@
 
 			<div class="mb-8 flex flex-col gap-2">
 				<h2 class="text-xl font-semibold">Danger Zone</h2>
-				<div class="rounded-md border border-red-500 p-4">
+				<div class="rounded-md border border-error p-4">
 					<div class="flex items-center justify-between gap-4">
 						<div class="flex flex-col">
 							<p class="font-semibold">Delete Project</p>
 							<span class="text-sm font-light">Delete this project and all associated data.</span>
 						</div>
-						<button class="button-destructive text-md" onclick={() => (confirmDelete = true)}>
+						<button class="btn btn-error text-md" onclick={() => (confirmDelete = true)}>
 							Delete this project
 						</button>
 					</div>
@@ -244,12 +246,14 @@
 		</div>
 	</div>
 	<div
-		class="dark:bg-background bg-surface1 sticky bottom-0 left-0 flex w-full justify-end gap-4 p-4 md:px-8"
+		class="dark:bg-base-100 bg-base-200 sticky bottom-0 left-0 flex w-full justify-end gap-4 p-4 md:px-8"
 	>
-		<button disabled={saving} class="button" onclick={() => closeAll(layout)}> Cancel </button>
-		<button disabled={saving} class="button-primary" onclick={handleUpdate}>
+		<button disabled={saving} class="btn btn-secondary" onclick={() => closeAll(layout)}>
+			Cancel
+		</button>
+		<button disabled={saving} class="btn btn-primary" onclick={handleUpdate}>
 			{#if saving}
-				<LoaderCircle class="size-4 animate-spin" />
+				<Loading class="size-4" />
 			{:else}
 				Update
 			{/if}

--- a/ui/user/src/lib/components/edit/ProjectConfigurationKnowledge.svelte
+++ b/ui/user/src/lib/components/edit/ProjectConfigurationKnowledge.svelte
@@ -9,6 +9,7 @@
 	import { type KnowledgeFile as KnowledgeFileType } from '$lib/services';
 	import { hasTool } from '$lib/tools';
 	import InfoTooltip from '../InfoTooltip.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2, TriangleAlert } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -47,7 +48,7 @@
 </script>
 
 <div class="flex flex-col gap-2">
-	<div class={twMerge('flex items-center gap-2', !hasKnowledgeCapability && 'text-on-surface1')}>
+	<div class={twMerge('flex items-center gap-2', !hasKnowledgeCapability && 'text-muted-content')}>
 		<h2 class="text-xl font-semibold">Knowledge Files</h2>
 		{#if !hasKnowledgeCapability}
 			<div use:tooltip={'Capability Required'}>
@@ -60,7 +61,7 @@
 
 	<div class="flex flex-col gap-4">
 		{#if !hasKnowledgeCapability}
-			<p class="text-on-surface1 flex items-center gap-1 text-sm font-light">
+			<p class="text-muted-content flex items-center gap-1 text-sm font-light">
 				<span> Enable Knowledge in "Built-In Capabilities" to add knowledge to your project. </span>
 			</p>
 		{/if}
@@ -68,12 +69,12 @@
 			<div class="flex flex-col gap-2">
 				{#if knowledgeFiles.length > 0}
 					<div
-						class="text-md dark:bg-surface1 dark:border-surface3 bg-background gap-4 rounded-md border border-transparent shadow-sm"
+						class="text-md dark:bg-base-200 dark:border-base-400 bg-base-100 gap-4 rounded-md border border-transparent shadow-sm"
 					>
 						{#each knowledgeFiles as file (file.fileName)}
 							{#key file.fileName}
 								<KnowledgeFile
-									classes={{ button: 'p-4', delete: 'flex-shrink-0 icon-button mr-2' }}
+									classes={{ button: 'p-4', delete: 'shrink-0 btn btn-square btn-ghost mr-2' }}
 									{file}
 									onDelete={() => remove(file)}
 									iconSize={5}
@@ -110,7 +111,7 @@
 			<div class="flex flex-col gap-2">
 				{#each project.websiteKnowledge.sites as _, i (i)}
 					<div
-						class="group dark:border-surface3 bg-background flex gap-2 rounded-md p-2 text-xs shadow-sm dark:border"
+						class="group dark:border-base-400 bg-base-100 flex gap-2 rounded-md p-2 text-xs shadow-sm dark:border"
 					>
 						<div class="flex grow flex-col gap-2">
 							<div>
@@ -121,7 +122,7 @@
 									id={`website-address-${i}`}
 									bind:value={project.websiteKnowledge.sites[i].site}
 									placeholder="example.com"
-									class="ghost-input border-surface2 w-full"
+									class="ghost-input border-base-300 w-full"
 								/>
 							</div>
 							<div>
@@ -130,7 +131,7 @@
 								>
 								<textarea
 									id={`website-description-${i}`}
-									class="ghost-input border-surface2 w-full resize-none"
+									class="ghost-input border-base-300 w-full resize-none"
 									bind:value={project.websiteKnowledge.sites[i].description}
 									rows="1"
 									placeholder="Description"
@@ -139,14 +140,13 @@
 							</div>
 						</div>
 						<div class="flex items-center justify-end">
-							<button
-								class="icon-button size-fit"
+							<IconButton
 								onclick={() => {
 									project.websiteKnowledge?.sites?.splice(i, 1);
 								}}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						</div>
 					</div>
 				{/each}
@@ -154,7 +154,7 @@
 		{/if}
 		<div class="self-end">
 			<button
-				class="button-small text-xs"
+				class="btn btn-secondary btn-sm"
 				onclick={() => {
 					if (!project.websiteKnowledge) {
 						project.websiteKnowledge = {

--- a/ui/user/src/lib/components/edit/ProjectInvitations.svelte
+++ b/ui/user/src/lib/components/edit/ProjectInvitations.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import {
@@ -12,6 +11,7 @@
 	import { profile, responsive } from '$lib/stores';
 	import { formatTimeAgo } from '$lib/time';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Trash2, Plus, Clock, X, Crown } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -102,10 +102,10 @@
 			<div class="dark:bg-gray-980 flex flex-col gap-2 rounded-md bg-gray-50 p-2 shadow-inner">
 				{#each members as member (member.userID)}
 					<div
-						class="group dark:bg-surface1 dark:border-surface3 bg-background flex w-full items-center rounded-md p-2 shadow-sm dark:border"
+						class="group dark:bg-base-200 dark:border-base-400 bg-base-100 flex w-full items-center rounded-md p-2 shadow-sm dark:border"
 					>
 						<div class="flex grow items-center gap-2">
-							<div class="size-10 overflow-hidden rounded-full bg-gray-50 dark:bg-gray-600">
+							<div class="size-10 overflow-hidden rounded-full bg-base-200 dark:bg-base-300">
 								<img
 									src={member.iconURL}
 									class="h-full w-full object-cover"
@@ -120,22 +120,22 @@
 										<Crown class="size-4" />
 									{/if}
 									{#if member.email === profile.current.email}
-										<span class="text-on-surface1 text-xs">(Me)</span>
+										<span class="text-muted-content text-xs">(Me)</span>
 									{/if}
 								</p>
-								<span class="text-on-surface1 text-sm font-light">
+								<span class="text-muted-content text-sm font-light">
 									{member.isOwner ? 'Owner' : 'Member'}
 								</span>
 							</div>
 						</div>
 						{#if isOwnerOrAdmin && profile.current.email !== member.email && !member.isOwner}
-							<button
-								class="button-destructive"
+							<IconButton
+								variant="danger2"
+								tooltip={{ text: 'Remove member' }}
 								onclick={() => (toDelete = member.email)}
-								use:tooltip={'Remove member'}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					</div>
 				{/each}
@@ -145,7 +145,7 @@
 				<h2 class="text-xl font-semibold">Project Invitations</h2>
 				{#if isOwnerOrAdmin}
 					<button
-						class="button flex items-center gap-1 text-sm"
+						class="btn btn-secondary flex items-center gap-1 text-sm"
 						onclick={createInvitation}
 						disabled={isCreating}
 					>
@@ -159,7 +159,9 @@
 	<div class="dark:bg-gray-980 flex w-full grow items-center bg-gray-50 p-4">
 		<div class="mx-auto flex w-full flex-col self-start md:max-w-[1200px]">
 			{#if !isOwnerOrAdmin}
-				<p class="text-on-surface1 p-4 text-center">Only project owners can manage invitations.</p>
+				<p class="text-muted-content p-4 text-center">
+					Only project owners can manage invitations.
+				</p>
 			{:else if isLoading}
 				<div class="flex grow items-center justify-center">
 					<div
@@ -167,31 +169,31 @@
 					></div>
 				</div>
 			{:else if invitations.length === 0}
-				<p class="text-on-surface1 p-4 text-center">No invitations found</p>
+				<p class="text-muted-content p-4 text-center">No invitations found</p>
 			{:else}
 				<ul class="flex flex-col gap-4">
 					{#each invitations as invitation (invitation.code)}
 						<li
-							class="dark:bg-surface1 dark:border-surface3 bg-background flex items-center justify-between gap-4 rounded-md p-4 shadow-sm dark:border"
+							class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex items-center justify-between gap-4 rounded-md p-4 shadow-sm dark:border"
 						>
 							<div class="flex grow flex-col gap-2 md:gap-1">
 								<div class="line-clamp-1 overflow-x-auto text-sm font-medium break-all">
 									{invitation.code}
 								</div>
-								<div class="flex flex-shrink-0 gap-4">
+								<div class="flex shrink-0 gap-4">
 									<span
 										class={twMerge(
 											'inline-flex rounded-lg border px-2 py-0.5 text-xs leading-5 font-semibold whitespace-nowrap capitalize dark:opacity-75',
-											invitation.status === 'pending' && 'border-yellow-500 text-yellow-500',
-											invitation.status === 'accepted' && 'border-green-500 text-green-500',
-											invitation.status === 'rejected' && 'border-red-500 text-red-500',
-											invitation.status === 'expired' && 'border-on-surface1 text-on-surface1'
+											invitation.status === 'pending' && 'border-warning text-warning',
+											invitation.status === 'accepted' && 'border-success text-success',
+											invitation.status === 'rejected' && 'border-error text-error',
+											invitation.status === 'expired' && 'border-base-content/40 text-muted-content'
 										)}
 									>
 										{invitation.status}
 									</span>
-									<div class="bg-surface2 dark:bg-surface3 h-6 w-[1px]"></div>
-									<div class="text-on-surface1 flex items-center gap-2 text-xs">
+									<div class="bg-base-300 dark:bg-base-400 h-6 w-px"></div>
+									<div class="text-muted-content flex items-center gap-2 text-xs">
 										<Clock class="size-3.5" />
 										<span>{formatTimeAgo(invitation.created).relativeTime}</span>
 									</div>
@@ -204,7 +206,7 @@
 									/>
 								{/if}
 							</div>
-							<div class="flex flex-shrink-0 gap-4 self-start md:self-center">
+							<div class="flex shrink-0 gap-4 self-start md:self-center">
 								{#if invitation.status === 'pending' && !responsive.isMobile}
 									<CopyButton
 										text={`${window.location.protocol}//${window.location.host}/i/${invitation.code}`}
@@ -212,7 +214,7 @@
 									/>
 								{/if}
 								<button
-									class="button-destructive flex-shrink-0"
+									class="btn btn-error shrink-0"
 									onclick={() => (deleteInvitationCode = invitation.code)}
 								>
 									<Trash2 class="size-4" />
@@ -249,13 +251,13 @@
 />
 
 <ResponsiveDialog bind:this={invitationDialog} class="relative p-4 py-8 md:w-lg" animate="fade">
-	<button
-		class="icon-button relative top-2 right-2 z-40 float-right self-end md:absolute"
+	<IconButton
+		class="relative top-2 right-2 z-40 float-right self-end md:absolute"
 		onclick={() => invitationDialog?.close()}
-		use:tooltip={{ disablePortal: true, text: 'Close Project Catalog' }}
+		tooltip={{ disablePortal: true, text: 'Close Project Catalog' }}
 	>
 		<X class="size-6" />
-	</button>
+	</IconButton>
 
 	<div class="flex flex-col items-center gap-4">
 		<img src="/user/images/sharing-agent.webp" alt="invitation" />
@@ -269,7 +271,7 @@
 			buttonText="Copy Invite Link"
 			classes={{ button: 'text-md px-6 gap-2' }}
 		/>
-		<span class="text-on-surface1 line-clamp-1 text-xs break-all">{invitationUrl}</span>
+		<span class="text-muted-content line-clamp-1 text-xs break-all">{invitationUrl}</span>
 	</div>
 </ResponsiveDialog>
 

--- a/ui/user/src/lib/components/edit/Sharing.svelte
+++ b/ui/user/src/lib/components/edit/Sharing.svelte
@@ -6,6 +6,7 @@
 	import { HELPER_TEXTS } from '$lib/context/helperMode.svelte';
 	import { ChatService, type Project, type ProjectMember } from '$lib/services';
 	import { profile } from '$lib/stores';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Crown, Plus, Trash2 } from 'lucide-svelte';
 	import { fade } from 'svelte/transition';
 
@@ -57,8 +58,8 @@
 	<div class="flex flex-col">
 		<CollapsePane
 			classes={{
-				header: 'pl-3 pr-5.5 py-2 border-surface3 border-b',
-				content: 'p-3 border-b border-surface3 overflow-x-hidden',
+				header: 'pl-3 pr-5.5 py-2 border-base-400 border-b',
+				content: 'p-3 border-b border-base-400 overflow-x-hidden',
 				headerText: 'text-sm font-normal'
 			}}
 			iconSize={4}
@@ -66,13 +67,13 @@
 			helpText={HELPER_TEXTS.chatbot}
 		>
 			<div class="flex flex-col gap-3">
-				<p class="text-on-surface1 text-xs">
+				<p class="text-muted-content text-xs">
 					Configure ChatBot to produce a link that allows anyone to use this project in a read-only
 					mode.
 				</p>
 				<div class="mt-2 flex justify-end" in:fade>
 					<button
-						class="button flex cursor-pointer items-center justify-end gap-1 text-xs"
+						class="btn btn-secondary btn-sm flex cursor-pointer items-center justify-end gap-1"
 						onclick={openChatbotConfig}
 					>
 						<span>Configure ChatBot</span>
@@ -83,8 +84,8 @@
 
 		<CollapsePane
 			classes={{
-				header: 'pl-3 pr-5.5 py-2 border-surface3 border-b',
-				content: 'p-3 border-b border-surface3',
+				header: 'pl-3 pr-5.5 py-2 border-base-400 border-b',
+				content: 'p-3 border-b border-base-400',
 				headerText: 'text-sm font-normal'
 			}}
 			iconSize={4}
@@ -97,13 +98,9 @@
 						<span class="text-sm font-medium">Project Members</span>
 						{#if isOwnerOrAdmin}
 							<div class="flex gap-2">
-								<button
-									class="icon-button"
-									onclick={manageInvitations}
-									use:tooltip={'Manage invitations'}
-								>
+								<IconButton onclick={manageInvitations} tooltip={{ text: 'Manage invitations' }}>
 									<Plus class="size-4" />
-								</button>
+								</IconButton>
 							</div>
 						{/if}
 					</div>
@@ -112,7 +109,7 @@
 							class="group flex min-h-9 w-full items-center rounded-md transition-colors duration-300"
 						>
 							<div class="flex grow items-center gap-2">
-								<div class="size-6 overflow-hidden rounded-full bg-gray-50 dark:bg-gray-600">
+								<div class="size-6 overflow-hidden rounded-full bg-base-200 dark:bg-base-300">
 									<img
 										src={member.iconURL}
 										class="h-full w-full object-cover"
@@ -130,13 +127,12 @@
 								{/if}
 							</div>
 							{#if isOwnerOrAdmin && profile.current.email !== member.email && !member.isOwner}
-								<button
-									class="icon-button"
+								<IconButton
 									onclick={() => (toDelete = member.email)}
-									use:tooltip={'Remove member'}
+									tooltip={{ text: 'Remove member' }}
 								>
 									<Trash2 class="size-4" />
-								</button>
+								</IconButton>
 							{/if}
 						</div>
 					{/each}

--- a/ui/user/src/lib/components/edit/SystemPrompt.svelte
+++ b/ui/user/src/lib/components/edit/SystemPrompt.svelte
@@ -19,7 +19,7 @@
 >
 	<textarea
 		id="project-instructions"
-		class="dark:border-surface3 bg-background grow resize-none rounded-lg p-2 text-sm shadow-sm dark:border"
+		class="dark:border-base-400 bg-base-100 grow resize-none rounded-lg p-2 text-sm shadow-sm dark:border"
 		rows="12"
 		use:autoHeight
 		bind:value={project.prompt}

--- a/ui/user/src/lib/components/edit/TaskItem.svelte
+++ b/ui/user/src/lib/components/edit/TaskItem.svelte
@@ -70,8 +70,8 @@
 <li class="flex min-h-9 flex-col">
 	<div
 		class={twMerge(
-			'hover:bg-surface3/90 active:bg-surface3/100 group mb-[2px] flex items-center rounded-md font-light transition-colors duration-200',
-			layout.editTaskID === task.id && 'bg-surface3/60',
+			'hover:bg-base-400/90 active:bg-base-400 group mb-[2px] flex items-center rounded-md font-light transition-colors duration-200',
+			layout.editTaskID === task.id && 'bg-base-400/60',
 			layout.displayTaskRun && layout.displayTaskRun.taskID === task.id && 'font-medium'
 		)}
 	>
@@ -111,11 +111,11 @@
 					<li class="track-mark relative w-full pb-[2px] pl-3">
 						<div
 							class={twMerge(
-								'hover:bg-surface3/90 active:bg-surface3/100 group flex items-center rounded-md transition-colors duration-200',
-								currentThreadID === taskRun.id && !isSomethingSelected(layout) && 'bg-surface2',
+								'hover:bg-base-400/90 active:bg-base-400 group flex items-center rounded-md transition-colors duration-200',
+								currentThreadID === taskRun.id && !isSomethingSelected(layout) && 'bg-base-300',
 								layout.displayTaskRun &&
 									layout.displayTaskRun.id === taskRun.taskRunID &&
-									'bg-surface3/60'
+									'bg-base-300/60'
 							)}
 						>
 							<button
@@ -154,7 +154,7 @@
 					</li>
 				{/each}
 				{#if taskRuns?.length && taskRuns?.length > displayCount}
-					<li class="hover:bg-surface3 flex w-full justify-center rounded-md p-2">
+					<li class="hover:bg-base-400 flex w-full justify-center rounded-md p-2">
 						<button class="w-full text-xs" onclick={loadMore}> Show More </button>
 					</li>
 				{/if}
@@ -178,7 +178,7 @@
 		left: 0;
 		width: 12px;
 		height: 1px;
-		background-color: var(--surface3);
+		background-color: var(--color-base-400);
 	}
 	.track-mark::before {
 		content: '';
@@ -187,7 +187,7 @@
 		left: 0;
 		height: 100%;
 		width: 1px;
-		background-color: var(--surface3);
+		background-color: var(--color-base-400);
 	}
 	.track-mark:last-child::before {
 		content: '';
@@ -196,6 +196,6 @@
 		left: 0;
 		height: 50%;
 		width: 1px;
-		background-color: var(--surface3);
+		background-color: var(--color-base-400);
 	}
 </style>

--- a/ui/user/src/lib/components/edit/Tasks.svelte
+++ b/ui/user/src/lib/components/edit/Tasks.svelte
@@ -83,7 +83,7 @@
 	<div class="flex items-center justify-between">
 		<p class="text-md grow font-medium">Tasks</p>
 		<button
-			class="hover:text-on-background text-on-surface1 p-2 transition-colors duration-200"
+			class="hover:text-base-content text-muted-content p-2 transition-colors duration-200"
 			onclick={() => newTask()}
 			use:tooltip={'Start New Task'}
 		>
@@ -115,7 +115,7 @@
 	<div class="flex grow"></div>
 	<div class="mt-4 flex w-full flex-col justify-between gap-4 md:flex-row md:justify-end">
 		<button
-			class="button-primary w-full md:w-fit"
+			class="btn btn-primary w-full md:w-fit"
 			onclick={() => {
 				runTask(waitingTask);
 				inputDialog?.close();

--- a/ui/user/src/lib/components/edit/ThreadModelSelector.svelte
+++ b/ui/user/src/lib/components/edit/ThreadModelSelector.svelte
@@ -364,7 +364,7 @@
 <div class="relative mr-2 md:mr-6 lg:mr-8">
 	<button
 		class={twMerge(
-			'hover:bg-surface2/50 active:bg-surface2/80 flex h-10 items-center gap-3 rounded-full px-2  py-1 text-xs text-gray-600 md:px-4 lg:px-6',
+			'hover:bg-base-300/50 active:bg-base-300/80 flex h-10 items-center gap-3 rounded-sm px-2  py-1 text-xs text-muted-content md:px-4 lg:px-6',
 			(isDefaultModelSelected || (!threadType?.model && defaultModel)) &&
 				'text-primary hover:bg-primary/10 active:bg-primary/15 bg-transparent',
 			isUsingFallback && 'text-orange-600'
@@ -423,11 +423,11 @@
 				<span class="sr-only">Loading models...</span>
 			</div>
 		{:else if modelsError}
-			<div class="text-on-surface1 p-4 text-sm">
+			<div class="text-muted-content p-4 text-sm">
 				{modelsError}
 			</div>
 		{:else if availableModels.length === 0}
-			<div class="text-on-surface1 p-4 text-sm">No Model Available</div>
+			<div class="text-muted-content p-4 text-sm">No Model Available</div>
 		{:else}
 			<div class="flex flex-col">
 				{#each (() => {
@@ -446,7 +446,7 @@
 				})() as [providerId, models] (providerId)}
 					{#if models.length > 0}
 						{@const provider = modelProvidersMap.get(providerId)}
-						<div class="border-surface1 flex flex-col border-b py-2 last:border-transparent">
+						<div class="border-base-200 flex flex-col border-b py-2 last:border-transparent">
 							<div class="mb-2 flex gap-1 text-xs">
 								{#if provider?.icon || provider?.iconDark}
 									<img
@@ -474,7 +474,7 @@
 										role="option"
 										aria-selected={isModelSelected}
 										class={twMerge(
-											'hover:bg-surface1/70 active:bg-surface1/80 focus:bg-surface1/70 flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors duration-200 focus:outline-none',
+											'hover:bg-base-200/70 active:bg-base-200/80 focus:bg-base-200/70 flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors duration-200 focus:outline-none',
 											isModelSelected &&
 												'text-primary bg-primary/10 hover:bg-primary/15 active:bg-primary/20'
 										)}

--- a/ui/user/src/lib/components/edit/knowledge/KnowledgeFile.svelte
+++ b/ui/user/src/lib/components/edit/knowledge/KnowledgeFile.svelte
@@ -29,7 +29,7 @@
 			<span class="truncate">{file.fileName}</span>
 		</div>
 		{#if file.state === 'error' || file.state === 'failed'}
-			<CircleX class={`ms-2 size-${iconSize} text-red-500`} />
+			<CircleX class={`ms-2 size-${iconSize} text-error`} />
 		{:else if file.state === 'pending' || file.state === 'ingesting'}
 			<Loading class="mx-1.5" />
 		{/if}

--- a/ui/user/src/lib/components/edit/knowledge/KnowledgeUpload.svelte
+++ b/ui/user/src/lib/components/edit/knowledge/KnowledgeUpload.svelte
@@ -65,7 +65,9 @@
 	});
 </script>
 
-<label class={twMerge('button flex items-center justify-end gap-1 text-sm', classes?.button)}>
+<label
+	class={twMerge('btn btn-secondary flex items-center justify-end gap-1 text-sm', classes?.button)}
+>
 	{#await uploadInProgress}
 		<Loading class="size-4" />
 	{:catch error}

--- a/ui/user/src/lib/components/editor/Codemirror.svelte
+++ b/ui/user/src/lib/components/editor/Codemirror.svelte
@@ -296,9 +296,9 @@
 ></div>
 
 <div class="absolute flex">
-	<div class="bg-gray-70 flex rounded-3xl shadow-lg" bind:this={explain} class:hidden={!ttVisible}>
+	<div class="bg-base-200 flex rounded-3xl shadow-lg" bind:this={explain} class:hidden={!ttVisible}>
 		<button
-			class="flex items-center gap-2 rounded-s-3xl p-4 ps-5 hover:bg-gray-100 dark:bg-gray-950 dark:hover:bg-gray-900"
+			class="flex items-center gap-2 rounded-s-3xl p-4 ps-5 btn btn-secondary"
 			onclick={onExplain}
 			class:hidden={ttImprove}
 		>
@@ -306,7 +306,7 @@
 			<CircleHelp class="h-5 w-5" />
 		</button>
 		<button
-			class="flex items-center gap-2 rounded-e-3xl p-4 pe-5 hover:bg-gray-100 dark:bg-gray-950 dark:hover:bg-gray-900"
+			class="flex items-center gap-2 rounded-e-3xl p-4 pe-5 btn btn-secondary"
 			onclick={async () => {
 				ttImprove = true;
 				await tick();

--- a/ui/user/src/lib/components/editor/FileEditors.svelte
+++ b/ui/user/src/lib/components/editor/FileEditors.svelte
@@ -49,6 +49,6 @@
 {#snippet unsupportedFile()}
 	<div class="flex h-full w-full flex-col items-center justify-center">
 		<Logo variant="warning" class="size-[200px] opacity-50" />
-		<p class="text-on-surface1 text-lg">This type of file cannot be opened in the editor</p>
+		<p class="text-muted-content text-lg">This type of file cannot be opened in the editor</p>
 	</div>
 {/snippet}

--- a/ui/user/src/lib/components/editor/MarkdownFile.svelte
+++ b/ui/user/src/lib/components/editor/MarkdownFile.svelte
@@ -57,9 +57,9 @@
 			bind:value={contents}
 			{disabled}
 			disablePreview
-			class="border-surface3 h-full grow rounded-none border-0 bg-inherit shadow-none"
+			class="border-base-400 h-full grow rounded-none border-0 bg-inherit shadow-none"
 			classes={{
-				input: 'bg-surface1 h-full max-h-full pb-8 grid'
+				input: 'bg-base-200 h-full max-h-full pb-8 grid'
 			}}
 			typewriterOnAutonomous
 			{overrideContent}

--- a/ui/user/src/lib/components/editor/Milkdown.svelte
+++ b/ui/user/src/lib/components/editor/Milkdown.svelte
@@ -235,7 +235,7 @@
 ></div>
 
 <div
-	class="bg-surface1 absolute flex rounded-3xl shadow-lg"
+	class="bg-base-200 absolute flex rounded-3xl shadow-lg"
 	bind:this={ttDiv}
 	class:hidden={!ttVisible}
 >

--- a/ui/user/src/lib/components/editor/RawEditor.svelte
+++ b/ui/user/src/lib/components/editor/RawEditor.svelte
@@ -298,7 +298,7 @@
 
 <div
 	class={twMerge(
-		'text-input-filled border-surface3 dark:bg-background flex flex-col gap-0 overflow-hidden border p-0 transition-colors',
+		'text-input-filled border-base-400 dark:bg-base-100 flex flex-col gap-0 overflow-hidden border p-0 transition-colors',
 		focused && !disabled && !disablePreview && 'ring-primary ring-2 outline-none',
 		disabled && 'disabled',
 		klass
@@ -306,13 +306,13 @@
 >
 	{#if !disablePreview}
 		<div
-			class="dark:border-surface3 dark:bg-surface2 text-on-surface1 flex items-center border-b text-sm font-light"
+			class="dark:border-base-400 dark:bg-base-300 text-muted-content flex items-center border-b text-sm font-light"
 		>
 			<button
 				class={twMerge(
 					'px-4 py-2',
 					!showPreview &&
-						'dark:border-surface3 bg-background text-on-background relative z-10 translate-y-[1px] border-r font-medium'
+						'dark:border-base-400 bg-base-100 text-base-content relative z-10 translate-y-px border-r font-medium'
 				)}
 				onclick={() => {
 					showPreview = false;
@@ -328,7 +328,7 @@
 				class={twMerge(
 					'px-4 py-2',
 					showPreview &&
-						'dark:border-surface3 bg-background text-on-background relative z-10 translate-y-[1px] border-x font-medium'
+						'dark:border-base-400 bg-base-100 text-base-content relative z-10 translate-y-px border-x font-medium'
 				)}
 				onclick={() => (showPreview = true)}>Preview</button
 			>
@@ -336,14 +336,14 @@
 	{/if}
 	{#if !disablePreview && showPreview}
 		<div
-			class="milkdown-content default-scrollbar-thin bg-background max-h-[650px] min-h-48 overflow-y-auto p-4"
+			class="milkdown-content default-scrollbar-thin bg-base-100 max-h-[650px] min-h-48 overflow-y-auto p-4"
 		>
 			{@html toHTMLFromMarkdownWithNewTabLinks(value)}
 		</div>
 	{:else}
 		<div
 			class={twMerge(
-				'default-scrollbar-thin bg-background max-h-[650px] min-h-48 overflow-y-auto p-4 ',
+				'default-scrollbar-thin bg-base-100 max-h-[650px] min-h-48 overflow-y-auto p-4 ',
 				classes?.input
 			)}
 			use:cmEditor

--- a/ui/user/src/lib/components/graph/DonutGraph.svelte
+++ b/ui/user/src/lib/components/graph/DonutGraph.svelte
@@ -336,7 +336,7 @@
 	>
 		{#if highlightedArcElement && currentItem}
 			<div
-				class="tooltip bg-background dark:bg-surface2 pointer-events-none fixed top-0 left-0 z-50 flex flex-col shadow-md min-w-32"
+				class="tooltip bg-base-100 dark:bg-base-300 pointer-events-none fixed top-0 left-0 z-50 flex flex-col shadow-md min-w-32"
 				{@attach (node) => tooltip(highlightedArcElement!, node)}
 				in:fade={{ duration: 100, delay: 10 }}
 				out:fade={{ duration: 100 }}
@@ -346,7 +346,7 @@
 				{:else}
 					{@const parts = tooltipLabelParts(currentItem.label)}
 					<div class="flex flex-col gap-0 text-xs">
-						<div class="text-on-background text-sm">
+						<div class="text-base-content text-sm">
 							{#if parts.detail !== undefined}
 								<span class="font-semibold">{parts.main}</span>
 								<span>{TOOLTIP_LABEL_SEP}{parts.detail}</span>
@@ -354,17 +354,17 @@
 								<span class="font-semibold">{parts.main}</span>
 							{/if}
 						</div>
-						<div class="border-on-surface1 mb-2 border-b pb-2">
+						<div class="text-muted-content mb-2 border-b pb-2">
 							{currentItem.percentOfTotal.toFixed(1)}% of total
 						</div>
 					</div>
-					<div class="text-on-background text-2xl font-bold">{formatValue(currentItem.value)}</div>
+					<div class="text-base-content text-2xl font-bold">{formatValue(currentItem.value)}</div>
 				{/if}
 			</div>
 		{/if}
 
 		{#if total <= 0}
-			<p class="text-on-surface1 font-light text-sm">No data</p>
+			<p class="text-muted-content font-light text-sm">No data</p>
 		{:else}
 			<svg
 				class="max-h-full max-w-full overflow-visible"
@@ -383,7 +383,7 @@
 							fill={slice.color}
 							class={twMerge(
 								'cursor-pointer stroke-1',
-								useGroupSeparators ? '' : 'stroke-background dark:stroke-surface1'
+								useGroupSeparators ? '' : 'stroke-base-100 dark:stroke-base-200'
 							)}
 							onpointerenter={(e) => {
 								cancelHoverSliceClear();
@@ -421,7 +421,7 @@
 						<path
 							d={sepPath}
 							fill="none"
-							class="stroke-background dark:stroke-surface1 stroke-1 pointer-events-none"
+							class="stroke-base-100 dark:stroke-base-200 stroke-1 pointer-events-none"
 							aria-hidden="true"
 						/>
 					{/each}

--- a/ui/user/src/lib/components/graph/HorizontalBarGraph.svelte
+++ b/ui/user/src/lib/components/graph/HorizontalBarGraph.svelte
@@ -107,7 +107,7 @@
 	<div bind:clientWidth bind:clientHeight class="min-h-0 min-w-0 flex-1">
 		{#if highlightedRectElement && currentItem}
 			<div
-				class="tooltip bg-background dark:bg-surface2 pointer-events-none fixed top-0 left-0 z-50 flex flex-col shadow-md"
+				class="tooltip bg-base-100 dark:bg-base-300 pointer-events-none fixed top-0 left-0 z-50 flex flex-col shadow-md"
 				{@attach (node) => tooltip(highlightedRectElement!, node)}
 				in:fade={{ duration: 100, delay: 10 }}
 				out:fade={{ duration: 100 }}
@@ -128,7 +128,7 @@
 		<svg width={clientWidth} height={clientHeight} viewBox="0 0 {clientWidth} {clientHeight}">
 			<g transform="translate({paddingLeft}, {paddingTop})">
 				<g
-					class="x-axis text-on-surface3/20 dark:text-on-surface1/10"
+					class="x-axis text-base-content/10"
 					transform="translate(0, {innerHeight})"
 					{@attach (node: SVGGElement) => {
 						select(node)
@@ -145,7 +145,7 @@
 				></g>
 
 				<g
-					class="y-axis text-on-surface3/20 dark:text-on-surface1/10"
+					class="y-axis text-base-content/10"
 					{@attach (node: SVGGElement) => {
 						select(node)
 							.transition()
@@ -199,7 +199,7 @@
 							fill={fitsInside ? 'white' : 'currentColor'}
 							font-size="12"
 							font-weight="500"
-							class="text-on-surface1 pointer-events-none"
+							class="text-muted-content pointer-events-none"
 						>
 							{label}
 						</text>

--- a/ui/user/src/lib/components/graph/HorizontalBarRow.svelte
+++ b/ui/user/src/lib/components/graph/HorizontalBarRow.svelte
@@ -42,4 +42,5 @@
 	class={klass}
 	{onpointerenter}
 	{onpointerleave}
+	role="presentation"
 />

--- a/ui/user/src/lib/components/graph/StackedTimeline.svelte
+++ b/ui/user/src/lib/components/graph/StackedTimeline.svelte
@@ -1,8 +1,8 @@
 <script lang="ts" generics="T extends object">
-	import { tooltip as tooltipAction } from '$lib/actions/tooltip.svelte';
 	import { lightenHex } from '$lib/colors';
 	import { darkMode, timePreference } from '$lib/stores';
 	import { formatLogTimestamp } from '$lib/time';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { autoUpdate, computePosition, flip, offset } from '@floating-ui/dom';
 	import {
 		scaleBand,
@@ -588,7 +588,7 @@
 <div class={twMerge('group relative flex h-full w-full flex-col', klass)}>
 	<div class="flex min-h-0 flex-1 gap-0">
 		<div
-			class="y-axis-labels text-on-surface3/20 dark:text-on-surface1/10 relative shrink-0 self-stretch text-xs"
+			class="y-axis-labels text-base-content/15 dark:text-base-content/10 relative shrink-0 self-stretch text-xs"
 			style="width: {yAxisLabelWidth}px;"
 			aria-hidden="true"
 		>
@@ -611,7 +611,7 @@
 		<div bind:clientHeight bind:clientWidth class="min-h-0 min-w-0 flex-1">
 			{#if highlightedRectElement && currentItem}
 				<div
-					class="tooltip bg-background dark:bg-surface2 pointer-events-none fixed top-0 left-0 z-50 flex flex-col shadow-md"
+					class="tooltip bg-base-100 dark:bg-base-300 pointer-events-none fixed top-0 left-0 z-50 flex flex-col shadow-md"
 					{@attach (node) => tooltip(highlightedRectElement!, node)}
 					in:fade={{ duration: 100, delay: 10 }}
 					out:fade={{ duration: 100 }}
@@ -620,14 +620,14 @@
 						{@render tooltipContent(currentItem)}
 					{:else}
 						<div class="flex flex-col gap-0 text-xs">
-							<div class="text-on-background text-sm">
+							<div class="text-base-content text-sm">
 								{currentItem?.key}
 							</div>
-							<div class="border-on-surface1 mb-2 border-b pb-2">
+							<div class="border-base-200 mb-2 border-b pb-2">
 								{currentItem?.date}
 							</div>
 						</div>
-						<div class="text-on-background text-2xl font-bold">{currentItem?.value}</div>
+						<div class="text-base-content text-2xl font-bold">{currentItem?.value}</div>
 					{/if}
 				</div>
 			{/if}
@@ -636,7 +636,7 @@
 				<g transform="translate({paddingLeft}, {paddingTop})">
 					{#key timePreference.timeFormat}
 						<g
-							class="x-axis text-on-surface3/20 dark:text-on-surface1/10"
+							class="x-axis text-base-content/15 dark:text-base-content/10"
 							transform="translate(0 {innerHeight})"
 							{@attach (node: SVGGElement) => {
 								const selection = select(node);
@@ -737,7 +737,7 @@
 										const baseClassName = ['duration-500', 'transition-all'];
 										add(...baseClassName);
 
-										const activeClassName = ['text-on-surface3', 'dark:text-on-surface1'];
+										const activeClassName = ['text-base-content/15', 'dark:text-base-content/10'];
 										const inactiveClassName = ['opacity-0', 'duration-500', 'transition-opacity'];
 
 										if (isActive) {
@@ -769,7 +769,7 @@
 					{/key}
 
 					<g
-						class="y-axis text-on-surface3/20 dark:text-on-surface1/10"
+						class="y-axis text-base-content/15 dark:text-base-content/10"
 						{@attach (node: SVGGElement) => {
 							select(node)
 								.transition()
@@ -897,7 +897,7 @@
 									return base;
 								})
 								.attr('cursor', 'pointer')
-								.attr('class', 'text-on-surface1')
+								.attr('class', 'text-muted-content')
 								.on('pointerenter', function (ev, d) {
 									highlightedRectElement = this as SVGGraphicsElement;
 									const bucketKey =
@@ -957,18 +957,17 @@
 		{#if hasMoreLegendCategories}
 			{#if legendExpanded}
 				<button
-					class="text-on-surface1 hover:underline"
+					class="text-muted-content hover:underline"
 					onclick={() => (legendExpanded = !legendExpanded)}>Show less</button
 				>
 			{:else}
-				<button
-					type="button"
-					class="button-icon min-h-fit min-w-fit p-2"
+				<IconButton
+					class="btn-xs"
+					tooltip={{ text: 'Show all legend items' }}
 					onclick={() => (legendExpanded = !legendExpanded)}
-					use:tooltipAction={'Show all legend items'}
 				>
 					<Ellipsis class="size-3" />
-				</button>
+				</IconButton>
 			{/if}
 		{/if}
 	</div>
@@ -979,7 +978,7 @@
 		<span class="size-2 shrink-0 rounded-full" style="background-color: {color}"></span>
 		<span class="ml-0.5">
 			{#if label && category}
-				{category} <span class="text-on-surface1">{label}</span>
+				{category} <span class="text-muted-content">{label}</span>
 			{:else}
 				{label || category}
 			{/if}

--- a/ui/user/src/lib/components/mcp/CapacityBanner.svelte
+++ b/ui/user/src/lib/components/mcp/CapacityBanner.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import type { MCPCapacityInfo } from '$lib/services/admin/types';
-	import { Info, LoaderCircle } from 'lucide-svelte';
+	import { Info } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
 	let capacityInfo = $state<MCPCapacityInfo | null>(null);
@@ -43,16 +44,16 @@
 </script>
 
 {#if loading}
-	<div class="bg-surface2 dark:bg-surface1 mb-4 flex items-center justify-center rounded-md p-4">
-		<LoaderCircle class="size-5 animate-spin" />
+	<div class="bg-base-300 dark:bg-base-200 mb-4 flex items-center justify-center rounded-md p-4">
+		<Loading />
 	</div>
 {:else if capacityInfo && !capacityInfo.error}
-	<div class="bg-surface2 dark:bg-surface1 p-4 shadow-sm">
+	<div class="bg-base-300 dark:bg-base-200 p-4 shadow-sm">
 		<div class="mb-3 flex items-center gap-1">
 			<h3 class="text-sm font-semibold">MCP Requested Resources</h3>
 			{#if capacityInfo.source === 'resourceQuota'}
 				<span
-					class="text-on-surface1"
+					class="text-muted-content"
 					use:tooltip={{
 						text: 'Maximums based on resource quotas',
 						disablePortal: true
@@ -66,13 +67,13 @@
 		<div class="grid grid-cols-3 gap-4">
 			<!-- Active Deployments -->
 			<div class="flex flex-col">
-				<span class="text-on-surface1 text-xs">Active Deployments</span>
+				<span class="text-muted-content text-xs">Active Deployments</span>
 				<span class="text-lg font-semibold">{capacityInfo.activeDeployments}</span>
 			</div>
 
 			<!-- CPU -->
 			<div class="flex flex-col">
-				<span class="text-on-surface1 text-xs">CPU Requested</span>
+				<span class="text-muted-content text-xs">CPU Requested</span>
 				<span class="text-lg font-semibold">
 					{#if capacityInfo.cpuLimit}
 						{formatValue(capacityInfo.cpuRequested)} / {formatValue(capacityInfo.cpuLimit)}
@@ -84,7 +85,7 @@
 
 			<!-- Memory -->
 			<div class="flex flex-col">
-				<span class="text-on-surface1 text-xs">Memory Requested</span>
+				<span class="text-muted-content text-xs">Memory Requested</span>
 				<span class="text-lg font-semibold">
 					{#if capacityInfo.memoryLimit}
 						{formatValue(capacityInfo.memoryRequested)} / {formatValue(capacityInfo.memoryLimit)}

--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+	import Loading from '$lib/icons/Loading.svelte';
 	import { hasSecretBinding, type MCPServerInfo } from '$lib/services/chat/mcp';
 	import Confirm from '../Confirm.svelte';
 	import InfoTooltip from '../InfoTooltip.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import SensitiveInput from '../SensitiveInput.svelte';
 	import Toggle from '../Toggle.svelte';
-	import { AlertCircle, LoaderCircle, Server } from 'lucide-svelte';
+	import { CircleAlert, Server } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -302,7 +303,7 @@
 		servers are included to match your needs.
 	</p>
 	<button
-		class="button mt-4"
+		class="btn btn-secondary mt-4"
 		onclick={() => {
 			compositeInfoDialog?.close();
 			openConfig();
@@ -330,11 +331,11 @@
 			isOpen = false;
 		}
 	}}
-	class={isCompositeForm(form) ? 'bg-surface1 dark:bg-background' : ''}
+	class={isCompositeForm(form) ? 'bg-base-200 dark:bg-base-100' : ''}
 >
 	{#snippet titleContent()}
 		<div class="flex items-center gap-2">
-			<div class="bg-surface1 rounded-sm p-1 dark:bg-gray-600">
+			<div class="bg-base-200 rounded-sm p-1 dark:bg-base-300">
 				{#if icon}
 					<img src={icon} alt={name} class="size-8" />
 				{:else}
@@ -357,7 +358,7 @@
 {#snippet content()}
 	{#if error || localError}
 		<div class="notification-error flex items-center gap-2">
-			<AlertCircle class="size-6 flex-shrink-0 text-red-500" />
+			<CircleAlert class="size-6 shrink-0 text-error" />
 			<p class="flex flex-col text-sm font-light">
 				<span class="font-semibold">Error:</span>
 				<span>
@@ -377,7 +378,7 @@
 					<div class="flex flex-col gap-1">
 						<span class="flex items-center gap-2">
 							<label for="name"> Server Alias </label>
-							<span class="text-on-surface1">(optional)</span>
+							<span class="text-muted-content">(optional)</span>
 							<InfoTooltip
 								text="Uses server name as default. Duplicate instances default to a number increment added at the end of name."
 							/>
@@ -389,7 +390,7 @@
 				{#if 'componentConfigs' in form}
 					{#each Object.entries(form.componentConfigs) as [compId, comp] (compId)}
 						<div
-							class="dark:bg-surface2 dark:border-surface3 bg-background rounded-lg border border-transparent shadow-sm"
+							class="dark:bg-base-300 dark:border-base-400 bg-base-100 rounded-lg border border-transparent shadow-sm"
 						>
 							<div class="flex items-center gap-2 p-2">
 								{#if comp.icon}
@@ -407,7 +408,7 @@
 							{#if componentHasConfig(comp)}
 								{@const headers = getNonStaticServerHeaders(comp.headers)}
 
-								<div class="border-t border-gray-200 p-3">
+								<div class="border-t border-base-300 p-3">
 									{#if comp.envs && comp.envs.length > 0}
 										{#each comp.envs as env, i (env.key)}
 											{#if !hasSecretBinding(env)}
@@ -417,11 +418,11 @@
 													<span class="flex items-center gap-2">
 														<label
 															for={`${compId}-${env.key}`}
-															class={highlightRequired ? 'text-red-500' : ''}
+															class={highlightRequired ? 'text-error' : ''}
 														>
 															{env.name}
 															{#if !env.required}
-																<span class="text-on-surface1">(optional)</span>
+																<span class="text-muted-content">(optional)</span>
 															{/if}
 														</label>
 														{#if !displayDescriptionInline}
@@ -445,7 +446,7 @@
 															class={twMerge(
 																'text-input-filled h-32 resize-y whitespace-pre-wrap',
 																highlightRequired &&
-																	'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
+																	'border-error bg-error/20 ring-error focus:ring-1'
 															)}
 															onmousedown={() => (resizing = true)}
 															onmouseup={() => (resizing = false)}
@@ -459,12 +460,12 @@
 															class={twMerge(
 																'text-input-filled',
 																highlightRequired &&
-																	'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
+																	'border-error bg-error/20 ring-error focus:ring-1'
 															)}
 														/>
 													{/if}
 													{#if displayDescriptionInline}
-														<p class="text-on-surface1 text-xs font-light break-all">
+														<p class="text-muted-content text-xs font-light break-all">
 															{env.description}
 														</p>
 													{/if}
@@ -482,11 +483,11 @@
 												<span class="flex items-center gap-2">
 													<label
 														for={`${compId}-${header.data.key}`}
-														class={highlightRequired ? 'text-red-500' : ''}
+														class={highlightRequired ? 'text-error' : ''}
 													>
 														{header.data.name}
 														{#if !header.data.required}
-															<span class="text-on-surface1">(optional)</span>
+															<span class="text-muted-content">(optional)</span>
 														{/if}
 													</label>
 													{#if !displayDescriptionInline}
@@ -509,12 +510,12 @@
 														class={twMerge(
 															'text-input-filled',
 															highlightRequired &&
-																'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
+																'border-error bg-error/20 ring-error focus:ring-1'
 														)}
 													/>
 												{/if}
 												{#if displayDescriptionInline}
-													<p class="text-on-surface1 text-xs font-light break-all">
+													<p class="text-muted-content text-xs font-light break-all">
 														{header.data.description}
 													</p>
 												{/if}
@@ -531,7 +532,7 @@
 											disabled={form.componentConfigs[compId].disabled}
 											class="text-input-filled"
 										/>
-										<span class="text-on-surface1 font-light">
+										<span class="text-muted-content font-light">
 											The URL must contain the hostname: <b class="font-semibold">{comp.hostname}</b
 											>
 										</span>
@@ -551,10 +552,10 @@
 								{@const highlightRequired = highlightedFields.has(env.key) && !env.value}
 								<div class="flex flex-col gap-1">
 									<span class="flex items-center gap-2">
-										<label for={env.key} class={highlightRequired ? 'text-red-500' : ''}>
+										<label for={env.key} class={highlightRequired ? 'text-error' : ''}>
 											{env.name}
 											{#if !env.required}
-												<span class="text-on-surface1">(optional)</span>
+												<span class="text-muted-content">(optional)</span>
 											{/if}
 										</label>
 										{#if !displayDescriptionInline}
@@ -575,8 +576,7 @@
 											bind:value={form.envs[i].value}
 											class={twMerge(
 												'text-input-filled h-32 resize-y whitespace-pre-wrap',
-												highlightRequired &&
-													'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
+												highlightRequired && 'border-error bg-error/20 ring-error focus:ring-1'
 											)}
 											onmousedown={() => (resizing = true)}
 											onmouseup={() => (resizing = false)}
@@ -588,13 +588,12 @@
 											bind:value={form.envs[i].value}
 											class={twMerge(
 												'text-input-filled',
-												highlightRequired &&
-													'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
+												highlightRequired && 'border-error bg-error/20 ring-error focus:ring-1'
 											)}
 										/>
 									{/if}
 									{#if displayDescriptionInline}
-										<p class="text-on-surface1 text-xs font-light break-all">
+										<p class="text-muted-content text-xs font-light break-all">
 											{env.description}
 										</p>
 									{/if}
@@ -609,10 +608,10 @@
 								highlightedFields.has(header.data.key) && !header.data.value}
 							<div class="flex flex-col gap-1">
 								<span class="flex items-center gap-2">
-									<label for={header.data.key} class={highlightRequired ? 'text-red-500' : ''}>
+									<label for={header.data.key} class={highlightRequired ? 'text-error' : ''}>
 										{header.data.name}
 										{#if !header.data.required}
-											<span class="text-on-surface1">(optional)</span>
+											<span class="text-muted-content">(optional)</span>
 										{/if}
 									</label>
 									<InfoTooltip text={header.data.description} />
@@ -630,7 +629,7 @@
 										bind:value={form!.headers![header.index].value}
 										class={twMerge(
 											'text-input-filled',
-											highlightRequired && 'border-red-500 bg-red-500/20 ring-red-500 focus:ring-1'
+											highlightRequired && 'border-error bg-error/20 ring-error focus:ring-1'
 										)}
 									/>
 								{/if}
@@ -646,7 +645,7 @@
 							bind:value={form.url}
 							class="text-input-filled"
 						/>
-						<span class="text-on-surface1 font-light">
+						<span class="text-muted-content font-light">
 							The URL must contain the hostname: <b class="font-semibold">
 								{form.hostname}
 							</b>
@@ -657,13 +656,13 @@
 		</form>
 		<div class="flex justify-end gap-2">
 			{#if onCancel}
-				<button class="button" onclick={onCancel}>
+				<button class="btn btn-secondary" onclick={onCancel}>
 					{cancelText}
 				</button>
 			{/if}
-			<button class="button-primary" onclick={handleSave} disabled={loading || disableSave}>
+			<button class="btn btn-primary" onclick={handleSave} disabled={loading || disableSave}>
 				{#if loading}
-					<LoaderCircle class="size-4 animate-spin" />
+					<Loading class="size-4" />
 				{:else}
 					{submitText}
 				{/if}
@@ -684,7 +683,7 @@
 	title="Confirm Cancel"
 >
 	{#snippet msgContent()}
-		<h3 class="text-on-background text-lg font-semibold break-words">
+		<h3 class="text-base-content text-lg font-semibold wrap-break-word">
 			Are you sure you want to exit?
 		</h3>
 	{/snippet}

--- a/ui/user/src/lib/components/mcp/CatalogEditAliasForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogEditAliasForm.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+	import Loading from '$lib/icons/Loading.svelte';
 	import { ChatService, type MCPCatalogServer } from '$lib/services';
 	import { errors } from '$lib/stores';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
-	import { LoaderCircle, Server } from 'lucide-svelte';
+	import { Server } from 'lucide-svelte';
 
 	interface Props {
 		server?: MCPCatalogServer;
@@ -54,7 +55,7 @@
 >
 	{#snippet titleContent()}
 		<div class="flex items-center gap-2">
-			<div class="bg-surface1 rounded-sm p-1 dark:bg-gray-600">
+			<div class="bg-base-200 rounded-sm p-1 dark:bg-base-300">
 				{#if server?.manifest?.icon}
 					<img
 						src={server.manifest.icon}
@@ -91,12 +92,12 @@
 
 	<div class="flex justify-end gap-2">
 		<button
-			class="button-primary"
+			class="btn btn-primary"
 			onclick={handleSave}
 			disabled={saving || !newName.trim() || newName.trim() === originalName}
 		>
 			{#if saving}
-				<LoaderCircle class="size-4 animate-spin" />
+				<Loading class="size-4" />
 			{:else}
 				Update
 			{/if}

--- a/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		type CompositeCatalogConfig,
@@ -19,6 +19,7 @@
 		type ToolNameIssue
 	} from '$lib/services/chat/mcp';
 	import Toggle from '../Toggle.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import ToolNameIssueIcon from './ToolNameIssueIcon.svelte';
 	import CompositeToolsSetup from './composite/CompositeSelectServerAndToolsSetup.svelte';
 	import {
@@ -27,8 +28,7 @@
 		Trash2,
 		ChevronDown,
 		ChevronUp,
-		LoaderCircle,
-		AlertTriangle,
+		TriangleAlert,
 		RefreshCcw
 	} from 'lucide-svelte';
 	import { onMount } from 'svelte';
@@ -351,25 +351,25 @@
 </script>
 
 <div
-	class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 >
 	<h4 class="text-md font-semibold">Component Servers</h4>
 
 	<div class="flex flex-col gap-2">
 		{#if loading}
-			<div class="text-on-surface1 text-sm">Loading component servers...</div>
+			<div class="text-muted-content text-sm">Loading component servers...</div>
 		{:else if config.componentServers.length > 0}
 			{#each config.componentServers as entry (getComponentId(entry))}
 				{@const componentId = getComponentId(entry)}
 				{@const headerSeverity = componentSeverity(entry)}
 				<div
-					class="dark:bg-surface2 dark:border-surface3 rounded-lg border border-gray-200 bg-gray-50"
+					class="dark:bg-base-300 dark:border-base-400 rounded-lg border border-gray-200 bg-gray-50"
 				>
 					<div class="flex items-center gap-3 p-3">
 						{#if entry.manifest?.icon}
 							<img src={entry.manifest.icon} alt={entry.manifest.name} class="size-8" />
 						{:else}
-							<Server class="text-on-surface1 size-8" />
+							<Server class="text-muted-content size-8" />
 						{/if}
 						<div class="flex min-w-0 flex-1 items-center gap-1.5">
 							<div class="truncate font-medium" title={entry.manifest?.name || 'Unnamed Server'}>
@@ -385,39 +385,35 @@
 							{/if}
 						</div>
 						{#if entry.toolOverrides?.length && !readonly}
-							<button
-								type="button"
-								class="icon-button"
-								use:tooltip={'Refresh tool overrides'}
+							<IconButton
+								tooltip={{ text: 'Refresh tool overrides' }}
 								disabled={loadingByEntry[componentId]}
 								onclick={() => openToolsConfigurator(componentId)}
 							>
 								<RefreshCcw class={`size-4 ${loadingByEntry[componentId] ? 'animate-spin' : ''}`} />
-							</button>
+							</IconButton>
 						{/if}
-						<button
-							type="button"
-							class="icon-button"
+						<IconButton
+							tooltip={{ text: expanded[componentId] ? 'Collapse' : 'Expand' }}
 							onclick={() => (expanded[componentId] = !expanded[componentId])}
-							aria-label={expanded[componentId] ? 'Collapse' : 'Expand'}
 						>
 							{#if expanded[componentId]}
 								<ChevronUp class="size-4" />
 							{:else}
 								<ChevronDown class="size-4" />
 							{/if}
-						</button>
+						</IconButton>
 						{#if !readonly}
-							<button class="icon-button text-red-500" onclick={() => removeServer(componentId)}>
+							<IconButton variant="danger" onclick={() => removeServer(componentId)}>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					</div>
 					{#if expanded[componentId]}
 						{@const issue = prefixIssue(entry)}
 						<div class="border-t border-gray-200 p-3" in:slide={{ axis: 'y' }}>
 							<div class="mb-3 flex flex-col gap-1">
-								<p class="flex items-center gap-1.5 text-xs text-gray-500">
+								<p class="flex items-center gap-1.5 text-xs text-muted-content">
 									<span>Tool name prefix</span>
 									{#if issue}
 										<ToolNameIssueIcon {issue} />
@@ -433,7 +429,7 @@
 									{#if !readonly}
 										<button
 											type="button"
-											class="button px-3 py-1 text-xs"
+											class="btn btn-secondary btn-sm text-xs"
 											onclick={() => {
 												entry.toolPrefix = '';
 											}}
@@ -444,27 +440,27 @@
 								</div>
 								{#if issue}
 									<p
-										class={`text-xs ${issue.severity === 'error' ? 'text-red-500' : 'text-yellow-500'}`}
+										class={`text-xs ${issue.severity === 'error' ? 'text-error' : 'text-warning'}`}
 									>
 										{issue.message}
 									</p>
 								{:else}
-									<p class="text-on-surface2 text-[11px]">
+									<p class="text-muted-content text-[11px]">
 										Prepended to every tool name exposed by this component. Clear to remove.
 									</p>
 								{/if}
 							</div>
 							{#if !populatedByEntry[componentId]}
 								<div class="flex flex-col items-center justify-center pb-2">
-									<p class="text-on-surface1 text-sm font-light">
+									<p class="text-muted-content text-sm font-light">
 										All tools are enabled by default.
 									</p>
-									<p class="text-on-surface1 mb-4 text-sm font-light">
+									<p class="text-muted-content mb-4 text-sm font-light">
 										Click below to further modify tool availability or details.
 									</p>
 									<button
 										type="button"
-										class="button-primary text-sm"
+										class="btn btn-primary text-sm"
 										disabled={loadingByEntry[componentId]}
 										onclick={async () => {
 											if (readonly) return;
@@ -477,7 +473,7 @@
 										}}
 									>
 										{#if loadingByEntry[componentId]}
-											<LoaderCircle class="size-4 animate-spin" />
+											<Loading class="size-4" />
 										{:else}
 											Configure Tools
 										{/if}
@@ -503,7 +499,7 @@
 												: undefined}
 
 										<div
-											class="dark:bg-surface2 dark:border-surface3 flex items-start gap-2 rounded border border-transparent bg-white p-2 shadow-sm"
+											class="dark:bg-base-300 dark:border-base-400 flex items-start gap-2 rounded border border-transparent bg-white p-2 shadow-sm"
 										>
 											<div class="flex min-w-0 grow flex-col gap-2">
 												<div class="flex items-start justify-between gap-2">
@@ -513,7 +509,7 @@
 																class="min-w-0 flex-1 truncate text-sm font-medium"
 																title={effectiveName}
 															>
-																{#if entry.toolPrefix}<span class="text-on-surface2"
+																{#if entry.toolPrefix}<span class="text-base-content/75"
 																		>{entry.toolPrefix}</span
 																	>{/if}{currentName}
 															</div>
@@ -529,7 +525,7 @@
 															</p>
 														{/if}
 													</div>
-													<div class="flex flex-shrink-0 items-center gap-2">
+													<div class="flex shrink-0 items-center gap-2">
 														<Toggle
 															checked={tool.enabled === true}
 															onChange={(checked) => {
@@ -540,7 +536,7 @@
 														/>
 														<button
 															type="button"
-															class="button px-3 py-1 text-xs"
+															class="btn btn-secondary btn-sm text-xs"
 															onclick={() => {
 																const toolKey = `${componentId}-${tool.name}`;
 																// When expanding, initialize inputs with current effective values
@@ -563,7 +559,7 @@
 
 												{#if isCustomized}
 													<div class="mt-1 flex items-center gap-1 text-[11px] text-amber-600">
-														<AlertTriangle class="size-3 flex-shrink-0" />
+														<TriangleAlert class="size-3 shrink-0" />
 														<p>
 															Modified: This tool has been customized. The description or name has
 															been changed.
@@ -574,7 +570,7 @@
 												{#if expandedTools[`${componentId}-${tool.name}`]}
 													<div class="mt-2 flex flex-col gap-2">
 														<div class="flex flex-col gap-1">
-															<p class="text-xs text-gray-500">Tool name</p>
+															<p class="text-xs text-muted-content">Tool name</p>
 															<input
 																class="text-input-filled flex-1 text-sm"
 																bind:value={tool.overrideName}
@@ -582,7 +578,7 @@
 														</div>
 
 														<div class="flex flex-col gap-1">
-															<p class="text-xs text-gray-500">Description</p>
+															<p class="text-xs text-muted-content">Description</p>
 															<textarea
 																class="text-input-filled h-24 resize-none text-xs"
 																bind:value={tool.overrideDescription}
@@ -593,7 +589,7 @@
 														<div class="mt-2 flex justify-end">
 															<button
 																type="button"
-																class="button px-3 py-1 text-xs"
+																class="btn btn-sm btn-secondary text-xs"
 																onclick={() => {
 																	tool.overrideName = tool.name;
 																	tool.overrideDescription = tool.description;
@@ -614,7 +610,7 @@
 				</div>
 			{/each}
 		{:else}
-			<div class="text-on-surface1 text-sm">
+			<div class="text-muted-content text-sm">
 				Select one or more MCP servers to include in the composite server. Users will see this as a
 				single server with aggregated tools and resources.
 			</div>
@@ -631,7 +627,7 @@
 				toolsToEdit = [];
 				compositeToolsSetupDialog?.open();
 			}}
-			class="dark:bg-surface2 dark:border-surface3 dark:hover:bg-surface3 bg-background flex items-center justify-center gap-2 rounded-lg border border-gray-200 p-2 text-sm font-medium hover:bg-gray-50"
+			class="dark:bg-base-300 dark:border-base-400 dark:hover:bg-base-400 bg-base-100 flex items-center justify-center gap-2 rounded-lg border border-gray-200 p-2 text-sm font-medium hover:bg-gray-50"
 		>
 			<Plus class="size-4" />
 			Add MCP Server

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -22,6 +22,7 @@
 	import CopyButton from '../CopyButton.svelte';
 	import PageLoading from '../PageLoading.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import CatalogConfigureForm, {
 		type CompositeLaunchFormData,
 		type LaunchFormData
@@ -759,7 +760,7 @@
 		{#if server}
 			{@const icon = server.manifest.icon ?? ''}
 
-			<div class="bg-surface1 rounded-sm p-1 dark:bg-gray-600">
+			<div class="bg-base-200 rounded-sm p-1 dark:bg-base-300">
 				{#if icon}
 					<img src={icon} alt={name} class="size-8" />
 				{:else}
@@ -786,21 +787,22 @@
 						showTextLeft
 						text={url}
 						classes={{
-							button: 'flex-shrink-0 flex items-center gap-1 text-xs font-light hover:text-blue-500'
+							button: 'shrink-0 flex items-center gap-1 text-xs font-light hover:text-blue-500'
 						}}
 					/>
 				</div>
+
+				{#if !hideActions && version.current.disableLegacyChat !== true}
+					<div class="w-32">
+						<button
+							class="btn btn-primary flex h-9 w-full grow items-center justify-center gap-2 text-sm"
+							onclick={() => handleSetupChat(server!, instance)}
+						>
+							Chat <ExternalLink class="size-4" />
+						</button>
+					</div>
+				{/if}
 			</div>
-			{#if !hideActions && version.current.disableLegacyChat !== true}
-				<div class="w-32">
-					<button
-						class="button-primary flex h-fit w-full grow items-center justify-center gap-2 text-sm"
-						onclick={() => handleSetupChat(server!, instance)}
-					>
-						Chat <ExternalLink class="size-4" />
-					</button>
-				</div>
-			{/if}
 		</div>
 
 		{#if url}
@@ -809,11 +811,11 @@
 
 		{#if entry && !hideActions}
 			<p
-				class="text-on-surface1 flex items-center justify-end gap-2 text-sm font-light md:px-0 px-4"
+				class="text-muted-content flex items-center justify-end gap-2 text-sm font-light md:px-0 px-4"
 			>
 				Need to set up a different instance?
 				<button
-					class="button-small button-primary hover:bg-primary px-3 text-xs"
+					class="btn btn-sm btn-primary text-xs"
 					onclick={() => {
 						server = undefined;
 						initCatalogEntry();
@@ -872,11 +874,11 @@
 	{#snippet errorPostContent()}
 		{#if launchLogs.length > 0}
 			<div
-				class="default-scrollbar-thin bg-surface1 max-h-[50vh] w-full overflow-y-auto rounded-lg p-4 shadow-inner"
+				class="default-scrollbar-thin bg-base-200 max-h-[50vh] w-full overflow-y-auto rounded-lg p-4 shadow-inner"
 			>
 				{#each launchLogs as log, i (i)}
 					<div class="font-mono text-sm">
-						<span class="text-on-surface1">{log}</span>
+						<span class="text-muted-content">{log}</span>
 					</div>
 				{/each}
 			</div>
@@ -887,7 +889,7 @@
 		<div class="flex w-full flex-col items-center gap-2 md:flex-row">
 			{#if entry}
 				<button
-					class="button-primary w-full md:w-1/2 md:flex-1"
+					class="btn btn-primary w-full md:w-1/2 md:flex-1"
 					onclick={() => {
 						launchState = 'relaunching';
 						launchError = undefined;
@@ -901,7 +903,7 @@
 					Update Configuration and Try Again
 				</button>
 			{/if}
-			<button class="button w-full md:w-1/2 md:flex-1" onclick={handleCancelLaunch}>
+			<button class="btn btn-secondary w-full md:w-1/2 md:flex-1" onclick={handleCancelLaunch}>
 				Cancel and Delete Server
 			</button>
 		</div>
@@ -913,12 +915,12 @@
 		<div class="flex flex-col gap-4 p-4">
 			{#if oauthURL}
 				<div class="absolute top-2 right-2">
-					<button class="icon-button" onclick={handleOauthClose}>
+					<IconButton onclick={handleOauthClose}>
 						<X class="size-4" />
-					</button>
+					</IconButton>
 				</div>
 				<div class="flex items-center gap-2">
-					<div class="h-fit flex-shrink-0 self-start rounded-md bg-gray-50 p-1 dark:bg-gray-600">
+					<div class="h-fit shrink-0 self-start rounded-md bg-base-200 p-1 dark:bg-base-300">
 						{#if server?.manifest.icon}
 							<img
 								src={server?.manifest.icon}
@@ -946,7 +948,7 @@
 					href={oauthURL}
 					rel="external"
 					target="_blank"
-					class="button-primary text-center text-sm outline-none"
+					class="btn btn-primary text-center text-sm outline-none"
 					onclick={() => {
 						oauthVerifying = true;
 					}}

--- a/ui/user/src/lib/components/mcp/ConnectorsView.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectorsView.svelte
@@ -8,6 +8,7 @@
 	import McpMultiDeleteBlockedDialog from '$lib/components/mcp/McpMultiDeleteBlockedDialog.svelte';
 	import StaticOAuthConfigureModal from '$lib/components/mcp/StaticOAuthConfigureModal.svelte';
 	import Table, { type InitSort, type InitSortFn } from '$lib/components/table/Table.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		ChatService,
@@ -30,14 +31,13 @@
 	import { formatTimeAgo } from '$lib/time';
 	import { openUrl, isOwnSingleUserServer } from '$lib/utils';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import EditExistingDeployment from './EditExistingDeployment.svelte';
 	import {
-		AlertTriangle,
 		Captions,
 		CircleFadingArrowUp,
 		Ellipsis,
 		KeyRound,
-		LoaderCircle,
 		MessageCircle,
 		PencilLine,
 		ReceiptText,
@@ -290,8 +290,8 @@
 
 <div class="flex flex-col gap-2">
 	{#if mcpServersAndEntries.current.loading}
-		<div class="my-2 flex items-center justify-center">
-			<LoaderCircle class="size-6 animate-spin" />
+		<div class="my-2 flex items-center justify-center h-72">
+			<Loading class="size-6" />
 		</div>
 	{:else if mcpServersAndEntries.current.entries.length + mcpServersAndEntries.current.servers.length === 0}
 		{#if noDataContent}
@@ -302,7 +302,7 @@
 		{#if hasCatalogErrors && !catalog?.isSyncing}
 			<div class="w-full p-4" in:slide={{ axis: 'y' }} out:slide={{ axis: 'y', duration: 0 }}>
 				<div class="notification-alert flex w-full items-center gap-2 rounded-md p-3 text-sm">
-					<AlertTriangle class="size-" />
+					<TriangleAlert class="size-" />
 					<p class="">Some servers failed to sync. See "Registry Sources" tab for more details.</p>
 				</div>
 			</div>
@@ -368,7 +368,7 @@
 				return 'isCatalogEntry' in d.data && d.data.needsUpdate
 					? 'bg-primary/10'
 					: matchingServers.some(requiresUserUpdate)
-						? 'bg-yellow-500/10'
+						? 'bg-warning/10'
 						: '';
 			}}
 		>
@@ -379,7 +379,7 @@
 					? getConfiguredServersForCatalogEntry(catalogEntry)
 					: []}
 				{#if property === 'name'}
-					<div class="flex flex-shrink-0 items-center gap-2">
+					<div class="flex shrink-0 items-center gap-2">
 						<div class="icon">
 							{#if d.icon}
 								<img src={d.icon} alt={d.name} class="size-6" />
@@ -400,7 +400,7 @@
 								</span>
 							{:else if matchingServers.some(requiresUserUpdate)}
 								<span
-									class="text-yellow-500"
+									class="text-warning"
 									use:tooltip={{
 										text: 'Server requires an update.'
 									}}
@@ -449,7 +449,7 @@
 				{@const requiresOAuth =
 					catalogEntry?.manifest?.runtime === 'remote' &&
 					catalogEntry.manifest?.remoteConfig?.staticOAuthRequired}
-				<DotDotDot class="icon-button hover:dark:bg-background/50" classes={{ menu: 'p-0' }}>
+				<DotDotDot class="hover:dark:bg-base-100/50" classes={{ menu: 'p-0' }}>
 					{#snippet icon()}
 						<Ellipsis class="size-4" />
 					{/snippet}
@@ -457,17 +457,17 @@
 					{#snippet children({ toggle })}
 						{#if hasConnectedOptions}
 							<div
-								class="bg-background dark:bg-surface2 rounded-t-xl p-2 pl-4 text-[11px] font-semibold uppercase"
+								class="bg-base-100 dark:bg-base-300 rounded-t-xl p-2 pl-4 text-[11px] font-semibold uppercase"
 							>
 								My Connection(s)
 							</div>
-							<div class="bg-surface1 flex flex-col gap-1 p-2">
+							<div class="bg-base-200 flex flex-col gap-1 p-2">
 								{#if !requiresOAuth || catalogEntry?.oauthCredentialConfigured}
 									{@render connectToServerAction(d.data, toggle)}
 								{/if}
 								{#if version.current.disableLegacyChat !== true}
 									<button
-										class="menu-button hover:bg-surface3"
+										class="menu-button hover:bg-base-400"
 										onclick={async (e) => {
 											e.stopPropagation();
 											if (catalogEntry) {
@@ -499,7 +499,7 @@
 
 								{#if oauthServers.length > 0 && catalogEntry}
 									<button
-										class="menu-button hover:bg-surface3"
+										class="menu-button hover:bg-base-400"
 										onclick={async (e) => {
 											e.stopPropagation();
 											if (oauthServers.length === 1) {
@@ -519,7 +519,7 @@
 
 								{#if matchingInstance && !isCatalogEntry && hasInstanceConfiguration(d.data as MCPCatalogServer)}
 									<button
-										class="menu-button hover:bg-surface3"
+										class="menu-button hover:bg-base-400"
 										onclick={(e) => {
 											e.stopPropagation();
 											connectToServerDialog?.open({
@@ -536,7 +536,7 @@
 
 								{#if matchingServers.length > 0 && catalogEntry}
 									<button
-										class="menu-button hover:bg-surface3"
+										class="menu-button hover:bg-base-400"
 										onclick={async (e) => {
 											e.stopPropagation();
 											if (matchingServers.length === 1) {
@@ -557,7 +557,7 @@
 
 								{#if matchingServers.length > 0 && catalogEntry}
 									<button
-										class="menu-button hover:bg-surface3"
+										class="menu-button hover:bg-base-400"
 										onclick={async (e) => {
 											e.stopPropagation();
 											if (matchingServers.length === 1) {
@@ -575,7 +575,7 @@
 
 								{#if matchingServers.length > 0 && catalogEntry}
 									<button
-										class="menu-button hover:bg-surface3"
+										class="menu-button hover:bg-base-400"
 										onclick={async (e) => {
 											e.stopPropagation();
 
@@ -593,7 +593,7 @@
 									</button>
 								{:else if matchingInstance}
 									<button
-										class="menu-button hover:bg-surface3"
+										class="menu-button hover:bg-base-400"
 										onclick={async (e) => {
 											e.stopPropagation();
 											await ChatService.deleteMcpServerInstance(matchingInstance.id);
@@ -614,7 +614,7 @@
 							{/if}
 							{#if requiresOAuth && catalogEntry}
 								<button
-									class="menu-button hover:bg-surface3"
+									class="menu-button hover:bg-base-400"
 									onclick={async (e) => {
 										e.stopPropagation();
 										await handleConfigureOAuth(catalogEntry);
@@ -666,8 +666,8 @@
 	{#if canConfigure}
 		<button
 			class={twMerge(
-				'menu-button hover:bg-surface3',
-				requiresUpdate && 'bg-yellow-500/10 text-yellow-500 hover:bg-yellow-500/30'
+				'menu-button hover:bg-base-400',
+				requiresUpdate && 'bg-warning/10 text-warning hover:bg-warning/30'
 			)}
 			onclick={() => {
 				if (configuredServers.length === 1) {
@@ -687,7 +687,7 @@
 
 {#snippet renameCatalogEntryAction(d: MCPCatalogEntry, configuredServers: MCPCatalogServer[])}
 	<button
-		class="menu-button hover:bg-surface3"
+		class="menu-button hover:bg-base-400"
 		onclick={() => {
 			if (configuredServers.length === 1) {
 				editExistingDialog?.rename({
@@ -875,7 +875,7 @@
 />
 
 <ResponsiveDialog
-	class="bg-surface1 dark:bg-background"
+	class="bg-base-200 dark:bg-base-100"
 	bind:this={selectServerDialog}
 	title="Select Your Server"
 >
@@ -933,7 +933,7 @@
 	>
 		{#snippet onRenderColumn(property, d)}
 			{#if property === 'name'}
-				<div class="flex flex-shrink-0 items-center gap-2">
+				<div class="flex shrink-0 items-center gap-2">
 					<div class="icon">
 						{#if d.manifest.icon}
 							<img src={d.manifest.icon} alt={d.manifest.name} class="size-6" />
@@ -960,9 +960,9 @@
 			{/if}
 		{/snippet}
 		{#snippet actions()}
-			<button class="icon-button hover:dark:bg-background/50">
+			<IconButton class="hover:dark:bg-base-100/50">
 				<StepForward class="size-4" />
-			</button>
+			</IconButton>
 		{/snippet}
 	</Table>
 </ResponsiveDialog>

--- a/ui/user/src/lib/components/mcp/ContainerizedRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/ContainerizedRuntimeForm.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Toggle from '$lib/components/Toggle.svelte';
 	import { MultiValueInput } from '$lib/components/ui/multi-value-input';
 	import type { ContainerizedRuntimeConfig } from '$lib/services/chat/types';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2 } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -130,10 +130,10 @@
 </script>
 
 <div
-	class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 >
 	<h4 class="text-sm font-semibold">Containerized Runtime Configuration</h4>
-	<p class="text-on-surface1 text-xs">Only Streamable HTTP and SSE servers are supported.</p>
+	<p class="text-muted-content text-xs">Only Streamable HTTP and SSE servers are supported.</p>
 
 	<!-- Image field (required) -->
 	<div class="flex items-center gap-4">
@@ -143,7 +143,7 @@
 		>
 		<input
 			id="containerized-image"
-			class={twMerge('text-input-filled dark:bg-background w-full', showRequired?.image && 'error')}
+			class={twMerge('text-input-filled dark:bg-base-100 w-full', showRequired?.image && 'error')}
 			bind:value={config.image}
 			disabled={readonly}
 			placeholder="e.g. docker.io/myorg/mcp-server:latest"
@@ -168,7 +168,7 @@
 		<input
 			id="containerized-port"
 			type="number"
-			class={twMerge('text-input-filled dark:bg-background w-full', showRequired?.port && 'error')}
+			class={twMerge('text-input-filled dark:bg-base-100 w-full', showRequired?.port && 'error')}
 			value={config.port > 0 ? config.port : ''}
 			disabled={readonly}
 			placeholder="e.g. 8080"
@@ -190,7 +190,7 @@
 		>
 		<input
 			id="containerized-path"
-			class={twMerge('text-input-filled dark:bg-background w-full', showRequired?.path && 'error')}
+			class={twMerge('text-input-filled dark:bg-base-100 w-full', showRequired?.path && 'error')}
 			bind:value={config.path}
 			disabled={readonly}
 			placeholder="e.g. /mcp"
@@ -211,7 +211,7 @@
 		<label for="containerized-command" class="w-20 text-sm font-light">Command</label>
 		<input
 			id="containerized-command"
-			class="text-input-filled dark:bg-background w-full"
+			class="text-input-filled dark:bg-base-100 w-full"
 			bind:value={config.command}
 			disabled={readonly}
 			placeholder="e.g. node server.js"
@@ -231,7 +231,7 @@
 				{#each config.args as _arg, i (i)}
 					<div class="flex items-center gap-2">
 						<input
-							class="text-input-filled dark:bg-background w-full"
+							class="text-input-filled dark:bg-base-100 w-full"
 							bind:value={config.args[i]}
 							disabled={readonly}
 							placeholder="e.g. --config /app/config.json"
@@ -243,20 +243,19 @@
 							onpaste={(e) => handlePaste(e, i)}
 						/>
 						{#if !readonly}
-							<button
-								class="icon-button"
-								onclick={() => removeArgument(i)}
-								use:tooltip={'Remove argument'}
-							>
+							<IconButton onclick={() => removeArgument(i)} tooltip={{ text: 'Remove argument' }}>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					</div>
 				{/each}
 
 				{#if !readonly}
 					<div class="flex justify-end">
-						<button class="button flex items-center gap-1 text-xs" onclick={addArgument}>
+						<button
+							class="btn btn-secondary btn-sm flex items-center gap-1 text-xs"
+							onclick={addArgument}
+						>
 							<Plus class="size-4" /> Argument
 						</button>
 					</div>
@@ -278,11 +277,11 @@
 				/>
 				<MultiValueInput
 					bind:value={config.egressDomains}
-					class="text-input-filled dark:bg-background"
+					class="text-input-filled dark:bg-base-100"
 					readonly={inputReadonly}
 					placeholder="hit &quot;Enter&quot; to insert"
 				/>
-				<p class="text-on-surface1 text-xs">{egressHelpText}</p>
+				<p class="text-muted-content text-xs">{egressHelpText}</p>
 			</div>
 		</div>
 	{/if}
@@ -301,7 +300,7 @@
 			placeholder="60"
 			bind:value={startupTimeoutSeconds}
 			class={twMerge(
-				'text-input-filled dark:bg-background w-32',
+				'text-input-filled dark:bg-base-100 w-32',
 				showRequired?.startupTimeoutSeconds && 'error'
 			)}
 			disabled={readonly}

--- a/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
@@ -2,6 +2,7 @@
 	import type { LaunchServerType, MCPCatalogEntryFieldManifest } from '$lib/services';
 	import { hasSecretBinding } from '$lib/services/chat/mcp';
 	import Select from '../Select.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2 } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 
@@ -39,7 +40,7 @@
 <!-- Environment Variables / Files Section -->
 {#if !readonly || (readonly && userConfig.length > 0)}
 	<div
-		class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 	>
 		<h4 class="text-sm font-semibold">
 			{type === 'single' ? 'User Supplied Configuration' : 'Configuration'}
@@ -50,13 +51,13 @@
 				{@render overrideEnvTemplate({ config: config![i], index: i })}
 			{:else}
 				<div
-					class="dark:border-surface3 bg-surface2 flex w-full items-center gap-4 rounded-lg border border-transparent p-4"
+					class="dark:border-base-400 bg-base-300 flex w-full items-center gap-4 rounded-lg border border-transparent p-4"
 				>
 					<div class="flex w-full flex-col gap-4">
 						<div class="flex w-full flex-col gap-1">
 							<label for={`env-type-${i}`} class="text-sm font-light">Type</label>
 							<Select
-								class="dark:border-surface3 bg-background border border-transparent"
+								class="dark:border-base-400 bg-base-100 border border-transparent"
 								classes={{
 									root: 'flex grow'
 								}}
@@ -77,7 +78,7 @@
 							/>
 						</div>
 
-						<p class="text-on-surface1 text-xs font-light">
+						<p class="text-muted-content text-xs font-light">
 							{#if config![i].file}
 								The value {type === 'single' ? 'the user supplies' : 'you provide'} will be written to
 								a file. An environment variable will be created using the name you specify in the Key
@@ -93,7 +94,7 @@
 						</p>
 
 						{#if type === 'single'}
-							<p class="text-on-surface1 text-xs font-light">
+							<p class="text-muted-content text-xs font-light">
 								The Name and Description fields will be displayed to the user when configuring this
 								server. The Key field will not.
 							</p>
@@ -101,7 +102,7 @@
 								<label for={`env-name-${i}`} class="text-sm font-light">Name</label>
 								<input
 									id={`env-name-${i}`}
-									class="text-input-filled bg-background w-full shadow-none"
+									class="text-input-filled bg-base-100 w-full shadow-none"
 									bind:value={config![i].name}
 									disabled={readonly || isPrebuiltEntry}
 								/>
@@ -110,7 +111,7 @@
 								<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
 								<input
 									id={`env-description-${i}`}
-									class="text-input-filled bg-background w-full shadow-none"
+									class="text-input-filled bg-base-100 w-full shadow-none"
 									bind:value={config![i].description}
 									disabled={readonly || isPrebuiltEntry}
 								/>
@@ -119,7 +120,7 @@
 								<label for={`env-key-${i}`} class="text-sm font-light">Key</label>
 								<input
 									id={`env-key-${i}`}
-									class="text-input-filled bg-background w-full shadow-none"
+									class="text-input-filled bg-base-100 w-full shadow-none"
 									bind:value={config![i].key}
 									placeholder="e.g. CUSTOM_API_KEY"
 									disabled={readonly || isPrebuiltEntry}
@@ -148,13 +149,13 @@
 								<label for={`env-key-${i}`} class="text-sm font-light">Key</label>
 								<input
 									id={`env-key-${i}`}
-									class="text-input-filled bg-background w-full shadow-none"
+									class="text-input-filled bg-base-100 w-full shadow-none"
 									bind:value={config![i].key}
 									placeholder="e.g. CUSTOM_API_KEY"
 									disabled={readonly || isPrebuiltEntry}
 								/>
 								{#if isPrebuiltEntry && config![i].description}
-									<p class="text-on-surface1 text-xs font-light break-all">
+									<p class="text-muted-content text-xs font-light break-all">
 										{config![i].description}
 									</p>
 								{/if}
@@ -164,7 +165,7 @@
 								{#if config![i].file}
 									<textarea
 										id={`env-value-${i}`}
-										class="text-input-filled bg-background min-h-24 w-full resize-y shadow-none"
+										class="text-input-filled bg-base-100 min-h-24 w-full resize-y shadow-none"
 										bind:value={config![i].value}
 										disabled={readonly}
 										rows={(config![i].value ?? '').split('\n').length + 1}
@@ -172,7 +173,7 @@
 								{:else}
 									<input
 										id={`env-value-${i}`}
-										class="text-input-filled bg-background w-full shadow-none"
+										class="text-input-filled bg-base-100 w-full shadow-none"
 										bind:value={config![i].value}
 										placeholder="e.g. 123abcdef456"
 										disabled={readonly}
@@ -193,15 +194,16 @@
 						{/if}
 					</div>
 					{#if !readonly && !isPrebuiltEntry}
-						<button
-							class="icon-button hover:text-red-500"
+						<IconButton
+							variant="danger2"
+							class="hover:text-error"
 							onclick={() => {
 								config!.splice(i, 1);
 							}}
 							disabled={isPrebuiltEntry}
 						>
 							<Trash2 class="size-4" />
-						</button>
+						</IconButton>
 					{/if}
 				</div>
 			{/if}
@@ -210,7 +212,7 @@
 		{#if !readonly && !isPrebuiltEntry}
 			<div class="flex justify-end">
 				<button
-					class="button flex items-center gap-1 text-xs"
+					class="btn btn-secondary btn-sm flex items-center gap-1 text-xs"
 					onclick={() => {
 						if (config) {
 							config.push({
@@ -236,42 +238,45 @@
 <!-- Secret-bound Configuration Section -->
 {#if allSecretBound.length > 0}
 	<div
-		class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 	>
 		<h4 class="text-sm font-semibold">Secret-bound Configuration</h4>
 
-		{#each allSecretBound as { item, source } (`${source}:${item.key}`)}
+		{#each allSecretBound as { item, source }, sbIdx (`${source}:${item.key}`)}
 			<div
-				class="dark:border-surface3 bg-surface2 flex w-full items-center gap-4 rounded-lg border border-transparent p-4"
+				class="dark:border-base-400 bg-base-300 flex w-full items-center gap-4 rounded-lg border border-transparent p-4"
 			>
 				<div class="flex w-full flex-col gap-4">
 					<div class="flex w-full flex-col gap-1">
-						<label class="text-sm font-light">Type</label>
-						<span class="text-sm"
+						<div id={`sb-${sbIdx}-type`} class="text-sm font-light">Type</div>
+						<span class="text-sm" aria-labelledby={`sb-${sbIdx}-type`}
 							>{source === 'header' ? 'Header' : item.file ? 'File' : 'Environment Variable'}</span
 						>
 					</div>
 
 					<div class="flex w-full flex-col gap-1">
-						<label class="text-sm font-light">Name</label>
-						<span class="text-sm">{item.name || item.key}</span>
+						<div id={`sb-${sbIdx}-name`} class="text-sm font-light">Name</div>
+						<span class="text-sm" aria-labelledby={`sb-${sbIdx}-name`}>{item.name || item.key}</span
+						>
 					</div>
 
 					{#if item.description}
 						<div class="flex w-full flex-col gap-1">
-							<label class="text-sm font-light">Description</label>
-							<span class="text-sm">{item.description}</span>
+							<div id={`sb-${sbIdx}-description`} class="text-sm font-light">Description</div>
+							<span class="text-sm" aria-labelledby={`sb-${sbIdx}-description`}
+								>{item.description}</span
+							>
 						</div>
 					{/if}
 
 					<div class="flex w-full flex-col gap-1">
-						<label class="text-sm font-light">Key</label>
-						<span class="text-sm font-mono">{item.key}</span>
+						<div id={`sb-${sbIdx}-key`} class="text-sm font-light">Key</div>
+						<span class="text-sm font-mono" aria-labelledby={`sb-${sbIdx}-key`}>{item.key}</span>
 					</div>
 
 					<div class="flex w-full flex-col gap-1">
-						<label class="text-sm font-light">Secret</label>
-						<span class="text-sm">
+						<div id={`sb-${sbIdx}-secret`} class="text-sm font-light">Secret</div>
+						<span class="text-sm" aria-labelledby={`sb-${sbIdx}-secret`}>
 							<code class="font-mono">{item.secretBinding?.name}</code> /
 							<code class="font-mono">{item.secretBinding?.key}</code>
 						</span>

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -8,6 +8,7 @@
 	import McpMultiDeleteBlockedDialog from '$lib/components/mcp/McpMultiDeleteBlockedDialog.svelte';
 	import Table, { type InitSort, type InitSortFn } from '$lib/components/table/Table.svelte';
 	import { ADMIN_SESSION_STORAGE } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		ChatService,
@@ -37,7 +38,6 @@
 		Ellipsis,
 		ExternalLink,
 		GitCompare,
-		LoaderCircle,
 		MessageCircle,
 		PencilLine,
 		Power,
@@ -507,8 +507,8 @@
 
 <div class="flex flex-col gap-0.5">
 	{#if loading}
-		<div class="my-2 flex items-center justify-center">
-			<LoaderCircle class="size-6 animate-spin" />
+		<div class="my-2 flex items-center justify-center h-72">
+			<Loading class="size-6" />
 		</div>
 	{:else}
 		{#if entity === 'catalog' && profile.current.hasAdminAccess?.()}
@@ -579,7 +579,7 @@
 					}
 
 					if (d.needsK8sUpdate) {
-						return 'bg-yellow-500/5 hover:bg-yellow-500/10 border-yellow-500/20';
+						return 'bg-warning/5 hover:bg-warning/10 border-warning/20';
 					}
 
 					return '';
@@ -587,7 +587,7 @@
 			>
 				{#snippet onRenderColumn(property, d)}
 					{#if property === 'displayName'}
-						<div class="flex flex-shrink-0 items-center gap-2">
+						<div class="flex shrink-0 items-center gap-2">
 							<div class="icon">
 								{#if d.manifest.icon}
 									<img src={d.manifest.icon} alt={d.manifest.name} class="size-6" />
@@ -598,7 +598,7 @@
 							<p class="flex flex-col">
 								{d.displayName}
 								{#if d.compositeParentName}
-									<span class="text-on-surface1 text-xs">
+									<span class="text-muted-content text-xs">
 										({d.compositeParentName})
 									</span>
 								{/if}
@@ -625,7 +625,7 @@
 					{@const instance = instancesMap.get(d.id)}
 					{@const hasMyConnection = d.isMyServer || !!instance}
 
-					<DotDotDot class="icon-button hover:dark:bg-background/50" classes={{ menu: 'p-0' }}>
+					<DotDotDot class="hover:dark:bg-base-100/50" classes={{ menu: 'p-0' }}>
 						{#snippet icon()}
 							<Ellipsis class="size-4" />
 						{/snippet}
@@ -633,12 +633,12 @@
 						{#snippet children({ toggle })}
 							{#if !isComposite && hasMyConnection}
 								<div
-									class="bg-background dark:bg-surface2 rounded-t-xl p-2 pl-4 text-[11px] font-semibold uppercase"
+									class="bg-base-100 dark:bg-base-300 rounded-t-xl p-2 pl-4 text-[11px] font-semibold uppercase"
 								>
 									My Connection
 								</div>
 								<div
-									class={twMerge('flex flex-col gap-1 p-2', d.isMyServer ? 'bg-surface1' : 'pb-0')}
+									class={twMerge('flex flex-col gap-1 p-2', d.isMyServer ? 'bg-base-200' : 'pb-0')}
 								>
 									<button
 										class="menu-button"
@@ -741,7 +741,7 @@
 											: undefined}
 									>
 										{#if updating[d.id]?.inProgress}
-											<LoaderCircle class="size-4 animate-spin" />
+											<Loading class="size-4" />
 										{:else}
 											<CircleFadingArrowUp class="size-4" />
 										{/if}
@@ -769,7 +769,7 @@
 
 								{#if (d.isMyServer || (hasAdminAccess && !readonly)) && d.needsK8sUpdate}
 									<button
-										class="menu-button-primary bg-yellow-500/10 text-yellow-500 text-yellow-700 hover:bg-yellow-500/20"
+										class="menu-button-primary bg-warning/10 text-warning hover:bg-warning/20"
 										disabled={updating[d.id]?.inProgress || readonly || !!d.compositeName}
 										onclick={(e) => {
 											e.stopPropagation();
@@ -782,7 +782,7 @@
 										}}
 									>
 										{#if updating[d.id]?.inProgress}
-											<LoaderCircle class="size-4 animate-spin" />
+											<Loading class="size-4" />
 										{:else}
 											<CircleFadingArrowUp class="size-4" />
 										{/if}
@@ -812,7 +812,7 @@
 										}}
 									>
 										{#if restarting}
-											<LoaderCircle class="size-4 animate-spin" /> Restarting...
+											<Loading class="size-4" /> Restarting...
 										{:else}
 											<Power class="size-4" />
 											Restart Server
@@ -881,7 +881,7 @@
 
 					<div class="flex grow items-center justify-end gap-2 px-4 py-2">
 						<button
-							class="button flex items-center gap-1 text-sm font-normal"
+							class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 							onclick={() => {
 								selected = currentSelected;
 								handleBulkRestart();
@@ -889,7 +889,7 @@
 							disabled={restarting || readonly || restartableCount === 0}
 						>
 							{#if restarting}
-								<LoaderCircle class="size-4 animate-spin self-center" /> Restarting...
+								<Loading class="size-4 self-center" /> Restarting...
 							{:else}
 								<Power class="size-4" /> Restart
 							{/if}
@@ -900,7 +900,7 @@
 							{/if}
 						</button>
 						<button
-							class="button flex items-center gap-1 text-sm font-normal"
+							class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 							onclick={() => {
 								selected = currentSelected;
 								showUpgradeConfirm = {
@@ -920,7 +920,7 @@
 							{/if}
 						</button>
 						<button
-							class="button flex items-center gap-1 text-sm font-normal"
+							class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 							onclick={() => {
 								selected = currentSelected;
 								const type = Object.keys(selected).length > 1 ? 'multi' : 'single';
@@ -947,7 +947,7 @@
 							{/if}
 						</button>
 						<button
-							class="button flex items-center gap-1 text-sm font-normal"
+							class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 							onclick={() => {
 								selected = currentSelected;
 								showDeleteConfirm = {
@@ -981,7 +981,7 @@
 		<button
 			class={twMerge(
 				'menu-button',
-				requiresUpdate && 'bg-yellow-500/10 text-yellow-500 hover:bg-yellow-500/30'
+				requiresUpdate && 'bg-warning/10 text-warning hover:bg-warning/30'
 			)}
 			onclick={() => {
 				editExistingDialog?.edit({

--- a/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
+++ b/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
@@ -215,11 +215,11 @@
 	{#snippet errorPostContent()}
 		{#if launchLogs.length > 0}
 			<div
-				class="default-scrollbar-thin bg-surface1 max-h-[50vh] w-full overflow-y-auto rounded-lg p-4 shadow-inner"
+				class="default-scrollbar-thin bg-base-200 max-h-[50vh] w-full overflow-y-auto rounded-lg p-4 shadow-inner"
 			>
 				{#each launchLogs as log, i (i)}
 					<div class="font-mono text-sm">
-						<span class="text-on-surface1">{log}</span>
+						<span class="text-muted-content">{log}</span>
 					</div>
 				{/each}
 			</div>
@@ -230,7 +230,7 @@
 		<div class="flex w-full flex-col items-center gap-2 md:flex-row">
 			{#if entry}
 				<button
-					class="button-primary w-full md:w-1/2 md:flex-1"
+					class="btn btn-primary w-full md:w-1/2 md:flex-1"
 					onclick={() => {
 						launchError = undefined;
 						configDialog?.open();

--- a/ui/user/src/lib/components/mcp/HowToConnect.svelte
+++ b/ui/user/src/lib/components/mcp/HowToConnect.svelte
@@ -27,7 +27,7 @@
 	];
 </script>
 
-<div class="w-full overflow-hidden border-b border-surface2 dark:border-surface3 mb-4">
+<div class="w-full overflow-hidden border-b border-base-300 dark:border-base-400 mb-4">
 	<div class="flex gap-4 flex-col mb-4">
 		<p class="text-sm font-light w-md max-w-full text-center self-center">
 			For more documentation on how to set up your MCP server, click the appropriate resource below:
@@ -37,9 +37,9 @@
 				href={option.url}
 				target="_blank"
 				rel="noopener noreferrer external"
-				class="flex uppercase font-medium font-mono text-xs items-center gap-2 self-center bg-surface2 dark:bg-background hover:bg-surface3 dark:hover:bg-surface1 rounded-xs px-4 py-2 w-64 justify-center"
+				class="flex uppercase font-medium font-mono text-xs items-center gap-2 self-center bg-base-300 dark:bg-base-100 hover:bg-base-400 dark:hover:bg-base-200 rounded-xs px-4 py-2 w-64 justify-center"
 			>
-				<span class="p-0.5 rounded-sm dark:bg-surface2">
+				<span class="p-0.5 rounded-sm dark:bg-base-300">
 					<img src={option.icon} alt={`${option.label} branding icon`} class="size-4" />
 				</span>
 				{option.label}

--- a/ui/user/src/lib/components/mcp/McpCard.svelte
+++ b/ui/user/src/lib/components/mcp/McpCard.svelte
@@ -26,14 +26,14 @@
 <div class="relative flex flex-col">
 	<button
 		class={twMerge(
-			'dark:bg-surface1 dark:border-surface3 bg-background flex h-full min-h-[120px] w-full flex-col rounded-lg border border-transparent p-3 text-left shadow-sm',
-			needsUpdate && 'bg-background border-yellow-500 dark:border-yellow-500 dark:bg-yellow-500/20'
+			'dark:bg-base-200 dark:border-base-400 bg-base-100 flex h-full min-h-[120px] w-full flex-col rounded-lg border border-transparent p-3 text-left shadow-sm',
+			needsUpdate && 'bg-base-100 border-warning dark:border-warning dark:bg-warning/20'
 		)}
 		onclick={onClick}
 	>
 		<div class="flex items-center gap-2 pr-6">
 			<div
-				class="flex size-5 flex-shrink-0 items-center justify-center self-start rounded-md bg-transparent p-0.5 dark:bg-gray-600"
+				class="flex size-5 shrink-0 items-center justify-center self-start rounded-md bg-transparent p-0.5 dark:bg-base-300"
 			>
 				{#if icon}
 					<img src={icon} alt={name} />
@@ -47,7 +47,7 @@
 		</div>
 		<span
 			class={twMerge(
-				'text-on-surface1 mt-2 text-xs leading-4.5 font-light break-all',
+				'text-muted-content mt-2 text-xs leading-4.5 font-light break-all',
 				categories.length > 0 ? 'line-clamp-2' : 'line-clamp-3'
 			)}
 		>
@@ -56,7 +56,7 @@
 		<div class="line-clamp-1 flex w-full gap-1 pt-2">
 			{#each categories as category (category)}
 				<div
-					class="border-surface3 text-on-surface1 truncate rounded-full border px-1.5 py-0.5 text-[10px] font-light"
+					class="border-base-400 text-muted-content truncate rounded-full border px-1.5 py-0.5 text-[10px] font-light"
 				>
 					{category}
 				</div>
@@ -73,7 +73,7 @@
 			class="absolute -top-1 right-7 flex h-full translate-y-2 flex-col justify-between gap-4 p-2"
 			use:tooltip={'Server requires an update.'}
 		>
-			<TriangleAlert class="size-4 text-yellow-500" />
+			<TriangleAlert class="size-4 text-warning" />
 		</div>
 	{/if}
 </div>

--- a/ui/user/src/lib/components/mcp/McpCompositeOauth.svelte
+++ b/ui/user/src/lib/components/mcp/McpCompositeOauth.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { parseErrorContent } from '$lib/errors';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { ChatService, type MCPCatalogServer } from '$lib/services';
-	import { LoaderCircle, Server } from 'lucide-svelte';
+	import { Server } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
 	interface Props {
@@ -128,7 +129,7 @@
 <div class="colors-background flex min-h-screen items-center justify-center p-4">
 	<div class="popover w-full max-w-lg p-6">
 		<div class="mb-6 flex items-center gap-3">
-			<div class="bg-surface1 flex-shrink-0 rounded-md p-2">
+			<div class="bg-base-200 shrink-0 rounded-md p-2">
 				{#if compositeServer?.manifest?.icon}
 					<img
 						src={compositeServer.manifest.icon}
@@ -153,7 +154,7 @@
 
 		{#if loading && pending.length === 0}
 			<div class="flex items-center justify-center gap-2 py-8">
-				<LoaderCircle class="size-6 animate-spin" />
+				<Loading class="size-6" />
 				<span>Loading servers...</span>
 			</div>
 		{:else if error}
@@ -164,7 +165,7 @@
 			<div class="flex flex-col gap-4">
 				{#each pending as item (item.mcpServerID)}
 					<div
-						class="border-surface3 bg-surface1 flex items-center justify-between rounded-lg border p-4"
+						class="border-base-400 bg-base-200 flex items-center justify-between rounded-lg border p-4"
 					>
 						<div class="flex items-center gap-3">
 							{#if componentInfos[item.catalogEntryID || '']?.icon}
@@ -184,17 +185,17 @@
 						</div>
 						<div class="flex items-center gap-2">
 							<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external OAuth URL -->
-							<a href={item.authURL} rel="external" target="_blank" class="button-primary"
+							<a href={item.authURL} rel="external" target="_blank" class="btn btn-primary"
 								>Authenticate</a
 							>
 							{#if enabledCount > 1}
 								<button
-									class="button-text"
+									class="btn btn-text"
 									disabled={item.loading}
 									onclick={() => skip(item.mcpServerID)}
 								>
 									{#if item.loading}
-										<LoaderCircle class="size-4 animate-spin" />
+										<Loading class="size-4" />
 									{:else}
 										Skip
 									{/if}

--- a/ui/user/src/lib/components/mcp/McpMultiDeleteBlockedDialog.svelte
+++ b/ui/user/src/lib/components/mcp/McpMultiDeleteBlockedDialog.svelte
@@ -5,7 +5,7 @@
 		MCPCompositeDeletionDependency,
 		MCPCompositeDeletionDependencyError
 	} from '$lib/services';
-	import { AlertTriangle, Server } from 'lucide-svelte/icons';
+	import { TriangleAlert, Server } from 'lucide-svelte/icons';
 
 	interface Props {
 		show: boolean;
@@ -70,10 +70,10 @@
 	<div class="default-scrollbar-thin flex flex-col gap-4 overflow-y-auto p-4">
 		<div class="notification-alert mb-2 flex flex-col gap-2">
 			<div class="flex gap-2">
-				<AlertTriangle class="size-6 flex-shrink-0 self-start text-yellow-500" />
+				<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
 				<p class="my-0.5 flex flex-col text-sm font-semibold">Action Required</p>
 			</div>
-			<span class="text-left text-sm font-light break-words">
+			<span class="text-left text-sm font-light wrap-break-word">
 				To delete this server, please remove it from the servers below and update all deployed
 				instances.
 			</span>
@@ -83,13 +83,13 @@
 			<ul class="space-y-2 text-sm">
 				{#each groupedLinks as dep (dep.catalogEntryID)}
 					<li
-						class="dark:bg-surface2 dark:border-surface3 bg-background flex items-center justify-between gap-3 rounded-md border border-gray-200 p-3 shadow-sm"
+						class="dark:bg-base-300 dark:border-base-400 bg-base-100 flex items-center justify-between gap-3 rounded-md border border-gray-200 p-3 shadow-sm"
 					>
 						<div class="flex min-w-0 items-center gap-3">
 							{#if dep.icon}
-								<img src={dep.icon} alt={dep.name} class="size-6 flex-shrink-0" />
+								<img src={dep.icon} alt={dep.name} class="size-6 shrink-0" />
 							{:else}
-								<Server class="size-6 flex-shrink-0" />
+								<Server class="size-6 shrink-0" />
 							{/if}
 							<span class="truncate font-medium text-gray-900 dark:text-gray-100">
 								{dep.name}

--- a/ui/user/src/lib/components/mcp/McpOauth.svelte
+++ b/ui/user/src/lib/components/mcp/McpOauth.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { parseErrorContent } from '$lib/errors';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		ChatService,
@@ -8,7 +9,7 @@
 		type Project,
 		type ProjectMCP
 	} from '$lib/services';
-	import { Info, LoaderCircle } from 'lucide-svelte';
+	import { Info } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
 	interface Props {
@@ -108,7 +109,7 @@
 {#if oauthURL}
 	<div class="notification-info flex w-full flex-row justify-between p-3 text-sm font-light">
 		<div class="flex items-center gap-3">
-			<Info class="size-6 flex-shrink-0" />
+			<Info class="size-6 shrink-0" />
 			{#if text}
 				<p>{text}</p>
 			{:else}
@@ -117,7 +118,7 @@
 		</div>
 		{#if showRefresh && loading}
 			<div class="flex items-center gap-2 text-sm font-light">
-				<LoaderCircle class="size-4 animate-spin" />
+				<Loading class="size-4" />
 				Authenticating...
 			</div>
 		{:else}
@@ -126,7 +127,7 @@
 				target="_blank"
 				href={oauthURL}
 				rel="external"
-				class="button-primary text-center text-sm"
+				class="btn btn-primary text-center text-sm"
 				onclick={() => {
 					setTimeout(() => {
 						showRefresh = true;

--- a/ui/user/src/lib/components/mcp/McpPrompts.svelte
+++ b/ui/user/src/lib/components/mcp/McpPrompts.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import Menu from '$lib/components/navbar/Menu.svelte';
 	import { getProjectMCPs, validateOauthProjectMcps } from '$lib/context/projectMcps.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { ChatService, type MCPServerPrompt, type Project, type ProjectMCP } from '$lib/services';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
-	import { LoaderCircle, MessageSquarePlus } from 'lucide-svelte';
+	import { MessageSquarePlus } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -126,11 +127,11 @@
 {#snippet content()}
 	{#if loading}
 		<div class="flex h-full flex-col items-center justify-center">
-			<LoaderCircle class="size-4 animate-spin" />
+			<Loading class="size-4" />
 		</div>
 	{:else if !hasPrompts && variant !== 'messages'}
 		<div class="flex h-full flex-col items-center justify-center">
-			<p class="text-on-surface1 text-sm">No prompts available</p>
+			<p class="text-muted-content text-sm">No prompts available</p>
 		</div>
 	{:else}
 		{#each setsToUse as mcpPromptSet (mcpPromptSet.mcp.id)}
@@ -142,12 +143,12 @@
 						variant !== 'messages' && 'border-0 px-2 py-2 first:pt-0'
 					)}
 				>
-					<div class="flex-shrink-0 rounded-sm">
+					<div class="shrink-0 rounded-sm">
 						{#if variant === 'messages'}
 							{#if mcpPromptSet.mcp.icon}
 								<img src={mcpPromptSet.mcp.icon} alt={mcpPromptSet.mcp.name} class="size-4" />
 							{:else}
-								<MessageSquarePlus class="text-on-surface1 size-4" />
+								<MessageSquarePlus class="text-muted-content size-4" />
 							{/if}
 						{/if}
 					</div>
@@ -155,7 +156,7 @@
 				</div>
 
 				<div
-					class="dark:border-surface3 flex flex-col border-0 bg-gray-50 p-2 shadow-inner dark:bg-gray-950"
+					class="dark:border-base-400 flex flex-col border-0 bg-gray-50 p-2 shadow-inner dark:bg-gray-950"
 				>
 					{#each mcpPromptSet.prompts as prompt (prompt.name)}
 						<button
@@ -164,15 +165,15 @@
 								indexMatchedPrompt?.prompt.name === prompt.name &&
 									indexMatchedPrompt?.mcp.id === mcpPromptSet.mcp.id &&
 									!isHovering &&
-									'bg-surface2 dark:bg-surface3 hover:bg-surface2 dark:hover:bg-surface3'
+									'bg-base-300 dark:bg-base-400 hover:bg-base-300 dark:hover:bg-base-400'
 							)}
 							onclick={() => handleClick(prompt, mcpPromptSet.mcp)}
 						>
-							<div class="flex-shrink-0 rounded-sm">
+							<div class="shrink-0 rounded-sm">
 								{#if mcpPromptSet.mcp.icon}
 									<img src={mcpPromptSet.mcp.icon} alt={mcpPromptSet.mcp.name} class="size-6" />
 								{:else}
-									<MessageSquarePlus class="text-on-surface1 size-5" />
+									<MessageSquarePlus class="text-muted-content size-5" />
 								{/if}
 							</div>
 							<div class="flex flex-col">
@@ -180,13 +181,13 @@
 									{prompt.name}
 									{#if variant === 'popover' && prompt.arguments}
 										{#each prompt.arguments as argument (argument.name)}
-											<span class="text-on-surface1 text-xs">
+											<span class="text-muted-content text-xs">
 												[{argument.name}]
 											</span>
 										{/each}
 									{/if}
 								</p>
-								<p class="text-on-surface1 text-xs font-light">
+								<p class="text-muted-content text-xs font-light">
 									{prompt.description}
 								</p>
 							</div>
@@ -233,7 +234,7 @@
 	<div class="flex grow"></div>
 	<div class="flex justify-end">
 		<button
-			class="button-primary"
+			class="btn btn-primary"
 			onclick={() => {
 				if (selectedPrompt) {
 					onSelect?.(selectedPrompt.prompt, selectedPrompt.mcp, params);

--- a/ui/user/src/lib/components/mcp/McpResources.svelte
+++ b/ui/user/src/lib/components/mcp/McpResources.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { DEFAULT_CUSTOM_SERVER_NAME } from '$lib/constants';
 	import { getProjectMCPs, type ProjectMcpItem } from '$lib/context/projectMcps.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		ChatService,
 		type McpServerResource,
@@ -12,7 +12,8 @@
 	import { errors } from '$lib/stores';
 	import { poll } from '$lib/utils';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
-	import { LoaderCircle, HardDrive, Search, Download, ChevronsRight, Server } from 'lucide-svelte';
+	import IconButton from '../primitives/IconButton.svelte';
+	import { HardDrive, Search, Download, ChevronsRight, Server } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
 	interface Props {
@@ -259,11 +260,11 @@
 
 {#if (!loading && filteredResources.length > 0) || loading}
 	<button
-		class="button mt-3 -mr-3 -mb-3 flex min-h-9 items-center justify-end gap-1 text-sm"
+		class="btn btn-secondary btn-sm mt-3 -mr-3 -mb-3 flex min-h-9 items-center justify-end gap-1 text-sm"
 		onclick={open}
 	>
 		{#if loading}
-			<LoaderCircle class="size-4 animate-spin" />
+			<Loading class="size-4" />
 		{:else}
 			<HardDrive class="size-4" />
 			Add MCP Servers
@@ -283,31 +284,31 @@
 		</div>
 	{/snippet}
 
-	<div class="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+	<div class="border-b border-base-400 px-4 py-3">
 		<div class="relative">
-			<Search class="text-on-surface1 absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+			<Search class="text-muted-content absolute top-1/2 left-3 size-4 -translate-y-1/2" />
 			<input
 				bind:this={searchInput}
 				bind:value={searchQuery}
 				type="text"
 				placeholder="Search by MCP server or resource name..."
-				class="focus:border-primary focus:ring-primary dark:focus:border-primary/50 bg-background dark:text-on-background w-full rounded-lg border border-gray-300 py-2 pr-4 pl-10 text-sm focus:ring-1 focus:outline-none dark:border-gray-600 dark:bg-gray-800"
+				class="focus:border-primary focus:ring-primary dark:focus:border-primary/50 bg-base-100 dark:text-base-content w-full rounded-lg border border-gray-300 py-2 pr-4 pl-10 text-sm focus:ring-1 focus:outline-none dark:border-gray-600 dark:bg-gray-800"
 			/>
 		</div>
 	</div>
 
 	<div
-		class="default-scrollbar-thin bg-surface1 flex flex-1 grow flex-col overflow-y-auto p-2 dark:bg-gray-950"
+		class="default-scrollbar-thin bg-base-200 flex flex-1 grow flex-col overflow-y-auto p-2 dark:bg-gray-950"
 	>
 		{#if loading}
 			<div class="flex h-full flex-col items-center justify-center">
-				<LoaderCircle class="size-6 animate-spin" />
-				<p class="text-on-surface1 mt-2 text-sm">Loading resources...</p>
+				<Loading class="size-6" />
+				<p class="text-muted-content mt-2 text-sm">Loading resources...</p>
 			</div>
 		{:else if filteredResources.length === 0}
 			<div class="flex h-full flex-col items-center justify-center">
 				<HardDrive class="size-12 text-gray-300" />
-				<p class="text-on-surface1 mt-2 text-sm">
+				<p class="text-muted-content mt-2 text-sm">
 					{searchQuery ? 'No resources found matching your search' : 'No resources available'}
 				</p>
 			</div>
@@ -318,7 +319,7 @@
 				{@const resources = serverResources.resources}
 				<div class="mb-4">
 					<div class="flex grow items-center gap-1 py-2 pl-1.5">
-						<div class="rounded-md bg-gray-50 p-1 dark:bg-gray-600">
+						<div class="rounded-md bg-base-200 p-1 dark:bg-base-300">
 							{#if mcp.icon}
 								<img src={mcp.icon} alt={name} class="size-4" />
 							{:else}
@@ -331,18 +332,17 @@
 					</div>
 
 					{#if resources.length > 0}
-						<div class="mb-2 border-b border-gray-200 dark:border-gray-700"></div>
+						<div class="mb-2 border-b border-base-400"></div>
 						<div class="flex flex-col gap-2">
 							{#each resources as resource (resource.uri)}
 								{@const alreadyAdded = resourceFileExists(resource, mcp)}
 								<div class="resource flex items-center gap-2">
-									<button
-										class="icon-button"
+									<IconButton
 										onclick={() => downloadResource(resource, mcp)}
-										use:tooltip={'Download'}
+										tooltip={{ text: 'Download' }}
 									>
 										<Download class="size-4" />
-									</button>
+									</IconButton>
 									<button
 										class="flex grow gap-4 text-left"
 										onclick={() => {
@@ -357,21 +357,21 @@
 									>
 										<div>
 											<p class="text-sm">{resource.name}</p>
-											<p class="text-on-surface1 text-xs font-light">{resource.mimeType}</p>
+											<p class="text-muted-content text-xs font-light">{resource.mimeType}</p>
 										</div>
 										<div class="flex grow"></div>
 										{#if alreadyAdded}
-											<div class="button-text flex items-center gap-1 p-2 pr-0 text-xs">
+											<div class="btn btn-text flex items-center gap-1 p-2 pr-0 text-xs">
 												{#if targetResourceUri === resource.uri}
-													<LoaderCircle class="size-3 animate-spin" />
+													<Loading class="size-3" />
 												{:else}
 													Remove from thread files <ChevronsRight class="size-3" />
 												{/if}
 											</div>
 										{:else}
-											<div class="button-text flex items-center gap-1 p-2 pr-0 text-xs">
+											<div class="btn btn-text flex items-center gap-1 p-2 pr-0 text-xs">
 												{#if loadingFiles || targetResourceUri === resource.uri}
-													<LoaderCircle class="size-3 animate-spin" />
+													<Loading class="size-3" />
 												{:else}
 													Add to thread files <ChevronsRight class="size-3" />
 												{/if}
@@ -384,9 +384,9 @@
 					{:else}
 						<div class="p-4 text-center">
 							{#if mcp.authenticated}
-								<p class="text-on-surface1 text-sm">No resources available</p>
+								<p class="text-muted-content text-sm">No resources available</p>
 							{:else}
-								<p class="text-on-surface1 text-sm">Authentication required to view resources</p>
+								<p class="text-muted-content text-sm">Authentication required to view resources</p>
 							{/if}
 						</div>
 					{/if}
@@ -415,17 +415,17 @@
 
 		&:not(:disabled) {
 			&:hover {
-				background-color: var(--surface2);
+				background-color: var(--color-base-300);
 			}
 		}
 
 		:global(.dark) & {
-			background-color: var(--surface2);
-			border: 1px solid var(--surface3);
+			background-color: var(--color-base-300);
+			border: 1px solid var(--color-base-400);
 
 			&:not(:disabled) {
 				&:hover {
-					background-color: var(--surface3);
+					background-color: var(--color-base-400);
 				}
 			}
 		}

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		ChatService,
 		AdminService,
@@ -15,12 +16,12 @@
 	import { goto } from '$lib/url';
 	import DotDotDot from '../DotDotDot.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import ConnectToServer from './ConnectToServer.svelte';
 	import EditExistingDeployment from './EditExistingDeployment.svelte';
 	import StaticOAuthConfigureModal from './StaticOAuthConfigureModal.svelte';
 	import {
-		LoaderCircle,
 		KeyRound,
 		MessageCircle,
 		PencilLine,
@@ -217,7 +218,7 @@
 <!-- Use class:hidden to avoid Svelte 5 production build with conditional DOM cleanup -->
 <div class="contents" class:hidden={belongsToComposite}>
 	<button
-		class="button-primary flex w-full items-center gap-1 text-sm disabled:cursor-not-allowed disabled:opacity-50 md:w-fit"
+		class="btn btn-primary flex w-full items-center gap-1 text-sm disabled:cursor-not-allowed disabled:opacity-50 md:w-fit"
 		class:hidden={!(
 			(entry && !server) ||
 			(server &&
@@ -247,7 +248,7 @@
 		disabled={loading || !canConnect || (requiresStaticOAuth && oauthConfigured === false)}
 	>
 		{#if loading}
-			<LoaderCircle class="size-4 animate-spin" />
+			<Loading class="size-4" />
 		{:else}
 			Connect To Server
 		{/if}
@@ -255,7 +256,7 @@
 
 	<div class:hidden={loading || !hasActions}>
 		<DotDotDot
-			class="icon-button hover:bg-surface1 dark:hover:bg-surface2 hover:text-primary flex-shrink-0"
+			class={!connectOnly ? 'hover:bg-base-200 dark:hover:bg-base-300' : ''}
 			disablePortal={connectOnly}
 			classes={{ menu: 'min-w-48 p-0', popover: 'z-60' }}
 		>
@@ -280,7 +281,7 @@
 <EditExistingDeployment bind:this={editExistingDialog} onUpdateConfigure={refresh} />
 
 <ResponsiveDialog
-	class="bg-surface1 dark:bg-background"
+	class="bg-base-200 dark:bg-base-100"
 	bind:this={selectServerDialog}
 	title="Select Your Server"
 >
@@ -345,7 +346,7 @@
 	>
 		{#snippet onRenderColumn(property, d)}
 			{#if property === 'name'}
-				<div class="flex flex-shrink-0 items-center gap-2">
+				<div class="flex shrink-0 items-center gap-2">
 					<div class="icon">
 						{#if d.manifest.icon}
 							<img src={d.manifest.icon} alt={d.manifest.name} class="size-6" />
@@ -362,9 +363,9 @@
 			{/if}
 		{/snippet}
 		{#snippet actions()}
-			<button class="icon-button hover:dark:bg-background/50">
+			<IconButton class="hover:dark:bg-base-100/50">
 				<StepForward class="size-4" />
-			</button>
+			</IconButton>
 		{/snippet}
 	</Table>
 </ResponsiveDialog>
@@ -401,9 +402,9 @@
 		<p class="mb-2 text-center">Would you like to connect now?</p>
 		<div class="flex grow"></div>
 		<div class="flex flex-col gap-2">
-			<button class="button" onclick={() => launchDialog?.close()}>Skip</button>
+			<button class="btn btn-secondary" onclick={() => launchDialog?.close()}>Skip</button>
 			<button
-				class="button-primary"
+				class="btn btn-primary"
 				onclick={() => {
 					launchDialog?.close();
 					connectToServerDialog?.open({
@@ -419,7 +420,7 @@
 {#snippet serverActions(toggle: (value: boolean) => void)}
 	{#if server && (server.userID === profile.current.id || canEditMultiUserServerConfiguration)}
 		<div
-			class="flex flex-col gap-1 p-2 {!isProjectMcp && 'bg-surface1'} {!isProjectMcp &&
+			class="flex flex-col gap-1 p-2 {!isProjectMcp && 'bg-base-200'} {!isProjectMcp &&
 				'rounded-t-xl'}"
 		>
 			{#if canEditMultiUserServerConfiguration}
@@ -477,7 +478,7 @@
 					<button
 						class={twMerge(
 							'menu-button',
-							requiresUpdate && 'bg-yellow-500/10 text-yellow-500 hover:bg-yellow-500/30'
+							requiresUpdate && 'bg-warning/10 text-warning hover:bg-warning/30'
 						)}
 						onclick={() => {
 							editExistingDialog?.edit({
@@ -507,7 +508,7 @@
 					}}
 				>
 					{#if restarting}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 					{:else}
 						<RefreshCw class="size-4" />
 					{/if} Restart
@@ -540,7 +541,7 @@
 					}}
 				>
 					{#if disconnecting}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 					{:else}
 						<Unplug class="size-4" />
 					{/if} Disconnect
@@ -572,7 +573,7 @@
 					}}
 				>
 					{#if disconnecting}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 					{:else}
 						<Trash2 class="size-4" />
 					{/if} Disconnect
@@ -581,11 +582,11 @@
 		</div>
 	{:else if entry && configuredServers.length > 0}
 		<div
-			class="bg-background dark:bg-surface2 rounded-t-xl p-2 pl-4 text-[11px] font-semibold uppercase"
+			class="bg-base-100 dark:bg-base-300 rounded-t-xl p-2 pl-4 text-[11px] font-semibold uppercase"
 		>
 			My Connection(s)
 		</div>
-		<div class="bg-surface1 flex flex-col gap-1 p-2">
+		<div class="bg-base-200 flex flex-col gap-1 p-2">
 			{#if !connectOnly && version.current.disableLegacyChat !== true}
 				<button
 					class="menu-button"
@@ -620,7 +621,7 @@
 					<button
 						class={twMerge(
 							'menu-button',
-							requiresUpdate && 'bg-yellow-500/10 text-yellow-500 hover:bg-yellow-500/30'
+							requiresUpdate && 'bg-warning/10 text-warning hover:bg-warning/30'
 						)}
 						onclick={() => {
 							if (configuredServers.length === 1) {
@@ -658,7 +659,7 @@
 					}}
 				>
 					{#if restarting}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 					{:else}
 						<RefreshCw class="size-4" />
 					{/if} Restart
@@ -709,7 +710,7 @@
 	{#if showDisconnectUser && server}
 		<div class="flex flex-col gap-2 p-2">
 			<button
-				class="menu-button text-red-500"
+				class="menu-button text-error"
 				onclick={async (e) => {
 					e.stopPropagation();
 					await ChatService.deleteSingleOrRemoteMcpServer(server.id);

--- a/ui/user/src/lib/components/mcp/McpServerInfo.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerInfo.svelte
@@ -143,14 +143,14 @@
 
 <div class="flex w-full flex-col gap-4 md:flex-row">
 	<div
-		class="dark:bg-surface1 dark:border-surface3 bg-background flex h-fit w-full flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex h-fit w-full flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 	>
 		{#if description && browser}
 			<div class="milkdown-content">
 				{@html toHTMLFromMarkdownWithNewTabLinks(description, true)}
 			</div>
 		{:else}
-			<p class="text-md text-on-surface1 text-center font-light italic">
+			<p class="text-md text-muted-content text-center font-light italic">
 				{descriptionPlaceholder}
 			</p>
 		{/if}
@@ -165,7 +165,7 @@
 		<div class="flex flex-col gap-4">
 			{#each details.filter( (d) => (Array.isArray(d.value) ? d.value.length > 0 : d.value) ) as detail, i (i)}
 				<div
-					class="dark:bg-surface2 dark:border-surface3 border-surface2 rounded-md border bg-gray-50 p-3"
+					class="dark:bg-base-300 dark:border-base-400 border-base-200 rounded-md border bg-gray-50 p-3"
 				>
 					<p class="mb-1 text-xs font-medium">{detail.label}</p>
 					{#if detail.link}

--- a/ui/user/src/lib/components/mcp/McpServerInfoAndTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerInfoAndTools.svelte
@@ -23,7 +23,7 @@
 	import McpOauth from './McpOauth.svelte';
 	import McpServerInfo from './McpServerInfo.svelte';
 	import McpServerTools from './McpServerTools.svelte';
-	import { AlertTriangle } from 'lucide-svelte';
+	import { TriangleAlert } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -155,10 +155,10 @@
 							selected = tab.view;
 						}}
 						class={twMerge(
-							'w-48 flex-shrink-0 rounded-md border border-transparent px-4 py-2 text-center transition-colors duration-300',
+							'w-48 shrink-0 rounded-md border border-transparent px-4 py-2 text-center transition-colors duration-300',
 							selected === tab.view &&
-								'dark:bg-surface1 dark:border-surface3 bg-background shadow-sm',
-							selected !== tab.view && 'hover:bg-surface3'
+								'dark:bg-base-200 dark:border-base-400 bg-base-100 shadow-sm',
+							selected !== tab.view && 'hover:bg-base-400'
 						)}
 					>
 						{tab.label}
@@ -181,7 +181,7 @@
 							<div class="notification-alert mb-4 flex gap-2">
 								<div class="flex grow flex-col gap-2">
 									<div class="flex items-center gap-2">
-										<AlertTriangle class="size-6 flex-shrink-0 self-start text-yellow-500" />
+										<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
 										<p class="my-0.5 flex flex-col text-sm font-semibold">
 											{#if isAdminOAuthOnly}
 												Admin Configuration Required
@@ -201,9 +201,9 @@
 									</span>
 								</div>
 								{#if !isAdminOAuthOnly}
-									<div class="flex flex-shrink-0 items-center">
+									<div class="flex shrink-0 items-center">
 										<button
-											class="button-primary text-sm"
+											class="btn btn-primary text-sm"
 											onclick={() => {
 												if (onEditConfiguration) {
 													onEditConfiguration();

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { toHTMLFromMarkdownWithNewTabLinks } from '$lib/markdown';
 	import {
 		ChatService,
@@ -13,9 +14,10 @@
 	import { responsive } from '$lib/stores';
 	import Search from '../Search.svelte';
 	import Toggle from '../Toggle.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import McpOauth from './McpOauth.svelte';
 	import ToolNameIssueIcon from './ToolNameIssueIcon.svelte';
-	import { AlertCircle, ChevronDown, ChevronUp, Info, LoaderCircle, Wrench } from 'lucide-svelte';
+	import { CircleAlert, ChevronDown, ChevronUp, Info, Wrench } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -171,7 +173,7 @@
 		{#if showPreviewTools}
 			<div class="notification-info w-full p-3 text-sm font-light">
 				<div class="flex items-center gap-3">
-					<Info class="size-6 flex-shrink-0" />
+					<Info class="size-6 shrink-0" />
 					<div>
 						This is a preview of the tools that are available for this MCP server; the actual tools
 						may differ on user connection.
@@ -185,7 +187,7 @@
 		{/if}
 		{#if error}
 			<div class="notification-error flex w-full items-center gap-2 p-3">
-				<AlertCircle class="size-4" />
+				<CircleAlert class="size-4" />
 				<div class="flex flex-col">
 					<p class="text-sm font-semibold">Unable to retrieve the server's tools</p>
 					<p class="text-sm font-light">
@@ -198,7 +200,7 @@
 
 	<div class="flex w-full flex-col gap-2">
 		<div class="mb-2 flex w-full flex-col gap-4">
-			<div class="flex flex-wrap items-center justify-end gap-2 md:flex-shrink-0">
+			<div class="flex flex-wrap items-center justify-end gap-2 md:shrink-0">
 				<Toggle
 					checked={allDescriptionsEnabled}
 					onChange={(checked) => {
@@ -214,7 +216,7 @@
 
 				{#if project}
 					{#if !responsive.isMobile}
-						<div class="bg-surface3 mx-2 h-5 w-0.5"></div>
+						<div class="bg-base-400 mx-2 h-5 w-0.5"></div>
 					{/if}
 
 					<Toggle
@@ -232,7 +234,7 @@
 			</div>
 
 			<Search
-				class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+				class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 				onChange={(val) => (search = val)}
 				placeholder="Search tools..."
 			/>
@@ -240,13 +242,13 @@
 		<div class="flex flex-col gap-4 overflow-hidden">
 			{#if loading}
 				<div class="flex items-center justify-center">
-					<LoaderCircle class="size-6 animate-spin" />
+					<Loading class="size-6" />
 				</div>
 			{:else if displayTools.length > 0}
 				{#each displayTools as tool, index (`${tool.name}-${index}`)}
 					{@const hasContentDisplayed = allDescriptionsEnabled || expanded[tool.id]}
 					<div
-						class="border-surface2 dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-2 rounded-md border p-3 shadow-sm"
+						class="border-base-200 dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-2 rounded-md border p-3 shadow-sm"
 						class:pb-2={hasContentDisplayed}
 					>
 						<div class="flex items-center justify-between gap-2">
@@ -257,14 +259,14 @@
 									<ToolNameIssueIcon issue={conflict ?? toolNameIssue(tool.name)} />
 								{/if}
 								{#if tool.unsupported}
-									<span class="text-on-surface1 ml-3 flex-shrink-0 text-sm">
+									<span class="text-muted-content ml-3 shrink-0 text-sm">
 										⚠️ Not yet fully supported in Obot
 									</span>
 								{/if}
 							</p>
-							<div class="flex flex-shrink-0 items-center gap-2">
-								<button
-									class="icon-button h-fit min-h-auto w-fit min-w-auto flex-shrink-0 p-1"
+							<div class="flex shrink-0 items-center gap-2">
+								<IconButton
+									class="btn-sm"
 									onclick={() => handleToggleDescription(tool.id, !hasContentDisplayed)}
 								>
 									{#if hasContentDisplayed}
@@ -272,7 +274,7 @@
 									{:else}
 										<ChevronDown class="size-4" />
 									{/if}
-								</button>
+								</IconButton>
 								{#if project}
 									<Toggle
 										checked={selected.includes(tool.id) || allToolsEnabled}
@@ -295,14 +297,14 @@
 							{#if browser}
 								<div
 									in:slide={{ axis: 'y' }}
-									class="milkdown-content text-on-surface1 max-w-none text-sm font-light"
+									class="milkdown-content text-muted-content max-w-none text-sm font-light"
 								>
 									{@html toHTMLFromMarkdownWithNewTabLinks(tool.description || '', true)}
 								</div>
 							{/if}
 							{#if Object.keys(tool.params ?? {}).length > 0}
 								<div
-									class="from-surface2 dark:from-surface3 text-on-surface1 flex w-full flex-shrink-0 bg-linear-to-r to-transparent px-4 py-2 text-xs font-semibold md:w-sm"
+									class="from-base-300 dark:from-base-400 text-muted-content flex w-full shrink-0 bg-linear-to-r to-transparent px-4 py-2 text-xs font-semibold md:w-sm"
 								>
 									Parameters
 								</div>
@@ -310,10 +312,10 @@
 									<div class="flex flex-col gap-2">
 										{#each Object.keys(tool.params ?? {}) as paramKey (paramKey)}
 											<div class="flex flex-col items-center gap-2 md:flex-row">
-												<p class="text-on-surface1 self-start font-semibold md:min-w-xs">
+												<p class="text-muted-content self-start font-semibold md:min-w-xs">
 													{paramKey}
 												</p>
-												<p class="text-on-surface1 self-start font-light">
+												<p class="text-muted-content self-start font-light">
 													{tool.params?.[paramKey]}
 												</p>
 											</div>
@@ -328,9 +330,9 @@
 				{@render noToolsContent()}
 			{:else}
 				<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-					<Wrench class="text-on-surface1 size-24 opacity-50" />
-					<h4 class="text-on-surface1 text-lg font-semibold">No tools</h4>
-					<p class="text-on-surface1 text-sm font-light">
+					<Wrench class="text-muted-content size-24 opacity-50" />
+					<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
+					<p class="text-muted-content text-sm font-light">
 						{#if !entry || hasConnectedServer}
 							Looks like this MCP server doesn't have any tools available.
 						{:else}
@@ -347,7 +349,7 @@
 
 {#if project && !loading && !error}
 	<div class="sticky bottom-0 left-0 flex w-full justify-end bg-inherit py-4 md:px-4">
-		<button class="button-primary flex items-center gap-1" onclick={handleProjectToolsUpdate}>
+		<button class="btn btn-primary flex items-center gap-1" onclick={handleProjectToolsUpdate}>
 			Save
 		</button>
 	</div>

--- a/ui/user/src/lib/components/mcp/MultiUserHeadersForm.svelte
+++ b/ui/user/src/lib/components/mcp/MultiUserHeadersForm.svelte
@@ -2,6 +2,7 @@
 	import type { MCPSubField } from '$lib/services';
 	import InfoTooltip from '../InfoTooltip.svelte';
 	import Toggle from '../Toggle.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2 } from 'lucide-svelte';
 
 	interface Props {
@@ -13,11 +14,11 @@
 </script>
 
 <div
-	class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 >
 	<div class="flex flex-col gap-1">
 		<h4 class="text-sm font-semibold">User-Defined Headers</h4>
-		<p class="text-on-surface1 text-xs font-light">
+		<p class="text-muted-content text-xs font-light">
 			These headers are collected from each user when they connect to this multi-user MCP server.
 		</p>
 	</div>
@@ -25,14 +26,14 @@
 	{#if headers}
 		{#each headers as header, i (i)}
 			<div
-				class="dark:border-surface3 bg-surface2 flex w-full items-center gap-4 rounded-lg border border-transparent p-4"
+				class="dark:border-base-400 bg-base-300 flex w-full items-center gap-4 rounded-lg border border-transparent p-4"
 			>
 				<div class="flex w-full flex-col gap-4">
 					<div class="flex w-full flex-col gap-1">
 						<label for={`multi-user-header-name-${i}`} class="text-sm font-light">Name</label>
 						<input
 							id={`multi-user-header-name-${i}`}
-							class="text-input-filled bg-background w-full shadow-none"
+							class="text-input-filled bg-base-100 w-full shadow-none"
 							bind:value={headers[i].name}
 							disabled={readonly}
 						/>
@@ -44,7 +45,7 @@
 						>
 						<input
 							id={`multi-user-header-description-${i}`}
-							class="text-input-filled bg-background w-full shadow-none"
+							class="text-input-filled bg-base-100 w-full shadow-none"
 							bind:value={headers[i].description}
 							disabled={readonly}
 						/>
@@ -54,7 +55,7 @@
 						<label for={`multi-user-header-key-${i}`} class="text-sm font-light">Key</label>
 						<input
 							id={`multi-user-header-key-${i}`}
-							class="text-input-filled bg-background w-full shadow-none"
+							class="text-input-filled bg-base-100 w-full shadow-none"
 							bind:value={headers[i].key}
 							placeholder="e.g. X-API-Key"
 							disabled={readonly}
@@ -74,7 +75,7 @@
 						</label>
 						<input
 							id={`multi-user-header-prefix-${i}`}
-							class="text-input-filled bg-background w-full shadow-none"
+							class="text-input-filled bg-base-100 w-full shadow-none"
 							bind:value={headers[i].prefix}
 							disabled={readonly}
 						/>
@@ -105,14 +106,15 @@
 				</div>
 
 				{#if !readonly}
-					<button
-						class="icon-button hover:text-red-500"
+					<IconButton
+						class="hover:text-error"
 						onclick={() => {
 							headers?.splice(i, 1);
 						}}
+						variant="danger"
 					>
 						<Trash2 class="size-4" />
-					</button>
+					</IconButton>
 				{/if}
 			</div>
 		{/each}

--- a/ui/user/src/lib/components/mcp/NpxRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/NpxRuntimeForm.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Toggle from '$lib/components/Toggle.svelte';
 	import { MultiValueInput } from '$lib/components/ui/multi-value-input';
 	import type { NPXRuntimeConfig } from '$lib/services/chat/types';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2 } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -111,10 +111,10 @@
 </script>
 
 <div
-	class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 >
 	<h4 class="text-sm font-semibold">NPX Runtime Configuration</h4>
-	<p class="text-on-surface1 text-xs">Only STDIO servers are supported.</p>
+	<p class="text-muted-content text-xs">Only STDIO servers are supported.</p>
 
 	<!-- Package field (required) -->
 	<div class="flex items-center gap-4">
@@ -125,10 +125,7 @@
 		>
 		<input
 			id="npx-package"
-			class={twMerge(
-				'text-input-filled dark:bg-background w-full',
-				showRequired?.package && 'error'
-			)}
+			class={twMerge('text-input-filled dark:bg-base-100 w-full', showRequired?.package && 'error')}
 			bind:value={config.package}
 			disabled={readonly}
 			placeholder="e.g. @modelcontextprotocol/server-filesystem"
@@ -152,7 +149,7 @@
 				{#each config.args as _arg, i (i)}
 					<div class="flex items-center gap-2">
 						<input
-							class="text-input-filled dark:bg-background w-full"
+							class="text-input-filled dark:bg-base-100 w-full"
 							bind:value={config.args[i]}
 							disabled={readonly}
 							onblur={() => {
@@ -164,20 +161,20 @@
 							onpaste={(e) => handlePaste(e, i)}
 						/>
 						{#if !readonly}
-							<button
-								class="icon-button"
+							<IconButton
+								variant="danger"
 								onclick={() => removeArgument(i)}
-								use:tooltip={'Remove argument'}
+								tooltip={{ text: 'Remove argument' }}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					</div>
 				{/each}
 
 				{#if !readonly}
 					<div class="flex justify-end">
-						<button class="button flex items-center gap-1 text-xs" onclick={addArgument}>
+						<button class="btn btn-secondary btn-sm flex items-center gap-1" onclick={addArgument}>
 							<Plus class="size-4" /> Argument
 						</button>
 					</div>
@@ -199,11 +196,11 @@
 				/>
 				<MultiValueInput
 					bind:value={config.egressDomains}
-					class="text-input-filled dark:bg-background"
+					class="text-input-filled dark:bg-base-100"
 					readonly={inputReadonly}
 					placeholder="hit &quot;Enter&quot; to insert"
 				/>
-				<p class="text-on-surface1 text-xs">{egressHelpText}</p>
+				<p class="text-muted-content text-xs">{egressHelpText}</p>
 			</div>
 		</div>
 	{/if}
@@ -222,7 +219,7 @@
 			placeholder="60"
 			bind:value={startupTimeoutSeconds}
 			class={twMerge(
-				'text-input-filled dark:bg-background w-32',
+				'text-input-filled dark:bg-base-100 w-32',
 				showRequired?.startupTimeoutSeconds && 'error'
 			)}
 			disabled={readonly}

--- a/ui/user/src/lib/components/mcp/OAuthMetadataDebug.svelte
+++ b/ui/user/src/lib/components/mcp/OAuthMetadataDebug.svelte
@@ -16,34 +16,34 @@
 </script>
 
 <div
-	class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 >
 	<div class="flex items-center justify-between gap-3">
 		<h2 class="text-lg font-semibold">OAuth Metadata</h2>
 		{#if metadata}
-			<span class="text-on-surface1 text-xs">
+			<span class="text-muted-content text-xs">
 				{hasMetadata ? 'Discovered' : 'No metadata discovered'}
 			</span>
 		{/if}
 	</div>
 
 	{#if !metadata}
-		<p class="text-sm text-on-surface1">OAuth metadata has not been reconciled yet.</p>
+		<p class="text-sm text-muted-content">OAuth metadata has not been reconciled yet.</p>
 	{:else if !hasMetadata}
-		<p class="text-sm text-on-surface1">No OAuth metadata was returned by this MCP server.</p>
+		<p class="text-sm text-muted-content">No OAuth metadata was returned by this MCP server.</p>
 	{:else}
 		<div class="grid gap-3 text-sm">
 			{#if metadata.protectedResourceUrl}
 				<div class="grid gap-1">
 					<p class="font-medium">Protected Resource URL</p>
-					<p class="break-all text-on-surface1">{metadata.protectedResourceUrl}</p>
+					<p class="break-all text-muted-content">{metadata.protectedResourceUrl}</p>
 				</div>
 			{/if}
 
 			{#if metadata.authorizationServerUrl}
 				<div class="grid gap-1">
 					<p class="font-medium">Authorization Server URL</p>
-					<p class="break-all text-on-surface1">
+					<p class="break-all text-muted-content">
 						{metadata.authorizationServerUrl}
 					</p>
 				</div>
@@ -51,7 +51,7 @@
 
 			<div class="grid gap-1">
 				<p class="font-medium">Dynamic Client Registration</p>
-				<p class="text-on-surface1">
+				<p class="text-muted-content">
 					{metadata.dynamicClientRegistration ? 'Supported' : 'Not advertised'}
 				</p>
 			</div>
@@ -60,7 +60,7 @@
 				<div class="grid gap-1">
 					<p class="font-medium">Protected Resource Metadata</p>
 					<pre
-						class="bg-surface1 dark:bg-surface2 mt-1 overflow-auto rounded-md p-3 text-xs">{formatJSON(
+						class="bg-base-200 dark:bg-base-300 mt-1 overflow-auto rounded-md p-3 text-xs">{formatJSON(
 							metadata.protectedResourceMetadata
 						)}</pre>
 				</div>
@@ -70,7 +70,7 @@
 				<div class="grid gap-1">
 					<p class="font-medium">Authorization Server Metadata</p>
 					<pre
-						class="bg-surface1 dark:bg-surface2 mt-1 overflow-auto rounded-md p-3 text-xs">{formatJSON(
+						class="bg-base-200 dark:bg-base-300 mt-1 overflow-auto rounded-md p-3 text-xs">{formatJSON(
 							metadata.authorizationServerMetadata
 						)}</pre>
 				</div>

--- a/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import type {
 		RemoteCatalogConfigAdmin,
 		RemoteRuntimeConfigAdmin
@@ -8,6 +7,7 @@
 	import InfoTooltip from '../InfoTooltip.svelte';
 	import Select from '../Select.svelte';
 	import Toggle from '../Toggle.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2, Info, Settings } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
@@ -65,10 +65,10 @@
 {#snippet remoteHeaders(showUrlTemplateHelp: boolean)}
 	<div class="flex w-full flex-col gap-8" in:slide>
 		<div
-			class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 		>
 			<h4 class="text-sm font-semibold">Headers</h4>
-			<p class="text-on-surface1 text-xs font-light">
+			<p class="text-muted-content text-xs font-light">
 				{#if showUrlTemplateHelp}
 					Header values will be supplied with the URL to configure the MCP server. Their values can
 					be supplied by the user during initial setup or as static provided values. Only values
@@ -82,14 +82,14 @@
 				{#each config.headers as header, i (i)}
 					{#if !hasSecretBinding(header)}
 						<div
-							class="dark:border-surface3 bg-surface2 flex w-full items-center gap-4 rounded-lg border border-transparent p-4"
+							class="dark:border-base-400 bg-base-300 flex w-full items-center gap-4 rounded-lg border border-transparent p-4"
 						>
 							<div class="flex w-full flex-col gap-4">
 								<div class="flex w-full flex-col gap-1">
 									<label for={`header-key-${i}`} class="text-sm font-light">Key</label>
 									<input
 										id={`header-key-${i}`}
-										class="text-input-filled bg-background w-full shadow-none"
+										class="text-input-filled bg-base-100 w-full shadow-none"
 										bind:value={config.headers[i].key}
 										placeholder="e.g. CUSTOM_HEADER_KEY"
 										disabled={readonly}
@@ -99,7 +99,7 @@
 									{#if variant === 'catalog'}
 										<label for={`env-type-${i}`} class="text-sm font-light">Value</label>
 										<Select
-											class="bg-background dark:border-surface3 border border-transparent shadow-none"
+											class="bg-base-100 dark:border-base-400 border border-transparent shadow-none"
 											classes={{
 												root: 'flex grow'
 											}}
@@ -129,7 +129,7 @@
 										<label for={`header-name-${i}`} class="text-sm font-light">Name</label>
 										<input
 											id={`header-name-${i}`}
-											class="text-input-filled bg-background w-full shadow-none"
+											class="text-input-filled bg-base-100 w-full shadow-none"
 											bind:value={config.headers[i].name}
 											disabled={readonly}
 										/>
@@ -140,7 +140,7 @@
 										>
 										<input
 											id={`header-description-${i}`}
-											class="text-input-filled bg-background w-full shadow-none"
+											class="text-input-filled bg-base-100 w-full shadow-none"
 											bind:value={config.headers[i].description}
 											disabled={readonly}
 										/>
@@ -158,7 +158,7 @@
 										</label>
 										<input
 											id={`header-prefix-${i}`}
-											class="text-input-filled bg-background w-full shadow-none"
+											class="text-input-filled bg-base-100 w-full shadow-none"
 											bind:value={config.headers[i].prefix}
 											disabled={readonly}
 										/>
@@ -183,7 +183,7 @@
 										{/if}
 										<input
 											id={`header-description-${i}`}
-											class="text-input-filled bg-background w-full shadow-none"
+											class="text-input-filled bg-base-100 w-full shadow-none"
 											bind:value={config.headers[i].value}
 											disabled={readonly}
 										/>
@@ -192,15 +192,15 @@
 							</div>
 
 							{#if !readonly}
-								<button
-									class="icon-button"
+								<IconButton
+									variant="danger2"
 									onclick={() => {
 										config.headers?.splice(i, 1);
 									}}
-									use:tooltip={'Delete Header'}
+									tooltip={{ text: 'Delete Header' }}
 								>
 									<Trash2 class="size-4" />
-								</button>
+								</IconButton>
 							{/if}
 						</div>
 					{/if}
@@ -209,7 +209,7 @@
 			{#if !readonly}
 				<div class="flex justify-end">
 					<button
-						class="button flex items-center gap-1 text-xs"
+						class="btn btn-secondary btn-sm flex items-center gap-1"
 						onclick={() => {
 							if (!config.headers) {
 								config.headers = [];
@@ -237,7 +237,7 @@
 {#if variant === 'server'}
 	{@const serverConfig = config as RemoteRuntimeConfigAdmin}
 	<div
-		class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-6 rounded-lg border border-transparent p-4 shadow-sm"
+		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-6 rounded-lg border border-transparent p-4 shadow-sm"
 		in:fade={{ duration: 200 }}
 	>
 		<h4 class="text-sm font-semibold">Remote Runtime Configuration</h4>
@@ -249,7 +249,7 @@
 			<input
 				id="multi-user-remote-url"
 				class={twMerge(
-					'text-input-filled dark:bg-background flex grow',
+					'text-input-filled dark:bg-base-100 flex grow',
 					showRequired?.url && 'error'
 				)}
 				bind:value={serverConfig.url}
@@ -269,7 +269,7 @@
 	{@const remoteConfig = config as RemoteCatalogConfigAdmin}
 	<!-- For catalog entries, show simple fixed URL when not in advanced mode -->
 	<div
-		class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-6 rounded-lg border border-transparent p-4 shadow-sm"
+		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-6 rounded-lg border border-transparent p-4 shadow-sm"
 		in:fade={{ duration: 200 }}
 	>
 		<div class="flex flex-col gap-2">
@@ -280,7 +280,7 @@
 			<input
 				id="basic-url"
 				class={twMerge(
-					'text-input-filled dark:bg-background flex grow',
+					'text-input-filled dark:bg-base-100 flex grow',
 					showRequired?.fixedURL && 'error'
 				)}
 				bind:value={remoteConfig.fixedURL}
@@ -293,14 +293,13 @@
 {:else if showAdvanced}
 	<div class="flex w-full flex-col gap-8" in:slide>
 		<div
-			class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 		>
 			<div class="flex items-center gap-4 {readonly ? 'hidden' : ''}">
-				<label for="remote-type" class="flex-shrink-0 text-sm font-light"
-					>Restrict connections to:</label
+				<label for="remote-type" class="shrink-0 text-sm font-light">Restrict connections to:</label
 				>
 				<Select
-					class="bg-surface1 dark:border-surface3 dark:bg-background border border-transparent shadow-inner"
+					class="bg-base-100 dark:border-base-400 dark:bg-base-100 border border-transparent shadow-inner"
 					classes={{
 						root: 'flex grow'
 					}}
@@ -341,7 +340,7 @@
 					>
 					<input
 						class={twMerge(
-							'text-input-filled dark:bg-background flex grow',
+							'text-input-filled dark:bg-base-100 flex grow',
 							showRequired?.fixedURL && 'error'
 						)}
 						bind:value={remoteConfig.fixedURL}
@@ -362,7 +361,7 @@
 					>
 					<input
 						class={twMerge(
-							'text-input-filled dark:bg-background flex grow',
+							'text-input-filled dark:bg-base-100 flex grow',
 							showRequired?.hostname && 'error'
 						)}
 						bind:value={remoteConfig.hostname}
@@ -386,7 +385,7 @@
 						>
 						<input
 							class={twMerge(
-								'text-input-filled dark:bg-background flex grow',
+								'text-input-filled dark:bg-base-100 flex grow',
 								showRequired?.urlTemplate && 'error'
 							)}
 							bind:value={remoteConfig.urlTemplate}
@@ -401,17 +400,16 @@
 					<!-- Info message about header interpolation -->
 					<div class="notification-info p-3 text-sm font-light">
 						<div class="flex items-start gap-3">
-							<Info class="mt-0.5 size-5 flex-shrink-0" />
+							<Info class="mt-0.5 size-5 shrink-0" />
 							<div class="flex flex-col gap-1">
 								<p class="font-semibold">Variable Interpolation</p>
 								<p>
-									Use <code class="rounded bg-gray-100 px-1 py-0.5 dark:bg-gray-800"
-										>${'{VARIABLE_NAME}'}</code
-									> syntax in your URL template. Variables can be populated from header values that users
-									provide during setup.
+									Use <code class="rounded bg-base-300 px-1 py-0.5">${'{VARIABLE_NAME}'}</code> syntax
+									in your URL template. Variables can be populated from header values that users provide
+									during setup.
 								</p>
 								<p class="text-xs">
-									Example: <code class="rounded bg-gray-100 px-1 py-0.5 text-xs dark:bg-gray-800"
+									Example: <code class="rounded bg-base-300 px-1 py-0.5 text-xs"
 										>https://${'{WORKSPACE_URL}'}/api/2.0/mcp/genie/${'{SPACE_ID}'}</code
 									>
 								</p>
@@ -439,7 +437,7 @@
 	{#if config && !disableStaticOAuth}
 		{@const remoteConfig = config as RemoteCatalogConfigAdmin}
 		<div
-			class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 		>
 			<div class="flex justify-between">
 				<button
@@ -461,7 +459,7 @@
 							Static OAuth
 						</h4>
 					</div>
-					<p class="text-on-surface1 text-xs font-light">
+					<p class="text-muted-content text-xs font-light">
 						Enable this if the remote MCP server requires OAuth authentication with a static client
 						ID and secret.
 					</p>
@@ -486,13 +484,13 @@
 					{#if isNewEntry}
 						<div class="notification-info p-3 text-sm font-light">
 							<div class="flex items-start gap-3">
-								<Info class="mt-0.5 size-5 flex-shrink-0" />
+								<Info class="mt-0.5 size-5 shrink-0" />
 								<p>You can provide OAuth credentials after saving.</p>
 							</div>
 						</div>
 					{:else if onConfigureOAuth}
 						<button
-							class="button flex w-fit items-center gap-2 text-sm"
+							class="btn btn-secondary flex w-fit items-center gap-2 text-sm"
 							onclick={onConfigureOAuth}
 							disabled={readonly}
 							type="button"
@@ -509,7 +507,7 @@
 
 {#if variant === 'catalog'}
 	<button
-		class="button-text pl-0"
+		class="btn btn-text pl-0"
 		onclick={() => {
 			showAdvanced = !showAdvanced;
 

--- a/ui/user/src/lib/components/mcp/RuntimeSelector.svelte
+++ b/ui/user/src/lib/components/mcp/RuntimeSelector.svelte
@@ -62,7 +62,7 @@
 </script>
 
 <div
-	class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm {serverType ===
+	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm {serverType ===
 		'remote' || serverType === 'composite'
 		? 'hidden'
 		: ''}"
@@ -74,7 +74,7 @@
 		<div class="w-full">
 			<Select
 				id="runtime-selector"
-				class="bg-surface1 dark:bg-surface2 dark:border-surface3 flex-1 border border-transparent shadow-inner"
+				class="bg-base-100 dark:bg-base-200 dark:border-base-400 flex-1 border border-transparent shadow-inner"
 				options={runtimeOptions}
 				selected={runtime}
 				onSelect={handleRuntimeChange}
@@ -84,6 +84,6 @@
 	</div>
 
 	{#if !readonly && serverType !== 'remote'}
-		<p class="text-on-surface1 text-xs">Choose the runtime environment for your MCP server.</p>
+		<p class="text-muted-content text-xs">Choose the runtime environment for your MCP server.</p>
 	{/if}
 </div>

--- a/ui/user/src/lib/components/mcp/SelectServerType.svelte
+++ b/ui/user/src/lib/components/mcp/SelectServerType.svelte
@@ -24,15 +24,15 @@
 <ResponsiveDialog title="Select Server Type" class="md:w-lg" bind:this={selectServerTypeDialog}>
 	<div class="flex flex-col gap-4 p-4 md:p-0">
 		<button
-			class="dark:bg-surface2 hover:bg-surface1 dark:hover:bg-surface3 dark:border-surface3 border-surface2 group bg-background flex cursor-pointer items-center gap-4 rounded-md border px-2 py-4 text-left transition-colors duration-300"
+			class="dark:bg-base-300 hover:bg-base-200 dark:hover:bg-base-400 dark:border-base-400 border-base-300 group bg-base-100 flex cursor-pointer items-center gap-4 rounded-md border px-2 py-4 text-left transition-colors duration-300"
 			onclick={() => onSelectServerType('single')}
 		>
 			<User
-				class="text-on-surface1 size-12 flex-shrink-0 pl-1 transition-colors group-hover:text-inherit"
+				class="text-muted-content size-12 shrink-0 pl-1 transition-colors group-hover:text-inherit"
 			/>
 			<div>
 				<p class="mb-1 text-sm font-semibold">Single User Server</p>
-				<span class="text-on-surface1 block text-xs leading-4">
+				<span class="text-muted-content block text-xs leading-4">
 					This option is appropriate for servers that require individualized configuration or were
 					not designed for multi-user access, such as most stdio MCP servers. When a user selects
 					this server, a private instance will be created for them.
@@ -41,15 +41,15 @@
 		</button>
 		{#if profile.current?.groups.includes(Group.POWERUSER_PLUS)}
 			<button
-				class="dark:bg-surface2 hover:bg-surface1 dark:hover:bg-surface3 dark:border-surface3 border-surface2 group bg-background flex cursor-pointer items-center gap-4 rounded-md border px-2 py-4 text-left transition-colors duration-300"
+				class="dark:bg-base-300 hover:bg-base-200 dark:hover:bg-base-400 dark:border-base-400 border-base-300 group bg-base-100 flex cursor-pointer items-center gap-4 rounded-md border px-2 py-4 text-left transition-colors duration-300"
 				onclick={() => onSelectServerType('multi')}
 			>
 				<Users
-					class="text-on-surface1 size-12 flex-shrink-0 pl-1 transition-colors group-hover:text-inherit"
+					class="text-muted-content size-12 shrink-0 pl-1 transition-colors group-hover:text-inherit"
 				/>
 				<div>
 					<p class="mb-1 text-sm font-semibold">Multi-User Server</p>
-					<span class="text-on-surface1 block text-xs leading-4">
+					<span class="text-muted-content block text-xs leading-4">
 						This option is appropriate for servers designed to handle multiple user connections,
 						such as most Streamable HTTP servers. When you create this server, a running instance
 						will be deployed and any user with access to this catalog will be able to connect to it.
@@ -58,15 +58,15 @@
 			</button>
 		{/if}
 		<button
-			class="dark:bg-surface2 hover:bg-surface1 dark:hover:bg-surface3 dark:border-surface3 border-surface2 group bg-background flex cursor-pointer items-center gap-4 rounded-md border px-2 py-4 text-left transition-colors duration-300"
+			class="dark:bg-base-300 hover:bg-base-200 dark:hover:bg-base-400 dark:border-base-400 border-base-300 group bg-base-100 flex cursor-pointer items-center gap-4 rounded-md border px-2 py-4 text-left transition-colors duration-300"
 			onclick={() => onSelectServerType('remote')}
 		>
 			<Container
-				class="text-on-surface1 size-12 flex-shrink-0 pl-1 transition-colors group-hover:text-inherit"
+				class="text-muted-content size-12 shrink-0 pl-1 transition-colors group-hover:text-inherit"
 			/>
 			<div>
 				<p class="mb-1 text-sm font-semibold">Remote Server</p>
-				<span class="text-on-surface1 block text-xs leading-4">
+				<span class="text-muted-content block text-xs leading-4">
 					This option is appropriate for allowing users to connect to MCP servers that are already
 					elsewhere. When a user selects this server, their connection to the remote MCP server will
 					go through the Obot gateway.
@@ -75,15 +75,15 @@
 		</button>
 		{#if entity === 'catalog' && profile.current?.groups.includes(Group.ADMIN)}
 			<button
-				class="dark:bg-surface2 hover:bg-surface1 dark:hover:bg-surface3 dark:border-surface3 border-surface2 group bg-background flex cursor-pointer items-center gap-4 rounded-md border px-2 py-4 text-left transition-colors duration-300"
+				class="dark:bg-base-300 hover:bg-base-200 dark:hover:bg-base-400 dark:border-base-400 border-base-300 group bg-base-100 flex cursor-pointer items-center gap-4 rounded-md border px-2 py-4 text-left transition-colors duration-300"
 				onclick={() => onSelectServerType('composite')}
 			>
 				<Layers
-					class="text-on-surface1 size-12 flex-shrink-0 pl-1 transition-colors group-hover:text-inherit"
+					class="text-muted-content size-12 shrink-0 pl-1 transition-colors group-hover:text-inherit"
 				/>
 				<div>
 					<p class="mb-1 text-sm font-semibold">Composite Server</p>
-					<span class="text-on-surface1 block text-xs leading-4">
+					<span class="text-muted-content block text-xs leading-4">
 						This option allows you to combine multiple MCP catalog entries into a single unified
 						server. Users will connect via a single URL that aggregates tools and resources from all
 						component servers.

--- a/ui/user/src/lib/components/mcp/StaticOAuthConfigureModal.svelte
+++ b/ui/user/src/lib/components/mcp/StaticOAuthConfigureModal.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+	import Loading from '$lib/icons/Loading.svelte';
 	import type { MCPServerOAuthCredentialStatus } from '$lib/services/admin/types';
 	import Confirm from '../Confirm.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import SensitiveInput from '../SensitiveInput.svelte';
-	import { LoaderCircle, AlertCircle, Trash2 } from 'lucide-svelte';
+	import { CircleAlert, Trash2 } from 'lucide-svelte';
 
 	interface Props {
 		oauthStatus?: MCPServerOAuthCredentialStatus;
@@ -125,18 +126,18 @@
 	>
 		{#if error}
 			<div class="notification-error flex items-center gap-2">
-				<AlertCircle class="size-6 text-red-500" />
+				<CircleAlert class="size-6 text-error" />
 				<p class="text-sm font-light">{error}</p>
 			</div>
 		{/if}
 
 		{#if oauthStatus?.configured}
-			<p class="text-on-surface1 text-sm font-light">
+			<p class="text-muted-content text-sm font-light">
 				OAuth credentials are configured. To change the client ID or secret, clear the credentials
 				and re-enter all values.
 			</p>
 		{:else}
-			<p class="text-on-surface1 text-sm font-light">
+			<p class="text-muted-content text-sm font-light">
 				This remote MCP server requires OAuth configuration. Provide the client credentials from
 				your OAuth provider.
 			</p>
@@ -144,9 +145,7 @@
 
 		<div class="flex flex-col gap-4">
 			<div class="flex flex-col gap-1">
-				<label for="clientID" class:text-red-500={showRequired && !form.clientID}>
-					Client ID
-				</label>
+				<label for="clientID" class:text-error={showRequired && !form.clientID}> Client ID </label>
 				<input
 					type="text"
 					id="clientID"
@@ -160,7 +159,7 @@
 			</div>
 
 			<div class="flex flex-col gap-1">
-				<label for="clientSecret" class:text-red-500={showRequired && !form.clientSecret}>
+				<label for="clientSecret" class:text-error={showRequired && !form.clientSecret}>
 					Client Secret
 				</label>
 				<SensitiveInput
@@ -179,7 +178,7 @@
 		{#if oauthStatus?.configured && onDelete}
 			<button
 				type="button"
-				class="button-destructive flex items-center gap-1"
+				class="btn btn-error flex items-center gap-1"
 				onclick={() => {
 					dialog?.close();
 					showDeleteConfirm = true;
@@ -196,16 +195,16 @@
 		{#if !oauthStatus?.configured}
 			<div class="flex gap-2">
 				{#if showSkip}
-					<button type="button" class="button" onclick={handleSkip} disabled={loading}>
+					<button type="button" class="btn btn-secondary" onclick={handleSkip} disabled={loading}>
 						Skip
 					</button>
 				{/if}
-				<button type="button" class="button" onclick={handleCancel} disabled={loading}>
+				<button type="button" class="btn btn-secondary" onclick={handleCancel} disabled={loading}>
 					Cancel
 				</button>
-				<button type="button" class="button-primary" onclick={handleSave} disabled={loading}>
+				<button type="button" class="btn btn-primary" onclick={handleSave} disabled={loading}>
 					{#if loading}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 					{:else}
 						Save
 					{/if}

--- a/ui/user/src/lib/components/mcp/ToolNameIssueIcon.svelte
+++ b/ui/user/src/lib/components/mcp/ToolNameIssueIcon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { type ToolNameIssue } from '$lib/services/chat/mcp';
-	import { AlertTriangle } from 'lucide-svelte';
+	import { TriangleAlert } from 'lucide-svelte';
 
 	interface Props {
 		issue: ToolNameIssue | undefined;
@@ -16,10 +16,10 @@
 
 {#if issue}
 	<span
-		class={`inline-flex flex-shrink-0 items-center ${issue.severity === 'error' ? 'text-red-500' : 'text-yellow-500'}`}
+		class={`inline-flex shrink-0 items-center ${issue.severity === 'error' ? 'text-error' : 'text-warning'}`}
 		use:tooltip={{ text: issue.message, placement: 'top', disablePortal }}
 		aria-label={issue.message}
 	>
-		<AlertTriangle class="size-4 flex-shrink-0" />
+		<TriangleAlert class="size-4 shrink-0" />
 	</span>
 {/if}

--- a/ui/user/src/lib/components/mcp/UvxRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/UvxRuntimeForm.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Toggle from '$lib/components/Toggle.svelte';
 	import { MultiValueInput } from '$lib/components/ui/multi-value-input';
 	import type { UVXRuntimeConfig } from '$lib/services/chat/types';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2 } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -111,10 +111,10 @@
 </script>
 
 <div
-	class="dark:bg-surface1 dark:border-surface3 bg-background flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 >
 	<h4 class="text-sm font-semibold">UVX Runtime Configuration</h4>
-	<p class="text-on-surface1 text-xs">Only STDIO servers are supported.</p>
+	<p class="text-muted-content text-xs">Only STDIO servers are supported.</p>
 
 	<!-- Package field (required) -->
 	<div class="flex items-center gap-4">
@@ -125,10 +125,7 @@
 		>
 		<input
 			id="uvx-package"
-			class={twMerge(
-				'text-input-filled dark:bg-background w-full',
-				showRequired?.package && 'error'
-			)}
+			class={twMerge('text-input-filled dark:bg-base-100 w-full', showRequired?.package && 'error')}
 			bind:value={config.package}
 			disabled={readonly}
 			placeholder="e.g. @modelcontextprotocol/server-filesystem"
@@ -149,7 +146,7 @@
 		<label for="uvx-command" class="text-sm font-light">Command</label>
 		<input
 			id="uvx-command"
-			class="text-input-filled dark:bg-background w-full"
+			class="text-input-filled dark:bg-base-100 w-full"
 			bind:value={config.command}
 			disabled={readonly}
 			placeholder="e.g. mcp-server-filesystem"
@@ -169,7 +166,7 @@
 				{#each config.args as _arg, i (i)}
 					<div class="flex items-center gap-2">
 						<input
-							class="text-input-filled dark:bg-background w-full"
+							class="text-input-filled dark:bg-base-100 w-full"
 							bind:value={config.args[i]}
 							disabled={readonly}
 							placeholder="e.g. /path/to/directory"
@@ -181,20 +178,20 @@
 							onpaste={(e) => handlePaste(e, i)}
 						/>
 						{#if !readonly}
-							<button
-								class="icon-button"
+							<IconButton
+								variant="danger"
 								onclick={() => removeArgument(i)}
-								use:tooltip={'Remove argument'}
+								tooltip={{ text: 'Remove argument' }}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					</div>
 				{/each}
 
 				{#if !readonly}
 					<div class="flex justify-end">
-						<button class="button flex items-center gap-1 text-xs" onclick={addArgument}>
+						<button class="btn btn-secondary btn-sm flex items-center gap-1" onclick={addArgument}>
 							<Plus class="size-4" /> Argument
 						</button>
 					</div>
@@ -216,11 +213,11 @@
 				/>
 				<MultiValueInput
 					bind:value={config.egressDomains}
-					class="text-input-filled dark:bg-background"
+					class="text-input-filled dark:bg-base-100"
 					readonly={inputReadonly}
 					placeholder="hit &quot;Enter&quot; to insert"
 				/>
-				<p class="text-on-surface1 text-xs">{egressHelpText}</p>
+				<p class="text-muted-content text-xs">{egressHelpText}</p>
 			</div>
 		</div>
 	{/if}
@@ -239,7 +236,7 @@
 			placeholder="60"
 			bind:value={startupTimeoutSeconds}
 			class={twMerge(
-				'text-input-filled dark:bg-background w-32',
+				'text-input-filled dark:bg-base-100 w-32',
 				showRequired?.startupTimeoutSeconds && 'error'
 			)}
 			disabled={readonly}

--- a/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
@@ -13,7 +13,7 @@
 		toolNameIssue
 	} from '$lib/services/chat/mcp';
 	import ToolNameIssueIcon from '../ToolNameIssueIcon.svelte';
-	import { AlertTriangle } from 'lucide-svelte';
+	import { TriangleAlert } from 'lucide-svelte';
 
 	interface Props {
 		configuringEntry?: MCPCatalogEntry | MCPCatalogServer;
@@ -153,11 +153,11 @@
 	bind:this={dialog}
 	animate="slide"
 	title={`Configure ${configuringEntry?.manifest?.name ?? 'MCP Server'} Tools`}
-	class="bg-surface1 md:w-2xl"
+	class="bg-base-200 md:w-2xl"
 	classes={{ content: 'p-0', header: 'p-4 pb-0' }}
 	onClickOutside={handleClose}
 >
-	<p class="text-on-surface1 px-4 text-xs font-light">
+	<p class="text-muted-content px-4 text-xs font-light">
 		Toggle what tools are available to users of this composite server. Or modify the name or
 		description of a tool; this will override the default name or description provided by the
 		server. It may affect the LLM's ability to understand the tool so be careful when adjusting
@@ -165,7 +165,7 @@
 	</p>
 	<div class="relative flex flex-col gap-2 overflow-x-hidden p-4">
 		<div class="flex flex-col gap-1">
-			<p class="flex items-center gap-1.5 text-xs text-gray-500">
+			<p class="flex items-center gap-1.5 text-xs text-muted-content">
 				<span>Tool name prefix</span>
 				{#if prefixIssue}
 					<ToolNameIssueIcon issue={prefixIssue} disablePortal />
@@ -179,7 +179,7 @@
 				/>
 				<button
 					type="button"
-					class="button px-3 py-1 text-xs"
+					class="btn btn-secondary btn-sm px-3 py-1"
 					onclick={() => {
 						toolPrefix = '';
 					}}
@@ -188,13 +188,11 @@
 				</button>
 			</div>
 			{#if prefixIssue}
-				<p
-					class={`text-xs ${prefixIssue.severity === 'error' ? 'text-red-500' : 'text-yellow-500'}`}
-				>
+				<p class={`text-xs ${prefixIssue.severity === 'error' ? 'text-error' : 'text-warning'}`}>
 					{prefixIssue.message}
 				</p>
 			{:else}
-				<p class="text-on-surface2 text-[11px]">
+				<p class="text-muted-content text-[11px]">
 					Prepended to every tool name exposed by this component. Clear to remove.
 				</p>
 			{/if}
@@ -216,7 +214,7 @@
 			/>
 		</div>
 		<Search
-			class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 			onChange={(val) => (search = val)}
 			placeholder="Search tools..."
 		/>
@@ -232,14 +230,14 @@
 			{@const effectiveName = effectiveToolName(tool.name, tool.overrideName, toolPrefix)}
 			{@const conflict = tool.enabled ? conflictIssue(effectiveName, conflictSet) : undefined}
 			<div
-				class="dark:bg-surface2 dark:border-surface3 bg-background flex items-start gap-2 rounded border border-transparent p-2 shadow-sm"
+				class="dark:bg-base-300 dark:border-base-400 bg-base-100 flex items-start gap-2 rounded border border-transparent p-2 shadow-sm"
 			>
 				<div class="flex min-w-0 grow flex-col gap-2">
 					<div class="flex items-start justify-between gap-2">
 						<div class="min-w-0 flex-1">
 							<div class="flex min-w-0 items-center gap-1.5">
 								<div class="min-w-0 flex-1 truncate text-sm font-medium" title={effectiveName}>
-									{#if toolPrefix}<span class="text-on-surface2">{toolPrefix}</span
+									{#if toolPrefix}<span class="text-muted-content">{toolPrefix}</span
 										>{/if}{currentName}
 								</div>
 								{#if tool.enabled}
@@ -255,7 +253,7 @@
 								</p>
 							{/if}
 						</div>
-						<div class="flex flex-shrink-0 items-center gap-2">
+						<div class="flex shrink-0 items-center gap-2">
 							<!-- Enabled/disabled toggle for this tool -->
 							<Toggle
 								checked={tool.enabled}
@@ -267,7 +265,7 @@
 							/>
 							<button
 								type="button"
-								class="button px-3 py-1 text-xs"
+								class="btn btn-secondary btn-sm px-3 py-1"
 								onclick={() => {
 									// When expanding, initialize inputs with current effective values
 									if (!expandedTools[tool.id]) {
@@ -285,7 +283,7 @@
 
 					{#if isCustomized}
 						<div class="mt-1 flex items-center gap-1 text-[11px] text-amber-600">
-							<AlertTriangle class="size-3 flex-shrink-0" />
+							<TriangleAlert class="size-3 shrink-0" />
 							<p>
 								Modified: This tool has been customized. The description or name has been changed.
 							</p>
@@ -295,12 +293,12 @@
 					{#if expandedTools[tool.id]}
 						<div class="mt-2 flex flex-col gap-2">
 							<div class="flex flex-col gap-1">
-								<p class="text-xs text-gray-500">Tool name</p>
+								<p class="text-xs text-muted-content">Tool name</p>
 								<input class="text-input-filled flex-1 text-sm" bind:value={tool.overrideName} />
 							</div>
 
 							<div class="flex flex-col gap-1">
-								<p class="text-xs text-gray-500">Description</p>
+								<p class="text-xs text-muted-content">Description</p>
 								<textarea
 									class="text-input-filled h-24 resize-none text-xs"
 									bind:value={tool.overrideDescription}
@@ -311,7 +309,7 @@
 							<div class="mt-2 flex justify-end">
 								<button
 									type="button"
-									class="button px-3 py-1 text-xs"
+									class="btn btn-sm btn-secondary px-3 py-1"
 									onclick={() => {
 										tool.overrideName = tool.name;
 										tool.overrideDescription = tool.description;
@@ -326,10 +324,10 @@
 			</div>
 		{/each}
 	</div>
-	<div class="bg-surface1 sticky bottom-0 left-0 mt-4 flex w-full justify-end gap-2 p-4">
-		<button class="button" onclick={handleCancel}>Cancel</button>
+	<div class="bg-base-200 sticky bottom-0 left-0 mt-4 flex w-full justify-end gap-2 p-4">
+		<button class="btn btn-secondary" onclick={handleCancel}>Cancel</button>
 		<button
-			class="button-primary"
+			class="btn btn-primary"
 			disabled={hasBlockingToolNameErrors || prefixIssue?.severity === 'error'}
 			onclick={() => {
 				onSuccess?.();
@@ -341,15 +339,13 @@
 
 <!-- Confirmation Dialog for Unsaved Changes -->
 <ResponsiveDialog bind:this={confirmDialog} title="Discard Changes?" class="max-w-xl">
-	<p class="text-on-surface1 mb-4 text-sm">
+	<p class="text-muted-content mb-4 text-sm">
 		You have unsaved changes for {configuringEntry?.manifest?.name ?? 'MCP Server'} configuration. Are
 		you sure you want to discard these changes?
 	</p>
 
 	<div class="flex justify-end gap-3">
-		<button class="button" onclick={cancelDiscard}>Keep Editing</button>
-		<button class="button-primary bg-red-600 hover:bg-red-700" onclick={confirmDiscard}>
-			Discard Changes
-		</button>
+		<button class="btn btn-secondary" onclick={cancelDiscard}>Keep Editing</button>
+		<button class="btn btn-error" onclick={confirmDiscard}> Discard Changes </button>
 	</div>
 </ResponsiveDialog>

--- a/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import SearchMcpServers from '$lib/components/admin/SearchMcpServers.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		ChatService,
@@ -19,7 +20,6 @@
 	import { mcpServersAndEntries, version } from '$lib/stores';
 	import CatalogConfigureForm, { type LaunchFormData } from '../CatalogConfigureForm.svelte';
 	import CompositeEditTools from './CompositeEditTools.svelte';
-	import { LoaderCircle } from 'lucide-svelte';
 
 	interface Props {
 		catalogId?: string;
@@ -351,13 +351,13 @@
 	bind:this={choiceDialog}
 	animate="slide"
 	title={`Configure ${configuringEntry?.manifest?.name ?? 'MCP Server'} Tools`}
-	class="bg-surface1 md:w-md"
+	class="bg-base-200 md:w-md"
 >
-	<p class="text-on-surface1 text-sm font-light">
+	<p class="text-muted-content text-sm font-light">
 		All <i>{configuringEntry?.manifest?.name ?? 'MCP Server'}</i> tools are enabled by default. Would
 		you like to modify the available tools?
 	</p>
-	<p class="text-on-surface1 mt-2 mb-6 text-sm font-light">
+	<p class="text-muted-content mt-2 mb-6 text-sm font-light">
 		You can also choose to skip and make these changes at a later time.
 	</p>
 
@@ -373,7 +373,7 @@
 			Skip, I'll Do Later
 		</button>
 		<button
-			class="button-primary"
+			class="btn btn-primary"
 			onclick={() => {
 				if (!configuringEntry) return;
 				ready = false;
@@ -403,8 +403,8 @@
 		<div class="flex h-full min-h-32 flex-col items-center justify-center">
 			{#if loading && !ready}
 				<div class="mb-8 flex items-center justify-center gap-1">
-					<LoaderCircle class="text-on-surface1 size-4 animate-spin" />
-					<p class="text-on-surface1 text-sm font-light">Fetching tools...</p>
+					<Loading class="text-muted-content size-4" />
+					<p class="text-muted-content text-sm font-light">Fetching tools...</p>
 				</div>
 			{:else}
 				<div class="mb-6 h-full text-left">
@@ -437,10 +437,10 @@
 						href={oauthURL}
 						rel="external"
 						target="_blank"
-						class="button-primary flex w-full justify-center"
+						class="btn btn-primary flex w-full justify-center"
 					>
 						{#if loading}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Authenticate
 						{/if}
@@ -448,12 +448,12 @@
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 				{:else}
 					<button
-						class="button-primary flex w-full justify-center"
+						class="btn btn-primary flex w-full justify-center"
 						disabled={loading || !!secretBindingEngineError}
 						onclick={handleConfigureToolsInit}
 					>
 						{#if loading}
-							<LoaderCircle class="size-4 animate-spin" />
+							<Loading class="size-4" />
 						{:else}
 							Get Started
 						{/if}
@@ -547,8 +547,8 @@
 >
 	{#snippet loadingContent()}
 		<div class="mb-8 flex items-center justify-center gap-1">
-			<LoaderCircle class="text-on-surface1 size-4 animate-spin" />
-			<p class="text-on-surface1 text-sm font-light">Fetching tools...</p>
+			<Loading class="text-muted-content size-4" />
+			<p class="text-muted-content text-sm font-light">Fetching tools...</p>
 		</div>
 	{/snippet}
 </CatalogConfigureForm>

--- a/ui/user/src/lib/components/messages/Input.svelte
+++ b/ui/user/src/lib/components/messages/Input.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import Loading from '$lib/icons/Loading.svelte';
 	import { type InvokeInput } from '$lib/services';
 	import type { EditorItem } from '$lib/services/editor/index.svelte';
 	import PlaintextEditor from './PlaintextEditor.svelte';
-	import { ArrowUp, LoaderCircle } from 'lucide-svelte';
+	import { ArrowUp } from 'lucide-svelte';
 	import { onMount, type Snippet, tick, untrack } from 'svelte';
+	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
 		id?: string;
@@ -139,15 +141,13 @@
 		type="submit"
 		onclick={() => submit()}
 		{disabled}
-		class="button-colors text-primary h-fit self-end rounded-full p-2 transition-all duration-100 hover:border-none {disabled
-			? 'cursor-not-allowed opacity-50'
-			: ''}"
+		class={twMerge('btn btn-circle btn-primary', disabled ? 'cursor-not-allowed opacity-50' : '')}
 		title={disabled ? 'No model selected' : ''}
 	>
 		{#if readonly}
-			<div class="bg-background m-1.5 h-3 w-3 place-self-center rounded-xs"></div>
+			<div class="bg-base-100 m-1.5 h-3 w-3 place-self-center rounded-xs"></div>
 		{:else if pending}
-			<LoaderCircle class="animate-spin" />
+			<Loading />
 		{:else}
 			<ArrowUp class={disabled ? 'opacity-50' : ''} />
 		{/if}
@@ -160,7 +160,7 @@
 		{@render inputPopover(value)}
 	{/if}
 	<div
-		class="focus-within:ring-primary bg-surface1 mt-4 flex h-fit max-h-[80svh] rounded-2xl focus-within:shadow-md focus-within:ring-1"
+		class="focus-within:ring-primary bg-base-200 mt-4 flex h-fit max-h-[80svh] rounded-2xl focus-within:shadow-md focus-within:ring-1"
 		style="anchor-name: --input-anchor"
 	>
 		<div class="flex min-h-full w-full flex-col" {id}>
@@ -212,6 +212,6 @@
 	}
 
 	.chat-footer {
-		background: linear-gradient(to bottom, rgb(0 0 0 / 0), var(--surface1) 40%);
+		background: linear-gradient(to bottom, rgb(0 0 0 / 0), var(--color-base-200) 40%);
 	}
 </style>

--- a/ui/user/src/lib/components/messages/Message.svelte
+++ b/ui/user/src/lib/components/messages/Message.svelte
@@ -18,19 +18,18 @@
 	import { formatTime } from '$lib/time';
 	import { hasTool } from '$lib/tools';
 	import { isTextFile } from '$lib/utils';
+	import IconButton from '../primitives/IconButton.svelte';
 	import highlight from 'highlight.js';
-	import { Paperclip } from 'lucide-svelte';
+	import { Paperclip, SquarePen } from 'lucide-svelte';
 	import {
 		FileText,
 		Copy,
-		Edit,
 		Info,
 		X,
 		Brain,
 		FileSymlink,
 		Download,
 		TriangleAlert,
-		LoaderCircle,
 		Code
 	} from 'lucide-svelte/icons';
 	import { linear } from 'svelte/easing';
@@ -251,10 +250,13 @@
 			formatted = formatted.replace(/"([^"]+)":/g, '<span class="text-primary">"$1"</span>:');
 
 			// Replace string values (must come after keys)
-			formatted = formatted.replace(/: "([^"]+)"/g, ': <span class="text-on-surface1">"$1"</span>');
+			formatted = formatted.replace(
+				/: "([^"]+)"/g,
+				': <span class="text-muted-content">"$1"</span>'
+			);
 
 			// Replace null
-			formatted = formatted.replace(/: (null)/g, ': <span class="text-on-surface1">$1</span>');
+			formatted = formatted.replace(/: (null)/g, ': <span class="text-muted-content">$1</span>');
 
 			// Replace brackets and braces
 			formatted = formatted.replace(/(".*?")|([{}[\]])/g, (match, stringContent, bracket) => {
@@ -263,7 +265,7 @@
 					return stringContent;
 				}
 				// If it's a bracket/brace outside of strings, wrap it
-				return `<span class="text-on-background">${bracket}</span>`;
+				return `<span class="text-base-content">${bracket}</span>`;
 			});
 
 			return formatted;
@@ -345,16 +347,16 @@
 {#snippet timeAndUsername()}
 	{#if msg.time}
 		<div
-			class="text-on-surface1 mt-1 flex items-center justify-end gap-2 self-end text-xs whitespace-nowrap"
+			class="text-muted-content mt-1 flex items-center justify-end gap-2 self-end text-xs whitespace-nowrap"
 		>
 			{#if msg.userNotice}
 				<span class="inline-flex cursor-help" use:tooltip={msg.userNotice}>
-					<TriangleAlert class="size-3 text-yellow-500" />
+					<TriangleAlert class="size-3 text-warning" />
 				</span>
 			{/if}
 			<span>{formatTime(msg.time, timePreference.timeFormat)}</span>
 			{#if msg.username}
-				<span class="text-on-surface1">•</span>
+				<span class="text-muted-content">•</span>
 				<span class="max-w-[100px] truncate font-medium">by {msg.username?.split(' ')[0]}</span>
 			{/if}
 		</div>
@@ -398,22 +400,21 @@
 		{/if}
 
 		{#if onDebugMessageRun && profile.current.hasAdminAccess?.()}
-			<button
-				class="button-icon"
+			<IconButton
 				onclick={async () => {
 					loadingDebug = true;
 					const response = await AdminService.listCallFramesForDebugRunById(msg.runID);
 					onDebugMessageRun(msg.runID, response);
 					loadingDebug = false;
 				}}
-				use:tooltip={'Debug Message Information'}
+				tooltip={{ text: 'Debug Message Information' }}
 			>
 				{#if loadingDebug}
-					<LoaderCircle class="size-4 animate-spin" />
+					<Loading class="size-4" />
 				{:else}
 					<Code class="size-4" />
 				{/if}
-			</button>
+			</IconButton>
 		{/if}
 	</div>
 {/snippet}
@@ -424,17 +425,17 @@
 		class:contents={!showBubble}
 		class:message-content={renderMarkdown}
 		class={twMerge(
-			'bg-gray-70 text-on-background flex w-full flex-col rounded-2xl px-6 py-3 dark:bg-gray-950 ',
+			'bg-gray-70 text-base-content flex w-full flex-col rounded-2xl px-6 py-3 dark:bg-gray-950 ',
 			classes?.messageBody
 		)}
 	>
 		{#if clearable}
 			<button
-				class="text-on-surface1 absolute top-0 right-0 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+				class="text-muted-content absolute top-0 right-0 hover:text-base-content"
 				aria-label="Clear message"
 				onclick={() => (msg.ignore = true)}
 			>
-				<X class="icon-default" />
+				<X class="size-5" />
 			</button>
 		{/if}
 		{#if msg.oauthURL}
@@ -456,7 +457,7 @@
 	{#if msg.file}
 		<button
 			class={twMerge(
-				'bg-background my-2 flex w-md max-w-full cursor-pointer flex-col rounded-3xl border border-gray-300 text-start text-black shadow-lg md:w-[750px] dark:text-gray-50',
+				'bg-base-100 my-2 flex w-md max-w-full cursor-pointer flex-col rounded-3xl border border-base-300 text-start text-base-content shadow-lg md:w-[750px]',
 				!msg.file?.filename && !msg.aborted && !msg.done && 'cursor-wait'
 			)}
 			disabled={!msg.file?.filename}
@@ -468,17 +469,17 @@
 					{#if msg.file?.filename}
 						<span use:overflowToolTip>{msg.file.filename}</span>
 					{:else}
-						<span class="text-on-surface1">...</span>
+						<span class="text-muted-content">...</span>
 					{/if}
 				</div>
 			</div>
 			<div class="relative" transition:slide={{ axis: 'y', duration: 50 }}>
 				{#if compactFilePreview}
-					<div class="font-body text-md p-5 whitespace-pre-wrap text-gray-700 dark:text-gray-300">
+					<div class="font-body text-md p-5 whitespace-pre-wrap text-muted-content">
 						{msg.file.content.split('\n').splice(0, 6).join('\n')}
 					</div>
 				{:else}
-					<div class="font-body text-md p-5 whitespace-pre-wrap text-gray-700 dark:text-gray-300">
+					<div class="font-body text-md p-5 whitespace-pre-wrap text-muted-content">
 						{animatedFileContent}
 					</div>
 				{/if}
@@ -492,13 +493,13 @@
 		{#if msg.file.content && isTextFile(msg.file.filename)}
 			<div class="flex gap-2">
 				<div>
-					<button
-						use:tooltip={'Copy file contents to clipboard'}
-						class="icon-button-small"
+					<IconButton
+						tooltip={{ text: 'Copy file contents to clipboard' }}
+						class="btn-sm"
 						onclick={() => copyContentToClipboard(msg.file?.content)}
 					>
-						<Copy class="h-4 w-4" />
-					</button>
+						<Copy class="size-4" />
+					</IconButton>
 				</div>
 			</div>
 		{/if}
@@ -509,11 +510,11 @@
 	{#if msg.explain}
 		<div
 			role="none"
-			class="bg-background -m-6 mt-2 -mb-4 flex
+			class="bg-base-100 -m-6 mt-2 -mb-4 flex
 		 flex-col divide-y
-		 divide-gray-300 rounded-3xl
-		 border border-gray-300
-		 text-black shadow-lg dark:text-gray-50"
+		 divide-base-300 rounded-3xl
+		 border border-base-300
+		 text-base-content shadow-lg"
 		>
 			<div class="flex gap-2 px-5 py-4">
 				<Paperclip />
@@ -527,7 +528,7 @@
 					}}>{msg.explain.filename}</button
 				>
 			</div>
-			<div class="font-body text-md p-5 whitespace-pre-wrap text-gray-700 dark:text-gray-300">
+			<div class="font-body text-md p-5 whitespace-pre-wrap text-muted-content">
 				{msg.explain.selection}
 			</div>
 		</div>
@@ -539,7 +540,7 @@
 		<p class="p-0 text-xs font-semibold">{title}</p>
 		<pre
 			transition:slide={{ duration: 300 }}
-			class="default-scrollbar-thin bg-surface1 text-on-background mt-0! max-h-[300px] w-fit max-w-full overflow-auto rounded-lg px-4 py-2 text-xs break-all whitespace-pre-wrap">{@html formatJson(
+			class="default-scrollbar-thin bg-base-200 text-base-content mt-0! max-h-[300px] w-fit max-w-full overflow-auto rounded-lg px-4 py-2 text-xs break-all whitespace-pre-wrap">{@html formatJson(
 				stringifiedJson ?? ''
 			)}</pre>
 	</div>
@@ -596,20 +597,20 @@
 									const img = e.currentTarget as HTMLImageElement;
 									img.style.display = 'none';
 									const fallbackDiv = document.createElement('div');
-									fallbackDiv.className = 'text-on-surface1 text-xs';
+									fallbackDiv.className = 'text-muted-content text-xs';
 									fallbackDiv.textContent = '[Image Failed to Load.]';
 									img.parentNode?.insertBefore(fallbackDiv, img.nextSibling);
 								}}
 							/>
 						</button>
 						<div class="flex gap-2">
-							<button
-								class="icon-button-small"
-								use:tooltip={'Add to Workspace Files'}
+							<IconButton
+								class="btn-sm"
+								tooltip={{ text: 'Add to Workspace Files' }}
 								onclick={() => addImageContentInEditor(content)}
 							>
 								<FileSymlink class="size-4" />
-							</button>
+							</IconButton>
 							{@render downloadImageButton(
 								`data:${content.mimeType};base64,${content.data}`,
 								`image-${Date.now()}.${content.mimeType.split('/')[1]}`
@@ -632,7 +633,7 @@
 		{/if}
 	{/if}
 	{#if shell.input && shell.output}
-		<div class="mt-1 rounded-3xl bg-gray-100 p-5 dark:bg-gray-900 dark:text-gray-50">
+		<div class="mt-1 rounded-3xl bg-base-300 p-5 dark:bg-base-200 text-base-content">
 			<div class="pb-1 font-mono">
 				> {shell.input}
 			</div>
@@ -701,7 +702,7 @@
 						<div class="inline-flex flex-col gap-2">
 							{#each msg.fields[0].options as option, i (i)}
 								<button
-									class="button-primary"
+									class="btn btn-primary"
 									onclick={() => (promptCredentials[msg.fields![0].name] = option)}
 								>
 									{option}
@@ -709,7 +710,7 @@
 							{/each}
 							{#if onSendCredentialsCancel}
 								<button
-									class="button-secondary hover:bg-surface3 border-transparent"
+									class="btn btn-secondary hover:bg-base-400 border-transparent"
 									type="button"
 									onclick={() => onSendCredentialsCancel(msg.promptId ?? '')}
 								>
@@ -726,40 +727,43 @@
 						{#if field.options}
 							<div class="flex flex-col gap-2">
 								{#each field.options as option, i (i)}
-									<button class="button" onclick={() => (promptCredentials[field.name] = option)}>
+									<button
+										class="btn btn-secondary"
+										onclick={() => (promptCredentials[field.name] = option)}
+									>
 										{option}
 									</button>
 								{/each}
 							</div>
 						{:else}
 							<input
-								class="bg-background dark:bg-surface2 rounded-lg p-2 outline-hidden"
+								class="bg-base-100 dark:bg-base-300 rounded-lg p-2 outline-hidden"
 								type={field.sensitive ? 'password' : 'text'}
 								name={field.name}
 								bind:value={promptCredentials[field.name]}
 							/>
 						{/if}
 						{#if field.description}
-							<p class="text-on-surface1 text-xs">{field.description}</p>
+							<p class="text-muted-content text-xs">{field.description}</p>
 						{/if}
 					</div>
 				{/each}
 
-				<span class="text-gray mt-1 flex grow items-end self-end text-sm">
+				<span class="text-muted-content mt-1 flex grow items-end self-end text-sm">
 					*The submitted contents are not visible to AI.
 				</span>
 
 				<div class="item-center flex gap-2 self-end">
 					{#if onSendCredentialsCancel}
 						<button
-							class="button-secondary"
+							class="btn btn-secondary"
 							type="button"
 							onclick={() => onSendCredentialsCancel(msg.promptId ?? '')}
 						>
 							Cancel
 						</button>
 					{/if}
-					<button class="button-primary" type="submit">Submit</button>
+					<button class="btn btn-primary" type="submit">Submit</button>
 				</div>
 			{/if}
 		</form>
@@ -778,7 +782,7 @@
 						href={citationURL(url)}
 						rel="external"
 						target="_blank"
-						class="flex w-fit items-center gap-2 rounded-full bg-gray-100 p-2 text-sm dark:bg-gray-900"
+						class="flex w-fit items-center gap-2 rounded-full bg-base-300 p-2 text-sm dark:bg-gray-900"
 						transition:fly={{ y: 100, delay: 50 * i, duration: 250 }}
 					>
 						<img
@@ -804,7 +808,7 @@
 	<div
 		class={twMerge(
 			'group relative flex items-start gap-3',
-			isPrompt && '-m-5 rounded-3xl bg-gray-100 p-5 dark:bg-gray-950',
+			isPrompt && '-m-5 rounded-3xl bg-base-300 p-5',
 			isPrompt && classes?.prompt,
 			classes?.root
 		)}
@@ -830,24 +834,24 @@
 				{#if !msg.sent && msg.done && !msg.toolCall && msg.time && content && !animating && content.length > 0}
 					<div class={twMerge('mt-2 -ml-1 flex gap-2', classes?.messageActions)}>
 						<div>
-							<button
-								use:tooltip={showCopied ? 'Copied!' : 'Copy message to clipboard'}
-								class="icon-button-small"
+							<IconButton
+								tooltip={{ text: showCopied ? 'Copied!' : 'Copy message to clipboard' }}
+								class="btn-sm"
 								onclick={() => copyContentToClipboard()}
 							>
-								<Copy class="h-4 w-4" />
-							</button>
+								<Copy class="size-4" />
+							</IconButton>
 						</div>
 
 						{#if !disableMessageToEditor}
 							<div>
-								<button
-									use:tooltip={'Open message in editor'}
-									class="icon-button-small"
+								<IconButton
+									tooltip={{ text: 'Open message in editor' }}
+									class="btn-sm"
 									onclick={() => openContentInEditor()}
 								>
-									<Edit class="h-4 w-4" />
-								</button>
+									<SquarePen class="size-4" />
+								</IconButton>
 							</div>
 						{/if}
 					</div>
@@ -855,7 +859,7 @@
 
 				{#if isAbortedContent}
 					<div class="mt-2 flex w-full items-center gap-1" class:justify-end={msg.sent}>
-						<div class="flex-shrink-0">
+						<div class="shrink-0">
 							<Info class="size-3" />
 						</div>
 						<p class="mb-0 text-xs">
@@ -871,9 +875,9 @@
 <MemoriesDialog bind:this={memoriesDialog} {project} />
 
 {#snippet downloadImageButton(data: string, filename: string)}
-	<button
-		class="icon-button-small"
-		use:tooltip={'Download'}
+	<IconButton
+		class="btn-sm"
+		tooltip={{ text: 'Download' }}
 		onclick={() => {
 			const link = document.createElement('a');
 			link.href = data;
@@ -884,7 +888,7 @@
 		}}
 	>
 		<Download class="size-4" />
-	</button>
+	</IconButton>
 {/snippet}
 
 <style lang="postcss">

--- a/ui/user/src/lib/components/messages/MessageIcon.svelte
+++ b/ui/user/src/lib/components/messages/MessageIcon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import ProfileIcon from '$lib/components/profile/ProfileIcon.svelte';
 	import type { Message } from '$lib/services';
-	import { AlertCircle } from 'lucide-svelte';
+	import { CircleAlert } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -21,10 +21,10 @@
 		{#if msg.icon === 'Profile'}
 			<ProfileIcon />
 		{:else if msg.icon === 'Error'}
-			<AlertCircle class="size-4 text-red-500 md:size-6" />
+			<CircleAlert class="size-4 text-error md:size-6" />
 		{:else}
 			<img
-				class="text-primary size-4 rounded-md bg-gray-100 p-1 md:size-6"
+				class="text-primary size-4 rounded-md bg-base-300 p-1 md:size-6"
 				src={msg.icon}
 				alt="message icon"
 			/>

--- a/ui/user/src/lib/components/messages/ToolConfirmBar.svelte
+++ b/ui/user/src/lib/components/messages/ToolConfirmBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import popover from '$lib/actions/popover.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		ChatService,
 		type Project,
@@ -7,7 +8,7 @@
 		type ToolConfirmDecision,
 		type Message
 	} from '$lib/services';
-	import { ChevronDown, LoaderCircle } from 'lucide-svelte/icons';
+	import { ChevronDown } from 'lucide-svelte/icons';
 	import { slide } from 'svelte/transition';
 
 	interface Props {
@@ -83,16 +84,16 @@
 {#if current}
 	{@const dropdown = popover({ placement: 'bottom-end' })}
 	<div
-		class="bg-surface1 text-on-background mb-2 w-full max-w-[900px] overflow-hidden rounded-xl px-5 shadow-lg"
+		class="bg-base-200 text-base-content mb-2 w-full max-w-[900px] overflow-hidden rounded-xl px-5 shadow-lg"
 	>
 		{#key current.confirm.id}
 			<div class="flex min-h-[48px] items-center gap-3 px-4 py-2.5">
 				<div class="flex min-w-0 flex-1 items-center gap-2">
-					<span class="text-on-background text-sm font-medium">{current.displayName}</span>
+					<span class="text-base-content text-sm font-medium">{current.displayName}</span>
 
 					{#if current.confirm.input}
 						<button
-							class="text-on-surface1 hover:text-on-background flex items-center gap-1 text-xs"
+							class="text-muted-content hover:text-base-content flex items-center gap-1 text-xs"
 							onclick={() => (isExpanded = !isExpanded)}
 						>
 							{#if isExpanded}Hide details{:else}Show details{/if}
@@ -100,22 +101,22 @@
 					{/if}
 
 					{#if isSubmitted}
-						<LoaderCircle class="text-on-surface1 size-5 animate-spin" />
+						<Loading class="text-muted-content" />
 					{/if}
 				</div>
 
-				<div class="flex flex-shrink-0 items-center gap-2">
+				<div class="flex shrink-0 items-center gap-2">
 					{#if !isSubmitted}
 						<button
-							class="text-on-surface1 hover:bg-surface2 hover:text-on-background rounded px-3 py-1 text-xs transition-colors"
+							class="text-muted-content hover:bg-base-300 hover:text-base-content rounded px-3 py-1 text-xs transition-colors"
 							onclick={() => handleConfirm(current.confirm, 'deny')}
 						>
 							Deny
 						</button>
 
-						<div class="bg-surface2 border-surface2 flex rounded-lg border">
+						<div class="bg-base-300 border-base-300 flex rounded-lg border">
 							<button
-								class="text-on-background hover:bg-surface3 border-surface3 flex flex-1 items-center justify-center gap-1 rounded-l-lg rounded-r-none border-r px-3 py-1 text-xs transition-colors hover:opacity-80"
+								class="text-muted-content hover:bg-base-400 border-base-400 flex flex-1 items-center justify-center gap-1 rounded-l-lg rounded-r-none border-r px-3 py-1 text-xs transition-colors hover:opacity-80"
 								onclick={() => handleConfirm(current.confirm, 'approve')}
 							>
 								Allow
@@ -123,19 +124,19 @@
 
 							<button
 								use:dropdown.ref
-								class="hover:bg-surface3 flex items-center justify-center rounded-l-none rounded-r-lg px-2 py-1 transition-colors hover:opacity-80"
+								class="hover:bg-base-400 flex items-center justify-center rounded-l-none rounded-r-lg px-2 py-1 transition-colors hover:opacity-80"
 								onclick={() => dropdown.toggle()}
 							>
-								<ChevronDown class="text-on-background size-3" />
+								<ChevronDown class="text-base-content size-3" />
 							</button>
 						</div>
 
 						<div
 							use:dropdown.tooltip
-							class="bg-surface2 border-surface3 z-50 flex min-w-[180px] flex-col rounded-lg border py-1 shadow-xl"
+							class="bg-base-300 border-base-400 z-50 flex min-w-[180px] flex-col rounded-lg border py-1 shadow-xl"
 						>
 							<button
-								class="text-on-background hover:bg-surface3 px-3 py-1.5 text-left text-xs transition-colors"
+								class="text-base-content hover:bg-base-400 px-3 py-1.5 text-left text-xs transition-colors"
 								onclick={() => {
 									dropdown.toggle(false);
 									handleConfirm(current.confirm, 'approve_thread', current.confirm.toolName);
@@ -146,7 +147,7 @@
 
 							{#if current.serverPrefix}
 								<button
-									class="text-on-background hover:bg-surface3 px-3 py-1.5 text-left text-xs transition-colors"
+									class="text-base-content hover:bg-base-400 px-3 py-1.5 text-left text-xs transition-colors"
 									onclick={() => {
 										dropdown.toggle(false);
 										handleConfirm(current.confirm, 'approve_thread', current.serverPrefix + '*');
@@ -157,7 +158,7 @@
 							{/if}
 
 							<button
-								class="text-on-background hover:bg-surface3 px-3 py-1.5 text-left text-xs transition-colors"
+								class="text-base-content hover:bg-base-400 px-3 py-1.5 text-left text-xs transition-colors"
 								onclick={() => {
 									dropdown.toggle(false);
 									handleConfirm(current.confirm, 'approve_thread', '*');
@@ -171,8 +172,8 @@
 			</div>
 
 			{#if isExpanded && current.confirm.input}
-				<div class="border-surface2 border-t px-4 py-3" transition:slide={{ duration: 150 }}>
-					<pre class="bg-background text-on-background max-h-48 overflow-auto rounded p-3 text-xs">
+				<div class="border-base-300 border-t px-4 py-3" transition:slide={{ duration: 150 }}>
+					<pre class="bg-base-200 text-base-content max-h-48 overflow-auto rounded p-3 text-xs">
 {formatJson(current.confirm.input)}</pre>
 				</div>
 			{/if}

--- a/ui/user/src/lib/components/nanobot/ConfirmDiffWorkflow.svelte
+++ b/ui/user/src/lib/components/nanobot/ConfirmDiffWorkflow.svelte
@@ -140,7 +140,7 @@
 						{:else}
 							Version {selectedVersion.toFixed(1)}
 							{#if selectedVersion === latestVersion}
-								<span class="text-base-content/50 text-xs font-light">(latest)</span>
+								<span class="text-muted-content text-xs font-light">(latest)</span>
 							{/if}
 						{/if}
 					</h4>

--- a/ui/user/src/lib/components/nanobot/Elicitation.svelte
+++ b/ui/user/src/lib/components/nanobot/Elicitation.svelte
@@ -312,7 +312,7 @@
 									? 'bg-primary text-primary-content'
 									: hasAnswer(i)
 										? 'bg-success/20 text-success ring-success/30 ring-1'
-										: 'bg-base-200 text-base-content/40 hover:bg-base-300'
+										: 'bg-base-200 text-muted-content hover:bg-base-300'
 							)}
 						>
 							{q.header || q.question}
@@ -329,13 +329,14 @@
 						<div class="bg-base-200/60 flex items-start justify-between rounded-lg px-3 py-2">
 							<div class="min-w-0 flex-1">
 								<div class="flex items-baseline gap-1.5">
-									<span class="text-base-content/40 text-xs font-bold">{i + 1}.</span>
+									<span class="text-muted-content text-xs font-bold">{i + 1}.</span>
 									<span class="text-sm font-medium">{q.header || q.question}</span>
 								</div>
 								<p
-									class="ml-4 text-sm {hasAnswer(i)
-										? 'text-base-content/70'
-										: 'text-base-content/30 italic'}"
+									class={twMerge(
+										'ml-4 text-sm',
+										hasAnswer(i) ? 'text-base-content/70' : 'text-base-content/30 italic'
+									)}
 								>
 									{getAnswerSummary(i)}
 								</p>
@@ -361,7 +362,7 @@
 					</button>
 					<button
 						type="button"
-						class="btn btn-ghost btn-sm text-base-content/40"
+						class="btn btn-ghost btn-sm text-muted-content"
 						onclick={handleDecline}>Cancel</button
 					>
 					<button type="button" class="btn btn-primary btn-sm" onclick={handleQuestionSubmit}
@@ -377,7 +378,7 @@
 				{/if}
 				<p class="mb-2 text-sm font-medium">{q.question}</p>
 				{#if q.multiple}
-					<p class="text-base-content/40 mb-2 text-xs">Select all that apply</p>
+					<p class="text-muted-content mb-2 text-xs">Select all that apply</p>
 				{/if}
 
 				<!-- Options -->
@@ -386,8 +387,12 @@
 						{@const isSelected = selectedOptions.get(currentStep)?.has(option.label) ?? false}
 						<button
 							type="button"
-							class="flex w-full cursor-pointer items-start gap-2.5 rounded-lg border p-2.5 text-left transition-colors
-								{isSelected ? 'border-primary bg-primary/10' : 'border-base-300 hover:border-base-content/20'}"
+							class={twMerge(
+								'flex w-full cursor-pointer items-start gap-2.5 rounded-lg border p-2.5 text-left transition-colors',
+								isSelected
+									? 'border-primary bg-primary/10'
+									: 'border-base-300 hover:border-base-content/20'
+							)}
 							onclick={() => toggleOption(currentStep, option.label)}
 						>
 							{#if q.multiple}
@@ -408,7 +413,7 @@
 							<div class="min-w-0 flex-1">
 								<span class="text-sm font-medium">{option.label}</span>
 								{#if option.description}
-									<p class="text-base-content/50 text-xs">{option.description}</p>
+									<p class="text-muted-content text-xs">{option.description}</p>
 								{/if}
 							</div>
 						</button>
@@ -420,10 +425,12 @@
 				<div
 					role="button"
 					tabindex="0"
-					class="mt-1.5 flex w-full cursor-pointer items-start gap-2.5 rounded-lg border p-2.5 text-left transition-colors
-						{isCustomSelected
-						? 'border-primary bg-primary/10'
-						: 'border-base-300 hover:border-base-content/20'}"
+					class={twMerge(
+						'mt-1.5 flex w-full cursor-pointer items-start gap-2.5 rounded-lg border p-2.5 text-left transition-colors',
+						isCustomSelected
+							? 'border-primary bg-primary/10'
+							: 'border-base-300 hover:border-base-content/20'
+					)}
 					onclick={() => toggleCustomInput(currentStep)}
 					onkeydown={(e) => {
 						if (e.key === 'Enter') toggleCustomInput(currentStep);
@@ -498,7 +505,7 @@
 						{:else}
 							<button
 								type="button"
-								class="btn btn-ghost btn-sm text-base-content/40"
+								class="btn btn-ghost btn-sm text-muted-content"
 								onclick={nextStep}
 								disabled={currentStep === questions.length - 1}
 							>
@@ -605,14 +612,14 @@
 									<div
 										class="tooltip tooltip-right border-transparent bg-transparent p-0 shadow-none"
 									>
-										<div class="tooltip-content text-left break-words">
+										<div class="tooltip-content text-left wrap-break-word">
 											<p class="text-xs font-light">{schema.description}</p>
 										</div>
 										{#if optional}
-											<span class="text-base-content/40">(optional)</span>
+											<span class="text-muted-content">(optional)</span>
 										{/if}
 										<div class="btn btn-circle size-4 bg-transparent">
-											<Info class="text-base-content/40 size-4" />
+											<Info class="text-muted-content size-4" />
 										</div>
 									</div>
 								{/if}

--- a/ui/user/src/lib/components/nanobot/FileEditor.svelte
+++ b/ui/user/src/lib/components/nanobot/FileEditor.svelte
@@ -327,9 +327,10 @@
 >
 	<!-- Resize handle -->
 	<div
-		class="hover:bg-base-300/75 absolute top-0 left-0 z-10 h-full w-1 cursor-ew-resize transition-colors {isResizing
-			? 'bg-base-300/75'
-			: 'bg-transparent'}"
+		class={twMerge(
+			'hover:bg-base-300/75 absolute top-0 left-0 z-10 h-full w-1 cursor-ew-resize transition-colors',
+			isResizing ? 'bg-base-300/75' : 'bg-transparent'
+		)}
 		onmousedown={handleResizeStart}
 		onkeydown={handleResizeKeydown}
 		role="slider"
@@ -399,7 +400,7 @@
 				{:else if isPdf}
 					<PDF class="h-full" base64={resource.blob} classes={{ iframe: 'h-full' }} />
 				{:else}
-					<div class="text-base-content/40 italic">This file could not be displayed.</div>
+					<div class="text-muted-content italic">This file could not be displayed.</div>
 				{/if}
 			{:else if isSvg && content}
 				<!-- SVG as text (no blob) - display as image -->
@@ -431,11 +432,9 @@
 </div>
 
 {#snippet closeButton()}
-	<button
-		class="btn md:btn-sm btn-square md:tooltip md:tooltip-left"
-		data-tip="Close"
-		onclick={onClose}
-	>
-		<X class="size-5 md:size-4" />
-	</button>
+	<div class="md:tooltip md:tooltip-left" data-tip="Close">
+		<button class="btn md:btn-sm btn-square" onclick={onClose}>
+			<X class="size-5 md:size-4" />
+		</button>
+	</div>
 {/snippet}

--- a/ui/user/src/lib/components/nanobot/FileItem.svelte
+++ b/ui/user/src/lib/components/nanobot/FileItem.svelte
@@ -115,7 +115,7 @@
 	{#if compact}
 		<button
 			class={twMerge(
-				'btn btn-ghost btn-circle text-base-content/50 size-10 self-center',
+				'btn btn-ghost btn-circle text-muted-content size-10 self-center',
 				isSelected ? 'bg-base-200 hover:bg-base-200 hover:border-base-200' : 'hover:bg-base-300'
 			)}
 			use:tooltip={{

--- a/ui/user/src/lib/components/nanobot/MessageInput.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageInput.svelte
@@ -229,7 +229,7 @@
 				onpaste={handlePaste}
 				oninput={autoResize}
 				{placeholder}
-				class="placeholder:text-base-content/50 max-h-32 min-h-[2.5rem] w-full resize-none bg-transparent p-1 text-sm leading-6 outline-none"
+				class="placeholder:text-muted-content max-h-32 min-h-10 w-full resize-none bg-transparent p-1 text-sm leading-6 outline-none"
 				rows="1"
 				bind:this={textareaRef}
 			></textarea>
@@ -240,7 +240,7 @@
 					transition:slide={{ axis: 'y', duration: 150 }}
 				>
 					<div class="flex items-center gap-1">
-						<CircleAlert class="text-error size-3 flex-shrink-0" />
+						<CircleAlert class="text-error size-3 shrink-0" />
 						<div class="flex flex-col gap-1">
 							{#each uploadErrors as error, i (i)}
 								{error}
@@ -311,7 +311,7 @@
 					{#if onCancel && disabled}
 						<button
 							onclick={onCancel}
-							class="btn btn-sm btn-primary h-9 w-9 rounded-full p-0"
+							class="btn btn-sm btn-primary size-9 btn-circle p-0"
 							aria-label="Stop generating"
 						>
 							<Square class="size-4" />
@@ -319,7 +319,7 @@
 					{:else}
 						<button
 							type="submit"
-							class="btn btn-sm btn-primary h-9 w-9 rounded-full p-0"
+							class="btn btn-sm btn-primary size-9 btn-circle p-0"
 							disabled={disabled || isUploading || !message.trim()}
 							aria-label="Send message"
 						>

--- a/ui/user/src/lib/components/nanobot/MessageItemResource.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageItemResource.svelte
@@ -4,7 +4,7 @@
 	import type { ChatMessageItemResource } from '$lib/services/nanobot/types';
 	import { isCancellationError } from '$lib/services/nanobot/utils';
 	import PDF from './PDF.svelte';
-	import { AlertCircle, AlertTriangle } from 'lucide-svelte';
+	import { CircleAlert, TriangleAlert } from 'lucide-svelte';
 
 	interface Props {
 		item: ChatMessageItemResource;
@@ -78,13 +78,13 @@
 
 {#if isError && isCancelledError(item.resource.text)}
 	<div class="my-4 flex items-center gap-1 text-xs italic">
-		<AlertCircle class="size-3" />
+		<CircleAlert class="size-3" />
 		Aborted. This message has been discarded.
 	</div>
 {:else if isError}
 	<div class="border-error/20 bg-error/10 mt-3 mb-3 rounded-lg border p-3">
 		<div class="mb-2 flex items-center gap-2 text-sm">
-			<AlertTriangle class="text-error h-4 w-4" />
+			<TriangleAlert class="text-error h-4 w-4" />
 			<span class="text-error font-medium">Error</span>
 		</div>
 		{#if item.resource.text}
@@ -99,7 +99,7 @@
 		<div class="card-body">
 			<div class="flex items-start gap-3">
 				<!-- Large icon -->
-				<div class="flex-shrink-0">
+				<div class="shrink-0">
 					<div class="bg-primary/10 flex h-12 w-12 items-center justify-center rounded-xl text-2xl">
 						{getFileIcon(item.resource.mimeType)}
 					</div>
@@ -125,7 +125,7 @@
 					<div class="mt-2 flex items-center gap-2">
 						<span class="badge badge-ghost badge-xs">{item.resource.mimeType}</span>
 						{#if item.resource.size}
-							<span class="text-base-content/50 text-xs">
+							<span class="text-muted-content text-xs">
 								{formatFileSize(item.resource.size)}
 							</span>
 						{/if}
@@ -167,7 +167,7 @@
 					<span class="badge badge-ghost badge-sm">{formatFileSize(item.resource.size)}</span>
 				{/if}
 				{#if item.resource.annotations?.lastModified}
-					<span class="text-base-content/50 text-xs">
+					<span class="text-muted-content text-xs">
 						Modified: {new Date(item.resource.annotations.lastModified).toLocaleDateString()}
 					</span>
 				{/if}
@@ -188,11 +188,11 @@
 						<div class="mb-4 text-6xl">{getFileIcon(item.resource.mimeType)}</div>
 						<p class="text-base-content/60">Preview not available for this resource type</p>
 						{#if item.resource.blob}
-							<p class="text-base-content/40 mt-2 text-sm">
+							<p class="text-muted-content mt-2 text-sm">
 								Resource data is available but cannot be previewed
 							</p>
 						{:else}
-							<p class="text-base-content/40 mt-2 text-sm">No resource data available</p>
+							<p class="text-muted-content mt-2 text-sm">No resource data available</p>
 						{/if}
 					</div>
 				{/if}

--- a/ui/user/src/lib/components/nanobot/MessageItemResourceLink.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageItemResourceLink.svelte
@@ -4,6 +4,7 @@
 	import type { ChatMessageItemResourceLink, ResourceContents } from '$lib/services/nanobot/types';
 	import { isSafeImageMimeType } from '$lib/services/nanobot/utils';
 	import PDF from './PDF.svelte';
+	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
 		item: ChatMessageItemResourceLink;
@@ -167,9 +168,12 @@
 
 <button
 	type="button"
-	class="mb-2 inline-flex max-w-full items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors {isMissing
-		? 'border-error/30 bg-error/10 text-error hover:bg-error/20'
-		: 'border-base-300 bg-base-200 hover:bg-base-300'}"
+	class={twMerge(
+		'mb-2 inline-flex max-w-full items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors',
+		isMissing
+			? 'border-error/30 bg-error/10 text-error hover:bg-error/20'
+			: 'border-base-300 bg-base-200 hover:bg-base-300'
+	)}
 	onclick={handleClick}
 	title={displayName}
 >
@@ -233,7 +237,7 @@
 			{:else}
 				<div class="py-8 text-center">
 					<p class="text-base-content/60">Preview not available for this resource type</p>
-					<p class="text-base-content/40 mt-2 text-sm break-all">{item.uri}</p>
+					<p class="text-muted-content mt-2 text-sm break-all">{item.uri}</p>
 				</div>
 			{/if}
 		</div>

--- a/ui/user/src/lib/components/nanobot/MessageItemText.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageItemText.svelte
@@ -2,7 +2,7 @@
 	import { toHTMLFromMarkdownWithNewTabLinks } from '$lib/markdown';
 	import type { ChatMessageItemText } from '$lib/services/nanobot/types';
 	import { CANCELLATION_PHRASE_CLIENT } from '$lib/services/nanobot/utils';
-	import { AlertCircle } from 'lucide-svelte';
+	import { CircleAlert } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -34,8 +34,8 @@
 		{@html renderedContent}
 	{/if}
 	{#if hasClientCancellation}
-		<div class="text-base-content/50 my-4 flex items-center gap-1 text-xs italic">
-			<AlertCircle class="size-3" />
+		<div class="text-muted-content my-4 flex items-center gap-1 text-xs italic">
+			<CircleAlert class="size-3" />
 			Aborted. This message has been discarded.
 		</div>
 	{/if}

--- a/ui/user/src/lib/components/nanobot/MessageItemTool.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageItemTool.svelte
@@ -210,7 +210,7 @@
 			{:else if item.output}
 				<!-- Already has output but collapsed: show nothing here (lazy) -->
 			{:else}
-				<div class="text-base-content/50 flex items-center gap-2 text-xs italic">
+				<div class="text-muted-content flex items-center gap-2 text-xs italic">
 					<span class="loading loading-xs loading-spinner"></span>
 					Running...
 				</div>

--- a/ui/user/src/lib/components/nanobot/MessageResources.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageResources.svelte
@@ -2,6 +2,7 @@
 	import { getFileIcon } from '$lib/components/nanobot/MessageAttachments.svelte';
 	import type { Resource, ChatMessage } from '$lib/services/nanobot/types';
 	import { Library } from 'lucide-svelte';
+	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
 		disabled?: boolean;
@@ -91,11 +92,10 @@
 				<li>
 					<button
 						type="button"
-						class="flex items-center space-x-2 {selectedResources.some(
-							(r) => r.uri === resource.uri
-						)
-							? 'active'
-							: ''}"
+						class={twMerge(
+							'flex items-center space-x-2',
+							selectedResources.some((r) => r.uri === resource.uri) ? 'active' : ''
+						)}
 						onclick={() => toggleResource(resource)}
 					>
 						<span class="text-base">{getFileIcon(resource.mimeType)}</span>

--- a/ui/user/src/lib/components/nanobot/MessageSlashPrompts.svelte
+++ b/ui/user/src/lib/components/nanobot/MessageSlashPrompts.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Prompt } from '$lib/services/nanobot/types';
+	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
 		prompts: Prompt[];
@@ -60,10 +61,10 @@
 		{#each filteredPrompts as prompt, index (prompt.name)}
 			<button
 				type="button"
-				class="hover:bg-base-200 w-full px-4 py-2 text-left transition-colors {index ===
-				selectedCommandIndex
-					? 'bg-primary/10'
-					: ''}"
+				class={twMerge(
+					'hover:bg-base-200 w-full px-4 py-2 text-left transition-colors',
+					index === selectedCommandIndex ? 'bg-primary/10' : ''
+				)}
 				onclick={() => executeSlashCommand(prompt)}
 			>
 				<div class="flex items-center space-x-2">
@@ -81,7 +82,7 @@
 		{/each}
 
 		{#if filteredPrompts.length === 0}
-			<div class="text-base-content/50 px-4 py-2 text-sm">
+			<div class="text-muted-content px-4 py-2 text-sm">
 				No commands found for "{slashQuery}"
 			</div>
 		{/if}

--- a/ui/user/src/lib/components/nanobot/ProjectStartThread.svelte
+++ b/ui/user/src/lib/components/nanobot/ProjectStartThread.svelte
@@ -68,7 +68,7 @@
 							<h1 class="w-full text-center text-xl font-semibold md:text-3xl">
 								What would you like to work on?
 							</h1>
-							<p class="text-base-content/50 md:text-md text-center text-sm font-light">
+							<p class="text-muted-content md:text-md text-center text-sm font-light">
 								Choose an entry point or begin a conversation to get started.
 							</p>
 						</div>
@@ -81,7 +81,7 @@
 							>
 								<Sparkles class="mb-4 size-5" />
 								<h3 class="text-base font-semibold">Create a workflow</h3>
-								<p class="text-base-content/50 text-sm font-light">
+								<p class="text-muted-content text-sm font-light">
 									Design and execute an agentic workflow through conversation
 								</p>
 							</button>
@@ -95,7 +95,7 @@
 							>
 								<MessageCircle class="mb-4 size-5" />
 								<h3 class="text-base font-semibold">Just explore</h3>
-								<p class="text-base-content/50 min-h-[2lh] text-sm font-light">
+								<p class="text-muted-content min-h-[2lh] text-sm font-light">
 									Learn what the agent can do and take it from there
 								</p>
 							</button>

--- a/ui/user/src/lib/components/nanobot/PublishedWorkflowVersionDialog.svelte
+++ b/ui/user/src/lib/components/nanobot/PublishedWorkflowVersionDialog.svelte
@@ -143,7 +143,7 @@
 		</div>
 
 		<div class="bg-primary/10 mt-2 flex items-center gap-2 rounded-md px-4 py-2">
-			<CircleAlert class="text-primary size-5 flex-shrink-0" />
+			<CircleAlert class="text-primary size-5 shrink-0" />
 			<p class="text-base-content mt-1 text-sm font-light">
 				{#if !activeVersion}
 					Select a version to manage sharing.
@@ -162,7 +162,7 @@
 		</div>
 
 		{#if versions.length === 0}
-			<div class="text-base-content/50 my-4 text-center text-sm">
+			<div class="text-muted-content my-4 text-center text-sm">
 				<p class="font-medium">No versions found.</p>
 			</div>
 		{:else}
@@ -301,7 +301,7 @@
 					<MarkdownEditor value={versionContents} readonly />
 				</div>
 			{:else}
-				<div class="text-base-content/50 py-8 text-center text-sm">No version contents found.</div>
+				<div class="text-muted-content py-8 text-center text-sm">No version contents found.</div>
 			{/if}
 		</div>
 	</div>

--- a/ui/user/src/lib/components/nanobot/QuickAccess.svelte
+++ b/ui/user/src/lib/components/nanobot/QuickAccess.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import FileItem from '$lib/components/nanobot/FileItem.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import type { ChatMessageItemToolCall, ProjectLayoutContext } from '$lib/services/nanobot/types';
 	import { PROJECT_LAYOUT_CONTEXT } from '$lib/services/nanobot/types';
 	import { responsive } from '$lib/stores';
@@ -8,14 +9,13 @@
 	import Profile from '../navbar/Profile.svelte';
 	import {
 		Circle,
-		CheckCircle2,
-		Loader2,
 		ChevronUp,
 		ChevronDown,
 		Monitor,
-		SidebarOpen,
-		SidebarClose,
-		ListCheck
+		ListCheck,
+		CircleCheck,
+		PanelLeftClose,
+		PanelLeftOpen
 	} from 'lucide-svelte';
 	import { getContext } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -222,7 +222,7 @@
 
 <div
 	class={twMerge(
-		'bg-base-100 border-base-300 h-[100dvh] w-18 min-w-18 overflow-y-auto border-l',
+		'bg-base-100 border-base-300 h-dvh w-18 min-w-18 overflow-y-auto border-l',
 		responsive.isMobile
 			? open
 				? 'fixed top-0 left-0 h-[calc(100dvh-3.5rem)] w-full max-w-full'
@@ -238,7 +238,7 @@
 			open ? 'p-4 pt-1' : 'pt-1 pb-4'
 		)}
 	>
-		<div class={twMerge(open ? 'self-end' : 'w-14 self-center')}>
+		<div class={twMerge(open ? 'self-end' : 'w-14 self-center flex items-center justify-center')}>
 			<Profile {agentId} {projectId} {impersonating} />
 		</div>
 
@@ -304,11 +304,11 @@
 										{#each todoItems as item, i (i)}
 											<li class="flex items-start gap-2 text-sm font-light">
 												{#if item.status === 'completed' || item.status === 'cancelled'}
-													<CheckCircle2 class="text-success mt-0.5 size-4 shrink-0" />
+													<CircleCheck class="text-success mt-0.5 size-4 shrink-0" />
 												{:else if item.status === 'in_progress'}
-													<Loader2 class="text-primary mt-0.5 size-4 shrink-0 animate-spin" />
+													<Loading class="mt-0.5 size-4 shrink-0" />
 												{:else}
-													<Circle class="text-base-content/40 mt-0.5 size-4 shrink-0" />
+													<Circle class="text-muted-content mt-0.5 size-4 shrink-0" />
 												{/if}
 												<span
 													class:line-through={item.status === 'completed' ||
@@ -321,7 +321,7 @@
 										{/each}
 									{:else}
 										<li
-											class="text-base-content/50 flex min-w-0 items-start gap-2 text-xs font-light italic"
+											class="text-muted-content flex min-w-0 items-start gap-2 text-xs font-light italic"
 										>
 											<span class="min-w-0 truncate"
 												>Running to-dos for longer tasks will display here. You do not currently
@@ -344,7 +344,7 @@
 					onclick={() => onToggle()}
 					aria-label="Expand to show to-do list"
 				>
-					<ListCheck class="text-base-content/50 size-5" />
+					<ListCheck class="text-muted-content size-5" />
 				</button>
 
 				{@render listThreadFiles(true)}
@@ -353,7 +353,7 @@
 			{#if onToggle && !responsive.isMobile}
 				<div
 					class={twMerge(
-						'sticky right-0 bottom-2 flex flex-shrink-0',
+						'sticky right-0 bottom-2 flex shrink-0',
 						open ? 'justify-start' : 'justify-center'
 					)}
 				>
@@ -367,9 +367,9 @@
 						onclick={() => onToggle()}
 					>
 						{#if open}
-							<SidebarOpen class="text-base-content/50 size-6" />
+							<PanelLeftOpen class="text-muted-content size-6" />
 						{:else}
-							<SidebarClose class="text-base-content/50 size-6" />
+							<PanelLeftClose class="text-muted-content size-6" />
 						{/if}
 					</button>
 				</div>

--- a/ui/user/src/lib/components/nanobot/ScheduledTaskDialog.svelte
+++ b/ui/user/src/lib/components/nanobot/ScheduledTaskDialog.svelte
@@ -3,6 +3,7 @@
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import Select from '$lib/components/Select.svelte';
 	import TimeInput from '$lib/components/TimeInput.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import type { ChatAPI } from '$lib/services/nanobot/chat/index.svelte';
 	import type {
 		CreateScheduledTaskRequest,
@@ -20,7 +21,7 @@
 		parseCronSchedule,
 		type TaskFrequency
 	} from './taskSchedule';
-	import { Check, ChevronDown, LoaderCircle } from 'lucide-svelte';
+	import { Check, ChevronDown } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -304,7 +305,10 @@
 							onclick={() => toggleSchedulePicker('weekly')}
 						>
 							<span
-								class={twMerge('truncate text-left', daysOfWeek.length === 0 && 'text-on-surface1')}
+								class={twMerge(
+									'truncate text-left',
+									daysOfWeek.length === 0 && 'text-muted-content'
+								)}
 							>
 								{schedulePickerButtonLabel('weekly')}
 							</span>
@@ -345,7 +349,7 @@
 							<span
 								class={twMerge(
 									'truncate text-left',
-									daysOfMonth.length === 0 && 'text-on-surface1'
+									daysOfMonth.length === 0 && 'text-muted-content'
 								)}
 							>
 								{schedulePickerButtonLabel('monthly')}
@@ -409,7 +413,7 @@
 
 		<div class="flex flex-col gap-3">
 			<label for="schedule-expiration" class="input-label text-base font-medium">
-				Expiration Date <span class="text-on-surface1 font-normal">(optional)</span>
+				Expiration Date <span class="text-muted-content font-normal">(optional)</span>
 			</label>
 			<DatePicker
 				id="schedule-expiration"
@@ -445,18 +449,14 @@
 				<div class="flex flex-wrap items-center justify-between gap-4">
 					<div class="space-y-1">
 						<div class="text-sm font-medium">Enabled</div>
-						<p class="text-on-surface1 text-sm">
+						<p class="text-muted-content text-sm">
 							Runs until it is disabled or reaches its expiration.
 						</p>
 					</div>
-					<input
-						type="checkbox"
-						class="toggle text-background dark:text-surface2 bg-surface3 checked:bg-primary border-transparent"
-						bind:checked={enabled}
-					/>
+					<input type="checkbox" class="toggle" bind:checked={enabled} />
 				</div>
 				{#if currentTask}
-					<div class="text-on-surface1 mt-4 text-sm">
+					<div class="text-muted-content mt-4 text-sm">
 						Timezone: <span class="text-base-content">{timezone}</span>
 					</div>
 				{/if}
@@ -480,7 +480,7 @@
 				disabled={saving}
 			>
 				{#if saving}
-					<LoaderCircle class="size-4 animate-spin" />
+					<Loading class="size-4" />
 				{/if}
 				Save
 			</button>

--- a/ui/user/src/lib/components/nanobot/Thread.svelte
+++ b/ui/user/src/lib/components/nanobot/Thread.svelte
@@ -583,7 +583,7 @@
 			class="bg-base-300 hover:bg-primary w-1 cursor-col-resize transition-colors"
 			onmousedown={startResize}
 			aria-label="Resize browser viewer panel"
-			role="separator"
+			role="slider"
 			aria-orientation="vertical"
 			aria-valuenow={browserViewerWidth}
 			aria-valuemin="20"

--- a/ui/user/src/lib/components/nanobot/Threads.svelte
+++ b/ui/user/src/lib/components/nanobot/Threads.svelte
@@ -5,7 +5,7 @@
 	import { nanobotChat } from '$lib/stores/nanobotChat.svelte';
 	import { isRecent } from '$lib/time';
 	import { goto } from '$lib/url';
-	import { Check, Edit, EllipsisVertical, Trash2, X, Plus } from 'lucide-svelte';
+	import { Check, EllipsisVertical, Trash2, X, Plus, SquarePen } from 'lucide-svelte';
 	import { tick } from 'svelte';
 	import { get } from 'svelte/store';
 	import { fly } from 'svelte/transition';
@@ -165,14 +165,14 @@
 <div class="flex w-full grow flex-col">
 	{#if !responsive.isMobile}
 		<!-- Header -->
-		<div class="mb-2 flex flex-shrink-0 items-center justify-between gap-2 pr-3 pl-4">
-			<h2 class="text-base-content/50 text-md font-semibold">Sessions</h2>
+		<div class="mb-2 flex shrink-0 items-center justify-between gap-2 pr-3 pl-4">
+			<h2 class="text-muted-content text-md font-semibold">Sessions</h2>
 			<button
 				class="btn btn-square btn-ghost btn-sm tooltip tooltip-left"
 				data-tip="Start New Conversation"
 				onclick={onCreateSession}
 			>
-				<Plus class="text-base-content/50 size-6" />
+				<Plus class="text-muted-content size-6" />
 			</button>
 		</div>
 	{/if}
@@ -230,7 +230,7 @@
 								{/if}
 							</div>
 							{#if editingSessionId !== session.id}
-								<span class="text-base-content/50 flex-shrink-0 text-xs">
+								<span class="text-muted-content shrink-0 text-xs">
 									{formatTime(session.created)}
 								</span>
 							{/if}
@@ -245,14 +245,14 @@
 								onclick={cancelRename}
 								aria-label="Cancel editing"
 							>
-								<X class="h-3 w-3" />
+								<X class="size-3" />
 							</button>
 							<button
 								class="btn text-success btn-ghost btn-xs hover:bg-success/20"
 								onclick={saveRename}
 								aria-label="Save changes"
 							>
-								<Check class="h-3 w-3" />
+								<Check class="size-3" />
 							</button>
 						</div>
 					{/if}
@@ -266,10 +266,10 @@
 							<div tabindex="0" role="button" class="btn btn-square btn-ghost btn-sm">
 								<EllipsisVertical class="h-4 w-4" />
 							</div>
-							<ul class="dropdown-content menu dropdown-menu z-[1] w-32">
+							<ul class="dropdown-content menu dropdown-menu z-1 w-32">
 								<li>
 									<button onclick={() => startRename(session.id, session.title)} class="text-sm">
-										<Edit class="h-4 w-4" />
+										<SquarePen class="h-4 w-4" />
 										Rename
 									</button>
 								</li>

--- a/ui/user/src/lib/components/navbar/BetaLogo.svelte
+++ b/ui/user/src/lib/components/navbar/BetaLogo.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { darkMode } from '$lib/stores';
 	import appPreferences from '$lib/stores/appPreferences.svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -23,20 +22,20 @@
 		}
 	});
 
-	const logoSrc = $derived.by(() => {
-		const theme = darkMode.isDark ? 'dark' : 'light';
-		if (chat) {
-			return logos[theme].chat;
-		} else if (enterprise) {
-			return logos[theme].enterprise;
-		}
-		return logos[theme].default;
-	});
+	const logoPair = $derived(
+		chat
+			? { light: logos.light.chat, dark: logos.dark.chat }
+			: enterprise
+				? { light: logos.light.enterprise, dark: logos.dark.enterprise }
+				: { light: logos.light.default, dark: logos.dark.default }
+	);
 
 	const heightClass = $derived(chat ? 'h-[43px]' : 'h-12');
 	const paddingClass = $derived(chat ? 'pl-[1px]' : '');
+	const imgClass = $derived(twMerge(heightClass, paddingClass));
 </script>
 
-<div class={twMerge('flex flex-shrink-0', klass)}>
-	<img src={logoSrc} class={twMerge(heightClass, paddingClass)} alt="Obot logo" />
+<div class={twMerge('flex shrink-0', klass)}>
+	<img src={logoPair.light} class={twMerge(imgClass, 'dark:hidden')} alt="Obot logo" />
+	<img src={logoPair.dark} class={twMerge(imgClass, 'hidden dark:block')} alt="Obot logo" />
 </div>

--- a/ui/user/src/lib/components/navbar/EditorToggle.svelte
+++ b/ui/user/src/lib/components/navbar/EditorToggle.svelte
@@ -25,7 +25,7 @@
 			layout.projectEditorOpen = true;
 			layout.sidebarOpen = false;
 		}}
-		class="text-gray hover:bg-surface3 border-surface3 relative flex items-center rounded-full border bg-transparent p-2 text-xs opacity-50 transition-[background-color] duration-200 hover:opacity-100"
+		class="text-gray hover:bg-base-400 border-base-400 relative flex items-center rounded-full border bg-transparent p-2 text-xs opacity-50 transition-[background-color] duration-200 hover:opacity-100"
 	>
 		<Pencil class="size-5" />
 	</button>

--- a/ui/user/src/lib/components/navbar/Menu.svelte
+++ b/ui/user/src/lib/components/navbar/Menu.svelte
@@ -77,7 +77,7 @@
 
 <button
 	use:ref
-	class={twMerge('icon-button z-20', classes?.button)}
+	class={twMerge('btn btn-ghost btn-square z-20', classes?.button)}
 	onclick={() => {
 		load();
 		toggle();
@@ -90,7 +90,7 @@
 <div
 	use:tooltip={{ slide, fixed }}
 	class={twMerge(
-		'dropdown-menu z-40 flex w-screen min-w-fit flex-col divide-y divide-gray-200 p-4 md:w-96 dark:divide-gray-700',
+		'dropdown-menu z-40 flex w-screen min-w-fit flex-col divide-y divide-base-400 p-4 md:w-96',
 		classes?.menu
 	)}
 >
@@ -109,7 +109,7 @@
 				</div>
 			{/if}
 			{#if description}
-				<p class="mt-1 text-xs font-normal text-gray-700 dark:text-gray-300">{description}</p>
+				<p class="mt-1 text-xs font-normal text-muted-content">{description}</p>
 			{/if}
 		</div>
 	{/if}

--- a/ui/user/src/lib/components/navbar/Profile.svelte
+++ b/ui/user/src/lib/components/navbar/Profile.svelte
@@ -13,6 +13,7 @@
 	import Confirm from '../Confirm.svelte';
 	import InfoTooltip from '../InfoTooltip.svelte';
 	import PageLoading from '../PageLoading.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import MyAccount from '../profile/MyAccount.svelte';
 	import {
 		Book,
@@ -140,6 +141,7 @@
 	slide={responsive.isMobile ? 'left' : undefined}
 	fixed={responsive.isMobile}
 	classes={{
+		button: 'btn-circle btn-lg',
 		menu: twMerge(
 			'p-0 md:w-fit overflow-hidden z-50',
 			responsive.isMobile &&
@@ -148,11 +150,11 @@
 	}}
 >
 	{#snippet icon()}
-		<div class="relative flex-shrink-0">
+		<div class="relative shrink-0">
 			<ProfileIcon {impersonating} />
 			{#if showUpgradeAvailable}
 				<CircleFadingArrowUp
-					class="text-primary bg-background absolute -right-0.5 -bottom-0.5 z-10 size-3 rounded-full"
+					class="text-primary bg-base-100 absolute -right-0.5 -bottom-0.5 z-10 size-3 rounded-full"
 				/>
 			{/if}
 		</div>
@@ -165,7 +167,7 @@
 					<span>
 						{profile.current.displayName || 'Anonymous'}
 					</span>
-					<span class="text-on-surface1 text-sm">
+					<span class="text-muted-content text-sm">
 						{getUserRoleLabel(profile.current.effectiveRole)}
 					</span>
 				</div>
@@ -176,7 +178,7 @@
 					darkMode.setDark(!darkMode.isDark);
 				}}
 				role="menuitem"
-				class="after:content=[''] border-surface3 bg-surface2 dark:bg-surface3 relative cursor-pointer flex-col rounded-full border p-2 shadow-inner after:absolute after:top-1 after:left-1 after:z-0 after:size-7 after:rounded-full after:bg-transparent after:transition-all after:duration-200 dark:border-white/15"
+				class="after:content=[''] border-base-400 bg-base-300 dark:bg-base-400 relative cursor-pointer flex-col rounded-full border p-2 shadow-inner after:absolute after:top-1 after:left-1 after:z-0 after:size-7 after:rounded-full after:bg-transparent after:transition-all after:duration-200 dark:border-white/15"
 				class:dark-selected={darkMode.isDark}
 				class:light-selected={!darkMode.isDark}
 			>
@@ -244,7 +246,7 @@
 					}}
 					aria-disabled={!agentLinkEnabled}
 				>
-					<span class={twMerge('flex items-center gap-1', !agentLinkEnabled && 'opacity-50')}>
+					<span class={twMerge('flex items-center gap-2', !agentLinkEnabled && 'opacity-50')}>
 						<BotMessageSquare class="size-4" /> Launch Agent
 					</span>
 					{#if !agentLinkEnabled}
@@ -299,8 +301,8 @@
 			{/if}
 			{#if version.current.obot}
 				{#if showUpgradeAvailable}
-					<div class="text-on-background flex items-center gap-1 p-1 text-[11px]">
-						<CircleFadingArrowUp class="text-primary size-4 flex-shrink-0" />
+					<div class="text-base-content flex items-center gap-1 p-1 text-[11px]">
+						<CircleFadingArrowUp class="text-primary size-4 shrink-0" />
 						<p>
 							Upgrade Available. <br /> Check out the
 							<a
@@ -313,7 +315,7 @@
 						</p>
 					</div>
 				{/if}
-				<div class="text-on-surface1 flex justify-end p-2 text-xs">
+				<div class="text-muted-content flex justify-end p-2 text-xs">
 					<div class="flex gap-2">
 						{#if version.current.obot}
 							{@const link = getLink('obot', version.current.obot)}
@@ -342,14 +344,13 @@
 <dialog bind:this={versionDialog} class="dialog">
 	<div class="dialog-container relative z-50 max-w-lg min-w-sm p-4">
 		<div class="absolute top-2 right-2">
-			<button
+			<IconButton
 				onclick={() => {
 					versionDialog?.close();
 				}}
-				class="icon-button"
 			>
 				<X class="size-4" />
-			</button>
+			</IconButton>
 		</div>
 		<h4 class="mb-4 text-base font-semibold">Version Information</h4>
 		<div class="flex flex-col gap-1 text-xs">
@@ -403,7 +404,7 @@
 <style lang="postcss">
 	.dark-selected::after {
 		transform: translateY(2rem);
-		background-color: var(--surface1);
+		background-color: var(--color-base-200);
 	}
 
 	.light-selected::after {

--- a/ui/user/src/lib/components/navbar/Projects.svelte
+++ b/ui/user/src/lib/components/navbar/Projects.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { popover } from '$lib/actions';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { DEFAULT_PROJECT_NAME } from '$lib/constants';
 	import { closeAll, getLayout } from '$lib/context/chatLayout.svelte';
 	import { ChatService, type Project } from '$lib/services';
 	import { goto } from '$lib/url';
 	import Confirm from '../Confirm.svelte';
 	import PageLoading from '../PageLoading.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { ChevronDown, Plus, Settings } from 'lucide-svelte/icons';
 	import { twMerge } from 'tailwind-merge';
 
@@ -58,10 +58,10 @@
 <div class="flex" bind:this={container} use:ref>
 	<button
 		class={twMerge(
-			'hover:bg-surface3 bg-primary/10  relative z-10 flex min-h-10 grow items-center justify-between gap-2 truncate py-2 pr-6 pl-2 transition-colors duration-200',
+			'hover:bg-base-400 bg-primary/10  relative z-10 flex min-h-10 grow items-center justify-between gap-2 truncate py-2 pr-6 pl-2 transition-colors duration-200',
 			classes?.button
 		)}
-		class:hover:bg-surface2={!disabled}
+		class:hover:bg-base-300={!disabled}
 		class:cursor-default={disabled}
 		onclick={async () => {
 			if (disabled) {
@@ -73,7 +73,7 @@
 		}}
 	>
 		<div
-			class="text-on-background text-md flex w-full max-w-[100%-24px] flex-col truncate text-left"
+			class="text-base-content text-md flex w-full max-w-[100%-24px] flex-col truncate text-left"
 		>
 			<span class="text-[11px] font-normal">Project</span>
 			<p class="text-primary text-base font-semibold">{project.name || DEFAULT_PROJECT_NAME}</p>
@@ -81,7 +81,7 @@
 		{#if !disabled}
 			<div
 				class={twMerge(
-					'text-gray translate-x-[1px] transition-transform duration-200',
+					'text-gray translate-x-px transition-transform duration-200',
 					open && 'rotate-180'
 				)}
 			>
@@ -95,7 +95,7 @@
 	<div
 		use:buttonPopover={{ disablePortal: true }}
 		class={twMerge(
-			'border-surface3 dark:bg-surface1 default-scrollbar-thin bg-background flex max-h-[calc(100vh-123px)] -translate-x-[3px] -translate-y-[3px] flex-col overflow-hidden overflow-y-auto rounded-b-xs border',
+			'border-base-400 dark:bg-base-200 default-scrollbar-thin bg-base-100 flex max-h-[calc(100vh-123px)] -translate-x-[3px] -translate-y-[3px] flex-col overflow-hidden overflow-y-auto rounded-b-xs border',
 			classes?.tooltip
 		)}
 		style="width: {container?.clientWidth}px"
@@ -123,8 +123,8 @@
 	{@const isActive = p.id === project.id}
 	<div
 		class={twMerge(
-			'group hover:bg-surface3 flex min-h-14 items-center transition-colors',
-			isActive && 'bg-surface1 dark:bg-surface2'
+			'group hover:bg-base-400 flex min-h-14 items-center transition-colors',
+			isActive && 'bg-base-200 dark:bg-base-300'
 		)}
 	>
 		<a
@@ -135,30 +135,29 @@
 			}}
 		>
 			<div class="flex grow flex-col">
-				<span class="text-on-background text-sm font-semibold"
-					>{p.name || DEFAULT_PROJECT_NAME}</span
+				<span class="text-base-content text-sm font-semibold">{p.name || DEFAULT_PROJECT_NAME}</span
 				>
 				{#if p.description}
-					<span class="text-on-background line-clamp-1 text-xs font-light">{p.description}</span>
+					<span class="text-base-content line-clamp-1 text-xs font-light">{p.description}</span>
 				{/if}
 			</div>
 		</a>
-		<button
-			class="icon-button hover:text-primary flex-shrink-0 opacity-0 group-hover:opacity-100"
+		<IconButton
+			class="opacity-0 group-hover:opacity-100 border-transparent bg-transparent hover:text-primary"
 			onclick={() => {
 				goto(`/o/${p.id}?edit=true`);
 			}}
-			use:tooltip={'Configure Project'}
+			tooltip={{ text: 'Configure Project' }}
 		>
 			<Settings class="size-5" />
-		</button>
+		</IconButton>
 	</div>
 {/snippet}
 
 {#snippet LoadMoreButton(totalLength: number, limit: number)}
 	{#if totalLength > limit}
 		<button
-			class="hover:bg-surface2 text-primary mt-1 w-full rounded-sm py-1 text-sm"
+			class="hover:bg-base-300 text-primary mt-1 w-full rounded-sm py-1 text-sm"
 			onclick={(e) => {
 				e.stopPropagation();
 				loadMore();

--- a/ui/user/src/lib/components/primitives/IconButton.svelte
+++ b/ui/user/src/lib/components/primitives/IconButton.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { tooltip, type TooltipOptions } from '$lib/actions/tooltip.svelte';
+	import type { Snippet } from 'svelte';
+	import type { HTMLButtonAttributes } from 'svelte/elements';
+	import { twMerge, type ClassNameValue } from 'tailwind-merge';
+
+	interface Props extends HTMLButtonAttributes {
+		children: Snippet;
+		tooltip?: TooltipOptions;
+		variant?: 'default' | 'danger' | 'danger2' | 'primary';
+	}
+
+	const defaultClasses = 'btn btn-square shrink-0 disabled:cursor-not-allowed disabled:opacity-50';
+	let {
+		children,
+		class: className,
+		tooltip: tooltipOptions,
+		variant = 'default',
+		...props
+	}: Props = $props();
+
+	const variantClasses = $derived(
+		variant === 'danger2'
+			? 'btn-error'
+			: variant === 'primary'
+				? 'btn-primary btn-soft'
+				: variant === 'danger'
+					? 'btn-ghost text-muted-content hover:text-error'
+					: 'btn-ghost text-muted-content'
+	);
+</script>
+
+{#if tooltipOptions}
+	<button
+		type="button"
+		aria-label={tooltipOptions.text}
+		class={twMerge(defaultClasses, variantClasses, className as ClassNameValue)}
+		{...props}
+		use:tooltip={{
+			...tooltipOptions,
+			classes: [...(tooltipOptions?.classes ?? []), 'z-50']
+		}}
+	>
+		{@render children()}
+	</button>
+{:else}
+	<button
+		type="button"
+		class={twMerge(defaultClasses, variantClasses, className as ClassNameValue)}
+		{...props}
+	>
+		{@render children()}
+	</button>
+{/if}

--- a/ui/user/src/lib/components/primitives/draggable/DraggableItem.svelte
+++ b/ui/user/src/lib/components/primitives/draggable/DraggableItem.svelte
@@ -149,6 +149,7 @@
 
 <svelte:element
 	this={as ?? 'div'}
+	role="presentation"
 	bind:this={rootElement}
 	class={twMerge(
 		'draggable-element relative min-w-full touch-none',
@@ -183,9 +184,9 @@
 	<div
 		bind:this={containerElement}
 		class={twMerge(
-			'draggable-inner-element relative isolate z-[1] flex justify-start gap-2 rounded-sm border border-transparent transition-colors duration-200',
+			'draggable-inner-element relative isolate z-1 flex justify-start gap-2 rounded-sm border border-transparent transition-colors duration-200',
 			isPointerEntered && 'border-primary bg-primary/5',
-			!isActive && isDragOver && 'bg-surface2 pointer-events-none',
+			!isActive && isDragOver && 'bg-base-300 pointer-events-none',
 			klass
 		)}
 	>

--- a/ui/user/src/lib/components/profile/MyAccount.svelte
+++ b/ui/user/src/lib/components/profile/MyAccount.svelte
@@ -142,7 +142,7 @@
 	<div class="mt-2 flex flex-col gap-4 py-3">
 		{#if version.current.sessionStore === 'db'}
 			<button
-				class="w-full rounded-3xl border-2 border-red-600 px-4 py-2 font-medium text-red-600 hover:border-red-700 hover:text-red-700"
+				class="w-full btn btn-error"
 				onclick={(e) => {
 					e.preventDefault();
 					toRevoke = !toRevoke;
@@ -151,7 +151,7 @@
 			>
 		{/if}
 		<button
-			class="w-full rounded-3xl bg-red-600 px-4 py-2 font-medium text-white hover:bg-red-700"
+			class="w-full btn btn-error"
 			onclick={(e) => {
 				e.preventDefault();
 				toDelete = !toDelete;

--- a/ui/user/src/lib/components/profile/ProfileIcon.svelte
+++ b/ui/user/src/lib/components/profile/ProfileIcon.svelte
@@ -48,9 +48,11 @@
 			referrerpolicy="no-referrer"
 		/>
 	{:else if profile.current.isBootstrapUser?.()}
-		<ShieldUser class="text-on-surface1 size-8 rounded-full" />
+		<ShieldUser class="text-muted-content size-8 rounded-full" />
 	{:else}
-		<div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-600 text-white">
+		<div
+			class="flex h-8 w-8 items-center justify-center rounded-full bg-base-300 dark:bg-base-200 text-white"
+		>
 			{initials}
 		</div>
 	{/if}

--- a/ui/user/src/lib/components/table/Pagination.svelte
+++ b/ui/user/src/lib/components/table/Pagination.svelte
@@ -28,7 +28,7 @@
 	>
 		<ChevronsLeft class="size-4" /> Previous
 	</button>
-	<p class="text-on-surface1 text-xs">
+	<p class="text-muted-content text-xs">
 		{pageIndex + 1} of {lastPageIndex + 1}{#if itemLabelSingular}
 			· {total}
 			{itemLabelSingular}{total === 1 ? '' : 's'}{/if}

--- a/ui/user/src/lib/components/table/Table.svelte
+++ b/ui/user/src/lib/components/table/Table.svelte
@@ -2,6 +2,7 @@
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import DotDotDot from '../DotDotDot.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import TableColumnFilter from './TableColumnFilter.svelte';
 	import TableHeader from './TableHeader.svelte';
 	import {
@@ -597,7 +598,7 @@
 
 <div bind:this={wrapperRef} data-table-root>
 	<div
-		class={twMerge('dark:bg-surface1 bg-surface2 sticky left-0 z-40 w-full', classes?.thead)}
+		class={twMerge('dark:bg-base-200 bg-base-300 sticky left-0 z-40 w-full', classes?.thead)}
 		style="top: {stickyTop}px;"
 	>
 		{#if tableSelectActions && Object.keys(selected).length > 0}
@@ -605,7 +606,7 @@
 				<div class="shrink-0 p-2">
 					{@render selectAll()}
 				</div>
-				<div class="text-on-surface1 px-4 py-2 text-left text-sm font-semibold">
+				<div class="text-muted-content px-4 py-2 text-left text-sm font-semibold">
 					{Object.keys(selected).length} of {totalSelectable} selected
 				</div>
 				<div class="flex grow items-center justify-end">
@@ -642,7 +643,7 @@
 	</div>
 	<div
 		class={twMerge(
-			'dark:bg-surface2 default-scrollbar-thin bg-background relative overflow-hidden rounded-b-md shadow-sm',
+			'dark:bg-base-300 default-scrollbar-thin bg-base-100 relative overflow-hidden rounded-b-md shadow-sm',
 			classes?.root
 		)}
 		bind:this={bodyScrollRef}
@@ -678,7 +679,7 @@
 
 							{#if sectionA.length > 0}
 								{#if sectionB.length > 0}
-									<tr class="bg-surface3" data-section-header>
+									<tr class="bg-base-400" data-section-header>
 										<th
 											colspan={visibleFields.length +
 												(tableSelectActions ? 1 : 0) +
@@ -695,7 +696,7 @@
 							{/if}
 							{#if sectionB.length > 0}
 								{#if sectionA.length > 0}
-									<tr class="bg-surface3" data-section-header>
+									<tr class="bg-base-400" data-section-header>
 										<th
 											colspan={visibleFields.length +
 												(tableSelectActions ? 1 : 0) +
@@ -724,9 +725,9 @@
 {#if tableData.length === 0}
 	<div class="my-2 flex flex-col items-center justify-center gap-2">
 		{#if Object.keys(filteredBy || {}).length > 0}
-			<p class="text-on-surface1 text-sm font-light">No results found.</p>
+			<p class="text-muted-content text-sm font-light">No results found.</p>
 			<button
-				class="button text-sm"
+				class="btn btn-sm btn-secondary"
 				onclick={() => {
 					filteredBy = undefined;
 					onClearAllFilters?.();
@@ -735,7 +736,7 @@
 				Clear All Filters
 			</button>
 		{:else}
-			<p class="text-on-surface1 text-sm font-light">{noDataMessage}</p>
+			<p class="text-muted-content text-sm font-light">{noDataMessage}</p>
 		{/if}
 	</div>
 {/if}
@@ -743,19 +744,19 @@
 {#if pageSize && tableData.length > pageSize}
 	<div class="flex items-center justify-center gap-4">
 		<button
-			class="button-text flex items-center gap-1 text-xs"
+			class="btn btn-text flex items-center gap-1 text-xs"
 			disabled={page === 0}
 			onclick={() => page--}
 		>
 			<ChevronsLeft class="size-4" /> Previous
 		</button>
 
-		<p class="text-on-surface1 text-xs">
+		<p class="text-muted-content text-xs">
 			{page + 1} of {Math.ceil(total / pageSize)}
 		</p>
 
 		<button
-			class="button-text flex items-center gap-1 text-xs"
+			class="btn btn-text flex items-center gap-1 text-xs"
 			disabled={page === Math.floor(total / pageSize)}
 			onclick={() => page++}
 		>
@@ -766,8 +767,7 @@
 
 {#snippet selectAll()}
 	<div class="flex items-center gap-1">
-		<button
-			class="icon-button"
+		<IconButton
 			onclick={(e) => {
 				e.stopPropagation();
 				if (Object.keys(selected).length > 0) {
@@ -793,9 +793,9 @@
 			{:else}
 				<Square class="size-5" />
 			{/if}
-		</button>
+		</IconButton>
 		{#if validateSelect}
-			<DotDotDot class="text-on-surface1" {disablePortal}>
+			<DotDotDot class="text-muted-content" {disablePortal}>
 				{#snippet icon()}
 					<ChevronDown class="size-4" />
 				{/snippet}
@@ -839,11 +839,7 @@
 
 {#snippet header(hidden?: boolean)}
 	<thead
-		class={twMerge(
-			'dark:bg-surface1 bg-surface2 border-surface2 border-b',
-			hidden && 'hidden',
-			classes?.thead
-		)}
+		class={twMerge('dark:bg-base-200 bg-base-300', hidden && 'hidden', classes?.thead)}
 		bind:this={headerTableRef}
 	>
 		<tr>
@@ -878,7 +874,7 @@
 				{@const actionHeaderClass = headerClasses?.find((hc) => hc.property === 'actions')?.class}
 				<th
 					class={twMerge(
-						'text-md text-on-surface1 float-right w-auto px-4 py-2 text-left font-medium',
+						'text-md text-muted-content float-right w-auto px-4 py-2 text-left font-medium',
 						actionHeaderClass
 					)}
 				>
@@ -900,8 +896,8 @@
 {#snippet row(d: T)}
 	<tr
 		class={twMerge(
-			'border-surface2 dark:border-surface2 border-b shadow-xs transition-colors duration-300 last:border-b-0',
-			onClickRow && ' hover:bg-surface1 dark:hover:bg-surface3 cursor-pointer',
+			'border-base-200 dark:border-base-400 border-b shadow-xs last:border-b-0',
+			onClickRow && ' hover:bg-base-200 dark:hover:bg-base-400 cursor-pointer',
 			setRowClasses?.(d)
 		)}
 		onclick={(e) => {
@@ -914,8 +910,7 @@
 			{@const canSelect = validateSelect ? validateSelect(d) : true}
 			{#if canSelect}
 				<td class="p-2">
-					<button
-						class="button-icon"
+					<IconButton
 						onclick={(e) => {
 							e.stopPropagation();
 							if (selected[d.id]) {
@@ -930,13 +925,13 @@
 						{:else}
 							<Square class="size-5" />
 						{/if}
-					</button>
+					</IconButton>
 				</td>
 			{:else}
 				<td class="p-2" use:tooltip={disabledSelectMessage || 'This item is not selectable'}>
-					<button class="button-icon opacity-30" disabled>
+					<IconButton class="opacity-30" disabled>
 						<Square class="size-5" />
-					</button>
+					</IconButton>
 				</td>
 			{/if}
 		{/if}

--- a/ui/user/src/lib/components/table/TableColumnFilter.svelte
+++ b/ui/user/src/lib/components/table/TableColumnFilter.svelte
@@ -56,14 +56,14 @@
 	use:tooltip={{ disablePortal, text: 'Filter columns', classes: ['z-60'] }}
 	onclick={() => toggle()}
 >
-	<Columns3Cog class="size-4 flex-shrink-0" />
+	<Columns3Cog class="size-4 shrink-0" />
 </button>
 <div use:tooltipRef={{ disablePortal }} class="popover w-xs rounded-xs">
 	<Select
 		class="rounded-xs border border-transparent font-normal shadow-inner"
 		classes={{
 			root: 'flex grow',
-			option: 'font-normal bg-background'
+			option: 'font-normal dark:bg-base-300 bg-base-100'
 		}}
 		options={fields.map((f) => ({
 			label: getFieldLabel(f),

--- a/ui/user/src/lib/components/table/TableHeader.svelte
+++ b/ui/user/src/lib/components/table/TableHeader.svelte
@@ -55,7 +55,7 @@
 
 <th
 	class={twMerge(
-		'text-md group text-on-surface1 px-4 py-2 text-left font-medium capitalize',
+		'text-md group text-muted-content px-4 py-2 text-left font-medium capitalize',
 		pointerOnTHeader && 'cursor-pointer',
 		headerClass
 	)}
@@ -77,16 +77,16 @@
 				{headerTitle ?? property}
 				{#if headerTooltip}
 					<div use:tooltip={{ text: headerTooltip, classes: ['w-64', 'break-normal', 'z-[60]'] }}>
-						<CircleHelp class="text-on-surface1 size-3.5" />
+						<CircleHelp class="text-muted-content size-3.5" />
 					</div>
 				{/if}
 				<div
 					class={twMerge(
 						'flex items-center gap-1 px-2 py-0.5',
-						selectedFilterValues.length > 0 && 'bg-surface3 rounded-full'
+						selectedFilterValues.length > 0 && 'bg-base-400 rounded-full'
 					)}
 				>
-					<Funnel class="size-3 flex-shrink-0" />
+					<Funnel class="size-3 shrink-0" />
 					{#if selectedFilterValues.length > 0}
 						<span class="text-xs font-semibold">{selectedFilterValues.length}</span>
 					{/if}
@@ -97,7 +97,7 @@
 				{headerTitle ?? property}
 				{#if headerTooltip}
 					<div use:tooltip={{ text: headerTooltip, classes: ['w-64', 'break-normal', 'z-[60]'] }}>
-						<CircleHelp class="text-on-surface1 size-3.5" />
+						<CircleHelp class="text-muted-content size-3.5" />
 					</div>
 				{/if}
 			</span>

--- a/ui/user/src/lib/components/tasks/Dropdown.svelte
+++ b/ui/user/src/lib/components/tasks/Dropdown.svelte
@@ -15,6 +15,7 @@
 		placement: 'bottom-start'
 	});
 	let { values, selected, disabled = false, onSelected, class: kclass = '' }: Props = $props();
+	let button = $state<HTMLButtonElement>();
 
 	async function select(value: string) {
 		await onSelected?.(value);
@@ -25,37 +26,41 @@
 {#if disabled}
 	<span
 		class={twMerge(
-			'text-gray flex items-center justify-between gap-2 rounded-3xl p-3 px-4 capitalize dark:hover:bg-gray-900',
+			'text-muted-content bg-base-100 flex items-center justify-between gap-2 p-3 px-4 capitalize',
 			kclass
 		)}
 	>
 		{selected ? values[selected] : values[''] || ''}
-		<ChevronDown class="text-gray" />
+		<ChevronDown class="text-muted-content" />
 	</span>
 {:else}
 	<button
+		bind:this={button}
 		use:ref
 		type="button"
 		onclick={() => {
 			toggle();
 		}}
 		class={twMerge(
-			'hover:bg-gray-70 flex items-center justify-between gap-2 rounded-3xl p-3 px-4 capitalize dark:hover:bg-gray-900',
+			'flex items-center justify-between gap-2 rounded-sm p-3 px-4 capitalize',
 			kclass
 		)}
 	>
 		{selected ? values[selected] : values[''] || ''}
 		<ChevronDown />
 	</button>
-	<div use:tooltip class="bg-background min-w-[150px] rounded-3xl shadow dark:bg-gray-900">
+	<div
+		use:tooltip
+		class="bg-base-100 min-w-[150px] rounded-sm shadow"
+		style="width: {button?.getBoundingClientRect().width || 150}px;"
+	>
 		<ul>
 			{#each Object.keys(values) as key (key)}
 				{@const value = values[key]}
 				<li>
 					<button
-						class:bg-gray-70={selected === key}
-						class:dark:bg-gray-800={selected === key}
-						class="w-full px-6 py-2.5 text-start capitalize hover:bg-gray-100 dark:hover:bg-gray-800"
+						class:bg-base-200={selected === key}
+						class="w-full px-6 py-2.5 text-start capitalize hover:bg-base-300"
 						onclick={() => select(key)}
 					>
 						{value}
@@ -65,16 +70,3 @@
 		</ul>
 	</div>
 {/if}
-
-<style lang="postcss">
-	li:first-child button {
-		border-top-left-radius: 1.5rem;
-		border-top-right-radius: 1.5rem;
-		padding-top: 1rem;
-	}
-	li:last-child button {
-		border-bottom-left-radius: 1.5rem;
-		border-bottom-right-radius: 1.5rem;
-		padding-bottom: 1rem;
-	}
-</style>

--- a/ui/user/src/lib/components/tasks/Files.svelte
+++ b/ui/user/src/lib/components/tasks/Files.svelte
@@ -3,6 +3,7 @@
 	import Confirm from '$lib/components/Confirm.svelte';
 	import { getLayout } from '$lib/context/chatLayout.svelte';
 	import { ChatService, EditorService, type Files, type Project } from '$lib/services';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Download, RotateCw } from 'lucide-svelte';
 	import { FileText, Trash2 } from 'lucide-svelte/icons';
 	import { onDestroy } from 'svelte';
@@ -71,7 +72,7 @@
 
 {#if files && files.items.length > 0}
 	<div
-		class="dark:bg-surface1 dark:border-surface3 bg-background rounded-3xl p-5 shadow-md dark:border"
+		class="dark:bg-base-200 dark:border-base-400 bg-base-100 rounded-3xl p-5 shadow-md dark:border"
 	>
 		<div class="mb-3 flex items-center justify-between">
 			<h4 class="text-xl font-semibold">Files</h4>
@@ -100,27 +101,27 @@
 							<FileText />
 							<span class="ms-3">{file.name}</span>
 						</button>
-						<button
-							class="icon-button ms-2 opacity-0 group-hover:opacity-100"
+						<IconButton
+							class="ms-2 opacity-0 group-hover:opacity-100"
 							onclick={() => {
 								EditorService.download(layout.items, project, file.name, {
 									taskID,
 									runID
 								});
 							}}
-							use:tooltip={'Download File'}
+							tooltip={{ text: 'Download File' }}
 						>
-							<Download class="text-gray size-5" />
-						</button>
-						<button
-							class="icon-button ms-2 opacity-0 group-hover:opacity-100"
+							<Download class="text-muted-content size-5" />
+						</IconButton>
+						<IconButton
+							class="ms-2 opacity-0 group-hover:opacity-100"
 							onclick={() => {
 								fileToDelete = file.name;
 							}}
-							use:tooltip={'Delete File'}
+							tooltip={{ text: 'Delete File' }}
 						>
-							<Trash2 class="text-gray size-5" />
-						</button>
+							<Trash2 class="text-muted-content size-5" />
+						</IconButton>
 					</div>
 				</li>
 			{/each}

--- a/ui/user/src/lib/components/tasks/Input.svelte
+++ b/ui/user/src/lib/components/tasks/Input.svelte
@@ -20,9 +20,9 @@
 	});
 </script>
 
-<div class="border-surface2 dark:border-surface3 relative w-full rounded-lg border-2 p-5 pt-2">
+<div class="border-base-400 dark:border-base-400 relative w-full rounded-lg border-2 p-5 pt-2">
 	<h4
-		class="dark:bg-surface2 bg-background absolute top-0 left-3 w-fit -translate-y-3.5 px-2 text-base font-semibold"
+		class="dark:bg-base-300 bg-base-100 absolute top-0 left-3 w-fit -translate-y-3.5 px-2 text-base font-semibold"
 	>
 		{#if task?.onDemand?.params}
 			Arguments

--- a/ui/user/src/lib/components/tasks/LoopStep.svelte
+++ b/ui/user/src/lib/components/tasks/LoopStep.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { transitionParentHeight } from '$lib/actions/size.svelte';
 	import { autoHeight } from '$lib/actions/textarea.js';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Message from '$lib/components/messages/Message.svelte';
 	import { getLayout } from '$lib/context/chatLayout.svelte';
 	import { EditorService, type Messages, type Project } from '$lib/services';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Trash2, Plus } from 'lucide-svelte/icons';
 	import { linear } from 'svelte/easing';
 	import type { KeyboardEventHandler } from 'svelte/elements';
@@ -67,7 +67,7 @@
 			{value}
 			rows="1"
 			placeholder="Instructions..."
-			class="ghost-input border-surface2 h-auto grow resize-none"
+			class="ghost-input border-base-300 h-auto grow resize-none"
 			disabled={isReadOnly}
 			readonly={isReadOnly || isTaskRunning}
 			onkeydown={onKeydown}
@@ -78,13 +78,13 @@
 
 		{#if !isReadOnly && !isStepRunned && !isStepRunning}
 			<div class="flex items-center">
-				<button class="icon-button" onclick={onDelete} use:tooltip={'Remove step from loop'}>
+				<IconButton onclick={onDelete} tooltip={{ text: 'Remove step from loop' }}>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 
-				<button class="icon-button self-start" onclick={onAdd} use:tooltip={'Add step to loop'}>
+				<IconButton class="self-start" onclick={onAdd} tooltip={{ text: 'Add step to loop' }}>
 					<Plus class="size-4" />
-				</button>
+				</IconButton>
 			</div>
 		{/if}
 	</div>

--- a/ui/user/src/lib/components/tasks/OnDemand.svelte
+++ b/ui/user/src/lib/components/tasks/OnDemand.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { autoHeight } from '$lib/actions/textarea';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import type { OnDemand } from '$lib/services';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { Plus, Trash2 } from 'lucide-svelte';
 
 	interface Props {
@@ -32,7 +32,7 @@
 	</p>
 	<p class="text-gray text-sm">
 		You can reference these arguments in your steps using
-		<span class="text-on-background font-mono">$name</span> syntax, like “Crawl $website and find pages
+		<span class="text-base-content font-mono">$name</span> syntax, like “Crawl $website and find pages
 		it links to.”
 	</p>
 
@@ -51,7 +51,7 @@
 							<input
 								value={key}
 								placeholder="Enter Name"
-								class="text-input w-full"
+								class="input-text w-full"
 								oninput={(e) => {
 									if (e.target instanceof HTMLInputElement && onDemand?.params) {
 										const oldKey = order[i];
@@ -68,7 +68,7 @@
 							<textarea
 								use:autoHeight
 								bind:value={onDemand!.params![order[i]]}
-								class="text-input w-full resize-none py-2.5 align-bottom"
+								class="input-text w-full resize-none py-2.5 align-bottom"
 								disabled={readOnly}
 								placeholder="Add a good description"
 								rows="1"
@@ -76,8 +76,8 @@
 						</td>
 						{#if !readOnly}
 							<td class="flex justify-end">
-								<button
-									class="icon-button"
+								<IconButton
+									variant="danger"
 									onclick={() => {
 										const key = order[i];
 
@@ -87,10 +87,10 @@
 
 										order = order.filter((k) => k !== key);
 									}}
-									use:tooltip={'Remove Argument'}
+									tooltip={{ text: 'Remove Argument' }}
 								>
 									<Trash2 class="size-5" />
-								</button>
+								</IconButton>
 							</td>
 						{/if}
 					</tr>
@@ -102,7 +102,7 @@
 	{#if !readOnly}
 		<div class="self-end">
 			<button
-				class="button-small"
+				class="btn btn-sm btn-secondary"
 				onclick={() => {
 					if (!onDemand?.params) {
 						onDemand = {

--- a/ui/user/src/lib/components/tasks/Schedule.svelte
+++ b/ui/user/src/lib/components/tasks/Schedule.svelte
@@ -140,7 +140,7 @@
 
 <style lang="postcss">
 	:global(.schedule-dropdown) {
-		background-color: var(--surface2);
+		background-color: var(--color-base-300);
 		font-size: var(--text-md);
 		display: flex;
 		flex-grow: 1;

--- a/ui/user/src/lib/components/tasks/Step.svelte
+++ b/ui/user/src/lib/components/tasks/Step.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { transitionParentHeight } from '$lib/actions/size.svelte';
 	import { autoHeight } from '$lib/actions/textarea.js';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Message from '$lib/components/messages/Message.svelte';
 	import { getLayout } from '$lib/context/chatLayout.svelte';
@@ -14,9 +13,10 @@
 		type Task,
 		type TaskStep
 	} from '$lib/services';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { DraggableHandle, DraggableItem } from '../primitives/draggable';
 	import LoopStep from './LoopStep.svelte';
-	import { LoaderCircle, OctagonX, Play, RefreshCcw } from 'lucide-svelte';
+	import { OctagonX, Play, RefreshCcw } from 'lucide-svelte';
 	import { Plus, Trash2, Repeat } from 'lucide-svelte/icons';
 	import { untrack } from 'svelte';
 	import { linear } from 'svelte/easing';
@@ -262,7 +262,7 @@
 	as="li"
 	class={twMerge(
 		'w-full gap-2 rounded-md',
-		toDelete && 'bg-surface1 dark:bg-surface2',
+		toDelete && 'bg-base-200 dark:bg-base-300',
 		isTaskRunning &&
 			((index > 0 && !isRunning) || (index === 0 && messages.length && !isRunning)) &&
 			'opacity-50'
@@ -281,7 +281,7 @@
 					use:autoHeight
 					id={'step' + step.id}
 					value={step.step}
-					class="ghost-input border-surface2 ml-1 grow resize-none"
+					class="ghost-input border-base-300 ml-1 grow resize-none"
 					readonly={readOnly}
 					oninput={(ev) => {
 						const value = (ev.target as HTMLInputElement).value;
@@ -297,42 +297,44 @@
 
 				{#if !readOnly}
 					<div class="flex items-start">
-						<button
-							class="icon-button"
-							class:text-primary={isLoopStep}
+						<IconButton
+							class={isLoopStep ? 'text-primary' : ''}
 							data-testid="step-loop-btn"
 							onclick={toggleLoop}
-							use:tooltip={isLoopStep
-								? 'Convert to regular step'
-								: 'Iterate through the results of this step'}
+							tooltip={{
+								text: isLoopStep
+									? 'Convert to regular step'
+									: 'Iterate through the results of this step'
+							}}
 						>
 							<Repeat class="size-4" />
-						</button>
+						</IconButton>
 
-						<button
-							class="icon-button"
+						<IconButton
 							data-testid="step-run-btn"
 							onclick={doRun}
-							use:tooltip={isRunning
-								? 'Abort'
-								: pending
-									? 'Running...'
-									: simpleStepMessages.length > 0
-										? 'Re-run Step'
-										: 'Run Step'}
+							tooltip={{
+								text: isRunning
+									? 'Abort'
+									: pending
+										? 'Running...'
+										: simpleStepMessages.length > 0
+											? 'Re-run Step'
+											: 'Run Step'
+							}}
 						>
 							{#if isRunning}
 								<OctagonX class="size-4" />
 							{:else if pending}
-								<LoaderCircle class="size-4 animate-spin" />
+								<Loading class="size-4" />
 							{:else if simpleStepMessages.length > 0}
 								<RefreshCcw class="size-4" />
 							{:else}
 								<Play class="size-4" />
 							{/if}
-						</button>
-						<button
-							class="icon-button"
+						</IconButton>
+						<IconButton
+							variant="danger"
 							data-testid="step-delete-btn"
 							onclick={() => {
 								if (step.step?.trim()) {
@@ -342,22 +344,22 @@
 									onDelete?.();
 								}
 							}}
-							use:tooltip={'Delete Step'}
+							tooltip={{ text: 'Delete Step' }}
 						>
 							<Trash2 class="size-4" />
-						</button>
+						</IconButton>
 						<div class="flex grow">
 							<div class="size-10">
 								{#if (step.step?.trim() || '').length > 0}
-									<button
-										class="icon-button"
-										data-testid="step-add-btn"
-										onclick={onAdd}
-										use:tooltip={'Add Step'}
-										transition:fade={{ duration: 200 }}
-									>
-										<Plus class="size-4" />
-									</button>
+									<div transition:fade={{ duration: 200 }}>
+										<IconButton
+											data-testid="step-add-btn"
+											onclick={onAdd}
+											tooltip={{ text: 'Add Step' }}
+										>
+											<Plus class="size-4" />
+										</IconButton>
+									</div>
 								{/if}
 							</div>
 						</div>
@@ -393,7 +395,7 @@
 							}
 							class={twMerge(
 								'rounded-md',
-								loopStepToDeleteIndex === i && 'bg-surface1 dark:bg-surface2'
+								loopStepToDeleteIndex === i && 'bg-base-200 dark:bg-base-300'
 							)}
 							{project}
 							messages={stepMessages}
@@ -427,7 +429,7 @@
 				{@const shouldShowOutline = isRunning || (isTaskRunning && !messages.length && index === 0)}
 
 				<div
-					class="transition-height bg-background relative my-3 -ml-4 box-content flex min-h-6 flex-col gap-4 overflow-hidden rounded-lg p-5"
+					class="transition-height bg-base-100 relative my-3 -ml-4 box-content flex min-h-6 flex-col gap-4 overflow-hidden rounded-lg p-5"
 					class:outline-2={shouldShowOutline}
 					class:outline-primary={shouldShowOutline}
 					transition:slide={{
@@ -483,7 +485,7 @@
 							{@const messages = iteration ?? []}
 
 							<div
-								class="iteration border-surface2 -ml-4 flex flex-col rounded-lg border pt-4"
+								class="iteration border-base-300 -ml-4 flex flex-col rounded-lg border pt-4"
 								in:fade|global={{ duration: 200 }}
 								out:fade={{ duration: 0 }}
 							>
@@ -500,7 +502,7 @@
 										{@const stepMessages = messages[j] ?? []}
 
 										<LoopStep
-											class="border-surface2 border-b pr-4 last:border-none"
+											class="border-base-300 border-b pr-4 last:border-none"
 											value={step.loop![j]}
 											{project}
 											messages={stepMessages}

--- a/ui/user/src/lib/components/tasks/Steps.svelte
+++ b/ui/user/src/lib/components/tasks/Steps.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Files from '$lib/components/tasks/Files.svelte';
 	import Step from '$lib/components/tasks/Step.svelte';
 	import { type Messages, type Project, type Task, type TaskStep } from '$lib/services';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { DraggableList } from '../primitives/draggable';
 	import { Eye, EyeClosed, UsersRound, ArrowBigDown } from 'lucide-svelte';
 	import { tick, untrack } from 'svelte';
@@ -253,14 +253,13 @@
 
 <div
 	bind:this={element}
-	class="task-steps dark:bg-surface1 dark:border-surface3 bg-background relative rounded-lg p-5 pb-10 shadow-sm dark:border"
+	class="task-steps dark:bg-base-200 dark:border-base-400 bg-base-100 relative rounded-lg p-5 pb-10 shadow-sm dark:border"
 >
 	<div class="flex w-full items-center justify-between">
 		<h4 class="text-lg font-semibold">Steps</h4>
 
 		{#if shouldShowToggleAllOutput}
-			<button
-				class="icon-button"
+			<IconButton
 				data-testid="steps-toggle-output-btn"
 				onclick={async () => {
 					if (showAllOutput) {
@@ -276,14 +275,14 @@
 						showAllOutput = true;
 					}
 				}}
-				use:tooltip={'Toggle All Output Visbility'}
+				tooltip={{ text: 'Toggle All Output Visbility' }}
 			>
 				{#if showAllOutput}
 					<Eye class="size-5" />
 				{:else}
 					<EyeClosed class="size-5" />
 				{/if}
-			</button>
+			</IconButton>
 		{/if}
 	</div>
 
@@ -332,7 +331,7 @@
 	</DraggableList>
 
 	{#if error}
-		<div class="mt-2 text-red-500">{error}</div>
+		<div class="mt-2 text-error">{error}</div>
 	{/if}
 
 	{#if (!readOnly && isTaskRunning) || hasScrollingContent}
@@ -341,7 +340,7 @@
 		<div class="pointer-events-none absolute inset-0 z-10 flex items-end justify-end p-4">
 			<button
 				class={twMerge(
-					'bg-surface2 pointer-events-auto sticky right-0 bottom-4 box-border flex aspect-square h-8 items-center justify-center rounded-lg transition-colors duration-200',
+					'bg-base-300 pointer-events-auto sticky right-0 bottom-4 box-border flex aspect-square h-8 items-center justify-center rounded-lg transition-colors duration-200',
 					isFollowModeActive &&
 						'bg-primary/0 text-primary/70 hover:bg-primary/10 active:bg-primary/20 border border-current'
 				)}

--- a/ui/user/src/lib/components/tasks/Task.svelte
+++ b/ui/user/src/lib/components/tasks/Task.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Steps from '$lib/components/tasks/Steps.svelte';
 	import { TASK_NEW_ID } from '$lib/constants';
 	import { getLayout } from '$lib/context/chatLayout.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { newSaveMonitor } from '$lib/save.js';
 	import {
 		ChatService,
@@ -18,9 +18,10 @@
 	import { errors, responsive } from '$lib/stores';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import ChatInput from '../messages/Input.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
 	import Input from './Input.svelte';
 	import TaskOptions from './TaskOptions.svelte';
-	import { LoaderCircle, OctagonX, Play } from 'lucide-svelte';
+	import { OctagonX, Play } from 'lucide-svelte';
 	import { MessageCircle, MessageCircleOff, Trash2, TriangleAlert } from 'lucide-svelte/icons';
 	import { onDestroy, onMount, untrack } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
@@ -313,34 +314,31 @@
 {#snippet mainActions()}
 	<div class="flex items-center gap-2">
 		{#if allMessages.messages.length > 0 && !noChat}
-			<button
-				class="icon-button"
-				onclick={() => (showChat = !showChat)}
-				use:tooltip={'Toggle Chat'}
-				transition:fade
-			>
-				{#if showChat}
-					<MessageCircleOff class="size-6" />
-				{:else}
-					<MessageCircle class="size-6" />
-				{/if}
-			</button>
+			<div transition:fade>
+				<IconButton onclick={() => (showChat = !showChat)} tooltip={{ text: 'Toggle Chat' }}>
+					{#if showChat}
+						<MessageCircleOff class="size-6" />
+					{:else}
+						<MessageCircle class="size-6" />
+					{/if}
+				</IconButton>
+			</div>
 		{/if}
 		{#if !readOnly}
 			<button
-				class="bg-primary hover:bg-primary/50 flex items-center justify-center gap-2 rounded-2xl px-12 py-2 text-white transition-all duration-200"
+				class="bg-primary hover:bg-primary/50 flex items-center justify-center gap-2 rounded-sm px-12 py-2 text-white transition-all duration-200"
 				onclick={click}
 				class:grow={responsive.isMobile}
 			>
 				{#if isRunning}
 					Stop
-					<OctagonX class="h-4 w-4" />
+					<OctagonX class="size-4" />
 				{:else if pending}
 					Cancel
-					<LoaderCircle class="h-4 w-4 animate-spin" />
+					<Loading class="size-4" />
 				{:else}
 					Run
-					<Play class="h-4 w-4" />
+					<Play class="size-4" />
 				{/if}
 			</button>
 		{/if}
@@ -406,13 +404,11 @@
 						>
 							{@render mainActions()}
 							{#if !readOnly}
-								<button
-									in:slide={{ axis: 'x', duration: 150 }}
-									class="button-destructive p-3"
-									onclick={() => (toDelete = true)}
-								>
-									<Trash2 class="size-4" />
-								</button>
+								<div in:slide={{ axis: 'x', duration: 150 }}>
+									<IconButton variant="danger2" onclick={() => (toDelete = true)}>
+										<Trash2 class="size-4" />
+									</IconButton>
+								</div>
 							{/if}
 						</div>
 					{/if}
@@ -423,9 +419,9 @@
 							{@render mainActions()}
 						</div>
 						{#if !readOnly}
-							<button class="button-destructive p-4" onclick={() => (toDelete = true)}>
+							<IconButton variant="danger2" onclick={() => (toDelete = true)}>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/if}
 					</div>
 				{/if}
@@ -433,7 +429,7 @@
 			{#if taskRunData?.warning}
 				<div class="notification-alert flex w-full flex-col gap-2">
 					<div class="flex items-center gap-2">
-						<TriangleAlert class="size-6 flex-shrink-0 self-start text-yellow-500" />
+						<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
 						<p class="my-0.5 flex flex-col text-sm font-semibold">Warning</p>
 					</div>
 					<span class="text-sm font-light break-all">{taskRunData.warning}</span>
@@ -441,7 +437,7 @@
 			{/if}
 			<div class="flex w-full justify-center">
 				<div
-					class="bg-surface1 dark:bg-background flex w-full flex-col gap-4 rounded-xl p-4 shadow-inner md:max-w-[1200px]"
+					class="bg-base-200 dark:bg-base-100 flex w-full flex-col gap-4 rounded-xl p-4 shadow-inner md:max-w-[1200px]"
 				>
 					<div class="flex flex-col gap-4">
 						<TaskOptions bind:task {readOnly} />
@@ -468,7 +464,7 @@
 			<div class="grow"></div>
 
 			<div
-				class="bg-background sticky bottom-0 z-50 flex items-center justify-center px-6 opacity-0 transition-opacity"
+				class="bg-base-100 sticky bottom-0 z-50 flex items-center justify-center px-6 opacity-0 transition-opacity"
 				class:chat-overlay={showChat}
 			>
 				{#if allMessages.messages.length > 0 && showChat}
@@ -507,7 +503,7 @@
 				<div class="flex grow"></div>
 				<div class="flex w-full flex-col justify-between gap-4 md:flex-row md:justify-end">
 					<button
-						class="button-primary w-full md:w-fit"
+						class="btn btn-primary w-full md:w-fit"
 						onclick={() => {
 							run();
 							inputDialog?.close();
@@ -530,7 +526,7 @@
 			left: 0;
 			width: 100%;
 			height: 3rem;
-			background: linear-gradient(to bottom, transparent, var(--background));
+			background: linear-gradient(to bottom, transparent, var(--color-base-100));
 		}
 	}
 </style>

--- a/ui/user/src/lib/components/tasks/TaskOptions.svelte
+++ b/ui/user/src/lib/components/tasks/TaskOptions.svelte
@@ -50,16 +50,16 @@
 
 {#if !readOnly}
 	<div
-		class="dark:bg-surface1 dark:border-surface3 bg-background flex grow flex-col overflow-visible rounded-lg p-5 shadow-sm dark:border"
+		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex grow flex-col overflow-visible rounded-lg p-5 shadow-sm dark:border"
 	>
 		{#if triggerType === 'onDemand' || triggerType === 'schedule'}
-			<div class="border-surface3 mb-4 flex flex-col gap-4 border-b pb-4">
+			<div class="border-base-400 mb-4 flex flex-col gap-4 border-b pb-4">
 				<div
 					class="flex w-full flex-col justify-start gap-4 lg:flex-row lg:items-center lg:justify-between"
 				>
 					<h3 class="text-lg font-semibold">How do you want to run this task?</h3>
 					<Dropdown
-						class="bg-surface2 xl:min-w-sm"
+						class="bg-base-300 xl:min-w-sm"
 						selected={selectedTrigger()}
 						values={options}
 						onSelected={selected}

--- a/ui/user/src/lib/components/tasks/Trigger.svelte
+++ b/ui/user/src/lib/components/tasks/Trigger.svelte
@@ -64,11 +64,13 @@
 	{#if selectedTrigger() === 'webhook'}
 		<div class="flex flex-col justify-between gap-2 pr-5">
 			<h4 class="text-base font-medium">Webhook URL</h4>
-			<div class="bg-surface2 flex gap-2 rounded-xl px-4 py-2">
+			<div class="bg-base-300 flex gap-2 rounded-xl px-4 py-2">
 				<CopyButton text={webhook} />
 				{webhook}
 			</div>
-			<p class="text-on-surface1 text-sm">You can send webhooks to this URL to trigger the task.</p>
+			<p class="text-muted-content text-sm">
+				You can send webhooks to this URL to trigger the task.
+			</p>
 		</div>
 	{/if}
 	{#if selectedTrigger() === 'email' && email}
@@ -78,7 +80,7 @@
 				<CopyButton text={email} />
 				{email}
 			</div>
-			<p class="text-on-surface1 text-sm">
+			<p class="text-muted-content text-sm">
 				You can send emails to this address to trigger the task.
 			</p>
 		</div>
@@ -90,7 +92,7 @@
 		<div class="flex grow flex-col gap-4">
 			<div class="flex items-center justify-between">
 				<div class="flex gap-2">
-					<p class="text-on-surface1 text-sm">
+					<p class="text-muted-content text-sm">
 						This task will be triggered when you mention the bot in any Slack channel
 					</p>
 				</div>
@@ -101,7 +103,7 @@
 		<div class="flex grow flex-col gap-4">
 			<div class="flex items-center justify-between">
 				<div class="flex gap-2">
-					<p class="text-on-surface1 text-sm">
+					<p class="text-muted-content text-sm">
 						This task will be triggered when you mention the bot in any Discord channel
 					</p>
 				</div>

--- a/ui/user/src/lib/components/tasks/Type.svelte
+++ b/ui/user/src/lib/components/tasks/Type.svelte
@@ -86,12 +86,12 @@
 </script>
 
 <div
-	class="dark:bg-surface1 dark:border-surface3 bg-background flex grow flex-col overflow-visible rounded-2xl p-5 shadow-sm dark:border"
+	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex grow flex-col overflow-visible rounded-2xl p-5 shadow-sm dark:border"
 >
-	<div class="border-surface3 mb-4 flex items-center justify-between gap-4 border-b pb-4">
+	<div class="border-base-400 mb-4 flex items-center justify-between gap-4 border-b pb-4">
 		<h3 class="text-lg font-semibold">Trigger Type</h3>
 		<Dropdown
-			class="bg-surface2 md:min-w-sm"
+			class="bg-base-300 md:min-w-sm"
 			selected={selectedTrigger()}
 			values={options}
 			onSelected={selected}

--- a/ui/user/src/lib/components/templates/TemplateConfig.svelte
+++ b/ui/user/src/lib/components/templates/TemplateConfig.svelte
@@ -23,6 +23,7 @@
 	} from '$lib/services';
 	import { sortShownToolsPriority } from '$lib/sort';
 	import { poll } from '$lib/utils';
+	import IconButton from '../primitives/IconButton.svelte';
 	import { XIcon, Loader2, Trash2, Server } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -151,19 +152,19 @@
 {#snippet displayTasks(taskList: Task[])}
 	{#if taskList.length > 0}
 		<div class="p-3">
-			<h4 class="text-on-surface1 mb-1 text-xs font-medium">Tasks</h4>
+			<h4 class="text-muted-content mb-1 text-xs font-medium">Tasks</h4>
 			<div class="flex flex-col gap-2">
 				{#each taskList as t (t.id)}
-					<div class="rounded-md border border-gray-100 p-2 text-xs dark:border-gray-700">
-						<div class="font-medium text-gray-700 dark:text-gray-200">{t.name || t.id}</div>
+					<div class="rounded-md border border-base-400 p-2 text-xs">
+						<div class="font-medium text-muted-content">{t.name || t.id}</div>
 						{#if t.description}
-							<div class="text-on-surface1 mt-0.5">{t.description}</div>
+							<div class="text-muted-content mt-0.5">{t.description}</div>
 						{/if}
 						{#if t.steps && t.steps.length > 0}
-							<div class="text-on-surface1 mt-1">
+							<div class="text-muted-content mt-1">
 								{t.steps.length} step{t.steps.length === 1 ? '' : 's'}
 							</div>
-							<ol class="text-on-surface1 mt-1 list-decimal pl-4 text-[11px]">
+							<ol class="text-muted-content mt-1 list-decimal pl-4 text-[11px]">
 								{#each t.steps as s, idx (s.id)}
 									<li>
 										<span>{s.step || 'Step ' + (idx + 1)}</span>
@@ -188,8 +189,8 @@
 {#if loading}
 	<div class="flex items-center justify-center p-6">
 		<div class="flex flex-col items-center gap-2">
-			<Loader2 class="text-on-surface1 size-6 animate-spin" />
-			<span class="text-on-surface1 text-sm">Loading Project Share...</span>
+			<Loader2 class="text-muted-content size-6 animate-spin" />
+			<span class="text-muted-content text-sm">Loading Project Share...</span>
 		</div>
 	</div>
 {:else}
@@ -197,7 +198,7 @@
 		<div class="flex w-full items-center justify-end">
 			<button
 				onclick={() => closeSidebarConfig(layout)}
-				class="ml-auto text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+				class="ml-auto text-muted-content hover:text-base-content dark:text-muted-content dark:hover:text-base-content"
 			>
 				<XIcon class="size-6" />
 			</button>
@@ -224,7 +225,7 @@
 						</p>
 					</div>
 					<button
-						class="button-primary"
+						class="btn btn-primary"
 						onclick={createFromSnapshot}
 						disabled={hasCompositeServer}
 						use:tooltip={hasCompositeServer
@@ -248,13 +249,13 @@
 					<div class="flex items-center gap-2">
 						{#if template.projectSnapshotStale}
 							{#if template.projectSnapshotUpgradeInProgress}
-								<div class="text-on-surface1 flex items-center gap-1 text-xs">
+								<div class="text-muted-content flex items-center gap-1 text-xs">
 									<Loader2 class="size-4 animate-spin" />
 									Updating...
 								</div>
 							{:else}
 								<button
-									class="button-primary px-3 py-1 text-sm"
+									class="btn btn-primary px-3 py-1 text-sm"
 									onclick={createFromSnapshot}
 									disabled={hasCompositeServer}
 									use:tooltip={hasCompositeServer
@@ -268,20 +269,20 @@
 								</button>
 							{/if}
 						{/if}
-						<button
-							class="icon-button hover:text-red-500"
+						<IconButton
+							variant="danger"
 							onclick={() => (toDelete = true)}
-							use:tooltip={'Delete Project Share'}
+							tooltip={{ text: 'Delete Project Share' }}
 						>
 							<Trash2 class="size-4" />
-						</button>
+						</IconButton>
 					</div>
 				</div>
 			</div>
 
 			{#if template.publicID}
-				<div class="rounded-md border border-gray-100 dark:border-gray-700">
-					<div class="border-b border-gray-100 p-3 dark:border-gray-700">
+				<div class="rounded-md border border-base-400">
+					<div class="border-b border-base-400 p-3">
 						<h3 class="text-sm font-medium">Project Share URL</h3>
 					</div>
 					<div class="p-3">
@@ -297,14 +298,14 @@
 			{/if}
 
 			{#if templateTools.length > 0}
-				<div class="rounded-md border border-gray-100 dark:border-gray-700">
-					<div class="border-b border-gray-100 p-3 dark:border-gray-700">
+				<div class="rounded-md border border-base-400">
+					<div class="border-b border-base-400 p-3">
 						<h3 class="text-sm font-medium">Tools</h3>
 					</div>
 					<div class="flex flex-wrap gap-2 p-3">
 						{#each templateTools as tool (tool.id)}
 							<div
-								class="flex items-center gap-2 rounded-md bg-gray-50 px-2 py-1 text-xs dark:bg-gray-700"
+								class="flex items-center gap-2 rounded-md bg-base-200 dark:bg-base-400 px-2 py-1 text-xs"
 							>
 								<ToolPill {tool} />
 								<span>{tool.name}</span>
@@ -314,14 +315,14 @@
 				</div>
 			{/if}
 
-			<div class="rounded-md border border-gray-100 dark:border-gray-700">
-				<div class="border-b border-gray-100 p-3 dark:border-gray-700">
+			<div class="rounded-md border border-base-400">
+				<div class="border-b border-base-400 p-3">
 					<h3 class="text-sm font-medium">Project Share details</h3>
 				</div>
-				<div class="flex flex-col divide-y divide-gray-100 dark:divide-gray-700">
+				<div class="flex flex-col divide-y divide-base-400">
 					{#if template.projectSnapshotLastUpgraded}
 						<div class="p-3">
-							<h4 class="text-on-surface1 mb-1 text-xs font-medium">Last Updated</h4>
+							<h4 class="text-muted-content mb-1 text-xs font-medium">Last Updated</h4>
 							<p class="text-sm text-gray-600 dark:text-gray-300">
 								{formatDate(template.projectSnapshotLastUpgraded)}
 							</p>
@@ -330,7 +331,7 @@
 
 					{#if template.projectSnapshot.description}
 						<div class="p-3">
-							<h4 class="text-on-surface1 mb-1 text-xs font-medium">Description</h4>
+							<h4 class="text-muted-content mb-1 text-xs font-medium">Description</h4>
 							<p class="text-sm text-gray-600 dark:text-gray-300">
 								{template.projectSnapshot.description}
 							</p>
@@ -339,7 +340,7 @@
 
 					{#if template.projectSnapshot.prompt}
 						<div class="p-3">
-							<h4 class="text-on-surface1 mb-1 text-xs font-medium">System Prompt</h4>
+							<h4 class="text-muted-content mb-1 text-xs font-medium">System Prompt</h4>
 							<p class="text-xs whitespace-pre-wrap text-gray-600 dark:text-gray-300">
 								{template.projectSnapshot.prompt}
 							</p>
@@ -348,7 +349,7 @@
 
 					{#if template.projectSnapshot.introductionMessage}
 						<div class="p-3">
-							<h4 class="text-on-surface1 mb-1 text-xs font-medium">Introduction Message</h4>
+							<h4 class="text-muted-content mb-1 text-xs font-medium">Introduction Message</h4>
 							<p class="text-xs whitespace-pre-wrap text-gray-600 dark:text-gray-300">
 								{template.projectSnapshot.introductionMessage}
 							</p>
@@ -357,11 +358,11 @@
 
 					{#if template.projectSnapshot.starterMessages && template.projectSnapshot.starterMessages.length > 0}
 						<div class="p-3">
-							<h4 class="text-on-surface1 mb-2 text-xs font-medium">Conversation Starters</h4>
+							<h4 class="text-muted-content mb-2 text-xs font-medium">Conversation Starters</h4>
 							<div class="flex flex-col gap-2">
 								{#each template.projectSnapshot.starterMessages as message (message)}
 									<div
-										class="bg-primary/10 w-fit max-w-[90%] rounded-lg rounded-tl-none p-2 text-xs whitespace-pre-wrap text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+										class="bg-primary/10 w-fit max-w-[90%] rounded-lg rounded-tl-none p-2 text-xs whitespace-pre-wrap text-muted-content"
 									>
 										{message}
 									</div>
@@ -372,13 +373,13 @@
 
 					{#if mcpServers.length > 0}
 						<div class="p-3">
-							<h4 class="text-on-surface1 mb-2 text-xs font-medium">MCP Servers</h4>
+							<h4 class="text-muted-content mb-2 text-xs font-medium">MCP Servers</h4>
 							<div class="flex flex-col gap-2">
 								{#each mcpServers as mcpServer (mcpServer.id)}
 									<div
-										class="group hover:bg-surface3 flex w-full items-center rounded-md transition-colors duration-200"
+										class="group hover:bg-base-400 flex w-full items-center rounded-md transition-colors duration-200"
 									>
-										<div class="rounded-md bg-gray-50 p-1 dark:bg-gray-600">
+										<div class="rounded-md bg-base-200 p-1 dark:bg-base-300">
 											{#if mcpServer.icon}
 												<img
 													src={mcpServer.icon}
@@ -402,7 +403,7 @@
 
 					{#if knowledgeFiles.length > 0}
 						<div class="p-3">
-							<h4 class="text-on-surface1 mb-1 text-xs font-medium">Knowledge Files</h4>
+							<h4 class="text-muted-content mb-1 text-xs font-medium">Knowledge Files</h4>
 							<ul class="mt-2">
 								{#each knowledgeFiles as file (file.fileName)}
 									<li class="mb-1 text-xs text-gray-600 last:mb-0 dark:text-gray-300">

--- a/ui/user/src/lib/components/ui/multi-value-input/Input.svelte
+++ b/ui/user/src/lib/components/ui/multi-value-input/Input.svelte
@@ -61,7 +61,7 @@
 <div
 	{id}
 	class={twMerge(
-		'dark:bg-surface1 text-md bg-surface-1 flex min-h-10 w-full grow resize-none flex-wrap items-center gap-2 rounded-lg px-2 py-2 text-left shadow-inner',
+		'dark:bg-base-200 text-md bg-base-100 flex min-h-10 w-full grow resize-none flex-wrap items-center gap-2 rounded-lg px-2 py-2 text-left shadow-inner',
 		disabled && 'pointer-events-none cursor-default opacity-50',
 		readonly && 'pointer-events-none',
 		klass
@@ -72,7 +72,7 @@
 			{#each values as v (v)}
 				<div
 					class={twMerge(
-						'text-md bg-surface3/50 dark:bg-surface2 inline-flex items-center gap-1 rounded-sm px-1',
+						'text-md bg-base-400/50 dark:bg-base-300 inline-flex items-center gap-1 rounded-sm px-1',
 						classes?.chip
 					)}
 					in:fade={{ duration: 100 }}
@@ -86,7 +86,7 @@
 					<div class="flex h-[22.5px] items-center place-self-start">
 						<button
 							class={twMerge(
-								'button rounded-xs p-0 transition-colors duration-300',
+								'btn btn-circle btn-secondary size-4 btn-xs border-transparent text-muted-content hover:text-base-content',
 								classes?.clearButton
 							)}
 							{disabled}
@@ -97,7 +97,7 @@
 								assignValues(values.filter((d) => d !== v));
 							}}
 						>
-							<X class="size-4 " />
+							<X class="size-3" />
 						</button>
 					</div>
 				</div>
@@ -158,7 +158,7 @@
 		<button
 			transition:fade={{ duration: 100 }}
 			class={twMerge(
-				'bg-surface3/50 hover:bg-surface3/70 active:bg-surface3/80 rounded-sm p-0.5 transition-colors duration-300',
+				'bg-base-400/50 hover:bg-base-400/70 active:bg-base-400/80 rounded-sm p-0.5 transition-colors duration-300',
 				classes?.clearButton
 			)}
 			type="button"

--- a/ui/user/src/lib/components/ui/virtual-page/virtual-page-viewport.svelte
+++ b/ui/user/src/lib/components/ui/virtual-page/virtual-page-viewport.svelte
@@ -291,7 +291,7 @@
 </script>
 
 <Render
-	class="bg-surface1 dark:bg-background flex h-[100svh] max-h-[100svh] w-full overflow-hidden"
+	class="bg-base-200 dark:bg-base-100 flex h-svh max-h-svh w-full overflow-hidden"
 	as={as ?? 'div'}
 	{...restProps}
 	{@attach (node: HTMLElement) => {

--- a/ui/user/src/lib/diff.ts
+++ b/ui/user/src/lib/diff.ts
@@ -22,14 +22,14 @@ export function formatJsonWithHighlighting(json: unknown): string {
 		);
 
 		// Replace null
-		highlighted = highlighted.replace(/: (null)/g, ': <span class="text-on-surface1">$1</span>');
+		highlighted = highlighted.replace(/: (null)/g, ': <span class="text-muted-content">$1</span>');
 
 		// Replace brackets and braces
 		highlighted = highlighted.replace(/(".*?")|([{}[\]])/g, (match, stringContent, bracket) => {
 			if (stringContent) {
 				return stringContent;
 			}
-			return `<span class="text-on-background">${bracket}</span>`;
+			return `<span class="text-base-content">${bracket}</span>`;
 		});
 
 		return highlighted;
@@ -196,13 +196,13 @@ export function formatTextWithDiffHighlighting(
 		const escaped = escapeHtml(op.line);
 		let lineClass = 'text-base-content';
 		if (op.type === 'removed') {
-			lineClass = 'bg-red-500/20 text-red-700 dark:text-red-400';
+			lineClass = 'bg-error/20 text-error';
 		} else if (op.type === 'added') {
-			lineClass = 'bg-green-500/20 text-green-700 dark:text-green-400';
+			lineClass = 'bg-success/20 text-success';
 		} else if (op.type === 'modified') {
-			lineClass = 'bg-yellow-500/20 text-yellow-800 dark:text-yellow-300';
+			lineClass = 'bg-warning/20 text-warning';
 		}
-		html += `<div class="font-mono text-sm whitespace-pre-wrap break-words ${lineClass} px-2 py-0.5 border-l-2 border-transparent">${escaped}</div>`;
+		html += `<div class="font-mono text-sm whitespace-pre-wrap wrap-break-word ${lineClass} px-2 py-0.5 border-l-2 border-transparent">${escaped}</div>`;
 	}
 	return html;
 }
@@ -256,10 +256,10 @@ export function formatDiffLine(line: string, type: 'added' | 'removed' | 'unchan
 	const baseClass = 'font-mono text-sm';
 	const typeClass =
 		type === 'added'
-			? 'bg-green-500/10 dark:bg-green-900/30 text-green-500'
+			? 'bg-success/10 text-success'
 			: type === 'removed'
-				? 'bg-red-500/10 text-red-500'
-				: 'text-gray-700 dark:text-gray-300';
+				? 'bg-error/10 text-error'
+				: 'text-muted-content';
 
 	return `<div class="${baseClass} ${typeClass} px-2 py-0.5">${prefix}${line}</div>`;
 }
@@ -297,12 +297,12 @@ export function formatJsonWithDiffHighlighting(
 			const line = op.line;
 
 			// Determine line styling based on operation type
-			let lineClass = 'text-gray-700 dark:text-gray-300';
+			let lineClass = 'text-muted-content';
 
 			if (op.type === 'removed') {
-				lineClass = 'bg-red-500/10 text-red-500';
+				lineClass = 'bg-error/10 text-error';
 			} else if (op.type === 'added') {
-				lineClass = 'bg-green-500/10 text-green-500';
+				lineClass = 'bg-success/10 text-success';
 			}
 
 			// Apply JSON syntax highlighting
@@ -329,13 +329,13 @@ export function formatJsonWithDiffHighlighting(
 			// Replace string values
 			highlightedLine = highlightedLine.replace(
 				/: "([^"]+)"/g,
-				': <span class="text-gray-600 dark:text-gray-300 whitespace-normal break-words">"$1"</span>'
+				': <span class="text-gray-600 dark:text-gray-300 whitespace-normal wrap-break-word">"$1"</span>'
 			);
 
 			// Replace null
 			highlightedLine = highlightedLine.replace(
 				/: (null)/g,
-				': <span class="text-on-surface1">$1</span>'
+				': <span class="text-muted-content">$1</span>'
 			);
 
 			// Replace brackets and braces
@@ -345,7 +345,7 @@ export function formatJsonWithDiffHighlighting(
 					if (stringContent) {
 						return stringContent;
 					}
-					return `<span class="text-on-background">${bracket}</span>`;
+					return `<span class="text-base-content">${bracket}</span>`;
 				}
 			);
 

--- a/ui/user/src/lib/icons/Loading.svelte
+++ b/ui/user/src/lib/icons/Loading.svelte
@@ -9,4 +9,4 @@
 	let { class: klass = '' }: Props = $props();
 </script>
 
-<LoaderCircle class={twMerge('text-primary h-5 w-5 animate-spin', klass)} />
+<LoaderCircle class={twMerge('text-primary size-5 animate-spin', klass)} />

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -797,18 +797,33 @@ export interface AppPreferencesManifest {
 	theme?: {
 		backgroundColor?: string;
 		onBackgroundColor?: string;
-		onSurfaceColor?: string;
 		surface1Color?: string;
 		surface2Color?: string;
 		surface3Color?: string;
+		secondaryColor?: string;
+		successColor?: string;
+		warningColor?: string;
+		errorColor?: string;
 		primaryColor?: string;
+		onPrimaryColor?: string;
+		onSuccessColor?: string;
+		onWarningColor?: string;
+		onErrorColor?: string;
 		darkBackgroundColor?: string;
 		darkOnBackgroundColor?: string;
-		darkOnSurfaceColor?: string;
 		darkSurface1Color?: string;
 		darkSurface2Color?: string;
 		darkSurface3Color?: string;
+		darkSecondaryColor?: string;
+		darkSuccessColor?: string;
+		darkWarningColor?: string;
+		darkErrorColor?: string;
 		darkPrimaryColor?: string;
+		darkOnPrimaryColor?: string;
+		darkOnSuccessColor?: string;
+		darkOnWarningColor?: string;
+		darkOnErrorColor?: string;
+		fontFamily?: string;
 	};
 }
 
@@ -827,18 +842,33 @@ export interface AppPreferences {
 	theme: {
 		backgroundColor: string;
 		onBackgroundColor: string;
-		onSurfaceColor: string;
+		onPrimaryColor: string;
+		onSuccessColor: string;
+		onWarningColor: string;
+		onErrorColor: string;
 		surface1Color: string;
 		surface2Color: string;
 		surface3Color: string;
+		secondaryColor: string;
 		primaryColor: string;
+		successColor: string;
+		warningColor: string;
+		errorColor: string;
 		darkBackgroundColor: string;
 		darkOnBackgroundColor: string;
-		darkOnSurfaceColor: string;
+		darkOnPrimaryColor: string;
+		darkOnSuccessColor: string;
+		darkOnWarningColor: string;
+		darkOnErrorColor: string;
 		darkSurface1Color: string;
 		darkSurface2Color: string;
 		darkSurface3Color: string;
+		darkSecondaryColor: string;
 		darkPrimaryColor: string;
+		darkSuccessColor: string;
+		darkWarningColor: string;
+		darkErrorColor: string;
+		fontFamily: string;
 	};
 }
 

--- a/ui/user/src/lib/stores/appPreferences.svelte.ts
+++ b/ui/user/src/lib/stores/appPreferences.svelte.ts
@@ -23,6 +23,20 @@ export const DEFAULT_LOGOS = {
 	}
 } as const;
 
+/** Default UI font stack; kept in sync with `app.css` (`--theme-font-family` fallback). */
+export const DEFAULT_FONT_FAMILY =
+	'Poppins, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji';
+
+export const FONT_FAMILY_PRESETS: { label: string; value: string }[] = [
+	{ label: 'Poppins', value: DEFAULT_FONT_FAMILY },
+	{
+		label: 'Helvetica Neue',
+		value:
+			'Helvetica Neue, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji'
+	},
+	{ label: 'System Default', value: 'ui-sans-serif, system-ui, sans-serif' }
+];
+
 export function compileAppPreferences(preferences?: AppPreferences): AppPreferences {
 	return {
 		logos: {
@@ -40,18 +54,33 @@ export function compileAppPreferences(preferences?: AppPreferences): AppPreferen
 		theme: {
 			backgroundColor: preferences?.theme?.backgroundColor ?? 'hsl(0 0 100)',
 			onBackgroundColor: preferences?.theme?.onBackgroundColor ?? 'hsl(0 0 0)',
-			onSurfaceColor: preferences?.theme?.onSurfaceColor ?? 'hsl(0 0 calc(2.5 + 60))',
 			surface1Color: preferences?.theme?.surface1Color ?? 'hsl(0 0 calc(2.5 + 93))',
 			surface2Color: preferences?.theme?.surface2Color ?? 'hsl(0 0 calc(2.5 + 90))',
 			surface3Color: preferences?.theme?.surface3Color ?? 'hsl(0 0 calc(2.5 + 80))',
+			secondaryColor: preferences?.theme?.secondaryColor ?? 'hsl(0 0 82.5)',
+			successColor: preferences?.theme?.successColor ?? 'oklch(67% 0.13 149)',
+			warningColor: preferences?.theme?.warningColor ?? 'oklch(79.5% 0.184 86.047)',
+			errorColor: preferences?.theme?.errorColor ?? '#ef4444',
 			primaryColor: preferences?.theme?.primaryColor ?? '#4f7ef3',
+			onPrimaryColor: preferences?.theme?.onPrimaryColor ?? 'hsl(0 0 100)',
+			onSuccessColor: preferences?.theme?.onSuccessColor ?? 'hsl(0 0 100)',
+			onWarningColor: preferences?.theme?.onWarningColor ?? 'hsl(0 0 100)',
+			onErrorColor: preferences?.theme?.onErrorColor ?? 'hsl(0 0 100)',
 			darkBackgroundColor: preferences?.theme?.darkBackgroundColor ?? 'hsl(0 0 0)',
 			darkOnBackgroundColor: preferences?.theme?.darkOnBackgroundColor ?? 'hsl(0 0 calc(2.5 + 95))',
-			darkOnSurfaceColor: preferences?.theme?.darkOnSurfaceColor ?? 'hsl(0 0 calc(2.5 + 50))',
 			darkSurface1Color: preferences?.theme?.darkSurface1Color ?? 'hsl(0 0 calc(2.5 + 5))',
 			darkSurface2Color: preferences?.theme?.darkSurface2Color ?? 'hsl(0 0 calc(2.5 + 10))',
 			darkSurface3Color: preferences?.theme?.darkSurface3Color ?? 'hsl(0 0 calc(2.5 + 20))',
-			darkPrimaryColor: preferences?.theme?.darkPrimaryColor ?? '#4f7ef3'
+			darkSecondaryColor: preferences?.theme?.darkSecondaryColor ?? 'hsl(0 0 22.5)',
+			darkSuccessColor: preferences?.theme?.darkSuccessColor ?? 'oklch(67% 0.13 149)',
+			darkWarningColor: preferences?.theme?.darkWarningColor ?? 'oklch(79.5% 0.184 86.047)',
+			darkErrorColor: preferences?.theme?.darkErrorColor ?? '#ef4444',
+			darkPrimaryColor: preferences?.theme?.darkPrimaryColor ?? '#4f7ef3',
+			darkOnPrimaryColor: preferences?.theme?.darkOnPrimaryColor ?? 'hsl(0 0 97.5)',
+			darkOnSuccessColor: preferences?.theme?.darkOnSuccessColor ?? 'hsl(0 0 97.5)',
+			darkOnWarningColor: preferences?.theme?.darkOnWarningColor ?? 'hsl(0 0 97.5)',
+			darkOnErrorColor: preferences?.theme?.darkOnErrorColor ?? 'hsl(0 0 97.5)',
+			fontFamily: preferences?.theme?.fontFamily ?? DEFAULT_FONT_FAMILY
 		}
 	};
 }
@@ -75,11 +104,18 @@ function setThemeColors(colors: AppPreferences['theme']) {
 		'--theme-on-background-light',
 		colors.onBackgroundColor
 	);
-	document.documentElement.style.setProperty('--theme-on-surface-light', colors.onSurfaceColor);
 	document.documentElement.style.setProperty('--theme-surface1-light', colors.surface1Color);
 	document.documentElement.style.setProperty('--theme-surface2-light', colors.surface2Color);
 	document.documentElement.style.setProperty('--theme-surface3-light', colors.surface3Color);
 	document.documentElement.style.setProperty('--theme-primary-light', colors.primaryColor);
+	document.documentElement.style.setProperty('--theme-on-primary-light', colors.onPrimaryColor);
+	document.documentElement.style.setProperty('--theme-on-success-light', colors.onSuccessColor);
+	document.documentElement.style.setProperty('--theme-on-warning-light', colors.onWarningColor);
+	document.documentElement.style.setProperty('--theme-on-error-light', colors.onErrorColor);
+	document.documentElement.style.setProperty('--theme-secondary-light', colors.secondaryColor);
+	document.documentElement.style.setProperty('--theme-success-light', colors.successColor);
+	document.documentElement.style.setProperty('--theme-warning-light', colors.warningColor);
+	document.documentElement.style.setProperty('--theme-error-light', colors.errorColor);
 
 	// Set dark theme colors
 	document.documentElement.style.setProperty('--theme-background-dark', colors.darkBackgroundColor);
@@ -87,11 +123,19 @@ function setThemeColors(colors: AppPreferences['theme']) {
 		'--theme-on-background-dark',
 		colors.darkOnBackgroundColor
 	);
-	document.documentElement.style.setProperty('--theme-on-surface-dark', colors.darkOnSurfaceColor);
 	document.documentElement.style.setProperty('--theme-surface1-dark', colors.darkSurface1Color);
 	document.documentElement.style.setProperty('--theme-surface2-dark', colors.darkSurface2Color);
 	document.documentElement.style.setProperty('--theme-surface3-dark', colors.darkSurface3Color);
 	document.documentElement.style.setProperty('--theme-primary-dark', colors.darkPrimaryColor);
+	document.documentElement.style.setProperty('--theme-on-primary-dark', colors.darkOnPrimaryColor);
+	document.documentElement.style.setProperty('--theme-on-success-dark', colors.darkOnSuccessColor);
+	document.documentElement.style.setProperty('--theme-on-warning-dark', colors.darkOnWarningColor);
+	document.documentElement.style.setProperty('--theme-on-error-dark', colors.darkOnErrorColor);
+	document.documentElement.style.setProperty('--theme-secondary-dark', colors.darkSecondaryColor);
+	document.documentElement.style.setProperty('--theme-success-dark', colors.darkSuccessColor);
+	document.documentElement.style.setProperty('--theme-warning-dark', colors.darkWarningColor);
+	document.documentElement.style.setProperty('--theme-error-dark', colors.darkErrorColor);
+	document.documentElement.style.setProperty('--theme-font-family', colors.fontFamily);
 }
 
 function initialize(preferences: AppPreferences) {

--- a/ui/user/src/routes/+error.svelte
+++ b/ui/user/src/routes/+error.svelte
@@ -29,9 +29,9 @@
 			<Logo variant="error" class="h-[200px] w-[200px]" />
 		</div>
 		<div
-			class="speech-bubble bg-surface2 after:border-r-surface2 relative m-4 flex flex-col items-center justify-center rounded-md
+			class="speech-bubble bg-base-300 after:border-r-base-300 relative m-4 flex flex-col items-center justify-center rounded-md
     p-4 after:absolute after:top-[50%] after:left-0 after:mt-[-20px] after:ml-[-40px]
-    after:h-0 after:w-0 after:border-[40px] after:border-b-0
+    after:h-0 after:w-0 after:border-40 after:border-b-0
     after:border-l-0 after:border-transparent after:content-['']"
 		>
 			<div class="text-8xl font-bold">{page.status}</div>
@@ -45,8 +45,8 @@
 			<CollapsePane
 				header="More Details"
 				classes={{
-					header: 'bg-surface2 justify-between',
-					content: 'bg-surface1'
+					header: 'bg-base-300 justify-between',
+					content: 'bg-base-200'
 				}}
 			>
 				<div class="">{page.error.message}</div>
@@ -54,5 +54,5 @@
 		</div>
 	{/if}
 
-	<a href={resolve('/')} class="button-primary"> Go Home </a>
+	<a href={resolve('/')} class="btn btn-primary"> Go Home </a>
 </div>

--- a/ui/user/src/routes/+layout.svelte
+++ b/ui/user/src/routes/+layout.svelte
@@ -60,8 +60,10 @@
 		const html = document.querySelector('html');
 		if (darkMode.isDark) {
 			html?.classList.add('dark');
+			html?.setAttribute('data-theme', 'nanobotdark');
 		} else {
 			html?.classList.remove('dark');
+			html?.setAttribute('data-theme', 'nanobotlight');
 		}
 
 		// Hide the initial loader

--- a/ui/user/src/routes/+page.svelte
+++ b/ui/user/src/routes/+page.svelte
@@ -39,25 +39,25 @@
 {/if}
 
 {#snippet unauthorizedContent()}
-	<div class="text-on-background relative flex h-dvh w-full flex-col">
+	<div class="text-base-content relative flex h-dvh w-full flex-col">
 		<main
-			class="dark:from-surface2 to-surface1 mx-auto flex h-full w-full flex-col items-center justify-center gap-18 bg-radial-[at_50%_50%] from-gray-50 pb-6 md:gap-24 md:pb-12 dark:to-black"
+			class="dark:from-base-300 to-base-200 mx-auto flex h-full w-full flex-col items-center justify-center gap-18 bg-radial-[at_50%_50%] from-gray-50 pb-6 md:gap-24 md:pb-12 dark:to-black"
 		>
 			<div
 				class="absolute top-1/2 left-1/2 flex w-md -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-4"
 			>
 				<Logo class="h-16" />
 				<h1 class="text-2xl font-semibold">Welcome to Obot</h1>
-				<p class="text-md text-on-surface1 mb-1 text-center font-light">
+				<p class="text-md text-muted-content mb-1 text-center font-light">
 					Log in or create your account to continue
 				</p>
 
 				<div
-					class="dark:border-surface3 dark:bg-gray-930 bg-background flex w-sm flex-col gap-4 rounded-xl border border-transparent p-4 shadow-sm"
+					class="dark:border-base-400 dark:bg-base-200 bg-base-100 flex w-sm flex-col gap-4 rounded-xl border border-transparent p-4 shadow-sm"
 				>
 					{#each authProviders as provider (provider.id)}
 						<button
-							class="group bg-surface2 hover:bg-surface3 flex w-full items-center justify-center gap-1.5 rounded-full p-2 px-8 text-lg font-semibold transition-colors duration-200"
+							class="btn btn-secondary w-full"
 							onclick={() => {
 								localStorage.setItem('preAuthRedirect', window.location.href);
 								window.location.href = `/oauth2/start?rd=${encodeURIComponent(
@@ -67,7 +67,7 @@
 						>
 							{#if provider.icon}
 								<img
-									class="h-6 w-6 rounded-full bg-transparent p-1 dark:bg-gray-600"
+									class="h-6 w-6 rounded-full bg-base-100 p-1 dark:bg-gray-600"
 									src={provider.icon}
 									alt={provider.name}
 								/>

--- a/ui/user/src/routes/admin/+page.svelte
+++ b/ui/user/src/routes/admin/+page.svelte
@@ -3,9 +3,10 @@
 	import Navbar from '$lib/components/Navbar.svelte';
 	import SensitiveInput from '$lib/components/SensitiveInput.svelte';
 	import BetaLogo from '$lib/components/navbar/BetaLogo.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, type BootstrapStatus, type TempUser } from '$lib/services';
 	import { goto } from '$lib/url';
-	import { AlertCircle, Handshake, LoaderCircle, ShieldAlert } from 'lucide-svelte';
+	import { CircleAlert, Handshake, ShieldAlert } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { slide } from 'svelte/transition';
 
@@ -43,13 +44,13 @@
 
 <div class="flex min-h-dvh flex-col items-center">
 	<main
-		class="bg-surface1 default-scrollbar-thin dark:bg-background relative flex h-svh w-full grow flex-col overflow-y-auto"
+		class="bg-base-200 default-scrollbar-thin dark:bg-base-100 relative flex h-svh w-full grow flex-col overflow-y-auto"
 	>
 		<Navbar class="dark:bg-gray-990 sticky top-0 left-0 z-30 w-full" unauthorized />
 		<div class="flex min-h-1 w-full grow items-center justify-center">
 			{#await fetchBootstrapStatus}
 				<div class="size-10">
-					<LoaderCircle class="text-primary size-8 animate-spin" />
+					<Loading class="size-8" />
 				</div>
 			{:then bootstrapStatus}
 				{#if showSetupHandoff}
@@ -65,14 +66,14 @@
 {#snippet setupView()}
 	{#await tempDataPromises}
 		<div class="size-10">
-			<LoaderCircle class="text-primary size-8 animate-spin" />
+			<Loading class="size-8" />
 		</div>
 	{:then response}
 		{@const [tempUser, explicitRoles] = response ?? []}
 		{@const isExplicitAdmin = explicitRoles?.admins?.includes(tempUser?.email ?? '') ?? false}
 		{#if tempUser}
 			<div
-				class="dark:bg-surface2 dark:border-surface3 bg-background flex w-md max-w-full flex-col rounded-lg border border-transparent px-4 py-8 shadow-sm"
+				class="dark:bg-base-300 dark:border-base-400 bg-base-100 flex w-md max-w-full flex-col rounded-lg border border-transparent px-4 py-8 shadow-sm"
 			>
 				<BetaLogo class="self-center" />
 
@@ -89,7 +90,7 @@
 						</p>
 					</div>
 					<button
-						class="button place-items-center"
+						class="btn btn-secondary place-items-center"
 						onclick={async () => {
 							await AdminService.bootstrapLogout();
 							// make sure to clear seenSplashDialog so splash will show for logged in owner if needed
@@ -136,7 +137,7 @@
 					<div class="flex flex-col gap-2">
 						{#if !isExplicitAdmin}
 							<button
-								class="button-primary place-items-center"
+								class="btn btn-primary place-items-center"
 								onclick={async () => {
 									loadingConfirmTempUser = true;
 									await AdminService.confirmTempUserAsOwner(tempUser.email);
@@ -146,14 +147,14 @@
 								disabled={loadingCancelTempUser || loadingConfirmTempUser}
 							>
 								{#if loadingConfirmTempUser}
-									<LoaderCircle class="size-4 animate-spin" />
+									<Loading class="size-4" />
 								{:else}
 									Yes, make this account an owner
 								{/if}
 							</button>
 						{/if}
 						<button
-							class="button place-items-center"
+							class="btn btn-secondary place-items-center"
 							onclick={async () => {
 								loadingCancelTempUser = true;
 								await AdminService.cancelTempLogin();
@@ -162,7 +163,7 @@
 							disabled={loadingCancelTempUser || loadingConfirmTempUser}
 						>
 							{#if loadingCancelTempUser}
-								<LoaderCircle class="size-4 animate-spin" />
+								<Loading class="size-4" />
 							{:else}
 								{isExplicitAdmin ? 'Go Back' : 'No, cancel & go back'}
 							{/if}
@@ -176,14 +177,14 @@
 
 {#snippet loginView(bootstrapStatus?: BootstrapStatus)}
 	<form
-		class="dark:bg-surface2 dark:border-surface3 bg-background flex w-sm flex-col rounded-lg border border-transparent px-4 py-8 shadow-sm"
+		class="dark:bg-base-300 dark:border-base-400 bg-base-100 flex w-sm flex-col rounded-lg border border-transparent px-4 py-8 shadow-sm"
 		onsubmit={(e) => e.preventDefault()}
 	>
 		<BetaLogo class="self-center" />
 
 		{#if error}
 			<div class="notification-error mt-4 flex items-center gap-2">
-				<AlertCircle class="size-6 text-red-500" />
+				<CircleAlert class="size-6 text-error" />
 				<p class="flex flex-col text-sm font-light">
 					<span class="font-semibold">An error occurred!</span>
 					<span>
@@ -195,7 +196,7 @@
 
 		{#if loggedIn && !hasAccess}
 			<div class="relative z-10 my-6 flex w-full flex-col items-center justify-center gap-6">
-				<p class="text-on-surface1 px-8 text-center text-sm font-light md:px-8">
+				<p class="text-muted-content px-8 text-center text-sm font-light md:px-8">
 					You are not authorized to access this page. Please sign in with an authorized account or
 					contact your administrator.
 				</p>
@@ -203,26 +204,26 @@
 
 			<a
 				href={resolve('/oauth2/sign_out?rd=/admin')}
-				class="bg-surface1 hover:bg-surface2 dark:bg-surface1 dark:hover:bg-surface3 flex w-full items-center justify-center gap-1.5 rounded-full p-2 px-8 text-lg font-semibold"
+				class="bg-base-200 hover:bg-base-300 dark:bg-base-200 dark:hover:bg-base-300 flex w-full items-center justify-center gap-1.5 rounded-full p-2 px-8 text-lg font-semibold"
 			>
 				<p class="text-center text-sm font-medium">Sign Out</p>
 			</a>
 		{:else if authProviders.length > 0}
 			<div class="relative z-10 mt-6 flex w-full flex-col items-center justify-center gap-6">
-				<p class="text-md text-on-surface1 px-8 text-center font-light md:px-8">
+				<p class="text-md text-muted-content px-8 text-center font-light md:px-8">
 					To access the admin panel, you need to sign in with an option below.
 				</p>
-				<h3 class="dark:bg-surface2 bg-background px-2 text-lg font-semibold">
+				<h3 class="dark:bg-base-300 bg-base-100 px-2 text-lg font-semibold">
 					Sign in to Your Account
 				</h3>
 			</div>
 
 			<div
-				class="border-surface3 relative flex -translate-y-4 flex-col items-center gap-4 rounded-xl border-2 px-4 pt-6 pb-4"
+				class="border-base-400 relative flex -translate-y-4 flex-col items-center gap-4 rounded-xl border-2 px-4 pt-6 pb-4"
 			>
 				{#each authProviders as authProvider (authProvider.id)}
 					<button
-						class="group bg-surface1 hover:bg-surface2 dark:bg-surface1 dark:hover:bg-surface3 flex w-full items-center justify-center gap-1.5 rounded-full p-2 px-8 text-lg font-semibold"
+						class="btn btn-secondary w-full"
 						onclick={() => {
 							localStorage.setItem('preAuthRedirect', window.location.href);
 							window.location.href = `/oauth2/start?rd=${encodeURIComponent(
@@ -232,7 +233,7 @@
 					>
 						{#if authProvider.icon}
 							<img
-								class="h-6 w-6 rounded-full bg-transparent p-1 dark:bg-gray-600"
+								class="h-6 w-6 rounded-full bg-base-100 p-1 dark:bg-gray-600"
 								src={authProvider.icon}
 								alt={authProvider.name}
 							/>
@@ -244,7 +245,7 @@
 				{#if !showBootstrapLogin && bootstrapStatus?.enabled}
 					<button
 						onclick={() => (showBootstrapLogin = true)}
-						class="bg-surface1 hover:bg-surface2 dark:bg-surface1 dark:hover:bg-surface3 flex w-full items-center justify-center gap-1.5 rounded-full p-2 px-8 text-lg font-semibold"
+						class="bg-base-200 hover:bg-base-300 dark:bg-base-200 dark:hover:bg-base-300 flex w-full items-center justify-center gap-1.5 rounded-full p-2 px-8 text-lg font-semibold"
 					>
 						<p class="text-center text-sm font-medium">Sign in with Bootstrap Token</p>
 					</button>
@@ -269,7 +270,7 @@
 					'Bootstrap Token', or configure it directly through environment variables at startup.
 				</i>
 
-				<button class="button-primary mt-4 text-sm" onclick={handleBootstrapLogin}> Login </button>
+				<button class="btn btn-primary mt-4 text-sm" onclick={handleBootstrapLogin}> Login </button>
 			</div>
 		{/if}
 	</form>

--- a/ui/user/src/routes/admin/agents/+page.svelte
+++ b/ui/user/src/routes/admin/agents/+page.svelte
@@ -4,6 +4,7 @@
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import Search from '$lib/components/Search.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { NanobotService } from '$lib/services';
 	import type { OrgUser } from '$lib/services/admin/types';
@@ -62,7 +63,7 @@
 <Layout title="Agents">
 	<div class="flex flex-col gap-4">
 		<div class="flex items-center justify-between">
-			<p class="text-sm text-gray-500">
+			<p class="text-sm text-muted-content">
 				Browse and connect to agents across all users. Clicking "Connect" will open the agent's chat
 				interface in a new tab.
 			</p>
@@ -70,7 +71,7 @@
 
 		<Search
 			value={query}
-			class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 			onChange={(v) => {
 				const currentUrl = new URL(page.url);
 				if (v) {
@@ -119,8 +120,8 @@
 				{/if}
 			{/snippet}
 			{#snippet actions(agent)}
-				<button
-					class="icon-button hover:text-primary"
+				<IconButton
+					variant="primary"
 					onclick={(e) => {
 						e.stopPropagation();
 						confirmImpersonate = { userDisplayName: agent.ownerDisplay, agent };
@@ -128,14 +129,17 @@
 					disabled={launchingAgentId === agent.id ||
 						!profile.current.canImpersonate?.() ||
 						agent.userID === profile.current.id}
-					use:tooltip={profile.current.canImpersonate?.() && agent.userID !== profile.current.id
-						? `Impersonate ${agent.ownerDisplay}`
-						: agent.userID === profile.current.id
-							? 'You cannot impersonate yourself.'
-							: 'You do not have permission to impersonate other users.'}
+					tooltip={{
+						text:
+							profile.current.canImpersonate?.() && agent.userID !== profile.current.id
+								? `Impersonate ${agent.ownerDisplay}`
+								: agent.userID === profile.current.id
+									? 'You cannot impersonate yourself.'
+									: 'You do not have permission to impersonate other users.'
+					}}
 				>
 					<HatGlasses class="size-4" />
-				</button>
+				</IconButton>
 			{/snippet}
 		</Table>
 	</div>
@@ -156,7 +160,7 @@
 				>{confirmImpersonate?.userDisplayName || 'user'}</b
 			>. Any actions you take will be attributed to this user. Are you sure you wish to continue?
 		</p>
-		<p class="text-on-surface1 mt-4 text-sm">Note: This will open in a new window.</p>
+		<p class="text-muted-content mt-4 text-sm">Note: This will open in a new window.</p>
 	{/snippet}
 </Confirm>
 

--- a/ui/user/src/routes/admin/agents/p/[pid]/s/[id]/details/+page.svelte
+++ b/ui/user/src/routes/admin/agents/p/[pid]/s/[id]/details/+page.svelte
@@ -4,10 +4,11 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerK8sInfo from '$lib/components/admin/McpServerK8sInfo.svelte';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, NanobotService, type OrgUser } from '$lib/services';
 	import { profile } from '$lib/stores';
 	import { getUserDisplayName } from '$lib/utils';
-	import { HatGlasses, LoaderCircle } from 'lucide-svelte';
+	import { HatGlasses } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -48,7 +49,7 @@
 <Layout {title} showBackButton>
 	{#snippet rightNavActions()}
 		<button
-			class="button-primary flex items-center gap-1 text-sm"
+			class="btn btn-primary flex items-center gap-1 text-sm"
 			onclick={() => (confirmImpersonate = true)}
 			use:tooltip={profile.current.canImpersonate?.() && agent?.userID !== profile.current.id
 				? undefined
@@ -64,7 +65,7 @@
 	<div class="flex flex-col gap-6 pb-8" in:fly={{ x: 100, delay: PAGE_TRANSITION_DURATION }}>
 		{#if loading}
 			<div class="flex w-full justify-center">
-				<LoaderCircle class="size-6 animate-spin" />
+				<Loading class="size-6" />
 			</div>
 		{:else}
 			<div class="flex flex-col gap-6">
@@ -100,7 +101,7 @@
 			>. Any actions you take will be attributed to this user. Are you sure you wish to continue?
 		</p>
 
-		<p class="text-on-surface1 mt-4 text-sm">Note: This will open in a new window.</p>
+		<p class="text-muted-content mt-4 text-sm">Note: This will open in a new window.</p>
 	{/snippet}
 </Confirm>
 

--- a/ui/user/src/routes/admin/api-keys/+page.svelte
+++ b/ui/user/src/routes/admin/api-keys/+page.svelte
@@ -93,9 +93,9 @@
 		<div class="flex flex-col gap-4">
 			{#if allApiKeys.length === 0}
 				<div class="mt-26 flex w-md flex-col items-center gap-4 self-center text-center">
-					<KeyRound class="text-on-surface1 size-24 opacity-50" />
-					<h4 class="text-on-surface1 text-lg font-semibold">No API keys</h4>
-					<p class="text-on-surface1 text-sm font-light">
+					<KeyRound class="text-muted-content size-24 opacity-50" />
+					<h4 class="text-muted-content text-lg font-semibold">No API keys</h4>
+					<p class="text-muted-content text-sm font-light">
 						Looks like there aren't any API keys in the system yet. <br />
 						Click the "Create API Key" button above to get started.
 					</p>
@@ -157,7 +157,7 @@
 					{#snippet actions(d)}
 						{#if !isAdminReadonly}
 							<DotDotDot>
-								<button class="menu-button text-red-500" onclick={() => (deletingKey = d)}>
+								<button class="menu-button text-error" onclick={() => (deletingKey = d)}>
 									<Trash2 class="size-4" />
 									Delete
 								</button>
@@ -171,7 +171,7 @@
 
 	{#snippet rightNavActions()}
 		{#if !showCreateNew && !profile.current.isAdminReadonly?.()}
-			<button class="button-primary flex items-center gap-2 text-sm" onclick={showCreateForm}>
+			<button class="btn btn-primary flex items-center gap-2 text-sm" onclick={showCreateForm}>
 				<Plus class="size-4" />
 				Create API Key
 			</button>

--- a/ui/user/src/routes/admin/app-preferences/+page.svelte
+++ b/ui/user/src/routes/admin/app-preferences/+page.svelte
@@ -1,15 +1,43 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import { invalidateAll } from '$app/navigation';
+	import {
+		computeTintedThemePatch,
+		SHADE_TICK_NEUTRAL,
+		type TintedSurfaceSnapshot
+	} from '$lib/colors';
 	import Layout from '$lib/components/Layout.svelte';
+	import Logo from '$lib/components/Logo.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
-	import Toggle from '$lib/components/Toggle.svelte';
+	import Select from '$lib/components/Select.svelte';
 	import UploadImage from '$lib/components/UploadImage.svelte';
-	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import CustomConfigurationForm from '$lib/components/mcp/CustomConfigurationForm.svelte';
+	import Table from '$lib/components/table/Table.svelte';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, type AppPreferences } from '$lib/services';
-	import appPreferences, { compileAppPreferences } from '$lib/stores/appPreferences.svelte';
-	import { darkMode, profile } from '$lib/stores/index.js';
-	import { LoaderCircle, Pencil } from 'lucide-svelte';
+	import { darkMode, profile } from '$lib/stores';
+	import appPreferences, {
+		compileAppPreferences,
+		FONT_FAMILY_PRESETS
+	} from '$lib/stores/appPreferences.svelte';
+	import { formatTimeAgo } from '$lib/time';
+	import TintedSurfaceHueTintShadeControls from './TintedSurfaceHueTintShadeControls.svelte';
+	import {
+		MOCK_CONNECTOR_TABLE_DATA,
+		type BrandingMockConnectorRow,
+		themeLightSurfaceFields,
+		themeDarkSurfaceFields,
+		themeLightIndicatorFields,
+		themeDarkIndicatorFields,
+		textLightFields,
+		textDarkFields,
+		themeLightLogoFields,
+		themeDarkLogoFields,
+		standardIconFields
+	} from './constants.js';
+	import 'devicon/devicon.min.css';
+	import { CircleAlert, HouseIcon, Info, Pencil, X } from 'lucide-svelte';
 	import { onDestroy, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -21,9 +49,6 @@
 	let saving = $state(false);
 	let showSaved = $state(false);
 	let timeout = $state<ReturnType<typeof setTimeout>>();
-	let displayPreviewMode = $state(false);
-	let selectedColorTab = $state<'light' | 'dark'>('light');
-	let selectedIconTab = $state<'light' | 'dark'>('light');
 
 	let editUrlDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let uploadImage = $state<ReturnType<typeof UploadImage>>();
@@ -32,11 +57,206 @@
 
 	let isAdminReadonly = $derived(profile.current.isAdminReadonly?.());
 
+	let selectedColorScheme = $state(untrack(() => (darkMode.isDark ? 'dark' : 'light')));
+	let initialColorScheme = $state(untrack(() => (darkMode.isDark ? 'dark' : 'light')));
+	let selectedSurfaceMode = $state<'solid' | 'tinted'>('solid');
+	let selectedConfigurationMode = $state<'theme' | 'logos'>('theme');
+	let isPerThemeColorsEnabled = $state(false);
+
+	function isLogoAssetUrl(s: string): boolean {
+		const t = s.trim();
+		if (!t) return false;
+		return (
+			t.startsWith('http://') ||
+			t.startsWith('https://') ||
+			t.startsWith('blob:') ||
+			t.startsWith('data:') ||
+			t.startsWith('/')
+		);
+	}
+
+	const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+	/**
+	 * When Per-Theme Colors is off, editing mirrors to the paired light/dark key.
+	 * Background & surface colors are omitted—they always stay independent per theme.
+	 */
+	const THEME_COLOR_COUNTERPART: Partial<
+		Record<keyof AppPreferences['theme'], keyof AppPreferences['theme']>
+	> = {
+		primaryColor: 'darkPrimaryColor',
+		darkPrimaryColor: 'primaryColor',
+		secondaryColor: 'darkSecondaryColor',
+		darkSecondaryColor: 'secondaryColor',
+		successColor: 'darkSuccessColor',
+		darkSuccessColor: 'successColor',
+		warningColor: 'darkWarningColor',
+		darkWarningColor: 'warningColor',
+		errorColor: 'darkErrorColor',
+		darkErrorColor: 'errorColor',
+		onBackgroundColor: 'darkOnBackgroundColor',
+		darkOnBackgroundColor: 'onBackgroundColor',
+		onPrimaryColor: 'darkOnPrimaryColor',
+		darkOnPrimaryColor: 'onPrimaryColor',
+		onSuccessColor: 'darkOnSuccessColor',
+		darkOnSuccessColor: 'onSuccessColor',
+		onWarningColor: 'darkOnWarningColor',
+		darkOnWarningColor: 'onWarningColor',
+		onErrorColor: 'darkOnErrorColor',
+		darkOnErrorColor: 'onErrorColor'
+	};
+
+	function isValidThemeColorString(raw: string): boolean {
+		const value = raw.trim();
+		if (!value) return false;
+		if (value.startsWith('#')) {
+			return HEX_COLOR_RE.test(value);
+		}
+		const lower = value.toLowerCase();
+		if (lower.startsWith('hsl(') || lower.startsWith('hsla(')) {
+			return typeof CSS !== 'undefined' && CSS.supports('color', value);
+		}
+		if (lower.startsWith('oklch(')) {
+			return typeof CSS !== 'undefined' && CSS.supports('color', value);
+		}
+		return false;
+	}
+
+	function surfacesSnapshotFromTheme(theme: AppPreferences['theme']): TintedSurfaceSnapshot {
+		return {
+			light: {
+				backgroundColor: theme.backgroundColor,
+				surface1Color: theme.surface1Color,
+				surface2Color: theme.surface2Color,
+				surface3Color: theme.surface3Color
+			},
+			dark: {
+				darkBackgroundColor: theme.darkBackgroundColor,
+				darkSurface1Color: theme.darkSurface1Color,
+				darkSurface2Color: theme.darkSurface2Color,
+				darkSurface3Color: theme.darkSurface3Color
+			}
+		};
+	}
+
+	/** Surfaces under Custom (solid); unchanged while editing Tinted so switching modes restores each side. */
+	let customSurfaces = $state<TintedSurfaceSnapshot>(
+		surfacesSnapshotFromTheme(compileAppPreferences(untrack(() => data.appPreferences)).theme)
+	);
+
+	let tintedHueLight = $state(0);
+	let tintedHueDark = $state(0);
+	let tintedTintLight = $state(0);
+	let tintedTintDark = $state(0);
+	let tintedShadeLight = $state(SHADE_TICK_NEUTRAL);
+	let tintedShadeDark = $state(SHADE_TICK_NEUTRAL);
+	let tintedSurfaceSnapshot = $state<TintedSurfaceSnapshot | null>(null);
+
+	function themeSurfacePatch(snapshot: TintedSurfaceSnapshot): Partial<AppPreferences['theme']> {
+		return {
+			backgroundColor: snapshot.light.backgroundColor,
+			surface1Color: snapshot.light.surface1Color,
+			surface2Color: snapshot.light.surface2Color,
+			surface3Color: snapshot.light.surface3Color,
+			darkBackgroundColor: snapshot.dark.darkBackgroundColor,
+			darkSurface1Color: snapshot.dark.darkSurface1Color,
+			darkSurface2Color: snapshot.dark.darkSurface2Color,
+			darkSurface3Color: snapshot.dark.darkSurface3Color
+		};
+	}
+
+	function patchCustomSurface(
+		snapshot: TintedSurfaceSnapshot,
+		key: keyof AppPreferences['theme'],
+		value: string
+	): TintedSurfaceSnapshot {
+		switch (key) {
+			case 'backgroundColor':
+			case 'surface1Color':
+			case 'surface2Color':
+			case 'surface3Color':
+				return {
+					...snapshot,
+					light: { ...snapshot.light, [key]: value }
+				};
+			case 'darkBackgroundColor':
+			case 'darkSurface1Color':
+			case 'darkSurface2Color':
+			case 'darkSurface3Color':
+				return {
+					...snapshot,
+					dark: { ...snapshot.dark, [key]: value }
+				};
+			default:
+				return snapshot;
+		}
+	}
+
+	function applyCustomSurfacesToForm(): AppPreferences {
+		return {
+			...form,
+			theme: { ...form.theme, ...themeSurfacePatch(customSurfaces) }
+		};
+	}
+
+	/** Tinted bases always use the stock default surface ladder from compile defaults—not Custom colors. */
+	function captureTintedSurfaceSnapshot() {
+		const defaultTheme = compileAppPreferences().theme;
+		tintedSurfaceSnapshot = surfacesSnapshotFromTheme(defaultTheme);
+	}
+
+	function resetTintedControls() {
+		tintedHueLight = 0;
+		tintedHueDark = 0;
+		tintedTintLight = 0;
+		tintedTintDark = 0;
+		tintedShadeLight = SHADE_TICK_NEUTRAL;
+		tintedShadeDark = SHADE_TICK_NEUTRAL;
+	}
+
+	$effect(() => {
+		if (!browser) return;
+		if (selectedSurfaceMode !== 'tinted') return;
+		const snap = tintedSurfaceSnapshot;
+		if (!snap) return;
+		const patch = computeTintedThemePatch(
+			snap,
+			{
+				hueDeg: tintedHueLight,
+				tint0to100: tintedTintLight,
+				shadeTick: tintedShadeLight
+			},
+			{
+				hueDeg: tintedHueDark,
+				tint0to100: tintedTintDark,
+				shadeTick: tintedShadeDark
+			}
+		);
+		untrack(() => {
+			form = { ...form, theme: { ...form.theme, ...patch } };
+			appPreferences.setThemeColors(form.theme);
+		});
+	});
+
 	onDestroy(() => {
 		if (browser) {
+			darkMode.setDark(initialColorScheme === 'dark');
 			appPreferences.setThemeColors(appPreferences.current.theme);
 		}
 	});
+
+	function isSurfaceThemeKey(id: keyof AppPreferences['theme']): boolean {
+		return (
+			id === 'backgroundColor' ||
+			id === 'surface1Color' ||
+			id === 'surface2Color' ||
+			id === 'surface3Color' ||
+			id === 'darkBackgroundColor' ||
+			id === 'darkSurface1Color' ||
+			id === 'darkSurface2Color' ||
+			id === 'darkSurface3Color'
+		);
+	}
 
 	async function handleSave() {
 		if (timeout) {
@@ -44,11 +264,17 @@
 		}
 		saving = true;
 		try {
-			appPreferences.current = form;
-			appPreferences.setThemeColors(form.theme);
-			await AdminService.updateAppPreferences(form);
+			let saveForm = form;
+			if (selectedSurfaceMode === 'solid') {
+				saveForm = applyCustomSurfacesToForm();
+				form = saveForm;
+			}
+			appPreferences.current = saveForm;
+			appPreferences.setThemeColors(saveForm.theme);
+			await AdminService.updateAppPreferences(saveForm);
 			await invalidateAll();
-			prevAppPreferences = form;
+			prevAppPreferences = saveForm;
+			customSurfaces = surfacesSnapshotFromTheme(saveForm.theme);
 			showSaved = true;
 			timeout = setTimeout(() => {
 				showSaved = false;
@@ -60,364 +286,560 @@
 			saving = false;
 		}
 	}
-
-	const standardIconFields: { id: keyof AppPreferences['logos']; label: string }[] = [
-		{
-			id: 'logoIcon',
-			label: 'Default Icon'
-		},
-		{
-			id: 'logoIconError',
-			label: 'Error Icon'
-		},
-		{
-			id: 'logoIconWarning',
-			label: 'Warning Icon'
-		}
-	];
-
-	const themeLightLogoFields: { id: keyof AppPreferences['logos']; label: string }[] = [
-		{
-			id: 'logoDefault',
-			label: 'Full Logo'
-		},
-		{
-			id: 'logoEnterprise',
-			label: 'Full Enterprise Logo'
-		},
-		{
-			id: 'logoChat',
-			label: 'Full Chat Logo'
-		}
-	];
-
-	const themeDarkLogoFields: { id: keyof AppPreferences['logos']; label: string }[] = [
-		{
-			id: 'darkLogoDefault',
-			label: 'Full Logo'
-		},
-		{
-			id: 'darkLogoEnterprise',
-			label: 'Full Enterprise Logo'
-		},
-		{
-			id: 'darkLogoChat',
-			label: 'Full Chat Logo'
-		}
-	];
-
-	const themeLightColorFields: { id: keyof AppPreferences['theme']; label: string }[][] = [
-		[
-			{
-				id: 'primaryColor',
-				label: 'Primary'
-			}
-		],
-		[
-			{
-				id: 'backgroundColor',
-				label: 'Background'
-			},
-			{
-				id: 'onBackgroundColor',
-				label: 'Primary Text'
-			},
-			{
-				id: 'onSurfaceColor',
-				label: 'Secondary Text'
-			}
-		],
-		[
-			{
-				id: 'surface1Color',
-				label: 'Surface 1'
-			},
-			{
-				id: 'surface2Color',
-				label: 'Surface 2'
-			},
-			{
-				id: 'surface3Color',
-				label: 'Surface 3'
-			}
-		]
-	];
-
-	const themeDarkColorFields: { id: keyof AppPreferences['theme']; label: string }[][] = [
-		[
-			{
-				id: 'darkPrimaryColor',
-				label: 'Primary'
-			}
-		],
-		[
-			{
-				id: 'darkBackgroundColor',
-				label: 'Background'
-			},
-			{
-				id: 'darkOnBackgroundColor',
-				label: 'Primary Text'
-			},
-			{
-				id: 'darkOnSurfaceColor',
-				label: 'Secondary Text'
-			}
-		],
-		[
-			{
-				id: 'darkSurface1Color',
-				label: 'Surface 1'
-			},
-			{
-				id: 'darkSurface2Color',
-				label: 'Surface 2'
-			},
-			{
-				id: 'darkSurface3Color',
-				label: 'Surface 3'
-			}
-		]
-	];
 </script>
 
-<Layout classes={{ container: 'pb-0' }}>
-	<div class="relative h-full w-full" transition:fade={{ duration }}>
-		<div class="flex flex-col gap-8">
-			<div class="flex items-center gap-4">
-				<h1 class="text-2xl font-semibold">Branding</h1>
-				<button
-					class="button text-xs"
-					onclick={() => {
-						form = compileAppPreferences();
-						if (displayPreviewMode) {
-							appPreferences.setThemeColors(form.theme);
-						}
-					}}
-				>
-					Restore Default
-				</button>
-			</div>
+<Layout title="Branding" classes={{ container: 'pb-0' }}>
+	{#snippet rightSidebar()}
+		<div
+			class="bg-base-100 dark:bg-base-200 border-base-300 h-dvh w-sm min-w-sm overflow-y-auto border-l flex flex-col"
+		>
+			<div class="flex flex-col divide-y divide-base-300">
+				<div class="flex items-center justify-between px-4 py-2">
+					<h3 class="text-base font-semibold">Configuration</h3>
+					<div
+						class="flex items-center p-1.5 bg-base-200 dark:bg-base-300 rounded-4xl shadow-inner"
+					>
+						<button
+							class={twMerge(
+								'btn btn-sm rounded-r-none!',
+								selectedConfigurationMode === 'theme' ? 'btn-primary' : 'btn-secondary'
+							)}
+							onclick={() => {
+								selectedConfigurationMode = 'theme';
+							}}>Theme</button
+						>
+						<button
+							class={twMerge(
+								'btn btn-sm rounded-l-none!',
+								selectedConfigurationMode === 'logos' ? 'btn-primary' : 'btn-secondary'
+							)}
+							onclick={() => {
+								selectedConfigurationMode = 'logos';
+							}}>Logos</button
+						>
+					</div>
+				</div>
+				<div class="flex items-center justify-between px-4 py-2">
+					<p class="text-sm font-medium">Mode</p>
+					<div
+						class="flex items-center p-1.5 bg-base-200 dark:bg-base-300 rounded-4xl shadow-inner"
+					>
+						<button
+							class={twMerge(
+								'btn btn-sm rounded-r-none!',
+								selectedColorScheme === 'light' ? 'btn-primary' : 'btn-secondary'
+							)}
+							onclick={() => {
+								selectedColorScheme = 'light';
+								darkMode.setDark(false);
+								appPreferences.setThemeColors(form.theme);
+							}}>Light</button
+						>
+						<button
+							class={twMerge(
+								'btn btn-sm rounded-l-none!',
+								selectedColorScheme === 'dark' ? 'btn-primary' : 'btn-secondary'
+							)}
+							onclick={() => {
+								selectedColorScheme = 'dark';
+								darkMode.setDark(true);
+								appPreferences.setThemeColors(form.theme);
+							}}>Dark</button
+						>
+					</div>
+				</div>
 
-			<div class="flex flex-col gap-1">
-				<div class="flex justify-between gap-4">
-					<h2 class="text-lg font-semibold">Theme Colors</h2>
-					<Toggle
-						label="Live Preview Mode"
-						labelInline
-						checked={displayPreviewMode}
-						onChange={(checked) => {
-							displayPreviewMode = checked;
-							appPreferences.setThemeColors(checked ? form.theme : appPreferences.current.theme);
-						}}
-					/>
-				</div>
-				<div class="paper p-0">
-					<div class="flex">
-						<button
-							class={twMerge(
-								'page-tab max-w-full flex-1',
-								selectedColorTab === 'light' && 'page-tab-active'
-							)}
-							onclick={() => (selectedColorTab = 'light')}
-						>
-							Light Scheme
-						</button>
-						<button
-							class={twMerge(
-								'page-tab max-w-full flex-1',
-								selectedColorTab === 'dark' && 'page-tab-active'
-							)}
-							onclick={() => (selectedColorTab = 'dark')}
-						>
-							Dark Scheme
-						</button>
-					</div>
-					<div class="flex flex-col gap-8 pt-4 pb-8">
-						{#if selectedColorTab === 'light'}
-							{@render colorFields('light')}
-						{:else}
-							{@render colorFields('dark')}
-						{/if}
-					</div>
-				</div>
+				{#if selectedConfigurationMode === 'theme'}
+					{@render themeConfiguration()}
+				{/if}
+				{#if selectedConfigurationMode === 'logos'}
+					{@render logosConfiguration()}
+				{/if}
 			</div>
-			<div class="flex flex-col gap-1">
-				<h2 class="text-lg font-semibold">Icons & Logos</h2>
-				{@render iconFields('standard')}
-			</div>
-			<div class="flex flex-col gap-1">
-				<div
-					class={twMerge(
-						'paper p-0',
-						!darkMode.isDark &&
-							selectedIconTab === 'dark' &&
-							'bg-[var(--theme-background-dark)] text-[var(--theme-on-background-dark)]',
-						darkMode.isDark &&
-							selectedIconTab === 'light' &&
-							'bg-[var(--theme-background-light)] text-[var(--theme-on-background-light)]'
-					)}
-				>
-					<div class="flex">
-						<button
-							class={twMerge(
-								'page-tab max-w-full flex-1',
-								selectedIconTab === 'light' &&
-									'page-tab-active hover:bg-[var(--theme-surface1-light)]',
-								selectedIconTab === 'dark' && 'hover:bg-[var(--theme-surface2-dark)]'
-							)}
-							onclick={() => (selectedIconTab = 'light')}
-						>
-							Light Scheme
-						</button>
-						<button
-							class={twMerge(
-								'page-tab max-w-full flex-1',
-								selectedIconTab === 'dark' &&
-									'page-tab-active hover:bg-[var(--theme-surface2-dark)]',
-								selectedIconTab === 'light' &&
-									'bg-[var(--theme-background-light)] hover:bg-[var(--theme-surface1-light)]'
-							)}
-							onclick={() => (selectedIconTab = 'dark')}
-						>
-							Dark Scheme
-						</button>
-					</div>
-					<div class="flex flex-col gap-8 pt-4 pb-8">
-						{#if selectedIconTab === 'light'}
-							{@render iconFields('light')}
-						{:else}
-							{@render iconFields('dark')}
-						{/if}
-					</div>
-				</div>
-			</div>
-
+			<div class="flex grow"></div>
 			{#if !isAdminReadonly}
 				<div
-					class="bg-surface1 dark:bg-background sticky bottom-0 left-0 flex w-[calc(100%+2em)] -translate-x-4 justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
+					class="sticky bottom-0 left-0 w-full bg-base-100 dark:bg-base-200 px-4 py-2 border-t border-base-300"
 				>
-					{#if showSaved}
-						<span
-							in:fade={{ duration: 200 }}
-							class="text-on-surface1 flex min-h-10 items-center px-4 text-sm font-extralight"
+					<div class="flex justify-between items-center gap-2">
+						<button
+							class="btn btn-sm btn-secondary font-medium"
+							onclick={() => {
+								form = compileAppPreferences();
+								customSurfaces = surfacesSnapshotFromTheme(form.theme);
+								appPreferences.current = compileAppPreferences(form);
+								appPreferences.setThemeColors(form.theme);
+								if (selectedSurfaceMode === 'tinted') {
+									captureTintedSurfaceSnapshot();
+								}
+								resetTintedControls();
+								editUrlDialog?.close();
+							}}
 						>
-							Your changes have been saved.
-						</span>
-					{/if}
-
-					<button
-						class="button hover:bg-surface3 flex items-center gap-1 bg-transparent"
-						onclick={() => {
-							form = prevAppPreferences;
-							appPreferences.setThemeColors(prevAppPreferences.theme);
-						}}
-					>
-						Cancel
-					</button>
-					<button
-						class="button-primary flex items-center gap-1"
-						disabled={saving}
-						onclick={handleSave}
-					>
-						{#if saving}
-							<LoaderCircle class="size-4 animate-spin" />
-						{:else}
-							Save
-						{/if}
-					</button>
+							Restore Default
+						</button>
+						<div class="flex items-center gap-2">
+							<button class="btn btn-primary" onclick={handleSave}>
+								{#if saving}
+									<Loading class="size-4" />
+								{:else}
+									Save
+								{/if}
+							</button>
+							<button
+								class="btn btn-secondary"
+								onclick={() => {
+									form = prevAppPreferences;
+									customSurfaces = surfacesSnapshotFromTheme(prevAppPreferences.theme);
+									form = applyCustomSurfacesToForm();
+									appPreferences.current = compileAppPreferences(prevAppPreferences);
+									appPreferences.setThemeColors(form.theme);
+									resetTintedControls();
+									selectedSurfaceMode = 'solid';
+									editUrlDialog?.close();
+								}}>Cancel</button
+							>
+						</div>
+					</div>
 				</div>
-			{:else}
-				<div class="h-4"></div>
 			{/if}
 		</div>
+	{/snippet}
+	{#if showSaved}
+		<div class="absolute bottom-0 right-0">
+			<span
+				in:fade={{ duration: 200 }}
+				class="text-muted-content flex min-h-10 items-center px-4 text-sm font-extralight"
+			>
+				Your changes have been saved.
+			</span>
+		</div>
+	{/if}
+	<div class="relative h-full w-full @container mb-8" transition:fade={{ duration }}>
+		<div>
+			<div class="notification-info p-3 text-sm font-light">
+				<div class="flex items-center gap-3">
+					<Info class="size-6 shrink-0" />
+					<div class="flex flex-col gap-1">
+						<p class="font-semibold">Example Components</p>
+						<p>
+							Below are some example components used in the application for easy previewing. This
+							itself is a commonly used notification that is displayed to provide information to the
+							user in a detail view.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="grid grid-cols-12 gap-4 mt-8">
+			<div class="relative h-72 col-span-12 @min-[768px]:col-span-6">
+				<div
+					class="absolute top-1/2 left-1/2 flex w-md -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-4"
+				>
+					<Logo class="h-16" />
+					<h1 class="text-2xl font-semibold">Welcome to Obot</h1>
+					<p class="text-md text-muted-content mb-1 text-center font-light">
+						Log in or create your account to continue
+					</p>
+
+					<div
+						class="dark:border-base-400 dark:bg-base-200 bg-base-100 flex w-sm flex-col gap-4 rounded-xl border border-transparent p-4 shadow-sm"
+					>
+						<button class="btn btn-secondary w-full">
+							<img
+								class="h-6 w-6 rounded-full bg-base-100 p-1 dark:bg-gray-600"
+								src="/user/images/github-mark/github-mark.svg"
+								alt="Github"
+							/>
+							<span class="text-center text-sm font-light">Continue with Github</span>
+						</button>
+					</div>
+				</div>
+			</div>
+			<div class="flex justify-center items-center col-span-12 @min-[768px]:col-span-6">
+				<div class="dialog-container max-w-md">
+					<div class="dialog-title p-4 pb-0">
+						Confirm Action
+						<button type="button">
+							<X class="size-5" />
+						</button>
+					</div>
+					<div class="flex flex-col items-center justify-center gap-2 p-4 pt-0">
+						<div class="rounded-full p-2 bg-primary/10">
+							<CircleAlert class="size-8 text-primary" />
+						</div>
+						<p class="text-center text-base font-medium">
+							Are you sure you want to confirm this action?
+						</p>
+
+						<div class="mb-4 self-center text-center font-light">
+							<p>
+								This is an example of a confirmation dialog. It can be used to confirm any action
+								that is irreversible or information that needs to be conveyed before submission.
+							</p>
+						</div>
+
+						<div
+							class="flex w-full flex-col items-center justify-center gap-2 @min-[768px]:flex-col @min-[768px]:justify-end"
+						>
+							<button type="button" class="flex w-full justify-center p-3 btn btn-primary">
+								Confirm
+							</button>
+							<button type="button" class="btn btn-secondary w-full justify-center">Cancel</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="flex gap-4 items-center flex-wrap mt-8">
+			<div class="flex gap-4 grow flex-wrap">
+				<div class="bg-base-100 dark:bg-base-200 rounded-md p-3 flex gap-4">
+					<button class="btn btn-circle btn-primary"><HouseIcon /></button>
+					<button class="btn btn-primary">Confirm</button>
+				</div>
+				<div class="bg-base-100 dark:bg-base-200 rounded-md p-3 flex gap-4">
+					<button class="btn btn-circle btn-secondary"><HouseIcon /></button>
+					<button class="btn btn-secondary">Confirm</button>
+				</div>
+				<div class="bg-base-100 dark:bg-base-200 rounded-md p-3 flex gap-4">
+					<button class="btn btn-circle btn-success"><HouseIcon /></button>
+					<button class="btn btn-success">Confirm</button>
+				</div>
+				<div class="bg-base-100 dark:bg-base-200 rounded-md p-3 flex gap-4">
+					<button class="btn btn-circle btn-warning"><HouseIcon /></button>
+					<button class="btn btn-warning">Confirm</button>
+				</div>
+				<div class="bg-base-100 dark:bg-base-200 rounded-md p-3 flex gap-4">
+					<button class="btn btn-circle btn-error"><HouseIcon /></button>
+					<button class="btn btn-error">Confirm</button>
+				</div>
+			</div>
+		</div>
+		<div class="w-full mt-8">
+			<div class="dark:bg-base-300 bg-base-100 rounded-t-md shadow-sm">
+				<div class="flex">
+					<button class="page-tab w-1/2 max-w-1/2 page-tab-active"> Servers </button>
+					<button class="page-tab w-1/2 max-w-1/2"> Users </button>
+				</div>
+				<Table
+					data={MOCK_CONNECTOR_TABLE_DATA}
+					fields={['name', 'status', 'created']}
+					filterable={['name', 'status']}
+					sortable={['name', 'created', 'status']}
+				>
+					{#snippet onRenderColumn(field: string, row: BrandingMockConnectorRow)}
+						{#if field === 'name'}
+							<span class="flex items-center gap-2">
+								<i class={twMerge('devicon', row.devicon)}></i>
+								{row.name}
+							</span>
+						{/if}
+						{#if field === 'status'}
+							{#if row.status === 'Connected'}
+								<div class="pill-primary bg-primary">{row.status}</div>
+							{:else}
+								<div class="text-xs font-light">{row.status}</div>
+							{/if}
+						{/if}
+						{#if field === 'created'}
+							{formatTimeAgo(row.created).relativeTime}
+						{/if}
+					{/snippet}
+				</Table>
+			</div>
+		</div>
+
+		<div class="w-full paper my-8">
+			<h4 class="text-lg font-semibold">Custom Form</h4>
+			<div class="flex flex-col gap-1">
+				<label for="description" class="text-sm font-light">Description</label>
+				<input class="text-input-filled" placeholder="Write a description..." />
+			</div>
+			<div class="flex gap-4 items-center justify-between">
+				<p class="text-sm font-light">Example Selector</p>
+				<div class="flex grow">
+					<Select
+						class="bg-base-200 dark:bg-base-100 dark:border-base-400 border border-transparent shadow-inner"
+						classes={{
+							root: 'flex grow'
+						}}
+						selected="a"
+						options={[
+							{ label: 'Option 1', id: 'a' },
+							{ label: 'Option 2', id: 'b' },
+							{ label: 'Option 3', id: 'c' },
+							{ label: 'Option 4', id: 'd' }
+						]}
+					/>
+				</div>
+			</div>
+			<div class="flex justify-end">
+				<label for="toggle" class="label text-sm">
+					Toggle
+					<input id="toggle" type="checkbox" checked={true} class="toggle" />
+				</label>
+			</div>
+		</div>
+
+		<CustomConfigurationForm
+			config={[
+				{
+					key: 'Example Key',
+					value: 'Example Value',
+					description: 'Example Description',
+					name: 'Example Name',
+					required: true,
+					sensitive: false
+				}
+			]}
+		/>
 	</div>
 </Layout>
 
-{#snippet colorFields(scheme: 'light' | 'dark')}
-	{@const fieldsToUse = scheme === 'light' ? themeLightColorFields : themeDarkColorFields}
-	{#each fieldsToUse as fieldset, i (i)}
-		<div class="grid grid-cols-3 gap-4">
-			{#each fieldset as field (field.id)}
-				<div class="flex flex-col items-center justify-center gap-1">
-					<label class="text-on-surface1 text-xs" for={field.id}>{field.label}</label>
-					<div class="relative">
-						<div
-							class="size-8 rounded-full border dark:border-white"
-							style="background-color: {form.theme[field.id]}"
-						></div>
-						<input
-							class="absolute top-0 left-0 size-8 cursor-pointer opacity-0"
-							type="color"
-							id={field.id}
-							value={form.theme[field.id].startsWith('#') ? form.theme[field.id] : '#ffffff'}
-							oninput={(e) => {
-								if (!e.currentTarget.value.startsWith('#')) {
-									return;
-								}
-								const newForm = {
-									...form,
-									theme: { ...form.theme, [field.id]: e.currentTarget.value }
-								};
-								if (displayPreviewMode) {
-									appPreferences.setThemeColors(newForm.theme);
-								}
-								form = newForm;
-							}}
-						/>
-					</div>
+{#snippet themeConfiguration()}
+	<div class="flex flex-col gap-2 px-4 pt-2 pb-4">
+		<div class="flex items-center justify-between">
+			<p class="text-sm font-medium">Surfaces</p>
+
+			<div class="flex items-center p-1.5 bg-base-200 dark:bg-base-300 rounded-4xl shadow-inner">
+				<button
+					class={twMerge(
+						'btn btn-sm rounded-r-none!',
+						selectedSurfaceMode === 'solid' ? 'btn-primary' : 'btn-secondary'
+					)}
+					onclick={() => {
+						selectedSurfaceMode = 'solid';
+						form = applyCustomSurfacesToForm();
+						appPreferences.setThemeColors(form.theme);
+					}}>Custom</button
+				>
+				<button
+					class={twMerge(
+						'btn btn-sm rounded-l-none!',
+						selectedSurfaceMode === 'tinted' ? 'btn-primary' : 'btn-secondary'
+					)}
+					onclick={() => {
+						selectedSurfaceMode = 'tinted';
+						captureTintedSurfaceSnapshot();
+					}}>Tinted</button
+				>
+			</div>
+		</div>
+
+		{#if selectedSurfaceMode === 'solid'}
+			<!-- solid custom -->
+			{#each selectedColorScheme === 'light' ? themeLightSurfaceFields : themeDarkSurfaceFields as field (field.id)}
+				<div class="flex items-center justify-between">
+					<p class="text-sm font-light">{field.label}</p>
+					{@render colorSelector({ id: field.id, label: field.label })}
 				</div>
 			{/each}
+		{:else}
+			<p class="text-xs font-light text-muted-content">
+				Tinted always starts from the built-in default surface ramp; hue, tint, and shade adjust
+				that. Custom picker colors stay on Custom only.
+			</p>
+			{#if selectedColorScheme === 'light'}
+				<TintedSurfaceHueTintShadeControls
+					bind:hue={tintedHueLight}
+					bind:tint={tintedTintLight}
+					bind:shade={tintedShadeLight}
+					hueAriaLabel="Light mode surface hue"
+				/>
+			{:else}
+				<TintedSurfaceHueTintShadeControls
+					bind:hue={tintedHueDark}
+					bind:tint={tintedTintDark}
+					bind:shade={tintedShadeDark}
+					hueAriaLabel="Dark mode surface hue"
+				/>
+			{/if}
+			<p class="text-xs font-light text-muted-content pl-22 mt-1">
+				{SHADE_TICK_NEUTRAL} is neutral for shade. Light and dark each have their own hue, tint, and shade—adjusting
+				one scheme does not change the other’s sliders.
+			</p>
+		{/if}
+	</div>
+
+	<div class="flex flex-col gap-2 p-4">
+		<div class="flex justify-between items-center gap-4 pb-1">
+			<p class="text-sm font-medium">Per-Theme Colors</p>
+			<input type="checkbox" class="toggle toggle-sm" bind:checked={isPerThemeColorsEnabled} />
+		</div>
+
+		<p class="text-xs font-light text-muted-content">
+			Per-Theme Colors is <span class="font-semibold text-base-content"
+				>{isPerThemeColorsEnabled ? 'enabled' : 'disabled'}
+			</span>.
+			{#if isPerThemeColorsEnabled}
+				Accent color, button & indicator colors, and text options are separately customizable for
+				light &amp; dark modes.
+			{:else}
+				Accent color, button & indicator colors, and text options stay aligned between light & dark
+				i.e. changing one updates the paired value for the other mode.
+			{/if}
+		</p>
+	</div>
+
+	<div class="flex justify-between items-center gap-4 px-4 py-2">
+		<p class="text-sm font-medium">Accent Color</p>
+		{@render colorSelector({
+			id: selectedColorScheme === 'light' ? 'primaryColor' : 'darkPrimaryColor',
+			label: 'Primary'
+		})}
+	</div>
+
+	<div class="flex flex-col gap-2 p-4">
+		<p class="text-sm font-medium">Buttons & Indicators</p>
+		{#each selectedColorScheme === 'light' ? themeLightIndicatorFields : themeDarkIndicatorFields as field (field.id)}
+			<div class="flex items-center justify-between">
+				<p class="text-sm font-light">{field.label}</p>
+				{@render colorSelector({ id: field.id, label: field.label })}
+			</div>
+		{/each}
+	</div>
+
+	<div class="flex flex-col gap-2 p-4">
+		<p class="text-sm font-medium">Text</p>
+		{#each selectedColorScheme === 'light' ? textLightFields : textDarkFields as field (field.id)}
+			<div class="flex items-center justify-between">
+				<p class="text-sm font-light">{field.label}</p>
+				{@render colorSelector({ id: field.id, label: field.label })}
+			</div>
+		{/each}
+		<div class="flex items-center justify-between gap-2">
+			<p class="text-sm font-light shrink-0">Font Family</p>
+			<select
+				class="select select-sm max-w-46 min-w-0"
+				value={form.theme.fontFamily}
+				onchange={(e) => {
+					const fontFamily = e.currentTarget.value;
+					const newForm = { ...form, theme: { ...form.theme, fontFamily } };
+					form = newForm;
+					appPreferences.setThemeColors(newForm.theme);
+				}}
+			>
+				{#each FONT_FAMILY_PRESETS as preset (preset.value)}
+					<option value={preset.value}>{preset.label}</option>
+				{/each}
+			</select>
+		</div>
+	</div>
+{/snippet}
+
+{#snippet logosConfiguration()}
+	{#each standardIconFields as field (field.id)}
+		<div class="flex flex-col gap-2 p-4 relative">
+			<p class="text-sm font-medium">{field.label}</p>
+			{@render iconSelector({ id: field.id, label: field.label }, 'standard')}
+		</div>
+	{/each}
+
+	{#each selectedColorScheme === 'light' ? themeLightLogoFields : themeDarkLogoFields as field (field.id)}
+		<div class="flex flex-col gap-2 p-4 relative">
+			<p class="text-sm font-medium">{field.label}</p>
+			{@render iconSelector(
+				{ id: field.id, label: field.label },
+				selectedColorScheme as 'light' | 'dark'
+			)}
 		</div>
 	{/each}
 {/snippet}
 
-{#snippet iconFields(type: 'standard' | 'light' | 'dark')}
-	{@const fieldsToUse =
-		type === 'standard'
-			? standardIconFields
-			: type === 'light'
-				? themeLightLogoFields
-				: themeDarkLogoFields}
-	<div
-		class={twMerge(
-			type === 'standard' ? 'grid grid-cols-2 gap-8 md:grid-cols-4' : 'flex flex-col gap-8'
-		)}
-	>
-		{#each fieldsToUse as field (field.id)}
-			<button
-				class={twMerge(
-					'group active:bg-surface1 dark:active:bg-surface3 relative flex flex-col items-center justify-center gap-2',
-					type === 'standard' ? 'paper gap-4' : 'w-full self-center rounded-sm p-2 md:w-xl'
-				)}
-				onclick={() => {
-					editImageUrl = form.logos[field.id].startsWith('/user/images/')
-						? ''
-						: form.logos[field.id];
-					selectedImageField = field.id;
-					editUrlDialog?.open();
+{#snippet colorSelector(field: { id: keyof AppPreferences['theme']; label: string })}
+	<div class="flex items-center gap-2">
+		<div class="relative group">
+			<div
+				class="size-7 rounded-full border dark:border-white group-focus-within:ring-2 group-focus-within:ring-base-content"
+				style="background-color: {form.theme[field.id]}"
+			></div>
+			<input
+				class="absolute top-0 left-0 size-7 cursor-pointer opacity-0 focus:outline-none"
+				type="color"
+				id={field.id}
+				value={form.theme[field.id].startsWith('#') ? form.theme[field.id] : '#ffffff'}
+				oninput={(e) => {
+					if (!e.currentTarget.value.startsWith('#')) {
+						return;
+					}
+					const value = e.currentTarget.value;
+					const counterpart = !isPerThemeColorsEnabled
+						? THEME_COLOR_COUNTERPART[field.id]
+						: undefined;
+					let nextTheme = { ...form.theme, [field.id]: value };
+					if (counterpart) {
+						nextTheme = { ...nextTheme, [counterpart]: value };
+					}
+					const newForm = { ...form, theme: nextTheme };
+					appPreferences.setThemeColors(newForm.theme);
+					form = newForm;
+					if (selectedSurfaceMode === 'solid' && isSurfaceThemeKey(field.id)) {
+						customSurfaces = patchCustomSurface(customSurfaces, field.id, value);
+					}
 				}}
-			>
-				<p class="text-on-surface1 text-sm">{field.label}</p>
-				<img
-					src={form.logos[field.id]}
-					alt={field.label}
-					class={twMerge(
-						'flex-shrink-0 object-contain',
-						type === 'standard' ? 'h-24' : 'max-h-32 max-w-full'
-					)}
-				/>
-				<Pencil
-					class="text-on-surface1 absolute top-2 right-2 size-6 opacity-0 transition-opacity group-hover:opacity-100"
-				/>
-			</button>
-		{/each}
+			/>
+		</div>
+		<input
+			type="text"
+			class="input input-sm"
+			value={form.theme[field.id]}
+			oninput={(e) => {
+				const value = e.currentTarget.value.trim();
+				if (!isValidThemeColorString(value)) {
+					return;
+				}
+				const counterpart = !isPerThemeColorsEnabled
+					? THEME_COLOR_COUNTERPART[field.id]
+					: undefined;
+				let nextTheme = { ...form.theme, [field.id]: value };
+				if (counterpart) {
+					nextTheme = { ...nextTheme, [counterpart]: value };
+				}
+				const newForm = { ...form, theme: nextTheme };
+				appPreferences.setThemeColors(newForm.theme);
+				form = newForm;
+				if (selectedSurfaceMode === 'solid' && isSurfaceThemeKey(field.id)) {
+					customSurfaces = patchCustomSurface(customSurfaces, field.id, value);
+				}
+			}}
+		/>
 	</div>
+{/snippet}
+
+{#snippet iconSelector(
+	field: { id: keyof AppPreferences['logos']; label: string },
+	type: 'standard' | 'light' | 'dark'
+)}
+	<button
+		class={twMerge('group flex flex-col items-center justify-center gap-2')}
+		onclick={() => {
+			editImageUrl = form.logos[field.id].startsWith('/user/images/') ? '' : form.logos[field.id];
+			selectedImageField = field.id;
+			editUrlDialog?.open();
+		}}
+	>
+		<img
+			src={form.logos[field.id]}
+			alt={field.label}
+			class={twMerge(
+				'shrink-0 object-contain transition-transform group-hover:scale-115 group-active:brightness-135',
+				type === 'standard' ? 'size-18' : 'max-h-18 max-w-full'
+			)}
+		/>
+		<Pencil
+			class="text-muted-content transition-colors group-hover:text-base-content absolute top-4 right-4 size-4"
+		/>
+	</button>
 {/snippet}
 
 <ResponsiveDialog
 	bind:this={editUrlDialog}
 	title={editImageUrl ? 'Edit Image URL' : 'Add Image URL'}
+	onClose={() => {
+		editImageUrl = '';
+		selectedImageField = undefined;
+		uploadImage?.clearPreview();
+	}}
 >
 	<UploadImage
 		label="Upload Image"
@@ -428,16 +850,28 @@
 		bind:this={uploadImage}
 	/>
 	<div class="flex grow"></div>
-	<div class="flex justify-end gap-2">
+	<div class="flex flex-wrap justify-end gap-2">
 		<button
-			class="button-primary mt-4 w-full md:w-fit"
+			type="button"
+			class="btn btn-secondary mt-4 w-full md:w-fit"
+			onclick={() => editUrlDialog?.close()}>Cancel</button
+		>
+		<button
+			type="button"
+			class="btn btn-primary mt-4 w-full md:w-fit"
 			onclick={() => {
 				if (!selectedImageField) return;
+				const candidate = editImageUrl.trim();
+				const resolvedUrl =
+					candidate !== '' && isLogoAssetUrl(candidate)
+						? candidate
+						: form.logos[selectedImageField];
 				const newForm = {
 					...form,
-					logos: { ...form.logos, [selectedImageField]: editImageUrl }
+					logos: { ...form.logos, [selectedImageField]: resolvedUrl }
 				};
 				form = newForm;
+				appPreferences.current = compileAppPreferences(newForm);
 				editImageUrl = '';
 				selectedImageField = undefined;
 				editUrlDialog?.close();

--- a/ui/user/src/routes/admin/app-preferences/+page.svelte
+++ b/ui/user/src/routes/admin/app-preferences/+page.svelte
@@ -12,15 +12,17 @@
 	import Select from '$lib/components/Select.svelte';
 	import UploadImage from '$lib/components/UploadImage.svelte';
 	import CustomConfigurationForm from '$lib/components/mcp/CustomConfigurationForm.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, type AppPreferences } from '$lib/services';
-	import { darkMode, profile } from '$lib/stores';
+	import { darkMode, profile, responsive } from '$lib/stores';
 	import appPreferences, {
 		compileAppPreferences,
 		FONT_FAMILY_PRESETS
 	} from '$lib/stores/appPreferences.svelte';
+	import { success } from '$lib/stores/success';
 	import { formatTimeAgo } from '$lib/time';
 	import TintedSurfaceHueTintShadeControls from './TintedSurfaceHueTintShadeControls.svelte';
 	import {
@@ -37,7 +39,15 @@
 		standardIconFields
 	} from './constants.js';
 	import 'devicon/devicon.min.css';
-	import { CircleAlert, HouseIcon, Info, Pencil, X } from 'lucide-svelte';
+	import {
+		CircleAlert,
+		HouseIcon,
+		Info,
+		PanelRightClose,
+		PanelRightOpen,
+		Pencil,
+		X
+	} from 'lucide-svelte';
 	import { onDestroy, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -47,8 +57,8 @@
 	let form = $state<AppPreferences>(untrack(() => data.appPreferences));
 	let prevAppPreferences = $state<AppPreferences>(untrack(() => data.appPreferences));
 	let saving = $state(false);
-	let showSaved = $state(false);
 	let timeout = $state<ReturnType<typeof setTimeout>>();
+	let showConfigurationSidebar = $state(untrack(() => (responsive.isMobile ? false : true)));
 
 	let editUrlDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let uploadImage = $state<ReturnType<typeof UploadImage>>();
@@ -62,6 +72,12 @@
 	let selectedSurfaceMode = $state<'solid' | 'tinted'>('solid');
 	let selectedConfigurationMode = $state<'theme' | 'logos'>('theme');
 	let isPerThemeColorsEnabled = $state(false);
+
+	$effect(() => {
+		if (!responsive.isMobile) {
+			showConfigurationSidebar = true;
+		}
+	});
 
 	function isLogoAssetUrl(s: string): boolean {
 		const t = s.trim();
@@ -275,10 +291,7 @@
 			await invalidateAll();
 			prevAppPreferences = saveForm;
 			customSurfaces = surfacesSnapshotFromTheme(saveForm.theme);
-			showSaved = true;
-			timeout = setTimeout(() => {
-				showSaved = false;
-			}, 3000);
+			success.add('Your changes have been saved.');
 		} catch (err) {
 			console.error(err);
 			// default behavior will show snackbar error
@@ -289,19 +302,48 @@
 </script>
 
 <Layout title="Branding" classes={{ container: 'pb-0' }}>
+	{#if responsive.isMobile && !showConfigurationSidebar}
+		<div class="fixed top-20 right-4 z-40">
+			<IconButton
+				onclick={() => (showConfigurationSidebar = !showConfigurationSidebar)}
+				tooltip={{ text: 'Open Branding Sidebar' }}
+			>
+				<PanelRightOpen class="size-6 text-muted-content" />
+			</IconButton>
+		</div>
+	{/if}
+
 	{#snippet rightSidebar()}
 		<div
-			class="bg-base-100 dark:bg-base-200 border-base-300 h-dvh w-sm min-w-sm overflow-y-auto border-l flex flex-col"
+			class={twMerge(
+				'bg-base-100 dark:bg-base-200 border-base-300 overflow-y-auto border-l flex flex-col transition-transform',
+				responsive.isMobile
+					? 'fixed z-40 h-[calc(100dvh-4rem)] w-dvw top-16 translate-x-full'
+					: 'static w-sm min-w-sm h-dvh',
+				responsive.isMobile && showConfigurationSidebar ? 'translate-x-0' : ''
+			)}
 		>
 			<div class="flex flex-col divide-y divide-base-300">
-				<div class="flex items-center justify-between px-4 py-2">
-					<h3 class="text-base font-semibold">Configuration</h3>
+				{#if responsive.isMobile}
 					<div
-						class="flex items-center p-1.5 bg-base-200 dark:bg-base-300 rounded-4xl shadow-inner"
+						class="flex justify-between items-center p-4 sticky bg-base-100 dark:bg-base-200 top-0 left-0"
+					>
+						<h3 class="text-base font-semibold">Configuration</h3>
+						<IconButton onclick={() => (showConfigurationSidebar = !showConfigurationSidebar)}>
+							<PanelRightClose class="size-6 text-muted-content" />
+						</IconButton>
+					</div>
+				{/if}
+				<div class="flex items-center justify-between px-4 py-2">
+					{#if !responsive.isMobile}
+						<h3 class="text-base font-semibold">Configuration</h3>
+					{/if}
+					<div
+						class="flex items-center p-1.5 bg-base-200 dark:bg-base-300 rounded-4xl shadow-inner w-full md:w-auto"
 					>
 						<button
 							class={twMerge(
-								'btn btn-sm rounded-r-none!',
+								'btn btn-sm rounded-r-none! w-1/2 md:w-auto',
 								selectedConfigurationMode === 'theme' ? 'btn-primary' : 'btn-secondary'
 							)}
 							onclick={() => {
@@ -310,7 +352,7 @@
 						>
 						<button
 							class={twMerge(
-								'btn btn-sm rounded-l-none!',
+								'btn btn-sm rounded-l-none! w-1/2 md:w-auto',
 								selectedConfigurationMode === 'logos' ? 'btn-primary' : 'btn-secondary'
 							)}
 							onclick={() => {
@@ -405,16 +447,6 @@
 			{/if}
 		</div>
 	{/snippet}
-	{#if showSaved}
-		<div class="absolute bottom-0 right-0">
-			<span
-				in:fade={{ duration: 200 }}
-				class="text-muted-content flex min-h-10 items-center px-4 text-sm font-extralight"
-			>
-				Your changes have been saved.
-			</span>
-		</div>
-	{/if}
 	<div class="relative h-full w-full @container mb-8" transition:fade={{ duration }}>
 		<div>
 			<div class="notification-info p-3 text-sm font-light">

--- a/ui/user/src/routes/admin/app-preferences/TintedSurfaceHueTintShadeControls.svelte
+++ b/ui/user/src/routes/admin/app-preferences/TintedSurfaceHueTintShadeControls.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { SHADE_TICK_MAX, SHADE_TICK_NEUTRAL } from '$lib/colors';
+	import SpectrumSlider from '$lib/components/SpectrumSlider.svelte';
+
+	let {
+		hue = $bindable(0),
+		tint = $bindable(0),
+		shade = $bindable(SHADE_TICK_NEUTRAL),
+		hueAriaLabel = 'Surface hue'
+	}: {
+		hue?: number;
+		tint?: number;
+		shade?: number;
+		hueAriaLabel?: string;
+	} = $props();
+</script>
+
+<div class="flex items-center justify-between gap-2">
+	<p class="text-sm font-light w-20 shrink-0">Hue</p>
+	<SpectrumSlider bind:hue aria-label={hueAriaLabel} class="min-w-0 grow" />
+</div>
+
+<div class="flex items-center justify-between gap-2 mb-2">
+	<p class="text-sm font-light w-20 shrink-0">Tint</p>
+	<input
+		type="range"
+		min="0"
+		max="100"
+		bind:value={tint}
+		class="range grow"
+		aria-valuetext={`${tint}%`}
+	/>
+</div>
+
+<div class="flex flex-col gap-1">
+	<div class="flex items-center justify-between gap-2">
+		<p class="text-sm font-light w-20 shrink-0">Shade</p>
+		<div class="flex grow items-center gap-2 min-w-0 justify-end">
+			<input
+				type="range"
+				min="0"
+				max={SHADE_TICK_MAX}
+				step="1"
+				bind:value={shade}
+				class="range grow"
+				aria-valuemin={0}
+				aria-valuemax={SHADE_TICK_MAX}
+				aria-valuenow={shade}
+				aria-valuetext={shade === SHADE_TICK_NEUTRAL
+					? 'Balanced'
+					: shade < SHADE_TICK_NEUTRAL
+						? 'Darker'
+						: 'Lighter'}
+			/>
+			<span class="text-xs font-light tabular-nums text-base-content/60 w-4 shrink-0 text-right"
+				>{shade}</span
+			>
+		</div>
+	</div>
+</div>

--- a/ui/user/src/routes/admin/app-preferences/constants.ts
+++ b/ui/user/src/routes/admin/app-preferences/constants.ts
@@ -1,0 +1,242 @@
+import type { AppPreferences } from '$lib/services';
+
+export type BrandingMockConnectorRow = {
+	id: string;
+	name: string;
+	devicon: string;
+	type: string;
+	status: string;
+	created: string;
+	registry: string;
+	users: number;
+};
+
+export const MOCK_CONNECTOR_TABLE_DATA: BrandingMockConnectorRow[] = [
+	{
+		id: 'mock-braintree',
+		name: 'Braintree MCP',
+		devicon: 'devicon-python-plain',
+		type: 'single',
+		status: 'Connected',
+		created: new Date(Date.now() - 1000 * 60 * 45).toISOString(),
+		registry: 'Global Registry',
+		users: 1
+	},
+	{
+		id: 'mock-acme-api',
+		name: 'Acme Remote API',
+		devicon: 'devicon-typescript-plain',
+		type: 'remote',
+		status: 'Requires OAuth Config',
+		created: new Date(Date.now() - 1000 * 60 * 60 * 20).toISOString(),
+		registry: 'Global Registry',
+		users: 0
+	},
+	{
+		id: 'mock-analytics',
+		name: 'Analytics Warehouse',
+		devicon: 'devicon-postgresql-plain',
+		type: 'multi',
+		status: 'Connected',
+		created: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
+		registry: 'My Registry',
+		users: 12
+	},
+	{
+		id: 'mock-compose',
+		name: 'Composite Toolkit',
+		devicon: 'devicon-docker-plain',
+		type: 'composite',
+		status: '',
+		created: new Date(Date.now() - 1000 * 60 * 60 * 24 * 14).toISOString(),
+		registry: 'Global Registry',
+		users: 4
+	},
+	{
+		id: 'mock-slack',
+		name: 'Slack Connector',
+		devicon: 'devicon-slack-plain',
+		type: 'remote',
+		status: '',
+		created: new Date(Date.now() - 1000 * 60 * 60 * 24 * 30).toISOString(),
+		registry: "Partner's Registry",
+		users: 0
+	},
+	{
+		id: 'mock-react',
+		name: 'UI Automation Server',
+		devicon: 'devicon-react-original',
+		type: 'single',
+		status: 'Connected',
+		created: new Date(Date.now() - 1000 * 60 * 8).toISOString(),
+		registry: 'Global Registry',
+		users: 2
+	}
+];
+
+export const standardIconFields: { id: keyof AppPreferences['logos']; label: string }[] = [
+	{
+		id: 'logoIcon',
+		label: 'Default Icon'
+	},
+	{
+		id: 'logoIconError',
+		label: 'Error Icon'
+	},
+	{
+		id: 'logoIconWarning',
+		label: 'Warning Icon'
+	}
+];
+
+export const themeLightLogoFields: { id: keyof AppPreferences['logos']; label: string }[] = [
+	{
+		id: 'logoDefault',
+		label: 'Full Logo'
+	},
+	{
+		id: 'logoEnterprise',
+		label: 'Full Enterprise Logo'
+	},
+	{
+		id: 'logoChat',
+		label: 'Full Chat Logo'
+	}
+];
+
+export const themeDarkLogoFields: { id: keyof AppPreferences['logos']; label: string }[] = [
+	{
+		id: 'darkLogoDefault',
+		label: 'Full Logo'
+	},
+	{
+		id: 'darkLogoEnterprise',
+		label: 'Full Enterprise Logo'
+	},
+	{
+		id: 'darkLogoChat',
+		label: 'Full Chat Logo'
+	}
+];
+
+export const themeLightSurfaceFields: { id: keyof AppPreferences['theme']; label: string }[] = [
+	{
+		id: 'backgroundColor',
+		label: 'Background'
+	},
+	{
+		id: 'surface1Color',
+		label: 'Surface 1'
+	},
+	{
+		id: 'surface2Color',
+		label: 'Surface 2'
+	},
+	{
+		id: 'surface3Color',
+		label: 'Surface 3'
+	}
+];
+
+export const themeDarkSurfaceFields: { id: keyof AppPreferences['theme']; label: string }[] = [
+	{
+		id: 'darkBackgroundColor',
+		label: 'Background'
+	},
+	{
+		id: 'darkSurface1Color',
+		label: 'Surface 1'
+	},
+	{
+		id: 'darkSurface2Color',
+		label: 'Surface 2'
+	},
+	{
+		id: 'darkSurface3Color',
+		label: 'Surface 3'
+	}
+];
+
+export const themeLightIndicatorFields: { id: keyof AppPreferences['theme']; label: string }[] = [
+	{
+		id: 'secondaryColor',
+		label: 'Secondary'
+	},
+	{
+		id: 'successColor',
+		label: 'Success'
+	},
+	{
+		id: 'warningColor',
+		label: 'Warning'
+	},
+	{
+		id: 'errorColor',
+		label: 'Error'
+	}
+];
+
+export const themeDarkIndicatorFields: { id: keyof AppPreferences['theme']; label: string }[] = [
+	{
+		id: 'darkSecondaryColor',
+		label: 'Secondary'
+	},
+	{
+		id: 'darkSuccessColor',
+		label: 'Success'
+	},
+	{
+		id: 'darkWarningColor',
+		label: 'Warning'
+	},
+	{
+		id: 'darkErrorColor',
+		label: 'Error'
+	}
+];
+
+export const textLightFields: { id: keyof AppPreferences['theme']; label: string }[] = [
+	{
+		id: 'onBackgroundColor',
+		label: 'Base Font Color'
+	},
+	{
+		id: 'onPrimaryColor',
+		label: 'Primary Button Text'
+	},
+	{
+		id: 'onSuccessColor',
+		label: 'Success Button Text'
+	},
+	{
+		id: 'onWarningColor',
+		label: 'Warning Button Text'
+	},
+	{
+		id: 'onErrorColor',
+		label: 'Error Button Text'
+	}
+];
+
+export const textDarkFields: { id: keyof AppPreferences['theme']; label: string }[] = [
+	{
+		id: 'darkOnBackgroundColor',
+		label: 'Primary Text'
+	},
+	{
+		id: 'darkOnPrimaryColor',
+		label: 'Primary Text'
+	},
+	{
+		id: 'darkOnSuccessColor',
+		label: 'Success Text'
+	},
+	{
+		id: 'darkOnWarningColor',
+		label: 'Warning Text'
+	},
+	{
+		id: 'darkOnErrorColor',
+		label: 'Error Text'
+	}
+];

--- a/ui/user/src/routes/admin/audit-logs/exports/+page.svelte
+++ b/ui/user/src/routes/admin/audit-logs/exports/+page.svelte
@@ -162,7 +162,7 @@
 	const duration = PAGE_TRANSITION_DURATION;
 </script>
 
-<Layout classes={{ navbar: 'bg-surface1' }} showBackButton title="Audit Log Exports">
+<Layout classes={{ navbar: 'bg-base-200' }} showBackButton title="Audit Log Exports">
 	<div class="flex min-h-full flex-col gap-8" in:fade>
 		{#if showForm}
 			{@render formScreen()}
@@ -185,11 +185,11 @@
 				<h1 class="text-2xl font-semibold">Audit Log Exports</h1>
 			</div>
 
-			<div class="mt-4 w-full flex-shrink-0 md:mt-0 md:w-fit">
+			<div class="mt-4 w-full shrink-0 md:mt-0 md:w-fit">
 				<div class="flex gap-2">
 					{#if !isAdminReadonly}
 						<button
-							class="button-secondary flex items-center gap-1 text-sm font-normal"
+							class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 							onclick={() => openForm('storage')}
 						>
 							<Settings class="size-4" />
@@ -201,17 +201,17 @@
 			</div>
 		</div>
 
-		<div class="bg-surface1 dark:bg-background sticky top-16 left-0 z-20 w-full pb-1">
+		<div class="bg-base-200 dark:bg-base-100 sticky top-16 left-0 z-20 w-full pb-1">
 			<div class="mb-2">
 				<Search
-					class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+					class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 					onChange={(val) => (query = val)}
 					placeholder={view === 'exports' ? 'Search exports...' : 'Search schedules...'}
 				/>
 			</div>
 		</div>
 
-		<div class="dark:bg-surface2 bg-background rounded-t-md shadow-sm">
+		<div class="dark:bg-base-300 bg-base-100 rounded-t-md shadow-sm">
 			<div class="flex">
 				<button
 					class={twMerge('page-tab', view === 'exports' && 'page-tab-active')}
@@ -253,7 +253,7 @@
 {/snippet}
 
 {#snippet addButton()}
-	<DotDotDot class="button-primary w-full text-sm md:w-fit" placement="bottom">
+	<DotDotDot class="btn btn-block btn-primary w-full text-sm md:w-fit" placement="bottom">
 		{#snippet icon()}
 			<span class="flex items-center justify-center gap-1">
 				<Plus class="size-4" /> Add Export

--- a/ui/user/src/routes/admin/audit-logs/exports/ExportsView.svelte
+++ b/ui/user/src/routes/admin/audit-logs/exports/ExportsView.svelte
@@ -3,11 +3,12 @@
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { formatFileSize } from '$lib/format';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import type { AuditLogExport } from '$lib/services/admin/types';
 	import { formatTimeAgo } from '$lib/time';
 	import { goto } from '$lib/url';
-	import { FileArchive, LoaderCircle, CircleAlert, AlertCircle } from 'lucide-svelte';
+	import { FileArchive, CircleAlert } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
 	interface Props {
@@ -125,13 +126,13 @@
 <div class="flex flex-col gap-2">
 	{#if loading}
 		<div class="my-2 flex items-center justify-center">
-			<LoaderCircle class="size-6 animate-spin" />
+			<Loading class="size-6" />
 		</div>
 	{:else if exports.length === 0}
 		<div class="my-12 flex w-md flex-col items-center gap-4 self-center text-center">
-			<FileArchive class="text-surface3 size-24 opacity-25" />
-			<h4 class="text-on-surface1 text-lg font-semibold">No exports found.</h4>
-			<p class="text-on-surface1 text-sm font-light">
+			<FileArchive class="text-base-content/80 size-24 opacity-25" />
+			<h4 class="text-muted-content text-lg font-semibold">No exports found.</h4>
+			<p class="text-muted-content text-sm font-light">
 				Create your first audit log export to get started.
 			</p>
 		</div>
@@ -158,9 +159,9 @@
 		>
 			{#snippet onRenderColumn(property, d)}
 				{#if property === 'displayName'}
-					<div class="flex flex-shrink-0 items-center gap-2">
+					<div class="flex shrink-0 items-center gap-2">
 						<div
-							class="bg-surface1 flex items-center justify-center rounded-sm p-0.5 dark:bg-gray-600"
+							class="bg-base-200 flex items-center justify-center rounded-sm p-0.5 dark:bg-base-300"
 						>
 							<FileArchive class="size-6" />
 						</div>
@@ -176,26 +177,26 @@
 						{#if d.state === 'failed' && d.error}
 							<button
 								type="button"
-								class="text-red-500 transition-colors hover:text-red-600"
+								class="text-error transition-colors hover:text-error"
 								use:tooltip={{
 									text: d.error,
 									placement: 'top',
 									classes: [
 										'max-w-80',
-										'break-words',
+										'wrap-break-word',
 										'whitespace-pre-wrap',
-										'bg-background',
-										'text-gray-900',
+										'bg-base-100',
+										'text-base-content',
 										'border',
 										'shadow-lg'
 									]
 								}}
 							>
-								<AlertCircle class="size-4" />
+								<CircleAlert class="size-4" />
 							</button>
 						{:else if d.state === 'running'}
 							<div class="size-4">
-								<LoaderCircle class="size-full animate-spin duration-100" />
+								<Loading class="size-full animate-spin duration-100" />
 							</div>
 						{/if}
 					</div>

--- a/ui/user/src/routes/admin/audit-logs/exports/ScheduledExportsView.svelte
+++ b/ui/user/src/routes/admin/audit-logs/exports/ScheduledExportsView.svelte
@@ -2,21 +2,14 @@
 	import Confirm from '$lib/components/Confirm.svelte';
 	import DotDotDot from '$lib/components/DotDotDot.svelte';
 	import Table from '$lib/components/table/Table.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import type { ScheduledAuditLogExport } from '$lib/services/admin/types';
 	import type { ScheduledAuditLogExportInput } from '$lib/services/admin/types';
 	import type { Schedule } from '$lib/services/chat/types';
 	import { formatTimeAgo } from '$lib/time';
 	import { goto } from '$lib/url';
-	import {
-		Calendar,
-		LoaderCircle,
-		Ellipsis,
-		Trash2,
-		PlayCircle,
-		PauseCircle,
-		CircleAlert
-	} from 'lucide-svelte';
+	import { Calendar, Ellipsis, Trash2, CircleAlert, CirclePlay, CirclePause } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
 	interface Props {
@@ -177,13 +170,13 @@
 <div class="flex flex-col gap-2">
 	{#if loading}
 		<div class="my-2 flex items-center justify-center">
-			<LoaderCircle class="size-6 animate-spin" />
+			<Loading class="size-6" />
 		</div>
 	{:else if scheduledExports.length === 0}
 		<div class="my-12 flex w-md flex-col items-center gap-4 self-center text-center">
-			<Calendar class="text-surface3 size-24 opacity-50" />
-			<h4 class="text-on-surface1 text-lg font-semibold">No export schedules found.</h4>
-			<p class="text-on-surface1 text-sm font-light">
+			<Calendar class="text-base-content/80 size-24 opacity-50" />
+			<h4 class="text-muted-content text-lg font-semibold">No export schedules found.</h4>
+			<p class="text-muted-content text-sm font-light">
 				Create your first export schedule to automate your audit log exports.
 			</p>
 		</div>
@@ -209,9 +202,9 @@
 		>
 			{#snippet onRenderColumn(property, d)}
 				{#if property === 'displayName'}
-					<div class="flex flex-shrink-0 items-center gap-2">
+					<div class="flex shrink-0 items-center gap-2">
 						<div
-							class="bg-surface1 flex items-center justify-center rounded-sm p-0.5 dark:bg-gray-600"
+							class="bg-base-200 flex items-center justify-center rounded-sm p-0.5 dark:bg-base-300"
 						>
 							<Calendar class="size-6" />
 						</div>
@@ -226,7 +219,7 @@
 				{/if}
 			{/snippet}
 			{#snippet actions(d)}
-				<DotDotDot class="icon-button hover:dark:bg-background/50">
+				<DotDotDot class="hover:dark:bg-base-100/50">
 					{#snippet icon()}
 						<Ellipsis class="size-4" />
 					{/snippet}
@@ -245,9 +238,9 @@
 									}}
 								>
 									{#if toggleAction?.id === d.id && toggleAction.action === 'pause'}
-										<LoaderCircle class="size-4 animate-spin" />
+										<Loading class="size-4" />
 									{:else}
-										<PauseCircle class="size-4" />
+										<CirclePause class="size-4" />
 									{/if}
 									Pause Schedule
 								</button>
@@ -262,9 +255,9 @@
 									}}
 								>
 									{#if toggleAction?.id === d.id && toggleAction.action === 'resume'}
-										<LoaderCircle class="size-4 animate-spin" />
+										<Loading class="size-4" />
 									{:else}
-										<PlayCircle class="size-4" />
+										<CirclePlay class="size-4" />
 									{/if}
 									Resume Schedule
 								</button>
@@ -293,14 +286,14 @@
 				<div class="flex grow items-center justify-end gap-2 px-4 py-2">
 					{#if bulkActionState === 'pause'}
 						<button
-							class="button flex items-center gap-1 text-sm font-normal"
+							class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 							onclick={() => {
 								selected = currentSelected;
 								handleBulkPause();
 							}}
 							disabled={readonly}
 						>
-							<PauseCircle class="size-4" /> Pause
+							<CirclePause class="size-4" /> Pause
 							{#if !readonly}
 								<span class="pill-primary">
 									{Object.keys(currentSelected).length}
@@ -309,14 +302,14 @@
 						</button>
 					{:else if bulkActionState === 'resume'}
 						<button
-							class="button flex items-center gap-1 text-sm font-normal"
+							class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 							onclick={() => {
 								selected = currentSelected;
 								handleBulkResume();
 							}}
 							disabled={readonly}
 						>
-							<PlayCircle class="size-4" /> Resume
+							<CirclePause class="size-4" /> Resume
 							{#if !readonly}
 								<span class="pill-primary">
 									{Object.keys(currentSelected).length}
@@ -325,7 +318,7 @@
 						</button>
 					{/if}
 					<button
-						class="button flex items-center gap-1 text-sm font-normal"
+						class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 						onclick={() => {
 							selected = currentSelected;
 							showDeleteConfirm = {

--- a/ui/user/src/routes/admin/audit-logs/exports/[id]/view/+page.svelte
+++ b/ui/user/src/routes/admin/audit-logs/exports/[id]/view/+page.svelte
@@ -3,9 +3,10 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import CreateAuditLogExportForm from '$lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import type { AuditLogExport } from '$lib/services/admin/types';
-	import { LoaderCircle } from 'lucide-svelte';
+	import { TriangleAlert } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fade, fly } from 'svelte/transition';
 
@@ -29,29 +30,21 @@
 	let title = $derived(exportData?.name ?? 'View Export');
 </script>
 
-<Layout classes={{ navbar: 'bg-surface1' }} {title} showBackButton>
+<Layout classes={{ navbar: 'bg-base-200' }} {title} showBackButton>
 	<div class="flex min-h-full flex-col gap-8" in:fade>
 		{#if loading}
 			<div class="flex items-center justify-center py-8">
-				<LoaderCircle class="text-primary size-8 animate-spin" />
+				<Loading class="size-8" />
 				<span class="ml-2 text-lg">Loading export details...</span>
 			</div>
 		{:else if error}
 			<div class="flex flex-col gap-6" in:fly={{ x: 100, delay: duration, duration }}>
-				<div class="rounded-md bg-red-50 p-4 dark:bg-red-950/50">
+				<div class="rounded-md bg-error/10">
 					<div class="flex items-center gap-2">
-						<svg class="size-5 text-red-600" fill="currentColor" viewBox="0 0 20 20">
-							<path
-								fill-rule="evenodd"
-								d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-								clip-rule="evenodd"
-							></path>
-						</svg>
-						<span class="text-sm font-medium text-red-800 dark:text-red-200"
-							>Error loading export</span
-						>
+						<TriangleAlert class="size-5 text-error" />
+						<span class="text-sm font-medium text-error">Error loading export</span>
 					</div>
-					<p class="mt-2 text-sm text-red-700 dark:text-red-300">{error}</p>
+					<p class="mt-2 text-sm text-error">{error}</p>
 				</div>
 			</div>
 		{:else if exportData}

--- a/ui/user/src/routes/admin/audit-logs/exports/scheduled/[id]/edit/+page.svelte
+++ b/ui/user/src/routes/admin/audit-logs/exports/scheduled/[id]/edit/+page.svelte
@@ -3,10 +3,11 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import CreateScheduleForm from '$lib/components/admin/audit-log-exports/CreateScheduleForm.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import type { ScheduledAuditLogExport } from '$lib/services/admin/types';
 	import { goto } from '$lib/url';
-	import { LoaderCircle } from 'lucide-svelte';
+	import { TriangleAlert } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fade, fly } from 'svelte/transition';
 
@@ -39,29 +40,21 @@
 	let title = $derived(scheduleData?.name ?? 'Edit Scheduled Export');
 </script>
 
-<Layout classes={{ navbar: 'bg-surface1' }} {title} showBackButton>
+<Layout classes={{ navbar: 'bg-base-200' }} {title} showBackButton>
 	<div class="flex min-h-full flex-col gap-8" in:fade>
 		{#if loading}
 			<div class="flex items-center justify-center py-8">
-				<LoaderCircle class="text-primary size-8 animate-spin" />
+				<Loading class="size-8" />
 				<span class="ml-2 text-lg">Loading scheduled export details...</span>
 			</div>
 		{:else if error}
 			<div class="flex flex-col gap-6" in:fly={{ x: 100, delay: duration, duration }}>
-				<div class="rounded-md bg-red-50 p-4 dark:bg-red-950/50">
+				<div class="rounded-md bg-error/10">
 					<div class="flex items-center gap-2">
-						<svg class="size-5 text-red-600" fill="currentColor" viewBox="0 0 20 20">
-							<path
-								fill-rule="evenodd"
-								d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-								clip-rule="evenodd"
-							></path>
-						</svg>
-						<span class="text-sm font-medium text-red-800 dark:text-red-200"
-							>Error loading scheduled export</span
-						>
+						<TriangleAlert class="size-5 text-error" />
+						<span class="text-sm font-medium text-error">Error loading scheduled export</span>
 					</div>
-					<p class="mt-2 text-sm text-red-700 dark:text-red-300">{error}</p>
+					<p class="mt-2 text-sm text-error">{error}</p>
 				</div>
 			</div>
 		{:else if scheduleData}

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -14,7 +14,7 @@
 	import { AdminService, Role } from '$lib/services/index.js';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte.js';
 	import { darkMode, errors, profile } from '$lib/stores/index.js';
-	import { AlertTriangle, Info } from 'lucide-svelte';
+	import { TriangleAlert, Info } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -181,7 +181,7 @@
 			{#if !atLeastOneConfigured}
 				<div class="notification-alert mb-4 flex flex-col gap-2">
 					<div class="flex items-center gap-2">
-						<AlertTriangle class="size-6 flex-shrink-0 self-start text-yellow-500" />
+						<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
 						<p class="my-0.5 flex flex-col text-sm font-semibold">No Auth Providers Configured!</p>
 					</div>
 					<span class="text-sm font-light break-all">
@@ -282,7 +282,7 @@
 				alt={confirmDeconfigureAuthProvider?.name}
 				class={twMerge(
 					'size-6 rounded-sm p-0.5',
-					!confirmDeconfigureAuthProvider?.iconDark && 'bg-surface1 dark:bg-gray-600'
+					!confirmDeconfigureAuthProvider?.iconDark && 'bg-base-200 dark:bg-base-300'
 				)}
 			/>
 			<h3 class="text-lg font-semibold">Deconfigure {confirmDeconfigureAuthProvider?.name}</h3>
@@ -332,10 +332,10 @@
 
 		<div class="my-4 flex flex-col gap-2">
 			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external temp login URL -->
-			<a class="button-auth group" href={setupTempLoginUrl} rel="external">
+			<a class="btn btn-secondary w-full" href={setupTempLoginUrl} rel="external">
 				{#if configuringAuthProvider?.icon}
 					<img
-						class="h-6 w-6 rounded-full bg-transparent p-1 dark:bg-gray-600"
+						class="h-6 w-6 rounded-full bg-base-100 p-1 dark:bg-gray-600"
 						src={configuringAuthProvider.icon}
 						alt={configuringAuthProvider.name}
 					/>

--- a/ui/user/src/routes/admin/chat-configuration/+page.svelte
+++ b/ui/user/src/routes/admin/chat-configuration/+page.svelte
@@ -6,10 +6,11 @@
 	import Search from '$lib/components/Search.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import { HELPER_TEXTS } from '$lib/context/helperMode.svelte.js';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, ModelUsage, type Model, type ModelProvider } from '$lib/services';
 	import { sortModelProviders } from '$lib/sort';
 	import { profile } from '$lib/stores/index.js';
-	import { Check, Info, LoaderCircle, TriangleAlert } from 'lucide-svelte';
+	import { Check, Info, TriangleAlert } from 'lucide-svelte';
 	import { onMount, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -159,7 +160,7 @@
 									type="text"
 									id="name"
 									bind:value={baseAgent.name}
-									class="text-input-filled dark:bg-background"
+									class="text-input-filled dark:bg-base-100"
 									disabled={isAdminReadonly}
 								/>
 							</div>
@@ -169,7 +170,7 @@
 									type="text"
 									id="description"
 									bind:value={baseAgent.description}
-									class="text-input-filled dark:bg-background"
+									class="text-input-filled dark:bg-base-100"
 									disabled={isAdminReadonly}
 								/>
 							</div>
@@ -191,7 +192,7 @@
 							rows={6}
 							id="prompt"
 							bind:value={baseAgent.prompt}
-							class="text-input-filled dark:bg-background"
+							class="text-input-filled dark:bg-base-100"
 							placeholder={HELPER_TEXTS.prompt}
 							use:autoHeight
 							disabled={isAdminReadonly}
@@ -201,19 +202,19 @@
 
 				{#if !isAdminReadonly}
 					<div
-						class="bg-surface1 dark:bg-background sticky bottom-0 left-0 flex w-[calc(100%+2em)] -translate-x-4 justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
+						class="bg-base-200 dark:bg-base-100 sticky bottom-0 left-0 flex w-[calc(100%+2em)] -translate-x-4 justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
 					>
 						{#if showSaved}
 							<span
 								in:fade={{ duration: 200 }}
-								class="text-on-surface1 flex min-h-10 items-center px-4 text-sm font-extralight"
+								class="text-muted-content flex min-h-10 items-center px-4 text-sm font-extralight"
 							>
 								Your changes have been saved.
 							</span>
 						{/if}
 
 						<button
-							class="button hover:bg-surface3 flex items-center gap-1 bg-transparent"
+							class="btn btn-secondary hover:bg-base-400 flex items-center gap-1 bg-transparent"
 							onclick={() => {
 								baseAgent = prevAgent;
 							}}
@@ -221,12 +222,12 @@
 							Reset
 						</button>
 						<button
-							class="button-primary flex items-center gap-1"
+							class="btn btn-primary flex items-center gap-1"
 							disabled={saving}
 							onclick={handleSave}
 						>
 							{#if saving}
-								<LoaderCircle class="size-4 animate-spin" />
+								<Loading class="size-4" />
 							{:else}
 								Save
 							{/if}
@@ -237,9 +238,9 @@
 				{/if}
 			{:else}
 				<div class="h-full w-full items-center justify-center">
-					<TriangleAlert class="text-on-surface1 size-24 opacity-50" />
-					<h4 class="text-on-surface1 text-lg font-semibold">An Error Occurred!</h4>
-					<p class="text-on-surface1 text-sm font-light">
+					<TriangleAlert class="text-base-content/80 size-24 opacity-50" />
+					<h4 class="text-muted-content text-lg font-semibold">An Error Occurred!</h4>
+					<p class="text-muted-content text-sm font-light">
 						We were unable to load the default base agent. Please try again later or contact
 						support.
 					</p>
@@ -252,7 +253,7 @@
 <ResponsiveDialog
 	bind:this={showAddModelsDialog}
 	title="Add Models"
-	class="dark:bg-surface1"
+	class="dark:bg-base-200"
 	classes={{
 		header: 'p-4 pb-0',
 		content: 'p-0'
@@ -265,7 +266,7 @@
 	{#if baseAgent}
 		<div class="mb-4 px-4">
 			<Search
-				class="dark:border-surface3 bg-background border border-transparent shadow-sm"
+				class="dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 				onChange={(val) => (addModelsSearch = val)}
 				placeholder="Search models..."
 			/>
@@ -284,8 +285,8 @@
 						{#each models as model (model.id)}
 							<button
 								class={twMerge(
-									'hover:bg-surface3 flex items-center justify-between gap-4 rounded-md bg-transparent p-2 font-light',
-									addModelsSelected[model.id] && 'bg-surface2'
+									'hover:bg-base-400 flex items-center justify-between gap-4 rounded-md bg-transparent p-2 font-light',
+									addModelsSelected[model.id] && 'bg-base-300'
 								)}
 								onclick={() => {
 									if (addModelsSelected[model.id]) {
@@ -308,8 +309,8 @@
 	{/if}
 
 	<div class="mt-auto flex justify-end gap-4 p-4">
-		<button class="button" onclick={resetAddModels}> Cancel </button>
-		<button class="button-primary" onclick={handleAddModels}> Add </button>
+		<button class="btn btn-secondary" onclick={resetAddModels}> Cancel </button>
+		<button class="btn btn-primary" onclick={handleAddModels}> Add </button>
 	</div>
 </ResponsiveDialog>
 

--- a/ui/user/src/routes/admin/chat-threads/+page.svelte
+++ b/ui/user/src/routes/admin/chat-threads/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import Search from '$lib/components/Search.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, type ProjectThread, type Project, type OrgUser } from '$lib/services';
 	import { Group } from '$lib/services/admin/types';
 	import { profile } from '$lib/stores';
@@ -18,7 +19,7 @@
 	} from '$lib/url';
 	import { openUrl } from '$lib/utils';
 	import { debounce } from 'es-toolkit';
-	import { Eye, LoaderCircle, MessageCircle } from 'lucide-svelte';
+	import { Eye, MessageCircle } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -129,7 +130,7 @@
 				<div class="flex items-center gap-4">
 					<Search
 						value={query}
-						class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+						class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 						onChange={updateQuery}
 						placeholder="Search threads..."
 					/>
@@ -137,13 +138,13 @@
 
 				{#if loading}
 					<div class="flex w-full justify-center py-12">
-						<LoaderCircle class="text-primary size-8 animate-spin" />
+						<Loading class="size-8" />
 					</div>
 				{:else if filteredThreads.length === 0}
 					<div class="flex w-full flex-col items-center justify-center py-12 text-center">
-						<MessageCircle class="text-on-surface1 size-24 opacity-50" />
-						<h3 class="text-on-surface1 mt-4 text-lg font-semibold">No threads available</h3>
-						<p class="text-on-surface1 mt-2 text-sm font-light">
+						<MessageCircle class="text-base-content/80 size-24 opacity-50" />
+						<h3 class="text-muted-content mt-4 text-lg font-semibold">No threads available</h3>
+						<p class="text-muted-content mt-2 text-sm font-light">
 							Threads will appear here once they are created.
 						</p>
 					</div>
@@ -194,25 +195,24 @@
 						onSort={setSortUrlParams}
 					>
 						{#snippet actions()}
-							<button
+							<IconButton
 								class={twMerge(
-									'icon-button',
 									isAuditor && 'hover:text-primary',
 									!isAuditor && 'opacity-50 hover:bg-transparent dark:hover:bg-transparent'
 								)}
 								title="View Thread"
-								use:tooltip={{
+								tooltip={{
 									text: isAuditor
 										? 'View Thread'
 										: 'To view details, auditing permissions are required.'
 								}}
 							>
 								<Eye class="size-4" />
-							</button>
+							</IconButton>
 						{/snippet}
 						{#snippet onRenderColumn(property, thread)}
 							{#if property === 'created'}
-								<span class="text-on-surface1 text-sm">
+								<span class="text-muted-content text-sm">
 									{formatTimeAgo(thread.created).relativeTime}
 								</span>
 							{:else}

--- a/ui/user/src/routes/admin/chat-threads/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/chat-threads/[id]/+page.svelte
@@ -3,12 +3,13 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import DebugCallFrames from '$lib/components/chat/DebugCallFrames.svelte';
 	import MessageComponent from '$lib/components/messages/Message.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, type ProjectThread } from '$lib/services';
 	import { Thread } from '$lib/services/chat/thread.svelte';
 	import type { CallFrame, Project } from '$lib/services/chat/types';
 	import type { Messages } from '$lib/services/chat/types';
 	import { formatTimeAgo } from '$lib/time';
-	import { LoaderCircle, MessageCircle } from 'lucide-svelte';
+	import { MessageCircle } from 'lucide-svelte';
 	import { onMount, onDestroy } from 'svelte';
 	import { fly, fade } from 'svelte/transition';
 
@@ -217,7 +218,7 @@
 							{#if showLoadOlderButton}
 								<div class="mb-4 flex justify-center">
 									<button
-										class="border-surface3 hover:bg-surface2 bg-background rounded-full border px-4 py-2 text-sm font-light transition-all duration-300"
+										class="border-base-400 hover:bg-base-300 bg-base-100 rounded-full border px-4 py-2 text-sm font-light transition-all duration-300"
 										onclick={loadOlderMessages}
 										disabled={loadingOlderMessages}
 									>
@@ -255,7 +256,7 @@
 											? 'bg-primary/10'
 											: 'bg-gray-50 dark:bg-gray-900/20'}"
 									>
-										<div class="flex-shrink-0">
+										<div class="shrink-0">
 											{#if msg.sent}
 												<div
 													class="bg-primary flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium text-white"
@@ -276,22 +277,22 @@
 													{msg.sent ? 'User' : msg.sourceName || 'Assistant'}
 												</span>
 												{#if msg.time}
-													<span class="text-on-surface1 text-xs">
+													<span class="text-muted-content text-xs">
 														{formatTimeAgo(msg.time.toISOString())}
 													</span>
 												{/if}
 											</div>
-											<div class="text-sm text-gray-700 dark:text-gray-300">
+											<div class="text-sm text-muted-content">
 												{#if msg.message && msg.message.length > 0}
 													{#each msg.message as msgPart, i (i)}
 														<p class="mb-2 last:mb-0">{msgPart}</p>
 													{/each}
 												{:else}
-													<span class="text-on-surface1 italic">No message content</span>
+													<span class="text-muted-content italic">No message content</span>
 												{/if}
 											</div>
 											{#if msg.toolCall}
-												<div class="mt-2 rounded bg-gray-100 p-2 text-xs dark:bg-gray-800">
+												<div class="mt-2 rounded bg-base-300 p-2 text-xs">
 													<strong>Tool Call:</strong>
 													{msg.toolCall.name || 'Unknown tool'}
 												</div>
@@ -306,15 +307,15 @@
 						</div>
 					{:else if loadingMessages}
 						<div class="flex items-center justify-center py-12 text-center">
-							<div class="text-on-surface1">
-								<LoaderCircle class="text-primary mx-auto mb-4 size-8 animate-spin" />
+							<div class="text-muted-content">
+								<Loading class="mx-auto mb-4 size-8" />
 								<h3 class="mb-2 text-lg font-medium">Loading Messages...</h3>
 								<p class="text-sm">Please wait while we load the thread messages.</p>
 							</div>
 						</div>
 					{:else}
 						<div class="flex items-center justify-center py-12 text-center">
-							<div class="text-on-surface1">
+							<div class="text-muted-content">
 								<MessageCircle class="mx-auto mb-4 size-16" />
 								<h3 class="mb-2 text-lg font-medium">No Messages Found</h3>
 								<p class="text-sm">This thread doesn't have any messages yet.</p>

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -402,7 +402,7 @@
 				)}
 			>
 				{#if hasDeviceScans}
-					<div class="shrink-0 border-b border-surface2 px-4 py-2">
+					<div class="shrink-0 border-b border-base-300 px-4 py-2">
 						<h4 class="flex items-center font-light text-xs uppercase">On Platform</h4>
 					</div>
 				{/if}
@@ -419,7 +419,7 @@
 					class="gap-0 paper min-w-0 p-0 col-span-12 @3xl:col-span-7"
 					in:fly={{ x: 100, duration: 150 }}
 				>
-					<div class="col-span-12 border-b border-surface2 px-4 py-2">
+					<div class="col-span-12 border-b border-base-300 px-4 py-2">
 						<h4 class="flex items-center font-light text-xs uppercase">Device Scans</h4>
 					</div>
 					<div class="@container min-w-0 w-full max-w-full">
@@ -445,17 +445,12 @@
 			{/if}
 
 			{#if loadingToolUsage}
-				<div
-					class={twMerge(
-						'bg-surface3 animate-pulse rounded-md',
-						hasDeviceScans ? 'h-81' : 'h-[400px]'
-					)}
-				></div>
+				<div class={twMerge('skeleton rounded-md', hasDeviceScans ? 'h-81' : 'h-[400px]')}></div>
 			{:else}
 				<div in:fade={{ duration: 150 }} class="paper gap-1 w-full min-h-72">
 					<div class="flex flex-wrap items-center justify-between gap-4">
 						<h4 class="flex items-center gap-1 font-semibold">
-							Top Servers Used <span class="text-on-surface1 text-xs font-light"
+							Top Servers Used <span class="text-muted-content text-xs font-light"
 								>(Last 30 Days)</span
 							>
 						</h4>
@@ -469,9 +464,9 @@
 					>
 						{#snippet tooltipContent(item)}
 							<div class="flex flex-col gap-0 text-xs">
-								<div class="text-on-surface1 text-xs">{item.label}</div>
+								<div class="text-muted-content text-xs">{item.label}</div>
 							</div>
-							<div class="text-on-background font-semibold">
+							<div class="text-base-content font-semibold">
 								{item.value} calls
 							</div>
 						{/snippet}
@@ -494,7 +489,7 @@
 				{#if loadingDeviceScanStats}
 					<div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
 						{#each Array.from({ length: 4 }) as _, i (i)}
-							<div class="paper min-h-72 animate-pulse bg-surface3/40"></div>
+							<div class="min-h-72 skeleton rounded-md"></div>
 						{/each}
 					</div>
 				{:else}
@@ -552,16 +547,16 @@
 
 {#snippet serverActivityGraph()}
 	{#if serverAndEntries.loading || loading}
-		<div class={twMerge('bg-surface3 animate-pulse rounded-md', 'h-[530px]')}></div>
+		<div class={twMerge('skeleton rounded-md', 'h-[530px]')}></div>
 		<div class="paper gap-1 flex grow">
 			<h4 class="flex items-center gap-2 font-semibold">Most Popular Servers</h4>
 			<div class="pt-2 flex flex-col gap-4">
 				{#each Array.from({ length: 5 }) as _, i (i)}
-					<div class="flex gap-2 items-center animate-pulse w-full">
-						<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
+					<div class="flex gap-2 items-center w-full">
+						<div class="size-8 rounded-md skeleton shrink-0"></div>
 						<div class="flex flex-col gap-2 flex-1">
-							<div class="h-4 w-full rounded bg-surface3"></div>
-							<div class="h-3 w-full rounded bg-surface3"></div>
+							<div class="h-4 w-full rounded-md skeleton"></div>
+							<div class="h-3 w-full rounded-md skeleton"></div>
 						</div>
 					</div>
 				{/each}
@@ -581,7 +576,7 @@
 								'flex flex-col items-center justify-center px-1 text-center',
 								deploymentStatusGridColClass(i, deploymentStatusBreakdown.length),
 								deploymentStatusGridShowBorderRight(i, deploymentStatusBreakdown.length) &&
-									'border-r border-surface2'
+									'border-r border-base-300'
 							)}
 						>
 							<div class="flex items-center gap-1">
@@ -591,9 +586,9 @@
 								{#if row.status === 'Available'}
 									<Server class="size-6 text-primary" />
 								{:else if row.status === 'Needs Attention'}
-									<Siren class="size-6 text-yellow-500" />
+									<Siren class="size-6 text-warning" />
 								{:else}
-									<Server class="size-6 text-on-surface1/75" />
+									<Server class="size-6 text-muted-content/75" />
 								{/if}
 							</div>
 							<div class="text-xs">{row.status}</div>
@@ -626,7 +621,7 @@
 						legend={doesSupportK8sUpdates ? entryTypeDonutLegend : undefined}
 					/>
 				{:else}
-					<p class="font-light text-xs text-on-surface1 pt-2 text-center">
+					<p class="font-light text-xs text-muted-content pt-2 text-center">
 						No servers have been deployed yet.
 					</p>
 				{/if}
@@ -636,7 +631,7 @@
 				<div class="flex justify-end">
 					<a
 						href={resolve('/admin/mcp-servers?view=deployments')}
-						class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+						class="text-[11px] transition-colors self-end translate-x-2 duration-200 bg-base-400/50 hover:bg-base-400 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
 					>
 						See More <ChevronRight class="size-3" />
 					</a>
@@ -652,11 +647,11 @@
 		{#if mcpServersAndEntries.current.loading || loading}
 			<div class="pt-2 flex flex-col gap-4">
 				{#each Array.from({ length: 5 }) as _, i (i)}
-					<div class="flex gap-2 items-center animate-pulse w-full">
-						<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
+					<div class="flex gap-2 items-center w-full">
+						<div class="size-8 rounded-md skeleton shrink-0"></div>
 						<div class="flex flex-col gap-2 flex-1">
-							<div class="h-4 w-full rounded bg-surface3"></div>
-							<div class="h-3 w-full rounded bg-surface3"></div>
+							<div class="h-4 w-full rounded-md skeleton"></div>
+							<div class="h-3 w-full rounded-md skeleton"></div>
 						</div>
 					</div>
 				{/each}
@@ -677,17 +672,17 @@
 							? getEntryUrl(info.entry)
 							: undefined}
 					<a
-						class="flex gap-2 items-center dark:hover:bg-surface2 hover:bg-surface1 transition-colors duration-150 -mx-2 px-2 py-1 rounded-md"
+						class="flex gap-2 items-center dark:hover:bg-base-300 hover:bg-base-200 transition-colors duration-150 -mx-2 px-2 py-1 rounded-md"
 						href={url ? resolve(url as `/${string}`) : undefined}
 					>
 						{#if icon}
 							<img
 								src={icon}
 								alt={info.id}
-								class="size-9 bg-surface1 dark:bg-surface2 rounded-md p-1"
+								class="size-9 bg-base-200 dark:bg-base-300 rounded-md p-1"
 							/>
 						{:else}
-							<Server class="size-9 opacity-65 bg-surface1 rounded-md p-1" />
+							<Server class="size-9 opacity-65 bg-base-200 rounded-md p-1" />
 						{/if}
 						<div class="flex flex-col gap-0.5 max-w-[calc(100%-4.5rem)]">
 							<p class="text-sm font-medium">{displayName}</p>
@@ -696,7 +691,7 @@
 									{stripMarkdownToText(description ?? '')}
 								</p>
 							{/if}
-							<p class="text-xs text-on-surface1 italic">Deployed {info.count} times</p>
+							<p class="text-xs text-muted-content italic">Deployed {info.count} times</p>
 						</div>
 						<ChevronRight class="size-5 shrink-0" />
 					</a>
@@ -704,7 +699,7 @@
 			</div>
 		{:else}
 			<p
-				class="text-xs text-on-surface1 pt-2 font-light text-center h-full flex items-center justify-center"
+				class="text-xs text-muted-content pt-2 font-light text-center h-full flex items-center justify-center"
 			>
 				No servers have been deployed yet.
 			</p>
@@ -713,7 +708,7 @@
 		{#if popularServers.length > 0 && !isBootStrapUser}
 			<a
 				href={resolve('/admin/mcp-servers')}
-				class="justify-end self-end text-[11px] translate-x-2 transition-colors duration-200 bg-surface3/50 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
+				class="justify-end self-end text-[11px] translate-x-2 transition-colors duration-200 bg-base-400/50 hover:bg-base-400 rounded-md py-0.5 w-fit px-2 flex items-center gap-1"
 			>
 				See More <ChevronRight class="size-3" />
 			</a>
@@ -724,13 +719,13 @@
 {#snippet platformStatCell(platformStat: (typeof platformStatTiles)[number])}
 	{@const defaultClasses = 'col-span-4 p-2 flex gap-4 items-center justify-between w-full'}
 	<div
-		class="col-span-1 min-w-0 border-r-0 px-2 my-2 flex [&:last-child:nth-child(odd)]:col-span-2 @md:col-span-4 @md:[&:last-child:nth-child(odd)]:col-span-4 @md:not-last:border-r @md:not-last:border-surface2"
+		class="col-span-1 min-w-0 border-r-0 px-2 my-2 flex [&:last-child:nth-child(odd)]:col-span-2 @md:col-span-4 @md:[&:last-child:nth-child(odd)]:col-span-4 @md:not-last:border-r @md:not-last:border-base-300"
 	>
 		{#if platformStat.seeMore && !isBootStrapUser}
 			<a
 				class={twMerge(
 					defaultClasses,
-					'group w-full hover:bg-surface2/50 transition-colors duration-200 rounded-md'
+					'group w-full hover:bg-base-300/50 transition-colors duration-200 rounded-md'
 				)}
 				href={resolve(platformStat.seeMore as `/${string}`)}
 			>
@@ -747,14 +742,14 @@
 {#snippet deviceScanStatCell(deviceScanStat: (typeof deviceScanTiles)[number])}
 	{@const defaultClasses = 'p-2 flex gap-4 items-center justify-between w-full'}
 	<div
-		class="col-span-1 min-w-0 flex border-r-0 px-2 my-2 [&:last-child:nth-child(odd)]:col-span-2 @md:flex-1 @md:col-span-auto @md:[&:last-child:nth-child(odd)]:col-span-auto @md:not-last:border-r @md:not-last:border-surface2"
+		class="col-span-1 min-w-0 flex border-r-0 px-2 my-2 [&:last-child:nth-child(odd)]:col-span-2 @md:flex-1 @md:col-span-auto @md:[&:last-child:nth-child(odd)]:col-span-auto @md:not-last:border-r @md:not-last:border-base-300"
 	>
 		{#if deviceScanStat.seeMore}
 			<a
 				href={resolve(deviceScanStat.seeMore as `/${string}`)}
 				class={twMerge(
 					defaultClasses,
-					'group w-full hover:bg-surface2/50 transition-colors duration-200 rounded-md'
+					'group w-full hover:bg-base-300/50 transition-colors duration-200 rounded-md'
 				)}
 			>
 				{@render statContent(deviceScanStat)}
@@ -769,7 +764,7 @@
 
 {#snippet statContent(platformStat: (typeof platformStatTiles | typeof deviceScanTiles)[number])}
 	<div class="w-full">
-		<div class="text-xs text-on-surface1 flex items-center gap-1 shrink-0 mb-0.5">
+		<div class="text-xs text-muted-content flex items-center gap-1 shrink-0 mb-0.5">
 			{platformStat.label}
 		</div>
 
@@ -786,7 +781,7 @@
 					class="size-4 text-primary transition-opacity duration-200 group-hover:opacity-0"
 				/>
 				<ChevronRight
-					class="pointer-events-none text-on-surface1 absolute inset-0 size-4 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+					class="pointer-events-none text-muted-content absolute inset-0 size-4 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
 				/>
 			</div>
 		</div>
@@ -802,23 +797,23 @@
 	>
 		<h4 class="flex items-center gap-2 font-semibold mb-1">
 			Recently Popular Tools
-			<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
+			<span class="text-muted-content text-xs font-light">(Last 30 Days)</span>
 		</h4>
 		{#if loadingToolUsage}
 			<div class="pt-2 flex flex-col gap-4 w-full">
 				{#each Array.from({ length: maxToolsToShow }) as _, i (i)}
-					<div class="flex gap-2 items-center animate-pulse w-full">
-						<div class="size-8 rounded-md bg-surface3 shrink-0"></div>
+					<div class="flex gap-2 items-center w-full">
+						<div class="size-8 rounded-md skeleton shrink-0"></div>
 						<div class="flex flex-col gap-2 flex-1">
-							<div class="h-4 w-full rounded bg-surface3"></div>
-							<div class="h-3 w-full rounded bg-surface3"></div>
+							<div class="h-4 w-full rounded-md skeleton"></div>
+							<div class="h-3 w-full rounded-md skeleton"></div>
 						</div>
 					</div>
 				{/each}
 			</div>
 		{:else if topToolCalls.length === 0}
 			<p
-				class="text-xs text-on-surface1 pt-2 font-light grow flex items-center justify-center h-full text-center"
+				class="text-xs text-muted-content pt-2 font-light grow flex items-center justify-center h-full text-center"
 			>
 				No recent tool calls.
 			</p>
@@ -827,7 +822,7 @@
 				{#each topToolCalls.slice(0, maxToolsToShow) as row (row.compositeKey)}
 					<li class="flex gap-2 items-center">
 						<div
-							class="size-8 items-center justify-center shrink-0 bg-surface1 dark:bg-surface2 rounded-md p-1"
+							class="size-8 items-center justify-center shrink-0 bg-base-200 dark:bg-base-300 rounded-md p-1"
 						>
 							<Wrench class="size-6 opacity-65 shrink-0" />
 						</div>
@@ -835,7 +830,7 @@
 							<p class="text-sm font-medium truncate">
 								{row.toolLabel.split('.').slice(1).join('.') || row.compositeKey}
 							</p>
-							<p class="text-xs text-on-surface1">
+							<p class="text-xs text-muted-content">
 								{formatNumber(row.count)} calls · {row.serverDisplayName}
 							</p>
 						</div>
@@ -849,7 +844,7 @@
 		{#if topToolCalls.length > 0 && !isBootStrapUser}
 			<a
 				href={resolve('/admin/usage')}
-				class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
+				class="text-[11px] translate-x-2 self-end bg-base-400/50 transition-colors duration-200 hover:bg-base-400 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
 			>
 				See More <ChevronRight class="size-3" />
 			</a>
@@ -866,22 +861,22 @@
 	>
 		<h4 class="flex items-center gap-2 font-semibold mb-1">
 			Tool Call Average Response Time
-			<span class="text-on-surface1 text-xs font-light">(Last 30 Days)</span>
+			<span class="text-muted-content text-xs font-light">(Last 30 Days)</span>
 		</h4>
 		{#if loadingToolUsage}
 			<div class="pt-2 flex flex-col gap-4 w-full">
 				{#each Array.from({ length: maxToolsToShow }) as _, i (i)}
-					<div class="flex gap-2 items-center animate-pulse w-full">
+					<div class="flex gap-2 items-center w-full">
 						<div class="flex flex-col gap-2 flex-1">
-							<div class="h-4 w-full rounded bg-surface3"></div>
-							<div class="h-3 w-full rounded bg-surface3"></div>
+							<div class="h-4 w-full rounded-md skeleton"></div>
+							<div class="h-3 w-full rounded-md skeleton"></div>
 						</div>
 					</div>
 				{/each}
 			</div>
 		{:else if avgToolCallResponseTime.length === 0}
 			<p
-				class="text-xs text-on-surface1 pt-2 font-light grow flex items-center justify-center h-full text-center"
+				class="text-xs text-muted-content pt-2 font-light grow flex items-center justify-center h-full text-center"
 			>
 				No recent tool calls.
 			</p>
@@ -894,7 +889,7 @@
 								<p class="text-sm font-medium truncate">
 									{row.toolName.split('.').slice(1).join('.')}
 								</p>
-								<p class="text-xs text-on-surface1">
+								<p class="text-xs text-muted-content">
 									{row.serverDisplayName}
 								</p>
 							</div>
@@ -912,7 +907,7 @@
 		{#if avgToolCallResponseTime.length > 0 && !isBootStrapUser}
 			<a
 				href={resolve('/admin/usage')}
-				class="text-[11px] translate-x-2 self-end bg-surface3/50 transition-colors duration-200 hover:bg-surface3 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
+				class="text-[11px] translate-x-2 self-end bg-base-400/50 transition-colors duration-200 hover:bg-base-400 rounded-md py-0.5 w-fit px-2 flex items-center gap-1 mt-2"
 			>
 				See More <ChevronRight class="size-3" />
 			</a>
@@ -923,3 +918,16 @@
 <svelte:head>
 	<title>Obot | Dashboard</title>
 </svelte:head>
+
+<style lang="postcss">
+	.skeleton-list-item .skeleton {
+		:global(.dark) & {
+			background-image: linear-gradient(
+				105deg,
+				var(--color-base-300) 0% 40%,
+				var(--color-base-400) 50%,
+				var(--color-base-300) 60% 100%
+			);
+		}
+	}
+</style>

--- a/ui/user/src/routes/admin/device-clients/+page.svelte
+++ b/ui/user/src/routes/admin/device-clients/+page.svelte
@@ -81,16 +81,16 @@
 	>
 		<Search
 			value={nameFilter}
-			class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 			onChange={updateName}
 			placeholder="Search by client name..."
 		/>
 
 		{#if clients.length === 0}
 			<div class="mx-auto mt-12 flex w-md flex-col items-center gap-4 text-center">
-				<MonitorCheck class="text-on-surface1 size-24 opacity-50" />
-				<h4 class="text-on-surface1 text-lg font-semibold">No clients observed yet</h4>
-				<p class="text-on-surface1 text-sm font-light">
+				<MonitorCheck class="text-muted-content size-24 opacity-50" />
+				<h4 class="text-muted-content text-lg font-semibold">No clients observed yet</h4>
+				<p class="text-muted-content text-sm font-light">
 					Run <code class="font-mono">obot scan</code> from a managed device with clients to populate
 					this view.
 				</p>
@@ -115,7 +115,7 @@
 						{#if d.name?.trim()}
 							<span class="font-medium">{d.name}</span>
 						{:else}
-							<span class="text-on-surface2 italic">(unnamed)</span>
+							<span class="text-muted-content italic">(unnamed)</span>
 						{/if}
 					{:else if property === 'skills'}
 						{d.skills.length}

--- a/ui/user/src/routes/admin/device-clients/[name]/+page.svelte
+++ b/ui/user/src/routes/admin/device-clients/[name]/+page.svelte
@@ -56,14 +56,14 @@
 		out:fly={{ x: -100, duration }}
 	>
 		{#if !client}
-			<p class="text-on-surface1 text-sm font-light">Client not found.</p>
+			<p class="text-muted-content text-sm font-light">Client not found.</p>
 		{:else}
-			<div class="dark:bg-surface2 bg-background flex flex-col gap-4 rounded-md p-4 shadow-sm">
+			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-4 rounded-md p-4 shadow-sm">
 				<div class="flex flex-col gap-2">
 					<h2 class="flex items-center gap-2 text-xl font-semibold">
 						{detail.name}
 					</h2>
-					<div class="text-on-surface1 flex flex-wrap items-center gap-3 text-xs">
+					<div class="text-muted-content flex flex-wrap items-center gap-3 text-xs">
 						<span>{detail.users.length} user{detail.users.length === 1 ? '' : 's'}</span>
 						<span>·</span>
 						{#if detail.mcpServers}
@@ -82,7 +82,7 @@
 			</div>
 
 			<div class="flex flex-col gap-2">
-				<div class="border-surface2 dark:border-surface2 flex gap-2 border-b">
+				<div class="border-base-300 dark:border-base-400 flex gap-2 border-b">
 					{@render tabButton('users', Users, 'Users', detail.users.length)}
 					{@render tabButton('mcp', Server, 'MCP Servers', detail.mcpServers?.length ?? 0)}
 					{@render tabButton('skills', PencilRuler, 'Skills', detail.skills?.length ?? 0)}
@@ -162,12 +162,12 @@
 								{#if property === 'name'}
 									{d.name}
 								{:else if property === 'description'}
-									<span class="text-on-surface1 text-xs">{d.description ?? '—'}</span>
+									<span class="text-muted-content text-xs">{d.description ?? '—'}</span>
 								{:else if property === 'hasScripts'}
 									{#if d.hasScripts}
 										<CheckIcon class="text-primary size-3 shrink-0" />
 									{:else}
-										<XIcon class="text-on-surface1 size-3 shrink-0" />
+										<XIcon class="text-muted-content size-3 shrink-0" />
 									{/if}
 								{:else if property === 'files'}
 									{d.files ?? '-'}
@@ -185,12 +185,12 @@
 	<button class="tab-button" class:tab-active={activeTab === tab} onclick={() => (activeTab = tab)}>
 		<Icon class="size-4" />
 		{label}
-		<span class="text-on-surface1">({count})</span>
+		<span class="text-muted-content">({count})</span>
 	</button>
 {/snippet}
 
 {#snippet emptyTab(msg: string)}
-	<div class="text-on-surface1 flex items-center gap-2 p-4 text-sm font-light">
+	<div class="text-muted-content flex items-center gap-2 p-4 text-sm font-light">
 		{msg}
 	</div>
 {/snippet}

--- a/ui/user/src/routes/admin/device-mcp-servers/+page.svelte
+++ b/ui/user/src/routes/admin/device-mcp-servers/+page.svelte
@@ -51,16 +51,16 @@
 	>
 		<Search
 			value={nameFilter}
-			class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 			onChange={updateName}
 			placeholder="Search by server name..."
 		/>
 
 		{#if allRows.length === 0}
 			<div class="mx-auto mt-12 flex w-md flex-col items-center gap-4 text-center">
-				<Server class="text-on-surface1 size-24 opacity-50" />
-				<h4 class="text-on-surface1 text-lg font-semibold">No MCP servers observed yet</h4>
-				<p class="text-on-surface1 text-sm font-light">
+				<Server class="text-muted-content size-24 opacity-50" />
+				<h4 class="text-muted-content text-lg font-semibold">No MCP servers observed yet</h4>
+				<p class="text-muted-content text-sm font-light">
 					Run <code class="font-mono">obot scan</code> from a managed device with configured MCP servers
 					to populate this view.
 				</p>
@@ -89,7 +89,7 @@
 						{#if d.name?.trim()}
 							<span class="font-medium">{d.name}</span>
 						{:else}
-							<span class="text-on-surface2 italic">(unnamed)</span>
+							<span class="text-muted-content italic">(unnamed)</span>
 						{/if}
 					{:else if property === 'transport'}
 						<span class="pill-primary bg-primary text-xs">{d.transport}</span>

--- a/ui/user/src/routes/admin/device-mcp-servers/[hash]/+page.svelte
+++ b/ui/user/src/routes/admin/device-mcp-servers/[hash]/+page.svelte
@@ -86,19 +86,19 @@
 		out:fly={{ x: -100, duration }}
 	>
 		{#if !detail}
-			<p class="text-on-surface1 text-sm font-light">MCP server not found.</p>
+			<p class="text-muted-content text-sm font-light">MCP server not found.</p>
 		{:else}
-			<div class="dark:bg-surface2 bg-background flex flex-col gap-4 rounded-md p-4 shadow-sm">
+			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-4 rounded-md p-4 shadow-sm">
 				<div class="flex flex-col gap-2">
 					<h2 class="flex items-center gap-2 text-xl font-semibold">
 						{#if detail.name?.trim()}
 							{detail.name}
 						{:else}
-							<span class="text-on-surface2 italic">(unnamed)</span>
+							<span class="text-muted-content italic">(unnamed)</span>
 						{/if}
 						<span class="pill-primary bg-primary text-xs">{detail.transport}</span>
 					</h2>
-					<div class="text-on-surface1 flex flex-wrap items-center gap-3 text-xs">
+					<div class="text-muted-content flex flex-wrap items-center gap-3 text-xs">
 						<span>{detail.deviceCount} device{detail.deviceCount === 1 ? '' : 's'}</span>
 						<span>·</span>
 						<span>{detail.userCount} user{detail.userCount === 1 ? '' : 's'}</span>
@@ -110,7 +110,7 @@
 				<div class="grid grid-cols-1 gap-3 md:grid-cols-2">
 					{#if detail.command}
 						<div class="flex flex-col gap-1">
-							<span class="text-on-surface2 text-xs uppercase">Command</span>
+							<span class="text-muted-content text-xs uppercase">Command</span>
 							<code class="font-mono text-xs break-all">
 								{[detail.command, ...(detail.args ?? [])].join(' ')}
 							</code>
@@ -118,26 +118,26 @@
 					{/if}
 					{#if detail.url}
 						<div class="flex flex-col gap-1">
-							<span class="text-on-surface2 text-xs uppercase">URL</span>
+							<span class="text-muted-content text-xs uppercase">URL</span>
 							<code class="font-mono text-xs break-all">{detail.url}</code>
 						</div>
 					{/if}
 					{#if detail.envKeys?.length}
 						<div class="flex flex-col gap-1">
-							<span class="text-on-surface2 text-xs uppercase">Env keys</span>
+							<span class="text-muted-content text-xs uppercase">Env keys</span>
 							<div class="flex flex-wrap gap-1">
 								{#each detail.envKeys as k (k)}
-									<code class="bg-surface3 rounded px-1.5 py-0.5 font-mono text-xs">{k}</code>
+									<code class="bg-base-400 rounded px-1.5 py-0.5 font-mono text-xs">{k}</code>
 								{/each}
 							</div>
 						</div>
 					{/if}
 					{#if detail.headerKeys?.length}
 						<div class="flex flex-col gap-1">
-							<span class="text-on-surface2 text-xs uppercase">Header keys</span>
+							<span class="text-muted-content text-xs uppercase">Header keys</span>
 							<div class="flex flex-wrap gap-1">
 								{#each detail.headerKeys as k (k)}
-									<code class="bg-surface3 rounded px-1.5 py-0.5 font-mono text-xs">{k}</code>
+									<code class="bg-base-400 rounded px-1.5 py-0.5 font-mono text-xs">{k}</code>
 								{/each}
 							</div>
 						</div>
@@ -146,7 +146,7 @@
 			</div>
 
 			<div class="flex flex-col gap-2">
-				<h3 class="text-on-surface1 text-sm font-semibold">
+				<h3 class="text-muted-content text-sm font-semibold">
 					Occurrences · {total}
 				</h3>
 				<Table
@@ -170,7 +170,7 @@
 						{#if property === 'shortDeviceID'}
 							<a
 								href={resolve(`/admin/devices/${d.deviceID}`)}
-								class="font-mono text-xs btn-link text-blue-500"
+								class="font-mono text-xs btn-link text-primary"
 								title={d.deviceID}
 								onclick={(e) => e.stopPropagation()}
 							>

--- a/ui/user/src/routes/admin/device-overview/+page.svelte
+++ b/ui/user/src/routes/admin/device-overview/+page.svelte
@@ -190,15 +190,15 @@
 
 		{#if !stats || stats.deviceCount === 0}
 			<div class="mx-auto mt-12 flex w-md flex-col items-center gap-4 text-center">
-				<ScanLine class="text-on-surface1 size-24 opacity-50" />
-				<h4 class="text-on-surface1 text-lg font-semibold">No device scans in this window</h4>
-				<p class="text-on-surface1 text-sm font-light">
+				<ScanLine class="text-muted-content size-24 opacity-50" />
+				<h4 class="text-muted-content text-lg font-semibold">No device scans in this window</h4>
+				<p class="text-muted-content text-sm font-light">
 					Adjust the date range or run <code class="font-mono">obot scan</code> from a managed device.
 				</p>
 			</div>
 		{:else}
 			<div
-				class="paper dark:divide-surface3 divide-surface2 grid grid-cols-2 divide-x sm:grid-cols-3 lg:grid-cols-5"
+				class="paper dark:divide-base-400 divide-base-300 grid grid-cols-2 divide-x sm:grid-cols-3 lg:grid-cols-5"
 			>
 				{#each tiles as tile (tile.key)}
 					{@render statCell(tile)}
@@ -243,7 +243,7 @@
 				e.preventDefault();
 				openUrl(resolve('/admin/devices'), e.ctrlKey || e.metaKey);
 			}}
-			class="hover:bg-surface2/50 group flex items-center justify-between gap-3 p-4 transition-colors"
+			class="hover:bg-base-300/50 group flex items-center justify-between gap-3 p-4 transition-colors"
 		>
 			{@render statCellInner(tile, true)}
 		</a>
@@ -254,7 +254,7 @@
 				e.preventDefault();
 				openUrl(resolve('/admin/device-mcp-servers'), e.ctrlKey || e.metaKey);
 			}}
-			class="hover:bg-surface2/50 group flex items-center justify-between gap-3 p-4 transition-colors"
+			class="hover:bg-base-300/50 group flex items-center justify-between gap-3 p-4 transition-colors"
 		>
 			{@render statCellInner(tile, true)}
 		</a>
@@ -265,7 +265,7 @@
 				e.preventDefault();
 				openUrl(resolve('/admin/device-skills'), e.ctrlKey || e.metaKey);
 			}}
-			class="hover:bg-surface2/50 group flex items-center justify-between gap-3 p-4 transition-colors"
+			class="hover:bg-base-300/50 group flex items-center justify-between gap-3 p-4 transition-colors"
 		>
 			{@render statCellInner(tile, true)}
 		</a>
@@ -278,7 +278,7 @@
 
 {#snippet statCellInner(tile: StatTile, clickable: boolean)}
 	<div class="flex min-w-0 flex-col">
-		<span class="text-on-surface1 truncate text-xs">
+		<span class="text-muted-content truncate text-xs">
 			{tile.label}{#if clickable}<ChevronRight
 					class="ml-0.5 inline size-3 -translate-x-0.5 opacity-0 transition group-hover:translate-x-0 group-hover:opacity-100"
 				/>{/if}

--- a/ui/user/src/routes/admin/device-skills/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/+page.svelte
@@ -85,16 +85,16 @@
 	>
 		<Search
 			value={nameFilter}
-			class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+			class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 			onChange={updateName}
 			placeholder="Search by skill name..."
 		/>
 
 		{#if total === 0 && !loading}
 			<div class="mx-auto mt-12 flex w-md flex-col items-center gap-4 text-center">
-				<PencilRuler class="text-on-surface1 size-24 opacity-50" />
-				<h4 class="text-on-surface1 text-lg font-semibold">No skills observed yet</h4>
-				<p class="text-on-surface1 text-sm font-light">
+				<PencilRuler class="text-muted-content size-24 opacity-50" />
+				<h4 class="text-muted-content text-lg font-semibold">No skills observed yet</h4>
+				<p class="text-muted-content text-sm font-light">
 					Run <code class="font-mono">obot scan</code> from a managed device with SKILL.md files to populate
 					this view.
 				</p>

--- a/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
@@ -87,9 +87,9 @@
 		out:fly={{ x: -100, duration }}
 	>
 		{#if !detail}
-			<p class="text-on-surface1 text-sm font-light">Skill not found.</p>
+			<p class="text-muted-content text-sm font-light">Skill not found.</p>
 		{:else}
-			<div class="dark:bg-surface2 bg-background flex flex-col gap-4 rounded-md p-4 shadow-sm">
+			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-4 rounded-md p-4 shadow-sm">
 				<div class="flex flex-col gap-2">
 					<h2 class="flex items-center gap-2 text-xl font-semibold">
 						{detail.name}
@@ -97,7 +97,7 @@
 							<span class="pill-primary bg-primary text-xs">has scripts</span>
 						{/if}
 					</h2>
-					<div class="text-on-surface1 flex flex-wrap items-center gap-3 text-xs">
+					<div class="text-muted-content flex flex-wrap items-center gap-3 text-xs">
 						<span>{detail.deviceCount} device{detail.deviceCount === 1 ? '' : 's'}</span>
 						<span>·</span>
 						<span>{detail.userCount} user{detail.userCount === 1 ? '' : 's'}</span>
@@ -110,7 +110,7 @@
 
 				{#if detail.description}
 					<div class="flex flex-col gap-1">
-						<span class="text-on-surface2 text-xs uppercase">Description</span>
+						<span class="text-muted-content text-xs uppercase">Description</span>
 						<p class="text-sm">{detail.description}</p>
 					</div>
 				{/if}
@@ -118,19 +118,19 @@
 				<div class="grid grid-cols-1 gap-3 md:grid-cols-2">
 					{#if detail.gitRemoteURL}
 						<div class="flex flex-col gap-1">
-							<span class="text-on-surface2 text-xs uppercase">Git remote</span>
+							<span class="text-muted-content text-xs uppercase">Git remote</span>
 							<code class="font-mono text-xs break-all">{detail.gitRemoteURL}</code>
 						</div>
 					{/if}
 					{#if detail.files?.length}
 						<div class="flex flex-col gap-1 md:col-span-2">
-							<span class="text-on-surface2 text-xs uppercase">
+							<span class="text-muted-content text-xs uppercase">
 								Files ({detail.files.length})
 							</span>
 							<ul class="flex flex-col gap-0.5">
 								{#each detail.files as f (f)}
 									<li class="flex items-center gap-1.5 font-mono text-xs">
-										<FileText class="text-on-surface1 size-3 shrink-0" />
+										<FileText class="text-muted-content size-3 shrink-0" />
 										<span class="break-all">{f}</span>
 									</li>
 								{/each}
@@ -141,7 +141,7 @@
 			</div>
 
 			<div class="flex flex-col gap-2">
-				<h3 class="text-on-surface1 text-sm font-semibold">
+				<h3 class="text-muted-content text-sm font-semibold">
 					Occurrences · {total}
 				</h3>
 				<Table
@@ -173,14 +173,14 @@
 						{#if property === 'shortDeviceID'}
 							<a
 								href={resolve(`/admin/devices/${d.deviceID}`)}
-								class="font-mono text-xs btn-link text-blue-500"
+								class="font-mono text-xs btn-link text-primary"
 								title={d.deviceID}
 								onclick={(e) => e.stopPropagation()}
 							>
 								{d.shortDeviceID}
 							</a>
 						{:else if property === 'projectPath'}
-							<span class="text-on-surface1 font-mono text-xs">{d.projectPath ?? '—'}</span>
+							<span class="text-muted-content font-mono text-xs">{d.projectPath ?? '—'}</span>
 						{:else}
 							{d[property as keyof Row]}
 						{/if}

--- a/ui/user/src/routes/admin/devices/+page.svelte
+++ b/ui/user/src/routes/admin/devices/+page.svelte
@@ -122,16 +122,16 @@
 	>
 		{#if total === 0 && !loading}
 			<div class="mx-auto mt-12 flex w-md flex-col items-center gap-4 text-center">
-				<Laptop class="text-on-surface1 size-24 opacity-50" />
-				<h4 class="text-on-surface1 text-lg font-semibold">No devices scanned yet</h4>
-				<p class="text-on-surface1 text-sm font-light">
+				<Laptop class="text-muted-content size-24 opacity-50" />
+				<h4 class="text-muted-content text-lg font-semibold">No devices scanned yet</h4>
+				<p class="text-muted-content text-sm font-light">
 					Run <code class="font-mono">obot scan</code> from a managed device to populate this view.
 				</p>
 			</div>
 		{:else}
 			<Search
 				value={query}
-				class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+				class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 				onChange={updateQuery}
 				placeholder="Search by device ID or user..."
 			/>
@@ -172,7 +172,7 @@
 						{#if u}
 							<div class="flex items-center gap-2">
 								<div
-									class="size-5 shrink-0 overflow-hidden rounded-full bg-gray-50 dark:bg-gray-600"
+									class="size-5 shrink-0 overflow-hidden rounded-full bg-base-100 dark:bg-base-300"
 								>
 									{#if u.iconURL}
 										<img

--- a/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
@@ -203,28 +203,30 @@
 		out:fly={{ x: -100, duration }}
 	>
 		{#if !latest}
-			<p class="text-on-surface1 text-sm font-light">No scans found for this device.</p>
+			<p class="text-muted-content text-sm font-light">No scans found for this device.</p>
 		{:else}
 			<!-- Header card -->
-			<div class="dark:bg-surface2 bg-background flex flex-col gap-4 rounded-md p-4 shadow-sm">
+			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-4 rounded-md p-4 shadow-sm">
 				<dl class="grid grid-cols-[max-content_1fr] items-center gap-x-4 gap-y-2 text-sm">
-					<dt class="text-on-surface1 text-xs font-medium tracking-wide uppercase">Device ID</dt>
+					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">Device ID</dt>
 					<dd class="flex items-center gap-2">
 						<span class="font-mono text-base font-semibold">{deviceId}</span>
 						<CopyButton text={deviceId} />
 					</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium tracking-wide uppercase">OS / Arch</dt>
+					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">OS / Arch</dt>
 					<dd>
 						<span class="pill-primary bg-primary">{latest.os}/{latest.arch}</span>
 					</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium tracking-wide uppercase">Submitted by</dt>
+					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">
+						Submitted by
+					</dt>
 					<dd>
 						{#if submittedByUser}
 							<div class="flex items-center gap-2">
 								<div
-									class="size-6 shrink-0 overflow-hidden rounded-full bg-gray-50 dark:bg-gray-600"
+									class="size-6 shrink-0 overflow-hidden rounded-full bg-base-100 dark:bg-base-300"
 								>
 									{#if submittedByUser.iconURL}
 										<img
@@ -240,39 +242,43 @@
 						{:else if latest.submittedBy}
 							<span class="font-mono text-xs">{latest.submittedBy}</span>
 						{:else}
-							<span class="text-on-surface1">—</span>
+							<span class="text-muted-content">—</span>
 						{/if}
 					</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium tracking-wide uppercase">OS user</dt>
+					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">OS user</dt>
 					<dd class="font-mono">{latest.username || '—'}</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium tracking-wide uppercase">Hostname</dt>
+					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">Hostname</dt>
 					<dd class="font-mono">{latest.hostname || '—'}</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium tracking-wide uppercase">Scanner</dt>
+					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">Scanner</dt>
 					<dd class="font-mono">{latest.scannerVersion || '—'}</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium tracking-wide uppercase">Last scanned</dt>
+					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">
+						Last scanned
+					</dt>
 					<dd use:tooltip={scannedTime.fullDate}>
 						{scannedTime.relativeTime || '—'}
 					</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium tracking-wide uppercase">Total scans</dt>
+					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">
+						Total scans
+					</dt>
 					<dd>{scans.length}</dd>
 				</dl>
 			</div>
 
 			<!-- Latest scan tabs -->
 			<div class="flex flex-col gap-2">
-				<div class="border-surface2 dark:border-surface2 flex gap-2 border-b">
+				<div class="border-base-300 flex gap-2 border-b">
 					<button
 						class="tab-button"
 						class:tab-active={activeTab === 'mcp'}
 						onclick={() => (activeTab = 'mcp')}
 					>
 						<Server class="size-4" /> MCP Servers
-						<span class="text-on-surface1">({mcpServers.length})</span>
+						<span class="text-muted-content">({mcpServers.length})</span>
 					</button>
 					<button
 						class="tab-button"
@@ -280,7 +286,7 @@
 						onclick={() => (activeTab = 'skills')}
 					>
 						<PencilRuler class="size-4" /> Skills
-						<span class="text-on-surface1">({skills.length})</span>
+						<span class="text-muted-content">({skills.length})</span>
 					</button>
 					<button
 						class="tab-button"
@@ -288,7 +294,7 @@
 						onclick={() => (activeTab = 'plugins')}
 					>
 						<Boxes class="size-4" /> Plugins
-						<span class="text-on-surface1">({plugins.length})</span>
+						<span class="text-muted-content">({plugins.length})</span>
 					</button>
 					<button
 						class="tab-button"
@@ -296,7 +302,7 @@
 						onclick={() => (activeTab = 'clients')}
 					>
 						<MonitorCheck class="size-4" /> Clients
-						<span class="text-on-surface1">({clients.length})</span>
+						<span class="text-muted-content">({clients.length})</span>
 					</button>
 				</div>
 
@@ -337,7 +343,7 @@
 							{/snippet}
 
 							{#snippet actions(d)}
-								<DotDotDot class="icon-button hover:dark:bg-background/50">
+								<DotDotDot class="hover:dark:bg-base-100/50">
 									{#snippet icon()}
 										<Ellipsis class="size-4" />
 									{/snippet}
@@ -393,7 +399,7 @@
 						>
 							{#snippet onRenderColumn(property, d: SkillRow)}
 								{#if property === 'description'}
-									<span class="text-on-surface1 text-xs">{d.description ?? '—'}</span>
+									<span class="text-muted-content text-xs">{d.description ?? '—'}</span>
 								{:else if property === 'hasScripts'}
 									{d.hasScripts ? 'yes' : 'no'}
 								{:else if property === 'client'}
@@ -404,7 +410,7 @@
 							{/snippet}
 
 							{#snippet actions(d)}
-								<DotDotDot class="icon-button hover:dark:bg-background/50">
+								<DotDotDot class="hover:dark:bg-base-100/50">
 									{#snippet icon()}
 										<Ellipsis class="size-4" />
 									{/snippet}
@@ -509,7 +515,7 @@
 
 			<!-- Scan history (includes latest as first row) -->
 			<div class="flex flex-col gap-2">
-				<h3 class="text-on-surface1 text-sm font-semibold">
+				<h3 class="text-muted-content text-sm font-semibold">
 					Scan history · {scans.length}
 				</h3>
 				<Table
@@ -559,7 +565,7 @@
 </Layout>
 
 {#snippet emptyTab(msg: string)}
-	<div class="text-on-surface1 flex items-center gap-2 p-4 text-sm font-light">
+	<div class="text-muted-content flex items-center gap-2 p-4 text-sm font-light">
 		<Cpu class="size-4 opacity-50" />
 		{msg}
 	</div>
@@ -587,7 +593,7 @@
 		padding: 0.5rem 0.75rem;
 		border-bottom: 2px solid transparent;
 		font-size: 0.875rem;
-		color: var(--on-surface1, #6b7280);
+		color: var(--muted-content, #6b7280);
 		transition:
 			color 200ms,
 			border-color 200ms;

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
@@ -213,14 +213,14 @@
 		out:fly={{ x: -100, duration }}
 	>
 		{#if !scan}
-			<p class="text-on-surface1 text-sm font-light">Scan not found.</p>
+			<p class="text-muted-content text-sm font-light">Scan not found.</p>
 		{:else}
 			<!-- Header card -->
 			<div
-				class="dark:bg-surface2 bg-background flex flex-col gap-4 rounded-md p-4 shadow-sm md:flex-row md:items-start md:justify-between"
+				class="dark:bg-base-300 bg-base-100 flex flex-col gap-4 rounded-md p-4 shadow-sm md:flex-row md:items-start md:justify-between"
 			>
 				<dl class="grid flex-1 grid-cols-[max-content_1fr] items-center gap-x-4 gap-y-2 text-sm">
-					<dt class="text-on-surface1 text-xs font-medium uppercase tracking-wide">Device ID</dt>
+					<dt class="text-muted-content text-xs font-medium uppercase tracking-wide">Device ID</dt>
 					<dd class="flex items-center gap-2">
 						<span class="font-mono text-base font-semibold">{scan.deviceID}</span>
 						<CopyButton text={scan.deviceID} />
@@ -233,17 +233,19 @@
 						{/if}
 					</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium uppercase tracking-wide">OS / Arch</dt>
+					<dt class="text-muted-content text-xs font-medium uppercase tracking-wide">OS / Arch</dt>
 					<dd>
 						<span class="pill-primary bg-primary">{scan.os}/{scan.arch}</span>
 					</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium uppercase tracking-wide">Submitted by</dt>
+					<dt class="text-muted-content text-xs font-medium uppercase tracking-wide">
+						Submitted by
+					</dt>
 					<dd>
 						{#if submittedByUser}
 							<div class="flex items-center gap-2">
 								<div
-									class="size-6 shrink-0 overflow-hidden rounded-full bg-gray-50 dark:bg-gray-600"
+									class="size-6 shrink-0 overflow-hidden rounded-full bg-base-100 dark:bg-base-300"
 								>
 									{#if submittedByUser.iconURL}
 										<img
@@ -259,14 +261,14 @@
 						{:else if scan.submittedBy}
 							<span class="font-mono text-xs">{scan.submittedBy}</span>
 						{:else}
-							<span class="text-on-surface1">—</span>
+							<span class="text-muted-content">—</span>
 						{/if}
 					</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium uppercase tracking-wide">Scanner</dt>
+					<dt class="text-muted-content text-xs font-medium uppercase tracking-wide">Scanner</dt>
 					<dd class="font-mono">{scan.scannerVersion || '—'}</dd>
 
-					<dt class="text-on-surface1 text-xs font-medium uppercase tracking-wide">Scanned</dt>
+					<dt class="text-muted-content text-xs font-medium uppercase tracking-wide">Scanned</dt>
 					<dd use:tooltip={scannedTime.fullDate}>
 						{scannedTime.relativeTime || '—'}
 					</dd>
@@ -274,7 +276,7 @@
 				{#if canDelete}
 					<button
 						type="button"
-						class="button-destructive flex items-center gap-1.5 self-start"
+						class="btn btn-error flex items-center gap-1.5 self-start"
 						onclick={() => (deleteOpen = true)}
 					>
 						<Trash2 class="size-4" /> Delete
@@ -284,14 +286,14 @@
 
 			<!-- Tabs -->
 			<div class="flex flex-col gap-2">
-				<div class="border-surface2 dark:border-surface2 flex gap-2 border-b">
+				<div class="border-base-300 flex gap-2 border-b">
 					<button
 						class="tab-button"
 						class:tab-active={activeTab === 'mcp'}
 						onclick={() => (activeTab = 'mcp')}
 					>
 						<Server class="size-4" /> MCP Servers
-						<span class="text-on-surface1">({mcpServers.length})</span>
+						<span class="text-muted-content">({mcpServers.length})</span>
 					</button>
 					<button
 						class="tab-button"
@@ -299,7 +301,7 @@
 						onclick={() => (activeTab = 'skills')}
 					>
 						<PencilRuler class="size-4" /> Skills
-						<span class="text-on-surface1">({skills.length})</span>
+						<span class="text-muted-content">({skills.length})</span>
 					</button>
 					<button
 						class="tab-button"
@@ -307,7 +309,7 @@
 						onclick={() => (activeTab = 'plugins')}
 					>
 						<Boxes class="size-4" /> Plugins
-						<span class="text-on-surface1">({plugins.length})</span>
+						<span class="text-muted-content">({plugins.length})</span>
 					</button>
 					<button
 						class="tab-button"
@@ -315,7 +317,7 @@
 						onclick={() => (activeTab = 'clients')}
 					>
 						<MonitorCheck class="size-4" /> Clients
-						<span class="text-on-surface1">({clients.length})</span>
+						<span class="text-muted-content">({clients.length})</span>
 					</button>
 				</div>
 
@@ -383,7 +385,7 @@
 						>
 							{#snippet onRenderColumn(property, d: SkillRow)}
 								{#if property === 'description'}
-									<span class="text-on-surface1 text-xs">{d.description ?? '—'}</span>
+									<span class="text-muted-content text-xs">{d.description ?? '—'}</span>
 								{:else if property === 'hasScripts'}
 									{d.hasScripts ? 'yes' : 'no'}
 								{:else if property === 'client'}
@@ -513,7 +515,7 @@
 {/snippet}
 
 {#snippet emptyTab(msg: string)}
-	<div class="text-on-surface1 flex items-center gap-2 p-4 text-sm font-light">
+	<div class="text-muted-content flex items-center gap-2 p-4 text-sm font-light">
 		<Cpu class="size-4 opacity-50" />
 		{msg}
 	</div>

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
@@ -67,81 +67,81 @@
 		out:fly={{ x: -100, duration }}
 	>
 		{#if !scan || !server}
-			<p class="text-on-surface1 text-sm font-light">MCP server not found in this scan.</p>
+			<p class="text-muted-content text-sm font-light">MCP server not found in this scan.</p>
 		{:else}
-			<div class="dark:bg-surface2 bg-background flex flex-col gap-3 rounded-md p-4 shadow-sm">
+			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-3 rounded-md p-4 shadow-sm">
 				<div class="flex flex-wrap items-baseline gap-2">
 					<h2 class="font-mono text-xl font-semibold">{server.name}</h2>
 					<span class="pill-primary bg-primary">{server.transport}</span>
-					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
 						{server.client}
 					</span>
-					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
 						{scope}
 					</span>
 				</div>
 
 				<dl class="grid grid-cols-1 gap-x-6 gap-y-2 text-sm md:grid-cols-[max-content_1fr]">
 					{#if endpoint}
-						<dt class="text-on-surface1">Endpoint</dt>
+						<dt class="text-muted-content">Endpoint</dt>
 						<dd class="font-mono break-all">{endpoint}</dd>
 					{/if}
 					{#if server.command}
-						<dt class="text-on-surface1">Command</dt>
+						<dt class="text-muted-content">Command</dt>
 						<dd class="font-mono break-all">{server.command}</dd>
 					{/if}
 					{#if server.args && server.args.length > 0}
-						<dt class="text-on-surface1">Args</dt>
+						<dt class="text-mute-content">Args</dt>
 						<dd class="font-mono text-xs break-all">
 							{#each server.args as arg, i (i)}
-								<span class="dark:bg-surface3 bg-surface2 mr-1 inline-block rounded px-1.5 py-0.5">
+								<span class="dark:bg-base-400 bg-base-300 mr-1 inline-block rounded px-1.5 py-0.5">
 									{arg}
 								</span>
 							{/each}
 						</dd>
 					{/if}
 					{#if server.url}
-						<dt class="text-on-surface1">URL</dt>
+						<dt class="text-muted-content">URL</dt>
 						<dd class="font-mono break-all">{server.url}</dd>
 					{/if}
-					<dt class="text-on-surface1">Env keys</dt>
+					<dt class="text-muted-content">Env keys</dt>
 					<dd>
 						{#if server.envKeys && server.envKeys.length > 0}
 							<div class="flex flex-wrap gap-1">
 								{#each server.envKeys as k (k)}
 									<span
-										class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs"
+										class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs"
 									>
 										{k}
 									</span>
 								{/each}
 							</div>
 						{:else}
-							<span class="text-on-surface1">none</span>
+							<span class="text-muted-content">none</span>
 						{/if}
 					</dd>
-					<dt class="text-on-surface1">Header keys</dt>
+					<dt class="text-muted-content">Header keys</dt>
 					<dd>
 						{#if server.headerKeys && server.headerKeys.length > 0}
 							<div class="flex flex-wrap gap-1">
 								{#each server.headerKeys as k (k)}
 									<span
-										class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs"
+										class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs"
 									>
 										{k}
 									</span>
 								{/each}
 							</div>
 						{:else}
-							<span class="text-on-surface1">none</span>
+							<span class="text-muted-content">none</span>
 						{/if}
 					</dd>
 					{#if server.file}
-						<dt class="text-on-surface1">File</dt>
+						<dt class="text-muted-content">File</dt>
 						<dd class="font-mono text-xs break-all">{server.file}</dd>
 					{/if}
 					{#if parentPlugin}
-						<dt class="text-on-surface1">Part of plugin</dt>
+						<dt class="text-muted-content">Part of plugin</dt>
 						<dd>
 							<a
 								class="text-link font-mono"
@@ -154,11 +154,11 @@
 						</dd>
 					{/if}
 					{#if server.projectPath}
-						<dt class="text-on-surface1">Project path</dt>
+						<dt class="text-muted-content">Project path</dt>
 						<dd class="font-mono text-xs break-all">{server.projectPath}</dd>
 					{/if}
 					{#if server.configHash}
-						<dt class="text-on-surface1">Config hash</dt>
+						<dt class="text-muted-content">Config hash</dt>
 						<dd class="flex items-center gap-1">
 							<span class="font-mono text-xs" use:tooltip={server.configHash}>
 								{shortHash(server.configHash)}
@@ -174,12 +174,12 @@
 					<h3 class="text-base font-semibold">Configuration</h3>
 					<CopyButton text={renderConfig(server)} />
 				</div>
-				<div class="dark:bg-surface2 bg-background flex flex-col gap-2 rounded-md p-3 shadow-sm">
+				<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-2 rounded-md p-3 shadow-sm">
 					<pre
-						class="dark:bg-surface3 bg-surface1 text-on-background max-h-96 overflow-auto rounded p-2 font-mono text-xs">{renderConfig(
+						class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs">{renderConfig(
 							server
 						)}</pre>
-					<p class="text-on-surface1 text-xs">
+					<p class="text-muted-content text-xs">
 						Reconstructed from parsed fields. <code>&lt;set&gt;</code> indicates the key was present but
 						the value was not captured.
 					</p>

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
@@ -40,25 +40,25 @@
 		out:fly={{ x: -100, duration }}
 	>
 		{#if !scan || !plugin}
-			<p class="text-on-surface1 text-sm font-light">Plugin not found in this scan.</p>
+			<p class="text-muted-content text-sm font-light">Plugin not found in this scan.</p>
 		{:else}
-			<div class="dark:bg-surface2 bg-background flex flex-col gap-3 rounded-md p-4 shadow-sm">
+			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-3 rounded-md p-4 shadow-sm">
 				<div class="flex flex-wrap items-baseline gap-2">
 					<h2 class="font-mono text-xl font-semibold">{plugin.name}</h2>
 					{#if plugin.version}
-						<span class="text-on-surface1 font-mono text-sm">v{plugin.version}</span>
+						<span class="text-muted-content font-mono text-sm">v{plugin.version}</span>
 					{/if}
 					<span class="pill-primary bg-primary">{plugin.pluginType}</span>
-					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
 						{plugin.client}
 					</span>
-					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
 						{scope}
 					</span>
 					<span
 						class="pill text-xs"
 						class:bg-success={plugin.enabled}
-						class:bg-surface3={!plugin.enabled}
+						class:bg-base-400={!plugin.enabled}
 					>
 						{plugin.enabled ? 'enabled' : 'disabled'}
 					</span>
@@ -66,34 +66,34 @@
 
 				<dl class="grid grid-cols-1 gap-x-6 gap-y-2 text-sm md:grid-cols-[max-content_1fr]">
 					{#if plugin.description}
-						<dt class="text-on-surface1">Description</dt>
+						<dt class="text-muted-content">Description</dt>
 						<dd>{plugin.description}</dd>
 					{/if}
 					{#if plugin.author}
-						<dt class="text-on-surface1">Author</dt>
+						<dt class="text-muted-content">Author</dt>
 						<dd>{plugin.author}</dd>
 					{/if}
 					{#if plugin.marketplace}
-						<dt class="text-on-surface1">Marketplace</dt>
+						<dt class="text-muted-content">Marketplace</dt>
 						<dd class="font-mono text-xs break-all">{plugin.marketplace}</dd>
 					{/if}
 					{#if plugin.configPath}
-						<dt class="text-on-surface1">File</dt>
+						<dt class="text-muted-content">File</dt>
 						<dd class="font-mono text-xs break-all">{plugin.configPath}</dd>
 					{/if}
 					{#if plugin.projectPath}
-						<dt class="text-on-surface1">Project path</dt>
+						<dt class="text-muted-content">Project path</dt>
 						<dd class="font-mono text-xs break-all">{plugin.projectPath}</dd>
 					{/if}
-					<dt class="text-on-surface1">Capabilities</dt>
+					<dt class="text-muted-content">Capabilities</dt>
 					<dd>
 						{#if capabilities.length === 0}
-							<span class="text-on-surface1">none detected</span>
+							<span class="text-muted-content">none detected</span>
 						{:else}
 							<div class="flex flex-wrap gap-1">
 								{#each capabilities as c (c.key)}
 									<span
-										class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs"
+										class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs"
 									>
 										{c.key}
 									</span>
@@ -107,27 +107,27 @@
 			<div class="flex flex-col gap-2">
 				<h3 class="text-base font-semibold">Supporting files ({files.length})</h3>
 				{#if files.length === 0}
-					<p class="text-on-surface1 text-sm font-light">No supporting files referenced.</p>
+					<p class="text-muted-content text-sm font-light">No supporting files referenced.</p>
 				{:else}
 					<div class="flex flex-col gap-3">
 						{#each files as { path, file } (path)}
 							<div
-								class="dark:bg-surface2 bg-background flex flex-col gap-2 rounded-md p-3 shadow-sm"
+								class="dark:bg-base-300 bg-base-100 flex flex-col gap-2 rounded-md p-3 shadow-sm"
 							>
 								<div class="flex flex-wrap items-center gap-2 text-xs">
 									<span class="font-mono break-all">{path}</span>
 									{#if file}
-										<span class="text-on-surface1">{formatBytes(file.sizeBytes)}</span>
+										<span class="text-muted-content">{formatBytes(file.sizeBytes)}</span>
 										{#if file.oversized}
 											<span class="pill bg-warning">oversized</span>
 										{/if}
 									{:else}
-										<span class="text-on-surface1">not collected</span>
+										<span class="text-muted-content">not collected</span>
 									{/if}
 								</div>
 								{#if file?.content}
 									<pre
-										class="dark:bg-surface3 bg-surface1 text-on-background max-h-96 overflow-auto rounded p-2 font-mono text-xs">{file.content}</pre>
+										class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs">{file.content}</pre>
 								{/if}
 							</div>
 						{/each}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
@@ -43,15 +43,15 @@
 		out:fly={{ x: -100, duration }}
 	>
 		{#if !scan || !skill}
-			<p class="text-on-surface1 text-sm font-light">Skill not found in this scan.</p>
+			<p class="text-muted-content text-sm font-light">Skill not found in this scan.</p>
 		{:else}
-			<div class="dark:bg-surface2 bg-background flex flex-col gap-3 rounded-md p-4 shadow-sm">
+			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-3 rounded-md p-4 shadow-sm">
 				<div class="flex flex-wrap items-baseline gap-2">
 					<h2 class="font-mono text-xl font-semibold">{skill.name}</h2>
-					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
 						{clientLabel}
 					</span>
-					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
 						{scope}
 					</span>
 					{#if skill.hasScripts}
@@ -61,23 +61,23 @@
 
 				<dl class="grid grid-cols-1 gap-x-6 gap-y-2 text-sm md:grid-cols-[max-content_1fr]">
 					{#if skill.description}
-						<dt class="text-on-surface1">Description</dt>
+						<dt class="text-muted-content">Description</dt>
 						<dd>{skill.description}</dd>
 					{/if}
 					{#if skill.gitRemoteURL}
-						<dt class="text-on-surface1">Git remote</dt>
+						<dt class="text-muted-content">Git remote</dt>
 						<dd class="font-mono text-xs break-all">{skill.gitRemoteURL}</dd>
 					{/if}
 					{#if skill.file}
-						<dt class="text-on-surface1">File</dt>
+						<dt class="text-muted-content">File</dt>
 						<dd class="font-mono text-xs break-all">{skill.file}</dd>
 					{/if}
 					{#if skill.projectPath}
-						<dt class="text-on-surface1">Project path</dt>
+						<dt class="text-muted-content">Project path</dt>
 						<dd class="font-mono text-xs break-all">{skill.projectPath}</dd>
 					{/if}
 					{#if parentPlugin}
-						<dt class="text-on-surface1">Part of plugin</dt>
+						<dt class="text-muted-content">Part of plugin</dt>
 						<dd>
 							<a
 								class="text-link font-mono"
@@ -95,27 +95,27 @@
 			<div class="flex flex-col gap-2">
 				<h3 class="text-base font-semibold">Supporting files ({files.length})</h3>
 				{#if files.length === 0}
-					<p class="text-on-surface1 text-sm font-light">No supporting files referenced.</p>
+					<p class="text-muted-content text-sm font-light">No supporting files referenced.</p>
 				{:else}
 					<div class="flex flex-col gap-3">
 						{#each files as { path, file } (path)}
 							<div
-								class="dark:bg-surface2 bg-background flex flex-col gap-2 rounded-md p-3 shadow-sm"
+								class="dark:bg-base-300 bg-base-100 flex flex-col gap-2 rounded-md p-3 shadow-sm"
 							>
 								<div class="flex flex-wrap items-center gap-2 text-xs">
 									<span class="font-mono break-all">{path}</span>
 									{#if file}
-										<span class="text-on-surface1">{formatBytes(file.sizeBytes)}</span>
+										<span class="text-muted-content">{formatBytes(file.sizeBytes)}</span>
 										{#if file.oversized}
 											<span class="pill bg-warning">oversized</span>
 										{/if}
 									{:else}
-										<span class="text-on-surface1">not collected</span>
+										<span class="text-muted-content">not collected</span>
 									{/if}
 								</div>
 								{#if file?.content}
 									<pre
-										class="dark:bg-surface3 bg-surface1 text-on-background max-h-96 overflow-auto rounded p-2 font-mono text-xs">{file.content}</pre>
+										class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs">{file.content}</pre>
 								{/if}
 							</div>
 						{/each}

--- a/ui/user/src/routes/admin/filters/+page.svelte
+++ b/ui/user/src/routes/admin/filters/+page.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import DotDotDot from '$lib/components/DotDotDot.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import Search from '$lib/components/Search.svelte';
 	import FilterForm from '$lib/components/admin/FilterForm.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, type MCPFilter, type SystemMCPServerCatalogEntry } from '$lib/services';
 	import { profile } from '$lib/stores';
 	import { replaceState } from '$lib/url';
@@ -23,7 +24,7 @@
 	import { openUrl } from '$lib/utils';
 	import BuiltInFilters from './BuiltInFilters.svelte';
 	import { debounce } from 'es-toolkit';
-	import { Filter, LoaderCircle, Plus, Trash2 } from 'lucide-svelte';
+	import { Funnel, Plus, Trash2 } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -100,9 +101,9 @@
 			>
 				{#if filters.length === 0}
 					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-						<Filter class="text-on-surface1 size-24 opacity-50" />
-						<h4 class="text-on-surface1 text-lg font-semibold">No created filters</h4>
-						<p class="text-on-surface1 text-sm font-light">
+						<Funnel class="text-muted-content size-24 opacity-50" />
+						<h4 class="text-muted-content text-lg font-semibold">No created filters</h4>
+						<p class="text-muted-content text-sm font-light">
 							Looks like you don't have any filters created yet. <br />
 							Click the "Add New Filter" button above to get started.
 						</p>
@@ -111,7 +112,7 @@
 					<div class="flex flex-col gap-2">
 						<Search
 							value={query}
-							class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+							class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 							onChange={updateQuery}
 							placeholder="Search filters..."
 						/>
@@ -143,16 +144,16 @@
 						>
 							{#snippet actions(d: MCPFilter)}
 								{#if !profile.current.isAdminReadonly?.()}
-									<button
-										class="icon-button hover:text-red-500"
+									<IconButton
+										variant="danger"
 										onclick={(e) => {
 											e.stopPropagation();
 											filterToDelete = d;
 										}}
-										use:tooltip={'Delete Filter'}
+										tooltip={{ text: 'Delete Filter' }}
 									>
 										<Trash2 class="size-4" />
-									</button>
+									</IconButton>
 								{/if}
 							{/snippet}
 							{#snippet onRenderColumn(property, d: (typeof tableData)[number])}
@@ -166,7 +167,7 @@
 								{:else if property === 'status'}
 									<span
 										class={d.status === 'Disabled'
-											? 'text-on-surface1 font-light italic text-xs'
+											? 'text-muted-content font-light italic text-xs'
 											: 'pill-primary bg-primary'}>{d.status}</span
 									>
 								{:else}
@@ -182,7 +183,7 @@
 
 	{#snippet rightNavActions()}
 		{#if loading}
-			<LoaderCircle class="size-4 animate-spin" />
+			<Loading class="size-4" />
 		{/if}
 		{#if !profile.current.isAdminReadonly?.()}
 			{@render addFilterButton()}
@@ -192,7 +193,7 @@
 
 {#snippet addFilterButton()}
 	<DotDotDot
-		class="button-primary w-full text-sm md:w-fit"
+		class="btn btn-block btn-primary w-full text-sm md:w-fit"
 		placement="bottom"
 		classes={{ popover: 'z-50' }}
 	>
@@ -244,7 +245,7 @@
 />
 
 <ResponsiveDialog
-	class="bg-surface1 dark:bg-background md:max-w-dvw md:w-6xl"
+	class="bg-base-200 dark:bg-base-100 md:max-w-dvw md:w-6xl"
 	title="Select Built-in Filter"
 	bind:this={builtInFiltersDialog}
 >

--- a/ui/user/src/routes/admin/filters/BuiltInFilters.svelte
+++ b/ui/user/src/routes/admin/filters/BuiltInFilters.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
 	import { type SystemMCPServerCatalogEntry } from '$lib/services';
@@ -52,26 +53,26 @@
 			{/if}
 		{/snippet}
 		{#snippet actions()}
-			<button class="icon-button hover:dark:bg-background/50">
-				<StepForward class="size-4 text-on-surface1" />
-			</button>
+			<IconButton class="hover:dark:bg-base-100/50">
+				<StepForward class="size-4 text-muted-content" />
+			</IconButton>
 		{/snippet}
 	</Table>
 {:else if filteredBuiltInFiltersData.length > 0}
 	<div class="p-4 md:p-0">
 		<button
-			class="p-4 rounded-sm flex items-center gap-6 justify-between bg-background dark:bg-surface1 shadow-md transition-colors duration-300 hover:bg-surface2 dark:hover:bg-surface2"
+			class="p-4 rounded-sm flex items-center gap-6 justify-between bg-base-100 dark:bg-base-200 shadow-md transition-colors duration-300 hover:bg-base-300 dark:hover:bg-base-300"
 			onclick={() => onSelect?.(filteredBuiltInFiltersData[0])}
 		>
 			<p class="flex flex-col gap-1 text-left">
 				<span class="text-base font-semibold">{filteredBuiltInFiltersData[0].name}</span>
-				<span class="text-sm font-light text-on-surface1 line-clamp-3">
+				<span class="text-sm font-light text-muted-content line-clamp-3">
 					{stripMarkdownToText(filteredBuiltInFiltersData[0].manifest.description)}
 				</span>
 			</p>
-			<StepForward class="size-4 shrink-0 text-on-surface1" />
+			<StepForward class="size-4 shrink-0 text-muted-content" />
 		</button>
 	</div>
 
-	<div class="text-on-surface1 text-sm font-light mt-4 text-center italic">More Coming Soon!</div>
+	<div class="text-muted-content text-sm font-light mt-4 text-center italic">More Coming Soon!</div>
 {/if}

--- a/ui/user/src/routes/admin/filters/EnableFilter.svelte
+++ b/ui/user/src/routes/admin/filters/EnableFilter.svelte
@@ -265,11 +265,11 @@
 	{#snippet errorPostContent()}
 		{#if launchLogs.length > 0}
 			<div
-				class="default-scrollbar-thin bg-surface1 max-h-[50vh] w-full overflow-y-auto rounded-lg p-4 shadow-inner"
+				class="default-scrollbar-thin bg-base-200 max-h-[50vh] w-full overflow-y-auto rounded-lg p-4 shadow-inner"
 			>
 				{#each launchLogs as log, i (i)}
 					<div class="font-mono text-sm">
-						<span class="text-on-surface1">{log}</span>
+						<span class="text-muted-content">{log}</span>
 					</div>
 				{/each}
 			</div>
@@ -280,7 +280,7 @@
 		<div class="flex w-full flex-col items-center gap-2 md:flex-row">
 			{#if entry}
 				<button
-					class="button-primary w-full md:w-1/2 md:flex-1"
+					class="btn btn-primary w-full md:w-1/2 md:flex-1"
 					onclick={() => {
 						launchState = 'relaunching';
 						launchError = undefined;
@@ -294,7 +294,9 @@
 					Update Configuration and Try Again
 				</button>
 			{/if}
-			<button class="button w-full md:w-1/2 md:flex-1" onclick={handleCancel}> Cancel </button>
+			<button class="btn btn-secondary w-full md:w-1/2 md:flex-1" onclick={handleCancel}>
+				Cancel
+			</button>
 		</div>
 	{/snippet}
 </PageLoading>
@@ -312,14 +314,14 @@
 		<div class="flex w-full justify-end gap-2">
 			{#if entry && hasEditableConfiguration(entry)}
 				<button
-					class="button text-sm"
+					class="btn btn-secondary text-sm"
 					onclick={() => {
 						selectorsAndMcpServersDialog?.close();
 						configDialog?.open();
 					}}>Go Back</button
 				>
 			{/if}
-			<button class="button-primary text-sm" onclick={handleFinish}>Save</button>
+			<button class="btn btn-primary text-sm" onclick={handleFinish}>Save</button>
 		</div>
 	</div>
 </ResponsiveDialog>

--- a/ui/user/src/routes/admin/filters/FilterView.svelte
+++ b/ui/user/src/routes/admin/filters/FilterView.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import FilterForm from '$lib/components/admin/FilterForm.svelte';
 	import McpServerK8sInfo from '$lib/components/admin/McpServerK8sInfo.svelte';
 	import AuditLogsPageContent from '$lib/components/admin/audit-logs/AuditLogsPageContent.svelte';
 	import UsageGraphs from '$lib/components/admin/usage/UsageGraphs.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import { AdminService } from '$lib/services';
@@ -65,13 +65,13 @@
 					{title || filter.name || 'Filter'}
 				</h1>
 				{#if !profile.current.isAdminReadonly?.() && !entry?.id}
-					<button
-						class="button-destructive flex items-center gap-1 text-xs font-normal"
-						use:tooltip={{ text: 'Delete Filter', placement: 'left' }}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete Filter', placement: 'left' }}
 						onclick={() => (deletingFilter = true)}
 					>
 						<Trash2 class="size-4" />
-					</button>
+					</IconButton>
 				{/if}
 			</div>
 			<div class="flex flex-1 gap-2 py-1 text-sm font-light max-h-11.5">
@@ -83,8 +83,8 @@
 						class={twMerge(
 							'min-w-fit flex-1 rounded-md border border-transparent px-3 py-2 text-center whitespace-nowrap transition-colors duration-300',
 							selected === tab.view &&
-								'dark:bg-surface1 dark:border-surface3 bg-background shadow-sm',
-							selected !== tab.view && 'hover:bg-surface3'
+								'dark:bg-base-200 dark:border-base-400 bg-base-100 shadow-sm',
+							selected !== tab.view && 'hover:bg-base-400'
 						)}
 					>
 						{tab.label}
@@ -121,9 +121,9 @@
 					<AuditLogsPageContent mcpId={mcpServerId} mcpServerDisplayName={filter.name}>
 						{#snippet emptyContent()}
 							<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-								<BookOpenText class="text-on-surface1 size-24 opacity-50" />
-								<h4 class="text-on-surface1 text-lg font-semibold">No recent audit logs</h4>
-								<p class="text-on-surface1 text-sm font-light">
+								<BookOpenText class="text-muted-content size-24 opacity-50" />
+								<h4 class="text-muted-content text-lg font-semibold">No recent audit logs</h4>
+								<p class="text-muted-content text-sm font-light">
 									This web validation server has not had any active usage in the last 7 days.
 								</p>
 							</div>

--- a/ui/user/src/routes/admin/groups/+page.svelte
+++ b/ui/user/src/routes/admin/groups/+page.svelte
@@ -137,7 +137,7 @@
 		<div class="flex flex-col gap-8">
 			<div class="flex flex-col gap-2">
 				<Search
-					class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+					class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 					value={query}
 					onChange={updateQuery}
 					placeholder="Search by group name..."
@@ -181,7 +181,7 @@
 									</button>
 									{#if d.assignment}
 										<button
-											class="menu-button text-red-500"
+											class="menu-button text-error"
 											disabled={!profile.current.groups.includes(Group.OWNER) &&
 												d.roleId === Role.OWNER}
 											onclick={() => (deletingGroup = d)}
@@ -201,7 +201,7 @@
 	{#snippet rightNavActions()}
 		{#if !isAdminReadonly}
 			<button
-				class="button-primary w-full text-sm sm:w-auto"
+				class="btn btn-primary w-full text-sm sm:w-auto"
 				onclick={() => {
 					showAddAssignment = true;
 					addGroupAssignmentDialog?.clear();

--- a/ui/user/src/routes/admin/groups/AddGroupAssignmentDialog.svelte
+++ b/ui/user/src/routes/admin/groups/AddGroupAssignmentDialog.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import Search from '$lib/components/Search.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { Role, type OrgGroup, type GroupRoleAssignment } from '$lib/services/admin/types';
 	import { responsive } from '$lib/stores/index.js';
 	import { getUserRoleLabel } from '$lib/utils';
 	import GroupRoleForm from './GroupRoleForm.svelte';
 	import type { GroupAssignment } from './types';
 	import { debounce } from 'es-toolkit';
-	import { LoaderCircle, ChevronLeft } from 'lucide-svelte';
+	import { ChevronLeft } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -158,13 +160,13 @@
 
 {#snippet groupList()}
 	<div class="flex h-full flex-col gap-4 overflow-y-auto px-1 pr-2">
-		<div class="bg-background dark:bg-surface2 sticky top-0 w-full pt-1">
+		<div class="bg-base-100 dark:bg-base-300 sticky top-0 w-full pt-1">
 			<Search value={searchQuery} onChange={updateSearch} />
 		</div>
 
 		<div class="flex flex-col gap-2">
 			{#if availableGroups.length === 0}
-				<p class="text-on-surface1 py-8 text-center text-sm">
+				<p class="text-muted-content py-8 text-center text-sm">
 					{searchQuery ? 'No groups found matching your search.' : 'No groups available.'}
 				</p>
 			{:else}
@@ -174,7 +176,7 @@
 					<button
 						onclick={() => handleGroupSelect(group)}
 						class={twMerge(
-							'border-surface3 hover:bg-background/5 flex items-center gap-3 rounded-lg border p-3 text-left transition-colors',
+							'border-base-400 hover:bg-base-100/5 flex items-center gap-3 rounded-lg border p-3 text-left transition-colors',
 							selectedGroup?.id === group.id && 'bg-primary/10 border-primary'
 						)}
 					>
@@ -182,7 +184,7 @@
 							<div class="flex flex-1 flex-col">
 								<span class="font-medium">{group.name}</span>
 								{#if hasAssignment && assignedRole}
-									<span class="text-on-surface1 text-xs">{getUserRoleLabel(assignedRole)}</span>
+									<span class="text-muted-content text-xs">{getUserRoleLabel(assignedRole)}</span>
 								{/if}
 							</div>
 						</div>
@@ -196,11 +198,11 @@
 {#snippet roleForm()}
 	<div class="flex h-full flex-col gap-4 overflow-y-auto pr-2">
 		{#if selectedGroup}
-			<div class="dark:bg-surface1 flex flex-col gap-1 rounded-lg bg-gray-50 p-3">
+			<div class="dark:bg-base-200 flex flex-col gap-1 rounded-lg bg-gray-50 p-3">
 				<div class="text-md flex items-center gap-2">
 					<span class="font-semibold">{selectedGroup.name}</span>
 				</div>
-				<div class="text-on-surface1 text-xs">
+				<div class="text-muted-content text-xs">
 					{#if groupRoleMap[selectedGroup.id]}
 						Update the role for this group
 					{:else}
@@ -215,7 +217,7 @@
 				bind:hasUserImpersonationPrivilege={draftHaveUserImpersonationPrivilege}
 			/>
 		{:else}
-			<div class="text-on-surface1 flex h-full items-center justify-center py-12 text-sm">
+			<div class="text-muted-content flex h-full items-center justify-center py-12 text-sm">
 				Select a group to assign a role
 			</div>
 		{/if}
@@ -234,13 +236,9 @@
 	>
 		{#snippet titleContent()}
 			{#if isSmallScreen && selectedGroup}
-				<button
-					onclick={handleBack}
-					class="icon-button mr-2 -ml-2 flex-shrink-0"
-					aria-label="Go back"
-				>
+				<IconButton onclick={handleBack} class="mr-2 -ml-2" aria-label="Go back">
 					<ChevronLeft class="size-6" />
-				</button>
+				</IconButton>
 			{:else if isSmallScreen}
 				<div class="size-11"></div>
 			{/if}
@@ -258,11 +256,11 @@
 			<!-- Large screen: two-column layout -->
 			<div class="grid flex-1 grid-cols-2 gap-8 overflow-hidden">
 				<div class="flex flex-col overflow-hidden">
-					<h4 class="mb-4 flex-shrink-0 text-sm font-semibold">Select Group</h4>
+					<h4 class="mb-4 shrink-0 text-sm font-semibold">Select Group</h4>
 					{@render groupList()}
 				</div>
 				<div class="flex flex-col overflow-hidden">
-					<h4 class="mb-4 flex-shrink-0 text-sm font-semibold">Assign Role</h4>
+					<h4 class="mb-4 shrink-0 text-sm font-semibold">Assign Role</h4>
 					{@render roleForm()}
 				</div>
 			</div>
@@ -270,7 +268,7 @@
 			<!-- Small screen: single column with conditional rendering -->
 			{#if !selectedGroup}
 				<div class="flex flex-1 flex-col overflow-hidden">
-					<h4 class="mb-4 flex-shrink-0 text-sm font-semibold">Select Group</h4>
+					<h4 class="mb-4 shrink-0 text-sm font-semibold">Select Group</h4>
 					{@render groupList()}
 				</div>
 			{:else}
@@ -280,15 +278,15 @@
 			{/if}
 		{/if}
 
-		<div class="mt-6 flex flex-shrink-0 flex-col justify-end gap-2 md:flex-row">
-			<button class="button" onclick={handleClose}>Cancel</button>
+		<div class="mt-6 flex shrink-0 flex-col justify-end gap-2 md:flex-row">
+			<button class="btn btn-secondary" onclick={handleClose}>Cancel</button>
 			<button
-				class="button-primary"
+				class="btn btn-primary"
 				onclick={handleConfirm}
 				disabled={loading || !selectedGroup || draftRoleId === 0}
 			>
 				{#if loading}
-					<LoaderCircle class="size-4 animate-spin" />
+					<Loading class="size-4" />
 				{:else if selectedGroup && groupRoleMap[selectedGroup.id]}
 					Update Role
 				{:else}

--- a/ui/user/src/routes/admin/groups/AssignGroupRoleDialog.svelte
+++ b/ui/user/src/routes/admin/groups/AssignGroupRoleDialog.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { Role } from '$lib/services/admin/types';
 	import { getUserRoleLabel } from '$lib/utils';
 	import GroupRoleForm from './GroupRoleForm.svelte';
 	import type { GroupAssignment } from './types';
-	import { LoaderCircle, Group as GroupIcon } from 'lucide-svelte';
+	import { Group as GroupIcon } from 'lucide-svelte';
 
 	interface Props {
 		groupAssignment?: GroupAssignment;
@@ -145,7 +146,7 @@
 
 	{#if groupAssignment}
 		{#if groupAssignment.assignment.role}
-			<div class="dark:bg-surface1 mb-8 flex flex-col gap-1 rounded-lg bg-gray-50 p-3">
+			<div class="dark:bg-base-200 mb-8 flex flex-col gap-1 rounded-lg bg-gray-50 p-3">
 				<div class="flex items-center gap-2">
 					{#if groupAssignment.group.iconURL}
 						<img
@@ -154,11 +155,11 @@
 							class="size-5 rounded-full"
 						/>
 					{:else}
-						<GroupIcon class="text-on-surface1 size-5" />
+						<GroupIcon class="text-muted-content size-5" />
 					{/if}
 					<span class="font-semibold">{groupAssignment.group.name}</span>
 				</div>
-				<div class="text-on-surface1 text-xs">
+				<div class="text-muted-content text-xs">
 					Current: {getUserRoleLabel(groupAssignment.assignment.role)}
 				</div>
 			</div>
@@ -172,15 +173,15 @@
 			/>
 		</div>
 
-		<div class="mt-4 flex flex-shrink-0 justify-end gap-2">
-			<button class="button" onclick={handleClose}>Cancel</button>
+		<div class="mt-4 flex shrink-0 justify-end gap-2">
+			<button class="btn btn-secondary" onclick={handleClose}>Cancel</button>
 			<button
-				class="button-primary"
+				class="btn btn-primary"
 				onclick={handleConfirm}
 				disabled={loading || (!!groupAssignment.assignment.role && !hasChanges)}
 			>
 				{#if loading}
-					<LoaderCircle class="size-4 animate-spin" />
+					<Loading class="size-4" />
 				{:else}
 					{groupAssignment.assignment.role ? 'Update' : 'Assign'}
 				{/if}

--- a/ui/user/src/routes/admin/groups/ConfirmOwnerRoleDialog.svelte
+++ b/ui/user/src/routes/admin/groups/ConfirmOwnerRoleDialog.svelte
@@ -26,7 +26,7 @@
 >
 	{#snippet note()}
 		<div class="mt-4 mb-8 flex flex-col gap-4">
-			<p class="text-left text-yellow-500">
+			<p class="text-left text-warning">
 				Warning: Assigning the Owner role to a group grants extensive privileges.
 			</p>
 			<div class="text-left text-sm">

--- a/ui/user/src/routes/admin/groups/GroupRoleForm.svelte
+++ b/ui/user/src/routes/admin/groups/GroupRoleForm.svelte
@@ -71,7 +71,7 @@
 
 {#snippet roleUi(role: RoleOption)}
 	<label
-		class="border-surface3 hover:bg-background/2 active:bg-background/5 flex cursor-pointer gap-4 rounded-lg border p-3"
+		class="border-base-400 hover:bg-base-100/2 active:bg-base-100/5 flex cursor-pointer gap-4 rounded-lg border p-3"
 	>
 		<input
 			type="radio"
@@ -84,8 +84,8 @@
 			class="flex flex-col"
 			class:opacity-50={!profile.current.groups.includes(Group.OWNER) && role.id === Role.OWNER}
 		>
-			<div class="w-28 flex-shrink-0 font-semibold whitespace-nowrap">{role.label}</div>
-			<p class="text-on-surface1 text-xs">
+			<div class="w-28 shrink-0 font-semibold whitespace-nowrap">{role.label}</div>
+			<p class="text-muted-content text-xs">
 				{#if role.id === Role.OWNER}
 					All group members will have Owner privileges and can manage all aspects of the platform.
 				{:else if role.id === Role.ADMIN}
@@ -107,7 +107,7 @@
 		{@const isDisabled = roleId === 0}
 		<label
 			class={twMerge(
-				'border-surface3 hover:bg-background/2 active:bg-background/5 my-4 flex cursor-pointer gap-4 rounded-lg border p-3',
+				'border-base-400 hover:bg-base-100/2 active:bg-base-100/5 my-4 flex cursor-pointer gap-4 rounded-lg border p-3',
 				isDisabled ? 'pointer-events-none opacity-50' : ''
 			)}
 			aria-disabled={isDisabled}
@@ -119,8 +119,8 @@
 				disabled={isDisabled}
 			/>
 			<div class="flex flex-col">
-				<div class="w-28 flex-shrink-0 font-semibold">Auditor</div>
-				<p class="text-on-surface1 text-xs">
+				<div class="w-28 shrink-0 font-semibold">Auditor</div>
+				<p class="text-muted-content text-xs">
 					{#if auditorReadonlyAdminRoles.includes(roleId)}
 						All group members will have read-only access to the admin system and see additional
 						details such as response, request, and header information in the audit logs.
@@ -135,7 +135,7 @@
 			isDisabled || (roleId !== Role.ADMIN && roleId !== Role.OWNER)}
 		<label
 			class={twMerge(
-				'border-surface3 hover:bg-background/2 active:bg-background/5 my-4 flex cursor-pointer gap-4 rounded-lg border p-3',
+				'border-base-400 hover:bg-base-100/2 active:bg-base-100/5 my-4 flex cursor-pointer gap-4 rounded-lg border p-3',
 				isUserImpersonationDisabled ? 'pointer-events-none opacity-50' : ''
 			)}
 			aria-disabled={isUserImpersonationDisabled}
@@ -147,8 +147,8 @@
 				disabled={isUserImpersonationDisabled}
 			/>
 			<div class="flex flex-col">
-				<div class="w-28 flex-shrink-0 font-semibold">Impersonator</div>
-				<p class="text-on-surface1 text-xs">
+				<div class="w-28 shrink-0 font-semibold">Impersonator</div>
+				<p class="text-muted-content text-xs">
 					All group members will be able to connect to other users' Obot Agents. Must be combined
 					with Admin or Owner.
 				</p>

--- a/ui/user/src/routes/admin/mcp-registries/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-registries/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import { invalidate } from '$app/navigation';
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import AccessControlRuleForm from '$lib/components/admin/AccessControlRuleForm.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import { type AccessControlRule, type OrgUser } from '$lib/services/admin/types';
@@ -115,9 +115,9 @@
 			>
 				{#if accessControlRules.length === 0}
 					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-						<BookOpenText class="text-on-surface1 size-24 opacity-25" />
-						<h4 class="text-on-surface1 text-lg font-semibold">No created MCP registries</h4>
-						<p class="text-on-surface1 text-sm font-light">
+						<BookOpenText class="text-muted-content size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">No created MCP registries</h4>
+						<p class="text-muted-content text-sm font-light">
 							Looks like you don't have any registries created yet. <br />
 							{#if !isReadonly}
 								Click the button below to get started.
@@ -178,16 +178,16 @@
 	>
 		{#snippet actions(d)}
 			{#if !isReadonly}
-				<button
-					class="icon-button hover:text-red-500"
+				<IconButton
+					variant="danger"
 					onclick={(e) => {
 						e.stopPropagation();
 						ruleToDelete = d;
 					}}
-					use:tooltip={'Delete Rule'}
+					tooltip={{ text: 'Delete Rule' }}
 				>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 			{/if}
 		{/snippet}
 		{#snippet onRenderColumn(property, d)}
@@ -203,7 +203,7 @@
 {#snippet addRuleButton()}
 	{#if !profile.current.isAdminReadonly?.()}
 		<button
-			class="button-primary flex items-center gap-1 text-sm"
+			class="btn btn-primary flex items-center gap-1 text-sm"
 			onclick={() => {
 				goto(`/admin/mcp-registries?new=true`);
 			}}

--- a/ui/user/src/routes/admin/mcp-registries/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-registries/[id]/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Layout {title} showBackButton>
-	<div class="mb-4 h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
+	<div class="h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
 		<AccessControlRuleForm
 			{accessControlRule}
 			onUpdate={() => {

--- a/ui/user/src/routes/admin/mcp-registries/w/[wid]/r/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-registries/w/[wid]/r/[id]/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Layout {title} showBackButton>
-	<div class="mb-4 h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
+	<div class="h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
 		<AccessControlRuleForm
 			{accessControlRule}
 			onUpdate={() => {

--- a/ui/user/src/routes/admin/mcp-servers/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/+page.svelte
@@ -11,6 +11,7 @@
 	import SelectServerType from '$lib/components/mcp/SelectServerType.svelte';
 	import type { InitSort } from '$lib/components/table/Table.svelte';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, Group, type LaunchServerType } from '$lib/services';
 	import type { MCPCatalog, OrgUser } from '$lib/services/admin/types';
 	import { getServerTypeLabelByType } from '$lib/services/chat/mcp';
@@ -26,7 +27,7 @@
 		replaceState
 	} from '$lib/url';
 	import SourceUrlsView from './SourceUrlsView.svelte';
-	import { Info, LoaderCircle, Plus, RefreshCcw, Server } from 'lucide-svelte';
+	import { Info, Plus, RefreshCcw, Server } from 'lucide-svelte';
 	import { onDestroy, onMount } from 'svelte';
 	import { fade, fly, slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -163,7 +164,7 @@
 </script>
 
 <Layout
-	classes={{ navbar: 'bg-surface1' }}
+	classes={{ navbar: 'bg-base-200' }}
 	title={showServerForm
 		? `Create ${getServerTypeLabelByType(selectedServerType)} Server`
 		: 'MCP Servers'}
@@ -178,9 +179,9 @@
 	</div>
 	{#snippet rightNavActions()}
 		{#if !isAdminReadonly && !showServerForm}
-			<button class="button flex items-center gap-1 text-sm" onclick={sync}>
+			<button class="btn btn-secondary flex items-center gap-1 text-sm" onclick={sync}>
 				{#if syncing}
-					<LoaderCircle class="size-4 animate-spin" /> Syncing...
+					<Loading class="size-4" /> Syncing...
 				{:else}
 					<RefreshCcw class="size-4" />
 					Sync
@@ -199,17 +200,17 @@
 		in:fly={{ x: 100, delay: duration, duration }}
 		out:fly={{ x: -100, duration }}
 	>
-		<div class="bg-surface1 dark:bg-background sticky top-16 left-0 z-20 w-full py-1">
+		<div class="bg-base-200 dark:bg-base-100 sticky top-16 left-0 z-20 w-full py-1">
 			<div class="mb-2">
 				<Search
-					class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+					class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 					value={query}
 					onChange={updateSearchQuery}
 					placeholder={view !== 'urls' ? 'Search servers...' : 'Search sources...'}
 				/>
 			</div>
 		</div>
-		<div class="dark:bg-surface2 bg-background rounded-t-md shadow-sm">
+		<div class="dark:bg-base-300 bg-base-100 rounded-t-md shadow-sm">
 			<div class="flex">
 				<button
 					class={twMerge('page-tab', view === 'registry' && 'page-tab-active')}
@@ -295,9 +296,9 @@
 
 {#snippet displayNoData()}
 	<div class="my-12 flex w-md flex-col items-center gap-4 self-center text-center">
-		<Server class="text-on-surface1 size-24 opacity-25" />
-		<h4 class="text-on-surface1 text-lg font-semibold">No created MCP servers</h4>
-		<p class="text-on-surface1 text-sm font-light">
+		<Server class="text-muted-content size-24 opacity-25" />
+		<h4 class="text-muted-content text-lg font-semibold">No created MCP servers</h4>
+		<p class="text-muted-content text-sm font-light">
 			Looks like you don't have any servers created yet. <br />
 			Click the button below to get started.
 		</p>
@@ -346,7 +347,7 @@
 
 {#snippet addServerButton()}
 	<DotDotDot
-		class="button-primary w-full text-sm md:w-fit"
+		class="btn-primary btn-block w-full text-sm md:w-fit"
 		placement="bottom"
 		classes={{ popover: 'z-50' }}
 	>

--- a/ui/user/src/routes/admin/mcp-servers/SourceUrlsView.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/SourceUrlsView.svelte
@@ -2,9 +2,10 @@
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { AdminService, type MCPCatalog } from '$lib/services';
-	import { AlertTriangle, Link2, Pencil, Trash2, TriangleAlert } from 'lucide-svelte';
+	import { TriangleAlert, Link2, Pencil, Trash2 } from 'lucide-svelte';
 
 	interface Props {
 		catalog?: MCPCatalog;
@@ -46,7 +47,7 @@
 			noDataMessage="No Git Source URLs added."
 			setRowClasses={(d) => {
 				if (catalog?.syncErrors?.[d.url]) {
-					return 'bg-yellow-500/10';
+					return 'bg-warning/10';
 				}
 				return '';
 			}}
@@ -57,24 +58,23 @@
 			{#snippet actions(d)}
 				{#if !readonly}
 					{#if onEdit}
-						<button
-							class="icon-button"
+						<IconButton
 							onclick={() => {
 								const index = catalog?.sourceURLs?.indexOf(d.url) ?? -1;
 								onEdit(d.url, index);
 							}}
 						>
 							<Pencil class="size-4" />
-						</button>
+						</IconButton>
 					{/if}
-					<button
-						class="icon-button hover:text-red-500"
+					<IconButton
+						variant="danger"
 						onclick={() => {
 							deletingSource = { type: 'single', source: d.url };
 						}}
 					>
 						<Trash2 class="size-4" />
-					</button>
+					</IconButton>
 				{/if}
 			{/snippet}
 			{#snippet onRenderColumn(property, d)}
@@ -92,10 +92,10 @@
 								}}
 								use:tooltip={{
 									text: 'An issue occurred. Click to see more details.',
-									classes: ['break-words']
+									classes: ['wrap-break-word']
 								}}
 							>
-								<TriangleAlert class="size-4 text-yellow-500" />
+								<TriangleAlert class="size-4 text-warning" />
 							</button>
 						{/if}
 					</div>
@@ -104,7 +104,7 @@
 			{#snippet tableSelectActions(currentSelected)}
 				<div class="flex grow items-center justify-end gap-2 px-4 py-2">
 					<button
-						class="button flex items-center gap-1 text-sm font-normal"
+						class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 						onclick={() => {
 							selected = Object.values(currentSelected).map((d) => d.url);
 							deletingSource = { type: 'multi' };
@@ -118,9 +118,9 @@
 		</Table>
 	{:else}
 		<div class="my-12 flex w-md flex-col items-center gap-4 self-center text-center">
-			<Link2 class="text-surface3 size-24" />
-			<h4 class="text-on-surface1 text-lg font-semibold">No current Git Source URLs.</h4>
-			<p class="text-on-surface1 text-sm font-light">
+			<Link2 class="text-base-content/80 size-24" />
+			<h4 class="text-muted-content text-lg font-semibold">No current Git Source URLs.</h4>
+			<p class="text-muted-content text-sm font-light">
 				Once a Git Source URL has been added, its <br />
 				information will be quickly accessible here.
 			</p>
@@ -164,7 +164,7 @@
 	<div class="mb-4 flex flex-col gap-4">
 		<div class="notification-alert flex flex-col gap-2">
 			<div class="flex items-center gap-2">
-				<AlertTriangle class="size-6 flex-shrink-0 self-start text-yellow-500" />
+				<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
 				<p class="my-0.5 flex flex-col text-sm font-semibold">
 					An issue occurred fetching this source URL:
 				</p>

--- a/ui/user/src/routes/admin/mcp-servers/c/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/c/[id]/+page.svelte
@@ -193,7 +193,7 @@
 	<div class="flex h-full flex-col gap-6" in:fly={{ x: 100, delay: duration, duration }}>
 		{#if showUpgradeNotification}
 			<div class="border-primary bg-primary/10 flex items-center gap-3 rounded-lg border p-4">
-				<Info class="text-primary size-5 flex-shrink-0" />
+				<Info class="text-primary size-5 shrink-0" />
 				<div class="flex-1">
 					<p class="text-sm font-medium">Component updates available</p>
 					<p class="text-muted-foreground mt-1 text-xs">
@@ -201,7 +201,7 @@
 					</p>
 				</div>
 				<button
-					class="button-primary flex items-center gap-1.5 text-sm font-normal"
+					class="btn btn-primary flex items-center gap-1.5 text-sm font-normal"
 					onclick={handleUpgradeClick}
 					disabled={upgrading}
 				>
@@ -253,7 +253,7 @@
 									{diff.name}
 									{#if !diff.newManifest}
 										<span
-											class="ml-2 rounded bg-red-500/10 px-2 py-0.5 text-xs font-normal text-red-500"
+											class="ml-2 rounded bg-error/10 px-2 py-0.5 text-xs font-normal text-error"
 										>
 											Removed
 										</span>

--- a/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
@@ -180,7 +180,7 @@
 	<div class="flex h-full flex-col gap-6" in:fly={{ x: 100, delay: duration, duration }}>
 		{#if showUpgradeNotification}
 			<div class="border-primary bg-primary/10 flex items-center gap-3 rounded-lg border p-4">
-				<Info class="text-primary size-5 flex-shrink-0" />
+				<Info class="text-primary size-5 shrink-0" />
 				<div class="flex-1">
 					<p class="text-sm font-medium">Component updates available</p>
 					<p class="text-muted-foreground mt-1 text-xs">
@@ -188,7 +188,7 @@
 					</p>
 				</div>
 				<button
-					class="button-primary flex items-center gap-1.5 text-sm font-normal"
+					class="btn btn-primary flex items-center gap-1.5 text-sm font-normal"
 					onclick={handleUpgradeClick}
 					disabled={upgrading}
 				>
@@ -237,7 +237,7 @@
 									{diff.name}
 									{#if !diff.newManifest}
 										<span
-											class="ml-2 rounded bg-red-500/10 px-2 py-0.5 text-xs font-normal text-red-500"
+											class="ml-2 rounded bg-error/10 px-2 py-0.5 text-xs font-normal text-error"
 										>
 											Removed
 										</span>

--- a/ui/user/src/routes/admin/mcp-servers/s/[id]/details/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/s/[id]/details/+page.svelte
@@ -4,9 +4,9 @@
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import OAuthMetadataDebug from '$lib/components/mcp/OAuthMetadataDebug.svelte';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, type MCPServerInstance, type OrgUser } from '$lib/services';
 	import { profile } from '$lib/stores/index.js';
-	import { LoaderCircle } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -47,7 +47,7 @@
 	<div class="flex flex-col gap-6 pb-8" in:fly={{ x: 100, delay: PAGE_TRANSITION_DURATION }}>
 		{#if loading}
 			<div class="flex w-full justify-center">
-				<LoaderCircle class="size-6 animate-spin" />
+				<Loading class="size-6" />
 			</div>
 		{:else}
 			<div class="flex flex-col gap-6">

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/details/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/details/+page.svelte
@@ -4,9 +4,9 @@
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import OAuthMetadataDebug from '$lib/components/mcp/OAuthMetadataDebug.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, ChatService, type MCPServerInstance, type OrgUser } from '$lib/services';
 	import { profile } from '$lib/stores/index.js';
-	import { LoaderCircle } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -43,7 +43,7 @@
 	<div class="flex flex-col gap-6 pb-8" in:fly={{ x: 100, delay: PAGE_TRANSITION_DURATION }}>
 		{#if loading}
 			<div class="flex w-full justify-center">
-				<LoaderCircle class="size-6 animate-spin" />
+				<Loading class="size-6" />
 			</div>
 		{:else}
 			<div class="flex flex-col gap-6">

--- a/ui/user/src/routes/admin/message-policies/+page.svelte
+++ b/ui/user/src/routes/admin/message-policies/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import MessagePolicyForm from '$lib/components/admin/MessagePolicyForm.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import { type MessagePolicy, PolicyDirectionLabels } from '$lib/services/admin/types';
@@ -58,9 +58,9 @@
 			>
 				{#if messagePolicies.length === 0}
 					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-						<ShieldAlert class="text-on-surface1 size-24 opacity-25" />
-						<h4 class="text-on-surface1 text-lg font-semibold">No message policies</h4>
-						<p class="text-on-surface1 text-sm font-light">
+						<ShieldAlert class="text-base-content/80 size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">No message policies</h4>
+						<p class="text-muted-content text-sm font-light">
 							Looks like you don't have any message policies created yet. <br />
 							{#if !isReadonly}
 								Click the button below to get started.
@@ -110,16 +110,16 @@
 	>
 		{#snippet actions(d)}
 			{#if !isReadonly}
-				<button
-					class="icon-button hover:text-red-500"
+				<IconButton
+					variant="danger"
 					onclick={(e) => {
 						e.stopPropagation();
 						policyToDelete = d;
 					}}
-					use:tooltip={'Delete Policy'}
+					tooltip={{ text: 'Delete Policy' }}
 				>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 			{/if}
 		{/snippet}
 	</Table>
@@ -128,7 +128,7 @@
 {#snippet addPolicyButton()}
 	{#if !profile.current.isAdminReadonly?.()}
 		<button
-			class="button-primary flex items-center gap-1 text-sm"
+			class="btn btn-primary flex items-center gap-1 text-sm"
 			onclick={() => {
 				goto(`/admin/message-policies?new=true`);
 			}}

--- a/ui/user/src/routes/admin/message-policies/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/message-policies/[id]/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Layout {title} showBackButton>
-	<div class="mb-4 h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
+	<div class="h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
 		<MessagePolicyForm
 			{messagePolicy}
 			onUpdate={() => {

--- a/ui/user/src/routes/admin/model-access-policies/+page.svelte
+++ b/ui/user/src/routes/admin/model-access-policies/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import ModelAccessPolicyForm from '$lib/components/admin/ModelAccessPolicyForm.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import { type ModelAccessPolicy } from '$lib/services/admin/types';
@@ -60,9 +60,9 @@
 			>
 				{#if modelAccessPolicies.length === 0}
 					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-						<LockKeyhole class="text-on-surface1 size-24 opacity-25" />
-						<h4 class="text-on-surface1 text-lg font-semibold">No model access policies</h4>
-						<p class="text-on-surface1 text-sm font-light">
+						<LockKeyhole class="text-base-content/80 size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">No model access policies</h4>
+						<p class="text-muted-content text-sm font-light">
 							Looks like you don't have any model access policies created yet. <br />
 							{#if !isReadonly}
 								Click the button below to get started.
@@ -112,16 +112,16 @@
 	>
 		{#snippet actions(d)}
 			{#if !isReadonly}
-				<button
-					class="icon-button hover:text-red-500"
+				<IconButton
+					variant="danger"
 					onclick={(e) => {
 						e.stopPropagation();
 						policyToDelete = d;
 					}}
-					use:tooltip={'Delete Policy'}
+					tooltip={{ text: 'Delete Policy' }}
 				>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 			{/if}
 		{/snippet}
 		{#snippet onRenderColumn(property, d)}
@@ -137,7 +137,7 @@
 {#snippet addPolicyButton()}
 	{#if !profile.current.isAdminReadonly?.()}
 		<button
-			class="button-primary flex items-center gap-1 text-sm"
+			class="btn btn-primary flex items-center gap-1 text-sm"
 			onclick={() => {
 				goto(`/admin/model-access-policies?new=true`);
 			}}

--- a/ui/user/src/routes/admin/model-access-policies/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/model-access-policies/[id]/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Layout {title} showBackButton>
-	<div class="mb-4 h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
+	<div class="h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
 		<ModelAccessPolicyForm
 			{modelAccessPolicy}
 			onUpdate={() => {

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -16,7 +16,7 @@
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte.js';
 	import { profile } from '$lib/stores/index.js';
 	import { delay } from '$lib/utils';
-	import { AlertTriangle } from 'lucide-svelte';
+	import { TriangleAlert } from 'lucide-svelte';
 	import { onMount, untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 
@@ -148,12 +148,12 @@
 </script>
 
 <Layout title="Model Providers">
-	<div class="mb-4" in:fade={{ duration }} out:fade={{ duration }}>
+	<div class="mb-4 @container" in:fade={{ duration }} out:fade={{ duration }}>
 		<div class="flex flex-col gap-8">
 			{#if !atLeastOneConfigured}
 				<div class="notification-alert mb-4 flex flex-col gap-2">
 					<div class="flex items-center gap-2">
-						<AlertTriangle class="size-6 flex-shrink-0 self-start text-yellow-500" />
+						<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
 						<p class="my-0.5 flex flex-col text-sm font-semibold">No Model Providers Configured!</p>
 					</div>
 					<span class="text-sm font-light break-all">
@@ -163,7 +163,9 @@
 				</div>
 			{/if}
 		</div>
-		<div class="grid grid-cols-1 gap-4 px-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+		<div
+			class="grid grid-cols-1 gap-4 @min-[768px]:grid-cols-2 @min-[1024px]:grid-cols-3 @min-[1280px]:grid-cols-4"
+		>
 			{#each sortedModelProviders as modelProvider (modelProvider.id)}
 				<ProviderCard
 					experimental={modelProvider.id === CommonModelProviderIds.GENERIC_RESPONSES}
@@ -219,7 +221,7 @@
 >
 	{#snippet note()}
 		{#if configuringModelProvider && isAnthropic(configuringModelProvider)}
-			<p class="text-on-surface1 py-4 font-light">
+			<p class="text-muted-content py-4 font-light">
 				Note: Anthropic does not have an embeddings model.
 			</p>
 		{/if}

--- a/ui/user/src/routes/admin/policy-violations/+page.svelte
+++ b/ui/user/src/routes/admin/policy-violations/+page.svelte
@@ -4,6 +4,7 @@
 	import Select from '$lib/components/Select.svelte';
 	import AuditLogCalendar from '$lib/components/admin/audit-logs/AuditLogCalendar.svelte';
 	import StackedTimeline from '$lib/components/graph/StackedTimeline.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
@@ -278,7 +279,7 @@
 				out:fade|global={{ duration: 300, delay: 500 }}
 			>
 				<div
-					class="bg-surface3/50 border-surface3 text-primary dark:text-primary flex flex-col items-center gap-4 rounded-2xl border px-16 py-8 shadow-md backdrop-blur-[1px]"
+					class="bg-base-400/50 border-base-400 text-primary dark:text-primary flex flex-col items-center gap-4 rounded-2xl border px-16 py-8 shadow-md backdrop-blur-[1px]"
 				>
 					<Loading class="size-32 stroke-1" />
 					<div class="text-2xl font-semibold">Loading violations...</div>
@@ -288,12 +289,12 @@
 
 		<div class="mb-4 flex flex-col gap-4">
 			<!-- Overall Stats -->
-			<div class="bg-surface2 dark:bg-surface1 w-full">
+			<div class="bg-base-300 dark:bg-base-200 w-full">
 				<div class="m-auto w-full px-4 py-4 md:max-w-(--breakpoint-xl) md:px-8">
 					<h4 class="font-semibold">Overall Stats</h4>
 					<div class="flex flex-col flex-wrap items-stretch gap-4 md:flex-row">
 						<div class="flex min-w-0 flex-1 flex-col gap-1 py-2">
-							<div class="text-on-background text-xs font-light">Total Violations</div>
+							<div class="text-base-content text-xs font-light">Total Violations</div>
 							<div class="text-primary flex items-center gap-1 text-xl font-semibold">
 								{#if loading}
 									<Loading class="size-4 animate-spin" />
@@ -304,7 +305,7 @@
 						</div>
 						<div class="divider-horizontal hidden md:block"></div>
 						<div class="flex min-w-0 flex-1 flex-col gap-1 py-2">
-							<div class="text-on-background text-xs font-light">User Message Violations</div>
+							<div class="text-base-content text-xs font-light">User Message Violations</div>
 							<div class="text-primary flex items-center gap-1 text-xl font-semibold">
 								{#if loading}
 									<Loading class="size-4 animate-spin" />
@@ -315,7 +316,7 @@
 						</div>
 						<div class="divider-horizontal hidden md:block"></div>
 						<div class="flex min-w-0 flex-1 flex-col gap-1 py-2">
-							<div class="text-on-background text-xs font-light">Tool Call Violations</div>
+							<div class="text-base-content text-xs font-light">Tool Call Violations</div>
 							<div class="text-primary flex items-center gap-1 text-xl font-semibold">
 								{#if loading}
 									<Loading class="size-4 animate-spin" />
@@ -333,10 +334,10 @@
 				class="m-auto flex w-full max-w-full flex-col gap-4 px-4 md:max-w-(--breakpoint-xl) md:px-8"
 			>
 				<div class="flex w-full flex-wrap items-center justify-end gap-4">
-					<p class="text-on-surface1 w-full text-sm md:w-fit">Filter by:</p>
+					<p class="text-muted-content w-full text-sm md:w-fit">Filter by:</p>
 					<Select
-						class="dark:border-surface3 border border-transparent"
-						classes={{ root: 'w-full md:flex-1 dark:border-surface3' }}
+						class="dark:border-base-400 border border-transparent"
+						classes={{ root: 'w-full md:flex-1 dark:border-base-400' }}
 						options={directionSelectOptions}
 						bind:selected={filterDirection}
 						multiple
@@ -353,8 +354,8 @@
 						displayCount={!!filterDirection && filterDirection !== 'all_directions'}
 					/>
 					<Select
-						class="dark:border-surface3 border border-transparent"
-						classes={{ root: 'w-full md:flex-1 dark:border-surface3' }}
+						class="dark:border-base-400 border border-transparent"
+						classes={{ root: 'w-full md:flex-1 dark:border-base-400' }}
 						options={userSelectOptions}
 						bind:selected={filterUserID}
 						multiple
@@ -371,8 +372,8 @@
 						displayCount={!!filterUserID && filterUserID !== 'all_users'}
 					/>
 					<Select
-						class="dark:border-surface3 border border-transparent"
-						classes={{ root: 'w-full md:flex-1 dark:border-surface3' }}
+						class="dark:border-base-400 border border-transparent"
+						classes={{ root: 'w-full md:flex-1 dark:border-base-400' }}
 						options={policySelectOptions}
 						bind:selected={filterPolicyID}
 						multiple
@@ -388,7 +389,7 @@
 						buttonTitle="Policies"
 						displayCount={!!filterPolicyID && filterPolicyID !== 'all_policies'}
 					/>
-					<div class="bg-surface3 hidden h-8 w-0.5 md:block"></div>
+					<div class="bg-base-400 hidden h-8 w-0.5 md:block"></div>
 					<AuditLogCalendar start={startTime} end={endTime} onChange={handleTimeRangeChange} />
 				</div>
 
@@ -439,7 +440,7 @@
 							{/if}
 						</h4>
 						<Select
-							class="bg-surface2 dark:bg-background dark:border-surface3 w-[50dvw] border border-transparent shadow-inner md:w-64"
+							class="bg-base-300 dark:bg-base-100 dark:border-base-400 w-[50dvw] border border-transparent shadow-inner md:w-64"
 							options={groupByOptions}
 							selected={groupBy}
 							onSelect={handleGroupByChange}
@@ -465,11 +466,11 @@
 								{#snippet tooltipContent(item)}
 									<div class="flex flex-col gap-0 text-xs">
 										<div class="text-sm font-light">{item.key}</div>
-										<div class="text-on-surface1">{item.date}</div>
+										<div class="text-muted-content">{item.date}</div>
 										<div class="divider"></div>
 									</div>
 									<div class="flex flex-col gap-1">
-										<div class="text-on-background text-xl font-bold">
+										<div class="text-base-content text-xl font-bold">
 											{(item.primaryTotal ?? 0).toLocaleString()}
 										</div>
 									</div>
@@ -484,42 +485,42 @@
 					<div
 						class="mt-12 flex w-md max-w-full flex-col items-center gap-4 self-center text-center"
 					>
-						<ShieldAlert class="text-on-surface1 size-24 opacity-50" />
-						<h4 class="text-on-surface1 text-lg font-semibold">No policy violations</h4>
-						<p class="text-on-surface text-sm font-light">
+						<ShieldAlert class="text-muted-content size-24 opacity-50" />
+						<h4 class="text-muted-content text-lg font-semibold">No policy violations</h4>
+						<p class="text-muted-content text-sm font-light">
 							Currently, there are no policy violations for the selected range or filters. Try
 							modifying your search criteria or try again later.
 						</p>
 					</div>
 				{:else if violations.length > 0}
 					<div
-						class="dark:bg-surface2 bg-background flex w-full min-w-full flex-1 divide-y divide-gray-200 overflow-x-auto overflow-y-visible rounded-lg border border-transparent shadow-sm"
+						class="dark:bg-base-300 bg-base-100 flex w-full min-w-full flex-1 divide-y divide-gray-200 overflow-x-auto overflow-y-visible rounded-lg border border-transparent shadow-sm"
 					>
 						<table class="w-full flex-1 table-fixed border-collapse border-spacing-0">
 							<thead>
 								<tr>
 									<th
-										class="dark:bg-surface1 bg-surface2 text-on-surface1 sticky top-0 box-content w-[4ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
+										class="dark:bg-base-200 bg-base-300 text-muted-content sticky top-0 box-content w-[4ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
 									>
 										#
 									</th>
 									<th
-										class="dark:bg-surface1 bg-surface2 text-on-surface1 sticky top-0 box-content w-[34ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
+										class="dark:bg-base-200 bg-base-300 text-muted-content sticky top-0 box-content w-[34ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
 									>
 										Timestamp
 									</th>
 									<th
-										class="dark:bg-surface1 bg-surface2 text-on-surface1 sticky top-0 box-content w-[24ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
+										class="dark:bg-base-200 bg-base-300 text-muted-content sticky top-0 box-content w-[24ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
 									>
 										User
 									</th>
 									<th
-										class="dark:bg-surface1 bg-surface2 text-on-surface1 sticky top-0 box-content w-[24ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
+										class="dark:bg-base-200 bg-base-300 text-muted-content sticky top-0 box-content w-[24ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
 									>
 										Policy
 									</th>
 									<th
-										class="dark:bg-surface1 bg-surface2 text-on-surface1 sticky top-0 box-content w-[24ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
+										class="dark:bg-base-200 bg-base-300 text-muted-content sticky top-0 box-content w-[24ch] px-6 py-3 text-left text-xs font-medium tracking-wider uppercase"
 									>
 										Applies To
 									</th>
@@ -528,7 +529,7 @@
 							<tbody>
 								{#each violations as v, i (v.id)}
 									<tr
-										class="hover:bg-surface1 dark:hover:bg-surface3 group h-14 cursor-pointer text-sm transition-colors duration-300"
+										class="hover:bg-base-400 dark:hover:bg-base-400 group h-14 cursor-pointer text-sm transition-colors duration-300"
 										onclick={() => viewDetail(v)}
 									>
 										<td class="px-6 py-3">{pageOffset + i + 1}</td>
@@ -555,7 +556,7 @@
 					<!-- Pagination -->
 					{#if totalPages > 1}
 						<div
-							class="dark:bg-surface2 bg-background flex items-center justify-between gap-2 rounded-lg border border-transparent px-4 py-3 text-xs text-gray-600 shadow-sm"
+							class="dark:bg-base-300 bg-base-100 flex items-center justify-between gap-2 rounded-lg border border-transparent px-4 py-3 text-xs text-gray-600 shadow-sm"
 						>
 							<div class="flex gap-4">
 								<div>
@@ -568,7 +569,7 @@
 							</div>
 							<div class="flex gap-4">
 								<button
-									class="hover:text-on-surface1/80 active:text-on-surface1/100 flex items-center text-xs transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50"
+									class="hover:text-base-content/80 active:text-base-content flex items-center text-xs transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50"
 									disabled={pageOffset === 0}
 									onclick={() => {
 										pageOffset = Math.max(0, pageOffset - pageLimit);
@@ -578,7 +579,7 @@
 									Previous
 								</button>
 								<button
-									class="hover:text-on-surface1/80 active:text-on-surface1/100 flex items-center text-xs transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50"
+									class="hover:text-base-content/80 active:text-base-content flex items-center text-xs transition-colors duration-100 disabled:pointer-events-none disabled:opacity-50"
 									disabled={currentPage >= totalPages}
 									onclick={() => {
 										pageOffset += pageLimit;
@@ -611,39 +612,37 @@
 		{/if}
 
 		{#if selectedViolation}
-			<div
-				class="dark:bg-gray-990 text-on-background flex h-full w-[inherit] min-w-[inherit] flex-col bg-gray-50"
-			>
+			<div class="bg-base-200 text-base-content flex h-full w-[inherit] min-w-[inherit] flex-col">
 				<div
-					class="dark:bg-surface1 bg-background relative flex w-full items-center justify-between p-4 pl-5 shadow-xs"
+					class="dark:bg-base-200 bg-base-100 relative flex w-full items-center justify-between p-4 pl-5 shadow-xs"
 				>
 					<div class="bg-primary absolute top-0 left-0 h-full w-1"></div>
 					<h3 class="text-lg font-semibold">Violation Detail</h3>
-					<button onclick={closeSidebar} class="icon-button">
+					<IconButton onclick={closeSidebar}>
 						<X class="size-5" />
-					</button>
+					</IconButton>
 				</div>
 
 				<div class="default-scrollbar-thin relative flex-1 overflow-y-auto pb-4">
-					<div class="bg-surface2 absolute top-0 left-0 h-full w-1"></div>
+					<div class="bg-base-300 absolute top-0 left-0 h-full w-1"></div>
 
 					{#if detailedViolation}
 						<div class="flex flex-wrap gap-2 p-4 pl-5">
 							<div
-								class="dark:bg-surface3 bg-surface2 rounded-full px-3 py-1 text-[11px] font-light"
+								class="dark:bg-base-400 bg-base-300 rounded-full px-3 py-1 text-[11px] font-light"
 							>
 								<span class="font-medium">Policy:</span>
 								{detailedViolation.policyName}
 							</div>
 							<div
-								class="dark:bg-surface3 bg-surface2 rounded-full px-3 py-1 text-[11px] font-light"
+								class="dark:bg-base-400 bg-base-300 rounded-full px-3 py-1 text-[11px] font-light"
 							>
 								<span class="font-medium">Applies To:</span>
 								{directionLabel(detailedViolation.direction)}
 							</div>
 							{#if detailedViolation.projectID}
 								<div
-									class="dark:bg-surface3 bg-surface2 rounded-full px-3 py-1 text-[11px] font-light"
+									class="dark:bg-base-400 bg-base-300 rounded-full px-3 py-1 text-[11px] font-light"
 								>
 									<span class="font-medium">Project:</span>
 									{detailedViolation.projectID}
@@ -651,7 +650,7 @@
 							{/if}
 							{#if detailedViolation.threadID}
 								<div
-									class="dark:bg-surface3 bg-surface2 rounded-full px-3 py-1 text-[11px] font-light"
+									class="dark:bg-base-400 bg-base-300 rounded-full px-3 py-1 text-[11px] font-light"
 								>
 									<span class="font-medium">Thread:</span>
 									{detailedViolation.threadID}
@@ -680,25 +679,25 @@
 							<p class="mt-6 mb-2 text-base font-semibold">Blocked Content</p>
 							{#if detailedViolation.blockedContent}
 								<div
-									class="dark:bg-surface2 bg-background relative overflow-hidden rounded-md p-4 pl-5"
+									class="dark:bg-base-300 bg-base-100 relative overflow-hidden rounded-md p-4 pl-5"
 								>
 									<div class="bg-primary/50 absolute top-0 left-0 h-full w-1"></div>
 									<pre
-										class="default-scrollbar-thin max-h-96 overflow-y-auto text-sm break-words whitespace-pre-wrap">{JSON.stringify(
+										class="default-scrollbar-thin max-h-96 overflow-y-auto text-sm wrap-break-word whitespace-pre-wrap">{JSON.stringify(
 											detailedViolation.blockedContent,
 											null,
 											2
 										)}</pre>
 								</div>
 							{:else}
-								<p class="text-sm font-light text-gray-500">
+								<p class="text-sm font-light text-muted-content">
 									Blocked content is only visible to auditors.
 								</p>
 							{/if}
 						</div>
 					{:else}
 						<div
-							class="text-on-surface1 flex items-center justify-center gap-2 py-12 text-sm font-light"
+							class="text-muted-content flex items-center justify-center gap-2 py-12 text-sm font-light"
 						>
 							<Loading class="size-5 animate-spin" />
 							<span>Loading details...</span>
@@ -714,7 +713,7 @@
 	.divider {
 		height: 1px;
 		width: 100%;
-		background-color: var(--color-surface3);
+		background-color: var(--color-base-400);
 		margin-top: 0.5rem;
 		margin-bottom: 0.5rem;
 	}

--- a/ui/user/src/routes/admin/server-scheduling/+page.svelte
+++ b/ui/user/src/routes/admin/server-scheduling/+page.svelte
@@ -2,9 +2,10 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import YamlEditor from '$lib/components/admin/YamlEditor.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, type K8sSettings } from '$lib/services';
 	import { profile } from '$lib/stores/index.js';
-	import { Info, LoaderCircle, Lock } from 'lucide-svelte';
+	import { Info, Lock } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 
@@ -275,7 +276,7 @@
 								type="text"
 								id="cpu-request"
 								bind:value={resourceInfo.requests.cpu}
-								class="text-input-filled dark:bg-background"
+								class="text-input-filled dark:bg-base-100"
 								disabled={readonly}
 								placeholder="example: 500m"
 							/>
@@ -286,7 +287,7 @@
 								type="text"
 								id="cpu-limit"
 								bind:value={resourceInfo.limits.cpu}
-								class="text-input-filled dark:bg-background"
+								class="text-input-filled dark:bg-base-100"
 								disabled={readonly}
 								placeholder="example: 1"
 							/>
@@ -300,7 +301,7 @@
 								type="text"
 								id="memory-request"
 								bind:value={resourceInfo.requests.memory}
-								class="text-input-filled dark:bg-background"
+								class="text-input-filled dark:bg-base-100"
 								disabled={readonly}
 								placeholder="example: 512Mi"
 							/>
@@ -311,7 +312,7 @@
 								type="text"
 								id="memory-limit"
 								bind:value={resourceInfo.limits.memory}
-								class="text-input-filled dark:bg-background"
+								class="text-input-filled dark:bg-base-100"
 								disabled={readonly}
 								placeholder="example: 1Gi"
 							/>
@@ -346,11 +347,11 @@
 							type="text"
 							id="runtime-class-name"
 							bind:value={k8sSettings.runtimeClassName}
-							class="text-input-filled dark:bg-background"
+							class="text-input-filled dark:bg-base-100"
 							disabled={readonly}
 							placeholder="example: gvisor"
 						/>
-						<p class="text-xs font-light text-gray-500">
+						<p class="text-xs font-light text-muted-content">
 							Leave empty to use the cluster's default container runtime.
 						</p>
 					</div>
@@ -376,11 +377,11 @@
 								type="text"
 								id="storage-class-name"
 								bind:value={k8sSettings.storageClassName}
-								class="text-input-filled dark:bg-background"
+								class="text-input-filled dark:bg-base-100"
 								disabled={readonly}
 								placeholder="example: fast-ssd"
 							/>
-							<p class="text-xs font-light text-gray-500">
+							<p class="text-xs font-light text-muted-content">
 								Leave empty to use the cluster default StorageClass.
 							</p>
 						</div>
@@ -390,11 +391,11 @@
 								type="text"
 								id="nanobot-workspace-size"
 								bind:value={k8sSettings.nanobotWorkspaceSize}
-								class="text-input-filled dark:bg-background"
+								class="text-input-filled dark:bg-base-100"
 								disabled={readonly}
 								placeholder="example: 10Gi"
 							/>
-							<p class="text-xs font-light text-gray-500">
+							<p class="text-xs font-light text-muted-content">
 								Use units like Gi or Mi (example: 10Gi, 512Mi).
 							</p>
 						</div>
@@ -403,19 +404,19 @@
 
 				{#if !readonly}
 					<div
-						class="bg-surface1 dark:bg-background sticky bottom-0 left-0 flex w-[calc(100%+2em)] -translate-x-4 justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
+						class="bg-base-200 dark:bg-base-100 sticky bottom-0 left-0 flex w-[calc(100%+2em)] -translate-x-4 justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
 					>
 						{#if showSaved}
 							<span
 								in:fade={{ duration: 200 }}
-								class="text-on-surface1 flex min-h-10 items-center px-4 text-sm font-extralight"
+								class="text-muted-content flex min-h-10 items-center px-4 text-sm font-extralight"
 							>
 								Your changes have been saved.
 							</span>
 						{/if}
 
 						<button
-							class="button hover:bg-surface3 flex items-center gap-1 bg-transparent"
+							class="btn btn-secondary hover:bg-base-400 flex items-center gap-1 bg-transparent"
 							onclick={() => {
 								k8sSettings = prevK8sSettings;
 								resourceInfo = convertResourcesForInput(prevK8sSettings?.resources);
@@ -424,12 +425,12 @@
 							Reset
 						</button>
 						<button
-							class="button-primary flex items-center gap-1"
+							class="btn btn-primary flex items-center gap-1"
 							disabled={saving}
 							onclick={handleSave}
 						>
 							{#if saving}
-								<LoaderCircle class="size-4 animate-spin" />
+								<Loading class="size-4" />
 							{:else}
 								Save
 							{/if}

--- a/ui/user/src/routes/admin/skill-access-policies/+page.svelte
+++ b/ui/user/src/routes/admin/skill-access-policies/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import SkillAccessPolicyForm from '$lib/components/admin/SkillAccessPolicyForm.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import { type SkillAccessPolicy } from '$lib/services/admin/types';
@@ -48,9 +48,9 @@
 			>
 				{#if skillAccessPolicies.length === 0}
 					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-						<Vault class="text-on-surface1 size-24 opacity-25" />
-						<h4 class="text-on-surface1 text-lg font-semibold">No skill access policies</h4>
-						<p class="text-on-surface1 text-sm font-light">
+						<Vault class="text-muted-content size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">No skill access policies</h4>
+						<p class="text-muted-content text-sm font-light">
 							Looks like you don't have any skill access policies created yet. <br />
 							{#if !isReadonly}
 								Click the button below to get started.
@@ -90,16 +90,16 @@
 	>
 		{#snippet actions(d)}
 			{#if !isReadonly}
-				<button
-					class="icon-button hover:text-red-500"
+				<IconButton
+					variant="danger"
 					onclick={(e) => {
 						e.stopPropagation();
 						policyToDelete = d;
 					}}
-					use:tooltip={'Delete Policy'}
+					tooltip={{ text: 'Delete Policy' }}
 				>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 			{/if}
 		{/snippet}
 		{#snippet onRenderColumn(property, d)}
@@ -111,7 +111,7 @@
 {#snippet addPolicyButton()}
 	{#if !profile.current.isAdminReadonly?.()}
 		<button
-			class="button-primary flex items-center gap-1 text-sm"
+			class="btn btn-primary flex items-center gap-1 text-sm"
 			onclick={() => {
 				goto(`/admin/skill-access-policies?new=true`);
 			}}

--- a/ui/user/src/routes/admin/skill-access-policies/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/skill-access-policies/[id]/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Layout {title} showBackButton>
-	<div class="mb-4 h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
+	<div class="h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
 		<SkillAccessPolicyForm
 			{skillAccessPolicy}
 			onUpdate={() => {

--- a/ui/user/src/routes/admin/skills/+page.svelte
+++ b/ui/user/src/routes/admin/skills/+page.svelte
@@ -6,7 +6,9 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import Search from '$lib/components/Search.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import type { SkillRepository } from '$lib/services/admin/types';
 	import type { Skill } from '$lib/services/nanobot/types';
@@ -14,16 +16,7 @@
 	import { formatTimeAgo } from '$lib/time';
 	import { goto } from '$lib/url.js';
 	import { openUrl } from '$lib/utils.js';
-	import {
-		TriangleAlert,
-		Info,
-		LoaderCircle,
-		PencilRuler,
-		Plus,
-		RefreshCcw,
-		Trash2,
-		X
-	} from 'lucide-svelte';
+	import { TriangleAlert, Info, PencilRuler, Plus, RefreshCcw, Trash2, X } from 'lucide-svelte';
 	import { onDestroy, untrack } from 'svelte';
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 	import { slide } from 'svelte/transition';
@@ -153,20 +146,20 @@
 	}
 </script>
 
-<Layout classes={{ navbar: 'bg-surface1' }} title="Skills">
+<Layout classes={{ navbar: 'bg-base-200' }} title="Skills">
 	<div class="flex min-h-full flex-col gap-8">
 		<div class="flex min-h-full flex-col">
-			<div class="bg-surface1 dark:bg-background sticky top-16 left-0 z-20 w-full py-1">
+			<div class="bg-base-200 dark:bg-base-100 sticky top-16 left-0 z-20 w-full py-1">
 				<div class="mb-2">
 					<Search
-						class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+						class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 						value={query}
 						onChange={updateSearchQuery}
 						placeholder={view == 'skills' ? 'Search skills...' : 'Search sources...'}
 					/>
 				</div>
 			</div>
-			<div class="dark:bg-surface2 bg-background rounded-t-md shadow-sm">
+			<div class="dark:bg-base-300 bg-base-100 rounded-t-md shadow-sm">
 				<div class="flex">
 					<button
 						class={twMerge('page-tab max-w-1/2', view === 'skills' && 'page-tab-active')}
@@ -204,7 +197,7 @@
 	{#snippet rightNavActions()}
 		{#if !isAdminReadonly}
 			<button
-				class="button-primary flex items-center gap-1 text-sm"
+				class="btn btn-primary flex items-center gap-1 text-sm"
 				onclick={() => {
 					editingSource = { index: -1, value: '', name: '', ref: 'main' };
 					sourceDialog?.showModal();
@@ -254,7 +247,7 @@
 							{d.displayName}
 							{#if d.validationError}
 								<div use:tooltip={{ text: d.validationError }}>
-									<TriangleAlert class="size-3 text-yellow-500" />
+									<TriangleAlert class="size-3 text-warning" />
 								</div>
 							{/if}
 						</span>
@@ -272,9 +265,9 @@
 			</Table>
 		{:else}
 			<div class="my-12 flex w-md flex-col items-center gap-4 self-center text-center">
-				<PencilRuler class="text-surface3 size-24" />
-				<h4 class="text-on-surface1 text-lg font-semibold">No current skills.</h4>
-				<p class="text-on-surface1 text-sm font-light">
+				<PencilRuler class="text-base-content/80 size-24" />
+				<h4 class="text-muted-content text-lg font-semibold">No current skills.</h4>
+				<p class="text-muted-content text-sm font-light">
 					Once a Git Source URL has been added, the skills <br />
 					discovered will be viewable from here.
 				</p>
@@ -302,7 +295,7 @@
 				noDataMessage="No Git Source URLs added."
 				setRowClasses={(d) => {
 					if (d.syncError) {
-						return 'bg-yellow-500/10';
+						return 'bg-warning/10';
 					}
 					return '';
 				}}
@@ -313,15 +306,15 @@
 			>
 				{#snippet actions(d)}
 					{#if !isAdminReadonly}
-						<button
-							class="icon-button hover:text-red-500"
+						<IconButton
+							variant="danger"
 							onclick={(e) => {
 								e.stopPropagation();
 								deletingSources = [d];
 							}}
 						>
 							<Trash2 class="size-4" />
-						</button>
+						</IconButton>
 					{/if}
 				{/snippet}
 				{#snippet onRenderColumn(property, d)}
@@ -340,10 +333,10 @@
 									}}
 									use:tooltip={{
 										text: 'An issue occurred. Click to see more details.',
-										classes: ['break-words']
+										classes: ['wrap-break-word']
 									}}
 								>
-									<TriangleAlert class="size-4 text-yellow-500" />
+									<TriangleAlert class="size-4 text-warning" />
 								</button>
 							{/if}
 						</div>
@@ -354,7 +347,7 @@
 				{#snippet tableSelectActions(currentSelected)}
 					<div class="flex grow items-center justify-end gap-2 px-4 py-2">
 						<button
-							class="button flex items-center gap-1 text-sm font-normal"
+							class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 							onclick={() => {
 								for (const id of Object.keys(currentSelected)) {
 									sync(id);
@@ -363,13 +356,13 @@
 							disabled={isAdminReadonly || isSyncing}
 						>
 							{#if isSyncing}
-								<LoaderCircle class="size-4 animate-spin" /> Syncing...
+								<Loading class="size-4" /> Syncing...
 							{:else}
 								<RefreshCcw class="size-4" /> Sync
 							{/if}
 						</button>
 						<button
-							class="button flex items-center gap-1 text-sm font-normal"
+							class="btn btn-secondary flex items-center gap-1 text-sm font-normal"
 							onclick={() => {
 								deletingSources = Object.values(currentSelected);
 							}}
@@ -382,9 +375,9 @@
 			</Table>
 		{:else}
 			<div class="my-12 flex w-md flex-col items-center gap-4 self-center text-center">
-				<PencilRuler class="text-surface3 size-24" />
-				<h4 class="text-on-surface1 text-lg font-semibold">No current Git Source URLs.</h4>
-				<p class="text-on-surface1 text-sm font-light">
+				<PencilRuler class="text-base-content/80 size-24" />
+				<h4 class="text-muted-content text-lg font-semibold">No current Git Source URLs.</h4>
+				<p class="text-muted-content text-sm font-light">
 					Once a Git Source URL has been added, its <br />
 					information will be quickly accessible here.
 				</p>
@@ -439,7 +432,7 @@
 	<div class="mb-4 flex flex-col gap-4">
 		<div class="notification-alert flex flex-col gap-2">
 			<div class="flex items-center gap-2">
-				<TriangleAlert class="size-6 flex-shrink-0 self-start text-yellow-500" />
+				<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
 				<p class="my-0.5 flex flex-col text-sm font-semibold">
 					An issue occurred fetching this source URL:
 				</p>
@@ -454,9 +447,9 @@
 		{#if editingSource}
 			<h3 class="dialog-title">
 				{editingSource.index === -1 ? 'Add Source URL' : 'Edit Source URL'}
-				<button onclick={() => closeSourceDialog()} class="icon-button dialog-close-btn">
+				<IconButton onclick={() => closeSourceDialog()} class="btn-sm dialog-close-btn">
 					<X class="size-5" />
-				</button>
+				</IconButton>
 			</h3>
 
 			<div class="mt-4 mb-8 flex flex-col gap-4">
@@ -485,16 +478,16 @@
 						>Reference
 					</label>
 					<input id="catalog-source-ref" bind:value={editingSource.ref} class="text-input-filled" />
-					<span class="text-on-surface1 text-xs"
+					<span class="text-muted-content text-xs"
 						>The branch, commit SHA, or tag to index and pull skills from.</span
 					>
 				</div>
 			</div>
 
 			{#if sourceError}
-				<div class="mb-4 flex flex-col gap-2 text-red-500 dark:text-red-400">
+				<div class="mb-4 flex flex-col gap-2 text-error">
 					<div class="flex items-center gap-2">
-						<TriangleAlert class="size-6 flex-shrink-0 self-start" />
+						<TriangleAlert class="size-6 shrink-0 self-start" />
 						<p class="my-0.5 flex flex-col text-sm font-semibold">Error adding source URL:</p>
 					</div>
 					<span class="font-sm font-light break-all">{sourceError}</span>
@@ -502,9 +495,11 @@
 			{/if}
 
 			<div class="flex w-full justify-end gap-2">
-				<button class="button" disabled={saving} onclick={() => closeSourceDialog()}>Cancel</button>
+				<button class="btn btn-secondary" disabled={saving} onclick={() => closeSourceDialog()}
+					>Cancel</button
+				>
 				<button
-					class="button-primary"
+					class="btn btn-primary"
 					disabled={saving}
 					onclick={async () => {
 						if (!editingSource) {

--- a/ui/user/src/routes/admin/task-runs/+page.svelte
+++ b/ui/user/src/routes/admin/task-runs/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import Search from '$lib/components/Search.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		type ProjectThread,
@@ -24,7 +25,7 @@
 	} from '$lib/url';
 	import { openUrl } from '$lib/utils';
 	import { debounce } from 'es-toolkit';
-	import { Eye, LoaderCircle, MessageCircle } from 'lucide-svelte';
+	import { Eye, MessageCircle } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -157,20 +158,20 @@
 			<div class="flex flex-col gap-2">
 				<Search
 					value={query}
-					class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+					class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 					onChange={updateQuery}
 					placeholder="Search threads..."
 				/>
 
 				{#if loading}
 					<div class="flex w-full justify-center py-12">
-						<LoaderCircle class="text-primary size-8 animate-spin" />
+						<Loading class="size-8" />
 					</div>
 				{:else if filteredThreads.length === 0}
 					<div class="flex w-full flex-col items-center justify-center py-12 text-center">
-						<MessageCircle class="text-on-surface1 size-24 opacity-50" />
-						<h3 class="text-on-surface1 mt-4 text-lg font-semibold">No task runs available</h3>
-						<p class="text-on-surface1 mt-2 text-sm font-light">
+						<MessageCircle class="text-base-content/80 size-24 opacity-50" />
+						<h3 class="text-muted-content mt-4 text-lg font-semibold">No task runs available</h3>
+						<p class="text-muted-content mt-2 text-sm font-light">
 							Task runs will appear here once they are created.
 						</p>
 					</div>
@@ -208,14 +209,13 @@
 						onSort={setSortUrlParams}
 					>
 						{#snippet actions()}
-							<button
+							<IconButton
 								class={twMerge(
-									'icon-button',
 									isAuditor && 'hover:text-primary',
 									!isAuditor && 'opacity-50 hover:bg-transparent dark:hover:bg-transparent'
 								)}
 								title="View Thread"
-								use:tooltip={{
+								tooltip={{
 									text: isAuditor
 										? 'View Task Run'
 										: 'To view details, auditing permissions are required.'
@@ -223,13 +223,13 @@
 								disabled={!isAuditor}
 							>
 								<Eye class="size-4" />
-							</button>
+							</IconButton>
 						{/snippet}
 						{#snippet onRenderColumn(property, thread)}
 							{#if property === 'name'}
 								<span>{thread.name || 'Unnamed Task Run'}</span>
 							{:else if property === 'created'}
-								<span class="text-on-surface1 text-sm">
+								<span class="text-muted-content text-sm">
 									{formatTimeAgo(thread.created).relativeTime}
 								</span>
 							{:else}

--- a/ui/user/src/routes/admin/tasks/+page.svelte
+++ b/ui/user/src/routes/admin/tasks/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import Search from '$lib/components/Search.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		type ProjectThread,
@@ -23,10 +24,9 @@
 	} from '$lib/url';
 	import { openUrl } from '$lib/utils';
 	import { debounce } from 'es-toolkit';
-	import { Eye, LoaderCircle, MessageCircle } from 'lucide-svelte';
+	import { Eye, MessageCircle } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
-	import { twMerge } from 'tailwind-merge';
 
 	let tasks = $state<ProjectTask[]>([]);
 	let threads = $state<ProjectThread[]>([]);
@@ -145,20 +145,20 @@
 			<div class="flex flex-col gap-2">
 				<Search
 					value={query}
-					class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+					class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 					onChange={updateQuery}
 					placeholder="Search threads..."
 				/>
 
 				{#if loading}
 					<div class="flex w-full justify-center py-12">
-						<LoaderCircle class="text-primary size-8 animate-spin" />
+						<Loading class="size-8" />
 					</div>
 				{:else if tasks.length === 0}
 					<div class="flex w-full flex-col items-center justify-center py-12 text-center">
-						<MessageCircle class="text-on-surface1 size-24 opacity-50" />
-						<h3 class="text-on-surface1 mt-4 text-lg font-semibold">No task available</h3>
-						<p class="text-on-surface1 mt-2 text-sm font-light">
+						<MessageCircle class="text-base-content/80 size-24 opacity-50" />
+						<h3 class="text-muted-content mt-4 text-lg font-semibold">No task available</h3>
+						<p class="text-muted-content mt-2 text-sm font-light">
 							Task will appear here once they are created.
 						</p>
 					</div>
@@ -196,21 +196,15 @@
 						onSort={setSortUrlParams}
 					>
 						{#snippet actions()}
-							<button
-								class={twMerge('icon-button hover:text-primary')}
-								title="View Task"
-								use:tooltip={{
-									text: 'View Task'
-								}}
-							>
+							<IconButton variant="primary" tooltip={{ text: 'View Task' }}>
 								<Eye class="size-4" />
-							</button>
+							</IconButton>
 						{/snippet}
 						{#snippet onRenderColumn(property, task)}
 							{#if property === 'name'}
 								<span>{task.name || 'Unnamed Task'}</span>
 							{:else if property === 'created'}
-								<span class="text-on-surface1 text-sm">
+								<span class="text-muted-content text-sm">
 									{formatTimeAgo(task.created).relativeTime}
 								</span>
 							{:else if property === 'runs'}

--- a/ui/user/src/routes/admin/token-usage/+page.svelte
+++ b/ui/user/src/routes/admin/token-usage/+page.svelte
@@ -587,7 +587,7 @@
 			out:fade|global={{ duration: 300, delay: 500 }}
 		>
 			<div
-				class="bg-surface3/50 border-surface3 text-primary dark:text-primary flex flex-col items-center gap-4 rounded-2xl border px-16 py-8 shadow-md backdrop-blur-[1px]"
+				class="bg-base-400/50 border-base-400 text-primary dark:text-primary flex flex-col items-center gap-4 rounded-2xl border px-16 py-8 shadow-md backdrop-blur-[1px]"
 			>
 				<Loading class="size-32 stroke-1" />
 				<div class="text-2xl font-semibold">Loading data...</div>
@@ -596,7 +596,7 @@
 	{/if}
 
 	<div class="mb-4 flex flex-col gap-4" transition:fade={{ duration }}>
-		<div class="bg-surface2 dark:bg-surface1 w-full">
+		<div class="bg-base-300 dark:bg-base-200 w-full">
 			<div class="m-auto w-full px-4 py-4 md:max-w-(--breakpoint-xl) md:px-8">
 				<h4 class="font-semibold">Overall Stats</h4>
 				<div class="flex flex-col flex-wrap items-stretch gap-4 md:flex-row">
@@ -612,11 +612,11 @@
 			class="m-auto flex w-full max-w-full flex-col gap-4 px-4 md:max-w-(--breakpoint-xl) md:px-8"
 		>
 			<div class="flex w-full flex-wrap items-center justify-end gap-4">
-				<p class="text-on-surface1 w-full text-sm md:w-fit">Filter by:</p>
+				<p class="text-muted-content w-full text-sm md:w-fit">Filter by:</p>
 				<Select
-					class="dark:border-surface3 border border-transparent"
+					class="dark:border-base-400 border border-transparent"
 					classes={{
-						root: 'w-full md:flex-1 dark:border-surface3'
+						root: 'w-full md:flex-1 dark:border-base-400'
 					}}
 					options={usersOptions}
 					selected={selectedUserIdsForSelect}
@@ -634,9 +634,9 @@
 					displayCount={!!selectedUserIdsForSelect && selectedUserIdsForSelect !== 'all_users'}
 				/>
 				<Select
-					class="dark:border-surface3 border border-transparent"
+					class="dark:border-base-400 border border-transparent"
 					classes={{
-						root: 'w-full md:flex-1 dark:border-surface3'
+						root: 'w-full md:flex-1 dark:border-base-400'
 					}}
 					options={modelsOptions}
 					selected={filteredByModel}
@@ -653,7 +653,7 @@
 					buttonTitle="Models"
 					displayCount={!!filteredByModel && filteredByModel !== 'all_models'}
 				/>
-				<div class="bg-surface3 hidden h-8 w-0.5 md:block"></div>
+				<div class="bg-base-400 hidden h-8 w-0.5 md:block"></div>
 				<AuditLogCalendar start={startDate} end={endDate} onChange={handleDateRangeChange} />
 			</div>
 			{#if filteredByModel !== 'all_models' || selectedUserIdsForSelect !== 'all_users'}
@@ -701,8 +701,8 @@
 						<div class="flex shrink-0">
 							<button
 								class={twMerge(
-									'button-secondary rounded-r-none border border-r-0 text-xs',
-									selectedTokenType === 'input' && 'bg-surface2 border-surface2'
+									'btn btn-secondary bg-base-300 dark:hover:bg-base-400 border-base-300 rounded-r-none! border border-r-0 text-xs',
+									selectedTokenType !== 'input' && 'bg-base-100 dark:bg-base-200 hover:bg-base-400 '
 								)}
 								onclick={() => handleTokenTypeChange('input')}
 							>
@@ -710,8 +710,8 @@
 							</button>
 							<button
 								class={twMerge(
-									'button-secondary rounded-l-none border text-xs',
-									selectedTokenType === 'output' && 'bg-surface2 border-surface2'
+									'btn btn-secondary bg-base-300 dark:hover:bg-base-400 border-base-300 rounded-l-none! border text-xs',
+									selectedTokenType !== 'output' && 'bg-base-100 dark:bg-base-200 hover:bg-base-400'
 								)}
 								onclick={() => handleTokenTypeChange('output')}
 							>
@@ -720,7 +720,7 @@
 						</div>
 					</div>
 					<Select
-						class="bg-surface2 dark:bg-background dark:border-surface3 w-[50dvw] border border-transparent shadow-inner md:w-64"
+						class="bg-base-300 dark:bg-base-100 dark:border-base-400 w-[50dvw] border border-transparent shadow-inner md:w-64"
 						options={[
 							{ label: 'Group by Token Type', id: 'group_by_default' },
 							{ label: 'Group by Users', id: 'group_by_users' },
@@ -755,11 +755,11 @@
 								{@const value = item.primaryTotal ?? 0}
 								<div class="flex flex-col gap-0 text-xs">
 									<div class="text-sm font-light">{item.key}</div>
-									<div class="text-on-surface1">{item.date}</div>
+									<div class="text-muted-content">{item.date}</div>
 									<div class="tooltip-divider"></div>
 								</div>
 								<div class="flex flex-col gap-1">
-									<div class="text-on-background flex flex-col">
+									<div class="text-base-content flex flex-col">
 										<div class="text-xl font-bold">{value.toLocaleString()}</div>
 									</div>
 								</div>
@@ -798,7 +798,7 @@
 						</button>
 					</div>
 					<Select
-						class="bg-surface1 hover:bg-surface2 dark:bg-background dark:hover:bg-surface1 mb-1.5 border border-transparent shadow-none md:w-64"
+						class="bg-base-200 hover:bg-base-300 dark:bg-base-100 dark:hover:bg-base-200 mb-1.5 border border-transparent shadow-none md:w-64"
 						options={[
 							{ label: 'Sort by Name (A-Z)', id: 'sort_by_name' },
 							{ label: 'Sort by Name (Z-A)', id: 'sort_by_name_reverse' },
@@ -818,10 +818,10 @@
 						id="sub-view-sort-by-select"
 					/>
 				</div>
-				<div class="bg-surface3 h-0.5 w-full shrink-0 -translate-y-1"></div>
+				<div class="bg-base-400 h-0.5 w-full shrink-0 -translate-y-1"></div>
 
 				<Search
-					class="bg-background dark:border-surface3 mt-2 mb-3 border border-transparent"
+					class="bg-base-100 dark:border-base-400 mt-2 mb-3 border border-transparent"
 					value={subViewSearchQuery}
 					onChange={(value) => (subViewSearchQuery = value)}
 					placeholder={`Search ${selectedSubview === 'models' ? 'models' : 'users'}...`}
@@ -831,7 +831,7 @@
 					<div class="min-h-[300px]">
 						{#if !gridDataReady}
 							<div
-								class="text-on-surface1 flex items-center justify-center gap-2 py-12 text-sm"
+								class="text-muted-content flex items-center justify-center gap-2 py-12 text-sm"
 								aria-live="polite"
 							>
 								<Loading class="size-4 animate-spin" />
@@ -840,9 +840,13 @@
 						{:else if displayGraphItems.length > 0}
 							<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 								{#each displayGraphItems.slice(0, visibleChartCount) as item (item.label)}
-									<div class="paper flex min-h-0 flex-col overflow-hidden">
-										<h5 class="shrink-0 text-sm font-medium">{item.label}</h5>
-										<div class="w-full shrink-0">
+									<div class="paper p-0 flex min-h-0 flex-col overflow-hidden">
+										<h5
+											class="shrink-0 text-xs font-medium uppercase border-b dark:border-base-400 border-base-300 px-4 py-2 rounded-t-md"
+										>
+											{item.label}
+										</h5>
+										<div class="w-full shrink-0 p-4">
 											<StackedTimeline
 												start={startDate}
 												end={endDate}
@@ -871,11 +875,11 @@
 														<div class="text-sm font-light">
 															{item.hoveredPart === 'primary' ? 'Input tokens' : 'Output tokens'}
 														</div>
-														<div class="text-on-surface1">{item.date}</div>
+														<div class="text-muted-content">{item.date}</div>
 														<div class="tooltip-divider"></div>
 													</div>
 													<div class="flex flex-col gap-1">
-														<div class="text-on-background flex flex-col">
+														<div class="text-base-content flex flex-col">
 															<div class="text-xl font-bold">{value.toLocaleString()}</div>
 														</div>
 													</div>
@@ -887,7 +891,7 @@
 							</div>
 							{#if visibleChartCount < displayGraphItems.length}
 								<div
-									class="text-on-surface1 flex items-center justify-center gap-2 py-4 text-sm"
+									class="text-muted-content flex items-center justify-center gap-2 py-4 text-sm"
 									aria-live="polite"
 								>
 									<Loading class="size-4 animate-spin" />
@@ -895,13 +899,13 @@
 								</div>
 							{/if}
 						{:else}
-							<div class="text-on-surface1 mx-auto py-12 text-center text-sm font-light">
+							<div class="text-muted-content mx-auto py-12 text-center text-sm font-light">
 								No matches found.
 							</div>
 						{/if}
 					</div>
 				{:else}
-					<div class="text-on-surface1 mx-auto py-12 text-sm font-light">No data available.</div>
+					<div class="text-muted-content mx-auto py-12 text-sm font-light">No data available.</div>
 				{/if}
 			</div>
 		</div>
@@ -910,7 +914,7 @@
 
 {#snippet summary(title: string, value: number)}
 	<div class="flex min-w-0 flex-1 flex-col gap-1 py-2">
-		<div class="text-on-background text-xs font-light">{title}</div>
+		<div class="text-base-content text-xs font-light">{title}</div>
 		<div class="text-primary flex items-center gap-1 text-xl font-semibold">
 			{#if loadingTotalTokensData}
 				<div class="py-2">
@@ -932,7 +936,7 @@
 	.divider-horizontal {
 		width: 1px;
 		height: auto;
-		background-color: var(--color-surface3);
+		background-color: var(--color-base-400);
 		margin-left: 1rem;
 		margin-right: 1rem;
 	}

--- a/ui/user/src/routes/admin/user-roles/+page.svelte
+++ b/ui/user/src/routes/admin/user-roles/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import Layout from '$lib/components/Layout.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService } from '$lib/services';
 	import { userRoleOptions } from '$lib/services/admin/constants';
 	import { Role } from '$lib/services/admin/types';
 	import { profile } from '$lib/stores/index.js';
-	import { LoaderCircle } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 
@@ -47,7 +47,7 @@
 				<div class="flex grow flex-col gap-4">
 					<div class="flex flex-col gap-1">
 						<h4 class="text-lg font-semibold">Default User Role</h4>
-						<p class="text-on-surface1 text-sm font-light">
+						<p class="text-muted-content text-sm font-light">
 							Set the initial default role for all new users when they first log into the system.
 							User roles can be changed individually from the "Users" page.
 						</p>
@@ -65,7 +65,7 @@
 									/>
 									<div class="flex flex-col">
 										<p class="text-sm font-medium">{role.label}</p>
-										<p class="text-on-surface1 text-sm font-light">{role.description}</p>
+										<p class="text-muted-content text-sm font-light">{role.description}</p>
 									</div>
 								</label>
 							{/each}
@@ -79,19 +79,19 @@
 
 		{#if !isAdminReadonly}
 			<div
-				class="bg-surface1 dark:bg-background sticky bottom-0 left-0 flex w-[calc(100%+2em)] -translate-x-4 justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
+				class="bg-base-200 dark:bg-base-100 sticky bottom-0 left-0 flex w-[calc(100%+2em)] -translate-x-4 justify-end gap-4 p-4 md:w-[calc(100%+4em)] md:-translate-x-8 md:px-8"
 			>
 				{#if showSaved}
 					<span
 						in:fade={{ duration: 200 }}
-						class="text-on-surface1 flex min-h-10 items-center px-4 text-sm font-extralight"
+						class="text-muted-content flex min-h-10 items-center px-4 text-sm font-extralight"
 					>
 						Your changes have been saved.
 					</span>
 				{/if}
 
 				<button
-					class="button hover:bg-surface3 flex items-center gap-1 bg-transparent"
+					class="btn btn-secondary hover:bg-base-400 flex items-center gap-1 bg-transparent"
 					onclick={() => {
 						baseDefaultRole = prevBaseDefaultRole;
 					}}
@@ -99,12 +99,12 @@
 					Reset
 				</button>
 				<button
-					class="button-primary flex items-center gap-1"
+					class="btn btn-primary flex items-center gap-1"
 					disabled={saving}
 					onclick={handleSave}
 				>
 					{#if saving}
-						<LoaderCircle class="size-4 animate-spin" />
+						<Loading class="size-4" />
 					{:else}
 						Save
 					{/if}

--- a/ui/user/src/routes/admin/users/+page.svelte
+++ b/ui/user/src/routes/admin/users/+page.svelte
@@ -8,6 +8,7 @@
 	import Search from '$lib/components/Search.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { userRoleOptions } from '$lib/services/admin/constants.js';
 	import { Group, Role, type OrgUser } from '$lib/services/admin/types';
 	import { AdminService, ChatService } from '$lib/services/index.js';
@@ -23,7 +24,7 @@
 	} from '$lib/url.js';
 	import { getUserRoleLabel } from '$lib/utils';
 	import { debounce } from 'es-toolkit';
-	import { Handshake, Info, LoaderCircle, ShieldAlert } from 'lucide-svelte';
+	import { Handshake, Info, ShieldAlert } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
 
@@ -181,7 +182,7 @@
 			<div class="flex flex-col gap-2">
 				<Search
 					value={query}
-					class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+					class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 					onChange={updateQuery}
 					placeholder="Search by name or email..."
 				/>
@@ -243,7 +244,7 @@
 									Update Role
 								</button>
 								<button
-									class="menu-button text-red-500"
+									class="menu-button text-error"
 									disabled={d.explicitRole ||
 										(d.groups.includes(Group.OWNER) &&
 											!profile.current.groups.includes(Group.OWNER))}
@@ -308,8 +309,8 @@
 						disabled={updatingRole.explicitRole}
 					/>
 					<span class="flex flex-col" class:opacity-50={updatingRole.explicitRole}>
-						<p class="w-28 flex-shrink-0 font-semibold">{role.label}</p>
-						<p class="text-on-surface1">
+						<p class="w-28 shrink-0 font-semibold">{role.label}</p>
+						<p class="text-muted-content">
 							{#if role.id === Role.OWNER}
 								Owners can manage all aspects of the platform and can also assign the Owner role to
 								other users.
@@ -327,14 +328,14 @@
 				<label class="mt-4 flex gap-4">
 					<input type="checkbox" bind:checked={updatingRole.auditor} />
 					<span class="flex flex-col">
-						<p class="w-28 flex-shrink-0 font-semibold">Auditor</p>
+						<p class="w-28 shrink-0 font-semibold">Auditor</p>
 						{#if auditorReadonlyAdminRoles.includes(updatingRole.roleId)}
-							<p class="text-on-surface1">
+							<p class="text-muted-content">
 								Will have read-only access to the admin system and see additional details such as
 								response, request, and header information in the audit logs.
 							</p>
 						{:else}
-							<p class="text-on-surface1">
+							<p class="text-muted-content">
 								Will gain access to additional details such as response, request, and header
 								information in the audit logs.
 							</p>
@@ -352,8 +353,8 @@
 						class:opacity-50={updatingRole.roleId !== Role.ADMIN &&
 							updatingRole.roleId !== Role.OWNER}
 					>
-						<p class="flex-shrink-0 font-semibold">Impersonator</p>
-						<p class="text-on-surface1">
+						<p class="shrink-0 font-semibold">Impersonator</p>
+						<p class="text-muted-content">
 							Will be able to connect to other users' Obot Agents. Requires Admin or Owner base
 							role.
 						</p>
@@ -363,9 +364,9 @@
 		</div>
 		<div class="flex grow"></div>
 		<div class="mt-4 flex flex-col justify-end gap-2 p-4 md:flex-row md:p-0">
-			<button class="button" onclick={() => closeUpdateRoleDialog()}>Cancel</button>
+			<button class="btn btn-secondary" onclick={() => closeUpdateRoleDialog()}>Cancel</button>
 			<button
-				class="button-primary"
+				class="btn btn-primary"
 				onclick={async () => {
 					if (!updatingRole) return;
 					roleUpdateError = '';
@@ -400,7 +401,7 @@
 				disabled={loading}
 			>
 				{#if loading}
-					<LoaderCircle class="size-4 animate-spin" />
+					<Loading class="size-4" />
 				{:else}
 					Update
 				{/if}

--- a/ui/user/src/routes/agent/ImpersonateBanner.svelte
+++ b/ui/user/src/routes/agent/ImpersonateBanner.svelte
@@ -33,7 +33,7 @@
 			<HatGlasses class="inline-block size-5" /> <span class="font-semibold">CAUTION!</span> You are
 			currently impersonating <span class="font-semibold">{ownerEmail}.</span> <br />
 		</p>
-		<a href={resolve('/admin/agents')} class="button text-on-background text-xs font-normal"
+		<a href={resolve('/admin/agents')} class="btn btn-sm text-base-content font-normal"
 			>Stop Impersonating</a
 		>
 	</div>

--- a/ui/user/src/routes/agent/ProjectSidebar.svelte
+++ b/ui/user/src/routes/agent/ProjectSidebar.svelte
@@ -99,7 +99,7 @@
 
 <div
 	class={twMerge(
-		'bg-base-200 z-10 h-[100dvh] w-18 min-w-18 flex-shrink-0 overflow-visible',
+		'bg-base-200 z-10 h-dvh w-18 min-w-18 shrink-0 overflow-visible',
 		layout.sidebarOpen && 'w-[300px] md:min-w-[300px]'
 	)}
 >
@@ -126,7 +126,7 @@
 				>
 					<button
 						type="button"
-						class="btn btn-ghost text-base-content/50 text-md justify-between rounded-none"
+						class="btn btn-ghost text-muted-content text-md justify-between rounded-none"
 						onclick={() => goto(`/agent/p/${projectId}/workflows`)}
 						class:bg-base-100={activeView === 'workflows'}
 					>
@@ -135,7 +135,7 @@
 
 					<button
 						type="button"
-						class="btn btn-ghost text-base-content/50 text-md justify-between rounded-none"
+						class="btn btn-ghost text-muted-content text-md justify-between rounded-none"
 						onclick={() => goto(`/agent/p/${projectId}/scheduler`)}
 						class:bg-base-100={activeView === 'scheduler'}
 					>
@@ -144,7 +144,7 @@
 
 					<button
 						type="button"
-						class="btn btn-ghost text-base-content/50 text-md justify-between rounded-none"
+						class="btn btn-ghost text-muted-content text-md justify-between rounded-none"
 						onclick={() => goto(`/agent/p/${projectId}/files`)}
 						class:bg-base-100={activeView === 'files'}
 					>
@@ -161,7 +161,7 @@
 					/>
 				</div>
 			{:else}
-				<div class="flex flex-shrink-0 flex-col items-center justify-center gap-4 pb-3">
+				<div class="flex shrink-0 flex-col items-center justify-center gap-4 pb-3">
 					<div class="w-fit">
 						<button
 							class="btn btn-ghost btn-circle tooltip tooltip-right size-10 self-center"
@@ -172,7 +172,7 @@
 							<Workflow
 								class={twMerge(
 									'size-6',
-									activeView === 'workflows' ? 'text-primary' : 'text-base-content/50'
+									activeView === 'workflows' ? 'text-primary' : 'text-muted-content'
 								)}
 							/>
 						</button>
@@ -187,7 +187,7 @@
 							<Clock3
 								class={twMerge(
 									'size-6',
-									activeView === 'scheduler' ? 'text-primary' : 'text-base-content/50'
+									activeView === 'scheduler' ? 'text-primary' : 'text-muted-content'
 								)}
 							/>
 						</button>
@@ -202,7 +202,7 @@
 							<Folders
 								class={twMerge(
 									'size-6',
-									activeView === 'files' ? 'text-primary' : 'text-base-content/50'
+									activeView === 'files' ? 'text-primary' : 'text-muted-content'
 								)}
 							/>
 						</button>
@@ -214,16 +214,14 @@
 							data-tip="Start new conversation"
 							onclick={handleCreateSession}
 						>
-							<Plus class="text-base-content/50 size-6" />
+							<Plus class="text-muted-content size-6" />
 						</button>
 					</div>
 				</div>
 				<div class="flex grow"></div>
 			{/if}
 
-			<div
-				class="bg-base-200 sticky bottom-0 flex flex-shrink-0 justify-end overflow-visible pr-4 pb-3"
-			>
+			<div class="bg-base-200 sticky bottom-0 flex shrink-0 justify-end overflow-visible pr-4 pb-3">
 				<button
 					class={twMerge(
 						'btn btn-ghost btn-circle tooltip size-10 self-center',
@@ -234,9 +232,9 @@
 					onclick={toggleSidebar}
 				>
 					{#if layout.sidebarOpen}
-						<SidebarClose class="text-base-content/50 size-6" />
+						<SidebarClose class="text-muted-content size-6" />
 					{:else}
-						<SidebarOpen class="text-base-content/50 size-6" />
+						<SidebarOpen class="text-muted-content size-6" />
 					{/if}
 				</button>
 			</div>

--- a/ui/user/src/routes/agent/p/[projectId]/files/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/files/+page.svelte
@@ -388,7 +388,7 @@
 									<td>
 										<div class="w-full min-w-0">
 											<p
-												class="text-base-content/50 w-full min-w-0 truncate text-sm font-light break-all italic"
+												class="text-muted-content w-full min-w-0 truncate text-sm font-light break-all italic"
 											>
 												{node.uri}
 											</p>
@@ -402,7 +402,7 @@
 					<tr>
 						<td
 							colspan={columnCount}
-							class="text-base-content/50 text-center text-sm font-light italic"
+							class="text-muted-content text-center text-sm font-light italic"
 						>
 							<span>No files found.</span>
 						</td>
@@ -455,7 +455,7 @@
 					</li>
 				{/each}
 			{:else}
-				<li class="text-base-content/50 flex items-start gap-2 px-4 font-light italic">
+				<li class="text-muted-content flex items-start gap-2 px-4 font-light italic">
 					<span>No files found.</span>
 				</li>
 			{/if}

--- a/ui/user/src/routes/agent/p/[projectId]/scheduler/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/scheduler/+page.svelte
@@ -273,7 +273,7 @@
 			aria-label="Create schedule"
 			onclick={() => createDialog?.open()}
 		>
-			<Plus class="size-5" />
+			<Plus class="size-5 text-primary-content" />
 		</button>
 	</div>
 
@@ -318,7 +318,7 @@
 						</td>
 						<td class="text-right" onclick={(event) => event.stopPropagation()}>
 							<DotDotDot
-								class="icon-button hover:bg-base-200 dark:hover:bg-surface3"
+								class="hover:bg-base-200 dark:hover:bg-base-400"
 								placement="bottom-end"
 								disablePortal
 								classes={{
@@ -331,7 +331,7 @@
 								{#snippet children({ toggle })}
 									<button
 										type="button"
-										class="hover:bg-base-200 dark:hover:bg-surface3 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors"
+										class="hover:bg-base-200 dark:hover:bg-base-400 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors"
 										disabled={mutatingTaskURI === task.uri}
 										onclick={async (event) => {
 											event.preventDefault();
@@ -345,7 +345,7 @@
 									</button>
 									<button
 										type="button"
-										class="hover:bg-base-200 dark:hover:bg-surface3 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors"
+										class="hover:bg-base-200 dark:hover:bg-base-400 flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors"
 										disabled={mutatingTaskURI === task.uri}
 										onclick={async (event) => {
 											event.preventDefault();
@@ -390,7 +390,7 @@
 				{/each}
 			{:else}
 				<tr>
-					<td colspan="4" class="text-base-content/50 text-center text-sm font-light italic">
+					<td colspan="4" class="text-muted-content text-center text-sm font-light italic">
 						{taskQuery.trim() ? 'No schedules found.' : 'No schedules yet.'}
 					</td>
 				</tr>

--- a/ui/user/src/routes/agent/p/[projectId]/scheduler/[scheduleId]/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/scheduler/[scheduleId]/+page.svelte
@@ -331,25 +331,25 @@
 		<div class="bg-base-100 rounded-box border-base-300 border">
 			<div class="grid gap-0 md:grid-cols-2">
 				<div class="border-base-300 border-b px-5 py-4 md:border-r">
-					<div class="text-base-content/50 text-xs font-medium uppercase">Schedule</div>
+					<div class="text-muted-content text-xs font-medium uppercase">Schedule</div>
 					<div class="mt-2 text-sm">
 						{scheduleSummary(task.schedule, task.expiration, timePreference.timeFormat)}
 					</div>
 				</div>
 				<div class="border-base-300 border-b px-5 py-4">
-					<div class="text-base-content/50 text-xs font-medium uppercase">Next run</div>
+					<div class="text-muted-content text-xs font-medium uppercase">Next run</div>
 					<div class="mt-2 text-sm">
 						{formatScheduleDateTime(task.nextRunAt, timePreference.timeFormat)}
 					</div>
 				</div>
 				<div class="border-base-300 px-5 py-4 md:border-r">
-					<div class="text-base-content/50 text-xs font-medium uppercase">Expiration</div>
+					<div class="text-muted-content text-xs font-medium uppercase">Expiration</div>
 					<div class="mt-2 text-sm">
 						{task.expiration ? formatScheduleDate(task.expiration) : 'No expiration'}
 					</div>
 				</div>
 				<div class="px-5 py-4">
-					<div class="text-base-content/50 text-xs font-medium uppercase">Last run</div>
+					<div class="text-muted-content text-xs font-medium uppercase">Last run</div>
 					<div class="mt-2 text-sm">
 						{formatScheduleDateTime(sortedSessions[0]?.created, timePreference.timeFormat)}
 					</div>

--- a/ui/user/src/routes/agent/p/[projectId]/workflows/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/workflows/+page.svelte
@@ -294,7 +294,7 @@
 			{/if}
 		</div>
 
-		<p class="text-base-content/50 text-sm font-light">
+		<p class="text-muted-content text-sm font-light">
 			Workflows are AI-powered tools that can be used to automate tasks and processes.
 		</p>
 	</div>
@@ -518,7 +518,7 @@
 									</button>
 								{/if}
 								<button
-									class="btn btn-ghost hover:btn-error btn-square tooltip tooltip-top flex-shrink-0"
+									class="btn btn-ghost hover:btn-error btn-square tooltip tooltip-top shrink-0"
 									data-tip="Delete workflow"
 									onclick={(e) => {
 										e.preventDefault();
@@ -537,7 +537,7 @@
 									<Trash2 class="size-4" />
 								</button>
 								<button
-									class="btn btn-ghost hover:btn-primary btn-square tooltip tooltip-top flex-shrink-0"
+									class="btn btn-ghost hover:btn-primary btn-square tooltip tooltip-top shrink-0"
 									data-tip="Run this workflow"
 									onclick={(e) => {
 										e.preventDefault();
@@ -594,7 +594,7 @@
 				<tr>
 					<td
 						colspan={activeTab === 'my' || showingSearchResults ? 5 : 3}
-						class="text-base-content/50 text-center text-sm font-light italic"
+						class="text-muted-content text-center text-sm font-light italic"
 					>
 						<span>No workflows found.</span>
 					</td>

--- a/ui/user/src/routes/agent/p/[projectId]/workflows/[workflowId]/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/workflows/[workflowId]/+page.svelte
@@ -617,12 +617,8 @@
 		tr.list-row {
 			cursor: pointer;
 			&:hover {
-				background-color: color-mix(in oklch, var(--color-base-100) 95%, var(--color-black));
+				background-color: var(--color-base-200);
 				transition: background-color 0.2s ease;
-			}
-
-			.dark &:hover {
-				background-color: color-mix(in oklch, var(--color-base-100) 80%, var(--color-white));
 			}
 		}
 	}

--- a/ui/user/src/routes/agent/p/[projectId]/workflows/[workflowId]/+page.svelte
+++ b/ui/user/src/routes/agent/p/[projectId]/workflows/[workflowId]/+page.svelte
@@ -324,7 +324,7 @@
 							<td>
 								<div class="w-full min-w-0">
 									<p
-										class="text-base-content/50 w-full min-w-0 truncate text-sm font-light break-all italic"
+										class="text-muted-content w-full min-w-0 truncate text-sm font-light break-all italic"
 									>
 										{resource.uri}
 									</p>

--- a/ui/user/src/routes/i/[code]/+page.svelte
+++ b/ui/user/src/routes/i/[code]/+page.svelte
@@ -83,7 +83,7 @@
 </script>
 
 <div class="flex min-h-svh flex-col">
-	<header class="bg-surface1 border-surface2 sticky top-0 z-40 border-b">
+	<header class="bg-base-200 border-base-300 sticky top-0 z-40 border-b">
 		<div class="colors-background sticky top-0 z-30 flex h-16 w-full items-center">
 			<div class="relative flex items-end p-5">
 				<BetaLogo />
@@ -91,12 +91,10 @@
 		</div>
 	</header>
 
-	<main
-		class="bg-surface1 dark:bg-gray-980 flex w-full grow flex-col items-center justify-center px-4 py-8"
-	>
+	<main class="bg-base-100 flex w-full grow flex-col items-center justify-center px-4 py-8">
 		{#if invitation.status !== 'pending'}
 			<div
-				class="dark:bg-surface1 dark:border-surface3 bg-background w-full max-w-lg rounded-xl p-8 shadow-md dark:border"
+				class="dark:bg-base-200 dark:border-base-400 bg-base-100 w-full max-w-lg rounded-xl p-8 shadow-md dark:border"
 			>
 				<div class="flex flex-col items-center gap-4">
 					<img src="/user/images/sharing-agent-expired.webp" alt="invitation" />
@@ -109,7 +107,7 @@
 						error, please contact support.
 					</p>
 					<div class="mt-4 flex w-full justify-center">
-						<a href={resolve('/')} class="button-primary w-full rounded-full p-2 px-6 text-center">
+						<a href={resolve('/')} class="btn btn-primary w-full rounded-full p-2 px-6 text-center">
 							Go Home
 						</a>
 					</div>
@@ -117,7 +115,7 @@
 			</div>
 		{:else if view === 'rejected'}
 			<div
-				class="dark:bg-surface1 dark:border-surface3 bg-background w-full max-w-lg rounded-xl p-8 shadow-md dark:border"
+				class="dark:bg-base-200 dark:border-base-400 bg-base-100 w-full max-w-lg rounded-xl p-8 shadow-md dark:border"
 			>
 				<div class="flex flex-col items-center gap-4">
 					<img src="/user/images/sharing-agent-expired.webp" alt="invitation" />
@@ -129,7 +127,7 @@
 					</h2>
 					<p class="text-md text-center leading-6 font-light">Thank you for your response!</p>
 					<div class="mt-4 flex w-full justify-center">
-						<a href={resolve('/')} class="button-primary w-full rounded-full p-2 px-6 text-center">
+						<a href={resolve('/')} class="btn btn-primary w-full rounded-full p-2 px-6 text-center">
 							Go Home
 						</a>
 					</div>
@@ -137,7 +135,7 @@
 			</div>
 		{:else if view === 'joined'}
 			<div
-				class="dark:bg-surface1 dark:border-surface3 bg-background w-full max-w-lg rounded-xl p-8 shadow-md dark:border"
+				class="dark:bg-base-200 dark:border-base-400 bg-base-100 w-full max-w-lg rounded-xl p-8 shadow-md dark:border"
 			>
 				<div class="flex flex-col items-center gap-4">
 					<img src="/user/images/sharing-agent.webp" alt="invitation" />
@@ -152,13 +150,16 @@
 					<div class="mt-4 flex w-full justify-center">
 						<a
 							href={resolve(`/o/${invitation.project?.id}`)}
-							class="button-primary w-full rounded-full p-2 px-6 text-center"
+							class="btn btn-primary w-full rounded-full p-2 px-6 text-center"
 						>
 							Go To Project
 						</a>
 					</div>
 					<div class="flex w-full justify-center">
-						<a href={resolve('/')} class="button w-full rounded-full p-2 px-6 text-center">
+						<a
+							href={resolve('/')}
+							class="btn btn-secondary w-full rounded-full p-2 px-6 text-center"
+						>
 							Go Home
 						</a>
 					</div>
@@ -166,7 +167,7 @@
 			</div>
 		{:else}
 			<div
-				class="dark:bg-surface1 dark:border-surface3 bg-background w-full max-w-lg rounded-xl p-8 text-center shadow-md dark:border"
+				class="dark:bg-base-200 dark:border-base-400 bg-base-100 w-full max-w-lg rounded-xl p-8 text-center shadow-md dark:border"
 			>
 				<div class="flex flex-col items-center gap-4">
 					<img src="/user/images/sharing-agent.webp" alt="invitation" />
@@ -176,7 +177,7 @@
 					</h2>
 					{#if invitation.project}
 						<div
-							class="bg-surface1 dark:bg-surface2 flex w-full max-w-xs flex-col items-center gap-4 rounded-xl p-4 text-center"
+							class="bg-base-200 dark:bg-base-300 flex w-full max-w-xs flex-col items-center gap-4 rounded-xl p-4 text-center"
 						>
 							<img
 								src={getProjectImage(invitation.project, darkMode.isDark)}
@@ -184,36 +185,28 @@
 								class="size-16 rounded-full"
 							/>
 							{#if projectDescription}
-								<p class="text-md text-on-surface1">
+								<p class="text-md text-muted-content">
 									{projectDescription}
 								</p>
 							{/if}
 						</div>
 					{/if}
-					<p class="text-on-surface1 text-xs">
+					<p class="text-muted-content text-xs">
 						Invitation sent on {invitationDate}
 					</p>
 					<div class="mt-6 flex w-full justify-center gap-4">
-						<button
-							class="button-destructive text-md w-full justify-center rounded-full p-4 px-6"
-							disabled={isProcessing}
-							onclick={rejectInvitation}
-						>
+						<button class="btn btn-error" disabled={isProcessing} onclick={rejectInvitation}>
 							<X class="size-5" />
 							Reject
 						</button>
-						<button
-							class="button dark:hover:bg-surface2 hover:bg-surface1 flex w-full items-center justify-center gap-1 rounded-full bg-transparent p-4 px-6"
-							disabled={isProcessing}
-							onclick={acceptInvitation}
-						>
+						<button class="btn btn-secondary" disabled={isProcessing} onclick={acceptInvitation}>
 							<Check class="size-5" />
 							Accept
 						</button>
 					</div>
 
 					{#if responseMessage}
-						<p class="mt-4 text-center {responseError ? 'text-red-500' : 'text-green-500'}">
+						<p class="mt-4 text-center {responseError ? 'text-error' : 'text-success'}">
 							{responseMessage}
 						</p>
 					{/if}

--- a/ui/user/src/routes/keys/+page.svelte
+++ b/ui/user/src/routes/keys/+page.svelte
@@ -3,6 +3,7 @@
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import ServersLabel from '$lib/components/api-keys/ServersLabel.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { ApiKeysService } from '$lib/services';
@@ -84,9 +85,9 @@
 		<div class="flex flex-col gap-4">
 			{#if apiKeys.length === 0}
 				<div class="mt-26 flex w-lg flex-col items-center gap-4 self-center text-center">
-					<KeyRound class="text-on-surface1 size-24 opacity-50" />
-					<h4 class="text-on-surface1 text-lg font-semibold">No API keys</h4>
-					<p class="text-on-surface1 text-sm font-light">
+					<KeyRound class="text-base-content/80 size-24 opacity-50" />
+					<h4 class="text-muted-content text-lg font-semibold">No API keys</h4>
+					<p class="text-muted-content text-sm font-light">
 						Looks like you don't have any API keys yet! <br />
 						Click the "Create API Key" button above to get started.
 					</p>
@@ -94,7 +95,7 @@
 					<div class="notification-info mt-8">
 						<div class="flex flex-col gap-2">
 							<div class="flex items-center gap-2">
-								<Info class="size-4 flex-shrink-0" />
+								<Info class="size-4 shrink-0" />
 								<p class="text-sm font-semibold">What are these for?</p>
 							</div>
 							<p class="text-left text-sm font-light">
@@ -163,9 +164,9 @@
 						{/if}
 					{/snippet}
 					{#snippet actions(d)}
-						<button class="icon-button" onclick={() => (deletingKey = d)}>
+						<IconButton variant="danger" onclick={() => (deletingKey = d)}>
 							<Trash2 class="size-4" />
-						</button>
+						</IconButton>
 					{/snippet}
 				</Table>
 			{/if}
@@ -174,7 +175,7 @@
 
 	{#snippet rightNavActions()}
 		{#if !showCreateNew}
-			<button class="button-primary flex items-center gap-2 text-sm" onclick={showCreateForm}>
+			<button class="btn btn-primary flex items-center gap-2 text-sm" onclick={showCreateForm}>
 				<Plus class="size-4" />
 				Create API Key
 			</button>

--- a/ui/user/src/routes/keys/ApiKeyRevealDialog.svelte
+++ b/ui/user/src/routes/keys/ApiKeyRevealDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
-	import { AlertTriangle, KeyRound, ExternalLink } from 'lucide-svelte';
+	import { TriangleAlert, KeyRound, ExternalLink } from 'lucide-svelte';
 
 	interface Props {
 		keyValue?: string;
@@ -35,7 +35,7 @@
 		<div class="flex flex-col gap-6">
 			<div class="notification-alert">
 				<div class="flex items-start gap-3">
-					<AlertTriangle class="size-5 flex-shrink-0" />
+					<TriangleAlert class="size-5 shrink-0" />
 					<div class="flex flex-col gap-1">
 						<p class="text-sm font-medium">Save this key now</p>
 						<p class="text-xs">
@@ -49,8 +49,8 @@
 			<div class="flex flex-col gap-2">
 				<p class="text-sm font-medium">Your API Key</p>
 				<div class="flex items-center gap-2">
-					<div class="bg-surface1 flex flex-1 items-center gap-2 rounded-md border px-3 py-2">
-						<KeyRound class="text-on-surface1 size-4 flex-shrink-0" />
+					<div class="bg-base-200 flex flex-1 items-center gap-2 rounded-md border px-3 py-2">
+						<KeyRound class="text-muted-content size-4 shrink-0" />
 						<code class="flex-1 font-mono text-sm break-all">{keyValue}</code>
 					</div>
 					<CopyButton text={keyValue} buttonText="Copy" />
@@ -72,7 +72,7 @@
 		</div>
 
 		<div class="mt-6 flex justify-end">
-			<button class="button-primary" onclick={handleClose}> I've saved my key </button>
+			<button class="btn btn-primary" onclick={handleClose}> I've saved my key </button>
 		</div>
 	</ResponsiveDialog>
 {/if}

--- a/ui/user/src/routes/keys/CreateApiKeyForm.svelte
+++ b/ui/user/src/routes/keys/CreateApiKeyForm.svelte
@@ -2,13 +2,14 @@
 	import DatePicker from '$lib/components/DatePicker.svelte';
 	import Search from '$lib/components/Search.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
 	import { ApiKeysService } from '$lib/services';
 	import type { APIKeyCreateResponse } from '$lib/services/api-keys/types';
 	import { compileAvailableMcpServers } from '$lib/services/chat/mcp';
 	import type { MCPCatalogServer } from '$lib/services/chat/types';
 	import { mcpServersAndEntries } from '$lib/stores';
-	import { Check, LoaderCircle, Server } from 'lucide-svelte';
+	import { Check, Server } from 'lucide-svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 	import { fly } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -113,7 +114,7 @@
 				<label for="api-key-name" class="input-label">
 					Name
 					{#if nameError}
-						<span class="text-xs text-red-600 dark:text-red-400">Name is required</span>
+						<span class="text-xs text-error">Name is required</span>
 					{/if}
 				</label>
 				<input
@@ -123,7 +124,7 @@
 					placeholder="My API Key"
 					class={twMerge(
 						'text-input-filled',
-						nameError && 'border-red-500 focus:border-red-500 focus:ring-red-500'
+						nameError && 'border-error focus:border-error focus:ring-error'
 					)}
 				/>
 			</div>
@@ -151,9 +152,9 @@
 				<p class="input-description">Leave empty for no expiration</p>
 			</div>
 
-			<div class="flex flex-col gap-2">
-				<label class="input-label">Optional Capabilities</label>
-				<label class="bg-surface1 flex items-start gap-3 rounded-lg border p-3">
+			<div class="flex flex-col gap-2" role="group" aria-labelledby="api-key-optional-capabilities">
+				<div id="api-key-optional-capabilities" class="input-label">Optional Capabilities</div>
+				<label class="bg-base-200 flex items-start gap-3 rounded-lg border border-base-400 p-3">
 					<input type="checkbox" bind:checked={canAccessSkills} class="mt-1" />
 					<div class="flex flex-col gap-1">
 						<span class="text-sm font-medium">Allow skill access</span>
@@ -170,9 +171,7 @@
 		<p>
 			<span class="text-lg font-semibold">MCP Servers</span>
 			{#if serverError}
-				<span class="text-xs text-red-600 dark:text-red-400">
-					Select at least one server or enable skill access
-				</span>
+				<span class="text-xs text-error"> Select at least one server or enable skill access </span>
 			{/if}
 		</p>
 		<p class="input-description">
@@ -194,12 +193,12 @@
 
 		<div
 			class={twMerge(
-				'bg-surface1 default-scrollbar-thin flex max-h-64 flex-col overflow-y-auto rounded-lg',
-				serverError && 'ring-1 ring-red-500'
+				'bg-base-200 default-scrollbar-thin flex max-h-64 flex-col overflow-y-auto rounded-lg',
+				serverError && 'ring-1 ring-error'
 			)}
 		>
 			{#if filteredServers.length === 0}
-				<div class="text-on-surface1 flex items-center justify-center py-8 text-sm">
+				<div class="text-muted-content flex items-center justify-center py-8 text-sm">
 					{search ? 'No servers match your search' : 'No MCP servers available'}
 				</div>
 			{:else}
@@ -207,13 +206,13 @@
 					<button
 						type="button"
 						class={twMerge(
-							'hover:bg-surface2 flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors',
-							selectedServerIds.has(server.id) && 'bg-surface2'
+							'hover:bg-base-300 flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors',
+							selectedServerIds.has(server.id) && 'bg-base-300'
 						)}
 						onclick={() => toggleServer(server.id)}
 					>
 						<div class="flex w-full items-center gap-3 overflow-hidden">
-							<div class="flex-shrink-0">
+							<div class="shrink-0">
 								{#if server.manifest.icon}
 									<img
 										src={server.manifest.icon}
@@ -221,19 +220,19 @@
 										class="size-6"
 									/>
 								{:else}
-									<Server class="text-on-surface1 size-6" />
+									<Server class="text-muted-content size-6" />
 								{/if}
 							</div>
 							<div class="flex min-w-0 grow flex-col">
 								<p class="truncate text-sm">{getServerDisplayName(server)}</p>
 								{#if server.manifest.description}
-									<span class="text-on-surface1 line-clamp-1 text-xs">
+									<span class="text-muted-content line-clamp-1 text-xs">
 										{stripMarkdownToText(server.manifest.description)}
 									</span>
 								{/if}
 							</div>
 						</div>
-						<div class="flex size-5 flex-shrink-0 items-center justify-center">
+						<div class="flex size-5 shrink-0 items-center justify-center">
 							{#if selectedServerIds.has(server.id)}
 								<Check class="text-primary size-5" />
 							{/if}
@@ -247,15 +246,15 @@
 	<div class="flex grow"></div>
 
 	<div
-		class="bg-surface1 dark:bg-background dark:text-on-surface1 sticky bottom-0 left-0 flex w-full justify-end gap-2 py-4 text-gray-400"
+		class="bg-base-200 dark:bg-base-100 dark:text-muted-content sticky bottom-0 left-0 flex w-full justify-end gap-2 py-4 text-gray-400"
 		out:fly={{ x: -100, duration }}
 		in:fly={{ x: -100 }}
 	>
 		<div class="flex w-full justify-end gap-2">
-			<button class="button text-sm" onclick={onCancel}>Cancel</button>
-			<button class="button-primary text-sm" disabled={loading} onclick={handleCreate}>
+			<button class="btn btn-secondary text-sm" onclick={onCancel}>Cancel</button>
+			<button class="btn btn-primary text-sm" disabled={loading} onclick={handleCreate}>
 				{#if loading}
-					<LoaderCircle class="size-4 animate-spin" />
+					<Loading class="size-4" />
 				{:else}
 					Create API Key
 				{/if}

--- a/ui/user/src/routes/login_complete/+page.svelte
+++ b/ui/user/src/routes/login_complete/+page.svelte
@@ -5,9 +5,7 @@
 <main id="main-content" class="flex h-dvh justify-center">
 	<div class="relative mt-32 text-center">
 		<Logo class="mx-auto mb-4 size-72" />
-		<h1 class="text-on-background my-4 text-6xl font-extrabold">All Set!</h1>
-		<p class="text-on-background text-lg">
-			You can close this window and return to the application
-		</p>
+		<h1 class="text-base-content my-4 text-6xl font-extrabold">All Set!</h1>
+		<p class="text-base-content text-lg">You can close this window and return to the application</p>
 	</div>
 </main>

--- a/ui/user/src/routes/mcp-registries/+page.svelte
+++ b/ui/user/src/routes/mcp-registries/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import AccessControlRuleForm from '$lib/components/admin/AccessControlRuleForm.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { MCP_PUBLISHER_ALL_OPTION, PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import {
@@ -66,9 +66,9 @@
 			>
 				{#if accessControlRules.length === 0}
 					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-						<BookOpenText class="text-on-surface1 size-24 opacity-25" />
-						<h4 class="text-on-surface1 text-lg font-semibold">No created MCP registries.</h4>
-						<p class="text-on-surface1 text-sm font-light">
+						<BookOpenText class="text-base-content/80 size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">No created MCP registries.</h4>
+						<p class="text-muted-content text-sm font-light">
 							Looks like you don't have any registries created yet. <br />
 							Click the button below to get started.
 						</p>
@@ -91,16 +91,16 @@
 						]}
 					>
 						{#snippet actions(d)}
-							<button
-								class="icon-button hover:text-red-500"
+							<IconButton
+								variant="danger"
 								onclick={(e) => {
 									e.stopPropagation();
 									ruleToDelete = d;
 								}}
-								use:tooltip={'Delete Rule'}
+								tooltip={{ text: 'Delete Rule' }}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						{/snippet}
 						{#snippet onRenderColumn(property, d)}
 							{#if property === 'servers'}
@@ -126,7 +126,7 @@
 
 {#snippet addRuleButton()}
 	<button
-		class="button-primary flex items-center gap-1 text-sm"
+		class="btn btn-primary flex items-center gap-1 text-sm"
 		onclick={() => {
 			goto(`/mcp-registries?new=true`);
 		}}

--- a/ui/user/src/routes/mcp-servers/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/+page.svelte
@@ -89,7 +89,7 @@
 	);
 </script>
 
-<Layout classes={{ navbar: 'bg-surface1' }} {title} showBackButton={showServerForm}>
+<Layout classes={{ navbar: 'bg-base-200' }} {title} showBackButton={showServerForm}>
 	<div class="flex min-h-full flex-col gap-8" in:fade>
 		{#if showServerForm}
 			{@render configureEntryScreen()}
@@ -111,17 +111,17 @@
 		in:fly={{ x: 100, delay: duration, duration }}
 		out:fly={{ x: -100, duration }}
 	>
-		<div class="bg-surface1 dark:bg-background sticky top-16 left-0 z-20 w-full py-1">
+		<div class="bg-base-200 dark:bg-base-100 sticky top-16 left-0 z-20 w-full py-1">
 			<div class="mb-2">
 				<Search
-					class="dark:bg-surface1 dark:border-surface3 bg-background border border-transparent shadow-sm"
+					class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
 					value={registrySearchQuery}
 					onChange={updateSearchQuery}
 					placeholder="Search servers..."
 				/>
 			</div>
 		</div>
-		<div class="dark:bg-surface2 bg-background rounded-t-md shadow-sm">
+		<div class="dark:bg-base-300 bg-base-100 rounded-t-md shadow-sm">
 			<ConnectorsView
 				id={workspaceId}
 				entity="workspace"
@@ -142,9 +142,9 @@
 			>
 				{#snippet noDataContent()}
 					<div class="my-12 flex w-md flex-col items-center gap-4 self-center text-center">
-						<Server class="text-on-surface1 size-24 opacity-25" />
-						<h4 class="text-on-surface1 text-lg font-semibold">No created MCP servers</h4>
-						<p class="text-on-surface1 text-sm font-light">
+						<Server class="text-base-content/80 size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">No created MCP servers</h4>
+						<p class="text-muted-content text-sm font-light">
 							{#if isAtLeastPowerUser}
 								Looks like you don't have any servers created yet. <br />
 								Click the button below to get started.
@@ -192,7 +192,7 @@
 
 {#snippet addServerButton()}
 	<button
-		class="button-primary flex w-full items-center gap-1 text-sm md:w-fit"
+		class="btn btn-primary flex w-full items-center gap-1 text-sm md:w-fit"
 		onclick={() => {
 			selectServerTypeDialog?.open();
 		}}

--- a/ui/user/src/routes/mcp-servers/s/[id]/details/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/s/[id]/details/+page.svelte
@@ -4,9 +4,9 @@
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import OAuthMetadataDebug from '$lib/components/mcp/OAuthMetadataDebug.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, ChatService, type MCPServerInstance, type OrgUser } from '$lib/services';
 	import { profile } from '$lib/stores/index.js';
-	import { LoaderCircle } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -47,7 +47,7 @@
 	<div class="flex flex-col gap-6 pb-8" in:fly={{ x: 100, delay: PAGE_TRANSITION_DURATION }}>
 		{#if loading}
 			<div class="flex w-full justify-center">
-				<LoaderCircle class="size-6 animate-spin" />
+				<Loading class="size-6" />
 			</div>
 		{:else}
 			<div class="flex flex-col gap-6">

--- a/ui/user/src/routes/o/[project]/+page.svelte
+++ b/ui/user/src/routes/o/[project]/+page.svelte
@@ -102,7 +102,7 @@
 <div class="h-svh">
 	{#if project}
 		{#key project.id}
-			<div class="bg-surface1 flex size-full flex-col">
+			<div class="bg-base-200 flex size-full flex-col">
 				<div class="flex grow overflow-auto">
 					<div class="contents h-full grow border-r-0">
 						<div class="size-full overflow-clip rounded-none transition-all">

--- a/ui/user/src/routes/privacy-policy/+page.svelte
+++ b/ui/user/src/routes/privacy-policy/+page.svelte
@@ -81,8 +81,13 @@
 </script>
 
 {#snippet navLinks()}
-	<a href="https://docs.obot.ai" class="icon-button" rel="external" target="_blank">Docs</a>
-	<a href="https://discord.gg/9sSf4UyAMC" class="icon-button" rel="external" target="_blank">
+	<a href="https://docs.obot.ai" class="btn btn-secondary" rel="external" target="_blank">Docs</a>
+	<a
+		href="https://discord.gg/9sSf4UyAMC"
+		class="btn btn-ghost btn-square"
+		rel="external"
+		target="_blank"
+	>
 		{#if darkMode.isDark}
 			<img src="/user/images/discord-mark/discord-mark-white.svg" alt="Discord" class="h-6" />
 		{:else}
@@ -91,7 +96,7 @@
 	</a>
 	<a
 		href="https://github.com/obot-platform/obot"
-		class="icon-button"
+		class="btn btn-ghost btn-square"
 		rel="external"
 		target="_blank"
 	>
@@ -107,7 +112,7 @@
 	<title>Obot - Privacy Policy</title>
 </svelte:head>
 
-<div class="text-on-background relative flex h-dvh w-full flex-col">
+<div class="text-base-content relative flex h-dvh w-full flex-col">
 	<!-- Header with logo and navigation -->
 	<div class="colors-background flex h-16 w-full items-center p-5">
 		<div class="relative flex items-end">
@@ -118,7 +123,7 @@
 			{#if !responsive.isMobile}
 				{@render navLinks()}
 			{/if}
-			<button class="icon-button" onclick={() => goto('/?rd=/')}>Login</button>
+			<button class="btn btn-secondary" onclick={() => goto('/?rd=/')}>Login</button>
 			{#if responsive.isMobile}
 				<Menu
 					slide="left"
@@ -153,7 +158,7 @@
 			</h1>
 		</div>
 		<div class="relative mt-12 flex w-full gap-8">
-			<div class="hidden flex-shrink-0 flex-col text-base font-light md:flex md:w-xs lg:w-sm">
+			<div class="hidden shrink-0 flex-col text-base font-light md:flex md:w-xs lg:w-sm">
 				<ul class="sticky top-0 left-0 flex flex-col pt-8 pr-8">
 					{#each sectionHeaders as header (header.id)}
 						<li

--- a/ui/user/src/routes/s/[id]/+page.svelte
+++ b/ui/user/src/routes/s/[id]/+page.svelte
@@ -8,11 +8,11 @@
 	import { initProjectMCPs } from '$lib/context/projectMcps.svelte';
 	import { initProjectTools, getProjectTools } from '$lib/context/projectTools.svelte';
 	import { initToolReferences } from '$lib/context/toolReferences.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
 	import { type Assistant, ChatService, type Project } from '$lib/services';
 	import { profile, responsive } from '$lib/stores';
 	import { goto } from '$lib/url';
 	import { type PageProps } from './$types';
-	import { LoaderCircle } from 'lucide-svelte';
 	import { onMount, untrack } from 'svelte';
 
 	let { data }: PageProps = $props();
@@ -82,7 +82,7 @@
 <div class="flex h-dvh w-dvw flex-col">
 	{#if showWarning}
 		<div
-			class="bg-surface1 relative z-40 flex h-16 w-full items-center justify-between gap-4 p-3 shadow-md md:gap-8"
+			class="bg-base-200 relative z-40 flex h-16 w-full items-center justify-between gap-4 p-3 shadow-md md:gap-8"
 		>
 			<div class="flex shrink-0 items-center gap-2">
 				<Logo />
@@ -93,10 +93,10 @@
 		</div>
 		<div class="flex grow items-center justify-center">
 			<div
-				class="bg-surface1 dark:bg-surface2 flex h-full w-full flex-col items-center justify-center gap-4 p-5 md:h-fit md:max-w-md md:rounded-xl"
+				class="bg-base-200 dark:bg-base-300 flex h-full w-full flex-col items-center justify-center gap-4 p-5 md:h-fit md:max-w-md md:rounded-xl"
 			>
 				<div class="flex max-w-sm grow flex-col gap-4 text-center md:grow-0">
-					<h2 class="border-surface3 border-b pb-4 text-xl font-semibold">Shared Project</h2>
+					<h2 class="border-base-400 border-b pb-4 text-xl font-semibold">Shared Project</h2>
 					<p class="text-md">
 						This project was published by a third-party user and may include prompts or tools not
 						reviewed or verified by our team. It could interact with external systems, access
@@ -111,12 +111,12 @@
 					{/if}
 				</div>
 
-				<button class="button-primary mt-2 w-full" onclick={createProject}>I Understand</button>
-				<button class="button w-full" onclick={() => goto('/')}>Go Back</button>
+				<button class="btn btn-primary mt-2 w-full" onclick={createProject}>I Understand</button>
+				<button class="btn btn-secondary w-full" onclick={() => goto('/')}>Go Back</button>
 			</div>
 		</div>
 	{:else if project}
-		<div class="bg-surface1 flex size-full flex-col">
+		<div class="bg-base-200 flex size-full flex-col">
 			<div class="flex grow overflow-auto">
 				<div class="contents h-full grow border-r-0">
 					<div class="size-full overflow-clip rounded-none transition-all">
@@ -128,7 +128,7 @@
 	{:else}
 		<div class="flex grow items-center justify-center">
 			<div class="size-6">
-				<LoaderCircle class="text-primary size-6 animate-spin" />
+				<Loading class="size-6" />
 			</div>
 		</div>
 	{/if}

--- a/ui/user/src/routes/styles/+page.svelte
+++ b/ui/user/src/routes/styles/+page.svelte
@@ -1,42 +1,19 @@
 <script lang="ts">
-	import { Trash2 } from 'lucide-svelte';
 </script>
 
 <div class="flex h-dvh flex-col items-center justify-center gap-2 p-5">
 	<h2 class="self-center text-xl">Buttons</h2>
 	<div class="flex gap-2">
-		<button class="button">button</button>
-		<button class="button-secondary">button-secondary</button>
-		<button class="button-primary">button-primary</button>
-	</div>
-
-	<h2 class="mt-5 self-center text-xl">Icons</h2>
-	<div class="flex items-center gap-2">
-		<Trash2 class="icon-default" />
-		icon-default
-	</div>
-
-	<div class="flex items-center gap-2">
-		<button class="icon-button">
-			<Trash2 class="icon-default" />
-		</button>
-		icon-button
+		<button class="btn">button</button>
+		<button class="btn btn-secondary">btn-secondary</button>
+		<button class="btn btn-primary">btn-primary</button>
 	</div>
 
 	<div class="mt-5 flex flex-col gap-3">
 		<h2 class="self-center text-xl">Surfaces</h2>
 		<div class="colors grid grid-cols-4 gap-4">
-			<div class="bg-background text-on-background">
+			<div class="bg-base-100 text-base-content">
 				<span>background</span>
-			</div>
-			<div class="bg-surface1 text-on-surface1">
-				<span>surface1</span>
-			</div>
-			<div class="bg-surface2 text-on-surface2">
-				<span>surface2</span>
-			</div>
-			<div class="bg-surface3 text-on-surface3">
-				<span>surface3</span>
 			</div>
 		</div>
 	</div>
@@ -60,6 +37,6 @@
 		justify-content: center;
 		border-width: 2px;
 		border-style: dotted;
-		border-color: var(--on-background);
+		border-color: var(--color-base-content);
 	}
 </style>

--- a/ui/user/src/routes/t/[id]/+page.svelte
+++ b/ui/user/src/routes/t/[id]/+page.svelte
@@ -17,9 +17,9 @@
 	});
 </script>
 
-<div class="bg-surface1 dark:bg-background flex h-dvh w-dvw flex-col">
+<div class="bg-base-200 dark:bg-base-100 flex h-dvh w-dvw flex-col">
 	<div
-		class="bg-surface1 relative z-40 flex h-16 w-full items-center justify-between gap-4 p-3 shadow-md md:gap-8"
+		class="bg-base-200 relative z-40 flex h-16 w-full items-center justify-between gap-4 p-3 shadow-md md:gap-8"
 	>
 		<div class="flex shrink-0 items-center gap-2">
 			<Logo />

--- a/ui/user/src/routes/terms-of-service/+page.svelte
+++ b/ui/user/src/routes/terms-of-service/+page.svelte
@@ -70,8 +70,15 @@
 </script>
 
 {#snippet navLinks()}
-	<a href="https://docs.obot.ai" class="icon-button" rel="external" target="_blank">Docs</a>
-	<a href="https://discord.gg/9sSf4UyAMC" class="icon-button" rel="external" target="_blank">
+	<a href="https://docs.obot.ai" class="btn btn-ghost btn-squaren" rel="external" target="_blank"
+		>Docs</a
+	>
+	<a
+		href="https://discord.gg/9sSf4UyAMC"
+		class="btn btn-ghost btn-square"
+		rel="external"
+		target="_blank"
+	>
 		{#if darkMode.isDark}
 			<img src="/user/images/discord-mark/discord-mark-white.svg" alt="Discord" class="h-6" />
 		{:else}
@@ -80,7 +87,7 @@
 	</a>
 	<a
 		href="https://github.com/obot-platform/obot"
-		class="icon-button"
+		class="btn btn-ghost btn-square"
 		rel="external"
 		target="_blank"
 	>
@@ -107,7 +114,7 @@
 			{#if !responsive.isMobile}
 				{@render navLinks()}
 			{/if}
-			<button class="icon-button" onclick={() => goto('/?rd=/')}>Login</button>
+			<button class="btn btn-secondary" onclick={() => goto('/?rd=/')}>Login</button>
 			{#if responsive.isMobile}
 				<Menu
 					slide="left"
@@ -142,7 +149,7 @@
 			</h1>
 		</div>
 		<div class="relative mt-12 flex w-full gap-8">
-			<div class="hidden flex-shrink-0 flex-col text-base font-light md:flex md:w-xs lg:w-sm">
+			<div class="hidden shrink-0 flex-col text-base font-light md:flex md:w-xs lg:w-sm">
 				<ul class="sticky top-0 left-0 flex flex-col pt-8 pr-8">
 					{#each sectionHeaders as header (header.id)}
 						<li


### PR DESCRIPTION
Addresses #5785 
Addresses #5152 

* removes/replaces no longer needed css vars in lieu of DaisyUI vars
* cleanup of deprecated/lint warning from dependency upgrades (ex. lucide icon deprecation / tailwind class name changes such as `flex-shrink-0` -> `shrink-0`) 
* component updates based on what's available in DaisyUI etc.

* removed instances of hardcoded styled buttons to appropriate btn-primary, btn-secondary, etc.
* surfaces with hardcoded color values changed to a surface var when makes sense

* also updates Branding page to reflect DaisyUI changes & allow more customization

Please post any inconsistencies or things I have missed! Will continually keep up to date as PRs get merged.

"Branding Page" (WIP):

<img width="1665" height="965" alt="Screenshot 2026-05-06 at 7 03 18 PM" src="https://github.com/user-attachments/assets/d03cfdc6-1080-4590-8f9c-87531da0358b" />

---

<img width="1660" height="962" alt="Screenshot 2026-05-06 at 7 03 30 PM" src="https://github.com/user-attachments/assets/846bde22-6ada-42bf-8874-b8a94dd2cdf7" />

---

<img width="1663" height="965" alt="Screenshot 2026-05-06 at 7 03 53 PM" src="https://github.com/user-attachments/assets/1c9f23ff-5da7-4080-94d7-83a3881ba70d" />


---

* minor: also some tightening of ui whitespace
* example: the space when creating a server or empty white space in audit logs/usage view where filters could fill up
* using `@container` styling to make sure things adjust appropriately based on container size with sidebar open
<img width="1228" height="309" alt="Screenshot 2026-05-06 at 4 21 50 PM" src="https://github.com/user-attachments/assets/4b552ed7-b4fc-4496-a036-fec21a3de852" />
<img width="1234" height="307" alt="Screenshot 2026-05-06 at 4 21 41 PM" src="https://github.com/user-attachments/assets/52c1076b-0368-4afb-ba9e-912d65ba59b1" />

---
<img width="1236" height="385" alt="Screenshot 2026-05-06 at 4 25 54 PM" src="https://github.com/user-attachments/assets/5049d325-89bd-4db1-8ede-48a1c5cf3bd6" />
<img width="1229" height="443" alt="Screenshot 2026-05-06 at 4 25 41 PM" src="https://github.com/user-attachments/assets/63c07ff4-2672-4626-bfb3-e94d115e5319" />




