### PR TITLE
fix: incorrect View Diff shown for up-to-date MCP servers

### DIFF
--- a/ui/user/src/lib/components/admin/DiffDialog.svelte
+++ b/ui/user/src/lib/components/admin/DiffDialog.svelte
@@ -100,6 +100,10 @@
 					</div>
 				</div>
 			{/if}
+		{:else}
+			<div class="flex items-center justify-center py-8">
+				<p class="text-muted-content">Unable to compare manifests. Missing manifest data.</p>
+			</div>
 		{/if}
 	{:else}
 		<div class="flex items-center justify-center py-8">

--- a/ui/user/src/lib/components/admin/DiffDialog.svelte
+++ b/ui/user/src/lib/components/admin/DiffDialog.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
-	import { generateJsonDiff, formatJsonWithDiffHighlighting } from '$lib/diff';
+	import {
+		generateJsonDiff,
+		formatJsonWithDiffHighlighting,
+		stripManifestMetadata
+	} from '$lib/diff';
 	import type { MCPCatalogEntry, MCPCatalogServer } from '$lib/services';
-	import { stripManifestMetadata } from '$lib/services/user/mcp';
 	import { responsive } from '$lib/stores';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import { Server } from 'lucide-svelte';

--- a/ui/user/src/lib/components/admin/DiffDialog.svelte
+++ b/ui/user/src/lib/components/admin/DiffDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { generateJsonDiff, formatJsonWithDiffHighlighting } from '$lib/diff';
 	import type { MCPCatalogEntry, MCPCatalogServer } from '$lib/services';
+	import { stripManifestMetadata } from '$lib/services/user/mcp';
 	import { responsive } from '$lib/stores';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import { Server } from 'lucide-svelte';
