### PR TITLE
feat(docs): customize Obot URL in examples

### DIFF
--- a/docs/docs/functionality/api-keys.md
+++ b/docs/docs/functionality/api-keys.md
@@ -2,6 +2,10 @@
 title: API Keys
 ---
 
+import ObotUrlExamples from '@site/src/components/ObotUrlExamples';
+
+<ObotUrlExamples>
+
 # API Keys
 
 API Keys provide programmatic access to Obot from scripts, automation tools, external MCP clients, and compatible LLM clients. Instead of using interactive browser-based OAuth authentication, you can create API keys with only the capabilities each integration needs.
@@ -208,6 +212,8 @@ MCP server access is independent from the optional capabilities. For example, yo
 
 ## Creating API Keys with the CLI
 
+The examples in this section use the URL configured under **Set Obot URL** in the navigation bar.
+
 The `obot login` command creates and stores an API key through the browser-based login flow. By default, it requests API access:
 
 ```bash
@@ -262,3 +268,5 @@ Administrators can delete any user's API key:
 - **Never share keys**: Each integration should have its own API key
 - **Delete unused keys**: Remove keys that are no longer needed
 - **Store securely**: Treat API keys like passwords - never commit them to version control or share them in plain text
+
+</ObotUrlExamples>

--- a/docs/docs/functionality/llm-gateway.md
+++ b/docs/docs/functionality/llm-gateway.md
@@ -4,6 +4,9 @@ title: LLM Gateway
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import ObotUrlExamples from '@site/src/components/ObotUrlExamples';
+
+<ObotUrlExamples>
 
 ## Overview
 
@@ -58,6 +61,8 @@ To use the gateway you need:
 3. **The Obot CLI.** Install and set up the `obot` CLI to obtain an API key. See [Obot CLI Setup](/installation/cli-setup/).
 
 ## Getting your API key
+
+The examples on this page use the URL configured under **Set Obot URL** in the navigation bar.
 
 Your API key for the gateway must include LLM proxy access. Print one with the CLI:
 
@@ -307,8 +312,6 @@ claude --model anthropic.claude-haiku-4-5
   </TabItem>
 </Tabs>
 
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in the selected base URL.
-
 `--model` is optional, but it is useful since Claude Code does not support model discovery with AWS Bedrock. The default models presented by Claude Code's model selector should be compatible with our Bedrock provider as long as the corresponding Bedrock model ID is enabled in Obot.
 
 For more details, see Claude Code's [Route Mantle through a gateway](https://code.claude.com/docs/en/amazon-bedrock#route-mantle-through-a-gateway) documentation.
@@ -339,8 +342,6 @@ claude --model my-claude-deployment
 
   </TabItem>
 </Tabs>
-
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in both the selected base URL and the `obot login` command.
 
 `ANTHROPIC_FOUNDRY_API_KEY` contains an Obot gateway token in this setup, not an Azure API key; Obot replaces it with the configured Azure credential before forwarding the request. The value passed to `--model` must be the exact Azure deployment name listed in the Anthropic-compatible Azure section on the Models page.
 
@@ -373,8 +374,6 @@ Codex works with the OpenAI passthrough. Because Codex uses the OpenAI **Respons
    env_key_instructions = "Set OBOT_API_KEY and restart to authenticate with the Obot LLM Gateway"
    supports_websockets = false
    ```
-
-   For a local deployment, use `base_url = "http://localhost:8080/api/llm-proxy/openai"`.
 
 2. Set your API key and start Codex:
 
@@ -434,8 +433,6 @@ supports_websockets = false
   </TabItem>
 </Tabs>
 
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in the selected base URL.
-
 ### Codex with Azure
 
 Codex can use an Azure deployment whose model dialect is `OpenAIResponses`. Add the configuration for your Azure authentication method to `~/.codex/config.toml`, replacing the example deployment name and Obot URL:
