### PR TITLE
fix: allow access to mcp-connect URLs with extra path

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -370,7 +370,6 @@ var (
 			"GET /api/me",
 			"GET /api/users",
 			"GET /api/groups",
-			"/mcp-connect/",
 			"POST /api/published-artifacts",
 			"GET /api/published-artifacts",
 			"GET /api/published-artifacts/{id}",

--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -40,6 +40,7 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user us
 
 		// For single-user MCP servers, ensure the user owns the server.
 		return mcpServer.Spec.UserID == user.GetUID(), nil
+
 	default:
 		var entry v1.MCPServerCatalogEntry
 		if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &entry); err != nil {

--- a/pkg/api/authz/mcpid_test.go
+++ b/pkg/api/authz/mcpid_test.go
@@ -1,9 +1,11 @@
 package authz
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
@@ -61,5 +63,219 @@ func TestCheckMCPIDChecksMCPServerInstanceOwner(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("checkMCPID() = false, want true")
+	}
+}
+
+func TestMCPConnectSubtreeAuthorization(t *testing.T) {
+	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		&v1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ms1test",
+				Namespace: system.DefaultNamespace,
+			},
+			Spec: v1.MCPServerSpec{
+				UserID: "user-uid",
+			},
+		},
+		&v1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ms1keytest",
+				Namespace: system.DefaultNamespace,
+			},
+			Spec: v1.MCPServerSpec{
+				UserID: "key-user-uid",
+			},
+		},
+		&v1.MCPServerInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "msi1test",
+				Namespace: system.DefaultNamespace,
+			},
+			Spec: v1.MCPServerInstanceSpec{
+				UserID: "user-uid",
+			},
+		},
+		&v1.MCPServerInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "msi1keytest",
+				Namespace: system.DefaultNamespace,
+			},
+			Spec: v1.MCPServerInstanceSpec{
+				UserID: "key-user-uid",
+			},
+		},
+	).Build()
+	authorizer := NewAuthorizer(storage, storage, false, nil, false)
+
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		user    user.Info
+		allowed bool
+	}{
+		{
+			name:   "basic user can access exact connect path",
+			method: http.MethodGet,
+			path:   "/mcp-connect/msi1test",
+			user: &user.DefaultInfo{
+				Name:   "user",
+				UID:    "user-uid",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+			},
+			allowed: true,
+		},
+		{
+			name:   "basic user can access exact server connect path",
+			method: http.MethodGet,
+			path:   "/mcp-connect/ms1test",
+			user: &user.DefaultInfo{
+				Name:   "user",
+				UID:    "user-uid",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+			},
+			allowed: true,
+		},
+		{
+			name:   "basic user can access trailing slash",
+			method: http.MethodPost,
+			path:   "/mcp-connect/msi1test/",
+			user: &user.DefaultInfo{
+				Name:   "user",
+				UID:    "user-uid",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+			},
+			allowed: true,
+		},
+		{
+			name:   "basic user can access server trailing slash",
+			method: http.MethodPost,
+			path:   "/mcp-connect/ms1test/",
+			user: &user.DefaultInfo{
+				Name:   "user",
+				UID:    "user-uid",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+			},
+			allowed: true,
+		},
+		{
+			name:   "basic user can access subpath",
+			method: http.MethodDelete,
+			path:   "/mcp-connect/msi1test/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "user",
+				UID:    "user-uid",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+			},
+			allowed: true,
+		},
+		{
+			name:   "basic user can access server subpath",
+			method: http.MethodDelete,
+			path:   "/mcp-connect/ms1test/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "user",
+				UID:    "user-uid",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+			},
+			allowed: true,
+		},
+		{
+			name:   "api key cannot access subpath for a server they don't own",
+			method: http.MethodGet,
+			path:   "/mcp-connect/msi1test/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "key-user",
+				UID:    "key-user-uid",
+				Groups: []string{types.GroupAPIKey},
+			},
+			allowed: false,
+		},
+		{
+			name:   "api key cannot access subpath for an MCP server they don't own",
+			method: http.MethodGet,
+			path:   "/mcp-connect/ms1test/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "key-user",
+				UID:    "key-user-uid",
+				Groups: []string{types.GroupAPIKey},
+			},
+			allowed: false,
+		},
+		{
+			name:   "api key can access subpath for a server they own",
+			method: http.MethodGet,
+			path:   "/mcp-connect/msi1keytest/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "key-user",
+				UID:    "key-user-uid",
+				Groups: []string{types.GroupAPIKey},
+			},
+			allowed: true,
+		},
+		{
+			name:   "api key can access subpath for an MCP server they own",
+			method: http.MethodGet,
+			path:   "/mcp-connect/ms1keytest/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "key-user",
+				UID:    "key-user-uid",
+				Groups: []string{types.GroupAPIKey},
+			},
+			allowed: true,
+		},
+		{
+			name:   "authenticated user without basic group cannot access subpath",
+			method: http.MethodGet,
+			path:   "/mcp-connect/msi1test/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "user",
+				UID:    "user-uid",
+				Groups: []string{types.GroupAuthenticated},
+			},
+			allowed: false,
+		},
+		{
+			name:   "authenticated user without basic group cannot access server subpath",
+			method: http.MethodGet,
+			path:   "/mcp-connect/ms1test/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "user",
+				UID:    "user-uid",
+				Groups: []string{types.GroupAuthenticated},
+			},
+			allowed: false,
+		},
+		{
+			name:   "basic user cannot access another user's instance subpath",
+			method: http.MethodGet,
+			path:   "/mcp-connect/msi1test/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "other-user",
+				UID:    "other-user-uid",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+			},
+			allowed: false,
+		},
+		{
+			name:   "basic user cannot access another user's server subpath",
+			method: http.MethodGet,
+			path:   "/mcp-connect/ms1test/messages/123",
+			user: &user.DefaultInfo{
+				Name:   "other-user",
+				UID:    "other-user-uid",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+			},
+			allowed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			if got := authorizer.Authorize(req, tt.user); got != tt.allowed {
+				t.Fatalf("Authorize() = %v, want %v", got, tt.allowed)
+			}
+		})
 	}
 }

