### PR TITLE
enhance: show notices for deprecated catalog entries

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -164,6 +164,7 @@
 			const isHostedType = type === 'hosted';
 			return {
 				categories: [''],
+				metadata: undefined,
 				name: '',
 				description: '',
 				env: [],
@@ -190,6 +191,7 @@
 
 			const formData: RuntimeFormData = {
 				categories: manifest.metadata?.categories?.split(',').filter((c) => c.trim()) ?? [''],
+				metadata: manifest.metadata,
 				icon: manifest.icon ?? '',
 				name: manifest.name ?? '',
 				description: manifest.description ?? '',
@@ -239,6 +241,7 @@
 
 			const formData: RuntimeFormData = {
 				categories: manifest.metadata?.categories?.split(',').filter((c) => c.trim()) ?? [''],
+				metadata: manifest.metadata,
 				name: manifest.name ?? '',
 				icon: manifest.icon ?? '',
 				env: manifest.env?.map((env) => ({ ...env, value: env.value ?? '' })) ?? [],
@@ -408,7 +411,7 @@
 	});
 
 	function convertToEntryManifest(formData: RuntimeFormData): MCPCatalogEntryServerManifest {
-		const { categories, ...baseData } = formData;
+		const { categories, metadata, ...baseData } = formData;
 		const startupTimeoutSeconds = baseData.startupTimeoutSeconds;
 		const startupTimeoutConfig =
 			typeof startupTimeoutSeconds === 'number' &&
@@ -433,7 +436,7 @@
 			multiUserConfig:
 				baseData.serverUserType === 'multiUser' ? baseData.multiUserConfig : undefined,
 			...(resources ? { resources } : {}),
-			...convertCategoriesToMetadata(categories)
+			...convertCategoriesToMetadata(categories, metadata)
 		};
 
 		// Add runtime-specific config based on the runtime type

--- a/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
@@ -8,8 +8,10 @@
 		type MCPCatalogServer,
 		type OrgUser
 	} from '$lib/services';
+	import { isDeprecatedMCPServer } from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
 	import { openUrl } from '$lib/utils';
+	import McpDeprecatedNotice from '../mcp/McpDeprecatedNotice.svelte';
 	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import { CircleAlert, ChevronRight, Server } from '@lucide/svelte';
@@ -69,6 +71,7 @@
 				{@const mcpServerId =
 					componentServer.mcpServerID && serversMap.get(componentServer.mcpServerID)?.id}
 				{@const componentExists = !!(catalogEntryServerId || mcpServerId)}
+				{@const deprecated = isDeprecatedMCPServer(componentServer)}
 
 				{#if componentExists}
 					<button
@@ -107,6 +110,7 @@
 								{/if}
 							</div>
 							<p class="text-sm">{componentServer.manifest?.name}</p>
+							<McpDeprecatedNotice {deprecated} child />
 							{#if catalogEntryServerId}
 								<span class="text-muted-content text-sm">({catalogEntryServerId})</span>
 							{/if}
@@ -132,6 +136,7 @@
 								{/if}
 							</div>
 							<p class="text-sm">{componentServer.manifest?.name}</p>
+							<McpDeprecatedNotice {deprecated} child />
 							<span
 								class="text-muted-content flex items-center gap-1 text-xs"
 								title="This component server no longer exists"

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -22,6 +22,7 @@
 		getServerTypeLabel,
 		getSource,
 		isMultiUserCatalogEntry,
+		isDeprecatedMCPServer,
 		isMultiUserServer
 	} from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
@@ -1435,6 +1436,7 @@
 	submitText="Launch"
 	loading={saving}
 	isNew={false}
+	deprecated={isDeprecatedMCPServer(entry)}
 />
 
 <ResponsiveDialog

--- a/ui/user/src/lib/components/admin/SearchMcpServers.svelte
+++ b/ui/user/src/lib/components/admin/SearchMcpServers.svelte
@@ -8,9 +8,11 @@
 		type MCPCatalogServer,
 		type OrgUser
 	} from '$lib/services';
+	import { isDeprecatedMCPServer } from '$lib/services/user/mcp';
 	import { getUserDisplayName } from '$lib/utils';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import Search from '../Search.svelte';
+	import McpDeprecatedNotice from '../mcp/McpDeprecatedNotice.svelte';
 	import { Check, Server } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -39,6 +41,7 @@
 		id: string;
 		type: 'mcpcatalogentry' | 'mcpserver' | 'all' | 'mcpCatalog';
 		registry?: string;
+		deprecated?: boolean;
 	};
 
 	let {
@@ -100,6 +103,7 @@
 					description: entry.manifest?.description,
 					id: entry.id,
 					type: 'mcpcatalogentry' as const,
+					deprecated: isDeprecatedMCPServer(entry),
 					registry:
 						entry.powerUserID && isAdminView
 							? `${getUserDisplayName(usersMap, entry.powerUserID)}'s Registry`
@@ -123,6 +127,7 @@
 					description: server.manifest.description,
 					id: server.id,
 					type: 'mcpserver' as const,
+					deprecated: isDeprecatedMCPServer(server),
 					registry:
 						server.userID && server.powerUserWorkspaceID && isAdminView
 							? `${getUserDisplayName(usersMap, server.userID)}'s Registry`
@@ -235,6 +240,7 @@
 												{item.registry}
 											</div>
 										{/if}
+										<McpDeprecatedNotice deprecated={item.deprecated} />
 									</div>
 									<span class="text-muted-content line-clamp-2 text-xs">
 										{stripMarkdownToText(item.description ?? '')}

--- a/ui/user/src/lib/components/api-keys/ServersLabel.svelte
+++ b/ui/user/src/lib/components/api-keys/ServersLabel.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
-	import { compileAvailableMcpServers, getMCPDisplayName } from '$lib/services/user/mcp';
+	import {
+		compileAvailableMcpServers,
+		getMCPDisplayName,
+		isDeprecatedMCPServer
+	} from '$lib/services/user/mcp';
 	import { mcpServersAndEntries } from '$lib/stores';
+	import McpDeprecatedNotice from '../mcp/McpDeprecatedNotice.svelte';
 	import { TriangleAlert } from '@lucide/svelte';
 
 	interface Props {
@@ -29,15 +34,27 @@
 		return mcpServerIds
 			.map((id) => {
 				const server = serverMap.get(id);
-				return getMCPDisplayName(server, '');
+				return server
+					? {
+							name: getMCPDisplayName(server, ''),
+							deprecated: isDeprecatedMCPServer(server)
+						}
+					: undefined;
 			})
-			.filter((name): name is string => name !== '');
+			.filter(
+				(server): server is { name: string; deprecated: boolean } =>
+					server !== undefined && server.name !== ''
+			);
 	});
 
