### PR TITLE
Chore: Update release-notes skill and add security skill

### DIFF
--- a/.claude/skills/draft-release-blog/SKILL.md
+++ b/.claude/skills/draft-release-blog/SKILL.md
@@ -7,23 +7,23 @@ description: Draft a release announcement blog post for an obot release, modeled
 
 Drafts a blog post announcing an obot release. Sources the feature spine from the draft GitHub release (the output of the `draft-release` skill or an existing draft on GitHub), then does additional research to add the kind of detail, context, and rationale that release notes deliberately omit but a blog post needs.
 
-The blog is for obot.ai's hosted Wordpress CMS. The default output is a markdown file at `/tmp/release-blog-<VERSION>.md` that the user can paste into the CMS themselves. If the user explicitly asks to post it (e.g. "post it up there", "create the draft in Wordpress"), the skill can also create the post as a Wordpress **draft** via the `obot-wordpress` MCP server (see step 8). The skill never publishes a live post without explicit user confirmation of the `publish` status.
+The blog is for obot.ai's hosted Wordpress CMS. The default output is a markdown file at `<repo root>/release-blog-<VERSION>.md` (i.e. the current project directory) that the user can paste into the CMS themselves. Writing it into the repo makes it easy to review in the IDE; it is an intentionally untracked file — do not commit it and do not add it to `.gitignore`. If the user explicitly asks to post it (e.g. "post it up there", "create the draft in Wordpress"), the skill can also create the post as a Wordpress **draft** via the `obot-wordpress` MCP server (see step 8). The skill never publishes a live post without explicit user confirmation of the `publish` status.
 
 ## Voice reference
 
-Read both before drafting, every time:
+Read both before drafting, every time. Both are multi-feature roundups, which is the shape every obot release blog uses:
 
-- https://obot.ai/blog/obot-v0210-network-egress-control-for-mcp-servers/ — single-feature deep-dive shape, first-person personal voice, ~600 words
-- https://obot.ai/blog/announcing-obot-mcp-platform-v0-16-0-api-keys-model-access-policies-and-other-enterprise-ready-controls/ — multi-feature roundup shape, "we are excited" framing, ~1200 words
+- https://obot.ai/blog/announcing-obot-platform-v0-22-0-centrally-managed-skills-fleet-scanning-and-enterprise-controls-for-mcp/ — ~2,100 words, one `## <Feature Name>` section per feature, closes with a multi-CTA "Get started". Note: this post opens with a "client zoo" problem-first hook. Use it as a reference for body voice and structure only. Do NOT copy its opener; the required opener pattern is in step 6.
+- https://obot.ai/blog/announcing-obot-platform-v0-23-0/ — ~1,800 words, opens with the mandated pattern ("The Obot Platform v0.23.0 release is out."), same per-feature section structure and multi-CTA close. This is the opener to model.
 
-Author byline is **Craig Jellick** (`craig@obot.ai`). The personal voice in the deep-dive shape is his — when the post uses "I", that's him. Don't use "I" in the roundup shape; use "we".
+Author byline is **Craig Jellick** (`craig@obot.ai`). Write in the first-person plural ("we") throughout — these are company announcements, not personal essays. Reserve first-person singular for a specific personal-stake line only if the user supplies one.
 
 ## Hard constraints
 
 - No emojis. No em dashes (`—`). Use plain hyphens or rewrite. No "thrilled / proud / revolutionary / game-changing / unlock the power of" hype words.
 - Use straight quotes (`'` and `"`), not curly quotes.
 - Do not invent statistics, customer quotes, partner endorsements, or technical claims not grounded in the PRs, issues, code, or docs you have actually read.
