### PR TITLE
fix: recover Docker containers hidden from list

### DIFF
--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -724,6 +724,45 @@ func inspectResponseToSummary(name string, inspect container.InspectResponse) *c
 				})
 			}
 		}
+
+		hostIPRank := func(hostIP string) int {
+			switch hostIP {
+			case "127.0.0.1":
+				return 0
+			case "":
+				return 1
+			case "::1":
+				return 2
+			}
+
+			ip := net.ParseIP(hostIP)
+			if ip != nil && ip.To4() != nil {
+				return 1
+			}
+			if ip != nil {
+				return 3
+			}
+			return 4
+		}
+		sort.Slice(summary.Ports, func(i, j int) bool {
+			left, right := summary.Ports[i], summary.Ports[j]
+			if left.PrivatePort != right.PrivatePort {
+				return left.PrivatePort < right.PrivatePort
+			}
+			if left.Type != right.Type {
+				return left.Type < right.Type
+			}
+			if (left.PublicPort != 0) != (right.PublicPort != 0) {
+				return left.PublicPort != 0
+			}
+			if leftRank, rightRank := hostIPRank(left.IP), hostIPRank(right.IP); leftRank != rightRank {
+				return leftRank < rightRank
+			}
+			if left.IP != right.IP {
+				return left.IP < right.IP
+			}
+			return left.PublicPort < right.PublicPort
+		})
 	}
 
 	return summary

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -663,6 +664,71 @@ func (d *dockerBackend) getContainer(ctx context.Context, name string) (*contain
 	return nil, nil
 }
 
