### PR TITLE
fix: licensing bugfixes

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -51,7 +51,8 @@ var (
 		"GET /debug/pprof/",
 		"GET /debug/triggers",
 		"GET /debug/metrics",
-		"/api/license",
+		"PUT /api/license",
+		"DELETE /api/license",
 		"/api/auth-providers",
 		"/api/auth-providers/",
 		"/api/model-providers",
@@ -335,6 +336,7 @@ var (
 			"POST /api/logout-all",
 			"GET /api/version",
 			"GET /api/default-k8s-settings",
+			"GET /api/license",
 			"GET /api/setup/oauth-complete",
 
 			// API key management for user's own keys

--- a/pkg/api/handlers/license.go
+++ b/pkg/api/handlers/license.go
@@ -95,11 +95,8 @@ func displayLicenseKey(licenseKey string, canViewPartial bool) string {
 	if licenseKey == "" {
 		return ""
 	}
-	if !canViewPartial {
+	if !canViewPartial || len(licenseKey) <= licenseKeyVisibleSuffix {
 		return licenseKeyMask
-	}
-	if len(licenseKey) <= licenseKeyVisibleSuffix {
-		return licenseKeyMask + licenseKey
 	}
 	return licenseKeyMask + licenseKey[len(licenseKey)-licenseKeyVisibleSuffix:]
 }

--- a/pkg/api/handlers/license.go
+++ b/pkg/api/handlers/license.go
@@ -75,7 +75,7 @@ func (h *LicenseHandler) Delete(req api.Context) error {
 func (h *LicenseHandler) status(req api.Context) LicenseStatus {
 	licenseKey := h.licenseProvider.LicenseKey()
 	status := LicenseStatus{
-		LicenseKey:   displayLicenseKey(licenseKey, req.UserIsAdmin() || req.UserIsOwner()),
+		LicenseKey:   displayLicenseKey(licenseKey, req.UserIsAdmin()),
 		Locked:       h.licenseProvider.LicenseKeyViaConfiguration(),
 		Enterprise:   h.licenseProvider.HasValidLicense(),
 		Entitlements: h.licenseProvider.Entitlements(),

--- a/pkg/api/handlers/license.go
+++ b/pkg/api/handlers/license.go
@@ -25,12 +25,17 @@ type LicenseUpdate struct {
 	LicenseKey string `json:"licenseKey"`
 }
 
+const (
+	licenseKeyMask          = "****"
+	licenseKeyVisibleSuffix = 8
+)
+
 func NewLicenseHandler(licenseProvider *license.KeygenProvider) *LicenseHandler {
 	return &LicenseHandler{licenseProvider: licenseProvider}
 }
 
 func (h *LicenseHandler) Get(req api.Context) error {
-	return req.Write(h.status())
+	return req.Write(h.status(req))
 }
 
 func (h *LicenseHandler) Update(req api.Context) error {
@@ -53,7 +58,7 @@ func (h *LicenseHandler) Update(req api.Context) error {
 		return err
 	}
 
-	return req.Write(h.status())
+	return req.Write(h.status(req))
 }
 
 func (h *LicenseHandler) Delete(req api.Context) error {
@@ -64,12 +69,13 @@ func (h *LicenseHandler) Delete(req api.Context) error {
 		return err
 	}
 
-	return req.Write(h.status())
+	return req.Write(h.status(req))
 }
 
-func (h *LicenseHandler) status() LicenseStatus {
+func (h *LicenseHandler) status(req api.Context) LicenseStatus {
+	licenseKey := h.licenseProvider.LicenseKey()
 	status := LicenseStatus{
-		LicenseKey:   h.licenseProvider.LicenseKey(),
+		LicenseKey:   displayLicenseKey(licenseKey, req.UserIsAdmin() || req.UserIsOwner()),
 		Locked:       h.licenseProvider.LicenseKeyViaConfiguration(),
 		Enterprise:   h.licenseProvider.HasValidLicense(),
 		Entitlements: h.licenseProvider.Entitlements(),
@@ -77,9 +83,23 @@ func (h *LicenseHandler) status() LicenseStatus {
 
 	if status.Locked {
 		status.Source = "config"
-	} else if status.LicenseKey != "" {
+	} else if licenseKey != "" {
 		status.Source = "database"
 	}
 
 	return status
+}
+
+func displayLicenseKey(licenseKey string, canViewPartial bool) string {
+	licenseKey = strings.TrimSpace(licenseKey)
+	if licenseKey == "" {
+		return ""
+	}
+	if !canViewPartial {
+		return licenseKeyMask
+	}
+	if len(licenseKey) <= licenseKeyVisibleSuffix {
+		return licenseKeyMask + licenseKey
+	}
+	return licenseKeyMask + licenseKey[len(licenseKey)-licenseKeyVisibleSuffix:]
 }

--- a/pkg/api/handlers/license_test.go
+++ b/pkg/api/handlers/license_test.go
@@ -1,0 +1,54 @@
+package handlers
+
+import "testing"
+
+func TestDisplayLicenseKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		licenseKey     string
+		canViewPartial bool
+		want           string
+	}{
+		{
+			name:           "empty key",
+			licenseKey:     "",
+			canViewPartial: true,
+			want:           "",
+		},
+		{
+			name:           "non admin masks key",
+			licenseKey:     "keygen/abc123invalid",
+			canViewPartial: false,
+			want:           licenseKeyMask,
+		},
+		{
+			name:           "admin shows suffix",
+			licenseKey:     "keygen/abc123j13lasds",
+			canViewPartial: true,
+			want:           "****j13lasds",
+		},
+		{
+			name:           "admin short key shows full suffix",
+			licenseKey:     "shortkey",
+			canViewPartial: true,
+			want:           "****shortkey",
+		},
+		{
+			name:           "trims whitespace",
+			licenseKey:     "  keygen/license-key  ",
+			canViewPartial: false,
+			want:           licenseKeyMask,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := displayLicenseKey(tt.licenseKey, tt.canViewPartial); got != tt.want {
+				t.Fatalf("displayLicenseKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/handlers/license_test.go
+++ b/pkg/api/handlers/license_test.go
@@ -30,10 +30,10 @@ func TestDisplayLicenseKey(t *testing.T) {
 			want:           "****j13lasds",
 		},
 		{
-			name:           "admin short key shows full suffix",
+			name:           "admin short key is fully masked",
 			licenseKey:     "shortkey",
 			canViewPartial: true,
-			want:           "****shortkey",
+			want:           licenseKeyMask,
 		},
 		{
 			name:           "trims whitespace",

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -722,7 +722,7 @@
 			<div class="sticky top-0 left-0 z-50 w-full">
 				{#if banner}
 					{@render banner()}
-				{:else if isAdminRoute && version.current.licenseEntitlementViolations}
+				{:else if version.current.licenseEntitlementViolations}
 					<LicenseViolationBanner />
 				{/if}
 				<Navbar class={twMerge('dark:bg-base-100', classes?.navbar)} {hideProfileButton}>

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -6,7 +6,9 @@
 		'mcp-server-management': true,
 		'skills-management': true,
 		'device-management': true,
-		'user-management': true
+		'user-management': true,
+		'llm-gateway': true,
+		advanced: true
 	};
 
 	function readNavCollapsedFromStorage(): Record<string, boolean> {
@@ -722,7 +724,7 @@
 			<div class="sticky top-0 left-0 z-50 w-full">
 				{#if banner}
 					{@render banner()}
-				{:else if version.current.licenseEntitlementViolations}
+				{:else if (version.current.licenseEntitlementViolations?.length ?? 0) > 0}
 					<LicenseViolationBanner />
 				{/if}
 				<Navbar class={twMerge('dark:bg-base-100', classes?.navbar)} {hideProfileButton}>

--- a/ui/user/src/lib/components/Tour.svelte
+++ b/ui/user/src/lib/components/Tour.svelte
@@ -33,7 +33,7 @@
 	});
 
 	const correctRoute = $derived(
-		['/admin/dashboard', '/admin/mcp-servers', '/mcp-servers'].includes(page.url.pathname)
+		['/admin/dashboard', '/admin/mcp-catalog', '/mcp-catalog'].includes(page.url.pathname)
 	);
 
 	const POPOVER_CLASS = 'w-2xl! max-w-2xl! min-w-2xl!';

--- a/ui/user/src/lib/components/admin/ProviderDeconfigureConfirm.svelte
+++ b/ui/user/src/lib/components/admin/ProviderDeconfigureConfirm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Loading from '$lib/icons/Loading.svelte';
-	import type { AuthProvider } from '$lib/services';
+	import type { AuthProvider, ModelProvider } from '$lib/services';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 
 	interface Props {
@@ -8,7 +8,7 @@
 		onCancel: () => void | Promise<void>;
 		loading?: boolean;
 		title?: string;
-		provider?: AuthProvider;
+		provider?: AuthProvider | ModelProvider;
 		confirmButtonText?: string;
 	}
 
@@ -21,21 +21,21 @@
 		confirmButtonText = 'Deconfigure'
 	}: Props = $props();
 
-	let authDeconfigureConfirmDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let providerDeconfigureConfirmDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let confirmationInput = $state('');
 
 	export function open() {
 		confirmationInput = '';
-		authDeconfigureConfirmDialog?.open();
+		providerDeconfigureConfirmDialog?.open();
 	}
 
 	export function close() {
-		authDeconfigureConfirmDialog?.close();
+		providerDeconfigureConfirmDialog?.close();
 	}
 </script>
 
 <ResponsiveDialog
-	bind:this={authDeconfigureConfirmDialog}
+	bind:this={providerDeconfigureConfirmDialog}
 	{title}
 	classes={{
 		header: 'border-t-4 border-error px-4 pt-4 md:pb-0',
@@ -46,10 +46,11 @@
 	<div class="flex h-full">
 		<div class="px-4 py-4 md:py-0 flex flex-col gap-4 h-full">
 			<p>
-				This action will deconfigure {provider?.name || 'this provider'}. This action cannot be
-				undone. Are you sure you wish to continue?
+				{#if provider}This action will deconfigure {provider?.name || 'this provider'}.{/if} This action
+				cannot be undone. Are you sure you wish to continue?
 			</p>
 			<div class="p-4 bg-error/10 text-error rounded-md text-sm">
+				<!-- provider is AuthProvider -->
 				<p class="mb-2">
 					Deconfiguring <b>{provider?.name || 'this provider'}</b> will result in the following:
 				</p>
@@ -69,13 +70,15 @@
 				</ul>
 			</div>
 
-			<div class="flex flex-col gap-1">
-				<p>
-					Type the provider ID <code class="text-xs p-1 bg-base-200">{provider?.id}</code> to confirm.
-				</p>
+			{#if provider}
+				<div class="flex flex-col gap-1">
+					<p>
+						Type the provider ID <code class="text-xs p-1 bg-base-200">{provider?.id}</code> to confirm.
+					</p>
 
-				<input type="text" class="input-text-filled w-full" bind:value={confirmationInput} />
-			</div>
+					<input type="text" class="input-text-filled w-full" bind:value={confirmationInput} />
+				</div>
+			{/if}
 			<div class="md:hidden flex grow"></div>
 			<div class="flex gap-4 w-full pt-4 md:py-4">
 				<button class="btn btn-secondary flex-1" disabled={loading} onclick={onCancel}
@@ -83,7 +86,7 @@
 				>
 				<button
 					class="btn btn-error btn-soft flex-1"
-					disabled={loading || !provider || confirmationInput !== provider.id}
+					disabled={loading || (provider && confirmationInput !== provider.id)}
 					onclick={onConfirm}
 				>
 					{#if loading}

--- a/ui/user/src/lib/components/admin/license/LicenseDowngradeDialog.svelte
+++ b/ui/user/src/lib/components/admin/license/LicenseDowngradeDialog.svelte
@@ -137,7 +137,10 @@
 <AuthDeconfigureConfirm
 	bind:this={confirmDowngradeDialog}
 	onConfirm={handleDowngrade}
-	onCancel={() => licenseViolationDialog?.open()}
+	onCancel={() => {
+		confirmDowngradeDialog?.close();
+		licenseViolationDialog?.open();
+	}}
 	loading={downgrading}
 	provider={authProviderToDeconfigure}
 	title="Confirm Downgrade"

--- a/ui/user/src/lib/components/admin/license/LicenseDowngradeDialog.svelte
+++ b/ui/user/src/lib/components/admin/license/LicenseDowngradeDialog.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import ProviderDeconfigureConfirm from '$lib/components/admin/ProviderDeconfigureConfirm.svelte';
-	import { AdminService, type AuthProvider, type LicenseEntitlementViolation } from '$lib/services';
+	import {
+		AdminService,
+		type AuthProvider,
+		type LicenseEntitlementViolation,
+		type ModelProvider
+	} from '$lib/services';
 	import { version, darkMode } from '$lib/stores';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte';
 	import { success } from '$lib/stores/success';
@@ -10,8 +15,7 @@
 
 	let licenseViolationDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let confirmDowngradeDialog = $state<ReturnType<typeof ProviderDeconfigureConfirm>>();
-
-	let authProviderToDeconfigure = $state<AuthProvider | undefined>();
+	let providerToDeconfigure = $state<AuthProvider | ModelProvider | undefined>();
 
 	let downgrading = $state(false);
 	let error = $state('');
@@ -134,12 +138,16 @@
 					const authProviderName = version.current.licenseEntitlementViolations?.find(
 						(violation) => violation.type === 'authProvider'
 					)?.name;
+					const modelProviderName = version.current.licenseEntitlementViolations?.find(
+						(violation) => violation.type === 'modelProvider'
+					)?.name;
 					const authProvider = $adminConfigStore.authProviders.find(
 						(p) => p.id === authProviderName
 					);
-					if (authProvider) {
-						authProviderToDeconfigure = authProvider;
-					}
+					const modelProvider = $adminConfigStore.modelProviders.find(
+						(p) => p.id === modelProviderName
+					);
+					providerToDeconfigure = authProvider || modelProvider;
 					confirmDowngradeDialog?.open();
 				}}
 			>
@@ -157,7 +165,7 @@
 		licenseViolationDialog?.open();
 	}}
 	loading={downgrading}
-	provider={authProviderToDeconfigure}
+	provider={providerToDeconfigure}
 	title="Confirm Downgrade"
 	confirmButtonText="Downgrade"
 />

--- a/ui/user/src/lib/components/admin/license/LicenseDowngradeDialog.svelte
+++ b/ui/user/src/lib/components/admin/license/LicenseDowngradeDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
-	import AuthDeconfigureConfirm from '$lib/components/admin/AuthDeconfigureConfirm.svelte';
-	import { AdminService, type AuthProvider } from '$lib/services';
+	import ProviderDeconfigureConfirm from '$lib/components/admin/ProviderDeconfigureConfirm.svelte';
+	import { AdminService, type AuthProvider, type LicenseEntitlementViolation } from '$lib/services';
 	import { version, darkMode } from '$lib/stores';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte';
 	import { success } from '$lib/stores/success';
@@ -9,7 +9,7 @@
 	import { slide } from 'svelte/transition';
 
 	let licenseViolationDialog = $state<ReturnType<typeof ResponsiveDialog>>();
-	let confirmDowngradeDialog = $state<ReturnType<typeof AuthDeconfigureConfirm>>();
+	let confirmDowngradeDialog = $state<ReturnType<typeof ProviderDeconfigureConfirm>>();
 
 	let authProviderToDeconfigure = $state<AuthProvider | undefined>();
 
@@ -31,12 +31,27 @@
 
 		downgrading = true;
 		try {
-			for (const provider of version.current.licenseEntitlementViolations) {
-				if (provider.type === 'authProvider') {
-					await AdminService.deconfigureAuthProvider(provider.name);
-				} else if (provider.type === 'modelProvider') {
-					await AdminService.deconfigureModelProvider(provider.name);
-				}
+			// do model provider deconfigures first, then auth provider deconfigures
+			const { modelProviderViolations, authProviderViolations } =
+				version.current.licenseEntitlementViolations.reduce<{
+					modelProviderViolations: LicenseEntitlementViolation[];
+					authProviderViolations: LicenseEntitlementViolation[];
+				}>(
+					(acc, provider) => {
+						if (provider.type === 'modelProvider') {
+							acc.modelProviderViolations.push(provider);
+						} else if (provider.type === 'authProvider') {
+							acc.authProviderViolations.push(provider);
+						}
+						return acc;
+					},
+					{ modelProviderViolations: [], authProviderViolations: [] }
+				);
+			for (const modelProvider of modelProviderViolations) {
+				await AdminService.deconfigureModelProvider(modelProvider.name);
+			}
+			for (const authProvider of authProviderViolations) {
+				await AdminService.deconfigureAuthProvider(authProvider.name);
 			}
 
 			const modelProviders = await AdminService.listModelProviders();
@@ -134,7 +149,7 @@
 	</div>
 </ResponsiveDialog>
 
-<AuthDeconfigureConfirm
+<ProviderDeconfigureConfirm
 	bind:this={confirmDowngradeDialog}
 	onConfirm={handleDowngrade}
 	onCancel={() => {

--- a/ui/user/src/lib/components/admin/license/LicenseViolationBanner.svelte
+++ b/ui/user/src/lib/components/admin/license/LicenseViolationBanner.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { MCP_CONNECTION_INVALID_LICENSE_MESSAGE } from '$lib/services/user/constants';
-	import { license, version, profile } from '$lib/stores';
+	import { license, profile } from '$lib/stores';
 	import LicenseDowngradeDialog from './LicenseDowngradeDialog.svelte';
 	import { ShieldAlert } from 'lucide-svelte';
 
@@ -8,26 +8,25 @@
 	let licenseKey = $derived(license.current.licenseKey);
 </script>
 
-{#if version.current.licenseEntitlementViolations}
-	<div class="bg-base-100">
-		<div class="bg-warning/10 text-warning px-4 py-2 flex justify-between md:justify-center gap-2">
-			<div class="flex items-center gap-4 md:gap-0.5 justify-center">
-				<ShieldAlert class="text-warning size-4 shrink-0" />
-				<p class="text-xs">
-					{#if profile.current.hasAdminAccess?.()}
-						Your license is <b class="font-semibold uppercase"
-							>{licenseKey ? 'invalid' : 'missing'}</b
-						>. For full functionality, it is recommended to resolve the outstanding issues.
-					{:else}
-						{MCP_CONNECTION_INVALID_LICENSE_MESSAGE}
-					{/if}
-				</p>
-			</div>
+<div class="bg-base-100">
+	<div class="bg-warning/10 text-warning px-4 py-2 flex justify-between md:justify-center gap-2">
+		<div class="flex items-center gap-4 md:gap-0.5 justify-center">
+			<ShieldAlert class="text-warning size-4 shrink-0" />
+			<p class="text-xs">
+				{#if profile.current.hasAdminAccess?.()}
+					Your license is <b class="font-semibold uppercase">{licenseKey ? 'invalid' : 'missing'}</b
+					>. For full functionality, it is recommended to resolve the outstanding issues.
+				{:else}
+					{MCP_CONNECTION_INVALID_LICENSE_MESSAGE}
+				{/if}
+			</p>
+		</div>
+		{#if profile.current.hasAdminAccess?.()}
 			<button class="btn btn-xs btn-warning" onclick={() => downgradeDialog?.open()}>
 				Resolve
 			</button>
-		</div>
+		{/if}
 	</div>
+</div>
 
-	<LicenseDowngradeDialog bind:this={downgradeDialog} />
-{/if}
+<LicenseDowngradeDialog bind:this={downgradeDialog} />

--- a/ui/user/src/lib/components/admin/license/LicenseViolationBanner.svelte
+++ b/ui/user/src/lib/components/admin/license/LicenseViolationBanner.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { version } from '$lib/stores';
+	import { license, version } from '$lib/stores';
 	import LicenseDowngradeDialog from './LicenseDowngradeDialog.svelte';
 	import { ShieldAlert } from 'lucide-svelte';
 
 	let downgradeDialog = $state<ReturnType<typeof LicenseDowngradeDialog>>();
+	let licenseKey = $derived(license.current.licenseKey);
 </script>
 
 {#if version.current.licenseEntitlementViolations}
@@ -12,8 +13,8 @@
 			<div class="flex items-center gap-4 md:gap-0.5 justify-center">
 				<ShieldAlert class="text-warning size-4 shrink-0" />
 				<p class="text-xs">
-					Your license is <b class="font-semibold uppercase">invalid</b>. For full functionality, it
-					is recommended to resolve the outstanding issues.
+					Your license is <b class="font-semibold uppercase">{licenseKey ? 'invalid' : 'missing'}</b
+					>. For full functionality, it is recommended to resolve the outstanding issues.
 				</p>
 			</div>
 			<button class="btn btn-xs btn-warning" onclick={() => downgradeDialog?.open()}>

--- a/ui/user/src/lib/components/admin/license/LicenseViolationBanner.svelte
+++ b/ui/user/src/lib/components/admin/license/LicenseViolationBanner.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { MCP_CONNECTION_INVALID_LICENSE_MESSAGE } from '$lib/services/user/constants';
 	import { license, version, profile } from '$lib/stores';
 	import LicenseDowngradeDialog from './LicenseDowngradeDialog.svelte';
 	import { ShieldAlert } from 'lucide-svelte';
@@ -17,8 +18,9 @@
 						Your license is <b class="font-semibold uppercase"
 							>{licenseKey ? 'invalid' : 'missing'}</b
 						>. For full functionality, it is recommended to resolve the outstanding issues.
-					{:else}We're sorry, this system is currently operating with limited functionality. Please
-						contact your administrator.{/if}
+					{:else}
+						{MCP_CONNECTION_INVALID_LICENSE_MESSAGE}
+					{/if}
 				</p>
 			</div>
 			<button class="btn btn-xs btn-warning" onclick={() => downgradeDialog?.open()}>

--- a/ui/user/src/lib/components/admin/license/LicenseViolationBanner.svelte
+++ b/ui/user/src/lib/components/admin/license/LicenseViolationBanner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { license, version } from '$lib/stores';
+	import { license, version, profile } from '$lib/stores';
 	import LicenseDowngradeDialog from './LicenseDowngradeDialog.svelte';
 	import { ShieldAlert } from 'lucide-svelte';
 
@@ -13,8 +13,12 @@
 			<div class="flex items-center gap-4 md:gap-0.5 justify-center">
 				<ShieldAlert class="text-warning size-4 shrink-0" />
 				<p class="text-xs">
-					Your license is <b class="font-semibold uppercase">{licenseKey ? 'invalid' : 'missing'}</b
-					>. For full functionality, it is recommended to resolve the outstanding issues.
+					{#if profile.current.hasAdminAccess?.()}
+						Your license is <b class="font-semibold uppercase"
+							>{licenseKey ? 'invalid' : 'missing'}</b
+						>. For full functionality, it is recommended to resolve the outstanding issues.
+					{:else}We're sorry, this system is currently operating with limited functionality. Please
+						contact your administrator.{/if}
 				</p>
 			</div>
 			<button class="btn btn-xs btn-warning" onclick={() => downgradeDialog?.open()}>

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -10,6 +10,7 @@
 		type MCPCatalogServer,
 		type MCPServerInstance
 	} from '$lib/services';
+	import { MCP_CONNECTION_INVALID_LICENSE_MESSAGE } from '$lib/services/user/constants';
 	import {
 		deleteMcpServerDeployment,
 		disconnectMcpServerUser,
@@ -303,8 +304,9 @@
 					(server.catalogEntryID && server.userID === profile.current.id)))
 		)}
 		use:tooltip={{
-			text:
-				isMultiUserCatalogEntryRow && !catalogID && !workspaceID
+			text: hasLicenseEntitlementViolations
+				? MCP_CONNECTION_INVALID_LICENSE_MESSAGE
+				: isMultiUserCatalogEntryRow && !catalogID && !workspaceID
 					? 'This is a multi-user catalog entry. An administrator must deploy it before you can connect.'
 					: canConnect
 						? ''
@@ -344,6 +346,7 @@
 			}
 		}}
 		disabled={loading ||
+			hasLicenseEntitlementViolations ||
 			(isMultiUserCatalogEntryRow && !catalogID && !workspaceID) ||
 			!canConnect ||
 			(requiresStaticOAuth && oauthConfigured === false)}
@@ -352,7 +355,7 @@
 			<Loading class="size-4" />
 		{:else if isMultiUserCatalogEntryRow && configuredServers.length === 0}
 			Create Server
-		{:else if !hasLicenseEntitlementViolations}
+		{:else}
 			Connect To Server
 		{/if}
 	</button>
@@ -487,13 +490,20 @@
 				Your server has been configured.
 			{/if}
 		</p>
-		<p class="mb-2 text-center">
-			{#if isMultiUserCatalogEntry(entry)}
-				Would you like to launch a server now?
-			{:else}
-				Would you like to connect now?
-			{/if}
-		</p>
+		{#if hasLicenseEntitlementViolations}
+			<p class="mb-2 text-center text-muted-content">
+				Connection is currently disabled due to limited functionality. Resolve existing licensing
+				issues to re-enable this feature.
+			</p>
+		{:else}
+			<p class="mb-2 text-center">
+				{#if isMultiUserCatalogEntry(entry)}
+					Would you like to launch a server now?
+				{:else}
+					Would you like to connect now?
+				{/if}
+			</p>
+		{/if}
 		<div class="flex grow"></div>
 		<div class="flex flex-col gap-2">
 			<button class="btn btn-secondary" onclick={() => launchDialog?.close()}>Skip</button>
@@ -506,6 +516,7 @@
 						server
 					});
 				}}
+				disabled={hasLicenseEntitlementViolations}
 			>
 				{#if isMultiUserCatalogEntry(entry)}
 					Launch Server

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -20,7 +20,7 @@
 		requiresUserUpdate,
 		restartMcpServer
 	} from '$lib/services/user/mcp';
-	import { mcpServersAndEntries, profile } from '$lib/stores';
+	import { mcpServersAndEntries, profile, version } from '$lib/stores';
 	import { formatTimeAgo } from '$lib/time';
 	import { goto } from '$lib/url';
 	import DotDotDot from '../DotDotDot.svelte';
@@ -181,6 +181,9 @@
 	);
 	let canCreateAnotherMultiUserServer = $derived(
 		isMultiUserCatalogEntry(entry) && (!!catalogID || !!workspaceID) && configuredServers.length > 0
+	);
+	let hasLicenseEntitlementViolations = $derived(
+		(version.current.licenseEntitlementViolations || []).length > 0
 	);
 	let hasActions = $derived.by(() => {
 		return Boolean(
@@ -349,7 +352,7 @@
 			<Loading class="size-4" />
 		{:else if isMultiUserCatalogEntryRow && configuredServers.length === 0}
 			Create Server
-		{:else}
+		{:else if !hasLicenseEntitlementViolations}
 			Connect To Server
 		{/if}
 	</button>

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -1923,10 +1923,6 @@ export async function listAllUserWorkspaceAccessControlRules(opts?: { fetch?: Fe
 
 // License
 
-export async function getLicense(opts?: { fetch?: Fetcher }): Promise<License> {
-	return (await doGet('/license', opts)) as License;
-}
-
 export async function deleteLicense(): Promise<void> {
 	await doDelete('/license');
 }

--- a/ui/user/src/lib/services/user/constants.ts
+++ b/ui/user/src/lib/services/user/constants.ts
@@ -1,0 +1,2 @@
+export const MCP_CONNECTION_INVALID_LICENSE_MESSAGE =
+	"We're sorry, this system is currently operating with limited functionality. Please contact your administrator.";

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -5,6 +5,7 @@ import { Group } from '$lib/services/admin/types';
 import { buildQueryString } from '$lib/url';
 import type {
 	AuthProvider,
+	License,
 	MCPCatalogEntry,
 	MCPCatalogEntryServerManifest,
 	MCPCatalogServerManifest,
@@ -1243,4 +1244,10 @@ export async function fetchWorkspaceIDForProfile(
 		throw new HttpError(404, 'Workspace not found.');
 	}
 	return workspaceID;
+}
+
+// License
+
+export async function getLicense(opts?: { fetch?: Fetcher }): Promise<License> {
+	return (await doGet('/license', opts)) as License;
 }

--- a/ui/user/src/lib/stores/index.ts
+++ b/ui/user/src/lib/stores/index.ts
@@ -7,3 +7,4 @@ export { default as appPreferences } from './appPreferences.svelte';
 export { default as mcpServersAndEntries } from './mcpServersAndEntries.svelte';
 export { default as defaultModelAliases } from './defaultModelAliases.svelte';
 export { default as userDeviceSettings } from './userDeviceSettings.svelte';
+export { default as license } from './license.svelte';

--- a/ui/user/src/lib/stores/license.svelte.ts
+++ b/ui/user/src/lib/stores/license.svelte.ts
@@ -1,0 +1,23 @@
+import { type License } from '$lib/services/admin/types';
+
+const emptyLicense: License = {
+	licenseKey: '',
+	source: '',
+	locked: false,
+	enterprise: false,
+	entitlements: null
+};
+const store = $state<{ current: License; initialize: (license?: License) => void }>({
+	current: emptyLicense,
+	initialize
+});
+
+function initialize(license?: License) {
+	if (license) {
+		store.current = license;
+	} else {
+		store.current = emptyLicense;
+	}
+}
+
+export default store;

--- a/ui/user/src/routes/+layout.svelte
+++ b/ui/user/src/routes/+layout.svelte
@@ -45,9 +45,7 @@
 			version.initialize(data.version);
 		}
 
-		if (data.license) {
-			license.initialize(data.license);
-		}
+		license.initialize(data.license);
 
 		if (data.defaultModelAliases) {
 			untrack(() => defaultModelAliases.initialize(data.defaultModelAliases));

--- a/ui/user/src/routes/+layout.svelte
+++ b/ui/user/src/routes/+layout.svelte
@@ -11,7 +11,8 @@
 		version,
 		mcpServersAndEntries,
 		defaultModelAliases,
-		userDeviceSettings
+		userDeviceSettings,
+		license
 	} from '$lib/stores';
 	import '../app.css';
 	import type { PageData } from './$types';
@@ -42,6 +43,10 @@
 
 		if (data.version) {
 			version.initialize(data.version);
+		}
+
+		if (data.license) {
+			license.initialize(data.license);
 		}
 
 		if (data.defaultModelAliases) {

--- a/ui/user/src/routes/+layout.ts
+++ b/ui/user/src/routes/+layout.ts
@@ -3,6 +3,7 @@ import {
 	UserService,
 	type AppPreferences,
 	type DefaultModelAlias,
+	type License,
 	type Profile,
 	type Version
 } from '$lib/services';
@@ -16,12 +17,19 @@ export const load: LayoutLoad = async ({ fetch }) => {
 	let appPreferences: AppPreferences | undefined;
 	let profile: Profile | undefined;
 	let version: Version | undefined;
+	let license: License | undefined;
 	let defaultModelAliases: DefaultModelAlias[] | undefined;
 
 	try {
 		version = await UserService.getVersion({ fetch });
 	} catch {
 		version = undefined;
+	}
+
+	try {
+		license = await UserService.getLicense({ fetch });
+	} catch {
+		license = undefined;
 	}
 
 	try {
@@ -61,6 +69,7 @@ export const load: LayoutLoad = async ({ fetch }) => {
 		appPreferences,
 		profile,
 		version,
+		license,
 		defaultModelAliases
 	};
 };

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -347,7 +347,7 @@
 
 <LicenseProviderDialog
 	bind:provider={licenseRequiredProvider}
-	licenseKey={data.license?.licenseKey}
+	licenseKey={license.current.licenseKey}
 />
 
 <svelte:head>

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -12,10 +12,10 @@
 		RecommendedModelProviders
 	} from '$lib/constants';
 	import { HttpError } from '$lib/errors.js';
+	import { AdminService, Role, UserService } from '$lib/services';
 	import type { AuthProvider } from '$lib/services/admin/types.js';
-	import { AdminService, Role, UserService } from '$lib/services/index.js';
+	import { errors, license, profile } from '$lib/stores';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte.js';
-	import { errors, profile } from '$lib/stores/index.js';
 	import { TriangleAlert, Info } from 'lucide-svelte';
 	import { untrack } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -249,7 +249,7 @@
 						deconfigureAuthProviderDialog?.open();
 					}}
 					readonly={profile.current.isAdminReadonly?.()}
-					licenseKey={data.license?.licenseKey}
+					licenseKey={license.current.licenseKey}
 				/>
 			{/each}
 		</div>

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -2,9 +2,9 @@
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
-	import AuthDeconfigureConfirm from '$lib/components/admin/AuthDeconfigureConfirm.svelte';
 	import ProviderCard from '$lib/components/admin/ProviderCard.svelte';
 	import ProviderConfigure from '$lib/components/admin/ProviderConfigure.svelte';
+	import ProviderDeconfigureConfirm from '$lib/components/admin/ProviderDeconfigureConfirm.svelte';
 	import LicenseProviderDialog from '$lib/components/admin/license/LicenseProviderDialog.svelte';
 	import {
 		CommonAuthProviderIds,
@@ -63,7 +63,7 @@
 	let loading = $state(false);
 	let configureError = $state<string>();
 
-	let deconfigureAuthProviderDialog = $state<ReturnType<typeof AuthDeconfigureConfirm>>();
+	let deconfigureAuthProviderDialog = $state<ReturnType<typeof ProviderDeconfigureConfirm>>();
 	let confirmDeconfigureAuthProvider = $state<AuthProvider>();
 
 	const duration = PAGE_TRANSITION_DURATION;
@@ -287,7 +287,7 @@
 	{/snippet}
 </ProviderConfigure>
 
-<AuthDeconfigureConfirm
+<ProviderDeconfigureConfirm
 	bind:this={deconfigureAuthProviderDialog}
 	provider={confirmDeconfigureAuthProvider}
 	onConfirm={handleDeconfigureAuthProvider}

--- a/ui/user/src/routes/admin/auth-providers/+page.ts
+++ b/ui/user/src/routes/admin/auth-providers/+page.ts
@@ -1,6 +1,6 @@
 import { handleRouteError } from '$lib/errors';
 import { AdminService, UserService } from '$lib/services';
-import type { AuthProvider, License } from '$lib/services/admin/types';
+import type { AuthProvider } from '$lib/services/admin/types';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
@@ -12,16 +12,13 @@ export const load: PageLoad = async ({ fetch }) => {
 	}
 
 	let authProviders: AuthProvider[] = [];
-	let license: License | undefined = undefined;
 	try {
 		authProviders = await AdminService.listAuthProviders({ fetch });
-		license = await AdminService.getLicense({ fetch });
 	} catch (err) {
 		handleRouteError(err, '/admin/auth-providers', profile.current);
 	}
 
 	return {
-		authProviders,
-		license
+		authProviders
 	};
 };

--- a/ui/user/src/routes/admin/license/+page.svelte
+++ b/ui/user/src/routes/admin/license/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import Confirm from '$lib/components/Confirm.svelte';
-	import CopyButton from '$lib/components/CopyButton.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import SensitiveInput from '$lib/components/SensitiveInput.svelte';
@@ -119,15 +118,10 @@
 				{#if license}
 					{#if license.licenseKey}
 						<div class="flex flex-col gap-1">
-							<div class="flex items-center gap-2">
-								<label for="license-key" class="text-sm font-light">License Key</label>
-
-								<CopyButton
-									classes={{ button: 'flex items-center gap-1 text-xs text-primary' }}
-									text={license.licenseKey}
-								/>
+							<div class="text-sm font-light">License Key</div>
+							<div class="font-mono text-sm text-muted-content">
+								{license.licenseKey}
 							</div>
-							<SensitiveInput name="license-key" value={license.licenseKey} disabled />
 						</div>
 					{/if}
 					<div class="flex items-center justify-between gap-4">

--- a/ui/user/src/routes/admin/license/+page.ts
+++ b/ui/user/src/routes/admin/license/+page.ts
@@ -1,12 +1,12 @@
 import { handleRouteError } from '$lib/errors';
-import { AdminService, type License } from '$lib/services';
+import { UserService, type License } from '$lib/services';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
 	const { profile } = await parent();
 	let license: License | undefined = undefined;
 	try {
-		license = await AdminService.getLicense({ fetch });
+		license = await UserService.getLicense({ fetch });
 	} catch (err) {
 		handleRouteError(err, '/admin/license', profile);
 	}

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -10,7 +10,7 @@
 	import { HttpError } from '$lib/errors.js';
 	import { AdminService, type ModelProvider as ModelProviderType } from '$lib/services';
 	import { sortModelProviders } from '$lib/sort.js';
-	import { defaultModelAliases as defaultModelAliasesStore } from '$lib/stores';
+	import { defaultModelAliases as defaultModelAliasesStore, license } from '$lib/stores';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte.js';
 	import { profile } from '$lib/stores/index.js';
 	import { delay } from '$lib/utils';
@@ -191,7 +191,7 @@
 						adminConfigStore.updateModelProviders(modelProviders);
 					}}
 					readonly={isAdminReadonly}
-					licenseKey={data.license?.licenseKey}
+					licenseKey={license.current.licenseKey}
 				>
 					{#snippet configuredActions(provider)}
 						<ListModels {provider} readonly={isAdminReadonly} />

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -230,7 +230,7 @@
 
 <LicenseProviderDialog
 	bind:provider={licenseRequiredProvider}
-	licenseKey={data.license?.licenseKey}
+	licenseKey={license.current.licenseKey}
 />
 
 <svelte:head>

--- a/ui/user/src/routes/admin/model-providers/+page.ts
+++ b/ui/user/src/routes/admin/model-providers/+page.ts
@@ -1,20 +1,17 @@
 import { handleRouteError } from '$lib/errors';
-import { AdminService, type License, type ModelProvider } from '$lib/services';
+import { AdminService, type ModelProvider } from '$lib/services';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch }) => {
 	let modelProviders: ModelProvider[] = [];
-	let license: License | undefined = undefined;
 	try {
 		modelProviders = await AdminService.listModelProviders({ fetch });
-		license = await AdminService.getLicense({ fetch });
 	} catch (err) {
 		handleRouteError(err, '/admin/model-providers', profile.current);
 	}
 
 	return {
-		license,
 		modelProviders
 	};
 };

--- a/ui/user/src/routes/admin/server-scheduling/+page.svelte
+++ b/ui/user/src/routes/admin/server-scheduling/+page.svelte
@@ -258,8 +258,8 @@
 					<div>
 						{@render headerContent('Resource Limits & Requests')}
 						<p class="text-sm">
-							Define the CPU and memory requests and limits for pods in every MCP deployment. See
-							the Kubernetes <a
+							Define the CPU and memory requests and limits for pods in every hosted single or
+							multi-tenant deployment. See the Kubernetes <a
 								href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits"
 								class="text-link"
 								rel="external"

--- a/ui/user/src/routes/admin/skills/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/skills/[id]/+page.svelte
@@ -18,7 +18,7 @@
 		{#if data?.showLicenseError}
 			<div class="my-12 flex w-md flex-col items-center gap-4 m-auto text-center">
 				<TriangleAlert class="size-12 text-warning" />
-				<h4 class="text-muted-content text-lg font-semibold">License Error</h4>
+				<h4 class="text-muted-content text-lg font-semibold">Limited Functionality</h4>
 				<p class="text-muted-content text-sm font-light">
 					An issue occurred with fetching the skill due to licensing. Please resolve outstanding
 					licensing issues or contact support at

--- a/ui/user/src/routes/skills/+page.svelte
+++ b/ui/user/src/routes/skills/+page.svelte
@@ -6,6 +6,7 @@
 	import Search from '$lib/components/Search.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import type { Skill } from '$lib/services/nanobot/types';
+	import { MCP_CONNECTION_INVALID_LICENSE_MESSAGE } from '$lib/services/user/constants.js';
 	import { formatTimeAgo } from '$lib/time';
 	import { setUrlParamAndUpdateUrl } from '$lib/url.js';
 	import { TriangleAlert, PencilRuler } from 'lucide-svelte';
@@ -55,7 +56,15 @@
 
 {#snippet skillsView()}
 	<div class="flex flex-col gap-2">
-		{#if skills.length > 0}
+		{#if data?.showLicenseError}
+			<div class="my-12 flex w-md flex-col items-center gap-4 self-center text-center">
+				<TriangleAlert class="size-12 text-warning" />
+				<h4 class="text-muted-content text-lg font-semibold">Limited Functionality</h4>
+				<p class="text-muted-content text-sm font-light">
+					{MCP_CONNECTION_INVALID_LICENSE_MESSAGE}
+				</p>
+			</div>
+		{:else if skills.length > 0}
 			<Table
 				data={skillsTableData}
 				fields={['displayName', 'description', 'created']}

--- a/ui/user/src/routes/skills/+page.ts
+++ b/ui/user/src/routes/skills/+page.ts
@@ -1,18 +1,26 @@
-import { handleRouteError } from '$lib/errors';
+import { handleRouteError, HttpError } from '$lib/errors';
 import { NanobotService } from '$lib/services';
+import type { Skill } from '$lib/services/nanobot/types';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
 	const { profile } = await parent();
-	let skills;
+	let skills: Skill[] = [];
+	let showLicenseError = false;
 
 	try {
 		skills = await NanobotService.listSkills({ fetch });
 	} catch (err) {
-		handleRouteError(err, `/skills`, profile);
+		if (err instanceof HttpError && err.statusCode === 402) {
+			skills = [];
+			showLicenseError = true;
+		} else {
+			handleRouteError(err, `/skills`, profile);
+		}
 	}
 
 	return {
-		skills
+		skills,
+		showLicenseError
 	};
 };


### PR DESCRIPTION
Addresses #6814 
Addresses #6808 
Addresses #6809 
Addresses #6816 
Addresses #6805
Addresses #6799 - super quick text change

Backend Changes:
* GET /api/license becomes available for all authenticated users, the `licenseKey` property is fully masked for non-admins, partially masked for admins

Frontend Changes:
* moved getLicense call to UserService & license store
* address bugs mentioned in issues