### PR TITLE
feat: add built-in local authentication

### DIFF
--- a/docs/docs/configuration/auth-providers.md
+++ b/docs/docs/configuration/auth-providers.md
@@ -63,7 +63,25 @@ You can:
 
 ## Available Auth Providers
 
-Obot currently supports the following authentication providers (using OAuth2). Before getting started you will need to follow the instructions in the auth provider for setting up a new app. You can get the callback URL from the Obot Admin -> Auth Providers -> \<Auth Provider> -> Configure page. The configuration form will also have fields for the data required.
+Obot supports the built-in [Local](#local) provider, as well as the following providers that authenticate against an external identity provider using OAuth2. For the OAuth2 providers, you will need to follow the instructions in the auth provider for setting up a new app before getting started. You can get the callback URL from the Obot Admin -> Auth Providers -> \<Auth Provider> -> Configure page. The configuration form will also have fields for the data required.
+
+### Local
+
+The Local provider authenticates users with an email address and password stored in Obot's own database. It requires no external identity provider, which makes it a good fit for evaluations, air-gapped installations, and small deployments.
+
+Passwords are hashed with [argon2id](https://en.wikipedia.org/wiki/Argon2) and are never stored, logged, or returned by the API.
+
+To set it up:
+
+1. Go to Admin -> Auth Providers and configure the **Local** provider, setting the email domains that local users are allowed to have (`*` allows any domain).
+2. Click the **Manage Users** button on the Local provider card, and create a user. Share the password with them over a secure channel.
+3. Local users sign in from the Obot login page by choosing **Local**, then entering their email and password.
+
+:::note
+Local users cannot change their own password. An administrator resets a password from the same Manage Users dialog, which also signs the user out of all of their existing sessions.
+:::
+
+Deleting a local user prevents them from signing in again, but it does not delete the Obot user account they created by signing in. Delete that from the Users page, as you would for any other user.
 
 ### GitHub
 

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -56,6 +56,8 @@ var (
 		"DELETE /api/license",
 		"/api/auth-providers",
 		"/api/auth-providers/",
+		"/api/local-auth/users",
+		"/api/local-auth/users/",
 		"/api/model-providers",
 		"/api/model-providers/",
 		"GET /api/bookstrap",

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -168,6 +168,8 @@ var (
 			"GET /api/image-pull-secrets",
 			"GET /api/image-pull-secrets/",
 			"POST /api/auth-providers/",
+			"GET /api/local-auth/users",
+			"GET /api/local-auth/users/",
 			"GET /api/workspaces/",
 			"/api/audit-log-exports",
 			"/api/audit-log-exports/",

--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
 	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/license"
+	"github.com/obot-platform/obot/pkg/localauth"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/wait"
@@ -181,6 +182,14 @@ func (ap *AuthProviderHandler) Deconfigure(req api.Context) error {
 
 	// Stop the auth provider so that the credential is completely removed from the system.
 	ap.dispatcher.StopAuthProvider(authProvider.Namespace, authProvider.Name)
+
+	// The local auth provider keeps its sessions in Obot's database rather than in the sessions
+	// table the block below drops, so clear them out here.
+	if authProvider.Name == localauth.ProviderName {
+		if err := req.GatewayClient.DeleteAllLocalAuthSessions(req.Context()); err != nil {
+			return fmt.Errorf("failed to delete local auth sessions: %w", err)
+		}
+	}
 
 	if authProvider.Annotations[v1.AuthProviderSyncAnnotation] == "" {
 		if authProvider.Annotations == nil {

--- a/pkg/api/handlers/localauth.go
+++ b/pkg/api/handlers/localauth.go
@@ -124,8 +124,7 @@ func (h *LocalAuthHandler) Delete(req api.Context) error {
 		return err
 	}
 
-	err = h.provider.DeleteUser(req.Context(), id)
-	if errors.Is(err, gorm.ErrRecordNotFound) {
+	if err = h.provider.DeleteUser(req.Context(), id); errors.Is(err, gorm.ErrRecordNotFound) {
 		return types.NewErrNotFound("local auth user not found")
 	} else if err != nil {
 		return fmt.Errorf("failed to delete local auth user: %w", err)

--- a/pkg/api/handlers/localauth.go
+++ b/pkg/api/handlers/localauth.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	gateway "github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/localauth"
+	"gorm.io/gorm"
+)
+
+type LocalAuthHandler struct {
+	provider *localauth.Provider
+}
+
+func NewLocalAuthHandler(provider *localauth.Provider) *LocalAuthHandler {
+	return &LocalAuthHandler{
+		provider: provider,
+	}
+}
+
+// LocalAuthUser is a user of the local auth provider, as returned by the API.
+// Passwords are never returned, in any form.
+type LocalAuthUser struct {
+	types.Metadata
+	Email string `json:"email"`
+}
+
+type localAuthUserRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+func (h *LocalAuthHandler) List(req api.Context) error {
+	if err := h.enabled(); err != nil {
+		return err
+	}
+
+	users, err := h.provider.Users(req.Context())
+	if err != nil {
+		return fmt.Errorf("failed to list local auth users: %w", err)
+	}
+
+	items := make([]LocalAuthUser, 0, len(users))
+	for _, user := range users {
+		items = append(items, LocalAuthUser{
+			Metadata: types.Metadata{
+				ID:      strconv.FormatUint(uint64(user.ID), 10),
+				Created: *types.NewTime(user.CreatedAt),
+			},
+			Email: user.Email,
+		})
+	}
+
+	return req.Write(types.List[LocalAuthUser]{Items: items})
+}
+
+func (h *LocalAuthHandler) Create(req api.Context) error {
+	if err := h.enabled(); err != nil {
+		return err
+	}
+
+	var body localAuthUserRequest
+	if err := req.Read(&body); err != nil {
+		return types.NewErrBadRequest("invalid request body: %v", err)
+	}
+
+	user, err := h.provider.CreateUser(req.Context(), body.Email, body.Password)
+	if errors.Is(err, gateway.ErrLocalAuthUserExists) {
+		return types.NewErrBadRequest("a local user with that email already exists")
+	} else if invalid := (localauth.InvalidUserError{}); errors.As(err, &invalid) {
+		return types.NewErrBadRequest("%s", invalid.Error())
+	} else if err != nil {
+		return fmt.Errorf("failed to create local auth user: %w", err)
+	}
+
+	return req.Write(LocalAuthUser{
+		Metadata: types.Metadata{
+			ID:      strconv.FormatUint(uint64(user.ID), 10),
+			Created: *types.NewTime(user.CreatedAt),
+		},
+		Email: user.Email,
+	})
+}
+
+// SetPassword resets a local user's password, which also signs them out of all their sessions.
+func (h *LocalAuthHandler) SetPassword(req api.Context) error {
+	if err := h.enabled(); err != nil {
+		return err
+	}
+
+	id, err := localAuthUserID(req)
+	if err != nil {
+		return err
+	}
+
+	var body localAuthUserRequest
+	if err := req.Read(&body); err != nil {
+		return types.NewErrBadRequest("invalid request body: %v", err)
+	}
+
+	err = h.provider.SetPassword(req.Context(), id, body.Password)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return types.NewErrNotFound("local auth user not found")
+	} else if invalid := (localauth.InvalidUserError{}); errors.As(err, &invalid) {
+		return types.NewErrBadRequest("%s", invalid.Error())
+	} else if err != nil {
+		return fmt.Errorf("failed to set password for local auth user: %w", err)
+	}
+
+	return nil
+}
+
+func (h *LocalAuthHandler) Delete(req api.Context) error {
+	if err := h.enabled(); err != nil {
+		return err
+	}
+
+	id, err := localAuthUserID(req)
+	if err != nil {
+		return err
+	}
+
+	err = h.provider.DeleteUser(req.Context(), id)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return types.NewErrNotFound("local auth user not found")
+	} else if err != nil {
+		return fmt.Errorf("failed to delete local auth user: %w", err)
+	}
+
+	return nil
+}
+
+func (h *LocalAuthHandler) enabled() error {
+	if h.provider == nil {
+		return types.NewErrBadRequest("the local auth provider is not available because authentication is disabled")
+	}
+	return nil
+}
+
+func localAuthUserID(req api.Context) (uint, error) {
+	id, err := strconv.ParseUint(req.PathValue("id"), 10, 64)
+	if err != nil {
+		return 0, types.NewErrBadRequest("invalid local auth user ID")
+	}
+	return uint(id), nil
+}

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -101,6 +101,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mdmConfigurations := handlers.NewMDMConfigurationsHandler(services.ServerURL)
 	deviceEnroll := handlers.NewDeviceEnrollHandler()
 	authProviders := handlers.NewAuthProviderHandler(services.ProviderDispatcher, services.PostgresDSN, services.LicenseProvider)
+	localAuth := handlers.NewLocalAuthHandler(services.LocalAuthProvider)
 	defaultModelAliases := handlers.NewDefaultModelAliasHandler()
 	images := handlers.NewImageHandler()
 	mcp := handlers.NewMCPHandler(services.MCPSessionManager, services.AccessControlRuleHelper, oauthChecker, services.Router.Backend(), services.MCPImagePullSecrets, services.ServerURL, services.MCPSecretBindingAllowedLabel)
@@ -499,6 +500,12 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mux.HandleFunc("POST /api/auth-providers/{id}/configure", authProviders.Configure)
 	mux.HandleFunc("POST /api/auth-providers/{id}/deconfigure", authProviders.Deconfigure)
 	mux.HandleFunc("POST /api/auth-providers/{id}/reveal", authProviders.Reveal)
+
+	// Local auth provider users
+	mux.HandleFunc("GET /api/local-auth/users", localAuth.List)
+	mux.HandleFunc("POST /api/local-auth/users", localAuth.Create)
+	mux.HandleFunc("POST /api/local-auth/users/{id}/password", localAuth.SetPassword)
+	mux.HandleFunc("DELETE /api/local-auth/users/{id}", localAuth.Delete)
 
 	// Bootstrap
 	mux.HandleFunc("GET /api/bootstrap", services.Bootstrapper.IsEnabled)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -617,14 +617,7 @@ func (c *Controller) ensureAuthProvidersAndModelProviders(ctx context.Context) e
 	// shutting down properly, which caused a significant delay in startup when upgrading from
 	// v0.22.1. The built-in local auth provider doesn't come from the registry, so it doesn't
 	// count towards this check.
-	registryProviders := 0
-	for _, authProvider := range authProviders.Items {
-		if authProvider.Name != localauth.ProviderName {
-			registryProviders++
-		}
-	}
-
-	if registryProviders == 0 {
+	if len(authProviders.Items) <= 1 {
 		if err := c.providerHandler.ReadFromRegistry(ctx, c.services.StorageClient); err != nil {
 			return fmt.Errorf("failed to read from registry: %w", err)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/obot-platform/obot/pkg/controller/handlers/modelinfosource"
 	"github.com/obot-platform/obot/pkg/controller/handlers/provider"
 	"github.com/obot-platform/obot/pkg/controller/handlers/secret"
+	"github.com/obot-platform/obot/pkg/localauth"
 	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/obot-platform/obot/pkg/serviceaccounts"
 	"github.com/obot-platform/obot/pkg/services"
@@ -575,16 +576,55 @@ func (c *Controller) setupLocalK8sRoutes() {
 	c.services.LocalRouter.Type(&corev1.Secret{}).Namespace(c.services.ServiceNamespace).Name(serviceaccounts.NetworkPolicySecretName).IncludeRemoved().HandlerFunc(c.reconcileServiceAccountSecretChange)
 }
 
+// ensureLocalAuthProvider creates or updates the AuthProvider resource for the built-in local
+// auth provider. It doesn't come from the provider registry like the others, because it runs
+// inside this process rather than as a daemon.
+func (c *Controller) ensureLocalAuthProvider(ctx context.Context) error {
+	if c.services.LocalAuthProvider == nil {
+		// Authentication is disabled, so there is nothing to log into.
+		return nil
+	}
+
+	authProvider := localauth.AuthProvider()
+
+	var existing v1.AuthProvider
+	if err := c.services.StorageClient.Get(ctx, kclient.ObjectKeyFromObject(authProvider), &existing); apierrors.IsNotFound(err) {
+		return c.services.StorageClient.Create(ctx, authProvider)
+	} else if err != nil {
+		return fmt.Errorf("failed to get local auth provider: %w", err)
+	}
+
+	if equality.Semantic.DeepEqual(existing.Spec, authProvider.Spec) {
+		return nil
+	}
+
+	existing.Spec = authProvider.Spec
+	return c.services.StorageClient.Update(ctx, &existing)
+}
+
 func (c *Controller) ensureAuthProvidersAndModelProviders(ctx context.Context) error {
+	if err := c.ensureLocalAuthProvider(ctx); err != nil {
+		return fmt.Errorf("failed to ensure local auth provider: %w", err)
+	}
+
 	var authProviders v1.AuthProviderList
 	if err := c.services.StorageClient.List(ctx, &authProviders); err != nil {
 		return fmt.Errorf("failed to list auth providers: %w", err)
 	}
 
-	// If there are no auth providers, then read the registry to get them populated and statuses set.
-	// This works around a problem where the controllers weren't shutting down properly, which caused
-	// a significant delay in startup when upgrading from v0.22.1.
-	if len(authProviders.Items) == 0 {
+	// If there are no auth providers from the registry, then read the registry to get them
+	// populated and statuses set. This works around a problem where the controllers weren't
+	// shutting down properly, which caused a significant delay in startup when upgrading from
+	// v0.22.1. The built-in local auth provider doesn't come from the registry, so it doesn't
+	// count towards this check.
+	registryProviders := 0
+	for _, authProvider := range authProviders.Items {
+		if authProvider.Name != localauth.ProviderName {
+			registryProviders++
+		}
+	}
+
+	if registryProviders == 0 {
 		if err := c.providerHandler.ReadFromRegistry(ctx, c.services.StorageClient); err != nil {
 			return fmt.Errorf("failed to read from registry: %w", err)
 		}

--- a/pkg/controller/handlers/cleanup/user.go
+++ b/pkg/controller/handlers/cleanup/user.go
@@ -39,7 +39,7 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 		return err
 	}
 
-	if err = u.gatewayClient.DeleteSessionsForUser(req.Ctx, req.Client, identities, ""); err != nil {
+	if err = u.gatewayClient.DeleteSessionsForUser(req.Ctx, req.Client, identities, "", ""); err != nil {
 		if !errors.Is(err, gclient.LogoutAllErr{}) {
 			return err
 		}

--- a/pkg/gateway/client/localauth.go
+++ b/pkg/gateway/client/localauth.go
@@ -1,0 +1,229 @@
+package client
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/hash"
+	"gorm.io/gorm"
+	"k8s.io/apiserver/pkg/storage/value"
+)
+
+// ErrLocalAuthUserExists is returned when creating a local auth user whose email is already taken.
+var ErrLocalAuthUserExists = errors.New("local auth user already exists")
+
+// NormalizeEmail lowercases and trims an email address so that logins are case-insensitive.
+func NormalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+func (c *Client) LocalAuthUsers(ctx context.Context) ([]types.LocalAuthUser, error) {
+	var users []types.LocalAuthUser
+	if err := c.db.WithContext(ctx).Order("created_at").Find(&users).Error; err != nil {
+		return nil, err
+	}
+
+	for i := range users {
+		if err := c.decryptLocalAuthUser(ctx, &users[i]); err != nil {
+			return nil, fmt.Errorf("failed to decrypt local auth user: %w", err)
+		}
+	}
+
+	return users, nil
+}
+
+func (c *Client) LocalAuthUserByEmail(ctx context.Context, email string) (*types.LocalAuthUser, error) {
+	var user types.LocalAuthUser
+	if err := c.db.WithContext(ctx).Where("hashed_email = ?", hash.String(NormalizeEmail(email))).First(&user).Error; err != nil {
+		return nil, err
+	}
+
+	if err := c.decryptLocalAuthUser(ctx, &user); err != nil {
+		return nil, fmt.Errorf("failed to decrypt local auth user: %w", err)
+	}
+
+	return &user, nil
+}
+
+// CreateLocalAuthUser creates a new local auth user. The password must already be hashed.
+func (c *Client) CreateLocalAuthUser(ctx context.Context, email, passwordHash string) (*types.LocalAuthUser, error) {
+	email = NormalizeEmail(email)
+	user := types.LocalAuthUser{
+		Email:        email,
+		HashedEmail:  hash.String(email),
+		PasswordHash: passwordHash,
+	}
+
+	if err := c.encryptLocalAuthUser(ctx, &user); err != nil {
+		return nil, fmt.Errorf("failed to encrypt local auth user: %w", err)
+	}
+
+	if err := c.db.WithContext(ctx).Create(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(strings.ToLower(err.Error()), "unique") {
+			return nil, ErrLocalAuthUserExists
+		}
+		return nil, err
+	}
+
+	user.Email = email
+	user.Encrypted = false
+	return &user, nil
+}
+
+// SetLocalAuthUserPassword updates a user's password hash and invalidates all of their sessions,
+// so that a password reset actually kicks the old sessions out.
+func (c *Client) SetLocalAuthUserPassword(ctx context.Context, id uint, passwordHash string) error {
+	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Model(new(types.LocalAuthUser)).Where("id = ?", id).Update("password_hash", passwordHash)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return gorm.ErrRecordNotFound
+		}
+
+		return tx.Where("user_id = ?", id).Delete(new(types.LocalAuthSession)).Error
+	})
+}
+
+func (c *Client) DeleteLocalAuthUser(ctx context.Context, id uint) error {
+	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Where("id = ?", id).Delete(new(types.LocalAuthUser))
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return gorm.ErrRecordNotFound
+		}
+
+		return tx.Where("user_id = ?", id).Delete(new(types.LocalAuthSession)).Error
+	})
+}
+
+// CreateLocalAuthSession records a session for the given user. The ID must be a hash of the
+// token that is handed to the browser, never the token itself.
+func (c *Client) CreateLocalAuthSession(ctx context.Context, id string, userID uint, expiresAt time.Time) error {
+	return c.db.WithContext(ctx).Create(&types.LocalAuthSession{
+		ID:        id,
+		UserID:    userID,
+		ExpiresAt: expiresAt,
+	}).Error
+}
+
+// LocalAuthSession returns the unexpired session with the given ID, along with its user.
+// Expired sessions are treated as missing and deleted.
+func (c *Client) LocalAuthSession(ctx context.Context, id string) (*types.LocalAuthSession, *types.LocalAuthUser, error) {
+	var session types.LocalAuthSession
+	if err := c.db.WithContext(ctx).Where("id = ?", id).First(&session).Error; err != nil {
+		return nil, nil, err
+	}
+
+	if !session.ExpiresAt.After(time.Now()) {
+		_ = c.DeleteLocalAuthSession(ctx, id)
+		return nil, nil, gorm.ErrRecordNotFound
+	}
+
+	var user types.LocalAuthUser
+	if err := c.db.WithContext(ctx).Where("id = ?", session.UserID).First(&user).Error; err != nil {
+		return nil, nil, err
+	}
+
+	if err := c.decryptLocalAuthUser(ctx, &user); err != nil {
+		return nil, nil, fmt.Errorf("failed to decrypt local auth user: %w", err)
+	}
+
+	return &session, &user, nil
+}
+
+func (c *Client) DeleteLocalAuthSession(ctx context.Context, id string) error {
+	return c.db.WithContext(ctx).Where("id = ?", id).Delete(new(types.LocalAuthSession)).Error
+}
+
+// DeleteLocalAuthSessionsForEmail signs the local user with the given email out of all sessions.
+// If exceptSessionID is non-empty, that one session is kept (used to preserve the caller's own
+// session when they log out everywhere else).
+func (c *Client) DeleteLocalAuthSessionsForEmail(ctx context.Context, email, exceptSessionID string) error {
+	var user types.LocalAuthUser
+	if err := c.db.WithContext(ctx).Where("hashed_email = ?", hash.String(NormalizeEmail(email))).First(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	q := c.db.WithContext(ctx).Where("user_id = ?", user.ID)
+	if exceptSessionID != "" {
+		q = q.Where("id != ?", exceptSessionID)
+	}
+
+	return q.Delete(new(types.LocalAuthSession)).Error
+}
+
+// DeleteAllLocalAuthSessions signs every local user out. It is used when the provider is
+// deconfigured, so that reconfiguring it later doesn't bring old sessions back to life.
+func (c *Client) DeleteAllLocalAuthSessions(ctx context.Context) error {
+	return c.db.WithContext(ctx).Where("1 = 1").Delete(new(types.LocalAuthSession)).Error
+}
+
+// DeleteExpiredLocalAuthSessions removes sessions that are past their expiration.
+func (c *Client) DeleteExpiredLocalAuthSessions(ctx context.Context) error {
+	return c.db.WithContext(ctx).Where("expires_at < ?", time.Now()).Delete(new(types.LocalAuthSession)).Error
+}
+
+func localAuthUserDataCtx(user *types.LocalAuthUser) value.Context {
+	return value.DefaultContext(fmt.Sprintf("%s/%s", userGroupResource.String(), user.HashedEmail))
+}
+
+// encryptLocalAuthUser encrypts the email address at rest, reusing the same transformer as the
+// users table. The password hash is not encrypted: it is already a one-way hash.
+func (c *Client) encryptLocalAuthUser(ctx context.Context, user *types.LocalAuthUser) error {
+	if c.encryptionConfig == nil {
+		return nil
+	}
+
+	transformer := c.encryptionConfig.Transformers[userGroupResource]
+	if transformer == nil {
+		return nil
+	}
+
+	b, err := transformer.TransformToStorage(ctx, []byte(user.Email), localAuthUserDataCtx(user))
+	if err != nil {
+		return err
+	}
+
+	user.Email = base64.StdEncoding.EncodeToString(b)
+	user.Encrypted = true
+
+	return nil
+}
+
+func (c *Client) decryptLocalAuthUser(ctx context.Context, user *types.LocalAuthUser) error {
+	if !user.Encrypted || c.encryptionConfig == nil {
+		return nil
+	}
+
+	transformer := c.encryptionConfig.Transformers[userGroupResource]
+	if transformer == nil {
+		return nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(user.Email)
+	if err != nil {
+		return err
+	}
+
+	out, _, err := transformer.TransformFromStorage(ctx, decoded, localAuthUserDataCtx(user))
+	if err != nil {
+		return err
+	}
+
+	user.Email = string(out)
+	user.Encrypted = false
+
+	return nil
+}

--- a/pkg/gateway/client/session.go
+++ b/pkg/gateway/client/session.go
@@ -20,19 +20,44 @@ func (e LogoutAllErr) Error() string {
 	return "logout all is not supported in the current configuration"
 }
 
-func (c *Client) DeleteSessionsForUser(ctx context.Context, storageClient kclient.Client, identities []types.Identity, sessionID string) error {
-	return c.deleteSessionsForUser(ctx, c.db.WithContext(ctx), storageClient, identities, sessionID)
+// DeleteSessionsForUser deletes the user's sessions across all of their identities. When
+// keepSessionID / keepLocalSessionID are non-empty, the caller's current session is preserved
+// (the "log out everywhere else" flow); when both are empty, every session is deleted (e.g. when
+// the user is being deleted).
+func (c *Client) DeleteSessionsForUser(ctx context.Context, storageClient kclient.Client, identities []types.Identity, sessionID, localSessionID string) error {
+	return c.deleteSessionsForUser(ctx, c.db.WithContext(ctx), storageClient, identities, sessionID, localSessionID)
 }
 
-func (c *Client) deleteSessionsForUser(ctx context.Context, db *gorm.DB, storageClient kclient.Client, identities []types.Identity, sessionID string) error {
-	// Logout all sessions is only supported when using PostgreSQL.
-	if db.Name() != "postgres" {
-		return LogoutAllErr{}
-	}
-
+func (c *Client) deleteSessionsForUser(ctx context.Context, db *gorm.DB, storageClient kclient.Client, identities []types.Identity, sessionID, localSessionID string) error {
 	logger := gcontext.GetLogger(ctx)
 	var errs []error
+
+	// The local auth provider keeps its sessions in Obot's own database, so they can be deleted on
+	// any database backend, unlike the oauth2-proxy sessions handled below.
+	var external []types.Identity
 	for _, identity := range identities {
+		if identity.AuthProviderName == system.LocalAuthProvider && identity.AuthProviderNamespace == system.DefaultNamespace {
+			if err := c.DeleteLocalAuthSessionsForEmail(ctx, identity.Email, localSessionID); err != nil {
+				errs = append(errs, fmt.Errorf("failed to delete local auth sessions: %w", err))
+			} else {
+				logger.Infof("deleted sessions: provider=%s emailHash=%s", identity.AuthProviderName, hash.String(identity.Email))
+			}
+			continue
+		}
+
+		external = append(external, identity)
+	}
+
+	if len(external) == 0 {
+		return errors.Join(errs...)
+	}
+
+	// Logging out of the other providers' sessions is only supported when using PostgreSQL.
+	if db.Name() != "postgres" {
+		return errors.Join(append(errs, LogoutAllErr{})...)
+	}
+
+	for _, identity := range external {
 		if identity.AuthProviderName == "" || identity.AuthProviderNamespace == "" {
 			continue
 		}

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -14,6 +14,7 @@ import (
 	"github.com/obot-platform/obot/pkg/accesstoken"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
@@ -355,6 +356,11 @@ func (c *Client) UpdateProfileIfNeeded(ctx context.Context, user *types.User, au
 		}
 	case "okta-auth-provider":
 		// Okta does not support profile pictures
+		if displayName, ok := profile["name"].(string); ok {
+			user.DisplayName = displayName
+		}
+	case system.LocalAuthProvider:
+		// Local users have no profile beyond their email address, and no picture.
 		if displayName, ok := profile["name"].(string); ok {
 			user.DisplayName = displayName
 		}

--- a/pkg/gateway/db/db.go
+++ b/pkg/gateway/db/db.go
@@ -136,6 +136,8 @@ func (db *DB) AutoMigrate() (err error) {
 		types.DeviceEnrollmentKey{},
 		types.Device{},
 		types.Credential{},
+		types.LocalAuthUser{},
+		types.LocalAuthSession{},
 	); err != nil {
 		return fmt.Errorf("failed to auto migrate gateway types: %w", err)
 	}

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/gateway/client"
@@ -35,17 +36,21 @@ type Dispatcher struct {
 	internalServerURL    string
 	authProviderExtraEnv map[string]string
 	ports                *ports
+
+	builtinLock         sync.RWMutex
+	builtinAuthProvider map[string]url.URL
 }
 
 func New(sessionManager *mcp.SessionManager, c kclient.Client, gatewayClient *client.Client, licenseProvider *license.Provider, serverURL, internalServerURL, postgresDSN string) *Dispatcher {
 	d := &Dispatcher{
-		sessionManager:    sessionManager,
-		client:            c,
-		gatewayClient:     gatewayClient,
-		licenseProvider:   licenseProvider,
-		serverURL:         serverURL,
-		internalServerURL: internalServerURL,
-		ports:             newPorts(),
+		sessionManager:      sessionManager,
+		client:              c,
+		gatewayClient:       gatewayClient,
+		licenseProvider:     licenseProvider,
+		serverURL:           serverURL,
+		internalServerURL:   internalServerURL,
+		ports:               newPorts(),
+		builtinAuthProvider: map[string]url.URL{},
 	}
 
 	if postgresDSN != "" {
@@ -64,8 +69,29 @@ func (d *Dispatcher) Close() {
 	d.closeDaemons()
 }
 
+// RegisterBuiltinAuthProvider registers an auth provider that runs inside the Obot process,
+// rather than as a daemon launched from the provider registry.
+func (d *Dispatcher) RegisterBuiltinAuthProvider(namespace, authProviderName string, u url.URL) {
+	d.builtinLock.Lock()
+	defer d.builtinLock.Unlock()
+
+	d.builtinAuthProvider[providerKeyForAuthProvider(namespace, authProviderName)] = u
+}
+
+func (d *Dispatcher) builtinAuthProviderURL(key string) (url.URL, bool) {
+	d.builtinLock.RLock()
+	defer d.builtinLock.RUnlock()
+
+	u, ok := d.builtinAuthProvider[key]
+	return u, ok
+}
+
 func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProviderName string) (url.URL, error) {
 	key := providerKeyForAuthProvider(namespace, authProviderName)
+
+	if u, ok := d.builtinAuthProviderURL(key); ok {
+		return u, nil
+	}
 
 	d.ports.daemonLock.RLock()
 	if port := d.ports.daemonPorts[key]; port != 0 {

--- a/pkg/gateway/server/logout_all.go
+++ b/pkg/gateway/server/logout_all.go
@@ -6,18 +6,32 @@ import (
 	"strings"
 
 	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/hash"
 	"github.com/obot-platform/obot/pkg/proxy"
 )
 
 func (s *Server) logoutAll(apiContext api.Context) error {
 	sessionID := getSessionID(apiContext.Request)
+	localSessionID := getLocalSessionID(apiContext.Request)
 
 	identities, err := apiContext.GatewayClient.FindIdentitiesForUser(apiContext.Context(), apiContext.UserID())
 	if err != nil {
 		return err
 	}
 
-	return apiContext.GatewayClient.DeleteSessionsForUser(apiContext.Context(), apiContext.Storage, identities, sessionID)
+	return apiContext.GatewayClient.DeleteSessionsForUser(apiContext.Context(), apiContext.Storage, identities, sessionID, localSessionID)
+}
+
+// getLocalSessionID returns the local auth provider's session ID for the current request, which is
+// the hash of the access-token cookie (matching how the local provider stores sessions). It is
+// empty when there is no cookie. For a non-local cookie the value simply won't match any local
+// session, so passing it is harmless.
+func getLocalSessionID(req *http.Request) string {
+	cookie, err := req.Cookie(proxy.ObotAccessTokenCookie)
+	if err != nil {
+		return ""
+	}
+	return hash.String(cookie.Value)
 }
 
 func getSessionID(req *http.Request) string {

--- a/pkg/gateway/types/localauth.go
+++ b/pkg/gateway/types/localauth.go
@@ -1,0 +1,27 @@
+//nolint:revive
+package types
+
+import "time"
+
+// LocalAuthUser is a username/password user managed by the local auth provider.
+// The email address is the login name and is also what identifies the user to the rest of Obot,
+// so it is immutable: to change it, delete the user and create a new one.
+type LocalAuthUser struct {
+	ID           uint      `json:"id" gorm:"primaryKey"`
+	CreatedAt    time.Time `json:"createdAt"`
+	UpdatedAt    time.Time `json:"updatedAt"`
+	Email        string    `json:"email"`
+	HashedEmail  string    `json:"-" gorm:"uniqueIndex"`
+	PasswordHash string    `json:"-"`
+	Encrypted    bool      `json:"-"`
+}
+
+// LocalAuthSession is a login session created by the local auth provider.
+// ID is the SHA-256 hash of the session token that is handed to the browser,
+// so a database leak does not hand out usable sessions.
+type LocalAuthSession struct {
+	ID        string    `json:"-" gorm:"primaryKey"`
+	CreatedAt time.Time `json:"createdAt"`
+	ExpiresAt time.Time `json:"expiresAt" gorm:"index"`
+	UserID    uint      `json:"userID" gorm:"index"`
+}

--- a/pkg/localauth/manifest.go
+++ b/pkg/localauth/manifest.go
@@ -1,0 +1,44 @@
+package localauth
+
+import (
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The icons are inlined so that the provider has no external dependencies, unlike the other
+// providers whose icons are shipped in the provider registry image.
+const (
+	icon     = `data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMWYyOTM3IiBzdHJva2Utd2lkdGg9IjEuNzUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHJlY3QgeD0iMyIgeT0iMTAiIHdpZHRoPSIxOCIgaGVpZ2h0PSIxMSIgcng9IjIiLz48cGF0aCBkPSJNNyAxMFY3YTUgNSAwIDAgMSAxMCAwdjMiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjE1LjUiIHI9IjEuMjUiIGZpbGw9IiMxZjI5MzciIHN0cm9rZT0ibm9uZSIvPjxwYXRoIGQ9Ik0xMiAxNi43NXYxLjc1Ii8+PC9zdmc+`
+	iconDark = `data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZTVlN2ViIiBzdHJva2Utd2lkdGg9IjEuNzUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHJlY3QgeD0iMyIgeT0iMTAiIHdpZHRoPSIxOCIgaGVpZ2h0PSIxMSIgcng9IjIiLz48cGF0aCBkPSJNNyAxMFY3YTUgNSAwIDAgMSAxMCAwdjMiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjE1LjUiIHI9IjEuMjUiIGZpbGw9IiNlNWU3ZWIiIHN0cm9rZT0ibm9uZSIvPjxwYXRoIGQ9Ik0xMiAxNi43NXYxLjc1Ii8+PC9zdmc+`
+)
+
+// AuthProvider returns the AuthProvider resource for the built-in local auth provider.
+// It has no Command: the dispatcher serves it from within the Obot process instead of launching
+// a daemon for it.
+func AuthProvider() *v1.AuthProvider {
+	return &v1.AuthProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ProviderName,
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.AuthProviderSpec{
+			AuthProviderManifest: types.AuthProviderManifest{
+				CommonProviderMetadata: types.CommonProviderMetadata{
+					Name:        "Local",
+					Icon:        icon,
+					IconDark:    iconDark,
+					Description: "Authenticate users with an email address and password stored in Obot. No external identity provider required.",
+					RequiredConfigurationParameters: []types.ProviderConfigurationParameter{
+						{
+							Name:         EmailDomainsEnvVar,
+							FriendlyName: "Allowed Email Domains",
+							Description:  "Comma-separated list of email domains that local users may have. Use * to allow any domain.",
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/localauth/password.go
+++ b/pkg/localauth/password.go
@@ -11,17 +11,17 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-// MinPasswordLength is the shortest password that can be set on a local user.
-const MinPasswordLength = 12
-
-// Argon2id parameters. These follow the OWASP recommendation of 19 MiB of memory,
-// 2 iterations, and 1 degree of parallelism.
 const (
+	// Argon2id parameters. These follow the OWASP recommendation of 19 MiB of memory,
+	// 2 iterations, and 1 degree of parallelism.
 	argonTime    = 2
 	argonMemory  = 19 * 1024 // KiB
 	argonThreads = 1
 	argonKeyLen  = 32
 	argonSaltLen = 16
+
+	// minPasswordLength is the shortest password that can be set on a local user.
+	minPasswordLength = 12
 )
 
 var (
@@ -34,8 +34,8 @@ var (
 // HashPassword hashes a plaintext password with argon2id and returns it in the PHC string format,
 // which carries the parameters and salt alongside the derived key.
 func HashPassword(password string) (string, error) {
-	if len(password) < MinPasswordLength {
-		return "", fmt.Errorf("password must be at least %d characters", MinPasswordLength)
+	if len(password) < minPasswordLength {
+		return "", fmt.Errorf("password must be at least %d characters", minPasswordLength)
 	}
 
 	salt := make([]byte, argonSaltLen)

--- a/pkg/localauth/password.go
+++ b/pkg/localauth/password.go
@@ -1,0 +1,93 @@
+package localauth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// MinPasswordLength is the shortest password that can be set on a local user.
+const MinPasswordLength = 12
+
+// Argon2id parameters. These follow the OWASP recommendation of 19 MiB of memory,
+// 2 iterations, and 1 degree of parallelism.
+const (
+	argonTime    = 2
+	argonMemory  = 19 * 1024 // KiB
+	argonThreads = 1
+	argonKeyLen  = 32
+	argonSaltLen = 16
+)
+
+var (
+	// ErrInvalidPassword is returned when a password does not match its hash.
+	ErrInvalidPassword = errors.New("invalid password")
+
+	errInvalidHash = errors.New("invalid password hash")
+)
+
+// HashPassword hashes a plaintext password with argon2id and returns it in the PHC string format,
+// which carries the parameters and salt alongside the derived key.
+func HashPassword(password string) (string, error) {
+	if len(password) < MinPasswordLength {
+		return "", fmt.Errorf("password must be at least %d characters", MinPasswordLength)
+	}
+
+	salt := make([]byte, argonSaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("failed to generate salt: %w", err)
+	}
+
+	key := argon2.IDKey([]byte(password), salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+
+	return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version, argonMemory, argonTime, argonThreads,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(key),
+	), nil
+}
+
+// VerifyPassword checks a plaintext password against a PHC-encoded argon2id hash.
+// It returns ErrInvalidPassword if the password does not match.
+func VerifyPassword(encodedHash, password string) error {
+	parts := strings.Split(encodedHash, "$")
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return errInvalidHash
+	}
+
+	var version int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &version); err != nil {
+		return errInvalidHash
+	} else if version != argon2.Version {
+		return fmt.Errorf("%w: unsupported argon2 version %d", errInvalidHash, version)
+	}
+
+	var memory, time uint32
+	var threads uint8
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &memory, &time, &threads); err != nil {
+		return errInvalidHash
+	}
+
+	salt, err := base64.RawStdEncoding.Strict().DecodeString(parts[4])
+	if err != nil {
+		return errInvalidHash
+	}
+
+	key, err := base64.RawStdEncoding.Strict().DecodeString(parts[5])
+	if err != nil {
+		return errInvalidHash
+	}
+
+	//nolint:gosec // the key length is bounded by the stored hash, which we produced.
+	other := argon2.IDKey([]byte(password), salt, time, memory, threads, uint32(len(key)))
+	if subtle.ConstantTimeCompare(key, other) != 1 {
+		return ErrInvalidPassword
+	}
+
+	return nil
+}

--- a/pkg/localauth/password_test.go
+++ b/pkg/localauth/password_test.go
@@ -1,0 +1,106 @@
+package localauth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestHashPasswordRoundTrip(t *testing.T) {
+	const password = "correct horse battery staple"
+
+	hash, err := HashPassword(password)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	if strings.Contains(hash, password) {
+		t.Fatal("hash contains the plaintext password")
+	}
+
+	if err := VerifyPassword(hash, password); err != nil {
+		t.Fatalf("failed to verify correct password: %v", err)
+	}
+
+	if err := VerifyPassword(hash, password+"!"); !errors.Is(err, ErrInvalidPassword) {
+		t.Fatalf("expected ErrInvalidPassword for the wrong password, got %v", err)
+	}
+}
+
+func TestHashPasswordIsSalted(t *testing.T) {
+	const password = "correct horse battery staple"
+
+	first, err := HashPassword(password)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	second, err := HashPassword(password)
+	if err != nil {
+		t.Fatalf("failed to hash password: %v", err)
+	}
+
+	if first == second {
+		t.Fatal("hashing the same password twice produced the same hash, so it is not salted")
+	}
+}
+
+func TestHashPasswordRejectsShortPasswords(t *testing.T) {
+	if _, err := HashPassword(strings.Repeat("a", MinPasswordLength-1)); err == nil {
+		t.Fatal("expected an error for a password below the minimum length")
+	}
+}
+
+func TestVerifyPasswordRejectsMalformedHashes(t *testing.T) {
+	for _, hash := range []string{
+		"",
+		"plaintext",
+		"$argon2i$v=19$m=19456,t=2,p=1$c2FsdHNhbHRzYWx0c2E$aGFzaA",
+		"$argon2id$v=19$m=19456,t=2,p=1$not-base64!$aGFzaA",
+	} {
+		if err := VerifyPassword(hash, "correct horse battery staple"); err == nil {
+			t.Fatalf("expected an error for malformed hash %q", hash)
+		}
+	}
+}
+
+func TestEmailDomainAllowed(t *testing.T) {
+	tests := []struct {
+		domains, email string
+		want           bool
+	}{
+		{"*", "user@example.com", true},
+		{"example.com", "user@example.com", true},
+		{"example.com", "user@EXAMPLE.com", false}, // emails are normalized before this check
+		{"example.com, other.com", "user@other.com", true},
+		{"@example.com", "user@example.com", true},
+		{"example.com", "user@notexample.com", false},
+		{"example.com", "user@evil.com", false},
+		{"", "user@example.com", false},
+		{"*", "not-an-email", false},
+	}
+
+	for _, tt := range tests {
+		if got := emailDomainAllowed(tt.domains, tt.email); got != tt.want {
+			t.Errorf("emailDomainAllowed(%q, %q) = %v, want %v", tt.domains, tt.email, got, tt.want)
+		}
+	}
+}
+
+func TestRedirectTarget(t *testing.T) {
+	tests := []struct {
+		rd, want string
+	}{
+		{"", "/"},
+		{"/admin", "/admin"},
+		{"//evil.com", "/"},
+		{"https://evil.com", "/"},
+		{"javascript:alert(1)", "/"},
+	}
+
+	for _, tt := range tests {
+		if got := redirectTarget(tt.rd); got != tt.want {
+			t.Errorf("redirectTarget(%q) = %q, want %q", tt.rd, got, tt.want)
+		}
+	}
+}

--- a/pkg/localauth/password_test.go
+++ b/pkg/localauth/password_test.go
@@ -46,7 +46,7 @@ func TestHashPasswordIsSalted(t *testing.T) {
 }
 
 func TestHashPasswordRejectsShortPasswords(t *testing.T) {
-	if _, err := HashPassword(strings.Repeat("a", MinPasswordLength-1)); err == nil {
+	if _, err := HashPassword(strings.Repeat("a", minPasswordLength-1)); err == nil {
 		t.Fatal("expected an error for a password below the minimum length")
 	}
 }

--- a/pkg/localauth/provider.go
+++ b/pkg/localauth/provider.go
@@ -328,13 +328,13 @@ func (p *Provider) emailDomainAllowed(ctx context.Context, email string) (bool, 
 
 func emailDomainAllowed(domains, email string) bool {
 	_, domain, ok := strings.Cut(email, "@")
-	if !ok {
+	if !ok || domain == "" {
 		return false
 	}
 
-	for _, allowed := range strings.Split(domains, ",") {
+	for allowed := range strings.SplitSeq(domains, ",") {
 		allowed = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(allowed, "@")))
-		if allowed == "*" || (allowed != "" && allowed == domain) {
+		if allowed == "*" || allowed == domain {
 			return true
 		}
 	}

--- a/pkg/localauth/provider.go
+++ b/pkg/localauth/provider.go
@@ -1,0 +1,399 @@
+// Package localauth implements a built-in username/password auth provider.
+//
+// Unlike the other auth providers, which are external binaries launched as daemons by the
+// dispatcher, this provider runs in-process so that it can share Obot's database. It speaks the
+// same HTTP protocol as the external providers (/oauth2/start, /oauth2/callback, /oauth2/sign_out,
+// /obot-get-state, /obot-get-user-info), so the rest of the auth stack treats it like any other.
+package localauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/obot-platform/obot/logger"
+	"github.com/obot-platform/obot/pkg/auth"
+	"github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/system"
+	"gorm.io/gorm"
+)
+
+const (
+	// ProviderName is the name of the AuthProvider resource for this provider.
+	ProviderName = system.LocalAuthProvider
+
+	// EmailDomainsEnvVar is the configuration parameter that restricts which email domains
+	// can be used for local users. It matches the name used by the external auth providers.
+	EmailDomainsEnvVar = "OBOT_AUTH_PROVIDER_EMAIL_DOMAINS"
+
+	// LoginPath is the UI route that renders the login form.
+	LoginPath = "/login/local"
+
+	sessionDuration = 7 * 24 * time.Hour
+
+	// The error body the proxy translates into an invalid session, which makes the browser drop
+	// its cookie and log in again. See pkg/proxy/proxy.go.
+	invalidSessionBody = "record not found"
+)
+
+var log = logger.Package()
+
+type Provider struct {
+	gatewayClient *client.Client
+	serverURL     string
+	throttle      *throttle
+	tokens        *tokenSigner
+}
+
+func New(gatewayClient *client.Client, serverURL string) (*Provider, error) {
+	tokens, err := newTokenSigner()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Provider{
+		gatewayClient: gatewayClient,
+		serverURL:     serverURL,
+		throttle:      newThrottle(),
+		tokens:        tokens,
+	}, nil
+}
+
+// Start serves the provider on a random loopback port and returns its URL.
+// The server is shut down when the context is cancelled.
+func (p *Provider) Start(ctx context.Context) (url.URL, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return url.URL{}, fmt.Errorf("failed to listen for local auth provider: %w", err)
+	}
+
+	server := &http.Server{
+		Handler:           p.handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	go func() {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Errorf("local auth provider server exited: %v", err)
+		}
+	}()
+
+	go p.cleanupSessions(ctx)
+	go p.throttle.run(ctx)
+
+	u := url.URL{Scheme: "http", Host: listener.Addr().String()}
+	log.Infof("Started local auth provider: url=%s", u.String())
+
+	return u, nil
+}
+
+func (p *Provider) handler() http.Handler {
+	mux := http.NewServeMux()
+	// Health check, matching what the dispatcher expects of daemon-based providers.
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("GET /oauth2/start", p.start)
+	// The login form posts back to /oauth2/start rather than /oauth2/callback: the proxy only
+	// forwards a callback when it holds the short-lived cookie it sets at the start of an OAuth
+	// flow, and it drops that cookie once used, which would break retries after a failed login.
+	mux.HandleFunc("POST /oauth2/start", p.login)
+	mux.HandleFunc("GET /oauth2/sign_out", p.signOut)
+	mux.HandleFunc("POST /obot-get-state", p.getState)
+	mux.HandleFunc("GET /obot-get-user-info", p.getUserInfo)
+	return mux
+}
+
+func (p *Provider) cleanupSessions(ctx context.Context) {
+	t := time.NewTicker(time.Hour)
+	defer t.Stop()
+	for {
+		if err := p.gatewayClient.DeleteExpiredLocalAuthSessions(ctx); err != nil {
+			log.Warnf("failed to clean up expired local auth sessions: %v", err)
+		}
+
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// start redirects to the login form in the UI, preserving the post-login redirect target.
+func (p *Provider) start(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, LoginPath+"?rd="+url.QueryEscape(redirectTarget(r.URL.Query().Get("rd"))), http.StatusFound)
+}
+
+func (p *Provider) login(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+
+	rd := redirectTarget(r.FormValue("rd"))
+
+	// Reject cross-origin logins. Browsers always send Origin on POST, so this blocks login CSRF
+	// without requiring the login form to carry a token.
+	if !sameOrigin(r) {
+		http.Error(w, "cross-origin login is not allowed", http.StatusForbidden)
+		return
+	}
+
+	email := client.NormalizeEmail(r.FormValue("email"))
+	password := r.FormValue("password")
+	if email == "" || password == "" {
+		p.loginFailed(w, r, rd, "Enter your email and password.")
+		return
+	}
+
+	if p.throttle.blocked(email) {
+		p.loginFailed(w, r, rd, "Too many failed login attempts. Try again later.")
+		return
+	}
+
+	user, err := p.gatewayClient.LocalAuthUserByEmail(r.Context(), email)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		log.Errorf("failed to look up local auth user: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Verify a dummy hash when the user doesn't exist so that a missing user and a wrong password
+	// take about the same amount of time.
+	passwordHash := dummyHash
+	if user != nil {
+		passwordHash = user.PasswordHash
+	}
+
+	if err := VerifyPassword(passwordHash, password); err != nil || user == nil {
+		if err != nil && !errors.Is(err, ErrInvalidPassword) {
+			log.Warnf("failed to verify password for local auth user: %v", err)
+		}
+		p.throttle.failed(email)
+		p.loginFailed(w, r, rd, "Incorrect email or password.")
+		return
+	}
+
+	allowed, err := p.emailDomainAllowed(r.Context(), email)
+	if err != nil {
+		log.Errorf("failed to check allowed email domains: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	} else if !allowed {
+		p.loginFailed(w, r, rd, "This email domain is not allowed to sign in.")
+		return
+	}
+
+	p.throttle.succeeded(email)
+
+	token, err := generateToken()
+	if err != nil {
+		log.Errorf("failed to generate session token: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	expiresAt := time.Now().Add(sessionDuration)
+	if err := p.gatewayClient.CreateLocalAuthSession(r.Context(), hash.String(token), user.ID, expiresAt); err != nil {
+		log.Errorf("failed to create local auth session: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     auth.ObotAccessTokenCookie,
+		Value:    token,
+		Path:     "/",
+		Expires:  expiresAt,
+		HttpOnly: true,
+		Secure:   p.secureCookies(),
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	http.Redirect(w, r, rd, http.StatusFound)
+}
+
+func (p *Provider) loginFailed(w http.ResponseWriter, r *http.Request, rd, message string) {
+	http.Redirect(w, r, fmt.Sprintf("%s?rd=%s&error=%s", LoginPath, url.QueryEscape(rd), url.QueryEscape(message)), http.StatusFound)
+}
+
+func (p *Provider) signOut(w http.ResponseWriter, r *http.Request) {
+	if cookie, err := r.Cookie(auth.ObotAccessTokenCookie); err == nil {
+		if err := p.gatewayClient.DeleteLocalAuthSession(r.Context(), hash.String(cookie.Value)); err != nil {
+			log.Warnf("failed to delete local auth session: %v", err)
+		}
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     auth.ObotAccessTokenCookie,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   p.secureCookies(),
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	http.Redirect(w, r, redirectTarget(r.URL.Query().Get("rd")), http.StatusFound)
+}
+
+// getState resolves the session cookie on a serialized request into the user it belongs to.
+// This is what authenticates every API request made with a local auth session cookie.
+func (p *Provider) getState(w http.ResponseWriter, r *http.Request) {
+	var sr auth.SerializableRequest
+	if err := json.NewDecoder(r.Body).Decode(&sr); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+
+	token := cookieValue(sr.Header, auth.ObotAccessTokenCookie)
+	if token == "" {
+		http.Error(w, invalidSessionBody, http.StatusInternalServerError)
+		return
+	}
+
+	session, user, err := p.gatewayClient.LocalAuthSession(r.Context(), hash.String(token))
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		http.Error(w, invalidSessionBody, http.StatusInternalServerError)
+		return
+	} else if err != nil {
+		log.Errorf("failed to look up local auth session: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, auth.SerializableState{
+		ExpiresOn: &session.ExpiresAt,
+		// The access token is what the gateway passes back to /obot-get-user-info. It carries the
+		// email rather than the session token so that user info needs no database lookup: the
+		// gateway asks for it from inside an open transaction, and on SQLite — which allows a
+		// single connection — a query here would deadlock against that transaction.
+		AccessToken:       p.tokens.sign(user.Email),
+		User:              user.Email,
+		PreferredUsername: user.Email,
+		Email:             user.Email,
+	})
+}
+
+// getUserInfo returns the profile for the access token in the Authorization header.
+// The gateway uses it to fill in the user's display name.
+func (p *Provider) getUserInfo(w http.ResponseWriter, r *http.Request) {
+	email, err := p.tokens.verify(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"id":    email,
+		"email": email,
+		"name":  email,
+	})
+}
+
+// EmailDomainAllowed reports whether the given email is allowed by the provider's configured
+// email domain restriction. An unconfigured provider allows nothing.
+func (p *Provider) EmailDomainAllowed(ctx context.Context, email string) (bool, error) {
+	return p.emailDomainAllowed(ctx, client.NormalizeEmail(email))
+}
+
+func (p *Provider) emailDomainAllowed(ctx context.Context, email string) (bool, error) {
+	cred, err := p.gatewayClient.RevealCredential(ctx, []string{ProviderName, system.GenericAuthProviderCredentialContext}, ProviderName)
+	if err != nil {
+		if errors.As(err, &client.CredentialNotFoundError{}) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return emailDomainAllowed(cred.Secrets[EmailDomainsEnvVar], email), nil
+}
+
+func emailDomainAllowed(domains, email string) bool {
+	_, domain, ok := strings.Cut(email, "@")
+	if !ok {
+		return false
+	}
+
+	for _, allowed := range strings.Split(domains, ",") {
+		allowed = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(allowed, "@")))
+		if allowed == "*" || (allowed != "" && allowed == domain) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (p *Provider) secureCookies() bool {
+	return strings.HasPrefix(p.serverURL, "https://")
+}
+
+// redirectTarget sanitizes a post-login redirect so that it can only point back into Obot.
+func redirectTarget(rd string) string {
+	if !strings.HasPrefix(rd, "/") || strings.HasPrefix(rd, "//") {
+		return "/"
+	}
+	return rd
+}
+
+// sameOrigin reports whether the request was initiated by the page it claims to come from.
+// Requests without an Origin or Referer (curl, tests) are allowed: CSRF requires a browser.
+func sameOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		origin = r.Header.Get("Referer")
+	}
+	if origin == "" {
+		return true
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+
+	return u.Host == r.Host
+}
+
+func cookieValue(header map[string][]string, name string) string {
+	// http.Request.Cookie is the only reliable cookie parser, so build a request to use it.
+	r := http.Request{Header: http.Header(header)}
+	cookie, err := r.Cookie(name)
+	if err != nil {
+		return ""
+	}
+	return cookie.Value
+}
+
+func generateToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func writeJSON(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		log.Warnf("failed to write local auth provider response: %v", err)
+	}
+}

--- a/pkg/localauth/throttle.go
+++ b/pkg/localauth/throttle.go
@@ -1,0 +1,109 @@
+package localauth
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	maxFailedAttempts = 10
+	failureWindow     = 15 * time.Minute
+)
+
+// dummyHash is verified when a login is attempted for an email that has no local user, so that
+// the response time doesn't reveal whether the account exists. It is the hash of a password that
+// cannot be entered, since it is longer than any form field allows.
+var dummyHash = mustHash(strings.Repeat("x", 128))
+
+func mustHash(password string) string {
+	h, err := HashPassword(password)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
+// throttle slows down password guessing by locking an email out after too many failures.
+// It is per-process and in-memory: it is a speed bump, not a distributed rate limiter.
+type throttle struct {
+	lock     sync.Mutex
+	failures map[string]*failureCount
+}
+
+type failureCount struct {
+	count int
+	first time.Time
+}
+
+func newThrottle() *throttle {
+	return &throttle{
+		failures: map[string]*failureCount{},
+	}
+}
+
+func (t *throttle) blocked(email string) bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	f := t.failures[email]
+	if f == nil {
+		return false
+	}
+
+	if time.Since(f.first) > failureWindow {
+		delete(t.failures, email)
+		return false
+	}
+
+	return f.count >= maxFailedAttempts
+}
+
+func (t *throttle) failed(email string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	f := t.failures[email]
+	if f == nil || time.Since(f.first) > failureWindow {
+		t.failures[email] = &failureCount{count: 1, first: time.Now()}
+		return
+	}
+
+	f.count++
+}
+
+func (t *throttle) succeeded(email string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	delete(t.failures, email)
+}
+
+// sweep drops entries whose failure window has elapsed. Without it the map would grow one entry
+// per distinct failing email and only ever shrink when that exact email is retried or succeeds,
+// so an enumeration attempt (many unique emails) would leak memory unbounded.
+func (t *throttle) sweep() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	for email, f := range t.failures {
+		if time.Since(f.first) > failureWindow {
+			delete(t.failures, email)
+		}
+	}
+}
+
+// run periodically sweeps expired entries until the context is cancelled.
+func (t *throttle) run(ctx context.Context) {
+	ticker := time.NewTicker(failureWindow)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			t.sweep()
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/pkg/localauth/throttle_test.go
+++ b/pkg/localauth/throttle_test.go
@@ -1,0 +1,47 @@
+package localauth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestThrottleBlocksAfterMaxAttempts(t *testing.T) {
+	th := newThrottle()
+
+	for range maxFailedAttempts {
+		if th.blocked("user@example.com") {
+			t.Fatal("blocked before reaching the attempt limit")
+		}
+		th.failed("user@example.com")
+	}
+
+	if !th.blocked("user@example.com") {
+		t.Fatal("expected the email to be blocked after the attempt limit")
+	}
+
+	// A successful login clears the block.
+	th.succeeded("user@example.com")
+	if th.blocked("user@example.com") {
+		t.Fatal("expected the block to clear after a successful login")
+	}
+}
+
+func TestThrottleSweepDropsExpiredEntries(t *testing.T) {
+	th := newThrottle()
+
+	// Simulate one failure per distinct email, all outside the failure window.
+	for _, email := range []string{"a@example.com", "b@example.com", "c@example.com"} {
+		th.failures[email] = &failureCount{count: 1, first: time.Now().Add(-2 * failureWindow)}
+	}
+	// And one recent failure that must survive the sweep.
+	th.failed("fresh@example.com")
+
+	th.sweep()
+
+	if len(th.failures) != 1 {
+		t.Fatalf("expected sweep to leave only the fresh entry, got %d entries", len(th.failures))
+	}
+	if _, ok := th.failures["fresh@example.com"]; !ok {
+		t.Fatal("sweep removed the in-window entry")
+	}
+}

--- a/pkg/localauth/token.go
+++ b/pkg/localauth/token.go
@@ -1,0 +1,62 @@
+package localauth
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// tokenSigner mints the short-lived access tokens the gateway hands back to the provider when it
+// asks for user info. They are signed rather than looked up so that user info can be served
+// without touching the database. The key is per-process: tokens don't outlive a restart, and the
+// gateway gets a fresh one with every session state response.
+type tokenSigner struct {
+	key []byte
+}
+
+func newTokenSigner() (*tokenSigner, error) {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("failed to generate token signing key: %w", err)
+	}
+
+	return &tokenSigner{key: key}, nil
+}
+
+func (t *tokenSigner) sign(email string) string {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(email))
+	return payload + "." + base64.RawURLEncoding.EncodeToString(t.mac(payload))
+}
+
+func (t *tokenSigner) verify(token string) (string, error) {
+	payload, signature, ok := strings.Cut(token, ".")
+	if !ok {
+		return "", errors.New("malformed token")
+	}
+
+	decodedSignature, err := base64.RawURLEncoding.DecodeString(signature)
+	if err != nil {
+		return "", errors.New("malformed token signature")
+	}
+
+	if !hmac.Equal(decodedSignature, t.mac(payload)) {
+		return "", errors.New("invalid token signature")
+	}
+
+	email, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		return "", errors.New("malformed token payload")
+	}
+
+	return string(email), nil
+}
+
+func (t *tokenSigner) mac(payload string) []byte {
+	mac := hmac.New(sha256.New, t.key)
+	mac.Write([]byte(payload))
+	return mac.Sum(nil)
+}

--- a/pkg/localauth/token_test.go
+++ b/pkg/localauth/token_test.go
@@ -1,0 +1,58 @@
+package localauth
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestTokenSignerRoundTrip(t *testing.T) {
+	signer, err := newTokenSigner()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const email = "user@example.com"
+	token := signer.sign(email)
+
+	got, err := signer.verify(token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != email {
+		t.Fatalf("expected %q, got %q", email, got)
+	}
+}
+
+func TestTokenSignerRejectsInvalidTokens(t *testing.T) {
+	signer, err := newTokenSigner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherSigner, err := newTokenSigner()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validToken := signer.sign("user@example.com")
+	payload, signature, ok := strings.Cut(validToken, ".")
+	if !ok {
+		t.Fatal("expected signed token to contain a separator")
+	}
+
+	tests := map[string]string{
+		"missing signature":   payload,
+		"malformed signature": payload + ".%%%",
+		"forged payload":      base64.RawURLEncoding.EncodeToString([]byte("attacker@example.com")) + "." + signature,
+		"different signer":    otherSigner.sign("user@example.com"),
+		"malformed payload":   "%%%." + base64.RawURLEncoding.EncodeToString(signer.mac("%%%")),
+	}
+
+	for name, token := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := signer.verify(token); err == nil {
+				t.Fatal("expected token verification to fail")
+			}
+		})
+	}
+}

--- a/pkg/localauth/users.go
+++ b/pkg/localauth/users.go
@@ -1,0 +1,93 @@
+package localauth
+
+import (
+	"context"
+	"fmt"
+	"net/mail"
+
+	"github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+// InvalidUserError is returned when a local user cannot be created or updated as requested.
+// It is a user error, not a server error: the message is safe to return to the caller.
+type InvalidUserError struct {
+	message string
+}
+
+func (e InvalidUserError) Error() string {
+	return e.message
+}
+
+func (p *Provider) Users(ctx context.Context) ([]types.LocalAuthUser, error) {
+	return p.gatewayClient.LocalAuthUsers(ctx)
+}
+
+// CreateUser creates a local user with the given email and plaintext password.
+func (p *Provider) CreateUser(ctx context.Context, email, password string) (*types.LocalAuthUser, error) {
+	parsed, err := mail.ParseAddress(client.NormalizeEmail(email))
+	if err != nil {
+		return nil, InvalidUserError{message: "a valid email address is required"}
+	}
+	// Use the bare address from the parse, not the raw input: mail.ParseAddress accepts
+	// display-name forms like "Name <a@b>", and storing that whole string as the login email
+	// would make the account impossible to sign in to. Re-normalize since parsing preserves case.
+	email = client.NormalizeEmail(parsed.Address)
+
+	allowed, err := p.emailDomainAllowed(ctx, email)
+	if err != nil {
+		return nil, err
+	} else if !allowed {
+		return nil, InvalidUserError{message: fmt.Sprintf("email domain of %q is not in the provider's allowed email domains", email)}
+	}
+
+	passwordHash, err := hashUserPassword(password)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := p.gatewayClient.CreateLocalAuthUser(ctx, email, passwordHash)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Created local auth user: id=%d", user.ID)
+
+	return user, nil
+}
+
+// SetPassword sets a local user's password, which also signs them out everywhere.
+func (p *Provider) SetPassword(ctx context.Context, id uint, password string) error {
+	passwordHash, err := hashUserPassword(password)
+	if err != nil {
+		return err
+	}
+
+	if err := p.gatewayClient.SetLocalAuthUserPassword(ctx, id, passwordHash); err != nil {
+		return err
+	}
+
+	log.Infof("Reset password for local auth user: id=%d", id)
+
+	return nil
+}
+
+// DeleteUser removes a local user and their sessions. It does not delete the Obot user that the
+// local user logged in as: that is managed from the Users page like any other user.
+func (p *Provider) DeleteUser(ctx context.Context, id uint) error {
+	if err := p.gatewayClient.DeleteLocalAuthUser(ctx, id); err != nil {
+		return err
+	}
+
+	log.Infof("Deleted local auth user: id=%d", id)
+
+	return nil
+}
+
+func hashUserPassword(password string) (string, error) {
+	if len(password) < MinPasswordLength {
+		return "", InvalidUserError{message: fmt.Sprintf("password must be at least %d characters", MinPasswordLength)}
+	}
+
+	return HashPassword(password)
+}

--- a/pkg/localauth/users.go
+++ b/pkg/localauth/users.go
@@ -38,7 +38,7 @@ func (p *Provider) CreateUser(ctx context.Context, email, password string) (*typ
 	if err != nil {
 		return nil, err
 	} else if !allowed {
-		return nil, InvalidUserError{message: fmt.Sprintf("email domain of %q is not in the provider's allowed email domains", email)}
+		return nil, InvalidUserError{message: fmt.Sprintf("email %q is not in the provider's allowed email domains", email)}
 	}
 
 	passwordHash, err := hashUserPassword(password)

--- a/pkg/localauth/users.go
+++ b/pkg/localauth/users.go
@@ -85,8 +85,8 @@ func (p *Provider) DeleteUser(ctx context.Context, id uint) error {
 }
 
 func hashUserPassword(password string) (string, error) {
-	if len(password) < MinPasswordLength {
-		return "", InvalidUserError{message: fmt.Sprintf("password must be at least %d characters", MinPasswordLength)}
+	if len(password) < minPasswordLength {
+		return "", InvalidUserError{message: fmt.Sprintf("password must be at least %d characters", minPasswordLength)}
 	}
 
 	return HashPassword(password)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -39,6 +39,7 @@ import (
 	"github.com/obot-platform/obot/pkg/imagepullsecrets"
 	"github.com/obot-platform/obot/pkg/jwt/persistent"
 	"github.com/obot-platform/obot/pkg/license"
+	"github.com/obot-platform/obot/pkg/localauth"
 	"github.com/obot-platform/obot/pkg/logutil"
 	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/obot-platform/obot/pkg/messagepolicy"
@@ -175,6 +176,7 @@ type Services struct {
 	UserUIPort                  int
 	GatewayServer               *gserver.Server
 	Bootstrapper                *bootstrap.Bootstrap
+	LocalAuthProvider           *localauth.Provider
 	AuthEnabled                 bool
 	DefaultMCPCatalogPath       string
 	DefaultSystemMCPCatalogPath string
@@ -833,8 +835,22 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	}
 
 	authenticators := gserver.NewGatewayTokenReviewer(gatewayClient, providerDispatcher)
+	var localAuthProvider *localauth.Provider
 	if config.EnableAuthentication {
 		proxyManager = proxy.NewProxyManager(providerDispatcher)
+
+		// The local auth provider runs in-process, rather than as a daemon launched from the
+		// provider registry, so that it can use Obot's own database for users and sessions.
+		localAuthProvider, err = localauth.New(gatewayClient, config.Hostname)
+		if err != nil {
+			return nil, err
+		}
+
+		localAuthProviderURL, err := localAuthProvider.Start(ctx)
+		if err != nil {
+			return nil, err
+		}
+		providerDispatcher.RegisterBuiltinAuthProvider(system.DefaultNamespace, localauth.ProviderName, localAuthProviderURL)
 
 		// Token Auth + OAuth auth
 		authenticators = union.NewFailOnError(authenticators, proxyManager)
@@ -970,6 +986,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		GatewayServer:                gatewayServer,
 		AuthEnabled:                  config.EnableAuthentication,
 		Bootstrapper:                 bootstrapper,
+		LocalAuthProvider:            localAuthProvider,
 
 		DefaultMCPCatalogPath:          config.DefaultMCPCatalogPath,
 		MDMAssetSource:                 config.MDMAssetSource,

--- a/pkg/system/tools.go
+++ b/pkg/system/tools.go
@@ -11,6 +11,10 @@ const (
 	AzureModelProvider               = "azure-model-provider"
 	AzureEntraModelProvider          = "azure-entra-model-provider"
 
+	// LocalAuthProvider is the built-in username/password auth provider, implemented in
+	// pkg/localauth. It runs in-process instead of as a daemon from the provider registry.
+	LocalAuthProvider = "local-auth-provider"
+
 	OpenAIAPIKeyEnvVar    = "OPENAI_API_KEY"
 	AnthropicAPIKeyEnvVar = "ANTHROPIC_API_KEY"
 

--- a/ui/user/src/lib/components/admin/LocalAuthConfigure.svelte
+++ b/ui/user/src/lib/components/admin/LocalAuthConfigure.svelte
@@ -1,0 +1,353 @@
+<script lang="ts">
+	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
+	import { MultiValueInput } from '$lib/components/ui/multi-value-input';
+	import { LOCAL_AUTH_MIN_PASSWORD_LENGTH } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
+	import { AdminService, type AuthProvider, type LocalAuthUser } from '$lib/services';
+	import { darkMode } from '$lib/stores';
+	import {
+		ArrowLeft,
+		CircleAlert,
+		KeyRound,
+		Trash2,
+		TriangleAlert,
+		UserPlus
+	} from '@lucide/svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	interface Props {
+		provider?: AuthProvider;
+		values?: Record<string, string>;
+		readonly?: boolean;
+		// Save the email-domains config. Returns an error message, or undefined on success.
+		onConfigure: (form: Record<string, string>) => Promise<string | undefined>;
+		// Called after the modal closes, with the number of local users that currently exist.
+		onClose?: (userCount: number) => void;
+	}
+
+	const { provider, values, readonly, onConfigure, onClose }: Props = $props();
+
+	const DOMAINS_KEY = 'OBOT_AUTH_PROVIDER_EMAIL_DOMAINS';
+
+	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	// The modal is a two-step flow: configure the provider, then manage its users. Users can only
+	// be created once the provider is configured (the server needs the allowed-domains credential),
+	// so an unconfigured provider opens on 'config' and a configured one opens straight on 'users'.
+	let step = $state<'config' | 'users'>('config');
+	let domains = $state('');
+	let configuring = $state(false);
+	let configError = $state<string>();
+
+	let users = $state<LocalAuthUser[]>([]);
+	let loadingUsers = $state(false);
+	let savingUser = $state(false);
+	let userError = $state<string>();
+	let email = $state('');
+	let password = $state('');
+	let resettingUser = $state<LocalAuthUser>();
+
+	export function open() {
+		domains = values?.[DOMAINS_KEY] ?? '*';
+		configError = undefined;
+		userError = undefined;
+		email = '';
+		password = '';
+		resettingUser = undefined;
+		users = [];
+		step = provider?.configured ? 'users' : 'config';
+		dialog?.open();
+		if (step === 'users') refreshUsers();
+	}
+
+	export function close() {
+		dialog?.close();
+	}
+
+	async function handleContinue(e?: SubmitEvent) {
+		e?.preventDefault();
+
+		// A readonly admin can look but not save; just move on to view the users.
+		if (readonly) {
+			step = 'users';
+			await refreshUsers();
+			return;
+		}
+
+		if (!domains.trim()) {
+			configError = 'Enter at least one allowed email domain (use * to allow any).';
+			return;
+		}
+
+		configuring = true;
+		configError = undefined;
+		try {
+			const err = await onConfigure({ [DOMAINS_KEY]: domains });
+			if (err) {
+				configError = err;
+				return;
+			}
+			step = 'users';
+			await refreshUsers();
+		} finally {
+			configuring = false;
+		}
+	}
+
+	async function refreshUsers() {
+		loadingUsers = true;
+		userError = undefined;
+		try {
+			users = await AdminService.listLocalAuthUsers();
+		} catch (err) {
+			userError = errorMessage(err, 'Failed to load local users.');
+		} finally {
+			loadingUsers = false;
+		}
+	}
+
+	async function handleUserSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		savingUser = true;
+		userError = undefined;
+		try {
+			if (resettingUser) {
+				await AdminService.setLocalAuthUserPassword(resettingUser.id, password);
+				resettingUser = undefined;
+			} else {
+				await AdminService.createLocalAuthUser(email, password);
+			}
+			email = '';
+			password = '';
+			await refreshUsers();
+		} catch (err) {
+			userError = errorMessage(err, 'Failed to save the user.');
+		} finally {
+			savingUser = false;
+		}
+	}
+
+	async function handleDelete(user: LocalAuthUser) {
+		savingUser = true;
+		userError = undefined;
+		try {
+			await AdminService.deleteLocalAuthUser(user.id);
+			await refreshUsers();
+		} catch (err) {
+			userError = errorMessage(err, 'Failed to delete the user.');
+		} finally {
+			savingUser = false;
+		}
+	}
+
+	// The API returns errors as {"error": "..."}; surface the message rather than the raw body.
+	function errorMessage(err: unknown, fallback: string) {
+		if (!(err instanceof Error)) return fallback;
+		const match = err.message.match(/{"error":\s*"(.*?)"}/);
+		return match ? (JSON.parse(match[0]).error as string) : err.message || fallback;
+	}
+</script>
+
+<ResponsiveDialog bind:this={dialog} class="w-xl" onClose={() => onClose?.(users.length)}>
+	{#snippet titleContent()}
+		<div class="flex items-center gap-2">
+			{#if darkMode.isDark}
+				{@const url = provider?.iconDark ?? provider?.icon}
+				<img
+					src={url}
+					alt={provider?.name}
+					class={twMerge('size-9 rounded-md p-1', !provider?.iconDark && 'bg-base-300')}
+				/>
+			{:else}
+				<img src={provider?.icon} alt={provider?.name} class="bg-base-200 size-9 rounded-md p-1" />
+			{/if}
+			Set Up {provider?.name}
+		</div>
+	{/snippet}
+
+	<div class="flex flex-col gap-4">
+		<div class="notification-alert flex items-start gap-2">
+			<TriangleAlert class="text-warning mt-0.5 size-5 shrink-0" />
+			<p class="text-sm font-light">
+				Local authentication stores passwords in Obot and is intended for development or testing.
+				For production, use an SSO provider such as Google, GitHub, or Okta.
+			</p>
+		</div>
+
+		{#if step === 'config'}
+			<form class="flex flex-col gap-4" onsubmit={handleContinue}>
+				{#if configError}
+					<div class="notification-error flex items-center gap-2">
+						<CircleAlert class="text-error size-5 shrink-0" />
+						<p class="text-sm font-light">{configError}</p>
+					</div>
+				{/if}
+
+				<div class="flex flex-col gap-1">
+					<label for="local-auth-domains">Allowed Email Domains</label>
+					<span class="text-gray text-xs">
+						Local users must have an email address in one of these domains. Use * to allow any
+						domain.
+					</span>
+					<MultiValueInput
+						bind:value={domains}
+						id="local-auth-domains"
+						labels={{ '*': 'All domains' }}
+						class="text-input-filled"
+						placeholder={`Hit "Enter" to insert`.toString()}
+						disabled={readonly}
+					/>
+				</div>
+
+				<div class="flex justify-end">
+					<button class="btn btn-primary" type="submit" disabled={configuring}>
+						{#if configuring}
+							<Loading class="size-4" />
+						{:else}
+							Continue
+						{/if}
+					</button>
+				</div>
+			</form>
+		{:else}
+			<div class="flex flex-col gap-4">
+				<div class="flex items-center justify-between gap-2">
+					<h4 class="text-sm font-semibold">Users</h4>
+					{#if !readonly}
+						<button
+							class="text-link flex items-center gap-1 text-xs font-light"
+							type="button"
+							onclick={() => {
+								configError = undefined;
+								step = 'config';
+							}}
+						>
+							<ArrowLeft class="size-3.5" /> Configuration
+						</button>
+					{/if}
+				</div>
+
+				<p class="text-muted-content text-sm font-light">
+					These users sign in with an email address and password. Grant them roles from the Users
+					page after their first sign-in.
+				</p>
+
+				{#if userError}
+					<div class="notification-error flex items-center gap-2">
+						<CircleAlert class="text-error size-5 shrink-0" />
+						<p class="text-sm font-light">{userError}</p>
+					</div>
+				{/if}
+
+				{#if loadingUsers}
+					<div class="flex justify-center py-4"><Loading class="size-5" /></div>
+				{:else if users.length === 0}
+					<p class="text-muted-content py-2 text-sm font-light">
+						No local users yet. Create one below so that someone can sign in.
+					</p>
+				{:else}
+					<ul class="divide-base-300 dark:divide-base-400 divide-y">
+						{#each users as user (user.id)}
+							<li class="flex items-center justify-between gap-2 py-2">
+								<span class="truncate text-sm">{user.email}</span>
+								{#if !readonly}
+									<div class="flex shrink-0 items-center gap-1">
+										<IconButton
+											tooltip={{ text: 'Reset password' }}
+											disabled={savingUser}
+											onclick={() => {
+												resettingUser = user;
+												password = '';
+												userError = undefined;
+											}}
+										>
+											<KeyRound class="size-4" />
+										</IconButton>
+										<IconButton
+											variant="danger"
+											tooltip={{ text: 'Delete user' }}
+											disabled={savingUser}
+											onclick={() => handleDelete(user)}
+										>
+											<Trash2 class="size-4" />
+										</IconButton>
+									</div>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{/if}
+
+				{#if !readonly}
+					<form
+						class="border-base-300 dark:border-base-400 flex flex-col gap-3 border-t pt-4"
+						onsubmit={handleUserSubmit}
+					>
+						<h4 class="text-sm font-semibold">
+							{resettingUser ? `Reset password for ${resettingUser.email}` : 'Add a user'}
+						</h4>
+
+						{#if !resettingUser}
+							<label class="flex flex-col gap-1 text-sm font-light" for="local-user-email">
+								Email
+								<input
+									id="local-user-email"
+									class="text-input-filled"
+									type="email"
+									bind:value={email}
+									autocomplete="off"
+									required
+								/>
+							</label>
+						{/if}
+
+						<label class="flex flex-col gap-1 text-sm font-light" for="local-user-password">
+							Password
+							<input
+								id="local-user-password"
+								class="text-input-filled"
+								type="password"
+								bind:value={password}
+								autocomplete="new-password"
+								minlength={LOCAL_AUTH_MIN_PASSWORD_LENGTH}
+								required
+							/>
+							<span class="text-muted-content text-xs">
+								At least {LOCAL_AUTH_MIN_PASSWORD_LENGTH} characters. Share it with the user over a secure
+								channel; they can't change it themselves yet.
+							</span>
+						</label>
+
+						<div class="flex justify-end gap-2">
+							{#if resettingUser}
+								<button
+									class="btn btn-secondary"
+									type="button"
+									onclick={() => {
+										resettingUser = undefined;
+										password = '';
+									}}
+								>
+									Cancel
+								</button>
+							{/if}
+							<button class="btn btn-primary" type="submit" disabled={savingUser}>
+								{#if savingUser}
+									<Loading class="size-4" />
+								{:else if resettingUser}
+									<KeyRound class="size-4" /> Reset Password
+								{:else}
+									<UserPlus class="size-4" /> Add User
+								{/if}
+							</button>
+						</div>
+					</form>
+				{/if}
+
+				<div class="border-base-300 dark:border-base-400 flex justify-end border-t pt-4">
+					<button class="btn btn-primary" type="button" onclick={close}>Done</button>
+				</div>
+			</div>
+		{/if}
+	</div>
+</ResponsiveDialog>

--- a/ui/user/src/lib/components/admin/LocalAuthConfigure.svelte
+++ b/ui/user/src/lib/components/admin/LocalAuthConfigure.svelte
@@ -3,6 +3,7 @@
 	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import { MultiValueInput } from '$lib/components/ui/multi-value-input';
 	import { LOCAL_AUTH_MIN_PASSWORD_LENGTH } from '$lib/constants';
+	import { parseErrorContent } from '$lib/errors';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, type AuthProvider, type LocalAuthUser } from '$lib/services';
 	import { darkMode } from '$lib/stores';
@@ -143,8 +144,7 @@
 	// The API returns errors as {"error": "..."}; surface the message rather than the raw body.
 	function errorMessage(err: unknown, fallback: string) {
 		if (!(err instanceof Error)) return fallback;
-		const match = err.message.match(/{"error":\s*"(.*?)"}/);
-		return match ? (JSON.parse(match[0]).error as string) : err.message || fallback;
+		return parseErrorContent(err).message || fallback;
 	}
 </script>
 

--- a/ui/user/src/lib/constants.ts
+++ b/ui/user/src/lib/constants.ts
@@ -1,7 +1,15 @@
 export const ABORTED_THREAD_MESSAGE = 'thread was aborted, cancelling run';
 export const ABORTED_BY_USER_MESSAGE = 'aborted by user';
 
-export const UNAUTHORIZED_PATHS = new Set(['/', '/privacy-policy', '/terms-of-service', '/admin']);
+export const UNAUTHORIZED_PATHS = new Set([
+	'/',
+	'/privacy-policy',
+	'/terms-of-service',
+	'/admin',
+	// The local auth provider's login form: anonymous by definition, so a 401 from the layout's
+	// profile fetch must not bounce the user back to the provider list.
+	'/login/local'
+]);
 
 export const PAGE_TRANSITION_DURATION = 200;
 export const PAGE_SIZE = 50;
@@ -44,8 +52,12 @@ export const CommonAuthProviderIds = {
 	OKTA: 'okta-auth-provider',
 	ENTRA: 'entra-auth-provider',
 	AUTH0: 'auth0-auth-provider',
-	JUMPCLOUD: 'jumpcloud-auth-provider'
+	JUMPCLOUD: 'jumpcloud-auth-provider',
+	LOCAL: 'local-auth-provider'
 } as const;
+
+/** Matches localauth.MinPasswordLength on the server. */
+export const LOCAL_AUTH_MIN_PASSWORD_LENGTH = 12;
 
 export const BOOTSTRAP_USER_ID = 'bootstrap';
 

--- a/ui/user/src/lib/errors.ts
+++ b/ui/user/src/lib/errors.ts
@@ -33,7 +33,25 @@ function toAppError(e: Error): App.Error {
 function parseHttpErrorMessage(message: string): string {
 	// Match format i.e. "400 /path/to/resource: message"
 	const errorMatch = message.match(/^\d+\s+\/[^:]+:\s+(.*)/s);
-	return errorMatch?.[1] || message || defaultErrorMessage;
+	return parseResponseError(errorMatch?.[1] || message || defaultErrorMessage);
+}
+
+function parseResponseError(message: string): string {
+	try {
+		const body = JSON.parse(message) as unknown;
+		if (
+			typeof body === 'object' &&
+			body !== null &&
+			'error' in body &&
+			typeof body.error === 'string'
+		) {
+			return body.error;
+		}
+	} catch {
+		// The response wasn't JSON, so use it as-is.
+	}
+
+	return message;
 }
 
 export function handleRouteError(e: unknown, path: string, profile?: Profile): never {
@@ -81,13 +99,16 @@ export function parseErrorContent(e: unknown) {
 
 	// Match format i.e. "400 /path/to/resource: message"
 	const errorMatch = e.message.match(/^(\d+)(?:\s+\/[^:]+)?:\s+(.*)/);
+	if (!errorMatch) {
+		return { status: 500, message: parseResponseError(e.message || defaultErrorMessage) };
+	}
 
-	const [, legacyStatusCode, messageContent] = errorMatch || [];
+	const [, legacyStatusCode, messageContent] = errorMatch;
 	const status = parseInt(legacyStatusCode);
 
 	return {
 		status: Number.isInteger(status) ? status : 500,
-		message: messageContent || 'Unknown error occurred'
+		message: parseResponseError(messageContent || defaultErrorMessage)
 	};
 }
 

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -360,8 +360,8 @@ export async function setLocalAuthUserPassword(
 	await doPost(`/local-auth/users/${id}/password`, { password }, opts);
 }
 
-export async function deleteLocalAuthUser(id: string): Promise<void> {
-	await doDelete(`/local-auth/users/${id}`);
+export async function deleteLocalAuthUser(id: string, opts?: { fetch?: Fetcher }): Promise<void> {
+	await doDelete(`/local-auth/users/${id}`, opts);
 }
 
 // Bootstrap

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -110,7 +110,8 @@ import type {
 	MDMConfigurationCreateResponse,
 	MDMDevice,
 	MDMEnrollmentKey,
-	MDMEnrollmentKeyCreateResponse
+	MDMEnrollmentKeyCreateResponse,
+	LocalAuthUser
 } from './types';
 import { MCPCompositeDeletionDependencyError } from './types';
 
@@ -334,6 +335,33 @@ export async function deconfigureAuthProvider(
 	opts?: { fetch?: Fetcher }
 ): Promise<void> {
 	await doPost(`/auth-providers/${authProviderID}/deconfigure`, {}, opts);
+}
+
+// Local auth provider users
+
+export async function listLocalAuthUsers(opts?: { fetch?: Fetcher }): Promise<LocalAuthUser[]> {
+	const list = (await doGet('/local-auth/users', opts)) as ItemsResponse<LocalAuthUser>;
+	return list.items ?? [];
+}
+
+export async function createLocalAuthUser(
+	email: string,
+	password: string,
+	opts?: { fetch?: Fetcher }
+): Promise<LocalAuthUser> {
+	return (await doPost('/local-auth/users', { email, password }, opts)) as LocalAuthUser;
+}
+
+export async function setLocalAuthUserPassword(
+	id: string,
+	password: string,
+	opts?: { fetch?: Fetcher }
+): Promise<void> {
+	await doPost(`/local-auth/users/${id}/password`, { password }, opts);
+}
+
+export async function deleteLocalAuthUser(id: string): Promise<void> {
+	await doDelete(`/local-auth/users/${id}`);
 }
 
 // Bootstrap

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -241,6 +241,13 @@ export interface AuthProvider extends BaseProvider {
 	type: 'authprovider';
 }
 
+// A user of the built-in local auth provider. Passwords are never returned by the API.
+export interface LocalAuthUser {
+	id: string;
+	email: string;
+	created: string;
+}
+
 // Devices
 export interface DeviceMCPServerStat {
 	configHash: string;

--- a/ui/user/src/lib/services/http.ts
+++ b/ui/user/src/lib/services/http.ts
@@ -101,11 +101,13 @@ export async function doDelete(
 	opts?: {
 		signal?: AbortSignal;
 		dontLogErrors?: boolean;
+		fetch?: typeof fetch;
 		responseHandler?: ResponseHandler;
 		keepalive?: boolean;
 	}
 ): Promise<unknown> {
-	const resp = await fetch(baseURL + path, {
+	const f = opts?.fetch || fetch;
+	const resp = await f(baseURL + path, {
 		method: 'DELETE',
 		headers: getAuthHeaders(),
 		...(opts?.keepalive ? { keepalive: true } : { signal: opts?.signal })

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -2,6 +2,7 @@
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
+	import LocalAuthConfigure from '$lib/components/admin/LocalAuthConfigure.svelte';
 	import ProviderCard from '$lib/components/admin/ProviderCard.svelte';
 	import ProviderConfigure from '$lib/components/admin/ProviderConfigure.svelte';
 	import ProviderDeconfigureConfirm from '$lib/components/admin/ProviderDeconfigureConfirm.svelte';
@@ -66,11 +67,20 @@
 	let deconfigureAuthProviderDialog = $state<ReturnType<typeof ProviderDeconfigureConfirm>>();
 	let confirmDeconfigureAuthProvider = $state<AuthProvider>();
 
+	let localAuthConfigure = $state<ReturnType<typeof LocalAuthConfigure>>();
+	// True while the local auth configure/users modal is open, so the bootstrap owner-setup prompt
+	// doesn't fire on top of it (it fires once the modal closes with at least one user).
+	let localAuthConfigureOpen = $state(false);
+
 	let isBootstrapUser = $derived(profile.current.isBootstrapUser?.());
 
 	const duration = PAGE_TRANSITION_DURATION;
 
 	const prepareOwnerSetup = async () => {
+		// Don't prompt for owner login while the local auth modal is open — the admin may still be
+		// configuring it or adding the first user.
+		if (localAuthConfigureOpen) return;
+
 		const configuredAuthProvider = authProviders.find(
 			(provider) => provider.configured && (provider.missingEntitlements || []).length === 0
 		);
@@ -78,6 +88,12 @@
 
 		const bootstrapStatus = await UserService.getBootstrapStatus();
 		if (!bootstrapStatus.setupEnabled) return;
+
+		// Local auth has nobody to log in as until at least one user exists.
+		if (configuredAuthProvider.id === CommonAuthProviderIds.LOCAL) {
+			const localUsers = await AdminService.listLocalAuthUsers();
+			if (localUsers.length === 0) return;
+		}
 
 		if (!setupLoading && !setupTempLoginUrl) {
 			configuringAuthProvider = configuredAuthProvider;
@@ -163,6 +179,7 @@
 				authProviders = await AdminService.listAuthProviders();
 				adminConfigStore.updateAuthProviders(authProviders);
 				providerConfigure?.close();
+
 				if (isBootstrapUser) {
 					await handleOwnerSetup();
 				}
@@ -179,6 +196,28 @@
 			} finally {
 				loading = false;
 			}
+		}
+	}
+
+	// Saves the local auth provider's email-domain config. Returns an error message to show inside
+	// the local auth modal, or undefined on success. The local provider manages its own users, so
+	// unlike the OAuth providers it doesn't hand off to the owner-setup flow here — that happens
+	// when the modal closes with at least one user.
+	async function handleLocalAuthConfigure(
+		form: Record<string, string>
+	): Promise<string | undefined> {
+		try {
+			await AdminService.configureAuthProvider(CommonAuthProviderIds.LOCAL, form);
+			authProviders = await AdminService.listAuthProviders();
+			adminConfigStore.updateAuthProviders(authProviders);
+			return undefined;
+		} catch (err) {
+			if (err instanceof Error) {
+				const match = err.message.match(/{"error":\s*"(.*?)"}/);
+				if (match) return JSON.parse(match[0]).error;
+				return err.message;
+			}
+			return 'Failed to configure auth provider';
 		}
 	}
 
@@ -250,7 +289,14 @@
 								};
 							}
 						}
-						providerConfigure?.open();
+
+						// Local auth has its own configure/manage-users modal.
+						if (authProvider.id === CommonAuthProviderIds.LOCAL) {
+							localAuthConfigureOpen = true;
+							localAuthConfigure?.open();
+						} else {
+							providerConfigure?.open();
+						}
 					}}
 					onDeconfigure={async () => {
 						confirmDeconfigureAuthProvider = authProvider;
@@ -305,6 +351,20 @@
 		{/if}
 	{/snippet}
 </ProviderConfigure>
+
+<LocalAuthConfigure
+	bind:this={localAuthConfigure}
+	provider={configuringAuthProvider}
+	values={configuringAuthProviderValues}
+	readonly={profile.current.isAdminReadonly?.()}
+	onConfigure={handleLocalAuthConfigure}
+	onClose={async (userCount) => {
+		localAuthConfigureOpen = false;
+		if (isBootstrapUser && userCount > 0) {
+			await prepareOwnerSetup();
+		}
+	}}
+/>
 
 <ProviderDeconfigureConfirm
 	bind:this={deconfigureAuthProviderDialog}

--- a/ui/user/src/routes/admin/auth-providers/+page.svelte
+++ b/ui/user/src/routes/admin/auth-providers/+page.svelte
@@ -12,7 +12,7 @@
 		PAGE_TRANSITION_DURATION,
 		RecommendedModelProviders
 	} from '$lib/constants';
-	import { HttpError } from '$lib/errors.js';
+	import { HttpError, parseErrorContent } from '$lib/errors.js';
 	import { AdminService, UserService } from '$lib/services';
 	import type { AuthProvider } from '$lib/services/admin/types.js';
 	import { errors, license, profile } from '$lib/stores';
@@ -184,15 +184,7 @@
 					await handleOwnerSetup();
 				}
 			} catch (err: unknown) {
-				if (err instanceof Error) {
-					const errorMessageMatch = err.message.match(/{"error":\s*"(.*?)"}/);
-					if (errorMessageMatch) {
-						const errorMessage = JSON.parse(errorMessageMatch[0]).error;
-						configureError = errorMessage;
-					}
-				} else {
-					configureError = 'Failed to configure auth provider';
-				}
+				configureError = parseErrorContent(err).message;
 			} finally {
 				loading = false;
 			}
@@ -212,12 +204,7 @@
 			adminConfigStore.updateAuthProviders(authProviders);
 			return undefined;
 		} catch (err) {
-			if (err instanceof Error) {
-				const match = err.message.match(/{"error":\s*"(.*?)"}/);
-				if (match) return JSON.parse(match[0]).error;
-				return err.message;
-			}
-			return 'Failed to configure auth provider';
+			return parseErrorContent(err).message;
 		}
 	}
 

--- a/ui/user/src/routes/login/local/+page.svelte
+++ b/ui/user/src/routes/login/local/+page.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import Logo from '$lib/components/Logo.svelte';
+	import { LOCAL_AUTH_MIN_PASSWORD_LENGTH } from '$lib/constants';
+	import { CircleAlert } from '@lucide/svelte';
+
+	// The form posts to the auth provider, which sets the session cookie and redirects to `rd`.
+	// On failure it redirects back here with an `error` message to show.
+	let params = $derived(browser ? new URL(window.location.href).searchParams : undefined);
+	let rd = $derived(params?.get('rd') ?? '/');
+	let error = $derived(params?.get('error'));
+</script>
+
+<svelte:head>
+	<title>Obot | Sign In</title>
+</svelte:head>
+
+<div
+	class="text-base-content dark:from-base-300 to-base-200 flex h-dvh w-full flex-col items-center justify-center bg-radial-[at_50%_50%] from-gray-50 dark:to-black"
+>
+	<form
+		method="POST"
+		action="/oauth2/start"
+		class="dark:border-base-400 dark:bg-base-200 bg-base-100 flex w-sm flex-col gap-4 rounded-xl border border-transparent p-6 shadow-sm"
+	>
+		<Logo class="h-12 self-center" />
+		<h1 class="text-center text-xl font-semibold">Sign in to Obot</h1>
+
+		{#if error}
+			<div class="notification-error flex items-center gap-2">
+				<CircleAlert class="text-error size-5 shrink-0" />
+				<p class="text-sm font-light">{error}</p>
+			</div>
+		{/if}
+
+		<input type="hidden" name="rd" value={rd} />
+
+		<label class="flex flex-col gap-1 text-sm font-light" for="local-auth-email">
+			Email
+			<input
+				id="local-auth-email"
+				class="text-input-filled"
+				type="email"
+				name="email"
+				autocomplete="username"
+				required
+			/>
+		</label>
+
+		<label class="flex flex-col gap-1 text-sm font-light" for="local-auth-password">
+			Password
+			<input
+				id="local-auth-password"
+				class="text-input-filled"
+				type="password"
+				name="password"
+				autocomplete="current-password"
+				minlength={LOCAL_AUTH_MIN_PASSWORD_LENGTH}
+				required
+			/>
+		</label>
+
+		<button class="btn btn-primary w-full" type="submit">Sign in</button>
+
+		<p class="text-muted-content text-center text-xs font-light">
+			Don't have an account? Ask an administrator to create one for you.
+		</p>
+	</form>
+</div>


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/7227

## Summary

- add an in-process Local authentication provider backed by the Obot database
- add admin APIs and UI for configuring allowed email domains and managing local users
- add email/password login, Argon2id password hashing, throttling, session storage, logout-all behavior, and tests
- document setup, password reset, and user deletion behavior

## Why

This provides a built-in authentication option for evaluations, air-gapped installations, and smaller deployments that do not have an external OAuth2 identity provider.

## Impact

Administrators can enable Local authentication, restrict permitted email domains, and create, reset, or delete local credentials. Users can then sign in with an email address and password. Existing authentication providers continue to use the current flow.

## Screenshots

### Local provider

![Local provider configured](https://raw.githubusercontent.com/ibuildthecloud/otto8/9f8bece94de376c5358f66fa72c23d97ba301a78/01-auth-provider-card.png)

### Manage local users

![Manage local users](https://raw.githubusercontent.com/ibuildthecloud/otto8/9f8bece94de376c5358f66fa72c23d97ba301a78/02-manage-local-users.png)

### Allowed email domains

![Configure allowed email domains](https://raw.githubusercontent.com/ibuildthecloud/otto8/9f8bece94de376c5358f66fa72c23d97ba301a78/03-allowed-email-domains.png)

### Reset a local password

![Reset a local password](https://raw.githubusercontent.com/ibuildthecloud/otto8/9f8bece94de376c5358f66fa72c23d97ba301a78/04-reset-password.png)

### Local sign-in

![Local sign-in form](https://raw.githubusercontent.com/ibuildthecloud/otto8/9f8bece94de376c5358f66fa72c23d97ba301a78/05-local-login.png)

## Validation

- `make test`
- `pnpm run ci` in `ui/user`
- `git diff --check upstream/main...HEAD`