### PR TITLE
docs: clarify NetworkPolicy scope and Obot server egress hardening

### DIFF
--- a/docs/docs/configuration/mcp-deployments-in-kubernetes.md
+++ b/docs/docs/configuration/mcp-deployments-in-kubernetes.md
@@ -178,6 +178,10 @@ Enabling the NetworkPolicy is recommended for production deployments to prevent 
 If your MCP servers need to access internal Kubernetes services or private network resources, you will need to either disable the NetworkPolicy or create additional NetworkPolicy rules to allow specific traffic.
 :::
 
+:::note Scope: MCP server pods only
+This NetworkPolicy (`mcp-egress-restrictions`) applies to the **MCP server pods** in the MCP namespace. It does **not** restrict egress from the Obot server pod itself, which makes its own outbound connections as part of normal operation. Restricting the Obot server's own egress is left to the operator; see [Restricting Obot Server Egress](/installation/kubernetes-deployment/#restricting-obot-server-egress).
+:::
+
 ### Pod Security Admission
 
 Obot supports Pod Security Admission (PSA) configuration for the MCP namespace to enforce Kubernetes Pod Security Standards. PSA provides a way to enforce security policies on pods at the namespace level.

--- a/docs/docs/installation/kubernetes-deployment.md
+++ b/docs/docs/installation/kubernetes-deployment.md
@@ -145,6 +145,12 @@ The restricted policy follows current Pod hardening best practices and provides 
 
 For details, see [MCP Deployments in Kubernetes - Pod Security Admission](../configuration/mcp-deployments-in-kubernetes.md#pod-security-admission).
 
+### Restricting Obot Server Egress
+
+The [Network Policy for MCP Servers](#network-policy-for-mcp-servers) above restricts the **MCP server pods**. It does not restrict the **Obot server** itself, which makes its own outbound connections as part of normal operation. In multi-tenant deployments or deployments with untrusted users, you may want to constrain which destinations the Obot server can reach, as a defense-in-depth measure.
+
+If you want to constrain the Obot server's egress as a defense-in-depth measure, scope it tightly to your specific deployment — there is no safe blanket blocklist. Depending on your setup, the Obot server legitimately needs to reach private ranges (its database and in-cluster services such as a self-hosted model provider or the MCP namespace) and, with some cloud authentication methods, the cloud instance metadata endpoint (`169.254.169.254`), where it obtains credentials for integrations such as KMS.
+
 ## Agent Persistence
 
 By default, Obot Agent uses storage inside its pod, which means all agent state is lost if the pod restarts. For production deployments, configure a persistent `StorageClass`.

--- a/docs/versioned_docs/version-v0.22.0/configuration/mcp-deployments-in-kubernetes.md
+++ b/docs/versioned_docs/version-v0.22.0/configuration/mcp-deployments-in-kubernetes.md
@@ -178,6 +178,10 @@ Enabling the NetworkPolicy is recommended for production deployments to prevent 
 If your MCP servers need to access internal Kubernetes services or private network resources, you will need to either disable the NetworkPolicy or create additional NetworkPolicy rules to allow specific traffic.
 :::
 
+:::note Scope: MCP server pods only
+This NetworkPolicy (`mcp-egress-restrictions`) applies to the **MCP server pods** in the MCP namespace. It does **not** restrict egress from the Obot server pod itself, which makes its own outbound connections as part of normal operation. Restricting the Obot server's own egress is left to the operator; see [Restricting Obot Server Egress](/installation/kubernetes-deployment/#restricting-obot-server-egress).
+:::
+
 ### Pod Security Admission
 
 Obot supports Pod Security Admission (PSA) configuration for the MCP namespace to enforce Kubernetes Pod Security Standards. PSA provides a way to enforce security policies on pods at the namespace level.

--- a/docs/versioned_docs/version-v0.22.0/installation/kubernetes-deployment.md
+++ b/docs/versioned_docs/version-v0.22.0/installation/kubernetes-deployment.md
@@ -145,6 +145,12 @@ The restricted policy follows current Pod hardening best practices and provides 
 
 For details, see [MCP Deployments in Kubernetes - Pod Security Admission](../configuration/mcp-deployments-in-kubernetes.md#pod-security-admission).
 
+### Restricting Obot Server Egress
+
+The [Network Policy for MCP Servers](#network-policy-for-mcp-servers) above restricts the **MCP server pods**. It does not restrict the **Obot server** itself, which makes its own outbound connections as part of normal operation. In multi-tenant deployments or deployments with untrusted users, you may want to constrain which destinations the Obot server can reach, as a defense-in-depth measure.
+
+If you want to constrain the Obot server's egress as a defense-in-depth measure, scope it tightly to your specific deployment — there is no safe blanket blocklist. Depending on your setup, the Obot server legitimately needs to reach private ranges (its database and in-cluster services such as a self-hosted model provider or the MCP namespace) and, with some cloud authentication methods, the cloud instance metadata endpoint (`169.254.169.254`), where it obtains credentials for integrations such as KMS.
+
 ## Agent Persistence
 
 By default, Obot Agent uses storage inside its pod, which means all agent state is lost if the pod restarts. For production deployments, configure a persistent `StorageClass`.


### PR DESCRIPTION
- mcp-deployments-in-kubernetes.md: note that the bundled
  mcp-egress-restrictions policy governs MCP server pods only, not the
  Obot server pod.
- kubernetes-deployment.md: add "Restricting Obot Server Egress" to the
  Security Configuration section, explaining why Obot does not ship an
  egress policy for its own pod and giving prose guidance on which ranges
  to block/allow.
- reference architectures (EKS/GKE/AKS): add instance-metadata hardening
  guidance (IMDSv2/hop-limit, metadata concealment, Workload Identity).

Applied to both the current docs and the default-served v0.22.0
versioned docs.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
