### PR TITLE
feat: Add ServerUserType

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -22,7 +22,7 @@ const (
 	defaultStartupTimeoutSeconds = 60
 )
 
-// ServerUserType specifies whether a catalog entry or MCP server is single-user or multi-user.
+// ServerUserType specifies whether a catalog entry is a single-user or multi-user template.
 type ServerUserType string
 
 const (
@@ -241,7 +241,6 @@ type MCPSecretBinding struct {
 	Name string `json:"name"`
 	Key  string `json:"key"`
 }
-
 
 type MCPEnv struct {
 	MCPHeader `json:",inline"`

--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -22,6 +22,23 @@ const (
 	defaultStartupTimeoutSeconds = 60
 )
 
+// ServerUserType specifies whether a catalog entry or MCP server is single-user or multi-user.
+type ServerUserType string
+
+const (
+	// ServerUserTypeSingleUser indicates each user gets their own MCP server instance.
+	// This is the default when the field is empty.
+	ServerUserTypeSingleUser ServerUserType = "singleUser"
+	// ServerUserTypeMultiUser indicates all users share a single MCP server.
+	ServerUserTypeMultiUser ServerUserType = "multiUser"
+)
+
+// IsSingleUser returns true if the type represents a single-user server.
+// An empty value defaults to single-user for backward compatibility.
+func (t ServerUserType) IsSingleUser() bool {
+	return t == "" || t == ServerUserTypeSingleUser
+}
+
 // UVXRuntimeConfig represents configuration for UVX runtime (Python packages via uvx)
 type UVXRuntimeConfig struct {
 	Package               string   `json:"package"`                         // Required: Python package name
@@ -171,6 +188,10 @@ type MCPServerCatalogEntryManifest struct {
 
 	// MultiUserConfig is the multi-user specific configuration for this component server, if applicable.
 	MultiUserConfig *MultiUserConfig `json:"multiUserConfig,omitempty"`
+
+	// ServerUserType specifies whether this catalog entry produces single-user or multi-user servers.
+	// Only "singleUser" is currently supported. Empty value defaults to "singleUser".
+	ServerUserType ServerUserType `json:"serverUserType,omitempty"`
 
 	Env []MCPEnv `json:"env,omitempty"`
 }
@@ -326,6 +347,20 @@ type MCPServer struct {
 
 	// CompositeName is the name of the composite server that this MCP server is a component of, if there is one.
 	CompositeName string `json:"compositeName,omitempty"`
+
+	// ServerUserType specifies whether this is a single-user or multi-user MCP server.
+	// Empty value uses legacy inference from MCPCatalogID and PowerUserWorkspaceID.
+	ServerUserType ServerUserType `json:"serverUserType,omitempty"`
+}
+
+// IsSingleUser returns true if this is a single-user MCP server.
+// For servers created before this field existed, falls back to legacy inference from ownership fields.
+func (s MCPServer) IsSingleUser() bool {
+	if s.ServerUserType != "" {
+		return s.ServerUserType.IsSingleUser()
+	}
+	// Legacy fallback: infer from ownership fields
+	return s.MCPCatalogID == "" && s.PowerUserWorkspaceID == ""
 }
 
 type OAuthMetadata struct {

--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -347,19 +347,10 @@ type MCPServer struct {
 
 	// CompositeName is the name of the composite server that this MCP server is a component of, if there is one.
 	CompositeName string `json:"compositeName,omitempty"`
-
-	// ServerUserType specifies whether this is a single-user or multi-user MCP server.
-	// Empty value uses legacy inference from MCPCatalogID and PowerUserWorkspaceID.
-	ServerUserType ServerUserType `json:"serverUserType,omitempty"`
 }
 
 // IsSingleUser returns true if this is a single-user MCP server.
-// For servers created before this field existed, falls back to legacy inference from ownership fields.
 func (s MCPServer) IsSingleUser() bool {
-	if s.ServerUserType != "" {
-		return s.ServerUserType.IsSingleUser()
-	}
-	// Legacy fallback: infer from ownership fields
 	return s.MCPCatalogID == "" && s.PowerUserWorkspaceID == ""
 }
 

--- a/apiclient/types/mcpserver_test.go
+++ b/apiclient/types/mcpserver_test.go
@@ -1,6 +1,8 @@
 package types
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestMapCatalogEntryToServer_UVX(t *testing.T) {
 	catalogEntry := MCPServerCatalogEntryManifest{
@@ -487,6 +489,90 @@ func TestValidateURLMatchesHostname(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
+			}
+		})
+	}
+}
+
+func TestServerUserType_IsSingleUser(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverType ServerUserType
+		want       bool
+	}{
+		{
+			name:       "empty defaults to single-user",
+			serverType: "",
+			want:       true,
+		},
+		{
+			name:       "explicit singleUser",
+			serverType: ServerUserTypeSingleUser,
+			want:       true,
+		},
+		{
+			name:       "multiUser returns false",
+			serverType: ServerUserTypeMultiUser,
+			want:       false,
+		},
+		{
+			name:       "unknown value returns false",
+			serverType: ServerUserType("unknown"),
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.serverType.IsSingleUser(); got != tt.want {
+				t.Errorf("ServerUserType(%q).IsSingleUser() = %v, want %v", tt.serverType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMCPServer_IsSingleUser(t *testing.T) {
+	tests := []struct {
+		name   string
+		server MCPServer
+		want   bool
+	}{
+		{
+			name:   "new server with singleUser type",
+			server: MCPServer{ServerUserType: ServerUserTypeSingleUser},
+			want:   true,
+		},
+		{
+			name:   "new server with multiUser type",
+			server: MCPServer{ServerUserType: ServerUserTypeMultiUser},
+			want:   false,
+		},
+		{
+			name:   "legacy single-user: empty type, no catalog/workspace",
+			server: MCPServer{MCPCatalogID: "", PowerUserWorkspaceID: ""},
+			want:   true,
+		},
+		{
+			name:   "legacy multi-user: empty type, catalog set",
+			server: MCPServer{MCPCatalogID: "default"},
+			want:   false,
+		},
+		{
+			name:   "legacy multi-user: empty type, workspace set",
+			server: MCPServer{PowerUserWorkspaceID: "ws-1"},
+			want:   false,
+		},
+		{
+			name:   "ServerUserType takes precedence over legacy fields",
+			server: MCPServer{ServerUserType: ServerUserTypeSingleUser, MCPCatalogID: "default"},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.server.IsSingleUser(); got != tt.want {
+				t.Errorf("MCPServer.IsSingleUser() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/apiclient/types/mcpserver_test.go
+++ b/apiclient/types/mcpserver_test.go
@@ -538,34 +538,19 @@ func TestMCPServer_IsSingleUser(t *testing.T) {
 		want   bool
 	}{
 		{
-			name:   "new server with singleUser type",
-			server: MCPServer{ServerUserType: ServerUserTypeSingleUser},
-			want:   true,
-		},
-		{
-			name:   "new server with multiUser type",
-			server: MCPServer{ServerUserType: ServerUserTypeMultiUser},
-			want:   false,
-		},
-		{
-			name:   "legacy single-user: empty type, no catalog/workspace",
+			name:   "no catalog/workspace: single-user",
 			server: MCPServer{MCPCatalogID: "", PowerUserWorkspaceID: ""},
 			want:   true,
 		},
 		{
-			name:   "legacy multi-user: empty type, catalog set",
+			name:   "catalog set: multi-user",
 			server: MCPServer{MCPCatalogID: "default"},
 			want:   false,
 		},
 		{
-			name:   "legacy multi-user: empty type, workspace set",
+			name:   "workspace set: multi-user",
 			server: MCPServer{PowerUserWorkspaceID: "ws-1"},
 			want:   false,
-		},
-		{
-			name:   "ServerUserType takes precedence over legacy fields",
-			server: MCPServer{ServerUserType: ServerUserTypeSingleUser, MCPCatalogID: "default"},
-			want:   true,
 		},
 	}
 

--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -112,6 +112,18 @@ env:
     description: Description of this variable
 ```
 
+### Server User Type
+
+```yaml
+serverUserType: singleUser  # Optional, defaults to "singleUser"
+```
+
+The `serverUserType` field specifies how users interact with the catalog entry:
+
+- `singleUser` (default): Each user who installs this catalog entry gets their own independent MCP server instance.
+
+Omitting the field or setting it to `""` is equivalent to `singleUser`.
+
 ### Kubernetes Secret Bindings
 
 Secret bindings let you wire an env var, header, or file to a key in an externally-managed Kubernetes Secret instead of asking the user to supply the value at install time.

--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -122,7 +122,7 @@ The `serverUserType` field specifies how users interact with the catalog entry:
 
 - `singleUser` (default): Each user who installs this catalog entry gets their own independent MCP server instance.
 
-Omitting the field or setting it to `""` is equivalent to `singleUser`.
+Omitting the field or setting it to `""` is equivalent to `singleUser`. Currently only `singleUser` is supported; other values will be rejected at validation time.
 
 ### Kubernetes Secret Bindings
 

--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -32,9 +32,9 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user us
 			return false, err
 		}
 
-		if mcpServer.Spec.MCPCatalogID != "" {
+		if mcpServer.Spec.IsCatalogServer() {
 			return a.acrHelper.UserHasAccessToMCPServerInCatalog(user, resources.MCPID, mcpServer.Spec.MCPCatalogID)
-		} else if mcpServer.Spec.PowerUserWorkspaceID != "" {
+		} else if mcpServer.Spec.IsPowerUserWorkspaceServer() {
 			return a.acrHelper.UserHasAccessToMCPServerInWorkspace(user, resources.MCPID, mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Spec.UserID)
 		}
 

--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -38,8 +38,7 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user us
 			return a.acrHelper.UserHasAccessToMCPServerInWorkspace(user, resources.MCPID, mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Spec.UserID)
 		}
 
-		// For single-user MCP servers, ensure the user owns the server.
-		return mcpServer.Spec.UserID == user.GetUID(), nil
+		return mcpServer.Spec.IsOwnedBy(user.GetUID()), nil
 
 	case system.IsSystemMCPServerID(resources.MCPID):
 		var systemMCPServer v1.SystemMCPServer

--- a/pkg/api/authz/mcpserver.go
+++ b/pkg/api/authz/mcpserver.go
@@ -20,8 +20,7 @@ func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, u u
 	}
 
 	// If the user owns the MCP server, then authorization is granted.
-	// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should also get direct access here.
-	if mcpServer.Spec.UserID == u.GetUID() && mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.IsOwnedBy(u.GetUID()) {
 		resources.Authorizated.MCPServer = &mcpServer
 		return true, nil
 	}

--- a/pkg/api/authz/mcpserver.go
+++ b/pkg/api/authz/mcpserver.go
@@ -20,7 +20,8 @@ func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, u u
 	}
 
 	// If the user owns the MCP server, then authorization is granted.
-	if mcpServer.Spec.UserID == u.GetUID() && mcpServer.Spec.IsSingleUser() {
+	// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should also get direct access here.
+	if mcpServer.Spec.UserID == u.GetUID() && mcpServer.Spec.MCPCatalogID == "" {
 		resources.Authorizated.MCPServer = &mcpServer
 		return true, nil
 	}

--- a/pkg/api/authz/mcpserver.go
+++ b/pkg/api/authz/mcpserver.go
@@ -36,7 +36,7 @@ func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, u u
 
 		resources.Authorizated.MCPServer = &mcpServer
 		return true, nil
-	} else if mcpServer.Spec.PowerUserWorkspaceID != "" {
+	} else if mcpServer.Spec.IsPowerUserWorkspaceServer() {
 		hasAccess, err := a.acrHelper.UserHasAccessToMCPServerInWorkspace(u, mcpServer.Name, mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Spec.UserID)
 		if err != nil || !hasAccess {
 			return false, err

--- a/pkg/api/authz/mcpserver.go
+++ b/pkg/api/authz/mcpserver.go
@@ -20,7 +20,7 @@ func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, u u
 	}
 
 	// If the user owns the MCP server, then authorization is granted.
-	if mcpServer.Spec.UserID == u.GetUID() && mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.UserID == u.GetUID() && mcpServer.Spec.IsSingleUser() {
 		resources.Authorizated.MCPServer = &mcpServer
 		return true, nil
 	}

--- a/pkg/api/authz/mcpserver.go
+++ b/pkg/api/authz/mcpserver.go
@@ -19,7 +19,7 @@ func (a *Authorizer) checkMCPServer(req *http.Request, resources *Resources, u u
 		return false, err
 	}
 
-	// If the user owns the MCP server, then authorization is granted.
+	// If the user owns this server (personal or workspace), grant direct access.
 	if mcpServer.Spec.IsOwnedBy(u.GetUID()) {
 		resources.Authorizated.MCPServer = &mcpServer
 		return true, nil

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1907,7 +1907,8 @@ func (m *MCPHandler) UpdateServerAlias(req api.Context) error {
 		return err
 	}
 
-	if !server.Spec.IsSingleUser() {
+	// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should also be blocked here.
+	if server.Spec.MCPCatalogID != "" {
 		return types.NewErrBadRequest("cannot update alias for a multi-user MCP server")
 	}
 
@@ -2757,7 +2758,8 @@ func ConvertMCPServer(server v1.MCPServer, credEnv map[string]string, serverURL,
 	var connectURL string
 	// Only single-user servers get a connect URL.
 	// Multi-user servers have connect URLs on the MCPServerInstances instead.
-	if server.Spec.IsSingleUser() {
+	// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should get a connect URL.
+	if server.Spec.MCPCatalogID == "" {
 		connectURL = system.MCPConnectURL(serverURL, slug)
 	}
 
@@ -3656,7 +3658,8 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 		return fmt.Errorf("failed to get server: %w", err)
 	}
 
-	if !mcpServer.Spec.IsSingleUser() {
+	// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should also be blocked here.
+	if mcpServer.Spec.MCPCatalogID != "" {
 		return types.NewErrBadRequest("cannot update the URL for a multi-user MCP server; use the UpdateServer endpoint instead")
 	}
 

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1048,7 +1048,7 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 			return v1.MCPServer{}, v1.MCPServerInstance{}, err
 		}
 
-		if server.Spec.MCPCatalogID != "" || server.Spec.PowerUserWorkspaceID != "" {
+		if !server.Spec.IsSingleUser() {
 			// This is a multi-user MCP server, and user is trying to connect to it.
 			// List the MCP server instances, sort by creation time, and take the first one.
 			var instances v1.MCPServerInstanceList
@@ -1709,6 +1709,12 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 			return types.NewErrForbidden("user does not have access to MCP server catalog entry")
 		}
 
+		// Validate that the catalog entry type matches the route.
+		// Single-user routes only support single-user catalog entries.
+		if catalogID == "" && workspaceID == "" && !catalogEntry.Spec.Manifest.ServerUserType.IsSingleUser() {
+			return types.NewErrBadRequest("only single-user catalog entries are supported")
+		}
+
 		// Block server creation if OAuth is required but not configured
 		if entryRequiresStaticOAuthCreds(catalogEntry) {
 			return types.NewErrBadRequest("catalog entry requires OAuth configuration by an administrator before it can be used")
@@ -1730,7 +1736,14 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 		return types.NewErrBadRequest("catalogEntryID is required")
 	}
 
-	if err := validation.ValidateServerManifest(server.Spec.Manifest, server.Spec.MCPCatalogID != "" || server.Spec.PowerUserWorkspaceID != ""); err != nil {
+	// Set ServerUserType explicitly based on the route.
+	if catalogID != "" || workspaceID != "" {
+		server.Spec.ServerUserType = types.ServerUserTypeMultiUser
+	} else {
+		server.Spec.ServerUserType = types.ServerUserTypeSingleUser
+	}
+
+	if err := validation.ValidateServerManifest(server.Spec.Manifest, !server.Spec.IsSingleUser()); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 	if err := validation.ValidateSecretBindings(server.Spec.Manifest, gitManagedEntry, m.mcpBackend); err != nil {
@@ -1832,7 +1845,7 @@ func (m *MCPHandler) UpdateServer(req api.Context) error {
 		return err
 	}
 
-	if err := validation.ValidateServerManifest(updated, existing.Spec.MCPCatalogID != "" || existing.Spec.PowerUserWorkspaceID != ""); err != nil {
+	if err := validation.ValidateServerManifest(updated, !existing.Spec.IsSingleUser()); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 
@@ -1894,7 +1907,7 @@ func (m *MCPHandler) UpdateServerAlias(req api.Context) error {
 		return err
 	}
 
-	if server.Spec.MCPCatalogID != "" {
+	if !server.Spec.IsSingleUser() {
 		return types.NewErrBadRequest("cannot update alias for a multi-user MCP server")
 	}
 
@@ -1976,7 +1989,7 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 			}
 			mcpServer.Spec.Manifest.RemoteConfig.URL = finalURL
 
-			if err := validation.ValidateServerManifest(mcpServer.Spec.Manifest, mcpServer.Spec.MCPCatalogID != "" || mcpServer.Spec.PowerUserWorkspaceID != ""); err != nil {
+			if err := validation.ValidateServerManifest(mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser()); err != nil {
 				return types.NewErrBadRequest("validation failed: %v", err)
 			}
 
@@ -2744,7 +2757,7 @@ func ConvertMCPServer(server v1.MCPServer, credEnv map[string]string, serverURL,
 	var connectURL string
 	// Only single-user servers get a connect URL.
 	// Multi-user servers have connect URLs on the MCPServerInstances instead.
-	if server.Spec.MCPCatalogID == "" {
+	if server.Spec.IsSingleUser() {
 		connectURL = system.MCPConnectURL(serverURL, slug)
 	}
 
@@ -2788,6 +2801,7 @@ func ConvertMCPServer(server v1.MCPServer, credEnv map[string]string, serverURL,
 		Template:                    server.Spec.Template,
 		CompositeName:               server.Spec.CompositeName,
 		NanobotAgentID:              server.Spec.NanobotAgentID,
+		ServerUserType:              server.Spec.ServerUserType,
 	}
 
 	// For composite servers, also consider component configuration if provided
@@ -3185,8 +3199,7 @@ func (m *MCPHandler) RestartServerDeployment(req api.Context) error {
 	if !req.UserIsAdmin() {
 		// Allow users to restart their own single-user servers.
 		userOwnsServer := server.Spec.UserID == req.User.GetUID() &&
-			server.Spec.MCPCatalogID == "" &&
-			server.Spec.PowerUserWorkspaceID == ""
+			server.Spec.IsSingleUser()
 
 		if !userOwnsServer {
 			// Fall back to workspace-based authorization
@@ -3592,7 +3605,7 @@ func (m *MCPHandler) StreamServerLogs(req api.Context) error {
 	}
 
 	// If this is a single-user MCP server that belongs to the user, then let them access the logs.
-	if server.Spec.UserID != req.User.GetUID() || server.Spec.PowerUserWorkspaceID != "" || server.Spec.MCPCatalogID != "" {
+	if server.Spec.UserID != req.User.GetUID() || !server.Spec.IsSingleUser() {
 		// If the user doesn't own the server and is not an admin or auditor, check if they have access to the workspace.
 		if !req.UserIsAdmin() && !req.UserIsAuditor() {
 			workspaceID := req.PathValue("workspace_id")
@@ -3643,7 +3656,7 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 		return fmt.Errorf("failed to get server: %w", err)
 	}
 
-	if mcpServer.Spec.MCPCatalogID != "" {
+	if !mcpServer.Spec.IsSingleUser() {
 		return types.NewErrBadRequest("cannot update the URL for a multi-user MCP server; use the UpdateServer endpoint instead")
 	}
 
@@ -3700,7 +3713,7 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 	mcpServer.Spec.NeedsURL = false
 	mcpServer.Spec.PreviousURL = ""
 
-	if err := validation.ValidateServerManifest(mcpServer.Spec.Manifest, mcpServer.Spec.MCPCatalogID != "" || mcpServer.Spec.PowerUserWorkspaceID != ""); err != nil {
+	if err := validation.ValidateServerManifest(mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser()); err != nil {
 		return err
 	}
 
@@ -3722,7 +3735,7 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 		return err
 	}
 
-	if server.Spec.MCPCatalogID != "" || server.Spec.PowerUserWorkspaceID != "" {
+	if !server.Spec.IsSingleUser() {
 		return types.NewErrBadRequest("cannot trigger update for a multi-user MCP server; use the UpdateServer endpoint instead")
 	}
 

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -3746,8 +3746,7 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 	if !req.UserIsAdmin() {
 		// Allow users to upgrade their own single-user servers.
 		// (We already verified this is a single-user server at the check above.)
-		userOwnsServer := server.Spec.UserID == req.User.GetUID()
-		if !userOwnsServer {
+		if !server.Spec.IsOwnedBy(req.User.GetUID()) {
 			// Workspace-based authorization for power user workspace entries
 			workspaceID := req.PathValue("workspace_id")
 			if workspaceID == "" {

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1709,10 +1709,9 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 			return types.NewErrForbidden("user does not have access to MCP server catalog entry")
 		}
 
-		// Validate that the catalog entry type matches the route.
-		// Single-user routes only support single-user catalog entries.
-		if catalogID == "" && workspaceID == "" && !catalogEntry.Spec.Manifest.ServerUserType.IsSingleUser() {
-			return types.NewErrBadRequest("only single-user catalog entries are supported")
+		// Validate that the catalog entry type is compatible with the route used.
+		if err := validation.ValidateCatalogEntryForRoute(catalogEntry.Spec.Manifest, catalogID, workspaceID); err != nil {
+			return types.NewErrBadRequest("%v", err)
 		}
 
 		// Block server creation if OAuth is required but not configured

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1907,8 +1907,7 @@ func (m *MCPHandler) UpdateServerAlias(req api.Context) error {
 		return err
 	}
 
-	// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should also be blocked here.
-	if server.Spec.MCPCatalogID != "" {
+	if !server.Spec.IsSingleUser() {
 		return types.NewErrBadRequest("cannot update alias for a multi-user MCP server")
 	}
 
@@ -2758,8 +2757,7 @@ func ConvertMCPServer(server v1.MCPServer, credEnv map[string]string, serverURL,
 	var connectURL string
 	// Only single-user servers get a connect URL.
 	// Multi-user servers have connect URLs on the MCPServerInstances instead.
-	// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should get a connect URL.
-	if server.Spec.MCPCatalogID == "" {
+	if server.Spec.IsSingleUser() {
 		connectURL = system.MCPConnectURL(serverURL, slug)
 	}
 
@@ -3657,8 +3655,7 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 		return fmt.Errorf("failed to get server: %w", err)
 	}
 
-	// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should also be blocked here.
-	if mcpServer.Spec.MCPCatalogID != "" {
+	if !mcpServer.Spec.IsSingleUser() {
 		return types.NewErrBadRequest("cannot update the URL for a multi-user MCP server; use the UpdateServer endpoint instead")
 	}
 

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -255,12 +255,12 @@ func (m *MCPHandler) ListServer(req api.Context) error {
 			hasAccess = true
 		} else {
 			// Apply ACR filtering for regular users and for admins without ?all=true
-			if server.Spec.MCPCatalogID != "" {
+			if server.Spec.IsCatalogServer() {
 				hasAccess, err = m.acrHelper.UserHasAccessToMCPServerCatalogEntryInCatalog(req.User, server.Name, server.Spec.MCPCatalogID)
 				if err != nil {
 					return fmt.Errorf("failed to check access: %w", err)
 				}
-			} else if server.Spec.PowerUserWorkspaceID != "" {
+			} else if server.Spec.IsPowerUserWorkspaceServer() {
 				hasAccess, err = m.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.Context(), req.User, server.Name, server.Spec.PowerUserWorkspaceID)
 				if err != nil {
 					return fmt.Errorf("failed to check access: %w", err)
@@ -2968,9 +2968,9 @@ func (m *MCPHandler) ListServersFromAllSources(req api.Context) error {
 
 	var credCtxs []string
 	for _, server := range allowedServers {
-		if server.Spec.MCPCatalogID != "" {
+		if server.Spec.IsCatalogServer() {
 			credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name))
-		} else if server.Spec.PowerUserWorkspaceID != "" {
+		} else if server.Spec.IsPowerUserWorkspaceServer() {
 			credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name))
 		}
 	}
@@ -3064,9 +3064,9 @@ func (m *MCPHandler) GetServerFromAllSources(req api.Context) error {
 			err       error
 		)
 
-		if server.Spec.MCPCatalogID != "" {
+		if server.Spec.IsCatalogServer() {
 			hasAccess, err = m.acrHelper.UserHasAccessToMCPServerInCatalog(req.User, server.Name, server.Spec.MCPCatalogID)
-		} else if server.Spec.PowerUserWorkspaceID != "" {
+		} else if server.Spec.IsPowerUserWorkspaceServer() {
 			hasAccess, err = m.acrHelper.UserHasAccessToMCPServerInWorkspace(req.User, server.Name, server.Spec.PowerUserWorkspaceID, server.Spec.UserID)
 		}
 		if err != nil {
@@ -3079,9 +3079,9 @@ func (m *MCPHandler) GetServerFromAllSources(req api.Context) error {
 
 	// Get credential context based on server scoping
 	var credCtxs []string
-	if server.Spec.MCPCatalogID != "" {
+	if server.Spec.IsCatalogServer() {
 		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)}
-	} else if server.Spec.PowerUserWorkspaceID != "" {
+	} else if server.Spec.IsPowerUserWorkspaceServer() {
 		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)}
 	}
 

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -3189,8 +3189,7 @@ func (m *MCPHandler) RestartServerDeployment(req api.Context) error {
 
 	if !req.UserIsAdmin() {
 		// Allow users to restart their own single-user servers.
-		userOwnsServer := server.Spec.IsOwnedBy(req.User.GetUID())
-
+		userOwnsServer := server.Spec.IsOwnedBy(req.User.GetUID()) && server.Spec.IsSingleUser()
 		if !userOwnsServer {
 			// Fall back to workspace-based authorization
 			workspaceID := req.PathValue("workspace_id")
@@ -3595,7 +3594,7 @@ func (m *MCPHandler) StreamServerLogs(req api.Context) error {
 	}
 
 	// If this is a single-user MCP server that belongs to the user, then let them access the logs.
-	if !server.Spec.IsOwnedBy(req.User.GetUID()) {
+	if !server.Spec.IsOwnedBy(req.User.GetUID()) || !server.Spec.IsSingleUser() {
 		// If the user doesn't own the server and is not an admin or auditor, check if they have access to the workspace.
 		if !req.UserIsAdmin() && !req.UserIsAuditor() {
 			workspaceID := req.PathValue("workspace_id")

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1736,13 +1736,6 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 		return types.NewErrBadRequest("catalogEntryID is required")
 	}
 
-	// Set ServerUserType explicitly based on the route.
-	if catalogID != "" || workspaceID != "" {
-		server.Spec.ServerUserType = types.ServerUserTypeMultiUser
-	} else {
-		server.Spec.ServerUserType = types.ServerUserTypeSingleUser
-	}
-
 	if err := validation.ValidateServerManifest(server.Spec.Manifest, !server.Spec.IsSingleUser()); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
@@ -2801,7 +2794,6 @@ func ConvertMCPServer(server v1.MCPServer, credEnv map[string]string, serverURL,
 		Template:                    server.Spec.Template,
 		CompositeName:               server.Spec.CompositeName,
 		NanobotAgentID:              server.Spec.NanobotAgentID,
-		ServerUserType:              server.Spec.ServerUserType,
 	}
 
 	// For composite servers, also consider component configuration if provided

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -3200,8 +3200,7 @@ func (m *MCPHandler) RestartServerDeployment(req api.Context) error {
 
 	if !req.UserIsAdmin() {
 		// Allow users to restart their own single-user servers.
-		userOwnsServer := server.Spec.UserID == req.User.GetUID() &&
-			server.Spec.IsSingleUser()
+		userOwnsServer := server.Spec.IsOwnedBy(req.User.GetUID())
 
 		if !userOwnsServer {
 			// Fall back to workspace-based authorization
@@ -3607,7 +3606,7 @@ func (m *MCPHandler) StreamServerLogs(req api.Context) error {
 	}
 
 	// If this is a single-user MCP server that belongs to the user, then let them access the logs.
-	if server.Spec.UserID != req.User.GetUID() || !server.Spec.IsSingleUser() {
+	if !server.Spec.IsOwnedBy(req.User.GetUID()) {
 		// If the user doesn't own the server and is not an admin or auditor, check if they have access to the workspace.
 		if !req.UserIsAdmin() && !req.UserIsAuditor() {
 			workspaceID := req.PathValue("workspace_id")

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1569,7 +1569,7 @@ func (h *MCPCatalogHandler) populateComponentManifests(req api.Context, manifest
 			}
 
 			// Verify this is actually a multi-user server
-			if server.Spec.MCPCatalogID == "" && server.Spec.PowerUserWorkspaceID == "" {
+			if server.Spec.IsSingleUser() {
 				return types.NewErrBadRequest("server %s is not a multi-user server", component.MCPServerID)
 			}
 

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -467,12 +467,13 @@ func (h *MCPCatalogHandler) AdminListServersForEntryInCatalog(req api.Context) e
 		}
 
 		var credCtx string
-		if server.Spec.MCPCatalogID != "" {
+		if server.Spec.IsCatalogServer() {
 			credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
+		} else if server.Spec.IsPowerUserWorkspaceServer() {
+			credCtx = fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
 		} else {
 			credCtx = fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)
 		}
-
 		cred, err := req.GPTClient.RevealCredential(req.Context(), []string{credCtx}, server.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -551,12 +552,13 @@ func (h *MCPCatalogHandler) AdminListServersForAllEntriesInCatalog(req api.Conte
 	var items []types.MCPServer
 	for _, server := range filteredServers {
 		var credCtx string
-		if server.Spec.MCPCatalogID != "" {
+		if server.Spec.IsCatalogServer() {
 			credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
+		} else if server.Spec.IsPowerUserWorkspaceServer() {
+			credCtx = fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
 		} else {
 			credCtx = fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)
 		}
-
 		cred, err := req.GPTClient.RevealCredential(req.Context(), []string{credCtx}, server.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -631,9 +633,9 @@ func (h *MCPCatalogHandler) ListServersForEntry(req api.Context) error {
 		}
 
 		var credCtx string
-		if server.Spec.MCPCatalogID != "" {
+		if server.Spec.IsCatalogServer() {
 			credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
-		} else if server.Spec.PowerUserWorkspaceID != "" {
+		} else if server.Spec.IsPowerUserWorkspaceServer() {
 			credCtx = fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
 		} else {
 			credCtx = fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)
@@ -703,14 +705,13 @@ func (h *MCPCatalogHandler) GetServerFromEntry(req api.Context) error {
 	}
 
 	var credCtx string
-	if server.Spec.MCPCatalogID != "" {
+	if server.Spec.IsCatalogServer() {
 		credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
-	} else if server.Spec.PowerUserWorkspaceID != "" {
+	} else if server.Spec.IsPowerUserWorkspaceServer() {
 		credCtx = fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
 	} else {
 		credCtx = fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)
 	}
-
 	cred, err := req.GPTClient.RevealCredential(req.Context(), []string{credCtx}, server.Name)
 	if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 		return fmt.Errorf("failed to find credential: %w", err)

--- a/pkg/api/handlers/mcpgateway/auditlog.go
+++ b/pkg/api/handlers/mcpgateway/auditlog.go
@@ -28,10 +28,9 @@ func NewAuditLogHandler() *AuditLogHandler {
 }
 
 // getOwnServerMCPIDs returns the MCP server IDs for servers that the user owns directly
-// (not through a workspace or catalog). These are servers where:
+// (not through a workspace or catalog). These are single-user servers where:
 // - Spec.UserID == user's ID
-// - Spec.MCPCatalogID == ""
-// - Spec.PowerUserWorkspaceID == ""
+// - Spec.IsSingleUser() == true
 func getOwnServerMCPIDs(req api.Context) ([]string, error) {
 	var mcpServers v1.MCPServerList
 	if err := req.List(&mcpServers, &kclient.ListOptions{
@@ -42,7 +41,7 @@ func getOwnServerMCPIDs(req api.Context) ([]string, error) {
 
 	var mcpIDs []string
 	for _, server := range mcpServers.Items {
-		if server.Spec.MCPCatalogID == "" && server.Spec.PowerUserWorkspaceID == "" {
+		if server.Spec.IsSingleUser() {
 			mcpIDs = append(mcpIDs, server.Name)
 		}
 	}

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -58,7 +58,7 @@ func convertProjectMCPServer(projectServer *v1.ProjectMCPServer, mcpServer *v1.M
 	}
 	pmcp.Alias = mcpServer.Spec.Alias
 
-	if mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.IsSingleUser() {
 		// For single-user and composite servers, grab more status information from the MCP server.
 		// We don't show this for shared servers, because the user can't do anything about it
 		// if something is wrong with one of those; only the admin can.
@@ -120,7 +120,7 @@ func (p *ProjectMCPHandler) ListServer(req api.Context) error {
 		if mcpServer != nil {
 			mcpServers[server.Name] = *mcpServer
 
-			if mcpServer.Spec.MCPCatalogID == "" {
+			if mcpServer.Spec.IsSingleUser() {
 				credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name))
 			}
 		}
@@ -159,7 +159,7 @@ func (p *ProjectMCPHandler) ListServer(req api.Context) error {
 
 		// Gather components for single-user composite servers
 		var components []types.MCPServer
-		if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+		if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 			if c, err := resolveCompositeComponents(req, mcpServer); err == nil {
 				components = c
 			} else {
@@ -224,7 +224,7 @@ func (p *ProjectMCPHandler) CreateServer(req api.Context) error {
 	}
 
 	var cred map[string]string
-	if mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.IsSingleUser() {
 		gptscriptCred, err := req.GPTClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)}, mcpServer.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -243,7 +243,7 @@ func (p *ProjectMCPHandler) CreateServer(req api.Context) error {
 
 	// Gather components for single-user composite servers
 	var components []types.MCPServer
-	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+	if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 		if c, err := resolveCompositeComponents(req, *mcpServer); err == nil {
 			components = c
 		} else {
@@ -265,7 +265,7 @@ func (p *ProjectMCPHandler) GetServer(req api.Context) error {
 	}
 
 	var cred map[string]string
-	if mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.IsSingleUser() {
 		gptscriptCred, err := req.GPTClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)}, mcpServer.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -280,7 +280,7 @@ func (p *ProjectMCPHandler) GetServer(req api.Context) error {
 
 	// Gather components for single-user composite servers
 	var components []types.MCPServer
-	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+	if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 		if c, err := resolveCompositeComponents(req, *mcpServer); err == nil {
 			components = c
 		} else {
@@ -302,7 +302,7 @@ func (p *ProjectMCPHandler) DeleteServer(req api.Context) error {
 	}
 
 	var cred map[string]string
-	if mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.IsSingleUser() {
 		gptscriptCred, err := req.GPTClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)}, mcpServer.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -325,7 +325,7 @@ func (p *ProjectMCPHandler) DeleteServer(req api.Context) error {
 
 	// Gather components for single-user composite servers
 	var components []types.MCPServer
-	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+	if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 		if c, err := resolveCompositeComponents(req, *mcpServer); err == nil {
 			components = c
 		} else {

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -58,7 +58,8 @@ func convertProjectMCPServer(projectServer *v1.ProjectMCPServer, mcpServer *v1.M
 	}
 	pmcp.Alias = mcpServer.Spec.Alias
 
-	if mcpServer.Spec.IsSingleUser() {
+	// TODO(IsSingleUser): determine if workspace servers should also apply here.
+	if mcpServer.Spec.MCPCatalogID == "" {
 		// For single-user and composite servers, grab more status information from the MCP server.
 		// We don't show this for shared servers, because the user can't do anything about it
 		// if something is wrong with one of those; only the admin can.
@@ -120,7 +121,8 @@ func (p *ProjectMCPHandler) ListServer(req api.Context) error {
 		if mcpServer != nil {
 			mcpServers[server.Name] = *mcpServer
 
-			if mcpServer.Spec.IsSingleUser() {
+			// TODO(IsSingleUser): determine if workspace servers should also apply here.
+	if mcpServer.Spec.MCPCatalogID == "" {
 				credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name))
 			}
 		}
@@ -159,7 +161,8 @@ func (p *ProjectMCPHandler) ListServer(req api.Context) error {
 
 		// Gather components for single-user composite servers
 		var components []types.MCPServer
-		if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+		// TODO(IsSingleUser): determine if workspace servers should also apply here.
+	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 			if c, err := resolveCompositeComponents(req, mcpServer); err == nil {
 				components = c
 			} else {
@@ -224,7 +227,8 @@ func (p *ProjectMCPHandler) CreateServer(req api.Context) error {
 	}
 
 	var cred map[string]string
-	if mcpServer.Spec.IsSingleUser() {
+	// TODO(IsSingleUser): determine if workspace servers should also apply here.
+	if mcpServer.Spec.MCPCatalogID == "" {
 		gptscriptCred, err := req.GPTClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)}, mcpServer.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -243,7 +247,8 @@ func (p *ProjectMCPHandler) CreateServer(req api.Context) error {
 
 	// Gather components for single-user composite servers
 	var components []types.MCPServer
-	if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+	// TODO(IsSingleUser): determine if workspace servers should also apply here.
+	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 		if c, err := resolveCompositeComponents(req, *mcpServer); err == nil {
 			components = c
 		} else {
@@ -265,7 +270,8 @@ func (p *ProjectMCPHandler) GetServer(req api.Context) error {
 	}
 
 	var cred map[string]string
-	if mcpServer.Spec.IsSingleUser() {
+	// TODO(IsSingleUser): determine if workspace servers should also apply here.
+	if mcpServer.Spec.MCPCatalogID == "" {
 		gptscriptCred, err := req.GPTClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)}, mcpServer.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -280,7 +286,8 @@ func (p *ProjectMCPHandler) GetServer(req api.Context) error {
 
 	// Gather components for single-user composite servers
 	var components []types.MCPServer
-	if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+	// TODO(IsSingleUser): determine if workspace servers should also apply here.
+	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 		if c, err := resolveCompositeComponents(req, *mcpServer); err == nil {
 			components = c
 		} else {
@@ -302,7 +309,8 @@ func (p *ProjectMCPHandler) DeleteServer(req api.Context) error {
 	}
 
 	var cred map[string]string
-	if mcpServer.Spec.IsSingleUser() {
+	// TODO(IsSingleUser): determine if workspace servers should also apply here.
+	if mcpServer.Spec.MCPCatalogID == "" {
 		gptscriptCred, err := req.GPTClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)}, mcpServer.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -325,7 +333,8 @@ func (p *ProjectMCPHandler) DeleteServer(req api.Context) error {
 
 	// Gather components for single-user composite servers
 	var components []types.MCPServer
-	if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+	// TODO(IsSingleUser): determine if workspace servers should also apply here.
+	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 		if c, err := resolveCompositeComponents(req, *mcpServer); err == nil {
 			components = c
 		} else {

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -209,9 +209,9 @@ func (p *ProjectMCPHandler) CreateServer(req api.Context) error {
 			hasAccess bool
 			err       error
 		)
-		if mcpServer.Spec.MCPCatalogID != "" {
+		if mcpServer.Spec.IsCatalogServer() {
 			hasAccess, err = p.acrHelper.UserHasAccessToMCPServerInCatalog(req.User, mcpServer.Name, mcpServer.Spec.MCPCatalogID)
-		} else if mcpServer.Spec.PowerUserWorkspaceID != "" {
+		} else if mcpServer.Spec.IsPowerUserWorkspaceServer() {
 			hasAccess, err = p.acrHelper.UserHasAccessToMCPServerInWorkspace(req.User, mcpServer.Name, mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Spec.UserID)
 		}
 

--- a/pkg/api/handlers/projectmcp.go
+++ b/pkg/api/handlers/projectmcp.go
@@ -58,8 +58,7 @@ func convertProjectMCPServer(projectServer *v1.ProjectMCPServer, mcpServer *v1.M
 	}
 	pmcp.Alias = mcpServer.Spec.Alias
 
-	// TODO(IsSingleUser): determine if workspace servers should also apply here.
-	if mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.IsSingleUser() {
 		// For single-user and composite servers, grab more status information from the MCP server.
 		// We don't show this for shared servers, because the user can't do anything about it
 		// if something is wrong with one of those; only the admin can.
@@ -121,8 +120,7 @@ func (p *ProjectMCPHandler) ListServer(req api.Context) error {
 		if mcpServer != nil {
 			mcpServers[server.Name] = *mcpServer
 
-			// TODO(IsSingleUser): determine if workspace servers should also apply here.
-	if mcpServer.Spec.MCPCatalogID == "" {
+			if mcpServer.Spec.IsSingleUser() {
 				credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name))
 			}
 		}
@@ -161,8 +159,7 @@ func (p *ProjectMCPHandler) ListServer(req api.Context) error {
 
 		// Gather components for single-user composite servers
 		var components []types.MCPServer
-		// TODO(IsSingleUser): determine if workspace servers should also apply here.
-	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+		if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 			if c, err := resolveCompositeComponents(req, mcpServer); err == nil {
 				components = c
 			} else {
@@ -227,8 +224,7 @@ func (p *ProjectMCPHandler) CreateServer(req api.Context) error {
 	}
 
 	var cred map[string]string
-	// TODO(IsSingleUser): determine if workspace servers should also apply here.
-	if mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.IsSingleUser() {
 		gptscriptCred, err := req.GPTClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)}, mcpServer.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -247,8 +243,7 @@ func (p *ProjectMCPHandler) CreateServer(req api.Context) error {
 
 	// Gather components for single-user composite servers
 	var components []types.MCPServer
-	// TODO(IsSingleUser): determine if workspace servers should also apply here.
-	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+	if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 		if c, err := resolveCompositeComponents(req, *mcpServer); err == nil {
 			components = c
 		} else {
@@ -270,8 +265,7 @@ func (p *ProjectMCPHandler) GetServer(req api.Context) error {
 	}
 
 	var cred map[string]string
-	// TODO(IsSingleUser): determine if workspace servers should also apply here.
-	if mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.IsSingleUser() {
 		gptscriptCred, err := req.GPTClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)}, mcpServer.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -286,8 +280,7 @@ func (p *ProjectMCPHandler) GetServer(req api.Context) error {
 
 	// Gather components for single-user composite servers
 	var components []types.MCPServer
-	// TODO(IsSingleUser): determine if workspace servers should also apply here.
-	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+	if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 		if c, err := resolveCompositeComponents(req, *mcpServer); err == nil {
 			components = c
 		} else {
@@ -309,8 +302,7 @@ func (p *ProjectMCPHandler) DeleteServer(req api.Context) error {
 	}
 
 	var cred map[string]string
-	// TODO(IsSingleUser): determine if workspace servers should also apply here.
-	if mcpServer.Spec.MCPCatalogID == "" {
+	if mcpServer.Spec.IsSingleUser() {
 		gptscriptCred, err := req.GPTClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)}, mcpServer.Name)
 		if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
@@ -333,8 +325,7 @@ func (p *ProjectMCPHandler) DeleteServer(req api.Context) error {
 
 	// Gather components for single-user composite servers
 	var components []types.MCPServer
-	// TODO(IsSingleUser): determine if workspace servers should also apply here.
-	if mcpServer.Spec.MCPCatalogID == "" && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+	if mcpServer.Spec.IsSingleUser() && mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
 		if c, err := resolveCompositeComponents(req, *mcpServer); err == nil {
 			components = c
 		} else {

--- a/pkg/api/handlers/registry/convert.go
+++ b/pkg/api/handlers/registry/convert.go
@@ -82,8 +82,8 @@ func ConvertMCPServerToRegistry(
 	}
 
 	// Determine if server should show connection URL
-	isPersonalServer := convertedServer.UserID == userID && convertedServer.MCPCatalogID == "" && convertedServer.PowerUserWorkspaceID == ""
-	isMultiUserServer := convertedServer.MCPCatalogID != "" || convertedServer.PowerUserWorkspaceID != ""
+	isPersonalServer := convertedServer.UserID == userID && convertedServer.IsSingleUser()
+	isMultiUserServer := !convertedServer.IsSingleUser()
 
 	// For configured servers, add remote with mcp-connect URL
 	// All Obot servers are exposed as streamable-http remotes regardless of underlying runtime

--- a/pkg/api/handlers/registry/handler.go
+++ b/pkg/api/handlers/registry/handler.go
@@ -765,7 +765,7 @@ func (h *Handler) findMCPServer(req api.Context, serverName, reverseDNS string) 
 	// Get the credentials for the server. We ignore errors if we get any,
 	// as we can still convert the server anyway and display it.
 	// Worst-case scenario is that a server that is configured will show up without a connect URL.
-	if server.Spec.UserID == req.User.GetUID() && server.Spec.IsSingleUser() {
+	if server.Spec.IsOwnedBy(req.User.GetUID()) {
 		// Personal server - user owns it
 		slug, err = handlers.SlugForMCPServer(req.Context(), req.Storage, server, req.User.GetUID(), "", "")
 		if err != nil {

--- a/pkg/api/handlers/registry/handler.go
+++ b/pkg/api/handlers/registry/handler.go
@@ -765,7 +765,7 @@ func (h *Handler) findMCPServer(req api.Context, serverName, reverseDNS string) 
 	// Get the credentials for the server. We ignore errors if we get any,
 	// as we can still convert the server anyway and display it.
 	// Worst-case scenario is that a server that is configured will show up without a connect URL.
-	if server.Spec.UserID == req.User.GetUID() && server.Spec.MCPCatalogID == "" && server.Spec.PowerUserWorkspaceID == "" {
+	if server.Spec.UserID == req.User.GetUID() && server.Spec.IsSingleUser() {
 		// Personal server - user owns it
 		slug, err = handlers.SlugForMCPServer(req.Context(), req.Storage, server, req.User.GetUID(), "", "")
 		if err != nil {

--- a/pkg/api/handlers/registry/handler.go
+++ b/pkg/api/handlers/registry/handler.go
@@ -765,7 +765,7 @@ func (h *Handler) findMCPServer(req api.Context, serverName, reverseDNS string) 
 	// Get the credentials for the server. We ignore errors if we get any,
 	// as we can still convert the server anyway and display it.
 	// Worst-case scenario is that a server that is configured will show up without a connect URL.
-	if server.Spec.IsOwnedBy(req.User.GetUID()) {
+	if server.Spec.IsOwnedBy(req.User.GetUID()) && server.Spec.IsSingleUser() {
 		// Personal server - user owns it
 		slug, err = handlers.SlugForMCPServer(req.Context(), req.Storage, server, req.User.GetUID(), "", "")
 		if err != nil {

--- a/pkg/api/handlers/serverinstances.go
+++ b/pkg/api/handlers/serverinstances.go
@@ -115,9 +115,9 @@ func (h *ServerInstancesHandler) CreateServerInstance(req api.Context) error {
 			err       error
 		)
 
-		if server.Spec.MCPCatalogID != "" {
+		if server.Spec.IsCatalogServer() {
 			hasAccess, err = h.acrHelper.UserHasAccessToMCPServerInCatalog(req.User, server.Name, server.Spec.MCPCatalogID)
-		} else if server.Spec.PowerUserWorkspaceID != "" {
+		} else if server.Spec.IsPowerUserWorkspaceServer() {
 			hasAccess, err = h.acrHelper.UserHasAccessToMCPServerInWorkspace(req.User, server.Name, server.Spec.PowerUserWorkspaceID, server.Spec.UserID)
 		}
 

--- a/pkg/controller/handlers/cleanup/credentials.go
+++ b/pkg/controller/handlers/cleanup/credentials.go
@@ -145,9 +145,9 @@ func (c *Credentials) RemoveMCPCredentials(req router.Request, _ router.Response
 	}
 
 	var credCtx string
-	if mcpServer.Spec.MCPCatalogID != "" {
+	if mcpServer.Spec.IsCatalogServer() {
 		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.MCPCatalogID, mcpServer.Name)
-	} else if mcpServer.Spec.PowerUserWorkspaceID != "" {
+	} else if mcpServer.Spec.IsPowerUserWorkspaceServer() {
 		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Name)
 	} else {
 		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -788,9 +788,8 @@ func (h *Handler) DeleteUnauthorizedMCPServersForCatalog(req router.Request, _ r
 		}
 		// Iterate through each MCPServer and make sure it is still allowed to exist.
 		for _, server := range mcpServers.Items {
-			// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should also be skipped here.
-			if !server.DeletionTimestamp.IsZero() || server.Spec.ThreadName != "" || server.Spec.MCPCatalogID != "" {
-				// For legacy project-scoped servers and multi-user servers created by the admin, we don't need to check them.
+			if !server.DeletionTimestamp.IsZero() || server.Spec.ThreadName != "" || !server.Spec.IsSingleUser() {
+				// For legacy project-scoped servers and multi-user servers, we don't need to check them.
 				continue
 			}
 

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -788,7 +788,8 @@ func (h *Handler) DeleteUnauthorizedMCPServersForCatalog(req router.Request, _ r
 		}
 		// Iterate through each MCPServer and make sure it is still allowed to exist.
 		for _, server := range mcpServers.Items {
-			if !server.DeletionTimestamp.IsZero() || server.Spec.ThreadName != "" || !server.Spec.IsSingleUser() {
+			// TODO(IsSingleUser): determine if workspace servers (PowerUserWorkspaceID != "") should also be skipped here.
+			if !server.DeletionTimestamp.IsZero() || server.Spec.ThreadName != "" || server.Spec.MCPCatalogID != "" {
 				// For legacy project-scoped servers and multi-user servers created by the admin, we don't need to check them.
 				continue
 			}

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -788,7 +788,7 @@ func (h *Handler) DeleteUnauthorizedMCPServersForCatalog(req router.Request, _ r
 		}
 		// Iterate through each MCPServer and make sure it is still allowed to exist.
 		for _, server := range mcpServers.Items {
-			if !server.DeletionTimestamp.IsZero() || server.Spec.ThreadName != "" || server.Spec.MCPCatalogID != "" {
+			if !server.DeletionTimestamp.IsZero() || server.Spec.ThreadName != "" || !server.Spec.IsSingleUser() {
 				// For legacy project-scoped servers and multi-user servers created by the admin, we don't need to check them.
 				continue
 			}

--- a/pkg/controller/handlers/mcpcatalog/usergroupchange.go
+++ b/pkg/controller/handlers/mcpcatalog/usergroupchange.go
@@ -86,11 +86,6 @@ func (h *Handler) deleteUnauthorizedServersForUser(ctx context.Context, client k
 				continue
 			}
 
-			// Only handle single-user catalog entries here.
-			if !entry.Spec.Manifest.ServerUserType.IsSingleUser() {
-				continue
-			}
-
 			// Check access based on whether the catalog entry is in a workspace or regular catalog
 			if entry.Spec.PowerUserWorkspaceID != "" {
 				// Catalog entry is in a PowerUserWorkspace

--- a/pkg/controller/handlers/mcpcatalog/usergroupchange.go
+++ b/pkg/controller/handlers/mcpcatalog/usergroupchange.go
@@ -63,14 +63,13 @@ func (h *Handler) deleteUnauthorizedServersForUser(ctx context.Context, client k
 		}
 
 		// Skip multi-user servers - we only care about a user's own single-user servers
-		// Multi-user servers have MCPCatalogID or PowerUserWorkspaceID set
-		if server.Spec.MCPCatalogID != "" || server.Spec.PowerUserWorkspaceID != "" {
+		if !server.Spec.IsSingleUser() {
 			continue
 		}
 
-		// At this point, we only have single-user servers created from catalog entries
+		// At this point, we only have single-user servers created from catalog entries.
 		// For every server, fetch its catalog entry and check that the user has an ACR
-		// that gives them access to that catalog entry
+		// that gives them access to that catalog entry.
 		var (
 			hasAccess bool
 			err       error
@@ -84,6 +83,11 @@ func (h *Handler) deleteUnauthorizedServersForUser(ctx context.Context, client k
 				Name:      server.Spec.MCPServerCatalogEntryName,
 			}, &entry); getErr != nil {
 				log.Warnf("Failed to get catalog entry %s: %v", server.Spec.MCPServerCatalogEntryName, getErr)
+				continue
+			}
+
+			// Only handle single-user catalog entries here.
+			if !entry.Spec.Manifest.ServerUserType.IsSingleUser() {
 				continue
 			}
 

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -741,7 +741,6 @@ func (h *Handler) EnsureCompositeComponents(req router.Request, _ router.Respons
 					MCPServerCatalogEntryName: component.CatalogEntryID,
 					UserID:                    compositeServer.Spec.UserID,
 					CompositeName:             compositeServer.Name,
-					ServerUserType:            types.ServerUserTypeSingleUser,
 				},
 			})
 

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -404,7 +404,7 @@ func compositeConfigHasDrifted(serverConfig *types.CompositeRuntimeConfig, entry
 // EnsureMCPServerInstanceUserCount ensures that mcp server instance user count for multi-user MCP servers is up to date.
 func (*Handler) EnsureMCPServerInstanceUserCount(req router.Request, _ router.Response) error {
 	server := req.Object.(*v1.MCPServer)
-	if server.Spec.MCPCatalogID == "" && server.Spec.PowerUserWorkspaceID == "" {
+	if server.Spec.IsSingleUser() {
 		// Server is not multi-user, ensure we're not tracking the instance user count
 		if server.Status.MCPServerInstanceUserCount == nil {
 			return nil
@@ -741,6 +741,7 @@ func (h *Handler) EnsureCompositeComponents(req router.Request, _ router.Respons
 					MCPServerCatalogEntryName: component.CatalogEntryID,
 					UserID:                    compositeServer.Spec.UserID,
 					CompositeName:             compositeServer.Name,
+					ServerUserType:            types.ServerUserTypeSingleUser,
 				},
 			})
 
@@ -957,7 +958,7 @@ func (h *Handler) ShutdownIdleServers(req router.Request, resp router.Response) 
 		idleInterval = h.singleUserIdleShutdownDelay
 		if mcpServer.Spec.NanobotAgentID != "" {
 			idleInterval = h.agentIdleShutdownDelay
-		} else if mcpServer.Spec.MCPCatalogID != "" || mcpServer.Spec.PowerUserWorkspaceID != "" {
+		} else if !mcpServer.Spec.IsSingleUser() {
 			idleInterval = h.multiUserIdleShutdownDelay
 		}
 	}

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -859,14 +859,13 @@ func (h *Handler) SyncOAuthMetadata(req router.Request, _ router.Response) error
 	}
 
 	var credCtxs []string
-	if server.Spec.MCPCatalogID != "" {
+	if server.Spec.IsCatalogServer() {
 		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)}
-	} else if server.Spec.PowerUserWorkspaceID != "" {
+	} else if server.Spec.IsPowerUserWorkspaceServer() {
 		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)}
 	} else {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name))
+		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)}
 	}
-
 	cred, err := h.gptClient.RevealCredential(req.Ctx, credCtxs, server.Name)
 	if err != nil && !errors.As(err, &gptscript.ErrNotFound{}) {
 		return fmt.Errorf("failed to reveal credential: %w", err)

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -33,8 +33,14 @@ func NewHandler(gClient *gptscript.GPTScript) *Handler {
 }
 
 // EnsureUserCount ensures that the user count for an MCP server catalog entry is up to date.
+// This only applies to single-user catalog entries, where each user gets their own MCPServer.
 func (*Handler) EnsureUserCount(req router.Request, _ router.Response) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
+
+	// User count tracking via MCPServers only applies to single-user catalog entries.
+	if !entry.Spec.Manifest.ServerUserType.IsSingleUser() {
+		return nil
+	}
 
 	var mcpServers v1.MCPServerList
 	if err := req.List(&mcpServers, &kclient.ListOptions{

--- a/pkg/controller/handlers/mcpserverinstance/mcpserverinstance.go
+++ b/pkg/controller/handlers/mcpserverinstance/mcpserverinstance.go
@@ -29,8 +29,8 @@ func (h *Handler) MigrationDeleteSingleUserInstances(req router.Request, _ route
 		return err
 	}
 
-	if server.Spec.MCPCatalogID == "" && server.Spec.PowerUserWorkspaceID == "" {
-		// This server is unshared (neither catalog-shared nor workspace-scoped), so it should not have any server instances.
+	if server.Spec.IsSingleUser() {
+		// This server is single-user, so it should not have any server instances.
 		// Delete this instance.
 		log.Infof("Deleting invalid single-user MCPServerInstance for unshared server: instance=%s server=%s", instance.Name, server.Name)
 		return req.Delete(instance)
@@ -50,7 +50,7 @@ func (h *Handler) UpdateMultiUserConfig(req router.Request, _ router.Response) e
 		return err
 	}
 
-	if server.Spec.MCPCatalogID != "" || server.Spec.PowerUserWorkspaceID != "" {
+	if !server.Spec.IsSingleUser() {
 		if !equality.Semantic.DeepEqual(instance.Spec.MultiUserConfig, server.Spec.Manifest.MultiUserConfig) {
 			instance.Spec.MultiUserConfig = server.Spec.Manifest.MultiUserConfig
 			return req.Client.Update(req.Ctx, instance)

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -168,6 +168,7 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 		Spec: v1.MCPServerSpec{
 			UserID:         agent.Spec.UserID,
 			NanobotAgentID: agent.Name,
+			ServerUserType: types.ServerUserTypeSingleUser,
 			Manifest: types.MCPServerManifest{
 				Name:             agent.Name,
 				ShortDescription: agent.Spec.DisplayName,

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -168,7 +168,6 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 		Spec: v1.MCPServerSpec{
 			UserID:         agent.Spec.UserID,
 			NanobotAgentID: agent.Name,
-			ServerUserType: types.ServerUserTypeSingleUser,
 			Manifest: types.MCPServerManifest{
 				Name:             agent.Name,
 				ShortDescription: agent.Spec.DisplayName,

--- a/pkg/controller/handlers/threads/threads.go
+++ b/pkg/controller/handlers/threads/threads.go
@@ -768,9 +768,9 @@ func (*Handler) copyMCPServer(req router.Request, sourcePMS *v1.ProjectMCPServer
 				Alias:                     sourceMCPServer.Spec.Alias,
 				UserID:                    thread.Spec.UserID,
 				MCPServerCatalogEntryName: sourceMCPServer.Spec.MCPServerCatalogEntryName,
-				MCPCatalogID:         sourceMCPServer.Spec.MCPCatalogID,
-				PowerUserWorkspaceID: sourceMCPServer.Spec.PowerUserWorkspaceID,
-				Template:             thread.Spec.Template,
+				MCPCatalogID:              sourceMCPServer.Spec.MCPCatalogID,
+				PowerUserWorkspaceID:      sourceMCPServer.Spec.PowerUserWorkspaceID,
+				Template:                  thread.Spec.Template,
 			},
 		}
 

--- a/pkg/controller/handlers/threads/threads.go
+++ b/pkg/controller/handlers/threads/threads.go
@@ -768,10 +768,9 @@ func (*Handler) copyMCPServer(req router.Request, sourcePMS *v1.ProjectMCPServer
 				Alias:                     sourceMCPServer.Spec.Alias,
 				UserID:                    thread.Spec.UserID,
 				MCPServerCatalogEntryName: sourceMCPServer.Spec.MCPServerCatalogEntryName,
-				MCPCatalogID:              sourceMCPServer.Spec.MCPCatalogID,
-				PowerUserWorkspaceID:      sourceMCPServer.Spec.PowerUserWorkspaceID,
-				Template:                  thread.Spec.Template,
-				ServerUserType:            sourceMCPServer.Spec.ServerUserType,
+				MCPCatalogID:         sourceMCPServer.Spec.MCPCatalogID,
+				PowerUserWorkspaceID: sourceMCPServer.Spec.PowerUserWorkspaceID,
+				Template:             thread.Spec.Template,
 			},
 		}
 
@@ -789,7 +788,6 @@ func (*Handler) copyMCPServer(req router.Request, sourcePMS *v1.ProjectMCPServer
 		copiedMCPServer.Spec.MCPCatalogID = sourceMCPServer.Spec.MCPCatalogID
 		copiedMCPServer.Spec.PowerUserWorkspaceID = sourceMCPServer.Spec.PowerUserWorkspaceID
 		copiedMCPServer.Spec.Template = thread.Spec.Template
-		copiedMCPServer.Spec.ServerUserType = sourceMCPServer.Spec.ServerUserType
 
 		if err := req.Client.Update(req.Ctx, &copiedMCPServer); err != nil {
 			return nil, err

--- a/pkg/controller/handlers/threads/threads.go
+++ b/pkg/controller/handlers/threads/threads.go
@@ -771,6 +771,7 @@ func (*Handler) copyMCPServer(req router.Request, sourcePMS *v1.ProjectMCPServer
 				MCPCatalogID:              sourceMCPServer.Spec.MCPCatalogID,
 				PowerUserWorkspaceID:      sourceMCPServer.Spec.PowerUserWorkspaceID,
 				Template:                  thread.Spec.Template,
+				ServerUserType:            sourceMCPServer.Spec.ServerUserType,
 			},
 		}
 
@@ -788,6 +789,7 @@ func (*Handler) copyMCPServer(req router.Request, sourcePMS *v1.ProjectMCPServer
 		copiedMCPServer.Spec.MCPCatalogID = sourceMCPServer.Spec.MCPCatalogID
 		copiedMCPServer.Spec.PowerUserWorkspaceID = sourceMCPServer.Spec.PowerUserWorkspaceID
 		copiedMCPServer.Spec.Template = thread.Spec.Template
+		copiedMCPServer.Spec.ServerUserType = sourceMCPServer.Spec.ServerUserType
 
 		if err := req.Client.Update(req.Ctx, &copiedMCPServer); err != nil {
 			return nil, err

--- a/pkg/gateway/server/apikey.go
+++ b/pkg/gateway/server/apikey.go
@@ -96,12 +96,12 @@ func (s *Server) userHasAccessToMCPServer(apiContext api.Context, server *v1.MCP
 	}
 
 	// Check ACR for catalog-scoped servers
-	if server.Spec.MCPCatalogID != "" {
+	if server.Spec.IsCatalogServer() {
 		return s.acrHelper.UserHasAccessToMCPServerInCatalog(apiContext.User, server.Name, server.Spec.MCPCatalogID)
 	}
 
 	// Check ACR for workspace-scoped servers
-	if server.Spec.PowerUserWorkspaceID != "" {
+	if server.Spec.IsPowerUserWorkspaceServer() {
 		return s.acrHelper.UserHasAccessToMCPServerInWorkspace(apiContext.User, server.Name, server.Spec.PowerUserWorkspaceID, server.Spec.UserID)
 	}
 

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -140,6 +140,12 @@ func (s MCPServerSpec) IsSingleUser() bool {
 	return s.MCPCatalogID == "" && s.PowerUserWorkspaceID == ""
 }
 
+// IsOwnedBy returns true if the given user directly owns this server.
+// Only true for single-user servers — multi-user servers are accessed via ACR, not direct ownership.
+func (s MCPServerSpec) IsOwnedBy(userID string) bool {
+	return s.UserID == userID && s.IsSingleUser()
+}
+
 type MCPServerStatus struct {
 	// MCPCatalogID is the catalog ID of the catalog entry that this MCP server is based on.
 	MCPCatalogID string `json:"mcpCatalogID,omitempty"`

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -125,18 +125,10 @@ type MCPServerSpec struct {
 	CompositeName string `json:"compositeName,omitempty"`
 	// NanobotAgentID is the name of the NanobotAgent that created this MCP server, if there is one.
 	NanobotAgentID string `json:"nanobotAgentID,omitempty"`
-	// ServerUserType specifies whether this is a single-user or multi-user MCP server.
-	// Empty value uses legacy inference from MCPCatalogID and PowerUserWorkspaceID.
-	ServerUserType types.ServerUserType `json:"serverUserType,omitempty"`
 }
 
 // IsSingleUser returns true if this is a single-user MCP server.
-// For servers created before this field existed, falls back to legacy inference from ownership fields.
 func (s MCPServerSpec) IsSingleUser() bool {
-	if s.ServerUserType != "" {
-		return s.ServerUserType.IsSingleUser()
-	}
-	// Legacy fallback: infer from ownership fields
 	return s.MCPCatalogID == "" && s.PowerUserWorkspaceID == ""
 }
 

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -146,6 +146,16 @@ func (s MCPServerSpec) IsOwnedBy(userID string) bool {
 	return s.UserID == userID && s.IsSingleUser()
 }
 
+// IsCatalogServer returns true if this server is owned by a catalog (admin-deployed multi-user server).
+func (s MCPServerSpec) IsCatalogServer() bool {
+	return s.MCPCatalogID != ""
+}
+
+// IsPowerUserWorkspaceServer returns true if this server is owned by a PowerUserWorkspace.
+func (s MCPServerSpec) IsPowerUserWorkspaceServer() bool {
+	return s.PowerUserWorkspaceID != ""
+}
+
 type MCPServerStatus struct {
 	// MCPCatalogID is the catalog ID of the catalog entry that this MCP server is based on.
 	MCPCatalogID string `json:"mcpCatalogID,omitempty"`

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -125,6 +125,19 @@ type MCPServerSpec struct {
 	CompositeName string `json:"compositeName,omitempty"`
 	// NanobotAgentID is the name of the NanobotAgent that created this MCP server, if there is one.
 	NanobotAgentID string `json:"nanobotAgentID,omitempty"`
+	// ServerUserType specifies whether this is a single-user or multi-user MCP server.
+	// Empty value uses legacy inference from MCPCatalogID and PowerUserWorkspaceID.
+	ServerUserType types.ServerUserType `json:"serverUserType,omitempty"`
+}
+
+// IsSingleUser returns true if this is a single-user MCP server.
+// For servers created before this field existed, falls back to legacy inference from ownership fields.
+func (s MCPServerSpec) IsSingleUser() bool {
+	if s.ServerUserType != "" {
+		return s.ServerUserType.IsSingleUser()
+	}
+	// Legacy fallback: infer from ownership fields
+	return s.MCPCatalogID == "" && s.PowerUserWorkspaceID == ""
 }
 
 type MCPServerStatus struct {

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -132,10 +132,10 @@ func (s MCPServerSpec) IsSingleUser() bool {
 	return s.MCPCatalogID == "" && s.PowerUserWorkspaceID == ""
 }
 
-// IsOwnedBy returns true if the given user directly owns this server.
-// Only true for single-user servers — multi-user servers are accessed via ACR, not direct ownership.
+// IsOwnedBy returns true if the given user created this server and it is not
+// an admin-deployed catalog server. Covers personal and workspace servers.
 func (s MCPServerSpec) IsOwnedBy(userID string) bool {
-	return s.UserID == userID && s.IsSingleUser()
+	return s.UserID == userID && !s.IsCatalogServer()
 }
 
 // IsCatalogServer returns true if this server is owned by a catalog (admin-deployed multi-user server).

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
@@ -1,10 +1,6 @@
 package v1
 
-import (
-	"testing"
-
-	"github.com/obot-platform/obot/apiclient/types"
-)
+import "testing"
 
 func TestMCPServerSpec_IsCatalogServer(t *testing.T) {
 	if (MCPServerSpec{MCPCatalogID: "default"}).IsCatalogServer() != true {
@@ -39,31 +35,25 @@ func TestMCPServerSpec_IsOwnedBy(t *testing.T) {
 	}{
 		{
 			name:   "single-user server owned by user",
-			spec:   MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser, UserID: "user-1"},
-			userID: "user-1",
-			want:   true,
-		},
-		{
-			name:   "single-user server owned by different user",
-			spec:   MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser, UserID: "user-1"},
-			userID: "user-2",
-			want:   false,
-		},
-		{
-			name:   "multi-user server — never directly owned",
-			spec:   MCPServerSpec{ServerUserType: types.ServerUserTypeMultiUser, UserID: "user-1"},
-			userID: "user-1",
-			want:   false,
-		},
-		{
-			name:   "legacy single-user: no catalog/workspace",
 			spec:   MCPServerSpec{UserID: "user-1"},
 			userID: "user-1",
 			want:   true,
 		},
 		{
-			name:   "legacy multi-user: catalog set — not directly owned even if UserID matches",
+			name:   "single-user server owned by different user",
+			spec:   MCPServerSpec{UserID: "user-1"},
+			userID: "user-2",
+			want:   false,
+		},
+		{
+			name:   "catalog server — never directly owned even if UserID matches",
 			spec:   MCPServerSpec{UserID: "user-1", MCPCatalogID: "default"},
+			userID: "user-1",
+			want:   false,
+		},
+		{
+			name:   "workspace server — never directly owned even if UserID matches",
+			spec:   MCPServerSpec{UserID: "user-1", PowerUserWorkspaceID: "ws-1"},
 			userID: "user-1",
 			want:   false,
 		},
@@ -85,43 +75,18 @@ func TestMCPServerSpec_IsSingleUser(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "explicit singleUser type",
-			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser},
-			want: true,
-		},
-		{
-			name: "explicit multiUser type",
-			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeMultiUser},
-			want: false,
-		},
-		{
-			name: "legacy: empty type, no catalog/workspace",
+			name: "no catalog/workspace: single-user",
 			spec: MCPServerSpec{MCPCatalogID: "", PowerUserWorkspaceID: ""},
 			want: true,
 		},
 		{
-			name: "legacy: empty type, catalog set",
+			name: "catalog set: multi-user",
 			spec: MCPServerSpec{MCPCatalogID: "default"},
 			want: false,
 		},
 		{
-			name: "legacy: empty type, workspace set",
+			name: "workspace set: multi-user",
 			spec: MCPServerSpec{PowerUserWorkspaceID: "ws-1"},
-			want: false,
-		},
-		{
-			name: "ServerUserType takes precedence over legacy MCPCatalogID",
-			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser, MCPCatalogID: "default"},
-			want: true,
-		},
-		{
-			name: "ServerUserType takes precedence over legacy PowerUserWorkspaceID",
-			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser, PowerUserWorkspaceID: "ws-1"},
-			want: true,
-		},
-		{
-			name: "multiUser type with empty ownership fields",
-			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeMultiUser},
 			want: false,
 		},
 	}

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
@@ -34,28 +34,28 @@ func TestMCPServerSpec_IsOwnedBy(t *testing.T) {
 		want   bool
 	}{
 		{
-			name:   "single-user server owned by user",
+			name:   "matching UserID",
 			spec:   MCPServerSpec{UserID: "user-1"},
 			userID: "user-1",
 			want:   true,
 		},
 		{
-			name:   "single-user server owned by different user",
+			name:   "non-matching UserID",
 			spec:   MCPServerSpec{UserID: "user-1"},
 			userID: "user-2",
 			want:   false,
 		},
 		{
-			name:   "catalog server — never directly owned even if UserID matches",
+			name:   "admin-deployed catalog server — not owned even if UserID matches",
 			spec:   MCPServerSpec{UserID: "user-1", MCPCatalogID: "default"},
 			userID: "user-1",
 			want:   false,
 		},
 		{
-			name:   "workspace server — never directly owned even if UserID matches",
+			name:   "workspace server with matching UserID — owned",
 			spec:   MCPServerSpec{UserID: "user-1", PowerUserWorkspaceID: "ws-1"},
 			userID: "user-1",
-			want:   false,
+			want:   true,
 		},
 	}
 

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
@@ -1,0 +1,64 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+func TestMCPServerSpec_IsSingleUser(t *testing.T) {
+	tests := []struct {
+		name   string
+		spec   MCPServerSpec
+		want   bool
+	}{
+		{
+			name: "explicit singleUser type",
+			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser},
+			want: true,
+		},
+		{
+			name: "explicit multiUser type",
+			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeMultiUser},
+			want: false,
+		},
+		{
+			name: "legacy: empty type, no catalog/workspace",
+			spec: MCPServerSpec{MCPCatalogID: "", PowerUserWorkspaceID: ""},
+			want: true,
+		},
+		{
+			name: "legacy: empty type, catalog set",
+			spec: MCPServerSpec{MCPCatalogID: "default"},
+			want: false,
+		},
+		{
+			name: "legacy: empty type, workspace set",
+			spec: MCPServerSpec{PowerUserWorkspaceID: "ws-1"},
+			want: false,
+		},
+		{
+			name: "ServerUserType takes precedence over legacy MCPCatalogID",
+			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser, MCPCatalogID: "default"},
+			want: true,
+		},
+		{
+			name: "ServerUserType takes precedence over legacy PowerUserWorkspaceID",
+			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser, PowerUserWorkspaceID: "ws-1"},
+			want: true,
+		},
+		{
+			name: "multiUser type with empty ownership fields",
+			spec: MCPServerSpec{ServerUserType: types.ServerUserTypeMultiUser},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.spec.IsSingleUser(); got != tt.want {
+				t.Errorf("MCPServerSpec.IsSingleUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
@@ -6,6 +6,54 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 )
 
+func TestMCPServerSpec_IsOwnedBy(t *testing.T) {
+	tests := []struct {
+		name   string
+		spec   MCPServerSpec
+		userID string
+		want   bool
+	}{
+		{
+			name:   "single-user server owned by user",
+			spec:   MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser, UserID: "user-1"},
+			userID: "user-1",
+			want:   true,
+		},
+		{
+			name:   "single-user server owned by different user",
+			spec:   MCPServerSpec{ServerUserType: types.ServerUserTypeSingleUser, UserID: "user-1"},
+			userID: "user-2",
+			want:   false,
+		},
+		{
+			name:   "multi-user server — never directly owned",
+			spec:   MCPServerSpec{ServerUserType: types.ServerUserTypeMultiUser, UserID: "user-1"},
+			userID: "user-1",
+			want:   false,
+		},
+		{
+			name:   "legacy single-user: no catalog/workspace",
+			spec:   MCPServerSpec{UserID: "user-1"},
+			userID: "user-1",
+			want:   true,
+		},
+		{
+			name:   "legacy multi-user: catalog set — not directly owned even if UserID matches",
+			spec:   MCPServerSpec{UserID: "user-1", MCPCatalogID: "default"},
+			userID: "user-1",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.spec.IsOwnedBy(tt.userID); got != tt.want {
+				t.Errorf("MCPServerSpec.IsOwnedBy(%q) = %v, want %v", tt.userID, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMCPServerSpec_IsSingleUser(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
@@ -6,6 +6,30 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 )
 
+func TestMCPServerSpec_IsCatalogServer(t *testing.T) {
+	if (MCPServerSpec{MCPCatalogID: "default"}).IsCatalogServer() != true {
+		t.Error("expected true for catalog server")
+	}
+	if (MCPServerSpec{PowerUserWorkspaceID: "ws-1"}).IsCatalogServer() != false {
+		t.Error("expected false for workspace server")
+	}
+	if (MCPServerSpec{}).IsCatalogServer() != false {
+		t.Error("expected false for single-user server")
+	}
+}
+
+func TestMCPServerSpec_IsPowerUserWorkspaceServer(t *testing.T) {
+	if (MCPServerSpec{PowerUserWorkspaceID: "ws-1"}).IsPowerUserWorkspaceServer() != true {
+		t.Error("expected true for workspace server")
+	}
+	if (MCPServerSpec{MCPCatalogID: "default"}).IsPowerUserWorkspaceServer() != false {
+		t.Error("expected false for catalog server")
+	}
+	if (MCPServerSpec{}).IsPowerUserWorkspaceServer() != false {
+		t.Error("expected false for single-user server")
+	}
+}
+
 func TestMCPServerSpec_IsOwnedBy(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -56,9 +80,9 @@ func TestMCPServerSpec_IsOwnedBy(t *testing.T) {
 
 func TestMCPServerSpec_IsSingleUser(t *testing.T) {
 	tests := []struct {
-		name   string
-		spec   MCPServerSpec
-		want   bool
+		name string
+		spec MCPServerSpec
+		want bool
 	}{
 		{
 			name: "explicit singleUser type",

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -6702,13 +6702,6 @@ func schema_obot_platform_obot_apiclient_types_MCPServer(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
-					"serverUserType": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ServerUserType specifies whether this is a single-user or multi-user MCP server. Empty value uses legacy inference from MCPCatalogID and PowerUserWorkspaceID.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 				},
 				Required: []string{"Metadata", "manifest", "userID", "configured", "catalogEntryID", "powerUserWorkspaceID"},
 			},
@@ -19673,13 +19666,6 @@ func schema_storage_apis_obotobotai_v1_MCPServerSpec(ref common.ReferenceCallbac
 					"nanobotAgentID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NanobotAgentID is the name of the NanobotAgent that created this MCP server, if there is one.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"serverUserType": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ServerUserType specifies whether this is a single-user or multi-user MCP server. Empty value uses legacy inference from MCPCatalogID and PowerUserWorkspaceID.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -6702,6 +6702,13 @@ func schema_obot_platform_obot_apiclient_types_MCPServer(ref common.ReferenceCal
 							Format:      "",
 						},
 					},
+					"serverUserType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServerUserType specifies whether this is a single-user or multi-user MCP server. Empty value uses legacy inference from MCPCatalogID and PowerUserWorkspaceID.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"Metadata", "manifest", "userID", "configured", "catalogEntryID", "powerUserWorkspaceID"},
 			},
@@ -6930,6 +6937,13 @@ func schema_obot_platform_obot_apiclient_types_MCPServerCatalogEntryManifest(ref
 						SchemaProps: spec.SchemaProps{
 							Description: "MultiUserConfig is the multi-user specific configuration for this component server, if applicable.",
 							Ref:         ref("github.com/obot-platform/obot/apiclient/types.MultiUserConfig"),
+						},
+					},
+					"serverUserType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServerUserType specifies whether this catalog entry produces single-user or multi-user servers. Only \"singleUser\" is currently supported. Empty value defaults to \"singleUser\".",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"env": {
@@ -19659,6 +19673,13 @@ func schema_storage_apis_obotobotai_v1_MCPServerSpec(ref common.ReferenceCallbac
 					"nanobotAgentID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NanobotAgentID is the name of the NanobotAgent that created this MCP server, if there is one.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"serverUserType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServerUserType specifies whether this is a single-user or multi-user MCP server. Empty value uses legacy inference from MCPCatalogID and PowerUserWorkspaceID.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/validation/mcpvalidators.go
+++ b/pkg/validation/mcpvalidators.go
@@ -996,6 +996,10 @@ func ValidateServerManifest(manifest types.MCPServerManifest, isMultiUser bool) 
 }
 
 func ValidateCatalogEntryManifest(manifest types.MCPServerCatalogEntryManifest) error {
+	if !manifest.ServerUserType.IsSingleUser() {
+		return fmt.Errorf("unsupported serverUserType %q: only %q is currently supported for catalog entries", manifest.ServerUserType, types.ServerUserTypeSingleUser)
+	}
+
 	if err := validateRuntimeStartupTimeout(manifest.Runtime, manifest.RuntimeStartupTimeoutSeconds()); err != nil {
 		return err
 	}

--- a/pkg/validation/mcpvalidators.go
+++ b/pkg/validation/mcpvalidators.go
@@ -995,6 +995,21 @@ func ValidateServerManifest(manifest types.MCPServerManifest, isMultiUser bool) 
 	}
 }
 
+// ValidateCatalogEntryForRoute checks that a catalog entry is compatible with the
+// route used to create a server. catalogID and workspaceID come from the URL path.
+func ValidateCatalogEntryForRoute(manifest types.MCPServerCatalogEntryManifest, catalogID, workspaceID string) error {
+	isMultiUser := catalogID != "" || workspaceID != ""
+	if isMultiUser {
+		// Deploying catalog entries as multi-user servers is not yet supported.
+		// This will be enabled when multi-user template deployment is implemented.
+		return fmt.Errorf("deploying catalog entries as multi-user servers is not yet supported")
+	}
+	if !manifest.ServerUserType.IsSingleUser() {
+		return fmt.Errorf("only single-user catalog entries are supported")
+	}
+	return nil
+}
+
 func ValidateCatalogEntryManifest(manifest types.MCPServerCatalogEntryManifest) error {
 	if !manifest.ServerUserType.IsSingleUser() {
 		return fmt.Errorf("unsupported serverUserType %q: only %q is currently supported for catalog entries", manifest.ServerUserType, types.ServerUserTypeSingleUser)

--- a/pkg/validation/mcpvalidators_test.go
+++ b/pkg/validation/mcpvalidators_test.go
@@ -2093,6 +2093,74 @@ func TestValidateTemplateReferences_CatalogEntry(t *testing.T) {
 	}
 }
 
+func TestValidateCatalogEntryForRoute(t *testing.T) {
+	singleUserManifest := types.MCPServerCatalogEntryManifest{ServerUserType: types.ServerUserTypeSingleUser}
+	multiUserManifest := types.MCPServerCatalogEntryManifest{ServerUserType: types.ServerUserTypeMultiUser}
+	defaultManifest := types.MCPServerCatalogEntryManifest{} // empty = singleUser
+
+	tests := []struct {
+		name        string
+		manifest    types.MCPServerCatalogEntryManifest
+		catalogID   string
+		workspaceID string
+		expectError bool
+	}{
+		{
+			name:        "single-user entry on single-user route: ok",
+			manifest:    singleUserManifest,
+			catalogID:   "",
+			workspaceID: "",
+			expectError: false,
+		},
+		{
+			name:        "empty serverUserType on single-user route: ok",
+			manifest:    defaultManifest,
+			catalogID:   "",
+			workspaceID: "",
+			expectError: false,
+		},
+		{
+			name:        "multiUser entry on single-user route: rejected",
+			manifest:    multiUserManifest,
+			catalogID:   "",
+			workspaceID: "",
+			expectError: true,
+		},
+		{
+			name:        "single-user entry on catalog route: rejected (deploying catalog entries as multi-user not yet supported)",
+			manifest:    singleUserManifest,
+			catalogID:   "default",
+			workspaceID: "",
+			expectError: true,
+		},
+		{
+			name:        "single-user entry on workspace route: rejected (deploying catalog entries as multi-user not yet supported)",
+			manifest:    singleUserManifest,
+			catalogID:   "",
+			workspaceID: "ws-1",
+			expectError: true,
+		},
+		{
+			name:        "multiUser entry on catalog route: rejected (deploying catalog entries as multi-user not yet supported)",
+			manifest:    multiUserManifest,
+			catalogID:   "default",
+			workspaceID: "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCatalogEntryForRoute(tt.manifest, tt.catalogID, tt.workspaceID)
+			if tt.expectError && err == nil {
+				t.Error("expected error, got nil")
+			} else if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestValidateCatalogEntryManifest_ServerUserType(t *testing.T) {
 	baseManifest := types.MCPServerCatalogEntryManifest{
 		Runtime: types.RuntimeNPX,

--- a/pkg/validation/mcpvalidators_test.go
+++ b/pkg/validation/mcpvalidators_test.go
@@ -2092,3 +2092,52 @@ func TestValidateTemplateReferences_CatalogEntry(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCatalogEntryManifest_ServerUserType(t *testing.T) {
+	baseManifest := types.MCPServerCatalogEntryManifest{
+		Runtime: types.RuntimeNPX,
+		NPXConfig: &types.NPXRuntimeConfig{
+			Package: "test-server",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		serverUserType types.ServerUserType
+		expectError    bool
+	}{
+		{
+			name:           "empty serverUserType is valid (defaults to singleUser)",
+			serverUserType: "",
+			expectError:    false,
+		},
+		{
+			name:           "explicit singleUser is valid",
+			serverUserType: types.ServerUserTypeSingleUser,
+			expectError:    false,
+		},
+		{
+			name:           "multiUser is rejected for catalog entries",
+			serverUserType: types.ServerUserTypeMultiUser,
+			expectError:    true,
+		},
+		{
+			name:           "unknown value is rejected",
+			serverUserType: types.ServerUserType("unknown"),
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := baseManifest
+			manifest.ServerUserType = tt.serverUserType
+			err := ValidateCatalogEntryManifest(manifest)
+			if tt.expectError && err == nil {
+				t.Errorf("expected error for serverUserType=%q, got nil", tt.serverUserType)
+			} else if !tt.expectError && err != nil {
+				t.Errorf("unexpected error for serverUserType=%q: %v", tt.serverUserType, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Addresses https://github.com/obot-platform/obot/issues/6578

**Refactor: make catalog entry server type explicit and clean up implicit single/multi-user assumptions throughout the codebase.**

- Add `ServerUserType` string type with `singleUser` and `multiUser` constants to `apiclient/types`
- Add `ServerUserType` field to `MCPServerCatalogEntryManifest` — declares whether a catalog entry is a template for single-user servers (each user installs their own) or multi-user servers (admin deploys centrally, users share via instances). Defaults to `singleUser` when empty.
- Validate `serverUserType` on catalog entry write — only `""` or `"singleUser"` accepted until multi-user template deployment is implemented
- Gate `CreateServer`: reject attempts to install a `multiUser` catalog entry via the single-user route (`POST /api/mcp-servers`)
- `MCPServerSpec.IsSingleUser()` — replaces scattered `MCPCatalogID == "" && PowerUserWorkspaceID == ""` checks with a single named method; `IsCatalogServer()`, `IsPowerUserWorkspaceServer()`, and `IsOwnedBy(userID)` added alongside it
- Replace all incomplete `MCPCatalogID == ""` single-condition checks with `IsSingleUser()` — these were bugs where workspace servers (PowerUserWorkspaceID != "") were incorrectly treated as single-user in `projectmcp.go`, `mcp.go`, and `mcpcatalog.go`
- Replace ACR routing if/else chains with `IsCatalogServer()`/`IsPowerUserWorkspaceServer()` across authz, handlers, and gateway
- `ServerUserType` intentionally kept **only** on `MCPServerCatalogEntryManifest`, not on `MCPServerSpec` — the MCPServer's type is already fully determined by `MCPCatalogID`/`PowerUserWorkspaceID`