### PR TITLE
fix: include static env vars in drift detection

### DIFF
--- a/apiclient/registry_test.go
+++ b/apiclient/registry_test.go
@@ -1,7 +1,6 @@
 package apiclient
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -36,7 +35,7 @@ func TestListRegistryServersUsesAppBaseURLAndAuth(t *testing.T) {
 	result, err := (&Client{
 		BaseURL: server.URL + "/api/",
 		Token:   "test-token",
-	}).ListRegistryServers(context.Background(), ListRegistryServersOptions{
+	}).ListRegistryServers(t.Context(), ListRegistryServersOptions{
 		Search: "github issues",
 		Cursor: "next",
 		Limit:  100,
@@ -56,7 +55,7 @@ func TestListRegistryServersOmitsEmptyParameters(t *testing.T) {
 	}))
 	defer server.Close()
 
-	result, err := (&Client{BaseURL: server.URL + "/api"}).ListRegistryServers(context.Background(), ListRegistryServersOptions{})
+	result, err := (&Client{BaseURL: server.URL + "/api"}).ListRegistryServers(t.Context(), ListRegistryServersOptions{})
 	require.NoError(t, err)
 	require.Empty(t, result.Servers)
 }

--- a/apiclient/skill_test.go
+++ b/apiclient/skill_test.go
@@ -1,7 +1,6 @@
 package apiclient
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,7 +27,7 @@ func TestListSkillsEncodesQueryParameters(t *testing.T) {
 	}))
 	defer server.Close()
 
-	result, err := (&Client{BaseURL: server.URL}).ListSkills(context.Background(), "github review", 25)
+	result, err := (&Client{BaseURL: server.URL}).ListSkills(t.Context(), "github review", 25)
 	require.NoError(t, err)
 	require.Len(t, result.Items, 1)
 	require.Equal(t, "sk1", result.Items[0].ID)
@@ -42,7 +41,7 @@ func TestListSkillsOmitsEmptyParameters(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := (&Client{BaseURL: server.URL}).ListSkills(context.Background(), "", 0)
+	_, err := (&Client{BaseURL: server.URL}).ListSkills(t.Context(), "", 0)
 	require.NoError(t, err)
 }
 
@@ -56,7 +55,7 @@ func TestGetSkillEscapesIDAndDecodesResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	skill, err := (&Client{BaseURL: server.URL}).GetSkill(context.Background(), "skill/with space")
+	skill, err := (&Client{BaseURL: server.URL}).GetSkill(t.Context(), "skill/with space")
 	require.NoError(t, err)
 	require.Equal(t, "skill/with space", skill.ID)
 	require.Equal(t, "reviewer", skill.Name)
@@ -73,7 +72,7 @@ func TestPreviewSkillReturnsRawBytes(t *testing.T) {
 	}))
 	defer server.Close()
 
-	got, err := (&Client{BaseURL: server.URL}).PreviewSkill(context.Background(), "sk1")
+	got, err := (&Client{BaseURL: server.URL}).PreviewSkill(t.Context(), "sk1")
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }
@@ -89,7 +88,7 @@ func TestDownloadSkillReturnsRawBytes(t *testing.T) {
 	}))
 	defer server.Close()
 
-	got, err := (&Client{BaseURL: server.URL}).DownloadSkill(context.Background(), "sk1")
+	got, err := (&Client{BaseURL: server.URL}).DownloadSkill(t.Context(), "sk1")
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }
@@ -104,7 +103,7 @@ func TestDownloadSkillRejectsOversizedContentLength(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := (&Client{BaseURL: server.URL}).DownloadSkill(context.Background(), "sk1")
+	_, err := (&Client{BaseURL: server.URL}).DownloadSkill(t.Context(), "sk1")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "skill download exceeds maximum size")
 }
@@ -121,7 +120,7 @@ func TestDownloadSkillRejectsOversizedBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := (&Client{BaseURL: server.URL}).DownloadSkill(context.Background(), "sk1")
+	_, err := (&Client{BaseURL: server.URL}).DownloadSkill(t.Context(), "sk1")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "skill download exceeds maximum size")
 }
@@ -142,7 +141,7 @@ func TestSkillHelpersPropagateHTTPErrors(t *testing.T) {
 	defer server.Close()
 
 	client := &Client{BaseURL: server.URL}
-	_, err := client.ListSkills(context.Background(), "anything", 10)
+	_, err := client.ListSkills(t.Context(), "anything", 10)
 	require.Error(t, err)
 
 	var httpErr *types.ErrHTTP

--- a/pkg/api/authz/mcpid_test.go
+++ b/pkg/api/authz/mcpid_test.go
@@ -1,7 +1,6 @@
 package authz
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -490,7 +489,7 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			storage := newMCPIDIsAuthorizedTestStorage(tt.objects...)
 
-			got, err := MCPIDIsAuthorized(context.Background(), storage, tt.authorized, tt.userID, tt.mcpID)
+			got, err := MCPIDIsAuthorized(t.Context(), storage, tt.authorized, tt.userID, tt.mcpID)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("MCPIDIsAuthorized() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -161,7 +160,7 @@ func TestUpdateServerAliasUnscopedSharedServer(t *testing.T) {
 	assert.True(t, types.IsNotFound(err), "expected not found error, got %v", err)
 
 	var updated v1.MCPServer
-	require.NoError(t, storage.Get(context.Background(), kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: "server"}, &updated))
+	require.NoError(t, storage.Get(t.Context(), kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: "server"}, &updated))
 	assert.Empty(t, updated.Spec.Alias)
 }
 
@@ -203,7 +202,7 @@ func TestMCPServerOrInstanceFromConnectURLRejectsCatalogEntryResourcesAboveMaxim
 	assert.Contains(t, err.Error(), "resources.requests.cpu 250m exceeds configured maximum 100m")
 
 	var servers v1.MCPServerList
-	require.NoError(t, storage.List(context.Background(), &servers, kclient.InNamespace(system.DefaultNamespace)))
+	require.NoError(t, storage.List(t.Context(), &servers, kclient.InNamespace(system.DefaultNamespace)))
 	assert.Empty(t, servers.Items)
 }
 
@@ -1084,7 +1083,7 @@ func TestCreateServerRejectsMissingSecretBinding(t *testing.T) {
 	assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
 
 	var servers v1.MCPServerList
-	require.NoError(t, storage.List(context.Background(), &servers))
+	require.NoError(t, storage.List(t.Context(), &servers))
 	assert.Empty(t, servers.Items)
 }
 
@@ -1596,7 +1595,7 @@ func TestEntryMissingAdminConfig(t *testing.T) {
 				Spec:   v1.MCPServerCatalogEntrySpec{Manifest: tt.manifest},
 				Status: v1.MCPServerCatalogEntryStatus{OAuthCredentialConfigured: tt.oauthConfigured},
 			}
-			got, err := entryMissingAdminConfig(context.Background(), tt.client, ns, entry, "label")
+			got, err := entryMissingAdminConfig(t.Context(), tt.client, ns, entry, "label")
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantFields, got.SecretBoundFields)
 			assert.Equal(t, tt.wantOAuth, got.StaticOAuth)

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
@@ -1,7 +1,6 @@
 package oauth
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strconv"
@@ -95,7 +94,7 @@ func TestResolveClientIDMetadataDocument(t *testing.T) {
 		}, nil
 	})
 
-	client, err := h.resolveClientIDMetadataDocument(context.Background(), clientID)
+	client, err := h.resolveClientIDMetadataDocument(t.Context(), clientID)
 	if err != nil {
 		t.Fatalf("resolve metadata: %v", err)
 	}
@@ -112,7 +111,7 @@ func TestResolveClientIDMetadataDocument(t *testing.T) {
 		t.Fatalf("expected default application type web, got %q", client.Spec.Manifest.ApplicationType)
 	}
 
-	if _, err = h.resolveClientIDMetadataDocument(context.Background(), clientID); err != nil {
+	if _, err = h.resolveClientIDMetadataDocument(t.Context(), clientID); err != nil {
 		t.Fatalf("resolve cached metadata: %v", err)
 	}
 	if requests != 1 {
@@ -171,7 +170,7 @@ func TestResolveClientIDMetadataDocumentValidation(t *testing.T) {
 				}, nil
 			})
 
-			if _, err := h.resolveClientIDMetadataDocument(context.Background(), "https://client.example/oauth/client.json"); err == nil {
+			if _, err := h.resolveClientIDMetadataDocument(t.Context(), "https://client.example/oauth/client.json"); err == nil {
 				t.Fatal("expected validation error")
 			}
 		})
@@ -196,7 +195,7 @@ func TestResolveClientIDMetadataDocumentPrivateKeyJWT(t *testing.T) {
 		}, nil
 	})
 
-	client, err := h.resolveClientIDMetadataDocument(context.Background(), clientID)
+	client, err := h.resolveClientIDMetadataDocument(t.Context(), clientID)
 	if err != nil {
 		t.Fatalf("resolve metadata: %v", err)
 	}
@@ -225,7 +224,7 @@ func TestResolveClientIDMetadataDocumentNativeApplicationType(t *testing.T) {
 		}, nil
 	})
 
-	client, err := h.resolveClientIDMetadataDocument(context.Background(), clientID)
+	client, err := h.resolveClientIDMetadataDocument(t.Context(), clientID)
 	if err != nil {
 		t.Fatalf("resolve metadata: %v", err)
 	}
@@ -270,7 +269,7 @@ func TestFetchClientIDMetadataDocumentRejectsOversizedResponse(t *testing.T) {
 		}, nil
 	})
 
-	if _, _, err := h.fetchClientIDMetadataDocument(context.Background(), "https://client.example/oauth/client.json"); err == nil {
+	if _, _, err := h.fetchClientIDMetadataDocument(t.Context(), "https://client.example/oauth/client.json"); err == nil {
 		t.Fatal("expected oversized metadata error")
 	}
 }

--- a/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
@@ -1,7 +1,6 @@
 package oauth
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
@@ -74,12 +73,12 @@ func TestValidatePrivateKeyJWT(t *testing.T) {
 		"client_assertion":      {assertion},
 	}
 
