### PR TITLE
chore: audit logs: remove target.resolved field

### DIFF
--- a/apiclient/types/auditlogevent.go
+++ b/apiclient/types/auditlogevent.go
@@ -127,12 +127,10 @@ type AuditLogTargetRef struct {
 }
 
 // AuditLogTarget describes the direct object of an action. Parent expresses containment, such as
-// an MCP tool belonging to an MCP server. Resolved is true only when Obot correlated the target to
-// a server-side object; client-reported names and hints remain unresolved.
+// an MCP tool belonging to an MCP server.
 type AuditLogTarget struct {
 	AuditLogTargetRef `json:",inline"`
 	Parent            *AuditLogTargetRef `json:"parent,omitempty"`
-	Resolved          bool               `json:"resolved"`
 }
 
 // AuditLogOutcome contains the normalized result plus source-specific evidence. Reason is a stable

--- a/pkg/auditlog/presenter.go
+++ b/pkg/auditlog/presenter.go
@@ -151,7 +151,6 @@ func mcpTarget(mcp *gatewaytypes.MCPAuditLogFields) api.AuditLogTarget {
 	}
 	target := api.AuditLogTarget{
 		AuditLogTargetRef: server,
-		Resolved:          true,
 	}
 	if mcp.CallIdentifier == "" {
 		return target
@@ -200,7 +199,6 @@ func presentLocalAgent(event *api.AuditLogEvent, log gatewaytypes.MCPAuditLog, o
 			TargetType: local.TargetType,
 			Name:       local.TargetName,
 		},
-		Resolved: false,
 	}
 	if local.TargetParentType != "" {
 		event.Target.Parent = &api.AuditLogTargetRef{

--- a/pkg/auditlog/presenter_test.go
+++ b/pkg/auditlog/presenter_test.go
@@ -53,7 +53,7 @@ func TestPresentMCPNormalizesSummaryAndDetails(t *testing.T) {
 	if summary.Actor.ActorType != api.AuditLogActorTypeUser || summary.Actor.ID != "user-1" || summary.Actor.CredentialID != "credential-1" {
 		t.Fatalf("unexpected actor: %#v", summary.Actor)
 	}
-	if summary.Target.TargetType != api.AuditLogTargetTypeMCPTool || summary.Target.Parent == nil || !summary.Target.Resolved {
+	if summary.Target.TargetType != api.AuditLogTargetTypeMCPTool || summary.Target.Parent == nil {
 		t.Fatalf("unexpected target: %#v", summary.Target)
 	}
 	if summary.Outcome.Status != api.AuditLogOutcomeStatusSuccess || summary.Timestamp.Source != api.AuditLogTimestampSourceServer {
@@ -94,7 +94,7 @@ func TestPresentLocalAgentIdentityTargetAndTimestamp(t *testing.T) {
 	if event.Actor.ActorType != api.AuditLogActorTypeDevice || event.Actor.ID != "device-1" {
 		t.Fatalf("unexpected actor: %#v", event.Actor)
 	}
-	if event.Target.TargetType != api.AuditLogTargetTypeMCPTool || event.Target.Parent == nil || event.Target.Parent.Name != "github" || event.Target.Resolved {
+	if event.Target.TargetType != api.AuditLogTargetTypeMCPTool || event.Target.Parent == nil || event.Target.Parent.Name != "github" {
 		t.Fatalf("unexpected target: %#v", event.Target)
 	}
 	if event.Outcome.Status != api.AuditLogOutcomeStatusDenied || event.Outcome.Reason != "policy" {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -1899,7 +1899,7 @@ func schema_obot_platform_obot_apiclient_types_AuditLogTarget(ref common.Referen
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "AuditLogTarget describes the direct object of an action. Parent expresses containment, such as an MCP tool belonging to an MCP server. Resolved is true only when Obot correlated the target to a server-side object; client-reported names and hints remain unresolved.",
+				Description: "AuditLogTarget describes the direct object of an action. Parent expresses containment, such as an MCP tool belonging to an MCP server.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"targetType": {
@@ -1926,15 +1926,8 @@ func schema_obot_platform_obot_apiclient_types_AuditLogTarget(ref common.Referen
 							Ref: ref("github.com/obot-platform/obot/apiclient/types.AuditLogTargetRef"),
 						},
 					},
-					"resolved": {
-						SchemaProps: spec.SchemaProps{
-							Default: false,
-							Type:    []string{"boolean"},
-							Format:  "",
-						},
-					},
 				},
-				Required: []string{"targetType", "resolved"},
+				Required: []string{"targetType"},
 			},
 		},
 		Dependencies: []string{

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogEventDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogEventDetails.svelte
@@ -68,7 +68,6 @@
 				{@render field('Action Kind', auditLog.action.kind)}
 				{@render field('Target', auditLog.target.name || auditLog.target.id)}
 				{@render field('Parent Target', auditLog.target.parent?.name || auditLog.target.parent?.id)}
-				{@render field('Resolved', auditLog.target.resolved ? 'Yes' : 'No')}
 				{@render field('HTTP Status', auditLog.outcome.httpStatus)}
 				{@render field('Reason', auditLog.outcome.reason)}
 				{@render field('Duration (ms)', auditLog.outcome.durationMs)}

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -200,7 +200,7 @@ export interface AuditLogEvent {
 		credentialID?: string;
 	};
 	action: { operation: string; name?: string; kind?: string };
-	target: AuditLogTargetRef & { parent?: AuditLogTargetRef; resolved: boolean };
+	target: AuditLogTargetRef & { parent?: AuditLogTargetRef };
 	outcome: {
 		status: AuditLogOutcomeStatus;
 		httpStatus?: number;


### PR DESCRIPTION
Removing per @cjellick's request. This information was just not all that useful.