### PR TITLE
fix: ui: prompt for new required config params after trigger-update for multi-user

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerInstances.svelte
+++ b/ui/user/src/lib/components/admin/McpServerInstances.svelte
@@ -20,6 +20,7 @@
 	import { openUrl, isOwnSingleUserServer, getUserDisplayName } from '$lib/utils';
 	import Confirm from '../Confirm.svelte';
 	import DotDotDot from '../DotDotDot.svelte';
+	import EditExistingDeployment from '../mcp/EditExistingDeployment.svelte';
 	import Table from '../table/Table.svelte';
 	import DiffDialog from './DiffDialog.svelte';
 	import McpServerK8sInfo from './McpServerK8sInfo.svelte';
@@ -60,6 +61,7 @@
 		{ type: 'multi' } | { type: 'single'; server: MCPCatalogServer } | undefined
 	>();
 	let diffDialog = $state<ReturnType<typeof DiffDialog>>();
+	let editExistingDialog = $state<ReturnType<typeof EditExistingDeployment>>();
 	let diffServer = $state<MCPCatalogServer>();
 	let selected = $state<Record<string, MCPCatalogServer>>({});
 	let updating = $state<Record<string, { inProgress: boolean; error: string }>>({});
@@ -192,6 +194,27 @@
 		throw new Error('This server cannot be updated from the current view.');
 	}
 
