### PR TITLE
fix(composite): ensure components are deployed and contactable

### DIFF
--- a/pkg/mcp/action.go
+++ b/pkg/mcp/action.go
@@ -375,7 +375,7 @@ func (sm *SessionManager) serverConfigForAction(ctx context.Context, server v1.M
 			return ServerConfig{}, nil, fmt.Errorf("failed to list component servers instances: %w", err)
 		}
 
-		serverConfig, missingConfig, err = CompositeServerToServerConfig(server, componentServers.Items, componentInstances.Items, server.ValidConnectURLs(sm.baseURL), sm.baseURL, userID, scope, catalogName, mergedEnv, tokenExchangeCred.Secrets)
+		serverConfig, missingConfig, err = CompositeServerToServerConfig(server, componentServers.Items, componentInstances.Items, server.ValidConnectURLs(sm.baseURL), sm.httpListenPort, userID, scope, catalogName, mergedEnv, tokenExchangeCred.Secrets)
 		componentMissingConfig, componentErr := sm.compositeComponentsMissingConfig(ctx, userID, componentServers.Items, componentInstances.Items)
 		if componentErr != nil {
 			return ServerConfig{}, nil, componentErr

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -38,6 +38,7 @@ type dockerBackend struct {
 	client                      *client.Client
 	containerEnv                bool
 	network                     string
+	httpListenPort              int
 	hostBaseURL                 string
 	hostBaseURLWithPort         string
 	containerizedBaseImage      string
@@ -71,6 +72,7 @@ func newDockerBackend(ctx context.Context, authEnabled bool, exposedPort int, op
 		client:                 cli,
 		containerEnv:           containerEnv,
 		network:                network,
+		httpListenPort:         exposedPort,
 		hostBaseURL:            "http://" + host,
 		hostBaseURLWithPort:    "http://" + fmt.Sprintf("%s:%d", host, exposedPort),
 		containerizedBaseImage: opts.MCPBaseImage,
@@ -157,7 +159,7 @@ func (d *dockerBackend) remoteConfig(globalConfig RemoteMCPURLValidationConfig) 
 		// If Obot is not running in a container, then Obot communicates with the MCP containers via localhost.
 		globalConfig.AllowLocalhostMCP = true
 	}
-	return globalConfig, []string{strings.TrimPrefix(d.hostBaseURLWithPort, "http://")}
+	return globalConfig, []string{fmt.Sprintf("localhost:%d", d.httpListenPort), strings.TrimPrefix(d.hostBaseURLWithPort, "http://")}
 }
 
 func (d *dockerBackend) transformObotHostname(rawURL string) string {

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -53,6 +53,7 @@ type kubernetesBackend struct {
 	clientset         *kubernetes.Clientset
 	client            kclient.WithWatch
 	cachedClient      kclient.WithWatch
+	httpListenPort    int
 	baseImage         string
 	mcpNamespace      string
 	mcpClusterDomain  string
@@ -70,7 +71,7 @@ type kubernetesDeploymentCacheEntry struct {
 	podName string
 }
 
-func newKubernetesBackend(authEnabled bool, clientset *kubernetes.Clientset, client, cachedClient, obotClient kclient.WithWatch, opts Options, resourceMaximums ResourceMaximums) backend {
+func newKubernetesBackend(httpListenPort int, authEnabled bool, clientset *kubernetes.Clientset, client, cachedClient, obotClient kclient.WithWatch, opts Options, resourceMaximums ResourceMaximums) backend {
 	var serviceFQDN string
 	if opts.ServiceName != "" && opts.ServiceNamespace != "" {
 		serviceFQDN = fmt.Sprintf("%s.%s.svc.%s", opts.ServiceName, opts.ServiceNamespace, opts.MCPClusterDomain)
@@ -80,6 +81,7 @@ func newKubernetesBackend(authEnabled bool, clientset *kubernetes.Clientset, cli
 		clientset:        clientset,
 		client:           client,
 		cachedClient:     cachedClient,
+		httpListenPort:   httpListenPort,
 		baseImage:        opts.MCPBaseImage,
 		mcpNamespace:     opts.MCPNamespace,
 		mcpClusterDomain: opts.MCPClusterDomain,
@@ -136,8 +138,8 @@ func (k *kubernetesBackend) ensureServerDeployment(ctx context.Context, server S
 		server.Webhooks[i] = webhook
 	}
 
-	if server.Runtime == types.RuntimeRemote {
-		// Remove any existing deployment for remote servers
+	if server.Runtime == types.RuntimeRemote || server.Runtime == types.RuntimeComposite {
+		// Remove any existing deployment for remote and composite servers
 		return server, k.deployServerObjects(ctx, server, nil)
 	}
 
@@ -338,7 +340,10 @@ func (k *kubernetesBackend) streamServerLogs(ctx context.Context, id string) (io
 }
 
 func (k *kubernetesBackend) remoteConfig(globalConfig RemoteMCPURLValidationConfig) (RemoteMCPURLValidationConfig, []string) {
-	return globalConfig, []string{strings.TrimPrefix(k.serviceFQDN, "http://"), fmt.Sprintf("*.%s.svc.%s", k.mcpNamespace, k.mcpClusterDomain)}
+	return globalConfig, []string{
+		fmt.Sprintf("localhost:%d", k.httpListenPort),
+		strings.TrimPrefix(k.serviceFQDN, "http://"), fmt.Sprintf("*.%s.svc.%s", k.mcpNamespace, k.mcpClusterDomain),
+	}
 }
 
 // transformObotHostname replaces the host and port in a URL with the internal service FQDN.

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -299,7 +299,7 @@ func TestNewKubernetesBackend_ServiceFQDN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			backend := newKubernetesBackend(true, nil, nil, nil, nil, Options{ServiceName: tt.serviceName, ServiceNamespace: tt.serviceNamespace, MCPClusterDomain: tt.clusterDomain}, ResourceMaximums{})
+			backend := newKubernetesBackend(0, true, nil, nil, nil, nil, Options{ServiceName: tt.serviceName, ServiceNamespace: tt.serviceNamespace, MCPClusterDomain: tt.clusterDomain}, ResourceMaximums{})
 			k := backend.(*kubernetesBackend)
 			if k.serviceFQDN != tt.expectedFQDN {
 				t.Errorf("newKubernetesBackend() serviceFQDN = %v, want %v", k.serviceFQDN, tt.expectedFQDN)

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -85,6 +85,7 @@ type SessionManager struct {
 	tokenService              *persistent.TokenService
 	globalTokenStore          GlobalTokenStore
 	baseURL                   string
+	httpListenPort            int
 	remoteURLValidationConfig RemoteMCPURLValidationConfig
 	resourceMaximums          ResourceMaximums
 	storageClient             kclient.WithWatch
@@ -164,7 +165,7 @@ func NewSessionManager(ctx context.Context, authEnabled bool, globalTokenStore G
 			return nil, err
 		}
 
-		backend = newKubernetesBackend(authEnabled, clientset, client, cachedClient, obotStorageClient, opts, resourceMaximums)
+		backend = newKubernetesBackend(httpListenPort, authEnabled, clientset, client, cachedClient, obotStorageClient, opts, resourceMaximums)
 	default:
 		return nil, fmt.Errorf("unknown runtime backend: %s", opts.MCPRuntimeBackend)
 	}
@@ -176,6 +177,7 @@ func NewSessionManager(ctx context.Context, authEnabled bool, globalTokenStore G
 		backend:                   backend,
 		runtimeBackend:            opts.MCPRuntimeBackend,
 		baseURL:                   baseURL,
+		httpListenPort:            httpListenPort,
 		resourceMaximums:          resourceMaximums,
 		storageClient:             obotStorageClient,
 		gatewayClient:             gatewayClient,

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -265,13 +265,13 @@ func configureCompositeRuntime(serverConfig ServerConfig) (ServerConfig, []strin
 	return serverConfig, nil, nil
 }
 
-func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPServer, instances []v1.MCPServerInstance, audiences []string, serverURL, userID, scope, mcpCatalogName string, credEnv, tokenExchangeCredEnv map[string]string) (ServerConfig, []string, error) {
+func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPServer, instances []v1.MCPServerInstance, audiences []string, httpListenPort int, userID, scope, mcpCatalogName string, credEnv, tokenExchangeCredEnv map[string]string) (ServerConfig, []string, error) {
 	config, missing, err := ServerToServerConfig(mcpServer, audiences, userID, scope, mcpCatalogName, credEnv, tokenExchangeCredEnv)
 	if err != nil {
 		return config, missing, err
 	}
 
-	config.URL = system.MCPConnectCompositeURL(serverURL, config.MCPServerName)
+	config.URL = system.MCPConnectCompositeURL(config.MCPServerName, httpListenPort)
 
 	overrides := make(map[string]types.ComponentServer, len(mcpServer.Spec.Manifest.CompositeConfig.ComponentServers))
 	for _, component := range mcpServer.Spec.Manifest.CompositeConfig.ComponentServers {
@@ -308,7 +308,7 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 
 		config.Components = append(config.Components, ComponentServer{
 			Name:       name,
-			URL:        system.MCPConnectURL(serverURL, component.Name),
+			URL:        system.LocalMCPConnectURL(component.Name, httpListenPort),
 			Tools:      tools,
 			noTools:    len(override.ToolOverrides) > 0 && len(tools) == 0,
 			ToolPrefix: override.ToolPrefix,
@@ -335,7 +335,7 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 
 		config.Components = append(config.Components, ComponentServer{
 			Name:       instance.Name,
-			URL:        system.MCPConnectURL(serverURL, instance.Name),
+			URL:        system.LocalMCPConnectURL(instance.Name, httpListenPort),
 			Tools:      tools,
 			noTools:    len(override.ToolOverrides) > 0 && len(tools) == 0,
 			ToolPrefix: override.ToolPrefix,

--- a/pkg/mcp/types_test.go
+++ b/pkg/mcp/types_test.go
@@ -198,7 +198,7 @@ func TestCompositeServerToServerConfig_OmittedToolOverridesRemainNil(t *testing.
 	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"}}
 	component.Name = "search-server"
 
-	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), baseURL, "test-user-id", "test-scope", "test-catalog", nil, nil)
+	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), 8080, "test-user-id", "test-scope", "test-catalog", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestCompositeServerToServerConfig_TokenExchangeConfig(t *testing.T) {
 		nil,
 		nil,
 		mcpServer.ValidConnectURLs(baseURL),
-		baseURL,
+		8080,
 		"test-user-id",
 		"test-scope",
 		"test-catalog",
@@ -275,7 +275,7 @@ func TestCompositeServerToServerConfig_AllDisabledToolOverridesSetNoTools(t *tes
 	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"}}
 	component.Name = "search-server"
 
-	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), baseURL, "test-user-id", "test-scope", "test-catalog", nil, nil)
+	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), 8080, "test-user-id", "test-scope", "test-catalog", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestCompositeServerToServerConfig_ConnectCompositeURL(t *testing.T) {
 	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"}}
 	component.Name = "search-server"
 
-	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), baseURL, "test-user-id", "test-scope", "test-catalog", nil, nil)
+	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), 8080, "test-user-id", "test-scope", "test-catalog", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -319,8 +319,8 @@ func TestCompositeServerToServerConfig_ConnectCompositeURL(t *testing.T) {
 	if len(config.Components) != 1 {
 		t.Fatalf("expected one component, got %d", len(config.Components))
 	}
-	if config.URL != system.MCPConnectCompositeURL(baseURL, mcpServer.Name) {
-		t.Fatalf("expected URL %s, got %s", system.MCPConnectCompositeURL(baseURL, mcpServer.Name), config.URL)
+	if config.URL != system.MCPConnectCompositeURL(mcpServer.Name, 8080) {
+		t.Fatalf("expected URL %s, got %s", system.MCPConnectCompositeURL(mcpServer.Name, 8080), config.URL)
 	}
 }
 

--- a/pkg/system/mcp.go
+++ b/pkg/system/mcp.go
@@ -17,11 +17,23 @@ func MCPOAuthCredentialName(mcpServerName string) string {
 }
 
 func MCPConnectURL(serverURL, id string) string {
-	return fmt.Sprintf("%s/mcp-connect/%s", serverURL, id)
+	return mcpConnectURL(serverURL, "mcp-connect", id)
 }
 
-func MCPConnectCompositeURL(serverURL, id string) string {
-	return fmt.Sprintf("%s/mcp-connect-composite/%s", serverURL, id)
+func LocalMCPConnectURL(id string, httpListenPort int) string {
+	return MCPConnectURL(fmt.Sprintf("http://localhost:%d", httpListenPort), id)
+}
+
+func MCPConnectCompositeURL(id string, httpListenPort int) string {
+	return mcpConnectURL(fmt.Sprintf("http://localhost:%d", httpListenPort), "mcp-connect-composite", id)
+}
+
+func mcpConnectURL(serverURL, path, id string) string {
+	return fmt.Sprintf("%s/%s/%s",
+		strings.TrimRight(serverURL, "/"),
+		strings.Trim(path, "/"),
+		strings.TrimLeft(id, "/"),
+	)
 }
 
 func NanobotAgentConnectURL(serverURL, id string) string {

--- a/pkg/system/mcp_test.go
+++ b/pkg/system/mcp_test.go
@@ -1,0 +1,43 @@
+package system
+
+import "testing"
+
+func TestMCPConnectURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		serverURL string
+		path      string
+		id        string
+		want      string
+	}{
+		{
+			name:      "server URL without trailing slash",
+			serverURL: "https://obot.example.com",
+			path:      "/mcp-connect/",
+			id:        "server-id",
+			want:      "https://obot.example.com/mcp-connect/server-id",
+		},
+		{
+			name:      "server URL with trailing slash",
+			serverURL: "https://obot.example.com/",
+			path:      "/mcp-connect/",
+			id:        "server-id",
+			want:      "https://obot.example.com/mcp-connect/server-id",
+		},
+		{
+			name:      "extra separator slashes",
+			serverURL: "https://obot.example.com///",
+			path:      "//mcp-connect-composite//",
+			id:        "/server-id",
+			want:      "https://obot.example.com/mcp-connect-composite/server-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mcpConnectURL(tt.serverURL, tt.path, tt.id); got != tt.want {
+				t.Fatalf("mcpConnectURL(%q, %q, %q) = %q, want %q", tt.serverURL, tt.path, tt.id, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The component servers are connected to from Obot iteself, so we should connect to them via localhost and allow that specifically.

Issue: https://github.com/obot-platform/obot/issues/7161