### PR TITLE
chore: disable Obot Agent features by default

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -91,6 +91,8 @@ config:
   OBOT_SERVER_ENABLE_AUTHENTICATION: false
   # config.OBOT_SERVER_ENABLE_REGISTRY_AUTH -- Enables authentication for the MCP registry API. When false (default), registry is accessible without authentication and returns only default catalog items with wildcard access control rules.
   OBOT_SERVER_ENABLE_REGISTRY_AUTH: false
+  # config.OBOT_ENABLE_AGENTS -- Controls Obot Agent features. Leave empty (default) to disable agents for new deployments while grandfathering in (keeping enabled) existing deployments that already have agents. Set to "true" to force-enable, or "false" to force-disable, regardless of grandfathering.
+  OBOT_ENABLE_AGENTS: ""
   # config.OBOT_SERVER_UNAUTHENTICATED_RATE_LIMIT -- Rate limit for unauthenticated requests in requests per second. Tracked by source IP address. Defaults to 100.
   OBOT_SERVER_UNAUTHENTICATED_RATE_LIMIT: ""
   # config.OBOT_SERVER_AUTHENTICATED_RATE_LIMIT -- Rate limit for authenticated non-admin requests in requests per second. Tracked by user ID. Admin users are exempt. Defaults to 200.