-	if err := h.validatePrivateKeyJWT(context.Background(), form, client, clientID); err != nil {
+	if err := h.validatePrivateKeyJWT(t.Context(), form, client, clientID); err != nil {
 		t.Fatalf("validate private_key_jwt: %v", err)
 	}
 
 	form.Set("client_assertion", signClientAssertion(t, key, "test-key", clientID, "https://other.example/oauth/token"))
-	if err := h.validatePrivateKeyJWT(context.Background(), form, client, clientID); err == nil {
+	if err := h.validatePrivateKeyJWT(t.Context(), form, client, clientID); err == nil {
 		t.Fatal("expected invalid audience to fail")
 	}
 }

--- a/pkg/api/handlers/mdmassets_test.go
+++ b/pkg/api/handlers/mdmassets_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -89,7 +88,7 @@ func TestMDMAssetSourceHandlerRefreshOnlyRequestsReconciliation(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, recorder.Code)
 
 	var source v1.MDMAssetSource
-	require.NoError(t, storage.Get(context.Background(), kclient.ObjectKey{
+	require.NoError(t, storage.Get(t.Context(), kclient.ObjectKey{
 		Name:      system.DefaultMDMAssetSource,
 		Namespace: system.DefaultNamespace,
 	}, &source))

--- a/pkg/api/handlers/publishedartifact_test.go
+++ b/pkg/api/handlers/publishedartifact_test.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -635,7 +634,7 @@ func TestPublishedArtifactCreate_InheritsSubjectsFromPreviousVersion(t *testing.
 	}
 
 	var artifact v1.PublishedArtifact
-	if err := storage.Get(context.Background(), kclient.ObjectKey{
+	if err := storage.Get(t.Context(), kclient.ObjectKey{
 		Namespace: system.DefaultNamespace,
 		Name:      artifactName,
 	}, &artifact); err != nil {

--- a/pkg/api/handlers/registry/convert_test.go
+++ b/pkg/api/handlers/registry/convert_test.go
@@ -1,7 +1,6 @@
 package registry
 
 import (
-	"context"
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
@@ -14,7 +13,7 @@ func TestConvertMCPServerCatalogEntryToRegistryRemoteFixedURLHasRemote(t *testin
 		FixedURL: "https://api.example.com/mcp",
 	})
 
-	got, err := ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	got, err := ConvertMCPServerCatalogEntryToRegistry(t.Context(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +34,7 @@ func TestConvertMCPServerCatalogEntryToRegistryRemoteHostnameRequiresConfigurati
 		Hostname: "api.example.com",
 	})
 
-	got, err := ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	got, err := ConvertMCPServerCatalogEntryToRegistry(t.Context(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +52,7 @@ func TestConvertMCPServerCatalogEntryToRegistryRemoteURLTemplateRequiresConfigur
 		URLTemplate: "https://${WORKSPACE}.example.com/mcp",
 	})
 
-	got, err := ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	got, err := ConvertMCPServerCatalogEntryToRegistry(t.Context(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +71,7 @@ func TestConvertMCPServerCatalogEntryToRegistryRemoteStaticOAuthRequiresConfigur
 		StaticOAuthRequired: true,
 	})
 
-	got, err := ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	got, err := ConvertMCPServerCatalogEntryToRegistry(t.Context(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +84,7 @@ func TestConvertMCPServerCatalogEntryToRegistryRemoteStaticOAuthRequiresConfigur
 	}
 
 	entry.Status.OAuthCredentialConfigured = true
-	got, err = ConvertMCPServerCatalogEntryToRegistry(context.Background(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
+	got, err = ConvertMCPServerCatalogEntryToRegistry(t.Context(), entry, "https://obot.example.com", "com.example.obot", newMimeFetcher())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +115,7 @@ func TestConvertMCPServerToRegistryNeedsURLRequiresConfiguration(t *testing.T) {
 		},
 	}
 
-	got, err := ConvertMCPServerToRegistry(context.Background(), server, nil, "https://obot.example.com", server.Name, "com.example.obot", "user-1", newMimeFetcher())
+	got, err := ConvertMCPServerToRegistry(t.Context(), server, nil, "https://obot.example.com", server.Name, "com.example.obot", "user-1", newMimeFetcher())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/api/handlers/skills_test.go
+++ b/pkg/api/handlers/skills_test.go
@@ -48,11 +48,11 @@ func TestRevealSkillRepositoryToken(t *testing.T) {
 		Secrets: map[string]string{skill.Spec.RepoURL: "private-token"},
 	}}
 
-	token, err := revealSkillRepositoryToken(context.Background(), client, skill)
+	token, err := revealSkillRepositoryToken(t.Context(), client, skill)
 	require.NoError(t, err)
 	assert.Equal(t, "private-token", token)
 
-	_, err = revealSkillRepositoryToken(context.Background(), credentialNotFoundClient{}, skill)
+	_, err = revealSkillRepositoryToken(t.Context(), credentialNotFoundClient{}, skill)
 	require.NoError(t, err)
 }
 
@@ -163,7 +163,7 @@ func TestSkillRepositoryHandlerRefresh(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 
 	var repo v1.SkillRepository
-	require.NoError(t, storage.Get(context.Background(), kclient.ObjectKey{Name: "skr1", Namespace: system.DefaultNamespace}, &repo))
+	require.NoError(t, storage.Get(t.Context(), kclient.ObjectKey{Name: "skr1", Namespace: system.DefaultNamespace}, &repo))
 	assert.Equal(t, "true", repo.Annotations[v1.SkillRepositorySyncAnnotation])
 }
 

--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -66,9 +65,6 @@ type PromptConfig struct {
 
 func (p PromptConfig) Pre(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if p.NonInteractive {
 		ctx = internal.WithNonInteractive(ctx)
 	}

--- a/pkg/cli/mcp_test.go
+++ b/pkg/cli/mcp_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -57,7 +56,7 @@ func TestMCPSearchPaginatesAndWritesTable(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stdout, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search", "github", "issues", "--limit", "3")
+	stdout, err := executeMCPTestCommand(t, mcpTestRoot(server.URL), "search", "github", "issues", "--limit", "3")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +90,7 @@ func TestMCPSearchJSONMode(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stdout, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search", "--json")
+	stdout, err := executeMCPTestCommand(t, mcpTestRoot(server.URL), "search", "--json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +122,7 @@ func TestMCPSearchJSONModeIncludesConfigurationURL(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stdout, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search", "--json")
+	stdout, err := executeMCPTestCommand(t, mcpTestRoot(server.URL), "search", "--json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +147,7 @@ func TestMCPSearchEmptyResult(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stdout, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search")
+	stdout, err := executeMCPTestCommand(t, mcpTestRoot(server.URL), "search")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +172,7 @@ func TestMCPSearchRegistryAuthErrors(t *testing.T) {
 			}))
 			defer server.Close()
 
-			_, err := executeMCPTestCommand(mcpTestRoot(server.URL), "search")
+			_, err := executeMCPTestCommand(t, mcpTestRoot(server.URL), "search")
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -191,10 +190,11 @@ func mcpTestRoot(baseURL string) *Obot {
 	}}
 }
 
-func executeMCPTestCommand(root *Obot, args ...string) (string, error) {
+func executeMCPTestCommand(t *testing.T, root *Obot, args ...string) (string, error) {
+	t.Helper()
 	var stdout bytes.Buffer
 	cmd := cmd.Command(&MCP{root: root})
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 	cmd.SetOut(&stdout)
 	cmd.SetArgs(args)
 	err := cmd.Execute()

--- a/pkg/cli/setup.go
+++ b/pkg/cli/setup.go
@@ -65,9 +65,6 @@ func (s *Setup) Run(cmd *cobra.Command, _ []string) error {
 
 func (s *Setup) run(cmd *cobra.Command, progress setupProgressWriter) error {
 	ctx := cmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if progress.json {
 		if s.NonInteractive {
 			ctx = cliinternal.WithOutputWriter(ctx, io.Discard)
@@ -175,9 +172,6 @@ func (s *Setup) resolveClientSelection(cmd *cobra.Command) (setupClientSelection
 	}
 
 	ctx := cmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	claudeDetected := false
 	for _, agent := range localagents.DetectedAgents() {
 		if agent.ID() == localagents.ClaudeCodeAgentID && agent.Detect(ctx).State == localagents.DetectionPresent {

--- a/pkg/cli/setup_status.go
+++ b/pkg/cli/setup_status.go
@@ -36,9 +36,6 @@ func (s *SetupStatus) Customize(cmd *cobra.Command) {
 
 func (s *SetupStatus) Run(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
 
 	status, err := s.status(ctx)
 	if err != nil {
@@ -103,10 +100,6 @@ func (s *SetupDetectClients) Customize(cmd *cobra.Command) {
 
 func (s *SetupDetectClients) Run(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	result := detectSetupClients(ctx)
 	if s.JSON {
 		return writeJSON(cmd, result)

--- a/pkg/cli/setup_test.go
+++ b/pkg/cli/setup_test.go
@@ -38,7 +38,7 @@ func TestSetupNonInteractiveExplicitInstallsClaudeCode(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd := setupTestCommand(nil, &stdout, &stderr)
+	cmd := setupTestCommand(t, nil, &stdout, &stderr)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestSetupExplicitSharedAgents(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd := setupTestCommand(nil, &stdout, &stderr)
+	cmd := setupTestCommand(t, nil, &stdout, &stderr)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestSetupExplicitInstallsMultipleTargets(t *testing.T) {
 		root:    root,
 	}
 
-	if err := setup.Run(setupTestCommand(nil, nil, nil), nil); err != nil {
+	if err := setup.Run(setupTestCommand(t, nil, nil, nil), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -145,7 +145,7 @@ func TestSetupNonInteractiveMissingURLFailsWithoutPrompt(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	cmd := setupTestCommand(strings.NewReader("https://obot.example.com\n"), &stdout, nil)
+	cmd := setupTestCommand(t, strings.NewReader("https://obot.example.com\n"), &stdout, nil)
 	err := setup.Run(cmd, nil)
 	if err == nil {
 		t.Fatal("expected error")
@@ -180,7 +180,7 @@ func TestSetupClientsNoneSkipsLocalClientInstall(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd := setupTestCommand(nil, &stdout, &stderr)
+	cmd := setupTestCommand(t, nil, &stdout, &stderr)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestSetupJSONProgressSuccessfulSequence(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd := setupTestCommand(nil, &stdout, &stderr)
+	cmd := setupTestCommand(t, nil, &stdout, &stderr)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +268,7 @@ func TestSetupJSONProgressStructuredError(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	cmd := setupTestCommand(strings.NewReader("https://obot.example.com\n"), &stdout, nil)
+	cmd := setupTestCommand(t, strings.NewReader("https://obot.example.com\n"), &stdout, nil)
 	err := setup.Run(cmd, nil)
 	if err == nil {
 		t.Fatal("expected error")
@@ -304,7 +304,7 @@ func TestSetupRefusesToReplaceConfiguredURLWithoutYes(t *testing.T) {
 		Clients: "agents",
 		root:    setupTestRoot(nil),
 	}
-	err := setup.Run(setupTestCommand(nil, nil, nil), nil)
+	err := setup.Run(setupTestCommand(t, nil, nil, nil), nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -328,7 +328,7 @@ func TestSetupJSONConfiguredURLMismatchErrorCode(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	err := setup.Run(setupTestCommand(nil, &stdout, nil), nil)
+	err := setup.Run(setupTestCommand(t, nil, &stdout, nil), nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -373,7 +373,7 @@ func TestSetupInteractiveUsesConfiguredURL(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	cmd := setupTestCommand(strings.NewReader("y\n"), &stdout, nil)
+	cmd := setupTestCommand(t, strings.NewReader("y\n"), &stdout, nil)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestSetupPromptsForClientsWhenOmittedWithoutClaudeCode(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	cmd := setupTestCommand(strings.NewReader("agents\n"), &stdout, nil)
+	cmd := setupTestCommand(t, strings.NewReader("agents\n"), &stdout, nil)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestSetupPromptsForClientsWhenOmittedWithClaudeCode(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	cmd := setupTestCommand(strings.NewReader("claude-code,agents\n"), &stdout, nil)
+	cmd := setupTestCommand(t, strings.NewReader("claude-code,agents\n"), &stdout, nil)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +459,7 @@ func TestSetupPromptEmptySelectionSkipsLocalClientInstall(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	cmd := setupTestCommand(strings.NewReader("\n"), &stdout, nil)
+	cmd := setupTestCommand(t, strings.NewReader("\n"), &stdout, nil)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestSetupYesDefaultsToSharedAgentsWhenClientsOmitted(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	cmd := setupTestCommand(strings.NewReader(""), &stdout, nil)
+	cmd := setupTestCommand(t, strings.NewReader(""), &stdout, nil)
 	if err := setup.Run(cmd, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +514,7 @@ func TestSetupNonInteractiveRequiresClientsWhenOmitted(t *testing.T) {
 		root: root,
 	}
 
-	err := setup.Run(setupTestCommand(nil, nil, nil), nil)
+	err := setup.Run(setupTestCommand(t, nil, nil, nil), nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -566,7 +566,7 @@ func TestSetupStatusJSONNoConfig(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	if err := status.Run(setupTestCommand(nil, &stdout, nil), nil); err != nil {
+	if err := status.Run(setupTestCommand(t, nil, &stdout, nil), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -620,7 +620,7 @@ func TestSetupStatusSetupCompleteRequiresConfiguredURLAndValidToken(t *testing.T
 			}
 
 			var stdout bytes.Buffer
-			if err := status.Run(setupTestCommand(nil, &stdout, nil), nil); err != nil {
+			if err := status.Run(setupTestCommand(t, nil, &stdout, nil), nil); err != nil {
 				t.Fatal(err)
 			}
 
@@ -651,7 +651,7 @@ func TestSetupDetectClientsJSON(t *testing.T) {
 
 	var stdout bytes.Buffer
 	detect := &SetupDetectClients{JSON: true}
-	if err := detect.Run(setupTestCommand(nil, &stdout, nil), nil); err != nil {
+	if err := detect.Run(setupTestCommand(t, nil, &stdout, nil), nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -684,8 +684,10 @@ func setupTestRoot(fetcher func(context.Context, string, apiclient.TokenFetchOpt
 	return &Obot{Client: client}
 }
 
-func setupTestCommand(stdin *strings.Reader, stdout, stderr *bytes.Buffer) *cobra.Command {
+func setupTestCommand(t *testing.T, stdin *strings.Reader, stdout, stderr *bytes.Buffer) *cobra.Command {
+	t.Helper()
 	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
 	if stdin != nil {
 		cmd.SetIn(stdin)
 	}

--- a/pkg/cli/skills_test.go
+++ b/pkg/cli/skills_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -50,7 +49,7 @@ func TestSkillsSearchCallsAPIWithQueryAndLimit(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stdout, err := executeSkillsTestCommand(skillsTestRoot(server.URL), "search", "github", "--limit", "7")
+	stdout, err := executeSkillsTestCommand(t, skillsTestRoot(server.URL), "search", "github", "--limit", "7")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +68,7 @@ func TestSkillsSearchEmptyResult(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stdout, err := executeSkillsTestCommand(skillsTestRoot(server.URL), "search")
+	stdout, err := executeSkillsTestCommand(t, skillsTestRoot(server.URL), "search")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +87,7 @@ func TestSkillsSearchJSONMode(t *testing.T) {
 	}))
 	defer server.Close()
 
-	stdout, err := executeSkillsTestCommand(skillsTestRoot(server.URL), "search", "--json")
+	stdout, err := executeSkillsTestCommand(t, skillsTestRoot(server.URL), "search", "--json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +110,7 @@ func TestSkillsInstallExactIDInstallsClaudeCode(t *testing.T) {
 	}})
 	defer server.Close()
 
-	stdout, err := executeSkillsTestCommand(skillsTestRoot(server.URL), "install", "sk1", "--destination", "~/.claude/skills")
+	stdout, err := executeSkillsTestCommand(t, skillsTestRoot(server.URL), "install", "sk1", "--destination", "~/.claude/skills")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +130,7 @@ func TestSkillsInstallExactIDInstallsSharedAgents(t *testing.T) {
 	}})
 	defer server.Close()
 
-	stdout, err := executeSkillsTestCommand(skillsTestRoot(server.URL), "install", "sk1", "--destination", "~/.agents/skills")
+	stdout, err := executeSkillsTestCommand(t, skillsTestRoot(server.URL), "install", "sk1", "--destination", "~/.agents/skills")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +145,7 @@ func TestSkillsInstallNoMatches(t *testing.T) {
 	server := skillInstallTestServer(t, nil)
 	defer server.Close()
 
-	_, err := executeSkillsTestCommand(skillsTestRoot(server.URL), "install", "missing", "--destination", "~/.claude/skills")
+	_, err := executeSkillsTestCommand(t, skillsTestRoot(server.URL), "install", "missing", "--destination", "~/.claude/skills")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -164,7 +163,7 @@ func TestSkillsInstallRequiresDestination(t *testing.T) {
 	}})
 	defer server.Close()
 
-	_, err := executeSkillsTestCommand(skillsTestRoot(server.URL), "install", "sk1")
+	_, err := executeSkillsTestCommand(t, skillsTestRoot(server.URL), "install", "sk1")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -182,7 +181,7 @@ func TestSkillsInstallJSONMode(t *testing.T) {
 	}})
 	defer server.Close()
 
-	stdout, err := executeSkillsTestCommand(skillsTestRoot(server.URL), "install", "sk1", "--destination", "~/.claude/skills", "--json")
+	stdout, err := executeSkillsTestCommand(t, skillsTestRoot(server.URL), "install", "sk1", "--destination", "~/.claude/skills", "--json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,10 +221,12 @@ func skillsTestRoot(baseURL string) *Obot {
 	}}
 }
 
-func executeSkillsTestCommand(root *Obot, args ...string) (string, error) {
+func executeSkillsTestCommand(t *testing.T, root *Obot, args ...string) (string, error) {
+	t.Helper()
+
 	var stdout bytes.Buffer
 	cmd := cmd.Command(&Skills{root: root})
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 	cmd.SetOut(&stdout)
 	cmd.SetArgs(args)
 	err := cmd.Execute()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -92,10 +92,6 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to delete ToolReference-owned models: %w", err)
 	}
 
-	if err := migrateMultiUserMCPServerManifestValuesToCredentials(ctx, c.services.StorageClient, c.services.GatewayClient); err != nil {
-		return fmt.Errorf("failed to migrate MCP server manifest values to credentials: %w", err)
-	}
-
 	// Ensure PowerUserWorkspaces exist for all admin users on startup
 	if err := c.adminWorkspaceHandler.EnsureAllAdminAndOwnerWorkspaces(ctx, c.services.StorageClient, system.DefaultNamespace); err != nil {
 		return fmt.Errorf("failed to ensure admin workspaces: %w", err)

--- a/pkg/controller/data/data_test.go
+++ b/pkg/controller/data/data_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"context"
 	"testing"
 
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -22,7 +21,7 @@ func newFakeClient(t *testing.T, objects ...kclient.Object) kclient.Client {
 }
 
 func TestCreateDefaultSkillRepository(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("empty URL is no-op", func(t *testing.T) {
 		c := newFakeClient(t)

--- a/pkg/controller/handlers/auditlogexport/auditlogexport_test.go
+++ b/pkg/controller/handlers/auditlogexport/auditlogexport_test.go
@@ -536,7 +536,7 @@ func waitForMCPAuditLog(t *testing.T, c *gatewayclient.Client) {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		logs, total, err := c.GetMCPAuditLogs(context.Background(), gatewayclient.MCPAuditLogOptions{
+		logs, total, err := c.GetMCPAuditLogs(t.Context(), gatewayclient.MCPAuditLogOptions{
 			SourceTypes: []types.AuditLogSourceType{types.AuditLogSourceTypeMCP},
 			Limit:       1,
 		})

--- a/pkg/controller/handlers/mcpcatalog/github_test.go
+++ b/pkg/controller/handlers/mcpcatalog/github_test.go
@@ -1,7 +1,6 @@
 package mcpcatalog
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -81,7 +80,7 @@ func TestReadGitCatalog(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			entries, err := readGitCatalogEntries[types.MCPServerCatalogEntryManifest](context.Background(), tt.catalog, "")
+			entries, err := readGitCatalogEntries[types.MCPServerCatalogEntryManifest](t.Context(), tt.catalog, "")
 			if tt.wantErr {
 				assert.Error(t, err)
 				return

--- a/pkg/controller/handlers/mcpcatalog/source_refs_test.go
+++ b/pkg/controller/handlers/mcpcatalog/source_refs_test.go
@@ -1,7 +1,6 @@
 package mcpcatalog
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +30,7 @@ npxConfig:
 `), 0o600))
 
 	h := &Handler{}
-	objs, err := h.readMCPCatalog(context.Background(), "default", dir, "")
+	objs, err := h.readMCPCatalog(t.Context(), "default", dir, "")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `duplicate source entry key "shared"`)
@@ -51,7 +50,7 @@ npxConfig:
 `), 0o600))
 
 	h := &Handler{}
-	objs, err := h.readMCPCatalog(context.Background(), "default", dir, "")
+	objs, err := h.readMCPCatalog(t.Context(), "default", dir, "")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `source entry key "bad::key" cannot contain ::`)
@@ -71,7 +70,7 @@ npxConfig:
 `), 0o600))
 
 	h := &Handler{}
-	objs, err := h.readMCPCatalog(context.Background(), "default", dir, "")
+	objs, err := h.readMCPCatalog(t.Context(), "default", dir, "")
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), `source entry key "Bad_Key" must be DNS-friendly`)

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -87,6 +87,63 @@ func (h *Handler) DetectDrift(req router.Request, _ router.Response) error {
 		return err
 	}
 
+	staticEnvKeys := make(map[string]struct{})
+	for _, env := range entry.Spec.Manifest.Env {
+		if env.Value != "" {
+			staticEnvKeys[env.Key] = struct{}{}
+		}
+	}
+	if entry.Spec.Manifest.RemoteConfig != nil {
+		for _, hdr := range entry.Spec.Manifest.RemoteConfig.Headers {
+			if hdr.Value != "" {
+				staticEnvKeys[hdr.Key] = struct{}{}
+			}
+		}
+	}
+
+	if len(staticEnvKeys) > 0 {
+		var (
+			cred gatewaytypes.Credential
+			err  error
+		)
+		if server.Spec.MCPCatalogID != "" {
+			cred, err = h.gatewayClient.RevealCredential(req.Ctx, []string{fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)}, server.Name)
+		} else if server.Spec.PowerUserWorkspaceID != "" {
+			cred, err = h.gatewayClient.RevealCredential(req.Ctx, []string{fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)}, server.Name)
+		} else {
+			cred, err = h.gatewayClient.RevealCredential(req.Ctx, []string{fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)}, server.Name)
+		}
+		if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
+			return err
+		}
+
+		originalEnv := slices.Clone(server.Spec.Manifest.Env)
+		defer func() {
+			// Ensure we revert to the original values after processing
+			server.Spec.Manifest.Env = originalEnv
+		}()
+
+		for i, env := range server.Spec.Manifest.Env {
+			if _, ok := staticEnvKeys[env.Key]; ok && env.Value == "" {
+				server.Spec.Manifest.Env[i].Value = cred.Secrets[env.Key]
+			}
+		}
+
+		if server.Spec.Manifest.RemoteConfig != nil {
+			originalHeaders := slices.Clone(server.Spec.Manifest.RemoteConfig.Headers)
+			defer func() {
+				// Ensure we revert to the original values after processing
+				server.Spec.Manifest.RemoteConfig.Headers = originalHeaders
+			}()
+
+			for i, hdr := range server.Spec.Manifest.RemoteConfig.Headers {
+				if _, ok := staticEnvKeys[hdr.Key]; ok && hdr.Value == "" {
+					server.Spec.Manifest.RemoteConfig.Headers[i].Value = cred.Secrets[hdr.Key]
+				}
+			}
+		}
+	}
+
 	drifted, err := ConfigurationHasDrifted(server.Spec.Manifest, entry.Spec.Manifest, h.defaultDenyAllEgress)
 	if err != nil {
 		return err
@@ -485,6 +542,7 @@ func mcpEnvMatchesCatalog(serverField, entryField types.MCPEnv) bool {
 		entryField.SecretBinding = nil
 		entryField.Value = serverField.Value
 	}
+
 	return reflect.DeepEqual(serverField, entryField)
 }
 

--- a/pkg/controller/handlers/mcpserver/mcpserver_test.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver_test.go
@@ -1,7 +1,6 @@
 package mcpserver
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -1416,6 +1415,23 @@ func TestDetectDriftClearsMultiUserCatalogEntryDeploymentWithAdminAddedEnvBindin
 	var updated v1.MCPServer
 	require.NoError(t, client.Get(context.Background(), router.Key(server.Namespace, server.Name), &updated))
 	assert.False(t, updated.Status.NeedsUpdate)
+}
+
+func TestDetectDriftReturnsConfigurationComparisonError(t *testing.T) {
+	entry := newMCPServerCatalogEntry("template-entry", types.MCPServerCatalogEntryManifest{Runtime: types.Runtime("invalid")})
+	server := newMCPServer("shared-server")
+	server.Spec.MCPServerCatalogEntryName = entry.Name
+	server.Spec.Manifest.Runtime = types.Runtime("invalid")
+	storageClient := newFakeClient(t, entry, server)
+
+	err := (&Handler{}).DetectDrift(router.Request{
+		Client:    storageClient,
+		Ctx:       t.Context(),
+		Object:    server,
+		Namespace: server.Namespace,
+		Name:      server.Name,
+	}, &router.ResponseWrapper{})
+	require.EqualError(t, err, "unknown runtime type: invalid")
 }
 
 func newMCPServerCatalogEntry(name string, manifest types.MCPServerCatalogEntryManifest) *v1.MCPServerCatalogEntry {

--- a/pkg/controller/handlers/mcpserver/mcpserver_test.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver_test.go
@@ -1273,7 +1273,7 @@ func TestDetectDriftMarksCatalogEntryDeploymentNeedingUpdateForResources(t *test
 	client := newFakeClient(t, entry, server)
 	err := (&Handler{}).DetectDrift(router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1281,7 +1281,7 @@ func TestDetectDriftMarksCatalogEntryDeploymentNeedingUpdateForResources(t *test
 	require.NoError(t, err)
 
 	var updated v1.MCPServer
-	require.NoError(t, client.Get(context.Background(), router.Key(server.Namespace, server.Name), &updated))
+	require.NoError(t, client.Get(t.Context(), router.Key(server.Namespace, server.Name), &updated))
 	assert.True(t, updated.Status.NeedsUpdate)
 }
 
@@ -1312,7 +1312,7 @@ func TestDetectDriftMarksMultiUserCatalogEntryDeploymentNeedingUpdate(t *testing
 	client := newFakeClient(t, entry, server)
 	err := (&Handler{}).DetectDrift(router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1320,7 +1320,7 @@ func TestDetectDriftMarksMultiUserCatalogEntryDeploymentNeedingUpdate(t *testing
 	require.NoError(t, err)
 
 	var updated v1.MCPServer
-	require.NoError(t, client.Get(context.Background(), router.Key(server.Namespace, server.Name), &updated))
+	require.NoError(t, client.Get(t.Context(), router.Key(server.Namespace, server.Name), &updated))
 	assert.True(t, updated.Status.NeedsUpdate)
 }
 
@@ -1352,7 +1352,7 @@ func TestDetectDriftClearsMultiUserCatalogEntryDeploymentWhenConfigurationMatche
 	client := newFakeClient(t, entry, server)
 	err := (&Handler{}).DetectDrift(router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1360,7 +1360,7 @@ func TestDetectDriftClearsMultiUserCatalogEntryDeploymentWhenConfigurationMatche
 	require.NoError(t, err)
 
 	var updated v1.MCPServer
-	require.NoError(t, client.Get(context.Background(), router.Key(server.Namespace, server.Name), &updated))
+	require.NoError(t, client.Get(t.Context(), router.Key(server.Namespace, server.Name), &updated))
 	assert.False(t, updated.Status.NeedsUpdate)
 }
 
@@ -1405,7 +1405,7 @@ func TestDetectDriftClearsMultiUserCatalogEntryDeploymentWithAdminAddedEnvBindin
 	client := newFakeClient(t, entry, server)
 	err := (&Handler{}).DetectDrift(router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1413,7 +1413,7 @@ func TestDetectDriftClearsMultiUserCatalogEntryDeploymentWithAdminAddedEnvBindin
 	require.NoError(t, err)
 
 	var updated v1.MCPServer
-	require.NoError(t, client.Get(context.Background(), router.Key(server.Namespace, server.Name), &updated))
+	require.NoError(t, client.Get(t.Context(), router.Key(server.Namespace, server.Name), &updated))
 	assert.False(t, updated.Status.NeedsUpdate)
 }
 
@@ -1506,7 +1506,7 @@ func TestShutdownIdleServersSetsLastRequestTimeForOlderServers(t *testing.T) {
 	client := newFakeClient(t, server)
 	req := router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1516,7 +1516,7 @@ func TestShutdownIdleServersSetsLastRequestTimeForOlderServers(t *testing.T) {
 	require.NoError(t, err)
 
 	var updated v1.MCPServer
-	require.NoError(t, client.Get(context.Background(), router.Key(server.Namespace, server.Name), &updated))
+	require.NoError(t, client.Get(t.Context(), router.Key(server.Namespace, server.Name), &updated))
 	assert.False(t, updated.Status.LastRequestTime.IsZero())
 	assert.WithinDuration(t, time.Now(), updated.Status.LastRequestTime.Time, 5*time.Second)
 }
@@ -1528,7 +1528,7 @@ func TestShutdownIdleServersSkipsRecentlyCreatedServersWithoutLastRequestTime(t 
 	client := newFakeClient(t, server)
 	req := router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1538,7 +1538,7 @@ func TestShutdownIdleServersSkipsRecentlyCreatedServersWithoutLastRequestTime(t 
 	require.NoError(t, err)
 
 	var updated v1.MCPServer
-	require.NoError(t, client.Get(context.Background(), router.Key(server.Namespace, server.Name), &updated))
+	require.NoError(t, client.Get(t.Context(), router.Key(server.Namespace, server.Name), &updated))
 	assert.True(t, updated.Status.LastRequestTime.IsZero())
 }
 
@@ -1549,7 +1549,7 @@ func TestShutdownIdleServersSchedulesRetryUsingServerSpecificInterval(t *testing
 
 	req := router.Request{
 		Client:    newFakeClient(t, server),
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1573,7 +1573,7 @@ func TestShutdownIdleServersUsesAgentDefaultIdleInterval(t *testing.T) {
 
 	req := router.Request{
 		Client:    newFakeClient(t, server),
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1597,7 +1597,7 @@ func TestShutdownIdleServersUsesMultiUserDefaultIdleInterval(t *testing.T) {
 
 	req := router.Request{
 		Client:    newFakeClient(t, server),
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1621,7 +1621,7 @@ func TestShutdownIdleServersSkipsWhenShutdownDisabled(t *testing.T) {
 
 	req := router.Request{
 		Client:    newFakeClient(t, server),
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1646,7 +1646,7 @@ func TestEnsureMCPNetworkPolicyCreatesPolicy(t *testing.T) {
 	client := newFakeClient(t, server)
 	req := router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1656,7 +1656,7 @@ func TestEnsureMCPNetworkPolicyCreatesPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	var policies v1.MCPNetworkPolicyList
-	require.NoError(t, client.List(context.Background(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
+	require.NoError(t, client.List(t.Context(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
 		"spec.mcpServerName": server.Name,
 	}))
 	require.Len(t, policies.Items, 1)
@@ -1679,7 +1679,7 @@ func TestEnsureMCPNetworkPolicyCreatesDenyAllPolicy(t *testing.T) {
 	client := newFakeClient(t, server)
 	req := router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1689,7 +1689,7 @@ func TestEnsureMCPNetworkPolicyCreatesDenyAllPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	var policies v1.MCPNetworkPolicyList
-	require.NoError(t, client.List(context.Background(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
+	require.NoError(t, client.List(t.Context(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
 		"spec.mcpServerName": server.Name,
 	}))
 	require.Len(t, policies.Items, 1)
@@ -1712,7 +1712,7 @@ func TestEnsureMCPNetworkPolicyDeletesPolicyWhenProviderDisabled(t *testing.T) {
 	client := newFakeClient(t, server, existing)
 	req := router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1722,7 +1722,7 @@ func TestEnsureMCPNetworkPolicyDeletesPolicyWhenProviderDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	var policies v1.MCPNetworkPolicyList
-	require.NoError(t, client.List(context.Background(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
+	require.NoError(t, client.List(t.Context(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
 		"spec.mcpServerName": server.Name,
 	}))
 	require.Empty(t, policies.Items)
@@ -1740,7 +1740,7 @@ func TestEnsureMCPNetworkPolicySkipsNanobotAgentServer(t *testing.T) {
 	client := newFakeClient(t, server)
 	req := router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1750,7 +1750,7 @@ func TestEnsureMCPNetworkPolicySkipsNanobotAgentServer(t *testing.T) {
 	require.NoError(t, err)
 
 	var policies v1.MCPNetworkPolicyList
-	require.NoError(t, client.List(context.Background(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
+	require.NoError(t, client.List(t.Context(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
 		"spec.mcpServerName": server.Name,
 	}))
 	require.Empty(t, policies.Items)
@@ -1774,7 +1774,7 @@ func TestEnsureMCPNetworkPolicyDeletesPolicyForUnsupportedRuntime(t *testing.T) 
 	client := newFakeClient(t, server, existing)
 	req := router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    server,
 		Namespace: server.Namespace,
 		Name:      server.Name,
@@ -1784,7 +1784,7 @@ func TestEnsureMCPNetworkPolicyDeletesPolicyForUnsupportedRuntime(t *testing.T) 
 	require.NoError(t, err)
 
 	var policies v1.MCPNetworkPolicyList
-	require.NoError(t, client.List(context.Background(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
+	require.NoError(t, client.List(t.Context(), &policies, kclient.InNamespace(server.Namespace), kclient.MatchingFields{
 		"spec.mcpServerName": server.Name,
 	}))
 	require.Empty(t, policies.Items)

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
@@ -1,7 +1,6 @@
 package mcpservercatalogentry
 
 import (
-	"context"
 	"testing"
 
 	"github.com/obot-platform/nah/pkg/router"
@@ -325,7 +324,7 @@ func TestEnsureUserCountSingleUserEntryCountsUniqueServerUsers(t *testing.T) {
 	client := newFakeClient(entry, server1, server2, server3)
 	err := (&Handler{}).EnsureUserCount(router.Request{
 		Client:    client,
-		Ctx:       context.Background(),
+		Ctx:       t.Context(),
 		Object:    entry,
 		Namespace: entry.Namespace,
 		Name:      entry.Name,

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
@@ -1,7 +1,6 @@
 package modelaccesspolicy
 
 import (
-	"context"
 	"testing"
 
 	"github.com/obot-platform/nah/pkg/router"
@@ -93,12 +92,12 @@ func TestPruneModels(t *testing.T) {
 			// Fetch the stored policy so the handler updates it with a valid resource version
 			var policy v1.ModelAccessPolicy
 			key := kclient.ObjectKey{Namespace: "default", Name: "test-policy"}
-			require.NoError(t, client.Get(context.Background(), key, &policy))
+			require.NoError(t, client.Get(t.Context(), key, &policy))
 
 			initialVersion := policy.ResourceVersion
 			err := PruneModels(router.Request{
 				Client:    client,
-				Ctx:       context.Background(),
+				Ctx:       t.Context(),
 				Object:    &policy,
 				Namespace: policy.Namespace,
 				Name:      policy.Name,
@@ -106,7 +105,7 @@ func TestPruneModels(t *testing.T) {
 			require.NoError(t, err)
 
 			var updated v1.ModelAccessPolicy
-			require.NoError(t, client.Get(context.Background(), key, &updated))
+			require.NoError(t, client.Get(t.Context(), key, &updated))
 
 			gotIDs := make([]string, 0, len(updated.Spec.Manifest.Models))
 			for _, m := range updated.Spec.Manifest.Models {

--- a/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
+++ b/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
@@ -95,7 +95,7 @@ func TestParseModelInfos_NoKnownProviders(t *testing.T) {
 }
 
 func TestSync(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("skips recent sync", func(t *testing.T) {
 		called := false

--- a/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
@@ -1,7 +1,6 @@
 package nanobotagent
 
 import (
-	"context"
 	"testing"
 
 	nanobottypes "github.com/obot-platform/nanobot/pkg/types"
@@ -40,7 +39,7 @@ func TestChooseModelPrefersKnownNames(t *testing.T) {
 		},
 	}
 
-	model, err := chooseModel(context.Background(), nil, "", models, types.DefaultModelAliasTypeLLM)
+	model, err := chooseModel(t.Context(), nil, "", models, types.DefaultModelAliasTypeLLM)
 	if err != nil {
 		t.Fatalf("expected model, got error: %v", err)
 	}
@@ -65,7 +64,7 @@ func TestChooseModelFallsBackToFirstActiveModel(t *testing.T) {
 		},
 	}
 
-	model, err := chooseModel(context.Background(), nil, "", models, types.DefaultModelAliasTypeLLM)
+	model, err := chooseModel(t.Context(), nil, "", models, types.DefaultModelAliasTypeLLM)
 	if err != nil {
 		t.Fatalf("expected model, got error: %v", err)
 	}
@@ -101,7 +100,7 @@ func TestChooseModelPrefersSuggestedOrder(t *testing.T) {
 		},
 	}
 
-	model, err := chooseModel(context.Background(), nil, "", models, types.DefaultModelAliasTypeLLM)
+	model, err := chooseModel(t.Context(), nil, "", models, types.DefaultModelAliasTypeLLM)
 	if err != nil {
 		t.Fatalf("expected model, got error: %v", err)
 	}
@@ -386,7 +385,7 @@ func TestResolveModelCarriesProviderAndDialect(t *testing.T) {
 			},
 		).Build()
 
-	model, err := resolveModel(context.Background(), c, "", types.DefaultModelAliasTypeLLM)
+	model, err := resolveModel(t.Context(), c, "", types.DefaultModelAliasTypeLLM)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -500,7 +499,7 @@ func TestChooseModelMiniFallsBackToResolvedLLM(t *testing.T) {
 		},
 	}
 
-	model, err := chooseModel(context.Background(), client, "", models, types.DefaultModelAliasTypeLLMMini)
+	model, err := chooseModel(t.Context(), client, "", models, types.DefaultModelAliasTypeLLMMini)
 	if err != nil {
 		t.Fatalf("expected model, got error: %v", err)
 	}

--- a/pkg/controller/handlers/skillrepository/skillrepository_test.go
+++ b/pkg/controller/handlers/skillrepository/skillrepository_test.go
@@ -111,7 +111,7 @@ func createFetchedRepo(t *testing.T, skills map[string]string) *fetchedRepositor
 }
 
 func TestUpsertSkills(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("create from scratch", func(t *testing.T) {
 		c := newFakeClient(t)
@@ -221,7 +221,7 @@ func TestUpsertSkills(t *testing.T) {
 }
 
 func TestListSkillsForRepo(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("filters by repoID", func(t *testing.T) {
 		skills := []kclient.Object{
@@ -279,7 +279,7 @@ func TestSync(t *testing.T) {
 		req := router.Request{
 			Client:    c,
 			Object:    repo,
-			Ctx:       context.Background(),
+			Ctx:       t.Context(),
 			Namespace: repo.Namespace,
 			Name:      repo.Name,
 			Key:       repo.Namespace + "/" + repo.Name,
@@ -291,7 +291,7 @@ func TestSync(t *testing.T) {
 
 		// Verify status
 		var updated v1.SkillRepository
-		require.NoError(t, c.Get(context.Background(), kclient.ObjectKey{Namespace: "default", Name: "repo1"}, &updated))
+		require.NoError(t, c.Get(t.Context(), kclient.ObjectKey{Namespace: "default", Name: "repo1"}, &updated))
 		assert.Empty(t, updated.Status.SyncError)
 		assert.Equal(t, "abc123def456", updated.Status.ResolvedCommitSHA)
 		assert.Equal(t, 2, updated.Status.DiscoveredSkillCount)
@@ -299,7 +299,7 @@ func TestSync(t *testing.T) {
 
 		// Verify skills created
 		var skills v1.SkillList
-		require.NoError(t, c.List(context.Background(), &skills, kclient.InNamespace("default")))
+		require.NoError(t, c.List(t.Context(), &skills, kclient.InNamespace("default")))
 		assert.Len(t, skills.Items, 2)
 
 		// Verify retry
@@ -325,7 +325,7 @@ func TestSync(t *testing.T) {
 		req := router.Request{
 			Client:    c,
 			Object:    repo,
-			Ctx:       context.Background(),
+			Ctx:       t.Context(),
 			Namespace: repo.Namespace,
 			Name:      repo.Name,
 			Key:       repo.Namespace + "/" + repo.Name,
@@ -365,7 +365,7 @@ func TestSync(t *testing.T) {
 		req := router.Request{
 			Client:    c,
 			Object:    repo,
-			Ctx:       context.Background(),
+			Ctx:       t.Context(),
 			Namespace: repo.Namespace,
 			Name:      repo.Name,
 			Key:       repo.Namespace + "/" + repo.Name,
@@ -378,7 +378,7 @@ func TestSync(t *testing.T) {
 
 		// Verify annotation was cleared
 		var updated v1.SkillRepository
-		require.NoError(t, c.Get(context.Background(), kclient.ObjectKey{Namespace: "default", Name: "repo1"}, &updated))
+		require.NoError(t, c.Get(t.Context(), kclient.ObjectKey{Namespace: "default", Name: "repo1"}, &updated))
 		_, hasAnnotation := updated.Annotations[v1.SkillRepositorySyncAnnotation]
 		assert.False(t, hasAnnotation, "sync annotation should be cleared after successful force sync")
 	})
@@ -399,7 +399,7 @@ func TestSync(t *testing.T) {
 		req := router.Request{
 			Client:    c,
 			Object:    repo,
-			Ctx:       context.Background(),
+			Ctx:       t.Context(),
 			Namespace: repo.Namespace,
 			Name:      repo.Name,
 			Key:       repo.Namespace + "/" + repo.Name,
@@ -410,7 +410,7 @@ func TestSync(t *testing.T) {
 		require.NoError(t, err) // handler returns nil, records error in status
 
 		var updated v1.SkillRepository
-		require.NoError(t, c.Get(context.Background(), kclient.ObjectKey{Namespace: "default", Name: "repo1"}, &updated))
+		require.NoError(t, c.Get(t.Context(), kclient.ObjectKey{Namespace: "default", Name: "repo1"}, &updated))
 		assert.Contains(t, updated.Status.SyncError, "network timeout")
 		assert.False(t, updated.Status.IsSyncing)
 		assert.Equal(t, syncInterval, resp.Delay)
@@ -444,7 +444,7 @@ func TestSync(t *testing.T) {
 		req := router.Request{
 			Client:    c,
 			Object:    repo,
-			Ctx:       context.Background(),
+			Ctx:       t.Context(),
 			Namespace: repo.Namespace,
 			Name:      repo.Name,
 			Key:       repo.Namespace + "/" + repo.Name,
@@ -455,7 +455,7 @@ func TestSync(t *testing.T) {
 		require.NoError(t, err)
 
 		var updated v1.SkillRepository
-		require.NoError(t, c.Get(context.Background(), kclient.ObjectKey{Namespace: "default", Name: "repo1"}, &updated))
+		require.NoError(t, c.Get(t.Context(), kclient.ObjectKey{Namespace: "default", Name: "repo1"}, &updated))
 		assert.NotEmpty(t, updated.Status.SyncError)
 		assert.False(t, updated.Status.IsSyncing)
 	})
@@ -464,7 +464,7 @@ func TestSync(t *testing.T) {
 func TestClearIsSyncing(t *testing.T) {
 	fixedTime := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
 	h := &Handler{now: func() time.Time { return fixedTime }}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("clears when true", func(t *testing.T) {
 		repo := newSkillRepository("repo1", "default")
@@ -502,7 +502,7 @@ func TestClearIsSyncing(t *testing.T) {
 }
 
 func TestClearSyncAnnotation(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("removes annotation", func(t *testing.T) {
 		repo := newSkillRepository("repo1", "default")
@@ -544,7 +544,7 @@ func TestClearSyncAnnotation(t *testing.T) {
 func TestRecordFailure(t *testing.T) {
 	fixedTime := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
 	h := &Handler{now: func() time.Time { return fixedTime }}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	repo := newSkillRepository("repo1", "default")
 	c := newFakeClient(t, repo)
@@ -562,7 +562,7 @@ func TestRecordFailure(t *testing.T) {
 func TestRecordSuccess(t *testing.T) {
 	fixedTime := time.Date(2026, 3, 11, 12, 0, 0, 0, time.UTC)
 	h := &Handler{now: func() time.Time { return fixedTime }}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	repo := newSkillRepository("repo1", "default")
 	repo.Status.SyncError = "previous error"
@@ -583,7 +583,7 @@ func TestRecordSuccess(t *testing.T) {
 }
 
 func TestMaterializeSkillSource(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("missing repoURL", func(t *testing.T) {
 		skill := &v1.Skill{

--- a/pkg/controller/migrate.go
+++ b/pkg/controller/migrate.go
@@ -2,13 +2,9 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"maps"
 
 	"github.com/obot-platform/obot/apiclient/types"
-	gateway "github.com/obot-platform/obot/pkg/gateway/client"
-	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -120,50 +116,6 @@ func deleteToolReferenceOwnedModels(ctx context.Context, client kclient.Client) 
 				return fmt.Errorf("failed to delete ToolReference-owned model %s/%s: %w", model.Namespace, model.Name, err)
 			}
 			break
-		}
-	}
-
-	return nil
-}
-
-func migrateMultiUserMCPServerManifestValuesToCredentials(ctx context.Context, client kclient.Client, gatewayClient *gateway.Client) error {
-	var servers v1.MCPServerList
-	if err := client.List(ctx, &servers); err != nil {
-		return err
-	}
-
-	for i := range servers.Items {
-		server := &servers.Items[i]
-		credCtx := mcpServerCredentialContext(*server)
-		if credCtx == "" {
-			continue
-		}
-
-		configValues, changed := extractAndClearMCPServerConfigValues(&server.Spec.Manifest)
-		if !changed {
-			continue
-		}
-
-		if len(configValues) > 0 {
-			if existingCred, err := gatewayClient.RevealCredential(ctx, []string{credCtx}, server.Name); err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
-				return fmt.Errorf("failed to find credential for MCP server %s: %w", server.Name, err)
-			} else if err == nil {
-				// Copy the new config values into the existing credential values so we don't lose any existing values that aren't in the manifest.
-				maps.Copy(existingCred.Secrets, configValues)
-				configValues = existingCred.Secrets
-			}
-
-			if err := gatewayClient.UpsertCredential(ctx, gatewaytypes.Credential{
-				Context: credCtx,
-				Name:    server.Name,
-				Secrets: configValues,
-			}); err != nil {
-				return fmt.Errorf("failed to create credential for MCP server %s: %w", server.Name, err)
-			}
-		}
-
-		if err := client.Update(ctx, server); err != nil {
-			return fmt.Errorf("failed to clear manifest config values for MCP server %s: %w", server.Name, err)
 		}
 	}
 

--- a/pkg/controller/migrate_test.go
+++ b/pkg/controller/migrate_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
@@ -26,7 +25,7 @@ func newFakeClient(t *testing.T, objects ...kclient.Object) kclient.Client {
 }
 
 func TestMigratePublishedArtifactVisibility(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("migrates public and private artifacts", func(t *testing.T) {
 		client := newFakeClient(t,
@@ -187,7 +186,7 @@ func TestMigrateAuditLogExportSourceTypes(t *testing.T) {
 }
 
 func TestDeleteToolReferenceOwnedModels(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	client := newFakeClient(t,
 		&v1.Model{
 			TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/serviceaccount_test.go
+++ b/pkg/controller/serviceaccount_test.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -45,7 +44,7 @@ func newRuntimeSecretClient() kclient.Client {
 }
 
 func TestReconcileServiceAccountKeyBootstrapsSecret(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gatewayClient := newTestGatewayClient(t)
 	base := time.Now().UTC().Add(-time.Hour)
 	controller := &Controller{
@@ -100,7 +99,7 @@ func TestReconcileServiceAccountKeyBootstrapsSecret(t *testing.T) {
 }
 
 func TestReconcileServiceAccountKeyRotatesWithOverlap(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gatewayClient := newTestGatewayClient(t)
 	base := time.Now().UTC().Add(-11 * time.Hour)
 	controller := &Controller{
@@ -175,7 +174,7 @@ func TestReconcileServiceAccountKeyRotatesWithOverlap(t *testing.T) {
 }
 
 func TestReconcileServiceAccountSecretChangeRecreatesDeletedSecret(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gatewayClient := newTestGatewayClient(t)
 	base := time.Now().UTC().Add(-time.Hour)
 	controller := &Controller{
@@ -302,7 +301,7 @@ func TestReconcileServiceAccountKeyRecreatesMissingFreshSecret(t *testing.T) {
 }
 
 func TestReconcileServiceAccountKeyDeletesExpiredOverlapKeys(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gatewayClient := newTestGatewayClient(t)
 	base := time.Now().UTC().Add(-11 * time.Hour)
 	controller := &Controller{
@@ -340,7 +339,7 @@ func TestReconcileServiceAccountKeyDeletesExpiredOverlapKeys(t *testing.T) {
 }
 
 func TestReconcileServiceAccountKeysSkipsWhenBackendNotKubernetes(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gatewayClient := newTestGatewayClient(t)
 	base := time.Now().UTC()
 	controller := &Controller{
@@ -371,7 +370,7 @@ func TestReconcileServiceAccountKeysSkipsWhenBackendNotKubernetes(t *testing.T) 
 }
 
 func TestReconcileServiceAccountKeysSkipsWhenNetworkPolicyProviderDisabled(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gatewayClient := newTestGatewayClient(t)
 	base := time.Now().UTC()
 	controller := &Controller{
@@ -402,7 +401,7 @@ func TestReconcileServiceAccountKeysSkipsWhenNetworkPolicyProviderDisabled(t *te
 }
 
 func TestReconcileServiceAccountKeysCleansUpWhenBackendDisabled(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gatewayClient := newTestGatewayClient(t)
 	base := time.Now().UTC()
 	account, _ := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)
@@ -455,7 +454,7 @@ func TestReconcileServiceAccountKeysCleansUpWhenBackendDisabled(t *testing.T) {
 }
 
 func TestReconcileServiceAccountKeysCleansUpWhenNetworkPolicyProviderDisabled(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	gatewayClient := newTestGatewayClient(t)
 	base := time.Now().UTC()
 	account, _ := serviceaccounts.Get(serviceaccounts.NetworkPolicyProvider)

--- a/pkg/gateway/client/apikey_create_test.go
+++ b/pkg/gateway/client/apikey_create_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -11,7 +10,7 @@ import (
 
 func TestCreateAPIKeyFromTokenRequestCopiesScopesAndUpdatesRequest(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tr := &types.TokenRequest{
 		ID:          "token-request-1",
@@ -75,7 +74,7 @@ func TestCreateAPIKeyFromTokenRequestCopiesScopesAndUpdatesRequest(t *testing.T)
 
 func TestCreateAPIKeyFromTokenRequestNoExpiration(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tr := &types.TokenRequest{
 		ID:           "token-request-1",

--- a/pkg/gateway/client/auditlogcleanup_test.go
+++ b/pkg/gateway/client/auditlogcleanup_test.go
@@ -42,7 +42,7 @@ func newTestClient(t *testing.T) *Client {
 func insertAuditLog(t *testing.T, c *Client, createdAt time.Time) {
 	t.Helper()
 	entry := types.MCPAuditLog{CreatedAt: createdAt}
-	if err := c.db.WithContext(context.Background()).Create(&entry).Error; err != nil {
+	if err := c.db.WithContext(t.Context()).Create(&entry).Error; err != nil {
 		t.Fatalf("failed to insert audit log: %v", err)
 	}
 }
@@ -50,7 +50,7 @@ func insertAuditLog(t *testing.T, c *Client, createdAt time.Time) {
 func countAuditLogs(t *testing.T, c *Client) int64 {
 	t.Helper()
 	var count int64
-	if err := c.db.WithContext(context.Background()).Model(&types.MCPAuditLog{}).Count(&count).Error; err != nil {
+	if err := c.db.WithContext(t.Context()).Model(&types.MCPAuditLog{}).Count(&count).Error; err != nil {
 		t.Fatalf("failed to count audit logs: %v", err)
 	}
 	return count
@@ -75,7 +75,7 @@ func countLLMAuditLogs(t *testing.T, c *Client) int64 {
 
 func TestDeleteOldAuditLogs(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Now().UTC()
 	today := now.Truncate(24 * time.Hour)
@@ -101,7 +101,7 @@ func TestDeleteOldAuditLogs(t *testing.T) {
 
 func TestDeleteOldAuditLogsDisabled(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Now().UTC()
 	insertAuditLog(t, c, now.AddDate(0, 0, -200))
@@ -119,7 +119,7 @@ func TestDeleteOldAuditLogsDisabled(t *testing.T) {
 
 func TestDeleteOldAuditLogsBatching(t *testing.T) {
 	c := newTestClient(t) // auditLogDeleteBatchSize = 3
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Now().UTC()
 	// Insert 7 old logs (requires 3 batches: 3+3+1) and 2 recent ones.
@@ -145,7 +145,7 @@ func TestRunAuditLogCleanup(t *testing.T) {
 	insertAuditLog(t, c, now.AddDate(0, 0, -100)) // old
 	insertAuditLog(t, c, now.AddDate(0, 0, -1))   // recent
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	go c.runMCPAuditLogCleanup(ctx, 90)

--- a/pkg/gateway/client/credential_migration_test.go
+++ b/pkg/gateway/client/credential_migration_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"testing"
 
 	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
@@ -9,7 +8,7 @@ import (
 
 func TestMigrateToolReferenceCredentialContexts(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	db := c.db.WithContext(ctx)
 
 	if err := db.Exec("CREATE TABLE toolreference (uid text)").Error; err != nil {

--- a/pkg/gateway/client/devicescan_test.go
+++ b/pkg/gateway/client/devicescan_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -13,7 +12,7 @@ import (
 
 func insertScan(t *testing.T, c *Client, scan types.DeviceScan) types.DeviceScan {
 	t.Helper()
-	if err := c.db.WithContext(context.Background()).Create(&scan).Error; err != nil {
+	if err := c.db.WithContext(t.Context()).Create(&scan).Error; err != nil {
 		t.Fatalf("failed to insert scan: %v", err)
 	}
 	return scan
@@ -24,7 +23,7 @@ func insertScan(t *testing.T, c *Client, scan types.DeviceScan) types.DeviceScan
 // for clients/skills, and time-window bounding.
 func TestGetDeviceScanStats(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Now().UTC()
 	old := now.Add(-180 * 24 * time.Hour)
@@ -151,7 +150,7 @@ func TestGetDeviceScanStats(t *testing.T) {
 // drops a previously-seen entity removes that device's contribution.
 func TestGetDeviceScanStats_LatestScanWins(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Now().UTC()
 	hash := "hash-changing"
@@ -200,7 +199,7 @@ func TestGetDeviceScanStats_LatestScanWins(t *testing.T) {
 // EnvKeys / HeaderKeys are unioned across observations.
 func TestGetMCPServerDetail(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Now().UTC()
 	hash := "h"
@@ -248,7 +247,7 @@ func TestGetMCPServerDetail(t *testing.T) {
 
 func TestDeviceClientFleetSummaries(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	now := time.Now().UTC()
 	h1 := "hash-one"

--- a/pkg/gateway/client/mcpauditlog_test.go
+++ b/pkg/gateway/client/mcpauditlog_test.go
@@ -58,7 +58,7 @@ func TestInsertMCPAuditLogsAllowsMultipleMCPRowsWithLocalAgentIndexes(t *testing
 
 func TestInsertMCPAuditLogsMergesResponseOnlyRowWithGroupedFields(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	now := time.Now().UTC()
 
 	request := types.MCPAuditLog{

--- a/pkg/gateway/client/serviceaccountapikey_test.go
+++ b/pkg/gateway/client/serviceaccountapikey_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -12,7 +11,7 @@ import (
 
 func TestCreateAndValidateServiceAccountAPIKey(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	created, err := c.CreateServiceAccountAPIKey(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC())
 	if err != nil {
@@ -31,7 +30,7 @@ func TestCreateAndValidateServiceAccountAPIKey(t *testing.T) {
 
 func TestValidateServiceAccountAPIKeyRejectsRetiredKey(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	created, err := c.CreateServiceAccountAPIKey(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC())
 	if err != nil {
@@ -53,7 +52,7 @@ func TestValidateServiceAccountAPIKeyRejectsRetiredKey(t *testing.T) {
 
 func TestDeleteExpiredServiceAccountAPIKeys(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	created, err := c.CreateServiceAccountAPIKey(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC())
 	if err != nil {
@@ -86,7 +85,7 @@ func TestDeleteExpiredServiceAccountAPIKeys(t *testing.T) {
 
 func TestRetireOtherServiceAccountAPIKeys(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	first, err := c.CreateServiceAccountAPIKey(ctx, serviceaccounts.NetworkPolicyProvider, time.Now().UTC().Add(-time.Hour))
 	if err != nil {
@@ -121,7 +120,7 @@ func TestRetireOtherServiceAccountAPIKeys(t *testing.T) {
 
 func TestValidateServiceAccountAPIKeyRejectsUnknownToken(t *testing.T) {
 	c := newTestClient(t)
-	if _, err := c.ValidateStorageServiceAccountToken(context.Background(), "osa1.bad.token"); err == nil {
+	if _, err := c.ValidateStorageServiceAccountToken(t.Context(), "osa1.bad.token"); err == nil {
 		t.Fatal("expected unknown token to be rejected")
 	} else if err != gorm.ErrRecordNotFound {
 		t.Fatalf("expected gorm.ErrRecordNotFound, got %v", err)

--- a/pkg/gateway/client/tokenactivity_test.go
+++ b/pkg/gateway/client/tokenactivity_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"math"
 	"testing"
 	"time"
@@ -12,7 +11,7 @@ import (
 // TestTokenActivityRoundTrip verifies TokenUsage persistence and aggregation.
 func TestTokenActivityRoundTrip(t *testing.T) {
 	c := newTestClient(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	now := time.Now()
 
 	rows := []types.RunTokenActivity{

--- a/pkg/gateway/server/llmproxy_model_reference_test.go
+++ b/pkg/gateway/server/llmproxy_model_reference_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	types2 "github.com/obot-platform/obot/apiclient/types"
@@ -17,7 +16,7 @@ func TestGetModelFromReference_ReturnsNotFoundWhenNameAndTargetMiss(t *testing.T
 		WithScheme(storagescheme.Scheme).
 		Build()
 
-	_, err := getModelFromReference(context.Background(), client, "default", "missing-model")
+	_, err := getModelFromReference(t.Context(), client, "default", "missing-model")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -45,7 +44,7 @@ func TestGetModelFromReference_ReturnsModelByResourceName(t *testing.T) {
 		WithObjects(model).
 		Build()
 
-	got, err := getModelFromReference(context.Background(), client, "default", "openai-gpt-4.1-mini")
+	got, err := getModelFromReference(t.Context(), client, "default", "openai-gpt-4.1-mini")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -74,7 +73,7 @@ func TestGetModelFromReference_DoesNotFallbackToManifestNameOrTargetModel(t *tes
 		Build()
 
 	for _, ref := range []string{"manifest-name", "target-model-id"} {
-		_, err := getModelFromReference(context.Background(), client, "default", ref)
+		_, err := getModelFromReference(t.Context(), client, "default", ref)
 		if err == nil {
 			t.Fatalf("%s: expected error, got nil", ref)
 		}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -228,7 +227,7 @@ func TestRepositorySizeChecksReturnSentinel(t *testing.T) {
 			}, nil
 		})
 
-		err := checkGitHubRepoSize(context.Background(), "example", "repo", 100, "")
+		err := checkGitHubRepoSize(t.Context(), "example", "repo", 100, "")
 		assert.ErrorIs(t, err, errRepoTooLarge)
 	})
 
@@ -241,7 +240,7 @@ func TestRepositorySizeChecksReturnSentinel(t *testing.T) {
 			}, nil
 		})
 
-		err := checkGitLabRepoSize(context.Background(), "gitlab.com", "example/repo", 100, "token")
+		err := checkGitLabRepoSize(t.Context(), "gitlab.com", "example/repo", 100, "token")
 		assert.ErrorIs(t, err, errRepoTooLarge)
 	})
 }

--- a/pkg/imagepullsecrets/imagepullsecrets_test.go
+++ b/pkg/imagepullsecrets/imagepullsecrets_test.go
@@ -1,7 +1,6 @@
 package imagepullsecrets
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -223,7 +222,7 @@ func TestBasicRegistryManifestBasicAuth(t *testing.T) {
 	}))
 	defer server.Close()
 
-	result, err := testBasicRegistryCredentials(context.Background(), server.Client(), strings.TrimPrefix(server.URL, "https://"), "grant", "secret", "team/app:1.0")
+	result, err := testBasicRegistryCredentials(t.Context(), server.Client(), strings.TrimPrefix(server.URL, "https://"), "grant", "secret", "team/app:1.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -264,7 +263,7 @@ func TestBasicRegistryManifestBearerAuth(t *testing.T) {
 	defer server.Close()
 	serverURL = server.URL
 
-	result, err := testBasicRegistryCredentials(context.Background(), server.Client(), strings.TrimPrefix(server.URL, "https://"), "grant", "secret", "team/app:1.0")
+	result, err := testBasicRegistryCredentials(t.Context(), server.Client(), strings.TrimPrefix(server.URL, "https://"), "grant", "secret", "team/app:1.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -292,7 +291,7 @@ func TestBasicRegistryManifestBearerRejectsCrossRegistryRealm(t *testing.T) {
 	}))
 	defer registry.Close()
 
-	_, err := testBasicRegistryCredentials(context.Background(), registry.Client(), strings.TrimPrefix(registry.URL, "https://"), "username", "secret", "team/app:1.0")
+	_, err := testBasicRegistryCredentials(t.Context(), registry.Client(), strings.TrimPrefix(registry.URL, "https://"), "username", "secret", "team/app:1.0")
 	if err == nil {
 		t.Fatal("expected cross-registry token realm to be rejected")
 	}
@@ -322,7 +321,7 @@ func TestBasicRegistryManifestBearerRejectsHTTPRealm(t *testing.T) {
 	defer server.Close()
 	serverURL = server.URL
 
-	_, err := testBasicRegistryCredentials(context.Background(), server.Client(), strings.TrimPrefix(server.URL, "https://"), "username", "secret", "team/app:1.0")
+	_, err := testBasicRegistryCredentials(t.Context(), server.Client(), strings.TrimPrefix(server.URL, "https://"), "username", "secret", "team/app:1.0")
 	if err == nil {
 		t.Fatal("expected http token realm to be rejected")
 	}
@@ -371,7 +370,7 @@ func TestDockerConfigJSONManifestAccess(t *testing.T) {
 		t.Fatalf("unexpected error building docker config: %v", err)
 	}
 
-	result, err := testDockerConfigJSONCredentials(context.Background(), server.Client(), configJSON, registry+"/team/app:1.0")
+	result, err := testDockerConfigJSONCredentials(t.Context(), server.Client(), configJSON, registry+"/team/app:1.0")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/license/provider_test.go
+++ b/pkg/license/provider_test.go
@@ -53,7 +53,7 @@ func TestRequireEntitlement(t *testing.T) {
 	}))
 	defer server.Close()
 	keygen.APIURL = server.URL
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	provider, err := NewProvider(ctx, nil, Config{
@@ -94,7 +94,7 @@ func TestRequireEntitlementMissing(t *testing.T) {
 	}))
 	defer server.Close()
 	keygen.APIURL = server.URL
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	provider, err := NewProvider(ctx, nil, Config{
@@ -115,7 +115,7 @@ func TestRequireEntitlementMissing(t *testing.T) {
 func TestNewProviderNotConfigured(t *testing.T) {
 	resetKeygen(t)
 
-	provider, err := NewProvider(context.Background(), nil, Config{})
+	provider, err := NewProvider(t.Context(), nil, Config{})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -159,7 +159,7 @@ func TestNewProviderActivatesLicenseOnNoMachine(t *testing.T) {
 	}))
 	defer server.Close()
 	keygen.APIURL = server.URL
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	provider, err := NewProvider(ctx, nil, Config{
@@ -203,7 +203,7 @@ func TestUpdateRefreshesEntitlements(t *testing.T) {
 	}))
 	defer server.Close()
 	keygen.APIURL = server.URL
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	provider, err := NewProvider(ctx, nil, Config{
@@ -251,7 +251,7 @@ func TestUpdateClearsEntitlementsWhenLicenseInvalid(t *testing.T) {
 	}))
 	defer server.Close()
 	keygen.APIURL = server.URL
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	provider, err := NewProvider(ctx, nil, Config{

--- a/pkg/localagents/claudecode_test.go
+++ b/pkg/localagents/claudecode_test.go
@@ -1,7 +1,6 @@
 package localagents
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,7 +16,7 @@ func TestClaudeCodeDetectPresentFromConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := ClaudeCode{home: home}.Detect(context.Background())
+	result := ClaudeCode{home: home}.Detect(t.Context())
 	if result.State != DetectionPresent {
 		t.Fatalf("State = %q, want %q; reason: %s", result.State, DetectionPresent, result.Reason)
 	}
@@ -29,7 +28,7 @@ func TestClaudeCodeDetectPresentFromConfig(t *testing.T) {
 func TestClaudeCodeDetectMissing(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 
-	result := ClaudeCode{home: t.TempDir()}.Detect(context.Background())
+	result := ClaudeCode{home: t.TempDir()}.Detect(t.Context())
 	if result.State != DetectionMissing {
 		t.Fatalf("State = %q, want %q; reason: %s", result.State, DetectionMissing, result.Reason)
 	}
@@ -38,7 +37,7 @@ func TestClaudeCodeDetectMissing(t *testing.T) {
 func TestClaudeCodeInstallBootstrapWritesExpectedSkills(t *testing.T) {
 	home := t.TempDir()
 
-	result, err := NewClaudeCode().InstallBootstrap(context.Background(), home)
+	result, err := NewClaudeCode().InstallBootstrap(t.Context(), home)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +68,7 @@ func TestClaudeCodeInstallBootstrapOverwritesExistingContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := NewClaudeCode().InstallBootstrap(context.Background(), home); err != nil {
+	if _, err := NewClaudeCode().InstallBootstrap(t.Context(), home); err != nil {
 		t.Fatal(err)
 	}
 
@@ -99,7 +98,7 @@ func TestClaudeCodeInstallSkillWritesSanitizedDirectory(t *testing.T) {
 		},
 	}
 
-	result, err := NewClaudeCode().InstallSkill(context.Background(), home, skill)
+	result, err := NewClaudeCode().InstallSkill(t.Context(), home, skill)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +129,7 @@ func TestClaudeCodeInstallSkillReplacesExistingTarget(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := NewClaudeCode().InstallSkill(context.Background(), home, SkillArchive{
+	_, err := NewClaudeCode().InstallSkill(t.Context(), home, SkillArchive{
 		Name: "github-review",
 		Files: []SkillArchiveFile{
 			{
@@ -152,7 +151,7 @@ func TestClaudeCodeInstallSkillReplacesExistingTarget(t *testing.T) {
 func TestClaudeCodeInstallSkillRejectsUnsafeArchivePaths(t *testing.T) {
 	for _, relPath := range []string{"/tmp/escape", "../escape", "nested/../../escape"} {
 		t.Run(relPath, func(t *testing.T) {
-			_, err := NewClaudeCode().InstallSkill(context.Background(), t.TempDir(), SkillArchive{
+			_, err := NewClaudeCode().InstallSkill(t.Context(), t.TempDir(), SkillArchive{
 				Name: "safe-name",
 				Files: []SkillArchiveFile{
 					{RelPath: skillformat.SkillMainFile, Content: []byte("---\nname: safe-name\ndescription: Safe.\n---\n")},

--- a/pkg/mcp/backend_test.go
+++ b/pkg/mcp/backend_test.go
@@ -32,7 +32,7 @@ func TestEnsureServerReadyUsesHealthzPath(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	if err := ensureServerReady(ctx, server.URL, ServerConfig{
@@ -66,7 +66,7 @@ func TestEnsureServerReadyHealthzPathWaitsForOK(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	if err := ensureServerReady(ctx, server.URL+"/", ServerConfig{HealthzPath: "healthz"}); err != nil {

--- a/pkg/mcp/secretbindings_test.go
+++ b/pkg/mcp/secretbindings_test.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"context"
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
@@ -39,7 +38,7 @@ func TestMergeBoundCreds(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
 		})
 
-		out, err := MergeBoundCreds(context.Background(), c, ns, manifestEnv, nil, input, label)
+		out, err := MergeBoundCreds(t.Context(), c, ns, manifestEnv, nil, input, label)
 		require.NoError(t, err)
 		assert.Equal(t, inputBefore, input)
 		assert.Equal(t, "fresh", out["API_KEY"])
@@ -50,7 +49,7 @@ func TestMergeBoundCreds(t *testing.T) {
 		manifestEnv := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", SecretBinding: binding("missing-secret", "api_key")}}}
 		input := map[string]string{"API_KEY": "stale", "OTHER": "ok"}
 
-		out, err := MergeBoundCreds(context.Background(), newClient(t), ns, manifestEnv, nil, input, label)
+		out, err := MergeBoundCreds(t.Context(), newClient(t), ns, manifestEnv, nil, input, label)
 		require.NoError(t, err)
 		assert.NotContains(t, out, "API_KEY")
 		assert.Equal(t, "ok", out["OTHER"])
@@ -60,7 +59,7 @@ func TestMergeBoundCreds(t *testing.T) {
 			Data:       map[string][]byte{"other": []byte("x")},
 			ObjectMeta: metav1.ObjectMeta{Name: "present-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
 		})
-		out, err = MergeBoundCreds(context.Background(), c, ns, manifestEnv, nil, input, label)
+		out, err = MergeBoundCreds(t.Context(), c, ns, manifestEnv, nil, input, label)
 		require.NoError(t, err)
 		assert.NotContains(t, out, "API_KEY")
 	})
@@ -72,7 +71,7 @@ func TestMergeBoundCreds(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "auth-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
 		})
 
-		out, err := MergeBoundCreds(context.Background(), c, ns, nil, remote, map[string]string{"Authorization": "stale"}, label)
+		out, err := MergeBoundCreds(t.Context(), c, ns, nil, remote, map[string]string{"Authorization": "stale"}, label)
 		require.NoError(t, err)
 		assert.Equal(t, "Bearer abc", out["Authorization"])
 	})
@@ -82,7 +81,7 @@ func TestMergeBoundCreds(t *testing.T) {
 		remote := &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", SecretBinding: binding("s", "token")}}}
 		in := map[string]string{"API_KEY": "x", "Authorization": "y", "OTHER": "ok"}
 
-		out, err := MergeBoundCreds(context.Background(), nil, ns, manifestEnv, remote, in, label)
+		out, err := MergeBoundCreds(t.Context(), nil, ns, manifestEnv, remote, in, label)
 		require.NoError(t, err)
 		assert.NotContains(t, out, "API_KEY")
 		assert.NotContains(t, out, "Authorization")
@@ -97,7 +96,7 @@ func TestMergeBoundCreds(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
 		})
 
-		out, err := MergeBoundCreds(context.Background(), c, ns, manifestEnv, nil, in, label)
+		out, err := MergeBoundCreds(t.Context(), c, ns, manifestEnv, nil, in, label)
 		require.NoError(t, err)
 		assert.NotContains(t, out, "API_KEY")
 	})
@@ -110,7 +109,7 @@ func TestMergeBoundCreds(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns},
 		})
 
-		out, err := MergeBoundCreds(context.Background(), c, ns, manifestEnv, nil, in, label)
+		out, err := MergeBoundCreds(t.Context(), c, ns, manifestEnv, nil, in, label)
 		require.NoError(t, err)
 		assert.NotContains(t, out, "API_KEY")
 		assert.Equal(t, "ok", out["OTHER"])
@@ -136,11 +135,11 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
 		})
 
-		require.NoError(t, ValidateSecretBindingsAvailable(context.Background(), c, ns, requiredEnv, nil, label))
+		require.NoError(t, ValidateSecretBindingsAvailable(t.Context(), c, ns, requiredEnv, nil, label))
 	})
 
 	t.Run("missing secret", func(t *testing.T) {
-		err := ValidateSecretBindingsAvailable(context.Background(), newClient(t), ns, requiredEnv, nil, label)
+		err := ValidateSecretBindingsAvailable(t.Context(), newClient(t), ns, requiredEnv, nil, label)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
 	})
@@ -151,7 +150,7 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
 		})
 
-		err := ValidateSecretBindingsAvailable(context.Background(), c, ns, requiredEnv, nil, label)
+		err := ValidateSecretBindingsAvailable(t.Context(), c, ns, requiredEnv, nil, label)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
 	})
@@ -162,7 +161,7 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
 		})
 
-		err := ValidateSecretBindingsAvailable(context.Background(), c, ns, requiredEnv, nil, label)
+		err := ValidateSecretBindingsAvailable(t.Context(), c, ns, requiredEnv, nil, label)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
 	})
@@ -173,7 +172,7 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns},
 		})
 
-		err := ValidateSecretBindingsAvailable(context.Background(), c, ns, requiredEnv, nil, label)
+		err := ValidateSecretBindingsAvailable(t.Context(), c, ns, requiredEnv, nil, label)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
 	})
@@ -181,7 +180,7 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 	t.Run("binding is checked even when optional", func(t *testing.T) {
 		env := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", SecretBinding: binding("missing", "api_key")}}}
 
-		err := ValidateSecretBindingsAvailable(context.Background(), newClient(t), ns, env, nil, label)
+		err := ValidateSecretBindingsAvailable(t.Context(), newClient(t), ns, env, nil, label)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unavailable Kubernetes Secret")
 	})
@@ -193,13 +192,13 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "auth-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
 		})
 
-		require.NoError(t, ValidateSecretBindingsAvailable(context.Background(), c, ns, nil, remote, label))
+		require.NoError(t, ValidateSecretBindingsAvailable(t.Context(), c, ns, nil, remote, label))
 	})
 
 	t.Run("reports all missing bindings", func(t *testing.T) {
 		remote := &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", Required: true, SecretBinding: binding("auth-secret", "token")}}}
 
-		err := ValidateSecretBindingsAvailable(context.Background(), newClient(t), ns, requiredEnv, remote, label)
+		err := ValidateSecretBindingsAvailable(t.Context(), newClient(t), ns, requiredEnv, remote, label)
 		require.Error(t, err)
 		assert.Equal(t, err.Error(), `secret bindings reference unavailable Kubernetes Secrets: env "API_KEY" references obot-ns/bound-secret, header "Authorization" references obot-ns/auth-secret`)
 	})
@@ -216,7 +215,7 @@ func TestMissingSecretBindings(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
 	}).Build()
 
-	missing, err := MissingSecretBindings(context.Background(), c, ns,
+	missing, err := MissingSecretBindings(t.Context(), c, ns,
 		[]types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "ENV_KEY", SecretBinding: binding("bound-secret", "env_key")}}},
 		&types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", SecretBinding: binding("missing-secret", "token")}}},
 		label,
@@ -252,7 +251,7 @@ func TestListAllowedSecretBindingTargets(t *testing.T) {
 		},
 	).Build()
 
-	targets, err := ListAllowedSecretBindingTargets(context.Background(), c, ns, label)
+	targets, err := ListAllowedSecretBindingTargets(t.Context(), c, ns, label)
 	require.NoError(t, err)
 	assert.Equal(t, []types.MCPAllowedSecretBindingTarget{
 		{Name: "a-secret", Keys: []string{"token"}},

--- a/pkg/mdmassets/import_test.go
+++ b/pkg/mdmassets/import_test.go
@@ -19,11 +19,11 @@ import (
 
 func TestImportDirectoryProducesImmutableDatabaseBundle(t *testing.T) {
 	dir := writeAssets(t, SchemaVersion)
-	first, err := Import(context.Background(), dir)
+	first, err := Import(t.Context(), dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := Import(context.Background(), dir)
+	second, err := Import(t.Context(), dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,12 +57,12 @@ func TestImportDirectoryProducesImmutableDatabaseBundle(t *testing.T) {
 
 func TestImportPersistsOnlyManifestClosure(t *testing.T) {
 	dir := writeAssets(t, SchemaVersion)
-	before, err := Import(context.Background(), dir)
+	before, err := Import(t.Context(), dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	mustWrite(t, filepath.Join(dir, "unrelated-secret.txt"), "must-not-enter-database")
-	after, err := Import(context.Background(), dir)
+	after, err := Import(t.Context(), dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestImportPersistsOnlyManifestClosure(t *testing.T) {
 
 func TestImportRemoteTarStripsCommonRoot(t *testing.T) {
 	dir := writeAssets(t, SchemaVersion)
-	want, err := Import(context.Background(), dir)
+	want, err := Import(t.Context(), dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestImportRemoteTarStripsCommonRoot(t *testing.T) {
 			Body:       io.NopCloser(bytes.NewReader(archive)),
 		}, nil
 	})}
-	got, err := importSource(context.Background(), "https://example.test/release.tar", client)
+	got, err := importSource(t.Context(), "https://example.test/release.tar", client)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestImportRejectsUnsafeArchiveEntries(t *testing.T) {
 			if err := tw.Close(); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := readTar(context.Background(), buf.Bytes()); err == nil {
+			if _, err := readTar(t.Context(), buf.Bytes()); err == nil {
 				t.Fatalf("unsafe tar entry %q was accepted", header.Name)
 			}
 		})
@@ -142,7 +142,7 @@ func TestImportRejectsOverflowingTarSize(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readTar(context.Background(), buf.Bytes()); err == nil || !strings.Contains(err.Error(), "maximum extracted size") {
+	if _, err := readTar(t.Context(), buf.Bytes()); err == nil || !strings.Contains(err.Error(), "maximum extracted size") {
 		t.Fatalf("overflowing tar entry should be rejected by the size limit, got %v", err)
 	}
 }
@@ -163,7 +163,7 @@ func TestImportRejectsDirectoryHeaderBomb(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := readTar(context.Background(), buf.Bytes())
+	_, err := readTar(t.Context(), buf.Bytes())
 	if err == nil || !strings.Contains(err.Error(), "maximum entry count") {
 		t.Fatalf("directory header bomb should be rejected by the entry limit, got %v", err)
 	}
@@ -201,14 +201,14 @@ func TestImportRejectsDecodedGzipExpansion(t *testing.T) {
 		t.Fatalf("test archive did not compress below decoded limit: %d bytes", compressed.Len())
 	}
 
-	_, err := readTarWithDecodedLimit(context.Background(), compressed.Bytes(), decodedLimit)
+	_, err := readTarWithDecodedLimit(t.Context(), compressed.Bytes(), decodedLimit)
 	if err == nil || !strings.Contains(err.Error(), "maximum decoded size") {
 		t.Fatalf("gzip expansion should be rejected by the decoded-size limit, got %v", err)
 	}
 }
 
 func TestImportTarScanHonorsCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	_, err := readTar(ctx, nil)
@@ -221,7 +221,7 @@ func TestRemoteImportErrorDoesNotLeakSignedURL(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return nil, &url.Error{URL: "https://redirect.example/assets.tar?token=redirect-secret", Err: errors.New("failed")}
 	})}
-	_, err := importSource(context.Background(), "https://example.test/assets.tar?token=source-secret", client)
+	_, err := importSource(t.Context(), "https://example.test/assets.tar?token=source-secret", client)
 	if err == nil {
 		t.Fatal("expected download error")
 	}
@@ -242,7 +242,7 @@ func TestImportRejectsLocalSymlink(t *testing.T) {
 	if err := os.Symlink(filepath.Join(dir, "manifest.json"), filepath.Join(dir, "manifest-link.json")); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
-	if _, err := Import(context.Background(), dir); err == nil || !strings.Contains(err.Error(), "symbolic link") {
+	if _, err := Import(t.Context(), dir); err == nil || !strings.Contains(err.Error(), "symbolic link") {
 		t.Fatalf("symlink should be rejected, got %v", err)
 	}
 }

--- a/pkg/messagepolicy/evaluate_test.go
+++ b/pkg/messagepolicy/evaluate_test.go
@@ -1,7 +1,6 @@
 package messagepolicy
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -29,7 +28,7 @@ func TestCallLLMBedrockAnthropicMessages(t *testing.T) {
 	}))
 	defer server.Close()
 
-	result, err := (&Helper{}).callLLM(context.Background(), &resolvedModel{
+	result, err := (&Helper{}).callLLM(t.Context(), &resolvedModel{
 		targetModel:  "anthropic.claude-haiku-4-5",
 		providerName: system.AmazonBedrockModelProvider,
 		providerURL:  server.URL + "/anthropic/v1",
@@ -63,7 +62,7 @@ func TestCallLLMBedrockOpenAIResponses(t *testing.T) {
 	defer server.Close()
 
 	for _, dialect := range []nanobottypes.Dialect{nanobottypes.DialectOpenAIResponses, nanobottypes.DialectOpenResponses} {
-		result, err := (&Helper{}).callLLM(context.Background(), &resolvedModel{
+		result, err := (&Helper{}).callLLM(t.Context(), &resolvedModel{
 			targetModel:  "openai.gpt-oss-120b-1:0",
 			providerName: system.AmazonBedrockAPIKeyModelProvider,
 			providerURL:  server.URL + "/openai/v1",
@@ -95,7 +94,7 @@ func TestCallLLMGenericResponses(t *testing.T) {
 	}))
 	defer server.Close()
 
-	result, err := (&Helper{}).callLLM(context.Background(), &resolvedModel{
+	result, err := (&Helper{}).callLLM(t.Context(), &resolvedModel{
 		targetModel:  "open-model",
 		providerName: system.GenericResponsesModelProvider,
 		providerURL:  server.URL + "/v1",
@@ -134,7 +133,7 @@ func TestCallLLMAzureAnthropicMessages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := (&Helper{}).callLLM(context.Background(), &resolvedModel{
+	result, err := (&Helper{}).callLLM(t.Context(), &resolvedModel{
 		targetModel:  "claude-sonnet",
 		providerName: system.AzureModelProvider,
 		providerURL:  server.URL + "/anthropic/v1",
@@ -162,7 +161,7 @@ func TestCallLLMAzureOpenAIResponses(t *testing.T) {
 	}))
 	defer server.Close()
 
-	result, err := (&Helper{}).callLLM(context.Background(), &resolvedModel{
+	result, err := (&Helper{}).callLLM(t.Context(), &resolvedModel{
 		targetModel:  "gpt-5",
 		providerName: system.AzureEntraModelProvider,
 		providerURL:  server.URL + "/openai/v1",
@@ -185,7 +184,7 @@ func TestCallLLMNonBedrockAnthropicUsesChatCompletions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	result, err := (&Helper{}).callLLM(context.Background(), &resolvedModel{
+	result, err := (&Helper{}).callLLM(t.Context(), &resolvedModel{
 		targetModel:  "claude-haiku-4-5",
 		providerName: system.AnthropicModelProvider,
 		providerURL:  server.URL + "/v1",

--- a/pkg/storage/blob/directory_test.go
+++ b/pkg/storage/blob/directory_test.go
@@ -2,7 +2,6 @@ package blob
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -40,7 +39,7 @@ func TestDirectoryStore_UploadAndDownload(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	content := []byte("hello, world")
 
 	if err := store.Upload(ctx, "bucket", "key.txt", bytes.NewReader(content)); err != nil {
@@ -68,7 +67,7 @@ func TestDirectoryStore_UploadNestedKey(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	content := []byte("nested content")
 
 	if err := store.Upload(ctx, "bucket", "published-artifacts/my-artifact/v1.zip", bytes.NewReader(content)); err != nil {
@@ -96,7 +95,7 @@ func TestDirectoryStore_DownloadNotFound(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	_, err = store.Download(context.Background(), "bucket", "nonexistent")
+	_, err = store.Download(t.Context(), "bucket", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for nonexistent key")
 	}
@@ -108,7 +107,7 @@ func TestDirectoryStore_Delete(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := store.Upload(ctx, "bucket", "key.txt", bytes.NewReader([]byte("data"))); err != nil {
 		t.Fatalf("upload failed: %v", err)
 	}
@@ -129,7 +128,7 @@ func TestDirectoryStore_DeleteNotFound(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	err = store.Delete(context.Background(), "bucket", "nonexistent")
+	err = store.Delete(t.Context(), "bucket", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for deleting nonexistent key")
 	}
@@ -141,7 +140,7 @@ func TestDirectoryStore_PathTraversal(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Traversal in bucket
 	if err := store.Upload(ctx, "../escape", "key.txt", bytes.NewReader([]byte("bad"))); err == nil {
@@ -190,7 +189,7 @@ func TestDirectoryStore_Test(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if err := store.Test(context.Background()); err != nil {
+	if err := store.Test(t.Context()); err != nil {
 		t.Fatalf("test failed: %v", err)
 	}
 }
@@ -201,7 +200,7 @@ func TestDirectoryStore_UploadOverwrite(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	if err := store.Upload(ctx, "bucket", "key.txt", bytes.NewReader([]byte("first"))); err != nil {
 		t.Fatalf("first upload failed: %v", err)


### PR DESCRIPTION
A previous change remove all environment variable values from the MCP server object and stored them in a credential. Since we removed them from the MCP server but they remain on the MCP server catalog entry, this caused erroneous drift detection results.

This change will populate the credential for the MCP server when doing drift detection so we can properly compare the values against those on the catalog entry.

Additionally, we remove a migration that was causing this issue. The actual problem is not fixed and migrating doesn't make sense until we fix the underlying issue.

Issue: https://github.com/obot-platform/obot/issues/7223