### PR TITLE
fix: trigger needsUpdate on deployments when entry resources change

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -3849,6 +3849,7 @@ func updateServerFromCatalogEntry(server *v1.MCPServer, entry v1.MCPServerCatalo
 	server.Spec.Manifest.Description = entry.Spec.Manifest.Description
 	server.Spec.Manifest.Icon = entry.Spec.Manifest.Icon
 	server.Spec.Manifest.Env = entry.Spec.Manifest.Env
+	server.Spec.Manifest.Resources = entry.Spec.Manifest.Resources
 	server.Spec.Manifest.Runtime = entry.Spec.Manifest.Runtime
 	server.Spec.Manifest.UVXConfig = entry.Spec.Manifest.UVXConfig
 	server.Spec.Manifest.NPXConfig = entry.Spec.Manifest.NPXConfig

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -931,3 +931,33 @@ func composite(components ...types.CatalogComponentServer) types.MCPServerCatalo
 		CompositeConfig: &types.CompositeCatalogConfig{ComponentServers: components},
 	}
 }
+
+func TestUpdateServerFromCatalogEntryCopiesResources(t *testing.T) {
+	resources := &types.MCPResourceRequirements{
+		Requests: types.MCPResourceRequests{CPU: "500m", Memory: "512Mi"},
+		Limits:   types.MCPResourceRequests{CPU: "1", Memory: "1Gi"},
+	}
+	server := v1.MCPServer{
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{
+				Name:    "server",
+				Runtime: types.RuntimeContainerized,
+				Resources: &types.MCPResourceRequirements{
+					Requests: types.MCPResourceRequests{CPU: "250m", Memory: "256Mi"},
+				},
+			},
+		},
+	}
+	entry := v1.MCPServerCatalogEntry{
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Name:      "entry",
+				Runtime:   types.RuntimeContainerized,
+				Resources: resources,
+			},
+		},
+	}
+
+	updateServerFromCatalogEntry(&server, entry)
+	assert.Equal(t, resources, server.Spec.Manifest.Resources)
+}

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -255,7 +255,7 @@ func (h *Handler) DetectK8sSettingsDrift(req router.Request, _ router.Response) 
 	return nil
 }
 
