### PR TITLE
fix: make the license provider more HA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ thoughts/
 thoughts
 
 .opencode/
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/

--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -47,7 +47,12 @@ func (ap *AuthProviderHandler) ByID(req api.Context) error {
 		return err
 	}
 
-	resp, err := ap.convertAuthProvider(authProvider)
+	authProviderStatus, err := providers.AuthProviderStatus(req.Context(), authProvider, nil, ap.license)
+	if err != nil {
+		return err
+	}
+
+	resp, err := ap.convertAuthProvider(authProvider, *authProviderStatus)
 	if err != nil {
 		return err
 	}
@@ -65,7 +70,12 @@ func (ap *AuthProviderHandler) List(req api.Context) error {
 
 	resp := make([]types.AuthProvider, 0, len(authProviders.Items))
 	for _, a := range authProviders.Items {
-		authProvider, err := ap.convertAuthProvider(a)
+		authProviderStatus, err := providers.AuthProviderStatus(req.Context(), a, nil, ap.license)
+		if err != nil {
+			return err
+		}
+
+		authProvider, err := ap.convertAuthProvider(a, *authProviderStatus)
 		if err != nil {
 			log.Warnf("failed to convert auth provider %q: %v", a.Name, err)
 			continue
@@ -82,7 +92,7 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 		return err
 	}
 
-	if err := ap.license.RequireEntitlements(authProvider.Spec.RequiredEntitlements); err != nil {
+	if err := ap.license.RequireEntitlements(req.Context(), authProvider.Spec.RequiredEntitlements); err != nil {
 		return err
 	}
 
@@ -256,16 +266,11 @@ func (ap *AuthProviderHandler) Reveal(req api.Context) error {
 	return types.NewErrNotFound("no credential found for %q", authProvider.Name)
 }
 
-func (ap *AuthProviderHandler) convertAuthProvider(authProvider v1.AuthProvider) (types.AuthProvider, error) {
-	authProviderStatus, err := providers.AuthProviderStatus(authProvider, nil, ap.license)
-	if err != nil {
-		return types.AuthProvider{}, fmt.Errorf("failed to get auth provider status: %w", err)
-	}
-
+func (ap *AuthProviderHandler) convertAuthProvider(authProvider v1.AuthProvider, authProviderStatus types.AuthProviderStatus) (types.AuthProvider, error) {
 	return types.AuthProvider{
 		Metadata:             MetadataFrom(&authProvider),
 		AuthProviderManifest: authProvider.Spec.AuthProviderManifest,
-		AuthProviderStatus:   *authProviderStatus,
+		AuthProviderStatus:   authProviderStatus,
 	}, nil
 }
 

--- a/pkg/api/handlers/availablemodels.go
+++ b/pkg/api/handlers/availablemodels.go
@@ -36,13 +36,11 @@ func (a *AvailableModelsHandler) List(req api.Context) error {
 
 	var oModels openai.ModelsList
 	for _, modelProvider := range modelProviders.Items {
-		convertedModelProvider, err := providers.ModelProviderStatus(modelProvider, nil, a.licenseProvider)
+		mps, err := providers.ModelProviderStatus(req.Context(), modelProvider, nil, a.licenseProvider)
 		if err != nil {
-			log.Warnf("failed to convert model provider %q: %v", modelProvider.Name, err)
-			continue
+			return err
 		}
-
-		if !convertedModelProvider.Configured {
+		if !mps.Configured {
 			continue
 		}
 

--- a/pkg/api/handlers/license.go
+++ b/pkg/api/handlers/license.go
@@ -43,7 +43,11 @@ func NewLicenseHandler(licenseProvider *license.Provider) *LicenseHandler {
 }
 
 func (h *LicenseHandler) Get(req api.Context) error {
-	return req.Write(h.status(req))
+	status, err := h.status(req)
+	if err != nil {
+		return err
+	}
+	return req.Write(status)
 }
 
 func (h *LicenseHandler) Update(req api.Context) error {
@@ -66,7 +70,11 @@ func (h *LicenseHandler) Update(req api.Context) error {
 		return err
 	}
 
-	return req.Write(h.status(req))
+	status, err := h.status(req)
+	if err != nil {
+		return err
+	}
+	return req.Write(status)
 }
 
 func (h *LicenseHandler) CheckLicense(req api.Context) error {
@@ -81,7 +89,11 @@ func (h *LicenseHandler) CheckLicense(req api.Context) error {
 		return err
 	}
 
-	return req.Write(h.status(req))
+	status, err := h.status(req)
+	if err != nil {
+		return err
+	}
+	return req.Write(status)
 }
 
 // reserveManualLicenseCheck reserves a manual license check, returning the time at which it can be checked again and whether the reservation was successful.
@@ -118,16 +130,31 @@ func (h *LicenseHandler) Delete(req api.Context) error {
 		return err
 	}
 
-	return req.Write(h.status(req))
+	status, err := h.status(req)
+	if err != nil {
+		return err
+	}
+	return req.Write(status)
 }
 
-func (h *LicenseHandler) status(req api.Context) LicenseStatus {
-	licenseKey := h.licenseProvider.LicenseKey()
+func (h *LicenseHandler) status(req api.Context) (LicenseStatus, error) {
+	licenseKey, err := h.licenseProvider.LicenseKey(req.Context())
+	if err != nil {
+		return LicenseStatus{}, err
+	}
+	enterprise, err := h.licenseProvider.HasValidLicense(req.Context())
+	if err != nil {
+		return LicenseStatus{}, err
+	}
+	entitlements, err := h.licenseProvider.Entitlements(req.Context())
+	if err != nil {
+		return LicenseStatus{}, err
+	}
 	status := LicenseStatus{
 		LicenseKey:             displayLicenseKey(licenseKey, req.UserIsAdmin()),
 		Locked:                 h.licenseProvider.LicenseKeyViaConfiguration(),
-		Enterprise:             h.licenseProvider.HasValidLicense(),
-		Entitlements:           h.licenseProvider.Entitlements(),
+		Enterprise:             enterprise,
+		Entitlements:           entitlements,
 		ManualCheckAvailableAt: h.manualLicenseCheckAvailableAt(),
 	}
 
@@ -137,7 +164,7 @@ func (h *LicenseHandler) status(req api.Context) LicenseStatus {
 		status.Source = "database"
 	}
 
-	return status
+	return status, nil
 }
 
 func (h *LicenseHandler) manualLicenseCheckAvailableAt() *time.Time {

--- a/pkg/api/handlers/modelprovider.go
+++ b/pkg/api/handlers/modelprovider.go
@@ -37,7 +37,12 @@ func (mp *ModelProviderHandler) ByID(req api.Context) error {
 		return err
 	}
 
-	resp, err := mp.convertModelProvider(modelProvider)
+	mps, err := providers.ModelProviderStatus(req.Context(), modelProvider, nil, mp.license)
+	if err != nil {
+		return err
+	}
+
+	resp, err := mp.convertModelProvider(modelProvider, *mps)
 	if err != nil {
 		return err
 	}
@@ -54,13 +59,18 @@ func (mp *ModelProviderHandler) List(req api.Context) error {
 	}
 
 	resp := make([]types.ModelProvider, 0, len(modelProviders.Items))
-	for _, ref := range modelProviders.Items {
-		modelProvider, err := mp.convertModelProvider(ref)
+	for _, modelProvider := range modelProviders.Items {
+		mps, err := providers.ModelProviderStatus(req.Context(), modelProvider, nil, mp.license)
 		if err != nil {
-			log.Errorf("failed to convert model provider %q: %v", ref.Name, err)
+			return err
+		}
+
+		modelProviderResp, err := mp.convertModelProvider(modelProvider, *mps)
+		if err != nil {
+			log.Errorf("failed to convert model provider %q: %v", modelProvider.Name, err)
 			continue
 		}
-		resp = append(resp, modelProvider)
+		resp = append(resp, modelProviderResp)
 	}
 
 	return req.Write(types.ModelProviderList{Items: resp})
@@ -72,7 +82,7 @@ func (mp *ModelProviderHandler) Validate(req api.Context) error {
 		return err
 	}
 
-	if err := mp.license.RequireEntitlements(modelProvider.Spec.RequiredEntitlements); err != nil {
+	if err := mp.license.RequireEntitlements(req.Context(), modelProvider.Spec.RequiredEntitlements); err != nil {
 		return err
 	}
 
@@ -96,7 +106,7 @@ func (mp *ModelProviderHandler) Configure(req api.Context) error {
 		return err
 	}
 
-	if err := mp.license.RequireEntitlements(modelProvider.Spec.RequiredEntitlements); err != nil {
+	if err := mp.license.RequireEntitlements(req.Context(), modelProvider.Spec.RequiredEntitlements); err != nil {
 		return err
 	}
 
@@ -209,7 +219,12 @@ func (mp *ModelProviderHandler) RefreshModels(req api.Context) error {
 		return err
 	}
 
-	resp, err := mp.convertModelProvider(modelProvider)
+	mps, err := providers.ModelProviderStatus(req.Context(), modelProvider, nil, mp.license)
+	if err != nil {
+		return err
+	}
+
+	resp, err := mp.convertModelProvider(modelProvider, *mps)
 	if err != nil {
 		return err
 	}
@@ -233,15 +248,10 @@ func (mp *ModelProviderHandler) RefreshModels(req api.Context) error {
 	return req.Write(resp)
 }
 
-func (mp *ModelProviderHandler) convertModelProvider(modelProvider v1.ModelProvider) (types.ModelProvider, error) {
-	mps, err := providers.ModelProviderStatus(modelProvider, nil, mp.license)
-	if err != nil {
-		return types.ModelProvider{}, err
-	}
-
+func (mp *ModelProviderHandler) convertModelProvider(modelProvider v1.ModelProvider, modelProviderStatus types.ModelProviderStatus) (types.ModelProvider, error) {
 	return types.ModelProvider{
 		Metadata:              MetadataFrom(&modelProvider),
 		ModelProviderManifest: modelProvider.Spec.ModelProviderManifest,
-		ModelProviderStatus:   *mps,
+		ModelProviderStatus:   modelProviderStatus,
 	}, nil
 }

--- a/pkg/api/handlers/providers/authproviders.go
+++ b/pkg/api/handlers/providers/authproviders.go
@@ -1,12 +1,14 @@
 package providers
 
 import (
+	"context"
+
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/license"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 )
 
-func AuthProviderStatus(authProvider v1.AuthProvider, cred map[string]string, licenseProvider *license.Provider) (*types.AuthProviderStatus, error) {
+func AuthProviderStatus(ctx context.Context, authProvider v1.AuthProvider, cred map[string]string, licenseProvider *license.Provider) (*types.AuthProviderStatus, error) {
 	var missingEnvVars []string
 
 	if cred != nil {
@@ -24,10 +26,15 @@ func AuthProviderStatus(authProvider v1.AuthProvider, cred map[string]string, li
 		}
 	}
 
+	missingEntitlements, err := licenseProvider.MissingEntitlements(ctx, authProvider.Spec.RequiredEntitlements)
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.AuthProviderStatus{
 		CommonProviderStatus: types.CommonProviderStatus{
 			Configured:                     len(missingEnvVars) == 0,
-			MissingEntitlements:            licenseProvider.MissingEntitlements(authProvider.Spec.RequiredEntitlements),
+			MissingEntitlements:            missingEntitlements,
 			MissingConfigurationParameters: missingEnvVars,
 		},
 		Namespace: authProvider.Namespace,

--- a/pkg/api/handlers/providers/modelproviders.go
+++ b/pkg/api/handlers/providers/modelproviders.go
@@ -1,12 +1,14 @@
 package providers
 
 import (
+	"context"
+
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/license"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 )
 
-func ModelProviderStatus(modelProvider v1.ModelProvider, cred map[string]string, licenseProvider *license.Provider) (*types.ModelProviderStatus, error) {
+func ModelProviderStatus(ctx context.Context, modelProvider v1.ModelProvider, cred map[string]string, licenseProvider *license.Provider) (*types.ModelProviderStatus, error) {
 	var (
 		modelsPopulated *bool
 		missingEnvVars  []string
@@ -31,10 +33,15 @@ func ModelProviderStatus(modelProvider v1.ModelProvider, cred map[string]string,
 		modelsPopulated = new(modelProvider.Status.ObservedGeneration == modelProvider.Generation)
 	}
 
+	missingEntitlements, err := licenseProvider.MissingEntitlements(ctx, modelProvider.Spec.RequiredEntitlements)
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.ModelProviderStatus{
 		CommonProviderStatus: types.CommonProviderStatus{
 			Configured:                     len(missingEnvVars) == 0,
-			MissingEntitlements:            licenseProvider.MissingEntitlements(modelProvider.Spec.RequiredEntitlements),
+			MissingEntitlements:            missingEntitlements,
 			MissingConfigurationParameters: missingEnvVars,
 		},
 		ModelsBackPopulated: modelsPopulated,

--- a/pkg/api/handlers/providers/providers_test.go
+++ b/pkg/api/handlers/providers/providers_test.go
@@ -86,7 +86,7 @@ func TestAuthProviderStatus(t *testing.T) {
 	licenseProvider := testLicenseProvider(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := AuthProviderStatus(tt.authProvider, tt.cred, licenseProvider)
+			got, err := AuthProviderStatus(t.Context(), tt.authProvider, tt.cred, licenseProvider)
 			if err != nil {
 				t.Fatalf("AuthProviderStatus() error = %v", err)
 			}
@@ -207,7 +207,7 @@ func TestModelProviderStatus(t *testing.T) {
 	licenseProvider := testLicenseProvider(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ModelProviderStatus(tt.modelProvider, tt.cred, licenseProvider)
+			got, err := ModelProviderStatus(t.Context(), tt.modelProvider, tt.cred, licenseProvider)
 			if err != nil {
 				t.Fatalf("ModelProviderStatus() error = %v", err)
 			}

--- a/pkg/api/handlers/version.go
+++ b/pkg/api/handlers/version.go
@@ -125,14 +125,23 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 	latestVersion := v.latestVersion
 	v.upgradeLock.RUnlock()
 
+	hasValidLicense, err := v.LicenseProvider.HasValidLicense(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entitlements, err := v.LicenseProvider.Entitlements(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	values := map[string]any{
 		"upgradeAvailable":             upgradeAvailable,
 		"latestVersion":                latestVersion,
 		"obot":                         version.Get().String(),
 		"authEnabled":                  v.AuthEnabled,
 		"sessionStore":                 v.sessionStore,
-		"enterprise":                   v.LicenseProvider.HasValidLicense(),
-		"licenseEntitlements":          v.LicenseProvider.Entitlements(),
+		"enterprise":                   hasValidLicense,
+		"licenseEntitlements":          entitlements,
 		"engine":                       engine,
 		"mcpNetworkPolicyEnabled":      v.MCPNetworkPolicyEnabled,
 		"mcpDefaultDenyAllEgress":      v.MCPDefaultDenyAllEgress,
@@ -178,7 +187,10 @@ func (v *VersionHandler) startUpgradeCheck(ctx context.Context, installationID, 
 	var err error
 	for {
 		distribution := "oss"
-		if v.LicenseProvider.HasValidLicense() {
+		hasValidLicense, licenseErr := v.LicenseProvider.HasValidLicense(ctx)
+		if licenseErr != nil {
+			log.Debugf("failed to refresh license state for upgrade check: %v", licenseErr)
+		} else if hasValidLicense {
 			distribution = "enterprise"
 		}
 		if err = v.checkForUpgrade(ctx, installationID, currentVersion, engine, distribution); err != nil {

--- a/pkg/controller/handlers/provider/provider.go
+++ b/pkg/controller/handlers/provider/provider.go
@@ -411,7 +411,7 @@ func SetAuthProviderConfiguredStatus(ctx context.Context, gatewayClient *gateway
 			cred.Secrets = make(map[string]string)
 		}
 
-		providerStatus, err := providers.AuthProviderStatus(*authProvider, cred.Secrets, licenseProvider)
+		providerStatus, err := providers.AuthProviderStatus(ctx, *authProvider, cred.Secrets, licenseProvider)
 		if err != nil {
 			return err
 		}
@@ -447,7 +447,7 @@ func SetModelProviderConfiguredStatus(ctx context.Context, gatewayClient *gatewa
 			cred.Secrets = make(map[string]string)
 		}
 
-		providerStatus, err := providers.ModelProviderStatus(*modelProvider, cred.Secrets, licenseProvider)
+		providerStatus, err := providers.ModelProviderStatus(ctx, *modelProvider, cred.Secrets, licenseProvider)
 		if err != nil {
 			return err
 		}

--- a/pkg/license/entitlements.go
+++ b/pkg/license/entitlements.go
@@ -83,8 +83,16 @@ func (g *ProviderEntitlementGate) requiresProviderEntitlements(req *http.Request
 	return pattern != ""
 }
 
-// Missing returns the required entitlements that are unavailable from the current license.
-func (p *Provider) MissingEntitlements(requiredEntitlements []string) []string {
+// MissingEntitlements returns the required entitlements that are unavailable
+// from the current database/config license key.
+func (p *Provider) MissingEntitlements(ctx context.Context, requiredEntitlements []string) ([]string, error) {
+	if err := p.refresh(ctx, false); err != nil {
+		return nil, err
+	}
+	return p.missingEntitlements(requiredEntitlements), nil
+}
+
+func (p *Provider) missingEntitlements(requiredEntitlements []string) []string {
 	var missing []string
 	for _, entitlement := range requiredEntitlements {
 		if !p.hasEntitlement(entitlement) {
@@ -94,9 +102,12 @@ func (p *Provider) MissingEntitlements(requiredEntitlements []string) []string {
 	return missing
 }
 
-// Require returns Payment Required if any required entitlements are unavailable.
-func (p *Provider) RequireEntitlements(requiredEntitlements []string) error {
-	missing := p.MissingEntitlements(requiredEntitlements)
+// RequireEntitlements returns Payment Required if any required entitlements are unavailable.
+func (p *Provider) RequireEntitlements(ctx context.Context, requiredEntitlements []string) error {
+	missing, err := p.MissingEntitlements(ctx, requiredEntitlements)
+	if err != nil {
+		return fmt.Errorf("failed to refresh license entitlements: %w", err)
+	}
 	if len(missing) == 0 {
 		return nil
 	}
@@ -106,6 +117,10 @@ func (p *Provider) RequireEntitlements(requiredEntitlements []string) error {
 // ConfiguredProviderViolations returns any globally configured auth/model providers
 // that are currently missing required license entitlements.
 func (p *Provider) ConfiguredProviderViolations(ctx context.Context, c kclient.Client) ([]ProviderViolation, error) {
+	if err := p.refresh(ctx, false); err != nil {
+		return nil, fmt.Errorf("failed to refresh license entitlements: %w", err)
+	}
+
 	modelProviderViolations, err := p.configuredModelProviderViolations(ctx, c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check model provider license entitlements: %w", err)
@@ -130,7 +145,7 @@ func (p *Provider) configuredModelProviderViolations(ctx context.Context, c kcli
 	var violations []ProviderViolation
 	for _, mp := range modelProviders.Items {
 		if mp.Status.Configured {
-			missingEntitlements := p.MissingEntitlements(mp.Spec.RequiredEntitlements)
+			missingEntitlements := p.missingEntitlements(mp.Spec.RequiredEntitlements)
 			if len(missingEntitlements) > 0 {
 				violations = append(violations, ProviderViolation{
 					Type:                 "modelProvider",
@@ -157,7 +172,7 @@ func (p *Provider) configuredAuthProviderViolations(ctx context.Context, c kclie
 	var violations []ProviderViolation
 	for _, ap := range authProviders.Items {
 		if ap.Status.Configured {
-			missingEntitlements := p.MissingEntitlements(ap.Spec.RequiredEntitlements)
+			missingEntitlements := p.missingEntitlements(ap.Spec.RequiredEntitlements)
 			if len(missingEntitlements) > 0 {
 				violations = append(violations, ProviderViolation{
 					Type:                 "authProvider",

--- a/pkg/license/entitlements_test.go
+++ b/pkg/license/entitlements_test.go
@@ -16,16 +16,19 @@ func TestMissingAndRequire(t *testing.T) {
 		},
 	}
 
-	missing := provider.MissingEntitlements([]string{"ENTITLED", "MISSING"})
+	missing, err := provider.MissingEntitlements(t.Context(), []string{"ENTITLED", "MISSING"})
+	if err != nil {
+		t.Fatalf("Missing() error = %v, want nil", err)
+	}
 	if len(missing) != 1 || missing[0] != "MISSING" {
 		t.Fatalf("Missing() = %v, want [MISSING]", missing)
 	}
 
-	if err := provider.RequireEntitlements([]string{"ENTITLED"}); err != nil {
+	if err := provider.RequireEntitlements(t.Context(), []string{"ENTITLED"}); err != nil {
 		t.Fatalf("Require() error = %v, want nil", err)
 	}
 
-	err := provider.RequireEntitlements([]string{"MISSING"})
+	err = provider.RequireEntitlements(t.Context(), []string{"MISSING"})
 	var httpErr *types.ErrHTTP
 	if !errors.As(err, &httpErr) {
 		t.Fatalf("Require() error = %T, want *types.ErrHTTP", err)

--- a/pkg/license/provider.go
+++ b/pkg/license/provider.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"os"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -32,6 +35,9 @@ const (
 	defaultPollInterval = 24 * time.Hour
 	keygenProduct       = "18a762f2-5281-45cf-93fc-e45e2d932094"
 	keygenAccount       = "7565373b-6069-4a0b-9495-9777d9db3fd9"
+	keygenAPIURL        = "https://api.keygen.sh"
+	keygenAPIPrefix     = "v1"
+	keygenAPIVersion    = "1.8"
 )
 
 var (
@@ -53,46 +59,52 @@ type Config struct {
 }
 
 type Provider struct {
-	lock                       sync.RWMutex
-	entitlements               map[keygen.EntitlementCode]struct{}
-	machineFingerprint         string
-	gatewayClient              *client.Client
-	licenseKeyViaConfiguration bool
+	lock                 sync.RWMutex
+	refreshLock          sync.Mutex
+	entitlements         map[keygen.EntitlementCode]struct{}
+	licenseKeySnapshot   licenseKeySnapshot
+	machineFingerprint   string
+	gatewayClient        *client.Client
+	configuredLicenseKey string
+	keygenAPIURL         string
+}
+
+type licenseKeySnapshot struct {
+	key              string
+	updatedAt        time.Time
+	viaConfiguration bool
+}
+
+func (s licenseKeySnapshot) equal(other licenseKeySnapshot) bool {
+	return s.key == other.key &&
+		s.viaConfiguration == other.viaConfiguration &&
+		s.updatedAt.Equal(other.updatedAt)
 }
 
 // NewProvider creates a Keygen-backed license provider.
 func NewProvider(ctx context.Context, gatewayClient *client.Client, config Config) (*Provider, error) {
-	keygen.Account = keygenAccount
-	keygen.Product = keygenProduct
+	return newProvider(ctx, gatewayClient, config, keygenAPIURL)
+}
 
+func newProvider(ctx context.Context, gatewayClient *client.Client, config Config, apiURL string) (*Provider, error) {
 	machineFingerprint, err := ensureMachineFingerprint(ctx, gatewayClient)
 	if err != nil {
 		return nil, err
 	}
 
-	k := &Provider{
-		machineFingerprint: machineFingerprint,
-		gatewayClient:      gatewayClient,
+	if apiURL == "" {
+		apiURL = keygenAPIURL
 	}
 
-	if licenseKey := strings.TrimSpace(config.LicenseKey); licenseKey != "" {
-		if err := k.setLicenseKey(ctx, licenseKey, true, true); err != nil {
-			return nil, err
-		}
-	} else if gatewayClient != nil {
-		property, err := gatewayClient.GetProperty(ctx, LicenseKeyPropertyKey)
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("failed to get license key property: %w", err)
-		}
-		if err == nil {
-			if err := k.setLicenseKey(ctx, property.Value, false, true); err != nil {
-				return nil, err
-			}
-		} else {
-			log.Infof("license provider is not configured, license key is empty")
-		}
-	} else {
-		log.Infof("license provider is not configured, license key is empty")
+	k := &Provider{
+		machineFingerprint:   machineFingerprint,
+		gatewayClient:        gatewayClient,
+		configuredLicenseKey: strings.TrimSpace(config.LicenseKey),
+		keygenAPIURL:         apiURL,
+	}
+
+	if err := k.refresh(ctx, true); err != nil {
+		log.Warnf("initial license refresh failed: %v", err)
 	}
 
 	if k.entitlements != nil {
@@ -116,119 +128,196 @@ func ensureMachineFingerprint(ctx context.Context, gatewayClient *client.Client)
 	return property.Value, nil
 }
 
-func (p *Provider) LicenseKey() string {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-
-	return keygen.LicenseKey
+func (p *Provider) LicenseKey(ctx context.Context) (string, error) {
+	snapshot, err := p.loadLicenseKey(ctx)
+	if err != nil {
+		return "", err
+	}
+	return snapshot.key, nil
 }
 
 func (p *Provider) LicenseKeyViaConfiguration() bool {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+	return p.configuredLicenseKey != ""
+}
 
-	return p.licenseKeyViaConfiguration
+func (p *Provider) loadLicenseKey(ctx context.Context) (licenseKeySnapshot, error) {
+	if p.configuredLicenseKey != "" {
+		return licenseKeySnapshot{
+			key:              p.configuredLicenseKey,
+			viaConfiguration: true,
+		}, nil
+	}
+	if p.gatewayClient == nil {
+		return licenseKeySnapshot{}, nil
+	}
+
+	property, err := p.gatewayClient.GetProperty(ctx, LicenseKeyPropertyKey)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return licenseKeySnapshot{}, nil
+	}
+	if err != nil {
+		return licenseKeySnapshot{}, fmt.Errorf("failed to get license key property: %w", err)
+	}
+
+	return licenseKeySnapshot{
+		key:       strings.TrimSpace(property.Value),
+		updatedAt: property.UpdatedAt,
+	}, nil
 }
 
 func (p *Provider) SetLicenseKey(ctx context.Context, licenseKey string) error {
 	if p.LicenseKeyViaConfiguration() {
 		return ErrLicenseKeyViaConfiguration
 	}
-	return p.setLicenseKey(ctx, licenseKey, false, false)
-}
-
-func (p *Provider) Validate(ctx context.Context) error {
-	return p.update(ctx)
-}
-
-func (p *Provider) setLicenseKey(ctx context.Context, licenseKey string, viaConfiguration, allowInvalid bool) error {
 	licenseKey = strings.TrimSpace(licenseKey)
 
-	p.lock.Lock()
-	previousLicenseKey := keygen.LicenseKey
-	previousViaConfiguration := p.licenseKeyViaConfiguration
-	previousEntitlements := p.entitlements
-
-	keygen.LicenseKey = licenseKey
-	p.licenseKeyViaConfiguration = viaConfiguration
-	p.lock.Unlock()
-
-	entitlements, err := p.validate(ctx)
-	if err != nil && !errors.Is(err, ErrNotConfigured) {
-		p.restoreLicenseState(previousLicenseKey, previousViaConfiguration, previousEntitlements)
+	entitlements, err := p.validate(ctx, licenseKey)
+	if err != nil {
 		return err
 	}
-	if entitlements == nil && !allowInvalid {
-		p.restoreLicenseState(previousLicenseKey, previousViaConfiguration, previousEntitlements)
+	if entitlements == nil {
 		return ErrInvalidLicense
 	}
 
-	if !viaConfiguration && entitlements != nil && p.gatewayClient != nil {
-		if _, err := p.gatewayClient.SetProperty(ctx, LicenseKeyPropertyKey, licenseKey); err != nil {
-			p.restoreLicenseState(previousLicenseKey, previousViaConfiguration, previousEntitlements)
-			return err
-		}
+	if p.gatewayClient == nil {
+		return fmt.Errorf("failed to persist license key: gateway client is not configured")
 	}
 
-	p.lock.Lock()
-	p.entitlements = entitlements
-	p.lock.Unlock()
+	// Serialize the persisted value and its cached representation with refresh.
+	// Otherwise, an in-flight refresh of the previous key could overwrite this
+	// state after the new key has been committed.
+	p.refreshLock.Lock()
+	defer p.refreshLock.Unlock()
 
+	property, err := p.gatewayClient.SetProperty(ctx, LicenseKeyPropertyKey, licenseKey)
+	if err != nil {
+		return err
+	}
+	p.setCachedState(licenseKeySnapshot{
+		key:       licenseKey,
+		updatedAt: property.UpdatedAt,
+	}, entitlements)
 	return nil
 }
 
-func (p *Provider) restoreLicenseState(licenseKey string, viaConfiguration bool, entitlements map[keygen.EntitlementCode]struct{}) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	keygen.LicenseKey = licenseKey
-	p.licenseKeyViaConfiguration = viaConfiguration
-	p.entitlements = entitlements
+func (p *Provider) Validate(ctx context.Context) error {
+	return p.refresh(ctx, true)
 }
 
 func (p *Provider) RemoveLicenseKey(ctx context.Context) error {
 	if p.LicenseKeyViaConfiguration() {
 		return ErrLicenseKeyViaConfiguration
 	}
+
+	// Keep deletion and cache invalidation ordered with refresh so an in-flight
+	// validation cannot restore the state for the removed key.
+	p.refreshLock.Lock()
+	defer p.refreshLock.Unlock()
+
 	if p.gatewayClient != nil {
 		if err := p.gatewayClient.DeleteProperty(ctx, LicenseKeyPropertyKey); err != nil {
 			return err
 		}
 	}
 
-	p.lock.Lock()
-	keygen.LicenseKey = ""
-	p.lock.Unlock()
-
-	return p.update(ctx)
+	p.setCachedState(licenseKeySnapshot{}, nil)
+	return nil
 }
 
-func (p *Provider) validate(ctx context.Context) (map[keygen.EntitlementCode]struct{}, error) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
+func (p *Provider) keygenClient(licenseKey string) *keygen.Client {
+	keygenClient := keygen.NewClientWithOptions(&keygen.ClientOptions{
+		Account:    keygenAccount,
+		LicenseKey: licenseKey,
+		APIVersion: keygenAPIVersion,
+		APIPrefix:  keygenAPIPrefix,
+		APIURL:     p.keygenAPIURL,
+	})
+	// Avoid Keygen's package-level HTTP client. The transport remains shared and
+	// safe for concurrent use, while redirect policy is scoped to this client.
+	keygenClient.HTTPClient = &http.Client{Transport: http.DefaultTransport}
+	return keygenClient
+}
 
-	if err := validateConfig(); err != nil {
-		return nil, err
+type validationRequest struct {
+	fingerprint string
+}
+
+func (v validationRequest) GetMeta() any {
+	return struct {
+		Scope struct {
+			Fingerprint string `json:"fingerprint,omitempty"`
+			Product     string `json:"product"`
+		} `json:"scope"`
+	}{
+		Scope: struct {
+			Fingerprint string `json:"fingerprint,omitempty"`
+			Product     string `json:"product"`
+		}{
+			Fingerprint: v.fingerprint,
+			Product:     keygenProduct,
+		},
+	}
+}
+
+type keygenValidationResponse struct {
+	License keygen.License
+	Result  keygen.ValidationResult
+}
+
+func (v *keygenValidationResponse) SetData(to func(target any) error) error {
+	return to(&v.License)
+}
+
+func (v *keygenValidationResponse) SetMeta(to func(target any) error) error {
+	return to(&v.Result)
+}
+
+func (p *Provider) validate(ctx context.Context, licenseKey string) (map[keygen.EntitlementCode]struct{}, error) {
+	if strings.TrimSpace(licenseKey) == "" {
+		return nil, ErrNotConfigured
 	}
 
-	lic, err := keygen.Validate(ctx, p.machineFingerprint)
+	keygenClient := p.keygenClient(licenseKey)
+	lic := &keygen.License{}
+	if _, err := keygenClient.Get(ctx, "me", nil, lic); err != nil {
+		log.Warnf("license lookup failed: %v", err)
+		return nil, nil
+	}
+
+	validation, err := p.validateLicense(ctx, keygenClient, lic)
 	if err != nil {
-		if lic != nil && lic.LastValidation != nil && errors.Is(err, keygen.ErrLicenseNotActivated) {
-			if _, activationErr := lic.Activate(ctx, p.machineFingerprint); activationErr != nil && !errors.Is(activationErr, keygen.ErrMachineAlreadyActivated) {
+		return nil, err
+	}
+	if !validation.Result.Valid {
+		if validation.Result.Code == keygen.ValidationCodeFingerprintScopeMismatch ||
+			validation.Result.Code == keygen.ValidationCodeNoMachines ||
+			validation.Result.Code == keygen.ValidationCodeNoMachine {
+			machine := &keygen.Machine{
+				Fingerprint: p.machineFingerprint,
+				LicenseID:   lic.ID,
+			}
+			machine.Hostname, _ = os.Hostname()
+			machine.Platform = runtime.GOOS + "/" + runtime.GOARCH
+			machine.Cores = runtime.NumCPU()
+			if _, activationErr := keygenClient.Post(ctx, "machines", machine, &keygen.Machine{}); activationErr != nil &&
+				!errors.Is(activationErr, keygen.ErrMachineAlreadyActivated) {
 				log.Warnf("license activation failed: %v", activationErr)
 				return nil, nil
 			}
 
-			lic, err = keygen.Validate(ctx, p.machineFingerprint)
-		}
-		if err != nil {
-			log.Warnf("license validation failed: %v", err)
-			return nil, nil
+			validation, err = p.validateLicense(ctx, keygenClient, lic)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
+	if !validation.Result.Valid {
+		log.Warnf("license validation failed: code=%s detail=%s", validation.Result.Code, validation.Result.Detail)
+		return nil, nil
+	}
 
-	entitlements, err := lic.Entitlements(ctx)
-	if err != nil {
+	entitlements := keygen.Entitlements{}
+	if _, err := keygenClient.Get(ctx, fmt.Sprintf("licenses/%s/entitlements?limit=100", lic.ID), nil, &entitlements); err != nil {
 		return nil, fmt.Errorf("list license entitlements: %w", err)
 	}
 
@@ -240,19 +329,36 @@ func (p *Provider) validate(ctx context.Context) (map[keygen.EntitlementCode]str
 	return entitlementSet, nil
 }
 
-func (p *Provider) HasValidLicense() bool {
+func (p *Provider) validateLicense(ctx context.Context, keygenClient *keygen.Client, lic *keygen.License) (*keygenValidationResponse, error) {
+	validation := &keygenValidationResponse{}
+	if _, err := keygenClient.Post(ctx, "licenses/"+lic.ID+"/actions/validate", validationRequest{
+		fingerprint: p.machineFingerprint,
+	}, validation); err != nil {
+		return validation, fmt.Errorf("validate license failed: %w", err)
+	}
+	*lic = validation.License
+	return validation, nil
+}
+
+func (p *Provider) HasValidLicense(ctx context.Context) (bool, error) {
+	if err := p.refresh(ctx, false); err != nil {
+		return false, err
+	}
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	return p.entitlements != nil
+	return p.entitlements != nil, nil
 }
 
-func (p *Provider) Entitlements() []string {
+func (p *Provider) Entitlements(ctx context.Context) ([]string, error) {
+	if err := p.refresh(ctx, false); err != nil {
+		return nil, err
+	}
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
 	if p.entitlements == nil {
-		return nil
+		return nil, nil
 	}
 
 	entitlements := make([]string, 0, len(p.entitlements))
@@ -262,7 +368,7 @@ func (p *Provider) Entitlements() []string {
 
 	slices.Sort(entitlements)
 
-	return entitlements
+	return entitlements, nil
 }
 
 func (p *Provider) hasEntitlement(key string) bool {
@@ -298,41 +404,49 @@ func (p *Provider) poll(ctx context.Context) {
 func (p *Provider) update(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-
-	var (
-		entitlements  map[keygen.EntitlementCode]struct{}
-		hasLicenseKey bool
-		err           error
-	)
-
-	p.lock.RLock()
-	if keygen.LicenseKey != "" {
-		hasLicenseKey = true
-		entitlements, err = p.validate(ctx)
-	}
-	p.lock.RUnlock()
-
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	if err != nil || !hasLicenseKey {
-		p.entitlements = nil
-		return err
-	}
-
-	p.entitlements = entitlements
-	return nil
+	return p.refresh(ctx, true)
 }
 
-func validateConfig() error {
-	if strings.TrimSpace(keygen.Account) == "" {
-		return fmt.Errorf("%w: missing Keygen account", ErrNotConfigured)
+func (p *Provider) cachedSnapshotMatches(snapshot licenseKeySnapshot) bool {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	return p.licenseKeySnapshot.equal(snapshot)
+}
+
+func (p *Provider) setCachedState(snapshot licenseKeySnapshot, entitlements map[keygen.EntitlementCode]struct{}) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.licenseKeySnapshot = snapshot
+	p.entitlements = entitlements
+}
+
+func (p *Provider) refresh(ctx context.Context, force bool) error {
+	snapshot, err := p.loadLicenseKey(ctx)
+	if err != nil {
+		return err
 	}
-	if strings.TrimSpace(keygen.Product) == "" {
-		return fmt.Errorf("%w: missing Keygen product", ErrNotConfigured)
+	if !force && p.cachedSnapshotMatches(snapshot) {
+		return nil
 	}
-	if strings.TrimSpace(keygen.LicenseKey) == "" {
-		return fmt.Errorf("%w: missing license key or token", ErrNotConfigured)
+
+	p.refreshLock.Lock()
+	defer p.refreshLock.Unlock()
+
+	// Another request may have refreshed the provider while this request waited.
+	snapshot, err = p.loadLicenseKey(ctx)
+	if err != nil {
+		return err
 	}
-	return nil
+	if !force && p.cachedSnapshotMatches(snapshot) {
+		return nil
+	}
+
+	if snapshot.key == "" {
+		p.setCachedState(snapshot, nil)
+		return nil
+	}
+
+	entitlements, err := p.validate(ctx, snapshot.key)
+	p.setCachedState(snapshot, entitlements)
+	return err
 }

--- a/pkg/license/provider_test.go
+++ b/pkg/license/provider_test.go
@@ -8,35 +8,23 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
-	keygen "github.com/keygen-sh/keygen-go/v3"
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
+	storageservices "github.com/obot-platform/obot/pkg/storage/services"
 )
 
-func resetKeygen(t *testing.T) {
+func requireValidLicense(ctx context.Context, t *testing.T, provider *Provider) bool {
 	t.Helper()
-
-	account := keygen.Account
-	product := keygen.Product
-	licenseKey := keygen.LicenseKey
-	token := keygen.Token
-	publicKey := keygen.PublicKey
-	apiURL := keygen.APIURL
-	environment := keygen.Environment
-
-	t.Cleanup(func() {
-		keygen.Account = account
-		keygen.Product = product
-		keygen.LicenseKey = licenseKey
-		keygen.Token = token
-		keygen.PublicKey = publicKey
-		keygen.APIURL = apiURL
-		keygen.Environment = environment
-	})
+	valid, err := provider.HasValidLicense(ctx)
+	if err != nil {
+		t.Fatalf("expected license state lookup to succeed: %v", err)
+	}
+	return valid
 }
 
 func TestRequireEntitlement(t *testing.T) {
-	resetKeygen(t)
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
 
@@ -52,32 +40,32 @@ func TestRequireEntitlement(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	keygen.APIURL = server.URL
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	provider, err := NewProvider(ctx, nil, Config{
+	provider, err := newProvider(ctx, nil, Config{
 		LicenseKey: "license-key",
-	})
+	}, server.URL)
 	if err != nil {
 		t.Fatalf("expected provider to be created: %v", err)
 	}
 
-	if !provider.HasValidLicense() {
+	if !requireValidLicense(ctx, t, provider) {
 		t.Fatal("expected license to be valid")
 	}
 	if !provider.hasEntitlement(EnterpriseAuthProvidersEntitlement) {
 		t.Fatal("expected entitlement to be accepted")
 	}
-	entitlements := provider.Entitlements()
+	entitlements, err := provider.Entitlements(ctx)
+	if err != nil {
+		t.Fatalf("expected entitlements lookup to succeed: %v", err)
+	}
 	if len(entitlements) != 1 || entitlements[0] != EnterpriseAuthProvidersEntitlement {
 		t.Fatalf("expected entitlement list to contain %q, got %v", EnterpriseAuthProvidersEntitlement, entitlements)
 	}
 }
 
 func TestRequireEntitlementMissing(t *testing.T) {
-	resetKeygen(t)
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
 
@@ -93,18 +81,17 @@ func TestRequireEntitlementMissing(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	keygen.APIURL = server.URL
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	provider, err := NewProvider(ctx, nil, Config{
+	provider, err := newProvider(ctx, nil, Config{
 		LicenseKey: "license-key",
-	})
+	}, server.URL)
 	if err != nil {
 		t.Fatalf("expected provider to be created: %v", err)
 	}
 
-	if !provider.HasValidLicense() {
+	if !requireValidLicense(ctx, t, provider) {
 		t.Fatal("expected license to be valid")
 	}
 	if provider.hasEntitlement(EnterpriseAuthProvidersEntitlement) {
@@ -113,8 +100,6 @@ func TestRequireEntitlementMissing(t *testing.T) {
 }
 
 func TestNewProviderNotConfigured(t *testing.T) {
-	resetKeygen(t)
-
 	provider, err := NewProvider(t.Context(), nil, Config{})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -122,14 +107,61 @@ func TestNewProviderNotConfigured(t *testing.T) {
 	if provider == nil {
 		t.Fatal("expected provider to be created")
 	}
-	if provider.HasValidLicense() {
+	if requireValidLicense(t.Context(), t, provider) {
 		t.Fatal("expected license to be invalid")
 	}
 }
 
-func TestNewProviderActivatesLicenseOnNoMachine(t *testing.T) {
-	resetKeygen(t)
+func TestNewProviderContinuesWhenInitialRefreshFails(t *testing.T) {
+	refreshFails := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
 
+		switch r.URL.Path {
+		case "/v1/me":
+			_, _ = fmt.Fprint(w, licenseResponse("license-1"))
+		case "/v1/licenses/license-1/actions/validate":
+			if refreshFails {
+				http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			_, _ = fmt.Fprint(w, validationResponse("license-1"))
+		case "/v1/licenses/license-1/entitlements":
+			_, _ = fmt.Fprint(w, entitlementsResponse(EnterpriseAuthProvidersEntitlement))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	provider, err := newProvider(ctx, nil, Config{
+		LicenseKey: "license-key",
+	}, server.URL)
+	if err != nil {
+		t.Fatalf("expected provider to be created despite refresh failure: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("expected provider to be created")
+	}
+	if requireValidLicense(ctx, t, provider) {
+		t.Fatal("expected provider to start unlicensed")
+	}
+	if provider.hasEntitlement(EnterpriseAuthProvidersEntitlement) {
+		t.Fatal("expected provider to start without entitlements")
+	}
+
+	refreshFails = false
+	if err := provider.Validate(ctx); err != nil {
+		t.Fatalf("expected subsequent refresh to succeed: %v", err)
+	}
+	if !provider.hasEntitlement(EnterpriseAuthProvidersEntitlement) {
+		t.Fatal("expected entitlement after successful refresh")
+	}
+}
+
+func TestNewProviderActivatesLicenseOnNoMachine(t *testing.T) {
 	machineFingerprint := ""
 	validationCount := 0
 	activated := false
@@ -158,13 +190,12 @@ func TestNewProviderActivatesLicenseOnNoMachine(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	keygen.APIURL = server.URL
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	provider, err := NewProvider(ctx, nil, Config{
+	provider, err := newProvider(ctx, nil, Config{
 		LicenseKey: "license-key",
-	})
+	}, server.URL)
 	if err != nil {
 		t.Fatalf("expected provider to be created: %v", err)
 	}
@@ -175,7 +206,7 @@ func TestNewProviderActivatesLicenseOnNoMachine(t *testing.T) {
 	if validationCount != 2 {
 		t.Fatalf("expected license to be validated before and after activation, got %d validations", validationCount)
 	}
-	if !provider.HasValidLicense() {
+	if !requireValidLicense(ctx, t, provider) {
 		t.Fatal("expected license to be valid after activation")
 	}
 	if !provider.hasEntitlement(EnterpriseAuthProvidersEntitlement) {
@@ -184,8 +215,6 @@ func TestNewProviderActivatesLicenseOnNoMachine(t *testing.T) {
 }
 
 func TestUpdateRefreshesEntitlements(t *testing.T) {
-	resetKeygen(t)
-
 	entitlement := EnterpriseAuthProvidersEntitlement
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
@@ -202,13 +231,12 @@ func TestUpdateRefreshesEntitlements(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	keygen.APIURL = server.URL
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	provider, err := NewProvider(ctx, nil, Config{
+	provider, err := newProvider(ctx, nil, Config{
 		LicenseKey: "license-key",
-	})
+	}, server.URL)
 	if err != nil {
 		t.Fatalf("expected provider to be created: %v", err)
 	}
@@ -227,8 +255,6 @@ func TestUpdateRefreshesEntitlements(t *testing.T) {
 }
 
 func TestUpdateClearsEntitlementsWhenLicenseInvalid(t *testing.T) {
-	resetKeygen(t)
-
 	invalid := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
@@ -250,13 +276,12 @@ func TestUpdateClearsEntitlementsWhenLicenseInvalid(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	keygen.APIURL = server.URL
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	provider, err := NewProvider(ctx, nil, Config{
+	provider, err := newProvider(ctx, nil, Config{
 		LicenseKey: "license-key",
-	})
+	}, server.URL)
 	if err != nil {
 		t.Fatalf("expected provider to be created: %v", err)
 	}
@@ -266,15 +291,261 @@ func TestUpdateClearsEntitlementsWhenLicenseInvalid(t *testing.T) {
 		t.Fatalf("expected provider update to succeed: %v", err)
 	}
 
-	if provider.HasValidLicense() {
+	if requireValidLicense(ctx, t, provider) {
 		t.Fatal("expected license to be marked invalid")
 	}
 	if provider.hasEntitlement(EnterpriseAuthProvidersEntitlement) {
 		t.Fatal("expected entitlement to be cleared")
 	}
-	if entitlements := provider.Entitlements(); len(entitlements) != 0 {
+	entitlements, err := provider.Entitlements(ctx)
+	if err != nil {
+		t.Fatalf("expected entitlements lookup to succeed: %v", err)
+	}
+	if len(entitlements) != 0 {
 		t.Fatalf("expected entitlements to be cleared, got %v", entitlements)
 	}
+}
+
+func TestProviderRefreshesDatabaseLicenseAcrossReplicas(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+
+		switch r.URL.Path {
+		case "/v1/me":
+			_, _ = fmt.Fprint(w, licenseResponse("license-1"))
+		case "/v1/licenses/license-1/actions/validate":
+			_, _ = fmt.Fprint(w, validationResponse("license-1"))
+		case "/v1/licenses/license-1/entitlements":
+			switch r.Header.Get("Authorization") {
+			case "License license-one":
+				_, _ = fmt.Fprint(w, entitlementsResponse("ENTITLEMENT_ONE"))
+			case "License license-two":
+				_, _ = fmt.Fprint(w, entitlementsResponse("ENTITLEMENT_TWO"))
+			default:
+				http.Error(w, "unexpected license key", http.StatusUnauthorized)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	gatewayClient := newTestLicenseGatewayClient(t)
+	replicaOne, err := newProvider(ctx, gatewayClient, Config{}, server.URL)
+	if err != nil {
+		t.Fatalf("expected first provider to be created: %v", err)
+	}
+	replicaTwo, err := newProvider(ctx, gatewayClient, Config{}, server.URL)
+	if err != nil {
+		t.Fatalf("expected second provider to be created: %v", err)
+	}
+
+	if err := replicaOne.SetLicenseKey(ctx, "license-one"); err != nil {
+		t.Fatalf("expected first license key to be stored: %v", err)
+	}
+	entitlements, err := replicaTwo.Entitlements(ctx)
+	if err != nil {
+		t.Fatalf("expected second replica to load first license: %v", err)
+	}
+	if len(entitlements) != 1 || entitlements[0] != "ENTITLEMENT_ONE" {
+		t.Fatalf("expected second replica to use first license, got %v", entitlements)
+	}
+
+	if err := replicaOne.SetLicenseKey(ctx, "license-two"); err != nil {
+		t.Fatalf("expected replacement license key to be stored: %v", err)
+	}
+	entitlements, err = replicaTwo.Entitlements(ctx)
+	if err != nil {
+		t.Fatalf("expected second replica to refresh replacement license: %v", err)
+	}
+	if len(entitlements) != 1 || entitlements[0] != "ENTITLEMENT_TWO" {
+		t.Fatalf("expected second replica to use replacement license, got %v", entitlements)
+	}
+
+	if err := replicaOne.RemoveLicenseKey(ctx); err != nil {
+		t.Fatalf("expected license key to be removed: %v", err)
+	}
+	if requireValidLicense(ctx, t, replicaTwo) {
+		t.Fatal("expected second replica to clear its cached license after removal")
+	}
+	entitlements, err = replicaTwo.Entitlements(ctx)
+	if err != nil {
+		t.Fatalf("expected second replica entitlement lookup after removal to succeed: %v", err)
+	}
+	if len(entitlements) != 0 {
+		t.Fatalf("expected second replica entitlements to be cleared, got %v", entitlements)
+	}
+}
+
+func TestCachedSnapshotMatchesEquivalentTimestamps(t *testing.T) {
+	updatedAt := time.Now()
+	provider := &Provider{
+		licenseKeySnapshot: licenseKeySnapshot{
+			key:       "license-key",
+			updatedAt: updatedAt,
+		},
+	}
+
+	// Database round trips strip time.Time's monotonic clock reading.
+	databaseSnapshot := licenseKeySnapshot{
+		key:       "license-key",
+		updatedAt: updatedAt.Round(0),
+	}
+	if !provider.cachedSnapshotMatches(databaseSnapshot) {
+		t.Fatal("expected snapshots representing the same timestamp to match")
+	}
+}
+
+func TestSetLicenseKeyWaitsForRefreshBeforeCommitting(t *testing.T) {
+	validationCompleted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+
+		switch r.URL.Path {
+		case "/v1/me":
+			_, _ = fmt.Fprint(w, licenseResponse("license-1"))
+		case "/v1/licenses/license-1/actions/validate":
+			_, _ = fmt.Fprint(w, validationResponse("license-1"))
+		case "/v1/licenses/license-1/entitlements":
+			_, _ = fmt.Fprint(w, entitlementsResponse("NEW_ENTITLEMENT"))
+			close(validationCompleted)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	provider, err := newProvider(ctx, newTestLicenseGatewayClient(t), Config{}, server.URL)
+	if err != nil {
+		t.Fatalf("expected provider to be created: %v", err)
+	}
+
+	// Model a refresh that is still validating the previous database snapshot.
+	provider.refreshLock.Lock()
+	setDone := make(chan error, 1)
+	go func() {
+		setDone <- provider.SetLicenseKey(ctx, "new-license")
+	}()
+
+	select {
+	case <-validationCompleted:
+	case <-time.After(5 * time.Second):
+		provider.refreshLock.Unlock()
+		t.Fatal("timed out waiting for candidate license validation")
+	}
+
+	select {
+	case err := <-setDone:
+		provider.refreshLock.Unlock()
+		if err != nil {
+			t.Fatalf("expected license key update to succeed: %v", err)
+		}
+		t.Fatal("SetLicenseKey committed while a refresh was in progress")
+	case <-time.After(500 * time.Millisecond):
+		provider.refreshLock.Unlock()
+	}
+
+	if err := <-setDone; err != nil {
+		t.Fatalf("expected license key update to succeed after refresh: %v", err)
+	}
+	licenseKey, err := provider.LicenseKey(ctx)
+	if err != nil {
+		t.Fatalf("expected stored license key lookup to succeed: %v", err)
+	}
+	if licenseKey != "new-license" {
+		t.Fatalf("expected new license key to be stored, got %q", licenseKey)
+	}
+	if !provider.hasEntitlement("NEW_ENTITLEMENT") {
+		t.Fatal("expected new license entitlements to be cached")
+	}
+}
+
+func TestRemoveLicenseKeyWaitsForRefreshBeforeClearingState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+
+		switch r.URL.Path {
+		case "/v1/me":
+			_, _ = fmt.Fprint(w, licenseResponse("license-1"))
+		case "/v1/licenses/license-1/actions/validate":
+			_, _ = fmt.Fprint(w, validationResponse("license-1"))
+		case "/v1/licenses/license-1/entitlements":
+			_, _ = fmt.Fprint(w, entitlementsResponse("OLD_ENTITLEMENT"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	provider, err := newProvider(ctx, newTestLicenseGatewayClient(t), Config{}, server.URL)
+	if err != nil {
+		t.Fatalf("expected provider to be created: %v", err)
+	}
+	if err := provider.SetLicenseKey(ctx, "old-license"); err != nil {
+		t.Fatalf("expected initial license key to be stored: %v", err)
+	}
+
+	// Model a refresh that is still validating the license being removed.
+	provider.refreshLock.Lock()
+	removeDone := make(chan error, 1)
+	go func() {
+		removeDone <- provider.RemoveLicenseKey(ctx)
+	}()
+
+	select {
+	case err := <-removeDone:
+		provider.refreshLock.Unlock()
+		if err != nil {
+			t.Fatalf("expected license key removal to succeed: %v", err)
+		}
+		t.Fatal("RemoveLicenseKey cleared state while a refresh was in progress")
+	case <-time.After(500 * time.Millisecond):
+		provider.refreshLock.Unlock()
+	}
+
+	if err := <-removeDone; err != nil {
+		t.Fatalf("expected license key removal to succeed after refresh: %v", err)
+	}
+	licenseKey, err := provider.LicenseKey(ctx)
+	if err != nil {
+		t.Fatalf("expected stored license key lookup to succeed: %v", err)
+	}
+	if licenseKey != "" {
+		t.Fatalf("expected license key to be removed, got %q", licenseKey)
+	}
+	if provider.hasEntitlement("OLD_ENTITLEMENT") {
+		t.Fatal("expected removed license entitlements to be cleared")
+	}
+}
+
+func newTestLicenseGatewayClient(t *testing.T) *gatewayclient.Client {
+	t.Helper()
+
+	storageServices, err := storageservices.New(storageservices.Config{DSN: "sqlite://:memory:"})
+	if err != nil {
+		t.Fatalf("failed to create storage services: %v", err)
+	}
+	database, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
+	if err != nil {
+		t.Fatalf("failed to create gateway database: %v", err)
+	}
+	if err := database.AutoMigrate(); err != nil {
+		t.Fatalf("failed to migrate gateway database: %v", err)
+	}
+
+	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, false)
+	t.Cleanup(func() {
+		if err := gatewayClient.Close(); err != nil {
+			t.Errorf("failed to close gateway client: %v", err)
+		}
+	})
+	return gatewayClient
 }
 
 func licenseResponse(id string) string {
@@ -363,6 +634,9 @@ func assertValidateFingerprint(t *testing.T, r *http.Request, expected string) s
 		t.Fatalf("expected validate request scope, got %#v", body)
 	}
 	fingerprint, _ := scope["fingerprint"].(string)
+	if product, _ := scope["product"].(string); product != keygenProduct {
+		t.Fatalf("expected validate product %q, got %q", keygenProduct, product)
+	}
 	if expected == "" {
 		if fingerprint == "" {
 			t.Fatal("expected validate fingerprint to be set")


### PR DESCRIPTION
The keygen package uses package variables by default, which doesn't work well with HA setups. This change uses a lower-level keygen client and less caching to make licensing more HA-friendly.

Part of https://github.com/obot-platform/obot/issues/7290