### PR TITLE
fix: stop refreshing invalid MCP tokens

### DIFF
--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -1,12 +1,16 @@
 package authz
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/pkg/accesscontrolrule"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user User) (bool, error) {
@@ -16,46 +20,50 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user Us
 		return true, nil
 	}
 
+	return CheckMCPIDAccess(req.Context(), a.uncached, a.acrHelper, user.Info, resources.MCPID)
+}
+
+func CheckMCPIDAccess(ctx context.Context, client kclient.Client, acrHelper *accesscontrolrule.Helper, user kuser.Info, mcpID string) (bool, error) {
 	switch {
-	case system.IsMCPServerInstanceID(resources.MCPID):
+	case system.IsMCPServerInstanceID(mcpID):
 		var mcpServerInstance v1.MCPServerInstance
-		if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &mcpServerInstance); err != nil {
+		if err := client.Get(ctx, router.Key(system.DefaultNamespace, mcpID), &mcpServerInstance); err != nil {
 			return false, err
 		}
 
 		return mcpServerInstance.Spec.UserID == user.GetUID(), nil
 
-	case system.IsMCPServerID(resources.MCPID):
+	case system.IsMCPServerID(mcpID):
 		var mcpServer v1.MCPServer
-		if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &mcpServer); err != nil {
+		if err := client.Get(ctx, router.Key(system.DefaultNamespace, mcpID), &mcpServer); err != nil {
 			return false, err
 		}
 
 		if mcpServer.Spec.IsCatalogServer() {
-			return a.acrHelper.UserHasAccessToMCPServerInCatalog(user, resources.MCPID, mcpServer.Spec.MCPCatalogID)
+			return acrHelper.UserHasAccessToMCPServerInCatalog(user, mcpID, mcpServer.Spec.MCPCatalogID)
 		} else if mcpServer.Spec.IsPowerUserWorkspaceServer() {
-			return a.acrHelper.UserHasAccessToMCPServerInWorkspace(user, resources.MCPID, mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Spec.UserID)
+			return acrHelper.UserHasAccessToMCPServerInWorkspace(user, mcpID, mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Spec.UserID)
 		}
 
 		return mcpServer.Spec.IsOwnedBy(user.GetUID()), nil
 
-	case system.IsSystemMCPServerID(resources.MCPID):
+	case system.IsSystemMCPServerID(mcpID):
 		var systemMCPServer v1.SystemMCPServer
-		if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &systemMCPServer); err != nil {
+		if err := client.Get(ctx, router.Key(system.DefaultNamespace, mcpID), &systemMCPServer); err != nil {
 			return false, err
 		}
 		// If this is a system MCP server, then allow access. The system MCP server will enforce its own authorization.
 		return systemMCPServer.Spec.Manifest.Enabled == nil || *systemMCPServer.Spec.Manifest.Enabled, nil
 	default:
 		var entry v1.MCPServerCatalogEntry
-		if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.MCPID), &entry); err != nil {
+		if err := client.Get(ctx, router.Key(system.DefaultNamespace, mcpID), &entry); err != nil {
 			return false, err
 		}
 
 		if entry.Spec.MCPCatalogName != "" {
-			return a.acrHelper.UserHasAccessToMCPServerCatalogEntryInCatalog(user, resources.MCPID, entry.Spec.MCPCatalogName)
+			return acrHelper.UserHasAccessToMCPServerCatalogEntryInCatalog(user, mcpID, entry.Spec.MCPCatalogName)
 		} else if entry.Spec.PowerUserWorkspaceID != "" {
-			return a.acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(req.Context(), user, resources.MCPID, entry.Spec.PowerUserWorkspaceID)
+			return acrHelper.UserHasAccessToMCPServerCatalogEntryInWorkspace(ctx, user, mcpID, entry.Spec.PowerUserWorkspaceID)
 		}
 
 		return false, nil

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -25,6 +25,7 @@ import (
 type ErrorCode string
 
 const (
+	ErrInvalidClient           ErrorCode = "invalid_client"
 	ErrInvalidRequest          ErrorCode = "invalid_request"
 	ErrUnauthorizedClient      ErrorCode = "unauthorized_client"
 	ErrAccessDenied            ErrorCode = "access_denied"
@@ -48,6 +49,17 @@ func (e Error) Error() string {
 		return string(e.Code) + ": " + e.Description
 	}
 	return string(b)
+}
+
+func newOAuthErrHTTP(statusCode int, oauthErr Error) *types.ErrHTTP {
+	return types.NewErrHTTP(statusCode, oauthErr.Error())
+}
+
+func newInvalidClientErr(statusCode int, description string) *types.ErrHTTP {
+	return newOAuthErrHTTP(statusCode, Error{
+		Code:        ErrInvalidClient,
+		Description: description,
+	})
 }
 
 func (e Error) toQuery() url.Values {
@@ -123,7 +135,7 @@ func (h *handler) authorize(req api.Context) error {
 
 	if !isRedirectURIAllowed(oauthClient.Spec.Manifest, redirectURI) {
 		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
+			Code:        ErrInvalidClient,
 			Description: "redirect_uri is invalid for this client",
 			State:       state,
 		})
@@ -387,6 +399,11 @@ func (h *handler) consent(req api.Context) error {
 
 	oauthClient, err := h.resolveOAuthClient(req.Context(), req.Storage, clientID)
 	if err != nil {
+		if oauthErr, ok := errors.AsType[Error](err); ok {
+			oauthErr.State = oauthAppAuthRequest.Spec.State
+			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, oauthErr)
+			return nil
+		}
 		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
 			Code:        ErrServerError,
 			Description: fmt.Sprintf("failed to get OAuth client: %v", err),

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
@@ -51,7 +51,7 @@ func (h *handler) resolveOAuthClient(ctx context.Context, c kclient.Client, clie
 	clientNamespace, clientName, ok := strings.Cut(clientID, ":")
 	if !ok {
 		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidRequest,
+			Code:        ErrInvalidClient,
 			Description: "client_id is invalid",
 		}
 	}
@@ -59,7 +59,7 @@ func (h *handler) resolveOAuthClient(ctx context.Context, c kclient.Client, clie
 	var oauthClient v1.OAuthClient
 	if err := c.Get(ctx, kclient.ObjectKey{Namespace: clientNamespace, Name: clientName}, &oauthClient); apierrors.IsNotFound(err) {
 		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidRequest,
+			Code:        ErrInvalidClient,
 			Description: fmt.Sprintf("client_id does not exist: %s", clientID),
 		}
 	} else if err != nil {
@@ -75,7 +75,7 @@ func (h *handler) resolveOAuthClient(ctx context.Context, c kclient.Client, clie
 func (h *handler) resolveClientIDMetadataDocument(ctx context.Context, clientID string) (v1.OAuthClient, error) {
 	if err := validateClientIDMetadataDocumentURL(clientID); err != nil {
 		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidClientMetadata,
+			Code:        ErrInvalidClient,
 			Description: err.Error(),
 		}
 	}
@@ -87,7 +87,7 @@ func (h *handler) resolveClientIDMetadataDocument(ctx context.Context, clientID 
 	doc, expiresAt, err := h.fetchClientIDMetadataDocument(ctx, clientID)
 	if err != nil {
 		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidClientMetadata,
+			Code:        ErrInvalidClient,
 			Description: err.Error(),
 		}
 	}
@@ -95,7 +95,7 @@ func (h *handler) resolveClientIDMetadataDocument(ctx context.Context, clientID 
 	client, err := h.oauthClientFromMetadataDocument(clientID, doc)
 	if err != nil {
 		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidClientMetadata,
+			Code:        ErrInvalidClient,
 			Description: err.Error(),
 		}
 	}

--- a/pkg/api/handlers/mcpgateway/oauth/handler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/obot-platform/nanobot/pkg/safehttp"
+	"github.com/obot-platform/obot/pkg/accesscontrolrule"
 	"github.com/obot-platform/obot/pkg/api/handlers"
 	"github.com/obot-platform/obot/pkg/api/server"
 	"github.com/obot-platform/obot/pkg/jwt/persistent"
@@ -18,6 +19,7 @@ type handler struct {
 	tokenService     *persistent.TokenService
 	oauthConfig      handlers.OAuthAuthorizationServerConfig
 	tokenStore       mcp.GlobalTokenStore
+	acrHelper        *accesscontrolrule.Helper
 	baseURL          string
 	clientExpiration time.Duration
 
@@ -26,7 +28,7 @@ type handler struct {
 	clientMetadataCacheLock  sync.Mutex
 }
 
-func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTokenStore, tokenService *persistent.TokenService, oauthConfig handlers.OAuthAuthorizationServerConfig, mcpSessionManager *mcp.SessionManager, baseURL string, clientSecretExpiration time.Duration, mux *server.Server) {
+func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTokenStore, tokenService *persistent.TokenService, oauthConfig handlers.OAuthAuthorizationServerConfig, mcpSessionManager *mcp.SessionManager, acrHelper *accesscontrolrule.Helper, baseURL string, clientSecretExpiration time.Duration, mux *server.Server) {
 	remoteURLValidationConfig := mcpSessionManager.RemoteMCPURLValidationConfig()
 	h := &handler{
 		tokenStore:               tokenStore,
@@ -35,6 +37,7 @@ func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTo
 		clientMetadataHTTPClient: safehttp.NewClientWithTimeout(!remoteURLValidationConfig.AllowLocalhostMCP, !remoteURLValidationConfig.AllowPrivateIPMCP, !remoteURLValidationConfig.AllowLinkLocalMCP, clientMetadataFetchTimeout),
 		baseURL:                  baseURL,
 		oauthChecker:             oauthChecker,
+		acrHelper:                acrHelper,
 		clientExpiration:         clientSecretExpiration,
 		clientMetadataCache:      map[string]clientMetadataCacheEntry{},
 	}

--- a/pkg/api/handlers/mcpgateway/oauth/private_key_jwt.go
+++ b/pkg/api/handlers/mcpgateway/oauth/private_key_jwt.go
@@ -49,7 +49,7 @@ func clientIDFromClientAssertion(form url.Values) (string, error) {
 	return claims.Subject, nil
 }
 
-func (h *handler) validatePrivateKeyJWT(ctx context.Context, form url.Values, client v1.OAuthClient) error {
+func (h *handler) validatePrivateKeyJWT(ctx context.Context, form url.Values, client v1.OAuthClient, clientID string) error {
 	if form.Get("client_assertion_type") != clientAssertionTypeJWTBearer {
 		return fmt.Errorf("client_assertion_type must be %s", clientAssertionTypeJWTBearer)
 	}
@@ -78,8 +78,8 @@ func (h *handler) validatePrivateKeyJWT(ctx context.Context, form url.Values, cl
 	parser := jwt.NewParser(
 		jwt.WithAudience(tokenEndpoint),
 		jwt.WithExpirationRequired(),
-		jwt.WithIssuer(client.Name),
-		jwt.WithSubject(client.Name),
+		jwt.WithIssuer(clientID),
+		jwt.WithSubject(clientID),
 		jwt.WithValidMethods(validMethods),
 	)
 

--- a/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -19,6 +21,7 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
+	"golang.org/x/crypto/bcrypt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -58,6 +61,7 @@ func TestValidatePrivateKeyJWT(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: clientID},
 		Spec: v1.OAuthClientSpec{
 			Manifest: types.OAuthClientManifest{
+				RedirectURIs:            []string{"http://127.0.0.1/callback"},
 				TokenEndpointAuthMethod: "private_key_jwt",
 				JWKS:                    string(jwks),
 			},
@@ -70,12 +74,12 @@ func TestValidatePrivateKeyJWT(t *testing.T) {
 		"client_assertion":      {assertion},
 	}
 
-	if err := h.validatePrivateKeyJWT(context.Background(), form, client); err != nil {
+	if err := h.validatePrivateKeyJWT(context.Background(), form, client, clientID); err != nil {
 		t.Fatalf("validate private_key_jwt: %v", err)
 	}
 
 	form.Set("client_assertion", signClientAssertion(t, key, "test-key", clientID, "https://other.example/oauth/token"))
-	if err := h.validatePrivateKeyJWT(context.Background(), form, client); err == nil {
+	if err := h.validatePrivateKeyJWT(context.Background(), form, client, clientID); err == nil {
 		t.Fatal("expected invalid audience to fail")
 	}
 }
@@ -109,6 +113,17 @@ func TestTokenExtractsClientIDFromClientAssertion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate rsa key: %v", err)
 	}
+	jwks, err := json.Marshal(jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{{
+			Key:       &key.PublicKey,
+			KeyID:     "test-key",
+			Algorithm: "RS256",
+			Use:       "sig",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal jwks: %v", err)
+	}
 
 	const clientName = "test-client"
 	clientID := system.DefaultNamespace + ":" + clientName
@@ -119,7 +134,9 @@ func TestTokenExtractsClientIDFromClientAssertion(t *testing.T) {
 		},
 		Spec: v1.OAuthClientSpec{
 			Manifest: types.OAuthClientManifest{
+				RedirectURIs:            []string{"http://127.0.0.1/callback"},
 				TokenEndpointAuthMethod: "private_key_jwt",
+				JWKS:                    string(jwks),
 			},
 		},
 	}).Build()
@@ -134,7 +151,16 @@ func TestTokenExtractsClientIDFromClientAssertion(t *testing.T) {
 
 	err = (&handler{
 		oauthConfig: handlers.OAuthAuthorizationServerConfig{
-			GrantTypesSupported: []string{"authorization_code"},
+			TokenEndpoint:          "https://obot.example/oauth/token",
+			GrantTypesSupported:    []string{"authorization_code"},
+			ScopesSupported:        []string{"profile"},
+			ResponseTypesSupported: []string{"code"},
+			TokenEndpointAuthMethodsSupported: []string{
+				"client_secret_basic",
+				"client_secret_post",
+				"private_key_jwt",
+				"none",
+			},
 		},
 	}).token(api.Context{
 		ResponseWriter: httptest.NewRecorder(),
@@ -146,6 +172,106 @@ func TestTokenExtractsClientIDFromClientAssertion(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "grant_type") {
 		t.Fatalf("expected request to reach grant type validation, got %v", err)
+	}
+}
+
+func TestTokenInvalidClientErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing credentials", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader("grant_type=authorization_code"))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		err := (&handler{}).token(api.Context{
+			ResponseWriter: httptest.NewRecorder(),
+			Request:        req,
+		})
+		assertInvalidClientErr(t, err)
+	})
+
+	t.Run("unknown client", func(t *testing.T) {
+		t.Parallel()
+
+		form := url.Values{
+			"grant_type": {"authorization_code"},
+			"client_id":  {system.DefaultNamespace + ":missing-client"},
+		}
+		req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		err := (&handler{
+			oauthConfig: handlers.OAuthAuthorizationServerConfig{
+				ScopesSupported:                   []string{"profile"},
+				ResponseTypesSupported:            []string{"code"},
+				TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post", "private_key_jwt", "none"},
+			},
+		}).token(api.Context{
+			ResponseWriter: httptest.NewRecorder(),
+			Request:        req,
+			Storage:        clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).Build(),
+		})
+		assertInvalidClientErr(t, err)
+	})
+
+	t.Run("invalid client secret", func(t *testing.T) {
+		t.Parallel()
+
+		secretHash, err := bcrypt.GenerateFromPassword([]byte("correct-secret"), bcrypt.DefaultCost)
+		if err != nil {
+			t.Fatalf("hash secret: %v", err)
+		}
+		const clientName = "test-client"
+		storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.OAuthClient{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.DefaultNamespace,
+				Name:      clientName,
+			},
+			Spec: v1.OAuthClientSpec{
+				ClientSecretHash: secretHash,
+				Manifest: types.OAuthClientManifest{
+					RedirectURIs:            []string{"http://127.0.0.1/callback"},
+					TokenEndpointAuthMethod: "client_secret_post",
+				},
+			},
+		}).Build()
+
+		form := url.Values{
+			"grant_type":    {"authorization_code"},
+			"client_id":     {system.DefaultNamespace + ":" + clientName},
+			"client_secret": {"wrong-secret"},
+		}
+		req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		err = (&handler{
+			oauthConfig: handlers.OAuthAuthorizationServerConfig{
+				ScopesSupported:                   []string{"profile"},
+				ResponseTypesSupported:            []string{"code"},
+				TokenEndpointAuthMethodsSupported: []string{"client_secret_basic", "client_secret_post", "private_key_jwt", "none"},
+			},
+		}).token(api.Context{
+			ResponseWriter: httptest.NewRecorder(),
+			Request:        req,
+			Storage:        storage,
+		})
+		assertInvalidClientErr(t, err)
+	})
+}
+
+func assertInvalidClientErr(t *testing.T, err error) {
+	t.Helper()
+
+	var errHTTP *types.ErrHTTP
+	if !errors.As(err, &errHTTP) {
+		t.Fatalf("expected ErrHTTP, got %T: %v", err, err)
+	}
+	if errHTTP.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, errHTTP.Code)
+	}
+	if !strings.Contains(errHTTP.Message, `"error":"invalid_client"`) {
+		t.Fatalf("expected invalid_client error, got %s", errHTTP.Message)
 	}
 }
 

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -17,6 +17,8 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/obot-platform/obot/pkg/auth"
 	gwtypes "github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/jwt/persistent"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -61,27 +63,24 @@ func (h *handler) token(req api.Context) error {
 			c, err := base64.StdEncoding.DecodeString(creds)
 			if err != nil {
 				log.Infof("Denied OAuth token request due to invalid basic auth encoding")
-				return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
+				return newInvalidClientErr(http.StatusUnauthorized, "invalid client credentials")
 			}
 
 			idx := bytes.LastIndex(c, []byte{':'})
 			if idx == -1 {
 				log.Infof("Denied OAuth token request due to malformed basic auth credentials")
-				return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
+				return newInvalidClientErr(http.StatusUnauthorized, "invalid client credentials")
 			}
 
 			clientID, clientSecret = string(c[:idx]), string(c[idx+1:])
 			if clientID == "" {
-				return types.NewErrBadRequest("%v", Error{
-					Code:        ErrInvalidRequest,
-					Description: "client_id is required",
-				})
+				return newInvalidClientErr(http.StatusUnauthorized, "client_id is required")
 			}
 
 			clientID, err = url.QueryUnescape(clientID)
 			if err != nil {
-				return types.NewErrBadRequest("%v", Error{
-					Code:        ErrInvalidRequest,
+				return newOAuthErrHTTP(http.StatusBadRequest, Error{
+					Code:        ErrInvalidClient,
 					Description: "client_id is invalid",
 				})
 			}
@@ -94,22 +93,22 @@ func (h *handler) token(req api.Context) error {
 		var err error
 		clientID, err = clientIDFromClientAssertion(req.Form)
 		if err != nil {
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: err.Error(),
-			})
+			return newInvalidClientErr(http.StatusUnauthorized, err.Error())
 		}
 	}
 
 	if clientID == "" {
 		log.Infof("Denied OAuth token request due to missing client credentials")
-		return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
+		return newInvalidClientErr(http.StatusUnauthorized, "invalid client credentials")
 	}
 
 	client, err := h.resolveOAuthClient(req.Context(), req.Storage, clientID)
 	if err != nil {
 		if oauthErr, ok := errors.AsType[Error](err); ok {
-			return types.NewErrBadRequest("%v", oauthErr)
+			if oauthErr.Code == ErrInvalidClient {
+				return newOAuthErrHTTP(http.StatusUnauthorized, oauthErr)
+			}
+			return newOAuthErrHTTP(http.StatusBadRequest, oauthErr)
 		}
 		return err
 	}
@@ -118,7 +117,12 @@ func (h *handler) token(req api.Context) error {
 	case "client_secret_basic", "client_secret_post":
 		if bcrypt.CompareHashAndPassword(client.Spec.ClientSecretHash, []byte(clientSecret)) != nil {
 			log.Infof("Denied OAuth token request due to invalid client secret: client=%s/%s", client.Namespace, client.Name)
-			return types.NewErrHTTP(http.StatusUnauthorized, "Invalid client credentials")
+			return newInvalidClientErr(http.StatusUnauthorized, "invalid client credentials")
+		}
+	case "private_key_jwt":
+		if err := h.validatePrivateKeyJWT(req.Context(), req.Form, client, clientID); err != nil {
+			log.Infof("Denied OAuth token request due to invalid private_key_jwt client assertion: client=%s/%s error=%v", client.Namespace, client.Name, err)
+			return newInvalidClientErr(http.StatusUnauthorized, err.Error())
 		}
 	}
 
@@ -132,7 +136,7 @@ func (h *handler) token(req api.Context) error {
 
 	if len(client.Spec.Manifest.GrantTypes) > 0 && !slices.Contains(client.Spec.Manifest.GrantTypes, grantType) || len(client.Spec.Manifest.GrantTypes) == 0 && grantType != "authorization_code" {
 		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
+			Code:        ErrInvalidClient,
 			Description: "client is not allowed to use authorization_code grant type",
 		})
 	}
@@ -303,8 +307,7 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 		return fmt.Errorf("failed to refresh oauth token: %w", err)
 	}
 
-	userID := fmt.Sprintf("%d", oauthToken.Spec.UserID)
-	user, err := req.GatewayClient.UserByID(req.Context(), userID)
+	user, err := req.GatewayClient.UserInfoByID(req.Context(), oauthToken.Spec.UserID)
 	if err != nil {
 		return types.NewErrBadRequest("%v", Error{
 			Code:        ErrInvalidRequest,
@@ -312,18 +315,23 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 		})
 	}
 
-	// If this is an MCP server instance and the resource isn't the MCP server, then update it to the MCP server.
-	if system.IsMCPServerInstanceID(oauthToken.Spec.MCPID) && strings.HasSuffix(oauthToken.Spec.Resource, "/"+oauthToken.Spec.MCPID) {
-		// If this is an MCP server instance ID, we need to get the MCP server ID
-		var mcpServerInstance v1.MCPServerInstance
-		if err := req.Storage.Get(req.Context(), kclient.ObjectKey{Namespace: oauthClient.Namespace, Name: oauthToken.Spec.MCPID}, &mcpServerInstance); err != nil {
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: "invalid MCP server",
-			})
+	allowed, err := authz.CheckMCPIDAccess(req.Context(), req.Storage, h.acrHelper, user, oauthToken.Spec.MCPID)
+	if apierrors.IsNotFound(err) {
+		return types.NewErrBadRequest("%v", Error{
+			Code:        ErrInvalidRequest,
+			Description: "invalid MCP server",
+		})
+	} else if err != nil {
+		return Error{
+			Code:        ErrServerError,
+			Description: fmt.Sprintf("failed to check access to MCP server: %v", err),
 		}
-
-		oauthToken.Spec.Resource = fmt.Sprintf("%s/mcp-connect/%s", h.baseURL, mcpServerInstance.Spec.MCPServerName)
+	}
+	if !allowed {
+		return types.NewErrBadRequest("%v", Error{
+			Code:        ErrInvalidRequest,
+			Description: "invalid MCP server",
+		})
 	}
 
 	now := time.Now()
@@ -332,10 +340,9 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 		Audience:              oauthToken.Spec.Resource,
 		IssuedAt:              now,
 		ExpiresAt:             now.Add(tokenExpiration),
-		UserID:                userID,
-		UserName:              user.Username,
-		UserEmail:             user.Email,
-		Picture:               user.IconURL,
+		UserID:                user.GetUID(),
+		UserName:              user.GetName(),
+		UserEmail:             auth.FirstExtraValue(user.GetExtra(), "email"),
 		UserGroups:            []string{types.GroupMCP, types.GroupAuthenticated},
 		AuthProviderName:      oauthToken.Spec.AuthProviderName,
 		AuthProviderNamespace: oauthToken.Spec.AuthProviderNamespace,

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -579,7 +579,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	wellknown.SetupHandlers(services.ServerURL, services.OAuthServerConfig, services.RegistryNoAuth, mux)
 
 	// Obot OAuth
-	oauth.SetupHandlers(oauthChecker, services.MCPOAuthTokenStorage, services.PersistentTokenServer, services.OAuthServerConfig, services.MCPSessionManager, services.ServerURL, services.MCPOAuthClientSecretExpiration, mux)
+	oauth.SetupHandlers(oauthChecker, services.MCPOAuthTokenStorage, services.PersistentTokenServer, services.OAuthServerConfig, services.MCPSessionManager, services.AccessControlRuleHelper, services.ServerURL, services.MCPOAuthClientSecretExpiration, mux)
 
 	// Gateway APIs
 	services.GatewayServer.AddRoutes(services.APIServer)

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -623,6 +623,7 @@ func (c *Client) UserInfoByID(ctx context.Context, userID uint) (kuser.Info, err
 		Groups: u.Role.Groups(),
 		Extra: map[string][]string{
 			"auth_provider_groups": groupIDs,
+			"email":                {u.Email},
 		},
 	}, nil
 }


### PR DESCRIPTION
If the MCP server for a given token was deleted or if the user has lost access to said server, then this change will stop refreshing such tokens.

This change also incorporates invalid_client errors where appropriate.

Issue: https://github.com/obot-platform/obot/issues/7046