### PR TITLE
fix: set composite shim container resources as remote

### DIFF
--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -1144,21 +1144,21 @@ func (k *kubernetesBackend) deleteDeploymentCache(mcpServerName string) {
 
 func mcpContainerResources(serverSpecificResources *corev1.ResourceRequirements, runtime types.Runtime, nanobotAgent bool, k8sSettings v1.K8sSettingsSpec) corev1.ResourceRequirements {
 	var defaults corev1.ResourceRequirements
-	if runtime == types.RuntimeRemote {
+	if runtime == types.RuntimeRemote || runtime == types.RuntimeComposite {
 		defaults = memoryRequestResources(remoteMemoryRequest)
 	} else if nanobotAgent {
 		if k8sSettings.NanobotAgentResources != nil {
-			defaults = withDefaultCPURequest(*k8sSettings.NanobotAgentResources)
+			defaults = *k8sSettings.NanobotAgentResources
 		} else {
 			defaults = memoryRequestResources(defaultAgentMemoryRequest)
 		}
 	} else if k8sSettings.Resources != nil {
-		defaults = withDefaultCPURequest(*k8sSettings.Resources)
+		defaults = *k8sSettings.Resources
 	} else {
 		defaults = memoryRequestResources(defaultMCPMemoryRequest)
 	}
 
-	return withServerResourceOverrides(defaults, serverSpecificResources)
+	return withServerResourceOverrides(withDefaultCPURequest(defaults), serverSpecificResources)
 }
 
 func withServerResourceOverrides(defaults corev1.ResourceRequirements, overrides *corev1.ResourceRequirements) corev1.ResourceRequirements {
@@ -1184,11 +1184,11 @@ func withServerResourceOverrides(defaults corev1.ResourceRequirements, overrides
 }
 
 func memoryRequestResources(memory resource.Quantity) corev1.ResourceRequirements {
-	return withDefaultCPURequest(corev1.ResourceRequirements{
+	return corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceMemory: memory,
 		},
-	})
+	}
 }
 
 func withDefaultCPURequest(resources corev1.ResourceRequirements) corev1.ResourceRequirements {

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -53,6 +53,14 @@ func TestComputeK8sSettingsHashUsesServerSpecificResources(t *testing.T) {
 		t.Fatalf("remote server hash = %s, want %s", got, remoteBaseHash)
 	}
 
+	compositeBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeComposite, false, nil)
+	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeComposite, false, nil); got != compositeBaseHash {
+		t.Fatalf("composite server hash = %s, want %s", got, compositeBaseHash)
+	}
+	if compositeBaseHash != remoteBaseHash {
+		t.Fatalf("composite base hash = %s, want remote base hash %s", compositeBaseHash, remoteBaseHash)
+	}
+
 	nanobotBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeNPX, true, nil)
 	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, true, nil); got != nanobotBaseHash {
 		t.Fatalf("nanobot agent server hash = %s, want %s before nanobot-only settings are set", got, nanobotBaseHash)
@@ -408,6 +416,23 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 				Spec: v1.K8sSettingsSpec{
 					Resources: &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("250Mi")},
+						Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+					},
+				},
+			},
+			wantMemoryRequest: "100Mi",
+		},
+		{
+			name: "composite runtime hard-codes 100Mi memory request",
+			server: ServerConfig{
+				Runtime: types.RuntimeComposite,
+			},
+			settings: &v1.K8sSettings{
+				ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+				Spec: v1.K8sSettingsSpec{
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("250Mi")},
+						Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
 					},
 				},
 			},


### PR DESCRIPTION
This change will ensure that the hard-coded remote resource requests are set for the composite shim container.

Issue: https://github.com/obot-platform/obot/issues/6797