### PR TITLE
fix: validate audience on JWT tokens

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -24,8 +24,6 @@ const (
 
 var (
 	adminAndOwnerRules = []string{
-		"/api/tool-references",
-		"/api/tool-references/",
 		"/api/mcp-catalogs",
 		"/api/mcp-catalogs/",
 		"/api/mcp-servers",
@@ -210,8 +208,6 @@ var (
 			"GET /api/auth-providers",
 			"GET /api/auth-providers/{id}",
 
-			"GET /api/tool-references",
-
 			"GET /.well-known/",
 			"POST /oauth/register/{mcp_id}",
 			"POST /oauth/register",
@@ -277,12 +273,10 @@ var (
 			"GET /api/api-keys/{id}",
 			"DELETE /api/api-keys/{id}",
 
-			"GET /oauth/userinfo",
 			"GET /api/users",
 			"GET /api/users/{user_id}",
 			"GET /api/default-model-aliases",
 			"/api/oauth/redirect/{namespace}/{name}",
-			"GET /api/me",
 			"DELETE /api/me",
 			"PATCH /api/me",
 			"POST /api/logout-all",
@@ -304,7 +298,7 @@ var (
 			"GET /api/mcp-stats/{mcp_id}",
 		},
 
-		types.GroupMCP: {
+		types.GroupAuthenticated: {
 			"GET /oauth/userinfo",
 			"GET /api/me",
 		},

--- a/pkg/api/authz/mcpoauth_test.go
+++ b/pkg/api/authz/mcpoauth_test.go
@@ -28,7 +28,7 @@ func TestMCPGroupAllowsMCPAndAnyGroupRoutes(t *testing.T) {
 	mcpUser := &user.DefaultInfo{
 		Name:   "mcp-user",
 		UID:    "mcpoauth-user-uid",
-		Groups: []string{types.GroupMCP},
+		Groups: []string{types.GroupMCP, types.GroupAuthenticated},
 	}
 
 	tests := []struct {

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -568,18 +568,12 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 		return types.NewErrNotFound("no token exchange for %s", resource)
 	} else if mcpID == system.ObotMCPServerName {
 		// Return a new token that represents the user, so that the Obot MCP server can make API calls to Obot on behalf of the user.
-		// Preserve the user's existing groups/roles when available from the subject token,
-		// otherwise look up the user to determine their role.
-		var userGroups []string
-		if tokenCtx != nil && len(tokenCtx.UserGroups) > 0 {
-			userGroups = tokenCtx.UserGroups
-		} else {
-			user, err := req.GatewayClient.UserByID(req.Context(), userID)
-			if err != nil {
-				return fmt.Errorf("failed to look up user for token exchange: %w", err)
-			}
-			userGroups = user.Role.Groups()
+		// This token must have the user's groups to allow API access. Get the groups from the user's role.
+		user, err := req.GatewayClient.UserByID(req.Context(), userID)
+		if err != nil {
+			return fmt.Errorf("failed to look up user for token exchange: %w", err)
 		}
+		userGroups := user.Role.Groups()
 
 		now := time.Now()
 		expiresAt := now.Add(time.Hour)

--- a/pkg/jwt/persistent/persistent.go
+++ b/pkg/jwt/persistent/persistent.go
@@ -182,13 +182,16 @@ func (t *TokenService) AuthenticateRequest(req *http.Request) (*authenticator.Re
 		} else {
 			extra["auth_provider_groups"] = authGroupIDs
 
-			// Resolve effective role by merging individual + group roles
-			if gatewayUser, err := t.gatewayClient.UserByID(req.Context(), tokenContext.UserID); err != nil {
-				log.Warnf("failed to look up user %s for role resolution: %s", tokenContext.UserID, err.Error())
-			} else if effectiveRole, err := t.gatewayClient.ResolveUserEffectiveRole(req.Context(), gatewayUser, authGroupIDs); err != nil {
-				log.Warnf("failed to resolve effective role for user %s: %s", tokenContext.UserID, err.Error())
-			} else {
-				groups = effectiveRole.Groups()
+			// If this token is scoped to the user's groups, then resolve the effective role.
+			if slices.Contains(groups, types.GroupBasic) {
+				// Resolve effective role by merging individual + group roles
+				if gatewayUser, err := t.gatewayClient.UserByID(req.Context(), tokenContext.UserID); err != nil {
+					log.Warnf("failed to look up user %s for role resolution: %s", tokenContext.UserID, err.Error())
+				} else if effectiveRole, err := t.gatewayClient.ResolveUserEffectiveRole(req.Context(), gatewayUser, authGroupIDs); err != nil {
+					log.Warnf("failed to resolve effective role for user %s: %s", tokenContext.UserID, err.Error())
+				} else {
+					groups = effectiveRole.Groups()
+				}
 			}
 		}
 	}
@@ -197,7 +200,7 @@ func (t *TokenService) AuthenticateRequest(req *http.Request) (*authenticator.Re
 		User: &user.DefaultInfo{
 			UID:    tokenContext.UserID,
 			Name:   tokenContext.UserName,
-			Groups: append(groups, types.GroupMCP),
+			Groups: groups,
 			Extra:  extra,
 		},
 	}, true, nil
@@ -226,15 +229,29 @@ func (t *TokenService) DecodeToken(ctx context.Context, token string) (*TokenCon
 	if err != nil {
 		return nil, err
 	}
+
 	claims, ok := tk.Claims.(jwt.MapClaims)
 	if !ok {
 		return nil, err
 	}
 
+	audiences, err := claims.GetAudience()
+	if err != nil {
+		return nil, err
+	}
+
 	var groups []string
-	if userGroups, ok := claims["UserGroups"].(string); ok {
-		groups = strings.Split(userGroups, ",")
-		groups = slices.DeleteFunc(groups, func(s string) bool { return s == "" })
+	if len(audiences) == 0 {
+		return nil, fmt.Errorf("no audience")
+	} else if audiences[0] == t.serverURL {
+		// In this case, the token was meant for API access, use the UserGroups claim
+		if userGroups, ok := claims["UserGroups"].(string); ok {
+			groups = strings.Split(userGroups, ",")
+			groups = slices.DeleteFunc(groups, func(s string) bool { return s == "" })
+		}
+	} else if strings.HasPrefix(audiences[0], t.serverURL+"/mcp-connect/") {
+		// In this case, the token was meant for MCP access, just give it the MCP group.
+		groups = []string{types.GroupMCP, types.GroupAuthenticated}
 	}
 
 	var issuedAt, expiresAt time.Time

--- a/pkg/jwt/persistent/persistent_test.go
+++ b/pkg/jwt/persistent/persistent_test.go
@@ -1,0 +1,86 @@
+package persistent
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testServerURL = "https://obot.example.com"
+
+func newTestTokenService(t *testing.T) *TokenService {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	tokenService, err := NewTokenService(testServerURL, nil)
+	require.NoError(t, err)
+	require.NoError(t, tokenService.replaceKey(t.Context(), privateKey))
+
+	return tokenService
+}
+
+func TestDecodeTokenUsesUserGroupsForAPIAudience(t *testing.T) {
+	tokenService := newTestTokenService(t)
+
+	token, err := tokenService.NewToken(t.Context(), TokenContext{
+		Audience:   testServerURL,
+		IssuedAt:   time.Now().Add(-time.Minute),
+		ExpiresAt:  time.Now().Add(time.Hour),
+		UserID:     "123",
+		UserName:   "test-user",
+		UserEmail:  "test@example.com",
+		UserGroups: []string{types.GroupAdmin, "", types.GroupAuthenticated},
+	})
+	require.NoError(t, err)
+
+	tokenContext, err := tokenService.DecodeToken(t.Context(), token)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{types.GroupAdmin, types.GroupAuthenticated}, tokenContext.UserGroups)
+	assert.Equal(t, testServerURL, tokenContext.Audience)
+	assert.Equal(t, "123", tokenContext.UserID)
+	assert.Equal(t, "test-user", tokenContext.UserName)
+	assert.Equal(t, "test@example.com", tokenContext.UserEmail)
+}
+
+func TestDecodeTokenUsesMCPGroupsForMCPConnectAudience(t *testing.T) {
+	tokenService := newTestTokenService(t)
+	audience := testServerURL + "/mcp-connect/server-id"
+
+	token, err := tokenService.NewToken(t.Context(), TokenContext{
+		Audience:   audience,
+		IssuedAt:   time.Now().Add(-time.Minute),
+		ExpiresAt:  time.Now().Add(time.Hour),
+		UserID:     "123",
+		UserGroups: []string{types.GroupAdmin, types.GroupOwner, types.GroupAuthenticated},
+	})
+	require.NoError(t, err)
+
+	tokenContext, err := tokenService.DecodeToken(t.Context(), token)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{types.GroupMCP, types.GroupAuthenticated}, tokenContext.UserGroups)
+	assert.Equal(t, audience, tokenContext.Audience)
+}
+
+func TestDecodeTokenRejectsMissingAudience(t *testing.T) {
+	tokenService := newTestTokenService(t)
+
+	_, token, err := tokenService.NewTokenWithClaims(t.Context(), jwt.MapClaims{
+		"aud": nil,
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+		"iat": float64(time.Now().Add(-time.Minute).Unix()),
+		"sub": "123",
+	})
+	require.NoError(t, err)
+
+	_, err = tokenService.DecodeToken(t.Context(), token)
+	require.ErrorContains(t, err, "no audience")
+}


### PR DESCRIPTION
If the audience is an MCP server, then this change ensures that only the MCP and authenticated groups are used. If the audience is the Obot instance itself, then the UserGroups passed to the context are used.

This is really only a fail-safe. The authorization logic would do the right thing if the correct groups were provided when creating the token.