### PR TITLE
fix: improve auth provider path

### DIFF
--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -165,6 +166,21 @@ func (d *Dispatcher) stopProvider(providerType, namespace, providerName string) 
 
 func (d *Dispatcher) GetConfiguredAuthProvider(ctx context.Context) (string, error) {
 	var authProviders v1.AuthProviderList
+	// First check for an auth provider whose status field is configured.
+	if err := d.client.List(ctx, &authProviders, &kclient.ListOptions{
+		Namespace:     system.DefaultNamespace,
+		FieldSelector: fields.SelectorFromSet(map[string]string{"status.configured": "true"}),
+	}); err != nil {
+		return "", fmt.Errorf("failed to list auth providers: %w", err)
+	}
+
+	for _, authProvider := range authProviders.Items {
+		if d.isAuthProviderConfigured(ctx, authProvider) {
+			return authProvider.Name, nil
+		}
+	}
+
+	// If no auth provider is configured, then check all of them in case the controller hasn't updated yet.
 	if err := d.client.List(ctx, &authProviders, &kclient.ListOptions{
 		Namespace: system.DefaultNamespace,
 	}); err != nil {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -263,7 +263,10 @@ func (p *Proxy) authenticateRequest(req *http.Request) (*authenticator.Response,
 		return nil, false, err
 	}
 
-	stateRequest, err := http.NewRequest(http.MethodPost, p.url+"/obot-get-state", strings.NewReader(string(srJSON)))
+	ctx, cancel := context.WithTimeout(req.Context(), 15*time.Second)
+	defer cancel()
+
+	stateRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, p.url+"/obot-get-state", strings.NewReader(string(srJSON)))
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/storage/apis/obot.obot.ai/v1/authprovider.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/authprovider.go
@@ -1,9 +1,15 @@
 package v1
 
 import (
+	"slices"
+	"strconv"
+
+	"github.com/obot-platform/nah/pkg/fields"
 	"github.com/obot-platform/obot/apiclient/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var _ fields.Fields = (*AuthProvider)(nil)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -13,6 +19,22 @@ type AuthProvider struct {
 
 	Spec   AuthProviderSpec   `json:"spec,omitempty"`
 	Status AuthProviderStatus `json:"status,omitempty"`
+}
+
+func (in *AuthProvider) Has(field string) (exists bool) {
+	return slices.Contains(in.FieldNames(), field)
+}
+
+func (in *AuthProvider) Get(field string) (value string) {
+	switch field {
+	case "status.configured":
+		return strconv.FormatBool(in.Status.Configured)
+	}
+	return ""
+}
+
+func (in *AuthProvider) FieldNames() []string {
+	return []string{"status.configured"}
 }
 
 func (in *AuthProvider) GetColumns() [][]string {


### PR DESCRIPTION
This change will use a context with a 15 second timeout when calling the auth provider to avoid handing requests.

Additionally, this will use a slightly more intelligent way of determining which auth provider is configured to avoid unnecessary database calls.