### PR TITLE
chore: fetch full git history in image build workflow

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -26,6 +26,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Fetch tags and full commit history for branch builds.
+          # This provides the VCS info required for `go build` to produce a binary that contains a
+          # main module pseudo-version with a core segment relative to the most recent release tag
+          # (e.g. vX.Y.(Z+1)-0.<ts>-<rev>).
+          # Without the full history, branch builds generate versions like v0.0.0-<ts>-<rev>,
+          # which can cause false positives in vulnerability scans.
+          fetch-depth: ${{ case(github.ref_type == 'tag', 1, 0) }}
 
       - name: Setup Depot
         uses: depot/setup-action@v1
@@ -123,6 +131,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ case(github.ref_type == 'tag', 1, 0) }}
 
       - name: Setup Depot
         uses: depot/setup-action@v1


### PR DESCRIPTION
Fetch tags and full commit history. This provides the VCS info required for
`go build` to produce a binary that contains a main module pseudo-version with
a core segment relative to the most recent release tag (e.g.
vX.Y.(Z+1)-0.<ts>-<rev>). Without the full history, branch builds generate
versions like v0.0.0-<ts>-<rev>, which can cause false positives in
vulnerability scans.

Addresses https://github.com/obot-platform/obot/issues/6962
