### PR TITLE
chore: clean up image builds

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -20,7 +20,7 @@ on:
       - .github/workflows/**
 
 jobs:
-  oss-build:
+  build:
     runs-on: depot-ubuntu-22.04
 
     steps:
@@ -52,7 +52,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push OSS Docker image
+      - name: Build and push Docker images
         uses: depot/build-push-action@v1
         id: build-and-push
         with:
@@ -63,6 +63,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}-enterprise:${{ github.ref_name }}
             ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') && format('docker.io/obot/{0}:{1}', github.event.repository.name, github.ref_name) || '' }}
           build-args: |
             BASE_IMAGE=ghcr.io/obot-platform/obot/base:latest
@@ -77,7 +78,10 @@ jobs:
       - name: Sign Images
         env:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
-          TAGS: ghcr.io/${{ github.repository }}:${{ github.ref_name }} ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') && format('docker.io/obot/{0}:{1}', github.event.repository.name, github.ref_name) || '' }}
+          TAGS: >-
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}-enterprise:${{ github.ref_name }}
+            ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') && format('docker.io/obot/{0}:{1}', github.event.repository.name, github.ref_name) || '' }}
         run: |
           images=""
           for tag in ${TAGS}; do
@@ -88,15 +92,16 @@ jobs:
       - name: Setup crane
         uses: imjasonh/setup-crane@v0.5
 
-      - name: Copy OSS image to latest tag
+      - name: Copy images to latest tag
         if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
         run: |
           crane tag ghcr.io/${{ github.repository }}:${{ github.ref_name }} latest
+          crane tag ghcr.io/${{ github.repository }}-enterprise:${{ github.ref_name }} latest
           crane tag docker.io/obot/${{ github.event.repository.name }}:${{ github.ref_name }} latest
 
-  oss-image-scan:
+  image-scan:
     runs-on: depot-ubuntu-22.04
-    needs: oss-build
+    needs: build
 
     steps:
       - name: Checkout code
@@ -116,103 +121,6 @@ jobs:
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-          skip-dirs: "**/venv"
-          format: "sarif"
-          output: "trivy-results.sarif"
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-results.sarif
-
-  enterprise-build:
-    runs-on: depot-ubuntu-22.04
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: ${{ case(github.ref_type == 'tag', 1, 0) }}
-
-      - name: Setup Depot
-        uses: depot/setup-action@v1
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
-
-      - name: Log in to Docker Hub
-        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push Enterprise Docker image
-        uses: depot/build-push-action@v1
-        id: build-and-push
-        with:
-          project: bbqjs4tj1g
-          context: .
-          push: true
-          pull: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ghcr.io/${{ github.repository }}-enterprise:${{ github.ref_name }}
-          build-args: |
-            BASE_IMAGE=ghcr.io/obot-platform/obot/base:latest
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.8.1
-        with:
-          cosign-release: "v2.4.3"
-      - name: Check install!
-        run: cosign version
-
-      - name: Sign Images
-        env:
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-          TAGS: ghcr.io/${{ github.repository }}-enterprise:${{ github.ref_name }}
-        run: |
-          images=""
-          for tag in ${TAGS}; do
-            images+="${tag}@${DIGEST} "
-          done
-          cosign sign --yes ${images}
-
-      - name: Setup crane
-        uses: imjasonh/setup-crane@v0.5
-
-      - name: Copy Enterprise image to latest tag
-        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-        run: |
-          crane tag ghcr.io/${{ github.repository }}-enterprise:${{ github.ref_name }} latest
-
-  enterprise-image-scan:
-    runs-on: depot-ubuntu-22.04
-    needs: enterprise-build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Depot
-        uses: depot/setup-action@v1
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
-
-      - name: Run Trivy
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
-        with:
-          image-ref: ghcr.io/${{ github.repository }}-enterprise:${{ github.ref_name }}
           skip-dirs: "**/venv"
           format: "sarif"
           output: "trivy-results.sarif"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PROVIDERS_IMAGE=ghcr.io/obot-platform/providers:latest
+ARG ENTERPRISE_PROVIDERS_IMAGE=ghcr.io/obot-platform/enterprise-providers:latest
 ARG ENCRYPTION_BINS_IMAGE=ghcr.io/obot-platform/providers/encryption-bins:latest
-ARG ENTERPRISE_IMAGE=ghcr.io/obot-platform/enterprise-providers:latest
 ARG BASE_IMAGE=cgr.dev/chainguard/wolfi-base
 
 FROM ${BASE_IMAGE} AS base
@@ -32,34 +32,12 @@ RUN apk add --no-cache postgresql-17 postgresql-17-oci-entrypoint postgresql-17-
 
 ENTRYPOINT [ "/usr/bin/docker-entrypoint.sh", "postgres" ]
 
