### PR TITLE
fix: obot icon in navigation layout

### DIFF
--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -38,12 +38,12 @@
 		type Layout as LayoutState
 	} from '$lib/context/layout.svelte';
 	import Bots from '$lib/icons/Bots.svelte';
+	import LogoIcon from '$lib/icons/LogoIcon.svelte';
 	import { Group } from '$lib/services';
 	import { defaultModelAliases, profile, responsive, version } from '$lib/stores';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte';
 	import { isAgentEnabled } from '$lib/utils';
 	import InfoTooltip from './InfoTooltip.svelte';
-	import Logo from './Logo.svelte';
 	import Tour from './Tour.svelte';
 	import ConfigureBanner from './admin/ConfigureBanner.svelte';
 	import SetupSplashDialog from './admin/SetupSplashDialog.svelte';
@@ -245,7 +245,7 @@
 		{
 			id: 'install-cli',
 			href: '/install-cli',
-			icon: Logo,
+			icon: LogoIcon,
 			label: 'Obot CLI',
 			collapsible: false
 		},

--- a/ui/user/src/lib/icons/LogoIcon.svelte
+++ b/ui/user/src/lib/icons/LogoIcon.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { appPreferences } from '$lib/stores';
+
+	let logoSrc = $derived(appPreferences.current.logos?.logoIcon);
+</script>
+
+<div
+	class="size-5"
+	role="img"
+	aria-label="Obot logo icon"
+	style="background-color: currentColor; mask: url({logoSrc}) center / contain no-repeat; -webkit-mask: url({logoSrc}) center / contain no-repeat;"
+></div>


### PR DESCRIPTION
* have obot icon in sidebar navigation match text-base-content color instead of blue obot logo
<img width="298" height="50" alt="Screenshot 2026-06-16 at 1 32 02 PM" src="https://github.com/user-attachments/assets/92166a28-0c79-415d-84bc-b3942fc5a320" />
