### PR TITLE
fix: check access to MCP ID during OAuth

### DIFF
--- a/pkg/api/authz/oauthauthrequest.go
+++ b/pkg/api/authz/oauthauthrequest.go
@@ -1,0 +1,27 @@
+package authz
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/obot-platform/nah/pkg/router"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+)
+
+func (a *Authorizer) checkOAuthAuthRequest(req *http.Request, resources *Resources, u User) (bool, error) {
+	if resources.OAuthAuthRequestID == "" {
+		return true, nil
+	}
+
+	var oauthAuthRequest v1.OAuthAuthRequest
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.OAuthAuthRequestID), &oauthAuthRequest); err != nil {
+		return false, err
+	}
+
+	if oauthAuthRequest.Spec.UserID != 0 && strconv.FormatUint(uint64(oauthAuthRequest.Spec.UserID), 10) != u.GetUID() {
+		return false, nil
+	}
+
+	return CheckMCPIDAccess(req.Context(), a.uncached, a.acrHelper, u, oauthAuthRequest.Spec.MCPID)
+}

--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -17,12 +17,11 @@ var apiResources = map[string][]string{
 		"GET    /api/all-mcps/servers/{mcpserver_id}/prompts/{prompt_name}",
 		"GET    /api/all-mcps/entries/{entry_id}",
 		"GET    /oauth/callback/{oauth_request_id}",
-		"GET    /oauth/callback/{oauth_request_id}/{mcp_id}",
 		"GET    /oauth/mcp/callback",
-		"GET    /oauth/consent/{oauth_auth_request}",
-		"POST   /oauth/consent/{oauth_auth_request}/approve",
-		"POST   /oauth/consent/{oauth_auth_request}/cancel",
-		"GET    /oauth/complete/{oauth_auth_request}",
+		"GET    /oauth/consent/{oauth_request_id}",
+		"POST   /oauth/consent/{oauth_request_id}/approve",
+		"POST   /oauth/consent/{oauth_request_id}/cancel",
+		"GET    /oauth/complete/{oauth_request_id}",
 		"GET    /auth/mcp/composite/{mcp_id}",
 		"GET    /api/oauth/composite/{mcp_id}",
 		"GET    /api/mcp-stats/{mcp_id}",
@@ -155,6 +154,7 @@ type Resources struct {
 	ArtifactVersion     string
 	SkillID             string
 	DeviceScanID        string
+	OAuthAuthRequestID  string
 	Authorizated        ResourcesAuthorized
 }
 
@@ -182,6 +182,7 @@ func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user User
 		ArtifactVersion:         vars("artifact_version"),
 		SkillID:                 vars("skill_id"),
 		DeviceScanID:            vars("scan_id"),
+		OAuthAuthRequestID:      vars("oauth_request_id"),
 	}
 
 	if !a.checkUser(user, vars("user_id")) {
@@ -225,6 +226,10 @@ func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user User
 	}
 
 	if ok, err := a.checkDeviceScan(req, &resources, user); !ok || err != nil {
+		return false, err
+	}
+
+	if ok, err := a.checkOAuthAuthRequest(req, &resources, user); !ok || err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
This change errors earlier when the user doesn't have access to the MCP server they are trying to connect to.

Issue: https://github.com/obot-platform/security-issues/issues/71