### PR TITLE
feat: add ability to configure MCP server on first connect

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -587,6 +587,7 @@ func MapCatalogEntryToServer(catalogEntry MCPServerCatalogEntryManifest, userURL
 			remoteConfig.URL = userURL
 		case catalogEntry.RemoteConfig.URLTemplate != "":
 			remoteConfig.IsTemplate = true
+			remoteConfig.URLTemplate = catalogEntry.RemoteConfig.URLTemplate
 		default:
 			return serverManifest, RuntimeValidationError{
 				Runtime: RuntimeRemote,

--- a/apiclient/types/mcpserver_test.go
+++ b/apiclient/types/mcpserver_test.go
@@ -289,6 +289,39 @@ func TestMapCatalogEntryToServer_RemoteHostname(t *testing.T) {
 	}
 }
 
+func TestMapCatalogEntryToServer_RemoteURLTemplate(t *testing.T) {
+	const template = "https://${WORKSPACE}.example.com/mcp/${SPACE_ID}"
+	catalogEntry := MCPServerCatalogEntryManifest{
+		Name:        "Test Remote Server",
+		Description: "Test remote server description",
+		Runtime:     RuntimeRemote,
+		RemoteConfig: &RemoteCatalogConfig{
+			URLTemplate: template,
+		},
+	}
+
+	result, err := MapCatalogEntryToServer(catalogEntry, "", false)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if result.RemoteConfig == nil {
+		t.Fatal("Expected RemoteConfig to be populated")
+	}
+
+	if !result.RemoteConfig.IsTemplate {
+		t.Fatal("Expected remote config to be marked as template")
+	}
+
+	if result.RemoteConfig.URLTemplate != template {
+		t.Errorf("Expected URL template %q, got %q", template, result.RemoteConfig.URLTemplate)
+	}
+
+	if result.RemoteConfig.URL != "" {
+		t.Errorf("Expected URL to remain empty until configured, got %q", result.RemoteConfig.URL)
+	}
+}
+
 func TestMapCatalogEntryToServer_RemoteHostnameMismatch(t *testing.T) {
 	catalogEntry := MCPServerCatalogEntryManifest{
 		Name:        "Test Remote Server",

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -36,7 +36,10 @@ import (
 
 var envVarRegex = regexp.MustCompile(`\${([^}]+)}`)
 
-const requestTimeUpdateInterval = 15 * time.Minute
+const (
+	requestTimeUpdateInterval = 15 * time.Minute
+	configURLKey              = "__url"
+)
 
 // MCPOAuthChecker will check the OAuth status for an MCP server. This interface breaks an import cycle.
 type MCPOAuthChecker interface {
@@ -579,7 +582,7 @@ func (m *MCPHandler) LaunchServer(req api.Context) error {
 				continue
 			}
 
-			config, err := serverConfigForAction(req, component)
+			config, _, err := serverConfigForAction(req, component, false)
 			if err != nil {
 				return fmt.Errorf("failed to get config for component server %s: %w", component.Name, err)
 			}
@@ -931,15 +934,6 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 				return v1.MCPServer{}, v1.MCPServerInstance{}, err
 			}
 			if len(instances.Items) == 0 {
-				// Check that the multi-user server doesn't have any required configuration.
-				if server.Spec.Manifest.MultiUserConfig != nil {
-					for _, header := range server.Spec.Manifest.MultiUserConfig.UserDefinedHeaders {
-						if header.Required {
-							return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("user has not configured an instance for the multi-user MCP server %s", id)
-						}
-					}
-				}
-
 				// If none exist, then create one for the user.
 				instance := v1.MCPServerInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -947,9 +941,12 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 						Namespace:    server.Namespace,
 					},
 					Spec: v1.MCPServerInstanceSpec{
-						MCPServerName:  id,
-						MCPCatalogName: server.Spec.MCPCatalogID,
-						UserID:         req.User.GetUID(),
+						MCPServerName:             id,
+						MCPCatalogName:            server.Spec.MCPCatalogID,
+						MCPServerCatalogEntryName: server.Spec.MCPServerCatalogEntryName,
+						PowerUserWorkspaceID:      server.Spec.PowerUserWorkspaceID,
+						UserID:                    req.User.GetUID(),
+						MultiUserConfig:           server.Spec.Manifest.MultiUserConfig,
 					},
 				}
 				if err := req.Create(&instance); err != nil {
@@ -974,6 +971,7 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 		if err := req.Get(&entry, id); err != nil {
 			return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("catalog entry %s not found", id)
 		}
+		addExtractedEnvVarsToCatalogEntry(&entry)
 
 		// List the MCP servers for the user and take the first one.
 		var servers v1.MCPServerList
@@ -988,8 +986,7 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 			return v1.MCPServer{}, v1.MCPServerInstance{}, err
 		}
 		if len(servers.Items) == 0 {
-			// If the user has not configured an MCP server for the catalog entry, and the catalog
-			// entry can be launched without further configuration, then create a server for the user.
+			// If the user has not configured an MCP server for the catalog entry, create a server for the user.
 			missingAdminConfig, err := entryMissingAdminConfig(req.Context(), req.LocalK8sClient, req.ObotNamespace, entry)
 			if err != nil {
 				return v1.MCPServer{}, v1.MCPServerInstance{}, fmt.Errorf("failed to determine required admin configuration for catalog entry %s: %w", id, err)
@@ -998,16 +995,9 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 				return v1.MCPServer{}, v1.MCPServerInstance{}, err
 			}
 
-			needsConfig, err := entryNeedsUserConfig(req.Context(), req.LocalK8sClient, req.ObotNamespace, entry)
-			if err != nil {
-				return v1.MCPServer{}, v1.MCPServerInstance{}, fmt.Errorf("failed to determine required configuration for catalog entry %s: %w", id, err)
-			}
-			if needsConfig {
-				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrNotFound("catalog entry %s requires user configuration before it can be connected", id)
-			}
-
 			// Convert the catalog entry manifest to a server manifest. Treat the user as non-admin always.
-			manifest, err := serverManifestFromCatalogEntryManifest(false, false, entry.Spec.Manifest, types.MCPServerManifest{})
+			allowMissingURL := catalogEntryRequiresUserURL(entry.Spec.Manifest)
+			manifest, err := serverManifestFromCatalogEntryManifest(false, allowMissingURL, entry.Spec.Manifest, types.MCPServerManifest{})
 			if err != nil {
 				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrBadRequest("catalog entry %s cannot be connected because it could not be converted to an MCP server: %v", id, err)
 			}
@@ -1023,6 +1013,7 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 					UnsupportedTools:          entry.Spec.UnsupportedTools,
 					MCPServerCatalogEntryName: id,
 					UserID:                    req.User.GetUID(),
+					NeedsURL:                  allowMissingURL && (manifest.RemoteConfig == nil || manifest.RemoteConfig.URL == ""),
 				},
 			}
 			if err := req.Create(&server); err != nil {
@@ -1049,7 +1040,14 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id string) (v1.MCPServer
 			return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
 		})
 
-		return servers.Items[0], v1.MCPServerInstance{}, nil
+		server := servers.Items[0]
+		if syncConnectServerRemoteConfigFromCatalogEntry(&server, entry) {
+			if err := req.Update(&server); err != nil {
+				return v1.MCPServer{}, v1.MCPServerInstance{}, fmt.Errorf("failed to update MCP server configuration from catalog entry %s: %w", id, err)
+			}
+		}
+
+		return server, v1.MCPServerInstance{}, nil
 	}
 }
 
@@ -1232,6 +1230,68 @@ func entryNeedsUserConfig(ctx context.Context, client kclient.Client, obotNamesp
 	return false, nil
 }
 
+func catalogEntryRequiresUserURL(manifest types.MCPServerCatalogEntryManifest) bool {
+	if manifest.Runtime == types.RuntimeRemote &&
+		manifest.RemoteConfig != nil &&
+		(manifest.RemoteConfig.Hostname != "" || manifest.RemoteConfig.URLTemplate != "") {
+		return true
+	}
+	if manifest.Runtime != types.RuntimeComposite || manifest.CompositeConfig == nil {
+		return false
+	}
+	for _, component := range manifest.CompositeConfig.ComponentServers {
+		if component.MCPServerID != "" {
+			continue
+		}
+		if catalogEntryRequiresUserURL(component.Manifest) {
+			return true
+		}
+	}
+	return false
+}
+
+func syncConnectServerRemoteConfigFromCatalogEntry(server *v1.MCPServer, entry v1.MCPServerCatalogEntry) bool {
+	if server.Spec.Manifest.Runtime != types.RuntimeRemote || entry.Spec.Manifest.Runtime != types.RuntimeRemote || entry.Spec.Manifest.RemoteConfig == nil {
+		return false
+	}
+
+	before := utils.Digest(server.Spec)
+	entryRemote := entry.Spec.Manifest.RemoteConfig
+	if server.Spec.Manifest.RemoteConfig == nil {
+		server.Spec.Manifest.RemoteConfig = new(types.RemoteRuntimeConfig)
+	}
+	serverRemote := server.Spec.Manifest.RemoteConfig
+
+	serverRemote.Headers = entryRemote.Headers
+	serverRemote.StaticOAuthRequired = entryRemote.StaticOAuthRequired
+	switch {
+	case entryRemote.Hostname != "":
+		serverRemote.Hostname = entryRemote.Hostname
+		serverRemote.IsTemplate = false
+		serverRemote.URLTemplate = ""
+		if serverRemote.URL == "" {
+			server.Spec.NeedsURL = true
+		} else if err := types.ValidateURLHostname(serverRemote.URL, entryRemote.Hostname); err != nil {
+			server.Spec.NeedsURL = true
+			server.Spec.PreviousURL = serverRemote.URL
+			serverRemote.URL = ""
+		} else {
+			server.Spec.NeedsURL = false
+			server.Spec.PreviousURL = ""
+		}
+	case entryRemote.URLTemplate != "":
+		serverRemote.IsTemplate = true
+		serverRemote.URLTemplate = entryRemote.URLTemplate
+		serverRemote.Hostname = ""
+		server.Spec.NeedsURL = serverRemote.URL == ""
+		if !server.Spec.NeedsURL {
+			server.Spec.PreviousURL = ""
+		}
+	}
+
+	return before != utils.Digest(server.Spec)
+}
+
 // MCPIDAndAudienceFromConnectURL returns the MCP server or instance name and audience based on the provided connect URL.
 // The connect URL could have an MCP server ID, server instance ID, or MCP catalog entry ID.
 func MCPIDAndAudienceFromConnectURL(req api.Context, id string) (string, string, error) {
@@ -1251,31 +1311,43 @@ func MCPIDAndAudienceFromConnectURL(req api.Context, id string) (string, string,
 }
 
 func ServerForActionWithConnectID(req api.Context, id string) (string, v1.MCPServer, mcp.ServerConfig, error) {
+	id, server, config, _, err := serverForActionWithConnectID(req, id, false)
+	return id, server, config, err
+}
+
+func ServerForActionWithConnectIDAllowMissingConfig(req api.Context, id string) (string, v1.MCPServer, mcp.ServerConfig, []string, error) {
+	return serverForActionWithConnectID(req, id, true)
+}
+
+func serverForActionWithConnectID(req api.Context, id string, allowMissingConfig bool) (string, v1.MCPServer, mcp.ServerConfig, []string, error) {
 	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id)
 	if err != nil {
-		return "", v1.MCPServer{}, mcp.ServerConfig{}, err
+		return "", v1.MCPServer{}, mcp.ServerConfig{}, nil, err
 	}
 
 	switch {
 	case instance.Name != "":
-		server, config, err := serverFromMCPServerInstance(req, instance)
-		return instance.Name, server, config, err
+		server, config, missingConfig, err := serverFromMCPServerInstance(req, instance, allowMissingConfig)
+		return instance.Name, server, config, missingConfig, err
 	case server.Name != "":
-		config, err := serverConfigForAction(req, server)
-		return server.Name, server, config, err
+		config, missingConfig, err := serverConfigForAction(req, server, allowMissingConfig)
+		return server.Name, server, config, missingConfig, err
 	default:
-		return "", v1.MCPServer{}, mcp.ServerConfig{}, fmt.Errorf("unknown MCP server ID %s", id)
+		return "", v1.MCPServer{}, mcp.ServerConfig{}, nil, fmt.Errorf("unknown MCP server ID %s", id)
 	}
 }
 
