### PR TITLE
feat: support GitHub Enterprise Server for catalog and skill loading

### DIFF
--- a/pkg/controller/handlers/mcpcatalog/github.go
+++ b/pkg/controller/handlers/mcpcatalog/github.go
@@ -47,8 +47,25 @@ func gitCloneAuthAttempts(catalogToken, fallbackToken string) []gitCloneAuthAtte
 	return []gitCloneAuthAttempt{{name: "anonymous"}}
 }
 
+// isGitHubHost returns true for github.com or a GitHub Enterprise Server host
+// explicitly allowlisted via the OBOT_GITHUB_ENTERPRISE_HOSTS environment
+// variable (a comma-separated list of exact hostnames). Matching against an
+// allowlist avoids treating arbitrary hosts that merely contain "github"
+// (e.g. notgithub.example.com) as GitHub.
+func isGitHubHost(host string) bool {
+	if host == "github.com" {
+		return true
+	}
+	for _, h := range strings.Split(os.Getenv("OBOT_GITHUB_ENTERPRISE_HOSTS"), ",") {
+		if h = strings.TrimSpace(h); h != "" && strings.EqualFold(h, host) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsGitRepoURL returns true if the URL points to a git repository on a known
-// hosting platform (GitHub, GitLab) or ends with ".git".
+// hosting platform (GitHub, GitHub Enterprise, GitLab) or ends with ".git".
 func IsGitRepoURL(catalogURL string) bool {
 	if !strings.Contains(catalogURL, "://") {
 		catalogURL = "https://" + catalogURL
@@ -58,8 +75,7 @@ func IsGitRepoURL(catalogURL string) bool {
 	if err != nil {
 		return false
 	}
-	switch u.Host {
-	case "github.com", "gitlab.com":
+	if isGitHubHost(u.Host) || u.Host == "gitlab.com" {
 		return true
 	}
 	// Treat any HTTPS URL that contains ".git" as a path segment boundary as a git repo
@@ -73,14 +89,20 @@ func isGitRepoURL(catalogURL string) bool {
 }
 
 // checkGitHubRepoSize checks repo size via the GitHub API before cloning.
-func checkGitHubRepoSize(ctx context.Context, org, repo string, maxSizeMB int, token string) error {
+// For github.com it uses api.github.com; for GitHub Enterprise Server it uses
+// the host's /api/v3/ endpoint.
+func checkGitHubRepoSize(ctx context.Context, host, org, repo string, maxSizeMB int, token string) error {
 	if org == "obot-platform" {
 		return nil
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s", org, repo)
+	var apiURL string
+	if host == "github.com" {
+		apiURL = fmt.Sprintf("https://api.github.com/repos/%s/%s", org, repo)
+	} else {
+		apiURL = fmt.Sprintf("https://%s/api/v3/repos/%s/%s", host, org, repo)
+	}
 
-	// Create HTTP client with timeout
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 	}
@@ -291,8 +313,8 @@ func parseGitURL(catalogURL string) (string, string, error) {
 	// The repo is assumed to be at parts[1] (e.g. github.com/org/repo or gitlab.com/org/repo).
 	// Subgroups without .git are not supported; use the .git suffix form instead.
 	if repoPath == "" {
-		switch u.Host {
-		case "github.com", "gitlab.com":
+		switch {
+		case isGitHubHost(u.Host), u.Host == "gitlab.com":
 			repoPath = strings.Join(parts[:2], "/") + ".git"
 			if len(parts) > 2 {
 				branch = strings.Join(parts[2:], "/")
@@ -350,22 +372,22 @@ func readGitCatalogEntriesFromSubdir[T any](ctx context.Context, catalogURL stri
 	const maxRepoSizeMB = 100
 	repoPath := strings.TrimPrefix(strings.TrimPrefix(cloneURL, "https://"+u.Host+"/"), "/")
 	repoPath = strings.TrimSuffix(repoPath, ".git")
-	switch u.Host {
-	case "github.com":
+	switch {
+	case isGitHubHost(u.Host):
 		parts := strings.SplitN(repoPath, "/", 2)
 		if len(parts) == 2 {
 			apiToken := token
 			if apiToken == "" {
 				apiToken = fallbackToken
 			}
-			if err := checkGitHubRepoSize(ctx, parts[0], parts[1], maxRepoSizeMB, apiToken); err != nil {
+			if err := checkGitHubRepoSize(ctx, u.Host, parts[0], parts[1], maxRepoSizeMB, apiToken); err != nil {
 				if errors.Is(err, errRepoTooLarge) || isContextError(err) {
 					return nil, fmt.Errorf("repository size check failed: %w", err)
 				}
 				log.Warnf("GitHub catalog repository size check failed; continuing with clone-time size limit: repo=%s error=%v", repoPath, err)
 			}
 		}
-	case "gitlab.com":
+	case u.Host == "gitlab.com":
 		if err := checkGitLabRepoSize(ctx, u.Host, repoPath, maxRepoSizeMB, token); err != nil {
 			if errors.Is(err, errRepoTooLarge) || isContextError(err) {
 				return nil, fmt.Errorf("repository size check failed: %w", err)

--- a/pkg/controller/handlers/mcpcatalog/github.go
+++ b/pkg/controller/handlers/mcpcatalog/github.go
@@ -53,7 +53,7 @@ func gitCloneAuthAttempts(catalogToken, fallbackToken string) []gitCloneAuthAtte
 // allowlist avoids treating arbitrary hosts that merely contain "github"
 // (e.g. notgithub.example.com) as GitHub.
 func isGitHubHost(host string) bool {
-	if host == "github.com" {
+	if strings.EqualFold(host, "github.com") {
 		return true
 	}
 	for _, h := range strings.Split(os.Getenv("OBOT_GITHUB_ENTERPRISE_HOSTS"), ",") {
@@ -97,7 +97,7 @@ func checkGitHubRepoSize(ctx context.Context, host, org, repo string, maxSizeMB 
 	}
 
 	var apiURL string
-	if host == "github.com" {
+	if strings.EqualFold(host, "github.com") {
 		apiURL = fmt.Sprintf("https://api.github.com/repos/%s/%s", org, repo)
 	} else {
 		apiURL = fmt.Sprintf("https://%s/api/v3/repos/%s/%s", host, org, repo)
@@ -365,7 +365,13 @@ func readGitCatalogEntriesFromSubdir[T any](ctx context.Context, catalogURL stri
 		return nil, err
 	}
 
-	fallbackToken := os.Getenv("GITHUB_AUTH_TOKEN")
+	// Only fall back to GITHUB_AUTH_TOKEN for GitHub hosts, so the server-level
+	// GitHub credential is never sent (via API or clone BasicAuth) to GitLab or
+	// other self-hosted git endpoints.
+	var fallbackToken string
+	if isGitHubHost(u.Host) {
+		fallbackToken = os.Getenv("GITHUB_AUTH_TOKEN")
+	}
 
 	// Platform API pre-clone size checks: faster and more accurate than waiting
 	// for the clone to start. The generic clone-time check below acts as a fallback.

--- a/pkg/controller/handlers/mcpcatalog/github_test.go
+++ b/pkg/controller/handlers/mcpcatalog/github_test.go
@@ -31,6 +31,24 @@ func TestIsGitRepoURL(t *testing.T) {
 	}
 }
 
+func TestIsGitHubHostAllowlist(t *testing.T) {
+	// Without an allowlist, only github.com (case-insensitive) is recognized;
+	// a "github"-substring host must NOT be treated as GitHub.
+	assert.True(t, isGitHubHost("github.com"))
+	assert.True(t, isGitHubHost("GitHub.com"))
+	assert.False(t, isGitHubHost("github.enterprise.com"))
+	assert.False(t, isGitHubHost("notgithub.example.com"))
+
+	// With the allowlist set, listed enterprise hosts are recognized
+	// case-insensitively; unlisted "github" hosts remain rejected.
+	t.Setenv("OBOT_GITHUB_ENTERPRISE_HOSTS", "github.enterprise.com, ghe.internal")
+	assert.True(t, isGitHubHost("github.enterprise.com"))
+	assert.True(t, isGitHubHost("GHE.Internal"))
+	assert.True(t, isGitHubHost("github.com"))
+	assert.False(t, isGitHubHost("notgithub.example.com"))
+	assert.False(t, isGitHubHost("github.other.com"))
+}
+
 func TestReadMCPCatalogSetsSourceMetadata(t *testing.T) {
 	dir := t.TempDir()
 	assert.NoError(t, os.WriteFile(filepath.Join(dir, "entry.yaml"), []byte(`entryKey: test-entry

--- a/pkg/controller/handlers/skillrepository/github.go
+++ b/pkg/controller/handlers/skillrepository/github.go
@@ -58,7 +58,7 @@ type githubRepository struct {
 // variable (a comma-separated list of exact hostnames), matching the rule used
 // by the MCP catalog handler.
 func isGitHubHost(host string) bool {
-	if host == "github.com" {
+	if strings.EqualFold(host, "github.com") {
 		return true
 	}
 	for _, h := range strings.Split(os.Getenv("OBOT_GITHUB_ENTERPRISE_HOSTS"), ",") {
@@ -73,7 +73,7 @@ func isGitHubHost(host string) bool {
 // For github.com it returns the configured apiBaseURL (so tests can inject an
 // httptest URL). For GitHub Enterprise Server it derives https://<host>/api/v3.
 func (f *githubRepositoryFetcher) apiBaseFor(repo githubRepository) string {
-	if repo.Host == "github.com" {
+	if strings.EqualFold(repo.Host, "github.com") {
 		return f.apiBaseURL
 	}
 	return fmt.Sprintf("https://%s/api/v3", repo.Host)

--- a/pkg/controller/handlers/skillrepository/github.go
+++ b/pkg/controller/handlers/skillrepository/github.go
@@ -48,8 +48,44 @@ func (f *fetchedRepository) Cleanup() {
 }
 
 type githubRepository struct {
+	Host  string
 	Owner string
 	Repo  string
+}
+
+// isGitHubHost returns true for github.com or a GitHub Enterprise Server host
+// explicitly allowlisted via the OBOT_GITHUB_ENTERPRISE_HOSTS environment
+// variable (a comma-separated list of exact hostnames), matching the rule used
+// by the MCP catalog handler.
+func isGitHubHost(host string) bool {
+	if host == "github.com" {
+		return true
+	}
+	for _, h := range strings.Split(os.Getenv("OBOT_GITHUB_ENTERPRISE_HOSTS"), ",") {
+		if h = strings.TrimSpace(h); h != "" && strings.EqualFold(h, host) {
+			return true
+		}
+	}
+	return false
+}
+
+// apiBaseFor returns the GitHub REST API base for the given repository host.
+// For github.com it returns the configured apiBaseURL (so tests can inject an
+// httptest URL). For GitHub Enterprise Server it derives https://<host>/api/v3.
+func (f *githubRepositoryFetcher) apiBaseFor(repo githubRepository) string {
+	if repo.Host == "github.com" {
+		return f.apiBaseURL
+	}
+	return fmt.Sprintf("https://%s/api/v3", repo.Host)
+}
+
+// tokenFor returns the auth token to send for a request to the given
+// repository. GITHUB_AUTH_TOKEN is treated as the credential for whichever
+// GitHub host is in use, since deployments typically configure it for either
+// github.com or their GitHub Enterprise instance — not both. parseGitHubRepository
+// already restricts the host to github.com or a GHE-style host.
+func (f *githubRepositoryFetcher) tokenFor(_ githubRepository) string {
+	return f.token
 }
 
 type githubRepositoryMetadata struct {
@@ -139,8 +175,8 @@ func parseGitHubRepository(repoURL string) (githubRepository, error) {
 	if u.Scheme != "https" {
 		return githubRepository{}, fmt.Errorf("repository URL must use HTTPS")
 	}
-	if u.Host != "github.com" {
-		return githubRepository{}, fmt.Errorf("repository host must be github.com")
+	if !isGitHubHost(u.Host) {
+		return githubRepository{}, fmt.Errorf("repository host must be github.com or a GitHub Enterprise Server instance")
 	}
 	if u.User != nil {
 		return githubRepository{}, fmt.Errorf("repository URL must not include credentials")
@@ -149,10 +185,11 @@ func parseGitHubRepository(repoURL string) (githubRepository, error) {
 	trimmed := strings.Trim(strings.TrimSuffix(u.Path, ".git"), "/")
 	parts := strings.Split(trimmed, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return githubRepository{}, fmt.Errorf("repository URL must be of the form https://github.com/{owner}/{repo}")
+		return githubRepository{}, fmt.Errorf("repository URL must be of the form https://%s/{owner}/{repo}", u.Host)
 	}
 
 	return githubRepository{
+		Host:  u.Host,
 		Owner: parts[0],
 		Repo:  parts[1],
 	}, nil
@@ -160,7 +197,7 @@ func parseGitHubRepository(repoURL string) (githubRepository, error) {
 
 func (f *githubRepositoryFetcher) getRepositoryMetadata(ctx context.Context, repo githubRepository) (githubRepositoryMetadata, error) {
 	var metadata githubRepositoryMetadata
-	if err := f.getJSON(ctx, fmt.Sprintf("%s/repos/%s/%s", strings.TrimRight(f.apiBaseURL, "/"), repo.Owner, repo.Repo), &metadata); err != nil {
+	if err := f.getJSON(ctx, fmt.Sprintf("%s/repos/%s/%s", strings.TrimRight(f.apiBaseFor(repo), "/"), repo.Owner, repo.Repo), f.tokenFor(repo), &metadata); err != nil {
 		return githubRepositoryMetadata{}, err
 	}
 	return metadata, nil
@@ -168,7 +205,7 @@ func (f *githubRepositoryFetcher) getRepositoryMetadata(ctx context.Context, rep
 
 func (f *githubRepositoryFetcher) resolveCommitSHA(ctx context.Context, repo githubRepository, ref string) (string, error) {
 	var commit githubCommit
-	if err := f.getJSON(ctx, fmt.Sprintf("%s/repos/%s/%s/commits/%s", strings.TrimRight(f.apiBaseURL, "/"), repo.Owner, repo.Repo, url.PathEscape(ref)), &commit); err != nil {
+	if err := f.getJSON(ctx, fmt.Sprintf("%s/repos/%s/%s/commits/%s", strings.TrimRight(f.apiBaseFor(repo), "/"), repo.Owner, repo.Repo, url.PathEscape(ref)), f.tokenFor(repo), &commit); err != nil {
 		return "", err
 	}
 	if commit.SHA == "" {
@@ -179,7 +216,7 @@ func (f *githubRepositoryFetcher) resolveCommitSHA(ctx context.Context, repo git
 
 func (f *githubRepositoryFetcher) countRepositoryEntries(ctx context.Context, repo githubRepository, commitSHA string) (int, error) {
 	var tree githubTree
-	if err := f.getJSON(ctx, fmt.Sprintf("%s/repos/%s/%s/git/trees/%s?recursive=1", strings.TrimRight(f.apiBaseURL, "/"), repo.Owner, repo.Repo, url.PathEscape(commitSHA)), &tree); err != nil {
+	if err := f.getJSON(ctx, fmt.Sprintf("%s/repos/%s/%s/git/trees/%s?recursive=1", strings.TrimRight(f.apiBaseFor(repo), "/"), repo.Owner, repo.Repo, url.PathEscape(commitSHA)), f.tokenFor(repo), &tree); err != nil {
 		return 0, err
 	}
 	if tree.Truncated {
@@ -206,13 +243,13 @@ func (f *githubRepositoryFetcher) downloadArchive(ctx context.Context, repo gith
 		_ = os.RemoveAll(workspace)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/repos/%s/%s/zipball/%s", strings.TrimRight(f.apiBaseURL, "/"), repo.Owner, repo.Repo, url.PathEscape(ref)), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/repos/%s/%s/zipball/%s", strings.TrimRight(f.apiBaseFor(repo), "/"), repo.Owner, repo.Repo, url.PathEscape(ref)), nil)
 	if err != nil {
 		cleanup()
 		return nil, fmt.Errorf("failed to create archive request: %w", err)
 	}
-	if f.token != "" {
-		req.Header.Set("Authorization", "Bearer "+f.token)
+	if token := f.tokenFor(repo); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	resp, err := f.client.Do(req)
@@ -256,13 +293,13 @@ func (f *githubRepositoryFetcher) downloadArchive(ctx context.Context, repo gith
 	}, nil
 }
 
-func (f *githubRepositoryFetcher) getJSON(ctx context.Context, endpoint string, target any) error {
+func (f *githubRepositoryFetcher) getJSON(ctx context.Context, endpoint, token string, target any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create GitHub API request: %w", err)
 	}
-	if f.token != "" {
-		req.Header.Set("Authorization", "Bearer "+f.token)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	resp, err := f.client.Do(req)

--- a/pkg/controller/handlers/skillrepository/github_test.go
+++ b/pkg/controller/handlers/skillrepository/github_test.go
@@ -18,9 +18,11 @@ import (
 )
 
 func TestParseGitHubRepository(t *testing.T) {
+	t.Setenv("OBOT_GITHUB_ENTERPRISE_HOSTS", "github.enterprise.com")
 	tests := []struct {
 		name      string
 		url       string
+		wantHost  string
 		wantOwner string
 		wantRepo  string
 		wantErr   string
@@ -28,18 +30,35 @@ func TestParseGitHubRepository(t *testing.T) {
 		{
 			name:      "valid HTTPS URL",
 			url:       "https://github.com/owner/repo",
+			wantHost:  "github.com",
 			wantOwner: "owner",
 			wantRepo:  "repo",
 		},
 		{
 			name:      "valid with .git suffix",
 			url:       "https://github.com/owner/repo.git",
+			wantHost:  "github.com",
 			wantOwner: "owner",
 			wantRepo:  "repo",
 		},
 		{
 			name:      "valid with trailing slash",
 			url:       "https://github.com/owner/repo/",
+			wantHost:  "github.com",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			name:      "valid GitHub Enterprise host",
+			url:       "https://github.enterprise.com/owner/repo",
+			wantHost:  "github.enterprise.com",
+			wantOwner: "owner",
+			wantRepo:  "repo",
+		},
+		{
+			name:      "valid GitHub Enterprise with .git suffix",
+			url:       "https://github.enterprise.com/owner/repo.git",
+			wantHost:  "github.enterprise.com",
 			wantOwner: "owner",
 			wantRepo:  "repo",
 		},
@@ -56,6 +75,11 @@ func TestParseGitHubRepository(t *testing.T) {
 		{
 			name:    "non-github host",
 			url:     "https://gitlab.com/owner/repo",
+			wantErr: "github.com",
+		},
+		{
+			name:    "github-substring host not in allowlist rejected",
+			url:     "https://notgithub.example.com/owner/repo",
 			wantErr: "github.com",
 		},
 		{
@@ -104,6 +128,7 @@ func TestParseGitHubRepository(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			assert.Equal(t, tt.wantHost, got.Host)
 			assert.Equal(t, tt.wantOwner, got.Owner)
 			assert.Equal(t, tt.wantRepo, got.Repo)
 		})
@@ -111,8 +136,31 @@ func TestParseGitHubRepository(t *testing.T) {
 }
 
 func TestValidateRepositoryURL(t *testing.T) {
+	t.Setenv("OBOT_GITHUB_ENTERPRISE_HOSTS", "github.enterprise.com")
 	assert.NoError(t, ValidateRepositoryURL("https://github.com/owner/repo"))
+	assert.NoError(t, ValidateRepositoryURL("https://github.enterprise.com/owner/repo"))
 	assert.Error(t, ValidateRepositoryURL("http://github.com/owner/repo"))
+	assert.Error(t, ValidateRepositoryURL("https://gitlab.com/owner/repo"))
+}
+
+func TestGitHubRepositoryFetcher_RoutesByHost(t *testing.T) {
+	t.Run("github.com uses configured apiBaseURL", func(t *testing.T) {
+		f := &githubRepositoryFetcher{apiBaseURL: "https://override.example/api"}
+		got := f.apiBaseFor(githubRepository{Host: "github.com", Owner: "o", Repo: "r"})
+		assert.Equal(t, "https://override.example/api", got)
+	})
+
+	t.Run("GHE host derives /api/v3 base", func(t *testing.T) {
+		f := &githubRepositoryFetcher{apiBaseURL: "https://api.github.com"}
+		got := f.apiBaseFor(githubRepository{Host: "github.enterprise.com", Owner: "o", Repo: "r"})
+		assert.Equal(t, "https://github.enterprise.com/api/v3", got)
+	})
+
+	t.Run("token sent to both github.com and GHE hosts", func(t *testing.T) {
+		f := &githubRepositoryFetcher{token: "secret"}
+		assert.Equal(t, "secret", f.tokenFor(githubRepository{Host: "github.com"}))
+		assert.Equal(t, "secret", f.tokenFor(githubRepository{Host: "github.enterprise.com"}))
+	})
 }
 
 // zipEntry describes a single entry in a test ZIP archive.


### PR DESCRIPTION
## Problem

Loading MCP server catalogs and skill repositories hard-codes `github.com` in the host checks, API URL construction, and clone URLs, so GitHub Enterprise Server instances can't be used as a source.

## What's changed

- **Host recognition via an explicit allowlist.** `OBOT_GITHUB_ENTERPRISE_HOSTS` (comma-separated exact hostnames) plus `github.com`. An allowlist is used deliberately so arbitrary hosts that merely contain the substring "github" (e.g. `notgithub.example.com`) are **not** treated as GitHub.
- **API + clone URLs are host-aware.** GitHub Enterprise Server uses the host's `/api/v3/` endpoint (vs `api.github.com` for github.com); clone URLs are derived from the actual host.
- **`GITHUB_AUTH_TOKEN` fallback for any recognized GitHub host** (not just github.com), so a GHE-only deployment authenticates instead of silently sending unauthenticated requests and getting 401s. Non-GitHub hosts still receive no token.

## Testing

- Added tests for GHE host parsing/validation and a negative case proving a `github`-substring host not in the allowlist is rejected.
- `go test ./pkg/controller/handlers/mcpcatalog/... ./pkg/controller/handlers/skillrepository/...` passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)