### PR TITLE
fix: reject multi-user catalog entries in composites

### DIFF
--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1610,6 +1610,10 @@ func (h *MCPCatalogHandler) populateComponentManifests(req api.Context, manifest
 				return types.NewErrBadRequest("component entry %s does not belong to workspace %s", component.CatalogEntryID, workspaceID)
 			}
 
+			if entry.Spec.Manifest.ServerUserType == types.ServerUserTypeMultiUser {
+				return types.NewErrBadRequest("multi-user catalog entry %s cannot be included in a composite server; use the multi-user MCP server instead", component.CatalogEntryID)
+			}
+
 			// Reject remote entries with static OAuth from being included in composites
 			if entry.Spec.Manifest.Runtime == types.RuntimeRemote &&
 				entry.Spec.Manifest.RemoteConfig != nil &&

--- a/pkg/validation/mcpvalidators.go
+++ b/pkg/validation/mcpvalidators.go
@@ -834,6 +834,14 @@ func (v CompositeValidator) ValidateCatalogConfig(manifest types.MCPServerCatalo
 			}
 		}
 
+		if hasCatalogEntry && component.Manifest.ServerUserType == types.ServerUserTypeMultiUser {
+			return types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   fmt.Sprintf("compositeConfig.componentServers[%d]", i),
+				Message: "multi-user catalog entries cannot be included in a composite server; use the multi-user MCP server instead",
+			}
+		}
+
 		// Prevent composite MCP servers from being nested
 		if component.Manifest.Runtime == types.RuntimeComposite {
 			return types.RuntimeValidationError{

--- a/pkg/validation/mcpvalidators_test.go
+++ b/pkg/validation/mcpvalidators_test.go
@@ -1099,6 +1099,46 @@ func TestCompositeValidator_ValidateCatalogConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "multi-user catalog entry component not allowed in catalog",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "entry-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime:        types.RuntimeRemote,
+								ServerUserType: types.ServerUserTypeMultiUser,
+							},
+						},
+					},
+				},
+			},
+			expectedError: types.RuntimeValidationError{
+				Runtime: types.RuntimeComposite,
+				Field:   "compositeConfig.componentServers[0]",
+				Message: "multi-user catalog entries cannot be included in a composite server; use the multi-user MCP server instead",
+			},
+		},
+		{
+			name: "multi-user MCP server component is allowed in catalog",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							MCPServerID: "server-1",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime:        types.RuntimeRemote,
+								ServerUserType: types.ServerUserTypeMultiUser,
+							},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
 			name: "duplicate component servers detected in catalog",
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeComposite,

--- a/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
@@ -351,7 +351,9 @@
 		};
 		return {
 			...ctx,
-			entries: ctx.entries.filter((e) => e.manifest?.runtime !== 'composite')
+			entries: ctx.entries.filter(
+				(e) => e.manifest?.runtime !== 'composite' && e.manifest?.serverUserType !== 'multiUser'
+			)
 		};
 	}}
 	singleSelect


### PR DESCRIPTION
Addresses #6762 

- Do not show Multi-User Catalog Entry in the UI for creating Composite Server
- Validate on the backend API to prevent this as well