### PR TITLE
fix: aggregate multi-user catalog entry user counts

### DIFF
--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -457,45 +457,6 @@ func compositeConfigHasDrifted(serverConfig *types.CompositeRuntimeConfig, entry
 	return false, nil
 }
 
-// EnsureMCPServerInstanceUserCount ensures that mcp server instance user count for multi-user MCP servers is up to date.
-func (*Handler) EnsureMCPServerInstanceUserCount(req router.Request, _ router.Response) error {
-	server := req.Object.(*v1.MCPServer)
-	if server.Spec.IsSingleUser() {
-		// Server is not multi-user, ensure we're not tracking the instance user count
-		if server.Status.MCPServerInstanceUserCount == nil {
-			return nil
-		}
-
-		// Corrupt state, drop the field to fix it
-		server.Status.MCPServerInstanceUserCount = nil
-		return req.Client.Status().Update(req.Ctx, server)
-	}
-
-	// Get the set of unique users with server instances pointing to this MCP server
-	var mcpServerInstances v1.MCPServerInstanceList
-	if err := req.List(&mcpServerInstances, &kclient.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("spec.mcpServerName", server.Name),
-		Namespace:     system.DefaultNamespace,
-	}); err != nil {
-		return fmt.Errorf("failed to list MCP server instances: %w", err)
-	}
-
-	uniqueUsers := make(map[string]struct{}, len(mcpServerInstances.Items))
-	for _, instance := range mcpServerInstances.Items {
-		if userID := instance.Spec.UserID; userID != "" && instance.DeletionTimestamp.IsZero() {
-			uniqueUsers[userID] = struct{}{}
-		}
-	}
-
-	if oldUserCount, newUserCount := server.Status.MCPServerInstanceUserCount, len(uniqueUsers); oldUserCount == nil || *oldUserCount != newUserCount {
-		log.Infof("Updated MCP server instance user count: server=%s newCount=%d", server.Name, newUserCount)
-		server.Status.MCPServerInstanceUserCount = &newUserCount
-		return req.Client.Status().Update(req.Ctx, server)
-	}
-
-	return nil
-}
-
 func (h *Handler) DeleteServersWithoutRuntime(req router.Request, _ router.Response) error {
 	server := req.Object.(*v1.MCPServer)
 	if string(server.Spec.Manifest.Runtime) == "" {

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -38,47 +38,18 @@ func NewHandler(gatewayClient *gclient.Client) *Handler {
 // For multi-user entries, this sums the unique users connected to each MCPServer created from the entry.
 func (*Handler) EnsureUserCount(req router.Request, _ router.Response) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
-	userCount, err := userCountForEntry(req, *entry)
+	userCount, err := UserCountForEntry(req, *entry)
 	if err != nil {
 		return err
 	}
 
-	return updateEntryUserCount(req, entry, userCount)
+	return UpdateUserCount(req, entry, userCount)
 }
 
-// EnsureUserCountForMCPServerInstance refreshes the parent catalog entry count when a multi-user connection changes.
-func (*Handler) EnsureUserCountForMCPServerInstance(req router.Request, _ router.Response) error {
-	instance := req.Object.(*v1.MCPServerInstance)
-	if instance.Spec.MCPServerName == "" {
-		return nil
-	}
-
-	var server v1.MCPServer
-	if err := req.Get(&server, req.Namespace, instance.Spec.MCPServerName); apierrors.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		return err
-	}
-	if server.Spec.MCPServerCatalogEntryName == "" || server.Spec.CompositeName != "" {
-		return nil
-	}
-
-	var entry v1.MCPServerCatalogEntry
-	if err := req.Get(&entry, req.Namespace, server.Spec.MCPServerCatalogEntryName); apierrors.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	userCount, err := userCountForEntry(req, entry)
-	if err != nil {
-		return err
-	}
-
-	return updateEntryUserCount(req, &entry, userCount)
-}
-
-func userCountForEntry(req router.Request, entry v1.MCPServerCatalogEntry) (int, error) {
+// UserCountForEntry calculates the current user count for an MCP server catalog entry.
+// For single-user entries, this counts unique users who have an MCPServer created from the entry.
+// For multi-user entries, this sums the unique non-composite users connected to each MCPServer created from the entry.
+func UserCountForEntry(req router.Request, entry v1.MCPServerCatalogEntry) (int, error) {
 	var mcpServers v1.MCPServerList
 	if err := req.List(&mcpServers, &kclient.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector("spec.mcpServerCatalogEntryName", entry.Name),
@@ -111,14 +82,14 @@ func userCountForEntry(req router.Request, entry v1.MCPServerCatalogEntry) (int,
 	return userCount, nil
 }
 
-func updateEntryUserCount(req router.Request, entry *v1.MCPServerCatalogEntry, newUserCount int) error {
-	if entry.Status.UserCount != newUserCount {
-		log.Infof("Updated MCP catalog entry user count: entry=%s oldCount=%d newCount=%d", entry.Name, entry.Status.UserCount, newUserCount)
-		entry.Status.UserCount = newUserCount
-		return req.Client.Status().Update(req.Ctx, entry)
+// UpdateUserCount updates the catalog entry status when the calculated count changed.
+func UpdateUserCount(req router.Request, entry *v1.MCPServerCatalogEntry, newUserCount int) error {
+	if entry.Status.UserCount == newUserCount {
+		return nil
 	}
 
-	return nil
+	entry.Status.UserCount = newUserCount
+	return req.Client.Status().Update(req.Ctx, entry)
 }
 
 func mcpServerInstanceUserCount(req router.Request, serverName string) (int, error) {

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -35,21 +35,61 @@ func NewHandler(gatewayClient *gclient.Client) *Handler {
 
 // EnsureUserCount ensures that the user count for an MCP server catalog entry is up to date.
 // For single-user entries, this counts unique users who have an MCPServer created from the entry.
-// For multi-user entries, this counts the number of deployed MCPServers from the catalog entry.
+// For multi-user entries, this sums the unique users connected to each MCPServer created from the entry.
 func (*Handler) EnsureUserCount(req router.Request, _ router.Response) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
+	userCount, err := userCountForEntry(req, *entry)
+	if err != nil {
+		return err
+	}
 
+	return updateEntryUserCount(req, entry, userCount)
+}
+
+// EnsureUserCountForMCPServerInstance refreshes the parent catalog entry count when a multi-user connection changes.
+func (*Handler) EnsureUserCountForMCPServerInstance(req router.Request, _ router.Response) error {
+	instance := req.Object.(*v1.MCPServerInstance)
+	if instance.Spec.MCPServerName == "" {
+		return nil
+	}
+
+	var server v1.MCPServer
+	if err := req.Get(&server, req.Namespace, instance.Spec.MCPServerName); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	if server.Spec.MCPServerCatalogEntryName == "" || server.Spec.CompositeName != "" {
+		return nil
+	}
+
+	var entry v1.MCPServerCatalogEntry
+	if err := req.Get(&entry, req.Namespace, server.Spec.MCPServerCatalogEntryName); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	userCount, err := userCountForEntry(req, entry)
+	if err != nil {
+		return err
+	}
+
+	return updateEntryUserCount(req, &entry, userCount)
+}
+
+func userCountForEntry(req router.Request, entry v1.MCPServerCatalogEntry) (int, error) {
 	var mcpServers v1.MCPServerList
 	if err := req.List(&mcpServers, &kclient.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector("spec.mcpServerCatalogEntryName", entry.Name),
 		Namespace:     system.DefaultNamespace,
 	}); err != nil {
-		return fmt.Errorf("failed to list MCP servers: %w", err)
+		return 0, fmt.Errorf("failed to list MCP servers: %w", err)
 	}
 
-	// For single-user entries, count unique users. For multi-user entries, count deployed servers.
 	isSingleUser := entry.Spec.Manifest.ServerUserType.IsSingleUser()
 	uniqueUsers := make(map[string]struct{}, len(mcpServers.Items))
+	userCount := 0
 	for _, server := range mcpServers.Items {
 		if !server.DeletionTimestamp.IsZero() || server.Spec.CompositeName != "" {
 			continue
@@ -57,17 +97,47 @@ func (*Handler) EnsureUserCount(req router.Request, _ router.Response) error {
 		if isSingleUser && server.Spec.UserID != "" {
 			uniqueUsers[server.Spec.UserID] = struct{}{}
 		} else if !isSingleUser {
-			uniqueUsers[server.Name] = struct{}{}
+			serverUserCount, err := mcpServerInstanceUserCount(req, server.Name)
+			if err != nil {
+				return 0, err
+			}
+			userCount += serverUserCount
 		}
 	}
+	if isSingleUser {
+		userCount = len(uniqueUsers)
+	}
 
-	if newUserCount := len(uniqueUsers); entry.Status.UserCount != newUserCount {
+	return userCount, nil
+}
+
+func updateEntryUserCount(req router.Request, entry *v1.MCPServerCatalogEntry, newUserCount int) error {
+	if entry.Status.UserCount != newUserCount {
 		log.Infof("Updated MCP catalog entry user count: entry=%s oldCount=%d newCount=%d", entry.Name, entry.Status.UserCount, newUserCount)
 		entry.Status.UserCount = newUserCount
 		return req.Client.Status().Update(req.Ctx, entry)
 	}
 
 	return nil
+}
+
+func mcpServerInstanceUserCount(req router.Request, serverName string) (int, error) {
+	var mcpServerInstances v1.MCPServerInstanceList
+	if err := req.List(&mcpServerInstances, &kclient.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("spec.mcpServerName", serverName),
+		Namespace:     system.DefaultNamespace,
+	}); err != nil {
+		return 0, fmt.Errorf("failed to list MCP server instances: %w", err)
+	}
+
+	uniqueUsers := make(map[string]struct{}, len(mcpServerInstances.Items))
+	for _, instance := range mcpServerInstances.Items {
+		if instance.DeletionTimestamp.IsZero() && instance.Spec.CompositeName == "" && instance.Spec.UserID != "" {
+			uniqueUsers[instance.Spec.UserID] = struct{}{}
+		}
+	}
+
+	return len(uniqueUsers), nil
 }
 
 // EnsureServerUserType backfills the serverUserType field to "singleUser" for

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
@@ -290,43 +290,6 @@ func TestEnsureUserCountSingleUserEntryCountsUniqueServerUsers(t *testing.T) {
 	assert.Equal(t, 2, updated.Status.UserCount)
 }
 
-func TestEnsureUserCountForMCPServerInstanceUpdatesParentEntry(t *testing.T) {
-	entry := newMCPServerCatalogEntry("multi-entry", types.MCPServerCatalogEntryManifest{
-		Name:           "Multi User Template",
-		Runtime:        types.RuntimeContainerized,
-		ServerUserType: types.ServerUserTypeMultiUser,
-		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
-			Image: "example/mcp:1.0.0",
-			Port:  8080,
-			Path:  "/mcp",
-		},
-	})
-
-	server := newMCPServer("server-1", types.MCPServerManifest{
-		Runtime: types.RuntimeContainerized,
-		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
-			Image: "example/mcp:1.0.0",
-		},
-	})
-	server.Spec.MCPServerCatalogEntryName = entry.Name
-
-	instance := newMCPServerInstance("server-1-user-1", server.Name, "user1")
-
-	client := newFakeClient(entry, server, instance)
-	err := (&Handler{}).EnsureUserCountForMCPServerInstance(router.Request{
-		Client:    client,
-		Ctx:       context.Background(),
-		Object:    instance,
-		Namespace: instance.Namespace,
-		Name:      instance.Name,
-	}, &router.ResponseWrapper{})
-	require.NoError(t, err)
-
-	var updated v1.MCPServerCatalogEntry
-	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updated))
-	assert.Equal(t, 1, updated.Status.UserCount)
-}
-
 func newMCPServer(name string, manifest types.MCPServerManifest) *v1.MCPServer {
 	return &v1.MCPServer{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
@@ -123,6 +123,13 @@ func newFakeClient(objects ...kclient.Object) kclient.WithWatch {
 			}
 			return []string{server.Spec.MCPServerCatalogEntryName}
 		}).
+		WithIndex(&v1.MCPServerInstance{}, "spec.mcpServerName", func(obj kclient.Object) []string {
+			instance := obj.(*v1.MCPServerInstance)
+			if instance.Spec.MCPServerName == "" {
+				return nil
+			}
+			return []string{instance.Spec.MCPServerName}
+		}).
 		WithObjects(objects...).
 		Build()
 }
@@ -173,7 +180,12 @@ func TestEnsureUserCountMultiUserEntry(t *testing.T) {
 	server2.Spec.MCPServerCatalogEntryName = entry.Name
 	server2.Spec.UserID = "admin2"
 
-	client := newFakeClient(entry, server1, server2)
+	server1User1 := newMCPServerInstance("server-1-user-1", server1.Name, "user1")
+	server1User1Duplicate := newMCPServerInstance("server-1-user-1-duplicate", server1.Name, "user1")
+	server1User2 := newMCPServerInstance("server-1-user-2", server1.Name, "user2")
+	server2User1 := newMCPServerInstance("server-2-user-1", server2.Name, "user1")
+
+	client := newFakeClient(entry, server1, server2, server1User1, server1User1Duplicate, server1User2, server2User1)
 	err := (&Handler{}).EnsureUserCount(router.Request{
 		Client:    client,
 		Ctx:       context.Background(),
@@ -185,7 +197,7 @@ func TestEnsureUserCountMultiUserEntry(t *testing.T) {
 
 	var updated v1.MCPServerCatalogEntry
 	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updated))
-	assert.Equal(t, 2, updated.Status.UserCount)
+	assert.Equal(t, 3, updated.Status.UserCount, "should count unique users per server and sum across servers")
 }
 
 func TestEnsureUserCountMultiUserEntryExcludesComposite(t *testing.T) {
@@ -219,7 +231,12 @@ func TestEnsureUserCountMultiUserEntryExcludesComposite(t *testing.T) {
 	compositeChild.Spec.UserID = "admin2"
 	compositeChild.Spec.CompositeName = "parent-composite"
 
-	client := newFakeClient(entry, activeServer, compositeChild)
+	activeInstance := newMCPServerInstance("active-instance", activeServer.Name, "user1")
+	compositeServerInstance := newMCPServerInstance("composite-server-instance", compositeChild.Name, "user2")
+	compositeInstance := newMCPServerInstance("composite-instance", activeServer.Name, "user3")
+	compositeInstance.Spec.CompositeName = "parent-composite"
+
+	client := newFakeClient(entry, activeServer, compositeChild, activeInstance, compositeServerInstance, compositeInstance)
 	err := (&Handler{}).EnsureUserCount(router.Request{
 		Client:    client,
 		Ctx:       context.Background(),
@@ -231,7 +248,83 @@ func TestEnsureUserCountMultiUserEntryExcludesComposite(t *testing.T) {
 
 	var updated v1.MCPServerCatalogEntry
 	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updated))
-	assert.Equal(t, 1, updated.Status.UserCount, "should only count active non-composite server")
+	assert.Equal(t, 1, updated.Status.UserCount, "should only count active non-composite server instances")
+}
+
+func TestEnsureUserCountSingleUserEntryCountsUniqueServerUsers(t *testing.T) {
+	entry := newMCPServerCatalogEntry("single-entry", types.MCPServerCatalogEntryManifest{
+		Name:           "Single User Template",
+		Runtime:        types.RuntimeContainerized,
+		ServerUserType: types.ServerUserTypeSingleUser,
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/mcp:1.0.0",
+			Port:  8080,
+			Path:  "/mcp",
+		},
+	})
+
+	server1 := newMCPServer("server-1", types.MCPServerManifest{Runtime: types.RuntimeContainerized})
+	server1.Spec.MCPServerCatalogEntryName = entry.Name
+	server1.Spec.UserID = "user1"
+
+	server2 := newMCPServer("server-2", types.MCPServerManifest{Runtime: types.RuntimeContainerized})
+	server2.Spec.MCPServerCatalogEntryName = entry.Name
+	server2.Spec.UserID = "user1"
+
+	server3 := newMCPServer("server-3", types.MCPServerManifest{Runtime: types.RuntimeContainerized})
+	server3.Spec.MCPServerCatalogEntryName = entry.Name
+	server3.Spec.UserID = "user2"
+
+	client := newFakeClient(entry, server1, server2, server3)
+	err := (&Handler{}).EnsureUserCount(router.Request{
+		Client:    client,
+		Ctx:       context.Background(),
+		Object:    entry,
+		Namespace: entry.Namespace,
+		Name:      entry.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	var updated v1.MCPServerCatalogEntry
+	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updated))
+	assert.Equal(t, 2, updated.Status.UserCount)
+}
+
+func TestEnsureUserCountForMCPServerInstanceUpdatesParentEntry(t *testing.T) {
+	entry := newMCPServerCatalogEntry("multi-entry", types.MCPServerCatalogEntryManifest{
+		Name:           "Multi User Template",
+		Runtime:        types.RuntimeContainerized,
+		ServerUserType: types.ServerUserTypeMultiUser,
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/mcp:1.0.0",
+			Port:  8080,
+			Path:  "/mcp",
+		},
+	})
+
+	server := newMCPServer("server-1", types.MCPServerManifest{
+		Runtime: types.RuntimeContainerized,
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/mcp:1.0.0",
+		},
+	})
+	server.Spec.MCPServerCatalogEntryName = entry.Name
+
+	instance := newMCPServerInstance("server-1-user-1", server.Name, "user1")
+
+	client := newFakeClient(entry, server, instance)
+	err := (&Handler{}).EnsureUserCountForMCPServerInstance(router.Request{
+		Client:    client,
+		Ctx:       context.Background(),
+		Object:    instance,
+		Namespace: instance.Namespace,
+		Name:      instance.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	var updated v1.MCPServerCatalogEntry
+	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updated))
+	assert.Equal(t, 1, updated.Status.UserCount)
 }
 
 func newMCPServer(name string, manifest types.MCPServerManifest) *v1.MCPServer {
@@ -246,6 +339,23 @@ func newMCPServer(name string, manifest types.MCPServerManifest) *v1.MCPServer {
 		},
 		Spec: v1.MCPServerSpec{
 			Manifest: manifest,
+		},
+	}
+}
+
+func newMCPServerInstance(name, serverName, userID string) *v1.MCPServerInstance {
+	return &v1.MCPServerInstance{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "MCPServerInstance",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: v1.MCPServerInstanceSpec{
+			MCPServerName: serverName,
+			UserID:        userID,
 		},
 	}
 }

--- a/pkg/controller/handlers/mcpserverinstance/mcpserverinstance.go
+++ b/pkg/controller/handlers/mcpserverinstance/mcpserverinstance.go
@@ -1,12 +1,18 @@
 package mcpserverinstance
 
 import (
+	"fmt"
+
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/logger"
+	"github.com/obot-platform/obot/pkg/controller/handlers/mcpservercatalogentry"
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var log = logger.Package()
@@ -58,4 +64,84 @@ func (h *Handler) UpdateMultiUserConfig(req router.Request, _ router.Response) e
 	}
 
 	return nil
+}
+
+// EnsureUserCounts refreshes denormalized user counts affected by an MCPServerInstance change.
+func (h *Handler) EnsureUserCounts(req router.Request, _ router.Response) error {
+	instance := req.Object.(*v1.MCPServerInstance)
+	if instance.Spec.MCPServerName == "" {
+		return nil
+	}
+
+	var server v1.MCPServer
+	if err := req.Get(&server, req.Namespace, instance.Spec.MCPServerName); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	if err := updateMCPServerInstanceUserCount(req, &server); err != nil {
+		return err
+	}
+
+	if server.Spec.MCPServerCatalogEntryName == "" || server.Spec.CompositeName != "" {
+		return nil
+	}
+
+	var entry v1.MCPServerCatalogEntry
+	if err := req.Get(&entry, req.Namespace, server.Spec.MCPServerCatalogEntryName); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	userCount, err := mcpservercatalogentry.UserCountForEntry(req, entry)
+	if err != nil {
+		return err
+	}
+
+	return mcpservercatalogentry.UpdateUserCount(req, &entry, userCount)
+}
+
+func updateMCPServerInstanceUserCount(req router.Request, server *v1.MCPServer) error {
+	if server.Spec.IsSingleUser() {
+		if server.Status.MCPServerInstanceUserCount == nil {
+			return nil
+		}
+
+		server.Status.MCPServerInstanceUserCount = nil
+		return req.Client.Status().Update(req.Ctx, server)
+	}
+
+	userCount, err := mcpServerInstanceUserCount(req, server.Name)
+	if err != nil {
+		return err
+	}
+
+	if oldUserCount := server.Status.MCPServerInstanceUserCount; oldUserCount == nil || *oldUserCount != userCount {
+		log.Infof("Updated MCP server instance user count: server=%s newCount=%d", server.Name, userCount)
+		server.Status.MCPServerInstanceUserCount = &userCount
+		return req.Client.Status().Update(req.Ctx, server)
+	}
+
+	return nil
+}
+
+func mcpServerInstanceUserCount(req router.Request, serverName string) (int, error) {
+	var mcpServerInstances v1.MCPServerInstanceList
+	if err := req.List(&mcpServerInstances, &kclient.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("spec.mcpServerName", serverName),
+		Namespace:     system.DefaultNamespace,
+	}); err != nil {
+		return 0, fmt.Errorf("failed to list MCP server instances: %w", err)
+	}
+
+	uniqueUsers := make(map[string]struct{}, len(mcpServerInstances.Items))
+	for _, instance := range mcpServerInstances.Items {
+		if instance.DeletionTimestamp.IsZero() && instance.Spec.UserID != "" {
+			uniqueUsers[instance.Spec.UserID] = struct{}{}
+		}
+	}
+
+	return len(uniqueUsers), nil
 }

