### PR TITLE
fix: ensure NeedsK8sUpdate is set properly

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -3512,35 +3512,14 @@ func (m *MCPHandler) RedeployWithK8sSettings(req api.Context) error {
 			}
 			return fmt.Errorf("failed to redeploy server: %w", err)
 		}
-	}
 
-	if server.Status.NeedsK8sUpdate || hashDrift {
-		// Clear the NeedsK8sUpdate flag now that the redeployment has been initiated.
-		// Also update the K8sSettingsHash to the current expected hash so that the
-		// deployment handler won't re-set NeedsK8sUpdate when it observes the old
-		// deployment before the new one is created.
-		//
-		// Use retry.RetryOnConflict because the RestartServerDeployment call above
-		// can trigger controller-side status updates (e.g. UpdateMCPServerStatus)
-		// that race with this write and bump the ResourceVersion.
-		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			var latest v1.MCPServer
-			if err := req.Storage.Get(req.Context(), kclient.ObjectKey{
-				Namespace: req.Namespace(),
-				Name:      server.Name,
-			}, &latest); err != nil {
-				return err
-			}
-			latest.Status.NeedsK8sUpdate = false
-			latest.Status.K8sSettingsHash = currentHash
-			if err := req.Storage.Status().Update(req.Context(), &latest); err != nil {
-				return err
-			}
-			// Refresh server so the API response reflects the updated status.
-			server = latest
-			return nil
-		}); err != nil {
-			return fmt.Errorf("failed to update server status: %w", err)
+		// Wait for the redeployment to complete
+		_, err := wait.For(req.Context(), req.Storage, &server, func(s *v1.MCPServer) (bool, error) {
+			server = *s
+			return !s.Status.NeedsK8sUpdate, nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed to wait for redeployment: %w", err)
 		}
 	}
 

--- a/pkg/controller/handlers/deployment/deployment.go
+++ b/pkg/controller/handlers/deployment/deployment.go
@@ -55,6 +55,8 @@ func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) e
 		mcpServer.Status.DeploymentReadyReplicas = nil
 		mcpServer.Status.DeploymentReplicas = nil
 		mcpServer.Status.DeploymentConditions = nil
+		mcpServer.Status.K8sSettingsHash = ""
+		mcpServer.Status.NeedsK8sUpdate = false
 
 		return h.storageClient.Status().Update(req.Ctx, &mcpServer)
 	}
@@ -79,6 +81,13 @@ func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) e
 		return fmt.Errorf("failed to get MCPServer %s: %w", mcpServerName, err)
 	}
 
+	var needsUpdate bool
+
+	if deploymentK8sSettingsHash := deployment.Annotations["obot.ai/k8s-settings-hash"]; deploymentK8sSettingsHash != "" && mcpServer.Status.K8sSettingsHash != deploymentK8sSettingsHash {
+		mcpServer.Status.K8sSettingsHash = deploymentK8sSettingsHash
+		needsUpdate = true
+	}
+
 	// Extract deployment status information
 	deploymentStatus := getDeploymentStatus(deployment)
 	availableReplicas := deployment.Status.AvailableReplicas
@@ -86,11 +95,6 @@ func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) e
 	replicas := deployment.Spec.Replicas
 	conditions := getDeploymentConditions(deployment)
 
-	// Extract K8s settings hash from deployment annotation (only for Kubernetes runtime)
-	k8sSettingsHash := deployment.Annotations["obot.ai/k8s-settings-hash"]
-
-	// Check if we need to update the MCPServer status
-	var needsUpdate bool
 	if mcpServer.Status.DeploymentStatus != deploymentStatus {
 		mcpServer.Status.DeploymentStatus = deploymentStatus
 		needsUpdate = true
@@ -130,45 +134,12 @@ func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) e
 
 		currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", imagePullSecretNames)
 
-		shouldSetNeedsK8sUpdate := !mcpServer.Status.NeedsK8sUpdate &&
-			k8sSettingsHash != currentHash &&
-			mcpServer.Status.K8sSettingsHash != currentHash
-
-		// Update K8sSettingsHash from deployment only if:
-		// 1. The MCPServer has no hash yet (empty), OR
-		// 2. The deployment's hash matches the current K8sSettings (deployment is up-to-date)
-		// This prevents overwriting a hash that was set by the API handler during a redeploy
-		// before the deployment has been updated.
-		if k8sSettingsHash != "" {
-			if mcpServer.Status.K8sSettingsHash == "" || k8sSettingsHash == currentHash {
-				if mcpServer.Status.K8sSettingsHash != k8sSettingsHash {
-					mcpServer.Status.K8sSettingsHash = k8sSettingsHash
-					needsUpdate = true
-				}
-			}
-		}
-
-		// Only set NeedsK8sUpdate if:
-		// 1. It's not already set
-		// 2. The deployment has a hash (not initializing)
-		// 3. The deployment's hash doesn't match current K8sSettings
-		// 4. The MCPServer's expected hash also doesn't match current K8sSettings
-		//    (if MCPServer already expects the current hash, a redeploy is pending)
-		if !mcpServer.Status.NeedsK8sUpdate {
-			if shouldSetNeedsK8sUpdate {
-				mcpServer.Status.NeedsK8sUpdate = true
-				needsUpdate = true
-			}
-		}
-	} else {
-		// For non-K8s runtimes, just sync the hash from the deployment annotation
-		if mcpServer.Status.K8sSettingsHash != k8sSettingsHash {
-			mcpServer.Status.K8sSettingsHash = k8sSettingsHash
+		if k8sUpdateNeeded := mcpServer.Status.K8sSettingsHash != currentHash; k8sUpdateNeeded != mcpServer.Status.NeedsK8sUpdate {
+			mcpServer.Status.NeedsK8sUpdate = k8sUpdateNeeded
 			needsUpdate = true
 		}
 	}
 
-	// Update the MCPServer status if needed
 	if needsUpdate {
 		return h.storageClient.Status().Update(req.Ctx, &mcpServer)
 	}

--- a/pkg/controller/handlers/provider/provider.go
+++ b/pkg/controller/handlers/provider/provider.go
@@ -527,7 +527,6 @@ func (h *Handler) BackPopulateModels(req router.Request, _ router.Response) erro
 		})
 	}
 
-	// TODO: ensure this works when the owner reference type changes. Maybe we need to migrate.
 	if err = apply.New(req.Client).Apply(req.Ctx, modelProvider, models...); err != nil {
 		return fmt.Errorf("failed to create models for model provider %q: %w", modelProvider.Name, err)
 	}


### PR DESCRIPTION
This change simplifies the logic for setting the boolean identifying when a server needs a K8s settings update.

Issue: https://github.com/obot-platform/obot/issues/6785