### PR TITLE
fix: error status code in errors page

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { HttpError } from '$lib/errors';
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
@@ -272,7 +273,7 @@
 				}
 			}
 		} catch (error) {
-			if (error instanceof Error && error.message.includes('404')) {
+			if (error instanceof HttpError && error.statusCode === 404) {
 				// ignore, 404 means no credentials were set
 				return;
 			}

--- a/ui/user/src/lib/components/admin/FilterForm.svelte
+++ b/ui/user/src/lib/components/admin/FilterForm.svelte
@@ -2,6 +2,7 @@
 	import { beforeNavigate } from '$app/navigation';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { PAGE_TRANSITION_DURATION, PII_REDACT_TYPES, PII_BLOCK_TYPES } from '$lib/constants';
+	import { HttpError } from '$lib/errors';
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
@@ -192,7 +193,7 @@
 				}
 			}
 		} catch (error) {
-			if (error instanceof Error && error.message.includes('404')) {
+			if (error instanceof HttpError && error.statusCode === 404) {
 				// ignore, 404 means no credentials were set
 				return;
 			}

--- a/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
+++ b/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { HttpError } from '$lib/errors';
 	import { UserService, type MCPCatalogEntry, type MCPCatalogServer } from '$lib/services';
 	import type { EventStreamService } from '$lib/services/admin/eventstream.svelte';
 	import {
@@ -66,7 +67,7 @@
 				dontLogErrors: true
 			});
 		} catch (error) {
-			if (error instanceof Error && !error.message.includes('404')) {
+			if (error instanceof HttpError && error.statusCode !== 404) {
 				console.error('Failed to reveal user server values due to unexpected error', error);
 			}
 			values = {};

--- a/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
+++ b/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
@@ -67,7 +67,7 @@
 				dontLogErrors: true
 			});
 		} catch (error) {
-			if (error instanceof HttpError && error.statusCode !== 404) {
+			if (!(error instanceof HttpError) || error.statusCode !== 404) {
 				console.error('Failed to reveal user server values due to unexpected error', error);
 			}
 			values = {};

--- a/ui/user/src/lib/errors.ts
+++ b/ui/user/src/lib/errors.ts
@@ -1,31 +1,69 @@
 import type { Profile } from '$lib/services';
 import { error, redirect } from '@sveltejs/kit';
 
+const defaultErrorMessage = 'Unknown error occurred';
+
+export class HttpError extends Error {
+	constructor(
+		public statusCode: number,
+		message: string
+	) {
+		super(message);
+		this.name = 'HttpError';
+	}
+}
+
+export function createHttpError(statusCode: number, path: string, body: string): HttpError {
+	return new HttpError(statusCode, `${statusCode} ${path}: ${body}`);
+}
+
+export function getHttpStatusCode(e: unknown): number | undefined {
+	if (e instanceof HttpError) {
+		return e.statusCode;
+	}
+	return undefined;
+}
+
+function toAppError(e: Error): App.Error {
+	return {
+		message: e.message || defaultErrorMessage
+	};
+}
+
+function parseHttpErrorMessage(message: string): string {
+	// Match format i.e. "400 /path/to/resource: message"
+	const errorMatch = message.match(/^\d+\s+\/[^:]+:\s+(.*)/s);
+	return errorMatch?.[1] || message || defaultErrorMessage;
+}
+
 export function handleRouteError(e: unknown, path: string, profile?: Profile) {
 	if (!(e instanceof Error)) {
-		throw new Error('Unknown error occurred');
+		throw error(500, { message: 'Unknown error occurred' });
 	}
 
-	if (e.message?.includes('403') || e.message?.includes('forbidden')) {
+	const appError = toAppError(e);
+	const statusCode = getHttpStatusCode(e) ?? 500;
+
+	if (statusCode === 403) {
 		if (profile?.role === 0) {
 			throw redirect(303, `/?rd=${path}`);
 		}
-		throw error(403, e.message);
+		throw error(403, appError);
 	}
 
-	if (e.message?.includes('401') || e.message?.includes('unauthorized')) {
+	if (statusCode === 401) {
 		throw redirect(303, `/?rd=${path}`);
 	}
 
-	if (e.message?.includes('404') || e.message?.includes('not found')) {
+	if (statusCode === 404) {
 		if (path.includes('/s/')) {
 			throw error(404, `The chatbot at ${path} does not exist`);
 		}
 
-		throw error(404, e.message);
+		throw error(404, appError);
 	}
 
-	throw error(500, e.message);
+	throw error(statusCode, appError);
 }
 
 export function parseErrorContent(e: unknown) {
@@ -33,11 +71,19 @@ export function parseErrorContent(e: unknown) {
 		return { status: 500, message: 'Unknown error occurred' };
 	}
 
+	const statusCode = getHttpStatusCode(e);
+	if (statusCode !== undefined) {
+		return {
+			status: statusCode,
+			message: parseHttpErrorMessage(e.message)
+		};
+	}
+
 	// Match format i.e. "400 /path/to/resource: message"
 	const errorMatch = e.message.match(/^(\d+)(?:\s+\/[^:]+)?:\s+(.*)/);
 
-	const [, statusCode, messageContent] = errorMatch || [];
-	const status = parseInt(statusCode);
+	const [, legacyStatusCode, messageContent] = errorMatch || [];
+	const status = parseInt(legacyStatusCode);
 
 	return {
 		status: Number.isInteger(status) ? status : 500,

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
+import { HttpError } from '$lib/errors';
 import type { Skill } from '$lib/services/nanobot/types';
 import { buildQueryString } from '$lib/url';
 import {
@@ -1025,7 +1026,7 @@ export async function isMCPCatalogServerOauthNeeded(
 			signal: opts?.signal
 		});
 	} catch (err) {
-		if (err instanceof Error && err.message.includes('412')) {
+		if (err instanceof HttpError && err.statusCode === 412) {
 			return true;
 		}
 	}
@@ -1085,26 +1086,19 @@ export async function launchMCPFilter(id: string): Promise<{
 			success: true
 		};
 	} catch (err) {
+		if (err instanceof HttpError) {
+			return {
+				success: false,
+				message: err.message,
+				code: err.statusCode
+			};
+		}
 		if (err instanceof Error) {
-			if (err.message.includes('404')) {
-				return {
-					success: false,
-					message: err.message,
-					code: 404
-				};
-			} else if (err.message.includes('503')) {
-				return {
-					success: false,
-					message: err.message,
-					code: 503
-				};
-			} else {
-				return {
-					success: false,
-					message: err.message,
-					code: 500
-				};
-			}
+			return {
+				success: false,
+				message: err.message,
+				code: 500
+			};
 		}
 
 		throw err;

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -1086,18 +1086,11 @@ export async function launchMCPFilter(id: string): Promise<{
 			success: true
 		};
 	} catch (err) {
-		if (err instanceof HttpError) {
-			return {
-				success: false,
-				message: err.message,
-				code: err.statusCode
-			};
-		}
 		if (err instanceof Error) {
 			return {
 				success: false,
 				message: err.message,
-				code: 500
+				code: err instanceof HttpError ? err.statusCode : 500
 			};
 		}
 

--- a/ui/user/src/lib/services/http.ts
+++ b/ui/user/src/lib/services/http.ts
@@ -1,4 +1,5 @@
 import { UNAUTHORIZED_PATHS } from '$lib/constants';
+import { createHttpError } from '$lib/errors';
 import { profile } from '$lib/stores';
 import errors from '$lib/stores/errors.svelte';
 
@@ -70,7 +71,7 @@ export async function doGet(path: string, opts?: GetOptions): Promise<unknown> {
 			handle401Redirect();
 		}
 		const body = await resp.text();
-		const e = new Error(`${resp.status} ${path}: ${body}`);
+		const e = createHttpError(resp.status, path, body);
 		if (opts?.dontLogErrors) {
 			throw e;
 		}
@@ -137,7 +138,7 @@ export async function handleResponse(
 ): Promise<unknown> {
 	if (!resp.ok) {
 		const body = await resp.text();
-		const e = new Error(`${resp.status} ${path}: ${body}`);
+		const e = createHttpError(resp.status, path, body);
 		if (opts?.dontLogErrors) {
 			throw e;
 		}

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -1,4 +1,5 @@
 import { BOOTSTRAP_USER_ID } from '$lib/constants';
+import { HttpError } from '$lib/errors';
 import { Group } from '$lib/services/admin/types';
 import { buildQueryString } from '$lib/url';
 import type {
@@ -465,7 +466,7 @@ export async function isMcpServerOauthNeeded(
 			signal: opts?.signal
 		});
 	} catch (err) {
-		if (err instanceof Error && err.message.includes('412')) {
+		if (err instanceof HttpError && err.statusCode === 412) {
 			return true;
 		}
 	}
@@ -506,26 +507,19 @@ export async function validateSingleOrRemoteMcpServerLaunched(mcpServerId: strin
 			success: true
 		};
 	} catch (err) {
+		if (err instanceof HttpError) {
+			return {
+				success: false,
+				message: err.message,
+				code: err.statusCode
+			};
+		}
 		if (err instanceof Error) {
-			if (err.message.includes('404')) {
-				return {
-					success: false,
-					message: err.message,
-					code: 404
-				};
-			} else if (err.message.includes('503')) {
-				return {
-					success: false,
-					message: err.message,
-					code: 503
-				};
-			} else {
-				return {
-					success: false,
-					message: err.message,
-					code: 500
-				};
-			}
+			return {
+				success: false,
+				message: err.message,
+				code: 500
+			};
 		}
 
 		throw err;
@@ -1192,7 +1186,7 @@ export async function fetchWorkspaceIDForProfile(
 	const workspaces = await listWorkspaces(opts);
 	const workspaceID = workspaces.find((w) => w.userID === currentProfileID)?.id ?? null;
 	if (!workspaceID) {
-		throw new Error('404 Workspace not found.');
+		throw new HttpError(404, 'Workspace not found.');
 	}
 	return workspaceID;
 }

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -507,18 +507,11 @@ export async function validateSingleOrRemoteMcpServerLaunched(mcpServerId: strin
 			success: true
 		};
 	} catch (err) {
-		if (err instanceof HttpError) {
-			return {
-				success: false,
-				message: err.message,
-				code: err.statusCode
-			};
-		}
 		if (err instanceof Error) {
 			return {
 				success: false,
 				message: err.message,
-				code: 500
+				code: err instanceof HttpError ? err.statusCode : 500
 			};
 		}
 

--- a/ui/user/src/routes/+error.svelte
+++ b/ui/user/src/routes/+error.svelte
@@ -4,22 +4,27 @@
 	import Logo from '$lib/components/Logo.svelte';
 
 	const errorTitles = {
+		400: 'Bad Request',
 		401: 'Unauthorized',
 		403: 'Access Denied',
 		404: 'Page Not Found',
+		422: 'Unprocessable Entity',
+		429: 'Too Many Requests',
 		500: 'Internal Server Error'
 	};
 
-	const defaultMessage = {
+	const defaultErrorCodeMessage = {
 		401: 'You are not logged in.',
 		403: 'You are not allowed to access this page.',
 		404: 'It looks like the page you are trying to access does not exist.',
 		500: 'An error occurred while loading the page.'
 	};
 
+	const defaultMessage = defaultErrorCodeMessage[500];
+
 	const title = errorTitles[page.status as keyof typeof errorTitles] || 'Error';
 	const message =
-		defaultMessage[page.status as keyof typeof defaultMessage] || 'Please try again later.';
+		defaultErrorCodeMessage[page.status as keyof typeof defaultErrorCodeMessage] || defaultMessage;
 </script>
 
 <div class="flex h-dvh w-full flex-col items-center justify-center gap-4">
@@ -39,11 +44,15 @@
 	</div>
 	<p class="text-gray">{message}</p>
 
-	{#if page.error}
+	{#if page.error?.message}
 		<details class="collapse bg-base-300 collapse-arrow border max-w-xl mb-2 w-full">
 			<summary class="collapse-title font-semibold text-base">Error Details</summary>
-			<div class="collapse-content text-sm bg-base-200 pt-4">
-				{page.error.message}
+			<div class="collapse-content p-0 text-sm bg-base-200 space-y-3">
+				<div class="p-4 overflow-y-auto default-scrollbar-thin max-h-64">
+					{#if page.error.message}
+						<p class="wrap-break-word">{page.error.message}</p>
+					{/if}
+				</div>
 			</div>
 		</details>
 	{/if}

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -10,6 +10,7 @@
 		PAGE_TRANSITION_DURATION,
 		RecommendedModelProviders
 	} from '$lib/constants';
+	import { HttpError } from '$lib/errors.js';
 	import type { AuthProvider } from '$lib/services/admin/types.js';
 	import { AdminService, Role, UserService } from '$lib/services/index.js';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte.js';
@@ -124,7 +125,7 @@
 		try {
 			await AdminService.cancelTempLogin();
 		} catch (err) {
-			if (err instanceof Error && err.message.includes('404')) {
+			if (err instanceof HttpError && err.statusCode === 404) {
 				// ignore, no current temp login to cancel
 			} else {
 				errors.append(err);
@@ -205,7 +206,7 @@
 							);
 						} catch (err) {
 							// if 404, ignore, it means no credentials are set
-							if (err instanceof Error && !err.message.includes('404')) {
+							if (err instanceof HttpError && err.statusCode !== 404) {
 								console.error('An error occurred while revealing auth provider credentials', err);
 							} else {
 								// no credentials set, set initial default value for allowed domains

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -206,7 +206,7 @@
 							);
 						} catch (err) {
 							// if 404, ignore, it means no credentials are set
-							if (err instanceof HttpError && err.statusCode !== 404) {
+							if (!(err instanceof HttpError) || err.statusCode !== 404) {
 								console.error('An error occurred while revealing auth provider credentials', err);
 							} else {
 								// no credentials set, set initial default value for allowed domains

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -6,6 +6,7 @@
 	import ProviderConfigure from '$lib/components/admin/ProviderConfigure.svelte';
 	import { CommonModelProviderIds, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { getAdminModels, initModels } from '$lib/context/admin/models.svelte.js';
+	import { HttpError } from '$lib/errors.js';
 	import { AdminService, type ModelProvider as ModelProviderType } from '$lib/services';
 	import { sortModelProviders } from '$lib/sort.js';
 	import { defaultModelAliases as defaultModelAliasesStore } from '$lib/stores';
@@ -172,7 +173,7 @@
 							);
 						} catch (err) {
 							// if 404, ignore, it means no credentials are set
-							if (err instanceof Error && !err.message.includes('404')) {
+							if (err instanceof HttpError && err.statusCode !== 404) {
 								console.error('An error occurred while revealing model provider credentials', err);
 							}
 						}

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -173,7 +173,7 @@
 							);
 						} catch (err) {
 							// if 404, ignore, it means no credentials are set
-							if (err instanceof HttpError && err.statusCode !== 404) {
+							if (!(err instanceof HttpError) || err.statusCode !== 404) {
 								console.error('An error occurred while revealing model provider credentials', err);
 							}
 						}


### PR DESCRIPTION
* change doPut/doGet/doDelete/doPost so it uses `HttpError` instead of putting the status into `message` & then having to parse the status code from `e.message`
* display status code 