### PR TITLE
fix: move published artifacts authorization out of API layer

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -308,15 +308,10 @@ var (
 			"GET /api/mcp-stats",
 			"GET /api/mcp-stats/{mcp_id}",
 
-			// Published artifacts — any authenticated user can publish, search, and download.
-			// Ownership checks for update/delete are enforced in the handler.
-			"POST /api/published-artifacts",
-			"GET /api/published-artifacts",
-			"GET /api/published-artifacts/{id}",
-			"GET /api/published-artifacts/{id}/download",
-			"GET /api/published-artifacts/{id}/{version}/skill",
-			"PUT /api/published-artifacts/{id}",
-			"DELETE /api/published-artifacts/{id}",
+			// Published artifacts — any authenticated user can publish and search.
+			// Artifact-specific access is enforced by resource authorization.
+			"POST   /api/published-artifacts",
+			"GET    /api/published-artifacts",
 
 			// Skill discovery and download are filtered in the handler.
 			"GET /api/skills",
@@ -372,10 +367,6 @@ var (
 			"GET /api/groups",
 			"POST /api/published-artifacts",
 			"GET /api/published-artifacts",
-			"GET /api/published-artifacts/{id}",
-			"PUT /api/published-artifacts/{id}",
-			"GET /api/published-artifacts/{id}/download",
-			"GET /api/published-artifacts/{id}/{version}/skill",
 		},
 
 		MetricsGroup: {

--- a/pkg/api/authz/publishedartifact.go
+++ b/pkg/api/authz/publishedartifact.go
@@ -1,0 +1,61 @@
+package authz
+
+import (
+	"net/http"
+	"slices"
+	"strconv"
+
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/publishedartifact"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func (a *Authorizer) checkPublishedArtifact(req *http.Request, resources *Resources, u user.Info) (bool, error) {
+	if resources.PublishedArtifactID == "" {
+		return true, nil
+	}
+
+	var artifact v1.PublishedArtifact
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.PublishedArtifactID), &artifact); err != nil {
+		return false, err
+	}
+
+	isAdmin := slices.Contains(u.GetGroups(), types.GroupAdmin)
+	if isAdmin || artifact.Spec.AuthorID == u.GetUID() {
+		resources.Authorizated.PublishedArtifact = &artifact
+		return true, nil
+	}
+
+	if req.Method == http.MethodPut || req.Method == http.MethodDelete {
+		return false, nil
+	}
+
+	var version int
+	if resources.ArtifactVersion != "" {
+		if parsed, err := strconv.Atoi(resources.ArtifactVersion); err == nil && parsed >= 1 {
+			version = parsed
+		}
+	} else if v := req.URL.Query().Get("version"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			version = parsed
+		}
+	}
+
+	if version != 0 {
+		if !publishedartifact.CanAccessVersion(&artifact, version, u, isAdmin) {
+			return false, nil
+		}
+		resources.Authorizated.PublishedArtifact = &artifact
+		return true, nil
+	}
+
+	if publishedartifact.CanAccess(&artifact, u, isAdmin) {
+		resources.Authorizated.PublishedArtifact = &artifact
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/api/authz/publishedartifact_test.go
+++ b/pkg/api/authz/publishedartifact_test.go
@@ -1,0 +1,101 @@
+package authz
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPublishedArtifactAuthorization(t *testing.T) {
+	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.PublishedArtifact{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pa1test",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.PublishedArtifactSpec{
+			AuthorID:      "owner",
+			LatestVersion: 2,
+		},
+		Status: v1.PublishedArtifactStatus{
+			Versions: []types.PublishedArtifactVersionEntry{
+				{
+					Version:  1,
+					Subjects: []types.Subject{{Type: types.SubjectTypeGroup, ID: "group1"}},
+				},
+				{
+					Version: 2,
+				},
+			},
+		},
+	}).Build()
+	authorizer := NewAuthorizer(storage, storage, false, nil, false)
+
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		user    user.Info
+		allowed bool
+	}{
+		{
+			name:   "owner can update",
+			method: http.MethodPut,
+			path:   "/api/published-artifacts/pa1test",
+			user: &user.DefaultInfo{
+				UID:    "owner",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+			},
+			allowed: true,
+		},
+		{
+			name:   "subject can get shared artifact",
+			method: http.MethodGet,
+			path:   "/api/published-artifacts/pa1test",
+			user: &user.DefaultInfo{
+				UID:    "other",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+				Extra:  map[string][]string{"auth_provider_groups": {"group1"}},
+			},
+			allowed: true,
+		},
+		{
+			name:   "subject cannot update shared artifact",
+			method: http.MethodPut,
+			path:   "/api/published-artifacts/pa1test",
+			user: &user.DefaultInfo{
+				UID:    "other",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+				Extra:  map[string][]string{"auth_provider_groups": {"group1"}},
+			},
+			allowed: false,
+		},
+		{
+			name:   "subject cannot get unshared version",
+			method: http.MethodGet,
+			path:   "/api/published-artifacts/pa1test/2/skill",
+			user: &user.DefaultInfo{
+				UID:    "other",
+				Groups: []string{types.GroupBasic, types.GroupAuthenticated},
+				Extra:  map[string][]string{"auth_provider_groups": {"group1"}},
+			},
+			allowed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			if allowed := authorizer.Authorize(req, tt.user); allowed != tt.allowed {
+				t.Fatalf("Authorize() = %v, want %v", allowed, tt.allowed)
+			}
+		})
+	}
+}

