### PR TITLE
feat: cli: add obot mcp search command

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -100,6 +100,10 @@ func (c *Client) doStream(ctx context.Context, method, path string, body io.Read
 }
 
 func (c *Client) doRequest(ctx context.Context, method, path string, body io.Reader, headerKV ...string) (*http.Request, *http.Response, error) {
+	return c.doRequestWithBaseURL(ctx, method, c.BaseURL, path, body, headerKV...)
+}
+
+func (c *Client) doRequestWithBaseURL(ctx context.Context, method, baseURL, path string, body io.Reader, headerKV ...string) (*http.Request, *http.Response, error) {
 	if log.IsDebug() {
 		var (
 			data    = "[NONE]"
@@ -125,7 +129,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body io.Rea
 		log.Fields("method", method, "path", path, "body", data, "headers", headers).Debugf("HTTP Request")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, body)
+	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(baseURL, "/")+path, body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/apiclient/registry.go
+++ b/apiclient/registry.go
@@ -1,0 +1,49 @@
+package apiclient
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+type ListRegistryServersOptions struct {
+	Search string
+	Cursor string
+	Limit  int
+}
+
+func (c *Client) ListRegistryServers(ctx context.Context, opts ListRegistryServersOptions) (types.RegistryServerList, error) {
+	values := url.Values{}
+	if opts.Search != "" {
+		values.Set("search", opts.Search)
+	}
+	if opts.Cursor != "" {
+		values.Set("cursor", opts.Cursor)
+	}
+	if opts.Limit > 0 {
+		values.Set("limit", strconv.Itoa(opts.Limit))
+	}
+
+	path := "/v0.1/servers"
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	_, resp, err := c.doRequestWithBaseURL(ctx, http.MethodGet, appBaseURLForAPIBaseURL(c.BaseURL), path, nil)
+	if err != nil {
+		return types.RegistryServerList{}, err
+	}
+
+	var result types.RegistryServerList
+	_, err = toObject(resp, &result)
+	return result, err
+}
+
+func appBaseURLForAPIBaseURL(baseURL string) string {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	return strings.TrimSuffix(baseURL, "/api")
+}

--- a/apiclient/registry_test.go
+++ b/apiclient/registry_test.go
@@ -1,0 +1,62 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListRegistryServersUsesAppBaseURLAndAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v0.1/servers", r.URL.Path)
+		require.Equal(t, "github issues", r.URL.Query().Get("search"))
+		require.Equal(t, "next", r.URL.Query().Get("cursor"))
+		require.Equal(t, "100", r.URL.Query().Get("limit"))
+		require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		require.NoError(t, json.NewEncoder(w).Encode(types.RegistryServerList{
+			Servers: []types.RegistryServerResponse{{
+				Server: types.RegistryServerDetail{
+					Name:        "io.example.github",
+					Title:       "GitHub",
+					Description: "GitHub MCP server",
+				},
+			}},
+			Metadata: &types.RegistryServerListMetadata{NextCursor: "done", Count: 1},
+		}))
+	}))
+	defer server.Close()
+
+	result, err := (&Client{
+		BaseURL: server.URL + "/api/",
+		Token:   "test-token",
+	}).ListRegistryServers(context.Background(), ListRegistryServersOptions{
+		Search: "github issues",
+		Cursor: "next",
+		Limit:  100,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Servers, 1)
+	require.Equal(t, "io.example.github", result.Servers[0].Server.Name)
+	require.Equal(t, "done", result.Metadata.NextCursor)
+}
+
+func TestListRegistryServersOmitsEmptyParameters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v0.1/servers", r.URL.Path)
+		require.Equal(t, "", r.URL.RawQuery)
+		require.NoError(t, json.NewEncoder(w).Encode(types.RegistryServerList{}))
+	}))
+	defer server.Close()
+
+	result, err := (&Client{BaseURL: server.URL + "/api"}).ListRegistryServers(context.Background(), ListRegistryServersOptions{})
+	require.NoError(t, err)
+	require.Empty(t, result.Servers)
+}

--- a/pkg/api/handlers/registry/convert.go
+++ b/pkg/api/handlers/registry/convert.go
@@ -183,29 +183,7 @@ func ConvertMCPServerCatalogEntryToRegistry(
 		}
 	}
 
