### PR TITLE
Fix: Use correct email for license

### DIFF
--- a/ui/user/src/lib/components/admin/license/LicenseDowngradeDialog.svelte
+++ b/ui/user/src/lib/components/admin/license/LicenseDowngradeDialog.svelte
@@ -76,9 +76,9 @@
 		<div class="flex flex-col gap-4">
 			<p class="font-light">
 				To re-enable full access to existing functionality, please contact support at
-				<a href="mailto:licensing@obot.ai" class="text-link">licensing@obot.ai</a> to renew your license.
+				<a href="mailto:info@obot.ai" class="text-link">info@obot.ai</a> to renew your license.
 			</p>
-			<a href="mailto:licensing@obot.ai" class="btn btn-primary">
+			<a href="mailto:info@obot.ai" class="btn btn-primary">
 				<Mail class="size-4" />
 				Contact Support
 			</a>

--- a/ui/user/src/lib/components/admin/license/LicenseProviderDialog.svelte
+++ b/ui/user/src/lib/components/admin/license/LicenseProviderDialog.svelte
@@ -47,11 +47,11 @@
 			<p>
 				{#if provider?.configured}
 					Your license for or access to {provider.name} is invalid. Please contact support at
-					<a href="mailto:licensing@obot.ai" class="text-link">licensing@obot.ai</a> to renew your license.
+					<a href="mailto:info@obot.ai" class="text-link">info@obot.ai</a> to renew your license.
 				{:else}
 					A valid license is required to use {provider.name}. Please contact support at
-					<a href="mailto:licensing@obot.ai" class="text-link">licensing@obot.ai</a> for more information
-					or to purchase a license.
+					<a href="mailto:info@obot.ai" class="text-link">info@obot.ai</a> for more information or to
+					purchase a license.
 				{/if}
 			</p>
 		{/if}

--- a/ui/user/src/routes/admin/license/+page.svelte
+++ b/ui/user/src/routes/admin/license/+page.svelte
@@ -127,8 +127,8 @@
 						<Info class="size-6" />
 						<div>
 							Interested in purchasing a license or want to learn more? Contact support at <a
-								href="mailto:licensing@obot.ai"
-								class="text-link">licensing@obot.ai</a
+								href="mailto:info@obot.ai"
+								class="text-link">info@obot.ai</a
 							>.
 						</div>
 					</div>
@@ -139,8 +139,7 @@
 						<CircleAlert class="size-6" />
 						<div>
 							The license key is <b class="font-semibold">invalid</b>. Please contact support at
-							<a href="mailto:licensing@obot.ai" class="text-link">licensing@obot.ai</a> to renew your
-							license.
+							<a href="mailto:info@obot.ai" class="text-link">info@obot.ai</a> to renew your license.
 						</div>
 					</div>
 				</div>

--- a/ui/user/src/routes/admin/skills/+page.svelte
+++ b/ui/user/src/routes/admin/skills/+page.svelte
@@ -337,7 +337,7 @@
 				<p class="text-muted-content text-sm font-light">
 					An issue occurred with fetching skills due to licensing. Please resolve outstanding
 					licensing issues or contact support at
-					<a href="mailto:licensing@obot.ai" class="text-link">licensing@obot.ai</a>.
+					<a href="mailto:info@obot.ai" class="text-link">info@obot.ai</a>.
 				</p>
 			</div>
 		{:else}

--- a/ui/user/src/routes/admin/skills/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/skills/[id]/+page.svelte
@@ -22,7 +22,7 @@
 				<p class="text-muted-content text-sm font-light">
 					An issue occurred with fetching the skill due to licensing. Please resolve outstanding
 					licensing issues or contact support at
-					<a href="mailto:licensing@obot.ai" class="text-link">licensing@obot.ai</a>.
+					<a href="mailto:info@obot.ai" class="text-link">info@obot.ai</a>.
 				</p>
 			</div>
 		{:else if skill}


### PR DESCRIPTION
We were directing peopel to licensing@obot.ai, which is not a valid
email.

addresses https://github.com/obot-platform/obot/issues/7226

Signed-off-by: Craig Jellick <craig@obot.ai>