-FROM final-base AS build-pgvector
-RUN apk add --no-cache build-base git postgresql-17-dev clang-19
-RUN git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git && \
-  cd pgvector && \
-  make clean && \
-  make OPTFLAGS="" && \
-  PG_MAJOR=17 make install && \
-  cd .. && \
-  rm -rf pgvector
-
 FROM ${PROVIDERS_IMAGE} AS providers
+FROM ${ENTERPRISE_PROVIDERS_IMAGE} AS enterprise-providers
 FROM ${ENCRYPTION_BINS_IMAGE} AS encryption-bins
-FROM ${ENTERPRISE_IMAGE} AS enterprise-providers
-RUN mkdir -p /obot-providers
 
 FROM final-base AS final
-ENV POSTGRES_USER=obot
-ENV POSTGRES_PASSWORD=obot
-ENV POSTGRES_DB=obot
-ENV PGDATA=/data/postgresql
-
-COPY --from=build-pgvector /usr/lib/postgresql17/vector.so /usr/lib/postgresql17/
-COPY --from=build-pgvector /usr/share/postgresql17/extension/vector* /usr/share/postgresql17/extension/
-
-RUN apk add --no-cache git npm nodejs bash tini procps libreoffice perl-utils sqlite sqlite-dev curl kubectl jq
-
-ENV OBOT_SERVER_DEFAULT_MCPCATALOG_PATH=https://github.com/obot-platform/mcp-catalog
-ENV OBOT_SERVER_DEFAULT_SYSTEM_MCPCATALOG_PATH=https://github.com/obot-platform/system-mcp-catalog
+RUN apk add --no-cache bash tini procps curl kubectl jq
 
 COPY aws-encryption.yaml /
 COPY azure-encryption.yaml /
