### PR TITLE
fix: friendlyName not being supplied in provider

### DIFF
--- a/apiclient/types/modelprovider.go
+++ b/apiclient/types/modelprovider.go
@@ -21,7 +21,7 @@ type CommonProviderStatus struct {
 
 type ProviderConfigurationParameter struct {
 	Name         string `json:"name"`
-	FriendlyName string `json:"friendlyName,omitempty"`
+	FriendlyName string `json:"friendlyName,omitempty" yaml:"friendlyName,omitempty"`
 	Description  string `json:"description,omitempty"`
 	Sensitive    bool   `json:"sensitive,omitempty"`
 	Hidden       bool   `json:"hidden,omitempty"`


### PR DESCRIPTION
Addresses #6870

Before: 
<img width="705" height="794" alt="Screenshot 2026-06-11 at 5 10 54 PM" src="https://github.com/user-attachments/assets/7242ceb2-148b-4729-8a97-c7767c1f1c17" />

After:
<img width="691" height="828" alt="Screenshot 2026-06-11 at 5 10 32 PM" src="https://github.com/user-attachments/assets/3387cbad-cbce-4b23-8922-0f93c5873eef" />