--- a/pkg/controller/handlers/mcpserverinstance/mcpserverinstance_test.go
+++ b/pkg/controller/handlers/mcpserverinstance/mcpserverinstance_test.go
@@ -1,0 +1,175 @@
+package mcpserverinstance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEnsureUserCountsUpdatesParentServerAndCatalogEntry(t *testing.T) {
+	entry := newMCPServerCatalogEntry("multi-entry", types.MCPServerCatalogEntryManifest{
+		Name:           "Multi User Template",
+		Runtime:        types.RuntimeContainerized,
+		ServerUserType: types.ServerUserTypeMultiUser,
+	})
+
+	server1 := newMCPServer("server-1")
+	server1.Spec.MCPCatalogID = "default"
+	server1.Spec.MCPServerCatalogEntryName = entry.Name
+	server2 := newMCPServer("server-2")
+	server2.Spec.MCPCatalogID = "default"
+	server2.Spec.MCPServerCatalogEntryName = entry.Name
+
+	server1User1 := newMCPServerInstance("server-1-user-1", server1.Name, "user1")
+	server1User1Duplicate := newMCPServerInstance("server-1-user-1-duplicate", server1.Name, "user1")
+	server1User2 := newMCPServerInstance("server-1-user-2", server1.Name, "user2")
+	server2User1 := newMCPServerInstance("server-2-user-1", server2.Name, "user1")
+
+	client := newFakeClient(t, entry, server1, server2, server1User1, server1User1Duplicate, server1User2, server2User1)
+	err := (&Handler{}).EnsureUserCounts(router.Request{
+		Client:    client,
+		Ctx:       context.Background(),
+		Object:    server1User1,
+		Namespace: server1User1.Namespace,
+		Name:      server1User1.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	var updatedServer v1.MCPServer
+	require.NoError(t, client.Get(context.Background(), router.Key(server1.Namespace, server1.Name), &updatedServer))
+	require.NotNil(t, updatedServer.Status.MCPServerInstanceUserCount)
+	assert.Equal(t, 2, *updatedServer.Status.MCPServerInstanceUserCount)
+
+	var updatedEntry v1.MCPServerCatalogEntry
+	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updatedEntry))
+	assert.Equal(t, 3, updatedEntry.Status.UserCount)
+}
+
+func TestEnsureUserCountsClearsSingleUserParentServer(t *testing.T) {
+	server := newMCPServer("single-user-server")
+	count := 1
+	server.Status.MCPServerInstanceUserCount = &count
+	instance := newMCPServerInstance("instance-1", server.Name, "user1")
+
+	client := newFakeClient(t, server, instance)
+	err := (&Handler{}).EnsureUserCounts(router.Request{
+		Client:    client,
+		Ctx:       context.Background(),
+		Object:    instance,
+		Namespace: instance.Namespace,
+		Name:      instance.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	var updatedServer v1.MCPServer
+	require.NoError(t, client.Get(context.Background(), router.Key(server.Namespace, server.Name), &updatedServer))
+	assert.Nil(t, updatedServer.Status.MCPServerInstanceUserCount)
+}
+
+func TestEnsureUserCountsSkipsCatalogEntryForCompositeServer(t *testing.T) {
+	entry := newMCPServerCatalogEntry("multi-entry", types.MCPServerCatalogEntryManifest{
+		Name:           "Multi User Template",
+		Runtime:        types.RuntimeContainerized,
+		ServerUserType: types.ServerUserTypeMultiUser,
+	})
+	entry.Status.UserCount = 4
+
+	server := newMCPServer("component-server")
+	server.Spec.MCPCatalogID = "default"
+	server.Spec.MCPServerCatalogEntryName = entry.Name
+	server.Spec.CompositeName = "composite-server"
+	instance := newMCPServerInstance("instance-1", server.Name, "user1")
+
+	client := newFakeClient(t, entry, server, instance)
+	err := (&Handler{}).EnsureUserCounts(router.Request{
+		Client:    client,
+		Ctx:       context.Background(),
+		Object:    instance,
+		Namespace: instance.Namespace,
+		Name:      instance.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	var updatedEntry v1.MCPServerCatalogEntry
+	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updatedEntry))
+	assert.Equal(t, 4, updatedEntry.Status.UserCount)
+}
+
+func newFakeClient(t *testing.T, objects ...kclient.Object) kclient.WithWatch {
+	t.Helper()
+
+	return fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithStatusSubresource(&v1.MCPServer{}, &v1.MCPServerCatalogEntry{}).
+		WithIndex(&v1.MCPServer{}, "spec.mcpServerCatalogEntryName", func(obj kclient.Object) []string {
+			server := obj.(*v1.MCPServer)
+			if server.Spec.MCPServerCatalogEntryName == "" {
+				return nil
+			}
+			return []string{server.Spec.MCPServerCatalogEntryName}
+		}).
+		WithIndex(&v1.MCPServerInstance{}, "spec.mcpServerName", func(obj kclient.Object) []string {
+			instance := obj.(*v1.MCPServerInstance)
+			if instance.Spec.MCPServerName == "" {
+				return nil
+			}
+			return []string{instance.Spec.MCPServerName}
+		}).
+		WithObjects(objects...).
+		Build()
+}
+
+func newMCPServerCatalogEntry(name string, manifest types.MCPServerCatalogEntryManifest) *v1.MCPServerCatalogEntry {
+	return &v1.MCPServerCatalogEntry{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "MCPServerCatalogEntry",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: manifest,
+		},
+	}
+}
+
+func newMCPServer(name string) *v1.MCPServer {
+	return &v1.MCPServer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "MCPServer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+	}
+}
+
+func newMCPServerInstance(name, serverName, userID string) *v1.MCPServerInstance {
+	return &v1.MCPServerInstance{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "MCPServerInstance",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: v1.MCPServerInstanceSpec{
+			MCPServerName: serverName,
+			UserID:        userID,
+		},
+	}
+}

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -138,6 +138,7 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPServerInstance{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.MCPServerInstance{}).HandlerFunc(mcpserverinstance.MigrationDeleteSingleUserInstances)
 	root.Type(&v1.MCPServerInstance{}).HandlerFunc(mcpserverinstance.UpdateMultiUserConfig)
+	root.Type(&v1.MCPServerInstance{}).HandlerFunc(mcpServerCatalogEntryHandler.EnsureUserCountForMCPServerInstance)
 	root.Type(&v1.MCPServerInstance{}).FinalizeFunc(v1.MCPServerInstanceFinalizer, credentialCleanup.RemoveMCPInstanceCredentials)
 
 	// AccessControlRule

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -123,7 +123,6 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.DetectDrift)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.DetectK8sSettingsDrift)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureMCPNetworkPolicy)
-	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureMCPServerInstanceUserCount)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.SyncOAuthCredentialStatus)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.SyncOAuthMetadata)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureMCPServerSecretInfo)
@@ -138,7 +137,7 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPServerInstance{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.MCPServerInstance{}).HandlerFunc(mcpserverinstance.MigrationDeleteSingleUserInstances)
 	root.Type(&v1.MCPServerInstance{}).HandlerFunc(mcpserverinstance.UpdateMultiUserConfig)
