### PR TITLE
fix: llm token usage

### DIFF
--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -310,7 +310,7 @@ func copyBody(r *http.Request) ([]byte, error) {
 }
 
 type responseModifier struct {
-	userID, runID, model                        string
+	userID, model                               string
 	projectID, threadID                         string
 	personalToken                               bool
 	client                                      *client.Client
@@ -769,13 +769,11 @@ func buildToolCallTargetMessage(toolCalls []messagepolicy.ToolCallInfo) string {
 
 func (r *responseModifier) Close() error {
 	r.lock.Lock()
-	runID := r.runID
 	totalTokens := r.totalTokens
 	if totalTokens == 0 {
 		totalTokens = r.promptTokens + r.completionTokens
 	}
 	activity := &types.RunTokenActivity{
-		Name:             runID,
 		UserID:           r.userID,
 		Model:            r.model,
 		PromptTokens:     r.promptTokens,
@@ -784,10 +782,8 @@ func (r *responseModifier) Close() error {
 		PersonalToken:    r.personalToken,
 	}
 	r.lock.Unlock()
-	if runID != "" {
-		if err := r.client.InsertTokenUsage(context.Background(), activity); err != nil {
-			log.Warnf("failed to save token usage for run %s: %v", runID, err)
-		}
+	if err := r.client.InsertTokenUsage(context.Background(), activity); err != nil {
+		log.Warnf("failed to save token usage for user %s: %v", r.userID, err)
 	}
 	return r.c.Close()
 }

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -1786,8 +1786,12 @@ function unwrapTokenUsageList(response: unknown): TokenUsage[] {
 	return list?.items ?? [];
 }
 
-export async function listTotalTokenUsage(opts?: { fetch?: Fetcher }) {
-	const response = await doGet('/total-token-usage', opts);
+export async function listTotalTokenUsage(
+	timeRange: TokenUsageTimeRange,
+	opts?: { fetch?: Fetcher; signal?: AbortSignal }
+) {
+	const queryString = tokenUsageQueryString(timeRange);
+	const response = await doGet(`/total-token-usage?${queryString}`, opts);
 	return response as TotalTokenUsage;
 }
 

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -258,7 +258,7 @@
 
 		const [users, tokens, catalogServers, workspaceServers] = await Promise.all([
 			UserService.listUsersIncludeDeleted(),
-			AdminService.listTotalTokenUsage(),
+			AdminService.listTotalTokenUsage({ start, end }),
 			AdminService.listAllCatalogDeployedSingleRemoteServers(DEFAULT_MCP_CATALOG_ID),
 			AdminService.listAllWorkspaceDeployedSingleRemoteServers()
 		]);

--- a/ui/user/src/routes/admin/token-usage/+page.svelte
+++ b/ui/user/src/routes/admin/token-usage/+page.svelte
@@ -100,17 +100,6 @@
 	onMount(async () => {
 		usersData = await UserService.listUsersIncludeDeleted();
 		modelsData = await AdminService.listModels({ all: true });
-
-		AdminService.listTotalTokenUsage()
-			.then((response) => {
-				totalTokensData = response;
-			})
-			.catch((error) => {
-				errors.append(error);
-			})
-			.finally(() => {
-				loadingTotalTokensData = false;
-			});
 	});
 
 	let fetchAbortController: AbortController | null = null;
@@ -122,7 +111,22 @@
 		const signal = fetchAbortController.signal;
 
 		loadingTableData = true;
+		loadingTotalTokensData = true;
 		const timeRange = { start, end };
+
+		AdminService.listTotalTokenUsage(timeRange, { signal })
+			.then((response) => {
+				if (signal.aborted) return;
+				totalTokensData = response;
+			})
+			.catch((error) => {
+				if (error?.name === 'AbortError') return;
+				errors.append(error);
+			})
+			.finally(() => {
+				if (!signal.aborted) loadingTotalTokensData = false;
+			});
+
 		AdminService.listTokenUsage(timeRange, { signal })
 			.then((tokenUsage) => {
 				if (signal.aborted) return;


### PR DESCRIPTION
PR https://github.com/obot-platform/obot/pull/6642 removed RunID from TokenContext and added an `if runID != ""` guard around InsertTokenUsage in responseModifier.Close(). Since r.runID is never populated by either dispatchLLMProxy (no longer set) or llmProviderProxy.proxy (never set), the guard silently suppressed all token usage recording — which also disabled daily quota enforcement via RemainingTokenUsageForUser.

Drop the guard so InsertTokenUsage runs unconditionally, matching the
pre-https://github.com/obot-platform/obot/pull/6642 behavior. Rows are recorded with an empty Name, which is fine — every query aggregates by user_id / model / created_at and
never references Name.

This change also makes the total token counts respect the selected date range.

Addresses https://github.com/obot-platform/obot/issues/6696