### PR TITLE
fix: ensure token has requested scopes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ generate:
 
 test:
 	go test -v -cover ./...
+	cd apiclient && go test -v -cover ./... && cd ..
+	cd logger && go test -v -cover ./... && cd ..
 
 # Runs Go linters and validates that all generated code is committed.
 validate-go-code: tidy generate lint-go no-changes

--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -47,13 +47,77 @@ func (c *Client) WithToken(token string) *Client {
 }
 
 func (c *Client) GetToken(ctx context.Context, opts TokenFetchOptions) (string, error) {
-	if c.Token != "" && !opts.ForceRefresh {
-		return c.Token, nil
+	if !opts.ForceRefresh && c.Token != "" {
+		return c.Token, TokenHasScopes(ctx, c.BaseURL, c.Token, opts.Scopes)
 	}
 	if c.tokenFetcher != nil {
 		return c.tokenFetcher(ctx, c.BaseURL, opts)
 	}
 	return "", fmt.Errorf("no token or token fetcher")
+}
+
+type tokenScopeValidationResponse struct {
+	Allowed bool `json:"allowed"`
+	Scopes  struct {
+		CanAccessSkills             bool     `json:"canAccessSkills"`
+		CanAccessAPI                bool     `json:"canAccessAPI"`
+		CanAccessLLMProxy           bool     `json:"canAccessLLMProxy"`
+		CanAccessPublishedArtifacts bool     `json:"canAccessPublishedArtifacts"`
+		MCPServerIDs                []string `json:"mcpServerIds,omitempty"`
+	} `json:"scopes"`
+}
+
+// TokenHasScopes reports whether token is valid for baseURL and includes all requested scopes.
+func TokenHasScopes(ctx context.Context, baseURL, token string, scopes []string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(baseURL, "/")+"/api-keys/auth", strings.NewReader(`{"validateOnly": true}`))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var validation tokenScopeValidationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&validation); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+	if !validation.Allowed {
+		return fmt.Errorf("token is not allowed")
+	}
+
+	for _, scope := range scopes {
+		switch scope {
+		case "api":
+			if !validation.Scopes.CanAccessAPI {
+				return fmt.Errorf("token does not have scope: %s", scope)
+			}
+		case "skills":
+			if !validation.Scopes.CanAccessSkills && !validation.Scopes.CanAccessAPI {
+				return fmt.Errorf("token does not have scope: %s", scope)
+			}
+		case "llm":
+			if !validation.Scopes.CanAccessLLMProxy && !validation.Scopes.CanAccessAPI {
+				return fmt.Errorf("token does not have scope: %s", scope)
+			}
+		case "published-artifacts":
+			if !validation.Scopes.CanAccessPublishedArtifacts && !validation.Scopes.CanAccessAPI {
+				return fmt.Errorf("token does not have scope: %s", scope)
+			}
+		case "all-mcp":
+			if !slices.Contains(validation.Scopes.MCPServerIDs, "*") {
+				return fmt.Errorf("token does not have scope: %s", scope)
+			}
+		default:
+			return fmt.Errorf("unknown scope: %s", scope)
+		}
+	}
+
+	return nil
 }
 
 func (c *Client) postJSON(ctx context.Context, path string, obj any, headerKV ...string) (*http.Request, *http.Response, error) {

--- a/apiclient/client_test.go
+++ b/apiclient/client_test.go
@@ -1,0 +1,101 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTokenHasScopes(t *testing.T) {
+	tests := []struct {
+		name   string
+		scopes []string
+		resp   map[string]any
+		want   bool
+	}{
+		{
+			name:   "API scope satisfies non-MCP scopes",
+			scopes: []string{"skills", "llm", "published-artifacts"},
+			resp: map[string]any{
+				"allowed": true,
+				"scopes": map[string]any{
+					"canAccessAPI": true,
+				},
+			},
+			want: true,
+		},
+		{
+			name:   "API scope does not satisfy MCP scope",
+			scopes: []string{"all-mcp"},
+			resp: map[string]any{
+				"allowed": true,
+				"scopes": map[string]any{
+					"canAccessAPI": true,
+				},
+			},
+			want: false,
+		},
+		{
+			name:   "MCP wildcard satisfies MCP scope",
+			scopes: []string{"all-mcp"},
+			resp: map[string]any{
+				"allowed": true,
+				"scopes": map[string]any{
+					"mcpServerIds": []string{"*"},
+				},
+			},
+			want: true,
+		},
+		{
+			name:   "specific scope satisfies matching request",
+			scopes: []string{"skills"},
+			resp: map[string]any{
+				"allowed": true,
+				"scopes": map[string]any{
+					"canAccessSkills": true,
+				},
+			},
+			want: true,
+		},
+		{
+			name:   "missing requested scope fails",
+			scopes: []string{"api"},
+			resp: map[string]any{
+				"allowed": true,
+				"scopes":  map[string]any{},
+			},
+			want: false,
+		},
+		{
+			name:   "disallowed token fails",
+			scopes: []string{"api"},
+			resp: map[string]any{
+				"allowed": false,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api-keys/auth" {
+					t.Fatalf("unexpected path %s", r.URL.Path)
+				}
+				if r.Method != http.MethodPost {
+					t.Fatalf("method = %s, want POST", r.Method)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+					t.Fatalf("Authorization = %q, want bearer token", got)
+				}
+				_ = json.NewEncoder(w).Encode(tt.resp)
+			}))
+			defer srv.Close()
+
+			if got := TokenHasScopes(t.Context(), srv.URL+"/", "test-token", tt.scopes); (got == nil) != tt.want {
+				t.Fatalf("TokenHasScopes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/internal/token.go
+++ b/pkg/cli/internal/token.go
@@ -25,8 +25,12 @@ import (
 	"github.com/pkg/browser"
 )
 
-var credentialStore credentials.Store = credentials.NewKeyringStore()
-var openBrowser = browser.OpenURL
+var (
+	credentialStore credentials.Store = credentials.NewKeyringStore()
+	openBrowser                       = browser.OpenURL
+)
+
+const TokenEnvVar = "OBOT_TOKEN"
 
 func init() {
 	// Browser launchers (e.g. xdg-open) may write to stdout; keep stdout
@@ -169,7 +173,7 @@ func Token(ctx context.Context, baseURL string, opts apiclient.TokenFetchOptions
 	if tokenErr != nil && !credentials.IsNotFound(tokenErr) {
 		return "", tokenErr
 	}
-	if hasStoredToken && !opts.ForceRefresh && testToken(ctx, baseURL, token) {
+	if hasStoredToken && !opts.ForceRefresh && testToken(ctx, baseURL, token, opts.Scopes...) {
 		return token, nil
 	}
 
@@ -201,7 +205,7 @@ func Token(ctx context.Context, baseURL string, opts apiclient.TokenFetchOptions
 		fmt.Fprintln(w, color.GreenString("========================"))
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, color.CyanString(provider.Name)+" is used for authentication using the browser. This can be bypassed by setting")
-		fmt.Fprintln(w, "the env var "+color.CyanString("OBOT_TOKEN")+" to your API key.")
+		fmt.Fprintln(w, "the env var "+color.CyanString(TokenEnvVar)+" to your API key.")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, color.GreenString("Press ENTER to continue (CTRL+C to exit)"))
 		if err := enter(ctx); err != nil {
@@ -240,9 +244,10 @@ type createResponse struct {
 
 func create(ctx context.Context, baseURL, uuid, providerName, providerNamespace, tokenName, tokenDescription string, noExpiration bool, scopes []string) (string, error) {
 	apiScopes := types.APIKeyScopes{
-		CanAccessSkills:   slices.Contains(scopes, "skills"),
-		CanAccessAPI:      slices.Contains(scopes, "api"),
-		CanAccessLLMProxy: slices.Contains(scopes, "llm"),
+		CanAccessSkills:             slices.Contains(scopes, "skills"),
+		CanAccessAPI:                slices.Contains(scopes, "api"),
+		CanAccessLLMProxy:           slices.Contains(scopes, "llm"),
+		CanAccessPublishedArtifacts: slices.Contains(scopes, "published-artifacts"),
 	}
 	if slices.Contains(scopes, "all-mcp") {
 		apiScopes.MCPServerIDs = []string{"*"}
@@ -317,7 +322,7 @@ func get(ctx context.Context, baseURL, uuid string) (string, error) {
 	}
 }
 
-func testToken(ctx context.Context, baseURL, token string) bool {
+func testToken(ctx context.Context, baseURL, token string, scopes ...string) bool {
 	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/me", nil)
 	if err != nil {
 		return false
@@ -337,7 +342,17 @@ func testToken(ctx context.Context, baseURL, token string) bool {
 		return false
 	}
 
-	return resp.StatusCode == 200 && user.Username != "anonymous"
+	if resp.StatusCode != http.StatusOK || user.Username == "anonymous" {
+		return false
+	}
+
+	if len(scopes) == 0 || token == "" {
+		// If no scopes are specified or the request passed without a token,
+		// then we don't need to check the token's scopes.
+		return true
+	}
+
+	return apiclient.TokenHasScopes(ctx, baseURL, token, scopes) == nil
 }
 
 func getAuthProviderServiceInfo(ctx context.Context, baseURL string) ([]types2.AuthProvider, error) {

--- a/pkg/cli/internal/token_test.go
+++ b/pkg/cli/internal/token_test.go
@@ -348,6 +348,209 @@ func TestTokenRequestIncludesRequestedScopes(t *testing.T) {
 	}
 }
 
+func TestTokenRefreshesValidKeyringTokenMissingRequestedScopes(t *testing.T) {
+	store := newFakeCredentialStore()
+	restoreStore := useCredentialStore(t, store)
+	defer restoreStore()
+
+	restoreBrowser := useOpenBrowser(t, func(string) error { return nil })
+	defer restoreBrowser()
+
+	var createdRequest createRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/me":
+			switch r.Header.Get("Authorization") {
+			case "":
+				_ = json.NewEncoder(w).Encode(types.User{Username: "anonymous"})
+			case "Bearer scoped-token":
+				_ = json.NewEncoder(w).Encode(types.User{Username: "alice"})
+			default:
+				t.Fatalf("unexpected authorization header %q", r.Header.Get("Authorization"))
+			}
+		case "/api/api-keys/auth":
+			if r.Header.Get("Authorization") != "Bearer scoped-token" {
+				t.Fatalf("unexpected scope validation authorization header %q", r.Header.Get("Authorization"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"allowed": true,
+				"scopes": map[string]any{
+					"canAccessSkills": true,
+				},
+			})
+		case "/api/auth-providers":
+			_ = json.NewEncoder(w).Encode(types.AuthProviderList{Items: []types.AuthProvider{{
+				Metadata: types.Metadata{ID: "github"},
+				AuthProviderManifest: types.AuthProviderManifest{
+					CommonProviderMetadata: types.CommonProviderMetadata{
+						Name: "GitHub",
+					},
+				},
+				AuthProviderStatus: types.AuthProviderStatus{
+					CommonProviderStatus: types.CommonProviderStatus{Configured: true},
+					Namespace:            "default",
+				},
+			}}})
+		case "/api/token-request":
+			if err := json.NewDecoder(r.Body).Decode(&createdRequest); err != nil {
+				t.Fatalf("decode token request: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"token-path": "https://example.com/login"})
+		default:
+			if strings.HasPrefix(r.URL.Path, "/api/token-request/") {
+				_ = json.NewEncoder(w).Encode(map[string]string{"Token": "new-token"})
+				return
+			}
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	store.tokens[srv.URL] = "scoped-token"
+
+	token, err := Token(WithNonInteractive(t.Context()), srv.URL+"/api", apiclient.TokenFetchOptions{
+		Scopes: []string{"api"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "new-token" {
+		t.Fatalf("token = %q, want new token", token)
+	}
+	if got := store.tokens[srv.URL]; got != "new-token" {
+		t.Fatalf("stored token = %q, want new token", got)
+	}
+	if !createdRequest.Scopes.CanAccessAPI {
+		t.Fatalf("new token request should ask for API scope")
+	}
+}
+
+func TestTokenReusesAPIKeyringTokenForNonMCPScopes(t *testing.T) {
+	store := newFakeCredentialStore()
+	restoreStore := useCredentialStore(t, store)
+	defer restoreStore()
+
+	authProvidersCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/me":
+			switch r.Header.Get("Authorization") {
+			case "":
+				_ = json.NewEncoder(w).Encode(types.User{Username: "anonymous"})
+			case "Bearer api-token":
+				_ = json.NewEncoder(w).Encode(types.User{Username: "alice"})
+			default:
+				t.Fatalf("unexpected authorization header %q", r.Header.Get("Authorization"))
+			}
+		case "/api/api-keys/auth":
+			if r.Header.Get("Authorization") != "Bearer api-token" {
+				t.Fatalf("unexpected scope validation authorization header %q", r.Header.Get("Authorization"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"allowed": true,
+				"scopes": map[string]any{
+					"canAccessAPI": true,
+				},
+			})
+		case "/api/auth-providers":
+			authProvidersCalled = true
+			t.Fatalf("auth provider discovery should not run for reusable API token")
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	store.tokens[srv.URL] = "api-token"
+
+	token, err := Token(WithNonInteractive(t.Context()), srv.URL+"/api", apiclient.TokenFetchOptions{
+		Scopes: []string{"skills", "llm", "published-artifacts"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "api-token" {
+		t.Fatalf("token = %q, want API token", token)
+	}
+	if authProvidersCalled {
+		t.Fatalf("auth provider discovery should not run")
+	}
+}
+
+func TestTokenRefreshesAPIKeyringTokenForMCPScope(t *testing.T) {
+	store := newFakeCredentialStore()
+	restoreStore := useCredentialStore(t, store)
+	defer restoreStore()
+
+	restoreBrowser := useOpenBrowser(t, func(string) error { return nil })
+	defer restoreBrowser()
+
+	var createdRequest createRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/me":
+			switch r.Header.Get("Authorization") {
+			case "":
+				_ = json.NewEncoder(w).Encode(types.User{Username: "anonymous"})
+			case "Bearer api-token":
+				_ = json.NewEncoder(w).Encode(types.User{Username: "alice"})
+			default:
+				t.Fatalf("unexpected authorization header %q", r.Header.Get("Authorization"))
+			}
+		case "/api/api-keys/auth":
+			if r.Header.Get("Authorization") != "Bearer api-token" {
+				t.Fatalf("unexpected scope validation authorization header %q", r.Header.Get("Authorization"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"allowed": true,
+				"scopes": map[string]any{
+					"canAccessAPI": true,
+				},
+			})
+		case "/api/auth-providers":
+			_ = json.NewEncoder(w).Encode(types.AuthProviderList{Items: []types.AuthProvider{{
+				Metadata: types.Metadata{ID: "github"},
+				AuthProviderManifest: types.AuthProviderManifest{
+					CommonProviderMetadata: types.CommonProviderMetadata{
+						Name: "GitHub",
+					},
+				},
+				AuthProviderStatus: types.AuthProviderStatus{
+					CommonProviderStatus: types.CommonProviderStatus{Configured: true},
+					Namespace:            "default",
+				},
+			}}})
+		case "/api/token-request":
+			if err := json.NewDecoder(r.Body).Decode(&createdRequest); err != nil {
+				t.Fatalf("decode token request: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"token-path": "https://example.com/login"})
+		default:
+			if strings.HasPrefix(r.URL.Path, "/api/token-request/") {
+				_ = json.NewEncoder(w).Encode(map[string]string{"Token": "new-token"})
+				return
+			}
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	store.tokens[srv.URL] = "api-token"
+
+	token, err := Token(WithNonInteractive(t.Context()), srv.URL+"/api", apiclient.TokenFetchOptions{
+		Scopes: []string{"all-mcp"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "new-token" {
+		t.Fatalf("token = %q, want new token", token)
+	}
+	if strings.Join(createdRequest.Scopes.MCPServerIDs, ",") != "*" {
+		t.Fatalf("MCPServerIDs = %v, want [*]", createdRequest.Scopes.MCPServerIDs)
+	}
+}
+
 func TestTokenNonInteractiveSkipsBrowserEnterGate(t *testing.T) {
 	store := newFakeCredentialStore()
 	restoreStore := useCredentialStore(t, store)

--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/obot-platform/obot/apiclient"
+	"github.com/obot-platform/obot/pkg/cli/internal"
 	"github.com/obot-platform/obot/pkg/cli/internal/localconfig"
 	"github.com/spf13/cobra"
 )
@@ -43,6 +44,9 @@ func (l *Login) Run(cmd *cobra.Command, _ []string) error {
 		Scopes:       l.Scopes,
 	})
 	if err != nil {
+		if l.root.Client.Token != "" {
+			return fmt.Errorf("unable to validate provided %s: %w", internal.TokenEnvVar, err)
+		}
 		return err
 	}
 	fmt.Fprintf(os.Stderr, "Logged in to %s\n", l.root.Client.BaseURL)

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -79,6 +79,6 @@ func newClient() *apiclient.Client {
 
 	return &apiclient.Client{
 		BaseURL: baseURL,
-		Token:   os.Getenv("OBOT_TOKEN"),
+		Token:   os.Getenv(internal.TokenEnvVar),
 	}
 }

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/adrg/xdg"
+	"github.com/obot-platform/obot/pkg/cli/internal"
 	"github.com/obot-platform/obot/pkg/cli/internal/localconfig"
 )
 
@@ -21,7 +22,7 @@ func TestNewClientUsesEnvOverrides(t *testing.T) {
 	if err := os.Setenv("OBOT_BASE_URL", "https://env.example.com/api"); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Setenv("OBOT_TOKEN", "env-token"); err != nil {
+	if err := os.Setenv(internal.TokenEnvVar, "env-token"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -124,13 +125,13 @@ func useRootTestEnv(t *testing.T) func() {
 	configHome := filepath.Join(t.TempDir(), "config")
 	oldConfigHome, hadConfigHome := os.LookupEnv("XDG_CONFIG_HOME")
 	oldBaseURL, hadBaseURL := os.LookupEnv("OBOT_BASE_URL")
-	oldToken, hadToken := os.LookupEnv("OBOT_TOKEN")
+	oldToken, hadToken := os.LookupEnv(internal.TokenEnvVar)
 
 	if err := os.Setenv("XDG_CONFIG_HOME", configHome); err != nil {
 		t.Fatal(err)
 	}
 	_ = os.Unsetenv("OBOT_BASE_URL")
-	_ = os.Unsetenv("OBOT_TOKEN")
+	_ = os.Unsetenv(internal.TokenEnvVar)
 	xdg.Reload()
 
 	return func() {
@@ -145,9 +146,9 @@ func useRootTestEnv(t *testing.T) func() {
 			_ = os.Unsetenv("OBOT_BASE_URL")
 		}
 		if hadToken {
-			_ = os.Setenv("OBOT_TOKEN", oldToken)
+			_ = os.Setenv(internal.TokenEnvVar, oldToken)
 		} else {
-			_ = os.Unsetenv("OBOT_TOKEN")
+			_ = os.Unsetenv(internal.TokenEnvVar)
 		}
 		xdg.Reload()
 	}

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -385,6 +385,7 @@ const (
 	setupErrorConfigSaveFailed      setupErrorCode = "config_save_failed"
 	setupErrorClientDetectionFailed setupErrorCode = "client_detection_failed"
 	setupErrorClientInstallFailed   setupErrorCode = "client_install_failed"
+	setupErrorAuthInvalid           setupErrorCode = "auth_invalid"
 	setupErrorUnknown               setupErrorCode = "unknown"
 )
 
@@ -461,6 +462,10 @@ func setupAuthErrorCode(err error) setupErrorCode {
 		strings.Contains(msg, "no such host") ||
 		strings.Contains(msg, "server misbehaving") {
 		return setupErrorServerUnreachable
+	}
+
+	if strings.Contains(msg, "token does not have scope") {
+		return setupErrorAuthInvalid
 	}
 
 	return setupErrorUnknown

--- a/pkg/gateway/server/apikey.go
+++ b/pkg/gateway/server/apikey.go
@@ -224,12 +224,14 @@ func (s *Server) deleteAnyAPIKey(apiContext api.Context) error {
 // Authentication webhook endpoint
 
 type apiKeyAuthRequest struct {
-	MCPID string `json:"mcpId,omitempty"`
+	MCPID        string `json:"mcpId,omitempty"`
+	ValidateOnly bool   `json:"validateOnly,omitempty"`
 }
 
 type apiKeyAuthResponse struct {
-	Allowed bool   `json:"allowed"`
-	Reason  string `json:"reason,omitempty"`
+	Allowed bool               `json:"allowed"`
+	Reason  string             `json:"reason,omitempty"`
+	Scopes  types.APIKeyScopes `json:"scopes"`
 
 	Subject           string `json:"sub,omitempty"`
 	Name              string `json:"name,omitempty"`
@@ -288,8 +290,7 @@ func (s *Server) authenticateAPIKey(apiContext api.Context) error {
 	}
 
 	hasWildcard := slices.Contains(apiKey.MCPServerIDs, "*")
-	// Tokens have access to all webhook system MCP servers, so we only need to check if the request is not for such an MCP server.
-	if !system.IsWebhookSystemMCPServerID(req.MCPID) {
+	if !req.ValidateOnly && !system.IsWebhookSystemMCPServerID(req.MCPID) {
 		// Check if this server is in the key's allowed list
 		// "*" is a special wildcard that grants access to all servers the user can access
 		if !hasWildcard && !slices.Contains(apiKey.MCPServerIDs, req.MCPID) {
@@ -309,6 +310,7 @@ func (s *Server) authenticateAPIKey(apiContext api.Context) error {
 
 	err = apiContext.Write(apiKeyAuthResponse{
 		Allowed:           true,
+		Scopes:            apiKey.APIKeyScopes,
 		Subject:           fmt.Sprintf("%d", apiKey.UserID),
 		Name:              user.DisplayName,
 		PreferredUsername: user.Username,

--- a/pkg/gateway/types/apikeys.go
+++ b/pkg/gateway/types/apikeys.go
@@ -45,7 +45,7 @@ func (as APIKeyScopes) Groups(u *User) []string {
 		return u.Role.Groups()
 	}
 
-	groups := make([]string, 0, 4)
+	groups := make([]string, 0, 5)
 	if as.CanAccessSkills {
 		groups = append(groups, types.GroupSkills)
 	}


### PR DESCRIPTION
If the token doesn't have the requested scopes, then the CLI will request one unless the OBOT_TOKEN environment variable is set. In that case, the CLI will return an error.

Issue: https://github.com/obot-platform/obot/issues/6954