### PR TITLE
enhance: improve repository credential selection

### DIFF
--- a/ui/user/src/lib/components/Select.svelte
+++ b/ui/user/src/lib/components/Select.svelte
@@ -17,6 +17,7 @@
 		};
 		position?: 'top' | 'bottom';
 		placeholder?: string;
+		searchPlaceholder?: string;
 		clearAllLabel?: string;
 		onClear?: (option?: T, value?: string | number) => void;
 		onClearAll?: () => void;
@@ -51,6 +52,7 @@
 		classes,
 		position = 'bottom',
 		placeholder,
+		searchPlaceholder,
 		clearAllLabel,
 		onClear,
 		onClearAll,
@@ -370,7 +372,7 @@
 			'min-w-0 flex-1 bg-inherit focus:ring-0 focus:outline-none',
 			!multiple && 'px-2 py-4'
 		)}
-		{placeholder}
+		placeholder={searchInDropdown ? (searchPlaceholder ?? placeholder) : placeholder}
 		bind:this={input}
 		bind:value={query}
 		{disabled}

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -22,7 +22,7 @@
 	type RepositoryCredentialType = '' | 'shared' | 'token';
 
 	const repositoryCredentialOptions = [
-		{ id: 'shared', label: 'Shared Git Credential' },
+		{ id: 'shared', label: 'Saved Git Credential' },
 		{ id: 'token', label: 'Personal Access Token' }
 	];
 
@@ -235,15 +235,15 @@
 			{#if editingSource.credentialType === 'shared'}
 				<div class="mb-4 flex flex-col gap-1">
 					<label for="catalog-source-git-credential" class="text-sm font-light">
-						Shared Git credential
+						Saved Git credential
 					</label>
 					<Select
 						id="catalog-source-git-credential"
 						options={gitCredentialOptions}
 						selected={editingSource.gitCredentialID}
 						placeholder={gitCredentials.length
-							? 'Select a shared credential'
-							: 'No shared credentials'}
+							? 'Select a saved credential'
+							: 'No saved credentials'}
 						searchInDropdown
 						onSelect={(option) => {
 							if (editingSource) {

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -275,6 +275,7 @@
 
 			{#if editingSource.credentialType === 'token'}
 				<div class="mb-4 flex flex-col gap-1">
+					<label for="catalog-source-token" class="sr-only">Personal Access Token</label>
 					{#if editingSource.index >= 0 && hasSourceURLCredential(defaultCatalog?.sourceURLs?.[editingSource.index]) && !editingSource.clearToken}
 						<div class="flex justify-end">
 							<button

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -268,7 +268,7 @@
 				<div class="mb-4 flex flex-col gap-1">
 					<div class="flex items-center justify-between">
 						<label for="catalog-source-token" class="flex items-center gap-1 text-sm font-light">
-							Personal access token
+							Personal Access Token
 							<span
 								use:tooltip={{
 									text: 'Required scopes:\n• GitHub: repo\n• GitLab: read_repository + read_api\n\nIf no token is set, Obot falls back to the GITHUB_AUTH_TOKEN environment variable.',

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -19,6 +19,13 @@
 		gitCredentials?: GitCredential[];
 	}
 
+	type RepositoryCredentialType = '' | 'shared' | 'token';
+
+	const repositoryCredentialOptions = [
+		{ id: 'shared', label: 'Shared Git Credential' },
+		{ id: 'token', label: 'Personal Access Token' }
+	];
+
 	let { defaultCatalog, onSync, defaultCatalogId, gitCredentials = [] }: Props = $props();
 
 	let saving = $state(false);
@@ -28,6 +35,7 @@
 		value: string;
 		token: string;
 		gitCredentialID: string;
+		credentialType: RepositoryCredentialType;
 		clearToken?: boolean;
 	}>();
 	let sourceDialog = $state<HTMLDialogElement>();
@@ -42,7 +50,8 @@
 			index: -1,
 			value: '',
 			token: '',
-			gitCredentialID: ''
+			gitCredentialID: '',
+			credentialType: ''
 		};
 		sourceDialog?.showModal();
 	}
@@ -55,7 +64,12 @@
 			index,
 			value: url,
 			token: '',
-			gitCredentialID: defaultCatalog?.sourceURLGitCredentialIDs?.[url] ?? ''
+			gitCredentialID: defaultCatalog?.sourceURLGitCredentialIDs?.[url] ?? '',
+			credentialType: defaultCatalog?.sourceURLGitCredentialIDs?.[url]
+				? 'shared'
+				: hasSourceURLCredential(url)
+					? 'token'
+					: ''
 		};
 		sourceDialog?.showModal();
 	}
@@ -90,6 +104,17 @@
 			editingSource.value !== editingSourceURL &&
 			hasSourceURLCredential(editingSourceURL, defaultCatalog) &&
 			!editingSource.token
+		)
+	);
+	const credentialSelectionIncomplete = $derived(
+		Boolean(
+			editingSource &&
+			((editingSource.credentialType === 'shared' && !editingSource.gitCredentialID) ||
+				(editingSource.credentialType === 'token' &&
+					!editingSource.token.trim() &&
+					(editingSource.clearToken ||
+						editingSource.value !== editingSourceURL ||
+						!hasSourceURLCredential(editingSourceURL))))
 		)
 	);
 	const editingSourceHost = $derived(sourceHost(editingSource?.value ?? ''));