-	// Check if the catalog entry requires configuration.
-	// Composite servers always require configuration in the UI before they can be used.
-	requiresConfiguration := manifest.Runtime == obottypes.RuntimeComposite
-
-	// Check for required environment variables
-	if !requiresConfiguration {
-		for _, env := range manifest.Env {
-			if env.Required {
-				requiresConfiguration = true
-				break
-			}
-		}
-	}
-
-	// Check for required headers (for remote runtime)
-	if !requiresConfiguration && manifest.Runtime == obottypes.RuntimeRemote && manifest.RemoteConfig != nil {
-		for _, header := range manifest.RemoteConfig.Headers {
-			if header.Required {
-				requiresConfiguration = true
-				break
-			}
-		}
-	}
+	requiresConfiguration := catalogEntryRequiresConfiguration(entry)
 
 	// Create metadata
 	meta := obottypes.RegistryMeta{
@@ -242,6 +220,45 @@ func ConvertMCPServerCatalogEntryToRegistry(
 }
 
 // Helper functions
+
+func catalogEntryRequiresConfiguration(entry v1.MCPServerCatalogEntry) bool {
+	manifest := entry.Spec.Manifest
+
+	// Composite servers always require configuration in the UI before they can be used.
+	if manifest.Runtime == obottypes.RuntimeComposite {
+		return true
+	}
+
+	for _, env := range manifest.Env {
+		if env.Required {
+			return true
+		}
+	}
+
+	if manifest.Runtime == obottypes.RuntimeRemote && manifest.RemoteConfig != nil {
+		if manifest.RemoteConfig.StaticOAuthRequired && !entry.Status.OAuthCredentialConfigured {
+			return true
+		}
+
+		// A hostname is not a usable connection URL. It is only a constraint for
+		// the URL the user must supply when configuring the server.
+		if manifest.RemoteConfig.Hostname != "" {
+			return true
+		}
+
+		if manifest.RemoteConfig.URLTemplate != "" {
+			return true
+		}
+
+		for _, header := range manifest.RemoteConfig.Headers {
+			if header.Required {
+				return true
+			}
+		}
+	}
+
+	return false
+}
 
 func guessRepoSource(repoURL string) string {
 	lower := strings.ToLower(repoURL)

--- a/pkg/api/handlers/registry/convert.go
+++ b/pkg/api/handlers/registry/convert.go
@@ -240,13 +240,8 @@ func catalogEntryRequiresConfiguration(entry v1.MCPServerCatalogEntry) bool {
 			return true
 		}
 
-		// A hostname is not a usable connection URL. It is only a constraint for
-		// the URL the user must supply when configuring the server.
-		if manifest.RemoteConfig.Hostname != "" {
-			return true
-		}
-
-		if manifest.RemoteConfig.URLTemplate != "" {
+		// Without a fixed URL, the user must supply a connection URL.
+		if manifest.RemoteConfig.FixedURL == "" {
 			return true
 		}
 

--- a/pkg/api/handlers/registry/convert.go
+++ b/pkg/api/handlers/registry/convert.go
@@ -247,7 +247,7 @@ func catalogEntryRequiresConfiguration(entry v1.MCPServerCatalogEntry) bool {
 		}
 
 		for _, header := range manifest.RemoteConfig.Headers {
-			if header.Required {
+			if header.Required && header.Value == "" && header.SecretBinding == nil {
 				return true
 			}
 		}

--- a/pkg/api/handlers/registry/convert.go
+++ b/pkg/api/handlers/registry/convert.go
@@ -230,7 +230,8 @@ func catalogEntryRequiresConfiguration(entry v1.MCPServerCatalogEntry) bool {
 	}
 
 	for _, env := range manifest.Env {
-		if env.Required {
+		// Required env values without a secret binding must be configured
+		if env.Required && env.SecretBinding == nil {
 			return true
 		}
 	}

--- a/pkg/api/handlers/registry/convert_test.go
+++ b/pkg/api/handlers/registry/convert_test.go
@@ -1,0 +1,152 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConvertMCPServerCatalogEntryToRegistryRemoteFixedURLHasRemote(t *testing.T) {
+	entry := registryTestCatalogEntry(types.RemoteCatalogConfig{
+		FixedURL: "https://api.example.com/mcp",
+	})
+
+	got, err := ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Meta.Obot != nil && got.Meta.Obot.ConfigurationRequired {
+		t.Fatalf("expected fixed URL entry to be directly connectable, got obot meta %#v", got.Meta.Obot)
+	}
+	if len(got.Server.Remotes) != 1 {
+		t.Fatalf("remote count = %d, want 1", len(got.Server.Remotes))
+	}
+	if got.Server.Remotes[0].URL != "https://obot.example.com/mcp-connect/remote-entry" {
+		t.Fatalf("remote URL = %q, want mcp-connect URL", got.Server.Remotes[0].URL)
+	}
+}
+
+func TestConvertMCPServerCatalogEntryToRegistryRemoteHostnameRequiresConfiguration(t *testing.T) {
+	entry := registryTestCatalogEntry(types.RemoteCatalogConfig{
+		Hostname: "api.example.com",
+	})
+
+	got, err := ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Meta.Obot == nil || !got.Meta.Obot.ConfigurationRequired {
+		t.Fatalf("expected hostname entry to require configuration, got obot meta %#v", got.Meta.Obot)
+	}
+	if len(got.Server.Remotes) != 0 {
+		t.Fatalf("expected no remotes for hostname entry, got %#v", got.Server.Remotes)
+	}
+}
+
+func TestConvertMCPServerCatalogEntryToRegistryRemoteURLTemplateRequiresConfiguration(t *testing.T) {
+	entry := registryTestCatalogEntry(types.RemoteCatalogConfig{
+		URLTemplate: "https://${WORKSPACE}.example.com/mcp",
+	})
+
+	got, err := ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Meta.Obot == nil || !got.Meta.Obot.ConfigurationRequired {
+		t.Fatalf("expected URL template entry to require configuration, got obot meta %#v", got.Meta.Obot)
+	}
+	if len(got.Server.Remotes) != 0 {
+		t.Fatalf("expected no remotes for URL template entry, got %#v", got.Server.Remotes)
+	}
+}
+
+func TestConvertMCPServerCatalogEntryToRegistryRemoteStaticOAuthRequiresConfigurationUntilConfigured(t *testing.T) {
+	entry := registryTestCatalogEntry(types.RemoteCatalogConfig{
+		FixedURL:            "https://api.example.com/mcp",
+		StaticOAuthRequired: true,
+	})
+
+	got, err := ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Meta.Obot == nil || !got.Meta.Obot.ConfigurationRequired {
+		t.Fatalf("expected unconfigured static OAuth entry to require configuration, got obot meta %#v", got.Meta.Obot)
+	}
+	if len(got.Server.Remotes) != 0 {
+		t.Fatalf("expected no remotes for unconfigured static OAuth entry, got %#v", got.Server.Remotes)
+	}
+
+	entry.Status.OAuthCredentialConfigured = true
+	got, err = ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Meta.Obot != nil && got.Meta.Obot.ConfigurationRequired {
+		t.Fatalf("expected configured static OAuth entry to be directly connectable, got obot meta %#v", got.Meta.Obot)
+	}
+	if len(got.Server.Remotes) != 1 {
+		t.Fatalf("remote count = %d, want 1", len(got.Server.Remotes))
+	}
+}
+
+func TestConvertMCPServerToRegistryNeedsURLRequiresConfiguration(t *testing.T) {
+	server := v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ms1needsurl",
+		},
+		Spec: v1.MCPServerSpec{
+			UserID:   "user-1",
+			NeedsURL: true,
+			Manifest: types.MCPServerManifest{
+				Name:    "Needs URL",
+				Runtime: types.RuntimeRemote,
+				RemoteConfig: &types.RemoteRuntimeConfig{
+					Hostname: "api.example.com",
+				},
+			},
+		},
+	}
+
+	got, err := ConvertMCPServerToRegistry(context.Background(), server, nil, "https://obot.example.com", server.Name, "com.example.obot", "user-1", newMimeFetcher())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Meta.Obot == nil || !got.Meta.Obot.ConfigurationRequired {
+		t.Fatalf("expected server needing URL to require configuration, got obot meta %#v", got.Meta.Obot)
+	}
+	if len(got.Server.Remotes) != 0 {
+		t.Fatalf("expected no remotes for server needing URL, got %#v", got.Server.Remotes)
+	}
+}
+
+func registryTestCatalogEntry(remoteConfig types.RemoteCatalogConfig) v1.MCPServerCatalogEntry {
+	return v1.MCPServerCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "remote-entry",
+		},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Name:        "Remote Entry",
+				Description: "Remote entry",
+				Runtime:     types.RuntimeRemote,
+				RemoteConfig: &types.RemoteCatalogConfig{
+					FixedURL:            remoteConfig.FixedURL,
+					Hostname:            remoteConfig.Hostname,
+					URLTemplate:         remoteConfig.URLTemplate,
+					Headers:             remoteConfig.Headers,
+					StaticOAuthRequired: remoteConfig.StaticOAuthRequired,
+				},
+			},
+		},
+	}
+}

