### PR TITLE
fix: healthz check in launch readiness check

### DIFF
--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -52,6 +52,7 @@ var (
 const (
 	maxDeploymentWatchRetries    = 5
 	nanobotPodHealthPollInterval = 250 * time.Millisecond
+	mcpServerRevisionAnnotation  = "obot.ai/mcp-server-revision"
 )
 
 type kubernetesBackend struct {
@@ -388,6 +389,11 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 		return nil, nil
 	}
 
+	// Capture the revision before rendering mutates its copy of server. The
+	// readiness path hashes the original ServerConfig and uses this annotation
+	// to distinguish the desired rollout from stale ReplicaSet pods.
+	serverRevision := utils.Digest(server)
+
 	if !k.authEnabled {
 		server.Audiences = nil
 		server.TokenExchangeClientID = ""
@@ -403,9 +409,10 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 		portName = "mcp"
 
 		annotations = map[string]string{
-			"mcp-server-display-name": server.MCPServerDisplayName,
-			"mcp-server-scope":        server.MCPServerName,
-			"mcp-user-id":             server.OwnerUserID,
+			"mcp-server-display-name":   server.MCPServerDisplayName,
+			"mcp-server-scope":          server.MCPServerName,
+			"mcp-user-id":               server.OwnerUserID,
+			mcpServerRevisionAnnotation: serverRevision,
 		}
 
 		fileMapping        = make(map[string]string, len(server.Files))
@@ -770,6 +777,24 @@ func getNewestPod(pods []corev1.Pod) (*corev1.Pod, error) {
 	return newest, nil
 }
 
+// getNewestActivePodForRevision returns the newest non-terminating pod from
+// the desired rollout. During a rolling update, pods from the previous
+// ReplicaSet can remain alive while the replacement starts.
+func getNewestActivePodForRevision(pods []corev1.Pod, revision string) (*corev1.Pod, error) {
+	matchingPods := make([]corev1.Pod, 0, len(pods))
+	for i := range pods {
+		if !pods[i].DeletionTimestamp.IsZero() {
+			continue
+		}
+		if revision != "" && pods[i].Annotations[mcpServerRevisionAnnotation] != revision {
+			continue
+		}
+		matchingPods = append(matchingPods, pods[i])
+	}
+
+	return getNewestPod(matchingPods)
+}
+
 // analyzePodStatus examines a pod's status to determine if we should retry waiting for it
 // or if we should fail immediately. Returns (shouldRetry, error).
 func analyzePodStatus(pod *corev1.Pod, isAgent bool) (bool, error) {
@@ -871,7 +896,7 @@ func (k *kubernetesBackend) checkNanobotPodHealth(ctx context.Context, pod *core
 	return fmt.Errorf("%w: internal server error: %s", ErrHealthCheckFailed, strings.TrimSpace(string(body)))
 }
 
-func (k *kubernetesBackend) pollNanobotPodHealth(ctx context.Context, id string) error {
+func (k *kubernetesBackend) pollNanobotPodHealth(ctx context.Context, id, revision string) error {
 	ticker := time.NewTicker(nanobotPodHealthPollInterval)
 	defer ticker.Stop()
 
@@ -883,7 +908,7 @@ func (k *kubernetesBackend) pollNanobotPodHealth(ctx context.Context, id string)
 				"app": id,
 			}),
 		}); err == nil && len(pods.Items) > 0 {
-			newestPod, err := getNewestPod(pods.Items)
+			newestPod, err := getNewestActivePodForRevision(pods.Items, revision)
 			if err == nil {
 				if err := k.checkNanobotPodHealth(ctx, newestPod); err != nil {
 					return err
@@ -902,9 +927,13 @@ func (k *kubernetesBackend) pollNanobotPodHealth(ctx context.Context, id string)
 func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id string, server ServerConfig, previousPodName string) (string, error) {
 	// Wait for the deployment to be ready, checking pod status on each update to fail fast on permanent errors.
 	var (
-		err     error
-		lastErr error
+		err             error
+		lastErr         error
+		desiredRevision string
 	)
+	if server.Runtime == types.RuntimeNPX || server.Runtime == types.RuntimeUVX {
+		desiredRevision = utils.Digest(server)
+	}
 	for attempt := range maxDeploymentWatchRetries {
 		waitCtx, cancelWait := context.WithCancel(ctx)
 		var healthErrCh <-chan error
@@ -913,7 +942,7 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 			healthErrCh = ch
 			go func() {
 				defer close(ch)
-				if healthErr := k.pollNanobotPodHealth(waitCtx, id); healthErr != nil {
+				if healthErr := k.pollNanobotPodHealth(waitCtx, id, desiredRevision); healthErr != nil {
 					ch <- healthErr
 					cancelWait()
 				}
@@ -922,6 +951,10 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 
 		_, err := wait.For(waitCtx, k.cachedClient, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: id, Namespace: k.mcpNamespace}},
 			func(dep *appsv1.Deployment) (bool, error) {
+				if desiredRevision != "" && dep.Spec.Template.Annotations[mcpServerRevisionAnnotation] != desiredRevision {
+					return false, nil
+				}
+
 				if dep.Generation == dep.Status.ObservedGeneration && dep.Status.UpdatedReplicas == 1 && dep.Status.ReadyReplicas == 1 && dep.Status.AvailableReplicas == 1 {
 					return true, nil
 				}
@@ -942,7 +975,7 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 					return false, nil // No pods yet, keep waiting
 				}
 
-				newestPod, err := getNewestPod(pods.Items)
+				newestPod, err := getNewestActivePodForRevision(pods.Items, desiredRevision)
 				if err != nil {
 					return false, nil // Keep waiting
 				}
@@ -993,7 +1026,9 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 		pods    corev1.PodList
 		podName string
 	)
-	if err = k.cachedClient.List(ctx, &pods, &kclient.ListOptions{
+	// Read directly from the API after the cached Deployment reports ready.
+	// Pod and Deployment informer caches can observe a rollout at different times.
+	if err = k.client.List(ctx, &pods, &kclient.ListOptions{
 		Namespace: k.mcpNamespace,
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"app": id,
@@ -1004,7 +1039,10 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 
 	var newestCreatedTime metav1.Time
 	for _, p := range pods.Items {
-		if p.DeletionTimestamp.IsZero() && p.CreationTimestamp.After(newestCreatedTime.Time) && p.Status.Phase == corev1.PodRunning {
+		if p.DeletionTimestamp.IsZero() &&
+			(desiredRevision == "" || p.Annotations[mcpServerRevisionAnnotation] == desiredRevision) &&
+			p.CreationTimestamp.After(newestCreatedTime.Time) &&
+			p.Status.Phase == corev1.PodRunning {
 			podName = p.Name
 			newestCreatedTime = p.CreationTimestamp
 		}

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net"
+	"net/http"
 	"reflect"
 	"slices"
 	"sort"
@@ -47,7 +49,10 @@ var (
 	defaultCPURequest         = resource.MustParse("10m")
 )
 
-const maxDeploymentWatchRetries = 5
+const (
+	maxDeploymentWatchRetries    = 5
+	nanobotPodHealthPollInterval = 250 * time.Millisecond
+)
 
 type kubernetesBackend struct {
 	clientset         *kubernetes.Clientset
@@ -61,6 +66,7 @@ type kubernetesBackend struct {
 	authEnabled       bool
 	obotClient        kclient.Client
 	resourceMaximums  ResourceMaximums
+	healthCheckClient *http.Client
 	deploymentCacheMu sync.RWMutex
 	deploymentCache   map[string]*kubernetesDeploymentCacheEntry
 }
@@ -835,6 +841,64 @@ func analyzePodStatus(pod *corev1.Pod, isAgent bool) (bool, error) {
 	return true, fmt.Errorf("pod in phase %s, waiting for containers to be ready", pod.Status.Phase)
 }
 
+func (k *kubernetesBackend) checkNanobotPodHealth(ctx context.Context, pod *corev1.Pod) error {
+	if pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+		return nil
+	}
+
+	client := k.healthCheckClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+
+	healthURL := "http://" + net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(defaultContainerPort)) + "/healthz"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create pod health check request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil // The pod may not be accepting connections yet.
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		return nil
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	return fmt.Errorf("%w: internal server error: %s", ErrHealthCheckFailed, strings.TrimSpace(string(body)))
+}
+
+func (k *kubernetesBackend) pollNanobotPodHealth(ctx context.Context, id string) error {
+	ticker := time.NewTicker(nanobotPodHealthPollInterval)
+	defer ticker.Stop()
+
+	for {
+		var pods corev1.PodList
+		if err := k.cachedClient.List(ctx, &pods, &kclient.ListOptions{
+			Namespace: k.mcpNamespace,
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				"app": id,
+			}),
+		}); err == nil && len(pods.Items) > 0 {
+			newestPod, err := getNewestPod(pods.Items)
+			if err == nil {
+				if err := k.checkNanobotPodHealth(ctx, newestPod); err != nil {
+					return err
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+	}
+}
+
 func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id string, server ServerConfig, previousPodName string) (string, error) {
 	// Wait for the deployment to be ready, checking pod status on each update to fail fast on permanent errors.
 	var (
@@ -842,7 +906,21 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 		lastErr error
 	)
 	for attempt := range maxDeploymentWatchRetries {
-		_, err := wait.For(ctx, k.cachedClient, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: id, Namespace: k.mcpNamespace}},
+		waitCtx, cancelWait := context.WithCancel(ctx)
+		var healthErrCh <-chan error
+		if server.Runtime == types.RuntimeNPX || server.Runtime == types.RuntimeUVX {
+			ch := make(chan error, 1)
+			healthErrCh = ch
+			go func() {
+				defer close(ch)
+				if healthErr := k.pollNanobotPodHealth(waitCtx, id); healthErr != nil {
+					ch <- healthErr
+					cancelWait()
+				}
+			}()
+		}
+
+		_, err := wait.For(waitCtx, k.cachedClient, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: id, Namespace: k.mcpNamespace}},
 			func(dep *appsv1.Deployment) (bool, error) {
 				if dep.Generation == dep.Status.ObservedGeneration && dep.Status.UpdatedReplicas == 1 && dep.Status.ReadyReplicas == 1 && dep.Status.AvailableReplicas == 1 {
 					return true, nil
@@ -850,7 +928,7 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 
 				// Deployment not ready yet - check pod status for early failure detection.
 				var pods corev1.PodList
-				if listErr := k.cachedClient.List(ctx, &pods, &kclient.ListOptions{
+				if listErr := k.cachedClient.List(waitCtx, &pods, &kclient.ListOptions{
 					Namespace: k.mcpNamespace,
 					LabelSelector: labels.SelectorFromSet(map[string]string{
 						"app": id,
@@ -875,11 +953,16 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 					olog.Debugf("pod in non-retryable state: id=%s error=%v attempt=%d", id, podErr, attempt+1)
 					return false, podErr
 				}
-
 				return false, nil // Keep waiting.
 			},
 			wait.Option{Timeout: server.StartupTimeout},
 		)
+		cancelWait()
+		if healthErrCh != nil {
+			if healthErr := <-healthErrCh; healthErr != nil {
+				return "", healthErr
+			}
+		}
 		if err == nil {
 			break
 		}
@@ -889,6 +972,7 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 			return "", fmt.Errorf("%w: timeout waiting for deployment readiness", ErrHealthCheckTimeout)
 		}
 		if errors.Is(err, ErrHealthCheckTimeout) ||
+			errors.Is(err, ErrHealthCheckFailed) ||
 			errors.Is(err, ErrPodCrashLoopBackOff) ||
 			errors.Is(err, ErrImagePullFailed) ||
 			errors.Is(err, ErrPodSchedulingFailed) ||

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	"github.com/obot-platform/obot/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -786,6 +787,7 @@ func TestAnalyzePodStatus(t *testing.T) {
 type fakeWithWatch struct {
 	client.Client // controller-runtime fake for Get/List/Create etc.
 	watcher       *watch.FakeWatcher
+	watchStarted  chan struct{}
 }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -795,6 +797,12 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (f *fakeWithWatch) Watch(ctx context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+	if f.watchStarted != nil {
+		select {
+		case f.watchStarted <- struct{}{}:
+		default:
+		}
+	}
 	go func() {
 		<-ctx.Done()
 		f.watcher.Stop()
@@ -811,8 +819,16 @@ func TestUpdatedMCPPodName_FailsFastOnNanobotHealthError(t *testing.T) {
 		t.Fatalf("AddToScheme(corev1) error = %v", err)
 	}
 
+	server := ServerConfig{
+		Runtime:        types.RuntimeNPX,
+		StartupTimeout: 5 * time.Minute,
+	}
+	revision := utils.Digest(server)
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "obot-mcp"},
+		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{mcpServerRevisionAnnotation: revision},
+		}}},
 		Status: appsv1.DeploymentStatus{
 			ObservedGeneration: 1,
 			UpdatedReplicas:    1,
@@ -824,6 +840,7 @@ func TestUpdatedMCPPodName_FailsFastOnNanobotHealthError(t *testing.T) {
 			Namespace:         "obot-mcp",
 			CreationTimestamp: metav1.Now(),
 			Labels:            map[string]string{"app": "test-server"},
+			Annotations:       map[string]string{mcpServerRevisionAnnotation: revision},
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
@@ -872,15 +889,196 @@ func TestUpdatedMCPPodName_FailsFastOnNanobotHealthError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
-	_, err := k.updatedMCPPodName(ctx, "http://mcp.example.com", "test-server", ServerConfig{
-		Runtime:        types.RuntimeNPX,
-		StartupTimeout: 5 * time.Minute,
-	}, "")
+	_, err := k.updatedMCPPodName(ctx, "http://mcp.example.com", "test-server", server, "")
 	if !errors.Is(err, ErrHealthCheckFailed) {
 		t.Fatalf("updatedMCPPodName() error = %v, want %v", err, ErrHealthCheckFailed)
 	}
 	if !strings.Contains(err.Error(), "npm error 404 Not Found") {
 		t.Fatalf("updatedMCPPodName() error = %q, want npm failure", err)
+	}
+}
+
+func TestUpdatedMCPPodName_IgnoresPodsOutsideDesiredRollout(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(appsv1) error = %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(corev1) error = %v", err)
+	}
+
+	server := ServerConfig{Runtime: types.RuntimeNPX, StartupTimeout: 5 * time.Minute}
+	revision := utils.Digest(server)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "obot-mcp"},
+		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{mcpServerRevisionAnnotation: revision},
+		}}},
+		Status: appsv1.DeploymentStatus{ObservedGeneration: 1, UpdatedReplicas: 1},
+	}
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-server-old",
+			Namespace:         "obot-mcp",
+			CreationTimestamp: metav1.Now(),
+			Labels:            map[string]string{"app": "test-server"},
+			Annotations:       map[string]string{mcpServerRevisionAnnotation: "old-revision"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.1"},
+	}
+	terminatingPod := oldPod.DeepCopy()
+	terminatingPod.Name = "test-server-terminating"
+	terminatingPod.Status.PodIP = "10.0.0.2"
+	terminatingPod.Annotations[mcpServerRevisionAnnotation] = revision
+	terminatingPod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	terminatingPod.Finalizers = []string{"test-finalizer"}
+
+	watcher := watch.NewFake()
+	client := &fakeWithWatch{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			deployment, oldPod, terminatingPod,
+		).Build(),
+		watcher: watcher,
+	}
+	healthCalls := make(chan string, 1)
+	k := &kubernetesBackend{
+		client:       client,
+		cachedClient: client,
+		mcpNamespace: "obot-mcp",
+		healthCheckClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			healthCalls <- req.URL.Hostname()
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader("desired rollout failure")),
+				Header:     make(http.Header),
+			}, nil
+		})},
+	}
+
+	createErr := make(chan error, 1)
+	go func() {
+		timer := time.NewTimer(100 * time.Millisecond)
+		defer timer.Stop()
+		<-timer.C
+		createErr <- client.Create(t.Context(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-server-new",
+				Namespace:         "obot-mcp",
+				CreationTimestamp: metav1.Now(),
+				Labels:            map[string]string{"app": "test-server"},
+				Annotations:       map[string]string{mcpServerRevisionAnnotation: revision},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.3"},
+		})
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, err := k.updatedMCPPodName(ctx, "http://mcp.example.com", "test-server", server, "")
+	if createErr := <-createErr; createErr != nil {
+		t.Fatalf("Create() error = %v", createErr)
+	}
+	if !errors.Is(err, ErrHealthCheckFailed) || !strings.Contains(err.Error(), "desired rollout failure") {
+		t.Fatalf("updatedMCPPodName() error = %v, want desired rollout health failure", err)
+	}
+	if got := <-healthCalls; got != "10.0.0.3" {
+		t.Fatalf("health check pod IP = %q, want desired active pod IP", got)
+	}
+}
+
+func TestUpdatedMCPPodName_WaitsForDesiredDeploymentRevision(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(appsv1) error = %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(corev1) error = %v", err)
+	}
+
+	server := ServerConfig{Runtime: types.RuntimeNPX, StartupTimeout: time.Second}
+	revision := utils.Digest(server)
+	oldDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-server",
+			Namespace:  "obot-mcp",
+			Generation: 1,
+		},
+		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{mcpServerRevisionAnnotation: "old-revision"},
+		}}},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			UpdatedReplicas:    1,
+			ReadyReplicas:      1,
+			AvailableReplicas:  1,
+		},
+	}
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-server-old",
+			Namespace:         "obot-mcp",
+			CreationTimestamp: metav1.Now(),
+			Labels:            map[string]string{"app": "test-server"},
+			Annotations:       map[string]string{mcpServerRevisionAnnotation: "old-revision"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	watcher := watch.NewFake()
+	watchStarted := make(chan struct{}, 1)
+	client := &fakeWithWatch{
+		Client:       fake.NewClientBuilder().WithScheme(scheme).WithObjects(oldDeployment, oldPod).Build(),
+		watcher:      watcher,
+		watchStarted: watchStarted,
+	}
+	k := &kubernetesBackend{
+		client:       client,
+		cachedClient: client,
+		mcpNamespace: "obot-mcp",
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	asyncErr := make(chan error, 1)
+	go func() {
+		select {
+		case <-watchStarted:
+		case <-ctx.Done():
+			return
+		}
+
+		newPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-server-new",
+				Namespace:         "obot-mcp",
+				CreationTimestamp: metav1.Now(),
+				Labels:            map[string]string{"app": "test-server"},
+				Annotations:       map[string]string{mcpServerRevisionAnnotation: revision},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		}
+		if err := client.Create(ctx, newPod); err != nil {
+			asyncErr <- err
+			return
+		}
+
+		desiredDeployment := oldDeployment.DeepCopy()
+		desiredDeployment.Generation = 2
+		desiredDeployment.Spec.Template.Annotations[mcpServerRevisionAnnotation] = revision
+		desiredDeployment.Status.ObservedGeneration = 2
+		watcher.Modify(desiredDeployment)
+		asyncErr <- nil
+	}()
+
+	podName, err := k.updatedMCPPodName(ctx, "http://mcp.example.com", "test-server", server, "test-server-new")
+	if err != nil {
+		t.Fatalf("updatedMCPPodName() error = %v", err)
+	}
+	if err := <-asyncErr; err != nil {
+		t.Fatalf("creating desired rollout pod: %v", err)
+	}
+	if podName != "test-server-new" {
+		t.Fatalf("updatedMCPPodName() pod = %q, want desired rollout pod", podName)
 	}
 }
 

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -786,8 +788,100 @@ type fakeWithWatch struct {
 	watcher       *watch.FakeWatcher
 }
 
