### PR TITLE
chore: registry API: use only the short description

### DIFF
--- a/pkg/api/handlers/registry/convert.go
+++ b/pkg/api/handlers/registry/convert.go
@@ -38,18 +38,9 @@ func ConvertMCPServerToRegistry(
 
 	registryName := FormatRegistryServerName(reverseDNS, slug)
 
-	// Create ServerDetail
-	// Use ShortDescription if available, otherwise fall back to Description
-	description := convertedServer.MCPServerManifest.ShortDescription
-	if description == "" {
-		description = convertedServer.MCPServerManifest.Description
-		if description == "" {
-			description = "(no description)"
-		}
-	}
 	serverDetail := obottypes.RegistryServerDetail{
 		Name:        registryName,
-		Description: description,
+		Description: convertedServer.MCPServerManifest.ShortDescription,
 		Title:       displayName,
 		Version:     "latest",
 		Schema:      "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
@@ -138,18 +129,9 @@ func ConvertMCPServerCatalogEntryToRegistry(
 	}
 	registryName := FormatRegistryServerName(reverseDNS, entry.Name)
 
-	// Create ServerDetail
-	// Use ShortDescription if available, otherwise fall back to Description
-	description := manifest.ShortDescription
-	if description == "" {
-		description = manifest.Description
-		if description == "" {
-			description = "(no description)"
-		}
-	}
 	serverDetail := obottypes.RegistryServerDetail{
 		Name:        registryName,
-		Description: description,
+		Description: manifest.ShortDescription,
 		Title:       displayName,
 		Version:     "latest",
 		Schema:      "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",


### PR DESCRIPTION
Requested by Craig.

for https://github.com/obot-platform/obot/issues/6993

Falling back to the full description could lead to some really ugly table output in `obot mcp search` so we're just gonna always return the ShortDescription, even if it is unset.