-	root.Type(&v1.MCPServerInstance{}).HandlerFunc(mcpServerCatalogEntryHandler.EnsureUserCountForMCPServerInstance)
+	root.Type(&v1.MCPServerInstance{}).HandlerFunc(mcpserverinstance.EnsureUserCounts)
 	root.Type(&v1.MCPServerInstance{}).FinalizeFunc(v1.MCPServerInstanceFinalizer, credentialCleanup.RemoveMCPInstanceCredentials)
 
 	// AccessControlRule

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
@@ -80,6 +80,7 @@ type MCPServerCatalogEntrySpec struct {
 
 type MCPServerCatalogEntryStatus struct {
 	// UserCount contains the current number of users with an MCP server created from this catalog entry.
+	// For multi-user entries, this is the sum of users connected to each MCP server created from this entry.
 	UserCount int `json:"userCount,omitempty"`
 	// LastUpdated is the timestamp when this catalog entry was last updated.
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`


### PR DESCRIPTION
Addresses #6764 

The first commit updates `MCPServerCatalogEntry.UserCount` for multi-user catalog entries to aggregate connected users across all `MCPServer`s created from that entry. It counts unique users per server from `MCPServerInstance`s, then sums those per-server counts.

The second commit consolidates count maintenance around `MCPServerInstance` changes:
- Moves `MCPServer.Status.MCPServerInstanceUserCount` updates into the `MCPServerInstance` handler path.
- Uses the same `MCPServerInstance` handler to refresh the parent `MCPServerCatalogEntry.UserCount` when applicable.
- Extracts/reuses catalog-entry count helpers so single-user and multi-user `MCPServerCatalogEntry.UserCount` semantics stay in one place.

**Please let me know if we prefer the first commit only, which is a simpler path but does result in some duplication**