### PR TITLE
fix: fix code blocks font color in sentry install instructions & copy snippet option

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -258,6 +258,89 @@
 		}
 	}
 
+	.markdown-code-block {
+		position: relative;
+		margin-top: 1.75em;
+		margin-bottom: 1.75em;
+		padding-right: 2rem;
+		background: var(--color-base-200);
+		border-radius: var(--radius-md);
+
+		& > pre {
+			margin-top: 0;
+			margin-bottom: 0;
+			padding-right: 3rem;
+		}
+
+		& > .markdown-copy-btn {
+			position: absolute;
+			top: 0.5rem;
+			right: 0;
+			padding-right: 0.5rem;
+			padding-left: 0.5rem;
+			z-index: 1;
+			color: color-mix(in oklab, var(--color-base-content) 50%, transparent);
+			background: var(--color-base-200);
+
+			.dark & {
+				background: var(--color-base-300);
+			}
+
+			&:hover,
+			&:focus-visible {
+				color: var(--color-base-content);
+			}
+		}
+	}
+
+	.markdown-copy-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: auto;
+		height: auto;
+		padding: 0.3125rem;
+		border: none;
+		border-radius: 0.25rem;
+		cursor: pointer;
+
+		&::before {
+			content: '';
+			display: block;
+			flex-shrink: 0;
+			width: 0.875rem;
+			height: 0.875rem;
+			background-color: currentColor;
+			mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='14' height='14' x='8' y='8' rx='2' ry='2'/%3E%3Cpath d='M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2'/%3E%3C/svg%3E")
+				center / contain no-repeat;
+			-webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='14' height='14' x='8' y='8' rx='2' ry='2'/%3E%3Cpath d='M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2'/%3E%3C/svg%3E")
+				center / contain no-repeat;
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--color-primary);
+			outline-offset: 1px;
+		}
+	}
+
+	.markdown-copy-btn.markdown-copy-btn--copied,
+	.markdown-code-block > .markdown-copy-btn.markdown-copy-btn--copied {
+		color: var(--color-primary);
+		opacity: 1;
+
+		&:hover,
+		&:focus-visible {
+			color: var(--color-primary);
+		}
+
+		&::before {
+			mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E")
+				center / contain no-repeat;
+			-webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M20 6 9 17l-5-5'/%3E%3C/svg%3E")
+				center / contain no-repeat;
+		}
+	}
+
 	.scrollbar-gutter-stable {
 		scrollbar-gutter: stable;
 	}

--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -266,6 +266,10 @@
 		background: var(--color-base-200);
 		border-radius: var(--radius-md);
 
