### PR TITLE
chore: cli: raise max skill files to 200

### DIFF
--- a/pkg/localagents/skillarchive.go
+++ b/pkg/localagents/skillarchive.go
@@ -28,7 +28,7 @@ type SkillArchiveFile struct {
 }
 
 const (
-	maxSkillArchiveFiles             = 50
+	maxSkillArchiveFiles             = 200
 	maxSkillArchiveEntryBytes        = 100 * 1024 * 1024
 	maxSkillArchiveUncompressedBytes = 100 * 1024 * 1024
 )


### PR DESCRIPTION
50 was too low, as one of our default skills had eighty-something files in it.