### PR TITLE
enhance: include cowork skills and plugins in claude desktop scan results

### DIFF
--- a/pkg/devicescan/claudedesktop.go
+++ b/pkg/devicescan/claudedesktop.go
@@ -1,17 +1,17 @@
 package devicescan
 
 import (
+	"io/fs"
+	"path"
 	"strings"
 
 	"github.com/obot-platform/obot/apiclient/types"
 )
 
-// Claude Desktop on-disk layout (macOS only — Windows %APPDATA% is not
-// reachable through os.DirFS rooted at $HOME, so the file simply will
-// not exist there).
 const (
-	claudeDesktopExtRel    = "Library/Application Support/Claude/extensions-installations.json"
-	claudeDesktopConfigRel = "Library/Application Support/Claude/claude_desktop_config.json"
+	claudeDesktopAppSupportDir = "Library/Application Support/Claude"
+	claudeDesktopExtRel        = claudeDesktopAppSupportDir + "/extensions-installations.json"
+	claudeDesktopConfigRel     = claudeDesktopAppSupportDir + "/claude_desktop_config.json"
 )
 
 // claudeDesktopExtensions wraps the top-level `extensions` map in
@@ -22,7 +22,6 @@ type claudeDesktopExtensions struct {
 		Manifest struct {
 			DisplayName string `json:"display_name"`
 			Server      struct {
-				Type       string         `json:"type"`
 				MCPConfig  *mcpServerSpec `json:"mcp_config"`
 				EntryPoint string         `json:"entry_point"`
 			} `json:"server"`
@@ -44,7 +43,7 @@ func (claudeDesktopScanner) Name() string { return "claude_desktop" }
 func (claudeDesktopScanner) Presence() clientPresenceDef {
 	return clientPresenceDef{
 		appBundles:  []string{"Claude.app"},
-		configPaths: []string{"Library/Application Support/Claude", ".config/Claude"},
+		configPaths: []string{claudeDesktopAppSupportDir},
 	}
 }
 
@@ -62,17 +61,36 @@ func (c claudeDesktopScanner) ScanGlobal(s *scanState) []types.DeviceScanMCPServ
 
 func (claudeDesktopScanner) ScanProject(*scanState, string) []types.DeviceScanMCPServer { return nil }
 
-// ScanPlugins emits one DeviceScanPlugin (plugin_type =
-// claude_desktop_connector) per entry in the mcpServers block of
-// claude_desktop_config.json. The MCP server itself is already produced
-// by ScanGlobal — the plugin entry captures the connector as a
-// first-class artifact alongside.
-func (claudeDesktopScanner) ScanPlugins(s *scanState) (
+// ScanPlugins emits three flavors of observation, all tagged
+// client=claude_desktop:
+//
+//  1. One DeviceScanPlugin per Cowork RPM-installed plugin under
+//     local-agent-mode-sessions/<X>/<Y>/rpm/plugin_<id>/, plus its
+//     nested MCP servers (from .mcp.json) and skills.
+//  2. One DeviceScanPlugin per entry in the mcpServers block of
+//     claude_desktop_config.json (plugin_type =
+//     claude_desktop_connector). The MCP server itself is produced by
+//     ScanGlobal; the plugin entry captures the connector as a
+//     first-class artifact alongside.
+//  3. DeviceScanSkills for every skills/<name>/SKILL.md under
+//     local-agent-mode-sessions/skills-plugin/<install-uuid>/<plugin-uuid>/.
+//     Cowork ships these as a bundle (the "anthropic-skills" delivery
+//     vehicle) — there's no .mcp.json, no commands, no hooks; treating
+//     them as a Plugin would inflate the inventory with an empty
+//     wrapper. We surface the skills only.
+func (c claudeDesktopScanner) ScanPlugins(s *scanState) (
 	[]types.DeviceScanPlugin, []types.DeviceScanMCPServer, []types.DeviceScanSkill,
 ) {
+	plugins, servers, skills := c.scanRpmPlugins(s)
+	plugins = append(c.scanConnectors(s), plugins...)
+	skills = append(c.scanSkillsPlugin(s), skills...)
+	return plugins, servers, skills
+}
+
+func (claudeDesktopScanner) scanConnectors(s *scanState) []types.DeviceScanPlugin {
 	cfg, ok := readJSON[claudeDesktopConfig](s.fsys, claudeDesktopConfigRel)
 	if !ok || len(cfg.MCPServers) == 0 {
-		return nil, nil, nil
+		return nil
 	}
 	configAbs := s.addFileOrAbs(claudeDesktopConfigRel)
 
@@ -88,7 +106,170 @@ func (claudeDesktopScanner) ScanPlugins(s *scanState) (
 			HasMCPServers: true,
 		})
 	}
-	return out, nil, nil
+	return out
+}
+
+// claudeDesktopSkillsManifest is the shape of <snapshot>/manifest.json.
+// We only need lastUpdated for active-snapshot selection; per-skill
+// metadata (description, enabled) is already available through SKILL.md
+// frontmatter, which ingestSkill reads.
+type claudeDesktopSkillsManifest struct {
+	LastUpdated int64 `json:"lastUpdated"`
+}
+
+// scanSkillsPlugin enumerates Cowork's persistent skills bundle.
+// Cowork lays it out as
+// <root>/<install-uuid>/<plugin-uuid>/{.claude-plugin/plugin.json,
+// manifest.json, skills/<name>/SKILL.md}. Multiple <install-uuid>
+// snapshots of the same <plugin-uuid> can coexist on disk; we keep
+// only the snapshot with the newest manifest.json:lastUpdated so we
+// don't emit phantom skill rows for stale copies Cowork has left
+// behind.
+//
+// We emit ONLY skill rows here. The wrapping .claude-plugin/plugin.json
+// is a delivery-vehicle manifest (no MCP servers, no commands, no
+// hooks) — treating it as a DeviceScanPlugin would inflate inventory
+// with an empty wrapper. Real Cowork plugins live under rpm/ and are
+// handled by scanRpmPlugins.
+func (claudeDesktopScanner) scanSkillsPlugin(s *scanState) []types.DeviceScanSkill {
+	bundleRoot := path.Join(claudeDesktopAppSupportDir, "local-agent-mode-sessions/skills-plugin")
+	snapshotInstalls, err := fs.ReadDir(s.fsys, bundleRoot)
+	if err != nil {
+		return nil
+	}
+
+	type snapshot struct {
+		installRel  string
+		lastUpdated int64
+	}
+	newestByPluginID := map[string]snapshot{}
+	for _, snapshotInstall := range snapshotInstalls {
+		if !snapshotInstall.IsDir() {
+			continue
+		}
+		pluginDirs, err := fs.ReadDir(s.fsys, path.Join(bundleRoot, snapshotInstall.Name()))
+		if err != nil {
+			continue
+		}
+		for _, pluginDir := range pluginDirs {
+			if !pluginDir.IsDir() {
+				continue
+			}
+			installRel := path.Join(bundleRoot, snapshotInstall.Name(), pluginDir.Name())
+			if !fileExists(s.fsys, path.Join(installRel, ".claude-plugin/plugin.json")) {
+				continue
+			}
+			var lastUpdated int64
+			if manifest, ok := readJSON[claudeDesktopSkillsManifest](s.fsys, path.Join(installRel, "manifest.json")); ok {
+				lastUpdated = manifest.LastUpdated
+			}
+			pluginID := pluginDir.Name()
+			existing, seen := newestByPluginID[pluginID]
+			if !seen || lastUpdated > existing.lastUpdated || (lastUpdated == existing.lastUpdated && installRel < existing.installRel) {
+				newestByPluginID[pluginID] = snapshot{installRel: installRel, lastUpdated: lastUpdated}
+			}
+		}
+	}
+
+	var sks []types.DeviceScanSkill
+	for _, newest := range newestByPluginID {
+		sks = append(sks, emitNestedSkills(s, newest.installRel, "claude_desktop")...)
+	}
+	return sks
+}
+
+// claudeDesktopRpmManifest is the partial shape of rpm/manifest.json
+// we consume. We only read what's not in .claude-plugin/plugin.json:
+// the per-plugin marketplaceName. Everything else (name, version,
+// description, author) comes from plugin.json via emitPlugin.
+type claudeDesktopRpmManifest struct {
+	Plugins []struct {
+		ID              string `json:"id"`
+		MarketplaceName string `json:"marketplaceName"`
+	} `json:"plugins"`
+}
+
+// scanRpmPlugins enumerates Cowork's server-pushed RPM plugin
+// installations. Layout:
+//
+//	<root>/local-agent-mode-sessions/<X>/<Y>/rpm/
+//	    manifest.json                                ← marketplace metadata join
+//	    plugin_<id>/                                  ← install root
+//	        .claude-plugin/plugin.json                ← name, version, description, author
+//	        .mcp.json                                 ← nested MCP servers (optional)
+//	        skills/<name>/SKILL.md                    ← nested skills (optional)
+//	        README.md
+//
+// .claude-plugin/plugin.json is the source of truth for plugin
+// metadata; rpm/manifest.json supplies marketplaceName (joined by
+// plugin id) as enrichment. Install paths are naturally unique across
+// rpm/ trees (each is rooted at a distinct <X>/<Y> session context),
+// so no dedup is needed.
+func (claudeDesktopScanner) scanRpmPlugins(s *scanState) (
+	[]types.DeviceScanPlugin, []types.DeviceScanMCPServer, []types.DeviceScanSkill,
+) {
+	sessionsRoot := path.Join(claudeDesktopAppSupportDir, "local-agent-mode-sessions")
+	outerSessionDirs, err := fs.ReadDir(s.fsys, sessionsRoot)
+	if err != nil {
+		return nil, nil, nil
+	}
+
+	var (
+		ps  []types.DeviceScanPlugin
+		ms  []types.DeviceScanMCPServer
+		sks []types.DeviceScanSkill
+	)
+	for _, outerSession := range outerSessionDirs {
+		if !outerSession.IsDir() || outerSession.Name() == "skills-plugin" {
+			continue
+		}
+		innerSessionDirs, err := fs.ReadDir(s.fsys, path.Join(sessionsRoot, outerSession.Name()))
+		if err != nil {
+			continue
+		}
+		for _, innerSession := range innerSessionDirs {
+			if !innerSession.IsDir() {
+				continue
+			}
+			rpmRoot := path.Join(sessionsRoot, outerSession.Name(), innerSession.Name(), "rpm")
+			pluginDirs, err := fs.ReadDir(s.fsys, rpmRoot)
+			if err != nil {
+				continue
+			}
+			marketplaceByPluginID := map[string]string{}
+			if manifest, ok := readJSON[claudeDesktopRpmManifest](s.fsys, path.Join(rpmRoot, "manifest.json")); ok {
+				for _, p := range manifest.Plugins {
+					if p.ID != "" && p.MarketplaceName != "" {
+						marketplaceByPluginID[p.ID] = p.MarketplaceName
+					}
+				}
+			}
+			for _, pluginDir := range pluginDirs {
+				if !pluginDir.IsDir() || !strings.HasPrefix(pluginDir.Name(), "plugin_") {
+					continue
+				}
+				installRel := path.Join(rpmRoot, pluginDir.Name())
+				if !fileExists(s.fsys, path.Join(installRel, ".claude-plugin/plugin.json")) {
+					// Half-written snapshot or non-install dir. Skip.
+					continue
+				}
+				ep := emitPlugin(s, emitPluginOpts{
+					installRel:   installRel,
+					manifestRel:  path.Join(installRel, ".claude-plugin/plugin.json"),
+					pluginType:   "claude_desktop_plugin",
+					client:       "claude_desktop",
+					marketplace:  marketplaceByPluginID[pluginDir.Name()],
+					enabled:      true,
+					nameFallback: pluginDir.Name(), // "plugin_<id>" when plugin.json lacks name
+					nestedMCPRel: []string{".mcp.json"},
+				})
+				ps = append(ps, ep.plugin)
+				ms = append(ms, ep.servers...)
+				sks = append(sks, ep.skills...)
+			}
+		}
+	}
+	return ps, ms, sks
 }
 
 func scanClaudeDesktopExtensions(s *scanState) []types.DeviceScanMCPServer {
@@ -100,60 +281,39 @@ func scanClaudeDesktopExtensions(s *scanState) []types.DeviceScanMCPServer {
 
 	out := make([]types.DeviceScanMCPServer, 0, len(cfg.Extensions))
 	for name, ext := range cfg.Extensions {
-		out = append(out, claudeDesktopExtensionToServer(name, ext, configAbs))
+		displayName := name
+		if ext.Manifest.DisplayName != "" {
+			displayName = ext.Manifest.DisplayName
+		}
+
+		var (
+			command string
+			args    []string
+			env     map[string]any
+		)
+		if mc := ext.Manifest.Server.MCPConfig; mc != nil {
+			command = mc.Command
+			args = mc.Args
+			env = mc.Env
+		} else if ep := ext.Manifest.Server.EntryPoint; ep != "" {
+			parts := strings.Fields(ep)
+			if len(parts) > 0 {
+				command = parts[0]
+				args = parts[1:]
+			}
+		}
+
+		out = append(out, types.DeviceScanMCPServer{
+			Client:     "claude_desktop",
+			File:       configAbs,
+			Name:       displayName,
+			Transport:  "stdio",
+			Command:    command,
+			Args:       args,
+			EnvKeys:    sortedMapKeys(env),
+			HeaderKeys: []string{},
+			ConfigHash: mcpConfigHash(displayName, "stdio", command, args, ""),
+		})
 	}
 	return out
-}
-
-func claudeDesktopExtensionToServer(name string, ext struct {
-	Manifest struct {
-		DisplayName string `json:"display_name"`
-		Server      struct {
-			Type       string         `json:"type"`
-			MCPConfig  *mcpServerSpec `json:"mcp_config"`
-			EntryPoint string         `json:"entry_point"`
-		} `json:"server"`
-	} `json:"manifest"`
-}, configAbs string) types.DeviceScanMCPServer {
-	displayName := name
-	if ext.Manifest.DisplayName != "" {
-		displayName = ext.Manifest.DisplayName
-	}
-
-	transport := ext.Manifest.Server.Type
-	if transport == "" {
-		transport = "stdio"
-	}
-	if transport == "node" {
-		transport = "stdio"
-	}
-
-	var (
-		command string
-		args    []string
-		env     map[string]any
-	)
-	if mc := ext.Manifest.Server.MCPConfig; mc != nil {
-		command = mc.Command
-		args = mc.Args
-		env = mc.Env
-	} else if ep := ext.Manifest.Server.EntryPoint; ep != "" {
-		parts := strings.Fields(ep)
-		if len(parts) > 0 {
-			command = parts[0]
-			args = parts[1:]
-		}
-	}
-
-	return types.DeviceScanMCPServer{
-		Client:     "claude_desktop",
-		File:       configAbs,
-		Name:       displayName,
-		Transport:  transport,
-		Command:    command,
-		Args:       args,
-		EnvKeys:    sortedMapKeys(env),
-		HeaderKeys: []string{},
-		ConfigHash: mcpConfigHash(displayName, transport, command, args, ""),
-	}
 }

--- a/pkg/devicescan/claudedesktop_test.go
+++ b/pkg/devicescan/claudedesktop_test.go
@@ -1,0 +1,113 @@
+package devicescan
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClaudeDesktopScanSkillsPlugin covers the Cowork skills-plugin
+// scan: two snapshots of the same plugin-uuid (older and newer
+// manifest.json:lastUpdated) plus an ephemeral session sibling. The
+// active snapshot wins; the ephemeral sibling is ignored entirely.
+//
+// The skills-plugin bundle is intentionally NOT surfaced as a plugin
+// row — it's a delivery vehicle for bundled skills, not a plugin in
+// the sense of MCP servers/commands/hooks. Only skill rows are
+// emitted; real plugins come through scanRpmPlugins.
+func TestClaudeDesktopScanSkillsPlugin(t *testing.T) {
+	sessionsDir := path.Join(claudeDesktopAppSupportDir, "local-agent-mode-sessions")
+	skillsPluginDir := path.Join(sessionsDir, "skills-plugin")
+	installA := path.Join(skillsPluginDir, "install-a", "plugin-x")
+	installB := path.Join(skillsPluginDir, "install-b", "plugin-x")
+	ephemeralDir := path.Join(sessionsDir, "session-uuid", "inner-uuid", "local_abc")
+
+	pluginManifest := `{"name":"anthropic-skills","version":"1.0.0","description":"Bundled skills"}`
+	skillNewer := "---\nname: foo\ndescription: newer copy\n---\nbody\n"
+	skillOlder := "---\nname: foo\ndescription: older copy\n---\nbody\n"
+	skillEphemeral := "---\nname: bad\ndescription: ephemeral\n---\nbody\n"
+
+	scan := runScanFS(t, map[string]string{
+		// Newer snapshot (lastUpdated=2000).
+		path.Join(installA, ".claude-plugin", "plugin.json"): pluginManifest,
+		path.Join(installA, "manifest.json"):                 `{"lastUpdated":2000}`,
+		path.Join(installA, "skills", "foo", "SKILL.md"):     skillNewer,
+		// Older snapshot of the same plugin-uuid (lastUpdated=1000).
+		path.Join(installB, ".claude-plugin", "plugin.json"): pluginManifest,
+		path.Join(installB, "manifest.json"):                 `{"lastUpdated":1000}`,
+		path.Join(installB, "skills", "foo", "SKILL.md"):     skillOlder,
+		// Ephemeral session sandbox — must not produce any rows.
+		path.Join(ephemeralDir, ".claude", "skills", "bad", "SKILL.md"): skillEphemeral,
+	})
+
+	require.Len(t, scan.Plugins, 0)
+	require.Len(t, scan.Skills, 1)
+
+	skill := scan.Skills[0]
+	require.Equal(t, "foo", skill.Name)
+	require.Equal(t, "newer copy", skill.Description, "active snapshot should win")
+}
+
+// TestClaudeDesktopScanRpmPlugin covers Cowork's RPM (server-pushed)
+// plugin scan. Fixture mirrors a real install: a plugin_<id>/ with
+// .claude-plugin/plugin.json, .mcp.json (HTTP transport), a nested
+// skill, and a sibling rpm/manifest.json carrying the marketplace name.
+// Plugin name/version/description/author come from plugin.json;
+// Marketplace comes from rpm/manifest.json joined by plugin id.
+func TestClaudeDesktopScanRpmPlugin(t *testing.T) {
+	// The two UUID levels under local-agent-mode-sessions/ are opaque
+	// (one is the account/user id, the other the org id, in an order
+	// that has varied between Cowork versions). The scanner treats them
+	// as opaque, so we use stand-in labels.
+	rpmDir := path.Join(claudeDesktopAppSupportDir, "local-agent-mode-sessions", "outerUUID", "innerUUID", "rpm")
+	pluginID := "plugin_01XXJmxLXPEhPMmnxmrgntNw"
+	installDir := path.Join(rpmDir, pluginID)
+
+	// Note: rpm/manifest.json's plugins[].name is intentionally a decoy —
+	// the scanner sources Name from .claude-plugin/plugin.json, and only
+	// reads this file for marketplaceName joined by plugin id. If a
+	// refactor ever starts pulling Name from here, the assertion below
+	// will catch it.
+	rpmManifest := `{
+		"lastUpdated": 1779337664941,
+		"plugins": [{
+			"id": "` + pluginID + `",
+			"name": "design-from-rpm-manifest",
+			"marketplaceId": "marketplace_01QRn9XAjzzeAokB5nPWVMxP",
+			"marketplaceName": "knowledge-work-plugins",
+			"installedBy": "user"
+		}]
+	}`
+	pluginManifest := `{"name":"design","version":"1.2.0","description":"Design workflows","author":{"name":"Anthropic"}}`
+	mcpConfig := `{"mcpServers":{"figma":{"type":"http","url":"https://mcp.figma.com/mcp"}}}`
+	skillBody := "---\nname: design-critique\ndescription: Get structured design feedback\n---\nbody\n"
+
+	scan := runScanFS(t, map[string]string{
+		path.Join(rpmDir, "manifest.json"):                             rpmManifest,
+		path.Join(installDir, ".claude-plugin", "plugin.json"):         pluginManifest,
+		path.Join(installDir, ".mcp.json"):                             mcpConfig,
+		path.Join(installDir, "skills", "design-critique", "SKILL.md"): skillBody,
+	})
+
+	require.Len(t, scan.Plugins, 1)
+
+	plugin := scan.Plugins[0]
+	require.Equal(t, "design", plugin.Name, "should come from .claude-plugin/plugin.json, not rpm/manifest.json or opaque dir name")
+	require.Equal(t, "1.2.0", plugin.Version)
+	require.Equal(t, "Design workflows", plugin.Description)
+	require.Equal(t, "Anthropic", plugin.Author)
+	require.Equal(t, "knowledge-work-plugins", plugin.Marketplace, "should come from rpm/manifest.json")
+	require.True(t, plugin.HasMCPServers)
+	require.True(t, plugin.HasSkills)
+
+	require.Len(t, scan.MCPServers, 1)
+
+	server := scan.MCPServers[0]
+	require.Equal(t, "figma", server.Name)
+	require.Equal(t, "http", server.Transport)
+	require.Equal(t, "https://mcp.figma.com/mcp", server.URL)
+
+	require.Len(t, scan.Skills, 1)
+	require.Equal(t, "design-critique", scan.Skills[0].Name)
+}


### PR DESCRIPTION
Scan `~/Library/Application Support/Claude/local-agent-mode-sessions` for cowork skills and plugins.