-- The markdown file at `/tmp/release-blog-<VERSION>.md` is always the first output. Posting to Wordpress (step 8) is opt-in: only do it when the user explicitly asks.
+- The markdown file at `<repo root>/release-blog-<VERSION>.md` is always the first output. Posting to Wordpress (step 8) is opt-in: only do it when the user explicitly asks.
 - When posting to Wordpress, the post status MUST be `draft` unless the user explicitly confirms `publish`. Never default to publishing live.
 - Never write the post as a "we shipped a lot of stuff this quarter" generic update. Anchor on the specific release.
 
@@ -42,14 +42,17 @@ If a draft or published release exists, its Big Updates section is the spine. Th
 
 If no release exists yet, ask the user whether to run `draft-release` first, or proceed by surveying commits directly. Do not invent a feature list out of commits alone for the blog — the release notes are where editorial alignment happens, and the blog should follow that.
 
-### 2. Choose the blog shape
+### 2. Structure the roundup
 
-The two reference posts use different shapes. Pick based on the release character:
+Every obot release blog uses the same multi-feature roundup shape as the two reference posts. Target ~1,800-2,100 words. The structure is:
 
-- **Single-feature deep-dive** (model on v0.21.0 blog): use when the release has one obviously dominant feature and one or two minor supporting items. ~500-800 words. Sections: opener, "Why we built this", "How it works", optional partner/collab section, "What's next".
-- **Multi-feature roundup** (model on v0.16.0 blog): use when the release has 3-6 features of comparable weight. ~1000-1400 words. Sections: opener with bulleted summary, one subsection per feature, "Additional improvements" if relevant, "Get started" CTA.
+- **Opener** (1-2 short paragraphs). Always lead with the plain fact that the release is out, then state concretely what it adds. There is one opener pattern, not a menu: start with `The Obot Platform <VERSION> release is out.` (or a very close variant), then short factual sentences naming the headline change and the other notable ones. No problem-first hook, no suspense, no marketing framing. See step 6 for the required pattern, the model opener, and the banned phrasings.
+- **One `## <Feature Name>` section per feature**, in the same order as the release notes' Big Updates. Each section gives the concrete problem, how the feature works, and (where relevant) a short code/config example.
+- **`## Additional Improvements`** with one short bullet per notable smaller item.
+- **`## Upgrade Notes`** with one short bullet per breaking change or migration callout, followed by a link to the version's GitHub release notes for complete instructions.
+- **`## Get started`** closing CTA (see step 6 for the exact links).
 
-Present the recommended shape to the user before drafting and let them override. If they pick deep-dive but there are multiple features, the others can be mentioned briefly at the end ("This release also includes X, Y, Z — see the release notes for details").
+There is no separate deep-dive shape. If one feature dominates the release, give it the longest section and let the smaller ones be brief; do not switch to a single-feature format.
 
 ### 3. Deep research for blog-quality detail
 
@@ -58,23 +61,33 @@ This is the step that separates a blog from rephrased release notes. The release
 - Re-read the PR(s) and any linked issues (remember: this repo does NOT use `closes #N`, so grep PR body/comments for issue numbers; see the related memory). The design discussions, alternatives considered, and user-reported problems live here.
 - Look at the actual code or config surface the feature exposes. The blog should be able to describe what configuring this feature looks like in concrete terms ("you get a section for network egress policies", "you define the external domains the server should be allowed to reach"), not abstract terms.
 - Check `docs/` for any feature documentation written for this release. Pull concrete language from the docs where it's clearer than what's in the PR.
