### PR TITLE
fix: detect external tools

### DIFF
--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -3,6 +3,7 @@ package render
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/obot-platform/nah/pkg/router"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -11,6 +12,10 @@ import (
 )
 
 func ResolveToolReference(ctx context.Context, c kclient.Client, toolRefType v1.ToolReferenceType, ns, name string) (string, error) {
+	if strings.ContainsAny(name, " .\\/") {
+		return name, nil
+	}
+
 	var tool v1.ToolReference
 	if err := c.Get(ctx, router.Key(ns, name), &tool); apierrors.IsNotFound(err) {
 		return name, nil


### PR DESCRIPTION
An external tool is one that is not the name of a tool reference. This was mistakenly removed when we cleaned up legacy APIs.

Issue: https://github.com/obot-platform/obot/issues/6658