### PR TITLE
fix: add sorting and filtering to device management tables

### DIFF
--- a/pkg/api/handlers/devicescans.go
+++ b/pkg/api/handlers/devicescans.go
@@ -465,11 +465,15 @@ func (*DeviceScansHandler) ListClients(req api.Context) error {
 		}
 	}
 	name := strings.TrimSpace(q.Get("name"))
+	sortBy := q.Get("sort_by")
+	sortOrder := q.Get("sort_order")
 
 	rows, total, err := req.GatewayClient.ListDeviceClientFleetSummaries(req.Context(), gateway.DeviceClientFleetListOptions{
-		Name:   name,
-		Limit:  limit,
-		Offset: offset,
+		Name:      name,
+		SortBy:    sortBy,
+		SortOrder: sortOrder,
+		Limit:     limit,
+		Offset:    offset,
 	})
 	if err != nil {
 		return err

--- a/pkg/gateway/client/devicescan.go
+++ b/pkg/gateway/client/devicescan.go
@@ -421,13 +421,6 @@ type SkillStatListOptions struct {
 	Offset    int
 }
 
-var skillStatSortColumns = map[string]string{
-	"name":              "name",
-	"device_count":      "device_count",
-	"user_count":        "user_count",
-	"observation_count": "observation_count",
-}
-
 // ListSkillStats returns one row per distinct skill name observed in
 // the latest scan of any device within the requested window.
 // Paginated, sortable, optional name LIKE filter.
@@ -462,13 +455,19 @@ func (c *Client) ListSkillStats(ctx context.Context, opts SkillStatListOptions) 
 		return nil, 0, fmt.Errorf("failed to count skill stats: %w", err)
 	}
 
