### PR TITLE
feat: add support for CIMD

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -366,12 +366,13 @@ func (s MCPServer) IsSingleUser() bool {
 }
 
 type OAuthMetadata struct {
-	ProtectedResourceURL        string          `json:"protectedResourceUrl,omitempty"`
-	AuthorizationServerURL      string          `json:"authorizationServerUrl,omitempty"`
-	ProtectedResourceMetadata   json.RawMessage `json:"protectedResourceMetadata,omitempty"`
-	AuthorizationServerMetadata json.RawMessage `json:"authorizationServerMetadata,omitempty"`
-	DynamicClientRegistration   bool            `json:"dynamicClientRegistration,omitempty"`
-	ClientRegistration          json.RawMessage `json:"clientRegistration,omitempty"`
+	ProtectedResourceURL              string          `json:"protectedResourceUrl,omitempty"`
+	AuthorizationServerURL            string          `json:"authorizationServerUrl,omitempty"`
+	ProtectedResourceMetadata         json.RawMessage `json:"protectedResourceMetadata,omitempty"`
+	AuthorizationServerMetadata       json.RawMessage `json:"authorizationServerMetadata,omitempty"`
+	DynamicClientRegistration         bool            `json:"dynamicClientRegistration,omitempty"`
+	ClientRegistration                json.RawMessage `json:"clientRegistration,omitempty"`
+	ClientIDMetadataDocumentSupported bool            `json:"clientIdMetadataDocumentSupported,omitempty"`
 }
 
 type DeploymentCondition struct {

--- a/apiclient/types/oauth.go
+++ b/apiclient/types/oauth.go
@@ -13,6 +13,12 @@ type OAuthClientManifest struct {
 	// Required for redirect-based flows.
 	RedirectURIs []string `json:"redirect_uris,omitempty"`
 
+	// ApplicationType is a string indicator of the requested client application type.
+	// Values defined include: "web", "native".
+	// If unspecified or omitted, the default is "web".
+	// Optional.
+	ApplicationType string `json:"application_type,omitempty"`
+
 	// TokenEndpointAuthMethod is a string indicator of the requested authentication method for the token endpoint.
 	// Values defined include: "none", "client_secret_post", "client_secret_basic".
 	// If unspecified or omitted, the default is "client_secret_basic".

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.57.2
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.94.0
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/containerd/errdefs v1.0.0
 	github.com/docker/go-connections v0.6.0
@@ -30,6 +30,7 @@ require (
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/jsonschema-go v0.4.2
@@ -43,7 +44,7 @@ require (
 	github.com/obot-platform/cmd v0.0.0-20260615195405-fab7a186f46c
 	github.com/obot-platform/kinm v0.0.0-20260420174234-eec2cd66c333
 	github.com/obot-platform/nah v0.0.0-20260424131842-3fc648d20cac
-	github.com/obot-platform/nanobot v0.0.85
+	github.com/obot-platform/nanobot v0.0.86-0.20260619135558-06f0043756cf
 	github.com/obot-platform/obot/apiclient v0.0.0-20250813183905-ade719c1e8bf
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
@@ -163,7 +164,6 @@ require (
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 h1:c31//R3x
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21/go.mod h1:r6+pf23ouCB718FUxaqzZdbpYFyDtehyZcmP5KL9FkA=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 h1:ZlvrNcHSFFWURB8avufQq9gFsheUgjVD9536obIknfM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21/go.mod h1:cv3TNhVrssKR0O/xxLJVRfd2oazSnZnkUeTf6ctUwfQ=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.94.0 h1:SWTxh/EcUCDVqi/0s26V6pVUq0BBG7kx0tDTmF/hCgA=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.94.0/go.mod h1:79S2BdqCJpScXZA2y+cpZuocWsjGjJINyXnOsf5DTz8=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 h1:HwxWTbTrIHm5qY+CAEur0s/figc3qwvLWsNkF4RPToo=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 h1:lFd1+ZSEYJZYvv9d6kXzhkZu07si3f+GQ1AaYwa2LUM=
@@ -500,8 +500,8 @@ github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00 h1
 github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00/go.mod h1:IBdiWaE+aSlf5TpqKhtDkpGwxPetHtjaScewJ/UoSGQ=
 github.com/obot-platform/nah v0.0.0-20260424131842-3fc648d20cac h1:bHzcvYVp5AW+NyS45YzUmp6bZS5iUO9BY0HZX+MMi98=
 github.com/obot-platform/nah v0.0.0-20260424131842-3fc648d20cac/go.mod h1:+dYHcGg+BgcdZ2+eo3XCxhJFNQjmaKNRgD2loOvcFN0=
-github.com/obot-platform/nanobot v0.0.85 h1:O8KNeGkZo47UOIOyvkRXpqfyJNFKtpdxBK/7O67rcHs=
-github.com/obot-platform/nanobot v0.0.85/go.mod h1:lBBUrPngm/jJpwgLrqJzgup4hFniLpXzd6JIRDh1JZM=
+github.com/obot-platform/nanobot v0.0.86-0.20260619135558-06f0043756cf h1:LibEVDhpQYARCWaxMNxVxqhMcoXvG/osc21rxwziry8=
+github.com/obot-platform/nanobot v0.0.86-0.20260619135558-06f0043756cf/go.mod h1:lBBUrPngm/jJpwgLrqJzgup4hFniLpXzd6JIRDh1JZM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -207,6 +207,7 @@ var (
 			"POST /oauth/token/{mcp_id}",
 			"POST /oauth/token",
 			"GET /oauth/jwks.json",
+			"GET /oauth/client-metadata.json",
 
 			// Allow any user to read stored images.
 			// This allows the UI to display custom images to unauthenticated users.

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2946,13 +2946,19 @@ func convertOAuthMetadata(metadata *v1.OAuthMetadata) *types.OAuthMetadata {
 		return nil
 	}
 
+	registration := metadata.ClientRegistration
+	if metadata.ClientIDMetadataDocumentSupported {
+		registration = nil
+	}
+
 	return &types.OAuthMetadata{
-		ProtectedResourceURL:        metadata.ProtectedResourceURL,
-		AuthorizationServerURL:      metadata.AuthorizationServerURL,
-		ProtectedResourceMetadata:   metadata.ProtectedResourceMetadata,
-		AuthorizationServerMetadata: metadata.AuthorizationServerMetadata,
-		DynamicClientRegistration:   metadata.DynamicClientRegistration,
-		ClientRegistration:          metadata.ClientRegistration,
+		ProtectedResourceURL:              metadata.ProtectedResourceURL,
+		AuthorizationServerURL:            metadata.AuthorizationServerURL,
+		ProtectedResourceMetadata:         metadata.ProtectedResourceMetadata,
+		AuthorizationServerMetadata:       metadata.AuthorizationServerMetadata,
+		DynamicClientRegistration:         metadata.DynamicClientRegistration,
+		ClientRegistration:                registration,
+		ClientIDMetadataDocumentSupported: metadata.ClientIDMetadataDocumentSupported,
 	}
 }
 

--- a/pkg/api/handlers/mcp_oauth_debugger.go
+++ b/pkg/api/handlers/mcp_oauth_debugger.go
@@ -40,12 +40,20 @@ func (m *MCPHandler) RegisterOAuthDebuggerClient(req api.Context) error {
 	}
 
 	clientID, clientSecret, err := m.lookupStaticOAuthClient(req, server)
-	if err != nil && authServer.RegistrationEndpoint == "" {
+	useCIMD := m.useOAuthDebuggerCIMD(server, clientID, clientSecret)
+	if err != nil && authServer.RegistrationEndpoint == "" && !useCIMD {
 		return err
 	}
 
 	var registered types.OAuthClient
-	if clientID == "" || clientSecret == "" {
+	if clientID != "" && clientSecret != "" {
+		registered = oauthDebuggerStaticClient(clientID, clientSecret, authServer)
+	} else if useCIMD {
+		clientID = system.OAuthClientIDMetadataURL(m.serverURL)
+		clientSecret = ""
+		registration.TokenEndpointAuthMethod = "none"
+		registered = m.oauthDebuggerCIMDClient(authServer, registration)
+	} else {
 		if authServer.RegistrationEndpoint == "" {
 			return types.NewErrBadRequest("OAuth metadata does not include a dynamic client registration endpoint, must configure static client ID and secret")
 		}
@@ -63,8 +71,6 @@ func (m *MCPHandler) RegisterOAuthDebuggerClient(req api.Context) error {
 		if registered.Scope != "" {
 			registration.Scope = registered.Scope
 		}
-	} else {
-		registered = oauthDebuggerStaticClient(clientID, clientSecret, authServer)
 	}
 
 	if clientID == "" {
@@ -275,6 +281,30 @@ func (m *MCPHandler) lookupStaticOAuthClient(req api.Context, server v1.MCPServe
 	}
 
 	return "", "", nil
+}
+
+func (m *MCPHandler) useOAuthDebuggerCIMD(server v1.MCPServer, clientID, clientSecret string) bool {
+	return (clientID == "" || clientSecret == "") &&
+		server.Status.OAuthMetadata != nil &&
+		server.Status.OAuthMetadata.ClientIDMetadataDocumentSupported &&
+		strings.HasPrefix(m.serverURL, "https://")
+}
+
+func (m *MCPHandler) oauthDebuggerCIMDClient(authServer nmcp.AuthorizationServerMetadata, registration nmcp.ClientRegistrationMetadata) types.OAuthClient {
+	return types.OAuthClient{
+		OAuthClientManifest: types.OAuthClientManifest{
+			RedirectURIs:            registration.RedirectURIs,
+			TokenEndpointAuthMethod: "none",
+			GrantTypes:              registration.GrantTypes,
+			ResponseTypes:           registration.ResponseTypes,
+			ClientName:              registration.ClientName,
+			ClientURI:               m.serverURL,
+			Scope:                   registration.Scope,
+		},
+		ClientID:     system.OAuthClientIDMetadataURL(m.serverURL),
+		AuthorizeURL: authServer.AuthorizationEndpoint,
+		TokenURL:     authServer.TokenEndpoint,
+	}
 }
 
 func oauthDebuggerStaticClient(clientID, clientSecret string, authServer nmcp.AuthorizationServerMetadata) types.OAuthClient {

--- a/pkg/api/handlers/mcp_oauth_debugger_test.go
+++ b/pkg/api/handlers/mcp_oauth_debugger_test.go
@@ -8,6 +8,7 @@ import (
 
 	nmcp "github.com/obot-platform/nanobot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
 	"golang.org/x/oauth2"
 )
 
@@ -151,6 +152,97 @@ func TestOAuthDebuggerStaticClient(t *testing.T) {
 	}
 	if client.AuthorizeURL != authServer.AuthorizationEndpoint || client.TokenURL != authServer.TokenEndpoint {
 		t.Fatalf("expected auth server URLs to be set")
+	}
+}
+
+func TestOAuthDebuggerUsesCIMD(t *testing.T) {
+	tests := []struct {
+		name         string
+		serverURL    string
+		oauthMeta    *v1.OAuthMetadata
+		clientID     string
+		clientSecret string
+		expected     bool
+	}{
+		{
+			name:      "supported without static credentials",
+			serverURL: "https://obot.example.com",
+			oauthMeta: &v1.OAuthMetadata{
+				ClientIDMetadataDocumentSupported: true,
+			},
+			expected: true,
+		},
+		{
+			name:      "static credentials win",
+			serverURL: "https://obot.example.com",
+			oauthMeta: &v1.OAuthMetadata{
+				ClientIDMetadataDocumentSupported: true,
+			},
+			clientID:     "client-id",
+			clientSecret: "client-secret",
+		},
+		{
+			name:      "unsupported by auth server",
+			serverURL: "https://obot.example.com",
+			oauthMeta: &v1.OAuthMetadata{
+				ClientIDMetadataDocumentSupported: false,
+			},
+		},
+		{
+			name:      "obot client id must be https",
+			serverURL: "http://obot.example.com",
+			oauthMeta: &v1.OAuthMetadata{
+				ClientIDMetadataDocumentSupported: true,
+			},
+		},
+		{
+			name:      "missing metadata",
+			serverURL: "https://obot.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := v1.MCPServer{
+				Status: v1.MCPServerStatus{OAuthMetadata: tt.oauthMeta},
+			}
+			got := (&MCPHandler{serverURL: tt.serverURL}).useOAuthDebuggerCIMD(server, tt.clientID, tt.clientSecret)
+			if got != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestOAuthDebuggerCIMDClient(t *testing.T) {
+	authServer := nmcp.AuthorizationServerMetadata{
+		AuthorizationEndpoint: "https://auth.example.com/authorize",
+		TokenEndpoint:         "https://auth.example.com/token",
+	}
+	registration := nmcp.ClientRegistrationMetadata{
+		RedirectURIs:  []string{"https://obot.example.com/oauth/mcp/callback"},
+		GrantTypes:    []string{"authorization_code", "refresh_token"},
+		ResponseTypes: []string{"code"},
+		ClientName:    "Obot MCP OAuth Debugger",
+		Scope:         "read write",
+	}
+
+	client := (&MCPHandler{serverURL: "https://obot.example.com"}).oauthDebuggerCIMDClient(authServer, registration)
+
+	if client.ClientID != system.OAuthClientIDMetadataURL("https://obot.example.com") {
+		t.Fatalf("expected CIMD client ID, got %q", client.ClientID)
+	}
+	if client.ClientSecret != "" {
+		t.Fatalf("expected no client secret, got %q", client.ClientSecret)
+	}
+	if client.TokenEndpointAuthMethod != "none" {
+		t.Fatalf("expected token_endpoint_auth_method none, got %q", client.TokenEndpointAuthMethod)
+	}
+	if client.AuthorizeURL != authServer.AuthorizationEndpoint || client.TokenURL != authServer.TokenEndpoint {
+		t.Fatalf("expected auth server URLs to be set")
+	}
+	if !reflect.DeepEqual(client.RedirectURIs, registration.RedirectURIs) {
+		t.Fatalf("expected redirect URIs %#v, got %#v", registration.RedirectURIs, client.RedirectURIs)
 	}
 }
 

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -121,7 +121,7 @@ func (h *handler) authorize(req api.Context) error {
 		return err
 	}
 
-	if !slices.Contains(oauthClient.Spec.Manifest.RedirectURIs, redirectURI) {
+	if !isRedirectURIAllowed(oauthClient.Spec.Manifest, redirectURI) {
 		return types.NewErrBadRequest("%v", Error{
 			Code:        ErrInvalidRequest,
 			Description: "redirect_uri is invalid for this client",

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -18,9 +18,7 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ErrorCode defines the set of OAuth 2.0 error codes as per RFC 6749.
@@ -89,15 +87,6 @@ func (h *handler) authorize(req api.Context) error {
 		})
 	}
 
-	clientNamespace, clientName, ok := strings.Cut(clientID, ":")
-	if !ok {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "client_id is invalid",
-			State:       state,
-		})
-	}
-
 	redirectURI := req.FormValue("redirect_uri")
 	if redirectURI == "" {
 		return types.NewErrBadRequest("%v", Error{
@@ -123,19 +112,13 @@ func (h *handler) authorize(req api.Context) error {
 		})
 	}
 
-	var oauthClient v1.OAuthClient
-	if err := req.Storage.Get(req.Context(), kclient.ObjectKey{Namespace: clientNamespace, Name: clientName}, &oauthClient); apierrors.IsNotFound(err) {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: fmt.Sprintf("client_id does not exist: %s", clientID),
-			State:       state,
-		})
-	} else if err != nil {
-		return Error{
-			Code:        ErrServerError,
-			Description: fmt.Sprintf("failed to get OAuth client: %v", err),
-			State:       state,
+	oauthClient, err := h.resolveOAuthClient(req.Context(), req.Storage, clientID)
+	if err != nil {
+		if oauthErr, ok := errors.AsType[Error](err); ok {
+			oauthErr.State = state
+			return types.NewErrBadRequest("%v", oauthErr)
 		}
+		return err
 	}
 
 	if !slices.Contains(oauthClient.Spec.Manifest.RedirectURIs, redirectURI) {
@@ -160,6 +143,7 @@ func (h *handler) authorize(req api.Context) error {
 			Code:        ErrInvalidRequest,
 			Description: "code_challenge is required when using token endpoint auth method none",
 		})
+		return nil
 	}
 
 	scope := req.FormValue("scope")
@@ -357,7 +341,28 @@ func (h *handler) consent(req api.Context) error {
 		return err
 	}
 
-	oauthClient, err := h.oauthClientForAuthRequest(req, oauthAppAuthRequest)
+	if _, _, ok := authenticatedOAuthUser(req, oauthAppAuthRequest, "OAuth consent"); !ok {
+		return nil
+	}
+	if !authenticatedOAuthConsentUser(req, oauthAppAuthRequest) {
+		return nil
+	}
+
+	if !oauthAppAuthRequest.Spec.ConsentPrepared {
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
+			Code:        ErrInvalidRequest,
+			Description: "OAuth consent has not been prepared",
+			State:       oauthAppAuthRequest.Spec.State,
+		})
+		return nil
+	}
+
+	clientID := oauthAppAuthRequest.Spec.ClientID
+	if !isClientIDMetadataDocumentURL(clientID) {
+		clientID = oauthAppAuthRequest.Namespace + ":" + clientID
+	}
+
+	oauthClient, err := h.resolveOAuthClient(req.Context(), req.Storage, clientID)
 	if err != nil {
 		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
 			Code:        ErrServerError,
@@ -590,19 +595,12 @@ func authenticatedOAuthConsentUser(req api.Context, oauthAppAuthRequest v1.OAuth
 	return false
 }
 
-func (h *handler) oauthClientForAuthRequest(req api.Context, oauthAppAuthRequest v1.OAuthAuthRequest) (v1.OAuthClient, error) {
-	var oauthClient v1.OAuthClient
-	return oauthClient, req.Storage.Get(req.Context(), kclient.ObjectKey{
-		Namespace: oauthAppAuthRequest.Namespace,
-		Name:      oauthAppAuthRequest.Spec.ClientID,
-	}, &oauthClient)
-}
-
 type oauthConsentData struct {
 	AuthRequestID             string `json:"authRequestID"`
 	ContinueURL               string `json:"continueURL"`
 	CancelURL                 string `json:"cancelURL"`
 	ClientName                string `json:"clientName"`
+	ClientCredentialSource    string `json:"clientCredentialSource"`
 	ClientURI                 string `json:"clientURI,omitempty"`
 	RedirectURI               string `json:"redirectURI"`
 	Scope                     string `json:"scope,omitempty"`
@@ -626,6 +624,7 @@ func oauthConsentPageData(oauthAppAuthRequest v1.OAuthAuthRequest, oauthClient v
 		ContinueURL:               continueURL,
 		CancelURL:                 cancelURL,
 		ClientName:                clientName,
+		ClientCredentialSource:    oauthConsentClientCredentialSource(oauthClient),
 		ClientURI:                 oauthClient.Spec.Manifest.ClientURI,
 		RedirectURI:               oauthAppAuthRequest.Spec.RedirectURI,
 		Scope:                     oauthAppAuthRequest.Spec.Scope,
@@ -637,6 +636,16 @@ func oauthConsentPageData(oauthAppAuthRequest v1.OAuthAuthRequest, oauthClient v
 		MCPServerURL:              originOnly(oauthAppAuthRequest.Spec.ConsentMCPServerURL),
 		ThirdPartyAuthURL:         originOnly(oauthAppAuthRequest.Spec.ConsentMCPAuthURL),
 	}
+}
+
+func oauthConsentClientCredentialSource(oauthClient v1.OAuthClient) string {
+	if isClientIDMetadataDocumentURL(oauthClient.Name) {
+		return "client_id_metadata_document"
+	}
+	if oauthClient.Spec.Static {
+		return "static_client_credentials"
+	}
+	return "dynamic_client"
 }
 
 func mcpServerDisplayName(mcpServer v1.MCPServer) string {

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
@@ -27,6 +27,10 @@ const (
 	clientMetadataCacheMaxEntries    = 1000
 )
 
+var clientIDNativeExceptions = map[string]struct{}{
+	"https://claude.ai/oauth/claude-code-client-metadata": {},
+}
+
 type clientMetadataCacheEntry struct {
 	client    v1.OAuthClient
 	expiresAt time.Time
@@ -200,6 +204,16 @@ func (h *handler) oauthClientFromMetadataDocument(clientID string, doc clientIDM
 	}
 	if len(doc.RedirectURIs) == 0 {
 		return v1.OAuthClient{}, fmt.Errorf("client metadata document must include redirect_uris")
+	}
+	if doc.ApplicationType == "" {
+		if _, ok := clientIDNativeExceptions[clientID]; ok {
+			doc.ApplicationType = "native"
+		} else {
+			doc.ApplicationType = "web"
+		}
+	}
+	if doc.ApplicationType != "web" && doc.ApplicationType != "native" {
+		return v1.OAuthClient{}, fmt.Errorf("client metadata document application_type must be web or native")
 	}
 	if isSharedSecretAuthMethod(doc.TokenEndpointAuthMethod) {
 		return v1.OAuthClient{}, fmt.Errorf("client metadata document must not use shared-secret token endpoint authentication")

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
@@ -1,0 +1,327 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api/handlers"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	maxClientIDMetadataDocumentBytes = 5 * 1024
+	clientMetadataFetchTimeout       = 5 * time.Second
+	clientMetadataCacheMaxEntries    = 1000
+)
+
+type clientMetadataCacheEntry struct {
+	client    v1.OAuthClient
+	expiresAt time.Time
+	cachedAt  time.Time
+}
+
+type clientIDMetadataDocument struct {
+	types.OAuthClientManifest
+	ClientID string          `json:"client_id"`
+	JWKS     json.RawMessage `json:"jwks,omitempty"`
+}
+
+func (h *handler) resolveOAuthClient(ctx context.Context, c kclient.Client, clientID string) (v1.OAuthClient, error) {
+	if isClientIDMetadataDocumentURL(clientID) {
+		return h.resolveClientIDMetadataDocument(ctx, clientID)
+	}
+
+	clientNamespace, clientName, ok := strings.Cut(clientID, ":")
+	if !ok {
+		return v1.OAuthClient{}, Error{
+			Code:        ErrInvalidRequest,
+			Description: "client_id is invalid",
+		}
+	}
+
+	var oauthClient v1.OAuthClient
+	if err := c.Get(ctx, kclient.ObjectKey{Namespace: clientNamespace, Name: clientName}, &oauthClient); apierrors.IsNotFound(err) {
+		return v1.OAuthClient{}, Error{
+			Code:        ErrInvalidRequest,
+			Description: fmt.Sprintf("client_id does not exist: %s", clientID),
+		}
+	} else if err != nil {
+		return v1.OAuthClient{}, Error{
+			Code:        ErrServerError,
+			Description: fmt.Sprintf("failed to get OAuth client: %v", err),
+		}
+	}
+
+	return oauthClient, nil
+}
+
+func (h *handler) resolveClientIDMetadataDocument(ctx context.Context, clientID string) (v1.OAuthClient, error) {
+	if err := validateClientIDMetadataDocumentURL(clientID); err != nil {
+		return v1.OAuthClient{}, Error{
+			Code:        ErrInvalidClientMetadata,
+			Description: err.Error(),
+		}
+	}
+
+	if client, ok := h.getCachedClientMetadata(clientID); ok {
+		return client, nil
+	}
+
+	doc, expiresAt, err := h.fetchClientIDMetadataDocument(ctx, clientID)
+	if err != nil {
+		return v1.OAuthClient{}, Error{
+			Code:        ErrInvalidClientMetadata,
+			Description: err.Error(),
+		}
+	}
+
+	client, err := h.oauthClientFromMetadataDocument(clientID, doc)
+	if err != nil {
+		return v1.OAuthClient{}, Error{
+			Code:        ErrInvalidClientMetadata,
+			Description: err.Error(),
+		}
+	}
+
+	h.cacheClientMetadata(clientID, client, expiresAt)
+
+	return client, nil
+}
+
+func isClientIDMetadataDocumentURL(clientID string) bool {
+	u, err := url.Parse(clientID)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+func validateClientIDMetadataDocumentURL(clientID string) error {
+	u, err := url.Parse(clientID)
+	if err != nil {
+		return fmt.Errorf("client_id metadata document URL is invalid: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("client_id metadata document URL must use https")
+	}
+	if u.Host == "" {
+		return fmt.Errorf("client_id metadata document URL must include a host")
+	}
+	if u.User != nil {
+		return fmt.Errorf("client_id metadata document URL must not include userinfo")
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("client_id metadata document URL must not include a fragment")
+	}
+	if u.Path == "" || u.Path == "/" {
+		return fmt.Errorf("client_id metadata document URL must include a path component")
+	}
+	for segment := range strings.SplitSeq(u.EscapedPath(), "/") {
+		if segment == "." || segment == ".." || strings.EqualFold(segment, "%2e") || strings.EqualFold(segment, "%2e%2e") {
+			return fmt.Errorf("client_id metadata document URL path must not contain dot segments")
+		}
+	}
+	return nil
+}
+
+func (h *handler) fetchClientIDMetadataDocument(ctx context.Context, clientID string) (clientIDMetadataDocument, time.Time, error) {
+	ctx, cancel := context.WithTimeout(ctx, clientMetadataFetchTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, clientID, nil)
+	if err != nil {
+		return clientIDMetadataDocument{}, time.Time{}, err
+	}
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := h.clientMetadataClient().Do(httpReq)
+	if err != nil {
+		return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("failed to fetch client metadata document: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("client metadata document returned status %d", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		mediaType, _, err := mime.ParseMediaType(ct)
+		if err != nil || mediaType != "application/json" && !strings.HasSuffix(mediaType, "+json") {
+			return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("client metadata document must be JSON")
+		}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxClientIDMetadataDocumentBytes+1))
+	if err != nil {
+		return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("failed to read client metadata document: %w", err)
+	}
+	if len(body) > maxClientIDMetadataDocumentBytes {
+		return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("client metadata document exceeds %d bytes", maxClientIDMetadataDocumentBytes)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("client metadata document is invalid JSON: %w", err)
+	}
+	if _, ok := raw["client_secret"]; ok {
+		return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("client metadata document must not include client_secret")
+	}
+	if _, ok := raw["client_secret_expires_at"]; ok {
+		return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("client metadata document must not include client_secret_expires_at")
+	}
+
+	var doc clientIDMetadataDocument
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("client metadata document is invalid: %w", err)
+	}
+	if len(doc.JWKS) > 0 {
+		doc.OAuthClientManifest.JWKS = string(doc.JWKS)
+	}
+
+	return doc, clientMetadataCacheExpiration(resp.Header), nil
+}
+
+func (h *handler) oauthClientFromMetadataDocument(clientID string, doc clientIDMetadataDocument) (v1.OAuthClient, error) {
+	if doc.ClientID != clientID {
+		return v1.OAuthClient{}, fmt.Errorf("client metadata document client_id must exactly match the document URL")
+	}
+	if doc.ClientName == "" {
+		return v1.OAuthClient{}, fmt.Errorf("client metadata document must include client_name")
+	}
+	if len(doc.RedirectURIs) == 0 {
+		return v1.OAuthClient{}, fmt.Errorf("client metadata document must include redirect_uris")
+	}
+	if isSharedSecretAuthMethod(doc.TokenEndpointAuthMethod) {
+		return v1.OAuthClient{}, fmt.Errorf("client metadata document must not use shared-secret token endpoint authentication")
+	}
+	if doc.TokenEndpointAuthMethod == "" {
+		doc.TokenEndpointAuthMethod = "none"
+	}
+	if doc.JWKSURI != "" && doc.JWKS != nil {
+		return v1.OAuthClient{}, fmt.Errorf("client metadata document must not include both jwks_uri and jwks")
+	}
+	if doc.TokenEndpointAuthMethod == "private_key_jwt" && doc.JWKSURI == "" && doc.JWKS == nil {
+		return v1.OAuthClient{}, fmt.Errorf("client metadata document using private_key_jwt must include jwks_uri or jwks")
+	}
+
+	client := v1.OAuthClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.DefaultNamespace,
+			Name:      clientID,
+		},
+		Spec: v1.OAuthClientSpec{
+			Manifest: doc.OAuthClientManifest,
+		},
+	}
+
+	if err := handlers.ValidateClientConfig(&client, h.oauthConfig); err != nil {
+		return v1.OAuthClient{}, err
+	}
+
+	return client, nil
+}
+
+func isSharedSecretAuthMethod(method string) bool {
+	return strings.Contains(method, "client_secret")
+}
+
+func (h *handler) clientMetadataClient() *http.Client {
+	if h.clientMetadataHTTPClient != nil {
+		return h.clientMetadataHTTPClient
+	}
+	return &http.Client{Timeout: clientMetadataFetchTimeout}
+}
+
+func (h *handler) getCachedClientMetadata(clientID string) (v1.OAuthClient, bool) {
+	h.clientMetadataCacheLock.Lock()
+	defer h.clientMetadataCacheLock.Unlock()
+
+	entry, ok := h.clientMetadataCache[clientID]
+	if !ok || time.Now().After(entry.expiresAt) {
+		delete(h.clientMetadataCache, clientID)
+		return v1.OAuthClient{}, false
+	}
+	return entry.client, true
+}
+
+func (h *handler) cacheClientMetadata(clientID string, client v1.OAuthClient, expiresAt time.Time) {
+	if expiresAt.IsZero() {
+		return
+	}
+
+	h.clientMetadataCacheLock.Lock()
+	defer h.clientMetadataCacheLock.Unlock()
+
+	now := time.Now()
+	for cachedClientID, entry := range h.clientMetadataCache {
+		if now.After(entry.expiresAt) {
+			delete(h.clientMetadataCache, cachedClientID)
+		}
+	}
+
+	if _, ok := h.clientMetadataCache[clientID]; !ok && len(h.clientMetadataCache) >= clientMetadataCacheMaxEntries {
+		h.evictOldestClientMetadata()
+	}
+
+	h.clientMetadataCache[clientID] = clientMetadataCacheEntry{
+		client:    client,
+		expiresAt: expiresAt,
+		cachedAt:  now,
+	}
+}
+
+func (h *handler) evictOldestClientMetadata() {
+	var oldestClientID string
+	var oldestCachedAt time.Time
+	for clientID, entry := range h.clientMetadataCache {
+		if oldestClientID == "" || entry.cachedAt.Before(oldestCachedAt) {
+			oldestClientID = clientID
+			oldestCachedAt = entry.cachedAt
+		}
+	}
+	delete(h.clientMetadataCache, oldestClientID)
+}
+
+func clientMetadataCacheExpiration(header http.Header) time.Time {
+	var maxAge time.Duration
+	for _, cacheControl := range header.Values("Cache-Control") {
+		cacheControl = strings.ToLower(cacheControl)
+		for directive := range strings.SplitSeq(cacheControl, ",") {
+			directive = strings.TrimSpace(directive)
+			if directive == "no-store" || directive == "no-cache" {
+				return time.Time{}
+			}
+			if value, ok := strings.CutPrefix(directive, "max-age="); ok {
+				seconds, err := strconv.Atoi(strings.Trim(value, `"`))
+				if err == nil {
+					if seconds <= 0 {
+						return time.Time{}
+					}
+					maxAge = time.Duration(seconds) * time.Second
+				}
+			}
+		}
+	}
+	if maxAge > 0 {
+		return time.Now().Add(maxAge)
+	}
+
+	if expires := header.Get("Expires"); expires != "" {
+		t, err := http.ParseTime(expires)
+		if err == nil && time.Now().Before(t) {
+			return t
+		}
+	}
+
+	return time.Time{}
+}

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
@@ -1,0 +1,275 @@
+package oauth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/api/handlers"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newTestCIMDHandler(rt roundTripFunc) *handler {
+	return &handler{
+		oauthConfig: handlers.OAuthAuthorizationServerConfig{
+			ScopesSupported:                            []string{"profile"},
+			ResponseTypesSupported:                     []string{"code"},
+			GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
+			TokenEndpointAuthMethodsSupported:          []string{"client_secret_basic", "client_secret_post", "private_key_jwt", "none"},
+			TokenEndpointAuthSigningAlgValuesSupported: []string{"RS256"},
+		},
+		clientMetadataHTTPClient: &http.Client{Transport: rt},
+		clientMetadataCache:      map[string]clientMetadataCacheEntry{},
+	}
+}
+
+func TestValidateClientIDMetadataDocumentURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "valid", url: "https://client.example/oauth/client.json"},
+		{name: "query is allowed", url: "https://client.example/oauth/client.json?v=1"},
+		{name: "http rejected", url: "http://client.example/oauth/client.json", wantErr: true},
+		{name: "missing path rejected", url: "https://client.example", wantErr: true},
+		{name: "root path rejected", url: "https://client.example/", wantErr: true},
+		{name: "fragment rejected", url: "https://client.example/oauth/client.json#frag", wantErr: true},
+		{name: "userinfo rejected", url: "https://user@client.example/oauth/client.json", wantErr: true},
+		{name: "dot segment rejected", url: "https://client.example/oauth/../client.json", wantErr: true},
+		{name: "encoded dot segment rejected", url: "https://client.example/oauth/%2e%2e/client.json", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateClientIDMetadataDocumentURL(tt.url)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveClientIDMetadataDocument(t *testing.T) {
+	t.Parallel()
+
+	const clientID = "https://client.example/oauth/client.json"
+	var requests int
+	h := newTestCIMDHandler(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.URL.String() != clientID {
+			t.Fatalf("unexpected metadata URL: %s", req.URL.String())
+		}
+		if got := req.Header.Get("Accept"); got != "application/json" {
+			t.Fatalf("unexpected accept header: %s", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type":  []string{"application/json"},
+				"Cache-Control": []string{"max-age=60"},
+			},
+			Body: io.NopCloser(strings.NewReader(`{
+				"client_id":"https://client.example/oauth/client.json",
+				"client_name":"Example Client",
+				"redirect_uris":["http://127.0.0.1:3000/callback"],
+				"scope":"profile"
+			}`)),
+		}, nil
+	})
+
+	client, err := h.resolveClientIDMetadataDocument(context.Background(), clientID)
+	if err != nil {
+		t.Fatalf("resolve metadata: %v", err)
+	}
+	if client.Name != clientID {
+		t.Fatalf("expected client name %q, got %q", clientID, client.Name)
+	}
+	if client.Spec.Manifest.ClientName != "Example Client" {
+		t.Fatalf("unexpected client name: %s", client.Spec.Manifest.ClientName)
+	}
+	if client.Spec.Manifest.TokenEndpointAuthMethod != "none" {
+		t.Fatalf("expected default token endpoint auth method none, got %q", client.Spec.Manifest.TokenEndpointAuthMethod)
+	}
+
+	if _, err = h.resolveClientIDMetadataDocument(context.Background(), clientID); err != nil {
+		t.Fatalf("resolve cached metadata: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("expected cached metadata to avoid second fetch, got %d requests", requests)
+	}
+}
+
+func TestResolveClientIDMetadataDocumentValidation(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{
+			name: "client id mismatch",
+			body: `{"client_id":"https://other.example/client.json","client_name":"Example Client","redirect_uris":["http://127.0.0.1/callback"]}`,
+		},
+		{
+			name: "missing client name",
+			body: `{"client_id":"https://client.example/oauth/client.json","redirect_uris":["http://127.0.0.1/callback"]}`,
+		},
+		{
+			name: "missing redirect uris",
+			body: `{"client_id":"https://client.example/oauth/client.json","client_name":"Example Client"}`,
+		},
+		{
+			name: "shared secret auth rejected",
+			body: `{"client_id":"https://client.example/oauth/client.json","client_name":"Example Client","redirect_uris":["http://127.0.0.1/callback"],"token_endpoint_auth_method":"client_secret_post"}`,
+		},
+		{
+			name: "client secret rejected",
+			body: `{"client_id":"https://client.example/oauth/client.json","client_name":"Example Client","redirect_uris":["http://127.0.0.1/callback"],"client_secret":"secret"}`,
+		},
+		{
+			name: "private key jwt requires keys",
+			body: `{"client_id":"https://client.example/oauth/client.json","client_name":"Example Client","redirect_uris":["http://127.0.0.1/callback"],"token_endpoint_auth_method":"private_key_jwt"}`,
+		},
+		{
+			name: "jwks and jwks uri rejected",
+			body: `{"client_id":"https://client.example/oauth/client.json","client_name":"Example Client","redirect_uris":["http://127.0.0.1/callback"],"token_endpoint_auth_method":"private_key_jwt","jwks_uri":"https://client.example/jwks.json","jwks":{"keys":[]}}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTestCIMDHandler(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(tt.body)),
+				}, nil
+			})
+
+			if _, err := h.resolveClientIDMetadataDocument(context.Background(), "https://client.example/oauth/client.json"); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestResolveClientIDMetadataDocumentPrivateKeyJWT(t *testing.T) {
+	t.Parallel()
+
+	const clientID = "https://client.example/oauth/client.json"
+	h := newTestCIMDHandler(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(`{
+				"client_id":"https://client.example/oauth/client.json",
+				"client_name":"Example Client",
+				"redirect_uris":["http://127.0.0.1/callback"],
+				"token_endpoint_auth_method":"private_key_jwt",
+				"jwks":{"keys":[]}
+			}`)),
+		}, nil
+	})
+
+	client, err := h.resolveClientIDMetadataDocument(context.Background(), clientID)
+	if err != nil {
+		t.Fatalf("resolve metadata: %v", err)
+	}
+	if client.Spec.Manifest.TokenEndpointAuthMethod != "private_key_jwt" {
+		t.Fatalf("expected private_key_jwt, got %q", client.Spec.Manifest.TokenEndpointAuthMethod)
+	}
+	if client.Spec.Manifest.JWKS == "" {
+		t.Fatal("expected raw jwks to be retained")
+	}
+}
+
+func TestFetchClientIDMetadataDocumentRejectsOversizedResponse(t *testing.T) {
+	t.Parallel()
+
+	h := newTestCIMDHandler(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(strings.Repeat(" ", maxClientIDMetadataDocumentBytes+1))),
+		}, nil
+	})
+
+	if _, _, err := h.fetchClientIDMetadataDocument(context.Background(), "https://client.example/oauth/client.json"); err == nil {
+		t.Fatal("expected oversized metadata error")
+	}
+}
+
+func TestClientMetadataCacheExpiration(t *testing.T) {
+	t.Parallel()
+
+	expiration := clientMetadataCacheExpiration(http.Header{"Cache-Control": []string{"max-age=30"}})
+	if time.Until(expiration) <= 0 {
+		t.Fatalf("expected future expiration, got %v", expiration)
+	}
+
+	expiration = clientMetadataCacheExpiration(http.Header{"Cache-Control": []string{"no-store, max-age=30"}})
+	if !expiration.IsZero() {
+		t.Fatalf("expected no-store to disable caching, got %v", expiration)
+	}
+
+	expiration = clientMetadataCacheExpiration(http.Header{"Cache-Control": []string{"max-age=30, no-store"}})
+	if !expiration.IsZero() {
+		t.Fatalf("expected later no-store to disable caching, got %v", expiration)
+	}
+
+	expiration = clientMetadataCacheExpiration(http.Header{"Cache-Control": []string{"max-age=30, no-cache"}})
+	if !expiration.IsZero() {
+		t.Fatalf("expected later no-cache to disable caching, got %v", expiration)
+	}
+
+	expiration = clientMetadataCacheExpiration(http.Header{"Cache-Control": []string{"max-age=30", "no-store"}})
+	if !expiration.IsZero() {
+		t.Fatalf("expected no-store in second cache-control header to disable caching, got %v", expiration)
+	}
+}
+
+func TestCacheClientMetadataEvictsOldestEntryAtLimit(t *testing.T) {
+	t.Parallel()
+
+	h := newTestCIMDHandler(nil)
+	now := time.Now()
+	for i := range clientMetadataCacheMaxEntries {
+		clientID := "https://client.example/client-" + strconv.Itoa(i) + ".json"
+		h.clientMetadataCache[clientID] = clientMetadataCacheEntry{
+			client:    v1.OAuthClient{ObjectMeta: metav1.ObjectMeta{Name: clientID}},
+			expiresAt: now.Add(time.Hour),
+			cachedAt:  now.Add(time.Duration(i) * time.Second),
+		}
+	}
+
+	const oldestClientID = "https://client.example/client-0.json"
+	const newClientID = "https://client.example/new-client.json"
+	h.cacheClientMetadata(newClientID, v1.OAuthClient{ObjectMeta: metav1.ObjectMeta{Name: newClientID}}, now.Add(time.Hour))
+
+	if len(h.clientMetadataCache) != clientMetadataCacheMaxEntries {
+		t.Fatalf("expected cache size %d, got %d", clientMetadataCacheMaxEntries, len(h.clientMetadataCache))
+	}
+	if _, ok := h.clientMetadataCache[oldestClientID]; ok {
+		t.Fatalf("expected oldest entry %q to be evicted", oldestClientID)
+	}
+	if _, ok := h.clientMetadataCache[newClientID]; !ok {
+		t.Fatalf("expected new entry %q to be cached", newClientID)
+	}
+}

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api/handlers"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,6 +108,9 @@ func TestResolveClientIDMetadataDocument(t *testing.T) {
 	if client.Spec.Manifest.TokenEndpointAuthMethod != "none" {
 		t.Fatalf("expected default token endpoint auth method none, got %q", client.Spec.Manifest.TokenEndpointAuthMethod)
 	}
+	if client.Spec.Manifest.ApplicationType != "web" {
+		t.Fatalf("expected default application type web, got %q", client.Spec.Manifest.ApplicationType)
+	}
 
 	if _, err = h.resolveClientIDMetadataDocument(context.Background(), clientID); err != nil {
 		t.Fatalf("resolve cached metadata: %v", err)
@@ -138,6 +142,10 @@ func TestResolveClientIDMetadataDocumentValidation(t *testing.T) {
 		{
 			name: "shared secret auth rejected",
 			body: `{"client_id":"https://client.example/oauth/client.json","client_name":"Example Client","redirect_uris":["http://127.0.0.1/callback"],"token_endpoint_auth_method":"client_secret_post"}`,
+		},
+		{
+			name: "invalid application type rejected",
+			body: `{"client_id":"https://client.example/oauth/client.json","client_name":"Example Client","redirect_uris":["http://127.0.0.1/callback"],"application_type":"service"}`,
 		},
 		{
 			name: "client secret rejected",
@@ -197,6 +205,57 @@ func TestResolveClientIDMetadataDocumentPrivateKeyJWT(t *testing.T) {
 	}
 	if client.Spec.Manifest.JWKS == "" {
 		t.Fatal("expected raw jwks to be retained")
+	}
+}
+
+func TestResolveClientIDMetadataDocumentNativeApplicationType(t *testing.T) {
+	t.Parallel()
+
+	const clientID = "https://client.example/oauth/client.json"
+	h := newTestCIMDHandler(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(`{
+				"client_id":"https://client.example/oauth/client.json",
+				"client_name":"Example Client",
+				"redirect_uris":["http://127.0.0.1/callback"],
+				"application_type":"native"
+			}`)),
+		}, nil
+	})
+
+	client, err := h.resolveClientIDMetadataDocument(context.Background(), clientID)
+	if err != nil {
+		t.Fatalf("resolve metadata: %v", err)
+	}
+	if client.Spec.Manifest.ApplicationType != "native" {
+		t.Fatalf("expected native application type, got %q", client.Spec.Manifest.ApplicationType)
+	}
+}
+
+func TestClientIDNativeExceptionsDefaultToNative(t *testing.T) {
+	t.Parallel()
+
+	h := newTestCIMDHandler(nil)
+	for clientID := range clientIDNativeExceptions {
+		t.Run(clientID, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := h.oauthClientFromMetadataDocument(clientID, clientIDMetadataDocument{
+				OAuthClientManifest: types.OAuthClientManifest{
+					ClientName:   "Example Client",
+					RedirectURIs: []string{"http://127.0.0.1/callback"},
+				},
+				ClientID: clientID,
+			})
+			if err != nil {
+				t.Fatalf("resolve metadata: %v", err)
+			}
+			if client.Spec.Manifest.ApplicationType != "native" {
+				t.Fatalf("expected native application type, got %q", client.Spec.Manifest.ApplicationType)
+			}
+		})
 	}
 }
 

--- a/pkg/api/handlers/mcpgateway/oauth/consent_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/consent_test.go
@@ -1,0 +1,51 @@
+package oauth
+
+import (
+	"testing"
+
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOAuthConsentClientCredentialSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		client   v1.OAuthClient
+		expected string
+	}{
+		{
+			name: "client ID metadata document",
+			client: v1.OAuthClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "https://client.example/oauth/client.json"},
+			},
+			expected: "client_id_metadata_document",
+		},
+		{
+			name: "static client credentials",
+			client: v1.OAuthClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "static-client"},
+				Spec:       v1.OAuthClientSpec{Static: true},
+			},
+			expected: "static_client_credentials",
+		},
+		{
+			name: "dynamic client",
+			client: v1.OAuthClient{
+				ObjectMeta: metav1.ObjectMeta{Name: "dynamic-client"},
+			},
+			expected: "dynamic_client",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := oauthConsentClientCredentialSource(tt.client); got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/api/handlers/mcpgateway/oauth/handler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/handler.go
@@ -1,12 +1,15 @@
 package oauth
 
 import (
+	"net/http"
+	"sync"
 	"time"
 
 	"github.com/obot-platform/obot/pkg/api/handlers"
 	"github.com/obot-platform/obot/pkg/api/server"
 	"github.com/obot-platform/obot/pkg/jwt/persistent"
 	"github.com/obot-platform/obot/pkg/mcp"
+	"github.com/obot-platform/obot/pkg/system"
 )
 
 type handler struct {
@@ -16,16 +19,21 @@ type handler struct {
 	tokenStore       mcp.GlobalTokenStore
 	baseURL          string
 	clientExpiration time.Duration
+
+	clientMetadataHTTPClient *http.Client
+	clientMetadataCache      map[string]clientMetadataCacheEntry
+	clientMetadataCacheLock  sync.Mutex
 }
 
 func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTokenStore, tokenService *persistent.TokenService, oauthConfig handlers.OAuthAuthorizationServerConfig, baseURL string, clientSecretExpiration time.Duration, mux *server.Server) {
 	h := &handler{
-		tokenStore:       tokenStore,
-		tokenService:     tokenService,
-		oauthConfig:      oauthConfig,
-		baseURL:          baseURL,
-		oauthChecker:     oauthChecker,
-		clientExpiration: clientSecretExpiration,
+		tokenStore:          tokenStore,
+		tokenService:        tokenService,
+		oauthConfig:         oauthConfig,
+		baseURL:             baseURL,
+		oauthChecker:        oauthChecker,
+		clientExpiration:    clientSecretExpiration,
+		clientMetadataCache: map[string]clientMetadataCacheEntry{},
 	}
 
 	// Expose two sets of endpoints: one for clients that look at the oauth-protected-resource metadata and one for clients that don't.
@@ -56,6 +64,7 @@ func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTo
 
 	mux.HandleFunc("GET /oauth/jwks.json", h.tokenService.ServeJWKS)
 	mux.HandleFunc("POST /oauth/replace-jwks", h.tokenService.ReplaceJWK)
+	mux.HandleFunc("GET "+system.OAuthClientIDMetadataPath, h.obotClientIDMetadata)
 
 	mux.HandleFunc("GET /api/oauth/composite/{mcp_id}", h.checkCompositeAuth)
 

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -105,15 +105,20 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(req api.Context, mcpServer v1.M
 
 	go func() {
 		defer close(errChan)
+		httpClientOptions := nmcp.HTTPClientOptions{
+			OAuthRedirectURL: system.MCPOAuthCallbackURL(f.baseURL),
+			OAuthClientName:  "Obot MCP Gateway",
+			CallbackHandler:  oauthHandler,
+			ClientCredLookup: oauthHandler,
+			TokenStorage:     f.tokenStore.ForUserAndMCP(oauthHandler.userID, oauthHandler.mcpID),
+		}
+		if strings.HasPrefix(f.baseURL, "https://") {
+			httpClientOptions.OAuthClientIDMetadataDocument = system.OAuthClientIDMetadataURL(f.baseURL)
+		}
+
 		_, err := f.mcpSessionManager.ClientForMCPServerForOAuthCheck(req.Context(), "Obot OAuth Check", mcpServerConfig, nmcp.ClientOption{
-			ClientName: "Obot MCP OAuth",
-			HTTPClientOptions: nmcp.HTTPClientOptions{
-				OAuthRedirectURL: system.MCPOAuthCallbackURL(f.baseURL),
-				OAuthClientName:  "Obot MCP Gateway",
-				CallbackHandler:  oauthHandler,
-				ClientCredLookup: oauthHandler,
-				TokenStorage:     f.tokenStore.ForUserAndMCP(oauthHandler.userID, oauthHandler.mcpID),
-			},
+			ClientName:        "Obot MCP OAuth",
+			HTTPClientOptions: httpClientOptions,
 		})
 		if err != nil {
 			errChan <- fmt.Errorf("failed to get client for server %s: %v", mcpServer.Name, err)

--- a/pkg/api/handlers/mcpgateway/oauth/obot_client_metadata.go
+++ b/pkg/api/handlers/mcpgateway/oauth/obot_client_metadata.go
@@ -1,0 +1,22 @@
+package oauth
+
+import (
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/system"
+)
+
+func (h *handler) obotClientIDMetadata(req api.Context) error {
+	return req.Write(clientIDMetadataDocument{
+		ClientID: system.OAuthClientIDMetadataURL(h.baseURL),
+		OAuthClientManifest: types.OAuthClientManifest{
+			RedirectURIs:            []string{system.MCPOAuthCallbackURL(h.baseURL)},
+			TokenEndpointAuthMethod: "none",
+			GrantTypes:              []string{"authorization_code", "refresh_token"},
+			ResponseTypes:           []string{"code"},
+			ClientName:              "Obot MCP Gateway",
+			ClientURI:               h.baseURL,
+			SoftwareID:              "obot",
+		},
+	})
+}

--- a/pkg/api/handlers/mcpgateway/oauth/obot_client_metadata_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/obot_client_metadata_test.go
@@ -1,0 +1,53 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/system"
+)
+
+func TestObotClientIDMetadata(t *testing.T) {
+	t.Parallel()
+
+	const baseURL = "https://obot.example"
+	h := &handler{baseURL: baseURL}
+	req := httptest.NewRequest(http.MethodGet, system.OAuthClientIDMetadataPath, nil)
+	rec := httptest.NewRecorder()
+
+	if err := h.obotClientIDMetadata(api.Context{
+		ResponseWriter: rec,
+		Request:        req,
+	}); err != nil {
+		t.Fatalf("serve metadata: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var got struct {
+		types.OAuthClientManifest
+		ClientID string `json:"client_id"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+
+	if got.ClientID != system.OAuthClientIDMetadataURL(baseURL) {
+		t.Fatalf("expected client_id %q, got %q", system.OAuthClientIDMetadataURL(baseURL), got.ClientID)
+	}
+	if got.ClientName != "Obot MCP Gateway" {
+		t.Fatalf("unexpected client_name: %s", got.ClientName)
+	}
+	if got.TokenEndpointAuthMethod != "none" {
+		t.Fatalf("expected token_endpoint_auth_method none, got %q", got.TokenEndpointAuthMethod)
+	}
+	if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != system.MCPOAuthCallbackURL(baseURL) {
+		t.Fatalf("unexpected redirect_uris: %#v", got.RedirectURIs)
+	}
+}

--- a/pkg/api/handlers/mcpgateway/oauth/private_key_jwt.go
+++ b/pkg/api/handlers/mcpgateway/oauth/private_key_jwt.go
@@ -1,0 +1,216 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/golang-jwt/jwt/v5"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+)
+
+const (
+	clientAssertionTypeJWTBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+	maxClientJWKSetBytes         = 100 * 1024
+)
+
+var privateKeyJWTSigningAlgorithms = []string{
+	"RS256", "RS384", "RS512",
+	"PS256", "PS384", "PS512",
+	"ES256", "ES384", "ES512",
+	"EdDSA",
+}
+
+func clientIDFromClientAssertion(form url.Values) (string, error) {
+	if form.Get("client_assertion_type") != clientAssertionTypeJWTBearer {
+		return "", fmt.Errorf("client_assertion_type must be %s", clientAssertionTypeJWTBearer)
+	}
+
+	assertion := form.Get("client_assertion")
+	if assertion == "" {
+		return "", fmt.Errorf("client_assertion is required")
+	}
+
+	var claims jwt.RegisteredClaims
+	if _, _, err := new(jwt.Parser).ParseUnverified(assertion, &claims); err != nil {
+		return "", fmt.Errorf("client_assertion is invalid: %w", err)
+	}
+	if claims.Issuer == "" || claims.Subject == "" || claims.Issuer != claims.Subject {
+		return "", fmt.Errorf("client_assertion issuer and subject must both match the client_id")
+	}
+
+	return claims.Subject, nil
+}
+
+func (h *handler) validatePrivateKeyJWT(ctx context.Context, form url.Values, client v1.OAuthClient) error {
+	if form.Get("client_assertion_type") != clientAssertionTypeJWTBearer {
+		return fmt.Errorf("client_assertion_type must be %s", clientAssertionTypeJWTBearer)
+	}
+
+	assertion := form.Get("client_assertion")
+	if assertion == "" {
+		return fmt.Errorf("client_assertion is required")
+	}
+
+	jwks, err := h.clientJWKSet(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	tokenEndpoint := h.oauthConfig.TokenEndpoint
+	if tokenEndpoint == "" {
+		tokenEndpoint = strings.TrimRight(h.baseURL, "/") + "/oauth/token"
+	}
+
+	validMethods := h.oauthConfig.TokenEndpointAuthSigningAlgValuesSupported
+	if len(validMethods) == 0 {
+		validMethods = privateKeyJWTSigningAlgorithms
+	}
+
+	claims := jwt.RegisteredClaims{}
+	parser := jwt.NewParser(
+		jwt.WithAudience(tokenEndpoint),
+		jwt.WithExpirationRequired(),
+		jwt.WithIssuer(client.Name),
+		jwt.WithSubject(client.Name),
+		jwt.WithValidMethods(validMethods),
+	)
+
+	tkn, err := parser.ParseWithClaims(assertion, &claims, func(tkn *jwt.Token) (any, error) {
+		return verificationKeysForJWT(tkn, jwks, validMethods)
+	})
+	if err != nil {
+		return fmt.Errorf("client_assertion is invalid: %w", err)
+	}
+	if !tkn.Valid {
+		return fmt.Errorf("client_assertion is invalid")
+	}
+
+	return nil
+}
+
+func (h *handler) clientJWKSet(ctx context.Context, client v1.OAuthClient) (jose.JSONWebKeySet, error) {
+	if client.Spec.Manifest.JWKS != "" {
+		return parseClientJWKSet([]byte(client.Spec.Manifest.JWKS))
+	}
+	if client.Spec.Manifest.JWKSURI == "" {
+		return jose.JSONWebKeySet{}, fmt.Errorf("client jwks_uri or jwks is required")
+	}
+	if err := validateClientJWKSetURL(client.Spec.Manifest.JWKSURI); err != nil {
+		return jose.JSONWebKeySet{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, client.Spec.Manifest.JWKSURI, nil)
+	if err != nil {
+		return jose.JSONWebKeySet{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := h.clientMetadataClient().Do(req)
+	if err != nil {
+		return jose.JSONWebKeySet{}, fmt.Errorf("failed to fetch client jwks_uri: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return jose.JSONWebKeySet{}, fmt.Errorf("client jwks_uri returned status %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		mediaType, _, err := mime.ParseMediaType(ct)
+		if err != nil || mediaType != "application/json" && !strings.HasSuffix(mediaType, "+json") {
+			return jose.JSONWebKeySet{}, fmt.Errorf("client jwks_uri must return JSON")
+		}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxClientJWKSetBytes+1))
+	if err != nil {
+		return jose.JSONWebKeySet{}, fmt.Errorf("failed to read client jwks_uri: %w", err)
+	}
+	if len(body) > maxClientJWKSetBytes {
+		return jose.JSONWebKeySet{}, fmt.Errorf("client jwks_uri exceeds %d bytes", maxClientJWKSetBytes)
+	}
+
+	return parseClientJWKSet(body)
+}
+
+func parseClientJWKSet(data []byte) (jose.JSONWebKeySet, error) {
+	var jwks jose.JSONWebKeySet
+	if err := json.Unmarshal(data, &jwks); err != nil {
+		return jose.JSONWebKeySet{}, fmt.Errorf("client jwks is invalid JSON: %w", err)
+	}
+	if len(jwks.Keys) == 0 {
+		return jose.JSONWebKeySet{}, fmt.Errorf("client jwks must contain at least one key")
+	}
+	return jwks, nil
+}
+
+func validateClientJWKSetURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("client jwks_uri is invalid: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("client jwks_uri must use https")
+	}
+	if u.Host == "" {
+		return fmt.Errorf("client jwks_uri must include a host")
+	}
+	if u.User != nil {
+		return fmt.Errorf("client jwks_uri must not include userinfo")
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("client jwks_uri must not include a fragment")
+	}
+	return nil
+}
+
+func verificationKeysForJWT(tkn *jwt.Token, jwks jose.JSONWebKeySet, validMethods []string) (any, error) {
+	alg := tkn.Method.Alg()
+	if alg == "" || strings.EqualFold(alg, "none") || strings.HasPrefix(alg, "HS") {
+		return nil, fmt.Errorf("client_assertion signing algorithm is not allowed")
+	}
+	if len(validMethods) > 0 && !slices.Contains(validMethods, alg) {
+		return nil, fmt.Errorf("client_assertion signing algorithm %s is not supported", alg)
+	}
+
+	var keys []jose.JSONWebKey
+	if kid, _ := tkn.Header["kid"].(string); kid != "" {
+		keys = jwks.Key(kid)
+	} else {
+		keys = jwks.Keys
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("client_assertion signing key was not found")
+	}
+
+	keySet := jwt.VerificationKeySet{}
+	for _, key := range keys {
+		if key.Use != "" && key.Use != "sig" {
+			continue
+		}
+		if key.Algorithm != "" && key.Algorithm != alg {
+			continue
+		}
+		if !key.Valid() {
+			continue
+		}
+		switch key.Key.(type) {
+		case []byte:
+			continue
+		default:
+			keySet.Keys = append(keySet.Keys, key.Key)
+		}
+	}
+	if len(keySet.Keys) == 0 {
+		return nil, fmt.Errorf("client_assertion signing key was not found")
+	}
+
+	return keySet, nil
+}

--- a/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
@@ -1,0 +1,171 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/api/handlers"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestValidatePrivateKeyJWT(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clientID      = "https://client.example/oauth/client.json"
+		tokenEndpoint = "https://obot.example/oauth/token"
+	)
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+
+	jwks, err := json.Marshal(jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{{
+			Key:       &key.PublicKey,
+			KeyID:     "test-key",
+			Algorithm: "RS256",
+			Use:       "sig",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal jwks: %v", err)
+	}
+
+	h := &handler{
+		oauthConfig: handlers.OAuthAuthorizationServerConfig{
+			TokenEndpoint: tokenEndpoint,
+			TokenEndpointAuthSigningAlgValuesSupported: []string{"RS256"},
+		},
+	}
+	client := v1.OAuthClient{
+		ObjectMeta: metav1.ObjectMeta{Name: clientID},
+		Spec: v1.OAuthClientSpec{
+			Manifest: types.OAuthClientManifest{
+				TokenEndpointAuthMethod: "private_key_jwt",
+				JWKS:                    string(jwks),
+			},
+		},
+	}
+
+	assertion := signClientAssertion(t, key, "test-key", clientID, tokenEndpoint)
+	form := url.Values{
+		"client_assertion_type": {clientAssertionTypeJWTBearer},
+		"client_assertion":      {assertion},
+	}
+
+	if err := h.validatePrivateKeyJWT(context.Background(), form, client); err != nil {
+		t.Fatalf("validate private_key_jwt: %v", err)
+	}
+
+	form.Set("client_assertion", signClientAssertion(t, key, "test-key", clientID, "https://other.example/oauth/token"))
+	if err := h.validatePrivateKeyJWT(context.Background(), form, client); err == nil {
+		t.Fatal("expected invalid audience to fail")
+	}
+}
+
+func TestClientIDFromClientAssertion(t *testing.T) {
+	t.Parallel()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+
+	const clientID = "https://client.example/oauth/client.json"
+	assertion := signClientAssertion(t, key, "test-key", clientID, "https://obot.example/oauth/token")
+	got, err := clientIDFromClientAssertion(url.Values{
+		"client_assertion_type": {clientAssertionTypeJWTBearer},
+		"client_assertion":      {assertion},
+	})
+	if err != nil {
+		t.Fatalf("client id from assertion: %v", err)
+	}
+	if got != clientID {
+		t.Fatalf("expected client id %q, got %q", clientID, got)
+	}
+}
+
+func TestTokenExtractsClientIDFromClientAssertion(t *testing.T) {
+	t.Parallel()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+
+	const clientName = "test-client"
+	clientID := system.DefaultNamespace + ":" + clientName
+	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.OAuthClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.DefaultNamespace,
+			Name:      clientName,
+		},
+		Spec: v1.OAuthClientSpec{
+			Manifest: types.OAuthClientManifest{
+				TokenEndpointAuthMethod: "private_key_jwt",
+			},
+		},
+	}).Build()
+
+	form := url.Values{
+		"grant_type":            {"unsupported"},
+		"client_assertion_type": {clientAssertionTypeJWTBearer},
+		"client_assertion":      {signClientAssertion(t, key, "test-key", clientID, "https://obot.example/oauth/token")},
+	}
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	err = (&handler{
+		oauthConfig: handlers.OAuthAuthorizationServerConfig{
+			GrantTypesSupported: []string{"authorization_code"},
+		},
+	}).token(api.Context{
+		ResponseWriter: httptest.NewRecorder(),
+		Request:        req,
+		Storage:        storage,
+	})
+	if err == nil {
+		t.Fatal("expected unsupported grant type error")
+	}
+	if !strings.Contains(err.Error(), "grant_type") {
+		t.Fatalf("expected request to reach grant type validation, got %v", err)
+	}
+}
+
+func signClientAssertion(t *testing.T, key *rsa.PrivateKey, kid, clientID, audience string) string {
+	t.Helper()
+
+	claims := jwt.RegisteredClaims{
+		Issuer:    clientID,
+		Subject:   clientID,
+		Audience:  jwt.ClaimStrings{audience},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute)),
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ID:        "assertion-id",
+	}
+	tkn := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tkn.Header["kid"] = kid
+
+	assertion, err := tkn.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign assertion: %v", err)
+	}
+	return assertion
+}

--- a/pkg/api/handlers/mcpgateway/oauth/redirect_uri.go
+++ b/pkg/api/handlers/mcpgateway/oauth/redirect_uri.go
@@ -1,0 +1,62 @@
+package oauth
+
+import (
+	"net/netip"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+func isRedirectURIAllowed(manifest types.OAuthClientManifest, redirectURI string) bool {
+	if slices.Contains(manifest.RedirectURIs, redirectURI) {
+		return true
+	}
+	if manifest.ApplicationType != "native" {
+		return false
+	}
+
+	for _, registeredRedirectURI := range manifest.RedirectURIs {
+		if isNativeLoopbackRedirectURIWithRequestedPort(registeredRedirectURI, redirectURI) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isNativeLoopbackRedirectURIWithRequestedPort(registeredRedirectURI, requestedRedirectURI string) bool {
+	registered, err := url.Parse(registeredRedirectURI)
+	if err != nil {
+		return false
+	}
+	requested, err := url.Parse(requestedRedirectURI)
+	if err != nil {
+		return false
+	}
+	if registered.Port() != "" || requested.Port() == "" {
+		return false
+	}
+	registeredHost := registered.Hostname()
+	requestedHost := requested.Hostname()
+	if !isLoopbackHost(registeredHost) || !strings.EqualFold(registeredHost, requestedHost) {
+		return false
+	}
+
+	return registered.Scheme == requested.Scheme &&
+		registered.User == nil &&
+		requested.User == nil &&
+		registered.EscapedPath() == requested.EscapedPath() &&
+		registered.RawQuery == requested.RawQuery &&
+		registered.Fragment == requested.Fragment
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.ToLower(host)
+	if host == "localhost" {
+		return true
+	}
+	ip, err := netip.ParseAddr(host)
+	return err == nil && ip.IsLoopback()
+}

--- a/pkg/api/handlers/mcpgateway/oauth/redirect_uri_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/redirect_uri_test.go
@@ -1,0 +1,119 @@
+package oauth
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+func TestIsRedirectURIAllowed(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		manifest    types.OAuthClientManifest
+		redirectURI string
+		want        bool
+	}{
+		{
+			name: "exact match allowed",
+			manifest: types.OAuthClientManifest{
+				RedirectURIs: []string{"https://client.example/callback"},
+			},
+			redirectURI: "https://client.example/callback",
+			want:        true,
+		},
+		{
+			name: "web client requires exact match",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "web",
+				RedirectURIs:    []string{"http://127.0.0.1/callback"},
+			},
+			redirectURI: "http://127.0.0.1:49152/callback",
+		},
+		{
+			name: "native loopback request may add port",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "native",
+				RedirectURIs:    []string{"http://127.0.0.1/callback"},
+			},
+			redirectURI: "http://127.0.0.1:49152/callback",
+			want:        true,
+		},
+		{
+			name: "native ipv6 loopback request may add port",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "native",
+				RedirectURIs:    []string{"http://[::1]/callback"},
+			},
+			redirectURI: "http://[::1]:49152/callback",
+			want:        true,
+		},
+		{
+			name: "native localhost request may add port",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "native",
+				RedirectURIs:    []string{"http://localhost/callback"},
+			},
+			redirectURI: "http://localhost:49152/callback",
+			want:        true,
+		},
+		{
+			name: "native exact match remains allowed",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "native",
+				RedirectURIs:    []string{"http://127.0.0.1/callback"},
+			},
+			redirectURI: "http://127.0.0.1/callback",
+			want:        true,
+		},
+		{
+			name: "native registered URI with port does not relax",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "native",
+				RedirectURIs:    []string{"http://127.0.0.1:3000/callback"},
+			},
+			redirectURI: "http://127.0.0.1:49152/callback",
+		},
+		{
+			name: "native non-loopback request does not relax",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "native",
+				RedirectURIs:    []string{"https://client.example/callback"},
+			},
+			redirectURI: "https://client.example:49152/callback",
+		},
+		{
+			name: "native path must still match",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "native",
+				RedirectURIs:    []string{"http://127.0.0.1/callback"},
+			},
+			redirectURI: "http://127.0.0.1:49152/other",
+		},
+		{
+			name: "native query must still match",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "native",
+				RedirectURIs:    []string{"http://127.0.0.1/callback?client=desktop"},
+			},
+			redirectURI: "http://127.0.0.1:49152/callback?client=mobile",
+		},
+		{
+			name: "native host must still match",
+			manifest: types.OAuthClientManifest{
+				ApplicationType: "native",
+				RedirectURIs:    []string{"http://127.0.0.1/callback"},
+			},
+			redirectURI: "http://127.0.0.2:49152/callback",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isRedirectURIAllowed(tt.manifest, tt.redirectURI); got != tt.want {
+				t.Fatalf("allowed = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -31,10 +32,11 @@ import (
 var log = logger.Package()
 
 const (
-	tokenExpiration         = 10 * time.Minute
-	tokenTypeJWT            = "urn:ietf:params:oauth:token-type:jwt"
-	tokenTypeAccessToken    = "urn:ietf:params:oauth:token-type:access_token"
-	tokenTypeAPIKey         = "urn:obot:token-type:api-key"
+	tokenExpiration      = 10 * time.Minute
+	tokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"
+	tokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
+	tokenTypeAPIKey      = "urn:obot:token-type:api-key"
+
 	ErrUnsupportedGrantType = ErrorCode("unsupported_grant_type")
 )
 
@@ -55,52 +57,60 @@ func (h *handler) token(req api.Context) error {
 	clientID := req.FormValue("client_id")
 	if clientID == "" {
 		creds := strings.TrimPrefix(req.Request.Header.Get("Authorization"), "Basic ")
-		if creds == "" {
-			log.Infof("Denied OAuth token request due to missing client credentials")
-			return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
-		}
+		if creds != "" {
+			c, err := base64.StdEncoding.DecodeString(creds)
+			if err != nil {
+				log.Infof("Denied OAuth token request due to invalid basic auth encoding")
+				return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
+			}
 
-		c, err := base64.StdEncoding.DecodeString(creds)
-		if err != nil {
-			log.Infof("Denied OAuth token request due to invalid basic auth encoding")
-			return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
-		}
+			idx := bytes.LastIndex(c, []byte{':'})
+			if idx == -1 {
+				log.Infof("Denied OAuth token request due to malformed basic auth credentials")
+				return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
+			}
 
-		idx := bytes.LastIndex(c, []byte{':'})
-		if idx == -1 {
-			log.Infof("Denied OAuth token request due to malformed basic auth credentials")
-			return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
-		}
+			clientID, clientSecret = string(c[:idx]), string(c[idx+1:])
+			if clientID == "" {
+				return types.NewErrBadRequest("%v", Error{
+					Code:        ErrInvalidRequest,
+					Description: "client_id is required",
+				})
+			}
 
-		clientID, clientSecret = string(c[:idx]), string(c[idx+1:])
-		if clientID == "" {
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: "client_id is required",
-			})
-		}
-
-		clientID, err = url.QueryUnescape(clientID)
-		if err != nil {
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: "client_id is invalid",
-			})
+			clientID, err = url.QueryUnescape(clientID)
+			if err != nil {
+				return types.NewErrBadRequest("%v", Error{
+					Code:        ErrInvalidRequest,
+					Description: "client_id is invalid",
+				})
+			}
 		}
 	} else {
 		clientSecret = req.FormValue("client_secret")
 	}
 
-	clientNamespace, clientName, ok := strings.Cut(clientID, ":")
-	if !ok {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "client_id is invalid",
-		})
+	if clientID == "" && req.FormValue("client_assertion_type") == clientAssertionTypeJWTBearer {
+		var err error
+		clientID, err = clientIDFromClientAssertion(req.Form)
+		if err != nil {
+			return types.NewErrBadRequest("%v", Error{
+				Code:        ErrInvalidRequest,
+				Description: err.Error(),
+			})
+		}
 	}
 
-	var client v1.OAuthClient
-	if err := req.Storage.Get(req.Context(), kclient.ObjectKey{Namespace: clientNamespace, Name: clientName}, &client); err != nil {
+	if clientID == "" {
+		log.Infof("Denied OAuth token request due to missing client credentials")
+		return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
+	}
+
+	client, err := h.resolveOAuthClient(req.Context(), req.Storage, clientID)
+	if err != nil {
+		if oauthErr, ok := errors.AsType[Error](err); ok {
+			return types.NewErrBadRequest("%v", oauthErr)
+		}
 		return err
 	}
 
@@ -167,6 +177,12 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 	}
 
 	oauthAuthRequest := oauthAuthRequestList.Items[0]
+	if oauthAuthRequest.Spec.ClientID != oauthClient.Name {
+		return types.NewErrBadRequest("%v", Error{
+			Code:        ErrInvalidRequest,
+			Description: "code is invalid",
+		})
+	}
 
 	// Authorization codes are one-time use
 	if err := req.Storage.Delete(req.Context(), &oauthAuthRequest); err != nil {
@@ -271,6 +287,12 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 
 	var oauthToken v1.OAuthToken
 	if err := req.Storage.Get(req.Context(), kclient.ObjectKey{Namespace: oauthClient.Namespace, Name: fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken)))}, &oauthToken); err != nil {
+		return types.NewErrBadRequest("%v", Error{
+			Code:        ErrInvalidRequest,
+			Description: "refresh_token is invalid",
+		})
+	}
+	if oauthToken.Spec.ClientID != oauthClient.Name {
 		return types.NewErrBadRequest("%v", Error{
 			Code:        ErrInvalidRequest,
 			Description: "refresh_token is invalid",

--- a/pkg/api/handlers/oauthclients.go
+++ b/pkg/api/handlers/oauthclients.go
@@ -285,4 +285,8 @@ type OAuthAuthorizationServerConfig struct {
 
 	// Additional fields can be added here
 	UserInfoEndpoint string `json:"userinfo_endpoint,omitempty"`
+
+	// ClientIDMetadataDocumentSupported indicates whether the client ID metadata document is supported by this authorization server.
+	// OPTIONAL.
+	ClientIDMetadataDocumentSupported bool `json:"client_id_metadata_document_supported,omitempty"`
 }

--- a/pkg/api/handlers/oauthclients.go
+++ b/pkg/api/handlers/oauthclients.go
@@ -176,6 +176,9 @@ func ValidateClientConfig(oauthClient *v1.OAuthClient, oauthConfig OAuthAuthoriz
 	if len(oauthClient.Spec.Manifest.RedirectURIs) == 0 {
 		return fmt.Errorf("redirect_uris is required")
 	}
+	if oauthClient.Spec.Manifest.ApplicationType != "" && oauthClient.Spec.Manifest.ApplicationType != "web" && oauthClient.Spec.Manifest.ApplicationType != "native" {
+		return fmt.Errorf("application_type must be web or native")
+	}
 	if oauthClient.Spec.Manifest.TokenEndpointAuthMethod != "" && !slices.Contains(oauthConfig.TokenEndpointAuthMethodsSupported, oauthClient.Spec.Manifest.TokenEndpointAuthMethod) {
 		return fmt.Errorf("token_endpoint_auth_method must be %s, not %s", strings.Join(oauthConfig.TokenEndpointAuthMethodsSupported, ", "), oauthClient.Spec.Manifest.TokenEndpointAuthMethod)
 	}

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -964,12 +964,13 @@ func (h *Handler) SyncOAuthMetadata(req router.Request, _ router.Response) error
 	}
 
 	statusMetadata := &v1.OAuthMetadata{
-		ProtectedResourceURL:        metadata.ProtectedResourceMetadataURL,
-		AuthorizationServerURL:      metadata.AuthorizationServerMetadataURL,
-		ProtectedResourceMetadata:   metadata.ProtectedResourceMetadata,
-		AuthorizationServerMetadata: metadata.AuthorizationServerMetadata,
-		ClientRegistration:          metadata.ClientRegistration,
-		DynamicClientRegistration:   metadata.DynamicClientRegistration,
+		ProtectedResourceURL:              metadata.ProtectedResourceMetadataURL,
+		AuthorizationServerURL:            metadata.AuthorizationServerMetadataURL,
+		ProtectedResourceMetadata:         metadata.ProtectedResourceMetadata,
+		AuthorizationServerMetadata:       metadata.AuthorizationServerMetadata,
+		ClientRegistration:                metadata.ClientRegistration,
+		DynamicClientRegistration:         metadata.DynamicClientRegistration,
+		ClientIDMetadataDocumentSupported: metadata.ClientIDMetadataDocumentSupported,
 	}
 
 	syncTime := metav1.Now()

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -910,8 +910,10 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		ResponseTypesSupported:            []string{"code"},
 		GrantTypesSupported:               []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:token-exchange"},
 		CodeChallengeMethodsSupported:     []string{"S256", "plain"},
-		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post", "none"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post", "private_key_jwt", "none"},
+		TokenEndpointAuthSigningAlgValuesSupported: []string{"RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512", "EdDSA"},
 		UserInfoEndpoint:                  fmt.Sprintf("%s/oauth/userinfo", config.Hostname),
+		ClientIDMetadataDocumentSupported: true,
 	}
 
 	// For now, always auto-migrate the gateway database

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -186,12 +186,13 @@ type MCPServerStatus struct {
 }
 
 type OAuthMetadata struct {
-	ProtectedResourceURL        string          `json:"protectedResourceUrl,omitempty"`
-	AuthorizationServerURL      string          `json:"authorizationServerUrl,omitempty"`
-	ProtectedResourceMetadata   json.RawMessage `json:"protectedResourceMetadata,omitempty"`
-	AuthorizationServerMetadata json.RawMessage `json:"authorizationServerMetadata,omitempty"`
-	ClientRegistration          json.RawMessage `json:"clientRegistration,omitempty"`
-	DynamicClientRegistration   bool            `json:"dynamicClientRegistration,omitempty"`
+	ProtectedResourceURL              string          `json:"protectedResourceUrl,omitempty"`
+	AuthorizationServerURL            string          `json:"authorizationServerUrl,omitempty"`
+	ProtectedResourceMetadata         json.RawMessage `json:"protectedResourceMetadata,omitempty"`
+	AuthorizationServerMetadata       json.RawMessage `json:"authorizationServerMetadata,omitempty"`
+	ClientRegistration                json.RawMessage `json:"clientRegistration,omitempty"`
+	DynamicClientRegistration         bool            `json:"dynamicClientRegistration,omitempty"`
+	ClientIDMetadataDocumentSupported bool            `json:"clientIdMetadataDocumentSupported,omitempty"`
 }
 
 type DeploymentCondition struct {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -8482,6 +8482,13 @@ func schema_obot_platform_obot_apiclient_types_OAuthClientManifest(ref common.Re
 							},
 						},
 					},
+					"application_type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ApplicationType is a string indicator of the requested client application type. Values defined include: \"web\", \"native\". If unspecified or omitted, the default is \"web\". Optional.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"token_endpoint_auth_method": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TokenEndpointAuthMethod is a string indicator of the requested authentication method for the token endpoint. Values defined include: \"none\", \"client_secret_post\", \"client_secret_basic\". If unspecified or omitted, the default is \"client_secret_basic\". Optional.",

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -8725,6 +8725,12 @@ func schema_obot_platform_obot_apiclient_types_OAuthMetadata(ref common.Referenc
 							Format: "byte",
 						},
 					},
