### PR TITLE
enhance: add quick start guides for custom catalog entries & mcp access policy

### DIFF
--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -3,7 +3,8 @@
 		PAGE_TRANSITION_DURATION,
 		ADMIN_SESSION_STORAGE,
 		DEFAULT_MCP_CATALOG_ID,
-		ADMIN_ALL_OPTION
+		ADMIN_ALL_OPTION,
+		MCP_ACCESS_POLICY_FIELD_IDS
 	} from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
@@ -320,11 +321,14 @@
 			>
 				<div class="flex flex-col gap-6">
 					<div class="flex flex-col gap-2">
-						<label for="mcp-catalog-name" class="flex-1 text-sm font-light capitalize">
+						<label
+							for={MCP_ACCESS_POLICY_FIELD_IDS.name}
+							class="flex-1 text-sm font-light capitalize"
+						>
 							Name
 						</label>
 						<input
-							id="mcp-catalog-name"
+							id={MCP_ACCESS_POLICY_FIELD_IDS.name}
 							bind:value={accessControlRule.displayName}
 							class="text-input-filled mt-0.5"
 							disabled={readonly}
@@ -334,17 +338,22 @@
 			</div>
 		{/if}
 
-		<div class="flex flex-col gap-2">
+		<div id={MCP_ACCESS_POLICY_FIELD_IDS.usersGroupsSection} class="flex flex-col gap-2">
 			<div class="mb-2 flex items-center justify-between">
 				<h2 class="text-lg font-semibold">User & Groups</h2>
 				{#if !readonly}
 					<div class="relative flex items-center gap-4">
 						{#if loadingUsersAndGroups}
-							<button class="btn btn-primary flex items-center gap-1 text-sm" disabled>
+							<button
+								id={MCP_ACCESS_POLICY_FIELD_IDS.addUserGroupBtn}
+								class="btn btn-primary flex items-center gap-1 text-sm"
+								disabled
+							>
 								<Plus class="size-4" /> Add User/Group
 							</button>
 						{:else}
 							<button
+								id={MCP_ACCESS_POLICY_FIELD_IDS.addUserGroupBtn}
 								class="btn btn-primary flex items-center gap-1 text-sm"
 								onclick={() => {
 									addUserGroupDialog?.open();
@@ -391,12 +400,13 @@
 			{/if}
 		</div>
 
-		<div class="flex flex-col gap-2">
+		<div id={MCP_ACCESS_POLICY_FIELD_IDS.serversSection} class="flex flex-col gap-2">
 			<div class="mb-2 flex items-center justify-between">
 				<h2 class="text-lg font-semibold">Servers</h2>
 				{#if !readonly}
 					<div class="relative flex items-center gap-4">
 						<button
+							id={MCP_ACCESS_POLICY_FIELD_IDS.addServerBtn}
 							class="btn btn-primary flex items-center gap-1 text-sm"
 							onclick={() => {
 								addMcpServerDialog?.open();
@@ -435,10 +445,10 @@
 			out:fly={{ x: -100, duration }}
 			in:fly={{ x: -100 }}
 		>
-			<div class="flex w-full justify-end gap-2">
+			<div class="flex w-full justify-end gap-4">
 				{#if !accessControlRule.id}
 					<button
-						class="btn btn-secondary btn-sm"
+						class="btn btn-secondary"
 						onclick={() => {
 							if (redirect) {
 								goto(redirect);
@@ -452,7 +462,8 @@
 						Cancel
 					</button>
 					<button
-						class="btn btn-primary btn-sm"
+						id={MCP_ACCESS_POLICY_FIELD_IDS.saveBtn}
+						class="btn btn-primary"
 						disabled={!validate(accessControlRule) || saving}
 						onclick={async () => {
 							if (!id) return;

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
 	import { HttpError } from '$lib/errors';
 	import { highlightFirstAvailableField } from '$lib/form';
 	import Loading from '$lib/icons/Loading.svelte';
@@ -55,6 +56,17 @@
 		onConfigureOAuth?: () => void;
 	}
 
+	let {
+		id,
+		entity = 'catalog',
+		entry,
+		readonly,
+		type: newType = 'hosted',
+		onCancel,
+		onSubmit,
+		readonlyMessage,
+		onConfigureOAuth
+	}: Props = $props();
 	function getType(entry?: MCPCatalogEntry | MCPCatalogServer) {
 		if (!entry) return undefined;
 		if (entry.type === 'mcpserver') {
@@ -70,19 +82,7 @@
 		}
 	}
 
-	let {
-		id,
-		entity = 'catalog',
-		entry,
-		readonly,
-		type: newType = 'hosted',
-		onCancel,
-		onSubmit,
-		readonlyMessage,
-		onConfigureOAuth
-	}: Props = $props();
 	let type = $derived(getType(entry) ?? newType);
-
 	let savedEntry = $state<MCPCatalogEntry | MCPCatalogServer>();
 	let selectRulesDialog = $state<ReturnType<typeof SelectMcpAccessControlRules>>();
 	let showRequired = $state<Record<string, boolean>>({});
@@ -93,20 +93,6 @@
 	let secretBindingTargets = $state<MCPAllowedSecretBindingTarget[]>();
 
 	let formData = $state<RuntimeFormData>(untrack(() => convertToFormData(entry)));
-	const fieldIds = {
-		name: 'catalog-server-name',
-		description: 'catalog-server-description-label',
-		descriptionHint: 'catalog-server-description-hint',
-		shortDescription: 'catalog-server-short-description',
-		shortDescriptionHint: 'catalog-server-short-description-hint',
-		shortDescriptionCount: 'catalog-server-short-description-count',
-		shortDescriptionError: 'catalog-server-short-description-error',
-		icon: 'catalog-server-icon',
-		serverType: 'catalog-server-tenancy-type-label',
-		serverTypeHint: 'catalog-server-tenancy-hint',
-		nameError: 'catalog-server-name-error',
-		formError: 'catalog-server-form-error'
-	};
 
 	const isAtLeastPowerUserPlus = $derived(profile.current?.groups.includes(Group.POWERUSER_PLUS));
 	const showEgressDomains = $derived(!!version.current.mcpNetworkPolicyEnabled);
@@ -645,7 +631,7 @@
 		if (Object.keys(required).length > 0 || Object.keys(invalid).length > 0) {
 			showRequired = required;
 			showInvalid = invalid;
-			highlightFirstAvailableField({ ...required, ...invalid }, fieldIds);
+			highlightFirstAvailableField({ ...required, ...invalid }, CATALOG_SERVER_FIELD_IDS);
 			return;
 		}
 
@@ -714,9 +700,11 @@
 	class="flex flex-col gap-8"
 	novalidate
 	onsubmit={handleFormSubmit}
-	aria-describedby={Object.keys(showRequired).length > 0 ? fieldIds.formError : undefined}
+	aria-describedby={Object.keys(showRequired).length > 0
+		? CATALOG_SERVER_FIELD_IDS.formError
+		: undefined}
 >
-	<section class="paper p-4" id="catalog-server-form-details">
+	<section class="paper p-4" id={CATALOG_SERVER_FIELD_IDS.serverFormDetails}>
 		<div class="flex flex-col gap-8">
 			{#if readonly && readonlyMessage}
 				<div class="notification-info p-3 text-sm font-light" role="status">
@@ -729,9 +717,9 @@
 				</div>
 			{/if}
 
-			<div class="flex flex-col gap-1">
+			<div class="flex flex-col gap-1" id={`${CATALOG_SERVER_FIELD_IDS.name}-container`}>
 				<label
-					for={fieldIds.name}
+					for={CATALOG_SERVER_FIELD_IDS.name}
 					class={twMerge('text-sm font-light capitalize', showRequired.name && 'error')}
 				>
 					Name
@@ -742,27 +730,29 @@
 				</label>
 				<input
 					type="text"
-					id={fieldIds.name}
+					id={CATALOG_SERVER_FIELD_IDS.name}
 					name="name"
 					bind:value={formData.name}
 					class={twMerge('text-input-filled dark:bg-base-100', showRequired.name && 'error')}
 					disabled={readonly}
 					aria-required={!readonly ? 'true' : undefined}
 					aria-invalid={showRequired.name ? 'true' : undefined}
-					aria-describedby={showRequired.name ? fieldIds.nameError : undefined}
+					aria-describedby={showRequired.name ? CATALOG_SERVER_FIELD_IDS.nameError : undefined}
 					oninput={() => {
 						updateRequired('name');
 					}}
 				/>
 				{#if showRequired.name}
-					<p id={fieldIds.nameError} class="text-xs text-error" role="alert">Name is required</p>
+					<p id={CATALOG_SERVER_FIELD_IDS.nameError} class="text-xs text-error" role="alert">
+						Name is required
+					</p>
 				{/if}
 			</div>
 
-			<div class="flex flex-col gap-1">
-				<span id={fieldIds.description} class="text-sm font-light capitalize">
+			<div class="flex flex-col gap-1" id={`${CATALOG_SERVER_FIELD_IDS.description}-container`}>
+				<span id={CATALOG_SERVER_FIELD_IDS.description} class="text-sm font-light capitalize">
 					Description
-					<span id={fieldIds.descriptionHint} class="text-muted-content text-xs">
+					<span id={CATALOG_SERVER_FIELD_IDS.descriptionHint} class="text-muted-content text-xs">
 						(Markdown syntax supported)
 					</span>
 				</span>
@@ -770,14 +760,17 @@
 					bind:value={formData.description}
 					disabled={readonly}
 					placeholder="Provide details about the MCP catalog entry."
-					labelledBy={fieldIds.description}
-					describedBy={fieldIds.descriptionHint}
+					labelledBy={CATALOG_SERVER_FIELD_IDS.description}
+					describedBy={CATALOG_SERVER_FIELD_IDS.descriptionHint}
 				/>
 			</div>
 
-			<div class="flex flex-col gap-1">
+			<div
+				class="flex flex-col gap-1"
+				id={`${CATALOG_SERVER_FIELD_IDS.shortDescription}-container`}
+			>
 				<label
-					for={fieldIds.shortDescription}
+					for={CATALOG_SERVER_FIELD_IDS.shortDescription}
 					class={twMerge('text-sm font-light capitalize', hasShortDescriptionError && 'error')}
 				>
 					Short Description
@@ -785,13 +778,16 @@
 						<span class={hasShortDescriptionError ? 'text-error' : ''} aria-hidden="true">*</span>
 						<span class="sr-only">(required)</span>
 					{/if}
-					<span id={fieldIds.shortDescriptionHint} class="text-muted-content text-xs">
+					<span
+						id={CATALOG_SERVER_FIELD_IDS.shortDescriptionHint}
+						class="text-muted-content text-xs"
+					>
 						(max {MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH} characters)
 					</span>
 				</label>
 				<input
 					type="text"
-					id={fieldIds.shortDescription}
+					id={CATALOG_SERVER_FIELD_IDS.shortDescription}
 					name="shortDescription"
 					bind:value={formData.shortDescription}
 					class={twMerge('text-input-filled dark:bg-base-100', hasShortDescriptionError && 'error')}
@@ -799,9 +795,11 @@
 					placeholder="Provide a brief summary that will be shown in catalog listings."
 					maxlength={MAX_CATALOG_ENTRY_SHORT_DESCRIPTION_LENGTH}
 					aria-required={!readonly ? 'true' : undefined}
-					aria-describedby={`${fieldIds.shortDescriptionHint} ${fieldIds.shortDescriptionCount}`}
+					aria-describedby={`${CATALOG_SERVER_FIELD_IDS.shortDescriptionHint} ${CATALOG_SERVER_FIELD_IDS.shortDescriptionCount}`}
 					aria-invalid={hasShortDescriptionError ? 'true' : undefined}
-					aria-errormessage={hasShortDescriptionError ? fieldIds.shortDescriptionError : undefined}
+					aria-errormessage={hasShortDescriptionError
+						? CATALOG_SERVER_FIELD_IDS.shortDescriptionError
+						: undefined}
 					oninput={() => {
 						updateInvalid('shortDescription');
 						updateRequired('shortDescription');
@@ -809,14 +807,18 @@
 				/>
 				<div class="flex justify-between gap-4">
 					{#if hasShortDescriptionError}
-						<p id={fieldIds.shortDescriptionError} class="text-xs text-error" role="alert">
+						<p
+							id={CATALOG_SERVER_FIELD_IDS.shortDescriptionError}
+							class="text-xs text-error"
+							role="alert"
+						>
 							{shortDescriptionError}
 						</p>
 					{:else}
 						<p></p>
 					{/if}
 					<span
-						id={fieldIds.shortDescriptionCount}
+						id={CATALOG_SERVER_FIELD_IDS.shortDescriptionCount}
 						class={twMerge(
 							'pl-0.5 text-xs text-muted-content flex justify-end',
 							showInvalid.shortDescription && 'text-error'
@@ -828,11 +830,13 @@
 				</div>
 			</div>
 
-			<div class="flex flex-col gap-1">
-				<label for={fieldIds.icon} class="text-sm font-light capitalize">Icon URL</label>
+			<div class="flex flex-col gap-1" id={`${CATALOG_SERVER_FIELD_IDS.icon}-container`}>
+				<label for={CATALOG_SERVER_FIELD_IDS.icon} class="text-sm font-light capitalize"
+					>Icon URL</label
+				>
 				<input
 					type="text"
-					id={fieldIds.icon}
+					id={CATALOG_SERVER_FIELD_IDS.icon}
 					name="icon"
 					bind:value={formData.icon}
 					class="text-input-filled dark:bg-base-100"
@@ -847,10 +851,12 @@
 	{#if type === 'hosted'}
 		<section
 			class="paper p-4"
-			aria-labelledby="catalog-server-tenancy-heading"
-			id="catalog-server-tenancy"
+			aria-labelledby={`${CATALOG_SERVER_FIELD_IDS.tenancy}-heading`}
+			id={CATALOG_SERVER_FIELD_IDS.tenancy}
 		>
-			<h4 id="catalog-server-tenancy-heading" class="text-sm font-semibold">Server Tenancy</h4>
+			<h4 id={`${CATALOG_SERVER_FIELD_IDS.tenancy}-heading`} class="text-sm font-semibold">
+				Server Tenancy
+			</h4>
 
 			{#if entity === 'catalog'}
 				<div class="notification-info" role="status">
@@ -867,7 +873,7 @@
 			{/if}
 
 			<div class="flex items-center gap-4">
-				<span id={fieldIds.serverType} class="text-sm font-light">Type</span>
+				<span id={CATALOG_SERVER_FIELD_IDS.serverType} class="text-sm font-light">Type</span>
 				<div class="w-full">
 					<Select
 						id="server-configuration-selector"
@@ -877,8 +883,8 @@
 							{ id: 'singleUser', label: 'Single-tenant' }
 						]}
 						selected={formData.serverUserType}
-						ariaLabelledby={fieldIds.serverType}
-						ariaDescribedby={fieldIds.serverTypeHint}
+						ariaLabelledby={CATALOG_SERVER_FIELD_IDS.serverType}
+						ariaDescribedby={CATALOG_SERVER_FIELD_IDS.serverTypeHint}
 						onSelect={(option) => {
 							formData.serverUserType = option.id as 'singleUser' | 'multiUser';
 							formData.multiUserConfig =
@@ -898,7 +904,7 @@
 				</div>
 			</div>
 
-			<p id={fieldIds.serverTypeHint} class="text-muted-content text-xs">
+			<p id={CATALOG_SERVER_FIELD_IDS.serverTypeHint} class="text-muted-content text-xs">
 				{#if entity === 'catalog'}
 					Set tenancy to <i>Single-tenant</i> if each user should connect to their own private
 					instance of the server. <br />
@@ -919,89 +925,91 @@
 	/>
 
 	<!-- Runtime-specific Forms -->
-	{#if formData.runtime === 'npx' && formData.npxConfig}
-		<NpxRuntimeForm
-			bind:config={formData.npxConfig}
-			{showEgressDomains}
-			{defaultDenyAllEgress}
-			bind:startupTimeoutSeconds={formData.startupTimeoutSeconds}
-			{readonly}
-			{showRequired}
-			onFieldChange={updateRequired}
-		/>
-	{:else if formData.runtime === 'uvx' && formData.uvxConfig}
-		<UvxRuntimeForm
-			bind:config={formData.uvxConfig}
-			{showEgressDomains}
-			{defaultDenyAllEgress}
-			bind:startupTimeoutSeconds={formData.startupTimeoutSeconds}
-			{readonly}
-			{showRequired}
-			onFieldChange={updateRequired}
-		/>
-	{:else if formData.runtime === 'containerized' && formData.containerizedConfig}
-		<ContainerizedRuntimeForm
-			bind:config={formData.containerizedConfig}
-			{showEgressDomains}
-			{defaultDenyAllEgress}
-			bind:startupTimeoutSeconds={formData.startupTimeoutSeconds}
-			{readonly}
-			{showRequired}
-			onFieldChange={updateRequired}
-		/>
-	{:else if formData.runtime === 'remote' && type === 'multi' && formData.remoteServerConfig}
-		<RemoteRuntimeForm
-			bind:config={formData.remoteServerConfig}
-			variant="server"
-			{readonly}
-			{showRequired}
-			onFieldChange={updateRequired}
-			isNewEntry={!entry}
-			{onConfigureOAuth}
-			secretBindingTargets={editableSecretBindingTargets}
-		>
-			{#snippet afterHeaders()}
-				{#if secretBoundHeaders.length > 0}
-					<CustomConfigurationForm
-						bind:config={formData.env}
-						{readonly}
-						serverUserType={formData.serverUserType}
-						{secretBoundHeaders}
-						showRequired={showRequired.env}
-					/>
-				{/if}
-			{/snippet}
-		</RemoteRuntimeForm>
-	{:else if formData.runtime === 'remote' && formData.remoteConfig}
-		<RemoteRuntimeForm
-			bind:config={formData.remoteConfig}
-			{readonly}
-			{showRequired}
-			onFieldChange={updateRequired}
-			isNewEntry={!entry}
-			{onConfigureOAuth}
-		>
-			{#snippet afterHeaders()}
-				{#if secretBoundHeaders.length > 0}
-					<CustomConfigurationForm
-						bind:config={formData.env}
-						{readonly}
-						serverUserType={formData.serverUserType}
-						{secretBoundHeaders}
-						showRequired={showRequired.env}
-					/>
-				{/if}
-			{/snippet}
-		</RemoteRuntimeForm>
-	{:else if formData.runtime === 'composite' && formData.compositeConfig}
-		<CompositeRuntimeForm
-			bind:config={formData.compositeConfig}
-			bind:hasToolNameErrors={compositeHasToolNameErrors}
-			{readonly}
-			catalogId={id}
-			id={entry?.id}
-		/>
-	{/if}
+	<div class="flex flex-col gap-8" id={`${CATALOG_SERVER_FIELD_IDS.runtimeConfiguration}`}>
+		{#if formData.runtime === 'npx' && formData.npxConfig}
+			<NpxRuntimeForm
+				bind:config={formData.npxConfig}
+				{showEgressDomains}
+				{defaultDenyAllEgress}
+				bind:startupTimeoutSeconds={formData.startupTimeoutSeconds}
+				{readonly}
+				{showRequired}
+				onFieldChange={updateRequired}
+			/>
+		{:else if formData.runtime === 'uvx' && formData.uvxConfig}
+			<UvxRuntimeForm
+				bind:config={formData.uvxConfig}
+				{showEgressDomains}
+				{defaultDenyAllEgress}
+				bind:startupTimeoutSeconds={formData.startupTimeoutSeconds}
+				{readonly}
+				{showRequired}
+				onFieldChange={updateRequired}
+			/>
+		{:else if formData.runtime === 'containerized' && formData.containerizedConfig}
+			<ContainerizedRuntimeForm
+				bind:config={formData.containerizedConfig}
+				{showEgressDomains}
+				{defaultDenyAllEgress}
+				bind:startupTimeoutSeconds={formData.startupTimeoutSeconds}
+				{readonly}
+				{showRequired}
+				onFieldChange={updateRequired}
+			/>
+		{:else if formData.runtime === 'remote' && type === 'multi' && formData.remoteServerConfig}
+			<RemoteRuntimeForm
+				bind:config={formData.remoteServerConfig}
+				variant="server"
+				{readonly}
+				{showRequired}
+				onFieldChange={updateRequired}
+				isNewEntry={!entry}
+				{onConfigureOAuth}
+				secretBindingTargets={editableSecretBindingTargets}
+			>
+				{#snippet afterHeaders()}
+					{#if secretBoundHeaders.length > 0}
+						<CustomConfigurationForm
+							bind:config={formData.env}
+							{readonly}
+							serverUserType={formData.serverUserType}
+							{secretBoundHeaders}
+							showRequired={showRequired.env}
+						/>
+					{/if}
+				{/snippet}
+			</RemoteRuntimeForm>
+		{:else if formData.runtime === 'remote' && formData.remoteConfig}
+			<RemoteRuntimeForm
+				bind:config={formData.remoteConfig}
+				{readonly}
+				{showRequired}
+				onFieldChange={updateRequired}
+				isNewEntry={!entry}
+				{onConfigureOAuth}
+			>
+				{#snippet afterHeaders()}
+					{#if secretBoundHeaders.length > 0}
+						<CustomConfigurationForm
+							bind:config={formData.env}
+							{readonly}
+							serverUserType={formData.serverUserType}
+							{secretBoundHeaders}
+							showRequired={showRequired.env}
+						/>
+					{/if}
+				{/snippet}
+			</RemoteRuntimeForm>
+		{:else if formData.runtime === 'composite' && formData.compositeConfig}
+			<CompositeRuntimeForm
+				bind:config={formData.compositeConfig}
+				bind:hasToolNameErrors={compositeHasToolNameErrors}
+				{readonly}
+				catalogId={id}
+				id={entry?.id}
+			/>
+		{/if}
+	</div>
 
 	{#if version.current.engine === 'kubernetes' && !['remote', 'composite'].includes(formData.runtime) && formData.resources}
 		<ResourceRuntimeForm
@@ -1033,7 +1041,7 @@
 		>
 			{#if Object.keys(showRequired).length > 0}
 				<span
-					id={fieldIds.formError}
+					id={CATALOG_SERVER_FIELD_IDS.formError}
 					class="text-sm font-medium text-error"
 					role="alert"
 					tabindex="-1"
@@ -1045,7 +1053,7 @@
 				type="button"
 				class="btn btn-secondary flex items-center gap-1"
 				onclick={() => onCancel?.()}
-				id="catalog-server-form-cancel"
+				id={CATALOG_SERVER_FIELD_IDS.cancelBtn}
 			>
 				Cancel
 			</button>
@@ -1059,7 +1067,7 @@
 							formData.compositeConfig.componentServers.length === 0 ||
 							compositeHasToolNameErrors))}
 				aria-busy={loading}
-				id="catalog-server-form-submit"
+				id={CATALOG_SERVER_FIELD_IDS.submitBtn}
 			>
 				{#if loading}
 					<span aria-hidden="true">

--- a/ui/user/src/lib/components/admin/SearchMcpServers.svelte
+++ b/ui/user/src/lib/components/admin/SearchMcpServers.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ADMIN_ALL_OPTION } from '$lib/constants';
+	import { ADMIN_ALL_OPTION, MCP_ACCESS_POLICY_FIELD_IDS } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
 	import {
@@ -175,10 +175,11 @@
 </script>
 
 <ResponsiveDialog
+	id="search-mcp-servers-dialog"
 	bind:this={addMcpServerDialog}
 	{onClose}
 	{title}
-	class="h-full w-full overflow-visible md:h-[500px] md:max-w-md"
+	class="h-full w-full overflow-visible md:h-125 md:max-w-md"
 	classes={{ header: 'p-4 md:pb-0', content: 'min-h-inherit p-0' }}
 >
 	<div class="default-scrollbar-thin flex grow flex-col gap-4 overflow-y-auto pt-1">
@@ -200,6 +201,9 @@
 				<div class="flex flex-col">
 					{#each filteredData as item (item.id)}
 						<button
+							id={item.id === '*'
+								? MCP_ACCESS_POLICY_FIELD_IDS.everythingOption
+								: `search-mcp-server-${item.id}`}
 							class={twMerge(
 								'dark:hover:bg-base-200 hover:bg-base-300 flex w-full items-center gap-2 px-4 py-2 text-left',
 								selectedMap.has(item.id) && 'bg-base-200/50'
@@ -268,12 +272,21 @@
 			</div>
 			<div class="flex items-center gap-2">
 				<button
+					id="search-mcp-servers-cancel-btn"
 					class="btn btn-secondary w-full md:w-fit"
 					onclick={() => addMcpServerDialog?.close()}
 				>
 					Cancel
 				</button>
-				<button class="btn btn-primary w-full md:w-fit" onclick={handleAdd}> Confirm </button>
+				<button
+					id={type === 'acr'
+						? MCP_ACCESS_POLICY_FIELD_IDS.serverConfirmBtn
+						: 'search-mcp-servers-confirm-btn'}
+					class="btn btn-primary w-full md:w-fit"
+					onclick={handleAdd}
+				>
+					Confirm
+				</button>
 			</div>
 		{/if}
 	</div>

--- a/ui/user/src/lib/components/admin/SearchUsers.svelte
+++ b/ui/user/src/lib/components/admin/SearchUsers.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { MCP_ACCESS_POLICY_FIELD_IDS } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { UserService, type OrgGroup, type OrgUser } from '$lib/services';
 	import { getUserRoleLabel } from '$lib/utils';
@@ -122,11 +123,12 @@
 </script>
 
 <ResponsiveDialog
+	id="add-user-group-dialog"
 	bind:this={addUserGroupDialog}
 	{onClose}
 	{onOpen}
 	title="Add User/Group"
-	class="h-full w-full overflow-visible md:h-[500px] md:max-w-md"
+	class="h-full w-full overflow-visible md:h-125 md:max-w-md"
 	classes={{ header: 'p-4 md:pb-0', content: 'min-h-inherit p-0' }}
 >
 	<div class="default-scrollbar-thin flex grow flex-col gap-4 overflow-y-auto pt-1">
@@ -149,6 +151,7 @@
 			<div class="flex flex-col">
 				{#each filteredData ?? [] as item (item.id)}
 					<button
+						id={item.id === '*' ? MCP_ACCESS_POLICY_FIELD_IDS.allUsersOption : undefined}
 						class={twMerge(
 							'dark:hover:bg-base-200 hover:bg-base-400 flex items-center gap-2 px-4 py-2 text-left',
 							selectedUsersMap.has(item.id) && 'bg-base-200/50'
@@ -202,6 +205,7 @@
 				Cancel
 			</button>
 			<button
+				id={MCP_ACCESS_POLICY_FIELD_IDS.userGroupConfirmBtn}
 				class="btn btn-primary w-full md:w-fit"
 				onclick={() => {
 					const users = selectedUsers.filter((user) => !isGroup(user)) as OrgUser[];

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogDetails.svelte
@@ -153,7 +153,7 @@
 					{#if auditLog.user || additRequestContent}
 						<div class="flex flex-col gap-1 px-4 py-2 text-sm font-light">
 							{#if auditLog.user}
-								<p class="grid grid-cols-2 gap-2">
+								<p class="grid grid-cols-2 gap-2 break-all">
 									<span class="font-medium">User:</span>
 									{auditLog.user}
 								</p>

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogEventDetails.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogEventDetails.svelte
@@ -243,7 +243,10 @@
 
 {#snippet field(label: string, value: string | number | undefined | null)}
 	{#if value !== undefined && value !== null && value !== ''}
-		<p class="grid grid-cols-2 gap-2"><span class="font-medium">{label}:</span> {value}</p>
+		<p class="grid grid-cols-2 gap-2 break-all">
+			<span class="font-medium">{label}:</span>
+			{value}
+		</p>
 	{/if}
 {/snippet}
 

--- a/ui/user/src/lib/components/guides/GuidePanel.svelte
+++ b/ui/user/src/lib/components/guides/GuidePanel.svelte
@@ -21,9 +21,10 @@
 	import { fade, fly } from 'svelte/transition';
 
 	const CONTENT_FADE_MS = 500;
-	// Short poll after clicks (nav expand). Highlight waits separately for post-nav targets.
 	const ACTION_RESOLVE_ATTEMPTS = 10;
 	const ACTION_RESOLVE_INTERVAL_MS = 50;
+	const WAIT_FOR_TIMEOUT_MS = 5 * 60 * 1000;
+	const WAIT_FOR_INTERVAL_MS = 500;
 
 	function youtubeEmbedUrl(url: string): string | undefined {
 		try {
@@ -255,11 +256,12 @@
 		}
 	});
 
-	/** True when a step/action still has listener, next (Next-button chain), or dialog work. */
+	/** True when a step/action still has listener, next (Next-button chain), dialog, or waitFor work. */
 	function actionHasPendingChain(action: GuideAction | GuideAction[] | undefined): boolean {
 		if (!action) return false;
 		for (const a of Array.isArray(action) ? action : [action]) {
 			if (a.dialog) return true;
+			if (a.waitFor) return true;
 			if (a.listener) {
 				// Listener requires progression; nested actions under it are also pending.
 				return true;
@@ -314,6 +316,37 @@
 
 	function isCurrentGuideSession(generation: number) {
 		return generation === guideSessionGeneration && Boolean(guide.selectedGuide);
+	}
+
+	function isOpenDialog(id: string): boolean {
+		const el = document.getElementById(id);
+		return el instanceof HTMLDialogElement && el.open;
+	}
+
+	async function waitForOpenDialog(
+		id: string,
+		sessionGeneration: number,
+		generation: number
+	): Promise<boolean> {
+		const stepAtStart = guide.currentStep;
+		const start = Date.now();
+		while (Date.now() - start < WAIT_FOR_TIMEOUT_MS) {
+			if (
+				generation !== actionGeneration ||
+				!isCurrentGuideSession(sessionGeneration) ||
+				guide.currentStep !== stepAtStart
+			) {
+				return false;
+			}
+			if (isOpenDialog(id)) return true;
+			await sleep(WAIT_FOR_INTERVAL_MS);
+		}
+		return (
+			generation === actionGeneration &&
+			isCurrentGuideSession(sessionGeneration) &&
+			guide.currentStep === stepAtStart &&
+			isOpenDialog(id)
+		);
 	}
 
 	function findListenerTarget(listener: GuideListener): HTMLElement | undefined {
@@ -524,6 +557,21 @@
 
 		if (resolved.closeExistingElement) {
 			closeGuideElement(resolved);
+		}
+
+		if (resolved.waitFor) {
+			const stepAtStart = guide.currentStep;
+			const opened = await waitForOpenDialog(resolved.waitFor, sessionGeneration, generation);
+			if (
+				!opened ||
+				generation !== actionGeneration ||
+				!isCurrentGuideSession(sessionGeneration) ||
+				guide.currentStep !== stepAtStart
+			) {
+				return;
+			}
+			handleNextStep();
+			return;
 		}
 
 		if (resolved.highlight) {

--- a/ui/user/src/lib/components/guides/Guides.svelte
+++ b/ui/user/src/lib/components/guides/Guides.svelte
@@ -218,7 +218,7 @@
 		{/if}
 		<div
 			id="btn-get-started-guide"
-			class="flex bg-primary rounded-full text-primary-content text-sm items-center gap-2 shadow-md"
+			class="flex items-center gap-2 rounded-full bg-primary text-primary-content text-sm shadow-lg shadow-black/40 outline-2 outline-offset-0 outline-base-100/80 dark:outline-base-300/80"
 		>
 			<button
 				class="shrink-0 flex items-center gap-2 w-fit py-3 pl-4"
@@ -242,7 +242,7 @@
 		<h4 class="font-semibold border-b-2 pb-3 mb-3 text-sm border-b-primary-content">
 			Quick Start Guides
 		</h4>
-		<div class="flex flex-col gap-2">
+		<div class="flex flex-col">
 			{#each visibleLessonItems as lessonItem (lessonItem.label)}
 				{@const isUnderConstruction = lessonItem.guide === undefined}
 				<button

--- a/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
+++ b/ui/user/src/lib/components/mcp/CatalogConfigureForm.svelte
@@ -817,6 +817,7 @@
 				</button>
 			{/if}
 			<button
+				id="mcp-catalog-configure-submit-btn"
 				class="btn btn-primary"
 				type="submit"
 				form="mcp-catalog-configure-form"

--- a/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
@@ -358,6 +359,7 @@
 </script>
 
 <div
+	id={CATALOG_SERVER_FIELD_IDS.compositeEntries}
 	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 >
 	<h4 class="text-md font-semibold">Component Entries</h4>
@@ -403,6 +405,7 @@
 							</IconButton>
 						{/if}
 						<IconButton
+							id={`${CATALOG_SERVER_FIELD_IDS.compositeEntryToolCollapseBtn}-${componentId}`}
 							tooltip={{ text: expanded[componentId] ? 'Collapse' : 'Expand' }}
 							onclick={() => (expanded[componentId] = !expanded[componentId])}
 						>
@@ -636,6 +639,7 @@
 
 	{#if !readonly}
 		<button
+			id={CATALOG_SERVER_FIELD_IDS.addCompositeEntryBtn}
 			type="button"
 			onclick={() => {
 				configuringEntry = undefined;

--- a/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
@@ -84,7 +84,7 @@
 		{/if}
 	</div>
 
-	<div class="flex w-full flex-col gap-1">
+	<div class="flex w-full flex-col gap-1" id={`${id}-value-type-container`}>
 		{@render label('Value', `env-value-type-${id}`)}
 		<Select
 			class="bg-base-100 dark:border-base-400 border border-transparent shadow-none"
@@ -196,7 +196,7 @@
 {/snippet}
 
 {#snippet keyInput()}
-	<div class="flex w-full flex-col gap-1">
+	<div class="flex w-full flex-col gap-1" id={`${id}-key-container`}>
 		{@render label('Key', `env-key-${id}`, true, missingKey)}
 		<input
 			id={`env-key-${id}`}
@@ -210,7 +210,7 @@
 {/snippet}
 
 {#snippet nameAndDescriptionInputs()}
-	<div class="flex w-full flex-col gap-1">
+	<div class="flex w-full flex-col gap-1" id={`${id}-name-container`}>
 		{@render label('Name', `env-name-${id}`, true, missingName)}
 		<input
 			id={`env-name-${id}`}
@@ -220,7 +220,7 @@
 			disabled={readonly || isPrebuiltEntry}
 		/>
 	</div>
-	<div class="flex w-full flex-col gap-1">
+	<div class="flex w-full flex-col gap-1" id={`${id}-description-container`}>
 		{@render label('Description', `env-description-${id}`, false)}
 		<input
 			id={`env-description-${id}`}

--- a/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
 	import type { MCPAllowedSecretBindingTarget, MCPCatalogEntryFieldManifest } from '$lib/services';
 	import { hasSecretBinding } from '$lib/services/user/mcp';
 	import Select from '../Select.svelte';
@@ -54,6 +55,7 @@
 {#if !readonly || (readonly && userConfig.length > 0)}
 	<div
 		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+		id={CATALOG_SERVER_FIELD_IDS.configuration}
 	>
 		<h4 class="text-sm font-semibold">
 			{serverUserType === 'singleUser' ? 'User Supplied Configuration' : 'Configuration'}
@@ -108,7 +110,7 @@
 						</p>
 
 						<CustomConfigurationFieldset
-							id={`env-${i}`}
+							id={`${CATALOG_SERVER_FIELD_IDS.env}-${i}`}
 							bind:data={config![i]}
 							{serverUserType}
 							{readonly}
@@ -122,6 +124,7 @@
 					</div>
 					{#if !readonly && !isPrebuiltEntry}
 						<IconButton
+							id={`${CATALOG_SERVER_FIELD_IDS.removeConfigurationBtn}-${i}`}
 							variant="danger"
 							onclick={() => {
 								config!.splice(i, 1);
@@ -138,6 +141,7 @@
 		{#if !readonly && !isPrebuiltEntry}
 			<div class="flex justify-end">
 				<button
+					id={CATALOG_SERVER_FIELD_IDS.addConfigurationBtn}
 					class="btn btn-secondary btn-sm flex items-center gap-1 text-xs"
 					type="button"
 					onclick={() => {

--- a/ui/user/src/lib/components/mcp/MultiUserHeadersForm.svelte
+++ b/ui/user/src/lib/components/mcp/MultiUserHeadersForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
 	import type { MCPSubField } from '$lib/services';
 	import InfoTooltip from '../InfoTooltip.svelte';
 	import Toggle from '../Toggle.svelte';
@@ -15,6 +16,7 @@
 
 <div
 	class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
+	id={CATALOG_SERVER_FIELD_IDS.headers}
 >
 	<div class="flex flex-col gap-1">
 		<h4 class="text-sm font-semibold">User-Defined Headers</h4>

--- a/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
 	import type { MCPAllowedSecretBindingTarget } from '$lib/services';
 	import type {
 		RemoteCatalogConfigAdmin,
@@ -75,7 +76,7 @@
 </script>
 
 {#snippet remoteHeaders(showUrlTemplateHelp: boolean)}
-	<div class="flex w-full flex-col gap-8" in:slide>
+	<div id={CATALOG_SERVER_FIELD_IDS.remoteHeaders} class="flex w-full flex-col gap-8" in:slide>
 		<div
 			class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 		>
@@ -261,6 +262,7 @@
 {#if variant === 'server'}
 	{@const serverConfig = config as RemoteRuntimeConfigAdmin}
 	<div
+		id={CATALOG_SERVER_FIELD_IDS.remoteURL}
 		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-6 rounded-lg border border-transparent p-4 shadow-sm"
 		in:fade={{ duration: 200 }}
 	>
@@ -293,6 +295,7 @@
 	{@const remoteConfig = config as RemoteCatalogConfigAdmin}
 	<!-- For catalog entries, show simple fixed URL when not in advanced mode -->
 	<div
+		id={CATALOG_SERVER_FIELD_IDS.remoteURL}
 		class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-6 rounded-lg border border-transparent p-4 shadow-sm"
 		in:fade={{ duration: 200 }}
 	>
@@ -317,6 +320,7 @@
 {:else if showAdvanced}
 	<div class="flex w-full flex-col gap-8" in:slide>
 		<div
+			id={CATALOG_SERVER_FIELD_IDS.remoteConnection}
 			class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 		>
 			<div class="flex items-center gap-4 {readonly ? 'hidden' : ''}">
@@ -461,6 +465,7 @@
 	{#if config && !disableStaticOAuth}
 		{@const remoteConfig = config as RemoteCatalogConfigAdmin}
 		<div
+			id={CATALOG_SERVER_FIELD_IDS.remoteStaticOAuth}
 			class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4 shadow-sm"
 		>
 			<div class="flex justify-between">
@@ -531,6 +536,7 @@
 
 {#if variant === 'catalog'}
 	<button
+		id={CATALOG_SERVER_FIELD_IDS.remoteAdvancedBtn}
 		type="button"
 		class="btn btn-text pl-0"
 		onclick={() => {

--- a/ui/user/src/lib/components/mcp/RuntimeSelector.svelte
+++ b/ui/user/src/lib/components/mcp/RuntimeSelector.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
 	import type { LaunchServerType, Runtime } from '$lib/services/user/types';
 	import Select from '../Select.svelte';
 	import { twMerge } from 'tailwind-merge';
@@ -67,10 +68,10 @@
 		'paper p-4',
 		serverType === 'remote' || serverType === 'composite' ? 'hidden' : ''
 	)}
-	aria-labelledby="runtime-selector-heading"
-	id="runtime-selector"
+	aria-labelledby={`${CATALOG_SERVER_FIELD_IDS.runtime}-heading`}
+	id={CATALOG_SERVER_FIELD_IDS.runtime}
 >
-	<h4 id="runtime-selector-heading" class="text-sm font-semibold">Runtime</h4>
+	<h4 id={`${CATALOG_SERVER_FIELD_IDS.runtime}-heading`} class="text-sm font-semibold">Runtime</h4>
 
 	<div class="flex items-center gap-4">
 		<span id="runtime-selector-label" class="text-sm font-light">Type</span>

--- a/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
@@ -2,6 +2,7 @@
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import Search from '$lib/components/Search.svelte';
 	import Toggle from '$lib/components/Toggle.svelte';
+	import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
 	import type { CompositeServerToolRow, MCPCatalogEntry, MCPCatalogServer } from '$lib/services';
 	import {
 		conflictIssue,
@@ -153,6 +154,7 @@
 </script>
 
 <ResponsiveDialog
+	id={CATALOG_SERVER_FIELD_IDS.compositeEntryEditToolsDialog}
 	bind:this={dialog}
 	animate="slide"
 	title={`Configure ${configuringEntry?.manifest?.name ?? 'MCP Server'} Tools`}
@@ -206,7 +208,10 @@
 				</p>
 			{/if}
 		</div>
-		<div class="flex w-full justify-end">
+		<div
+			class="flex w-full justify-end"
+			id={CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsToggleAll}
+		>
 			<Toggle
 				checked={allToolsEnabled}
 				onChange={(checked) => {
@@ -240,6 +245,7 @@
 			{@const conflict = tool.enabled ? conflictIssue(effectiveName, conflictSet) : undefined}
 			<div
 				class="dark:bg-base-300 dark:border-base-400 bg-base-100 flex items-start gap-2 rounded border border-transparent p-2 shadow-sm"
+				id={`edit-tool-${tool.id}`}
 			>
 				<div class="flex min-w-0 grow flex-col gap-2">
 					<div class="flex items-start justify-between gap-2">
@@ -336,6 +342,7 @@
 	<div class="bg-base-200 sticky bottom-0 left-0 mt-4 flex w-full justify-end gap-2 p-4">
 		<button class="btn btn-secondary" onclick={handleCancel}>Cancel</button>
 		<button
+			id={CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsConfirmBtn}
 			class="btn btn-primary"
 			disabled={hasBlockingToolNameErrors || prefixIssue?.severity === 'error'}
 			onclick={() => {

--- a/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import SearchMcpServers from '$lib/components/admin/SearchMcpServers.svelte';
+	import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
@@ -364,6 +365,7 @@
 />
 
 <ResponsiveDialog
+	id={CATALOG_SERVER_FIELD_IDS.compositeEntryChoice}
 	bind:this={choiceDialog}
 	animate="slide"
 	title={`Configure ${configuringEntry?.manifest?.name ?? 'MCP Server'} Tools`}
@@ -386,6 +388,7 @@
 	<div class="flex w-full flex-col gap-2">
 		<button
 			class="button"
+			id={CATALOG_SERVER_FIELD_IDS.compositeEntrySkipBtn}
 			onclick={() => {
 				if (!componentConfig || !configuringEntry) return;
 				onSuccess?.(componentConfig, configuringEntry);
@@ -396,6 +399,7 @@
 		</button>
 		<button
 			class="btn btn-primary"
+			id={CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsBtn}
 			onclick={() => {
 				if (!configuringEntry) return;
 				ready = false;
@@ -409,6 +413,7 @@
 </ResponsiveDialog>
 
 <ResponsiveDialog
+	id={CATALOG_SERVER_FIELD_IDS.compositeConfigureEntryToolsDialog}
 	bind:this={initConfigureToolsDialog}
 	animate="slide"
 	title={`Configure ${configuringEntry?.manifest?.name ?? 'MCP Server'} Tools`}
@@ -476,6 +481,7 @@
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 				{:else}
 					<button
+						id={CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsGetStartedBtn}
 						class="btn btn-primary flex w-full justify-center"
 						disabled={loading || !!secretBindingEngineError}
 						onclick={handleConfigureToolsInit}

--- a/ui/user/src/lib/components/navbar/Profile.svelte
+++ b/ui/user/src/lib/components/navbar/Profile.svelte
@@ -90,6 +90,7 @@
 
 	let setPreferredClientsDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let selectedClients = $state<AiClient[]>([]);
+	let menu = $state<ReturnType<typeof Menu>>();
 
 	const clientsMap = $derived(new Map(COMMON_AI_CLIENTS.map((client) => [client.id, client])));
 	const clients = $derived.by(() => {
@@ -168,6 +169,7 @@
 </script>
 
 <Menu
+	bind:this={menu}
 	title={profile.current.displayName || 'Anonymous'}
 	slide={responsive.isMobile ? 'left' : undefined}
 	fixed={responsive.isMobile}
@@ -247,7 +249,7 @@
 			{/if}
 			{#if !impersonating}
 				{#if profile.current.email && !page.url.pathname.startsWith('/profile')}
-					<MyAccount />
+					<MyAccount onClose={() => menu?.toggle(false)} />
 				{/if}
 				{#if showApiKeysLink}
 					<a href={resolve('/keys')} role="menuitem" class="dropdown-link"
@@ -259,6 +261,7 @@
 					onclick={() => {
 						selectedClients = userDeviceSettings.aiClientPreference ?? [];
 						setPreferredClientsDialog?.open();
+						menu?.toggle(false);
 					}}
 				>
 					<Terminal class="size-4" /> Client Preference

--- a/ui/user/src/lib/components/profile/MyAccount.svelte
+++ b/ui/user/src/lib/components/profile/MyAccount.svelte
@@ -10,6 +10,12 @@
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import { User } from '@lucide/svelte';
 
+	interface Props {
+		onClose?: () => void;
+	}
+
+	let { onClose }: Props = $props();
+
 	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let toDelete = $state(false);
 	let toRevoke = $state(false);
@@ -53,7 +59,12 @@
 	}
 </script>
 
-<button class="dropdown-link" onclick={() => dialog?.open()}>
+<button
+	class="dropdown-link"
+	onclick={() => {
+		dialog?.open();
+	}}
+>
 	<User class="size-4" /> My Account
 </button>
 
@@ -62,6 +73,7 @@
 	title="My Account"
 	class="w-full max-w-lg"
 	classes={{ content: 'p-6' }}
+	{onClose}
 >
 	<img
 		src={profile.current.iconURL}

--- a/ui/user/src/lib/constants.ts
+++ b/ui/user/src/lib/constants.ts
@@ -339,3 +339,66 @@ export const OBOT_GUIDE_KEYS = {
 } as const;
 
 export const AI_CLIENT_PREFERENCE_KEY = 'aiClientPreference';
+
+// IDs
+export const CATALOG_SERVER_FIELD_IDS = {
+	serverFormDetails: 'catalog-server-form-details',
+	name: 'catalog-server-name',
+	description: 'catalog-server-description-label',
+	descriptionHint: 'catalog-server-description-hint',
+	shortDescription: 'catalog-server-short-description',
+	shortDescriptionHint: 'catalog-server-short-description-hint',
+	shortDescriptionCount: 'catalog-server-short-description-count',
+	shortDescriptionError: 'catalog-server-short-description-error',
+	icon: 'catalog-server-icon',
+	serverType: 'catalog-server-tenancy-type-label',
+	serverTypeHint: 'catalog-server-tenancy-hint',
+	nameError: 'catalog-server-name-error',
+	formError: 'catalog-server-form-error',
+	tenancy: 'catalog-server-tenancy',
+	runtime: 'catalog-server-runtime',
+	runtimeConfiguration: 'catalog-server-runtime-configuration',
+	configuration: 'catalog-server-configuration',
+	addConfigurationBtn: 'catalog-server-add-configuration-btn',
+	env: 'catalog-server-env',
+	header: 'catalog-server-header',
+	headers: 'catalog-server-user-headers',
+	remoteURL: 'catalog-server-remote-url',
+	remoteAdvancedBtn: 'catalog-server-remote-advanced-btn',
+	remoteConnection: 'catalog-server-remote-connection',
+	remoteHeaders: 'catalog-server-remote-headers',
+	remoteStaticOAuth: 'catalog-server-remote-static-oauth',
+	compositeEntries: 'catalog-server-composite-entries',
+	addCompositeEntryBtn: 'catalog-server-add-composite-entry-btn',
+	submitBtn: 'catalog-server-form-submit',
+	cancelBtn: 'catalog-server-form-cancel',
+	removeConfigurationBtn: 'catalog-server-remove-configuration-btn',
+	compositeEntryChoice: 'catalog-server-composite-entry-choice',
+	compositeConfigureEntryToolsDialog: 'catalog-server-composite-entry-configure-tools',
+	compositeEntrySearchMcpServersDialog: 'search-mcp-servers-dialog',
+	compositeEntrySearchMcpServersConfirmBtn: 'search-mcp-servers-confirm-btn',
+	compositeEntrySearchMcpServersCancelBtn: 'search-mcp-servers-cancel-btn',
+	compositeEntrySkipBtn: 'composite-entry-choice-skip-btn',
+	compositeEntryConfigureToolsBtn: 'composite-entry-choice-configure-tools-btn',
+	compositeEntryConfigureToolsGetStartedBtn:
+		'composite-entry-choice-configure-tools-get-started-btn',
+	compositeEntryConfigureToolsToggleAll: 'composite-entry-choice-configure-tools-toggle-all',
+	compositeEntryConfigureToolsConfirmBtn: 'composite-entry-choice-configure-tools-confirm-btn',
+	compositeEntryToolCollapseBtn: 'composite-entry-tool-collapse-btn',
+	compositeEntryEditToolsDialog: 'composite-entry-edit-tools-dialog'
+};
+
+export const MCP_ACCESS_POLICY_FIELD_IDS = {
+	addPolicyBtn: 'mcp-access-policy-add-btn',
+	addPolicyEmptyBtn: 'mcp-access-policy-empty-add-btn',
+	name: 'mcp-access-policy-name',
+	usersGroupsSection: 'mcp-access-policy-users-groups-section',
+	addUserGroupBtn: 'mcp-access-policy-add-user-group-btn',
+	allUsersOption: 'mcp-access-policy-all-users-option',
+	userGroupConfirmBtn: 'mcp-access-policy-user-group-confirm-btn',
+	serversSection: 'mcp-access-policy-servers-section',
+	addServerBtn: 'mcp-access-policy-add-server-btn',
+	everythingOption: 'mcp-access-policy-everything-option',
+	serverConfirmBtn: 'mcp-access-policy-server-confirm-btn',
+	saveBtn: 'mcp-access-policy-save-btn'
+} as const;

--- a/ui/user/src/lib/services/guides/accesspolicy/create.ts
+++ b/ui/user/src/lib/services/guides/accesspolicy/create.ts
@@ -1,0 +1,201 @@
+import { MCP_ACCESS_POLICY_FIELD_IDS } from '$lib/constants';
+import { getExpandAdvancedPaneAction } from '../actions';
+import {
+	highlightMcpAccessPoliciesLink,
+	listenMcpAccessPoliciesLink,
+	SIDEBAR_MCP_ACCESS_POLICIES_LINK
+} from '../mcp/constants';
+import type { GuideStep } from '../types';
+
+export const steps: GuideStep[] = [
+	{
+		content: ["To get started, let's head to the MCP Access Policies page!"],
+		action: [
+			{
+				elementExists: SIDEBAR_MCP_ACCESS_POLICIES_LINK,
+				highlight: highlightMcpAccessPoliciesLink,
+				listener: listenMcpAccessPoliciesLink
+			},
+			getExpandAdvancedPaneAction({
+				elementMissing: SIDEBAR_MCP_ACCESS_POLICIES_LINK,
+				highlight: highlightMcpAccessPoliciesLink,
+				listener: listenMcpAccessPoliciesLink
+			})
+		]
+	},
+	{
+		content: [
+			'Create and manage your MCP access policies here. To start creating a new access policy, click the "Add Access Policy" button.'
+		],
+		action: {
+			routeContains: 'mcp-access-policies',
+			highlight: {
+				selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.addPolicyBtn },
+				side: 'left',
+				title: 'Add Access Policy',
+				description: 'Click here to create a new MCP access policy.'
+			},
+			listener: {
+				id: MCP_ACCESS_POLICY_FIELD_IDS.addPolicyBtn,
+				action: { success: true }
+			}
+		}
+	},
+	{
+		content: ["Let's go over the basic fields for the access policy."],
+		action: {
+			highlight: {
+				selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.name },
+				side: 'top',
+				title: 'Policy Name',
+				description: 'Enter a recognizable name for this access policy.'
+			},
+			next: {
+				action: {
+					highlight: {
+						selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.usersGroupsSection },
+						side: 'top',
+						title: 'Users & Groups',
+						description: 'Subjects added here receive access to the servers selected below.'
+					},
+					listener: {
+						id: MCP_ACCESS_POLICY_FIELD_IDS.usersGroupsSection,
+						skipClickTargetOnNext: true,
+						action: {
+							highlight: {
+								selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.addUserGroupBtn },
+								side: 'left',
+								title: 'Add User/Group',
+								description: 'Click here to add to User & Groups.'
+							},
+							listener: {
+								id: MCP_ACCESS_POLICY_FIELD_IDS.addUserGroupBtn,
+								action: {
+									highlight: {
+										selector: { id: 'add-user-group-dialog-content' },
+										title: 'Adding Users/Groups',
+										description:
+											'This is where you can add who will be able to access the catalog entries & servers.'
+									},
+									listener: {
+										id: 'add-user-group-dialog-content',
+										skipClickTargetOnNext: true,
+										action: {
+											highlight: {
+												selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.allUsersOption },
+												side: 'right',
+												title: 'Select A User/Group',
+												description:
+													"For now, let's select All Obot Users. This will grant access to everyone."
+											},
+											listener: {
+												id: MCP_ACCESS_POLICY_FIELD_IDS.allUsersOption,
+												action: {
+													highlight: {
+														selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.userGroupConfirmBtn },
+														side: 'top',
+														title: 'Confirm Selection',
+														description: 'Click here to apply your changes.'
+													},
+													listener: {
+														id: MCP_ACCESS_POLICY_FIELD_IDS.userGroupConfirmBtn,
+														action: {
+															highlight: {
+																selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.serversSection },
+																side: 'top',
+																title: 'Servers',
+																description:
+																	'This is where you can add the servers that will be available to the selected users and groups.'
+															},
+															listener: {
+																id: MCP_ACCESS_POLICY_FIELD_IDS.serversSection,
+																skipClickTargetOnNext: true,
+																action: {
+																	highlight: {
+																		selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.addServerBtn },
+																		side: 'left',
+																		title: 'Add Server',
+																		description: 'Click here to begin adding a server.'
+																	},
+																	listener: {
+																		id: MCP_ACCESS_POLICY_FIELD_IDS.addServerBtn,
+																		action: {
+																			highlight: {
+																				selector: { id: 'search-mcp-servers-dialog-content' },
+																				title: 'Adding A Server',
+																				description:
+																					'From here, you can search and add any servers that you want to make available to the selected users and groups.'
+																			},
+																			listener: {
+																				id: 'search-mcp-servers-dialog-content',
+																				skipClickTargetOnNext: true,
+																				action: {
+																					highlight: {
+																						selector: {
+																							id: MCP_ACCESS_POLICY_FIELD_IDS.everythingOption
+																						},
+																						side: 'right',
+																						title: 'Add a Server',
+																						description:
+																							"For this guide, let's go ahead and add everything. You can choose to modify this later."
+																					},
+																					listener: {
+																						id: MCP_ACCESS_POLICY_FIELD_IDS.everythingOption,
+																						action: {
+																							highlight: {
+																								selector: {
+																									id: MCP_ACCESS_POLICY_FIELD_IDS.serverConfirmBtn
+																								},
+																								side: 'top',
+																								title: 'Confirm Changes',
+																								description: 'Click here to apply your changes.'
+																							},
+																							listener: {
+																								id: MCP_ACCESS_POLICY_FIELD_IDS.serverConfirmBtn,
+																								action: {
+																									highlight: {
+																										selector: {
+																											id: MCP_ACCESS_POLICY_FIELD_IDS.saveBtn
+																										},
+																										side: 'left',
+																										title: 'Save Access Policy',
+																										description:
+																											"Once you've finished configuring the access policy, you can save it here."
+																									},
+																									listener: {
+																										id: MCP_ACCESS_POLICY_FIELD_IDS.saveBtn,
+																										skipClickTargetOnNext: true,
+																										action: { success: true }
+																									}
+																								}
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+];
+
+export default {
+	steps,
+	title: 'Create MCP Access Policy',
+	description: 'Grant users and groups access to MCP servers.',
+	id: 'mcp-create-access-policy-guide'
+};

--- a/ui/user/src/lib/services/guides/actions.ts
+++ b/ui/user/src/lib/services/guides/actions.ts
@@ -1,5 +1,6 @@
 import type { GuideAction, GuideHighlight, GuideListener } from './types';
 
+// shared action that can be used in multiple guides
 export function getExpandAdvancedPaneAction({
 	elementMissing,
 	highlight,

--- a/ui/user/src/lib/services/guides/index.ts
+++ b/ui/user/src/lib/services/guides/index.ts
@@ -1,4 +1,7 @@
 export { default as McpConnectGuide } from './mcp/connect';
-export { default as McpCreateCustomGuide } from './mcp/customMcp';
+export { default as McpCustomHostedGuide } from './mcp/customHosted';
+export { default as McpCustomRemoteGuide } from './mcp/customRemote';
+export { default as McpCustomCompositeGuide } from './mcp/customComposite';
+export { default as McpAccessPolicyCreateGuide } from './accesspolicy/create';
 export { default as SkillsInstallGuide } from './skills/install';
 export * from './types';

--- a/ui/user/src/lib/services/guides/mcp/constants.ts
+++ b/ui/user/src/lib/services/guides/mcp/constants.ts
@@ -32,3 +32,12 @@ export const listenMcpAccessPoliciesLink: GuideListener = {
 		success: true
 	}
 };
+
+export const addCatalogEntryDescriptions = {
+	hosted:
+		'A hosted catalog entry is great for setting up an MCP server hosted under the Obot platform.',
+	remote:
+		'A remote catalog entry is great for allowing users to connect to MCP servers that are already elsewhere. When they deploy from Obot, the MCP server will go through the gateway.',
+	composite:
+		'A composite catalog entry is great for combining tools from multiple existing MCP servers into single deployment. You can also configure which tools to expose and customize their names or descriptions.'
+};

--- a/ui/user/src/lib/services/guides/mcp/customComposite.ts
+++ b/ui/user/src/lib/services/guides/mcp/customComposite.ts
@@ -1,0 +1,222 @@
+import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
+import type { GuideStep } from '../types';
+import { addCatalogEntryDescriptions } from './constants';
+import {
+	getHighlightAddCatalogEntryStep,
+	getNavigateBasicCatalogEntryFieldsStep,
+	getNavigateToMCPCatalogStep
+} from './steps';
+
+export const steps: GuideStep[] = [
+	{
+		content: ['What is a composite catalog entry?', addCatalogEntryDescriptions.composite]
+	},
+	getNavigateToMCPCatalogStep(),
+	getHighlightAddCatalogEntryStep('composite'),
+	getNavigateBasicCatalogEntryFieldsStep(),
+	{
+		content: [
+			'Composite servers present tools from multiple existing MCP servers through one catalog entry.',
+			"Let's go through the process of adding a component entry to the composite server."
+		],
+		action: {
+			highlight: {
+				selector: { id: CATALOG_SERVER_FIELD_IDS.compositeEntries },
+				side: 'top',
+				align: 'center',
+				title: 'Component Entries',
+				description:
+					'This list contains the catalog entries and deployed multi-user servers whose tools will be combined into the composite server.'
+			},
+			next: {
+				action: {
+					highlight: {
+						selector: { id: CATALOG_SERVER_FIELD_IDS.addCompositeEntryBtn },
+						side: 'top',
+						align: 'center',
+						title: 'Add Component Entry',
+						description: 'Click here to begin adding a component entry to the composite server.'
+					},
+					listener: {
+						id: CATALOG_SERVER_FIELD_IDS.addCompositeEntryBtn,
+						action: {
+							highlight: {
+								selector: {
+									id: `${CATALOG_SERVER_FIELD_IDS.compositeEntrySearchMcpServersDialog}-content`
+								},
+								side: 'right',
+								title: 'Adding Component Entries',
+								description:
+									'Here you can add the component entries that will be combined into the composite server.'
+							},
+							listener: {
+								id: `${CATALOG_SERVER_FIELD_IDS.compositeEntrySearchMcpServersDialog}-content`,
+								skipClickTargetOnNext: true,
+								action: {
+									highlight: {
+										selector: {
+											beginsWith: ['search-mcp-server-default-antv-charts']
+										},
+										title: 'Add a Component Entry',
+										description:
+											"For this example, let's go ahead and select AntV Charts as a component entry."
+									},
+									listener: {
+										beginsWith: ['search-mcp-server-default-antv-charts'],
+										action: {
+											highlight: {
+												selector: {
+													id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsBtn
+												},
+												side: 'right',
+												title: 'Configure Tools',
+												description:
+													"Let's go ahead and configure the tools for this component entry."
+											},
+											listener: {
+												id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsBtn,
+												action: {
+													highlight: {
+														selector: {
+															id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsGetStartedBtn
+														},
+														title: 'Get Started',
+														description:
+															"In order to get the tools, we'll need to supply any required configuration to deploy the entry. Similarly, when a user deploys this composite server, they'll also have to provide the required configuration details for each component entry."
+													},
+													listener: {
+														id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsGetStartedBtn,
+														action: {
+															highlight: {
+																selector: {
+																	id: 'mcp-catalog-configure-submit-btn'
+																},
+																side: 'left',
+																title: 'Configure the Entry',
+																description:
+																	'Luckily, this entry does not have any required configuration. Go ahead and click Continue.'
+															},
+															listener: {
+																id: 'mcp-catalog-configure-submit-btn',
+																action: {
+																	success: true
+																}
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	{
+		content: ['__Waiting for tools to be fetched...__'],
+		action: {
+			waitFor: CATALOG_SERVER_FIELD_IDS.compositeEntryEditToolsDialog
+		}
+	},
+	{
+		content: [
+			'Each component keeps its own configuration and authentication requirements. You can also choose which tools to expose and customize their names or descriptions.'
+		],
+		action: {
+			highlight: {
+				selector: { id: CATALOG_SERVER_FIELD_IDS.compositeEntryEditToolsDialog },
+				title: 'Configuring Entry Tools',
+				description:
+					'This is the tool configuration dialog for the component entry that was just added. From here, you can choose which tools to expose and customize their names or descriptions.'
+			},
+			listener: {
+				id: CATALOG_SERVER_FIELD_IDS.compositeEntryEditToolsDialog,
+				skipClickTargetOnNext: true,
+				action: {
+					highlight: {
+						selector: { id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsToggleAll },
+						side: 'bottom',
+						align: 'center',
+						title: 'Toggle All Tools',
+						description:
+							'If you want to enable or disable all tools at once, you can use this toggle.'
+					},
+					listener: {
+						id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsToggleAll,
+						skipClickTargetOnNext: true,
+						action: {
+							highlight: {
+								selector: {
+									beginsWith: ['edit-tool-']
+								},
+								side: 'right',
+								title: 'Toggle a Tool',
+								description:
+									'You choose individually which tools to expose and customize their names or descriptions.'
+							},
+							listener: {
+								beginsWith: ['edit-tool-'],
+								skipClickTargetOnNext: true,
+								action: {
+									highlight: {
+										selector: {
+											id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsConfirmBtn
+										},
+										side: 'left',
+										title: 'Save Tools',
+										description:
+											"Once you have configured the tools, you can confirm the changes by clicking the button here. For now, let's just confirm the changes."
+									},
+									listener: {
+										id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsConfirmBtn,
+										action: {
+											highlight: {
+												selector: {
+													beginsWith: [`${CATALOG_SERVER_FIELD_IDS.compositeEntryToolCollapseBtn}-`]
+												},
+												side: 'left',
+												title: 'See Added Tools & Update',
+												description:
+													'If you want to make additional changes, you can expand the tools you just added and edit them from here. Go ahead and expand this to see.'
+											},
+											listener: {
+												beginsWith: [`${CATALOG_SERVER_FIELD_IDS.compositeEntryToolCollapseBtn}-`],
+												skipClickTargetOnNext: true,
+												action: {
+													highlight: {
+														selector: { id: CATALOG_SERVER_FIELD_IDS.submitBtn },
+														side: 'left',
+														title: 'Save the entry',
+														description:
+															'Once you have finished configuring the composite catalog entry, you can save here.'
+													},
+													listener: {
+														id: CATALOG_SERVER_FIELD_IDS.submitBtn,
+														skipClickTargetOnNext: true,
+														action: { success: true }
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+];
+
+export default {
+	steps,
+	title: 'Create a Composite MCP Server',
+	description:
+		'Combine multiple existing MCP servers & apply fine-grained access control on their tools.',
+	id: 'mcp-create-composite-guide'
+};

--- a/ui/user/src/lib/services/guides/mcp/customHosted.ts
+++ b/ui/user/src/lib/services/guides/mcp/customHosted.ts
@@ -1,0 +1,173 @@
+import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
+import type { GuideAction, GuideListener, GuideStep } from '../types';
+import { addCatalogEntryDescriptions } from './constants';
+import {
+	getHighlightAddCatalogEntryStep,
+	getNavigateBasicCatalogEntryFieldsStep,
+	getNavigateToMCPCatalogStep
+} from './steps';
+
+function getCustomConfigurationAction(): GuideAction[] {
+	const configurationHighlight = {
+		selector: {
+			id: CATALOG_SERVER_FIELD_IDS.configuration
+		},
+		side: 'top' as const,
+		align: 'center' as const,
+		title: 'Custom Configuration'
+	};
+
+	const configurationListener = {
+		id: CATALOG_SERVER_FIELD_IDS.configuration,
+		action: {
+			success: true
+		}
+	};
+
+	return [
+		{
+			routeContains: 'admin',
+			highlight: {
+				...configurationHighlight,
+				description:
+					"If the MCP server requires any custom configuration such as API keys or secrets, you'll want to add them here. For multi-tenancy, you can supply configuration that'll be used by all users or set up it so each user can supply their own. In single-tenancy, the user will have to provide their custom configuration when deploying the server."
+			},
+			listener: configurationListener
+		},
+		{
+			highlight: {
+				...configurationHighlight,
+				description:
+					"If the MCP server requires any custom configuration such as API keys or secrets, you'll want to add them here. The user will have to provide their custom configuration when deploying the server."
+			},
+			listener: configurationListener
+		}
+	];
+}
+
+function getHostedFieldsListener(): GuideListener {
+	return {
+		id: CATALOG_SERVER_FIELD_IDS.tenancy,
+		action: {
+			highlight: {
+				selector: {
+					id: CATALOG_SERVER_FIELD_IDS.runtime
+				},
+				side: 'top',
+				align: 'center',
+				title: 'Runtime',
+				description: 'This is where you choose the runtime configuration for your MCP server.'
+			},
+			listener: {
+				id: CATALOG_SERVER_FIELD_IDS.runtime,
+				action: {
+					highlight: {
+						selector: {
+							id: CATALOG_SERVER_FIELD_IDS.runtimeConfiguration
+						},
+						side: 'top',
+						align: 'center',
+						title: 'Runtime Configuration',
+						description:
+							'Depending on which runtime you choose, you will see the appropriate form for that runtime form here to fill out.'
+					},
+					listener: {
+						id: CATALOG_SERVER_FIELD_IDS.runtimeConfiguration,
+						action: getCustomConfigurationAction()
+					}
+				}
+			}
+		}
+	};
+}
+
+function getHostedFieldsActions(admin: boolean): GuideAction {
+	return {
+		...(admin ? { routeContains: 'admin' } : {}),
+		highlight: {
+			selector: {
+				id: CATALOG_SERVER_FIELD_IDS.tenancy
+			},
+			side: 'top',
+			align: 'center',
+			title: 'Server Tenancy',
+			description: admin
+				? 'This is where you choose the tenancy type of your MCP server. If each user should have their own deployment, Single-tenant is recommended.'
+				: 'For any catalog entry you create, a user will deploy their own instance of the MCP server.'
+		},
+		listener: getHostedFieldsListener()
+	};
+}
+
+function getSubmitAction(): GuideAction {
+	return {
+		highlight: {
+			selector: {
+				id: CATALOG_SERVER_FIELD_IDS.submitBtn
+			},
+			side: 'left',
+			title: 'Save the entry.',
+			description: "Once you've filled out all necessary fields, you can save the entry here."
+		},
+		listener: {
+			skipClickTargetOnNext: true,
+			id: CATALOG_SERVER_FIELD_IDS.submitBtn,
+			action: {
+				success: true
+			}
+		}
+	};
+}
+
+export const steps: GuideStep[] = [
+	{
+		content: ['What is a hosted catalog entry?', addCatalogEntryDescriptions.hosted]
+	},
+	getNavigateToMCPCatalogStep(),
+	getHighlightAddCatalogEntryStep('hosted'),
+	getNavigateBasicCatalogEntryFieldsStep(),
+	{
+		content: ["Now let's go over the hosted specific fields."],
+		action: [getHostedFieldsActions(true), getHostedFieldsActions(false)]
+	},
+	{
+		content: [
+			"Once you've properly filled out the form, you'll get access to additional tabs such as:",
+			'**Server Details**: This is where you see the deployments related to the catalog entry.',
+			'**Tools**: This is where you can preview/set up the list of previewable tools for a catalog entry that a user can see before deploying the server.',
+			'**Audit Logs**: This is where you can see logs pertaining to the usage of the catalog entry.',
+			'**Usage**: This is where you can see usage metrics for the catalog entry.',
+			'**Access Policies**: This is where you can access policies pertaining to the catalog entry.',
+			'**Filters**: This is where you can see filters tied to the catalog entry.'
+		],
+		action: [
+			{
+				elementExists: CATALOG_SERVER_FIELD_IDS.headers,
+				highlight: {
+					selector: {
+						id: CATALOG_SERVER_FIELD_IDS.headers
+					},
+					side: 'top',
+					align: 'center',
+					title: 'Headers',
+					description: 'Add any headers that the MCP server requires.'
+				},
+				listener: {
+					id: CATALOG_SERVER_FIELD_IDS.headers,
+					action: getSubmitAction()
+				}
+			},
+			{
+				elementMissing: CATALOG_SERVER_FIELD_IDS.headers,
+				...getSubmitAction()
+			}
+		]
+	}
+];
+
+export default {
+	steps,
+	title: 'Host MCP Server w/ Obot',
+	description: 'Add a hosted MCP server to the catalog.',
+	id: 'mcp-create-hosted-guide'
+};

--- a/ui/user/src/lib/services/guides/mcp/customRemote.ts
+++ b/ui/user/src/lib/services/guides/mcp/customRemote.ts
@@ -1,0 +1,110 @@
+import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
+import type { GuideStep } from '../types';
+import {
+	getHighlightAddCatalogEntryStep,
+	getNavigateBasicCatalogEntryFieldsStep,
+	getNavigateToMCPCatalogStep
+} from './steps';
+
+export const steps: GuideStep[] = [
+	{
+		content: [
+			'What is a remote catalog entry?',
+			'A remote catalog entry is great for allowing users to connect to MCP servers that are already elsewhere. When they deploy from Obot, the MCP server will go through the gateway.'
+		]
+	},
+	getNavigateToMCPCatalogStep(),
+	getHighlightAddCatalogEntryStep('remote'),
+	getNavigateBasicCatalogEntryFieldsStep(),
+	{
+		content: ["Now let's go over the remote specific fields."],
+		action: {
+			highlight: {
+				selector: { id: CATALOG_SERVER_FIELD_IDS.remoteURL },
+				side: 'top',
+				align: 'center',
+				title: 'Remote Server URL',
+				description:
+					'Enter the complete MCP endpoint when every user should connect to the same exact URL.'
+			},
+			listener: {
+				id: CATALOG_SERVER_FIELD_IDS.remoteURL,
+				action: {
+					highlight: {
+						selector: { id: CATALOG_SERVER_FIELD_IDS.remoteAdvancedBtn },
+						side: 'top',
+						title: 'Advanced Configuration',
+						description:
+							"Open this section when the connection needs a hostname or URL template, custom headers, or static OAuth. Let's go ahead and open it."
+					},
+					listener: {
+						id: CATALOG_SERVER_FIELD_IDS.remoteAdvancedBtn,
+						action: {
+							elementExists: CATALOG_SERVER_FIELD_IDS.remoteConnection,
+							highlight: {
+								selector: { id: CATALOG_SERVER_FIELD_IDS.remoteConnection },
+								side: 'top',
+								align: 'center',
+								title: 'Connection Restriction',
+								description:
+									'Choose an exact URL, allow a user-configured URL on one hostname, or build a URL from a template. Template variables come from user-supplied header values.'
+							},
+							listener: {
+								id: CATALOG_SERVER_FIELD_IDS.remoteConnection,
+								action: {
+									highlight: {
+										selector: { id: CATALOG_SERVER_FIELD_IDS.remoteHeaders },
+										side: 'top',
+										align: 'center',
+										title: 'Request Headers',
+										description:
+											'Add HTTP headers required by the upstream server. Values can be fixed for everyone or requested from each user during setup; keep secrets in headers instead of URLs.'
+									},
+									listener: {
+										id: CATALOG_SERVER_FIELD_IDS.remoteHeaders,
+										skipClickTargetOnNext: true,
+										action: {
+											highlight: {
+												selector: { id: CATALOG_SERVER_FIELD_IDS.remoteStaticOAuth },
+												side: 'top',
+												align: 'center',
+												title: 'Static OAuth',
+												description:
+													'Enable this only when the provider requires a pre-registered OAuth app. The entry will need to be saved first, then the shared client ID and secret can be configured; each user will still need to complete their own OAuth login.'
+											},
+											listener: {
+												id: CATALOG_SERVER_FIELD_IDS.remoteStaticOAuth,
+												skipClickTargetOnNext: true,
+												action: {
+													highlight: {
+														selector: { id: CATALOG_SERVER_FIELD_IDS.submitBtn },
+														side: 'left',
+														title: 'Save the entry',
+														description:
+															'Once you have finished configuring the remote catalog entry, you can save here.'
+													},
+													listener: {
+														id: CATALOG_SERVER_FIELD_IDS.submitBtn,
+														skipClickTargetOnNext: true,
+														action: { success: true }
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+];
+
+export default {
+	steps,
+	title: 'Reroute a Remote MCP Through Obot',
+	description: 'Add auditing & governance to an existing MCP server.',
+	id: 'mcp-create-remote-guide'
+};

--- a/ui/user/src/lib/services/guides/mcp/steps.ts
+++ b/ui/user/src/lib/services/guides/mcp/steps.ts
@@ -1,13 +1,16 @@
+import { CATALOG_SERVER_FIELD_IDS } from '$lib/constants';
 import { getExpandAdvancedPaneAction } from '../actions';
 import type { GuideStep } from '../types';
 import {
 	highlightMcpCatalogLink,
 	listenMcpCatalogLink,
-	SIDEBAR_MCP_CATALOG_LINK
+	SIDEBAR_MCP_CATALOG_LINK,
+	addCatalogEntryDescriptions
 } from './constants';
 
-export const steps: GuideStep[] = [
-	{
+// shared steps that are used in mcp specific guides
+export function getNavigateToMCPCatalogStep(): GuideStep {
+	return {
 		content: ["To begin, let's head to the MCP Catalog page!"],
 		action: [
 			{
@@ -46,11 +49,18 @@ export const steps: GuideStep[] = [
 				}
 			}
 		]
-	},
-	{
+	};
+}
+
+export function getHighlightAddCatalogEntryStep(
+	type: 'hosted' | 'remote' | 'composite'
+): GuideStep {
+	const SECTION_ID = `add-${type}-server-button`;
+	const toCapitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
+
+	return {
 		content: [
-			'Click the Add Catalog Entry button to start creating a new entry.',
-			'For the purpose of this guide, what type of entry are you interested in creating?'
+			'Create and manage your MCP catalog entries here. To start creating a custom entry, click the "Add Catalog Entry" button.'
 		],
 		action: {
 			highlight: {
@@ -58,7 +68,7 @@ export const steps: GuideStep[] = [
 					id: 'add-catalog-entry-button'
 				},
 				title: 'Add Catalog Entry',
-				description: 'Click here to add a new catalog entry.',
+				description: 'Click here to start adding a new catalog entry.',
 				side: 'left'
 			},
 			listener: {
@@ -66,13 +76,13 @@ export const steps: GuideStep[] = [
 				action: {
 					highlight: {
 						selector: {
-							id: 'add-hosted-server-button'
+							id: SECTION_ID
 						},
-						title: 'Add Hosted Server',
-						description: 'Click here to add a hosted server entry.'
+						title: `Add ${toCapitalize(type)} Server`,
+						description: `${addCatalogEntryDescriptions[type]} Click here and let's go through creating one now.`
 					},
 					listener: {
-						id: 'add-hosted-server-button',
+						id: SECTION_ID,
 						action: {
 							success: true
 						}
@@ -80,34 +90,29 @@ export const steps: GuideStep[] = [
 				}
 			}
 		}
-	},
-	{
-		content: [
-			"We're going to use the Everything server as an example. Name and package are required, but feel free to fill out the rest of the form.",
-			"For 'Package', use the following: @modelcontextprotocol/server-everything",
-			'Go ahead and click Save.'
-		],
-		buttons: [
-			{
-				text: "I'm done, what next?",
+	};
+}
+
+export function getNavigateBasicCatalogEntryFieldsStep(): GuideStep {
+	return {
+		content: ['These are the standard fields for a catalog entry.'],
+		action: {
+			highlight: {
+				selector: {
+					id: `${CATALOG_SERVER_FIELD_IDS.serverFormDetails}`
+				},
+				side: 'top',
+				align: 'center',
+				title: 'Describe Your MCP',
+				description:
+					'This is where you provide user friendly details about your MCP server; the information here is displayed to users when previewing the catalog entry.'
+			},
+			listener: {
+				id: `${CATALOG_SERVER_FIELD_IDS.serverFormDetails}`,
 				action: {
 					success: true
 				}
 			}
-		]
-	},
-	{
-		content: [
-			'Great! You should see more options available to you now. If your server is deployed, check out the deployment details in Server Details.',
-			'For single-tenant catalog entries, it is recommended to populate the tools with an example set for users to see. This can be done in Tools.',
-			"And that's it! You've completed the guide on creating a custom MCP server."
-		]
-	}
-];
-
-export default {
-	steps,
-	title: 'Create MCP Server',
-	description: 'Add a custom MCP server to the catalog.',
-	id: 'mcp-create-custom-guide'
-};
+		}
+	};
+}

--- a/ui/user/src/lib/services/guides/types.ts
+++ b/ui/user/src/lib/services/guides/types.ts
@@ -53,6 +53,7 @@ export interface GuideAction {
 	setPreferredClient?: boolean;
 	skipClickTargetOnNext?: boolean;
 	success?: boolean;
+	waitFor?: string;
 }
 
 export interface GuideListener extends GuideSelector {

--- a/ui/user/src/lib/services/guides/utils.ts
+++ b/ui/user/src/lib/services/guides/utils.ts
@@ -3,7 +3,14 @@ import { page } from '$app/state';
 import { OBOT_GUIDE_KEYS } from '$lib/constants';
 import { Group } from '$lib/services/admin/types';
 import { profile } from '$lib/stores';
-import { SkillsInstallGuide, McpConnectGuide, McpCreateCustomGuide } from '.';
+import {
+	SkillsInstallGuide,
+	McpConnectGuide,
+	McpCustomHostedGuide,
+	McpCustomRemoteGuide,
+	McpCustomCompositeGuide,
+	McpAccessPolicyCreateGuide
+} from '.';
 import { isValid } from 'date-fns';
 
 export function generateLessonItems() {
@@ -12,13 +19,37 @@ export function generateLessonItems() {
 		page.url.pathname.includes('mcp-catalog') ||
 		page.url.pathname.includes('access-policies');
 	const isAtLeastPoweruser = profile.current.groups.includes(Group.POWERUSER);
+	const isAtLeastPowerUserPlus = profile.current.groups.includes(Group.POWERUSER_PLUS);
 	return isAdvancedRoute && isAtLeastPoweruser
 		? [
 				{
-					label: McpCreateCustomGuide.title,
-					description: McpCreateCustomGuide.description,
-					guide: McpCreateCustomGuide
-				}
+					label: McpCustomHostedGuide.title,
+					description: McpCustomHostedGuide.description,
+					guide: McpCustomHostedGuide
+				},
+				{
+					label: McpCustomRemoteGuide.title,
+					description: McpCustomRemoteGuide.description,
+					guide: McpCustomRemoteGuide
+				},
+				...(profile.current.isAdmin?.()
+					? [
+							{
+								label: McpCustomCompositeGuide.title,
+								description: McpCustomCompositeGuide.description,
+								guide: McpCustomCompositeGuide
+							}
+						]
+					: []),
+				...(isAtLeastPowerUserPlus
+					? [
+							{
+								label: McpAccessPolicyCreateGuide.title,
+								description: McpAccessPolicyCreateGuide.description,
+								guide: McpAccessPolicyCreateGuide
+							}
+						]
+					: [])
 			]
 		: [
 				{

--- a/ui/user/src/routes/admin/+page.ts
+++ b/ui/user/src/routes/admin/+page.ts
@@ -17,7 +17,10 @@ export const load: PageLoad = async ({ fetch, url }) => {
 	const hasAccess =
 		profile?.groups.includes(Group.ADMIN) || profile?.groups.includes(Group.AUDITOR);
 	if (hasAccess && !showSetupHandoff) {
-		throw redirect(307, '/admin/dashboard');
+		throw redirect(
+			307,
+			profile?.isBootstrapUser?.() ? '/admin/auth-providers' : '/admin/dashboard'
+		);
 	}
 
 	return {

--- a/ui/user/src/routes/admin/mcp-access-policies/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-access-policies/+page.svelte
@@ -6,7 +6,7 @@
 	import AccessControlRuleForm from '$lib/components/admin/AccessControlRuleForm.svelte';
 	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
-	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { MCP_ACCESS_POLICY_FIELD_IDS, PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { AdminService, UserService, type OrgUser, type AccessControlRule } from '$lib/services';
 	import { mcpServersAndEntries, profile } from '$lib/stores';
 	import { goto, clearUrlParams } from '$lib/url';
@@ -123,7 +123,7 @@
 							{/if}
 						</p>
 
-						{@render addRuleButton()}
+						{@render addRuleButton(MCP_ACCESS_POLICY_FIELD_IDS.addPolicyEmptyBtn)}
 					</div>
 				{:else}
 					<div class="flex flex-col gap-2">
@@ -143,7 +143,7 @@
 	{#snippet rightNavActions()}
 		{#if !showCreateRule}
 			<div class="relative flex items-center gap-4">
-				{@render addRuleButton()}
+				{@render addRuleButton(MCP_ACCESS_POLICY_FIELD_IDS.addPolicyBtn)}
 			</div>
 		{/if}
 	{/snippet}
@@ -199,9 +199,10 @@
 	</Table>
 {/snippet}
 
-{#snippet addRuleButton()}
+{#snippet addRuleButton(id: string)}
 	{#if !profile.current.isAdminReadonly?.()}
 		<button
+			{id}
 			class="btn btn-primary flex items-center gap-1 text-sm"
 			onclick={() => {
 				goto(`/admin/mcp-access-policies?new=true`);

--- a/ui/user/src/routes/mcp-access-policies/+page.svelte
+++ b/ui/user/src/routes/mcp-access-policies/+page.svelte
@@ -6,6 +6,7 @@
 	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Table from '$lib/components/table/Table.svelte';
 	import { MCP_PUBLISHER_ALL_OPTION, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import { MCP_ACCESS_POLICY_FIELD_IDS } from '$lib/constants';
 	import {
 		fetchMcpServerAndEntries,
 		getPoweruserWorkspace,
@@ -74,7 +75,7 @@
 							Click the button below to get started.
 						</p>
 
-						{@render addRuleButton()}
+						{@render addRuleButton(MCP_ACCESS_POLICY_FIELD_IDS.addPolicyEmptyBtn)}
 					</div>
 				{:else}
 					<Table
@@ -125,8 +126,9 @@
 	</div>
 </Layout>
 
-{#snippet addRuleButton()}
+{#snippet addRuleButton(id: string = MCP_ACCESS_POLICY_FIELD_IDS.addPolicyBtn)}
 	<button
+		{id}
 		class="btn btn-primary flex items-center gap-1 text-sm"
 		onclick={() => {
 			goto(`/mcp-access-policies?new=true`);


### PR DESCRIPTION
This adds the following quick start guides on the admin side:
- Create a hosted catalog entry
- Create a remote catalog entry
- Create a composite catalog entry
- Create a MCP access policy

Addresses #6375 

Also quickly addressed #7232 here; was a one-liner change