### PR TITLE
fix: show partial pat in edit of mcp catalog source url

### DIFF
--- a/pkg/api/handlers/systemmcpcatalogs.go
+++ b/pkg/api/handlers/systemmcpcatalogs.go
@@ -300,7 +300,7 @@ const (
 
 func maskCatalogCredential(token string) string {
 	if len(token) <= catalogCredentialVisibleSuffix {
-		return catalogCredentialMask + token
+		return catalogCredentialMask
 	}
 	return catalogCredentialMask + token[len(token)-catalogCredentialVisibleSuffix:]
 }

--- a/pkg/api/handlers/systemmcpcatalogs.go
+++ b/pkg/api/handlers/systemmcpcatalogs.go
@@ -293,6 +293,25 @@ func normalizeAndValidateCatalogSourceURLs(sourceURLs []string, localPath string
 	return nil
 }
 
+const (
+	catalogCredentialMask          = "****"
+	catalogCredentialVisibleSuffix = 4
+)
+
+func maskCatalogCredential(token string) string {
+	if len(token) <= catalogCredentialVisibleSuffix {
+		return catalogCredentialMask + token
+	}
+	return catalogCredentialMask + token[len(token)-catalogCredentialVisibleSuffix:]
+}
+
+func isMaskedCatalogCredential(token string) bool {
+	if !strings.HasPrefix(token, catalogCredentialMask) {
+		return false
+	}
+	return len(token)-len(catalogCredentialMask) <= catalogCredentialVisibleSuffix
+}
+
 func mergeCatalogTokens(sourceURLs []string, incoming, existing map[string]string) map[string]string {
 	activeURLs := make(map[string]struct{}, len(sourceURLs))
 	for _, u := range sourceURLs {
@@ -311,7 +330,13 @@ func mergeCatalogTokens(sourceURLs []string, incoming, existing map[string]strin
 				newTokens[u] = existingToken
 			}
 		default:
-			newTokens[u] = token
+			if isMaskedCatalogCredential(token) {
+				if existingToken, ok := existing[u]; ok {
+					newTokens[u] = existingToken
+				}
+			} else {
+				newTokens[u] = token
+			}
 		}
 	}
 	for _, u := range sourceURLs {
@@ -349,7 +374,7 @@ func maskCatalogCredentials(sourceURLs []string, tokenEnv map[string]string) map
 			if maskedCredentials == nil {
 				maskedCredentials = make(map[string]string)
 			}
-			maskedCredentials[u] = "*"
+			maskedCredentials[u] = maskCatalogCredential(tokenEnv[u])
 		}
 	}
 	return maskedCredentials

