### PR TITLE
fix: hydrate composite multi-user components

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -518,8 +518,11 @@ func (m MCPServerManifest) ConvertToCatalogEntry() MCPServerCatalogEntryManifest
 	case RuntimeRemote:
 		if m.RemoteConfig != nil {
 			catalogManifest.RemoteConfig = &RemoteCatalogConfig{
-				FixedURL: m.RemoteConfig.URL,
-				Headers:  m.RemoteConfig.Headers,
+				FixedURL:            m.RemoteConfig.URL,
+				URLTemplate:         m.RemoteConfig.URLTemplate,
+				Hostname:            m.RemoteConfig.Hostname,
+				Headers:             m.RemoteConfig.Headers,
+				StaticOAuthRequired: m.RemoteConfig.StaticOAuthRequired,
 			}
 		}
 	case RuntimeComposite:
@@ -531,6 +534,7 @@ func (m MCPServerManifest) ConvertToCatalogEntry() MCPServerCatalogEntryManifest
 					MCPServerID:    comp.MCPServerID,
 					Manifest:       comp.Manifest.ConvertToCatalogEntry(),
 					ToolOverrides:  comp.ToolOverrides,
+					ToolPrefix:     comp.ToolPrefix,
 				}
 			}
 			catalogManifest.CompositeConfig = &CompositeCatalogConfig{ComponentServers: componentServers}

--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -493,6 +493,53 @@ func (m SystemMCPServerManifest) RuntimeStartupTimeoutSeconds() int {
 	return startupTimeoutSeconds(m.Runtime, m.UVXConfig, m.NPXConfig, m.ContainerizedConfig)
 }
 
+// ConvertToCatalogEntry converts an MCPServerManifest to an MCPServerCatalogEntryManifest.
+func (m MCPServerManifest) ConvertToCatalogEntry() MCPServerCatalogEntryManifest {
+	catalogManifest := MCPServerCatalogEntryManifest{
+		Metadata:         m.Metadata,
+		Name:             m.Name,
+		ShortDescription: m.ShortDescription,
+		Description:      m.Description,
+		Icon:             m.Icon,
+		Runtime:          m.Runtime,
+		Env:              m.Env,
+		ToolPreview:      m.ToolPreview,
+		MultiUserConfig:  m.MultiUserConfig,
+		Resources:        m.Resources,
+	}
+
+	switch m.Runtime {
+	case RuntimeUVX:
+		catalogManifest.UVXConfig = m.UVXConfig
+	case RuntimeNPX:
+		catalogManifest.NPXConfig = m.NPXConfig
+	case RuntimeContainerized:
+		catalogManifest.ContainerizedConfig = m.ContainerizedConfig
+	case RuntimeRemote:
+		if m.RemoteConfig != nil {
+			catalogManifest.RemoteConfig = &RemoteCatalogConfig{
+				FixedURL: m.RemoteConfig.URL,
+				Headers:  m.RemoteConfig.Headers,
+			}
+		}
+	case RuntimeComposite:
+		if m.CompositeConfig != nil {
+			componentServers := make([]CatalogComponentServer, len(m.CompositeConfig.ComponentServers))
+			for i, comp := range m.CompositeConfig.ComponentServers {
+				componentServers[i] = CatalogComponentServer{
+					CatalogEntryID: comp.CatalogEntryID,
+					MCPServerID:    comp.MCPServerID,
+					Manifest:       comp.Manifest.ConvertToCatalogEntry(),
+					ToolOverrides:  comp.ToolOverrides,
+				}
+			}
+			catalogManifest.CompositeConfig = &CompositeCatalogConfig{ComponentServers: componentServers}
+		}
+	}
+
+	return catalogManifest
+}
+
 // MapCatalogEntryToServer converts an MCPServerCatalogEntryManifest to an MCPServerManifest
 // For remote runtime, userURL is used when the catalog entry has a hostname constraint
 // If disableHostnameValidation is true, the hostname constraint is not validated.

--- a/apiclient/types/mcpserver_test.go
+++ b/apiclient/types/mcpserver_test.go
@@ -25,6 +25,64 @@ func TestMapCatalogEntryToServerCopiesResources(t *testing.T) {
 	}
 }
 
