### PR TITLE
Chore: Drop experimental from generic responses

### DIFF
--- a/ui/user/src/routes/admin/model-providers/+page.svelte
+++ b/ui/user/src/routes/admin/model-providers/+page.svelte
@@ -169,7 +169,6 @@
 		<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 			{#each sortedModelProviders as modelProvider (modelProvider.id)}
 				<ProviderCard
-					experimental={modelProvider.id === CommonModelProviderIds.GENERIC_RESPONSES}
 					provider={modelProvider}
 					deprecated={modelProvider.id === CommonModelProviderIds.ANTHROPIC_BEDROCK}
 					onConfigure={async () => {


### PR DESCRIPTION
The Responses Compatible Generic Model Provider no longer needs to be
marked as experimental.

Signed-off-by: Craig Jellick <craig@obot.ai>
