### PR TITLE
fix: default devices sorting by last scanned desc

### DIFF
--- a/ui/user/src/routes/devices/+page.svelte
+++ b/ui/user/src/routes/devices/+page.svelte
@@ -152,7 +152,7 @@
 					'skill_count',
 					'plugin_count',
 					'client_count',
-					'scanned_relative'
+					'scannedAt'
 				]}
 				headers={[
 					{ title: 'Device', property: 'short_device_id' },
@@ -162,9 +162,10 @@
 					{ title: 'Skills', property: 'skill_count' },
 					{ title: 'Plugins', property: 'plugin_count' },
 					{ title: 'Clients', property: 'client_count' },
-					{ title: 'Last Scanned', property: 'scanned_relative' }
+					{ title: 'Last Scanned', property: 'scannedAt' }
 				]}
-				sortable={['short_device_id', 'os_arch', 'username']}
+				sortable={['short_device_id', 'os_arch', 'username', 'scannedAt']}
+				initSort={{ property: 'scannedAt', order: 'desc' }}
 				filterable={['os_arch']}
 				onClickRow={(d, isCtrlClick) => {
 					const prefix = hasAdminAccess ? '/admin' : '';
@@ -172,7 +173,9 @@
 				}}
 			>
 				{#snippet onRenderColumn(property, d: Row)}
-					{#if property === 'short_device_id'}
+					{#if property === 'scannedAt'}
+						<span title={d.scannedAt}>{d.scanned_relative}</span>
+					{:else if property === 'short_device_id'}
 						<span title={d.deviceID}>{d.short_device_id}</span>
 					{:else if property === 'username'}
 						{@const u = d.submittedBy ? userById.get(d.submittedBy) : undefined}


### PR DESCRIPTION
## Summary (#6736 Open)

Changes the Devices page default sort order from Device to Last Scanned (descending), ensuring the most recently scanned devices appear first.

### Changes

* Use `scannedAt` as the sort field
* Update Last Scanned header property to `scannedAt`
* Add default sort: `scannedAt DESC`
* Add `scannedAt` to sortable columns
* Continue displaying relative time while sorting using the raw timestamp

### Testing

* Created multiple test device scan records with different `scannedAt` timestamps
* Verified newest scanned device appears first on page load
* Verified Last Scanned column shows the active sort indicator
* Verified clicking Last Scanned toggles ascending/descending order
* Verified relative time display remains unchanged

Closes #6736