--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -22,6 +22,9 @@ var apiResources = map[string][]string{
 		"GET    /mcp-connect/{mcp_id}",
 		"POST   /mcp-connect/{mcp_id}",
 		"DELETE /mcp-connect/{mcp_id}",
+		"GET    /mcp-connect/{mcp_id}/",
+		"POST   /mcp-connect/{mcp_id}/",
+		"DELETE /mcp-connect/{mcp_id}/",
 		"GET    /api/mcp-stats/{mcp_id}",
 		"GET    /api/mcp-audit-logs/{mcp_id}",
 		"GET    /api/assistants",
@@ -225,7 +228,6 @@ var apiResources = map[string][]string{
 		//
 		"GET    /api/tool-references",
 		"GET    /api/tool-references/{id}",
-		"GET    /{ui}/projects/{id}",
 		"GET    /api/users/{user_id}",
 		"PATCH  /api/users/{user_id}",
 		"GET    /api/users/{user_id}/activities",
@@ -284,6 +286,14 @@ var apiResources = map[string][]string{
 		"DELETE /api/workspaces/{workspace_id}/access-control-rules/{access_control_rule_id}",
 		"GET    /api/workspaces/{workspace_id}/access-control-rules/{access_control_rule_id}",
 		"PUT    /api/workspaces/{workspace_id}/access-control-rules/{access_control_rule_id}",
+	},
+	types.GroupAPIKey: {
+		"GET    /mcp-connect/{mcp_id}",
+		"POST   /mcp-connect/{mcp_id}",
+		"DELETE /mcp-connect/{mcp_id}",
+		"GET    /mcp-connect/{mcp_id}/",
+		"POST   /mcp-connect/{mcp_id}/",
+		"DELETE /mcp-connect/{mcp_id}/",
 	},
 }
 


### PR DESCRIPTION
The nanobot agents need to access extra paths for their MCP calls.