-func serverFromMCPServerInstance(req api.Context, instance v1.MCPServerInstance) (v1.MCPServer, mcp.ServerConfig, error) {
+func serverFromMCPServerInstance(req api.Context, instance v1.MCPServerInstance, allowMissingConfig bool) (v1.MCPServer, mcp.ServerConfig, []string, error) {
 	var server v1.MCPServer
 	if err := req.Get(&server, instance.Spec.MCPServerName); err != nil {
-		return server, mcp.ServerConfig{}, err
+		return server, mcp.ServerConfig{}, nil, err
 	}
 
 	if server.Spec.NeedsURL {
-		return server, mcp.ServerConfig{}, fmt.Errorf("mcp server %s needs to update its URL", server.Name)
+		if allowMissingConfig {
+			return server, mcp.ServerConfig{}, []string{"URL"}, nil
+		}
+		return server, mcp.ServerConfig{}, nil, fmt.Errorf("mcp server %s needs to update its URL", server.Name)
 	}
 
 	addExtractedEnvVars(&server)
@@ -1294,7 +1366,7 @@ func serverFromMCPServerInstance(req api.Context, instance v1.MCPServerInstance)
 
 	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credCtx}, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
-		return server, mcp.ServerConfig{}, fmt.Errorf("failed to find credential: %w", err)
+		return server, mcp.ServerConfig{}, nil, fmt.Errorf("failed to find credential: %w", err)
 	}
 
 	catalogName := server.Spec.MCPCatalogID
@@ -1309,7 +1381,7 @@ func serverFromMCPServerInstance(req api.Context, instance v1.MCPServerInstance)
 	if server.Spec.MCPServerCatalogEntryName != "" {
 		var entry v1.MCPServerCatalogEntry
 		if err := req.Get(&entry, server.Spec.MCPServerCatalogEntryName); err != nil {
-			return server, mcp.ServerConfig{}, fmt.Errorf("failed to get MCP server catalog entry: %w", err)
+			return server, mcp.ServerConfig{}, nil, fmt.Errorf("failed to get MCP server catalog entry: %w", err)
 		}
 		if catalogName == "" {
 			catalogName = entry.Spec.MCPCatalogName
@@ -1321,23 +1393,23 @@ func serverFromMCPServerInstance(req api.Context, instance v1.MCPServerInstance)
 
 	tokenExchangeCred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.Name}, server.Name)
 	if err != nil {
-		return server, mcp.ServerConfig{}, fmt.Errorf("failed to find token exchange credential: %w", err)
+		return server, mcp.ServerConfig{}, nil, fmt.Errorf("failed to find token exchange credential: %w", err)
 	}
 
 	mergedEnv, err := mcp.MergeBoundCreds(req.Context(), req.LocalK8sClient, req.ObotNamespace, server.Spec.Manifest.Env, server.Spec.Manifest.RemoteConfig, cred.Secrets)
 	if err != nil {
-		return server, mcp.ServerConfig{}, fmt.Errorf("failed to resolve secret bindings: %w", err)
+		return server, mcp.ServerConfig{}, nil, fmt.Errorf("failed to resolve secret bindings: %w", err)
 	}
 
 	baseURL := strings.TrimSuffix(req.APIBaseURL, "/api")
 	serverConfig, missingConfig, err := mcp.ServerToServerConfig(server, instance.ValidConnectURLs(baseURL), baseURL, req.User.GetUID(), scope, catalogName, mergedEnv, tokenExchangeCred.Secrets)
 	if err != nil {
-		return server, mcp.ServerConfig{}, err
+		return server, mcp.ServerConfig{}, nil, err
 	}
 
 	instanceCredEnv, err := mcpServerInstanceCredEnv(req, instance)
 	if err != nil {
-		return server, mcp.ServerConfig{}, err
+		return server, mcp.ServerConfig{}, nil, err
 	}
 
 	var missingInstanceConfig []string
@@ -1345,7 +1417,10 @@ func serverFromMCPServerInstance(req api.Context, instance v1.MCPServerInstance)
 	missingConfig = append(missingConfig, missingInstanceConfig...)
 
 	if len(missingConfig) > 0 {
-		return server, mcp.ServerConfig{}, types.NewErrBadRequest("missing required config: %s", strings.Join(missingConfig, ", "))
+		if allowMissingConfig {
+			return server, serverConfig, missingConfig, nil
+		}
+		return server, mcp.ServerConfig{}, missingConfig, types.NewErrBadRequest("missing required config: %s", strings.Join(missingConfig, ", "))
 	}
 
 	// Best effort to update the last request time.
@@ -1357,7 +1432,7 @@ func serverFromMCPServerInstance(req api.Context, instance v1.MCPServerInstance)
 		}
 	}
 
-	return server, serverConfig, nil
+	return server, serverConfig, nil, nil
 }
 
 func ServerForAction(req api.Context, id string) (v1.MCPServer, mcp.ServerConfig, error) {
@@ -1366,7 +1441,7 @@ func ServerForAction(req api.Context, id string) (v1.MCPServer, mcp.ServerConfig
 		return server, mcp.ServerConfig{}, err
 	}
 
-	serverConfig, err := serverConfigForAction(req, server)
+	serverConfig, _, err := serverConfigForAction(req, server, false)
 	return server, serverConfig, err
 }
 
@@ -1374,9 +1449,12 @@ func ServerForAction(req api.Context, id string) (v1.MCPServer, mcp.ServerConfig
 // For composite servers, it uses the tokenService to create an ephemeral token and constructs
 // a remote MCP server config pointing to the gateway. For non-composite servers, it retrieves
 // credentials and builds the appropriate server configuration.
-func serverConfigForAction(req api.Context, server v1.MCPServer) (mcp.ServerConfig, error) {
+func serverConfigForAction(req api.Context, server v1.MCPServer, allowMissingConfig bool) (mcp.ServerConfig, []string, error) {
 	if server.Spec.NeedsURL {
-		return mcp.ServerConfig{}, types.NewErrBadRequest("mcp server %s needs to update its URL", server.Name)
+		if allowMissingConfig {
+			return mcp.ServerConfig{}, []string{"URL"}, nil
+		}
+		return mcp.ServerConfig{}, nil, types.NewErrBadRequest("mcp server %s needs to update its URL", server.Name)
 	}
 
 	var (
@@ -1399,12 +1477,12 @@ func serverConfigForAction(req api.Context, server v1.MCPServer) (mcp.ServerConf
 
 	cred, err := req.GatewayClient.RevealCredential(req.Context(), credCtxs, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
-		return mcp.ServerConfig{}, fmt.Errorf("failed to find credential: %w", err)
+		return mcp.ServerConfig{}, nil, fmt.Errorf("failed to find credential: %w", err)
 	}
 
 	mergedEnv, err := mcp.MergeBoundCreds(req.Context(), req.LocalK8sClient, req.ObotNamespace, server.Spec.Manifest.Env, server.Spec.Manifest.RemoteConfig, cred.Secrets)
 	if err != nil {
-		return mcp.ServerConfig{}, fmt.Errorf("failed to resolve secret bindings: %w", err)
+		return mcp.ServerConfig{}, nil, fmt.Errorf("failed to resolve secret bindings: %w", err)
 	}
 
 	catalogName := server.Spec.MCPCatalogID
@@ -1434,7 +1512,7 @@ func serverConfigForAction(req api.Context, server v1.MCPServer) (mcp.ServerConf
 				catalogName = system.DefaultCatalog
 			}
 		} else {
-			return mcp.ServerConfig{}, fmt.Errorf("failed to get MCP server catalog entry: %w", err)
+			return mcp.ServerConfig{}, nil, fmt.Errorf("failed to get MCP server catalog entry: %w", err)
 		}
 	}
 
@@ -1453,7 +1531,7 @@ func serverConfigForAction(req api.Context, server v1.MCPServer) (mcp.ServerConf
 		tokenExchangeCred, tokenCredErr = req.GatewayClient.RevealCredential(req.Context(), []string{server.Name}, server.Name)
 		return tokenCredErr
 	}); err != nil {
-		return mcp.ServerConfig{}, fmt.Errorf("failed to find token exchange credential: %w", tokenCredErr)
+		return mcp.ServerConfig{}, nil, fmt.Errorf("failed to find token exchange credential: %w", tokenCredErr)
 	}
 
 	baseURL := strings.TrimSuffix(req.APIBaseURL, "/api")
@@ -1467,7 +1545,7 @@ func serverConfigForAction(req api.Context, server v1.MCPServer) (mcp.ServerConf
 			kclient.InNamespace(server.Namespace),
 			kclient.MatchingFields{"spec.compositeName": server.Name},
 		); err != nil {
-			return mcp.ServerConfig{}, fmt.Errorf("failed to list component servers: %w", err)
+			return mcp.ServerConfig{}, nil, fmt.Errorf("failed to list component servers: %w", err)
 		}
 
 		var componentInstances v1.MCPServerInstanceList
@@ -1475,19 +1553,27 @@ func serverConfigForAction(req api.Context, server v1.MCPServer) (mcp.ServerConf
 			kclient.InNamespace(server.Namespace),
 			kclient.MatchingFields{"spec.compositeName": server.Name},
 		); err != nil {
-			return mcp.ServerConfig{}, fmt.Errorf("failed to list component servers instances: %w", err)
+			return mcp.ServerConfig{}, nil, fmt.Errorf("failed to list component servers instances: %w", err)
 		}
 
 		serverConfig, missingConfig, err = mcp.CompositeServerToServerConfig(server, componentServers.Items, componentInstances.Items, server.ValidConnectURLs(baseURL), baseURL, req.User.GetUID(), scope, catalogName, mergedEnv, tokenExchangeCred.Secrets)
+		componentMissingConfig, componentErr := compositeComponentsMissingConfig(req, componentServers.Items, componentInstances.Items)
+		if componentErr != nil {
+			return mcp.ServerConfig{}, nil, componentErr
+		}
+		missingConfig = append(missingConfig, componentMissingConfig...)
 	} else {
 		serverConfig, missingConfig, err = mcp.ServerToServerConfig(server, server.ValidConnectURLs(baseURL), baseURL, req.User.GetUID(), scope, catalogName, mergedEnv, tokenExchangeCred.Secrets)
 	}
 	if err != nil {
-		return mcp.ServerConfig{}, err
+		return mcp.ServerConfig{}, nil, err
 	}
 
 	if len(missingConfig) > 0 {
-		return mcp.ServerConfig{}, types.NewErrBadRequest("missing required config: %s", strings.Join(missingConfig, ", "))
+		if allowMissingConfig {
+			return serverConfig, missingConfig, nil
+		}
+		return mcp.ServerConfig{}, missingConfig, types.NewErrBadRequest("missing required config: %s", strings.Join(missingConfig, ", "))
 	}
 
 	// Best effort to update the last request time.
@@ -1499,7 +1585,32 @@ func serverConfigForAction(req api.Context, server v1.MCPServer) (mcp.ServerConf
 		}
 	}
 