-	sortCol := skillStatSortColumns[opts.SortBy]
-	if sortCol == "" {
-		sortCol = "device_count"
+	validSortFields := map[string]bool{
+		"name":              true,
+		"device_count":      true,
+		"user_count":        true,
+		"observation_count": true,
 	}
-	sortDir := "DESC"
+	sortBy := opts.SortBy
+	if !validSortFields[sortBy] {
+		sortBy = "device_count"
+	}
+	sortOrder := "DESC"
 	if strings.EqualFold(opts.SortOrder, "asc") {
-		sortDir = "ASC"
+		sortOrder = "ASC"
 	}
 
 	q := base.Session(&gorm.Session{}).
@@ -477,7 +476,7 @@ func (c *Client) ListSkillStats(ctx context.Context, opts SkillStatListOptions) 
 			COUNT(DISTINCT s.submitted_by) AS user_count,
 			COUNT(*) AS observation_count`).
 		Group("sk.name").
-		Order(fmt.Sprintf("%s %s, sk.name ASC", sortCol, sortDir))
+		Order(fmt.Sprintf("%s %s, sk.name ASC", sortBy, sortOrder))
 
 	if opts.Limit > 0 {
 		q = q.Limit(opts.Limit)
@@ -559,18 +558,22 @@ type DeviceClientFleetListOptions struct {
 	// Name, when non-empty after trimming, restricts distinct client names to
 	// those matching as a case-insensitive substring (LIKE/ILIKE %Name%).
 	Name string
+	// SortBy is name | mcp_server_count | skill_count | user_count.
+	SortBy string
+	// SortOrder is asc | desc.
+	SortOrder string
 	// Limit is the max number of client rows to return; 0 means no limit.
 	Limit int
-	// Offset skips that many client names in name order.
+	// Offset skips that many client names in the selected sort order.
 	Offset int
 }
 
 // ListDeviceClientFleetSummaries returns one row per distinct client name
 // observed in device_scan_clients on each device's all-time latest scan,
-// paginated by name. Each row lists distinct submitters, skills with
-// metadata, and MCP servers (by config_hash) attributed to that client on
-// those scans. Optional Name filters distinct names by case-insensitive
-// substring match.
+// paginated after applying the selected sort order. Each row lists distinct
+// submitters, skills with metadata, and MCP servers (by config_hash) attributed
+// to that client on those scans. Optional Name filters distinct names by
+// case-insensitive substring match.
 func (c *Client) ListDeviceClientFleetSummaries(ctx context.Context, opts DeviceClientFleetListOptions) ([]DeviceClientFleetSummary, int64, error) {
 	db := c.db.WithContext(ctx)
 	latest := db.Model(&types.DeviceScan{}).Select("MAX(id)").Group("device_id")
@@ -594,19 +597,73 @@ func (c *Client) ListDeviceClientFleetSummaries(ctx context.Context, opts Device
 		return nil, 0, fmt.Errorf("failed to count distinct clients: %w", err)
 	}
 
-	qNames := base.Session(&gorm.Session{}).
-		Distinct("cl.name").
-		Order("cl.name ASC")
-	if opts.Limit > 0 {
-		qNames = qNames.Limit(opts.Limit)
+	userCounts := db.Table("device_scan_clients AS cl").
+		Joins("JOIN device_scans AS s ON s.id = cl.device_scan_id").
+		Where("s.id IN (?)", latest).
+		Where("s.submitted_by <> ''").
+		Select("cl.name AS name, COUNT(DISTINCT s.submitted_by) AS user_count").
+		Group("cl.name")
+
+	skillCounts := db.Table("device_scan_skills AS sk").
+		Joins("JOIN device_scans AS s ON s.id = sk.device_scan_id").
+		Where("s.id IN (?)", latest).
+		Where("sk.client <> ?", "multi").
+		Where("sk.name <> ''").
+		Select("sk.client AS name, COUNT(DISTINCT sk.name) AS skill_count").
+		Group("sk.client")
+
+	mcpServerCounts := db.Table("device_scan_mcp_servers AS m").
+		Joins("JOIN device_scans AS s ON s.id = m.device_scan_id").
+		Where("s.id IN (?)", latest).
+		Where("m.client <> ?", "multi").
+		Select("m.client AS name, COUNT(DISTINCT m.config_hash) AS mcp_server_count").
+		Group("m.client")
+
+	validSortFields := map[string]bool{
+		"name":             true,
+		"mcp_server_count": true,
+		"skill_count":      true,
+		"user_count":       true,
 	}
-	if opts.Offset > 0 {
-		qNames = qNames.Offset(opts.Offset)
+	sortBy := opts.SortBy
+	if !validSortFields[sortBy] {
+		sortBy = "name"
+	}
+	sortColumn := sortBy
+	if sortBy == "name" {
+		sortColumn = "cl.name"
+	}
+	sortOrder := "ASC"
+	if strings.EqualFold(opts.SortOrder, "desc") {
+		sortOrder = "DESC"
 	}
 
-	var names []string
-	if err := qNames.Pluck("cl.name", &names).Error; err != nil {
+	q := base.Session(&gorm.Session{}).
+		Select(`cl.name AS name,
+			COALESCE(user_counts.user_count, 0) AS user_count,
+			COALESCE(skill_counts.skill_count, 0) AS skill_count,
+			COALESCE(mcp_server_counts.mcp_server_count, 0) AS mcp_server_count`).
+		Joins("LEFT JOIN (?) AS user_counts ON user_counts.name = cl.name", userCounts).
+		Joins("LEFT JOIN (?) AS skill_counts ON skill_counts.name = cl.name", skillCounts).
+		Joins("LEFT JOIN (?) AS mcp_server_counts ON mcp_server_counts.name = cl.name", mcpServerCounts).
+		Group("cl.name, user_counts.user_count, skill_counts.skill_count, mcp_server_counts.mcp_server_count").
+		Order(fmt.Sprintf("%s %s, cl.name ASC", sortColumn, sortOrder))
+	if opts.Limit > 0 {
+		q = q.Limit(opts.Limit)
+	}
+	if opts.Offset > 0 {
+		q = q.Offset(opts.Offset)
+	}
+
+	var rows []struct {
+		Name string `gorm:"column:name"`
+	}
+	if err := q.Scan(&rows).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to list client names: %w", err)
+	}
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		names = append(names, row.Name)
 	}
 	if len(names) == 0 {
 		return nil, total, nil

--- a/pkg/gateway/client/devicescan.go
+++ b/pkg/gateway/client/devicescan.go
@@ -584,12 +584,13 @@ func (c *Client) ListDeviceClientFleetSummaries(ctx context.Context, opts Device
 		Where("cl.name <> ''")
 
 	nameFilter := strings.TrimSpace(opts.Name)
+	like := "LIKE"
+	if db.Name() == "postgres" {
+		like = "ILIKE"
+	}
+	nameFilterArg := "%" + nameFilter + "%"
 	if nameFilter != "" {
-		like := "LIKE"
-		if db.Name() == "postgres" {
-			like = "ILIKE"
-		}
-		base = base.Where(fmt.Sprintf("cl.name %s ?", like), "%"+nameFilter+"%")
+		base = base.Where(fmt.Sprintf("cl.name %s ?", like), nameFilterArg)
 	}
 
 	var total int64
@@ -600,24 +601,36 @@ func (c *Client) ListDeviceClientFleetSummaries(ctx context.Context, opts Device
 	userCounts := db.Table("device_scan_clients AS cl").
 		Joins("JOIN device_scans AS s ON s.id = cl.device_scan_id").
 		Where("s.id IN (?)", latest).
+		Where("cl.name <> ''").
 		Where("s.submitted_by <> ''").
 		Select("cl.name AS name, COUNT(DISTINCT s.submitted_by) AS user_count").
 		Group("cl.name")
+	if nameFilter != "" {
+		userCounts = userCounts.Where(fmt.Sprintf("cl.name %s ?", like), nameFilterArg)
+	}
 
 	skillCounts := db.Table("device_scan_skills AS sk").
 		Joins("JOIN device_scans AS s ON s.id = sk.device_scan_id").
 		Where("s.id IN (?)", latest).
+		Where("sk.client <> ''").
 		Where("sk.client <> ?", "multi").
 		Where("sk.name <> ''").
 		Select("sk.client AS name, COUNT(DISTINCT sk.name) AS skill_count").
 		Group("sk.client")
+	if nameFilter != "" {
+		skillCounts = skillCounts.Where(fmt.Sprintf("sk.client %s ?", like), nameFilterArg)
+	}
 
 	mcpServerCounts := db.Table("device_scan_mcp_servers AS m").
 		Joins("JOIN device_scans AS s ON s.id = m.device_scan_id").
 		Where("s.id IN (?)", latest).
+		Where("m.client <> ''").
 		Where("m.client <> ?", "multi").
 		Select("m.client AS name, COUNT(DISTINCT m.config_hash) AS mcp_server_count").
 		Group("m.client")
+	if nameFilter != "" {
+		mcpServerCounts = mcpServerCounts.Where(fmt.Sprintf("m.client %s ?", like), nameFilterArg)
+	}
 
 	validSortFields := map[string]bool{
 		"name":             true,

--- a/pkg/gateway/client/devicescan_test.go
+++ b/pkg/gateway/client/devicescan_test.go
@@ -278,6 +278,10 @@ func TestDeviceClientFleetSummaries(t *testing.T) {
 			Files: datatypes.JSONSlice[string]{"SKILL.md"},
 		}},
 	})
+	insertScan(t, c, types.DeviceScan{
+		SubmittedBy: "charlie", DeviceID: "dev-3", ScannedAt: now.Add(2 * time.Hour),
+		Clients: []types.DeviceScanClient{{Name: "cursor"}},
+	})
 
 	list, total, err := c.ListDeviceClientFleetSummaries(ctx, DeviceClientFleetListOptions{Limit: 50})
 	if err != nil {
@@ -354,5 +358,32 @@ func TestDeviceClientFleetSummaries(t *testing.T) {
 	}
 	if len(list2) != 1 {
 		t.Fatalf("limit=1 offset=1: want 1 row, got %d", len(list2))
+	}
+	if list2[0].Name != "codex" {
+		t.Errorf("default sort page 2: want codex, got %q", list2[0].Name)
+	}
+
+	byUsers, _, err := c.ListDeviceClientFleetSummaries(ctx, DeviceClientFleetListOptions{SortBy: "user_count", SortOrder: "desc", Limit: 50})
+	if err != nil {
+		t.Fatalf("list sort user_count: %v", err)
+	}
+	if len(byUsers) == 0 || byUsers[0].Name != "cursor" {
+		t.Errorf("sort user_count desc: want cursor first, got %+v", byUsers)
+	}
+
+	bySkills, _, err := c.ListDeviceClientFleetSummaries(ctx, DeviceClientFleetListOptions{SortBy: "skill_count", SortOrder: "desc", Limit: 50})
+	if err != nil {
+		t.Fatalf("list sort skill_count: %v", err)
+	}
+	if len(bySkills) < 3 || bySkills[0].Name != "claude-code" || bySkills[1].Name != "codex" || bySkills[2].Name != "cursor" {
+		t.Errorf("sort skill_count desc: got %+v", bySkills)
+	}
+
+	byMCPServers, _, err := c.ListDeviceClientFleetSummaries(ctx, DeviceClientFleetListOptions{SortBy: "mcp_server_count", SortOrder: "desc", Limit: 50})
+	if err != nil {
+		t.Fatalf("list sort mcp_server_count: %v", err)
+	}
+	if len(byMCPServers) == 0 || byMCPServers[0].Name != "claude-code" {
+		t.Errorf("sort mcp_server_count desc: want claude-code first, got %+v", byMCPServers)
 	}
 }

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -364,7 +364,10 @@ export type DeviceClientListFilters = {
 	name?: string;
 	limit?: number;
 	offset?: number;
+	sortBy?: DeviceClientSortKey;
+	sortOrder?: 'asc' | 'desc';
 };
+export type DeviceClientSortKey = 'name' | 'mcp_server_count' | 'skill_count' | 'user_count';
 export interface DeviceSkillStat {
 	name: string;
 	deviceCount: number;

--- a/ui/user/src/lib/utils.ts
+++ b/ui/user/src/lib/utils.ts
@@ -1,6 +1,26 @@
 import { Role, type OrgUser, Group, type DefaultModelAlias, ModelAlias } from './services';
 import { goto } from './url';
 
+type TableSort = { property: string; order: 'asc' | 'desc' };
+
+export function getSortParams<TSortBy extends string>(
+	sort: TableSort | undefined,
+	sortFields: Record<string, TSortBy>,
+	defaultSort: TableSort
+): { sortBy: TSortBy; sortOrder: 'asc' | 'desc' } {
+	const property = sort?.property;
+	if (!property || !Object.hasOwn(sortFields, property)) {
+		return {
+			sortBy: sortFields[defaultSort.property],
+			sortOrder: defaultSort.order
+		};
+	}
+	return {
+		sortBy: sortFields[property],
+		sortOrder: sort.order
+	};
+}
+
 /**
  * Check if the user is a Basic user (not PowerUser or higher).
  *

--- a/ui/user/src/routes/admin/device-clients/+page.svelte
+++ b/ui/user/src/routes/admin/device-clients/+page.svelte
@@ -27,7 +27,7 @@
 	} as const;
 
 	function isSortProperty(property: string | undefined): property is keyof typeof sortFields {
-		return property != null && property in sortFields;
+		return property != null && Object.hasOwn(sortFields, property);
 	}
 
 	let initSort = $derived.by(() => {

--- a/ui/user/src/routes/admin/device-clients/+page.svelte
+++ b/ui/user/src/routes/admin/device-clients/+page.svelte
@@ -8,7 +8,8 @@
 	import { PAGE_SIZE, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { AdminService } from '$lib/services/index.js';
 	import { getTableUrlParamsSort, replaceState } from '$lib/url';
-	import { openUrl } from '$lib/utils';
+	import { getSortParams, openUrl } from '$lib/utils';
+	import { defaultSort, sortFields } from './constants';
 	import { MonitorCheck } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -18,13 +19,6 @@
 	let clients = $derived(clientsData.items ?? []);
 	let total = $derived(clientsData.total ?? 0);
 	let userMap = $derived(new Map(data?.users?.map((u) => [u.id, u]) ?? []));
-	const defaultSort = { property: 'name', order: 'asc' } as const;
-	const sortFields = {
-		name: 'name',
-		mcpServerCount: 'mcp_server_count',
-		skillCount: 'skill_count',
-		userCount: 'user_count'
-	} as const;
 
 	function isSortProperty(property: string | undefined): property is keyof typeof sortFields {
 		return property != null && Object.hasOwn(sortFields, property);
@@ -69,19 +63,6 @@
 		replaceState(next, {});
 	}
 
-	function getSortParams(sort = initSort) {
-		if (!isSortProperty(sort?.property)) {
-			return {
-				sortBy: sortFields[defaultSort.property],
-				sortOrder: defaultSort.order
-			};
-		}
-		return {
-			sortBy: sortFields[sort.property],
-			sortOrder: sort.order
-		};
-	}
-
 	async function reload(idx: number, sort = initSort) {
 		loading = true;
 		try {
@@ -89,7 +70,7 @@
 				limit: pageSize,
 				offset: idx * pageSize,
 				name: nameFilter,
-				...getSortParams(sort)
+				...getSortParams(sort, sortFields, defaultSort)
 			});
 		} finally {
 			loading = false;

--- a/ui/user/src/routes/admin/device-clients/+page.svelte
+++ b/ui/user/src/routes/admin/device-clients/+page.svelte
@@ -7,7 +7,7 @@
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_SIZE, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { AdminService } from '$lib/services/index.js';
-	import { setFilterUrlParams, setUrlParam } from '$lib/url';
+	import { getTableUrlParamsSort, replaceState } from '$lib/url';
 	import { openUrl } from '$lib/utils';
 	import { MonitorCheck } from 'lucide-svelte';
 	import { untrack } from 'svelte';
@@ -18,15 +18,34 @@
 	let clients = $derived(clientsData.items ?? []);
 	let total = $derived(clientsData.total ?? 0);
 	let userMap = $derived(new Map(data?.users?.map((u) => [u.id, u]) ?? []));
+	const defaultSort = { property: 'name', order: 'asc' } as const;
+	const sortFields = {
+		name: 'name',
+		mcpServerCount: 'mcp_server_count',
+		skillCount: 'skill_count',
+		userCount: 'user_count'
+	} as const;
+
+	function isSortProperty(property: string | undefined): property is keyof typeof sortFields {
+		return property != null && property in sortFields;
+	}
+
+	let initSort = $derived.by(() => {
+		const sort = getTableUrlParamsSort(defaultSort);
+		return isSortProperty(sort?.property) ? sort : defaultSort;
+	});
 	let rows = $derived(
 		clients.map((c) => ({
 			id: c.name ?? '',
 			name: c.name ?? '',
 			mcpServers: c.mcpServers ?? [],
+			mcpServerCount: c.mcpServers?.length ?? 0,
 			skills: c.skills ?? [],
+			skillCount: c.skills?.length ?? 0,
 			users:
 				c.users?.map((u) => userMap.get(u) ?? { id: u, displayName: u, email: u, username: u }) ??
-				[]
+				[],
+			userCount: c.users?.length ?? 0
 		}))
 	);
 	let pageSize = $derived(
@@ -37,17 +56,40 @@
 	let nameFilter = $state(untrack(() => page.url.searchParams.get('name') ?? ''));
 	let loading = $state(false);
 
-	let filteredRows = $derived(
-		nameFilter ? rows.filter((c) => c.name.toLowerCase().includes(nameFilter.toLowerCase())) : rows
-	);
+	function syncUrl(nextPageIndex: number, sort = initSort) {
+		const next = new URL(page.url);
+		if (nameFilter) next.searchParams.set('name', nameFilter);
+		else next.searchParams.delete('name');
+		if (nextPageIndex > 0) next.searchParams.set('offset', String(nextPageIndex * pageSize));
+		else next.searchParams.delete('offset');
+		if (isSortProperty(sort?.property)) {
+			next.searchParams.set('sort', sort.property);
+			next.searchParams.set('sortDirection', sort.order);
+		}
+		replaceState(next, {});
+	}
 
-	async function reload(idx: number) {
+	function getSortParams(sort = initSort) {
+		if (!isSortProperty(sort?.property)) {
+			return {
+				sortBy: sortFields[defaultSort.property],
+				sortOrder: defaultSort.order
+			};
+		}
+		return {
+			sortBy: sortFields[sort.property],
+			sortOrder: sort.order
+		};
+	}
+
+	async function reload(idx: number, sort = initSort) {
 		loading = true;
 		try {
 			clientsData = await AdminService.listDeviceClients({
 				limit: pageSize,
 				offset: idx * pageSize,
-				name: nameFilter
+				name: nameFilter,
+				...getSortParams(sort)
 			});
 		} finally {
 			loading = false;
@@ -56,14 +98,19 @@
 
 	function updateName(value: string) {
 		nameFilter = value;
-		setFilterUrlParams('name', value ? [value] : []);
+		syncUrl(0);
 		reload(0);
 	}
 
 	function fetchPage(idx: number) {
-		setUrlParam(page.url, 'name', nameFilter);
-		setFilterUrlParams('offset', idx > 0 ? [String(idx * pageSize)] : []);
+		syncUrl(idx);
 		reload(idx);
+	}
+
+	function handleSort(property: string, order: 'asc' | 'desc') {
+		const sort = { property, order };
+		syncUrl(0, sort);
+		reload(0, sort);
 	}
 
 	const duration = PAGE_TRANSITION_DURATION;
@@ -97,15 +144,18 @@
 			</div>
 		{:else}
 			<Table
-				data={filteredRows}
+				data={rows}
 				{pageSize}
-				fields={['name', 'mcpServers', 'skills', 'users']}
+				fields={['name', 'mcpServerCount', 'skillCount', 'userCount']}
 				headers={[
 					{ title: 'Name', property: 'name' },
-					{ title: 'MCP Servers', property: 'mcpServers' },
-					{ title: 'Skills', property: 'skills' },
-					{ title: 'Users', property: 'users' }
+					{ title: 'MCP Servers', property: 'mcpServerCount' },
+					{ title: 'Skills', property: 'skillCount' },
+					{ title: 'Users', property: 'userCount' }
 				]}
+				sortable={['name', 'mcpServerCount', 'skillCount', 'userCount']}
+				{initSort}
+				onSort={handleSort}
 				onClickRow={(d, isCtrlClick) => {
 					openUrl(resolve(`/admin/device-clients/${encodeURIComponent(d.name)}`), isCtrlClick);
 				}}
@@ -117,12 +167,6 @@
 						{:else}
 							<span class="text-muted-content italic">(unnamed)</span>
 						{/if}
-					{:else if property === 'skills'}
-						{d.skills.length}
-					{:else if property === 'mcpServers'}
-						{d.mcpServers.length}
-					{:else if property === 'users'}
-						{d.users.length}
 					{:else}
 						{d[property as keyof (typeof rows)[number]]}
 					{/if}

--- a/ui/user/src/routes/admin/device-clients/+page.ts
+++ b/ui/user/src/routes/admin/device-clients/+page.ts
@@ -19,7 +19,8 @@ const DEFAULT_SORT_BY: DeviceClientSortKey = 'name';
 const DEFAULT_SORT_ORDER = 'asc';
 
 function getSortBy(property: string | null): DeviceClientSortKey {
-	return sortFields[property ?? ''] ?? DEFAULT_SORT_BY;
+	const key = property ?? '';
+	return Object.hasOwn(sortFields, key) ? sortFields[key] : DEFAULT_SORT_BY;
 }
 
 function getSortOrder(order: string | null): 'asc' | 'desc' {
@@ -31,7 +32,7 @@ export const load: PageLoad = async ({ fetch, url }) => {
 	const offset = parseInt(url.searchParams.get('offset') ?? '0', 10) || 0;
 	const name = url.searchParams.get('name') ?? '';
 	const sortProperty = url.searchParams.get('sort');
-	const hasValidSortProperty = Boolean(sortFields[sortProperty ?? '']);
+	const hasValidSortProperty = sortProperty != null && Object.hasOwn(sortFields, sortProperty);
 	const sortBy = getSortBy(sortProperty);
 	const sortOrder = hasValidSortProperty
 		? getSortOrder(url.searchParams.get('sortDirection'))

--- a/ui/user/src/routes/admin/device-clients/+page.ts
+++ b/ui/user/src/routes/admin/device-clients/+page.ts
@@ -8,15 +8,7 @@ import {
 } from '$lib/services';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
-
-const sortFields: Record<string, DeviceClientSortKey> = {
-	name: 'name',
-	mcpServerCount: 'mcp_server_count',
-	skillCount: 'skill_count',
-	userCount: 'user_count'
-};
-const DEFAULT_SORT_BY: DeviceClientSortKey = 'name';
-const DEFAULT_SORT_ORDER = 'asc';
+import { DEFAULT_SORT_BY, DEFAULT_SORT_ORDER, sortFields } from './constants';
 
 function getSortBy(property: string | null): DeviceClientSortKey {
 	const key = property ?? '';

--- a/ui/user/src/routes/admin/device-clients/+page.ts
+++ b/ui/user/src/routes/admin/device-clients/+page.ts
@@ -1,6 +1,7 @@
 import { handleRouteError } from '$lib/errors';
 import {
 	AdminService,
+	type DeviceClientSortKey,
 	type DeviceClientFleetSummaryResponse,
 	type OrgUser,
 	UserService
@@ -8,10 +9,33 @@ import {
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
+const sortFields: Record<string, DeviceClientSortKey> = {
+	name: 'name',
+	mcpServerCount: 'mcp_server_count',
+	skillCount: 'skill_count',
+	userCount: 'user_count'
+};
+const DEFAULT_SORT_BY: DeviceClientSortKey = 'name';
+const DEFAULT_SORT_ORDER = 'asc';
+
+function getSortBy(property: string | null): DeviceClientSortKey {
+	return sortFields[property ?? ''] ?? DEFAULT_SORT_BY;
+}
+
+function getSortOrder(order: string | null): 'asc' | 'desc' {
+	return order === 'desc' ? 'desc' : 'asc';
+}
+
 export const load: PageLoad = async ({ fetch, url }) => {
 	const limit = parseInt(url.searchParams.get('pageSize') ?? '50', 10) || 50;
 	const offset = parseInt(url.searchParams.get('offset') ?? '0', 10) || 0;
 	const name = url.searchParams.get('name') ?? '';
+	const sortProperty = url.searchParams.get('sort');
+	const hasValidSortProperty = Boolean(sortFields[sortProperty ?? '']);
+	const sortBy = getSortBy(sortProperty);
+	const sortOrder = hasValidSortProperty
+		? getSortOrder(url.searchParams.get('sortDirection'))
+		: DEFAULT_SORT_ORDER;
 	let clients: DeviceClientFleetSummaryResponse = {
 		items: [],
 		total: 0,
@@ -21,7 +45,7 @@ export const load: PageLoad = async ({ fetch, url }) => {
 	let users: OrgUser[] = [];
 	try {
 		[clients, users] = await Promise.all([
-			AdminService.listDeviceClients({ limit, offset, name }, { fetch }),
+			AdminService.listDeviceClients({ limit, offset, name, sortBy, sortOrder }, { fetch }),
 			UserService.listUsers({ fetch })
 		]);
 		return { clients, users };

--- a/ui/user/src/routes/admin/device-clients/constants.ts
+++ b/ui/user/src/routes/admin/device-clients/constants.ts
@@ -1,0 +1,16 @@
+import type { DeviceClientSortKey } from '$lib/services/admin/types';
+
+export const defaultSort = {
+	property: 'name',
+	order: 'asc'
+} as const;
+
+export const sortFields: Record<string, DeviceClientSortKey> = {
+	name: 'name',
+	mcpServerCount: 'mcp_server_count',
+	skillCount: 'skill_count',
+	userCount: 'user_count'
+};
+
+export const DEFAULT_SORT_BY = sortFields[defaultSort.property];
+export const DEFAULT_SORT_ORDER = defaultSort.order;

--- a/ui/user/src/routes/admin/device-mcp-servers/+page.svelte
+++ b/ui/user/src/routes/admin/device-mcp-servers/+page.svelte
@@ -6,7 +6,14 @@
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_SIZE, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { type DeviceMCPServerStat } from '$lib/services';
-	import { setFilterUrlParams } from '$lib/url';
+	import {
+		clearUrlParams,
+		getTableUrlParamsFilters,
+		getTableUrlParamsSort,
+		replaceState,
+		setFilterUrlParams,
+		setSortUrlParams
+	} from '$lib/url';
 	import { openUrl } from '$lib/utils';
 	import { Server } from 'lucide-svelte';
 	import { untrack } from 'svelte';
@@ -14,7 +21,9 @@
 
 	let { data } = $props();
 
-	let nameFilter = $state(untrack(() => page.url.searchParams.get('name') ?? ''));
+	let nameFilter = $state(untrack(() => page.url.searchParams.get('query') ?? ''));
+	let urlFilters = $derived(getTableUrlParamsFilters());
+	let initSort = $derived(getTableUrlParamsSort({ property: 'deviceCount', order: 'desc' }));
 
 	type Row = DeviceMCPServerStat & { id: string };
 
@@ -33,7 +42,10 @@
 
 	function updateName(value: string) {
 		nameFilter = value;
-		setFilterUrlParams('name', value ? [value] : []);
+		const next = new URL(page.url);
+		if (value) next.searchParams.set('query', value);
+		else next.searchParams.delete('query');
+		replaceState(next, {});
 	}
 
 	const duration = PAGE_TRANSITION_DURATION;
@@ -77,6 +89,13 @@
 					{ title: 'Users', property: 'userCount' },
 					{ title: 'Observations', property: 'observationCount' }
 				]}
+				sortable={['name', 'transport', 'deviceCount', 'userCount', 'observationCount']}
+				filterable={['name', 'transport']}
+				filters={urlFilters}
+				{initSort}
+				onSort={setSortUrlParams}
+				onFilter={setFilterUrlParams}
+				onClearAllFilters={clearUrlParams}
 				onClickRow={(d, isCtrlClick) => {
 					openUrl(
 						resolve(`/admin/device-mcp-servers/${encodeURIComponent(d.configHash)}`),

--- a/ui/user/src/routes/admin/device-skills/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/+page.svelte
@@ -8,14 +8,15 @@
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { AdminService, type DeviceSkillStat, type DeviceSkillStatResponse } from '$lib/services';
 	import { getTableUrlParamsSort, replaceState, setSortUrlParams } from '$lib/url';
-	import { openUrl } from '$lib/utils';
+	import { getSortParams, openUrl } from '$lib/utils';
+	import { PAGE_SIZE as DEFAULT_PAGE_SIZE, defaultSort, sortFields } from './constants';
 	import { debounce } from 'es-toolkit';
 	import { PencilRuler } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
 
 	let { data } = $props();
-	const PAGE_SIZE = untrack(() => data?.pageSize ?? 50);
+	const PAGE_SIZE = untrack(() => data?.pageSize ?? DEFAULT_PAGE_SIZE);
 
 	let skillsResp = $state<DeviceSkillStatResponse>(
 		untrack(() => data?.skills ?? { items: [], total: 0, limit: PAGE_SIZE, offset: 0 })
@@ -25,13 +26,6 @@
 	let nameFilter = $state(untrack(() => page.url.searchParams.get('name') ?? ''));
 
 	type Row = DeviceSkillStat & { id: string };
-	const defaultSort = { property: 'deviceCount', order: 'desc' } as const;
-	const sortFields = {
-		name: 'name',
-		deviceCount: 'device_count',
-		userCount: 'user_count',
-		observationCount: 'observation_count'
-	} as const;
 
 	function isSortProperty(property: string | undefined): property is keyof typeof sortFields {
 		return property != null && Object.hasOwn(sortFields, property);
@@ -61,19 +55,6 @@
 		replaceState(next, {});
 	}
 
-	function getSortParams(sort = initSort) {
-		if (!isSortProperty(sort?.property)) {
-			return {
-				sortBy: sortFields[defaultSort.property],
-				sortOrder: defaultSort.order
-			};
-		}
-		return {
-			sortBy: sortFields[sort.property],
-			sortOrder: sort?.order
-		};
-	}
-
 	async function reload(sort = initSort) {
 		loading = true;
 		try {
@@ -81,7 +62,7 @@
 				limit: PAGE_SIZE,
 				offset: pageIndex * PAGE_SIZE,
 				name: nameFilter || undefined,
-				...getSortParams(sort)
+				...getSortParams(sort, sortFields, defaultSort)
 			});
 		} finally {
 			loading = false;

--- a/ui/user/src/routes/admin/device-skills/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/+page.svelte
@@ -7,7 +7,7 @@
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { AdminService, type DeviceSkillStat, type DeviceSkillStatResponse } from '$lib/services';
-	import { replaceState } from '$lib/url';
+	import { getTableUrlParamsSort, replaceState, setSortUrlParams } from '$lib/url';
 	import { openUrl } from '$lib/utils';
 	import { debounce } from 'es-toolkit';
 	import { PencilRuler } from 'lucide-svelte';
@@ -25,6 +25,22 @@
 	let nameFilter = $state(untrack(() => page.url.searchParams.get('name') ?? ''));
 
 	type Row = DeviceSkillStat & { id: string };
+	const defaultSort = { property: 'deviceCount', order: 'desc' } as const;
+	const sortFields = {
+		name: 'name',
+		deviceCount: 'device_count',
+		userCount: 'user_count',
+		observationCount: 'observation_count'
+	} as const;
+
+	function isSortProperty(property: string | undefined): property is keyof typeof sortFields {
+		return property != null && property in sortFields;
+	}
+
+	let initSort = $derived.by(() => {
+		const sort = getTableUrlParamsSort(defaultSort);
+		return isSortProperty(sort?.property) ? sort : defaultSort;
+	});
 
 	let rows = $derived<Row[]>(
 		(skillsResp.items ?? []).map((s) => ({
@@ -45,13 +61,27 @@
 		replaceState(next, {});
 	}
 
-	async function reload() {
+	function getSortParams(sort = initSort) {
+		if (!isSortProperty(sort?.property)) {
+			return {
+				sortBy: sortFields[defaultSort.property],
+				sortOrder: defaultSort.order
+			};
+		}
+		return {
+			sortBy: sortFields[sort?.property as keyof typeof sortFields],
+			sortOrder: sort?.order
+		};
+	}
+
+	async function reload(sort = initSort) {
 		loading = true;
 		try {
 			skillsResp = await AdminService.listDeviceSkills({
 				limit: PAGE_SIZE,
 				offset: pageIndex * PAGE_SIZE,
-				name: nameFilter || undefined
+				name: nameFilter || undefined,
+				...getSortParams(sort)
 			});
 		} finally {
 			loading = false;
@@ -68,6 +98,12 @@
 	function fetchPage(idx: number) {
 		pageIndex = idx;
 		reload();
+	}
+
+	function handleSort(property: string, order: 'asc' | 'desc') {
+		setSortUrlParams(property, order);
+		pageIndex = 0;
+		reload({ property, order });
 	}
 
 	const duration = PAGE_TRANSITION_DURATION;
@@ -109,6 +145,9 @@
 					{ title: 'Users', property: 'userCount' },
 					{ title: 'Observations', property: 'observationCount' }
 				]}
+				sortable={['name', 'deviceCount', 'userCount', 'observationCount']}
+				{initSort}
+				onSort={handleSort}
 				onClickRow={(d, isCtrlClick) => {
 					openUrl(resolve(`/admin/device-skills/${encodeURIComponent(d.name)}`), isCtrlClick);
 				}}

--- a/ui/user/src/routes/admin/device-skills/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/+page.svelte
@@ -34,7 +34,7 @@
 	} as const;
 
 	function isSortProperty(property: string | undefined): property is keyof typeof sortFields {
-		return property != null && property in sortFields;
+		return property != null && Object.hasOwn(sortFields, property);
 	}
 
 	let initSort = $derived.by(() => {
@@ -69,7 +69,7 @@
 			};
 		}
 		return {
-			sortBy: sortFields[sort?.property as keyof typeof sortFields],
+			sortBy: sortFields[sort.property],
 			sortOrder: sort?.order
 		};
 	}

--- a/ui/user/src/routes/admin/device-skills/+page.ts
+++ b/ui/user/src/routes/admin/device-skills/+page.ts
@@ -3,16 +3,7 @@ import { AdminService } from '$lib/services';
 import type { DeviceSkillSortKey, DeviceSkillStatResponse } from '$lib/services/admin/types';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
-
-const PAGE_SIZE = 50;
-const sortFields: Record<string, DeviceSkillSortKey> = {
-	name: 'name',
-	deviceCount: 'device_count',
-	userCount: 'user_count',
-	observationCount: 'observation_count'
-};
-const DEFAULT_SORT_BY: DeviceSkillSortKey = 'device_count';
-const DEFAULT_SORT_ORDER = 'desc';
+import { DEFAULT_SORT_BY, DEFAULT_SORT_ORDER, PAGE_SIZE, sortFields } from './constants';
 
 function getSortBy(property: string | null): DeviceSkillSortKey {
 	const key = property ?? '';

--- a/ui/user/src/routes/admin/device-skills/+page.ts
+++ b/ui/user/src/routes/admin/device-skills/+page.ts
@@ -15,7 +15,8 @@ const DEFAULT_SORT_BY: DeviceSkillSortKey = 'device_count';
 const DEFAULT_SORT_ORDER = 'desc';
 
 function getSortBy(property: string | null): DeviceSkillSortKey {
-	return sortFields[property ?? ''] ?? DEFAULT_SORT_BY;
+	const key = property ?? '';
+	return Object.hasOwn(sortFields, key) ? sortFields[key] : DEFAULT_SORT_BY;
 }
 
 function getSortOrder(order: string | null): 'asc' | 'desc' {
@@ -26,7 +27,7 @@ export const load: PageLoad = async ({ url, fetch }) => {
 	const offset = parseInt(url.searchParams.get('offset') ?? '0', 10) || 0;
 	const name = url.searchParams.get('name') ?? '';
 	const sortProperty = url.searchParams.get('sort');
-	const hasValidSortProperty = Boolean(sortFields[sortProperty ?? '']);
+	const hasValidSortProperty = sortProperty != null && Object.hasOwn(sortFields, sortProperty);
 	const sortBy = getSortBy(sortProperty);
 	const sortOrder = hasValidSortProperty
 		? getSortOrder(url.searchParams.get('sortDirection'))

--- a/ui/user/src/routes/admin/device-skills/+page.ts
+++ b/ui/user/src/routes/admin/device-skills/+page.ts
@@ -1,19 +1,41 @@
 import { handleRouteError } from '$lib/errors';
 import { AdminService } from '$lib/services';
-import type { DeviceSkillStatResponse } from '$lib/services/admin/types';
+import type { DeviceSkillSortKey, DeviceSkillStatResponse } from '$lib/services/admin/types';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
 const PAGE_SIZE = 50;
+const sortFields: Record<string, DeviceSkillSortKey> = {
+	name: 'name',
+	deviceCount: 'device_count',
+	userCount: 'user_count',
+	observationCount: 'observation_count'
+};
+const DEFAULT_SORT_BY: DeviceSkillSortKey = 'device_count';
+const DEFAULT_SORT_ORDER = 'desc';
+
+function getSortBy(property: string | null): DeviceSkillSortKey {
+	return sortFields[property ?? ''] ?? DEFAULT_SORT_BY;
+}
+
+function getSortOrder(order: string | null): 'asc' | 'desc' {
+	return order === 'asc' ? 'asc' : 'desc';
+}
 
 export const load: PageLoad = async ({ url, fetch }) => {
 	const offset = parseInt(url.searchParams.get('offset') ?? '0', 10) || 0;
 	const name = url.searchParams.get('name') ?? '';
+	const sortProperty = url.searchParams.get('sort');
+	const hasValidSortProperty = Boolean(sortFields[sortProperty ?? '']);
+	const sortBy = getSortBy(sortProperty);
+	const sortOrder = hasValidSortProperty
+		? getSortOrder(url.searchParams.get('sortDirection'))
+		: DEFAULT_SORT_ORDER;
 
 	let skills: DeviceSkillStatResponse = { items: [], total: 0, limit: PAGE_SIZE, offset };
 	try {
 		skills = await AdminService.listDeviceSkills(
-			{ limit: PAGE_SIZE, offset, name: name || undefined },
+			{ limit: PAGE_SIZE, offset, name: name || undefined, sortBy, sortOrder },
 			{ fetch }
 		);
 		return { skills, pageSize: PAGE_SIZE };

--- a/ui/user/src/routes/admin/device-skills/constants.ts
+++ b/ui/user/src/routes/admin/device-skills/constants.ts
@@ -1,0 +1,18 @@
+import type { DeviceSkillSortKey } from '$lib/services/admin/types';
+
+export const PAGE_SIZE = 50;
+
+export const defaultSort = {
+	property: 'deviceCount',
+	order: 'desc'
+} as const;
+
+export const sortFields: Record<string, DeviceSkillSortKey> = {
+	name: 'name',
+	deviceCount: 'device_count',
+	userCount: 'user_count',
+	observationCount: 'observation_count'
+};
+
+export const DEFAULT_SORT_BY = sortFields[defaultSort.property];
+export const DEFAULT_SORT_ORDER = defaultSort.order;


### PR DESCRIPTION
Add missing sort and filter support across the Device Management pages.

- Device MCP Servers now uses the shared table sort/filter controls for the in-memory scan stats data. The table supports sorting by name, transport, device count, user count, and observation count, plus filtering by name and transport. The fuzzy search parameter was moved to query so it does not conflict with table field filters.
- Device Skills now wires table sorting through the existing paginated device skills API. Sorting supports name, device count, user count, and observation count, preserves sort state in the URL, and resets pagination when the sort changes while keeping the existing name search behavior.
- Device Clients now supports server-side sorting before pagination. The clients API accepts sort_by and sort_order, and the gateway query computes user, skill, and MCP server counts so the table can sort correctly by name, MCP server count, skill count, and user count across the full result set instead of only the current page.

Also align the new backend sorting and aggregate query code with existing gateway conventions, including validated sort fields, conventional query local naming, and filtered aggregate subqueries for derived count sorting.

Addresses https://github.com/obot-platform/obot/issues/6601