--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -196,6 +196,11 @@ var apiResources = map[string][]string{
 		"GET    /api/templates",
 		"GET    /api/templates/{template_public_id}",
 		"POST   /api/templates/{template_public_id}",
+		"GET    /api/published-artifacts/{artifact_id}",
+		"GET    /api/published-artifacts/{artifact_id}/download",
+		"GET    /api/published-artifacts/{artifact_id}/{artifact_version}/skill",
+		"PUT    /api/published-artifacts/{artifact_id}",
+		"DELETE /api/published-artifacts/{artifact_id}",
 
 		// These can be removed when we get rid of the legacy admin side of things.
 		"DELETE /api/threads/{thread_id}",
@@ -294,6 +299,10 @@ var apiResources = map[string][]string{
 		"GET    /mcp-connect/{mcp_id}/",
 		"POST   /mcp-connect/{mcp_id}/",
 		"DELETE /mcp-connect/{mcp_id}/",
+		"GET    /api/published-artifacts/{artifact_id}",
+		"PUT    /api/published-artifacts/{artifact_id}",
+		"GET    /api/published-artifacts/{artifact_id}/download",
+		"GET    /api/published-artifacts/{artifact_id}/{artifact_version}/skill",
 	},
 }
 
@@ -316,6 +325,8 @@ type Resources struct {
 	WorkspaceID            string
 	NanobotAgentID         string
 	ProjectV2ID            string
+	PublishedArtifactID    string
+	ArtifactVersion        string
 	Authorizated           ResourcesAuthorized
 }
 
@@ -333,6 +344,7 @@ type ResourcesAuthorized struct {
 	PowerUserWorkspace *v1.PowerUserWorkspace
 	NanobotAgent       *v1.NanobotAgent
 	ProjectV2          *v1.ProjectV2
+	PublishedArtifact  *v1.PublishedArtifact
 }
 
 func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user user.Info) (bool, error) {
@@ -354,6 +366,8 @@ func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user user
 		WorkspaceID:            vars("workspace_id"),
 		NanobotAgentID:         vars("nanobot_agent_id"),
 		ProjectV2ID:            vars("projectv2_id"),
+		PublishedArtifactID:    vars("artifact_id"),
+		ArtifactVersion:        vars("artifact_version"),
 	}
 
 	if !a.checkUser(user, vars("user_id")) {
@@ -421,6 +435,10 @@ func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user user
 	}
 
 	if ok, err := a.checkNanobotAgent(req, &resources, user); !ok || err != nil {
+		return false, err
+	}
+
+	if ok, err := a.checkPublishedArtifact(req, &resources, user); !ok || err != nil {
 		return false, err
 	}
 

