### PR TITLE
fix: stop just-in-time CLI auth from hanging on stdin in agents

### DIFF
--- a/pkg/cli/internal/token.go
+++ b/pkg/cli/internal/token.go
@@ -169,10 +169,11 @@ func Token(ctx context.Context, baseURL string, opts apiclient.TokenFetchOptions
 	}
 
 	token, tokenErr := credentialStore.Get(appURL)
-	hasStoredToken := tokenErr == nil
 	if tokenErr != nil && !credentials.IsNotFound(tokenErr) {
 		return "", tokenErr
 	}
+
+	hasStoredToken := tokenErr == nil
 	if hasStoredToken && !opts.ForceRefresh && testToken(ctx, baseURL, token, opts.Scopes...) {
 		return token, nil
 	}
@@ -198,24 +199,35 @@ func Token(ctx context.Context, baseURL string, opts apiclient.TokenFetchOptions
 		return "", fmt.Errorf("failed to create login request: %w", err)
 	}
 
-	if !hasStoredToken && !isNonInteractive(ctx) {
-		w := outputWriter(ctx)
+	w := outputWriter(ctx)
+	nonInteractive := isNonInteractive(ctx)
+	if !hasStoredToken {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, color.GreenString("Authentication is needed"))
 		fmt.Fprintln(w, color.GreenString("========================"))
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, color.CyanString(provider.Name)+" is used for authentication using the browser. This can be bypassed by setting")
-		fmt.Fprintln(w, "the env var "+color.CyanString(TokenEnvVar)+" to your API key.")
+		fmt.Fprintln(w, color.CyanString(provider.Name), "is used for authentication using the browser.")
+		fmt.Fprintln(w, "This can be bypassed by setting the env var", color.CyanString(TokenEnvVar), "to your API key.")
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, color.GreenString("Press ENTER to continue (CTRL+C to exit)"))
-		if err := enter(ctx); err != nil {
-			return "", err
+
+		if !nonInteractive {
+			fmt.Fprintln(w, color.GreenString("Press ENTER to continue (CTRL+C to exit)"))
+			if err := enter(ctx); err != nil {
+				return "", err
+			}
+			fmt.Fprintln(w)
 		}
-		fmt.Fprintln(w)
 	}
 
-	fmt.Fprintf(outputWriter(ctx), "Opening browser to %s. if there is an issue paste this link into a browser manually\n", loginURL)
-	_ = openBrowser(loginURL)
+	fmt.Fprintln(w, "Opening browser to", loginURL, "for authentication.")
+	if err := openBrowser(loginURL); err != nil {
+		if nonInteractive {
+			return "", fmt.Errorf("failed to open browser: %w", err)
+		}
+
+		fmt.Fprintln(w, "Failed to open browser:", err.Error())
+		fmt.Fprintln(w, "To finish authenticating, paste", loginURL, "into your browser manually.")
+	}
 
 	ctx, timeoutCancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer timeoutCancel()

--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,6 +12,7 @@ import (
 )
 
 type Login struct {
+	PromptConfig
 	TokenName        string   `usage:"Name of the token for identification" default:"CLI token"`
 	TokenDescription string   `usage:"Optional description of the token"`
 	NoExpiration     bool     `usage:"Set the token to never expire"`
@@ -49,9 +51,28 @@ func (l *Login) Run(cmd *cobra.Command, _ []string) error {
 		}
 		return err
 	}
-	fmt.Fprintf(os.Stderr, "Logged in to %s\n", l.root.Client.BaseURL)
+	fmt.Fprintln(os.Stderr, "Logged in to", l.root.Client.BaseURL)
 	if l.PrintToken {
 		fmt.Println(token)
 	}
+	return nil
+}
+
+// PromptConfig contains shared local options for commands that may require interactive input from users.
+// e.g. Any command that performs just-in-time authentication for unauthenticated users.
+type PromptConfig struct {
+	NonInteractive bool `usage:"Never read from stdin; fail if required input is missing" env:"OBOT_NON_INTERACTIVE" local:"true"`
+}
+
+func (p PromptConfig) Pre(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if p.NonInteractive {
+		ctx = internal.WithNonInteractive(ctx)
+	}
+	cmd.SetContext(ctx)
+
 	return nil
 }

