### PR TITLE
fix: ui: disable test button for invalid image pull secrets

### DIFF
--- a/ui/user/src/lib/services/admin/utils.ts
+++ b/ui/user/src/lib/services/admin/utils.ts
@@ -1,0 +1,5 @@
+import type { ImagePullSecret } from './types';
+
+export function canTest(secret: ImagePullSecret) {
+	return !secret.manifest.enabled || !secret.status?.lastError;
+}

--- a/ui/user/src/lib/services/index.ts
+++ b/ui/user/src/lib/services/index.ts
@@ -1,6 +1,7 @@
 export * from './user/operations';
 export * from './user/types';
 export * from './admin/types';
+export * from './admin/utils';
 export * from './api-keys/types';
 export { default as AdminService } from './admin';
 export { default as ApiKeysService } from './api-keys';

--- a/ui/user/src/routes/admin/image-pull-secrets/+page.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/+page.svelte
@@ -17,7 +17,13 @@
 	import ImagePullSecretStatusDialog from './ImagePullSecretStatusDialog.svelte';
 	import ImagePullSecretTestDialog from './ImagePullSecretTestDialog.svelte';
 	import ImagePullSecretsList from './ImagePullSecretsList.svelte';
-	import { defaultForm, displayName, formFromSecret, type ImagePullSecretFormState } from './types';
+	import {
+		canTest,
+		defaultForm,
+		displayName,
+		formFromSecret,
+		type ImagePullSecretFormState
+	} from './types';
 	import { Plus } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -169,6 +175,7 @@
 	}
 
 	function openTestDialog(secret: ImagePullSecret) {
+		if (!canTest(secret)) return;
 		testingSecret = secret;
 		testImage = '';
 		testResult = undefined;
@@ -184,7 +191,7 @@
 	}
 
 	async function testSecret() {
-		if (!testingSecret || !testImage.trim() || mutationsDisabled) return;
+		if (!testingSecret || !canTest(testingSecret) || !testImage.trim() || mutationsDisabled) return;
 		testing = true;
 		testResult = undefined;
 		testError = '';

--- a/ui/user/src/routes/admin/image-pull-secrets/+page.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/+page.svelte
@@ -10,6 +10,7 @@
 		type ImagePullSecretManifest,
 		type ImagePullSecretTestResponse
 	} from '$lib/services';
+	import { canTest } from '$lib/services/admin/utils';
 	import { profile } from '$lib/stores/index.js';
 	import { goto } from '$lib/url';
 	import CapabilityBanner from './CapabilityBanner.svelte';
@@ -17,13 +18,7 @@
 	import ImagePullSecretStatusDialog from './ImagePullSecretStatusDialog.svelte';
 	import ImagePullSecretTestDialog from './ImagePullSecretTestDialog.svelte';
 	import ImagePullSecretsList from './ImagePullSecretsList.svelte';
-	import {
-		canTest,
-		defaultForm,
-		displayName,
-		formFromSecret,
-		type ImagePullSecretFormState
-	} from './types';
+	import { defaultForm, displayName, formFromSecret, type ImagePullSecretFormState } from './types';
 	import { Plus } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fly } from 'svelte/transition';

--- a/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretsList.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretsList.svelte
@@ -2,10 +2,11 @@
 	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import type { ImagePullSecret } from '$lib/services';
+	import { canTest } from '$lib/services/admin/utils';
 	import { userDeviceSettings } from '$lib/stores';
 	import { formatTime } from '$lib/time.js';
 	import { openUrl } from '$lib/utils.js';
-	import { canTest, displayName, statusClass, statusLabel, statusMessage } from './types';
+	import { displayName, statusClass, statusLabel, statusMessage } from './types';
 	import { Info, KeyRound, Plus, RefreshCw, ShieldCheck, Trash2 } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 

--- a/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretsList.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ImagePullSecretsList.svelte
@@ -5,7 +5,7 @@
 	import { userDeviceSettings } from '$lib/stores';
 	import { formatTime } from '$lib/time.js';
 	import { openUrl } from '$lib/utils.js';
-	import { displayName, statusClass, statusLabel, statusMessage } from './types';
+	import { canTest, displayName, statusClass, statusLabel, statusMessage } from './types';
 	import { Info, KeyRound, Plus, RefreshCw, ShieldCheck, Trash2 } from 'lucide-svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -87,7 +87,7 @@
 					{#snippet actions(secret)}
 						<div class="flex items-center gap-1">
 							<IconButton
-								disabled={mutationsDisabled}
+								disabled={mutationsDisabled || !canTest(secret)}
 								tooltip={{ text: 'Test' }}
 								onclick={(e) => {
 									e.stopPropagation();
@@ -158,7 +158,7 @@
 					<Info class="size-4" />
 				</IconButton>
 				<IconButton
-					disabled={mutationsDisabled}
+					disabled={mutationsDisabled || !canTest(secret)}
 					tooltip={{ text: 'Test' }}
 					onclick={(e) => {
 						e.stopPropagation();

--- a/ui/user/src/routes/admin/image-pull-secrets/types.ts
+++ b/ui/user/src/routes/admin/image-pull-secrets/types.ts
@@ -67,6 +67,10 @@ export function statusMessage(secret?: ImagePullSecret) {
 	return secret?.status?.lastError ?? '';
 }
 
+export function canTest(secret: ImagePullSecret) {
+	return statusLabel(secret) !== 'Error';
+}
+
 export function statusClass(secret: ImagePullSecret) {
 	switch (statusLabel(secret)) {
 		case 'Ready':

--- a/ui/user/src/routes/admin/image-pull-secrets/types.ts
+++ b/ui/user/src/routes/admin/image-pull-secrets/types.ts
@@ -67,10 +67,6 @@ export function statusMessage(secret?: ImagePullSecret) {
 	return secret?.status?.lastError ?? '';
 }
 
-export function canTest(secret: ImagePullSecret) {
-	return statusLabel(secret) !== 'Error';
-}
-
 export function statusClass(secret: ImagePullSecret) {
 	switch (statusLabel(secret)) {
 		case 'Ready':


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/6639

With this change, we gray out and disable the Test button if there is something wrong with the secret:

<img width="1352" height="219" alt="image" src="https://github.com/user-attachments/assets/621ffd59-1322-4245-9ea0-bca50ebe3c0f" />