### PR TITLE
fix: allow users to access system MCP servers

### DIFF
--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -41,6 +41,13 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user us
 		// For single-user MCP servers, ensure the user owns the server.
 		return mcpServer.Spec.UserID == user.GetUID(), nil
 
+	case system.IsSystemMCPServerID(resources.MCPID):
+		var systemMCPServer v1.SystemMCPServer
+		if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &systemMCPServer); err != nil {
+			return false, err
+		}
+		// If this is a system MCP server, then allow access. The system MCP server will enforce its own authorization.
+		return systemMCPServer.Spec.Manifest.Enabled == nil || *systemMCPServer.Spec.Manifest.Enabled, nil
 	default:
 		var entry v1.MCPServerCatalogEntry
 		if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &entry); err != nil {

--- a/pkg/api/authz/mcpid_test.go
+++ b/pkg/api/authz/mcpid_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/accesscontrolrule"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
+	gocache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -63,6 +66,218 @@ func TestCheckMCPIDChecksMCPServerInstanceOwner(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("checkMCPID() = false, want true")
+	}
+}
+
+func TestCheckMCPIDChecksSystemMCPServerEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled *bool
+		allowed bool
+	}{
+		{
+			name:    "nil enabled defaults to allowed",
+			allowed: true,
+		},
+		{
+			name:    "explicitly enabled is allowed",
+			enabled: new(true),
+			allowed: true,
+		},
+		{
+			name:    "explicitly disabled is denied",
+			enabled: new(false),
+			allowed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.SystemMCPServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sms1test",
+					Namespace: system.DefaultNamespace,
+				},
+				Spec: v1.SystemMCPServerSpec{
+					Manifest: types.SystemMCPServerManifest{
+						Enabled: tt.enabled,
+					},
+				},
+			}).Build()
+
+			authorizer := &Authorizer{cache: storage, uncached: storage}
+			req := httptest.NewRequest(http.MethodGet, "/mcp-connect/sms1test", nil)
+
+			ok, err := authorizer.checkMCPID(req, &Resources{MCPID: "sms1test"}, &user.DefaultInfo{
+				Name: "user",
+				UID:  "user-uid",
+			})
+			if err != nil {
+				t.Fatalf("checkMCPID() error = %v", err)
+			}
+			if ok != tt.allowed {
+				t.Fatalf("checkMCPID() = %v, want %v", ok, tt.allowed)
+			}
+		})
+	}
+}
+
+func TestCheckMCPIDChecksMCPServerCatalogAccess(t *testing.T) {
+	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ms1catalog",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.MCPServerSpec{
+			MCPCatalogID: "catalog-a",
+			UserID:       "owner-uid",
+		},
+	}).Build()
+	authorizer := newMCPIDTestAuthorizer(t, storage, &v1.AccessControlRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "acr1server",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.AccessControlRuleSpec{
+			MCPCatalogID: "catalog-a",
+			Manifest: types.AccessControlRuleManifest{
+				Subjects:  []types.Subject{{Type: types.SubjectTypeUser, ID: "user-uid"}},
+				Resources: []types.Resource{{Type: types.ResourceTypeMCPServer, ID: "ms1catalog"}},
+			},
+		},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/mcp-connect/ms1catalog", nil)
+
+	ok, err := authorizer.checkMCPID(req, &Resources{MCPID: "ms1catalog"}, &user.DefaultInfo{Name: "user", UID: "user-uid"})
+	if err != nil {
+		t.Fatalf("checkMCPID() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("checkMCPID() = false, want true")
+	}
+
+	ok, err = authorizer.checkMCPID(req, &Resources{MCPID: "ms1catalog"}, &user.DefaultInfo{Name: "other", UID: "other-uid"})
+	if err != nil {
+		t.Fatalf("checkMCPID() error = %v", err)
+	}
+	if ok {
+		t.Fatal("checkMCPID() = true, want false")
+	}
+}
+
+func TestCheckMCPIDChecksCatalogEntryAccess(t *testing.T) {
+	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServerCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "entry-test",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			MCPCatalogName: "catalog-a",
+		},
+	}).Build()
+	authorizer := newMCPIDTestAuthorizer(t, storage, &v1.AccessControlRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "acr1entry",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.AccessControlRuleSpec{
+			MCPCatalogID: "catalog-a",
+			Manifest: types.AccessControlRuleManifest{
+				Subjects:  []types.Subject{{Type: types.SubjectTypeUser, ID: "user-uid"}},
+				Resources: []types.Resource{{Type: types.ResourceTypeMCPServerCatalogEntry, ID: "entry-test"}},
+			},
+		},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/mcp-connect/entry-test", nil)
+
+	ok, err := authorizer.checkMCPID(req, &Resources{MCPID: "entry-test"}, &user.DefaultInfo{Name: "user", UID: "user-uid"})
+	if err != nil {
+		t.Fatalf("checkMCPID() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("checkMCPID() = false, want true")
+	}
+
+	ok, err = authorizer.checkMCPID(req, &Resources{MCPID: "entry-test"}, &user.DefaultInfo{Name: "other", UID: "other-uid"})
+	if err != nil {
+		t.Fatalf("checkMCPID() error = %v", err)
+	}
+	if ok {
+		t.Fatal("checkMCPID() = true, want false")
+	}
+}
+
+func TestCheckMCPIDChecksWorkspaceAccess(t *testing.T) {
+	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		&v1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ms1workspace",
+				Namespace: system.DefaultNamespace,
+			},
+			Spec: v1.MCPServerSpec{
+				PowerUserWorkspaceID: "puw1test",
+				UserID:               "owner-uid",
+			},
+		},
+		&v1.MCPServerCatalogEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "workspace-entry",
+				Namespace: system.DefaultNamespace,
+			},
+			Spec: v1.MCPServerCatalogEntrySpec{
+				PowerUserWorkspaceID: "puw1test",
+			},
+		},
+		&v1.PowerUserWorkspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "puw1test",
+				Namespace: system.DefaultNamespace,
+			},
+			Spec: v1.PowerUserWorkspaceSpec{
+				UserID: "owner-uid",
+			},
+		},
+	).Build()
+	authorizer := newMCPIDTestAuthorizer(t, storage, &v1.AccessControlRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "acr1workspace",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.AccessControlRuleSpec{
+			PowerUserWorkspaceID: "puw1test",
+			Manifest: types.AccessControlRuleManifest{
+				Subjects:  []types.Subject{{Type: types.SubjectTypeUser, ID: "shared-user-uid"}},
+				Resources: []types.Resource{{Type: types.ResourceTypeSelector, ID: "*"}},
+			},
+		},
+	})
+
+	tests := []struct {
+		name    string
+		mcpID   string
+		userID  string
+		allowed bool
+	}{
+		{name: "server owner is allowed", mcpID: "ms1workspace", userID: "owner-uid", allowed: true},
+		{name: "server shared user is allowed", mcpID: "ms1workspace", userID: "shared-user-uid", allowed: true},
+		{name: "server unrelated user is denied", mcpID: "ms1workspace", userID: "other-uid", allowed: false},
+		{name: "entry workspace owner is allowed", mcpID: "workspace-entry", userID: "owner-uid", allowed: true},
+		{name: "entry shared user is allowed", mcpID: "workspace-entry", userID: "shared-user-uid", allowed: true},
+		{name: "entry unrelated user is denied", mcpID: "workspace-entry", userID: "other-uid", allowed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/mcp-connect/"+tt.mcpID, nil)
+
+			ok, err := authorizer.checkMCPID(req, &Resources{MCPID: tt.mcpID}, &user.DefaultInfo{Name: "user", UID: tt.userID})
+			if err != nil {
+				t.Fatalf("checkMCPID() error = %v", err)
+			}
+			if ok != tt.allowed {
+				t.Fatalf("checkMCPID() = %v, want %v", ok, tt.allowed)
+			}
+		})
 	}
 }
 
