### PR TITLE
fix: hydrate composite catalog entry refs

### DIFF
--- a/pkg/api/handlers/mcpcatalogs_test.go
+++ b/pkg/api/handlers/mcpcatalogs_test.go
@@ -1,10 +1,21 @@
 package handlers
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/storage"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestNormalizeName(t *testing.T) {
@@ -282,5 +293,87 @@ func TestValidateEntryVisibleFromScope(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestPopulateComponentManifestsHydratesMCPServerID(t *testing.T) {
+	server := &v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-server", Namespace: system.DefaultNamespace},
+		Spec: v1.MCPServerSpec{
+			MCPCatalogID: "default",
+			Manifest: types.MCPServerManifest{
+				Name:            "Shared Server",
+				Runtime:         types.RuntimeContainerized,
+				MultiUserConfig: &types.MultiUserConfig{UserDefinedHeaders: []types.MCPHeader{{Key: "API_KEY", Name: "API Key"}}},
+				ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+					Image: "example/shared:1.0.0",
+					Port:  8080,
+					Path:  "/mcp",
+				},
+			},
+		},
+	}
+	manifest := types.MCPServerCatalogEntryManifest{
+		Runtime: types.RuntimeComposite,
+		CompositeConfig: &types.CompositeCatalogConfig{ComponentServers: []types.CatalogComponentServer{
+			{MCPServerID: "shared-server"},
+		}},
+	}
+
+	err := (&MCPCatalogHandler{}).populateComponentManifests(newPopulateComponentManifestsRequest(server), &manifest, "default", "")
+
+	require.NoError(t, err)
+	require.Len(t, manifest.CompositeConfig.ComponentServers, 1)
+	component := manifest.CompositeConfig.ComponentServers[0]
+	assert.Equal(t, "shared-server", component.MCPServerID)
+	assert.Empty(t, component.CatalogEntryID)
+	assert.Equal(t, "Shared Server", component.Manifest.Name)
+	assert.Equal(t, types.RuntimeContainerized, component.Manifest.Runtime)
+	require.NotNil(t, component.Manifest.ContainerizedConfig)
+	assert.Equal(t, "example/shared:1.0.0", component.Manifest.ContainerizedConfig.Image)
+	require.NotNil(t, component.Manifest.MultiUserConfig)
+}
+
+func TestPopulateComponentManifestsHydratesSameCatalogEntryID(t *testing.T) {
+	entry := &v1.MCPServerCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: "component-entry", Namespace: system.DefaultNamespace},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			MCPCatalogName: "custom",
+			Manifest: types.MCPServerCatalogEntryManifest{
+				Name:           "Component Server",
+				Runtime:        types.RuntimeNPX,
+				ServerUserType: types.ServerUserTypeSingleUser,
+				NPXConfig:      &types.NPXRuntimeConfig{Package: "@example/component"},
+			},
+		},
+	}
+	manifest := types.MCPServerCatalogEntryManifest{
+		Runtime: types.RuntimeComposite,
+		CompositeConfig: &types.CompositeCatalogConfig{ComponentServers: []types.CatalogComponentServer{
+			{CatalogEntryID: "component-entry"},
+		}},
+	}
+
+	err := (&MCPCatalogHandler{}).populateComponentManifests(newPopulateComponentManifestsRequest(entry), &manifest, "custom", "")
+
+	require.NoError(t, err)
+	require.Len(t, manifest.CompositeConfig.ComponentServers, 1)
+	component := manifest.CompositeConfig.ComponentServers[0]
+	assert.Equal(t, "component-entry", component.CatalogEntryID)
+	assert.Empty(t, component.MCPServerID)
+	assert.Equal(t, "Component Server", component.Manifest.Name)
+	assert.Equal(t, types.RuntimeNPX, component.Manifest.Runtime)
+	require.NotNil(t, component.Manifest.NPXConfig)
+	assert.Equal(t, "@example/component", component.Manifest.NPXConfig.Package)
+}
+
+func newPopulateComponentManifestsRequest(objects ...client.Object) api.Context {
+	return api.Context{
+		Request:        httptest.NewRequest(http.MethodGet, "/", nil),
+		ResponseWriter: httptest.NewRecorder(),
+		Storage: storage.Client(fake.NewClientBuilder().
+			WithScheme(storagescheme.Scheme).
+			WithObjects(objects...).
+			Build()),
 	}
 }

