### PR TITLE
fix: forward passthrough headers to composite MCP children

### DIFF
--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -222,10 +222,26 @@ func urlWithPath(urlStr, path string) string {
 	return u.String()
 }
 
-func constructMCPServerNanobotYAMLForComposite(servers []ComponentServer) ([]byte, error) {
+func constructMCPServerNanobotYAMLForComposite(servers []ComponentServer, passthroughHeaderNames []string) ([]byte, error) {
 	mcpServers := make(map[string]nanobotConfigMCPServer, len(servers))
 	names := make([]string, 0, len(servers))
 	replacer := strings.NewReplacer("/", "-", ":", "-", "?", "-")
+
+	// #6845: composite children are always internal Obot /mcp-connect endpoints
+	// that resolve the caller's per-user credentials, so the caller's auth must
+	// reach them. Forward the operator-configured passthrough headers plus
+	// Authorization (required for the child endpoint to identify the user).
+	childPassthrough := append([]string(nil), passthroughHeaderNames...)
+	hasAuth := false
+	for _, h := range childPassthrough {
+		if strings.EqualFold(h, "Authorization") {
+			hasAuth = true
+			break
+		}
+	}
+	if !hasAuth {
+		childPassthrough = append(childPassthrough, "Authorization")
+	}
 
 	for _, component := range servers {
 		tools := make(map[string]toolOverride, len(component.Tools))
@@ -241,9 +257,10 @@ func constructMCPServerNanobotYAMLForComposite(servers []ComponentServer) ([]byt
 
 		name := replacer.Replace(component.Name)
 		mcpServers[name] = nanobotConfigMCPServer{
-			BaseURL:       component.URL,
-			ToolOverrides: tools,
-			ToolPrefix:    component.ToolPrefix,
+			BaseURL:            component.URL,
+			ToolOverrides:      tools,
+			ToolPrefix:         component.ToolPrefix,
+			PassthroughHeaders: childPassthrough,
 		}
 
 		names = append(names, name)

--- a/pkg/mcp/backend_test.go
+++ b/pkg/mcp/backend_test.go
@@ -4,11 +4,78 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/oasdiff/yaml"
 	"github.com/obot-platform/obot/apiclient/types"
 )
+
+func containsFold(s []string, v string) bool {
+	for _, x := range s {
+		if strings.EqualFold(x, v) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCompositeNanobotYAMLForwardsAuthHeaders covers #6845: the composite
+// nanobot config must forward the caller's auth to each child. Children are
+// always internal Obot /mcp-connect endpoints, so Authorization is always
+// included, plus any operator-configured passthrough header names — without
+// duplicating Authorization if it was already configured.
+func TestCompositeNanobotYAMLForwardsAuthHeaders(t *testing.T) {
+	components := []ComponentServer{
+		{Name: "child-a", URL: "http://obot/mcp-connect/child-a"},
+		{Name: "child-b", URL: "http://obot/mcp-connect/child-b", ToolPrefix: "bq_"},
+	}
+
+	cases := []struct {
+		name         string
+		passthrough  []string
+		wantContains []string
+	}{
+		{name: "default adds Authorization", passthrough: nil, wantContains: []string{"Authorization"}},
+		{name: "configured names plus Authorization", passthrough: []string{"X-Tenant"}, wantContains: []string{"X-Tenant", "Authorization"}},
+		{name: "no duplicate Authorization", passthrough: []string{"authorization"}, wantContains: []string{"authorization"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := constructMCPServerNanobotYAMLForComposite(components, tc.passthrough)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var cfg nanobotConfig
+			if err := yaml.Unmarshal(data, &cfg); err != nil {
+				t.Fatalf("failed to unmarshal composite config: %v", err)
+			}
+			if len(cfg.MCPServers) != len(components) {
+				t.Fatalf("expected %d child servers, got %d", len(components), len(cfg.MCPServers))
+			}
+
+			for name, child := range cfg.MCPServers {
+				for _, want := range tc.wantContains {
+					if !containsFold(child.PassthroughHeaders, want) {
+						t.Fatalf("child %q passthrough %v missing %q", name, child.PassthroughHeaders, want)
+					}
+				}
+				authCount := 0
+				for _, h := range child.PassthroughHeaders {
+					if strings.EqualFold(h, "Authorization") {
+						authCount++
+					}
+				}
+				if authCount != 1 {
+					t.Fatalf("child %q expected exactly one Authorization, got %v", name, child.PassthroughHeaders)
+				}
+			}
+		})
+	}
+}
 
 func TestEnsureServerReadyUsesHealthzPath(t *testing.T) {
 	var healthzCalls, mcpCalls int

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -1533,7 +1533,7 @@ func (d *dockerBackend) prepareMCPServerNanobotConfig(ctx context.Context, serve
 		err         error
 	)
 	if server.Runtime == otypes.RuntimeComposite {
-		nanobotYAML, err = constructMCPServerNanobotYAMLForComposite(server.Components)
+		nanobotYAML, err = constructMCPServerNanobotYAMLForComposite(server.Components, server.PassthroughHeaderNames)
 	} else {
 		nanobotYAML, err = constructMCPServerNanobotYAML(server.MCPServerDisplayName, server.URL, server.Command, server.Args, server.PassthroughHeaderNames, allEnvVars, headers, webhooks)
 	}

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -831,7 +831,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 		// to the underlying MCP server) and mount it into the last container in the deployment.
 		var nanobotFileString []byte
 		if server.Runtime == types.RuntimeComposite {
-			nanobotFileString, err = constructMCPServerNanobotYAMLForComposite(server.Components)
+			nanobotFileString, err = constructMCPServerNanobotYAMLForComposite(server.Components, server.PassthroughHeaderNames)
 			annotations["nanobot-composite-file-rev"] = utils.Digest(nanobotFileString)
 		} else {
 			nanobotFileString, err = constructMCPServerNanobotYAML(server.MCPServerDisplayName, server.URL, server.Command, server.Args, server.PassthroughHeaderNames, secretEnvData, headerData, webhooks)


### PR DESCRIPTION
## What

`constructMCPServerNanobotYAMLForComposite` now threads the composite server's
configured `PassthroughHeaderNames` to each child, and always includes
`Authorization` (deduped, case-insensitive). The two call sites (`docker.go`,
`kubernetes.go`) pass `server.PassthroughHeaderNames`.

```go
func constructMCPServerNanobotYAMLForComposite(servers []ComponentServer, passthroughHeaderNames []string) ([]byte, error)
```

## Why

Composite MCP servers did not propagate per-request auth to their child servers:
the composite branch only set `BaseURL`/`ToolOverrides`/`ToolPrefix` per child,
while the non-composite path already forwards `PassthroughHeaderNames`. As a
result the child never received the inbound bearer and downstream calls failed
with "access token missing".

Composite children are internal Obot `/mcp-connect` endpoints that resolve the
caller's per-user credentials, so forwarding `Authorization` only ever crosses
an Obot→Obot hop and lets each child authenticate as the calling user. This
makes the composite path consistent with the non-composite one.

Fixes #6845

## Tests

`TestCompositeNanobotYAMLForwardsAuthHeaders` (table-driven):
- default adds `Authorization`
- operator-configured names are forwarded plus `Authorization`
- `Authorization` is not duplicated when already configured

`make validate` (gofmt, `go vet`, `go test ./...`) passes.
