### PR TITLE
fix: configure multi-user MCP secrets after create

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -103,7 +103,7 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to migrate published artifact visibility: %w", err)
 	}
 
-	if err := migrateMCPServerManifestValuesToCredentials(ctx, c.services.StorageClient, c.services.GPTClient); err != nil {
+	if err := migrateMultiUserMCPServerManifestValuesToCredentials(ctx, c.services.StorageClient, c.services.GPTClient); err != nil {
 		return fmt.Errorf("failed to migrate MCP server manifest values to credentials: %w", err)
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -103,6 +103,10 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to migrate published artifact visibility: %w", err)
 	}
 
+	if err := migrateMCPServerManifestValuesToCredentials(ctx, c.services.StorageClient, c.services.GPTClient); err != nil {
+		return fmt.Errorf("failed to migrate MCP server manifest values to credentials: %w", err)
+	}
+
 	// Ensure PowerUserWorkspaces exist for all admin users on startup
 	if err := c.adminWorkspaceHandler.EnsureAllAdminAndOwnerWorkspaces(ctx, c.services.StorageClient, system.DefaultNamespace); err != nil {
 		return fmt.Errorf("failed to ensure admin workspaces: %w", err)

--- a/pkg/controller/migrate.go
+++ b/pkg/controller/migrate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/obot/apiclient/types"
@@ -11,8 +12,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-const mcpServerManifestValuesCredentialMigrationName = "mcp_server_manifest_values_to_credentials"
 
 func addCatalogIDToAccessControlRules(ctx context.Context, client kclient.Client) error {
 	var acRules v1.AccessControlRuleList
@@ -73,7 +72,7 @@ func migratePublishedArtifactVisibility(ctx context.Context, client kclient.Clie
 	return nil
 }
 
-func migrateMCPServerManifestValuesToCredentials(ctx context.Context, client kclient.Client, gptClient *gptscript.GPTScript) error {
+func migrateMultiUserMCPServerManifestValuesToCredentials(ctx context.Context, client kclient.Client, gptClient *gptscript.GPTScript) error {
 	var servers v1.MCPServerList
 	if err := client.List(ctx, &servers); err != nil {
 		return err
@@ -92,19 +91,21 @@ func migrateMCPServerManifestValuesToCredentials(ctx context.Context, client kcl
 		}
 
 		if len(configValues) > 0 {
-			if _, err := gptClient.RevealCredential(ctx, []string{credCtx}, server.Name); err != nil {
-				if !errors.As(err, &gptscript.ErrNotFound{}) {
-					return fmt.Errorf("failed to find credential for MCP server %s: %w", server.Name, err)
-				}
+			if existingCred, err := gptClient.RevealCredential(ctx, []string{credCtx}, server.Name); err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
+				return fmt.Errorf("failed to find credential for MCP server %s: %w", server.Name, err)
+			} else if err == nil {
+				// Copy the new config values into the existing credential values so we don't lose any existing values that aren't in the manifest.
+				maps.Copy(existingCred.Env, configValues)
+				configValues = existingCred.Env
+			}
 
-				if err := gptClient.CreateCredential(ctx, gptscript.Credential{
-					Context:  credCtx,
-					ToolName: server.Name,
-					Type:     gptscript.CredentialTypeTool,
-					Env:      configValues,
-				}); err != nil {
-					return fmt.Errorf("failed to create credential for MCP server %s: %w", server.Name, err)
-				}
+			if err := gptClient.CreateCredential(ctx, gptscript.Credential{
+				Context:  credCtx,
+				ToolName: server.Name,
+				Type:     gptscript.CredentialTypeTool,
+				Env:      configValues,
+			}); err != nil {
+				return fmt.Errorf("failed to create credential for MCP server %s: %w", server.Name, err)
 			}
 		}
 

--- a/pkg/controller/migrate.go
+++ b/pkg/controller/migrate.go
@@ -2,12 +2,17 @@ package controller
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/gptscript-ai/go-gptscript"
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const mcpServerManifestValuesCredentialMigrationName = "mcp_server_manifest_values_to_credentials"
 
 func addCatalogIDToAccessControlRules(ctx context.Context, client kclient.Client) error {
 	var acRules v1.AccessControlRuleList
@@ -66,4 +71,87 @@ func migratePublishedArtifactVisibility(ctx context.Context, client kclient.Clie
 	}
 
 	return nil
+}
+
+func migrateMCPServerManifestValuesToCredentials(ctx context.Context, client kclient.Client, gptClient *gptscript.GPTScript) error {
+	var servers v1.MCPServerList
+	if err := client.List(ctx, &servers); err != nil {
+		return err
+	}
+
+	for i := range servers.Items {
+		server := &servers.Items[i]
+		credCtx := mcpServerCredentialContext(*server)
+		if credCtx == "" {
+			continue
+		}
+
+		configValues, changed := extractAndClearMCPServerConfigValues(&server.Spec.Manifest)
+		if !changed {
+			continue
+		}
+
+		if len(configValues) > 0 {
+			if _, err := gptClient.RevealCredential(ctx, []string{credCtx}, server.Name); err != nil {
+				if !errors.As(err, &gptscript.ErrNotFound{}) {
+					return fmt.Errorf("failed to find credential for MCP server %s: %w", server.Name, err)
+				}
+
+				if err := gptClient.CreateCredential(ctx, gptscript.Credential{
+					Context:  credCtx,
+					ToolName: server.Name,
+					Type:     gptscript.CredentialTypeTool,
+					Env:      configValues,
+				}); err != nil {
+					return fmt.Errorf("failed to create credential for MCP server %s: %w", server.Name, err)
+				}
+			}
+		}
+
+		if err := client.Update(ctx, server); err != nil {
+			return fmt.Errorf("failed to clear manifest config values for MCP server %s: %w", server.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func mcpServerCredentialContext(server v1.MCPServer) string {
+	switch {
+	case server.Spec.MCPCatalogID != "":
+		return fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
+	case server.Spec.PowerUserWorkspaceID != "":
+		return fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
+	default:
+		return ""
+	}
+}
+
+func extractAndClearMCPServerConfigValues(manifest *types.MCPServerManifest) (map[string]string, bool) {
+	configValues := make(map[string]string)
+	var changed bool
+
+	for i := range manifest.Env {
+		if manifest.Env[i].Value != "" {
+			if manifest.Env[i].Key != "" {
+				configValues[manifest.Env[i].Key] = manifest.Env[i].Value
+			}
+			manifest.Env[i].Value = ""
+			changed = true
+		}
+	}
+
+	if manifest.RemoteConfig != nil {
+		for i := range manifest.RemoteConfig.Headers {
+			if manifest.RemoteConfig.Headers[i].Value != "" {
+				if manifest.RemoteConfig.Headers[i].Key != "" {
+					configValues[manifest.RemoteConfig.Headers[i].Key] = manifest.RemoteConfig.Headers[i].Value
+				}
+				manifest.RemoteConfig.Headers[i].Value = ""
+				changed = true
+			}
+		}
+	}
+
+	return configValues, changed
 }

--- a/pkg/controller/migrate_test.go
+++ b/pkg/controller/migrate_test.go
@@ -126,3 +126,87 @@ func TestMigratePublishedArtifactVisibility(t *testing.T) {
 		assert.Empty(t, publicArtifact.Status.Versions[0].Subjects)
 	})
 }
+
+func TestExtractAndClearMCPServerConfigValues(t *testing.T) {
+	manifest := types.MCPServerManifest{
+		Env: []types.MCPEnv{
+			{
+				MCPHeader: types.MCPHeader{
+					Key:   "TOKEN",
+					Value: "secret-token",
+				},
+			},
+			{
+				MCPHeader: types.MCPHeader{
+					Key: "EMPTY",
+				},
+			},
+			{
+				MCPHeader: types.MCPHeader{
+					Value: "missing-key",
+				},
+			},
+		},
+		RemoteConfig: &types.RemoteRuntimeConfig{
+			Headers: []types.MCPHeader{
+				{
+					Key:   "Authorization",
+					Value: "Bearer secret",
+				},
+				{
+					Key: "X-Empty",
+				},
+			},
+		},
+	}
+
+	values, changed := extractAndClearMCPServerConfigValues(&manifest)
+
+	assert.True(t, changed)
+	assert.Equal(t, map[string]string{
+		"TOKEN":         "secret-token",
+		"Authorization": "Bearer secret",
+	}, values)
+	assert.Empty(t, manifest.Env[0].Value)
+	assert.Empty(t, manifest.Env[1].Value)
+	assert.Empty(t, manifest.Env[2].Value)
+	assert.Empty(t, manifest.RemoteConfig.Headers[0].Value)
+	assert.Empty(t, manifest.RemoteConfig.Headers[1].Value)
+}
+
+func TestExtractAndClearMCPServerConfigValuesNoValues(t *testing.T) {
+	manifest := types.MCPServerManifest{
+		Env: []types.MCPEnv{
+			{
+				MCPHeader: types.MCPHeader{
+					Key: "TOKEN",
+				},
+			},
+		},
+	}
+
+	values, changed := extractAndClearMCPServerConfigValues(&manifest)
+
+	assert.False(t, changed)
+	assert.Empty(t, values)
+}
+
+func TestMCPServerCredentialContext(t *testing.T) {
+	assert.Equal(t, "default-server-1", mcpServerCredentialContext(v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "server-1"},
+		Spec: v1.MCPServerSpec{
+			MCPCatalogID: "default",
+		},
+	}))
+
+	assert.Equal(t, "workspace-1-server-2", mcpServerCredentialContext(v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "server-2"},
+		Spec: v1.MCPServerSpec{
+			PowerUserWorkspaceID: "workspace-1",
+		},
+	}))
+
+	assert.Empty(t, mcpServerCredentialContext(v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "server-3"},
+	}))
+}

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -24,7 +24,7 @@ const (
 type Client struct {
 	db                      *db.DB
 	encryptionConfig        *encryptionconfig.EncryptionConfiguration
-	emailsWithExplictRoles  map[string]types2.Role
+	emailsWithExplicitRoles map[string]types2.Role
 	auditLock               sync.Mutex
 	auditBuffer             []types.MCPAuditLog
 	kickAuditPersist        chan struct{}
@@ -53,7 +53,7 @@ func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptio
 	c := &Client{
 		db:                      db,
 		encryptionConfig:        encryptionConfig,
-		emailsWithExplictRoles:  explicitRoleEmailsSet,
+		emailsWithExplicitRoles: explicitRoleEmailsSet,
 		auditBuffer:             make([]types.MCPAuditLog, 0, 2*auditLogBatchSize),
 		kickAuditPersist:        make(chan struct{}),
 		storageClient:           storageClient,
@@ -82,12 +82,12 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) HasExplicitRole(email string) types2.Role {
-	return c.emailsWithExplictRoles[strings.ToLower(email)]
+	return c.emailsWithExplicitRoles[strings.ToLower(email)]
 }
 
 // GetExplicitRoleEmails returns a copy of all emails with explicit roles.
 // Used by setup endpoints to list Owner and Admin emails.
 func (c *Client) GetExplicitRoleEmails() map[string]types2.Role {
 	// No lock needed - map is immutable after construction
-	return maps.Clone(c.emailsWithExplictRoles)
+	return maps.Clone(c.emailsWithExplicitRoles)
 }

--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -53,7 +53,7 @@ func (c *Client) FindIdentitiesForUser(ctx context.Context, userID uint) ([]type
 
 // EnsureIdentity ensures that the given identity exists in the database, and returns the user associated with it.
 func (c *Client) EnsureIdentity(ctx context.Context, id *types.Identity, timezone string) (*types.User, error) {
-	return c.EnsureIdentityWithRole(ctx, id, timezone, c.emailsWithExplictRoles[strings.ToLower(id.Email)])
+	return c.EnsureIdentityWithRole(ctx, id, timezone, c.emailsWithExplicitRoles[strings.ToLower(id.Email)])
 }
 
 // EnsureIdentityWithRole ensures the given identity exists in the database with the at least the given role, and returns the user associated with it.

--- a/pkg/gateway/db/db.go
+++ b/pkg/gateway/db/db.go
@@ -56,7 +56,7 @@ func (db *DB) AutoMigrate() (err error) {
 		return fmt.Errorf("failed to drop mcp_server_instance table: %w", err)
 	}
 
-	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "auditor_user_role", migrateUserRoles); err != nil {
+	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "auditor_user_role", migrateUserRoles); err != nil {
 		return fmt.Errorf("failed to migrate user roles: %w", err)
 	}
 
@@ -64,23 +64,23 @@ func (db *DB) AutoMigrate() (err error) {
 		return fmt.Errorf("failed to migrate mcp_audit_log client info: %w", err)
 	}
 
-	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "drop_session_cookies", dropSessionCookiesTable); err != nil {
+	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "drop_session_cookies", dropSessionCookiesTable); err != nil {
 		return fmt.Errorf("failed to drop session_cookies table: %w", err)
 	}
 
-	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "remove_github_groups", removeGitHubGroups); err != nil {
+	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "remove_github_groups", removeGitHubGroups); err != nil {
 		return fmt.Errorf("failed to remove GitHub groups: %w", err)
 	}
 
-	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "drop_obot_mcp_tokens", dropObotMCPTokensTable); err != nil {
+	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "drop_obot_mcp_tokens", dropObotMCPTokensTable); err != nil {
 		return fmt.Errorf("failed to drop obot_mcp_tokens table: %w", err)
 	}
 
-	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "drop_mcp_oauth_token_state_columns", dropMCPOAuthTokenStateColumns); err != nil {
+	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "drop_mcp_oauth_token_state_columns", dropMCPOAuthTokenStateColumns); err != nil {
 		return fmt.Errorf("failed to drop state columns from mcp_oauth_tokens: %w", err)
 	}
 
