### PR TITLE
fix: don't auto-connect admins when deploying multi-user catalog entries and rename to "Create Server"

### DIFF
--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -595,15 +595,9 @@
 				? await UserService.configureWorkspaceMCPCatalogServer(workspaceID, created.id, envs)
 				: await AdminService.configureMCPCatalogServer(catalogID!, created.id, envs);
 
-			if (hasMultiUserInstanceConfiguration(server)) {
-				await initMultiUserInstanceForm(server);
-				launchHandedOff = true;
-				return;
-			}
-
-			instance = await UserService.createMcpServerInstance(server.id);
-			await finishMultiUserServerConnect();
+			instance = undefined;
 			launchHandedOff = true;
+			onConnect?.({ server, entry });
 		} catch (err) {
 			if (created && !launchHandedOff) {
 				try {
@@ -924,7 +918,11 @@
 	icon={manifest?.icon}
 	name={server?.alias || manifest?.name || ''}
 	onSave={handleConfigureForm}
-	submitText={isConfigured ? 'Update' : 'Launch'}
+	submitText={isDeployingMultiUserCatalogEntry
+		? 'Create Server'
+		: isConfigured
+			? 'Update'
+			: 'Launch'}
 	loading={saving}
 	disableSave={!!secretBindingEngineError}
 	isNew={!isConfigured}

--- a/ui/user/src/lib/components/mcp/ConnectorsView.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectorsView.svelte
@@ -264,8 +264,14 @@
 		selectServerMode = mode;
 	}
 
-	function handleConnectToServer({ instance }: { instance?: MCPServerInstance }) {
-		if (instance) {
+	function handleConnectToServer({
+		server,
+		instance
+	}: {
+		server?: MCPCatalogServer;
+		instance?: MCPServerInstance;
+	}) {
+		if (instance || server) {
 			mcpServersAndEntries.refreshAll();
 		}
 		onConnect?.({ instance });

--- a/ui/user/src/lib/components/mcp/ConnectorsView.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectorsView.svelte
@@ -798,7 +798,8 @@
 			toggle(false);
 		}}
 	>
-		<SatelliteDish class="size-4" /> Connect To Server
+		<SatelliteDish class="size-4" />
+		{isMultiUserCatalogEntryRow ? 'Create Server' : 'Connect To Server'}
 	</button>
 {/snippet}
 

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -329,6 +329,8 @@
 	>
 		{#if loading}
 			<Loading class="size-4" />
+		{:else if isMultiUserCatalogEntryRow}
+			Create Server
 		{:else}
 			Connect To Server
 		{/if}


### PR DESCRIPTION
Deploying a multi-user catalog entry no longer creates a personal MCPServerInstance for the deploying admin or opens the per-user connect dialog. The flow now just creates the shared server and refreshes the list.

Also renames the deploy-path button copy from "Connect To Server" / "Launch" to "Create Server" for multi-user catalog entries so the action is unambiguous. Single-user, composite, and end-user connect flows are unchanged.

Addresses #6757
Addresses #6758

<img width="1320" height="353" alt="Screenshot 2026-05-29 at 12 52 21" src="https://github.com/user-attachments/assets/baa41059-08a0-4380-a3ef-585a3a1d6bef" />
<img width="1341" height="564" alt="Screenshot 2026-05-29 at 12 52 27" src="https://github.com/user-attachments/assets/6f9cb547-82fb-4526-89d8-d416de20c169" />
