### PR TITLE
chore: goreleaser: skip brew upload for pre-releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,7 +51,7 @@ brews:
     install: |
       bin.install "obot"
     homepage: "https://github.com/obot-platform/obot"
-    skip_upload: false
+    skip_upload: auto
     directory: "Formula"
     repository:
       owner: obot-platform


### PR DESCRIPTION
Per the [docs](https://www.goreleaser.com/customization/publish/homebrew_formulas/), setting this to `auto` will skip pre-release versions but upload normal releases.