### PR TITLE
fix: stop including server type and entry key in drift

### DIFF
--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"cmp"
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -87,64 +88,7 @@ func (h *Handler) DetectDrift(req router.Request, _ router.Response) error {
 		return err
 	}
 
-	staticEnvKeys := make(map[string]struct{})
-	for _, env := range entry.Spec.Manifest.Env {
-		if env.Value != "" {
-			staticEnvKeys[env.Key] = struct{}{}
-		}
-	}
-	if entry.Spec.Manifest.RemoteConfig != nil {
-		for _, hdr := range entry.Spec.Manifest.RemoteConfig.Headers {
-			if hdr.Value != "" {
-				staticEnvKeys[hdr.Key] = struct{}{}
-			}
-		}
-	}
-
-	if len(staticEnvKeys) > 0 {
-		var (
-			cred gatewaytypes.Credential
-			err  error
-		)
-		if server.Spec.MCPCatalogID != "" {
-			cred, err = h.gatewayClient.RevealCredential(req.Ctx, []string{fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)}, server.Name)
-		} else if server.Spec.PowerUserWorkspaceID != "" {
-			cred, err = h.gatewayClient.RevealCredential(req.Ctx, []string{fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)}, server.Name)
-		} else {
-			cred, err = h.gatewayClient.RevealCredential(req.Ctx, []string{fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)}, server.Name)
-		}
-		if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
-			return err
-		}
-
-		originalEnv := slices.Clone(server.Spec.Manifest.Env)
-		defer func() {
-			// Ensure we revert to the original values after processing
-			server.Spec.Manifest.Env = originalEnv
-		}()
-
-		for i, env := range server.Spec.Manifest.Env {
-			if _, ok := staticEnvKeys[env.Key]; ok && env.Value == "" {
-				server.Spec.Manifest.Env[i].Value = cred.Secrets[env.Key]
-			}
-		}
-
-		if server.Spec.Manifest.RemoteConfig != nil {
-			originalHeaders := slices.Clone(server.Spec.Manifest.RemoteConfig.Headers)
-			defer func() {
-				// Ensure we revert to the original values after processing
-				server.Spec.Manifest.RemoteConfig.Headers = originalHeaders
-			}()
-
-			for i, hdr := range server.Spec.Manifest.RemoteConfig.Headers {
-				if _, ok := staticEnvKeys[hdr.Key]; ok && hdr.Value == "" {
-					server.Spec.Manifest.RemoteConfig.Headers[i].Value = cred.Secrets[hdr.Key]
-				}
-			}
-		}
-	}
-
-	drifted, err := ConfigurationHasDrifted(server.Spec.Manifest, entry.Spec.Manifest, h.defaultDenyAllEgress)
+	drifted, err := ConfigurationHasDrifted(req.Ctx, h.gatewayClient, server, entry.Spec.Manifest, h.defaultDenyAllEgress)
 	if err != nil {
 		return err
 	}
@@ -318,9 +262,63 @@ func (h *Handler) DetectK8sSettingsDrift(req router.Request, _ router.Response) 
 }
 
 // ConfigurationHasDrifted compares runtime config, env, resources, and multi-user config between a server
