### PR TITLE
fix(composite): stop using proxy for tool previews

### DIFF
--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -98,7 +98,8 @@ func (sm *SessionManager) loadSession(ctx context.Context, server ServerConfig, 
 	var jwtToken *jwt.Token
 	// If the token storage is not set, then this is a client we use in our API.
 	// This needs authentication for it to work.
-	if clientOpts.TokenStorage == nil {
+	// If this is a system client, we don't need to authenticate because we are talking directly to the MCP server.
+	if clientOpts.TokenStorage == nil && server.UserID != "system" {
 		var (
 			token string
 			err   error
@@ -121,7 +122,7 @@ func (sm *SessionManager) loadSession(ctx context.Context, server ServerConfig, 
 	}
 
 	url := server.URL
-	if !isOAuthCheck {
+	if !isOAuthCheck && server.UserID != "system" {
 		url = sm.TransformObotHostname(system.MCPConnectURL(sm.baseURL, server.MCPServerName))
 	}
 

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -7,7 +7,9 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
+	nmcp "github.com/obot-platform/nanobot/pkg/mcp"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
@@ -81,6 +83,7 @@ type SessionManager struct {
 	cancel                    func()
 	sessions                  sync.Map
 	tokenService              *persistent.TokenService
+	globalTokenStore          GlobalTokenStore
 	baseURL                   string
 	remoteURLValidationConfig RemoteMCPURLValidationConfig
 	resourceMaximums          ResourceMaximums
@@ -113,7 +116,7 @@ const streamableHTTPHealthcheckBody string = `{
     }
 }`
 
-func NewSessionManager(ctx context.Context, authEnabled bool, tokenService *persistent.TokenService, baseURL string, httpListenPort int, opts Options, webhookHelper *WebhookHelper, localK8sConfig *rest.Config, client, cachedClient, obotStorageClient kclient.WithWatch, gatewayClient *gateway.Client, obotNamespace string) (*SessionManager, error) {
+func NewSessionManager(ctx context.Context, authEnabled bool, globalTokenStore GlobalTokenStore, tokenService *persistent.TokenService, baseURL string, httpListenPort int, opts Options, webhookHelper *WebhookHelper, localK8sConfig *rest.Config, client, cachedClient, obotStorageClient kclient.WithWatch, gatewayClient *gateway.Client, obotNamespace string) (*SessionManager, error) {
 	var backend backend
 	resourceMaximums, err := ParseResourceMaximums(opts)
 	if err != nil {
@@ -169,6 +172,7 @@ func NewSessionManager(ctx context.Context, authEnabled bool, tokenService *pers
 	return &SessionManager{
 		webhookHelper:             webhookHelper,
 		tokenService:              tokenService,
+		globalTokenStore:          globalTokenStore,
 		backend:                   backend,
 		runtimeBackend:            opts.MCPRuntimeBackend,
 		baseURL:                   baseURL,
@@ -425,16 +429,28 @@ func clientID(server ServerConfig, clientScope string) string {
 func (sm *SessionManager) GenerateToolPreviews(ctx context.Context, tempMCPServer v1.MCPServer, serverConfig ServerConfig) ([]types.MCPServerTool, error) {
 	// Ensure cleanup happens regardless of success or failure
 	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
 		if cleanupErr := sm.ShutdownServer(ctx, serverConfig.MCPServerName); cleanupErr != nil {
 			log.Errorf("failed to clean up temporary instance %s: %v", tempMCPServer.Name, cleanupErr)
 		}
 	}()
 
+	serverConfig, err := sm.LaunchServer(ctx, serverConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	// Use "system" for the user ID to identify non-user MCP servers.
 	serverConfig.UserID = "system"
 
 	// Create MCP client and list tools
-	client, err := sm.clientForServer(ctx, serverConfig)
+	client, err := sm.clientForServerWithOptions(ctx, "default", serverConfig, nmcp.ClientOption{
+		ClientName: "Obot Tool Preview",
+		HTTPClientOptions: nmcp.HTTPClientOptions{
+			TokenStorage: sm.globalTokenStore.ForUserAndMCP(serverConfig.UserID, serverConfig.MCPServerName),
+		},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -526,7 +526,6 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		}
 		return apiKey.ServiceAccountName, nil
 	})
-	mcpOAuthTokenStorage := mcpgateway.NewGlobalTokenStore(gatewayClient)
 
 	// Build local Kubernetes config for deployment monitoring (optional)
 	var (
@@ -656,7 +655,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 
 	webhookHelper := mcp.NewWebhookHelper(mcpWebhookValidationInformer.GetIndexer(), config.Hostname)
 
-	mcpSessionManager, err := mcp.NewSessionManager(ctx, config.EnableAuthentication, persistentTokenServer, config.Hostname, config.HTTPListenPort, mcp.Options(config.MCPConfig), webhookHelper, localK8sConfig, apiLocalK8sClient, localCacheClient, storageClient, gatewayClient, config.ServiceNamespace)
+	mcpOAuthTokenStorage := mcpgateway.NewGlobalTokenStore(gatewayClient)
+	mcpSessionManager, err := mcp.NewSessionManager(ctx, config.EnableAuthentication, mcpOAuthTokenStorage, persistentTokenServer, config.Hostname, config.HTTPListenPort, mcp.Options(config.MCPConfig), webhookHelper, localK8sConfig, apiLocalK8sClient, localCacheClient, storageClient, gatewayClient, config.ServiceNamespace)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We can't go through the proxy for tool previews because the proxy tries to launch an MCP server. A server doesn't exist in the database for tool-previews so it would fail.

This change addresses it by connecting to the MCP server directly.

Issue: https://github.com/obot-platform/obot/issues/7161