### PR TITLE
chore: add Claude Code skills for drafting releases

### DIFF
--- a/.claude/skills/draft-release-blog/SKILL.md
+++ b/.claude/skills/draft-release-blog/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: draft-release-blog
+description: Draft a release announcement blog post for an obot release, modeled on the existing obot.ai blog voice. Use when the user asks to draft a release blog, write a launch post, or write a blog announcement for a vX.Y.0 release. Outputs a markdown file the user can paste into the CMS. Can also create the post as a Wordpress draft via the `obot-wordpress` MCP server when the user asks, but never publishes a live post without explicit confirmation.
+---
+
+# Draft Release Blog Post
+
+Drafts a blog post announcing an obot release. Sources the feature spine from the draft GitHub release (the output of the `draft-release` skill or an existing draft on GitHub), then does additional research to add the kind of detail, context, and rationale that release notes deliberately omit but a blog post needs.
+
+The blog is for obot.ai's hosted Wordpress CMS. The default output is a markdown file at `/tmp/release-blog-<VERSION>.md` that the user can paste into the CMS themselves. If the user explicitly asks to post it (e.g. "post it up there", "create the draft in Wordpress"), the skill can also create the post as a Wordpress **draft** via the `obot-wordpress` MCP server (see step 8). The skill never publishes a live post without explicit user confirmation of the `publish` status.
+
+## Voice reference
+
+Read both before drafting, every time:
+
+- https://obot.ai/blog/obot-v0210-network-egress-control-for-mcp-servers/ — single-feature deep-dive shape, first-person personal voice, ~600 words
+- https://obot.ai/blog/announcing-obot-mcp-platform-v0-16-0-api-keys-model-access-policies-and-other-enterprise-ready-controls/ — multi-feature roundup shape, "we are excited" framing, ~1200 words
+
+Author byline is **Craig Jellick** (`craig@obot.ai`). The personal voice in the deep-dive shape is his — when the post uses "I", that's him. Don't use "I" in the roundup shape; use "we".
+
+## Hard constraints
+
+- No emojis. No em dashes (`—`). Use plain hyphens or rewrite. No "thrilled / proud / revolutionary / game-changing / unlock the power of" hype words.
+- Use straight quotes (`'` and `"`), not curly quotes.
+- Do not invent statistics, customer quotes, partner endorsements, or technical claims not grounded in the PRs, issues, code, or docs you have actually read.
+- The markdown file at `/tmp/release-blog-<VERSION>.md` is always the first output. Posting to Wordpress (step 8) is opt-in: only do it when the user explicitly asks.
+- When posting to Wordpress, the post status MUST be `draft` unless the user explicitly confirms `publish`. Never default to publishing live.
+- Never write the post as a "we shipped a lot of stuff this quarter" generic update. Anchor on the specific release.
+
+## Procedure
+
+### 1. Determine the source material
+
+Confirm with the user which release the blog is for. Then find the canonical feature list:
+
+```bash
+# Look for an existing draft (or published) release for the version:
+gh release view <VERSION> --repo obot-platform/obot
+```
+
+If a draft or published release exists, its Big Updates section is the spine. The blog highlights those same features in the same order — do not introduce features that didn't make it into the release notes, and do not silently demote features the release notes promoted.
+
+If no release exists yet, ask the user whether to run `draft-release` first, or proceed by surveying commits directly. Do not invent a feature list out of commits alone for the blog — the release notes are where editorial alignment happens, and the blog should follow that.
+
+### 2. Choose the blog shape
+
+The two reference posts use different shapes. Pick based on the release character:
+
+- **Single-feature deep-dive** (model on v0.21.0 blog): use when the release has one obviously dominant feature and one or two minor supporting items. ~500-800 words. Sections: opener, "Why we built this", "How it works", optional partner/collab section, "What's next".
+- **Multi-feature roundup** (model on v0.16.0 blog): use when the release has 3-6 features of comparable weight. ~1000-1400 words. Sections: opener with bulleted summary, one subsection per feature, "Additional improvements" if relevant, "Get started" CTA.
+
+Present the recommended shape to the user before drafting and let them override. If they pick deep-dive but there are multiple features, the others can be mentioned briefly at the end ("This release also includes X, Y, Z — see the release notes for details").
+
+### 3. Deep research for blog-quality detail
+
+This is the step that separates a blog from rephrased release notes. The release notes answer *what*. The blog needs *why* and *context*. For each feature being covered:
+
+- Re-read the PR(s) and any linked issues (remember: this repo does NOT use `closes #N`, so grep PR body/comments for issue numbers; see the related memory). The design discussions, alternatives considered, and user-reported problems live here.
+- Look at the actual code or config surface the feature exposes. The blog should be able to describe what configuring this feature looks like in concrete terms ("you get a section for network egress policies", "you define the external domains the server should be allowed to reach"), not abstract terms.
+- Check `docs/` for any feature documentation written for this release. Pull concrete language from the docs where it's clearer than what's in the PR.
+- For security/compliance features, look for real-world context that explains why the feature matters now. The v0.21.0 post cites the Axios supply chain compromise. Use external context only when you can name it specifically — never write "recent attacks have shown..." without naming one.
+- Note any partner/integration angle (e.g. Aviatrix in v0.21.0). If the feature involves a named third party, plan to dedicate a short section to that collaboration.
+
+The goal: walk away from research with enough material to write three things per feature that release notes don't have:
+1. The user problem in concrete terms (not "users wanted X" but "before this, admins had to do Y, and Y broke when Z").
+2. A specific, visualizable example of using the feature.
+3. Forward-looking context (what comes next, what this unlocks, what's still open).
+
+### 4. Surface places that need the user's personal voice
+
+The deep-dive shape has lines that can only come from the user. Examples from v0.21.0:
+
+> What I appreciate about working with their team: they think about this the same way we do.
+
+> We're already in conversations with other networking companies about additional integrations, so if you're using a different platform, let us know what you'd like to see supported.
+
+These are POV statements about partners, future plans, or personal stake. The skill should NOT invent these. Before drafting, identify 2-4 places in the planned structure where personal POV would belong, then ask the user:
+
+```
+For the blog draft, these spots are best filled by your voice rather than mine. Want to give me a sentence or two for each, or should I leave them as `[POV: ...]` placeholders for you to fill in after?
+
+1. <Feature A> — your take on the partner / why you bet on this approach / what you'd say to skeptics
+2. <Feature B> — what's next / what you're excited about next quarter
+3. ...
+```
+
+Use AskUserQuestion when the placeholders map to clean forks. Otherwise plain text reply.
+
+### 5. Confirm shape, angles, and POV with the user
+
+Before writing prose, post a short plan:
+
+```
+Blog plan for <VERSION>:
+
+Shape: <Deep-dive | Roundup>
+Working title: <draft title>
+Opening hook angle: <one sentence>
+
+Sections:
+1. <Section name> — <one-line description of angle/content>
+2. ...
+
+Features covered: <list>
+Features omitted from blog (but in release notes): <list, with brief reason>
+
+POV inputs needed from you: <list from step 4, or "none">
+
+OK to draft, or want to adjust?
+```
+
+Wait for confirmation or adjustments before writing prose.
+
+### 6. Draft the post
+
+Match the reference posts:
+
+- Title format: For deep-dive, `New in Obot: <Feature Phrase>` (e.g. "New in Obot: Network Egress Control for MCP Servers"). For roundup, `Announcing Obot MCP Platform <VERSION>: <feature, feature, and other theme>`.
+- Open with a one-paragraph hook. Deep-dive: first person, states what was built and the partner if any. Roundup: "We're excited to announce..." + brief framing of the release theme.
+- Use `## Why we built this` / `## How it works` / `## What's next` headings in the deep-dive shape, or `## <Feature Name>` headings in the roundup shape. Match the reference structure exactly.
+- Concrete > abstract in every sentence. If a sentence could appear in any company's launch blog, rewrite or delete it.
+- End with a CTA. Reference posts use either `reach out at info@obot.ai` or `Check out our installation guide`. Default to `info@obot.ai` for deep-dives where there's a partner/conversation angle, installation guide for roundups.
+
+Add a frontmatter block at the top of the markdown for the CMS to consume:
+
+```markdown
+---
+title: <full title>
+category: Blog
+author: Craig Jellick
+date: <today, ISO format>
+version: <VERSION>
+---
+```
+
+### 7. Write to disk and report
+
+Write the post to `/tmp/release-blog-<VERSION>.md`. Print:
+- The file path
+- The chosen shape and word count
+- A list of any `[POV: ...]` placeholders that still need the user's personal voice
+- A reminder that this is a draft markdown file for the CMS — the skill has not published anything
+
+End the turn there. Do not run any publish/upload commands. Do not modify the GitHub release. Do not commit anything to the repo.
+
+### 8. (Optional) Post to Wordpress as a draft via the MCP server
+
+Skip this step unless the user explicitly asks for it. Phrases that mean yes: "post it to Wordpress", "create the draft", "post it up there", "put it in the CMS". If the user just says "good draft" or stops at step 7, leave it as a local file.
+
+When the user does ask, post the blog as a Wordpress **draft** (never `publish` without explicit confirmation) via the `obot-wordpress` MCP server. The flow has four sub-steps.
+
+**8a. Authenticate (one time per session).** Call `mcp__obot-wordpress__authenticate` to start the OAuth flow. Share the authorization URL it returns with the user; tell them the redirect to `localhost` may show a connection error and that's fine. The server's full tool set (`create_post`, `list_categories`, `list_users`, `update_post`, etc.) becomes available once auth completes. If auto-completion doesn't fire after they authorize, ask for the full callback URL from their browser and pass it to `mcp__obot-wordpress__complete_authentication`.
+
+**8b. Convert the markdown to HTML.** Wordpress's `create_post` expects the post body as HTML. A helper script lives next to this SKILL.md:
+
+```bash
+uv run "$CLAUDE_PROJECT_DIR/.claude/skills/draft-release-blog/md_to_html.py" \
+  /tmp/release-blog-<VERSION>.md \
+  > /tmp/release-blog-<VERSION>.html
+```
+
+It strips the YAML frontmatter so it doesn't render in the post body and emits HTML5 with the Python `markdown` library's `extra` and `sane_lists` extensions. Dependencies are declared inline (PEP 723) so `uv run` resolves them automatically — no virtualenv setup needed. Important: redirect only stdout (no `2>&1`) so uv's "Installed N packages" line doesn't get mixed into the HTML.
+
+**8c. Look up category and author IDs.** The `create_post` tool wants integer IDs, not names. Run these in parallel:
+
+```
+mcp__obot-wordpress__list_categories(search_query="Blog")  # → expect id 6
+mcp__obot-wordpress__list_users()                           # → find Craig Jellick, expect id 9
+```
+
+IDs may differ if the Wordpress site is reconfigured. Always look them up; don't hardcode.
+
+**8d. Create the draft.** Call `mcp__obot-wordpress__create_post` with:
+
+- `title`: the full title from the markdown frontmatter (`title:` line), unquoted.
+- `content`: the HTML from step 8b, pasted in as a single string.
+- `status`: `"draft"`. Never `"publish"` unless the user has explicitly confirmed publishing live.
+- `author_id`: the integer from `list_users` for Craig Jellick.
+- `categories`: the Blog category ID as a string (e.g. `"6"`), since the tool accepts a comma-separated list.
+
+The response returns a post `id` and a `link` like `https://obot.ai/?p=<id>`. Share both with the user and remind them to review and publish from the WP admin (Posts → Drafts).
+
+**Sanity checks before posting:**
+
+- Run `grep -nF $'\xe2\x80\x94' /tmp/release-blog-<VERSION>.md` (or `grep -nF $'—'`) to confirm no em dashes slipped in. The hard constraints forbid them; the markdown editor sometimes auto-substitutes when copy-pasting.
+- Confirm the HTML file does not start with a uv "Installed N packages" line.
+- Confirm the title in the frontmatter matches the title you're sending to `create_post`.
+
+## Tone reference snippets
+
+From v0.21.0 (deep-dive):
+
+> I'm excited to announce a new framework in Obot that lets you define and enforce network egress policies for the MCP servers running in your Obot environment.
+
+> The MCP server works exactly like it did before. It just can't access external sites it shouldn't.
+
+From v0.16.0 (roundup):
+
+> We are excited to announce the release of Obot v0.16.0, a significant update focused on enterprise readiness and operational control.
+
+> Perfect for CI/CD pipelines, automation scripts, monitoring tools, and other integrations.
+
+Match that register: confident, concrete, no rhetorical flourishes, technical without being dry, first-person plural for the company and first-person singular only when speaking with personal stake.

--- a/.claude/skills/draft-release-blog/md_to_html.py
+++ b/.claude/skills/draft-release-blog/md_to_html.py
@@ -1,0 +1,48 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "markdown>=3.5",
+# ]
+# ///
+"""Convert a release blog markdown file to HTML for the Wordpress CMS.
+
+Strips the leading YAML frontmatter block (between two `---` lines) so the
+CMS doesn't render it as content. Emits the rendered HTML to stdout.
+
+Usage:
+    uv run md_to_html.py /tmp/release-blog-vX.Y.0.md > /tmp/release-blog-vX.Y.0.html
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import markdown
+
+
+def strip_frontmatter(text: str) -> str:
+    if not text.startswith("---\n"):
+        return text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return text
+    return text[end + len("\n---\n"):]
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: md_to_html.py <path-to-md-file>", file=sys.stderr)
+        return 1
+    src = Path(sys.argv[1]).read_text(encoding="utf-8")
+    body = strip_frontmatter(src)
+    html = markdown.markdown(
+        body,
+        extensions=["extra", "sane_lists"],
+        output_format="html5",
+    )
+    sys.stdout.write(html)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/draft-release/SKILL.md
+++ b/.claude/skills/draft-release/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: draft-release
+description: Draft a GitHub release (as a draft, not published) for an upcoming obot minor release by analyzing git history since the previous release. Use when the user asks to draft a release, prepare release notes, or write release notes for an upcoming vX.Y.0 release. Creates a DRAFT GitHub release; never publishes it and never creates the git tag.
+---
+
+# Draft Release Notes
+
+Drafts release notes for the next obot minor release and creates a draft (unpublished) GitHub release containing them. The release stays in draft state for the user to review, edit, and publish themselves. Never creates the git tag, never publishes the release, never pushes anything.
+
+## Inputs
+
+- **Target version** (e.g. `v0.22.0`): ask the user if not provided. If recent pre-release tags exist (e.g. `v0.22.0-rc3`), suggest the corresponding minor (`v0.22.0`) and confirm.
+- **Diff baseline** (e.g. `v0.21.3`): auto-detect as the highest non-pre-release tag, regardless of whether it is a minor or patch. This is the range used to find changes (`<DIFF_BASELINE>..HEAD`) and the left side of the "Full Changelog" compare link. Use `git tag --sort=-v:refname | grep -v -- '-' | head -1`.
+- **Style reference** (e.g. `v0.21.0`): auto-detect as the highest `vX.Y.0` tag that is not a pre-release. Use `git tag --list 'v*.*.0' --sort=-v:refname | grep -v -- '-' | head -1`. This release's notes are the tone/structure template. It is often the same as the diff baseline but may differ when patch releases exist between minors.
+
+## Hard constraints
+
+- Do NOT create git tags. Do NOT run `git tag` or `git push --tags`. The draft release does not require the tag to exist locally — GitHub creates it only when the draft is published, which the user does manually.
+- `gh release create` is allowed ONLY with `--draft`. Never run it without `--draft`. Never run `gh release edit --draft=false`. Never publish.
+- Do NOT model the notes on patch releases (`vX.Y.Z` where Z > 0) or pre-releases (`-rc`, `-alpha`, `-beta`). Those use minimal notes. Always model on the most recent `vX.Y.0`.
+- No emojis. No em dashes (`—`). Use plain hyphens or rewrite the sentence. No "we're thrilled / excited to / proud to" beyond the one opening line the template already uses. No marketing fluff.
+- Use straight quotes (`'` and `"`), not curly quotes.
+- Do not invent PRs, authors, or commit messages in "What's Changed". That section must be sourced from the GitHub API, not synthesized.
+
+## Procedure
+
+### 1. Confirm version, diff baseline, and style reference
+
+```bash
+# Diff baseline: latest non-pre-release tag (minor OR patch):
+git tag --sort=-v:refname | grep -v -- '-' | head -1
+# Style reference: latest published minor (vX.Y.0, no pre-releases):
+git tag --list 'v*.*.0' --sort=-v:refname | grep -v -- '-' | head -1
+# Recent tags to suggest the target version:
+git tag --sort=-creatordate | head -10
+```
+
+Confirm the target version, diff baseline, and style reference with the user before proceeding. The diff baseline and style reference often differ — e.g. baseline `v0.21.3`, style `v0.21.0`. Use the baseline for everything that touches commit range, and the style reference for tone/structure.
+
+### 2. Read the style reference's notes for tone and structure
+
+```bash
+gh release view <STYLE_REF> --repo obot-platform/obot
+```
+
+Match its structure exactly:
+1. One-paragraph opener: `We're excited to announce the <VERSION> release of the Obot MCP Platform. This release <one-sentence theme summary>.`
+2. `## Big Updates` with 3-6 `### Feature Name` subsections. Each subsection is 1-3 short paragraphs in plain prose. Link to docs with `[docs](https://docs.obot.ai/...)` when a docs page exists.
+3. Optional `## Improvements` section with a short bulleted list of smaller usability/perf items. Include only if there are clearly several smaller user-facing improvements worth calling out. Omit otherwise (v0.21.0 has no Improvements section).
+4. `## Upgrade Notes` — usually `There are no major breaking changes in this release.` If the diff contains breaking changes (removed APIs, renamed config, schema migrations, removed env vars), call them out explicitly and concretely. Check commits with `chore: remove`, `BREAKING`, or schema/migration changes.
+5. `## What's Changed` — generated via API (see step 5).
+6. Trailing `**Full Changelog**: https://github.com/obot-platform/obot/compare/<DIFF_BASELINE>...<VERSION>`.
+
+### 3. Survey the commit range
+
+```bash
+git log <DIFF_BASELINE>..HEAD --oneline
+git log <DIFF_BASELINE>..HEAD --format='%H%n%s%n%b%n---'  # full bodies if more context needed
+```
+
+Identify candidate big features. Heuristics:
+- `feat:` commits are top candidates.
+- `enhance:` commits that introduce notable user-visible capability also qualify.
+- Group related commits into one theme (e.g. several `image pull secrets` commits become one "Image Pull Secrets" feature).
+- `fix:`, `chore:`, `docs:`, dependabot, and CI commits are NOT big features.
+
+Aim for 3-6 Big Updates. If the range is small, fewer is fine. If many candidates exist, prioritize features that change what users can do, not internal refactors.
+
+**Deep-read each candidate before drafting its gist.** Commit subjects are too thin to build a release note on. For every candidate Big Update (and every PR that gets merged into one as part of a theme), do all of:
+
+```bash
+# Full PR body + comments + reviewers:
+gh pr view <NUM> --repo obot-platform/obot --comments
+
+# Files changed (helps confirm scope and spot user-facing surface area):
+gh pr view <NUM> --repo obot-platform/obot --json files --jq '.files[].path'
+```
+
+**Finding linked issues.** This repo deliberately does NOT use GitHub's `closes #N` / `fixes #N` keywords, so the `closingIssuesReferences` field will almost always be empty. Issues are referenced in PR body or comments as plain text. Grep the PR body and the comment thread (both come back from `gh pr view --comments`) for:
+- bare `#<number>` references
+- `obot-platform/obot#<number>`
+- full URLs like `https://github.com/obot-platform/obot/issues/<number>`
+- "issue 1234", "see 1234", or similar prose mentions of a 3-5 digit number near words like "issue", "tracked in", "addresses", "from"
+
+For every issue number found that way, read it:
+
+```bash
+gh issue view <ISSUE_NUM> --repo obot-platform/obot --comments
+```
+
+Be slightly generous — false positives (numbers that turn out to be PR numbers, version numbers, or unrelated) are cheap to read and discard. Missing the issue that explains the *why* is what you're avoiding. Linked issues usually contain the user problem, the design discussion, and the constraints that the PR body and commit message omit. That context is what makes the difference between a release note that says "added X" and one that explains what X actually unlocks for users.
+
+If a candidate is a theme spanning multiple PRs, deep-read the largest one (or two) — not every single follow-up fix PR. Use judgement: enough reading to write an accurate gist, not exhaustive.
+
+Do not write up a feature whose PR(s) and linked issues you have not actually read in this session.
+
+### 4. Check the milestone for `release-note` issues
+
+The team flags items that need an explicit callout in the release (deprecations, upgrade warnings, behavior changes, required config changes) by labeling GitHub issues with `release-note` and attaching them to the milestone matching the release.
+
+Look them up:
+
+```bash
+# Try the version both with and without the leading "v" — milestones are usually "v0.22.0" but check both.
+gh issue list --repo obot-platform/obot --milestone "<VERSION>" --label "release-note" --state all \
+  --json number,title,body,url,state,labels --limit 50
+gh issue list --repo obot-platform/obot --milestone "<VERSION_NO_V>" --label "release-note" --state all \
+  --json number,title,body,url,state,labels --limit 50
+```
+
+If neither returns results, also check whether the milestone exists at all:
+
+```bash
+gh api repos/obot-platform/obot/milestones --jq '.[] | {title, number, state}'
+```
+
+If the milestone is missing or has no `release-note` issues, note that to the user and continue without callouts. Do not invent callouts.
+
+For each issue found, draft a concise note:
+- One or two sentences max. State the deprecation, warning, or required action plainly.
+- Link to the issue at the end: `See [#<NUMBER>](<URL>) for details.`
+- Classify each as either:
+  - **Upgrade Notes item** (default): goes into the `## Upgrade Notes` section as a bullet or short paragraph. Use for deprecations, removed config, required migrations, behavior changes that affect all users.
+  - **Feature-attached callout**: render as a blockquote inside the relevant `### Feature` subsection in Big Updates. Use only when the note is specifically about how to enable, configure, or be aware of one of the features being highlighted. Mirror the blockquote style from v0.19.0's Message Policies entry.
+
+Do not paste the issue body verbatim. Distill it. The issue is for details; the release note is the headline.
+
+### 5. Confirm the feature list and release-note callouts with the user (required, do not skip)
+
+Before writing any prose, present the candidate Big Updates AND the release-note callouts back to the user for review. This catches three failure modes: highlighting the wrong things, mis-describing what a feature actually does, and misclassifying a release-note callout. Format the review like this:
+
+```
+Candidate Big Updates for <VERSION> (range <DIFF_BASELINE>..HEAD):
+
+1. <Proposed feature title>
+   Gist: <one or two sentences summarizing what this feature is and why it matters>
+   Source PRs: #6567, #6605, #6636, ...
+
+2. <Proposed feature title>
+   Gist: ...
+   Source PRs: ...
+
+Also considered but dropped (say if any should be promoted):
+- <feature> — reason dropped (e.g. "internal refactor only", "rolled into #N", "fix not feat")
+
+Release-note callouts found in milestone <VERSION>:
+
+1. [#<NUM>] <issue title>
+   Proposed note: <drafted one or two sentences>
+   Classified as: Upgrade Notes  (or: Feature-attached callout under "<Feature Title>")
+
+(If none: "No release-note issues found in milestone <VERSION>.")
+
+Questions for you:
+a. Are these the right features to highlight? Any to add, drop, or merge?
+b. For each kept feature, is the gist accurate? Reply with corrections inline or just "all good".
+c. Any feature here that should be downgraded to the Improvements bullet list instead?
+d. For each release-note callout: is the wording accurate, and is it classified in the right place (Upgrade Notes vs. attached to a feature)?
+```
+
+Use AskUserQuestion when there are concrete forks (e.g. multiple ways to title or scope a feature, or whether a callout belongs in Upgrade Notes vs. on a feature). For open-ended gist corrections, plain text reply is fine. Wait for the user's response and incorporate corrections before proceeding to step 6. Do not draft prose for a feature or callout whose wording the user has not confirmed or corrected.
+
+If the user corrects a gist or callout, mirror their wording closely in the draft. They know the feature better than the commit messages or issue body do.
+
+### 6. Draft Big Updates, Improvements, and Upgrade Notes
+
+For each Big Update:
+- `### Title` in title case, matching the style of previous minors (e.g. "Aviatrix Integration for MCP Server Egress Control", "JumpCloud Authentication Provider").
+- 1-3 short paragraphs. First paragraph states what the feature is. Second paragraph (optional) explains the impact or how it is used. Third paragraph (optional) links to docs or notes follow-ups.
+- Avoid restating the title in the opening sentence verbatim; instead state the capability.
+- No bulleted lists inside Big Updates subsections (the previous minors don't use them there).
+
+For Improvements (optional): a bulleted list of 4-10 short items. One line each. Skip the section entirely if there is nothing meaningful to list.
+
+For Upgrade Notes: if step 4 surfaced release-note issues classified as Upgrade Notes items, include them as bullets (or short paragraphs if longer). Each ends with a `See [#<NUMBER>](<URL>) for details.` link. If there were no callouts and no breaking changes detected in the commits, fall back to the default `There are no major breaking changes in this release.` line.
+
+For feature-attached callouts: render the confirmed note as a blockquote (`> ...`) inside the relevant `### Feature` subsection in Big Updates, ending with the issue link.
+
+### 7. Generate "What's Changed" without hallucinating
+
+Use the GitHub-authoritative source — the same endpoint the release UI uses:
+
+```bash
+gh api -X POST repos/obot-platform/obot/releases/generate-notes \
+  -f tag_name="<VERSION>" \
+  -f previous_tag_name="<DIFF_BASELINE>" \
+  -f target_commitish="main" \
+  --jq .body
+```
+
+Paste the `## What's Changed` section and `**Full Changelog**` line from the response verbatim. Do not edit PR titles, authors, or links. If the endpoint also returns headings above What's Changed (it sometimes includes a "## What's Changed" header itself), keep only the list and the Full Changelog line, integrating with the rest of the draft.
+
+If `gh api` fails (auth, network), fall back to:
+
+```bash
+gh pr list --repo obot-platform/obot --state merged \
+  --search "merged:>=<DIFF_BASELINE_DATE> base:main" \
+  --json number,title,author,url --limit 200
+```
+
+Format each as `* <title> by @<author> in <url>`. If using this fallback, tell the user the list came from `gh pr list` and recommend they regenerate it from the GitHub UI when they create the release, since the UI's list is the canonical one.
+
+### 8. Create the draft release on GitHub
+
+First write the assembled notes to `/tmp/release-notes-<VERSION>.md` so there's a local copy the user can re-use if they want to recreate the draft. Then create the draft release on GitHub with that file as the body:
+
+```bash
+gh release create <VERSION> \
+  --repo obot-platform/obot \
+  --draft \
+  --title "<VERSION>" \
+  --target main \
+  --notes-file /tmp/release-notes-<VERSION>.md
+```
+
+Notes on the flags:
+- `--draft` is mandatory. Never omit it. The draft does not create the tag — GitHub creates the tag only when the draft is published (and the user does that themselves through the UI).
+- `--title "<VERSION>"` matches the project convention (release title equals the tag name, e.g. `v0.22.0`).
+- `--target main` so the tag, when eventually published, points at `main`. Adjust only if the user has explicitly told you to release from another branch.
+- Do NOT pass `--latest`, `--prerelease`, or `--generate-notes`. We already have the notes; we are not publishing; this is not a pre-release.
+
+If a draft already exists for this version, `gh release create` will fail with "already exists". In that case ask the user whether to delete the existing draft (`gh release delete <VERSION> --repo obot-platform/obot --yes`) and recreate, or leave the existing one alone. Do not delete without asking.
+
+Print the draft URL returned by `gh release create` and a one-line summary of what's in the draft (feature count, callout count). End the turn telling the user the release exists as a draft on GitHub — they should review it there, edit if needed, and publish manually when ready. Remind them publishing is what creates the actual tag.
+
+## Tone reference (from v0.21.0)
+
+> We're excited to announce the v0.21.0 release of the Obot MCP Platform. This release introduces MCP server egress control with an Aviatrix integration and improves the admin dashboard experience.
+>
+> ## Big Updates
+>
+> ### Aviatrix Integration for MCP Server Egress Control
+>
+> Obot now supports MCP server egress control for Kubernetes-hosted MCP servers, with Aviatrix as the first supported network policy provider.
+>
+> Administrators can configure domain allowlists for individual `npx`, `uvx`, and `containerized` MCP servers. ...
+
+Match that register: declarative, concrete, no hype words, no rhetorical flourishes.

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ catalog.json
 .zed/
 __debug_*
 
-.claude/
+**/.claude/settings.local.json
 thoughts/
 thoughts
 


### PR DESCRIPTION
Adds two project-local Claude Code skills used to draft releases:

- draft-release: surveys git history since the last non-pre-release
  tag, deep-reads candidate feature PRs and linked issues, gathers
  release-note callouts from the milestone, and creates a DRAFT GitHub
  release (never publishes, never creates the tag). Models tone and
  structure on the previous vX.Y.0 release.
- draft-release-blog: drafts a release announcement blog modeled on
  the obot.ai blog voice, sourced from the draft release plus deep
  research for blog-quality detail. Outputs markdown for the CMS and
  can post to Wordpress as a draft via MCP when explicitly asked.

Adjusts .gitignore so .claude/skills/ is tracked while .claude/
settings.local.json and other local files stay ignored. The
draft-release-video-script skill is intentionally kept ignored until
it has been tested end-to-end.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