+func (d *dockerBackend) inspectContainer(ctx context.Context, name string) (*container.Summary, error) {
+	inspect, err := d.client.ContainerInspect(ctx, name)
+	if cerrdefs.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimPrefix(inspect.Name, "/") != name {
+		return nil, nil
+	}
+
+	return inspectResponseToSummary(name, inspect), nil
+}
+
+func inspectResponseToSummary(name string, inspect container.InspectResponse) *container.Summary {
+	summary := &container.Summary{
+		ID:              inspect.ID,
+		Names:           []string{inspect.Name},
+		Image:           inspect.Image,
+		Labels:          map[string]string{},
+		Mounts:          inspect.Mounts,
+		NetworkSettings: &container.NetworkSettingsSummary{},
+	}
+	if summary.Names[0] == "" {
+		summary.Names[0] = "/" + name
+	}
+	if inspect.Config != nil {
+		summary.Image = inspect.Config.Image
+		if inspect.Config.Labels != nil {
+			summary.Labels = maps.Clone(inspect.Config.Labels)
+		}
+	}
+	if inspect.State != nil {
+		summary.State = inspect.State.Status
+	}
+	if inspect.NetworkSettings != nil {
+		summary.NetworkSettings.Networks = inspect.NetworkSettings.Networks
+		for port, bindings := range inspect.NetworkSettings.Ports {
+			privatePort := uint16(port.Int())
+			if len(bindings) == 0 {
+				summary.Ports = append(summary.Ports, container.Port{
+					PrivatePort: privatePort,
+					Type:        port.Proto(),
+				})
+				continue
+			}
+			for _, binding := range bindings {
+				publicPort, err := strconv.ParseUint(binding.HostPort, 10, 16)
+				if err != nil {
+					continue
+				}
+				summary.Ports = append(summary.Ports, container.Port{
+					IP:          binding.HostIP,
+					PrivatePort: privatePort,
+					PublicPort:  uint16(publicPort),
+					Type:        port.Proto(),
+				})
+			}
+		}
+	}
+
+	return summary
+}
+
 func (d *dockerBackend) getDeploymentCache(mcpServerName string) *dockerDeploymentCacheEntry {
 	d.deploymentCacheMu.RLock()
 	defer d.deploymentCacheMu.RUnlock()
@@ -1070,6 +1136,12 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 			cont, getErr := d.getContainer(ctx, server.MCPServerName)
 			if getErr != nil {
 				return "", 0, fmt.Errorf("failed to create container: %w", err)
+			}
+			if cont == nil {
+				cont, getErr = d.inspectContainer(ctx, server.MCPServerName)
+				if getErr != nil {
+					return "", 0, fmt.Errorf("failed to inspect conflicting container: %w", getErr)
+				}
 			}
 			if cont == nil {
 				time.Sleep(time.Second)

--- a/pkg/mcp/docker_test.go
+++ b/pkg/mcp/docker_test.go
@@ -439,6 +439,39 @@ func TestInspectResponseToSummaryPreservesDeploymentFields(t *testing.T) {
 	require.Equal(t, "172.17.0.2", summary.NetworkSettings.Networks["bridge"].IPAddress)
 }
 
+func TestInspectResponseToSummaryOrdersPublishedPorts(t *testing.T) {
+	summary := inspectResponseToSummary("system-mcp-server", container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{Name: "/system-mcp-server"},
+		NetworkSettings: &container.NetworkSettings{
+			NetworkSettingsBase: container.NetworkSettingsBase{
+				Ports: nat.PortMap{
+					nat.Port("9090/tcp"): {{HostIP: "::1", HostPort: "49090"}},
+					nat.Port("8080/udp"): nil,
+					nat.Port("8080/tcp"): {
+						{HostIP: "::1", HostPort: "49153"},
+						{HostIP: "192.0.2.10", HostPort: "49154"},
+						{HostIP: "0.0.0.0", HostPort: "49155"},
+						{HostIP: "127.0.0.1", HostPort: "49152"},
+					},
+				},
+			},
+		},
+	})
+
+	require.Equal(t, []container.Port{
+		{IP: "127.0.0.1", PrivatePort: 8080, PublicPort: 49152, Type: "tcp"},
+		{IP: "0.0.0.0", PrivatePort: 8080, PublicPort: 49155, Type: "tcp"},
+		{IP: "192.0.2.10", PrivatePort: 8080, PublicPort: 49154, Type: "tcp"},
+		{IP: "::1", PrivatePort: 8080, PublicPort: 49153, Type: "tcp"},
+		{PrivatePort: 8080, Type: "udp"},
+		{IP: "::1", PrivatePort: 9090, PublicPort: 49090, Type: "tcp"},
+	}, summary.Ports)
+
+	hostPort, err := (&dockerBackend{}).getHostPort(summary, 8080)
+	require.NoError(t, err)
+	require.Equal(t, 49152, hostPort)
+}
+
 func TestInspectResponseToSummaryKeepsLabelsWritable(t *testing.T) {
 	summary := inspectResponseToSummary("system-mcp-server", container.InspectResponse{
 		ContainerJSONBase: &container.ContainerJSONBase{Name: "/system-mcp-server"},

--- a/pkg/mcp/docker_test.go
+++ b/pkg/mcp/docker_test.go
@@ -1,11 +1,25 @@
 package mcp
 
 import (
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
+	otypes "github.com/obot-platform/obot/apiclient/types"
+	"github.com/stretchr/testify/require"
 )
+
+var dockerAPIVersionPrefix = regexp.MustCompile(`^/v\d+(?:\.\d+)*`)
 
 func TestDockerTransformObotHostnameAlwaysRewritesHost(t *testing.T) {
 	d := &dockerBackend{hostBaseURLWithPort: "http://172.17.0.1:8080"}
@@ -244,4 +258,194 @@ func TestApplyServerConfigToContainerConfigNoImageNoChanges(t *testing.T) {
 	if _, ok := config.Labels["mcp.file.env.keys.hash"]; ok {
 		t.Fatalf("did not expect mcp.file.env.keys.hash label to be set")
 	}
+}
+
+func TestCreateAndStartContainerUsesInspectFallbackForCreatedNameConflict(t *testing.T) {
+	const (
+		containerName = "sms1obot-mcp-server"
+		containerID   = "17f163b3e3d6685f518c2b4cdbbd2545cc9228b57bb120555675bcf6fdf81d3c"
+		imageName     = "ghcr.io/obot-platform/obot-mcp-server:v0.1.1"
+	)
+
+	var createCalls atomic.Int32
+	var listCalls atomic.Int32
+	var inspectCalls atomic.Int32
+	var startCalls atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := dockerAPIVersionPrefix.ReplaceAllString(r.URL.Path, "")
+		switch {
+		case r.Method == http.MethodPost && path == "/images/create":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "{}")
+		case r.Method == http.MethodPost && path == "/containers/create":
+			createCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"message": "container name \"" + containerName + "\" is already in use by " + containerID,
+			})
+		case r.Method == http.MethodGet && path == "/containers/json":
+			listCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "[]")
+		case r.Method == http.MethodGet && path == "/containers/"+containerName+"/json":
+			inspectCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(container.InspectResponse{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					ID:    containerID,
+					Name:  "/" + containerName,
+					Image: imageName,
+					State: &container.State{Status: container.StateCreated},
+				},
+				Config: &container.Config{
+					Image: imageName,
+					Labels: map[string]string{
+						"mcp.config.hash":        "config-hash",
+						"mcp.file.env.keys.hash": "",
+					},
+				},
+				NetworkSettings: &container.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{"bridge": {}},
+				},
+			})
+		case r.Method == http.MethodPost && path == "/containers/"+containerID+"/start":
+			startCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected docker API request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	cli, err := client.NewClientWithOpts(
+		client.WithHost("tcp://"+strings.TrimPrefix(server.URL, "http://")),
+		client.WithHTTPClient(server.Client()),
+		client.WithVersion("1.51"),
+	)
+	require.NoError(t, err)
+
+	d := &dockerBackend{
+		client:  cli,
+		network: "bridge",
+	}
+
+	id, port, err := d.createAndStartContainer(t.Context(), ServerConfig{
+		MCPServerName:        containerName,
+		MCPServerDisplayName: "SMS MCP Server",
+		Runtime:              otypes.RuntimeContainerized,
+		ContainerImage:       imageName,
+		ContainerPort:        8080,
+	}, containerName, "config-hash", "")
+	require.NoError(t, err)
+	require.Equal(t, containerID, id)
+	require.Equal(t, 8080, port)
+	require.Equal(t, int32(1), createCalls.Load())
+	require.Equal(t, int32(1), listCalls.Load())
+	require.Equal(t, int32(1), inspectCalls.Load())
+	require.Equal(t, int32(1), startCalls.Load())
+}
+
+func TestGetContainerNotFoundDoesNotInspect(t *testing.T) {
+	const containerName = "missing-mcp-server"
+
+	var inspectCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := dockerAPIVersionPrefix.ReplaceAllString(r.URL.Path, "")
+		switch {
+		case r.Method == http.MethodGet && path == "/containers/json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "[]")
+		case r.Method == http.MethodGet && path == "/containers/"+containerName+"/json":
+			inspectCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "No such container"})
+		default:
+			t.Fatalf("unexpected docker API request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	cli, err := client.NewClientWithOpts(
+		client.WithHost("tcp://"+strings.TrimPrefix(server.URL, "http://")),
+		client.WithHTTPClient(server.Client()),
+		client.WithVersion("1.51"),
+	)
+	require.NoError(t, err)
+
+	summary, err := (&dockerBackend{client: cli}).getContainer(t.Context(), containerName)
+	require.NoError(t, err)
+	require.Nil(t, summary)
+	require.Zero(t, inspectCalls.Load())
+}
+
+func TestInspectResponseToSummaryPreservesDeploymentFields(t *testing.T) {
+	const containerName = "system-mcp-server"
+
+	summary := inspectResponseToSummary(containerName, container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:    "container-id",
+			Name:  "/" + containerName,
+			Image: "old-image",
+			State: &container.State{Status: container.StateCreated},
+		},
+		Config: &container.Config{
+			Image: "desired-image",
+			Labels: map[string]string{
+				"mcp.config.hash":        "config-hash",
+				"mcp.file.env.keys.hash": "file-env-hash",
+			},
+		},
+		NetworkSettings: &container.NetworkSettings{
+			NetworkSettingsBase: container.NetworkSettingsBase{
+				Ports: nat.PortMap{
+					nat.Port("8080/tcp"): {
+						{HostIP: "127.0.0.1", HostPort: "49152"},
+						{HostIP: "::1", HostPort: "49153"},
+					},
+					nat.Port("9090/udp"): nil,
+					nat.Port("7070/tcp"): {
+						{HostIP: "127.0.0.1", HostPort: ""},
+						{HostIP: "127.0.0.1", HostPort: "not-a-port"},
+					},
+				},
+			},
+			Networks: map[string]*network.EndpointSettings{"bridge": {IPAddress: "172.17.0.2"}},
+		},
+	})
+
+	require.Equal(t, "container-id", summary.ID)
+	require.Equal(t, []string{"/" + containerName}, summary.Names)
+	require.Equal(t, "desired-image", summary.Image)
+	require.Equal(t, container.StateCreated, summary.State)
+	require.Equal(t, "config-hash", summary.Labels["mcp.config.hash"])
+	require.Equal(t, "file-env-hash", summary.Labels["mcp.file.env.keys.hash"])
+	require.ElementsMatch(t, []container.Port{{
+		IP:          "127.0.0.1",
+		PrivatePort: 8080,
+		PublicPort:  49152,
+		Type:        "tcp",
+	}, {
+		IP:          "::1",
+		PrivatePort: 8080,
+		PublicPort:  49153,
+		Type:        "tcp",
+	}, {
+		PrivatePort: 9090,
+		Type:        "udp",
+	}}, summary.Ports)
+	require.Equal(t, "172.17.0.2", summary.NetworkSettings.Networks["bridge"].IPAddress)
+}
+
+func TestInspectResponseToSummaryKeepsLabelsWritable(t *testing.T) {
+	summary := inspectResponseToSummary("system-mcp-server", container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{Name: "/system-mcp-server"},
+		Config:            &container.Config{},
+	})
+
+	require.NotNil(t, summary.Labels)
+	summary.Labels["mcp.config.hash"] = "config-hash"
+	require.Equal(t, "config-hash", summary.Labels["mcp.config.hash"])
 }


