### PR TITLE
fix: default unknown model providers to OpenAI Chat Completions dialect

### DIFF
--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -406,11 +406,12 @@ type nanobotLLMProvider struct {
 // parseModelProvider returns the nanobot provider config and the fully-qualified
 // model name (provider/model) for a resolved model.
 //
-// If the provider has declared a dialect via ProviderMeta.Dialect, that dialect
-// is used and the base URL is derived from it. Otherwise the known built-in
-// providers (openai, anthropic) supply both; everything else falls back to
-// OpenAI Chat Completions via the generic /api/llm-proxy dispatch, since most
-// "OpenAI compatible" services only implement /v1/chat/completions.
+// If the model declares a dialect (resolvedLLMModel.ProviderDialect, populated
+// from the model manifest's Dialect field), that dialect is used and the base
+// URL is derived from it. Otherwise the known built-in providers (openai,
+// anthropic) supply both; everything else falls back to OpenAI Chat Completions
+// via the generic /api/llm-proxy dispatch, since most "OpenAI compatible"
+// services only implement /v1/chat/completions.
 func (h *Handler) parseModelProvider(model resolvedLLMModel) (nanobotLLMProvider, string) {
 	name := model.ModelProvider
 	envVarName := strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "_API_KEY"

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -409,7 +409,8 @@ type nanobotLLMProvider struct {
 // If the provider has declared a dialect via ProviderMeta.Dialect, that dialect
 // is used and the base URL is derived from it. Otherwise the known built-in
 // providers (openai, anthropic) supply both; everything else falls back to
-// OpenResponses via the generic /api/llm-proxy dispatch.
+// OpenAI Chat Completions via the generic /api/llm-proxy dispatch, since most
+// "OpenAI compatible" services only implement /v1/chat/completions.
 func (h *Handler) parseModelProvider(model resolvedLLMModel) (nanobotLLMProvider, string) {
 	name := model.ModelProvider
 	envVarName := strings.ToUpper(strings.ReplaceAll(name, "-", "_")) + "_API_KEY"
@@ -423,7 +424,7 @@ func (h *Handler) parseModelProvider(model resolvedLLMModel) (nanobotLLMProvider
 		case system.OpenAIModelProvider:
 			dialect = nanobottypes.DialectOpenAIResponses
 		default:
-			dialect = nanobottypes.DialectOpenResponses
+			dialect = nanobottypes.DialectOpenAIChatCompletions
 		}
 	}
 

--- a/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
@@ -149,7 +149,7 @@ func TestNanobotParseModelProviderBuiltinFallbacks(t *testing.T) {
 	}{
 		{system.OpenAIModelProvider, nanobottypes.DialectOpenAIResponses, "https://obot.example.com/api/llm-proxy/openai"},
 		{system.AnthropicModelProvider, nanobottypes.DialectAnthropicMessages, "https://obot.example.com/api/llm-proxy/anthropic"},
-		{"unknown-model-provider", nanobottypes.DialectOpenResponses, "https://obot.example.com/api/llm-proxy"},
+		{"unknown-model-provider", nanobottypes.DialectOpenAIChatCompletions, "https://obot.example.com/api/llm-proxy"},
 	} {
 		model := resolvedLLMModel{Name: "my-model", ModelProvider: tc.modelProvider}
 		p, qualifiedName := h.parseModelProvider(model)


### PR DESCRIPTION
## Problem

`parseModelProvider` falls back to `DialectOpenResponses` for any model provider that doesn't declare a dialect via `ProviderMeta.Dialect`. That makes nanobot POST to `/v1/responses` on the proxied endpoint. Most "OpenAI compatible" services — LM-Studio, Ollama, vLLM, llama.cpp — and Obot's own `generic-openai-model-provider` only implement `/v1/chat/completions`, so those providers are broken.

## Fix

Fall back to `DialectOpenAIChatCompletions` instead of `DialectOpenResponses` for providers without a declared dialect. Providers that explicitly declare a dialect, and the built-in openai/anthropic providers, are unaffected.

## Testing

- Updated `TestNanobotParseModelProviderBuiltinFallbacks` to expect the chat-completions dialect for an unknown provider.
- `go test ./pkg/controller/handlers/nanobotagent/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)