### PR TITLE
chore: change language when user configuration is required

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
@@ -631,13 +631,11 @@
 			<div class="flex grow flex-col gap-2">
 				<div class="flex items-center gap-2">
 					<TriangleAlert class="size-6 shrink-0 self-start text-warning" />
-					<p class="my-0.5 flex flex-col text-sm font-semibold">
-						User Configuration Update Required
-					</p>
+					<p class="my-0.5 flex flex-col text-sm font-semibold">User Configuration Required</p>
 				</div>
 				<span class="text-sm font-light break-all">
-					The server was recently updated and requires the user to update their configuration.
-					Server details and logs are temporarily unavailable as a result.
+					Required user configuration is missing, either from initial setup or a catalog entry
+					update. Server details and logs are temporarily unavailable as a result.
 				</span>
 			</div>
 		</div>
@@ -656,7 +654,7 @@
 							: missingSecretBindings.length > 0
 								? 'Missing Kubernetes Secret'
 								: needsUpdate
-									? 'Update Required'
+									? 'Configuration Required'
 									: 'Error'}
 					</p>
 				</div>

--- a/ui/user/src/routes/mcp-catalog/EntriesView.svelte
+++ b/ui/user/src/routes/mcp-catalog/EntriesView.svelte
@@ -296,7 +296,7 @@
 											classes: ['border-primary', 'bg-primary/10', 'dark:bg-primary/50'],
 											text: deploymentsNeedingAttentionByCatalogEntry.has(d.data.id)
 												? 'One or multiple deployments require your attention'
-												: 'An update requires your attention'
+												: 'Configuration requires your attention'
 										}}
 									>
 										<CircleFadingArrowUp class="text-primary size-4" />

--- a/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
+++ b/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
@@ -290,7 +290,7 @@
 								<span
 									use:tooltip={{
 										classes: ['border-primary', 'bg-primary/10', 'dark:bg-primary/50'],
-										text: 'An update requires your attention'
+										text: 'Configuration requires your attention'
 									}}
 								>
 									<CircleFadingArrowUp class="text-primary size-4" />
@@ -409,7 +409,7 @@
 							<span
 								use:tooltip={{
 									classes: ['border-primary', 'bg-primary/10', 'dark:bg-primary/50'],
-									text: 'An update requires your attention'
+									text: 'Configuration requires your attention'
 								}}
 							>
 								<CircleFadingArrowUp class="text-primary size-4" />


### PR DESCRIPTION
Previously, the only way for required configuation to not be set for an MCP server was when a catalog entry was updated and pushed out. Now that a user can go through the OAuth flow and bail at the end, we've made it easier for users to get in the state of having an MCP server with no required configuration set. This change updates the language in the UI.

Issue: https://github.com/obot-platform/obot/issues/7041