### PR TITLE
fix: deep-link scan observations by row id instead of slice index

### DIFF
--- a/apiclient/types/devicescan.go
+++ b/apiclient/types/devicescan.go
@@ -2,6 +2,10 @@ package types
 
 // DeviceScanManifest is what `obot scan` submits. Server-assigned
 // fields (id, receivedAt, submittedBy) live on DeviceScan instead.
+// Child observations share the same wire type for submission and
+// response — the ID field is server-set and decoded into a zero value
+// on submission, which DeviceScanFromManifest deliberately does not
+// copy. Submitters cannot trample existing row PKs.
 type DeviceScanManifest struct {
 	// ScannerVersion is the obot version that produced the scan.
 	ScannerVersion string `json:"scannerVersion"`
@@ -64,8 +68,13 @@ type DeviceScanFile struct {
 	Content string `json:"content,omitempty"`
 }
 
-// DeviceScanMCPServer is one MCP server observation.
+// DeviceScanMCPServer is one MCP server observation. On submission ID
+// is zero and server-assigned on insert; on responses it is the row's
+// PK inside device_scan_mcp_servers. Use ID as the {id} segment of
+// scan-scoped detail URLs.
 type DeviceScanMCPServer struct {
+	// ID is the row's primary key. Server-set; ignored on submission.
+	ID uint `json:"id,omitempty"`
 	// Client is the canonical client name (e.g. "cursor"); empty for orphans.
 	Client string `json:"client"`
 	// ProjectPath is the project root for project-scope observations; empty for global.
@@ -92,8 +101,13 @@ type DeviceScanMCPServer struct {
 	URL string `json:"url,omitempty"`
 }
 
-// DeviceScanSkill is one skill (SKILL.md) observation.
+// DeviceScanSkill is one skill (SKILL.md) observation. On submission
+// ID is zero and server-assigned on insert; on responses it is the
+// row's PK inside device_scan_skills. Use ID as the {id} segment of
+// scan-scoped detail URLs.
 type DeviceScanSkill struct {
+	// ID is the row's primary key. Server-set; ignored on submission.
+	ID uint `json:"id,omitempty"`
 	// Client is the canonical client name; "multi" for free-floating
 	// SKILL.md files with no canonical owning client (e.g.
 	// .agents/skills, .agent/skills, project skills outside a known
@@ -137,8 +151,13 @@ type DeviceScanClient struct {
 	HasPlugins bool `json:"hasPlugins"`
 }
 
-// DeviceScanPlugin is one plugin observation.
+// DeviceScanPlugin is one plugin observation. On submission ID is
+// zero and server-assigned on insert; on responses it is the row's
+// PK inside device_scan_plugins. Use ID as the {id} segment of
+// scan-scoped detail URLs.
 type DeviceScanPlugin struct {
+	// ID is the row's primary key. Server-set; ignored on submission.
+	ID uint `json:"id,omitempty"`
 	// Client is the canonical client name that owns the plugin host.
 	Client string `json:"client"`
 	// ProjectPath is the project root for project-scope plugins.
@@ -294,8 +313,9 @@ type DeviceMCPServerOccurrence struct {
 	Scope string `json:"scope"`
 	// ScannedAt is when the parent scan was collected on the device.
 	ScannedAt Time `json:"scannedAt"`
-	// Index is the position of this row inside the parent scan's MCPServers slice.
-	Index int `json:"index"`
+	// ID is the PK of this row inside device_scan_mcp_servers. Use it
+	// to deep-link to /api/devices/scans/{deviceScanID}/mcp-servers/{id}.
+	ID uint `json:"id"`
 }
 
 type DeviceMCPServerOccurrenceList List[DeviceMCPServerOccurrence]
@@ -324,8 +344,9 @@ type DeviceSkillOccurrence struct {
 	ProjectPath string `json:"projectPath,omitempty"`
 	// ScannedAt is when the parent scan was collected on the device.
 	ScannedAt Time `json:"scannedAt"`
-	// Index is the position of this row inside the parent scan's Skills slice.
-	Index int `json:"index"`
+	// ID is the PK of this row inside device_scan_skills. Use it to
+	// deep-link to /api/devices/scans/{deviceScanID}/skills/{id}.
+	ID uint `json:"id"`
 }
 
 type DeviceSkillOccurrenceList List[DeviceSkillOccurrence]

--- a/apiclient/types/devicescan.go
+++ b/apiclient/types/devicescan.go
@@ -68,10 +68,8 @@ type DeviceScanFile struct {
 	Content string `json:"content,omitempty"`
 }
 
-// DeviceScanMCPServer is one MCP server observation. On submission ID
-// is zero and server-assigned on insert; on responses it is the row's
-// PK inside device_scan_mcp_servers. Use ID as the {id} segment of
-// scan-scoped detail URLs.
+// DeviceScanMCPServer is one MCP server observation. ID is
+// server-assigned on insert and stable across responses.
 type DeviceScanMCPServer struct {
 	// ID is the row's primary key. Server-set; ignored on submission.
 	ID uint `json:"id,omitempty"`
@@ -101,10 +99,8 @@ type DeviceScanMCPServer struct {
 	URL string `json:"url,omitempty"`
 }
 
-// DeviceScanSkill is one skill (SKILL.md) observation. On submission
-// ID is zero and server-assigned on insert; on responses it is the
-// row's PK inside device_scan_skills. Use ID as the {id} segment of
-// scan-scoped detail URLs.
+// DeviceScanSkill is one skill (SKILL.md) observation. ID is
+// server-assigned on insert and stable across responses.
 type DeviceScanSkill struct {
 	// ID is the row's primary key. Server-set; ignored on submission.
 	ID uint `json:"id,omitempty"`
@@ -151,10 +147,8 @@ type DeviceScanClient struct {
 	HasPlugins bool `json:"hasPlugins"`
 }
 
-// DeviceScanPlugin is one plugin observation. On submission ID is
-// zero and server-assigned on insert; on responses it is the row's
-// PK inside device_scan_plugins. Use ID as the {id} segment of
-// scan-scoped detail URLs.
+// DeviceScanPlugin is one plugin observation. ID is server-assigned
+// on insert and stable across responses.
 type DeviceScanPlugin struct {
 	// ID is the row's primary key. Server-set; ignored on submission.
 	ID uint `json:"id,omitempty"`
@@ -313,8 +307,7 @@ type DeviceMCPServerOccurrence struct {
 	Scope string `json:"scope"`
 	// ScannedAt is when the parent scan was collected on the device.
 	ScannedAt Time `json:"scannedAt"`
-	// ID is the PK of this row inside device_scan_mcp_servers. Use it
-	// to deep-link to /api/devices/scans/{deviceScanID}/mcp-servers/{id}.
+	// ID is the observation's stable identifier.
 	ID uint `json:"id"`
 }
 
@@ -344,8 +337,7 @@ type DeviceSkillOccurrence struct {
 	ProjectPath string `json:"projectPath,omitempty"`
 	// ScannedAt is when the parent scan was collected on the device.
 	ScannedAt Time `json:"scannedAt"`
-	// ID is the PK of this row inside device_scan_skills. Use it to
-	// deep-link to /api/devices/scans/{deviceScanID}/skills/{id}.
+	// ID is the observation's stable identifier.
 	ID uint `json:"id"`
 }
 

--- a/pkg/api/handlers/devicescans.go
+++ b/pkg/api/handlers/devicescans.go
@@ -204,7 +204,7 @@ func (*DeviceScansHandler) ListMCPServerOccurrences(req api.Context) error {
 			Client:       r.Client,
 			Scope:        r.Scope,
 			ScannedAt:    *types.NewTime(r.ScannedAt),
-			Index:        r.Index,
+			ID:           r.ID,
 		})
 	}
 	return req.Write(types.DeviceMCPServerOccurrenceResponse{
@@ -344,7 +344,7 @@ func (*DeviceScansHandler) ListSkillOccurrences(req api.Context) error {
 			Scope:        r.Scope,
 			ProjectPath:  r.ProjectPath,
 			ScannedAt:    *types.NewTime(r.ScannedAt),
-			Index:        r.Index,
+			ID:           r.ID,
 		})
 	}
 	return req.Write(types.DeviceSkillOccurrenceResponse{

--- a/pkg/gateway/client/devicescan.go
+++ b/pkg/gateway/client/devicescan.go
@@ -364,9 +364,7 @@ func (c *Client) GetSkillDetail(ctx context.Context, name string) (*types.SkillD
 
 // ListSkillOccurrences returns one row per (device, observation) for
 // the given skill name, drawn from the all-time latest scan of every
-// device. Sorted scanned_at DESC, paginated. ID is the row's PK
-// inside device_scan_skills (so the UI can deep-link to
-// /admin/device-scans/{scan_id}/skills/{id}).
+// device. Sorted scanned_at DESC, paginated.
 func (c *Client) ListSkillOccurrences(ctx context.Context, name string, limit, offset int) ([]types.SkillOccurrence, int64, error) {
 	if name == "" {
 		return nil, 0, errors.New("empty skill name")

--- a/pkg/gateway/client/devicescan.go
+++ b/pkg/gateway/client/devicescan.go
@@ -364,9 +364,9 @@ func (c *Client) GetSkillDetail(ctx context.Context, name string) (*types.SkillD
 
 // ListSkillOccurrences returns one row per (device, observation) for
 // the given skill name, drawn from the all-time latest scan of every
-// device. Sorted scanned_at DESC, paginated. Index is the position
-// inside the parent scan's Skills slice (so the UI can deep-link to
-// /admin/device-scans/{scan_id}/skills/{index}).
+// device. Sorted scanned_at DESC, paginated. ID is the row's PK
+// inside device_scan_skills (so the UI can deep-link to
+// /admin/device-scans/{scan_id}/skills/{id}).
 func (c *Client) ListSkillOccurrences(ctx context.Context, name string, limit, offset int) ([]types.SkillOccurrence, int64, error) {
 	if name == "" {
 		return nil, 0, errors.New("empty skill name")
@@ -385,14 +385,13 @@ func (c *Client) ListSkillOccurrences(ctx context.Context, name string, limit, o
 	}
 
 	q := base.Session(&gorm.Session{}).
-		Select(`sk.device_scan_id AS device_scan_id,
+		Select(`sk.id AS id,
+			sk.device_scan_id AS device_scan_id,
 			s.device_id AS device_id,
 			sk.client AS client,
 			sk.scope AS scope,
 			sk.project_path AS project_path,
-			s.scanned_at AS scanned_at,
-			(SELECT COUNT(*) FROM device_scan_skills sk2
-			 WHERE sk2.device_scan_id = sk.device_scan_id AND sk2.id < sk.id) AS idx`).
+			s.scanned_at AS scanned_at`).
 		Order("s.scanned_at DESC, sk.id ASC")
 
 	if limit > 0 {
@@ -517,13 +516,12 @@ func (c *Client) ListMCPServerOccurrences(ctx context.Context, configHash string
 	}
 
 	q := base.Session(&gorm.Session{}).
-		Select(`m.device_scan_id AS device_scan_id,
+		Select(`m.id AS id,
+			m.device_scan_id AS device_scan_id,
 			s.device_id AS device_id,
 			m.client AS client,
 			m.scope AS scope,
-			s.scanned_at AS scanned_at,
-			(SELECT COUNT(*) FROM device_scan_mcp_servers m2
-			 WHERE m2.device_scan_id = m.device_scan_id AND m2.id < m.id) AS idx`).
+			s.scanned_at AS scanned_at`).
 		Order("s.scanned_at DESC, m.id ASC")
 
 	if limit > 0 {

--- a/pkg/gateway/client/devicescan_test.go
+++ b/pkg/gateway/client/devicescan_test.go
@@ -243,36 +243,3 @@ func TestGetMCPServerDetail(t *testing.T) {
 		t.Errorf("header keys: want [X-Auth], got %v", d.HeaderKeys)
 	}
 }
-
-// TestListMCPServerOccurrences_PaginationAndID verifies the
-// occurrence row carries the matching device_scan_mcp_servers PK.
-func TestListMCPServerOccurrences_PaginationAndID(t *testing.T) {
-	c := newTestClient(t)
-	ctx := context.Background()
-
-	now := time.Now().UTC()
-	hash := "h"
-	scan := types.DeviceScan{
-		SubmittedBy: "u", DeviceID: "d", ScannedAt: now,
-		MCPServers: []types.DeviceScanMCPServer{
-			{Client: "claude-code", Name: "first", Transport: "stdio", ConfigHash: "other-1"},
-			{Client: "claude-code", Name: "target", Transport: "stdio", ConfigHash: hash},
-			{Client: "claude-code", Name: "third", Transport: "stdio", ConfigHash: "other-2"},
-		},
-	}
-	insertScan(t, c, scan)
-
-	rows, total, err := c.ListMCPServerOccurrences(ctx, hash, 50, 0)
-	if err != nil {
-		t.Fatalf("list failed: %v", err)
-	}
-	if total != 1 {
-		t.Errorf("total: want 1, got %d", total)
-	}
-	if len(rows) != 1 {
-		t.Fatalf("rows: want 1, got %d", len(rows))
-	}
-	if rows[0].ID == 0 {
-		t.Errorf("occurrence ID: want non-zero PK, got 0")
-	}
-}

--- a/pkg/gateway/client/devicescan_test.go
+++ b/pkg/gateway/client/devicescan_test.go
@@ -244,23 +244,23 @@ func TestGetMCPServerDetail(t *testing.T) {
 	}
 }
 
-// TestListMCPServerOccurrences_PaginationAndIndex verifies the
-// occurrence index is the row's position within its parent scan.
-func TestListMCPServerOccurrences_PaginationAndIndex(t *testing.T) {
+// TestListMCPServerOccurrences_PaginationAndID verifies the
+// occurrence row carries the matching device_scan_mcp_servers PK.
+func TestListMCPServerOccurrences_PaginationAndID(t *testing.T) {
 	c := newTestClient(t)
 	ctx := context.Background()
 
 	now := time.Now().UTC()
 	hash := "h"
-	// Scan with the target row at index 1 (second of three).
-	insertScan(t, c, types.DeviceScan{
+	scan := types.DeviceScan{
 		SubmittedBy: "u", DeviceID: "d", ScannedAt: now,
 		MCPServers: []types.DeviceScanMCPServer{
 			{Client: "claude-code", Name: "first", Transport: "stdio", ConfigHash: "other-1"},
 			{Client: "claude-code", Name: "target", Transport: "stdio", ConfigHash: hash},
 			{Client: "claude-code", Name: "third", Transport: "stdio", ConfigHash: "other-2"},
 		},
-	})
+	}
+	insertScan(t, c, scan)
 
 	rows, total, err := c.ListMCPServerOccurrences(ctx, hash, 50, 0)
 	if err != nil {
@@ -272,7 +272,7 @@ func TestListMCPServerOccurrences_PaginationAndIndex(t *testing.T) {
 	if len(rows) != 1 {
 		t.Fatalf("rows: want 1, got %d", len(rows))
 	}
-	if rows[0].Index != 1 {
-		t.Errorf("occurrence index within parent scan: want 1, got %d", rows[0].Index)
+	if rows[0].ID == 0 {
+		t.Errorf("occurrence ID: want non-zero PK, got 0")
 	}
 }

--- a/pkg/gateway/types/devicescan.go
+++ b/pkg/gateway/types/devicescan.go
@@ -310,9 +310,7 @@ type SkillDetail struct {
 }
 
 // MCPServerOccurrence is one device's latest-scan instance of a given
-// ConfigHash. ID is the row's PK inside device_scan_mcp_servers, used
-// by the UI to deep-link to
-// /admin/device-scans/{deviceScanID}/mcp-servers/{id}.
+// ConfigHash.
 type MCPServerOccurrence struct {
 	DeviceScanID uint      `gorm:"column:device_scan_id"`
 	DeviceID     string    `gorm:"column:device_id"`
@@ -323,9 +321,7 @@ type MCPServerOccurrence struct {
 }
 
 // SkillOccurrence is one device's latest-scan instance of a given
-// skill name. ID is the row's PK inside device_scan_skills, used by
-// the UI to deep-link to
-// /admin/device-scans/{deviceScanID}/skills/{id}.
+// skill name.
 type SkillOccurrence struct {
 	DeviceScanID uint      `gorm:"column:device_scan_id"`
 	DeviceID     string    `gorm:"column:device_id"`

--- a/pkg/gateway/types/devicescan.go
+++ b/pkg/gateway/types/devicescan.go
@@ -201,6 +201,7 @@ func ConvertDeviceScanFile(f DeviceScanFile) types2.DeviceScanFile {
 
 func ConvertDeviceScanMCPServer(m DeviceScanMCPServer) types2.DeviceScanMCPServer {
 	return types2.DeviceScanMCPServer{
+		ID:          m.ID,
 		Client:      m.Client,
 		ProjectPath: m.ProjectPath,
 		File:        m.File,
@@ -217,6 +218,7 @@ func ConvertDeviceScanMCPServer(m DeviceScanMCPServer) types2.DeviceScanMCPServe
 
 func ConvertDeviceScanSkill(s DeviceScanSkill) types2.DeviceScanSkill {
 	return types2.DeviceScanSkill{
+		ID:           s.ID,
 		Client:       s.Client,
 		ProjectPath:  s.ProjectPath,
 		File:         s.File,
@@ -230,6 +232,7 @@ func ConvertDeviceScanSkill(s DeviceScanSkill) types2.DeviceScanSkill {
 
 func ConvertDeviceScanPlugin(p DeviceScanPlugin) types2.DeviceScanPlugin {
 	return types2.DeviceScanPlugin{
+		ID:            p.ID,
 		Client:        p.Client,
 		ProjectPath:   p.ProjectPath,
 		ConfigPath:    p.ConfigPath,
@@ -307,22 +310,22 @@ type SkillDetail struct {
 }
 
 // MCPServerOccurrence is one device's latest-scan instance of a given
-// ConfigHash. Index is the position of the row inside the parent scan's
-// MCPServers slice (GORM preload order, by id ASC) so the UI can deep-
-// link to /admin/device-scans/{deviceScanID}/mcp/{index}.
+// ConfigHash. ID is the row's PK inside device_scan_mcp_servers, used
+// by the UI to deep-link to
+// /admin/device-scans/{deviceScanID}/mcp-servers/{id}.
 type MCPServerOccurrence struct {
 	DeviceScanID uint      `gorm:"column:device_scan_id"`
 	DeviceID     string    `gorm:"column:device_id"`
 	Client       string    `gorm:"column:client"`
 	Scope        string    `gorm:"column:scope"`
 	ScannedAt    time.Time `gorm:"column:scanned_at"`
-	Index        int       `gorm:"column:idx"`
+	ID           uint      `gorm:"column:id"`
 }
 
 // SkillOccurrence is one device's latest-scan instance of a given
-// skill name. Index is the position of the row inside the parent
-// scan's Skills slice (GORM preload order) so the UI can deep-link
-// to /admin/device-scans/{deviceScanID}/skills/{index}.
+// skill name. ID is the row's PK inside device_scan_skills, used by
+// the UI to deep-link to
+// /admin/device-scans/{deviceScanID}/skills/{id}.
 type SkillOccurrence struct {
 	DeviceScanID uint      `gorm:"column:device_scan_id"`
 	DeviceID     string    `gorm:"column:device_id"`
@@ -330,7 +333,7 @@ type SkillOccurrence struct {
 	Scope        string    `gorm:"column:scope"`
 	ProjectPath  string    `gorm:"column:project_path"`
 	ScannedAt    time.Time `gorm:"column:scanned_at"`
-	Index        int       `gorm:"column:idx"`
+	ID           uint      `gorm:"column:id"`
 }
 
 // DeviceScanFromManifest builds a gateway DeviceScan + its children

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2944,7 +2944,7 @@ func schema_obot_platform_obot_apiclient_types_DeviceMCPServerOccurrence(ref com
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the PK of this row inside device_scan_mcp_servers. Use it to deep-link to /api/devices/scans/{deviceScanID}/mcp-servers/{id}.",
+							Description: "ID is the observation's stable identifier.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -3443,7 +3443,7 @@ func schema_obot_platform_obot_apiclient_types_DeviceScanMCPServer(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DeviceScanMCPServer is one MCP server observation. On submission ID is zero and server-assigned on insert; on responses it is the row's PK inside device_scan_mcp_servers. Use ID as the {id} segment of scan-scoped detail URLs.",
+				Description: "DeviceScanMCPServer is one MCP server observation. ID is server-assigned on insert and stable across responses.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"id": {
@@ -3707,7 +3707,7 @@ func schema_obot_platform_obot_apiclient_types_DeviceScanPlugin(ref common.Refer
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DeviceScanPlugin is one plugin observation. On submission ID is zero and server-assigned on insert; on responses it is the row's PK inside device_scan_plugins. Use ID as the {id} segment of scan-scoped detail URLs.",
+				Description: "DeviceScanPlugin is one plugin observation. ID is server-assigned on insert and stable across responses.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"id": {
@@ -3907,7 +3907,7 @@ func schema_obot_platform_obot_apiclient_types_DeviceScanSkill(ref common.Refere
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DeviceScanSkill is one skill (SKILL.md) observation. On submission ID is zero and server-assigned on insert; on responses it is the row's PK inside device_scan_skills. Use ID as the {id} segment of scan-scoped detail URLs.",
+				Description: "DeviceScanSkill is one skill (SKILL.md) observation. ID is server-assigned on insert and stable across responses.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"id": {
@@ -4203,7 +4203,7 @@ func schema_obot_platform_obot_apiclient_types_DeviceSkillOccurrence(ref common.
 					},
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the PK of this row inside device_scan_skills. Use it to deep-link to /api/devices/scans/{deviceScanID}/skills/{id}.",
+							Description: "ID is the observation's stable identifier.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -2942,16 +2942,16 @@ func schema_obot_platform_obot_apiclient_types_DeviceMCPServerOccurrence(ref com
 							Ref:         ref("github.com/obot-platform/obot/apiclient/types.Time"),
 						},
 					},
-					"index": {
+					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Index is the position of this row inside the parent scan's MCPServers slice.",
+							Description: "ID is the PK of this row inside device_scan_mcp_servers. Use it to deep-link to /api/devices/scans/{deviceScanID}/mcp-servers/{id}.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 				},
-				Required: []string{"deviceScanID", "deviceID", "client", "scope", "scannedAt", "index"},
+				Required: []string{"deviceScanID", "deviceID", "client", "scope", "scannedAt", "id"},
 			},
 		},
 		Dependencies: []string{
@@ -3443,9 +3443,16 @@ func schema_obot_platform_obot_apiclient_types_DeviceScanMCPServer(ref common.Re
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DeviceScanMCPServer is one MCP server observation.",
+				Description: "DeviceScanMCPServer is one MCP server observation. On submission ID is zero and server-assigned on insert; on responses it is the row's PK inside device_scan_mcp_servers. Use ID as the {id} segment of scan-scoped detail URLs.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"id": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ID is the row's primary key. Server-set; ignored on submission.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Client is the canonical client name (e.g. \"cursor\"); empty for orphans.",
@@ -3561,7 +3568,7 @@ func schema_obot_platform_obot_apiclient_types_DeviceScanManifest(ref common.Ref
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DeviceScanManifest is what `obot scan` submits. Server-assigned fields (id, receivedAt, submittedBy) live on DeviceScan instead.",
+				Description: "DeviceScanManifest is what `obot scan` submits. Server-assigned fields (id, receivedAt, submittedBy) live on DeviceScan instead. Child observations share the same wire type for submission and response — the ID field is server-set and decoded into a zero value on submission, which DeviceScanFromManifest deliberately does not copy. Submitters cannot trample existing row PKs.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"scannerVersion": {
@@ -3700,9 +3707,16 @@ func schema_obot_platform_obot_apiclient_types_DeviceScanPlugin(ref common.Refer
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DeviceScanPlugin is one plugin observation.",
+				Description: "DeviceScanPlugin is one plugin observation. On submission ID is zero and server-assigned on insert; on responses it is the row's PK inside device_scan_plugins. Use ID as the {id} segment of scan-scoped detail URLs.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"id": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ID is the row's primary key. Server-set; ignored on submission.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Client is the canonical client name that owns the plugin host.",
@@ -3893,9 +3907,16 @@ func schema_obot_platform_obot_apiclient_types_DeviceScanSkill(ref common.Refere
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "DeviceScanSkill is one skill (SKILL.md) observation.",
+				Description: "DeviceScanSkill is one skill (SKILL.md) observation. On submission ID is zero and server-assigned on insert; on responses it is the row's PK inside device_scan_skills. Use ID as the {id} segment of scan-scoped detail URLs.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"id": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ID is the row's primary key. Server-set; ignored on submission.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"client": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Client is the canonical client name; \"multi\" for free-floating SKILL.md files with no canonical owning client (e.g. .agents/skills, .agent/skills, project skills outside a known client tree).",
@@ -4180,16 +4201,16 @@ func schema_obot_platform_obot_apiclient_types_DeviceSkillOccurrence(ref common.
 							Ref:         ref("github.com/obot-platform/obot/apiclient/types.Time"),
 						},
 					},
-					"index": {
+					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Index is the position of this row inside the parent scan's Skills slice.",
+							Description: "ID is the PK of this row inside device_scan_skills. Use it to deep-link to /api/devices/scans/{deviceScanID}/skills/{id}.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 				},
-				Required: []string{"deviceScanID", "deviceID", "client", "scope", "scannedAt", "index"},
+				Required: []string{"deviceScanID", "deviceID", "client", "scope", "scannedAt", "id"},
 			},
 		},
 		Dependencies: []string{

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -1256,8 +1256,6 @@ export interface DeviceMCPServerOccurrence {
 	client: string;
 	scope: string;
 	scannedAt: string;
-	// id is the row's PK in device_scan_mcp_servers; use it as the
-	// {id} segment of scan-scoped detail URLs.
 	id: number;
 }
 
@@ -1325,8 +1323,6 @@ export interface DeviceSkillOccurrence {
 	scope: string;
 	projectPath?: string;
 	scannedAt: string;
-	// id is the row's PK in device_scan_skills; use it as the {id}
-	// segment of scan-scoped detail URLs.
 	id: number;
 }
 

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -1136,7 +1136,7 @@ export interface DeviceScanFile {
 }
 
 export interface DeviceScanMCPServer {
-	id?: number;
+	id: number;
 	client: string;
 	projectPath?: string;
 	file?: string;
@@ -1151,7 +1151,7 @@ export interface DeviceScanMCPServer {
 }
 
 export interface DeviceScanSkill {
-	id?: number;
+	id: number;
 	client: string;
 	projectPath?: string;
 	file?: string;
@@ -1163,7 +1163,7 @@ export interface DeviceScanSkill {
 }
 
 export interface DeviceScanPlugin {
-	id?: number;
+	id: number;
 	client: string;
 	projectPath?: string;
 	configPath?: string;

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -1136,6 +1136,7 @@ export interface DeviceScanFile {
 }
 
 export interface DeviceScanMCPServer {
+	id?: number;
 	client: string;
 	projectPath?: string;
 	file?: string;
@@ -1150,6 +1151,7 @@ export interface DeviceScanMCPServer {
 }
 
 export interface DeviceScanSkill {
+	id?: number;
 	client: string;
 	projectPath?: string;
 	file?: string;
@@ -1161,6 +1163,7 @@ export interface DeviceScanSkill {
 }
 
 export interface DeviceScanPlugin {
+	id?: number;
 	client: string;
 	projectPath?: string;
 	configPath?: string;
@@ -1253,7 +1256,9 @@ export interface DeviceMCPServerOccurrence {
 	client: string;
 	scope: string;
 	scannedAt: string;
-	index: number;
+	// id is the row's PK in device_scan_mcp_servers; use it as the
+	// {id} segment of scan-scoped detail URLs.
+	id: number;
 }
 
 export interface DeviceMCPServerOccurrenceList {
@@ -1320,7 +1325,9 @@ export interface DeviceSkillOccurrence {
 	scope: string;
 	projectPath?: string;
 	scannedAt: string;
-	index: number;
+	// id is the row's PK in device_scan_skills; use it as the {id}
+	// segment of scan-scoped detail URLs.
+	id: number;
 }
 
 export interface DeviceSkillOccurrenceList {

--- a/ui/user/src/routes/admin/device-mcp-servers/[hash]/+page.svelte
+++ b/ui/user/src/routes/admin/device-mcp-servers/[hash]/+page.svelte
@@ -31,15 +31,13 @@
 	let configHash = $derived(page.params.hash);
 
 	type Row = DeviceMCPServerOccurrence & {
-		id: string;
 		shortDeviceID: string;
 		scannedRelative: string;
 	};
 
 	let rows = $derived<Row[]>(
-		(occurrencesResp.items ?? []).map((o, i) => ({
+		(occurrencesResp.items ?? []).map((o) => ({
 			...o,
-			id: `${o.deviceScanID}-${o.index}-${i}`,
 			shortDeviceID: (o.deviceID ?? '').slice(0, 12),
 			scannedRelative: formatTimeAgo(o.scannedAt).relativeTime
 		}))
@@ -160,7 +158,7 @@
 					]}
 					onClickRow={(d, isCtrlClick) => {
 						openUrl(
-							`/admin/devices/${d.deviceID}/scans/${d.deviceScanID}/mcp/${d.index}`,
+							`/admin/devices/${d.deviceID}/scans/${d.deviceScanID}/mcp/${d.id}`,
 							isCtrlClick
 						);
 					}}

--- a/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
@@ -33,15 +33,13 @@
 	let skillName = $derived(page.params.name ?? '');
 
 	type Row = DeviceSkillOccurrence & {
-		id: string;
 		shortDeviceID: string;
 		scannedRelative: string;
 	};
 
 	let rows = $derived<Row[]>(
-		(occurrencesResp.items ?? []).map((o, i) => ({
+		(occurrencesResp.items ?? []).map((o) => ({
 			...o,
-			id: `${o.deviceScanID}-${o.index}-${i}`,
 			shortDeviceID: (o.deviceID ?? '').slice(0, 12),
 			scannedRelative: formatTimeAgo(o.scannedAt).relativeTime
 		}))
@@ -157,7 +155,7 @@
 					]}
 					onClickRow={(d, isCtrlClick) => {
 						openUrl(
-							resolve(`/admin/devices/${d.deviceID}/scans/${d.deviceScanID}/skills/${d.index}`),
+							resolve(`/admin/devices/${d.deviceID}/scans/${d.deviceScanID}/skills/${d.id}`),
 							isCtrlClick
 						);
 					}}

--- a/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
@@ -120,30 +120,33 @@
 	}
 
 	let mcpRows = $derived<MCPRow[]>(
-		mcpServers.map((m) => ({
-			...m,
-			id: m.id ?? 0,
-			scope: deriveScope(m.projectPath),
-			endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
-		}))
+		mcpServers
+			.filter((m): m is DeviceScanMCPServer & { id: number } => !!m.id)
+			.map((m) => ({
+				...m,
+				scope: deriveScope(m.projectPath),
+				endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
+			}))
 	);
 
 	let skillRows = $derived<SkillRow[]>(
-		skills.map((s) => ({
-			...s,
-			id: s.id ?? 0,
-			scope: deriveScope(s.projectPath),
-			files_count: (s.files ?? []).length
-		}))
+		skills
+			.filter((s): s is DeviceScanSkill & { id: number } => !!s.id)
+			.map((s) => ({
+				...s,
+				scope: deriveScope(s.projectPath),
+				files_count: (s.files ?? []).length
+			}))
 	);
 
 	let pluginRows = $derived<PluginRow[]>(
-		plugins.map((p) => ({
-			...p,
-			id: p.id ?? 0,
-			scope: deriveScope(p.projectPath),
-			capabilities: capabilitySummary(p)
-		}))
+		plugins
+			.filter((p): p is DeviceScanPlugin & { id: number } => !!p.id)
+			.map((p) => ({
+				...p,
+				scope: deriveScope(p.projectPath),
+				capabilities: capabilitySummary(p)
+			}))
 	);
 
 	let clientRows = $derived<ClientRow[]>(

--- a/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
@@ -59,26 +59,22 @@
 	let clients = $derived<DeviceScanClient[]>(latest?.clients ?? []);
 
 	type MCPRow = DeviceScanMCPServer & {
-		id: string;
-		index: number;
+		id: number;
 		scope: string;
 		endpoint: string;
 	};
 	type SkillRow = DeviceScanSkill & {
-		id: string;
-		index: number;
+		id: number;
 		scope: string;
 		files_count: number;
 	};
 	type PluginRow = DeviceScanPlugin & {
-		id: string;
-		index: number;
+		id: number;
 		scope: string;
 		capabilities: string;
 	};
 	type ClientRow = DeviceScanClient & {
 		id: string;
-		index: number;
 		paths_display: string;
 		has_display: string;
 	};
@@ -124,30 +120,27 @@
 	}
 
 	let mcpRows = $derived<MCPRow[]>(
-		mcpServers.map((m, i) => ({
+		mcpServers.map((m) => ({
 			...m,
-			id: `${m.client}-${m.name}-${i}`,
-			index: i,
+			id: m.id ?? 0,
 			scope: deriveScope(m.projectPath),
 			endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
 		}))
 	);
 
 	let skillRows = $derived<SkillRow[]>(
-		skills.map((s, i) => ({
+		skills.map((s) => ({
 			...s,
-			id: `${s.client}-${s.name}-${i}`,
-			index: i,
+			id: s.id ?? 0,
 			scope: deriveScope(s.projectPath),
 			files_count: (s.files ?? []).length
 		}))
 	);
 
 	let pluginRows = $derived<PluginRow[]>(
-		plugins.map((p, i) => ({
+		plugins.map((p) => ({
 			...p,
-			id: `${p.client}-${p.name}-${i}`,
-			index: i,
+			id: p.id ?? 0,
 			scope: deriveScope(p.projectPath),
 			capabilities: capabilitySummary(p)
 		}))
@@ -157,7 +150,6 @@
 		clients.map((c, i) => ({
 			...c,
 			id: `${c.name}-${i}`,
-			index: i,
 			paths_display: clientPathsSummary(c),
 			has_display: clientHasSummary(c)
 		}))
@@ -319,7 +311,7 @@
 							filterable={['client', 'transport', 'scope']}
 							onClickRow={(d, isCtrlClick) => {
 								openUrl(
-									resolve(`/admin/devices/${deviceId}/scans/${latest.id}/mcp/${d.index}`),
+									resolve(`/admin/devices/${deviceId}/scans/${latest?.id}/mcp/${d.id}`),
 									isCtrlClick
 								);
 							}}
@@ -355,7 +347,7 @@
 							filterable={['client', 'scope']}
 							onClickRow={(d, isCtrlClick) => {
 								openUrl(
-									resolve(`/admin/devices/${deviceId}/scans/${latest.id}/skills/${d.index}`),
+									resolve(`/admin/devices/${deviceId}/scans/${latest?.id}/skills/${d.id}`),
 									isCtrlClick
 								);
 							}}
@@ -400,7 +392,7 @@
 							filterable={['client', 'pluginType', 'scope']}
 							onClickRow={(d, isCtrlClick) => {
 								openUrl(
-									resolve(`/admin/devices/${deviceId}/scans/${latest.id}/plugins/${d.index}`),
+									resolve(`/admin/devices/${deviceId}/scans/${latest?.id}/plugins/${d.id}`),
 									isCtrlClick
 								);
 							}}

--- a/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
@@ -120,33 +120,27 @@
 	}
 
 	let mcpRows = $derived<MCPRow[]>(
-		mcpServers
-			.filter((m): m is DeviceScanMCPServer & { id: number } => !!m.id)
-			.map((m) => ({
-				...m,
-				scope: deriveScope(m.projectPath),
-				endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
-			}))
+		mcpServers.map((m) => ({
+			...m,
+			scope: deriveScope(m.projectPath),
+			endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
+		}))
 	);
 
 	let skillRows = $derived<SkillRow[]>(
-		skills
-			.filter((s): s is DeviceScanSkill & { id: number } => !!s.id)
-			.map((s) => ({
-				...s,
-				scope: deriveScope(s.projectPath),
-				files_count: (s.files ?? []).length
-			}))
+		skills.map((s) => ({
+			...s,
+			scope: deriveScope(s.projectPath),
+			files_count: (s.files ?? []).length
+		}))
 	);
 
 	let pluginRows = $derived<PluginRow[]>(
-		plugins
-			.filter((p): p is DeviceScanPlugin & { id: number } => !!p.id)
-			.map((p) => ({
-				...p,
-				scope: deriveScope(p.projectPath),
-				capabilities: capabilitySummary(p)
-			}))
+		plugins.map((p) => ({
+			...p,
+			scope: deriveScope(p.projectPath),
+			capabilities: capabilitySummary(p)
+		}))
 	);
 
 	let clientRows = $derived<ClientRow[]>(

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
@@ -130,33 +130,27 @@
 	}
 
 	let mcpRows = $derived<MCPRow[]>(
-		mcpServers
-			.filter((m): m is DeviceScanMCPServer & { id: number } => !!m.id)
-			.map((m) => ({
-				...m,
-				scope: deriveScope(m.projectPath),
-				endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
-			}))
+		mcpServers.map((m) => ({
+			...m,
+			scope: deriveScope(m.projectPath),
+			endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
+		}))
 	);
 
 	let skillRows = $derived<SkillRow[]>(
-		skills
-			.filter((s): s is DeviceScanSkill & { id: number } => !!s.id)
-			.map((s) => ({
-				...s,
-				scope: deriveScope(s.projectPath),
-				files_count: (s.files ?? []).length
-			}))
+		skills.map((s) => ({
+			...s,
+			scope: deriveScope(s.projectPath),
+			files_count: (s.files ?? []).length
+		}))
 	);
 
 	let pluginRows = $derived<PluginRow[]>(
-		plugins
-			.filter((p): p is DeviceScanPlugin & { id: number } => !!p.id)
-			.map((p) => ({
-				...p,
-				scope: deriveScope(p.projectPath),
-				capabilities: capabilitySummary(p)
-			}))
+		plugins.map((p) => ({
+			...p,
+			scope: deriveScope(p.projectPath),
+			capabilities: capabilitySummary(p)
+		}))
 	);
 
 	let clientRows = $derived<ClientRow[]>(

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
@@ -105,26 +105,22 @@
 	);
 
 	type MCPRow = DeviceScanMCPServer & {
-		id: string;
-		index: number;
+		id: number;
 		scope: string;
 		endpoint: string;
 	};
 	type SkillRow = DeviceScanSkill & {
-		id: string;
-		index: number;
+		id: number;
 		scope: string;
 		files_count: number;
 	};
 	type PluginRow = DeviceScanPlugin & {
-		id: string;
-		index: number;
+		id: number;
 		scope: string;
 		capabilities: string;
 	};
 	type ClientRow = DeviceScanClient & {
 		id: string;
-		index: number;
 		paths_display: string;
 		has_display: string;
 	};
@@ -134,30 +130,27 @@
 	}
 
 	let mcpRows = $derived<MCPRow[]>(
-		mcpServers.map((m, i) => ({
+		mcpServers.map((m) => ({
 			...m,
-			id: `${m.client}-${m.name}-${i}`,
-			index: i,
+			id: m.id ?? 0,
 			scope: deriveScope(m.projectPath),
 			endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
 		}))
 	);
 
 	let skillRows = $derived<SkillRow[]>(
-		skills.map((s, i) => ({
+		skills.map((s) => ({
 			...s,
-			id: `${s.client}-${s.name}-${i}`,
-			index: i,
+			id: s.id ?? 0,
 			scope: deriveScope(s.projectPath),
 			files_count: (s.files ?? []).length
 		}))
 	);
 
 	let pluginRows = $derived<PluginRow[]>(
-		plugins.map((p, i) => ({
+		plugins.map((p) => ({
 			...p,
-			id: `${p.client}-${p.name}-${i}`,
-			index: i,
+			id: p.id ?? 0,
 			scope: deriveScope(p.projectPath),
 			capabilities: capabilitySummary(p)
 		}))
@@ -167,14 +160,13 @@
 		clients.map((c, i) => ({
 			...c,
 			id: `${c.name}-${i}`,
-			index: i,
 			paths_display: clientPathsSummary(c),
 			has_display: clientHasSummary(c)
 		}))
 	);
 
-	let scanId = $derived(page.params.scan_id);
 	let deviceIdParam = $derived(page.params.device_id);
+	let scanIdParam = $derived(page.params.scan_id);
 
 	function formatCommand(cmd?: string, args?: string[]): string {
 		if (!cmd) return '—';
@@ -353,7 +345,7 @@
 							filterable={['client', 'transport', 'scope']}
 							onClickRow={(d, isCtrlClick) => {
 								openUrl(
-									`/admin/devices/${deviceIdParam}/scans/${scanId}/mcp/${d.index}`,
+									`/admin/devices/${deviceIdParam}/scans/${scanIdParam}/mcp/${d.id}`,
 									isCtrlClick
 								);
 							}}
@@ -389,7 +381,7 @@
 							filterable={['client', 'scope']}
 							onClickRow={(d, isCtrlClick) => {
 								openUrl(
-									`/admin/devices/${deviceIdParam}/scans/${scanId}/skills/${d.index}`,
+									`/admin/devices/${deviceIdParam}/scans/${scanIdParam}/skills/${d.id}`,
 									isCtrlClick
 								);
 							}}
@@ -434,7 +426,7 @@
 							filterable={['client', 'pluginType', 'scope']}
 							onClickRow={(d, isCtrlClick) => {
 								openUrl(
-									`/admin/devices/${deviceIdParam}/scans/${scanId}/plugins/${d.index}`,
+									`/admin/devices/${deviceIdParam}/scans/${scanIdParam}/plugins/${d.id}`,
 									isCtrlClick
 								);
 							}}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
@@ -130,30 +130,33 @@
 	}
 
 	let mcpRows = $derived<MCPRow[]>(
-		mcpServers.map((m) => ({
-			...m,
-			id: m.id ?? 0,
-			scope: deriveScope(m.projectPath),
-			endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
-		}))
+		mcpServers
+			.filter((m): m is DeviceScanMCPServer & { id: number } => !!m.id)
+			.map((m) => ({
+				...m,
+				scope: deriveScope(m.projectPath),
+				endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
+			}))
 	);
 
 	let skillRows = $derived<SkillRow[]>(
-		skills.map((s) => ({
-			...s,
-			id: s.id ?? 0,
-			scope: deriveScope(s.projectPath),
-			files_count: (s.files ?? []).length
-		}))
+		skills
+			.filter((s): s is DeviceScanSkill & { id: number } => !!s.id)
+			.map((s) => ({
+				...s,
+				scope: deriveScope(s.projectPath),
+				files_count: (s.files ?? []).length
+			}))
 	);
 
 	let pluginRows = $derived<PluginRow[]>(
-		plugins.map((p) => ({
-			...p,
-			id: p.id ?? 0,
-			scope: deriveScope(p.projectPath),
-			capabilities: capabilitySummary(p)
-		}))
+		plugins
+			.filter((p): p is DeviceScanPlugin & { id: number } => !!p.id)
+			.map((p) => ({
+				...p,
+				scope: deriveScope(p.projectPath),
+				capabilities: capabilitySummary(p)
+			}))
 	);
 
 	let clientRows = $derived<ClientRow[]>(

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/_shared/files.ts
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/_shared/files.ts
@@ -31,6 +31,6 @@ export function findParentPlugin(
 ): { id: number; name: string } | undefined {
 	if (!scan || !file) return undefined;
 	const match = scan.plugins?.find((p) => p.configPath === file || p.files?.includes(file));
-	if (!match || !match.id) return undefined;
+	if (!match) return undefined;
 	return { id: match.id, name: match.name };
 }

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/_shared/files.ts
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/_shared/files.ts
@@ -31,6 +31,6 @@ export function findParentPlugin(
 ): { id: number; name: string } | undefined {
 	if (!scan || !file) return undefined;
 	const match = scan.plugins?.find((p) => p.configPath === file || p.files?.includes(file));
-	if (!match || match.id === undefined) return undefined;
+	if (!match || !match.id) return undefined;
 	return { id: match.id, name: match.name };
 }

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/_shared/files.ts
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/_shared/files.ts
@@ -22,14 +22,15 @@ export function shortHash(h?: string): string {
 
 // findParentPlugin returns the plugin observation whose defining file or
 // supporting files contain `file`. Used to cross-link MCP servers and
-// skills back to the plugin that emitted them.
+// skills back to the plugin that emitted them. The returned id is the
+// plugin row's PK, suitable for the {id} segment of scan-scoped detail
+// URLs.
 export function findParentPlugin(
 	scan: DeviceScan | undefined,
 	file: string | undefined
-): { index: number; name: string } | undefined {
+): { id: number; name: string } | undefined {
 	if (!scan || !file) return undefined;
-	const idx =
-		scan.plugins?.findIndex((p) => p.configPath === file || p.files?.includes(file)) ?? -1;
-	if (idx < 0) return undefined;
-	return { index: idx, name: scan.plugins[idx].name };
+	const match = scan.plugins?.find((p) => p.configPath === file || p.files?.includes(file));
+	if (!match || match.id === undefined) return undefined;
+	return { id: match.id, name: match.name };
 }

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
@@ -12,8 +12,10 @@
 
 	let { data } = $props();
 	let scan = $derived(data?.scan);
-	let index = $derived(Number(page.params.index));
-	let server = $derived<DeviceScanMCPServer | undefined>(scan?.mcpServers?.[index]);
+	let id = $derived(Number(page.params.id));
+	let server = $derived<DeviceScanMCPServer | undefined>(
+		scan?.mcpServers?.find((m) => m.id === id)
+	);
 	let backHref = $derived(`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}`);
 
 	let endpoint = $derived(
@@ -138,7 +140,7 @@
 							<a
 								class="text-link font-mono"
 								href={resolve(
-									`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}/plugins/${parentPlugin.index}`
+									`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}/plugins/${parentPlugin.id}`
 								)}
 							>
 								{parentPlugin.name}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
@@ -1,84 +1,106 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import Layout from '$lib/components/Layout.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
-	import type { DeviceScanSkill } from '$lib/services/admin/types';
+	import type { DeviceScanPlugin } from '$lib/services/admin/types';
 	import { goto } from '$lib/url';
-	import { findParentPlugin, formatBytes, lookupFiles } from '../../_shared/files';
+	import { formatBytes, lookupFiles } from '../../_shared/files';
 	import { fly } from 'svelte/transition';
 
 	let { data } = $props();
 	let scan = $derived(data?.scan);
-	let index = $derived(Number(page.params.index));
-	let skill = $derived<DeviceScanSkill | undefined>(scan?.skills?.[index]);
+	let id = $derived(Number(page.params.id));
+	let plugin = $derived<DeviceScanPlugin | undefined>(scan?.plugins?.find((p) => p.id === id));
 	let backHref = $derived(`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}`);
 
-	let files = $derived(lookupFiles(scan?.files, skill?.files));
-	let parentPlugin = $derived(findParentPlugin(scan, skill?.file));
-	let scope = $derived(skill?.projectPath ? 'project' : 'global');
-	let clientLabel = $derived(skill?.client || '—');
+	let files = $derived(lookupFiles(scan?.files, plugin?.files));
+	let scope = $derived(plugin?.projectPath ? 'project' : 'global');
+
+	let capabilities = $derived(
+		plugin
+			? [
+					{ key: 'rules', has: plugin.hasRules },
+					{ key: 'commands', has: plugin.hasCommands },
+					{ key: 'hooks', has: plugin.hasHooks }
+				].filter((c) => c.has)
+			: []
+	);
 
 	const duration = PAGE_TRANSITION_DURATION;
 </script>
 
 <svelte:head>
-	<title>Obot | Skill {skill?.name ?? ''}</title>
+	<title>Obot | Plugin {plugin?.name ?? ''}</title>
 </svelte:head>
 
-<Layout title={skill?.name || 'Skill'} showBackButton onBackButtonClick={() => goto(backHref)}>
+<Layout title={plugin?.name || 'Plugin'} showBackButton onBackButtonClick={() => goto(backHref)}>
 	<div
 		class="flex flex-col gap-6"
 		in:fly={{ x: 100, duration, delay: duration }}
 		out:fly={{ x: -100, duration }}
 	>
-		{#if !scan || !skill}
-			<p class="text-on-surface1 text-sm font-light">Skill not found in this scan.</p>
+		{#if !scan || !plugin}
+			<p class="text-on-surface1 text-sm font-light">Plugin not found in this scan.</p>
 		{:else}
 			<div class="dark:bg-surface2 bg-background flex flex-col gap-3 rounded-md p-4 shadow-sm">
 				<div class="flex flex-wrap items-baseline gap-2">
-					<h2 class="font-mono text-xl font-semibold">{skill.name}</h2>
+					<h2 class="font-mono text-xl font-semibold">{plugin.name}</h2>
+					{#if plugin.version}
+						<span class="text-on-surface1 font-mono text-sm">v{plugin.version}</span>
+					{/if}
+					<span class="pill-primary bg-primary">{plugin.pluginType}</span>
 					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
-						{clientLabel}
+						{plugin.client}
 					</span>
 					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
 						{scope}
 					</span>
-					{#if skill.hasScripts}
-						<span class="pill-primary bg-primary">scripts</span>
-					{/if}
+					<span
+						class="pill text-xs"
+						class:bg-success={plugin.enabled}
+						class:bg-surface3={!plugin.enabled}
+					>
+						{plugin.enabled ? 'enabled' : 'disabled'}
+					</span>
 				</div>
 
 				<dl class="grid grid-cols-1 gap-x-6 gap-y-2 text-sm md:grid-cols-[max-content_1fr]">
-					{#if skill.description}
+					{#if plugin.description}
 						<dt class="text-on-surface1">Description</dt>
-						<dd>{skill.description}</dd>
+						<dd>{plugin.description}</dd>
 					{/if}
-					{#if skill.gitRemoteURL}
-						<dt class="text-on-surface1">Git remote</dt>
-						<dd class="font-mono text-xs break-all">{skill.gitRemoteURL}</dd>
+					{#if plugin.author}
+						<dt class="text-on-surface1">Author</dt>
+						<dd>{plugin.author}</dd>
 					{/if}
-					{#if skill.file}
+					{#if plugin.marketplace}
+						<dt class="text-on-surface1">Marketplace</dt>
+						<dd class="font-mono text-xs break-all">{plugin.marketplace}</dd>
+					{/if}
+					{#if plugin.configPath}
 						<dt class="text-on-surface1">File</dt>
-						<dd class="font-mono text-xs break-all">{skill.file}</dd>
+						<dd class="font-mono text-xs break-all">{plugin.configPath}</dd>
 					{/if}
-					{#if skill.projectPath}
+					{#if plugin.projectPath}
 						<dt class="text-on-surface1">Project path</dt>
-						<dd class="font-mono text-xs break-all">{skill.projectPath}</dd>
+						<dd class="font-mono text-xs break-all">{plugin.projectPath}</dd>
 					{/if}
-					{#if parentPlugin}
-						<dt class="text-on-surface1">Part of plugin</dt>
-						<dd>
-							<a
-								class="text-link font-mono"
-								href={resolve(
-									`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}/plugins/${parentPlugin.index}`
-								)}
-							>
-								{parentPlugin.name}
-							</a>
-						</dd>
-					{/if}
+					<dt class="text-on-surface1">Capabilities</dt>
+					<dd>
+						{#if capabilities.length === 0}
+							<span class="text-on-surface1">none detected</span>
+						{:else}
+							<div class="flex flex-wrap gap-1">
+								{#each capabilities as c (c.key)}
+									<span
+										class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs"
+									>
+										{c.key}
+									</span>
+								{/each}
+							</div>
+						{/if}
+					</dd>
 				</dl>
 			</div>
 

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
@@ -1,106 +1,84 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import Layout from '$lib/components/Layout.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
-	import type { DeviceScanPlugin } from '$lib/services/admin/types';
+	import type { DeviceScanSkill } from '$lib/services/admin/types';
 	import { goto } from '$lib/url';
-	import { formatBytes, lookupFiles } from '../../_shared/files';
+	import { findParentPlugin, formatBytes, lookupFiles } from '../../_shared/files';
 	import { fly } from 'svelte/transition';
 
 	let { data } = $props();
 	let scan = $derived(data?.scan);
-	let index = $derived(Number(page.params.index));
-	let plugin = $derived<DeviceScanPlugin | undefined>(scan?.plugins?.[index]);
+	let id = $derived(Number(page.params.id));
+	let skill = $derived<DeviceScanSkill | undefined>(scan?.skills?.find((s) => s.id === id));
 	let backHref = $derived(`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}`);
 
-	let files = $derived(lookupFiles(scan?.files, plugin?.files));
-	let scope = $derived(plugin?.projectPath ? 'project' : 'global');
-
-	let capabilities = $derived(
-		plugin
-			? [
-					{ key: 'rules', has: plugin.hasRules },
-					{ key: 'commands', has: plugin.hasCommands },
-					{ key: 'hooks', has: plugin.hasHooks }
-				].filter((c) => c.has)
-			: []
-	);
+	let files = $derived(lookupFiles(scan?.files, skill?.files));
+	let parentPlugin = $derived(findParentPlugin(scan, skill?.file));
+	let scope = $derived(skill?.projectPath ? 'project' : 'global');
+	let clientLabel = $derived(skill?.client || '—');
 
 	const duration = PAGE_TRANSITION_DURATION;
 </script>
 
 <svelte:head>
-	<title>Obot | Plugin {plugin?.name ?? ''}</title>
+	<title>Obot | Skill {skill?.name ?? ''}</title>
 </svelte:head>
 
-<Layout title={plugin?.name || 'Plugin'} showBackButton onBackButtonClick={() => goto(backHref)}>
+<Layout title={skill?.name || 'Skill'} showBackButton onBackButtonClick={() => goto(backHref)}>
 	<div
 		class="flex flex-col gap-6"
 		in:fly={{ x: 100, duration, delay: duration }}
 		out:fly={{ x: -100, duration }}
 	>
-		{#if !scan || !plugin}
-			<p class="text-on-surface1 text-sm font-light">Plugin not found in this scan.</p>
+		{#if !scan || !skill}
+			<p class="text-on-surface1 text-sm font-light">Skill not found in this scan.</p>
 		{:else}
 			<div class="dark:bg-surface2 bg-background flex flex-col gap-3 rounded-md p-4 shadow-sm">
 				<div class="flex flex-wrap items-baseline gap-2">
-					<h2 class="font-mono text-xl font-semibold">{plugin.name}</h2>
-					{#if plugin.version}
-						<span class="text-on-surface1 font-mono text-sm">v{plugin.version}</span>
-					{/if}
-					<span class="pill-primary bg-primary">{plugin.pluginType}</span>
+					<h2 class="font-mono text-xl font-semibold">{skill.name}</h2>
 					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
-						{plugin.client}
+						{clientLabel}
 					</span>
 					<span class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs">
 						{scope}
 					</span>
-					<span
-						class="pill text-xs"
-						class:bg-success={plugin.enabled}
-						class:bg-surface3={!plugin.enabled}
-					>
-						{plugin.enabled ? 'enabled' : 'disabled'}
-					</span>
+					{#if skill.hasScripts}
+						<span class="pill-primary bg-primary">scripts</span>
+					{/if}
 				</div>
 
 				<dl class="grid grid-cols-1 gap-x-6 gap-y-2 text-sm md:grid-cols-[max-content_1fr]">
-					{#if plugin.description}
+					{#if skill.description}
 						<dt class="text-on-surface1">Description</dt>
-						<dd>{plugin.description}</dd>
+						<dd>{skill.description}</dd>
 					{/if}
-					{#if plugin.author}
-						<dt class="text-on-surface1">Author</dt>
-						<dd>{plugin.author}</dd>
+					{#if skill.gitRemoteURL}
+						<dt class="text-on-surface1">Git remote</dt>
+						<dd class="font-mono text-xs break-all">{skill.gitRemoteURL}</dd>
 					{/if}
-					{#if plugin.marketplace}
-						<dt class="text-on-surface1">Marketplace</dt>
-						<dd class="font-mono text-xs break-all">{plugin.marketplace}</dd>
-					{/if}
-					{#if plugin.configPath}
+					{#if skill.file}
 						<dt class="text-on-surface1">File</dt>
-						<dd class="font-mono text-xs break-all">{plugin.configPath}</dd>
+						<dd class="font-mono text-xs break-all">{skill.file}</dd>
 					{/if}
-					{#if plugin.projectPath}
+					{#if skill.projectPath}
 						<dt class="text-on-surface1">Project path</dt>
-						<dd class="font-mono text-xs break-all">{plugin.projectPath}</dd>
+						<dd class="font-mono text-xs break-all">{skill.projectPath}</dd>
 					{/if}
-					<dt class="text-on-surface1">Capabilities</dt>
-					<dd>
-						{#if capabilities.length === 0}
-							<span class="text-on-surface1">none detected</span>
-						{:else}
-							<div class="flex flex-wrap gap-1">
-								{#each capabilities as c (c.key)}
-									<span
-										class="dark:bg-surface3 bg-surface2 rounded px-1.5 py-0.5 font-mono text-xs"
-									>
-										{c.key}
-									</span>
-								{/each}
-							</div>
-						{/if}
-					</dd>
+					{#if parentPlugin}
+						<dt class="text-on-surface1">Part of plugin</dt>
+						<dd>
+							<a
+								class="text-link font-mono"
+								href={resolve(
+									`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}/plugins/${parentPlugin.id}`
+								)}
+							>
+								{parentPlugin.name}
+							</a>
+						</dd>
+					{/if}
 				</dl>
 			</div>
 


### PR DESCRIPTION
Scan detail pages (MCP server, skill, plugin) were addressed by their
position inside the parent scan's preloaded child slice, e.g.
/admin/.../scans/{scan_id}/mcp/{index}. That index was a GORM
preload-order artifact, not a stable identifier — it shifted whenever
the underlying device_scan_* rows were re-ordered, paged, or filtered,
so bookmarked links and breadcrumb back-nav could resolve to the wrong
row or 404 against fresh scans.

Switch the URL segment and lookup key to each observation's row PK:

- Expose ID on DeviceScanMCPServer/Skill/Plugin (server-set, ignored on
  submission so scanners can't trample PKs) and on the occurrence
  list rows the dashboard ranks. The SELECTs in ListMCPServerOccurrences
  and ListSkillOccurrences drop their correlated COUNT(*) idx subquery
  and project the row id directly.
- Rename the SvelteKit routes from [index] to [id]; the detail pages
  still read the parent scan from the existing +layout.ts loader and
  now find their row via scan.<children>.find(r => r.id === id) instead
  of indexing by position.
- Update every callsite that builds these URLs (device dashboard, scan
  page, mcp-server-by-hash table, skill-by-name table) to pass d.id.
- findParentPlugin returns the plugin's id (not its index) so MCP/skill
  cross-links to the enclosing plugin stay correct.