--- a/pkg/cli/mcp.go
+++ b/pkg/cli/mcp.go
@@ -35,6 +35,8 @@ func (m *MCP) Run(cmd *cobra.Command, _ []string) error {
 }
 
 type MCPSearch struct {
+	PromptConfig
+
 	Limit int  `usage:"Maximum number of MCP servers to return; 0 means no limit" default:"50"`
 	JSON  bool `usage:"Print results as JSON"`
 

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -22,6 +22,7 @@ import (
 )
 
 type Scan struct {
+	PromptConfig
 	DeviceID string `usage:"Override the persisted device identifier. Empty resolves via OBOT_SCAN_DEVICE_ID env var or the file at $XDG_DATA_HOME/obot/device_id (generated on first run)" env:"OBOT_SCAN_DEVICE_ID" hidden:"true"`
 	Submit   bool   `usage:"Submit the scan to the configured Obot server" env:"OBOT_SCAN_SUBMIT"`
 	JSON     bool   `usage:"Print the scan result as JSON"`

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -21,11 +21,11 @@ import (
 )
 
 type Setup struct {
-	URL            string `usage:"Obot app URL to configure"`
-	Clients        string `usage:"Comma-separated target clients: none, claude-code, or agents"`
-	Yes            bool   `usage:"Accept confirmations and use defaults"`
-	NonInteractive bool   `usage:"Never read from stdin; fail if required input is missing"`
-	Output         string `usage:"Output format: text or json" default:"text"`
+	PromptConfig
+	URL     string `usage:"Obot app URL to configure" local:"true"`
+	Clients string `usage:"Comma-separated target clients: none, claude-code, or agents" local:"true"`
+	Yes     bool   `usage:"Accept confirmations and use defaults" local:"true"`
+	Output  string `usage:"Output format: text or json" default:"text" local:"true"`
 
 	root *Obot
 }
@@ -67,16 +67,10 @@ func (s *Setup) run(cmd *cobra.Command, progress setupProgressWriter) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if s.NonInteractive {
-		ctx = cliinternal.WithNonInteractive(ctx)
-		cmd.SetContext(ctx)
-	}
 	if progress.json {
-		authOutput := cmd.ErrOrStderr()
 		if s.NonInteractive {
-			authOutput = io.Discard
+			ctx = cliinternal.WithOutputWriter(ctx, io.Discard)
 		}
-		ctx = cliinternal.WithOutputWriter(ctx, authOutput)
 		cmd.SetContext(ctx)
 		cmd.SetOut(cmd.ErrOrStderr())
 	}

--- a/pkg/cli/setup_test.go
+++ b/pkg/cli/setup_test.go
@@ -137,9 +137,11 @@ func TestSetupNonInteractiveMissingURLFailsWithoutPrompt(t *testing.T) {
 		return "", nil
 	})
 	setup := &Setup{
-		Clients:        "agents",
-		NonInteractive: true,
-		root:           root,
+		PromptConfig: PromptConfig{
+			NonInteractive: true,
+		},
+		Clients: "agents",
+		root:    root,
 	}
 
 	var stdout bytes.Buffer
@@ -168,11 +170,13 @@ func TestSetupClientsNoneSkipsLocalClientInstall(t *testing.T) {
 		return "token", nil
 	})
 	setup := &Setup{
-		URL:            "https://obot.example.com/",
-		Clients:        "none",
-		Yes:            true,
-		NonInteractive: true,
-		root:           root,
+		PromptConfig: PromptConfig{
+			NonInteractive: true,
+		},
+		URL:     "https://obot.example.com/",
+		Clients: "none",
+		Yes:     true,
+		root:    root,
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -204,12 +208,14 @@ func TestSetupJSONProgressSuccessfulSequence(t *testing.T) {
 		return "token", nil
 	})
 	setup := &Setup{
-		URL:            "https://obot.example.com/",
-		Clients:        "claude-code",
-		Yes:            true,
-		NonInteractive: true,
-		Output:         "json",
-		root:           root,
+		PromptConfig: PromptConfig{
+			NonInteractive: true,
+		},
+		URL:     "https://obot.example.com/",
+		Clients: "claude-code",
+		Yes:     true,
+		Output:  "json",
+		root:    root,
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -253,10 +259,12 @@ func TestSetupJSONProgressStructuredError(t *testing.T) {
 		return "", nil
 	})
 	setup := &Setup{
-		Clients:        "none",
-		NonInteractive: true,
-		Output:         "json",
-		root:           root,
+		PromptConfig: PromptConfig{
+			NonInteractive: true,
+		},
+		Clients: "none",
+		Output:  "json",
+		root:    root,
 	}
 
 	var stdout bytes.Buffer
