### PR TITLE
fix: env var name in auth required text

### DIFF
--- a/docs/docs/functionality/llm-gateway.md
+++ b/docs/docs/functionality/llm-gateway.md
@@ -53,14 +53,8 @@ Your API key for the gateway must include LLM proxy access. Print one with the C
 obot login --url https://obot.example.com --scope llm --print-token
 ```
 
-This logs you in (opening a browser if needed) and prints the key to stdout, so you can capture it directly into an environment variable:
-
-```bash
-export OBOT_TOKEN="$(obot login --url https://obot.example.com --scope llm --print-token)"
-```
-
 :::note
-The `Logged in to ...` confirmation is printed to stderr, so command substitution captures only the key. Add `--no-expiration` if you want a key that doesn't expire.
+Add `--no-expiration` if you want a key that doesn't expire.
 :::
 
 ## Quick start with curl

--- a/pkg/cli/internal/token.go
+++ b/pkg/cli/internal/token.go
@@ -201,7 +201,7 @@ func Token(ctx context.Context, baseURL string, opts apiclient.TokenFetchOptions
 		fmt.Fprintln(w, color.GreenString("========================"))
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, color.CyanString(provider.Name)+" is used for authentication using the browser. This can be bypassed by setting")
-		fmt.Fprintln(w, "the env var "+color.CyanString("OBOT_API_KEY")+" to your API key.")
+		fmt.Fprintln(w, "the env var "+color.CyanString("OBOT_TOKEN")+" to your API key.")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, color.GreenString("Press ENTER to continue (CTRL+C to exit)"))
 		if err := enter(ctx); err != nil {


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/6945