+func TestMCPServerManifestConvertToCatalogEntryPreservesRemoteFields(t *testing.T) {
+	manifest := MCPServerManifest{
+		Runtime: RuntimeRemote,
+		RemoteConfig: &RemoteRuntimeConfig{
+			URL:                 "https://api.example.com/mcp",
+			URLTemplate:         "https://${WORKSPACE}.example.com/mcp",
+			Hostname:            "*.example.com",
+			Headers:             []MCPHeader{{Key: "Authorization", Name: "Authorization"}},
+			StaticOAuthRequired: true,
+		},
+	}
+
+	result := manifest.ConvertToCatalogEntry()
+
+	if result.RemoteConfig == nil {
+		t.Fatal("Expected RemoteConfig to be populated")
+	}
+	if result.RemoteConfig.FixedURL != manifest.RemoteConfig.URL {
+		t.Errorf("Expected fixedURL %q, got %q", manifest.RemoteConfig.URL, result.RemoteConfig.FixedURL)
+	}
+	if result.RemoteConfig.URLTemplate != manifest.RemoteConfig.URLTemplate {
+		t.Errorf("Expected urlTemplate %q, got %q", manifest.RemoteConfig.URLTemplate, result.RemoteConfig.URLTemplate)
+	}
+	if result.RemoteConfig.Hostname != manifest.RemoteConfig.Hostname {
+		t.Errorf("Expected hostname %q, got %q", manifest.RemoteConfig.Hostname, result.RemoteConfig.Hostname)
+	}
+	if len(result.RemoteConfig.Headers) != 1 || result.RemoteConfig.Headers[0].Key != "Authorization" {
+		t.Errorf("Expected headers to be copied, got %v", result.RemoteConfig.Headers)
+	}
+	if !result.RemoteConfig.StaticOAuthRequired {
+		t.Error("Expected staticOAuthRequired to be copied")
+	}
+}
+
+func TestMCPServerManifestConvertToCatalogEntryPreservesCompositeToolPrefix(t *testing.T) {
+	manifest := MCPServerManifest{
+		Runtime: RuntimeComposite,
+		CompositeConfig: &CompositeRuntimeConfig{ComponentServers: []ComponentServer{{
+			CatalogEntryID: "component",
+			ToolPrefix:     "prefix_",
+			Manifest: MCPServerManifest{
+				Runtime:   RuntimeNPX,
+				NPXConfig: &NPXRuntimeConfig{Package: "component"},
+			},
+		}}},
+	}
+
+	result := manifest.ConvertToCatalogEntry()
+
+	if result.CompositeConfig == nil || len(result.CompositeConfig.ComponentServers) != 1 {
+		t.Fatalf("Expected one composite component, got %#v", result.CompositeConfig)
+	}
+	component := result.CompositeConfig.ComponentServers[0]
+	if component.ToolPrefix != "prefix_" {
+		t.Errorf("Expected toolPrefix %q, got %q", "prefix_", component.ToolPrefix)
+	}
+}
+
 func TestMapCatalogEntryToServer_UVX(t *testing.T) {
 	catalogEntry := MCPServerCatalogEntryManifest{
 		Name:        "Test UVX Server",

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1594,11 +1594,11 @@ func (h *MCPCatalogHandler) populateComponentManifests(req api.Context, manifest
 
 			// Verify the server belongs to the same catalog
 			if catalogName != "" && server.Spec.MCPCatalogID != catalogName {
-				return types.NewErrBadRequest("multi-user server %s belongs to catalog %s, not %s", component.MCPServerID, server.Spec.MCPCatalogID, catalogName)
+				return types.NewErrBadRequest("multi-user server %q not found in catalog %q", component.MCPServerID, catalogName)
 			}
 
 			// Populate the manifest snapshot from the multi-user server
-			component.Manifest = convertServerManifestToCatalogManifest(server.Spec.Manifest)
+			component.Manifest = server.Spec.Manifest.ConvertToCatalogEntry()
 			// Keep this component
 			componentServers = append(componentServers, *component)
 		} else {
@@ -1642,58 +1642,6 @@ func (h *MCPCatalogHandler) populateComponentManifests(req api.Context, manifest
 	manifest.CompositeConfig.ComponentServers = componentServers
 
 	return nil
-}
-
-// convertServerManifestToCatalogManifest converts an MCPServerManifest to MCPServerCatalogEntryManifest
-func convertServerManifestToCatalogManifest(serverManifest types.MCPServerManifest) types.MCPServerCatalogEntryManifest {
-	catalogManifest := types.MCPServerCatalogEntryManifest{
-		Metadata:         serverManifest.Metadata,
-		Name:             serverManifest.Name,
-		ShortDescription: serverManifest.ShortDescription,
-		Description:      serverManifest.Description,
-		Icon:             serverManifest.Icon,
-		Runtime:          serverManifest.Runtime,
-		Env:              serverManifest.Env,
-		ToolPreview:      serverManifest.ToolPreview,
-		MultiUserConfig:  serverManifest.MultiUserConfig,
-		Resources:        serverManifest.Resources,
-	}
-
-	// Convert runtime-specific configs
-	switch serverManifest.Runtime {
-	case types.RuntimeUVX:
-		catalogManifest.UVXConfig = serverManifest.UVXConfig
-	case types.RuntimeNPX:
-		catalogManifest.NPXConfig = serverManifest.NPXConfig
-	case types.RuntimeContainerized:
-		catalogManifest.ContainerizedConfig = serverManifest.ContainerizedConfig
-	case types.RuntimeRemote:
-		if serverManifest.RemoteConfig != nil {
-			catalogManifest.RemoteConfig = &types.RemoteCatalogConfig{
-				FixedURL: serverManifest.RemoteConfig.URL,
-				Headers:  serverManifest.RemoteConfig.Headers,
-			}
-		}
-	case types.RuntimeComposite:
-		if serverManifest.CompositeConfig != nil {
-			// TODO(njhale): Figure out if this can be removed
-			// Convert CompositeRuntimeConfig to CompositeCatalogConfig
-			componentServers := make([]types.CatalogComponentServer, len(serverManifest.CompositeConfig.ComponentServers))
-			for i, comp := range serverManifest.CompositeConfig.ComponentServers {
-				componentServers[i] = types.CatalogComponentServer{
-					CatalogEntryID: comp.CatalogEntryID,
-					MCPServerID:    comp.MCPServerID,
-					Manifest:       convertServerManifestToCatalogManifest(comp.Manifest),
-					ToolOverrides:  comp.ToolOverrides,
-				}
-			}
-			catalogManifest.CompositeConfig = &types.CompositeCatalogConfig{
-				ComponentServers: componentServers,
-			}
-		}
-	}
-
-	return catalogManifest
 }
 
 // RefreshCompositeComponents refreshes the component snapshots in a composite catalog entry

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1594,7 +1594,7 @@ func (h *MCPCatalogHandler) populateComponentManifests(req api.Context, manifest
 
 			// Verify the server belongs to the same catalog
 			if catalogName != "" && server.Spec.MCPCatalogID != catalogName {
-				return types.NewErrBadRequest("multi-user server %q not found in catalog %q", component.MCPServerID, catalogName)
+				return types.NewErrBadRequest("multi-user server %s belongs to catalog %s, not %s", component.MCPServerID, server.Spec.MCPCatalogID, catalogName)
 			}
 
 			// Populate the manifest snapshot from the multi-user server

--- a/pkg/controller/handlers/mcpcatalog/composite_refs_test.go
+++ b/pkg/controller/handlers/mcpcatalog/composite_refs_test.go
@@ -1,7 +1,6 @@
 package mcpcatalog
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,9 +8,12 @@ import (
 
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestResolveCompositeSourceRefs(t *testing.T) {
@@ -36,7 +38,7 @@ func TestResolveCompositeSourceRefs(t *testing.T) {
 		}},
 	})
 
-	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(context.Background(), []client.Object{target, composite})
+	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(t.Context(), nil, "", "", []client.Object{target, composite})
 
 	assert.Empty(t, errsBySourceURL)
 	assert.Len(t, result, 2)
@@ -68,10 +70,10 @@ compositeConfig:
 `, sourceRef(dir, "tool")), 0o600))
 
 	h := &Handler{}
-	objs, err := h.readMCPCatalog(context.Background(), "default", dir, "")
+	objs, err := h.readMCPCatalog(t.Context(), "default", dir, "")
 	assert.NoError(t, err)
 
-	objs, errsBySourceURL := h.resolveCompositeSourceRefs(context.Background(), objs)
+	objs, errsBySourceURL := h.resolveCompositeSourceRefs(t.Context(), nil, "", "", objs)
 	assert.Empty(t, errsBySourceURL)
 	assert.Len(t, objs, 2)
 
@@ -114,10 +116,10 @@ compositeConfig:
 `), 0o600))
 
 	h := &Handler{}
