### PR TITLE
fix: enforce buttons in form don't trigger submit

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -691,8 +691,14 @@
 		delete showInvalid[field];
 	}
 
-	function handleFormSubmit(e: Event) {
+	function handleFormSubmit(e: SubmitEvent) {
 		e.preventDefault();
+		if (
+			e.submitter instanceof HTMLElement &&
+			e.submitter.getAttribute('data-form-action') !== 'save'
+		) {
+			return;
+		}
 		handleSubmit();
 	}
 </script>
@@ -1028,6 +1034,7 @@
 			</button>
 			<button
 				type="submit"
+				data-form-action="save"
 				class="btn btn-primary flex items-center gap-1"
 				disabled={loading ||
 					(formData.runtime === 'composite' &&

--- a/ui/user/src/lib/components/mcp/ContainerizedRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/ContainerizedRuntimeForm.svelte
@@ -270,6 +270,7 @@
 				{#if !readonly}
 					<div class="flex justify-end">
 						<button
+							type="button"
 							class="btn btn-secondary btn-sm flex items-center gap-1 text-xs"
 							onclick={addArgument}
 						>

--- a/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
@@ -260,6 +260,7 @@
 			<div class="flex justify-end">
 				<button
 					class="btn btn-secondary btn-sm flex items-center gap-1 text-xs"
+					type="button"
 					onclick={() => {
 						if (config) {
 							config.push({

--- a/ui/user/src/lib/components/mcp/MultiUserHeadersForm.svelte
+++ b/ui/user/src/lib/components/mcp/MultiUserHeadersForm.svelte
@@ -122,6 +122,7 @@
 	{#if !readonly}
 		<div class="flex justify-end">
 			<button
+				type="button"
 				class="btn btn-secondary btn-sm flex items-center gap-1 text-xs"
 				onclick={() => {
 					if (!headers) {

--- a/ui/user/src/lib/components/mcp/NpxRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/NpxRuntimeForm.svelte
@@ -174,7 +174,11 @@
 
 				{#if !readonly}
 					<div class="flex justify-end">
-						<button class="btn btn-secondary btn-sm flex items-center gap-1" onclick={addArgument}>
+						<button
+							type="button"
+							class="btn btn-secondary btn-sm flex items-center gap-1"
+							onclick={addArgument}
+						>
 							<Plus class="size-4" /> Argument
 						</button>
 					</div>

--- a/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
@@ -232,6 +232,7 @@
 			{#if !readonly}
 				<div class="flex justify-end">
 					<button
+						type="button"
 						class="btn btn-secondary btn-sm flex items-center gap-1"
 						onclick={() => {
 							if (!config.headers) {
@@ -530,6 +531,7 @@
 
 {#if variant === 'catalog'}
 	<button
+		type="button"
 		class="btn btn-text pl-0"
 		onclick={() => {
 			showAdvanced = !showAdvanced;

--- a/ui/user/src/lib/components/mcp/UvxRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/UvxRuntimeForm.svelte
@@ -191,7 +191,11 @@
 
 				{#if !readonly}
 					<div class="flex justify-end">
-						<button class="btn btn-secondary btn-sm flex items-center gap-1" onclick={addArgument}>
+						<button
+							type="button"
+							class="btn btn-secondary btn-sm flex items-center gap-1"
+							onclick={addArgument}
+						>
 							<Plus class="size-4" /> Argument
 						</button>
 					</div>


### PR DESCRIPTION
For better form accessibility, CatalogServerForm was updated with a `<form>` wrapper, but buttons included in the form without type="button" triggered the form submission. This addresses the issues of other buttons triggering the submit handler in `<form>` by applying type="button" and enforcing that the submit button must be the one triggered.

Addresses #7161 

For testing:
- Created MCP Catalog Entry Hosted Server, clicked every button encapsulated under form
- Created MCP Catalog Entry Remote Server, clicked every button encapsulated under form
- Created MCP Catalog Entry Composite Server, clicked buttons for Add Server -> Skip Tools / Configure Tools