@@ -277,5 +492,64 @@ func TestMCPConnectSubtreeAuthorization(t *testing.T) {
 				t.Fatalf("Authorize() = %v, want %v", got, tt.allowed)
 			}
 		})
+	}
+}
+
+func newMCPIDTestAuthorizer(t *testing.T, storage client.Client, acrs ...*v1.AccessControlRule) *Authorizer {
+	t.Helper()
+
+	indexer := gocache.NewIndexer(gocache.MetaNamespaceKeyFunc, gocache.Indexers{
+		"user-ids": func(obj any) ([]string, error) {
+			acr := obj.(*v1.AccessControlRule)
+			var results []string
+			for _, subject := range acr.Spec.Manifest.Subjects {
+				if subject.Type == types.SubjectTypeUser {
+					results = append(results, subject.ID)
+				}
+			}
+			return results, nil
+		},
+		"catalog-entry-names": func(obj any) ([]string, error) {
+			acr := obj.(*v1.AccessControlRule)
+			var results []string
+			for _, resource := range acr.Spec.Manifest.Resources {
+				if resource.Type == types.ResourceTypeMCPServerCatalogEntry {
+					results = append(results, resource.ID)
+				}
+			}
+			return results, nil
+		},
+		"server-names": func(obj any) ([]string, error) {
+			acr := obj.(*v1.AccessControlRule)
+			var results []string
+			for _, resource := range acr.Spec.Manifest.Resources {
+				if resource.Type == types.ResourceTypeMCPServer {
+					results = append(results, resource.ID)
+				}
+			}
+			return results, nil
+		},
+		"selectors": func(obj any) ([]string, error) {
+			acr := obj.(*v1.AccessControlRule)
+			var results []string
+			for _, resource := range acr.Spec.Manifest.Resources {
+				if resource.Type == types.ResourceTypeSelector {
+					results = append(results, resource.ID)
+				}
+			}
+			return results, nil
+		},
+	})
+
+	for _, acr := range acrs {
+		if err := indexer.Add(acr); err != nil {
+			t.Fatalf("add access control rule to indexer: %v", err)
+		}
+	}
+
+	return &Authorizer{
+		cache:     storage,
+		uncached:  storage,
+		acrHelper: accesscontrolrule.NewAccessControlRuleHelper(indexer, storage),
 	}
 }

