### PR TITLE
chore: remove obsolete nanobot disable-ui flag

### DIFF
--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -37,6 +37,16 @@ func IsKubernetesBackend(backend string) bool {
 	}
 }
 
+func serverContainerArgs(server ServerConfig) []string {
+	args := server.Args
+	if server.Runtime != types.RuntimeContainerized {
+		args = []string{"run", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
+	} else if server.IsNanobotAgentServer() {
+		args = append(args, "--enable-browser")
+	}
+	return args
+}
+
 type backend interface {
 	// ensureServerDeployment will deploy a server if it is not already deployed, and return the updated ServerConfig
 	ensureServerDeployment(ctx context.Context, serverConfig ServerConfig) (ServerConfig, error)

--- a/pkg/mcp/backend_test.go
+++ b/pkg/mcp/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,51 @@ import (
 	ntypes "github.com/obot-platform/nanobot/pkg/types"
 	"github.com/obot-platform/obot/apiclient/types"
 )
+
+func TestServerContainerArgs(t *testing.T) {
+	genericNanobotArgs := []string{"run", "--listen-address", ":8099", "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
+	tests := []struct {
+		name   string
+		server ServerConfig
+		want   []string
+	}{
+		{
+			name:   "generic NPX server has no UI or browser flag",
+			server: ServerConfig{Runtime: types.RuntimeNPX},
+			want:   genericNanobotArgs,
+		},
+		{
+			name:   "generic UVX server has no UI or browser flag",
+			server: ServerConfig{Runtime: types.RuntimeUVX},
+			want:   genericNanobotArgs,
+		},
+		{
+			name: "generic containerized server preserves configured args",
+			server: ServerConfig{
+				Runtime: types.RuntimeContainerized,
+				Args:    []string{"serve", "--verbose"},
+			},
+			want: []string{"serve", "--verbose"},
+		},
+		{
+			name: "NanobotAgent server enables browser",
+			server: ServerConfig{
+				Runtime:          types.RuntimeContainerized,
+				Args:             []string{"run", "--config", ".nanobot/"},
+				NanobotAgentName: "agent-1",
+			},
+			want: []string{"run", "--config", ".nanobot/", "--enable-browser"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := serverContainerArgs(tt.server); !slices.Equal(got, tt.want) {
+				t.Fatalf("serverContainerArgs() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestEnsureServerReadyUsesHealthzPath(t *testing.T) {
 	var healthzCalls, mcpCalls int

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -967,9 +967,6 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 			Target: "/config",
 		})
 
-		// Use nanobot command
-		cmd = []string{"run", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
-
 		// Set nanobot environment variables
 		env = append(env, "NANOBOT_RUN_HEALTHZ_PATH=/healthz", "OBOT_KUBERNETES_MODE=true")
 
@@ -986,8 +983,6 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 		if server.Command != "" {
 			entrypoint = []string{server.Command}
 		}
-		cmd = server.Args
-
 		// Use server's environment variables plus file env vars
 		metaEnvVar := make([]string, 0, len(server.Env)+len(fileEnvVars))
 		for _, val := range server.Env {
@@ -1007,6 +1002,7 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 	default:
 		return "", 0, fmt.Errorf("unsupported runtime: %s", server.Runtime)
 	}
+	cmd = serverContainerArgs(server)
 
 	// Prepare port binding
 	containerPortStr := fmt.Sprintf("%d/tcp", containerPort)

--- a/pkg/mcp/docker.go
+++ b/pkg/mcp/docker.go
@@ -968,7 +968,7 @@ func (d *dockerBackend) createAndStartContainer(ctx context.Context, server Serv
 		})
 
 		// Use nanobot command
-		cmd = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
+		cmd = []string{"run", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
 
 		// Set nanobot environment variables
 		env = append(env, "NANOBOT_RUN_HEALTHZ_PATH=/healthz", "OBOT_KUBERNETES_MODE=true")

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -396,7 +396,7 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 		command  []string
 		objs     = make([]kclient.Object, 0, 5)
 		image    = k.baseImage
-		args     = []string{"run", "--disable-ui", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
+		args     = []string{"run", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
 		port     = defaultContainerPort
 		portName = "mcp"
 

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -396,7 +396,6 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 		command  []string
 		objs     = make([]kclient.Object, 0, 5)
 		image    = k.baseImage
-		args     = []string{"run", "--listen-address", fmt.Sprintf(":%d", defaultContainerPort), "--exclude-built-in-agents", "--config", "/config/nanobot.yaml"}
 		port     = defaultContainerPort
 		portName = "mcp"
 
@@ -540,8 +539,8 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 		}
 
 		image = expandEnvVars(server.ContainerImage, fileMapping, nil)
-		args = server.Args
 	}
+	args := serverContainerArgs(server)
 
 	objs = append(objs, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

- remove the obsolete `--disable-ui` argument from all Obot-managed Nanobot commands
- pass `--enable-browser` only for NanobotAgent-backed workloads, identified by `ServerConfig.IsNanobotAgentServer()`
- keep generic NPX/UVX MCP workloads headless, with neither `--disable-ui` nor `--enable-browser`
- share the argument matrix across Docker and Kubernetes command construction
- add exact argument coverage for generic MCP, generic containerized, and NanobotAgent servers

## Dependency

Depends on obot-platform/nanobot#353.

Before this PR is merged, update Obot to the Nanobot version tag containing those merged and released changes.

## Testing

- `go test ./pkg/mcp`
- `make test`
- `make lint`