+					"clientIdMetadataDocumentSupported": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},
@@ -16111,6 +16117,12 @@ func schema_storage_apis_obotobotai_v1_OAuthMetadata(ref common.ReferenceCallbac
 						},
 					},
 					"dynamicClientRegistration": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"clientIdMetadataDocumentSupported": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
 							Format: "",

--- a/pkg/system/mcp.go
+++ b/pkg/system/mcp.go
@@ -2,11 +2,13 @@ package system
 
 import (
 	"fmt"
+	"strings"
 )
 
 const (
 	// MCPOAuthCredentialContextPrefix is the credential context prefix for MCP OAuth credentials
 	MCPOAuthCredentialContextPrefix = "mcp-oauth"
+	OAuthClientIDMetadataPath       = "/oauth/client-metadata.json"
 )
 
 // MCPOAuthCredentialName returns the credential name for an MCP server's OAuth credentials
@@ -24,4 +26,8 @@ func NanobotAgentConnectURL(serverURL, id string) string {
 
 func MCPOAuthCallbackURL(serverURL string) string {
 	return fmt.Sprintf("%s/oauth/mcp/callback", serverURL)
+}
+
+func OAuthClientIDMetadataURL(serverURL string) string {
+	return strings.TrimRight(serverURL, "/") + OAuthClientIDMetadataPath
 }

--- a/ui/user/src/lib/components/mcp/OAuthMetadataDebug.svelte
+++ b/ui/user/src/lib/components/mcp/OAuthMetadataDebug.svelte
@@ -63,6 +63,13 @@
 				</p>
 			</div>
 
+			<div class="grid gap-1">
+				<p class="font-medium">Client ID Metadata Document Supported</p>
+				<p class="text-muted-content">
+					{metadata.clientIdMetadataDocumentSupported ? 'Supported' : 'Unsupported'}
+				</p>
+			</div>
+
 			{#if metadata.protectedResourceMetadata}
 				<div class="grid gap-1">
 					<p class="font-medium">Protected Resource Metadata</p>

--- a/ui/user/src/lib/components/mcp/oauth/DebugOauthFlow.svelte
+++ b/ui/user/src/lib/components/mcp/oauth/DebugOauthFlow.svelte
@@ -198,6 +198,11 @@
 	});
 
 	const stepLoading = $derived(Object.values(loading).some(Boolean));
