### PR TITLE
chore: remove unused docker engine packages from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV PGDATA=/data/postgresql
 COPY --from=build-pgvector /usr/lib/postgresql17/vector.so /usr/lib/postgresql17/
 COPY --from=build-pgvector /usr/share/postgresql17/extension/vector* /usr/share/postgresql17/extension/
 
-RUN apk add --no-cache git python-3.13 py3.13-pip npm nodejs bash tini procps libreoffice docker perl-utils sqlite sqlite-dev curl kubectl jq
+RUN apk add --no-cache git python-3.13 py3.13-pip npm nodejs bash tini procps libreoffice perl-utils sqlite sqlite-dev curl kubectl jq
 
 ENV OBOT_SERVER_DEFAULT_MCPCATALOG_PATH=https://github.com/obot-platform/mcp-catalog
 ENV OBOT_SERVER_DEFAULT_SYSTEM_MCPCATALOG_PATH=https://github.com/obot-platform/system-mcp-catalog


### PR DESCRIPTION
The final image installed the `docker` apk meta-package, which drags in the docker CLI, dockerd, containerd, runc, and the buildx/compose plugins.

These packages are not required for the docker backend to work and only contributed vulnerabilities (CVE-2026-34040, CVE-2026-42306, CVE-2026-41567, and CVE-2025-15558 — the last being Windows-only and not exploitable here).
