### PR TITLE
enhance: add non-interactive mode to `obot setup`

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"log"
 	"os"
+	"strings"
 	_ "time/tzdata"
 
-	"github.com/gptscript-ai/cmd"
+	gptcmd "github.com/gptscript-ai/cmd"
 	"github.com/gptscript-ai/gptscript/pkg/embedded"
 	"github.com/obot-platform/nanobot/pkg/supervise"
 	"github.com/obot-platform/obot/pkg/cli"
@@ -25,6 +29,15 @@ func main() {
 		os.Exit(0)
 	}
 	// Don't shutdown on SIGTERM, only on SIGINT. SIGTERM is handled by the controller leader election
-	cmd.ShutdownSignals = []os.Signal{os.Interrupt}
-	cmd.Main(cli.New())
+	gptcmd.ShutdownSignals = []os.Signal{os.Interrupt}
+	root := cli.New()
+	if err := root.ExecuteContext(gptcmd.SetupSignalContext()); err != nil {
+		if strings.EqualFold("interrupt", err.Error()) || errors.Is(err, context.Canceled) {
+			os.Exit(1)
+		}
+		if cli.ErrorAlreadyReported(err) {
+			os.Exit(1)
+		}
+		log.Fatal(err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	_ "time/tzdata"
 
 	gptcmd "github.com/gptscript-ai/cmd"
@@ -32,7 +31,7 @@ func main() {
 	gptcmd.ShutdownSignals = []os.Signal{os.Interrupt}
 	root := cli.New()
 	if err := root.ExecuteContext(gptcmd.SetupSignalContext()); err != nil {
-		if strings.EqualFold("interrupt", err.Error()) || errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			os.Exit(1)
 		}
 		if cli.ErrorAlreadyReported(err) {

--- a/pkg/cli/internal/token.go
+++ b/pkg/cli/internal/token.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/signal"
@@ -26,6 +27,7 @@ var credentialStore credentials.Store = credentials.NewKeyringStore()
 var openBrowser = browser.OpenURL
 
 type nonInteractiveContextKey struct{}
+type outputWriterContextKey struct{}
 
 // WithNonInteractive marks ctx as safe for GUI orchestration: token acquisition
 // must not prompt or read from stdin.
@@ -33,9 +35,25 @@ func WithNonInteractive(ctx context.Context) context.Context {
 	return context.WithValue(ctx, nonInteractiveContextKey{}, true)
 }
 
+// WithOutputWriter routes token-acquisition user messages to w instead of
+// stdout. This lets commands that stream machine-readable stdout keep it clean.
+func WithOutputWriter(ctx context.Context, w io.Writer) context.Context {
+	if w == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, outputWriterContextKey{}, w)
+}
+
 func isNonInteractive(ctx context.Context) bool {
 	v, _ := ctx.Value(nonInteractiveContextKey{}).(bool)
 	return v
+}
+
+func outputWriter(ctx context.Context) io.Writer {
+	if w, _ := ctx.Value(outputWriterContextKey{}).(io.Writer); w != nil {
+		return w
+	}
+	return os.Stdout
 }
 
 // AppURLForAPIBaseURL returns the app URL that owns credentials for an
@@ -143,21 +161,22 @@ func Token(ctx context.Context, baseURL string, noExpiration, forceRefresh bool)
 	}
 
 	if !hasStoredToken && !isNonInteractive(ctx) {
-		fmt.Println()
-		fmt.Println(color.GreenString("Authentication is needed"))
-		fmt.Println(color.GreenString("========================"))
-		fmt.Println()
-		fmt.Println(color.CyanString(provider.Name) + " is used for authentication using the browser. This can be bypassed by setting")
-		fmt.Println("the env var " + color.CyanString("OBOT_API_KEY") + " to your API key.")
-		fmt.Println()
-		fmt.Println(color.GreenString("Press ENTER to continue (CTRL+C to exit)"))
+		w := outputWriter(ctx)
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, color.GreenString("Authentication is needed"))
+		fmt.Fprintln(w, color.GreenString("========================"))
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, color.CyanString(provider.Name)+" is used for authentication using the browser. This can be bypassed by setting")
+		fmt.Fprintln(w, "the env var "+color.CyanString("OBOT_API_KEY")+" to your API key.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, color.GreenString("Press ENTER to continue (CTRL+C to exit)"))
 		if err := enter(ctx); err != nil {
 			return "", err
 		}
-		fmt.Println()
+		fmt.Fprintln(w)
 	}
 
-	fmt.Printf("Opening browser to %s. if there is an issue paste this link into a browser manually\n", loginURL)
+	fmt.Fprintf(outputWriter(ctx), "Opening browser to %s. if there is an issue paste this link into a browser manually\n", loginURL)
 	_ = openBrowser(loginURL)
 
 	ctx, timeoutCancel := context.WithTimeout(ctx, 5*time.Minute)
@@ -317,13 +336,14 @@ func userSelectAuthProvider(ctx context.Context, authProviders []types2.AuthProv
 	sort.Slice(configuredAuthProviders, func(i, j int) bool {
 		return configuredAuthProviders[i].Name < configuredAuthProviders[j].Name
 	})
-	fmt.Println()
-	fmt.Println(color.CyanString("Select an authentication provider:"))
+	w := outputWriter(ctx)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, color.CyanString("Select an authentication provider:"))
 	for i, provider := range configuredAuthProviders {
-		fmt.Printf("  %d. %s\n", i+1, provider.Name)
+		fmt.Fprintf(w, "  %d. %s\n", i+1, provider.Name)
 	}
-	fmt.Println()
-	fmt.Println(color.GreenString("Enter the number of the provider you want to use:"))
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, color.GreenString("Enter the number of the provider you want to use:"))
 
 	var choice int
 	if _, err := fmt.Scanln(&choice); err != nil {

--- a/pkg/cli/internal/token.go
+++ b/pkg/cli/internal/token.go
@@ -64,6 +64,25 @@ func Logout(appURL string) (bool, error) {
 	return true, credentialStore.Delete(appURL)
 }
 
+// StoredTokenValid reports whether a stored token for appURL authenticates
+// successfully. It never initiates login or prompts for user input.
+func StoredTokenValid(ctx context.Context, appURL string) (bool, error) {
+	appURL, err := localconfig.NormalizeAppURL(appURL)
+	if err != nil {
+		return false, err
+	}
+
+	token, err := credentialStore.Get(appURL)
+	if err != nil {
+		if credentials.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return testToken(ctx, localconfig.APIBaseURL(appURL), token), nil
+}
+
 func enter(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/cli/internal/token.go
+++ b/pkg/cli/internal/token.go
@@ -25,6 +25,19 @@ import (
 var credentialStore credentials.Store = credentials.NewKeyringStore()
 var openBrowser = browser.OpenURL
 
+type nonInteractiveContextKey struct{}
+
+// WithNonInteractive marks ctx as safe for GUI orchestration: token acquisition
+// must not prompt or read from stdin.
+func WithNonInteractive(ctx context.Context) context.Context {
+	return context.WithValue(ctx, nonInteractiveContextKey{}, true)
+}
+
+func isNonInteractive(ctx context.Context) bool {
+	v, _ := ctx.Value(nonInteractiveContextKey{}).(bool)
+	return v
+}
+
 // AppURLForAPIBaseURL returns the app URL that owns credentials for an
 // API base URL.
 func AppURLForAPIBaseURL(baseURL string) (string, error) {
@@ -99,7 +112,7 @@ func Token(ctx context.Context, baseURL string, noExpiration, forceRefresh bool)
 	ctx, sigCancel := signal.NotifyContext(ctx, os.Interrupt)
 	defer sigCancel()
 
-	provider, err := userSelectAuthProvider(authProviders)
+	provider, err := userSelectAuthProvider(ctx, authProviders)
 	if err != nil {
 		return "", err
 	}
@@ -110,7 +123,7 @@ func Token(ctx context.Context, baseURL string, noExpiration, forceRefresh bool)
 		return "", fmt.Errorf("failed to create login request: %w", err)
 	}
 
-	if !hasStoredToken {
+	if !hasStoredToken && !isNonInteractive(ctx) {
 		fmt.Println()
 		fmt.Println(color.GreenString("Authentication is needed"))
 		fmt.Println(color.GreenString("========================"))
@@ -265,7 +278,7 @@ func getAuthProviderServiceInfo(ctx context.Context, baseURL string) ([]types2.A
 	return authProviders.Items, nil
 }
 
-func userSelectAuthProvider(authProviders []types2.AuthProvider) (types2.AuthProvider, error) {
+func userSelectAuthProvider(ctx context.Context, authProviders []types2.AuthProvider) (types2.AuthProvider, error) {
 	var configuredAuthProviders []types2.AuthProvider
 	for _, provider := range authProviders {
 		if provider.Configured {
@@ -277,6 +290,9 @@ func userSelectAuthProvider(authProviders []types2.AuthProvider) (types2.AuthPro
 		return types2.AuthProvider{}, fmt.Errorf("no configured auth providers found")
 	} else if len(configuredAuthProviders) == 1 {
 		return configuredAuthProviders[0], nil
+	}
+	if isNonInteractive(ctx) {
+		return types2.AuthProvider{}, fmt.Errorf("multiple configured auth providers found; interactive provider selection is not available in non-interactive mode")
 	}
 
 	sort.Slice(configuredAuthProviders, func(i, j int) bool {

--- a/pkg/cli/internal/token_test.go
+++ b/pkg/cli/internal/token_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -267,7 +268,8 @@ func TestTokenNonInteractiveSkipsBrowserEnterGate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	token, err := Token(WithNonInteractive(t.Context()), srv.URL+"/api", false, false)
+	var output bytes.Buffer
+	token, err := Token(WithOutputWriter(WithNonInteractive(t.Context()), &output), srv.URL+"/api", false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,6 +278,9 @@ func TestTokenNonInteractiveSkipsBrowserEnterGate(t *testing.T) {
 	}
 	if openedURL != "https://example.com/login" {
 		t.Fatalf("expected browser to open login URL, got %q", openedURL)
+	}
+	if !strings.Contains(output.String(), "Opening browser to https://example.com/login") {
+		t.Fatalf("expected browser login message in configured output writer, got %q", output.String())
 	}
 	if got := store.tokens[srv.URL]; got != "new-token" {
 		t.Fatalf("expected token stored by app URL, got %q", got)

--- a/pkg/cli/internal/token_test.go
+++ b/pkg/cli/internal/token_test.go
@@ -228,6 +228,60 @@ func TestTokenStoresNewTokenByAppURL(t *testing.T) {
 	}
 }
 
+func TestTokenNonInteractiveSkipsBrowserEnterGate(t *testing.T) {
+	store := newFakeCredentialStore()
+	restoreStore := useCredentialStore(t, store)
+	defer restoreStore()
+
+	var openedURL string
+	restoreBrowser := useOpenBrowser(t, func(url string) error {
+		openedURL = url
+		return nil
+	})
+	defer restoreBrowser()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/me":
+			_ = json.NewEncoder(w).Encode(types.User{Username: "anonymous"})
+		case "/api/auth-providers":
+			_ = json.NewEncoder(w).Encode(types.AuthProviderList{Items: []types.AuthProvider{{
+				Metadata: types.Metadata{ID: "github"},
+				AuthProviderManifest: types.AuthProviderManifest{
+					Name:      "GitHub",
+					Namespace: "default",
+				},
+				AuthProviderStatus: types.AuthProviderStatus{
+					CommonProviderStatus: types.CommonProviderStatus{Configured: true},
+				},
+			}}})
+		case "/api/token-request":
+			_ = json.NewEncoder(w).Encode(map[string]string{"token-path": "https://example.com/login"})
+		default:
+			if strings.HasPrefix(r.URL.Path, "/api/token-request/") {
+				_ = json.NewEncoder(w).Encode(map[string]string{"Token": "new-token"})
+				return
+			}
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	token, err := Token(WithNonInteractive(t.Context()), srv.URL+"/api", false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "new-token" {
+		t.Fatalf("expected new token, got %q", token)
+	}
+	if openedURL != "https://example.com/login" {
+		t.Fatalf("expected browser to open login URL, got %q", openedURL)
+	}
+	if got := store.tokens[srv.URL]; got != "new-token" {
+		t.Fatalf("expected token stored by app URL, got %q", got)
+	}
+}
+
 func TestLogoutDeletesSelectedAppURLToken(t *testing.T) {
 	store := newFakeCredentialStore()
 	store.tokens["https://obot.example.com"] = "token-a"

--- a/pkg/cli/internal/token_test.go
+++ b/pkg/cli/internal/token_test.go
@@ -282,6 +282,50 @@ func TestTokenNonInteractiveSkipsBrowserEnterGate(t *testing.T) {
 	}
 }
 
+func TestStoredTokenValid(t *testing.T) {
+	store := newFakeCredentialStore()
+	restore := useCredentialStore(t, store)
+	defer restore()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/me" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") == "Bearer valid-token" {
+			_ = json.NewEncoder(w).Encode(types.User{Username: "alice"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(types.User{Username: "anonymous"})
+	}))
+	defer srv.Close()
+
+	valid, err := StoredTokenValid(t.Context(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valid {
+		t.Fatalf("token should not be valid when no stored token exists")
+	}
+
+	store.tokens[srv.URL] = "invalid-token"
+	valid, err = StoredTokenValid(t.Context(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if valid {
+		t.Fatalf("invalid stored token should not be valid")
+	}
+
+	store.tokens[srv.URL] = "valid-token"
+	valid, err = StoredTokenValid(t.Context(), srv.URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !valid {
+		t.Fatalf("valid stored token should be valid")
+	}
+}
+
 func TestLogoutDeletesSelectedAppURLToken(t *testing.T) {
 	store := newFakeCredentialStore()
 	store.tokens["https://obot.example.com"] = "token-a"

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -197,7 +197,7 @@ func (s *Setup) resolveAppURL(cmd *cobra.Command) (string, error) {
 			return "", setupErrorf(setupErrorInvalidURL, "%w", err)
 		}
 		if cfg.DefaultURL != "" && cfg.DefaultURL != appURL && !s.Yes {
-			return "", fmt.Errorf("configured Obot URL is %s; pass --yes to replace it with %s", cfg.DefaultURL, appURL)
+			return "", setupErrorf(setupErrorInvalidURL, "configured Obot URL is %s; pass --yes to replace it with %s", cfg.DefaultURL, appURL)
 		}
 		return appURL, nil
 	}

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -20,6 +22,7 @@ type Setup struct {
 	Agents         string `usage:"Comma-separated target agents: detected, none, claude-code, or cursor" default:"detected"`
 	Yes            bool   `usage:"Accept confirmations and use defaults"`
 	NonInteractive bool   `usage:"Never read from stdin; fail if required input is missing"`
+	Output         string `usage:"Output format: text or json" default:"text"`
 
 	root *Obot
 }
@@ -33,6 +36,29 @@ func (s *Setup) Customize(cmd *cobra.Command) {
 }
 
 func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
+	output := strings.TrimSpace(s.Output)
+	if output == "" {
+		output = "text"
+	}
+	if output != "text" && output != "json" {
+		return fmt.Errorf("unsupported --output value %q; supported values are text and json", s.Output)
+	}
+
+	progress := newSetupProgressWriter(cmd, output == "json")
+	if err := s.run(cmd, progress); err != nil {
+		if progress.json {
+			_ = progress.emit(setupProgressEvent{
+				Type:    setupProgressError,
+				Code:    string(setupErrorCodeFor(err)),
+				Message: err.Error(),
+			})
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *Setup) run(cmd *cobra.Command, progress setupProgressWriter) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
@@ -41,6 +67,11 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 		ctx = cliinternal.WithNonInteractive(ctx)
 		cmd.SetContext(ctx)
 	}
+	if progress.json {
+		ctx = cliinternal.WithOutputWriter(ctx, cmd.ErrOrStderr())
+		cmd.SetContext(ctx)
+		cmd.SetOut(cmd.ErrOrStderr())
+	}
 
 	appURL, err := s.resolveAppURL(cmd)
 	if err != nil {
@@ -48,11 +79,20 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 	}
 
 	s.root.Client.BaseURL = localconfig.APIBaseURL(appURL)
+	if err := progress.emit(setupProgressEvent{Type: setupProgressAuthStarted, URL: appURL}); err != nil {
+		return err
+	}
 	if _, err := s.root.Client.GetToken(ctx, false, false); err != nil {
+		return setupErrorf(setupAuthErrorCode(err), "authenticate with Obot: %w", err)
+	}
+	if err := progress.emit(setupProgressEvent{Type: setupProgressAuthCompleted, URL: appURL}); err != nil {
 		return err
 	}
 	if err := localconfig.Save(localconfig.Config{DefaultURL: appURL}); err != nil {
-		return fmt.Errorf("save Obot config: %w", err)
+		return setupErrorf(setupErrorConfigSaveFailed, "save Obot config: %w", err)
+	}
+	if err := progress.emit(setupProgressEvent{Type: setupProgressConfigSaved, URL: appURL}); err != nil {
+		return err
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "Logged in to %s\n", appURL)
 
@@ -61,13 +101,18 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if selection.none {
-		fmt.Fprintln(cmd.OutOrStdout(), "Skipping local agent bootstrap installation")
+		if !progress.json {
+			fmt.Fprintln(cmd.OutOrStdout(), "Skipping local agent bootstrap installation")
+		}
+		if err := progress.emit(setupProgressEvent{Type: setupProgressComplete, URL: appURL}); err != nil {
+			return err
+		}
 		return nil
 	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("failed to get user home dir: %w", err)
+		return setupErrorf(setupErrorAgentDetectionFailed, "failed to get user home dir: %w", err)
 	}
 
 	installers := localagents.DirectInstallers()
@@ -76,14 +121,16 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 		detections[installer.ID()] = installer.Detect(ctx)
 	}
 
-	fmt.Fprintln(cmd.OutOrStdout(), "Detected:")
-	for _, installer := range installers {
-		detection := detections[installer.ID()]
-		status := "missing"
-		if detection.State == localagents.DetectionPresent {
-			status = "installed"
+	if !progress.json {
+		fmt.Fprintln(cmd.OutOrStdout(), "Detected:")
+		for _, installer := range installers {
+			detection := detections[installer.ID()]
+			status := "missing"
+			if detection.State == localagents.DetectionPresent {
+				status = "installed"
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "  %-15s %s\n", installer.DisplayName(), status)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "  %-15s %s\n", installer.DisplayName(), status)
 	}
 
 	var installed []localagents.InstallResult
@@ -93,7 +140,7 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 		shouldInstall := selection.detected && detection.State == localagents.DetectionPresent
 		if selection.agentIDs[installer.ID()] {
 			if detection.State != localagents.DetectionPresent {
-				return fmt.Errorf("%s was selected but was not detected", installer.DisplayName())
+				return setupErrorf(setupErrorAgentDetectionFailed, "%s was selected but was not detected", installer.DisplayName())
 			}
 			shouldInstall = true
 		}
@@ -102,24 +149,37 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 		}
 		result, err := installer.InstallBootstrap(ctx, home)
 		if err != nil {
-			installErrs = append(installErrs, fmt.Errorf("install bootstrap for %s: %w", installer.DisplayName(), err))
+			installErrs = append(installErrs, setupErrorf(setupErrorAgentInstallFailed, "install bootstrap for %s: %w", installer.DisplayName(), err))
 			continue
 		}
 		installed = append(installed, result)
+		if err := progress.emit(setupProgressEvent{
+			Type:        setupProgressAgentInstalled,
+			AgentID:     result.AgentID,
+			DisplayName: result.DisplayName,
+			Installed:   result.Installed,
+			Message:     result.Message,
+		}); err != nil {
+			return err
+		}
 	}
 	if err := errors.Join(installErrs...); err != nil {
 		return err
 	}
 
 	if len(installed) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "No supported local agents detected")
-		return nil
+		if !progress.json {
+			fmt.Fprintln(cmd.OutOrStdout(), "No supported local agents detected")
+		}
+		return progress.emit(setupProgressEvent{Type: setupProgressComplete, URL: appURL})
 	}
-	for _, result := range installed {
-		fmt.Fprintln(cmd.OutOrStdout(), result.Message)
+	if !progress.json {
+		for _, result := range installed {
+			fmt.Fprintln(cmd.OutOrStdout(), result.Message)
+		}
 	}
 
-	return nil
+	return progress.emit(setupProgressEvent{Type: setupProgressComplete, URL: appURL})
 }
 
 func (s *Setup) resolveAppURL(cmd *cobra.Command) (string, error) {
@@ -131,7 +191,7 @@ func (s *Setup) resolveAppURL(cmd *cobra.Command) (string, error) {
 	if strings.TrimSpace(s.URL) != "" {
 		appURL, err := localconfig.NormalizeAppURL(s.URL)
 		if err != nil {
-			return "", err
+			return "", setupErrorf(setupErrorInvalidURL, "%w", err)
 		}
 		if cfg.DefaultURL != "" && cfg.DefaultURL != appURL && !s.Yes {
 			return "", fmt.Errorf("configured Obot URL is %s; pass --yes to replace it with %s", cfg.DefaultURL, appURL)
@@ -144,7 +204,7 @@ func (s *Setup) resolveAppURL(cmd *cobra.Command) (string, error) {
 			return cfg.DefaultURL, nil
 		}
 		if s.NonInteractive {
-			return "", fmt.Errorf("configured Obot URL is %s; pass --yes to use it or pass --url to configure a different URL", cfg.DefaultURL)
+			return "", setupErrorf(setupErrorInvalidURL, "configured Obot URL is %s; pass --yes to use it or pass --url to configure a different URL", cfg.DefaultURL)
 		}
 
 		ok, err := promptYesNo(cmd, fmt.Sprintf("Current Obot URL: %s\nUse this URL? [Y/n] ", cfg.DefaultURL), true)
@@ -157,17 +217,137 @@ func (s *Setup) resolveAppURL(cmd *cobra.Command) (string, error) {
 	}
 
 	if s.Yes {
-		return "", fmt.Errorf("--url is required when no configured Obot URL is accepted")
+		return "", setupErrorf(setupErrorInvalidURL, "--url is required when no configured Obot URL is accepted")
 	}
 	if s.NonInteractive {
-		return "", fmt.Errorf("--url is required in non-interactive mode when no configured Obot URL is accepted")
+		return "", setupErrorf(setupErrorInvalidURL, "--url is required in non-interactive mode when no configured Obot URL is accepted")
 	}
 
 	raw, err := promptLine(cmd, "Obot URL: ")
 	if err != nil {
 		return "", err
 	}
-	return localconfig.NormalizeAppURL(raw)
+	appURL, err := localconfig.NormalizeAppURL(raw)
+	if err != nil {
+		return "", setupErrorf(setupErrorInvalidURL, "%w", err)
+	}
+	return appURL, nil
+}
+
+const (
+	setupProgressAuthStarted    = "auth_started"
+	setupProgressAuthCompleted  = "auth_completed"
+	setupProgressConfigSaved    = "config_saved"
+	setupProgressAgentInstalled = "agent_installed"
+	setupProgressComplete       = "complete"
+	setupProgressError          = "error"
+)
+
+type setupProgressEvent struct {
+	Type        string   `json:"type"`
+	Code        string   `json:"code,omitempty"`
+	Message     string   `json:"message,omitempty"`
+	URL         string   `json:"url,omitempty"`
+	AgentID     string   `json:"agentID,omitempty"`
+	DisplayName string   `json:"displayName,omitempty"`
+	Installed   []string `json:"installed,omitempty"`
+}
+
+type setupProgressWriter struct {
+	json bool
+	enc  *json.Encoder
+}
+
+func newSetupProgressWriter(cmd *cobra.Command, jsonOutput bool) setupProgressWriter {
+	if !jsonOutput {
+		return setupProgressWriter{}
+	}
+	return setupProgressWriter{
+		json: true,
+		enc:  json.NewEncoder(cmd.OutOrStdout()),
+	}
+}
+
+func (w setupProgressWriter) emit(event setupProgressEvent) error {
+	if !w.json {
+		return nil
+	}
+	return w.enc.Encode(event)
+}
+
+type setupErrorCode string
+
+const (
+	setupErrorInvalidURL           setupErrorCode = "invalid_url"
+	setupErrorServerUnreachable    setupErrorCode = "server_unreachable"
+	setupErrorAuthUnavailable      setupErrorCode = "auth_unavailable"
+	setupErrorAuthTimeout          setupErrorCode = "auth_timeout"
+	setupErrorAuthCanceled         setupErrorCode = "auth_canceled"
+	setupErrorConfigSaveFailed     setupErrorCode = "config_save_failed"
+	setupErrorAgentDetectionFailed setupErrorCode = "agent_detection_failed"
+	setupErrorAgentInstallFailed   setupErrorCode = "agent_install_failed"
+	setupErrorUnknown              setupErrorCode = "unknown"
+)
+
+type setupCodedError struct {
+	code setupErrorCode
+	err  error
+}
+
+func setupErrorf(code setupErrorCode, format string, args ...any) error {
+	return setupCodedError{
+		code: code,
+		err:  fmt.Errorf(format, args...),
+	}
+}
+
+func (e setupCodedError) Error() string {
+	return e.err.Error()
+}
+
+func (e setupCodedError) Unwrap() error {
+	return e.err
+}
+
+func setupErrorCodeFor(err error) setupErrorCode {
+	if coded, ok := errors.AsType[setupCodedError](err); ok {
+		return coded.code
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return setupErrorAuthTimeout
+	}
+	if errors.Is(err, context.Canceled) {
+		return setupErrorAuthCanceled
+	}
+	return setupErrorUnknown
+}
+
+func setupAuthErrorCode(err error) setupErrorCode {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return setupErrorAuthTimeout
+	}
+	if errors.Is(err, context.Canceled) {
+		return setupErrorAuthCanceled
+	}
+
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "no auth providers found"),
+		strings.Contains(msg, "no configured auth providers found"),
+		strings.Contains(msg, "multiple configured auth providers found"):
+		return setupErrorAuthUnavailable
+	}
+
+	if _, ok := errors.AsType[*url.Error](err); ok {
+		return setupErrorServerUnreachable
+	}
+	if strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "server misbehaving") {
+		return setupErrorServerUnreachable
+	}
+
+	return setupErrorUnknown
 }
 
 type setupAgentSelection struct {

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	gptcmd "github.com/gptscript-ai/cmd"
 	cliinternal "github.com/obot-platform/obot/pkg/cli/internal"
 	"github.com/obot-platform/obot/pkg/cli/internal/localconfig"
 	"github.com/obot-platform/obot/pkg/localagents"
@@ -27,6 +28,8 @@ func (s *Setup) Customize(cmd *cobra.Command) {
 	cmd.Use = "setup"
 	cmd.Short = "Configure Obot locally and install supported agent bootstrap assets"
 	cmd.Args = cobra.NoArgs
+	cmd.AddCommand(gptcmd.Command(&SetupStatus{}))
+	cmd.AddCommand(gptcmd.Command(&SetupDetectAgents{}))
 }
 
 func (s *Setup) Run(cmd *cobra.Command, _ []string) error {

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -8,15 +8,17 @@ import (
 	"os"
 	"strings"
 
+	cliinternal "github.com/obot-platform/obot/pkg/cli/internal"
 	"github.com/obot-platform/obot/pkg/cli/internal/localconfig"
 	"github.com/obot-platform/obot/pkg/localagents"
 	"github.com/spf13/cobra"
 )
 
 type Setup struct {
-	URL    string `usage:"Obot app URL to configure"`
-	Agents string `usage:"Comma-separated target agents: detected, claude-code, or cursor" default:"detected"`
-	Yes    bool   `usage:"Accept confirmations and use non-interactive defaults"`
+	URL            string `usage:"Obot app URL to configure"`
+	Agents         string `usage:"Comma-separated target agents: detected, none, claude-code, or cursor" default:"detected"`
+	Yes            bool   `usage:"Accept confirmations and use defaults"`
+	NonInteractive bool   `usage:"Never read from stdin; fail if required input is missing"`
 
 	root *Obot
 }
@@ -31,6 +33,10 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if s.NonInteractive {
+		ctx = cliinternal.WithNonInteractive(ctx)
+		cmd.SetContext(ctx)
 	}
 
 	appURL, err := s.resolveAppURL(cmd)
@@ -50,6 +56,10 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 	selection, err := parseSetupAgents(s.Agents)
 	if err != nil {
 		return err
+	}
+	if selection.none {
+		fmt.Fprintln(cmd.OutOrStdout(), "Skipping local agent bootstrap installation")
+		return nil
 	}
 
 	home, err := os.UserHomeDir()
@@ -130,6 +140,9 @@ func (s *Setup) resolveAppURL(cmd *cobra.Command) (string, error) {
 		if s.Yes {
 			return cfg.DefaultURL, nil
 		}
+		if s.NonInteractive {
+			return "", fmt.Errorf("configured Obot URL is %s; pass --yes to use it or pass --url to configure a different URL", cfg.DefaultURL)
+		}
 
 		ok, err := promptYesNo(cmd, fmt.Sprintf("Current Obot URL: %s\nUse this URL? [Y/n] ", cfg.DefaultURL), true)
 		if err != nil {
@@ -143,6 +156,9 @@ func (s *Setup) resolveAppURL(cmd *cobra.Command) (string, error) {
 	if s.Yes {
 		return "", fmt.Errorf("--url is required when no configured Obot URL is accepted")
 	}
+	if s.NonInteractive {
+		return "", fmt.Errorf("--url is required in non-interactive mode when no configured Obot URL is accepted")
+	}
 
 	raw, err := promptLine(cmd, "Obot URL: ")
 	if err != nil {
@@ -153,6 +169,7 @@ func (s *Setup) resolveAppURL(cmd *cobra.Command) (string, error) {
 
 type setupAgentSelection struct {
 	detected bool
+	none     bool
 	agentIDs map[string]bool
 }
 
@@ -172,17 +189,22 @@ func parseSetupAgents(raw string) (setupAgentSelection, error) {
 			continue
 		case "detected":
 			selection.detected = true
+		case "none":
+			selection.none = true
 		case localagents.ClaudeCodeAgentID:
 			selection.agentIDs[localagents.ClaudeCodeAgentID] = true
 		case localagents.CursorAgentID:
 			selection.agentIDs[localagents.CursorAgentID] = true
 		default:
-			return setupAgentSelection{}, fmt.Errorf("unsupported --agents value %q; supported values are detected, claude-code, and cursor", value)
+			return setupAgentSelection{}, fmt.Errorf("unsupported --agents value %q; supported values are detected, none, claude-code, and cursor", value)
 		}
 	}
 
-	if !selection.detected && len(selection.agentIDs) == 0 {
-		return setupAgentSelection{}, fmt.Errorf("--agents must include detected, claude-code, or cursor")
+	if selection.none && (selection.detected || len(selection.agentIDs) > 0) {
+		return setupAgentSelection{}, fmt.Errorf("--agents none cannot be combined with other values")
+	}
+	if !selection.none && !selection.detected && len(selection.agentIDs) == 0 {
+		return setupAgentSelection{}, fmt.Errorf("--agents must include detected, none, claude-code, or cursor")
 	}
 
 	return selection, nil

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -69,7 +69,11 @@ func (s *Setup) run(cmd *cobra.Command, progress setupProgressWriter) error {
 		cmd.SetContext(ctx)
 	}
 	if progress.json {
-		ctx = cliinternal.WithOutputWriter(ctx, io.Discard)
+		authOutput := cmd.ErrOrStderr()
+		if s.NonInteractive {
+			authOutput = io.Discard
+		}
+		ctx = cliinternal.WithOutputWriter(ctx, authOutput)
 		cmd.SetContext(ctx)
 		cmd.SetOut(cmd.ErrOrStderr())
 	}

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -52,6 +52,7 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 				Code:    string(setupErrorCodeFor(err)),
 				Message: err.Error(),
 			})
+			return errorAlreadyReported{err: err}
 		}
 		return err
 	}
@@ -68,7 +69,7 @@ func (s *Setup) run(cmd *cobra.Command, progress setupProgressWriter) error {
 		cmd.SetContext(ctx)
 	}
 	if progress.json {
-		ctx = cliinternal.WithOutputWriter(ctx, cmd.ErrOrStderr())
+		ctx = cliinternal.WithOutputWriter(ctx, io.Discard)
 		cmd.SetContext(ctx)
 		cmd.SetOut(cmd.ErrOrStderr())
 	}
@@ -94,7 +95,9 @@ func (s *Setup) run(cmd *cobra.Command, progress setupProgressWriter) error {
 	if err := progress.emit(setupProgressEvent{Type: setupProgressConfigSaved, URL: appURL}); err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "Logged in to %s\n", appURL)
+	if !progress.json {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Logged in to %s\n", appURL)
+	}
 
 	selection, err := parseSetupAgents(s.Agents)
 	if err != nil {
@@ -292,6 +295,23 @@ const (
 type setupCodedError struct {
 	code setupErrorCode
 	err  error
+}
+
+type errorAlreadyReported struct {
+	err error
+}
+
+func ErrorAlreadyReported(err error) bool {
+	var reported errorAlreadyReported
+	return errors.As(err, &reported)
+}
+
+func (e errorAlreadyReported) Error() string {
+	return e.err.Error()
+}
+
+func (e errorAlreadyReported) Unwrap() error {
+	return e.err
 }
 
 func setupErrorf(code setupErrorCode, format string, args ...any) error {

--- a/pkg/cli/setup_status.go
+++ b/pkg/cli/setup_status.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"text/tabwriter"
+
+	cliinternal "github.com/obot-platform/obot/pkg/cli/internal"
+	"github.com/obot-platform/obot/pkg/cli/internal/localconfig"
+	"github.com/obot-platform/obot/pkg/localagents"
+	"github.com/obot-platform/obot/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+var setupCapabilities = []string{
+	"setup.nonInteractive",
+	"setup.detectAgents",
+	"setup.progressJSON",
+}
+
+type setupTokenValidator func(context.Context, string) (bool, error)
+
+type SetupStatus struct {
+	JSON bool `usage:"Print status as JSON"`
+
+	tokenValid setupTokenValidator
+}
+
+func (s *SetupStatus) Customize(cmd *cobra.Command) {
+	cmd.Use = "status"
+	cmd.Short = "Show local Obot setup status"
+	cmd.Args = cobra.NoArgs
+}
+
+func (s *SetupStatus) Run(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	status, err := s.status(ctx)
+	if err != nil {
+		return err
+	}
+
+	if s.JSON {
+		return writeJSON(cmd, status)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Version: %s\n", status.Version)
+	fmt.Fprintf(cmd.OutOrStdout(), "Default URL: %s\n", status.DefaultURL)
+	fmt.Fprintf(cmd.OutOrStdout(), "Token valid: %t\n", status.TokenValid)
+	fmt.Fprintf(cmd.OutOrStdout(), "Setup complete: %t\n", status.SetupComplete)
+	return nil
+}
+
+func (s *SetupStatus) status(ctx context.Context) (setupStatusOutput, error) {
+	cfg, err := localconfig.Load()
+	if err != nil {
+		return setupStatusOutput{}, fmt.Errorf("load Obot config: %w", err)
+	}
+
+	var tokenValid bool
+	if cfg.DefaultURL != "" {
+		validator := s.tokenValid
+		if validator == nil {
+			validator = cliinternal.StoredTokenValid
+		}
+		tokenValid, err = validator(ctx, cfg.DefaultURL)
+		if err != nil {
+			return setupStatusOutput{}, fmt.Errorf("check stored token: %w", err)
+		}
+	}
+
+	return setupStatusOutput{
+		Version:       version.Get().String(),
+		Capabilities:  slices.Clone(setupCapabilities),
+		DefaultURL:    cfg.DefaultURL,
+		TokenValid:    tokenValid,
+		SetupComplete: cfg.DefaultURL != "" && tokenValid,
+	}, nil
+}
+
+type setupStatusOutput struct {
+	Version       string   `json:"version"`
+	Capabilities  []string `json:"capabilities"`
+	DefaultURL    string   `json:"defaultURL"`
+	TokenValid    bool     `json:"tokenValid"`
+	SetupComplete bool     `json:"setupComplete"`
+}
+
+type SetupDetectAgents struct {
+	JSON bool `usage:"Print detected agents as JSON"`
+}
+
+func (s *SetupDetectAgents) Customize(cmd *cobra.Command) {
+	cmd.Use = "detect-agents"
+	cmd.Short = "Detect supported local agents"
+	cmd.Args = cobra.NoArgs
+}
+
+func (s *SetupDetectAgents) Run(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	result := detectSetupAgents(ctx)
+	if s.JSON {
+		return writeJSON(cmd, result)
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tSTATE\tREASON")
+	for _, agent := range result.Agents {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			tableCell(agent.ID),
+			tableCell(agent.DisplayName),
+			tableCell(agent.State),
+			tableCell(agent.Reason),
+		)
+	}
+	return w.Flush()
+}
+
+func detectSetupAgents(ctx context.Context) setupDetectAgentsOutput {
+	installers := localagents.DirectInstallers()
+	result := setupDetectAgentsOutput{
+		Agents: make([]setupDetectedAgent, 0, len(installers)),
+	}
+	for _, installer := range installers {
+		detection := installer.Detect(ctx)
+		result.Agents = append(result.Agents, setupDetectedAgent{
+			ID:          detection.AgentID,
+			DisplayName: detection.DisplayName,
+			State:       string(detection.State),
+			Reason:      detection.Reason,
+		})
+	}
+	return result
+}
+
+type setupDetectAgentsOutput struct {
+	Agents []setupDetectedAgent `json:"agents"`
+}
+
+type setupDetectedAgent struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	State       string `json:"state"`
+	Reason      string `json:"reason"`
+}
+
+func writeJSON(cmd *cobra.Command, value any) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(value)
+}

--- a/pkg/cli/setup_test.go
+++ b/pkg/cli/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,6 +193,92 @@ func TestSetupAgentsNoneSkipsLocalAgentInstall(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(home, ".claude", "skills", "obot", skillformat.SkillMainFile)); !os.IsNotExist(err) {
 		t.Fatalf("expected no Claude Code skill to be installed, stat err: %v", err)
+	}
+}
+
+func TestSetupJSONProgressSuccessfulSequence(t *testing.T) {
+	restore := useRootTestEnv(t)
+	defer restore()
+	home := useSetupTestHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	root := setupTestRoot(func(_ context.Context, _ string, _, _ bool) (string, error) {
+		return "token", nil
+	})
+	setup := &Setup{
+		URL:            "https://obot.example.com/",
+		Agents:         "detected",
+		Yes:            true,
+		NonInteractive: true,
+		Output:         "json",
+		root:           root,
+	}
+
+	var stdout bytes.Buffer
+	cmd := setupTestCommand(nil, &stdout, nil)
+	if err := setup.Run(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	events := setupProgressEvents(t, stdout.Bytes())
+	gotTypes := make([]string, 0, len(events))
+	for _, event := range events {
+		gotTypes = append(gotTypes, event.Type)
+	}
+	wantTypes := []string{"auth_started", "auth_completed", "config_saved", "agent_installed", "complete"}
+	if strings.Join(gotTypes, ",") != strings.Join(wantTypes, ",") {
+		t.Fatalf("event types = %v, want %v\nstdout:\n%s", gotTypes, wantTypes, stdout.String())
+	}
+	if events[3].AgentID != localagents.ClaudeCodeAgentID {
+		t.Fatalf("agent_installed agentID = %q, want %q", events[3].AgentID, localagents.ClaudeCodeAgentID)
+	}
+	if events[3].DisplayName != "Claude Code" {
+		t.Fatalf("agent_installed displayName = %q, want Claude Code", events[3].DisplayName)
+	}
+	if len(events[3].Installed) == 0 {
+		t.Fatalf("agent_installed should include installed paths")
+	}
+	if strings.Contains(stdout.String(), "Detected:") {
+		t.Fatalf("JSON stdout should not include human setup output:\n%s", stdout.String())
+	}
+}
+
+func TestSetupJSONProgressStructuredError(t *testing.T) {
+	restore := useRootTestEnv(t)
+	defer restore()
+
+	root := setupTestRoot(func(context.Context, string, bool, bool) (string, error) {
+		t.Fatal("token fetcher should not be called without a URL")
+		return "", nil
+	})
+	setup := &Setup{
+		Agents:         "none",
+		NonInteractive: true,
+		Output:         "json",
+		root:           root,
+	}
+
+	var stdout bytes.Buffer
+	cmd := setupTestCommand(strings.NewReader("https://obot.example.com\n"), &stdout, nil)
+	err := setup.Run(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	events := setupProgressEvents(t, stdout.Bytes())
+	if len(events) != 1 {
+		t.Fatalf("expected one error event, got %#v\nstdout:\n%s", events, stdout.String())
+	}
+	if events[0].Type != "error" {
+		t.Fatalf("event type = %q, want error", events[0].Type)
+	}
+	if events[0].Code != "invalid_url" {
+		t.Fatalf("event code = %q, want invalid_url", events[0].Code)
+	}
+	if !strings.Contains(events[0].Message, "--url is required in non-interactive mode") {
+		t.Fatalf("unexpected error message: %q", events[0].Message)
 	}
 }
 
@@ -452,4 +539,22 @@ func useSetupTestHome(t *testing.T) string {
 		}
 	})
 	return home
+}
+
+func setupProgressEvents(t *testing.T, data []byte) []setupProgressEvent {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var events []setupProgressEvent
+	for {
+		var event setupProgressEvent
+		err := dec.Decode(&event)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("setup progress output should be newline-delimited JSON: %v\n%s", err, string(data))
+		}
+		events = append(events, event)
+	}
+	return events
 }

--- a/pkg/cli/setup_test.go
+++ b/pkg/cli/setup_test.go
@@ -129,6 +129,70 @@ func TestSetupExplicitCursor(t *testing.T) {
 	assertFileContains(t, filepath.Join(home, ".cursor", "skills", "obot", skillformat.SkillMainFile), "rendered for `cursor`")
 }
 
+func TestSetupNonInteractiveMissingURLFailsWithoutPrompt(t *testing.T) {
+	restore := useRootTestEnv(t)
+	defer restore()
+
+	root := setupTestRoot(func(context.Context, string, bool, bool) (string, error) {
+		t.Fatal("token fetcher should not be called without a URL")
+		return "", nil
+	})
+	setup := &Setup{
+		Agents:         "detected",
+		NonInteractive: true,
+		root:           root,
+	}
+
+	var stdout bytes.Buffer
+	cmd := setupTestCommand(strings.NewReader("https://obot.example.com\n"), &stdout, nil)
+	err := setup.Run(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--url is required in non-interactive mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stdout.String(), "Obot URL:") {
+		t.Fatalf("non-interactive setup should not prompt, got stdout:\n%s", stdout.String())
+	}
+}
+
+func TestSetupAgentsNoneSkipsLocalAgentInstall(t *testing.T) {
+	restore := useRootTestEnv(t)
+	defer restore()
+	home := useSetupTestHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	root := setupTestRoot(func(_ context.Context, _ string, _, _ bool) (string, error) {
+		return "token", nil
+	})
+	setup := &Setup{
+		URL:            "https://obot.example.com/",
+		Agents:         "none",
+		Yes:            true,
+		NonInteractive: true,
+		root:           root,
+	}
+
+	var stdout bytes.Buffer
+	cmd := setupTestCommand(nil, &stdout, nil)
+	if err := setup.Run(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(stdout.String(), "Detected:") {
+		t.Fatalf("expected agent detection to be skipped, got stdout:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Skipping local agent bootstrap installation") {
+		t.Fatalf("expected skip message, got stdout:\n%s", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills", "obot", skillformat.SkillMainFile)); !os.IsNotExist(err) {
+		t.Fatalf("expected no Claude Code skill to be installed, stat err: %v", err)
+	}
+}
+
 func TestSetupRefusesToReplaceConfiguredURLWithoutYes(t *testing.T) {
 	restore := useRootTestEnv(t)
 	defer restore()
@@ -191,6 +255,16 @@ func TestParseSetupAgentsRejectsAll(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	if !strings.Contains(err.Error(), "unsupported --agents value") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseSetupAgentsNoneIsExclusive(t *testing.T) {
+	_, err := parseSetupAgents("none,cursor")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cannot be combined") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/cli/setup_test.go
+++ b/pkg/cli/setup_test.go
@@ -89,7 +89,8 @@ func TestSetupNonInteractiveDetectedInstallsCursor(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	cmd := setupTestCommand(nil, &stdout, nil)
+	var stderr bytes.Buffer
+	cmd := setupTestCommand(nil, &stdout, &stderr)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -179,8 +180,8 @@ func TestSetupAgentsNoneSkipsLocalAgentInstall(t *testing.T) {
 		root:           root,
 	}
 
-	var stdout bytes.Buffer
-	cmd := setupTestCommand(nil, &stdout, nil)
+	var stdout, stderr bytes.Buffer
+	cmd := setupTestCommand(nil, &stdout, &stderr)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -216,8 +217,8 @@ func TestSetupJSONProgressSuccessfulSequence(t *testing.T) {
 		root:           root,
 	}
 
-	var stdout bytes.Buffer
-	cmd := setupTestCommand(nil, &stdout, nil)
+	var stdout, stderr bytes.Buffer
+	cmd := setupTestCommand(nil, &stdout, &stderr)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -243,6 +244,9 @@ func TestSetupJSONProgressSuccessfulSequence(t *testing.T) {
 	if strings.Contains(stdout.String(), "Detected:") {
 		t.Fatalf("JSON stdout should not include human setup output:\n%s", stdout.String())
 	}
+	if strings.Contains(stderr.String(), "Logged in to") {
+		t.Fatalf("JSON stderr should not include routine login status, got:\n%s", stderr.String())
+	}
 }
 
 func TestSetupJSONProgressStructuredError(t *testing.T) {
@@ -265,6 +269,9 @@ func TestSetupJSONProgressStructuredError(t *testing.T) {
 	err := setup.Run(cmd, nil)
 	if err == nil {
 		t.Fatal("expected error")
+	}
+	if !ErrorAlreadyReported(err) {
+		t.Fatalf("JSON setup errors should be marked already reported, got %T: %v", err, err)
 	}
 
 	events := setupProgressEvents(t, stdout.Bytes())

--- a/pkg/cli/setup_test.go
+++ b/pkg/cli/setup_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/obot-platform/obot/apiclient"
 	"github.com/obot-platform/obot/pkg/cli/internal/localconfig"
+	"github.com/obot-platform/obot/pkg/localagents"
 	"github.com/obot-platform/obot/pkg/skillformat"
 	"github.com/spf13/cobra"
 )
@@ -269,13 +271,138 @@ func TestParseSetupAgentsNoneIsExclusive(t *testing.T) {
 	}
 }
 
-func TestNewIncludesSetupCommand(t *testing.T) {
+func TestSetupStatusJSONNoConfig(t *testing.T) {
 	restore := useRootTestEnv(t)
 	defer restore()
 
-	root := New()
-	if _, _, err := root.Find([]string{"setup"}); err != nil {
-		t.Fatalf("setup command was not registered: %v", err)
+	status := &SetupStatus{
+		JSON: true,
+		tokenValid: func(context.Context, string) (bool, error) {
+			t.Fatal("token validator should not run without a configured URL")
+			return false, nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	if err := status.Run(setupTestCommand(nil, &stdout, nil), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var got setupStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("status output should be JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Version == "" {
+		t.Fatalf("expected version in status: %#v", got)
+	}
+	if got.DefaultURL != "" {
+		t.Fatalf("defaultURL = %q, want empty", got.DefaultURL)
+	}
+	if got.TokenValid {
+		t.Fatalf("tokenValid = true, want false")
+	}
+	if got.SetupComplete {
+		t.Fatalf("setupComplete = true, want false")
+	}
+	if !strings.Contains(stdout.String(), `"defaultURL": ""`) {
+		t.Fatalf("status JSON should include empty defaultURL, got:\n%s", stdout.String())
+	}
+}
+
+func TestSetupStatusSetupCompleteRequiresConfiguredURLAndValidToken(t *testing.T) {
+	restore := useRootTestEnv(t)
+	defer restore()
+	if err := localconfig.Save(localconfig.Config{DefaultURL: "https://obot.example.com/"}); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		tokenValid    bool
+		setupComplete bool
+	}{
+		{name: "valid token", tokenValid: true, setupComplete: true},
+		{name: "invalid token", tokenValid: false, setupComplete: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := &SetupStatus{
+				JSON: true,
+				tokenValid: func(_ context.Context, appURL string) (bool, error) {
+					if appURL != "https://obot.example.com" {
+						t.Fatalf("appURL = %q, want normalized URL", appURL)
+					}
+					return tt.tokenValid, nil
+				},
+			}
+
+			var stdout bytes.Buffer
+			if err := status.Run(setupTestCommand(nil, &stdout, nil), nil); err != nil {
+				t.Fatal(err)
+			}
+
+			var got setupStatusOutput
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("status output should be JSON: %v\n%s", err, stdout.String())
+			}
+			if got.DefaultURL != "https://obot.example.com" {
+				t.Fatalf("defaultURL = %q, want normalized configured URL", got.DefaultURL)
+			}
+			if got.TokenValid != tt.tokenValid {
+				t.Fatalf("tokenValid = %t, want %t", got.TokenValid, tt.tokenValid)
+			}
+			if got.SetupComplete != tt.setupComplete {
+				t.Fatalf("setupComplete = %t, want %t", got.SetupComplete, tt.setupComplete)
+			}
+		})
+	}
+}
+
+func TestSetupDetectAgentsJSON(t *testing.T) {
+	restore := useRootTestEnv(t)
+	defer restore()
+	home := useSetupTestHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	detect := &SetupDetectAgents{JSON: true}
+	if err := detect.Run(setupTestCommand(nil, &stdout, nil), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var got setupDetectAgentsOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("detect-agents output should be JSON: %v\n%s", err, stdout.String())
+	}
+	if len(got.Agents) != 2 {
+		t.Fatalf("expected two agents, got %#v", got.Agents)
+	}
+	if got.Agents[0].ID != localagents.ClaudeCodeAgentID {
+		t.Fatalf("first agent id = %q, want %q", got.Agents[0].ID, localagents.ClaudeCodeAgentID)
+	}
+	if got.Agents[0].DisplayName != "Claude Code" {
+		t.Fatalf("first agent displayName = %q, want Claude Code", got.Agents[0].DisplayName)
+	}
+	if got.Agents[0].State != string(localagents.DetectionPresent) {
+		t.Fatalf("first agent state = %q, want present; reason: %s", got.Agents[0].State, got.Agents[0].Reason)
+	}
+	if got.Agents[0].Reason == "" {
+		t.Fatalf("expected reason for first agent")
+	}
+	if got.Agents[1].ID != localagents.CursorAgentID {
+		t.Fatalf("second agent id = %q, want %q", got.Agents[1].ID, localagents.CursorAgentID)
+	}
+	if got.Agents[1].DisplayName != "Cursor" {
+		t.Fatalf("second agent displayName = %q, want Cursor", got.Agents[1].DisplayName)
+	}
+	if got.Agents[1].State != string(localagents.DetectionMissing) {
+		t.Fatalf("second agent state = %q, want missing; reason: %s", got.Agents[1].State, got.Agents[1].Reason)
+	}
+	if got.Agents[1].Reason == "" {
+		t.Fatalf("expected reason for second agent")
 	}
 }
 

--- a/pkg/cli/setup_test.go
+++ b/pkg/cli/setup_test.go
@@ -310,6 +310,44 @@ func TestSetupRefusesToReplaceConfiguredURLWithoutYes(t *testing.T) {
 	}
 }
 
+func TestSetupJSONConfiguredURLMismatchErrorCode(t *testing.T) {
+	restore := useRootTestEnv(t)
+	defer restore()
+	if err := localconfig.Save(localconfig.Config{DefaultURL: "https://old.example.com"}); err != nil {
+		t.Fatal(err)
+	}
+
+	setup := &Setup{
+		URL:    "https://new.example.com",
+		Agents: "none",
+		Output: "json",
+		root:   setupTestRoot(nil),
+	}
+
+	var stdout bytes.Buffer
+	err := setup.Run(setupTestCommand(nil, &stdout, nil), nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !ErrorAlreadyReported(err) {
+		t.Fatalf("JSON setup errors should be marked already reported, got %T: %v", err, err)
+	}
+
+	events := setupProgressEvents(t, stdout.Bytes())
+	if len(events) != 1 {
+		t.Fatalf("expected one error event, got %#v\nstdout:\n%s", events, stdout.String())
+	}
+	if events[0].Type != "error" {
+		t.Fatalf("event type = %q, want error", events[0].Type)
+	}
+	if events[0].Code != "invalid_url" {
+		t.Fatalf("event code = %q, want invalid_url", events[0].Code)
+	}
+	if !strings.Contains(events[0].Message, "pass --yes to replace") {
+		t.Fatalf("unexpected error message: %q", events[0].Message)
+	}
+}
+
 func TestSetupInteractiveUsesConfiguredURL(t *testing.T) {
 	restore := useRootTestEnv(t)
 	defer restore()


### PR DESCRIPTION
part of https://github.com/obot-platform/prospect-and-customer-issues/issues/3

This PR adds a new `--non-interactive` argument to `obot setup`, designed to be used in automated settings like scripts. This will also be used by the GUI installer that I will work on next.

This also adds two new subcommands: `obot setup detect-agents` and `obot setup status`. These are non-interactive commands that report about the state of the local installation, which will also be used in the GUI installer. The two subcommands support a `--json` argument, which outputs only JSON, designed to be consumed by the future GUI installer.