### PR TITLE
feat: Replace Ollama with generic provider

### DIFF
--- a/docs/docs/configuration/model-providers.md
+++ b/docs/docs/configuration/model-providers.md
@@ -153,7 +153,7 @@ Obot requires:
 
 #### Generic Responses Compatible Provider
 
-Use **Responses Compatible Generic Provider** to connect Obot to any Responses-compatible API.
+Use **Generic Responses Compatible Provider** to connect Obot to any Responses-compatible API.
 
 This provider supports:
 - A provider-level **Base URL** and optional **API Key**

--- a/docs/docs/configuration/model-providers.md
+++ b/docs/docs/configuration/model-providers.md
@@ -10,7 +10,7 @@ Obot supports a variety of model providers, including:
 - OpenAI
 - Anthropic
 - xAI
-- [Ollama](#ollama)
+- [Generic Responses Compatible Provider](#generic-responses-compatible-provider)
 - Groq
 - vLLM
 - DeepSeek
@@ -151,16 +151,46 @@ Obot requires:
 - **API Key** — your Bedrock API key
 - **AWS Region** — the region where your inference profiles are configured (e.g. `us-east-1`)
 
-#### Ollama
+#### Generic Responses Compatible Provider
 
-[Ollama](https://ollama.ai/) allows you to run LLMs locally. Two configuration steps are required to use it with Obot:
+Use **Responses Compatible Generic Provider** to connect Obot to any Responses-compatible API.
 
-1. **Expose Ollama to the network** - By default, Ollama only binds to `127.0.0.1:11434`. Since Obot runs in a container, `localhost` addresses resolve to Obot's container, not your host. Set `OLLAMA_HOST=0.0.0.0` before starting Ollama, then use your host's IP address in the endpoint URL.
+This provider supports:
+- A provider-level **Base URL** and optional **API Key**
 
-2. **Set the Ollama host**
-   ```
-   http://<your-host-ip>:11434
-   ```
-   - If you are running Obot in Docker, you should use `http://host.docker.internal:11434`. For linux users, run Obot in Docker with this additional flag `--add-host=host.docker.internal:host-gateway` or use an alternative method of allowing the container to access the host network
+##### Common examples
 
-See [Ollama's FAQ](https://docs.ollama.com/faq) for platform-specific instructions on setting `OLLAMA_HOST`.
+- **Ollama**: `http://127.0.0.1:11434/v1`
+- **LiteLLM**: `http://<litellm-host>:4000/v1`
+
+##### Using Ollama
+
+[Ollama](https://ollama.ai/) allows you to run models locally. When Obot runs in Docker, make Ollama reachable from the container:
+
+1. **Expose Ollama to the network**
+   Set `OLLAMA_HOST=0.0.0.0` before starting Ollama.
+
+2. **Set Base URL in Obot**
+   Use one of:
+   - `http://host.docker.internal:11434/v1` (recommended for Docker Desktop)
+   - `http://<your-host-ip>:11434/v1`
+
+For Linux Docker, add `--add-host=host.docker.internal:host-gateway` (or use another host-networking approach) so `host.docker.internal` resolves inside the Obot container.
+
+See [Ollama's FAQ](https://docs.ollama.com/faq) for platform-specific details.
+
+##### LiteLLM config example
+
+If you use LiteLLM, Obot works with LiteLLM's wildcard model list:
+
+```yaml
+model_list:
+  - model_name: openai/*
+    litellm_params:
+      model: openai/*
+      api_key: os.environ/OPENAI_API_KEY
+```
+
+In Obot, models discovered through this provider are currently treated as **Language Model (LLM chat)** models by default.
+
+If your upstream includes non-chat-capable models, use more specific model mappings instead of a broad wildcard, or avoid using these models with Obot.

--- a/pkg/api/handlers/model.go
+++ b/pkg/api/handlers/model.go
@@ -246,11 +246,14 @@ func convertModel(model v1.Model, toolRef v1.ToolReference) (types.Model, error)
 
 func validateModelManifestAndSetDefaults(newModel *v1.Model) error {
 	var errs []error
-	if strings.TrimSpace(newModel.Spec.Manifest.Name) == "" {
+	newModel.Spec.Manifest.Name = strings.TrimSpace(newModel.Spec.Manifest.Name)
+	if newModel.Spec.Manifest.Name == "" {
 		newModel.Spec.Manifest.Name = strings.ReplaceAll(strings.TrimSpace(newModel.Spec.Manifest.TargetModel), "/", "-")
 	}
-	if strings.TrimSpace(newModel.Spec.Manifest.Name) == "" {
+	if newModel.Spec.Manifest.Name == "" {
 		errs = append(errs, fmt.Errorf("field name is required"))
+	} else if strings.Contains(newModel.Spec.Manifest.Name, "/") {
+		errs = append(errs, fmt.Errorf("field name must be a single path segment and must not contain '/'"))
 	}
 	if strings.TrimSpace(newModel.Spec.Manifest.TargetModel) == "" {
 		errs = append(errs, fmt.Errorf("field targetModel is required"))

--- a/pkg/api/handlers/model.go
+++ b/pkg/api/handlers/model.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
@@ -245,10 +246,16 @@ func convertModel(model v1.Model, toolRef v1.ToolReference) (types.Model, error)
 
 func validateModelManifestAndSetDefaults(newModel *v1.Model) error {
 	var errs []error
-	if newModel.Spec.Manifest.TargetModel == "" {
+	if strings.TrimSpace(newModel.Spec.Manifest.Name) == "" {
+		newModel.Spec.Manifest.Name = strings.ReplaceAll(strings.TrimSpace(newModel.Spec.Manifest.TargetModel), "/", "-")
+	}
+	if strings.TrimSpace(newModel.Spec.Manifest.Name) == "" {
+		errs = append(errs, fmt.Errorf("field name is required"))
+	}
+	if strings.TrimSpace(newModel.Spec.Manifest.TargetModel) == "" {
 		errs = append(errs, fmt.Errorf("field targetModel is required"))
 	}
-	if newModel.Spec.Manifest.ModelProvider == "" {
+	if strings.TrimSpace(newModel.Spec.Manifest.ModelProvider) == "" {
 		errs = append(errs, fmt.Errorf("field modelProvider is required"))
 	}
 

--- a/pkg/api/handlers/model.go
+++ b/pkg/api/handlers/model.go
@@ -250,9 +250,7 @@ func validateModelManifestAndSetDefaults(newModel *v1.Model) error {
 	if newModel.Spec.Manifest.Name == "" {
 		newModel.Spec.Manifest.Name = strings.ReplaceAll(strings.TrimSpace(newModel.Spec.Manifest.TargetModel), "/", "-")
 	}
-	if newModel.Spec.Manifest.Name == "" {
-		errs = append(errs, fmt.Errorf("field name is required"))
-	} else if strings.Contains(newModel.Spec.Manifest.Name, "/") {
+	if strings.Contains(newModel.Spec.Manifest.Name, "/") {
 		errs = append(errs, fmt.Errorf("field name must be a single path segment and must not contain '/'"))
 	}
 	if strings.TrimSpace(newModel.Spec.Manifest.TargetModel) == "" {

--- a/pkg/api/handlers/model_test.go
+++ b/pkg/api/handlers/model_test.go
@@ -54,7 +54,6 @@ func TestValidateModelManifestAndSetDefaults(t *testing.T) {
 
 		err := validateModelManifestAndSetDefaults(model)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "field name is required")
 		assert.Contains(t, err.Error(), "field targetModel is required")
 	})
 }

--- a/pkg/api/handlers/model_test.go
+++ b/pkg/api/handlers/model_test.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateModelManifestAndSetDefaults(t *testing.T) {
+	t.Run("accepts valid manifest", func(t *testing.T) {
+		model := &v1.Model{Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+			Name:          "openai-gpt-4.1",
+			TargetModel:   "openai/gpt-4.1",
+			ModelProvider: "openai-model-provider",
+		}}}
+
+		err := validateModelManifestAndSetDefaults(model)
+		require.NoError(t, err)
+	})
+
+	t.Run("defaults empty name from target model", func(t *testing.T) {
+		model := &v1.Model{Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+			Name:          "   ",
+			TargetModel:   "openai/gpt-4.1",
+			ModelProvider: "openai-model-provider",
+		}}}
+
+		err := validateModelManifestAndSetDefaults(model)
+		require.NoError(t, err)
+		assert.Equal(t, "openai-gpt-4.1", model.Spec.Manifest.Name)
+	})
+
+	t.Run("rejects empty name when target model is empty", func(t *testing.T) {
+		model := &v1.Model{Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+			Name:          "   ",
+			TargetModel:   "   ",
+			ModelProvider: "openai-model-provider",
+		}}}
+
+		err := validateModelManifestAndSetDefaults(model)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field name is required")
+		assert.Contains(t, err.Error(), "field targetModel is required")
+	})
+}

--- a/pkg/api/handlers/model_test.go
+++ b/pkg/api/handlers/model_test.go
@@ -21,6 +21,18 @@ func TestValidateModelManifestAndSetDefaults(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("rejects slash-containing name", func(t *testing.T) {
+		model := &v1.Model{Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+			Name:          "openai/gpt-4.1",
+			TargetModel:   "openai/gpt-4.1",
+			ModelProvider: "openai-model-provider",
+		}}}
+
+		err := validateModelManifestAndSetDefaults(model)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field name must be a single path segment")
+	})
+
 	t.Run("defaults empty name from target model", func(t *testing.T) {
 		model := &v1.Model{Spec: v1.ModelSpec{Manifest: types.ModelManifest{
 			Name:          "   ",

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -493,10 +493,6 @@ func getModelForAlias(ctx context.Context, client kclient.Client, namespace stri
 		return resolvedLLMModel{}, err
 	}
 
-	if strings.TrimSpace(model.Spec.Manifest.TargetModel) == "" {
-		return resolvedLLMModel{}, fmt.Errorf("model %q has no target model", model.Name)
-	}
-
 	return resolvedLLMModel{
 		Name:            model.Name,
 		ModelProvider:   model.Spec.Manifest.ModelProvider,

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -398,7 +398,7 @@ func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, res
 // resolvedLLMModel pairs the resolved target model name with its configured provider reference
 // and the dialect declared by that provider (if any).
 type resolvedLLMModel struct {
-	Name            string               // slugified Manifest.Name (e.g. "openai-gpt-4.1"), safe for K8s/URL use
+	Name            string               // model Manifest.Name as stored on the Model resource
 	TargetModel     string               // real upstream model ID (e.g. "openai/gpt-4.1")
 	ModelProvider   string               // e.g. "openai-model-provider", "anthropic-model-provider"
 	ProviderDialect nanobottypes.Dialect // from ProviderMeta.Dialect; empty if not declared

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -395,11 +395,10 @@ func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, res
 	return nil
 }
 
-// resolvedLLMModel pairs the resolved target model name with its configured provider reference
+// resolvedLLMModel pairs the resolved model resource name with its configured provider reference
 // and the dialect declared by that provider (if any).
 type resolvedLLMModel struct {
-	Name            string               // model Manifest.Name as stored on the Model resource
-	TargetModel     string               // real upstream model ID (e.g. "openai/gpt-4.1")
+	Name            string               // Kubernetes Model resource name
 	ModelProvider   string               // e.g. "openai-model-provider", "anthropic-model-provider"
 	ProviderDialect nanobottypes.Dialect // from ProviderMeta.Dialect; empty if not declared
 }
@@ -494,9 +493,12 @@ func getModelForAlias(ctx context.Context, client kclient.Client, namespace stri
 		return resolvedLLMModel{}, err
 	}
 
+	if strings.TrimSpace(model.Spec.Manifest.TargetModel) == "" {
+		return resolvedLLMModel{}, fmt.Errorf("model %q has no target model", model.Name)
+	}
+
 	return resolvedLLMModel{
-		Name:            model.Spec.Manifest.Name,
-		TargetModel:     model.Spec.Manifest.TargetModel,
+		Name:            model.Name,
 		ModelProvider:   model.Spec.Manifest.ModelProvider,
 		ProviderDialect: nanobottypes.Dialect(model.Spec.Manifest.Dialect),
 	}, nil
@@ -511,7 +513,7 @@ func getModelForAlias(ctx context.Context, client kclient.Client, namespace stri
 // no preferred mini model is available. All other aliases fall back to the
 // first active LLM model available.
 func resolveModel(ctx context.Context, client kclient.Client, namespace string, aliasName types.DefaultModelAliasType) (resolvedLLMModel, error) {
-	if model, err := getModelForAlias(ctx, client, namespace, aliasName); err == nil && strings.TrimSpace(model.TargetModel) != "" {
+	if model, err := getModelForAlias(ctx, client, namespace, aliasName); err == nil {
 		return model, nil
 	}
 
@@ -556,8 +558,7 @@ func chooseModel(ctx context.Context, client kclient.Client, namespace string, m
 		for _, model := range models {
 			if model.Spec.Manifest.TargetModel == preferredName || model.Spec.Manifest.Name == preferredName {
 				return resolvedLLMModel{
-					Name:            model.Spec.Manifest.Name,
-					TargetModel:     model.Spec.Manifest.TargetModel,
+					Name:            model.Name,
 					ModelProvider:   model.Spec.Manifest.ModelProvider,
 					ProviderDialect: nanobottypes.Dialect(model.Spec.Manifest.Dialect),
 				}, nil
@@ -571,8 +572,7 @@ func chooseModel(ctx context.Context, client kclient.Client, namespace string, m
 
 	if len(models) > 0 {
 		return resolvedLLMModel{
-			Name:            models[0].Spec.Manifest.Name,
-			TargetModel:     models[0].Spec.Manifest.TargetModel,
+			Name:            models[0].Name,
 			ModelProvider:   models[0].Spec.Manifest.ModelProvider,
 			ProviderDialect: nanobottypes.Dialect(models[0].Spec.Manifest.Dialect),
 		}, nil

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -398,7 +398,8 @@ func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, res
 // resolvedLLMModel pairs the resolved target model name with its configured provider reference
 // and the dialect declared by that provider (if any).
 type resolvedLLMModel struct {
-	TargetModel     string
+	Name            string               // slugified Manifest.Name (e.g. "openai-gpt-4.1"), safe for K8s/URL use
+	TargetModel     string               // real upstream model ID (e.g. "openai/gpt-4.1")
 	ModelProvider   string               // e.g. "openai-model-provider", "anthropic-model-provider"
 	ProviderDialect nanobottypes.Dialect // from ProviderMeta.Dialect; empty if not declared
 }
@@ -453,7 +454,7 @@ func (h *Handler) parseModelProvider(model resolvedLLMModel) (nanobotLLMProvider
 		APIKey:  fmt.Sprintf("${%s}", envVarName),
 		BaseURL: baseURL,
 	}
-	return p, fmt.Sprintf("%s/%s", p.Name, model.TargetModel)
+	return p, fmt.Sprintf("%s/%s", p.Name, model.Name)
 }
 
 // buildNanobotProviderConfigYAML generates a nanobot Config YAML containing only the
@@ -494,6 +495,7 @@ func getModelForAlias(ctx context.Context, client kclient.Client, namespace stri
 	}
 
 	return resolvedLLMModel{
+		Name:            model.Spec.Manifest.Name,
 		TargetModel:     model.Spec.Manifest.TargetModel,
 		ModelProvider:   model.Spec.Manifest.ModelProvider,
 		ProviderDialect: nanobottypes.Dialect(model.Spec.Manifest.Dialect),
@@ -554,6 +556,7 @@ func chooseModel(ctx context.Context, client kclient.Client, namespace string, m
 		for _, model := range models {
 			if model.Spec.Manifest.TargetModel == preferredName || model.Spec.Manifest.Name == preferredName {
 				return resolvedLLMModel{
+					Name:            model.Spec.Manifest.Name,
 					TargetModel:     model.Spec.Manifest.TargetModel,
 					ModelProvider:   model.Spec.Manifest.ModelProvider,
 					ProviderDialect: nanobottypes.Dialect(model.Spec.Manifest.Dialect),
@@ -568,6 +571,7 @@ func chooseModel(ctx context.Context, client kclient.Client, namespace string, m
 
 	if len(models) > 0 {
 		return resolvedLLMModel{
+			Name:            models[0].Spec.Manifest.Name,
 			TargetModel:     models[0].Spec.Manifest.TargetModel,
 			ModelProvider:   models[0].Spec.Manifest.ModelProvider,
 			ProviderDialect: nanobottypes.Dialect(models[0].Spec.Manifest.Dialect),

--- a/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
@@ -17,6 +17,7 @@ import (
 func TestChooseModelPrefersKnownNames(t *testing.T) {
 	models := []v1.Model{
 		{
+			ObjectMeta: metav1.ObjectMeta{Name: "ollama-qwen3"},
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "other",
@@ -27,6 +28,7 @@ func TestChooseModelPrefersKnownNames(t *testing.T) {
 			},
 		},
 		{
+			ObjectMeta: metav1.ObjectMeta{Name: "openai-gpt-5.4"},
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "gpt-5.4",
@@ -43,14 +45,15 @@ func TestChooseModelPrefersKnownNames(t *testing.T) {
 		t.Fatalf("expected model, got error: %v", err)
 	}
 
-	if model.TargetModel != "gpt-5.4" {
-		t.Fatalf("expected gpt-5.4, got %q", model.TargetModel)
+	if model.Name != "openai-gpt-5.4" {
+		t.Fatalf("expected openai-gpt-5.4, got %q", model.Name)
 	}
 }
 
 func TestChooseModelFallsBackToFirstActiveModel(t *testing.T) {
 	models := []v1.Model{
 		{
+			ObjectMeta: metav1.ObjectMeta{Name: "groq-llama-3.1-70b-versatile"},
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "model-a",
@@ -67,14 +70,15 @@ func TestChooseModelFallsBackToFirstActiveModel(t *testing.T) {
 		t.Fatalf("expected model, got error: %v", err)
 	}
 
-	if model.TargetModel != "model-a" {
-		t.Fatalf("expected model-a, got %q", model.TargetModel)
+	if model.Name != "groq-llama-3.1-70b-versatile" {
+		t.Fatalf("expected groq-llama-3.1-70b-versatile, got %q", model.Name)
 	}
 }
 
 func TestChooseModelPrefersSuggestedOrder(t *testing.T) {
 	models := []v1.Model{
 		{
+			ObjectMeta: metav1.ObjectMeta{Name: "anthropic-claude-sonnet-4-6"},
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "claude-sonnet-4-6",
@@ -85,6 +89,7 @@ func TestChooseModelPrefersSuggestedOrder(t *testing.T) {
 			},
 		},
 		{
+			ObjectMeta: metav1.ObjectMeta{Name: "openai-gpt-5.4"},
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "gpt-5.4",
@@ -101,8 +106,8 @@ func TestChooseModelPrefersSuggestedOrder(t *testing.T) {
 		t.Fatalf("expected model, got error: %v", err)
 	}
 
-	if model.TargetModel != "gpt-5.4" {
-		t.Fatalf("expected gpt-5.4, got %q", model.TargetModel)
+	if model.Name != "openai-gpt-5.4" {
+		t.Fatalf("expected openai-gpt-5.4, got %q", model.Name)
 	}
 }
 
@@ -120,7 +125,7 @@ func TestNanobotParseModelProviderDeclaredDialectDrivesURL(t *testing.T) {
 		{nanobottypes.DialectBifrostRequest, "https://obot.example.com/api/llm-proxy"},
 	} {
 		model := resolvedLLMModel{
-			TargetModel:     "some-model",
+			Name:            "some-model",
 			ModelProvider:   "custom-model-provider",
 			ProviderDialect: tc.dialect,
 		}
@@ -280,8 +285,8 @@ func TestResolveModelCarriesProviderAndDialect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if model.TargetModel != "llama-3.1-70b-versatile" {
-		t.Errorf("TargetModel = %q, want llama-3.1-70b-versatile", model.TargetModel)
+	if model.Name != "groq-llama" {
+		t.Errorf("Name = %q, want groq-llama", model.Name)
 	}
 	if model.ModelProvider != "groq-model-provider" {
 		t.Errorf("ModelProvider = %q, want groq-model-provider", model.ModelProvider)
@@ -298,24 +303,22 @@ func TestMultipleProvidersWhenLLMAndMiniDiffer(t *testing.T) {
 	h := &Handler{serverURL: "https://obot.example.com"}
 
 	llmModel := resolvedLLMModel{
-		Name:          "claude-sonnet-4-6",
-		TargetModel:   "claude-sonnet-4-6",
+		Name:          "anthropic-claude-sonnet-4-6",
 		ModelProvider: system.AnthropicModelProviderTool,
 	}
 	miniModel := resolvedLLMModel{
-		Name:          "gpt-4.1-mini",
-		TargetModel:   "gpt-4.1-mini",
+		Name:          "openai-gpt-4.1-mini",
 		ModelProvider: system.OpenAIModelProviderTool,
 	}
 
 	llmProvider, llmDefault := h.parseModelProvider(llmModel)
 	miniProvider, miniDefault := h.parseModelProvider(miniModel)
 
-	if llmDefault != system.AnthropicModelProviderTool+"/claude-sonnet-4-6" {
-		t.Errorf("llmDefault = %q, want %s/claude-sonnet-4-6", llmDefault, system.AnthropicModelProviderTool)
+	if llmDefault != system.AnthropicModelProviderTool+"/anthropic-claude-sonnet-4-6" {
+		t.Errorf("llmDefault = %q, want %s/anthropic-claude-sonnet-4-6", llmDefault, system.AnthropicModelProviderTool)
 	}
-	if miniDefault != system.OpenAIModelProviderTool+"/gpt-4.1-mini" {
-		t.Errorf("miniDefault = %q, want %s/gpt-4.1-mini", miniDefault, system.OpenAIModelProviderTool)
+	if miniDefault != system.OpenAIModelProviderTool+"/openai-gpt-4.1-mini" {
+		t.Errorf("miniDefault = %q, want %s/openai-gpt-4.1-mini", miniDefault, system.OpenAIModelProviderTool)
 	}
 
 	yaml, err := buildNanobotProviderConfigYAML(llmProvider, miniProvider)
@@ -380,6 +383,7 @@ func TestChooseModelMiniFallsBackToResolvedLLM(t *testing.T) {
 
 	models := []v1.Model{
 		{
+			ObjectMeta: metav1.ObjectMeta{Name: "openai-gpt-5.4"},
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "gpt-5.4",
@@ -396,7 +400,7 @@ func TestChooseModelMiniFallsBackToResolvedLLM(t *testing.T) {
 		t.Fatalf("expected model, got error: %v", err)
 	}
 
-	if model.TargetModel != "gpt-5.4" {
-		t.Fatalf("expected gpt-5.4, got %q", model.TargetModel)
+	if model.Name != "openai-gpt-5.4" {
+		t.Fatalf("expected openai-gpt-5.4, got %q", model.Name)
 	}
 }

--- a/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
@@ -146,7 +146,7 @@ func TestNanobotParseModelProviderBuiltinFallbacks(t *testing.T) {
 		{system.AnthropicModelProviderTool, nanobottypes.DialectAnthropicMessages, "https://obot.example.com/api/llm-proxy/anthropic"},
 		{"unknown-model-provider", nanobottypes.DialectOpenResponses, "https://obot.example.com/api/llm-proxy"},
 	} {
-		model := resolvedLLMModel{TargetModel: "my-model", ModelProvider: tc.modelProvider}
+		model := resolvedLLMModel{Name: "my-model", ModelProvider: tc.modelProvider}
 		p, qualifiedName := h.parseModelProvider(model)
 		if p.Dialect != tc.wantDialect {
 			t.Errorf("%s: dialect = %q, want %q", tc.modelProvider, p.Dialect, tc.wantDialect)
@@ -298,10 +298,12 @@ func TestMultipleProvidersWhenLLMAndMiniDiffer(t *testing.T) {
 	h := &Handler{serverURL: "https://obot.example.com"}
 
 	llmModel := resolvedLLMModel{
+		Name:          "claude-sonnet-4-6",
 		TargetModel:   "claude-sonnet-4-6",
 		ModelProvider: system.AnthropicModelProviderTool,
 	}
 	miniModel := resolvedLLMModel{
+		Name:          "gpt-4.1-mini",
 		TargetModel:   "gpt-4.1-mini",
 		ModelProvider: system.OpenAIModelProviderTool,
 	}

--- a/pkg/controller/handlers/toolreference/toolreference.go
+++ b/pkg/controller/handlers/toolreference/toolreference.go
@@ -462,6 +462,10 @@ func (h *Handler) BackPopulateModels(req router.Request, _ router.Response) erro
 
 	models := make([]client.Object, 0, len(availableModels.Models))
 	for _, model := range availableModels.Models {
+		displayName := model.Metadata["displayName"]
+		if displayName == "" {
+			displayName = model.ID
+		}
 		models = append(models, &v1.Model{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: req.Namespace,
@@ -472,8 +476,8 @@ func (h *Handler) BackPopulateModels(req router.Request, _ router.Response) erro
 			},
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
-					Name:          model.ID,
-					DisplayName:   model.Metadata["displayName"],
+					Name:          strings.ReplaceAll(model.ID, "/", "-"),
+					DisplayName:   displayName,
 					TargetModel:   model.ID,
 					ModelProvider: toolRef.Name,
 					Active:        true,

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -304,14 +304,6 @@ func rewriteModelInBody(body []byte, model string) ([]byte, error) {
 	}
 	if _, ok := bodyMap["model"]; ok {
 		bodyMap["model"] = model
-	} else if message, ok := bodyMap["message"].(map[string]any); ok {
-		if _, ok := message["model"]; ok {
-			message["model"] = model
-		}
-	} else if response, ok := bodyMap["response"].(map[string]any); ok {
-		if _, ok := response["model"]; ok {
-			response["model"] = model
-		}
 	}
 	return json.Marshal(bodyMap)
 }
@@ -990,7 +982,7 @@ func (l *llmProviderProxy) proxy(req api.Context) error {
 			return fmt.Errorf("failed to get model: %w", err)
 		}
 		if model.Spec.Manifest.ModelProvider != l.modelProvider.Name {
-			return types2.NewErrForbidden("user does not have permission to use model %q", targetModel)
+			return types2.NewErrBadRequest("requested model does not match configured provider %q", targetModel)
 		}
 
 		hasAccess, err := l.mapHelper.UserHasAccessToModel(req.User, model.Name)

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -219,24 +219,28 @@ func (s *Server) dispatchLLMProxy(req api.Context) error {
 
 // getModelFromReference retrieves the model with a matching reference name.
 // The reference name must be any one of the following:
-// - The target name of a default model alias
-// - The target name of the model itself
-// - The actual name of the model
+// - The name of a default model alias
+// - The slugified manifest name of the model (e.g. "openai-gpt-4.1")
+// - The target model ID (e.g. "gpt-4.1")
+// - The actual Kubernetes resource name of the model
 func getModelFromReference(ctx context.Context, client kclient.Client, namespace, modelReference string) (*v1.Model, error) {
 	m, err := alias.GetFromScope(ctx, client, "Model", namespace, modelReference)
 	if apierrors.IsNotFound(err) {
-		// Maybe the user is trying to get a model by the target name.
 		var models v1.ModelList
 		if err := client.List(ctx, &models, &kclient.ListOptions{
 			Namespace:     namespace,
-			FieldSelector: fields.OneTermEqualSelector("spec.manifest.targetModel", modelReference),
+			FieldSelector: fields.OneTermEqualSelector("spec.manifest.name", modelReference),
 		}); err != nil {
 			return nil, err
 		}
 
 		if len(models.Items) == 0 {
-			// Return the original error if no models are found.
-			return nil, err
+			if err := client.List(ctx, &models, &kclient.ListOptions{
+				Namespace:     namespace,
+				FieldSelector: fields.OneTermEqualSelector("spec.manifest.targetModel", modelReference),
+			}); err != nil {
+				return nil, err
+			}
 		}
 
 		// Return the oldest one.

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -244,7 +244,7 @@ func getModelFromReference(ctx context.Context, client kclient.Client, namespace
 		}
 
 		if len(models.Items) == 0 {
-			return nil, errors.New("no models found")
+			return nil, fmt.Errorf("model %q not found", modelReference)
 		}
 
 		// Return the oldest one.

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tidwall/gjson"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -244,7 +245,7 @@ func getModelFromReference(ctx context.Context, client kclient.Client, namespace
 		}
 
 		if len(models.Items) == 0 {
-			return nil, fmt.Errorf("model %q not found", modelReference)
+			return nil, apierrors.NewNotFound(schema.GroupResource{Group: v1.SchemeGroupVersion.Group, Resource: "model"}, modelReference)
 		}
 
 		// Return the oldest one.
@@ -280,7 +281,7 @@ func getModelFromReference(ctx context.Context, client kclient.Client, namespace
 		return respModel, nil
 	}
 
-	return nil, fmt.Errorf("model %q not found", modelReference)
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: v1.SchemeGroupVersion.Group, Resource: "model"}, modelReference)
 }
 
 func envVarForModelProvider(modelProvider v1.ToolReference) (string, error) {

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"os"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,7 +30,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/tidwall/gjson"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -221,40 +219,10 @@ func (s *Server) dispatchLLMProxy(req api.Context) error {
 // getModelFromReference retrieves the model with a matching reference name.
 // The reference name must be any one of the following:
 // - The name of a default model alias
-// - The slugified manifest name of the model (e.g. "openai-gpt-4.1")
-// - The target model ID (e.g. "gpt-4.1")
 // - The actual Kubernetes resource name of the model
 func getModelFromReference(ctx context.Context, client kclient.Client, namespace, modelReference string) (*v1.Model, error) {
 	m, err := alias.GetFromScope(ctx, client, "Model", namespace, modelReference)
-	if apierrors.IsNotFound(err) {
-		var models v1.ModelList
-		if err := client.List(ctx, &models, &kclient.ListOptions{
-			Namespace:     namespace,
-			FieldSelector: fields.OneTermEqualSelector("spec.manifest.name", modelReference),
-		}); err != nil {
-			return nil, err
-		}
-
-		if len(models.Items) == 0 {
-			if err := client.List(ctx, &models, &kclient.ListOptions{
-				Namespace:     namespace,
-				FieldSelector: fields.OneTermEqualSelector("spec.manifest.targetModel", modelReference),
-			}); err != nil {
-				return nil, err
-			}
-		}
-
-		if len(models.Items) == 0 {
-			return nil, apierrors.NewNotFound(schema.GroupResource{Group: v1.SchemeGroupVersion.Group, Resource: "model"}, modelReference)
-		}
-
-		// Return the oldest one.
-		sort.Slice(models.Items, func(i, j int) bool {
-			return models.Items[i].CreationTimestamp.Before(&models.Items[j].CreationTimestamp)
-		})
-
-		return &models.Items[0], nil
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 
@@ -327,6 +295,15 @@ func extractModelFromBody(body []byte) string {
 		return model
 	}
 	return gjson.GetBytes(body, "response.model").String()
+}
+
+func rewriteTopLevelModelInBody(body []byte, model string) ([]byte, error) {
+	var bodyMap map[string]any
+	if err := json.Unmarshal(body, &bodyMap); err != nil {
+		return nil, err
+	}
+	bodyMap["model"] = model
+	return json.Marshal(bodyMap)
 }
 
 // copyBody returns a copy of the bytes in a request body.
@@ -998,33 +975,31 @@ func (l *llmProviderProxy) proxy(req api.Context) error {
 
 	targetModel := extractModelFromBody(body)
 	if targetModel != "" {
-		// Get the models matching the target model and provider.
-		var models v1.ModelList
-		if err := req.List(&models, &kclient.ListOptions{
-			Namespace: l.modelProvider.Namespace,
-			FieldSelector: fields.SelectorFromSet(map[string]string{
-				"spec.manifest.targetModel":   targetModel,
-				"spec.manifest.modelProvider": l.modelProvider.Name,
-			}),
-		}); err != nil {
-			return fmt.Errorf("failed to list models: %w", err)
+		model, err := getModelFromReference(req.Context(), req.Storage, l.modelProvider.Namespace, targetModel)
+		if err != nil {
+			return fmt.Errorf("failed to get model: %w", err)
+		}
+		if model.Spec.Manifest.ModelProvider != l.modelProvider.Name {
+			return types2.NewErrForbidden("user does not have permission to use model %q", targetModel)
 		}
 
-		var hasAccess bool
-		for _, model := range models.Items {
-			var err error
-			hasAccess, err = l.mapHelper.UserHasAccessToModel(req.User, model.Name)
-			if err != nil {
-				return fmt.Errorf("failed to check user access to model %q: %w", model.Name, err)
-			}
-			if hasAccess {
-				break
-			}
+		hasAccess, err := l.mapHelper.UserHasAccessToModel(req.User, model.Name)
+		if err != nil {
+			return fmt.Errorf("failed to check user access to model %q: %w", model.Name, err)
 		}
-
 		if !hasAccess {
 			return types2.NewErrForbidden("user does not have permission to use model %q", targetModel)
 		}
+
+		targetModel = model.Spec.Manifest.TargetModel
+
+		// Replace the model resource name with the actual provider model name
+		body, err = rewriteTopLevelModelInBody(body, targetModel)
+		if err != nil {
+			return fmt.Errorf("failed to rewrite model in request body: %w", err)
+		}
+		req.Request.Body = io.NopCloser(bytes.NewReader(body))
+		req.ContentLength = int64(len(body))
 	}
 
 	// Evaluate message policies if the helper is available and we have a user.

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -243,6 +243,10 @@ func getModelFromReference(ctx context.Context, client kclient.Client, namespace
 			}
 		}
 
+		if len(models.Items) == 0 {
+			return nil, errors.New("no models found")
+		}
+
 		// Return the oldest one.
 		sort.Slice(models.Items, func(i, j int) bool {
 			return models.Items[i].CreationTimestamp.Before(&models.Items[j].CreationTimestamp)

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -297,12 +297,22 @@ func extractModelFromBody(body []byte) string {
 	return gjson.GetBytes(body, "response.model").String()
 }
 
-func rewriteTopLevelModelInBody(body []byte, model string) ([]byte, error) {
+func rewriteModelInBody(body []byte, model string) ([]byte, error) {
 	var bodyMap map[string]any
 	if err := json.Unmarshal(body, &bodyMap); err != nil {
 		return nil, err
 	}
-	bodyMap["model"] = model
+	if _, ok := bodyMap["model"]; ok {
+		bodyMap["model"] = model
+	} else if message, ok := bodyMap["message"].(map[string]any); ok {
+		if _, ok := message["model"]; ok {
+			message["model"] = model
+		}
+	} else if response, ok := bodyMap["response"].(map[string]any); ok {
+		if _, ok := response["model"]; ok {
+			response["model"] = model
+		}
+	}
 	return json.Marshal(bodyMap)
 }
 
@@ -994,7 +1004,7 @@ func (l *llmProviderProxy) proxy(req api.Context) error {
 		targetModel = model.Spec.Manifest.TargetModel
 
 		// Replace the model resource name with the actual provider model name
-		body, err = rewriteTopLevelModelInBody(body, targetModel)
+		body, err = rewriteModelInBody(body, targetModel)
 		if err != nil {
 			return fmt.Errorf("failed to rewrite model in request body: %w", err)
 		}

--- a/pkg/gateway/server/llmproxy_model_reference_test.go
+++ b/pkg/gateway/server/llmproxy_model_reference_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -30,8 +30,8 @@ func TestGetModelFromReference_ReturnsNotFoundWhenNameAndTargetMiss(t *testing.T
 		t.Fatal("expected error, got nil")
 	}
 
-	if !strings.Contains(err.Error(), `model "missing-model" not found`) {
-		t.Fatalf("expected not found error, got %v", err)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected not found error type, got %T: %v", err, err)
 	}
 }
 

--- a/pkg/gateway/server/llmproxy_model_reference_test.go
+++ b/pkg/gateway/server/llmproxy_model_reference_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	types2 "github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetModelFromReference_ReturnsNotFoundWhenNameAndTargetMiss(t *testing.T) {
+	client := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithIndex(&v1.Model{}, "spec.manifest.name", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.Model).Spec.Manifest.Name}
+		}).
+		WithIndex(&v1.Model{}, "spec.manifest.targetModel", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.Model).Spec.Manifest.TargetModel}
+		}).
+		Build()
+
+	_, err := getModelFromReference(context.Background(), client, "default", "missing-model")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), `model "missing-model" not found`) {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestGetModelFromReference_FallsBackToTargetModelAndReturnsOldest(t *testing.T) {
+	oldest := &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "model-old",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+		},
+		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{Name: "provider-old", TargetModel: "gpt-4.1"}},
+	}
+
+	newest := &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "model-new",
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
+		},
+		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{Name: "provider-new", TargetModel: "gpt-4.1"}},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithIndex(&v1.Model{}, "spec.manifest.name", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.Model).Spec.Manifest.Name}
+		}).
+		WithIndex(&v1.Model{}, "spec.manifest.targetModel", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.Model).Spec.Manifest.TargetModel}
+		}).
+		WithObjects(newest, oldest).
+		Build()
+
+	model, err := getModelFromReference(context.Background(), client, "default", "gpt-4.1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if model.Name != "model-old" {
+		t.Fatalf("expected oldest model, got %q", model.Name)
+	}
+}

--- a/pkg/gateway/server/llmproxy_model_reference_test.go
+++ b/pkg/gateway/server/llmproxy_model_reference_test.go
@@ -3,26 +3,18 @@ package server
 import (
 	"context"
 	"testing"
-	"time"
 
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetModelFromReference_ReturnsNotFoundWhenNameAndTargetMiss(t *testing.T) {
 	client := fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
-		WithIndex(&v1.Model{}, "spec.manifest.name", func(obj kclient.Object) []string {
-			return []string{obj.(*v1.Model).Spec.Manifest.Name}
-		}).
-		WithIndex(&v1.Model{}, "spec.manifest.targetModel", func(obj kclient.Object) []string {
-			return []string{obj.(*v1.Model).Spec.Manifest.TargetModel}
-		}).
 		Build()
 
 	_, err := getModelFromReference(context.Background(), client, "default", "missing-model")
@@ -35,42 +27,60 @@ func TestGetModelFromReference_ReturnsNotFoundWhenNameAndTargetMiss(t *testing.T
 	}
 }
 
-func TestGetModelFromReference_FallsBackToTargetModelAndReturnsOldest(t *testing.T) {
-	oldest := &v1.Model{
+func TestGetModelFromReference_ReturnsModelByResourceName(t *testing.T) {
+	model := &v1.Model{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              "model-old",
-			Namespace:         "default",
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+			Name:      "openai-gpt-4.1-mini",
+			Namespace: "default",
 		},
-		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{Name: "provider-old", TargetModel: "gpt-4.1"}},
-	}
-
-	newest := &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "model-new",
-			Namespace:         "default",
-			CreationTimestamp: metav1.NewTime(time.Now().Add(-1 * time.Hour)),
-		},
-		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{Name: "provider-new", TargetModel: "gpt-4.1"}},
+		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{
+			Name:        "manifest-name",
+			TargetModel: "target-model-id",
+			Active:      true,
+		}},
 	}
 
 	client := fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
-		WithIndex(&v1.Model{}, "spec.manifest.name", func(obj kclient.Object) []string {
-			return []string{obj.(*v1.Model).Spec.Manifest.Name}
-		}).
-		WithIndex(&v1.Model{}, "spec.manifest.targetModel", func(obj kclient.Object) []string {
-			return []string{obj.(*v1.Model).Spec.Manifest.TargetModel}
-		}).
-		WithObjects(newest, oldest).
+		WithObjects(model).
 		Build()
 
-	model, err := getModelFromReference(context.Background(), client, "default", "gpt-4.1")
+	got, err := getModelFromReference(context.Background(), client, "default", "openai-gpt-4.1-mini")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if model.Name != "model-old" {
-		t.Fatalf("expected oldest model, got %q", model.Name)
+	if got.Name != "openai-gpt-4.1-mini" {
+		t.Fatalf("expected openai-gpt-4.1-mini, got %q", got.Name)
+	}
+}
+
+func TestGetModelFromReference_DoesNotFallbackToManifestNameOrTargetModel(t *testing.T) {
+	model := &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openai-gpt-4.1-mini",
+			Namespace: "default",
+		},
+		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{
+			Name:        "manifest-name",
+			TargetModel: "target-model-id",
+			Active:      true,
+		}},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(model).
+		Build()
+
+	for _, ref := range []string{"manifest-name", "target-model-id"} {
+		_, err := getModelFromReference(context.Background(), client, "default", ref)
+		if err == nil {
+			t.Fatalf("%s: expected error, got nil", ref)
+		}
+
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("%s: expected not found error type, got %T: %v", ref, err, err)
+		}
 	}
 }

--- a/pkg/gateway/server/llmproxy_model_reference_test.go
+++ b/pkg/gateway/server/llmproxy_model_reference_test.go
@@ -8,8 +8,8 @@ import (
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/gateway/server/llmproxy_test.go
+++ b/pkg/gateway/server/llmproxy_test.go
@@ -336,6 +336,22 @@ func TestExtractModelFromBody(t *testing.T) {
 	}
 }
 
+func TestRewriteTopLevelModelInBody(t *testing.T) {
+	body := []byte(`{"model":"anthropic-model-provider/anthropic-claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}`)
+
+	rewritten, err := rewriteTopLevelModelInBody(body, "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := extractModelFromBody(rewritten); got != "claude-sonnet-4-6" {
+		t.Fatalf("model = %q, want claude-sonnet-4-6", got)
+	}
+	if !strings.Contains(string(rewritten), `"messages"`) {
+		t.Fatalf("rewritten body should preserve messages: %s", string(rewritten))
+	}
+}
+
 func TestLLMTransformRequest_RemovesAcceptEncoding(t *testing.T) {
 	u := mustParseURL("https://api.example.com/v1")
 	director := llmTransformRequest(*u, nil)

--- a/pkg/gateway/server/llmproxy_test.go
+++ b/pkg/gateway/server/llmproxy_test.go
@@ -336,19 +336,36 @@ func TestExtractModelFromBody(t *testing.T) {
 	}
 }
 
-func TestRewriteTopLevelModelInBody(t *testing.T) {
-	body := []byte(`{"model":"anthropic-model-provider/anthropic-claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}`)
-
-	rewritten, err := rewriteTopLevelModelInBody(body, "claude-sonnet-4-6")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestRewriteModelInBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			"top-level model",
+			`{"model":"anthropic-model-provider/anthropic-claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}`,
+		},
+		{
+			"nested under message",
+			`{"type":"message_start","message":{"model":"anthropic-model-provider/anthropic-claude-sonnet-4-6"}}`,
+		},
+		{
+			"nested under response",
+			`{"type":"response.completed","response":{"model":"anthropic-model-provider/anthropic-claude-sonnet-4-6"}}`,
+		},
 	}
 
-	if got := extractModelFromBody(rewritten); got != "claude-sonnet-4-6" {
-		t.Fatalf("model = %q, want claude-sonnet-4-6", got)
-	}
-	if !strings.Contains(string(rewritten), `"messages"`) {
-		t.Fatalf("rewritten body should preserve messages: %s", string(rewritten))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rewritten, err := rewriteModelInBody([]byte(tt.body), "claude-sonnet-4-6")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got := extractModelFromBody(rewritten); got != "claude-sonnet-4-6" {
+				t.Fatalf("model = %q, want claude-sonnet-4-6", got)
+			}
+		})
 	}
 }
 

--- a/pkg/gateway/server/llmproxy_test.go
+++ b/pkg/gateway/server/llmproxy_test.go
@@ -337,35 +337,15 @@ func TestExtractModelFromBody(t *testing.T) {
 }
 
 func TestRewriteModelInBody(t *testing.T) {
-	tests := []struct {
-		name string
-		body string
-	}{
-		{
-			"top-level model",
-			`{"model":"anthropic-model-provider/anthropic-claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}`,
-		},
-		{
-			"nested under message",
-			`{"type":"message_start","message":{"model":"anthropic-model-provider/anthropic-claude-sonnet-4-6"}}`,
-		},
-		{
-			"nested under response",
-			`{"type":"response.completed","response":{"model":"anthropic-model-provider/anthropic-claude-sonnet-4-6"}}`,
-		},
+	body := `{"model":"anthropic-model-provider/anthropic-claude-sonnet-4-6","messages":[{"role":"user","content":"hello"}]}`
+
+	rewritten, err := rewriteModelInBody([]byte(body), "claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rewritten, err := rewriteModelInBody([]byte(tt.body), "claude-sonnet-4-6")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if got := extractModelFromBody(rewritten); got != "claude-sonnet-4-6" {
-				t.Fatalf("model = %q, want claude-sonnet-4-6", got)
-			}
-		})
+	if got := extractModelFromBody(rewritten); got != "claude-sonnet-4-6" {
+		t.Fatalf("model = %q, want claude-sonnet-4-6", got)
 	}
 }
 

--- a/pkg/storage/apis/obot.obot.ai/v1/model.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/model.go
@@ -41,6 +41,8 @@ func (m *Model) Get(field string) (value string) {
 			return m.Spec.Manifest.TargetModel
 		case "spec.manifest.usage":
 			return string(m.Spec.Manifest.Usage)
+		case "spec.manifest.name":
+			return m.Spec.Manifest.Name
 		}
 	}
 
@@ -48,7 +50,7 @@ func (m *Model) Get(field string) (value string) {
 }
 
 func (m *Model) FieldNames() []string {
-	return []string{"spec.manifest.modelProvider", "spec.manifest.targetModel", "spec.manifest.usage"}
+	return []string{"spec.manifest.modelProvider", "spec.manifest.targetModel", "spec.manifest.usage", "spec.manifest.name"}
 }
 
 func (m *Model) IsAssigned() bool {

--- a/ui/user/src/lib/components/admin/DefaultModels.svelte
+++ b/ui/user/src/lib/components/admin/DefaultModels.svelte
@@ -206,8 +206,8 @@
 					options={activeModelOptions
 						.map((model) => ({
 							label: (SUGGESTED_MODEL_SELECTIONS[modelAlias.alias] ?? []).includes(model.name ?? '')
-								? `${model.name ?? ''} (Suggested)`
-								: (model.name ?? ''),
+								? `${model.displayName || model.name || ''} (Suggested)`
+								: (model.displayName || model.name || ''),
 							id: model.id
 						}))
 						.sort((a, b) => {

--- a/ui/user/src/lib/components/admin/DefaultModels.svelte
+++ b/ui/user/src/lib/components/admin/DefaultModels.svelte
@@ -207,7 +207,7 @@
 						.map((model) => ({
 							label: (SUGGESTED_MODEL_SELECTIONS[modelAlias.alias] ?? []).includes(model.name ?? '')
 								? `${model.displayName || model.name || ''} (Suggested)`
-								: (model.displayName || model.name || ''),
+								: model.displayName || model.name || '',
 							id: model.id
 						}))
 						.sort((a, b) => {

--- a/ui/user/src/lib/components/admin/ProviderConfigure.svelte
+++ b/ui/user/src/lib/components/admin/ProviderConfigure.svelte
@@ -293,13 +293,13 @@
 				disabled={readonly}
 			/>
 			{#if error}
-				<div class="notification-error flex items-center gap-2">
-					<AlertCircle class="size-6 text-red-500" />
-					<p class="flex flex-col text-sm font-light">
+				<div class="notification-error flex min-w-0 items-start gap-2 overflow-hidden">
+					<AlertCircle class="mt-0.5 size-6 shrink-0 text-red-500" />
+					<p class="min-w-0 flex flex-col text-sm font-light">
 						<span class="font-semibold">An error occurred!</span>
-						<span>
+						<span class="max-h-28 overflow-auto break-words pr-1">
 							Your configuration could not be saved because it failed validation: <b
-								class="font-semibold">{error}</b
+								class="break-all font-semibold">{error}</b
 							>
 						</span>
 					</p>

--- a/ui/user/src/lib/constants.ts
+++ b/ui/user/src/lib/constants.ts
@@ -44,6 +44,7 @@ export const PAGE_SIZE = 50;
 
 export const CommonModelProviderIds = {
 	OLLAMA: 'ollama-model-provider',
+	GENERIC_RESPONSES: 'generic-responses-model-provider',
 	GROQ: 'groq-model-provider',
 	VLLM: 'vllm-model-provider',
 	ANTHROPIC: 'anthropic-model-provider',
@@ -66,7 +67,8 @@ export const RecommendedModelProviders = [
 	CommonModelProviderIds.AMAZON_BEDROCK,
 	CommonModelProviderIds.AMAZON_BEDROCK_API_KEY,
 	CommonModelProviderIds.AZURE,
-	CommonModelProviderIds.AZURE_ENTRA
+	CommonModelProviderIds.AZURE_ENTRA,
+	CommonModelProviderIds.GENERIC_RESPONSES
 ];
 
 export const PROJECT_MCP_SERVER_NAME = 'MCP Servers';

--- a/ui/user/src/lib/constants.ts
+++ b/ui/user/src/lib/constants.ts
@@ -67,8 +67,7 @@ export const RecommendedModelProviders = [
 	CommonModelProviderIds.AMAZON_BEDROCK,
 	CommonModelProviderIds.AMAZON_BEDROCK_API_KEY,
 	CommonModelProviderIds.AZURE,
-	CommonModelProviderIds.AZURE_ENTRA,
-	CommonModelProviderIds.GENERIC_RESPONSES
+	CommonModelProviderIds.AZURE_ENTRA
 ];
 
 export const PROJECT_MCP_SERVER_NAME = 'MCP Servers';

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -27,7 +27,7 @@
 		CommonModelProviderIds.AMAZON_BEDROCK_API_KEY,
 		CommonModelProviderIds.AZURE,
 		CommonModelProviderIds.AZURE_ENTRA,
-		CommonModelProviderIds.OLLAMA
+		CommonModelProviderIds.GENERIC_RESPONSES
 	];
 
 	let { data } = $props();
@@ -166,7 +166,7 @@
 		<div class="grid grid-cols-1 gap-4 px-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 			{#each sortedModelProviders as modelProvider (modelProvider.id)}
 				<ProviderCard
-					experimental={modelProvider.id === CommonModelProviderIds.OLLAMA}
+					experimental={modelProvider.id === CommonModelProviderIds.GENERIC_RESPONSES}
 					provider={modelProvider}
 					deprecated={modelProvider.id === CommonModelProviderIds.ANTHROPIC_BEDROCK}
 					recommended={!isLegacyDisabled && RecommendedModelProviders.includes(modelProvider.id)}


### PR DESCRIPTION
Depends on: https://github.com/obot-platform/tools/pull/802

Addresses: #6506 #6410 

- Add new Generic Responses Provider to UI
- Since LiteLLM often names models `openai/*`, `anthropic/*`, etc., I added a separate Name which is a slugified version of the TargetModel