### PR TITLE
fix: basic user mcp servers detail view comparison check fix

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -85,7 +85,7 @@
 	}: Props = $props();
 
 	let entry = $state(untrack(() => initialEntry));
-	let lastSyncedInitialEntry = $state<MCPCatalogEntry | MCPCatalogServer | undefined>(undefined);
+	let lastSyncedInitialEntry: MCPCatalogEntry | MCPCatalogServer | undefined = undefined;
 
 	$effect(() => {
 		const next = initialEntry;


### PR DESCRIPTION
* don't use state for the comparison value (doesn't need to be reactive since it's just for comparison & causes `state_proxy_equality_mismatch.`)

* note: error shows up cause the passed `entry` prop in basic users /mcp-servers/x route is passed slightly different (derived vs. untracked state)