### PR TITLE
feat: openai and anthropic passthroughs for external clients

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/sjson v1.2.5
 	github.com/zalando/go-keyring v0.2.8
 	go.opentelemetry.io/contrib/exporters/autoexport v0.68.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
@@ -86,8 +87,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.22.5
 	sigs.k8s.io/yaml v1.6.0
 )
-
-require github.com/tidwall/sjson v1.2.5
 
 require (
 	cel.dev/expr v0.25.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
+require github.com/tidwall/sjson v1.2.5
+
 require (
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.123.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -599,6 +599,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -606,6 +607,8 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -242,11 +242,22 @@ func (d *Dispatcher) providerEnv(credEnv map[string]string) []string {
 func TransformRequest(u url.URL, credEnv map[string]string) func(req *http.Request) {
 	return func(req *http.Request) {
 		reqPath := req.PathValue("path")
-		if u.Path == "" {
+		switch {
+		case u.Path == "":
+			// Upstream base has no path. Ensure exactly one /v1 prefix in the
+			// final URL regardless of whether the client supplied it.
 			if strings.HasPrefix(reqPath, "v1/") || reqPath == "v1" {
 				u.Path = "/"
 			} else {
 				u.Path = "/v1"
+			}
+		case strings.HasSuffix(u.Path, "/v1"):
+			// Upstream base already ends in /v1 (the openai/anthropic
+			// passthrough routes). Strip a leading v1/ from the client-supplied
+			// path so we don't produce /v1/v1/...
+			reqPath = strings.TrimPrefix(reqPath, "v1/")
+			if reqPath == "v1" {
+				reqPath = ""
 			}
 		}
 		u.Path = path.Join(u.Path, reqPath)

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -279,13 +280,13 @@ func rewriteModelInBody(body []byte, model string) ([]byte, error) {
 	return json.Marshal(bodyMap)
 }
 
-// copyBody returns a copy of the bytes in a request body.
-// If the copy was successful the request body is restored to its original state before returning so that
+// copyBody returns a copy of the bytes in a request or response body.
+// If the copy was successful the body is restored to its original state before returning so that
 // it can be reused.
-// The returned byte slice is safe to modify without affecting the request body.
-func copyBody(r *http.Request) ([]byte, error) {
-	b, err := io.ReadAll(r.Body)
-	r.Body.Close()
+// The returned byte slice is safe to modify without affecting the restored body.
+func copyBody(body *io.ReadCloser) ([]byte, error) {
+	b, err := io.ReadAll(*body)
+	(*body).Close()
 
 	if err != nil {
 		// b can be partial results on error, don't restore the body
@@ -293,7 +294,7 @@ func copyBody(r *http.Request) ([]byte, error) {
 	}
 
 	// Read was successful, restore the body with a copy.
-	r.Body = io.NopCloser(bytes.NewReader(slices.Clone(b)))
+	*body = io.NopCloser(bytes.NewReader(slices.Clone(b)))
 	return b, nil
 }
 
@@ -317,9 +318,21 @@ type responseModifier struct {
 	outputPolicies      []messagepolicy.ApplicablePolicy
 	conversationHistory []messagepolicy.ConversationMessage
 	pipeReader          *io.PipeReader // set when output policies are active; Read() reads from this
+
+	// allowedTargetModels restricts a GET /v1/models response to the
+	// provider-native target model ids in this set (the models the user may
+	// use). It is ignored when allowAllModels is true.
+	allowedTargetModels map[string]bool
+	// allowAllModels reports that the user may use every model, so a GET
+	// /v1/models response is passed through unfiltered.
+	allowAllModels bool
 }
 
 func (r *responseModifier) modifyResponse(resp *http.Response) error {
+	if resp.Request.URL.Path == "/v1/models" {
+		return r.filterModelListResponse(resp)
+	}
+
 	if r.inputPolicyReplacement != "" {
 		resp.Header.Set("X-Obot-Message-Policy-Replacement", r.inputPolicyReplacement)
 	}
@@ -342,6 +355,101 @@ func (r *responseModifier) modifyResponse(resp *http.Response) error {
 	}
 
 	return nil
+}
+
+// filterModelListResponse rewrites a provider models-list response, dropping any
+// model whose id is not in r.allowedTargetModels (the set the user may use). Both
+// the Anthropic and OpenAI list endpoints return a top-level
+// {"data": [{"id": ...}, ...]} envelope, so the same filtering applies to both
+// passthroughs. Surviving entries are kept as their exact upstream bytes — no
+// map[string]any round-trip that would reorder object keys or reformat numbers.
+// The body is copied up front and restored, so any failure (or an unrecognized
+// payload) just forwards the original response untouched.
+func (r *responseModifier) filterModelListResponse(resp *http.Response) error {
+	if resp.StatusCode != http.StatusOK || r.allowAllModels {
+		return nil
+	}
+
+	// copyBody restores resp.Body, so every early return below forwards the
+	// original response unchanged; we only swap in the filtered body once it's
+	// fully built.
+	body, err := copyBody(&resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// Only rewrite a recognized {"data": [...]} list envelope.
+	data := gjson.GetBytes(body, "data")
+	if !data.IsArray() {
+		return nil
+	}
+
+	// Keep each allowed entry exactly as the provider encoded it (its raw bytes).
+	var kept []string
+	data.ForEach(func(_, entry gjson.Result) bool {
+		if r.allowedTargetModels[entry.Get("id").String()] {
+			kept = append(kept, entry.Raw)
+		}
+		return true
+	})
+
+	out, err := sjson.SetRawBytes(body, "data", []byte("["+strings.Join(kept, ",")+"]"))
+	if err != nil {
+		return nil
+	}
+	out, err = rewriteAnthropicListCursors(out)
+	if err != nil {
+		return nil
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(out))
+	resp.ContentLength = int64(len(out))
+	resp.Header.Set("Content-Length", strconv.Itoa(len(out)))
+	resp.Header.Del("Content-Encoding")
+
+	return nil
+}
+
+// rewriteAnthropicListCursors repoints first_id/last_id at the (already filtered)
+// data array so the Anthropic pagination cursors never reference a model the user
+// can't see (the SDK paginates off last_id). OpenAI lists carry no such fields
+// and are returned unchanged. On an empty page the cursors are removed rather
+// than nulled, except last_id is kept when more pages remain so the client can
+// still advance.
+func rewriteAnthropicListCursors(body []byte) ([]byte, error) {
+	hasFirst := gjson.GetBytes(body, "first_id").Exists()
+	hasLast := gjson.GetBytes(body, "last_id").Exists()
+	if !hasFirst && !hasLast {
+		return body, nil
+	}
+
+	var err error
+	if ids := gjson.GetBytes(body, "data.#.id").Array(); len(ids) > 0 {
+		if hasFirst {
+			if body, err = sjson.SetBytes(body, "first_id", ids[0].String()); err != nil {
+				return nil, err
+			}
+		}
+		if hasLast {
+			if body, err = sjson.SetBytes(body, "last_id", ids[len(ids)-1].String()); err != nil {
+				return nil, err
+			}
+		}
+		return body, nil
+	}
+
+	// Empty page.
+	if hasFirst {
+		if body, err = sjson.DeleteBytes(body, "first_id"); err != nil {
+			return nil, err
+		}
+	}
+	if hasLast && !gjson.GetBytes(body, "has_more").Bool() {
+		if body, err = sjson.DeleteBytes(body, "last_id"); err != nil {
+			return nil, err
+		}
+	}
+	return body, nil
 }
 
 func (r *responseModifier) Read(p []byte) (int, error) {
@@ -940,18 +1048,21 @@ func (l *llmProviderProxy) proxy(req api.Context) error {
 	}
 
 	// Attempt to get the target model
-	body, err := copyBody(req.Request)
+	body, err := copyBody(&req.Request.Body)
 	if err != nil {
 		return fmt.Errorf("failed to copy body: %w", err)
 	}
 
 	targetModel := extractModelFromBody(body)
 	if targetModel != "" {
-		model, err := getModelFromReference(req.Context(), req.Storage, l.modelProvider.Namespace, targetModel)
+		model, err := getModelFromReference(req.Context(), req.Storage, modelProvider.Namespace, targetModel)
+		if apierrors.IsNotFound(err) {
+			model, err = l.mapHelper.ResolveTargetModel(modelProvider.Name, targetModel)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to get model: %w", err)
 		}
-		if model.Spec.Manifest.ModelProvider != l.modelProvider.Name {
+		if model.Spec.Manifest.ModelProvider != modelProvider.Name {
 			return types2.NewErrBadRequest("requested model does not match configured provider %q", targetModel)
 		}
 
@@ -1027,6 +1138,20 @@ func (l *llmProviderProxy) proxy(req api.Context) error {
 		req.Request.Header.Set("X-Api-Key", credEnv[credEnvKey])
 	}
 
+	// For the models-list endpoint, compute the set of provider-native target
+	// model ids the user may use so the response modifier can strip inaccessible
+	// models.
+	var (
+		allowedTargetModels map[string]bool
+		allowAllModels      bool
+	)
+	if isModelsListRequest(req.Request) && req.User.GetUID() != "" {
+		allowedTargetModels, allowAllModels, err = l.mapHelper.GetUserAllowedTargetModels(req.User, l.modelProviderName)
+		if err != nil {
+			return fmt.Errorf("failed to determine accessible models: %w", err)
+		}
+	}
+
 	(&httputil.ReverseProxy{
 		Director: llmTransformRequest(l.u, nil),
 		ModifyResponse: (&responseModifier{
@@ -1037,10 +1162,22 @@ func (l *llmProviderProxy) proxy(req api.Context) error {
 			messagePolicyHelper:    messagePolicyHelper,
 			outputPolicies:         outputPolicies,
 			conversationHistory:    conversationHistory,
+			allowedTargetModels:    allowedTargetModels,
+			allowAllModels:         allowAllModels,
 		}).modifyResponse,
 	}).ServeHTTP(req.ResponseWriter, req.Request)
 
 	return nil
+}
+
+// isModelsListRequest reports whether req targets the provider models-list
+// endpoint (GET .../v1/models) on the passthrough routes.
+func isModelsListRequest(req *http.Request) bool {
+	if req.Method != http.MethodGet {
+		return false
+	}
+	// The {path...} route value holds the client path, e.g. "v1/models".
+	return strings.TrimPrefix(req.PathValue("path"), "v1/") == "models"
 }
 
 // applyMessagePolicies evaluates input and output message policies against body, modifying

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -1145,7 +1145,7 @@ func (l *llmProviderProxy) proxy(req api.Context) error {
 		allowedTargetModels map[string]bool
 		allowAllModels      bool
 	)
-	if isModelsListRequest(req.Request) && req.User.GetUID() != "" {
+	if isModelsListRequest(req.Request) {
 		allowedTargetModels, allowAllModels, err = l.mapHelper.GetUserAllowedTargetModels(req.User, l.modelProviderName)
 		if err != nil {
 			return fmt.Errorf("failed to determine accessible models: %w", err)

--- a/pkg/gateway/server/llmproxy_test.go
+++ b/pkg/gateway/server/llmproxy_test.go
@@ -2,15 +2,18 @@ package server
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/messagepolicy"
+	"github.com/tidwall/gjson"
 )
 
 func TestShouldSkipMessagePolicyEnforcement(t *testing.T) {
@@ -376,6 +379,119 @@ func TestLLMTransformRequest_RemovesInternalRequestTypeHeader(t *testing.T) {
 
 	if got := req.Header.Get(internalRequestTypeHeader); got != "" {
 		t.Fatalf("%s = %q, want empty", internalRequestTypeHeader, got)
+	}
+}
+
+// TestLLMTransformRequest_UpstreamPath asserts the upstream URL.Path produced
+// by llmTransformRequest for every (base URL, reqPath) combination the proxy
+// should support. Every reqPath is grounded in real source — either nanobot
+// (nanobot/pkg/llm/{anthropic,responses,completions,bifrost}/client.go) or the
+// official SDK each documented external coding tool uses.
+//
+// The expected paths are also what modifyResponse in llmproxy.go checks against
+// (/v1/messages and /v1/responses) for token counting and policy enforcement.
+func TestLLMTransformRequest_UpstreamPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		reqPath string
+		want    string
+	}{
+		// --- Nanobot dialects (exact suffixes from nanobot source) ---
+		// nanobot/pkg/llm/anthropic/client.go → BaseURL + "/messages"
+		{
+			name:    "nanobot AnthropicMessages dialect",
+			baseURL: "https://api.anthropic.com/v1",
+			reqPath: "messages",
+			want:    "/v1/messages",
+		},
+		// nanobot/pkg/llm/responses/client.go → BaseURL + "/responses"
+		{
+			name:    "nanobot OpenAIResponses dialect",
+			baseURL: "https://api.openai.com/v1",
+			reqPath: "responses",
+			want:    "/v1/responses",
+		},
+		// nanobot/pkg/llm/client.go: OpenResponses uses the responses client
+		{
+			name:    "nanobot OpenResponses dialect (dispatch)",
+			baseURL: "http://127.0.0.1:8080",
+			reqPath: "responses",
+			want:    "/v1/responses",
+		},
+		// nanobot/pkg/llm/completions/client.go → BaseURL + "/chat/completions"
+		{
+			name:    "nanobot OpenAIChatCompletions dialect (dispatch)",
+			baseURL: "http://127.0.0.1:8080",
+			reqPath: "chat/completions",
+			want:    "/v1/chat/completions",
+		},
+		// nanobot/pkg/llm/bifrost/client.go → BaseURL + "/v1/responses"
+		{
+			name:    "nanobot BifrostRequest dialect (dispatch)",
+			baseURL: "http://127.0.0.1:8080",
+			reqPath: "v1/responses",
+			want:    "/v1/responses",
+		},
+
+		// --- External coding tools pointed at the passthrough routes ---
+		// Claude Code uses the official Anthropic SDK; its default base URL is
+		// "https://api.anthropic.com" (no /v1) and the SDK appends /v1/messages.
+		// With base=…/api/llm-proxy/anthropic, the mux captures "v1/messages".
+		{
+			name:    "Claude Code → /api/llm-proxy/anthropic",
+			baseURL: "https://api.anthropic.com/v1",
+			reqPath: "v1/messages",
+			want:    "/v1/messages",
+		},
+		// OpenCode's Anthropic provider (Vercel AI SDK) is documented with base
+		// "https://api.anthropic.com/v1" and appends "/messages". Pointed at
+		// base=…/api/llm-proxy/anthropic/v1 the mux still captures "v1/messages".
+		{
+			name:    "OpenCode (Anthropic via Vercel AI SDK) → /api/llm-proxy/anthropic/v1",
+			baseURL: "https://api.anthropic.com/v1",
+			reqPath: "v1/messages",
+			want:    "/v1/messages",
+		},
+		// OpenAI Python/TS SDKs default to base="https://api.openai.com/v1" and
+		// append "/responses". Pointed at base=…/api/llm-proxy/openai/v1 → mux
+		// captures "v1/responses".
+		{
+			name:    "OpenAI SDK (Responses API) → /api/llm-proxy/openai/v1",
+			baseURL: "https://api.openai.com/v1",
+			reqPath: "v1/responses",
+			want:    "/v1/responses",
+		},
+		// Same SDK, chat completions endpoint.
+		{
+			name:    "OpenAI SDK (Chat Completions) → /api/llm-proxy/openai/v1",
+			baseURL: "https://api.openai.com/v1",
+			reqPath: "v1/chat/completions",
+			want:    "/v1/chat/completions",
+		},
+		// OpenAI SDK list-models endpoint (GET /v1/models).
+		{
+			name:    "OpenAI SDK (list models) → /api/llm-proxy/openai/v1",
+			baseURL: "https://api.openai.com/v1",
+			reqPath: "v1/models",
+			want:    "/v1/models",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := mustParseURL(tt.baseURL)
+			director := llmTransformRequest(*u, nil)
+
+			req := httptest.NewRequest(http.MethodPost, "http://gateway.local/", nil)
+			req.SetPathValue("path", tt.reqPath)
+
+			director(req)
+
+			if got := req.URL.Path; got != tt.want {
+				t.Fatalf("URL.Path = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -1209,4 +1325,353 @@ func TestParseMessagesFromBody_ConversationHistoryForPolicyEval(t *testing.T) {
 	if !strings.Contains(ctx, "Find flights to NYC") {
 		t.Error("conversation context should contain user messages")
 	}
+}
+
+// runModelListFilter builds a GET /v1/models response carrying body and runs it
+// through modifyResponse exactly as the passthrough proxy would, returning the
+// (possibly rewritten) response and its body.
+func runModelListFilter(t *testing.T, statusCode int, allowAll bool, allowed map[string]bool, body string) (*http.Response, string) {
+	t.Helper()
+
+	r := &responseModifier{
+		userID:              "u1",
+		allowAllModels:      allowAll,
+		allowedTargetModels: allowed,
+	}
+	resp := &http.Response{
+		StatusCode: statusCode,
+		Header: http.Header{
+			"Content-Type":     []string{"application/json"},
+			"Content-Encoding": []string{"gzip"},
+		},
+		Body:    io.NopCloser(strings.NewReader(body)),
+		Request: &http.Request{URL: &url.URL{Path: "/v1/models"}},
+	}
+
+	if err := r.modifyResponse(resp); err != nil {
+		t.Fatalf("modifyResponse() error = %v", err)
+	}
+
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	return resp, string(out)
+}
+
+func modelDataIDs(body string) []string {
+	var ids []string
+	for _, r := range gjson.Get(body, "data.#.id").Array() {
+		ids = append(ids, r.String())
+	}
+	return ids
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// assertCursor checks a pagination cursor field: want == nil means the field must
+// be absent (deleted, not present-but-null); otherwise it must equal *want.
+func assertCursor(t *testing.T, body, key string, want *string) {
+	t.Helper()
+	got := gjson.Get(body, key)
+	if want == nil {
+		if got.Exists() {
+			t.Errorf("%s = %s, want field absent", key, got.Raw)
+		}
+		return
+	}
+	if got.String() != *want {
+		t.Errorf("%s = %q, want %q", key, got.String(), *want)
+	}
+}
+
+// assertEntriesPreserved checks that every surviving entry is byte-identical to
+// the one in the upstream body — the byte-perfect fidelity guarantee.
+func assertEntriesPreserved(t *testing.T, in, out string, ids []string) {
+	t.Helper()
+	for _, id := range ids {
+		q := fmt.Sprintf("data.#(id==%q)", id)
+		if want, got := gjson.Get(in, q).Raw, gjson.Get(out, q).Raw; want != got {
+			t.Errorf("entry %q not preserved byte-for-byte:\n upstream = %s\n filtered = %s", id, want, got)
+		}
+	}
+}
+
+func assertFilteredHeaders(t *testing.T, resp *http.Response, out string) {
+	t.Helper()
+	if got := resp.Header.Get("Content-Encoding"); got != "" {
+		t.Errorf("Content-Encoding = %q, want removed", got)
+	}
+	if got, want := resp.Header.Get("Content-Length"), strconv.Itoa(len(out)); got != want {
+		t.Errorf("Content-Length header = %q, want %q", got, want)
+	}
+	if resp.ContentLength != int64(len(out)) {
+		t.Errorf("ContentLength = %d, want %d", resp.ContentLength, len(out))
+	}
+}
+
+func TestModifyResponse_FiltersAnthropicModelList(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowed     map[string]bool
+		body        string
+		wantIDs     []string
+		wantFirstID *string
+		wantLastID  *string
+	}{
+		{
+			name:        "keeps allowed subset and repoints cursors to boundaries",
+			allowed:     map[string]bool{"claude-opus-4": true, "claude-haiku-4": true},
+			body:        `{"data":[{"type":"model","id":"claude-opus-4"},{"type":"model","id":"claude-sonnet-4"},{"type":"model","id":"claude-haiku-4"}],"first_id":"claude-opus-4","has_more":false,"last_id":"claude-haiku-4"}`,
+			wantIDs:     []string{"claude-opus-4", "claude-haiku-4"},
+			wantFirstID: new("claude-opus-4"),
+			wantLastID:  new("claude-haiku-4"),
+		},
+		{
+			name:        "single middle survivor becomes both cursors",
+			allowed:     map[string]bool{"claude-sonnet-4": true},
+			body:        `{"data":[{"type":"model","id":"claude-opus-4"},{"type":"model","id":"claude-sonnet-4"},{"type":"model","id":"claude-haiku-4"}],"first_id":"claude-opus-4","has_more":false,"last_id":"claude-haiku-4"}`,
+			wantIDs:     []string{"claude-sonnet-4"},
+			wantFirstID: new("claude-sonnet-4"),
+			wantLastID:  new("claude-sonnet-4"),
+		},
+		{
+			name:        "empty page on last page drops both cursors",
+			allowed:     map[string]bool{},
+			body:        `{"data":[{"type":"model","id":"claude-opus-4"}],"first_id":"claude-opus-4","has_more":false,"last_id":"claude-opus-4"}`,
+			wantIDs:     nil,
+			wantFirstID: nil,
+			wantLastID:  nil,
+		},
+		{
+			name:        "empty page with more pages retains upstream last_id",
+			allowed:     map[string]bool{},
+			body:        `{"data":[{"type":"model","id":"claude-opus-4"}],"first_id":"claude-opus-4","has_more":true,"last_id":"page-cursor"}`,
+			wantIDs:     nil,
+			wantFirstID: nil,
+			wantLastID:  new("page-cursor"),
+		},
+		{
+			name:        "preserves entry bytes (key order and large integers)",
+			allowed:     map[string]bool{"claude-sonnet-4": true},
+			body:        `{"data":[{"type":"model","id":"claude-opus-4"},{"zzz_meta":1,"id":"claude-sonnet-4","created":1234567890123456789,"display_name":"Sonnet"}],"first_id":"claude-opus-4","has_more":false,"last_id":"claude-sonnet-4"}`,
+			wantIDs:     []string{"claude-sonnet-4"},
+			wantFirstID: new("claude-sonnet-4"),
+			wantLastID:  new("claude-sonnet-4"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, out := runModelListFilter(t, http.StatusOK, false, tt.allowed, tt.body)
+
+			if got := modelDataIDs(out); !sameStrings(got, tt.wantIDs) {
+				t.Errorf("data ids = %v, want %v", got, tt.wantIDs)
+			}
+			assertCursor(t, out, "first_id", tt.wantFirstID)
+			assertCursor(t, out, "last_id", tt.wantLastID)
+			assertEntriesPreserved(t, tt.body, out, tt.wantIDs)
+			assertFilteredHeaders(t, resp, out)
+		})
+	}
+}
+
+func TestModifyResponse_FiltersOpenAIModelList(t *testing.T) {
+	tests := []struct {
+		name    string
+		allowed map[string]bool
+		body    string
+		wantIDs []string
+	}{
+		{
+			name:    "keeps allowed subset and leaves the envelope alone",
+			allowed: map[string]bool{"gpt-4o": true},
+			body:    `{"object":"list","data":[{"id":"gpt-4o","object":"model","created":1686935002,"owned_by":"openai"},{"id":"gpt-3.5-turbo","object":"model","created":1677610602,"owned_by":"openai"}]}`,
+			wantIDs: []string{"gpt-4o"},
+		},
+		{
+			name:    "allowed nothing yields empty list",
+			allowed: map[string]bool{},
+			body:    `{"object":"list","data":[{"id":"gpt-4o","object":"model","created":1686935002}]}`,
+			wantIDs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, out := runModelListFilter(t, http.StatusOK, false, tt.allowed, tt.body)
+
+			if got := modelDataIDs(out); !sameStrings(got, tt.wantIDs) {
+				t.Errorf("data ids = %v, want %v", got, tt.wantIDs)
+			}
+			if got := gjson.Get(out, "object").String(); got != "list" {
+				t.Errorf("object = %q, want \"list\"", got)
+			}
+			// OpenAI lists carry no cursors; we must not invent them.
+			assertCursor(t, out, "first_id", nil)
+			assertCursor(t, out, "last_id", nil)
+			assertEntriesPreserved(t, tt.body, out, tt.wantIDs)
+			assertFilteredHeaders(t, resp, out)
+		})
+	}
+}
+
+func TestModifyResponse_ModelListPassthrough(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		allowAll   bool
+		allowed    map[string]bool
+		body       string
+	}{
+		{
+			name:       "allow-all forwards the full list untouched",
+			statusCode: http.StatusOK,
+			allowAll:   true,
+			body:       `{"data":[{"id":"a"},{"id":"b"}],"first_id":"a","has_more":false,"last_id":"b"}`,
+		},
+		{
+			name:       "non-200 is forwarded untouched",
+			statusCode: http.StatusInternalServerError,
+			allowed:    map[string]bool{},
+			body:       `{"type":"error","error":{"message":"boom"}}`,
+		},
+		{
+			name:       "non-JSON body is forwarded untouched",
+			statusCode: http.StatusOK,
+			allowed:    map[string]bool{},
+			body:       "not json at all",
+		},
+		{
+			name:       "JSON without a data array is forwarded untouched",
+			statusCode: http.StatusOK,
+			allowed:    map[string]bool{},
+			body:       `{"error":{"message":"nope"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, out := runModelListFilter(t, tt.statusCode, tt.allowAll, tt.allowed, tt.body)
+
+			if out != tt.body {
+				t.Errorf("body modified:\n got = %s\nwant = %s", out, tt.body)
+			}
+			// Passthrough must not strip transfer headers.
+			if got := resp.Header.Get("Content-Encoding"); got != "gzip" {
+				t.Errorf("Content-Encoding = %q, want gzip (untouched)", got)
+			}
+		})
+	}
+}
+
+func TestRewriteAnthropicListCursors(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		wantFirstID   *string
+		wantLastID    *string
+		wantUnchanged bool
+	}{
+		{
+			name:        "non-empty repoints to boundary ids",
+			body:        `{"data":[{"id":"a"},{"id":"b"},{"id":"c"}],"first_id":"x","has_more":false,"last_id":"y"}`,
+			wantFirstID: new("a"),
+			wantLastID:  new("c"),
+		},
+		{
+			name:          "openai shape without cursors is untouched",
+			body:          `{"object":"list","data":[{"id":"a"}]}`,
+			wantFirstID:   nil,
+			wantLastID:    nil,
+			wantUnchanged: true,
+		},
+		{
+			name:        "empty page on last page drops both cursors",
+			body:        `{"data":[],"first_id":"x","has_more":false,"last_id":"y"}`,
+			wantFirstID: nil,
+			wantLastID:  nil,
+		},
+		{
+			name:        "empty page with more pages retains last_id",
+			body:        `{"data":[],"first_id":"x","has_more":true,"last_id":"y"}`,
+			wantFirstID: nil,
+			wantLastID:  new("y"),
+		},
+		{
+			name:        "only first_id present is the only field set",
+			body:        `{"data":[{"id":"a"}],"first_id":"x"}`,
+			wantFirstID: new("a"),
+			wantLastID:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := rewriteAnthropicListCursors([]byte(tt.body))
+			if err != nil {
+				t.Fatalf("rewriteAnthropicListCursors() error = %v", err)
+			}
+			if tt.wantUnchanged && string(out) != tt.body {
+				t.Errorf("body changed:\n got = %s\nwant = %s", out, tt.body)
+			}
+			assertCursor(t, string(out), "first_id", tt.wantFirstID)
+			assertCursor(t, string(out), "last_id", tt.wantLastID)
+		})
+	}
+}
+
+func TestCopyBody(t *testing.T) {
+	t.Run("restores body and returns a copy safe to modify", func(t *testing.T) {
+		body := io.NopCloser(strings.NewReader("hello"))
+
+		got, err := copyBody(&body)
+		if err != nil {
+			t.Fatalf("copyBody() error = %v", err)
+		}
+		if string(got) != "hello" {
+			t.Fatalf("copyBody() = %q, want %q", got, "hello")
+		}
+
+		// Mutating the returned slice must not affect the restored body.
+		got[0] = 'J'
+
+		restored, err := io.ReadAll(body)
+		if err != nil {
+			t.Fatalf("read restored body: %v", err)
+		}
+		if string(restored) != "hello" {
+			t.Errorf("restored body = %q, want %q (unaffected by caller mutation)", restored, "hello")
+		}
+	})
+
+	t.Run("works on an http.Response body field", func(t *testing.T) {
+		resp := &http.Response{Body: io.NopCloser(strings.NewReader("payload"))}
+
+		got, err := copyBody(&resp.Body)
+		if err != nil {
+			t.Fatalf("copyBody() error = %v", err)
+		}
+		if string(got) != "payload" {
+			t.Fatalf("copyBody() = %q, want %q", got, "payload")
+		}
+
+		restored, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read restored body: %v", err)
+		}
+		if string(restored) != "payload" {
+			t.Errorf("restored body = %q, want %q", restored, "payload")
+		}
+	})
 }

--- a/pkg/modelaccesspolicy/helper.go
+++ b/pkg/modelaccesspolicy/helper.go
@@ -10,19 +10,22 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	gocache "k8s.io/client-go/tools/cache"
 )
 
 const (
-	mapUserIndex     = "user-id"
-	mapGroupIndex    = "group-id"
-	mapSelectorIndex = "selector-id"
-	dmaModelIndex    = "model-id"
+	mapUserIndex       = "user-id"
+	mapGroupIndex      = "group-id"
+	mapSelectorIndex   = "selector-id"
+	dmaModelIndex      = "model-id"
+	modelProviderIndex = "model-provider"
 )
 
 type Helper struct {
-	mapIndexer, dmaIndexer gocache.Indexer
+	mapIndexer, dmaIndexer, modelIndexer gocache.Indexer
 }
 
 func NewHelper(ctx context.Context, backend backend.Backend) (*Helper, error) {
@@ -62,9 +65,29 @@ func NewHelper(ctx context.Context, backend backend.Backend) (*Helper, error) {
 		return nil, err
 	}
 
+	// Create indexer for Model, keyed by provider, so we can resolve external
+	// clients' provider-native target models (e.g. "claude-sonnet-4-5") to the
+	// internal models the user's access is evaluated against.
+	modelGVK, err := backend.GroupVersionKindFor(&v1.Model{})
+	if err != nil {
+		return nil, err
+	}
+
+	modelInformer, err := backend.GetInformerForKind(ctx, modelGVK)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := modelInformer.AddIndexers(gocache.Indexers{
+		modelProviderIndex: modelProviderIndexFunc,
+	}); err != nil {
+		return nil, err
+	}
+
 	return &Helper{
-		mapIndexer: mapInformer.GetIndexer(),
-		dmaIndexer: dmaInformer.GetIndexer(),
+		mapIndexer:   mapInformer.GetIndexer(),
+		dmaIndexer:   dmaInformer.GetIndexer(),
+		modelIndexer: modelInformer.GetIndexer(),
 	}, nil
 }
 
@@ -144,6 +167,79 @@ func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, e
 	}
 
 	return allowedModels, false, nil
+}
+
+// GetUserAllowedTargetModels returns the set of provider-native target model
+// ids (v1.Model.Spec.Manifest.TargetModel) for provider that the user is
+// allowed to use. A target is included iff a configured, active model maps to
+// it and the user is allowed that model. This mirrors the access check enforced
+// by the LLM passthrough: a target appears here iff a request for it would
+// succeed.
+//
+// allowAll reports that the user may use every model (admin/owner or a wildcard
+// model selector). In that case there's nothing to enumerate, so the returned
+// map is nil and callers should skip filtering entirely rather than treat the
+// nil map as "allow nothing".
+func (h *Helper) GetUserAllowedTargetModels(user kuser.Info, provider string) (allowed map[string]bool, allowAll bool, _ error) {
+	allowedModels, allowAll, err := h.GetUserAllowedModels(user)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if allowAll {
+		// The user may use any model, so there's nothing to filter; skip the
+		// provider lookup entirely.
+		return nil, true, nil
+	}
+
+	// Models served by provider. The provider index already drops deleted,
+	// inactive, and unconfigured models, so every entry has a usable target.
+	objs, err := h.modelIndexer.ByIndex(modelProviderIndex, provider)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get models for provider %q: %w", provider, err)
+	}
+
+	allowed = make(map[string]bool, len(objs))
+	for _, obj := range objs {
+		m, ok := obj.(*v1.Model)
+		if ok && allowedModels[m.Name] {
+			allowed[m.Spec.Manifest.TargetModel] = true
+		}
+	}
+
+	return allowed, false, nil
+}
+
+// ResolveTargetModel returns the active Model served by provider whose
+// TargetModel matches targetModel, preferring the most recently created when
+// more than one matches. The lookup is served directly from the
+// (provider, targetModel) index, so it doesn't scan all of a provider's models.
+// It is used to resolve external clients' provider-native model ids
+// (e.g. "claude-sonnet-4-5") to a configured model. Returns a NotFound error if
+// no active model matches. The returned Model is owned by the informer cache;
+// treat it as read-only.
+func (h *Helper) ResolveTargetModel(provider, targetModel string) (*v1.Model, error) {
+	objs, err := h.modelIndexer.ByIndex(modelProviderIndex, modelProviderTargetKey(provider, targetModel))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get models for provider %q target %q: %w", provider, targetModel, err)
+	}
+
+	var newest *v1.Model
+	for _, obj := range objs {
+		m, ok := obj.(*v1.Model)
+		if !ok || m.Spec.Manifest.ModelProvider != provider || m.Spec.Manifest.TargetModel != targetModel {
+			continue
+		}
+		if newest == nil || m.CreationTimestamp.After(newest.CreationTimestamp.Time) {
+			newest = m
+		}
+	}
+
+	if newest == nil {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: v1.SchemeGroupVersion.Group, Resource: "model"}, targetModel)
+	}
+
+	return newest, nil
 }
 
 // GetModelAccessPolicysForUser returns all policies that apply to a specific user.
@@ -237,6 +333,31 @@ func dmaModelIndexFunc(obj any) ([]string, error) {
 	return []string{
 		fmt.Sprintf("%s/%s", alias, model),
 	}, nil
+}
+
+// modelProviderIndexFunc indexes a Model by its provider. Deleted, inactive, and
+// unconfigured models are dropped from the index so consumers only ever see the
+// set of models that are actually usable.
+// modelProviderIndexFunc indexes a Model under two keys: its provider (for
+// enumerating a provider's models) and its provider/targetModel pair (for
+// resolving a provider-native target model id with a single lookup). Deleted,
+// inactive, and unconfigured models (no provider or no target model) are dropped
+// from the index.
+func modelProviderIndexFunc(obj any) ([]string, error) {
+	model := obj.(*v1.Model)
+	provider, target := model.Spec.Manifest.ModelProvider, model.Spec.Manifest.TargetModel
+	if !model.DeletionTimestamp.IsZero() || !model.Spec.Manifest.Active || provider == "" || target == "" {
+		return nil, nil
+	}
+
+	return []string{provider, modelProviderTargetKey(provider, target)}, nil
+}
+
+// modelProviderTargetKey builds the provider/targetModel index key. Provider
+// names are Kubernetes resource names and never contain "/", so this is an
+// unambiguous encoding even when targetModel itself contains "/".
+func modelProviderTargetKey(provider, targetModel string) string {
+	return fmt.Sprintf("%s/%s", provider, targetModel)
 }
 
 // authGroupSet returns a set of auth provider groups for a given user.

--- a/pkg/modelaccesspolicy/helper.go
+++ b/pkg/modelaccesspolicy/helper.go
@@ -227,7 +227,7 @@ func (h *Helper) ResolveTargetModel(provider, targetModel string) (*v1.Model, er
 	var newest *v1.Model
 	for _, obj := range objs {
 		m, ok := obj.(*v1.Model)
-		if !ok || m.Spec.Manifest.ModelProvider != provider || m.Spec.Manifest.TargetModel != targetModel {
+		if !ok {
 			continue
 		}
 		if newest == nil || m.CreationTimestamp.After(newest.CreationTimestamp.Time) {
@@ -338,11 +338,6 @@ func dmaModelIndexFunc(obj any) ([]string, error) {
 // modelProviderIndexFunc indexes a Model by its provider. Deleted, inactive, and
 // unconfigured models are dropped from the index so consumers only ever see the
 // set of models that are actually usable.
-// modelProviderIndexFunc indexes a Model under two keys: its provider (for
-// enumerating a provider's models) and its provider/targetModel pair (for
-// resolving a provider-native target model id with a single lookup). Deleted,
-// inactive, and unconfigured models (no provider or no target model) are dropped
-// from the index.
 func modelProviderIndexFunc(obj any) ([]string, error) {
 	model := obj.(*v1.Model)
 	provider, target := model.Spec.Manifest.ModelProvider, model.Spec.Manifest.TargetModel

--- a/pkg/modelaccesspolicy/helper_test.go
+++ b/pkg/modelaccesspolicy/helper_test.go
@@ -1,0 +1,224 @@
+package modelaccesspolicy
+
+import (
+	"testing"
+	"time"
+
+	types2 "github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+	gocache "k8s.io/client-go/tools/cache"
+)
+
+func TestResolveTargetModel(t *testing.T) {
+	const provider = "openai-model-provider"
+
+	tests := []struct {
+		name         string
+		models       []*v1.Model
+		provider     string
+		targetModel  string
+		wantName     string
+		wantNotFound bool
+	}{
+		{
+			name:        "finds active model",
+			models:      []*v1.Model{newModel("m1-openai-gpt-4o", provider, "gpt-4o", true)},
+			provider:    provider,
+			targetModel: "gpt-4o",
+			wantName:    "m1-openai-gpt-4o",
+		},
+		{
+			name:         "ignores model from a different provider",
+			models:       []*v1.Model{newModel("m1-other-gpt-4o", "some-other-provider", "gpt-4o", true)},
+			provider:     provider,
+			targetModel:  "gpt-4o",
+			wantNotFound: true,
+		},
+		{
+			name:         "ignores inactive model",
+			models:       []*v1.Model{newModel("m1-openai-gpt-4o-inactive", provider, "gpt-4o", false)},
+			provider:     provider,
+			targetModel:  "gpt-4o",
+			wantNotFound: true,
+		},
+		{
+			name: "most recently created wins on duplicate",
+			models: []*v1.Model{
+				newModel("m1-openai-gpt-4o-older", provider, "gpt-4o", true, withCreated(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))),
+				newModel("m1-openai-gpt-4o-newer", provider, "gpt-4o", true, withCreated(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))),
+			},
+			provider:    provider,
+			targetModel: "gpt-4o",
+			wantName:    "m1-openai-gpt-4o-newer",
+		},
+		{
+			name:         "no models configured",
+			provider:     provider,
+			targetModel:  "gpt-4o",
+			wantNotFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newModelHelper(t, tt.models)
+
+			got, err := h.ResolveTargetModel(tt.provider, tt.targetModel)
+			if tt.wantNotFound {
+				require.True(t, apierrors.IsNotFound(err), "expected NotFound, got %v", err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, got.Name)
+		})
+	}
+}
+
+func TestGetUserAllowedTargetModels(t *testing.T) {
+	const (
+		provider = "openai-model-provider"
+		userID   = "u1"
+	)
+
+	// userPolicy grants the given model IDs to userID.
+	userPolicy := func(modelIDs ...string) *v1.ModelAccessPolicy {
+		models := make([]types2.ModelResource, 0, len(modelIDs))
+		for _, id := range modelIDs {
+			models = append(models, types2.ModelResource{ID: id})
+		}
+		return &v1.ModelAccessPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: "p-user", Namespace: "default"},
+			Spec: v1.ModelAccessPolicySpec{Manifest: types2.ModelAccessPolicyManifest{
+				Subjects: []types2.Subject{{Type: types2.SubjectTypeUser, ID: userID}},
+				Models:   models,
+			}},
+		}
+	}
+
+	// wildcardPolicy grants every model to every user.
+	wildcardPolicy := &v1.ModelAccessPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-wildcard", Namespace: "default"},
+		Spec: v1.ModelAccessPolicySpec{Manifest: types2.ModelAccessPolicyManifest{
+			Subjects: []types2.Subject{{Type: types2.SubjectTypeSelector, ID: "*"}},
+			Models:   []types2.ModelResource{{ID: "*"}},
+		}},
+	}
+
+	tests := []struct {
+		name         string
+		models       []*v1.Model
+		policies     []*v1.ModelAccessPolicy
+		want         map[string]bool
+		wantAllowAll bool
+	}{
+		{
+			name: "returns target models the user is allowed",
+			models: []*v1.Model{
+				newModel("m1-gpt-4o", provider, "gpt-4o", true),
+				newModel("m1-gpt-4o-mini", provider, "gpt-4o-mini", true),
+			},
+			policies: []*v1.ModelAccessPolicy{userPolicy("m1-gpt-4o")},
+			want:     map[string]bool{"gpt-4o": true},
+		},
+		{
+			name: "excludes inactive and other providers",
+			models: []*v1.Model{
+				newModel("m1-gpt-4o", provider, "gpt-4o", true),
+				newModel("m1-gpt-4o-inactive", provider, "gpt-4o-inactive", false),
+				newModel("m1-other", "some-other-provider", "claude-sonnet-4-5", true),
+			},
+			// Grant every model name; only the active, same-provider one survives
+			// because the provider index drops the others.
+			policies: []*v1.ModelAccessPolicy{userPolicy("m1-gpt-4o", "m1-gpt-4o-inactive", "m1-other")},
+			want:     map[string]bool{"gpt-4o": true},
+		},
+		{
+			name: "wildcard policy reports allowAll without enumerating",
+			models: []*v1.Model{
+				newModel("m1-gpt-4o", provider, "gpt-4o", true),
+				newModel("m1-gpt-4o-mini", provider, "gpt-4o-mini", true),
+			},
+			policies:     []*v1.ModelAccessPolicy{wildcardPolicy},
+			want:         nil,
+			wantAllowAll: true,
+		},
+		{
+			name: "empty when user is allowed nothing",
+			models: []*v1.Model{
+				newModel("m1-gpt-4o", provider, "gpt-4o", true),
+			},
+			want: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newModelHelper(t, tt.models, tt.policies...)
+
+			got, allowAll, err := h.GetUserAllowedTargetModels(&kuser.DefaultInfo{Name: userID, UID: userID}, provider)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAllowAll, allowAll)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// newModelHelper returns a Helper whose model and policy indexers are populated,
+// mirroring the production indexes built in NewHelper.
+func newModelHelper(t *testing.T, models []*v1.Model, policies ...*v1.ModelAccessPolicy) *Helper {
+	t.Helper()
+
+	modelIndexer := gocache.NewIndexer(gocache.MetaNamespaceKeyFunc, gocache.Indexers{
+		modelProviderIndex: modelProviderIndexFunc,
+	})
+	for _, m := range models {
+		require.NoError(t, modelIndexer.Add(m))
+	}
+
+	mapIndexer := gocache.NewIndexer(gocache.MetaNamespaceKeyFunc, gocache.Indexers{
+		mapUserIndex:     mapSubjectIndexFunc(types2.SubjectTypeUser),
+		mapGroupIndex:    mapSubjectIndexFunc(types2.SubjectTypeGroup),
+		mapSelectorIndex: mapSubjectIndexFunc(types2.SubjectTypeSelector),
+	})
+	for _, p := range policies {
+		require.NoError(t, mapIndexer.Add(p))
+	}
+
+	return &Helper{
+		mapIndexer:   mapIndexer,
+		dmaIndexer:   gocache.NewIndexer(gocache.MetaNamespaceKeyFunc, gocache.Indexers{dmaModelIndex: dmaModelIndexFunc}),
+		modelIndexer: modelIndexer,
+	}
+}
+
+type modelOpt func(*v1.Model)
+
+func withCreated(ts time.Time) modelOpt {
+	return func(m *v1.Model) {
+		m.CreationTimestamp = metav1.NewTime(ts)
+	}
+}
+
+func newModel(name, provider, targetModel string, active bool, opts ...modelOpt) *v1.Model {
+	m := &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{
+			TargetModel:   targetModel,
+			ModelProvider: provider,
+			Active:        active,
+		}},
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -27,6 +27,7 @@
 	import {
 		AlarmClock,
 		Boxes,
+		BrainCog,
 		Captions,
 		ChartBarDecreasing,
 		ChevronDown,
@@ -371,6 +372,32 @@
 						collapsible: true,
 						items: [
 							{
+								id: 'admin-agents',
+								href: '/admin/agents',
+								icon: Bots,
+								label: 'Agents',
+								collapsible: false,
+								disabled: isBootStrapUser || !agentLinkEnabled
+							},
+							{
+								id: 'launch-agent-chat',
+								href: '/agent',
+								icon: BotMessageSquare,
+								label: 'Launch Agent',
+								disabled: isBootStrapUser || !agentLinkEnabled,
+								collapsible: false,
+								noteIcon: !agentLinkEnabled ? LockOpen : undefined,
+								note: !agentLinkEnabled ? renderAgentDisabledNote : undefined
+							}
+						]
+					},
+					{
+						id: 'llm-gateway',
+						icon: BrainCog,
+						label: 'LLM Gateway',
+						collapsible: true,
+						items: [
+							{
 								id: 'tokens',
 								href: '/admin/token-usage',
 								icon: Coins,
@@ -385,7 +412,6 @@
 								label: 'Model Providers',
 								collapsible: false
 							},
-
 							{
 								id: 'model-access-policies',
 								href: '/admin/model-access-policies',
@@ -411,26 +437,13 @@
 										}
 									]
 								: []),
-							...[
-								{
-									id: 'admin-agents',
-									href: '/admin/agents',
-									icon: Bots,
-									label: 'Agents',
-									collapsible: false,
-									disabled: isBootStrapUser || !agentLinkEnabled
-								},
-								{
-									id: 'launch-agent-chat',
-									href: '/agent',
-									icon: BotMessageSquare,
-									label: 'Launch Agent',
-									disabled: isBootStrapUser || !agentLinkEnabled,
-									collapsible: false,
-									noteIcon: !agentLinkEnabled ? LockOpen : undefined,
-									note: !agentLinkEnabled ? renderAgentDisabledNote : undefined
-								}
-							]
+							{
+								id: 'llm-gateway-models',
+								href: '/llm-gateway/models',
+								icon: Boxes,
+								label: 'Models',
+								collapsible: false
+							}
 						]
 					},
 					{
@@ -510,6 +523,21 @@
 						icon: Laptop,
 						label: 'Devices',
 						collapsible: false
+					},
+					{
+						id: 'llm-gateway',
+						icon: BrainCog,
+						label: 'LLM Gateway',
+						collapsible: true,
+						items: [
+							{
+								id: 'llm-gateway-models',
+								href: '/llm-gateway/models',
+								icon: Boxes,
+								label: 'Models',
+								collapsible: false
+							}
+						]
 					},
 					...chatLinks
 				]

--- a/ui/user/src/lib/components/llm-gateway/LLMGatewayCodeBlock.svelte
+++ b/ui/user/src/lib/components/llm-gateway/LLMGatewayCodeBlock.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import CopyButton from '$lib/components/CopyButton.svelte';
+	import type { SnippetBlock } from '$lib/services/llm-gateway/types';
+	import { twMerge } from 'tailwind-merge';
+
+	interface Props {
+		block: SnippetBlock;
+		class?: string;
+	}
+
+	let { block, class: clazz = '' }: Props = $props();
+</script>
+
+<div class={twMerge('flex flex-col gap-1', clazz)}>
+	{#if block.title}
+		<div class="text-muted-content flex items-center text-xs font-medium">
+			{block.title}
+		</div>
+	{/if}
+	<div class="bg-base-200 dark:bg-base-300 group relative rounded-md">
+		<div class="absolute top-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100">
+			<CopyButton
+				text={block.code}
+				classes={{ button: 'bg-base-100 dark:bg-base-200 rounded p-1.5' }}
+			/>
+		</div>
+		<pre class="default-scrollbar-thin overflow-x-auto p-3 pr-12 text-xs leading-relaxed"><code
+				class="font-mono">{block.code}</code
+			></pre>
+	</div>
+</div>

--- a/ui/user/src/lib/components/llm-gateway/LLMGatewayModelList.svelte
+++ b/ui/user/src/lib/components/llm-gateway/LLMGatewayModelList.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import CopyButton from '$lib/components/CopyButton.svelte';
+	import Search from '$lib/components/Search.svelte';
+	import type { Model } from '$lib/services';
+	import { ModelUsageLabels, type ModelUsage } from '$lib/services/admin/types';
+
+	interface Props {
+		models: Model[];
+	}
+
+	let { models }: Props = $props();
+
+	let search = $state('');
+
+	let filteredModels = $derived(
+		models
+			.filter((m) => {
+				if (!search) return true;
+				const lower = search.toLowerCase();
+				return (
+					m.name.toLowerCase().includes(lower) ||
+					(m.displayName ?? '').toLowerCase().includes(lower) ||
+					(m.usage ?? '').toLowerCase().includes(lower)
+				);
+			})
+			.sort((a, b) => (a.displayName || a.name).localeCompare(b.displayName || b.name))
+	);
+
+	function usageLabel(usage: string): string {
+		return ModelUsageLabels[usage as ModelUsage] || usage;
+	}
+</script>
+
+<div class="flex flex-col gap-3">
+	<Search
+		compact
+		class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
+		onChange={(val) => (search = val)}
+		value={search}
+		placeholder="Search models..."
+	/>
+
+	{#if filteredModels.length === 0}
+		<div class="text-muted-content py-4 text-center text-sm">
+			{#if models.length === 0}
+				No models available.
+			{:else}
+				No models match "{search}".
+			{/if}
+		</div>
+	{:else}
+		<ul class="flex flex-col">
+			{#each filteredModels as model (model.id)}
+				<li
+					class="border-base-300 dark:border-base-400 flex items-center justify-between gap-3 border-b py-2 last:border-b-0"
+				>
+					<div class="flex min-w-0 flex-col gap-0.5">
+						<div class="flex items-center gap-2">
+							<span class="truncate font-mono text-sm">{model.name}</span>
+							<CopyButton text={model.name} tooltipText="Copy model name" />
+						</div>
+						{#if model.displayName && model.displayName !== model.name}
+							<span class="text-muted-content truncate text-xs">{model.displayName}</span>
+						{/if}
+					</div>
+					{#if model.usage}
+						<span
+							class="bg-base-200 dark:bg-base-300 text-muted-content shrink-0 rounded px-2 py-0.5 text-xs"
+						>
+							{usageLabel(model.usage)}
+						</span>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</div>

--- a/ui/user/src/lib/components/llm-gateway/LLMGatewayProviderSection.svelte
+++ b/ui/user/src/lib/components/llm-gateway/LLMGatewayProviderSection.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import CopyButton from '$lib/components/CopyButton.svelte';
+	import type { Model } from '$lib/services';
+	import { renderCurlExample } from '$lib/services/llm-gateway/curl';
+	import type { RenderContext } from '$lib/services/llm-gateway/types';
+	import LLMGatewayCodeBlock from './LLMGatewayCodeBlock.svelte';
+	import LLMGatewayModelList from './LLMGatewayModelList.svelte';
+	import { ChevronDown, ChevronRight } from 'lucide-svelte';
+
+	interface Props {
+		ctx: RenderContext;
+		models: Model[];
+	}
+
+	let { ctx, models }: Props = $props();
+
+	let expanded = $state(true);
+
+	// Prefer a brand icon from one of the models (they all carry the provider's icon).
+	let icon = $derived(models[0]?.icon);
+	let iconDark = $derived(models[0]?.iconDark);
+
+	let curlBlock = $derived(renderCurlExample(ctx));
+</script>
+
+<section class="border-base-300 dark:border-base-400 rounded-lg border">
+	<button
+		type="button"
+		class="hover:bg-base-200 dark:hover:bg-base-300 flex w-full items-center justify-between gap-3 rounded-t-lg px-4 py-3 text-left transition-colors"
+		onclick={() => (expanded = !expanded)}
+	>
+		<div class="flex items-center gap-3">
+			{#if icon}
+				<img src={icon} alt={ctx.provider.displayName} class="icon size-6 shrink-0 dark:hidden" />
+			{/if}
+			{#if iconDark}
+				<img
+					src={iconDark}
+					alt={ctx.provider.displayName}
+					class="icon hidden size-6 shrink-0 dark:block"
+				/>
+			{/if}
+			<div class="flex flex-col">
+				<h3 class="text-lg font-semibold">{ctx.provider.displayName}</h3>
+				<span class="text-muted-content text-xs">
+					{models.length} model{models.length === 1 ? '' : 's'} available
+				</span>
+			</div>
+		</div>
+		{#if expanded}
+			<ChevronDown class="text-muted-content size-5 shrink-0" />
+		{:else}
+			<ChevronRight class="text-muted-content size-5 shrink-0" />
+		{/if}
+	</button>
+
+	{#if expanded}
+		<div class="border-base-300 dark:border-base-400 flex flex-col gap-6 border-t p-4">
+			<div class="flex flex-col gap-2">
+				<h4 class="text-sm font-semibold">Base URL</h4>
+				<div
+					class="bg-base-200 dark:bg-base-300 flex items-center justify-between gap-3 rounded-md px-3 py-2"
+				>
+					<code class="truncate font-mono text-xs">{ctx.baseURL}</code>
+					<CopyButton text={ctx.baseURL} tooltipText="Copy base URL" />
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<h4 class="text-sm font-semibold">Example request</h4>
+				<LLMGatewayCodeBlock block={curlBlock} />
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<h4 class="text-sm font-semibold">Available models</h4>
+				<LLMGatewayModelList {models} />
+			</div>
+		</div>
+	{/if}
+</section>

--- a/ui/user/src/lib/services/llm-gateway/curl.ts
+++ b/ui/user/src/lib/services/llm-gateway/curl.ts
@@ -1,0 +1,53 @@
+import type { RenderContext, SnippetBlock } from './types';
+
+function loginSubstitution(obotURL: string): string {
+	return `$(obot login --url ${obotURL} --print-token)`;
+}
+
+/** Build a copy-pasteable curl example for the provider's chat/messages endpoint. */
+export function renderCurlExample(ctx: RenderContext): SnippetBlock {
+	const model = ctx.exampleModel ?? '<model-name>';
+
+	if (ctx.provider.shortKey === 'anthropic') {
+		const body = JSON.stringify(
+			{
+				model,
+				max_tokens: 1024,
+				messages: [{ role: 'user', content: 'hello' }]
+			},
+			null,
+			2
+		);
+		const code = [
+			`export ANTHROPIC_BASE_URL="${ctx.baseURL}"`,
+			`export ANTHROPIC_API_KEY="${loginSubstitution(ctx.obotURL)}"`,
+			'',
+			'curl $ANTHROPIC_BASE_URL/v1/messages \\',
+			'  -H "x-api-key: $ANTHROPIC_API_KEY" \\',
+			'  -H "anthropic-version: 2023-06-01" \\',
+			'  -H "content-type: application/json" \\',
+			`  -d '${body}'`
+		].join('\n');
+		return { language: 'bash', code };
+	}
+
+	// OpenAI (Responses API)
+	const body = JSON.stringify(
+		{
+			model,
+			input: [{ role: 'user', content: 'hello' }]
+		},
+		null,
+		2
+	);
+	const code = [
+		`export OPENAI_BASE_URL="${ctx.baseURL}"`,
+		`export OPENAI_API_KEY="${loginSubstitution(ctx.obotURL)}"`,
+		'',
+		'curl $OPENAI_BASE_URL/v1/responses \\',
+		'  -H "Authorization: Bearer $OPENAI_API_KEY" \\',
+		'  -H "Content-Type: application/json" \\',
+		`  -d '${body}'`
+	].join('\n');
+	return { language: 'bash', code };
+}

--- a/ui/user/src/lib/services/llm-gateway/types.ts
+++ b/ui/user/src/lib/services/llm-gateway/types.ts
@@ -1,0 +1,44 @@
+import { CommonModelProviderIds } from '$lib/constants';
+
+export type ProviderShortKey = 'openai' | 'anthropic';
+
+export interface ProviderConnection {
+	id: string;
+	shortKey: ProviderShortKey;
+	displayName: string;
+}
+
+export const PROVIDER_CONNECTIONS: Record<ProviderShortKey, ProviderConnection> = {
+	openai: {
+		id: CommonModelProviderIds.OPENAI,
+		shortKey: 'openai',
+		displayName: 'OpenAI'
+	},
+	anthropic: {
+		id: CommonModelProviderIds.ANTHROPIC,
+		shortKey: 'anthropic',
+		displayName: 'Anthropic'
+	}
+};
+
+export const SUPPORTED_PROVIDER_IDS = new Set<string>([
+	CommonModelProviderIds.OPENAI,
+	CommonModelProviderIds.ANTHROPIC
+]);
+
+export interface RenderContext {
+	provider: ProviderConnection;
+	/** e.g. https://obot.example.com */
+	obotURL: string;
+	/** e.g. https://obot.example.com/api/llm-proxy/anthropic */
+	baseURL: string;
+	/** First available model name for the provider, used in example invocations. */
+	exampleModel?: string;
+}
+
+export interface SnippetBlock {
+	/** Optional label rendered above the code block. */
+	title?: string;
+	language: 'bash' | 'json' | 'toml';
+	code: string;
+}

--- a/ui/user/src/routes/llm-gateway/models/+page.svelte
+++ b/ui/user/src/routes/llm-gateway/models/+page.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import Layout from '$lib/components/Layout.svelte';
+	import LLMGatewayProviderSection from '$lib/components/llm-gateway/LLMGatewayProviderSection.svelte';
+	import { CommonModelProviderIds, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { PROVIDER_CONNECTIONS, type RenderContext } from '$lib/services/llm-gateway/types';
+	import { KeyRound } from 'lucide-svelte';
+	import { onMount } from 'svelte';
+	import { fly } from 'svelte/transition';
+
+	let { data } = $props();
+
+	let obotURL = $state('');
+
+	onMount(() => {
+		obotURL = window.location.origin;
+	});
+
+	let openaiModels = $derived(
+		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.OPENAI)
+	);
+	let anthropicModels = $derived(
+		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.ANTHROPIC)
+	);
+
+	function buildCtx(shortKey: 'openai' | 'anthropic', models: typeof data.models): RenderContext {
+		const provider = PROVIDER_CONNECTIONS[shortKey];
+		return {
+			provider,
+			obotURL,
+			baseURL: `${obotURL}/api/llm-proxy/${provider.shortKey}`,
+			exampleModel: models[0]?.name
+		};
+	}
+
+	let openaiCtx = $derived(buildCtx('openai', openaiModels));
+	let anthropicCtx = $derived(buildCtx('anthropic', anthropicModels));
+
+	let hasAny = $derived(openaiModels.length > 0 || anthropicModels.length > 0);
+	let ready = $derived(obotURL !== '');
+
+	const duration = PAGE_TRANSITION_DURATION;
+</script>
+
+<Layout title="LLM Gateway Models">
+	<div
+		class="flex h-full w-full flex-col gap-6"
+		in:fly={{ x: 100, duration, delay: duration }}
+		out:fly={{ x: -100, duration }}
+	>
+		<p class="text-muted-content max-w-3xl text-sm">
+			Use the Obot LLM Gateway to call OpenAI and Anthropic models with your Obot credentials.
+			Configure your client below, then pick from the models you have access to.
+		</p>
+
+		{#if !hasAny}
+			<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+				<KeyRound class="text-base-content/80 size-24 opacity-25" />
+				<h4 class="text-muted-content text-lg font-semibold">No gateway models available</h4>
+				<p class="text-muted-content text-sm font-light">
+					You don't currently have access to any OpenAI or Anthropic models through the gateway.
+					Contact an administrator to request access.
+				</p>
+			</div>
+		{:else if ready}
+			<div class="flex flex-col gap-4">
+				{#if anthropicModels.length > 0}
+					<LLMGatewayProviderSection ctx={anthropicCtx} models={anthropicModels} />
+				{/if}
+				{#if openaiModels.length > 0}
+					<LLMGatewayProviderSection ctx={openaiCtx} models={openaiModels} />
+				{/if}
+			</div>
+		{/if}
+	</div>
+</Layout>
+
+<svelte:head>
+	<title>Obot | LLM Gateway Models</title>
+</svelte:head>

--- a/ui/user/src/routes/llm-gateway/models/+page.ts
+++ b/ui/user/src/routes/llm-gateway/models/+page.ts
@@ -1,0 +1,23 @@
+import { CommonModelProviderIds } from '$lib/constants';
+import { handleRouteError } from '$lib/errors';
+import { UserService, type Model } from '$lib/services';
+import { profile } from '$lib/stores';
+import type { PageLoad } from './$types';
+
+const SUPPORTED_PROVIDER_IDS = new Set<string>([
+	CommonModelProviderIds.OPENAI,
+	CommonModelProviderIds.ANTHROPIC
+]);
+
+export const load: PageLoad = async ({ fetch }) => {
+	let models: Model[] = [];
+
+	try {
+		const all = await UserService.listModels({ fetch });
+		models = all.filter((m) => m.active && SUPPORTED_PROVIDER_IDS.has(m.modelProvider));
+	} catch (err) {
+		handleRouteError(err, '/llm-gateway/models', profile.current);
+	}
+
+	return { models };
+};


### PR DESCRIPTION
## Summary

The LLM Gateway passthrough routes existed but weren't usable by real external clients. This makes them work end-to-end: a user can point a client like **Claude Code** or **Codex** at the gateway's OpenAI or Anthropic passthrough route, authenticate with their Obot token, and call models by their native provider model names (`gpt-5.5`, `claude-sonnet-4-5`, etc...). The gateway proxies transparently to the vendor while enforcing per-user model access policy.

## What changed

### Backend: make the passthrough actually work

- **Resolve provider-native model names.** External clients send the vendor's own model IDs, which didn't map to anything internally. Added `ResolveTargetModel` to map a provider model ID back to its `Model` resource so access checks apply to the names clients actually send (newest wins when duplicates map to the same target).
- **Scope `/v1/models` to the user.** The models list now returns only the models the requesting user is allowed to call (`GetUserAllowedTargetModels`). Surviving entries are preserved byte-for-byte from upstream, and Anthropic pagination cursors are rewritten so clients never page into hidden models.
- **Normalize request paths.** Reconciled the differing base-URL conventions of internal vs. external clients so passthrough requests no longer produce malformed `/v1/v1/...` URLs.
- Pulled in `github.com/tidwall/sjson` for the in-place cursor rewriting.

### Frontend: model discovery + gateway sidenav

- **New `/llm-gateway/models` page** so users can see which OpenAI and Anthropic models they have access to, the provider base URL, and a copy-paste curl example (authenticated via `obot login --print-token`, pre-filled with one of their models).
- **Grouped the gateway pages under a new "LLM Gateway" sidenav section** (Tokens, Model Providers, Model Access Policies, and the new Models page), moving them out of the Obot Agent management group.

## Usage

```bash
export ANTHROPIC_BASE_URL="https://obot.example.com/api/llm-proxy/anthropic"
export ANTHROPIC_API_KEY="$(obot login --url https://obot.example.com --print-token)"

# Note: This assumes the authenticated user has been granted access to `claude-sonnet-4-6`
# with a ModelAccessPolicy in Obot
curl $ANTHROPIC_BASE_URL/v1/messages \
  -H "x-api-key: $ANTHROPIC_API_KEY" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{"model":"claude-sonnet-4-6","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}'
```

Setting up Claude Code for use with the gateway:

```bash
# 1. Logout of your existing anthropic account
claude auth logout

# 2. Setup base URL, API key
export ANTHROPIC_BASE_URL="https://obot.example.com/api/llm-proxy/anthropic"
export ANTHROPIC_API_KEY="$(obot login --url https://obot.example.com --print-token)"
export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 # Tells claude to query `/v1/models` for the set of available models at startup

# 3. Launch claude code
claude code
```

You can then run `/models` and select an Obot passthrough model to use (marked with "From Gateway").

Codex has also been tested with the openai passthrough, but requires more setup:

1. Update your `~/.codex/config.toml` with the following:

```toml
model_provider = "obot_openai"

[model_providers.obot_openai]
name = "OpenAI Obot LLM Gateway"
base_url = "http://localhost:8080/api/llm-proxy/openai"
env_key = "OBOT_API_KEY"
env_key_instructions = "Set the OBOT_API_KEY and restart to authenticate with the Obot LLM Gateway"
supports_websockets = false
```

2. Start the codex CLI or App

```bash
export OBOT_API_KEY="$(obot login --url https://obot.example.com --print-token)"
codex # Codex CLI
codex app # Open App
```



