### PR TITLE
fix: aggregate multi-user catalog entry user counts

### DIFF
--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -35,21 +35,29 @@ func NewHandler(gatewayClient *gclient.Client) *Handler {
 
 // EnsureUserCount ensures that the user count for an MCP server catalog entry is up to date.
 // For single-user entries, this counts unique users who have an MCPServer created from the entry.
-// For multi-user entries, this counts the number of deployed MCPServers from the catalog entry.
+// For multi-user entries, this sums the user count status from each MCPServer created from the entry.
 func (*Handler) EnsureUserCount(req router.Request, _ router.Response) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
+	userCount, err := userCountForEntry(req, *entry)
+	if err != nil {
+		return err
+	}
 
+	return updateEntryUserCount(req, entry, userCount)
+}
+
+func userCountForEntry(req router.Request, entry v1.MCPServerCatalogEntry) (int, error) {
 	var mcpServers v1.MCPServerList
 	if err := req.List(&mcpServers, &kclient.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector("spec.mcpServerCatalogEntryName", entry.Name),
 		Namespace:     system.DefaultNamespace,
 	}); err != nil {
-		return fmt.Errorf("failed to list MCP servers: %w", err)
+		return 0, fmt.Errorf("failed to list MCP servers: %w", err)
 	}
 
-	// For single-user entries, count unique users. For multi-user entries, count deployed servers.
 	isSingleUser := entry.Spec.Manifest.ServerUserType.IsSingleUser()
 	uniqueUsers := make(map[string]struct{}, len(mcpServers.Items))
