### PR TITLE
fix(mcp): reject reserved multi-user auth headers

### DIFF
--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -246,6 +246,10 @@ multiUserConfig:
       description: Personal token used by the upstream service for this user.
 ```
 
+`Authorization` and `X-API-Key` are reserved by Obot gateway authentication and
+cannot be used as multi-user per-user headers. Choose a service-specific header
+such as `X-User-Token` instead. Header-name matching is case-insensitive.
+
 ### Resource Requirements
 
 Catalog entries can optionally define CPU and memory requests and limits for hosted MCP server deployments. These values are useful when a specific server needs more or fewer resources than the platform defaults.

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -1100,7 +1100,7 @@ func TestCreateServerRejectsMultiUserHeaderSecretBinding(t *testing.T) {
 			Path:  "/mcp",
 		},
 		MultiUserConfig: &types.MultiUserConfig{UserDefinedHeaders: []types.MCPHeader{{
-			Key:           "X-API-Key",
+			Key:           "X-Service-Key",
 			SecretBinding: &types.MCPSecretBinding{Name: "source-secret", Key: "token"},
 		}}},
 	}
@@ -1125,7 +1125,7 @@ func TestCreateCatalogEntryRejectsMultiUserHeaderSecretBinding(t *testing.T) {
 			Path:  "/mcp",
 		},
 		MultiUserConfig: &types.MultiUserConfig{UserDefinedHeaders: []types.MCPHeader{{
-			Key:           "X-API-Key",
+			Key:           "X-Service-Key",
 			SecretBinding: &types.MCPSecretBinding{Name: "source-secret", Key: "token"},
 		}}},
 	}

--- a/pkg/mcp/mcpvalidators.go
+++ b/pkg/mcp/mcpvalidators.go
@@ -1118,6 +1118,28 @@ func validateCompositeCatalogEntryResourceMaximums(manifest types.MCPServerCatal
 	return nil
 }
 
+func validateMultiUserDefinedHeaders(runtime types.Runtime, config *types.MultiUserConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	for i, header := range config.UserDefinedHeaders {
+		switch strings.ToLower(strings.TrimSpace(header.Key)) {
+		case "authorization", "x-api-key":
+			return types.RuntimeValidationError{
+				Runtime: runtime,
+				Field:   fmt.Sprintf("multiUserConfig.userDefinedHeaders[%d].key", i),
+				Message: fmt.Sprintf(
+					"header %q is reserved by Obot gateway authentication; choose a different per-user header",
+					header.Key,
+				),
+			}
+		}
+	}
+
+	return nil
+}
+
 func ValidateServerManifest(ctx context.Context, manifest types.MCPServerManifest, isMultiUser bool, options ValidationOptions) error {
 	if err := validateMCPResourceRequirements(manifest.Runtime, manifest.Resources); err != nil {
 		return err
@@ -1132,6 +1154,9 @@ func ValidateServerManifest(ctx context.Context, manifest types.MCPServerManifes
 			Field:   "multiUserConfig",
 			Message: "multiUserConfig may only be set for multi-user servers",
 		}
+	}
+	if err := validateMultiUserDefinedHeaders(manifest.Runtime, manifest.MultiUserConfig); err != nil {
+		return err
 	}
 	if err := validateRuntimeStartupTimeout(manifest.Runtime, manifest.RuntimeStartupTimeoutSeconds()); err != nil {
 		return err
@@ -1190,6 +1215,9 @@ func ValidateCatalogEntryManifest(ctx context.Context, manifest types.MCPServerC
 			Field:   "multiUserConfig",
 			Message: "multiUserConfig may only be set for multi-user catalog entries",
 		}
+	}
+	if err := validateMultiUserDefinedHeaders(manifest.Runtime, manifest.MultiUserConfig); err != nil {
+		return err
 	}
 
 	if !manifest.ServerUserType.IsSingleUser() &&

--- a/pkg/mcp/mcpvalidators_test.go
+++ b/pkg/mcp/mcpvalidators_test.go
@@ -53,6 +53,48 @@ func TestValidateCatalogEntryManifest_MultiUserConfig(t *testing.T) {
 	require.NoError(t, ValidateCatalogEntryManifest(t.Context(), manifest, false, ValidationOptions{}))
 }
 
+func TestValidateMultiUserConfigRejectsGatewayAuthenticationHeaders(t *testing.T) {
+	validConfig := &types.MultiUserConfig{
+		UserDefinedHeaders: []types.MCPHeader{{Key: "X-Auth-Token", Required: true, Sensitive: true}},
+	}
+	require.NoError(t, ValidateServerManifest(t.Context(), types.MCPServerManifest{
+		Runtime:         types.RuntimeNPX,
+		NPXConfig:       &types.NPXRuntimeConfig{Package: "test-server"},
+		MultiUserConfig: validConfig,
+	}, true, ValidationOptions{}))
+	require.NoError(t, ValidateCatalogEntryManifest(t.Context(), types.MCPServerCatalogEntryManifest{
+		ServerUserType:  types.ServerUserTypeMultiUser,
+		Runtime:         types.RuntimeNPX,
+		NPXConfig:       &types.NPXRuntimeConfig{Package: "test-server"},
+		MultiUserConfig: validConfig,
+	}, false, ValidationOptions{}))
+
+	for _, key := range []string{"Authorization", " authorization ", "X-Api-Key", "x-api-key"} {
+		t.Run(key, func(t *testing.T) {
+			config := &types.MultiUserConfig{
+				UserDefinedHeaders: []types.MCPHeader{{Key: key, Required: true, Sensitive: true}},
+			}
+
+			serverErr := ValidateServerManifest(t.Context(), types.MCPServerManifest{
+				Runtime:         types.RuntimeNPX,
+				NPXConfig:       &types.NPXRuntimeConfig{Package: "test-server"},
+				MultiUserConfig: config,
+			}, true, ValidationOptions{})
+			require.ErrorContains(t, serverErr, "reserved by Obot gateway authentication")
+			require.ErrorContains(t, serverErr, "multiUserConfig.userDefinedHeaders[0].key")
+
+			catalogErr := ValidateCatalogEntryManifest(t.Context(), types.MCPServerCatalogEntryManifest{
+				ServerUserType:  types.ServerUserTypeMultiUser,
+				Runtime:         types.RuntimeNPX,
+				NPXConfig:       &types.NPXRuntimeConfig{Package: "test-server"},
+				MultiUserConfig: config,
+			}, false, ValidationOptions{})
+			require.ErrorContains(t, catalogErr, "reserved by Obot gateway authentication")
+			require.ErrorContains(t, catalogErr, "multiUserConfig.userDefinedHeaders[0].key")
+		})
+	}
+}
+
 func TestRemoteValidator_validateRemoteCatalogConfig(t *testing.T) {
 	validator := RemoteValidator{}
 


### PR DESCRIPTION
## Problem

Multi-user `userDefinedHeaders` currently accepts `Authorization` and
`X-API-Key`, but both names are reserved by Obot gateway authentication.

This produces a configuration that validates and deploys but cannot be used:
the gateway consumes the upstream service credential as an Obot credential
before MCP passthrough. For `X-API-Key`, a non-`ok1-...` service token is denied
with `invalid_api_key_format`.

## Change

- reject `Authorization` and `X-API-Key` case-insensitively for multi-user
  per-user headers
- apply the check to both catalog-entry and deployed-server manifest validation
- return the exact `multiUserConfig.userDefinedHeaders[index].key` field
- document the reserved names and recommend a service-specific header
- keep unrelated secret-binding tests focused by moving their fixture to
  `X-Service-Key`

## Verification

- new regression test fails before the implementation
- `go test ./pkg/mcp -count=1`
- `go vet ./pkg/mcp`
- `go test ./... -count=1`
