### PR TITLE
fix: invert model request audit filter

### DIFF
--- a/pkg/api/handlers/llmauditlog.go
+++ b/pkg/api/handlers/llmauditlog.go
@@ -73,13 +73,17 @@ var llmAuditLogFilterOptions = map[string][]any{
 
 func (h *LLMAuditLogHandler) ListFilterOptions(req api.Context) error {
 	filter := req.PathValue("filter")
+	opts := parseLLMAuditLogOpts(req.URL.Query())
+	if filter == "hide_models_requests" {
+		return req.Write(map[string]any{"options": hideModelsRequestsFilterOptions(opts.RequestPath)})
+	}
 
 	exclude, ok := llmAuditLogFilterOptions[filter]
 	if !ok {
 		return types.NewErrBadRequest("invalid filter: %s", filter)
 	}
 
-	options, err := req.GatewayClient.GetLLMAuditLogFilterOptions(req.Context(), filter, parseLLMAuditLogOpts(req.URL.Query()), exclude...)
+	options, err := req.GatewayClient.GetLLMAuditLogFilterOptions(req.Context(), filter, opts, exclude...)
 	if err != nil {
 		return err
 	}
@@ -88,21 +92,30 @@ func (h *LLMAuditLogHandler) ListFilterOptions(req api.Context) error {
 	return req.Write(map[string]any{"options": options})
 }
 
+func hideModelsRequestsFilterOptions(requestPaths []string) []string {
+	for _, path := range requestPaths {
+		if strings.HasSuffix(path, "/models") || strings.HasSuffix(path, "/models/") {
+			return []string{"false"}
+		}
+	}
+	return []string{"false", "true"}
+}
+
 func parseLLMAuditLogOpts(query url.Values) gateway.LLMAuditLogOptions {
-	includeModelsRequests, _ := strconv.ParseBool(query.Get("include_models_requests"))
+	hideModelsRequests, _ := strconv.ParseBool(query.Get("hide_models_requests"))
 	opts := gateway.LLMAuditLogOptions{
-		IncludeModelsRequests: includeModelsRequests,
-		UserID:                parseStringList(query, "user_id"),
-		ModelProvider:         parseStringList(query, "model_provider"),
-		TargetModel:           parseStringList(query, "target_model"),
-		RequestPath:           parseStringList(query, "request_path"),
-		Outcome:               parseStringList(query, "outcome"),
-		UserAgent:             parseStringList(query, "user_agent"),
-		ClientSessionID:       parseStringList(query, "client_session_id"),
-		Query:                 strings.TrimSpace(query.Get("query")),
-		SortBy:                query.Get("sort_by"),
-		SortOrder:             query.Get("sort_order"),
-		StartTime:             time.Now().UTC().AddDate(0, 0, -30),
+		HideModelsRequests: hideModelsRequests,
+		UserID:             parseStringList(query, "user_id"),
+		ModelProvider:      parseStringList(query, "model_provider"),
+		TargetModel:        parseStringList(query, "target_model"),
+		RequestPath:        parseStringList(query, "request_path"),
+		Outcome:            parseStringList(query, "outcome"),
+		UserAgent:          parseStringList(query, "user_agent"),
+		ClientSessionID:    parseStringList(query, "client_session_id"),
+		Query:              strings.TrimSpace(query.Get("query")),
+		SortBy:             query.Get("sort_by"),
+		SortOrder:          query.Get("sort_order"),
+		StartTime:          time.Now().UTC().AddDate(0, 0, -30),
 	}
 	for _, value := range parseStringList(query, "message_policy_triggered") {
 		if triggered, err := strconv.ParseBool(value); err == nil {

--- a/pkg/api/handlers/llmauditlog_test.go
+++ b/pkg/api/handlers/llmauditlog_test.go
@@ -47,7 +47,7 @@ func TestParseLLMAuditLogOptsParsesFilterFields(t *testing.T) {
 	}
 }
 
-func TestParseLLMAuditLogOptsIncludeModelsRequests(t *testing.T) {
+func TestParseLLMAuditLogOptsHideModelsRequests(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
 		value string
@@ -64,11 +64,39 @@ func TestParseLLMAuditLogOptsIncludeModelsRequests(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			query := url.Values{}
 			if tt.value != "" {
-				query.Set("include_models_requests", tt.value)
+				query.Set("hide_models_requests", tt.value)
 			}
 
-			if got := parseLLMAuditLogOpts(query).IncludeModelsRequests; got != tt.want {
-				t.Fatalf("expected IncludeModelsRequests=%t, got %t", tt.want, got)
+			if got := parseLLMAuditLogOpts(query).HideModelsRequests; got != tt.want {
+				t.Fatalf("expected HideModelsRequests=%t, got %t", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestHideModelsRequestsFilterOptions(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		paths []string
+		want  []string
+	}{
+		{name: "no path", want: []string{"false", "true"}},
+		{name: "non-models path", paths: []string{"/api/llm-proxy/openai/v1/responses"}, want: []string{"false", "true"}},
+		{name: "models path", paths: []string{"/api/llm-proxy/openai/models"}, want: []string{"false"}},
+		{name: "models path with trailing slash", paths: []string{"/api/llm-proxy/openai/models/"}, want: []string{"false"}},
+		{name: "nested models path", paths: []string{"/api/llm-proxy/openai/v1/models"}, want: []string{"false"}},
+		{name: "specific model path", paths: []string{"/api/llm-proxy/openai/models/model-1"}, want: []string{"false", "true"}},
+		{name: "mixed paths", paths: []string{"/api/llm-proxy/openai/v1/responses", "/api/llm-proxy/openai/models"}, want: []string{"false"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hideModelsRequestsFilterOptions(tt.paths)
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected options %v, got %v", tt.want, got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("expected options %v, got %v", tt.want, got)
+				}
 			}
 		})
 	}

--- a/pkg/gateway/client/llmauditlog.go
+++ b/pkg/gateway/client/llmauditlog.go
@@ -213,7 +213,7 @@ func (c *Client) runLLMAuditPersistenceLoop(ctx context.Context, batchSize int, 
 }
 
 func applyLLMAuditLogOptions(db *gorm.DB, opts LLMAuditLogOptions) *gorm.DB {
-	if !opts.IncludeModelsRequests {
+	if opts.HideModelsRequests {
 		db = db.Where("request_path NOT LIKE ? AND request_path NOT LIKE ?", "%/models", "%/models/")
 	}
 	if opts.Query != "" {
@@ -468,7 +468,7 @@ func llmAuditLogDataCtx(log *types.LLMAuditLog) value.Context {
 
 type LLMAuditLogOptions struct {
 	WithSensitiveFields    bool
-	IncludeModelsRequests  bool
+	HideModelsRequests     bool
 	UserID                 []string
 	ModelProvider          []string
 	TargetModel            []string

--- a/pkg/gateway/client/llmauditlog_test.go
+++ b/pkg/gateway/client/llmauditlog_test.go
@@ -219,7 +219,7 @@ func TestGetLLMAuditLogsFiltersAndStripsSensitiveFields(t *testing.T) {
 	}
 }
 
-func TestGetLLMAuditLogsExcludesModelsRequestsByDefault(t *testing.T) {
+func TestGetLLMAuditLogsCanHideModelsRequests(t *testing.T) {
 	c := newTestClient(t)
 	now := time.Now().UTC()
 	for _, path := range []string{
@@ -235,7 +235,7 @@ func TestGetLLMAuditLogsExcludesModelsRequestsByDefault(t *testing.T) {
 		}
 	}
 
-	logs, total, err := c.GetLLMAuditLogs(t.Context(), LLMAuditLogOptions{})
+	logs, total, err := c.GetLLMAuditLogs(t.Context(), LLMAuditLogOptions{HideModelsRequests: true})
 	if err != nil {
 		t.Fatalf("failed to list LLM audit logs: %v", err)
 	}
@@ -251,7 +251,7 @@ func TestGetLLMAuditLogsExcludesModelsRequestsByDefault(t *testing.T) {
 		t.Fatalf("expected non-models request paths, got %v", paths)
 	}
 
-	logs, total, err = c.GetLLMAuditLogs(t.Context(), LLMAuditLogOptions{IncludeModelsRequests: true})
+	logs, total, err = c.GetLLMAuditLogs(t.Context(), LLMAuditLogOptions{})
 	if err != nil {
 		t.Fatalf("failed to list all LLM audit logs: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestGetLLMAuditLogsExcludesModelsRequestsByDefault(t *testing.T) {
 		t.Fatalf("expected all requests, got total=%d len=%d", total, len(logs))
 	}
 
-	options, err := c.GetLLMAuditLogFilterOptions(t.Context(), "request_path", LLMAuditLogOptions{}, "")
+	options, err := c.GetLLMAuditLogFilterOptions(t.Context(), "request_path", LLMAuditLogOptions{HideModelsRequests: true}, "")
 	if err != nil {
 		t.Fatalf("failed to list request path options: %v", err)
 	}

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -41,7 +41,7 @@
 	const supportedFilters: SupportedFilter[] = [
 		'user_id',
 		'client_session_id',
-		'include_models_requests',
+		'hide_models_requests',
 		'message_policy_triggered',
 		'model_provider',
 		'outcome',
@@ -68,9 +68,6 @@
 	const isReachedMax = $derived(pageIndex >= numberOfPages - 1);
 
 	let query = $derived(page.url.searchParams.get('query') ?? '');
-	let includeModelsRequests = $derived(
-		page.url.searchParams.get('include_models_requests') === 'true'
-	);
 	let usersMap = $derived(new Map(users.map((user) => [user.id, user])));
 
 	const DEFER_THRESHOLD = 500;
@@ -107,7 +104,9 @@
 	const pageOffset = $derived(pageIndex * pageLimit);
 
 	const searchParamFiltersAsArray = $derived(
-		buildSearchParamFiltersArray<LLMAuditLogURLFilters>(supportedFilters)
+		buildSearchParamFiltersArray<LLMAuditLogURLFilters>(supportedFilters, {
+			hide_models_requests: 'true'
+		})
 	);
 	const searchParamFilters = $derived.by<LLMAuditLogURLFilters>(() => {
 		return searchParamFiltersAsArray.reduce(
@@ -115,16 +114,12 @@
 				acc[key!] = value;
 				return acc;
 			},
-			{
-				include_models_requests: includeModelsRequests.toString()
-			} as Record<string, unknown>
+			{} as Record<string, unknown>
 		);
 	});
 
 	const pillsSearchParamFilters = $derived(
-		buildPillSearchParamFilters<LLMAuditLogURLFilters>(searchParamFiltersAsArray, {
-			include_models_requests: includeModelsRequests.toString()
-		})
+		buildPillSearchParamFilters<LLMAuditLogURLFilters>(searchParamFiltersAsArray)
 	);
 	const hasFilterPills = $derived(Object.keys(pillsSearchParamFilters).length > 0);
 
@@ -145,7 +140,6 @@
 		end_time: timeRangeFilters.endTime.toISOString(),
 		limit: pageLimit,
 		offset: pageOffset,
-		include_models_requests: includeModelsRequests.toString(),
 		query
 	});
 
@@ -153,7 +147,6 @@
 		JSON.stringify({
 			...pillsSearchParamFilters,
 			query,
-			include_models_requests: includeModelsRequests,
 			start_time: timeRangeFilters.startTime.toISOString(),
 			end_time: timeRangeFilters.endTime.toISOString()
 		})
@@ -232,7 +225,7 @@
 		if (_key === 'user_id') return 'User';
 		if (_key === 'user_agent') return 'User Agent';
 		if (_key === 'client_session_id') return 'Client Session ID';
-		if (_key === 'include_models_requests') return 'Model discovery requests';
+		if (_key === 'hide_models_requests') return 'Model discovery requests';
 		if (_key === 'message_policy_triggered') return 'Message Policy Action';
 
 		return key.replace(/_(\w)/g, ' $1');
@@ -245,13 +238,9 @@
 		if (label === 'message_policy_triggered') {
 			return value === 'true' ? 'Triggered' : 'Not triggered';
 		}
-		if (label === 'include_models_requests') return value === 'true' ? 'Shown' : 'Hidden';
+		if (label === 'hide_models_requests') return value === 'true' ? 'Hidden' : 'Shown';
 
 		return value + '';
-	}
-
-	function isFilterClearable(filterKey: keyof LLMAuditLogURLFilters): boolean {
-		return filterKey !== 'include_models_requests';
 	}
 
 	function handleRightSidebarClose() {
@@ -268,6 +257,9 @@
 		page.url.searchParams.forEach((value, key) => {
 			url.searchParams.set(key, value);
 		});
+		if (pillsSearchParamFilters.hide_models_requests === 'true') {
+			url.searchParams.set('hide_models_requests', 'true');
+		}
 		url.searchParams.set('form', formType);
 		if (next) {
 			url.searchParams.set('next', next);
@@ -322,12 +314,7 @@
 		<div class="flex flex-col flex-nowrap gap-4 @min-[768px]:flex-row">
 			<div class="min-w-0 grow hidden @min-[768px]:block">
 				{#if hasFilterPills}
-					<AuditLogFilterPills
-						{pillsSearchParamFilters}
-						{getFilterDisplayLabel}
-						{getFilterValue}
-						{isFilterClearable}
-					/>
+					<AuditLogFilterPills {pillsSearchParamFilters} {getFilterDisplayLabel} {getFilterValue} />
 				{/if}
 			</div>
 			{#if !isAdminReadonly}
@@ -359,12 +346,7 @@
 			{/if}
 			<div class="min-w-0 grow block @min-[768px]:hidden">
 				{#if hasFilterPills}
-					<AuditLogFilterPills
-						{pillsSearchParamFilters}
-						{getFilterDisplayLabel}
-						{getFilterValue}
-						{isFilterClearable}
-					/>
+					<AuditLogFilterPills {pillsSearchParamFilters} {getFilterDisplayLabel} {getFilterValue} />
 				{/if}
 			</div>
 		</div>
@@ -459,25 +441,21 @@
 			onClose={handleRightSidebarClose}
 			filters={{ ...searchParamFilters }}
 			isFilterDisabled={() => false}
-			{isFilterClearable}
-			isFilterMultiSelect={(filterId) => filterId !== 'include_models_requests'}
-			getDefaultValue={(filterId) => (filterId === 'include_models_requests' ? 'false' : undefined)}
+			isFilterMultiSelect={(filterId) => filterId !== 'hide_models_requests'}
+			getDefaultValue={(filterId) => (filterId === 'hide_models_requests' ? 'true' : undefined)}
 			getUserDisplayName={(...args) => getUserDisplayName(usersMap, ...args)}
 			{getFilterDisplayLabel}
 			getFilterOptionLabel={(key, value) =>
-				key === 'include_models_requests'
+				key === 'hide_models_requests'
 					? value === 'true'
-						? 'Shown'
-						: 'Hidden'
+						? 'Hidden'
+						: 'Shown'
 					: key === 'message_policy_triggered'
 						? value === 'true'
 							? 'Triggered'
 							: 'Not triggered'
 						: value}
 			endpoint={async (filterId, opts) => {
-				if (filterId === 'include_models_requests') {
-					return { options: ['true', 'false'] };
-				}
 				const response = await AdminService.listLLMAuditLogFilterOptions(filterId, {
 					...opts,
 					start_time: timeRangeFilters.startTime.toISOString(),

--- a/ui/user/src/lib/components/admin/filters-drawer/FilterField.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FilterField.svelte
@@ -5,7 +5,6 @@
 	};
 
 	export type FilterInput = {
-		clearable?: boolean;
 		label: string;
 		multiple?: boolean;
 		tooltip?: string;
@@ -42,16 +41,20 @@
 
 	let options = $derived([...(filter?.options ?? [])].sort(optionsSort));
 
-	const value = $derived(
-		filter.selected === null ? (filter.default ?? '') : (filter.selected ?? '')
+	// Other active filters can make the configured default invalid, so only offer Reset when it is selectable.
+	const hasValidDefault = $derived(
+		filter.default !== undefined &&
+			filter.default !== null &&
+			options.some((option) => option.id === filter.default?.toString())
 	);
-
-	const hasDefaultValue = $derived(!!filter.default);
+	const value = $derived(
+		filter.selected === null && hasValidDefault ? (filter.default ?? '') : (filter.selected ?? '')
+	);
 
 	const shouldShowResetButton = $derived(
-		hasDefaultValue && filter.selected !== null && filter.default !== filter.selected
+		hasValidDefault && filter.selected !== null && filter.default !== filter.selected
 	);
-	const shouldShowClearButton = $derived((filter.clearable ?? true) && !!value);
+	const shouldShowClearButton = $derived(!!value);
 
 	const actions = $derived(
 		[

--- a/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
@@ -94,7 +94,6 @@
 	let filterInputs = $derived(
 		visibleFilterKeys.reduce((acc, filterId) => {
 			acc[filterId] = {
-				clearable: isFilterClearable?.(filterId) ?? true,
 				property: filterId,
 				label: getFilterDisplayLabel?.(filterId) ?? filterId.replace(/_(\w)/, ' $1'),
 				multiple: isFilterMultiSelect?.(filterId) ?? true,
@@ -205,13 +204,11 @@
 	}
 
 	function handleClearAllFilters() {
-		filterInputsAsArray.forEach((filterInput) => {
-			if (filterInput.clearable) {
+		filterInputsAsArray
+			.filter((filterInput) => isFilterClearable?.(filterInput.property as FilterKey) ?? true)
+			.forEach((filterInput) => {
 				filterInput.selected = '';
-			} else if (filterInput.default !== undefined) {
-				filterInput.selected = filterInput.default;
-			}
-		});
+			});
 	}
 </script>
 

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -556,7 +556,7 @@ export interface LLMAuditLog {
 export type LLMAuditLogURLFilters = {
 	client_session_id?: string | null;
 	end_time?: string | null;
-	include_models_requests?: string | null;
+	hide_models_requests?: string | null;
 	limit?: number | null;
 	message_policy_triggered?: string | null;
 	model_provider?: string | null;


### PR DESCRIPTION
Addresses #7147 

This change inverts the filter used to show/hide models requests (`include_models_requests` -> `hide_models_requests`). This improves the UX by making our pre-configured default (true/Hide) different from the "empty" backend default (false/Show). Now users can easily see that this filter is applied by default and then are able to dismiss/remove it.

This also removes some code that was added for this undismissable default case since it is no longer used.