-	return serverConfig, nil
+	return serverConfig, nil, nil
+}
+
+func compositeComponentsMissingConfig(req api.Context, componentServers []v1.MCPServer, componentInstances []v1.MCPServerInstance) ([]string, error) {
+	var missingConfig []string
+	for _, component := range componentServers {
+		_, componentMissingConfig, err := serverConfigForAction(req, component, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get config for component server %s: %w", component.Name, err)
+		}
+		for _, missing := range componentMissingConfig {
+			missingConfig = append(missingConfig, fmt.Sprintf("%s: %s", component.Spec.MCPServerCatalogEntryName, missing))
+		}
+	}
+
+	for _, instance := range componentInstances {
+		_, _, instanceMissingConfig, err := serverFromMCPServerInstance(req, instance, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get config for component server instance %s: %w", instance.Name, err)
+		}
+		for _, missing := range instanceMissingConfig {
+			missingConfig = append(missingConfig, fmt.Sprintf("%s: %s", instance.Spec.MCPServerName, missing))
+		}
+	}
+
+	return missingConfig, nil
 }
 
 // validateServerScope checks that the catalog_id or workspace_id in the request URL matches the server.
@@ -1520,7 +1631,7 @@ func serverForAction(req api.Context) (v1.MCPServer, mcp.ServerConfig, error) {
 		return server, mcp.ServerConfig{}, err
 	}
 
-	serverConfig, err := serverConfigForAction(req, server)
+	serverConfig, _, err := serverConfigForAction(req, server, false)
 	return server, serverConfig, err
 }
 
@@ -1633,7 +1744,7 @@ func serverManifestFromCatalogEntryManifest(
 		}
 
 		var err error
-		result, err = types.MapCatalogEntryToServer(entry, userURL, false)
+		result, err = types.MapCatalogEntryToServer(entry, userURL, disableHostnameValidation)
 		if err != nil {
 			return types.MCPServerManifest{}, err
 		}
@@ -2035,6 +2146,15 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 			return fmt.Errorf("failed to get catalog entry %s: %w", mcpServer.Spec.MCPServerCatalogEntryName, err)
 		}
 
+		if url := envVars[configURLKey]; url != "" {
+			if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, catalogEntry, url, validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
+				return err
+			}
+
+			// The URL is part of user configuration, but it is stored on the MCPServer spec rather than in credentials.
+			delete(envVars, configURLKey)
+		}
+
 		// Check if the catalog entry has a URL template for remote runtime
 		// Templates use ${VARIABLE_NAME} syntax for variable substitution
 		// Example: "https://${DATABRICKS_WORKSPACE_URL}/api/2.0/mcp/genie/${DATABRICKS_GENIE_SPACE_ID}"
@@ -2056,12 +2176,13 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 			if err := validation.ValidateServerManifest(req.Context(), mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser(), validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
 				return types.NewErrBadRequest("validation failed: %v", err)
 			}
-
-			// Save the updated server
-			if err := req.Update(&mcpServer); err != nil {
-				return fmt.Errorf("failed to update server with processed URL: %w", err)
-			}
+			mcpServer.Spec.NeedsURL = false
+			mcpServer.Spec.PreviousURL = ""
 		}
+	}
+
+	if err := req.Update(&mcpServer); err != nil {
+		return fmt.Errorf("failed to update server configuration: %w", err)
 	}
 
 	var credCtx string
