### PR TITLE
fix: include defaults when hashing Kubernetes settings

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -63,12 +63,20 @@ func (m *MCPHandler) currentImagePullSecretNames(req api.Context) ([]string, err
 	return mcp.CurrentImagePullSecretNames(req.Context(), req.Storage, m.mcpSessionManager.MCPRuntimeBackend(), m.mcpImagePullSecrets)
 }
 
-func (m *MCPHandler) currentK8sSettingsHash(req api.Context, settings v1.K8sSettingsSpec, serverRuntime types.Runtime, nanobotAgentServer bool) (string, error) {
+func (m *MCPHandler) currentK8sSettingsHash(req api.Context, settings v1.K8sSettingsSpec, mcpServer v1.MCPServer) (string, error) {
 	imagePullSecretNames, err := m.currentImagePullSecretNames(req)
 	if err != nil {
 		return "", err
 	}
-	return mcp.ComputeK8sSettingsHash(settings, serverRuntime, nanobotAgentServer, imagePullSecretNames), nil
+	return m.currentK8sSettingsHashWithImagePullSecrets(settings, mcpServer, imagePullSecretNames)
+}
+
+func (m *MCPHandler) currentK8sSettingsHashWithImagePullSecrets(settings v1.K8sSettingsSpec, mcpServer v1.MCPServer, imagePullSecretNames []string) (string, error) {
+	resources, err := mcp.CoreResourceRequirements(mcpServer.Spec.Manifest.Resources)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute core resource requirements: %w", err)
+	}
+	return mcp.ComputeK8sSettingsHash(settings, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", imagePullSecretNames), nil
 }
 
 func (m *MCPHandler) GetEntryFromAllSources(req api.Context) error {
@@ -3197,7 +3205,7 @@ func (m *MCPHandler) CheckK8sSettingsStatus(req api.Context) error {
 		return err
 	}
 
-	currentHash, err := m.currentK8sSettingsHash(req, k8sSettings.Spec, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "")
+	currentHash, err := m.currentK8sSettingsHash(req, k8sSettings.Spec, server)
 	if err != nil {
 		return err
 	}
@@ -3268,7 +3276,7 @@ func (m *MCPHandler) RedeployWithK8sSettings(req api.Context) error {
 		return err
 	}
 
-	currentHash, err := m.currentK8sSettingsHash(req, k8sSettings.Spec, serverConfig.Runtime, serverConfig.NanobotAgentName != "")
+	currentHash, err := m.currentK8sSettingsHash(req, k8sSettings.Spec, server)
 	if err != nil {
 		return err
 	}
@@ -3394,7 +3402,11 @@ func (m *MCPHandler) ListServersNeedingK8sUpdateInCatalog(req api.Context) error
 		}
 
 		// Check if hash differs from current settings
-		currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "", imagePullSecretNames)
+		currentHash, err := m.currentK8sSettingsHashWithImagePullSecrets(k8sSettings.Spec, server, imagePullSecretNames)
+		if err != nil {
+			return err
+		}
+
 		if server.Status.K8sSettingsHash != currentHash {
 			serversNeedingUpdate = append(serversNeedingUpdate, types.MCPServerNeedingK8sUpdate{
 				MCPServerID:             server.Name,
@@ -3457,7 +3469,11 @@ func (m *MCPHandler) ListServersNeedingK8sUpdateAcrossWorkspaces(req api.Context
 		}
 
 		// Check if hash differs from current settings
-		currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "", imagePullSecretNames)
+		currentHash, err := m.currentK8sSettingsHashWithImagePullSecrets(k8sSettings.Spec, server, imagePullSecretNames)
+		if err != nil {
+			return err
+		}
+
 		if server.Status.K8sSettingsHash != currentHash {
 			serversNeedingUpdate = append(serversNeedingUpdate, types.MCPServerNeedingK8sUpdate{
 				MCPServerID:             server.Name,

--- a/pkg/controller/handlers/deployment/deployment.go
+++ b/pkg/controller/handlers/deployment/deployment.go
@@ -129,7 +129,13 @@ func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) e
 			if err != nil {
 				return err
 			}
-			currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", imagePullSecretNames)
+
+			resources, err := mcp.CoreResourceRequirements(mcpServer.Spec.Manifest.Resources)
+			if err != nil {
+				return fmt.Errorf("failed to compute core resource requirements: %w", err)
+			}
+
+			currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", imagePullSecretNames)
 
 			shouldSetNeedsK8sUpdate := !mcpServer.Status.NeedsK8sUpdate &&
 				k8sSettingsHash != currentHash &&

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -237,7 +237,12 @@ func (h *Handler) DetectK8sSettingsDrift(req router.Request, _ router.Response) 
 		return err
 	}
 
-	currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "", imagePullSecretNames)
+	resources, err := mcp.CoreResourceRequirements(server.Spec.Manifest.Resources)
+	if err != nil {
+		return fmt.Errorf("failed to compute core resource requirements: %w", err)
+	}
+
+	currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "", imagePullSecretNames)
 	shouldSetNeedsK8sUpdate := server.Status.K8sSettingsHash != currentHash && !server.Status.NeedsK8sUpdate
 
 	if shouldSetNeedsK8sUpdate {

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -517,7 +517,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 		return nil, fmt.Errorf("failed to get effective image pull secrets: %w", err)
 	}
 
-	annotations["obot.ai/k8s-settings-hash"] = ComputeK8sSettingsHash(k8sSettings, server.Runtime, server.NanobotAgentName != "", effectiveImagePullSecrets)
+	annotations["obot.ai/k8s-settings-hash"] = ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", effectiveImagePullSecrets)
 
 	// Get PSA enforce level for security context decisions
 	psaLevel := GetPSAEnforceLevelFromSpec(k8sSettings)
@@ -713,7 +713,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 			Name:          portName,
 			ContainerPort: int32(port),
 		}},
