### PR TITLE
fix: ensure oauth-protected-resource endpoints have correct content-type

### DIFF
--- a/pkg/api/handlers/wellknown/oauth.go
+++ b/pkg/api/handlers/wellknown/oauth.go
@@ -16,21 +16,21 @@ func (h *handler) oauthAuthorization(req api.Context) error {
 func (h *handler) oauthProtectedResource(req api.Context) error {
 	mcpID := req.PathValue("mcp_id")
 	if mcpID != "" {
-		return req.Write(fmt.Sprintf(`{
-	"resource_name": "Obot MCP Gateway",
-	"resource": "%s/mcp-connect/%s",
-	"authorization_servers": ["%[1]s"],
-	"bearer_methods_supported": ["header"]
-}`, h.baseURL, mcpID))
+		return req.Write(map[string]any{
+			"resource_name":            "Obot MCP Gateway",
+			"resource":                 fmt.Sprintf("%s/mcp-connect/%s", h.baseURL, mcpID),
+			"authorization_servers":    []string{h.baseURL},
+			"bearer_methods_supported": []string{"header"},
+		})
 	}
 
-	// The client is hitting the "generic" metadata endpoint and is not supplying an MCP ID. Server the generic metadata.
-	return req.Write(fmt.Sprintf(`{
-	"resource_name": "Obot MCP Gateway",
-	"resource": "%s/mcp-connect",
-	"authorization_servers": ["%[1]s"],
-	"bearer_methods_supported": ["header"]
-}`, h.baseURL))
+	// The client is hitting the "generic" metadata endpoint and is not supplying an MCP ID. Serve the generic metadata.
+	return req.Write(map[string]any{
+		"resource_name":            "Obot MCP Gateway",
+		"resource":                 fmt.Sprintf("%s/mcp-connect", h.baseURL),
+		"authorization_servers":    []string{h.baseURL},
+		"bearer_methods_supported": []string{"header"},
+	})
 }
 
 func (h *handler) registryOAuthProtectedResource(req api.Context) error {


### PR DESCRIPTION
By using a string here, the HTTP abstraction would not detect that the
response was an object and would return a content-type of text/plain. By
using a map, application/json will be used insted.

Issue: https://github.com/obot-platform/obot/issues/6616