### PR TITLE
feat: add Community Edition enrollment API and UI

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -53,6 +53,7 @@ var (
 		"GET /debug/metrics",
 		"PUT /api/license",
 		"POST /api/license",
+		"POST /api/license/community",
 		"DELETE /api/license",
 		"/api/auth-providers",
 		"/api/auth-providers/",

--- a/pkg/api/authz/license_test.go
+++ b/pkg/api/authz/license_test.go
@@ -1,0 +1,95 @@
+package authz
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestLicenseRouteAuthorization(t *testing.T) {
+	authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, false)
+	users := []struct {
+		name      string
+		info      user.Info
+		canRead   bool
+		canMutate bool
+	}{
+		{
+			name:      "owner",
+			info:      &user.DefaultInfo{Name: "owner", Groups: types.RoleOwner.Groups()},
+			canRead:   true,
+			canMutate: true,
+		},
+		{
+			name:      "administrator",
+			info:      &user.DefaultInfo{Name: "admin", Groups: types.RoleAdmin.Groups()},
+			canRead:   true,
+			canMutate: true,
+		},
+		{
+			name:    "auditor",
+			info:    &user.DefaultInfo{Name: "auditor", Groups: types.RoleAuditor.Groups()},
+			canRead: true,
+		},
+		{
+			name:    "basic user",
+			info:    &user.DefaultInfo{Name: "basic", Groups: types.RoleBasic.Groups()},
+			canRead: true,
+		},
+		{
+			name: "unauthenticated user",
+			info: &user.DefaultInfo{Name: "anonymous", Groups: []string{UnauthenticatedGroup}},
+		},
+	}
+	routes := []struct {
+		name     string
+		method   string
+		path     string
+		readOnly bool
+	}{
+		{
+			name:     "read status",
+			method:   http.MethodGet,
+			path:     "/api/license",
+			readOnly: true,
+		},
+		{
+			name:   "update key",
+			method: http.MethodPut,
+			path:   "/api/license",
+		},
+		{
+			name:   "recheck key",
+			method: http.MethodPost,
+			path:   "/api/license",
+		},
+		{
+			name:   "delete key",
+			method: http.MethodDelete,
+			path:   "/api/license",
+		},
+		{
+			name:   "create community license",
+			method: http.MethodPost,
+			path:   "/api/license/community",
+		},
+	}
+
+	for _, route := range routes {
+		for _, testUser := range users {
+			t.Run(route.name+"/"+testUser.name, func(t *testing.T) {
+				request := httptest.NewRequest(route.method, route.path, nil)
+				allowed := testUser.canMutate
+				if route.readOnly {
+					allowed = testUser.canRead
+				}
+				if got := authorizer.Authorize(request, testUser.info); got != allowed {
+					t.Fatalf("Authorize(%s %s, %s) = %t, want %t", route.method, route.path, testUser.name, got, allowed)
+				}
+			})
+		}
+	}
+}

--- a/pkg/api/handlers/communitylicense.go
+++ b/pkg/api/handlers/communitylicense.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/mail"
+	"strings"
+
+	apitypes "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/license"
+	"github.com/obot-platform/obot/pkg/upgrade"
+)
+
+type CommunityLicenseEnrollment struct {
+	Name    string `json:"name"`
+	Email   string `json:"email"`
+	Company string `json:"company,omitempty"`
+}
+
+func (h *LicenseHandler) CreateCommunityLicense(req api.Context) error {
+	var input CommunityLicenseEnrollment
+	if err := req.Read(&input); err != nil {
+		return apitypes.NewErrBadRequest("invalid Community Edition enrollment request")
+	}
+
+	input.Name = strings.TrimSpace(input.Name)
+	input.Email = strings.TrimSpace(input.Email)
+	input.Company = strings.TrimSpace(input.Company)
+	if input.Name == "" {
+		return apitypes.NewErrBadRequest("name is required")
+	}
+	if input.Email == "" {
+		return apitypes.NewErrBadRequest("email is required")
+	}
+	parsedEmail, err := mail.ParseAddress(input.Email)
+	if err != nil {
+		return apitypes.NewErrBadRequest("a valid email address is required")
+	}
+	input.Email = parsedEmail.Address
+
+	if err := h.communityEligibilityError(req.Context()); err != nil {
+		return err
+	}
+	if !h.reserveCommunityEnrollment() {
+		return apitypes.NewErrAlreadyExists("a Community Edition enrollment request is already in progress")
+	}
+	defer h.releaseCommunityEnrollment()
+
+	if err := h.communityEligibilityError(req.Context()); err != nil {
+		return err
+	}
+
+	issuedKey, err := h.communityIssuer.Issue(req.Context(), upgrade.CommunityLicenseRequest{
+		Name:    input.Name,
+		Email:   input.Email,
+		Company: input.Company,
+	})
+	if err != nil {
+		return apitypes.NewErrHTTP(http.StatusBadGateway, "failed to obtain a Community Edition license")
+	}
+
+	if err := h.licenseProvider.SetLicenseKey(req.Context(), issuedKey); err != nil {
+		if errors.Is(err, license.ErrLicenseKeyViaConfiguration) {
+			return apitypes.NewErrAlreadyExists("license key is configured at startup and cannot be updated via the API")
+		}
+		if errors.Is(err, license.ErrInvalidLicense) {
+			return apitypes.NewErrHTTP(http.StatusBadGateway, "the issued Community Edition license is invalid")
+		}
+		return apitypes.NewErrHTTP(http.StatusInternalServerError, "failed to install the Community Edition license")
+	}
+
+	status, err := h.status(req)
+	if err != nil {
+		return err
+	}
+	return req.Write(status)
+}
+
+func (h *LicenseHandler) communityEligibilityError(ctx context.Context) error {
+	if ok, err := h.licenseProvider.HasValidLicense(ctx); err != nil {
+		return err
+	} else if ok {
+		return apitypes.NewErrAlreadyExists("a valid license is already active")
+	}
+	if h.licenseProvider.LicenseKeyViaConfiguration() {
+		return apitypes.NewErrAlreadyExists("license key is configured at startup and cannot be updated via the API")
+	}
+	return nil
+}
+
+func (h *LicenseHandler) reserveCommunityEnrollment() bool {
+	h.communityLock.Lock()
+	defer h.communityLock.Unlock()
+	if h.communityInFlight {
+		return false
+	}
+	h.communityInFlight = true
+	return true
+}
+
+func (h *LicenseHandler) releaseCommunityEnrollment() {
+	h.communityLock.Lock()
+	h.communityInFlight = false
+	h.communityLock.Unlock()
+}

