### PR TITLE
fix: filters ui with basic auditors role

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -177,6 +177,8 @@ var (
 			"GET /api/group-role-assignments",
 			"GET /api/group-role-assignments/",
 			"GET /api/mcp-catalogs/",
+			"GET /api/system-mcp-catalogs",
+			"GET /api/system-mcp-catalogs/",
 			"GET /api/mcp-webhook-validations",
 			"GET /api/mcp-webhook-validations/",
 			"GET /api/mcp-servers/",

--- a/ui/user/src/lib/components/admin/FilterForm.svelte
+++ b/ui/user/src/lib/components/admin/FilterForm.svelte
@@ -160,7 +160,7 @@
 	});
 
 	async function revealServerValues() {
-		if (!initialFilterId) return;
+		if (!initialFilterId || readonly) return;
 		try {
 			const response = await AdminService.revealMCPFilter(initialFilterId);
 

--- a/ui/user/src/routes/admin/filters/+page.svelte
+++ b/ui/user/src/routes/admin/filters/+page.svelte
@@ -211,6 +211,7 @@
 		</button>
 		<button
 			class="menu-button"
+			disabled={systemCatalogEntries.length === 0}
 			onclick={() => {
 				builtInFiltersDialog?.open();
 			}}

--- a/ui/user/src/routes/admin/filters/BuiltInFilters.svelte
+++ b/ui/user/src/routes/admin/filters/BuiltInFilters.svelte
@@ -57,7 +57,7 @@
 			</button>
 		{/snippet}
 	</Table>
-{:else}
+{:else if filteredBuiltInFiltersData.length > 0}
 	<div class="p-4 md:p-0">
 		<button
 			class="p-4 rounded-sm flex items-center gap-6 justify-between bg-background dark:bg-surface1 shadow-md transition-colors duration-300 hover:bg-surface2 dark:hover:bg-surface2"
@@ -72,6 +72,6 @@
 			<StepForward class="size-4 shrink-0 text-on-surface1" />
 		</button>
 	</div>
-{/if}
 
-<div class="text-on-surface1 text-sm font-light mt-4 text-center italic">More Coming Soon!</div>
+	<div class="text-on-surface1 text-sm font-light mt-4 text-center italic">More Coming Soon!</div>
+{/if}


### PR DESCRIPTION
- Correct auditor access to filters (stops 403 on filter button)
- Stop making reveal credential calls in readonly filter view (403 at `/admin/filters/{id}`)
- Disable builtin option in create filter button (broken modal)

Addresses: https://github.com/obot-platform/obot/issues/6477