-		Resources:       mcpContainerResources(server, k8sSettings),
+		Resources:       mcpContainerResources(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings),
 		SecurityContext: getContainerSecurityContext(psaLevel),
 		Command:         command,
 		Args:            args,
@@ -1123,11 +1123,11 @@ func (k *kubernetesBackend) deleteDeploymentCache(mcpServerName string) {
 	delete(k.deploymentCache, mcpServerName)
 }
 
-func mcpContainerResources(server ServerConfig, k8sSettings v1.K8sSettingsSpec) corev1.ResourceRequirements {
+func mcpContainerResources(serverSpecificResources *corev1.ResourceRequirements, runtime types.Runtime, nanobotAgent bool, k8sSettings v1.K8sSettingsSpec) corev1.ResourceRequirements {
 	var defaults corev1.ResourceRequirements
-	if server.Runtime == types.RuntimeRemote {
+	if runtime == types.RuntimeRemote {
 		defaults = memoryRequestResources(remoteMemoryRequest)
-	} else if server.NanobotAgentName != "" {
+	} else if nanobotAgent {
 		if k8sSettings.NanobotAgentResources != nil {
 			defaults = withDefaultCPURequest(*k8sSettings.NanobotAgentResources)
 		} else {
@@ -1139,11 +1139,11 @@ func mcpContainerResources(server ServerConfig, k8sSettings v1.K8sSettingsSpec) 
 		defaults = memoryRequestResources(defaultMCPMemoryRequest)
 	}
 
-	return withServerResourceOverrides(defaults, server.Resources)
+	return withServerResourceOverrides(defaults, serverSpecificResources)
 }
 
-func withServerResourceOverrides(defaults, overrides corev1.ResourceRequirements) corev1.ResourceRequirements {
-	if len(overrides.Requests) == 0 && len(overrides.Limits) == 0 {
+func withServerResourceOverrides(defaults corev1.ResourceRequirements, overrides *corev1.ResourceRequirements) corev1.ResourceRequirements {
+	if overrides == nil || len(overrides.Requests) == 0 && len(overrides.Limits) == 0 {
 		return defaults
 	}
 
@@ -1197,8 +1197,8 @@ func (k *kubernetesBackend) restartServer(ctx context.Context, server ServerConf
 	}
 
 	// Compute K8s settings hash
-	k8sSettingsHash := ComputeK8sSettingsHash(k8sSettings, server.Runtime, server.NanobotAgentName != "", effectiveImagePullSecrets)
-	desiredResources := mcpContainerResources(server, k8sSettings)
+	k8sSettingsHash := ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", effectiveImagePullSecrets)
+	desiredResources := mcpContainerResources(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings)
 
 	// Get PSA enforce level for security context decisions
 	psaLevel := GetPSAEnforceLevelFromSpec(k8sSettings)
@@ -1537,16 +1537,14 @@ func (k *kubernetesBackend) patchDeploymentHash(ctx context.Context, deployment 
 // allowed because some Kubernetes environments mutate resource requirements
 // after admission, for example GKE Autopilot adding ephemeral-storage.
 func resourcesMatch(actual corev1.ResourceRequirements, desired *corev1.ResourceRequirements) bool {
-	desiredResources := desiredMCPResourceRequirements(v1.K8sSettingsSpec{Resources: desired})
-
-	for resourceName, desiredQty := range desiredResources.Limits {
+	for resourceName, desiredQty := range desired.Limits {
 		actualQty, exists := actual.Limits[resourceName]
 		if !exists || !actualQty.Equal(desiredQty) {
 			return false
 		}
 	}
 
-	for resourceName, desiredQty := range desiredResources.Requests {
+	for resourceName, desiredQty := range desired.Requests {
 		actualQty, exists := actual.Requests[resourceName]
 		if !exists || !actualQty.Equal(desiredQty) {
 			return false
@@ -1569,21 +1567,6 @@ func stringValue(value *string) string {
 		return ""
 	}
 	return *value
-}
-
-func desiredMCPResourceRequirements(settings v1.K8sSettingsSpec) corev1.ResourceRequirements {
-	if settings.Resources != nil {
-		return *settings.Resources
-	}
-	return defaultMCPResourceRequirements()
-}
-
-func defaultMCPResourceRequirements() corev1.ResourceRequirements {
-	return corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("400Mi"),
-		},
-	}
 }
 
 // runtimeClassNameMatches checks if the runtime class names match
@@ -1813,7 +1796,7 @@ func getPodSecurityContextPatch(psaLevel PSAEnforceLevel) map[string]any {
 // MCP Deployment needs to be updated. The API/status field is still named
 // K8sSettingsHash, but managed image pull secret names are part of the same
 // v1 drift path.
-func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverRuntime types.Runtime, nanobotAgentServer bool, imagePullSecretNames []string) string {
+func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverSpecificResources *corev1.ResourceRequirements, serverRuntime types.Runtime, nanobotAgentServer bool, imagePullSecretNames []string) string {
 	var buf bytes.Buffer
 
 	// Hash affinity
@@ -1828,12 +1811,9 @@ func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverRuntime types.Run
 		buf.Write(tolerationsJSON)
 	}
 
-	// Hash resources for regular MCP server pods. Remote servers use fixed shim resources,
-	// and nanobot-agent-backed servers use NanobotAgentResources instead.
-	if serverRuntime != types.RuntimeRemote && !nanobotAgentServer && settings.Resources != nil {
-		resourcesJSON, _ := json.Marshal(settings.Resources)
-		buf.Write(resourcesJSON)
-	}
+	// Resources are server specific
+	// Ignoring errors from JSON encoding since the inputs are well-defined structs that should always marshal successfully
+	_ = json.NewEncoder(&buf).Encode(mcpContainerResources(serverSpecificResources, serverRuntime, nanobotAgentServer, settings))
 
 	// Hash runtimeClassName
 	if settings.RuntimeClassName != nil && *settings.RuntimeClassName != "" {
@@ -1847,10 +1827,6 @@ func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverRuntime types.Run
 
 	// Hash nanobot-only settings
 	if nanobotAgentServer {
-		if settings.NanobotAgentResources != nil {
-			resourcesJSON, _ := json.Marshal(settings.NanobotAgentResources)
-			buf.Write(resourcesJSON)
-		}
 		if settings.NanobotWorkspaceSize != "" {
 			buf.WriteString(settings.NanobotWorkspaceSize)
 		}
@@ -2071,7 +2047,7 @@ func (k *kubernetesBackend) CheckCapacity(ctx context.Context, server ServerConf
 
 	memoryRequest := resource.MustParse("0")
 	cpuRequest := resource.MustParse("0")
-	resources := mcpContainerResources(server, k8sSettings)
+	resources := mcpContainerResources(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings)
 	if mem, ok := resources.Requests[corev1.ResourceMemory]; ok {
 		memoryRequest = mem
 	}

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -43,36 +43,47 @@ func TestComputeK8sSettingsHashUsesServerSpecificResources(t *testing.T) {
 		},
 	}
 
-	baseHash := ComputeK8sSettingsHash(baseSettings, types.RuntimeNPX, false, nil)
-	if got := ComputeK8sSettingsHash(resourceSettings, types.RuntimeNPX, false, nil); got == baseHash {
-		t.Fatalf("regular server hash = %s, want it to differ when resources are set", got)
+	baseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeNPX, false, nil)
+	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, false, nil); got == baseHash {
+		t.Fatalf("regular server hash = %s, want it to differ when default resources are set", got)
 	}
-	if got := ComputeK8sSettingsHash(resourceSettings, types.RuntimeRemote, false, nil); got != baseHash {
-		t.Fatalf("remote server hash = %s, want %s", got, baseHash)
+
+	remoteBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeRemote, false, nil)
+	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeRemote, false, nil); got != remoteBaseHash {
+		t.Fatalf("remote server hash = %s, want %s", got, remoteBaseHash)
 	}
-	if got := ComputeK8sSettingsHash(resourceSettings, types.RuntimeNPX, true, nil); got != baseHash {
-		t.Fatalf("nanobot agent server hash = %s, want %s before nanobot-only settings are set", got, baseHash)
+
+	nanobotBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeNPX, true, nil)
+	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, true, nil); got != nanobotBaseHash {
+		t.Fatalf("nanobot agent server hash = %s, want %s before nanobot-only settings are set", got, nanobotBaseHash)
 	}
-	if got := ComputeK8sSettingsHash(nanobotSettings, types.RuntimeNPX, false, nil); got != ComputeK8sSettingsHash(resourceSettings, types.RuntimeNPX, false, nil) {
+	if got := ComputeK8sSettingsHash(nanobotSettings, nil, types.RuntimeNPX, false, nil); got != ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, false, nil) {
 		t.Fatalf("non-nanobot hash = %s, want nanobot-only settings ignored", got)
 	}
-	if got := ComputeK8sSettingsHash(nanobotSettings, types.RuntimeNPX, true, nil); got == baseHash {
+	if got := ComputeK8sSettingsHash(nanobotSettings, nil, types.RuntimeNPX, true, nil); got == nanobotBaseHash {
 		t.Fatalf("nanobot hash = %s, want it to differ when nanobot-only settings are set", got)
+	}
+
+	serverResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("768Mi"),
+		},
+	}
+	if got := ComputeK8sSettingsHash(baseSettings, serverResources, types.RuntimeNPX, false, nil); got == baseHash {
+		t.Fatalf("server-specific resources hash = %s, want it to differ from default resource hash", got)
 	}
 }
 
 func TestMCPContainerResourcesAppliesServerOverridesWithRequestDefaults(t *testing.T) {
-	resources := mcpContainerResources(ServerConfig{
-		Runtime: types.RuntimeNPX,
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse("1"),
-			},
+	serverResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
 		},
-	}, v1.K8sSettingsSpec{})
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("1"),
+		},
+	}
+	resources := mcpContainerResources(serverResources, types.RuntimeNPX, false, v1.K8sSettingsSpec{})
 
 	if got, want := resources.Requests[corev1.ResourceMemory], resource.MustParse("512Mi"); got.Cmp(want) != 0 {
 		t.Fatalf("memory request = %s, want %s", got.String(), want.String())
@@ -86,14 +97,12 @@ func TestMCPContainerResourcesAppliesServerOverridesWithRequestDefaults(t *testi
 }
 
 func TestMCPContainerResourcesAppliesServerCPURequestWithMemoryDefault(t *testing.T) {
-	resources := mcpContainerResources(ServerConfig{
-		Runtime: types.RuntimeNPX,
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU: resource.MustParse("250m"),
-			},
+	serverResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("250m"),
 		},
-	}, v1.K8sSettingsSpec{})
+	}
+	resources := mcpContainerResources(serverResources, types.RuntimeNPX, false, v1.K8sSettingsSpec{})
 
 	if got, want := resources.Requests[corev1.ResourceCPU], resource.MustParse("250m"); got.Cmp(want) != 0 {
 		t.Fatalf("cpu request = %s, want %s", got.String(), want.String())
@@ -707,7 +716,7 @@ func TestK8sObjects_ManagedImagePullSecrets(t *testing.T) {
 	dep := findDeployment(t, objs, "test-server")
 	assertImagePullSecrets(t, dep, []string{"managed-a", "managed-b"})
 
-	expectedHash := ComputeK8sSettingsHash(v1.K8sSettingsSpec{}, types.RuntimeContainerized, false, []string{"managed-b", "managed-a"})
+	expectedHash := ComputeK8sSettingsHash(v1.K8sSettingsSpec{}, nil, types.RuntimeContainerized, false, []string{"managed-b", "managed-a"})
 	if dep.Annotations["obot.ai/k8s-settings-hash"] != expectedHash {
 		t.Fatalf("k8s settings hash = %q, want %q", dep.Annotations["obot.ai/k8s-settings-hash"], expectedHash)
 	}

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -81,16 +81,16 @@ type ServerConfig struct {
 	AuditLogEndpoint string `json:"auditLogEndpoint"`
 	AuditLogMetadata string `json:"auditLogMetadata"`
 
-	StartupTimeout time.Duration               `json:"startupTimeout,omitempty"`
-	Resources      corev1.ResourceRequirements `json:"resources,omitempty"`
+	StartupTimeout time.Duration                `json:"startupTimeout,omitempty"`
+	Resources      *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
-func coreResourceRequirements(resources *types.MCPResourceRequirements) (corev1.ResourceRequirements, error) {
+func CoreResourceRequirements(resources *types.MCPResourceRequirements) (*corev1.ResourceRequirements, error) {
 	if resources == nil {
-		return corev1.ResourceRequirements{}, nil
+		return nil, nil
 	}
 
-	result := corev1.ResourceRequirements{}
+	result := new(corev1.ResourceRequirements)
 	if resources.Requests.CPU != "" || resources.Requests.Memory != "" {
 		result.Requests = corev1.ResourceList{}
 		if resources.Requests.CPU != "" {
@@ -377,7 +377,7 @@ func ServerToServerConfig(mcpServer v1.MCPServer, audiences []string, issuer, us
 		}
 	}
 
-	resources, err := coreResourceRequirements(mcpServer.Spec.Manifest.Resources)
+	resources, err := CoreResourceRequirements(mcpServer.Spec.Manifest.Resources)
 	if err != nil {
 		return ServerConfig{}, nil, err
 	}
@@ -490,7 +490,7 @@ func SystemServerToServerConfig(systemServer v1.SystemMCPServer, audiences []str
 		return ServerConfig{}, nil, fmt.Errorf("input %d exceeds the max of %s", startupTimeoutSeconds, MaxMCPServerStartupTimeout)
 	}
 
-	resources, err := coreResourceRequirements(systemServer.Spec.Manifest.Resources)
+	resources, err := CoreResourceRequirements(systemServer.Spec.Manifest.Resources)
 	if err != nil {
 		return ServerConfig{}, nil, err
 	}

--- a/pkg/mcp/types_test.go
+++ b/pkg/mcp/types_test.go
@@ -2,12 +2,73 @@ package mcp
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
+
+func TestCoreResourceRequirements(t *testing.T) {
+	t.Run("nil resources returns nil", func(t *testing.T) {
+		result, err := CoreResourceRequirements(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != nil {
+			t.Fatalf("expected nil result, got %#v", result)
+		}
+	})
+
+	t.Run("empty resources returns non nil empty requirements", func(t *testing.T) {
+		result, err := CoreResourceRequirements(&types.MCPResourceRequirements{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if len(result.Requests) != 0 || len(result.Limits) != 0 {
+			t.Fatalf("expected empty requirements, got %#v", result)
+		}
+	})
+
+	t.Run("valid resources are converted", func(t *testing.T) {
+		result, err := CoreResourceRequirements(&types.MCPResourceRequirements{
+			Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},
+			Limits:   types.MCPResourceRequests{CPU: "1", Memory: "1Gi"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertQuantityEqual(t, result.Requests[corev1.ResourceCPU], resource.MustParse("250m"), "cpu request")
+		assertQuantityEqual(t, result.Requests[corev1.ResourceMemory], resource.MustParse("512Mi"), "memory request")
+		assertQuantityEqual(t, result.Limits[corev1.ResourceCPU], resource.MustParse("1"), "cpu limit")
+		assertQuantityEqual(t, result.Limits[corev1.ResourceMemory], resource.MustParse("1Gi"), "memory limit")
+	})
+
+	t.Run("invalid quantity returns contextual error", func(t *testing.T) {
+		_, err := CoreResourceRequirements(&types.MCPResourceRequirements{
+			Requests: types.MCPResourceRequests{CPU: "not-a-quantity"},
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), `invalid CPU request "not-a-quantity"`) {
+			t.Fatalf("expected contextual error, got %v", err)
+		}
+	})
+}
+
+func assertQuantityEqual(t *testing.T, got, want resource.Quantity, name string) {
+	t.Helper()
+	if got.Cmp(want) != 0 {
+		t.Fatalf("%s = %s, want %s", name, got.String(), want.String())
+	}
+}
 
 func TestServerToServerConfig_StartupTimeoutFromRuntimeConfig(t *testing.T) {
 	baseURL := "http://localhost:8080"


### PR DESCRIPTION
This ensures that changes to defaults are detected during drift detection.

Issue: https://github.com/obot-platform/obot/issues/6652