--- a/pkg/api/handlers/systemmcpcatalogs_test.go
+++ b/pkg/api/handlers/systemmcpcatalogs_test.go
@@ -9,6 +9,95 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestMaskCatalogCredential(t *testing.T) {
+	assert.Equal(t, "****", maskCatalogCredential(""))
+	assert.Equal(t, "****abc", maskCatalogCredential("abc"))
+	assert.Equal(t, "****1234", maskCatalogCredential("ghp_abcdefghij1234"))
+}
+
+func TestIsMaskedCatalogCredential(t *testing.T) {
+	assert.True(t, isMaskedCatalogCredential("****"))
+	assert.True(t, isMaskedCatalogCredential("****1234"))
+	assert.True(t, isMaskedCatalogCredential("****abc"))
+	assert.False(t, isMaskedCatalogCredential("ghp_abcdefghij1234"))
+	assert.False(t, isMaskedCatalogCredential("****12345"))
+}
+
+func TestMaskCatalogCredentials(t *testing.T) {
+	masked := maskCatalogCredentials(
+		[]string{"https://github.com/org/repo", "https://github.com/org/other"},
+		map[string]string{
+			"https://github.com/org/repo": "ghp_abcdefghij1234",
+		},
+	)
+	assert.Equal(t, map[string]string{
+		"https://github.com/org/repo": "****1234",
+	}, masked)
+}
+
+func TestMergeCatalogTokens(t *testing.T) {
+	sourceURLs := []string{"https://github.com/org/repo", "https://github.com/org/other"}
+	existing := map[string]string{
+		"https://github.com/org/repo": "ghp_abcdefghij1234",
+	}
+
+	t.Run("preserves existing token for wildcard sentinel", func(t *testing.T) {
+		got := mergeCatalogTokens(sourceURLs, map[string]string{
+			"https://github.com/org/repo": "*",
+		}, existing)
+		assert.Equal(t, map[string]string{
+			"https://github.com/org/repo": "ghp_abcdefghij1234",
+		}, got)
+	})
+
+	t.Run("preserves existing token for masked round-trip", func(t *testing.T) {
+		got := mergeCatalogTokens(sourceURLs, map[string]string{
+			"https://github.com/org/repo": "****1234",
+		}, existing)
+		assert.Equal(t, map[string]string{
+			"https://github.com/org/repo": "ghp_abcdefghij1234",
+		}, got)
+	})
+
+	t.Run("stores new token when provided", func(t *testing.T) {
+		got := mergeCatalogTokens(sourceURLs, map[string]string{
+			"https://github.com/org/other": "new-token-value",
+		}, existing)
+		assert.Equal(t, map[string]string{
+			"https://github.com/org/repo":  "ghp_abcdefghij1234",
+			"https://github.com/org/other": "new-token-value",
+		}, got)
+	})
+
+	t.Run("ignores masked credential remapped to new source URL", func(t *testing.T) {
+		got := mergeCatalogTokens(
+			[]string{"https://github.com/org/renamed"},
+			map[string]string{
+				"https://github.com/org/renamed": "****1234",
+			},
+			map[string]string{
+				"https://github.com/org/repo": "ghp_abcdefghij1234",
+			},
+		)
+		assert.Empty(t, got)
+	})
+
+	t.Run("preserves existing token when masked credential already persisted as secret", func(t *testing.T) {
+		got := mergeCatalogTokens(
+			[]string{"https://github.com/sangee2004/mcp-catalog"},
+			map[string]string{
+				"https://github.com/sangee2004/mcp-catalog": "****3132",
+			},
+			map[string]string{
+				"https://github.com/sangee2004/mcp-catalog": "****3132",
+			},
+		)
+		assert.Equal(t, map[string]string{
+			"https://github.com/sangee2004/mcp-catalog": "****3132",
+		}, got)
+	})
+}
+
 func TestConvertSystemMCPServerCatalogEntryResources(t *testing.T) {
 	resources := &types.MCPResourceRequirements{
 		Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},

--- a/pkg/api/handlers/systemmcpcatalogs_test.go
+++ b/pkg/api/handlers/systemmcpcatalogs_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestMaskCatalogCredential(t *testing.T) {
 	assert.Equal(t, "****", maskCatalogCredential(""))
-	assert.Equal(t, "****abc", maskCatalogCredential("abc"))
+	assert.Equal(t, "****", maskCatalogCredential("abc"))
+	assert.Equal(t, "****", maskCatalogCredential("1234"))
 	assert.Equal(t, "****1234", maskCatalogCredential("ghp_abcdefghij1234"))
 }
 
@@ -56,6 +57,18 @@ func TestMergeCatalogTokens(t *testing.T) {
 		}, existing)
 		assert.Equal(t, map[string]string{
 			"https://github.com/org/repo": "ghp_abcdefghij1234",
+		}, got)
+	})
+
+	t.Run("preserves existing short token for fully masked round-trip", func(t *testing.T) {
+		shortExisting := map[string]string{
+			"https://github.com/org/repo": "abc",
+		}
+		got := mergeCatalogTokens(sourceURLs, map[string]string{
+			"https://github.com/org/repo": "****",
+		}, shortExisting)
+		assert.Equal(t, map[string]string{
+			"https://github.com/org/repo": "abc",
 		}, got)
 	})
 

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import SensitiveInput from '$lib/components/SensitiveInput.svelte';
-	import { AdminService, type MCPCatalog } from '$lib/services';
+	import { AdminService, type MCPCatalog, type MCPCatalogManifest } from '$lib/services';
 	import IconButton from '../primitives/IconButton.svelte';
 	import { Info, TriangleAlert, X } from '@lucide/svelte';
