### PR TITLE
fix: font-family consistency in Device Scan related pages

### DIFF
--- a/ui/user/src/routes/admin/device-clients/+page.svelte
+++ b/ui/user/src/routes/admin/device-clients/+page.svelte
@@ -113,7 +113,7 @@
 				{#snippet onRenderColumn(property, d)}
 					{#if property === 'name'}
 						{#if d.name?.trim()}
-							<span class="font-medium">{d.name}</span>
+							{d.name.trim()}
 						{:else}
 							<span class="text-muted-content italic">(unnamed)</span>
 						{/if}

--- a/ui/user/src/routes/admin/device-clients/[name]/+page.svelte
+++ b/ui/user/src/routes/admin/device-clients/[name]/+page.svelte
@@ -127,13 +127,7 @@
 							}}
 						>
 							{#snippet onRenderColumn(property, d)}
-								{#if property === 'name'}
-									<span class="font-mono text-xs">{d.name}</span>
-								{:else if property === 'endpoint'}
-									<span class="font-mono text-xs">{d.endpoint}</span>
-								{:else}
-									{d[property as keyof (typeof rows)[number]] ?? '—'}
-								{/if}
+								{d[property as keyof (typeof rows)[number]] ?? '—'}
 							{/snippet}
 						</Table>
 					{/if}

--- a/ui/user/src/routes/admin/device-mcp-servers/+page.svelte
+++ b/ui/user/src/routes/admin/device-mcp-servers/+page.svelte
@@ -87,7 +87,7 @@
 				{#snippet onRenderColumn(property, d: Row)}
 					{#if property === 'name'}
 						{#if d.name?.trim()}
-							<span class="font-medium">{d.name}</span>
+							{d.name.trim()}
 						{:else}
 							<span class="text-muted-content italic">(unnamed)</span>
 						{/if}

--- a/ui/user/src/routes/admin/device-mcp-servers/[hash]/+page.svelte
+++ b/ui/user/src/routes/admin/device-mcp-servers/[hash]/+page.svelte
@@ -119,7 +119,7 @@
 					{#if detail.url}
 						<div class="flex flex-col gap-1">
 							<span class="text-muted-content text-xs uppercase">URL</span>
-							<code class="text-sm break-all">{detail.url}</code>
+							<p class="text-sm break-all">{detail.url}</p>
 						</div>
 					{/if}
 					{#if detail.envKeys?.length}

--- a/ui/user/src/routes/admin/device-mcp-servers/[hash]/+page.svelte
+++ b/ui/user/src/routes/admin/device-mcp-servers/[hash]/+page.svelte
@@ -119,15 +119,15 @@
 					{#if detail.url}
 						<div class="flex flex-col gap-1">
 							<span class="text-muted-content text-xs uppercase">URL</span>
-							<code class="font-mono text-xs break-all">{detail.url}</code>
+							<code class="text-sm break-all">{detail.url}</code>
 						</div>
 					{/if}
 					{#if detail.envKeys?.length}
 						<div class="flex flex-col gap-1">
 							<span class="text-muted-content text-xs uppercase">Env keys</span>
-							<div class="flex flex-wrap gap-1">
+							<div class="flex flex-wrap gap-2">
 								{#each detail.envKeys as k (k)}
-									<code class="bg-base-400 rounded px-1.5 py-0.5 font-mono text-xs">{k}</code>
+									<code class="bg-base-400 rounded px-1.5 py-0.5 text-xs">{k}</code>
 								{/each}
 							</div>
 						</div>
@@ -135,9 +135,9 @@
 					{#if detail.headerKeys?.length}
 						<div class="flex flex-col gap-1">
 							<span class="text-muted-content text-xs uppercase">Header keys</span>
-							<div class="flex flex-wrap gap-1">
+							<div class="flex flex-wrap gap-2">
 								{#each detail.headerKeys as k (k)}
-									<code class="bg-base-400 rounded px-1.5 py-0.5 font-mono text-xs">{k}</code>
+									<code class="bg-base-400 rounded px-1.5 py-0.5 text-xs">{k}</code>
 								{/each}
 							</div>
 						</div>
@@ -170,7 +170,7 @@
 						{#if property === 'shortDeviceID'}
 							<a
 								href={resolve(`/admin/devices/${d.deviceID}`)}
-								class="font-mono text-xs btn-link text-primary"
+								class="btn-link text-primary"
 								title={d.deviceID}
 								onclick={(e) => e.stopPropagation()}
 							>

--- a/ui/user/src/routes/admin/device-skills/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/+page.svelte
@@ -114,11 +114,7 @@
 				}}
 			>
 				{#snippet onRenderColumn(property, d: Row)}
-					{#if property === 'name'}
-						<span class="font-medium">{d.name}</span>
-					{:else}
-						{d[property as keyof Row]}
-					{/if}
+					{d[property as keyof Row] ?? '—'}
 				{/snippet}
 			</Table>
 

--- a/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
@@ -119,7 +119,7 @@
 					{#if detail.gitRemoteURL}
 						<div class="flex flex-col gap-1">
 							<span class="text-muted-content text-xs uppercase">Git remote</span>
-							<code class="text-sm">{detail.gitRemoteURL}</code>
+							<code class="text-sm break-all">{detail.gitRemoteURL}</code>
 						</div>
 					{/if}
 					{#if detail.files?.length}

--- a/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
@@ -119,7 +119,7 @@
 					{#if detail.gitRemoteURL}
 						<div class="flex flex-col gap-1">
 							<span class="text-muted-content text-xs uppercase">Git remote</span>
-							<code class="font-mono text-xs break-all">{detail.gitRemoteURL}</code>
+							<code class="text-sm">{detail.gitRemoteURL}</code>
 						</div>
 					{/if}
 					{#if detail.files?.length}
@@ -127,9 +127,9 @@
 							<span class="text-muted-content text-xs uppercase">
 								Files ({detail.files.length})
 							</span>
-							<ul class="flex flex-col gap-0.5">
+							<ul class="flex flex-col gap-1.5">
 								{#each detail.files as f (f)}
-									<li class="flex items-center gap-1.5 font-mono text-xs">
+									<li class="flex items-center gap-1.5 text-xs">
 										<FileText class="text-muted-content size-3 shrink-0" />
 										<span class="break-all">{f}</span>
 									</li>
@@ -173,14 +173,14 @@
 						{#if property === 'shortDeviceID'}
 							<a
 								href={resolve(`/admin/devices/${d.deviceID}`)}
-								class="font-mono text-xs btn-link text-primary"
+								class="btn-link text-primary"
 								title={d.deviceID}
 								onclick={(e) => e.stopPropagation()}
 							>
 								{d.shortDeviceID}
 							</a>
 						{:else if property === 'projectPath'}
-							<span class="text-muted-content font-mono text-xs">{d.projectPath ?? '—'}</span>
+							{d.projectPath ?? '—'}
 						{:else}
 							{d[property as keyof Row]}
 						{/if}

--- a/ui/user/src/routes/admin/devices/+page.svelte
+++ b/ui/user/src/routes/admin/devices/+page.svelte
@@ -166,7 +166,7 @@
 			>
 				{#snippet onRenderColumn(property, d: Row)}
 					{#if property === 'short_device_id'}
-						<span class="font-mono text-xs" title={d.deviceID}>{d.short_device_id}</span>
+						<span title={d.deviceID}>{d.short_device_id}</span>
 					{:else if property === 'username'}
 						{@const u = d.submittedBy ? userById.get(d.submittedBy) : undefined}
 						{#if u}

--- a/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
@@ -210,7 +210,7 @@
 				<dl class="grid grid-cols-[max-content_1fr] items-center gap-x-4 gap-y-2 text-sm">
 					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">Device ID</dt>
 					<dd class="flex items-center gap-2">
-						<span class="font-mono text-base font-semibold">{deviceId}</span>
+						<span class="text-base font-semibold">{deviceId}</span>
 						<CopyButton text={deviceId} />
 					</dd>
 
@@ -240,20 +240,20 @@
 								<span>{userDisplay(submittedByUser)}</span>
 							</div>
 						{:else if latest.submittedBy}
-							<span class="font-mono text-xs">{latest.submittedBy}</span>
+							<span class="text-xs">{latest.submittedBy}</span>
 						{:else}
 							<span class="text-muted-content">—</span>
 						{/if}
 					</dd>
 
 					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">OS user</dt>
-					<dd class="font-mono">{latest.username || '—'}</dd>
+					<dd>{latest.username || '—'}</dd>
 
 					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">Hostname</dt>
-					<dd class="font-mono">{latest.hostname || '—'}</dd>
+					<dd>{latest.hostname || '—'}</dd>
 
 					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">Scanner</dt>
-					<dd class="font-mono">{latest.scannerVersion || '—'}</dd>
+					<dd>{latest.scannerVersion || '—'}</dd>
 
 					<dt class="text-muted-content text-xs font-medium tracking-wide uppercase">
 						Last scanned
@@ -331,11 +331,7 @@
 							}}
 						>
 							{#snippet onRenderColumn(property, d: MCPRow)}
-								{#if property === 'name'}
-									<span class="font-mono text-xs">{d.name}</span>
-								{:else if property === 'endpoint'}
-									<span class="font-mono text-xs">{d.endpoint}</span>
-								{:else if property === 'client'}
+								{#if property === 'client'}
 									{@render clientLink(d.client)}
 								{:else}
 									{d[property as keyof MCPRow] ?? '—'}
@@ -471,7 +467,7 @@
 								{#if property === 'enabled'}
 									{d.enabled ? 'yes' : 'no'}
 								{:else if property === 'version'}
-									<span class="font-mono text-xs">{d.version ?? '—'}</span>
+									{d.version ?? '—'}
 								{:else if property === 'client'}
 									{@render clientLink(d.client)}
 								{:else}
@@ -498,15 +494,7 @@
 							filterable={['name']}
 						>
 							{#snippet onRenderColumn(property, d: ClientRow)}
-								{#if property === 'version'}
-									<span class="font-mono text-xs">{d.version ?? '—'}</span>
-								{:else if property === 'paths_display'}
-									<span class="font-mono text-xs">{d.paths_display}</span>
-								{:else if property === 'has_display'}
-									<span class="text-xs">{d.has_display}</span>
-								{:else}
-									{d[property as keyof ClientRow] ?? '—'}
-								{/if}
+								{d[property as keyof ClientRow] ?? '—'}
 							{/snippet}
 						</Table>
 					{/if}
@@ -545,7 +533,7 @@
 					{#snippet onRenderColumn(property, d: HistoryRow)}
 						{#if property === 'id'}
 							<span class="flex items-center gap-2">
-								<span class="font-mono text-xs">#{d.id}</span>
+								<span class="text-xs">#{d.id}</span>
 								{#if d.is_latest}
 									<span
 										class="bg-primary/15 text-primary rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase"

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
@@ -222,7 +222,7 @@
 				<dl class="grid flex-1 grid-cols-[max-content_1fr] items-center gap-x-4 gap-y-2 text-sm">
 					<dt class="text-muted-content text-xs font-medium uppercase tracking-wide">Device ID</dt>
 					<dd class="flex items-center gap-2">
-						<span class="font-mono text-base font-semibold">{scan.deviceID}</span>
+						<span class="text-base font-semibold">{scan.deviceID}</span>
 						<CopyButton text={scan.deviceID} />
 						{#if isLatest}
 							<span
@@ -259,14 +259,14 @@
 								<span>{userDisplay(submittedByUser)}</span>
 							</div>
 						{:else if scan.submittedBy}
-							<span class="font-mono text-xs">{scan.submittedBy}</span>
+							<span class="text-xs">{scan.submittedBy}</span>
 						{:else}
 							<span class="text-muted-content">—</span>
 						{/if}
 					</dd>
 
 					<dt class="text-muted-content text-xs font-medium uppercase tracking-wide">Scanner</dt>
-					<dd class="font-mono">{scan.scannerVersion || '—'}</dd>
+					<dd>{scan.scannerVersion || '—'}</dd>
 
 					<dt class="text-muted-content text-xs font-medium uppercase tracking-wide">Scanned</dt>
 					<dd use:tooltip={scannedTime.fullDate}>
@@ -346,11 +346,7 @@
 							}}
 						>
 							{#snippet onRenderColumn(property, d: MCPRow)}
-								{#if property === 'name'}
-									<span class="font-mono text-xs">{d.name}</span>
-								{:else if property === 'endpoint'}
-									<span class="font-mono text-xs">{d.endpoint}</span>
-								{:else if property === 'client'}
+								{#if property === 'client'}
 									{@render clientLink(d.client)}
 								{:else}
 									{d[property as keyof MCPRow] ?? '—'}
@@ -433,8 +429,6 @@
 							{#snippet onRenderColumn(property, d: PluginRow)}
 								{#if property === 'enabled'}
 									{d.enabled ? 'yes' : 'no'}
-								{:else if property === 'version'}
-									<span class="font-mono text-xs">{d.version ?? '—'}</span>
 								{:else if property === 'client'}
 									{@render clientLink(d.client)}
 								{:else}
@@ -468,15 +462,7 @@
 							filterable={['name']}
 						>
 							{#snippet onRenderColumn(property, d: ClientRow)}
-								{#if property === 'version'}
-									<span class="font-mono text-xs">{d.version ?? '—'}</span>
-								{:else if property === 'paths_display'}
-									<span class="font-mono text-xs">{d.paths_display}</span>
-								{:else if property === 'has_display'}
-									<span class="text-xs">{d.has_display}</span>
-								{:else}
-									{d[property as keyof ClientRow] ?? '—'}
-								{/if}
+								{d[property as keyof ClientRow] ?? '—'}
 							{/snippet}
 						</Table>
 					{/if}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
@@ -88,10 +88,10 @@
 					{/if}
 					{#if server.command}
 						<dt class="text-muted-content">Command</dt>
-						<dd class="break-all">{server.command}</dd>
+						<dd class="font-mono break-all">{server.command}</dd>
 					{/if}
 					{#if server.args && server.args.length > 0}
-						<dt class="text-mute-content">Args</dt>
+						<dt class="text-muted-content">Args</dt>
 						<dd class="text-xs break-all">
 							{#each server.args as arg, i (i)}
 								<span class="dark:bg-base-400 bg-base-300 mr-1 inline-block rounded px-1.5 py-0.5">
@@ -134,7 +134,7 @@
 					</dd>
 					{#if server.file}
 						<dt class="text-muted-content">File</dt>
-						<dd class="text-sm">{server.file}</dd>
+						<dd class="text-sm break-all">{server.file}</dd>
 					{/if}
 					{#if parentPlugin}
 						<dt class="text-muted-content">Part of plugin</dt>

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
@@ -71,12 +71,12 @@
 		{:else}
 			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-3 rounded-md p-4 shadow-sm">
 				<div class="flex flex-wrap items-baseline gap-2">
-					<h2 class="font-mono text-xl font-semibold">{server.name}</h2>
+					<h2 class="text-xl font-semibold">{server.name}</h2>
 					<span class="pill-primary bg-primary">{server.transport}</span>
-					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 						{server.client}
 					</span>
-					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 						{scope}
 					</span>
 				</div>
@@ -84,15 +84,15 @@
 				<dl class="grid grid-cols-1 gap-x-6 gap-y-2 text-sm md:grid-cols-[max-content_1fr]">
 					{#if endpoint}
 						<dt class="text-muted-content">Endpoint</dt>
-						<dd class="font-mono break-all">{endpoint}</dd>
+						<dd class="break-all">{endpoint}</dd>
 					{/if}
 					{#if server.command}
 						<dt class="text-muted-content">Command</dt>
-						<dd class="font-mono break-all">{server.command}</dd>
+						<dd class="break-all">{server.command}</dd>
 					{/if}
 					{#if server.args && server.args.length > 0}
 						<dt class="text-mute-content">Args</dt>
-						<dd class="font-mono text-xs break-all">
+						<dd class="text-xs break-all">
 							{#each server.args as arg, i (i)}
 								<span class="dark:bg-base-400 bg-base-300 mr-1 inline-block rounded px-1.5 py-0.5">
 									{arg}
@@ -102,16 +102,14 @@
 					{/if}
 					{#if server.url}
 						<dt class="text-muted-content">URL</dt>
-						<dd class="font-mono break-all">{server.url}</dd>
+						<dd class="break-all">{server.url}</dd>
 					{/if}
 					<dt class="text-muted-content">Env keys</dt>
 					<dd>
 						{#if server.envKeys && server.envKeys.length > 0}
-							<div class="flex flex-wrap gap-1">
+							<div class="flex flex-wrap gap-2">
 								{#each server.envKeys as k (k)}
-									<span
-										class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs"
-									>
+									<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 										{k}
 									</span>
 								{/each}
@@ -123,11 +121,9 @@
 					<dt class="text-muted-content">Header keys</dt>
 					<dd>
 						{#if server.headerKeys && server.headerKeys.length > 0}
-							<div class="flex flex-wrap gap-1">
+							<div class="flex flex-wrap gap-2">
 								{#each server.headerKeys as k (k)}
-									<span
-										class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs"
-									>
+									<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 										{k}
 									</span>
 								{/each}
@@ -138,13 +134,13 @@
 					</dd>
 					{#if server.file}
 						<dt class="text-muted-content">File</dt>
-						<dd class="font-mono text-xs break-all">{server.file}</dd>
+						<dd class="text-sm">{server.file}</dd>
 					{/if}
 					{#if parentPlugin}
 						<dt class="text-muted-content">Part of plugin</dt>
 						<dd>
 							<a
-								class="text-link font-mono"
+								class="text-sm text-link"
 								href={resolve(
 									`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}/plugins/${parentPlugin.id}`
 								)}
@@ -155,12 +151,12 @@
 					{/if}
 					{#if server.projectPath}
 						<dt class="text-muted-content">Project path</dt>
-						<dd class="font-mono text-xs break-all">{server.projectPath}</dd>
+						<dd class="break-all">{server.projectPath}</dd>
 					{/if}
 					{#if server.configHash}
 						<dt class="text-muted-content">Config hash</dt>
 						<dd class="flex items-center gap-1">
-							<span class="font-mono text-xs" use:tooltip={server.configHash}>
+							<span class="text-sm" use:tooltip={server.configHash}>
 								{shortHash(server.configHash)}
 							</span>
 							<CopyButton text={server.configHash} />
@@ -176,7 +172,7 @@
 				</div>
 				<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-2 rounded-md p-3 shadow-sm">
 					<pre
-						class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs">{renderConfig(
+						class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs mb-0 mt-2">{renderConfig(
 							server
 						)}</pre>
 					<p class="text-muted-content text-xs">

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
@@ -44,15 +44,15 @@
 		{:else}
 			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-3 rounded-md p-4 shadow-sm">
 				<div class="flex flex-wrap items-baseline gap-2">
-					<h2 class="font-mono text-xl font-semibold">{plugin.name}</h2>
+					<h2 class="text-xl font-semibold">{plugin.name}</h2>
 					{#if plugin.version}
-						<span class="text-muted-content font-mono text-sm">v{plugin.version}</span>
+						<span class="text-muted-content text-sm">v{plugin.version}</span>
 					{/if}
 					<span class="pill-primary bg-primary">{plugin.pluginType}</span>
-					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 						{plugin.client}
 					</span>
-					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 						{scope}
 					</span>
 					<span
@@ -75,26 +75,24 @@
 					{/if}
 					{#if plugin.marketplace}
 						<dt class="text-muted-content">Marketplace</dt>
-						<dd class="font-mono text-xs break-all">{plugin.marketplace}</dd>
+						<dd class="break-all">{plugin.marketplace}</dd>
 					{/if}
 					{#if plugin.configPath}
 						<dt class="text-muted-content">File</dt>
-						<dd class="font-mono text-xs break-all">{plugin.configPath}</dd>
+						<dd class="break-all">{plugin.configPath}</dd>
 					{/if}
 					{#if plugin.projectPath}
 						<dt class="text-muted-content">Project path</dt>
-						<dd class="font-mono text-xs break-all">{plugin.projectPath}</dd>
+						<dd class="break-all">{plugin.projectPath}</dd>
 					{/if}
 					<dt class="text-muted-content">Capabilities</dt>
 					<dd>
 						{#if capabilities.length === 0}
 							<span class="text-muted-content">none detected</span>
 						{:else}
-							<div class="flex flex-wrap gap-1">
+							<div class="flex flex-wrap gap-2">
 								{#each capabilities as c (c.key)}
-									<span
-										class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs"
-									>
+									<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 										{c.key}
 									</span>
 								{/each}
@@ -115,7 +113,7 @@
 								class="dark:bg-base-300 bg-base-100 flex flex-col gap-2 rounded-md p-3 shadow-sm"
 							>
 								<div class="flex flex-wrap items-center gap-2 text-xs">
-									<span class="font-mono break-all">{path}</span>
+									<span class="break-all">{path}</span>
 									{#if file}
 										<span class="text-muted-content">{formatBytes(file.sizeBytes)}</span>
 										{#if file.oversized}
@@ -127,7 +125,7 @@
 								</div>
 								{#if file?.content}
 									<pre
-										class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs">{file.content}</pre>
+										class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs mb-0 mt-2">{file.content}</pre>
 								{/if}
 							</div>
 						{/each}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
@@ -47,11 +47,11 @@
 		{:else}
 			<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-3 rounded-md p-4 shadow-sm">
 				<div class="flex flex-wrap items-baseline gap-2">
-					<h2 class="font-mono text-xl font-semibold">{skill.name}</h2>
-					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
+					<h2 class="text-xl font-semibold">{skill.name}</h2>
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 						{clientLabel}
 					</span>
-					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 font-mono text-xs">
+					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 						{scope}
 					</span>
 					{#if skill.hasScripts}
@@ -66,21 +66,21 @@
 					{/if}
 					{#if skill.gitRemoteURL}
 						<dt class="text-muted-content">Git remote</dt>
-						<dd class="font-mono text-xs break-all">{skill.gitRemoteURL}</dd>
+						<dd class="break-all">{skill.gitRemoteURL}</dd>
 					{/if}
 					{#if skill.file}
 						<dt class="text-muted-content">File</dt>
-						<dd class="font-mono text-xs break-all">{skill.file}</dd>
+						<dd class="break-all">{skill.file}</dd>
 					{/if}
 					{#if skill.projectPath}
 						<dt class="text-muted-content">Project path</dt>
-						<dd class="font-mono text-xs break-all">{skill.projectPath}</dd>
+						<dd class="break-all">{skill.projectPath}</dd>
 					{/if}
 					{#if parentPlugin}
 						<dt class="text-muted-content">Part of plugin</dt>
 						<dd>
 							<a
-								class="text-link font-mono"
+								class="text-link text-sm"
 								href={resolve(
 									`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}/plugins/${parentPlugin.id}`
 								)}
@@ -103,7 +103,7 @@
 								class="dark:bg-base-300 bg-base-100 flex flex-col gap-2 rounded-md p-3 shadow-sm"
 							>
 								<div class="flex flex-wrap items-center gap-2 text-xs">
-									<span class="font-mono break-all">{path}</span>
+									<span class="break-all">{path}</span>
 									{#if file}
 										<span class="text-muted-content">{formatBytes(file.sizeBytes)}</span>
 										{#if file.oversized}
@@ -115,7 +115,7 @@
 								</div>
 								{#if file?.content}
 									<pre
-										class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs">{file.content}</pre>
+										class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs mb-0 mt-2">{file.content}</pre>
 								{/if}
 							</div>
 						{/each}


### PR DESCRIPTION
Addresses #6643 

* remove `font-mono` on elements except for parts displaying commands, `code` or `pre` elements
* consistent font-size on table columns