--- a/pkg/controller/handlers/mcpcatalog/composite_refs_test.go
+++ b/pkg/controller/handlers/mcpcatalog/composite_refs_test.go
@@ -190,6 +190,40 @@ func TestResolveCompositeSourceRefsHydratesInternalIDComponents(t *testing.T) {
 	assert.Equal(t, "Gmail", component.Manifest.Name)
 }
 
+func TestResolveCompositeSourceRefsHydratesUICreatedSameCatalogEntry(t *testing.T) {
+	target := testCatalogEntry("ui-created-component", "", "", types.MCPServerCatalogEntryManifest{
+		Name:             "UI Created Component",
+		ShortDescription: "UI Created Component",
+		Description:      "UI Created Component",
+		Icon:             "icon",
+		Runtime:          types.RuntimeNPX,
+		NPXConfig:        &types.NPXRuntimeConfig{Package: "ui-created-component"},
+		ServerUserType:   types.ServerUserTypeSingleUser,
+	})
+	target.Namespace = "default"
+	target.Spec.MCPCatalogName = "default"
+	target.Spec.Editable = true
+	composite := testCatalogEntry("composite", "source", "composite.yaml", types.MCPServerCatalogEntryManifest{
+		Name:           "Composite",
+		Runtime:        types.RuntimeComposite,
+		ServerUserType: types.ServerUserTypeSingleUser,
+		CompositeConfig: &types.CompositeCatalogConfig{ComponentServers: []types.CatalogComponentServer{
+			{CatalogEntryID: "ui-created-component"},
+		}},
+	})
+	c := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(target).Build()
+
+	result, errsBySourceURL := (&Handler{}).resolveCompositeSourceRefs(t.Context(), c, "default", "default", []client.Object{composite})
+
+	assert.Empty(t, errsBySourceURL)
+	assert.Len(t, result, 1)
+	component := composite.Spec.Manifest.CompositeConfig.ComponentServers[0]
+	assert.Equal(t, "ui-created-component", component.CatalogEntryID)
+	assert.Equal(t, "UI Created Component", component.Manifest.Name)
+	require.NotNil(t, component.Manifest.NPXConfig)
+	assert.Equal(t, "ui-created-component", component.Manifest.NPXConfig.Package)
+}
+
 func TestResolveCompositeSourceRefsHydratesMultiUserServerIDComponents(t *testing.T) {
 	server := testMCPServer("shared-server", "default", types.MCPServerManifest{
 		Name:            "Shared Server",

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -268,6 +268,19 @@ func (h *Handler) resolveCompositeSourceRefs(ctx context.Context, c client.Clien
 			if target == nil {
 				target = entriesByName[component.CatalogEntryID]
 			}
+			if target == nil && c != nil {
+				var storedEntry v1.MCPServerCatalogEntry
+				if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: component.CatalogEntryID}, &storedEntry); err != nil && !apierrors.IsNotFound(err) {
+					errs = append(errs, fmt.Errorf("failed to get component catalog entry %q: %w", component.CatalogEntryID, err))
+					continue
+				} else if err == nil {
+					if catalogName != "" && storedEntry.Spec.MCPCatalogName != catalogName {
+						errs = append(errs, fmt.Errorf("component catalog entry %q not found in catalog %q", component.CatalogEntryID, catalogName))
+						continue
+					}
+					target = &storedEntry
+				}
+			}
 			if target == nil {
 				continue
 			}


### PR DESCRIPTION
Addresses: #7114 #7116

Look up MCPServerCatalogEntry for non-git-synced entries