### PR TITLE
fix: improve LLM audit error details

### DIFF
--- a/pkg/gateway/server/llmaudit.go
+++ b/pkg/gateway/server/llmaudit.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/google/uuid"
 	nanobottypes "github.com/obot-platform/nanobot/pkg/types"
+	apitypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api/server/requestinfo"
 	"github.com/obot-platform/obot/pkg/gateway/client"
 	gatewaycontext "github.com/obot-platform/obot/pkg/gateway/context"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/tidwall/gjson"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -120,6 +122,13 @@ func (r *llmAuditRecorder) recordResponse(resp *http.Response) {
 	r.log.ResponseHeaders = redactedHeaders(resp.Header)
 }
 
+func (r *llmAuditRecorder) recordResponseStatus(status int) {
+	if r == nil {
+		return
+	}
+	r.log.ResponseStatus = status
+}
+
 func (r *llmAuditRecorder) captureResponseChunk(p []byte) {
 	if r == nil || len(p) == 0 {
 		return
@@ -153,26 +162,44 @@ func (r *llmAuditRecorder) finish(c *client.Client, err error) {
 	}
 	r.once.Do(func() {
 		r.log.Duration = time.Since(r.log.CreatedAt).Milliseconds()
-		r.setOutcome(err)
+		r.setOutcomeAndResponseStatus(err)
 		c.LogLLMAuditEntry(r.log, r.responseStream.Bytes())
 	})
 }
 
-func (r *llmAuditRecorder) setOutcome(err error) {
+func (r *llmAuditRecorder) setOutcomeAndResponseStatus(err error) {
 	if r == nil {
 		return
 	}
 	r.log.Outcome = types.LLMAuditOutcomeSuccess
 	r.log.Error = ""
+
+	if r.log.ResponseStatus >= http.StatusBadRequest {
+		r.log.Outcome = types.LLMAuditOutcomeError
+	}
+
 	if err == nil {
 		return
 	}
 	r.log.Error = err.Error()
+	r.log.Outcome = types.LLMAuditOutcomeError
 	if errors.Is(err, context.Canceled) {
 		r.log.Outcome = types.LLMAuditOutcomeCanceled
-		return
 	}
-	r.log.Outcome = types.LLMAuditOutcomeError
+
+	if r.log.ResponseStatus == 0 {
+		if errHTTP := (*apitypes.ErrHTTP)(nil); errors.As(err, &errHTTP) {
+			r.log.ResponseStatus = errHTTP.Code
+		} else if errStatus := (*apierrors.StatusError)(nil); errors.As(err, &errStatus) {
+			r.log.ResponseStatus = int(errStatus.ErrStatus.Code)
+		} else {
+			r.log.ResponseStatus = http.StatusInternalServerError
+		}
+
+		if r.log.ResponseStatus >= http.StatusBadRequest && r.log.Outcome != types.LLMAuditOutcomeCanceled {
+			r.log.Outcome = types.LLMAuditOutcomeError
+		}
+	}
 }
 
 type llmAuditResponseBody struct {

--- a/pkg/gateway/server/llmaudit_test.go
+++ b/pkg/gateway/server/llmaudit_test.go
@@ -10,10 +10,13 @@ import (
 	"testing"
 
 	nanobottypes "github.com/obot-platform/nanobot/pkg/types"
+	apitypes "github.com/obot-platform/obot/apiclient/types"
 	gatewayllmaudit "github.com/obot-platform/obot/pkg/gateway/llmaudit"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/tidwall/gjson"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestRedactedHeaders(t *testing.T) {
@@ -95,36 +98,79 @@ func TestLLMAuditRecorderCapturesOriginalAndPolicyModifiedRequestBodies(t *testi
 
 func TestLLMAuditRecorderSetOutcome(t *testing.T) {
 	for _, tt := range []struct {
-		name    string
-		err     error
-		outcome string
-		wantErr string
+		name           string
+		err            error
+		responseStatus int
+		outcome        string
+		wantErr        string
+		wantStatus     int
 	}{
 		{
 			name:    "success even if request context is canceled after response",
 			outcome: types.LLMAuditOutcomeSuccess,
 		},
 		{
-			name:    "actual context cancellation error",
-			err:     context.Canceled,
-			outcome: types.LLMAuditOutcomeCanceled,
-			wantErr: context.Canceled.Error(),
+			name:           "HTTP error response",
+			responseStatus: http.StatusForbidden,
+			outcome:        types.LLMAuditOutcomeError,
+			wantStatus:     http.StatusForbidden,
 		},
 		{
-			name:    "actual proxy error",
-			err:     errors.New("proxy failed"),
-			outcome: types.LLMAuditOutcomeError,
-			wantErr: "proxy failed",
+			name:       "actual context cancellation error",
+			err:        context.Canceled,
+			outcome:    types.LLMAuditOutcomeCanceled,
+			wantErr:    context.Canceled.Error(),
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "actual proxy error",
+			err:        errors.New("proxy failed"),
+			outcome:    types.LLMAuditOutcomeError,
+			wantErr:    "proxy failed",
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "application HTTP error",
+			err:        apitypes.NewErrForbidden("model is not allowed"),
+			outcome:    types.LLMAuditOutcomeError,
+			wantErr:    "error code 403 (Forbidden): model is not allowed",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "wrapped application HTTP error",
+			err:        errors.Join(errors.New("request rejected"), apitypes.NewErrBadRequest("invalid model")),
+			outcome:    types.LLMAuditOutcomeError,
+			wantErr:    "request rejected\nerror code 400 (Bad Request): invalid model",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "Kubernetes status error",
+			err:        apierrors.NewNotFound(schema.GroupResource{Group: "obot.obot.ai", Resource: "models"}, "missing"),
+			outcome:    types.LLMAuditOutcomeError,
+			wantErr:    `models.obot.obot.ai "missing" not found`,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:           "recorded response status is preserved",
+			err:            errors.New("response body failed"),
+			responseStatus: http.StatusTooManyRequests,
+			outcome:        types.LLMAuditOutcomeError,
+			wantErr:        "response body failed",
+			wantStatus:     http.StatusTooManyRequests,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			recorder := &llmAuditRecorder{}
-			recorder.setOutcome(tt.err)
+			recorder.recordResponseStatus(tt.responseStatus)
+			recorder.setOutcomeAndResponseStatus(tt.err)
 			if recorder.log.Outcome != tt.outcome {
 				t.Fatalf("expected outcome %q, got %q", tt.outcome, recorder.log.Outcome)
 			}
 			if recorder.log.Error != tt.wantErr {
 				t.Fatalf("expected error %q, got %q", tt.wantErr, recorder.log.Error)
+			}
+			if recorder.log.ResponseStatus != tt.wantStatus {
+				t.Fatalf("expected response status %d, got %d", tt.wantStatus, recorder.log.ResponseStatus)
 			}
 		})
 	}

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -1078,6 +1078,8 @@ func (l *llmProviderProxy) proxy(req api.Context) (retErr error) {
 	prepared := &preparedLLMProxyRequest{body: body}
 
 	if targetModel := extractModelFromBody(body); targetModel != "" {
+		audit.setModel(modelProvider.Name, "", targetModel)
+
 		model, err := getModelFromReference(req.Context(), req.Storage, modelProvider.Namespace, targetModel)
 		if apierrors.IsNotFound(err) {
 			model, err = l.mapHelper.ResolveTargetModel(modelProvider.Name, targetModel)
@@ -1088,6 +1090,9 @@ func (l *llmProviderProxy) proxy(req api.Context) (retErr error) {
 		if model.Spec.Manifest.ModelProvider != modelProvider.Name {
 			return types2.NewErrBadRequest("requested model does not match configured provider %q", targetModel)
 		}
+		prepared.model = model.Spec.Manifest.TargetModel
+		audit.setModel(modelProvider.Name, model.Name, prepared.model)
+
 		hasAccess, err := l.mapHelper.UserHasAccessToModel(req.User, model.Name)
 		if err != nil {
 			return fmt.Errorf("failed to check user access to model %q: %w", model.Name, err)
@@ -1097,8 +1102,6 @@ func (l *llmProviderProxy) proxy(req api.Context) (retErr error) {
 		}
 
 		prepared.tokenUsageTracker = newTokenUsageTracker(*model)
-		prepared.model = model.Spec.Manifest.TargetModel
-		audit.setModel(modelProvider.Name, model.Name, prepared.model)
 
 		prepared.body, err = rewriteModelInBody(body, prepared.model)
 		if err != nil {
@@ -1176,6 +1179,7 @@ func (l *llmProviderProxy) proxy(req api.Context) (retErr error) {
 		Transport: transport,
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
 			proxyErr = err
+			audit.recordResponseStatus(http.StatusBadGateway)
 			audit.finish(req.GatewayClient, err)
 			log.Warnf("LLM provider proxy error: %v", err)
 			http.Error(w, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)

--- a/pkg/gateway/server/llmproxy_test.go
+++ b/pkg/gateway/server/llmproxy_test.go
@@ -254,6 +254,9 @@ func TestResponseModifierPreservesUpstreamErrorBody(t *testing.T) {
 	if got := recorder.responseStream.String(); got != body {
 		t.Fatalf("captured response body = %q, want %q", got, body)
 	}
+	if got := recorder.log.ResponseStatus; got != http.StatusBadRequest {
+		t.Fatalf("response status = %d, want %d", got, http.StatusBadRequest)
+	}
 }
 
 func TestResponseModifier_ModelFromRequestPreserved(t *testing.T) {


### PR DESCRIPTION
Record HTTP statuses for Obot-generated gateway failures by mapping application and Kubernetes errors to the same statuses returned by the API server. Mark non-success HTTP responses as error outcomes and preserve explicit 502 statuses for reverse-proxy transport failures.

Capture the requested model and resolved model metadata before access checks so denied and unresolved requests retain useful model context in their audit entries.

Addresses #7200 