+	const clientRegistrationTitle = $derived(
+		mcpServer.oauthMetadata?.clientIdMetadataDocumentSupported
+			? 'Client ID Metadata Document'
+			: 'Client Registration'
+	);
 </script>
 
 <div class="flex flex-col gap-2 p-4 md:pt-0">
@@ -220,7 +225,7 @@
 	<DebugOauthSection
 		bind:open={expanded.clientRegistration}
 		loading={loading.clientRegistration}
-		title="Client Registration"
+		title={clientRegistrationTitle}
 		errors={errors.clientRegistration}
 		hasResults={Boolean(results.clientRegistration)}
 	>

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -734,6 +734,7 @@ export interface OAuthClient {
 export interface OAuthDebuggerRegisterClientResponse {
 	state: string;
 	client: OAuthClient;
+	clientIdMetadataDocument?: boolean;
 }
 export interface OAuthDebuggerAuthorizationURLRequest {
 	state: string;

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -977,6 +977,10 @@ export type OAuthConsent = {
 	continueURL: string;
 	cancelURL: string;
 	clientName: string;
+	clientCredentialSource:
+		| 'client_id_metadata_document'
+		| 'dynamic_client'
+		| 'static_client_credentials';
 	clientURI?: string;
 	redirectURI: string;
 	scope?: string;

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -410,6 +410,7 @@ export interface OAuthMetadata {
 	authorizationServerMetadata?: Record<string, unknown>;
 	clientRegistration?: Record<string, unknown>;
 	dynamicClientRegistration?: boolean;
+	clientIdMetadataDocumentSupported?: boolean;
 }
 export interface MCPServerInstance {
 	id: string;

--- a/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
+++ b/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
@@ -15,6 +15,9 @@
 	const consent = $derived(data.consent);
 	const scopes = $derived(consent.scope?.split(' ').filter(Boolean) ?? []);
 	const showMCPAuthNotice = $derived(consent.mcpAuthRequired || consent.userHasSecondLevelOAuthed);
+	const clientCredentialSourceLabel = $derived(
+		clientCredentialSourceLabelFor(consent.clientCredentialSource)
+	);
 
 	type DetailRow =
 		| { label: string; type: 'text'; value: string; valueClass?: string }
@@ -34,6 +37,13 @@
 		if (consent.clientURI) {
 			rows.push({ label: 'Application URL', type: 'link', value: consent.clientURI });
 		}
+
+		rows.push({
+			label: 'OAuth client',
+			type: 'text',
+			value: clientCredentialSourceLabel,
+			valueClass: 'wrap-break-word'
+		});
 
 		rows.push({
 			label: 'Redirect URL',
@@ -89,6 +99,19 @@
 
 		return rows;
 	});
+
+	function clientCredentialSourceLabelFor(source: OAuthConsent['clientCredentialSource']) {
+		switch (source) {
+			case 'client_id_metadata_document':
+				return 'Client ID Metadata Document';
+			case 'static_client_credentials':
+				return 'Static client credentials';
+			case 'dynamic_client':
+				return 'Dynamic client';
+			default:
+				return 'Unknown';
+		}
+	}
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This change adds support for Client ID Metadata Documents for Obot when it is functioning as an OAuth Authorization Server. That is, instead of clients dynamically registering, clients can use CIMD to request auth tokens on a user's behalf.

Additionally, if an authorization server for an MCP server supports CIMD, then Obot will use it to get access tokens.

Issue: https://github.com/obot-platform/obot/issues/6833

Requires: https://github.com/obot-platform/nanobot/pull/328