### PR TITLE
fix: show env var name in MultiUser launch UI

### DIFF
--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -224,7 +224,7 @@ Secret bindings let you wire an env var, header, or file to a key in an external
 
 Secret bindings are only available when Obot is using the Kubernetes MCP runtime backend.
 
-The referenced Kubernetes Secret must be in the Obot server namespace and must have the [configured allowed secret-binding label](./server-configuration.md#mcp-secret-binding-allowed-label).
+The referenced Kubernetes Secret must be in the Obot server namespace and must have the [configured allowed secret-binding label](./server-configuration.md).
 
 Obot checks this label when resolving bound values. If the Secret is missing the label, the binding is treated the same as a missing Secret or key. Required bound fields are reported as missing configuration.
 

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -42,7 +42,7 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_AUDIT_LOGS_STORE_USE_PATH_STYLE` | Whether to use path style for S3 object names | - |
 | `OBOT_SERVER_MCPBASE_IMAGE` | Deploy MCP servers in the kubernetes cluster or using docker with this base image. | `ghcr.io/obot-platform/mcp-images/stdio-wrapper:v0.24.0` |
 | `OBOT_SERVER_MCPIMAGE_PULL_SECRETS` | Comma-separated Kubernetes secret names to use as static image pull secrets for every MCP server Deployment. When set, managed image pull secrets are disabled. See [Image Pull Secrets](./image-pull-secrets.md). | - |
-| `OBOT_SERVER_MCPSECRET_BINDING_ALLOWED_LABEL` | Kubernetes Secret label key required before a Secret can be selected or resolved by MCP secret bindings. See [MCP Secret Binding Allowed Label](#mcp-secret-binding-allowed-label). | `obot.obot.ai/allow-secret-binding` |
+| `OBOT_SERVER_MCPSECRET_BINDING_ALLOWED_LABEL` | Kubernetes Secret label key required before a Secret can be selected or resolved by MCP secret bindings. Only label presence is checked; the label value is ignored. Secrets without this label are not shown as bindable targets in the admin UI and are treated as unavailable when Obot resolves a secret binding at runtime. | `obot.obot.ai/allow-secret-binding` |
 | `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/obot-platform/nanobot:v0.0.87` |
 | `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/obot-platform/nanobot-agent:v0.0.87` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.24.0` |
@@ -85,9 +85,3 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_ARTIFACT_AZURE_CLIENT_SECRET` | Azure client secret for published workflow storage when using explicit Azure credentials. | - |
 | `OBOT_DEFAULT_SKILL_REPO_URL` | The default skill repository URL. Must be a full HTTPS GitHub URL (e.g. `https://github.com/org/repo`). Only used on first-time setup (before the first owner user is created). A SkillRepository resource will be created from this URL and synced automatically. | `https://github.com/obot-platform/skills` |
 | `OBOT_DEFAULT_SKILL_REPO_REF` | The ref (branch, tag, or commit SHA) for the default skill repository. If empty, the repository's default branch is used. Only used on first-time setup. | - |
-
-## MCP Secret Binding Allowed Label
-
-`OBOT_SERVER_MCPSECRET_BINDING_ALLOWED_LABEL` sets the Kubernetes Secret label key required for MCP secret bindings. The default label key is `obot.obot.ai/allow-secret-binding`.
-
-Only label presence is checked; the label value is ignored. Secrets without this label are not shown as bindable targets in the admin UI and are treated as unavailable when Obot resolves a secret binding at runtime.

--- a/docs/docs/functionality/mcp-servers.md
+++ b/docs/docs/functionality/mcp-servers.md
@@ -194,7 +194,7 @@ Secret bindings are available only when Obot is using the Kubernetes MCP runtime
 
 ### Required Kubernetes Secret Label
 
-Secret binding selection in the admin UI is available for multi-user MCP deployments. The Kubernetes Secret must be in the Obot server's namespace and must have the [configured allowed secret-binding label](../configuration/server-configuration.md#mcp-secret-binding-allowed-label).
+Secret binding selection in the admin UI is available for multi-user MCP deployments. The Kubernetes Secret must be in the Obot server's namespace and must have the [configured allowed secret-binding label](../configuration/server-configuration.md).
 
 The label controls whether a Secret can be discovered and selected in the admin UI, and Obot also checks the label when resolving the binding at runtime. If the label is removed after an MCP server is already bound to that Secret, the binding is treated as unavailable. Required fields then appear as missing configuration until the label is restored or the binding is changed.
 

--- a/ui/user/src/lib/components/InfoTooltip.svelte
+++ b/ui/user/src/lib/components/InfoTooltip.svelte
@@ -56,6 +56,8 @@
 	});
 </script>
 
-<span class={twMerge('inline-flex size-3', klass)} use:tooltip={tooltipOpts}>
-	<Icon class={twMerge('text-gray size-3', classes?.icon)} />
-</span>
+{#if tooltipOpts}
+	<span class={twMerge('inline-flex size-3', klass)} use:tooltip={tooltipOpts}>
+		<Icon class={twMerge('text-gray size-3', classes?.icon)} />
+	</span>
+{/if}

--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -111,6 +111,10 @@
 		return Boolean(field?.secretBinding) || field?.secretBindingSource === 'secret';
 	}
 
