### PR TITLE
fix: launch catalog entry / troubleshooting for debuggability

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -1108,7 +1108,7 @@
 		padding: 0.5rem 0.75rem;
 		border-bottom: 2px solid transparent;
 		font-size: 0.875rem;
-		color: var(--on-surface1, #6b7280);
+		color: var(--color-muted-content, #6b7280);
 		transition:
 			color 200ms,
 			border-color 200ms;

--- a/ui/user/src/lib/components/Select.svelte
+++ b/ui/user/src/lib/components/Select.svelte
@@ -256,13 +256,18 @@
 					{#if buttonStartContent}
 						{@render buttonStartContent()}
 					{/if}
-					<div class="min-w-0 flex-1 items-center gap-2 truncate">
+					<div
+						class={twMerge(
+							'min-w-0 flex-1 items-center gap-2 truncate',
+							!buttonStartContent && 'pl-2'
+						)}
+					>
 						{selectedOptions[0]?.label || placeholder || ''}
 					</div>
 				{/if}
 			{/if}
 
-			<ChevronDown class="size-5 shrink-0 self-start" />
+			<ChevronDown class="size-5 shrink-0 self-start translate-y-0.5" />
 		</div>
 
 		{#if onClear && !multiple}

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -1289,7 +1289,7 @@
 				{#snippet noToolsContent()}
 					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
 						<Wrench class="text-muted-content size-24 opacity-50" />
-						{#if !entry || (entry && (readonly || server || connectOnly))}
+						{#if !entry || (entry && (readonly || server || deploymentToDisplayTools || connectOnly))}
 							<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
 							<p class="text-muted-content text-sm font-light">
 								Looks like this MCP server doesn't have any tools available currently.
@@ -1342,10 +1342,12 @@
 
 {#snippet troubleshootingView()}
 	<McpServerEntryTroubleshooting
+		entityId={id}
+		{entity}
 		{entry}
 		{server}
-		onCreateServerForEntry={(server) =>
-			(resolvedConfiguredServers = [...(resolvedConfiguredServers ?? []), server])}
+		servers={resolvedConfiguredServers}
+		onRefresh={reloadConfiguredServers}
 	/>
 {/snippet}
 

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -150,9 +150,22 @@
 		return tabs.some((t) => t.view === tab) ? tab : fallback;
 	});
 	let configurationReadonly = $derived(readonly || isCatalogEntryDeployedMultiUserServer(entry));
-	let showLeftChevron = $state(false);
-	let showRightChevron = $state(false);
-	let scrollContainer = $state<HTMLDivElement>();
+
+	type ScrollState = {
+		hasMoreLeft: boolean;
+		hasMoreRight: boolean;
+		ref?: HTMLDivElement;
+	};
+	let rootScrollContainer = $state<ScrollState>({
+		hasMoreLeft: false,
+		hasMoreRight: false,
+		ref: undefined
+	});
+	let toolScrollContainer = $state<ScrollState>({
+		hasMoreLeft: false,
+		hasMoreRight: false,
+		ref: undefined
+	});
 
 	let oauthDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let oauthURL = $state<string>();
@@ -190,6 +203,7 @@
 			resolvedConfiguredInstances?.some((i) => !i.configured)
 	);
 
+	let deploymentToDisplayTools = $state<MCPCatalogServer>();
 	let showRegenerateToolsButton = $derived(
 		entry &&
 			!server &&
@@ -361,13 +375,26 @@
 		});
 
 		checkScrollPosition();
-		scrollContainer?.addEventListener('scroll', checkScrollPosition);
+		rootScrollContainer.ref?.addEventListener('scroll', checkScrollPosition);
 		window.addEventListener('resize', checkScrollPosition);
 
 		return () => {
-			scrollContainer?.removeEventListener('scroll', checkScrollPosition);
+			rootScrollContainer.ref?.removeEventListener('scroll', checkScrollPosition);
 			window.removeEventListener('resize', checkScrollPosition);
 			document.removeEventListener('visibilitychange', handleVisibilityChange);
+		};
+	});
+
+	$effect(() => {
+		if (selected === 'tools' && toolScrollContainer.ref) {
+			checkToolScrollPosition();
+			toolScrollContainer.ref.addEventListener('scroll', checkToolScrollPosition);
+			window.addEventListener('resize', checkToolScrollPosition);
+		}
+
+		return () => {
+			toolScrollContainer.ref?.removeEventListener('scroll', checkToolScrollPosition);
+			window.removeEventListener('resize', checkToolScrollPosition);
 		};
 	});
 
@@ -409,22 +436,42 @@
 	}
 
 	function checkScrollPosition() {
-		if (!scrollContainer) return;
+		if (!rootScrollContainer.ref) return;
 
-		const { scrollLeft, scrollWidth, clientWidth } = scrollContainer;
-		showLeftChevron = scrollLeft > 0;
-		showRightChevron = scrollLeft < scrollWidth - clientWidth - 1; // -1 for rounding errors
+		const { scrollLeft, scrollWidth, clientWidth } = rootScrollContainer.ref;
+		rootScrollContainer.hasMoreLeft = scrollLeft > 0;
+		rootScrollContainer.hasMoreRight = scrollLeft < scrollWidth - clientWidth - 1; // -1 for rounding errors
 	}
 
 	function scrollLeft() {
-		if (scrollContainer) {
-			scrollContainer.scrollBy({ left: -200, behavior: 'smooth' });
+		if (rootScrollContainer.ref) {
+			rootScrollContainer.ref.scrollBy({ left: -200, behavior: 'smooth' });
 		}
 	}
 
 	function scrollRight() {
-		if (scrollContainer) {
-			scrollContainer.scrollBy({ left: 200, behavior: 'smooth' });
+		if (rootScrollContainer.ref) {
+			rootScrollContainer.ref.scrollBy({ left: 200, behavior: 'smooth' });
+		}
+	}
+
+	function checkToolScrollPosition() {
+		if (!toolScrollContainer.ref) return;
+
+		const { scrollLeft, scrollWidth, clientWidth } = toolScrollContainer.ref;
+		toolScrollContainer.hasMoreLeft = scrollLeft > 0;
+		toolScrollContainer.hasMoreRight = scrollLeft < scrollWidth - clientWidth - 1; // -1 for rounding errors
+	}
+
+	function scrollToolLeft() {
+		if (toolScrollContainer.ref) {
+			toolScrollContainer.ref.scrollBy({ left: -200, behavior: 'smooth' });
+		}
+	}
+
+	function scrollToolRight() {
+		if (toolScrollContainer.ref) {
+			toolScrollContainer.ref.scrollBy({ left: 200, behavior: 'smooth' });
 		}
 	}
 
@@ -812,13 +859,13 @@
 			<OverflowContainer
 				class="scrollbar-none flex min-h-12 w-full items-center gap-2 overflow-x-auto"
 				style="scroll-behavior: smooth;"
-				{@attach (node: HTMLDivElement) => (scrollContainer = node)}
+				{@attach (node: HTMLDivElement) => (rootScrollContainer.ref = node)}
 			>
 				{#snippet children({ x })}
 					{#if tabs.length > 0 && (entry?.id || server?.id)}
 						{#if x}
 							<button
-								disabled={!showLeftChevron}
+								disabled={!rootScrollContainer.hasMoreLeft}
 								onclick={scrollLeft}
 								class="bg-base-200 dark:bg-base-100 sticky left-0 flex aspect-square h-full items-center justify-center rounded-l-md p-2.5 opacity-100 transition-all duration-200 disabled:opacity-30"
 							>
@@ -859,7 +906,7 @@
 
 						{#if x}
 							<button
-								disabled={!showRightChevron}
+								disabled={!rootScrollContainer.hasMoreRight}
 								onclick={scrollRight}
 								class="bg-base-200 dark:bg-base-100 sticky right-0 flex aspect-square h-full items-center justify-center rounded-r-md p-2.5 opacity-100 transition-all duration-200 disabled:opacity-30"
 							>
@@ -903,61 +950,8 @@
 			</div>
 		{:else if selected === 'configuration'}
 			{@render configurationView()}
-		{:else if selected === 'tools' && entry}
-			<div class="pb-8">
-				{#if showRegenerateToolsButton}
-					<button class="btn btn-primary mb-4 text-sm" onclick={handleInitTemporaryInstance}>
-						Regenerate Tools & Capabilities
-					</button>
-				{/if}
-				<McpServerTools
-					{entry}
-					{server}
-					showToolNameIssues={entry.manifest?.runtime === 'composite'}
-				>
-					{#snippet noToolsContent()}
-						<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
-							<Wrench class="text-muted-content size-24 opacity-50" />
-							{#if !entry || (entry && (readonly || server || connectOnly))}
-								<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
-								<p class="text-muted-content text-sm font-light">
-									Looks like this MCP server doesn't have any tools available currently.
-								</p>
-							{:else if !readonly && !connectOnly}
-								<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
-								<button
-									class="btn btn-primary flex items-center gap-1 text-sm"
-									onclick={handleInitTemporaryInstance}
-									disabled={saving}
-								>
-									{#if saving}
-										<Loading class="size-4" />
-									{:else}
-										Populate Tool Preview
-									{/if}
-								</button>
-								{#if !error}
-									<p class="text-muted-content text-sm font-light">
-										{#if type === 'remote'}
-											Click above to connect to the remote MCP server to populate capabilities and
-											tools.
-										{:else}
-											Click above to set up a temporary instance that will populate capabilities and
-											tools. Otherwise, tools will populate when the user first deploys a server for
-											the catalog entry.
-										{/if}
-									</p>
-								{/if}
-							{/if}
-						</div>
-						{#if error && showButtonInlineError}
-							<div class="mt-4 w-full">
-								{@render errorSnippet()}
-							</div>
-						{/if}
-					{/snippet}
-				</McpServerTools>
-			</div>
+		{:else if selected === 'tools'}
+			{@render toolsView()}
 		{:else if selected === 'access-control'}
 			{@render accessControlView()}
 		{:else if selected === 'usage'}
@@ -1218,6 +1212,132 @@
 			</p>
 		</div>
 	{/if}
+{/snippet}
+
+{#snippet toolsView()}
+	{@const displayTabsByDeployment =
+		entry &&
+		!server &&
+		'isCatalogEntry' in entry &&
+		resolvedConfiguredServers &&
+		resolvedConfiguredServers.length > 0}
+
+	<div class="pb-8">
+		{#if displayTabsByDeployment}
+			<OverflowContainer
+				class="scrollbar-none flex min-h-12 w-full items-center gap-2 overflow-x-auto relative mb-4"
+				style="scroll-behavior: smooth;"
+				{@attach (node: HTMLDivElement) => (toolScrollContainer.ref = node)}
+			>
+				{#snippet children({ x })}
+					{#if x}
+						<button
+							disabled={!toolScrollContainer.hasMoreLeft}
+							onclick={scrollToolLeft}
+							class="shrink-0 bg-base-200 dark:bg-base-100 sticky left-0 flex aspect-square h-full items-center justify-center rounded-l-md p-2.5 pl-4 opacity-100 transition-all duration-200 disabled:opacity-30"
+						>
+							<ChevronLeft class="size-4" />
+						</button>
+					{/if}
+
+					<div role="tablist" class="border-base-400 flex flex-1 gap-2 border-b">
+						<button
+							role="tab"
+							class={twMerge(
+								'tab-button text-no-wrap',
+								deploymentToDisplayTools === undefined && 'tab-active'
+							)}
+							onclick={() => (deploymentToDisplayTools = undefined)}>Preview</button
+						>
+						{#each resolvedConfiguredServers as deployment (deployment.id)}
+							<button
+								role="tab"
+								class={twMerge(
+									'tab-button text-nowrap',
+									deploymentToDisplayTools?.id === deployment.id && 'tab-active'
+								)}
+								onclick={() => (deploymentToDisplayTools = deployment)}
+							>
+								{deployment.alias || deployment.manifest.name} ({deployment.id})
+							</button>
+						{/each}
+					</div>
+
+					{#if x}
+						<button
+							disabled={!toolScrollContainer.hasMoreRight}
+							onclick={scrollToolRight}
+							class="shrink-0 bg-base-200 dark:bg-base-100 sticky right-0 flex aspect-square h-full items-center justify-center rounded-r-md p-2.5 pr-4 opacity-100 transition-all duration-200 disabled:opacity-30"
+						>
+							<ChevronRight class="size-4" />
+						</button>
+					{/if}
+				{/snippet}
+			</OverflowContainer>
+		{/if}
+		{#if showRegenerateToolsButton}
+			<button class="btn btn-primary mb-4 text-sm" onclick={handleInitTemporaryInstance}>
+				Regenerate Tools & Capabilities
+			</button>
+		{/if}
+		{#if entry}
+			<McpServerTools
+				{entry}
+				server={server ?? deploymentToDisplayTools}
+				showToolNameIssues={entry.manifest?.runtime === 'composite'}
+			>
+				{#snippet noToolsContent()}
+					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+						<Wrench class="text-muted-content size-24 opacity-50" />
+						{#if !entry || (entry && (readonly || server || connectOnly))}
+							<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
+							<p class="text-muted-content text-sm font-light">
+								Looks like this MCP server doesn't have any tools available currently.
+							</p>
+						{:else if !readonly && !connectOnly}
+							<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
+							<button
+								class="btn btn-primary flex items-center gap-1 text-sm"
+								onclick={handleInitTemporaryInstance}
+								disabled={saving}
+							>
+								{#if saving}
+									<Loading class="size-4" />
+								{:else}
+									Populate Tool Preview
+								{/if}
+							</button>
+							{#if !error}
+								<p class="text-muted-content text-sm font-light">
+									{#if type === 'remote'}
+										Click above to connect to the remote MCP server to populate capabilities and
+										tools.
+									{:else}
+										Click above to set up a temporary instance that will populate capabilities and
+										tools. Otherwise, tools will populate when the user first deploys a server for
+										the catalog entry.
+									{/if}
+								</p>
+							{/if}
+						{/if}
+					</div>
+					{#if error && showButtonInlineError}
+						<div class="mt-4 w-full">
+							{@render errorSnippet()}
+						</div>
+					{/if}
+				{/snippet}
+			</McpServerTools>
+		{:else}
+			<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+				<Wrench class="text-muted-content size-24 opacity-50" />
+				<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
+				<p class="text-muted-content text-sm font-light">
+					Looks like this MCP server doesn't have any tools available currently.
+				</p>
+			</div>
+		{/if}
+	</div>
 {/snippet}
 
 {#snippet troubleshootingView()}

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -30,6 +30,7 @@
 	import Confirm from '../Confirm.svelte';
 	import OverflowContainer from '../OverflowContainer.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import Select from '../Select.svelte';
 	import CatalogConfigureForm, {
 		type LaunchFormData,
 		type CompositeLaunchFormData,
@@ -61,7 +62,8 @@
 		Trash2,
 		Users,
 		Wrench,
-		ExternalLink
+		ExternalLink,
+		X
 	} from '@lucide/svelte';
 	import { onMount, untrack } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -161,11 +163,6 @@
 		hasMoreRight: false,
 		ref: undefined
 	});
-	let toolScrollContainer = $state<ScrollState>({
-		hasMoreLeft: false,
-		hasMoreRight: false,
-		ref: undefined
-	});
 
 	let oauthDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let oauthURL = $state<string>();
@@ -181,6 +178,7 @@
 	let error = $state<string>();
 	let showButtonInlineError = $state(false);
 	let showUpdateExistingDeploymentsConfirm = $state(false);
+	let selectedDeploymentsToView = $state<MCPCatalogServer[]>([]);
 
 	let serverInstancesLoading = $state(false);
 	let resolvedConfiguredInstances = $state<MCPServerInstance[]>();
@@ -385,19 +383,6 @@
 		};
 	});
 
-	$effect(() => {
-		if (selected === 'tools' && toolScrollContainer.ref) {
-			checkToolScrollPosition();
-			toolScrollContainer.ref.addEventListener('scroll', checkToolScrollPosition);
-			window.addEventListener('resize', checkToolScrollPosition);
-		}
-
-		return () => {
-			toolScrollContainer.ref?.removeEventListener('scroll', checkToolScrollPosition);
-			window.removeEventListener('resize', checkToolScrollPosition);
-		};
-	});
-
 	function filterRulesByEntry(rules?: AccessControlRule[]) {
 		if (!entry || !rules) return [];
 		return rules.filter((r) =>
@@ -452,26 +437,6 @@
 	function scrollRight() {
 		if (rootScrollContainer.ref) {
 			rootScrollContainer.ref.scrollBy({ left: 200, behavior: 'smooth' });
-		}
-	}
-
-	function checkToolScrollPosition() {
-		if (!toolScrollContainer.ref) return;
-
-		const { scrollLeft, scrollWidth, clientWidth } = toolScrollContainer.ref;
-		toolScrollContainer.hasMoreLeft = scrollLeft > 0;
-		toolScrollContainer.hasMoreRight = scrollLeft < scrollWidth - clientWidth - 1; // -1 for rounding errors
-	}
-
-	function scrollToolLeft() {
-		if (toolScrollContainer.ref) {
-			toolScrollContainer.ref.scrollBy({ left: -200, behavior: 'smooth' });
-		}
-	}
-
-	function scrollToolRight() {
-		if (toolScrollContainer.ref) {
-			toolScrollContainer.ref.scrollBy({ left: 200, behavior: 'smooth' });
 		}
 	}
 
@@ -1224,56 +1189,74 @@
 
 	<div class="pb-8">
 		{#if displayTabsByDeployment}
-			<OverflowContainer
-				class="scrollbar-none flex min-h-12 w-full items-center gap-2 overflow-x-auto relative mb-4"
-				style="scroll-behavior: smooth;"
-				{@attach (node: HTMLDivElement) => (toolScrollContainer.ref = node)}
-			>
-				{#snippet children({ x })}
-					{#if x}
-						<button
-							disabled={!toolScrollContainer.hasMoreLeft}
-							onclick={scrollToolLeft}
-							class="shrink-0 bg-base-200 dark:bg-base-100 sticky left-0 flex aspect-square h-full items-center justify-center rounded-l-md p-2.5 pl-4 opacity-100 transition-all duration-200 disabled:opacity-30"
-						>
-							<ChevronLeft class="size-4" />
-						</button>
-					{/if}
+			<div class="flex justify-between gap-4 border-base-400 border-b mb-4">
+				<div role="tablist" class="flex flex-1">
+					<button
+						role="tab"
+						class={twMerge(
+							'tab-button text-nowrap',
+							deploymentToDisplayTools === undefined && 'tab-active'
+						)}
+						onclick={() => (deploymentToDisplayTools = undefined)}>Preview</button
+					>
 
-					<div role="tablist" class="border-base-400 flex flex-1 gap-2 border-b">
-						<button
+					{#each selectedDeploymentsToView as deployment (deployment.id)}
+						<div
 							role="tab"
 							class={twMerge(
-								'tab-button text-nowrap',
-								deploymentToDisplayTools === undefined && 'tab-active'
+								'tab-button text-nowrap flex items-center gap-1',
+								deploymentToDisplayTools?.id === deployment.id && 'tab-active'
 							)}
-							onclick={() => (deploymentToDisplayTools = undefined)}>Preview</button
 						>
-						{#each resolvedConfiguredServers as deployment (deployment.id)}
-							<button
-								role="tab"
-								class={twMerge(
-									'tab-button text-nowrap',
-									deploymentToDisplayTools?.id === deployment.id && 'tab-active'
-								)}
-								onclick={() => (deploymentToDisplayTools = deployment)}
-							>
+							<button onclick={() => (deploymentToDisplayTools = deployment)}>
 								{deployment.alias || deployment.manifest.name} ({deployment.id})
 							</button>
-						{/each}
-					</div>
+							<button
+								onclick={() => {
+									selectedDeploymentsToView = selectedDeploymentsToView.filter(
+										(d) => d.id !== deployment.id
+									);
+									if (deploymentToDisplayTools?.id === deployment.id) {
+										deploymentToDisplayTools = undefined;
+									}
+								}}
+								class="btn btn-circle btn-xs btn-ghost"
+							>
+								<X class="size-3" />
+							</button>
+						</div>
+					{/each}
+				</div>
 
-					{#if x}
-						<button
-							disabled={!toolScrollContainer.hasMoreRight}
-							onclick={scrollToolRight}
-							class="shrink-0 bg-base-200 dark:bg-base-100 sticky right-0 flex aspect-square h-full items-center justify-center rounded-r-md p-2.5 pr-4 opacity-100 transition-all duration-200 disabled:opacity-30"
-						>
-							<ChevronRight class="size-4" />
-						</button>
-					{/if}
-				{/snippet}
-			</OverflowContainer>
+				<Select
+					id="select-deployment-tools-view"
+					class="bg-base-200 hover:bg-base-300 dark:bg-base-100 dark:hover:bg-base-200 mb-0.5 border border-transparent shadow-none md:w-64"
+					options={(resolvedConfiguredServers ?? []).map((deployment) => ({
+						id: deployment.id,
+						label: `${deployment.alias || deployment.manifest.name} (${deployment.id})`,
+						data: deployment
+					}))}
+					multiple
+					selected={selectedDeploymentsToView.map((deployment) => deployment.id).join(',')}
+					onSelect={(option) => {
+						if (selectedDeploymentsToView.find((deployment) => deployment.id === option.id)) {
+							selectedDeploymentsToView = selectedDeploymentsToView.filter(
+								(deployment) => deployment.id !== option.id
+							);
+							if (deploymentToDisplayTools?.id === option.id) {
+								deploymentToDisplayTools = undefined;
+							}
+						} else {
+							selectedDeploymentsToView = [...selectedDeploymentsToView, option.data];
+							deploymentToDisplayTools = option.data;
+						}
+					}}
+					searchInDropdown
+					buttonReadOnly
+					buttonTitle="Include Deployment(s)"
+					displayCount={selectedDeploymentsToView.length > 0}
+				/>
+			</div>
 		{/if}
 		{#if showRegenerateToolsButton}
 			<button class="btn btn-primary mb-4 text-sm" onclick={handleInitTemporaryInstance}>

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -1192,7 +1192,9 @@
 			<div class="flex justify-between gap-4 border-base-400 border-b mb-4">
 				<div role="tablist" class="flex flex-1">
 					<button
+						type="button"
 						role="tab"
+						aria-selected={deploymentToDisplayTools === undefined}
 						class={twMerge(
 							'tab-button text-nowrap',
 							deploymentToDisplayTools === undefined && 'tab-active'
@@ -1201,17 +1203,26 @@
 					>
 
 					{#each selectedDeploymentsToView as deployment (deployment.id)}
+						{@const deploymentLabel = `${deployment.alias || deployment.manifest.name} (${deployment.id})`}
 						<div
-							role="tab"
+							role="presentation"
 							class={twMerge(
-								'tab-button text-nowrap flex items-center gap-1',
+								'inline-flex items-center tab-button',
 								deploymentToDisplayTools?.id === deployment.id && 'tab-active'
 							)}
 						>
-							<button onclick={() => (deploymentToDisplayTools = deployment)}>
-								{deployment.alias || deployment.manifest.name} ({deployment.id})
+							<button
+								type="button"
+								role="tab"
+								aria-selected={deploymentToDisplayTools?.id === deployment.id}
+								class="text-nowrap"
+								onclick={() => (deploymentToDisplayTools = deployment)}
+							>
+								{deploymentLabel}
 							</button>
 							<button
+								type="button"
+								aria-label="Close {deploymentLabel} tab"
 								onclick={() => {
 									selectedDeploymentsToView = selectedDeploymentsToView.filter(
 										(d) => d.id !== deployment.id
@@ -1222,7 +1233,7 @@
 								}}
 								class="btn btn-circle btn-xs btn-ghost"
 							>
-								<X class="size-3" />
+								<X class="size-3" aria-hidden="true" />
 							</button>
 						</div>
 					{/each}

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -1244,7 +1244,7 @@
 						<button
 							role="tab"
 							class={twMerge(
-								'tab-button text-no-wrap',
+								'tab-button text-nowrap',
 								deploymentToDisplayTools === undefined && 'tab-active'
 							)}
 							onclick={() => (deploymentToDisplayTools = undefined)}>Preview</button

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -40,11 +40,11 @@
 	import McpServerInfo from '../mcp/McpServerInfo.svelte';
 	import McpServerTools from '../mcp/McpServerTools.svelte';
 	import StaticOAuthConfigureModal from '../mcp/StaticOAuthConfigureModal.svelte';
-	import DebugOauthFlow from '../mcp/oauth/DebugOauthFlow.svelte';
 	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import { setVirtualPageDisabled } from '../ui/virtual-page/context';
 	import CatalogServerForm from './CatalogServerForm.svelte';
+	import McpServerEntryTroubleshooting from './McpServerEntryTroubleshooting.svelte';
 	import McpServerInstances from './McpServerInstances.svelte';
 	import AuditLogsPageContent from './audit-logs/AuditLogsPageContent.svelte';
 	import UsageGraphs from './usage/UsageGraphs.svelte';
@@ -233,15 +233,17 @@
 						...(isAtLeastPowerUserPlus && trueOwner
 							? [{ label: 'Access Policies', view: 'access-control' }]
 							: []),
-						...(profile.current?.hasAdminAccess?.() ? [{ label: 'Filters', view: 'filters' }] : [])
+						...(profile.current?.hasAdminAccess?.()
+							? [
+									{ label: 'Filters', view: 'filters' },
+									{ label: 'Troubleshooting', view: 'troubleshooting' }
+								]
+							: [])
 					]
 				: [
 						{ label: 'Overview', view: 'overview' },
 						...(belongsToUser ? [{ label: 'Server Details', view: 'server-instances' }] : []),
-						{ label: 'Tools', view: 'tools' },
-						...(profile.current?.hasAdminAccess?.() && entry?.manifest?.runtime === 'remote'
-							? [{ label: 'Troubleshooting', view: 'troubleshooting' }]
-							: [])
+						{ label: 'Tools', view: 'tools' }
 					];
 		return limitViews
 			? availableTabs.filter((tab) => limitViews.includes(tab.view))
@@ -307,7 +309,7 @@
 		} else {
 			if (configuredServers !== undefined) {
 				resolvedConfiguredServers = configuredServers.filter(
-					(s) => s.catalogEntryID === currentEntry.id
+					(s) => s.catalogEntryID === currentEntry.id && !s.deleted
 				);
 				resolvedConfiguredInstances = undefined;
 				serverInstancesLoading = false;
@@ -323,7 +325,7 @@
 			)
 				.then((response) => {
 					if (!cancelled) {
-						resolvedConfiguredServers = response;
+						resolvedConfiguredServers = response.filter((s) => !s.deleted);
 					}
 				})
 				.finally(() => {
@@ -689,10 +691,11 @@
 		if (!id || !entry || !('isCatalogEntry' in entry)) return;
 		serverInstancesLoading = true;
 		try {
-			resolvedConfiguredServers =
+			const response =
 				entity === 'workspace'
 					? await UserService.listWorkspaceMCPServersForEntry(id, entry.id)
 					: await AdminService.listMCPServersForEntry(id, entry.id);
+			resolvedConfiguredServers = response.filter((s) => !s.deleted);
 		} finally {
 			serverInstancesLoading = false;
 		}
@@ -714,7 +717,7 @@
 						? UserService.listWorkspaceMCPServersForEntry
 						: AdminService.listMCPServersForEntry;
 				listInstances(id, updatedEntry.id).then((response) => {
-					resolvedConfiguredServers = response;
+					resolvedConfiguredServers = response.filter((s) => !s.deleted);
 					if (response.length > 0 && response.some((instance) => instance)) {
 						showUpdateExistingDeploymentsConfirm = true;
 					}
@@ -1218,12 +1221,12 @@
 {/snippet}
 
 {#snippet troubleshootingView()}
-	{#if server}
-		<div class="flex flex-col bg-base-100 dark:bg-base-300 rounded-md pt-4">
-			<h1 class="text-lg font-semibold px-4 pb-2">Debug OAuth Flow</h1>
-			<DebugOauthFlow mcpServer={server} />
-		</div>
-	{/if}
+	<McpServerEntryTroubleshooting
+		{entry}
+		{server}
+		onCreateServerForEntry={(server) =>
+			(resolvedConfiguredServers = [...(resolvedConfiguredServers ?? []), server])}
+	/>
 {/snippet}
 
 <Confirm

--- a/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
@@ -17,7 +17,6 @@
 	import ConnectToServer from '../mcp/ConnectToServer.svelte';
 	import DebugOauthFlow from '../mcp/oauth/DebugOauthFlow.svelte';
 	import { CircleAlert } from '@lucide/svelte';
-	import { untrack } from 'svelte';
 	import { slide } from 'svelte/transition';
 
 	interface Props {
@@ -44,9 +43,7 @@
 	let launchSuccessDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let pending = $state<'deleting' | 'refreshing' | undefined>(undefined);
 
-	let selectedDebugOauthDeployment = $state<MCPCatalogServer | undefined>(
-		untrack(() => (servers ? (servers.length === 1 ? servers[0] : undefined) : undefined))
-	);
+	let selectedDebugOauthDeployment = $state<MCPCatalogServer | undefined>();
 
 	let selectableDeployments = $derived(
 		servers

--- a/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import Loading from '$lib/icons/Loading.svelte';
-	import { UserService, type MCPCatalogEntry, type MCPCatalogServer } from '$lib/services';
+	import {
+		AdminService,
+		UserService,
+		type MCPCatalogEntry,
+		type MCPCatalogServer
+	} from '$lib/services';
 	import {
 		MCP_MULTI_TENANT_LAUNCH_TEXT,
 		MCP_SINGLE_TENANT_LAUNCH_TEXT
@@ -12,16 +17,26 @@
 	import ConnectToServer from '../mcp/ConnectToServer.svelte';
 	import DebugOauthFlow from '../mcp/oauth/DebugOauthFlow.svelte';
 	import { CircleAlert } from '@lucide/svelte';
+	import { untrack } from 'svelte';
 	import { slide } from 'svelte/transition';
 
 	interface Props {
-		catalogID?: string;
+		entity?: 'workspace' | 'catalog';
+		entityId?: string;
 		entry?: MCPCatalogEntry | MCPCatalogServer;
 		server?: MCPCatalogServer;
-		onCreateServerForEntry?: (server: MCPCatalogServer) => void;
+		servers?: MCPCatalogServer[];
+		onRefresh?: () => void;
 	}
 
-	let { catalogID, entry, server, onCreateServerForEntry }: Props = $props();
+	let {
+		entry,
+		server: restrictedSingleDeployment,
+		servers,
+		entity,
+		entityId,
+		onRefresh
+	}: Props = $props();
 
 	let connectToServerDialog = $state<ReturnType<typeof ConnectToServer>>();
 	let launchError = $state('');
@@ -29,12 +44,16 @@
 	let launchSuccessDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let pending = $state<'deleting' | 'refreshing' | undefined>(undefined);
 
-	let selectedDebugOauthDeployment = $state<MCPCatalogServer | undefined>(undefined);
+	let selectedDebugOauthDeployment = $state<MCPCatalogServer | undefined>(
+		untrack(() => (servers ? (servers.length === 1 ? servers[0] : undefined) : undefined))
+	);
 
 	let selectableDeployments = $derived(
-		mcpServersAndEntries.current.userConfiguredServers.filter(
-			(server) => server.catalogEntryID === entry?.id
-		)
+		servers
+			? servers
+			: mcpServersAndEntries.current.userConfiguredServers.filter(
+					(server) => server.catalogEntryID === entry?.id
+				)
 	);
 	let deploymentOptions = $derived(
 		selectableDeployments.map((server) => ({
@@ -51,10 +70,11 @@
 	}
 </script>
 
-{#if entry && 'isCatalogEntry' in entry}
+{#if entry && 'isCatalogEntry' in entry && !restrictedSingleDeployment}
 	{#if entry?.manifest.runtime === 'remote'}
 		<div class="paper">
 			<h1 class="text-lg font-semibold">Debug OAuth Flow</h1>
+
 			<div class="flex flex-col gap-2">
 				<label for="debug-oauth-deployment-selector" class="text-sm font-light">Deployment</label>
 				<Select
@@ -74,6 +94,13 @@
 					placeholder="Select Deployment"
 				/>
 			</div>
+
+			{#if deploymentOptions.length === 0}
+				<div class="notification-info flex items-center gap-2">
+					<p class="text-xs">Launch a server below to begin debugging the OAuth flow.</p>
+				</div>
+			{/if}
+
 			{#if selectedDebugOauthDeployment}
 				<div
 					in:slide={{ axis: 'y', duration: 150 }}
@@ -90,7 +117,7 @@
 	<div class="paper gap-2">
 		<h1 class="text-lg font-semibold">Launch Server</h1>
 		<p class="text-sm text-muted-content">
-			Each launch will create a new deployment for this catalog entry.
+			Each launch will create a new server deployment for this catalog entry.
 		</p>
 		<button
 			class="btn btn-primary w-full"
@@ -101,8 +128,8 @@
 			Launch Server
 		</button>
 	</div>
-{:else if (entry && !('isCatalogEntry' in entry)) || server}
-	{@const mcpServer = entry || server}
+{:else if (entry && !('isCatalogEntry' in entry)) || restrictedSingleDeployment}
+	{@const mcpServer = restrictedSingleDeployment ?? (entry as MCPCatalogServer)}
 	{#if mcpServer?.manifest.runtime === 'remote'}
 		<div class="flex flex-col bg-base-100 dark:bg-base-300 rounded-md pt-4">
 			<h1 class="text-lg font-semibold px-4 pb-2">Debug OAuth Flow</h1>
@@ -113,7 +140,8 @@
 
 <ConnectToServer
 	bind:this={connectToServerDialog}
-	{catalogID}
+	catalogID={entity === 'catalog' ? entityId : undefined}
+	workspaceID={entity === 'workspace' ? entityId : undefined}
 	onConnect={({ server }) => {
 		if (!server) {
 			launchError = 'No server was launched';
@@ -155,15 +183,28 @@
 		<button
 			class="btn btn-error"
 			disabled={!!pending}
-			onclick={() => {
+			onclick={async () => {
 				if (launchedServer) {
 					pending = 'deleting';
 					try {
-						UserService.deleteSingleOrRemoteMcpServer(launchedServer.id);
-					} catch (_err) {
-						// built-in error will display a toast
+						if (
+							entry &&
+							'isCatalogEntry' in entry &&
+							isMultiUserCatalogEntry(entry) &&
+							entity &&
+							entityId
+						) {
+							if (entity === 'workspace') {
+								await UserService.deleteWorkspaceMCPCatalogServer(entityId, launchedServer.id);
+							} else {
+								await AdminService.deleteMCPCatalogServer(entityId, launchedServer.id);
+							}
+						} else {
+							await UserService.deleteSingleOrRemoteMcpServer(launchedServer.id);
+						}
+					} finally {
+						resetLaunchStates();
 					}
-					resetLaunchStates();
 				}
 			}}
 		>
@@ -179,9 +220,8 @@
 			onclick={async () => {
 				launchSuccessDialog?.close();
 				pending = 'refreshing';
-				await mcpServersAndEntries.refreshUserConfiguredServers();
 				if (launchedServer) {
-					onCreateServerForEntry?.(launchedServer);
+					onRefresh?.();
 				}
 				resetLaunchStates();
 			}}

--- a/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+	import Loading from '$lib/icons/Loading.svelte';
+	import { UserService, type MCPCatalogEntry, type MCPCatalogServer } from '$lib/services';
+	import { isMultiUserCatalogEntry } from '$lib/services/user/mcp';
+	import { mcpServersAndEntries } from '$lib/stores';
+	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import Select from '../Select.svelte';
+	import ConnectToServer from '../mcp/ConnectToServer.svelte';
+	import McpServerTools from '../mcp/McpServerTools.svelte';
+	import DebugOauthFlow from '../mcp/oauth/DebugOauthFlow.svelte';
+	import { CircleAlert } from '@lucide/svelte';
+	import { slide } from 'svelte/transition';
+
+	interface Props {
+		catalogID?: string;
+		entry?: MCPCatalogEntry | MCPCatalogServer;
+		server?: MCPCatalogServer;
+		onCreateServerForEntry?: (server: MCPCatalogServer) => void;
+	}
+
+	let { catalogID, entry, server, onCreateServerForEntry }: Props = $props();
+
+	// for launch testing
+	let connectToServerDialog = $state<ReturnType<typeof ConnectToServer>>();
+	let launchError = $state('');
+	let launchedServer = $state<MCPCatalogServer | undefined>(undefined);
+	let testLaunchSuccessDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let pending = $state<'deleting' | 'refreshing' | undefined>(undefined);
+
+	let selectedDebugOauthDeployment = $state<MCPCatalogServer | undefined>(undefined);
+	let selectedDebugToolsDeployment = $state<MCPCatalogServer | undefined>(undefined);
+
+	let selectableDeployments = $derived(
+		mcpServersAndEntries.current.userConfiguredServers.filter(
+			(server) => server.catalogEntryID === entry?.id
+		)
+	);
+	let deploymentOptions = $derived(
+		selectableDeployments.map((server) => ({
+			id: server.id,
+			label: `${server.id}: ${server.alias || server.manifest.name}`
+		}))
+	);
+
+	function resetLaunchStates() {
+		testLaunchSuccessDialog?.close();
+		launchedServer = undefined;
+		launchError = '';
+		pending = undefined;
+	}
+</script>
+
+{#if entry && 'isCatalogEntry' in entry}
+	<div class="paper gap-2">
+		<h1 class="text-lg font-semibold">Test Launch</h1>
+		<p class="text-sm text-muted-content">
+			This is to troubleshoot & verify the MCP catalog entry can be launched. Each launch will
+			create a new deployment for this catalog entry.
+		</p>
+		<button
+			class="btn btn-primary w-full"
+			onclick={() => {
+				connectToServerDialog?.setupNewInstance(entry!);
+			}}
+		>
+			Test Launch
+		</button>
+	</div>
+
+	{#if entry?.manifest.runtime === 'remote'}
+		<div class="paper">
+			<h1 class="text-lg font-semibold">Debug OAuth Flow</h1>
+			<div class="flex flex-col gap-2">
+				<label for="debug-oauth-deployment-selector" class="text-sm font-light">Deployment</label>
+				<Select
+					id="debug-oauth-deployment-selector"
+					classes={{
+						root: 'w-full'
+					}}
+					class="bg-base-200 dark:bg-base-100"
+					options={deploymentOptions}
+					selected={selectedDebugOauthDeployment?.id}
+					onSelect={(option) => {
+						const match = selectableDeployments.find((server) => server.id === option.id);
+						if (match) {
+							selectedDebugOauthDeployment = match;
+						}
+					}}
+					placeholder="Select Deployment"
+				/>
+			</div>
+			{#if selectedDebugOauthDeployment}
+				<div
+					in:slide={{ axis: 'y', duration: 150 }}
+					class="bg-base-200 dark:bg-base-100 shadow-inner p-2 rounded-md"
+				>
+					<div class="flex flex-col bg-base-100 dark:bg-base-300 rounded-md pt-4">
+						<DebugOauthFlow mcpServer={selectedDebugOauthDeployment} />
+					</div>
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<div class="paper">
+		<h1 class="text-lg font-semibold">Debug Tools</h1>
+		<div class="flex flex-col gap-2">
+			<label for="debug-tools-deployment-selector" class="text-sm font-light">Deployment</label>
+			<Select
+				id="debug-tools-deployment-selector"
+				classes={{
+					root: 'w-full'
+				}}
+				class="bg-base-200 dark:bg-base-100"
+				options={deploymentOptions}
+				selected={selectedDebugToolsDeployment?.id}
+				onSelect={(option) => {
+					const match = selectableDeployments.find((server) => server.id === option.id);
+					if (match) {
+						selectedDebugToolsDeployment = match;
+					}
+				}}
+				placeholder="Select Deployment"
+			/>
+		</div>
+		{#if selectedDebugToolsDeployment}
+			{#key selectedDebugToolsDeployment.id}
+				<div class="bg-base-200 dark:bg-base-100 shadow-inner p-2 rounded-md">
+					<McpServerTools
+						{entry}
+						server={selectedDebugToolsDeployment}
+						showToolNameIssues={entry.manifest?.runtime === 'composite'}
+						debugMode
+					>
+						{#snippet noToolsContent()}
+							<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
+							<p class="text-muted-content text-sm font-light">
+								This deployment does not have any tools available.
+							</p>
+						{/snippet}
+					</McpServerTools>
+				</div>
+			{/key}
+		{/if}
+	</div>
+{:else if (entry && !('isCatalogEntry' in entry)) || server}
+	{@const mcpServer = entry || server}
+	{#if mcpServer?.manifest.runtime === 'remote'}
+		<div class="flex flex-col bg-base-100 dark:bg-base-300 rounded-md pt-4">
+			<h1 class="text-lg font-semibold px-4 pb-2">Debug OAuth Flow</h1>
+			<DebugOauthFlow {mcpServer} />
+		</div>
+	{/if}
+{/if}
+
+<ConnectToServer
+	bind:this={connectToServerDialog}
+	{catalogID}
+	onConnect={({ server }) => {
+		if (!server) {
+			launchError = 'No server was launched';
+			return;
+		}
+
+		launchError = '';
+		launchedServer = server;
+		testLaunchSuccessDialog?.open();
+	}}
+	skipConnectDialog
+	renderIntroText={({ entry }) => {
+		if (isMultiUserCatalogEntry(entry)) {
+			return 'You are about to launch a new server.';
+		}
+		return 'You are about to launch a new connection.';
+	}}
+	introTitle="Test Launch"
+/>
+
+<ResponsiveDialog
+	title="Test Launch Successful"
+	bind:this={testLaunchSuccessDialog}
+	class="max-w-sm"
+	hideClose
+	disableClickOutside
+>
+	<div class="flex flex-col gap-2">
+		{#if launchError}
+			<div class="alert alert-error">
+				<CircleAlert class="size-6 text-error" />
+				<h4 class="text-md font-medium">MCP Server Launch Failed</h4>
+				<p>{launchError}</p>
+			</div>
+		{:else}
+			<p>The server was launched successfully.</p>
+		{/if}
+
+		<p class="mb-4">
+			Feel free to delete the created deployment below. {entry?.manifest.runtime === 'remote' &&
+				'Or use the existing deployment to test & debug the OAuth flow.'}
+		</p>
+
+		<button
+			class="btn btn-error"
+			disabled={!!pending}
+			onclick={() => {
+				if (launchedServer) {
+					pending = 'deleting';
+					try {
+						UserService.deleteSingleOrRemoteMcpServer(launchedServer.id);
+					} catch (_err) {
+						// built-in error will display a toast
+					}
+					resetLaunchStates();
+				}
+			}}
+		>
+			{#if pending === 'deleting'}
+				<Loading class="size-4" />
+			{:else}
+				Delete Deployment
+			{/if}
+		</button>
+		<button
+			class="btn btn-secondary"
+			disabled={!!pending}
+			onclick={async () => {
+				testLaunchSuccessDialog?.close();
+				pending = 'refreshing';
+				await mcpServersAndEntries.refreshUserConfiguredServers();
+				if (launchedServer) {
+					onCreateServerForEntry?.(launchedServer);
+				}
+				resetLaunchStates();
+			}}
+		>
+			{#if pending === 'refreshing'}
+				<Loading class="size-4" />
+			{:else}
+				Skip
+			{/if}
+		</button>
+	</div>
+</ResponsiveDialog>

--- a/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import Loading from '$lib/icons/Loading.svelte';
 	import { UserService, type MCPCatalogEntry, type MCPCatalogServer } from '$lib/services';
+	import {
+		MCP_MULTI_TENANT_LAUNCH_TEXT,
+		MCP_SINGLE_TENANT_LAUNCH_TEXT
+	} from '$lib/services/admin/constants';
 	import { isMultiUserCatalogEntry } from '$lib/services/user/mcp';
 	import { mcpServersAndEntries } from '$lib/stores';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import Select from '../Select.svelte';
 	import ConnectToServer from '../mcp/ConnectToServer.svelte';
-	import McpServerTools from '../mcp/McpServerTools.svelte';
 	import DebugOauthFlow from '../mcp/oauth/DebugOauthFlow.svelte';
 	import { CircleAlert } from '@lucide/svelte';
 	import { slide } from 'svelte/transition';
@@ -20,15 +23,13 @@
 
 	let { catalogID, entry, server, onCreateServerForEntry }: Props = $props();
 
-	// for launch testing
 	let connectToServerDialog = $state<ReturnType<typeof ConnectToServer>>();
 	let launchError = $state('');
 	let launchedServer = $state<MCPCatalogServer | undefined>(undefined);
-	let testLaunchSuccessDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let launchSuccessDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let pending = $state<'deleting' | 'refreshing' | undefined>(undefined);
 
 	let selectedDebugOauthDeployment = $state<MCPCatalogServer | undefined>(undefined);
-	let selectedDebugToolsDeployment = $state<MCPCatalogServer | undefined>(undefined);
 
 	let selectableDeployments = $derived(
 		mcpServersAndEntries.current.userConfiguredServers.filter(
@@ -43,7 +44,7 @@
 	);
 
 	function resetLaunchStates() {
-		testLaunchSuccessDialog?.close();
+		launchSuccessDialog?.close();
 		launchedServer = undefined;
 		launchError = '';
 		pending = undefined;
@@ -51,22 +52,6 @@
 </script>
 
 {#if entry && 'isCatalogEntry' in entry}
-	<div class="paper gap-2">
-		<h1 class="text-lg font-semibold">Test Launch</h1>
-		<p class="text-sm text-muted-content">
-			This is to troubleshoot & verify the MCP catalog entry can be launched. Each launch will
-			create a new deployment for this catalog entry.
-		</p>
-		<button
-			class="btn btn-primary w-full"
-			onclick={() => {
-				connectToServerDialog?.setupNewInstance(entry!);
-			}}
-		>
-			Test Launch
-		</button>
-	</div>
-
 	{#if entry?.manifest.runtime === 'remote'}
 		<div class="paper">
 			<h1 class="text-lg font-semibold">Debug OAuth Flow</h1>
@@ -102,46 +87,19 @@
 		</div>
 	{/if}
 
-	<div class="paper">
-		<h1 class="text-lg font-semibold">Debug Tools</h1>
-		<div class="flex flex-col gap-2">
-			<label for="debug-tools-deployment-selector" class="text-sm font-light">Deployment</label>
-			<Select
-				id="debug-tools-deployment-selector"
-				classes={{
-					root: 'w-full'
-				}}
-				class="bg-base-200 dark:bg-base-100"
-				options={deploymentOptions}
-				selected={selectedDebugToolsDeployment?.id}
-				onSelect={(option) => {
-					const match = selectableDeployments.find((server) => server.id === option.id);
-					if (match) {
-						selectedDebugToolsDeployment = match;
-					}
-				}}
-				placeholder="Select Deployment"
-			/>
-		</div>
-		{#if selectedDebugToolsDeployment}
-			{#key selectedDebugToolsDeployment.id}
-				<div class="bg-base-200 dark:bg-base-100 shadow-inner p-2 rounded-md">
-					<McpServerTools
-						{entry}
-						server={selectedDebugToolsDeployment}
-						showToolNameIssues={entry.manifest?.runtime === 'composite'}
-						debugMode
-					>
-						{#snippet noToolsContent()}
-							<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
-							<p class="text-muted-content text-sm font-light">
-								This deployment does not have any tools available.
-							</p>
-						{/snippet}
-					</McpServerTools>
-				</div>
-			{/key}
-		{/if}
+	<div class="paper gap-2">
+		<h1 class="text-lg font-semibold">Launch Server</h1>
+		<p class="text-sm text-muted-content">
+			Each launch will create a new deployment for this catalog entry.
+		</p>
+		<button
+			class="btn btn-primary w-full"
+			onclick={() => {
+				connectToServerDialog?.setupNewInstance(entry!);
+			}}
+		>
+			Launch Server
+		</button>
 	</div>
 {:else if (entry && !('isCatalogEntry' in entry)) || server}
 	{@const mcpServer = entry || server}
@@ -164,31 +122,26 @@
 
 		launchError = '';
 		launchedServer = server;
-		testLaunchSuccessDialog?.open();
+		launchSuccessDialog?.open();
 	}}
 	skipConnectDialog
-	renderIntroText={({ entry }) => {
-		if (isMultiUserCatalogEntry(entry)) {
-			return 'You are about to launch a new server.';
-		}
-		return 'You are about to launch a new connection.';
-	}}
-	introTitle="Test Launch"
+	renderIntroText={({ entry }) =>
+		isMultiUserCatalogEntry(entry) ? MCP_MULTI_TENANT_LAUNCH_TEXT : MCP_SINGLE_TENANT_LAUNCH_TEXT}
+	introTitle="Launch Server"
 />
 
 <ResponsiveDialog
-	title="Test Launch Successful"
-	bind:this={testLaunchSuccessDialog}
+	title={launchError ? 'Launch Failed' : 'Launch Successful'}
+	bind:this={launchSuccessDialog}
 	class="max-w-sm"
 	hideClose
 	disableClickOutside
 >
 	<div class="flex flex-col gap-2">
 		{#if launchError}
-			<div class="alert alert-error">
-				<CircleAlert class="size-6 text-error" />
-				<h4 class="text-md font-medium">MCP Server Launch Failed</h4>
-				<p>{launchError}</p>
+			<div class="alert alert-error alert-soft">
+				<CircleAlert class="size-4 text-error" />
+				<span>{launchError}</span>
 			</div>
 		{:else}
 			<p>The server was launched successfully.</p>
@@ -224,7 +177,7 @@
 			class="btn btn-secondary"
 			disabled={!!pending}
 			onclick={async () => {
-				testLaunchSuccessDialog?.close();
+				launchSuccessDialog?.close();
 				pending = 'refreshing';
 				await mcpServersAndEntries.refreshUserConfiguredServers();
 				if (launchedServer) {

--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -385,6 +385,8 @@
 		}
 	}}
 	class={isCompositeForm(form) ? 'bg-base-200 dark:bg-base-100' : ''}
+	disableClickOutside={loading}
+	hideClose={loading}
 >
 	{#snippet titleContent()}
 		<div class="flex items-center gap-2">

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -20,7 +20,7 @@
 		getMCPDisplayName,
 		hasSecretBinding
 	} from '$lib/services/user/mcp';
-	import { errors, version } from '$lib/stores';
+	import { errors, mcpServersAndEntries, version } from '$lib/stores';
 	import Confirm from '../Confirm.svelte';
 	import CopyField from '../CopyField.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
@@ -36,7 +36,6 @@
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
-		userConfiguredServers: MCPCatalogServer[];
 		catalogID?: string;
 		workspaceID?: string;
 		onConnect?: ({
@@ -57,21 +56,25 @@
 			entry?: MCPCatalogEntry;
 			server?: MCPCatalogServer;
 		}) => string;
+		introTitle?: string;
 	}
 
 	let {
-		userConfiguredServers,
 		catalogID,
 		workspaceID,
 		onConnect,
 		onClose,
 		skipConnectDialog,
-		renderIntroText
+		renderIntroText,
+		introTitle
 	}: Props = $props();
 
 	let server = $state<MCPCatalogServer>();
 	let entry = $state<MCPCatalogEntry>();
 	let instance = $state<MCPServerInstance>();
+	let userConfiguredServers = $derived(mcpServersAndEntries.current.userConfiguredServers);
+	let userInstances = $derived(mcpServersAndEntries.current.userInstances);
+
 	let manifest = $derived(server?.manifest || entry?.manifest);
 	let isConfigured = $derived(Boolean((entry && server) || (server && instance)));
 	let isDeployingMultiUserCatalogEntry = $derived(
@@ -147,6 +150,16 @@
 			.flatMap((server) => [server.manifest?.name || '', server.alias || ''])
 			.filter(Boolean)
 			.map((name) => name.toLowerCase())
+	);
+
+	let requiresConfiguration = $derived(
+		entry
+			? entry && !userConfiguredServers.some((s) => s.catalogEntryID === entry?.id)
+			: server &&
+				  hasMultiUserInstanceConfiguration(server) &&
+				  !userInstances.some((i) => i.mcpServerID === server?.id)
+				? true
+				: false
 	);
 
 	let howToConnect = $state<ReturnType<typeof HowToConnect>>();
@@ -934,7 +947,7 @@
 		entry = initEntry;
 		server = undefined;
 		instance = undefined;
-		initCatalogEntry();
+		showIntroDialog = true;
 	}
 
 	function handleLaunchOrConfigure() {
@@ -987,7 +1000,7 @@
 			(entry && server) ||
 			(server && instance)
 		) {
-			handleConnect(true);
+			connectDialog?.open();
 		} else {
 			showIntroDialog = true;
 		}
@@ -1004,6 +1017,11 @@
 			.toLowerCase()
 			.replace(/ /g, '-')
 			.replace(/[^a-z0-9-_]/g, '');
+	}
+
+	function initConnectFromUi() {
+		connectDialog?.close();
+		showIntroDialog = true;
 	}
 
 	onMount(() => {
@@ -1052,6 +1070,7 @@
 				{url}
 				id={generateIdFromName(displayName)}
 				{displayName}
+				onSetup={requiresConfiguration ? initConnectFromUi : undefined}
 			/>
 		{/if}
 	{/if}
@@ -1062,7 +1081,7 @@
 	onsuccess={handleLaunchOrConfigure}
 	submitText="Continue"
 	type="info"
-	title={isMultiUserCatalogEntry(entry) ? 'Launch Server' : 'Connect To Server'}
+	title={introTitle ?? (isMultiUserCatalogEntry(entry) ? 'Launch Server' : 'Connect To Server')}
 	oncancel={() => (showIntroDialog = false)}
 	hideCancelButton
 >

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -73,7 +73,6 @@
 	let entry = $state<MCPCatalogEntry>();
 	let instance = $state<MCPServerInstance>();
 	let userConfiguredServers = $derived(mcpServersAndEntries.current.userConfiguredServers);
-	let userInstances = $derived(mcpServersAndEntries.current.userInstances);
 
 	let manifest = $derived(server?.manifest || entry?.manifest);
 	let isConfigured = $derived(Boolean((entry && server) || (server && instance)));
@@ -150,16 +149,6 @@
 			.flatMap((server) => [server.manifest?.name || '', server.alias || ''])
 			.filter(Boolean)
 			.map((name) => name.toLowerCase())
-	);
-
-	let requiresConfiguration = $derived(
-		entry
-			? entry && !userConfiguredServers.some((s) => s.catalogEntryID === entry?.id)
-			: server &&
-				  hasMultiUserInstanceConfiguration(server) &&
-				  !userInstances.some((i) => i.mcpServerID === server?.id)
-				? true
-				: false
 	);
 
 	let howToConnect = $state<ReturnType<typeof HowToConnect>>();
@@ -1019,11 +1008,6 @@
 			.replace(/[^a-z0-9-_]/g, '');
 	}
 
-	function initConnectFromUi() {
-		connectDialog?.close();
-		showIntroDialog = true;
-	}
-
 	onMount(() => {
 		ensureOauthVisibilityListener();
 		return () => {
@@ -1070,7 +1054,6 @@
 				{url}
 				id={generateIdFromName(displayName)}
 				{displayName}
-				onSetup={requiresConfiguration ? initConnectFromUi : undefined}
 			/>
 		{/if}
 	{/if}

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -456,6 +456,8 @@
 				mcpServersAndEntries.current.servers = mcpServersAndEntries.current.servers.filter(
 					(s) => s.id !== server.id
 				);
+				mcpServersAndEntries.current.userConfiguredServers =
+					mcpServersAndEntries.current.userConfiguredServers.filter((s) => s.id !== server.id);
 			} catch (error) {
 				if (error instanceof MCPCompositeDeletionDependencyError) {
 					deleteConflictError = error;

--- a/ui/user/src/lib/components/mcp/HowToConnect.svelte
+++ b/ui/user/src/lib/components/mcp/HowToConnect.svelte
@@ -8,18 +8,15 @@
 	import { getAiClientCommand, getAiClientMagicLink } from '$lib/services/user/mcp';
 	import { userDeviceSettings } from '$lib/stores';
 	import CopyField from '../CopyField.svelte';
-	import DotDotDot from '../DotDotDot.svelte';
-	import { slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
 		id: string;
 		displayName: string;
 		url: string;
-		onSetup?: () => void;
 	}
 
-	let { id, displayName, url, onSetup }: Props = $props();
+	let { id, displayName, url }: Props = $props();
 
 	let aiClientsMap = $derived(new Map(COMMON_AI_CLIENTS.map((client) => [client.id, client])));
 	let magicLinks = $derived(generateMcpLinks(displayName, url));
@@ -166,20 +163,6 @@
 			{/each}
 		</div>
 	{/if}
-
-	{#if onSetup}
-		<div transition:slide={{ duration: 150 }}>
-			<div class="divider mt-8">Setup & Connect</div>
-			<p class="text-xs font-light mb-4 text-center">
-				On initial connection to the MCP server from your third party AI client, you will be
-				prompted to configure the server. Otherwise, click below to go ahead and setup the server
-				here.
-			</p>
-			<div class="flex justify-center">
-				<button class="btn btn-primary w-full" onclick={onSetup}>Launch {displayName} Now</button>
-			</div>
-		</div>
-	{/if}
 </div>
 <div class="divider mb-2"></div>
 <div class="w-full px-4 md:px-0">
@@ -200,12 +183,6 @@
 					<img src={option.icon} alt={`${option.label} branding icon`} class="size-4" />
 				</a>
 			{/each}
-
-			{#if onSetup}
-				<DotDotDot disablePortal class="btn-sm">
-					<button class="menu-button font-normal" onclick={onSetup}> Launch & Connect </button>
-				</DotDotDot>
-			{/if}
 		</div>
 	</div>
 </div>

--- a/ui/user/src/lib/components/mcp/HowToConnect.svelte
+++ b/ui/user/src/lib/components/mcp/HowToConnect.svelte
@@ -8,15 +8,18 @@
 	import { getAiClientCommand, getAiClientMagicLink } from '$lib/services/user/mcp';
 	import { userDeviceSettings } from '$lib/stores';
 	import CopyField from '../CopyField.svelte';
+	import DotDotDot from '../DotDotDot.svelte';
+	import { slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
 		id: string;
 		displayName: string;
 		url: string;
+		onSetup?: () => void;
 	}
 
-	let { id, displayName, url }: Props = $props();
+	let { id, displayName, url, onSetup }: Props = $props();
 
 	let aiClientsMap = $derived(new Map(COMMON_AI_CLIENTS.map((client) => [client.id, client])));
 	let magicLinks = $derived(generateMcpLinks(displayName, url));
@@ -163,6 +166,20 @@
 			{/each}
 		</div>
 	{/if}
+
+	{#if onSetup}
+		<div transition:slide={{ duration: 150 }}>
+			<div class="divider mt-8">Setup & Connect</div>
+			<p class="text-xs font-light mb-4 text-center">
+				On initial connection to the MCP server from your third party AI client, you will be
+				prompted to configure the server. Otherwise, click below to go ahead and setup the server
+				here.
+			</p>
+			<div class="flex justify-center">
+				<button class="btn btn-primary w-full" onclick={onSetup}>Launch {displayName} Now</button>
+			</div>
+		</div>
+	{/if}
 </div>
 <div class="divider mb-2"></div>
 <div class="w-full px-4 md:px-0">
@@ -183,6 +200,12 @@
 					<img src={option.icon} alt={`${option.label} branding icon`} class="size-4" />
 				</a>
 			{/each}
+
+			{#if onSetup}
+				<DotDotDot disablePortal class="btn-sm">
+					<button class="menu-button font-normal" onclick={onSetup}> Launch & Connect </button>
+				</DotDotDot>
+			{/if}
 		</div>
 	</div>
 </div>

--- a/ui/user/src/lib/components/mcp/McpSelectServerDeployment.svelte
+++ b/ui/user/src/lib/components/mcp/McpSelectServerDeployment.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { tooltip } from '$lib/actions/tooltip.svelte';
+	import type { MCPCatalogServer } from '$lib/services';
+	import { getMCPDisplayName, requiresUserUpdate } from '$lib/services/user/mcp';
+	import { formatTimeAgo } from '$lib/time';
+	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
+	import Table from '../table/Table.svelte';
+	import { CircleFadingArrowUp, Server, StepForward } from '@lucide/svelte';
+
+	interface Props {
+		onSelectServer: (server: MCPCatalogServer) => void;
+	}
+
+	let { onSelectServer }: Props = $props();
+
+	let selectServerDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let servers = $state<MCPCatalogServer[]>([]);
+
+	export function open(initServers: MCPCatalogServer[] = []) {
+		servers = initServers;
+		selectServerDialog?.open();
+	}
+
+	export function close() {
+		selectServerDialog?.close();
+	}
+</script>
+
+<ResponsiveDialog
+	class="bg-base-200 dark:bg-base-100"
+	bind:this={selectServerDialog}
+	title="Select Your Server"
+>
+	<Table
+		data={servers}
+		fields={['name', 'created']}
+		onClickRow={async (d) => {
+			selectServerDialog?.close();
+			onSelectServer?.(d);
+		}}
+		disablePortal
+	>
+		{#snippet onRenderColumn(property, d)}
+			{#if property === 'name'}
+				<div class="flex shrink-0 items-center gap-2">
+					<div class="icon">
+						{#if d.manifest.icon}
+							<img src={d.manifest.icon} alt={d.manifest.name} class="size-6" />
+						{:else}
+							<Server class="size-6" />
+						{/if}
+					</div>
+					<p class="flex items-center gap-2">
+						{getMCPDisplayName(d)}
+						{#if requiresUserUpdate(d)}
+							<span
+								use:tooltip={{
+									classes: ['border-primary', 'bg-primary/10', 'dark:bg-primary/50'],
+									text: 'Configuration requires your attention'
+								}}
+							>
+								<CircleFadingArrowUp class="text-primary size-4" />
+							</span>
+						{/if}
+					</p>
+				</div>
+			{:else if property === 'created'}
+				{formatTimeAgo(d.created).relativeTime}
+			{/if}
+		{/snippet}
+		{#snippet actions()}
+			<IconButton class="hover:dark:bg-base-100/50">
+				<StepForward class="size-4" />
+			</IconButton>
+		{/snippet}
+	</Table>
+</ResponsiveDialog>

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -14,7 +14,6 @@
 	import {
 		deleteMcpServerDeployment,
 		disconnectMcpServerUser,
-		getMCPDisplayName,
 		hasEditableConfiguration,
 		isMultiUserCatalogEntry,
 		isMultiUserServer,
@@ -22,15 +21,13 @@
 		restartMcpServer
 	} from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, profile, version } from '$lib/stores';
-	import { formatTimeAgo } from '$lib/time';
 	import { goto } from '$lib/url';
 	import CopyField from '../CopyField.svelte';
 	import DotDotDot from '../DotDotDot.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
-	import IconButton from '../primitives/IconButton.svelte';
-	import Table from '../table/Table.svelte';
 	import ConnectToServer from './ConnectToServer.svelte';
 	import EditExistingDeployment from './EditExistingDeployment.svelte';
+	import McpSelectServerDeployment from './McpSelectServerDeployment.svelte';
 	import StaticOAuthConfigureModal from './StaticOAuthConfigureModal.svelte';
 	import DebugOauthDialog from './oauth/DebugOauthDialog.svelte';
 	import {
@@ -40,7 +37,6 @@
 		RefreshCw,
 		Server,
 		ServerCog,
-		StepForward,
 		Trash2,
 		Unplug,
 		Bug
@@ -90,7 +86,7 @@
 	}: Props = $props();
 	let connectToServerDialog = $state<ReturnType<typeof ConnectToServer>>();
 	let editExistingDialog = $state<ReturnType<typeof EditExistingDeployment>>();
-	let selectServerDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let selectServerDialog = $state<ReturnType<typeof McpSelectServerDeployment>>();
 	let selectServerMode = $state<ServerSelectMode>('connect');
 	let launchDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let launchPromptHandled = $state(false);
@@ -279,8 +275,12 @@
 		}
 	});
 
-	function handleShowSelectServerDialog(mode: ServerSelectMode = 'connect') {
-		selectServerDialog?.open();
+	function handleShowSelectServerDialog(
+		mode: ServerSelectMode = 'connect',
+		servers: MCPCatalogServer[] = []
+	) {
+		if (!entry) return;
+		selectServerDialog?.open(servers);
 		selectServerMode = mode;
 	}
 
@@ -323,7 +323,7 @@
 						)
 					});
 				} else if (configuredServers.length > 1) {
-					handleShowSelectServerDialog();
+					handleShowSelectServerDialog('connect', configuredServers);
 				} else {
 					connectToServerDialog?.open({ entry });
 				}
@@ -334,7 +334,7 @@
 						server: configuredServers[0]
 					});
 				} else {
-					handleShowSelectServerDialog();
+					handleShowSelectServerDialog('connect', configuredServers);
 				}
 			} else {
 				connectToServerDialog?.open({
@@ -381,79 +381,47 @@
 
 <EditExistingDeployment bind:this={editExistingDialog} onUpdateConfigure={refresh} />
 
-<ResponsiveDialog
-	class="bg-base-200 dark:bg-base-100"
+<McpSelectServerDeployment
 	bind:this={selectServerDialog}
-	title="Select Your Server"
->
-	<Table
-		data={configuredServers || []}
-		fields={['name', 'created']}
-		onClickRow={async (d) => {
-			selectServerDialog?.close();
-			switch (selectServerMode) {
-				case 'rename': {
-					editExistingDialog?.rename({
-						server: d,
-						entry
-					});
-					break;
-				}
-				case 'edit': {
-					editExistingDialog?.edit({
-						server: d,
-						entry
-					});
-					break;
-				}
-				case 'restart': {
-					await restartServer(d);
-					await mcpServersAndEntries.refreshAll();
-					break;
-				}
-				case 'disconnect': {
-					await disconnectCurrentUser(d);
-					await mcpServersAndEntries.refreshAll();
-					break;
-				}
-				default:
-					connectToServerDialog?.open({
-						entry,
-						server: d,
-						instance: isMultiUserServer(d)
-							? mcpServersAndEntries.current.userInstances.find((i) => i.mcpServerID === d.id)
-							: undefined
-					});
-					break;
+	onSelectServer={async (d) => {
+		selectServerDialog?.close();
+		switch (selectServerMode) {
+			case 'rename': {
+				editExistingDialog?.rename({
+					server: d,
+					entry
+				});
+				break;
 			}
-		}}
-		disablePortal
-	>
-		{#snippet onRenderColumn(property, d)}
-			{#if property === 'name'}
-				<div class="flex shrink-0 items-center gap-2">
-					<div class="icon">
-						{#if d.manifest.icon}
-							<img src={d.manifest.icon} alt={d.manifest.name} class="size-6" />
-						{:else}
-							<Server class="size-6" />
-						{/if}
-					</div>
-					<p class="flex items-center gap-2">
-						{getMCPDisplayName(d)}
-					</p>
-				</div>
-			{:else if property === 'created'}
-				{formatTimeAgo(d.created).relativeTime}
-			{/if}
-		{/snippet}
-		{#snippet actions()}
-			<IconButton class="hover:dark:bg-base-100/50">
-				<StepForward class="size-4" />
-			</IconButton>
-		{/snippet}
-	</Table>
-</ResponsiveDialog>
+			case 'edit': {
+				editExistingDialog?.edit({
+					server: d,
+					entry
+				});
+				break;
+			}
+			case 'restart': {
+				await restartServer(d);
+				await mcpServersAndEntries.refreshAll();
+				break;
+			}
+			case 'disconnect': {
+				await disconnectCurrentUser(d);
+				await mcpServersAndEntries.refreshAll();
+				break;
+			}
+			default:
+				connectToServerDialog?.open({
+					entry,
+					server: d,
+					instance: isMultiUserServer(d)
+						? mcpServersAndEntries.current.userInstances.find((i) => i.mcpServerID === d.id)
+						: undefined
+				});
+				break;
+		}
+	}}
+/>
 
 <ResponsiveDialog
 	bind:this={launchDialog}
@@ -692,7 +660,7 @@
 									entry
 								});
 							} else {
-								handleShowSelectServerDialog('rename');
+								handleShowSelectServerDialog('rename', configuredServers);
 							}
 						}}
 					>
@@ -711,7 +679,7 @@
 										entry
 									});
 								} else {
-									handleShowSelectServerDialog('edit');
+									handleShowSelectServerDialog('edit', configuredServers);
 								}
 							}}
 						>
@@ -735,7 +703,7 @@
 									toggle(false);
 								}
 							} else {
-								handleShowSelectServerDialog('restart');
+								handleShowSelectServerDialog('restart', configuredServers);
 							}
 						}}
 					>
@@ -755,7 +723,7 @@
 								await disconnectCurrentUser(configuredServers[0]);
 								await mcpServersAndEntries.refreshAll();
 							} else {
-								handleShowSelectServerDialog('disconnect');
+								handleShowSelectServerDialog('disconnect', configuredServers);
 							}
 							toggle(false);
 						}}

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -370,7 +370,6 @@
 
 <ConnectToServer
 	bind:this={connectToServerDialog}
-	userConfiguredServers={mcpServersAndEntries.current.userConfiguredServers}
 	{catalogID}
 	{workspaceID}
 	onConnect={(data) => {

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -280,8 +280,8 @@
 		servers: MCPCatalogServer[] = []
 	) {
 		if (!entry) return;
-		selectServerDialog?.open(servers);
 		selectServerMode = mode;
+		selectServerDialog?.open(servers);
 	}
 
 	async function reauthenticateServer(item: MCPCatalogServer) {

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -284,7 +284,7 @@
 						{#if showRealTools}
 							Looks like this MCP server doesn't have any tools available.
 						{:else}
-							Connection to to the server is required to list available tools.
+							Connection to the server is required to list available tools.
 						{/if}
 					</p>
 				</div>

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -30,7 +30,6 @@
 		// name for names that may be problematic for MCP clients / inference
 		// APIs (length, disallowed chars, or duplicates in this list).
 		showToolNameIssues?: boolean;
-		debugMode?: boolean;
 	}
 
 	let {
@@ -39,14 +38,14 @@
 		onAuthenticate,
 		noToolsContent,
 		classes,
-		showToolNameIssues = false,
-		debugMode = false
+		showToolNameIssues = false
 	}: Props = $props();
 	let search = $state('');
 	let tools = $state<MCPServerTool[]>([]);
 	let previewTools = $derived(getToolPreview(entry));
 	let loading = $state(false);
 	let previousEntryId = $state<string | undefined>(undefined);
+	let previousServerId = $state<string | undefined>(undefined);
 	let error = $state('');
 
 	let expanded = $state<Record<string, boolean>>({});
@@ -121,15 +120,22 @@
 			});
 			tools = await toolCall;
 		} catch (err) {
-			console.error(err);
+			if (err instanceof DOMException && err.name === 'AbortError') return;
+			error = err instanceof Error ? err.message : 'An unknown error occurred';
 		} finally {
 			loading = false;
 		}
 	}
 
 	$effect(() => {
-		if (entry && showRealTools && (!previousEntryId || entry.id !== previousEntryId)) {
-			previousEntryId = entry.id;
+		if (!showRealTools) return;
+		const changedEntry = entry && (!previousEntryId || entry.id !== previousEntryId);
+		const changedServer =
+			(server?.id && (!previousServerId || server.id !== previousServerId)) ||
+			(!server && previousServerId);
+		if (changedEntry || changedServer) {
+			previousEntryId = entry?.id;
+			previousServerId = server?.id;
 			loadTools();
 		}
 	});
@@ -153,10 +159,6 @@
 						</div>
 					</div>
 				</div>
-			{:else}
-				{#key server?.id ?? entry.id}
-					<McpOauth entry={server ?? entry} onAuthenticate={handleAuthenticate} bind:error />
-				{/key}
 			{/if}
 			{#if error}
 				<div class="notification-error flex w-full items-center gap-2 p-3">
@@ -172,24 +174,28 @@
 		</div>
 	{/if}
 
+	{#if showRealTools}
+		{#key server?.id ?? entry.id}
+			<McpOauth entry={server ?? entry} onAuthenticate={handleAuthenticate} bind:error />
+		{/key}
+	{/if}
+
 	<div class="flex w-full flex-col gap-2">
 		<div class="mb-2 flex w-full flex-col gap-4">
-			{#if !debugMode}
-				<div class="flex flex-wrap items-center justify-end gap-2 md:shrink-0">
-					<Toggle
-						checked={allDescriptionsEnabled}
-						onChange={(checked) => {
-							allDescriptionsEnabled = checked;
-							expanded = {};
-						}}
-						label="Show All Descriptions"
-						labelInline
-						classes={{
-							label: 'text-sm gap-2'
-						}}
-					/>
-				</div>
-			{/if}
+			<div class="flex flex-wrap items-center justify-end gap-2 md:shrink-0">
+				<Toggle
+					checked={allDescriptionsEnabled}
+					onChange={(checked) => {
+						allDescriptionsEnabled = checked;
+						expanded = {};
+					}}
+					label="Show All Descriptions"
+					labelInline
+					classes={{
+						label: 'text-sm gap-2'
+					}}
+				/>
+			</div>
 
 			<Search
 				class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
@@ -197,7 +203,7 @@
 				placeholder="Search tools..."
 			/>
 		</div>
-		<div class={twMerge('flex flex-col gap-4 overflow-hidden', debugMode && 'gap-2')}>
+		<div class="flex flex-col gap-4 overflow-hidden">
 			{#if loading}
 				{#each Array.from({ length: 3 }) as _, i (i)}
 					<div class="skeleton h-14 w-full rounded-none"></div>
@@ -275,7 +281,7 @@
 					<Wrench class="text-muted-content size-24 opacity-50" />
 					<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
 					<p class="text-muted-content text-sm font-light">
-						{#if !entry || !showRealTools}
+						{#if showRealTools}
 							Looks like this MCP server doesn't have any tools available.
 						{:else}
 							Connection to to the server is required to list available tools.

--- a/ui/user/src/lib/components/mcp/McpServerTools.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerTools.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import Loading from '$lib/icons/Loading.svelte';
 	import { toHTMLFromMarkdownWithNewTabLinks } from '$lib/markdown';
 	import {
 		UserService,
@@ -31,6 +30,7 @@
 		// name for names that may be problematic for MCP clients / inference
 		// APIs (length, disallowed chars, or duplicates in this list).
 		showToolNameIssues?: boolean;
+		debugMode?: boolean;
 	}
 
 	let {
@@ -39,7 +39,8 @@
 		onAuthenticate,
 		noToolsContent,
 		classes,
-		showToolNameIssues = false
+		showToolNameIssues = false,
+		debugMode = false
 	}: Props = $props();
 	let search = $state('');
 	let tools = $state<MCPServerTool[]>([]);
@@ -53,13 +54,10 @@
 	let abortController = $state<AbortController | null>(null);
 
 	// Determine if we have "real" tools or should show previews
-	let hasConnectedServer = $derived(
+	let showRealTools = $derived(
 		!('isCatalogEntry' in entry) || ('isCatalogEntry' in entry && server)
 	);
-	let showRealTools = $derived(hasConnectedServer && tools.length > 0);
-	let showPreviewTools = $derived(
-		previewTools.length > 0 && (!hasConnectedServer || (loading && tools.length === 0))
-	);
+	let showPreviewTools = $derived(previewTools.length > 0 && !showRealTools);
 	let displayTools = $derived(
 		(showRealTools
 			? tools
@@ -130,7 +128,7 @@
 	}
 
 	$effect(() => {
-		if (entry && hasConnectedServer && (!previousEntryId || entry.id !== previousEntryId)) {
+		if (entry && showRealTools && (!previousEntryId || entry.id !== previousEntryId)) {
 			previousEntryId = entry.id;
 			loadTools();
 		}
@@ -143,51 +141,55 @@
 </script>
 
 <div class={twMerge('flex w-full flex-col gap-4', classes?.root)}>
-	<div class="flex w-full flex-col items-center gap-2 md:flex-row">
-		{#if showPreviewTools}
-			<div class="notification-info w-full p-3 text-sm font-light">
-				<div class="flex items-center gap-3">
-					<Info class="size-6 shrink-0" />
-					<div>
-						This is a preview of the tools that are available for this MCP server; the actual tools
-						may differ on user connection.
+	{#if showPreviewTools || error}
+		<div class="flex w-full flex-col items-center gap-2 md:flex-row">
+			{#if showPreviewTools}
+				<div class="notification-info w-full p-3 text-sm font-light">
+					<div class="flex items-center gap-3">
+						<Info class="size-6 shrink-0" />
+						<div>
+							This is a preview of the tools that are available for this MCP server; the actual
+							tools may differ on user connection.
+						</div>
 					</div>
 				</div>
-			</div>
-		{:else}
-			{#key server?.id ?? entry.id}
-				<McpOauth entry={server ?? entry} onAuthenticate={handleAuthenticate} bind:error />
-			{/key}
-		{/if}
-		{#if error}
-			<div class="notification-error flex w-full items-center gap-2 p-3">
-				<CircleAlert class="size-4" />
-				<div class="flex flex-col">
-					<p class="text-sm font-semibold">Unable to retrieve the server's tools</p>
-					<p class="text-sm font-light">
-						{error}
-					</p>
+			{:else}
+				{#key server?.id ?? entry.id}
+					<McpOauth entry={server ?? entry} onAuthenticate={handleAuthenticate} bind:error />
+				{/key}
+			{/if}
+			{#if error}
+				<div class="notification-error flex w-full items-center gap-2 p-3">
+					<CircleAlert class="size-4" />
+					<div class="flex flex-col">
+						<p class="text-sm font-semibold">Unable to retrieve the server's tools</p>
+						<p class="text-sm font-light">
+							{error}
+						</p>
+					</div>
 				</div>
-			</div>
-		{/if}
-	</div>
+			{/if}
+		</div>
+	{/if}
 
 	<div class="flex w-full flex-col gap-2">
 		<div class="mb-2 flex w-full flex-col gap-4">
-			<div class="flex flex-wrap items-center justify-end gap-2 md:shrink-0">
-				<Toggle
-					checked={allDescriptionsEnabled}
-					onChange={(checked) => {
-						allDescriptionsEnabled = checked;
-						expanded = {};
-					}}
-					label="Show All Descriptions"
-					labelInline
-					classes={{
-						label: 'text-sm gap-2'
-					}}
-				/>
-			</div>
+			{#if !debugMode}
+				<div class="flex flex-wrap items-center justify-end gap-2 md:shrink-0">
+					<Toggle
+						checked={allDescriptionsEnabled}
+						onChange={(checked) => {
+							allDescriptionsEnabled = checked;
+							expanded = {};
+						}}
+						label="Show All Descriptions"
+						labelInline
+						classes={{
+							label: 'text-sm gap-2'
+						}}
+					/>
+				</div>
+			{/if}
 
 			<Search
 				class="dark:bg-base-200 dark:border-base-400 bg-base-100 border border-transparent shadow-sm"
@@ -195,11 +197,11 @@
 				placeholder="Search tools..."
 			/>
 		</div>
-		<div class="flex flex-col gap-4 overflow-hidden">
+		<div class={twMerge('flex flex-col gap-4 overflow-hidden', debugMode && 'gap-2')}>
 			{#if loading}
-				<div class="flex items-center justify-center">
-					<Loading class="size-6" />
-				</div>
+				{#each Array.from({ length: 3 }) as _, i (i)}
+					<div class="skeleton h-14 w-full rounded-none"></div>
+				{/each}
 			{:else if displayTools.length > 0}
 				{#each displayTools as tool, index (`${tool.name}-${index}`)}
 					{@const hasContentDisplayed = allDescriptionsEnabled || expanded[tool.id]}
@@ -273,7 +275,7 @@
 					<Wrench class="text-muted-content size-24 opacity-50" />
 					<h4 class="text-muted-content text-lg font-semibold">No tools</h4>
 					<p class="text-muted-content text-sm font-light">
-						{#if !entry || hasConnectedServer}
+						{#if !entry || !showRealTools}
 							Looks like this MCP server doesn't have any tools available.
 						{:else}
 							Connection to to the server is required to list available tools.

--- a/ui/user/src/lib/components/mcp/oauth/DebugOauthDialog.svelte
+++ b/ui/user/src/lib/components/mcp/oauth/DebugOauthDialog.svelte
@@ -36,6 +36,6 @@
 		</div>
 	{/snippet}
 	{#if serverToDebug}
-		<DebugOauthFlow mcpServer={serverToDebug} />
+		<DebugOauthFlow mcpServer={serverToDebug} classes={{ footer: 'sticky bottom-0 left-0' }} />
 	{/if}
 </ResponsiveDialog>

--- a/ui/user/src/lib/components/mcp/oauth/DebugOauthFlow.svelte
+++ b/ui/user/src/lib/components/mcp/oauth/DebugOauthFlow.svelte
@@ -13,9 +13,12 @@
 
 	interface Props {
 		mcpServer: MCPCatalogServer;
+		classes?: {
+			footer?: string;
+		};
 	}
 
-	let { mcpServer }: Props = $props();
+	let { mcpServer, classes }: Props = $props();
 	const DEBUG_FLOW_STEPS = {
 		metadataDiscovery: 'metadataDiscovery',
 		clientRegistration: 'clientRegistration',
@@ -343,7 +346,10 @@
 	</DebugOauthSection>
 </div>
 <div
-	class="sticky bottom-0 left-0 w-full bg-base-100 dark:bg-base-200 p-4 border-t border-base-300 dark:border-base-200"
+	class={twMerge(
+		'w-full bg-base-100 dark:bg-base-200 p-4 border-t border-base-300 dark:border-base-200',
+		classes?.footer
+	)}
 >
 	<div class="flex justify-between gap-4">
 		<button

--- a/ui/user/src/lib/services/admin/constants.ts
+++ b/ui/user/src/lib/services/admin/constants.ts
@@ -45,3 +45,8 @@ export const groupRoleOptions = [
 ];
 
 export const OBOT_PLATFORM_REPO = 'https://github.com/obot-platform/';
+
+export const MCP_MULTI_TENANT_LAUNCH_TEXT =
+	'You are about to launch a new server for a multi-tenant catalog entry.';
+export const MCP_SINGLE_TENANT_LAUNCH_TEXT =
+	'You are about to launch a personal server for a single-tenant catalog entry. This will only be accessible to you.';

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -314,9 +314,9 @@ export function convertEntriesToTableData(
 		.map((entry) => {
 			const registry = getUserRegistry(entry, usersMap);
 			const { source, sourceType } = getSource(entry, usersMap);
-			const configuredServers = (userConfiguredServersByEntry.get(entry.id) ?? []).sort((a, b) => {
-				return new Date(b.created).getTime() - new Date(a.created).getTime();
-			});
+			const configuredServers = [...(userConfiguredServersByEntry.get(entry.id) ?? [])].sort(
+				(a, b) => new Date(b.created).getTime() - new Date(a.created).getTime()
+			);
 			const missingSecretBinding = hasMissingSecretBinding(entry, configuredServers);
 			const connected = configuredServers.some((s) => !serverHasMissingSecretBinding(entry, s));
 			const isMultiUserEntry = isMultiUserCatalogEntry(entry);

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -314,7 +314,9 @@ export function convertEntriesToTableData(
 		.map((entry) => {
 			const registry = getUserRegistry(entry, usersMap);
 			const { source, sourceType } = getSource(entry, usersMap);
-			const configuredServers = userConfiguredServersByEntry.get(entry.id) ?? [];
+			const configuredServers = (userConfiguredServersByEntry.get(entry.id) ?? []).sort((a, b) => {
+				return new Date(b.created).getTime() - new Date(a.created).getTime();
+			});
 			const missingSecretBinding = hasMissingSecretBinding(entry, configuredServers);
 			const connected = configuredServers.some((s) => !serverHasMissingSecretBinding(entry, s));
 			const isMultiUserEntry = isMultiUserCatalogEntry(entry);
@@ -338,6 +340,7 @@ export function convertEntriesToTableData(
 				sourceType,
 				needsUpdate: entry.needsUpdate,
 				connected,
+				connectedAt: configuredServers[0]?.created,
 				missingKubernetesSecret: missingSecretBinding,
 				status: missingSecretBinding
 					? ''
@@ -409,6 +412,7 @@ function convertServersToTableData(
 				created: server.created,
 				registry,
 				connected,
+				connectedAt: instance?.created,
 				status: connected
 					? instance.configured === false
 						? 'Configuration Required'

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -112,6 +112,12 @@ export async function listMcpCatalogServerTools(
 		if (error instanceof Error && error.message.startsWith('424')) {
 			return [];
 		}
+		if (
+			error instanceof Error &&
+			error.message.includes('oauth callback server is not configured')
+		) {
+			return [];
+		}
 		throw error;
 	}
 }

--- a/ui/user/src/routes/devices/[device_id]/+page.svelte
+++ b/ui/user/src/routes/devices/[device_id]/+page.svelte
@@ -582,27 +582,3 @@
 		{client || '-'}
 	{/if}
 {/snippet}
-
-<style lang="postcss">
-	.tab-button {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.5rem 0.75rem;
-		border-bottom: 2px solid transparent;
-		font-size: 0.875rem;
-		color: var(--muted-content, #6b7280);
-		transition:
-			color 200ms,
-			border-color 200ms;
-
-		&:hover {
-			color: inherit;
-		}
-	}
-	.tab-active {
-		color: inherit;
-		border-bottom-color: var(--primary);
-		font-weight: 500;
-	}
-</style>

--- a/ui/user/src/routes/mcp-catalog/EntriesView.svelte
+++ b/ui/user/src/routes/mcp-catalog/EntriesView.svelte
@@ -35,6 +35,7 @@
 		Ellipsis,
 		GitBranch,
 		Link2Icon,
+		RocketIcon,
 		Server,
 		Settings,
 		Trash2,
@@ -414,6 +415,17 @@
 									>
 										<Link2Icon class="size-4" /> Get Connect URL
 									</button>
+									<button
+										class="menu-button"
+										onclick={(e) => {
+											e.stopPropagation();
+											connectToServerDialog?.setupNewInstance(catalogEntry);
+											toggle(false);
+										}}
+									>
+										<RocketIcon class="size-4" />
+										{isMultiUserCatalogEntry(catalogEntry) ? 'Launch Server' : 'Launch Connection'}
+									</button>
 								{/if}
 								{#if canDelete}
 									<button
@@ -535,7 +547,6 @@
 
 <ConnectToServer
 	bind:this={connectToServerDialog}
-	userConfiguredServers={mcpServersAndEntries.current.userConfiguredServers}
 	catalogID={catalog?.id}
 	workspaceID={entity === 'workspace' ? id : undefined}
 	onConnect={handleConnectToServer}

--- a/ui/user/src/routes/mcp-catalog/EntriesView.svelte
+++ b/ui/user/src/routes/mcp-catalog/EntriesView.svelte
@@ -17,7 +17,11 @@
 		type MCPServerInstance,
 		type MCPServerOAuthCredentialStatus
 	} from '$lib/services';
-	import { OBOT_PLATFORM_REPO } from '$lib/services/admin/constants';
+	import {
+		MCP_MULTI_TENANT_LAUNCH_TEXT,
+		MCP_SINGLE_TENANT_LAUNCH_TEXT,
+		OBOT_PLATFORM_REPO
+	} from '$lib/services/admin/constants';
 	import {
 		convertEntriesToTableData,
 		deleteMcpServerDeployment,
@@ -93,6 +97,8 @@
 	let oauthConfigModal = $state<ReturnType<typeof StaticOAuthConfigureModal>>();
 	let oauthConfigEntry = $state<MCPCatalogEntry>();
 	let oauthStatus = $state<MCPServerOAuthCredentialStatus>();
+
+	let setupType = $state<'launch' | 'connect'>('launch');
 
 	let tableData = $derived(
 		convertEntriesToTableData(
@@ -170,6 +176,18 @@
 
 	function getMultiUserCatalogEntryServers(entry: MCPCatalogEntry) {
 		return mcpServersAndEntries.current.servers.filter((s) => s.catalogEntryID === entry.id);
+	}
+
+	function renderIntroText({ entry }: { entry?: MCPCatalogEntry }) {
+		if (isMultiUserCatalogEntry(entry)) {
+			return getMultiUserCatalogEntryServers(entry!).length > 0 || setupType === 'launch'
+				? MCP_MULTI_TENANT_LAUNCH_TEXT
+				: 'In order to receive a connect URL, a new server must be launched.';
+		}
+
+		return setupType === 'launch'
+			? MCP_SINGLE_TENANT_LAUNCH_TEXT
+			: 'In order to receive a connect URL, the initial setup process for this server must be completed.';
 	}
 
 	async function handleConfigureOAuth(entry: MCPCatalogEntry) {
@@ -409,6 +427,7 @@
 										class="menu-button"
 										onclick={(e) => {
 											e.stopPropagation();
+											setupType = 'connect';
 											connectUrlDialog?.open(catalogEntry);
 											toggle(false);
 										}}
@@ -419,12 +438,13 @@
 										class="menu-button"
 										onclick={(e) => {
 											e.stopPropagation();
+											setupType = 'launch';
 											connectToServerDialog?.setupNewInstance(catalogEntry);
 											toggle(false);
 										}}
 									>
 										<RocketIcon class="size-4" />
-										{isMultiUserCatalogEntry(catalogEntry) ? 'Launch Server' : 'Launch Connection'}
+										Launch Server
 									</button>
 								{/if}
 								{#if canDelete}
@@ -477,7 +497,7 @@
 <McpConnectUrlDialog
 	bind:this={connectUrlDialog}
 	onLaunchCatalogEntry={(entry) => {
-		connectToServerDialog?.open({ entry });
+		connectToServerDialog?.setupNewInstance(entry);
 	}}
 />
 
@@ -551,14 +571,7 @@
 	workspaceID={entity === 'workspace' ? id : undefined}
 	onConnect={handleConnectToServer}
 	skipConnectDialog
-	renderIntroText={({ entry }) => {
-		if (isMultiUserCatalogEntry(entry)) {
-			return getMultiUserCatalogEntryServers(entry!).length > 0
-				? 'You are about to launch a new server.'
-				: 'In order to receive a connect URL, a new server must be launched.';
-		}
-		return 'In order to receive a connect URL, the initial setup process for this server must be completed.';
-	}}
+	{renderIntroText}
 />
 
 <StaticOAuthConfigureModal

--- a/ui/user/src/routes/mcp-catalog/McpConnectUrlDialog.svelte
+++ b/ui/user/src/routes/mcp-catalog/McpConnectUrlDialog.svelte
@@ -1,17 +1,11 @@
 <script lang="ts">
 	import CopyField from '$lib/components/CopyField.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
-	import IconButton from '$lib/components/primitives/IconButton.svelte';
-	import Table from '$lib/components/table/Table.svelte';
-	import type { MCPCatalogEntry, MCPCatalogServer } from '$lib/services';
-	import {
-		getMCPDisplayName,
-		hasEditableConfiguration,
-		isMultiUserCatalogEntry
-	} from '$lib/services/user/mcp';
+	import McpSelectServerDeployment from '$lib/components/mcp/McpSelectServerDeployment.svelte';
+	import type { MCPCatalogEntry } from '$lib/services';
+	import { hasEditableConfiguration, isMultiUserCatalogEntry } from '$lib/services/user/mcp';
 	import { mcpServersAndEntries } from '$lib/stores';
-	import { formatTimeAgo } from '$lib/time';
-	import { Info, Plus, Server, StepForward } from '@lucide/svelte';
+	import { Info, Plus } from '@lucide/svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
@@ -21,12 +15,8 @@
 	let { onLaunchCatalogEntry }: Props = $props();
 	let connectUrlDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let displayConnectUrl = $state<{ url: string; catalogEntry?: MCPCatalogEntry }>();
-
-	let selectServerForCatalogEntry = $state<{
-		entry: MCPCatalogEntry;
-		servers: MCPCatalogServer[];
-	}>();
-	let selectServerDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let catalogEntry = $state<MCPCatalogEntry>();
+	let selectServerDialog = $state<ReturnType<typeof McpSelectServerDeployment>>();
 
 	function getMultiUserCatalogEntryServers(entry: MCPCatalogEntry) {
 		return mcpServersAndEntries.current.servers.filter((s) => s.catalogEntryID === entry.id);
@@ -38,15 +28,9 @@
 		);
 	}
 
-	function handleShowSelectServerDialog(entry: MCPCatalogEntry, servers: MCPCatalogServer[]) {
-		selectServerForCatalogEntry = {
-			entry,
-			servers
-		};
-		selectServerDialog?.open();
-	}
+	export function open(initEntry?: MCPCatalogEntry, urlToDisplay?: string) {
+		catalogEntry = initEntry;
 
-	export function open(catalogEntry?: MCPCatalogEntry, urlToDisplay?: string) {
 		if (urlToDisplay) {
 			displayConnectUrl = {
 				url: urlToDisplay,
@@ -56,36 +40,23 @@
 			return;
 		}
 
-		if (isMultiUserCatalogEntry(catalogEntry)) {
-			// multi user catalog requires configuration of at least one server to obtain connect URL
-			const matchingServers = getMultiUserCatalogEntryServers(catalogEntry!);
+		if (catalogEntry) {
+			const matchingServers = isMultiUserCatalogEntry(catalogEntry)
+				? getMultiUserCatalogEntryServers(catalogEntry)
+				: getUserConfiguredCatalogEntryServers(catalogEntry);
 			if (matchingServers.length > 1) {
-				handleShowSelectServerDialog(catalogEntry!, matchingServers);
+				selectServerDialog?.open(matchingServers);
 			} else if (matchingServers[0]?.connectURL) {
 				displayConnectUrl = {
 					url: matchingServers[0].connectURL,
 					catalogEntry
 				};
+
 				connectUrlDialog?.open();
 			} else {
 				onLaunchCatalogEntry?.(catalogEntry!);
 			}
-			return;
 		}
-
-		const matchingServers = getUserConfiguredCatalogEntryServers(catalogEntry!);
-		if (matchingServers.length > 1) {
-			handleShowSelectServerDialog(catalogEntry!, matchingServers);
-			return;
-		}
-
-		// single user catalog entry contains baseline connect URL
-		displayConnectUrl = {
-			url: catalogEntry?.connectURL ?? '',
-			catalogEntry
-		};
-
-		connectUrlDialog?.open();
 	}
 
 	function isConfigurableSingleUserCatalogEntry(entry?: MCPCatalogEntry) {
@@ -105,91 +76,61 @@
 	classes={{ content: 'p-0', header: 'p-4 pb-0' }}
 	disableMobileStyles
 >
-	{#if !needsSingleUserConfiguration(displayConnectUrl?.catalogEntry, displayConnectUrl?.url)}
+	{#if displayConnectUrl?.url}
 		<div
 			class={twMerge('px-4', !isMultiUserCatalogEntry(displayConnectUrl?.catalogEntry) && 'pb-4')}
 		>
 			<CopyField id="connect-url-dialog-connection-url" value={displayConnectUrl?.url ?? ''} />
 		</div>
-	{/if}
-	{#if isMultiUserCatalogEntry(displayConnectUrl?.catalogEntry)}
-		<div class="mt-4 p-4 border-t border-base-300 dark:border-base-400">
-			<p
-				class="text-muted-content flex items-center justify-end gap-2 text-sm font-light md:px-0 px-4"
-			>
-				Need to set up a different instance?
-				<button
-					class="btn btn-sm btn-primary text-xs"
-					onclick={() => {
-						if (displayConnectUrl?.catalogEntry) {
-							connectUrlDialog?.close();
-							onLaunchCatalogEntry?.(displayConnectUrl.catalogEntry);
-						}
-					}}
+		{#if isMultiUserCatalogEntry(displayConnectUrl?.catalogEntry)}
+			<div class="mt-4 p-4 border-t border-base-300 dark:border-base-400">
+				<p
+					class="text-muted-content flex items-center justify-end gap-2 text-sm font-light md:px-0 px-4"
 				>
-					<Plus class="size-3" />
-					Launch New Server
-				</button>
-			</p>
-		</div>
-	{:else if needsSingleUserConfiguration(displayConnectUrl?.catalogEntry, displayConnectUrl?.url)}
-		<div class="notification-info m-4 flex flex-col gap-3">
-			<p class="flex items-center gap-2 text-xs">
-				<Info class="size-4 shrink-0" />
-				This server requires user configuration on connection with an MCP client.
-			</p>
-		</div>
-	{:else if isConfigurableSingleUserCatalogEntry(displayConnectUrl?.catalogEntry)}
-		<div class="notification-info m-4 mt-0">
-			<p class="flex items-center gap-2 text-xs">
-				<Info class="size-4" />
-				This connection URL uses your configured server instance.
-			</p>
-		</div>
+					Need to set up a different instance?
+					<button
+						class="btn btn-sm btn-primary text-xs"
+						onclick={() => {
+							if (displayConnectUrl?.catalogEntry) {
+								connectUrlDialog?.close();
+								onLaunchCatalogEntry?.(displayConnectUrl.catalogEntry);
+							}
+						}}
+					>
+						<Plus class="size-3" />
+						Launch New Server
+					</button>
+				</p>
+			</div>
+		{:else if isConfigurableSingleUserCatalogEntry(displayConnectUrl?.catalogEntry)}
+			<div class="notification-info m-4 mt-0">
+				<p class="flex items-center gap-2 text-xs">
+					<Info class="size-4" />
+					This connection URL uses your configured server instance.
+				</p>
+			</div>
+		{:else if needsSingleUserConfiguration(displayConnectUrl?.catalogEntry, displayConnectUrl?.url)}
+			<div class="notification-info m-4 flex flex-col gap-3">
+				<p class="flex items-center gap-2 text-xs">
+					<Info class="size-4 shrink-0" />
+					This server requires user configuration on connection with an MCP client.
+				</p>
+			</div>
+		{/if}
+	{:else}
+		<p class="px-4 text-muted-content text-sm">No connection URL available.</p>
 	{/if}
 </ResponsiveDialog>
 
-<ResponsiveDialog
-	class="bg-base-200 dark:bg-base-100"
+<McpSelectServerDeployment
 	bind:this={selectServerDialog}
-	title="Select Your Server"
->
-	<Table
-		data={selectServerForCatalogEntry?.servers || []}
-		fields={['name', 'created']}
-		onClickRow={async (d) => {
-			selectServerDialog?.close();
-			if (!d.connectURL) return;
-			displayConnectUrl = {
-				url: d.connectURL,
-				catalogEntry: selectServerForCatalogEntry?.entry
-			};
-			connectUrlDialog?.open();
-		}}
-		disablePortal
-	>
-		{#snippet onRenderColumn(property, d)}
-			{#if property === 'name'}
-				<div class="flex shrink-0 items-center gap-2">
-					<div class="icon">
-						{#if d.manifest.icon}
-							<img src={d.manifest.icon} alt={d.manifest.name} class="size-6" />
-						{:else}
-							<Server class="size-6" />
-						{/if}
-					</div>
-					<p class="flex items-center gap-2">
-						{getMCPDisplayName(d)}
-					</p>
-				</div>
-			{:else if property === 'created'}
-				{formatTimeAgo(d.created).relativeTime}
-			{/if}
-		{/snippet}
-		{#snippet actions()}
-			<IconButton class="hover:dark:bg-base-100/50">
-				<StepForward class="size-4" />
-			</IconButton>
-		{/snippet}
-	</Table>
-</ResponsiveDialog>
+	onSelectServer={(d) => {
+		selectServerDialog?.close();
+		if (!d.connectURL) return;
+		displayConnectUrl = {
+			url: d.connectURL,
+			catalogEntry
+		};
+		connectUrlDialog?.open();
+	}}
+/>

--- a/ui/user/src/routes/mcp-catalog/McpConnectUrlDialog.svelte
+++ b/ui/user/src/routes/mcp-catalog/McpConnectUrlDialog.svelte
@@ -46,9 +46,9 @@
 				: getUserConfiguredCatalogEntryServers(catalogEntry);
 			if (matchingServers.length > 1) {
 				selectServerDialog?.open(matchingServers);
-			} else if (matchingServers[0]?.connectURL) {
+			} else if (matchingServers[0]?.connectURL || catalogEntry?.connectURL) {
 				displayConnectUrl = {
-					url: matchingServers[0].connectURL,
+					url: matchingServers[0]?.connectURL || catalogEntry?.connectURL || '',
 					catalogEntry
 				};
 
@@ -61,10 +61,6 @@
 
 	function isConfigurableSingleUserCatalogEntry(entry?: MCPCatalogEntry) {
 		return entry && !isMultiUserCatalogEntry(entry) && hasEditableConfiguration(entry);
-	}
-
-	function needsSingleUserConfiguration(entry?: MCPCatalogEntry, url?: string) {
-		return isConfigurableSingleUserCatalogEntry(entry) && !url;
 	}
 </script>
 
@@ -82,43 +78,40 @@
 		>
 			<CopyField id="connect-url-dialog-connection-url" value={displayConnectUrl?.url ?? ''} />
 		</div>
-		{#if isMultiUserCatalogEntry(displayConnectUrl?.catalogEntry)}
-			<div class="mt-4 p-4 border-t border-base-300 dark:border-base-400">
-				<p
-					class="text-muted-content flex items-center justify-end gap-2 text-sm font-light md:px-0 px-4"
-				>
-					Need to set up a different instance?
-					<button
-						class="btn btn-sm btn-primary text-xs"
-						onclick={() => {
-							if (displayConnectUrl?.catalogEntry) {
-								connectUrlDialog?.close();
-								onLaunchCatalogEntry?.(displayConnectUrl.catalogEntry);
-							}
-						}}
-					>
-						<Plus class="size-3" />
-						Launch New Server
-					</button>
-				</p>
-			</div>
-		{:else if isConfigurableSingleUserCatalogEntry(displayConnectUrl?.catalogEntry)}
-			<div class="notification-info m-4 mt-0">
-				<p class="flex items-center gap-2 text-xs">
-					<Info class="size-4" />
-					This connection URL uses your configured server instance.
-				</p>
-			</div>
-		{:else if needsSingleUserConfiguration(displayConnectUrl?.catalogEntry, displayConnectUrl?.url)}
-			<div class="notification-info m-4 flex flex-col gap-3">
-				<p class="flex items-center gap-2 text-xs">
-					<Info class="size-4 shrink-0" />
-					This server requires user configuration on connection with an MCP client.
-				</p>
-			</div>
-		{/if}
 	{:else}
-		<p class="px-4 text-muted-content text-sm">No connection URL available.</p>
+		<p class="px-4 text-muted-content text-sm text-center w-full">No connection URL available.</p>
+	{/if}
+	{#if isMultiUserCatalogEntry(displayConnectUrl?.catalogEntry)}
+		<div class="mt-4 p-4 border-t border-base-300 dark:border-base-400">
+			<p
+				class="text-muted-content flex items-center justify-end gap-2 text-sm font-light md:px-0 px-4"
+			>
+				Need to set up a different instance?
+				<button
+					class="btn btn-sm btn-primary text-xs"
+					onclick={() => {
+						if (displayConnectUrl?.catalogEntry) {
+							connectUrlDialog?.close();
+							onLaunchCatalogEntry?.(displayConnectUrl.catalogEntry);
+						}
+					}}
+				>
+					<Plus class="size-3" />
+					Launch New Server
+				</button>
+			</p>
+		</div>
+	{:else if isConfigurableSingleUserCatalogEntry(displayConnectUrl?.catalogEntry)}
+		<div class="notification-info m-4 mt-0">
+			<p class="flex items-center gap-2 text-xs">
+				<Info class="size-4" />
+				{#if getUserConfiguredCatalogEntryServers(displayConnectUrl!.catalogEntry!).length > 0}
+					This connection URL uses your configured server instance.
+				{:else}
+					This server requires user configuration on connection with an MCP client.
+				{/if}
+			</p>
+		</div>
 	{/if}
 </ResponsiveDialog>
 
@@ -126,9 +119,8 @@
 	bind:this={selectServerDialog}
 	onSelectServer={(d) => {
 		selectServerDialog?.close();
-		if (!d.connectURL) return;
 		displayConnectUrl = {
-			url: d.connectURL,
+			url: d.connectURL || catalogEntry?.connectURL || '',
 			catalogEntry
 		};
 		connectUrlDialog?.open();

--- a/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
+++ b/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
@@ -29,7 +29,6 @@
 	import { openUrl } from '$lib/utils';
 	import ResponsiveDialog from '../../lib/components/ResponsiveDialog.svelte';
 	import EditExistingDeployment from '../../lib/components/mcp/EditExistingDeployment.svelte';
-	import DebugOauthDialog from '../../lib/components/mcp/oauth/DebugOauthDialog.svelte';
 	import IconButton from '../../lib/components/primitives/IconButton.svelte';
 	import { CircleFadingArrowUp, Server, StepForward } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
@@ -62,8 +61,6 @@
 	let selectedEntry = $state<MCPCatalogEntry>();
 	let selectServerDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let selectServerMode = $state<ServerSelectMode>('connect');
-
-	let debugOauthDialog = $state<ReturnType<typeof DebugOauthDialog>>();
 
 	let instancesMap = $derived(
 		new Map(
@@ -105,9 +102,13 @@
 	);
 
 	let filteredTableData = $derived.by(() => {
-		const sorted = tableData.sort((a, b) => {
+		const sorted = [...tableData].sort((a, b) => {
+			if (a.connected !== b.connected) {
+				return a.connected ? -1 : 1;
+			}
 			return a.name.localeCompare(b.name);
 		});
+
 		return query
 			? sorted.filter((d) => d.name.toLowerCase().includes(query.toLowerCase()))
 			: sorted;
@@ -262,7 +263,7 @@
 				: userConfiguredServers.some(requiresUserUpdate)}
 			<div
 				class={twMerge(
-					'flex items-center justify-between gap-8 rounded-md p-3 bg-base-100 dark:bg-base-300 shadow-xs hover:bg-base-300 dark:hover:bg-base-400 cursor-pointer'
+					'flex items-center justify-between gap-8 rounded-md p-3 bg-base-100 dark:bg-base-300 shadow-xs hover:bg-base-300 dark:hover:bg-base-400/75 cursor-pointer'
 				)}
 				role="button"
 				tabindex="0"
@@ -284,8 +285,8 @@
 								<Server class="size-6" />
 							{/if}
 						</div>
-						<p class="flex items-center gap-2">
-							{d.name}
+						<div class="flex items-center gap-2">
+							<p>{d.name}</p>
 							{#if requiresUserAttention}
 								<span
 									use:tooltip={{
@@ -295,8 +296,13 @@
 								>
 									<CircleFadingArrowUp class="text-primary size-4" />
 								</span>
+							{:else if d.connected}
+								<div class="badge badge-xs badge-secondary gap-1">
+									<span class="status status-primary"></span>
+									Connected
+								</div>
 							{/if}
-						</p>
+						</div>
 					</div>
 					<p class="text-xs text-muted-content min-h-8 mt-2">
 						{stripMarkdownToText(d.data.manifest.description ?? '')}
@@ -327,7 +333,6 @@
 
 <ConnectToServer
 	bind:this={connectToServerDialog}
-	userConfiguredServers={mcpServersAndEntries.current.userConfiguredServers}
 	catalogID={catalog?.id}
 	workspaceID={entity === 'workspace' ? id : undefined}
 	onConnect={handleConnectToServer}
@@ -435,5 +440,3 @@
 		mcpServersAndEntries.refreshUserConfiguredServers();
 	}}
 />
-
-<DebugOauthDialog bind:this={debugOauthDialog} />

--- a/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
+++ b/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import ConnectToServer from '$lib/components/mcp/ConnectToServer.svelte';
-	import Table from '$lib/components/table/Table.svelte';
+	import McpSelectServerDeployment from '$lib/components/mcp/McpSelectServerDeployment.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
 	import {
 		UserService,
@@ -20,17 +20,13 @@
 		hasMissingSecretBindingConfig,
 		isMultiUserServer,
 		restartMcpServer,
-		getMCPDisplayName,
 		isMultiUserCatalogEntry,
 		requiresUserUpdate
 	} from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, profile, version } from '$lib/stores';
-	import { formatTimeAgo } from '$lib/time';
 	import { openUrl } from '$lib/utils';
-	import ResponsiveDialog from '../../lib/components/ResponsiveDialog.svelte';
 	import EditExistingDeployment from '../../lib/components/mcp/EditExistingDeployment.svelte';
-	import IconButton from '../../lib/components/primitives/IconButton.svelte';
-	import { CircleFadingArrowUp, Server, StepForward } from '@lucide/svelte';
+	import { CircleFadingArrowUp, Server } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -57,9 +53,8 @@
 	let connectToServerDialog = $state<ReturnType<typeof ConnectToServer>>();
 	let editExistingDialog = $state<ReturnType<typeof EditExistingDeployment>>();
 
-	let selectedConfiguredServers = $state<MCPCatalogServer[]>([]);
 	let selectedEntry = $state<MCPCatalogEntry>();
-	let selectServerDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let selectServerDialog = $state<ReturnType<typeof McpSelectServerDeployment>>();
 	let selectServerMode = $state<ServerSelectMode>('connect');
 
 	let instancesMap = $derived(
@@ -160,9 +155,8 @@
 			mode === 'connect'
 				? getUsableConfiguredServersForCatalogEntry(entry)
 				: getConfiguredServersForCatalogEntry(entry);
-		selectedConfiguredServers = allServers;
 		selectedEntry = entry;
-		selectServerDialog?.open();
+		selectServerDialog?.open(allServers);
 		selectServerMode = mode;
 	}
 
@@ -338,101 +332,59 @@
 	onConnect={handleConnectToServer}
 />
 
-<ResponsiveDialog
-	class="bg-base-200 dark:bg-base-100"
+<McpSelectServerDeployment
 	bind:this={selectServerDialog}
-	title="Select Your Server"
->
-	<Table
-		data={selectedConfiguredServers || []}
-		fields={['name', 'created']}
-		onClickRow={async (d) => {
-			selectServerDialog?.close();
-			switch (selectServerMode) {
-				case 'server-details': {
-					goto(
-						resolve(
-							isMultiUserServer(d)
-								? `/mcp-servers/s/${d.id}`
-								: `/mcp-servers/c/${d.catalogEntryID}/instance/${d.id}`
-						)
-					);
-					break;
-				}
-				case 'rename': {
-					editExistingDialog?.rename({
-						server: d,
-						entry: d.catalogEntryID ? entriesMap.get(d.catalogEntryID) : undefined
-					});
-					break;
-				}
-				case 'edit': {
-					editExistingDialog?.edit({
-						server: d,
-						entry: d.catalogEntryID ? entriesMap.get(d.catalogEntryID) : undefined
-					});
-					break;
-				}
-				case 'disconnect': {
-					await disconnectCurrentUser(d);
-					await mcpServersAndEntries.refreshAll();
-					break;
-				}
-				case 'restart': {
-					await restartServer(d);
-					await mcpServersAndEntries.refreshAll();
-					break;
-				}
-				case 'reauthenticate': {
-					await reauthenticateServer(d);
-					break;
-				}
-				default:
-					connectToServerDialog?.open({
-						entry: selectedEntry,
-						server: d,
-						instance: isMultiUserServer(d) ? instancesMap.get(d.id) : undefined
-					});
-					break;
+	onSelectServer={async (d) => {
+		selectServerDialog?.close();
+		switch (selectServerMode) {
+			case 'server-details': {
+				goto(
+					resolve(
+						isMultiUserServer(d)
+							? `/mcp-servers/s/${d.id}`
+							: `/mcp-servers/c/${d.catalogEntryID}/instance/${d.id}`
+					)
+				);
+				break;
 			}
-		}}
-		disablePortal
-	>
-		{#snippet onRenderColumn(property, d)}
-			{#if property === 'name'}
-				<div class="flex shrink-0 items-center gap-2">
-					<div class="icon">
-						{#if d.manifest.icon}
-							<img src={d.manifest.icon} alt={d.manifest.name} class="size-6" />
-						{:else}
-							<Server class="size-6" />
-						{/if}
-					</div>
-					<p class="flex items-center gap-2">
-						{getMCPDisplayName(d)}
-						{#if requiresUserUpdate(d)}
-							<span
-								use:tooltip={{
-									classes: ['border-primary', 'bg-primary/10', 'dark:bg-primary/50'],
-									text: 'Configuration requires your attention'
-								}}
-							>
-								<CircleFadingArrowUp class="text-primary size-4" />
-							</span>
-						{/if}
-					</p>
-				</div>
-			{:else if property === 'created'}
-				{formatTimeAgo(d.created).relativeTime}
-			{/if}
-		{/snippet}
-		{#snippet actions()}
-			<IconButton class="hover:dark:bg-base-100/50">
-				<StepForward class="size-4" />
-			</IconButton>
-		{/snippet}
-	</Table>
-</ResponsiveDialog>
+			case 'rename': {
+				editExistingDialog?.rename({
+					server: d,
+					entry: d.catalogEntryID ? entriesMap.get(d.catalogEntryID) : undefined
+				});
+				break;
+			}
+			case 'edit': {
+				editExistingDialog?.edit({
+					server: d,
+					entry: d.catalogEntryID ? entriesMap.get(d.catalogEntryID) : undefined
+				});
+				break;
+			}
+			case 'disconnect': {
+				await disconnectCurrentUser(d);
+				await mcpServersAndEntries.refreshAll();
+				break;
+			}
+			case 'restart': {
+				await restartServer(d);
+				await mcpServersAndEntries.refreshAll();
+				break;
+			}
+			case 'reauthenticate': {
+				await reauthenticateServer(d);
+				break;
+			}
+			default:
+				connectToServerDialog?.open({
+					entry: selectedEntry,
+					server: d,
+					instance: isMultiUserServer(d) ? instancesMap.get(d.id) : undefined
+				});
+				break;
+		}
+	}}
+/>
 
 <EditExistingDeployment
 	bind:this={editExistingDialog}


### PR DESCRIPTION
Addresses #7047 

* adds Launch Server to bring back launching a server in the UI for administrative side (MCP Catalog) & in Troubleshooting tab
* adds showing connected status back into user consumption side (MCP Servers)
* moves Debug Oauth into administrative catalog entry side (MCP Catalog) (selectable by deployment)
* adds viewing tools for a deployment in administrative catalog entry (MCP Catalog) (selectable by deployment)
* moves Select Your Select dialog that is used in various components as a reusable component