### PR TITLE
fix: emit WWW-Authenticate on /mcp-connect 401 (RFC 9728)

### DIFF
--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -45,6 +45,14 @@ func (h *Handler) Proxy(req api.Context) error {
 		return nil
 	}
 
+	// RFC 9728 §5.1: if the upstream MCP server replies 401 without pointing the
+	// client at its protected-resource metadata, advertise the path-aware
+	// metadata URL for this connect endpoint. Without this, clients that don't
+	// already know the path fall back to the host-root metadata document, which
+	// cannot identify this specific MCP server.
+	mcpID := req.PathValue("mcp_id")
+	connectBaseURL := strings.TrimSuffix(req.APIBaseURL, "/api")
+
 	(&httputil.ReverseProxy{
 		Transport: h.transport,
 		Director: func(r *http.Request) {
@@ -83,6 +91,12 @@ func (h *Handler) Proxy(req api.Context) error {
 					r.Header.Set(serverConfig.PassthroughHeaderNames[i], serverConfig.PassthroughHeaderValues[i])
 				}
 			}
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			if resp.StatusCode == http.StatusUnauthorized && mcpID != "" && resp.Header.Get("WWW-Authenticate") == "" {
+				resp.Header.Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s/.well-known/oauth-protected-resource/mcp-connect/%s"`, connectBaseURL, mcpID))
+			}
+			return nil
 		},
 	}).ServeHTTP(req.ResponseWriter, req.Request)
 

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -201,6 +201,14 @@ func (s *Server) Wrap(f api.HandlerFunc) http.HandlerFunc {
 				// Only set WWW-Authenticate if not in no-auth mode
 				if strings.HasPrefix(req.URL.Path, "/v0.1") && !s.registryNoAuth {
 					rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="MCP Registry", resource_metadata="%s/.well-known/oauth-protected-resource/v0.1/servers"`, strings.TrimSuffix(s.baseURL, "/api")))
+				} else if id, ok := strings.CutPrefix(req.URL.Path, "/mcp-connect/"); ok {
+					// RFC 9728 §5.1: point MCP clients at the path-aware protected-
+					// resource metadata for this specific connect endpoint, so they
+					// don't fall back to the host-root metadata document (which can't
+					// identify which MCP server is being connected).
+					if id, _, _ = strings.Cut(id, "/"); id != "" {
+						rw.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s/.well-known/oauth-protected-resource/mcp-connect/%s"`, strings.TrimSuffix(s.baseURL, "/api"), id))
+					}
 				}
 
 				if authenticated {


### PR DESCRIPTION
## What

Return a `WWW-Authenticate` header on `401` responses for `/mcp-connect/{id}`
endpoints, pointing at the path-aware protected-resource metadata for that
specific server:

```
WWW-Authenticate: Bearer resource_metadata="<base>/.well-known/oauth-protected-resource/mcp-connect/{id}"
```

Two places:
- `server.go` (auth middleware): set it when an unauthenticated request to
  `/mcp-connect/{id}` is rejected — mirrors the existing `/v0.1` registry branch.
- `mcpgateway/handler.go` (proxy `ModifyResponse`): add it to a proxied `401`
  from the upstream MCP server when the upstream didn't already send one.

## Why

RFC 9728 §5.1 says a protected resource SHOULD return `WWW-Authenticate` with a
`resource_metadata` pointer on `401`. Obot's `/mcp-connect/{id}` endpoints did
not, so a client that isn't already path-aware falls back to requesting the
host-root metadata (`/.well-known/oauth-protected-resource`). That document
can't identify a specific server, so discovery resolves the wrong resource and
the OAuth flow fails (observed as `invalid_request: catalog entry /mcp-connect
not found`, because the client sends a resource with no server id).

With the pointer present, any client — path-aware or not — follows it to the
correct path-scoped metadata. This affects every `/mcp-connect` server, not just
composites.

## Tests

`make validate` (gofmt, `go vet`, `go test ./...`) passes. Verified manually:
the 401 now carries the path-aware `resource_metadata`, and a client that
previously failed discovery now completes the OAuth flow.
