### PR TITLE
fix: resolve composite server details components

### DIFF
--- a/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
@@ -170,9 +170,7 @@
 								</span>
 							{/if}
 						</div>
-						<IconButton class="invisible" disabled tabindex={-1} aria-hidden="true">
-							<ChevronRight class="size-6" />
-						</IconButton>
+						<div class="size-10 shrink-0"></div>
 					</div>
 				{/if}
 			{/each}

--- a/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
@@ -82,7 +82,8 @@
 				{@const catalogEntryServerId =
 					componentServer.catalogEntryID && serversMap.get(componentServer.catalogEntryID)?.id}
 				{@const multiUserServerId = componentServer.mcpServerID}
-				{@const componentExists = !!(catalogEntryServerId || multiUserServerId)}
+				{@const componentServerId = catalogEntryServerId || multiUserServerId}
+				{@const componentExists = !!componentServerId}
 				{@const deprecated = isDeprecatedMCPServer(componentServer)}
 
 				{#if componentExists}
@@ -123,8 +124,8 @@
 							</div>
 							<p class="text-sm">{componentServer.manifest?.name}</p>
 							<McpDeprecatedNotice {deprecated} child />
-							{#if catalogEntryServerId}
-								<span class="text-muted-content text-sm">({catalogEntryServerId})</span>
+							{#if componentServerId}
+								<span class="text-muted-content text-sm">({componentServerId})</span>
 							{/if}
 						</div>
 						<IconButton>
@@ -169,6 +170,9 @@
 								</span>
 							{/if}
 						</div>
+						<IconButton class="invisible" disabled tabindex={-1} aria-hidden="true">
+							<ChevronRight class="size-6" />
+						</IconButton>
 					</div>
 				{/if}
 			{/each}

--- a/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
@@ -36,20 +36,33 @@
 		$props();
 	let isAdminUrl = $derived(page.url.pathname.includes('/admin'));
 	let servers = $state<MCPCatalogServer[]>([]);
+	let loadingServers = $state(true);
+	let failedToLoadServers = $state(false);
 	let serversMap = $derived(new Map(servers.map((s) => [s.catalogEntryID || s.id, s])));
 
 	onMount(async () => {
-		if (!mcpServerId || !catalogEntry?.id || !entityId) return;
+		if (!mcpServerId || !catalogEntry?.id || !entityId) {
+			loadingServers = false;
+			return;
+		}
 
-		const deployedCatalogEntryServers =
-			await AdminService.listAllCatalogDeployedSingleRemoteServers(DEFAULT_MCP_CATALOG_ID);
-		const deployedWorkspaceCatalogEntryServers =
-			await AdminService.listAllWorkspaceDeployedSingleRemoteServers();
+		try {
+			const [deployedCatalogEntryServers, deployedWorkspaceCatalogEntryServers] = await Promise.all(
+				[
+					AdminService.listAllCatalogDeployedSingleRemoteServers(DEFAULT_MCP_CATALOG_ID),
+					AdminService.listAllWorkspaceDeployedSingleRemoteServers()
+				]
+			);
 
-		servers = [
-			...deployedCatalogEntryServers.filter((s) => s.compositeName === mcpServerId),
-			...deployedWorkspaceCatalogEntryServers.filter((s) => s.compositeName === mcpServerId)
-		];
+			servers = [
+				...deployedCatalogEntryServers.filter((s) => s.compositeName === mcpServerId),
+				...deployedWorkspaceCatalogEntryServers.filter((s) => s.compositeName === mcpServerId)
+			];
+		} catch {
+			failedToLoadServers = true;
+		} finally {
+			loadingServers = false;
+		}
 	});
 </script>
 
@@ -68,9 +81,8 @@
 			{#each catalogEntry.manifest.compositeConfig.componentServers as componentServer (componentServer.catalogEntryID || componentServer.mcpServerID)}
 				{@const catalogEntryServerId =
 					componentServer.catalogEntryID && serversMap.get(componentServer.catalogEntryID)?.id}
-				{@const mcpServerId =
-					componentServer.mcpServerID && serversMap.get(componentServer.mcpServerID)?.id}
-				{@const componentExists = !!(catalogEntryServerId || mcpServerId)}
+				{@const multiUserServerId = componentServer.mcpServerID}
+				{@const componentExists = !!(catalogEntryServerId || multiUserServerId)}
 				{@const deprecated = isDeprecatedMCPServer(componentServer)}
 
 				{#if componentExists}
@@ -137,13 +149,25 @@
 							</div>
 							<p class="text-sm">{componentServer.manifest?.name}</p>
 							<McpDeprecatedNotice {deprecated} child />
-							<span
-								class="text-muted-content flex items-center gap-1 text-xs"
-								title="This component server no longer exists"
-							>
-								<CircleAlert class="size-4" />
-								<span>Deleted</span>
-							</span>
+							{#if loadingServers}
+								<span class="text-muted-content text-xs">Loading...</span>
+							{:else if failedToLoadServers}
+								<span
+									class="text-muted-content flex items-center gap-1 text-xs"
+									title="Unable to determine whether this component server still exists"
+								>
+									<CircleAlert class="size-4" />
+									<span>Unavailable</span>
+								</span>
+							{:else}
+								<span
+									class="text-muted-content flex items-center gap-1 text-xs"
+									title="This component server no longer exists"
+								>
+									<CircleAlert class="size-4" />
+									<span>Deleted</span>
+								</span>
+							{/if}
 						</div>
 					</div>
 				{/if}


### PR DESCRIPTION
## Summary

- distinguish loading and failed lookups from deleted composite components
- resolve and display multi-user components from their MCP server IDs
- keep component row dimensions stable while deployment details load
- load catalog and workspace component deployments concurrently

Addresses #7125
Addresses #7127


https://github.com/user-attachments/assets/70411ecb-8f90-4bfa-b4bf-94047a5d36ce

Note that the top row of the servers is an existing multi-user server referenced by `mcpServerID` which is why it did not need to load like the others did.