### PR TITLE
Update docs for GITHUB_AUTH_TOKEN clone catalogs

### DIFF
--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -53,7 +53,7 @@ To pull from a private repository, enter a **Personal access token** in the opti
 - **GitHub**: `repo` (read access is sufficient)
 - **GitLab**: `read_repository` (clone access) + `read_api` (pre-clone size check)
 
-If no per-URL token is configured, Obot falls back to the `GITHUB_AUTH_TOKEN` environment variable only when the catalog URL matches the default GitHub catalog URL. Other GitHub repository URLs require a token to be configured for that URL.
+If no per-URL token is configured, Obot falls back to the `GITHUB_AUTH_TOKEN` environment variable.
 
 ## Configuration Format
 

--- a/docs/versioned_docs/version-v0.20.0/configuration/mcp-server-gitops.md
+++ b/docs/versioned_docs/version-v0.20.0/configuration/mcp-server-gitops.md
@@ -47,7 +47,7 @@ To pull from a private repository, enter a **Personal access token** in the opti
 - **GitHub**: `repo` (read access is sufficient)
 - **GitLab**: `read_repository` (clone access) + `read_api` (pre-clone size check)
 
-If no per-URL token is configured, Obot falls back to the `GITHUB_AUTH_TOKEN` environment variable only when the catalog URL matches the default GitHub catalog URL. Other GitHub repository URLs require a token to be configured for that URL.
+If no per-URL token is configured, Obot falls back to the `GITHUB_AUTH_TOKEN` environment variable.
 
 ## Configuration Format
 

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -81,8 +81,17 @@
 
 			<div class="mb-4 flex flex-col gap-1">
 				<div class="flex items-center justify-between">
-					<label for="catalog-source-token" class="text-sm font-light"
-						>Personal access token (optional)
+					<label for="catalog-source-token" class="flex items-center gap-1 text-sm font-light">
+						Personal access token (optional)
+						<span
+							use:tooltip={{
+								text: 'Required scopes:\n• GitHub: repo\n• GitLab: read_repository + read_api\n\nIf no token is set, Obot falls back to the GITHUB_AUTH_TOKEN environment variable.',
+								classes: ['max-w-md', 'whitespace-pre-line'],
+								disablePortal: true
+							}}
+						>
+							<Info class="text-surface3 size-3.5" />
+						</span>
 					</label>
 					{#if editingSource.index >= 0 && defaultCatalog?.sourceURLCredentials?.[defaultCatalog?.sourceURLs?.[editingSource.index]] === '*' && !editingSource.clearToken}
 						<button


### PR DESCRIPTION
Update documentation for `GITHUB_AUTH_TOKEN` usage and add tooltip in UI