### PR TITLE
fix: fail sooner when command fails

### DIFF
--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net/http"
 	"reflect"
 	"slices"
 	"sort"
@@ -771,7 +772,11 @@ func getNewestPod(pods []corev1.Pod) (*corev1.Pod, error) {
 
 // analyzePodStatus examines a pod's status to determine if we should retry waiting for it
 // or if we should fail immediately. Returns (shouldRetry, error).
-func analyzePodStatus(pod *corev1.Pod, isAgent bool) (bool, error) {
+func analyzePodStatus(ctx context.Context, pod *corev1.Pod, server ServerConfig) (bool, error) {
+	return analyzePodStatusWithClient(ctx, pod, server, &http.Client{Timeout: time.Second})
+}
+
+func analyzePodStatusWithClient(ctx context.Context, pod *corev1.Pod, server ServerConfig, healthCheckClient *http.Client) (bool, error) {
 	// Check pod phase first
 	switch pod.Status.Phase {
 	case corev1.PodFailed:
@@ -779,7 +784,7 @@ func analyzePodStatus(pod *corev1.Pod, isAgent bool) (bool, error) {
 	case corev1.PodSucceeded:
 		// This shouldn't happen for a long-running deployment, but if it does, it's an error
 		// Except for agents. We use "recreate" update strategy for agents, so it's possible that the old pod exited while the new one is initializing.
-		return isAgent, fmt.Errorf("%w: pod succeeded and exited", ErrHealthCheckTimeout)
+		return server.NanobotAgentName != "", fmt.Errorf("%w: pod succeeded and exited", ErrHealthCheckTimeout)
 	case corev1.PodUnknown:
 		return false, fmt.Errorf("%w: pod is in Unknown phase", ErrHealthCheckTimeout)
 	}
@@ -836,6 +841,13 @@ func analyzePodStatus(pod *corev1.Pod, isAgent bool) (bool, error) {
 		return false, fmt.Errorf("%w: pod was evicted: %s", ErrPodSchedulingFailed, pod.Status.Message)
 	}
 
+	// If this is a command-based MCP server, then check for a 500 from the health check.
+	if pod.Status.PodIP != "" && (server.Runtime == types.RuntimeNPX || server.Runtime == types.RuntimeUVX) {
+		if err := ensureHTTPGetOK(ctx, healthCheckClient, fmt.Sprintf("http://%s:%d%s", pod.Status.PodIP, defaultContainerPort, server.HealthzPath)); err != nil {
+			return false, err
+		}
+	}
+
 	// Default: pod is in Pending or Running but not ready yet - should retry
 	return true, fmt.Errorf("pod in phase %s, waiting for containers to be ready", pod.Status.Phase)
 }
@@ -874,7 +886,7 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 					return false, nil // Keep waiting
 				}
 
-				shouldRetry, podErr := analyzePodStatus(newestPod, server.NanobotAgentName != "")
+				shouldRetry, podErr := analyzePodStatus(ctx, newestPod, server)
 				if !shouldRetry {
 					// Permanent failure - return the error with the appropriate type already wrapped
 					olog.Debugf("pod in non-retryable state: id=%s error=%v attempt=%d", id, podErr, attempt+1)
@@ -898,6 +910,7 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 			errors.Is(err, ErrImagePullFailed) ||
 			errors.Is(err, ErrPodSchedulingFailed) ||
 			errors.Is(err, ErrPodConfigurationFailed) ||
+			errors.Is(err, ErrHealthCheckFailed) ||
 			errors.Is(err, context.Canceled) {
 			return "", err
 		}
@@ -937,13 +950,6 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 
 	if podName == previousPodName {
 		return podName, nil
-	}
-
-	// For containerized runtimes, ensure that the real MCP server is healthy.
-	if server.Runtime == types.RuntimeContainerized {
-		if err = ensureServerReady(ctx, fmt.Sprintf("%s:%d", url, 8080), server); err != nil {
-			return "", fmt.Errorf("failed to ensure MCP server is ready: %w", err)
-		}
 	}
 
 	if err = ensureServerReady(ctx, url, server); err != nil {

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -632,7 +634,7 @@ func TestAnalyzePodStatus(t *testing.T) {
 	tests := []struct {
 		name            string
 		pod             corev1.Pod
-		isAgent         bool
+		server          ServerConfig
 		wantRetryable   bool
 		wantErr         error
 		wantErrContains string
@@ -725,7 +727,7 @@ func TestAnalyzePodStatus(t *testing.T) {
 					Phase: corev1.PodSucceeded,
 				},
 			},
-			isAgent:         true,
+			server:          ServerConfig{NanobotAgentName: "agent-1"},
 			wantRetryable:   true,
 			wantErr:         ErrHealthCheckTimeout,
 			wantErrContains: "pod succeeded and exited",
@@ -763,7 +765,7 @@ func TestAnalyzePodStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			retryable, err := analyzePodStatus(&tt.pod, tt.isAgent)
+			retryable, err := analyzePodStatus(t.Context(), &tt.pod, tt.server)
 			if tt.wantErr != nil {
 				if !errors.Is(err, tt.wantErr) {
 					t.Fatalf("analyzePodStatus() error = %v, want %v", err, tt.wantErr)
@@ -779,6 +781,107 @@ func TestAnalyzePodStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAnalyzePodStatusCommandRuntimeHealthCheck(t *testing.T) {
+	tests := []struct {
+		name              string
+		runtime           types.Runtime
+		podIP             string
+		statusCode        int
+		wantCalls         int
+		wantRetryable     bool
+		wantHealthFailure bool
+	}{
+		{
+			name:              "NPX fails immediately on health check 500",
+			runtime:           types.RuntimeNPX,
+			podIP:             "10.0.0.7",
+			statusCode:        http.StatusInternalServerError,
+			wantCalls:         1,
+			wantHealthFailure: true,
+		},
+		{
+			name:              "UVX fails immediately on health check 500",
+			runtime:           types.RuntimeUVX,
+			podIP:             "10.0.0.7",
+			statusCode:        http.StatusInternalServerError,
+			wantCalls:         1,
+			wantHealthFailure: true,
+		},
+		{
+			name:          "successful command health check remains retryable",
+			runtime:       types.RuntimeNPX,
+			podIP:         "10.0.0.7",
+			statusCode:    http.StatusOK,
+			wantCalls:     1,
+			wantRetryable: true,
+		},
+		{
+			name:          "containerized runtime skips pod health check",
+			runtime:       types.RuntimeContainerized,
+			podIP:         "10.0.0.7",
+			statusCode:    http.StatusInternalServerError,
+			wantRetryable: true,
+		},
+		{
+			name:          "command runtime without pod IP skips health check",
+			runtime:       types.RuntimeNPX,
+			statusCode:    http.StatusInternalServerError,
+			wantRetryable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				calls  int
+				gotURL string
+			)
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				gotURL = req.URL.String()
+				return &http.Response{
+					StatusCode: tt.statusCode,
+					Body:       io.NopCloser(strings.NewReader("tool discovery failed")),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			})}
+
+			retryable, err := analyzePodStatusWithClient(t.Context(), &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					PodIP: tt.podIP,
+				},
+			}, ServerConfig{
+				Runtime:     tt.runtime,
+				HealthzPath: "/healthz",
+			}, client)
+
+			if retryable != tt.wantRetryable {
+				t.Fatalf("analyzePodStatusWithClient() retryable = %v, want %v", retryable, tt.wantRetryable)
+			}
+			if errors.Is(err, ErrHealthCheckFailed) != tt.wantHealthFailure {
+				t.Fatalf("analyzePodStatusWithClient() error = %v, want health failure %v", err, tt.wantHealthFailure)
+			}
+			if tt.wantHealthFailure && !strings.Contains(err.Error(), "tool discovery failed") {
+				t.Fatalf("analyzePodStatusWithClient() error = %q, want response body", err)
+			}
+			if calls != tt.wantCalls {
+				t.Fatalf("health check calls = %d, want %d", calls, tt.wantCalls)
+			}
+			if tt.wantCalls > 0 && gotURL != "http://10.0.0.7:8099/healthz" {
+				t.Fatalf("health check URL = %q, want %q", gotURL, "http://10.0.0.7:8099/healthz")
+			}
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 type fakeWithWatch struct {


### PR DESCRIPTION
This change will detect a command failure in the uvx and npx runtimes sooner so the user doesn't have to wait for the timeout.

Issue: https://github.com/obot-platform/obot/issues/6503