### PR TITLE
fix: ensure proper shutdown on signals

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/obot-platform/obot/pkg/server"
 	"github.com/obot-platform/obot/pkg/services"
 	"github.com/spf13/cobra"
@@ -15,5 +19,8 @@ func (s *Server) Customize(cmd *cobra.Command) {
 }
 
 func (s *Server) Run(cmd *cobra.Command, _ []string) error {
-	return server.Run(cmd.Context(), s.Config)
+	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, os.Kill, syscall.SIGTERM)
+	defer cancel()
+
+	return server.Run(ctx, s.Config)
 }


### PR DESCRIPTION
This allows controllers and whatnot to properly shutdown when the application is terminated. This is specifically important for the controllers so that the lease can be properly released.

Issue: https://github.com/obot-platform/obot/issues/6899