### PR TITLE
fix: existing mcp server configuration form & consistent save behavior

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -33,7 +33,11 @@
 		type?: LaunchServerType;
 		readonly?: boolean;
 		onCancel?: () => void;
-		onSubmit?: (id: string, type: LaunchServerType, message?: string) => void;
+		onSubmit?: (
+			data: MCPCatalogEntry | MCPCatalogServer,
+			type: LaunchServerType,
+			message?: string
+		) => void;
 		hideTitle?: boolean;
 		readonlyMessage?: Snippet;
 		onConfigureOAuth?: () => void;
@@ -498,30 +502,26 @@
 			// Check if OAuth config is needed - redirect to detail page first, then show modal there
 			if (!entry && type === 'remote' && formData.remoteConfig?.staticOAuthRequired) {
 				loading = false;
-				onSubmit?.(entryResponse.id, type, 'requires-oauth-config');
+				onSubmit?.(entryResponse, type, 'requires-oauth-config');
 				return;
 			}
 
-			if (isAtLeastPowerUserPlus) {
-				const existingRules =
-					entity === 'workspace'
-						? await ChatService.listWorkspaceAccessControlRules(id)
-						: await AdminService.listAccessControlRules();
-				const hasEverythingEveryoneRule = existingRules.some(
-					(rule) =>
-						rule.subjects?.some((s) => s.id === '*') && rule.resources?.some((r) => r.id === '*')
-				);
-
-				if (!entry && !hasEverythingEveryoneRule) {
-					await selectRulesDialog?.open();
-					loading = false;
-				} else {
-					loading = false;
-					onSubmit?.(entryResponse.id, type, 'MCP server updated successfully!');
-				}
+			const existingRules = isAtLeastPowerUserPlus
+				? entity === 'workspace'
+					? await ChatService.listWorkspaceAccessControlRules(id)
+					: await AdminService.listAccessControlRules()
+				: [];
+			const hasEverythingEveryoneRule = existingRules.some(
+				(rule) =>
+					rule.subjects?.some((s) => s.id === '*') && rule.resources?.some((r) => r.id === '*')
+			);
+			if (isAtLeastPowerUserPlus && !entry && !hasEverythingEveryoneRule) {
+				await selectRulesDialog?.open();
+				loading = false;
 			} else {
 				loading = false;
-				onSubmit?.(entryResponse.id, type, 'MCP server updated successfully!');
+				formData = convertToFormData(entryResponse);
+				onSubmit?.(entryResponse, type, 'MCP server updated successfully!');
 			}
 		} catch (error) {
 			loading = false;
@@ -681,7 +681,7 @@
 	entry={savedEntry}
 	onSubmit={() => {
 		if (savedEntry) {
-			onSubmit?.(savedEntry.id, type);
+			onSubmit?.(savedEntry, type);
 		}
 	}}
 	{entity}

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -85,6 +85,16 @@
 	}: Props = $props();
 
 	let entry = $state(untrack(() => initialEntry));
+	let lastSyncedInitialEntry = $state<MCPCatalogEntry | MCPCatalogServer | undefined>(undefined);
+
+	$effect(() => {
+		const next = initialEntry;
+		if (next !== lastSyncedInitialEntry) {
+			lastSyncedInitialEntry = next;
+			entry = next;
+		}
+	});
+
 	let isAtLeastPowerUserPlus = $derived(profile.current?.groups.includes(Group.POWERUSER_PLUS));
 
 	// True owner: admin, workspace owner, or power user who created the server

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -16,6 +16,7 @@
 	import type { AccessControlRule, MCPCatalogEntry, OrgUser } from '$lib/services/admin/types';
 	import { getServerTypeLabel, getUserRegistry } from '$lib/services/chat/mcp';
 	import { profile } from '$lib/stores';
+	import { success } from '$lib/stores/success';
 	import { goto } from '$lib/url';
 	import { openUrl, isOwnSingleUserServer } from '$lib/utils';
 	import Confirm from '../Confirm.svelte';
@@ -50,7 +51,7 @@
 		Users,
 		Wrench
 	} from 'lucide-svelte';
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -69,7 +70,7 @@
 	}
 
 	let {
-		entry,
+		entry: initialEntry,
 		server,
 		id,
 		entity = 'catalog',
@@ -82,6 +83,8 @@
 		limitViews,
 		configuredServers
 	}: Props = $props();
+
+	let entry = $state(untrack(() => initialEntry));
 	let isAtLeastPowerUserPlus = $derived(profile.current?.groups.includes(Group.POWERUSER_PLUS));
 
 	// True owner: admin, workspace owner, or power user who created the server
