### PR TITLE
enhance: expose obot-mcp-server to external traffic

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,7 +51,7 @@ brews:
     install: |
       bin.install "obot"
     homepage: "https://github.com/obot-platform/obot"
-    skip_upload: false
+    skip_upload: auto
     directory: "Formula"
     repository:
       owner: obot-platform

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1030,6 +1030,13 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 // MCPIDAndAudienceFromConnectURL returns the MCP server or instance name and audience based on the provided connect URL.
 // The connect URL could have an MCP server ID, server instance ID, or MCP catalog entry ID.
 func MCPIDAndAudienceFromConnectURL(req api.Context, id string) (string, string, error) {
+	if system.IsSystemMCPServerID(id) {
+		if system.IsExternallyAccessibleSystemMCPServerID(id) {
+			return id, id, nil
+		}
+		return "", "", types.NewErrNotFound("system MCP server %s is not externally accessible", id)
+	}
+
 	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id)
 	if err != nil {
 		return "", "", err

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -124,6 +124,10 @@ func (h *Handler) ensureServerIsDeployed(req api.Context) (mcp.ServerConfig, str
 }
 
 func (h *Handler) ensureSystemServerIsDeployed(req api.Context, mcpID string) (mcp.ServerConfig, string, bool, error) {
+	if !system.IsProxyableSystemMCPServerID(mcpID) {
+		return mcp.ServerConfig{}, "", false, apierrors.NewNotFound(schema.GroupResource{Group: "obot.obot.ai", Resource: "systemmcpserver"}, mcpID)
+	}
+
 	var systemServer v1.SystemMCPServer
 	if err := req.Get(&systemServer, mcpID); err != nil {
 		return mcp.ServerConfig{}, "", false, fmt.Errorf("failed to get system MCP server %q: %w", mcpID, err)

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -194,6 +194,14 @@ func (h *handler) authorize(req api.Context) error {
 			return nil
 		}
 	}
+	if system.IsSystemMCPServerID(mcpID) && !system.IsExternallyAccessibleSystemMCPServerID(mcpID) {
+		redirectWithAuthorizeError(req, redirectURI, Error{
+			Code:        ErrAccessDenied,
+			Description: fmt.Sprintf("system MCP server %s is not externally accessible", mcpID),
+			State:       state,
+		})
+		return nil
+	}
 
 	if mcpID == "" {
 		redirectWithAuthorizeError(req, redirectURI, Error{

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -24,10 +24,12 @@ import (
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/proxy"
 	"github.com/obot-platform/obot/pkg/storage"
+	"github.com/obot-platform/obot/pkg/system"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 var log = logger.Package()
@@ -183,6 +185,11 @@ func (s *Server) Wrap(f api.HandlerFunc) http.HandlerFunc {
 			}
 		}
 
+		if isAnonymousRequestForNonExternalSystemMCPServer(req, user) {
+			http.NotFound(rw, req)
+			return
+		}
+
 		if !s.authorizer.Authorize(req, user) {
 			if _, err := req.Cookie(auth.ObotAccessTokenCookie); err == nil && req.URL.Path == "/api/me" {
 				// Tell the browser to delete the obot_access_token cookie.
@@ -244,6 +251,15 @@ func (s *Server) Wrap(f api.HandlerFunc) http.HandlerFunc {
 			log.Errorf("Error handling request for %s: %v", req.URL.Path, err)
 		}
 	}
+}
+
+func isAnonymousRequestForNonExternalSystemMCPServer(req *http.Request, user user.Info) bool {
+	if user.GetUID() != "anonymous" || !strings.HasPrefix(req.URL.Path, "/mcp-connect/") {
+		return false
+	}
+
+	mcpID := req.PathValue("mcp_id")
+	return system.IsSystemMCPServerID(mcpID) && !system.IsExternallyAccessibleSystemMCPServerID(mcpID)
 }
 
 type headersResponseWriter struct {

--- a/pkg/api/server/server_test.go
+++ b/pkg/api/server/server_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/api/authn"
+	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/obot-platform/obot/pkg/api/server/ratelimiter"
+	"github.com/obot-platform/obot/pkg/system"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestWrapAnonymousSystemMCPServerChallengeOnlyForExternallyAccessibleServers(t *testing.T) {
+	limiter, err := ratelimiter.New(ratelimiter.Options{
+		UnauthenticatedRateLimit: 100,
+		AuthenticatedRateLimit:   100,
+	})
+	if err != nil {
+		t.Fatalf("failed to create rate limiter: %v", err)
+	}
+
+	s := &Server{
+		authenticator: authn.NewAuthenticator(authenticator.RequestFunc(func(*http.Request) (*authenticator.Response, bool, error) {
+			return &authenticator.Response{
+				User: &user.DefaultInfo{
+					Name:   "anonymous",
+					UID:    "anonymous",
+					Groups: []string{authz.UnauthenticatedGroup},
+				},
+			}, true, nil
+		})),
+		authorizer:    authz.NewAuthorizer(nil, nil, false, nil, false),
+		rateLimiter:   limiter,
+		baseURL:       "https://obot.example.com/api",
+		mcpOAuthScope: `, scope="profile"`,
+	}
+
+	tests := []struct {
+		name          string
+		mcpID         string
+		wantStatus    int
+		wantChallenge bool
+	}{
+		{
+			name:          "obot system MCP server gets OAuth challenge",
+			mcpID:         system.ObotMCPServerName,
+			wantStatus:    http.StatusUnauthorized,
+			wantChallenge: true,
+		},
+		{
+			name:       "other system MCP server is hidden",
+			mcpID:      system.SystemMCPServerPrefix + "other",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "webhook system MCP server is hidden",
+			mcpID:      system.SystemMCPServerPrefix + system.MCPWebhookValidationPrefix + "test",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/mcp-connect/"+tt.mcpID, nil)
+			resp := httptest.NewRecorder()
+			mux := http.NewServeMux()
+			mux.Handle("/mcp-connect/{mcp_id}", s.Wrap(func(api.Context) error {
+				t.Fatal("handler should not be called for anonymous MCP connect requests")
+				return nil
+			}))
+
+			mux.ServeHTTP(resp, req)
+
+			if resp.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.Code, tt.wantStatus)
+			}
+
+			challenge := resp.Header().Get("WWW-Authenticate")
+			if tt.wantChallenge {
+				if !strings.Contains(challenge, `resource_metadata="https://obot.example.com/.well-known/oauth-protected-resource/mcp-connect/`+tt.mcpID+`"`) {
+					t.Fatalf("WWW-Authenticate = %q, want resource metadata for %s", challenge, tt.mcpID)
+				}
+				if !strings.Contains(challenge, `scope="profile"`) {
+					t.Fatalf("WWW-Authenticate = %q, want profile scope", challenge)
+				}
+			} else if challenge != "" {
+				t.Fatalf("WWW-Authenticate = %q, want empty", challenge)
+			}
+		})
+	}
+}

--- a/pkg/system/ids.go
+++ b/pkg/system/ids.go
@@ -65,6 +65,14 @@ func IsSystemMCPServerID(id string) bool {
 	return strings.HasPrefix(id, SystemMCPServerPrefix)
 }
 
+func IsExternallyAccessibleSystemMCPServerID(id string) bool {
+	return id == ObotMCPServerName
+}
+
+func IsProxyableSystemMCPServerID(id string) bool {
+	return IsExternallyAccessibleSystemMCPServerID(id) || IsWebhookSystemMCPServerID(id)
+}
+
 func IsWebhookSystemMCPServerID(id string) bool {
 	return strings.HasPrefix(id, SystemMCPServerPrefix+MCPWebhookValidationPrefix)
 }

--- a/pkg/system/ids_test.go
+++ b/pkg/system/ids_test.go
@@ -1,0 +1,55 @@
+package system
+
+import "testing"
+
+func TestSystemMCPServerAccessPolicies(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        string
+		external  bool
+		proxyable bool
+		webhook   bool
+		systemMCP bool
+	}{
+		{
+			name:      "obot mcp server",
+			id:        ObotMCPServerName,
+			external:  true,
+			proxyable: true,
+			systemMCP: true,
+		},
+		{
+			name:      "webhook validation system server",
+			id:        SystemMCPServerPrefix + MCPWebhookValidationPrefix + "test",
+			proxyable: true,
+			webhook:   true,
+			systemMCP: true,
+		},
+		{
+			name:      "other system server",
+			id:        SystemMCPServerPrefix + "other",
+			systemMCP: true,
+		},
+		{
+			name: "regular mcp server",
+			id:   MCPServerPrefix + "regular",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSystemMCPServerID(tt.id); got != tt.systemMCP {
+				t.Fatalf("IsSystemMCPServerID(%q) = %v, want %v", tt.id, got, tt.systemMCP)
+			}
+			if got := IsWebhookSystemMCPServerID(tt.id); got != tt.webhook {
+				t.Fatalf("IsWebhookSystemMCPServerID(%q) = %v, want %v", tt.id, got, tt.webhook)
+			}
+			if got := IsExternallyAccessibleSystemMCPServerID(tt.id); got != tt.external {
+				t.Fatalf("IsExternallyAccessibleSystemMCPServerID(%q) = %v, want %v", tt.id, got, tt.external)
+			}
+			if got := IsProxyableSystemMCPServerID(tt.id); got != tt.proxyable {
+				t.Fatalf("IsProxyableSystemMCPServerID(%q) = %v, want %v", tt.id, got, tt.proxyable)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows clients other than Nanobot Agents to connect to the obot-mcp-server. This will be useful for local agents to query for and configure MCP servers, and then set them up locally using the Obot CLI (a future change).

I made sure that webhook/filter SystemMCPServers still work properly. I tested this in both Docker and Kubernetes just to be extra safe.

This should not merge until after the release.