### PR TITLE
chore: gitignore goreleaser build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ kubeconfig
 # Ignore packed helm chart
 .packaged/
 
+# Ignore GoReleaser output
+/dist/
+
 # Ignore dependency directories
 vendor/
 


### PR DESCRIPTION
GoReleaser writes binaries and metadata to dist/ during the release workflow.
This caused untracked changes to be present during the build, which
resulted in shipped release binaries reporting a reporting a `-dirty` suffix
from `obot version` invocations.

Add `/dist/` to the .gitignore to prevent this from happening.

Addresses https://github.com/obot-platform/obot/issues/6752
