### PR TITLE
fix: enable sharable connect urls for composite servers

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -987,8 +987,12 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 		}
 		if len(servers.Items) == 0 {
 			// If the user has not configured an MCP server for the catalog entry, and the catalog
-			// entry does not require any user configuration, then create a server for the user.
-			if entryManifestNeedsUserConfig(entry.Spec.Manifest) {
+			// entry can be launched without further configuration, then create a server for the user.
+			needsConfig, err := entryNeedsUserConfig(req.Context(), req.LocalK8sClient, req.ObotNamespace, entry)
+			if err != nil {
+				return v1.MCPServer{}, v1.MCPServerInstance{}, fmt.Errorf("failed to determine required configuration for catalog entry %s: %w", id, err)
+			}
+			if needsConfig {
 				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("user has not configured an MCP server for catalog entry %s", id)
 			}
 
@@ -1039,53 +1043,88 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 	}
 }
 
-// entryManifestNeedsUserConfig reports whether a catalog entry manifest requires user-supplied
-// configuration before it can be instantiated.
-// For composite manifest, all components are checked for required configuration.
-func entryManifestNeedsUserConfig(m types.MCPServerCatalogEntryManifest) bool {
-	for _, e := range m.Env {
-		if e.Required {
-			return true
-		}
+// entryNeedsUserConfig reports whether a catalog entry can't be auto-launched for a user without
+// further configuration. That covers both user-supplied config (required env, headers, or a URL the
+// user must provide) and unfinished admin setup (a required secret binding that doesn't resolve, or
+// static OAuth that isn't configured yet). For composite entries, every component is checked.
+func entryNeedsUserConfig(ctx context.Context, client kclient.Client, obotNamespace string, entry v1.MCPServerCatalogEntry) (bool, error) {
+	// Static OAuth is admin config: if it's required but not configured yet, the entry can't launch.
+	if entryRequiresStaticOAuthCreds(entry) {
+		return true, nil
 	}
 
-	switch m.Runtime {
-	case types.RuntimeRemote:
-		if m.RemoteConfig == nil || m.RemoteConfig.FixedURL == "" {
-			// A hostname/template (or missing) remote config requires a user-supplied URL.
-			return true
-		}
-		for _, h := range m.RemoteConfig.Headers {
-			if h.Required {
-				return true
-			}
-		}
-	case types.RuntimeComposite:
+	m := entry.Spec.Manifest
+
+	// Gather the manifests whose required config must be satisfied: the entry itself, or each
+	// catalog-entry component of a composite. A multi-user component only blocks on its required
+	// user-defined headers (its URL/env/static headers are admin-supplied), so handle it here.
+	manifests := []types.MCPServerCatalogEntryManifest{m}
+	if m.Runtime == types.RuntimeComposite {
 		if m.CompositeConfig == nil {
-			return false
+			return false, nil
 		}
-		for _, c := range m.CompositeConfig.ComponentServers {
-			// Multi-user components proxy to an admin-managed multi-user server. Their URL, env,
-			// and static headers are admin-supplied; only required user-defined headers block the
-			// user, so don't recurse into the component's runtime config.
-			if c.MCPServerID != "" {
-				if c.Manifest.MultiUserConfig != nil {
-					for _, h := range c.Manifest.MultiUserConfig.UserDefinedHeaders {
+		manifests = nil
+		for _, comp := range m.CompositeConfig.ComponentServers {
+			if comp.MCPServerID != "" {
+				if comp.Manifest.MultiUserConfig != nil {
+					for _, h := range comp.Manifest.MultiUserConfig.UserDefinedHeaders {
 						if h.Required {
-							return true
+							return true, nil
 						}
 					}
 				}
 				continue
 			}
+			manifests = append(manifests, comp.Manifest)
+		}
+	}
 
-			if entryManifestNeedsUserConfig(c.Manifest) {
+	for _, cm := range manifests {
+		// Resolve admin-supplied secret bindings so a required value the admin already satisfied
+		// (a literal value, e.g. a git-managed catalog, or a binding to an existing secret) doesn't
+		// count as needing anything from the user.
+		var remote *types.RemoteRuntimeConfig
+		if cm.RemoteConfig != nil {
+			remote = &types.RemoteRuntimeConfig{Headers: cm.RemoteConfig.Headers}
+		}
+		resolved, err := mcp.MergeBoundCreds(ctx, client, obotNamespace, cm.Env, remote, nil)
+		if err != nil {
+			return false, err
+		}
+
+		// satisfied reports whether a required env/header is already provided without user input:
+		// a literal value, or a secret binding that resolved to a non-empty value.
+		satisfied := func(h types.MCPHeader) bool {
+			if h.Value != "" {
 				return true
+			}
+			if h.SecretBinding != nil {
+				_, ok := resolved[h.Key]
+				return ok
+			}
+			return false
+		}
+
+		for _, e := range cm.Env {
+			if e.Required && !satisfied(e.MCPHeader) {
+				return true, nil
+			}
+		}
+
+		if cm.Runtime == types.RuntimeRemote {
+			if cm.RemoteConfig == nil || cm.RemoteConfig.FixedURL == "" {
+				// A hostname/template (or missing) remote config requires a user-supplied URL.
+				return true, nil
+			}
+			for _, h := range cm.RemoteConfig.Headers {
+				if h.Required && !satisfied(h) {
+					return true, nil
+				}
 			}
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // MCPIDAndAudienceFromConnectURL returns the MCP server or instance name and audience based on the provided connect URL.

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -986,28 +986,10 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 			return v1.MCPServer{}, v1.MCPServerInstance{}, err
 		}
 		if len(servers.Items) == 0 {
-			// If the user has not configured an MCP server for the catalog entry, and the catalog entry does not have any required configuration, then create an server for the user.
-			if entry.Spec.Manifest.Runtime == types.RuntimeComposite {
-				// For now launching composite servers by connecting to a catalog entry ID is not supported.
-				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("user has not configured an MCP server for composite catalog entry %s", id)
-			}
-
-			for _, env := range entry.Spec.Manifest.Env {
-				if env.Required {
-					return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("user has not configured an MCP server for catalog entry %s", id)
-				}
-			}
-
-			if entry.Spec.Manifest.Runtime == types.RuntimeRemote {
-				if entry.Spec.Manifest.RemoteConfig.FixedURL == "" {
-					return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("user has not configured an MCP server for catalog entry %s", id)
-				}
-
-				for _, h := range entry.Spec.Manifest.RemoteConfig.Headers {
-					if h.Required {
-						return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("user has not configured an MCP server for catalog entry %s", id)
-					}
-				}
+			// If the user has not configured an MCP server for the catalog entry, and the catalog
+			// entry does not require any user configuration, then create a server for the user.
+			if entryManifestNeedsUserConfig(entry.Spec.Manifest) {
+				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("user has not configured an MCP server for catalog entry %s", id)
 			}
 
 			// Convert the catalog entry manifest to a server manifest. Treat the user as non-admin always.
@@ -1033,6 +1015,19 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("user has not configured an MCP server for catalog entry %s", id)
 			}
 
+			// The composite's component servers are created asynchronously by the controller
+			// (EnsureCompositeComponents). The connect path builds the nanobot config by listing
+			// components synchronously, so wait for the controller to reconcile them before
+			// returning to avoid baking a config with missing components.
+			if server.Spec.Manifest.Runtime == types.RuntimeComposite &&
+				server.Spec.Manifest.CompositeConfig != nil &&
+				len(server.Spec.Manifest.CompositeConfig.ComponentServers) > 0 {
+				server, err = waitForCompositeReady(req, server, 30*time.Second)
+				if err != nil {
+					return v1.MCPServer{}, v1.MCPServerInstance{}, fmt.Errorf("failed to wait for composite server to be ready: %w", err)
+				}
+			}
+
 			servers.Items = append(servers.Items, server)
 		}
 
@@ -1042,6 +1037,55 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 
 		return servers.Items[0], v1.MCPServerInstance{}, nil
 	}
+}
+
+// entryManifestNeedsUserConfig reports whether a catalog entry manifest requires user-supplied
+// configuration before it can be instantiated.
+// For composite manifest, all components are checked for required configuration.
+func entryManifestNeedsUserConfig(m types.MCPServerCatalogEntryManifest) bool {
+	for _, e := range m.Env {
+		if e.Required {
+			return true
+		}
+	}
+
+	switch m.Runtime {
+	case types.RuntimeRemote:
+		if m.RemoteConfig == nil || m.RemoteConfig.FixedURL == "" {
+			// A hostname/template (or missing) remote config requires a user-supplied URL.
+			return true
+		}
+		for _, h := range m.RemoteConfig.Headers {
+			if h.Required {
+				return true
+			}
+		}
+	case types.RuntimeComposite:
+		if m.CompositeConfig == nil {
+			return false
+		}
+		for _, c := range m.CompositeConfig.ComponentServers {
+			// Multi-user components proxy to an admin-managed multi-user server. Their URL, env,
+			// and static headers are admin-supplied; only required user-defined headers block the
+			// user, so don't recurse into the component's runtime config.
+			if c.MCPServerID != "" {
+				if c.Manifest.MultiUserConfig != nil {
+					for _, h := range c.Manifest.MultiUserConfig.UserDefinedHeaders {
+						if h.Required {
+							return true
+						}
+					}
+				}
+				continue
+			}
+
+			if entryManifestNeedsUserConfig(c.Manifest) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // MCPIDAndAudienceFromConnectURL returns the MCP server or instance name and audience based on the provided connect URL.
@@ -1927,7 +1971,7 @@ func (m *MCPHandler) configureCompositeServer(req api.Context, compositeServer v
 	}
 
 	// Wait for the composite server's child MCP servers and instances to match it's current runtime configuration.
-	compositeServer, err := m.waitForCompositeReady(req, compositeServer, 5*time.Second)
+	compositeServer, err := waitForCompositeReady(req, compositeServer, 5*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed to wait for composite server to be ready for configuration: %w", err)
 	}
@@ -2087,7 +2131,7 @@ func (m *MCPHandler) configureCompositeServer(req api.Context, compositeServer v
 		}
 
 		// Wait for the update to be applied across all component servers
-		compositeServer, err = m.waitForCompositeReady(req, compositeServer, 30)
+		compositeServer, err = waitForCompositeReady(req, compositeServer, 30*time.Second)
 		if err != nil {
 			return fmt.Errorf("failed to wait for composite server to be ready for configuration: %w", err)
 		}
@@ -2788,7 +2832,7 @@ func SlugForMCPServer(ctx context.Context, client kclient.Client, server v1.MCPS
 	}
 
 	slug := server.Spec.MCPServerCatalogEntryName
-	if shouldHaveUnique || server.Spec.MCPServerCatalogEntryName == "" || server.Spec.Manifest.Runtime == types.RuntimeComposite {
+	if shouldHaveUnique || server.Spec.MCPServerCatalogEntryName == "" {
 		slug = server.Name
 	}
 
@@ -3842,7 +3886,7 @@ func (m *MCPHandler) triggerCompositeUpdate(req api.Context, compositeServer v1.
 	}
 
 	// Wait for the composite server to apply the changes to all component servers
-	if _, err := m.waitForCompositeReady(req, compositeServer, 30*time.Second); err != nil {
+	if _, err := waitForCompositeReady(req, compositeServer, 30*time.Second); err != nil {
 		return fmt.Errorf("failed to wait for component servers to sync: %w", err)
 	}
 
@@ -3880,7 +3924,7 @@ func (*MCPHandler) updateCompositeManifest(req api.Context, name, oldManifestHas
 }
 
 // waitForCompositeReady waits until the given timeout for the composite server's current manifest to be applied to its component servers
-func (*MCPHandler) waitForCompositeReady(req api.Context, compositeServer v1.MCPServer, timeout time.Duration) (v1.MCPServer, error) {
+func waitForCompositeReady(req api.Context, compositeServer v1.MCPServer, timeout time.Duration) (v1.MCPServer, error) {
 	latest, err := wait.For(
 		req.Context(),
 		req.Storage,

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -15,9 +15,12 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestConvertMCPResources(t *testing.T) {
@@ -790,6 +793,18 @@ func TestConvertMCPServerCompositeSkipsDisabledAndConfiguredComponents(t *testin
 }
 
 func TestEntryManifestNeedsUserConfig(t *testing.T) {
+	const ns = "obot-ns"
+
+	newClient := func(t *testing.T, objects ...kclient.Object) kclient.Client {
+		t.Helper()
+		scheme := runtime.NewScheme()
+		require.NoError(t, corev1.AddToScheme(scheme))
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	}
+	secret := func(name string, data map[string][]byte) *corev1.Secret {
+		return &corev1.Secret{Data: data, ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+	}
+
 	requiredEnv := types.MCPEnv{MCPHeader: types.MCPHeader{Name: "TOKEN", Required: true}}
 	optionalEnv := types.MCPEnv{MCPHeader: types.MCPHeader{Name: "DEBUG"}}
 	requiredHeader := types.MCPHeader{Name: "X-Api-Key", Required: true}
@@ -802,14 +817,26 @@ func TestEntryManifestNeedsUserConfig(t *testing.T) {
 	remoteFixed := types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com"}}
 
 	tests := []struct {
-		name     string
-		manifest types.MCPServerCatalogEntryManifest
-		want     bool
+		name            string
+		manifest        types.MCPServerCatalogEntryManifest
+		oauthConfigured bool
+		client          kclient.Client
+		want            bool
 	}{
 		// Single-user (non-remote, non-composite): only required env blocks.
 		{name: "single-user no config", manifest: singleUserNoConfig, want: false},
 		{name: "single-user optional env", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeNPX, Env: []types.MCPEnv{optionalEnv}}, want: false},
 		{name: "single-user required env", manifest: singleUserRequiredEnv, want: true},
+
+		// A required value the admin already satisfied does not need user input: a literal value,
+		// or a secret binding that resolves to a non-empty value. An unresolved binding still blocks.
+		{name: "required env literal value", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeNPX, Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "TOKEN", Required: true, Value: "preset"}}}}, want: false},
+		{name: "required env resolved binding", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeNPX, Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "TOKEN", Required: true, SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"}}}}},
+			client: newClient(t, secret("s", map[string][]byte{"k": []byte("v")})), want: false},
+		{name: "required env unresolved binding", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeNPX, Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "TOKEN", Required: true, SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"}}}}},
+			client: newClient(t), want: true},
+		{name: "required env binding empty value", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeNPX, Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "TOKEN", Required: true, SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"}}}}},
+			client: newClient(t, secret("s", map[string][]byte{"k": []byte("")})), want: true},
 
 		// Remote: a fixed URL with no required headers is shareable; anything else blocks.
 		{name: "remote fixed url", manifest: remoteFixed, want: false},
@@ -818,6 +845,15 @@ func TestEntryManifestNeedsUserConfig(t *testing.T) {
 		{name: "remote empty fixed url", manifest: remoteNeedsURL, want: true},
 		{name: "remote required header", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com", Headers: []types.MCPHeader{requiredHeader}}}, want: true},
 		{name: "remote required env beats fixed url", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, Env: []types.MCPEnv{requiredEnv}, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com"}}, want: true},
+		{name: "remote required header literal value", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com", Headers: []types.MCPHeader{{Key: "X-Api-Key", Required: true, Value: "preset"}}}}, want: false},
+		{name: "remote required header resolved binding", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com", Headers: []types.MCPHeader{{Key: "X-Api-Key", Required: true, SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"}}}}},
+			client: newClient(t, secret("s", map[string][]byte{"k": []byte("v")})), want: false},
+		{name: "remote required header unresolved binding", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com", Headers: []types.MCPHeader{{Key: "X-Api-Key", Required: true, SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"}}}}},
+			client: newClient(t), want: true},
+
+		// Static OAuth is admin config: a launchable entry blocks until the admin configures it.
+		{name: "remote static oauth not configured", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com", StaticOAuthRequired: true}}, oauthConfigured: false, want: true},
+		{name: "remote static oauth configured", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com", StaticOAuthRequired: true}}, oauthConfigured: true, want: false},
 
 		// Composite: empty/nil cases are shareable.
 		{name: "composite nil config", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeComposite}, want: false},
@@ -873,23 +909,17 @@ func TestEntryManifestNeedsUserConfig(t *testing.T) {
 				MultiUserConfig: &types.MultiUserConfig{UserDefinedHeaders: []types.MCPHeader{optionalHeader}},
 			}},
 		), want: false},
-
-		// Nested composite: recursion descends into a sub-composite component.
-		{name: "nested composite component needs config", manifest: composite(
-			types.CatalogComponentServer{CatalogEntryID: "sub", Manifest: composite(
-				types.CatalogComponentServer{CatalogEntryID: "leaf", Manifest: singleUserRequiredEnv},
-			)},
-		), want: true},
-		{name: "nested composite component no config", manifest: composite(
-			types.CatalogComponentServer{CatalogEntryID: "sub", Manifest: composite(
-				types.CatalogComponentServer{CatalogEntryID: "leaf", Manifest: singleUserNoConfig},
-			)},
-		), want: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, entryManifestNeedsUserConfig(tt.manifest))
+			entry := v1.MCPServerCatalogEntry{
+				Spec:   v1.MCPServerCatalogEntrySpec{Manifest: tt.manifest},
+				Status: v1.MCPServerCatalogEntryStatus{OAuthCredentialConfigured: tt.oauthConfigured},
+			}
+			got, err := entryNeedsUserConfig(context.Background(), tt.client, ns, entry)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -788,3 +788,116 @@ func TestConvertMCPServerCompositeSkipsDisabledAndConfiguredComponents(t *testin
 	assert.Empty(t, converted.MissingRequiredEnvVars)
 	assert.Empty(t, converted.MissingRequiredHeaders)
 }
+
+func TestEntryManifestNeedsUserConfig(t *testing.T) {
+	requiredEnv := types.MCPEnv{MCPHeader: types.MCPHeader{Name: "TOKEN", Required: true}}
+	optionalEnv := types.MCPEnv{MCPHeader: types.MCPHeader{Name: "DEBUG"}}
+	requiredHeader := types.MCPHeader{Name: "X-Api-Key", Required: true}
+	optionalHeader := types.MCPHeader{Name: "X-Trace", Required: false}
+
+	// component manifests reused across composite cases
+	singleUserNoConfig := types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeNPX}
+	singleUserRequiredEnv := types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeNPX, Env: []types.MCPEnv{requiredEnv}}
+	remoteNeedsURL := types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{}}
+	remoteFixed := types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com"}}
+
+	tests := []struct {
+		name     string
+		manifest types.MCPServerCatalogEntryManifest
+		want     bool
+	}{
+		// Single-user (non-remote, non-composite): only required env blocks.
+		{name: "single-user no config", manifest: singleUserNoConfig, want: false},
+		{name: "single-user optional env", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeNPX, Env: []types.MCPEnv{optionalEnv}}, want: false},
+		{name: "single-user required env", manifest: singleUserRequiredEnv, want: true},
+
+		// Remote: a fixed URL with no required headers is shareable; anything else blocks.
+		{name: "remote fixed url", manifest: remoteFixed, want: false},
+		{name: "remote fixed url optional header", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com", Headers: []types.MCPHeader{optionalHeader}}}, want: false},
+		{name: "remote nil config", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote}, want: true},
+		{name: "remote empty fixed url", manifest: remoteNeedsURL, want: true},
+		{name: "remote required header", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com", Headers: []types.MCPHeader{requiredHeader}}}, want: true},
+		{name: "remote required env beats fixed url", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeRemote, Env: []types.MCPEnv{requiredEnv}, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com"}}, want: true},
+
+		// Composite: empty/nil cases are shareable.
+		{name: "composite nil config", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeComposite}, want: false},
+		{name: "composite no components", manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeComposite, CompositeConfig: &types.CompositeCatalogConfig{}}, want: false},
+
+		// Composite with catalog-entry components: recurse into each component manifest.
+		{name: "composite single-user component no config", manifest: composite(
+			types.CatalogComponentServer{CatalogEntryID: "c1", Manifest: singleUserNoConfig},
+		), want: false},
+		{name: "composite single-user component required env", manifest: composite(
+			types.CatalogComponentServer{CatalogEntryID: "c1", Manifest: singleUserRequiredEnv},
+		), want: true},
+		{name: "composite remote component needs url", manifest: composite(
+			types.CatalogComponentServer{CatalogEntryID: "c1", Manifest: remoteNeedsURL},
+		), want: true},
+		{name: "composite first ok second needs config", manifest: composite(
+			types.CatalogComponentServer{CatalogEntryID: "c1", Manifest: remoteFixed},
+			types.CatalogComponentServer{CatalogEntryID: "c2", Manifest: singleUserRequiredEnv},
+		), want: true},
+
+		// Composite with multi-user components (MCPServerID set): only required user-defined
+		// headers block. Admin-managed URL/env/static headers on the snapshot must NOT block.
+		{name: "composite multi-user required user header", manifest: composite(
+			types.CatalogComponentServer{MCPServerID: "ms1", Manifest: types.MCPServerCatalogEntryManifest{
+				Runtime:         types.RuntimeRemote,
+				RemoteConfig:    &types.RemoteCatalogConfig{FixedURL: "https://admin.example.com"},
+				MultiUserConfig: &types.MultiUserConfig{UserDefinedHeaders: []types.MCPHeader{requiredHeader}},
+			}},
+		), want: true},
+		{name: "composite multi-user remote admin header not blocking", manifest: composite(
+			types.CatalogComponentServer{MCPServerID: "ms1", Manifest: types.MCPServerCatalogEntryManifest{
+				Runtime:      types.RuntimeRemote,
+				RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://admin.example.com", Headers: []types.MCPHeader{requiredHeader}},
+			}},
+		), want: false},
+		{name: "composite multi-user empty fixed url not blocking", manifest: composite(
+			types.CatalogComponentServer{MCPServerID: "ms1", Manifest: types.MCPServerCatalogEntryManifest{
+				Runtime:      types.RuntimeRemote,
+				RemoteConfig: &types.RemoteCatalogConfig{},
+			}},
+		), want: false},
+		{name: "composite multi-user admin env not blocking", manifest: composite(
+			types.CatalogComponentServer{MCPServerID: "ms1", Manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeContainerized,
+				Env:     []types.MCPEnv{requiredEnv},
+			}},
+		), want: false},
+		{name: "composite multi-user nil multiuser config", manifest: composite(
+			types.CatalogComponentServer{MCPServerID: "ms1", Manifest: types.MCPServerCatalogEntryManifest{Runtime: types.RuntimeContainerized}},
+		), want: false},
+		{name: "composite multi-user optional user header", manifest: composite(
+			types.CatalogComponentServer{MCPServerID: "ms1", Manifest: types.MCPServerCatalogEntryManifest{
+				MultiUserConfig: &types.MultiUserConfig{UserDefinedHeaders: []types.MCPHeader{optionalHeader}},
+			}},
+		), want: false},
+
+		// Nested composite: recursion descends into a sub-composite component.
+		{name: "nested composite component needs config", manifest: composite(
+			types.CatalogComponentServer{CatalogEntryID: "sub", Manifest: composite(
+				types.CatalogComponentServer{CatalogEntryID: "leaf", Manifest: singleUserRequiredEnv},
+			)},
+		), want: true},
+		{name: "nested composite component no config", manifest: composite(
+			types.CatalogComponentServer{CatalogEntryID: "sub", Manifest: composite(
+				types.CatalogComponentServer{CatalogEntryID: "leaf", Manifest: singleUserNoConfig},
+			)},
+		), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, entryManifestNeedsUserConfig(tt.manifest))
+		})
+	}
+}
+
+// composite builds a composite catalog entry manifest from the given components.
+func composite(components ...types.CatalogComponentServer) types.MCPServerCatalogEntryManifest {
+	return types.MCPServerCatalogEntryManifest{
+		Runtime:         types.RuntimeComposite,
+		CompositeConfig: &types.CompositeCatalogConfig{ComponentServers: components},
+	}
+}


### PR DESCRIPTION
- Generate sharable connect URLs for composite servers
- Enable creation/launch of composite servers that don't require configuration
  on connect

Addresses https://github.com/obot-platform/obot/issues/6568

