### PR TITLE
fix: address catalog-entry form validation bugs

### DIFF
--- a/ui/user/src/lib/components/Toggle.svelte
+++ b/ui/user/src/lib/components/Toggle.svelte
@@ -35,7 +35,7 @@
 		{@render input()}
 	</label>
 {:else}
-	<label class={twMerge('text-muted-content flex items-center gap-1 text-xs', classes?.label)}>
+	<label class={twMerge('text-muted-content flex items-center gap-2 text-xs', classes?.label)}>
 		<span>{label}</span>
 		<div class="relative flex h-4.5 w-8.25">
 			{@render input()}

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -128,7 +128,14 @@
 		canEditSecretBindings ? secretBindingTargets : undefined
 	);
 	const defaultDenyAllEgress = $derived(!!version.current.mcpDefaultDenyAllEgress);
-	const shortDescriptionError = `Must be less than or equal to ${MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH} characters`;
+	const shortDescriptionError = $derived(
+		showRequired.shortDescription
+			? 'Short description is required'
+			: `Must be less than or equal to ${MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH} characters`
+	);
+	const hasShortDescriptionError = $derived(
+		showRequired.shortDescription ?? showInvalid.shortDescription
+	);
 
 	function defaultNpxConfig() {
 		return { package: '', args: [], egressDomains: [], denyAllEgress: undefined };
@@ -731,7 +738,7 @@
 				>
 					Name
 					{#if !readonly}
-						<span class="text-error" aria-hidden="true">*</span>
+						<span class={showRequired.name ? 'text-error' : ''} aria-hidden="true">*</span>
 						<span class="sr-only">(required)</span>
 					{/if}
 				</label>
@@ -771,8 +778,15 @@
 			</div>
 
 			<div class="flex flex-col gap-1">
-				<label for={fieldIds.shortDescription} class="text-sm font-light capitalize">
+				<label
+					for={fieldIds.shortDescription}
+					class={twMerge('text-sm font-light capitalize', hasShortDescriptionError && 'error')}
+				>
 					Short Description
+					{#if !readonly}
+						<span class={hasShortDescriptionError ? 'text-error' : ''} aria-hidden="true">*</span>
+						<span class="sr-only">(required)</span>
+					{/if}
 					<span id={fieldIds.shortDescriptionHint} class="text-muted-content text-xs">
 						(max {MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH} characters)
 					</span>
@@ -782,24 +796,21 @@
 					id={fieldIds.shortDescription}
 					name="shortDescription"
 					bind:value={formData.shortDescription}
-					class={twMerge(
-						'text-input-filled dark:bg-base-100',
-						showInvalid.shortDescription && 'error'
-					)}
+					class={twMerge('text-input-filled dark:bg-base-100', hasShortDescriptionError && 'error')}
 					disabled={readonly}
 					placeholder="Provide a brief summary that will be shown in catalog listings."
 					maxlength={MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH}
+					aria-required={!readonly ? 'true' : undefined}
 					aria-describedby={`${fieldIds.shortDescriptionHint} ${fieldIds.shortDescriptionCount}`}
-					aria-invalid={showInvalid.shortDescription ? 'true' : undefined}
-					aria-errormessage={showInvalid.shortDescription
-						? fieldIds.shortDescriptionError
-						: undefined}
+					aria-invalid={hasShortDescriptionError ? 'true' : undefined}
+					aria-errormessage={hasShortDescriptionError ? fieldIds.shortDescriptionError : undefined}
 					oninput={() => {
 						updateInvalid('shortDescription');
+						updateRequired('shortDescription');
 					}}
 				/>
 				<div class="flex justify-between gap-4">
-					{#if showInvalid.shortDescription}
+					{#if hasShortDescriptionError}
 						<p id={fieldIds.shortDescriptionError} class="text-xs text-error" role="alert">
 							{shortDescriptionError}
 						</p>
@@ -954,6 +965,7 @@
 						{readonly}
 						serverUserType={formData.serverUserType}
 						{secretBoundHeaders}
+						showRequired={showRequired.env}
 					/>
 				{/if}
 			{/snippet}
@@ -974,6 +986,7 @@
 						{readonly}
 						serverUserType={formData.serverUserType}
 						{secretBoundHeaders}
+						showRequired={showRequired.env}
 					/>
 				{/if}
 			{/snippet}
@@ -1004,6 +1017,7 @@
 			serverUserType={formData.serverUserType}
 			{secretBoundHeaders}
 			secretBindingTargets={editableSecretBindingTargets}
+			showRequired={showRequired.env}
 		/>
 	{/if}
 

--- a/ui/user/src/lib/components/admin/FilterForm.svelte
+++ b/ui/user/src/lib/components/admin/FilterForm.svelte
@@ -431,7 +431,7 @@
 
 		if (runtimeFormData) {
 			showRuntimeRequired = {}; // reset
-			const { required } = validateRuntimeForm(runtimeFormData as RuntimeFormData, 'multi', true);
+			const { required } = validateRuntimeForm(runtimeFormData as RuntimeFormData, 'filter', true);
 			if (Object.keys(required).length > 0) {
 				showRuntimeRequired = required;
 				return;
@@ -714,6 +714,7 @@
 					serverUserType="multiUser"
 					{isPrebuiltEntry}
 					overrideEnvField={[PII_REDACT_TYPES, PII_BLOCK_TYPES]}
+					showRequired={showRuntimeRequired.env}
 				>
 					{#snippet overrideEnvTemplate({ config })}
 						{#if config.key === PII_BLOCK_TYPES && runtimeFormData}

--- a/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { MCPAllowedSecretBindingTarget, MCPCatalogEntryFieldManifest } from '$lib/services';
+	import type { MCPAllowedSecretBindingTarget, MCPSubField } from '$lib/services';
 	import { version } from '$lib/stores';
 	import Select from '../Select.svelte';
 	import Toggle from '../Toggle.svelte';
@@ -8,7 +8,7 @@
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
-		data: MCPCatalogEntryFieldManifest;
+		data: MCPSubField & { secretBindingSource?: string };
 		id: string;
 		serverUserType?: 'singleUser' | 'multiUser';
 		readonly?: boolean;
@@ -40,9 +40,19 @@
 
 	let selectedType = $state(
 		untrack(() =>
-			data.value.length > 0 || usesSecretBindingSource(data) ? 'static' : 'user_supplied'
+			(data.value?.length ?? 0) > 0 || usesSecretBindingSource(data) ? 'static' : 'user_supplied'
 		)
 	);
+
+	let missingKey = $derived(showRequired && !data.key.trim());
+	let missingName = $derived(showRequired && !data.name.trim());
+	let missingValue = $derived(showRequired && !data.value?.trim());
+
+	$effect(() => {
+		if (data && usesSecretBindingSource(data)) {
+			data.sensitive = true;
+		}
+	});
 </script>
 
 {#if serverUserType === 'singleUser'}
@@ -90,13 +100,19 @@
 				if (!data) return;
 				selectedType = option.id;
 
-				data.required = option.id === 'static' ? true : false;
-				// do overall reset except for key
+				// Reset state when switching between static and user-supplied modes.
+				data.required = option.id === 'static';
 				data.name = '';
 				data.value = '';
 				data.description = '';
 				data.sensitive = false;
+
+				if (option.id === 'user_supplied') {
+					data.secretBinding = undefined;
+					data.secretBindingSource = 'value';
+				}
 			}}
+			readonly={readonly || isPrebuiltEntry}
 			id={`env-value-type-${id}`}
 		/>
 	</div>
@@ -110,12 +126,12 @@
 		{/if}
 		{#if !usesSecretBindingSource(data)}
 			<div class="flex w-full flex-col gap-1">
-				<label for={`env-value-${id}`} class="hidden" aria-hidden="true">Static Value</label>
+				<label for={`env-value-${id}`} class="sr-only">Static Value</label>
 				{#if data.file}
 					<textarea
 						id={`env-value-${id}`}
 						class="text-input-filled bg-base-100 min-h-24 w-full resize-y shadow-none"
-						class:error={showRequired && !data.value}
+						class:error={missingValue}
 						bind:value={data.value}
 						disabled={readonly}
 						rows={(data.value ?? '').split('\n').length + 1}
@@ -124,7 +140,7 @@
 					<input
 						id={`env-value-${id}`}
 						class="text-input-filled bg-base-100 w-full shadow-none"
-						class:error={showRequired && !data.value}
+						class:error={missingValue}
 						bind:value={data.value}
 						placeholder="e.g. 123abcdef456"
 						disabled={readonly}
@@ -181,11 +197,11 @@
 
 {#snippet keyInput()}
 	<div class="flex w-full flex-col gap-1">
-		{@render label('Key', `env-key-${id}`, true, showRequired && !data.key)}
+		{@render label('Key', `env-key-${id}`, true, missingKey)}
 		<input
 			id={`env-key-${id}`}
 			class={classes?.input}
-			class:error={showRequired && !data.key}
+			class:error={missingKey}
 			bind:value={data.key}
 			placeholder="e.g. CUSTOM_API_KEY"
 			disabled={readonly || isPrebuiltEntry}
@@ -195,11 +211,11 @@
 
 {#snippet nameAndDescriptionInputs()}
 	<div class="flex w-full flex-col gap-1">
-		{@render label('Name', `env-name-${id}`, true, showRequired && !data.name)}
+		{@render label('Name', `env-name-${id}`, true, missingName)}
 		<input
 			id={`env-name-${id}`}
 			class={classes?.input}
-			class:error={showRequired && !data.name}
+			class:error={missingName}
 			bind:value={data.name}
 			disabled={readonly || isPrebuiltEntry}
 		/>

--- a/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+	import type { MCPAllowedSecretBindingTarget, MCPCatalogEntryFieldManifest } from '$lib/services';
+	import { version } from '$lib/stores';
+	import Select from '../Select.svelte';
+	import Toggle from '../Toggle.svelte';
+	import SecretBindingPicker from './SecretBindingPicker.svelte';
+	import { untrack } from 'svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	interface Props {
+		data: MCPCatalogEntryFieldManifest;
+		id: string;
+		serverUserType?: 'singleUser' | 'multiUser';
+		readonly?: boolean;
+		isPrebuiltEntry?: boolean;
+		secretBindingTargets?: MCPAllowedSecretBindingTarget[];
+		classes?: {
+			input?: string;
+		};
+		showRequired?: boolean;
+	}
+
+	let {
+		id,
+		data = $bindable(),
+		serverUserType,
+		readonly,
+		isPrebuiltEntry,
+		secretBindingTargets,
+		classes,
+		showRequired
+	}: Props = $props();
+
+	function usesSecretBindingSource(field: {
+		secretBinding?: unknown;
+		secretBindingSource?: string;
+	}) {
+		return Boolean(field.secretBinding) || field.secretBindingSource === 'secret';
+	}
+
+	let selectedType = $state(
+		untrack(() =>
+			data.value.length > 0 || usesSecretBindingSource(data) ? 'static' : 'user_supplied'
+		)
+	);
+</script>
+
+{#if serverUserType === 'singleUser'}
+	<p class="text-muted-content text-xs font-light">
+		The Name and Description fields will be displayed to the user when configuring this server. The
+		Key field will not.
+	</p>
+
+	{@render keyInput()}
+	{@render nameAndDescriptionInputs()}
+	<div class="flex gap-8">
+		<label class="flex items-center gap-2">
+			<input type="checkbox" bind:checked={data.sensitive} disabled={readonly || isPrebuiltEntry} />
+			<span class="text-sm">Sensitive</span>
+		</label>
+		<label class="flex items-center gap-2">
+			<input type="checkbox" bind:checked={data.required} disabled={readonly || isPrebuiltEntry} />
+			<span class="text-sm">Required</span>
+		</label>
+	</div>
+{:else}
+	<div class="flex w-full flex-col gap-1">
+		{@render keyInput()}
+
+		{#if isPrebuiltEntry && data.description}
+			<p class="text-muted-content text-xs font-light break-all">
+				{data.description}
+			</p>
+		{/if}
+	</div>
+
+	<div class="flex w-full flex-col gap-1">
+		{@render label('Value', `env-value-type-${id}`)}
+		<Select
+			class="bg-base-100 dark:border-base-400 border border-transparent shadow-none"
+			classes={{
+				root: 'flex grow'
+			}}
+			options={[
+				{ label: 'Static', id: 'static' },
+				{ label: 'User-Supplied', id: 'user_supplied' }
+			]}
+			selected={selectedType}
+			onSelect={(option) => {
+				if (!data) return;
+				selectedType = option.id;
+
+				data.required = option.id === 'static' ? true : false;
+				// do overall reset except for key
+				data.name = '';
+				data.value = '';
+				data.description = '';
+				data.sensitive = false;
+			}}
+			id={`env-value-type-${id}`}
+		/>
+	</div>
+
+	{#if !isPrebuiltEntry && selectedType === 'user_supplied'}
+		{@render nameAndDescriptionInputs()}
+	{/if}
+	{#if selectedType === 'static'}
+		{#if secretBindingTargets && !version.current.hideK8sDetails}
+			<SecretBindingPicker bind:field={data} targets={secretBindingTargets} {readonly} />
+		{/if}
+		{#if !usesSecretBindingSource(data)}
+			<div class="flex w-full flex-col gap-1">
+				<label for={`env-value-${id}`} class="hidden" aria-hidden="true">Static Value</label>
+				{#if data.file}
+					<textarea
+						id={`env-value-${id}`}
+						class="text-input-filled bg-base-100 min-h-24 w-full resize-y shadow-none"
+						class:error={showRequired && !data.value}
+						bind:value={data.value}
+						disabled={readonly}
+						rows={(data.value ?? '').split('\n').length + 1}
+					></textarea>
+				{:else}
+					<input
+						id={`env-value-${id}`}
+						class="text-input-filled bg-base-100 w-full shadow-none"
+						class:error={showRequired && !data.value}
+						bind:value={data.value}
+						placeholder="e.g. 123abcdef456"
+						disabled={readonly}
+						type={data.sensitive ? 'password' : 'text'}
+					/>
+				{/if}
+			</div>
+		{/if}
+	{/if}
+	<div class="flex w-full">
+		{#if !usesSecretBindingSource(data)}
+			<Toggle
+				classes={{ label: 'text-sm text-inherit' }}
+				disabled={readonly || isPrebuiltEntry}
+				label="Sensitive"
+				labelInline
+				checked={!!data.sensitive}
+				onChange={(checked) => {
+					if (data) {
+						data.sensitive = checked;
+					}
+				}}
+			/>
+			{#if selectedType !== 'static'}
+				<div class="divider divider-horizontal"></div>
+			{/if}
+		{/if}
+		{#if selectedType !== 'static'}
+			<Toggle
+				classes={{ label: 'text-sm text-inherit' }}
+				disabled={readonly || isPrebuiltEntry}
+				label="Required"
+				labelInline
+				checked={!!data.required}
+				onChange={(checked) => {
+					if (data) {
+						data.required = checked;
+					}
+				}}
+			/>
+		{/if}
+	</div>
+{/if}
+
+{#snippet label(title: string, forInput: string, required?: boolean, showError?: boolean)}
+	<label for={forInput} class={twMerge('text-sm font-light', showError && 'text-error')}>
+		{title}
+		{#if !readonly && required}
+			<span class={showError ? 'text-error' : ''} aria-hidden="true">*</span>
+			<span class="sr-only">(required)</span>
+		{/if}
+	</label>
+{/snippet}
+
+{#snippet keyInput()}
+	<div class="flex w-full flex-col gap-1">
+		{@render label('Key', `env-key-${id}`, true, showRequired && !data.key)}
+		<input
+			id={`env-key-${id}`}
+			class={classes?.input}
+			class:error={showRequired && !data.key}
+			bind:value={data.key}
+			placeholder="e.g. CUSTOM_API_KEY"
+			disabled={readonly || isPrebuiltEntry}
+		/>
+	</div>
+{/snippet}
+
+{#snippet nameAndDescriptionInputs()}
+	<div class="flex w-full flex-col gap-1">
+		{@render label('Name', `env-name-${id}`, true, showRequired && !data.name)}
+		<input
+			id={`env-name-${id}`}
+			class={classes?.input}
+			class:error={showRequired && !data.name}
+			bind:value={data.name}
+			disabled={readonly || isPrebuiltEntry}
+		/>
+	</div>
+	<div class="flex w-full flex-col gap-1">
+		{@render label('Description', `env-description-${id}`, false)}
+		<input
+			id={`env-description-${id}`}
+			class={classes?.input}
+			bind:value={data.description}
+			disabled={readonly || isPrebuiltEntry}
+		/>
+	</div>
+{/snippet}

--- a/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import type { MCPAllowedSecretBindingTarget, MCPCatalogEntryFieldManifest } from '$lib/services';
 	import { hasSecretBinding } from '$lib/services/user/mcp';
-	import { version } from '$lib/stores';
 	import Select from '../Select.svelte';
 	import IconButton from '../primitives/IconButton.svelte';
-	import SecretBindingPicker from './SecretBindingPicker.svelte';
+	import CustomConfigurationFieldset from './CustomConfigurationFieldset.svelte';
 	import { Plus, Trash2 } from '@lucide/svelte';
 	import type { Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -18,6 +17,7 @@
 		secretBindingTargets?: MCPAllowedSecretBindingTarget[];
 		overrideEnvField?: string[];
 		overrideEnvTemplate?: Snippet<[{ config: MCPCatalogEntryFieldManifest; index: number }]>;
+		showRequired?: boolean;
 	}
 
 	let {
@@ -28,7 +28,8 @@
 		isPrebuiltEntry,
 		secretBindingTargets,
 		overrideEnvField,
-		overrideEnvTemplate
+		overrideEnvTemplate,
+		showRequired
 	}: Props = $props();
 
 	// Separate secret-bound fields from user-configurable fields, preserving
@@ -45,13 +46,6 @@
 		...secretBoundEnvs.map(({ item }) => ({ item, source: 'env' as const })),
 		...(secretBoundHeaders ?? []).map((item) => ({ item, source: 'header' as const }))
 	]);
-
-	function usesSecretBindingSource(field: {
-		secretBinding?: unknown;
-		secretBindingSource?: string;
-	}) {
-		return Boolean(field.secretBinding) || field.secretBindingSource === 'secret';
-	}
 
 	const inputClass = 'text-input-filled bg-base-100 w-full shadow-none';
 </script>
@@ -113,133 +107,18 @@
 							{/if}
 						</p>
 
-						{#if serverUserType === 'singleUser'}
-							<p class="text-muted-content text-xs font-light">
-								The Name and Description fields will be displayed to the user when configuring this
-								server. The Key field will not.
-							</p>
-							<div class="flex w-full flex-col gap-1">
-								<label for={`env-name-${i}`} class="text-sm font-light">Name</label>
-								<input
-									id={`env-name-${i}`}
-									class={inputClass}
-									bind:value={config![i].name}
-									disabled={readonly || isPrebuiltEntry}
-								/>
-							</div>
-							<div class="flex w-full flex-col gap-1">
-								<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
-								<input
-									id={`env-description-${i}`}
-									class={inputClass}
-									bind:value={config![i].description}
-									disabled={readonly || isPrebuiltEntry}
-								/>
-							</div>
-							<div class="flex w-full flex-col gap-1">
-								<label for={`env-key-${i}`} class="text-sm font-light">Key</label>
-								<input
-									id={`env-key-${i}`}
-									class={inputClass}
-									bind:value={config![i].key}
-									placeholder="e.g. CUSTOM_API_KEY"
-									disabled={readonly || isPrebuiltEntry}
-								/>
-							</div>
-							<div class="flex gap-8">
-								<label class="flex items-center gap-2">
-									<input
-										type="checkbox"
-										bind:checked={config![i].sensitive}
-										disabled={readonly || isPrebuiltEntry}
-									/>
-									<span class="text-sm">Sensitive</span>
-								</label>
-								<label class="flex items-center gap-2">
-									<input
-										type="checkbox"
-										bind:checked={config![i].required}
-										disabled={readonly || isPrebuiltEntry}
-									/>
-									<span class="text-sm">Required</span>
-								</label>
-							</div>
-						{:else}
-							<div class="flex w-full flex-col gap-1">
-								<label for={`env-key-${i}`} class="text-sm font-light">Key</label>
-								<input
-									id={`env-key-${i}`}
-									class={inputClass}
-									bind:value={config![i].key}
-									placeholder="e.g. CUSTOM_API_KEY"
-									disabled={readonly || isPrebuiltEntry}
-								/>
-								{#if isPrebuiltEntry && config![i].description}
-									<p class="text-muted-content text-xs font-light break-all">
-										{config![i].description}
-									</p>
-								{/if}
-							</div>
-							{#if !isPrebuiltEntry}
-								<div class="flex w-full flex-col gap-1">
-									<label for={`env-description-${i}`} class="text-sm font-light">Description</label>
-									<input
-										id={`env-description-${i}`}
-										class={inputClass}
-										bind:value={config![i].description}
-										disabled={readonly}
-									/>
-								</div>
-							{/if}
-							{#if secretBindingTargets && !version.current.hideK8sDetails}
-								<SecretBindingPicker
-									bind:field={config![i]}
-									targets={secretBindingTargets}
-									{readonly}
-								/>
-							{/if}
-							{#if !usesSecretBindingSource(config![i])}
-								<div class="flex w-full flex-col gap-1">
-									<label for={`env-value-${i}`} class="text-sm font-light">Value</label>
-									{#if config![i].file}
-										<textarea
-											id={`env-value-${i}`}
-											class="text-input-filled bg-base-100 min-h-24 w-full resize-y shadow-none"
-											bind:value={config![i].value}
-											disabled={readonly}
-											rows={(config![i].value ?? '').split('\n').length + 1}
-										></textarea>
-									{:else}
-										<input
-											id={`env-value-${i}`}
-											class="text-input-filled bg-base-100 w-full shadow-none"
-											bind:value={config![i].value}
-											placeholder="e.g. 123abcdef456"
-											disabled={readonly}
-											type={config![i].sensitive ? 'password' : 'text'}
-										/>
-									{/if}
-								</div>
-							{/if}
-							<div class="flex w-full gap-4">
-								<label class="flex items-center gap-2">
-									<input
-										type="checkbox"
-										bind:checked={config![i].sensitive}
-										disabled={readonly || isPrebuiltEntry}
-									/>
-									<span class="text-sm">Sensitive</span>
-								</label>
-								<label class="flex items-center gap-2">
-									<input
-										type="checkbox"
-										bind:checked={config![i].required}
-										disabled={readonly || isPrebuiltEntry}
-									/>
-									<span class="text-sm">Required</span>
-								</label>
-							</div>
-						{/if}
+						<CustomConfigurationFieldset
+							id={`env-${i}`}
+							bind:data={config![i]}
+							{serverUserType}
+							{readonly}
+							{isPrebuiltEntry}
+							{secretBindingTargets}
+							classes={{
+								input: inputClass
+							}}
+							{showRequired}
+						/>
 					</div>
 					{#if !readonly && !isPrebuiltEntry}
 						<IconButton

--- a/ui/user/src/lib/components/mcp/SecretBindingPicker.svelte
+++ b/ui/user/src/lib/components/mcp/SecretBindingPicker.svelte
@@ -58,7 +58,7 @@
 		return options;
 	});
 	const selectClasses =
-		'bg-base-200 dark:bg-base-300 border border-base-300 dark:border-base-400 w-full shadow-inner';
+		'bg-base-200 dark:bg-base-100 border border-base-300 dark:border-base-400 w-full shadow-inner';
 
 	function setValueSource(source: ValueSource) {
 		valueSource = source;

--- a/ui/user/src/lib/components/mcp/SecretBindingPicker.svelte
+++ b/ui/user/src/lib/components/mcp/SecretBindingPicker.svelte
@@ -72,6 +72,7 @@
 		if (!firstTarget || !firstKey) return;
 		field.value = '';
 		field.secretBinding = { name: firstTarget.name, key: firstKey };
+		field.sensitive = true;
 	}
 
 	function clearSecretBinding() {
@@ -86,6 +87,7 @@
 		if (!target || !key) return;
 		field.value = '';
 		field.secretBinding = { name: target.name, key };
+		field.sensitive = true;
 	}
 
 	function selectKey(key: string | number) {
@@ -93,6 +95,7 @@
 		if (!field.secretBinding) return;
 		field.value = '';
 		field.secretBinding = { ...field.secretBinding, key: String(key) };
+		field.sensitive = true;
 	}
 </script>
 

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -714,10 +714,14 @@ function validateEnvs(type: LaunchServerType | 'filter', envs: MCPServerInfo['en
 	if (!envs || type === 'composite') return true;
 
 	if (type === 'remote') {
-		return envs.every((env) => env.key);
+		return envs.every((env) => Boolean(env.key.trim()));
 	}
 
-	return envs.every((env) => env.key && (env.value || env.secretBinding || env.name));
+	return envs.every(
+		(env) =>
+			Boolean(env.key.trim()) &&
+			(Boolean(env.value?.trim()) || hasSecretBinding(env) || Boolean(env.name.trim()))
+	);
 }
 
 export const validateRuntimeForm = (
@@ -735,11 +739,10 @@ export const validateRuntimeForm = (
 	}
 
 	if (type !== 'filter') {
-		if (!formData.shortDescription) {
+		const shortDescription = formData.shortDescription?.trim();
+		if (!shortDescription) {
 			missingFields.shortDescription = true;
-		} else if (
-			Array.from(formData.shortDescription).length > MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH
-		) {
+		} else if (Array.from(shortDescription).length > MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH) {
 			invalid.shortDescription = true;
 		}
 	}

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -710,9 +710,19 @@ export const getMcpServerDeploymentStatus = (
 	return { updateStatus, updatesAvailable, updateStatusTooltip };
 };
 
+function validateEnvs(type: LaunchServerType | 'filter', envs: MCPServerInfo['env']) {
+	if (!envs || type === 'composite') return true;
+
+	if (type === 'remote') {
+		return envs.every((env) => env.key);
+	}
+
+	return envs.every((env) => env.key && (env.value || env.secretBinding || env.name));
+}
+
 export const validateRuntimeForm = (
 	formData: RuntimeFormData,
-	type: LaunchServerType,
+	type: LaunchServerType | 'filter',
 	nameNotRequired: boolean = false
 ): { required: Record<string, boolean>; invalid: Record<string, boolean> } => {
 	const missingFields: Record<string, boolean> = {};
@@ -724,16 +734,23 @@ export const validateRuntimeForm = (
 		missingFields.startupTimeoutSeconds = true;
 	}
 
-	if (
-		formData.shortDescription &&
-		Array.from(formData.shortDescription ?? '').length > MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH
-	) {
-		invalid.shortDescription = true;
+	if (type !== 'filter') {
+		if (!formData.shortDescription) {
+			missingFields.shortDescription = true;
+		} else if (
+			Array.from(formData.shortDescription).length > MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH
+		) {
+			invalid.shortDescription = true;
+		}
 	}
 
 	// Basic validation - name is required
 	if (!nameNotRequired && !formData.name.trim()) {
 		missingFields.name = true;
+	}
+
+	if (!validateEnvs(type, formData.env)) {
+		missingFields.env = true;
 	}
 
 	// Runtime-specific validation


### PR DESCRIPTION
This addresses three bugs in the catalog entry form:
- When adding a custom configuration (envs), they can be saved as empty. The UI now enforces that key must be required as well as additional validation depending on user-supplied or static.
- Multi-tenant catalog entry has User-supplied or Static differentation when adding a custom configuration
- Removal of sensitive toggle input for Kubernetes secret (will still set sensitive behind the scenes but essentially when a kubernetes secret binding is set, sensitive should just be true)
- Makes shortDescription a required field via UI

Addresses #7095
Addresses #7097 
Addresses #7099 
Addresses #6998