### PR TITLE
fix: set HealthzPath for composite MCP servers

### DIFF
--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -267,6 +267,7 @@ func configureRemoteRuntime(serverConfig *ServerConfig, remoteConfig *types.Remo
 }
 
 func configureCompositeRuntime(serverConfig ServerConfig) (ServerConfig, []string, error) {
+	serverConfig.HealthzPath = "/healthz"
 	return serverConfig, nil, nil
 }
 


### PR DESCRIPTION
Set HealthzPath to "/healthz" for composite-runtime MCP servers so readiness checks use GET /healthz instead of probing the MCP endpoint.

Addresses https://github.com/obot-platform/obot/issues/6823
