### PR TITLE
enhance: allow wildcard suffixes in model access policies

### DIFF
--- a/apiclient/types/modelaccesspolicy.go
+++ b/apiclient/types/modelaccesspolicy.go
@@ -68,7 +68,7 @@ type ModelResource struct {
 	// - the wildcard '*', which selects all available models
 	// - the model ID of a specific model
 	// - an Obot default model alias in the form "obot://<alias>"
-	// - a wildcard suffix pattern in the form "<prefix>*" (e.g. "claude-haiku-4.5*"), which selects
+	// - a wildcard suffix pattern in the form "<prefix>*" (e.g. "claude-haiku-4-5*"), which selects
 	//   every current and future model, from any provider, whose provider-native target model
 	//   starts with <prefix> (case-sensitive)
 	//
@@ -87,7 +87,7 @@ func (m ModelResource) Validate() error {
 		return nil
 	}
 	if _, isWildcardSuffix := m.IsWildcardSuffix(); strings.Contains(m.ID, "*") && !m.IsWildcard() && !isWildcardSuffix {
-		return fmt.Errorf("wildcard (*) is only allowed as the sole entry %q or as a trailing wildcard suffix (e.g. %q): %s", "*", "claude-haiku-4.5*", m.ID)
+		return fmt.Errorf("wildcard (*) is only allowed as the sole entry %q or as a trailing wildcard suffix (e.g. %q): %s", "*", "claude-haiku-4-5*", m.ID)
 	}
 	return nil
 }
@@ -103,7 +103,7 @@ func (m ModelResource) IsDefaultModelAliasRef() (string, bool) {
 }
 
 // IsWildcardSuffix returns the pattern's prefix and true if this model resource
-// is a wildcard suffix pattern; e.g. "claude-haiku-4.5*". A pattern consists of
+// is a wildcard suffix pattern; e.g. "claude-haiku-4-5*". A pattern consists of
 // a non-empty prefix followed by a single trailing '*'. The bare wildcard "*"
 // is not a pattern (see IsWildcard).
 func (m ModelResource) IsWildcardSuffix() (string, bool) {

--- a/apiclient/types/modelaccesspolicy.go
+++ b/apiclient/types/modelaccesspolicy.go
@@ -68,6 +68,9 @@ type ModelResource struct {
 	// - the wildcard '*', which selects all available models
 	// - the model ID of a specific model
 	// - an Obot default model alias in the form "obot://<alias>"
+	// - a wildcard suffix pattern in the form "<prefix>*" (e.g. "claude-haiku-4.5*"), which selects
+	//   every current and future model, from any provider, whose provider-native target model
+	//   starts with <prefix> (case-sensitive)
 	//
 	// When a model ID is provided, it must match the ID field of an existing referenced model.
 	ID string `json:"id"`
@@ -81,6 +84,10 @@ func (m ModelResource) Validate() error {
 		if DefaultModelAliasTypeFromString(alias) == DefaultModelAliasTypeUnknown {
 			return fmt.Errorf("unknown model alias type reference: %s", alias)
 		}
+		return nil
+	}
+	if _, isWildcardSuffix := m.IsWildcardSuffix(); strings.Contains(m.ID, "*") && !m.IsWildcard() && !isWildcardSuffix {
+		return fmt.Errorf("wildcard (*) is only allowed as the sole entry %q or as a trailing wildcard suffix (e.g. %q): %s", "*", "claude-haiku-4.5*", m.ID)
 	}
 	return nil
 }
@@ -93,6 +100,26 @@ func (m ModelResource) IsWildcard() bool {
 // IsModelAlias returns true if the given model references a DefaultModelAlias.
 func (m ModelResource) IsDefaultModelAliasRef() (string, bool) {
 	return strings.CutPrefix(m.ID, DefaultModelAliasRefPrefix)
+}
+
+// IsWildcardSuffix returns the pattern's prefix and true if this model resource
+// is a wildcard suffix pattern; e.g. "claude-haiku-4.5*". A pattern consists of
+// a non-empty prefix followed by a single trailing '*'. The bare wildcard "*"
+// is not a pattern (see IsWildcard).
+func (m ModelResource) IsWildcardSuffix() (string, bool) {
+	prefix, ok := strings.CutSuffix(m.ID, "*")
+	if !ok || prefix == "" || strings.Contains(prefix, "*") {
+		return "", false
+	}
+	return prefix, true
+}
+
+// MatchesTargetModel returns true if this model resource is a wildcard suffix
+// pattern whose prefix matches the given provider-native target model
+// (case-sensitive).
+func (m ModelResource) MatchesTargetModel(targetModel string) bool {
+	prefix, ok := m.IsWildcardSuffix()
+	return ok && strings.HasPrefix(targetModel, prefix)
 }
 
 type ModelAccessPolicyList List[ModelAccessPolicy]

--- a/apiclient/types/modelaccesspolicy.go
+++ b/apiclient/types/modelaccesspolicy.go
@@ -86,8 +86,10 @@ func (m ModelResource) Validate() error {
 		}
 		return nil
 	}
-	if _, isWildcardSuffix := m.IsWildcardSuffix(); strings.Contains(m.ID, "*") && !m.IsWildcard() && !isWildcardSuffix {
+	if prefix, isWildcardSuffix := m.IsWildcardSuffix(); strings.Contains(m.ID, "*") && !m.IsWildcard() && !isWildcardSuffix {
 		return fmt.Errorf("wildcard (*) is only allowed as the sole entry %q or as a trailing wildcard suffix (e.g. %q): %s", "*", "claude-haiku-4-5*", m.ID)
+	} else if isWildcardSuffix && prefix != strings.TrimSpace(prefix) {
+		return fmt.Errorf("wildcard suffix pattern prefix must not begin or end with whitespace: %q", m.ID)
 	}
 	return nil
 }

--- a/apiclient/types/modelaccesspolicy_test.go
+++ b/apiclient/types/modelaccesspolicy_test.go
@@ -364,6 +364,57 @@ func TestModelAccessPolicyManifestValidate(t *testing.T) {
 			errorMsg:    "wildcard (*) is only allowed",
 		},
 		{
+			name: "whitespace-only wildcard suffix prefix",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: " *"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "must not begin or end with whitespace",
+		},
+		{
+			name: "leading whitespace in wildcard suffix prefix",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: " gpt*"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "must not begin or end with whitespace",
+		},
+		{
+			name: "trailing whitespace in wildcard suffix prefix",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "gpt *"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "must not begin or end with whitespace",
+		},
+		{
+			name: "interior whitespace in wildcard suffix prefix is allowed",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "gpt 4*"},
+				},
+			},
+			expectError: false,
+		},
+		{
 			name: "wildcard suffix on model alias reference",
 			manifest: ModelAccessPolicyManifest{
 				Subjects: []Subject{

--- a/apiclient/types/modelaccesspolicy_test.go
+++ b/apiclient/types/modelaccesspolicy_test.go
@@ -109,7 +109,7 @@ func TestModelAccessPolicyManifestValidate(t *testing.T) {
 					{Type: SubjectTypeUser, ID: "user1"},
 				},
 				Models: []ModelResource{
-					{ID: "claude-haiku-4.5*"},
+					{ID: "claude-haiku-4-5*"},
 				},
 			},
 			expectError: false,
@@ -121,7 +121,7 @@ func TestModelAccessPolicyManifestValidate(t *testing.T) {
 					{Type: SubjectTypeUser, ID: "user1"},
 				},
 				Models: []ModelResource{
-					{ID: "claude-haiku-4.5*"},
+					{ID: "claude-haiku-4-5*"},
 					{ID: "m1234567"},
 					{ID: "obot://llm"},
 				},
@@ -384,7 +384,7 @@ func TestModelAccessPolicyManifestValidate(t *testing.T) {
 				},
 				Models: []ModelResource{
 					{ID: "*"},
-					{ID: "claude-haiku-4.5*"},
+					{ID: "claude-haiku-4-5*"},
 				},
 			},
 			expectError: true,
@@ -397,12 +397,12 @@ func TestModelAccessPolicyManifestValidate(t *testing.T) {
 					{Type: SubjectTypeUser, ID: "user1"},
 				},
 				Models: []ModelResource{
-					{ID: "claude-haiku-4.5*"},
-					{ID: "claude-haiku-4.5*"},
+					{ID: "claude-haiku-4-5*"},
+					{ID: "claude-haiku-4-5*"},
 				},
 			},
 			expectError: true,
