### PR TITLE
fix: stop immediate failed skill repository retries

### DIFF
--- a/pkg/controller/handlers/skillrepository/skillrepository.go
+++ b/pkg/controller/handlers/skillrepository/skillrepository.go
@@ -60,6 +60,11 @@ func (h *Handler) Sync(req router.Request, resp router.Response) error {
 	}
 
 	defer h.clearIsSyncing(req.Ctx, req.Client, namespace, repo.Name)
+	if forceSync {
+		if err := clearSyncAnnotation(req.Ctx, req.Client, namespace, repo.Name); err != nil {
+			return err
+		}
+	}
 
 	token, err := gitcredential.ResolveOrReveal(req.Ctx, req.Client, h.gatewayClient, repo.Namespace, repo.Spec.GitCredentialID, repo.Spec.RepoURL, repo.Name, SkillRepositoryCredentialToolName)
 	if errors.Is(err, gitcredential.ErrLegacyCredential) {
@@ -101,12 +106,6 @@ func (h *Handler) Sync(req router.Request, resp router.Response) error {
 
 	if err := h.recordSuccess(req.Ctx, req.Client, namespace, repo.Name, fetched.CommitSHA, len(skills)); err != nil {
 		return err
-	}
-
-	if forceSync {
-		if err := clearSyncAnnotation(req.Ctx, req.Client, namespace, repo.Name); err != nil {
-			return err
-		}
 	}
 
 	resp.RetryAfter(syncInterval)

--- a/pkg/controller/handlers/skillrepository/skillrepository_test.go
+++ b/pkg/controller/handlers/skillrepository/skillrepository_test.go
@@ -422,6 +422,58 @@ func TestSync(t *testing.T) {
 		assert.Equal(t, syncInterval, resp.Delay)
 	})
 
+	t.Run("failed force sync resumes hourly schedule", func(t *testing.T) {
+		repo := newSkillRepository("repo1", "default")
+		repo.Annotations = map[string]string{
+			v1.SkillRepositorySyncAnnotation: "true",
+		}
+		c := newFakeClient(t, repo)
+
+		fetchCalls := 0
+		h := &Handler{
+			gatewayClient: gatewayClient,
+			fetcher: &mockFetcher{
+				fetchFn: func(_ context.Context, _, _, _ string) (*fetchedRepository, error) {
+					fetchCalls++
+					return nil, fmt.Errorf("bad credentials")
+				},
+			},
+			now: func() time.Time { return fixedTime },
+		}
+
+		resp := &router.ResponseWrapper{}
+		err := h.Sync(router.Request{
+			Client:    c,
+			Object:    repo,
+			Ctx:       t.Context(),
+			Namespace: repo.Namespace,
+			Name:      repo.Name,
+			Key:       repo.Namespace + "/" + repo.Name,
+		}, resp)
+		require.NoError(t, err)
+
+		var updated v1.SkillRepository
+		require.NoError(t, c.Get(t.Context(), kclient.ObjectKey{Namespace: repo.Namespace, Name: repo.Name}, &updated))
+		assert.Equal(t, 1, fetchCalls)
+		assert.Contains(t, updated.Status.SyncError, "bad credentials")
+		assert.False(t, updated.Status.IsSyncing)
+		assert.NotContains(t, updated.Annotations, v1.SkillRepositorySyncAnnotation)
+		assert.Equal(t, syncInterval, resp.Delay)
+
+		resp = &router.ResponseWrapper{}
+		err = h.Sync(router.Request{
+			Client:    c,
+			Object:    &updated,
+			Ctx:       t.Context(),
+			Namespace: updated.Namespace,
+			Name:      updated.Name,
+			Key:       updated.Namespace + "/" + updated.Name,
+		}, resp)
+		require.NoError(t, err)
+		assert.Equal(t, 1, fetchCalls)
+		assert.Equal(t, syncInterval, resp.Delay)
+	})
+
 	t.Run("legacy credential failure falls back to unauthenticated fetch", func(t *testing.T) {
 		repo := newSkillRepository("repo1", "default")
 		c := newFakeClient(t, repo)


### PR DESCRIPTION
## Summary

- consume manual Skill Repository sync requests before starting the sync attempt
- prevent failed sync status updates from triggering immediate repeated fetches
- preserve the normal hourly retry schedule after failures
- add regression coverage for failed forced syncs

## Testing

- `go test ./pkg/controller/handlers/skillrepository -count=1`

Addresses #7270