--- a/pkg/api/handlers/publishedartifact.go
+++ b/pkg/api/handlers/publishedartifact.go
@@ -20,6 +20,7 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/auth"
 	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/publishedartifact"
 	"github.com/obot-platform/obot/pkg/skillformat"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/storage/blob"
@@ -123,7 +124,7 @@ func (h *PublishedArtifactHandler) Create(req api.Context) error {
 		}
 
 		// Update existing artifact with a new version.
-		previousVersionSubjects := versionSubjects(&existing, existing.Spec.LatestVersion)
+		previousVersionSubjects := publishedartifact.VersionSubjects(&existing, existing.Spec.LatestVersion)
 		version := existing.Spec.LatestVersion + 1
 
 		// Stamp publish metadata into SKILL.md before uploading the next version.
@@ -266,7 +267,7 @@ func (h *PublishedArtifactHandler) List(req api.Context) error {
 	for i := range artifacts.Items {
 		a := &artifacts.Items[i]
 
-		if !h.canAccessArtifact(a, req.User, req.UserIsAdmin()) {
+		if !publishedartifact.CanAccess(a, req.User, req.UserIsAdmin()) {
 			continue
 		}
 
@@ -297,10 +298,6 @@ func (h *PublishedArtifactHandler) Get(req api.Context) error {
 		return err
 	}
 
-	if err := h.checkVisibility(&artifact, req); err != nil {
-		return err
-	}
-
 	return req.Write(convertPublishedArtifactForRequester(&artifact, req.User, req.UserIsAdmin()))
 }
 
@@ -315,11 +312,7 @@ func (h *PublishedArtifactHandler) Download(req api.Context) error {
 		return err
 	}
 
-	if err := h.checkVisibility(&artifact, req); err != nil {
-		return err
-	}
-
-	version := h.defaultDownloadVersion(&artifact, req.User, req.UserIsAdmin())
+	version := publishedartifact.DefaultDownloadVersion(&artifact, req.User, req.UserIsAdmin())
 	if version == 0 {
 		return types.NewErrNotFound("artifact %s not found", id)
 	}
@@ -329,10 +322,6 @@ func (h *PublishedArtifactHandler) Download(req api.Context) error {
 			return types.NewErrBadRequest("invalid version: %s", v)
 		}
 		version = parsed
-	}
-
-	if !h.canAccessArtifactVersion(&artifact, version, req.User, req.UserIsAdmin()) {
-		return types.NewErrNotFound("version %d not found", version)
 	}
 
 	log.Debugf("Download requested: artifact=%s name=%q version=%d", id, artifact.Spec.Name, version)
@@ -382,16 +371,9 @@ func (h *PublishedArtifactHandler) GetSkillMD(req api.Context) error {
 		return err
 	}
 
-	if err := h.checkVisibility(&artifact, req); err != nil {
-		return err
-	}
-
 	version, err := strconv.Atoi(req.PathValue("version"))
 	if err != nil || version < 1 {
 		return types.NewErrBadRequest("invalid version: %s", req.PathValue("version"))
-	}
-	if !h.canAccessArtifactVersion(&artifact, version, req.User, req.UserIsAdmin()) {
-		return types.NewErrNotFound("version %d not found", version)
 	}
 
 	// Find the blob key for the requested version
@@ -462,10 +444,6 @@ func (h *PublishedArtifactHandler) Update(req api.Context) error {
 		return err
 	}
 
-	if err := h.checkOwnership(&artifact, req); err != nil {
-		return err
-	}
-
 	var update publishedArtifactUpdateRequest
 	if err := req.Read(&update); err != nil {
 		return err
@@ -492,7 +470,7 @@ func (h *PublishedArtifactHandler) Update(req api.Context) error {
 			}
 			version = *update.Version
 		}
-		entry := findVersionEntry(&artifact, version)
+		entry := publishedartifact.VersionEntry(&artifact, version)
 		if entry == nil {
 			return types.NewErrNotFound("version %d not found", version)
 		}
@@ -519,10 +497,6 @@ func (h *PublishedArtifactHandler) Delete(req api.Context) error {
 		return err
 	}
 
-	if err := h.checkOwnership(&artifact, req); err != nil {
-		return err
-	}
-
 	log.Debugf("Deleting artifact %s (%s), removing %d version blobs", id, artifact.Spec.Name, len(artifact.Status.Versions))
 
 	// Delete all version blobs
@@ -538,62 +512,6 @@ func (h *PublishedArtifactHandler) Delete(req api.Context) error {
 
 	log.Infof("Deleted artifact %s (%s)", id, artifact.Spec.Name)
 	return nil
-}
-
-func (h *PublishedArtifactHandler) checkVisibility(artifact *v1.PublishedArtifact, req api.Context) error {
-	if h.canAccessArtifact(artifact, req.User, req.UserIsAdmin()) {
-		return nil
-	}
-	return types.NewErrNotFound("artifact %s not found", req.PathValue("id"))
-}
-
-func (h *PublishedArtifactHandler) canAccessArtifact(artifact *v1.PublishedArtifact, requester user.Info, isAdmin bool) bool {
-	if requester == nil {
-		return false
-	}
-	if isAdmin || artifact.Spec.AuthorID == requester.GetUID() {
-		return true
-	}
-	for _, version := range artifact.Status.Versions {
-		if subjectsContainUser(version.Subjects, requester) {
-			return true
-		}
-	}
-	return false
-}
-
-func (h *PublishedArtifactHandler) checkOwnership(artifact *v1.PublishedArtifact, req api.Context) error {
-	if artifact.Spec.AuthorID == req.User.GetUID() || req.UserIsAdmin() {
-		return nil
-	}
-	return types.NewErrNotFound("artifact %s not found", req.PathValue("id"))
-}
-
-func (h *PublishedArtifactHandler) canAccessArtifactVersion(artifact *v1.PublishedArtifact, version int, requester user.Info, isAdmin bool) bool {
-	if requester == nil {
-		return false
-	}
-	if isAdmin || artifact.Spec.AuthorID == requester.GetUID() {
-		return findVersionEntry(artifact, version) != nil
-	}
-	return subjectsContainUser(versionSubjects(artifact, version), requester)
-}
-
-func (h *PublishedArtifactHandler) defaultDownloadVersion(artifact *v1.PublishedArtifact, requester user.Info, isAdmin bool) int {
-	if requester == nil {
-		return 0
-	}
-	if isAdmin || artifact.Spec.AuthorID == requester.GetUID() {
-		return artifact.Spec.LatestVersion
-	}
-
-	latestVisible := 0
-	for _, version := range artifact.Status.Versions {
-		if subjectsContainUser(version.Subjects, requester) && version.Version > latestVisible {
-			latestVisible = version.Version
-		}
-	}
-	return latestVisible
 }
 
 func validatePublishedArtifactSubjects(subjects []types.Subject) error {
@@ -615,60 +533,6 @@ func validatePublishedArtifactSubjects(subjects []types.Subject) error {
 	}
 
 	return nil
-}
-
-func findVersionEntry(artifact *v1.PublishedArtifact, version int) *types.PublishedArtifactVersionEntry {
-	for i := range artifact.Status.Versions {
-		if artifact.Status.Versions[i].Version == version {
-			return &artifact.Status.Versions[i]
-		}
-	}
-	return nil
-}
-
-func versionSubjects(artifact *v1.PublishedArtifact, version int) []types.Subject {
-	entry := findVersionEntry(artifact, version)
-	if entry == nil {
-		return nil
-	}
-	return entry.Subjects[:]
-}
-
-func subjectsContainUser(subjects []types.Subject, requester user.Info) bool {
-	if requester == nil {
-		return false
-	}
-	userID := requester.GetUID()
-	groups := authGroupSet(requester)
-	for _, subject := range subjects {
-		switch subject.Type {
-		case types.SubjectTypeUser:
-			if subject.ID == userID {
-				return true
-			}
-		case types.SubjectTypeGroup:
-			if _, ok := groups[subject.ID]; ok {
-				return true
-			}
-		case types.SubjectTypeSelector:
-			if subject.ID == "*" {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func authGroupSet(requester user.Info) map[string]struct{} {
-	if requester == nil {
-		return map[string]struct{}{}
-	}
-	result := make(map[string]struct{}, len(requester.GetExtra()["auth_provider_groups"]))
-	for _, group := range requester.GetExtra()["auth_provider_groups"] {
-		result[group] = struct{}{}
-	}
-	return result
 }
 
 // validateZIP checks the ZIP archive for file count limits, total declared uncompressed size,
@@ -900,7 +764,7 @@ func visibleVersionSummaries(a *v1.PublishedArtifact, requester user.Info, isAdm
 
 	result := make([]types.PublishedArtifactVersionSummary, 0, len(a.Status.Versions))
 	for _, version := range a.Status.Versions {
-		if a.Spec.AuthorID != requester.GetUID() && !isAdmin && !subjectsContainUser(version.Subjects, requester) {
+		if a.Spec.AuthorID != requester.GetUID() && !isAdmin && !publishedartifact.SubjectsContainUser(version.Subjects, requester) {
 			continue
 		}
 		result = append(result, types.PublishedArtifactVersionSummary{

--- a/pkg/api/handlers/publishedartifact_test.go
+++ b/pkg/api/handlers/publishedartifact_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/publishedartifact"
 	"github.com/obot-platform/obot/pkg/skillformat"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	blobpkg "github.com/obot-platform/obot/pkg/storage/blob"
@@ -491,7 +492,6 @@ func TestValidatePublishedArtifactSubjects(t *testing.T) {
 }
 
 func TestCanAccessArtifact(t *testing.T) {
-	handler := &PublishedArtifactHandler{}
 	artifact := &v1.PublishedArtifact{
 		Spec: v1.PublishedArtifactSpec{
 			AuthorID: "owner",
@@ -508,13 +508,13 @@ func TestCanAccessArtifact(t *testing.T) {
 		},
 	}
 
-	if !handler.canAccessArtifact(artifact, &kuser.DefaultInfo{UID: "owner"}, false) {
+	if !publishedartifact.CanAccess(artifact, &kuser.DefaultInfo{UID: "owner"}, false) {
 		t.Fatal("owner should have access")
 	}
-	if !handler.canAccessArtifact(artifact, &kuser.DefaultInfo{UID: "other"}, true) {
+	if !publishedartifact.CanAccess(artifact, &kuser.DefaultInfo{UID: "other"}, true) {
 		t.Fatal("admin should have access")
 	}
-	if !handler.canAccessArtifact(artifact, &kuser.DefaultInfo{
+	if !publishedartifact.CanAccess(artifact, &kuser.DefaultInfo{
 		UID: "other",
 		Extra: map[string][]string{
 			"auth_provider_groups": {"group1"},
@@ -522,7 +522,7 @@ func TestCanAccessArtifact(t *testing.T) {
 	}, false) {
 		t.Fatal("group member should have access")
 	}
-	if handler.canAccessArtifact(artifact, &kuser.DefaultInfo{UID: "other"}, false) {
+	if publishedartifact.CanAccess(artifact, &kuser.DefaultInfo{UID: "other"}, false) {
 		t.Fatal("unmatched user should not have access")
 	}
 }
@@ -733,38 +733,6 @@ func TestValidateZIP_Valid(t *testing.T) {
 	}
 	if err := validateZIP(r); err != nil {
 		t.Fatalf("validateZIP() unexpected error: %v", err)
-	}
-}
-
-func TestCheckOwnership_ReturnsNotFoundForNonOwner(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPatch, "/api/published-artifacts/pa123", nil)
-	req.SetPathValue("id", "pa123")
-
-	err := (&PublishedArtifactHandler{}).checkOwnership(&v1.PublishedArtifact{
-		Spec: v1.PublishedArtifactSpec{
-			AuthorID: "owner",
-		},
-	}, api.Context{
-		Request:        req,
-		ResponseWriter: httptest.NewRecorder(),
-		User: &kuser.DefaultInfo{
-			UID:    "other-user",
-			Groups: []string{types.GroupAuthenticated},
-		},
-	})
-	if err == nil {
-		t.Fatal("expected error for non-owner")
-	}
-
-	errHTTP, ok := err.(*types.ErrHTTP)
-	if !ok {
-		t.Fatalf("expected *types.ErrHTTP, got %T", err)
-	}
-	if errHTTP.Code != http.StatusNotFound {
-		t.Fatalf("status code = %d, want %d", errHTTP.Code, http.StatusNotFound)
-	}
-	if !strings.Contains(errHTTP.Message, "pa123") {
-		t.Fatalf("message = %q, want artifact id", errHTTP.Message)
 	}
 }
 

--- a/pkg/publishedartifact/access.go
+++ b/pkg/publishedartifact/access.go
@@ -1,0 +1,89 @@
+package publishedartifact
+
+import (
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func CanAccess(artifact *v1.PublishedArtifact, requester user.Info, isAdmin bool) bool {
+	if isAdmin || artifact.Spec.AuthorID == requester.GetUID() {
+		return true
+	}
+	for _, version := range artifact.Status.Versions {
+		if SubjectsContainUser(version.Subjects, requester) {
+			return true
+		}
+	}
+	return false
+}
+
+func CanAccessVersion(artifact *v1.PublishedArtifact, version int, requester user.Info, isAdmin bool) bool {
+	if isAdmin || artifact.Spec.AuthorID == requester.GetUID() {
+		return VersionEntry(artifact, version) != nil
+	}
+	return SubjectsContainUser(VersionSubjects(artifact, version), requester)
+}
+
+func DefaultDownloadVersion(artifact *v1.PublishedArtifact, requester user.Info, isAdmin bool) int {
+	if isAdmin || artifact.Spec.AuthorID == requester.GetUID() {
+		return artifact.Spec.LatestVersion
+	}
+
+	var latestVisible int
+	for _, version := range artifact.Status.Versions {
+		if SubjectsContainUser(version.Subjects, requester) && version.Version > latestVisible {
+			latestVisible = version.Version
+		}
+	}
+	return latestVisible
+}
+
+func VersionEntry(artifact *v1.PublishedArtifact, version int) *types.PublishedArtifactVersionEntry {
+	for _, v := range artifact.Status.Versions {
+		if v.Version == version {
+			return &v
+		}
+	}
+	return nil
+}
+
+func VersionSubjects(artifact *v1.PublishedArtifact, version int) []types.Subject {
+	entry := VersionEntry(artifact, version)
+	if entry == nil {
+		return nil
+	}
+	return entry.Subjects[:]
+}
+
+func SubjectsContainUser(subjects []types.Subject, requester user.Info) bool {
+	userID := requester.GetUID()
+	groups := authGroupSet(requester)
+	for _, subject := range subjects {
+		switch subject.Type {
+		case types.SubjectTypeUser:
+			if subject.ID == userID {
+				return true
+			}
+		case types.SubjectTypeGroup:
+			if _, ok := groups[subject.ID]; ok {
+				return true
+			}
+		case types.SubjectTypeSelector:
+			if subject.ID == "*" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func authGroupSet(requester user.Info) map[string]struct{} {
+	providerGroups := requester.GetExtra()["auth_provider_groups"]
+	result := make(map[string]struct{}, len(providerGroups))
+	for _, group := range providerGroups {
+		result[group] = struct{}{}
+	}
+	return result
+}


### PR DESCRIPTION
As much as possible, our authorization should remain outside the API layer. This change moves all but the list logic for published artifacts into the authorization layer.