-			errorMsg:    "duplicate model claude-haiku-4.5*",
+			errorMsg:    "duplicate model claude-haiku-4-5*",
 		},
 
 		// Combined validation failures

--- a/apiclient/types/modelaccesspolicy_test.go
+++ b/apiclient/types/modelaccesspolicy_test.go
@@ -102,6 +102,45 @@ func TestModelAccessPolicyManifestValidate(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "valid with wildcard suffix pattern only",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "claude-haiku-4.5*"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid with wildcard suffix pattern, model ID, and alias",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "claude-haiku-4.5*"},
+					{ID: "m1234567"},
+					{ID: "obot://llm"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid with overlapping wildcard suffix patterns",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "gpt*"},
+					{ID: "gpt-4*"},
+				},
+			},
+			expectError: false,
+		},
 
 		// Validation failures - subjects
 		{
@@ -271,6 +310,99 @@ func TestModelAccessPolicyManifestValidate(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "duplicate model m1234567",
+		},
+		{
+			name: "wildcard in the middle of model ID",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "claude*haiku"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "wildcard (*) is only allowed",
+		},
+		{
+			name: "leading wildcard in model ID",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "*haiku"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "wildcard (*) is only allowed",
+		},
+		{
+			name: "double trailing wildcard in model ID",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "claude**"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "wildcard (*) is only allowed",
+		},
+		{
+			name: "bare double wildcard model ID",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "**"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "wildcard (*) is only allowed",
+		},
+		{
+			name: "wildcard suffix on model alias reference",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "obot://llm*"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "unknown model alias type reference: llm*",
+		},
+		{
+			name: "wildcard model with wildcard suffix pattern",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "*"},
+					{ID: "claude-haiku-4.5*"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "wildcard model (*) must be the only model",
+		},
+		{
+			name: "duplicate wildcard suffix patterns",
+			manifest: ModelAccessPolicyManifest{
+				Subjects: []Subject{
+					{Type: SubjectTypeUser, ID: "user1"},
+				},
+				Models: []ModelResource{
+					{ID: "claude-haiku-4.5*"},
+					{ID: "claude-haiku-4.5*"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "duplicate model claude-haiku-4.5*",
 		},
 
 		// Combined validation failures

--- a/docs/docs/functionality/model-access-policies.md
+++ b/docs/docs/functionality/model-access-policies.md
@@ -31,11 +31,26 @@ When adding models to a policy, you can select:
 
 - **Specific models** — Individual models from your configured providers
 - **Default model aliases** — References to whichever model is currently set as the default for a given purpose (see [Default Model Aliases](#default-model-aliases))
+- **Wildcard suffix patterns** — Grants access to every model whose ID starts with a given prefix (see [Wildcard Suffix Patterns](#wildcard-suffix-patterns))
 - **All models** — Grants access to every available model
 
 :::info Administrators Must Follow Policies
 Administrators do not have automatic access to all models. Like any other user, an administrator must be included in a policy to use a model in Obot Agent.
 :::
+
+#### Wildcard Suffix Patterns
+
+To grant access to a family of models—including versions that don't exist yet—end your entry with a single `*`. For example, `claude-haiku-4.5*` grants access to every model whose provider-native ID starts with `claude-haiku-4.5`, such as date-suffixed releases like `claude-haiku-4.5-20251001`.
+
+To add a pattern, start typing a prefix into the search box of the **Add Models** dialog. A pattern entry (your prefix followed by `*`) is offered at the top of the results, along with a live count of the models it currently matches. You can also type the pattern out explicitly, ending with `*`.
+
+Patterns follow these rules:
+
+- The `*` is only allowed at the end of the entry, and the prefix cannot be empty (a bare `*` is the existing "All models" option)
+- Matching is case-sensitive and applies to the provider-native model ID
+- Patterns match models from **all** providers
+- Patterns automatically cover future models: when a provider adds a new model whose ID starts with the prefix, users gain access without any policy changes
+- Patterns can be combined with specific models and default model aliases in the same policy
 
 ## Model Availability
 

--- a/docs/docs/functionality/model-access-policies.md
+++ b/docs/docs/functionality/model-access-policies.md
@@ -40,7 +40,7 @@ Administrators do not have automatic access to all models. Like any other user, 
 
 #### Wildcard Suffix Patterns
 
-To grant access to a family of models—including versions that don't exist yet—end your entry with a single `*`. For example, `claude-haiku-4.5*` grants access to every model whose provider-native ID starts with `claude-haiku-4.5`, such as date-suffixed releases like `claude-haiku-4.5-20251001`.
+To grant access to a family of models—including versions that don't exist yet—end your entry with a single `*`. For example, `claude-haiku-4-5*` grants access to every model whose provider-native ID starts with `claude-haiku-4-5`, such as date-suffixed releases like `claude-haiku-4-5-20251001`.
 
 To add a pattern, start typing a prefix into the search box of the **Add Models** dialog. A pattern entry (your prefix followed by `*`) is offered at the top of the results, along with a live count of the models it currently matches. You can also type the pattern out explicitly, ending with `*`.
 

--- a/docs/docs/functionality/model-access-policies.md
+++ b/docs/docs/functionality/model-access-policies.md
@@ -46,7 +46,7 @@ To add a pattern, start typing a prefix into the search box of the **Add Models*
 
 Patterns follow these rules:
 
-- The `*` is only allowed at the end of the entry, and the prefix cannot be empty (a bare `*` is the existing "All models" option)
+- The `*` is only allowed at the end of the entry, and the prefix cannot be empty or begin/end with whitespace (a bare `*` is the existing "All models" option)
 - Matching is case-sensitive and applies to the provider-native model ID
 - Patterns match models from **all** providers
 - Patterns automatically cover future models: when a provider adds a new model whose ID starts with the prefix, users gain access without any policy changes

--- a/pkg/cli/internal/token.go
+++ b/pkg/cli/internal/token.go
@@ -28,6 +28,12 @@ import (
 var credentialStore credentials.Store = credentials.NewKeyringStore()
 var openBrowser = browser.OpenURL
 
+func init() {
+	// Browser launchers (e.g. xdg-open) may write to stdout; keep stdout
+	// reserved for machine-readable output like `login --print-token`.
+	browser.Stdout = os.Stderr
+}
+
 type nonInteractiveContextKey struct{}
 type outputWriterContextKey struct{}
 
@@ -38,7 +44,7 @@ func WithNonInteractive(ctx context.Context) context.Context {
 }
 
 // WithOutputWriter routes token-acquisition user messages to w instead of
-// stdout. This lets commands that stream machine-readable stdout keep it clean.
+// stderr.
 func WithOutputWriter(ctx context.Context, w io.Writer) context.Context {
 	if w == nil {
 		return ctx
@@ -55,7 +61,9 @@ func outputWriter(ctx context.Context) io.Writer {
 	if w, _ := ctx.Value(outputWriterContextKey{}).(io.Writer); w != nil {
 		return w
 	}
-	return os.Stdout
+	// User-facing auth prompts go to stderr so stdout stays clean for
+	// piping (e.g. `obot login --print-token`).
+	return os.Stderr
 }
 
 // AppURLForAPIBaseURL returns the app URL that owns credentials for an

--- a/pkg/cli/internal/token.go
+++ b/pkg/cli/internal/token.go
@@ -43,8 +43,9 @@ func WithNonInteractive(ctx context.Context) context.Context {
 	return context.WithValue(ctx, nonInteractiveContextKey{}, true)
 }
 
-// WithOutputWriter routes token-acquisition user messages to w instead of
-// stderr.
+// WithOutputWriter routes token-acquisition user messages to w. They default
+// to stderr to keep stdout reserved for machine-readable output like
+// `login --print-token`.
 func WithOutputWriter(ctx context.Context, w io.Writer) context.Context {
 	if w == nil {
 		return ctx

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy.go
@@ -13,6 +13,9 @@ import (
 // - Models that no longer exist
 // - Duplicates
 // - Explicit model references when a wildcard is present
+//
+// Wildcard suffix patterns (e.g. "claude-haiku-4.5*") are always kept, even when
+// they currently match no models, since they apply to future models as well.
 func PruneModels(req router.Request, _ router.Response) error {
 	policy := req.Object.(*v1.ModelAccessPolicy)
 
@@ -39,6 +42,13 @@ func PruneModels(req router.Request, _ router.Response) error {
 				resources = append(resources, resource)
 			}
 
+			continue
+		}
+
+		if _, isPattern := resource.IsWildcardSuffix(); isPattern {
+			// Keep wildcard suffix patterns unconditionally; they're forward-looking
+			// and may match models that don't exist yet.
+			resources = append(resources, resource)
 			continue
 		}
 

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy.go
@@ -14,7 +14,7 @@ import (
 // - Duplicates
 // - Explicit model references when a wildcard is present
 //
-// Wildcard suffix patterns (e.g. "claude-haiku-4.5*") are always kept, even when
+// Wildcard suffix patterns (e.g. "claude-haiku-4-5*") are always kept, even when
 // they currently match no models, since they apply to future models as well.
 func PruneModels(req router.Request, _ router.Response) error {
 	policy := req.Object.(*v1.ModelAccessPolicy)

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
@@ -1,0 +1,124 @@
+package modelaccesspolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPruneModels(t *testing.T) {
+	existingModel := &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "m1-existing",
+			Namespace: "default",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		modelIDs   []string
+		wantIDs    []string
+		wantUpdate bool
+	}{
+		{
+			name:       "keeps wildcard suffix pattern matching no models",
+			modelIDs:   []string{"claude-haiku-4.5*"},
+			wantIDs:    []string{"claude-haiku-4.5*"},
+			wantUpdate: false,
+		},
+		{
+			name:       "keeps pattern and existing model, prunes missing model",
+			modelIDs:   []string{"claude-haiku-4.5*", "m1-existing", "m1-missing"},
+			wantIDs:    []string{"claude-haiku-4.5*", "m1-existing"},
+			wantUpdate: true,
+		},
+		{
+			name:       "prunes invalid IDs including misplaced wildcards",
+			modelIDs:   []string{"not-a-model", "a*b", "*haiku", "m1-existing"},
+			wantIDs:    []string{"m1-existing"},
+			wantUpdate: true,
+		},
+		{
+			name:       "prunes duplicate patterns",
+			modelIDs:   []string{"claude-haiku-4.5*", "claude-haiku-4.5*"},
+			wantIDs:    []string{"claude-haiku-4.5*"},
+			wantUpdate: true,
+		},
+		{
+			name:       "wildcard collapses patterns and explicit references",
+			modelIDs:   []string{"claude-haiku-4.5*", "*", "m1-existing"},
+			wantIDs:    []string{"*"},
+			wantUpdate: true,
+		},
+		{
+			name:       "no update when nothing is pruned",
+			modelIDs:   []string{"m1-existing", "obot://llm", "gpt-4o*"},
+			wantIDs:    []string{"m1-existing", "obot://llm", "gpt-4o*"},
+			wantUpdate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			models := make([]types.ModelResource, 0, len(tt.modelIDs))
+			for _, id := range tt.modelIDs {
+				models = append(models, types.ModelResource{ID: id})
+			}
+
+			client := fake.NewClientBuilder().
+				WithScheme(storagescheme.Scheme).
+				WithObjects(existingModel, &v1.ModelAccessPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "default",
+					},
+					Spec: v1.ModelAccessPolicySpec{
+						Manifest: types.ModelAccessPolicyManifest{
+							Subjects: []types.Subject{{Type: types.SubjectTypeUser, ID: "u1"}},
+							Models:   models,
+						},
+					},
+				}).
+				Build()
+
+			// Fetch the stored policy so the handler updates it with a valid resource version
+			var policy v1.ModelAccessPolicy
+			key := kclient.ObjectKey{Namespace: "default", Name: "test-policy"}
+			require.NoError(t, client.Get(context.Background(), key, &policy))
+
+			initialVersion := policy.ResourceVersion
+			err := PruneModels(router.Request{
+				Client:    client,
+				Ctx:       context.Background(),
+				Object:    &policy,
+				Namespace: policy.Namespace,
+				Name:      policy.Name,
+			}, nil)
+			require.NoError(t, err)
+
+			var updated v1.ModelAccessPolicy
+			require.NoError(t, client.Get(context.Background(), key, &updated))
+
+			gotIDs := make([]string, 0, len(updated.Spec.Manifest.Models))
+			for _, m := range updated.Spec.Manifest.Models {
+				gotIDs = append(gotIDs, m.ID)
+			}
+			assert.Equal(t, tt.wantIDs, gotIDs)
+
+			if tt.wantUpdate {
+				assert.NotEqual(t, initialVersion, updated.ResourceVersion, "expected policy to be updated")
+			} else {
+				assert.Equal(t, initialVersion, updated.ResourceVersion, "expected no update")
+			}
+		})
+	}
+}

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
@@ -31,14 +31,14 @@ func TestPruneModels(t *testing.T) {
 	}{
 		{
 			name:       "keeps wildcard suffix pattern matching no models",
-			modelIDs:   []string{"claude-haiku-4.5*"},
-			wantIDs:    []string{"claude-haiku-4.5*"},
+			modelIDs:   []string{"claude-haiku-4-5*"},
+			wantIDs:    []string{"claude-haiku-4-5*"},
 			wantUpdate: false,
 		},
 		{
 			name:       "keeps pattern and existing model, prunes missing model",
-			modelIDs:   []string{"claude-haiku-4.5*", "m1-existing", "m1-missing"},
-			wantIDs:    []string{"claude-haiku-4.5*", "m1-existing"},
+			modelIDs:   []string{"claude-haiku-4-5*", "m1-existing", "m1-missing"},
+			wantIDs:    []string{"claude-haiku-4-5*", "m1-existing"},
 			wantUpdate: true,
 		},
 		{
@@ -49,13 +49,13 @@ func TestPruneModels(t *testing.T) {
 		},
 		{
 			name:       "prunes duplicate patterns",
-			modelIDs:   []string{"claude-haiku-4.5*", "claude-haiku-4.5*"},
-			wantIDs:    []string{"claude-haiku-4.5*"},
+			modelIDs:   []string{"claude-haiku-4-5*", "claude-haiku-4-5*"},
+			wantIDs:    []string{"claude-haiku-4-5*"},
 			wantUpdate: true,
 		},
 		{
 			name:       "wildcard collapses patterns and explicit references",
-			modelIDs:   []string{"claude-haiku-4.5*", "*", "m1-existing"},
+			modelIDs:   []string{"claude-haiku-4-5*", "*", "m1-existing"},
 			wantIDs:    []string{"*"},
 			wantUpdate: true,
 		},

--- a/pkg/modelaccesspolicy/helper.go
+++ b/pkg/modelaccesspolicy/helper.go
@@ -106,8 +106,25 @@ func (h *Helper) UserHasAccessToModel(user kuser.Info, modelID string) (bool, er
 // If a user is an owner/admin or has been granted access to all models via a wildcard model selector, this method returns nil and true.
 func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, error) {
 	var (
-		allowedModels   = make(map[string]bool)
-		aliasModels     = h.getAliasModels()
+		allowedModels = make(map[string]bool)
+		aliasModels   = h.getAliasModels()
+
+		// Models are listed at most once per call, no matter how many wildcard
+		// suffix patterns appear across the user's policies.
+		allModels  []*v1.Model
+		listModels = func() []*v1.Model {
+			if allModels == nil {
+				objs := h.modelIndexer.List()
+				allModels = make([]*v1.Model, 0, len(objs))
+				for _, obj := range objs {
+					if m, ok := obj.(*v1.Model); ok {
+						allModels = append(allModels, m)
+					}
+				}
+			}
+			return allModels
+		}
+
 		addAllowedModel = func(model types.ModelResource) bool {
 			if model.IsWildcard() {
 				return true
@@ -119,6 +136,15 @@ func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, e
 				// Look up the current model ID and swap it out
 				// If we can't find it, modelID will be an empty string, which is handled by the model ID check below
 				modelID = aliasModels[alias]
+			} else if _, isPattern := model.IsWildcardSuffix(); isPattern {
+				// The model ID is a wildcard suffix pattern (e.g. 'claude-haiku-4.5*')
+				// Allow every model, from any provider, whose target model matches it
+				for _, m := range listModels() {
+					if model.MatchesTargetModel(m.Spec.Manifest.TargetModel) {
+						allowedModels[m.Name] = true
+					}
+				}
+				return false
 			}
 
 			if system.IsModelID(modelID) {

--- a/pkg/modelaccesspolicy/helper.go
+++ b/pkg/modelaccesspolicy/helper.go
@@ -109,22 +109,6 @@ func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, e
 		allowedModels = make(map[string]bool)
 		aliasModels   = h.getAliasModels()
 
-		// Models are listed at most once per call, no matter how many wildcard
-		// suffix patterns appear across the user's policies.
-		allModels  []*v1.Model
-		listModels = func() []*v1.Model {
-			if allModels == nil {
-				objs := h.modelIndexer.List()
-				allModels = make([]*v1.Model, 0, len(objs))
-				for _, obj := range objs {
-					if m, ok := obj.(*v1.Model); ok {
-						allModels = append(allModels, m)
-					}
-				}
-			}
-			return allModels
-		}
-
 		addAllowedModel = func(model types.ModelResource) bool {
 			if model.IsWildcard() {
 				return true
@@ -139,8 +123,8 @@ func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, e
 			} else if _, isPattern := model.IsWildcardSuffix(); isPattern {
 				// The model ID is a wildcard suffix pattern (e.g. 'claude-haiku-4-5*')
 				// Allow every model, from any provider, whose target model matches it
-				for _, m := range listModels() {
-					if model.MatchesTargetModel(m.Spec.Manifest.TargetModel) {
+				for _, obj := range h.modelIndexer.List() {
+					if m, ok := obj.(*v1.Model); ok && model.MatchesTargetModel(m.Spec.Manifest.TargetModel) {
 						allowedModels[m.Name] = true
 					}
 				}

--- a/pkg/modelaccesspolicy/helper.go
+++ b/pkg/modelaccesspolicy/helper.go
@@ -137,7 +137,7 @@ func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, e
 				// If we can't find it, modelID will be an empty string, which is handled by the model ID check below
 				modelID = aliasModels[alias]
 			} else if _, isPattern := model.IsWildcardSuffix(); isPattern {
-				// The model ID is a wildcard suffix pattern (e.g. 'claude-haiku-4.5*')
+				// The model ID is a wildcard suffix pattern (e.g. 'claude-haiku-4-5*')
 				// Allow every model, from any provider, whose target model matches it
 				for _, m := range listModels() {
 					if model.MatchesTargetModel(m.Spec.Manifest.TargetModel) {

--- a/pkg/modelaccesspolicy/helper_test.go
+++ b/pkg/modelaccesspolicy/helper_test.go
@@ -178,7 +178,7 @@ func TestGetUserAllowedTargetModels(t *testing.T) {
 			models: []*v1.Model{
 				newModel("m1-gpt-4o", provider, "gpt-4o", true),
 			},
-			policies: []*v1.ModelAccessPolicy{userPolicy("claude-haiku-4.5*")},
+			policies: []*v1.ModelAccessPolicy{userPolicy("claude-haiku-4-5*")},
 			want:     map[string]bool{},
 		},
 		{

--- a/pkg/modelaccesspolicy/helper_test.go
+++ b/pkg/modelaccesspolicy/helper_test.go
@@ -155,6 +155,51 @@ func TestGetUserAllowedTargetModels(t *testing.T) {
 			},
 			want: map[string]bool{},
 		},
+		{
+			name: "wildcard suffix pattern matches target models by prefix",
+			models: []*v1.Model{
+				newModel("m1-gpt-4o", provider, "gpt-4o", true),
+				newModel("m1-gpt-4o-mini", provider, "gpt-4o-mini", true),
+				newModel("m1-gpt-5", provider, "gpt-5", true),
+			},
+			policies: []*v1.ModelAccessPolicy{userPolicy("gpt-4o*")},
+			want:     map[string]bool{"gpt-4o": true, "gpt-4o-mini": true},
+		},
+		{
+			name: "wildcard suffix pattern is case-sensitive",
+			models: []*v1.Model{
+				newModel("m1-gpt-4o", provider, "gpt-4o", true),
+			},
+			policies: []*v1.ModelAccessPolicy{userPolicy("GPT-4o*")},
+			want:     map[string]bool{},
+		},
+		{
+			name: "wildcard suffix pattern matching nothing allows nothing",
+			models: []*v1.Model{
+				newModel("m1-gpt-4o", provider, "gpt-4o", true),
+			},
+			policies: []*v1.ModelAccessPolicy{userPolicy("claude-haiku-4.5*")},
+			want:     map[string]bool{},
+		},
+		{
+			name: "wildcard suffix pattern combines with explicit model ID",
+			models: []*v1.Model{
+				newModel("m1-gpt-4o", provider, "gpt-4o", true),
+				newModel("m1-gpt-5", provider, "gpt-5", true),
+				newModel("m1-o3", provider, "o3", true),
+			},
+			policies: []*v1.ModelAccessPolicy{userPolicy("gpt-4o*", "m1-o3")},
+			want:     map[string]bool{"gpt-4o": true, "o3": true},
+		},
+		{
+			name: "wildcard suffix pattern matches inactive model but provider index drops it",
+			models: []*v1.Model{
+				newModel("m1-gpt-4o", provider, "gpt-4o", true),
+				newModel("m1-gpt-4o-mini", provider, "gpt-4o-mini", false),
+			},
+			policies: []*v1.ModelAccessPolicy{userPolicy("gpt-4o*")},
+			want:     map[string]bool{"gpt-4o": true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -166,6 +211,38 @@ func TestGetUserAllowedTargetModels(t *testing.T) {
 			assert.Equal(t, tt.wantAllowAll, allowAll)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func TestUserHasAccessToModelWithWildcardSuffix(t *testing.T) {
+	const userID = "u1"
+
+	models := []*v1.Model{
+		newModel("m1-anthropic-claude-haiku", "anthropic-model-provider", "claude-haiku-4-5-20251001", true),
+		newModel("m1-bedrock-claude-haiku", "bedrock-model-provider", "claude-haiku-4-5-20251001", true),
+		newModel("m1-anthropic-claude-opus", "anthropic-model-provider", "claude-opus-4-8", true),
+	}
+
+	policy := &v1.ModelAccessPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-pattern", Namespace: "default"},
+		Spec: v1.ModelAccessPolicySpec{Manifest: types2.ModelAccessPolicyManifest{
+			Subjects: []types2.Subject{{Type: types2.SubjectTypeUser, ID: userID}},
+			Models:   []types2.ModelResource{{ID: "claude-haiku-4-5*"}},
+		}},
+	}
+
+	h := newModelHelper(t, models, policy)
+	user := &kuser.DefaultInfo{Name: userID, UID: userID}
+
+	for modelID, want := range map[string]bool{
+		// The pattern grants matching models from every provider
+		"m1-anthropic-claude-haiku": true,
+		"m1-bedrock-claude-haiku":   true,
+		"m1-anthropic-claude-opus":  false,
+	} {
+		got, err := h.UserHasAccessToModel(user, modelID)
+		require.NoError(t, err)
+		assert.Equal(t, want, got, "access for %s", modelID)
 	}
 }
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -8050,7 +8050,7 @@ func schema_obot_platform_obot_apiclient_types_ModelResource(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the model resource. It either be: - the wildcard '*', which selects all available models - the model ID of a specific model - an Obot default model alias in the form \"obot://<alias>\"\n\nWhen a model ID is provided, it must match the ID field of an existing referenced model.",
+							Description: "ID is the unique identifier of the model resource. It either be: - the wildcard '*', which selects all available models - the model ID of a specific model - an Obot default model alias in the form \"obot://<alias>\" - a wildcard suffix pattern in the form \"<prefix>*\" (e.g. \"claude-haiku-4.5*\"), which selects\n  every current and future model, from any provider, whose provider-native target model\n  starts with <prefix> (case-sensitive)\n\nWhen a model ID is provided, it must match the ID field of an existing referenced model.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -8050,7 +8050,7 @@ func schema_obot_platform_obot_apiclient_types_ModelResource(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ID is the unique identifier of the model resource. It either be: - the wildcard '*', which selects all available models - the model ID of a specific model - an Obot default model alias in the form \"obot://<alias>\" - a wildcard suffix pattern in the form \"<prefix>*\" (e.g. \"claude-haiku-4.5*\"), which selects\n  every current and future model, from any provider, whose provider-native target model\n  starts with <prefix> (case-sensitive)\n\nWhen a model ID is provided, it must match the ID field of an existing referenced model.",
+							Description: "ID is the unique identifier of the model resource. It either be: - the wildcard '*', which selects all available models - the model ID of a specific model - an Obot default model alias in the form \"obot://<alias>\" - a wildcard suffix pattern in the form \"<prefix>*\" (e.g. \"claude-haiku-4-5*\"), which selects\n  every current and future model, from any provider, whose provider-native target model\n  starts with <prefix> (case-sensitive)\n\nWhen a model ID is provided, it must match the ID field of an existing referenced model.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
@@ -152,7 +152,9 @@
 				effectiveModel: alias.effectiveModelName,
 				isAlias: true,
 				isConfigured: alias.isConfigured,
-				usage: alias.usage
+				usage: alias.usage,
+				isPattern: false,
+				matchCount: 0
 			};
 		});
 
@@ -164,7 +166,9 @@
 			usage: model.usage,
 			effectiveModel: null,
 			isAlias: false,
-			isConfigured: true
+			isConfigured: true,
+			isPattern: model.isPattern,
+			matchCount: model.matchCount
 		}));
 
 		return [...aliasRows, ...regularRows];
@@ -256,13 +260,32 @@
 		);
 	}
 
-	function convertModelsToTableData(models: ModelResource[]) {
-		return models.map((model) => {
+	function convertModelsToTableData(modelResources: ModelResource[]) {
+		return modelResources.map((model) => {
 			if (model.id === '*') {
 				return {
 					id: model.id,
 					name: 'All Models',
-					provider: '-'
+					usage: undefined,
+					provider: '-',
+					isPattern: false,
+					matchCount: 0
+				};
+			}
+
+			if (model.id.endsWith('*')) {
+				// Wildcard suffix pattern; count the currently matching models
+				// (case-sensitive prefix match on target model, like the backend)
+				const prefix = model.id.slice(0, -1);
+				const matchCount = models.filter((m) => (m.targetModel || '').startsWith(prefix)).length;
+
+				return {
+					id: model.id,
+					name: model.id,
+					usage: undefined,
+					provider: '-',
+					isPattern: true,
+					matchCount
 				};
 			}
 
@@ -271,7 +294,9 @@
 				id: model.id,
 				name: m?.displayName || m?.name || model.id,
 				usage: m?.usage,
-				provider: m?.modelProviderName || '-'
+				provider: m?.modelProviderName || '-',
+				isPattern: false,
+				matchCount: 0
 			};
 		});
 	}
@@ -430,6 +455,25 @@
 										</span>
 									</div>
 									<span class="text-muted-content text-xs">{d.name}</span>
+								</div>
+							{:else if d.isPattern}
+								<div class="flex flex-col">
+									<div class="flex items-center gap-2">
+										<span class="font-mono font-medium">{d.name}</span>
+										<span
+											class="bg-base-300 dark:bg-base-400 rounded-full px-2 py-0.5 text-xs font-medium"
+										>
+											Pattern
+										</span>
+									</div>
+									<span class="text-muted-content text-xs">
+										{#if d.matchCount > 0}
+											Matches {d.matchCount}
+											{d.matchCount === 1 ? 'model' : 'models'} across all providers
+										{:else}
+											No current matches — applies to future models
+										{/if}
+									</span>
 								</div>
 							{:else}
 								<div class="flex flex-col">

--- a/ui/user/src/lib/components/admin/SearchModels.svelte
+++ b/ui/user/src/lib/components/admin/SearchModels.svelte
@@ -36,28 +36,27 @@
 		modelProviders = await AdminService.listModelProviders();
 	});
 
-	// When the search text is a wildcard suffix pattern (e.g. "claude-haiku-4-5*"),
-	// this holds its prefix; null otherwise. Mirrors backend validation: a single
-	// trailing '*' with a non-empty, non-alias prefix.
-	let patternPrefix = $derived(
-		search.endsWith('*') &&
-			search.length > 1 &&
-			!search.slice(0, -1).includes('*') &&
-			!search.startsWith('obot://')
-			? search.slice(0, -1)
-			: null
-	);
+	// When the (trimmed) search text is a wildcard suffix pattern (e.g.
+	// "claude-haiku-4-5*"), this holds its prefix; null otherwise. Mirrors
+	// backend validation: a single trailing '*' with a non-empty, non-alias
+	// prefix that doesn't begin or end with whitespace.
+	let patternPrefix = $derived.by(() => {
+		const s = search.trim();
+		if (!s.endsWith('*') || s.length < 2 || s.startsWith('obot://')) return null;
+		const prefix = s.slice(0, -1);
+		if (prefix.includes('*') || prefix !== prefix.trim()) return null;
+		return prefix;
+	});
 
 	// The wildcard pattern offered for the current search: the search text itself
 	// when it's an explicit pattern, or "<search>*" suggested while typing a plain
-	// prefix (no '*' required).
-	let patternOption = $derived(
-		patternPrefix !== null
-			? { id: search, prefix: patternPrefix }
-			: search && !search.includes('*') && !search.startsWith('obot://')
-				? { id: `${search}*`, prefix: search }
-				: null
-	);
+	// prefix (no '*' required). Surrounding whitespace is never part of a pattern.
+	let patternOption = $derived.by(() => {
+		if (patternPrefix !== null) return { id: `${patternPrefix}*`, prefix: patternPrefix };
+		const s = search.trim();
+		if (!s || s.includes('*') || s.startsWith('obot://')) return null;
+		return { id: `${s}*`, prefix: s };
+	});
 
 	// Live count of what the pattern currently grants: a case-sensitive prefix
 	// match on provider-native target models, like the backend.
@@ -241,8 +240,8 @@
 							<div class="flex flex-col">
 								<p class="font-mono font-medium">{pattern.id}</p>
 								<span class="text-muted-content text-xs">
-									Grants access to all current and future models whose ID starts with "{pattern.prefix}"
-									— currently matches {patternMatchCount}
+									Grants access to all current and future models whose provider model ID starts with
+									"{pattern.prefix}" — currently matches {patternMatchCount}
 									{patternMatchCount === 1 ? 'model' : 'models'}
 								</span>
 							</div>

--- a/ui/user/src/lib/components/admin/SearchModels.svelte
+++ b/ui/user/src/lib/components/admin/SearchModels.svelte
@@ -36,7 +36,7 @@
 		modelProviders = await AdminService.listModelProviders();
 	});
 
-	// When the search text is a wildcard suffix pattern (e.g. "claude-haiku-4.5*"),
+	// When the search text is a wildcard suffix pattern (e.g. "claude-haiku-4-5*"),
 	// this holds its prefix; null otherwise. Mirrors backend validation: a single
 	// trailing '*' with a non-empty, non-alias prefix.
 	let patternPrefix = $derived(

--- a/ui/user/src/lib/components/admin/SearchModels.svelte
+++ b/ui/user/src/lib/components/admin/SearchModels.svelte
@@ -36,12 +36,48 @@
 		modelProviders = await AdminService.listModelProviders();
 	});
 
+	// When the search text is a wildcard suffix pattern (e.g. "claude-haiku-4.5*"),
+	// this holds its prefix; null otherwise. Mirrors backend validation: a single
+	// trailing '*' with a non-empty, non-alias prefix.
+	let patternPrefix = $derived(
+		search.endsWith('*') &&
+			search.length > 1 &&
+			!search.slice(0, -1).includes('*') &&
+			!search.startsWith('obot://')
+			? search.slice(0, -1)
+			: null
+	);
+
+	// The wildcard pattern offered for the current search: the search text itself
+	// when it's an explicit pattern, or "<search>*" suggested while typing a plain
+	// prefix (no '*' required).
+	let patternOption = $derived(
+		patternPrefix !== null
+			? { id: search, prefix: patternPrefix }
+			: search && !search.includes('*') && !search.startsWith('obot://')
+				? { id: `${search}*`, prefix: search }
+				: null
+	);
+
+	// Live count of what the pattern currently grants: a case-sensitive prefix
+	// match on provider-native target models, like the backend.
+	let patternMatchCount = $derived.by(() => {
+		const opt = patternOption;
+		if (!opt) return 0;
+		return models.filter((m) => (m.targetModel || '').startsWith(opt.prefix)).length;
+	});
+
 	// Filter models based on exclude list and search
 	let filteredModels = $derived(
 		models
 			.filter((model) => !exclude?.includes(model.id))
 			.filter((model) => {
 				if (!search) return true;
+				if (patternPrefix !== null) {
+					// Preview exactly what the pattern grants: a case-sensitive prefix
+					// match on the provider-native target model, like the backend.
+					return (model.targetModel || '').startsWith(patternPrefix);
+				}
 				const lowerSearch = search.toLowerCase();
 				return (
 					(model.displayName || model.name).toLowerCase().includes(lowerSearch) ||
@@ -107,17 +143,19 @@
 
 	let availableAliases = $derived(aliasDisplayData.filter((a) => !a.isExcluded));
 
-	// Filter aliases based on search
+	// Filter aliases based on search; patterns only target models, never aliases
 	let filteredAliases = $derived(
-		availableAliases.filter((alias) => {
-			if (!search) return true;
-			const lowerSearch = search.toLowerCase();
-			return (
-				alias.aliasName.toLowerCase().includes(lowerSearch) ||
-				alias.label.toLowerCase().includes(lowerSearch) ||
-				alias.effectiveModelName.toLowerCase().includes(lowerSearch)
-			);
-		})
+		patternPrefix !== null
+			? []
+			: availableAliases.filter((alias) => {
+					if (!search) return true;
+					const lowerSearch = search.toLowerCase();
+					return (
+						alias.aliasName.toLowerCase().includes(lowerSearch) ||
+						alias.label.toLowerCase().includes(lowerSearch) ||
+						alias.effectiveModelName.toLowerCase().includes(lowerSearch)
+					);
+				})
 	);
 
 	let defaultAliasesAvailable = $derived(filteredAliases.length > 0);
@@ -183,6 +221,34 @@
 						</div>
 						<div class="flex size-6 items-center justify-center">
 							{#if selectedSet.has('*')}
+								<Check class="text-primary size-6" />
+							{/if}
+						</div>
+					</button>
+				{/if}
+
+				{#if patternOption !== null && !exclude?.includes(patternOption.id)}
+					{@const pattern = patternOption}
+					<button
+						class={twMerge(
+							'hover:bg-base-300 dark:hover:bg-base-200 flex items-center justify-between gap-4 px-4 py-3 text-left',
+							selectedSet.has(pattern.id) && 'bg-base-200/50'
+						)}
+						onclick={() => toggleSelection(pattern.id)}
+					>
+						<div class="flex items-center gap-2">
+							<Cpu class="size-8 shrink-0" />
+							<div class="flex flex-col">
+								<p class="font-mono font-medium">{pattern.id}</p>
+								<span class="text-muted-content text-xs">
+									Grants access to all current and future models whose ID starts with "{pattern.prefix}"
+									— currently matches {patternMatchCount}
+									{patternMatchCount === 1 ? 'model' : 'models'}
+								</span>
+							</div>
+						</div>
+						<div class="flex size-6 items-center justify-center">
+							{#if selectedSet.has(pattern.id)}
 								<Check class="text-primary size-6" />
 							{/if}
 						</div>

--- a/ui/user/src/lib/services/llm-gateway/curl.ts
+++ b/ui/user/src/lib/services/llm-gateway/curl.ts
@@ -1,7 +1,7 @@
 import type { RenderContext, SnippetBlock } from './types';
 
 function loginSubstitution(obotURL: string): string {
-	return `$(obot login --url ${obotURL} --print-token)`;
+	return `$(obot login --url ${obotURL} --scope llm --print-token)`;
 }
 
 /** Build a copy-pasteable curl example for the provider's chat/messages endpoint. */


### PR DESCRIPTION
Model Access Policies now accept wildcard suffix patterns (e.g.
"claude-haiku-4-5*") as model entries, granting access to every model
whose ID starts with the given prefix.

- A pattern is a non-empty prefix followed by a single trailing '*'.
  A '*' anywhere else is rejected at validation, and the bare "*"
  entry keeps its existing "all models" meaning.
- Patterns match case-sensitively against each model's provider-native
  target model (e.g. "claude-haiku-4-5-20251001"), across all model
  providers.
- Patterns are forward-looking: when a provider adds a new model whose
  target model starts with the prefix, subjects of the policy gain
  access without any policy changes. Accordingly, the reconciler keeps
  pattern entries even when they currently match no models.
- Patterns can coexist with explicit model IDs and default model alias
  references in the same policy; overlapping grants are harmless.

Patterns are expanded where user access is evaluated, so the LLM proxy
access check, the proxy model listing, and the user-facing models API
all honor them consistently. In the admin UI, typing a trailing '*' in
the Add Models dialog offers the pattern as a selectable entry with a
live preview of currently matching models, and saved patterns display
with a badge and match count.

Addresses https://github.com/obot-platform/obot/issues/6830

