### PR TITLE
fix: llm-gateway models page & navigation route only available when models available

### DIFF
--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -39,7 +39,7 @@
 	} from '$lib/context/layout.svelte';
 	import Bots from '$lib/icons/Bots.svelte';
 	import { Group } from '$lib/services';
-	import { defaultModelAliases, profile, responsive, version } from '$lib/stores';
+	import { accessibleModels, defaultModelAliases, profile, responsive, version } from '$lib/stores';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte';
 	import { isAgentEnabled } from '$lib/utils';
 	import InfoTooltip from './InfoTooltip.svelte';
@@ -72,7 +72,8 @@
 		PanelLeftOpen,
 		KeySquare,
 		Settings,
-		PanelLeftClose
+		PanelLeftClose,
+		Brain
 	} from 'lucide-svelte';
 	import { type Component, type Snippet, untrack } from 'svelte';
 	import { fade, slide, type TransitionConfig } from 'svelte/transition';
@@ -205,6 +206,8 @@
 	let isAtLeastPowerUser = $derived(profile.current.groups.includes(Group.POWERUSER));
 	let isAtLeastPowerUserPlus = $derived(profile.current.groups.includes(Group.POWERUSER_PLUS));
 
+	let hasAccessibleModels = $derived(accessibleModels.current.length > 0);
+
 	let defaultLinks = $derived<NavLink[]>([
 		...(profile.current.hasAdminAccess?.()
 			? [
@@ -229,13 +232,17 @@
 			label: 'Skills',
 			href: '/skills'
 		},
-		{
-			id: 'llm-gateway-models',
-			href: '/llm-gateway/models',
-			icon: BrainCog,
-			label: 'Models',
-			collapsible: false
-		},
+		...(hasAccessibleModels
+			? [
+					{
+						id: 'llm-gateway-models',
+						href: '/llm-gateway/models',
+						icon: Brain,
+						label: 'Models',
+						collapsible: false
+					}
+				]
+			: []),
 		{
 			id: 'devices',
 			icon: Laptop,

--- a/ui/user/src/lib/components/llm-gateway/LLMGatewayCodeBlock.svelte
+++ b/ui/user/src/lib/components/llm-gateway/LLMGatewayCodeBlock.svelte
@@ -24,7 +24,7 @@
 				classes={{ button: 'bg-base-100 dark:bg-base-200 rounded p-1.5' }}
 			/>
 		</div>
-		<pre class="default-scrollbar-thin overflow-x-auto p-3 pr-12 text-xs leading-relaxed"><code
+		<pre class="default-scrollbar-thin overflow-x-auto p-3 pr-12 text-xs leading-relaxed my-0"><code
 				class="font-mono">{block.code}</code
 			></pre>
 	</div>

--- a/ui/user/src/lib/stores/accessibleModels.svelte.ts
+++ b/ui/user/src/lib/stores/accessibleModels.svelte.ts
@@ -1,11 +1,7 @@
-import { CommonModelProviderIds } from '$lib/constants';
 import { UserService, type Model } from '$lib/services';
+import { SUPPORTED_PROVIDER_IDS } from '$lib/services/llm-gateway/types';
 
-// eslint-disable-next-line svelte/prefer-svelte-reactivity -- this is not a reactive Set
-export const SUPPORTED_MODEL_PROVIDER_IDS = new Set<string>([
-	CommonModelProviderIds.OPENAI,
-	CommonModelProviderIds.ANTHROPIC
-]);
+const SUPPORTED_MODEL_PROVIDER_IDS = new Set<string>(SUPPORTED_PROVIDER_IDS);
 
 export function filterAccessibleModels(models: Model[]): Model[] {
 	return models.filter((m) => m.active && SUPPORTED_MODEL_PROVIDER_IDS.has(m.modelProvider));
@@ -48,7 +44,7 @@ async function load() {
 async function initialize(models?: Model[]) {
 	if (store.initialized) return;
 	if (models) {
-		setModels(filterAccessibleModels(models));
+		setModels(models);
 	} else {
 		await load();
 	}

--- a/ui/user/src/lib/stores/accessibleModels.svelte.ts
+++ b/ui/user/src/lib/stores/accessibleModels.svelte.ts
@@ -1,0 +1,61 @@
+import { CommonModelProviderIds } from '$lib/constants';
+import { UserService, type Model } from '$lib/services';
+
+// eslint-disable-next-line svelte/prefer-svelte-reactivity -- this not a reactive Set
+export const SUPPORTED_MODEL_PROVIDER_IDS = new Set<string>([
+	CommonModelProviderIds.OPENAI,
+	CommonModelProviderIds.ANTHROPIC
+]);
+
+export function filterAccessibleModels(models: Model[]): Model[] {
+	return models.filter((m) => m.active && SUPPORTED_MODEL_PROVIDER_IDS.has(m.modelProvider));
+}
+
+const store = $state<{
+	current: Model[];
+	loading: boolean;
+	initialized: boolean;
+	set: (models: Model[]) => void;
+	initialize: (models?: Model[]) => Promise<void>;
+	refresh: () => Promise<void>;
+}>({
+	current: [],
+	loading: false,
+	initialized: false,
+	set: setModels,
+	initialize,
+	refresh
+});
+
+function setModels(models: Model[]) {
+	store.current = filterAccessibleModels(models);
+	store.initialized = true;
+}
+
+async function load() {
+	store.loading = true;
+	try {
+		const all = await UserService.listModels();
+		store.current = filterAccessibleModels(all);
+	} catch {
+		store.current = [];
+	} finally {
+		store.loading = false;
+		store.initialized = true;
+	}
+}
+
+async function initialize(models?: Model[]) {
+	if (store.initialized) return;
+	if (models) {
+		setModels(filterAccessibleModels(models));
+	} else {
+		await load();
+	}
+}
+
+async function refresh() {
+	await load();
+}
+
+export default store;

--- a/ui/user/src/lib/stores/accessibleModels.svelte.ts
+++ b/ui/user/src/lib/stores/accessibleModels.svelte.ts
@@ -1,7 +1,7 @@
 import { CommonModelProviderIds } from '$lib/constants';
 import { UserService, type Model } from '$lib/services';
 
-// eslint-disable-next-line svelte/prefer-svelte-reactivity -- this not a reactive Set
+// eslint-disable-next-line svelte/prefer-svelte-reactivity -- this is not a reactive Set
 export const SUPPORTED_MODEL_PROVIDER_IDS = new Set<string>([
 	CommonModelProviderIds.OPENAI,
 	CommonModelProviderIds.ANTHROPIC

--- a/ui/user/src/lib/stores/index.ts
+++ b/ui/user/src/lib/stores/index.ts
@@ -6,5 +6,6 @@ export { default as version } from './version.svelte';
 export { default as appPreferences } from './appPreferences.svelte';
 export { default as mcpServersAndEntries } from './mcpServersAndEntries.svelte';
 export { default as defaultModelAliases } from './defaultModelAliases.svelte';
+export { default as accessibleModels } from './accessibleModels.svelte';
 export { default as userDeviceSettings } from './userDeviceSettings.svelte';
 export { default as license } from './license.svelte';

--- a/ui/user/src/routes/+layout.svelte
+++ b/ui/user/src/routes/+layout.svelte
@@ -12,7 +12,8 @@
 		mcpServersAndEntries,
 		defaultModelAliases,
 		userDeviceSettings,
-		license
+		license,
+		accessibleModels
 	} from '$lib/stores';
 	import '../app.css';
 	import type { PageData } from './$types';
@@ -49,6 +50,10 @@
 
 		if (data.defaultModelAliases) {
 			untrack(() => defaultModelAliases.initialize(data.defaultModelAliases));
+		}
+
+		if (data.models) {
+			untrack(() => accessibleModels.initialize(data.models));
 		}
 
 		if (browser) {

--- a/ui/user/src/routes/+layout.ts
+++ b/ui/user/src/routes/+layout.ts
@@ -4,6 +4,7 @@ import {
 	type AppPreferences,
 	type DefaultModelAlias,
 	type License,
+	type Model,
 	type Profile,
 	type Version
 } from '$lib/services';
@@ -19,7 +20,7 @@ export const load: LayoutLoad = async ({ fetch }) => {
 	let version: Version | undefined;
 	let license: License | undefined;
 	let defaultModelAliases: DefaultModelAlias[] | undefined;
-
+	let models: Model[] | undefined;
 	try {
 		version = await UserService.getVersion({ fetch });
 	} catch {
@@ -63,6 +64,12 @@ export const load: LayoutLoad = async ({ fetch }) => {
 		} catch {
 			defaultModelAliases = undefined;
 		}
+
+		try {
+			models = await UserService.listModels({ fetch });
+		} catch {
+			models = undefined;
+		}
 	}
 
 	return {
@@ -70,6 +77,7 @@ export const load: LayoutLoad = async ({ fetch }) => {
 		profile,
 		version,
 		license,
-		defaultModelAliases
+		defaultModelAliases,
+		models
 	};
 };

--- a/ui/user/src/routes/admin/model-access-policies/+page.svelte
+++ b/ui/user/src/routes/admin/model-access-policies/+page.svelte
@@ -8,7 +8,7 @@
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import { type ModelAccessPolicy } from '$lib/services/admin/types';
 	import { AdminService } from '$lib/services/index.js';
-	import { profile } from '$lib/stores/index.js';
+	import { accessibleModels, profile } from '$lib/stores/index.js';
 	import { goto, clearUrlParams } from '$lib/url';
 	import { openUrl } from '$lib/utils.js';
 	import { LockKeyhole, Plus, Trash2 } from 'lucide-svelte';
@@ -35,6 +35,7 @@
 	let isReadonly = $derived(profile.current.isAdminReadonly?.());
 
 	async function navigateToCreated(policy: ModelAccessPolicy) {
+		accessibleModels.refresh();
 		clearUrlParams(['new']);
 		goto(`/admin/model-access-policies/${policy.id}`, { replaceState: false });
 	}
@@ -164,6 +165,7 @@
 		if (!policyToDelete) return;
 		await AdminService.deleteModelAccessPolicy(policyToDelete.id);
 		modelAccessPolicies = await AdminService.listModelAccessPolicies();
+		await accessibleModels.refresh();
 		policyToDelete = undefined;
 	}}
 	oncancel={() => (policyToDelete = undefined)}

--- a/ui/user/src/routes/admin/model-access-policies/+page.svelte
+++ b/ui/user/src/routes/admin/model-access-policies/+page.svelte
@@ -35,7 +35,7 @@
 	let isReadonly = $derived(profile.current.isAdminReadonly?.());
 
 	async function navigateToCreated(policy: ModelAccessPolicy) {
-		accessibleModels.refresh();
+		await accessibleModels.refresh();
 		clearUrlParams(['new']);
 		goto(`/admin/model-access-policies/${policy.id}`, { replaceState: false });
 	}

--- a/ui/user/src/routes/admin/model-access-policies/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/model-access-policies/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import ModelAccessPolicyForm from '$lib/components/admin/ModelAccessPolicyForm.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
-	import { profile } from '$lib/stores/index.js';
+	import { accessibleModels, profile } from '$lib/stores/index.js';
 	import { goto } from '$lib/url';
 	import { fly } from 'svelte/transition';
 
@@ -18,6 +18,7 @@
 		<ModelAccessPolicyForm
 			{modelAccessPolicy}
 			onUpdate={() => {
+				accessibleModels.refresh();
 				goto('/admin/model-access-policies');
 			}}
 			readonly={profile.current.isAdminReadonly?.()}

--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -10,7 +10,11 @@
 	import { HttpError } from '$lib/errors.js';
 	import { AdminService, type ModelProvider as ModelProviderType } from '$lib/services';
 	import { sortModelProviders } from '$lib/sort.js';
-	import { defaultModelAliases as defaultModelAliasesStore, license } from '$lib/stores';
+	import {
+		accessibleModels,
+		defaultModelAliases as defaultModelAliasesStore,
+		license
+	} from '$lib/stores';
 	import { adminConfigStore } from '$lib/stores/adminConfig.svelte.js';
 	import { profile } from '$lib/stores/index.js';
 	import { delay } from '$lib/utils';
@@ -120,6 +124,8 @@
 				adminConfigStore.updateModelProviders(modelProviders);
 				adminModels.items = await AdminService.listModels({ all: true });
 
+				await accessibleModels.refresh();
+
 				providerConfigure?.close();
 				if (!isAlreadyConfigured) {
 					// if first time configuring, open the default models dialog
@@ -189,6 +195,7 @@
 						await AdminService.deconfigureModelProvider(modelProvider.id);
 						modelProviders = await AdminService.listModelProviders();
 						adminConfigStore.updateModelProviders(modelProviders);
+						accessibleModels.refresh();
 					}}
 					readonly={isAdminReadonly}
 					licenseKey={license.current.licenseKey}

--- a/ui/user/src/routes/llm-gateway/models/+page.svelte
+++ b/ui/user/src/routes/llm-gateway/models/+page.svelte
@@ -3,11 +3,9 @@
 	import LLMGatewayProviderSection from '$lib/components/llm-gateway/LLMGatewayProviderSection.svelte';
 	import { CommonModelProviderIds, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { PROVIDER_CONNECTIONS, type RenderContext } from '$lib/services/llm-gateway/types';
-	import { KeyRound } from 'lucide-svelte';
+	import { accessibleModels } from '$lib/stores';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
-
-	let { data } = $props();
 
 	let obotURL = $state('');
 
@@ -16,13 +14,16 @@
 	});
 
 	let openaiModels = $derived(
-		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.OPENAI)
+		accessibleModels.current.filter((m) => m.modelProvider === CommonModelProviderIds.OPENAI)
 	);
 	let anthropicModels = $derived(
-		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.ANTHROPIC)
+		accessibleModels.current.filter((m) => m.modelProvider === CommonModelProviderIds.ANTHROPIC)
 	);
 
-	function buildCtx(shortKey: 'openai' | 'anthropic', models: typeof data.models): RenderContext {
+	function buildCtx(
+		shortKey: 'openai' | 'anthropic',
+		models: typeof accessibleModels.current
+	): RenderContext {
 		const provider = PROVIDER_CONNECTIONS[shortKey];
 		return {
 			provider,
@@ -35,7 +36,6 @@
 	let openaiCtx = $derived(buildCtx('openai', openaiModels));
 	let anthropicCtx = $derived(buildCtx('anthropic', anthropicModels));
 
-	let hasAny = $derived(openaiModels.length > 0 || anthropicModels.length > 0);
 	let ready = $derived(obotURL !== '');
 
 	const duration = PAGE_TRANSITION_DURATION;
@@ -52,16 +52,7 @@
 			Configure your client below, then pick from the models you have access to.
 		</p>
 
-		{#if !hasAny}
-			<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-				<KeyRound class="text-base-content/80 size-24 opacity-25" />
-				<h4 class="text-muted-content text-lg font-semibold">No gateway models available</h4>
-				<p class="text-muted-content text-sm font-light">
-					You don't currently have access to any OpenAI or Anthropic models through the gateway.
-					Contact an administrator to request access.
-				</p>
-			</div>
-		{:else if ready}
+		{#if ready}
 			<div class="flex flex-col gap-4">
 				{#if anthropicModels.length > 0}
 					<LLMGatewayProviderSection ctx={anthropicCtx} models={anthropicModels} />

--- a/ui/user/src/routes/llm-gateway/models/+page.svelte
+++ b/ui/user/src/routes/llm-gateway/models/+page.svelte
@@ -3,27 +3,24 @@
 	import LLMGatewayProviderSection from '$lib/components/llm-gateway/LLMGatewayProviderSection.svelte';
 	import { CommonModelProviderIds, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { PROVIDER_CONNECTIONS, type RenderContext } from '$lib/services/llm-gateway/types';
-	import { accessibleModels } from '$lib/stores';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 
 	let obotURL = $state('');
+	let { data } = $props();
 
 	onMount(() => {
 		obotURL = window.location.origin;
 	});
 
 	let openaiModels = $derived(
-		accessibleModels.current.filter((m) => m.modelProvider === CommonModelProviderIds.OPENAI)
+		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.OPENAI)
 	);
 	let anthropicModels = $derived(
-		accessibleModels.current.filter((m) => m.modelProvider === CommonModelProviderIds.ANTHROPIC)
+		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.ANTHROPIC)
 	);
 
-	function buildCtx(
-		shortKey: 'openai' | 'anthropic',
-		models: typeof accessibleModels.current
-	): RenderContext {
+	function buildCtx(shortKey: 'openai' | 'anthropic', models: typeof data.models): RenderContext {
 		const provider = PROVIDER_CONNECTIONS[shortKey];
 		return {
 			provider,

--- a/ui/user/src/routes/llm-gateway/models/+page.ts
+++ b/ui/user/src/routes/llm-gateway/models/+page.ts
@@ -1,22 +1,23 @@
-import { CommonModelProviderIds } from '$lib/constants';
 import { handleRouteError } from '$lib/errors';
 import { UserService, type Model } from '$lib/services';
-import { profile } from '$lib/stores';
+import accessibleModels, { filterAccessibleModels } from '$lib/stores/accessibleModels.svelte';
 import type { PageLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
 
-const SUPPORTED_PROVIDER_IDS = new Set<string>([
-	CommonModelProviderIds.OPENAI,
-	CommonModelProviderIds.ANTHROPIC
-]);
-
-export const load: PageLoad = async ({ fetch }) => {
+export const load: PageLoad = async ({ fetch, parent }) => {
+	const { profile } = await parent();
 	let models: Model[] = [];
 
 	try {
 		const all = await UserService.listModels({ fetch });
-		models = all.filter((m) => m.active && SUPPORTED_PROVIDER_IDS.has(m.modelProvider));
+		models = filterAccessibleModels(all);
+		accessibleModels.set(all);
 	} catch (err) {
-		handleRouteError(err, '/llm-gateway/models', profile.current);
+		handleRouteError(err, '/llm-gateway/models', profile);
+	}
+
+	if (models.length === 0) {
+		throw redirect(302, '/');
 	}
 
 	return { models };

--- a/ui/user/src/routes/llm-gateway/models/+page.ts
+++ b/ui/user/src/routes/llm-gateway/models/+page.ts
@@ -1,3 +1,4 @@
+import { browser } from '$app/environment';
 import { handleRouteError } from '$lib/errors';
 import { UserService, type Model } from '$lib/services';
 import accessibleModels, { filterAccessibleModels } from '$lib/stores/accessibleModels.svelte';
@@ -11,7 +12,9 @@ export const load: PageLoad = async ({ fetch, parent }) => {
 	try {
 		const all = await UserService.listModels({ fetch });
 		models = filterAccessibleModels(all);
-		accessibleModels.set(all);
+		if (browser) {
+			accessibleModels.set(all);
+		}
 	} catch (err) {
 		handleRouteError(err, '/llm-gateway/models', profile);
 	}

--- a/ui/user/src/routes/llm-gateway/models/+page.ts
+++ b/ui/user/src/routes/llm-gateway/models/+page.ts
@@ -5,12 +5,18 @@ import accessibleModels, { filterAccessibleModels } from '$lib/stores/accessible
 import type { PageLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 
+let isInitialLoad = true;
+
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { profile } = await parent();
+	const { profile, models: parentModels } = await parent();
 	let models: Model[] = [];
 
+	const reuseParentModels = isInitialLoad;
+	isInitialLoad = false;
+
 	try {
-		const all = await UserService.listModels({ fetch });
+		const all =
+			reuseParentModels && parentModels ? parentModels : await UserService.listModels({ fetch });
 		models = filterAccessibleModels(all);
 		if (browser) {
 			accessibleModels.set(all);


### PR DESCRIPTION
* shows 'Models' navigation in sidebar if models are available
* if user directly hits /llm-gateway/models when no models are available, reroute to root ('/')
* dynamically shows Models navigation during admin configuration (admin configures/deconfigures a Model Provider or admin updates/creates/deletes a Model Access Policy)