### PR TITLE
fix: allow creating MCP servers without URL during setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ thoughts/
 thoughts
 
 .opencode/
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/

--- a/pkg/mcp/action.go
+++ b/pkg/mcp/action.go
@@ -170,6 +170,7 @@ func (sm *SessionManager) serverOrInstanceFromConnectURL(ctx context.Context, id
 				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrBadRequest("catalog entry %s cannot be connected because it could not be converted to an MCP server: %v", id, err)
 			}
 			if err := ValidateServerManifest(ctx, manifest, false, ValidationOptions{
+				AllowMissingURL:              allowMissingURL,
 				RemoteMCPURLValidationConfig: sm.remoteURLValidationConfig,
 				ResourceMaximums:             sm.resourceMaximums,
 			}); err != nil {

--- a/pkg/mcp/action_test.go
+++ b/pkg/mcp/action_test.go
@@ -1,0 +1,67 @@
+package mcp
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestServerOrInstanceFromConnectURLCreatesRemoteServerThatNeedsUserURL(t *testing.T) {
+	const (
+		entryID = "catalog-entry"
+		userID  = "user-1"
+	)
+
+	entry := &v1.MCPServerCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      entryID,
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				ServerUserType: types.ServerUserTypeSingleUser,
+				Runtime:        types.RuntimeRemote,
+				RemoteConfig: &types.RemoteCatalogConfig{
+					Hostname: "api.example.com",
+				},
+			},
+		},
+	}
+
+	storageClient := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(entry).
+		WithIndex(&v1.MCPServer{}, "spec.mcpServerCatalogEntryName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.MCPServerCatalogEntryName}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.userID", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.UserID}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.template", func(obj kclient.Object) []string {
+			return []string{strconv.FormatBool(obj.(*v1.MCPServer).Spec.Template)}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.compositeName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.CompositeName}
+		}).
+		Build()
+
+	manager := SessionManager{storageClient: storageClient}
+	server, instance, err := manager.serverOrInstanceFromConnectURL(t.Context(), entryID, userID)
+	require.NoError(t, err)
+	require.Empty(t, instance.Name)
+	require.NotEmpty(t, server.Name)
+	require.Equal(t, entryID, server.Spec.MCPServerCatalogEntryName)
+	require.Equal(t, userID, server.Spec.UserID)
+	require.True(t, server.Spec.NeedsURL)
+	require.NotNil(t, server.Spec.Manifest.RemoteConfig)
+	require.Equal(t, "api.example.com", server.Spec.Manifest.RemoteConfig.Hostname)
+	require.Empty(t, server.Spec.Manifest.RemoteConfig.URL)
+}

--- a/pkg/mcp/mcpvalidators.go
+++ b/pkg/mcp/mcpvalidators.go
@@ -145,6 +145,7 @@ type RuntimeValidators map[types.Runtime]RuntimeValidator
 
 // Options configures runtime validation behavior.
 type ValidationOptions struct {
+	AllowMissingURL              bool
 	RemoteMCPURLValidationConfig RemoteMCPURLValidationConfig
 	ResourceMaximums             ResourceMaximums
 }
