### PR TITLE
fix: ui: image pull secrets: increase contrast in ECR JSON policies

### DIFF
--- a/ui/user/src/routes/admin/image-pull-secrets/ECRSetupGuide.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ECRSetupGuide.svelte
@@ -15,8 +15,8 @@
 	<div class="flex flex-col gap-1">
 		<h3 class="text-base font-semibold">AWS Setup Guide</h3>
 		<p class="text-muted-content text-sm">
-			Configure AWS to trust Obot's service account, then save the role ARN above and refresh the
-			generated pull secret.
+			Configure AWS to trust Obot's service account, then paste the role ARN above and create the
+			image pull secret.
 		</p>
 	</div>
 
@@ -58,8 +58,8 @@
 		<div class="pt-5">
 			{@render setupStep(
 				'4',
-				'Save and refresh in Obot',
-				'Paste the role ARN into the form, save the credential, then run Refresh Now to write the Kubernetes image pull secret.'
+				'Create the secret in Obot',
+				'Paste the role ARN into the form and click Create. Obot creates the Kubernetes image pull secret and returns you to the list view.'
 			)}
 		</div>
 	</div>
@@ -100,7 +100,7 @@
 			<CopyButton text={value} />
 		</div>
 		<pre
-			class="default-scrollbar-thin bg-base-200 dark:bg-base-100 dark:border-base-400 max-h-80 overflow-auto rounded-md border border-transparent p-3 text-xs">{value ||
+			class="default-scrollbar-thin dark:bg-base-400 bg-base-200 text-base-content max-h-80 overflow-auto rounded-md p-3 font-mono text-xs">{value ||
 				'-'}</pre>
 	</div>
 {/snippet}

--- a/ui/user/src/routes/admin/image-pull-secrets/ECRSetupGuide.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ECRSetupGuide.svelte
@@ -15,8 +15,8 @@
 	<div class="flex flex-col gap-1">
 		<h3 class="text-base font-semibold">AWS Setup Guide</h3>
 		<p class="text-muted-content text-sm">
-			Configure AWS to trust Obot's service account, then paste the role ARN above and create the
-			image pull secret.
+			Configure AWS to trust Obot's service account, then paste the role ARN above and save the
+			image pull secret in Obot.
 		</p>
 	</div>
 
@@ -58,8 +58,8 @@
 		<div class="pt-5">
 			{@render setupStep(
 				'4',
-				'Create the secret in Obot',
-				'Paste the role ARN into the form and click Create. Obot creates the Kubernetes image pull secret and returns you to the list view.'
+				'Save the secret in Obot',
+				'Paste the role ARN into the form, then click Create or Save. Obot writes the Kubernetes image pull secret and returns you to the list view.'
 			)}
 		</div>
 	</div>


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/6640

This is better now:

<img width="1274" height="915" alt="image" src="https://github.com/user-attachments/assets/14076516-22fa-4854-b87c-284df7fd60c9" />

<img width="1267" height="931" alt="image" src="https://github.com/user-attachments/assets/dfd6a9d3-6530-4801-8304-75c485c6c551" />
