### PR TITLE
fix: refresh LLM gateway models on navigation

### DIFF
--- a/ui/user/src/routes/llm-gateway/models/+page.svelte
+++ b/ui/user/src/routes/llm-gateway/models/+page.svelte
@@ -1,37 +1,46 @@
 <script lang="ts">
+	import { afterNavigate } from '$app/navigation';
 	import Layout from '$lib/components/Layout.svelte';
 	import LLMGatewayProviderSection from '$lib/components/llm-gateway/LLMGatewayProviderSection.svelte';
 	import { CommonModelProviderIds, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import type { Model } from '$lib/services';
 	import {
 		PROVIDER_CONNECTIONS,
 		type ProviderShortKey,
 		type RenderContext
 	} from '$lib/services/llm-gateway/types';
+	import accessibleModels from '$lib/stores/accessibleModels.svelte';
 	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 
 	let obotURL = $state('');
-	let { data } = $props();
+	let models = $derived(accessibleModels.current);
 
 	onMount(() => {
 		obotURL = window.location.origin;
 	});
 
+	afterNavigate(({ type }) => {
+		if (type !== 'enter') {
+			void accessibleModels.refresh();
+		}
+	});
+
 	let openaiModels = $derived(
-		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.OPENAI)
+		models.filter((m) => m.modelProvider === CommonModelProviderIds.OPENAI)
 	);
 	let anthropicModels = $derived(
-		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.ANTHROPIC)
+		models.filter((m) => m.modelProvider === CommonModelProviderIds.ANTHROPIC)
 	);
 	let genericResponsesModels = $derived(
-		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.GENERIC_RESPONSES)
+		models.filter((m) => m.modelProvider === CommonModelProviderIds.GENERIC_RESPONSES)
 	);
 	let genericResponsesDisplayModels = $derived(toCallableModelNames(genericResponsesModels));
 	let bedrockModels = $derived(
-		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.AMAZON_BEDROCK)
+		models.filter((m) => m.modelProvider === CommonModelProviderIds.AMAZON_BEDROCK)
 	);
 	let bedrockAPIKeyModels = $derived(
-		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.AMAZON_BEDROCK_API_KEY)
+		models.filter((m) => m.modelProvider === CommonModelProviderIds.AMAZON_BEDROCK_API_KEY)
 	);
 	let bedrockAnthropicModels = $derived(bedrockModels.filter(isBedrockAnthropicModel));
 	let bedrockOpenAIModels = $derived(bedrockModels.filter(isBedrockOpenAICompatibleModel));
@@ -46,10 +55,10 @@
 	);
 	let bedrockAPIKeyOpenAIDisplayModels = $derived(toCallableModelNames(bedrockAPIKeyOpenAIModels));
 	let azureModels = $derived(
-		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.AZURE)
+		models.filter((m) => m.modelProvider === CommonModelProviderIds.AZURE)
 	);
 	let azureEntraModels = $derived(
-		data.models.filter((m) => m.modelProvider === CommonModelProviderIds.AZURE_ENTRA)
+		models.filter((m) => m.modelProvider === CommonModelProviderIds.AZURE_ENTRA)
 	);
 	let azureAnthropicModels = $derived(azureModels.filter(isAnthropicDialect));
 	let azureOpenAIModels = $derived(azureModels.filter(isOpenAIDialect));
@@ -60,35 +69,35 @@
 	let azureEntraAnthropicDisplayModels = $derived(toCallableModelNames(azureEntraAnthropicModels));
 	let azureEntraOpenAIDisplayModels = $derived(toCallableModelNames(azureEntraOpenAIModels));
 
-	function modelID(model: (typeof data.models)[number]) {
+	function modelID(model: Model) {
 		return model.targetModel || model.name;
 	}
 
-	function isBedrockAnthropicModel(model: (typeof data.models)[number]) {
+	function isBedrockAnthropicModel(model: Model) {
 		return modelID(model).startsWith('anthropic.');
 	}
 
-	function isBedrockOpenAICompatibleModel(model: (typeof data.models)[number]) {
+	function isBedrockOpenAICompatibleModel(model: Model) {
 		const id = modelID(model);
 		return id.startsWith('openai.') || id.startsWith('google.');
 	}
 
-	function isAnthropicDialect(model: (typeof data.models)[number]) {
+	function isAnthropicDialect(model: Model) {
 		return model.dialect === 'AnthropicMessages';
 	}
 
-	function isOpenAIDialect(model: (typeof data.models)[number]) {
+	function isOpenAIDialect(model: Model) {
 		return model.dialect === 'OpenAIResponses';
 	}
 
-	function toCallableModelNames(models: typeof data.models): typeof data.models {
+	function toCallableModelNames(models: Model[]): Model[] {
 		return models.map((model) => ({
 			...model,
 			name: modelID(model)
 		}));
 	}
 
-	function buildCtx(shortKey: ProviderShortKey, models: typeof data.models): RenderContext {
+	function buildCtx(shortKey: ProviderShortKey, models: Model[]): RenderContext {
 		const provider = PROVIDER_CONNECTIONS[shortKey];
 		return {
 			provider,

--- a/ui/user/src/routes/llm-gateway/models/+page.ts
+++ b/ui/user/src/routes/llm-gateway/models/+page.ts
@@ -11,9 +11,9 @@ export const load: PageLoad = async ({ fetch, parent }) => {
 
 	try {
 		const response =
-			import.meta.env.SSR && initialModels
-				? initialModels
-				: await UserService.listModels({ fetch });
+			browser && accessibleModels.initialized && accessibleModels.current.length > 0
+				? accessibleModels.current
+				: (initialModels ?? (await UserService.listModels({ fetch })));
 
 		models = filterAccessibleModels(response ?? []);
 

--- a/ui/user/src/routes/llm-gateway/models/+page.ts
+++ b/ui/user/src/routes/llm-gateway/models/+page.ts
@@ -5,25 +5,15 @@ import accessibleModels, { filterAccessibleModels } from '$lib/stores/accessible
 import type { PageLoad } from './$types';
 import { redirect } from '@sveltejs/kit';
 
-// Distinguishes the first client run (SSR hydration) from later client-side navigations.
-let hasHydrated = false;
-
 export const load: PageLoad = async ({ fetch, parent }) => {
 	const { profile, models: initialModels } = await parent();
 	let models: Model[] = [];
 
 	try {
-		let response: Model[] | undefined;
-
-		if (import.meta.env.SSR && initialModels) {
-			response = initialModels;
-		} else if (!hasHydrated && initialModels) {
-			hasHydrated = true;
-			response = initialModels;
-		} else {
-			hasHydrated = true;
-			response = await UserService.listModels({ fetch });
-		}
+		const response =
+			import.meta.env.SSR && initialModels
+				? initialModels
+				: await UserService.listModels({ fetch });
 
 		models = filterAccessibleModels(response ?? []);
 


### PR DESCRIPTION
The root layout remains mounted while navigating between model provider configuration and the LLM Gateway. Its initial models can therefore be stale after configuring a provider.

Reuse the parent response only during SSR and fetch the current models for every browser-side page load, ensuring newly configured providers appear without a full refresh.