### PR TITLE
fix: show effective Kubernetes resource defaults in MCP forms

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -334,6 +334,7 @@ var (
 			"PATCH /api/me",
 			"POST /api/logout-all",
 			"GET /api/version",
+			"GET /api/default-k8s-settings",
 			"GET /api/setup/oauth-complete",
 
 			// API key management for user's own keys

--- a/pkg/api/handlers/k8ssettings.go
+++ b/pkg/api/handlers/k8ssettings.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +38,18 @@ func (h *K8sSettingsHandler) Get(req api.Context) error {
 	}
 
 	return req.Write(converted)
+}
+
+func (h *K8sSettingsHandler) Defaults(req api.Context) error {
+	var settings v1.K8sSettings
+	if err := req.Storage.Get(req.Context(), client.ObjectKey{
+		Namespace: req.Namespace(),
+		Name:      system.K8sSettingsName,
+	}, &settings); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return req.Write(convertResourceRequirements(mcp.EffectiveDefaultMCPResourceRequirements(settings.Spec)))
 }
 
 func (h *K8sSettingsHandler) Update(req api.Context) error {
@@ -168,6 +182,23 @@ func (h *K8sSettingsHandler) Update(req api.Context) error {
 	}
 
 	return req.Write(converted)
+}
+
+func convertResourceRequirements(resources corev1.ResourceRequirements) *types.MCPResourceRequirements {
+	result := &types.MCPResourceRequirements{}
+	if cpu, ok := resources.Requests[corev1.ResourceCPU]; ok {
+		result.Requests.CPU = cpu.String()
+	}
+	if memory, ok := resources.Requests[corev1.ResourceMemory]; ok {
+		result.Requests.Memory = memory.String()
+	}
+	if cpu, ok := resources.Limits[corev1.ResourceCPU]; ok {
+		result.Limits.CPU = cpu.String()
+	}
+	if memory, ok := resources.Limits[corev1.ResourceMemory]; ok {
+		result.Limits.Memory = memory.String()
+	}
+	return result
 }
 
 func convertK8sSettings(settings v1.K8sSettings) (types.K8sSettings, error) {

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -409,6 +409,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 
 	// K8s Settings
 	k8sSettingsHandler := handlers.NewK8sSettingsHandler()
+	mux.HandleFunc("GET /api/default-k8s-settings", k8sSettingsHandler.Defaults)
 	mux.HandleFunc("GET /api/k8s-settings", k8sSettingsHandler.Get)
 	mux.HandleFunc("PUT /api/k8s-settings", k8sSettingsHandler.Update)
 

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -1157,6 +1157,10 @@ func mcpContainerResources(serverSpecificResources *corev1.ResourceRequirements,
 	return withServerResourceOverrides(withDefaultCPURequest(defaults), serverSpecificResources)
 }
 
+func EffectiveDefaultMCPResourceRequirements(k8sSettings v1.K8sSettingsSpec) corev1.ResourceRequirements {
+	return mcpContainerResources(nil, types.RuntimeNPX, false, k8sSettings)
+}
+
 func withServerResourceOverrides(defaults corev1.ResourceRequirements, overrides *corev1.ResourceRequirements) corev1.ResourceRequirements {
 	if overrides == nil || len(overrides.Requests) == 0 && len(overrides.Limits) == 0 {
 		return defaults

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -104,6 +104,45 @@ func TestMCPContainerResourcesAppliesServerOverridesWithRequestDefaults(t *testi
 	}
 }
 
+func TestEffectiveDefaultMCPResourceRequirements(t *testing.T) {
+	t.Run("uses built-in defaults when no K8s resources are configured", func(t *testing.T) {
+		defaults := EffectiveDefaultMCPResourceRequirements(v1.K8sSettingsSpec{})
+
+		if got, want := defaults.Requests[corev1.ResourceCPU], defaultCPURequest; got.Cmp(want) != 0 {
+			t.Fatalf("cpu request = %s, want %s", got.String(), want.String())
+		}
+		if got, want := defaults.Requests[corev1.ResourceMemory], defaultMCPMemoryRequest; got.Cmp(want) != 0 {
+			t.Fatalf("memory request = %s, want %s", got.String(), want.String())
+		}
+		if len(defaults.Limits) != 0 {
+			t.Fatalf("limits = %#v, want none", defaults.Limits)
+		}
+	})
+
+	t.Run("uses configured MCP resources and adds missing CPU request", func(t *testing.T) {
+		defaults := EffectiveDefaultMCPResourceRequirements(v1.K8sSettingsSpec{
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		})
+
+		if got, want := defaults.Requests[corev1.ResourceCPU], defaultCPURequest; got.Cmp(want) != 0 {
+			t.Fatalf("cpu request = %s, want %s", got.String(), want.String())
+		}
+		if got, want := defaults.Requests[corev1.ResourceMemory], resource.MustParse("512Mi"); got.Cmp(want) != 0 {
+			t.Fatalf("memory request = %s, want %s", got.String(), want.String())
+		}
+		if got, want := defaults.Limits[corev1.ResourceMemory], resource.MustParse("1Gi"); got.Cmp(want) != 0 {
+			t.Fatalf("memory limit = %s, want %s", got.String(), want.String())
+		}
+	})
+}
+
 func TestMCPContainerResourcesAppliesServerCPURequestWithMemoryDefault(t *testing.T) {
 	serverResources := &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -7,6 +7,7 @@
 		type MCPCatalogServer,
 		type LaunchServerType,
 		type MCPCatalogEntry,
+		type MCPResourceRequirements,
 		type RuntimeFormData,
 		type MCPCatalogEntryServerManifest,
 		type Runtime,
@@ -83,6 +84,7 @@
 	let showRequired = $state<Record<string, boolean>>({});
 	let loading = $state(false);
 	let compositeHasToolNameErrors = $state(false);
+	let mcpResourceDefaults = $state<MCPResourceRequirements>();
 
 	let formData = $state<RuntimeFormData>(untrack(() => convertToFormData(entry)));
 
@@ -350,6 +352,15 @@
 	onMount(() => {
 		if ((type === 'multi' || type === 'remote') && entry && id) {
 			revealCatalogServer(id, entry.id, entity);
+		}
+		if (version.current.engine === 'kubernetes') {
+			UserService.getK8sResourceDefaults()
+				.then((defaults) => {
+					mcpResourceDefaults = defaults;
+				})
+				.catch((err) => {
+					console.error('Failed to load Kubernetes resource defaults:', err);
+				});
 		}
 	});
 
@@ -774,7 +785,11 @@
 {/if}
 
 {#if version.current.engine === 'kubernetes' && !['remote', 'composite'].includes(formData.runtime) && formData.resources}
-	<ResourceRuntimeForm bind:config={formData.resources} {readonly} />
+	<ResourceRuntimeForm
+		bind:config={formData.resources}
+		{readonly}
+		defaultResources={mcpResourceDefaults}
+	/>
 {/if}
 
 <!-- Environment Variables Section -->

--- a/ui/user/src/lib/components/mcp/ResourceRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/ResourceRuntimeForm.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-	import type { ResourceRuntimeConfig } from '$lib/services';
+	import type { MCPResourceRequirements, ResourceRuntimeConfig } from '$lib/services';
 
 	interface Props {
 		config: ResourceRuntimeConfig;
 		readonly?: boolean;
+		defaultResources?: MCPResourceRequirements;
 	}
 
-	let { config = $bindable(), readonly }: Props = $props();
+	let { config = $bindable(), readonly, defaultResources }: Props = $props();
 
 	if (!config.requests) {
 		config.requests = {
@@ -20,13 +21,20 @@
 			memory: ''
 		};
 	}
+
+	function defaultPlaceholder(value: string | undefined, example: string) {
+		if (defaultResources) {
+			return value || 'none';
+		}
+		return example;
+	}
 </script>
 
 <div class="paper">
 	<h4 class="text-sm font-semibold">Resource Limits & Requests</h4>
 	<p class="text-xs text-muted-content">
 		Define the CPU and memory requests and limits for deployments created by this MCP catalog entry.
-		See the Kubernetes <a
+		Leave fields blank to use the platform defaults shown in each field. See the Kubernetes <a
 			href="https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits"
 			class="text-link"
 			rel="external"
@@ -46,7 +54,7 @@
 					class="text-input-filled dark:bg-base-100 w-full"
 					bind:value={config.requests!.cpu}
 					disabled={readonly}
-					placeholder="e.g. 10m"
+					placeholder={defaultPlaceholder(defaultResources?.requests?.cpu, 'e.g. 10m')}
 					onblur={() => {
 						if (config.requests?.cpu) {
 							config.requests.cpu = config.requests.cpu.trim();
@@ -61,7 +69,7 @@
 					class="text-input-filled dark:bg-base-100 w-full"
 					bind:value={config.limits!.cpu}
 					disabled={readonly}
-					placeholder="e.g. 10m"
+					placeholder={defaultPlaceholder(defaultResources?.limits?.cpu, 'e.g. 10m')}
 					onblur={() => {
 						if (config.limits?.cpu) {
 							config.limits.cpu = config.limits.cpu.trim();
@@ -83,7 +91,7 @@
 						class="text-input-filled dark:bg-base-100 w-full"
 						bind:value={config.requests!.memory}
 						disabled={readonly}
-						placeholder="e.g. 200Mi"
+						placeholder={defaultPlaceholder(defaultResources?.requests?.memory, 'e.g. 200Mi')}
 						onblur={() => {
 							if (config.requests?.memory) {
 								config.requests.memory = config.requests.memory.trim();
@@ -98,7 +106,7 @@
 						class="text-input-filled dark:bg-base-100 w-full"
 						bind:value={config.limits!.memory}
 						disabled={readonly}
-						placeholder="e.g. 200Mi"
+						placeholder={defaultPlaceholder(defaultResources?.limits?.memory, 'e.g. 200Mi')}
 						onblur={() => {
 							if (config.limits?.memory) {
 								config.limits.memory = config.limits.memory.trim();

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -33,6 +33,7 @@ import {
 	type DeviceScanListFilters,
 	type DeviceScanResponse,
 	type ImageResponse,
+	type MCPResourceRequirements,
 	type MCPCatalogServer,
 	type MCPServerInstance,
 	type MCPServerPrompt,
@@ -682,6 +683,14 @@ export async function getUser(
 export async function getVersion(opts?: { fetch?: Fetcher }): Promise<Version> {
 	const version = (await doGet('/version', opts)) as Version;
 	return version;
+}
+
+export async function getK8sResourceDefaults(opts?: {
+	fetch?: Fetcher;
+	signal?: AbortSignal;
+	dontLogErrors?: boolean;
+}): Promise<MCPResourceRequirements> {
+	return (await doGet('/default-k8s-settings', opts)) as MCPResourceRequirements;
 }
 
 // Workspace access control rules


### PR DESCRIPTION
Expose the effective default Kubernetes resource requirements through a
focused default-k8s-settings endpoint and use it to annotate the MCP server
resource override form. The endpoint returns the raw resource requirements
that apply to MCP server deployments, including built-in fallbacks and
configured K8s settings.

The form fields remain empty unless the user explicitly sets per-server
overrides, so blank values continue to inherit platform defaults instead of
being saved as fixed server-specific settings.

This removes ambiguity in MCP server creation/edit flows by showing the CPU
and memory requests/limits that will apply when override fields are left blank.

Addresses https://github.com/obot-platform/obot/issues/6795

