### PR TITLE
enhance: update text on admin guides & simplify composite entry guide

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -1321,6 +1321,14 @@
 	pointer-events: none;
 }
 
+/*
+ * highlight.noDescendantInteraction — descendants are inert; the active element itself stays
+ * clickable so guide listeners can still advance the step.
+ */
+.driver-active .driver-active-element.guide-no-descendant-events * {
+	pointer-events: none !important;
+}
+
 @layer utilities {
 	.toggle {
 		border-color: transparent;

--- a/ui/user/src/lib/components/guides/highlight.ts
+++ b/ui/user/src/lib/components/guides/highlight.ts
@@ -166,6 +166,13 @@ export function createGuideHighlighter(options: GuideHighlighterOptions = {}): G
 	let highlightRingTarget: Element | undefined;
 	let highlightRingRaf = 0;
 	let highlightGeneration = 0;
+	let noDescendantInteractionActive = false;
+
+	function clearNoDescendantInteractionClass() {
+		document.querySelectorAll('.guide-no-descendant-events').forEach((el) => {
+			el.classList.remove('guide-no-descendant-events');
+		});
+	}
 
 	function destroyHighlightObot() {
 		if (highlightObot) {
@@ -189,6 +196,8 @@ export function createGuideHighlighter(options: GuideHighlighterOptions = {}): G
 	function destroyHighlightEffects() {
 		destroyHighlightObot();
 		destroyHighlightRing();
+		clearNoDescendantInteractionClass();
+		noDescendantInteractionActive = false;
 		options.onObotVisibilityChange?.(true);
 		options.onDestroyed?.();
 	}
@@ -240,7 +249,11 @@ export function createGuideHighlighter(options: GuideHighlighterOptions = {}): G
 		onDestroyed: destroyHighlightEffects,
 		onCloseClick: options.onCloseClick,
 		onHighlighted: (element) => {
-			if (element) promoteHighlightLayer(element);
+			if (!element) return;
+			promoteHighlightLayer(element);
+			if (noDescendantInteractionActive) {
+				element.classList.add('guide-no-descendant-events');
+			}
 		}
 	});
 
@@ -256,6 +269,8 @@ export function createGuideHighlighter(options: GuideHighlighterOptions = {}): G
 		const side = highlightConfig.side ?? 'right';
 
 		restoreHighlightLayerToBody();
+		clearNoDescendantInteractionClass();
+		noDescendantInteractionActive = highlightConfig.noDescendantInteraction === true;
 		guideDriver.highlight({
 			element,
 			popover: {

--- a/ui/user/src/lib/services/guides/accesspolicy/create.ts
+++ b/ui/user/src/lib/services/guides/accesspolicy/create.ts
@@ -9,7 +9,10 @@ import type { GuideStep } from '../types';
 
 export const steps: GuideStep[] = [
 	{
-		content: ["To get started, let's head to the MCP Access Policies page!"],
+		content: [
+			'**What is an MCP access policy?**',
+			'An MCP access policy allows you to grant one or more users or user groups access to one or more MCP servers.'
+		],
 		action: [
 			{
 				elementExists: SIDEBAR_MCP_ACCESS_POLICIES_LINK,
@@ -50,13 +53,16 @@ export const steps: GuideStep[] = [
 				title: 'Policy Name',
 				description: 'Enter a recognizable name for this access policy.'
 			},
-			next: {
+			listener: {
+				id: MCP_ACCESS_POLICY_FIELD_IDS.name,
 				action: {
 					highlight: {
 						selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.usersGroupsSection },
 						side: 'top',
 						title: 'Users & Groups',
-						description: 'Subjects added here receive access to the servers selected below.'
+						description:
+							'Add the users and groups that should have access to the selected MCP servers.',
+						noDescendantInteraction: true
 					},
 					listener: {
 						id: MCP_ACCESS_POLICY_FIELD_IDS.usersGroupsSection,
@@ -75,7 +81,8 @@ export const steps: GuideStep[] = [
 										selector: { id: 'add-user-group-dialog-content' },
 										title: 'Adding Users/Groups',
 										description:
-											'This is where you can add who will be able to access the catalog entries & servers.'
+											'This is where you can add who will be able to access the catalog entries & servers.',
+										noDescendantInteraction: true
 									},
 									listener: {
 										id: 'add-user-group-dialog-content',
@@ -105,7 +112,8 @@ export const steps: GuideStep[] = [
 																side: 'top',
 																title: 'Servers',
 																description:
-																	'This is where you can add the servers that will be available to the selected users and groups.'
+																	'Select the servers that will be available to the selected users and groups.',
+																noDescendantInteraction: true
 															},
 															listener: {
 																id: MCP_ACCESS_POLICY_FIELD_IDS.serversSection,
@@ -124,7 +132,8 @@ export const steps: GuideStep[] = [
 																				selector: { id: 'search-mcp-servers-dialog-content' },
 																				title: 'Adding A Server',
 																				description:
-																					'From here, you can search and add any servers that you want to make available to the selected users and groups.'
+																					'From here, you can search and add any servers that you want to make available to the selected users and groups.',
+																				noDescendantInteraction: true
 																			},
 																			listener: {
 																				id: 'search-mcp-servers-dialog-content',

--- a/ui/user/src/lib/services/guides/mcp/connect.ts
+++ b/ui/user/src/lib/services/guides/mcp/connect.ts
@@ -89,7 +89,8 @@ export const steps: GuideStep[] = [
 						},
 						title: 'Install via Quick Install Link',
 						description:
-							'Click the quick install link to install the MCP server into your AI client.'
+							'Click the quick install link to install the MCP server into your AI client.',
+						noDescendantInteraction: true
 					},
 					listener: {
 						id: 'magic-links-container',

--- a/ui/user/src/lib/services/guides/mcp/constants.ts
+++ b/ui/user/src/lib/services/guides/mcp/constants.ts
@@ -44,7 +44,7 @@ export const addCatalogEntryDescriptions = {
 
 export const obotCatalogEntryDescriptions = {
 	hosted:
-		'A hosted catalog entry provides a simple way to deploy and host an MCP server on the Obot platform, where Obot manages its operation and lifecycle.  Click here to get started.',
+		'A hosted catalog entry provides a simple way to deploy and host an MCP server on the Obot platform, where Obot manages its operation and lifecycle. Click here to get started.',
 	remote:
 		"A remote catalog entry lets you proxy all traffic to a remote MCP server through Obot, enabling you to take advantage of Obot's access policies and audit logging. Click here to get started.",
 	composite:

--- a/ui/user/src/lib/services/guides/mcp/constants.ts
+++ b/ui/user/src/lib/services/guides/mcp/constants.ts
@@ -35,9 +35,18 @@ export const listenMcpAccessPoliciesLink: GuideListener = {
 
 export const addCatalogEntryDescriptions = {
 	hosted:
-		'A hosted catalog entry is great for setting up an MCP server hosted under the Obot platform.',
+		'A hosted MCP catalog entry allows you to add a custom MCP server that is managed and hosted by Obot. By having Obot host your MCP server, you can take advantage of automatic scaling, lifecycle management, API key management, and access policy enforcement. Once deployed in Obot, the server is available as a remote MCP URL that your MCP clients can consume.',
 	remote:
-		'A remote catalog entry is great for allowing users to connect to MCP servers that are already elsewhere. When they deploy from Obot, the MCP server will go through the gateway.',
+		"A remote catalog entry allows you to proxy any remote MCP server through Obot, enabling you to take advantage of Obot's access policies, audit logging, and static OAuth integration.",
 	composite:
-		'A composite catalog entry is great for combining tools from multiple existing MCP servers into single deployment. You can also configure which tools to expose and customize their names or descriptions.'
+		'A composite catalog entry serves two purposes. First, it allows you to combine multiple MCP servers and publish them as a single remote MCP server. Second, it enables you to expose only the tools you want users to access, giving you fine-grained control over which capabilities are published.'
+};
+
+export const obotCatalogEntryDescriptions = {
+	hosted:
+		'A hosted catalog entry provides a simple way to deploy and host an MCP server on the Obot platform, where Obot manages its operation and lifecycle.  Click here to get started.',
+	remote:
+		"A remote catalog entry lets you proxy all traffic to a remote MCP server through Obot, enabling you to take advantage of Obot's access policies and audit logging. Click here to get started.",
+	composite:
+		'A composite catalog entry lets you combine multiple MCP servers into a single remote MCP server and expose only the tools you want users to access.'
 };

--- a/ui/user/src/lib/services/guides/mcp/customComposite.ts
+++ b/ui/user/src/lib/services/guides/mcp/customComposite.ts
@@ -9,7 +9,7 @@ import {
 
 export const steps: GuideStep[] = [
 	{
-		content: ['What is a composite catalog entry?', addCatalogEntryDescriptions.composite]
+		content: ['**What is a composite catalog entry?**', addCatalogEntryDescriptions.composite]
 	},
 	getNavigateToMCPCatalogStep(),
 	getHighlightAddCatalogEntryStep('composite'),
@@ -26,9 +26,12 @@ export const steps: GuideStep[] = [
 				align: 'center',
 				title: 'Component Entries',
 				description:
-					'This list contains the catalog entries and deployed multi-user servers whose tools will be combined into the composite server.'
+					'This list contains the catalog entries and deployed multi-user servers whose tools will be combined into the composite server.',
+				noDescendantInteraction: true
 			},
-			next: {
+			listener: {
+				id: CATALOG_SERVER_FIELD_IDS.compositeEntries,
+				skipClickTargetOnNext: true,
 				action: {
 					highlight: {
 						selector: { id: CATALOG_SERVER_FIELD_IDS.addCompositeEntryBtn },
@@ -47,67 +50,15 @@ export const steps: GuideStep[] = [
 								side: 'right',
 								title: 'Adding Component Entries',
 								description:
-									'Here you can add the component entries that will be combined into the composite server.'
+									'Here you can search and select the component entries that you want to add to the composite server. Each component will have its own configuration and authentication requirements. Follow the wizard to complete the process.',
+								noDescendantInteraction: true
 							},
 							listener: {
-								id: `${CATALOG_SERVER_FIELD_IDS.compositeEntrySearchMcpServersDialog}-content`,
-								skipClickTargetOnNext: true,
+								id: `${CATALOG_SERVER_FIELD_IDS.compositeEntrySearchMcpServersDialog}`,
 								action: {
-									highlight: {
-										selector: {
-											beginsWith: ['search-mcp-server-default-antv-charts']
-										},
-										title: 'Add a Component Entry',
-										description:
-											"For this example, let's go ahead and select AntV Charts as a component entry."
-									},
-									listener: {
-										beginsWith: ['search-mcp-server-default-antv-charts'],
-										action: {
-											highlight: {
-												selector: {
-													id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsBtn
-												},
-												side: 'right',
-												title: 'Configure Tools',
-												description:
-													"Let's go ahead and configure the tools for this component entry."
-											},
-											listener: {
-												id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsBtn,
-												action: {
-													highlight: {
-														selector: {
-															id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsGetStartedBtn
-														},
-														title: 'Get Started',
-														description:
-															"In order to get the tools, we'll need to supply any required configuration to deploy the entry. Similarly, when a user deploys this composite server, they'll also have to provide the required configuration details for each component entry."
-													},
-													listener: {
-														id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsGetStartedBtn,
-														action: {
-															highlight: {
-																selector: {
-																	id: 'mcp-catalog-configure-submit-btn'
-																},
-																side: 'left',
-																title: 'Configure the Entry',
-																description:
-																	'Luckily, this entry does not have any required configuration. Go ahead and click Continue.'
-															},
-															listener: {
-																id: 'mcp-catalog-configure-submit-btn',
-																action: {
-																	success: true
-																}
-															}
-														}
-													}
-												}
-											}
-										}
-									}
+									success: true,
+									elementExists: CATALOG_SERVER_FIELD_IDS.compositeEntrySearchMcpServersDialog,
+									closeExistingElement: true
 								}
 							}
 						}
@@ -117,97 +68,19 @@ export const steps: GuideStep[] = [
 		}
 	},
 	{
-		content: ['__Waiting for tools to be fetched...__'],
-		action: {
-			waitFor: CATALOG_SERVER_FIELD_IDS.compositeEntryEditToolsDialog
-		}
-	},
-	{
-		content: [
-			'Each component keeps its own configuration and authentication requirements. You can also choose which tools to expose and customize their names or descriptions.'
-		],
+		content: [''],
 		action: {
 			highlight: {
-				selector: { id: CATALOG_SERVER_FIELD_IDS.compositeEntryEditToolsDialog },
-				title: 'Configuring Entry Tools',
+				selector: { id: CATALOG_SERVER_FIELD_IDS.submitBtn },
+				side: 'left',
+				title: 'Save the entry',
 				description:
-					'This is the tool configuration dialog for the component entry that was just added. From here, you can choose which tools to expose and customize their names or descriptions.'
+					'Once you have finished configuring the composite catalog entry, you can save here.'
 			},
 			listener: {
-				id: CATALOG_SERVER_FIELD_IDS.compositeEntryEditToolsDialog,
+				id: CATALOG_SERVER_FIELD_IDS.submitBtn,
 				skipClickTargetOnNext: true,
-				action: {
-					highlight: {
-						selector: { id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsToggleAll },
-						side: 'bottom',
-						align: 'center',
-						title: 'Toggle All Tools',
-						description:
-							'If you want to enable or disable all tools at once, you can use this toggle.'
-					},
-					listener: {
-						id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsToggleAll,
-						skipClickTargetOnNext: true,
-						action: {
-							highlight: {
-								selector: {
-									beginsWith: ['edit-tool-']
-								},
-								side: 'right',
-								title: 'Toggle a Tool',
-								description:
-									'You choose individually which tools to expose and customize their names or descriptions.'
-							},
-							listener: {
-								beginsWith: ['edit-tool-'],
-								skipClickTargetOnNext: true,
-								action: {
-									highlight: {
-										selector: {
-											id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsConfirmBtn
-										},
-										side: 'left',
-										title: 'Save Tools',
-										description:
-											"Once you have configured the tools, you can confirm the changes by clicking the button here. For now, let's just confirm the changes."
-									},
-									listener: {
-										id: CATALOG_SERVER_FIELD_IDS.compositeEntryConfigureToolsConfirmBtn,
-										action: {
-											highlight: {
-												selector: {
-													beginsWith: [`${CATALOG_SERVER_FIELD_IDS.compositeEntryToolCollapseBtn}-`]
-												},
-												side: 'left',
-												title: 'See Added Tools & Update',
-												description:
-													'If you want to make additional changes, you can expand the tools you just added and edit them from here. Go ahead and expand this to see.'
-											},
-											listener: {
-												beginsWith: [`${CATALOG_SERVER_FIELD_IDS.compositeEntryToolCollapseBtn}-`],
-												skipClickTargetOnNext: true,
-												action: {
-													highlight: {
-														selector: { id: CATALOG_SERVER_FIELD_IDS.submitBtn },
-														side: 'left',
-														title: 'Save the entry',
-														description:
-															'Once you have finished configuring the composite catalog entry, you can save here.'
-													},
-													listener: {
-														id: CATALOG_SERVER_FIELD_IDS.submitBtn,
-														skipClickTargetOnNext: true,
-														action: { success: true }
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
+				action: { success: true }
 			}
 		}
 	}

--- a/ui/user/src/lib/services/guides/mcp/customHosted.ts
+++ b/ui/user/src/lib/services/guides/mcp/customHosted.ts
@@ -14,7 +14,8 @@ function getCustomConfigurationAction(): GuideAction[] {
 		},
 		side: 'top' as const,
 		align: 'center' as const,
-		title: 'Custom Configuration'
+		title: 'Custom Configuration',
+		noDescendantInteraction: true
 	};
 
 	const configurationListener = {
@@ -56,7 +57,8 @@ function getHostedFieldsListener(): GuideListener {
 				side: 'top',
 				align: 'center',
 				title: 'Runtime',
-				description: 'This is where you choose the runtime configuration for your MCP server.'
+				description: 'This is where you choose the runtime configuration for your MCP server.',
+				noDescendantInteraction: true
 			},
 			listener: {
 				id: CATALOG_SERVER_FIELD_IDS.runtime,
@@ -69,7 +71,8 @@ function getHostedFieldsListener(): GuideListener {
 						align: 'center',
 						title: 'Runtime Configuration',
 						description:
-							'Depending on which runtime you choose, you will see the appropriate form for that runtime form here to fill out.'
+							'Depending on which runtime you choose, you will see the appropriate form for that runtime here to fill out.',
+						noDescendantInteraction: true
 					},
 					listener: {
 						id: CATALOG_SERVER_FIELD_IDS.runtimeConfiguration,
@@ -92,8 +95,9 @@ function getHostedFieldsActions(admin: boolean): GuideAction {
 			align: 'center',
 			title: 'Server Tenancy',
 			description: admin
-				? 'This is where you choose the tenancy type of your MCP server. If each user should have their own deployment, Single-tenant is recommended.'
-				: 'For any catalog entry you create, a user will deploy their own instance of the MCP server.'
+				? 'This is where you choose the tenancy type for your MCP server. The default is multi-tenant, which allows multiple users to access the same MCP server. If your MCP server is intended for a single user or isolated deployment, select single-tenant instead.'
+				: 'For any catalog entry you create, a user will deploy their own instance of the MCP server.',
+			noDescendantInteraction: true
 		},
 		listener: getHostedFieldsListener()
 	};
@@ -121,7 +125,7 @@ function getSubmitAction(): GuideAction {
 
 export const steps: GuideStep[] = [
 	{
-		content: ['What is a hosted catalog entry?', addCatalogEntryDescriptions.hosted]
+		content: ['**What is a hosted catalog entry?**', addCatalogEntryDescriptions.hosted]
 	},
 	getNavigateToMCPCatalogStep(),
 	getHighlightAddCatalogEntryStep('hosted'),
@@ -150,7 +154,8 @@ export const steps: GuideStep[] = [
 					side: 'top',
 					align: 'center',
 					title: 'Headers',
-					description: 'Add any headers that the MCP server requires.'
+					description: 'Add any headers that the MCP server requires.',
+					noDescendantInteraction: true
 				},
 				listener: {
 					id: CATALOG_SERVER_FIELD_IDS.headers,

--- a/ui/user/src/lib/services/guides/mcp/customRemote.ts
+++ b/ui/user/src/lib/services/guides/mcp/customRemote.ts
@@ -9,7 +9,7 @@ import {
 export const steps: GuideStep[] = [
 	{
 		content: [
-			'What is a remote catalog entry?',
+			'**What is a remote catalog entry?**',
 			'A remote catalog entry is great for allowing users to connect to MCP servers that are already elsewhere. When they deploy from Obot, the MCP server will go through the gateway.'
 		]
 	},
@@ -24,8 +24,7 @@ export const steps: GuideStep[] = [
 				side: 'top',
 				align: 'center',
 				title: 'Remote Server URL',
-				description:
-					'Enter the complete MCP endpoint when every user should connect to the same exact URL.'
+				description: 'Enter the full URL of the remote MCP Server.'
 			},
 			listener: {
 				id: CATALOG_SERVER_FIELD_IDS.remoteURL,
@@ -35,7 +34,7 @@ export const steps: GuideStep[] = [
 						side: 'top',
 						title: 'Advanced Configuration',
 						description:
-							"Open this section when the connection needs a hostname or URL template, custom headers, or static OAuth. Let's go ahead and open it."
+							"Open this section if your remote MCP Server requires a hostname or URL template, custom headers, or only supports static OAuth. Let's go ahead and open it."
 					},
 					listener: {
 						id: CATALOG_SERVER_FIELD_IDS.remoteAdvancedBtn,
@@ -47,7 +46,8 @@ export const steps: GuideStep[] = [
 								align: 'center',
 								title: 'Connection Restriction',
 								description:
-									'Choose an exact URL, allow a user-configured URL on one hostname, or build a URL from a template. Template variables come from user-supplied header values.'
+									'Choose an exact URL, allow a user-configured URL on one hostname, or build a URL from a template. Template variables come from user-supplied header values.',
+								noDescendantInteraction: true
 							},
 							listener: {
 								id: CATALOG_SERVER_FIELD_IDS.remoteConnection,
@@ -58,7 +58,8 @@ export const steps: GuideStep[] = [
 										align: 'center',
 										title: 'Request Headers',
 										description:
-											'Add HTTP headers required by the upstream server. Values can be fixed for everyone or requested from each user during setup; keep secrets in headers instead of URLs.'
+											'Add HTTP headers required by the upstream server. Values can be fixed for everyone or requested from each user during setup; keep secrets in headers instead of URLs.',
+										noDescendantInteraction: true
 									},
 									listener: {
 										id: CATALOG_SERVER_FIELD_IDS.remoteHeaders,

--- a/ui/user/src/lib/services/guides/mcp/steps.ts
+++ b/ui/user/src/lib/services/guides/mcp/steps.ts
@@ -5,7 +5,7 @@ import {
 	highlightMcpCatalogLink,
 	listenMcpCatalogLink,
 	SIDEBAR_MCP_CATALOG_LINK,
-	addCatalogEntryDescriptions
+	obotCatalogEntryDescriptions
 } from './constants';
 
 // shared steps that are used in mcp specific guides
@@ -60,7 +60,7 @@ export function getHighlightAddCatalogEntryStep(
 
 	return {
 		content: [
-			'Create and manage your MCP catalog entries here. To start creating a custom entry, click the "Add Catalog Entry" button.'
+			'Create and manage your MCP catalog entries here. To start, click the "Add Catalog Entry" button.'
 		],
 		action: {
 			highlight: {
@@ -79,7 +79,7 @@ export function getHighlightAddCatalogEntryStep(
 							id: SECTION_ID
 						},
 						title: `Add ${toCapitalize(type)} Server`,
-						description: `${addCatalogEntryDescriptions[type]} Click here and let's go through creating one now.`
+						description: obotCatalogEntryDescriptions[type]
 					},
 					listener: {
 						id: SECTION_ID,

--- a/ui/user/src/lib/services/guides/types.ts
+++ b/ui/user/src/lib/services/guides/types.ts
@@ -39,6 +39,7 @@ export interface GuideHighlight {
 	description?: string;
 	side?: 'top' | 'right' | 'bottom' | 'left';
 	align?: 'start' | 'center' | 'end';
+	noDescendantInteraction?: boolean;
 }
 
 export interface GuideAction {


### PR DESCRIPTION
This updates the texts for the admin guides & simplifies the composite catalog entry "getting started" guide by skipping the dive into the wizard, simply explaining it, as well as adds a noDescendentInteraction option to keep user from interacting with a actionable descendant child during the guide if desired. (ex. During displaying the component entries for selection, allowing user to select an entry to go through the wizard is not desired with the simplification -- we just want to display the dialog and selection for them and continue on.)