### PR TITLE
fix: ensure user has access to mcp-connect URL

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -264,8 +264,6 @@ var (
 			"POST /oauth/token",
 			"GET /oauth/jwks.json",
 
-			"/mcp-connect/",
-
 			// Allow any user to read stored images.
 			// This allows the UI to display custom images to unauthenticated users.
 			"GET /api/image/{image_id}",

--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/obot-platform/nah/pkg/router"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -10,7 +11,9 @@ import (
 )
 
 func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user user.Info) (bool, error) {
-	if resources.MCPID == "" {
+	if resources.MCPID == "" || user.GetName() == "anonymous" && strings.HasPrefix(req.URL.Path, "/mcp-connect/") {
+		// If this is an MCP connect URL and the user is anonymous, then allow access.
+		// The handler will catch this and support the WWW-Authenticate header to trigger the login flow.
 		return true, nil
 	}
 

--- a/pkg/api/authz/mcpid_test.go
+++ b/pkg/api/authz/mcpid_test.go
@@ -1,0 +1,65 @@
+package authz
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCheckMCPIDAllowsAnonymousMCPConnect(t *testing.T) {
+	authorizer := &Authorizer{}
+	req := httptest.NewRequest("GET", "/mcp-connect/ms1test", nil)
+
+	ok, err := authorizer.checkMCPID(req, &Resources{MCPID: "ms1test"}, &user.DefaultInfo{Name: "anonymous"})
+	if err != nil {
+		t.Fatalf("checkMCPID() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("checkMCPID() = false, want true")
+	}
+}
+
+func TestCheckMCPIDDoesNotBypassNonMCPConnectForAnonymous(t *testing.T) {
+	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).Build()
+	authorizer := &Authorizer{cache: storage, uncached: storage}
+	req := httptest.NewRequest("GET", "/oauth/authorize/ms1test", nil)
+
+	ok, err := authorizer.checkMCPID(req, &Resources{MCPID: "ms1test"}, &user.DefaultInfo{Name: "anonymous"})
+	if err == nil {
+		t.Fatal("checkMCPID() error = nil, want error")
+	}
+	if ok {
+		t.Fatal("checkMCPID() = true, want false")
+	}
+}
+
+func TestCheckMCPIDChecksMCPServerInstanceOwner(t *testing.T) {
+	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServerInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "msi1test",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.MCPServerInstanceSpec{
+			UserID: "user-uid",
+		},
+	}).Build()
+	authorizer := &Authorizer{cache: storage, uncached: storage}
+	req := httptest.NewRequest("GET", "/mcp-connect/msi1test", nil)
+
+	ok, err := authorizer.checkMCPID(req, &Resources{MCPID: "msi1test"}, &user.DefaultInfo{
+		Name: "user",
+		UID:  "user-uid",
+	})
+	if err != nil {
+		t.Fatalf("checkMCPID() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("checkMCPID() = false, want true")
+	}
+}

--- a/pkg/api/authz/ui.go
+++ b/pkg/api/authz/ui.go
@@ -33,7 +33,7 @@ var uiResources = []string{
 
 func (a *Authorizer) checkUI(req *http.Request, user user.Info) bool {
 	// Reject direct access to /debug/, /api or /api paths for UI except for /api/image/{id}
-	if strings.HasPrefix(req.URL.Path, "/debug/") || req.URL.Path == "/api" || (strings.HasPrefix(req.URL.Path, "/api/") && !strings.HasPrefix(req.URL.Path, "/api/image/")) {
+	if req.URL.Path == "/api" || hasAnyPrefix(req.URL.Path, "/mcp-connect/", "/oauth/", "/debug/") || (strings.HasPrefix(req.URL.Path, "/api/") && !strings.HasPrefix(req.URL.Path, "/api/image/")) {
 		return false
 	}
 
@@ -57,4 +57,13 @@ func (a *Authorizer) checkUI(req *http.Request, user user.Info) bool {
 	// did not hit any above conditions, so allow access
 	// incorrect routes will handled by SvelteKit error page
 	return true
+}
+
+func hasAnyPrefix(path string, prefixes ...string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/api/authz/ui_test.go
+++ b/pkg/api/authz/ui_test.go
@@ -232,6 +232,24 @@ func TestCheckUI_V2AdminAccess(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "/mcp-connect is rejected by UI fallback",
+			path: "/mcp-connect/ms1test",
+			user: &user.DefaultInfo{
+				Name:   "anonymous",
+				Groups: []string{UnauthenticatedGroup},
+			},
+			expected: false,
+		},
+		{
+			name: "/oauth is rejected by UI fallback",
+			path: "/oauth/authorize",
+			user: &user.DefaultInfo{
+				Name:   "anonymous",
+				Groups: []string{UnauthenticatedGroup},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Even if the resources check denied the mcp-connect URL, it was being allowed by the UI check. This change fixes that and sures up other parts of the mcp-connect check.