### PR TITLE
fix: start Obot with a SQLite database

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/obot-platform/cmd v0.0.0-20260707150346-5103d461ab67
 	github.com/obot-platform/kinm v0.0.0-20260707163114-cfbe22091ffd
 	github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f
-	github.com/obot-platform/nanobot v0.0.89
+	github.com/obot-platform/nanobot v0.0.90
 	github.com/obot-platform/obot/apiclient v0.0.0-20250813183905-ade719c1e8bf
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00 h1
 github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00/go.mod h1:IBdiWaE+aSlf5TpqKhtDkpGwxPetHtjaScewJ/UoSGQ=
 github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f h1:yoMKu8I8gFlsBOSPs+guQdsSWscaipIjDIBIIl2a7ho=
 github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f/go.mod h1:m3e3C4G/Y/ZYRc6CdMj9n8JfVRCzIc7N8FUvjemsVtY=
-github.com/obot-platform/nanobot v0.0.89 h1:/h0bc6gz9F/cK09L0PPf3/bgaLRPSNIZxtV39jK1pm4=
-github.com/obot-platform/nanobot v0.0.89/go.mod h1:ZFecRkCv2RcMjatKKmWVdq1yuRwQa2yXXE83gdM3VNA=
+github.com/obot-platform/nanobot v0.0.90 h1:Yu0H+M8mb9venHViiVvOkW+qF3fQmoW6uaBi2mmcf5I=
+github.com/obot-platform/nanobot v0.0.90/go.mod h1:ZFecRkCv2RcMjatKKmWVdq1yuRwQa2yXXE83gdM3VNA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -40,7 +40,7 @@ type Handler struct {
 var errMCPServerRequiresConfiguration = errors.New("mcp server requires configuration")
 
 func NewHandler(ctx context.Context, mcpSessionManager *mcp.SessionManager, auditLogCollector auditlogs.Collector, serverURL, dsn, secretBindingAllowedLabel string) (*Handler, error) {
-	sessionStore, err := session.NewStoreFromDSN(nanobotSessionStoreDSN(dsn))
+	sessionStore, err := session.NewStoreFromDSN(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session store: %w", err)
 	}
@@ -90,13 +90,6 @@ func NewHandler(ctx context.Context, mcpSessionManager *mcp.SessionManager, audi
 		nanobot:                   nanobotHTTPServer,
 		secretBindingAllowedLabel: secretBindingAllowedLabel,
 	}, nil
-}
-
-func nanobotSessionStoreDSN(dsn string) string {
-	if sqliteDSN, ok := strings.CutPrefix(dsn, "sqlite://"); ok {
-		return "sqlite:" + sqliteDSN
-	}
-	return dsn
 }
 
 func (h *Handler) Proxy(req api.Context) error {

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -40,7 +40,7 @@ type Handler struct {
 var errMCPServerRequiresConfiguration = errors.New("mcp server requires configuration")
 
 func NewHandler(ctx context.Context, mcpSessionManager *mcp.SessionManager, auditLogCollector auditlogs.Collector, serverURL, dsn, secretBindingAllowedLabel string) (*Handler, error) {
-	sessionStore, err := session.NewStoreFromDSN(dsn)
+	sessionStore, err := session.NewStoreFromDSN(nanobotSessionStoreDSN(dsn))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session store: %w", err)
 	}
@@ -90,6 +90,13 @@ func NewHandler(ctx context.Context, mcpSessionManager *mcp.SessionManager, audi
 		nanobot:                   nanobotHTTPServer,
 		secretBindingAllowedLabel: secretBindingAllowedLabel,
 	}, nil
+}
+
+func nanobotSessionStoreDSN(dsn string) string {
+	if sqliteDSN, ok := strings.CutPrefix(dsn, "sqlite://"); ok {
+		return "sqlite:" + sqliteDSN
+	}
+	return dsn
 }
 
 func (h *Handler) Proxy(req api.Context) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,6 +25,20 @@ func Run(ctx context.Context, c services.Config) error {
 		return err
 	}
 
+	// Router construction migrates the Nanobot session schema. Finish it before
+	// controller initialization writes to the same SQLite database to avoid schema locks.
+	handler, err := router.Router(ctx, svcs)
+	if err != nil {
+		return err
+	}
+
+	if c.StaticDir != "" {
+		handler, err = static.Wrap(handler, c.StaticDir)
+		if err != nil {
+			return err
+		}
+	}
+
 	go func() {
 		ctrl, err := controller.New(svcs)
 		if err != nil {
@@ -37,18 +51,6 @@ func Run(ctx context.Context, c services.Config) error {
 			log.Fatalf("Failed to start controller: %v", err)
 		}
 	}()
-
-	handler, err := router.Router(ctx, svcs)
-	if err != nil {
-		return err
-	}
-
-	if c.StaticDir != "" {
-		handler, err = static.Wrap(handler, c.StaticDir)
-		if err != nil {
-			return err
-		}
-	}
 
 	if c.AllowedOrigin == "" {
 		c.AllowedOrigin = "*"


### PR DESCRIPTION
When Obot is started with SQLite, it fails to start.

Update Nanobot to new version that accepts `sqlite://` prefix.

Construct the API router before starting controllers so Nanobot session migrations finish before controller initialization writes to the same SQLite database. This avoids database schema lock failures during first startup.