### PR TITLE
fix: filter out /models requests by default in LLM audit logs

### DIFF
--- a/pkg/api/handlers/llmauditlog.go
+++ b/pkg/api/handlers/llmauditlog.go
@@ -90,17 +90,18 @@ func (h *LLMAuditLogHandler) ListFilterOptions(req api.Context) error {
 
 func parseLLMAuditLogOpts(query url.Values) gateway.LLMAuditLogOptions {
 	opts := gateway.LLMAuditLogOptions{
-		UserID:          parseStringList(query, "user_id"),
-		ModelProvider:   parseStringList(query, "model_provider"),
-		TargetModel:     parseStringList(query, "target_model"),
-		RequestPath:     parseStringList(query, "request_path"),
-		Outcome:         parseStringList(query, "outcome"),
-		Client:          parseStringList(query, "client"),
-		ClientSessionID: parseStringList(query, "client_session_id"),
-		Query:           strings.TrimSpace(query.Get("query")),
-		SortBy:          query.Get("sort_by"),
-		SortOrder:       query.Get("sort_order"),
-		StartTime:       time.Now().UTC().AddDate(0, 0, -30),
+		IncludeModelsRequests: query.Get("include_models_requests") == "true",
+		UserID:                parseStringList(query, "user_id"),
+		ModelProvider:         parseStringList(query, "model_provider"),
+		TargetModel:           parseStringList(query, "target_model"),
+		RequestPath:           parseStringList(query, "request_path"),
+		Outcome:               parseStringList(query, "outcome"),
+		Client:                parseStringList(query, "client"),
+		ClientSessionID:       parseStringList(query, "client_session_id"),
+		Query:                 strings.TrimSpace(query.Get("query")),
+		SortBy:                query.Get("sort_by"),
+		SortOrder:             query.Get("sort_order"),
+		StartTime:             time.Now().UTC().AddDate(0, 0, -30),
 	}
 	for _, value := range parseStringList(query, "message_policy_triggered") {
 		if triggered, err := strconv.ParseBool(value); err == nil {

--- a/pkg/api/handlers/llmauditlog.go
+++ b/pkg/api/handlers/llmauditlog.go
@@ -89,8 +89,9 @@ func (h *LLMAuditLogHandler) ListFilterOptions(req api.Context) error {
 }
 
 func parseLLMAuditLogOpts(query url.Values) gateway.LLMAuditLogOptions {
+	includeModelsRequests, _ := strconv.ParseBool(query.Get("include_models_requests"))
 	opts := gateway.LLMAuditLogOptions{
-		IncludeModelsRequests: query.Get("include_models_requests") == "true",
+		IncludeModelsRequests: includeModelsRequests,
 		UserID:                parseStringList(query, "user_id"),
 		ModelProvider:         parseStringList(query, "model_provider"),
 		TargetModel:           parseStringList(query, "target_model"),

--- a/pkg/api/handlers/llmauditlog_test.go
+++ b/pkg/api/handlers/llmauditlog_test.go
@@ -42,3 +42,27 @@ func TestParseLLMAuditLogOptsParsesFilterFields(t *testing.T) {
 		t.Fatalf("expected input policy trigger values [true false], got %v", got)
 	}
 }
+
+func TestParseLLMAuditLogOptsIncludeModelsRequests(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "absent defaults false"},
+		{name: "false", value: "false"},
+		{name: "invalid", value: "invalid"},
+		{name: "true", value: "true", want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			query := url.Values{}
+			if tt.value != "" {
+				query.Set("include_models_requests", tt.value)
+			}
+
+			if got := parseLLMAuditLogOpts(query).IncludeModelsRequests; got != tt.want {
+				t.Fatalf("expected IncludeModelsRequests=%t, got %t", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/api/handlers/llmauditlog_test.go
+++ b/pkg/api/handlers/llmauditlog_test.go
@@ -53,6 +53,9 @@ func TestParseLLMAuditLogOptsIncludeModelsRequests(t *testing.T) {
 		{name: "false", value: "false"},
 		{name: "invalid", value: "invalid"},
 		{name: "true", value: "true", want: true},
+		{name: "uppercase true", value: "TRUE", want: true},
+		{name: "one", value: "1", want: true},
+		{name: "short true", value: "t", want: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			query := url.Values{}

--- a/pkg/gateway/client/llmauditlog.go
+++ b/pkg/gateway/client/llmauditlog.go
@@ -213,6 +213,9 @@ func (c *Client) runLLMAuditPersistenceLoop(ctx context.Context, batchSize int, 
 }
 
 func applyLLMAuditLogOptions(db *gorm.DB, opts LLMAuditLogOptions) *gorm.DB {
+	if !opts.IncludeModelsRequests {
+		db = db.Where("request_path NOT LIKE ? AND request_path NOT LIKE ?", "%/models", "%/models/")
+	}
 	if opts.Query != "" {
 		searchTerm := "%" + opts.Query + "%"
 		like := "LIKE"
@@ -465,6 +468,7 @@ func llmAuditLogDataCtx(log *types.LLMAuditLog) value.Context {
 
 type LLMAuditLogOptions struct {
 	WithSensitiveFields    bool
+	IncludeModelsRequests  bool
 	UserID                 []string
 	ModelProvider          []string
 	TargetModel            []string

--- a/pkg/gateway/client/llmauditlog_test.go
+++ b/pkg/gateway/client/llmauditlog_test.go
@@ -219,6 +219,56 @@ func TestGetLLMAuditLogsFiltersAndStripsSensitiveFields(t *testing.T) {
 	}
 }
 
+func TestGetLLMAuditLogsExcludesModelsRequestsByDefault(t *testing.T) {
+	c := newTestClient(t)
+	now := time.Now().UTC()
+	for _, path := range []string{
+		"/api/llm-proxy/openai/v1/responses",
+		"/api/llm-proxy/openai/models",
+		"/api/llm-proxy/openai/v1/models",
+		"/api/llm-proxy/anthropic/models/",
+		"/api/llm-proxy/openai/models/model-1",
+	} {
+		entry := types.LLMAuditLog{ID: uuid.NewString(), CreatedAt: now, RequestPath: path}
+		if err := c.InsertLLMAuditLog(t.Context(), &entry); err != nil {
+			t.Fatalf("failed to insert LLM audit log for %q: %v", path, err)
+		}
+	}
+
+	logs, total, err := c.GetLLMAuditLogs(t.Context(), LLMAuditLogOptions{})
+	if err != nil {
+		t.Fatalf("failed to list LLM audit logs: %v", err)
+	}
+	if total != 2 || len(logs) != 2 {
+		t.Fatalf("expected two non-models requests, got total=%d len=%d", total, len(logs))
+	}
+	paths := []string{logs[0].RequestPath, logs[1].RequestPath}
+	slices.Sort(paths)
+	if !slices.Equal(paths, []string{
+		"/api/llm-proxy/openai/models/model-1",
+		"/api/llm-proxy/openai/v1/responses",
+	}) {
+		t.Fatalf("expected non-models request paths, got %v", paths)
+	}
+
+	logs, total, err = c.GetLLMAuditLogs(t.Context(), LLMAuditLogOptions{IncludeModelsRequests: true})
+	if err != nil {
+		t.Fatalf("failed to list all LLM audit logs: %v", err)
+	}
+	if total != 5 || len(logs) != 5 {
+		t.Fatalf("expected all requests, got total=%d len=%d", total, len(logs))
+	}
+
+	options, err := c.GetLLMAuditLogFilterOptions(t.Context(), "request_path", LLMAuditLogOptions{}, "")
+	if err != nil {
+		t.Fatalf("failed to list request path options: %v", err)
+	}
+	slices.Sort(options)
+	if !slices.Equal(options, paths) {
+		t.Fatalf("expected filtered request path options %v, got %v", paths, options)
+	}
+}
+
 func TestGetLLMAuditLogFilterOptions(t *testing.T) {
 	c := newTestClient(t)
 	if !c.db.WithContext(t.Context()).Migrator().HasIndex(&types.LLMAuditLog{}, "idx_llm_audit_message_policy_triggered_created") {

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogDetails.svelte
@@ -82,4 +82,10 @@
 			{/each}
 		</div>
 	{/snippet}
+
+	{#snippet additRequestContent(data)}
+		{#if data.requestPath}
+			<p class="break-all"><span class="font-medium">Request Path</span>: {data.requestPath}</p>
+		{/if}
+	{/snippet}
 </AuditLogDetails>

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogDetails.svelte
@@ -84,8 +84,9 @@
 	{/snippet}
 
 	{#snippet additRequestContent(data)}
-		{#if data.requestPath}
-			<p class="break-all"><span class="font-medium">Request Path</span>: {data.requestPath}</p>
+		{@const requestURL = [data.requestMethod, data.requestPath].filter(Boolean).join(' ')}
+		{#if requestURL}
+			<p class="break-all"><span class="font-medium">Request URL</span>: {requestURL}</p>
 		{/if}
 	{/snippet}
 </AuditLogDetails>

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -60,6 +60,10 @@
 	let includeModelsRequests = $derived(
 		page.url.searchParams.get('include_models_requests') === 'true'
 	);
+	let includeModelsRequestsDraft = $state(false);
+	$effect(() => {
+		includeModelsRequestsDraft = includeModelsRequests;
+	});
 	let usersMap = $derived(new Map(users.map((user) => [user.id, user])));
 
 	const DEFER_THRESHOLD = 500;
@@ -256,6 +260,7 @@
 			<button
 				class="btn btn-neutral h-12.5"
 				onclick={() => {
+					includeModelsRequestsDraft = includeModelsRequests;
 					showFilters = true;
 					selectedAuditLog = undefined;
 					rightSidebar?.showPopover();
@@ -367,7 +372,8 @@
 				{
 					property: 'include_models_requests',
 					label: 'Show model discovery requests',
-					selected: includeModelsRequests
+					selected: includeModelsRequestsDraft,
+					onChange: (selected) => (includeModelsRequestsDraft = selected)
 				}
 			]}
 			getUserDisplayName={(...args) => getUserDisplayName(usersMap, ...args)}

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -57,6 +57,9 @@
 	const isReachedMax = $derived(pageIndex >= numberOfPages - 1);
 
 	let query = $derived(page.url.searchParams.get('query') ?? '');
+	let includeModelsRequests = $derived(
+		page.url.searchParams.get('include_models_requests') === 'true'
+	);
 	let usersMap = $derived(new Map(users.map((user) => [user.id, user])));
 
 	const DEFER_THRESHOLD = 500;
@@ -127,6 +130,7 @@
 		end_time: timeRangeFilters.endTime.toISOString(),
 		limit: pageLimit,
 		offset: pageOffset,
+		include_models_requests: includeModelsRequests.toString(),
 		query
 	});
 
@@ -134,6 +138,7 @@
 		JSON.stringify({
 			...pillsSearchParamFilters,
 			query,
+			include_models_requests: includeModelsRequests,
 			start_time: timeRangeFilters.startTime.toISOString(),
 			end_time: timeRangeFilters.endTime.toISOString()
 		})
@@ -358,6 +363,13 @@
 			filters={{ ...searchParamFilters }}
 			isFilterDisabled={() => false}
 			isFilterClearable={() => true}
+			booleanFilters={[
+				{
+					property: 'include_models_requests',
+					label: 'Show model discovery requests',
+					selected: includeModelsRequests
+				}
+			]}
 			getUserDisplayName={(...args) => getUserDisplayName(usersMap, ...args)}
 			{getFilterDisplayLabel}
 			getFilterOptionLabel={(key, value) =>
@@ -369,6 +381,7 @@
 			endpoint={async (filterId, opts) => {
 				const response = await AdminService.listLLMAuditLogFilterOptions(filterId, {
 					...opts,
+					include_models_requests: includeModelsRequests.toString(),
 					start_time: timeRangeFilters.startTime.toISOString(),
 					end_time: timeRangeFilters.endTime.toISOString()
 				});

--- a/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
@@ -23,10 +23,11 @@
 	) => Promise<{ options: string[] } | undefined>;
 
 	type BooleanFilter = {
-		property: string;
+		property: FilterKey;
 		label: string;
 		selected: boolean;
 		default?: boolean;
+		onChange: (selected: boolean) => void;
 	};
 
 	interface Props {
@@ -59,9 +60,6 @@
 	}: Props = $props();
 
 	let filters = $derived({ ...(externFilters ?? {}) } as Partial<T>);
-	let booleanFilters = $state(
-		untrack(() => externalBooleanFilters.map((filter) => ({ ...filter })))
-	);
 
 	type FilterOptions = Record<FilterKey, FilterOption[]>;
 	let filtersOptions: FilterOptions = $state({} as FilterOptions);
@@ -159,7 +157,7 @@
 				}
 			}
 		}
-		for (const filter of booleanFilters) {
+		for (const filter of externalBooleanFilters) {
 			if (filter.selected === (filter.default ?? false)) {
 				url.searchParams.delete(filter.property);
 			} else {
@@ -180,8 +178,8 @@
 			.forEach((filterInput) => {
 				filterInput.selected = '';
 			});
-		booleanFilters.forEach((filter) => {
-			filter.selected = filter.default ?? false;
+		externalBooleanFilters.forEach((filter) => {
+			filter.onChange(filter.default ?? false);
 		});
 	}
 </script>
@@ -198,14 +196,10 @@
 	<div
 		class="default-scrollbar-thin flex h-[calc(100%-60px)] w-full flex-col gap-4 overflow-y-auto p-4 pt-0"
 	>
-		{#each booleanFilters as filter (filter.property)}
+		{#each externalBooleanFilters as filter (filter.property)}
 			<div class="border-base-300 flex items-center justify-between gap-4 rounded-lg border p-4">
 				<span class="text-sm font-medium">{filter.label}</span>
-				<Toggle
-					label={filter.label}
-					checked={filter.selected}
-					onChange={(checked) => (filter.selected = checked)}
-				/>
+				<Toggle label={filter.label} checked={filter.selected} onChange={filter.onChange} />
 			</div>
 		{/each}
 		{#each filterInputsAsArray as filterInput, index (filterInput.property)}

--- a/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" generics="T extends Record<string, string | number | null | undefined>">
 	import { page } from '$app/state';
+	import Toggle from '$lib/components/Toggle.svelte';
 	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import { UserService } from '$lib/services';
 	import { AUDIT_LOG_FILTER_OPTIONS_LIMIT } from '$lib/services/user/constants';
@@ -21,6 +22,13 @@
 		filters?: Partial<T>
 	) => Promise<{ options: string[] } | undefined>;
 
+	type BooleanFilter = {
+		property: string;
+		label: string;
+		selected: boolean;
+		default?: boolean;
+	};
+
 	interface Props {
 		filters?: Partial<T>;
 		isFilterDisabled?: (key: FilterKey) => boolean;
@@ -33,6 +41,7 @@
 		getFilterOptionLabel?: (key: string, value: string) => string;
 		getDefaultValue?: <K extends FilterKey>(filter: K) => T[K] | undefined;
 		endpoint?: FilterOptionsEndpoint;
+		booleanFilters?: BooleanFilter[];
 	}
 
 	let {
@@ -45,10 +54,14 @@
 		getFilterOptionLabel,
 		getDefaultValue,
 		filterOptions,
+		booleanFilters: externalBooleanFilters = [],
 		endpoint = UserService.listMcpAuditLogFilterOptions as FilterOptionsEndpoint
 	}: Props = $props();
 
 	let filters = $derived({ ...(externFilters ?? {}) } as Partial<T>);
+	let booleanFilters = $state(
+		untrack(() => externalBooleanFilters.map((filter) => ({ ...filter })))
+	);
 
 	type FilterOptions = Record<FilterKey, FilterOption[]>;
 	let filtersOptions: FilterOptions = $state({} as FilterOptions);
@@ -146,6 +159,13 @@
 				}
 			}
 		}
+		for (const filter of booleanFilters) {
+			if (filter.selected === (filter.default ?? false)) {
+				url.searchParams.delete(filter.property);
+			} else {
+				url.searchParams.set(filter.property, filter.selected.toString());
+			}
+		}
 
 		await goto(url, { noScroll: true });
 
@@ -160,6 +180,9 @@
 			.forEach((filterInput) => {
 				filterInput.selected = '';
 			});
+		booleanFilters.forEach((filter) => {
+			filter.selected = filter.default ?? false;
+		});
 	}
 </script>
 
@@ -175,6 +198,16 @@
 	<div
 		class="default-scrollbar-thin flex h-[calc(100%-60px)] w-full flex-col gap-4 overflow-y-auto p-4 pt-0"
 	>
+		{#each booleanFilters as filter (filter.property)}
+			<div class="border-base-300 flex items-center justify-between gap-4 rounded-lg border p-4">
+				<span class="text-sm font-medium">{filter.label}</span>
+				<Toggle
+					label={filter.label}
+					checked={filter.selected}
+					onChange={(checked) => (filter.selected = checked)}
+				/>
+			</div>
+		{/each}
 		{#each filterInputsAsArray as filterInput, index (filterInput.property)}
 			<AuditFilter
 				filter={filterInput}

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -521,8 +521,9 @@ export type LLMAuditLogURLFilters = {
 	client?: string | null;
 	client_session_id?: string | null;
 	end_time?: string | null;
-	message_policy_triggered?: string | null;
+	include_models_requests?: string | null;
 	limit?: number | null;
+	message_policy_triggered?: string | null;
 	model_provider?: string | null;
 	offset?: number | null;
 	outcome?: string | null;


### PR DESCRIPTION
## Summary

Addresses #7147 

- Add new `include_models_requests` query param which defaults to `false` and filters out based on `/models` in request path
- Add UI toggle for it
- Show Request URL in the details panel