--- a/pkg/api/handlers/registry/handler.go
+++ b/pkg/api/handlers/registry/handler.go
@@ -10,11 +10,13 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
 	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/api/authz"
 	"github.com/obot-platform/obot/pkg/api/handlers"
 	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apiserver/pkg/authentication/user"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -46,12 +48,12 @@ func (h *Handler) ListServers(req api.Context) error {
 		return fmt.Errorf("failed to generate reverse DNS: %w", err)
 	}
 
-	// Collect servers based on registry mode
+	// Collect servers based on the request user.
 	var servers []types.RegistryServerResponse
-	if h.registryNoAuth {
-		servers, err = h.collectAccessibleServersNoAuth(req, reverseDNS)
-	} else {
+	if registryUserAuthenticated(req.User) {
 		servers, err = h.collectAccessibleServers(req, reverseDNS)
+	} else {
+		servers, err = h.collectAccessibleServersNoAuth(req, reverseDNS)
 	}
 	if err != nil {
 		return err
@@ -66,6 +68,10 @@ func (h *Handler) ListServers(req api.Context) error {
 	response := paginateServers(servers, cursor, limit)
 
 	return req.Write(response)
+}
+
+func registryUserAuthenticated(u user.Info) bool {
+	return u != nil && !slices.Contains(u.GetGroups(), authz.UnauthenticatedGroup)
 }
 
 func (h *Handler) collectAccessibleServers(req api.Context, reverseDNS string) ([]types.RegistryServerResponse, error) {

--- a/pkg/api/handlers/registry/handler_test.go
+++ b/pkg/api/handlers/registry/handler_test.go
@@ -1,0 +1,45 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/api/authz"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestRegistryUserAuthenticated(t *testing.T) {
+	tests := []struct {
+		name string
+		user user.Info
+		want bool
+	}{
+		{
+			name: "authenticated user",
+			user: &user.DefaultInfo{UID: "user-1", Name: "user@example.com"},
+			want: true,
+		},
+		{
+			name: "no auth nobody owner user",
+			user: &user.DefaultInfo{UID: "1", Name: "nobody", Groups: []string{"owner"}},
+			want: true,
+		},
+		{
+			name: "anonymous user",
+			user: &user.DefaultInfo{UID: "anonymous", Name: "anonymous", Groups: []string{authz.UnauthenticatedGroup}},
+			want: false,
+		},
+		{
+			name: "nil user",
+			user: nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := registryUserAuthenticated(tt.user); got != tt.want {
+				t.Fatalf("registryUserAuthenticated() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/internal/token.go
+++ b/pkg/cli/internal/token.go
@@ -101,6 +101,29 @@ func StoredTokenValid(ctx context.Context, appURL string) (bool, error) {
 	return testToken(ctx, localconfig.APIBaseURL(appURL), token), nil
 }
 
+func ExistingToken(ctx context.Context, baseURL string) (string, error) {
+	if testToken(ctx, baseURL, "") {
+		return "", nil
+	}
+
+	appURL, err := AppURLForAPIBaseURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+
+	token, err := credentialStore.Get(appURL)
+	if err != nil {
+		if credentials.IsNotFound(err) {
+			return "", fmt.Errorf("no existing login for %s", appURL)
+		}
+		return "", err
+	}
+	if !testToken(ctx, baseURL, token) {
+		return "", fmt.Errorf("stored login for %s is not valid", appURL)
+	}
+	return token, nil
+}
+
 func enter(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/cli/mcp.go
+++ b/pkg/cli/mcp.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"text/tabwriter"
+
+	gptcmd "github.com/gptscript-ai/cmd"
+	"github.com/obot-platform/obot/apiclient"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/cli/internal"
+	"github.com/spf13/cobra"
+)
+
+const mcpSearchPageLimit = 100
+
+type MCP struct {
+	root *Obot
+}
+
+func (m *MCP) Customize(cmd *cobra.Command) {
+	cmd.Use = "mcp"
+	cmd.Short = "Manage MCP servers"
+	cmd.Args = cobra.NoArgs
+	cmd.AddCommand(gptcmd.Command(&MCPSearch{root: m.root}))
+}
+
+func (m *MCP) Run(cmd *cobra.Command, _ []string) error {
+	return cmd.Help()
+}
+
+type MCPSearch struct {
+	Limit int  `usage:"Maximum number of MCP servers to return; 0 means no limit" default:"50"`
+	JSON  bool `usage:"Print results as JSON"`
+
+	root *Obot
+}
+
+func (m *MCPSearch) Customize(cmd *cobra.Command) {
+	cmd.Use = "search [query...]"
+	cmd.Short = "Search Obot for MCP servers"
+	cmd.Args = cobra.ArbitraryArgs
+}
+
+func (m *MCPSearch) Run(cmd *cobra.Command, args []string) error {
+	if m.root == nil || m.root.Client == nil {
+		return fmt.Errorf("mcp search: no API client configured")
+	}
+
+	client := m.root.Client
+	if m.JSON && client.Token == "" {
+		token, err := internal.ExistingToken(cmd.Context(), client.BaseURL)
+		if err != nil {
+			return fmt.Errorf(`mcp search --json requires an existing login; run "obot login" first`)
+		}
+		client = client.WithTokenFetcher(nil).WithToken(token)
+	}
+
+	result, err := m.listServers(cmd, client, strings.TrimSpace(strings.Join(args, " ")))
+	if err != nil {
+		return registrySearchError(err)
+	}
+
+	output := normalizeRegistryServers(result)
+	if m.JSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(mcpSearchOutput{Servers: output})
+	}
+
+	if len(output) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No MCP servers found")
+		return nil
+	}
+
+	return writeMCPSearchTable(cmd, output)
+}
+
+func (m *MCPSearch) listServers(cmd *cobra.Command, client *apiclient.Client, query string) ([]types.RegistryServerResponse, error) {
+	var (
+		cursor  string
+		results []types.RegistryServerResponse
+	)
+	for {
+		pageLimit := mcpSearchPageLimit
+		if m.Limit > 0 && m.Limit-len(results) < pageLimit {
+			pageLimit = m.Limit - len(results)
+		}
+		if pageLimit <= 0 {
+			break
+		}
+
+		page, err := client.ListRegistryServers(cmd.Context(), apiclient.ListRegistryServersOptions{
+			Search: query,
+			Cursor: cursor,
+			Limit:  pageLimit,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, page.Servers...)
+		if m.Limit > 0 && len(results) >= m.Limit {
+			results = results[:m.Limit]
+			break
+		}
+		if page.Metadata == nil || page.Metadata.NextCursor == "" {
+			break
+		}
+		cursor = page.Metadata.NextCursor
+	}
+	return results, nil
+}
+
+type mcpSearchOutput struct {
+	Servers []mcpSearchServer `json:"servers"`
+}
+
+type mcpSearchServer struct {
+	Name                  string `json:"name"`
+	Title                 string `json:"title"`
+	Description           string `json:"description"`
+	Status                string `json:"status"`
+	ConfigurationRequired bool   `json:"configurationRequired"`
+	URL                   string `json:"url"`
+}
+
+func normalizeRegistryServers(servers []types.RegistryServerResponse) []mcpSearchServer {
+	result := make([]mcpSearchServer, 0, len(servers))
+	for _, registryServer := range servers {
+		url := firstRegistryRemoteURL(registryServer.Server)
+		configurationRequired := registryServer.Meta.Obot != nil && registryServer.Meta.Obot.ConfigurationRequired
+		result = append(result, mcpSearchServer{
+			Name:                  registryServer.Server.Name,
+			Title:                 registryServer.Server.Title,
+			Description:           registryServer.Server.Description,
+			Status:                registryServerStatus(configurationRequired, url),
+			ConfigurationRequired: configurationRequired,
+			URL:                   url,
+		})
+	}
+	return result
+}
+
+func firstRegistryRemoteURL(server types.RegistryServerDetail) string {
+	if len(server.Remotes) == 0 {
+		return ""
+	}
+	return server.Remotes[0].URL
+}
+
+func registryServerStatus(configurationRequired bool, url string) string {
+	if configurationRequired {
+		return "configuration required"
+	}
+	if url != "" {
+		return "ready"
+	}
+	return "unknown"
+}
+
+func writeMCPSearchTable(cmd *cobra.Command, servers []mcpSearchServer) error {
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "TITLE\tDESCRIPTION\tSTATUS\tURL")
+	for _, server := range servers {
+		url := server.URL
+		if url == "" {
+			url = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			tableCell(server.Title),
+			tableCell(server.Description),
+			tableCell(server.Status),
+			tableCell(url),
+		)
+	}
+	return w.Flush()
+}
+
+func registrySearchError(err error) error {
+	var httpErr *types.ErrHTTP
+	if !errors.As(err, &httpErr) {
+		return err
+	}
+	switch httpErr.Code {
+	case http.StatusUnauthorized:
+		return fmt.Errorf(`registry search requires login; run "obot login" first`)
+	case http.StatusForbidden:
+		return fmt.Errorf("authenticated user is not authorized to access the registry endpoint")
+	default:
+		return err
+	}
+}

--- a/pkg/cli/mcp.go
+++ b/pkg/cli/mcp.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"text/tabwriter"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/obot-platform/obot/apiclient"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/cli/internal"
+	"github.com/obot-platform/obot/pkg/system"
 	"github.com/spf13/cobra"
 )
 
@@ -64,7 +66,8 @@ func (m *MCPSearch) Run(cmd *cobra.Command, args []string) error {
 		return registrySearchError(err)
 	}
 
-	output := normalizeRegistryServers(result)
+	appURL, _ := internal.AppURLForAPIBaseURL(client.BaseURL)
+	output := normalizeRegistryServers(result, appURL)
 	if m.JSON {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
@@ -128,11 +131,14 @@ type mcpSearchServer struct {
 	URL                   string `json:"url"`
 }
 
-func normalizeRegistryServers(servers []types.RegistryServerResponse) []mcpSearchServer {
+func normalizeRegistryServers(servers []types.RegistryServerResponse, appURL string) []mcpSearchServer {
 	result := make([]mcpSearchServer, 0, len(servers))
 	for _, registryServer := range servers {
 		url := firstRegistryRemoteURL(registryServer.Server)
 		configurationRequired := registryServer.Meta.Obot != nil && registryServer.Meta.Obot.ConfigurationRequired
+		if configurationRequired && url == "" {
+			url = registryServerConfigurationURL(appURL, registryServer.Server.Name)
+		}
 		result = append(result, mcpSearchServer{
 			Name:                  registryServer.Server.Name,
 			Title:                 registryServer.Server.Title,
@@ -143,6 +149,27 @@ func normalizeRegistryServers(servers []types.RegistryServerResponse) []mcpSearc
 		})
 	}
 	return result
+}
+
+func registryServerConfigurationURL(appURL, registryName string) string {
+	if appURL == "" {
+		return ""
+	}
+
+	id := registryName
+	if _, resourceName, ok := strings.Cut(registryName, "/"); ok {
+		id = resourceName
+	}
+	if id == "" {
+		return ""
+	}
+
+	route := "c"
+	if system.IsMCPServerID(id) {
+		route = "s"
+	}
+
+	return strings.TrimRight(appURL, "/") + "/mcp-servers/" + route + "/" + url.PathEscape(id)
 }
 
 func firstRegistryRemoteURL(server types.RegistryServerDetail) string {

--- a/pkg/cli/mcp.go
+++ b/pkg/cli/mcp.go
@@ -51,6 +51,9 @@ func (m *MCPSearch) Run(cmd *cobra.Command, args []string) error {
 	if m.root == nil || m.root.Client == nil {
 		return fmt.Errorf("mcp search: no API client configured")
 	}
+	if m.Limit < 0 {
+		return fmt.Errorf("--limit must be >= 0")
+	}
 
 	client := m.root.Client
 	if m.JSON && client.Token == "" {

--- a/pkg/cli/mcp_test.go
+++ b/pkg/cli/mcp_test.go
@@ -37,7 +37,7 @@ func TestMCPSearchPaginatesAndWritesTable(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(types.RegistryServerList{
 				Servers: []types.RegistryServerResponse{
 					registryTestServer("io.example.one", "One", "first", "https://obot.example.com/mcp-connect/one", false),
-					registryTestServer("io.example.two", "Two", "second", "", true),
+					registryTestServer("io.example/two", "Two", "second", "", true),
 				},
 				Metadata: &types.RegistryServerListMetadata{NextCursor: "two", Count: 2},
 			})
@@ -65,7 +65,7 @@ func TestMCPSearchPaginatesAndWritesTable(t *testing.T) {
 	for _, want := range []string{
 		"TITLE", "DESCRIPTION", "STATUS", "URL",
 		"One", "first", "ready", "https://obot.example.com/mcp-connect/one",
-		"Two", "second", "configuration required", "-",
+		"Two", "second", "configuration required", server.URL + "/mcp-servers/c/two",
 		"Three", "third", "unknown",
 	} {
 		if !strings.Contains(stdout, want) {
@@ -106,6 +106,39 @@ func TestMCPSearchJSONMode(t *testing.T) {
 	got := result.Servers[0]
 	if got.Name != "io.example.github" || got.Status != "ready" || got.URL == "" || got.ConfigurationRequired {
 		t.Fatalf("unexpected JSON result: %#v", got)
+	}
+}
+
+func TestMCPSearchJSONModeIncludesConfigurationURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.1/servers" {
+			t.Fatalf("path = %s, want /v0.1/servers", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(types.RegistryServerList{
+			Servers: []types.RegistryServerResponse{
+				registryTestServer("io.example/ms1server", "Personal", "needs setup", "", true),
+			},
+			Metadata: &types.RegistryServerListMetadata{Count: 1},
+		})
+	}))
+	defer server.Close()
+
+	stdout, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result mcpSearchOutput
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, stdout)
+	}
+	if len(result.Servers) != 1 {
+		t.Fatalf("server count = %d, want 1", len(result.Servers))
+	}
+	got := result.Servers[0]
+	wantURL := server.URL + "/mcp-servers/s/ms1server"
+	if !got.ConfigurationRequired || got.Status != "configuration required" || got.URL != wantURL {
+		t.Fatalf("unexpected JSON result: %#v, want URL %q", got, wantURL)
 	}
 }
 

--- a/pkg/cli/mcp_test.go
+++ b/pkg/cli/mcp_test.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gptcmd "github.com/gptscript-ai/cmd"
+	"github.com/obot-platform/obot/apiclient"
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+func TestMCPSearchPaginatesAndWritesTable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v0.1/servers" {
+			t.Fatalf("path = %s, want /v0.1/servers", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("search"); got != "github issues" {
+			t.Fatalf("search = %q, want github issues", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("authorization = %q, want bearer token", got)
+		}
+
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			if got := r.URL.Query().Get("limit"); got != "3" {
+				t.Fatalf("first page limit = %q, want 3", got)
+			}
+			_ = json.NewEncoder(w).Encode(types.RegistryServerList{
+				Servers: []types.RegistryServerResponse{
+					registryTestServer("io.example.one", "One", "first", "https://obot.example.com/mcp-connect/one", false),
+					registryTestServer("io.example.two", "Two", "second", "", true),
+				},
+				Metadata: &types.RegistryServerListMetadata{NextCursor: "two", Count: 2},
+			})
+		case "two":
+			if got := r.URL.Query().Get("limit"); got != "1" {
+				t.Fatalf("second page limit = %q, want 1", got)
+			}
+			_ = json.NewEncoder(w).Encode(types.RegistryServerList{
+				Servers: []types.RegistryServerResponse{
+					registryTestServer("io.example.three", "Three", "third", "", false),
+				},
+				Metadata: &types.RegistryServerListMetadata{Count: 1},
+			})
+		default:
+			t.Fatalf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+		}
+	}))
+	defer server.Close()
+
+	stdout, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search", "github", "issues", "--limit", "3")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{
+		"TITLE", "DESCRIPTION", "STATUS", "URL",
+		"One", "first", "ready", "https://obot.example.com/mcp-connect/one",
+		"Two", "second", "configuration required", "-",
+		"Three", "third", "unknown",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "io.example.one") {
+		t.Fatalf("human table should not include registry name:\n%s", stdout)
+	}
+}
+
+func TestMCPSearchJSONMode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0.1/servers" {
+			t.Fatalf("path = %s, want /v0.1/servers", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(types.RegistryServerList{
+			Servers: []types.RegistryServerResponse{
+				registryTestServer("io.example.github", "GitHub", "GitHub MCP server", "https://obot.example.com/mcp-connect/github", false),
+			},
+			Metadata: &types.RegistryServerListMetadata{Count: 1},
+		})
+	}))
+	defer server.Close()
+
+	stdout, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result mcpSearchOutput
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, stdout)
+	}
+	if len(result.Servers) != 1 {
+		t.Fatalf("server count = %d, want 1", len(result.Servers))
+	}
+	got := result.Servers[0]
+	if got.Name != "io.example.github" || got.Status != "ready" || got.URL == "" || got.ConfigurationRequired {
+		t.Fatalf("unexpected JSON result: %#v", got)
+	}
+}
+
+func TestMCPSearchEmptyResult(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(types.RegistryServerList{Servers: []types.RegistryServerResponse{}})
+	}))
+	defer server.Close()
+
+	stdout, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "No MCP servers found") {
+		t.Fatalf("expected empty message, got:\n%s", stdout)
+	}
+}
+
+func TestMCPSearchRegistryAuthErrors(t *testing.T) {
+	tests := []struct {
+		status int
+		want   string
+	}{
+		{status: http.StatusUnauthorized, want: `registry search requires login; run "obot login" first`},
+		{status: http.StatusForbidden, want: "authenticated user is not authorized to access the registry endpoint"},
+	}
+
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "nope", tt.status)
+			}))
+			defer server.Close()
+
+			_, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func mcpTestRoot(baseURL string) *Obot {
+	return &Obot{Client: &apiclient.Client{
+		BaseURL: baseURL + "/api",
+		Token:   "test-token",
+	}}
+}
+
+func executeMCPTestCommand(root *Obot, args ...string) (string, error) {
+	var stdout bytes.Buffer
+	cmd := gptcmd.Command(&MCP{root: root})
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&stdout)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return stdout.String(), err
+}
+
+func registryTestServer(name, title, description, remoteURL string, configurationRequired bool) types.RegistryServerResponse {
+	server := types.RegistryServerResponse{
+		Server: types.RegistryServerDetail{
+			Name:        name,
+			Title:       title,
+			Description: description,
+		},
+	}
+	if remoteURL != "" {
+		server.Server.Remotes = []types.RegistryServerRemote{{Type: "streamable-http", URL: remoteURL}}
+	}
+	if configurationRequired {
+		server.Meta.Obot = &types.RegistryObotMeta{ConfigurationRequired: true}
+	}
+	return server
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -43,6 +43,7 @@ func New() *cobra.Command {
 		&Server{},
 		&Login{root: root},
 		&Logout{root: root},
+		&MCP{root: root},
 		&Scan{root: root},
 		&Setup{root: root},
 		&Skills{root: root},


### PR DESCRIPTION
This adds an `obot mcp search` command to list and search for available MCP servers and catalog entries in Obot. This will (in the future) be available to local agents to use to discover MCP servers for the user.

demo video: https://acorn-io.slack.com/archives/C03FU91U4SX/p1780063441124139

part of https://github.com/obot-platform/obot/issues/6666