### PR TITLE
fix: install cli text fix

### DIFF
--- a/ui/user/src/routes/install-cli/+page.svelte
+++ b/ui/user/src/routes/install-cli/+page.svelte
@@ -262,7 +262,7 @@
 				><CheckIcon class="text-success size-4 inline" /> Connected Cursor and Claude Code</code
 			></pre>
 		<pre></pre>
-		<pre data-prefix="$"><code>obot mcp</code></pre>
+		<pre data-prefix="$"><code>obot mcp search</code></pre>
 		<pre data-prefix=">"><code
 				><CheckIcon class="text-success size-4 inline" /> 24 MCP servers available</code
 			></pre>


### PR DESCRIPTION
Quick one-line fix!

Addresses the mock cli interface in Install CLI where it should be the full obot mcp command: obot mcp search instead of just obot mcp.

Addresses Follow-up In #7253 