### PR TITLE
feat(db): add more fine-grained db connection config

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -114,8 +114,22 @@ config:
 
   # config.NAH_THREADINESS -- Advanced - sets the number of concurrent threads that can run in the Obot controller
   NAH_THREADINESS: "10000"
-  # config.KINM_DB_CONNECTIONS -- Advanced - the number of connections in the database pool for kinm
+  # config.KINM_DB_CONNECTIONS -- Advanced - the number of connections in the database pool for kinm, both open and idle connections
   KINM_DB_CONNECTIONS: "5"
+  # config.KINM_DB_MAX_IDLE_CONNECTIONS -- Advanced - the number of idle connections in the database pool for kinm, overrides KINM_DB_CONNECTIONS
+  KINM_DB_MAX_IDLE_CONNECTIONS: "2"
+  # config.KINM_DB_MAX_CONNECTIONS -- Advanced - the number of open connections in the database pool for kinm, overrides KINM_DB_CONNECTIONS
+  KINM_DB_MAX_CONNECTIONS: "5"
+  # config.KINM_DB_MAX_CONNECTION_LIFETIME_SECONDS -- Advanced - the maximum lifetime of a connection in the database pool for kinm in seconds
+  KINM_DB_MAX_CONNECTION_LIFETIME_SECONDS: "180"
+  # config.OBOT_AUTH_PROVIDER_POSTGRES_MAX_IDLE_CONNECTIONS -- Advanced - the maximum number of idle connections in the database pool for the auth provider
+  OBOT_AUTH_PROVIDER_POSTGRES_MAX_IDLE_CONNECTIONS: "2"
+  # config.OBOT_AUTH_PROVIDER_POSTGRES_MAX_CONNECTIONS -- Advanced - the maximum number of connections in the database pool for the auth provider
+  OBOT_AUTH_PROVIDER_POSTGRES_MAX_CONNECTIONS: "5"
+  # config.OBOT_AUTH_PROVIDER_POSTGRES_CONNECTION_LIFETIME_SECONDS -- Advanced - the maximum lifetime of a connection in the database pool for the auth provider in seconds
+  OBOT_AUTH_PROVIDER_POSTGRES_CONNECTION_LIFETIME_SECONDS: "180"
+
+
 
   # config.OBOT_SERVER_ENABLE_AUTHENTICATION -- Enables authentication for Obot
   OBOT_SERVER_ENABLE_AUTHENTICATION: false

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -20,7 +20,13 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_SINGLE_USER_IDLE_SERVER_SHUTDOWN_HOURS` | The interval in hours to check for idle single-user MCP servers and shut them down. Set to `-1` to disable idle shutdown. | `24` (1 day) |
 | `OBOT_SERVER_MULTI_USER_IDLE_SERVER_SHUTDOWN_HOURS` | The interval in hours to check for idle multi-user MCP servers and shut them down. Set to `-1` to disable idle shutdown. | `168` (7 days) |
 | `NAH_THREADINESS` | Sets the number of concurrent threads that can run in the Obot controller. | `10` |
-| `KINM_DB_CONNECTIONS` | The number of connections in the database pool for kinm | `5` |
+| `KINM_DB_CONNECTIONS` | Sets both the maximum open and idle connection counts in the Kinm database pool. `KINM_DB_MAX_CONNECTIONS` and `KINM_DB_MAX_IDLE_CONNECTIONS` override the corresponding values. | `5` |
+| `KINM_DB_MAX_IDLE_CONNECTIONS` | The maximum number of idle connections in the Kinm database pool. Overrides the idle connection count set by `KINM_DB_CONNECTIONS`. | `2` |
+| `KINM_DB_MAX_CONNECTIONS` | The maximum number of open connections in the Kinm database pool. Overrides the open connection count set by `KINM_DB_CONNECTIONS`. | `5` |
+| `KINM_DB_MAX_CONNECTION_LIFETIME_SECONDS` | The maximum lifetime of a connection in the Kinm database pool, in seconds. | `180` |
+| `OBOT_AUTH_PROVIDER_POSTGRES_MAX_IDLE_CONNECTIONS` | The maximum number of idle connections in the PostgreSQL database pool used by authentication providers. | `2` |
+| `OBOT_AUTH_PROVIDER_POSTGRES_MAX_CONNECTIONS` | The maximum number of open connections in the PostgreSQL database pool used by authentication providers. | `5` |
+| `OBOT_AUTH_PROVIDER_POSTGRES_CONNECTION_LIFETIME_SECONDS` | The maximum lifetime of a connection in the PostgreSQL database pool used by authentication providers, in seconds. | `180` |
 | `OBOT_SERVER_ENABLE_AUTHENTICATION` | Enables authentication for Obot | `false` |
 | `OBOT_SERVER_UNAUTHENTICATED_RATE_LIMIT` | Rate limit for unauthenticated requests (requests per second). Unauthenticated requests are tracked by source IP address. | `100` |
 | `OBOT_SERVER_AUTHENTICATED_RATE_LIMIT` | Rate limit for authenticated non-admin requests (requests per second). Authenticated requests are tracked by user ID. Admin users are exempt from rate limiting. | `200` |

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037
 	github.com/obot-platform/chat-completion-client v0.0.0-20260529163740-88dd50945c18
 	github.com/obot-platform/cmd v0.0.0-20260707150346-5103d461ab67
-	github.com/obot-platform/kinm v0.0.0-20260714141330-7c64312d9627
+	github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e
 	github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f
 	github.com/obot-platform/nanobot v0.0.91-0.20260715195038-4dbde5629c2a
 	github.com/obot-platform/obot/apiclient v0.0.0-20250813183905-ade719c1e8bf

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/obot-platform/chat-completion-client v0.0.0-20260529163740-88dd50945c
 github.com/obot-platform/chat-completion-client v0.0.0-20260529163740-88dd50945c18/go.mod h1:YslCtQ/xUKpZUmiW8AFp2hBefikf4KcbEk57Jso1JAU=
 github.com/obot-platform/cmd v0.0.0-20260707150346-5103d461ab67 h1:QGhIjCb7NuBsI7g+gvVqYjyZ56uHgjteM0khJtR7+a4=
 github.com/obot-platform/cmd v0.0.0-20260707150346-5103d461ab67/go.mod h1:zj/4glDORtg3DKkLvTN2RUpm1gZnRU3dlbr3dZ4Pc2Q=
-github.com/obot-platform/kinm v0.0.0-20260714141330-7c64312d9627 h1:Z0gqfIwmXTJSmRSZicFIFDWf8hoiCvQnrFZVchroZOU=
-github.com/obot-platform/kinm v0.0.0-20260714141330-7c64312d9627/go.mod h1:mJ2Mx/FzMK2WmfxamD2V9N7TeakulKdmGHw4qvMjzUs=
+github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e h1:o439PMKepm2yIrx+2TmCZFCnFXRWObpo3zbK/Z+BUqk=
+github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e/go.mod h1:mJ2Mx/FzMK2WmfxamD2V9N7TeakulKdmGHw4qvMjzUs=
 github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00 h1:IzmiE4JJMEsceK7K5f/iYLG4f3YIFUHiSn6zWonypFc=
 github.com/obot-platform/mcp-oauth-proxy v0.0.3-0.20260526141817-32b8278fcf00/go.mod h1:IBdiWaE+aSlf5TpqKhtDkpGwxPetHtjaScewJ/UoSGQ=
 github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f h1:yoMKu8I8gFlsBOSPs+guQdsSWscaipIjDIBIIl2a7ho=

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/obot-platform/obot/logger"
@@ -17,7 +18,12 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const PostgresConnectionEnvVar = "OBOT_AUTH_PROVIDER_POSTGRES_CONNECTION_DSN"
+const (
+	postgresConnectionEnvVar      = "OBOT_AUTH_PROVIDER_POSTGRES_CONNECTION_DSN"
+	postgresMaxIdleConnsEnvVar    = "OBOT_AUTH_PROVIDER_POSTGRES_MAX_IDLE_CONNECTIONS"
+	postgresMaxOpenConnsEnvVar    = "OBOT_AUTH_PROVIDER_POSTGRES_MAX_CONNECTIONS"
+	postgresConnMaxLifetimeEnvVar = "OBOT_AUTH_PROVIDER_POSTGRES_CONNECTION_LIFETIME_SECONDS"
+)
 
 type Dispatcher struct {
 	sessionManager       *mcp.SessionManager
@@ -42,7 +48,12 @@ func New(sessionManager *mcp.SessionManager, c kclient.Client, gatewayClient *cl
 	}
 
 	if postgresDSN != "" {
-		d.authProviderExtraEnv = map[string]string{PostgresConnectionEnvVar: postgresDSN}
+		d.authProviderExtraEnv = map[string]string{
+			postgresConnectionEnvVar:      postgresDSN,
+			postgresMaxIdleConnsEnvVar:    os.Getenv(postgresMaxIdleConnsEnvVar),
+			postgresMaxOpenConnsEnvVar:    os.Getenv(postgresMaxOpenConnsEnvVar),
+			postgresConnMaxLifetimeEnvVar: os.Getenv(postgresConnMaxLifetimeEnvVar),
+		}
 	}
 
 	return d


### PR DESCRIPTION
This change adds the ability to configure kinm and auth provider db connection configuration separately, as well as configure max open, max idle, and lifetime separately.

Requires: https://github.com/obot-platform/enterprise-providers/pull/9, https://github.com/obot-platform/providers/pull/9