+	function fieldLabel(field: Partial<MCPSubField>) {
+		return field.name || field.key || '';
+	}
+
 	const remoteHeaders = $derived.by(() => {
 		if (form && 'headers' in form) {
 			return getNonStaticServerFields(form?.headers);
@@ -475,7 +479,7 @@
 														for={`${compId}-${env.data.key}`}
 														class={highlightRequired ? 'text-error' : ''}
 													>
-														{env.data.name}
+														{fieldLabel(env.data)}
 														{#if !env.data.required}
 															<span class="text-muted-content">(optional)</span>
 														{/if}
@@ -560,7 +564,7 @@
 														for={`${compId}-${header.data.key}`}
 														class={highlightRequired ? 'text-error' : ''}
 													>
-														{header.data.name}
+														{fieldLabel(header.data)}
 														{#if !header.data.required}
 															<span class="text-muted-content">(optional)</span>
 														{/if}
@@ -652,7 +656,7 @@
 							<div class="flex flex-col gap-1">
 								<span class="flex items-center gap-2">
 									<label for={env.data.key} class={highlightRequired ? 'text-error' : ''}>
-										{env.data.name}
+										{fieldLabel(env.data)}
 										{#if !env.data.required}
 											<span class="text-muted-content">(optional)</span>
 										{/if}
@@ -725,7 +729,7 @@
 							<div class="flex flex-col gap-1">
 								<span class="flex items-center gap-2">
 									<label for={header.data.key} class={highlightRequired ? 'text-error' : ''}>
-										{header.data.name}
+										{fieldLabel(header.data)}
 										{#if !header.data.required}
 											<span class="text-muted-content">(optional)</span>
 										{/if}

--- a/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
@@ -127,17 +127,15 @@
 									disabled={readonly || isPrebuiltEntry}
 								/>
 							</div>
-							{#if !isPrebuiltEntry}
-								<div class="flex w-full flex-col gap-1">
-									<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
-									<input
-										id={`env-description-${i}`}
-										class={inputClass}
-										bind:value={config![i].description}
-										disabled={readonly}
-									/>
-								</div>
-							{/if}
+							<div class="flex w-full flex-col gap-1">
+								<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
+								<input
+									id={`env-description-${i}`}
+									class={inputClass}
+									bind:value={config![i].description}
+									disabled={readonly || isPrebuiltEntry}
+								/>
+							</div>
 							<div class="flex w-full flex-col gap-1">
 								<label for={`env-key-${i}`} class="text-sm font-light">Key</label>
 								<input

--- a/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
@@ -182,15 +182,17 @@
 									</p>
 								{/if}
 							</div>
-							<div class="flex w-full flex-col gap-1">
-								<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
-								<input
-									id={`env-description-${i}`}
-									class="text-input-filled bg-base-100 w-full shadow-none"
-									bind:value={config![i].description}
-									disabled={readonly || isPrebuiltEntry}
-								/>
-							</div>
+							{#if !isPrebuiltEntry}
+								<div class="flex w-full flex-col gap-1">
+									<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
+									<input
+										id={`env-description-${i}`}
+										class={inputClass}
+										bind:value={config![i].description}
+										disabled={readonly}
+									/>
+								</div>
+							{/if}
 							{#if secretBindingTargets && !version.current.hideK8sDetails}
 								<SecretBindingPicker
 									bind:field={config![i]}

--- a/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
@@ -127,15 +127,17 @@
 									disabled={readonly || isPrebuiltEntry}
 								/>
 							</div>
-							<div class="flex w-full flex-col gap-1">
-								<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
-								<input
-									id={`env-description-${i}`}
-									class={inputClass}
-									bind:value={config![i].description}
-									disabled={readonly || isPrebuiltEntry}
-								/>
-							</div>
+							{#if !isPrebuiltEntry}
+								<div class="flex w-full flex-col gap-1">
+									<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
+									<input
+										id={`env-description-${i}`}
+										class={inputClass}
+										bind:value={config![i].description}
+										disabled={readonly}
+									/>
+								</div>
+							{/if}
 							<div class="flex w-full flex-col gap-1">
 								<label for={`env-key-${i}`} class="text-sm font-light">Key</label>
 								<input
@@ -180,6 +182,15 @@
 									</p>
 								{/if}
 							</div>
+							<div class="flex w-full flex-col gap-1">
+								<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
+								<input
+									id={`env-description-${i}`}
+									class="text-input-filled bg-base-100 w-full shadow-none"
+									bind:value={config![i].description}
+									disabled={readonly || isPrebuiltEntry}
+								/>
+							</div>
 							{#if secretBindingTargets && !version.current.hideK8sDetails}
 								<SecretBindingPicker
 									bind:field={config![i]}
@@ -218,6 +229,14 @@
 										disabled={readonly || isPrebuiltEntry}
 									/>
 									<span class="text-sm">Sensitive</span>
+								</label>
+								<label class="flex items-center gap-2">
+									<input
+										type="checkbox"
+										bind:checked={config![i].required}
+										disabled={readonly || isPrebuiltEntry}
+									/>
+									<span class="text-sm">Required</span>
 								</label>
 							</div>
 						{/if}


### PR DESCRIPTION
Addresses #7075 and also improves docs layout for secret binding env var

<img width="692" height="342" alt="Screenshot 2026-06-30 at 09 11 07" src="https://github.com/user-attachments/assets/086ec530-2010-421a-acc2-8cc34afa4ec1" />
