### PR TITLE
fix: identify Claude Code from session header

### DIFF
--- a/pkg/gateway/server/llmaudit.go
+++ b/pkg/gateway/server/llmaudit.go
@@ -31,7 +31,6 @@ const (
 
 	llmAuditUserAgentClaudeCode = "claude-code"
 	llmAuditUserAgentClaudeCLI  = "claude-cli"
-	llmAuditUserAgentClaudeGRI  = "gRi"
 	llmAuditUserAgentCodexCLI   = "codex_cli_rs"
 	llmAuditUserAgentCodexTUI   = "codex-tui"
 )
@@ -55,7 +54,7 @@ func newLLMAuditRecorder(req *http.Request, user user.Info, responseCaptureLimit
 	if user != nil {
 		userID = user.GetUID()
 	}
-	clientName, clientVersion := parseLLMClientUserAgent(req.UserAgent())
+	clientName, clientVersion := detectLLMClient(req)
 
 	return &llmAuditRecorder{
 		responseCaptureLimit: responseCaptureLimit,
@@ -248,11 +247,19 @@ func parseLLMClientUserAgent(userAgent string) (string, string) {
 	switch name {
 	case llmAuditUserAgentClaudeCode, llmAuditUserAgentClaudeCLI:
 		name = llmAuditClientClaudeCode
-	case llmAuditUserAgentClaudeGRI:
-		name = llmAuditClientClaudeCode
-		version = ""
 	case llmAuditUserAgentCodexCLI, llmAuditUserAgentCodexTUI:
 		name = llmAuditClientCodex
+	}
+	return name, version
+}
+
+func detectLLMClient(req *http.Request) (string, string) {
+	name, version := parseLLMClientUserAgent(req.UserAgent())
+	if name == llmAuditClientClaudeCode || name == llmAuditClientCodex {
+		return name, version
+	}
+	if req.Header.Get(claudeCodeSessionIDHeader) != "" {
+		return llmAuditClientClaudeCode, ""
 	}
 	return name, version
 }

--- a/pkg/gateway/server/llmaudit_test.go
+++ b/pkg/gateway/server/llmaudit_test.go
@@ -130,26 +130,102 @@ func TestLLMAuditRecorderSetOutcome(t *testing.T) {
 	}
 }
 
-func TestParseLLMClientUserAgent(t *testing.T) {
+func TestDetectLLMClient(t *testing.T) {
 	for _, tt := range []struct {
+		name      string
 		userAgent string
+		headers   http.Header
 		client    string
 		version   string
 	}{
-		{userAgent: "claude-code/2.1.176", client: llmAuditClientClaudeCode, version: "2.1.176"},
-		{userAgent: "claude-cli/2.1.176 (external, cli)", client: llmAuditClientClaudeCode, version: "2.1.176"},
-		{userAgent: "gRi/JS 0.94.0", client: llmAuditClientClaudeCode, version: ""},
-		{userAgent: "codex_cli_rs/0.142.4 (Mac OS 26.5.1; arm64) ghostty/1.3.1", client: llmAuditClientCodex, version: "0.142.4"},
-		{userAgent: "codex-tui/0.142.4 (Mac OS 26.5.1; arm64) ghostty/1.3.1 (codex-tui; 0.142.4)", client: llmAuditClientCodex, version: "0.142.4"},
-		{userAgent: "other-client/1.2.3", client: "other-client", version: "1.2.3"},
-		{userAgent: "opencode/brew/1.2.3", client: "opencode", version: "brew/1.2.3"},
-		{userAgent: "", client: "", version: ""},
-		{userAgent: "unknown-client", client: "unknown-client", version: ""},
+		{
+			name:      "Claude Code user agent",
+			userAgent: "claude-code/2.1.176",
+			client:    llmAuditClientClaudeCode,
+			version:   "2.1.176",
+		},
+		{
+			name:      "Claude CLI user agent",
+			userAgent: "claude-cli/2.1.176 (external, cli)",
+			client:    llmAuditClientClaudeCode,
+			version:   "2.1.176",
+		},
+		{
+			name:      "gRi user agent without Claude session header",
+			userAgent: "gRi/JS 0.94.0",
+			client:    "gRi",
+			version:   "JS",
+		},
+		{
+			name:      "Codex CLI user agent",
+			userAgent: "codex_cli_rs/0.142.4 (Mac OS 26.5.1; arm64) ghostty/1.3.1",
+			client:    llmAuditClientCodex,
+			version:   "0.142.4",
+		},
+		{
+			name:      "Codex TUI user agent",
+			userAgent: "codex-tui/0.142.4 (Mac OS 26.5.1; arm64) ghostty/1.3.1 (codex-tui; 0.142.4)",
+			client:    llmAuditClientCodex,
+			version:   "0.142.4",
+		},
+		{
+			name:      "other client user agent",
+			userAgent: "other-client/1.2.3",
+			client:    "other-client",
+			version:   "1.2.3",
+		},
+		{
+			name:      "user agent with multiple slashes",
+			userAgent: "opencode/brew/1.2.3",
+			client:    "opencode",
+			version:   "brew/1.2.3",
+		},
+		{
+			name: "missing user agent",
+		},
+		{
+			name:      "user agent without version",
+			userAgent: "unknown-client",
+			client:    "unknown-client",
+		},
+		{
+			name:      "Claude session header identifies unrecognized user agent",
+			userAgent: "gRi/JS 0.94.0",
+			headers:   http.Header{claudeCodeSessionIDHeader: []string{"session-id"}},
+			client:    llmAuditClientClaudeCode,
+		},
+		{
+			name:    "Claude session header identifies missing user agent",
+			headers: http.Header{claudeCodeSessionIDHeader: []string{"session-id"}},
+			client:  llmAuditClientClaudeCode,
+		},
+		{
+			name:      "recognized Claude user agent keeps version",
+			userAgent: "claude-code/2.1.176",
+			headers:   http.Header{claudeCodeSessionIDHeader: []string{"session-id"}},
+			client:    llmAuditClientClaudeCode,
+			version:   "2.1.176",
+		},
+		{
+			name:      "recognized Codex user agent takes precedence",
+			userAgent: "codex_cli_rs/0.142.4",
+			headers:   http.Header{claudeCodeSessionIDHeader: []string{"session-id"}},
+			client:    llmAuditClientCodex,
+			version:   "0.142.4",
+		},
 	} {
-		client, version := parseLLMClientUserAgent(tt.userAgent)
-		if client != tt.client || version != tt.version {
-			t.Fatalf("parseLLMClientUserAgent(%q) = %q/%q, want %q/%q", tt.userAgent, client, version, tt.client, tt.version)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			if tt.headers != nil {
+				req.Header = tt.headers.Clone()
+			}
+			req.Header.Set("User-Agent", tt.userAgent)
+
+			client, version := detectLLMClient(req)
+			if client != tt.client || version != tt.version {
+				t.Fatalf("detectLLMClient() = %q/%q, want %q/%q", client, version, tt.client, tt.version)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Addresses #7188 

`gRi` is not a reliable UserAgent for Claude Code since we started also seeing `PDi`. See [this comment](https://github.com/obot-platform/obot/issues/7188#issuecomment-5007501148) for probable explanation.

Now we fallback to the `X-Claude-Code-Session-Id` header before defaulting to the detected UserAgent. We might still end up with unknown clients, but the current fallback allows us to detect `curl`, `go-http-client` and likely other standard UserAgents. And now we have another method for detecting Claude Code reliably (without version)