@@ -446,6 +447,7 @@ func (v ContainerizedValidator) validateContainerizedConfig(config types.Contain
 
 // RemoteValidator implements RuntimeValidator for remote runtime
 type RemoteValidator struct {
+	AllowMissingURL              bool
 	RemoteMCPURLValidationConfig RemoteMCPURLValidationConfig
 }
 
@@ -510,36 +512,36 @@ func (v RemoteValidator) ValidateSystemConfig(ctx context.Context, manifest type
 }
 
 func (v RemoteValidator) validateRemoteConfig(ctx context.Context, config types.RemoteRuntimeConfig) error {
-	if strings.TrimSpace(config.URL) == "" {
-		if config.IsTemplate {
-			return nil
+	config.URL = strings.TrimSpace(config.URL)
+	if config.URL == "" {
+		if !v.AllowMissingURL && !config.IsTemplate {
+			return types.RuntimeValidationError{
+				Runtime: types.RuntimeRemote,
+				Field:   "url",
+				Message: "URL field cannot be empty",
+			}
 		}
-		return types.RuntimeValidationError{
-			Runtime: types.RuntimeRemote,
-			Field:   "url",
-			Message: "URL field cannot be empty",
+	} else {
+		// Validate URL format
+		parsedURL, err := url.Parse(config.URL)
+		if err != nil {
+			return types.RuntimeValidationError{
+				Runtime: types.RuntimeRemote,
+				Field:   "url",
+				Message: fmt.Sprintf("invalid URL format: %v", err),
+			}
 		}
-	}
 
-	// Validate URL format
-	parsedURL, err := url.Parse(config.URL)
-	if err != nil {
-		return types.RuntimeValidationError{
-			Runtime: types.RuntimeRemote,
-			Field:   "url",
-			Message: fmt.Sprintf("invalid URL format: %v", err),
+		if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
+			return types.RuntimeValidationError{
+				Runtime: types.RuntimeRemote,
+				Field:   "url",
+				Message: "URL scheme must be either https or http",
+			}
 		}
-	}
-
-	if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
-		return types.RuntimeValidationError{
-			Runtime: types.RuntimeRemote,
-			Field:   "url",
-			Message: "URL scheme must be either https or http",
+		if err := v.validateRemoteMCPURL(ctx, "url", config.URL); err != nil {
+			return err
 		}
-	}
-	if err := v.validateRemoteMCPURL(ctx, "url", config.URL); err != nil {
-		return err
 	}
 
 	// Validate headers
@@ -1005,8 +1007,11 @@ func getRuntimeValidators(options ValidationOptions) RuntimeValidators {
 		types.RuntimeUVX:           UVXValidator{},
 		types.RuntimeNPX:           NPXValidator{},
 		types.RuntimeContainerized: ContainerizedValidator{},
-		types.RuntimeRemote:        RemoteValidator{RemoteMCPURLValidationConfig: options.RemoteMCPURLValidationConfig},
-		types.RuntimeComposite:     CompositeValidator{},
+		types.RuntimeRemote: RemoteValidator{
+			RemoteMCPURLValidationConfig: options.RemoteMCPURLValidationConfig,
+			AllowMissingURL:              options.AllowMissingURL,
+		},
+		types.RuntimeComposite: CompositeValidator{},
 	}
 }
 

--- a/pkg/mcp/mcpvalidators_test.go
+++ b/pkg/mcp/mcpvalidators_test.go
@@ -972,6 +972,75 @@ func TestValidateRemoteManifestURLWithOptions(t *testing.T) {
 	}
 }
 
+func TestValidateRemoteManifestAllowMissingURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  types.RemoteRuntimeConfig
+		options ValidationOptions
+		wantErr string
+	}{
+		{
+			name:    "missing URL rejected by default",
+			wantErr: "URL field cannot be empty",
+		},
+		{
+			name:    "missing URL allowed",
+			options: ValidationOptions{AllowMissingURL: true},
+		},
+		{
+			name:    "whitespace URL allowed",
+			config:  types.RemoteRuntimeConfig{URL: " \t "},
+			options: ValidationOptions{AllowMissingURL: true},
+		},
+		{
+			name:   "template may omit URL by default",
+			config: types.RemoteRuntimeConfig{IsTemplate: true},
+		},
+		{
+			name:    "present URL still requires HTTP scheme",
+			config:  types.RemoteRuntimeConfig{URL: "ftp://example.com/mcp"},
+			options: ValidationOptions{AllowMissingURL: true},
+			wantErr: "URL scheme must be either https or http",
+		},
+		{
+			name:    "present URL still receives remote URL validation",
+			config:  types.RemoteRuntimeConfig{URL: "http://localhost:8080/mcp"},
+			options: ValidationOptions{AllowMissingURL: true},
+			wantErr: "localhost URL",
+		},
+		{
+			name: "missing URL still validates headers",
+			config: types.RemoteRuntimeConfig{
+				Headers: []types.MCPHeader{{Value: "value"}},
+			},
+			options: ValidationOptions{AllowMissingURL: true},
+			wantErr: "header key cannot be empty",
+		},
+		{
+			name: "template without URL still validates headers",
+			config: types.RemoteRuntimeConfig{
+				IsTemplate: true,
+				Headers:    []types.MCPHeader{{Value: "value"}},
+			},
+			wantErr: "header key cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateServerManifest(t.Context(), types.MCPServerManifest{
+				Runtime:      types.RuntimeRemote,
+				RemoteConfig: &tt.config,
+			}, false, tt.options)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestRemoteValidator_ValidateCatalogConfig_HeaderValidation(t *testing.T) {
 	validator := RemoteValidator{}
 


### PR DESCRIPTION
MCP servers should be allowed to have a missing URL if created during setup because the user will be prompted to enter one.