### PR TITLE
fix: sort devices user column by displayed name

### DIFF
--- a/ui/user/src/routes/admin/devices/+page.svelte
+++ b/ui/user/src/routes/admin/devices/+page.svelte
@@ -42,19 +42,6 @@
 		scanned_relative: string;
 	};
 
-	let rows = $derived<Row[]>(
-		(devicesResp.items ?? []).map((s) => ({
-			...s,
-			short_device_id: (s.deviceID ?? '').slice(0, 12),
-			os_arch: `${s.os} / ${s.arch}`,
-			mcp_count: s.mcpServers?.length ?? 0,
-			skill_count: s.skills?.length ?? 0,
-			plugin_count: s.plugins?.length ?? 0,
-			client_count: s.clients?.length ?? 0,
-			scanned_relative: formatTimeAgo(s.scannedAt).relativeTime
-		}))
-	);
-
 	const userById = $derived<Map<string, OrgUser>>(
 		new Map((data?.users ?? []).map((u) => [u.id, u]))
 	);
@@ -62,6 +49,23 @@
 	function userDisplay(u: OrgUser): string {
 		return u.displayName ?? u.email ?? u.username ?? u.id;
 	}
+
+	let rows = $derived<Row[]>(
+		(devicesResp.items ?? []).map((s) => {
+			const u = s.submittedBy ? userById.get(s.submittedBy) : undefined;
+			return {
+				...s,
+				username: u ? userDisplay(u) : s.username,
+				short_device_id: (s.deviceID ?? '').slice(0, 12),
+				os_arch: `${s.os} / ${s.arch}`,
+				mcp_count: s.mcpServers?.length ?? 0,
+				skill_count: s.skills?.length ?? 0,
+				plugin_count: s.plugins?.length ?? 0,
+				client_count: s.clients?.length ?? 0,
+				scanned_relative: formatTimeAgo(s.scannedAt).relativeTime
+			};
+		})
+	);
 
 	let filteredRows = $derived.by(() => {
 		const q = query.trim().toLowerCase();


### PR DESCRIPTION
The User column rendered the resolved OrgUser display name
(displayName → email → username → id) when submittedBy matched a known
user, but the row's sort key was still the raw device scan username
field. This meant the visible order didn't match the column you were
sorting by — e.g. a row showing "Nick Hale" would sort under the raw
username, or not sort at all when the scan carried no username.

Override row.username with userDisplay(u) when the submittedBy lookup
succeeds, falling back to the raw scan username otherwise, so the sort
key matches what's actually rendered in the cell.

https://github.com/obot-platform/obot/issues/6732

