### PR TITLE
chore: clean up old models that reference tool references

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -78,6 +78,10 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to migrate published artifact visibility: %w", err)
 	}
 
+	if err := deleteToolReferenceOwnedModels(ctx, c.services.StorageClient); err != nil {
+		return fmt.Errorf("failed to delete ToolReference-owned models: %w", err)
+	}
+
 	if err := migrateMultiUserMCPServerManifestValuesToCredentials(ctx, c.services.StorageClient, c.services.GatewayClient); err != nil {
 		return fmt.Errorf("failed to migrate MCP server manifest values to credentials: %w", err)
 	}

--- a/pkg/controller/handlers/provider/provider.go
+++ b/pkg/controller/handlers/provider/provider.go
@@ -527,7 +527,6 @@ func (h *Handler) BackPopulateModels(req router.Request, _ router.Response) erro
 		})
 	}
 
-	// TODO: ensure this works when the owner reference type changes. Maybe we need to migrate.
 	if err = apply.New(req.Client).Apply(req.Ctx, modelProvider, models...); err != nil {
 		return fmt.Errorf("failed to create models for model provider %q: %w", modelProvider.Name, err)
 	}

--- a/pkg/controller/migrate.go
+++ b/pkg/controller/migrate.go
@@ -73,6 +73,29 @@ func migratePublishedArtifactVisibility(ctx context.Context, client kclient.Clie
 	return nil
 }
 
+func deleteToolReferenceOwnedModels(ctx context.Context, client kclient.Client) error {
+	var models v1.ModelList
+	if err := client.List(ctx, &models); err != nil {
+		return err
+	}
+
+	for i := range models.Items {
+		model := &models.Items[i]
+		for _, owner := range model.OwnerReferences {
+			if owner.Kind != "ToolReference" {
+				continue
+			}
+
+			if err := kclient.IgnoreNotFound(client.Delete(ctx, model)); err != nil {
+				return fmt.Errorf("failed to delete ToolReference-owned model %s/%s: %w", model.Namespace, model.Name, err)
+			}
+			break
+		}
+	}
+
+	return nil
+}
+
 func migrateMultiUserMCPServerManifestValuesToCredentials(ctx context.Context, client kclient.Client, gatewayClient *gateway.Client) error {
 	var servers v1.MCPServerList
 	if err := client.List(ctx, &servers); err != nil {

--- a/pkg/controller/migrate_test.go
+++ b/pkg/controller/migrate_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -125,6 +127,76 @@ func TestMigratePublishedArtifactVisibility(t *testing.T) {
 		}, &publicArtifact))
 		assert.Empty(t, publicArtifact.Status.Versions[0].Subjects)
 	})
+}
+
+func TestDeleteToolReferenceOwnedModels(t *testing.T) {
+	ctx := context.Background()
+	client := newFakeClient(t,
+		&v1.Model{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "Model",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tool-reference-owned",
+				Namespace: system.DefaultNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: v1.SchemeGroupVersion.String(),
+						Kind:       "ToolReference",
+						Name:       "tool",
+						UID:        ktypes.UID("tool-uid"),
+					},
+				},
+			},
+		},
+		&v1.Model{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "Model",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "model-provider-owned",
+				Namespace: system.DefaultNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: v1.SchemeGroupVersion.String(),
+						Kind:       "ModelProvider",
+						Name:       "provider",
+						UID:        ktypes.UID("provider-uid"),
+					},
+				},
+			},
+		},
+		&v1.Model{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "Model",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unowned",
+				Namespace: system.DefaultNamespace,
+			},
+		},
+	)
+
+	require.NoError(t, deleteToolReferenceOwnedModels(ctx, client))
+
+	var model v1.Model
+	err := client.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      "tool-reference-owned",
+	}, &model)
+	require.True(t, apierrors.IsNotFound(err))
+
+	require.NoError(t, client.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      "model-provider-owned",
+	}, &model))
+	require.NoError(t, client.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      "unowned",
+	}, &model))
 }
 
 func TestExtractAndClearMCPServerConfigValues(t *testing.T) {


### PR DESCRIPTION
I've only run into this issue once in all the upgrade scenarios I've done from when we remove tool references. Since I hit it once, I figured we should migrate.