### PR TITLE
fix: support MCP servers with empty ToolOverrides and improve docs

### DIFF
--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -167,6 +167,8 @@ During sync, Obot resolves portable keys to internal generated catalog entry IDs
 | `componentServers[].toolOverrides[].overrideDescription` | No | Replacement tool description. Use this for custom tool text in Git-managed catalogs. |
 | `componentServers[].toolOverrides[].description` | No | Reserved for Obot's live/source tool metadata and rejected in Git-synced tool overrides. Use `overrideDescription` instead. |
 
+To get `mcpServerID` for an existing deployed multi-tenant server, open the server in Obot, choose **Connect URL**, and copy the path segment after `/mcp-connect/`. For example, if the connect URL is `https://obot.example.com/mcp-connect/ms1qc7nz`, use `ms1qc7nz` as `mcpServerID`.
+
 When `toolOverrides` is present, it acts as an allowlist. This means adding a tool to the list without `enabled: true` disables that tool, and also hides any other component tools that are not listed. To disable only a few tools, list those disabled tools and also list every tool you still want exposed with `enabled: true`. To rename or redescribe a tool while keeping it available, include `enabled: true`.
 
 This does not expose `web_search_exa`:

--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -152,7 +152,58 @@ compositeConfig:
 
 During sync, Obot resolves portable keys to internal generated catalog entry IDs and stores the internal IDs. If `catalogEntryID` does not contain `::` and does not match an `entryKey` in the same source, Obot treats it as an internal catalog entry ID and leaves it unchanged.
 