--- a/pkg/gateway/server/apikey.go
+++ b/pkg/gateway/server/apikey.go
@@ -293,34 +293,6 @@ func (s *Server) authenticateAPIKey(apiContext api.Context) error {
 				})
 			}
 		}
-
-		// Verify user still has access to the server
-		if system.IsMCPServerID(req.MCPID) {
-			var server v1.MCPServer
-			if err := apiContext.Storage.Get(apiContext.Context(), kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: req.MCPID}, &server); err != nil {
-				pkgLog.Infof("Denied API key auth request: reason=mcp_server_not_found keyUserID=%d mcpID=%s", apiKey.UserID, req.MCPID)
-				return apiContext.Write(apiKeyAuthResponse{
-					Allowed: false,
-					Reason:  "MCP server not found",
-				})
-			}
-
-			hasAccess, err := s.userHasAccessToMCPServerByUserID(apiContext, &server, apiKey.UserID)
-			if err != nil {
-				pkgLog.Infof("Denied API key auth request: reason=access_check_failed keyUserID=%d mcpID=%s", apiKey.UserID, req.MCPID)
-				return apiContext.Write(apiKeyAuthResponse{
-					Allowed: false,
-					Reason:  fmt.Sprintf("failed to verify access: %v", err),
-				})
-			}
-			if !hasAccess {
-				pkgLog.Infof("Denied API key auth request: reason=user_lost_mcp_access keyUserID=%d mcpID=%s", apiKey.UserID, req.MCPID)
-				return apiContext.Write(apiKeyAuthResponse{
-					Allowed: false,
-					Reason:  "user does not have access to this MCP server",
-				})
-			}
-		}
 	}
 
 	pkgLog.Debugf("Authorized API key request: keyUserID=%d mcpID=%s wildcardScope=%v", apiKey.UserID, req.MCPID, hasWildcard)
@@ -339,36 +311,6 @@ func (s *Server) authenticateAPIKey(apiContext api.Context) error {
 	}
 
 	return err
-}
-
-// userHasAccessToMCPServerByUserID checks if a specific user has access to the given MCPServer.
-// This is used in the auth webhook where we don't have an authenticated api.Context.
-func (s *Server) userHasAccessToMCPServerByUserID(apiContext api.Context, server *v1.MCPServer, userID uint) (bool, error) {
-	userIDStr := strconv.FormatUint(uint64(userID), 10)
-
-	// Owner always has access
-	if server.Spec.UserID == userIDStr {
-		return true, nil
-	}
-
-	// Get user info with groups for ACR checks
-	userInfo, err := apiContext.GatewayClient.UserInfoByID(apiContext.Context(), userID)
-	if err != nil {
-		return false, fmt.Errorf("failed to get user info: %w", err)
-	}
-
-	// Check ACR for catalog-scoped servers
-	if server.Spec.MCPCatalogID != "" {
-		return s.acrHelper.UserHasAccessToMCPServerInCatalog(userInfo, server.Name, server.Spec.MCPCatalogID)
-	}
-
-	// Check ACR for workspace-scoped servers
-	if server.Spec.PowerUserWorkspaceID != "" {
-		return s.acrHelper.UserHasAccessToMCPServerInWorkspace(userInfo, server.Name, server.Spec.PowerUserWorkspaceID, server.Spec.UserID)
-	}
-
-	// If not owner and not in catalog/workspace, no access
-	return false, nil
 }
 
 // updateKeyLastUsedTime updates the last used timestamp for an API key.


### PR DESCRIPTION
This change also simplifies the auth webhook to not check for user access because that is done on the incoming mcp-connect request now.