### PR TITLE
fix: clear needsK8sUpdate when trigger-update syncs server resources

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -51,6 +51,18 @@ type MCPHandler struct {
 
 	// shutdownMCPServer is only injected for testing
 	shutdownMCPServer func(string) error
+	// mcpRuntimeBackend is only injected for testing
+	mcpRuntimeBackend string
+}
+
+func (m *MCPHandler) runtimeBackend() string {
+	if m.mcpRuntimeBackend != "" {
+		return m.mcpRuntimeBackend
+	}
+	if m.mcpSessionManager == nil {
+		return ""
+	}
+	return m.mcpSessionManager.MCPRuntimeBackend()
 }
 
 func NewMCPHandler(mcpLoader *mcp.SessionManager, acrHelper *accesscontrolrule.Helper, mcpOAuthChecker MCPOAuthChecker, mcpImagePullSecrets []string, serverURL string) *MCPHandler {
@@ -64,7 +76,7 @@ func NewMCPHandler(mcpLoader *mcp.SessionManager, acrHelper *accesscontrolrule.H
 }
 
 func (m *MCPHandler) currentImagePullSecretNames(req api.Context) ([]string, error) {
-	return mcp.CurrentImagePullSecretNames(req.Context(), req.Storage, m.mcpSessionManager.MCPRuntimeBackend(), m.mcpImagePullSecrets)
+	return mcp.CurrentImagePullSecretNames(req.Context(), req.Storage, m.runtimeBackend(), m.mcpImagePullSecrets)
 }
 
 func (m *MCPHandler) currentK8sSettingsHash(req api.Context, settings v1.K8sSettingsSpec, mcpServer v1.MCPServer) (string, error) {
@@ -3953,12 +3965,59 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 		}
 
 		updateServerFromCatalogEntry(&latest, entry)
+		latest.Namespace = req.Namespace()
 		return req.Update(&latest)
 	}); err != nil {
 		return err
 	}
 
+	if err := m.clearK8sUpdateStatusAfterConfigSync(req, server.Name); err != nil {
+		return fmt.Errorf("failed to update server k8s status after config sync: %w", err)
+	}
+
 	return nil
+}
+
+// clearK8sUpdateStatusAfterConfigSync clears NeedsK8sUpdate and sets K8sSettingsHash to
+// the expected value after syncing server configuration from its catalog entry.
+// The server has already been shut down, so the next session start will deploy with
+// the updated settings.
+func (m *MCPHandler) clearK8sUpdateStatusAfterConfigSync(req api.Context, serverName string) error {
+	if !mcp.IsKubernetesBackend(m.runtimeBackend()) {
+		return nil
+	}
+
+	var k8sSettings v1.K8sSettings
+	if err := req.Storage.Get(req.Context(), kclient.ObjectKey{
+		Namespace: req.Namespace(),
+		Name:      system.K8sSettingsName,
+	}, &k8sSettings); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var latest v1.MCPServer
+		if err := req.Get(&latest, serverName); err != nil {
+			return err
+		}
+
+		currentHash, err := m.currentK8sSettingsHash(req, k8sSettings.Spec, latest)
+		if err != nil {
+			return err
+		}
+
+		if !latest.Status.NeedsK8sUpdate && latest.Status.K8sSettingsHash == currentHash {
+			return nil
+		}
+
+		latest.Status.NeedsK8sUpdate = false
+		latest.Status.K8sSettingsHash = currentHash
+		latest.Namespace = req.Namespace()
+		return req.Storage.Status().Update(req.Context(), &latest)
+	})
 }
 
 func updateServerFromCatalogEntry(server *v1.MCPServer, entry v1.MCPServerCatalogEntry) {

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -417,6 +419,82 @@ func TestTriggerUpdateScope(t *testing.T) {
 			},
 		})
 	})
+}
+
+func TestTriggerUpdateClearsK8sUpdateStatusAfterResourceSync(t *testing.T) {
+	oldResources := &types.MCPResourceRequirements{
+		Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},
+	}
+	newResources := &types.MCPResourceRequirements{
+		Requests: types.MCPResourceRequests{CPU: "500m", Memory: "512Mi"},
+	}
+
+	entry := &v1.MCPServerCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "entry", Namespace: system.DefaultNamespace},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Name:      "entry",
+				Runtime:   types.RuntimeNPX,
+				NPXConfig: &types.NPXRuntimeConfig{Package: "test"},
+				Resources: newResources,
+			},
+		},
+	}
+
+	server := v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "server", Namespace: system.DefaultNamespace},
+		Spec: v1.MCPServerSpec{
+			UserID:                    "owner",
+			MCPServerCatalogEntryName: "entry",
+			Manifest: types.MCPServerManifest{
+				Name:      "entry",
+				Runtime:   types.RuntimeNPX,
+				NPXConfig: &types.NPXRuntimeConfig{Package: "test"},
+				Resources: oldResources,
+			},
+		},
+		Status: v1.MCPServerStatus{
+			NeedsUpdate:     true,
+			NeedsK8sUpdate:  true,
+			K8sSettingsHash: "old-hash",
+		},
+	}
+
+	k8sSettings := &v1.K8sSettings{
+		ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+	}
+
+	storage := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithStatusSubresource(&v1.MCPServer{}).
+		WithObjects(entry, &server, k8sSettings).
+		Build()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp-servers/server/trigger-update", nil)
+	req.SetPathValue("mcp_server_id", "server")
+
+	err := (&MCPHandler{
+		mcpRuntimeBackend: mcp.RuntimeBackendKubernetes,
+		shutdownMCPServer: func(string) error { return nil },
+	}).TriggerUpdate(api.Context{
+		ResponseWriter: httptest.NewRecorder(),
+		Request:        req,
+		Storage:        storage,
+		User:           testUser("owner"),
+	})
+	require.NoError(t, err)
+
+	var updated v1.MCPServer
+	require.NoError(t, storage.Get(context.Background(), kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: "server"}, &updated))
+
+	assert.Equal(t, newResources, updated.Spec.Manifest.Resources)
+	assert.False(t, updated.Status.NeedsK8sUpdate)
+	assert.NotEqual(t, "old-hash", updated.Status.K8sSettingsHash)
+
+	coreResources, err := mcp.CoreResourceRequirements(newResources)
+	require.NoError(t, err)
+	wantHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, coreResources, types.RuntimeNPX, false, nil)
+	assert.Equal(t, wantHash, updated.Status.K8sSettingsHash)
 }
 
 // Test functions for applyURLTemplate


### PR DESCRIPTION
After Update Server is called, the MCP server is shut down and synced with updated catalog config, DetectK8sSettingsDrift could leave needsK8sUpdate set even though the next deploy would use the updated resource limits. Clear the flag and set K8sSettingsHash to the expected value after config sync on the Kubernetes backend.

To Address https://github.com/obot-platform/obot/issues/6785#issuecomment-4627151187

Wanted to check this is right path to address, otherwise happy to close it out!