### PR TITLE
fix: show model discovery filter status

### DIFF
--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -110,15 +110,15 @@
 		buildSearchParamFiltersArray<LLMAuditLogURLFilters>(supportedFilters)
 	);
 	const searchParamFilters = $derived.by<LLMAuditLogURLFilters>(() => {
-		const result = searchParamFiltersAsArray.reduce(
+		return searchParamFiltersAsArray.reduce(
 			(acc, [key, value]) => {
 				acc[key!] = value;
 				return acc;
 			},
-			{} as Record<string, unknown>
+			{
+				include_models_requests: includeModelsRequests.toString()
+			} as Record<string, unknown>
 		);
-		result.include_models_requests = includeModelsRequests.toString();
-		return result;
 	});
 
 	const pillsSearchParamFilters = $derived(

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -123,7 +123,9 @@
 	});
 
 	const pillsSearchParamFilters = $derived(
-		buildPillSearchParamFilters<LLMAuditLogURLFilters>(searchParamFiltersAsArray)
+		buildPillSearchParamFilters<LLMAuditLogURLFilters>(searchParamFiltersAsArray, {
+			include_models_requests: includeModelsRequests.toString()
+		})
 	);
 	const hasFilterPills = $derived(Object.keys(pillsSearchParamFilters).length > 0);
 
@@ -230,6 +232,7 @@
 		if (_key === 'response_status') return 'Status';
 		if (_key === 'user_id') return 'User';
 		if (_key === 'client_session_id') return 'Client Session ID';
+		if (_key === 'include_models_requests') return 'Model discovery requests';
 		if (_key === 'message_policy_triggered') return 'Message Policy Action';
 
 		return key.replace(/_(\w)/g, ' $1');
@@ -242,8 +245,13 @@
 		if (label === 'message_policy_triggered') {
 			return value === 'true' ? 'Triggered' : 'Not triggered';
 		}
+		if (label === 'include_models_requests') return value === 'true' ? 'Shown' : 'Hidden';
 
 		return value + '';
