### PR TITLE
Add workflow to post user-reported security advisories to Slack

### DIFF
--- a/.github/workflows/security-advisories-to-slack.yml
+++ b/.github/workflows/security-advisories-to-slack.yml
@@ -1,0 +1,54 @@
+name: Post Security Advisories to Slack
+
+on:
+  repository_advisory:
+    types: [reported]
+
+permissions: {}
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        uses: actions/github-script@v8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.COMMUNITY_ISSUES_SLACK_WEBHOOK_URL }}
+        with:
+          script: |
+            const adv = context.payload.repository_advisory;
+            // https://api.slack.com/reference/surfaces/formatting#escaping
+            // Escaping < also neutralizes Slack mention syntax (<!channel>, <@U123>, etc.).
+            const escape = (s) => String(s ?? '')
+              .replaceAll('&', '&amp;')
+              .replaceAll('<', '&lt;')
+              .replaceAll('>', '&gt;');
+            const summary = escape(adv.summary) || '(no summary)';
+            const severity = escape(adv.severity) || 'unset';
+            const cveId = escape(adv.cve_id) || 'unassigned';
+            const url = adv.html_url;
+            const payload = {
+              text: 'New security advisory reported',
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: [
+                      '*New Security Advisory Reported*',
+                      `<${url}|${summary}>`,
+                      `Severity: ${severity}`,
+                      `CVE ID: ${cveId}`,
+                    ].join('\n'),
+                  },
+                },
+              ],
+            };
+            const response = await fetch(process.env.SLACK_WEBHOOK_URL, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+            if (!response.ok) {
+              core.setFailed(`Slack webhook returned ${response.status}: ${await response.text()}`);
+            }


### PR DESCRIPTION
Listens for the `repository_advisory.reported` event, which fires when someone submits a private vulnerability report via GitHub's native security reporting. Reuses the existing community-issues Slack webhook.

Sets workflow-level `permissions: {}` so the default `GITHUB_TOKEN` has no scopes (this workflow only needs to call the Slack webhook). Builds the Slack payload via `actions/github-script` so user-controlled advisory fields (summary, severity, cve_id) are read from `context.payload` and escaped per Slack's mrkdwn rules. Escaping `<` also neutralizes Slack mention syntax (`<!channel>`, `<@U123>`, etc.).

Opening from a fork branch as a workaround for a Depot OIDC trust issue that rejects builds run on upstream branches. Supersedes #6534; please close that PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKxVh1ZDSQrjmb91XDdUh4)_