@@ -42,8 +43,8 @@
 		{/if}
 	{/snippet}
 	{#if toServer && fromServer}
-		{@const newServerManifest = toServer.manifest}
-		{@const diffManifest = fromServer?.manifest}
+		{@const newServerManifest = stripManifestMetadata(toServer.manifest)}
+		{@const diffManifest = stripManifestMetadata(fromServer?.manifest)}
 		{#if newServerManifest && diffManifest}
 			{@const diff = generateJsonDiff(diffManifest, newServerManifest)}
 			{#if !responsive.isMobile}

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -734,7 +734,7 @@
 									</button>
 								{/if}
 
-								{#if d.catalogEntryID}
+								{#if d.catalogEntryID && d.needsUpdate}
 									<button
 										class="menu-button-primary"
 										disabled={updating[d.id]?.inProgress || readonly || !!d.compositeName}

--- a/ui/user/src/lib/diff.ts
+++ b/ui/user/src/lib/diff.ts
@@ -1,4 +1,33 @@
 // json diff utility functions
+
+/**
+ * Strips fields from a manifest that should not be considered when computing
+ * configuration drift. These are either informational metadata or fields that
+ * differ structurally between catalog entry and runtime manifest types.
+ *
+ * - `repoURL`: tracks the source repository, not server configuration
+ * - `remoteConfig.fixedURL`: catalog-only field translated to `url` at deploy time
+ * - `remoteConfig.url`: runtime-only field derived from catalog's `fixedURL`
+ * - `remoteConfig.isTemplate`: runtime-only field not present on catalog manifests
+ */
+export function stripManifestMetadata<T>(manifest: T): T {
+	if (!manifest || typeof manifest !== 'object') return manifest;
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const clone: any = JSON.parse(JSON.stringify(manifest));
+
+	delete clone.repoURL;
+
+	if (clone.remoteConfig) {
+		// fixedURL is catalog-only; url and isTemplate are runtime-only
+		delete clone.remoteConfig.fixedURL;
+		delete clone.remoteConfig.url;
+		delete clone.remoteConfig.isTemplate;
+	}
+
+	return clone as T;
+}
+
 export function formatJsonWithHighlighting(json: unknown): string {
 	try {
 		const formatted = JSON.stringify(json, null, 2);

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -866,12 +866,15 @@ export function stripManifestMetadata<T>(manifest: T): T {
 	if (!manifest || typeof manifest !== 'object') return manifest;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const clone: any = structuredClone(manifest);
+	const clone: any = JSON.parse(JSON.stringify(manifest));
 
 	delete clone.repoURL;
 
 	if (clone.remoteConfig) {
+		// fixedURL is catalog-only; url and isTemplate are runtime-only
 		delete clone.remoteConfig.fixedURL;
+		delete clone.remoteConfig.url;
+		delete clone.remoteConfig.isTemplate;
 	}
 
 	return clone as T;

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -853,31 +853,3 @@ export function conflictIssue(
 	if (!duplicates.has(effectiveName)) return undefined;
 	return { severity: 'error', message: 'Tool name is not unique.' };
 }
-
-/**
- * Strips fields from a manifest that should not be considered when computing
- * configuration drift. These are either informational metadata or fields that
- * differ structurally between catalog entry and runtime manifest types.
- *
- * - `repoURL`: tracks the source repository, not server configuration
- * - `remoteConfig.fixedURL`: catalog-only field translated to `url` at deploy time
- * - `remoteConfig.url`: runtime-only field derived from catalog's `fixedURL`
- * - `remoteConfig.isTemplate`: runtime-only field not present on catalog manifests
- */
-export function stripManifestMetadata<T>(manifest: T): T {
-	if (!manifest || typeof manifest !== 'object') return manifest;
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const clone: any = JSON.parse(JSON.stringify(manifest));
-
-	delete clone.repoURL;
-
-	if (clone.remoteConfig) {
-		// fixedURL is catalog-only; url and isTemplate are runtime-only
-		delete clone.remoteConfig.fixedURL;
-		delete clone.remoteConfig.url;
-		delete clone.remoteConfig.isTemplate;
-	}
-
-	return clone as T;
-}

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -853,3 +853,26 @@ export function conflictIssue(
 	if (!duplicates.has(effectiveName)) return undefined;
 	return { severity: 'error', message: 'Tool name is not unique.' };
 }
+
+/**
+ * Strips metadata fields from a manifest that should not be considered when
+ * computing configuration drift. These fields are informational and do not
+ * affect a server's runtime behaviour.
+ *
+ * - `repoURL`: tracks the source repository, not server configuration
+ * - `remoteConfig.fixedURL`: catalog-level field translated to `url` at deploy time
+ */
+export function stripManifestMetadata<T>(manifest: T): T {
+	if (!manifest || typeof manifest !== 'object') return manifest;
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const clone: any = structuredClone(manifest);
+
+	delete clone.repoURL;
+
+	if (clone.remoteConfig) {
+		delete clone.remoteConfig.fixedURL;
+	}
+
+	return clone as T;
+}

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -855,12 +855,14 @@ export function conflictIssue(
 }
 
 /**
- * Strips metadata fields from a manifest that should not be considered when
- * computing configuration drift. These fields are informational and do not
- * affect a server's runtime behaviour.
+ * Strips fields from a manifest that should not be considered when computing
+ * configuration drift. These are either informational metadata or fields that
+ * differ structurally between catalog entry and runtime manifest types.
  *
  * - `repoURL`: tracks the source repository, not server configuration
- * - `remoteConfig.fixedURL`: catalog-level field translated to `url` at deploy time
+ * - `remoteConfig.fixedURL`: catalog-only field translated to `url` at deploy time
+ * - `remoteConfig.url`: runtime-only field derived from catalog's `fixedURL`
+ * - `remoteConfig.isTemplate`: runtime-only field not present on catalog manifests
  */
 export function stripManifestMetadata<T>(manifest: T): T {
 	if (!manifest || typeof manifest !== 'object') return manifest;

--- a/ui/user/src/routes/admin/mcp-servers/c/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/c/[id]/+page.svelte
@@ -8,6 +8,7 @@
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { stripManifestMetadata } from '$lib/diff';
 	import { parseErrorContent } from '$lib/errors';
 	import {
 		type MCPCatalogEntryServerManifest,
@@ -15,7 +16,6 @@
 		type MCPCatalogServer,
 		AdminService
 	} from '$lib/services';
-	import { stripManifestMetadata } from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, profile } from '$lib/stores';
 	import { CircleFadingArrowUp, Info, GitCompare } from 'lucide-svelte';
 	import { untrack, type Component } from 'svelte';

--- a/ui/user/src/routes/admin/mcp-servers/c/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/c/[id]/+page.svelte
@@ -15,6 +15,7 @@
 		type MCPCatalogServer,
 		AdminService
 	} from '$lib/services';
+	import { stripManifestMetadata } from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, profile } from '$lib/stores';
 	import { CircleFadingArrowUp, Info, GitCompare } from 'lucide-svelte';
 	import { untrack, type Component } from 'svelte';
@@ -98,8 +99,16 @@
 						componentType = 'Catalog Entry';
 					}
 
-					const currentManifestStr = JSON.stringify(currentManifest, null, 2);
-					const snapshotManifestStr = JSON.stringify(component.manifest, null, 2);
+					const currentManifestStr = JSON.stringify(
+						stripManifestMetadata(currentManifest),
+						null,
+						2
+					);
+					const snapshotManifestStr = JSON.stringify(
+						stripManifestMetadata(component.manifest),
+						null,
+						2
+					);
 
 					if (currentManifestStr !== snapshotManifestStr) {
 						diffs.push({

--- a/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
@@ -14,6 +14,7 @@
 		type MCPCatalogServer,
 		AdminService
 	} from '$lib/services';
+	import { stripManifestMetadata } from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, profile } from '$lib/stores';
 	import { CircleFadingArrowUp, Info, GitCompare } from 'lucide-svelte';
 	import { type Component, untrack } from 'svelte';
@@ -89,8 +90,16 @@
 						componentType = 'Catalog Entry';
 					}
 
-					const currentManifestStr = JSON.stringify(currentManifest, null, 2);
-					const snapshotManifestStr = JSON.stringify(component.manifest, null, 2);
+					const currentManifestStr = JSON.stringify(
+						stripManifestMetadata(currentManifest),
+						null,
+						2
+					);
+					const snapshotManifestStr = JSON.stringify(
+						stripManifestMetadata(component.manifest),
+						null,
+						2
+					);
 
 					if (currentManifestStr !== snapshotManifestStr) {
 						diffs.push({

--- a/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
@@ -7,6 +7,7 @@
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { stripManifestMetadata } from '$lib/diff';
 	import { parseErrorContent } from '$lib/errors';
 	import {
 		type MCPCatalogEntryServerManifest,
@@ -14,7 +15,6 @@
 		type MCPCatalogServer,
 		AdminService
 	} from '$lib/services';
-	import { stripManifestMetadata } from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, profile } from '$lib/stores';
 	import { CircleFadingArrowUp, Info, GitCompare } from 'lucide-svelte';
 	import { type Component, untrack } from 'svelte';


### PR DESCRIPTION
## Summary
- Hide the "View Diff" button in the deployments table when a server has no pending updates (Addresses #6630)
- Strip `repoURL` and `remoteConfig.fixedURL`, etc. metadata fields from manifests before diffing to eliminate false-positive configuration drift caused by comparing different manifest types (Addresses #5507)
