### PR TITLE
fix: only check for a valid license once per day

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -46,6 +46,7 @@ var (
 		"GET /debug/triggers",
 		"GET /debug/metrics",
 		"PUT /api/license",
+		"POST /api/license",
 		"DELETE /api/license",
 		"/api/auth-providers",
 		"/api/auth-providers/",

--- a/pkg/api/handlers/license.go
+++ b/pkg/api/handlers/license.go
@@ -2,7 +2,11 @@ package handlers
 
 import (
 	"errors"
+	"net/http"
+	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	apitypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
@@ -10,15 +14,18 @@ import (
 )
 
 type LicenseHandler struct {
-	licenseProvider *license.Provider
+	licenseProvider        *license.Provider
+	manualCheckLock        sync.RWMutex
+	lastManualLicenseCheck time.Time
 }
 
 type LicenseStatus struct {
-	LicenseKey   string   `json:"licenseKey"`
-	Source       string   `json:"source"`
-	Locked       bool     `json:"locked"`
-	Enterprise   bool     `json:"enterprise"`
-	Entitlements []string `json:"entitlements"`
+	LicenseKey             string     `json:"licenseKey"`
+	Source                 string     `json:"source"`
+	Locked                 bool       `json:"locked"`
+	Enterprise             bool       `json:"enterprise"`
+	Entitlements           []string   `json:"entitlements"`
+	ManualCheckAvailableAt *time.Time `json:"manualCheckAvailableAt,omitempty"`
 }
 
 type LicenseUpdate struct {
@@ -28,6 +35,7 @@ type LicenseUpdate struct {
 const (
 	licenseKeyMask          = "****"
 	licenseKeyVisibleSuffix = 8
+	manualCheckCoolDown     = 5 * time.Minute
 )
 
 func NewLicenseHandler(licenseProvider *license.Provider) *LicenseHandler {
@@ -61,6 +69,47 @@ func (h *LicenseHandler) Update(req api.Context) error {
 	return req.Write(h.status(req))
 }
 
+func (h *LicenseHandler) CheckLicense(req api.Context) error {
+	if availableAt, ok := h.reserveManualLicenseCheck(); !ok {
+		remaining := time.Until(availableAt)
+		retryAfter := max(int((remaining+time.Second-1)/time.Second), 1)
+		req.ResponseWriter.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+		return apitypes.NewErrHTTP(http.StatusTooManyRequests, "license can only be manually checked once every 5 minutes")
+	}
+
+	if err := h.licenseProvider.Validate(req.Context()); err != nil && !errors.Is(err, license.ErrNotConfigured) {
+		return err
+	}
+
+	return req.Write(h.status(req))
+}
+
+// reserveManualLicenseCheck reserves a manual license check, returning the time at which it can be checked again and whether the reservation was successful.
+// This isn't HA-safe, but is sufficient for the current use case.
+func (h *LicenseHandler) reserveManualLicenseCheck() (time.Time, bool) {
+	h.manualCheckLock.RLock()
+	last := h.lastManualLicenseCheck
+	h.manualCheckLock.RUnlock()
+
+	now := time.Now()
+	availableAt := last.Add(manualCheckCoolDown)
+	if !last.IsZero() && now.Before(availableAt) {
+		return availableAt, false
+	}
+
+	h.manualCheckLock.Lock()
+	defer h.manualCheckLock.Unlock()
+
+	// Check again with the write lock to avoid race conditions.
+	availableAt = last.Add(manualCheckCoolDown)
+	if !last.IsZero() && now.Before(availableAt) {
+		return availableAt, false
+	}
+
+	h.lastManualLicenseCheck = now
+	return now.Add(manualCheckCoolDown), true
+}
+
 func (h *LicenseHandler) Delete(req api.Context) error {
 	if err := h.licenseProvider.RemoveLicenseKey(req.Context()); err != nil {
 		if errors.Is(err, license.ErrLicenseKeyViaConfiguration) {
@@ -75,10 +124,11 @@ func (h *LicenseHandler) Delete(req api.Context) error {
 func (h *LicenseHandler) status(req api.Context) LicenseStatus {
 	licenseKey := h.licenseProvider.LicenseKey()
 	status := LicenseStatus{
-		LicenseKey:   displayLicenseKey(licenseKey, req.UserIsAdmin()),
-		Locked:       h.licenseProvider.LicenseKeyViaConfiguration(),
-		Enterprise:   h.licenseProvider.HasValidLicense(),
-		Entitlements: h.licenseProvider.Entitlements(),
+		LicenseKey:             displayLicenseKey(licenseKey, req.UserIsAdmin()),
+		Locked:                 h.licenseProvider.LicenseKeyViaConfiguration(),
+		Enterprise:             h.licenseProvider.HasValidLicense(),
+		Entitlements:           h.licenseProvider.Entitlements(),
+		ManualCheckAvailableAt: h.manualLicenseCheckAvailableAt(),
 	}
 
 	if status.Locked {
@@ -88,6 +138,23 @@ func (h *LicenseHandler) status(req api.Context) LicenseStatus {
 	}
 
 	return status
+}
+
+func (h *LicenseHandler) manualLicenseCheckAvailableAt() *time.Time {
+	h.manualCheckLock.RLock()
+	defer h.manualCheckLock.RUnlock()
+
+	if h.lastManualLicenseCheck.IsZero() {
+		return nil
+	}
+
+	availableAt := h.lastManualLicenseCheck.Add(manualCheckCoolDown)
+	if !time.Now().Before(availableAt) {
+		return nil
+	}
+
+	availableAt = availableAt.UTC()
+	return &availableAt
 }
 
 func displayLicenseKey(licenseKey string, canViewPartial bool) string {

--- a/pkg/api/handlers/license_test.go
+++ b/pkg/api/handlers/license_test.go
@@ -1,6 +1,15 @@
 package handlers
 
-import "testing"
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	apitypes "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+)
 
 func TestDisplayLicenseKey(t *testing.T) {
 	t.Parallel()
@@ -50,5 +59,29 @@ func TestDisplayLicenseKey(t *testing.T) {
 				t.Fatalf("displayLicenseKey() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCheckLicenseCooldown(t *testing.T) {
+	t.Parallel()
+
+	handler := NewLicenseHandler(nil)
+	handler.lastManualLicenseCheck = time.Now()
+
+	recorder := httptest.NewRecorder()
+	err := handler.CheckLicense(api.Context{
+		ResponseWriter: recorder,
+		Request:        httptest.NewRequest(http.MethodPost, "/api/license", nil),
+	})
+
+	var errHTTP *apitypes.ErrHTTP
+	if !errors.As(err, &errHTTP) {
+		t.Fatalf("expected ErrHTTP, got %T: %v", err, err)
+	}
+	if errHTTP.Code != http.StatusTooManyRequests {
+		t.Fatalf("ErrHTTP.Code = %d, want %d", errHTTP.Code, http.StatusTooManyRequests)
+	}
+	if got := recorder.Header().Get("Retry-After"); got == "" {
+		t.Fatal("expected Retry-After header")
 	}
 }

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -106,6 +106,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	// License
 	mux.HandleFunc("GET /api/license", licenseHandler.Get)
 	mux.HandleFunc("PUT /api/license", licenseHandler.Update)
+	mux.HandleFunc("POST /api/license", licenseHandler.CheckLicense)
 	mux.HandleFunc("DELETE /api/license", licenseHandler.Delete)
 
 	// MCP Catalog Entries (user routes to access single-user and remote MCP servers from all sources)

--- a/pkg/license/provider.go
+++ b/pkg/license/provider.go
@@ -29,7 +29,7 @@ const (
 	// EnterpriseModelProvidersEntitlement is required to enable enterprise model providers.
 	EnterpriseModelProvidersEntitlement = "OBOT_ENTERPRISE_MODEL_PROVIDERS"
 
-	defaultPollInterval = time.Hour
+	defaultPollInterval = 24 * time.Hour
 	keygenProduct       = "18a762f2-5281-45cf-93fc-e45e2d932094"
 	keygenAccount       = "7565373b-6069-4a0b-9495-9777d9db3fd9"
 )
@@ -133,6 +133,10 @@ func (p *Provider) SetLicenseKey(ctx context.Context, licenseKey string) error {
 	return p.setLicenseKey(ctx, licenseKey, false, false)
 }
 
+func (p *Provider) Validate(ctx context.Context) error {
+	return p.update(ctx)
+}
+
 func (p *Provider) setLicenseKey(ctx context.Context, licenseKey string, viaConfiguration, allowInvalid bool) error {
 	licenseKey = strings.TrimSpace(licenseKey)
 
@@ -192,8 +196,7 @@ func (p *Provider) RemoveLicenseKey(ctx context.Context) error {
 	keygen.LicenseKey = ""
 	p.lock.Unlock()
 
-	p.update(ctx)
-	return nil
+	return p.update(ctx)
 }
 
 func (p *Provider) validate(ctx context.Context) (map[keygen.EntitlementCode]struct{}, error) {
@@ -275,12 +278,14 @@ func (p *Provider) poll(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			p.update(ctx)
+			if err := p.update(ctx); err != nil {
+				log.Warnf("license update failed: %v", err)
+			}
 		}
 	}
 }
 
-func (p *Provider) update(ctx context.Context) {
+func (p *Provider) update(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
@@ -302,10 +307,11 @@ func (p *Provider) update(ctx context.Context) {
 
 	if err != nil || !hasLicenseKey {
 		p.entitlements = nil
-		return
+		return err
 	}
 
 	p.entitlements = entitlements
+	return nil
 }
 
 func validateConfig() error {

--- a/pkg/license/provider_test.go
+++ b/pkg/license/provider_test.go
@@ -214,7 +214,9 @@ func TestUpdateRefreshesEntitlements(t *testing.T) {
 	}
 
 	entitlement = "OTHER_ENTITLEMENT"
-	provider.update(ctx)
+	if err := provider.update(ctx); err != nil {
+		t.Fatalf("expected provider update to succeed: %v", err)
+	}
 
 	if provider.hasEntitlement(EnterpriseAuthProvidersEntitlement) {
 		t.Fatal("expected old entitlement to be removed")
@@ -260,7 +262,9 @@ func TestUpdateClearsEntitlementsWhenLicenseInvalid(t *testing.T) {
 	}
 
 	invalid = true
-	provider.update(ctx)
+	if err := provider.update(ctx); err != nil {
+		t.Fatalf("expected provider update to succeed: %v", err)
+	}
 
 	if provider.HasValidLicense() {
 		t.Fatal("expected license to be marked invalid")

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -1940,6 +1940,13 @@ export async function deleteLicense(): Promise<void> {
 	await doDelete('/license');
 }
 
+export async function recheckLicense(opts?: {
+	fetch?: Fetcher;
+	dontLogErrors?: boolean;
+}): Promise<License> {
+	return (await doPost('/license', {}, opts)) as License;
+}
+
 export async function updateLicense(
 	manifest: LicenseManifest,
 	opts?: { fetch?: Fetcher; dontLogErrors?: boolean }

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -478,6 +478,7 @@ export interface License {
 	locked: boolean;
 	enterprise: boolean;
 	entitlements: string[] | null;
+	manualCheckAvailableAt?: string;
 }
 
 export interface LicenseManifest {

--- a/ui/user/src/routes/admin/license/+page.svelte
+++ b/ui/user/src/routes/admin/license/+page.svelte
@@ -6,8 +6,8 @@
 	import SensitiveInput from '$lib/components/SensitiveInput.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
 	import { AdminService } from '$lib/services';
-	import { errors, profile } from '$lib/stores';
-	import { CircleAlert, Info } from '@lucide/svelte';
+	import { errors, license as licenseStore, profile } from '$lib/stores';
+	import { CircleAlert, Info, LoaderCircle, RefreshCw } from '@lucide/svelte';
 	import { untrack } from 'svelte';
 	import { fade, slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -20,6 +20,8 @@
 
 	let showDeleteLicenseDialog = $state(false);
 	let deleting = $state(false);
+	let rechecking = $state(false);
+	let now = $state(Date.now());
 
 	let updateLicenseDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let updateLicenseKey = $state('');
@@ -27,6 +29,22 @@
 	let updateError = $state('');
 	let updateLicenseTitle = $derived(license?.licenseKey ? 'Update License Key' : 'Add License Key');
 	let isAdminReadonly = $derived(profile.current.isAdminReadonly?.());
+	let manualCheckAvailableAt = $derived(
+		license?.manualCheckAvailableAt ? new Date(license.manualCheckAvailableAt).getTime() : 0
+	);
+	let manualCheckCooldownMs = $derived(Math.max(0, manualCheckAvailableAt - now));
+	let manualCheckCooldownLabel = $derived(formatCooldown(manualCheckCooldownMs));
+
+	$effect(() => {
+		if (!manualCheckAvailableAt || manualCheckCooldownMs <= 0) return;
+
+		now = Date.now();
+		const interval = window.setInterval(() => {
+			now = Date.now();
+		}, 1000);
+
+		return () => window.clearInterval(interval);
+	});
 
 	function handleOpenUpdateLicenseDialog() {
 		if (!license || license.locked) return;
@@ -59,6 +77,29 @@
 		} finally {
 			deleting = false;
 		}
+	}
+
+	async function handleRecheckLicense() {
+		if (!license?.licenseKey || manualCheckCooldownMs > 0) return;
+		rechecking = true;
+		try {
+			license = await AdminService.recheckLicense({ dontLogErrors: true });
+			licenseStore.initialize(license);
+		} catch (err) {
+			errors.append(`Failed to recheck license: ${err}`);
+		} finally {
+			rechecking = false;
+		}
+	}
+
+	function formatCooldown(ms: number) {
+		if (ms <= 0) return '';
+
+		const totalSeconds = Math.ceil(ms / 1000);
+		const minutes = Math.floor(totalSeconds / 60);
+		const seconds = totalSeconds % 60;
+
+		return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 	}
 
 	function convertUserFriendlyEntitlements(entitlements: string[]): string[] {
@@ -125,7 +166,7 @@
 							</div>
 						</div>
 					{/if}
-					<div class="flex items-center justify-between gap-4">
+					<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 						<div class="flex flex-col gap-1">
 							<p class="text-sm font-light">License Status</p>
 							<p
@@ -146,19 +187,38 @@
 								{/if}
 							</p>
 						</div>
-						<div
-							use:tooltip={{
-								text: license.locked ? lockedLicenseMessage : undefined,
-								classes: ['text-xs']
-							}}
-						>
-							<button
-								class="btn btn-secondary"
-								onclick={handleOpenUpdateLicenseDialog}
-								disabled={license.locked || isAdminReadonly}
+						<div class="flex w-full flex-col gap-2 sm:w-fit sm:flex-row">
+							{#if license.licenseKey}
+								<button
+									class="btn btn-secondary w-full sm:w-fit"
+									onclick={handleRecheckLicense}
+									disabled={rechecking || manualCheckCooldownMs > 0 || isAdminReadonly}
+								>
+									{#if rechecking}
+										<LoaderCircle class="size-4 animate-spin" />
+									{:else}
+										<RefreshCw class="size-4" />
+									{/if}
+									{manualCheckCooldownMs > 0
+										? `Recheck in ${manualCheckCooldownLabel}`
+										: 'Recheck License'}
+								</button>
+							{/if}
+							<div
+								use:tooltip={{
+									text: license.locked ? lockedLicenseMessage : undefined,
+									classes: ['text-xs']
+								}}
+								class="w-full sm:w-fit"
 							>
-								{updateLicenseTitle}
-							</button>
+								<button
+									class="btn btn-secondary w-full sm:w-fit"
+									onclick={handleOpenUpdateLicenseDialog}
+									disabled={license.locked || isAdminReadonly}
+								>
+									{updateLicenseTitle}
+								</button>
+							</div>
 						</div>
 					</div>
 					<div class="flex flex-col gap-1">


### PR DESCRIPTION
Previously, we would check for a valid license on startup and every hour after that. This change checks on startup and once per day.

Additionally, an API endpoint is added to allow users to manually check their license once every 5 minutes.