@@ -177,38 +202,73 @@
 			</div>
 
 			<div class="mb-4 flex flex-col gap-1">
-				<label for="catalog-source-git-credential" class="text-sm font-light">
-					Shared Git credential (optional)
-				</label>
 				<Select
-					id="catalog-source-git-credential"
-					options={gitCredentialOptions}
-					selected={editingSource.gitCredentialID}
-					placeholder={gitCredentials.length
-						? 'Use a one-off token or public access'
-						: 'No shared credentials'}
-					searchInDropdown
+					id="catalog-source-credential-type"
+					options={repositoryCredentialOptions}
+					selected={editingSource.credentialType}
+					placeholder="Repository Credential (optional)"
+					class={!editingSource.credentialType ? 'text-muted-content' : undefined}
 					onSelect={(option) => {
-						if (editingSource) {
-							editingSource.gitCredentialID = String(option.id);
+						if (!editingSource) return;
+						editingSource.credentialType = option.id as RepositoryCredentialType;
+						if (option.id === 'shared') {
 							editingSource.token = '';
-							editingSource.clearToken = false;
+						} else {
+							editingSource.gitCredentialID = '';
 						}
 					}}
-					onClear={() => {
-						if (editingSource) editingSource.gitCredentialID = '';
-					}}
+					onClear={editingSource.credentialType
+						? () => {
+								if (!editingSource) return;
+								editingSource.credentialType = '';
+								editingSource.gitCredentialID = '';
+								editingSource.token = '';
+								if (hasSourceURLCredential(editingSourceURL)) {
+									editingSource.clearToken = true;
+									tokenExplicitlyCleared = true;
+								}
+							}
+						: undefined}
 				/>
-				<span class="text-muted-content text-xs">
-					Only credentials matching the source host can be selected.
-				</span>
 			</div>
 
-			{#if !editingSource.gitCredentialID}
+			{#if editingSource.credentialType === 'shared'}
+				<div class="mb-4 flex flex-col gap-1">
+					<label for="catalog-source-git-credential" class="text-sm font-light">
+						Shared Git credential
+					</label>
+					<Select
+						id="catalog-source-git-credential"
+						options={gitCredentialOptions}
+						selected={editingSource.gitCredentialID}
+						placeholder={gitCredentials.length
+							? 'Select a shared credential'
+							: 'No shared credentials'}
+						searchInDropdown
+						onSelect={(option) => {
+							if (editingSource) {
+								editingSource.gitCredentialID = String(option.id);
+								editingSource.token = '';
+								editingSource.clearToken = false;
+							}
+						}}
+						onClear={editingSource.gitCredentialID
+							? () => {
+									if (editingSource) editingSource.gitCredentialID = '';
+								}
+							: undefined}
+					/>
+					<span class="text-muted-content text-xs">
+						Only credentials matching the source host can be selected.
+					</span>
+				</div>
+			{/if}
+
+			{#if editingSource.credentialType === 'token'}
 				<div class="mb-4 flex flex-col gap-1">
 					<div class="flex items-center justify-between">
 						<label for="catalog-source-token" class="flex items-center gap-1 text-sm font-light">
-							Personal access token (optional)
+							Personal access token
 							<span
 								use:tooltip={{
 									text: 'Required scopes:\n• GitHub: repo\n• GitLab: read_repository + read_api\n\nIf no token is set, Obot falls back to the GITHUB_AUTH_TOKEN environment variable.',
@@ -278,7 +338,7 @@
 				>
 				<button
 					class="btn btn-primary"
-					disabled={saving}
+					disabled={saving || credentialSelectionIncomplete}
 					onclick={async () => {
 						if (!editingSource || (!defaultCatalog && !defaultCatalogId)) {
 							return;
@@ -326,7 +386,12 @@
 								sourceURLCredentials[oldURL] = '';
 							}
 
-							if (editingSource.clearToken && !editingSource.token) {
+							if (
+								!editingSource.token &&
+								(editingSource.clearToken ||
+									(editingSource.credentialType !== 'token' &&
+										hasSourceURLCredential(oldURL, catalogToUse)))
+							) {
 								sourceURLCredentials[newURL] = '';
 							} else if (editingSource.token) {
 								sourceURLCredentials[newURL] = editingSource.token;

--- a/ui/user/src/lib/components/admin/McpServerGitSync.svelte
+++ b/ui/user/src/lib/components/admin/McpServerGitSync.svelte
@@ -170,6 +170,19 @@
 	}
 </script>
 
+{#snippet tokenScopesTooltip()}
+	<div class="text-left">
+		<p>Required scopes:</p>
+		<ul class="list-disc pl-4">
+			<li>GitHub: repo</li>
+			<li>GitLab: read_repository + read_api</li>
+		</ul>
+		<p class="mt-2">
+			If no token is set, Obot falls back to the GITHUB_AUTH_TOKEN environment variable.
+		</p>
+	</div>
+{/snippet}
+
 <dialog bind:this={sourceDialog} class="dialog">
 	<div class="dialog-container w-full max-w-md p-4">
 		{#if editingSource}
@@ -234,16 +247,12 @@
 
 			{#if editingSource.credentialType === 'shared'}
 				<div class="mb-4 flex flex-col gap-1">
-					<label for="catalog-source-git-credential" class="text-sm font-light">
-						Saved Git credential
-					</label>
 					<Select
 						id="catalog-source-git-credential"
 						options={gitCredentialOptions}
 						selected={editingSource.gitCredentialID}
-						placeholder={gitCredentials.length
-							? 'Select a saved credential'
-							: 'No saved credentials'}
+						placeholder={gitCredentials.length ? 'Select a credential' : 'No credentials'}
+						searchPlaceholder=""
 						searchInDropdown
 						onSelect={(option) => {
 							if (editingSource) {
@@ -266,20 +275,8 @@
 
 			{#if editingSource.credentialType === 'token'}
 				<div class="mb-4 flex flex-col gap-1">
-					<div class="flex items-center justify-between">
-						<label for="catalog-source-token" class="flex items-center gap-1 text-sm font-light">
-							Personal Access Token
-							<span
-								use:tooltip={{
-									text: 'Required scopes:\n• GitHub: repo\n• GitLab: read_repository + read_api\n\nIf no token is set, Obot falls back to the GITHUB_AUTH_TOKEN environment variable.',
-									classes: ['max-w-md', 'whitespace-pre-line'],
-									disablePortal: true
-								}}
-							>
-								<Info class="text-muted-content size-3.5" />
-							</span>
-						</label>
-						{#if editingSource.index >= 0 && hasSourceURLCredential(defaultCatalog?.sourceURLs?.[editingSource.index]) && !editingSource.clearToken}
+					{#if editingSource.index >= 0 && hasSourceURLCredential(defaultCatalog?.sourceURLs?.[editingSource.index]) && !editingSource.clearToken}
+						<div class="flex justify-end">
 							<button
 								class="text-xs text-error hover:underline"
 								onclick={() => {
@@ -291,29 +288,38 @@
 							>
 								Clear token
 							</button>
-						{/if}
-					</div>
-					{#if !editingSource.clearToken && editingSource.index >= 0 && hasSourceURLCredential(defaultCatalog?.sourceURLs?.[editingSource.index])}
-						<input
-							id="catalog-source-token"
-							type="text"
-							readonly
-							aria-readonly="true"
-							data-1p-ignore
-							value={defaultCatalog?.sourceURLCredentials?.[
-								defaultCatalog?.sourceURLs?.[editingSource.index]
-							] ?? ''}
-							class="text-sm text-muted-content w-full border-none bg-transparent p-0 outline-none focus:ring-0"
-						/>
-					{:else}
-						<SensitiveInput
-							name="catalog-source-token"
-							placeholder={editingSource.clearToken
-								? 'Enter a new value or leave empty to clear'
-								: ''}
-							bind:value={editingSource.token}
-						/>
+						</div>
 					{/if}
+					<div class="flex items-center gap-2">
+						{#if !editingSource.clearToken && editingSource.index >= 0 && hasSourceURLCredential(defaultCatalog?.sourceURLs?.[editingSource.index])}
+							<input
+								id="catalog-source-token"
+								type="text"
+								readonly
+								aria-readonly="true"
+								data-1p-ignore
+								value={defaultCatalog?.sourceURLCredentials?.[
+									defaultCatalog?.sourceURLs?.[editingSource.index]
+								] ?? ''}
+								class="text-sm text-muted-content w-full border-none bg-transparent p-0 outline-none focus:ring-0"
+							/>
+						{:else}
+							<SensitiveInput
+								name="catalog-source-token"
+								placeholder="Personal Access Token"
+								bind:value={editingSource.token}
+							/>
+						{/if}
+						<span
+							use:tooltip={{
+								snippet: tokenScopesTooltip,
+								classes: ['max-w-md'],
+								disablePortal: true
+							}}
+						>
+							<Info class="text-muted-content size-3.5" />
+						</span>
+					</div>
 				</div>
 			{/if}
 

--- a/ui/user/src/routes/admin/skills/+page.svelte
+++ b/ui/user/src/routes/admin/skills/+page.svelte
@@ -45,7 +45,7 @@
 	type RepositoryCredentialType = '' | 'shared' | 'token';
 
 	const repositoryCredentialOptions = [
-		{ id: 'shared', label: 'Shared Git Credential' },
+		{ id: 'shared', label: 'Saved Git Credential' },
 		{ id: 'token', label: 'Personal Access Token' }
 	];
 
@@ -708,15 +708,15 @@
 				{#if editingSource.credentialType === 'shared'}
 					<div class="flex flex-col gap-1">
 						<label for="skill-source-git-credential" class="text-sm font-light">
-							Shared Git credential
+							Saved Git credential
 						</label>
 						<Select
 							id="skill-source-git-credential"
 							options={gitCredentialOptions}
 							selected={editingSource.gitCredentialID}
 							placeholder={gitCredentials.length
-								? 'Select a shared credential'
-								: 'No shared credentials'}
+								? 'Select a saved credential'
+								: 'No saved credentials'}
 							searchInDropdown
 							onSelect={(option) => {
 								if (editingSource) {

--- a/ui/user/src/routes/admin/skills/+page.svelte
+++ b/ui/user/src/routes/admin/skills/+page.svelte
@@ -42,6 +42,13 @@
 	import { slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
 
+	type RepositoryCredentialType = '' | 'shared' | 'token';
+
+	const repositoryCredentialOptions = [
+		{ id: 'shared', label: 'Shared Git Credential' },
+		{ id: 'token', label: 'Personal Access Token' }
+	];
+
 	let { data } = $props();
 	let query = $derived(page.url.searchParams.get('query') ?? '');
 	let view = $derived<'skills' | 'urls'>(
@@ -111,6 +118,7 @@
 				ref: string;
 				token: string;
 				gitCredentialID: string;
+				credentialType: RepositoryCredentialType;
 				repositoryID?: string;
 		  }
 		| undefined
@@ -127,6 +135,21 @@
 				!credential.tokenConfigured ||
 				Boolean(editingSourceHost && editingSourceHost !== credential.host.toLowerCase())
 		}))
+	);
+	let editingSkillRepository = $derived(
+		editingSource?.repositoryID
+			? skillRepositories.find((repository) => repository.id === editingSource?.repositoryID)
+			: undefined
+	);
+	let credentialSelectionIncomplete = $derived(
+		Boolean(
+			editingSource &&
+			((editingSource.credentialType === 'shared' && !editingSource.gitCredentialID) ||
+				(editingSource.credentialType === 'token' &&
+					!editingSource.token.trim() &&
+					(!hasSkillRepositoryToken(editingSkillRepository) ||
+						editingSource.value.trim() !== editingSkillRepository?.repoURL)))
+		)
 	);
 
 	function sourceHost(value: string): string {
@@ -146,6 +169,12 @@
 		if (selectedCredential && host && host !== selectedCredential.host.toLowerCase()) {
 			editingSource.gitCredentialID = '';
 		}
+	}
+
+	function hasSkillRepositoryToken(repository: SkillRepository | undefined): boolean {
+		if (!repository) return false;
+		const token = repository.sourceURLCredentials?.[repository.repoURL];
+		return token !== undefined && token !== '';
 	}
 
 	function switchView(newView: 'skills' | 'urls', filterByRepository: string = '') {
@@ -308,7 +337,8 @@
 							name: '',
 							ref: 'main',
 							token: '',
-							gitCredentialID: ''
+							gitCredentialID: '',
+							credentialType: ''
 						};
 						sourceDialog?.showModal();
 					}}
@@ -454,6 +484,11 @@
 									ref: d.ref,
 									token: '',
 									gitCredentialID: d.gitCredentialID ?? '',
+									credentialType: d.gitCredentialID
+										? 'shared'
+										: hasSkillRepositoryToken(d)
+											? 'token'
+											: '',
 									repositoryID: d.id
 								};
 								sourceDialog?.showModal();
@@ -645,35 +680,65 @@
 					>
 				</div>
 				<div class="flex flex-col gap-1">
-					<label for="skill-source-git-credential" class="text-sm font-light">
-						Shared Git credential (optional)
-					</label>
 					<Select
-						id="skill-source-git-credential"
-						options={gitCredentialOptions}
-						selected={editingSource.gitCredentialID}
-						placeholder={gitCredentials.length
-							? 'Use a one-off token or public access'
-							: 'No shared credentials'}
-						searchInDropdown
+						id="skill-source-credential-type"
+						options={repositoryCredentialOptions}
+						selected={editingSource.credentialType}
+						placeholder="Repository Credential (optional)"
+						class={!editingSource.credentialType ? 'text-muted-content' : undefined}
 						onSelect={(option) => {
-							if (editingSource) {
-								editingSource.gitCredentialID = String(option.id);
+							if (!editingSource) return;
+							editingSource.credentialType = option.id as RepositoryCredentialType;
+							if (option.id === 'shared') {
 								editingSource.token = '';
+							} else {
+								editingSource.gitCredentialID = '';
 							}
 						}}
-						onClear={() => {
-							if (editingSource) editingSource.gitCredentialID = '';
-						}}
+						onClear={editingSource.credentialType
+							? () => {
+									if (!editingSource) return;
+									editingSource.credentialType = '';
+									editingSource.gitCredentialID = '';
+									editingSource.token = '';
+								}
+							: undefined}
 					/>
-					<span class="text-muted-content text-xs">
-						Only credentials matching the repository host can be selected.
-					</span>
 				</div>
-				{#if !editingSource.gitCredentialID}
+				{#if editingSource.credentialType === 'shared'}
+					<div class="flex flex-col gap-1">
+						<label for="skill-source-git-credential" class="text-sm font-light">
+							Shared Git credential
+						</label>
+						<Select
+							id="skill-source-git-credential"
+							options={gitCredentialOptions}
+							selected={editingSource.gitCredentialID}
+							placeholder={gitCredentials.length
+								? 'Select a shared credential'
+								: 'No shared credentials'}
+							searchInDropdown
+							onSelect={(option) => {
+								if (editingSource) {
+									editingSource.gitCredentialID = String(option.id);
+									editingSource.token = '';
+								}
+							}}
+							onClear={editingSource.gitCredentialID
+								? () => {
+										if (editingSource) editingSource.gitCredentialID = '';
+									}
+								: undefined}
+						/>
+						<span class="text-muted-content text-xs">
+							Only credentials matching the repository host can be selected.
+						</span>
+					</div>
+				{/if}
+				{#if editingSource.credentialType === 'token'}
 					<div class="flex flex-col gap-1">
 						<label for="skill-source-token" class="flex items-center gap-1 text-sm font-light">
-							Personal access token (optional)
+							Personal access token
 						</label>
 						<SensitiveInput
 							name="skill-source-token"
@@ -700,7 +765,7 @@
 				>
 				<button
 					class="btn btn-primary"
-					disabled={saving}
+					disabled={saving || credentialSelectionIncomplete}
 					onclick={async () => {
 						if (!editingSource) {
 							return;
@@ -719,8 +784,17 @@
 							};
 							if (editingSource.gitCredentialID) {
 								manifest.gitCredentialID = editingSource.gitCredentialID;
-							} else if (token) {
+							} else if (editingSource.credentialType === 'token' && token) {
 								manifest.sourceURLCredentials = { [repoURL]: token };
+							} else if (
+								editingSource.credentialType !== 'token' &&
+								hasSkillRepositoryToken(
+									skillRepositories.find(
+										(repository) => repository.id === editingSource?.repositoryID
+									)
+								)
+							) {
+								manifest.sourceURLCredentials = { [repoURL]: '' };
 							}
 							const response = editingSource.repositoryID
 								? await AdminService.updateSkillRepository(editingSource.repositoryID, manifest)

--- a/ui/user/src/routes/admin/skills/+page.svelte
+++ b/ui/user/src/routes/admin/skills/+page.svelte
@@ -707,16 +707,12 @@
 				</div>
 				{#if editingSource.credentialType === 'shared'}
 					<div class="flex flex-col gap-1">
-						<label for="skill-source-git-credential" class="text-sm font-light">
-							Saved Git credential
-						</label>
 						<Select
 							id="skill-source-git-credential"
 							options={gitCredentialOptions}
 							selected={editingSource.gitCredentialID}
-							placeholder={gitCredentials.length
-								? 'Select a saved credential'
-								: 'No saved credentials'}
+							placeholder={gitCredentials.length ? 'Select a credential' : 'No credentials'}
+							searchPlaceholder=""
 							searchInDropdown
 							onSelect={(option) => {
 								if (editingSource) {
@@ -737,10 +733,11 @@
 				{/if}
 				{#if editingSource.credentialType === 'token'}
 					<div class="flex flex-col gap-1">
-						<label for="skill-source-token" class="flex items-center gap-1 text-sm font-light">
-							Personal Access Token
-						</label>
-						<SensitiveInput name="skill-source-token" bind:value={editingSource.token} />
+						<SensitiveInput
+							name="skill-source-token"
+							placeholder="Personal Access Token"
+							bind:value={editingSource.token}
+						/>
 					</div>
 				{/if}
 			</div>

--- a/ui/user/src/routes/admin/skills/+page.svelte
+++ b/ui/user/src/routes/admin/skills/+page.svelte
@@ -738,13 +738,9 @@
 				{#if editingSource.credentialType === 'token'}
 					<div class="flex flex-col gap-1">
 						<label for="skill-source-token" class="flex items-center gap-1 text-sm font-light">
-							Personal access token
+							Personal Access Token
 						</label>
-						<SensitiveInput
-							name="skill-source-token"
-							placeholder="Required for private repositories"
-							bind:value={editingSource.token}
-						/>
+						<SensitiveInput name="skill-source-token" bind:value={editingSource.token} />
 					</div>
 				{/if}
 			</div>

--- a/ui/user/src/routes/admin/skills/+page.svelte
+++ b/ui/user/src/routes/admin/skills/+page.svelte
@@ -733,6 +733,7 @@
 				{/if}
 				{#if editingSource.credentialType === 'token'}
 					<div class="flex flex-col gap-1">
+						<label for="skill-source-token" class="sr-only">Personal Access Token</label>
 						<SensitiveInput
 							name="skill-source-token"
 							placeholder="Personal Access Token"


### PR DESCRIPTION
Addresses #7255 

Improve the menu for selecting git credentials to have a main dropdown to select credential type. Default is blank, then separate selections for Saved Git Credential and Personal Access Token which triggers the different input types.

<img width="458" height="457" alt="Screenshot 2026-07-22 at 15 38 58" src="https://github.com/user-attachments/assets/4a305a75-a873-4dc4-b025-ce432090a587" />
<img width="460" height="460" alt="Screenshot 2026-07-22 at 15 39 05" src="https://github.com/user-attachments/assets/0dbf77a2-d14c-4fd2-a14d-913e067e26be" />
<img width="463" height="387" alt="Screenshot 2026-07-22 at 16 10 44" src="https://github.com/user-attachments/assets/9ca16f91-03bc-4001-a297-6b89be77ba17" />
<img width="465" height="330" alt="Screenshot 2026-07-22 at 16 09 35" src="https://github.com/user-attachments/assets/9955253b-f224-4b31-aed5-d11df760202a" />