-	type DisplayItem = { name: string; deleted: boolean };
+	type DisplayItem = { name: string; deleted: boolean; deprecated?: boolean };
 	let displayItems = $derived.by((): DisplayItem[] => {
 		if (isAllServers) return [];
-		const items: DisplayItem[] = resolvedServers.map((name) => ({ name, deleted: false }));
+		const items: DisplayItem[] = resolvedServers.map((server) => ({
+			name: server.name,
+			deleted: false,
+			deprecated: server.deprecated
+		}));
 		for (let i = 0; i < deletedServersCount; i++) {
 			items.push({ name: 'Deleted', deleted: true });
 		}
@@ -46,8 +63,10 @@
 </script>
 
 {#snippet serverName(item: DisplayItem)}
-	{#if item.deleted}<i class="text-muted-content font-light italic">({item.name})</i
-		>{:else}{item.name}{/if}
+	{#if item.deleted}<i class="text-muted-content font-light italic">({item.name})</i>{:else}<span
+			class="inline-flex items-center gap-1"
+			>{item.name}<McpDeprecatedNotice deprecated={item.deprecated} /></span
+		>{/if}
 {/snippet}
 
 <div class="">

--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -8,6 +8,7 @@
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import SensitiveInput from '../SensitiveInput.svelte';
 	import Toggle from '../Toggle.svelte';
+	import McpDeprecatedNotice from './McpDeprecatedNotice.svelte';
 	import SecretBindingPicker from './SecretBindingPicker.svelte';
 	import { CircleAlert, Server } from '@lucide/svelte';
 	import { tick, type Snippet } from 'svelte';
@@ -28,6 +29,7 @@
 		hostname?: string;
 		name?: string;
 		icon?: string;
+		deprecated?: boolean;
 		disabled?: boolean; // source of truth; checkbox shows Enable and binds to !disabled
 		// When true, this component represents a multi-user server. Composite
 		// configuration can still collect the component instance's user-specific
@@ -64,6 +66,7 @@
 		configurationTitle?: string;
 		secretBindingTargets?: MCPAllowedSecretBindingTarget[];
 		disableEnvSecretBindings?: boolean;
+		deprecated?: boolean;
 	}
 	let {
 		form = $bindable(),
@@ -85,6 +88,7 @@
 		configurationTitle,
 		secretBindingTargets,
 		disableEnvSecretBindings,
+		deprecated,
 		animate = 'slide'
 	}: Props = $props();
 	let configDialog = $state<ReturnType<typeof ResponsiveDialog>>();
@@ -350,6 +354,7 @@
 						<Server class="size-6" />
 					{/if}
 					<div class="font-xs font-semibold">{comp.name}</div>
+					<McpDeprecatedNotice deprecated={comp.deprecated} child />
 				</div>
 			{/each}
 		</div>
@@ -435,6 +440,8 @@
 			}}
 		>
 			<div class="my-4 flex flex-col gap-4">
+				<McpDeprecatedNotice {deprecated} variant="notification" />
+
 				{#if showAlias}
 					<div class="flex flex-col gap-1">
 						<span class="flex items-center gap-2">
@@ -458,6 +465,7 @@
 									<img src={comp.icon} alt={comp.name || compId} class="size-8" />
 								{/if}
 								<div class="grow font-medium">{comp.name || compId}</div>
+								<McpDeprecatedNotice deprecated={comp.deprecated} child />
 								<Toggle
 									checked={!form.componentConfigs[compId].disabled}
 									onChange={(checked) => (form.componentConfigs[compId].disabled = !checked)}
@@ -471,6 +479,12 @@
 								{@const envs = getNonStaticServerFields(comp.envs)}
 
 								<div class="border-t border-base-300 p-3">
+									<McpDeprecatedNotice
+										deprecated={comp.deprecated}
+										variant="notification"
+										child
+										class="mb-3"
+									/>
 									{#each envs as env (env.data.key)}
 										{#if secretBindingTargets !== undefined || !hasSecretBinding(env.data)}
 											{@const highlightRequired =

--- a/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
@@ -15,11 +15,13 @@
 		MAX_TOOL_PREFIX_LENGTH,
 		TOOL_NAME_CHARSET_REGEX,
 		TOOL_NAME_SPECIAL_CHAR_WARNING,
+		isDeprecatedMCPServer,
 		toolNameIssue,
 		type ToolNameIssue
 	} from '$lib/services/user/mcp';
 	import Toggle from '../Toggle.svelte';
 	import IconButton from '../primitives/IconButton.svelte';
+	import McpDeprecatedNotice from './McpDeprecatedNotice.svelte';
 	import ToolNameIssueIcon from './ToolNameIssueIcon.svelte';
 	import CompositeToolsSetup from './composite/CompositeSelectServerAndToolsSetup.svelte';
 	import {
@@ -367,6 +369,7 @@
 			{#each config.componentServers as entry (getComponentId(entry))}
 				{@const componentId = getComponentId(entry)}
 				{@const headerSeverity = componentSeverity(entry)}
+				{@const deprecated = isDeprecatedMCPServer(entry)}
 				<div
 					class="dark:bg-base-300 dark:border-base-400 rounded-lg border border-gray-200 bg-gray-50"
 				>
@@ -380,6 +383,7 @@
 							<div class="truncate font-medium" title={entry.manifest?.name || 'Unnamed Server'}>
 								{entry.manifest?.name || 'Unnamed Server'}
 							</div>
+							<McpDeprecatedNotice {deprecated} child />
 							{#if headerSeverity}
 								<ToolNameIssueIcon
 									issue={{
@@ -417,6 +421,7 @@
 					{#if expanded[componentId]}
 						{@const issue = prefixIssue(entry)}
 						<div class="border-t border-gray-200 p-3" in:slide={{ axis: 'y' }}>
+							<McpDeprecatedNotice {deprecated} variant="notification" child class="mb-3" />
 							<div class="mb-3 flex flex-col gap-1">
 								<p class="flex items-center gap-1.5 text-xs text-muted-content">
 									<span>Tool name prefix</span>

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -97,7 +97,6 @@
 	);
 
 	let showIntroDialog = $state(false);
-	let showDeprecatedConnectDialog = $state(false);
 
 	let connectDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let configDialog = $state<ReturnType<typeof CatalogConfigureForm>>();
@@ -174,11 +173,6 @@
 		if (onConnect && !skipOnConnect) {
 			onConnect({ server, entry, instance });
 		}
-	}
-
-	function handleDeprecatedConnectContinue() {
-		showDeprecatedConnectDialog = false;
-		handleConnect();
 	}
 
 	export async function authenticate(item: MCPCatalogServer, parentEntry?: MCPCatalogEntry) {
@@ -991,7 +985,6 @@
 		entry = initEntry;
 		instance = initInstance;
 		configureInstance = initConfigureInstance ?? false;
-		const isDeprecated = isDeprecatedMCPServer(initEntry) || isDeprecatedMCPServer(initServer);
 
 		if (server && instance && configureInstance && hasMultiUserInstanceConfiguration(server)) {
 			initMultiUserInstanceForm(server, instance);
@@ -1001,11 +994,7 @@
 			(entry && server) ||
 			(server && instance)
 		) {
-			if (isDeprecated) {
-				showDeprecatedConnectDialog = true;
-			} else {
-				connectDialog?.open();
-			}
+			connectDialog?.open();
 		} else {
 			showIntroDialog = true;
 		}
@@ -1112,28 +1101,6 @@
 				<br />Click below to begin.
 			{/if}
 		</p>
-	{/snippet}
-</Confirm>
-
-<Confirm
-	show={showDeprecatedConnectDialog}
-	onsuccess={handleDeprecatedConnectContinue}
-	submitText="Continue"
-	type="info"
-	title="Deprecated Server"
-	oncancel={() => (showDeprecatedConnectDialog = false)}
->
-	{#snippet msgContent()}
-		<div class="flex items-center gap-2 text-lg font-semibold mb-2">
-			{@render dialogTitle(entry || server)}
-			<McpDeprecatedNotice {deprecated} />
-		</div>
-	{/snippet}
-	{#snippet note()}
-		<div class="flex flex-col gap-3">
-			<McpDeprecatedNotice {deprecated} variant="notification" />
-			<p>Continue to view the connection URL.</p>
-		</div>
 	{/snippet}
 </Confirm>
 

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -18,7 +18,8 @@
 		isKubernetesRuntimeBackend,
 		hasEditableConfiguration,
 		getMCPDisplayName,
-		hasSecretBinding
+		hasSecretBinding,
+		isDeprecatedMCPServer
 	} from '$lib/services/user/mcp';
 	import { errors, mcpServersAndEntries, version } from '$lib/stores';
 	import Confirm from '../Confirm.svelte';
@@ -30,6 +31,7 @@
 		type LaunchFormData
 	} from './CatalogConfigureForm.svelte';
 	import HowToConnect from './HowToConnect.svelte';
+	import McpDeprecatedNotice from './McpDeprecatedNotice.svelte';
 	import { Server, X, CircleAlert } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -75,6 +77,7 @@
 	let userConfiguredServers = $derived(mcpServersAndEntries.current.userConfiguredServers);
 
 	let manifest = $derived(server?.manifest || entry?.manifest);
+	let deprecated = $derived(isDeprecatedMCPServer(entry) || isDeprecatedMCPServer(server));
 	let isConfigured = $derived(Boolean((entry && server) || (server && instance)));
 	let isDeployingMultiUserCatalogEntry = $derived(
 		Boolean(entry && !server && isMultiUserCatalogEntry(entry))
@@ -94,6 +97,7 @@
 	);
 
 	let showIntroDialog = $state(false);
+	let showDeprecatedConnectDialog = $state(false);
 
 	let connectDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let configDialog = $state<ReturnType<typeof CatalogConfigureForm>>();
@@ -170,6 +174,11 @@
 		if (onConnect && !skipOnConnect) {
 			onConnect({ server, entry, instance });
 		}
+	}
+
+	function handleDeprecatedConnectContinue() {
+		showDeprecatedConnectDialog = false;
+		handleConnect();
 	}
 
 	export async function authenticate(item: MCPCatalogServer, parentEntry?: MCPCatalogEntry) {
@@ -314,6 +323,7 @@
 				{
 					name?: string;
 					icon?: string;
+					deprecated?: boolean;
 					hostname?: string;
 					url?: string;
 					disabled?: boolean;
@@ -330,6 +340,7 @@
 				componentConfigs[id] = {
 					name: m.name,
 					icon: m.icon,
+					deprecated: isDeprecatedMCPServer({ manifest: m }),
 					hostname: isMultiUser ? undefined : m.remoteConfig?.hostname,
 					url: isMultiUser ? undefined : (m.remoteConfig?.fixedURL ?? ''),
 					disabled: false,
@@ -980,6 +991,7 @@
 		entry = initEntry;
 		instance = initInstance;
 		configureInstance = initConfigureInstance ?? false;
+		const isDeprecated = isDeprecatedMCPServer(initEntry) || isDeprecatedMCPServer(initServer);
 
 		if (server && instance && configureInstance && hasMultiUserInstanceConfiguration(server)) {
 			initMultiUserInstanceForm(server, instance);
@@ -989,7 +1001,11 @@
 			(entry && server) ||
 			(server && instance)
 		) {
-			connectDialog?.open();
+			if (isDeprecated) {
+				showDeprecatedConnectDialog = true;
+			} else {
+				connectDialog?.open();
+			}
 		} else {
 			showIntroDialog = true;
 		}
@@ -1035,13 +1051,15 @@
 <ResponsiveDialog bind:this={connectDialog} animate="slide" onClose={handleOnClose}>
 	{#snippet titleContent()}
 		{@render dialogTitle(server || entry)}
+		<McpDeprecatedNotice {deprecated} />
 	{/snippet}
 
 	{#if entry?.connectURL || server?.connectURL || instance?.connectURL}
 		{@const url = instance?.connectURL || server?.connectURL || entry?.connectURL}
 		{@const displayName = getMCPDisplayName(server, entry?.manifest?.name ?? '')}
 		{#if url}
-			<div class="flex flex-col gap-1 md:p-0 pb-0 p-4">
+			<div class="flex flex-col gap-3 md:p-0 pb-0 p-4">
+				<McpDeprecatedNotice {deprecated} variant="notification" />
 				<CopyField
 					bind:this={connectionUrlField}
 					value={url}
@@ -1071,9 +1089,15 @@
 	{#snippet msgContent()}
 		<div class="flex items-center gap-2 text-lg font-semibold mb-2">
 			{@render dialogTitle(entry || server)}
+			<McpDeprecatedNotice {deprecated} />
 		</div>
 	{/snippet}
 	{#snippet note()}
+		{#if deprecated}
+			<div class="mb-3">
+				<McpDeprecatedNotice {deprecated} variant="notification" />
+			</div>
+		{/if}
 		<p>
 			{#if renderIntroText}
 				{renderIntroText({ entry, server })}
@@ -1088,6 +1112,28 @@
 				<br />Click below to begin.
 			{/if}
 		</p>
+	{/snippet}
+</Confirm>
+
+<Confirm
+	show={showDeprecatedConnectDialog}
+	onsuccess={handleDeprecatedConnectContinue}
+	submitText="Continue"
+	type="info"
+	title="Deprecated Server"
+	oncancel={() => (showDeprecatedConnectDialog = false)}
+>
+	{#snippet msgContent()}
+		<div class="flex items-center gap-2 text-lg font-semibold mb-2">
+			{@render dialogTitle(entry || server)}
+			<McpDeprecatedNotice {deprecated} />
+		</div>
+	{/snippet}
+	{#snippet note()}
+		<div class="flex flex-col gap-3">
+			<McpDeprecatedNotice {deprecated} variant="notification" />
+			<p>Continue to view the connection URL.</p>
+		</div>
 	{/snippet}
 </Confirm>
 
@@ -1110,6 +1156,7 @@
 	configurationTitle={configureFormTitle}
 	secretBindingTargets={canBindSecretsForCatalogEntry ? secretBindingTargets : undefined}
 	disableEnvSecretBindings={manifest?.runtime === 'remote'}
+	{deprecated}
 >
 	{#snippet loadingContent()}
 		<div in:fade class="h-full w-full flex items-center justify-center">

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -30,6 +30,7 @@
 	import { getUserDisplayName, openUrl } from '$lib/utils';
 	import CapacityBanner from './CapacityBanner.svelte';
 	import EditExistingDeployment from './EditExistingDeployment.svelte';
+	import McpDeprecatedNotice from './McpDeprecatedNotice.svelte';
 	import {
 		Captions,
 		CircleAlert,
@@ -650,6 +651,7 @@
 									</span>
 								{/if}
 							</p>
+							<McpDeprecatedNotice item={d} />
 							{#if 'missingKubernetesSecret' in d && d.missingKubernetesSecret}
 								<div
 									class="text-warning"

--- a/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
+++ b/ui/user/src/lib/components/mcp/EditExistingDeployment.svelte
@@ -17,6 +17,7 @@
 		getMCPDisplayName,
 		getSecretBindingEngineError,
 		hasSecretBinding,
+		isDeprecatedMCPServer,
 		isKubernetesRuntimeBackend
 	} from '$lib/services/user/mcp';
 	import { errors, version } from '$lib/stores';
@@ -44,6 +45,7 @@
 
 	let editingError = $state<string>();
 	let editingManifest = $derived(server?.manifest);
+	let deprecated = $derived(isDeprecatedMCPServer(entry) || isDeprecatedMCPServer(server));
 	let secretBindingEngineError = $derived(
 		isKubernetesRuntimeBackend(version.current.engine)
 			? undefined
@@ -497,6 +499,7 @@
 	configurationTitle={mode === 'catalog-update' ? 'Required Configuration' : undefined}
 	secretBindingTargets={editableSecretBindingTargets}
 	disableEnvSecretBindings={editingManifest?.runtime === 'remote'}
+	{deprecated}
 >
 	{#snippet loadingContent()}
 		<div in:fade class="h-full w-full flex items-center justify-center">

--- a/ui/user/src/lib/components/mcp/McpCard.svelte
+++ b/ui/user/src/lib/components/mcp/McpCard.svelte
@@ -2,7 +2,12 @@
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
 	import type { MCPCatalogServer, MCPCatalogEntry } from '$lib/services';
-	import { getMCPDisplayName, parseCategories } from '$lib/services/user/mcp';
+	import {
+		getMCPDisplayName,
+		isDeprecatedMCPServer,
+		parseCategories
+	} from '$lib/services/user/mcp';
+	import McpDeprecatedNotice from './McpDeprecatedNotice.svelte';
 	import { Server, TriangleAlert } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -21,6 +26,7 @@
 	let description = $derived(parent?.manifest?.description ?? data?.manifest?.description);
 	let categories = $derived(parent?.categories ?? data.categories! ?? parseCategories(data));
 	let needsUpdate = $derived(!('isCatalogEntry' in data) ? !data.configured : false);
+	let deprecated = $derived(isDeprecatedMCPServer(parent) || isDeprecatedMCPServer(data));
 </script>
 
 <div class="relative flex flex-col">
@@ -41,9 +47,10 @@
 					<Server />
 				{/if}
 			</div>
-			<div class="flex max-w-[calc(100%-2rem)]">
-				<p class="text-sm font-semibold">{name}</p>
+			<div class="flex min-w-0 max-w-[calc(100%-2rem)]">
+				<p class="truncate text-sm font-semibold">{name}</p>
 			</div>
+			<McpDeprecatedNotice {deprecated} />
 		</div>
 		<span
 			class={twMerge(

--- a/ui/user/src/lib/components/mcp/McpCompositeOauth.svelte
+++ b/ui/user/src/lib/components/mcp/McpCompositeOauth.svelte
@@ -2,7 +2,8 @@
 	import { parseErrorContent } from '$lib/errors';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { UserService, type MCPCatalogServer } from '$lib/services';
-	import { getMCPDisplayName } from '$lib/services/user/mcp';
+	import { getMCPDisplayName, isDeprecatedMCPServer } from '$lib/services/user/mcp';
+	import McpDeprecatedNotice from './McpDeprecatedNotice.svelte';
 	import { Server } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 
@@ -22,7 +23,9 @@
 	};
 
 	let compositeServer = $state<MCPCatalogServer>();
-	let componentInfos = $state<Record<string, { name?: string; icon?: string }>>({});
+	let componentInfos = $state<
+		Record<string, { name?: string; icon?: string; deprecated?: boolean }>
+	>({});
 	let pending = $state<PendingItem[]>([]);
 	let loading = $state(true);
 	let error = $state<string>('');
@@ -49,14 +52,18 @@
 			const componentServers = compositeServer?.manifest?.compositeConfig?.componentServers || [];
 			componentInfos = componentServers.reduce(
 				(
-					acc: Record<string, { name?: string; icon?: string }>,
-					c: { catalogEntryID?: string; manifest?: { name?: string; icon?: string } }
+					acc: Record<string, { name?: string; icon?: string; deprecated?: boolean }>,
+					c: {
+						catalogEntryID?: string;
+						manifest?: { name?: string; icon?: string; metadata?: { deprecated?: string } };
+					}
 				) => {
 					const id = c.catalogEntryID;
 					if (!id) return acc;
 					acc[id] = {
 						name: c.manifest?.name,
-						icon: c.manifest?.icon
+						icon: c.manifest?.icon,
+						deprecated: isDeprecatedMCPServer(c)
 					};
 					return acc;
 				},
@@ -183,6 +190,10 @@
 									item.catalogEntryID ||
 									item.mcpServerID}</span
 							>
+							<McpDeprecatedNotice
+								deprecated={componentInfos[item.catalogEntryID || '']?.deprecated}
+								child
+							/>
 						</div>
 						<div class="flex items-center gap-2">
 							<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external OAuth URL -->

--- a/ui/user/src/lib/components/mcp/McpDeprecatedNotice.svelte
+++ b/ui/user/src/lib/components/mcp/McpDeprecatedNotice.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import { isDeprecatedMCPServer } from '$lib/services/user/mcp';
+	import { TriangleAlert } from '@lucide/svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	type DeprecatedMCPItem = {
+		manifest?: {
+			metadata?: {
+				deprecated?: string;
+			};
+		};
+	};
+
+	interface Props {
+		item?: DeprecatedMCPItem | null;
+		deprecated?: boolean;
+		variant?: 'badge' | 'notification';
+		child?: boolean;
+		class?: string;
+	}
+
+	let { item, deprecated, variant = 'badge', child = false, class: className }: Props = $props();
+
+	let isDeprecated = $derived(deprecated ?? isDeprecatedMCPServer(item));
+	let subject = $derived(child ? 'component server' : 'server');
+	let replacement = $derived(child ? 'component' : 'server');
+</script>
+
+{#if isDeprecated}
+	{#if variant === 'notification'}
+		<div
+			class={twMerge(
+				'border-warning bg-warning/10 flex w-full items-start gap-2 rounded-md border p-3 text-left',
+				className
+			)}
+		>
+			<TriangleAlert class="text-warning mt-0.5 size-4 shrink-0" />
+			<div class="text-sm">
+				<p class="font-medium">This {subject} is deprecated.</p>
+				<p class="text-muted-content">
+					It may stop receiving updates or be removed in a future catalog release. Use a replacement
+					{replacement} when possible.
+				</p>
+			</div>
+		</div>
+	{:else}
+		<span
+			class={twMerge('badge badge-xs border-warning text-warning gap-1 bg-warning/10', className)}
+		>
+			<TriangleAlert class="size-3" />
+			Deprecated
+		</span>
+	{/if}
+{/if}

--- a/ui/user/src/lib/components/mcp/McpSelectServerDeployment.svelte
+++ b/ui/user/src/lib/components/mcp/McpSelectServerDeployment.svelte
@@ -1,18 +1,24 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
-	import type { MCPCatalogServer } from '$lib/services';
-	import { getMCPDisplayName, requiresUserUpdate } from '$lib/services/user/mcp';
+	import type { MCPCatalogEntry, MCPCatalogServer } from '$lib/services';
+	import {
+		getMCPDisplayName,
+		isDeprecatedMCPServer,
+		requiresUserUpdate
+	} from '$lib/services/user/mcp';
 	import { formatTimeAgo } from '$lib/time';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
+	import McpDeprecatedNotice from './McpDeprecatedNotice.svelte';
 	import { CircleFadingArrowUp, Server, StepForward } from '@lucide/svelte';
 
 	interface Props {
 		onSelectServer: (server: MCPCatalogServer) => void;
+		contextEntry?: MCPCatalogEntry;
 	}
 
-	let { onSelectServer }: Props = $props();
+	let { onSelectServer, contextEntry }: Props = $props();
 
 	let selectServerDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let servers = $state<MCPCatalogServer[]>([]);
@@ -53,6 +59,9 @@
 					</div>
 					<p class="flex items-center gap-2">
 						{getMCPDisplayName(d)}
+						<McpDeprecatedNotice
+							deprecated={isDeprecatedMCPServer(contextEntry) || isDeprecatedMCPServer(d)}
+						/>
 						{#if requiresUserUpdate(d)}
 							<span
 								use:tooltip={{

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -15,6 +15,7 @@
 		deleteMcpServerDeployment,
 		disconnectMcpServerUser,
 		hasEditableConfiguration,
+		isDeprecatedMCPServer,
 		isMultiUserCatalogEntry,
 		isMultiUserServer,
 		requiresUserUpdate,
@@ -27,6 +28,7 @@
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import ConnectToServer from './ConnectToServer.svelte';
 	import EditExistingDeployment from './EditExistingDeployment.svelte';
+	import McpDeprecatedNotice from './McpDeprecatedNotice.svelte';
 	import McpSelectServerDeployment from './McpSelectServerDeployment.svelte';
 	import StaticOAuthConfigureModal from './StaticOAuthConfigureModal.svelte';
 	import DebugOauthDialog from './oauth/DebugOauthDialog.svelte';
@@ -124,6 +126,7 @@
 	);
 	let canDebugOauth = $derived(canReauthenticate && profile.current?.hasAdminAccess?.());
 	let belongsToComposite = $derived(Boolean(server && server.compositeName));
+	let deprecated = $derived(isDeprecatedMCPServer(entry) || isDeprecatedMCPServer(server));
 	let configurableItem = $derived(server ?? entry);
 	// True when the user can manage the server deployment (restart, rename, edit config).
 	// For multi-user servers, only admins or the workspace owner who deployed it.
@@ -383,6 +386,7 @@
 
 <McpSelectServerDeployment
 	bind:this={selectServerDialog}
+	contextEntry={entry}
 	onSelectServer={async (d) => {
 		selectServerDialog?.close();
 		switch (selectServerMode) {
@@ -466,7 +470,8 @@
 		{:else if !entry && isMultiUserServer(server)}
 			<p class="mb-2 text-center">Would you like to connect to this server now?</p>
 		{:else}
-			<div class="mt-4">
+			<div class="mt-4 flex flex-col gap-3">
+				<McpDeprecatedNotice {deprecated} variant="notification" />
 				<CopyField
 					id="server-action-connection-url"
 					label="Connection URL"
@@ -782,6 +787,7 @@
 
 <StaticOAuthConfigureModal
 	bind:this={oauthConfigModal}
+	{deprecated}
 	onSave={async (credentials) => {
 		if (!entry) return;
 		if (entry.powerUserWorkspaceID) {

--- a/ui/user/src/lib/components/mcp/StaticOAuthConfigureModal.svelte
+++ b/ui/user/src/lib/components/mcp/StaticOAuthConfigureModal.svelte
@@ -4,6 +4,7 @@
 	import Confirm from '../Confirm.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import SensitiveInput from '../SensitiveInput.svelte';
+	import McpDeprecatedNotice from './McpDeprecatedNotice.svelte';
 	import { CircleAlert, Trash2 } from '@lucide/svelte';
 
 	interface Props {
@@ -13,9 +14,18 @@
 		onSkip?: () => void;
 		onCancel?: () => void;
 		showSkip?: boolean;
+		deprecated?: boolean;
 	}
 
-	let { oauthStatus, onSave, onDelete, onSkip, onCancel, showSkip = false }: Props = $props();
+	let {
+		oauthStatus,
+		onSave,
+		onDelete,
+		onSkip,
+		onCancel,
+		showSkip = false,
+		deprecated
+	}: Props = $props();
 
 	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let loading = $state(false);
@@ -130,6 +140,8 @@
 				<p class="text-sm font-light">{error}</p>
 			</div>
 		{/if}
+
+		<McpDeprecatedNotice {deprecated} variant="notification" />
 
 		{#if oauthStatus?.configured}
 			<p class="text-muted-content text-sm font-light">

--- a/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
@@ -7,11 +7,13 @@
 		conflictIssue,
 		duplicateToolNames,
 		effectiveToolName,
+		isDeprecatedMCPServer,
 		MAX_TOOL_PREFIX_LENGTH,
 		TOOL_NAME_CHARSET_REGEX,
 		TOOL_NAME_SPECIAL_CHAR_WARNING,
 		toolNameIssue
 	} from '$lib/services/user/mcp';
+	import McpDeprecatedNotice from '../McpDeprecatedNotice.svelte';
 	import ToolNameIssueIcon from '../ToolNameIssueIcon.svelte';
 	import { TriangleAlert } from '@lucide/svelte';
 
@@ -97,6 +99,7 @@
 	let initialConfigState = $state<string>('');
 
 	let allToolsEnabled = $derived(tools.every((tool) => tool.enabled));
+	let configuringEntryDeprecated = $derived(isDeprecatedMCPServer(configuringEntry));
 
 	let visibleTools = $derived(
 		tools.filter(
@@ -157,6 +160,12 @@
 	classes={{ content: 'p-0', header: 'p-4 pb-0' }}
 	onClickOutside={handleClose}
 >
+	<McpDeprecatedNotice
+		deprecated={configuringEntryDeprecated}
+		variant="notification"
+		child
+		class="mx-4 mb-3"
+	/>
 	<p class="text-muted-content px-4 text-xs font-light">
 		Toggle what tools are available to users of this composite server. Or modify the name or
 		description of a tool; this will override the default name or description provided by the

--- a/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
@@ -16,10 +16,12 @@
 		deriveToolPrefix,
 		getSecretBindingEngineError,
 		isKubernetesRuntimeBackend,
-		hasEditableConfiguration
+		hasEditableConfiguration,
+		isDeprecatedMCPServer
 	} from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, version } from '$lib/stores';
 	import CatalogConfigureForm, { type LaunchFormData } from '../CatalogConfigureForm.svelte';
+	import McpDeprecatedNotice from '../McpDeprecatedNotice.svelte';
 	import CompositeEditTools from './CompositeEditTools.svelte';
 
 	interface Props {
@@ -81,6 +83,7 @@
 			? undefined
 			: getSecretBindingEngineError(configuringEntry?.manifest)
 	);
+	let configuringEntryDeprecated = $derived(isDeprecatedMCPServer(configuringEntry));
 
 	function handleVisibilityChange() {
 		if (!componentConfig) return;
@@ -366,6 +369,12 @@
 	title={`Configure ${configuringEntry?.manifest?.name ?? 'MCP Server'} Tools`}
 	class="bg-base-200 md:w-md"
 >
+	<McpDeprecatedNotice
+		deprecated={configuringEntryDeprecated}
+		variant="notification"
+		child
+		class="mb-4"
+	/>
 	<p class="text-muted-content text-sm font-light">
 		All <i>{configuringEntry?.manifest?.name ?? 'MCP Server'}</i> tools are enabled by default. Would
 		you like to modify the available tools?
@@ -421,6 +430,12 @@
 				</div>
 			{:else}
 				<div class="mb-6 h-full text-left">
+					<McpDeprecatedNotice
+						deprecated={configuringEntryDeprecated}
+						variant="notification"
+						child
+						class="mb-4"
+					/>
 					{#if 'isCatalogEntry' in configuringEntry && hasEditableConfiguration(configuringEntry)}
 						<p>
 							In order to request tools from the server, you'll need to pass some configuration
@@ -535,6 +550,7 @@
 	icon={configuringEntry?.manifest?.icon}
 	submitText="Continue"
 	cancelText="Cancel"
+	deprecated={configuringEntryDeprecated}
 	onSave={async () => {
 		if (!configuringEntry) return;
 		const configValues = convertEnvHeadersToRecord(configureForm?.envs, configureForm?.headers);

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -556,6 +556,7 @@ export interface MCPCatalogEntryServerManifest {
 	toolPreview?: MCPServerTool[];
 	metadata?: {
 		categories?: string;
+		deprecated?: string;
 		'allow-multiple'?: string;
 	};
 
@@ -607,6 +608,7 @@ export interface RuntimeFormData {
 	description: string;
 	icon: string;
 	categories: string[];
+	metadata?: MCPCatalogEntryServerManifest['metadata'];
 	serverUserType: 'singleUser' | 'multiUser';
 	env: MCPCatalogEntryFieldManifest[];
 

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -8,6 +8,7 @@ import {
 	type AccessControlRule,
 	type LaunchServerType,
 	type MCPCatalogEntry,
+	type MCPCatalogEntryServerManifest,
 	type MCPCatalogServer,
 	type MCPCatalogServerManifest,
 	type MCPServer,
@@ -67,6 +68,12 @@ export function parseCategories(item?: MCPCatalogServer | MCPCatalogEntry | null
 	return item.manifest.metadata
 		? (item.manifest.metadata.categories?.split(',') ?? []).map((c) => c.trim()).filter((c) => c)
 		: [];
+}
+
+export function isDeprecatedMCPServer(
+	item?: { manifest?: Pick<MCPCatalogEntryServerManifest, 'metadata'> } | null
+) {
+	return item?.manifest?.metadata?.deprecated === 'true';
 }
 
 export function convertEnvHeadersToRecord(
@@ -531,6 +538,7 @@ export async function convertCompositeInfoToLaunchFormData(
 		{
 			name?: string;
 			icon?: string;
+			deprecated?: boolean;
 			hostname?: string;
 			url?: string;
 			disabled?: boolean;
@@ -551,6 +559,7 @@ export async function convertCompositeInfoToLaunchFormData(
 		componentConfigs[id] = {
 			name: m.name,
 			icon: m.icon,
+			deprecated: isDeprecatedMCPServer({ manifest: m }),
 			hostname:
 				isMultiUser || !(m.remoteConfig && 'hostname' in m.remoteConfig)
 					? ''
@@ -752,15 +761,19 @@ export const validateRuntimeForm = (
 	return missingFields;
 };
 
-export const convertCategoriesToMetadata = (categories: string[]) => {
+export const convertCategoriesToMetadata = (
+	categories: string[],
+	metadata?: RuntimeFormData['metadata']
+) => {
 	const validCategories = categories.filter((c) => c);
-	return validCategories
-		? {
-				metadata: {
-					categories: validCategories.join(',')
-				}
-			}
-		: undefined;
+	const nextMetadata = { ...metadata };
+	if (validCategories.length > 0) {
+		nextMetadata.categories = validCategories.join(',');
+	} else {
+		delete nextMetadata.categories;
+	}
+
+	return Object.keys(nextMetadata).length > 0 ? { metadata: nextMetadata } : undefined;
 };
 
 export const sanitizeEgressDomains = (egressDomains?: string[] | string) => {
@@ -812,7 +825,7 @@ export const sanitizeResourceRuntimeConfig = (
 export const convertServerRuntimeFormDataToManifest = (
 	formData: RuntimeFormData
 ): MCPCatalogServerManifest => {
-	const { categories, ...baseData } = formData;
+	const { categories, metadata, ...baseData } = formData;
 	const startupTimeoutSeconds = baseData.startupTimeoutSeconds;
 	const startupTimeoutConfig =
 		typeof startupTimeoutSeconds === 'number' &&
@@ -834,7 +847,7 @@ export const convertServerRuntimeFormDataToManifest = (
 			multiUserConfig: baseData.multiUserConfig,
 			runtime: baseData.runtime,
 			...(resources ? { resources } : {}),
-			...convertCategoriesToMetadata(categories)
+			...convertCategoriesToMetadata(categories, metadata)
 		}
 	};
 

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -606,6 +606,7 @@ export interface MCPServer {
 	toolPreview?: MCPServerTool[];
 	metadata?: {
 		categories?: string;
+		deprecated?: string;
 	};
 
 	runtime: Runtime;

--- a/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
+++ b/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
@@ -4,6 +4,7 @@
 		type CompositeLaunchFormData,
 		type LaunchFormData
 	} from '$lib/components/mcp/CatalogConfigureForm.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import BetaLogo from '$lib/components/navbar/BetaLogo.svelte';
 	import { HttpError } from '$lib/errors';
 	import { UserService, type OAuthConsent } from '$lib/services';
@@ -12,7 +13,8 @@
 		convertCompositeLaunchFormDataToPayload,
 		convertEnvHeadersToRecord,
 		hasEditableConfiguration,
-		hasSecretBinding
+		hasSecretBinding,
+		isDeprecatedMCPServer
 	} from '$lib/services/user/mcp';
 	import { ExternalLink, SettingsIcon, ShieldAlertIcon } from '@lucide/svelte';
 	import { onMount, tick, untrack } from 'svelte';
@@ -35,6 +37,7 @@
 	const consent = $derived(currentConsent);
 	const scopes = $derived(consent.scope?.split(' ').filter(Boolean) ?? []);
 	const showMCPAuthNotice = $derived(consent.mcpAuthRequired || consent.userHasSecondLevelOAuthed);
+	const deprecated = $derived(isDeprecatedMCPServer(consent.mcpServer));
 	const hasConfigurableMCPConfiguration = $derived.by(() => {
 		if (consent.mcpServer) {
 			return hasEditableConfiguration(consent.mcpServer);
@@ -290,6 +293,8 @@
 
 		{#if consent.mcpConfigRequired}
 			<section class="flex flex-col gap-5 p-4 py-0">
+				<McpDeprecatedNotice {deprecated} variant="notification" />
+
 				<div class="notification-info flex items-center gap-3 p-3">
 					<SettingsIcon class="size-5 shrink-0" />
 					<p class="min-w-0 text-sm">
@@ -304,6 +309,8 @@
 			</section>
 		{:else}
 			<section class="flex flex-col gap-5 p-4 pt-0">
+				<McpDeprecatedNotice {deprecated} variant="notification" />
+
 				{#if showMCPAuthNotice}
 					<div class="notification-info flex items-center gap-3 p-3">
 						<ShieldAlertIcon class="size-5 shrink-0" />
@@ -430,6 +437,7 @@
 	onCancel={() => configDialog?.close()}
 	loading={savingConfig}
 	error={configError}
+	{deprecated}
 	cancelText="Close"
 	submitText="Save"
 	configurationTitle="MCP Server Configuration"

--- a/ui/user/src/routes/keys/CreateApiKeyForm.svelte
+++ b/ui/user/src/routes/keys/CreateApiKeyForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import DatePicker from '$lib/components/DatePicker.svelte';
 	import Search from '$lib/components/Search.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
@@ -229,7 +230,10 @@
 								{/if}
 							</div>
 							<div class="flex min-w-0 grow flex-col">
-								<p class="truncate text-sm">{getMCPDisplayName(server)}</p>
+								<div class="flex items-center gap-2">
+									<p class="min-w-0 truncate text-sm">{getMCPDisplayName(server)}</p>
+									<McpDeprecatedNotice item={server} />
+								</div>
 								{#if server.manifest.description}
 									<span class="text-muted-content line-clamp-1 text-xs">
 										{stripMarkdownToText(server.manifest.description)}

--- a/ui/user/src/routes/mcp-catalog/EntriesView.svelte
+++ b/ui/user/src/routes/mcp-catalog/EntriesView.svelte
@@ -3,6 +3,7 @@
 	import DotDotDot from '$lib/components/DotDotDot.svelte';
 	import ConnectToServer from '$lib/components/mcp/ConnectToServer.svelte';
 	import McpConfirmDelete from '$lib/components/mcp/McpConfirmDelete.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import McpMultiDeleteBlockedDialog from '$lib/components/mcp/McpMultiDeleteBlockedDialog.svelte';
 	import StaticOAuthConfigureModal from '$lib/components/mcp/StaticOAuthConfigureModal.svelte';
 	import Table, { type InitSort, type InitSortFn } from '$lib/components/table/Table.svelte';
@@ -27,7 +28,8 @@
 		deleteMcpServerDeployment,
 		isMultiUserCatalogEntry,
 		getMCPDisplayName,
-		hasEditableConfiguration
+		hasEditableConfiguration,
+		isDeprecatedMCPServer
 	} from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, profile } from '$lib/stores';
 	import { formatTimeAgo } from '$lib/time';
@@ -170,7 +172,7 @@
 		}
 
 		if (server?.connectURL) {
-			connectUrlDialog?.open(entry, server.connectURL);
+			connectUrlDialog?.open(entry, server.connectURL, server);
 		}
 	}
 
@@ -298,6 +300,7 @@
 						(d.data.needsUpdate &&
 							!('missingKubernetesSecret' in d && d.missingKubernetesSecret)) ||
 						deploymentsNeedingAttentionByCatalogEntry.has(d.data.id)}
+					{@const deprecated = isDeprecatedMCPServer(d.data)}
 					{#if property === 'name'}
 						<div class="flex shrink-0 items-center gap-2">
 							<div class="icon">
@@ -336,6 +339,7 @@
 								{#if d.status.toLowerCase() === 'deployed'}
 									<span class="badge badge-xs badge-secondary">Deployed</span>
 								{/if}
+								<McpDeprecatedNotice {deprecated} />
 							</p>
 						</div>
 					{:else if property === 'type'}
@@ -577,6 +581,7 @@
 <StaticOAuthConfigureModal
 	bind:this={oauthConfigModal}
 	{oauthStatus}
+	deprecated={isDeprecatedMCPServer(oauthConfigEntry)}
 	onSave={handleSaveOAuth}
 	onDelete={handleDeleteOAuth}
 />

--- a/ui/user/src/routes/mcp-catalog/McpConnectUrlDialog.svelte
+++ b/ui/user/src/routes/mcp-catalog/McpConnectUrlDialog.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 	import CopyField from '$lib/components/CopyField.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import McpSelectServerDeployment from '$lib/components/mcp/McpSelectServerDeployment.svelte';
-	import type { MCPCatalogEntry } from '$lib/services';
-	import { hasEditableConfiguration, isMultiUserCatalogEntry } from '$lib/services/user/mcp';
+	import type { MCPCatalogEntry, MCPCatalogServer } from '$lib/services';
+	import {
+		hasEditableConfiguration,
+		isDeprecatedMCPServer,
+		isMultiUserCatalogEntry
+	} from '$lib/services/user/mcp';
 	import { mcpServersAndEntries } from '$lib/stores';
 	import { Info, Plus } from '@lucide/svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -14,7 +19,15 @@
 
 	let { onLaunchCatalogEntry }: Props = $props();
 	let connectUrlDialog = $state<ReturnType<typeof ResponsiveDialog>>();
-	let displayConnectUrl = $state<{ url: string; catalogEntry?: MCPCatalogEntry }>();
+	let displayConnectUrl = $state<{
+		url: string;
+		catalogEntry?: MCPCatalogEntry;
+		server?: MCPCatalogServer;
+	}>();
+	let displayConnectUrlDeprecated = $derived(
+		isDeprecatedMCPServer(displayConnectUrl?.catalogEntry) ||
+			isDeprecatedMCPServer(displayConnectUrl?.server)
+	);
 	let catalogEntry = $state<MCPCatalogEntry>();
 	let selectServerDialog = $state<ReturnType<typeof McpSelectServerDeployment>>();
 
@@ -28,13 +41,18 @@
 		);
 	}
 
-	export function open(initEntry?: MCPCatalogEntry, urlToDisplay?: string) {
+	export function open(
+		initEntry?: MCPCatalogEntry,
+		urlToDisplay?: string,
+		server?: MCPCatalogServer
+	) {
 		catalogEntry = initEntry;
 
 		if (urlToDisplay) {
 			displayConnectUrl = {
 				url: urlToDisplay,
-				catalogEntry
+				catalogEntry,
+				server
 			};
 			connectUrlDialog?.open();
 			return;
@@ -49,12 +67,13 @@
 			} else if (matchingServers[0]?.connectURL || catalogEntry?.connectURL) {
 				displayConnectUrl = {
 					url: matchingServers[0]?.connectURL || catalogEntry?.connectURL || '',
-					catalogEntry
+					catalogEntry,
+					server: matchingServers[0]
 				};
 
 				connectUrlDialog?.open();
 			} else {
-				onLaunchCatalogEntry?.(catalogEntry!);
+				onLaunchCatalogEntry?.(catalogEntry);
 			}
 		}
 	}
@@ -74,8 +93,12 @@
 >
 	{#if displayConnectUrl?.url}
 		<div
-			class={twMerge('px-4', !isMultiUserCatalogEntry(displayConnectUrl?.catalogEntry) && 'pb-4')}
+			class={twMerge(
+				'flex flex-col gap-3 px-4',
+				!isMultiUserCatalogEntry(displayConnectUrl?.catalogEntry) && 'pb-4'
+			)}
 		>
+			<McpDeprecatedNotice deprecated={displayConnectUrlDeprecated} variant="notification" />
 			<CopyField id="connect-url-dialog-connection-url" value={displayConnectUrl?.url ?? ''} />
 		</div>
 	{:else}
@@ -117,11 +140,13 @@
 
 <McpSelectServerDeployment
 	bind:this={selectServerDialog}
+	contextEntry={catalogEntry}
 	onSelectServer={(d) => {
 		selectServerDialog?.close();
 		displayConnectUrl = {
 			url: d.connectURL || catalogEntry?.connectURL || '',
-			catalogEntry
+			catalogEntry,
+			server: d
 		};
 		connectUrlDialog?.open();
 	}}

--- a/ui/user/src/routes/mcp-catalog/c/[id]/+page.svelte
+++ b/ui/user/src/routes/mcp-catalog/c/[id]/+page.svelte
@@ -5,6 +5,7 @@
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import DiffDialog from '$lib/components/admin/DiffDialog.svelte';
 	import McpServerEntryForm from '$lib/components/admin/McpServerEntryForm.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
@@ -16,7 +17,7 @@
 		type MCPCatalogServer,
 		AdminService
 	} from '$lib/services';
-	import { isMultiUserCatalogEntry } from '$lib/services/user/mcp';
+	import { isDeprecatedMCPServer, isMultiUserCatalogEntry } from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
 	import { success } from '$lib/stores/success';
 	import McpConnectUrlDialog from '../../McpConnectUrlDialog.svelte';
@@ -36,6 +37,7 @@
 	let isComposite = $derived(catalogEntry?.manifest?.runtime === 'composite');
 	let needsUpdate = $derived(catalogEntry?.needsUpdate === true);
 	let showUpgradeNotification = $derived(isComposite && needsUpdate && !isAdminReadonly);
+	let deprecated = $derived(isDeprecatedMCPServer(catalogEntry));
 
 	let workspaceId = $derived(catalogEntry?.powerUserWorkspaceID);
 	let serverScopeEntity = $derived(workspaceId ? ('workspace' as const) : ('catalog' as const));
@@ -208,7 +210,7 @@
 				}
 				if (showUrlOnConnect) {
 					showUrlOnConnect = false;
-					connectUrlDialog?.open(entry, server?.connectURL);
+					connectUrlDialog?.open(entry, server?.connectURL, server);
 				}
 			}}
 			hideActions
@@ -218,6 +220,8 @@
 		</button>
 	{/snippet}
 	<div class="flex h-full flex-col gap-6" in:fly={{ x: 100, delay: duration, duration }}>
+		<McpDeprecatedNotice {deprecated} variant="notification" />
+
 		{#if showUpgradeNotification}
 			<div class="border-primary bg-primary/10 flex items-center gap-3 rounded-lg border p-4">
 				<Info class="text-primary size-5 shrink-0" />

--- a/ui/user/src/routes/mcp-catalog/s/[id]/+page.svelte
+++ b/ui/user/src/routes/mcp-catalog/s/[id]/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerEntryForm from '$lib/components/admin/McpServerEntryForm.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { AdminService } from '$lib/services';
-	import { getMCPDisplayName } from '$lib/services/user/mcp';
+	import { getMCPDisplayName, isDeprecatedMCPServer } from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
 	import McpConnectUrlDialog from '../../McpConnectUrlDialog.svelte';
 	import { Link2Icon } from '@lucide/svelte';
@@ -22,6 +23,9 @@
 	let serverScopeEntity = $derived(workspaceId ? ('workspace' as const) : ('catalog' as const));
 	let serverScopeID = $derived(workspaceId || mcpServer?.mcpCatalogID || DEFAULT_MCP_CATALOG_ID);
 	let title = $derived(getMCPDisplayName(mcpServer) || 'MCP Server');
+	let deprecated = $derived(
+		isDeprecatedMCPServer(catalogEntry) || isDeprecatedMCPServer(mcpServer)
+	);
 </script>
 
 <Layout
@@ -50,13 +54,15 @@
 		/>
 		<button
 			class="btn btn-primary"
-			onclick={() => connectUrlDialog?.open(undefined, mcpServer?.connectURL)}
+			onclick={() => connectUrlDialog?.open(catalogEntry, mcpServer?.connectURL, mcpServer)}
 		>
 			<Link2Icon class="size-4" /> Connect URL
 		</button>
 	{/snippet}
 
 	<div class="flex h-full flex-col gap-6 pb-8" in:fly={{ x: 100, delay: duration, duration }}>
+		<McpDeprecatedNotice {deprecated} variant="notification" />
+
 		<McpServerEntryForm
 			entry={mcpServer}
 			type="multi"

--- a/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
+++ b/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
@@ -3,6 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import ConnectToServer from '$lib/components/mcp/ConnectToServer.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import McpSelectServerDeployment from '$lib/components/mcp/McpSelectServerDeployment.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
 	import {
@@ -21,7 +22,8 @@
 		isMultiUserServer,
 		restartMcpServer,
 		isMultiUserCatalogEntry,
-		requiresUserUpdate
+		requiresUserUpdate,
+		isDeprecatedMCPServer
 	} from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, profile, version } from '$lib/stores';
 	import { openUrl } from '$lib/utils';
@@ -255,6 +257,7 @@
 			{@const requiresUserAttention = instance
 				? instance.configured === false
 				: userConfiguredServers.some(requiresUserUpdate)}
+			{@const deprecated = isDeprecatedMCPServer(d.data)}
 			<div
 				class={twMerge(
 					'flex items-center justify-between gap-8 rounded-md p-3 bg-base-100 dark:bg-base-300 shadow-xs hover:bg-base-300 dark:hover:bg-base-400/75 cursor-pointer'
@@ -281,6 +284,7 @@
 						</div>
 						<div class="flex items-center gap-2">
 							<p>{d.name}</p>
+							<McpDeprecatedNotice {deprecated} />
 							{#if requiresUserAttention}
 								<span
 									use:tooltip={{
@@ -334,6 +338,7 @@
 
 <McpSelectServerDeployment
 	bind:this={selectServerDialog}
+	contextEntry={selectedEntry}
 	onSelectServer={async (d) => {
 		selectServerDialog?.close();
 		switch (selectServerMode) {

--- a/ui/user/src/routes/mcp-servers/c/[id]/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/c/[id]/+page.svelte
@@ -2,10 +2,12 @@
 	import { page } from '$app/state';
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerEntryForm from '$lib/components/admin/McpServerEntryForm.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { UserService } from '$lib/services';
+	import { isDeprecatedMCPServer } from '$lib/services/user/mcp';
 	import { mcpServersAndEntries } from '$lib/stores';
 	import { type Component } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -31,6 +33,7 @@
 			: []
 	);
 	let promptOAuthConfig = $derived(page.url.searchParams.get('configure-oauth') === 'true');
+	let deprecated = $derived(isDeprecatedMCPServer(catalogEntry));
 </script>
 
 <Layout
@@ -55,6 +58,8 @@
 		/>
 	{/snippet}
 	<div class="flex h-full flex-col gap-6" in:fly={{ x: 100, delay: duration, duration }}>
+		<McpDeprecatedNotice {deprecated} variant="notification" />
+
 		{#if catalogEntry}
 			<McpServerEntryForm
 				entry={catalogEntry}

--- a/ui/user/src/routes/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerEntryForm from '$lib/components/admin/McpServerEntryForm.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
-	import { getMCPDisplayName } from '$lib/services/user/mcp';
+	import { getMCPDisplayName, isDeprecatedMCPServer } from '$lib/services/user/mcp';
 	import type { Component } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -14,6 +15,9 @@
 	let { workspaceId, catalogEntry, mcpServer } = $derived(data);
 	let title = $derived(
 		getMCPDisplayName(mcpServer) || getMCPDisplayName(catalogEntry) || 'MCP Server'
+	);
+	let deprecated = $derived(
+		isDeprecatedMCPServer(catalogEntry) || isDeprecatedMCPServer(mcpServer)
 	);
 </script>
 
@@ -29,6 +33,8 @@
 		<McpServerActions entry={catalogEntry} server={mcpServer} />
 	{/snippet}
 	<div class="flex h-full flex-col gap-6" in:fly={{ x: 100, delay: duration, duration }}>
+		<McpDeprecatedNotice {deprecated} variant="notification" />
+
 		{#if catalogEntry}
 			<McpServerEntryForm
 				entry={catalogEntry}

--- a/ui/user/src/routes/mcp-servers/s/[id]/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/s/[id]/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerEntryForm from '$lib/components/admin/McpServerEntryForm.svelte';
+	import McpDeprecatedNotice from '$lib/components/mcp/McpDeprecatedNotice.svelte';
 	import McpServerActions from '$lib/components/mcp/McpServerActions.svelte';
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { UserService } from '$lib/services';
-	import { getMCPDisplayName } from '$lib/services/user/mcp';
+	import { getMCPDisplayName, isDeprecatedMCPServer } from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
 	import { type Component } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -27,6 +28,9 @@
 		(serverWorkspaceId && workspaceId === serverWorkspaceId) || profile.current.hasAdminAccess?.()
 			? ['overview', 'tools', 'server-instances']
 			: ['overview', 'tools']
+	);
+	let deprecated = $derived(
+		isDeprecatedMCPServer(catalogEntry) || isDeprecatedMCPServer(mcpServer)
 	);
 </script>
 
@@ -54,6 +58,8 @@
 		/>
 	{/snippet}
 	<div class="flex h-full flex-col gap-6 pb-8" in:fly={{ x: 100, delay: duration, duration }}>
+		<McpDeprecatedNotice {deprecated} variant="notification" />
+
 		{#if mcpServer}
 			<McpServerEntryForm
 				entry={mcpServer}


### PR DESCRIPTION
As part of my work on https://github.com/obot-platform/field-issues/issues/48, I'm replacing our old Slack MCP server with the official one, and marking the old one as deprecated (by adding a `metadata` field in the catalog). This UI adds deprecation notices all over the place to make it abundantly clear that the server will go away.

demo video: https://acorn-io.slack.com/archives/C07P0EZR917/p1782935755611239