+	userCount := 0
 	for _, server := range mcpServers.Items {
 		if !server.DeletionTimestamp.IsZero() || server.Spec.CompositeName != "" {
 			continue
@@ -57,11 +65,20 @@ func (*Handler) EnsureUserCount(req router.Request, _ router.Response) error {
 		if isSingleUser && server.Spec.UserID != "" {
 			uniqueUsers[server.Spec.UserID] = struct{}{}
 		} else if !isSingleUser {
-			uniqueUsers[server.Name] = struct{}{}
+			if server.Status.MCPServerInstanceUserCount != nil {
+				userCount += *server.Status.MCPServerInstanceUserCount
+			}
 		}
 	}
+	if isSingleUser {
+		userCount = len(uniqueUsers)
+	}
 
-	if newUserCount := len(uniqueUsers); entry.Status.UserCount != newUserCount {
+	return userCount, nil
+}
+
+func updateEntryUserCount(req router.Request, entry *v1.MCPServerCatalogEntry, newUserCount int) error {
+	if entry.Status.UserCount != newUserCount {
 		log.Infof("Updated MCP catalog entry user count: entry=%s oldCount=%d newCount=%d", entry.Name, entry.Status.UserCount, newUserCount)
 		entry.Status.UserCount = newUserCount
 		return req.Client.Status().Update(req.Ctx, entry)

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
@@ -163,6 +163,7 @@ func TestEnsureUserCountMultiUserEntry(t *testing.T) {
 	})
 	server1.Spec.MCPServerCatalogEntryName = entry.Name
 	server1.Spec.UserID = "admin1"
+	server1.Status.MCPServerInstanceUserCount = new(2)
 
 	server2 := newMCPServer("server-2", types.MCPServerManifest{
 		Runtime: types.RuntimeContainerized,
@@ -172,6 +173,7 @@ func TestEnsureUserCountMultiUserEntry(t *testing.T) {
 	})
 	server2.Spec.MCPServerCatalogEntryName = entry.Name
 	server2.Spec.UserID = "admin2"
+	server2.Status.MCPServerInstanceUserCount = new(1)
 
 	client := newFakeClient(entry, server1, server2)
 	err := (&Handler{}).EnsureUserCount(router.Request{
@@ -185,7 +187,7 @@ func TestEnsureUserCountMultiUserEntry(t *testing.T) {
 
 	var updated v1.MCPServerCatalogEntry
 	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updated))
-	assert.Equal(t, 2, updated.Status.UserCount)
+	assert.Equal(t, 3, updated.Status.UserCount, "should sum server instance user counts across servers")
 }
 
 func TestEnsureUserCountMultiUserEntryExcludesComposite(t *testing.T) {
@@ -208,6 +210,7 @@ func TestEnsureUserCountMultiUserEntryExcludesComposite(t *testing.T) {
 	})
 	activeServer.Spec.MCPServerCatalogEntryName = entry.Name
 	activeServer.Spec.UserID = "admin1"
+	activeServer.Status.MCPServerInstanceUserCount = new(1)
 
 	compositeChild := newMCPServer("composite-child", types.MCPServerManifest{
 		Runtime: types.RuntimeContainerized,
@@ -218,6 +221,7 @@ func TestEnsureUserCountMultiUserEntryExcludesComposite(t *testing.T) {
 	compositeChild.Spec.MCPServerCatalogEntryName = entry.Name
 	compositeChild.Spec.UserID = "admin2"
 	compositeChild.Spec.CompositeName = "parent-composite"
+	compositeChild.Status.MCPServerInstanceUserCount = new(1)
 
 	client := newFakeClient(entry, activeServer, compositeChild)
 	err := (&Handler{}).EnsureUserCount(router.Request{
@@ -231,7 +235,46 @@ func TestEnsureUserCountMultiUserEntryExcludesComposite(t *testing.T) {
 
 	var updated v1.MCPServerCatalogEntry
 	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updated))
-	assert.Equal(t, 1, updated.Status.UserCount, "should only count active non-composite server")
+	assert.Equal(t, 1, updated.Status.UserCount, "should only count active non-composite servers")
+}
+
+func TestEnsureUserCountSingleUserEntryCountsUniqueServerUsers(t *testing.T) {
+	entry := newMCPServerCatalogEntry("single-entry", types.MCPServerCatalogEntryManifest{
+		Name:           "Single User Template",
+		Runtime:        types.RuntimeContainerized,
+		ServerUserType: types.ServerUserTypeSingleUser,
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/mcp:1.0.0",
+			Port:  8080,
+			Path:  "/mcp",
+		},
+	})
+
+	server1 := newMCPServer("server-1", types.MCPServerManifest{Runtime: types.RuntimeContainerized})
+	server1.Spec.MCPServerCatalogEntryName = entry.Name
+	server1.Spec.UserID = "user1"
+
+	server2 := newMCPServer("server-2", types.MCPServerManifest{Runtime: types.RuntimeContainerized})
+	server2.Spec.MCPServerCatalogEntryName = entry.Name
+	server2.Spec.UserID = "user1"
+
+	server3 := newMCPServer("server-3", types.MCPServerManifest{Runtime: types.RuntimeContainerized})
+	server3.Spec.MCPServerCatalogEntryName = entry.Name
+	server3.Spec.UserID = "user2"
+
+	client := newFakeClient(entry, server1, server2, server3)
+	err := (&Handler{}).EnsureUserCount(router.Request{
+		Client:    client,
+		Ctx:       context.Background(),
+		Object:    entry,
+		Namespace: entry.Namespace,
+		Name:      entry.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	var updated v1.MCPServerCatalogEntry
+	require.NoError(t, client.Get(context.Background(), router.Key(entry.Namespace, entry.Name), &updated))
+	assert.Equal(t, 2, updated.Status.UserCount)
 }
 
 func newMCPServer(name string, manifest types.MCPServerManifest) *v1.MCPServer {

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
@@ -80,7 +80,7 @@ type MCPServerCatalogEntrySpec struct {
 
 type MCPServerCatalogEntryStatus struct {
 	// UserCount contains the current number of users with an MCP server created from this catalog entry.
-	// For multi-user entries, this is the sum of users connected to each MCP server created from this entry.
+	// For multi-user entries, this is the sum of MCPServerInstanceUserCount across each MCPServer created from this entry (not de-duplicated across servers).
 	UserCount int `json:"userCount,omitempty"`
 	// LastUpdated is the timestamp when this catalog entry was last updated.
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
@@ -80,6 +80,7 @@ type MCPServerCatalogEntrySpec struct {
 
 type MCPServerCatalogEntryStatus struct {
 	// UserCount contains the current number of users with an MCP server created from this catalog entry.
+	// For multi-user entries, this is the sum of users connected to each MCP server created from this entry.
 	UserCount int `json:"userCount,omitempty"`
 	// LastUpdated is the timestamp when this catalog entry was last updated.
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -13719,7 +13719,7 @@ func schema_storage_apis_obotobotai_v1_MCPServerCatalogEntryStatus(ref common.Re
 				Properties: map[string]spec.Schema{
 					"userCount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UserCount contains the current number of users with an MCP server created from this catalog entry.",
+							Description: "UserCount contains the current number of users with an MCP server created from this catalog entry. For multi-user entries, this is the sum of MCPServerInstanceUserCount across each MCPServer created from this entry (not de-duplicated across servers).",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},


### PR DESCRIPTION
Addresses #6764 

Aggregate MCPServerInstanceCount for Multi-User Catalog Entry UserCount instead of just counting MCPServers.