### PR TITLE
enhance: allow OAuth clients that don't supply resource to connect

### DIFF
--- a/pkg/api/handlers/wellknown/handler.go
+++ b/pkg/api/handlers/wellknown/handler.go
@@ -19,6 +19,8 @@ func SetupHandlers(baseURL string, config handlers.OAuthAuthorizationServerConfi
 	}
 
 	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp-connect/{mcp_id}", h.oauthProtectedResource)
+	mux.HandleFunc("GET /.well-known/oauth-authorization-server/{mcp_id}", h.oauthAuthorization)
+
 	mux.HandleFunc("GET /.well-known/oauth-protected-resource/v0.1/servers", h.registryOAuthProtectedResource)
 
 	mux.HandleFunc("GET /.well-known/oauth-protected-resource", h.oauthProtectedResource)

--- a/pkg/api/handlers/wellknown/oauth.go
+++ b/pkg/api/handlers/wellknown/oauth.go
@@ -3,14 +3,33 @@ package wellknown
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 )
 
-// oauthAuthorization handles the /.well-known/oauth-authorization-server endpoint
+// oauthAuthorization handles the /.well-known/oauth-authorization-server and /.well-known/oauth-authorization-server/{mcp_id} endpoints
 func (h *handler) oauthAuthorization(req api.Context) error {
-	return req.Write(h.config)
+	config := h.config
+	if mcpID := req.PathValue("mcp_id"); mcpID != "" {
+		config.AuthorizationEndpoint = appendPathSegment(config.AuthorizationEndpoint, mcpID)
+		config.RegistrationEndpoint = appendPathSegment(config.RegistrationEndpoint, mcpID)
+		config.TokenEndpoint = appendPathSegment(config.TokenEndpoint, mcpID)
+	}
+	return req.Write(config)
+}
+
+func appendPathSegment(rawURL, segment string) string {
+	if rawURL == "" || segment == "" {
+		return rawURL
+	}
+
+	joined, err := url.JoinPath(rawURL, segment)
+	if err != nil {
+		return rawURL
+	}
+	return joined
 }
 
 func (h *handler) oauthProtectedResource(req api.Context) error {
@@ -19,7 +38,7 @@ func (h *handler) oauthProtectedResource(req api.Context) error {
 		return req.Write(map[string]any{
 			"resource_name":            "Obot MCP Gateway",
 			"resource":                 fmt.Sprintf("%s/mcp-connect/%s", h.baseURL, mcpID),
-			"authorization_servers":    []string{h.baseURL},
+			"authorization_servers":    []string{h.baseURL + "/" + mcpID},
 			"bearer_methods_supported": []string{"header"},
 		})
 	}

--- a/pkg/api/handlers/wellknown/oauth_test.go
+++ b/pkg/api/handlers/wellknown/oauth_test.go
@@ -1,0 +1,55 @@
+package wellknown
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/api/handlers"
+)
+
+func TestOAuthAuthorizationAppendsMCPIDToOAuthEndpoints(t *testing.T) {
+	h := &handler{
+		config: handlers.OAuthAuthorizationServerConfig{
+			Issuer:                "https://obot.example.com",
+			AuthorizationEndpoint: "https://obot.example.com/oauth/authorize",
+			TokenEndpoint:         "https://obot.example.com/oauth/token",
+			RegistrationEndpoint:  "https://obot.example.com/oauth/register",
+			JWKSURI:               "https://obot.example.com/oauth/jwks.json",
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server/test-mcp", nil)
+	request.SetPathValue("mcp_id", "test-mcp")
+
+	if err := h.oauthAuthorization(api.Context{
+		ResponseWriter: recorder,
+		Request:        request,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var got handlers.OAuthAuthorizationServerConfig
+	if err := json.NewDecoder(recorder.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got.AuthorizationEndpoint != "https://obot.example.com/oauth/authorize/test-mcp" {
+		t.Fatalf("authorization_endpoint = %q", got.AuthorizationEndpoint)
+	}
+	if got.TokenEndpoint != "https://obot.example.com/oauth/token/test-mcp" {
+		t.Fatalf("token_endpoint = %q", got.TokenEndpoint)
+	}
+	if got.RegistrationEndpoint != "https://obot.example.com/oauth/register/test-mcp" {
+		t.Fatalf("registration_endpoint = %q", got.RegistrationEndpoint)
+	}
+	if got.Issuer != h.config.Issuer {
+		t.Fatalf("issuer = %q", got.Issuer)
+	}
+	if got.JWKSURI != h.config.JWKSURI {
+		t.Fatalf("jwks_uri = %q", got.JWKSURI)
+	}
+}


### PR DESCRIPTION
In order to know which MCP server the MCP client is trying to connect to, they should send a resource parameter with the authorize request. Not all clients do this. This change introduces a way to alter the metadata endpoints so that we can still determine which MCP server the client is connecting to when they don't send a resource parameter.