@@ -499,9 +507,11 @@ func TestSetupNonInteractiveRequiresClientsWhenOmitted(t *testing.T) {
 		return "token", nil
 	})
 	setup := &Setup{
-		URL:            "https://obot.example.com/",
-		NonInteractive: true,
-		root:           root,
+		PromptConfig: PromptConfig{
+			NonInteractive: true,
+		},
+		URL:  "https://obot.example.com/",
+		root: root,
 	}
 
 	err := setup.Run(setupTestCommand(nil, nil, nil), nil)

--- a/pkg/cli/skills.go
+++ b/pkg/cli/skills.go
@@ -33,6 +33,8 @@ func (s *Skills) Run(cmd *cobra.Command, _ []string) error {
 }
 
 type SkillsSearch struct {
+	PromptConfig
+
 	Limit int  `usage:"Maximum number of skills to return" default:"50"`
 	JSON  bool `usage:"Print results as JSON"`
 
@@ -108,6 +110,8 @@ func tableCell(value string) string {
 }
 
 type SkillsInstall struct {
+	PromptConfig
+
 	Destination string `usage:"Target skills directory, such as ~/.claude/skills or ~/.agents/skills"`
 	JSON        bool   `usage:"Print results as JSON"`
 

--- a/pkg/localagents/assets/assets_test.go
+++ b/pkg/localagents/assets/assets_test.go
@@ -14,17 +14,17 @@ func TestRenderAgentSkillsForClaudeCode(t *testing.T) {
 	}
 
 	install := renderedByName(t, rendered, "obot-install-skill")
-	assertContains(t, string(install.Content), "obot skills install --destination ~/.claude/skills <skill>")
+	assertContains(t, string(install.Content), "obot skills install --non-interactive --destination ~/.claude/skills <skill>")
 	assertNotContains(t, string(install.Content), "--json")
 
 	search := renderedByName(t, rendered, "obot-search-skills")
-	assertContains(t, string(search.Content), "obot skills search \"<query>\"")
-	assertContains(t, string(search.Content), "obot skills search\n")
+	assertContains(t, string(search.Content), "obot skills search --non-interactive \"<query>\"")
+	assertContains(t, string(search.Content), "obot skills search --non-interactive\n")
 
 	mcpSearch := renderedByName(t, rendered, "obot-search-mcp-servers")
 	assertContains(t, string(mcpSearch.Content), "Search the configured Obot server for available MCP servers.")
-	assertContains(t, string(mcpSearch.Content), "obot mcp search \"<query>\"")
-	assertContains(t, string(mcpSearch.Content), "obot mcp search\n")
+	assertContains(t, string(mcpSearch.Content), "obot mcp search --non-interactive \"<query>\"")
+	assertContains(t, string(mcpSearch.Content), "obot mcp search --non-interactive\n")
 	assertContains(t, string(mcpSearch.Content), "configuration required")
 
 	scan := renderedByName(t, rendered, "obot-scan")
@@ -39,7 +39,7 @@ func TestRenderAgentSkillsForSharedAgents(t *testing.T) {
 	rendered := renderAgentSkillsForTest(t, SharedAgentsTemplateData())
 
 	install := renderedByName(t, rendered, "obot-install-skill")
-	assertContains(t, string(install.Content), "obot skills install --destination ~/.agents/skills <skill>")
+	assertContains(t, string(install.Content), "obot skills install --non-interactive --destination ~/.agents/skills <skill>")
 
 	bootstrap := renderedByName(t, rendered, "obot")
 	assertContains(t, string(bootstrap.Content), "rendered for `agents`")

--- a/pkg/localagents/assets/files/skills/obot-install-skill/SKILL.md.tmpl
+++ b/pkg/localagents/assets/files/skills/obot-install-skill/SKILL.md.tmpl
@@ -13,7 +13,7 @@ Use this flow to determine which skill to install:
 - If the user provided anything other than a skill ID, use it as a search query:
 
 ```sh
-obot skills search "<query>"
+obot skills search --non-interactive "<query>"
 ```
 
 Handle the search results this way:
@@ -25,7 +25,7 @@ Handle the search results this way:
 When a skill has been selected, run the Obot CLI install command for this client:
 
 ```sh
-obot skills install --destination {{ .InstallDestination }} <skill>
+obot skills install --non-interactive --destination {{ .InstallDestination }} <skill>
 ```
 
 Report the CLI result to the user.

--- a/pkg/localagents/assets/files/skills/obot-scan/SKILL.md.tmpl
+++ b/pkg/localagents/assets/files/skills/obot-scan/SKILL.md.tmpl
@@ -16,5 +16,5 @@ Report the CLI result to the user and ask if they would like to submit.
 If they answer yes, then run the following command:
 
 ```sh
-obot scan --submit
+obot scan --non-interactive --submit
 ```

--- a/pkg/localagents/assets/files/skills/obot-search-mcp-servers/SKILL.md.tmpl
+++ b/pkg/localagents/assets/files/skills/obot-search-mcp-servers/SKILL.md.tmpl
@@ -11,13 +11,13 @@ Search the configured Obot server for available MCP servers.
 If the user provided a query, run:
 
 ```sh
-obot mcp search "<query>"
+obot mcp search --non-interactive "<query>"
 ```
 
 If the user did not provide a query, list all available MCP servers by running:
 
 ```sh
-obot mcp search
+obot mcp search --non-interactive
 ```
 
 Show the MCP servers returned by the CLI, including their connection or configuration URLs.

--- a/pkg/localagents/assets/files/skills/obot-search-skills/SKILL.md.tmpl
+++ b/pkg/localagents/assets/files/skills/obot-search-skills/SKILL.md.tmpl
@@ -9,13 +9,13 @@ disable-model-invocation: true
 Run the Obot CLI skill search command with the user's query:
 
 ```sh
-obot skills search "<query>"
+obot skills search --non-interactive "<query>"
 ```
 
 If the user did not provide a query, list all available skills by running:
 
 ```sh
-obot skills search
+obot skills search --non-interactive
 ```
 
 Show the matching skills returned by the CLI.

--- a/pkg/localagents/assets/files/skills/obot/SKILL.md.tmpl
+++ b/pkg/localagents/assets/files/skills/obot/SKILL.md.tmpl
@@ -9,20 +9,25 @@ Use the local `obot` CLI for Obot skill discovery, skill installation, and MCP s
 
 These instructions are rendered for `{{ .AgentID }}`.
 
-Authentication is managed by `obot login`. Do not ask the user for Obot API tokens, and do not call Obot APIs directly.
+Authentication can be managed in advance by `obot login`.
+
+`obot` CLI commands may also perform just-in-time authentication when invoked if a user isn't already authenticated. These commands have a `--non-interactive` option that must be used to prevent the command from blocking on user input over stdin.
+
+Do not ask the user for Obot API tokens, and do not call Obot APIs directly.
+
 
 ### Skill Discovery
 
 To find installable skills from Obot, run:
 
 ```sh
-obot skills search "<query>"
+obot skills search --non-interactive "<query>"
 ```
 
 To install a skill from Obot, run:
 
 ```sh
-obot skills install --destination {{ .InstallDestination }} <skill>
+obot skills install --non-interactive --destination {{ .InstallDestination }} <skill>
 ```
 
 Prefer the CLI for Obot-managed skills instead of hand-editing installed skill files from Obot.
@@ -32,13 +37,13 @@ Prefer the CLI for Obot-managed skills instead of hand-editing installed skill f
 To search the configured Obot server for available MCP servers, run:
 
 ```sh
-obot mcp search "<query>"
+obot mcp search --non-interactive "<query>"
 ```
 
 Omit the query to list all MCP servers:
 
 ```sh
-obot mcp search
+obot mcp search --non-interactive
 ```
 
 Always display the connection or configuration URL to the user if they asked you to find a server.


### PR DESCRIPTION
When a user is unauthenticated, obot CLI commands authenticate lazily — the first authenticated request invokes internal.Token, which waits on fmt.Scanln() for the user to press ENTER before opening the browser. When an agent runs such a command after `obot logout`, whether that read blocks depends on how the process is launched:
- Claude Code starts obot with stdin closed, so fmt.Scanln() returns immediately on EOF and the flow opens the browser — auth works.
- VS Code's default Chat agent leaves stdin open, so fmt.Scanln() blocks forever, the browser never opens, and the command is eventually cancelled.


To fix this, make non-interactive execution explicit and use it from the agent skills:
- PromptConfig adds a shared --non-interactive flag (and OBOT_NON_INTERACTIVE env), embedded into the obot CLI commands that can lazily authenticate — login, mcp search, scan, skills search, skills install, and setup. Its Pre hook marks the command context non-interactive, and internal.Token then skips the fmt.Scanln() gate so it never blocks on stdin, failing fast if the browser cannot be opened.
- The agent skill templates pass --non-interactive on the obot commands they document, and the `obot` skill explains just-in-time auth and the flag, so agents driven by these skills no longer hang.
- setup adopts the shared PromptConfig in place of its own NonInteractive field; render tests updated to match the templates.

Addresses https://github.com/obot-platform/obot/issues/6943