-	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "apikey_skills_access_backfill", migrateAPIKeySkillsAccess); err != nil {
+	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "apikey_skills_access_backfill", migrateAPIKeySkillsAccess); err != nil {
 		return fmt.Errorf("failed to migrate API key skills access: %w", err)
 	}
 

--- a/pkg/gateway/db/db.go
+++ b/pkg/gateway/db/db.go
@@ -56,7 +56,7 @@ func (db *DB) AutoMigrate() (err error) {
 		return fmt.Errorf("failed to drop mcp_server_instance table: %w", err)
 	}
 
-	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "auditor_user_role", migrateUserRoles); err != nil {
+	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "auditor_user_role", migrateUserRoles); err != nil {
 		return fmt.Errorf("failed to migrate user roles: %w", err)
 	}
 
@@ -64,23 +64,23 @@ func (db *DB) AutoMigrate() (err error) {
 		return fmt.Errorf("failed to migrate mcp_audit_log client info: %w", err)
 	}
 
-	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "drop_session_cookies", dropSessionCookiesTable); err != nil {
+	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "drop_session_cookies", dropSessionCookiesTable); err != nil {
 		return fmt.Errorf("failed to drop session_cookies table: %w", err)
 	}
 
-	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "remove_github_groups", removeGitHubGroups); err != nil {
+	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "remove_github_groups", removeGitHubGroups); err != nil {
 		return fmt.Errorf("failed to remove GitHub groups: %w", err)
 	}
 