+		.dark & {
+			background: var(--color-base-300);
+		}
+
 		& > pre {
 			margin-top: 0;
 			margin-bottom: 0;

--- a/ui/user/src/lib/actions/codeSnippetCopy.ts
+++ b/ui/user/src/lib/actions/codeSnippetCopy.ts
@@ -1,0 +1,157 @@
+const CODE_BLOCK_CLASS = 'markdown-code-block';
+const COPY_BUTTON_CLASS = 'markdown-copy-btn';
+const COPIED_CLASS = 'markdown-copy-btn--copied';
+
+interface EnhancedCodeBlock {
+	button: HTMLButtonElement;
+	code: HTMLElement;
+	onClick: (event: MouseEvent) => void;
+	resetTimer?: number;
+	wrapper: HTMLDivElement;
+}
+
+function createCopyButton(): HTMLButtonElement {
+	const button = document.createElement('button');
+	button.type = 'button';
+	button.className = COPY_BUTTON_CLASS;
+	button.setAttribute('aria-label', 'Copy code');
+	return button;
+}
+
+function fallbackCopyText(text: string): boolean {
+	const previousActiveElement = document.activeElement;
+	const textArea = document.createElement('textarea');
+	textArea.value = text;
+	textArea.setAttribute('readonly', '');
+	textArea.style.position = 'fixed';
+	textArea.style.left = '-9999px';
+	textArea.style.top = '0';
+	document.body.appendChild(textArea);
+	textArea.focus();
+	textArea.select();
+
+	try {
+		return document.execCommand('copy');
+	} catch {
+		return false;
+	} finally {
+		document.body.removeChild(textArea);
+		(previousActiveElement as HTMLElement | null)?.focus?.();
+	}
+}
+
+async function copyTextToClipboard(text: string): Promise<boolean> {
+	if (navigator.clipboard) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return true;
+		} catch {
+			return fallbackCopyText(text);
+		}
+	}
+	return fallbackCopyText(text);
+}
+
+export function codeSnippetCopy(node: HTMLElement) {
+	const enhancedBlocks = new Set<EnhancedCodeBlock>();
+	const createdWrappers = new WeakSet<HTMLDivElement>();
+
+	function removeBlock(block: EnhancedCodeBlock) {
+		block.button.removeEventListener('click', block.onClick);
+		if (block.resetTimer !== undefined) {
+			window.clearTimeout(block.resetTimer);
+		}
+		enhancedBlocks.delete(block);
+	}
+
+	function markCopied(block: EnhancedCodeBlock) {
+		if (block.resetTimer !== undefined) {
+			window.clearTimeout(block.resetTimer);
+		}
+		block.button.classList.add(COPIED_CLASS);
+		block.button.setAttribute('aria-label', 'Copied!');
+		block.resetTimer = window.setTimeout(() => {
+			block.button.classList.remove(COPIED_CLASS);
+			block.button.setAttribute('aria-label', 'Copy code');
+			block.resetTimer = undefined;
+		}, 750);
+	}
+
+	function enhancePre(pre: HTMLPreElement) {
+		if (
+			(pre.parentElement instanceof HTMLDivElement && createdWrappers.has(pre.parentElement)) ||
+			!node.contains(pre)
+		) {
+			return;
+		}
+
+		const code = pre.querySelector<HTMLElement>('code');
+		if (!code?.textContent) {
+			return;
+		}
+
+		const wrapper = document.createElement('div');
+		const button = createCopyButton();
+		wrapper.className = CODE_BLOCK_CLASS;
+		createdWrappers.add(wrapper);
+
+		const block: EnhancedCodeBlock = {
+			button,
+			code,
+			onClick: (event) => {
+				event.preventDefault();
+				const text = block.code.textContent ?? '';
+				if (!text) {
+					return;
+				}
+				void copyTextToClipboard(text).then((success) => {
+					if (success && node.contains(block.button)) {
+						markCopied(block);
+					}
+				});
+			},
+			wrapper
+		};
+
+		button.addEventListener('click', block.onClick);
+		pre.replaceWith(wrapper);
+		wrapper.append(button, pre);
+		enhancedBlocks.add(block);
+	}
+
+	function enhanceWithin(element: Element) {
+		if (element instanceof HTMLPreElement) {
+			enhancePre(element);
+		}
+		for (const pre of element.querySelectorAll<HTMLPreElement>('pre')) {
+			enhancePre(pre);
+		}
+	}
+
+	enhanceWithin(node);
+
+	const observer = new MutationObserver((mutations) => {
+		for (const block of enhancedBlocks) {
+			if (!node.contains(block.wrapper)) {
+				removeBlock(block);
+			}
+		}
+		for (const mutation of mutations) {
+			for (const addedNode of mutation.addedNodes) {
+				if (addedNode instanceof Element) {
+					enhanceWithin(addedNode);
+				}
+			}
+		}
+	});
+	observer.observe(node, { childList: true, subtree: true });
+
+	return {
+		destroy() {
+			observer.disconnect();
+			for (const block of Array.from(enhancedBlocks)) {
+				removeBlock(block);
+			}
+		}
+	};
+}

