### PR TITLE
fix: cleanup Obot user on local auth user delete

### DIFF
--- a/pkg/api/handlers/localauth.go
+++ b/pkg/api/handlers/localauth.go
@@ -3,13 +3,17 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/localauth"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type LocalAuthHandler struct {
@@ -122,6 +126,50 @@ func (h *LocalAuthHandler) Delete(req api.Context) error {
 	id, err := localAuthUserID(req)
 	if err != nil {
 		return err
+	}
+
+	localUser, err := h.provider.GetUser(req.Context(), id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return types.NewErrNotFound("local auth user not found")
+		}
+		return fmt.Errorf("failed to get local auth user: %w", err)
+	}
+
+	gatewayUser, err := req.GatewayClient.UserFromProviderUserID(req.Context(), system.DefaultNamespace, system.LocalAuthProvider, localUser.Email)
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return fmt.Errorf("failed to get user from provider user ID: %w", err)
+	}
+
+	if gatewayUser != nil {
+		if _, err = req.GatewayClient.DeleteUser(req.Context(), strconv.FormatUint(uint64(gatewayUser.ID), 10)); err != nil {
+			status := http.StatusInternalServerError
+			if _, ok := errors.AsType[*gateway.LastAdminError](err); ok {
+				status = http.StatusBadRequest
+			} else if _, ok := errors.AsType[*gateway.LastOwnerError](err); ok {
+				status = http.StatusBadRequest
+			}
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				// If the error is a record not found error, then someone else already deleted the user while we were processing.
+				return types.NewErrHTTP(status, fmt.Sprintf("failed to delete user: %v", err))
+			}
+		}
+
+		if err == nil {
+			if err = req.Create(&v1.UserDelete{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: system.UserDeletePrefix,
+					Namespace:    req.Namespace(),
+				},
+				Spec: v1.UserDeleteSpec{
+					UserID: gatewayUser.ID,
+				},
+			}); err != nil {
+				return fmt.Errorf("failed to start deletion of user owned objects: %v", err)
+			}
+
+			log.Infof("Scheduled user cleanup after deletion: targetUserID=%d", gatewayUser.ID)
+		}
 	}
 
 	if err = h.provider.DeleteUser(req.Context(), id); errors.Is(err, gorm.ErrRecordNotFound) {

--- a/pkg/gateway/client/localauth.go
+++ b/pkg/gateway/client/localauth.go
@@ -50,6 +50,19 @@ func (c *Client) LocalAuthUserByEmail(ctx context.Context, email string) (*types
 	return &user, nil
 }
 
+func (c *Client) LocalAuthUserByID(ctx context.Context, id uint) (*types.LocalAuthUser, error) {
+	var user types.LocalAuthUser
+	if err := c.db.WithContext(ctx).First(&user, id).Error; err != nil {
+		return nil, err
+	}
+
+	if err := c.decryptLocalAuthUser(ctx, &user); err != nil {
+		return nil, fmt.Errorf("failed to decrypt local auth user: %w", err)
+	}
+
+	return &user, nil
+}
+
 // CreateLocalAuthUser creates a new local auth user. The password must already be hashed.
 func (c *Client) CreateLocalAuthUser(ctx context.Context, email, passwordHash string) (*types.LocalAuthUser, error) {
 	email = NormalizeEmail(email)

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -106,6 +106,22 @@ func (c *Client) UserByIDIncludeDeleted(ctx context.Context, id string) (*types.
 	return u, c.decryptUser(ctx, u)
 }
 
+// UserFromProviderUserID returns a user by their provider user ID
+func (c *Client) UserFromProviderUserID(ctx context.Context, providerNamespace, providerName, providerUserID string) (*types.User, error) {
+	u := new(types.User)
+	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		id := new(types.Identity)
+		if err := tx.Where("auth_provider_namespace = ? AND auth_provider_name = ? AND hashed_provider_user_id = ?", providerNamespace, providerName, hash.String(providerUserID)).First(id).Error; err != nil {
+			return err
+		}
+		return tx.Where("id = ? AND deleted_at IS NULL", id.UserID).First(u).Error
+	}); err != nil {
+		return nil, err
+	}
+
+	return u, c.decryptUser(ctx, u)
+}
+
 // UsersIncludeDeleted returns all users including soft-deleted ones (for audit purposes)
 func (c *Client) UsersIncludeDeleted(ctx context.Context, query types.UserQuery) ([]types.User, error) {
 	query.IncludeDeleted = true

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -307,9 +307,9 @@ func (s *Server) deleteUser(apiContext api.Context) (err error) {
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			status = http.StatusNotFound
-		} else if lae := (*client.LastAdminError)(nil); errors.As(err, &lae) {
+		} else if _, ok := errors.AsType[*client.LastAdminError](err); ok {
 			status = http.StatusBadRequest
-		} else if loe := (*client.LastOwnerError)(nil); errors.As(err, &loe) {
+		} else if _, ok := errors.AsType[*client.LastOwnerError](err); ok {
 			status = http.StatusBadRequest
 		}
 		return types2.NewErrHTTP(status, fmt.Sprintf("failed to delete user: %v", err))

--- a/pkg/localauth/users.go
+++ b/pkg/localauth/users.go
@@ -23,6 +23,10 @@ func (p *Provider) Users(ctx context.Context) ([]types.LocalAuthUser, error) {
 	return p.gatewayClient.LocalAuthUsers(ctx)
 }
 
+func (p *Provider) GetUser(ctx context.Context, id uint) (*types.LocalAuthUser, error) {
+	return p.gatewayClient.LocalAuthUserByID(ctx, id)
+}
+
 // CreateUser creates a local user with the given email and plaintext password.
 func (p *Provider) CreateUser(ctx context.Context, email, password string) (*types.LocalAuthUser, error) {
 	parsed, err := mail.ParseAddress(client.NormalizeEmail(email))


### PR DESCRIPTION
This change will cleanup the Obot user when the local auth user is deleted. This allows us to use the same logic to detect the deletion of the last owner or admin. It also makes sense to remove the Obot user when the local auth user is deleted because said user can't login.

Note that removing the Obot user does not remove the local auth user.

Issue: https://github.com/obot-platform/obot/issues/7264