+	function getCatalogEntryForServer(server: MCPCatalogServer) {
+		if (catalogEntry?.id === server.catalogEntryID) return catalogEntry;
+		if (entry && 'isCatalogEntry' in entry && entry.id === server.catalogEntryID) return entry;
+		return undefined;
+	}
+
+	async function updateCatalogServerAndPromptForConfiguration(server: MCPCatalogServer) {
+		if (!isMultiUserServer(server) || !server.catalogEntryID) return undefined;
+
+		const entry = getCatalogEntryForServer(server);
+		// Return undefined so callers can use the normal update path when no entry context is available.
+		if (!entry) return undefined;
+
+		return (
+			(await editExistingDialog?.updateFromCatalogEntry({
+				server,
+				entry
+			})) ?? false
+		);
+	}
+
 	async function handleMultiUpdate() {
 		if (!id || !entry) return;
 		for (const serverId of Object.keys(selected)) {
@@ -200,7 +223,14 @@
 
 			updating[serverId] = { inProgress: true, error: '' };
 			try {
-				await triggerUpdate(server);
+				// Catalog-backed multi-user servers update first, then prompt for any new shared config.
+				const prompted = await updateCatalogServerAndPromptForConfiguration(server);
+				if (prompted === undefined) {
+					await triggerUpdate(server);
+				} else if (prompted) {
+					selected = {};
+					return;
+				}
 				updating[serverId] = { inProgress: false, error: '' };
 			} catch (error) {
 				updating[serverId] = {
@@ -221,8 +251,13 @@
 
 		updating[server.id] = { inProgress: true, error: '' };
 		try {
-			await triggerUpdate(server);
-			loadServers();
+			const prompted = await updateCatalogServerAndPromptForConfiguration(server);
+			if (prompted === undefined) {
+				await triggerUpdate(server);
+			}
+			if (!prompted) {
+				loadServers();
+			}
 		} catch (err) {
 			updating[server.id] = {
 				inProgress: false,
@@ -571,6 +606,8 @@
 
 <DiffDialog bind:this={diffDialog} fromServer={diffServer} toServer={entry} />
 
+<EditExistingDeployment bind:this={editExistingDialog} onUpdateConfigure={loadServers} />
+
 {#snippet emptyInstancesContent()}
 	<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
 		<Router class="text-muted-content size-24 opacity-50" />
@@ -599,7 +636,7 @@
 	title="Confirm Update"
 >
 	{#snippet note()}
-		If this update introduces new required configuration parameters, users will have to supply them
-		before they can use {showConfirm?.type === 'multi' ? 'these servers' : 'this server'} again.
+		If this update introduces new required shared configuration parameters, you will be prompted to
+		supply them after the update is applied.
 	{/snippet}
 </Confirm>

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -291,17 +291,11 @@
 			if (!server.needsUpdate || !canTriggerUpdate(server)) {
 				continue;
 			}
-			updating[serverId] = { inProgress: true, error: '' };
-			try {
-				await updateServer(server);
-				updating[serverId] = { inProgress: false, error: '' };
-			} catch (error) {
-				updating[serverId] = {
-					inProgress: false,
-					error: error instanceof Error ? error.message : 'An unknown error occurred'
-				};
-			} finally {
-				delete updating[serverId];
+			const prompted = await updateServer(server);
+			if (prompted) {
+				selected = {};
+				tableRef?.clearSelectAll();
+				return;
 			}
 		}
 
@@ -343,19 +337,44 @@
 		}
 	}
 
+	async function updateCatalogServerAndPromptForConfiguration(server: MCPCatalogServer) {
+		if (!isMultiUserServer(server) || !server.catalogEntryID) return false;
+
+		const entry = entriesMap[server.catalogEntryID];
+		if (!entry) {
+			// Without the entry manifest loaded, fall back to the plain update path.
+			if (server.powerUserWorkspaceID) {
+				await UserService.triggerWorkspaceMcpServerUpdate(
+					server.powerUserWorkspaceID,
+					server.catalogEntryID,
+					server.id
+				);
+			} else if (id) {
+				await AdminService.triggerMcpCatalogServerUpdate(id, server.id);
+			}
+			return false;
+		}
+
+		return (
+			(await editExistingDialog?.updateFromCatalogEntry({
+				server,
+				entry
+			})) ?? false
+		);
+	}
+
 	async function updateServer(server?: MCPCatalogServer) {
-		if (!server || !canTriggerUpdate(server)) return;
+		if (!server || !canTriggerUpdate(server)) return false;
+
 		updating[server.id] = { inProgress: true, error: '' };
+		let prompted = false;
 		try {
 			if (isMultiUserServer(server)) {
-				if (server.powerUserWorkspaceID) {
-					if (server.catalogEntryID) {
-						await UserService.triggerWorkspaceMcpServerUpdate(
-							server.powerUserWorkspaceID,
-							server.catalogEntryID,
-							server.id
-						);
-					}
+				if (server.catalogEntryID) {
+					// Catalog-backed multi-user servers may need shared config after the manifest update.
+					prompted = await updateCatalogServerAndPromptForConfiguration(server);
+				} else if (server.powerUserWorkspaceID) {
+					prompted = false;
 				} else if (id) {
 					await AdminService.triggerMcpCatalogServerUpdate(id, server.id);
 				}
@@ -371,6 +390,7 @@
 		}
 
 		delete updating[server.id];
+		return prompted;
 	}
 	async function updateK8sSettings(server?: MCPCatalogServer) {
 		if (!server) return;
@@ -1054,10 +1074,8 @@
 	{/snippet}
 	{#snippet note()}
 		<p class="text-sm font-light">
-			If this update introduces new required configuration parameters, users will have to supply
-			them before they can use {showUpgradeConfirm?.type === 'multi'
-				? 'these servers'
-				: 'this server'} again.
+			If this update introduces new required shared configuration parameters, you will be prompted
+			to supply them after the update is applied.
 		</p>
 	{/snippet}
 </Confirm>

--- a/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
+++ b/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
@@ -12,6 +12,7 @@
 		convertCompositeLaunchFormDataToPayload,
 		convertEnvHeadersToRecord,
 		getSecretBindingEngineError,
+		hasSecretBinding,
 		isKubernetesRuntimeBackend
 	} from '$lib/services/user/mcp';
 	import { version } from '$lib/stores';
@@ -33,6 +34,7 @@
 
 	let entry = $state<MCPCatalogEntry>();
 	let server = $state<MCPCatalogServer>();
+	let mode = $state<'edit' | 'catalog-update'>('edit');
 
 	let editingError = $state<string>();
 	let editingManifest = $derived(server?.manifest);
@@ -56,6 +58,7 @@
 	}) {
 		server = initServer;
 		entry = initEntry;
+		mode = 'edit';
 		editingError = isKubernetesRuntimeBackend(version.current.engine)
 			? undefined
 			: getSecretBindingEngineError(initServer.manifest);
@@ -92,6 +95,56 @@
 		configDialog?.open();
 	}
 
+	export async function updateFromCatalogEntry({
+		server: initServer,
+		entry: initEntry
+	}: {
+		server: MCPCatalogServer;
+		entry: MCPCatalogEntry;
+	}): Promise<boolean> {
+		server = initServer;
+		entry = initEntry;
+		mode = 'catalog-update';
+
+		// Apply the catalog manifest first; the updated server response tells us what is missing.
+		const updatedServer = await triggerCatalogUpdate(initServer);
+		server = updatedServer;
+		editingError = isKubernetesRuntimeBackend(version.current.engine)
+			? undefined
+			: getSecretBindingEngineError(updatedServer.manifest);
+
+		// Keep existing shared values so the dialog only asks for newly required input.
+		let values: Record<string, string>;
+		try {
+			values = await revealServerValues(updatedServer);
+		} catch (error) {
+			if (!(error instanceof HttpError) || error.statusCode !== 404) {
+				console.error('Failed to reveal server values due to unexpected error', error);
+			}
+			values = {};
+		}
+
+		const form: LaunchFormData = {
+			envs: updatedServer.manifest.env?.map((env) => ({
+				...env,
+				value: values[env.key] ?? ''
+			})),
+			headers: updatedServer.manifest.remoteConfig?.headers?.map((header) => ({
+				...header,
+				value: values[header.key] ?? '',
+				isStatic: header.value !== ''
+			}))
+		};
+
+		if (!hasMissingRequiredSharedConfiguration(updatedServer, form)) {
+			return false;
+		}
+
+		configureForm = form;
+		configDialog?.open();
+		return true;
+	}
+
 	async function revealServerValues(server: MCPCatalogServer) {
 		if (server.powerUserWorkspaceID) {
 			return UserService.revealWorkspaceMCPCatalogServer(server.powerUserWorkspaceID, server.id, {
@@ -119,6 +172,7 @@
 	}) {
 		server = initServer;
 		entry = initEntry;
+		mode = 'edit';
 
 		editAliasDialog?.open();
 	}
@@ -195,6 +249,61 @@
 		server = { ...server, alias };
 	}
 
+	function hasMissingRequiredSharedConfiguration(server: MCPCatalogServer, form: LaunchFormData) {
+		const missingKeys = new Set([
+			...(server.missingRequiredEnvVars ?? []),
+			...(server.missingRequiredHeader ?? [])
+		]);
+		if (missingKeys.size === 0) return false;
+
+		// Secret-bound and static values are managed outside this shared config form.
+		return [...(form.envs ?? []), ...(form.headers ?? [])].some(
+			(field) =>
+				missingKeys.has(field.key) &&
+				!hasSecretBinding(field) &&
+				!('isStatic' in field && field.isStatic) &&
+				field.required &&
+				!field.value
+		);
+	}
+
+	async function triggerCatalogUpdate(server: MCPCatalogServer): Promise<MCPCatalogServer> {
+		// trigger-update has no useful body, so fetch the scoped server after applying it.
+		if (server.powerUserWorkspaceID && server.catalogEntryID) {
+			await UserService.triggerWorkspaceMcpServerUpdate(
+				server.powerUserWorkspaceID,
+				server.catalogEntryID,
+				server.id
+			);
+			return UserService.getWorkspaceMCPCatalogServer(server.powerUserWorkspaceID, server.id);
+		}
+		if (server.mcpCatalogID) {
+			await AdminService.triggerMcpCatalogServerUpdate(server.mcpCatalogID, server.id);
+			return AdminService.getMCPCatalogServer(server.mcpCatalogID, server.id);
+		}
+		throw new Error('This server cannot be updated from the current view.');
+	}
+
+	async function configureSharedServer(server: MCPCatalogServer, envs: Record<string, string>) {
+		if (server.powerUserWorkspaceID) {
+			return UserService.configureWorkspaceMCPCatalogServer(
+				server.powerUserWorkspaceID,
+				server.id,
+				envs
+			);
+		}
+		if (server.mcpCatalogID) {
+			return AdminService.configureMCPCatalogServer(server.mcpCatalogID, server.id, envs);
+		}
+		throw new Error('This server cannot be configured from the current view.');
+	}
+
+	async function configureUpdatedCatalogServer(lf: LaunchFormData) {
+		if (!server) return;
+		const envs = convertEnvHeadersToRecord(lf.envs, lf.headers);
+		server = await configureSharedServer(server, envs);
+	}
+
 	async function updateExistingComposite(lf: CompositeLaunchFormData) {
 		if (!server) return;
 		// Composite flow using CatalogConfigureForm data
@@ -213,8 +322,10 @@
 		try {
 			configDialog?.close();
 			const { timeout1, timeout2, timeout3 } = initUpdatingOrLaunchProgress();
-			// updating existing
-			if (entry?.manifest.runtime === 'composite') {
+			if (mode === 'catalog-update') {
+				const lf = configureForm as LaunchFormData;
+				await configureUpdatedCatalogServer(lf);
+			} else if (entry?.manifest.runtime === 'composite') {
 				const lf = configureForm as CompositeLaunchFormData;
 				await updateExistingComposite(lf);
 			} else {
@@ -232,6 +343,7 @@
 			}, 1000);
 		} catch (_error) {
 			console.error('Error during configuration:', _error);
+			launchError = _error instanceof Error ? _error.message : 'An unknown error occurred';
 			configDialog?.close();
 		}
 	}
@@ -248,7 +360,8 @@
 	loading={editing}
 	disableSave={!!secretBindingEngineError}
 	isNew={false}
-	showAlias
+	showAlias={mode === 'edit'}
+	configurationTitle={mode === 'catalog-update' ? 'Required Configuration' : undefined}
 />
 
 <CatalogEditAliasForm bind:this={editAliasDialog} {server} {onUpdateConfigure} />
@@ -287,6 +400,8 @@
 					class="btn btn-primary w-full md:w-1/2 md:flex-1"
 					onclick={() => {
 						launchError = undefined;
+						editing = false;
+						launchProgress = 0;
 						configDialog?.open();
 					}}
 				>


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/6779

When you now call trigger-update on a multi-user server that was created from a multi-user catalog entry, we check after the update whether there are any new required configuration parameters, and prompt for them.

See it in action: https://www.loom.com/share/12058afd8a324034beebaaa893f5e9bd