### PR TITLE
fix(mcp): bound retired remote sessions

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -17,10 +17,23 @@ import (
 
 const oauthCheckClientScope = "Obot OAuth Check"
 
+type clientTokenService interface {
+	NewToken(context.Context, persistent.TokenContext) (*jwt.Token, string, error)
+}
+
 type Client struct {
 	*nmcp.Client
 
-	jwt *jwt.Token
+	jwt        *jwt.Token
+	serverName string
+	cacheID    string
+	retireOnce sync.Once
+}
+
+func (c *Client) retire() {
+	c.retireOnce.Do(func() {
+		c.Client.Close(true)
+	})
 }
 
 func (c *Client) hasValidToken() bool {
@@ -78,11 +91,9 @@ func (sm *SessionManager) loadSession(ctx context.Context, server ServerConfig, 
 			return c, nil
 		}
 
-		clientSessions.Delete(clientScope)
-		go func() {
-			time.Sleep(time.Minute)
-			c.Close(false)
-		}()
+		if clientSessions.CompareAndDelete(clientScope, c) {
+			sm.deferClientRetirement(c)
+		}
 	}
 
 	sm.contextLock.Lock()
@@ -134,27 +145,95 @@ func (sm *SessionManager) loadSession(ctx context.Context, server ServerConfig, 
 	}
 
 	result := &Client{
-		Client: c,
-		jwt:    jwtToken,
+		Client:     c,
+		jwt:        jwtToken,
+		serverName: server.MCPServerName,
+		cacheID:    clientScope,
 	}
 
-	res, ok := clientSessions.LoadOrStore(clientScope, result)
-	if ok {
+	for {
+		res, loaded := clientSessions.LoadOrStore(clientScope, result)
+		if !loaded {
+			return result, nil
+		}
+
 		existing := res.(*Client)
 		if existing.hasValidToken() {
-			result.Close(false)
+			result.retire()
 			return existing, nil
 		}
 
-		// Swap the existing client with the new one and close the old one.
-		clientSessions.Swap(clientScope, result)
-		go func() {
-			time.Sleep(time.Minute)
-			existing.Close(false)
-		}()
+		// Replace only the client we observed. A concurrent caller may have already
+		// installed a newer client, in which case retry against the current value.
+		if clientSessions.CompareAndSwap(clientScope, existing, result) {
+			sm.deferClientRetirement(existing)
+			return result, nil
+		}
+	}
+}
+
+func (sm *SessionManager) deferClientRetirement(client *Client) {
+	if sm.clientRetirementDelay <= 0 {
+		client.retire()
+		return
 	}
 
-	return result, nil
+	entry := &retiredClient{client: client}
+
+	sm.retiredClientsLock.Lock()
+	if sm.retiredClients == nil {
+		sm.retiredClients = map[string]*retiredClient{}
+	}
+
+	previous := sm.retiredClients[client.serverName]
+	sm.retiredClients[client.serverName] = entry
+	entry.timer = time.AfterFunc(sm.clientRetirementDelay, func() {
+		sm.expireRetiredClient(client.serverName, entry)
+	})
+	sm.retiredClientsLock.Unlock()
+
+	// Keep at most one client in the grace period for each MCP server. This
+	// bounds the remote process fan-out to the current session plus one retiring
+	// session even during a reconnect burst.
+	if previous != nil {
+		previous.timer.Stop()
+		previous.client.retire()
+	}
+}
+
+func (sm *SessionManager) expireRetiredClient(serverName string, target *retiredClient) {
+	sm.retiredClientsLock.Lock()
+	if sm.retiredClients[serverName] != target {
+		sm.retiredClientsLock.Unlock()
+		return
+	}
+	delete(sm.retiredClients, serverName)
+	sm.retiredClientsLock.Unlock()
+
+	target.client.retire()
+}
+
+func (sm *SessionManager) flushRetiredClients(serverName, cacheID string) {
+	var retiredClients []*retiredClient
+
+	sm.retiredClientsLock.Lock()
+	for name, retired := range sm.retiredClients {
+		if serverName != "" && name != serverName {
+			continue
+		}
+		if cacheID != "" && retired.client.cacheID != cacheID {
+			continue
+		}
+
+		retiredClients = append(retiredClients, retired)
+		delete(sm.retiredClients, name)
+	}
+	sm.retiredClientsLock.Unlock()
+
+	for _, retired := range retiredClients {
+		retired.timer.Stop()
+		retired.client.retire()
+	}
 }
 
 func copyListIntoMap(m map[string]string, list []string) {

--- a/pkg/mcp/client_lifecycle_test.go
+++ b/pkg/mcp/client_lifecycle_test.go
@@ -1,0 +1,294 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	nmcp "github.com/obot-platform/nanobot/pkg/mcp"
+	"github.com/obot-platform/obot/pkg/jwt/persistent"
+)
+
+type lifecycleTokenService struct {
+	next atomic.Int64
+}
+
+func (s *lifecycleTokenService) NewToken(_ context.Context, claims persistent.TokenContext) (*jwt.Token, string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	return token, fmt.Sprintf("test-token-%d", s.next.Add(1)), nil
+}
+
+type lifecycleMCPServer struct {
+	server *httptest.Server
+
+	initializeStarted chan struct{}
+	releaseInitialize <-chan struct{}
+
+	nextSession atomic.Int64
+
+	mu      sync.Mutex
+	deletes map[string]int
+}
+
+func newLifecycleMCPServer(t *testing.T, initializeStarted chan struct{}, releaseInitialize <-chan struct{}) *lifecycleMCPServer {
+	t.Helper()
+
+	s := &lifecycleMCPServer{
+		initializeStarted: initializeStarted,
+		releaseInitialize: releaseInitialize,
+		deletes:           map[string]int{},
+	}
+	s.server = httptest.NewServer(http.HandlerFunc(s.serveHTTP))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func (s *lifecycleMCPServer) serveHTTP(w http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case http.MethodPost:
+		var msg struct {
+			ID     any    `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&msg); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if msg.Method != "initialize" {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		sessionID := fmt.Sprintf("session-%d", s.nextSession.Add(1))
+		if s.initializeStarted != nil {
+			s.initializeStarted <- struct{}{}
+		}
+		if s.releaseInitialize != nil {
+			<-s.releaseInitialize
+		}
+
+		w.Header().Set(nmcp.SessionIDHeader, sessionID)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      msg.ID,
+			"result":  map[string]any{},
+		})
+	case http.MethodDelete:
+		sessionID := req.Header.Get(nmcp.SessionIDHeader)
+		s.mu.Lock()
+		s.deletes[sessionID]++
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		http.NotFound(w, req)
+	}
+}
+
+func (s *lifecycleMCPServer) deleteCount(sessionID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.deletes[sessionID]
+}
+
+func newLifecycleSessionManager(t *testing.T, serverURL string) (*SessionManager, ServerConfig) {
+	t.Helper()
+
+	sm := &SessionManager{
+		tokenService:          &lifecycleTokenService{},
+		clientRetirementDelay: 0,
+	}
+	t.Cleanup(sm.Close)
+
+	return sm, ServerConfig{
+		URL:                  serverURL,
+		MCPServerName:        "lifecycle-test",
+		MCPServerDisplayName: "Lifecycle Test",
+		UserID:               "user-1",
+		Audiences:            []string{"lifecycle-test"},
+	}
+}
+
+func loadLifecycleSession(t *testing.T, sm *SessionManager, server ServerConfig) *Client {
+	t.Helper()
+
+	client, err := sm.loadSession(t.Context(), server, oauthCheckClientScope, nmcp.ClientOption{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func expireClient(client *Client) {
+	client.jwt.Claims = jwt.MapClaims{
+		"exp": float64(time.Now().Add(-time.Hour).Unix()),
+	}
+}
+
+func TestRapidTokenReplacementBoundsRemoteSessions(t *testing.T) {
+	remote := newLifecycleMCPServer(t, nil, nil)
+	sm, server := newLifecycleSessionManager(t, remote.server.URL)
+	sm.clientRetirementDelay = time.Hour
+
+	current := loadLifecycleSession(t, sm, server)
+
+	const replacements = 10
+	for range replacements {
+		expireClient(current)
+		current = loadLifecycleSession(t, sm, server)
+	}
+
+	var liveSessions int
+	for i := 1; i <= replacements+1; i++ {
+		count := remote.deleteCount(fmt.Sprintf("session-%d", i))
+		if count > 1 {
+			t.Fatalf("session-%d DELETE count = %d, want at most 1", i, count)
+		}
+		if count == 0 {
+			liveSessions++
+		}
+	}
+	if liveSessions != 2 {
+		t.Fatalf("live remote sessions after replacement burst = %d, want 2", liveSessions)
+	}
+
+	sm.closeClients(server.MCPServerName)
+	for i := 1; i <= replacements+1; i++ {
+		if got := remote.deleteCount(fmt.Sprintf("session-%d", i)); got != 1 {
+			t.Fatalf("session-%d DELETE count after shutdown = %d, want 1", i, got)
+		}
+	}
+}
+
+func TestDeferredRetirementHasHardDeadline(t *testing.T) {
+	remote := newLifecycleMCPServer(t, nil, nil)
+	sm, server := newLifecycleSessionManager(t, remote.server.URL)
+	sm.clientRetirementDelay = 10 * time.Millisecond
+
+	oldClient := loadLifecycleSession(t, sm, server)
+	oldSessionID := oldClient.Session.ID()
+	expireClient(oldClient)
+	replacement := loadLifecycleSession(t, sm, server)
+
+	deadline := time.Now().Add(time.Second)
+	for remote.deleteCount(oldSessionID) == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := remote.deleteCount(oldSessionID); got != 1 {
+		t.Fatalf("expired remote session DELETE count after deadline = %d, want 1", got)
+	}
+	if got := remote.deleteCount(replacement.Session.ID()); got != 0 {
+		t.Fatalf("replacement remote session DELETE count = %d, want 0", got)
+	}
+}
+
+func TestLoadSessionRaceDeletesLosingRemoteSessionOnce(t *testing.T) {
+	initializeStarted := make(chan struct{}, 2)
+	releaseInitialize := make(chan struct{})
+	remote := newLifecycleMCPServer(t, initializeStarted, releaseInitialize)
+	sm, server := newLifecycleSessionManager(t, remote.server.URL)
+
+	results := make(chan *Client, 2)
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			client, err := sm.loadSession(t.Context(), server, oauthCheckClientScope, nmcp.ClientOption{})
+			results <- client
+			errs <- err
+		}()
+	}
+
+	for range 2 {
+		<-initializeStarted
+	}
+	close(releaseInitialize)
+
+	first, second := <-results, <-results
+	if err := <-errs; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-errs; err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("concurrent callers returned different cached clients")
+	}
+
+	var totalDeletes int
+	for i := 1; i <= 2; i++ {
+		count := remote.deleteCount(fmt.Sprintf("session-%d", i))
+		if count > 1 {
+			t.Fatalf("session-%d DELETE count = %d, want at most 1", i, count)
+		}
+		totalDeletes += count
+	}
+	if totalDeletes != 1 {
+		t.Fatalf("losing remote session DELETE count = %d, want 1", totalDeletes)
+	}
+}
+
+func TestCloseClientFlushesRetiredAndActiveSessionsOnce(t *testing.T) {
+	remote := newLifecycleMCPServer(t, nil, nil)
+	sm, server := newLifecycleSessionManager(t, remote.server.URL)
+	sm.clientRetirementDelay = time.Hour
+
+	oldClient := loadLifecycleSession(t, sm, server)
+	oldSessionID := oldClient.Session.ID()
+	expireClient(oldClient)
+	activeClient := loadLifecycleSession(t, sm, server)
+	activeSessionID := activeClient.Session.ID()
+
+	sm.CloseClient(server, oauthCheckClientScope)
+	sm.CloseClient(server, oauthCheckClientScope)
+
+	if got := remote.deleteCount(oldSessionID); got != 1 {
+		t.Fatalf("retired remote session DELETE count = %d, want 1", got)
+	}
+	if got := remote.deleteCount(activeSessionID); got != 1 {
+		t.Fatalf("active remote session DELETE count = %d, want 1", got)
+	}
+}
+
+func TestClientRetireIsIdempotent(t *testing.T) {
+	remote := newLifecycleMCPServer(t, nil, nil)
+	sm, server := newLifecycleSessionManager(t, remote.server.URL)
+
+	client := loadLifecycleSession(t, sm, server)
+	sessionID := client.Session.ID()
+
+	client.retire()
+	client.retire()
+
+	if got := remote.deleteCount(sessionID); got != 1 {
+		t.Fatalf("remote session DELETE count = %d, want 1", got)
+	}
+}
+
+func TestSessionManagerClosePreservesActiveAndDeletesRetiredSession(t *testing.T) {
+	remote := newLifecycleMCPServer(t, nil, nil)
+	sm, server := newLifecycleSessionManager(t, remote.server.URL)
+	sm.clientRetirementDelay = time.Hour
+
+	oldClient := loadLifecycleSession(t, sm, server)
+	oldSessionID := oldClient.Session.ID()
+	expireClient(oldClient)
+	activeClient := loadLifecycleSession(t, sm, server)
+	activeSessionID := activeClient.Session.ID()
+
+	sm.Close()
+
+	if got := remote.deleteCount(oldSessionID); got != 1 {
+		t.Fatalf("retired remote session DELETE count = %d, want 1", got)
+	}
+	if got := remote.deleteCount(activeSessionID); got != 0 {
+		t.Fatalf("active remote session DELETE count = %d, want 0", got)
+	}
+}

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
@@ -80,7 +81,10 @@ type SessionManager struct {
 	sessionCtx                context.Context
 	cancel                    func()
 	sessions                  sync.Map
-	tokenService              *persistent.TokenService
+	retiredClientsLock        sync.Mutex
+	retiredClients            map[string]*retiredClient
+	clientRetirementDelay     time.Duration
+	tokenService              clientTokenService
 	baseURL                   string
 	remoteURLValidationConfig RemoteMCPURLValidationConfig
 	resourceMaximums          ResourceMaximums
@@ -92,6 +96,16 @@ type SessionManager struct {
 
 	webhookHelper *WebhookHelper
 }
+
+type retiredClient struct {
+	client *Client
+	timer  *time.Timer
+}
+
+// Keep the most recently replaced client alive briefly for in-flight requests.
+// Older replaced clients are retired immediately, so reconnect bursts cannot
+// grow the number of remote sessions without bound.
+const defaultClientRetirementDelay = 15 * time.Second
 
 type RemoteMCPURLValidationConfig struct {
 	AllowLocalhostMCP bool
@@ -178,6 +192,7 @@ func NewSessionManager(ctx context.Context, authEnabled bool, tokenService *pers
 		localK8sClient:            client,
 		obotNamespace:             obotNamespace,
 		secretBindingAllowedLabel: strings.TrimSpace(opts.MCPSecretBindingAllowedLabel),
+		clientRetirementDelay:     defaultClientRetirementDelay,
 		remoteURLValidationConfig: RemoteMCPURLValidationConfig{
 			AllowLocalhostMCP: !opts.DisallowLocalhostMCP,
 			AllowPrivateIPMCP: !opts.DisallowPrivateIPMCP,
@@ -218,6 +233,8 @@ func (sm *SessionManager) RemoteConfigForBackend() (RemoteMCPURLValidationConfig
 
 // Close does nothing with the deployments and services. It just closes the local session.
 func (sm *SessionManager) Close() {
+	sm.flushRetiredClients("", "")
+
 	sm.contextLock.Lock()
 	if sm.sessionCtx == nil {
 		sm.contextLock.Unlock()
@@ -247,6 +264,9 @@ func (sm *SessionManager) Close() {
 
 // CloseClient will close the client for this MCP server, but leave the deployment running.
 func (sm *SessionManager) CloseClient(server ServerConfig, clientScope string) {
+	clientScope = clientID(server, clientScope)
+	sm.flushRetiredClients(server.MCPServerName, clientScope)
+
 	sm.contextLock.Lock()
 	if sm.sessionCtx == nil {
 		sm.contextLock.Unlock()
@@ -264,13 +284,13 @@ func (sm *SessionManager) CloseClient(server ServerConfig, clientScope string) {
 		return
 	}
 
-	sess, ok := clientSessions.LoadAndDelete(clientID(server, clientScope))
+	sess, ok := clientSessions.LoadAndDelete(clientScope)
 	if !ok || sess == nil {
 		return
 	}
 
 	if s, ok := sess.(*Client); ok && s.Client != nil {
-		s.Close(false)
+		s.retire()
 		s.Session.Wait()
 	}
 }
@@ -297,6 +317,8 @@ func (sm *SessionManager) shutdownServer(ctx context.Context, serverName string,
 }
 
 func (sm *SessionManager) closeClients(serverName string) {
+	sm.flushRetiredClients(serverName, "")
+
 	sm.contextLock.Lock()
 	if sm.sessionCtx == nil {
 		sm.contextLock.Unlock()
@@ -316,7 +338,7 @@ func (sm *SessionManager) closeClients(serverName string) {
 
 	clientSessions.Range(func(_, session any) bool {
 		if s, ok := session.(*Client); ok && s.Client != nil {
-			s.Close(true)
+			s.retire()
 			s.Session.Wait()
 		}
 		return true


### PR DESCRIPTION
## Problem

MCP clients replaced after token expiry, configuration races, or explicit client closure are currently closed with `Close(false)`. The replacement path also keeps every old client alive for one minute.

During a reconnect or token-refresh burst this permits an unbounded number of remote MCP sessions to remain alive at once. For hosted stdio servers, each retained remote session can own a separate downstream process tree, so the grace period can exhaust the pod memory limit before any delayed close runs.

## Fix

- retire permanently discarded clients with `Close(true)` so the remote server receives `DELETE`
- make retirement idempotent
- use compare-and-delete / compare-and-swap for replacement races
- retain at most one old client per MCP server for a 15-second in-flight grace period
- immediately retire an older grace client when a newer replacement arrives
- immediately retire cache-race losers and clients closed explicitly
- flush retired clients during server shutdown
- preserve the existing `Close(false)` behavior for the active client during process-wide `SessionManager.Close`, retaining restart/resume semantics

The resulting fan-out during a replacement burst is bounded to:

```text
one current remote session + one retiring remote session
```

## Tests

Added lifecycle tests with an in-process Streamable HTTP MCP server that records session deletion:

- ten rapid token replacements leave exactly two remote sessions alive
- the grace client is deleted at its hard deadline
- a concurrent initialization loser is deleted exactly once
- explicit `CloseClient` deletes active and pending sessions exactly once
- repeated retirement is idempotent
- manager shutdown deletes only already-retired sessions and preserves the active session

Validation on current `main`:

- `go test ./pkg/mcp -count=1`
- `go test ./... -count=1`
- `go vet ./pkg/mcp`
