### PR TITLE
fix: display ~/.agents multi client as "~/.agents" in device management

### DIFF
--- a/ui/user/src/lib/format.ts
+++ b/ui/user/src/lib/format.ts
@@ -81,3 +81,27 @@ export const formatDeviceCommand = (cmd?: string, args?: string[]): string => {
 	const parts = [cmd, ...(args ?? [])];
 	return parts.join(' ');
 };
+
+const AGENTS_HOME_PATTERN = /^(?:\/(?:Users|home|root)\/[^/]+|~)\/\.agents(?:\/|$)/;
+
+export const isAgentsHomeProjectPath = (projectPath?: string): boolean => {
+	if (!projectPath) return false;
+	return AGENTS_HOME_PATTERN.test(projectPath);
+};
+
+export const deriveDeviceScope = (projectPath?: string): string => {
+	if (!projectPath) return 'global';
+	if (isAgentsHomeProjectPath(projectPath)) return 'global';
+	return 'project';
+};
+
+export const MULTI_CLIENT_NAME = 'multi';
+export const AGENTS_HOME_CLIENT_LABEL = '~/.agents';
+
+export const formatDeviceClient = (client?: string, projectPath?: string): string => {
+	if (!client) return '—';
+	if (client.trim() === MULTI_CLIENT_NAME && isAgentsHomeProjectPath(projectPath)) {
+		return AGENTS_HOME_CLIENT_LABEL;
+	}
+	return client;
+};

--- a/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
+++ b/ui/user/src/routes/admin/device-skills/[name]/+page.svelte
@@ -5,6 +5,7 @@
 	import Pagination from '$lib/components/table/Pagination.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { deriveDeviceScope, formatDeviceClient } from '$lib/format.js';
 	import {
 		AdminService,
 		type DeviceSkillOccurrence,
@@ -42,7 +43,8 @@
 			...o,
 			rowIndex: ((occurrencesResp.offset ?? 0) + i + 1).toString(),
 			shortDeviceID: (o.deviceID ?? '').slice(0, 12),
-			scannedRelative: formatTimeAgo(o.scannedAt).relativeTime
+			scannedRelative: formatTimeAgo(o.scannedAt).relativeTime,
+			scope: o.projectPath ? deriveDeviceScope(o.projectPath) : o.scope
 		}))
 	);
 
@@ -181,6 +183,8 @@
 							</a>
 						{:else if property === 'projectPath'}
 							{d.projectPath ?? '—'}
+						{:else if property === 'client'}
+							{formatDeviceClient(d.client, d.projectPath)}
 						{:else}
 							{d[property as keyof Row]}
 						{/if}

--- a/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/+page.svelte
@@ -6,6 +6,7 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { AGENTS_HOME_CLIENT_LABEL, deriveDeviceScope, formatDeviceClient } from '$lib/format.js';
 	import {
 		UserService,
 		type DeviceScan,
@@ -80,10 +81,6 @@
 		has_display: string;
 	};
 