-	objs, err := h.readMCPCatalog(context.Background(), "default", dir, "")
+	objs, err := h.readMCPCatalog(t.Context(), "default", dir, "")
 	assert.NoError(t, err)
 
-	objs, errsBySourceURL := h.resolveCompositeSourceRefs(context.Background(), objs)
+	objs, errsBySourceURL := h.resolveCompositeSourceRefs(t.Context(), nil, "", "", objs)
 	assert.Empty(t, errsBySourceURL)
 	assert.Len(t, objs, 2)
 
@@ -150,7 +152,7 @@ func TestResolveCompositeSourceRefsLeavesUnknownShorthandAsInternalID(t *testing
 		}},
 	})
 
-	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(context.Background(), []client.Object{composite})
+	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(t.Context(), nil, "", "", []client.Object{composite})
 
 	assert.Empty(t, errsBySourceURL)
 	assert.Len(t, result, 1)
@@ -179,13 +181,49 @@ func TestResolveCompositeSourceRefsHydratesInternalIDComponents(t *testing.T) {
 		}},
 	})
 
-	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(context.Background(), []client.Object{target, composite})
+	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(t.Context(), nil, "", "", []client.Object{target, composite})
 
 	assert.Empty(t, errsBySourceURL)
 	assert.Len(t, result, 2)
 	component := composite.Spec.Manifest.CompositeConfig.ComponentServers[0]
 	assert.Equal(t, "default-gmail-8a99d8be", component.CatalogEntryID)
 	assert.Equal(t, "Gmail", component.Manifest.Name)
