### PR TITLE
fix: block missing mcp secret bindings

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1121,27 +1121,12 @@ func entryMissingAdminConfig(ctx context.Context, client kclient.Client, obotNam
 			remote = &types.RemoteRuntimeConfig{Headers: cm.RemoteConfig.Headers}
 		}
 
-		resolved, err := mcp.MergeBoundCreds(ctx, client, obotNamespace, cm.Env, remote, nil, secretBindingAllowedLabel)
+		missingBindings, err := mcp.MissingSecretBindings(ctx, client, obotNamespace, cm.Env, remote, secretBindingAllowedLabel)
 		if err != nil {
 			return missing, err
 		}
-
-		for _, e := range cm.Env {
-			if e.SecretBinding != nil {
-				if _, ok := resolved[e.Key]; !ok {
-					missing.SecretBoundFields = append(missing.SecretBoundFields, secretBoundFieldLabel(ref.prefix, "env", e.MCPHeader))
-				}
-			}
-		}
-
-		if cm.RemoteConfig != nil {
-			for _, h := range cm.RemoteConfig.Headers {
-				if h.SecretBinding != nil {
-					if _, ok := resolved[h.Key]; !ok {
-						missing.SecretBoundFields = append(missing.SecretBoundFields, secretBoundFieldLabel(ref.prefix, "header", h))
-					}
-				}
-			}
+		for _, binding := range missingBindings {
+			missing.SecretBoundFields = append(missing.SecretBoundFields, secretBoundFieldLabel(ref.prefix, binding.Kind, binding.Header))
 		}
 	}
 

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1114,7 +1114,6 @@ func entryMissingAdminConfig(ctx context.Context, client kclient.Client, obotNam
 			})
 		}
 	}
