### PR TITLE
fix: ensure composite and remote servers report available

### DIFF
--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -1186,6 +1186,20 @@ func (h *Handler) ShutdownIdleServers(req router.Request, resp router.Response) 
 	return nil
 }
 
+// SetNonDeployServerStatus sets the deployment status for servers that don't have a corresponding deployment.
+func (h *Handler) SetNonDeployServerStatus(req router.Request, _ router.Response) error {
+	mcpServer := req.Object.(*v1.MCPServer)
+	if mcpServer.Spec.Manifest.Runtime == types.RuntimeRemote || mcpServer.Spec.Manifest.Runtime == types.RuntimeComposite {
+		mcpServer.Status.DeploymentStatus = "Available"
+		mcpServer.Status.DeploymentAvailableReplicas = nil
+		mcpServer.Status.DeploymentReadyReplicas = nil
+		mcpServer.Status.DeploymentReplicas = nil
+		mcpServer.Status.DeploymentConditions = nil
+	}
+
+	return nil
+}
+
 // clearOAuthStatusIfSet clears the OAuthCredentialConfigured status if it is currently set.
 func clearOAuthStatusIfSet(req router.Request, server *v1.MCPServer) error {
 	if server.Status.OAuthCredentialConfigured {

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -141,6 +141,7 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureMCPServerSecretInfo)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.EnsureCompositeComponents)
 	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.ShutdownIdleServers)
+	root.Type(&v1.MCPServer{}).HandlerFunc(mcpserver.SetNonDeployServerStatus)
 	root.Type(&v1.MCPServer{}).FinalizeFunc(v1.MCPServerFinalizer, credentialCleanup.RemoveMCPCredentials)
 
 	// MCPNetworkPolicy


### PR DESCRIPTION
We added a change where composite and remote MCP servers now longer have deployments. This led to errouneous or unknown deployment statuses. This change ensures that such servers always have their deployment status set to available.

Issues: https://github.com/obot-platform/obot/issues/7220, https://github.com/obot-platform/obot/issues/7221