@@ -230,14 +233,18 @@
 	function filterRulesByEntry(rules?: AccessControlRule[]) {
 		if (!entry || !rules) return [];
 		return rules.filter((r) =>
-			r.resources?.find((resource) => resource.id === entry.id || resource.id === '*')
+			r.resources?.find(
+				(resource) => (entry?.id && resource.id === entry.id) || resource.id === '*'
+			)
 		);
 	}
 
 	function filterFiltersByEntry(filters?: MCPFilter[]) {
 		if (!entry || !filters) return [];
 		return filters.filter((f) =>
-			f.resources?.find((resource) => resource.id === entry.id || resource.id === '*')
+			f.resources?.find(
+				(resource) => (entry?.id && resource.id === entry.id) || resource.id === '*'
+			)
 		);
 	}
 
@@ -509,6 +516,30 @@
 		}
 		staticOauthConfigModal?.open();
 	}
+
+	function handleCancel() {
+		if (onCancel) {
+			onCancel();
+		} else {
+			const url = profile.current.hasAdminAccess?.() ? '/admin/mcp-servers' : '/mcp-servers';
+			goto(url);
+		}
+	}
+
+	function handleSubmit(
+		updatedEntry: MCPCatalogEntry | MCPCatalogServer,
+		type: LaunchServerType,
+		message?: string
+	) {
+		if (onSubmit) {
+			onSubmit(updatedEntry.id, type, message);
+		} else {
+			entry = updatedEntry;
+			if (message) {
+				success.add(message);
+			}
+		}
+	}
 </script>
 
 <div
@@ -523,11 +554,7 @@
 			<div class="flex items-center gap-2">
 				<div class="icon">
 					{#if entry.manifest.icon}
-						<img
-							src={entry.manifest.icon}
-							alt={entry.manifest.name}
-							class="size-10 flex-shrink-0"
-						/>
+						<img src={entry.manifest.icon} alt={entry.manifest.name} class="size-10 shrink-0" />
 					{:else}
 						<Server class="size-10" />
 					{/if}
@@ -735,8 +762,8 @@
 			{readonly}
 			{id}
 			{entity}
-			{onCancel}
-			{onSubmit}
+			onCancel={handleCancel}
+			onSubmit={handleSubmit}
 			hideTitle={Boolean(entry)}
 			onConfigureOAuth={handleConfigureOAuth}
 		>

--- a/ui/user/src/routes/admin/mcp-servers/c/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/c/[id]/+page.svelte
@@ -13,8 +13,6 @@
 	import type { MCPServer, MCPCatalogServer } from '$lib/services/chat/types';
 	import { AdminService } from '$lib/services/index.js';
 	import { mcpServersAndEntries, profile } from '$lib/stores/index.js';
-	import { success } from '$lib/stores/success';
-	import { goto } from '$lib/url';
 	import { CircleFadingArrowUp, Info, GitCompare } from 'lucide-svelte';
 	import { untrack, type Component } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -222,14 +220,6 @@
 					: 'single'}
 			readonly={isAdminReadonly || isSourcedEntry}
 			id={DEFAULT_MCP_CATALOG_ID}
-			onCancel={() => {
-				goto('/admin/mcp-servers');
-			}}
-			onSubmit={async (_id, _type, message) => {
-				if (message) {
-					success.add(message);
-				}
-			}}
 			{hasExistingConfigured}
 		/>
 	</div>

--- a/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { resolve } from '$app/paths';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
@@ -157,10 +155,6 @@
 		}
 	}
 
