### PR TITLE
fix: alway prompt configuration for composite & composite/remote server details route fix

### DIFF
--- a/ui/user/src/hooks.ts
+++ b/ui/user/src/hooks.ts
@@ -1,6 +1,7 @@
 import type { Reroute } from '@sveltejs/kit';
 
 const ADMIN_MCP_SERVERS_PREFIX = '/admin/mcp-catalog';
+const ADMIN_MCP_DEPLOYMENTS_PREFIX = '/admin/mcp-deployments';
 
 export const reroute: Reroute = ({ url }) => {
 	const { pathname } = url;
@@ -8,6 +9,10 @@ export const reroute: Reroute = ({ url }) => {
 
 	if (pathname.startsWith(`${ADMIN_DEVICES_PREFIX}/`)) {
 		return pathname.replace(ADMIN_DEVICES_PREFIX, '/devices');
+	}
+
+	if (pathname.startsWith(`${ADMIN_MCP_DEPLOYMENTS_PREFIX}/`)) {
+		return pathname.replace(ADMIN_MCP_DEPLOYMENTS_PREFIX, '/mcp-catalog');
 	}
 
 	if (

--- a/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerCompositeInfo.svelte
@@ -8,7 +8,7 @@
 		type MCPCatalogServer,
 		type OrgUser
 	} from '$lib/services';
-	import { isDeprecatedMCPServer, supportsMCPBackendDetails } from '$lib/services/user/mcp';
+	import { isDeprecatedMCPServer } from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
 	import { openUrl } from '$lib/utils';
 	import McpDeprecatedNotice from '../mcp/McpDeprecatedNotice.svelte';
@@ -89,11 +89,13 @@
 				{#if componentExists}
 					<button
 						onclick={(e) => {
+							const prefix = page.url.pathname.startsWith('/admin/mcp-deployments')
+								? 'mcp-deployments'
+								: 'mcp-catalog';
 							const isCtrlClick = e.metaKey || e.ctrlKey;
-							const supportsDetails = supportsMCPBackendDetails(componentServer);
 							const url = componentServer.catalogEntryID
-								? `/admin/mcp-catalog/c/${componentServer.catalogEntryID}/instance/${catalogEntryServerId}${supportsDetails ? '/details' : ''}`
-								: `/admin/mcp-catalog/s/${componentServer.mcpServerID}${supportsDetails ? '/details' : ''}`;
+								? `/admin/${prefix}/c/${componentServer.catalogEntryID}/instance/${catalogEntryServerId}/details`
+								: `/admin/${prefix}/s/${componentServer.mcpServerID}/details`;
 
 							sessionStorage.setItem(
 								ADMIN_SESSION_STORAGE.LAST_VISITED_MCP_SERVER,

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -24,8 +24,7 @@
 		getSource,
 		isMultiUserCatalogEntry,
 		isDeprecatedMCPServer,
-		isMultiUserServer,
-		supportsMCPBackendDetails
+		isMultiUserServer
 	} from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
 	import { success } from '$lib/stores/success';
@@ -222,7 +221,6 @@
 	let previewToolsOverride = $state<MCPCatalogEntryServerManifest['toolPreview']>();
 
 	const tabs = $derived.by(() => {
-		const supportsDetails = supportsMCPBackendDetails(server ?? entry);
 		const availableTabs =
 			entry && !server
 				? [
@@ -231,9 +229,7 @@
 						(!isCatalogEntryDeployedMultiUserServer(entry) || allowMultiUserServerConfigurationEdit)
 							? [{ label: 'Configuration', view: 'configuration' }]
 							: []),
-						...(belongsToUser && supportsDetails
-							? [{ label: 'Server Details', view: 'server-instances' }]
-							: []),
+						...(belongsToUser ? [{ label: 'Server Details', view: 'server-instances' }] : []),
 						{ label: 'Tools', view: 'tools' },
 						// Basic users who just connected don't see Configuration.
 						// Catalog entry-deployed multi-user servers also hide it: the configuration is
@@ -256,9 +252,7 @@
 					]
 				: [
 						{ label: 'Overview', view: 'overview' },
-						...(belongsToUser && supportsDetails
-							? [{ label: 'Server Details', view: 'server-instances' }]
-							: []),
+						...(belongsToUser ? [{ label: 'Server Details', view: 'server-instances' }] : []),
 						{ label: 'Tools', view: 'tools' },
 						...(profile.current?.hasAdminAccess?.() && entry?.manifest?.runtime === 'remote'
 							? [{ label: 'Troubleshooting', view: 'troubleshooting' }]

--- a/ui/user/src/lib/components/admin/McpServerInstances.svelte
+++ b/ui/user/src/lib/components/admin/McpServerInstances.svelte
@@ -10,7 +10,7 @@
 	import { hasMissingSecretBindingConfig } from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
 	import DeploymentsView from '../mcp/DeploymentsView.svelte';
-	import McpServerK8sInfo from './McpServerK8sInfo.svelte';
+	import McpServerDetails from '../mcp/McpServerDetails.svelte';
 	import { CircleFadingArrowUp, Router } from '@lucide/svelte';
 
 	interface Props {
@@ -30,7 +30,6 @@
 		id,
 		entity = 'catalog',
 		entry,
-		catalogEntry,
 		users = [],
 		type,
 		configuredInstances = [],
@@ -40,10 +39,6 @@
 	}: Props = $props();
 
 	let usersMap = $derived(new Map(users.map((u) => [u.id, u])));
-	let detailsCatalogEntry = $derived(
-		catalogEntry ?? (entry && 'isCatalogEntry' in entry ? entry : undefined)
-	);
-	let detailsMcpServer = $derived(entry && !('isCatalogEntry' in entry) ? entry : undefined);
 	let readonly = $derived(profile.current.isAdminReadonly?.());
 
 	function isMissingKubernetesSecret(server: MCPCatalogServer) {
@@ -61,29 +56,26 @@
 	</div>
 {:else if entry && !('isCatalogEntry' in entry) && id}
 	{#if entry && (type === 'multi' || configuredInstances.length > 0)}
-		<div class="flex flex-col gap-6">
-			<McpServerK8sInfo
-				{id}
-				{entity}
-				mcpServerId={entry.id}
-				name={'manifest' in entry ? entry.manifest.name || '' : ''}
-				catalogEntry={detailsCatalogEntry}
-				mcpServer={detailsMcpServer}
-				connectedUsers={configuredInstances.map((instance) => {
-					const user = usersMap.get(instance.userID)!;
-					return {
-						...user,
-						mcpInstanceId: instance.id,
-						mcpInstanceConfigured: instance.configured
-					};
-				})}
-				title="Details"
-				classes={{
+		<McpServerDetails
+			{entity}
+			entityId={id}
+			server={entry}
+			connectedUsers={configuredInstances.map((instance) => {
+				const user = usersMap.get(instance.userID)!;
+				return {
+					...user,
+					mcpInstanceId: instance.id,
+					mcpInstanceConfigured: instance.configured
+				};
+			})}
+			k8sOverrides={{
+				title: 'Details',
+				classes: {
 					title: 'text-lg font-semibold'
-				}}
-				{readonly}
-			/>
-		</div>
+				}
+			}}
+			{readonly}
+		/>
 	{:else}
 		{@render emptyInstancesContent()}
 	{/if}
@@ -126,6 +118,6 @@
 	<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
 		<Router class="text-muted-content size-24 opacity-50" />
 		<h4 class="text-muted-content text-lg font-semibold">No server details</h4>
-		<p class="text-muted-content text-sm font-light">No details available yet for this server.</p>
+		<p class="text-muted-content text-sm font-light">No details available yet for this entry.</p>
 	</div>
 {/snippet}

--- a/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
@@ -1,24 +1,19 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
-	import { page } from '$app/state';
 	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
 		UserService,
-		Group,
 		type K8sServerDetail,
 		type MCPCatalogEntry,
 		type MCPCatalogServer,
 		type MCPSecretBinding,
-		type OrgUser,
 		type ServerK8sSettings
 	} from '$lib/services';
 	import { EventStreamService } from '$lib/services/admin/eventstream.svelte';
 	import { supportsMCPBackendDetails } from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores';
 	import { formatTimeAgo } from '$lib/time';
-	import { isOwnSingleUserServer } from '$lib/utils';
 	import Confirm from '../Confirm.svelte';
 	import SensitiveInput from '../SensitiveInput.svelte';
 	import Table from '../table/Table.svelte';
@@ -30,10 +25,9 @@
 	interface Props {
 		id?: string;
 		entity?: 'workspace' | 'catalog' | 'agent' | 'webhook-validation';
-		mcpServerId: string;
 		name: string;
+		mcpServerId?: string;
 		mcpServerInstanceId?: string;
-		connectedUsers: (OrgUser & { mcpInstanceId?: string; mcpInstanceConfigured?: boolean })[];
 		title?: string;
 		classes?: {
 			title?: string;
@@ -47,15 +41,13 @@
 
 	const {
 		id: entityId,
-		mcpServerId,
+		mcpServerId: overrideMcpServerId,
 		mcpServerInstanceId,
 		name,
-		connectedUsers,
 		title,
 		classes,
 		catalogEntry,
 		mcpServer,
-		compositeParentName,
 		entity = 'catalog',
 		readonly,
 		hideTitle
@@ -72,10 +64,11 @@
 	let refreshingLogs = $state(false);
 	let showUpdateK8sSettingsConfirm = $state(false);
 	let updatingK8sSettings = $state(false);
-	let isAdminUrl = $derived(page.url.pathname.includes('/admin'));
 	let supportsDetails = $derived(supportsMCPBackendDetails(mcpServer ?? catalogEntry));
+	let mcpServerId = $derived(overrideMcpServerId ?? mcpServer?.id ?? mcpServerInstanceId);
 
 	let logsUrl = $derived.by(() => {
+		if (!mcpServerId) return null;
 		if (entity === 'workspace') {
 			return catalogEntry?.id
 				? `/api/workspaces/${entityId}/entries/${catalogEntry.id}/servers/${mcpServerId}/logs`
@@ -101,7 +94,7 @@
 	}
 
 	function getK8sInfo() {
-		if (!hasAdminAccess || !supportsDetails)
+		if (!hasAdminAccess || !supportsDetails || !mcpServerId)
 			return Promise.resolve<K8sServerDetail | undefined>(undefined);
 		return entity === 'workspace' && entityId
 			? catalogEntry?.id
@@ -120,7 +113,7 @@
 	}
 
 	function getK8sSettingsStatus() {
-		if (!hasAdminAccess || !supportsDetails || entity === 'webhook-validation')
+		if (!hasAdminAccess || !supportsDetails || entity === 'webhook-validation' || !mcpServerId)
 			return Promise.resolve<ServerK8sSettings | undefined>(undefined);
 		return entity === 'workspace' && entityId
 			? catalogEntry?.id
@@ -145,6 +138,7 @@
 	}
 
 	onMount(() => {
+		if (!mcpServerId) return;
 		// Only load sensitive server values and k8s info if the user has admin access
 		revealServerValues =
 			supportsDetails && profile.current.isAdmin?.()
@@ -193,7 +187,7 @@
 	});
 
 	async function handleRestart() {
-		if (!supportsRestart) return;
+		if (!supportsRestart || !mcpServerId) return;
 
 		restarting = true;
 		try {
@@ -288,6 +282,7 @@
 	}
 
 	async function handleRedeployWithK8sSettings() {
+		if (!mcpServerId) return;
 		updatingK8sSettings = true;
 		try {
 			await (entity === 'workspace' && entityId
@@ -442,31 +437,6 @@
 			}
 		}
 		return results;
-	}
-
-	function getAuditLogUrl(d: (typeof connectedUsers)[number]) {
-		const id = mcpServerId || mcpServerInstanceId;
-
-		// can agents have audit logs?
-		if (compositeParentName || entity === 'agent') return null;
-
-		if (isAdminUrl) {
-			if (!hasAdminAccess) return null;
-			return entity === 'workspace'
-				? catalogEntry?.id
-					? `/admin/mcp-catalog/w/${entityId}/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
-					: `/admin/mcp-catalog/w/${entityId}/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`
-				: catalogEntry?.id
-					? `/admin/mcp-catalog/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
-					: `/admin/mcp-catalog/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`;
-		}
-
-		// Basic users can access audit logs for their own single-user servers
-		let isOwnServer = mcpServer && isOwnSingleUserServer(mcpServer, profile.current?.id);
-		if (!isOwnServer && !profile.current?.groups.includes(Group.POWERUSER)) return null;
-		return catalogEntry?.id
-			? `/mcp-catalog/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
-			: `/mcp-catalog/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`;
 	}
 </script>
 
@@ -680,34 +650,6 @@
 	onRefresh={handleRefreshLogs}
 	onClear={() => (messages = [])}
 />
-
-{#if hasAdminAccess && entity !== 'webhook-validation' && connectedUsers.length > 0}
-	<div>
-		<h2 class="mb-2 text-lg font-semibold">Connected Users</h2>
-		<Table
-			data={connectedUsers ?? []}
-			fields={['name', 'updateStatus']}
-			headers={[{ title: 'Config Status', property: 'updateStatus' }]}
-		>
-			{#snippet onRenderColumn(property, d)}
-				{#if property === 'name'}
-					{d.email || d.username || 'Unknown'}
-				{:else if property === 'updateStatus'}
-					{d.mcpInstanceConfigured === false ? 'Not Configured' : 'Up to date'}
-				{:else}
-					{d[property as keyof typeof d]}
-				{/if}
-			{/snippet}
-
-			{#snippet actions(d)}
-				{@const auditLogsUrl = getAuditLogUrl(d)}
-				{#if auditLogsUrl}
-					<a href={resolve(auditLogsUrl as `/${string}`)} class="btn btn-link"> View Audit Logs </a>
-				{/if}
-			{/snippet}
-		</Table>
-	</div>
-{/if}
 
 {#snippet detailRow(label: string, value: string, id: string)}
 	<div

--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -396,6 +396,9 @@
 	class={isCompositeForm(form) ? 'bg-base-200 dark:bg-base-100' : ''}
 	disableClickOutside={loading}
 	hideClose={loading}
+	classes={{
+		header: 'mb-0'
+	}}
 >
 	{#snippet titleContent()}
 		<div class="flex items-center gap-2">
@@ -443,7 +446,7 @@
 				<McpDeprecatedNotice {deprecated} variant="notification" />
 
 				{#if showAlias}
-					<div class="flex flex-col gap-1">
+					<div class={twMerge('flex flex-col gap-1', isCompositeForm(form) && 'paper p-2')}>
 						<span class="flex items-center gap-2">
 							<label for="name"> Server Alias </label>
 							<span class="text-muted-content">(optional)</span>

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -68,6 +68,7 @@
 		onlyMyServers?: boolean;
 		servers?: MCPCatalogServer[];
 		skipLoadOnMount?: boolean;
+		serverPrefixPath?: string;
 	}
 
 	let {
@@ -86,7 +87,8 @@
 		noDataContent,
 		onlyMyServers,
 		servers: initialServers,
-		skipLoadOnMount
+		skipLoadOnMount,
+		serverPrefixPath
 	}: Props = $props();
 
 	const doesSupportK8sUpdates = $derived(version.current.engine === 'kubernetes');
@@ -558,6 +560,10 @@
 		// Global multi-user server
 		return `/admin/mcp-catalog/s/${d.id}`;
 	}
+
+	function isRestartableServer(d: MCPCatalogServer) {
+		return d.manifest.runtime !== 'remote' && d.manifest.runtime !== 'composite';
+	}
 </script>
 
 <div class="flex flex-col gap-0.5">
@@ -608,7 +614,7 @@
 				onClickRow={(d, isCtrlClick) => {
 					setLastVisitedMcpServer(d);
 
-					const url = getServerUrl(d);
+					const url = getServerUrl(d, serverPrefixPath);
 					openUrl(url, isCtrlClick);
 				}}
 				{onFilter}
@@ -815,7 +821,7 @@
 									</button>
 								{/if}
 
-								{#if d.isMyServer || (hasAdminAccess && !readonly)}
+								{#if isRestartableServer(d) && (d.isMyServer || (hasAdminAccess && !readonly))}
 									<button
 										class="menu-button"
 										disabled={restarting}

--- a/ui/user/src/lib/components/mcp/McpServerDetails.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerDetails.svelte
@@ -1,49 +1,146 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
 	import McpServerCompositeInfo from '$lib/components/admin/McpServerCompositeInfo.svelte';
 	import McpServerK8sInfo from '$lib/components/admin/McpServerK8sInfo.svelte';
 	import OAuthMetadataDebug from '$lib/components/mcp/OAuthMetadataDebug.svelte';
 	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
-	import type { MCPCatalogEntry, MCPCatalogServer } from '$lib/services';
+	import { Group, type MCPCatalogEntry, type MCPCatalogServer, type OrgUser } from '$lib/services';
 	import { getMCPDisplayName, supportsMCPBackendDetails } from '$lib/services/user/mcp';
+	import { profile } from '$lib/stores';
+	import { isOwnSingleUserServer } from '$lib/utils';
+	import Table from '../table/Table.svelte';
 	import { Info } from '@lucide/svelte';
 
 	interface Props {
 		catalogEntry?: MCPCatalogEntry;
-		server: MCPCatalogServer;
+		entity?: 'workspace' | 'catalog' | 'agent' | 'webhook-validation';
+		entityId?: string;
+		server?: MCPCatalogServer;
+		serverId?: string;
+		connectedUsers?: (OrgUser & { mcpInstanceId?: string; mcpInstanceConfigured?: boolean })[];
+		compositeParentName?: string;
+		k8sOverrides?: {
+			title?: string;
+			classes?: {
+				title?: string;
+			};
+		};
+		readonly?: boolean;
 	}
 
-	let { catalogEntry, server }: Props = $props();
-	let title = $derived(getMCPDisplayName(server, catalogEntry?.manifest.name));
+	let {
+		catalogEntry,
+		entity: overrideEntity,
+		entityId: overrideEntityId,
+		server,
+		serverId,
+		connectedUsers,
+		compositeParentName,
+		k8sOverrides,
+		readonly
+	}: Props = $props();
+	let title = $derived(
+		k8sOverrides?.title ?? getMCPDisplayName(server, catalogEntry?.manifest.name)
+	);
 	let supportsDetails = $derived(supportsMCPBackendDetails(server));
+	let hasAdminAccess = $derived(profile.current.hasAdminAccess?.());
+	let isAdminUrl = $derived(page.url.pathname.includes('/admin'));
+	let entity = $derived(
+		overrideEntity ?? (server && server?.powerUserWorkspaceID ? 'workspace' : 'catalog')
+	);
+	let entityId = $derived(
+		overrideEntityId ??
+			server?.powerUserWorkspaceID ??
+			server?.mcpCatalogID ??
+			catalogEntry?.id ??
+			DEFAULT_MCP_CATALOG_ID
+	);
+	let mcpServerId = $derived(serverId ?? server?.id);
+
+	function getAuditLogUrl(d: OrgUser) {
+		const id = serverId ?? server?.id;
+
+		if (!id) return null;
+
+		if (compositeParentName || entity === 'agent') return null;
+
+		if (isAdminUrl) {
+			if (!hasAdminAccess) return null;
+			return entity === 'workspace'
+				? catalogEntry?.id
+					? `/admin/mcp-catalog/w/${entityId}/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
+					: `/admin/mcp-catalog/w/${entityId}/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`
+				: catalogEntry?.id
+					? `/admin/mcp-catalog/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
+					: `/admin/mcp-catalog/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`;
+		}
+
+		// Basic users can access audit logs for their own single-user servers
+		let isOwnServer = server && isOwnSingleUserServer(server, profile.current?.id);
+		if (!isOwnServer && !profile.current?.groups.includes(Group.POWERUSER)) return null;
+		return catalogEntry?.id
+			? `/mcp-catalog/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
+			: `/mcp-catalog/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`;
+	}
 </script>
 
-{#if server}
+{#if server || mcpServerId}
 	<div class="flex flex-col gap-6">
 		{#if catalogEntry?.manifest.runtime === 'composite'}
 			<McpServerCompositeInfo
-				mcpServerId={server.id}
+				mcpServerId={server?.id}
 				name={title}
 				entity="catalog"
 				entityId={DEFAULT_MCP_CATALOG_ID}
 				{catalogEntry}
 				connectedUsers={[]}
 			/>
-		{:else if supportsDetails}
+		{:else if supportsDetails && mcpServerId}
 			<McpServerK8sInfo
-				mcpServerId={server.id}
+				{mcpServerId}
 				name={title}
-				connectedUsers={[]}
-				readonly
+				{readonly}
 				{catalogEntry}
 				mcpServer={server}
 				compositeParentName={server?.compositeName}
 				hideTitle
-				entity={server.powerUserWorkspaceID ? 'workspace' : 'catalog'}
-				id={server.powerUserWorkspaceID || server.mcpCatalogID || DEFAULT_MCP_CATALOG_ID}
+				{entity}
+				id={entityId}
+				{...k8sOverrides}
 			/>
-			{#if server?.manifest.runtime === 'remote'}
-				<OAuthMetadataDebug metadata={server.oauthMetadata} />
-			{/if}
+		{/if}
+		{#if hasAdminAccess && entity !== 'webhook-validation' && connectedUsers && connectedUsers.length > 0}
+			<div>
+				<h2 class="mb-2 text-lg font-semibold">Connected Users</h2>
+				<Table
+					data={connectedUsers ?? []}
+					fields={['name', 'updateStatus']}
+					headers={[{ title: 'Config Status', property: 'updateStatus' }]}
+				>
+					{#snippet onRenderColumn(property, d)}
+						{#if property === 'name'}
+							{d.email || d.username || 'Unknown'}
+						{:else if property === 'updateStatus'}
+							{d.mcpInstanceConfigured === false ? 'Not Configured' : 'Up to date'}
+						{:else}
+							{d[property as keyof typeof d]}
+						{/if}
+					{/snippet}
+
+					{#snippet actions(d)}
+						{@const auditLogsUrl = getAuditLogUrl(d)}
+						{#if auditLogsUrl}
+							<a href={resolve(auditLogsUrl as `/${string}`)} class="btn btn-link">
+								View Audit Logs
+							</a>
+						{/if}
+					{/snippet}
+				</Table>
+			</div>
+		{/if}
+		{#if server?.manifest.runtime === 'remote'}
+			<OAuthMetadataDebug metadata={server.oauthMetadata} />
 		{/if}
 	</div>
 {:else}

--- a/ui/user/src/lib/components/mcp/McpServerDetails.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerDetails.svelte
@@ -66,14 +66,18 @@
 		if (compositeParentName || entity === 'agent') return null;
 
 		if (isAdminUrl) {
+			const adminPrefix = page.url.pathname.startsWith('/admin/mcp-deployments')
+				? '/admin/mcp-deployments'
+				: '/admin/mcp-catalog';
+
 			if (!hasAdminAccess) return null;
 			return entity === 'workspace'
 				? catalogEntry?.id
-					? `/admin/mcp-catalog/w/${entityId}/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
-					: `/admin/mcp-catalog/w/${entityId}/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`
+					? `${adminPrefix}/w/${entityId}/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
+					: `${adminPrefix}/w/${entityId}/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`
 				: catalogEntry?.id
-					? `/admin/mcp-catalog/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
-					: `/admin/mcp-catalog/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`;
+					? `${adminPrefix}/c/${catalogEntry.id}?view=audit-logs&user_id=${d.id}`
+					: `${adminPrefix}/s/${encodeURIComponent(id ?? '')}?view=audit-logs&user_id=${d.id}`;
 		}
 
 		// Basic users can access audit logs for their own single-user servers
@@ -89,7 +93,7 @@
 	<div class="flex flex-col gap-6">
 		{#if catalogEntry?.manifest.runtime === 'composite'}
 			<McpServerCompositeInfo
-				mcpServerId={server?.id}
+				{mcpServerId}
 				name={title}
 				entity="catalog"
 				entityId={DEFAULT_MCP_CATALOG_ID}

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -598,7 +598,9 @@ export async function convertCompositeInfoToLaunchFormData(
 	return { componentConfigs } as CompositeLaunchFormData;
 }
 
-export function getServerUrl(d: MCPCatalogServer) {
+export function getServerUrl(d: MCPCatalogServer, prefixPath?: string) {
+	const prefix = prefixPath ?? '/mcp-catalog';
+	const adminPrefix = `/admin${prefix}`;
 	const belongsToWorkspace = d.powerUserWorkspaceID ? true : false;
 	// Route by the server's actual user type, not by the presence of a catalog
 	// entry. Multi-user servers deployed from a catalog entry carry a
@@ -607,41 +609,28 @@ export function getServerUrl(d: MCPCatalogServer) {
 	// The single-user instance page fetches via /mcp-catalog/{id}, which only
 	// resolves servers that are not scoped to a catalog or workspace.
 	const isMulti = isMultiUserServer(d);
-	const supportsDetails = supportsMCPBackendDetails(d);
-	const nonDetailsUrl = isMulti
-		? `/mcp-catalog/s/${d.id}`
-		: d.catalogEntryID
-			? `/mcp-catalog/c/${d.catalogEntryID}/instance/${d.id}`
-			: `/mcp-catalog/s/${d.id}`;
-
 	let url: string;
 	if (profile.current.hasAdminAccess?.()) {
-		if (!supportsDetails) {
-			url = belongsToWorkspace
-				? `/admin${nonDetailsUrl}?wid=${encodeURIComponent(d.powerUserWorkspaceID!)}`
-				: `/admin${nonDetailsUrl}`;
-		} else if (isMulti && d.catalogEntryID) {
+		if (isMulti && d.catalogEntryID) {
 			url =
 				belongsToWorkspace && d.powerUserWorkspaceID
-					? `/admin/mcp-catalog/s/${d.id}/details?wid=${encodeURIComponent(d.powerUserWorkspaceID)}`
-					: `/admin/mcp-catalog/s/${d.id}/details`;
+					? `${adminPrefix}/s/${d.id}/details?wid=${encodeURIComponent(d.powerUserWorkspaceID)}`
+					: `${adminPrefix}/s/${d.id}/details`;
 		} else if (isMulti) {
 			url =
 				belongsToWorkspace && d.powerUserWorkspaceID
-					? `/admin/mcp-catalog/s/${d.id}?wid=${encodeURIComponent(d.powerUserWorkspaceID)}`
-					: `/admin/mcp-catalog/s/${d.id}`;
+					? `${adminPrefix}/s/${d.id}?wid=${encodeURIComponent(d.powerUserWorkspaceID)}`
+					: `${adminPrefix}/s/${d.id}`;
 		} else {
 			url =
 				belongsToWorkspace && d.powerUserWorkspaceID
-					? `/admin/mcp-catalog/c/${d.catalogEntryID}/instance/${d.id}/details?wid=${encodeURIComponent(d.powerUserWorkspaceID)}`
-					: `/admin/mcp-catalog/c/${d.catalogEntryID}/instance/${d.id}/details`;
+					? `${adminPrefix}/c/${d.catalogEntryID}/instance/${d.id}/details?wid=${encodeURIComponent(d.powerUserWorkspaceID)}`
+					: `${adminPrefix}/c/${d.catalogEntryID}/instance/${d.id}/details`;
 		}
 	} else {
-		url = !supportsDetails
-			? nonDetailsUrl
-			: isMulti
-				? `/mcp-catalog/s/${d.id}/details`
-				: `/mcp-catalog/c/${d.catalogEntryID}/instance/${d.id}/details`;
+		url = isMulti
+			? `${prefix}/s/${d.id}/details`
+			: `${prefix}/c/${d.catalogEntryID}/instance/${d.id}/details`;
 	}
 	return url;
 }

--- a/ui/user/src/routes/admin/agents/p/[pid]/s/[id]/details/+page.svelte
+++ b/ui/user/src/routes/admin/agents/p/[pid]/s/[id]/details/+page.svelte
@@ -2,7 +2,7 @@
 	import { tooltip } from '$lib/actions/tooltip.svelte.js';
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
-	import McpServerK8sInfo from '$lib/components/admin/McpServerK8sInfo.svelte';
+	import McpServerDetails from '$lib/components/mcp/McpServerDetails.svelte';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { NanobotService, UserService, type OrgUser } from '$lib/services';
@@ -70,14 +70,18 @@
 		{:else}
 			<div class="flex flex-col gap-6">
 				{#if mcpServer}
-					<McpServerK8sInfo
-						id={DEFAULT_MCP_CATALOG_ID}
+					<McpServerDetails
 						entity="agent"
-						mcpServerId={mcpServer.id}
-						name={mcpServer.manifest.name || ''}
-						{title}
-						readonly={profile.current.isAdminReadonly?.()}
+						entityId={DEFAULT_MCP_CATALOG_ID}
+						server={mcpServer}
 						connectedUsers={user ? [user] : []}
+						readonly={profile.current.isAdminReadonly?.()}
+						k8sOverrides={{
+							title: 'Details',
+							classes: {
+								title: 'text-lg font-semibold'
+							}
+						}}
 					/>
 				{/if}
 			</div>

--- a/ui/user/src/routes/admin/filters/FilterView.svelte
+++ b/ui/user/src/routes/admin/filters/FilterView.svelte
@@ -2,9 +2,9 @@
 	import Confirm from '$lib/components/Confirm.svelte';
 	import Layout from '$lib/components/Layout.svelte';
 	import FilterForm from '$lib/components/admin/FilterForm.svelte';
-	import McpServerK8sInfo from '$lib/components/admin/McpServerK8sInfo.svelte';
 	import AuditLogsPageContent from '$lib/components/admin/audit-logs/AuditLogsPageContent.svelte';
 	import UsageGraphs from '$lib/components/admin/usage/UsageGraphs.svelte';
+	import McpServerDetails from '$lib/components/mcp/McpServerDetails.svelte';
 	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import { VirtualPageViewport } from '$lib/components/ui/virtual-page';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
@@ -102,20 +102,19 @@
 					mcpSystemCatalogEntryId={entry?.id || filter.systemMCPServerCatalogEntryID}
 				/>
 			{:else if selected === 'server-details'}
-				<div class="flex flex-col gap-6">
-					<McpServerK8sInfo
-						id={filter.id}
-						entity="webhook-validation"
-						mcpServerId={filter.id}
-						name={filter.name || ''}
-						connectedUsers={[]}
-						title="Details"
-						classes={{
+				<McpServerDetails
+					entity="webhook-validation"
+					entityId={filter.id}
+					serverId={filter.id}
+					readonly={profile.current.isAdminReadonly?.()}
+					connectedUsers={[]}
+					k8sOverrides={{
+						title: 'Details',
+						classes: {
 							title: 'text-lg font-semibold'
-						}}
-						readonly={profile.current.isAdminReadonly?.()}
-					/>
-				</div>
+						}
+					}}
+				/>
 			{:else if selected === 'audit-logs'}
 				<div class="mt-4 flex flex-1 flex-col gap-8 pb-8">
 					<AuditLogsPageContent mcpId={mcpServerId} mcpServerDisplayName={filter.name}>

--- a/ui/user/src/routes/admin/mcp-deployments/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-deployments/+page.svelte
@@ -91,6 +91,7 @@
 				onClearAllFilters={handleClearAllFilters}
 				onSort={setSortUrlParams}
 				{initSort}
+				serverPrefixPath="/mcp-deployments"
 			>
 				{#snippet noDataContent()}{@render displayNoData()}{/snippet}
 			</DeploymentsView>

--- a/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
+++ b/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
@@ -33,8 +33,13 @@
 	let configError = $state('');
 	let loadingConfig = $state(false);
 	let savingConfig = $state(false);
+	let hasConfiguredComposite = $state(false);
 
 	const consent = $derived(currentConsent);
+	const isCompositeMCPServer = $derived(consent.mcpServer?.manifest.runtime === 'composite');
+	const requiresMCPConfiguration = $derived(
+		consent.mcpConfigRequired || (isCompositeMCPServer && !hasConfiguredComposite)
+	);
 	const scopes = $derived(consent.scope?.split(' ').filter(Boolean) ?? []);
 	const showMCPAuthNotice = $derived(consent.mcpAuthRequired || consent.userHasSecondLevelOAuthed);
 	const deprecated = $derived(isDeprecatedMCPServer(consent.mcpServer));
@@ -135,7 +140,7 @@
 	});
 
 	onMount(() => {
-		if (currentConsent.mcpConfigRequired) {
+		if (requiresMCPConfiguration) {
 			void loadMCPConfiguration(currentConsent);
 		}
 	});
@@ -231,6 +236,7 @@
 				if (isCompositeForm(configureForm)) {
 					const payload = convertCompositeLaunchFormDataToPayload(configureForm);
 					await UserService.configureCompositeMcpServer(consent.mcpServer.id, payload);
+					hasConfiguredComposite = true;
 				} else {
 					const payload = convertEnvHeadersToRecord(configureForm.envs, configureForm.headers);
 					if (configureForm.hostname && configureForm.url) {
@@ -286,20 +292,25 @@
 	<main class="paper w-full max-w-lg overflow-hidden p-0">
 		<BetaLogo class="self-center mt-6" />
 		<h1 class="text-xl font-semibold text-center px-4">
-			{consent.mcpConfigRequired
+			{requiresMCPConfiguration
 				? `Configure ${consent.mcpServerName || 'MCP server'}`
 				: `Authorize ${consent.clientName}`}
 		</h1>
 
-		{#if consent.mcpConfigRequired}
+		{#if requiresMCPConfiguration}
 			<section class="flex flex-col gap-5 p-4 py-0">
 				<McpDeprecatedNotice {deprecated} variant="notification" />
 
 				<div class="notification-info flex items-center gap-3 p-3">
 					<SettingsIcon class="size-5 shrink-0" />
 					<p class="min-w-0 text-sm">
-						<b class="font-semibold">{consent.mcpServerName || 'This MCP server'}</b> needs required configuration
-						before Obot can finish authorizing this connection.
+						{#if isCompositeMCPServer && !hasConfiguredComposite}
+							Configure <b class="font-semibold">{consent.mcpServerName || 'this MCP server'}</b> to choose
+							which composite servers to use before continuing.
+						{:else}
+							<b class="font-semibold">{consent.mcpServerName || 'This MCP server'}</b> needs required
+							configuration before Obot can finish authorizing this connection.
+						{/if}
 					</p>
 				</div>
 
@@ -404,13 +415,13 @@
 		<footer
 			class={twMerge(
 				'border-base-300 bg-base-100 dark:bg-base-200 flex justify-end gap-3 border-t p-3 max-sm:flex-col-reverse',
-				consent.mcpConfigRequired && 'border-t-0'
+				requiresMCPConfiguration && 'border-t-0'
 			)}
 		>
 			<form method="POST" action={resolve(consent.cancelURL as `/${string}`)}>
 				<button class="btn btn-text w-full" type="submit" disabled={savingConfig}>Cancel</button>
 			</form>
-			{#if consent.mcpConfigRequired}
+			{#if requiresMCPConfiguration}
 				<button
 					class="btn btn-primary flex w-full items-center gap-2"
 					type="button"

--- a/ui/user/src/routes/mcp-catalog/c/[id]/instance/[ms_id]/details/+page.svelte
+++ b/ui/user/src/routes/mcp-catalog/c/[id]/instance/[ms_id]/details/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerCompositeInfo from '$lib/components/admin/McpServerCompositeInfo.svelte';
-	import McpServerK8sInfo from '$lib/components/admin/McpServerK8sInfo.svelte';
+	import McpServerDetails from '$lib/components/mcp/McpServerDetails.svelte';
 	import OAuthMetadataDebug from '$lib/components/mcp/OAuthMetadataDebug.svelte';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { UserService, type MCPCatalogServer, type OrgUser } from '$lib/services/index.js';
@@ -56,18 +56,20 @@
 					{catalogEntry}
 				/>
 			{:else if supportsDetails}
-				<McpServerK8sInfo
-					{mcpServerId}
-					name={title}
+				<McpServerDetails
+					serverId={mcpServerId}
 					{connectedUsers}
 					readonly={profile.current.isAdminReadonly?.()}
 					{catalogEntry}
-					{mcpServer}
+					server={mcpServer}
 					{compositeParentName}
+					k8sOverrides={{
+						title
+					}}
 				/>
-				{#if mcpServer?.manifest.runtime === 'remote'}
-					<OAuthMetadataDebug metadata={mcpServer.oauthMetadata} />
-				{/if}
+			{/if}
+			{#if mcpServer?.manifest.runtime === 'remote'}
+				<OAuthMetadataDebug metadata={mcpServer.oauthMetadata} />
 			{/if}
 		{:else}
 			<div class="notification-info p-3 text-sm font-light">

--- a/ui/user/src/routes/mcp-catalog/c/[id]/instance/[ms_id]/details/+page.svelte
+++ b/ui/user/src/routes/mcp-catalog/c/[id]/instance/[ms_id]/details/+page.svelte
@@ -2,10 +2,9 @@
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerCompositeInfo from '$lib/components/admin/McpServerCompositeInfo.svelte';
 	import McpServerDetails from '$lib/components/mcp/McpServerDetails.svelte';
-	import OAuthMetadataDebug from '$lib/components/mcp/OAuthMetadataDebug.svelte';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { UserService, type MCPCatalogServer, type OrgUser } from '$lib/services/index.js';
-	import { getMCPDisplayName, supportsMCPBackendDetails } from '$lib/services/user/mcp.js';
+	import { getMCPDisplayName } from '$lib/services/user/mcp.js';
 	import { profile } from '$lib/stores/index.js';
 	import { Info } from '@lucide/svelte';
 	import { fly } from 'svelte/transition';
@@ -20,7 +19,6 @@
 	let compositeParentName = $state<string | undefined>();
 	let mcpServer = $state<MCPCatalogServer>();
 	let catalogEntryName = $derived(catalogEntry?.manifest?.name ?? 'Unknown');
-	let supportsDetails = $derived(supportsMCPBackendDetails(mcpServer ?? catalogEntry));
 
 	async function fetchUserInfo() {
 		mcpServer = await UserService.getSingleOrRemoteMcpServer(mcpServerId);
@@ -55,7 +53,7 @@
 					entityId={DEFAULT_MCP_CATALOG_ID}
 					{catalogEntry}
 				/>
-			{:else if supportsDetails}
+			{:else}
 				<McpServerDetails
 					serverId={mcpServerId}
 					{connectedUsers}
@@ -67,9 +65,6 @@
 						title
 					}}
 				/>
-			{/if}
-			{#if mcpServer?.manifest.runtime === 'remote'}
-				<OAuthMetadataDebug metadata={mcpServer.oauthMetadata} />
 			{/if}
 		{:else}
 			<div class="notification-info p-3 text-sm font-light">

--- a/ui/user/src/routes/mcp-catalog/s/[id]/details/+page.svelte
+++ b/ui/user/src/routes/mcp-catalog/s/[id]/details/+page.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
 	import Layout from '$lib/components/Layout.svelte';
 	import McpServerDetails from '$lib/components/mcp/McpServerDetails.svelte';
-	import OAuthMetadataDebug from '$lib/components/mcp/OAuthMetadataDebug.svelte';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { AdminService, UserService, type MCPServerInstance, type OrgUser } from '$lib/services';
-	import { supportsMCPBackendDetails } from '$lib/services/user/mcp';
 	import { profile } from '$lib/stores/index.js';
-	import { Info } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -16,7 +13,6 @@
 	let workspaceId = $derived(mcpServer?.powerUserWorkspaceID);
 	let serverScopeEntity = $derived(workspaceId ? ('workspace' as const) : ('catalog' as const));
 	let serverScopeID = $derived(workspaceId || mcpServer?.mcpCatalogID || DEFAULT_MCP_CATALOG_ID);
-	let supportsDetails = $derived(supportsMCPBackendDetails(mcpServer));
 	let loading = $state(false);
 	let users = $state<OrgUser[]>([]);
 	let instances = $state<MCPServerInstance[]>([]);
@@ -43,37 +39,25 @@
 		{:else}
 			<div class="flex flex-col gap-6">
 				{#if mcpServer}
-					{#if supportsDetails}
-						<McpServerDetails
-							entityId={serverScopeID}
-							entity={serverScopeEntity}
-							serverId={mcpServer.id}
-							connectedUsers={(instances ?? []).map((instance) => {
-								const user = usersMap.get(instance.userID)!;
-								return {
-									...user,
-									mcpInstanceId: instance.id,
-									mcpInstanceConfigured: instance.configured
-								};
-							})}
-							readonly={profile.current.isAdminReadonly?.()}
-							server={mcpServer}
-							compositeParentName={mcpServer.compositeName}
-							k8sOverrides={{
-								title: mcpServer.manifest.name
-							}}
-						/>
-					{:else}
-						<div class="notification-info p-3 text-sm font-light">
-							<div class="flex items-center gap-3">
-								<Info class="size-6" />
-								<p>Server details are not available for this MCP server runtime.</p>
-							</div>
-						</div>
-					{/if}
-					{#if mcpServer.manifest.runtime === 'remote'}
-						<OAuthMetadataDebug metadata={mcpServer.oauthMetadata} />
-					{/if}
+					<McpServerDetails
+						entityId={serverScopeID}
+						entity={serverScopeEntity}
+						serverId={mcpServer.id}
+						connectedUsers={(instances ?? []).map((instance) => {
+							const user = usersMap.get(instance.userID)!;
+							return {
+								...user,
+								mcpInstanceId: instance.id,
+								mcpInstanceConfigured: instance.configured
+							};
+						})}
+						readonly={profile.current.isAdminReadonly?.()}
+						server={mcpServer}
+						compositeParentName={mcpServer.compositeName}
+						k8sOverrides={{
+							title: mcpServer.manifest.name
+						}}
+					/>
 				{/if}
 			</div>
 		{/if}

--- a/ui/user/src/routes/mcp-catalog/s/[id]/details/+page.svelte
+++ b/ui/user/src/routes/mcp-catalog/s/[id]/details/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Layout from '$lib/components/Layout.svelte';
-	import McpServerK8sInfo from '$lib/components/admin/McpServerK8sInfo.svelte';
+	import McpServerDetails from '$lib/components/mcp/McpServerDetails.svelte';
 	import OAuthMetadataDebug from '$lib/components/mcp/OAuthMetadataDebug.svelte';
 	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
@@ -44,12 +44,10 @@
 			<div class="flex flex-col gap-6">
 				{#if mcpServer}
 					{#if supportsDetails}
-						<McpServerK8sInfo
-							id={serverScopeID}
+						<McpServerDetails
+							entityId={serverScopeID}
 							entity={serverScopeEntity}
-							mcpServerId={mcpServer.id}
-							{mcpServer}
-							name={mcpServer.manifest.name || ''}
+							serverId={mcpServer.id}
 							connectedUsers={(instances ?? []).map((instance) => {
 								const user = usersMap.get(instance.userID)!;
 								return {
@@ -58,8 +56,12 @@
 									mcpInstanceConfigured: instance.configured
 								};
 							})}
-							title={mcpServer.manifest.name}
 							readonly={profile.current.isAdminReadonly?.()}
+							server={mcpServer}
+							compositeParentName={mcpServer.compositeName}
+							k8sOverrides={{
+								title: mcpServer.manifest.name
+							}}
 						/>
 					{:else}
 						<div class="notification-info p-3 text-sm font-light">

--- a/ui/user/src/routes/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
+++ b/ui/user/src/routes/mcp-servers/c/[id]/instance/[ms_id]/+page.svelte
@@ -48,6 +48,7 @@
 				id={workspaceId}
 				entity="workspace"
 				connectOnly
+				limitViews={['overview', 'tools']}
 			/>
 		{/if}
 	</div>


### PR DESCRIPTION
This addresses the following:
- When user connects via AI client for a composite catalog entry, they are prompted each time to enable/disable children servers tied to the composite.
- Brings back routing to the server details page for composite/remote deployments. With this, MCPServerDetails becomes the main wrapper component and moves Connected Users out of the K8sInfo component (since it is not specific to k8s configuration) into it.
- Also fixes when viewing a deployment from MCP Deployment, user sees MCP Catalog highlighted on the left by utilizing hooks.ts
- Addresses small styling fix for CatalogConfigureForm where alias input is wrong color in composite configuration
- Addresses Restart Server option should not be available for remote/composite deployments

Addresses #7176 
Addresses #7181 
Addresses #7149 