### PR TITLE
fix: ensure the www-authenticate header is returned on the MCP path

### DIFF
--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -15,6 +15,7 @@ var apiResources = map[string][]string{
 		"GET    /api/all-mcps/servers/{mcpserver_id}/resources/{resource_uri}",
 		"GET    /api/all-mcps/servers/{mcpserver_id}/prompts",
 		"GET    /api/all-mcps/servers/{mcpserver_id}/prompts/{prompt_name}",
+		"GET    /oauth/callback/{oauth_request_id}",
 		"GET    /oauth/callback/{oauth_request_id}/{mcp_id}",
 		"GET    /oauth/mcp/callback",
 		"GET    /auth/mcp/composite/{mcp_id}",

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -23,28 +23,17 @@ import (
 
 type Handler struct {
 	mcpSessionManager *mcp.SessionManager
-	scope             string
 	transport         http.RoundTripper
 }
 
-func NewHandler(mcpSessionManager *mcp.SessionManager, scopesSupported []string) *Handler {
-	var scope string
-	if len(scopesSupported) > 0 {
-		scope = fmt.Sprintf(", scope=\"%s\"", strings.Join(scopesSupported, " "))
-	}
+func NewHandler(mcpSessionManager *mcp.SessionManager) *Handler {
 	return &Handler{
 		mcpSessionManager: mcpSessionManager,
-		scope:             scope,
 		transport:         otelhttp.NewTransport(http.DefaultTransport),
 	}
 }
 
 func (h *Handler) Proxy(req api.Context) error {
-	if req.User.GetUID() == "anonymous" {
-		req.ResponseWriter.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_request", error_description="Invalid access token", resource_metadata="%s/.well-known/oauth-protected-resource%s"%s`, strings.TrimSuffix(req.APIBaseURL, "/api"), req.URL.Path, h.scope))
-		return apierrors.NewUnauthorized("user is not authenticated")
-	}
-
 	serverConfig, mcpURL, allowDifferentPaths, err := h.ensureServerIsDeployed(req)
 	if err != nil {
 		return fmt.Errorf("failed to ensure server is deployed: %v", err)

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -53,7 +53,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	defaultModelAliases := handlers.NewDefaultModelAliasHandler()
 	images := handlers.NewImageHandler()
 	mcp := handlers.NewMCPHandler(services.MCPLoader, services.AccessControlRuleHelper, oauthChecker, services.MCPImagePullSecrets, services.ServerURL)
-	mcpGateway := mcpgateway.NewHandler(services.MCPLoader, services.OAuthServerConfig.ScopesSupported)
+	mcpGateway := mcpgateway.NewHandler(services.MCPLoader)
 	mcpAuditLogs := mcpgateway.NewAuditLogHandler()
 	auditLogExports := handlers.NewAuditLogExportHandler(services.GPTClient)
 	serverInstances := handlers.NewServerInstancesHandler(services.AccessControlRuleHelper, services.ServerURL)

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -44,13 +44,18 @@ type Server struct {
 	auditLogger    audit.Logger
 	rateLimiter    *ratelimiter.RateLimiter
 	baseURL        string
+	mcpOAuthScope  string
 	registryNoAuth bool
 
 	mux         *http.ServeMux
 	otelHandler http.Handler
 }
 
-func NewServer(storageClient storage.Client, gatewayClient *gclient.Client, gptClient *gptscript.GPTScript, localK8sClient kclient.Client, obotNamespace string, authn *authn.Authenticator, authz *authz.Authorizer, proxyManager *proxy.Manager, auditLogger audit.Logger, rateLimiter *ratelimiter.RateLimiter, baseURL string, registryNoAuth bool) *Server {
+func NewServer(storageClient storage.Client, gatewayClient *gclient.Client, gptClient *gptscript.GPTScript, localK8sClient kclient.Client, obotNamespace string, authn *authn.Authenticator, authz *authz.Authorizer, proxyManager *proxy.Manager, auditLogger audit.Logger, rateLimiter *ratelimiter.RateLimiter, baseURL string, oauthScopesSupported []string, registryNoAuth bool) *Server {
+	var scope string
+	if len(oauthScopesSupported) > 0 {
+		scope = fmt.Sprintf(", scope=\"%s\"", strings.Join(oauthScopesSupported, " "))
+	}
 	s := &Server{
 		storageClient:  storageClient,
 		gatewayClient:  gatewayClient,
@@ -61,6 +66,7 @@ func NewServer(storageClient storage.Client, gatewayClient *gclient.Client, gptC
 		authorizer:     authz,
 		proxyManager:   proxyManager,
 		baseURL:        baseURL + "/api",
+		mcpOAuthScope:  scope,
 		auditLogger:    auditLogger,
 		rateLimiter:    rateLimiter,
 		registryNoAuth: registryNoAuth,
@@ -192,6 +198,8 @@ func (s *Server) Wrap(f api.HandlerFunc) http.HandlerFunc {
 			// Only set WWW-Authenticate if not in no-auth mode
 			if strings.HasPrefix(req.URL.Path, "/v0.1") && !s.registryNoAuth {
 				rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="MCP Registry", resource_metadata="%s/.well-known/oauth-protected-resource/v0.1/servers"`, strings.TrimSuffix(s.baseURL, "/api")))
+			} else if strings.HasPrefix(req.URL.Path, "/mcp-connect/") && user.GetUID() == "anonymous" {
+				rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_request", error_description="Invalid access token", resource_metadata="%s/.well-known/oauth-protected-resource%s"%s`, strings.TrimSuffix(s.baseURL, "/api"), req.URL.Path, s.mcpOAuthScope))
 			}
 
 			if authenticated {

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -995,6 +995,20 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	// When EnableRegistryAuth is false (default), registry is in no-auth mode
 	registryNoAuth := !config.EnableRegistryAuth
 
+	oauthServerConfig := handlers.OAuthAuthorizationServerConfig{
+		Issuer:                            config.Hostname,
+		AuthorizationEndpoint:             fmt.Sprintf("%s/oauth/authorize", config.Hostname),
+		TokenEndpoint:                     fmt.Sprintf("%s/oauth/token", config.Hostname),
+		RegistrationEndpoint:              fmt.Sprintf("%s/oauth/register", config.Hostname),
+		JWKSURI:                           config.Hostname + "/oauth/jwks.json",
+		ScopesSupported:                   []string{"profile"},
+		ResponseTypesSupported:            []string{"code"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:token-exchange"},
+		CodeChallengeMethodsSupported:     []string{"S256", "plain"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post", "none"},
+		UserInfoEndpoint:                  fmt.Sprintf("%s/oauth/userinfo", config.Hostname),
+	}
+
 	// For now, always auto-migrate the gateway database
 	svcs := &Services{
 		EncryptionConfig:  encryptionConfig,
@@ -1020,6 +1034,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 			auditLogger,
 			rateLimiter,
 			config.Hostname,
+			oauthServerConfig.ScopesSupported,
 			registryNoAuth,
 		),
 		PersistentTokenServer: persistentTokenServer,
@@ -1042,21 +1057,9 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		MCPLoader:                      mcpSessionManager,
 		MCPOAuthTokenStorage:           mcpOAuthTokenStorage,
 		MCPOAuthClientSecretExpiration: oauthClientExpiration,
-		OAuthServerConfig: handlers.OAuthAuthorizationServerConfig{
-			Issuer:                            config.Hostname,
-			AuthorizationEndpoint:             fmt.Sprintf("%s/oauth/authorize", config.Hostname),
-			TokenEndpoint:                     fmt.Sprintf("%s/oauth/token", config.Hostname),
-			RegistrationEndpoint:              fmt.Sprintf("%s/oauth/register", config.Hostname),
-			JWKSURI:                           config.Hostname + "/oauth/jwks.json",
-			ScopesSupported:                   []string{"profile"},
-			ResponseTypesSupported:            []string{"code"},
-			GrantTypesSupported:               []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:token-exchange"},
-			CodeChallengeMethodsSupported:     []string{"S256", "plain"},
-			TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post", "none"},
-			UserInfoEndpoint:                  fmt.Sprintf("%s/oauth/userinfo", config.Hostname),
-		},
-		AccessControlRuleHelper: acrHelper,
-		ModelAccessPolicyHelper: mapHelper,
+		OAuthServerConfig:              oauthServerConfig,
+		AccessControlRuleHelper:        acrHelper,
+		ModelAccessPolicyHelper:        mapHelper,
 
 		SkillAccessRuleHelper:                skillAccessRuleHelper,
 		WebhookHelper:                        webhookHelper,


### PR DESCRIPTION
A previous change fixed a problem where MCP servers were accessible to all authenticated users. That fix bypassed the code where we were setting the www-authentiate header. This change fixes that.