### PR TITLE
fix: use x-api-key header if authorization header is not set

### DIFF
--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -418,9 +418,9 @@ func (h *Handler) parseModelProvider(model resolvedLLMModel) (nanobotLLMProvider
 	if dialect == "" {
 		// No declared dialect — fall back to per-provider defaults.
 		switch model.ModelProvider {
-		case system.AnthropicModelProviderTool:
+		case system.AnthropicModelProvider:
 			dialect = nanobottypes.DialectAnthropicMessages
-		case system.OpenAIModelProviderTool:
+		case system.OpenAIModelProvider:
 			dialect = nanobottypes.DialectOpenAIResponses
 		default:
 			dialect = nanobottypes.DialectOpenResponses

--- a/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
@@ -147,8 +147,8 @@ func TestNanobotParseModelProviderBuiltinFallbacks(t *testing.T) {
 		wantDialect   nanobottypes.Dialect
 		wantBaseURL   string
 	}{
-		{system.OpenAIModelProviderTool, nanobottypes.DialectOpenAIResponses, "https://obot.example.com/api/llm-proxy/openai"},
-		{system.AnthropicModelProviderTool, nanobottypes.DialectAnthropicMessages, "https://obot.example.com/api/llm-proxy/anthropic"},
+		{system.OpenAIModelProvider, nanobottypes.DialectOpenAIResponses, "https://obot.example.com/api/llm-proxy/openai"},
+		{system.AnthropicModelProvider, nanobottypes.DialectAnthropicMessages, "https://obot.example.com/api/llm-proxy/anthropic"},
 		{"unknown-model-provider", nanobottypes.DialectOpenResponses, "https://obot.example.com/api/llm-proxy"},
 	} {
 		model := resolvedLLMModel{Name: "my-model", ModelProvider: tc.modelProvider}
@@ -304,21 +304,21 @@ func TestMultipleProvidersWhenLLMAndMiniDiffer(t *testing.T) {
 
 	llmModel := resolvedLLMModel{
 		Name:          "anthropic-claude-sonnet-4-6",
-		ModelProvider: system.AnthropicModelProviderTool,
+		ModelProvider: system.AnthropicModelProvider,
 	}
 	miniModel := resolvedLLMModel{
 		Name:          "openai-gpt-4.1-mini",
-		ModelProvider: system.OpenAIModelProviderTool,
+		ModelProvider: system.OpenAIModelProvider,
 	}
 
 	llmProvider, llmDefault := h.parseModelProvider(llmModel)
 	miniProvider, miniDefault := h.parseModelProvider(miniModel)
 
-	if llmDefault != system.AnthropicModelProviderTool+"/anthropic-claude-sonnet-4-6" {
-		t.Errorf("llmDefault = %q, want %s/anthropic-claude-sonnet-4-6", llmDefault, system.AnthropicModelProviderTool)
+	if llmDefault != system.AnthropicModelProvider+"/anthropic-claude-sonnet-4-6" {
+		t.Errorf("llmDefault = %q, want %s/anthropic-claude-sonnet-4-6", llmDefault, system.AnthropicModelProvider)
 	}
-	if miniDefault != system.OpenAIModelProviderTool+"/openai-gpt-4.1-mini" {
-		t.Errorf("miniDefault = %q, want %s/openai-gpt-4.1-mini", miniDefault, system.OpenAIModelProviderTool)
+	if miniDefault != system.OpenAIModelProvider+"/openai-gpt-4.1-mini" {
+		t.Errorf("miniDefault = %q, want %s/openai-gpt-4.1-mini", miniDefault, system.OpenAIModelProvider)
 	}
 
 	yaml, err := buildNanobotProviderConfigYAML(llmProvider, miniProvider)
@@ -334,10 +334,10 @@ func TestMultipleProvidersWhenLLMAndMiniDiffer(t *testing.T) {
 	if len(cfg.LLMProviders) != 2 {
 		t.Fatalf("expected 2 providers (one per model), got %d:\n%s", len(cfg.LLMProviders), yaml)
 	}
-	if _, ok := cfg.LLMProviders[system.AnthropicModelProviderTool]; !ok {
+	if _, ok := cfg.LLMProviders[system.AnthropicModelProvider]; !ok {
 		t.Errorf("anthropic-model-provider missing from YAML")
 	}
-	if _, ok := cfg.LLMProviders[system.OpenAIModelProviderTool]; !ok {
+	if _, ok := cfg.LLMProviders[system.OpenAIModelProvider]; !ok {
 		t.Errorf("openai-model-provider missing from YAML")
 	}
 }

--- a/pkg/controller/handlers/provider/provider.go
+++ b/pkg/controller/handlers/provider/provider.go
@@ -285,11 +285,11 @@ func (h *Handler) PollRegistries(ctx context.Context, c client.Client) {
 }
 
 func (h *Handler) EnsureOpenAIEnvCredentialAndDefaults(ctx context.Context, c client.Client) error {
-	return h.ensureModelProviderCredAndDefaults(ctx, c, OpenAIDefaultModelAliases(), system.OpenAIModelProviderTool, system.OpenAIAPIKeyEnvVar)
+	return h.ensureModelProviderCredAndDefaults(ctx, c, OpenAIDefaultModelAliases(), system.OpenAIModelProvider, system.OpenAIAPIKeyEnvVar)
 }
 
 func (h *Handler) EnsureAnthropicCredentialAndDefaults(ctx context.Context, c client.Client) error {
-	return h.ensureModelProviderCredAndDefaults(ctx, c, AnthropicDefaultModelAliases(), system.AnthropicModelProviderTool, system.AnthropicAPIKeyEnvVar)
+	return h.ensureModelProviderCredAndDefaults(ctx, c, AnthropicDefaultModelAliases(), system.AnthropicModelProvider, system.AnthropicAPIKeyEnvVar)
 }
 
 func (h *Handler) ensureModelProviderCredAndDefaults(ctx context.Context, c client.Client, defaultModelAliasMapping map[types.DefaultModelAliasType]string, modelProviderName, envVarName string) error {

--- a/pkg/gateway/server/apikey_auth.go
+++ b/pkg/gateway/server/apikey_auth.go
@@ -26,25 +26,21 @@ func NewAPIKeyAuthenticator(client *client.Client) *APIKeyAuthenticator {
 
 // AuthenticateRequest implements authenticator.Request.
 func (a *APIKeyAuthenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
-	// Extract Bearer token from Authorization header
-	authHeader := req.Header.Get("Authorization")
+	authHeader := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
 	if authHeader == "" {
-		return nil, false, nil
-	}
-
-	bearer := strings.TrimPrefix(authHeader, "Bearer ")
-	if bearer == authHeader {
-		// No "Bearer " prefix
-		return nil, false, nil
+		authHeader = req.Header.Get("X-API-Key")
+		if authHeader == "" {
+			return nil, false, nil
+		}
 	}
 
 	// Check if this is an API key (starts with ok1-)
-	if !strings.HasPrefix(bearer, apiKeyAuthPrefix) {
+	if !strings.HasPrefix(authHeader, apiKeyAuthPrefix) {
 		return nil, false, nil
 	}
 
 	// Validate the API key
-	apiKey, err := a.client.ValidateAPIKey(req.Context(), bearer)
+	apiKey, err := a.client.ValidateAPIKey(req.Context(), authHeader)
 	if err != nil {
 		// Return false, nil to let other authenticators try
 		// This allows the chain to continue if the key is invalid

--- a/pkg/gateway/server/router.go
+++ b/pkg/gateway/server/router.go
@@ -62,8 +62,8 @@ func (s *Server) AddRoutes(mux *server.Server) {
 	mux.HandleFunc("/api/oauth/redirect/{namespace}/{name}", wrap(s.redirect))
 
 	// LLM proxy
-	mux.HandleFunc("/api/llm-proxy/openai/{path...}", s.newLLMProviderProxy(mustParseURL(openAIBaseURL), system.OpenAIModelProviderTool).proxy)
-	mux.HandleFunc("/api/llm-proxy/anthropic/{path...}", s.newLLMProviderProxy(mustParseURL(anthropicBaseURL), system.AnthropicModelProviderTool).proxy)
+	mux.HandleFunc("/api/llm-proxy/openai/{path...}", s.newLLMProviderProxy(mustParseURL(openAIBaseURL), system.OpenAIModelProvider).proxy)
+	mux.HandleFunc("/api/llm-proxy/anthropic/{path...}", s.newLLMProviderProxy(mustParseURL(anthropicBaseURL), system.AnthropicModelProvider).proxy)
 	mux.HandleFunc("/api/llm-proxy/{path...}", s.dispatchLLMProxy)
 
 	// API Keys for MCP server access - user's own keys

--- a/pkg/storage/apis/obot.obot.ai/v1/authprovider.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/authprovider.go
@@ -18,7 +18,7 @@ type AuthProvider struct {
 func (in *AuthProvider) GetColumns() [][]string {
 	return [][]string{
 		{"Name", "Name"},
-		{"Image", "Spec.Image"},
+		{"Command", "Spec.Command"},
 		{"Created", "{{ago .CreationTimestamp}}"},
 	}
 }

--- a/pkg/storage/apis/obot.obot.ai/v1/modelprovider.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/modelprovider.go
@@ -18,7 +18,7 @@ type ModelProvider struct {
 func (in *ModelProvider) GetColumns() [][]string {
 	return [][]string{
 		{"Name", "Name"},
-		{"Image", "Spec.Image"},
+		{"Command", "Spec.Command"},
 		{"Created", "{{ago .CreationTimestamp}}"},
 	}
 }

--- a/pkg/system/tools.go
+++ b/pkg/system/tools.go
@@ -1,8 +1,8 @@
 package system
 
 const (
-	OpenAIModelProviderTool    = "openai-model-provider"
-	AnthropicModelProviderTool = "anthropic-model-provider"
+	OpenAIModelProvider    = "openai-model-provider"
+	AnthropicModelProvider = "anthropic-model-provider"
 
 	OpenAIAPIKeyEnvVar    = "OPENAI_API_KEY"
 	AnthropicAPIKeyEnvVar = "ANTHROPIC_API_KEY"


### PR DESCRIPTION
This allows MCP api keys to be used with Anthropic-style authentication.

Issue: https://github.com/obot-platform/obot/issues/6896