### PR TITLE
fix: mcp catalog administrative tools & debugging, filter configured servers by owner id

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -21,6 +21,7 @@
 		getMCPDisplayName,
 		getServerTypeLabel,
 		getSource,
+		isMultiUserCatalogEntry,
 		isMultiUserServer
 	} from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
@@ -199,6 +200,11 @@
 	let needsDeploymentsUpdate = $derived(
 		resolvedConfiguredServers?.some((s) => s.needsUpdate || s.needsK8sUpdate) ??
 			resolvedConfiguredInstances?.some((i) => !i.configured)
+	);
+	let ownedDeployments = $derived(
+		(isMultiUserCatalogEntry(entry)
+			? resolvedConfiguredServers
+			: resolvedConfiguredServers?.filter((s) => s.userID === profile.current?.id)) ?? []
 	);
 
 	let deploymentToDisplayTools = $state<MCPCatalogServer>();
@@ -1242,7 +1248,7 @@
 				<Select
 					id="select-deployment-tools-view"
 					class="bg-base-200 hover:bg-base-300 dark:bg-base-100 dark:hover:bg-base-200 mb-0.5 border border-transparent shadow-none md:w-64"
-					options={(resolvedConfiguredServers ?? []).map((deployment) => ({
+					options={ownedDeployments.map((deployment) => ({
 						id: deployment.id,
 						label: `${deployment.alias || deployment.manifest.name} (${deployment.id})`,
 						data: deployment
@@ -1340,7 +1346,7 @@
 		{entity}
 		{entry}
 		{server}
-		servers={resolvedConfiguredServers}
+		servers={ownedDeployments}
 		onRefresh={reloadConfiguredServers}
 	/>
 {/snippet}

--- a/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryTroubleshooting.svelte
@@ -12,6 +12,7 @@
 	} from '$lib/services/admin/constants';
 	import { isMultiUserCatalogEntry } from '$lib/services/user/mcp';
 	import { mcpServersAndEntries } from '$lib/stores';
+	import { profile } from '$lib/stores';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import Select from '../Select.svelte';
 	import ConnectToServer from '../mcp/ConnectToServer.svelte';
@@ -48,9 +49,16 @@
 	let selectableDeployments = $derived(
 		servers
 			? servers
-			: mcpServersAndEntries.current.userConfiguredServers.filter(
-					(server) => server.catalogEntryID === entry?.id
-				)
+			: mcpServersAndEntries.current.userConfiguredServers.filter((deployment) => {
+					if (isMultiUserCatalogEntry(entry)) {
+						return deployment.catalogEntryID === entry?.id;
+					}
+
+					// single-tenant entry: just get deployments tied to the user
+					return (
+						deployment.catalogEntryID === entry?.id && deployment.userID === profile.current?.id
+					);
+				})
 	);
 	let deploymentOptions = $derived(
 		selectableDeployments.map((server) => ({
@@ -184,13 +192,7 @@
 				if (launchedServer) {
 					pending = 'deleting';
 					try {
-						if (
-							entry &&
-							'isCatalogEntry' in entry &&
-							isMultiUserCatalogEntry(entry) &&
-							entity &&
-							entityId
-						) {
+						if (isMultiUserCatalogEntry(entry) && entity && entityId) {
 							if (entity === 'workspace') {
 								await UserService.deleteWorkspaceMCPCatalogServer(entityId, launchedServer.id);
 							} else {

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -449,7 +449,9 @@ export function getServerTypeLabel(server?: MCPCatalogServer | MCPCatalogEntry) 
 	return 'Hosted';
 }
 
-export function isMultiUserCatalogEntry(entry?: MCPCatalogEntry) {
+export function isMultiUserCatalogEntry(entry?: MCPCatalogEntry | MCPCatalogServer) {
+	if (!entry) return false;
+	if (!('isCatalogEntry' in entry)) return false;
 	return (
 		entry?.manifest?.serverUserType === 'multiUser' &&
 		entry.manifest.runtime !== 'remote' &&


### PR DESCRIPTION
* so admins only see their deployments when examining deployment tools or debugging oauth flow