-// ConfigurationHasDrifted compares runtime config, env, and multi-user config between a server
+// ConfigurationHasDrifted compares runtime config, env, resources, and multi-user config between a server
 // manifest and a catalog entry manifest. It handles the type difference between MCPServerManifest
 // and MCPServerCatalogEntryManifest by comparing only the fields common to both.
 func ConfigurationHasDrifted(serverManifest types.MCPServerManifest, entryManifest types.MCPServerCatalogEntryManifest, defaultDenyAllEgress bool) (bool, error) {
@@ -295,7 +295,21 @@ func ConfigurationHasDrifted(serverManifest types.MCPServerManifest, entryManife
 	}
 
 	// Check environment
-	return !slicesEqualIgnoreOrderDeep(serverManifest.Env, entryManifest.Env), nil
+	if !slicesEqualIgnoreOrderDeep(serverManifest.Env, entryManifest.Env) {
+		return true, nil
+	}
+
+	return resourcesHasDrifted(serverManifest.Resources, entryManifest.Resources), nil
+}
+
+func resourcesHasDrifted(serverResources, entryResources *types.MCPResourceRequirements) bool {
+	if serverResources == nil && entryResources == nil {
+		return false
+	}
+	if serverResources == nil || entryResources == nil {
+		return true
+	}
+	return !reflect.DeepEqual(serverResources, entryResources)
 }
 
 func multiUserConfigHasDrifted(serverConfig, entryConfig *types.MultiUserConfig) bool {

--- a/pkg/controller/handlers/mcpserver/mcpserver_test.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver_test.go
@@ -506,6 +506,88 @@ func TestConfigurationHasDrifted(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			name: "no drift - identical resources",
+			serverManifest: types.MCPServerManifest{
+				Name:    "test-server",
+				Runtime: types.RuntimeContainerized,
+				ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+					Image: "example/mcp:1.0.0",
+					Port:  8080,
+					Path:  "/mcp",
+				},
+				Resources: &types.MCPResourceRequirements{
+					Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},
+					Limits:   types.MCPResourceRequests{CPU: "1", Memory: "1Gi"},
+				},
+			},
+			entryManifest: types.MCPServerCatalogEntryManifest{
+				Name:    "test-server",
+				Runtime: types.RuntimeContainerized,
+				ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+					Image: "example/mcp:1.0.0",
+					Port:  8080,
+					Path:  "/mcp",
+				},
+				Resources: &types.MCPResourceRequirements{
+					Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},
+					Limits:   types.MCPResourceRequests{CPU: "1", Memory: "1Gi"},
+				},
+			},
+			expectedDrift: false,
+			expectedError: false,
+		},
+		{
+			name: "drift - different resources",
+			serverManifest: types.MCPServerManifest{
+				Name:    "test-server",
+				Runtime: types.RuntimeContainerized,
+				ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+					Image: "example/mcp:1.0.0",
+					Port:  8080,
+					Path:  "/mcp",
+				},
+				Resources: &types.MCPResourceRequirements{
+					Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},
+				},
+			},
+			entryManifest: types.MCPServerCatalogEntryManifest{
+				Name:    "test-server",
+				Runtime: types.RuntimeContainerized,
+				ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+					Image: "example/mcp:1.0.0",
+					Port:  8080,
+					Path:  "/mcp",
+				},
+				Resources: &types.MCPResourceRequirements{
+					Requests: types.MCPResourceRequests{CPU: "500m", Memory: "512Mi"},
+				},
+			},
+			expectedDrift: true,
+			expectedError: false,
+		},
+		{
+			name: "drift - resources added to catalog entry",
+			serverManifest: types.MCPServerManifest{
+				Name:    "test-server",
+				Runtime: types.RuntimeNPX,
+				NPXConfig: &types.NPXRuntimeConfig{
+					Package: "@test/package",
+				},
+			},
+			entryManifest: types.MCPServerCatalogEntryManifest{
+				Name:    "test-server",
+				Runtime: types.RuntimeNPX,
+				NPXConfig: &types.NPXRuntimeConfig{
+					Package: "@test/package",
+				},
+				Resources: &types.MCPResourceRequirements{
+					Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},
+				},
+			},
+			expectedDrift: true,
+			expectedError: false,
+		},
+		{
 			name: "error - invalid URL in remote server config",
 			serverManifest: types.MCPServerManifest{
 				Name:        "test-server",
@@ -797,6 +879,52 @@ func newMCPServer(name string) *v1.MCPServer {
 			Namespace: "default",
 		},
 	}
+}
+
+func TestDetectDriftMarksCatalogEntryDeploymentNeedingUpdateForResources(t *testing.T) {
+	resources := &types.MCPResourceRequirements{
+		Requests: types.MCPResourceRequests{CPU: "500m", Memory: "512Mi"},
+	}
+	entry := newMCPServerCatalogEntry("template-entry", types.MCPServerCatalogEntryManifest{
+		Name:           "Shared Template",
+		Runtime:        types.RuntimeContainerized,
+		ServerUserType: types.ServerUserTypeMultiUser,
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/mcp:1.0.0",
+			Port:  8080,
+			Path:  "/mcp",
+		},
+		Resources: resources,
+	})
+	server := newMCPServer("shared-server")
+	server.Spec.MCPCatalogID = "default"
+	server.Spec.MCPServerCatalogEntryName = entry.Name
+	server.Spec.Manifest = types.MCPServerManifest{
+		Name:    "Shared Template",
+		Runtime: types.RuntimeContainerized,
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/mcp:1.0.0",
+			Port:  8080,
+			Path:  "/mcp",
+		},
+		Resources: &types.MCPResourceRequirements{
+			Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},
+		},
+	}
+
+	client := newFakeClient(t, entry, server)
+	err := (&Handler{}).DetectDrift(router.Request{
+		Client:    client,
+		Ctx:       context.Background(),
+		Object:    server,
+		Namespace: server.Namespace,
+		Name:      server.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	var updated v1.MCPServer
+	require.NoError(t, client.Get(context.Background(), router.Key(server.Namespace, server.Name), &updated))
+	assert.True(t, updated.Status.NeedsUpdate)
 }
 
 func TestDetectDriftMarksMultiUserCatalogEntryDeploymentNeedingUpdate(t *testing.T) {


### PR DESCRIPTION
* to trigger needsUpdate when config drift happens causes of resources


This will trigger the Needs Update to update the deployment's config then they, after updating, the status updates to Needs Scheduling Update, where they then to the redeploy. 

todo: check with donnie about this & make sure going through `needsUpdate` first is correct to update deployment config vs. the issue's asking of it showing 'Needs Scheduling Update' after saving. 

Addresses #6785 