### PR TITLE
fix: indicate when multi-user server needs configuration

### DIFF
--- a/ui/user/src/lib/components/mcp/ConnectorsView.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectorsView.svelte
@@ -210,6 +210,13 @@
 		selectServerMode = mode;
 	}
 
+	function handleConnectToServer({ instance }: { instance?: MCPServerInstance }) {
+		if (instance) {
+			mcpServersAndEntries.refreshUserInstances();
+		}
+		onConnect?.({ instance });
+	}
+
 	async function handleConfigureOAuth(entry: MCPCatalogEntry) {
 		oauthConfigEntry = entry;
 		try {
@@ -389,7 +396,7 @@
 				{:else if property === 'status'}
 					{#if d.status}
 						<div
-							class={d.status === 'Requires OAuth Config'
+							class={d.status === 'Requires OAuth Config' || d.status === 'Configuration Required'
 								? 'pill-warning'
 								: 'pill-primary bg-primary'}
 						>
@@ -452,10 +459,13 @@
 													handleShowSelectServerDialog(catalogEntry, 'chat');
 												}
 											} else {
-												connectToServerDialog?.handleSetupChat(
-													d.data as MCPCatalogServer,
-													instancesMap.get(d.id)
-												);
+												const server = d.data as MCPCatalogServer;
+												const instance = instancesMap.get(d.id);
+												if (instance && !instance.configured) {
+													connectToServerDialog?.open({ server, instance });
+												} else {
+													connectToServerDialog?.handleSetupChat(server, instance);
+												}
 											}
 											toggle(false);
 										}}
@@ -823,7 +833,7 @@
 <ConnectToServer
 	bind:this={connectToServerDialog}
 	userConfiguredServers={mcpServersAndEntries.current.userConfiguredServers}
-	{onConnect}
+	onConnect={handleConnectToServer}
 />
 
 <ResponsiveDialog

--- a/ui/user/src/lib/services/chat/mcp.ts
+++ b/ui/user/src/lib/services/chat/mcp.ts
@@ -231,7 +231,8 @@ function convertServersToTableData(
 		.filter((server) => !server.catalogEntryID && !server.deleted)
 		.map((server) => {
 			const registry = getUserRegistry(server, usersMap);
-			const connected = instancesMap?.has(server.id);
+			const instance = instancesMap?.get(server.id);
+			const connected = !!instance;
 			return {
 				id: server.id,
 				name: server.manifest.name ?? '',
@@ -244,7 +245,11 @@ function convertServersToTableData(
 				created: server.created,
 				registry,
 				connected,
-				status: connected ? 'Connected' : ''
+				status: connected
+					? instance.configured === false
+						? 'Configuration Required'
+						: 'Connected'
+					: ''
 			};
 		});
 }


### PR DESCRIPTION
This change adds an indication in the UI when a multi-user MCP server that a user had previously connected to requires more configuration.

Issue: https://github.com/obot-platform/obot/issues/6523