### PR TITLE
fix: OBOT_SERVER_DISALLOW_PRIVATE_IP_MCP reference

### DIFF
--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -29,7 +29,7 @@ type Options struct {
 	MCPNamespace                      string   `usage:"The namespace to use for MCP containers" default:"obot-mcp"`
 	MCPClusterDomain                  string   `usage:"The cluster domain to use for MCP containers" default:"cluster.local"`
 	DisallowLocalhostMCP              bool     `usage:"Disallow MCP containers from connecting to localhost" default:"true"`
-	DisallowPrivateIPMCP              bool     `usage:"Disallow MCP containers from connecting to private IPs" default:"true"`
+	DisallowPrivateIPMCP              bool     `usage:"Disallow MCP containers from connecting to private IPs" default:"true" env:"OBOT_SERVER_DISALLOW_PRIVATE_IP_MCP"`
 	DisallowLinkLocalMCP              bool     `usage:"Disallow MCP containers from connecting to link-local addresses" default:"true"`
 	MCPRuntimeBackend                 string   `usage:"The runtime backend to use for running MCP servers: docker, kubernetes, or k8s. Defaults to docker" default:"docker"`
 	MCPImagePullSecrets               []string `usage:"The name of the image pull secret to use for pulling MCP images"`


### PR DESCRIPTION
## Problem
The `OBOT_SERVER_DISALLOW_PRIVATE_IP_MCP` env var documented in the chart and docs had no effect. The cmd framework derives env var names with a regex that only splits lower→Upper boundaries, so `DisallowPrivateIPMCP` collapsed the IP/MCP acronym adjacency into `OBOT_SERVER_DISALLOW_PRIVATE_IPMCP` (no underscore).

## Fix
Added an explicit `env:"OBOT_SERVER_DISALLOW_PRIVATE_IP_MCP"` tag to the field so the documented name is honored.