-	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "drop_obot_mcp_tokens", dropObotMCPTokensTable); err != nil {
+	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "drop_obot_mcp_tokens", dropObotMCPTokensTable); err != nil {
 		return fmt.Errorf("failed to drop obot_mcp_tokens table: %w", err)
 	}
 
-	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "drop_mcp_oauth_token_state_columns", dropMCPOAuthTokenStateColumns); err != nil {
+	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "drop_mcp_oauth_token_state_columns", dropMCPOAuthTokenStateColumns); err != nil {
 		return fmt.Errorf("failed to drop state columns from mcp_oauth_tokens: %w", err)
 	}
 
-	if err = migrateIfEntryNotFoundInMigrationsTable(tx, "apikey_skills_access_backfill", migrateAPIKeySkillsAccess); err != nil {
+	if err = MigrateIfEntryNotFoundInMigrationsTable(tx, "apikey_skills_access_backfill", migrateAPIKeySkillsAccess); err != nil {
 		return fmt.Errorf("failed to migrate API key skills access: %w", err)
 	}
 

--- a/pkg/gateway/db/migrations.go
+++ b/pkg/gateway/db/migrations.go
@@ -216,9 +216,9 @@ func dropMCPOAuthTokenStateColumns(tx *gorm.DB) error {
 	return nil
 }
 
-// MigrateIfEntryNotFoundInMigrationsTable runs f only when the named migration
+// migrateIfEntryNotFoundInMigrationsTable runs f only when the named migration
 // has not already been recorded in the migrations table.
-func MigrateIfEntryNotFoundInMigrationsTable(tx *gorm.DB, name string, f func(*gorm.DB) error) error {
+func migrateIfEntryNotFoundInMigrationsTable(tx *gorm.DB, name string, f func(*gorm.DB) error) error {
 	var migration types.Migration
 	if err := tx.Where("name = ?", name).First(&migration).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
 		return err

--- a/pkg/gateway/db/migrations.go
+++ b/pkg/gateway/db/migrations.go
@@ -216,7 +216,9 @@ func dropMCPOAuthTokenStateColumns(tx *gorm.DB) error {
 	return nil
 }
 
-func migrateIfEntryNotFoundInMigrationsTable(tx *gorm.DB, name string, f func(*gorm.DB) error) error {
+// MigrateIfEntryNotFoundInMigrationsTable runs f only when the named migration
+// has not already been recorded in the migrations table.
+func MigrateIfEntryNotFoundInMigrationsTable(tx *gorm.DB, name string, f func(*gorm.DB) error) error {
 	var migration types.Migration
 	if err := tx.Where("name = ?", name).First(&migration).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
 		return err

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -373,6 +373,30 @@
 		return manifest;
 	}
 
+	function omitSecretValuesFromServerManifest(
+		serverManifest: ReturnType<typeof convertServerRuntimeFormDataToManifest>
+	): ReturnType<typeof convertServerRuntimeFormDataToManifest> {
+		const manifest = { ...serverManifest.manifest };
+		if (manifest.env) {
+			manifest.env = manifest.env.map(
+				(env) =>
+					Object.fromEntries(Object.entries(env).filter(([key]) => key !== 'value')) as typeof env
+			);
+		}
+		if (manifest.remoteConfig?.headers) {
+			manifest.remoteConfig = {
+				...manifest.remoteConfig,
+				headers: manifest.remoteConfig.headers.map(
+					(header) =>
+						Object.fromEntries(
+							Object.entries(header).filter(([key]) => key !== 'value')
+						) as typeof header
+				)
+			};
+		}
+		return { ...serverManifest, manifest };
+	}
+
 	async function handleEntrySubmit(id: string) {
 		const manifest = convertToEntryManifest(formData);
 
@@ -404,13 +428,17 @@
 				entity === 'workspace'
 					? ChatService.updateWorkspaceMCPCatalogServer
 					: AdminService.updateMCPCatalogServer;
-			response = await updateServerFn(id, entry.id, serverManifest.manifest);
+			response = await updateServerFn(
+				id,
+				entry.id,
+				omitSecretValuesFromServerManifest(serverManifest).manifest
+			);
 		} else {
 			const createServerFn =
 				entity === 'workspace'
 					? ChatService.createWorkspaceMCPCatalogServer
 					: AdminService.createMCPCatalogServer;
-			response = await createServerFn(id, serverManifest);
+			response = await createServerFn(id, omitSecretValuesFromServerManifest(serverManifest));
 		}
 
 		let configValues: Record<string, string> = {};

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -378,20 +378,16 @@
 	): ReturnType<typeof convertServerRuntimeFormDataToManifest> {
 		const manifest = { ...serverManifest.manifest };
 		if (manifest.env) {
-			manifest.env = manifest.env.map(
-				(env) =>
-					Object.fromEntries(Object.entries(env).filter(([key]) => key !== 'value')) as typeof env
-			);
+			manifest.env = manifest.env.map(({ value: _value, ...rest }) => {
+				return { value: '', ...rest };
+			});
 		}
 		if (manifest.remoteConfig?.headers) {
 			manifest.remoteConfig = {
 				...manifest.remoteConfig,
-				headers: manifest.remoteConfig.headers.map(
-					(header) =>
-						Object.fromEntries(
-							Object.entries(header).filter(([key]) => key !== 'value')
-						) as typeof header
-				)
+				headers: manifest.remoteConfig.headers.map(({ value: _value, ...rest }) => {
+					return { value: '', ...rest };
+				})
 			};
 		}
 		return { ...serverManifest, manifest };


### PR DESCRIPTION
This change also migrates existing multi-user MCP servers to store their cofiguration in credentials.

Issue: https://github.com/obot-platform/sensitive-issues/issues/66