### PR TITLE
fix: make image pull secrets UI not broken

### DIFF
--- a/ui/user/src/routes/admin/image-pull-secrets/+page.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/+page.svelte
@@ -291,7 +291,7 @@
 
 	{#snippet rightNavActions()}
 		{#if !showForm && !mutationsDisabled}
-			<button class="button-primary flex items-center gap-1 text-sm" onclick={createNewSecret}>
+			<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={createNewSecret}>
 				<Plus class="size-4" />
 				Create New Secret
 			</button>

--- a/ui/user/src/routes/admin/image-pull-secrets/ECRSetupGuide.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ECRSetupGuide.svelte
@@ -13,14 +13,14 @@
 
 <section class="paper gap-5">
 	<div class="flex flex-col gap-1">
-		<h3 class="text-on-surface1 text-base font-semibold">AWS Setup Guide</h3>
-		<p class="text-on-surface1 text-sm">
+		<h3 class="text-base font-semibold">AWS Setup Guide</h3>
+		<p class="text-muted-content text-sm">
 			Configure AWS to trust Obot's service account, then save the role ARN above and refresh the
 			generated pull secret.
 		</p>
 	</div>
 
-	<div class="divide-surface2 dark:divide-surface3 flex flex-col divide-y">
+	<div class="divide-base-300 dark:divide-base-400 flex flex-col divide-y">
 		<div class="pb-5">
 			{@render setupStep(
 				'1',
@@ -68,13 +68,13 @@
 {#snippet setupStep(number: string, title: string, description: string)}
 	<div class="flex gap-3">
 		<div
-			class="bg-surface1 text-on-surface1 flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
+			class="bg-base-200 text-muted-content flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
 		>
 			{number}
 		</div>
 		<div class="min-w-0">
 			<h4 class="text-sm font-semibold">{title}</h4>
-			<p class="text-on-surface1 text-sm">{description}</p>
+			<p class="text-muted-content text-sm">{description}</p>
 		</div>
 	</div>
 {/snippet}
@@ -82,12 +82,12 @@
 {#snippet setupValue(label: string, value?: string)}
 	<div class="min-w-0">
 		<div class="mb-1 flex items-center gap-2">
-			<span class="text-on-surface1 text-xs font-medium">{label}</span>
+			<span class="text-muted-content text-xs font-medium">{label}</span>
 			{#if value}
 				<CopyButton text={value} />
 			{/if}
 		</div>
-		<div class="text-on-surface1 break-all font-mono text-xs">
+		<div class="text-base-content break-all font-mono text-xs">
 			{value || '-'}
 		</div>
 	</div>
@@ -100,7 +100,7 @@
 			<CopyButton text={value} />
 		</div>
 		<pre
-			class="default-scrollbar-thin dark:border-surface3 bg-surface1 dark:bg-background max-h-80 overflow-auto rounded-md border border-transparent p-3 text-xs">{value ||
+			class="default-scrollbar-thin bg-base-200 dark:bg-base-100 dark:border-base-400 max-h-80 overflow-auto rounded-md border border-transparent p-3 text-xs">{value ||
 				'-'}</pre>
 	</div>
 {/snippet}

--- a/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretForm.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretForm.svelte
@@ -102,7 +102,7 @@
 					/>
 					<Select
 						id="image-pull-secret-type"
-						class="bg-surface1 dark:bg-background dark:border-surface3 border border-transparent shadow-inner"
+						class="bg-base-200 dark:bg-base-100 dark:border-base-400 border border-transparent shadow-inner"
 						classes={{ root: 'w-full' }}
 						options={typeOptions}
 						selected={form.type}
@@ -152,7 +152,7 @@
 				{#if currentSecret && form.type === 'ecr'}
 					<button
 						type="button"
-						class="button flex items-center gap-1 text-sm"
+						class="btn btn-secondary flex items-center gap-1 text-sm"
 						disabled={mutationsDisabled || refreshing}
 						onclick={() => onRefresh(currentSecret)}
 					>
@@ -162,7 +162,7 @@
 				{/if}
 				<button
 					type="submit"
-					class="button-primary flex items-center gap-1 text-sm"
+					class="btn btn-primary flex items-center gap-1 text-sm"
 					disabled={mutationsDisabled || saving}
 				>
 					{#if saving}
@@ -194,7 +194,7 @@
 </div>
 
 {#snippet enabledToggle()}
-	<div class="border-surface2 flex items-center gap-1 border-t pt-4 text-sm">
+	<div class="border-base-300 dark:border-base-400 flex items-center gap-1 border-t pt-4 text-sm">
 		<Toggle
 			label="Enabled"
 			labelInline
@@ -306,10 +306,10 @@
 			{/if}
 		</label>
 
-		<div class="border-surface2 flex flex-col gap-4 border-t pt-4">
+		<div class="border-base-300 dark:border-base-400 flex flex-col gap-4 border-t pt-4">
 			<button
 				type="button"
-				class="text-on-surface1 flex w-fit items-center gap-1 text-sm font-medium"
+				class="text-muted-content hover:text-base-content flex w-fit items-center gap-1 text-sm font-medium"
 				aria-expanded={showECRAdvanced}
 				onclick={() => {
 					showECRAdvanced = !showECRAdvanced;

--- a/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretStatusDialog.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretStatusDialog.svelte
@@ -99,11 +99,11 @@
 				<section class="flex flex-col gap-3">
 					{@render sectionHeader('Registry Endpoints')}
 					<div
-						class="dark:bg-background dark:border-surface3 bg-surface1 flex flex-col gap-2 rounded-lg border border-transparent p-3 shadow-sm"
+						class="bg-base-200 dark:bg-base-100 dark:border-base-400 flex flex-col gap-2 rounded-lg border border-transparent p-3 shadow-sm"
 					>
 						{#each details.status.registryEndpoints as endpoint (endpoint)}
 							<div
-								class="dark:bg-surface2 bg-background text-on-surface1 rounded-md px-3 py-2 font-mono text-xs break-all"
+								class="bg-base-100 dark:bg-base-300 rounded-md px-3 py-2 font-mono text-xs break-all"
 							>
 								{endpoint}
 							</div>
@@ -116,22 +116,22 @@
 </ResponsiveDialog>
 
 {#snippet sectionHeader(title: string)}
-	<h4 class="text-on-surface1 text-sm font-semibold">{title}</h4>
+	<h4 class="text-sm font-semibold">{title}</h4>
 {/snippet}
 
 {#snippet statusValue(label: string, value?: string, Icon?: IconComponent)}
 	<div
-		class="dark:bg-background dark:border-surface3 bg-surface1 flex min-w-0 items-start gap-3 rounded-lg border border-transparent p-3 shadow-sm"
+		class="bg-base-200 dark:bg-base-100 dark:border-base-400 flex min-w-0 items-start gap-3 rounded-lg border border-transparent p-3 shadow-sm"
 	>
 		{#if Icon}
 			<div
-				class="dark:bg-surface2 bg-background text-on-surface1 flex size-8 shrink-0 items-center justify-center rounded-md"
+				class="bg-base-100 text-muted-content dark:bg-base-300 flex size-8 shrink-0 items-center justify-center rounded-md"
 			>
 				<Icon class="size-4" />
 			</div>
 		{/if}
 		<div class="min-w-0">
-			<div class="text-on-surface1 text-xs font-medium">{label}</div>
+			<div class="text-muted-content text-xs font-medium">{label}</div>
 			{#if shouldBadge(label)}
 				<div
 					class={twMerge(
@@ -142,7 +142,7 @@
 					<span class="truncate">{value || '-'}</span>
 				</div>
 			{:else}
-				<div class="text-on-background mt-1 break-words text-sm">{value || '-'}</div>
+				<div class="mt-1 break-words text-sm">{value || '-'}</div>
 			{/if}
 		</div>
 	</div>

--- a/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretTestDialog.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretTestDialog.svelte
@@ -85,10 +85,12 @@
 		{/if}
 
 		<div class="flex justify-end gap-2">
-			<button type="button" class="button" disabled={testing} onclick={close}>Cancel</button>
+			<button type="button" class="btn btn-secondary" disabled={testing} onclick={close}>
+				Cancel
+			</button>
 			<button
 				type="submit"
-				class="button-primary flex items-center gap-1 text-sm"
+				class="btn btn-primary flex items-center gap-1 text-sm"
 				disabled={testing || !testImage.trim()}
 			>
 				{#if testing}

--- a/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretsList.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretsList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tooltip } from '$lib/actions/tooltip.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import type { ImagePullSecret } from '$lib/services';
 	import { userDeviceSettings } from '$lib/stores';
@@ -54,13 +54,13 @@
 
 {#if imagePullSecrets.length === 0}
 	<div class="mt-12 flex w-md max-w-full flex-col items-center gap-4 self-center text-center">
-		<KeyRound class="text-on-surface1 size-24 opacity-25" />
-		<h4 class="text-on-surface1 text-lg font-semibold">No image pull secrets</h4>
-		<p class="text-on-surface1 text-sm font-light">
+		<KeyRound class="text-muted-content size-24 opacity-25" />
+		<h4 class="text-muted-content text-lg font-semibold">No image pull secrets</h4>
+		<p class="text-muted-content text-sm font-light">
 			Create a managed image pull secret to let Obot pull private MCP server images.
 		</p>
 		{#if !mutationsDisabled}
-			<button class="button-primary flex items-center gap-1 text-sm" onclick={onCreate}>
+			<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={onCreate}>
 				<Plus class="size-4" />
 				Create New Secret
 			</button>
@@ -70,7 +70,7 @@
 	<div class="flex flex-col gap-8">
 		{#if basicSecrets.length > 0}
 			<section class="flex flex-col gap-3">
-				<h2 class="text-on-surface1 text-lg font-semibold">Basic Secrets</h2>
+				<h2 class="text-lg font-semibold">Basic Secrets</h2>
 				<Table
 					data={basicSecrets}
 					fields={['displayName', 'detail', 'id']}
@@ -86,28 +86,27 @@
 				>
 					{#snippet actions(secret)}
 						<div class="flex items-center gap-1">
-							<button
-								class="icon-button"
+							<IconButton
 								disabled={mutationsDisabled}
-								use:tooltip={'Test'}
+								tooltip={{ text: 'Test' }}
 								onclick={(e) => {
 									e.stopPropagation();
 									onTest(secret);
 								}}
 							>
 								<ShieldCheck class="size-4" />
-							</button>
-							<button
-								class="icon-button hover:text-red-500"
+							</IconButton>
+							<IconButton
+								variant="danger"
 								disabled={mutationsDisabled}
-								use:tooltip={'Delete'}
+								tooltip={{ text: 'Delete' }}
 								onclick={(e) => {
 									e.stopPropagation();
 									onDelete(secret);
 								}}
 							>
 								<Trash2 class="size-4" />
-							</button>
+							</IconButton>
 						</div>
 					{/snippet}
 					{#snippet onRenderColumn(property, secret)}
@@ -123,7 +122,7 @@
 
 		{#if ecrSecrets.length > 0}
 			<section class="flex flex-col gap-3">
-				<h2 class="text-on-surface1 text-lg font-semibold">ECR Secrets</h2>
+				<h2 class="text-lg font-semibold">ECR Secrets</h2>
 				{@render ecrTable()}
 			</section>
 		{/if}
@@ -149,49 +148,46 @@
 	>
 		{#snippet actions(secret)}
 			<div class="flex items-center gap-1">
-				<button
-					class="icon-button"
-					use:tooltip={'Status'}
+				<IconButton
+					tooltip={{ text: 'Status' }}
 					onclick={(e) => {
 						e.stopPropagation();
 						onStatus(secret);
 					}}
 				>
 					<Info class="size-4" />
-				</button>
-				<button
-					class="icon-button"
+				</IconButton>
+				<IconButton
 					disabled={mutationsDisabled}
-					use:tooltip={'Test'}
+					tooltip={{ text: 'Test' }}
 					onclick={(e) => {
 						e.stopPropagation();
 						onTest(secret);
 					}}
 				>
 					<ShieldCheck class="size-4" />
-				</button>
-				<button
-					class="icon-button"
-					disabled={mutationsDisabled}
-					use:tooltip={'Refresh now'}
+				</IconButton>
+				<IconButton
+					disabled={mutationsDisabled || refreshing}
+					tooltip={{ text: 'Refresh now' }}
 					onclick={(e) => {
 						e.stopPropagation();
 						onRefresh(secret);
 					}}
 				>
 					<RefreshCw class={twMerge('size-4', refreshing && 'animate-spin')} />
-				</button>
-				<button
-					class="icon-button hover:text-red-500"
+				</IconButton>
+				<IconButton
+					variant="danger"
 					disabled={mutationsDisabled}
-					use:tooltip={'Delete'}
+					tooltip={{ text: 'Delete' }}
 					onclick={(e) => {
 						e.stopPropagation();
 						onDelete(secret);
 					}}
 				>
 					<Trash2 class="size-4" />
-				</button>
+				</IconButton>
 			</div>
 		{/snippet}
 		{#snippet onRenderColumn(property, secret)}


### PR DESCRIPTION
I think a lot of our tailwind class names got changed at some point while I was working on this, so it wound up looking pretty broken after it was merged.

for https://github.com/obot-platform/obot/issues/6632