-
 	for _, ref := range manifests {
 		cm := ref.manifest
 		var remote *types.RemoteRuntimeConfig
@@ -1128,7 +1127,7 @@ func entryMissingAdminConfig(ctx context.Context, client kclient.Client, obotNam
 		}
 
 		for _, e := range cm.Env {
-			if e.Required && e.SecretBinding != nil {
+			if e.SecretBinding != nil {
 				if _, ok := resolved[e.Key]; !ok {
 					missing.SecretBoundFields = append(missing.SecretBoundFields, secretBoundFieldLabel(ref.prefix, "env", e.MCPHeader))
 				}
@@ -1137,7 +1136,7 @@ func entryMissingAdminConfig(ctx context.Context, client kclient.Client, obotNam
 
 		if cm.RemoteConfig != nil {
 			for _, h := range cm.RemoteConfig.Headers {
-				if h.Required && h.SecretBinding != nil {
+				if h.SecretBinding != nil {
 					if _, ok := resolved[h.Key]; !ok {
 						missing.SecretBoundFields = append(missing.SecretBoundFields, secretBoundFieldLabel(ref.prefix, "header", h))
 					}
@@ -1999,6 +1998,11 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 	addExtractedEnvVars(&server)
+	if adminManagedSecretBindings && !server.Spec.IsSingleUser() {
+		if err := mcp.ValidateSecretBindingsAvailable(req.Context(), req.LocalK8sClient, req.ObotNamespace, server.Spec.Manifest.Env, server.Spec.Manifest.RemoteConfig, m.secretBindingAllowedLabel); err != nil {
+			return types.NewErrBadRequest("validation failed: %v", err)
+		}
+	}
 	// Run after extraction so auto-created Required=true entries cover any
 	// template references the user did not pre-declare. This still catches the
 	// case where the user pre-supplied a matching env entry with required=false
@@ -2106,6 +2110,14 @@ func (m *MCPHandler) UpdateServer(req api.Context) error {
 	}
 	if err := validation.ValidateTemplateReferences(updated); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
+	}
+	if adminManagedSecretBindings && !existing.Spec.IsSingleUser() {
+		updatedServer := existing
+		updatedServer.Spec.Manifest = updated
+		addExtractedEnvVars(&updatedServer)
+		if err := mcp.ValidateSecretBindingsAvailable(req.Context(), req.LocalK8sClient, req.ObotNamespace, updatedServer.Spec.Manifest.Env, updatedServer.Spec.Manifest.RemoteConfig, m.secretBindingAllowedLabel); err != nil {
+			return types.NewErrBadRequest("validation failed: %v", err)
+		}
 	}
 
 	// Shutdown the server only after the candidate configuration is known to be valid.

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -1050,6 +1050,45 @@ func TestCreateServerWorkspaceSecretBindingRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), `validation failed: env "API_TOKEN": secretBinding is only allowed on git-synced catalog entries, multi-user catalog entries, or admin-managed multi-user servers`)
 }
 
+func TestCreateServerRejectsMissingSecretBinding(t *testing.T) {
+	handler := newCreateServerSecretBindingTestHandler()
+	entry := v1.MCPServerCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "entry-1", Namespace: system.DefaultNamespace},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			MCPCatalogName: "catalog-1",
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Name:           "multi-user-entry",
+				Runtime:        types.RuntimeContainerized,
+				ServerUserType: types.ServerUserTypeMultiUser,
+				ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+					Image: "example/mcp:latest",
+					Port:  8080,
+					Path:  "/mcp",
+				},
+				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+					Key:           "API_TOKEN",
+					SecretBinding: &types.MCPSecretBinding{Name: "missing-secret", Key: "token"},
+				}}},
+			},
+		},
+	}
+	storage := newFakeStorage(t,
+		&v1.MCPCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1", Namespace: system.DefaultNamespace}},
+		&entry,
+	)
+
+	err := handler.CreateServer(newCreateServerSecretBindingRequest(t, storage, newCreateServerSecretBindingK8sClient(t), "catalog-1", "", types.MCPServer{
+		CatalogEntryID: "entry-1",
+	}))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
+
+	var servers v1.MCPServerList
+	require.NoError(t, storage.List(context.Background(), &servers))
+	assert.Empty(t, servers.Items)
+}
+
 func TestCreateServerRejectsMultiUserHeaderSecretBinding(t *testing.T) {
 	handler := newCreateServerSecretBindingTestHandler()
 	storage := newFakeStorage(t, &v1.MCPCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1", Namespace: system.DefaultNamespace}})
@@ -1458,6 +1497,20 @@ func TestEntryMissingAdminConfig(t *testing.T) {
 					MCPHeader: types.MCPHeader{
 						Key:           "TOKEN",
 						Required:      true,
+						SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
+					},
+				}},
+			},
+			client:     newClient(t),
+			wantFields: []string{"env TOKEN"},
+		},
+		{
+			name: "non-required env missing binding",
+			manifest: types.MCPServerCatalogEntryManifest{
+				Runtime: types.RuntimeNPX,
+				Env: []types.MCPEnv{{
+					MCPHeader: types.MCPHeader{
+						Key:           "TOKEN",
 						SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
 					},
 				}},

--- a/pkg/mcp/secretbindings.go
+++ b/pkg/mcp/secretbindings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"strings"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	corev1 "k8s.io/api/core/v1"
@@ -227,8 +228,11 @@ func ValidateSecretBindingsAvailable(ctx context.Context, c kclient.Client, obot
 		return err
 	}
 	if len(missing) > 0 {
-		field := missing[0]
-		return fmt.Errorf("secret binding %s %q references unavailable Kubernetes Secret %s/%s", field.Kind, field.Header.Key, obotNamespace, field.Binding.Name)
+		fields := make([]string, 0, len(missing))
+		for _, field := range missing {
+			fields = append(fields, fmt.Sprintf("%s %q references %s/%s", field.Kind, field.Header.Key, obotNamespace, field.Binding.Name))
+		}
+		return fmt.Errorf("secret bindings reference unavailable Kubernetes Secrets: %s", strings.Join(fields, ", "))
 	}
 	return nil
 }

--- a/pkg/mcp/secretbindings.go
+++ b/pkg/mcp/secretbindings.go
@@ -163,6 +163,61 @@ func MergeBoundCreds(
 	return merged, nil
 }
 
+// ValidateSecretBindingsAvailable verifies secret-bound config can be resolved
+// before creating/updating/launching a server that users cannot fix.
+func ValidateSecretBindingsAvailable(ctx context.Context, c kclient.Client, obotNamespace string, envs []types.MCPEnv, remoteConfig *types.RemoteRuntimeConfig, allowedLabel string) error {
+	hasBinding := false
+	for _, env := range envs {
+		if env.SecretBinding != nil {
+			hasBinding = true
+			break
+		}
+	}
+	if !hasBinding && remoteConfig != nil {
+		for _, header := range remoteConfig.Headers {
+			if header.SecretBinding != nil {
+				hasBinding = true
+				break
+			}
+		}
+	}
+	if !hasBinding {
+		return nil
+	}
+	if c == nil {
+		return fmt.Errorf("secret bindings require a Kubernetes client")
+	}
+
+	resolved, err := MergeBoundCreds(ctx, c, obotNamespace, envs, remoteConfig, nil, allowedLabel)
+	if err != nil {
+		return err
+	}
+
+	check := func(kind, key string, b *types.MCPSecretBinding) error {
+		if b == nil {
+			return nil
+		}
+		if _, ok := resolved[key]; !ok {
+			return fmt.Errorf("secret binding %s %q references unavailable Kubernetes Secret %s/%s", kind, key, obotNamespace, b.Name)
+		}
+		return nil
+	}
+
+	for _, env := range envs {
+		if err := check("env", env.Key, env.SecretBinding); err != nil {
+			return err
+		}
+	}
+	if remoteConfig != nil {
+		for _, header := range remoteConfig.Headers {
+			if err := check("header", header.Key, header.SecretBinding); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func hasAnyBinding(envs []types.MCPEnv, remoteConfig *types.RemoteRuntimeConfig) bool {
 	for _, e := range envs {
 		if e.SecretBinding != nil {

--- a/pkg/mcp/secretbindings.go
+++ b/pkg/mcp/secretbindings.go
@@ -163,9 +163,13 @@ func MergeBoundCreds(
 	return merged, nil
 }
 
-// ValidateSecretBindingsAvailable verifies secret-bound config can be resolved
-// before creating/updating/launching a server that users cannot fix.
-func ValidateSecretBindingsAvailable(ctx context.Context, c kclient.Client, obotNamespace string, envs []types.MCPEnv, remoteConfig *types.RemoteRuntimeConfig, allowedLabel string) error {
+type MissingSecretBinding struct {
+	Kind    string
+	Header  types.MCPHeader
+	Binding *types.MCPSecretBinding
+}
+
+func MissingSecretBindings(ctx context.Context, c kclient.Client, obotNamespace string, envs []types.MCPEnv, remoteConfig *types.RemoteRuntimeConfig, allowedLabel string) ([]MissingSecretBinding, error) {
 	hasBinding := false
 	for _, env := range envs {
 		if env.SecretBinding != nil {
@@ -182,38 +186,49 @@ func ValidateSecretBindingsAvailable(ctx context.Context, c kclient.Client, obot
 		}
 	}
 	if !hasBinding {
-		return nil
+		return nil, nil
 	}
 	if c == nil {
-		return fmt.Errorf("secret bindings require a Kubernetes client")
+		return nil, fmt.Errorf("secret bindings require a Kubernetes client")
 	}
 
 	resolved, err := MergeBoundCreds(ctx, c, obotNamespace, envs, remoteConfig, nil, allowedLabel)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	check := func(kind, key string, b *types.MCPSecretBinding) error {
-		if b == nil {
-			return nil
-		}
-		if _, ok := resolved[key]; !ok {
-			return fmt.Errorf("secret binding %s %q references unavailable Kubernetes Secret %s/%s", kind, key, obotNamespace, b.Name)
-		}
-		return nil
-	}
-
+	var missing []MissingSecretBinding
 	for _, env := range envs {
-		if err := check("env", env.Key, env.SecretBinding); err != nil {
-			return err
+		if env.SecretBinding == nil {
+			continue
+		}
+		if _, ok := resolved[env.Key]; !ok {
+			missing = append(missing, MissingSecretBinding{Kind: "env", Header: env.MCPHeader, Binding: env.SecretBinding})
 		}
 	}
 	if remoteConfig != nil {
 		for _, header := range remoteConfig.Headers {
-			if err := check("header", header.Key, header.SecretBinding); err != nil {
-				return err
+			if header.SecretBinding == nil {
+				continue
+			}
+			if _, ok := resolved[header.Key]; !ok {
+				missing = append(missing, MissingSecretBinding{Kind: "header", Header: header, Binding: header.SecretBinding})
 			}
 		}
+	}
+	return missing, nil
+}
+
+// ValidateSecretBindingsAvailable verifies secret-bound config can be resolved
+// before creating/updating/launching a server that users cannot fix.
+func ValidateSecretBindingsAvailable(ctx context.Context, c kclient.Client, obotNamespace string, envs []types.MCPEnv, remoteConfig *types.RemoteRuntimeConfig, allowedLabel string) error {
+	missing, err := MissingSecretBindings(ctx, c, obotNamespace, envs, remoteConfig, allowedLabel)
+	if err != nil {
+		return err
+	}
+	if len(missing) > 0 {
+		field := missing[0]
+		return fmt.Errorf("secret binding %s %q references unavailable Kubernetes Secret %s/%s", field.Kind, field.Header.Key, obotNamespace, field.Binding.Name)
 	}
 	return nil
 }

--- a/pkg/mcp/secretbindings_test.go
+++ b/pkg/mcp/secretbindings_test.go
@@ -195,6 +195,14 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 
 		require.NoError(t, ValidateSecretBindingsAvailable(context.Background(), c, ns, nil, remote, label))
 	})
+
+	t.Run("reports all missing bindings", func(t *testing.T) {
+		remote := &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", Required: true, SecretBinding: binding("auth-secret", "token")}}}
+
+		err := ValidateSecretBindingsAvailable(context.Background(), newClient(t), ns, requiredEnv, remote, label)
+		require.Error(t, err)
+		assert.Equal(t, err.Error(), `secret bindings reference unavailable Kubernetes Secrets: env "API_KEY" references obot-ns/bound-secret, header "Authorization" references obot-ns/auth-secret`)
+	})
 }
 
 func TestMissingSecretBindings(t *testing.T) {

--- a/pkg/mcp/secretbindings_test.go
+++ b/pkg/mcp/secretbindings_test.go
@@ -117,6 +117,86 @@ func TestMergeBoundCreds(t *testing.T) {
 	})
 }
 
+func TestValidateSecretBindingsAvailable(t *testing.T) {
+	const ns = "obot-ns"
+	const label = "test-secret-binding-label"
+
+	newClient := func(t *testing.T, objects ...kclient.Object) kclient.Client {
+		t.Helper()
+		scheme := runtime.NewScheme()
+		require.NoError(t, corev1.AddToScheme(scheme))
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	}
+
+	requiredEnv := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", Required: true, SecretBinding: binding("bound-secret", "api_key")}}}
+
+	t.Run("valid secret", func(t *testing.T) {
+		c := newClient(t, &corev1.Secret{
+			Data:       map[string][]byte{"api_key": []byte("fresh")},
+			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+		})
+
+		require.NoError(t, ValidateSecretBindingsAvailable(context.Background(), c, ns, requiredEnv, nil, label))
+	})
+
+	t.Run("missing secret", func(t *testing.T) {
+		err := ValidateSecretBindingsAvailable(context.Background(), newClient(t), ns, requiredEnv, nil, label)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		c := newClient(t, &corev1.Secret{
+			Data:       map[string][]byte{"other": []byte("fresh")},
+			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+		})
+
+		err := ValidateSecretBindingsAvailable(context.Background(), c, ns, requiredEnv, nil, label)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
+	})
+
+	t.Run("empty value is treated as unavailable", func(t *testing.T) {
+		c := newClient(t, &corev1.Secret{
+			Data:       map[string][]byte{"api_key": []byte("")},
+			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+		})
+
+		err := ValidateSecretBindingsAvailable(context.Background(), c, ns, requiredEnv, nil, label)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
+	})
+
+	t.Run("unlabeled secret", func(t *testing.T) {
+		c := newClient(t, &corev1.Secret{
+			Data:       map[string][]byte{"api_key": []byte("fresh")},
+			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns},
+		})
+
+		err := ValidateSecretBindingsAvailable(context.Background(), c, ns, requiredEnv, nil, label)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
+	})
+
+	t.Run("binding is checked even when optional", func(t *testing.T) {
+		env := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", SecretBinding: binding("missing", "api_key")}}}
+
+		err := ValidateSecretBindingsAvailable(context.Background(), newClient(t), ns, env, nil, label)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
+	})
+
+	t.Run("remote header", func(t *testing.T) {
+		remote := &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", Required: true, SecretBinding: binding("auth-secret", "token")}}}
+		c := newClient(t, &corev1.Secret{
+			Data:       map[string][]byte{"token": []byte("Bearer abc")},
+			ObjectMeta: metav1.ObjectMeta{Name: "auth-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+		})
+
+		require.NoError(t, ValidateSecretBindingsAvailable(context.Background(), c, ns, nil, remote, label))
+	})
+}
+
 func TestListAllowedSecretBindingTargets(t *testing.T) {
 	const ns = "obot-ns"
 	const label = "test-secret-binding-label"

--- a/pkg/mcp/secretbindings_test.go
+++ b/pkg/mcp/secretbindings_test.go
@@ -197,6 +197,29 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 	})
 }
 
+func TestMissingSecretBindings(t *testing.T) {
+	const ns = "obot-ns"
+	const label = "test-secret-binding-label"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.Secret{
+		Data:       map[string][]byte{"env_key": []byte("fresh")},
+		ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+	}).Build()
+
+	missing, err := MissingSecretBindings(context.Background(), c, ns,
+		[]types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "ENV_KEY", SecretBinding: binding("bound-secret", "env_key")}}},
+		&types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", SecretBinding: binding("missing-secret", "token")}}},
+		label,
+	)
+	require.NoError(t, err)
+	require.Len(t, missing, 1)
+	assert.Equal(t, "header", missing[0].Kind)
+	assert.Equal(t, "Authorization", missing[0].Header.Key)
+	assert.Equal(t, binding("missing-secret", "token"), missing[0].Binding)
+}
+
 func TestListAllowedSecretBindingTargets(t *testing.T) {
 	const ns = "obot-ns"
 	const label = "test-secret-binding-label"

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -737,6 +737,8 @@
 			configDialog?.close();
 			onConnect?.({ server, entry });
 		} catch (err) {
+			launchError = err instanceof Error ? err.message : 'An unknown error occurred';
+			launchMissingSecretBinding = launchError.includes('secret binding');
 			if (created && !launchHandedOff) {
 				try {
 					if (workspaceID) {
@@ -750,7 +752,6 @@
 					console.error('Failed to clean up partially-created multi-user server', cleanupErr);
 				}
 			}
-			error = err instanceof Error ? err.message : 'An unknown error occurred';
 		} finally {
 			clearTimeout(timeout1);
 			clearTimeout(timeout2);
@@ -1165,16 +1166,30 @@
 							{/each}
 						</div>
 					{:else}
-						<p class="text-sm self-start">An issue occurred while launching the MCP server.</p>
+						<p class="text-sm self-start">{launchError}</p>
 					{/if}
 					{#if canModifyCatalogEntry}
 						<div class="flex w-full items-center gap-0.5">
-							<button
-								onclick={handleCancelLaunch}
-								class="flex grow items-center justify-center btn btn-secondary rounded-r-none!"
-							>
-								Cancel and Delete Server
-							</button>
+							{#if server}
+								<button
+									onclick={handleCancelLaunch}
+									class="flex grow items-center justify-center btn btn-secondary rounded-r-none!"
+								>
+									Cancel and Delete Server
+								</button>
+							{:else}
+								<button
+									class="flex grow items-center justify-center btn btn-secondary rounded-r-none!"
+									onclick={() => {
+										launchState = undefined;
+										launchError = undefined;
+										launchMissingSecretBinding = false;
+										configDialog?.close();
+									}}
+								>
+									Close
+								</button>
+							{/if}
 							<DotDotDot
 								class="btn btn-secondary btn-block w-14 rounded-l-none! p-0!"
 								disablePortal
@@ -1225,12 +1240,26 @@
 									Update Configuration and Try Again
 								</button>
 							{/if}
-							<button
-								class="btn btn-secondary w-full md:w-1/2 md:flex-1"
-								onclick={handleCancelLaunch}
-							>
-								Cancel and Delete Server
-							</button>
+							{#if server}
+								<button
+									class="btn btn-secondary w-full md:w-1/2 md:flex-1"
+									onclick={handleCancelLaunch}
+								>
+									Cancel and Delete Server
+								</button>
+							{:else}
+								<button
+									class="btn btn-secondary w-full md:w-1/2 md:flex-1"
+									onclick={() => {
+										launchState = undefined;
+										launchError = undefined;
+										launchMissingSecretBinding = false;
+										configDialog?.close();
+									}}
+								>
+									Close
+								</button>
+							{/if}
 						</div>
 					{/if}
 				</div>

--- a/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
+++ b/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
@@ -222,7 +222,14 @@
 			entry = matchingEntry;
 		}
 
-		if (server && !server.configured) {
+		const missingAdminSecret = server
+			? hasMissingSecretBindingConfig(
+					server.manifest,
+					server.missingRequiredEnvVars,
+					server.missingRequiredHeader
+				)
+			: false;
+		if (server && !server.configured && !missingAdminSecret) {
 			editExistingDialog?.edit({
 				server,
 				entry


### PR DESCRIPTION
Addresses #7077 

This prevents creating a multi-user MCP server from a catalog entry if the secret does not exist or is empty

<img width="718" height="271" alt="Screenshot 2026-07-02 at 15 11 32" src="https://github.com/user-attachments/assets/fda96f8c-1f51-49cb-84ac-da47b1ab4e10" />

