### PR TITLE
fix: show Connect to Server button for Multi-User Catalog Entry when an MCPServer already exists

### DIFF
--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -891,7 +891,8 @@
 						connectDialog?.close();
 					}}
 				>
-					<Plus class="size-3" /> Connect to New Server
+					<Plus class="size-3" />
+					{isMultiUserCatalogEntry(entry) ? 'Create New Server' : 'Connect to New Server'}
 				</button>
 			</p>
 		{/if}

--- a/ui/user/src/lib/components/mcp/ConnectorsView.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectorsView.svelte
@@ -758,6 +758,9 @@
 )}
 	{@const canConnect = d.canConnect !== false}
 	{@const isMultiUserCatalogEntryRow = 'isCatalogEntry' in d && isMultiUserCatalogEntry(d)}
+	{@const multiUserCatalogEntryServers = isMultiUserCatalogEntryRow
+		? getConfiguredServersForCatalogEntry(d as MCPCatalogEntry)
+		: []}
 	{@const isAdminDeployable =
 		isMultiUserCatalogEntryRow &&
 		((!!catalog && profile.current?.hasAdminAccess?.()) || (entity === 'workspace' && !!id))}
@@ -778,7 +781,18 @@
 
 			if ('isCatalogEntry' in d) {
 				if (isMultiUserCatalogEntry(d)) {
-					connectToServerDialog?.open({ entry: d });
+					if (multiUserCatalogEntryServers.length === 1) {
+						const targetServer = multiUserCatalogEntryServers[0];
+						connectToServerDialog?.open({
+							entry: d,
+							server: targetServer,
+							instance: instancesMap.get(targetServer.id)
+						});
+					} else if (multiUserCatalogEntryServers.length > 1) {
+						handleShowSelectServerDialog(d);
+					} else {
+						connectToServerDialog?.open({ entry: d });
+					}
 					toggle(false);
 					return;
 				}
@@ -805,7 +819,9 @@
 		}}
 	>
 		<SatelliteDish class="size-4" />
-		{isMultiUserCatalogEntryRow ? 'Create Server' : 'Connect To Server'}
+		{isMultiUserCatalogEntryRow && multiUserCatalogEntryServers.length === 0
+			? 'Create Server'
+			: 'Connect To Server'}
 	</button>
 {/snippet}
 
@@ -974,7 +990,8 @@
 				default:
 					connectToServerDialog?.open({
 						entry: selectedEntry,
-						server: d
+						server: d,
+						instance: isMultiUserServer(d) ? instancesMap.get(d.id) : undefined
 					});
 					break;
 			}

