### PR TITLE
fix: capture LLM audit session IDs by dialect

### DIFF
--- a/pkg/gateway/server/llmaudit.go
+++ b/pkg/gateway/server/llmaudit.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	nanobottypes "github.com/obot-platform/nanobot/pkg/types"
 	"github.com/obot-platform/obot/pkg/api/server/requestinfo"
 	"github.com/obot-platform/obot/pkg/gateway/client"
 	gatewaycontext "github.com/obot-platform/obot/pkg/gateway/context"
@@ -23,12 +24,14 @@ import (
 
 const (
 	defaultLLMAuditLogResponseCaptureLimit = 5 << 20 // 5MiB
+	claudeCodeSessionIDHeader              = "X-Claude-Code-Session-Id"
 
 	llmAuditClientClaudeCode = "claude-code"
 	llmAuditClientCodex      = "codex"
 
 	llmAuditUserAgentClaudeCode = "claude-code"
 	llmAuditUserAgentClaudeCLI  = "claude-cli"
+	llmAuditUserAgentClaudeGRI  = "gRi"
 	llmAuditUserAgentCodexCLI   = "codex_cli_rs"
 	llmAuditUserAgentCodexTUI   = "codex-tui"
 )
@@ -95,11 +98,11 @@ func (r *llmAuditRecorder) setPolicyModifiedRequestBody(body []byte) {
 	r.log.MessagePolicyTriggered = len(body) > 0
 }
 
-func (r *llmAuditRecorder) setClientSessionID(modelProvider string, body []byte) {
+func (r *llmAuditRecorder) setClientSessionID(dialect nanobottypes.Dialect, headers http.Header, body []byte) {
 	if r == nil {
 		return
 	}
-	r.log.ClientSessionID = extractLLMClientSessionID(modelProvider, body)
+	r.log.ClientSessionID = extractLLMClientSessionID(dialect, headers, body)
 }
 
 func (r *llmAuditRecorder) setReasoningEffort(modelProvider string, body []byte) {
@@ -245,17 +248,24 @@ func parseLLMClientUserAgent(userAgent string) (string, string) {
 	switch name {
 	case llmAuditUserAgentClaudeCode, llmAuditUserAgentClaudeCLI:
 		name = llmAuditClientClaudeCode
+	case llmAuditUserAgentClaudeGRI:
+		name = llmAuditClientClaudeCode
+		version = ""
 	case llmAuditUserAgentCodexCLI, llmAuditUserAgentCodexTUI:
 		name = llmAuditClientCodex
 	}
 	return name, version
 }
 
-func extractLLMClientSessionID(modelProvider string, body []byte) string {
-	switch modelProvider {
-	case system.OpenAIModelProvider:
+func extractLLMClientSessionID(dialect nanobottypes.Dialect, headers http.Header, body []byte) string {
+	if sessionID := headers.Get(claudeCodeSessionIDHeader); sessionID != "" {
+		return sessionID
+	}
+
+	switch dialect {
+	case nanobottypes.DialectOpenAIResponses:
 		return gjson.GetBytes(body, "client_metadata.session_id").String()
-	case system.AnthropicModelProvider:
+	case nanobottypes.DialectAnthropicMessages:
 		userID := gjson.GetBytes(body, "metadata.user_id").String()
 		if !gjson.Valid(userID) {
 			return ""

--- a/pkg/gateway/server/llmaudit_test.go
+++ b/pkg/gateway/server/llmaudit_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	nanobottypes "github.com/obot-platform/nanobot/pkg/types"
 	gatewayllmaudit "github.com/obot-platform/obot/pkg/gateway/llmaudit"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/system"
@@ -137,6 +138,7 @@ func TestParseLLMClientUserAgent(t *testing.T) {
 	}{
 		{userAgent: "claude-code/2.1.176", client: llmAuditClientClaudeCode, version: "2.1.176"},
 		{userAgent: "claude-cli/2.1.176 (external, cli)", client: llmAuditClientClaudeCode, version: "2.1.176"},
+		{userAgent: "gRi/JS 0.94.0", client: llmAuditClientClaudeCode, version: ""},
 		{userAgent: "codex_cli_rs/0.142.4 (Mac OS 26.5.1; arm64) ghostty/1.3.1", client: llmAuditClientCodex, version: "0.142.4"},
 		{userAgent: "codex-tui/0.142.4 (Mac OS 26.5.1; arm64) ghostty/1.3.1 (codex-tui; 0.142.4)", client: llmAuditClientCodex, version: "0.142.4"},
 		{userAgent: "other-client/1.2.3", client: "other-client", version: "1.2.3"},
@@ -153,41 +155,48 @@ func TestParseLLMClientUserAgent(t *testing.T) {
 
 func TestExtractLLMClientSessionID(t *testing.T) {
 	for _, tt := range []struct {
-		name          string
-		modelProvider string
-		body          string
-		want          string
+		name    string
+		dialect nanobottypes.Dialect
+		headers http.Header
+		body    string
+		want    string
 	}{
 		{
-			name:          "openai client metadata session id",
-			modelProvider: system.OpenAIModelProvider,
-			body:          `{"client_metadata":{"session_id":"openai-session"}}`,
-			want:          "openai-session",
+			name:    "Claude Code session header preferred over body",
+			dialect: nanobottypes.DialectAnthropicMessages,
+			headers: http.Header{claudeCodeSessionIDHeader: []string{"header-session"}},
+			body:    `{"metadata":{"user_id":"{\"session_id\":\"body-session\"}"}}`,
+			want:    "header-session",
 		},
 		{
-			name:          "openai ignores codex metadata fallback",
-			modelProvider: system.OpenAIModelProvider,
-			body:          `{"client_metadata":{"x-codex-turn-metadata":"{\"session_id\":\"ignored\"}"}}`,
+			name:    "OpenAI dialect client metadata session id",
+			dialect: nanobottypes.DialectOpenAIResponses,
+			body:    `{"client_metadata":{"session_id":"openai-session"}}`,
+			want:    "openai-session",
 		},
 		{
-			name:          "anthropic metadata user id session id",
-			modelProvider: system.AnthropicModelProvider,
-			body:          `{"metadata":{"user_id":"{\"session_id\":\"claude-session\"}"}}`,
-			want:          "claude-session",
+			name:    "OpenAI dialect ignores Codex metadata fallback",
+			dialect: nanobottypes.DialectOpenAIResponses,
+			body:    `{"client_metadata":{"x-codex-turn-metadata":"{\"session_id\":\"ignored\"}"}}`,
 		},
 		{
-			name:          "anthropic malformed metadata user id",
-			modelProvider: system.AnthropicModelProvider,
-			body:          `{"metadata":{"user_id":"not-json"}}`,
+			name:    "Anthropic dialect metadata user id session id",
+			dialect: nanobottypes.DialectAnthropicMessages,
+			body:    `{"metadata":{"user_id":"{\"session_id\":\"claude-session\"}"}}`,
+			want:    "claude-session",
 		},
 		{
-			name:          "wrong provider",
-			modelProvider: "other",
-			body:          `{"client_metadata":{"session_id":"ignored"}}`,
+			name:    "Anthropic dialect malformed metadata user id",
+			dialect: nanobottypes.DialectAnthropicMessages,
+			body:    `{"metadata":{"user_id":"not-json"}}`,
+		},
+		{
+			name: "unknown dialect",
+			body: `{"client_metadata":{"session_id":"ignored"}}`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := extractLLMClientSessionID(tt.modelProvider, []byte(tt.body)); got != tt.want {
+			if got := extractLLMClientSessionID(tt.dialect, tt.headers, []byte(tt.body)); got != tt.want {
 				t.Fatalf("expected %q, got %q", tt.want, got)
 			}
 		})

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -1072,7 +1072,7 @@ func (l *llmProviderProxy) proxy(req api.Context) (retErr error) {
 		return fmt.Errorf("failed to copy body: %w", err)
 	}
 	audit.setRequestBody(body)
-	audit.setClientSessionID(l.backend.modelProviderName(), body)
+	audit.setClientSessionID(routeDialect, req.Request.Header, body)
 	audit.setReasoningEffort(l.backend.modelProviderName(), body)
 
 	prepared := &preparedLLMProxyRequest{body: body}

--- a/pkg/gateway/server/llmproxy_api_key.go
+++ b/pkg/gateway/server/llmproxy_api_key.go
@@ -20,7 +20,14 @@ func (a apiKeyLLMProviderBackend) modelProviderName() string {
 }
 
 func (a apiKeyLLMProviderBackend) upstreamURL(*http.Request, map[string]string) (url.URL, nanobottypes.Dialect, error) {
-	return a.u, "", nil
+	switch a.providerName {
+	case system.AnthropicModelProvider:
+		return a.u, nanobottypes.DialectAnthropicMessages, nil
+	case system.OpenAIModelProvider:
+		return a.u, nanobottypes.DialectOpenAIResponses, nil
+	default:
+		return a.u, "", nil
+	}
 }
 
 func (a apiKeyLLMProviderBackend) transport(modelProvider v1.ModelProvider, credEnv map[string]string) (http.RoundTripper, error) {

--- a/pkg/gateway/server/llmproxy_test.go
+++ b/pkg/gateway/server/llmproxy_test.go
@@ -528,6 +528,27 @@ func TestAPIKeyBackendTransportRequiresCredentialValue(t *testing.T) {
 	}
 }
 
+func TestAPIKeyBackendUpstreamURLDialect(t *testing.T) {
+	for _, tt := range []struct {
+		provider string
+		want     nanobottypes.Dialect
+	}{
+		{provider: system.AnthropicModelProvider, want: nanobottypes.DialectAnthropicMessages},
+		{provider: system.OpenAIModelProvider, want: nanobottypes.DialectOpenAIResponses},
+		{provider: "other"},
+	} {
+		t.Run(tt.provider, func(t *testing.T) {
+			_, got, err := (apiKeyLLMProviderBackend{providerName: tt.provider}).upstreamURL(nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("dialect = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGenericResponsesBackendUpstreamURL(t *testing.T) {
 	backend := genericResponsesProviderBackend{}
 


### PR DESCRIPTION
Addresses #7188 

Adds `gRi` to list of Claude Code clients for this initial request. Then, improves the SessionID extraction to be dialect-dependent instead of provider-dependent. Also check claude code session ID header.