--- a/ui/user/src/lib/markdown.ts
+++ b/ui/user/src/lib/markdown.ts
@@ -125,7 +125,15 @@ export function toHTMLFromMarkdownWithNewTabLinks(
 	markdown: string,
 	enableVideoAndIframeProcessing = false
 ): string {
-	return updateLinksWithTargetBlank(toHTMLFromMarkdown(markdown, enableVideoAndIframeProcessing));
+	const withLinks = updateLinksWithTargetBlank(
+		toHTMLFromMarkdown(markdown, enableVideoAndIframeProcessing)
+	);
+
+	if (typeof document === 'undefined') {
+		return withLinks;
+	}
+
+	return withLinks;
 }
 
 export function stripMarkdownToText(markdown: string): string {

--- a/ui/user/src/lib/markdown.ts
+++ b/ui/user/src/lib/markdown.ts
@@ -125,15 +125,7 @@ export function toHTMLFromMarkdownWithNewTabLinks(
 	markdown: string,
 	enableVideoAndIframeProcessing = false
 ): string {
-	const withLinks = updateLinksWithTargetBlank(
-		toHTMLFromMarkdown(markdown, enableVideoAndIframeProcessing)
-	);
-
-	if (typeof document === 'undefined') {
-		return withLinks;
-	}
-
-	return withLinks;
+	return updateLinksWithTargetBlank(toHTMLFromMarkdown(markdown, enableVideoAndIframeProcessing));
 }
 
 export function stripMarkdownToText(markdown: string): string {

--- a/ui/user/src/routes/admin/devices/EnrollmentConfigDownload.svelte
+++ b/ui/user/src/routes/admin/devices/EnrollmentConfigDownload.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { codeSnippetCopy } from '$lib/actions/codeSnippetCopy';
 	import { tooltip } from '$lib/actions/tooltip.svelte';
 	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import { saveBlob } from '$lib/download';
@@ -562,7 +563,7 @@
 					<div class="collapse-content px-0">
 						<div class="pl-9">
 							{#if selectedArtifact?.instructions}
-								<div class="instructions milkdown-content">
+								<div class="instructions milkdown-content" use:codeSnippetCopy>
 									<!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized by toHTMLFromMarkdownWithNewTabLinks -->
 									{@html toHTMLFromMarkdownWithNewTabLinks(selectedArtifact.instructions)}
 								</div>
@@ -688,5 +689,12 @@
 	}
 	:global(.dark) .instructions :global(pre) {
 		background-color: var(--color-base-300);
+	}
+	@layer base {
+		.instructions :global(pre),
+		.instructions :global(pre code),
+		.instructions :global(pre code *) {
+			color: var(--color-base-content) !important;
+		}
 	}
 </style>

--- a/ui/user/src/routes/admin/devices/EnrollmentConfigDownload.svelte
+++ b/ui/user/src/routes/admin/devices/EnrollmentConfigDownload.svelte
@@ -659,6 +659,7 @@
 	   article-scale milkdown typography is stepped down to match. */
 	.instructions {
 		font-size: 0.875rem;
+		--tw-prose-pre-code: var(--color-base-content);
 	}
 	.instructions :global(p),
 	.instructions :global(li),
@@ -689,12 +690,5 @@
 	}
 	:global(.dark) .instructions :global(pre) {
 		background-color: var(--color-base-300);
-	}
-	@layer base {
-		.instructions :global(pre),
-		.instructions :global(pre code),
-		.instructions :global(pre code *) {
-			color: var(--color-base-content) !important;
-		}
 	}
 </style>


### PR DESCRIPTION
This addresses the font color being unreadable for the sentry instructions as well as adds an option to include a copy button on code snippets (```) during markdown processing.

dark:
<img width="1266" height="686" alt="Screenshot 2026-07-23 at 3 04 58 PM" src="https://github.com/user-attachments/assets/b4273423-1d32-4fb6-b642-d2354378ee1b" />

light:
<img width="1273" height="598" alt="Screenshot 2026-07-23 at 3 04 51 PM" src="https://github.com/user-attachments/assets/f45b6f42-4a38-4484-8003-b15e96335775" />

Addresses #7274 