@@ -473,8 +470,6 @@ supports_websockets = false
   </TabItem>
 </Tabs>
 
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in the selected base URL.
-
 See the Codex documentation for details:
 
 - [Configuration reference](https://developers.openai.com/codex/config-reference) (the `[model_providers]` keys)
@@ -500,3 +495,5 @@ See the Codex documentation for details:
 - [Claude Code: Route Mantle through a gateway](https://code.claude.com/docs/en/amazon-bedrock#route-mantle-through-a-gateway)
 - [AWS Bedrock Anthropic model cards](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-anthropic.html) — check Anthropic model region availability
 - [Audit Log Export](/configuration/audit-log-export/) — export LLM gateway audit logs
+
+</ObotUrlExamples>

--- a/docs/docs/functionality/llm-gateway.md
+++ b/docs/docs/functionality/llm-gateway.md
@@ -4,6 +4,9 @@ title: LLM Gateway
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import ObotUrlExamples from '@site/src/components/ObotUrlExamples';
+
+<ObotUrlExamples>
 
 ## Overview
 
@@ -58,6 +61,8 @@ To use the gateway you need:
 3. **The Obot CLI.** Install and set up the `obot` CLI to obtain an API key. See [Obot CLI Setup](../installation/cli-setup.md).
 
 ## Getting your API key
+
+The examples on this page use the URL configured under **Set Obot URL** in the navigation bar.
 
 Your API key for the gateway must include LLM proxy access. Print one with the CLI:
 
@@ -307,8 +312,6 @@ claude --model anthropic.claude-haiku-4-5
   </TabItem>
 </Tabs>
 
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in the selected base URL.
-
 `--model` is optional, but it is useful since Claude Code does not support model discovery with AWS Bedrock. The default models presented by Claude Code's model selector should be compatible with our Bedrock provider as long as the corresponding Bedrock model ID is enabled in Obot.
 
 For more details, see Claude Code's [Route Mantle through a gateway](https://code.claude.com/docs/en/amazon-bedrock#route-mantle-through-a-gateway) documentation.
@@ -339,8 +342,6 @@ claude --model my-claude-deployment
 
   </TabItem>
 </Tabs>
-
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in both the selected base URL and the `obot login` command.
 
 `ANTHROPIC_FOUNDRY_API_KEY` contains an Obot gateway token in this setup, not an Azure API key; Obot replaces it with the configured Azure credential before forwarding the request. The value passed to `--model` must be the exact Azure deployment name listed in the Anthropic-compatible Azure section on the Models page.
 
@@ -373,8 +374,6 @@ Codex works with the OpenAI passthrough. Because Codex uses the OpenAI **Respons
    env_key_instructions = "Set OBOT_API_KEY and restart to authenticate with the Obot LLM Gateway"
    supports_websockets = false
    ```
-
-   For a local deployment, use `base_url = "http://localhost:8080/api/llm-proxy/openai"`.
 
 2. Set your API key and start Codex:
 
@@ -437,11 +436,9 @@ supports_websockets = false
   </TabItem>
 </Tabs>
 
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in the selected base URL.
-
 ### Codex with Azure
 
-Codex can use an Azure deployment whose model dialect is `OpenAIResponses`. Add the configuration for your Azure authentication method to `~/.codex/config.toml`, replacing the example deployment name and Obot URL:
+Codex can use an Azure deployment whose model dialect is `OpenAIResponses`. Add the configuration for your Azure authentication method to `~/.codex/config.toml`, replacing the example deployment name:
 Azure does not support Codex's built-in server-side web search, so disable it in the Codex configuration.
 
 <Tabs groupId="azure-auth">
@@ -479,8 +476,6 @@ supports_websockets = false
   </TabItem>
 </Tabs>
 
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in the selected base URL.
-
 See the Codex documentation for details:
 
 - [Configuration reference](https://developers.openai.com/codex/config-reference) (the `[model_providers]` keys)
@@ -506,3 +501,5 @@ See the Codex documentation for details:
 - [Claude Code: Route Mantle through a gateway](https://code.claude.com/docs/en/amazon-bedrock#route-mantle-through-a-gateway)
 - [AWS Bedrock Anthropic model cards](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-anthropic.html) — check Anthropic model region availability
 - [Audit Log Export](../configuration/audit-log-export.md) — export LLM gateway audit logs
+
+</ObotUrlExamples>

--- a/docs/docs/installation/cli-setup.md
+++ b/docs/docs/installation/cli-setup.md
@@ -2,6 +2,10 @@
 title: Obot CLI Setup
 ---
 
+import ObotUrlExamples from '@site/src/components/ObotUrlExamples';
+
+<ObotUrlExamples>
+
 The `obot setup` command prepares your local workstation to use an Obot server from the command line and from supported local AI clients.
 
 Use it after an Obot server is running and reachable from your machine.
@@ -33,16 +37,10 @@ If Obot authentication is enabled but no provider is configured yet, finish serv
 
 ## Basic usage
 
-Run setup with your Obot app URL:
+Run setup with your Obot app URL. The examples on this page use the URL configured under **Set Obot URL** in the navigation bar.
 
 ```bash
 obot setup --url https://obot.example.com
-```
-
-For a local Docker deployment using the default port:
-
-```bash
-obot setup --url http://localhost:8080
 ```
 
 If authentication is required, the CLI opens a browser to complete login. After login succeeds, setup saves the default URL and asks where to install local bootstrap skills.
@@ -146,3 +144,5 @@ Pass `--clients agents`, `--clients claude-code`, `--clients agents,claude-code`
 ### Existing URL mismatch
 
 If setup reports that another Obot URL is already configured, pass `--yes` to replace the stored default URL.
+
+</ObotUrlExamples>

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -139,6 +139,10 @@ const config: Config = {
           dropdownActiveClassDisabled: true,
         },
         {
+          type: "custom-obotUrl",
+          position: "left",
+        },
+        {
           href: "https://github.com/obot-platform/obot",
           label: "GitHub",
           position: "right",

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -154,6 +154,10 @@ const config: Config = {
           dropdownActiveClassDisabled: true,
         },
         {
+          type: "custom-obotUrl",
+          position: "left",
+        },
+        {
           href: "https://github.com/obot-platform/obot",
           label: "GitHub",
           position: "right",

--- a/docs/src/components/ObotUrlExamples/index.tsx
+++ b/docs/src/components/ObotUrlExamples/index.tsx
@@ -1,0 +1,14 @@
+import React, { type ReactNode } from "react";
+import { ObotUrlExamplesContext } from "../../lib/obotUrl";
+
+export default function ObotUrlExamples({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode {
+  return (
+    <ObotUrlExamplesContext.Provider value>
+      {children}
+    </ObotUrlExamplesContext.Provider>
+  );
+}

--- a/docs/src/components/ObotUrlNavbarItem/index.tsx
+++ b/docs/src/components/ObotUrlNavbarItem/index.tsx
@@ -1,0 +1,138 @@
+import React, {
+  type FormEvent,
+  type ReactNode,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import {
+  DEFAULT_OBOT_URL,
+  normalizeObotUrl,
+  saveObotUrl,
+  useObotUrl,
+} from "../../lib/obotUrl";
+import styles from "./styles.module.css";
+
+type Props = {
+  mobile?: boolean;
+};
+
+export default function ObotUrlNavbarItem({ mobile = false }: Props): ReactNode {
+  const obotUrl = useObotUrl();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
+  const [draft, setDraft] = useState(obotUrl);
+  const [error, setError] = useState("");
+
+  function openDialog(): void {
+    setDraft(obotUrl);
+    setError("");
+    dialogRef.current?.showModal();
+  }
+
+  function applyUrl(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    try {
+      const normalized = normalizeObotUrl(draft);
+      saveObotUrl(normalized);
+      setDraft(normalized);
+      setError("");
+      dialogRef.current?.close();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Enter a valid URL.");
+    }
+  }
+
+  const trigger = (
+    <button
+      type="button"
+      className={
+        mobile
+          ? `menu__link ${styles.trigger}`
+          : `navbar__item navbar__link ${styles.trigger}`
+      }
+      onClick={openDialog}
+    >
+      Set Obot URL
+    </button>
+  );
+
+  const dialog = (
+    <dialog
+      ref={dialogRef}
+      className={styles.dialog}
+      aria-labelledby={titleId}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          event.currentTarget.close();
+        }
+      }}
+    >
+      <form className={styles.form} onSubmit={applyUrl}>
+        <h2 id={titleId} className={styles.title}>
+          Obot URL
+        </h2>
+        <p className={styles.description}>
+          Code examples use this URL in place of {DEFAULT_OBOT_URL}.
+        </p>
+        <label className={styles.label} htmlFor={`${titleId}-input`}>
+          Base URL
+        </label>
+        <input
+          id={`${titleId}-input`}
+          className={styles.input}
+          type="url"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          aria-describedby={error ? `${titleId}-error` : undefined}
+          required
+        />
+        {error && (
+          <p id={`${titleId}-error`} className={styles.error} role="alert">
+            {error}
+          </p>
+        )}
+        <div className={styles.presets}>
+          <button
+            type="button"
+            className="button button--secondary button--sm"
+            onClick={() => setDraft("http://localhost:8080")}
+          >
+            Use localhost
+          </button>
+          <button
+            type="button"
+            className="button button--secondary button--sm"
+            onClick={() => setDraft(DEFAULT_OBOT_URL)}
+          >
+            Use default
+          </button>
+        </div>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className="button button--secondary"
+            onClick={() => dialogRef.current?.close()}
+          >
+            Cancel
+          </button>
+          <button type="submit" className="button button--primary">
+            Apply
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+
+  return mobile ? (
+    <li className="menu__list-item">
+      {trigger}
+      {dialog}
+    </li>
+  ) : (
+    <>
+      {trigger}
+      {dialog}
+    </>
+  );
+}

--- a/docs/src/components/ObotUrlNavbarItem/styles.module.css
+++ b/docs/src/components/ObotUrlNavbarItem/styles.module.css
@@ -1,0 +1,94 @@
+.trigger {
+  appearance: none;
+  background: var(--ifm-color-emphasis-200);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  color: var(--ifm-color-emphasis-800);
+  cursor: pointer;
+  font-size: 0.8rem;
+  line-height: 1.25;
+  padding: 0.35rem 0.65rem;
+  width: auto;
+}
+
+.trigger:hover {
+  background: var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-900);
+  text-decoration: none;
+}
+
+.dialog {
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  box-shadow: var(--ifm-global-shadow-lw);
+  color: var(--ifm-font-color-base);
+  margin: auto;
+  max-width: min(32rem, calc(100vw - 2rem));
+  padding: 0;
+  width: 100%;
+}
+
+.dialog::backdrop {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.form {
+  padding: 1.5rem;
+}
+
+.title {
+  font-size: 1.4rem;
+  margin-bottom: 0.5rem;
+}
+
+.description {
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 1.25rem;
+}
+
+.label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.input {
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-400);
+  border-radius: 6px;
+  color: var(--ifm-font-color-base);
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+  width: 100%;
+}
+
+.input:focus {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ifm-color-primary) 25%, transparent);
+  outline: none;
+}
+
+.error {
+  color: var(--ifm-color-danger-dark);
+  font-size: 0.875rem;
+  margin: 0.5rem 0 0;
+}
+
+.presets,
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.presets {
+  margin-top: 0.75rem;
+}
+
+.actions {
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+}

--- a/docs/src/lib/obotUrl.ts
+++ b/docs/src/lib/obotUrl.ts
@@ -1,0 +1,56 @@
+import { createContext, useContext, useSyncExternalStore } from "react";
+
+export const DEFAULT_OBOT_URL = "https://obot.example.com";
+
+const STORAGE_KEY = "obot-docs-url";
+const CHANGE_EVENT = "obot-docs-url-change";
+
+export const ObotUrlExamplesContext = createContext(false);
+
+export function normalizeObotUrl(value: string): string {
+  const normalized = value.trim().replace(/\/+$/, "");
+  const url = new URL(normalized);
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Enter a URL beginning with http:// or https://.");
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("Enter an Obot base URL without credentials, a query, or a fragment.");
+  }
+
+  return normalized;
+}
+
+function getStoredObotUrl(): string {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored ? normalizeObotUrl(stored) : DEFAULT_OBOT_URL;
+  } catch {
+    return DEFAULT_OBOT_URL;
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  window.addEventListener(CHANGE_EVENT, listener);
+  window.addEventListener("storage", listener);
+
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, listener);
+    window.removeEventListener("storage", listener);
+  };
+}
+
+export function useObotUrl(): string {
+  return useSyncExternalStore(subscribe, getStoredObotUrl, () => DEFAULT_OBOT_URL);
+}
+
+export function useObotUrlExamples(): boolean {
+  return useContext(ObotUrlExamplesContext);
+}
+
+export function saveObotUrl(value: string): string {
+  const normalized = normalizeObotUrl(value);
+  window.localStorage.setItem(STORAGE_KEY, normalized);
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+  return normalized;
+}

--- a/docs/src/theme/CodeBlock/index.tsx
+++ b/docs/src/theme/CodeBlock/index.tsx
@@ -1,0 +1,26 @@
+import React, { type ReactNode } from "react";
+import OriginalCodeBlock from "@theme-original/CodeBlock";
+import type { Props } from "@theme/CodeBlock";
+import {
+  DEFAULT_OBOT_URL,
+  useObotUrl,
+  useObotUrlExamples,
+} from "../../lib/obotUrl";
+
+function ConfigurableCodeBlock({ children, ...props }: Props): ReactNode {
+  const obotUrl = useObotUrl();
+  const content =
+    typeof children === "string"
+      ? children.replaceAll(DEFAULT_OBOT_URL, obotUrl)
+      : children;
+
+  return <OriginalCodeBlock {...props}>{content}</OriginalCodeBlock>;
+}
+
+export default function CodeBlock(props: Props): ReactNode {
+  return useObotUrlExamples() ? (
+    <ConfigurableCodeBlock {...props} />
+  ) : (
+    <OriginalCodeBlock {...props} />
+  );
+}

--- a/docs/src/theme/NavbarItem/ComponentTypes.tsx
+++ b/docs/src/theme/NavbarItem/ComponentTypes.tsx
@@ -1,0 +1,26 @@
+import DefaultNavbarItem from "@theme/NavbarItem/DefaultNavbarItem";
+import DropdownNavbarItem from "@theme/NavbarItem/DropdownNavbarItem";
+import LocaleDropdownNavbarItem from "@theme/NavbarItem/LocaleDropdownNavbarItem";
+import SearchNavbarItem from "@theme/NavbarItem/SearchNavbarItem";
+import HtmlNavbarItem from "@theme/NavbarItem/HtmlNavbarItem";
+import DocNavbarItem from "@theme/NavbarItem/DocNavbarItem";
+import DocSidebarNavbarItem from "@theme/NavbarItem/DocSidebarNavbarItem";
+import DocsVersionNavbarItem from "@theme/NavbarItem/DocsVersionNavbarItem";
+import DocsVersionDropdownNavbarItem from "@theme/NavbarItem/DocsVersionDropdownNavbarItem";
+import ObotUrlNavbarItem from "../../components/ObotUrlNavbarItem";
+import type { ComponentTypesObject } from "@theme/NavbarItem/ComponentTypes";
+
+const ComponentTypes: ComponentTypesObject = {
+  default: DefaultNavbarItem,
+  localeDropdown: LocaleDropdownNavbarItem,
+  search: SearchNavbarItem,
+  dropdown: DropdownNavbarItem,
+  html: HtmlNavbarItem,
+  doc: DocNavbarItem,
+  docSidebar: DocSidebarNavbarItem,
+  docsVersion: DocsVersionNavbarItem,
+  docsVersionDropdown: DocsVersionDropdownNavbarItem,
+  "custom-obotUrl": ObotUrlNavbarItem,
+};
+
+export default ComponentTypes;

--- a/docs/versioned_docs/version-v0.25.0/functionality/llm-gateway.md
+++ b/docs/versioned_docs/version-v0.25.0/functionality/llm-gateway.md
@@ -4,6 +4,9 @@ title: LLM Gateway
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import ObotUrlExamples from '@site/src/components/ObotUrlExamples';
+
+<ObotUrlExamples>
 
 ## Overview
 
@@ -58,6 +61,8 @@ To use the gateway you need:
 3. **The Obot CLI.** Install and set up the `obot` CLI to obtain an API key. See [Obot CLI Setup](../installation/cli-setup.md).
 
 ## Getting your API key
+
+The examples on this page use the URL configured under **Set Obot URL** in the navigation bar.
 
 Your API key for the gateway must include LLM proxy access. Print one with the CLI:
 
@@ -307,8 +312,6 @@ claude --model anthropic.claude-haiku-4-5
   </TabItem>
 </Tabs>
 
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in the selected base URL.
-
 `--model` is optional, but it is useful since Claude Code does not support model discovery with AWS Bedrock. The default models presented by Claude Code's model selector should be compatible with our Bedrock provider as long as the corresponding Bedrock model ID is enabled in Obot.
 
 For more details, see Claude Code's [Route Mantle through a gateway](https://code.claude.com/docs/en/amazon-bedrock#route-mantle-through-a-gateway) documentation.
@@ -339,8 +342,6 @@ claude --model my-claude-deployment
 
   </TabItem>
 </Tabs>
-
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in both the selected base URL and the `obot login` command.
 
 `ANTHROPIC_FOUNDRY_API_KEY` contains an Obot gateway token in this setup, not an Azure API key; Obot replaces it with the configured Azure credential before forwarding the request. The value passed to `--model` must be the exact Azure deployment name listed in the Anthropic-compatible Azure section on the Models page.
 
@@ -373,8 +374,6 @@ Codex works with the OpenAI passthrough. Because Codex uses the OpenAI **Respons
    env_key_instructions = "Set OBOT_API_KEY and restart to authenticate with the Obot LLM Gateway"
    supports_websockets = false
    ```
-
-   For a local deployment, use `base_url = "http://localhost:8080/api/llm-proxy/openai"`.
 
 2. Set your API key and start Codex:
 
@@ -437,11 +436,9 @@ supports_websockets = false
   </TabItem>
 </Tabs>
 
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in the selected base URL.
-
 ### Codex with Azure
 
-Codex can use an Azure deployment whose model dialect is `OpenAIResponses`. Add the configuration for your Azure authentication method to `~/.codex/config.toml`, replacing the example deployment name and Obot URL:
+Codex can use an Azure deployment whose model dialect is `OpenAIResponses`. Add the configuration for your Azure authentication method to `~/.codex/config.toml`, replacing the example deployment name:
 Azure does not support Codex's built-in server-side web search, so disable it in the Codex configuration.
 
 <Tabs groupId="azure-auth">
@@ -479,8 +476,6 @@ supports_websockets = false
   </TabItem>
 </Tabs>
 
-For a local Obot server, replace `https://obot.example.com` with `http://localhost:8080` in the selected base URL.
-
 See the Codex documentation for details:
 
 - [Configuration reference](https://developers.openai.com/codex/config-reference) (the `[model_providers]` keys)
@@ -506,3 +501,5 @@ See the Codex documentation for details:
 - [Claude Code: Route Mantle through a gateway](https://code.claude.com/docs/en/amazon-bedrock#route-mantle-through-a-gateway)
 - [AWS Bedrock Anthropic model cards](https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards-anthropic.html) — check Anthropic model region availability
 - [Audit Log Export](../configuration/audit-log-export.md) — export LLM gateway audit logs
+
+</ObotUrlExamples>

--- a/docs/versioned_docs/version-v0.25.0/installation/cli-setup.md
+++ b/docs/versioned_docs/version-v0.25.0/installation/cli-setup.md
@@ -2,6 +2,10 @@
 title: Obot CLI Setup
 ---
 
+import ObotUrlExamples from '@site/src/components/ObotUrlExamples';
+
+<ObotUrlExamples>
+
 The `obot setup` command prepares your local workstation to use an Obot server from the command line and from supported local AI clients.
 
 Use it after an Obot server is running and reachable from your machine.
@@ -33,16 +37,10 @@ If Obot authentication is enabled but no provider is configured yet, finish serv
 
 ## Basic usage
 
-Run setup with your Obot app URL:
+Run setup with your Obot app URL. The examples on this page use the URL configured under **Set Obot URL** in the navigation bar.
 
 ```bash
 obot setup --url https://obot.example.com
-```
-
-For a local Docker deployment using the default port:
-
-```bash
-obot setup --url http://localhost:8080
 ```
 
 If authentication is required, the CLI opens a browser to complete login. After login succeeds, setup saves the default URL and asks where to install local bootstrap skills.
@@ -146,3 +144,5 @@ Pass `--clients agents`, `--clients claude-code`, `--clients agents,claude-code`
 ### Existing URL mismatch
 
 If setup reports that another Obot URL is already configured, pass `--yes` to replace the stored default URL.
+
+</ObotUrlExamples>


### PR DESCRIPTION
Improve copy/paste ability from docs by allowing users to set their own URL
<img width="1624" height="1500" alt="Screenshot 2026-07-20 at 16 16 29" src="https://github.com/user-attachments/assets/4dc29323-fdad-446a-bba2-acdd8a87cdcd" />
<img width="1624" height="1500" alt="Screenshot 2026-07-20 at 16 16 34" src="https://github.com/user-attachments/assets/4323f458-af9e-4761-b309-18dd505f3ec0" />
