### PR TITLE
fix: allow MCP OAuth tokens to access a very specific subset of paths

### DIFF
--- a/apiclient/types/user.go
+++ b/apiclient/types/user.go
@@ -40,6 +40,7 @@ const (
 	GroupAuthenticated         = "authenticated"
 	GroupAPIKey                = "api-key"
 	APIKeySkillsAccessExtraKey = "api-key-can-access-skills"
+	GroupMCPOAuth              = "mcp-oauth"
 )
 
 type Role int

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -221,8 +221,6 @@ var (
 			"GET /api/app-oauth/get-token/{id}",
 			"GET /api/app-oauth/get-token",
 
-			"POST /api/sendgrid",
-
 			"GET /api/healthz",
 
 			"GET /api/app-preferences",
@@ -263,7 +261,6 @@ var (
 
 		types.GroupBasic: {
 			"/api/llm-proxy/",
-			"POST /api/prompt",
 			"GET /api/models",
 			"GET /api/model-providers",
 			"GET /api/users",
@@ -354,6 +351,11 @@ var (
 			"GET /api/published-artifacts",
 		},
 
+		// These are the only generic paths that MCP OAuth tokens can access, plus those for the anyGroup
+		types.GroupMCPOAuth: {
+			"GET /oauth/userinfo",
+		},
+
 		MetricsGroup: {
 			"/debug/metrics",
 		},
@@ -399,17 +401,29 @@ func NewAuthorizer(cache, uncached kclient.Client, devMode bool, acrHelper *acce
 }
 
 func (a *Authorizer) Authorize(req *http.Request, user user.Info) bool {
-	if authorizeAPIKeySkillRoutes(req, user) {
+	isMCPOAuthUser := slices.Contains(user.GetGroups(), types.GroupMCPOAuth)
+	if !isMCPOAuthUser && authorizeAPIKeySkillRoutes(req, user) {
 		return true
 	}
 
-	userGroups := user.GetGroups()
+	var userGroups []string
+	if isMCPOAuthUser {
+		// MCP OAuth tokens can only access routes for that group or those for the anyGroup.
+		userGroups = []string{types.GroupMCPOAuth}
+	} else {
+		userGroups = user.GetGroups()
+	}
+
 	for _, r := range a.rules {
 		if r.group == anyGroup || slices.Contains(userGroups, r.group) {
 			if _, pattern := r.mux.Handler(req); pattern != "" {
 				return true
 			}
 		}
+	}
+
+	if isMCPOAuthUser {
+		return a.authorizeAPIResources(req, user)
 	}
 
 	return a.authorizeAPIResources(req, user) || a.checkOAuthClient(req) || a.checkUI(req, user)
@@ -458,21 +472,31 @@ func defaultRules(devMode bool, registryNoAuth bool) []rule {
 		rules = append(rules, rule)
 	}
 
-	var registryRule rule
+	var registryRuleBasic, registryRuleMCPOAuth rule
 	if registryNoAuth {
-		registryRule = rule{
+		registryRuleBasic = rule{
+			group: anyGroup,
+			mux:   http.NewServeMux(),
+		}
+		registryRuleMCPOAuth = rule{
 			group: anyGroup,
 			mux:   http.NewServeMux(),
 		}
 	} else {
-		registryRule = rule{
+		registryRuleBasic = rule{
 			group: types.GroupBasic,
 			mux:   http.NewServeMux(),
 		}
+		registryRuleMCPOAuth = rule{
+			group: types.GroupMCPOAuth,
+			mux:   http.NewServeMux(),
+		}
 	}
-	registryRule.mux.Handle("GET /v0.1", f)
-	registryRule.mux.Handle("GET /v0.1/", f)
-	rules = append(rules, registryRule)
+	registryRuleBasic.mux.Handle("GET /v0.1", f)
+	registryRuleBasic.mux.Handle("GET /v0.1/", f)
+	registryRuleMCPOAuth.mux.Handle("GET /v0.1", f)
+	registryRuleMCPOAuth.mux.Handle("GET /v0.1/", f)
+	rules = append(rules, registryRuleBasic, registryRuleMCPOAuth)
 
 	if devMode {
 		for group := range devModeRules {

--- a/pkg/api/authz/mcpoauth_test.go
+++ b/pkg/api/authz/mcpoauth_test.go
@@ -1,0 +1,302 @@
+package authz
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMCPOAuthGroupAllowsOnlyMCPOAuthAndAnyGroupRoutes(t *testing.T) {
+	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServerInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "msi1test",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.MCPServerInstanceSpec{
+			UserID: "mcpoauth-user-uid",
+		},
+	}).Build()
+	authorizer := NewAuthorizer(storage, storage, false, nil, false)
+	mcpoauthUser := &user.DefaultInfo{
+		Name:   "mcpoauth-user",
+		UID:    "mcpoauth-user-uid",
+		Groups: []string{types.GroupMCPOAuth},
+	}
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{
+			name:   "MCPOAuth static route",
+			method: http.MethodGet,
+			path:   "/oauth/userinfo",
+		},
+		{
+			name:   "anyGroup static route",
+			method: http.MethodGet,
+			path:   "/api/healthz",
+		},
+		{
+			name:   "anyGroup OAuth token route",
+			method: http.MethodPost,
+			path:   "/oauth/token",
+		},
+		{
+			name:   "MCPOAuth registry route",
+			method: http.MethodGet,
+			path:   "/v0.1/servers",
+		},
+		{
+			name:   "MCPOAuth MCP connect route",
+			method: http.MethodGet,
+			path:   "/mcp-connect/msi1test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			if allowed := authorizer.Authorize(req, mcpoauthUser); !allowed {
+				t.Fatalf("Authorize() = false, want true")
+			}
+		})
+	}
+}
+
+func TestMCPOAuthGroupDeniesOtherGroupsAndUIRoutes(t *testing.T) {
+	authorizer := NewAuthorizer(nil, nil, false, nil, false)
+	mcpoauthUserWithOtherGroups := &user.DefaultInfo{
+		Name: "mcpoauth-user",
+		UID:  "mcpoauth-user-uid",
+		Groups: []string{
+			types.GroupMCPOAuth,
+			types.GroupAuthenticated,
+			types.GroupBasic,
+			types.GroupPowerUser,
+			types.GroupPowerUserPlus,
+			types.GroupAuditor,
+			types.GroupAdmin,
+			types.GroupOwner,
+			types.GroupAPIKey,
+			MetricsGroup,
+		},
+		Extra: map[string][]string{
+			types.APIKeySkillsAccessExtraKey: {"true"},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{
+			name:   "authenticated route is denied",
+			method: http.MethodGet,
+			path:   "/api/me",
+		},
+		{
+			name:   "basic route is denied",
+			method: http.MethodGet,
+			path:   "/api/models",
+		},
+		{
+			name:   "admin route is denied",
+			method: http.MethodPatch,
+			path:   "/api/model-providers/provider-id",
+		},
+		{
+			name:   "API key optional skill route is denied",
+			method: http.MethodGet,
+			path:   "/api/skills",
+		},
+		{
+			name:   "metrics route is denied",
+			method: http.MethodGet,
+			path:   "/debug/metrics",
+		},
+		{
+			name:   "UI root is denied",
+			method: http.MethodGet,
+			path:   "/",
+		},
+		{
+			name:   "admin UI route is denied",
+			method: http.MethodGet,
+			path:   "/admin",
+		},
+		{
+			name:   "non-UI auth route from another group is denied",
+			method: http.MethodGet,
+			path:   "/auth/mcp/composite/msi1test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			if allowed := authorizer.Authorize(req, mcpoauthUserWithOtherGroups); allowed {
+				t.Fatalf("Authorize() = true, want false")
+			}
+		})
+	}
+}
+
+func TestMCPOAuthGroupDoesNotInheritStaticOrAPIResourceRulesFromOtherGroups(t *testing.T) {
+	authorizer := NewAuthorizer(nil, nil, false, nil, false)
+	mcpoauthUserWithAllGroups := &user.DefaultInfo{
+		Name: "mcpoauth-user",
+		UID:  "mcpoauth-user-uid",
+		Groups: []string{
+			types.GroupMCPOAuth,
+			types.GroupAuthenticated,
+			types.GroupBasic,
+			types.GroupPowerUser,
+			types.GroupPowerUserPlus,
+			types.GroupAuditor,
+			types.GroupAdmin,
+			types.GroupOwner,
+			types.GroupAPIKey,
+			MetricsGroup,
+		},
+		Extra: map[string][]string{
+			types.APIKeySkillsAccessExtraKey: {"true"},
+		},
+	}
+
+	allowedStaticPatterns := map[string]struct{}{}
+	for _, pattern := range staticRules[anyGroup] {
+		allowedStaticPatterns[canonicalAuthzPattern(pattern)] = struct{}{}
+	}
+	for _, pattern := range staticRules[types.GroupMCPOAuth] {
+		allowedStaticPatterns[canonicalAuthzPattern(pattern)] = struct{}{}
+	}
+
+	for group, patterns := range staticRules {
+		if group == anyGroup || group == types.GroupMCPOAuth {
+			continue
+		}
+
+		for _, pattern := range patterns {
+			pattern := pattern
+			if _, allowed := allowedStaticPatterns[canonicalAuthzPattern(pattern)]; allowed {
+				continue
+			}
+
+			t.Run("static "+group+" "+pattern, func(t *testing.T) {
+				req := requestForAuthzPattern(t, pattern)
+				if allowed := authorizer.Authorize(req, mcpoauthUserWithAllGroups); allowed {
+					t.Fatalf("Authorize(%s %s) = true, want false", req.Method, req.URL.Path)
+				}
+			})
+		}
+	}
+
+	allowedAPIResourcePatterns := map[string]struct{}{}
+	for pattern := range allowedStaticPatterns {
+		allowedAPIResourcePatterns[pattern] = struct{}{}
+	}
+	for _, pattern := range apiResources[types.GroupMCPOAuth] {
+		allowedAPIResourcePatterns[canonicalAuthzPattern(pattern)] = struct{}{}
+	}
+
+	for group, patterns := range apiResources {
+		if group == types.GroupMCPOAuth {
+			continue
+		}
+
+		for _, pattern := range patterns {
+			pattern := pattern
+			if _, allowed := allowedAPIResourcePatterns[canonicalAuthzPattern(pattern)]; allowed {
+				continue
+			}
+
+			t.Run("api resource "+group+" "+pattern, func(t *testing.T) {
+				req := requestForAuthzPattern(t, pattern)
+				if allowed := authorizer.Authorize(req, mcpoauthUserWithAllGroups); allowed {
+					t.Fatalf("Authorize(%s %s) = true, want false", req.Method, req.URL.Path)
+				}
+			})
+		}
+	}
+}
+
+func canonicalAuthzPattern(pattern string) string {
+	fields := strings.Fields(pattern)
+	if len(fields) == 2 && isHTTPMethod(fields[0]) {
+		return fields[0] + " " + fields[1]
+	}
+	return pattern
+}
+
+func requestForAuthzPattern(t *testing.T, pattern string) *http.Request {
+	t.Helper()
+
+	fields := strings.Fields(pattern)
+	method := http.MethodPatch
+	path := pattern
+	if len(fields) == 2 && isHTTPMethod(fields[0]) {
+		method = fields[0]
+		path = fields[1]
+	}
+
+	return httptest.NewRequest(method, sampleAuthzPath(path), nil)
+}
+
+func sampleAuthzPath(pattern string) string {
+	for {
+		start := strings.Index(pattern, "{")
+		if start == -1 {
+			return pattern
+		}
+
+		end := strings.Index(pattern[start:], "}")
+		if end == -1 {
+			return pattern
+		}
+
+		end += start
+		pattern = pattern[:start] + sampleAuthzPathValue(pattern[start+1:end]) + pattern[end+1:]
+	}
+}
+
+func sampleAuthzPathValue(name string) string {
+	switch name {
+	case "mcp_id", "mcp_server_instance_id":
+		return "msi1test"
+	case "mcpserver_id", "mcp_server_id":
+		return "ms1test"
+	case "namespace":
+		return system.DefaultNamespace
+	default:
+		return "test"
+	}
+}
+
+func isHTTPMethod(method string) bool {
+	switch method {
+	case http.MethodConnect,
+		http.MethodDelete,
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodOptions,
+		http.MethodPatch,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -137,6 +138,14 @@ var apiResources = map[string][]string{
 		"GET    /api/published-artifacts/{artifact_id}/download",
 		"GET    /api/published-artifacts/{artifact_id}/{artifact_version}/skill",
 	},
+	types.GroupMCPOAuth: {
+		"GET    /mcp-connect/{mcp_id}",
+		"POST   /mcp-connect/{mcp_id}",
+		"DELETE /mcp-connect/{mcp_id}",
+		"GET    /mcp-connect/{mcp_id}/",
+		"POST   /mcp-connect/{mcp_id}/",
+		"DELETE /mcp-connect/{mcp_id}/",
+	},
 }
 
 type Resources struct {
@@ -209,7 +218,15 @@ func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user user
 }
 
 func (a *Authorizer) authorizeAPIResources(req *http.Request, user user.Info) bool {
-	for _, group := range user.GetGroups() {
+	var userGroups []string
+	if slices.Contains(user.GetGroups(), types.GroupMCPOAuth) {
+		// MCP OAuth tokens can only access routes for that group or those for the anyGroup.
+		userGroups = []string{types.GroupMCPOAuth}
+	} else {
+		userGroups = user.GetGroups()
+	}
+
+	for _, group := range userGroups {
 		vars, matches := a.apiResources[group].Match(req)
 		if !matches {
 			continue

--- a/pkg/api/handlers/wellknown/oauth.go
+++ b/pkg/api/handlers/wellknown/oauth.go
@@ -42,9 +42,9 @@ func (h *handler) registryOAuthProtectedResource(req api.Context) error {
 		}
 	}
 
-	return req.Write(fmt.Sprintf(`{
-	"resource": "%s",
-	"authorization_servers": ["%[1]s"],
-	"bearer_methods_supported": ["header"]
-}`, h.baseURL))
+	return req.Write(map[string]any{
+		"resource":                 h.baseURL,
+		"authorization_servers":    []string{h.baseURL},
+		"bearer_methods_supported": []string{"header"},
+	})
 }

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -201,8 +201,6 @@ func (s *Server) Wrap(f api.HandlerFunc) http.HandlerFunc {
 				// Only set WWW-Authenticate if not in no-auth mode
 				if strings.HasPrefix(req.URL.Path, "/v0.1") && !s.registryNoAuth {
 					rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="MCP Registry", resource_metadata="%s/.well-known/oauth-protected-resource/v0.1/servers"`, strings.TrimSuffix(s.baseURL, "/api")))
-				} else if strings.HasPrefix(req.URL.Path, "/mcp-connect/") && user.GetUID() == "anonymous" {
-					rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error="invalid_request", error_description="Invalid access token", resource_metadata="%s/.well-known/oauth-protected-resource%s"%s`, strings.TrimSuffix(s.baseURL, "/api"), req.URL.Path, s.mcpOAuthScope))
 				}
 
 				if authenticated {

--- a/pkg/jwt/persistent/persistent.go
+++ b/pkg/jwt/persistent/persistent.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/MicahParks/jwkset"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/gateway/client"
@@ -42,13 +43,6 @@ func NewTokenService(serverURL string, gatewayClient *client.Client) (*TokenServ
 	}
 	return t, nil
 }
-
-type TokenType string
-
-const (
-	TokenTypeRun      TokenType = "run"
-	TokenTypeWorkflow TokenType = "workflow"
-)
 
 // EnsureJWK ensures that the JWK is created and stored. It should only be called in a controller post-start hook which only allows one to be run at a time.
 func (t *TokenService) EnsureJWK(ctx context.Context) error {
@@ -155,8 +149,6 @@ type TokenContext struct {
 	ModelProvider string
 	Model         string
 	Scope         string
-
-	TokenType TokenType
 }
 
 func (t *TokenService) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
@@ -173,58 +165,42 @@ func (t *TokenService) AuthenticateRequest(req *http.Request) (*authenticator.Re
 		return nil, false, nil
 	}
 
-	switch tokenContext.TokenType {
-	case TokenTypeRun:
-		return &authenticator.Response{
-			User: &user.DefaultInfo{
-				UID:    tokenContext.UserID,
-				Name:   tokenContext.Scope,
-				Groups: tokenContext.UserGroups,
-				Extra: map[string][]string{
-					"obot:userID":    {tokenContext.UserID},
-					"obot:userName":  {tokenContext.UserName},
-					"obot:userEmail": {tokenContext.UserEmail},
-				},
-			},
-		}, true, nil
-	default:
-		extra := map[string][]string{
-			"email":                   {tokenContext.UserEmail},
-			"auth_provider_name":      {tokenContext.AuthProviderName},
-			"auth_provider_namespace": {tokenContext.AuthProviderNamespace},
-			"mcp_id":                  {tokenContext.MCPID},
-			"resource":                {tokenContext.Audience},
-			"oauthScope":              {tokenContext.OAuthScope},
-		}
-		groups := tokenContext.UserGroups
+	extra := map[string][]string{
+		"email":                   {tokenContext.UserEmail},
+		"auth_provider_name":      {tokenContext.AuthProviderName},
+		"auth_provider_namespace": {tokenContext.AuthProviderNamespace},
+		"mcp_id":                  {tokenContext.MCPID},
+		"resource":                {tokenContext.Audience},
+		"oauthScope":              {tokenContext.OAuthScope},
+	}
+	groups := tokenContext.UserGroups
 
-		// Look up auth provider group memberships from the gateway DB
-		if userID, err := strconv.ParseUint(tokenContext.UserID, 10, 64); err == nil {
-			if authGroupIDs, err := t.gatewayClient.ListGroupIDsForUser(req.Context(), uint(userID)); err != nil {
-				log.Warnf("failed to list auth provider groups for user %s: %s", tokenContext.UserID, err.Error())
+	// Look up auth provider group memberships from the gateway DB
+	if userID, err := strconv.ParseUint(tokenContext.UserID, 10, 64); err == nil {
+		if authGroupIDs, err := t.gatewayClient.ListGroupIDsForUser(req.Context(), uint(userID)); err != nil {
+			log.Warnf("failed to list auth provider groups for user %s: %s", tokenContext.UserID, err.Error())
+		} else {
+			extra["auth_provider_groups"] = authGroupIDs
+
+			// Resolve effective role by merging individual + group roles
+			if gatewayUser, err := t.gatewayClient.UserByID(req.Context(), tokenContext.UserID); err != nil {
+				log.Warnf("failed to look up user %s for role resolution: %s", tokenContext.UserID, err.Error())
+			} else if effectiveRole, err := t.gatewayClient.ResolveUserEffectiveRole(req.Context(), gatewayUser, authGroupIDs); err != nil {
+				log.Warnf("failed to resolve effective role for user %s: %s", tokenContext.UserID, err.Error())
 			} else {
-				extra["auth_provider_groups"] = authGroupIDs
-
-				// Resolve effective role by merging individual + group roles
-				if gatewayUser, err := t.gatewayClient.UserByID(req.Context(), tokenContext.UserID); err != nil {
-					log.Warnf("failed to look up user %s for role resolution: %s", tokenContext.UserID, err.Error())
-				} else if effectiveRole, err := t.gatewayClient.ResolveUserEffectiveRole(req.Context(), gatewayUser, authGroupIDs); err != nil {
-					log.Warnf("failed to resolve effective role for user %s: %s", tokenContext.UserID, err.Error())
-				} else {
-					groups = effectiveRole.Groups()
-				}
+				groups = effectiveRole.Groups()
 			}
 		}
-
-		return &authenticator.Response{
-			User: &user.DefaultInfo{
-				UID:    tokenContext.UserID,
-				Name:   tokenContext.UserName,
-				Groups: groups,
-				Extra:  extra,
-			},
-		}, true, nil
 	}
+
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			UID:    tokenContext.UserID,
+			Name:   tokenContext.UserName,
+			Groups: append(groups, types.GroupMCPOAuth),
+			Extra:  extra,
+		},
+	}, true, nil
 }
 
 func (t *TokenService) DecodeToken(ctx context.Context, token string) (*TokenContext, error) {
@@ -294,7 +270,6 @@ func (t *TokenService) DecodeToken(ctx context.Context, token string) (*TokenCon
 		ModelProvider:         getStringClaim("ModelProvider"),
 		Model:                 getStringClaim("Model"),
 		Scope:                 getStringClaim("Scope"),
-		TokenType:             TokenType(getStringClaim("TokenType")),
 		// These two fields were the latter names and changed the former.
 		// This makes this backwards compatible with older tokens.
 		UserName:  getStringClaim("name", "UserName"),
@@ -326,7 +301,6 @@ func (t *TokenService) NewToken(ctx context.Context, context TokenContext) (stri
 		"ModelProvider":         context.ModelProvider,
 		"Model":                 context.Model,
 		"Scope":                 context.Scope,
-		"TokenType":             string(context.TokenType),
 	}
 
 	_, s, err := t.NewTokenWithClaims(ctx, claims)


### PR DESCRIPTION
This change allows MCP OAuth tokens to only access a very small portion of paths that are necessary. This is so that MCP clients don't have access to the Obot API.