@@ -73,14 +51,20 @@ COPY --chmod=0755 /tools/combine-envrc.sh /
 RUN /combine-envrc.sh && rm /combine-envrc.sh
 COPY --from=encryption-bins /bin/*-encryption-provider /bin/
 COPY --from=bin /app/bin/obot /bin/
-COPY --from=bin --link /app/ui/user/build-node /ui
 
-ENV PATH=$PATH:/usr/lib/libreoffice/program
-ENV PATH=$PATH:/usr/bin
+ENV OBOT_SERVER_DEFAULT_MCPCATALOG_PATH=https://github.com/obot-platform/mcp-catalog
+ENV OBOT_SERVER_DEFAULT_SYSTEM_MCPCATALOG_PATH=https://github.com/obot-platform/system-mcp-catalog
+ENV OBOT_CONTAINER_ENV=true
+
+ENV POSTGRES_USER=obot
+ENV POSTGRES_PASSWORD=obot
+ENV POSTGRES_DB=obot
+ENV PGDATA=/data/postgresql
+
 ENV HOME=/data
 ENV XDG_CACHE_HOME=/data/cache
 ENV TERM=vt100
-ENV OBOT_CONTAINER_ENV=true
+
 WORKDIR /data
 VOLUME /data
 ENTRYPOINT ["run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ WORKDIR /app
 COPY . .
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
   --mount=type=cache,target=/root/.cache/go-build \
-  --mount=type=cache,target=/root/.cache/uv \
   --mount=type=cache,target=/root/go/pkg/mod \
   make all
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 default: build
 
 # All target
-all: ui
+all: ui-user
 	$(MAKE) build
 
 ui: ui-user ui-user-node

--- a/run.sh
+++ b/run.sh
@@ -23,10 +23,11 @@ if [ -z "$OBOT_SERVER_DSN" ]; then
 
   # Start PostgreSQL in the background
   echo "Starting PostgreSQL server..."
+
   /usr/bin/docker-entrypoint.sh postgres &
 
   check_postgres_active
-  export OBOT_SERVER_DSN="postgresql://obot:obot@localhost:5432/obot"
+  export OBOT_SERVER_DSN="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}"
 fi
 
 exec tini -- obot server

--- a/tools/combine-envrc.sh
+++ b/tools/combine-envrc.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
 set -e
-# Combine .envrc files from providers, enterprise-providers, and encryption-bins
-PROVIDERS_DIR=/obot-providers
-ENV_FILES=$(ls "$PROVIDERS_DIR"/.envrc.* 2>/dev/null)
 
+# Combine .envrc files from providers, enterprise-providers, and encryption-bins
 server_versions=""
 provider_registries=""
 
-for file in ${ENV_FILES[@]}; do
+shopt -s failglob
+for file in /obot-providers/.envrc.*; do
   eval "$(grep '^export ' "$file" | sed 's/^export //')"
 
   if [[ -n "$OBOT_SERVER_PROVIDER_REGISTRIES" ]]; then
@@ -20,12 +19,9 @@ for file in ${ENV_FILES[@]}; do
   fi
 done
 
-OBOT_SERVER_VERSIONS="${server_versions%,}"
-OBOT_SERVER_PROVIDER_REGISTRIES="${provider_registries%,}"
-
 cat <<EOF >/obot-providers/.envrc.providers
-export OBOT_SERVER_PROVIDER_REGISTRIES="${OBOT_SERVER_PROVIDER_REGISTRIES}"
-export OBOT_SERVER_VERSIONS="${OBOT_SERVER_VERSIONS}"
+export OBOT_SERVER_PROVIDER_REGISTRIES="${provider_registries%,}"
+export OBOT_SERVER_VERSIONS="${server_versions%,}"
 EOF
 
 rm -f /obot-providers/.envrc.providers.*

--- a/tools/dev.sh
+++ b/tools/dev.sh
@@ -64,15 +64,15 @@ cleanup() {
 
   # Kill monitoring process groups
   [[ -n "$server_ready_pid" ]] && kill "${kill_signal}" "-${server_ready_pid}" 2>/dev/null || true
-  [[ -n "$user_ui_ready_pid" ]] && kill "${kill_signal}" "-${user_ui_ready_pid}" 2>/dev/null || true
+  [[ -n "$ui_ready_pid" ]] && kill "${kill_signal}" "-${ui_ready_pid}" 2>/dev/null || true
 
   # Kill service process groups
   [[ -n "$server_pid" ]] && kill "${kill_signal}" "-${server_pid}" 2>/dev/null || true
-  [[ -n "$user_ui_pid" ]] && kill "${kill_signal}" "-${user_ui_pid}" 2>/dev/null || true
+  [[ -n "$ui_pid" ]] && kill "${kill_signal}" "-${ui_pid}" 2>/dev/null || true
 
   if [[ "$cleanup_count" -lt 2 ]]; then
-    print_section_header 196 "Waiting for services to exit (PIDs: ${server_pid}, ${user_ui_pid})..."
-    while kill -0 "${server_pid}" 2>/dev/null || kill -0 "${user_ui_pid}" 2>/dev/null; do
+    print_section_header 196 "Waiting for services to exit (PIDs: ${server_pid}, ${ui_pid})..."
+    while kill -0 "${server_pid}" 2>/dev/null || kill -0 "${ui_pid}" 2>/dev/null; do
       sleep 0.5
     done
 
@@ -114,14 +114,14 @@ server_ready_pid=$!
   cd ui/user
 
   pnpm i 2>&1 | while IFS= read -r line; do
-    print_with_color 217 "[user-ui](install)" " $line"
+    print_with_color 217 "[user](install)" " $line"
   done
 
   pnpm run dev --port 5174 2>&1 | while IFS= read -r line; do
-    print_with_color 217 "[user-ui]" " $line"
+    print_with_color 217 "[user]" " $line"
   done
 ) &
-user_ui_pid=$!
+ui_pid=$!
 
 (
   for _ in {1..60}; do # ~1 minute timeout
@@ -134,14 +134,14 @@ user_ui_pid=$!
 
   print_section_header 196 "Timeout waiting for user UI to start"
 ) &
-user_ui_ready_pid=$!
+ui_ready_pid=$!
 
 # Wait for all services to be ready
-wait "${server_ready_pid}" "${user_ui_ready_pid}"
+wait "${server_ready_pid}" "${ui_ready_pid}"
 
 # Services ready, open browser tabs if requested
 print_section_header 120 "All components ready!"
 open_browser_tabs http://localhost:8080/
 
 # Wait for services to exit
-wait "${server_pid}" "${user_ui_pid}"
+wait "${server_pid}" "${ui_pid}"


### PR DESCRIPTION
## Summary

Cleans up the Docker image build by removing legacy dependencies and
consolidating the duplicated OSS/Enterprise build pipeline into a single job.

## Changes

### Dockerfile cleanup
- Drop the `build-pgvector` stage and the pgvector extension install
- Remove unused runtime packages: `git`, `npm`,
  `nodejs`, `sqlite`, `sqlite-dev`, `libreoffice`, `perl-utils`
- Stop copying the Node build of the UI (`ui/user/build-node`)
- Reorganize docker instructions for clarity

### Workflow consolidation
- The `obot-enterprise` image is now identical to the OSS `obot` image, so
  its separate `enterprise-build`/`enterprise-image-scan` jobs are removed
- The single `build` job now also publishes/signs the `-enterprise` tag for
  backwards compatibility, and tags it `latest` on releases
- Rename `oss-build` → `build` and `oss-image-scan` → `image-scan`

Addresses https://github.com/obot-platform/obot/issues/6997