+	import { slide } from 'svelte/transition';
 
 	interface Props {
 		defaultCatalog?: MCPCatalog;
@@ -22,9 +23,11 @@
 		clearToken?: boolean;
 	}>();
 	let sourceDialog = $state<HTMLDialogElement>();
+	let tokenClearedForURLChange = $state(false);
 
 	export function open() {
 		sourceError = undefined;
+		tokenClearedForURLChange = false;
 		editingSource = {
 			index: -1,
 			value: '',
@@ -35,6 +38,7 @@
 
 	export function edit(url: string, index: number) {
 		sourceError = undefined;
+		tokenClearedForURLChange = false;
 		editingSource = {
 			index,
 			value: url,
@@ -46,15 +50,54 @@
 	function closeSourceDialog() {
 		editingSource = undefined;
 		sourceError = undefined;
+		tokenClearedForURLChange = false;
 		sourceDialog?.close();
 	}
 
-	function hasSourceURLCredential(url: string | undefined): boolean {
+	function hasSourceURLCredential(url: string | undefined, catalog = defaultCatalog): boolean {
 		if (!url) {
 			return false;
 		}
-		const credential = defaultCatalog?.sourceURLCredentials?.[url];
+		const credential = catalog?.sourceURLCredentials?.[url];
 		return credential !== undefined && credential !== '';
+	}
+
+	const editingSourceURL = $derived(
+		editingSource && editingSource.index >= 0
+			? defaultCatalog?.sourceURLs?.[editingSource.index]
+			: undefined
+	);
+
+	const sourceURLChangedWithCredential = $derived(
+		Boolean(
+			editingSource &&
+			editingSource.index >= 0 &&
+			editingSourceURL &&
+			editingSource.value !== editingSourceURL &&
+			hasSourceURLCredential(editingSourceURL, defaultCatalog) &&
+			!editingSource.token
+		)
+	);
+
+	function handleSourceURLInput() {
+		if (!editingSource || editingSource.index < 0 || !editingSourceURL) {
+			return;
+		}
+
+		const urlChanged = editingSource.value !== editingSourceURL;
+		const hadCredential = hasSourceURLCredential(editingSourceURL, defaultCatalog);
+
+		if (urlChanged && hadCredential) {
+			editingSource.clearToken = true;
+			if (!tokenClearedForURLChange) {
+				editingSource.token = '';
+				tokenClearedForURLChange = true;
+			}
+		} else if (!urlChanged && tokenClearedForURLChange) {
+			editingSource.clearToken = false;
+			editingSource.token = '';
+			tokenClearedForURLChange = false;
+		}
 	}
 </script>
 
@@ -84,6 +127,7 @@
 				<input
 					id="catalog-source-name"
 					bind:value={editingSource.value}
+					oninput={handleSourceURLInput}
 					class="text-input-filled"
 				/>
 			</div>
@@ -138,6 +182,11 @@
 					</div>
 					<span class="font-sm font-light break-all">{sourceError}</span>
 				</div>
+			{:else if sourceURLChangedWithCredential}
+				<p class="mb-4 text-xs notification-alert" in:slide={{ axis: 'y' }}>
+					The source URL has been changed. Please re-enter the personal access token tied to the
+					former URL, otherwise it will be cleared on save.
+				</p>
 			{/if}
 
 			<div class="flex w-full justify-end gap-2">
@@ -166,45 +215,42 @@
 						sourceError = undefined;
 
 						try {
-							const updatingCatalog = { ...catalogToUse };
+							const updatingCatalog: MCPCatalogManifest = {
+								displayName: catalogToUse.displayName,
+								sourceURLs: catalogToUse.sourceURLs ?? [],
+								allowedUserIDs: catalogToUse.allowedUserIDs
+							};
+							const oldURL =
+								editingSource.index >= 0
+									? catalogToUse.sourceURLs?.[editingSource.index]
+									: undefined;
+							const newURL = editingSource.value;
 
 							if (editingSource.index === -1) {
-								updatingCatalog.sourceURLs = [
-									...(updatingCatalog.sourceURLs ?? []),
-									editingSource.value
-								];
+								updatingCatalog.sourceURLs = [...(updatingCatalog.sourceURLs ?? []), newURL];
 							} else {
-								const oldUrl = catalogToUse.sourceURLs[editingSource.index];
 								updatingCatalog.sourceURLs = [...(updatingCatalog.sourceURLs ?? [])];
-								updatingCatalog.sourceURLs[editingSource.index] = editingSource.value;
-
-								// If the URL changed and the old URL had a credential, remap the
-								// credentials key so the backend can transfer it to the new URL.
-								if (oldUrl !== editingSource.value && hasSourceURLCredential(oldUrl)) {
-									updatingCatalog.sourceURLCredentials = {
-										...updatingCatalog.sourceURLCredentials,
-										[editingSource.value]: updatingCatalog.sourceURLCredentials?.[oldUrl] ?? '*'
-									};
-									delete updatingCatalog.sourceURLCredentials[oldUrl];
-								}
+								updatingCatalog.sourceURLs[editingSource.index] = newURL;
 							}
 
-							Object.keys(updatingCatalog.sourceURLCredentials ?? {}).forEach((key) => {
-								if (updatingCatalog.sourceURLCredentials?.[key]) {
-									updatingCatalog.sourceURLCredentials[key] = '*';
-								}
-							});
+							const sourceURLCredentials: Record<string, string> = {};
+
+							if (
+								oldURL !== undefined &&
+								oldURL !== newURL &&
+								hasSourceURLCredential(oldURL, catalogToUse)
+							) {
+								sourceURLCredentials[oldURL] = '';
+							}
 
 							if (editingSource.clearToken && !editingSource.token) {
-								updatingCatalog.sourceURLCredentials = {
-									...(updatingCatalog.sourceURLCredentials ?? {}),
-									[editingSource.value]: ''
-								};
+								sourceURLCredentials[newURL] = '';
 							} else if (editingSource.token) {
-								updatingCatalog.sourceURLCredentials = {
-									...(updatingCatalog.sourceURLCredentials ?? {}),
-									[editingSource.value]: editingSource.token
-								};
+								sourceURLCredentials[newURL] = editingSource.token;
+							}
+
+							if (Object.keys(sourceURLCredentials).length > 0) {
+								updatingCatalog.sourceURLCredentials = sourceURLCredentials;
 							}
 
 							const response = await AdminService.updateMCPCatalog(

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -165,11 +165,17 @@
 					{/if}
 				</div>
 				{#if !editingSource.clearToken && editingSource.index >= 0 && hasSourceURLCredential(defaultCatalog?.sourceURLs?.[editingSource.index])}
-					<p class="text-sm text-muted-content h-[39px]">
-						{defaultCatalog?.sourceURLCredentials?.[
+					<input
+						id="catalog-source-token"
+						type="text"
+						readonly
+						aria-readonly="true"
+						data-1p-ignore
+						value={defaultCatalog?.sourceURLCredentials?.[
 							defaultCatalog?.sourceURLs?.[editingSource.index]
-						]}
-					</p>
+						] ?? ''}
+						class="text-sm text-muted-content w-full border-none bg-transparent p-0 outline-none focus:ring-0"
+					/>
 				{:else}
 					<SensitiveInput
 						name="catalog-source-token"

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -48,6 +48,27 @@
 		sourceError = undefined;
 		sourceDialog?.close();
 	}
+
+	function hasSourceURLCredential(url: string | undefined): boolean {
+		if (!url) {
+			return false;
+		}
+		const credential = defaultCatalog?.sourceURLCredentials?.[url];
+		return credential !== undefined && credential !== '';
+	}
+
+	function hasSourceEditChanges(source: NonNullable<typeof editingSource>): boolean {
+		if (source.index === -1) {
+			return source.value.trim() !== '';
+		}
+
+		const originalUrl = defaultCatalog?.sourceURLs?.[source.index];
+		return (
+			source.value !== originalUrl ||
+			source.clearToken === true ||
+			source.token !== ''
+		);
+	}
 </script>
 
 <dialog bind:this={sourceDialog} class="dialog">
@@ -91,10 +112,10 @@
 								disablePortal: true
 							}}
 						>
-							<Info class="text-base-content size-3.5" />
+							<Info class="text-muted-content size-3.5" />
 						</span>
 					</label>
-					{#if editingSource.index >= 0 && defaultCatalog?.sourceURLCredentials?.[defaultCatalog?.sourceURLs?.[editingSource.index]] === '*' && !editingSource.clearToken}
+					{#if editingSource.index >= 0 && hasSourceURLCredential(defaultCatalog?.sourceURLs?.[editingSource.index]) && !editingSource.clearToken}
 						<button
 							class="text-xs text-error hover:underline"
 							onclick={() => {
@@ -105,17 +126,16 @@
 						</button>
 					{/if}
 				</div>
-				{#if editingSource.clearToken}
-					<p class="text-muted-content text-xs">Token will be removed on save.</p>
+				{#if !editingSource.clearToken && editingSource.index >= 0 && hasSourceURLCredential(defaultCatalog?.sourceURLs?.[editingSource.index])}
+					<p class="text-sm text-muted-content h-[39px]">
+						{defaultCatalog?.sourceURLCredentials?.[
+							defaultCatalog?.sourceURLs?.[editingSource.index]
+						]}
+					</p>
 				{:else}
 					<SensitiveInput
 						name="catalog-source-token"
-						placeholder={editingSource.index >= 0 &&
-						defaultCatalog?.sourceURLCredentials?.[
-							defaultCatalog?.sourceURLs?.[editingSource.index]
-						] === '*'
-							? 'Token is set — enter a new value to replace it'
-							: ''}
+						placeholder=""
 						bind:value={editingSource.token}
 					/>
 				{/if}
@@ -137,7 +157,7 @@
 				>
 				<button
 					class="btn btn-primary"
-					disabled={saving}
+					disabled={saving || !hasSourceEditChanges(editingSource)}
 					onclick={async () => {
 						if (!editingSource || (!defaultCatalog && !defaultCatalogId)) {
 							return;
@@ -171,22 +191,16 @@
 
 								// If the URL changed and the old URL had a credential, remap the
 								// credentials key so the backend can transfer it to the new URL.
-								if (
-									oldUrl !== editingSource.value &&
-									updatingCatalog.sourceURLCredentials?.[oldUrl] === '*'
-								) {
+								if (oldUrl !== editingSource.value && hasSourceURLCredential(oldUrl)) {
 									updatingCatalog.sourceURLCredentials = {
 										...updatingCatalog.sourceURLCredentials,
-										[editingSource.value]: '*'
+										[editingSource.value]: updatingCatalog.sourceURLCredentials?.[oldUrl] ?? '*'
 									};
 									delete updatingCatalog.sourceURLCredentials[oldUrl];
 								}
 							}
 
-							// Send a credential update only when the user typed a new token or
-							// explicitly clicked "Clear token". Leaving the field empty leaves
-							// any existing credential unchanged.
-							if (editingSource.clearToken) {
+							if (editingSource.clearToken && !editingSource.token) {
 								updatingCatalog.sourceURLCredentials = {
 									...(updatingCatalog.sourceURLCredentials ?? {}),
 									[editingSource.value]: ''

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -24,10 +24,12 @@
 	}>();
 	let sourceDialog = $state<HTMLDialogElement>();
 	let tokenClearedForURLChange = $state(false);
+	let tokenExplicitlyCleared = $state(false);
 
 	export function open() {
 		sourceError = undefined;
 		tokenClearedForURLChange = false;
+		tokenExplicitlyCleared = false;
 		editingSource = {
 			index: -1,
 			value: '',
@@ -39,6 +41,7 @@
 	export function edit(url: string, index: number) {
 		sourceError = undefined;
 		tokenClearedForURLChange = false;
+		tokenExplicitlyCleared = false;
 		editingSource = {
 			index,
 			value: url,
@@ -51,6 +54,7 @@
 		editingSource = undefined;
 		sourceError = undefined;
 		tokenClearedForURLChange = false;
+		tokenExplicitlyCleared = false;
 		sourceDialog?.close();
 	}
 
@@ -93,7 +97,7 @@
 				editingSource.token = '';
 				tokenClearedForURLChange = true;
 			}
-		} else if (!urlChanged && tokenClearedForURLChange) {
+		} else if (!urlChanged && tokenClearedForURLChange && !tokenExplicitlyCleared) {
 			editingSource.clearToken = false;
 			editingSource.token = '';
 			tokenClearedForURLChange = false;
@@ -150,7 +154,10 @@
 						<button
 							class="text-xs text-error hover:underline"
 							onclick={() => {
-								if (editingSource) editingSource.clearToken = true;
+								if (editingSource) {
+									editingSource.clearToken = true;
+									tokenExplicitlyCleared = true;
+								}
 							}}
 						>
 							Clear token
@@ -182,7 +189,7 @@
 					</div>
 					<span class="font-sm font-light break-all">{sourceError}</span>
 				</div>
-			{:else if sourceURLChangedWithCredential}
+			{:else if sourceURLChangedWithCredential && !tokenExplicitlyCleared}
 				<p class="mb-4 text-xs notification-alert" in:slide={{ axis: 'y' }}>
 					The source URL has been changed. Please re-enter the personal access token tied to the
 					former URL, otherwise it will be cleared on save.

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -56,19 +56,6 @@
 		const credential = defaultCatalog?.sourceURLCredentials?.[url];
 		return credential !== undefined && credential !== '';
 	}
-
-	function hasSourceEditChanges(source: NonNullable<typeof editingSource>): boolean {
-		if (source.index === -1) {
-			return source.value.trim() !== '';
-		}
-
-		const originalUrl = defaultCatalog?.sourceURLs?.[source.index];
-		return (
-			source.value !== originalUrl ||
-			source.clearToken === true ||
-			source.token !== ''
-		);
-	}
 </script>
 
 <dialog bind:this={sourceDialog} class="dialog">
@@ -135,7 +122,9 @@
 				{:else}
 					<SensitiveInput
 						name="catalog-source-token"
-						placeholder=""
+						placeholder={editingSource.clearToken
+							? 'Enter a new value or leave empty to clear'
+							: ''}
 						bind:value={editingSource.token}
 					/>
 				{/if}
@@ -157,7 +146,7 @@
 				>
 				<button
 					class="btn btn-primary"
-					disabled={saving || !hasSourceEditChanges(editingSource)}
+					disabled={saving}
 					onclick={async () => {
 						if (!editingSource || (!defaultCatalog && !defaultCatalogId)) {
 							return;
@@ -199,6 +188,12 @@
 									delete updatingCatalog.sourceURLCredentials[oldUrl];
 								}
 							}
+
+							Object.keys(updatingCatalog.sourceURLCredentials ?? {}).forEach((key) => {
+								if (updatingCatalog.sourceURLCredentials?.[key]) {
+									updatingCatalog.sourceURLCredentials[key] = '*';
+								}
+							});
 
 							if (editingSource.clearToken && !editingSource.token) {
 								updatingCatalog.sourceURLCredentials = {


### PR DESCRIPTION
Addresses #6417 
* show partial PAT in sourceURLCredentials for GET /mcp-catalog
<img width="475" height="300" alt="Screenshot 2026-06-23 at 10 57 27 AM" src="https://github.com/user-attachments/assets/a404714d-c7cd-4fda-92f6-54b0a7095973" />