--- a/pkg/api/handlers/communitylicense_test.go
+++ b/pkg/api/handlers/communitylicense_test.go
@@ -1,0 +1,453 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	apitypes "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/license"
+	"github.com/obot-platform/obot/pkg/upgrade"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+const communityEntitlement = "OBOT_COMMUNITY_EDITION"
+
+type fakeCommunityLicenseProvider struct {
+	lock              sync.Mutex
+	key               string
+	configured        bool
+	valid             bool
+	entitlements      []string
+	licenseKeyError   error
+	validErrors       []error
+	entitlementsError error
+	setError          error
+	setCalls          int
+	hasValidCalls     int
+	lastInstalledKey  string
+}
+
+func (p *fakeCommunityLicenseProvider) LicenseKey(context.Context) (string, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	return p.key, p.licenseKeyError
+}
+
+func (p *fakeCommunityLicenseProvider) LicenseKeyViaConfiguration() bool {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	return p.configured
+}
+
+func (p *fakeCommunityLicenseProvider) SetLicenseKey(_ context.Context, key string) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.setCalls++
+	p.lastInstalledKey = key
+	if p.setError != nil {
+		return p.setError
+	}
+	p.key = key
+	p.valid = true
+	p.entitlements = []string{communityEntitlement}
+	return nil
+}
+
+func (p *fakeCommunityLicenseProvider) RemoveLicenseKey(context.Context) error {
+	return nil
+}
+
+func (p *fakeCommunityLicenseProvider) Validate(context.Context) error {
+	return nil
+}
+
+func (p *fakeCommunityLicenseProvider) HasValidLicense(context.Context) (bool, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	call := p.hasValidCalls
+	p.hasValidCalls++
+	if call < len(p.validErrors) && p.validErrors[call] != nil {
+		return false, p.validErrors[call]
+	}
+	return p.valid, nil
+}
+
+func (p *fakeCommunityLicenseProvider) Entitlements(context.Context) ([]string, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	return append([]string(nil), p.entitlements...), p.entitlementsError
+}
+
+type fakeCommunityIssuer struct {
+	lock     sync.Mutex
+	key      string
+	errors   []error
+	requests []upgrade.CommunityLicenseRequest
+	started  chan struct{}
+	release  chan struct{}
+}
+
+func (i *fakeCommunityIssuer) Issue(ctx context.Context, request upgrade.CommunityLicenseRequest) (string, error) {
+	i.lock.Lock()
+	i.requests = append(i.requests, request)
+	call := len(i.requests) - 1
+	var err error
+	if call < len(i.errors) {
+		err = i.errors[call]
+	}
+	started := i.started
+	release := i.release
+	key := i.key
+	i.lock.Unlock()
+
+	if started != nil {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	if err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+func (i *fakeCommunityIssuer) requestCount() int {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return len(i.requests)
+}
+
+func (i *fakeCommunityIssuer) request(index int) upgrade.CommunityLicenseRequest {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return i.requests[index]
+}
+
+func communityAPIContext(t *testing.T, body string) (api.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/license/community", strings.NewReader(body))
+	return api.Context{
+		ResponseWriter: recorder,
+		Request:        request,
+		User: &user.DefaultInfo{
+			Name:   "admin",
+			Groups: apitypes.RoleAdmin.Groups(),
+		},
+	}, recorder
+}
+
+func requireHTTPError(t *testing.T, err error, code int) {
+	t.Helper()
+	var httpError *apitypes.ErrHTTP
+	if !errors.As(err, &httpError) {
+		t.Fatalf("expected HTTP error, got %T: %v", err, err)
+	}
+	if httpError.Code != code {
+		t.Fatalf("HTTP status = %d, want %d: %v", httpError.Code, code, err)
+	}
+}
+
+func TestCreateCommunityLicenseValidatesAndNormalizesInput(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "malformed input",
+			body: `{"name":"Sensitive Name"`,
+		},
+		{
+			name: "missing name",
+			body: `{"email":"ada@example.com"}`,
+		},
+		{
+			name: "whitespace name",
+			body: `{"name":"   ","email":"ada@example.com"}`,
+		},
+		{
+			name: "missing email",
+			body: `{"name":"Ada"}`,
+		},
+		{
+			name: "whitespace email",
+			body: `{"name":"Ada","email":"   "}`},
+		{
+			name: "invalid email",
+			body: `{"name":"Ada","email":"not-an-email"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &fakeCommunityLicenseProvider{}
+			issuer := &fakeCommunityIssuer{key: "issued-key"}
+			handler := NewLicenseHandler(provider, issuer)
+			request, _ := communityAPIContext(t, tt.body)
+			err := handler.CreateCommunityLicense(request)
+			requireHTTPError(t, err, http.StatusBadRequest)
+			if issuer.requestCount() != 0 {
+				t.Fatalf("issuer called %d times", issuer.requestCount())
+			}
+			if strings.Contains(err.Error(), "Sensitive Name") {
+				t.Fatalf("error leaked submitted data: %v", err)
+			}
+		})
+	}
+
+	provider := &fakeCommunityLicenseProvider{}
+	issuer := &fakeCommunityIssuer{key: "keygen/community-12345678"}
+	handler := NewLicenseHandler(provider, issuer)
+	request, _ := communityAPIContext(t, `{"name":"  Ada Lovelace  ","email":" Ada <ADA@example.com> ","company":"   "}`)
+	if err := handler.CreateCommunityLicense(request); err != nil {
+		t.Fatalf("CreateCommunityLicense() error = %v", err)
+	}
+	got := issuer.request(0)
+	if got.Name != "Ada Lovelace" || got.Email != "ADA@example.com" || got.Company != "" {
+		t.Fatalf("normalized request = %#v", got)
+	}
+	if got.InstallationID != "" {
+		t.Fatalf("browser handler supplied installation ID %q", got.InstallationID)
+	}
+}
+
+func TestCreateCommunityLicenseEligibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *fakeCommunityLicenseProvider
+	}{
+		{name: "valid license", provider: &fakeCommunityLicenseProvider{key: "existing", valid: true}},
+		{name: "configured invalid license", provider: &fakeCommunityLicenseProvider{key: "configured", configured: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer := &fakeCommunityIssuer{key: "issued-key"}
+			handler := NewLicenseHandler(tt.provider, issuer)
+			request, _ := communityAPIContext(t, `{"name":"Ada","email":"ada@example.com"}`)
+			requireHTTPError(t, handler.CreateCommunityLicense(request), http.StatusConflict)
+			if issuer.requestCount() != 0 {
+				t.Fatal("issuer was called for an ineligible installation")
+			}
+		})
+	}
+}
+
+func TestCreateCommunityLicensePropagatesEligibilityLookupError(t *testing.T) {
+	lookupErr := errors.New("license lookup failed")
+	tests := []struct {
+		name        string
+		validErrors []error
+	}{
+		{name: "initial check", validErrors: []error{lookupErr}},
+		{name: "check after reservation", validErrors: []error{nil, lookupErr}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &fakeCommunityLicenseProvider{validErrors: tt.validErrors}
+			issuer := &fakeCommunityIssuer{key: "issued-key"}
+			handler := NewLicenseHandler(provider, issuer)
+			request, recorder := communityAPIContext(t, `{"name":"Ada","email":"ada@example.com"}`)
+
+			err := handler.CreateCommunityLicense(request)
+			if !errors.Is(err, lookupErr) {
+				t.Fatalf("CreateCommunityLicense() error = %v, want %v", err, lookupErr)
+			}
+			if issuer.requestCount() != 0 {
+				t.Fatalf("issuer called %d times after eligibility lookup failed", issuer.requestCount())
+			}
+			if provider.setCalls != 0 {
+				t.Fatalf("license installed %d times after eligibility lookup failed", provider.setCalls)
+			}
+			if recorder.Body.Len() != 0 {
+				t.Fatalf("response written after eligibility lookup failed: %s", recorder.Body.String())
+			}
+
+			provider.validErrors = nil
+			retryRequest, _ := communityAPIContext(t, `{"name":"Ada","email":"ada@example.com"}`)
+			if err := handler.CreateCommunityLicense(retryRequest); err != nil {
+				t.Fatalf("retry after eligibility lookup failed: %v", err)
+			}
+			if issuer.requestCount() != 1 {
+				t.Fatalf("issuer called %d times after retry, want 1", issuer.requestCount())
+			}
+		})
+	}
+}
+
+func TestCreateCommunityLicensePropagatesStatusLookupErrors(t *testing.T) {
+	statusErr := errors.New("license status lookup failed")
+	tests := []struct {
+		name     string
+		provider *fakeCommunityLicenseProvider
+	}{
+		{
+			name:     "license key",
+			provider: &fakeCommunityLicenseProvider{licenseKeyError: statusErr},
+		},
+		{
+			name:     "valid license",
+			provider: &fakeCommunityLicenseProvider{validErrors: []error{nil, nil, statusErr}},
+		},
+		{
+			name:     "entitlements",
+			provider: &fakeCommunityLicenseProvider{entitlementsError: statusErr},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer := &fakeCommunityIssuer{key: "keygen/community-12345678"}
+			handler := NewLicenseHandler(tt.provider, issuer)
+			request, recorder := communityAPIContext(t, `{"name":"Ada","email":"ada@example.com"}`)
+
+			err := handler.CreateCommunityLicense(request)
+			if !errors.Is(err, statusErr) {
+				t.Fatalf("CreateCommunityLicense() error = %v, want %v", err, statusErr)
+			}
+			if issuer.requestCount() != 1 {
+				t.Fatalf("issuer called %d times, want 1", issuer.requestCount())
+			}
+			if tt.provider.setCalls != 1 {
+				t.Fatalf("license installed %d times, want 1", tt.provider.setCalls)
+			}
+			if recorder.Body.Len() != 0 {
+				t.Fatalf("response written after status lookup failed: %s", recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestCreateCommunityLicenseReplacesInvalidDatabaseKeyAndReturnsMaskedStatus(t *testing.T) {
+	const issuedKey = "keygen/community-full-12345678"
+	provider := &fakeCommunityLicenseProvider{key: "invalid-database-key"}
+	issuer := &fakeCommunityIssuer{key: issuedKey}
+	handler := NewLicenseHandler(provider, issuer)
+	request, recorder := communityAPIContext(t, `{"name":"Ada","email":"ada@example.com","company":"Analytical Engines"}`)
+
+	if err := handler.CreateCommunityLicense(request); err != nil {
+		t.Fatalf("CreateCommunityLicense() error = %v", err)
+	}
+	if provider.lastInstalledKey != issuedKey || provider.setCalls != 1 {
+		t.Fatalf("installed key = %q, calls = %d", provider.lastInstalledKey, provider.setCalls)
+	}
+	var status LicenseStatus
+	if err := json.NewDecoder(recorder.Body).Decode(&status); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if status.LicenseKey != "****12345678" || status.Source != "database" || !status.Enterprise {
+		t.Fatalf("status = %#v", status)
+	}
+	if len(status.Entitlements) != 1 || status.Entitlements[0] != communityEntitlement {
+		t.Fatalf("entitlements = %v", status.Entitlements)
+	}
+	responseBody := recorder.Body.String()
+	for _, sensitive := range []string{issuedKey, "Ada", "ada@example.com", "Analytical Engines"} {
+		if strings.Contains(responseBody, sensitive) {
+			t.Fatalf("response leaked %q: %s", sensitive, responseBody)
+		}
+	}
+}
+
+func TestCreateCommunityLicenseMapsIssuerAndInstallFailures(t *testing.T) {
+	secret := "sensitive upstream response and issued key"
+	tests := []struct {
+		name       string
+		issuerErr  error
+		installErr error
+		wantCode   int
+	}{
+		{
+			name:      "issuer failure",
+			issuerErr: errors.New(secret),
+			wantCode:  http.StatusBadGateway,
+		},
+		{
+			name:       "invalid issued key",
+			installErr: license.ErrInvalidLicense,
+			wantCode:   http.StatusBadGateway,
+		},
+		{
+			name:       "configuration changes during issuance",
+			installErr: license.ErrLicenseKeyViaConfiguration,
+			wantCode:   http.StatusConflict,
+		},
+		{
+			name:       "entitlement or persistence failure",
+			installErr: errors.New(secret),
+			wantCode:   http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &fakeCommunityLicenseProvider{setError: tt.installErr}
+			issuer := &fakeCommunityIssuer{key: secret, errors: []error{tt.issuerErr}}
+			handler := NewLicenseHandler(provider, issuer)
+			request, _ := communityAPIContext(t, `{"name":"Sensitive Name","email":"secret@example.com"}`)
+			err := handler.CreateCommunityLicense(request)
+			requireHTTPError(t, err, tt.wantCode)
+			for _, sensitive := range []string{secret, "Sensitive Name", "secret@example.com"} {
+				if strings.Contains(err.Error(), sensitive) {
+					t.Fatalf("error leaked %q: %v", sensitive, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateCommunityLicenseSerializesRequestsAndAllowsRetry(t *testing.T) {
+	provider := &fakeCommunityLicenseProvider{}
+	issuer := &fakeCommunityIssuer{
+		key:     "keygen/community-12345678",
+		errors:  []error{errors.New("temporary failure")},
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	handler := NewLicenseHandler(provider, issuer)
+	body := `{"name":"Ada","email":"ada@example.com"}`
+
+	firstRequest, _ := communityAPIContext(t, body)
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- handler.CreateCommunityLicense(firstRequest)
+	}()
+	<-issuer.started
+
+	secondRequest, _ := communityAPIContext(t, body)
+	requireHTTPError(t, handler.CreateCommunityLicense(secondRequest), http.StatusConflict)
+	if issuer.requestCount() != 1 {
+		t.Fatalf("issuer calls during concurrent request = %d", issuer.requestCount())
+	}
+
+	close(issuer.release)
+	requireHTTPError(t, <-firstDone, http.StatusBadGateway)
+
+	thirdRequest, recorder := communityAPIContext(t, body)
+	if err := handler.CreateCommunityLicense(thirdRequest); err != nil {
+		t.Fatalf("retry error = %v", err)
+	}
+	if issuer.requestCount() != 2 {
+		t.Fatalf("issuer calls after retry = %d", issuer.requestCount())
+	}
+	if !bytes.Contains(recorder.Body.Bytes(), []byte(`"enterprise":true`)) {
+		t.Fatalf("retry response = %s", recorder.Body.String())
+	}
+}

--- a/pkg/api/handlers/license.go
+++ b/pkg/api/handlers/license.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -11,10 +12,24 @@ import (
 	apitypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/license"
+	"github.com/obot-platform/obot/pkg/upgrade"
 )
 
+type LicenseProvider interface {
+	LicenseKey(context.Context) (string, error)
+	LicenseKeyViaConfiguration() bool
+	SetLicenseKey(context.Context, string) error
+	RemoveLicenseKey(context.Context) error
+	Validate(context.Context) error
+	HasValidLicense(context.Context) (bool, error)
+	Entitlements(context.Context) ([]string, error)
+}
+
 type LicenseHandler struct {
-	licenseProvider        *license.Provider
+	licenseProvider        LicenseProvider
+	communityIssuer        upgrade.CommunityLicenseIssuer
+	communityLock          sync.Mutex
+	communityInFlight      bool
 	manualCheckLock        sync.RWMutex
 	lastManualLicenseCheck time.Time
 }
@@ -38,8 +53,11 @@ const (
 	manualCheckCoolDown     = 5 * time.Minute
 )
 
-func NewLicenseHandler(licenseProvider *license.Provider) *LicenseHandler {
-	return &LicenseHandler{licenseProvider: licenseProvider}
+func NewLicenseHandler(licenseProvider LicenseProvider, communityIssuer upgrade.CommunityLicenseIssuer) *LicenseHandler {
+	return &LicenseHandler{
+		licenseProvider: licenseProvider,
+		communityIssuer: communityIssuer,
+	}
 }
 
 func (h *LicenseHandler) Get(req api.Context) error {

--- a/pkg/api/handlers/license_test.go
+++ b/pkg/api/handlers/license_test.go
@@ -65,7 +65,7 @@ func TestDisplayLicenseKey(t *testing.T) {
 func TestCheckLicenseCooldown(t *testing.T) {
 	t.Parallel()
 
-	handler := NewLicenseHandler(nil)
+	handler := NewLicenseHandler(nil, nil)
 	handler.lastManualLicenseCheck = time.Now()
 
 	recorder := httptest.NewRecorder()

--- a/pkg/api/handlers/version.go
+++ b/pkg/api/handlers/version.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,14 +12,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/license"
 	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/obot-platform/obot/pkg/storage"
+	"github.com/obot-platform/obot/pkg/upgrade"
 	"github.com/obot-platform/obot/pkg/version"
-	"gorm.io/gorm"
 )
 
 type SessionStore string
@@ -29,9 +27,7 @@ const (
 	SessionStoreDB     SessionStore = "db"
 	SessionStoreCookie SessionStore = "cookie"
 
-	installationIDPropertyKey   = "installation_id"
-	defaultUpgradeServerBaseURL = "https://upgrade-server.obot.ai"
-	updateCheckInterval         = 24 * time.Hour
+	updateCheckInterval = 24 * time.Hour
 )
 
 func sessionStoreFromPostgresDSN(postgresDSN string) SessionStore {
@@ -69,15 +65,10 @@ type VersionHandler struct {
 }
 
 func NewVersionHandler(ctx context.Context, opts VersionHandlerOptions) (*VersionHandler, error) {
-	upgradeServerBaseURL := defaultUpgradeServerBaseURL
-	if os.Getenv("OBOT_UPGRADE_SERVER_URL") != "" {
-		upgradeServerBaseURL = os.Getenv("OBOT_UPGRADE_SERVER_URL")
-	}
-
 	v := &VersionHandler{
 		VersionHandlerOptions: opts,
 		sessionStore:          sessionStoreFromPostgresDSN(opts.PostgresDSN),
-		upgradeServerURL:      fmt.Sprintf("%s/check-upgrade", upgradeServerBaseURL),
+		upgradeServerURL:      upgrade.EndpointURL(upgrade.ServerBaseURL(), "check-upgrade"),
 	}
 
 	currentVersion, _, _ := strings.Cut(version.Get().String(), "+")
@@ -85,17 +76,12 @@ func NewVersionHandler(ctx context.Context, opts VersionHandlerOptions) (*Versio
 
 	// Don't start the upgrade check if explicitly disabled or if this is a development version.
 	if !opts.DisableUpdateCheck && (!strings.HasPrefix(currentVersion, "v0.0.0") || os.Getenv("OBOT_FORCE_UPGRADE_CHECK") == "true") {
-		p, err := opts.GatewayClient.GetProperty(ctx, installationIDPropertyKey)
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			p, err = opts.GatewayClient.SetProperty(ctx, installationIDPropertyKey, uuid.NewString())
-			if err != nil {
-				return nil, fmt.Errorf("failed to set installation ID property: %w", err)
-			}
-		} else if err != nil {
-			return nil, fmt.Errorf("failed to get installation ID property: %w", err)
+		installationID, err := upgrade.GetInstallationID(ctx, opts.GatewayClient)
+		if err != nil {
+			return nil, err
 		}
 
-		go v.startUpgradeCheck(ctx, p.Value, currentVersion, opts.Engine)
+		go v.startUpgradeCheck(ctx, installationID, currentVersion, opts.Engine)
 	}
 
 	return v, nil

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/obot-platform/obot/pkg/api/handlers/wellknown"
 	"github.com/obot-platform/obot/pkg/services"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/upgrade"
 	"github.com/obot-platform/obot/ui"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -119,7 +120,8 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	oauthClients := handlers.NewOAuthClientsHandler(services.OAuthServerConfig, services.ServerURL)
 	publishedArtifacts := handlers.NewPublishedArtifactHandler(services.ArtifactBlobStore, services.ArtifactBlobBucket)
 	imagePullSecretsHandler := handlers.NewImagePullSecretHandler(services.MCPRuntimeBackend, services.MCPImagePullSecrets, services.MCPServerNamespace, services.ServiceNamespace, services.ServiceAccountName, services.LocalK8sClient, services.ServiceAccountIssuerURL, services.ServiceAccountIssuerError)
-	licenseHandler := handlers.NewLicenseHandler(services.LicenseProvider)
+	communityLicenseIssuer := upgrade.NewCommunityLicenseIssuer(services.GatewayClient, upgrade.ServerBaseURL(), http.DefaultClient)
+	licenseHandler := handlers.NewLicenseHandler(services.LicenseProvider, communityLicenseIssuer)
 
 	enforcement, err := handlers.NewEnforcementHandler(services.ServerURL)
 	if err != nil {
@@ -133,6 +135,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mux.HandleFunc("GET /api/license", licenseHandler.Get)
 	mux.HandleFunc("PUT /api/license", licenseHandler.Update)
 	mux.HandleFunc("POST /api/license", licenseHandler.CheckLicense)
+	mux.HandleFunc("POST /api/license/community", licenseHandler.CreateCommunityLicense)
 	mux.HandleFunc("DELETE /api/license", licenseHandler.Delete)
 
 	// MCP Catalog Entries (user routes to access single-user and remote MCP servers from all sources)

--- a/pkg/jwt/persistent/persistent.go
+++ b/pkg/jwt/persistent/persistent.go
@@ -145,6 +145,9 @@ type TokenContext struct {
 
 	MCPID string
 
+	// This is used for requesting community license
+	InstallationID string `json:"installation_id,omitempty"`
+
 	// The following fields are for runs
 	Namespace     string
 	ModelProvider string
@@ -347,6 +350,9 @@ func (t *TokenService) NewToken(ctx context.Context, context TokenContext) (*jwt
 		context.Picture = ""
 	}
 	context.Issuer = t.serverURL
+	if context.IssuedAt.IsZero() {
+		context.IssuedAt = NewTime(time.Now().Add(-time.Second))
+	}
 
 	t.lock.RLock()
 	privateKey := t.privateKey

--- a/pkg/upgrade/client.go
+++ b/pkg/upgrade/client.go
@@ -1,0 +1,43 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+const (
+	DefaultServerBaseURL      = "https://upgrade-server.obot.ai"
+	InstallationIDPropertyKey = "installation_id"
+)
+
+type propertyClient interface {
+	GetOrCreateProperty(context.Context, string, string) (gatewaytypes.Property, error)
+}
+
+func ServerBaseURL() string {
+	if baseURL := strings.TrimSpace(os.Getenv("OBOT_UPGRADE_SERVER_URL")); baseURL != "" {
+		return baseURL
+	}
+	return DefaultServerBaseURL
+}
+
+func EndpointURL(baseURL, endpoint string) string {
+	return strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(endpoint, "/")
+}
+
+func GetInstallationID(ctx context.Context, gatewayClient propertyClient) (string, error) {
+	if gatewayClient == nil {
+		return "", fmt.Errorf("gateway client is required")
+	}
+
+	property, err := gatewayClient.GetOrCreateProperty(ctx, InstallationIDPropertyKey, uuid.NewString())
+	if err != nil {
+		return "", fmt.Errorf("failed to ensure installation ID: %w", err)
+	}
+	return property.Value, nil
+}

--- a/pkg/upgrade/community.go
+++ b/pkg/upgrade/community.go
@@ -1,0 +1,153 @@
+package upgrade
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	communityLicenseEndpoint         = "community-license"
+	communityLicenseRequestTimeout   = 10 * time.Second
+	communityLicenseTokenLifetime    = 5 * time.Minute
+	maxCommunityLicenseResponseBytes = 64 * 1024
+)
+
+var (
+	ErrCommunityLicenseRequest  = errors.New("community license request failed")
+	ErrCommunityLicenseResponse = errors.New("community license response was invalid")
+)
+
+type CommunityLicenseRequest struct {
+	Name           string `json:"name"`
+	Email          string `json:"email"`
+	Company        string `json:"company,omitempty"`
+	InstallationID string `json:"installationId"`
+}
+
+type CommunityLicenseIssuer interface {
+	Issue(context.Context, CommunityLicenseRequest) (string, error)
+}
+
+type CommunityLicenseClient struct {
+	gatewayClient propertyClient
+	httpClient    *http.Client
+	issueURL      string
+}
+
+type communityLicenseResponse struct {
+	LicenseKey string `json:"licenseKey"`
+}
+
+type sanitizedError struct {
+	public error
+	cause  error
+}
+
+func (e *sanitizedError) Error() string {
+	return e.public.Error()
+}
+
+func (e *sanitizedError) Unwrap() []error {
+	if e.cause == nil {
+		return []error{e.public}
+	}
+	return []error{e.public, e.cause}
+}
+
+func NewCommunityLicenseIssuer(gatewayClient propertyClient, baseURL string, httpClient *http.Client) *CommunityLicenseClient {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &CommunityLicenseClient{
+		gatewayClient: gatewayClient,
+		httpClient:    httpClient,
+		issueURL:      EndpointURL(baseURL, communityLicenseEndpoint),
+	}
+}
+
+func (c *CommunityLicenseClient) Issue(ctx context.Context, request CommunityLicenseRequest) (string, error) {
+	installationID, err := GetInstallationID(ctx, c.gatewayClient)
+	if err != nil {
+		return "", requestError(err)
+	}
+
+	request.Name = strings.TrimSpace(request.Name)
+	request.Email = strings.TrimSpace(request.Email)
+	request.Company = strings.TrimSpace(request.Company)
+	request.InstallationID = installationID
+
+	body, err := json.Marshal(request)
+	if err != nil {
+		return "", requestError(err)
+	}
+
+	requestContext, cancel := context.WithTimeout(ctx, communityLicenseRequestTimeout)
+	defer cancel()
+
+	httpRequest, err := http.NewRequestWithContext(requestContext, http.MethodPost, c.issueURL, bytes.NewReader(body))
+	if err != nil {
+		return "", requestError(err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+
+	response, err := c.httpClient.Do(httpRequest)
+	if err != nil {
+		return "", requestError(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return "", requestError(fmt.Errorf("non-OK status code: %d", response.StatusCode))
+	}
+
+	limitedBody := io.LimitReader(response.Body, maxCommunityLicenseResponseBytes+1)
+	responseBody, err := io.ReadAll(limitedBody)
+	if err != nil {
+		return "", responseError(err)
+	}
+	if len(responseBody) > maxCommunityLicenseResponseBytes {
+		return "", responseError(fmt.Errorf("response body too large: %d", len(responseBody)))
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(responseBody))
+	decoder.DisallowUnknownFields()
+	var result communityLicenseResponse
+	if err := decoder.Decode(&result); err != nil {
+		return "", responseError(err)
+	}
+	if err := ensureJSONEnd(decoder); err != nil {
+		return "", responseError(err)
+	}
+
+	result.LicenseKey = strings.TrimSpace(result.LicenseKey)
+	if result.LicenseKey == "" {
+		return "", responseError(fmt.Errorf("license key is empty"))
+	}
+	return result.LicenseKey, nil
+}
+
+func ensureJSONEnd(decoder *json.Decoder) error {
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("unexpected trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func requestError(cause error) error {
+	return &sanitizedError{public: ErrCommunityLicenseRequest, cause: cause}
+}
+
+func responseError(cause error) error {
+	return &sanitizedError{public: ErrCommunityLicenseResponse, cause: cause}
+}

--- a/pkg/upgrade/community_test.go
+++ b/pkg/upgrade/community_test.go
@@ -1,0 +1,216 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+type testPropertyClient struct {
+	lock  sync.Mutex
+	value string
+	calls int
+	err   error
+}
+
+func (c *testPropertyClient) GetOrCreateProperty(_ context.Context, key, value string) (gatewaytypes.Property, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.calls++
+	if c.err != nil {
+		return gatewaytypes.Property{}, c.err
+	}
+	if c.value == "" {
+		c.value = value
+	}
+	return gatewaytypes.Property{Key: key, Value: c.value}, nil
+}
+
+func TestServerBaseURLAndEndpointURL(t *testing.T) {
+	t.Setenv("OBOT_UPGRADE_SERVER_URL", " https://upgrade.example.test/root/ ")
+	if got := ServerBaseURL(); got != "https://upgrade.example.test/root/" {
+		t.Fatalf("ServerBaseURL() = %q", got)
+	}
+	if got := EndpointURL(ServerBaseURL(), "/community-license"); got != "https://upgrade.example.test/root/community-license" {
+		t.Fatalf("EndpointURL() = %q", got)
+	}
+
+	t.Setenv("OBOT_UPGRADE_SERVER_URL", "   ")
+	if got := ServerBaseURL(); got != DefaultServerBaseURL {
+		t.Fatalf("ServerBaseURL() = %q, want default", got)
+	}
+}
+
+func TestCommunityLicenseIssue(t *testing.T) {
+	const (
+		issuer         = "https://obot.example.test"
+		installationID = "stable-installation-id"
+		licenseKey     = "keygen/community-secret-key"
+	)
+
+	propertyClient := &testPropertyClient{value: installationID}
+	var requests []CommunityLicenseRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/root/community-license" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q", got)
+		}
+
+		var request CommunityLicenseRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		requests = append(requests, request)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"licenseKey":%q}`, licenseKey)
+	}))
+	defer server.Close()
+
+	client := NewCommunityLicenseIssuer(propertyClient, server.URL+"/root/", server.Client())
+	for _, request := range []CommunityLicenseRequest{
+		{Name: "  Ada Lovelace  ", Email: " ada@example.com ", Company: "   "},
+		{Name: "Grace Hopper", Email: "grace@example.com", Company: "  US Navy  "},
+	} {
+		got, err := client.Issue(t.Context(), request)
+		if err != nil {
+			t.Fatalf("Issue() error = %v", err)
+		}
+		if got != licenseKey {
+			t.Fatalf("Issue() = %q", got)
+		}
+	}
+
+	if propertyClient.calls != 2 {
+		t.Fatalf("installation property calls = %d", propertyClient.calls)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d", len(requests))
+	}
+	if requests[0] != (CommunityLicenseRequest{Name: "Ada Lovelace", Email: "ada@example.com", InstallationID: installationID}) {
+		t.Fatalf("first request = %#v", requests[0])
+	}
+	if requests[1].Company != "US Navy" || requests[1].InstallationID != installationID {
+		t.Fatalf("second request = %#v", requests[1])
+	}
+}
+
+func TestCommunityLicenseIssueFailuresAreSanitized(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantError  error
+	}{
+		{
+			name:       "non-200",
+			statusCode: http.StatusBadRequest,
+			body:       `upstream secret response`,
+			wantError:  ErrCommunityLicenseRequest,
+		},
+		{
+			name:       "malformed JSON",
+			statusCode: http.StatusOK,
+			body:       `{"licenseKey":`,
+			wantError:  ErrCommunityLicenseResponse,
+		},
+		{
+			name:       "unknown response field",
+			statusCode: http.StatusOK,
+			body:       `{"licenseKey":"key","secret":"upstream secret response"}`,
+			wantError:  ErrCommunityLicenseResponse,
+		},
+		{
+			name:       "trailing response",
+			statusCode: http.StatusOK,
+			body:       `{"licenseKey":"key"} {"other":true}`,
+			wantError:  ErrCommunityLicenseResponse,
+		},
+		{
+			name:       "blank key",
+			statusCode: http.StatusOK,
+			body:       `{"licenseKey":"   "}`,
+			wantError:  ErrCommunityLicenseResponse,
+		},
+		{
+			name:       "oversized response",
+			statusCode: http.StatusOK,
+			body:       `{"licenseKey":"` + strings.Repeat("x", maxCommunityLicenseResponseBytes) + `"}`,
+			wantError:  ErrCommunityLicenseResponse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewCommunityLicenseIssuer(&testPropertyClient{value: "installation"}, server.URL, server.Client())
+			_, err := client.Issue(t.Context(), CommunityLicenseRequest{Name: "Sensitive Name", Email: "secret@example.com"})
+			if !errors.Is(err, tt.wantError) {
+				t.Fatalf("Issue() error = %v, want %v", err, tt.wantError)
+			}
+			for _, sensitive := range []string{"upstream secret response", "Sensitive Name", "secret@example.com"} {
+				if strings.Contains(err.Error(), sensitive) {
+					t.Fatalf("error leaked %q: %v", sensitive, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCommunityLicenseIssueCancellationAndTimeout(t *testing.T) {
+	releaseServer := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-releaseServer:
+		}
+	}))
+	defer server.Close()
+	defer close(releaseServer)
+
+	client := NewCommunityLicenseIssuer(&testPropertyClient{value: "installation"}, server.URL, server.Client())
+
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := client.Issue(cancelled, CommunityLicenseRequest{}); !errors.Is(err, context.Canceled) || !errors.Is(err, ErrCommunityLicenseRequest) {
+		t.Fatalf("cancelled Issue() error = %v", err)
+	}
+
+	timedOut, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := client.Issue(timedOut, CommunityLicenseRequest{}); !errors.Is(err, context.DeadlineExceeded) || !errors.Is(err, ErrCommunityLicenseRequest) {
+		t.Fatalf("timed out Issue() error = %v", err)
+	}
+}
+
+func TestCommunityLicenseIssueDependencyFailuresAreSanitized(t *testing.T) {
+	secret := errors.New("sensitive dependency details")
+	propertyClient := &testPropertyClient{err: secret}
+	client := NewCommunityLicenseIssuer(propertyClient, "https://upgrade.test", nil)
+	if _, err := client.Issue(t.Context(), CommunityLicenseRequest{}); !errors.Is(err, ErrCommunityLicenseRequest) || strings.Contains(err.Error(), secret.Error()) {
+		t.Fatalf("property error was not sanitized: %v", err)
+	}
+
+	client = NewCommunityLicenseIssuer(&testPropertyClient{value: "installation"}, "https://upgrade.test", nil)
+	if _, err := client.Issue(t.Context(), CommunityLicenseRequest{}); !errors.Is(err, ErrCommunityLicenseRequest) || strings.Contains(err.Error(), secret.Error()) {
+		t.Fatalf("token error was not sanitized: %v", err)
+	}
+}

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -103,6 +103,7 @@ import type {
 	AppNotificationManifest,
 	License,
 	LicenseManifest,
+	CommunityLicenseEnrollment,
 	LLMAuditLog,
 	LLMAuditLogURLFilters,
 	MDMAsset,
@@ -2086,6 +2087,13 @@ export async function updateLicense(
 	opts?: { fetch?: Fetcher; dontLogErrors?: boolean }
 ): Promise<License> {
 	return (await doPut('/license', manifest, opts)) as License;
+}
+
+export async function createCommunityLicense(
+	enrollment: CommunityLicenseEnrollment,
+	opts?: { fetch?: Fetcher; dontLogErrors?: boolean }
+): Promise<License> {
+	return (await doPost('/license/community', enrollment, opts)) as License;
 }
 
 // MDM configurations

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -574,6 +574,12 @@ export interface LicenseManifest {
 	licenseKey: string;
 }
 
+export interface CommunityLicenseEnrollment {
+	name: string;
+	email: string;
+	company?: string;
+}
+
 // LLM audit logs
 
 export interface LLMAuditLog {

--- a/ui/user/src/routes/admin/license/+page.svelte
+++ b/ui/user/src/routes/admin/license/+page.svelte
@@ -5,6 +5,7 @@
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
 	import SensitiveInput from '$lib/components/SensitiveInput.svelte';
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import { parseErrorContent } from '$lib/errors';
 	import { AdminService } from '$lib/services';
 	import { errors, license as licenseStore, profile } from '$lib/stores';
 	import { CircleAlert, Info, LoaderCircle, RefreshCw } from '@lucide/svelte';
@@ -14,6 +15,7 @@
 
 	let { data } = $props();
 
+	const communityEntitlement = 'OBOT_COMMUNITY_EDITION';
 	const lockedLicenseMessage = 'The license key is locked and cannot be updated.';
 
 	let license = $state(untrack(() => data.license));
@@ -29,6 +31,18 @@
 	let updateError = $state('');
 	let updateLicenseTitle = $derived(license?.licenseKey ? 'Update License Key' : 'Add License Key');
 	let isAdminReadonly = $derived(profile.current.isAdminReadonly?.());
+	let hasValidLicense = $derived(Boolean(license?.enterprise));
+	let isCommunityEdition = $derived(license?.entitlements?.includes(communityEntitlement) ?? false);
+	let showEnterpriseCTA = $derived(!hasValidLicense || isCommunityEdition);
+	let showCommunityEnrollment = $derived(
+		Boolean(license && !hasValidLicense && !license.locked && !isAdminReadonly)
+	);
+
+	let communityName = $state('');
+	let communityEmail = $state('');
+	let communityCompany = $state('');
+	let communitySaving = $state(false);
+	let communityError = $state('');
 	let manualCheckAvailableAt = $derived(
 		license?.manualCheckAvailableAt ? new Date(license.manualCheckAvailableAt).getTime() : 0
 	);
@@ -92,6 +106,30 @@
 		}
 	}
 
+	async function handleCommunitySubmit(event: SubmitEvent) {
+		event.preventDefault();
+		if (communitySaving) return;
+
+		communitySaving = true;
+		communityError = '';
+		try {
+			await AdminService.createCommunityLicense(
+				{
+					name: communityName.trim(),
+					email: communityEmail.trim(),
+					company: communityCompany.trim() || undefined
+				},
+				{ dontLogErrors: true }
+			);
+			window.location.reload();
+		} catch (err) {
+			communityError =
+				parseErrorContent(err).message || 'Failed to obtain a Community Edition license.';
+		} finally {
+			communitySaving = false;
+		}
+	}
+
 	function formatCooldown(ms: number) {
 		if (ms <= 0) return '';
 
@@ -105,6 +143,8 @@
 	function convertUserFriendlyEntitlements(entitlements: string[]): string[] {
 		return entitlements.map((entitlement) => {
 			switch (entitlement) {
+				case communityEntitlement:
+					return 'Community Edition';
 				case 'OBOT_ENTERPRISE_AUTH_PROVIDERS':
 					return 'Auth Providers';
 				case 'OBOT_ENTERPRISE_MODEL_PROVIDERS':
@@ -121,19 +161,20 @@
 <Layout title="License">
 	<div class="h-full w-full" in:fade={{ duration }} out:fade={{ duration }}>
 		<div class="flex flex-col gap-4">
-			{#if license && !license.licenseKey}
+			{#if showEnterpriseCTA}
 				<div class="notification-info p-3 text-sm font-light">
 					<div class="flex items-center gap-3">
 						<Info class="size-6" />
 						<div>
-							Interested in purchasing a license or want to learn more? Contact support at <a
-								href="mailto:info@obot.ai"
-								class="text-link">info@obot.ai</a
+							Ready for advanced features and support? <a
+								href="https://obot.ai/contact-us/"
+								class="text-link">Contact us to upgrade to Enterprise Edition</a
 							>.
 						</div>
 					</div>
 				</div>
-			{:else if license && license.licenseKey && !license.enterprise}
+			{/if}
+			{#if license && license.licenseKey && !license.enterprise}
 				<div class="notification-alert p-3 text-sm font-light">
 					<div class="flex items-center gap-3">
 						<CircleAlert class="size-6" />
@@ -154,6 +195,73 @@
 						</div>
 					</div>
 				</div>
+			{/if}
+
+			{#if showCommunityEnrollment}
+				<form class="paper flex flex-col gap-4" onsubmit={handleCommunitySubmit}>
+					<div class="flex flex-col gap-1">
+						<h2 class="text-xl font-semibold">Get Community Edition</h2>
+						<p class="text-muted-content text-sm font-light">
+							Register this installation for a free Community Edition license.
+						</p>
+					</div>
+
+					<div class="grid gap-4 md:grid-cols-2">
+						<label class="flex flex-col gap-1 text-sm font-light" for="community-name">
+							Name
+							<input
+								id="community-name"
+								class="text-input-filled"
+								name="name"
+								type="text"
+								autocomplete="name"
+								bind:value={communityName}
+								required
+							/>
+						</label>
+
+						<label class="flex flex-col gap-1 text-sm font-light" for="community-email">
+							Email
+							<input
+								id="community-email"
+								class="text-input-filled"
+								name="email"
+								type="email"
+								autocomplete="email"
+								bind:value={communityEmail}
+								required
+							/>
+						</label>
+
+						<label
+							class="flex flex-col gap-1 text-sm font-light md:col-span-2"
+							for="community-company"
+						>
+							Company <span class="text-muted-content text-xs">(optional)</span>
+							<input
+								id="community-company"
+								class="text-input-filled"
+								name="company"
+								type="text"
+								autocomplete="organization"
+								bind:value={communityCompany}
+							/>
+						</label>
+					</div>
+
+					{#if communityError}
+						<div in:slide={{ duration: 150, axis: 'y' }} class="alert alert-error alert-soft">
+							{communityError}
+						</div>
+					{/if}
+
+					<button class="btn btn-primary w-full sm:w-fit" type="submit" disabled={communitySaving}>
+						{#if communitySaving}
+							<LoaderCircle class="size-4 animate-spin" />
+						{/if}
+						{communitySaving ? 'Getting Community License...' : 'Get Community License'}
+					</button>
+				</form>
 			{/if}
 			<div class="paper flex flex-col gap-6">
 				{#if license}


### PR DESCRIPTION
This change allows users to request a community edition key from the upgrade server. By submitting their name, email, and, optionally, company name, Obot will make a request to the upgrade server to get a license. If a license is returned succesfully, then Obot will persist it.

Issue: https://github.com/obot-platform/obot/issues/7290