--- a/ui/user/src/lib/components/mcp/ConnectorsView.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectorsView.svelte
@@ -659,7 +659,7 @@
 								{#if !requiresOAuth || catalogEntry?.oauthCredentialConfigured}
 									{@render connectToServerAction(d.data, toggle, true)}
 								{/if}
-								{#if catalogEntry && isMultiUserCatalogEntry(catalogEntry) && matchingServers.length > 0}
+								{#if catalogEntry && isMultiUserCatalogEntry(catalogEntry) && matchingServers.length > 0 && ((!!catalog && profile.current?.hasAdminAccess?.()) || (entity === 'workspace' && !!id))}
 									<button
 										class="menu-button"
 										onclick={(e) => {

--- a/ui/user/src/lib/components/mcp/ConnectorsView.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectorsView.svelte
@@ -47,6 +47,7 @@
 		Ellipsis,
 		KeyRound,
 		PencilLine,
+		Plus,
 		ReceiptText,
 		RefreshCw,
 		SatelliteDish,
@@ -657,6 +658,18 @@
 							{#if !hasConnectedOptions}
 								{#if !requiresOAuth || catalogEntry?.oauthCredentialConfigured}
 									{@render connectToServerAction(d.data, toggle, true)}
+								{/if}
+								{#if catalogEntry && isMultiUserCatalogEntry(catalogEntry) && matchingServers.length > 0}
+									<button
+										class="menu-button"
+										onclick={(e) => {
+											e.stopPropagation();
+											connectToServerDialog?.open({ entry: catalogEntry });
+											toggle(false);
+										}}
+									>
+										<Plus class="size-4" /> Create Server
+									</button>
 								{/if}
 							{/if}
 							{#if requiresOAuth && catalogEntry}

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -177,12 +177,16 @@
 	let showConnectionActions = $derived(
 		!hasMultiUserServerNotOwned || hasConfiguredServerUserInstance
 	);
+	let canCreateAnotherMultiUserServer = $derived(
+		isMultiUserCatalogEntry(entry) && (!!catalogID || !!workspaceID) && configuredServers.length > 0
+	);
 	let hasActions = $derived.by(() => {
 		return Boolean(
 			(entry && server && isServerOwner) ||
 			(server && instance) ||
 			(showServerDetails && showConnectionActions) ||
-			canEditMultiUserServerConfiguration
+			canEditMultiUserServerConfiguration ||
+			canCreateAnotherMultiUserServer
 		);
 	});
 	let showDisconnectUser = $derived(
@@ -295,7 +299,7 @@
 		)}
 		use:tooltip={{
 			text:
-				isMultiUserCatalogEntryRow && !profile.current?.hasAdminAccess?.()
+				isMultiUserCatalogEntryRow && !catalogID && !workspaceID
 					? 'This is a multi-user catalog entry. An administrator must deploy it before you can connect.'
 					: canConnect
 						? ''
@@ -796,7 +800,7 @@
 				{/if}
 			</div>
 		{/if}
-		{#if isMultiUserCatalogEntry(entry)}
+		{#if isMultiUserCatalogEntry(entry) && (catalogID || workspaceID)}
 			<div class="flex flex-col gap-1 p-2">
 				<button
 					class="menu-button"

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -302,9 +302,20 @@
 		}}
 		onclick={async () => {
 			if (isMultiUserCatalogEntryRow) {
-				connectToServerDialog?.open({
-					entry
-				});
+				if (configuredServers.length === 1) {
+					const targetServer = configuredServers[0];
+					connectToServerDialog?.open({
+						entry,
+						server: targetServer,
+						instance: mcpServersAndEntries.current.userInstances.find(
+							(i) => i.mcpServerID === targetServer.id
+						)
+					});
+				} else if (configuredServers.length > 1) {
+					handleShowSelectServerDialog();
+				} else {
+					connectToServerDialog?.open({ entry });
+				}
 			} else if (entry && !server && configuredServers.length > 0) {
 				if (configuredServers.length === 1) {
 					connectToServerDialog?.open({
@@ -329,7 +340,7 @@
 	>
 		{#if loading}
 			<Loading class="size-4" />
-		{:else if isMultiUserCatalogEntryRow}
+		{:else if isMultiUserCatalogEntryRow && configuredServers.length === 0}
 			Create Server
 		{:else}
 			Connect To Server
@@ -426,7 +437,10 @@
 				default:
 					connectToServerDialog?.open({
 						entry,
-						server: d
+						server: d,
+						instance: isMultiUserServer(d)
+							? mcpServersAndEntries.current.userInstances.find((i) => i.mcpServerID === d.id)
+							: undefined
 					});
 					break;
 			}

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -33,6 +33,7 @@
 	import {
 		KeyRound,
 		PencilLine,
+		Plus,
 		ReceiptText,
 		RefreshCw,
 		Server,
@@ -793,6 +794,20 @@
 						<Unplug class="size-4" /> Disconnect
 					</button>
 				{/if}
+			</div>
+		{/if}
+		{#if isMultiUserCatalogEntry(entry)}
+			<div class="flex flex-col gap-1 p-2">
+				<button
+					class="menu-button"
+					onclick={(e) => {
+						e.stopPropagation();
+						connectToServerDialog?.open({ entry });
+						toggle(false);
+					}}
+				>
+					<Plus class="size-4" /> Create Server
+				</button>
 			</div>
 		{/if}
 	{/if}


### PR DESCRIPTION
Addresses #6765 

When an MCPServer already exists for the Multi-User Catalog Entry, go back to showing the Connect to Server button. This opens the connection URL dialog and changes the "Connect to New Server" to "Create New Server".

Since this hides the option to create a new server unless the Admin is connected to the existing server, a "Create Server" option is added to the DotDotDot menu.

<img width="1353" height="623" alt="Screenshot 2026-05-29 at 12 48 44" src="https://github.com/user-attachments/assets/fa8d954d-c999-4c61-8ad0-9bdc1fbca402" />
<img width="1351" height="662" alt="Screenshot 2026-05-29 at 12 48 51" src="https://github.com/user-attachments/assets/13738b85-7ccd-4034-a5c2-4396aec81532" />
<img width="1353" height="896" alt="Screenshot 2026-05-29 at 12 48 59" src="https://github.com/user-attachments/assets/27df0445-8982-43fb-9055-3bf4ccb446a0" />

~~This PR is based on changes in https://github.com/obot-platform/obot/pull/6780 and will likely need rebase once that one is squashed and merged. The newer 2 commits are the ones needing separate review.~~