### PR TITLE
feat: add env vars for k8s resource maximums

### DIFF
--- a/chart/templates/internal-configmap.yaml
+++ b/chart/templates/internal-configmap.yaml
@@ -48,3 +48,15 @@ data:
   {{- if .Values.mcpServerDefaults.nanobotWorkspaceSize }}
   OBOT_SERVER_MCPK8S_SETTINGS_NANOBOT_WORKSPACE_SIZE: {{ .Values.mcpServerDefaults.nanobotWorkspaceSize | quote }}
   {{- end }}
+  {{- if .Values.mcpServerDefaults.maxCPURequest }}
+  OBOT_SERVER_MCPK8S_MAX_CPUREQUEST: {{ .Values.mcpServerDefaults.maxCPURequest | quote }}
+  {{- end }}
+  {{- if .Values.mcpServerDefaults.maxCPULimit }}
+  OBOT_SERVER_MCPK8S_MAX_CPULIMIT: {{ .Values.mcpServerDefaults.maxCPULimit | quote }}
+  {{- end }}
+  {{- if .Values.mcpServerDefaults.maxMemoryRequest }}
+  OBOT_SERVER_MCPK8S_MAX_MEMORY_REQUEST: {{ .Values.mcpServerDefaults.maxMemoryRequest | quote }}
+  {{- end }}
+  {{- if .Values.mcpServerDefaults.maxMemoryLimit }}
+  OBOT_SERVER_MCPK8S_MAX_MEMORY_LIMIT: {{ .Values.mcpServerDefaults.maxMemoryLimit | quote }}
+  {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -380,6 +380,20 @@ mcpServerDefaults:
   # mcpServerDefaults.nanobotWorkspaceSize -- Size for nanobot workspace volumes (e.g., 1Gi)
   nanobotWorkspaceSize: ""
 
+  # mcpServerDefaults.maxCPURequest -- Maximum CPU request allowed for MCP server pods
+  # Also caps the built-in default CPU request when no explicit default is configured.
+  maxCPURequest: ""
+
+  # mcpServerDefaults.maxCPULimit -- Maximum CPU limit allowed for MCP server pods
+  maxCPULimit: ""
+
+  # mcpServerDefaults.maxMemoryRequest -- Maximum memory request allowed for MCP server pods
+  # Also caps the built-in default memory request when no explicit default is configured.
+  maxMemoryRequest: ""
+
+  # mcpServerDefaults.maxMemoryLimit -- Maximum memory limit allowed for MCP server pods
+  maxMemoryLimit: ""
+
 # nodeSelector -- Configure node selector for pod assignment
 nodeSelector: {}
 

--- a/docs/docs/configuration/mcp-deployments-in-kubernetes.md
+++ b/docs/docs/configuration/mcp-deployments-in-kubernetes.md
@@ -47,7 +47,7 @@ The values that are configurable, and how to change them, follow.
 #### Configurable Values
 
 - Affinity and Tolerations: can be set using the `.mcpServerDefaults.affinity` and `.mcpServerDefaults.tolerations` in Helm, or via the admin UI if not set in Helm values
-- Resources: the default value is a memory request of `400Mi` with no memory limit or CPU requests/limits. This can be set globally in Helm using the `.mcpServerDefaults.resources` value, or via the Admin UI if not set in Helm values. Individual catalog entries can also override CPU and memory requests and limits with a `resources` field; see [MCP Server GitOps](./mcp-server-gitops.md#resource-requirements).
+- Resources: the default value is a CPU request of `10m` and a memory request of `200Mi`, with no limits. Nanobot agent-backed MCP servers use a `400Mi` default memory request, and remote/composite servers use a `100Mi` default memory request. If resource maximums are configured and one of these built-in default requests is higher than the maximum, Obot uses the maximum as the default request instead. Resource defaults can be set globally in Helm using the `.mcpServerDefaults.resources` value, or via the Admin UI if not set in Helm values. Individual catalog entries can also override CPU and memory requests and limits with a `resources` field; see [MCP Server GitOps](./mcp-server-gitops.md#resource-requirements).
 - Image: the default value is `ghcr.io/obot-platform/mcp-images/stdio-wrapper:v0.24.0` and it can be changed by setting the Helm value `.config.OBOT_SERVER_MCPBASE_IMAGE`.
 - RuntimeClassName: can be set using `.mcpServerDefaults.runtimeClassName` in Helm, or via the admin UI if not set in Helm values. See [RuntimeClass](#runtimeclass) for details.
 - ImagePullSecrets: private registry credentials can be configured with static Helm `mcpImagePullSecrets` or managed image pull secrets in the admin UI. See [Image Pull Secrets](./image-pull-secrets.md).
@@ -56,9 +56,17 @@ The values that are configurable, and how to change them, follow.
 
 The configuration for affinity and tolerations applies to all MCP server Deployments across Obot and cannot be customized for individual MCP server Deployments.
 Resource requests and limits can be configured globally, and catalog entries can override individual CPU and memory requests or limits for servers created from that entry.
+Administrators can also set maximum allowed resource values for MCP server Deployments. These maximums are enforced when Obot creates or updates MCP server Deployments and when Kubernetes settings are updated through the API. Catalog entries can still be saved with higher resource values, but MCP server deployments that would exceed the maximums are blocked. Maximums also cap Obot's built-in fallback CPU and memory requests when no explicit resource defaults are configured.
 When configuration changes, it will only affect new Deployments (or restarted existing Deployments)
 from that point forward. The admin can use the UI to manually apply this configuration change to existing MCP server
 Deployments as desired.
+
+| Helm value | Environment variable | Description |
+|------------|----------------------|-------------|
+| `.mcpServerDefaults.maxCPURequest` | `OBOT_SERVER_MCPK8S_MAX_CPUREQUEST` | Maximum allowed CPU request |
+| `.mcpServerDefaults.maxCPULimit` | `OBOT_SERVER_MCPK8S_MAX_CPULIMIT` | Maximum allowed CPU limit |
+| `.mcpServerDefaults.maxMemoryRequest` | `OBOT_SERVER_MCPK8S_MAX_MEMORY_REQUEST` | Maximum allowed memory request |
+| `.mcpServerDefaults.maxMemoryLimit` | `OBOT_SERVER_MCPK8S_MAX_MEMORY_LIMIT` | Maximum allowed memory limit |
 
 ### RuntimeClass
 

--- a/docs/docs/configuration/mcp-deployments-in-kubernetes.md
+++ b/docs/docs/configuration/mcp-deployments-in-kubernetes.md
@@ -56,7 +56,7 @@ The values that are configurable, and how to change them, follow.
 
 The configuration for affinity and tolerations applies to all MCP server Deployments across Obot and cannot be customized for individual MCP server Deployments.
 Resource requests and limits can be configured globally, and catalog entries can override individual CPU and memory requests or limits for servers created from that entry.
-Administrators can also set maximum allowed resource values for MCP server Deployments. These maximums are enforced when Obot creates or updates MCP server Deployments and when Kubernetes settings are updated through the API. Catalog entries can still be saved with higher resource values, but MCP server deployments that would exceed the maximums are blocked. Maximums also cap Obot's built-in fallback CPU and memory requests when no explicit resource defaults are configured.
+Administrators can also set maximum allowed resource values for MCP server Deployments. These maximums are enforced when MCP server or catalog entry manifests are created or changed, when Obot creates an MCP server from a catalog entry at connection time, and when Kubernetes settings are updated through the API. Existing MCP servers that already exceed the configured maximums can still be connected to and started, but configuration changes to those servers are blocked until the resources are lowered below the maximums. Maximums also cap Obot's built-in fallback CPU and memory requests when no explicit resource defaults are configured.
 When configuration changes, it will only affect new Deployments (or restarted existing Deployments)
 from that point forward. The admin can use the UI to manually apply this configuration change to existing MCP server
 Deployments as desired.

--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -218,6 +218,8 @@ Values use standard Kubernetes resource quantity syntax, such as `250m`, `1`, `5
 
 When omitted, Obot uses the configured MCP server resource defaults. When specified, catalog entry resource values override the corresponding default request or limit for servers created from that catalog entry.
 
+If the Kubernetes runtime has MCP resource maximums configured, catalog entry resource values must be less than or equal to those maximums when the entry is created, updated, or refreshed from Git. If a previously-created MCP server already exceeds the current maximums, users can still connect to it, but configuration changes to that server must lower the resources below the maximums.
+
 ### Kubernetes Secret Bindings
 
 Secret bindings let you wire an env var, header, or file to a key in an externally-managed Kubernetes Secret instead of asking the user to supply the value at install time.

--- a/pkg/api/handlers/k8ssettings.go
+++ b/pkg/api/handlers/k8ssettings.go
@@ -55,7 +55,7 @@ func (h *K8sSettingsHandler) Defaults(req api.Context) error {
 
 	// Match the resources the Kubernetes backend will actually use when no
 	// explicit defaults are configured. Resource maximums cap implicit fallbacks.
-	return req.Write(convertResourceRequirements(mcp.EffectiveDefaultMCPResourceRequirementsWithMaximums(settings.Spec, k8sSettingsResourceMaximums(h.mcpSessionManager))))
+	return req.Write(convertResourceRequirements(mcp.EffectiveDefaultMCPResourceRequirementsWithMaximums(settings.Spec, h.mcpSessionManager.KubernetesResourceMaximums())))
 }
 
 func (h *K8sSettingsHandler) Update(req api.Context) error {

--- a/pkg/api/handlers/k8ssettings.go
+++ b/pkg/api/handlers/k8ssettings.go
@@ -17,10 +17,14 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-type K8sSettingsHandler struct{}
+type K8sSettingsHandler struct {
+	mcpSessionManager *mcp.SessionManager
+}
 
-func NewK8sSettingsHandler() *K8sSettingsHandler {
-	return &K8sSettingsHandler{}
+func NewK8sSettingsHandler(mcpSessionManager *mcp.SessionManager) *K8sSettingsHandler {
+	return &K8sSettingsHandler{
+		mcpSessionManager: mcpSessionManager,
+	}
 }
 
 func (h *K8sSettingsHandler) Get(req api.Context) error {
@@ -49,7 +53,9 @@ func (h *K8sSettingsHandler) Defaults(req api.Context) error {
 		return err
 	}
 
-	return req.Write(convertResourceRequirements(mcp.EffectiveDefaultMCPResourceRequirements(settings.Spec)))
+	// Match the resources the Kubernetes backend will actually use when no
+	// explicit defaults are configured. Resource maximums cap implicit fallbacks.
+	return req.Write(convertResourceRequirements(mcp.EffectiveDefaultMCPResourceRequirementsWithMaximums(settings.Spec, k8sSettingsResourceMaximums(h.mcpSessionManager))))
 }
 
 func (h *K8sSettingsHandler) Update(req api.Context) error {
@@ -169,6 +175,10 @@ func (h *K8sSettingsHandler) Update(req api.Context) error {
 			settings.Spec.NanobotAgentResources = &nanobotAgentResources
 		} else {
 			settings.Spec.NanobotAgentResources = nil
+		}
+
+		if err := validateK8sSettingsResourceMaximums(h.mcpSessionManager, settings.Spec); err != nil {
+			return err
 		}
 
 		return req.Storage.Update(req.Context(), &settings)

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -86,7 +86,7 @@ func ValidationOptionsWithResourceMaximums(sessionManager *mcp.SessionManager) v
 		return validation.Options{}
 	}
 	options := validationOptions(sessionManager.RemoteMCPURLValidationConfig())
-	options.ResourceMaximums = k8sSettingsResourceMaximums(sessionManager)
+	options.ResourceMaximums = sessionManager.KubernetesResourceMaximums()
 	return options
 }
 
@@ -107,7 +107,7 @@ func (m *MCPHandler) currentK8sSettingsHashWithImagePullSecrets(settings v1.K8sS
 	if err != nil {
 		return "", fmt.Errorf("failed to compute core resource requirements: %w", err)
 	}
-	return mcp.ComputeK8sSettingsHash(settings, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", k8sSettingsResourceMaximums(m.mcpSessionManager), imagePullSecretNames), nil
+	return mcp.ComputeK8sSettingsHash(settings, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", m.mcpSessionManager.KubernetesResourceMaximums(), imagePullSecretNames), nil
 }
 
 func (m *MCPHandler) GetEntryFromAllSources(req api.Context) error {

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -97,7 +97,7 @@ func (m *MCPHandler) currentK8sSettingsHashWithImagePullSecrets(settings v1.K8sS
 	if err != nil {
 		return "", fmt.Errorf("failed to compute core resource requirements: %w", err)
 	}
-	return mcp.ComputeK8sSettingsHash(settings, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", imagePullSecretNames), nil
+	return mcp.ComputeK8sSettingsHash(settings, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", k8sSettingsResourceMaximums(m.mcpSessionManager), imagePullSecretNames), nil
 }
 
 func (m *MCPHandler) GetEntryFromAllSources(req api.Context) error {

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -80,7 +80,8 @@ func validationOptions(remoteValidationConfig mcp.RemoteMCPURLValidationConfig) 
 	}
 }
 
-func validationOptionsWithResourceMaximums(sessionManager *mcp.SessionManager) validation.Options {
+// ValidationOptionsWithResourceMaximums builds MCP manifest validation options from the active MCP session manager.
+func ValidationOptionsWithResourceMaximums(sessionManager *mcp.SessionManager) validation.Options {
 	if sessionManager == nil {
 		return validation.Options{}
 	}
@@ -921,7 +922,7 @@ func (m *MCPHandler) GetPrompt(req api.Context) error {
 	})
 }
 
-func mcpServerOrInstanceFromConnectURL(req api.Context, id, secretBindingAllowedLabel string) (v1.MCPServer, v1.MCPServerInstance, error) {
+func mcpServerOrInstanceFromConnectURL(req api.Context, id, secretBindingAllowedLabel string, validationOptions validation.Options) (v1.MCPServer, v1.MCPServerInstance, error) {
 	switch {
 	case system.IsMCPServerInstanceID(id):
 		var instance v1.MCPServerInstance
@@ -1013,6 +1014,9 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id, secretBindingAllowed
 			manifest, err := serverManifestFromCatalogEntryManifest(false, allowMissingURL, entry.Spec.Manifest, types.MCPServerManifest{})
 			if err != nil {
 				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrBadRequest("catalog entry %s cannot be connected because it could not be converted to an MCP server: %v", id, err)
+			}
+			if err := validation.ValidateServerManifest(req.Context(), manifest, false, validationOptions); err != nil {
+				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrBadRequest("catalog entry %s cannot be connected because its MCP server manifest is invalid: %v", id, err)
 			}
 
 			// Create a new MCP server for the user.
@@ -1223,8 +1227,8 @@ func syncConnectServerRemoteConfigFromCatalogEntry(server *v1.MCPServer, entry v
 
 // MCPIDAndAudienceFromConnectURL returns the MCP server or instance name and audience based on the provided connect URL.
 // The connect URL could have an MCP server ID, server instance ID, or MCP catalog entry ID.
-func MCPIDAndAudienceFromConnectURL(req api.Context, id, secretBindingAllowedLabel string) (string, string, error) {
-	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id, secretBindingAllowedLabel)
+func MCPIDAndAudienceFromConnectURL(req api.Context, id, secretBindingAllowedLabel string, validationOptions validation.Options) (string, string, error) {
+	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id, secretBindingAllowedLabel, validationOptions)
 	if err != nil {
 		return "", "", err
 	}
@@ -1239,17 +1243,17 @@ func MCPIDAndAudienceFromConnectURL(req api.Context, id, secretBindingAllowedLab
 	}
 }
 
-func ServerForActionWithConnectID(req api.Context, id, secretBindingAllowedLabel string) (string, v1.MCPServer, mcp.ServerConfig, error) {
-	id, server, config, _, err := serverForActionWithConnectID(req, id, secretBindingAllowedLabel, false)
+func ServerForActionWithConnectID(req api.Context, id, secretBindingAllowedLabel string, validationOptions validation.Options) (string, v1.MCPServer, mcp.ServerConfig, error) {
+	id, server, config, _, err := serverForActionWithConnectID(req, id, secretBindingAllowedLabel, false, validationOptions)
 	return id, server, config, err
 }
 
-func ServerForActionWithConnectIDAllowMissingConfig(req api.Context, id, secretBindingAllowedLabel string) (string, v1.MCPServer, mcp.ServerConfig, []string, error) {
-	return serverForActionWithConnectID(req, id, secretBindingAllowedLabel, true)
+func ServerForActionWithConnectIDAllowMissingConfig(req api.Context, id, secretBindingAllowedLabel string, validationOptions validation.Options) (string, v1.MCPServer, mcp.ServerConfig, []string, error) {
+	return serverForActionWithConnectID(req, id, secretBindingAllowedLabel, true, validationOptions)
 }
 
-func serverForActionWithConnectID(req api.Context, id, secretBindingAllowedLabel string, allowMissingConfig bool) (string, v1.MCPServer, mcp.ServerConfig, []string, error) {
-	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id, secretBindingAllowedLabel)
+func serverForActionWithConnectID(req api.Context, id, secretBindingAllowedLabel string, allowMissingConfig bool, validationOptions validation.Options) (string, v1.MCPServer, mcp.ServerConfig, []string, error) {
+	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id, secretBindingAllowedLabel, validationOptions)
 	if err != nil {
 		return "", v1.MCPServer{}, mcp.ServerConfig{}, nil, err
 	}
@@ -1984,7 +1988,7 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 		return types.NewErrBadRequest("catalogEntryID is required")
 	}
 
-	if err := validation.ValidateServerManifest(req.Context(), server.Spec.Manifest, !server.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	if err := validation.ValidateServerManifest(req.Context(), server.Spec.Manifest, !server.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 	adminManagedSecretBindings := req.UserIsAdmin() && server.Spec.IsCatalogServer()
@@ -2077,7 +2081,7 @@ func (m *MCPHandler) UpdateServer(req api.Context) error {
 		return fmt.Errorf("failed to find credential: %w", err)
 	}
 
-	if err := validation.ValidateServerManifest(req.Context(), updated, !existing.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	if err := validation.ValidateServerManifest(req.Context(), updated, !existing.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 
@@ -2221,7 +2225,7 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 
 		var updateServer bool
 		if url := envVars[configURLKey]; url != "" {
-			if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, catalogEntry, url, validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+			if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, catalogEntry, url, ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 				return err
 			}
 
@@ -2248,7 +2252,7 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 			}
 			mcpServer.Spec.Manifest.RemoteConfig.URL = finalURL
 
-			if err := validation.ValidateServerManifest(req.Context(), mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+			if err := validation.ValidateServerManifest(req.Context(), mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 				return types.NewErrBadRequest("validation failed: %v", err)
 			}
 
@@ -2413,7 +2417,7 @@ func (m *MCPHandler) configureCompositeServer(req api.Context, compositeServer v
 				if remoteConfig.URL != originalURL {
 					// Capture and validate the changes
 					component.Manifest.RemoteConfig = remoteConfig
-					if err := validation.ValidateServerManifest(req.Context(), component.Manifest, false, validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+					if err := validation.ValidateServerManifest(req.Context(), component.Manifest, false, ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 						return fmt.Errorf("failed to validate server manifest %w", err)
 					}
 					server.Spec.Manifest = component.Manifest
@@ -3143,8 +3147,8 @@ func ConvertMCPServer(server v1.MCPServer, credEnv map[string]string, serverURL,
 	return converted
 }
 
-func ConfigurationTargetForConnectID(req api.Context, id, serverURL, secretBindingAllowedLabel string) (*types.MCPServer, *types.MCPServerInstance, error) {
-	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id, secretBindingAllowedLabel)
+func ConfigurationTargetForConnectID(req api.Context, id, serverURL, secretBindingAllowedLabel string, validationOptions validation.Options) (*types.MCPServer, *types.MCPServerInstance, error) {
+	server, instance, err := mcpServerOrInstanceFromConnectURL(req, id, secretBindingAllowedLabel, validationOptions)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -4097,7 +4101,7 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 		return fmt.Errorf("failed to read input: %w", err)
 	}
 
-	if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, entry, input.URL, validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, entry, input.URL, ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 		return err
 	}
 
@@ -4210,7 +4214,7 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 
 	candidate := server.DeepCopy()
 	updateServerFromCatalogEntry(candidate, entry)
-	if err := validation.ValidateServerManifest(req.Context(), candidate.Spec.Manifest, !candidate.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	if err := validation.ValidateServerManifest(req.Context(), candidate.Spec.Manifest, !candidate.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 
@@ -4236,7 +4240,7 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 		updateServerFromCatalogEntry(&latest, entry)
 
 		// Validate again in case the catalog entry changed between retries.
-		if err := validation.ValidateServerManifest(req.Context(), latest.Spec.Manifest, !latest.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+		if err := validation.ValidateServerManifest(req.Context(), latest.Spec.Manifest, !latest.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 			return types.NewErrBadRequest("validation failed: %v", err)
 		}
 		return req.Update(&latest)
@@ -4324,7 +4328,7 @@ func (m *MCPHandler) triggerCompositeUpdate(req api.Context, compositeServer v1.
 	if err != nil {
 		return err
 	}
-	if err := validation.ValidateServerManifest(req.Context(), updatedManifest, !compositeServer.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	if err := validation.ValidateServerManifest(req.Context(), updatedManifest, !compositeServer.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -80,6 +80,15 @@ func validationOptions(remoteValidationConfig mcp.RemoteMCPURLValidationConfig) 
 	}
 }
 
+func validationOptionsWithResourceMaximums(sessionManager *mcp.SessionManager) validation.Options {
+	if sessionManager == nil {
+		return validation.Options{}
+	}
+	options := validationOptions(sessionManager.RemoteMCPURLValidationConfig())
+	options.ResourceMaximums = k8sSettingsResourceMaximums(sessionManager)
+	return options
+}
+
 func (m *MCPHandler) currentImagePullSecretNames(req api.Context) ([]string, error) {
 	return mcp.CurrentImagePullSecretNames(req.Context(), req.Storage, m.mcpRuntimeBackend, m.mcpImagePullSecrets)
 }
@@ -1975,7 +1984,7 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 		return types.NewErrBadRequest("catalogEntryID is required")
 	}
 
-	if err := validation.ValidateServerManifest(req.Context(), server.Spec.Manifest, !server.Spec.IsSingleUser(), validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
+	if err := validation.ValidateServerManifest(req.Context(), server.Spec.Manifest, !server.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 	adminManagedSecretBindings := req.UserIsAdmin() && server.Spec.IsCatalogServer()
@@ -2068,19 +2077,7 @@ func (m *MCPHandler) UpdateServer(req api.Context) error {
 		return fmt.Errorf("failed to find credential: %w", err)
 	}
 
-	// Shutdown the server, even if there is no credential
-	if catalogID != "" {
-		err = m.removeMCPServer(req.Context(), existing)
-	} else if workspaceID != "" {
-		err = m.removeMCPServer(req.Context(), existing)
-	} else {
-		err = m.removeMCPServer(req.Context(), existing)
-	}
-	if err != nil {
-		return err
-	}
-
-	if err := validation.ValidateServerManifest(req.Context(), updated, !existing.Spec.IsSingleUser(), validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
+	if err := validation.ValidateServerManifest(req.Context(), updated, !existing.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 
@@ -2106,6 +2103,12 @@ func (m *MCPHandler) UpdateServer(req api.Context) error {
 	if err := validation.ValidateTemplateReferences(updated); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
+
+	// Shutdown the server only after the candidate configuration is known to be valid.
+	if err := m.removeMCPServer(req.Context(), existing); err != nil {
+		return err
+	}
+
 	// Use retry.RetryOnConflict because controllers (e.g. DetectK8sSettingsDrift,
 	// UpdateMCPServerStatus) can update this MCPServer concurrently, bumping the
 	// ResourceVersion between our read and write.
@@ -2218,7 +2221,7 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 
 		var updateServer bool
 		if url := envVars[configURLKey]; url != "" {
-			if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, catalogEntry, url, validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
+			if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, catalogEntry, url, validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 				return err
 			}
 
@@ -2245,7 +2248,7 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 			}
 			mcpServer.Spec.Manifest.RemoteConfig.URL = finalURL
 
-			if err := validation.ValidateServerManifest(req.Context(), mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser(), validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
+			if err := validation.ValidateServerManifest(req.Context(), mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 				return types.NewErrBadRequest("validation failed: %v", err)
 			}
 
@@ -2410,7 +2413,7 @@ func (m *MCPHandler) configureCompositeServer(req api.Context, compositeServer v
 				if remoteConfig.URL != originalURL {
 					// Capture and validate the changes
 					component.Manifest.RemoteConfig = remoteConfig
-					if err := validation.ValidateServerManifest(req.Context(), component.Manifest, false, validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
+					if err := validation.ValidateServerManifest(req.Context(), component.Manifest, false, validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 						return fmt.Errorf("failed to validate server manifest %w", err)
 					}
 					server.Spec.Manifest = component.Manifest
@@ -4094,7 +4097,7 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 		return fmt.Errorf("failed to read input: %w", err)
 	}
 
-	if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, entry, input.URL, validationOptions(m.mcpSessionManager.RemoteMCPURLValidationConfig())); err != nil {
+	if err := updateMCPServerURLFromCatalogEntry(req.Context(), &mcpServer, entry, input.URL, validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
 		return err
 	}
 
@@ -4205,6 +4208,12 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 		return m.triggerCompositeUpdate(req, server, entry)
 	}
 
+	candidate := server.DeepCopy()
+	updateServerFromCatalogEntry(candidate, entry)
+	if err := validation.ValidateServerManifest(req.Context(), candidate.Spec.Manifest, !candidate.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+		return types.NewErrBadRequest("validation failed: %v", err)
+	}
+
 	// Shutdown the server, even if there is no credential
 	if err := m.removeMCPServer(req.Context(), server); err != nil {
 		return err
@@ -4225,6 +4234,11 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 		}
 
 		updateServerFromCatalogEntry(&latest, entry)
+
+		// Validate again in case the catalog entry changed between retries.
+		if err := validation.ValidateServerManifest(req.Context(), latest.Spec.Manifest, !latest.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+			return types.NewErrBadRequest("validation failed: %v", err)
+		}
 		return req.Update(&latest)
 	}); err != nil {
 		return err
@@ -4309,6 +4323,9 @@ func (m *MCPHandler) triggerCompositeUpdate(req api.Context, compositeServer v1.
 	)
 	if err != nil {
 		return err
+	}
+	if err := validation.ValidateServerManifest(req.Context(), updatedManifest, !compositeServer.Spec.IsSingleUser(), validationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 
 	// Ensure the composite server's manifest is updated

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -17,9 +17,11 @@ import (
 	"github.com/obot-platform/obot/pkg/storage"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	"github.com/obot-platform/obot/pkg/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
@@ -162,6 +164,48 @@ func TestUpdateServerAliasUnscopedSharedServer(t *testing.T) {
 	var updated v1.MCPServer
 	require.NoError(t, storage.Get(context.Background(), kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: "server"}, &updated))
 	assert.Empty(t, updated.Spec.Alias)
+}
+
+func TestMCPServerOrInstanceFromConnectURLRejectsCatalogEntryResourcesAboveMaximum(t *testing.T) {
+	entry := v1.MCPServerCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "entry",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Name:           "entry",
+				ServerUserType: types.ServerUserTypeSingleUser,
+				Runtime:        types.RuntimeNPX,
+				NPXConfig: &types.NPXRuntimeConfig{
+					Package: "test-package",
+				},
+				Resources: &types.MCPResourceRequirements{
+					Requests: types.MCPResourceRequests{
+						CPU: "250m",
+					},
+				},
+			},
+		},
+	}
+	storage := newFakeStorage(t, &entry)
+
+	_, _, err := mcpServerOrInstanceFromConnectURL(api.Context{
+		ResponseWriter: httptest.NewRecorder(),
+		Request:        httptest.NewRequest(http.MethodGet, "/mcp-connect/entry", nil),
+		Storage:        storage,
+		User:           testUser("user"),
+	}, "entry", "", validation.Options{
+		ResourceMaximums: mcp.ResourceMaximums{
+			CPURequest: new(resource.MustParse("100m")),
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resources.requests.cpu 250m exceeds configured maximum 100m")
+
+	var servers v1.MCPServerList
+	require.NoError(t, storage.List(context.Background(), &servers, kclient.InNamespace(system.DefaultNamespace)))
+	assert.Empty(t, servers.Items)
 }
 
 func TestTriggerUpdateScope(t *testing.T) {

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -182,8 +182,9 @@ func TestTriggerUpdateScope(t *testing.T) {
 			Spec: v1.MCPServerCatalogEntrySpec{
 				PowerUserWorkspaceID: workspaceID,
 				Manifest: types.MCPServerCatalogEntryManifest{
-					Name:    "entry",
-					Runtime: types.RuntimeNPX,
+					Name:      "entry",
+					Runtime:   types.RuntimeNPX,
+					NPXConfig: &types.NPXRuntimeConfig{Package: "test-package"},
 				},
 			},
 		}
@@ -196,8 +197,9 @@ func TestTriggerUpdateScope(t *testing.T) {
 				UserID:                    userID,
 				MCPServerCatalogEntryName: "entry",
 				Manifest: types.MCPServerManifest{
-					Name:    "server",
-					Runtime: types.RuntimeNPX,
+					Name:      "server",
+					Runtime:   types.RuntimeNPX,
+					NPXConfig: &types.NPXRuntimeConfig{Package: "test-package"},
 				},
 			},
 			Status: v1.MCPServerStatus{NeedsUpdate: true},

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -320,6 +320,9 @@ func (h *MCPCatalogHandler) CreateEntry(req api.Context) error {
 	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, validationOptions(h.sessionManager.RemoteMCPURLValidationConfig())); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
 	}
+	if err := validateCatalogEntryResourceMaximums(k8sSettingsResourceMaximums(h.sessionManager), manifest); err != nil {
+		return err
+	}
 	// UI-created catalog entries are never git-managed, but multi-user catalog
 	// entries may still define secretBinding as part of their shared template.
 	if err := validation.ValidateSecretBindingsCatalogEntry(manifest, false, req.UserIsAdmin(), h.mcpBackend); err != nil {
@@ -399,6 +402,9 @@ func (h *MCPCatalogHandler) UpdateEntry(req api.Context) error {
 	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, validationOptions(h.sessionManager.RemoteMCPURLValidationConfig())); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
 	}
+	if err := validateCatalogEntryResourceMaximums(k8sSettingsResourceMaximums(h.sessionManager), manifest); err != nil {
+		return err
+	}
 	// UI-updated catalog entries are never git-managed at this call site. The
 	// git-sync controller reconciles git-managed entries through a separate path.
 	// Multi-user catalog entries may still define secretBinding as part of their
@@ -421,6 +427,26 @@ func (h *MCPCatalogHandler) UpdateEntry(req api.Context) error {
 	}
 
 	return req.Write(ConvertMCPServerCatalogEntry(entry, h.serverURL))
+}
+
+func validateCatalogEntryResourceMaximums(maximums mcp.ResourceMaximums, manifest types.MCPServerCatalogEntryManifest) error {
+	if maximums.Empty() || manifest.Resources == nil {
+		return nil
+	}
+
+	resources, err := mcp.CoreResourceRequirements(manifest.Resources)
+	if err != nil {
+		return types.NewErrBadRequest("failed to validate entry manifest resources: %v", err)
+	}
+	if resources == nil {
+		return nil
+	}
+
+	if err := maximums.Validate(*resources); err != nil {
+		return types.NewErrBadRequest("resource maximum validation failed: %v", err)
+	}
+
+	return nil
 }
 
 func (h *MCPCatalogHandler) DeleteEntry(req api.Context) error {

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -317,7 +317,7 @@ func (h *MCPCatalogHandler) CreateEntry(req api.Context) error {
 			return err
 		}
 	}
-	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, validationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
+	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, ValidationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
 	}
 	// UI-created catalog entries are never git-managed, but multi-user catalog
@@ -396,7 +396,7 @@ func (h *MCPCatalogHandler) UpdateEntry(req api.Context) error {
 	if manifest.ServerUserType == "" {
 		manifest.ServerUserType = types.ServerUserTypeSingleUser
 	}
-	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, validationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
+	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, ValidationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
 	}
 	// UI-updated catalog entries are never git-managed at this call site. The
@@ -1742,7 +1742,7 @@ func (h *MCPCatalogHandler) RefreshCompositeComponents(req api.Context) error {
 
 	// Validate the refreshed manifest to ensure it's still valid
 	entryGitManaged := entry.IsGitManaged()
-	if err := validation.ValidateCatalogEntryManifest(req.Context(), entry.Spec.Manifest, entryGitManaged, validationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
+	if err := validation.ValidateCatalogEntryManifest(req.Context(), entry.Spec.Manifest, entryGitManaged, ValidationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
 	}
 	// Preserve the git-managed status of the original entry when re-validating.

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -317,11 +317,8 @@ func (h *MCPCatalogHandler) CreateEntry(req api.Context) error {
 			return err
 		}
 	}
-	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, validationOptions(h.sessionManager.RemoteMCPURLValidationConfig())); err != nil {
+	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, validationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
-	}
-	if err := validateCatalogEntryResourceMaximums(k8sSettingsResourceMaximums(h.sessionManager), manifest); err != nil {
-		return err
 	}
 	// UI-created catalog entries are never git-managed, but multi-user catalog
 	// entries may still define secretBinding as part of their shared template.
@@ -399,11 +396,8 @@ func (h *MCPCatalogHandler) UpdateEntry(req api.Context) error {
 	if manifest.ServerUserType == "" {
 		manifest.ServerUserType = types.ServerUserTypeSingleUser
 	}
-	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, validationOptions(h.sessionManager.RemoteMCPURLValidationConfig())); err != nil {
+	if err := validation.ValidateCatalogEntryManifest(req.Context(), manifest, false, validationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
-	}
-	if err := validateCatalogEntryResourceMaximums(k8sSettingsResourceMaximums(h.sessionManager), manifest); err != nil {
-		return err
 	}
 	// UI-updated catalog entries are never git-managed at this call site. The
 	// git-sync controller reconciles git-managed entries through a separate path.
@@ -427,26 +421,6 @@ func (h *MCPCatalogHandler) UpdateEntry(req api.Context) error {
 	}
 
 	return req.Write(ConvertMCPServerCatalogEntry(entry, h.serverURL))
-}
-
-func validateCatalogEntryResourceMaximums(maximums mcp.ResourceMaximums, manifest types.MCPServerCatalogEntryManifest) error {
-	if maximums.Empty() || manifest.Resources == nil {
-		return nil
-	}
-
-	resources, err := mcp.CoreResourceRequirements(manifest.Resources)
-	if err != nil {
-		return types.NewErrBadRequest("failed to validate entry manifest resources: %v", err)
-	}
-	if resources == nil {
-		return nil
-	}
-
-	if err := maximums.Validate(*resources); err != nil {
-		return types.NewErrBadRequest("resource maximum validation failed: %v", err)
-	}
-
-	return nil
 }
 
 func (h *MCPCatalogHandler) DeleteEntry(req api.Context) error {
@@ -1768,7 +1742,7 @@ func (h *MCPCatalogHandler) RefreshCompositeComponents(req api.Context) error {
 
 	// Validate the refreshed manifest to ensure it's still valid
 	entryGitManaged := entry.IsGitManaged()
-	if err := validation.ValidateCatalogEntryManifest(req.Context(), entry.Spec.Manifest, entryGitManaged, validationOptions(h.sessionManager.RemoteMCPURLValidationConfig())); err != nil {
+	if err := validation.ValidateCatalogEntryManifest(req.Context(), entry.Spec.Manifest, entryGitManaged, validationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
 	}
 	// Preserve the git-managed status of the original entry when re-validating.

--- a/pkg/api/handlers/mcpcatalogs_test.go
+++ b/pkg/api/handlers/mcpcatalogs_test.go
@@ -3,11 +3,8 @@ package handlers
 import (
 	"testing"
 
-	"github.com/obot-platform/obot/apiclient/types"
-	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestNormalizeName(t *testing.T) {
@@ -286,40 +283,4 @@ func TestValidateEntryVisibleFromScope(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestValidateCatalogEntryResourceMaximums(t *testing.T) {
-	maxCPURequest := resource.MustParse("100m")
-
-	err := validateCatalogEntryResourceMaximums(mcp.ResourceMaximums{
-		CPURequest: &maxCPURequest,
-	}, types.MCPServerCatalogEntryManifest{
-		Resources: &types.MCPResourceRequirements{
-			Requests: types.MCPResourceRequests{
-				CPU: "250m",
-			},
-		},
-	})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "resource maximum validation failed: resources.requests.cpu 250m exceeds configured maximum 100m")
-
-	err = validateCatalogEntryResourceMaximums(mcp.ResourceMaximums{
-		CPURequest: &maxCPURequest,
-	}, types.MCPServerCatalogEntryManifest{
-		Resources: &types.MCPResourceRequirements{
-			Requests: types.MCPResourceRequests{
-				CPU: "50m",
-			},
-		},
-	})
-	assert.NoError(t, err)
-
-	err = validateCatalogEntryResourceMaximums(mcp.ResourceMaximums{}, types.MCPServerCatalogEntryManifest{
-		Resources: &types.MCPResourceRequirements{
-			Requests: types.MCPResourceRequests{
-				CPU: "250m",
-			},
-		},
-	})
-	assert.NoError(t, err)
 }

--- a/pkg/api/handlers/mcpcatalogs_test.go
+++ b/pkg/api/handlers/mcpcatalogs_test.go
@@ -3,8 +3,11 @@ package handlers
 import (
 	"testing"
 
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestNormalizeName(t *testing.T) {
@@ -283,4 +286,40 @@ func TestValidateEntryVisibleFromScope(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateCatalogEntryResourceMaximums(t *testing.T) {
+	maxCPURequest := resource.MustParse("100m")
+
+	err := validateCatalogEntryResourceMaximums(mcp.ResourceMaximums{
+		CPURequest: &maxCPURequest,
+	}, types.MCPServerCatalogEntryManifest{
+		Resources: &types.MCPResourceRequirements{
+			Requests: types.MCPResourceRequests{
+				CPU: "250m",
+			},
+		},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "resource maximum validation failed: resources.requests.cpu 250m exceeds configured maximum 100m")
+
+	err = validateCatalogEntryResourceMaximums(mcp.ResourceMaximums{
+		CPURequest: &maxCPURequest,
+	}, types.MCPServerCatalogEntryManifest{
+		Resources: &types.MCPResourceRequirements{
+			Requests: types.MCPResourceRequests{
+				CPU: "50m",
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	err = validateCatalogEntryResourceMaximums(mcp.ResourceMaximums{}, types.MCPServerCatalogEntryManifest{
+		Resources: &types.MCPResourceRequirements{
+			Requests: types.MCPResourceRequests{
+				CPU: "250m",
+			},
+		},
+	})
+	assert.NoError(t, err)
 }

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -105,7 +105,7 @@ func (h *Handler) ensureServerIsDeployed(req api.Context) (mcp.ServerConfig, str
 	}
 
 	connectID := mcpID
-	mcpID, mcpServer, mcpServerConfig, missingConfig, err := handlers.ServerForActionWithConnectIDAllowMissingConfig(req, mcpID, h.secretBindingAllowedLabel)
+	mcpID, mcpServer, mcpServerConfig, missingConfig, err := handlers.ServerForActionWithConnectIDAllowMissingConfig(req, mcpID, h.secretBindingAllowedLabel, handlers.ValidationOptionsWithResourceMaximums(h.mcpSessionManager))
 	if err != nil {
 		return mcp.ServerConfig{}, "", false, fmt.Errorf("failed to get mcp server config: %w", err)
 	}

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -259,7 +259,7 @@ func (h *handler) callback(req api.Context) error {
 
 	mcpID := oauthAppAuthRequest.Spec.MCPID
 	if mcpID != "" {
-		serverOrInstanceID, audience, err := handlers.MCPIDAndAudienceFromConnectURL(req, mcpID, h.oauthChecker.secretBindingAllowedLabel)
+		serverOrInstanceID, audience, err := handlers.MCPIDAndAudienceFromConnectURL(req, mcpID, h.oauthChecker.secretBindingAllowedLabel, handlers.ValidationOptionsWithResourceMaximums(h.oauthChecker.mcpSessionManager))
 		if err != nil {
 			if errHTTP := (*types.ErrHTTP)(nil); errors.As(err, &errHTTP) {
 				redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
@@ -327,7 +327,7 @@ func (h *handler) prepareOAuthConsent(req api.Context, oauthAppAuthRequest *v1.O
 	}
 
 	// Check whether the MCP server needs authentication.
-	mcpID, mcpServer, mcpServerConfig, missingConfig, err := handlers.ServerForActionWithConnectIDAllowMissingConfig(req, oauthAppAuthRequest.Spec.MCPID, h.oauthChecker.secretBindingAllowedLabel)
+	mcpID, mcpServer, mcpServerConfig, missingConfig, err := handlers.ServerForActionWithConnectIDAllowMissingConfig(req, oauthAppAuthRequest.Spec.MCPID, h.oauthChecker.secretBindingAllowedLabel, handlers.ValidationOptionsWithResourceMaximums(h.oauthChecker.mcpSessionManager))
 	if err != nil {
 		return err
 	}
@@ -417,7 +417,7 @@ func (h *handler) consent(req api.Context) error {
 		mcpServer         *types.MCPServer
 		mcpServerInstance *types.MCPServerInstance
 	)
-	mcpServer, mcpServerInstance, err = handlers.ConfigurationTargetForConnectID(req, oauthAppAuthRequest.Spec.MCPID, h.baseURL, h.oauthChecker.secretBindingAllowedLabel)
+	mcpServer, mcpServerInstance, err = handlers.ConfigurationTargetForConnectID(req, oauthAppAuthRequest.Spec.MCPID, h.baseURL, h.oauthChecker.secretBindingAllowedLabel, handlers.ValidationOptionsWithResourceMaximums(h.oauthChecker.mcpSessionManager))
 	if err != nil {
 		if oauthAppAuthRequest.Spec.ConsentMCPConfigRequired {
 			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
@@ -550,7 +550,7 @@ func (h *handler) oauthComplete(req api.Context) error {
 }
 
 func (h *handler) ensureMCPAuthComplete(req api.Context, oauthAppAuthRequest v1.OAuthAuthRequest) error {
-	mcpID, mcpServer, mcpServerConfig, err := handlers.ServerForActionWithConnectID(req, oauthAppAuthRequest.Spec.MCPID, h.oauthChecker.secretBindingAllowedLabel)
+	mcpID, mcpServer, mcpServerConfig, err := handlers.ServerForActionWithConnectID(req, oauthAppAuthRequest.Spec.MCPID, h.oauthChecker.secretBindingAllowedLabel, handlers.ValidationOptionsWithResourceMaximums(h.oauthChecker.mcpSessionManager))
 	if err != nil {
 		return err
 	}

--- a/pkg/api/handlers/mcpresourcemaximums.go
+++ b/pkg/api/handlers/mcpresourcemaximums.go
@@ -1,0 +1,25 @@
+package handlers
+
+import (
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/mcp"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+)
+
+func validateK8sSettingsResourceMaximums(sessionManager *mcp.SessionManager, settings v1.K8sSettingsSpec) error {
+	maximums := k8sSettingsResourceMaximums(sessionManager)
+	if maximums.Empty() {
+		return nil
+	}
+	if err := mcp.ValidateK8sSettingsResourceMaximums(settings, maximums); err != nil {
+		return types.NewErrBadRequest("resource maximum validation failed: %v", err)
+	}
+	return nil
+}
+
+func k8sSettingsResourceMaximums(sessionManager *mcp.SessionManager) mcp.ResourceMaximums {
+	if sessionManager == nil || !mcp.IsKubernetesBackend(sessionManager.MCPRuntimeBackend()) {
+		return mcp.ResourceMaximums{}
+	}
+	return sessionManager.ResourceMaximums()
+}

--- a/pkg/api/handlers/mcpresourcemaximums.go
+++ b/pkg/api/handlers/mcpresourcemaximums.go
@@ -7,7 +7,7 @@ import (
 )
 
 func validateK8sSettingsResourceMaximums(sessionManager *mcp.SessionManager, settings v1.K8sSettingsSpec) error {
-	maximums := k8sSettingsResourceMaximums(sessionManager)
+	maximums := sessionManager.KubernetesResourceMaximums()
 	if maximums.Empty() {
 		return nil
 	}
@@ -15,11 +15,4 @@ func validateK8sSettingsResourceMaximums(sessionManager *mcp.SessionManager, set
 		return types.NewErrBadRequest("resource maximum validation failed: %v", err)
 	}
 	return nil
-}
-
-func k8sSettingsResourceMaximums(sessionManager *mcp.SessionManager) mcp.ResourceMaximums {
-	if sessionManager == nil || !mcp.IsKubernetesBackend(sessionManager.MCPRuntimeBackend()) {
-		return mcp.ResourceMaximums{}
-	}
-	return sessionManager.ResourceMaximums()
 }

--- a/pkg/api/handlers/skills_test.go
+++ b/pkg/api/handlers/skills_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -399,6 +400,30 @@ func newFakeStorage(t *testing.T, objects ...kclient.Object) kclient.WithWatch {
 	builder := fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
 		WithObjects(objects...).
+		WithIndex(&v1.MCPServer{}, "spec.userID", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.UserID}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.mcpServerCatalogEntryName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.MCPServerCatalogEntryName}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.template", func(obj kclient.Object) []string {
+			return []string{strconv.FormatBool(obj.(*v1.MCPServer).Spec.Template)}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.compositeName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.CompositeName}
+		}).
+		WithIndex(&v1.MCPServerInstance{}, "spec.userID", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServerInstance).Spec.UserID}
+		}).
+		WithIndex(&v1.MCPServerInstance{}, "spec.mcpServerName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServerInstance).Spec.MCPServerName}
+		}).
+		WithIndex(&v1.MCPServerInstance{}, "spec.template", func(obj kclient.Object) []string {
+			return []string{strconv.FormatBool(obj.(*v1.MCPServerInstance).Spec.Template)}
+		}).
+		WithIndex(&v1.MCPServerInstance{}, "spec.compositeName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServerInstance).Spec.CompositeName}
+		}).
 		WithIndex(&v1.Skill{}, "spec.repoID", func(obj kclient.Object) []string {
 			skill := obj.(*v1.Skill)
 			if skill.Spec.RepoID == "" {

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -417,7 +417,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mux.HandleFunc("POST /api/user-default-role-settings", userDefaultRoleSettings.Set)
 
 	// K8s Settings
-	k8sSettingsHandler := handlers.NewK8sSettingsHandler()
+	k8sSettingsHandler := handlers.NewK8sSettingsHandler(services.MCPSessionManager)
 	mux.HandleFunc("GET /api/default-k8s-settings", k8sSettingsHandler.Defaults)
 	mux.HandleFunc("GET /api/k8s-settings", k8sSettingsHandler.Get)
 	mux.HandleFunc("PUT /api/k8s-settings", k8sSettingsHandler.Update)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -65,10 +65,7 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure default user role setting: %w", err)
 	}
 
-	resourceMaximums := mcp.ResourceMaximums{}
-	if mcp.IsKubernetesBackend(c.services.MCPRuntimeBackend) && c.services.MCPSessionManager != nil {
-		resourceMaximums = c.services.MCPSessionManager.ResourceMaximums()
-	}
+	resourceMaximums := c.services.MCPSessionManager.KubernetesResourceMaximums()
 	if err := ensureK8sSettings(ctx, c.services.StorageClient, c.services.PodSchedulingSettingsFromHelm, c.services.PSASettingsFromHelm, resourceMaximums); err != nil {
 		return fmt.Errorf("failed to ensure K8s settings: %w", err)
 	}
@@ -561,10 +558,7 @@ func (c *Controller) setupLocalK8sRoutes() {
 		return
 	}
 
-	resourceMaximums := mcp.ResourceMaximums{}
-	if mcp.IsKubernetesBackend(c.services.MCPRuntimeBackend) && c.services.MCPSessionManager != nil {
-		resourceMaximums = c.services.MCPSessionManager.ResourceMaximums()
-	}
+	resourceMaximums := c.services.MCPSessionManager.KubernetesResourceMaximums()
 	deploymentHandler := deployment.New(c.services.MCPServerNamespace, c.services.Router.Backend(), c.services.MCPRuntimeBackend, resourceMaximums, c.services.MCPImagePullSecrets)
 	c.services.LocalRouter.Type(&appsv1.Deployment{}).IncludeRemoved().HandlerFunc(deploymentHandler.UpdateMCPServerStatus)
 	c.services.LocalRouter.Type(&appsv1.Deployment{}).HandlerFunc(deploymentHandler.CleanupOldIDs)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/obot-platform/obot/pkg/controller/handlers/modelinfosource"
 	"github.com/obot-platform/obot/pkg/controller/handlers/provider"
 	"github.com/obot-platform/obot/pkg/controller/handlers/secret"
+	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/obot-platform/obot/pkg/serviceaccounts"
 	"github.com/obot-platform/obot/pkg/services"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -64,7 +65,11 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure default user role setting: %w", err)
 	}
 
-	if err := ensureK8sSettings(ctx, c.services.StorageClient, c.services.PodSchedulingSettingsFromHelm, c.services.PSASettingsFromHelm); err != nil {
+	resourceMaximums := mcp.ResourceMaximums{}
+	if mcp.IsKubernetesBackend(c.services.MCPRuntimeBackend) && c.services.MCPSessionManager != nil {
+		resourceMaximums = c.services.MCPSessionManager.ResourceMaximums()
+	}
+	if err := ensureK8sSettings(ctx, c.services.StorageClient, c.services.PodSchedulingSettingsFromHelm, c.services.PSASettingsFromHelm, resourceMaximums); err != nil {
 		return fmt.Errorf("failed to ensure K8s settings: %w", err)
 	}
 
@@ -374,7 +379,7 @@ func ensureDefaultUserRoleSetting(ctx context.Context, client kclient.Client) er
 // psaSettings: Pod Security Admission settings - always sourced from Helm/environment.
 //
 //	These are always applied regardless of SetViaHelm flag and cannot be modified via UI.
-func ensureK8sSettings(ctx context.Context, client kclient.Client, podSchedulingSettings *v1.K8sSettingsSpec, psaSettings *v1.PodSecurityAdmissionSettings) error {
+func ensureK8sSettings(ctx context.Context, client kclient.Client, podSchedulingSettings *v1.K8sSettingsSpec, psaSettings *v1.PodSecurityAdmissionSettings, resourceMaximums mcp.ResourceMaximums) error {
 	var k8sSettings v1.K8sSettings
 	if err := client.Get(ctx, kclient.ObjectKey{
 		Namespace: system.DefaultNamespace,
@@ -404,6 +409,10 @@ func ensureK8sSettings(ctx context.Context, client kclient.Client, podScheduling
 
 		// PSA settings are always applied from environment/Helm (independent of SetViaHelm)
 		k8sSettings.Spec.PodSecurityAdmission = psaSettings
+
+		if err := validateStartupK8sSettingsResourceMaximums(k8sSettings.Spec, resourceMaximums); err != nil {
+			return err
+		}
 
 		return client.Create(ctx, &k8sSettings)
 	} else if err != nil {
@@ -451,10 +460,21 @@ func ensureK8sSettings(ctx context.Context, client kclient.Client, podScheduling
 		needsUpdate = true
 	}
 
+	if err := validateStartupK8sSettingsResourceMaximums(k8sSettings.Spec, resourceMaximums); err != nil {
+		return err
+	}
+
 	if needsUpdate {
 		return client.Update(ctx, &k8sSettings)
 	}
 
+	return nil
+}
+
+func validateStartupK8sSettingsResourceMaximums(settings v1.K8sSettingsSpec, maximums mcp.ResourceMaximums) error {
+	if err := mcp.ValidateConfiguredK8sSettingsResourceMaximums(settings, maximums); err != nil {
+		return fmt.Errorf("configured K8s settings resource defaults exceed configured MCP Kubernetes resource maximums: %w. Increase the OBOT_SERVER_MCPK8S_MAX_* values or lower the configured K8s settings resources", err)
+	}
 	return nil
 }
 
@@ -541,7 +561,11 @@ func (c *Controller) setupLocalK8sRoutes() {
 		return
 	}
 
-	deploymentHandler := deployment.New(c.services.MCPServerNamespace, c.services.Router.Backend(), c.services.MCPRuntimeBackend, c.services.MCPImagePullSecrets)
+	resourceMaximums := mcp.ResourceMaximums{}
+	if mcp.IsKubernetesBackend(c.services.MCPRuntimeBackend) && c.services.MCPSessionManager != nil {
+		resourceMaximums = c.services.MCPSessionManager.ResourceMaximums()
+	}
+	deploymentHandler := deployment.New(c.services.MCPServerNamespace, c.services.Router.Backend(), c.services.MCPRuntimeBackend, resourceMaximums, c.services.MCPImagePullSecrets)
 	c.services.LocalRouter.Type(&appsv1.Deployment{}).IncludeRemoved().HandlerFunc(deploymentHandler.UpdateMCPServerStatus)
 	c.services.LocalRouter.Type(&appsv1.Deployment{}).HandlerFunc(deploymentHandler.CleanupOldIDs)
 

--- a/pkg/controller/handlers/deployment/deployment.go
+++ b/pkg/controller/handlers/deployment/deployment.go
@@ -21,15 +21,17 @@ type Handler struct {
 	mcpNamespace           string
 	storageClient          kclient.Client
 	mcpRuntimeBackend      string
+	resourceMaximums       mcp.ResourceMaximums
 	mcpImagePullSecrets    []string
 }
 
-func New(mcpNamespace string, storageClient kclient.Client, mcpRuntimeBackend string, mcpImagePullSecrets []string) *Handler {
+func New(mcpNamespace string, storageClient kclient.Client, mcpRuntimeBackend string, resourceMaximums mcp.ResourceMaximums, mcpImagePullSecrets []string) *Handler {
 	return &Handler{
 		mcpDeploymentNamespace: mcpNamespace,
 		mcpNamespace:           system.DefaultNamespace,
 		storageClient:          storageClient,
 		mcpRuntimeBackend:      mcpRuntimeBackend,
+		resourceMaximums:       resourceMaximums,
 		mcpImagePullSecrets:    mcpImagePullSecrets,
 	}
 }
@@ -132,7 +134,7 @@ func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) e
 			return fmt.Errorf("failed to compute core resource requirements: %w", err)
 		}
 
-		currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", imagePullSecretNames)
+		currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", h.resourceMaximums, imagePullSecretNames)
 
 		if k8sUpdateNeeded := mcpServer.Status.K8sSettingsHash != currentHash; k8sUpdateNeeded != mcpServer.Status.NeedsK8sUpdate {
 			mcpServer.Status.NeedsK8sUpdate = k8sUpdateNeeded

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -95,16 +95,21 @@ func (h *Handler) revealCatalogCredential(ctx context.Context, catalogName, sour
 
 func New(defaultCatalogPath, defaultSystemCatalogPath string, gatewayClient *gclient.Client, accessControlRuleHelper *accesscontrolrule.Helper, mcpSessionManager *mcp.SessionManager) *Handler {
 	remoteURLValidationConfig := mcpSessionManager.RemoteMCPURLValidationConfig()
+	validationOptions := validation.Options{
+		RemoteMCPURLValidationConfig: remoteURLValidationConfig,
+	}
+	if mcp.IsKubernetesBackend(mcpSessionManager.MCPRuntimeBackend()) {
+		validationOptions.ResourceMaximums = mcpSessionManager.ResourceMaximums()
+	}
+
 	return &Handler{
-		defaultCatalogPath:       defaultCatalogPath,
-		defaultSystemCatalogPath: defaultSystemCatalogPath,
-		gatewayClient:            gatewayClient,
-		httpClient:               safehttp.NewClient(!remoteURLValidationConfig.AllowLocalhostMCP, !remoteURLValidationConfig.AllowPrivateIPMCP, !remoteURLValidationConfig.AllowLinkLocalMCP),
-		accessControlRuleHelper:  accessControlRuleHelper,
-		remoteURLValidationConfig: validation.Options{
-			RemoteMCPURLValidationConfig: remoteURLValidationConfig,
-		},
-		mcpBackend: mcpSessionManager.MCPRuntimeBackend(),
+		defaultCatalogPath:        defaultCatalogPath,
+		defaultSystemCatalogPath:  defaultSystemCatalogPath,
+		gatewayClient:             gatewayClient,
+		httpClient:                safehttp.NewClient(!remoteURLValidationConfig.AllowLocalhostMCP, !remoteURLValidationConfig.AllowPrivateIPMCP, !remoteURLValidationConfig.AllowLinkLocalMCP),
+		accessControlRuleHelper:   accessControlRuleHelper,
+		remoteURLValidationConfig: validationOptions,
+		mcpBackend:                mcpSessionManager.MCPRuntimeBackend(),
 	}
 }
 

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -98,9 +98,7 @@ func New(defaultCatalogPath, defaultSystemCatalogPath string, gatewayClient *gcl
 	validationOptions := validation.Options{
 		RemoteMCPURLValidationConfig: remoteURLValidationConfig,
 	}
-	if mcp.IsKubernetesBackend(mcpSessionManager.MCPRuntimeBackend()) {
-		validationOptions.ResourceMaximums = mcpSessionManager.ResourceMaximums()
-	}
+	validationOptions.ResourceMaximums = mcpSessionManager.KubernetesResourceMaximums()
 
 	return &Handler{
 		defaultCatalogPath:        defaultCatalogPath,

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -247,10 +247,7 @@ func (h *Handler) DetectK8sSettingsDrift(req router.Request, _ router.Response) 
 		return fmt.Errorf("failed to compute core resource requirements: %w", err)
 	}
 
-	resourceMaximums := mcp.ResourceMaximums{}
-	if mcp.IsKubernetesBackend(h.mcpRuntimeBackend) {
-		resourceMaximums = h.mcpSessionManager.ResourceMaximums()
-	}
+	resourceMaximums := h.mcpSessionManager.KubernetesResourceMaximums()
 	currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "", resourceMaximums, imagePullSecretNames)
 	shouldSetNeedsK8sUpdate := server.Status.K8sSettingsHash != currentHash && !server.Status.NeedsK8sUpdate
 

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -247,7 +247,11 @@ func (h *Handler) DetectK8sSettingsDrift(req router.Request, _ router.Response) 
 		return fmt.Errorf("failed to compute core resource requirements: %w", err)
 	}
 
-	currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "", imagePullSecretNames)
+	resourceMaximums := mcp.ResourceMaximums{}
+	if mcp.IsKubernetesBackend(h.mcpRuntimeBackend) {
+		resourceMaximums = h.mcpSessionManager.ResourceMaximums()
+	}
+	currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "", resourceMaximums, imagePullSecretNames)
 	shouldSetNeedsK8sUpdate := server.Status.K8sSettingsHash != currentHash && !server.Status.NeedsK8sUpdate
 
 	if shouldSetNeedsK8sUpdate {

--- a/pkg/controller/k8ssettings_test.go
+++ b/pkg/controller/k8ssettings_test.go
@@ -1,0 +1,80 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/mcp"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestEnsureK8sSettingsRejectsExistingConfiguredResourcesAboveStartupMaximum(t *testing.T) {
+	ctx := t.Context()
+	client := newFakeClient(t, &v1.K8sSettings{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      system.K8sSettingsName,
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.K8sSettingsSpec{
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+		},
+	})
+
+	err := ensureK8sSettings(ctx, client, nil, nil, mcp.ResourceMaximums{
+		MemoryRequest: new(resource.MustParse("256Mi")),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "configured K8s settings resource defaults exceed configured MCP Kubernetes resource maximums")
+	require.Contains(t, err.Error(), "resources.requests.memory 512Mi exceeds configured maximum 256Mi")
+}
+
+func TestEnsureK8sSettingsRejectsHelmConfiguredResourcesAboveStartupMaximum(t *testing.T) {
+	ctx := t.Context()
+	client := newFakeClient(t)
+
+	err := ensureK8sSettings(ctx, client, &v1.K8sSettingsSpec{
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	}, nil, mcp.ResourceMaximums{
+		MemoryRequest: new(resource.MustParse("256Mi")),
+	})
+	require.Error(t, err)
+
+	var settings v1.K8sSettings
+	err = client.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      system.K8sSettingsName,
+	}, &settings)
+	require.True(t, apierrors.IsNotFound(err), "expected invalid Helm K8s settings to fail before create, got %v", err)
+}
+
+func TestEnsureK8sSettingsAllowsStartupMaximumsWithoutConfiguredResources(t *testing.T) {
+	ctx := t.Context()
+	client := newFakeClient(t)
+
+	err := ensureK8sSettings(ctx, client, nil, nil, mcp.ResourceMaximums{
+		MemoryRequest: new(resource.MustParse("1Mi")),
+	})
+	require.NoError(t, err)
+
+	var settings v1.K8sSettings
+	require.NoError(t, client.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      system.K8sSettingsName,
+	}, &settings))
+	require.Nil(t, settings.Spec.Resources)
+	require.Nil(t, settings.Spec.NanobotAgentResources)
+}

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -534,11 +534,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 	// Fetch K8s settings
 	k8sSettings := k.getK8sSettings(ctx)
 
-	// Make sure that the resources are under the configured maximums
 	mcpResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, k.resourceMaximums)
-	if err := validateServerResourceMaximums(server, mcpResources, k.resourceMaximums); err != nil {
-		return nil, err
-	}
 
 	effectiveImagePullSecrets, err := k.effectiveImagePullSecretNames(ctx)
 	if err != nil {
@@ -1206,14 +1202,6 @@ func EffectiveDefaultMCPResourceRequirementsWithMaximums(k8sSettings v1.K8sSetti
 	return mcpContainerResourcesWithMaximums(nil, types.RuntimeNPX, false, k8sSettings, maximums)
 }
 
-func validateServerResourceMaximums(server ServerConfig, resources corev1.ResourceRequirements, maximums ResourceMaximums) error {
-	if server.SystemMCPServer {
-		// Maximums are not enforced for SystemMCPServers
-		return nil
-	}
-	return maximums.Validate(resources)
-}
-
 func withServerResourceOverrides(defaults corev1.ResourceRequirements, overrides *corev1.ResourceRequirements) corev1.ResourceRequirements {
 	if overrides == nil || len(overrides.Requests) == 0 && len(overrides.Limits) == 0 {
 		return defaults
@@ -1284,11 +1272,6 @@ func (k *kubernetesBackend) restartServer(ctx context.Context, server ServerConf
 	// Compute K8s settings hash
 	k8sSettingsHash := ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", k.resourceMaximums, effectiveImagePullSecrets)
 	desiredResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, k.resourceMaximums)
-
-	// Make sure that the resources are under the configured maximums
-	if err := validateServerResourceMaximums(server, desiredResources, k.resourceMaximums); err != nil {
-		return err
-	}
 
 	// Get PSA enforce level for security context decisions
 	psaLevel := GetPSAEnforceLevelFromSpec(k8sSettings)

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -65,6 +65,7 @@ type kubernetesBackend struct {
 	auditLogsFlushIntervalSeconds int
 	authEnabled                   bool
 	obotClient                    kclient.Client
+	resourceMaximums              ResourceMaximums
 	deploymentCacheMu             sync.RWMutex
 	deploymentCache               map[string]*kubernetesDeploymentCacheEntry
 }
@@ -74,7 +75,7 @@ type kubernetesDeploymentCacheEntry struct {
 	podName string
 }
 
-func newKubernetesBackend(authEnabled bool, clientset *kubernetes.Clientset, client, cachedClient, obotClient kclient.WithWatch, opts Options) backend {
+func newKubernetesBackend(authEnabled bool, clientset *kubernetes.Clientset, client, cachedClient, obotClient kclient.WithWatch, opts Options, resourceMaximums ResourceMaximums) backend {
 	var serviceFQDN string
 	if opts.ServiceName != "" && opts.ServiceNamespace != "" {
 		serviceFQDN = fmt.Sprintf("%s.%s.svc.%s", opts.ServiceName, opts.ServiceNamespace, opts.MCPClusterDomain)
@@ -94,6 +95,7 @@ func newKubernetesBackend(authEnabled bool, clientset *kubernetes.Clientset, cli
 		auditLogsBatchSize:            opts.MCPAuditLogsPersistBatchSize,
 		auditLogsFlushIntervalSeconds: opts.MCPAuditLogPersistIntervalSeconds,
 		obotClient:                    obotClient,
+		resourceMaximums:              resourceMaximums,
 		deploymentCache:               map[string]*kubernetesDeploymentCacheEntry{},
 	}
 }
@@ -532,12 +534,18 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 	// Fetch K8s settings
 	k8sSettings := k.getK8sSettings(ctx)
 
+	// Make sure that the resources are under the configured maximums
+	mcpResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, k.resourceMaximums)
+	if err := validateServerResourceMaximums(server, mcpResources, k.resourceMaximums); err != nil {
+		return nil, err
+	}
+
 	effectiveImagePullSecrets, err := k.effectiveImagePullSecretNames(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get effective image pull secrets: %w", err)
 	}
 
-	annotations["obot.ai/k8s-settings-hash"] = ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", effectiveImagePullSecrets)
+	annotations["obot.ai/k8s-settings-hash"] = ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", k.resourceMaximums, effectiveImagePullSecrets)
 
 	// Get PSA enforce level for security context decisions
 	psaLevel := GetPSAEnforceLevelFromSpec(k8sSettings)
@@ -734,7 +742,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 			Name:          portName,
 			ContainerPort: int32(port),
 		}},
-		Resources:       mcpContainerResources(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings),
+		Resources:       mcpResources,
 		SecurityContext: getContainerSecurityContext(psaLevel),
 		Command:         command,
 		Args:            args,
@@ -1147,26 +1155,63 @@ func (k *kubernetesBackend) deleteDeploymentCache(mcpServerName string) {
 }
 
 func mcpContainerResources(serverSpecificResources *corev1.ResourceRequirements, runtime types.Runtime, nanobotAgent bool, k8sSettings v1.K8sSettingsSpec) corev1.ResourceRequirements {
-	var defaults corev1.ResourceRequirements
-	if runtime == types.RuntimeRemote || runtime == types.RuntimeComposite {
-		defaults = memoryRequestResources(remoteMemoryRequest)
-	} else if nanobotAgent {
-		if k8sSettings.NanobotAgentResources != nil {
-			defaults = *k8sSettings.NanobotAgentResources
-		} else {
-			defaults = memoryRequestResources(defaultAgentMemoryRequest)
-		}
-	} else if k8sSettings.Resources != nil {
-		defaults = *k8sSettings.Resources
-	} else {
-		defaults = memoryRequestResources(defaultMCPMemoryRequest)
-	}
+	return mcpContainerResourcesWithMaximums(serverSpecificResources, runtime, nanobotAgent, k8sSettings, ResourceMaximums{})
+}
 
-	return withServerResourceOverrides(withDefaultCPURequest(defaults), serverSpecificResources)
+func mcpContainerResourcesWithMaximums(serverSpecificResources *corev1.ResourceRequirements, runtime types.Runtime, nanobotAgent bool, k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) corev1.ResourceRequirements {
+	defaults, implicitMemoryRequest := mcpContainerDefaultResources(runtime, nanobotAgent, k8sSettings)
+	defaults = withImplicitResourceMaximums(defaults, implicitMemoryRequest, maximums)
+	return withServerResourceOverrides(defaults, serverSpecificResources)
+}
+
+// mcpContainerDefaultResources returns the default resource block and whether
+// its memory request came from a built-in fallback. Only built-in fallbacks are
+// capped by ResourceMaximums; explicit K8s settings remain explicit and are
+// validated separately.
+func mcpContainerDefaultResources(runtime types.Runtime, nanobotAgent bool, k8sSettings v1.K8sSettingsSpec) (corev1.ResourceRequirements, bool) {
+	if runtime == types.RuntimeRemote || runtime == types.RuntimeComposite {
+		return memoryRequestResources(remoteMemoryRequest), true
+	}
+	if nanobotAgent {
+		if k8sSettings.NanobotAgentResources != nil {
+			return *k8sSettings.NanobotAgentResources, false
+		}
+		return memoryRequestResources(defaultAgentMemoryRequest), true
+	}
+	if k8sSettings.Resources != nil {
+		return *k8sSettings.Resources, false
+	}
+	return memoryRequestResources(defaultMCPMemoryRequest), true
+}
+
+// withImplicitResourceMaximums lowers only implicit default requests to the
+// configured maximums. It intentionally leaves explicit K8s settings and
+// server-specific overrides alone so over-limit explicit values fail validation
+// instead of being silently rewritten.
+func withImplicitResourceMaximums(resources corev1.ResourceRequirements, implicitMemoryRequest bool, maximums ResourceMaximums) corev1.ResourceRequirements {
+	result := *resources.DeepCopy()
+	if implicitMemoryRequest && maximums.MemoryRequest != nil {
+		if actual, ok := result.Requests[corev1.ResourceMemory]; ok && actual.Cmp(*maximums.MemoryRequest) > 0 {
+			result.Requests[corev1.ResourceMemory] = *maximums.MemoryRequest
+		}
+	}
+	return withDefaultCPURequest(result, maximums.CPURequest)
 }
 
 func EffectiveDefaultMCPResourceRequirements(k8sSettings v1.K8sSettingsSpec) corev1.ResourceRequirements {
 	return mcpContainerResources(nil, types.RuntimeNPX, false, k8sSettings)
+}
+
+func EffectiveDefaultMCPResourceRequirementsWithMaximums(k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) corev1.ResourceRequirements {
+	return mcpContainerResourcesWithMaximums(nil, types.RuntimeNPX, false, k8sSettings, maximums)
+}
+
+func validateServerResourceMaximums(server ServerConfig, resources corev1.ResourceRequirements, maximums ResourceMaximums) error {
+	if server.SystemMCPServer {
+		// Maximums are not enforced for SystemMCPServers
+		return nil
+	}
+	return maximums.Validate(resources)
 }
 
 func withServerResourceOverrides(defaults corev1.ResourceRequirements, overrides *corev1.ResourceRequirements) corev1.ResourceRequirements {
@@ -1208,13 +1253,17 @@ func nanobotShimContainerResources() corev1.ResourceRequirements {
 	}
 }
 
-func withDefaultCPURequest(resources corev1.ResourceRequirements) corev1.ResourceRequirements {
+func withDefaultCPURequest(resources corev1.ResourceRequirements, maximum *resource.Quantity) corev1.ResourceRequirements {
 	result := *resources.DeepCopy()
 	if _, ok := result.Requests[corev1.ResourceCPU]; !ok {
 		if result.Requests == nil {
 			result.Requests = corev1.ResourceList{}
 		}
-		result.Requests[corev1.ResourceCPU] = defaultCPURequest
+		cpuRequest := defaultCPURequest
+		if maximum != nil && cpuRequest.Cmp(*maximum) > 0 {
+			cpuRequest = *maximum
+		}
+		result.Requests[corev1.ResourceCPU] = cpuRequest
 	}
 	return result
 }
@@ -1233,8 +1282,13 @@ func (k *kubernetesBackend) restartServer(ctx context.Context, server ServerConf
 	}
 
 	// Compute K8s settings hash
-	k8sSettingsHash := ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", effectiveImagePullSecrets)
-	desiredResources := mcpContainerResources(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings)
+	k8sSettingsHash := ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", k.resourceMaximums, effectiveImagePullSecrets)
+	desiredResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, k.resourceMaximums)
+
+	// Make sure that the resources are under the configured maximums
+	if err := validateServerResourceMaximums(server, desiredResources, k.resourceMaximums); err != nil {
+		return err
+	}
 
 	// Get PSA enforce level for security context decisions
 	psaLevel := GetPSAEnforceLevelFromSpec(k8sSettings)
@@ -1832,7 +1886,7 @@ func getPodSecurityContextPatch(psaLevel PSAEnforceLevel) map[string]any {
 // MCP Deployment needs to be updated. The API/status field is still named
 // K8sSettingsHash, but managed image pull secret names are part of the same
 // v1 drift path.
-func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverSpecificResources *corev1.ResourceRequirements, serverRuntime types.Runtime, nanobotAgentServer bool, imagePullSecretNames []string) string {
+func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverSpecificResources *corev1.ResourceRequirements, serverRuntime types.Runtime, nanobotAgentServer bool, maximums ResourceMaximums, imagePullSecretNames []string) string {
 	var buf bytes.Buffer
 
 	// Hash affinity
@@ -1847,9 +1901,11 @@ func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverSpecificResources
 		buf.Write(tolerationsJSON)
 	}
 
-	// Resources are server specific
+	// Resources are server specific. Hash the same effective resources that are
+	// applied to the Deployment, including ResourceMaximums capping implicit
+	// built-in defaults.
 	// Ignoring errors from JSON encoding since the inputs are well-defined structs that should always marshal successfully
-	_ = json.NewEncoder(&buf).Encode(mcpContainerResources(serverSpecificResources, serverRuntime, nanobotAgentServer, settings))
+	_ = json.NewEncoder(&buf).Encode(mcpContainerResourcesWithMaximums(serverSpecificResources, serverRuntime, nanobotAgentServer, settings, maximums))
 
 	// Hash runtimeClassName
 	if settings.RuntimeClassName != nil && *settings.RuntimeClassName != "" {
@@ -2075,7 +2131,7 @@ func (k *kubernetesBackend) CheckCapacity(ctx context.Context, server ServerConf
 
 	memoryRequest := resource.MustParse("0")
 	cpuRequest := resource.MustParse("0")
-	resources := mcpContainerResources(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings)
+	resources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, k.resourceMaximums)
 	if mem, ok := resources.Requests[corev1.ResourceMemory]; ok {
 		memoryRequest = mem
 	}

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -618,27 +618,6 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 	}
 }
 
-func TestK8sObjectsRejectsNormalServerResourcesAboveMaximum(t *testing.T) {
-	k := newTestKubernetesBackend(t)
-	k.resourceMaximums = ResourceMaximums{CPURequest: new(resource.MustParse("100m"))}
-
-	server := testK8sServerConfig()
-	server.Resources = &corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU: resource.MustParse("250m"),
-		},
-	}
-
-	_, err := k.k8sObjects(t.Context(), server, nil)
-	if err == nil {
-		t.Fatal("expected resources above maximum to fail")
-	}
-	var exceeded *ResourceMaximumExceededError
-	if !errors.As(err, &exceeded) {
-		t.Fatalf("expected ResourceMaximumExceededError, got %T: %v", err, err)
-	}
-}
-
 func TestK8sObjectsAllowsSystemServerResourcesAboveMaximum(t *testing.T) {
 	k := newTestKubernetesBackend(t)
 	k.resourceMaximums = ResourceMaximums{CPURequest: new(resource.MustParse("100m"))}

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -43,32 +43,32 @@ func TestComputeK8sSettingsHashUsesServerSpecificResources(t *testing.T) {
 		},
 	}
 
-	baseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeNPX, false, nil)
-	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, false, nil); got == baseHash {
+	baseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil)
+	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil); got == baseHash {
 		t.Fatalf("regular server hash = %s, want it to differ when default resources are set", got)
 	}
 
-	remoteBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeRemote, false, nil)
-	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeRemote, false, nil); got != remoteBaseHash {
+	remoteBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeRemote, false, ResourceMaximums{}, nil)
+	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeRemote, false, ResourceMaximums{}, nil); got != remoteBaseHash {
 		t.Fatalf("remote server hash = %s, want %s", got, remoteBaseHash)
 	}
 
-	compositeBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeComposite, false, nil)
-	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeComposite, false, nil); got != compositeBaseHash {
+	compositeBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeComposite, false, ResourceMaximums{}, nil)
+	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeComposite, false, ResourceMaximums{}, nil); got != compositeBaseHash {
 		t.Fatalf("composite server hash = %s, want %s", got, compositeBaseHash)
 	}
 	if compositeBaseHash != remoteBaseHash {
 		t.Fatalf("composite base hash = %s, want remote base hash %s", compositeBaseHash, remoteBaseHash)
 	}
 
-	nanobotBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeNPX, true, nil)
-	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, true, nil); got != nanobotBaseHash {
+	nanobotBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeNPX, true, ResourceMaximums{}, nil)
+	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, true, ResourceMaximums{}, nil); got != nanobotBaseHash {
 		t.Fatalf("nanobot agent server hash = %s, want %s before nanobot-only settings are set", got, nanobotBaseHash)
 	}
-	if got := ComputeK8sSettingsHash(nanobotSettings, nil, types.RuntimeNPX, false, nil); got != ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, false, nil) {
+	if got := ComputeK8sSettingsHash(nanobotSettings, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil); got != ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil) {
 		t.Fatalf("non-nanobot hash = %s, want nanobot-only settings ignored", got)
 	}
-	if got := ComputeK8sSettingsHash(nanobotSettings, nil, types.RuntimeNPX, true, nil); got == nanobotBaseHash {
+	if got := ComputeK8sSettingsHash(nanobotSettings, nil, types.RuntimeNPX, true, ResourceMaximums{}, nil); got == nanobotBaseHash {
 		t.Fatalf("nanobot hash = %s, want it to differ when nanobot-only settings are set", got)
 	}
 
@@ -77,8 +77,19 @@ func TestComputeK8sSettingsHashUsesServerSpecificResources(t *testing.T) {
 			corev1.ResourceMemory: resource.MustParse("768Mi"),
 		},
 	}
-	if got := ComputeK8sSettingsHash(baseSettings, serverResources, types.RuntimeNPX, false, nil); got == baseHash {
+	if got := ComputeK8sSettingsHash(baseSettings, serverResources, types.RuntimeNPX, false, ResourceMaximums{}, nil); got == baseHash {
 		t.Fatalf("server-specific resources hash = %s, want it to differ from default resource hash", got)
+	}
+}
+
+func TestComputeK8sSettingsHashUsesImplicitResourceMaximums(t *testing.T) {
+	baseHash := ComputeK8sSettingsHash(v1.K8sSettingsSpec{}, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil)
+	cappedHash := ComputeK8sSettingsHash(v1.K8sSettingsSpec{}, nil, types.RuntimeNPX, false, ResourceMaximums{
+		CPURequest:    new(resource.MustParse("5m")),
+		MemoryRequest: new(resource.MustParse("128Mi")),
+	}, nil)
+	if cappedHash == baseHash {
+		t.Fatalf("capped hash = %s, want it to differ from uncapped implicit defaults", cappedHash)
 	}
 }
 
@@ -288,7 +299,7 @@ func TestNewKubernetesBackend_ServiceFQDN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			backend := newKubernetesBackend(true, nil, nil, nil, nil, Options{ServiceName: tt.serviceName, ServiceNamespace: tt.serviceNamespace, MCPClusterDomain: tt.clusterDomain})
+			backend := newKubernetesBackend(true, nil, nil, nil, nil, Options{ServiceName: tt.serviceName, ServiceNamespace: tt.serviceNamespace, MCPClusterDomain: tt.clusterDomain}, ResourceMaximums{})
 			k := backend.(*kubernetesBackend)
 			if k.serviceFQDN != tt.expectedFQDN {
 				t.Errorf("newKubernetesBackend() serviceFQDN = %v, want %v", k.serviceFQDN, tt.expectedFQDN)
@@ -455,6 +466,8 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 		name              string
 		server            ServerConfig
 		settings          *v1.K8sSettings
+		resourceMaximums  ResourceMaximums
+		wantCPURequest    string
 		wantMemoryRequest string
 		wantMemoryLimit   string
 	}{
@@ -466,12 +479,37 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 			wantMemoryRequest: "200Mi",
 		},
 		{
+			name: "non-agent implicit defaults are capped by maximums",
+			server: ServerConfig{
+				Runtime: types.RuntimeContainerized,
+			},
+			resourceMaximums: ResourceMaximums{
+				CPURequest:    new(resource.MustParse("5m")),
+				MemoryRequest: new(resource.MustParse("128Mi")),
+			},
+			wantCPURequest:    "5m",
+			wantMemoryRequest: "128Mi",
+		},
+		{
 			name: "nanobot agent default requests 400Mi memory",
 			server: ServerConfig{
 				Runtime:          types.RuntimeContainerized,
 				NanobotAgentName: "agent-1",
 			},
 			wantMemoryRequest: "400Mi",
+		},
+		{
+			name: "nanobot agent implicit defaults are capped by maximums",
+			server: ServerConfig{
+				Runtime:          types.RuntimeContainerized,
+				NanobotAgentName: "agent-1",
+			},
+			resourceMaximums: ResourceMaximums{
+				CPURequest:    new(resource.MustParse("5m")),
+				MemoryRequest: new(resource.MustParse("256Mi")),
+			},
+			wantCPURequest:    "5m",
+			wantMemoryRequest: "256Mi",
 		},
 		{
 			name: "nanobot agent uses dedicated resources",
@@ -531,6 +569,7 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			k := newTestKubernetesBackend(t)
+			k.resourceMaximums = tt.resourceMaximums
 			if tt.settings != nil {
 				scheme := runtime.NewScheme()
 				if err := v1.AddToScheme(scheme); err != nil {
@@ -561,8 +600,12 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 				t.Fatalf("memory request = %q, want %q", memoryRequest.String(), tt.wantMemoryRequest)
 			}
 			cpuRequest := container.Resources.Requests[corev1.ResourceCPU]
-			if cpuRequest.String() != "10m" {
-				t.Fatalf("CPU request = %q, want %q", cpuRequest.String(), "10m")
+			wantCPURequest := tt.wantCPURequest
+			if wantCPURequest == "" {
+				wantCPURequest = "10m"
+			}
+			if cpuRequest.String() != wantCPURequest {
+				t.Fatalf("CPU request = %q, want %q", cpuRequest.String(), wantCPURequest)
 			}
 			memoryLimit, hasMemoryLimit := container.Resources.Limits[corev1.ResourceMemory]
 			if tt.wantMemoryLimit == "" && hasMemoryLimit {
@@ -572,6 +615,44 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 				t.Fatalf("memory limit = %q, want %q", memoryLimit.String(), tt.wantMemoryLimit)
 			}
 		})
+	}
+}
+
+func TestK8sObjectsRejectsNormalServerResourcesAboveMaximum(t *testing.T) {
+	k := newTestKubernetesBackend(t)
+	k.resourceMaximums = ResourceMaximums{CPURequest: new(resource.MustParse("100m"))}
+
+	server := testK8sServerConfig()
+	server.Resources = &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("250m"),
+		},
+	}
+
+	_, err := k.k8sObjects(t.Context(), server, nil)
+	if err == nil {
+		t.Fatal("expected resources above maximum to fail")
+	}
+	var exceeded *ResourceMaximumExceededError
+	if !errors.As(err, &exceeded) {
+		t.Fatalf("expected ResourceMaximumExceededError, got %T: %v", err, err)
+	}
+}
+
+func TestK8sObjectsAllowsSystemServerResourcesAboveMaximum(t *testing.T) {
+	k := newTestKubernetesBackend(t)
+	k.resourceMaximums = ResourceMaximums{CPURequest: new(resource.MustParse("100m"))}
+
+	server := testK8sServerConfig()
+	server.SystemMCPServer = true
+	server.Resources = &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("250m"),
+		},
+	}
+
+	if _, err := k.k8sObjects(t.Context(), server, nil); err != nil {
+		t.Fatalf("expected system MCP server resources to bypass maximums: %v", err)
 	}
 }
 
@@ -936,7 +1017,7 @@ func TestK8sObjects_ManagedImagePullSecrets(t *testing.T) {
 	dep := findDeployment(t, objs, "test-server")
 	assertImagePullSecrets(t, dep, []string{"managed-a", "managed-b"})
 
-	expectedHash := ComputeK8sSettingsHash(v1.K8sSettingsSpec{}, nil, types.RuntimeContainerized, false, []string{"managed-b", "managed-a"})
+	expectedHash := ComputeK8sSettingsHash(v1.K8sSettingsSpec{}, nil, types.RuntimeContainerized, false, ResourceMaximums{}, []string{"managed-b", "managed-a"})
 	if dep.Annotations["obot.ai/k8s-settings-hash"] != expectedHash {
 		t.Fatalf("k8s settings hash = %q, want %q", dep.Annotations["obot.ai/k8s-settings-hash"], expectedHash)
 	}
@@ -1152,6 +1233,21 @@ func newTestKubernetesBackend(t *testing.T, objs ...client.Object) *kubernetesBa
 		remoteShimBaseImage: "ghcr.io/obot-platform/remote-shim:main",
 		mcpNamespace:        "obot-mcp",
 		obotClient:          clientBuilder.Build(),
+	}
+}
+
+func testK8sServerConfig() ServerConfig {
+	return ServerConfig{
+		Runtime:              types.RuntimeContainerized,
+		MCPServerName:        "test-server",
+		MCPServerDisplayName: "Test Server",
+		UserID:               "user-1",
+		OwnerUserID:          "user-2",
+		ContainerImage:       "ghcr.io/obot-platform/mcp-images/stdio-wrapper:main",
+		ContainerPort:        8080,
+		ContainerPath:        "/mcp",
+		Command:              "server",
+		Args:                 []string{"run"},
 	}
 }
 

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -46,6 +46,10 @@ type Options struct {
 	MCPK8sSettingsRuntimeClassName      string `usage:"RuntimeClass name for MCP server pods (e.g., gvisor, kata)"`
 	MCPK8sSettingsStorageClassName      string `usage:"StorageClass name for nanobot workspace volumes"`
 	MCPK8sSettingsNanobotWorkspaceSize  string `usage:"Nanobot workspace size for MCP server pods (e.g., 1Gi)"`
+	MCPK8sMaxCPURequest                 string `usage:"Maximum CPU request allowed for normal MCP server pods"`
+	MCPK8sMaxCPULimit                   string `usage:"Maximum CPU limit allowed for normal MCP server pods"`
+	MCPK8sMaxMemoryRequest              string `usage:"Maximum memory request allowed for normal MCP server pods"`
+	MCPK8sMaxMemoryLimit                string `usage:"Maximum memory limit allowed for normal MCP server pods"`
 
 	// Obot service configuration for constructing internal service FQDN
 	ServiceName      string `usage:"The Kubernetes service name for the obot server"`
@@ -79,6 +83,7 @@ type SessionManager struct {
 	tokenService              TokenService
 	baseURL                   string
 	remoteURLValidationConfig RemoteMCPURLValidationConfig
+	resourceMaximums          ResourceMaximums
 
 	webhookHelper *WebhookHelper
 }
@@ -105,6 +110,10 @@ const streamableHTTPHealthcheckBody string = `{
 
 func NewSessionManager(ctx context.Context, authEnabled bool, tokenService TokenService, baseURL string, httpListenPort int, opts Options, webhookHelper *WebhookHelper, localK8sConfig *rest.Config, client, cachedClient, obotStorageClient kclient.WithWatch) (*SessionManager, error) {
 	var backend backend
+	resourceMaximums, err := ParseResourceMaximums(opts)
+	if err != nil {
+		return nil, err
+	}
 
 	switch opts.MCPRuntimeBackend {
 	case runtimeBackendDocker:
@@ -147,17 +156,18 @@ func NewSessionManager(ctx context.Context, authEnabled bool, tokenService Token
 			return nil, err
 		}
 
-		backend = newKubernetesBackend(authEnabled, clientset, client, cachedClient, obotStorageClient, opts)
+		backend = newKubernetesBackend(authEnabled, clientset, client, cachedClient, obotStorageClient, opts, resourceMaximums)
 	default:
 		return nil, fmt.Errorf("unknown runtime backend: %s", opts.MCPRuntimeBackend)
 	}
 
 	return &SessionManager{
-		webhookHelper:  webhookHelper,
-		tokenService:   tokenService,
-		backend:        backend,
-		runtimeBackend: opts.MCPRuntimeBackend,
-		baseURL:        baseURL,
+		webhookHelper:    webhookHelper,
+		tokenService:     tokenService,
+		backend:          backend,
+		runtimeBackend:   opts.MCPRuntimeBackend,
+		baseURL:          baseURL,
+		resourceMaximums: resourceMaximums,
 		remoteURLValidationConfig: RemoteMCPURLValidationConfig{
 			AllowLocalhostMCP: !opts.DisallowLocalhostMCP,
 			AllowPrivateIPMCP: !opts.DisallowPrivateIPMCP,
@@ -172,6 +182,13 @@ func (sm *SessionManager) MCPRuntimeBackend() string {
 
 func (sm *SessionManager) RemoteMCPURLValidationConfig() RemoteMCPURLValidationConfig {
 	return sm.remoteURLValidationConfig
+}
+
+func (sm *SessionManager) ResourceMaximums() ResourceMaximums {
+	if sm == nil {
+		return ResourceMaximums{}
+	}
+	return sm.resourceMaximums
 }
 
 func (sm *SessionManager) TransformObotHostname(hostname string) string {

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -191,6 +191,13 @@ func (sm *SessionManager) ResourceMaximums() ResourceMaximums {
 	return sm.resourceMaximums
 }
 
+func (sm *SessionManager) KubernetesResourceMaximums() ResourceMaximums {
+	if sm == nil || !IsKubernetesBackend(sm.runtimeBackend) {
+		return ResourceMaximums{}
+	}
+	return sm.resourceMaximums
+}
+
 func (sm *SessionManager) TransformObotHostname(hostname string) string {
 	return sm.backend.transformObotHostname(hostname)
 }

--- a/pkg/mcp/resource_maximums.go
+++ b/pkg/mcp/resource_maximums.go
@@ -67,10 +67,7 @@ func parseResourceMaximum(field, value string) (*resource.Quantity, error) {
 }
 
 func (m ResourceMaximums) Empty() bool {
-	return m.CPURequest == nil &&
-		m.CPULimit == nil &&
-		m.MemoryRequest == nil &&
-		m.MemoryLimit == nil
+	return m == ResourceMaximums{}
 }
 
 func (m ResourceMaximums) Validate(resources corev1.ResourceRequirements) error {

--- a/pkg/mcp/resource_maximums.go
+++ b/pkg/mcp/resource_maximums.go
@@ -1,0 +1,137 @@
+package mcp
+
+import (
+	"fmt"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type ResourceMaximums struct {
+	CPURequest    *resource.Quantity
+	CPULimit      *resource.Quantity
+	MemoryRequest *resource.Quantity
+	MemoryLimit   *resource.Quantity
+}
+
+type ResourceMaximumExceededError struct {
+	Field   string
+	Actual  resource.Quantity
+	Maximum resource.Quantity
+}
+
+func (e *ResourceMaximumExceededError) Error() string {
+	return fmt.Sprintf("%s %s exceeds configured maximum %s", e.Field, e.Actual.String(), e.Maximum.String())
+}
+
+func ParseResourceMaximums(opts Options) (ResourceMaximums, error) {
+	cpuRequest, err := parseResourceMaximum("MCPK8sMaxCPURequest", opts.MCPK8sMaxCPURequest)
+	if err != nil {
+		return ResourceMaximums{}, err
+	}
+	cpuLimit, err := parseResourceMaximum("MCPK8sMaxCPULimit", opts.MCPK8sMaxCPULimit)
+	if err != nil {
+		return ResourceMaximums{}, err
+	}
+	memoryRequest, err := parseResourceMaximum("MCPK8sMaxMemoryRequest", opts.MCPK8sMaxMemoryRequest)
+	if err != nil {
+		return ResourceMaximums{}, err
+	}
+	memoryLimit, err := parseResourceMaximum("MCPK8sMaxMemoryLimit", opts.MCPK8sMaxMemoryLimit)
+	if err != nil {
+		return ResourceMaximums{}, err
+	}
+
+	return ResourceMaximums{
+		CPURequest:    cpuRequest,
+		CPULimit:      cpuLimit,
+		MemoryRequest: memoryRequest,
+		MemoryLimit:   memoryLimit,
+	}, nil
+}
+
+func parseResourceMaximum(field, value string) (*resource.Quantity, error) {
+	if value == "" {
+		return nil, nil
+	}
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s %q: %w", field, value, err)
+	}
+	if quantity.Sign() < 0 {
+		return nil, fmt.Errorf("invalid %s %q: must be non-negative", field, value)
+	}
+	return &quantity, nil
+}
+
+func (m ResourceMaximums) Empty() bool {
+	return m.CPURequest == nil &&
+		m.CPULimit == nil &&
+		m.MemoryRequest == nil &&
+		m.MemoryLimit == nil
+}
+
+func (m ResourceMaximums) Validate(resources corev1.ResourceRequirements) error {
+	if m.Empty() {
+		return nil
+	}
+	if err := validateResourceMaximum("resources.requests.cpu", resources.Requests, corev1.ResourceCPU, m.CPURequest); err != nil {
+		return err
+	}
+	if err := validateResourceMaximum("resources.limits.cpu", resources.Limits, corev1.ResourceCPU, m.CPULimit); err != nil {
+		return err
+	}
+	if err := validateResourceMaximum("resources.requests.memory", resources.Requests, corev1.ResourceMemory, m.MemoryRequest); err != nil {
+		return err
+	}
+	return validateResourceMaximum("resources.limits.memory", resources.Limits, corev1.ResourceMemory, m.MemoryLimit)
+}
+
+func validateResourceMaximum(field string, resources corev1.ResourceList, resourceName corev1.ResourceName, maximum *resource.Quantity) error {
+	if maximum == nil {
+		return nil
+	}
+	actual, ok := resources[resourceName]
+	if !ok {
+		return nil
+	}
+	if actual.Cmp(*maximum) <= 0 {
+		return nil
+	}
+	return &ResourceMaximumExceededError{
+		Field:   field,
+		Actual:  actual,
+		Maximum: *maximum,
+	}
+}
+
+func ValidateK8sSettingsResourceMaximums(k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) error {
+	// Use the same capped default calculation as deployment so empty settings
+	// are allowed even when built-in fallback defaults are higher than maximums.
+	if err := maximums.Validate(mcpContainerResourcesWithMaximums(nil, types.RuntimeNPX, false, k8sSettings, maximums)); err != nil {
+		return fmt.Errorf("default MCP server resources exceed maximums: %w", err)
+	}
+	if err := maximums.Validate(mcpContainerResourcesWithMaximums(nil, types.RuntimeNPX, true, k8sSettings, maximums)); err != nil {
+		return fmt.Errorf("default nanobot agent MCP server resources exceed maximums: %w", err)
+	}
+	return nil
+}
+
+func ValidateConfiguredK8sSettingsResourceMaximums(k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) error {
+	if maximums.Empty() {
+		return nil
+	}
+	if k8sSettings.Resources != nil {
+		if err := maximums.Validate(mcpContainerResourcesWithMaximums(nil, types.RuntimeNPX, false, k8sSettings, maximums)); err != nil {
+			return fmt.Errorf("configured default MCP server resources exceed maximums: %w", err)
+		}
+	}
+	if k8sSettings.NanobotAgentResources != nil {
+		if err := maximums.Validate(mcpContainerResourcesWithMaximums(nil, types.RuntimeNPX, true, k8sSettings, maximums)); err != nil {
+			return fmt.Errorf("configured default nanobot agent MCP server resources exceed maximums: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/mcp/resource_maximums_test.go
+++ b/pkg/mcp/resource_maximums_test.go
@@ -1,0 +1,116 @@
+package mcp
+
+import (
+	"testing"
+
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestParseResourceMaximums(t *testing.T) {
+	maximums, err := ParseResourceMaximums(Options{
+		MCPK8sMaxCPURequest:    "500m",
+		MCPK8sMaxCPULimit:      "1",
+		MCPK8sMaxMemoryRequest: "512Mi",
+		MCPK8sMaxMemoryLimit:   "1Gi",
+	})
+	if err != nil {
+		t.Fatalf("ParseResourceMaximums() error = %v", err)
+	}
+	if got, want := maximums.CPURequest.String(), "500m"; got != want {
+		t.Fatalf("CPU request maximum = %q, want %q", got, want)
+	}
+	if got, want := maximums.CPULimit.String(), "1"; got != want {
+		t.Fatalf("CPU limit maximum = %q, want %q", got, want)
+	}
+	if got, want := maximums.MemoryRequest.String(), "512Mi"; got != want {
+		t.Fatalf("memory request maximum = %q, want %q", got, want)
+	}
+	if got, want := maximums.MemoryLimit.String(), "1Gi"; got != want {
+		t.Fatalf("memory limit maximum = %q, want %q", got, want)
+	}
+}
+
+func TestParseResourceMaximumsRejectsInvalidValues(t *testing.T) {
+	if _, err := ParseResourceMaximums(Options{MCPK8sMaxCPURequest: "nope"}); err == nil {
+		t.Fatal("expected invalid CPU request maximum to fail")
+	}
+	if _, err := ParseResourceMaximums(Options{MCPK8sMaxMemoryLimit: "-1Gi"}); err == nil {
+		t.Fatal("expected negative memory limit maximum to fail")
+	}
+}
+
+func TestValidateK8sSettingsResourceMaximumsUsesEffectiveDefaults(t *testing.T) {
+	maximums := ResourceMaximums{MemoryRequest: new(resource.MustParse("256Mi"))}
+	settings := v1.K8sSettingsSpec{
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+		NanobotAgentResources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	}
+
+	if err := ValidateK8sSettingsResourceMaximums(settings, maximums); err == nil {
+		t.Fatal("expected nanobot agent default memory request to exceed maximum")
+	}
+}
+
+func TestValidateK8sSettingsResourceMaximumsAllowsDefaultsBelowMaximum(t *testing.T) {
+	maximums := ResourceMaximums{MemoryRequest: new(resource.MustParse("256Mi"))}
+	settings := v1.K8sSettingsSpec{
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+		NanobotAgentResources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("192Mi"),
+			},
+		},
+	}
+
+	if err := ValidateK8sSettingsResourceMaximums(settings, maximums); err != nil {
+		t.Fatalf("expected defaults below maximum to pass: %v", err)
+	}
+}
+
+func TestValidateK8sSettingsResourceMaximumsAllowsUnconfiguredDefaultsAboveMaximum(t *testing.T) {
+	maximums := ResourceMaximums{
+		CPURequest:    new(resource.MustParse("1m")),
+		MemoryRequest: new(resource.MustParse("1Mi")),
+	}
+
+	if err := ValidateK8sSettingsResourceMaximums(v1.K8sSettingsSpec{}, maximums); err != nil {
+		t.Fatalf("expected unconfigured defaults to be capped below maximum: %v", err)
+	}
+}
+
+func TestValidateConfiguredK8sSettingsResourceMaximumsSkipsUnconfiguredDefaults(t *testing.T) {
+	maximums := ResourceMaximums{MemoryRequest: new(resource.MustParse("1Mi"))}
+
+	if err := ValidateConfiguredK8sSettingsResourceMaximums(v1.K8sSettingsSpec{}, maximums); err != nil {
+		t.Fatalf("expected unconfigured defaults to skip startup validation: %v", err)
+	}
+}
+
+func TestValidateConfiguredK8sSettingsResourceMaximumsRejectsConfiguredDefaultAboveMaximum(t *testing.T) {
+	maximums := ResourceMaximums{MemoryRequest: new(resource.MustParse("256Mi"))}
+	settings := v1.K8sSettingsSpec{
+		Resources: &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	}
+
+	if err := ValidateConfiguredK8sSettingsResourceMaximums(settings, maximums); err == nil {
+		t.Fatal("expected configured default memory request to exceed maximum")
+	}
+}

--- a/pkg/validation/mcpvalidators.go
+++ b/pkg/validation/mcpvalidators.go
@@ -143,6 +143,7 @@ type RuntimeValidators map[types.Runtime]RuntimeValidator
 // Options configures runtime validation behavior.
 type Options struct {
 	RemoteMCPURLValidationConfig mcp.RemoteMCPURLValidationConfig
+	ResourceMaximums             mcp.ResourceMaximums
 }
 
 // UVXValidator implements RuntimeValidator for UVX runtime
@@ -1001,7 +1002,7 @@ func getRuntimeValidators(options Options) RuntimeValidators {
 		types.RuntimeUVX:           UVXValidator{},
 		types.RuntimeNPX:           NPXValidator{},
 		types.RuntimeContainerized: ContainerizedValidator{},
-		types.RuntimeRemote:        RemoteValidator(options),
+		types.RuntimeRemote:        RemoteValidator{RemoteMCPURLValidationConfig: options.RemoteMCPURLValidationConfig},
 		types.RuntimeComposite:     CompositeValidator{},
 	}
 }
@@ -1068,8 +1069,57 @@ func validateMCPResourceRequirements(runtime types.Runtime, resources *types.MCP
 	return nil
 }
 
+func validateMCPResourceMaximums(resources *types.MCPResourceRequirements, maximums mcp.ResourceMaximums) error {
+	if maximums.Empty() || resources == nil {
+		return nil
+	}
+
+	coreResources, err := mcp.CoreResourceRequirements(resources)
+	if err != nil {
+		return err
+	}
+	if coreResources == nil {
+		return nil
+	}
+
+	return maximums.Validate(*coreResources)
+}
+
+// validateCompositeServerResourceMaximums validates the resource maximums for a composite server.
+// No-op if the server is not a composite server.
+func validateCompositeServerResourceMaximums(manifest types.MCPServerManifest, maximums mcp.ResourceMaximums) error {
+	if maximums.Empty() || manifest.CompositeConfig == nil {
+		return nil
+	}
+
+	for _, component := range manifest.CompositeConfig.ComponentServers {
+		if err := validateMCPResourceMaximums(component.Manifest.Resources, maximums); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateCompositeCatalogEntryResourceMaximums validates the resource maximums for a composite catalog entry.
+// No-op if the catalog entry is not a composite entry.
+func validateCompositeCatalogEntryResourceMaximums(manifest types.MCPServerCatalogEntryManifest, maximums mcp.ResourceMaximums) error {
+	if maximums.Empty() || manifest.CompositeConfig == nil {
+		return nil
+	}
+
+	for _, component := range manifest.CompositeConfig.ComponentServers {
+		if err := validateMCPResourceMaximums(component.Manifest.Resources, maximums); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func ValidateServerManifest(ctx context.Context, manifest types.MCPServerManifest, isMultiUser bool, options Options) error {
 	if err := validateMCPResourceRequirements(manifest.Runtime, manifest.Resources); err != nil {
+		return err
+	}
+	if err := validateMCPResourceMaximums(manifest.Resources, options.ResourceMaximums); err != nil {
 		return err
 	}
 
@@ -1081,6 +1131,10 @@ func ValidateServerManifest(ctx context.Context, manifest types.MCPServerManifes
 		}
 	}
 	if err := validateRuntimeStartupTimeout(manifest.Runtime, manifest.RuntimeStartupTimeoutSeconds()); err != nil {
+		return err
+	}
+
+	if err := validateCompositeServerResourceMaximums(manifest, options.ResourceMaximums); err != nil {
 		return err
 	}
 
@@ -1139,8 +1193,15 @@ func ValidateCatalogEntryManifest(ctx context.Context, manifest types.MCPServerC
 	if err := validateMCPResourceRequirements(manifest.Runtime, manifest.Resources); err != nil {
 		return err
 	}
+	if err := validateMCPResourceMaximums(manifest.Resources, options.ResourceMaximums); err != nil {
+		return err
+	}
 
 	if err := validateRuntimeStartupTimeout(manifest.Runtime, manifest.RuntimeStartupTimeoutSeconds()); err != nil {
+		return err
+	}
+
+	if err := validateCompositeCatalogEntryResourceMaximums(manifest, options.ResourceMaximums); err != nil {
 		return err
 	}
 

--- a/pkg/validation/mcpvalidators_test.go
+++ b/pkg/validation/mcpvalidators_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestValidateServerManifestForCatalog_MultiUserConfig(t *testing.T) {
@@ -2109,6 +2110,116 @@ func TestValidateMCPResourceRequirements(t *testing.T) {
 			require.Contains(t, validationErr.Message, tt.messagePart)
 		})
 	}
+}
+
+func TestValidateMCPResourceMaximums(t *testing.T) {
+	maxCPURequest := resource.MustParse("100m")
+	options := Options{
+		ResourceMaximums: mcp.ResourceMaximums{
+			CPURequest: &maxCPURequest,
+		},
+	}
+
+	t.Run("server manifest rejects resources above maximum", func(t *testing.T) {
+		err := ValidateServerManifest(t.Context(), types.MCPServerManifest{
+			Runtime:   types.RuntimeNPX,
+			NPXConfig: &types.NPXRuntimeConfig{Package: "test-package"},
+			Resources: &types.MCPResourceRequirements{
+				Requests: types.MCPResourceRequests{
+					CPU: "250m",
+				},
+			},
+		}, false, options)
+		require.ErrorContains(t, err, "resources.requests.cpu 250m exceeds configured maximum 100m")
+	})
+
+	t.Run("server manifest accepts resources below maximum", func(t *testing.T) {
+		err := ValidateServerManifest(t.Context(), types.MCPServerManifest{
+			Runtime:   types.RuntimeNPX,
+			NPXConfig: &types.NPXRuntimeConfig{Package: "test-package"},
+			Resources: &types.MCPResourceRequirements{
+				Requests: types.MCPResourceRequests{
+					CPU: "50m",
+				},
+			},
+		}, false, options)
+		require.NoError(t, err)
+	})
+
+	t.Run("server manifest skips empty maximums", func(t *testing.T) {
+		err := ValidateServerManifest(t.Context(), types.MCPServerManifest{
+			Runtime:   types.RuntimeNPX,
+			NPXConfig: &types.NPXRuntimeConfig{Package: "test-package"},
+			Resources: &types.MCPResourceRequirements{
+				Requests: types.MCPResourceRequests{
+					CPU: "250m",
+				},
+			},
+		}, false, Options{})
+		require.NoError(t, err)
+	})
+
+	t.Run("catalog manifest rejects resources above maximum", func(t *testing.T) {
+		err := ValidateCatalogEntryManifest(t.Context(), types.MCPServerCatalogEntryManifest{
+			ServerUserType: types.ServerUserTypeSingleUser,
+			Runtime:        types.RuntimeUVX,
+			UVXConfig:      &types.UVXRuntimeConfig{Package: "test-package"},
+			Resources: &types.MCPResourceRequirements{
+				Requests: types.MCPResourceRequests{
+					CPU: "250m",
+				},
+			},
+		}, false, options)
+		require.ErrorContains(t, err, "resources.requests.cpu 250m exceeds configured maximum 100m")
+	})
+
+	t.Run("composite server manifest rejects component resources above maximum", func(t *testing.T) {
+		err := ValidateServerManifest(t.Context(), types.MCPServerManifest{
+			Runtime: types.RuntimeComposite,
+			CompositeConfig: &types.CompositeRuntimeConfig{
+				ComponentServers: []types.ComponentServer{
+					{
+						CatalogEntryID: "component",
+						Manifest: types.MCPServerManifest{
+							Runtime:   types.RuntimeNPX,
+							NPXConfig: &types.NPXRuntimeConfig{Package: "test-package"},
+							Resources: &types.MCPResourceRequirements{
+								Requests: types.MCPResourceRequests{
+									CPU: "250m",
+								},
+							},
+						},
+					},
+				},
+			},
+		}, false, options)
+		require.ErrorContains(t, err, "resources.requests.cpu 250m exceeds configured maximum 100m")
+	})
+
+	t.Run("composite catalog manifest rejects component resources above maximum", func(t *testing.T) {
+		err := ValidateCatalogEntryManifest(t.Context(), types.MCPServerCatalogEntryManifest{
+			ServerUserType: types.ServerUserTypeSingleUser,
+			Runtime:        types.RuntimeComposite,
+			CompositeConfig: &types.CompositeCatalogConfig{
+				ComponentServers: []types.CatalogComponentServer{
+					{
+						CatalogEntryID: "component",
+						Manifest: types.MCPServerCatalogEntryManifest{
+							ServerUserType: types.ServerUserTypeSingleUser,
+							Runtime:        types.RuntimeNPX,
+							NPXConfig:      &types.NPXRuntimeConfig{Package: "test-package"},
+							Resources: &types.MCPResourceRequirements{
+								Requests: types.MCPResourceRequests{
+									CPU: "250m",
+								},
+							},
+						},
+					},
+				},
+			},
+		}, false, options)
+		require.ErrorContains(t, err, "resources.requests.cpu 250m exceeds configured maximum 100m")
+	})
 }
 
 func TestValidateSecretBindings(t *testing.T) {


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/6836

This introduces four new env vars to set a cap on the allowed CPU and memory requests and limits for MCP servers.

We do not allow the admin to configure default K8sSettings above the set maximums. We also check during startup to make sure that the new maximums are not lower than the current configured K8sSettings, if it is configured.

Also, in the implicit/hardcoded fallback when there are no K8sSettings configured, where we set i.e. a `10m` CPU request and a `200Mi` memory request, if the configured maximums are lower than these hardcoded fallbacks, we use those instead.

We block admins from creating new catalog entries that have reqs/limits higher than the maximums (or from updating existing ones to push them above the maximums), but this is just for convenience. Any attempt to ~~deploy a server~~ create an MCPServer from a catalog entry with resources above the maximums will fail at ~~deployment~~ creation time. Additionally, doing a TriggerUpdate to push updates from a catalog entry to an existing MCPServer will fail, if the catalog entry's resources are too high.

Design-wise, the only part of this I'm skeptical about is whether the SessionManager is the best place to store the configured maximums. I talked to Codex about it and ultimately this is what it recommended, but let me know if you have a different preference.