@@ -2205,6 +2326,9 @@ func (m *MCPHandler) configureCompositeServer(req api.Context, compositeServer v
 					remoteConfig.URL = finalURL
 				} else if remoteConfig.Hostname != "" {
 					remoteConfig.URL = config.URL
+					if remoteConfig.URL != "" && !strings.HasPrefix(remoteConfig.URL, "http") {
+						remoteConfig.URL = "https://" + remoteConfig.URL
+					}
 				}
 
 				if remoteConfig.URL != originalURL {
@@ -2213,6 +2337,13 @@ func (m *MCPHandler) configureCompositeServer(req api.Context, compositeServer v
 					if err := validation.ValidateServerManifest(req.Context(), component.Manifest, false, validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
 						return fmt.Errorf("failed to validate server manifest %w", err)
 					}
+					server.Spec.Manifest = component.Manifest
+					server.Spec.NeedsURL = false
+					server.Spec.PreviousURL = ""
+					if err := req.Update(&server); err != nil {
+						return fmt.Errorf("failed to update component server URL configuration: %w", err)
+					}
+					existingServers[componentID] = server
 
 					// Mark the composite manifest as changed
 					manifestChanged = true
@@ -2244,7 +2375,7 @@ func (m *MCPHandler) configureCompositeServer(req api.Context, compositeServer v
 
 			if modified {
 				if instance, ok := componentInstance[id]; ok {
-					_, serverConfig, err := serverFromMCPServerInstance(req, instance)
+					_, serverConfig, _, err := serverFromMCPServerInstance(req, instance, false)
 					if err == nil {
 						// Best effort
 						if err = m.mcpSessionManager.CloseClient(ctx, serverConfig, "default"); err != nil {
@@ -2430,7 +2561,7 @@ func (m *MCPHandler) deconfigureCompositeServer(req api.Context, compositeServer
 		if err := DeleteCredentialIfExists(req.Context(), req.GatewayClient, []string{MCPServerInstanceCredentialContext(instance)}, instance.Name); err != nil {
 			return fmt.Errorf("failed to delete component instance configuration %s: %w", instance.Name, err)
 		}
-		_, serverConfig, err := serverFromMCPServerInstance(req, instance)
+		_, serverConfig, _, err := serverFromMCPServerInstance(req, instance, false)
 		if err == nil {
 			// Best effort
 			if err = m.mcpSessionManager.CloseClient(req.Context(), serverConfig, "default"); err != nil {
@@ -2712,50 +2843,64 @@ func addExtractedEnvVars(server *v1.MCPServer) {
 
 // addExtractedEnvVarsToCatalogEntry extracts and adds environment variables to the catalog entry manifest
 func addExtractedEnvVarsToCatalogEntry(entry *v1.MCPServerCatalogEntry) {
+	addExtractedEnvVarsToCatalogEntryManifest(&entry.Spec.Manifest)
+}
+
+func addExtractedEnvVarsToCatalogEntryManifest(manifest *types.MCPServerCatalogEntryManifest) {
+	if manifest == nil {
+		return
+	}
+	if manifest.Runtime == types.RuntimeComposite && manifest.CompositeConfig != nil {
+		for i := range manifest.CompositeConfig.ComponentServers {
+			addExtractedEnvVarsToCatalogEntryManifest(&manifest.CompositeConfig.ComponentServers[i].Manifest)
+		}
+		return
+	}
+
 	// Keep track of existing env vars in the manifest to avoid duplicates
 	existing := make(map[string]struct{})
-	for _, env := range entry.Spec.Manifest.Env {
+	for _, env := range manifest.Env {
 		existing[env.Key] = struct{}{}
 	}
 
 	// Extract variables based on runtime type
 	var toExtract []string
 
-	switch entry.Spec.Manifest.Runtime {
+	switch manifest.Runtime {
 	case types.RuntimeUVX:
-		if entry.Spec.Manifest.UVXConfig != nil {
-			toExtract = append(toExtract, entry.Spec.Manifest.UVXConfig.Command)
-			if len(entry.Spec.Manifest.UVXConfig.Args) > 0 {
-				toExtract = append(toExtract, entry.Spec.Manifest.UVXConfig.Args...)
+		if manifest.UVXConfig != nil {
+			toExtract = append(toExtract, manifest.UVXConfig.Command)
+			if len(manifest.UVXConfig.Args) > 0 {
+				toExtract = append(toExtract, manifest.UVXConfig.Args...)
 			}
 		}
 	case types.RuntimeNPX:
-		if entry.Spec.Manifest.NPXConfig != nil && len(entry.Spec.Manifest.NPXConfig.Args) > 0 {
-			toExtract = append(toExtract, entry.Spec.Manifest.NPXConfig.Args...)
+		if manifest.NPXConfig != nil && len(manifest.NPXConfig.Args) > 0 {
+			toExtract = append(toExtract, manifest.NPXConfig.Args...)
 		}
 	case types.RuntimeContainerized:
-		if entry.Spec.Manifest.ContainerizedConfig != nil {
-			toExtract = append(toExtract, entry.Spec.Manifest.ContainerizedConfig.Command)
-			if len(entry.Spec.Manifest.ContainerizedConfig.Args) > 0 {
-				toExtract = append(toExtract, entry.Spec.Manifest.ContainerizedConfig.Args...)
+		if manifest.ContainerizedConfig != nil {
+			toExtract = append(toExtract, manifest.ContainerizedConfig.Command)
+			if len(manifest.ContainerizedConfig.Args) > 0 {
+				toExtract = append(toExtract, manifest.ContainerizedConfig.Args...)
 			}
 		}
 	case types.RuntimeRemote:
-		if entry.Spec.Manifest.RemoteConfig != nil {
+		if manifest.RemoteConfig != nil {
 			// Add the existing headers to the existing map.
-			for _, header := range entry.Spec.Manifest.RemoteConfig.Headers {
+			for _, header := range manifest.RemoteConfig.Headers {
 				existing[header.Key] = struct{}{}
 			}
 
-			toExtract = append(toExtract, entry.Spec.Manifest.RemoteConfig.URLTemplate)
+			toExtract = append(toExtract, manifest.RemoteConfig.URLTemplate)
 		}
 	}
 
 	for _, v := range toExtract {
 		for _, env := range extractEnvVars(v) {
 			if _, exists := existing[env]; !exists {
-				if entry.Spec.Manifest.Runtime != types.RuntimeRemote {
-					entry.Spec.Manifest.Env = append(entry.Spec.Manifest.Env, types.MCPEnv{
+				if manifest.Runtime != types.RuntimeRemote {
+					manifest.Env = append(manifest.Env, types.MCPEnv{
 						MCPHeader: types.MCPHeader{
 							Name:        env,
 							Key:         env,
@@ -2764,8 +2909,8 @@ func addExtractedEnvVarsToCatalogEntry(entry *v1.MCPServerCatalogEntry) {
 							Required:    true,
 						},
 					})
-				} else if entry.Spec.Manifest.RemoteConfig != nil {
-					entry.Spec.Manifest.RemoteConfig.Headers = append(entry.Spec.Manifest.RemoteConfig.Headers, types.MCPHeader{
+				} else if manifest.RemoteConfig != nil {
+					manifest.RemoteConfig.Headers = append(manifest.RemoteConfig.Headers, types.MCPHeader{
 						Name:        env,
 						Key:         env,
 						Description: "Automatically detected variable",
@@ -2907,6 +3052,72 @@ func ConvertMCPServer(server v1.MCPServer, credEnv map[string]string, serverURL,
 	}
 
 	return converted
+}
+
+func ConfigurationTargetForConnectID(req api.Context, id, serverURL string) (*types.MCPServer, *types.MCPServerInstance, error) {
+	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if instance.Name != "" {
+		credEnv, err := mcpServerInstanceCredEnv(req, instance)
+		if err != nil {
+			return nil, nil, err
+		}
+		slug, err := SlugForMCPServerInstance(req.Context(), req.Storage, instance)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to determine MCP server instance slug: %w", err)
+		}
+		converted := ConvertMCPServerInstance(instance, credEnv, serverURL, slug)
+		return nil, &converted, nil
+	}
+
+	credEnv, err := credentialEnvForMCPServer(req, server)
+	if err != nil {
+		return nil, nil, err
+	}
+	slug, err := SlugForMCPServer(req.Context(), req.Storage, server, req.User.GetUID(), server.Spec.MCPCatalogID, server.Spec.PowerUserWorkspaceID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to determine MCP server slug: %w", err)
+	}
+
+	var components []types.MCPServer
+	if server.Spec.Manifest.Runtime == types.RuntimeComposite {
+		components, err = resolveCompositeComponents(req, server)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	converted := ConvertMCPServer(server, credEnv, serverURL, slug, components...)
+	return &converted, nil, nil
+}
+
+func credentialEnvForMCPServer(req api.Context, server v1.MCPServer) (map[string]string, error) {
+	var credCtxs []string
+	switch {
+	case server.Spec.MCPCatalogID != "":
+		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name))
+	case server.Spec.PowerUserWorkspaceID != "":
+		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name))
+	default:
+		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name))
+	}
+
+	addExtractedEnvVars(&server)
+
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), credCtxs, server.Name)
+	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
+		return nil, fmt.Errorf("failed to find credential: %w", err)
+	}
+
+	mergedEnv, err := mcp.MergeBoundCreds(req.Context(), req.LocalK8sClient, req.ObotNamespace, server.Spec.Manifest.Env, server.Spec.Manifest.RemoteConfig, cred.Secrets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve secret bindings: %w", err)
+	}
+
+	return mergedEnv, nil
 }
 
 func secretBoundMissingConfig(server types.MCPServer) (missingEnvVars, missingHeaders []string) {
@@ -3363,7 +3574,7 @@ func (m *MCPHandler) RestartServerDeployment(req api.Context) error {
 				continue
 			}
 
-			componentConfig, err := serverConfigForAction(req, component)
+			componentConfig, _, err := serverConfigForAction(req, component, false)
 			if err != nil {
 				return err
 			}
@@ -3797,28 +4008,7 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 		return fmt.Errorf("failed to read input: %w", err)
 	}
 
-	if !strings.HasPrefix(input.URL, "http") {
-		input.URL = "https://" + input.URL
-	}
-
-	if err := types.ValidateURLHostname(input.URL, entry.Spec.Manifest.RemoteConfig.Hostname); err != nil {
-		return types.NewErrBadRequest("the hostname in the URL does not match the hostname in the catalog entry: %v", err)
-	}
-
-	parsedURL, err := url.Parse(input.URL)
-	if err != nil {
-		return types.NewErrBadRequest("failed to parse input URL: %v", err)
-	}
-
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return types.NewErrBadRequest("the URL must be HTTP or HTTPS")
-	}
-
-	mcpServer.Spec.Manifest.RemoteConfig.URL = input.URL
-	mcpServer.Spec.NeedsURL = false
-	mcpServer.Spec.PreviousURL = ""
-
-	if err := validation.ValidateServerManifest(req.Context(), mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser(), validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
+	if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, entry, input.URL, validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
 		return err
 	}
 
@@ -3832,6 +4022,45 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 	}
 
 	return req.Write(ConvertMCPServer(mcpServer, nil, m.serverURL, slug))
+}
+
+func updateMCPServerURLFromCatalogEntry(ctx context.Context, mcpServer *v1.MCPServer, entry v1.MCPServerCatalogEntry, inputURL string, opts validation.Options) error {
+	if entry.Spec.Manifest.RemoteConfig == nil {
+		return types.NewErrBadRequest("the catalog entry for this server does not have remote configuration")
+	}
+	if entry.Spec.Manifest.RemoteConfig.Hostname == "" {
+		return types.NewErrBadRequest("the catalog entry for this server does not have a hostname")
+	}
+
+	if !strings.HasPrefix(inputURL, "http") {
+		inputURL = "https://" + inputURL
+	}
+
+	if err := types.ValidateURLHostname(inputURL, entry.Spec.Manifest.RemoteConfig.Hostname); err != nil {
+		return types.NewErrBadRequest("the hostname in the URL does not match the hostname in the catalog entry: %v", err)
+	}
+
+	parsedURL, err := url.Parse(inputURL)
+	if err != nil {
+		return types.NewErrBadRequest("failed to parse input URL: %v", err)
+	}
+
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return types.NewErrBadRequest("the URL must be HTTP or HTTPS")
+	}
+
+	if mcpServer.Spec.Manifest.RemoteConfig == nil {
+		mcpServer.Spec.Manifest.RemoteConfig = &types.RemoteRuntimeConfig{}
+	}
+	mcpServer.Spec.Manifest.RemoteConfig.URL = inputURL
+	mcpServer.Spec.NeedsURL = false
+	mcpServer.Spec.PreviousURL = ""
+
+	if err := validation.ValidateServerManifest(ctx, mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser(), opts); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (m *MCPHandler) TriggerUpdate(req api.Context) error {

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -812,6 +812,171 @@ func TestConvertMCPServerCompositeSkipsDisabledAndConfiguredComponents(t *testin
 	assert.Empty(t, converted.MissingRequiredHeaders)
 }
 
+func TestServerManifestFromCatalogEntryManifestAllowsMissingRemoteHostname(t *testing.T) {
+	entry := types.MCPServerCatalogEntryManifest{
+		Runtime: types.RuntimeRemote,
+		RemoteConfig: &types.RemoteCatalogConfig{
+			Hostname: "api.example.com",
+		},
+	}
+
+	manifest, err := serverManifestFromCatalogEntryManifest(false, true, entry, types.MCPServerManifest{})
+	require.NoError(t, err)
+	require.NotNil(t, manifest.RemoteConfig)
+	assert.Equal(t, "api.example.com", manifest.RemoteConfig.Hostname)
+	assert.Empty(t, manifest.RemoteConfig.URL)
+}
+
+func TestServerManifestFromCatalogEntryManifestPreservesRemoteURLTemplateConfig(t *testing.T) {
+	const template = "https://${WORKSPACE}.example.com/mcp/${SPACE_ID}"
+	entry := v1.MCPServerCatalogEntry{
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeRemote,
+				RemoteConfig: &types.RemoteCatalogConfig{
+					URLTemplate: template,
+				},
+			},
+		},
+	}
+	addExtractedEnvVarsToCatalogEntry(&entry)
+
+	manifest, err := serverManifestFromCatalogEntryManifest(false, true, entry.Spec.Manifest, types.MCPServerManifest{})
+	require.NoError(t, err)
+	require.NotNil(t, manifest.RemoteConfig)
+	assert.True(t, manifest.RemoteConfig.IsTemplate)
+	assert.Equal(t, template, manifest.RemoteConfig.URLTemplate)
+	assert.Empty(t, manifest.RemoteConfig.URL)
+	assert.ElementsMatch(t, []types.MCPHeader{
+		{Name: "WORKSPACE", Key: "WORKSPACE", Description: "Automatically detected variable", Required: true},
+		{Name: "SPACE_ID", Key: "SPACE_ID", Description: "Automatically detected variable", Required: true},
+	}, manifest.RemoteConfig.Headers)
+}
+
+func TestServerManifestFromCatalogEntryManifestAllowsMissingCompositeRemoteHostname(t *testing.T) {
+	entry := types.MCPServerCatalogEntryManifest{
+		Runtime: types.RuntimeComposite,
+		CompositeConfig: &types.CompositeCatalogConfig{
+			ComponentServers: []types.CatalogComponentServer{
+				{
+					CatalogEntryID: "remote",
+					Manifest: types.MCPServerCatalogEntryManifest{
+						Runtime: types.RuntimeRemote,
+						RemoteConfig: &types.RemoteCatalogConfig{
+							Hostname: "api.example.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.True(t, catalogEntryRequiresUserURL(entry))
+	manifest, err := serverManifestFromCatalogEntryManifest(false, true, entry, types.MCPServerManifest{})
+	require.NoError(t, err)
+	require.NotNil(t, manifest.CompositeConfig)
+	require.Len(t, manifest.CompositeConfig.ComponentServers, 1)
+	component := manifest.CompositeConfig.ComponentServers[0]
+	require.NotNil(t, component.Manifest.RemoteConfig)
+	assert.Equal(t, "api.example.com", component.Manifest.RemoteConfig.Hostname)
+	assert.Empty(t, component.Manifest.RemoteConfig.URL)
+}
+
+func TestAddExtractedEnvVarsToCatalogEntryRecursesIntoCompositeComponents(t *testing.T) {
+	const template = "https://${WORKSPACE}.example.com/mcp/${SPACE_ID}"
+	entry := v1.MCPServerCatalogEntry{
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeCatalogConfig{
+					ComponentServers: []types.CatalogComponentServer{
+						{
+							CatalogEntryID: "remote",
+							Manifest: types.MCPServerCatalogEntryManifest{
+								Runtime: types.RuntimeRemote,
+								RemoteConfig: &types.RemoteCatalogConfig{
+									URLTemplate: template,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	addExtractedEnvVarsToCatalogEntry(&entry)
+	headers := entry.Spec.Manifest.CompositeConfig.ComponentServers[0].Manifest.RemoteConfig.Headers
+	assert.ElementsMatch(t, []types.MCPHeader{
+		{Name: "WORKSPACE", Key: "WORKSPACE", Description: "Automatically detected variable", Required: true},
+		{Name: "SPACE_ID", Key: "SPACE_ID", Description: "Automatically detected variable", Required: true},
+	}, headers)
+}
+
+func TestSyncConnectServerRemoteConfigFromCatalogEntryURLTemplate(t *testing.T) {
+	const template = "https://${WORKSPACE}.example.com/mcp/${SPACE_ID}"
+	server := v1.MCPServer{
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{
+				Runtime:      types.RuntimeRemote,
+				RemoteConfig: &types.RemoteRuntimeConfig{IsTemplate: true},
+			},
+		},
+	}
+	entry := v1.MCPServerCatalogEntry{
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeRemote,
+				RemoteConfig: &types.RemoteCatalogConfig{
+					URLTemplate: template,
+					Headers: []types.MCPHeader{
+						{Name: "WORKSPACE", Key: "WORKSPACE", Required: true},
+					},
+				},
+			},
+		},
+	}
+
+	changed := syncConnectServerRemoteConfigFromCatalogEntry(&server, entry)
+	assert.True(t, changed)
+	require.NotNil(t, server.Spec.Manifest.RemoteConfig)
+	assert.True(t, server.Spec.NeedsURL)
+	assert.True(t, server.Spec.Manifest.RemoteConfig.IsTemplate)
+	assert.Equal(t, template, server.Spec.Manifest.RemoteConfig.URLTemplate)
+	assert.Equal(t, entry.Spec.Manifest.RemoteConfig.Headers, server.Spec.Manifest.RemoteConfig.Headers)
+}
+
+func TestSyncConnectServerRemoteConfigFromCatalogEntryHostname(t *testing.T) {
+	server := v1.MCPServer{
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeRemote,
+				RemoteConfig: &types.RemoteRuntimeConfig{
+					URL: "https://old.example.com/mcp",
+				},
+			},
+		},
+	}
+	entry := v1.MCPServerCatalogEntry{
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeRemote,
+				RemoteConfig: &types.RemoteCatalogConfig{
+					Hostname: "api.example.com",
+				},
+			},
+		},
+	}
+
+	changed := syncConnectServerRemoteConfigFromCatalogEntry(&server, entry)
+	assert.True(t, changed)
+	require.NotNil(t, server.Spec.Manifest.RemoteConfig)
+	assert.True(t, server.Spec.NeedsURL)
+	assert.Equal(t, "https://old.example.com/mcp", server.Spec.PreviousURL)
+	assert.Empty(t, server.Spec.Manifest.RemoteConfig.URL)
+	assert.Equal(t, "api.example.com", server.Spec.Manifest.RemoteConfig.Hostname)
+}
+
 func TestEntryManifestNeedsUserConfig(t *testing.T) {
 	const ns = "obot-ns"
 

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -902,7 +902,7 @@ func (h *MCPCatalogHandler) generateCompositeToolPreviews(req api.Context, entry
 				return fmt.Errorf("failed to get MCP server %q: %w", componentEntry.MCPServerID, err)
 			}
 
-			serverConfig, err := serverConfigForAction(req, mcpServer)
+			serverConfig, _, err := serverConfigForAction(req, mcpServer, false)
 			if err != nil {
 				return fmt.Errorf("failed to build server configuration for MCP server %q: %w", mcpServer.Name, err)
 			}

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -1,6 +1,7 @@
 package mcpgateway
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -26,6 +27,8 @@ type Handler struct {
 	transport         http.RoundTripper
 }
 
+var errMCPServerRequiresConfiguration = errors.New("mcp server requires configuration")
+
 func NewHandler(mcpSessionManager *mcp.SessionManager) *Handler {
 	return &Handler{
 		mcpSessionManager: mcpSessionManager,
@@ -36,6 +39,9 @@ func NewHandler(mcpSessionManager *mcp.SessionManager) *Handler {
 func (h *Handler) Proxy(req api.Context) error {
 	serverConfig, mcpURL, allowDifferentPaths, err := h.ensureServerIsDeployed(req)
 	if err != nil {
+		if errors.Is(err, errMCPServerRequiresConfiguration) {
+			return nil
+		}
 		return fmt.Errorf("failed to ensure server is deployed: %v", err)
 	}
 
@@ -96,12 +102,17 @@ func (h *Handler) ensureServerIsDeployed(req api.Context) (mcp.ServerConfig, str
 		return h.ensureSystemServerIsDeployed(req, mcpID)
 	}
 
-	mcpID, mcpServer, mcpServerConfig, err := handlers.ServerForActionWithConnectID(req, mcpID)
+	connectID := mcpID
+	mcpID, mcpServer, mcpServerConfig, missingConfig, err := handlers.ServerForActionWithConnectIDAllowMissingConfig(req, mcpID)
 	if err != nil {
 		return mcp.ServerConfig{}, "", false, fmt.Errorf("failed to get mcp server config: %w", err)
 	}
 	if mcpServer.Spec.Template {
 		return mcp.ServerConfig{}, "", false, apierrors.NewNotFound(schema.GroupResource{Group: "obot.obot.ai", Resource: "mcpserver"}, mcpID)
+	}
+	if len(missingConfig) > 0 {
+		writeMCPAuthRequired(req, connectID)
+		return mcp.ServerConfig{}, "", false, errMCPServerRequiresConfiguration
 	}
 
 	// Add-hoc authorization for nanobot agents
@@ -121,6 +132,12 @@ func (h *Handler) ensureServerIsDeployed(req api.Context) (mcp.ServerConfig, str
 	}
 
 	return mcpServerConfig, url, mcpServerConfig.NanobotAgentName != "", nil
+}
+
+func writeMCPAuthRequired(req api.Context, mcpID string) {
+	baseURL := strings.TrimSuffix(req.APIBaseURL, "/api")
+	req.ResponseWriter.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="Obot MCP Gateway", resource_metadata="%s/.well-known/oauth-protected-resource/mcp-connect/%s"`, baseURL, url.PathEscape(mcpID)))
+	http.Error(req.ResponseWriter, "MCP server requires configuration", http.StatusUnauthorized)
 }
 
 func (h *Handler) ensureSystemServerIsDeployed(req api.Context, mcpID string) (mcp.ServerConfig, string, bool, error) {

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -310,14 +310,25 @@ func (h *handler) callback(req api.Context) error {
 }
 
 func (h *handler) prepareOAuthConsent(req api.Context, oauthAppAuthRequest *v1.OAuthAuthRequest) error {
-	if oauthAppAuthRequest.Spec.ConsentPrepared {
+	if oauthAppAuthRequest.Spec.ConsentPrepared && !oauthAppAuthRequest.Spec.ConsentMCPConfigRequired {
 		return nil
 	}
 
 	// Check whether the MCP server needs authentication.
-	mcpID, mcpServer, mcpServerConfig, err := handlers.ServerForActionWithConnectID(req, oauthAppAuthRequest.Spec.MCPID)
+	mcpID, mcpServer, mcpServerConfig, missingConfig, err := handlers.ServerForActionWithConnectIDAllowMissingConfig(req, oauthAppAuthRequest.Spec.MCPID)
 	if err != nil {
 		return err
+	}
+
+	if len(missingConfig) > 0 {
+		oauthAppAuthRequest.Spec.ConsentPrepared = true
+		oauthAppAuthRequest.Spec.ConsentMCPConfigRequired = true
+		oauthAppAuthRequest.Spec.ConsentMCPAuthRequired = false
+		oauthAppAuthRequest.Spec.ConsentMCPAuthURL = ""
+		oauthAppAuthRequest.Spec.UserHasSecondLevelOAuthed = false
+		oauthAppAuthRequest.Spec.ConsentMCPServerName = mcpServerDisplayName(mcpServer)
+		oauthAppAuthRequest.Spec.ConsentMCPServerURL = mcpServerConfig.URL
+		return req.Update(oauthAppAuthRequest)
 	}
 
 	u, err := h.oauthChecker.CheckForMCPAuth(req, mcpServer, mcpServerConfig, req.User.GetUID(), mcpID, oauthAppAuthRequest.Name)
@@ -326,6 +337,7 @@ func (h *handler) prepareOAuthConsent(req api.Context, oauthAppAuthRequest *v1.O
 	}
 
 	oauthAppAuthRequest.Spec.ConsentPrepared = true
+	oauthAppAuthRequest.Spec.ConsentMCPConfigRequired = false
 	oauthAppAuthRequest.Spec.ConsentMCPAuthRequired = u != ""
 	oauthAppAuthRequest.Spec.ConsentMCPAuthURL = u
 	oauthAppAuthRequest.Spec.UserHasSecondLevelOAuthed = u == "" && mcpServer.Status.UserHasAuthenticated
@@ -346,6 +358,17 @@ func (h *handler) consent(req api.Context) error {
 	}
 	if !authenticatedOAuthConsentUser(req, oauthAppAuthRequest) {
 		return nil
+	}
+
+	if !oauthAppAuthRequest.Spec.ConsentPrepared || oauthAppAuthRequest.Spec.ConsentMCPConfigRequired {
+		if err := h.prepareOAuthConsent(req, &oauthAppAuthRequest); err != nil {
+			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
+				Code:        ErrServerError,
+				Description: err.Error(),
+				State:       oauthAppAuthRequest.Spec.State,
+			})
+			return nil
+		}
 	}
 
 	if !oauthAppAuthRequest.Spec.ConsentPrepared {
@@ -373,7 +396,23 @@ func (h *handler) consent(req api.Context) error {
 	}
 
 	continueURL, cancelURL := oauthConsentURLs(oauthAppAuthRequest)
-	return req.Write(oauthConsentPageData(oauthAppAuthRequest, oauthClient, continueURL, cancelURL))
+	var (
+		mcpServer         *types.MCPServer
+		mcpServerInstance *types.MCPServerInstance
+	)
+	if oauthAppAuthRequest.Spec.ConsentMCPConfigRequired {
+		mcpServer, mcpServerInstance, err = handlers.ConfigurationTargetForConnectID(req, oauthAppAuthRequest.Spec.MCPID, h.baseURL)
+		if err != nil {
+			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
+				Code:        ErrServerError,
+				Description: err.Error(),
+				State:       oauthAppAuthRequest.Spec.State,
+			})
+			return nil
+		}
+	}
+
+	return req.Write(oauthConsentPageData(oauthAppAuthRequest, oauthClient, continueURL, cancelURL, mcpServer, mcpServerInstance))
 }
 
 func (h *handler) approveConsent(req api.Context) error {
@@ -383,6 +422,14 @@ func (h *handler) approveConsent(req api.Context) error {
 	}
 
 	oauthAppAuthRequest.Spec.ConsentApproved = true
+	if oauthAppAuthRequest.Spec.ConsentMCPConfigRequired {
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
+			Code:        ErrInvalidRequest,
+			Description: "MCP server configuration is required before consent can be approved",
+			State:       oauthAppAuthRequest.Spec.State,
+		})
+		return nil
+	}
 	if err := req.Update(&oauthAppAuthRequest); err != nil {
 		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
 			Code:        ErrServerError,
@@ -596,24 +643,27 @@ func authenticatedOAuthConsentUser(req api.Context, oauthAppAuthRequest v1.OAuth
 }
 
 type oauthConsentData struct {
-	AuthRequestID             string `json:"authRequestID"`
-	ContinueURL               string `json:"continueURL"`
-	CancelURL                 string `json:"cancelURL"`
-	ClientName                string `json:"clientName"`
-	ClientCredentialSource    string `json:"clientCredentialSource"`
-	ClientURI                 string `json:"clientURI,omitempty"`
-	RedirectURI               string `json:"redirectURI"`
-	Scope                     string `json:"scope,omitempty"`
-	PolicyURI                 string `json:"policyURI,omitempty"`
-	TOSURI                    string `json:"tosURI,omitempty"`
-	MCPAuthRequired           bool   `json:"mcpAuthRequired"`
-	UserHasSecondLevelOAuthed bool   `json:"userHasSecondLevelOAuthed"`
-	MCPServerName             string `json:"mcpServerName,omitempty"`
-	MCPServerURL              string `json:"mcpServerURL,omitempty"`
-	ThirdPartyAuthURL         string `json:"thirdPartyAuthURL,omitempty"`
+	AuthRequestID             string                   `json:"authRequestID"`
+	ContinueURL               string                   `json:"continueURL"`
+	CancelURL                 string                   `json:"cancelURL"`
+	ClientName                string                   `json:"clientName"`
+	ClientCredentialSource    string                   `json:"clientCredentialSource"`
+	ClientURI                 string                   `json:"clientURI,omitempty"`
+	RedirectURI               string                   `json:"redirectURI"`
+	Scope                     string                   `json:"scope,omitempty"`
+	PolicyURI                 string                   `json:"policyURI,omitempty"`
+	TOSURI                    string                   `json:"tosURI,omitempty"`
+	MCPConfigRequired         bool                     `json:"mcpConfigRequired"`
+	MCPServer                 *types.MCPServer         `json:"mcpServer,omitempty"`
+	MCPServerInstance         *types.MCPServerInstance `json:"mcpServerInstance,omitempty"`
+	MCPAuthRequired           bool                     `json:"mcpAuthRequired"`
+	UserHasSecondLevelOAuthed bool                     `json:"userHasSecondLevelOAuthed"`
+	MCPServerName             string                   `json:"mcpServerName,omitempty"`
+	MCPServerURL              string                   `json:"mcpServerURL,omitempty"`
+	ThirdPartyAuthURL         string                   `json:"thirdPartyAuthURL,omitempty"`
 }
 
-func oauthConsentPageData(oauthAppAuthRequest v1.OAuthAuthRequest, oauthClient v1.OAuthClient, continueURL, cancelURL string) oauthConsentData {
+func oauthConsentPageData(oauthAppAuthRequest v1.OAuthAuthRequest, oauthClient v1.OAuthClient, continueURL, cancelURL string, mcpServer *types.MCPServer, mcpServerInstance *types.MCPServerInstance) oauthConsentData {
 	clientName := oauthClient.Spec.Manifest.ClientName
 	if clientName == "" {
 		clientName = fmt.Sprintf("%s:%s", oauthClient.Namespace, oauthClient.Name)
@@ -630,6 +680,9 @@ func oauthConsentPageData(oauthAppAuthRequest v1.OAuthAuthRequest, oauthClient v
 		Scope:                     oauthAppAuthRequest.Spec.Scope,
 		PolicyURI:                 oauthClient.Spec.Manifest.PolicyURI,
 		TOSURI:                    oauthClient.Spec.Manifest.TOSURI,
+		MCPConfigRequired:         oauthAppAuthRequest.Spec.ConsentMCPConfigRequired,
+		MCPServer:                 mcpServer,
+		MCPServerInstance:         mcpServerInstance,
 		MCPAuthRequired:           oauthAppAuthRequest.Spec.ConsentMCPAuthRequired,
 		UserHasSecondLevelOAuthed: oauthAppAuthRequest.Spec.UserHasSecondLevelOAuthed,
 		MCPServerName:             oauthAppAuthRequest.Spec.ConsentMCPServerName,

--- a/pkg/api/handlers/nanobotagent.go
+++ b/pkg/api/handlers/nanobotagent.go
@@ -212,7 +212,7 @@ func (h *NanobotAgentHandler) Launch(req api.Context) error {
 	// "missing required config: NANOBOT_ENV_FILE" error before the credential exists.
 	var serverConfig mcp.ServerConfig
 	for {
-		serverConfig, err = serverConfigForAction(req, *server)
+		serverConfig, _, err = serverConfigForAction(req, *server, false)
 		if err == nil {
 			break
 		}

--- a/pkg/api/handlers/systemmcpserver.go
+++ b/pkg/api/handlers/systemmcpserver.go
@@ -288,7 +288,7 @@ func (h *SystemMCPServerHandler) RestartNanobotAgentDeployments(req api.Context)
 			continue
 		}
 
-		serverConfig, err := serverConfigForAction(req, server)
+		serverConfig, _, err := serverConfigForAction(req, server, false)
 		if err != nil {
 			failed = append(failed, map[string]string{
 				"serverID": server.Name,

--- a/pkg/storage/apis/obot.obot.ai/v1/oauthauthrequest.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/oauthauthrequest.go
@@ -60,6 +60,7 @@ type OAuthAuthRequestSpec struct {
 	AuthProviderNamespace     string `json:"authProviderNamespace"`
 	AuthProviderName          string `json:"authProviderName"`
 	ConsentPrepared           bool   `json:"consentPrepared"`
+	ConsentMCPConfigRequired  bool   `json:"consentMCPConfigRequired"`
 	ConsentApproved           bool   `json:"consentApproved"`
 	ConsentMCPAuthRequired    bool   `json:"consentMCPAuthRequired"`
 	ConsentMCPAuthURL         string `json:"consentMCPAuthURL"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -16021,6 +16021,13 @@ func schema_storage_apis_obotobotai_v1_OAuthAuthRequestSpec(ref common.Reference
 							Format:  "",
 						},
 					},
+					"consentMCPConfigRequired": {
+						SchemaProps: spec.SchemaProps{
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
+						},
+					},
 					"consentApproved": {
 						SchemaProps: spec.SchemaProps{
 							Default: false,
@@ -16064,7 +16071,7 @@ func schema_storage_apis_obotobotai_v1_OAuthAuthRequestSpec(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"redirectURI", "state", "clientID", "codeChallenge", "scope", "codeChallengeMethod", "grantType", "resource", "hashedAuthCode", "userID", "mcpID", "authProviderUserID", "authProviderNamespace", "authProviderName", "consentPrepared", "consentApproved", "consentMCPAuthRequired", "consentMCPAuthURL", "userHasSecondLevelOAuthed", "consentMCPServerName", "consentMCPServerURL"},
+				Required: []string{"redirectURI", "state", "clientID", "codeChallenge", "scope", "codeChallengeMethod", "grantType", "resource", "hashedAuthCode", "userID", "mcpID", "authProviderUserID", "authProviderNamespace", "authProviderName", "consentPrepared", "consentMCPConfigRequired", "consentApproved", "consentMCPAuthRequired", "consentMCPAuthURL", "userHasSecondLevelOAuthed", "consentMCPServerName", "consentMCPServerURL"},
 			},
 		},
 	}

--- a/ui/user/src/lib/components/SensitiveInput.svelte
+++ b/ui/user/src/lib/components/SensitiveInput.svelte
@@ -73,8 +73,9 @@
 
 		const deltaY = ev.clientY - startY;
 		const newHeight = Math.max(60, startHeight + deltaY); // Min height 60px
-		scrollableWrapper.style.maxHeight = `${newHeight}px`;
-		scrollableWrapper.style.minHeight = 'auto';
+		scrollableWrapper.style.height = `${newHeight}px`;
+		scrollableWrapper.style.minHeight = `${newHeight}px`;
+		scrollableWrapper.style.maxHeight = 'none';
 	}
 
 	function handleResizeEnd() {
@@ -143,7 +144,7 @@
 				<div
 					bind:this={scrollableWrapper}
 					class={twMerge(
-						'text-input-filled base flex w-full flex-1 flex-col overflow-x-hidden overflow-y-auto font-mono',
+						'text-input-filled base flex min-h-[60px] w-full shrink-0 flex-col overflow-x-hidden overflow-y-auto font-mono',
 						klass,
 						classes?.wrapper,
 						error && 'border-error bg-error/20 text-error ring-error focus:ring-1',

--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Loading from '$lib/icons/Loading.svelte';
+	import type { MCPSubField } from '$lib/services';
 	import { hasSecretBinding, type MCPServerInfo } from '$lib/services/user/mcp';
 	import Confirm from '../Confirm.svelte';
 	import InfoTooltip from '../InfoTooltip.svelte';
@@ -130,6 +131,16 @@
 		highlightedFields = new Set();
 	}
 
+	function startTextareaResize() {
+		resizing = true;
+		document.addEventListener('pointerup', stopTextareaResize, { once: true });
+		document.addEventListener('mouseup', stopTextareaResize, { once: true });
+	}
+
+	function stopTextareaResize() {
+		resizing = false;
+	}
+
 	function hasUrl(url?: string) {
 		return url?.trim().length ?? 0 > 0;
 	}
@@ -154,14 +165,14 @@
 
 	function componentHasConfig(comp?: ComponentLaunchFormData) {
 		if (!comp) return false;
-		// Multi-user component entries should not expose any configuration
-		// fields in this dialog; they are configured at the multi-user level.
-		if (comp.isMultiUser) return false;
-		const hasEnvs = Array.isArray(comp.envs) && comp.envs.some((e) => !hasSecretBinding(e));
-		const hasHeaders =
-			Array.isArray(comp.headers) && comp.headers.some((h) => !hasSecretBinding(h));
-		const needsURL = Boolean(comp.hostname);
+		const hasEnvs = Array.isArray(comp.envs) && comp.envs.some(isEditableField);
+		const hasHeaders = Array.isArray(comp.headers) && comp.headers.some(isEditableField);
+		const needsURL = !comp.isMultiUser && Boolean(comp.hostname);
 		return hasEnvs || hasHeaders || needsURL;
+	}
+
+	function isEditableField(field: Partial<MCPSubField> & { isStatic?: boolean }) {
+		return !hasSecretBinding(field) && !field.isStatic;
 	}
 
 	function missingRequiredFields(formAny: LaunchFormData | CompositeLaunchFormData) {
@@ -174,7 +185,7 @@
 				if (comp.hostname && !hasUrl(comp.url)) {
 					return true;
 				}
-				if ([...envs, ...headers].some((f) => !hasSecretBinding(f) && f.required && !f.value)) {
+				if ([...envs, ...headers].some((f) => isEditableField(f) && f.required && !f.value)) {
 					return true;
 				}
 			}
@@ -188,7 +199,7 @@
 		const envs = form.envs ?? [];
 		const headers = form.headers ?? [];
 		return [...envs, ...headers].some(
-			(field) => !hasSecretBinding(field) && field.required && !field.value
+			(field) => isEditableField(field) && field.required && !field.value
 		);
 	}
 
@@ -199,11 +210,11 @@
 			for (const [compId, comp] of Object.entries(formAny.componentConfigs || {})) {
 				if (comp.disabled) continue;
 				for (const f of comp.envs ?? []) {
-					if (!hasSecretBinding(f) && f.required && !f.value)
+					if (isEditableField(f) && f.required && !f.value)
 						fieldsToHighlight.add(keyFor(compId, f.key));
 				}
 				for (const f of comp.headers ?? []) {
-					if (!hasSecretBinding(f) && f.required && !f.value)
+					if (isEditableField(f) && f.required && !f.value)
 						fieldsToHighlight.add(keyFor(compId, f.key));
 				}
 				if (comp.hostname && !comp.url) fieldsToHighlight.add(keyFor(compId, 'url'));
@@ -213,7 +224,7 @@
 		}
 		const form = formAny as LaunchFormData;
 		[...(form.envs ?? []), ...(form.headers ?? [])].forEach((field) => {
-			if (!hasSecretBinding(field) && field.required && !field.value) {
+			if (isEditableField(field) && field.required && !field.value) {
 				fieldsToHighlight.add(field.key);
 			}
 		});
@@ -234,6 +245,7 @@
 
 		if (missingRequiredFields(form)) {
 			highlightMissingRequiredFields(form);
+			localError = 'Please fill out all required configuration fields.';
 			return;
 		}
 
@@ -254,7 +266,7 @@
 		if (isCompositeForm(formAny)) {
 			for (const comp of Object.values(formAny.componentConfigs || {})) {
 				const hasEnvOrHeaderFilled = [...(comp.envs ?? []), ...(comp.headers ?? [])].some(
-					(f) => !hasSecretBinding(f) && f.value
+					(f) => isEditableField(f) && f.value
 				);
 				const hasHostnameAndUrl = comp.hostname && hasUrl(comp.url);
 				if (hasEnvOrHeaderFilled || hasHostnameAndUrl) return true;
@@ -263,7 +275,7 @@
 		}
 		const form = formAny as LaunchFormData;
 		const hasEnvOrHeaderFilled = [...(form.envs ?? []), ...(form.headers ?? [])].some(
-			(field) => !hasSecretBinding(field) && field.value
+			(field) => isEditableField(field) && field.value
 		);
 		const hasHostnameAndUrl = form.hostname && hasUrl(form.url);
 		return hasEnvOrHeaderFilled || hasHostnameAndUrl;
@@ -383,8 +395,10 @@
 	{/if}
 	{#if form}
 		<form
+			id="mcp-catalog-configure-form"
 			onsubmit={(e) => {
 				e.preventDefault();
+				handleSave();
 			}}
 		>
 			<div class="my-4 flex flex-col gap-4">
@@ -457,13 +471,14 @@
 														id={`${compId}-${env.data.key}`}
 														bind:value={comp.envs![env.index].value}
 														disabled={form.componentConfigs[compId].disabled}
+														rows="8"
 														class={twMerge(
-															'text-input-filled h-32 resize-y whitespace-pre-wrap',
+															'text-input-filled h-32 min-h-32 resize-y overflow-auto whitespace-pre-wrap',
 															highlightRequired &&
 																'border-error bg-error/20 ring-error focus:ring-1'
 														)}
-														onmousedown={() => (resizing = true)}
-														onmouseup={() => (resizing = false)}
+														onpointerdown={startTextareaResize}
+														onmousedown={startTextareaResize}
 													></textarea>
 												{:else}
 													<input
@@ -537,13 +552,17 @@
 									{/each}
 
 									{#if comp.hostname}
+										{@const highlightRequired = highlightedFields.has(`${compId}:url`) && !comp.url}
 										<label for={`${compId}-url`}> URL </label>
 										<input
 											type="text"
 											id={`${compId}-url`}
 											bind:value={comp.url}
 											disabled={form.componentConfigs[compId].disabled}
-											class="text-input-filled"
+											class={twMerge(
+												'text-input-filled',
+												highlightRequired && 'border-error bg-error/20 ring-error focus:ring-1'
+											)}
 										/>
 										<span class="text-muted-content font-light">
 											The URL must contain the hostname: <b class="font-semibold">{comp.hostname}</b
@@ -586,12 +605,13 @@
 									<textarea
 										id={env.data.key}
 										bind:value={form.envs![env.index].value}
+										rows="8"
 										class={twMerge(
-											'text-input-filled h-32 resize-y whitespace-pre-wrap',
+											'text-input-filled h-32 min-h-32 resize-y overflow-auto whitespace-pre-wrap',
 											highlightRequired && 'border-error bg-error/20 ring-error focus:ring-1'
 										)}
-										onmousedown={() => (resizing = true)}
-										onmouseup={() => (resizing = false)}
+										onpointerdown={startTextareaResize}
+										onmousedown={startTextareaResize}
 									></textarea>
 								{:else}
 									<input
@@ -671,7 +691,12 @@
 					{cancelText}
 				</button>
 			{/if}
-			<button class="btn btn-primary" onclick={handleSave} disabled={loading || disableSave}>
+			<button
+				class="btn btn-primary"
+				type="submit"
+				form="mcp-catalog-configure-form"
+				disabled={loading || disableSave}
+			>
 				{#if loading}
 					<Loading class="size-4" />
 				{:else}

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -890,7 +890,12 @@
 
 		if (server && instance && configureInstance && hasMultiUserInstanceConfiguration(server)) {
 			initMultiUserInstanceForm(server, instance);
-		} else if ((entry && server) || (server && instance)) {
+		} else if (
+			entry?.connectURL ||
+			server?.connectURL ||
+			(entry && server) ||
+			(server && instance)
+		) {
 			handleConnect(true);
 		} else {
 			showIntroDialog = true;
@@ -936,20 +941,20 @@
 
 <ResponsiveDialog bind:this={connectDialog} animate="slide" onClose={handleOnClose}>
 	{#snippet titleContent()}
-		{@render dialogTitle(server)}
+		{@render dialogTitle(server || entry)}
 	{/snippet}
 
-	{#if server}
-		{@const url = instance ? instance.connectURL : server.connectURL}
-		<div class="flex flex-col gap-1 md:p-0 pb-0 p-4">
-			<CopyField
-				bind:this={connectionUrlField}
-				value={url}
-				id="connectURL"
-				label="Connection URL"
-			/>
-		</div>
+	{#if entry?.connectURL || server?.connectURL || instance?.connectURL}
+		{@const url = instance?.connectURL || server?.connectURL || entry?.connectURL}
 		{#if url}
+			<div class="flex flex-col gap-1 md:p-0 pb-0 p-4">
+				<CopyField
+					bind:this={connectionUrlField}
+					value={url}
+					id="connectURL"
+					label="Connection URL"
+				/>
+			</div>
 			<HowToConnect
 				bind:this={howToConnect}
 				{url}

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -558,7 +558,7 @@ export async function convertCompositeInfoToLaunchFormData(
 						...(e as unknown as Record<string, unknown>),
 						key: e.key,
 						value: init?.config?.[e.key] ?? e.value ?? '',
-						isStatic: Boolean(e.value)
+						isStatic: !init?.config?.[e.key] && Boolean(e.value)
 					})),
 			headers: isMultiUser
 				? (m.multiUserConfig?.userDefinedHeaders ?? []).map((h) => ({
@@ -571,7 +571,7 @@ export async function convertCompositeInfoToLaunchFormData(
 						...(h as unknown as Record<string, unknown>),
 						key: h.key,
 						value: init?.config?.[h.key] ?? h.value ?? '',
-						isStatic: Boolean(h.value)
+						isStatic: !init?.config?.[h.key] && Boolean(h.value)
 					}))
 		};
 	}

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -479,7 +479,9 @@ export function convertCompositeLaunchFormDataToPayload(lf: CompositeLaunchFormD
 			...(comp.envs ?? ([] as Array<{ key: string; value: string }>)),
 			...(comp.headers ?? ([] as Array<{ key: string; value: string }>))
 		]) {
-			if (!hasSecretBinding(f) && f.value) config[f.key] = f.value;
+			if (!hasSecretBinding(f) && !('isStatic' in f && f.isStatic) && f.value) {
+				config[f.key] = f.value;
+			}
 		}
 		payload[id] = {
 			config,
@@ -555,7 +557,8 @@ export async function convertCompositeInfoToLaunchFormData(
 				: (m.env ?? []).map((e) => ({
 						...(e as unknown as Record<string, unknown>),
 						key: e.key,
-						value: init?.config?.[e.key] ?? ''
+						value: init?.config?.[e.key] ?? e.value ?? '',
+						isStatic: Boolean(e.value)
 					})),
 			headers: isMultiUser
 				? (m.multiUserConfig?.userDefinedHeaders ?? []).map((h) => ({
@@ -567,7 +570,8 @@ export async function convertCompositeInfoToLaunchFormData(
 				: (m.remoteConfig?.headers ?? []).map((h) => ({
 						...(h as unknown as Record<string, unknown>),
 						key: h.key,
-						value: init?.config?.[h.key] ?? ''
+						value: init?.config?.[h.key] ?? h.value ?? '',
+						isStatic: Boolean(h.value)
 					}))
 		};
 	}

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -991,6 +991,9 @@ export type OAuthConsent = {
 	scope?: string;
 	policyURI?: string;
 	tosURI?: string;
+	mcpConfigRequired: boolean;
+	mcpServer?: MCPCatalogServer;
+	mcpServerInstance?: MCPServerInstance;
 	mcpAuthRequired: boolean;
 	userHasSecondLevelOAuthed: boolean;
 	mcpServerName?: string;

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -498,11 +498,14 @@ export interface RemoteRuntimeConfig {
 	url: string;
 	headers?: MCPSubField[];
 	fixedURL?: string;
+	hostname?: string;
 	isTemplate?: boolean;
+	urlTemplate?: string;
 }
 export interface RemoteCatalogConfig {
 	fixedURL?: string;
 	hostname?: string;
+	urlTemplate?: string;
 	headers?: MCPSubField[];
 }
 export type ResourceRuntimeConfig = MCPResourceRequirements;

--- a/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
+++ b/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
@@ -13,7 +13,7 @@
 		convertEnvHeadersToRecord
 	} from '$lib/services/user/mcp';
 	import { ExternalLink, SettingsIcon, ShieldAlertIcon } from '@lucide/svelte';
-	import { onMount, tick } from 'svelte';
+	import { onMount, tick, untrack } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	type Props = {
@@ -23,8 +23,7 @@
 	};
 
 	let { data }: Props = $props();
-	// svelte-ignore state_referenced_locally
-	let currentConsent = $state(data.consent);
+	let currentConsent = $state(untrack(() => data.consent));
 	let configureForm = $state<LaunchFormData | CompositeLaunchFormData>();
 	let configDialog = $state<ReturnType<typeof CatalogConfigureForm>>();
 	let configError = $state('');

--- a/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
+++ b/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
@@ -1,8 +1,19 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import CatalogConfigureForm, {
+		type CompositeLaunchFormData,
+		type LaunchFormData
+	} from '$lib/components/mcp/CatalogConfigureForm.svelte';
 	import BetaLogo from '$lib/components/navbar/BetaLogo.svelte';
-	import type { OAuthConsent } from '$lib/services';
-	import { ExternalLink, ShieldAlertIcon } from '@lucide/svelte';
+	import { HttpError } from '$lib/errors';
+	import { UserService, type OAuthConsent } from '$lib/services';
+	import {
+		convertCompositeInfoToLaunchFormData,
+		convertCompositeLaunchFormDataToPayload,
+		convertEnvHeadersToRecord
+	} from '$lib/services/user/mcp';
+	import { ExternalLink, SettingsIcon, ShieldAlertIcon } from '@lucide/svelte';
+	import { onMount, tick } from 'svelte';
 
 	type Props = {
 		data: {
@@ -11,8 +22,15 @@
 	};
 
 	let { data }: Props = $props();
+	// svelte-ignore state_referenced_locally
+	let currentConsent = $state(data.consent);
+	let configureForm = $state<LaunchFormData | CompositeLaunchFormData>();
+	let configDialog = $state<ReturnType<typeof CatalogConfigureForm>>();
+	let configError = $state('');
+	let loadingConfig = $state(false);
+	let savingConfig = $state(false);
 
-	const consent = $derived(data.consent);
+	const consent = $derived(currentConsent);
 	const scopes = $derived(consent.scope?.split(' ').filter(Boolean) ?? []);
 	const showMCPAuthNotice = $derived(consent.mcpAuthRequired || consent.userHasSecondLevelOAuthed);
 	const clientCredentialSourceLabel = $derived(
@@ -100,6 +118,136 @@
 		return rows;
 	});
 
+	onMount(() => {
+		if (currentConsent.mcpConfigRequired) {
+			void loadMCPConfiguration(currentConsent);
+		}
+	});
+
+	async function loadMCPConfiguration(nextConsent: OAuthConsent) {
+		loadingConfig = true;
+		configError = '';
+		try {
+			let values: Record<string, string> = {};
+			if (nextConsent.mcpServerInstance?.id) {
+				values = await revealExistingConfiguration(() =>
+					UserService.revealMcpServerInstance(nextConsent.mcpServerInstance!.id, {
+						dontLogErrors: true
+					})
+				);
+				configureForm = {
+					headers: nextConsent.mcpServerInstance.multiUserConfig?.userDefinedHeaders?.map(
+						(header) => ({
+							...header,
+							value: values[header.key] ?? '',
+							isStatic: false
+						})
+					)
+				};
+			} else if (nextConsent.mcpServer?.id) {
+				if (nextConsent.mcpServer.manifest.runtime === 'composite') {
+					configureForm = await convertCompositeInfoToLaunchFormData(nextConsent.mcpServer);
+					return;
+				}
+
+				values = await revealExistingConfiguration(() =>
+					UserService.revealSingleOrRemoteMcpServer(nextConsent.mcpServer!.id, {
+						dontLogErrors: true
+					})
+				);
+				configureForm = {
+					envs: nextConsent.mcpServer.manifest.env?.map((env) => ({
+						...env,
+						value: values[env.key] ?? ''
+					})),
+					headers: nextConsent.mcpServer.manifest.remoteConfig?.headers?.map((header) => ({
+						...header,
+						value: values[header.key] ?? '',
+						isStatic: Boolean(header.value)
+					})),
+					url: nextConsent.mcpServer.manifest.remoteConfig?.url,
+					hostname: nextConsent.mcpServer.manifest.remoteConfig?.hostname
+				};
+			}
+		} catch (_err) {
+			configureForm = undefined;
+			configError = 'Failed to load current MCP server configuration.';
+		} finally {
+			loadingConfig = false;
+		}
+	}
+
+	async function openMCPConfiguration() {
+		if (!configureForm) {
+			await loadMCPConfiguration(consent);
+		}
+		if (!configureForm) return;
+		await tick();
+		configDialog?.open();
+	}
+
+	async function revealExistingConfiguration(
+		reveal: () => Promise<Record<string, string>>
+	): Promise<Record<string, string>> {
+		try {
+			return await reveal();
+		} catch (err) {
+			if (err instanceof HttpError && err.statusCode === 404) {
+				return {};
+			}
+			throw err;
+		}
+	}
+
+	async function saveMCPConfiguration() {
+		if (!configureForm) return;
+
+		configError = '';
+		savingConfig = true;
+		try {
+			if (consent.mcpServerInstance?.id) {
+				if (isCompositeForm(configureForm)) {
+					throw new Error('Unexpected composite configuration for MCP server instance');
+				}
+				const payload = convertEnvHeadersToRecord(undefined, configureForm.headers);
+				await UserService.configureMcpServerInstance(consent.mcpServerInstance.id, payload);
+			} else if (consent.mcpServer?.id) {
+				if (isCompositeForm(configureForm)) {
+					const payload = convertCompositeLaunchFormDataToPayload(configureForm);
+					await UserService.configureCompositeMcpServer(consent.mcpServer.id, payload);
+				} else {
+					const payload = convertEnvHeadersToRecord(configureForm.envs, configureForm.headers);
+					if (configureForm.hostname && configureForm.url) {
+						payload.__url = configureForm.url.trim();
+					}
+					await UserService.configureSingleOrRemoteMcpServer(consent.mcpServer.id, payload);
+				}
+			} else {
+				throw new Error('Missing MCP server configuration target');
+			}
+			const nextConsent = await UserService.getOAuthConsent(consent.authRequestID);
+			currentConsent = nextConsent;
+			if (nextConsent.mcpConfigRequired) {
+				await loadMCPConfiguration(nextConsent);
+				configError =
+					'Configuration was saved, but additional required configuration is still missing.';
+			} else {
+				configureForm = undefined;
+				configDialog?.close();
+			}
+		} catch (err) {
+			configError = err instanceof Error ? err.message : 'Failed to save MCP server configuration.';
+		} finally {
+			savingConfig = false;
+		}
+	}
+
+	function isCompositeForm(
+		form: LaunchFormData | CompositeLaunchFormData
+	): form is CompositeLaunchFormData {
+		return 'componentConfigs' in form;
+	}
+
 	function clientCredentialSourceLabelFor(source: OAuthConsent['clientCredentialSource']) {
 		switch (source) {
 			case 'client_id_metadata_document':
@@ -121,75 +269,124 @@
 <div class="bg-base-200 dark:bg-base-100 flex min-h-screen items-center justify-center p-4">
 	<main class="paper w-full max-w-lg overflow-hidden p-0">
 		<BetaLogo class="self-center mt-6" />
-		<h1 class="truncate text-xl font-semibold text-center">Authorize {consent.clientName}</h1>
+		<h1 class="truncate text-xl font-semibold text-center">
+			{consent.mcpConfigRequired
+				? `Configure ${consent.mcpServerName || 'MCP server'}`
+				: `Authorize ${consent.clientName}`}
+		</h1>
 
-		<section class="flex flex-col gap-5 p-4 pt-0">
-			{#if showMCPAuthNotice}
+		{#if consent.mcpConfigRequired}
+			<section class="flex flex-col gap-5 p-4 pt-0">
 				<div class="notification-info flex items-center gap-3 p-3">
-					<ShieldAlertIcon class="size-5 shrink-0" />
+					<SettingsIcon class="size-5 shrink-0" />
 					<p class="min-w-0 text-sm">
-						{#if consent.mcpAuthRequired}
-							<b class="font-semibold">{consent.mcpServerName || 'This MCP server'}</b> requires its own
-							third-party OAuth authorization. You will be redirected to the third-party OAuth provider
-							to complete the authorization.
-						{:else if consent.userHasSecondLevelOAuthed}
-							<b class="font-semibold">{consent.mcpServerName || 'This MCP server'}</b> requires its own
-							third-party OAuth authorization, and you have already authorized it.
-						{/if}
+						<b class="font-semibold">{consent.mcpServerName || 'This MCP server'}</b> needs required configuration
+						before Obot can finish authorizing this connection.
 					</p>
 				</div>
-			{/if}
 
-			<p class="text-sm">
-				{consent.clientName} wants to authenticate with Obot for an MCP server connection. If you approve,
-				Obot will redirect you back to the OAuth client that started this request.
-			</p>
-
-			<div>
-				<details class="collapse collapse-arrow border border-base-300" name="more-details-content">
-					<summary class="collapse-title text-muted-content text-xs font-medium"
-						>See details</summary
-					>
-
-					<div class="collapse-content space-y-3 overflow-y-auto default-scrollbar-thin max-h-64">
-						{#each details as detail (detail.label)}
-							<div class="grid grid-cols-[9rem_minmax(0,1fr)] gap-3 text-xs max-sm:grid-cols-1">
-								<div class="text-muted-content font-medium">{detail.label}</div>
-
-								{#if detail.type === 'text'}
-									<div class="min-w-0 {detail.valueClass ?? ''}">{detail.value}</div>
-								{:else if detail.type === 'link'}
-									<a
-										class="link flex min-w-0 items-center gap-1 break-all"
-										href={detail.value}
-										rel="external noreferrer noopener"
-									>
-										<span class="truncate break-all">{detail.value}</span>
-										<ExternalLink class="size-3 shrink-0" />
-									</a>
-								{:else}
-									<div class="flex min-w-0 flex-wrap gap-2">
-										{#each detail.values as scope, i (i)}
-											<span class="badge badge-secondary badge-xs">{scope}</span>
-										{/each}
-									</div>
-								{/if}
-							</div>
-						{/each}
+				{#if configError}
+					<p class="text-error text-sm">{configError}</p>
+				{/if}
+			</section>
+		{:else}
+			<section class="flex flex-col gap-5 p-4 pt-0">
+				{#if showMCPAuthNotice}
+					<div class="notification-info flex items-center gap-3 p-3">
+						<ShieldAlertIcon class="size-5 shrink-0" />
+						<p class="min-w-0 text-sm">
+							{#if consent.mcpAuthRequired}
+								<b class="font-semibold">{consent.mcpServerName || 'This MCP server'}</b> requires its
+								own third-party OAuth authorization. You will be redirected to the third-party OAuth provider
+								to complete the authorization.
+							{:else if consent.userHasSecondLevelOAuthed}
+								<b class="font-semibold">{consent.mcpServerName || 'This MCP server'}</b> requires its
+								own third-party OAuth authorization, and you have already authorized it.
+							{/if}
+						</p>
 					</div>
-				</details>
-			</div>
-		</section>
+				{/if}
+
+				<p class="text-sm">
+					{consent.clientName} wants to authenticate with Obot for an MCP server connection. If you approve,
+					Obot will redirect you back to the OAuth client that started this request.
+				</p>
+
+				<div>
+					<details
+						class="collapse collapse-arrow border border-base-300"
+						name="more-details-content"
+					>
+						<summary class="collapse-title text-muted-content text-xs font-medium"
+							>See details</summary
+						>
+
+						<div class="collapse-content space-y-3 overflow-y-auto default-scrollbar-thin max-h-64">
+							{#each details as detail (detail.label)}
+								<div class="grid grid-cols-[9rem_minmax(0,1fr)] gap-3 text-xs max-sm:grid-cols-1">
+									<div class="text-muted-content font-medium">{detail.label}</div>
+
+									{#if detail.type === 'text'}
+										<div class="min-w-0 {detail.valueClass ?? ''}">{detail.value}</div>
+									{:else if detail.type === 'link'}
+										<a
+											class="link flex min-w-0 items-center gap-1 break-all"
+											href={detail.value}
+											rel="external noreferrer noopener"
+										>
+											<span class="truncate break-all">{detail.value}</span>
+											<ExternalLink class="size-3 shrink-0" />
+										</a>
+									{:else}
+										<div class="flex min-w-0 flex-wrap gap-2">
+											{#each detail.values as scope, i (i)}
+												<span class="badge badge-secondary badge-xs">{scope}</span>
+											{/each}
+										</div>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					</details>
+				</div>
+			</section>
+		{/if}
 
 		<footer
 			class="border-base-300 bg-base-100 dark:bg-base-200 flex justify-end gap-3 border-t p-3 max-sm:flex-col-reverse"
 		>
 			<form method="POST" action={resolve(consent.cancelURL as `/${string}`)}>
-				<button class="btn btn-text w-full" type="submit">Cancel</button>
+				<button class="btn btn-text w-full" type="submit" disabled={savingConfig}>Cancel</button>
 			</form>
-			<form method="POST" action={resolve(consent.continueURL as `/${string}`)}>
-				<button class="btn btn-primary w-full" type="submit">Continue</button>
-			</form>
+			{#if consent.mcpConfigRequired}
+				<button
+					class="btn btn-primary flex w-full items-center gap-2"
+					type="button"
+					onclick={openMCPConfiguration}
+					disabled={loadingConfig || savingConfig}
+				>
+					<SettingsIcon class="size-4" />
+					{loadingConfig ? 'Loading...' : 'Configure'}
+				</button>
+			{:else}
+				<form method="POST" action={resolve(consent.continueURL as `/${string}`)}>
+					<button class="btn btn-primary w-full" type="submit">Continue</button>
+				</form>
+			{/if}
 		</footer>
 	</main>
 </div>
+
+<CatalogConfigureForm
+	bind:this={configDialog}
+	bind:form={configureForm}
+	name={consent.mcpServerName || 'MCP server'}
+	onSave={saveMCPConfiguration}
+	onCancel={() => configDialog?.close()}
+	loading={savingConfig}
+	error={configError}
+	cancelText="Close"
+	submitText="Save"
+	configurationTitle="Required Configuration"
+	disableOutsideClick
+/>

--- a/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
+++ b/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
@@ -14,6 +14,7 @@
 	} from '$lib/services/user/mcp';
 	import { ExternalLink, SettingsIcon, ShieldAlertIcon } from '@lucide/svelte';
 	import { onMount, tick } from 'svelte';
+	import { twMerge } from 'tailwind-merge';
 
 	type Props = {
 		data: {
@@ -269,14 +270,14 @@
 <div class="bg-base-200 dark:bg-base-100 flex min-h-screen items-center justify-center p-4">
 	<main class="paper w-full max-w-lg overflow-hidden p-0">
 		<BetaLogo class="self-center mt-6" />
-		<h1 class="truncate text-xl font-semibold text-center">
+		<h1 class="text-xl font-semibold text-center px-4">
 			{consent.mcpConfigRequired
 				? `Configure ${consent.mcpServerName || 'MCP server'}`
 				: `Authorize ${consent.clientName}`}
 		</h1>
 
 		{#if consent.mcpConfigRequired}
-			<section class="flex flex-col gap-5 p-4 pt-0">
+			<section class="flex flex-col gap-5 p-4 py-0">
 				<div class="notification-info flex items-center gap-3 p-3">
 					<SettingsIcon class="size-5 shrink-0" />
 					<p class="min-w-0 text-sm">
@@ -286,7 +287,7 @@
 				</div>
 
 				{#if configError}
-					<p class="text-error text-sm">{configError}</p>
+					<p class="text-error text-sm mt-4">{configError}</p>
 				{/if}
 			</section>
 		{:else}
@@ -353,7 +354,10 @@
 		{/if}
 
 		<footer
-			class="border-base-300 bg-base-100 dark:bg-base-200 flex justify-end gap-3 border-t p-3 max-sm:flex-col-reverse"
+			class={twMerge(
+				'border-base-300 bg-base-100 dark:bg-base-200 flex justify-end gap-3 border-t p-3 max-sm:flex-col-reverse',
+				consent.mcpConfigRequired && 'border-t-0'
+			)}
 		>
 			<form method="POST" action={resolve(consent.cancelURL as `/${string}`)}>
 				<button class="btn btn-text w-full" type="submit" disabled={savingConfig}>Cancel</button>


### PR DESCRIPTION
Before this change, when a user connected to an MCP server for the first time through an MCP client without first configuring it in the Obot UI, the connection would fail if the server had required configuration.

After this change, the user will be able to provide the required configuration during the connection.

Issue: https://github.com/obot-platform/obot/issues/7004

Demo: https://caps.thedadams.com/s/c8gxmr7wr1eyx57