+}
+
+func TestResolveCompositeSourceRefsHydratesMultiUserServerIDComponents(t *testing.T) {
+	server := testMCPServer("shared-server", "default", types.MCPServerManifest{
+		Name:            "Shared Server",
+		Runtime:         types.RuntimeContainerized,
+		MultiUserConfig: &types.MultiUserConfig{UserDefinedHeaders: []types.MCPHeader{{Key: "API_KEY", Name: "API Key"}}},
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/shared:1.0.0",
+			Port:  8080,
+			Path:  "/mcp",
+		},
+	})
+	server.Spec.MCPCatalogID = "default"
+	composite := testCatalogEntry("composite", "source", "composite.yaml", types.MCPServerCatalogEntryManifest{
+		Name:           "Composite",
+		Runtime:        types.RuntimeComposite,
+		ServerUserType: types.ServerUserTypeSingleUser,
+		CompositeConfig: &types.CompositeCatalogConfig{ComponentServers: []types.CatalogComponentServer{
+			{MCPServerID: "shared-server"},
+		}},
+	})
+	c := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(server).Build()
+
+	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(t.Context(), c, "default", "default", []client.Object{composite})
+
+	assert.Empty(t, errsBySourceURL)
+	assert.Len(t, result, 1)
+	component := composite.Spec.Manifest.CompositeConfig.ComponentServers[0]
+	assert.Equal(t, "shared-server", component.MCPServerID)
+	assert.Empty(t, component.CatalogEntryID)
+	require.NotNil(t, component.Manifest.ContainerizedConfig)
+	assert.Equal(t, "Shared Server", component.Manifest.Name)
+	assert.Equal(t, types.RuntimeContainerized, component.Manifest.Runtime)
+	assert.Equal(t, "example/shared:1.0.0", component.Manifest.ContainerizedConfig.Image)
+	assert.NotNil(t, component.Manifest.MultiUserConfig)
 }
 
 func TestReadMCPCatalogResolvesCompositeSourceRefsAcrossSources(t *testing.T) {
@@ -213,12 +251,12 @@ compositeConfig:
 `, sourceRef(first, "tool")), 0o600))
 
 	h := &Handler{}
-	firstObjs, err := h.readMCPCatalog(context.Background(), "default", first, "")
+	firstObjs, err := h.readMCPCatalog(t.Context(), "default", first, "")
 	assert.NoError(t, err)
-	secondObjs, err := h.readMCPCatalog(context.Background(), "default", second, "")
+	secondObjs, err := h.readMCPCatalog(t.Context(), "default", second, "")
 	assert.NoError(t, err)
 
-	objs, errsBySourceURL := h.resolveCompositeSourceRefs(context.Background(), append(firstObjs, secondObjs...))
+	objs, errsBySourceURL := h.resolveCompositeSourceRefs(t.Context(), nil, "", "", append(firstObjs, secondObjs...))
 	assert.Empty(t, errsBySourceURL)
 	assert.Len(t, objs, 2)
 
@@ -260,7 +298,7 @@ func TestResolveCompositeSourceRefsResolvesExplicitSourceRefWithoutCurrentSource
 		}},
 	})
 
-	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(context.Background(), []client.Object{target, composite})
+	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(t.Context(), nil, "", "", []client.Object{target, composite})
 
 	assert.Empty(t, errsBySourceURL)
 	assert.Len(t, result, 2)
@@ -291,7 +329,7 @@ func TestResolveCompositeSourceRefsSkipsUnresolvedComposite(t *testing.T) {
 		}},
 	})
 
-	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(context.Background(), []client.Object{target, composite})
+	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(t.Context(), nil, "", "", []client.Object{target, composite})
 
 	assert.Len(t, result, 1)
 	assert.Equal(t, "target", result[0].GetName())
@@ -311,7 +349,7 @@ func TestResolveCompositeSourceRefsSkipsMalformedRef(t *testing.T) {
 		}},
 	})
 
-	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(context.Background(), []client.Object{composite})
+	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(t.Context(), nil, "", "", []client.Object{composite})
 
 	assert.Empty(t, result)
 	assert.Contains(t, errsBySourceURL["source"], `invalid catalogEntryID source ref "source::"`)
@@ -325,6 +363,15 @@ func testCatalogEntry(name, sourceID, entryKey string, manifest types.MCPServerC
 			SourceURL: sourceID,
 			Manifest:  manifest,
 			Editable:  false,
+		},
+	}
+}
+
+func testMCPServer(name, namespace string, manifest types.MCPServerManifest) *v1.MCPServer {
+	return &v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1.MCPServerSpec{
+			Manifest: manifest,
 		},
 	}
 }

--- a/pkg/controller/handlers/mcpcatalog/composite_refs_test.go
+++ b/pkg/controller/handlers/mcpcatalog/composite_refs_test.go
@@ -226,6 +226,34 @@ func TestResolveCompositeSourceRefsHydratesMultiUserServerIDComponents(t *testin
 	assert.NotNil(t, component.Manifest.MultiUserConfig)
 }
 
+func TestResolveCompositeSourceRefsRejectsMultiUserServerOutsideCatalog(t *testing.T) {
+	server := testMCPServer("shared-server", "default", types.MCPServerManifest{
+		Name:            "Shared Server",
+		Runtime:         types.RuntimeContainerized,
+		MultiUserConfig: &types.MultiUserConfig{},
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/shared:1.0.0",
+			Port:  8080,
+			Path:  "/mcp",
+		},
+	})
+	server.Spec.PowerUserWorkspaceID = "workspace-1"
+	composite := testCatalogEntry("composite", "source", "composite.yaml", types.MCPServerCatalogEntryManifest{
+		Name:           "Composite",
+		Runtime:        types.RuntimeComposite,
+		ServerUserType: types.ServerUserTypeSingleUser,
+		CompositeConfig: &types.CompositeCatalogConfig{ComponentServers: []types.CatalogComponentServer{
+			{MCPServerID: "shared-server"},
+		}},
+	})
+	c := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(server).Build()
+
+	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(t.Context(), c, "default", "default", []client.Object{composite})
+
+	assert.Empty(t, result)
+	assert.Contains(t, errsBySourceURL["source"], `multi-user server "shared-server" not found in catalog "default"`)
+}
+
 func TestReadMCPCatalogResolvesCompositeSourceRefsAcrossSources(t *testing.T) {
 	first := t.TempDir()
 	assert.NoError(t, os.WriteFile(filepath.Join(first, "target.yaml"), []byte(`entryKey: tool

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -156,7 +156,7 @@ func (h *Handler) Sync(req router.Request, resp router.Response) error {
 		toAdd = append(toAdd, objs...)
 	}
 
-	toAdd, compositeRefErrors := h.resolveCompositeSourceRefs(req.Ctx, toAdd)
+	toAdd, compositeRefErrors := h.resolveCompositeSourceRefs(req.Ctx, req.Client, mcpCatalog.Namespace, mcpCatalog.Name, toAdd)
 	for sourceURL, errMsg := range compositeRefErrors {
 		addSyncError(mcpCatalog.Status.SyncErrors, sourceURL, errMsg)
 	}
@@ -207,7 +207,7 @@ func addSyncError(syncErrors map[string]string, sourceURL, errMsg string) {
 // resolveCompositeSourceRefs rewrites GitOps portable component refs to stored
 // catalog entry names and snapshots the target manifests. Entries with invalid
 // portable refs are skipped so bad composites do not get applied.
-func (h *Handler) resolveCompositeSourceRefs(ctx context.Context, objs []client.Object) ([]client.Object, map[string]string) {
+func (h *Handler) resolveCompositeSourceRefs(ctx context.Context, c client.Client, namespace, catalogName string, objs []client.Object) ([]client.Object, map[string]string) {
 	refs := make(map[string]*v1.MCPServerCatalogEntry)
 	entriesByName := make(map[string]*v1.MCPServerCatalogEntry)
 	for _, obj := range objs {
@@ -234,6 +234,25 @@ func (h *Handler) resolveCompositeSourceRefs(ctx context.Context, objs []client.
 		var errs []error
 		for i := range entry.Spec.Manifest.CompositeConfig.ComponentServers {
 			component := &entry.Spec.Manifest.CompositeConfig.ComponentServers[i]
+			if component.MCPServerID != "" {
+				var server v1.MCPServer
+				if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: component.MCPServerID}, &server); err != nil {
+					errs = append(errs, fmt.Errorf("failed to get multi-user server %q: %w", component.MCPServerID, err))
+					continue
+				}
+				if server.Spec.IsSingleUser() {
+					errs = append(errs, fmt.Errorf("server %q is not a multi-user server", component.MCPServerID))
+					continue
+				}
+				if server.Spec.MCPCatalogID != "" && catalogName != "" && server.Spec.MCPCatalogID != catalogName {
+					errs = append(errs, fmt.Errorf("multi-user server %q not found in catalog %q", component.MCPServerID, catalogName))
+					continue
+				}
+
+				component.Manifest = server.Spec.Manifest.ConvertToCatalogEntry()
+				changed = true
+				continue
+			}
 			if component.CatalogEntryID == "" {
 				continue
 			}

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -244,7 +244,7 @@ func (h *Handler) resolveCompositeSourceRefs(ctx context.Context, c client.Clien
 					errs = append(errs, fmt.Errorf("server %q is not a multi-user server", component.MCPServerID))
 					continue
 				}
-				if server.Spec.MCPCatalogID != "" && catalogName != "" && server.Spec.MCPCatalogID != catalogName {
+				if catalogName != "" && server.Spec.MCPCatalogID != catalogName {
 					errs = append(errs, fmt.Errorf("multi-user server %q not found in catalog %q", component.MCPServerID, catalogName))
 					continue
 				}


### PR DESCRIPTION
## Summary

Addresses https://github.com/obot-platform/obot/issues/7083

- hydrate GitOps composite components that reference multi-user servers via mcpServerID
- reuse MCPServerManifest.ConvertToCatalogEntry for component manifest snapshots