-func (f *fakeWithWatch) Watch(_ context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func (f *fakeWithWatch) Watch(ctx context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+	go func() {
+		<-ctx.Done()
+		f.watcher.Stop()
+	}()
 	return f.watcher, nil
+}
+
+func TestUpdatedMCPPodName_FailsFastOnNanobotHealthError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(appsv1) error = %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(corev1) error = %v", err)
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "obot-mcp"},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			UpdatedReplicas:    1,
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-server-pod",
+			Namespace:         "obot-mcp",
+			CreationTimestamp: metav1.Now(),
+			Labels:            map[string]string{"app": "test-server"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.0.0.1",
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "mcp",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+			}},
+		},
+	}
+
+	watcher := watch.NewFake()
+
+	client := &fakeWithWatch{
+		Client:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(deployment, pod).Build(),
+		watcher: watcher,
+	}
+	healthCalls := 0
+	k := &kubernetesBackend{
+		client:       client,
+		cachedClient: client,
+		mcpNamespace: "obot-mcp",
+		healthCheckClient: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.String() != "http://10.0.0.1:8099/healthz" {
+				t.Fatalf("health check URL = %q, want pod health URL", req.URL)
+			}
+			if err := req.Context().Err(); err != nil {
+				return nil, err
+			}
+			healthCalls++
+			if healthCalls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusTooEarly,
+					Body:       io.NopCloser(strings.NewReader("waiting for startup")),
+					Header:     make(http.Header),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader("npm error 404 Not Found")),
+				Header:     make(http.Header),
+			}, nil
+		})},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	_, err := k.updatedMCPPodName(ctx, "http://mcp.example.com", "test-server", ServerConfig{
+		Runtime:        types.RuntimeNPX,
+		StartupTimeout: 5 * time.Minute,
+	}, "")
+	if !errors.Is(err, ErrHealthCheckFailed) {
+		t.Fatalf("updatedMCPPodName() error = %v, want %v", err, ErrHealthCheckFailed)
+	}
+	if !strings.Contains(err.Error(), "npm error 404 Not Found") {
+		t.Fatalf("updatedMCPPodName() error = %q, want npm failure", err)
+	}
 }
 
 func TestUpdatedMCPPodName_SucceededPodAgentRetryBehavior(t *testing.T) {
@@ -842,8 +936,9 @@ func TestUpdatedMCPPodName_SucceededPodAgentRetryBehavior(t *testing.T) {
 			}
 
 			watcher := watch.NewFake()
+			eventDeployment := deployment.DeepCopy()
 			go func() {
-				watcher.Add(deployment.DeepCopy())
+				watcher.Add(eventDeployment)
 				watcher.Stop()
 			}()
 


### PR DESCRIPTION
Related #6503 Follow Up

This pull request is to address the issue of, when launching a single-tenant catalog entry with UVX/NPX runtime and an invalid package, the `/launch` endpoint should properly return error as soon as the health check determines package is invalid instead of erroring later due to timeout.

Tested with: 
- Custom created hosted single-tenant catalog entry with valid package to ensure /launch is successful
- Custom created hosted single-tenant catalog entry with invalid package to validate /launch errors out on failed health check

Tested to make sure there wasn't regression in launch for:
- Creating and launching Multi-tenant catalog entry
- Creating and launching composite catalog entry
- Creating and launching remote catalog entry

Throwing this in draft and in eyes of backend engineers, but lemme know if it makes more sense to close this PR and reassign the issue instead!