-	function navigateToMcpServers() {
-		goto(resolve(`/admin/mcp-servers`));
-	}
-
 	$effect(() => {
 		if (catalogEntry?.manifest.runtime === 'composite') {
 			untrack(() => mcpServersAndEntries.refreshAll());
@@ -214,8 +208,6 @@
 					: 'single'}
 			readonly={isAdminReadonly || isSourcedEntry}
 			id={DEFAULT_MCP_CATALOG_ID}
-			onCancel={navigateToMcpServers}
-			onSubmit={navigateToMcpServers}
 		/>
 	</div>
 </Layout>

--- a/ui/user/src/routes/admin/mcp-servers/s/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/s/[id]/+page.svelte
@@ -7,7 +7,6 @@
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { AdminService } from '$lib/services/index.js';
 	import { profile } from '$lib/stores/index.js';
-	import { goto } from '$lib/url';
 	import type { Component } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -45,12 +44,6 @@
 			entry={mcpServer}
 			type="multi"
 			id={DEFAULT_MCP_CATALOG_ID}
-			onCancel={() => {
-				goto('/admin/mcp-servers');
-			}}
-			onSubmit={async () => {
-				goto('/admin/mcp-servers');
-			}}
 			readonly={profile.current.isAdminReadonly?.()}
 		/>
 	</div>

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/+page.svelte
@@ -5,7 +5,6 @@
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { mcpServersAndEntries, profile } from '$lib/stores/index.js';
-	import { goto } from '$lib/url';
 	import type { Component } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -45,12 +44,6 @@
 				type={catalogEntry?.manifest.runtime === 'remote' ? 'remote' : 'single'}
 				id={workspaceId}
 				entity="workspace"
-				onCancel={() => {
-					goto('/admin/mcp-servers');
-				}}
-				onSubmit={async () => {
-					goto('/admin/mcp-servers');
-				}}
 				{readonly}
 				{hasExistingConfigured}
 			/>

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/c/[id]/instance/[ms_id]/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { resolve } from '$app/paths';
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerEntryForm from '$lib/components/admin/McpServerEntryForm.svelte';
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
@@ -15,10 +13,6 @@
 	let { data } = $props();
 	let { workspaceId, catalogEntry, mcpServer, belongsToUser } = $derived(data);
 	let title = $derived(catalogEntry?.manifest?.name ?? 'MCP Server');
-
-	function navigateToMcpServers() {
-		goto(resolve(`/admin/mcp-servers`));
-	}
 </script>
 
 <Layout
@@ -40,8 +34,6 @@
 				type={catalogEntry?.manifest.runtime === 'remote' ? 'remote' : 'single'}
 				id={workspaceId}
 				entity="workspace"
-				onCancel={navigateToMcpServers}
-				onSubmit={navigateToMcpServers}
 				readonly={belongsToUser ? false : profile.current.isAdminReadonly?.()}
 			/>
 		{/if}

--- a/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/w/[wid]/s/[id]/+page.svelte
@@ -5,7 +5,6 @@
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { profile } from '$lib/stores/index.js';
-	import { goto } from '$lib/url';
 	import { type Component } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -34,12 +33,6 @@
 				type="multi"
 				id={workspaceId}
 				entity="workspace"
-				onCancel={() => {
-					goto('/admin/mcp-servers');
-				}}
-				onSubmit={async () => {
-					goto('/admin/mcp-servers');
-				}}
 				readonly={belongsToUser ? false : profile.current.isAdminReadonly?.()}
 			/>
 		{/if}

--- a/ui/user/src/routes/mcp-servers/c/[id]/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/c/[id]/+page.svelte
@@ -7,7 +7,6 @@
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { ChatService } from '$lib/services/index.js';
 	import { mcpServersAndEntries } from '$lib/stores/index.js';
-	import { goto } from '$lib/url';
 	import { type Component } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -68,12 +67,6 @@
 				readonly={catalogEntry && 'sourceURL' in catalogEntry && !!catalogEntry.sourceURL}
 				id={workspaceId}
 				entity="workspace"
-				onCancel={() => {
-					goto('/mcp-servers');
-				}}
-				onSubmit={async () => {
-					goto('/mcp-servers');
-				}}
 				{hasExistingConfigured}
 				{configuredServers}
 			/>

--- a/ui/user/src/routes/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { resolve } from '$app/paths';
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerEntryForm from '$lib/components/admin/McpServerEntryForm.svelte';
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
@@ -16,9 +14,6 @@
 	let title = $derived(
 		mcpServer?.alias || mcpServer?.manifest?.name || catalogEntry?.manifest?.name || 'MCP Server'
 	);
-	function navigateToMcpServers() {
-		goto(resolve(`/mcp-servers`));
-	}
 </script>
 
 <Layout
@@ -45,8 +40,6 @@
 				readonly={catalogEntry && 'sourceURL' in catalogEntry && !!catalogEntry.sourceURL}
 				id={workspaceId}
 				entity="workspace"
-				onCancel={navigateToMcpServers}
-				onSubmit={navigateToMcpServers}
 			/>
 		{/if}
 	</div>

--- a/ui/user/src/routes/mcp-servers/s/[id]/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/s/[id]/+page.svelte
@@ -6,7 +6,6 @@
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { ChatService } from '$lib/services/index.js';
-	import { goto } from '$lib/url';
 	import { type Component } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -40,18 +39,7 @@
 	{/snippet}
 	<div class="flex h-full flex-col gap-6 pb-8" in:fly={{ x: 100, delay: duration, duration }}>
 		{#if mcpServer}
-			<McpServerEntryForm
-				entry={mcpServer}
-				type="multi"
-				id={workspaceId}
-				entity="workspace"
-				onCancel={() => {
-					goto('/mcp-servers');
-				}}
-				onSubmit={async () => {
-					goto('/mcp-servers');
-				}}
-			/>
+			<McpServerEntryForm entry={mcpServer} type="multi" id={workspaceId} entity="workspace" />
 		{/if}
 	</div>
 </Layout>


### PR DESCRIPTION
Addresses #6489 

* on save, update state holding entry to reflect saved response data
* moves handleSubmit, handleCancel for consistent behavior in the CatalogServerForm:
* if onSubmit or orCancel provided, use that instead (used in the create new of /mcp-servers)
* Otherwise, default behavior is: 
* saving will just do success message (no route to /admin/mcp-servers or /mcp-servers
* canceling will route user to /admin/mcp-servers or /mcp-servers (route depending on admin access/readability)