-// manifest and a catalog entry manifest. It handles the type difference between MCPServerManifest
-// and MCPServerCatalogEntryManifest by comparing only the fields common to both.
-func ConfigurationHasDrifted(serverManifest types.MCPServerManifest, entryManifest types.MCPServerCatalogEntryManifest, defaultDenyAllEgress bool) (bool, error) {
+// and a catalog entry manifest. Static values omitted from the persisted server manifest are restored from
+// its gateway credential before comparison.
+func ConfigurationHasDrifted(ctx context.Context, gatewayClient *gateway.Client, server *v1.MCPServer, entryManifest types.MCPServerCatalogEntryManifest, defaultDenyAllEgress bool) (bool, error) {
+	staticKeys := make(map[string]struct{})
+	for _, env := range entryManifest.Env {
+		if env.Value != "" {
+			staticKeys[env.Key] = struct{}{}
+		}
+	}
+	if entryManifest.RemoteConfig != nil {
+		for _, header := range entryManifest.RemoteConfig.Headers {
+			if header.Value != "" {
+				staticKeys[header.Key] = struct{}{}
+			}
+		}
+	}
+
+	serverManifest := server.Spec.Manifest
+	if len(staticKeys) > 0 {
+		credentialContext := server.Spec.UserID
+		if server.Spec.MCPCatalogID != "" {
+			credentialContext = server.Spec.MCPCatalogID
+		} else if server.Spec.PowerUserWorkspaceID != "" {
+			credentialContext = server.Spec.PowerUserWorkspaceID
+		}
+
+		credential, err := gatewayClient.RevealCredential(ctx, []string{fmt.Sprintf("%s-%s", credentialContext, server.Name)}, server.Name)
+		if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
+			return false, err
+		}
+
+		serverManifest.Env = slices.Clone(serverManifest.Env)
+		for i, env := range serverManifest.Env {
+			if _, ok := staticKeys[env.Key]; ok && env.Value == "" {
+				serverManifest.Env[i].Value = credential.Secrets[env.Key]
+			}
+		}
+
+		if serverManifest.RemoteConfig != nil {
+			remoteConfig := *serverManifest.RemoteConfig
+			remoteConfig.Headers = slices.Clone(remoteConfig.Headers)
+			serverManifest.RemoteConfig = &remoteConfig
+			for i, header := range serverManifest.RemoteConfig.Headers {
+				if _, ok := staticKeys[header.Key]; ok && header.Value == "" {
+					serverManifest.RemoteConfig.Headers[i].Value = credential.Secrets[header.Key]
+				}
+			}
+		}
+	}
+
+	return configurationHasDrifted(serverManifest, entryManifest, defaultDenyAllEgress)
+}
+
+// configurationHasDrifted compares only the fields common to MCPServerManifest and
+// MCPServerCatalogEntryManifest. It is also used for nested composite components,
+// which do not have their own MCPServer object or credential context.
+func configurationHasDrifted(serverManifest types.MCPServerManifest, entryManifest types.MCPServerCatalogEntryManifest, defaultDenyAllEgress bool) (bool, error) {
 	// Check if runtime types differ
 	if serverManifest.Runtime != entryManifest.Runtime {
 		return true, nil
@@ -606,7 +604,7 @@ func compositeConfigHasDrifted(serverConfig *types.CompositeRuntimeConfig, entry
 		}
 
 		// Compare manifests
-		drifted, err := ConfigurationHasDrifted(serverComponent.Manifest, entryComponent.Manifest, defaultDenyAllEgress)
+		drifted, err := configurationHasDrifted(serverComponent.Manifest, entryComponent.Manifest, defaultDenyAllEgress)
 		if err != nil || drifted {
 			return drifted, err
 		}

--- a/pkg/controller/handlers/mcpserver/mcpserver_test.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver_test.go
@@ -7,8 +7,12 @@ import (
 
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/apiclient/types"
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	storageservices "github.com/obot-platform/obot/pkg/storage/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +21,7 @@ import (
 )
 
 func TestConfigurationHasDrifted(t *testing.T) {
+	gatewayClient := newTestGatewayClient(t)
 	tests := []struct {
 		name           string
 		serverManifest types.MCPServerManifest
@@ -1004,7 +1009,14 @@ func TestConfigurationHasDrifted(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			drifted, err := ConfigurationHasDrifted(tt.serverManifest, tt.entryManifest, false)
+			server := &v1.MCPServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-server"},
+				Spec: v1.MCPServerSpec{
+					UserID:   "test-user",
+					Manifest: tt.serverManifest,
+				},
+			}
+			drifted, err := ConfigurationHasDrifted(t.Context(), gatewayClient, server, tt.entryManifest, false)
 
 			if tt.expectedError {
 				if err == nil {
@@ -1021,6 +1033,58 @@ func TestConfigurationHasDrifted(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigurationHasDriftedRestoresStaticValuesWithoutMutatingServer(t *testing.T) {
+	gatewayClient := newTestGatewayClient(t)
+	referenceManifest := types.MCPServerCatalogEntryManifest{
+		Runtime: types.RuntimeRemote,
+		Env: []types.MCPEnv{
+			{MCPHeader: types.MCPHeader{Key: "STATIC_ENV", Value: "stored-env"}},
+			{MCPHeader: types.MCPHeader{Key: "DYNAMIC_ENV"}},
+		},
+		RemoteConfig: &types.RemoteCatalogConfig{
+			FixedURL: "https://api.example.com/mcp",
+			Headers: []types.MCPHeader{
+				{Key: "STATIC_HEADER", Value: "stored-header"},
+				{Key: "EXISTING_HEADER", Value: "configured"},
+			},
+		},
+	}
+	server := &v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-server"},
+		Spec: v1.MCPServerSpec{
+			MCPCatalogID: "default",
+			Manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeRemote,
+				Env: []types.MCPEnv{
+					{MCPHeader: types.MCPHeader{Key: "STATIC_ENV"}},
+					{MCPHeader: types.MCPHeader{Key: "DYNAMIC_ENV"}},
+				},
+				RemoteConfig: &types.RemoteRuntimeConfig{
+					URL: "https://api.example.com/mcp",
+					Headers: []types.MCPHeader{
+						{Key: "STATIC_HEADER"},
+						{Key: "EXISTING_HEADER", Value: "configured"},
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+		Context: "default-shared-server",
+		Name:    server.Name,
+		Secrets: map[string]string{
+			"STATIC_ENV":    "stored-env",
+			"STATIC_HEADER": "stored-header",
+		},
+	}))
+
+	drifted, err := ConfigurationHasDrifted(t.Context(), gatewayClient, server, referenceManifest, false)
+	require.NoError(t, err)
+	assert.False(t, drifted)
+	assert.Empty(t, server.Spec.Manifest.Env[0].Value)
+	assert.Empty(t, server.Spec.Manifest.RemoteConfig.Headers[0].Value)
 }
 
 func TestRuntimeSpecificDriftFunctions(t *testing.T) {
@@ -1448,6 +1512,18 @@ func newMCPServerCatalogEntry(name string, manifest types.MCPServerCatalogEntryM
 			Manifest: manifest,
 		},
 	}
+}
+
+func newTestGatewayClient(t *testing.T) *gatewayclient.Client {
+	t.Helper()
+	storageServices, err := storageservices.New(storageservices.Config{DSN: "sqlite://:memory:"})
+	require.NoError(t, err)
+	database, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate())
+	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, true)
+	t.Cleanup(func() { _ = gatewayClient.Close() })
+	return gatewayClient
 }
 
 func TestShouldSyncOAuthMetadata(t *testing.T) {

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -139,7 +139,7 @@ func (*Handler) UpdateSystemManifestHashAndLastUpdated(req router.Request, _ rou
 
 // DetectCompositeDrift detects when a composite catalog entry's component snapshots have drifted
 // from their source catalog entries or multi-user servers
-func (*Handler) DetectCompositeDrift(req router.Request, _ router.Response) error {
+func (h *Handler) DetectCompositeDrift(req router.Request, _ router.Response) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
 
 	if entry.Spec.Manifest.Runtime != types.RuntimeComposite {
@@ -164,7 +164,7 @@ func (*Handler) DetectCompositeDrift(req router.Request, _ router.Response) erro
 				return fmt.Errorf("failed to get multi-user server %s: %w", component.MCPServerID, err)
 			}
 
-			hasDrifted, err := mcpserver.ConfigurationHasDrifted(server.Spec.Manifest, component.Manifest, false)
+			hasDrifted, err := mcpserver.ConfigurationHasDrifted(req.Ctx, h.gatewayClient, &server, component.Manifest, false)
 			if err != nil {
 				return fmt.Errorf("failed to detect drift for multi-user server %s: %w", component.MCPServerID, err)
 			}
@@ -181,6 +181,16 @@ func (*Handler) DetectCompositeDrift(req router.Request, _ router.Response) erro
 					break
 				}
 				return fmt.Errorf("failed to get component catalog entry %s: %w", component.CatalogEntryID, err)
+			}
+
+			// We added the EntryKey field, but it really shouldn't affect drift detection here.
+			if component.Manifest.EntryKey == "" && componentEntry.Spec.Manifest.EntryKey != "" {
+				component.Manifest.EntryKey = componentEntry.Spec.Manifest.EntryKey
+			}
+
+			// Same for serverUserType
+			if component.Manifest.ServerUserType == "" && componentEntry.Spec.Manifest.ServerUserType != "" {
+				component.Manifest.ServerUserType = componentEntry.Spec.Manifest.ServerUserType
 			}
 
 			var (

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
@@ -62,6 +62,54 @@ func TestDetectCompositeDriftMarksEntryNeedingUpdateWhenMultiUserComponentDrifts
 	assert.True(t, updated.Status.NeedsUpdate)
 }
 
+func TestDetectCompositeDriftIgnoresCatalogOnlyComponentFields(t *testing.T) {
+	componentSnapshot := types.MCPServerCatalogEntryManifest{
+		Name:    "Catalog Component",
+		Runtime: types.RuntimeContainerized,
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/component:1.0.0",
+			Port:  8080,
+			Path:  "/mcp",
+		},
+	}
+	compositeEntry := newMCPServerCatalogEntry("composite-entry", types.MCPServerCatalogEntryManifest{
+		Name:    "Composite Entry",
+		Runtime: types.RuntimeComposite,
+		CompositeConfig: &types.CompositeCatalogConfig{
+			ComponentServers: []types.CatalogComponentServer{{
+				CatalogEntryID: "component-entry",
+				Manifest:       componentSnapshot,
+			}},
+		},
+	})
+	compositeEntry.Status.NeedsUpdate = true
+	componentEntry := newMCPServerCatalogEntry("component-entry", types.MCPServerCatalogEntryManifest{
+		EntryKey:       "catalog-only-entry-key",
+		Name:           "Catalog Component",
+		Runtime:        types.RuntimeContainerized,
+		ServerUserType: types.ServerUserTypeSingleUser,
+		ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+			Image: "example/component:1.0.0",
+			Port:  8080,
+			Path:  "/mcp",
+		},
+	})
+
+	client := newFakeClient(compositeEntry, componentEntry)
+	err := (&Handler{}).DetectCompositeDrift(router.Request{
+		Client:    client,
+		Ctx:       t.Context(),
+		Object:    compositeEntry,
+		Namespace: compositeEntry.Namespace,
+		Name:      compositeEntry.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	var updated v1.MCPServerCatalogEntry
+	require.NoError(t, client.Get(t.Context(), router.Key(compositeEntry.Namespace, compositeEntry.Name), &updated))
+	assert.False(t, updated.Status.NeedsUpdate)
+}
+
 func TestDetectCompositeDriftIgnoresAdminAddedSecretBindings(t *testing.T) {
 	binding := &types.MCPSecretBinding{Name: "admin-secret", Key: "api-key", AdminAdded: true}
 	componentSnapshot := types.MCPServerCatalogEntryManifest{


### PR DESCRIPTION
These fields are relatively new and shouldn't factor into whether a composite has drifted.

Additionally, we include the same static env and header changes to composites as we did for multi-user servers.

Issue: https://github.com/obot-platform/obot/issues/7222