--- a/pkg/api/handlers/nanobotagent.go
+++ b/pkg/api/handlers/nanobotagent.go
@@ -23,12 +23,14 @@ import (
 type NanobotAgentHandler struct {
 	sessionManager *mcp.SessionManager
 	serverURL      string
+	agentsEnabled  bool
 }
 
-func NewNanobotAgentHandler(sessionManager *mcp.SessionManager, serverURL string) *NanobotAgentHandler {
+func NewNanobotAgentHandler(sessionManager *mcp.SessionManager, serverURL string, agentsEnabled bool) *NanobotAgentHandler {
 	return &NanobotAgentHandler{
 		sessionManager: sessionManager,
 		serverURL:      serverURL,
+		agentsEnabled:  agentsEnabled,
 	}
 }
 
@@ -73,6 +75,10 @@ func (h *NanobotAgentHandler) List(req api.Context) error {
 }
 
 func (h *NanobotAgentHandler) Create(req api.Context) error {
+	if !h.agentsEnabled {
+		return types.NewErrHTTP(http.StatusForbidden, "Obot Agent features are disabled")
+	}
+
 	var manifest types.NanobotAgentManifest
 	if err := req.Read(&manifest); err != nil {
 		return err

--- a/pkg/api/handlers/version.go
+++ b/pkg/api/handlers/version.go
@@ -52,6 +52,7 @@ type VersionHandlerOptions struct {
 	AuthEnabled             bool
 	DisableUpdateCheck      bool
 	MessagePoliciesEnabled  bool
+	AgentsEnabled           bool
 }
 
 type VersionHandler struct {
@@ -134,6 +135,7 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 		"mcpNetworkPolicyEnabled":      v.MCPNetworkPolicyEnabled,
 		"mcpDefaultDenyAllEgress":      v.MCPDefaultDenyAllEgress,
 		"messagePoliciesEnabled":       v.MessagePoliciesEnabled,
+		"agentsEnabled":                v.AgentsEnabled,
 		"licenseEntitlementViolations": violations,
 		"missingLicenseEntitlements":   missingEntitlements(violations),
 	}, nil

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/obot-platform/obot/pkg/api/handlers"
@@ -11,13 +12,42 @@ import (
 	"github.com/obot-platform/obot/pkg/api/handlers/setup"
 	"github.com/obot-platform/obot/pkg/api/handlers/wellknown"
 	"github.com/obot-platform/obot/pkg/services"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/ui"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/component-base/metrics/legacyregistry"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// resolveAgentsEnabled determines whether Obot Agent features are enabled.
+//
+// An explicitly-set OBOT_ENABLE_AGENTS value (or --enable-agents flag) always
+// wins. Otherwise agents are enabled only if the deployment already has at least
+// one agent: new deployments start with no agents and are therefore disabled by
+// default, while existing deployments that already use agents stay enabled.
+//
+// This is evaluated once at startup, so the value is fixed for the lifetime of
+// the process.
+func resolveAgentsEnabled(ctx context.Context, services *services.Services) (bool, error) {
+	if services.EnableAgents != nil {
+		return *services.EnableAgents, nil
+	}
+
+	// Only need to know whether at least one agent exists.
+	var agents v1.NanobotAgentList
+	if err := services.StorageClient.List(ctx, &agents, kclient.Limit(1)); err != nil {
+		return false, fmt.Errorf("failed to list nanobot agents: %w", err)
+	}
+	return len(agents.Items) > 0, nil
+}
 
 func Router(ctx context.Context, services *services.Services) (http.Handler, error) {
 	mux := services.APIServer
+
+	agentsEnabled, err := resolveAgentsEnabled(ctx, services)
+	if err != nil {
+		return nil, err
+	}
 
 	version, err := handlers.NewVersionHandler(ctx, handlers.VersionHandlerOptions{
 		GatewayClient:           services.GatewayClient,
@@ -30,6 +60,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 		AuthEnabled:             services.AuthEnabled,
 		DisableUpdateCheck:      services.DisableUpdateCheck,
 		MessagePoliciesEnabled:  services.MessagePoliciesEnabled,
+		AgentsEnabled:           agentsEnabled,
 	})
 	if err != nil {
 		return nil, err
@@ -516,7 +547,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mux.HandleFunc("DELETE /api/projects/{project_id}", projects.Delete)
 
 	// NanobotAgents
-	nanobotAgents := handlers.NewNanobotAgentHandler(services.MCPSessionManager, services.ServerURL)
+	nanobotAgents := handlers.NewNanobotAgentHandler(services.MCPSessionManager, services.ServerURL, agentsEnabled)
 	mux.HandleFunc("GET /api/nanobot-agents", nanobotAgents.ListAll)
 	mux.HandleFunc("POST /api/projects/{project_id}/agents", nanobotAgents.Create)
 	mux.HandleFunc("GET /api/projects/{project_id}/agents", nanobotAgents.List)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -108,6 +108,7 @@ type Config struct {
 	DisableUpdateCheck                   bool   `usage:"Disable Obot server update checks"`
 	EnableRegistryAuth                   bool   `usage:"Enable authentication for the MCP registry API" default:"false" env:"OBOT_SERVER_ENABLE_REGISTRY_AUTH"`
 	EnableMessagePolicies                bool   `usage:"Enable message policies for LLM proxy content enforcement" default:"false"`
+	EnableAgents                         *bool  `usage:"Enable Obot Agent features. When unset, agents are disabled for new deployments but grandfathered in for deployments that already have agents. Explicitly set to true to force-enable, or false to force-disable, regardless of grandfathering." env:"OBOT_ENABLE_AGENTS"`
 	MCPOAuthClientExpiration             string `usage:"The expiration time in dynamically registered MCP OAuth clients, must be a valid duration string and may include days, hours, or minutes" default:"30d"`
 	MCPServerSearchImage                 string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.2.0"`
 	NanobotAgentImage                    string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/obot-platform/nanobot-agent:v0.0.83"`
@@ -225,6 +226,7 @@ type Services struct {
 	MCPHTTPWebhookBaseImage              string
 	RegistryNoAuth                       bool
 	MessagePoliciesEnabled               bool
+	EnableAgents                         *bool
 	MCPNetworkPolicyEnabled              bool
 	MCPDefaultDenyAllEgress              bool
 	MCPServerSearchImage                 string
@@ -961,6 +963,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		AgentIdleServerShutdownInterval:      time.Duration(config.IdleAgentShutdownHours) * time.Hour,
 		RegistryNoAuth:                       registryNoAuth,
 		MessagePoliciesEnabled:               config.EnableMessagePolicies,
+		EnableAgents:                         config.EnableAgents,
 		MCPNetworkPolicyEnabled:              mcpNetworkPolicyEnabled,
 		MCPDefaultDenyAllEgress:              config.MCPDefaultDenyAllEgress,
 		MCPServerSearchImage:                 config.MCPServerSearchImage,

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -142,22 +142,32 @@
 	let collapsed = $state<Record<string, boolean>>({});
 	let pathname = $derived(page.url.pathname);
 
-	let agentLinkEnabled = $derived(isAgentEnabled(defaultModelAliases.current));
+	// Whether the Obot Agent feature is enabled server-side. When false, agent entry
+	// points are removed entirely (not just disabled). When the feature is enabled but
+	// models aren't configured, agentLinkEnabled is false so links show as disabled.
+	let agentsFeatureEnabled = $derived(version.current.agentsEnabled !== false);
+	let agentLinkEnabled = $derived(
+		isAgentEnabled(defaultModelAliases.current) && agentsFeatureEnabled
+	);
 
 	let isBootStrapUser = $derived(profile.current.isBootstrapUser?.() ?? false);
 	let isAtLeastPowerUserPlus = $derived(profile.current.groups.includes(Group.POWERUSER_PLUS));
-	let chatLinks = $derived<NavLink[]>([
-		{
-			id: 'launch-agent-chat',
-			href: '/agent',
-			icon: BotMessageSquare,
-			disabled: isBootStrapUser || !agentLinkEnabled,
-			label: 'Launch Agent',
-			collapsible: false,
-			noteIcon: !agentLinkEnabled ? LockOpen : undefined,
-			note: !agentLinkEnabled ? renderAgentDisabledNote : undefined
-		}
-	]);
+	let chatLinks = $derived<NavLink[]>(
+		agentsFeatureEnabled
+			? [
+					{
+						id: 'launch-agent-chat',
+						href: '/agent',
+						icon: BotMessageSquare,
+						disabled: isBootStrapUser || !agentLinkEnabled,
+						label: 'Launch Agent',
+						collapsible: false,
+						noteIcon: !agentLinkEnabled ? LockOpen : undefined,
+						note: !agentLinkEnabled ? renderAgentDisabledNote : undefined
+					}
+				]
+			: []
+	);
 	let cliLink = $derived<NavLink[]>([
 		{
 			id: 'install-cli',
@@ -168,6 +178,38 @@
 			beta: true
 		}
 	]);
+	let agentManagementLinks = $derived<NavLink[]>(
+		agentsFeatureEnabled
+			? [
+					{
+						id: 'agent-management',
+						icon: Bot,
+						label: 'Obot Agent Management',
+						collapsible: true,
+						items: [
+							{
+								id: 'admin-agents',
+								href: '/admin/agents',
+								icon: Bots,
+								label: 'Agents',
+								collapsible: false,
+								disabled: isBootStrapUser || !agentLinkEnabled
+							},
+							{
+								id: 'launch-agent-chat',
+								href: '/agent',
+								icon: BotMessageSquare,
+								label: 'Launch Agent',
+								disabled: isBootStrapUser || !agentLinkEnabled,
+								collapsible: false,
+								noteIcon: !agentLinkEnabled ? LockOpen : undefined,
+								note: !agentLinkEnabled ? renderAgentDisabledNote : undefined
+							}
+						]
+					}
+				]
+			: []
+	);
 	let navLinks = $derived<NavLink[]>(
 		profile.current.hasAdminAccess?.()
 			? [
@@ -365,32 +407,7 @@
 						]
 					},
 					...cliLink,
-					{
-						id: 'agent-management',
-						icon: Bot,
-						label: 'Obot Agent Management',
-						collapsible: true,
-						items: [
-							{
-								id: 'admin-agents',
-								href: '/admin/agents',
-								icon: Bots,
-								label: 'Agents',
-								collapsible: false,
-								disabled: isBootStrapUser || !agentLinkEnabled
-							},
-							{
-								id: 'launch-agent-chat',
-								href: '/agent',
-								icon: BotMessageSquare,
-								label: 'Launch Agent',
-								disabled: isBootStrapUser || !agentLinkEnabled,
-								collapsible: false,
-								noteIcon: !agentLinkEnabled ? LockOpen : undefined,
-								note: !agentLinkEnabled ? renderAgentDisabledNote : undefined
-							}
-						]
-					},
+					...agentManagementLinks,
 					{
 						id: 'llm-gateway',
 						icon: BrainCog,

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -765,6 +765,7 @@ export interface Version {
 	mcpDefaultDenyAllEgress?: boolean;
 	autonomousToolUseEnabled?: boolean;
 	messagePoliciesEnabled?: boolean;
+	agentsEnabled?: boolean;
 	disableLegacyChat?: boolean;
 }
 

--- a/ui/user/src/routes/admin/agents/+page.ts
+++ b/ui/user/src/routes/admin/agents/+page.ts
@@ -2,9 +2,15 @@ import { handleRouteError } from '$lib/errors';
 import { UserService, NanobotService, type OrgUser } from '$lib/services';
 import type { ProjectV2Agent } from '$lib/services/nanobot/types';
 import type { PageLoad } from './$types';
+import { error } from '@sveltejs/kit';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { profile } = await parent();
+	const { profile, version } = await parent();
+
+	if (version?.agentsEnabled === false) {
+		throw error(403, 'Obot Agent features are disabled.');
+	}
+
 	let agents: ProjectV2Agent[] = [];
 	let users: OrgUser[] = [];
 	try {

--- a/ui/user/src/routes/agent/+layout.ts
+++ b/ui/user/src/routes/agent/+layout.ts
@@ -6,7 +6,11 @@ import { error } from '@sveltejs/kit';
 export const ssr = false;
 
 export const load: LayoutLoad = async ({ fetch, url, parent }) => {
-	const { profile } = await parent();
+	const { profile, version } = await parent();
+
+	if (version?.agentsEnabled === false) {
+		throw error(403, 'Obot Agent features are disabled.');
+	}
 
 	// Check for an explicit project ID from query params or URL path.
 	// This allows impersonation: navigating directly to another user's project.


### PR DESCRIPTION
Obot Agent features are now disabled by default for new deployments and
gated behind the new OBOT_ENABLE_AGENTS environment variable.

OBOT_ENABLE_AGENTS is a tri-state flag:
  - true:  force-enabled, regardless of existing data
  - false: force-disabled, even if agents already exist
  - unset (default): enabled only if the deployment already has at least
    one agent. New deployments start with zero agents and are therefore
    disabled, while existing deployments that already use agents stay
    enabled across upgrades with no migration required.

The effective value is resolved once at server startup (by checking the
env var, then falling back to whether any NanobotAgents exist) and is
surfaced to clients via the `agentsEnabled` field on GET /api/version.

Enforcement:
  - UI (primary): the agent navigation entries (the user "Launch Agent"
    link and the admin "Obot Agent Management" section) are hidden/locked,
    and the /agent and /admin/agents routes return 403 when disabled.
  - API: agent creation (POST /api/projects/{id}/agents) returns 403 when
    disabled. All other agent operations (list, get, update, delete,
    launch) remain available so disabled instances stay manageable and no
    existing agents are orphaned.

Helm: adds config.OBOT_ENABLE_AGENTS, defaulting to "" so the env var is
omitted from the rendered config secret and the existing-agents fallback
applies. An empty string is required because the chart only renders
truthy config values; a literal `false` would render and force-disable on
every upgrade. Set it to "true"/"false" to force the feature on/off.

Addresses https://github.com/obot-platform/obot/issues/6832
