### PR TITLE
fix: details & logs for server instance using incorrect URL

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -842,7 +842,7 @@
 										{tab.label}
 										{#if needsDeploymentsUpdate}
 											<CircleFadingArrowUp class="size-3 shrink-0 text-primary" />
-										{:else if numDeploymentsCount > 0}
+										{:else if numDeploymentsCount > 0 && !connectOnly && !(entry && server)}
 											<span class="text-muted-content text-[10px] font-medium"
 												>({numDeploymentsCount})</span
 											>

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -908,7 +908,8 @@
 					</button>
 				{/if}
 				<McpServerTools
-					entry={'isCatalogEntry' in entry && server ? server : entry}
+					{entry}
+					{server}
 					showToolNameIssues={entry.manifest?.runtime === 'composite'}
 				>
 					{#snippet noToolsContent()}

--- a/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
@@ -74,6 +74,7 @@
 	let isAdminUrl = $derived(page.url.pathname.includes('/admin'));
 
 	let logsUrl = $derived.by(() => {
+		console.log(entity, entityId, catalogEntry, mcpServerId);
 		if (entity === 'workspace') {
 			return catalogEntry?.id
 				? `/api/workspaces/${entityId}/entries/${catalogEntry.id}/servers/${mcpServerId}/logs`
@@ -82,10 +83,6 @@
 
 		if (entity === 'webhook-validation') {
 			return `/api/mcp-webhook-validations/${mcpServerId}/logs`;
-		}
-
-		if (entity === 'catalog' && entityId) {
-			return `/api/mcp-catalogs/${entityId}/servers/${mcpServerId}/logs`;
 		}
 
 		return `/api/mcp-servers/${mcpServerId}/logs`;
@@ -114,7 +111,7 @@
 				: UserService.getWorkspaceK8sServerDetail(entityId, mcpServerId, { dontLogErrors })
 			: entity === 'webhook-validation'
 				? AdminService.getMCPFilterDetails(mcpServerId, { dontLogErrors })
-				: entity === 'catalog' && entityId
+				: entity === 'catalog' && entityId && mcpServer && !mcpServer.catalogEntryID
 					? AdminService.getMcpCatalogServerK8sDetail(entityId, mcpServerId, { dontLogErrors })
 					: AdminService.getK8sServerDetail(mcpServerId, { dontLogErrors });
 	}

--- a/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
@@ -74,7 +74,6 @@
 	let isAdminUrl = $derived(page.url.pathname.includes('/admin'));
 
 	let logsUrl = $derived.by(() => {
-		console.log(entity, entityId, catalogEntry, mcpServerId);
 		if (entity === 'workspace') {
 			return catalogEntry?.id
 				? `/api/workspaces/${entityId}/entries/${catalogEntry.id}/servers/${mcpServerId}/logs`

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -21,6 +21,7 @@
 
 	interface Props {
 		entry: MCPCatalogEntry | MCPCatalogServer;
+		server?: MCPCatalogServer;
 		onAuthenticate?: () => void;
 		noToolsContent?: Snippet;
 		classes?: {
@@ -34,6 +35,7 @@
 
 	let {
 		entry,
+		server,
 		onAuthenticate,
 		noToolsContent,
 		classes,
@@ -52,7 +54,7 @@
 
 	// Determine if we have "real" tools or should show previews
 	let hasConnectedServer = $derived(
-		'mcpCatalogID' in entry || 'connectURL' in entry || 'mcpID' in entry
+		!('isCatalogEntry' in entry) || ('isCatalogEntry' in entry && server)
 	);
 	let showRealTools = $derived(hasConnectedServer && tools.length > 0);
 	let showPreviewTools = $derived(
@@ -115,7 +117,8 @@
 		loading = true;
 		try {
 			// Make a best effort attempt to load tools, prompts, and resources concurrently
-			let toolCall = UserService.listMcpCatalogServerTools(entry.id, {
+			let id = 'isCatalogEntry' in entry && server ? server.id : entry.id;
+			let toolCall = UserService.listMcpCatalogServerTools(id, {
 				signal: abortController.signal
 			});
 			tools = await toolCall;

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -155,8 +155,8 @@
 				</div>
 			</div>
 		{:else}
-			{#key entry.id}
-				<McpOauth {entry} onAuthenticate={handleAuthenticate} bind:error />
+			{#key server?.id ?? entry.id}
+				<McpOauth entry={server ?? entry} onAuthenticate={handleAuthenticate} bind:error />
 			{/key}
 		{/if}
 		{#if error}

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -554,20 +554,6 @@ export async function listSingleOrRemoteMcpServerLogs(mcpServerId: string): Prom
 	return response.items ?? [];
 }
 
-export async function listSingleOrRemoteMcpServerTools(id: string): Promise<MCPServerTool[]> {
-	try {
-		const response = (await doGet(`/mcp-servers/${id}/tools`, {
-			dontLogErrors: true
-		})) as ItemsResponse<MCPServerTool>;
-		return response.items ?? [];
-	} catch (error) {
-		if (error instanceof Error && error.message.startsWith('424')) {
-			return [];
-		}
-		throw error;
-	}
-}
-
 export async function listSingleOrRemoteMcpServerPrompts(id: string): Promise<MCPServerPrompt[]> {
 	try {
 		const response = (await doGet(`/mcp-servers/${id}/prompts`, {

--- a/ui/user/src/routes/mcp-catalog/s/[id]/details/+page.svelte
+++ b/ui/user/src/routes/mcp-catalog/s/[id]/details/+page.svelte
@@ -44,6 +44,7 @@
 						id={serverScopeID}
 						entity={serverScopeEntity}
 						mcpServerId={mcpServer.id}
+						{mcpServer}
 						name={mcpServer.manifest.name || ''}
 						connectedUsers={(instances ?? []).map((instance) => {
 							const user = usersMap.get(instance.userID)!;


### PR DESCRIPTION
* fix to get proper url based on passed props
* also small fix: no need to show deployment count if the view is for a server of a catalog entry (it'll only ever be 1)
* also includes fix for Tools tab improperly calling `loadTools`

Checked following areas:
MCP Servers page: (admin & poweruser)
After connecting, click & view Server Details for a single-tenant catalog entry
After connecting, click & view Server Details for a multi-user server deployed from a multi-tenant catalog entry
After connecting, click & view Server Details for a legacy multi-user server 

MCP Catalog: (admin & poweruser)
Go to Server Details for a single-tenant catalog entry, select a deployment and see Server Details
Go to Server Details for a multi-tenant catalog entry, select a deployment and see Server Details

MCP Deployments:
Click and view details of a single-tenant catalog entry deployment
Click and view details of a multi-tenant catalog entry deployment
Click a legacy multiuser server, click and view Server Details

Filters:
Create a Filter, click and view Server Details

Agents:
Enable Agents
Click agent and see Server Details