### PR TITLE
enhance: disallow loopback, private IP and link-local in more places

### DIFF
--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -42,8 +42,8 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_AUDIT_LOGS_STORE_USE_PATH_STYLE` | Whether to use path style for S3 object names | - |
 | `OBOT_SERVER_MCPBASE_IMAGE` | Deploy MCP servers in the kubernetes cluster or using docker with this base image. | `ghcr.io/obot-platform/mcp-images/stdio-wrapper:v0.24.0` |
 | `OBOT_SERVER_MCPIMAGE_PULL_SECRETS` | Comma-separated Kubernetes secret names to use as static image pull secrets for every MCP server Deployment. When set, managed image pull secrets are disabled. See [Image Pull Secrets](./image-pull-secrets.md). | - |
-| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/obot-platform/nanobot:v0.0.86` |
-| `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/obot-platform/nanobot-agent:v0.0.86` |
+| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/obot-platform/nanobot:v0.0.87` |
+| `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/obot-platform/nanobot-agent:v0.0.87` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.24.0` |
 | `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker or kubernetes. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/obot-platform/cmd v0.0.0-20260615195405-fab7a186f46c
 	github.com/obot-platform/kinm v0.0.0-20260420174234-eec2cd66c333
 	github.com/obot-platform/nah v0.0.0-20260424131842-3fc648d20cac
-	github.com/obot-platform/nanobot v0.0.87-0.20260623172115-5f5123a827ca
+	github.com/obot-platform/nanobot v0.0.87
 	github.com/obot-platform/obot/apiclient v0.0.0-20250813183905-ade719c1e8bf
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.sum
+++ b/go.sum
@@ -500,8 +500,8 @@ github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00 h1
 github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00/go.mod h1:IBdiWaE+aSlf5TpqKhtDkpGwxPetHtjaScewJ/UoSGQ=
 github.com/obot-platform/nah v0.0.0-20260424131842-3fc648d20cac h1:bHzcvYVp5AW+NyS45YzUmp6bZS5iUO9BY0HZX+MMi98=
 github.com/obot-platform/nah v0.0.0-20260424131842-3fc648d20cac/go.mod h1:+dYHcGg+BgcdZ2+eo3XCxhJFNQjmaKNRgD2loOvcFN0=
-github.com/obot-platform/nanobot v0.0.87-0.20260623172115-5f5123a827ca h1:s2UlkjVpe3ptTJS0nalxkziwf8j/s0+rBXQ3tXLPJxw=
-github.com/obot-platform/nanobot v0.0.87-0.20260623172115-5f5123a827ca/go.mod h1:lBBUrPngm/jJpwgLrqJzgup4hFniLpXzd6JIRDh1JZM=
+github.com/obot-platform/nanobot v0.0.87 h1:VYgn1QzPvu81Ztx92aDL5NkHGmLXvD6N5uJuXcNeQwE=
+github.com/obot-platform/nanobot v0.0.87/go.mod h1:lBBUrPngm/jJpwgLrqJzgup4hFniLpXzd6JIRDh1JZM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
@@ -148,7 +148,7 @@ func (h *handler) fetchClientIDMetadataDocument(ctx context.Context, clientID st
 	}
 	httpReq.Header.Set("Accept", "application/json")
 
-	resp, err := h.clientMetadataClient().Do(httpReq)
+	resp, err := h.clientMetadataHTTPClient.Do(httpReq)
 	if err != nil {
 		return clientIDMetadataDocument{}, time.Time{}, fmt.Errorf("failed to fetch client metadata document: %w", err)
 	}
@@ -247,13 +247,6 @@ func (h *handler) oauthClientFromMetadataDocument(clientID string, doc clientIDM
 
 func isSharedSecretAuthMethod(method string) bool {
 	return strings.Contains(method, "client_secret")
-}
-
-func (h *handler) clientMetadataClient() *http.Client {
-	if h.clientMetadataHTTPClient != nil {
-		return h.clientMetadataHTTPClient
-	}
-	return &http.Client{Timeout: clientMetadataFetchTimeout}
 }
 
 func (h *handler) getCachedClientMetadata(clientID string) (v1.OAuthClient, bool) {

--- a/pkg/api/handlers/mcpgateway/oauth/handler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/handler.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/obot-platform/nanobot/pkg/safehttp"
 	"github.com/obot-platform/obot/pkg/api/handlers"
 	"github.com/obot-platform/obot/pkg/api/server"
 	"github.com/obot-platform/obot/pkg/jwt/persistent"
@@ -25,15 +26,17 @@ type handler struct {
 	clientMetadataCacheLock  sync.Mutex
 }
 
-func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTokenStore, tokenService *persistent.TokenService, oauthConfig handlers.OAuthAuthorizationServerConfig, baseURL string, clientSecretExpiration time.Duration, mux *server.Server) {
+func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTokenStore, tokenService *persistent.TokenService, oauthConfig handlers.OAuthAuthorizationServerConfig, mcpSessionManager *mcp.SessionManager, baseURL string, clientSecretExpiration time.Duration, mux *server.Server) {
+	remoteURLValidationConfig := mcpSessionManager.RemoteMCPURLValidationConfig()
 	h := &handler{
-		tokenStore:          tokenStore,
-		tokenService:        tokenService,
-		oauthConfig:         oauthConfig,
-		baseURL:             baseURL,
-		oauthChecker:        oauthChecker,
-		clientExpiration:    clientSecretExpiration,
-		clientMetadataCache: map[string]clientMetadataCacheEntry{},
+		tokenStore:               tokenStore,
+		tokenService:             tokenService,
+		oauthConfig:              oauthConfig,
+		clientMetadataHTTPClient: safehttp.NewClientWithTimeout(!remoteURLValidationConfig.AllowLocalhostMCP, !remoteURLValidationConfig.AllowPrivateIPMCP, !remoteURLValidationConfig.AllowLinkLocalMCP, clientMetadataFetchTimeout),
+		baseURL:                  baseURL,
+		oauthChecker:             oauthChecker,
+		clientExpiration:         clientSecretExpiration,
+		clientMetadataCache:      map[string]clientMetadataCacheEntry{},
 	}
 
 	// Expose two sets of endpoints: one for clients that look at the oauth-protected-resource metadata and one for clients that don't.

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -105,12 +105,17 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(req api.Context, mcpServer v1.M
 
 	go func() {
 		defer close(errChan)
+
+		blockingConfig := f.mcpSessionManager.RemoteMCPURLValidationConfig()
 		httpClientOptions := nmcp.HTTPClientOptions{
 			OAuthRedirectURL: system.MCPOAuthCallbackURL(f.baseURL),
 			OAuthClientName:  "Obot MCP Gateway",
 			CallbackHandler:  oauthHandler,
 			ClientCredLookup: oauthHandler,
 			TokenStorage:     f.tokenStore.ForUserAndMCP(oauthHandler.userID, oauthHandler.mcpID),
+			BlockLoopback:    !blockingConfig.AllowLocalhostMCP,
+			BlockPrivateIP:   !blockingConfig.AllowPrivateIPMCP,
+			BlockLinkLocal:   !blockingConfig.AllowLinkLocalMCP,
 		}
 		if strings.HasPrefix(f.baseURL, "https://") {
 			httpClientOptions.OAuthClientIDMetadataDocument = system.OAuthClientIDMetadataURL(f.baseURL)

--- a/pkg/api/handlers/mcpgateway/oauth/private_key_jwt.go
+++ b/pkg/api/handlers/mcpgateway/oauth/private_key_jwt.go
@@ -113,7 +113,7 @@ func (h *handler) clientJWKSet(ctx context.Context, client v1.OAuthClient) (jose
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := h.clientMetadataClient().Do(req)
+	resp, err := h.clientMetadataHTTPClient.Do(req)
 	if err != nil {
 		return jose.JSONWebKeySet{}, fmt.Errorf("failed to fetch client jwks_uri: %w", err)
 	}

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -574,7 +574,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	wellknown.SetupHandlers(services.ServerURL, services.OAuthServerConfig, services.RegistryNoAuth, mux)
 
 	// Obot OAuth
-	oauth.SetupHandlers(oauthChecker, services.MCPOAuthTokenStorage, services.PersistentTokenServer, services.OAuthServerConfig, services.ServerURL, services.MCPOAuthClientSecretExpiration, mux)
+	oauth.SetupHandlers(oauthChecker, services.MCPOAuthTokenStorage, services.PersistentTokenServer, services.OAuthServerConfig, services.MCPSessionManager, services.ServerURL, services.MCPOAuthClientSecretExpiration, mux)
 
 	// Gateway APIs
 	services.GatewayServer.AddRoutes(services.APIServer)

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -17,6 +17,7 @@ import (
 	"github.com/obot-platform/nah/pkg/apply"
 	"github.com/obot-platform/nah/pkg/name"
 	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/nanobot/pkg/safehttp"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
@@ -65,6 +66,7 @@ const (
 type Handler struct {
 	defaultCatalogPath        string
 	defaultSystemCatalogPath  string
+	httpClient                *http.Client
 	gatewayClient             *gclient.Client
 	accessControlRuleHelper   *accesscontrolrule.Helper
 	remoteURLValidationConfig validation.Options
@@ -89,13 +91,15 @@ func (h *Handler) revealCatalogCredential(ctx context.Context, catalogName, sour
 }
 
 func New(defaultCatalogPath, defaultSystemCatalogPath string, gatewayClient *gclient.Client, accessControlRuleHelper *accesscontrolrule.Helper, mcpSessionManager *mcp.SessionManager) *Handler {
+	remoteURLValidationConfig := mcpSessionManager.RemoteMCPURLValidationConfig()
 	return &Handler{
 		defaultCatalogPath:       defaultCatalogPath,
 		defaultSystemCatalogPath: defaultSystemCatalogPath,
 		gatewayClient:            gatewayClient,
+		httpClient:               safehttp.NewClient(!remoteURLValidationConfig.AllowLocalhostMCP, !remoteURLValidationConfig.AllowPrivateIPMCP, !remoteURLValidationConfig.AllowLinkLocalMCP),
 		accessControlRuleHelper:  accessControlRuleHelper,
 		remoteURLValidationConfig: validation.Options{
-			RemoteMCPURLValidationConfig: mcpSessionManager.RemoteMCPURLValidationConfig(),
+			RemoteMCPURLValidationConfig: remoteURLValidationConfig,
 		},
 		mcpBackend: mcpSessionManager.MCPRuntimeBackend(),
 	}
@@ -261,7 +265,7 @@ func (h *Handler) SyncSystem(req router.Request, resp router.Response) error {
 }
 
 func (h *Handler) readSystemMCPCatalog(ctx context.Context, catalogName, sourceURL, token string) ([]client.Object, error) {
-	entries, err := readCatalogManifests[types.SystemMCPServerCatalogEntryManifest](ctx, sourceURL, token)
+	entries, err := readCatalogManifests[types.SystemMCPServerCatalogEntryManifest](ctx, h.httpClient, sourceURL, token)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +369,7 @@ func (h *Handler) readMCPCatalog(ctx context.Context, catalogName, sourceURL, to
 			if token != "" {
 				req.Header.Set("Authorization", "Bearer "+token)
 			}
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := h.httpClient.Do(req)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read catalog %s: %w", sourceURL, err)
 			}
@@ -462,7 +466,7 @@ func (h *Handler) readMCPCatalog(ctx context.Context, catalogName, sourceURL, to
 	return objs, errors.Join(errs...)
 }
 
-func readCatalogManifests[T any](ctx context.Context, sourceURL, token string) ([]T, error) {
+func readCatalogManifests[T any](ctx context.Context, httpClient *http.Client, sourceURL, token string) ([]T, error) {
 	if strings.HasPrefix(sourceURL, "http://") || strings.HasPrefix(sourceURL, "https://") {
 		if isGitRepoURL(sourceURL) {
 			entries, err := readGitCatalogEntries[T](ctx, sourceURL, token)
@@ -479,7 +483,7 @@ func readCatalogManifests[T any](ctx context.Context, sourceURL, token string) (
 		if token != "" {
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read catalog %s: %w", sourceURL, err)
 		}

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -925,7 +925,9 @@ func (h *Handler) SyncOAuthMetadata(req router.Request, _ router.Response) error
 		return setOAuthMetadata(req, server, new(v1.OAuthMetadata), nil)
 	}
 
-	if err := mcp.ValidateRemoteMCPURL(req.Ctx, server.Spec.Manifest.RemoteConfig.URL, h.mcpSessionManager.RemoteMCPURLValidationConfig()); err != nil {
+	blockingConfig := h.mcpSessionManager.RemoteMCPURLValidationConfig()
+
+	if err := mcp.ValidateRemoteMCPURL(req.Ctx, server.Spec.Manifest.RemoteConfig.URL, blockingConfig); err != nil {
 		// If the URL doesn't pass validation, then don't do anything so that we sync as soon as the configuration is updated.
 		log.Infof("Remote MCP URL validation failed, not checking OAuth metadata: server=%s error=%v", server.Name, err)
 		return nil
@@ -955,10 +957,12 @@ func (h *Handler) SyncOAuthMetadata(req router.Request, _ router.Response) error
 		return nil
 	}
 
-	metadata, err := nmcp.GetOAuthMetadata(req.Ctx, nmcp.Server{
+	metadata, err := nmcp.GetOAuthMetadataWithBlockingConfig(req.Ctx, nmcp.Server{
 		BaseURL: serverConfig.URL,
 		Headers: serverConfigHeaders(serverConfig),
-	}, "Obot Test MCP OAuth Client", system.MCPOAuthCallbackURL(h.baseURL))
+	}, "Obot Test MCP OAuth Client", system.MCPOAuthCallbackURL(h.baseURL),
+		!blockingConfig.AllowLocalhostMCP, !blockingConfig.AllowPrivateIPMCP, !blockingConfig.AllowLinkLocalMCP,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to get OAuth metadata: %w", err)
 	}

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -1026,6 +1026,9 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 					"NANOBOT_RUN_AUDIT_LOG_BATCH_SIZE=" + strconv.Itoa(d.auditLogsBatchSize),
 					"NANOBOT_RUN_AUDIT_LOG_FLUSH_INTERVAL_SECONDS=" + strconv.Itoa(d.auditLogsFlushIntervalSeconds),
 					"NANOBOT_RUN_AUDIT_LOG_METADATA=" + server.AuditLogMetadata,
+					"NANOBOT_RUN_BLOCK_LINK_LOCAL=true",
+					"NANOBOT_RUN_BLOCK_LOOPBACK=true",
+					// Explicitly not blocking private IP because the shim will communicate with the MCP server via the MCP server's private IP.
 				}...)
 
 				for key, value := range nanobotOTELEnv("nanobot-shim", d.transformCollectorEndpoint) {

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -509,6 +509,10 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 		secretEnvData["NANOBOT_RUN_AUDIT_LOG_FLUSH_INTERVAL_SECONDS"] = []byte(strconv.Itoa(k.auditLogsFlushIntervalSeconds))
 		secretEnvData["NANOBOT_RUN_AUDIT_LOG_METADATA"] = []byte(server.AuditLogMetadata)
 
+		secretEnvData["NANOBOT_RUN_BLOCK_LINK_LOCAL"] = []byte("true")
+		secretEnvData["NANOBOT_RUN_BLOCK_PRIVATE_IP"] = []byte("true")
+		// Explicitly not blocking loopback because the shim will communicate with the MCP server via loopback.
+
 		if server.Runtime == types.RuntimeRemote {
 			// non-remote runtimes will have their otel config added to the shim container below
 			maps.Copy(secretEnvData, nanobotOTELEnv("nanobot-shim", nil))

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -25,7 +25,7 @@ var log = logger.Package()
 type Options struct {
 	MCPBaseImage                      string   `usage:"The base image to use for MCP containers" default:"ghcr.io/obot-platform/mcp-images/stdio-wrapper:v0.24.0"`
 	MCPHTTPWebhookBaseImage           string   `usage:"The base image to use for HTTP-based MCP webhook containers" default:"ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.24.0"`
-	MCPRemoteShimBaseImage            string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/obot-platform/nanobot:v0.0.86"`
+	MCPRemoteShimBaseImage            string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/obot-platform/nanobot:v0.0.87"`
 	MCPNamespace                      string   `usage:"The namespace to use for MCP containers" default:"obot-mcp"`
 	MCPClusterDomain                  string   `usage:"The cluster domain to use for MCP containers" default:"cluster.local"`
 	DisallowLocalhostMCP              bool     `usage:"Disallow MCP containers from connecting to localhost" default:"true"`

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -112,7 +112,7 @@ type Config struct {
 	EnableAgents                         *bool  `usage:"Enable Obot Agent features. When unset, agents are disabled for new deployments but grandfathered in for deployments that already have agents. Explicitly set to true to force-enable, or false to force-disable, regardless of grandfathering." env:"OBOT_ENABLE_AGENTS"`
 	MCPOAuthClientExpiration             string `usage:"The expiration time in dynamically registered MCP OAuth clients, must be a valid duration string and may include days, hours, or minutes" default:"30d"`
 	MCPServerSearchImage                 string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.2.0"`
-	NanobotAgentImage                    string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/obot-platform/nanobot-agent:v0.0.86"`
+	NanobotAgentImage                    string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/obot-platform/nanobot-agent:v0.0.87"`
 	MCPNetworkPolicyProviderChartRepo    string `usage:"Helm repository URL for the network policy provider chart"`
 	MCPNetworkPolicyProviderChartName    string `usage:"Helm chart name for the network policy provider chart"`
 	MCPNetworkPolicyProviderChartVersion string `usage:"Helm chart version for the network policy provider chart"`


### PR DESCRIPTION
The goal of this change is to block these for Client ID Metatdata Documents. However, for extra safety, these are also block for OAuth URL fetching.

Requires: https://github.com/obot-platform/nanobot/pull/336