### PR TITLE
docs: document MCP hosting trust model and harden deployment guidance

### DIFF
--- a/docs/docs/concepts/mcp-hosting.md
+++ b/docs/docs/concepts/mcp-hosting.md
@@ -49,6 +49,17 @@ Obot handles OAuth 2.1 flows for MCP servers that require authentication:
 
 See [MCP Server OAuth Configuration](/configuration/mcp-server-oauth-configuration/) for details on configuring OAuth for MCP servers.
 
+## Security and Isolation
+
+Adding an MCP server causes Obot to run code on the hosting backend: `npx` and `uvx` servers execute the requested npm/PyPI package, and **containerized** servers run an arbitrary OCI image with a user-supplied command. The [Power User and Power User+ roles](/configuration/user-roles/#security-model) can deploy servers, so granting those roles is, by design, granting the ability to run code on your infrastructure.
+
+How well that code is contained depends on the deployment environment:
+
+- **Docker** runs MCP servers as sibling containers through the host Docker socket, which provides little isolation from the host. Use it for development or single-tenant, trusted use only.
+- **Kubernetes** runs each MCP server in its own pod and supports the restricted Pod Security Admission policy, a NetworkPolicy, and sandboxed container runtimes (gVisor, Kata Containers) for stronger isolation. Use it for multi-tenant or untrusted workloads.
+
+See [User Roles — Security Model](/configuration/user-roles/#security-model) and [MCP Deployments in Kubernetes](/configuration/mcp-deployments-in-kubernetes/) for details.
+
 ## Learn More
 
 - [MCP Servers](/functionality/mcp-servers/) - Adding and configuring MCP servers

--- a/docs/docs/configuration/user-roles.md
+++ b/docs/docs/configuration/user-roles.md
@@ -53,6 +53,17 @@ Add-on permission that grants read-only access to sensitive data across the plat
 
 \*\* Metadata only. Full request/response bodies require the Auditor role. Owners can assign Auditor to themselves, but this is an explicit action to prevent accidental exposure to sensitive data.
 
+## Security Model
+
+Obot's MCP hosting platform runs the MCP servers that users add. The **Power User** and **Power User+** roles can publish and deploy MCP servers — including `npx` (npm) and `uvx` (PyPI) packages, and **containerized** servers that run an arbitrary OCI image with a user-supplied command, arguments, and environment. By design, these roles can therefore cause code to execute on Obot's MCP hosting backend.
+
+Treat Power User and Power User+ as **privileged** roles. Grant them only to users you trust to run code on your infrastructure, and harden the hosting backend so that the code those users deploy stays contained:
+
+- **Docker deployments** bind-mount the host Docker socket, so a containerized MCP server runs on the host Docker daemon — effectively host-level access on that machine. Use Docker deployments only for development or single-machine, single-tenant use. See [Docker Deployment](/installation/docker-deployment/).
+- **Kubernetes deployments** isolate each MCP server in its own pod. For multi-tenant or untrusted users, keep the restricted Pod Security Admission policy and the MCP NetworkPolicy enabled (both are on by default), and consider a sandboxed container runtime such as gVisor or Kata Containers. See [MCP Deployments in Kubernetes](/configuration/mcp-deployments-in-kubernetes/).
+
+The [default role for new users](#default-role-for-new-users) is configurable. Do not default new users to Power User or Power User+ unless every user who can sign up is trusted to run code on your infrastructure.
+
 ## Managing User Roles
 
 ### Updating a User's Role

--- a/docs/docs/installation/docker-deployment.md
+++ b/docs/docs/installation/docker-deployment.md
@@ -39,6 +39,12 @@ docker run -d \
 Running Obot without authentication is not recommended unless you are behind a secure firewall, as unauthenticated users could launch MCP servers by sending requests to port 8080 on your system.
 :::
 
+:::warning Host access and trusted users
+This deployment bind-mounts the host Docker socket (`-v /var/run/docker.sock:/var/run/docker.sock`) so Obot can run MCP servers as sibling containers. Any MCP server Obot launches — including a **containerized** server, which runs an arbitrary container image with a user-supplied command — therefore runs on the host Docker daemon, which is equivalent to host-level access on that machine.
+
+Users with the **Power User** or **Power User+** role can deploy MCP servers, so on this deployment they can effectively run code on the host. Use Docker deployment only for development, evaluation, or single-tenant use where all such users are trusted. For multi-tenant deployments or untrusted users, use the [Kubernetes deployment](/installation/kubernetes-deployment/), which isolates each MCP server in a hardened pod. See [User Roles — Security Model](/configuration/user-roles/#security-model).
+:::
+
 #### With Authentication (Recommended)
 
 ```bash

--- a/docs/docs/installation/docker-deployment.md
+++ b/docs/docs/installation/docker-deployment.md
@@ -42,7 +42,7 @@ Running Obot without authentication is not recommended unless you are behind a s
 :::warning Host access and trusted users
 This deployment bind-mounts the host Docker socket (`-v /var/run/docker.sock:/var/run/docker.sock`) so Obot can run MCP servers as sibling containers. Any MCP server Obot launches — including a **containerized** server, which runs an arbitrary container image with a user-supplied command — therefore runs on the host Docker daemon, which is equivalent to host-level access on that machine.
 
-Users with the **Power User** or **Power User+** role can deploy MCP servers, so on this deployment they can effectively run code on the host. Use Docker deployment only for development, evaluation, or single-tenant use where all such users are trusted. For multi-tenant deployments or untrusted users, use the [Kubernetes deployment](/installation/kubernetes-deployment/), which isolates each MCP server in a hardened pod. See [User Roles — Security Model](/configuration/user-roles/#security-model).
+Users with the **Power User** or **Power User+** role can deploy MCP servers, so on this deployment they can effectively run code on the host. Use Docker deployment only for development, evaluation, or single-tenant use where all such users are trusted. For multi-tenant deployments or untrusted users, use the [Kubernetes deployment](/installation/kubernetes-deployment/), which runs each MCP server in its own pod and supports stronger isolation controls you configure (restricted Pod Security Admission, a NetworkPolicy, and sandboxed runtimes such as gVisor or Kata Containers). See [User Roles — Security Model](/configuration/user-roles/#security-model).
 :::
 
 #### With Authentication (Recommended)

--- a/docs/versioned_docs/version-v0.22.0/concepts/mcp-hosting.md
+++ b/docs/versioned_docs/version-v0.22.0/concepts/mcp-hosting.md
@@ -49,6 +49,17 @@ Obot handles OAuth 2.1 flows for MCP servers that require authentication:
 
 See [MCP Server OAuth Configuration](/configuration/mcp-server-oauth-configuration/) for details on configuring OAuth for MCP servers.
 
+## Security and Isolation
+
+Adding an MCP server causes Obot to run code on the hosting backend: `npx` and `uvx` servers execute the requested npm/PyPI package, and **containerized** servers run an arbitrary OCI image with a user-supplied command. The [Power User and Power User+ roles](/configuration/user-roles/#security-model) can deploy servers, so granting those roles is, by design, granting the ability to run code on your infrastructure.
+
+How well that code is contained depends on the deployment environment:
+
+- **Docker** runs MCP servers as sibling containers through the host Docker socket, which provides little isolation from the host. Use it for development or single-tenant, trusted use only.
+- **Kubernetes** runs each MCP server in its own pod and supports the restricted Pod Security Admission policy, a NetworkPolicy, and sandboxed container runtimes (gVisor, Kata Containers) for stronger isolation. Use it for multi-tenant or untrusted workloads.
+
+See [User Roles — Security Model](/configuration/user-roles/#security-model) and [MCP Deployments in Kubernetes](/configuration/mcp-deployments-in-kubernetes/) for details.
+
 ## Learn More
 
 - [MCP Servers](/functionality/mcp-servers/) - Adding and configuring MCP servers

--- a/docs/versioned_docs/version-v0.22.0/configuration/user-roles.md
+++ b/docs/versioned_docs/version-v0.22.0/configuration/user-roles.md
@@ -53,6 +53,17 @@ Add-on permission that grants read-only access to sensitive data across the plat
 
 \*\* Metadata only. Full request/response bodies require the Auditor role. Owners can assign Auditor to themselves, but this is an explicit action to prevent accidental exposure to sensitive data.
 
+## Security Model
+
+Obot's MCP hosting platform runs the MCP servers that users add. The **Power User** and **Power User+** roles can publish and deploy MCP servers — including `npx` (npm) and `uvx` (PyPI) packages, and **containerized** servers that run an arbitrary OCI image with a user-supplied command, arguments, and environment. By design, these roles can therefore cause code to execute on Obot's MCP hosting backend.
+
+Treat Power User and Power User+ as **privileged** roles. Grant them only to users you trust to run code on your infrastructure, and harden the hosting backend so that the code those users deploy stays contained:
+
+- **Docker deployments** bind-mount the host Docker socket, so a containerized MCP server runs on the host Docker daemon — effectively host-level access on that machine. Use Docker deployments only for development or single-machine, single-tenant use. See [Docker Deployment](/installation/docker-deployment/).
+- **Kubernetes deployments** isolate each MCP server in its own pod. For multi-tenant or untrusted users, keep the restricted Pod Security Admission policy and the MCP NetworkPolicy enabled (both are on by default), and consider a sandboxed container runtime such as gVisor or Kata Containers. See [MCP Deployments in Kubernetes](/configuration/mcp-deployments-in-kubernetes/).
+
+The [default role for new users](#default-role-for-new-users) is configurable. Do not default new users to Power User or Power User+ unless every user who can sign up is trusted to run code on your infrastructure.
+
 ## Managing User Roles
 
 ### Updating a User's Role

--- a/docs/versioned_docs/version-v0.22.0/installation/docker-deployment.md
+++ b/docs/versioned_docs/version-v0.22.0/installation/docker-deployment.md
@@ -39,6 +39,12 @@ docker run -d \
 Running Obot without authentication is not recommended unless you are behind a secure firewall, as unauthenticated users could launch MCP servers by sending requests to port 8080 on your system.
 :::
 
+:::warning Host access and trusted users
+This deployment bind-mounts the host Docker socket (`-v /var/run/docker.sock:/var/run/docker.sock`) so Obot can run MCP servers as sibling containers. Any MCP server Obot launches — including a **containerized** server, which runs an arbitrary container image with a user-supplied command — therefore runs on the host Docker daemon, which is equivalent to host-level access on that machine.
+
+Users with the **Power User** or **Power User+** role can deploy MCP servers, so on this deployment they can effectively run code on the host. Use Docker deployment only for development, evaluation, or single-tenant use where all such users are trusted. For multi-tenant deployments or untrusted users, use the [Kubernetes deployment](/installation/kubernetes-deployment/), which isolates each MCP server in a hardened pod. See [User Roles — Security Model](/configuration/user-roles/#security-model).
+:::
+
 #### With Authentication (Recommended)
 
 ```bash

--- a/docs/versioned_docs/version-v0.22.0/installation/docker-deployment.md
+++ b/docs/versioned_docs/version-v0.22.0/installation/docker-deployment.md
@@ -42,7 +42,7 @@ Running Obot without authentication is not recommended unless you are behind a s
 :::warning Host access and trusted users
 This deployment bind-mounts the host Docker socket (`-v /var/run/docker.sock:/var/run/docker.sock`) so Obot can run MCP servers as sibling containers. Any MCP server Obot launches — including a **containerized** server, which runs an arbitrary container image with a user-supplied command — therefore runs on the host Docker daemon, which is equivalent to host-level access on that machine.
 
-Users with the **Power User** or **Power User+** role can deploy MCP servers, so on this deployment they can effectively run code on the host. Use Docker deployment only for development, evaluation, or single-tenant use where all such users are trusted. For multi-tenant deployments or untrusted users, use the [Kubernetes deployment](/installation/kubernetes-deployment/), which isolates each MCP server in a hardened pod. See [User Roles — Security Model](/configuration/user-roles/#security-model).
+Users with the **Power User** or **Power User+** role can deploy MCP servers, so on this deployment they can effectively run code on the host. Use Docker deployment only for development, evaluation, or single-tenant use where all such users are trusted. For multi-tenant deployments or untrusted users, use the [Kubernetes deployment](/installation/kubernetes-deployment/), which runs each MCP server in its own pod and supports stronger isolation controls you configure (restricted Pod Security Admission, a NetworkPolicy, and sandboxed runtimes such as gVisor or Kata Containers). See [User Roles — Security Model](/configuration/user-roles/#security-model).
 :::
 
 #### With Authentication (Recommended)


### PR DESCRIPTION
## What

Adds explicit security framing for how MCP servers are hosted and which roles can deploy them, and clarifies deployment-hardening guidance. No behavior changes — docs only.

The **Power User** and **Power User+** roles can deploy MCP servers (npx/uvx packages and containerized images) that run code on the MCP hosting backend, by design. These docs make that trust model explicit and explain how the code is contained per deployment environment.

## Changes

Applied to both the current (`next`) docs and the default-served `v0.22.0` versioned docs:

- **`configuration/user-roles.md`** — new "Security Model" section: Power User / Power User+ are privileged roles; grant only to trusted users; harden the backend; don't default new users into them unless all signups are trusted.
- **`installation/docker-deployment.md`** — new warning callout: the Docker socket mount means containerized servers run on the host daemon, so Docker deployment is for dev/single-tenant/trusted use; multi-tenant/untrusted should use Kubernetes.
- **`concepts/mcp-hosting.md`** — new "Security and Isolation" section tying the role trust model to per-environment isolation (Docker vs. hardened Kubernetes with PSA / NetworkPolicy / sandboxed runtimes).

All six files share identical wording and cross-links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)