-When customizing composite tools in GitOps manifests, use `overrideDescription` for custom tool text. The `description` field is reserved for Obot and is rejected in Git-synced tool overrides.
+#### Composite configuration fields
+
+| Field | Required | Description |
+|---|---:|---|
+| `compositeConfig.componentServers` | Yes | List of component servers included in the composite server. |
+| `componentServers[].catalogEntryID` | Yes, unless `mcpServerID` is set | Catalog entry reference. This can be an internal catalog entry ID, same-source `entryKey`, or cross-source `{sourceID}::{entryKey}`. |
+| `componentServers[].mcpServerID` | Yes, unless `catalogEntryID` is set | Existing deployed MCP server to include as a component. Use this when a composite should include a multi-user server that has already been deployed. |
+| `componentServers[].toolPrefix` | No | Prefix added to every exposed tool from this component after any `overrideName` is applied. For example, `configured_` turns `echo` into `configured_echo`. |
+| `componentServers[].toolOverrides` | No | Tool allowlist and customization list. If omitted, all tools from the component are exposed. If present, only tools listed with `enabled: true` are exposed; tools not listed are hidden. |
+| `componentServers[].toolOverrides[].name` | Yes | Original tool name returned by the component server. |
+| `componentServers[].toolOverrides[].enabled` | No | Whether this tool is exposed by the composite server. Defaults to `false`, so set `enabled: true` for every tool you want to expose. |
+| `componentServers[].toolOverrides[].overrideName` | No | Replacement tool name before `toolPrefix` is applied. If omitted, the original `name` is used. |
+| `componentServers[].toolOverrides[].overrideDescription` | No | Replacement tool description. Use this for custom tool text in Git-managed catalogs. |
+| `componentServers[].toolOverrides[].description` | No | Reserved for Obot's live/source tool metadata and rejected in Git-synced tool overrides. Use `overrideDescription` instead. |
+
+When `toolOverrides` is present, it acts as an allowlist. This means adding a tool to the list without `enabled: true` disables that tool, and also hides any other component tools that are not listed. To disable only a few tools, list those disabled tools and also list every tool you still want exposed with `enabled: true`. To rename or redescribe a tool while keeping it available, include `enabled: true`.
+
+This does not expose `web_search_exa`:
+
+```yaml
+name: Research Search Composite
+runtime: composite
+compositeConfig:
+  componentServers:
+    - catalogEntryID: github.com/obot-platform/mcp-catalog::obot-exa-search
+      toolOverrides:
+        - name: web_search_exa
+```
+
+Because `enabled` defaults to `false`, that component exposes no tools. Set `enabled: true` for each tool that should be available:
+
+```yaml
+name: Research Search Composite
+runtime: composite
+compositeConfig:
+  componentServers:
+    - catalogEntryID: github.com/obot-platform/mcp-catalog::obot-exa-search
+      toolPrefix: research_
+      toolOverrides:
+        - name: web_search_exa
+          enabled: true
+          overrideName: web_search
+          overrideDescription: Search the web for current research and source material.
+        - name: company_research_exa
+          enabled: true
+          overrideName: company_research
+          overrideDescription: Find company information and market context.
+        - name: crawling_exa
+          enabled: false
+```
+
+This example exposes `research_web_search` and `research_company_research`, and hides `crawling_exa`. Because `toolOverrides` is an allowlist, any other tools from the Exa component are also hidden unless they are listed with `enabled: true`.
 
 #### Multi-user template with shared configuration
 

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -43,8 +43,8 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_MCPBASE_IMAGE` | Deploy MCP servers in the kubernetes cluster or using docker with this base image. | `ghcr.io/obot-platform/mcp-images/stdio-wrapper:v0.24.0` |
 | `OBOT_SERVER_MCPIMAGE_PULL_SECRETS` | Comma-separated Kubernetes secret names to use as static image pull secrets for every MCP server Deployment. When set, managed image pull secrets are disabled. See [Image Pull Secrets](./image-pull-secrets.md). | - |
 | `OBOT_SERVER_MCPSECRET_BINDING_ALLOWED_LABEL` | Kubernetes Secret label key required before a Secret can be selected or resolved by MCP secret bindings. Only label presence is checked; the label value is ignored. Secrets without this label are not shown as bindable targets in the admin UI and are treated as unavailable when Obot resolves a secret binding at runtime. | `obot.obot.ai/allow-secret-binding` |
-| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/obot-platform/nanobot:v0.0.87` |
-| `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/obot-platform/nanobot-agent:v0.0.87` |
+| `OBOT_SERVER_MCPREMOTE_SHIM_BASE_IMAGE` | Deploy MCP remote shim servers in the cluster using this base image. | `ghcr.io/obot-platform/nanobot:v0.0.88` |
+| `OBOT_SERVER_NANOBOT_AGENT_IMAGE` | Deploy the Nanobot agent in the cluster using this image. | `ghcr.io/obot-platform/nanobot-agent:v0.0.88` |
 | `OBOT_SERVER_MCPHTTPWEBHOOK_BASE_IMAGE` | Deploy MCP HTTP webhook servers in the cluster using this base image. | `ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.24.0` |
 | `OBOT_SERVER_MCPRUNTIME_BACKEND` | The runtime backend to use for running MCP servers: docker or kubernetes. | `kubernetes` in the helm chart, `docker` otherwise |
 | `OBOT_SERVER_MCPCLUSTER_DOMAIN` | The cluster domain to use for MCP services. Only matters if `OBOT_SERVER_MCPBASE_IMAGE` is set. | `cluster.local` |

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -238,11 +238,13 @@ func constructMCPServerNanobotYAMLForComposite(servers []ComponentServer) ([]byt
 				Description: tool.OverrideDescription,
 			}
 		}
+		noTools := component.Tools != nil && len(tools) == 0
 
 		name := replacer.Replace(component.Name)
 		mcpServers[name] = nanobotConfigMCPServer{
 			BaseURL:       component.URL,
 			ToolOverrides: tools,
+			NoTools:       noTools,
 			ToolPrefix:    component.ToolPrefix,
 		}
 
@@ -344,6 +346,7 @@ type nanobotConfigMCPServer struct {
 	BaseURL            string              `json:"url,omitempty"`
 
 	ToolOverrides map[string]toolOverride `json:"toolOverrides,omitempty"`
+	NoTools       bool                    `json:"noTools,omitempty"`
 	ToolPrefix    string                  `json:"toolPrefix,omitempty"`
 }
 

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -238,13 +238,12 @@ func constructMCPServerNanobotYAMLForComposite(servers []ComponentServer) ([]byt
 				Description: tool.OverrideDescription,
 			}
 		}
