### PR TITLE
fix: use a catalog entry's static OAuth credentials when generating tool previews

### DIFF
--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -818,6 +818,7 @@ func (h *MCPCatalogHandler) GenerateToolPreviews(req api.Context) error {
 		req.ObotNamespace,
 		entry.Namespace,
 		catalogName,
+		entry.Name,
 		entry.Spec.Manifest,
 		configRequest.Config,
 		configRequest.URL,
@@ -942,6 +943,7 @@ func (h *MCPCatalogHandler) generateCompositeToolPreviews(req api.Context, entry
 			req.ObotNamespace,
 			entry.Namespace,
 			catalogName,
+			componentEntry.CatalogEntryID,
 			componentEntry.Manifest,
 			config.Config,
 			config.URL,
@@ -1065,7 +1067,7 @@ func (h *MCPCatalogHandler) GenerateToolPreviewsOAuthURL(req api.Context) error 
 	if catalogName == "" {
 		catalogName = entry.Spec.PowerUserWorkspaceID
 	}
-	server, serverConfig, err := tempServerAndConfig(req.Context(), req.GatewayClient, req.Storage, req.LocalK8sClient, req.ObotNamespace, entry.Namespace, catalogName, entry.Spec.Manifest, configRequest.Config, configRequest.URL, h.serverURL)
+	server, serverConfig, err := tempServerAndConfig(req.Context(), req.GatewayClient, req.Storage, req.LocalK8sClient, req.ObotNamespace, entry.Namespace, catalogName, entry.Name, entry.Spec.Manifest, configRequest.Config, configRequest.URL, h.serverURL)
 	if err != nil {
 		return types.NewErrBadRequest("failed to create temporary server and config: %v", err)
 	}
@@ -1158,6 +1160,7 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviews(req api.Context) error
 		req.ObotNamespace,
 		composite.Namespace,
 		catalogName,
+		component.CatalogEntryID,
 		component.Manifest,
 		configRequest.Config,
 		configRequest.URL,
@@ -1282,6 +1285,7 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviewsOAuthURL(req api.Contex
 		req.ObotNamespace,
 		composite.Namespace,
 		catalogName,
+		component.CatalogEntryID,
 		component.Manifest,
 		configRequest.Config,
 		configRequest.URL,
@@ -1365,6 +1369,7 @@ func (h *MCPCatalogHandler) generateCompositeOAuthURLs(req api.Context, entry v1
 			req.ObotNamespace,
 			entry.Namespace,
 			catalogName,
+			componentEntry.CatalogEntryID,
 			componentEntry.Manifest,
 			config.Config,
 			config.URL,
@@ -1391,7 +1396,7 @@ func (h *MCPCatalogHandler) generateCompositeOAuthURLs(req api.Context, entry v1
 	return req.Write(oauthURLs)
 }
 
-func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, client client.Client, localK8sClient client.Client, obotNamespace, namespace, catalogName string, entryManifest types.MCPServerCatalogEntryManifest, config map[string]string, url, baseURL string) (v1.MCPServer, mcp.ServerConfig, error) {
+func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, client client.Client, localK8sClient client.Client, obotNamespace, namespace, catalogName, mcpServerCatalogEntryName string, entryManifest types.MCPServerCatalogEntryManifest, config map[string]string, url, baseURL string) (v1.MCPServer, mcp.ServerConfig, error) {
 	// Convert catalog entry to server manifest
 	serverManifest, err := types.MapCatalogEntryToServer(entryManifest, url, false)
 	if err != nil {
@@ -1414,6 +1419,9 @@ func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, cli
 		},
 		Spec: v1.MCPServerSpec{
 			Manifest: serverManifest,
+			// Link back to the catalog entry so its static OAuth credentials are
+			// resolvable during the preview (this temp server is never persisted).
+			MCPServerCatalogEntryName: mcpServerCatalogEntryName,
 		},
 	}
 

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -97,6 +97,10 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(req api.Context, mcpServer v1.M
 
 	// Remote server, check for OAuth directly
 	oauthHandler := f.newMCPOAuthHandler(req.GatewayClient, userID, mcpID, mcpServerConfig.URL, oauthAppAuthRequestID)
+	// Carry the catalog entry so static OAuth credentials can be resolved even for
+	// ephemeral servers (e.g. tool previews) that are never persisted and therefore
+	// can't be fetched from storage by name.
+	oauthHandler.mcpServerCatalogEntryName = mcpServer.Spec.MCPServerCatalogEntryName
 	errChan := make(chan error, 1)
 
 	go func() {
@@ -132,14 +136,15 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(req api.Context, mcpServer v1.M
 }
 
 type mcpOAuthHandler struct {
-	client             kclient.Client
-	gatewayClient      *client.Client
-	stateMgr           *stateManager
-	mcpID              string
-	mcpURL             string
-	userID             string
-	oauthAuthRequestID string
-	urlChan            chan string
+	client                    kclient.Client
+	gatewayClient             *client.Client
+	stateMgr                  *stateManager
+	mcpID                     string
+	mcpServerCatalogEntryName string
+	mcpURL                    string
+	userID                    string
+	oauthAuthRequestID        string
+	urlChan                   chan string
 }
 
 func (f *MCPOAuthHandlerFactory) newMCPOAuthHandler(gatewayClient *client.Client, userID, mcpID, mcpURL, oauthAuthRequestID string) *mcpOAuthHandler {
@@ -182,20 +187,26 @@ func (m *mcpOAuthHandler) NewState(ctx context.Context, conf *oauth2.Config, ver
 }
 
 func (m *mcpOAuthHandler) Lookup(ctx context.Context, _ string) (string, string, error) {
-	if m.mcpID != "" {
+	// Resolve the catalog entry this server came from so we can look up its static
+	// OAuth credentials. The entry name is carried on the handler when known (set by
+	// the caller, e.g. for ephemeral tool-preview servers that aren't persisted);
+	// otherwise fall back to reading it from the persisted server by name.
+	mcpServerCatalogEntryName := m.mcpServerCatalogEntryName
+	if mcpServerCatalogEntryName == "" && m.mcpID != "" {
 		var server v1.MCPServer
 		if err := m.client.Get(ctx, kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: m.mcpID}, &server); err == nil {
-			// If the server was created from a catalog entry, look up OAuth credentials by catalog entry name
-			if server.Spec.MCPServerCatalogEntryName != "" {
-				credName := system.MCPOAuthCredentialName(server.Spec.MCPServerCatalogEntryName)
-				cred, err := m.gatewayClient.RevealCredential(ctx, []string{credName}, "oauth")
-				if err == nil {
-					clientID := cred.Secrets["CLIENT_ID"]
-					clientSecret := cred.Secrets["CLIENT_SECRET"]
-					if clientID != "" && clientSecret != "" {
-						return clientID, clientSecret, nil
-					}
-				}
+			mcpServerCatalogEntryName = server.Spec.MCPServerCatalogEntryName
+		}
+	}
+
+	if mcpServerCatalogEntryName != "" {
+		credName := system.MCPOAuthCredentialName(mcpServerCatalogEntryName)
+		cred, err := m.gatewayClient.RevealCredential(ctx, []string{credName}, "oauth")
+		if err == nil {
+			clientID := cred.Secrets["CLIENT_ID"]
+			clientSecret := cred.Secrets["CLIENT_SECRET"]
+			if clientID != "" && clientSecret != "" {
+				return clientID, clientSecret, nil
 			}
 		}
 	}


### PR DESCRIPTION
Generating tool previews for an OAuth-protected remote catalog entry fails even when the entry has static OAuth credentials configured.

### Problem
`GenerateToolPreviews` launches an ephemeral, never-persisted MCP server (`tool-preview-<hash>`) and connects to it to enumerate tools. For an OAuth-protected remote server this should use the catalog entry's configured static OAuth client, but it never can:

- `tempServerAndConfig` builds the temp server without setting `Spec.MCPServerCatalogEntryName`.
- The OAuth `ClientCredLookup` (`mcpOAuthHandler.Lookup`) resolves the static client by fetching the server **from storage by name** and reading `MCPServerCatalogEntryName` off it. The temp preview server isn't persisted, so that `Get` fails, `Lookup` returns "no credentials found", and the client falls back to Dynamic Client Registration — which strict IdPs (e.g. Keycloak) reject (`invalid_client_metadata`), surfacing as a 500.

### Fix
- Set `MCPServerCatalogEntryName` on the temp preview server (all `tempServerAndConfig` call sites pass the entry / component catalog-entry name).
- Carry the entry name onto `mcpOAuthHandler` (set in `CheckForMCPAuth` from the passed `mcpServer`).
- `Lookup` uses the carried entry name to resolve the static OAuth credentials directly, falling back to the storage lookup for persisted servers.

### Testing
Built locally and verified against an OAuth-protected remote server (Keycloak-fronted) with static OAuth credentials configured on the catalog entry: "Populate Tool Preview" now resolves the entry's static client, performs the normal login flow, and lists tools — instead of falling back to DCR and returning a 500.

`gofmt` clean; affected packages build.