+	}
+
+	function isFilterClearable(filterKey: keyof LLMAuditLogURLFilters): boolean {
+		return filterKey !== 'include_models_requests';
 	}
 
 	function handleRightSidebarClose() {
@@ -315,7 +323,12 @@
 		<div class="flex flex-col flex-nowrap gap-4 @min-[768px]:flex-row">
 			<div class="min-w-0 grow hidden @min-[768px]:block">
 				{#if hasFilterPills}
-					<AuditLogFilterPills {pillsSearchParamFilters} {getFilterDisplayLabel} {getFilterValue} />
+					<AuditLogFilterPills
+						{pillsSearchParamFilters}
+						{getFilterDisplayLabel}
+						{getFilterValue}
+						{isFilterClearable}
+					/>
 				{/if}
 			</div>
 			{#if !isAdminReadonly}
@@ -347,7 +360,12 @@
 			{/if}
 			<div class="min-w-0 grow block @min-[768px]:hidden">
 				{#if hasFilterPills}
-					<AuditLogFilterPills {pillsSearchParamFilters} {getFilterDisplayLabel} {getFilterValue} />
+					<AuditLogFilterPills
+						{pillsSearchParamFilters}
+						{getFilterDisplayLabel}
+						{getFilterValue}
+						{isFilterClearable}
+					/>
 				{/if}
 			</div>
 		</div>

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -42,6 +42,7 @@
 		'user_id',
 		'client',
 		'client_session_id',
+		'include_models_requests',
 		'message_policy_triggered',
 		'model_provider',
 		'outcome',
@@ -70,10 +71,6 @@
 	let includeModelsRequests = $derived(
 		page.url.searchParams.get('include_models_requests') === 'true'
 	);
-	let includeModelsRequestsDraft = $state(false);
-	$effect(() => {
-		includeModelsRequestsDraft = includeModelsRequests;
-	});
 	let usersMap = $derived(new Map(users.map((user) => [user.id, user])));
 
 	const DEFER_THRESHOLD = 500;
@@ -113,13 +110,15 @@
 		buildSearchParamFiltersArray<LLMAuditLogURLFilters>(supportedFilters)
 	);
 	const searchParamFilters = $derived.by<LLMAuditLogURLFilters>(() => {
-		return searchParamFiltersAsArray.reduce(
+		const result = searchParamFiltersAsArray.reduce(
 			(acc, [key, value]) => {
 				acc[key!] = value;
 				return acc;
 			},
 			{} as Record<string, unknown>
 		);
+		result.include_models_requests = includeModelsRequests.toString();
+		return result;
 	});
 
 	const pillsSearchParamFilters = $derived(
@@ -307,7 +306,6 @@
 			<button
 				class="btn btn-neutral h-12.5"
 				onclick={() => {
-					includeModelsRequestsDraft = includeModelsRequests;
 					showFilters = true;
 					selectedAuditLog = undefined;
 					rightSidebar?.showPopover();
@@ -460,27 +458,27 @@
 			onClose={handleRightSidebarClose}
 			filters={{ ...searchParamFilters }}
 			isFilterDisabled={() => false}
-			isFilterClearable={() => true}
-			booleanFilters={[
-				{
-					property: 'include_models_requests',
-					label: 'Show model discovery requests',
-					selected: includeModelsRequestsDraft,
-					onChange: (selected) => (includeModelsRequestsDraft = selected)
-				}
-			]}
+			{isFilterClearable}
+			isFilterMultiSelect={(filterId) => filterId !== 'include_models_requests'}
+			getDefaultValue={(filterId) => (filterId === 'include_models_requests' ? 'false' : undefined)}
 			getUserDisplayName={(...args) => getUserDisplayName(usersMap, ...args)}
 			{getFilterDisplayLabel}
 			getFilterOptionLabel={(key, value) =>
-				key === 'message_policy_triggered'
+				key === 'include_models_requests'
 					? value === 'true'
-						? 'Triggered'
-						: 'Not triggered'
-					: value}
+						? 'Shown'
+						: 'Hidden'
+					: key === 'message_policy_triggered'
+						? value === 'true'
+							? 'Triggered'
+							: 'Not triggered'
+						: value}
 			endpoint={async (filterId, opts) => {
+				if (filterId === 'include_models_requests') {
+					return { options: ['true', 'false'] };
+				}
 				const response = await AdminService.listLLMAuditLogFilterOptions(filterId, {
 					...opts,
-					include_models_requests: includeModelsRequestsDraft.toString(),
 					start_time: timeRangeFilters.startTime.toISOString(),
 					end_time: timeRangeFilters.endTime.toISOString()
 				});

--- a/ui/user/src/lib/components/admin/filters-drawer/FilterField.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FilterField.svelte
@@ -5,7 +5,9 @@
 	};
 
 	export type FilterInput = {
+		clearable?: boolean;
 		label: string;
+		multiple?: boolean;
 		tooltip?: string;
 		property: string;
 		selected?: string | number | null;
@@ -49,7 +51,7 @@
 	const shouldShowResetButton = $derived(
 		hasDefaultValue && filter.selected !== null && filter.default !== filter.selected
 	);
-	const shouldShowClearButton = $derived(!!value);
+	const shouldShowClearButton = $derived((filter.clearable ?? true) && !!value);
 
 	const actions = $derived(
 		[
@@ -125,7 +127,7 @@
 				filter.selected = v;
 			}
 		}
-		multiple
+		multiple={filter.multiple ?? true}
 		{onSelect}
 		position="top"
 	/>

--- a/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
@@ -1,6 +1,5 @@
 <script lang="ts" generics="T extends Record<string, string | number | null | undefined>">
 	import { page } from '$app/state';
-	import Toggle from '$lib/components/Toggle.svelte';
 	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import { UserService } from '$lib/services';
 	import { AUDIT_LOG_FILTER_OPTIONS_LIMIT } from '$lib/services/user/constants';
@@ -23,18 +22,11 @@
 		filters?: Partial<T>
 	) => Promise<{ options: string[] } | undefined>;
 
-	type BooleanFilter = {
-		property: FilterKey;
-		label: string;
-		selected: boolean;
-		default?: boolean;
-		onChange: (selected: boolean) => void;
-	};
-
 	interface Props {
 		filters?: Partial<T>;
 		isFilterDisabled?: (key: FilterKey) => boolean;
 		isFilterClearable?: (key: FilterKey) => boolean;
+		isFilterMultiSelect?: (key: FilterKey) => boolean;
 		// Used to filter server ids when selecting a multi instance server
 		filterOptions?: (option: string, filterId?: FilterKey) => boolean;
 		onClose: () => void;
@@ -50,13 +42,13 @@
 		// switching event types clears filters that no longer apply to the new selection.
 		resetOnChangeKeys?: FilterKey[];
 		endpoint?: FilterOptionsEndpoint;
-		booleanFilters?: BooleanFilter[];
 	}
 
 	let {
 		filters: externFilters,
 		isFilterDisabled,
 		isFilterClearable,
+		isFilterMultiSelect,
 		onClose,
 		getUserDisplayName,
 		getFilterDisplayLabel,
@@ -65,7 +57,6 @@
 		getVisibleFilterKeys,
 		resetOnChangeKeys,
 		filterOptions,
-		booleanFilters: externalBooleanFilters = [],
 		endpoint = UserService.listAuditLogFilterOptions as FilterOptionsEndpoint
 	}: Props = $props();
 
@@ -103,8 +94,10 @@
 	let filterInputs = $derived(
 		visibleFilterKeys.reduce((acc, filterId) => {
 			acc[filterId] = {
+				clearable: isFilterClearable?.(filterId) ?? true,
 				property: filterId,
 				label: getFilterDisplayLabel?.(filterId) ?? filterId.replace(/_(\w)/, ' $1'),
+				multiple: isFilterMultiSelect?.(filterId) ?? true,
 				get tooltip() {
 					const count = filtersOptions[filterId]?.length ?? 0;
 					return count >= AUDIT_LOG_FILTER_OPTIONS_LIMIT
@@ -206,29 +199,18 @@
 				}
 			}
 		}
-		for (const filter of externalBooleanFilters) {
-			if (filter.selected === (filter.default ?? false)) {
-				url.searchParams.delete(filter.property);
-			} else {
-				url.searchParams.set(filter.property, filter.selected.toString());
-			}
-		}
-
 		await goto(url, { noScroll: true });
 
 		onClose?.();
 	}
 
 	function handleClearAllFilters() {
-		filterInputsAsArray
-			.filter((filter) =>
-				isFilterClearable ? isFilterClearable?.(filter.property as FilterKey) : true
-			)
-			.forEach((filterInput) => {
+		filterInputsAsArray.forEach((filterInput) => {
+			if (filterInput.clearable) {
 				filterInput.selected = '';
-			});
-		externalBooleanFilters.forEach((filter) => {
-			filter.onChange(filter.default ?? false);
+			} else if (filterInput.default !== undefined) {
+				filterInput.selected = filterInput.default;
+			}
 		});
 	}
 </script>
@@ -245,12 +227,6 @@
 	<div
 		class="default-scrollbar-thin flex h-[calc(100%-60px)] w-full flex-col gap-4 overflow-y-auto p-4 pt-0"
 	>
-		{#each externalBooleanFilters as filter (filter.property)}
-			<div class="border-base-300 flex items-center justify-between gap-4 rounded-lg border p-4">
-				<span class="text-sm font-medium">{filter.label}</span>
-				<Toggle label={filter.label} checked={filter.selected} onChange={filter.onChange} />
-			</div>
-		{/each}
 		{#each filterInputsAsArray as filterInput, index (filterInput.property)}
 			<AuditFilter
 				filter={filterInput}


### PR DESCRIPTION
Addresses #7147 by showing the currently-applied filters for `/models` requests. Also changed it to use a dropdown instead of a toggle so it's more similar to other fields.

<img width="326" height="133" alt="Screenshot 2026-07-16 at 12 48 21" src="https://github.com/user-attachments/assets/79eb9c59-d2db-4c75-a65b-f976db011757" />
<img width="562" height="109" alt="Screenshot 2026-07-16 at 12 48 28" src="https://github.com/user-attachments/assets/bdb67f50-eed0-45a2-9959-bfd1e57a8efb" />
<img width="564" height="108" alt="Screenshot 2026-07-16 at 12 48 34" src="https://github.com/user-attachments/assets/e2b3224f-2336-4fa7-9793-cab114e23983" />
<img width="312" height="132" alt="Screenshot 2026-07-16 at 12 48 42" src="https://github.com/user-attachments/assets/e5cd0059-eb9b-4c6a-900a-09be213e2651" />
