### PR TITLE
fix: stop block nanobot private IPs in Kubernetes

### DIFF
--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -703,11 +703,6 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig,
 		}
 	}
 
-	if server.Runtime != types.RuntimeComposite {
-		// Composite runtimes talk to Obot via a service domain, which resolves to a private address.
-		secretEnvData["NANOBOT_RUN_BLOCK_PRIVATE_IP"] = []byte("true")
-	}
-
 	objs = append(objs, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name.SafeConcatName(server.MCPServerName, "mcp", "config"),


### PR DESCRIPTION
Various containers need to use private service domains. Instead of playing whack-a-mole on this, it's better to just let the network policies block this traffic.

Issue: https://github.com/obot-platform/obot/issues/7063