### PR TITLE
enhance: request & limits configuration in ui for mcp server entry

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -17,6 +17,7 @@
 		convertServerRuntimeFormDataToManifest,
 		hasSecretBinding,
 		sanitizeEgressDomains,
+		sanitizeResourceRuntimeConfig,
 		validateRuntimeForm
 	} from '$lib/services/user/mcp';
 	import { profile, version } from '$lib/stores';
@@ -27,6 +28,7 @@
 	import MultiUserHeadersForm from '../mcp/MultiUserHeadersForm.svelte';
 	import NpxRuntimeForm from '../mcp/NpxRuntimeForm.svelte';
 	import RemoteRuntimeForm from '../mcp/RemoteRuntimeForm.svelte';
+	import ResourceRuntimeForm from '../mcp/ResourceRuntimeForm.svelte';
 	import RuntimeSelector from '../mcp/RuntimeSelector.svelte';
 	import UvxRuntimeForm from '../mcp/UvxRuntimeForm.svelte';
 	import SelectMcpAccessControlRules from './SelectMcpAccessControlRules.svelte';
@@ -102,6 +104,13 @@
 		return { package: '', command: '', args: [], egressDomains: [], denyAllEgress: undefined };
 	}
 
+	function defaultResourceRuntimeConfig() {
+		return {
+			requests: { cpu: '', memory: '' },
+			limits: { cpu: '', memory: '' }
+		};
+	}
+
 	function defaultContainerizedConfig() {
 		return {
 			image: '',
@@ -126,6 +135,12 @@
 		return config ? { ...defaultContainerizedConfig(), ...config } : defaultContainerizedConfig();
 	}
 
+	function normalizeResourceRuntimeConfig(config?: RuntimeFormData['resources']) {
+		return config
+			? { ...defaultResourceRuntimeConfig(), ...config }
+			: defaultResourceRuntimeConfig();
+	}
+
 	function convertToFormData(item?: MCPCatalogEntry | MCPCatalogServer): RuntimeFormData {
 		if (!item) {
 			// Default initialization for new servers
@@ -136,6 +151,7 @@
 				env: [],
 				icon: '',
 				runtime: 'npx' as Runtime,
+				resources: type !== 'remote' ? defaultResourceRuntimeConfig() : undefined,
 				npxConfig: defaultNpxConfig(),
 				uvxConfig: undefined,
 				containerizedConfig: undefined,
@@ -159,6 +175,7 @@
 				description: manifest.description ?? '',
 				env: manifest.env?.map((env) => ({ ...env, value: '' })) ?? [],
 				runtime: manifest.runtime,
+				resources: normalizeResourceRuntimeConfig(manifest.resources),
 				npxConfig: undefined,
 				uvxConfig: undefined,
 				containerizedConfig: undefined,
@@ -206,6 +223,7 @@
 				env: manifest.env?.map((env) => ({ ...env, value: '' })) ?? [],
 				description: manifest.description ?? '',
 				runtime: manifest.runtime,
+				resources: normalizeResourceRuntimeConfig(manifest.resources),
 				npxConfig: undefined,
 				uvxConfig: undefined,
 				containerizedConfig: undefined,
@@ -293,6 +311,12 @@
 		formData.remoteConfig = undefined;
 		formData.remoteServerConfig = undefined;
 
+		if (newRuntime === 'remote') {
+			formData.resources = undefined;
+		} else if (!formData.resources) {
+			formData.resources = defaultResourceRuntimeConfig();
+		}
+
 		// Initialize the appropriate config based on the new runtime
 		switch (newRuntime) {
 			case 'npx':
@@ -330,6 +354,9 @@
 				? { startupTimeoutSeconds }
 				: {};
 
+		const resources =
+			baseData.runtime !== 'remote' ? sanitizeResourceRuntimeConfig(baseData.resources) : undefined;
+
 		// Build base manifest structure
 		const manifest: MCPCatalogEntryServerManifest = {
 			name: baseData.name,
@@ -338,6 +365,7 @@
 			env: baseData.env,
 			runtime: baseData.runtime,
 			serverUserType: type === 'multi' ? 'multiUser' : 'singleUser',
+			...(resources ? { resources } : {}),
 			...convertCategoriesToMetadata(categories)
 		};
 
@@ -685,6 +713,11 @@
 		id={entry?.id}
 	/>
 {/if}
+
+{#if version.current.engine === 'kubernetes' && formData.runtime !== 'remote' && formData.resources}
+	<ResourceRuntimeForm bind:config={formData.resources} {readonly} />
+{/if}
+
 <!-- Environment Variables Section -->
 {#if !['remote', 'composite'].includes(formData.runtime)}
 	<CustomConfigurationForm bind:config={formData.env} {readonly} {type} {secretBoundHeaders} />

--- a/ui/user/src/lib/components/mcp/ResourceRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/ResourceRuntimeForm.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import type { ResourceRuntimeConfig } from '$lib/services';
+
+	interface Props {
+		config: ResourceRuntimeConfig;
+		readonly?: boolean;
+	}
+
+	let { config = $bindable(), readonly }: Props = $props();
+
+	if (!config.requests) {
+		config.requests = {
+			cpu: '',
+			memory: ''
+		};
+	}
+	if (!config.limits) {
+		config.limits = {
+			cpu: '',
+			memory: ''
+		};
+	}
+</script>
+
+<div class="paper">
+	<h4 class="text-sm font-semibold">Resource Limits & Requests</h4>
+	<p class="text-xs text-muted-content">
+		Define the CPU and memory requests and limits for this MCP server's deployments. See the
+		Kubernetes <a
+			href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits"
+			class="text-link"
+			rel="external"
+			target="_blank">resource management documentation</a
+		> for more information.
+	</p>
+
+	<div class="flex flex-col gap-3">
+		<div class="flex items-center gap-1">
+			<h5 class="text-xs font-semibold uppercase tracking-wide">CPU Settings</h5>
+		</div>
+		<div class="flex items-center gap-4 w-full">
+			<div class="flex flex-col gap-1 flex-1">
+				<label for="resource-requests-cpu" class="w-20 text-sm font-light"> Request </label>
+				<input
+					id="resource-requests-cpu"
+					class="text-input-filled dark:bg-base-100 w-full"
+					bind:value={config.requests!.cpu}
+					disabled={readonly}
+					placeholder="e.g. 10m"
+					onblur={() => {
+						if (config.requests?.cpu) {
+							config.requests.cpu = config.requests.cpu.trim();
+						}
+					}}
+				/>
+			</div>
+			<div class="flex flex-col gap-1 flex-1">
+				<label for="resource-limits-cpu" class="w-20 text-sm font-light"> Limit </label>
+				<input
+					id="resource-limits-cpu"
+					class="text-input-filled dark:bg-base-100 w-full"
+					bind:value={config.limits!.cpu}
+					disabled={readonly}
+					placeholder="e.g. 10m"
+					onblur={() => {
+						if (config.limits?.cpu) {
+							config.limits.cpu = config.limits.cpu.trim();
+						}
+					}}
+				/>
+			</div>
+		</div>
+
+		<div class="divider"></div>
+
+		<div class="flex flex-col gap-3">
+			<h5 class="text-xs font-semibold uppercase tracking-wide">Memory Settings</h5>
+			<div class="flex items-center gap-4 w-full">
+				<div class="flex flex-col gap-1 flex-1">
+					<label for="resource-requests-memory" class="w-20 text-sm font-light"> Request </label>
+					<input
+						id="resource-requests-memory"
+						class="text-input-filled dark:bg-base-100 w-full"
+						bind:value={config.requests!.memory}
+						disabled={readonly}
+						placeholder="e.g. 200Mi"
+						onblur={() => {
+							if (config.requests?.memory) {
+								config.requests.memory = config.requests.memory.trim();
+							}
+						}}
+					/>
+				</div>
+				<div class="flex flex-col gap-1 flex-1">
+					<label for="resource-limits-memory" class="w-20 text-sm font-light"> Limit </label>
+					<input
+						id="resource-limits-memory"
+						class="text-input-filled dark:bg-base-100 w-full"
+						bind:value={config.limits!.memory}
+						disabled={readonly}
+						placeholder="e.g. 200Mi"
+						onblur={() => {
+							if (config.limits?.memory) {
+								config.limits.memory = config.limits.memory.trim();
+							}
+						}}
+					/>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -11,7 +11,8 @@ import {
 	type ToolOverride,
 	type Schedule,
 	ModelAlias,
-	type AccessControlRuleSubject
+	type AccessControlRuleSubject,
+	type MCPResourceRequirements
 } from '../user/types';
 
 /**
@@ -560,10 +561,6 @@ export interface MCPCapacityInfo {
 	activeDeployments: number;
 	error?: string;
 }
-export interface MCPResourceRequests {
-	cpu?: string;
-	memory?: string;
-}
 
 // MCP catalog
 
@@ -634,6 +631,7 @@ export interface MCPCatalogEntryServerManifest {
 	remoteConfig?: RemoteCatalogConfigAdmin;
 	compositeConfig?: CompositeCatalogConfig;
 	multiUserConfig?: MultiUserConfig;
+	resources?: MCPResourceRequirements;
 }
 export interface MCPCatalogEntry {
 	id: string;
@@ -686,6 +684,7 @@ export interface RuntimeFormData {
 	compositeConfig?: CompositeCatalogConfig; // For catalog entries
 	compositeServerConfig?: CompositeRuntimeConfig; // For servers
 	multiUserConfig?: MultiUserConfig; // For servers
+	resources?: MCPResourceRequirements;
 
 	startupTimeoutSeconds?: number;
 }

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -11,6 +11,8 @@ import {
 	type MCPCatalogServerManifest,
 	type MCPServer,
 	type MCPServerInstance,
+	type MCPResourceRequests,
+	type MCPResourceRequirements,
 	type MCPSubField,
 	type OrgUser,
 	type RuntimeFormData,
@@ -723,6 +725,47 @@ export const sanitizeEgressDomains = (egressDomains?: string[] | string) => {
 	return domains?.map((domain) => domain.trim()).filter(Boolean) || [];
 };
 
+const sanitizeResourceRequests = (
+	requests?: MCPResourceRequests
+): MCPResourceRequests | undefined => {
+	if (!requests) {
+		return undefined;
+	}
+
+	const sanitized: MCPResourceRequests = {};
+	const cpu = requests.cpu?.trim();
+	const memory = requests.memory?.trim();
+
+	if (cpu) {
+		sanitized.cpu = cpu;
+	}
+	if (memory) {
+		sanitized.memory = memory;
+	}
+
+	return cpu || memory ? sanitized : undefined;
+};
+
+export const sanitizeResourceRuntimeConfig = (
+	resources?: MCPResourceRequirements
+): MCPResourceRequirements | undefined => {
+	if (!resources) {
+		return undefined;
+	}
+
+	const requests = sanitizeResourceRequests(resources.requests);
+	const limits = sanitizeResourceRequests(resources.limits);
+
+	if (!requests && !limits) {
+		return undefined;
+	}
+
+	return {
+		...(requests ? { requests } : {}),
+		...(limits ? { limits } : {})
+	};
+};
+
 export const convertServerRuntimeFormDataToManifest = (
 	formData: RuntimeFormData
 ): MCPCatalogServerManifest => {
@@ -735,6 +778,9 @@ export const convertServerRuntimeFormDataToManifest = (
 			? { startupTimeoutSeconds }
 			: {};
 
+	const resources =
+		baseData.runtime !== 'remote' ? sanitizeResourceRuntimeConfig(baseData.resources) : undefined;
+
 	// Build base manifest structure for server
 	const serverManifest: MCPCatalogServerManifest = {
 		manifest: {
@@ -744,6 +790,7 @@ export const convertServerRuntimeFormDataToManifest = (
 			env: baseData.env,
 			multiUserConfig: baseData.multiUserConfig,
 			runtime: baseData.runtime,
+			...(resources ? { resources } : {}),
 			...convertCategoriesToMetadata(categories)
 		}
 	};

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -364,6 +364,14 @@ export interface ContainerizedRuntimeConfig {
 	denyAllEgress?: boolean;
 	startupTimeoutSeconds?: number;
 }
+export interface MCPResourceRequests {
+	cpu?: string;
+	memory?: string;
+}
+export interface MCPResourceRequirements {
+	requests?: MCPResourceRequests;
+	limits?: MCPResourceRequests;
+}
 export interface RemoteRuntimeConfig {
 	url: string;
 	headers?: MCPSubField[];
@@ -375,6 +383,7 @@ export interface RemoteCatalogConfig {
 	hostname?: string;
 	headers?: MCPSubField[];
 }
+export type ResourceRuntimeConfig = MCPResourceRequirements;
 export interface MultiUserConfig {
 	userDefinedHeaders?: MCPSubField[];
 }
@@ -432,6 +441,7 @@ export interface MCPServer {
 	remoteConfig?: RemoteRuntimeConfig;
 	compositeConfig?: CompositeRuntimeConfig;
 	multiUserConfig?: MultiUserConfig;
+	resources?: MCPResourceRequirements;
 }
 export interface MCPServerTool {
 	id: string;


### PR DESCRIPTION
Addresses #6629 

* similar to Server Scheduling page's Request/Limits for CPU/Memory except for per entry (excluding remote)
* shows when kubernetes engine enabled

<img width="1204" height="441" alt="Screenshot 2026-05-27 at 2 20 54 PM" src="https://github.com/user-attachments/assets/cbb417bc-7e9d-4da6-8f9f-1e25d6395ab0" />