-	function deriveScope(projectPath?: string): string {
-		return projectPath ? 'project' : 'global';
-	}
-
 	function formatCommand(cmd?: string, args?: string[]): string {
 		if (!cmd) return '—';
 		const parts = [cmd, ...(args ?? [])];
@@ -123,7 +120,8 @@
 	let mcpRows = $derived<MCPRow[]>(
 		mcpServers.map((m) => ({
 			...m,
-			scope: deriveScope(m.projectPath),
+			client: formatDeviceClient(m.client, m.projectPath),
+			scope: deriveDeviceScope(m.projectPath),
 			endpoint: m.transport === 'stdio' ? formatCommand(m.command, m.args) : m.url || '—'
 		}))
 	);
@@ -131,7 +129,8 @@
 	let skillRows = $derived<SkillRow[]>(
 		skills.map((s) => ({
 			...s,
-			scope: deriveScope(s.projectPath),
+			client: formatDeviceClient(s.client, s.projectPath),
+			scope: deriveDeviceScope(s.projectPath),
 			files_count: (s.files ?? []).length
 		}))
 	);
@@ -139,7 +138,8 @@
 	let pluginRows = $derived<PluginRow[]>(
 		plugins.map((p) => ({
 			...p,
-			scope: deriveScope(p.projectPath),
+			client: formatDeviceClient(p.client, p.projectPath),
+			scope: deriveDeviceScope(p.projectPath),
 			capabilities: capabilitySummary(p)
 		}))
 	);
@@ -560,7 +560,7 @@
 {/snippet}
 
 {#snippet clientLink(client?: string)}
-	{#if client && client.trim() !== 'multi'}
+	{#if client && client.trim() !== 'multi' && client !== AGENTS_HOME_CLIENT_LABEL}
 		<a
 			class="btn-link text-blue-500"
 			href={resolve(`/admin/device-clients/${encodeURIComponent(client)}`)}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/+page.svelte
@@ -7,7 +7,12 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
-	import { formatDeviceCommand } from '$lib/format.js';
+	import {
+		AGENTS_HOME_CLIENT_LABEL,
+		deriveDeviceScope,
+		formatDeviceClient,
+		formatDeviceCommand
+	} from '$lib/format.js';
 	import { AdminService, UserService } from '$lib/services';
 	import {
 		Group,
@@ -127,14 +132,11 @@
 		has_display: string;
 	};
 
-	function deriveScope(projectPath?: string): string {
-		return projectPath ? 'project' : 'global';
-	}
-
 	let mcpRows = $derived<MCPRow[]>(
 		mcpServers.map((m) => ({
 			...m,
-			scope: deriveScope(m.projectPath),
+			client: formatDeviceClient(m.client, m.projectPath),
+			scope: deriveDeviceScope(m.projectPath),
 			endpoint: m.transport === 'stdio' ? formatDeviceCommand(m.command, m.args) : m.url || '—'
 		}))
 	);
@@ -142,7 +144,8 @@
 	let skillRows = $derived<SkillRow[]>(
 		skills.map((s) => ({
 			...s,
-			scope: deriveScope(s.projectPath),
+			client: formatDeviceClient(s.client, s.projectPath),
+			scope: deriveDeviceScope(s.projectPath),
 			files_count: (s.files ?? []).length
 		}))
 	);
@@ -150,7 +153,8 @@
 	let pluginRows = $derived<PluginRow[]>(
 		plugins.map((p) => ({
 			...p,
-			scope: deriveScope(p.projectPath),
+			client: formatDeviceClient(p.client, p.projectPath),
+			scope: deriveDeviceScope(p.projectPath),
 			capabilities: capabilitySummary(p)
 		}))
 	);
@@ -487,7 +491,7 @@
 />
 
 {#snippet clientLink(client?: string)}
-	{#if client && client.trim() !== 'multi'}
+	{#if client && client.trim() !== 'multi' && client !== AGENTS_HOME_CLIENT_LABEL}
 		<a
 			class="btn-link text-blue-500"
 			href={resolve(`/admin/device-clients/${encodeURIComponent(client)}`)}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
@@ -5,6 +5,7 @@
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { deriveDeviceScope, formatDeviceClient } from '$lib/format.js';
 	import type { DeviceScanMCPServer } from '$lib/services/admin/types';
 	import { goto } from '$lib/url';
 	import { findParentPlugin, shortHash } from '../../_shared/files';
@@ -27,7 +28,7 @@
 	);
 
 	let parentPlugin = $derived(findParentPlugin(scan, server?.file));
-	let scope = $derived(server?.projectPath ? 'project' : 'global');
+	let scope = $derived(deriveDeviceScope(server?.projectPath));
 
 	function renderConfig(s: DeviceScanMCPServer): string {
 		const entry: Record<string, unknown> = { type: s.transport };
@@ -74,7 +75,7 @@
 					<h2 class="text-xl font-semibold">{server.name}</h2>
 					<span class="pill-primary bg-primary">{server.transport}</span>
 					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
-						{server.client}
+						{formatDeviceClient(server.client, server.projectPath)}
 					</span>
 					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 						{scope}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import Layout from '$lib/components/Layout.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { deriveDeviceScope, formatDeviceClient } from '$lib/format.js';
 	import type { DeviceScanPlugin } from '$lib/services/admin/types';
 	import { goto } from '$lib/url';
 	import { formatBytes, lookupFiles } from '../../_shared/files';
@@ -14,7 +15,7 @@
 	let backHref = $derived(`/admin/devices/${page.params.device_id}/scans/${page.params.scan_id}`);
 
 	let files = $derived(lookupFiles(scan?.files, plugin?.files));
-	let scope = $derived(plugin?.projectPath ? 'project' : 'global');
+	let scope = $derived(deriveDeviceScope(plugin?.projectPath));
 
 	let capabilities = $derived(
 		plugin
@@ -50,7 +51,7 @@
 					{/if}
 					<span class="pill-primary bg-primary">{plugin.pluginType}</span>
 					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
-						{plugin.client}
+						{formatDeviceClient(plugin.client, plugin.projectPath)}
 					</span>
 					<span class="dark:bg-base-400 bg-base-300 rounded px-1.5 py-0.5 text-xs">
 						{scope}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import Layout from '$lib/components/Layout.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { deriveDeviceScope, formatDeviceClient } from '$lib/format.js';
 	import type { DeviceScanSkill } from '$lib/services/admin/types';
 	import { goto } from '$lib/url';
 	import { findParentPlugin, formatBytes, lookupFiles } from '../../_shared/files';
@@ -16,8 +17,8 @@
 
 	let files = $derived(lookupFiles(scan?.files, skill?.files));
 	let parentPlugin = $derived(findParentPlugin(scan, skill?.file));
-	let scope = $derived(skill?.projectPath ? 'project' : 'global');
-	let clientLabel = $derived(skill?.client || '—');
+	let scope = $derived(deriveDeviceScope(skill?.projectPath));
+	let clientLabel = $derived(formatDeviceClient(skill?.client, skill?.projectPath));
 
 	const duration = PAGE_TRANSITION_DURATION;
 </script>


### PR DESCRIPTION
When a device scan records an MCP server, skill, or plugin whose client is
"multi" and whose project path lives under the user's ~/.agents directory,
the entry is conceptually global — it isn't tied to a specific MCP client
or project. Display it that way in the admin Device Management views:

- Rename the client to "~/.agents" only when the row's client is
  "multi" AND its projectPath matches /Users/<user>/.agents/... (also
  /home/<user>, /root/<user>, and ~/.agents). Other "multi" entries are
  left untouched so we don't lose information when the path isn't known.
- Treat scope as "global" for the same project-path pattern, in addition
  to the existing empty-projectPath case.

<img width="1273" height="762" alt="Screenshot 2026-05-27 at 12 02 27 PM" src="https://github.com/user-attachments/assets/0b26357d-7bc5-408d-9432-77fd351d3571" />
<img width="1284" height="1066" alt="Screenshot 2026-05-27 at 12 02 49 PM" src="https://github.com/user-attachments/assets/740a4054-04e9-4399-8473-bac8f579fbfa" />