-- For security/compliance features, look for real-world context that explains why the feature matters now. The v0.21.0 post cites the Axios supply chain compromise. Use external context only when you can name it specifically — never write "recent attacks have shown..." without naming one.
-- Note any partner/integration angle (e.g. Aviatrix in v0.21.0). If the feature involves a named third party, plan to dedicate a short section to that collaboration.
+- For security/compliance features, look for real-world context that explains why the feature matters now (an earlier obot post, for example, cited the Axios supply chain compromise). Use external context only when you can name it specifically — never write "recent attacks have shown..." without naming one.
+- Note any partner/integration angle. If the feature involves a named third party, plan to dedicate a short section to that collaboration.
+
+Research implementation details to establish accuracy, but write from the user's perspective. Explain what users can now do and why it matters. Avoid internal IDs, controller behavior, database shapes, resolution mechanics, and other implementation details unless readers need them to use or upgrade the feature.
 
 The goal: walk away from research with enough material to write three things per feature that release notes don't have:
 1. The user problem in concrete terms (not "users wanted X" but "before this, admins had to do Y, and Y broke when Z").
 2. A specific, visualizable example of using the feature.
 3. Forward-looking context (what comes next, what this unlocks, what's still open).
 
-### 4. Surface places that need the user's personal voice
+### 4. Surface places that need the user's voice
 
-The deep-dive shape has lines that can only come from the user. Examples from v0.21.0:
-
-> What I appreciate about working with their team: they think about this the same way we do.
+Even in the roundup shape, some lines can only come from the user: forward-looking commitments, statements about a partner, or a "why we bet on this" take. For example:
 
 > We're already in conversations with other networking companies about additional integrations, so if you're using a different platform, let us know what you'd like to see supported.
 
-These are POV statements about partners, future plans, or personal stake. The skill should NOT invent these. Before drafting, identify 2-4 places in the planned structure where personal POV would belong, then ask the user:
+> This is just the start of what we're building here.
+
+These are POV statements about partners, future plans, or company stake. The skill should NOT invent them. Before drafting, identify 2-4 places in the planned structure where such POV would belong, then ask the user:
+
+Look for POV opportunities that answer:
+
+- Why this capability matters now
+- Why Obot chose this approach
+- How organizations differ in the level of control or flexibility they need
+- What direction the capability may take next
+- Why a particular integration or partner came first
 
 ```
 For the blog draft, these spots are best filled by your voice rather than mine. Want to give me a sentence or two for each, or should I leave them as `[POV: ...]` placeholders for you to fill in after?
@@ -86,16 +99,15 @@ For the blog draft, these spots are best filled by your voice rather than mine. 
 
 Use AskUserQuestion when the placeholders map to clean forks. Otherwise plain text reply.
 
-### 5. Confirm shape, angles, and POV with the user
+### 5. Confirm angles and POV with the user
 
 Before writing prose, post a short plan:
 
 ```
 Blog plan for <VERSION>:
 
-Shape: <Deep-dive | Roundup>
 Working title: <draft title>
-Opening hook angle: <one sentence>
+Opening: leads with "The Obot Platform <VERSION> release is out." then <one line on the concrete facts the first paragraph will state>
 
 Sections:
 1. <Section name> — <one-line description of angle/content>
@@ -115,11 +127,20 @@ Wait for confirmation or adjustments before writing prose.
 
 Match the reference posts:
 
-- Title format: For deep-dive, `New in Obot: <Feature Phrase>` (e.g. "New in Obot: Network Egress Control for MCP Servers"). For roundup, `Announcing Obot MCP Platform <VERSION>: <feature, feature, and other theme>`.
-- Open with a one-paragraph hook. Deep-dive: first person, states what was built and the partner if any. Roundup: "We're excited to announce..." + brief framing of the release theme.
-- Use `## Why we built this` / `## How it works` / `## What's next` headings in the deep-dive shape, or `## <Feature Name>` headings in the roundup shape. Match the reference structure exactly.
+- Title format: `Announcing Obot Platform <VERSION>: <feature, feature, and theme>` (e.g. "Announcing Obot Platform v0.22.0: Centrally Managed Skills, Fleet Scanning, and Enterprise Controls for MCP"). The subtitle after the colon is optional — v0.23.0 used just `Announcing Obot Platform v0.23.0`. Use "Obot Platform", not "Obot MCP Platform".
+- **Opener: always lead with the release being out, stated plainly.** Start with `The Obot Platform <VERSION> release is out.` (or a very close variant), then short, concrete, factual sentences: what the headline change is, followed by a sentence listing the other notable additions. Sound like an engineer explaining the release to another engineer, not a copywriter creating suspense. Lead with a fact, never a hook.
+
+  Banned in the opener (and generally): rhetorical questions; "We're thrilled/proud/excited to announce"; "visibility/security/X is more important than ever"; the cadence "as X grows" or "as teams adopt Y, the same question keeps coming up"; dramatic before/after contrasts; and phrases like "changes everything", "closes the gap", "pulls into view", and "the theme of this release".
+
+  Model opener (from the v0.24.0 post):
+
+  > The Obot Platform v0.24.0 release is out. It adds audit logging for AI activity that previously happened outside Obot. A new companion tool, Obot Sentry, captures tool calls made by Claude Code, Codex, VS Code, and Cursor on developer machines and sends them to Obot's existing audit logs. This release also adds full LLM Gateway audit logs, three new model providers, and a reworked MCP proxy that substantially reduces the resources required to run Obot.
+- Use `## <Feature Name>` headings, one per feature, then separate `## Additional Improvements`, `## Upgrade Notes`, and `## Get started` sections.
+- Keep Additional Improvements and Upgrade Notes scannable: one short bullet per item. Do not reproduce detailed migration steps, cleanup commands, or implementation notes in the blog. End Upgrade Notes with a link to `https://github.com/obot-platform/obot/releases/tag/<VERSION>` for the complete details.
+- For supporting features, lead with the intended scenario instead of lower-level implementation or security details. For example, frame local authentication as a fast path for evaluations and development or test environments, not as a password-storage feature.
 - Concrete > abstract in every sentence. If a sentence could appear in any company's launch blog, rewrite or delete it.
-- End with a CTA. Reference posts use either `reach out at info@obot.ai` or `Check out our installation guide`. Default to `info@obot.ai` for deep-dives where there's a partner/conversation angle, installation guide for roundups.
+- End `## Get started` with one casual sentence that summarizes the release, followed by the CTA paragraph. Do not introduce a new product thesis, roadmap, or upgrade summary in the closing.
+- In the CTA paragraph, include a link to try Obot free, a link to request a demo, and a link to the docs, followed by a short invitation to email feedback to `info@obot.ai`. Use the same links the current reference posts use — verify them by re-reading the reference post rather than inventing URLs.
 
 Add a frontmatter block at the top of the markdown for the CMS to consume:
 
@@ -135,11 +156,11 @@ version: <VERSION>
 
 ### 7. Write to disk and report
 
-Write the post to `/tmp/release-blog-<VERSION>.md`. Print:
+Write the post to `$CLAUDE_PROJECT_DIR/release-blog-<VERSION>.md` (the repo root of the current project). This is an intentionally untracked file for easy IDE review; do not commit it and do not touch `.gitignore`. Print:
 - The file path
-- The chosen shape and word count
+- The word count (target ~1,800-2,100)
 - A list of any `[POV: ...]` placeholders that still need the user's personal voice
-- A reminder that this is a draft markdown file for the CMS — the skill has not published anything
+- A reminder that this is a draft markdown file for the CMS, written into the repo root for review — the skill has not published anything and the file should not be committed
 
 End the turn there. Do not run any publish/upload commands. Do not modify the GitHub release. Do not commit anything to the repo.
 
@@ -153,11 +174,16 @@ When the user does ask, post the blog as a Wordpress **draft** (never `publish` 
 
 **8b. Convert the markdown to HTML.** Wordpress's `create_post` expects the post body as HTML. A helper script lives next to this SKILL.md:
 
+Immediately before conversion, re-read the markdown from disk and confirm it contains the user's latest requested revisions. Record its SHA-256 hash so the exact source state being uploaded is explicit.
+
 ```bash
+shasum -a 256 "$CLAUDE_PROJECT_DIR/release-blog-<VERSION>.md"
 uv run "$CLAUDE_PROJECT_DIR/.claude/skills/draft-release-blog/md_to_html.py" \
-  /tmp/release-blog-<VERSION>.md \
+  "$CLAUDE_PROJECT_DIR/release-blog-<VERSION>.md" \
   > /tmp/release-blog-<VERSION>.html
 ```
+
+The markdown source lives in the repo root; the HTML is just a transient intermediate for the Wordpress upload, so it stays in `/tmp`.
 
 It strips the YAML frontmatter so it doesn't render in the post body and emits HTML5 with the Python `markdown` library's `extra` and `sane_lists` extensions. Dependencies are declared inline (PEP 723) so `uv run` resolves them automatically — no virtualenv setup needed. Important: redirect only stdout (no `2>&1`) so uv's "Installed N packages" line doesn't get mixed into the HTML.
 
@@ -165,7 +191,7 @@ It strips the YAML frontmatter so it doesn't render in the post body and emits H
 
 ```
 mcp__obot-wordpress__list_categories(search_query="Blog")  # → expect id 6
-mcp__obot-wordpress__list_users()                           # → find Craig Jellick, expect id 9
+mcp__obot-wordpress__list_users(context="view")             # → find Craig Jellick, expect id 9
 ```
 
 IDs may differ if the Wordpress site is reconfigured. Always look them up; don't hardcode.
@@ -180,24 +206,23 @@ IDs may differ if the Wordpress site is reconfigured. Always look them up; don't
 
 The response returns a post `id` and a `link` like `https://obot.ai/?p=<id>`. Share both with the user and remind them to review and publish from the WP admin (Posts → Drafts).
 
+After creation, retrieve the post by ID and verify that its status is `draft`, its title matches the frontmatter, and its author and category match the resolved IDs. Report only the verified result.
+
 **Sanity checks before posting:**
 
-- Run `grep -nF $'\xe2\x80\x94' /tmp/release-blog-<VERSION>.md` (or `grep -nF $'—'`) to confirm no em dashes slipped in. The hard constraints forbid them; the markdown editor sometimes auto-substitutes when copy-pasting.
+- Run `grep -nF $'\xe2\x80\x94' "$CLAUDE_PROJECT_DIR/release-blog-<VERSION>.md"` (or `grep -nF $'—'`) to confirm no em dashes slipped in. The hard constraints forbid them; the markdown editor sometimes auto-substitutes when copy-pasting.
 - Confirm the HTML file does not start with a uv "Installed N packages" line.
 - Confirm the title in the frontmatter matches the title you're sending to `create_post`.
+- Re-run the SHA-256 command and confirm the markdown has not changed since conversion. If it changed, discard the generated HTML and convert again.
 
 ## Tone reference snippets
 
-From v0.21.0 (deep-dive):
+The opener always leads with the plain announcement, as in v0.23.0:
 
-> I'm excited to announce a new framework in Obot that lets you define and enforce network egress policies for the MCP servers running in your Obot environment.
+> The Obot Platform v0.23.0 release is out. It is a step toward deeper integration between Obot and the clients and agents that connect to it.
 
-> The MCP server works exactly like it did before. It just can't access external sites it shouldn't.
+For the body, match this register: confident, concrete, no rhetorical flourishes, technical without being dry, first-person plural for the company. For example (v0.23.0):
 
-From v0.16.0 (roundup):
+> A developer points their agent at the gateway and gets to work.
 
-> We are excited to announce the release of Obot v0.16.0, a significant update focused on enterprise readiness and operational control.
-
-> Perfect for CI/CD pipelines, automation scripts, monitoring tools, and other integrations.
-
-Match that register: confident, concrete, no rhetorical flourishes, technical without being dry, first-person plural for the company and first-person singular only when speaking with personal stake.
+Lead with a plain statement of what shipped, never with a hook, a rhetorical question, or hype. The v0.22.0 post opened with a 'client zoo' problem framing; do not copy that approach for the opener. Lead with the release being out instead.

--- a/.claude/skills/draft-release/SKILL.md
+++ b/.claude/skills/draft-release/SKILL.md
@@ -10,7 +10,7 @@ Drafts release notes for the next obot minor release and creates a draft (unpubl
 ## Inputs
 
 - **Target version** (e.g. `v0.22.0`): ask the user if not provided. If recent pre-release tags exist (e.g. `v0.22.0-rc3`), suggest the corresponding minor (`v0.22.0`) and confirm.
-- **Diff baseline** (e.g. `v0.21.3`): auto-detect as the highest non-pre-release tag, regardless of whether it is a minor or patch. This is the range used to find changes (`<DIFF_BASELINE>..HEAD`) and the left side of the "Full Changelog" compare link. Use `git tag --sort=-v:refname | grep -v -- '-' | head -1`.
+- **Diff baseline** (e.g. `v0.21.3`): auto-detect as the highest non-pre-release tag, regardless of whether it is a minor or patch, **that is also an ancestor of `HEAD`**. This is the range used to find changes (`<DIFF_BASELINE>..HEAD`) and the left side of the "Full Changelog" compare link. Use `git tag --sort=-v:refname | grep -v -- '-' | head -1`, then verify with `git merge-base --is-ancestor <candidate> HEAD`. Patch releases are sometimes cut from a separate release branch that never merges back into `main` — if the highest-sorted tag fails the ancestor check, walk down to the next-highest tag and check again until one passes. Do not silently trust version-sort order alone.
 - **Style reference** (e.g. `v0.21.0`): auto-detect as the highest `vX.Y.0` tag that is not a pre-release. Use `git tag --list 'v*.*.0' --sort=-v:refname | grep -v -- '-' | head -1`. This release's notes are the tone/structure template. It is often the same as the diff baseline but may differ when patch releases exist between minors.
 
 ## Hard constraints
@@ -21,6 +21,7 @@ Drafts release notes for the next obot minor release and creates a draft (unpubl
 - No emojis. No em dashes (`—`). Use plain hyphens or rewrite the sentence. No "we're thrilled / excited to / proud to" beyond the one opening line the template already uses. No marketing fluff.
 - Use straight quotes (`'` and `"`), not curly quotes.
 - Do not invent PRs, authors, or commit messages in "What's Changed". That section must be sourced from the GitHub API, not synthesized.
+- Never run `gh release create` (or any other command that writes to GitHub) until the user has seen the fully assembled draft (opener, Big Updates, Improvements, Upgrade Notes, What's Changed, Full Changelog line — the whole document, not just the feature list from step 5) and explicitly approved it. Step 5's feature-list confirmation is necessary but not sufficient; the user must sign off on the actual prose before anything is pushed to GitHub.
 
 ## Procedure
 
@@ -48,7 +49,7 @@ Match its structure exactly:
 2. `## Big Updates` with 3-6 `### Feature Name` subsections. Each subsection is 1-3 short paragraphs in plain prose. Link to docs with `[docs](https://docs.obot.ai/...)` when a docs page exists.
 3. Optional `## Improvements` section with a short bulleted list of smaller usability/perf items. Include only if there are clearly several smaller user-facing improvements worth calling out. Omit otherwise (v0.21.0 has no Improvements section).
 4. `## Upgrade Notes` — usually `There are no major breaking changes in this release.` If the diff contains breaking changes (removed APIs, renamed config, schema migrations, removed env vars), call them out explicitly and concretely. Check commits with `chore: remove`, `BREAKING`, or schema/migration changes.
-5. `## What's Changed` — generated via API (see step 5).
+5. `## What's Changed` — generated via API (see step 7).
 6. Trailing `**Full Changelog**: https://github.com/obot-platform/obot/compare/<DIFF_BASELINE>...<VERSION>`.
 
 ### 3. Survey the commit range
@@ -200,9 +201,17 @@ gh pr list --repo obot-platform/obot --state merged \
 
 Format each as `* <title> by @<author> in <url>`. If using this fallback, tell the user the list came from `gh pr list` and recommend they regenerate it from the GitHub UI when they create the release, since the UI's list is the canonical one.
 
-### 8. Create the draft release on GitHub
+### 8. Show the full assembled draft and wait for approval (required, do not skip)
 
-First write the assembled notes to `/tmp/release-notes-<VERSION>.md` so there's a local copy the user can re-use if they want to recreate the draft. Then create the draft release on GitHub with that file as the body:
+Write the fully assembled notes (opener, Big Updates, Improvements, Upgrade Notes, What's Changed, Full Changelog line) to `<REPO_ROOT>/release-notes-<VERSION>.md` — in the project working directory itself (not `/tmp`), so the user can open it directly in their IDE for review/editing.
+
+Then show the complete rendered document to the user in the chat too — not just a summary or the feature list from step 5, and not just a pointer to the file. This is a second, distinct checkpoint from step 5: step 5 confirms *which* features and callouts to include, this step confirms the *actual wording* of the finished document, since prose can drift from an approved gist during drafting.
+
+Explicitly ask for approval before doing anything on GitHub, e.g. "Here's the full draft, also written to `release-notes-<VERSION>.md` if you'd rather review it in your IDE — let me know if you want changes, or I'll go ahead and create the GitHub draft release." If the user edits the file directly, re-read it before proceeding rather than relying on your in-memory copy. Do not proceed to step 9 until the user responds with approval (or with edits, which you incorporate and then re-confirm if they're substantial). Do not treat silence, an unrelated reply, or a reply about something else in the conversation as approval.
+
+### 9. Create the draft release on GitHub
+
+Only after the user has approved the full draft in step 8. Reuse the same `<REPO_ROOT>/release-notes-<VERSION>.md` file written in step 8 (re-read it first if the user said they edited it) as the body:
 
 ```bash
 gh release create <VERSION> \
@@ -210,7 +219,7 @@ gh release create <VERSION> \
   --draft \
   --title "<VERSION>" \
   --target main \
-  --notes-file /tmp/release-notes-<VERSION>.md
+  --notes-file release-notes-<VERSION>.md
 ```
 
 Notes on the flags:

--- a/.claude/skills/rewrite-security-advisory/SKILL.md
+++ b/.claude/skills/rewrite-security-advisory/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: rewrite-security-advisory
+description: Rewrite an obot GitHub security advisory into Obot's short, user-facing format (Summary / Am I affected? / Details / Impact / Mitigation / Severity / Credits). Use when the user gives a GHSA id or advisory URL and asks to rewrite, simplify, or reformat it. Writes the result to a markdown file in the repo root for the user to paste into the advisory editor.
+---
+
+# Rewrite Security Advisory
+
+Take a verbose, reporter-submitted obot security advisory and rewrite it into
+Obot's concise, user-facing format. The goal is a short writeup a deployer can
+read and immediately know whether they're affected and what to do — not a
+reproduction of the researcher's full report.
+
+Output is a markdown file at the repo root named `<GHSA-id>.md`. The user reviews
+it and pastes it into the GitHub advisory editor themselves. Do not push it to
+GitHub or modify the live advisory unless explicitly asked.
+
+## 1. Fetch the advisory
+
+The advisory is usually a private draft, so the web URL 404s for WebFetch. Pull
+it via the authenticated API instead:
+
+```bash
+gh api repos/obot-platform/obot/security-advisories/<GHSA-id> --jq '{summary, description, severity, cvss: .cvss.vector_string, score: .cvss.score, vuln_range: .vulnerabilities[0].vulnerable_version_range, patched: .vulnerabilities[0].patched_versions, credits: [.credits_detailed[].user.login], cwes: [.cwes[].cwe_id]}'
+```
+
+This gives you the title, the reporter's full description (Summary/Details/PoC/Impact),
+CVSS vector + score, affected range, and the credited reporters.
+
+## 2. Read the comments — they matter
+
+The advisory's comment thread is NOT exposed by the GitHub API (REST or GraphQL),
+and the web page 404s for WebFetch on drafts. **Ask the user to paste the
+comments**, especially the obot team's response (often from the lead eng). The
+comments frequently change the framing — e.g. clarifying that the reporter's
+headline mechanism was actually a fail-safe and the real fix was something else,
+or noting which parts were disputed. Do not finalize the rewrite without them.
+
+## 3. Confirm the patched version
+
+The advisory's `patched` field is often empty and `vuln_range` may be recorded as
+a commit hash. **Always express versions as release tags, never commit hashes**
+(users reason about releases, not commits). Ask the user which release contains
+the fix if it isn't obvious; the affected range is then `<= <last release before
+the fix>` (e.g. fixed in v0.23.0 → affected `<= v0.22.1`).
+
+## 4. Write in Obot's format
+
+Use exactly these sections, in this order. Keep it tight — a few sentences per
+section. This is a summary for deployers, not the researcher's report.
+
+- **Title** (`# ...`): a plain-language description of the actual issue and its
+  real impact. Don't just copy the reporter's title if it leads with a mechanism
+  that the team's comments downgraded (e.g. don't headline "audience confusion"
+  if that turned out to be a fail-safe). Keep the `(incomplete fix of GHSA-...)`
+  style suffix when the advisory metadata has one.
+- **## Summary**: 2-4 sentences. What the flaw is and what an attacker could do.
+- **## Am I affected?**: the affected release range (`<= vX.Y.Z`) plus the
+  preconditions (config flags, required role, required user interaction). Note
+  when a configuration makes it a non-issue.
+- **## Details**: one paragraph on the root cause, written generically. Do NOT
+  cite internal function names, file paths, or line numbers — those are
+  implementation details that don't belong in a user-facing advisory. Describe
+  behavior ("the authorizer default-allows unrecognized top-level paths"), not
+  symbols (~~`checkUI`~~). Mention the relationship to prior advisories if any.
+- **## Impact**: worst-case consequence in plain terms. Mirror what the user has
+  liked before: state the worst case, then clarify what is NOT exposed/possible
+  (e.g. "No credential values are exposed").
+- **## Mitigation**: "Upgrade to **vX.Y.Z** or later, which ..." — describe what
+  the fix does at a behavioral level (again, no symbol/commit references). If the
+  team's comments listed multiple protections, summarize them.
+- **## Severity**: `CVSS v3.1 Score: **<score>/10 (<Severity>)** — \`<vector>\``
+- **## Credits**: the fixed boilerplate below.
+
+### Credits boilerplate
+
+```
+The Obot team would like to thank [@<reporter>](https://github.com/<reporter>) for responsibly disclosing this issue in accordance with our [security policy](https://github.com/obot-platform/obot/?tab=security-ov-file).
+```
+
+If there are multiple reporters, thank each (`[@a](...) and [@b](...)`).
+
+## 5. Write the file and present it
+
+Write to `<repo-root>/<GHSA-id>.md`, then paste the full rendered text back in the
+chat so the user can review inline. Flag anything you assumed (patched version,
+title change) so they can correct it.
+
+## Reference: a finished example
+
+See the advisory writeups already in the repo root (e.g. `GHSA-jgh3-fggc-mcpm.md`,
+`GHSA-pr6h-vr44-xq8j.md`, `GHSA-xwmw-prc4-v3cr.md`) for the exact tone and length
+to match.


### PR DESCRIPTION
Some tweaks to the release-notes skill based on my most recent use of
it. Also I previously wrote a skill to help me rewrite security
advisories to prepare them for publishing. Committing that as well.

Signed-off-by: Craig Jellick <craig@obot.ai>
