### PR TITLE
Post user-reported security advisories to Slack

### DIFF
--- a/.github/workflows/security-advisories-to-slack.yml
+++ b/.github/workflows/security-advisories-to-slack.yml
@@ -1,0 +1,26 @@
+name: Post Security Advisories to Slack
+
+on:
+  repository_advisory:
+    types: [reported]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.COMMUNITY_ISSUES_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "New security advisory reported"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *New Security Advisory Reported*
+                    <${{ github.event.repository_advisory.html_url }}|${{ github.event.repository_advisory.summary }}>
+                    Severity: ${{ github.event.repository_advisory.severity }}
+                    CVE ID: ${{ github.event.repository_advisory.cve_id }}

--- a/.github/workflows/security-advisories-to-slack.yml
+++ b/.github/workflows/security-advisories-to-slack.yml
@@ -4,23 +4,51 @@ on:
   repository_advisory:
     types: [reported]
 
+permissions: {}
+
 jobs:
   notify-slack:
     runs-on: ubuntu-latest
     steps:
       - name: Post to Slack
-        uses: slackapi/slack-github-action@v2
+        uses: actions/github-script@v8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.COMMUNITY_ISSUES_SLACK_WEBHOOK_URL }}
         with:
-          webhook: ${{ secrets.COMMUNITY_ISSUES_SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "New security advisory reported"
-            blocks:
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *New Security Advisory Reported*
-                    <${{ github.event.repository_advisory.html_url }}|${{ github.event.repository_advisory.summary }}>
-                    Severity: ${{ github.event.repository_advisory.severity }}
-                    CVE ID: ${{ github.event.repository_advisory.cve_id }}
+          script: |
+            const adv = context.payload.repository_advisory;
+            // https://api.slack.com/reference/surfaces/formatting#escaping
+            // Escaping < also neutralizes Slack mention syntax (<!channel>, <@U123>, etc.).
+            const escape = (s) => String(s ?? '')
+              .replaceAll('&', '&amp;')
+              .replaceAll('<', '&lt;')
+              .replaceAll('>', '&gt;');
+            const summary = escape(adv.summary) || '(no summary)';
+            const severity = escape(adv.severity) || 'unset';
+            const cveId = escape(adv.cve_id) || 'unassigned';
+            const url = adv.html_url;
+            const payload = {
+              text: 'New security advisory reported',
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: [
+                      '*New Security Advisory Reported*',
+                      `<${url}|${summary}>`,
+                      `Severity: ${severity}`,
+                      `CVE ID: ${cveId}`,
+                    ].join('\n'),
+                  },
+                },
+              ],
+            };
+            const response = await fetch(process.env.SLACK_WEBHOOK_URL, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+            if (!response.ok) {
+              core.setFailed(`Slack webhook returned ${response.status}: ${await response.text()}`);
+            }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/security-advisories-to-slack.yml`, which listens for the `repository_advisory.reported` event and posts to the same Slack channel as the existing community-issues workflow.
- The `reported` action fires when an external user submits a private vulnerability report via GitHub's native "Report a vulnerability" feature (Security → Advisories). It does not fire for advisories maintainers create directly.
- Reuses the existing `COMMUNITY_ISSUES_SLACK_WEBHOOK_URL` secret so no new secret is required.
- No org-membership filter (unlike the issues workflow): private vuln reports are low-volume / high-signal, and even an internal-reporter advisory is worth alerting on. Easy to add the same `actions/github-script` membership check later if desired.

## Notes
- "Privately report a vulnerability" must be enabled on the repo (Settings → Code security → Private vulnerability reporting) for the event to fire.
- Severity and CVE ID may be empty on a fresh report; they'll just render blank in the message.

## Test plan
- [ ] Confirm "Private vulnerability reporting" is enabled on the repo.
- [ ] Submit a test private vulnerability report and verify the Slack message lands in the expected channel with the advisory link, summary, severity, and CVE ID fields.
- [ ] Verify the workflow run shows up under Actions with no errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwXZyaiSpQr1JaeDqMA8eA)_