### PR DESCRIPTION
## Summary

Refs #6543

## Changes

- Add an exact-name `ContainerInspect` fallback when Docker-compatible backends report a create name conflict but the name-filtered container list returns no match.
- Convert the inspect response into the existing container summary shape so created containers can be adopted and started through the normal deployment path.
- Keep ordinary container not-found lookups list-only so deploy, ensure, shutdown, and details paths do not gain an extra Docker API call.
- Preserve valid published ports and exposed ports while ignoring empty or non-numeric host bindings.
- Order inspected port bindings deterministically and prefer IPv4 loopback bindings for host-port selection.
- Add regression coverage for the conflict/list-miss case, field preservation, invalid bindings, binding selection, and the ordinary not-found path.

## Scope and risk

The inspect fallback is limited to the existing bounded create-conflict retry path. It requires an exact container-name match and does not change Kubernetes behavior, public APIs, or runtime configuration.

## Verification

```bash
go test ./pkg/mcp -run 'Test(CreateAndStartContainerUsesInspectFallbackForCreatedNameConflict|GetContainerNotFoundDoesNotInspect|InspectResponseToSummaryPreservesDeploymentFields|InspectResponseToSummaryOrdersPublishedPorts|InspectResponseToSummaryKeepsLabelsWritable)$' -count=1
go test ./pkg/mcp -count=1
go test ./pkg/mcp ./pkg/controller/handlers/systemmcpserver -count=1
go test ./... -count=1
git diff --check
```