-		noTools := component.Tools != nil && len(tools) == 0
 
 		name := replacer.Replace(component.Name)
 		mcpServers[name] = nanobotConfigMCPServer{
 			BaseURL:       component.URL,
 			ToolOverrides: tools,
-			NoTools:       noTools,
+			NoTools:       component.noTools,
 			ToolPrefix:    component.ToolPrefix,
 		}
 

--- a/pkg/mcp/backend_test.go
+++ b/pkg/mcp/backend_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/oasdiff/yaml"
 	"github.com/obot-platform/obot/apiclient/types"
 )
 
@@ -92,14 +92,22 @@ func TestConstructMCPServerNanobotYAMLForCompositeIncludesOnlyEnabledTools(t *te
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	yaml := string(data)
-	for _, expected := range []string{"toolOverrides:", "echo:", "toolPrefix: configured_"} {
-		if !strings.Contains(yaml, expected) {
-			t.Fatalf("expected YAML to contain %q, got:\n%s", expected, yaml)
-		}
+	config := mustUnmarshalNanobotConfig(t, data)
+	server := config.MCPServers["configured-ping-echo"]
+	if server.ToolPrefix != "configured_" {
+		t.Fatalf("expected toolPrefix configured_, got %q", server.ToolPrefix)
 	}
-	if strings.Contains(yaml, "\n            ping:") {
-		t.Fatalf("expected disabled tool to be omitted, got:\n%s", yaml)
+	if server.NoTools {
+		t.Fatal("expected noTools to be false")
+	}
+	if len(server.ToolOverrides) != 1 {
+		t.Fatalf("expected one tool override, got %#v", server.ToolOverrides)
+	}
+	if _, ok := server.ToolOverrides["echo"]; !ok {
+		t.Fatalf("expected echo to be included, got %#v", server.ToolOverrides)
+	}
+	if _, ok := server.ToolOverrides["ping"]; ok {
+		t.Fatalf("expected ping to be omitted, got %#v", server.ToolOverrides)
 	}
 }
 
@@ -114,9 +122,13 @@ func TestConstructMCPServerNanobotYAMLForCompositeOmitsToolConfigWhenOverridesOm
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	yaml := string(data)
-	if strings.Contains(yaml, "noTools") || strings.Contains(yaml, "toolOverrides") {
-		t.Fatalf("expected omitted overrides to expose all tools, got:\n%s", yaml)
+	config := mustUnmarshalNanobotConfig(t, data)
+	server := config.MCPServers["default-tools"]
+	if server.NoTools {
+		t.Fatal("expected omitted overrides not to set noTools")
+	}
+	if server.ToolOverrides != nil {
+		t.Fatalf("expected omitted overrides not to set toolOverrides, got %#v", server.ToolOverrides)
 	}
 }
 
@@ -143,15 +155,39 @@ func TestConstructMCPServerNanobotYAMLForCompositePreservesComponentsWithNoEnabl
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	yaml := string(data)
-	for _, expected := range []string{"\n    ping-echo:", "noTools: true", "configured-ping-echo:", "toolPrefix: configured_", "echo:"} {
-		if !strings.Contains(yaml, expected) {
-			t.Fatalf("expected YAML to contain %q, got:\n%s", expected, yaml)
-		}
+	config := mustUnmarshalNanobotConfig(t, data)
+
+	disabledOnlyServer := config.MCPServers["ping-echo"]
+	if !disabledOnlyServer.NoTools {
+		t.Fatal("expected component with no enabled tools to set noTools")
 	}
-	for _, unexpected := range []string{"repeat", "\n            ping:", "noTools: false"} {
-		if strings.Contains(yaml, unexpected) {
-			t.Fatalf("expected YAML not to contain %q, got:\n%s", unexpected, yaml)
-		}
+	if len(disabledOnlyServer.ToolOverrides) != 0 {
+		t.Fatalf("expected no enabled tool overrides, got %#v", disabledOnlyServer.ToolOverrides)
 	}
+
+	configuredServer := config.MCPServers["configured-ping-echo"]
+	if configuredServer.ToolPrefix != "configured_" {
+		t.Fatalf("expected toolPrefix configured_, got %q", configuredServer.ToolPrefix)
+	}
+	if configuredServer.NoTools {
+		t.Fatal("expected configured component to expose enabled tools")
+	}
+	if len(configuredServer.ToolOverrides) != 1 {
+		t.Fatalf("expected one configured tool override, got %#v", configuredServer.ToolOverrides)
+	}
+	if _, ok := configuredServer.ToolOverrides["echo"]; !ok {
+		t.Fatalf("expected echo to be included, got %#v", configuredServer.ToolOverrides)
+	}
+	if _, ok := configuredServer.ToolOverrides["ping"]; ok {
+		t.Fatalf("expected ping to be omitted, got %#v", configuredServer.ToolOverrides)
+	}
+}
+
+func mustUnmarshalNanobotConfig(t *testing.T, data []byte) nanobotConfig {
+	t.Helper()
+	var config nanobotConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("failed to unmarshal nanobot config: %v\n%s", err, string(data))
+	}
+	return config
 }

--- a/pkg/mcp/backend_test.go
+++ b/pkg/mcp/backend_test.go
@@ -135,11 +135,10 @@ func TestConstructMCPServerNanobotYAMLForCompositeOmitsToolConfigWhenOverridesOm
 func TestConstructMCPServerNanobotYAMLForCompositePreservesComponentsWithNoEnabledTools(t *testing.T) {
 	data, err := constructMCPServerNanobotYAMLForComposite([]ComponentServer{
 		{
-			Name: "ping-echo",
-			URL:  "https://example.com/mcp",
-			Tools: []types.ToolOverride{
-				{Name: "echo", OverrideName: "repeat", OverrideDescription: "Repeat a message", Enabled: false},
-			},
+			Name:    "ping-echo",
+			URL:     "https://example.com/mcp",
+			Tools:   []types.ToolOverride{},
+			noTools: true,
 		},
 		{
 			Name:       "configured-ping-echo",

--- a/pkg/mcp/backend_test.go
+++ b/pkg/mcp/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -72,5 +73,68 @@ func TestEnsureServerReadyHealthzPathWaitsForOK(t *testing.T) {
 
 	if calls != 2 {
 		t.Fatalf("expected two healthz calls, got %d", calls)
+	}
+}
+
+func TestConstructMCPServerNanobotYAMLForCompositeIncludesOnlyEnabledTools(t *testing.T) {
+	data, err := constructMCPServerNanobotYAMLForComposite([]ComponentServer{
+		{
+			Name:       "configured-ping-echo",
+			URL:        "https://example.com/mcp",
+			ToolPrefix: "configured_",
+			Tools: []types.ToolOverride{
+				{Name: "ping", Enabled: false},
+				{Name: "echo", Enabled: true},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	yaml := string(data)
+	for _, expected := range []string{"toolOverrides:", "echo:", "toolPrefix: configured_"} {
+		if !strings.Contains(yaml, expected) {
+			t.Fatalf("expected YAML to contain %q, got:\n%s", expected, yaml)
+		}
+	}
+	if strings.Contains(yaml, "\n            ping:") {
+		t.Fatalf("expected disabled tool to be omitted, got:\n%s", yaml)
+	}
+}
+
+func TestConstructMCPServerNanobotYAMLForCompositePreservesComponentsWithNoEnabledTools(t *testing.T) {
+	data, err := constructMCPServerNanobotYAMLForComposite([]ComponentServer{
+		{
+			Name: "ping-echo",
+			URL:  "https://example.com/mcp",
+			Tools: []types.ToolOverride{
+				{Name: "echo", OverrideName: "repeat", OverrideDescription: "Repeat a message", Enabled: false},
+			},
+		},
+		{
+			Name:       "configured-ping-echo",
+			URL:        "https://example.com/configured-mcp",
+			ToolPrefix: "configured_",
+			Tools: []types.ToolOverride{
+				{Name: "ping", Enabled: false},
+				{Name: "echo", Enabled: true},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	yaml := string(data)
+	for _, expected := range []string{"\n    ping-echo:", "noTools: true", "configured-ping-echo:", "toolPrefix: configured_", "echo:"} {
+		if !strings.Contains(yaml, expected) {
+			t.Fatalf("expected YAML to contain %q, got:\n%s", expected, yaml)
+		}
+	}
+	for _, unexpected := range []string{"repeat", "\n            ping:", "noTools: false"} {
+		if strings.Contains(yaml, unexpected) {
+			t.Fatalf("expected YAML not to contain %q, got:\n%s", unexpected, yaml)
+		}
 	}
 }

--- a/pkg/mcp/backend_test.go
+++ b/pkg/mcp/backend_test.go
@@ -103,6 +103,23 @@ func TestConstructMCPServerNanobotYAMLForCompositeIncludesOnlyEnabledTools(t *te
 	}
 }
 
+func TestConstructMCPServerNanobotYAMLForCompositeOmitsToolConfigWhenOverridesOmitted(t *testing.T) {
+	data, err := constructMCPServerNanobotYAMLForComposite([]ComponentServer{
+		{
+			Name: "default-tools",
+			URL:  "https://example.com/mcp",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	yaml := string(data)
+	if strings.Contains(yaml, "noTools") || strings.Contains(yaml, "toolOverrides") {
+		t.Fatalf("expected omitted overrides to expose all tools, got:\n%s", yaml)
+	}
+}
+
 func TestConstructMCPServerNanobotYAMLForCompositePreservesComponentsWithNoEnabledTools(t *testing.T) {
 	data, err := constructMCPServerNanobotYAMLForComposite([]ComponentServer{
 		{

--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -25,7 +25,7 @@ var log = logger.Package()
 type Options struct {
 	MCPBaseImage                      string   `usage:"The base image to use for MCP containers" default:"ghcr.io/obot-platform/mcp-images/stdio-wrapper:v0.24.0"`
 	MCPHTTPWebhookBaseImage           string   `usage:"The base image to use for HTTP-based MCP webhook containers" default:"ghcr.io/obot-platform/mcp-images/http-webhook-mcp-converter:v0.24.0"`
-	MCPRemoteShimBaseImage            string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/obot-platform/nanobot:v0.0.87"`
+	MCPRemoteShimBaseImage            string   `usage:"The base image to use for MCP remote shim containers" default:"ghcr.io/obot-platform/nanobot:v0.0.88"`
 	MCPNamespace                      string   `usage:"The namespace to use for MCP containers" default:"obot-mcp"`
 	MCPClusterDomain                  string   `usage:"The cluster domain to use for MCP containers" default:"cluster.local"`
 	DisallowLocalhostMCP              bool     `usage:"Disallow MCP containers from connecting to localhost" default:"true"`

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -143,7 +143,8 @@ type ComponentServer struct {
 	Name       string               `json:"name"`
 	URL        string               `json:"url"`
 	Tools      []types.ToolOverride `json:"tools"`
-	ToolPrefix string               `json:"toolPrefix"`
+	noTools    bool
+	ToolPrefix string `json:"toolPrefix"`
 }
 
 var envVarRegex = regexp.MustCompile(`\${([^}]+)}`)
@@ -296,18 +297,15 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 			continue
 		}
 
-		var tools []types.ToolOverride
-		if override.ToolOverrides != nil {
-			tools = make([]types.ToolOverride, 0, len(override.ToolOverrides))
-			for _, tool := range override.ToolOverrides {
-				if tool.Enabled {
-					tools = append(tools, types.ToolOverride{
-						Name:                tool.Name,
-						OverrideName:        tool.OverrideName,
-						OverrideDescription: tool.OverrideDescription,
-						Enabled:             tool.Enabled,
-					})
-				}
+		tools := make([]types.ToolOverride, 0, len(override.ToolOverrides))
+		for _, tool := range override.ToolOverrides {
+			if tool.Enabled {
+				tools = append(tools, types.ToolOverride{
+					Name:                tool.Name,
+					OverrideName:        tool.OverrideName,
+					OverrideDescription: tool.OverrideDescription,
+					Enabled:             tool.Enabled,
+				})
 			}
 		}
 
@@ -315,6 +313,7 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 			Name:       name,
 			URL:        system.MCPConnectURL(issuer, component.Name),
 			Tools:      tools,
+			noTools:    len(override.ToolOverrides) > 0 && len(tools) == 0,
 			ToolPrefix: override.ToolPrefix,
 		})
 	}
@@ -325,18 +324,15 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 			continue
 		}
 
-		var tools []types.ToolOverride
-		if override.ToolOverrides != nil {
-			tools = make([]types.ToolOverride, 0, len(override.ToolOverrides))
-			for _, tool := range override.ToolOverrides {
-				if tool.Enabled {
-					tools = append(tools, types.ToolOverride{
-						Name:                tool.Name,
-						OverrideName:        tool.OverrideName,
-						OverrideDescription: tool.OverrideDescription,
-						Enabled:             tool.Enabled,
-					})
-				}
+		tools := make([]types.ToolOverride, 0, len(override.ToolOverrides))
+		for _, tool := range override.ToolOverrides {
+			if tool.Enabled {
+				tools = append(tools, types.ToolOverride{
+					Name:                tool.Name,
+					OverrideName:        tool.OverrideName,
+					OverrideDescription: tool.OverrideDescription,
+					Enabled:             tool.Enabled,
+				})
 			}
 		}
 
@@ -344,6 +340,7 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 			Name:       instance.Name,
 			URL:        system.MCPConnectURL(issuer, instance.Name),
 			Tools:      tools,
+			noTools:    len(override.ToolOverrides) > 0 && len(tools) == 0,
 			ToolPrefix: override.ToolPrefix,
 		})
 	}

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -296,15 +296,18 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 			continue
 		}
 
-		tools := make([]types.ToolOverride, 0, len(override.ToolOverrides))
-		for _, tool := range override.ToolOverrides {
-			if tool.Enabled {
-				tools = append(tools, types.ToolOverride{
-					Name:                tool.Name,
-					OverrideName:        tool.OverrideName,
-					OverrideDescription: tool.OverrideDescription,
-					Enabled:             tool.Enabled,
-				})
+		var tools []types.ToolOverride
+		if override.ToolOverrides != nil {
+			tools = make([]types.ToolOverride, 0, len(override.ToolOverrides))
+			for _, tool := range override.ToolOverrides {
+				if tool.Enabled {
+					tools = append(tools, types.ToolOverride{
+						Name:                tool.Name,
+						OverrideName:        tool.OverrideName,
+						OverrideDescription: tool.OverrideDescription,
+						Enabled:             tool.Enabled,
+					})
+				}
 			}
 		}
 
@@ -322,15 +325,18 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 			continue
 		}
 
-		tools := make([]types.ToolOverride, 0, len(override.ToolOverrides))
-		for _, tool := range override.ToolOverrides {
-			if tool.Enabled {
-				tools = append(tools, types.ToolOverride{
-					Name:                tool.Name,
-					OverrideName:        tool.OverrideName,
-					OverrideDescription: tool.OverrideDescription,
-					Enabled:             tool.Enabled,
-				})
+		var tools []types.ToolOverride
+		if override.ToolOverrides != nil {
+			tools = make([]types.ToolOverride, 0, len(override.ToolOverrides))
+			for _, tool := range override.ToolOverrides {
+				if tool.Enabled {
+					tools = append(tools, types.ToolOverride{
+						Name:                tool.Name,
+						OverrideName:        tool.OverrideName,
+						OverrideDescription: tool.OverrideDescription,
+						Enabled:             tool.Enabled,
+					})
+				}
 			}
 		}
 

--- a/pkg/mcp/types_test.go
+++ b/pkg/mcp/types_test.go
@@ -207,8 +207,47 @@ func TestCompositeServerToServerConfig_OmittedToolOverridesRemainNil(t *testing.
 	if len(config.Components) != 1 {
 		t.Fatalf("expected one component, got %d", len(config.Components))
 	}
-	if config.Components[0].Tools != nil {
-		t.Fatalf("expected omitted tool overrides to keep nil tools, got %#v", config.Components[0].Tools)
+	if len(config.Components[0].Tools) != 0 {
+		t.Fatalf("expected omitted tool overrides to have empty tools, got %#v", config.Components[0].Tools)
+	}
+	if config.Components[0].noTools {
+		t.Fatal("expected omitted tool overrides not to disable tools")
+	}
+}
+
+func TestCompositeServerToServerConfig_AllDisabledToolOverridesSetNoTools(t *testing.T) {
+	baseURL := "http://localhost:8080"
+	mcpServer := v1.MCPServer{
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeRuntimeConfig{ComponentServers: []types.ComponentServer{
+					{CatalogEntryID: "search", ToolOverrides: []types.ToolOverride{
+						{Name: "search", Enabled: false},
+					}},
+				}},
+			},
+		},
+	}
+	mcpServer.Name = "composite"
+	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"}}
+	component.Name = "search-server"
+
+	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), baseURL, "test-user-id", "test-scope", "test-catalog", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missing) > 0 {
+		t.Fatalf("expected no missing config, got %v", missing)
+	}
+	if len(config.Components) != 1 {
+		t.Fatalf("expected one component, got %d", len(config.Components))
+	}
+	if len(config.Components[0].Tools) != 0 {
+		t.Fatalf("expected all disabled tools to be filtered out, got %#v", config.Components[0].Tools)
+	}
+	if !config.Components[0].noTools {
+		t.Fatal("expected all disabled tool overrides to disable tools")
 	}
 }
 

--- a/pkg/mcp/types_test.go
+++ b/pkg/mcp/types_test.go
@@ -181,6 +181,37 @@ func TestServerToServerConfig_MultiUserPassthroughHeaders(t *testing.T) {
 	}
 }
 
+func TestCompositeServerToServerConfig_OmittedToolOverridesRemainNil(t *testing.T) {
+	baseURL := "http://localhost:8080"
+	mcpServer := v1.MCPServer{
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeComposite,
+				CompositeConfig: &types.CompositeRuntimeConfig{ComponentServers: []types.ComponentServer{
+					{CatalogEntryID: "search"},
+				}},
+			},
+		},
+	}
+	mcpServer.Name = "composite"
+	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"}}
+	component.Name = "search-server"
+
+	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), baseURL, "test-user-id", "test-scope", "test-catalog", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missing) > 0 {
+		t.Fatalf("expected no missing config, got %v", missing)
+	}
+	if len(config.Components) != 1 {
+		t.Fatalf("expected one component, got %d", len(config.Components))
+	}
+	if config.Components[0].Tools != nil {
+		t.Fatalf("expected omitted tool overrides to keep nil tools, got %#v", config.Components[0].Tools)
+	}
+}
+
 func TestServerToServerConfig_StaticHeaders_Remote(t *testing.T) {
 	baseURL := "http://localhost:8080"
 	tests := []struct {

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -117,7 +117,7 @@ type Config struct {
 	EnableAgents                         *bool  `usage:"Enable Obot Agent features. When unset, agents are disabled for new deployments but grandfathered in for deployments that already have agents. Explicitly set to true to force-enable, or false to force-disable, regardless of grandfathering." env:"OBOT_ENABLE_AGENTS"`
 	MCPOAuthClientExpiration             string `usage:"The expiration time in dynamically registered MCP OAuth clients, must be a valid duration string and may include days, hours, or minutes" default:"30d"`
 	MCPServerSearchImage                 string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.2.0"`
-	NanobotAgentImage                    string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/obot-platform/nanobot-agent:v0.0.87"`
+	NanobotAgentImage                    string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/obot-platform/nanobot-agent:v0.0.88"`
 	MCPNetworkPolicyProviderChartRepo    string `usage:"Helm repository URL for the network policy provider chart"`
 	MCPNetworkPolicyProviderChartName    string `usage:"Helm chart name for the network policy provider chart"`
 	MCPNetworkPolicyProviderChartVersion string `usage:"Helm chart version for the network policy provider chart"`


### PR DESCRIPTION
Addresses: https://github.com/obot-platform/obot/issues/7085, https://github.com/obot-platform/obot/issues/7088
Depends on: https://github.com/obot-platform/nanobot/pull/338

Adds `NoTools` in Nanobot YAML to communicate the difference between "all allowed" and "all disabled" when tool overrides are empty.
