### PR TITLE
fix: allow MCP server containers to get jwks.json always

### DIFF
--- a/pkg/license/entitlements.go
+++ b/pkg/license/entitlements.go
@@ -14,7 +14,11 @@ import (
 var entitlementPathsToGate = []string{
 	"/mcp-connect/{mcp_id}",
 	"/mcp-connect/{mcp_id}/",
-	"/oauth/",
+	"GET /oauth/authorize",
+	"GET /oauth/authorize/",
+	"GET /oauth/mcp/callback/",
+	"POST /oauth/",
+	"PUT /oauth/",
 	"GET /api/oauth/composite/{mcp_id}",
 	"/api/llm-proxy/",
 	"/api/skills",


### PR DESCRIPTION
This should happen even if the license becomes invalid because the implementation will check periodically.

Issue: https://github.com/obot-platform/obot/issues/6810