### PR TITLE
feat: add support for user limits

### DIFF
--- a/pkg/api/authn/noauth.go
+++ b/pkg/api/authn/noauth.go
@@ -30,6 +30,9 @@ func (n *NoAuth) AuthenticateRequest(req *http.Request) (*authenticator.Response
 		},
 		req.Header.Get("X-Obot-User-Timezone"),
 		types2.RoleOwner|types2.RoleAuditor,
+		// Pass unlimited user limit because we always need to ensure this user is created.
+		// This user will only exist for unauthenticated setups.
+		client.UserLimit{Unlimited: true},
 	)
 	if err != nil {
 		return nil, false, err

--- a/pkg/api/authz/ui_test.go
+++ b/pkg/api/authz/ui_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/system"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -38,7 +39,7 @@ func TestCheckUI_V2AdminAccess(t *testing.T) {
 			name: "bootstrap user can access /admin/auth-providers",
 			path: "/admin/auth-providers",
 			user: &user.DefaultInfo{
-				Name:   "bootstrap",
+				Name:   system.BootstrapName,
 				Groups: types.RoleOwner.Groups(),
 			},
 			expected: true,

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -592,7 +592,7 @@ func (h *handler) oauthCallback(req api.Context) error {
 
 	authProviderName, authProviderNamespace := req.AuthProviderNameAndNamespace()
 
-	if !req.UserIsAuthenticated() || req.User.GetName() == "bootstrap" || authProviderName == "bootstrap" || authProviderNamespace == "bootstrap" {
+	if !req.UserIsAuthenticated() || req.User.GetName() == system.BootstrapName || authProviderName == system.BootstrapName || authProviderNamespace == system.BootstrapName {
 		// The user is either not authenticated or is authenticated as the bootstrap user.
 		log.Infof("Denied MCP OAuth callback because user is not authenticated with a non-bootstrap identity: authRequest=%s", oauthAppAuthRequest.Name)
 		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
@@ -631,9 +631,9 @@ func (h *handler) oauthCallback(req api.Context) error {
 func authenticatedOAuthUser(req api.Context, oauthAppAuthRequest v1.OAuthAuthRequest, phase string) (authProviderName, authProviderNamespace string, ok bool) {
 	authProviderName, authProviderNamespace = req.AuthProviderNameAndNamespace()
 	if req.UserIsAuthenticated() &&
-		req.User.GetName() != "bootstrap" &&
-		authProviderName != "bootstrap" &&
-		authProviderNamespace != "bootstrap" {
+		req.User.GetName() != system.BootstrapName &&
+		authProviderName != system.BootstrapName &&
+		authProviderNamespace != system.BootstrapName {
 		return authProviderName, authProviderNamespace, true
 	}
 

--- a/pkg/api/handlers/setup/handler.go
+++ b/pkg/api/handlers/setup/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/bootstrap"
+	"github.com/obot-platform/obot/pkg/system"
 )
 
 type Handler struct {
@@ -25,7 +26,7 @@ func NewHandler(serverURL string, bootstrapEnabler *bootstrap.Bootstrap) *Handle
 // Returns an error if not authenticated as bootstrap.
 func (h *Handler) requireBootstrap(req api.Context) error {
 	// Check if user is bootstrap user
-	if req.User.GetName() != "bootstrap" {
+	if req.User.GetName() != system.BootstrapName {
 		log.Infof("Denied setup endpoint for non-bootstrap user")
 		return types.NewErrHTTP(http.StatusForbidden,
 			"this endpoint requires bootstrap authentication")

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -125,12 +125,11 @@ func (s *Server) Wrap(f api.HandlerFunc) http.HandlerFunc {
 				return
 			}
 
-			http.Error(rw, err.Error(), http.StatusUnauthorized)
-
 			// Check if this is a FetchUserGroupsError which indicates an auth provider configuration issue
-			var fetchGroupsErr *gclient.FetchUserGroupsError
-			if errors.As(err, &fetchGroupsErr) {
-				http.Error(rw, fmt.Sprintf("Authentication provider configuration error: %s. Please contact an administrator to fix the auth provider configuration.", err.Error()), http.StatusInternalServerError)
+			if fetchGroupsErr, ok := errors.AsType[*gclient.FetchUserGroupsError](err); ok {
+				http.Error(rw, fmt.Sprintf("Authentication provider configuration error: %s. Please contact an administrator to fix the auth provider configuration.", fetchGroupsErr.Message), http.StatusInternalServerError)
+			} else {
+				http.Error(rw, err.Error(), http.StatusUnauthorized)
 			}
 
 			return

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -14,14 +14,12 @@ import (
 	"github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/system"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
-const (
-	ObotBootstrapCookie = "obot-bootstrap"
-	bootstrapUsername   = "bootstrap"
-)
+const ObotBootstrapCookie = "obot-bootstrap"
 
 type Bootstrap struct {
 	token, serverURL                  string
@@ -165,12 +163,14 @@ func (b *Bootstrap) AuthenticateRequest(req *http.Request) (*authenticator.Respo
 	gatewayUser, err := b.gatewayClient.EnsureIdentityWithRole(
 		req.Context(),
 		&types.Identity{
-			ProviderUsername:     "bootstrap",
-			ProviderUserID:       "bootstrap",
-			HashedProviderUserID: hash.String("bootstrap"),
+			ProviderUsername:     system.BootstrapName,
+			ProviderUserID:       system.BootstrapName,
+			HashedProviderUserID: hash.String(system.BootstrapName),
 		},
 		req.Header.Get("X-Obot-User-Timezone"),
 		types2.RoleOwner,
+		// Pass unlimited user limit because we always need to ensure the bootstrap user is created.
+		client.UserLimit{Unlimited: true},
 	)
 	if err != nil {
 		return nil, false, err
@@ -178,11 +178,11 @@ func (b *Bootstrap) AuthenticateRequest(req *http.Request) (*authenticator.Respo
 
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
-			Name:   "bootstrap",
+			Name:   system.BootstrapName,
 			UID:    fmt.Sprintf("%d", gatewayUser.ID),
 			Groups: types2.RoleOwner.Groups(),
 			Extra: map[string][]string{
-				"auth_provider_name": {"bootstrap"},
+				"auth_provider_name": {system.BootstrapName},
 			},
 		},
 	}, true, nil
@@ -302,7 +302,7 @@ func (b *Bootstrap) setupEnabled(ctx context.Context) (bool, error) {
 	}
 
 	for _, u := range ownerUsers {
-		if u.Username == bootstrapUsername || u.Email == "" {
+		if u.Username == system.BootstrapName || u.Email == "" {
 			continue
 		}
 

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -74,7 +74,7 @@ func ensureOwner(t *testing.T, c *client.Client, username, email, authProviderNa
 		AuthProviderNamespace: "default",
 		ProviderUsername:      username,
 		ProviderUserID:        username,
-	}, "", types2.RoleOwner); err != nil {
+	}, "", types2.RoleOwner, client.UserLimit{Unlimited: true}); err != nil {
 		t.Fatalf("failed to ensure owner identity: %v", err)
 	}
 }

--- a/pkg/gateway/client/apiactivity.go
+++ b/pkg/gateway/client/apiactivity.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
 )
 
@@ -35,7 +36,7 @@ func (c *Client) ActiveUsersByDate(ctx context.Context, start, end time.Time) ([
 		if err := tx.Model(new(types.APIActivity)).
 			Distinct("user_id").
 			Where("date >= ? AND date < ?", start, end).
-			Where("user_id != ?", "bootstrap").
+			Where("user_id != ?", system.BootstrapName).
 			Where("user_id != ?", "anonymous").
 			Where("user_id != ?", "").
 			Pluck("user_id", &ids).Error; err != nil {

--- a/pkg/gateway/client/auth.go
+++ b/pkg/gateway/client/auth.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -11,14 +12,16 @@ import (
 )
 
 type UserDecorator struct {
-	next   authenticator.Request
-	client *Client
+	next              authenticator.Request
+	client            *Client
+	userLimitProvider UserLimitProvider
 }
 
-func NewUserDecorator(next authenticator.Request, client *Client) *UserDecorator {
+func NewUserDecorator(next authenticator.Request, client *Client, userLimitProvider UserLimitProvider) *UserDecorator {
 	return &UserDecorator{
-		next:   next,
-		client: client,
+		next:              next,
+		client:            client,
+		userLimitProvider: userLimitProvider,
 	}
 }
 
@@ -42,7 +45,13 @@ func (u UserDecorator) AuthenticateRequest(req *http.Request) (*authenticator.Re
 			ProviderUsername:      resp.User.GetName(),
 			ProviderUserID:        resp.User.GetUID(),
 		}
-		gatewayUser, err = u.client.EnsureIdentity(req.Context(), identity, req.Header.Get("X-Obot-User-Timezone"))
+
+		userLimit, err := u.resolveUserLimit(req.Context())
+		if err != nil {
+			return nil, false, err
+		}
+
+		gatewayUser, err = u.client.EnsureIdentity(req.Context(), identity, req.Header.Get("X-Obot-User-Timezone"), userLimit)
 		if err != nil {
 			return nil, false, err
 		}
@@ -70,4 +79,29 @@ func (u UserDecorator) AuthenticateRequest(req *http.Request) (*authenticator.Re
 		Groups: effectiveRole.Groups(),
 	}
 	return resp, true, nil
+}
+
+func (u UserDecorator) resolveUserLimit(ctx context.Context) (UserLimit, error) {
+	userLimit, err := u.userLimitProvider.UserLimit(ctx)
+	if err != nil {
+		return UserLimit{}, fmt.Errorf("failed to resolve user limit: %w", err)
+	}
+
+	if !userLimit.Unlimited && userLimit.Maximum <= 0 {
+		return UserLimit{}, fmt.Errorf("invalid user limit %d", userLimit.Maximum)
+	}
+
+	return userLimit, nil
+}
+
+// UserLimit describes the maximum number of users an installation may have.
+// Maximum is ignored when Unlimited is true.
+type UserLimit struct {
+	Maximum   int
+	Unlimited bool
+}
+
+// UserLimitProvider resolves the current license-derived user limit.
+type UserLimitProvider interface {
+	UserLimit(context.Context) (UserLimit, error)
 }

--- a/pkg/gateway/client/auth_user_limit_test.go
+++ b/pkg/gateway/client/auth_user_limit_test.go
@@ -1,0 +1,119 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+type userLimitProviderFunc func(context.Context) (UserLimit, error)
+
+func (f userLimitProviderFunc) UserLimit(ctx context.Context) (UserLimit, error) {
+	return f(ctx)
+}
+
+func TestUserDecoratorResolveUserLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		limit   UserLimit
+		wantErr bool
+	}{
+		{
+			name:  "bounded",
+			limit: UserLimit{Maximum: 100},
+		},
+		{
+			name:  "unlimited ignores maximum",
+			limit: UserLimit{Unlimited: true},
+		},
+		{
+			name:    "zero maximum",
+			limit:   UserLimit{},
+			wantErr: true,
+		},
+		{
+			name:    "negative maximum",
+			limit:   UserLimit{Maximum: -1},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decorator := UserDecorator{
+				userLimitProvider: userLimitProviderFunc(func(context.Context) (UserLimit, error) {
+					return tt.limit, nil
+				}),
+			}
+
+			got, err := decorator.resolveUserLimit(t.Context())
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveUserLimit() = %+v, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveUserLimit() error = %v", err)
+			}
+			if got != tt.limit {
+				t.Fatalf("resolveUserLimit() = %+v, want %+v", got, tt.limit)
+			}
+		})
+	}
+}
+
+func TestUserDecoratorDoesNotCreateUserWhenUserLimitProviderFails(t *testing.T) {
+	c := newIdentityUserLimitTestClient(t)
+	providerErr := errors.New("license lookup failed")
+	currentErr := providerErr
+
+	decorator := NewUserDecorator(
+		authenticator.RequestFunc(func(*http.Request) (*authenticator.Response, bool, error) {
+			return &authenticator.Response{
+				User: &user.DefaultInfo{
+					Name: "user-1",
+					UID:  "user-1",
+					Extra: map[string][]string{
+						"email":                   {"user-1@example.com"},
+						"auth_provider_name":      {"test-auth-provider"},
+						"auth_provider_namespace": {"default"},
+					},
+				},
+			}, true, nil
+		}),
+		c,
+		userLimitProviderFunc(func(context.Context) (UserLimit, error) {
+			return UserLimit{Maximum: 1}, currentErr
+		}),
+	)
+
+	_, ok, err := decorator.AuthenticateRequest(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil))
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("error = %v, want %v", err, providerErr)
+	}
+	if ok {
+		t.Fatal("authentication succeeded despite user-limit provider failure")
+	}
+	if got := countIdentityUserLimitTestUsers(t, c, false); got != 0 {
+		t.Fatalf("users = %d, want 0 after provider failure", got)
+	}
+	if got := countIdentityUserLimitTestIdentities(t, c); got != 0 {
+		t.Fatalf("identities = %d, want 0 after provider failure", got)
+	}
+
+	currentErr = nil
+	if _, ok, err := decorator.AuthenticateRequest(httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)); err != nil {
+		t.Fatalf("authenticating after provider recovery: %v", err)
+	} else if !ok {
+		t.Fatal("authentication did not succeed after provider recovery")
+	}
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != 1 {
+		t.Fatalf("users counted toward limit = %d, want 1", got)
+	}
+}

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -19,6 +19,10 @@ import (
 const (
 	defaultAuditLogCleanupInterval = 24 * time.Hour
 	defaultAuditLogDeleteBatchSize = 1000
+
+	// DefaultUserLimit is the maximum number of users allowed when no
+	// license-derived user-limit provider is configured.
+	DefaultUserLimit = 100
 )
 
 type Client struct {

--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strings"
 	"time"
@@ -34,6 +35,8 @@ var (
 		Resource: "identities",
 	}
 )
+
+const userCreationAdvisoryLockID int64 = 0x6f626f7455736572 // "obotUser"
 
 // FindIdentitiesForUser finds all identities for the given user.
 func (c *Client) FindIdentitiesForUser(ctx context.Context, userID uint) ([]types.Identity, error) {
@@ -65,21 +68,22 @@ func (c *Client) UserHasIdentityForAuthProvider(ctx context.Context, userID uint
 }
 
 // EnsureIdentity ensures that the given identity exists in the database, and returns the user associated with it.
-func (c *Client) EnsureIdentity(ctx context.Context, id *types.Identity, timezone string) (*types.User, error) {
-	return c.EnsureIdentityWithRole(ctx, id, timezone, c.emailsWithExplicitRoles[strings.ToLower(id.Email)])
+func (c *Client) EnsureIdentity(ctx context.Context, id *types.Identity, timezone string, userLimit UserLimit) (*types.User, error) {
+	return c.EnsureIdentityWithRole(ctx, id, timezone, c.emailsWithExplicitRoles[strings.ToLower(id.Email)], userLimit)
 }
 
 // EnsureIdentityWithRole ensures the given identity exists in the database with the at least the given role, and returns the user associated with it.
 // If the user already exists with a superset of the given role, it will not be updated.
-func (c *Client) EnsureIdentityWithRole(ctx context.Context, id *types.Identity, timezone string, role types2.Role) (*types.User, error) {
+func (c *Client) EnsureIdentityWithRole(ctx context.Context, id *types.Identity, timezone string, role types2.Role, userLimit UserLimit) (*types.User, error) {
 	var (
 		user    *types.User
 		created bool
 	)
+
 	// Transaction #1: ensure the identity + user rows exist / are corrected, and read what we need.
 	err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var err error
-		user, created, err = c.ensureIdentity(ctx, tx, id, timezone, role)
+		user, created, err = c.ensureIdentity(ctx, tx, id, timezone, role, userLimit)
 		return err
 	})
 	if err != nil {
@@ -146,7 +150,7 @@ func (c *Client) EncryptIdentities(ctx context.Context, force bool) error {
 }
 
 // ensureIdentity ensures that the given identity exists in the database, and returns the user associated with it.
-func (c *Client) ensureIdentity(ctx context.Context, tx *gorm.DB, id *types.Identity, timezone string, role types2.Role) (*types.User, bool, error) {
+func (c *Client) ensureIdentity(ctx context.Context, tx *gorm.DB, id *types.Identity, timezone string, role types2.Role, userLimit UserLimit) (*types.User, bool, error) {
 	verified := slices.Contains(verifiedAuthProviders, fmt.Sprintf("%s/%s", id.AuthProviderNamespace, id.AuthProviderName))
 
 	email := id.Email
@@ -247,7 +251,7 @@ func (c *Client) ensureIdentity(ctx context.Context, tx *gorm.DB, id *types.Iden
 			if err = c.encryptUser(ctx, &u); err != nil {
 				return nil, false, fmt.Errorf("failed to encrypt user: %w", err)
 			}
-			if err = tx.Create(&u).Error; err != nil {
+			if err = c.createUser(tx, &u, userLimit); err != nil {
 				return nil, false, err
 			}
 
@@ -330,7 +334,7 @@ func (c *Client) ensureIdentity(ctx context.Context, tx *gorm.DB, id *types.Iden
 		if err := c.encryptUser(ctx, &u); err != nil {
 			return nil, false, fmt.Errorf("failed to encrypt user: %w", err)
 		}
-		if err := tx.Create(&u).Error; err != nil {
+		if err := c.createUser(tx, &u, userLimit); err != nil {
 			return nil, false, err
 		}
 
@@ -349,6 +353,54 @@ func (c *Client) ensureIdentity(ctx context.Context, tx *gorm.DB, id *types.Iden
 	}
 
 	return user, created, nil
+}
+
+func (c *Client) createUser(tx *gorm.DB, user *types.User, userLimit UserLimit) error {
+	if userLimit.Unlimited {
+		return tx.Create(user).Error
+	}
+
+	if err := lockUserCreation(tx); err != nil {
+		return err
+	}
+
+	userCount, err := countUsersTowardLimit(tx)
+	if err != nil {
+		return fmt.Errorf("failed to count users: %w", err)
+	}
+	if userCount >= int64(userLimit.Maximum) {
+		return newUserLimitError(userLimit.Maximum)
+	}
+
+	return tx.Create(user).Error
+}
+
+func countUsersTowardLimit(tx *gorm.DB) (int64, error) {
+	var userCount int64
+	err := tx.Model(new(types.User)).
+		Where("deleted_at IS NULL").
+		Where("hashed_username != ?", hash.String(system.BootstrapName)).
+		Count(&userCount).Error
+	return userCount, err
+}
+
+func lockUserCreation(tx *gorm.DB) error {
+	// PostgreSQL installations may have multiple Obot replicas, so serialize
+	// all operations that allocate user seats across them. SQLite operations
+	// acquire its write lock before calling this helper.
+	if tx.Name() == "postgres" {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", userCreationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to lock user creation: %w", err)
+		}
+	}
+	return nil
+}
+
+func newUserLimitError(maximum int) error {
+	return types2.NewErrHTTP(
+		http.StatusPaymentRequired,
+		fmt.Sprintf("user limit of %d reached; delete an existing user or install a license that permits additional users", maximum),
+	)
 }
 
 // ensureIdentityProviderData fetches auth-provider data (the provider-native group lookup ID and

--- a/pkg/gateway/client/identity_user_limit_postgres_test.go
+++ b/pkg/gateway/client/identity_user_limit_postgres_test.go
@@ -1,0 +1,235 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	apitypes "github.com/obot-platform/obot/apiclient/types"
+	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	storageservices "github.com/obot-platform/obot/pkg/storage/services"
+	"github.com/obot-platform/obot/pkg/system"
+	"gorm.io/gorm"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const postgresUserLimitTestDSNEnv = "OBOT_TEST_POSTGRES_DSN"
+
+func TestEnsureIdentityWithRoleEnforcesUserLimitAcrossPostgresClients(t *testing.T) {
+	postgresDSN := os.Getenv(postgresUserLimitTestDSNEnv)
+	if postgresDSN == "" {
+		t.Skipf("set %s to a PostgreSQL URL whose user can create schemas", postgresUserLimitTestDSNEnv)
+	}
+
+	adminServices, err := storageservices.New(storageservices.Config{DSN: postgresDSN})
+	if err != nil {
+		t.Fatalf("opening PostgreSQL admin connection: %v", err)
+	}
+
+	schema := "obot_user_limit_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	if err := adminServices.DB.DB.Exec("CREATE SCHEMA " + schema).Error; err != nil {
+		_ = adminServices.DB.SQLDB.Close()
+		t.Fatalf("creating isolated PostgreSQL schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := adminServices.DB.DB.Exec("DROP SCHEMA " + schema + " CASCADE").Error; err != nil {
+			t.Errorf("dropping isolated PostgreSQL schema: %v", err)
+		}
+		if err := adminServices.DB.SQLDB.Close(); err != nil {
+			t.Errorf("closing PostgreSQL admin connection: %v", err)
+		}
+	})
+
+	scopedDSN := postgresUserLimitTestDSN(t, postgresDSN, schema)
+	dbA := newPostgresUserLimitTestDB(t, scopedDSN)
+	dbB := newPostgresUserLimitTestDB(t, scopedDSN)
+	if err := dbA.WithContext(t.Context()).AutoMigrate(&gatewaytypes.User{}, &gatewaytypes.Identity{}); err != nil {
+		t.Fatalf("migrating PostgreSQL user-limit tables: %v", err)
+	}
+
+	const maximum = 1
+	userLimit := UserLimit{Maximum: maximum}
+	clientA := newPostgresUserLimitTestClient(dbA)
+	clientB := newPostgresUserLimitTestClient(dbB)
+
+	// Hold the production advisory lock so both independent gateway clients have
+	// to reach and wait on it before either can perform the count-and-create.
+	lockTx := adminServices.DB.DB.WithContext(t.Context()).Begin()
+	if lockTx.Error != nil {
+		t.Fatalf("starting advisory-lock transaction: %v", lockTx.Error)
+	}
+	lockHeld := true
+	defer func() {
+		if lockHeld {
+			_ = lockTx.Rollback().Error
+		}
+	}()
+	if err := lockTx.Exec("SELECT pg_advisory_xact_lock(?)", userCreationAdvisoryLockID).Error; err != nil {
+		t.Fatalf("holding user-creation advisory lock: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	for i, c := range []*Client{clientA, clientB} {
+		go func(i int, c *Client) {
+			<-start
+			username := fmt.Sprintf("postgres-concurrent-user-%d", i)
+			_, err := ensureUserLimitTestIdentity(ctx, c, username, username+"@example.com", userLimit)
+			results <- err
+		}(i, c)
+	}
+	close(start)
+
+	if err := waitForPostgresUserLimitLockWaiters(ctx, adminServices.DB.DB, 2); err != nil {
+		t.Fatalf("waiting for both gateway clients to contend on the advisory lock: %v", err)
+	}
+
+	if err := lockTx.Commit().Error; err != nil {
+		t.Fatalf("releasing user-creation advisory lock: %v", err)
+	}
+	lockHeld = false
+
+	var (
+		succeeded int
+		rejected  int
+		rejectErr error
+	)
+	for range 2 {
+		select {
+		case err := <-results:
+			if err == nil {
+				succeeded++
+				continue
+			}
+
+			var httpErr *apitypes.ErrHTTP
+			if errors.As(err, &httpErr) && httpErr.Code == http.StatusPaymentRequired {
+				rejected++
+				rejectErr = err
+				continue
+			}
+			t.Fatalf("concurrent PostgreSQL user creation returned unexpected error: %v", err)
+		case <-ctx.Done():
+			t.Fatalf("concurrent PostgreSQL user creation did not finish: %v", ctx.Err())
+		}
+	}
+
+	if succeeded != maximum {
+		t.Fatalf("successful concurrent PostgreSQL creations = %d, want %d", succeeded, maximum)
+	}
+	if rejected != 1 {
+		t.Fatalf("rejected concurrent PostgreSQL creations = %d, want 1", rejected)
+	}
+	requireIdentityUserLimitPaymentError(t, rejectErr, maximum)
+	if got := countIdentityUserLimitTestUsers(t, clientA, true); got != maximum {
+		t.Fatalf("users counted toward limit = %d, want %d", got, maximum)
+	}
+	if got := countIdentityUserLimitTestIdentities(t, clientA); got != maximum {
+		t.Fatalf("identities = %d, want %d; rejected identity was not rolled back", got, maximum)
+	}
+}
+
+func postgresUserLimitTestDSN(t *testing.T, dsn, schema string) string {
+	t.Helper()
+
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", postgresUserLimitTestDSNEnv, err)
+	}
+	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
+		t.Fatalf("%s must use a postgres:// or postgresql:// URL", postgresUserLimitTestDSNEnv)
+	}
+
+	query := u.Query()
+	query.Set("search_path", schema)
+	u.RawQuery = query.Encode()
+	return u.String()
+}
+
+func newPostgresUserLimitTestDB(t *testing.T, dsn string) *gatewaydb.DB {
+	t.Helper()
+
+	services, err := storageservices.New(storageservices.Config{DSN: dsn})
+	if err != nil {
+		t.Fatalf("opening scoped PostgreSQL connection: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := services.DB.SQLDB.Close(); err != nil {
+			t.Errorf("closing scoped PostgreSQL connection: %v", err)
+		}
+	})
+
+	database, err := gatewaydb.New(services.DB.DB, services.DB.SQLDB, false)
+	if err != nil {
+		t.Fatalf("creating gateway PostgreSQL database: %v", err)
+	}
+	return database
+}
+
+func newPostgresUserLimitTestClient(database *gatewaydb.DB) *Client {
+	storageClient := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(&v1.UserDefaultRoleSetting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.DefaultNamespace,
+				Name:      system.DefaultRoleSettingName,
+			},
+			Spec: v1.UserDefaultRoleSettingSpec{
+				Role: apitypes.RoleBasic,
+			},
+		}).
+		Build()
+
+	return &Client{
+		db:            database,
+		storageClient: storageClient,
+	}
+}
+
+func waitForPostgresUserLimitLockWaiters(ctx context.Context, db *gorm.DB, want int64) error {
+	const pollInterval = 10 * time.Millisecond
+
+	lockClassID := uint64(userCreationAdvisoryLockID) >> 32
+	lockObjectID := uint64(userCreationAdvisoryLockID) & 0xffffffff
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		var waiters int64
+		if err := db.WithContext(ctx).Raw(`
+			SELECT COUNT(*)
+			FROM pg_locks
+			WHERE locktype = 'advisory'
+			  AND database = (SELECT oid FROM pg_database WHERE datname = current_database())
+			  AND classid = CAST(? AS oid)
+			  AND objid = CAST(? AS oid)
+			  AND objsubid = 1
+			  AND NOT granted
+		`, lockClassID, lockObjectID).Scan(&waiters).Error; err != nil {
+			return err
+		}
+		if waiters == want {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("found %d of %d lock waiters: %w", waiters, want, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}

--- a/pkg/gateway/client/identity_user_limit_test.go
+++ b/pkg/gateway/client/identity_user_limit_test.go
@@ -1,0 +1,372 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	apitypes "github.com/obot-platform/obot/apiclient/types"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newIdentityUserLimitTestClient(t *testing.T) *Client {
+	t.Helper()
+
+	c := newTestClient(t)
+	c.storageClient = fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(&v1.UserDefaultRoleSetting{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.DefaultNamespace,
+				Name:      system.DefaultRoleSettingName,
+			},
+			Spec: v1.UserDefaultRoleSettingSpec{
+				Role: apitypes.RoleBasic,
+			},
+		}).
+		Build()
+	return c
+}
+
+func ensureUserLimitTestIdentity(ctx context.Context, c *Client, username, email string, userLimit UserLimit) (*gatewaytypes.User, error) {
+	return c.EnsureIdentityWithRole(ctx, &gatewaytypes.Identity{
+		ProviderUsername: username,
+		ProviderUserID:   username,
+		Email:            email,
+	}, "", apitypes.RoleBasic, userLimit)
+}
+
+func countIdentityUserLimitTestUsers(t *testing.T, c *Client, countableOnly bool) int64 {
+	t.Helper()
+
+	if countableOnly {
+		count, err := countUsersTowardLimit(c.db.WithContext(t.Context()))
+		if err != nil {
+			t.Fatalf("failed to count users toward limit: %v", err)
+		}
+		return count
+	}
+
+	var count int64
+	if err := c.db.WithContext(t.Context()).Model(new(gatewaytypes.User)).Count(&count).Error; err != nil {
+		t.Fatalf("failed to count users: %v", err)
+	}
+	return count
+}
+
+func countIdentityUserLimitTestIdentities(t *testing.T, c *Client) int64 {
+	t.Helper()
+
+	var count int64
+	if err := c.db.WithContext(t.Context()).Model(new(gatewaytypes.Identity)).Count(&count).Error; err != nil {
+		t.Fatalf("failed to count identities: %v", err)
+	}
+	return count
+}
+
+func countIdentityUserLimitTestLocalAuthUsers(t *testing.T, c *Client) int64 {
+	t.Helper()
+
+	var count int64
+	if err := c.db.WithContext(t.Context()).Model(new(gatewaytypes.LocalAuthUser)).Count(&count).Error; err != nil {
+		t.Fatalf("failed to count local auth users: %v", err)
+	}
+	return count
+}
+
+func requireIdentityUserLimitPaymentError(t *testing.T, err error, maximum int) {
+	t.Helper()
+
+	var httpErr *apitypes.ErrHTTP
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error = %T %v, want *types.ErrHTTP", err, err)
+	}
+	if httpErr.Code != http.StatusPaymentRequired {
+		t.Fatalf("HTTP status = %d, want %d", httpErr.Code, http.StatusPaymentRequired)
+	}
+
+	message := strings.ToLower(httpErr.Message)
+	if !strings.Contains(message, "user") || !strings.Contains(message, "limit") || !strings.Contains(message, strconv.Itoa(maximum)) {
+		t.Fatalf("error message %q does not describe the user limit of %d", httpErr.Message, maximum)
+	}
+}
+
+func TestEnsureIdentityWithRoleEnforcesUserLimit(t *testing.T) {
+	const maximum = 2
+	c := newIdentityUserLimitTestClient(t)
+	userLimit := UserLimit{Maximum: maximum}
+
+	for i := 1; i <= maximum; i++ {
+		username := fmt.Sprintf("user-%d", i)
+		if _, err := ensureUserLimitTestIdentity(t.Context(), c, username, username+"@example.com", userLimit); err != nil {
+			t.Fatalf("creating user %d: %v", i, err)
+		}
+	}
+
+	_, err := ensureUserLimitTestIdentity(t.Context(), c, "user-3", "user-3@example.com", userLimit)
+	requireIdentityUserLimitPaymentError(t, err, maximum)
+
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != maximum {
+		t.Fatalf("users counted toward limit = %d, want %d", got, maximum)
+	}
+	if got := countIdentityUserLimitTestIdentities(t, c); got != maximum {
+		t.Fatalf("identities = %d, want %d; rejected identity was not rolled back", got, maximum)
+	}
+}
+
+func TestEnsureIdentityWithRoleAllowsExistingUserWhenOverLimit(t *testing.T) {
+	limit := UserLimit{Unlimited: true}
+	c := newIdentityUserLimitTestClient(t)
+
+	var thirdUser *gatewaytypes.User
+	for i := 1; i <= 3; i++ {
+		username := fmt.Sprintf("user-%d", i)
+		user, err := ensureUserLimitTestIdentity(t.Context(), c, username, username+"@example.com", limit)
+		if err != nil {
+			t.Fatalf("creating user %d: %v", i, err)
+		}
+		if i == 3 {
+			thirdUser = user
+		}
+	}
+
+	limit = UserLimit{Maximum: 2}
+
+	existing, err := ensureUserLimitTestIdentity(t.Context(), c, "user-3", "user-3@example.com", limit)
+	if err != nil {
+		t.Fatalf("ensuring an existing user while over limit: %v", err)
+	}
+	if existing.ID != thirdUser.ID {
+		t.Fatalf("existing user ID = %d, want %d", existing.ID, thirdUser.ID)
+	}
+
+	_, err = ensureUserLimitTestIdentity(t.Context(), c, "user-4", "user-4@example.com", limit)
+	requireIdentityUserLimitPaymentError(t, err, limit.Maximum)
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != 3 {
+		t.Fatalf("users counted toward limit = %d, want 3", got)
+	}
+}
+
+func TestEnsureIdentityWithRoleAllowsVerifiedIdentityForExistingUserAtLimit(t *testing.T) {
+	limit := UserLimit{Unlimited: true}
+	c := newIdentityUserLimitTestClient(t)
+
+	googleIdentity := &gatewaytypes.Identity{
+		AuthProviderNamespace: "default",
+		AuthProviderName:      "google-auth-provider",
+		ProviderUsername:      "google-user",
+		ProviderUserID:        "google-user",
+		Email:                 "same-user@example.com",
+	}
+	first, err := c.EnsureIdentityWithRole(t.Context(), googleIdentity, "", apitypes.RoleBasic, limit)
+	if err != nil {
+		t.Fatalf("creating user through first verified provider: %v", err)
+	}
+
+	limit = UserLimit{Maximum: 1}
+	githubIdentity := &gatewaytypes.Identity{
+		AuthProviderNamespace: "default",
+		AuthProviderName:      "github-auth-provider",
+		ProviderUsername:      "github-user",
+		ProviderUserID:        "github-user",
+		Email:                 "same-user@example.com",
+	}
+	existing, err := c.EnsureIdentityWithRole(t.Context(), githubIdentity, "", apitypes.RoleBasic, limit)
+	if err != nil {
+		t.Fatalf("linking a verified identity at the user limit: %v", err)
+	}
+	if existing.ID != first.ID {
+		t.Fatalf("linked user ID = %d, want existing user ID %d", existing.ID, first.ID)
+	}
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != 1 {
+		t.Fatalf("users counted toward limit = %d, want 1", got)
+	}
+	if got := countIdentityUserLimitTestIdentities(t, c); got != 2 {
+		t.Fatalf("identities = %d, want 2", got)
+	}
+}
+
+func TestEnsureIdentityWithRoleRecoversAfterUserDeletion(t *testing.T) {
+	const maximum = 1
+	c := newIdentityUserLimitTestClient(t)
+	userLimit := UserLimit{Maximum: maximum}
+
+	first, err := ensureUserLimitTestIdentity(t.Context(), c, "user-1", "user-1@example.com", userLimit)
+	if err != nil {
+		t.Fatalf("creating first user: %v", err)
+	}
+
+	_, err = ensureUserLimitTestIdentity(t.Context(), c, "user-2", "user-2@example.com", userLimit)
+	requireIdentityUserLimitPaymentError(t, err, maximum)
+
+	if _, err := c.DeleteUser(t.Context(), strconv.FormatUint(uint64(first.ID), 10)); err != nil {
+		t.Fatalf("deleting first user: %v", err)
+	}
+	if _, err := ensureUserLimitTestIdentity(t.Context(), c, "user-2", "user-2@example.com", userLimit); err != nil {
+		t.Fatalf("creating user after returning below the limit: %v", err)
+	}
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != maximum {
+		t.Fatalf("users counted toward limit = %d, want %d", got, maximum)
+	}
+}
+
+func TestEnsureIdentityWithRoleDoesNotCountBootstrapUser(t *testing.T) {
+	const maximum = 2
+	c := newIdentityUserLimitTestClient(t)
+	userLimit := UserLimit{Maximum: maximum}
+
+	for _, systemUser := range []string{system.BootstrapName, "nobody", "somebody"} {
+		if _, err := ensureUserLimitTestIdentity(t.Context(), c, systemUser, "", userLimit); err != nil {
+			t.Fatalf("creating user row for %q: %v", systemUser, err)
+		}
+	}
+
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != maximum {
+		t.Fatalf("users counted toward limit = %d, want %d", got, maximum)
+	}
+
+	_, err := ensureUserLimitTestIdentity(t.Context(), c, "user-3", "user-3@example.com", userLimit)
+	requireIdentityUserLimitPaymentError(t, err, maximum)
+}
+
+func TestCreateLocalAuthUserDoesNotConsumeUserLimit(t *testing.T) {
+	const maximum = 1
+	c := newIdentityUserLimitTestClient(t)
+	userLimit := UserLimit{Maximum: maximum}
+
+	const localAuthUsers = 3
+	for i := 1; i <= localAuthUsers; i++ {
+		email := fmt.Sprintf("local-user-%d@example.com", i)
+		if _, err := c.CreateLocalAuthUser(t.Context(), email, "password-hash"); err != nil {
+			t.Fatalf("creating local auth user %d: %v", i, err)
+		}
+	}
+
+	activeUser, err := ensureUserLimitTestIdentity(t.Context(), c, "active-user", "active-user@example.com", userLimit)
+	if err != nil {
+		t.Fatalf("creating active user: %v", err)
+	}
+
+	if got := countIdentityUserLimitTestLocalAuthUsers(t, c); got != localAuthUsers {
+		t.Fatalf("local auth users = %d, want %d", got, localAuthUsers)
+	}
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != maximum {
+		t.Fatalf("users counted toward limit = %d, want %d", got, maximum)
+	}
+
+	firstLocalEmail := "local-user-1@example.com"
+	_, err = c.EnsureIdentityWithRole(t.Context(), &gatewaytypes.Identity{
+		AuthProviderNamespace: system.DefaultNamespace,
+		AuthProviderName:      system.LocalAuthProvider,
+		ProviderUsername:      firstLocalEmail,
+		ProviderUserID:        firstLocalEmail,
+		Email:                 firstLocalEmail,
+	}, "", apitypes.RoleBasic, userLimit)
+	requireIdentityUserLimitPaymentError(t, err, maximum)
+
+	if _, err := c.DeleteUser(t.Context(), strconv.FormatUint(uint64(activeUser.ID), 10)); err != nil {
+		t.Fatalf("deleting active user: %v", err)
+	}
+	if _, err := c.EnsureIdentityWithRole(t.Context(), &gatewaytypes.Identity{
+		AuthProviderNamespace: system.DefaultNamespace,
+		AuthProviderName:      system.LocalAuthProvider,
+		ProviderUsername:      firstLocalEmail,
+		ProviderUserID:        firstLocalEmail,
+		Email:                 firstLocalEmail,
+	}, "", apitypes.RoleBasic, userLimit); err != nil {
+		t.Fatalf("creating user row for local auth account after capacity was freed: %v", err)
+	}
+
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != maximum {
+		t.Fatalf("users counted toward limit = %d, want %d", got, maximum)
+	}
+
+	secondLocalEmail := "local-user-2@example.com"
+	_, err = c.EnsureIdentityWithRole(t.Context(), &gatewaytypes.Identity{
+		AuthProviderNamespace: system.DefaultNamespace,
+		AuthProviderName:      system.LocalAuthProvider,
+		ProviderUsername:      secondLocalEmail,
+		ProviderUserID:        secondLocalEmail,
+		Email:                 secondLocalEmail,
+	}, "", apitypes.RoleBasic, userLimit)
+	requireIdentityUserLimitPaymentError(t, err, maximum)
+}
+
+func TestEnsureIdentityWithRoleAllowsUnlimitedUsers(t *testing.T) {
+	c := newIdentityUserLimitTestClient(t)
+	userLimit := UserLimit{Maximum: 1, Unlimited: true}
+
+	for i := 1; i <= 3; i++ {
+		username := fmt.Sprintf("user-%d", i)
+		if _, err := ensureUserLimitTestIdentity(t.Context(), c, username, username+"@example.com", userLimit); err != nil {
+			t.Fatalf("creating unlimited user %d: %v", i, err)
+		}
+	}
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != 3 {
+		t.Fatalf("users counted toward limit = %d, want 3", got)
+	}
+}
+
+func TestEnsureIdentityWithRoleEnforcesUserLimitConcurrently(t *testing.T) {
+	const (
+		maximum  = 2
+		attempts = 8
+	)
+	c := newIdentityUserLimitTestClient(t)
+	userLimit := UserLimit{Maximum: maximum}
+
+	start := make(chan struct{})
+	errorsByAttempt := make(chan error, attempts)
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			username := fmt.Sprintf("concurrent-user-%d", i)
+			_, err := ensureUserLimitTestIdentity(t.Context(), c, username, username+"@example.com", userLimit)
+			errorsByAttempt <- err
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errorsByAttempt)
+
+	var succeeded, rejected int
+	for err := range errorsByAttempt {
+		if err == nil {
+			succeeded++
+			continue
+		}
+
+		var httpErr *apitypes.ErrHTTP
+		if errors.As(err, &httpErr) && httpErr.Code == http.StatusPaymentRequired {
+			rejected++
+			continue
+		}
+		t.Fatalf("concurrent creation returned unexpected error: %v", err)
+	}
+
+	if succeeded != maximum {
+		t.Fatalf("successful concurrent creations = %d, want %d", succeeded, maximum)
+	}
+	if rejected != attempts-maximum {
+		t.Fatalf("rejected concurrent creations = %d, want %d", rejected, attempts-maximum)
+	}
+	if got := countIdentityUserLimitTestUsers(t, c, true); got != maximum {
+		t.Fatalf("users counted toward limit = %d, want %d", got, maximum)
+	}
+	if got := countIdentityUserLimitTestIdentities(t, c); got != maximum {
+		t.Fatalf("identities = %d, want %d", got, maximum)
+	}
+}

--- a/pkg/gateway/client/mdmconfiguration_test.go
+++ b/pkg/gateway/client/mdmconfiguration_test.go
@@ -5,6 +5,7 @@ import (
 
 	apitypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/system"
 )
 
 func renderedArtifact(platform, osName, content string) types.MDMConfigurationArtifact {
@@ -136,7 +137,7 @@ func TestCreateDeviceEnrollmentKeyIsSeparate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key, err := client.CreateDeviceEnrollmentKey(t.Context(), configuration.ID, 42, "bootstrap", nil)
+	key, err := client.CreateDeviceEnrollmentKey(t.Context(), configuration.ID, 42, system.BootstrapName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,7 +375,7 @@ func TestDeleteMDMConfigurationRemovesArtifactsAndKeysKeepsDevices(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := client.CreateDeviceEnrollmentKey(t.Context(), configuration.ID, 42, "bootstrap", nil); err != nil {
+	if _, err := client.CreateDeviceEnrollmentKey(t.Context(), configuration.ID, 42, system.BootstrapName, nil); err != nil {
 		t.Fatal(err)
 	}
 	device, err := client.EnrollDevice(t.Context(), DeviceEnrollment{

--- a/pkg/gateway/server/activeusers.go
+++ b/pkg/gateway/server/activeusers.go
@@ -6,6 +6,7 @@ import (
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/system"
 )
 
 func (s *Server) activeUsers(apiContext api.Context) error {
@@ -24,7 +25,7 @@ func (s *Server) activeUsers(apiContext api.Context) error {
 
 	items := make([]types2.User, 0, len(activeUsers))
 	for _, user := range activeUsers {
-		if user.Username != "bootstrap" && user.Email != "" { // Filter out the bootstrap admin
+		if user.Username != system.BootstrapName && user.Email != "" { // Filter out the bootstrap admin
 			items = append(items, *types.ConvertUser(&user, apiContext.GatewayClient.HasExplicitRole(user.Email) != types2.RoleUnknown, ""))
 		}
 	}

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -64,7 +64,7 @@ func (s *Server) getUsers(apiContext api.Context) error {
 	validUsers := make([]types.User, 0, len(users))
 	userIDs := make([]uint, 0, len(users))
 	for _, user := range users {
-		if user.Username != "bootstrap" && user.Email != "" {
+		if user.Username != system.BootstrapName && user.Email != "" {
 			validUsers = append(validUsers, user)
 			userIDs = append(userIDs, user.ID)
 		}

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -9,6 +9,7 @@ import (
 
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
 )
 
@@ -47,7 +48,7 @@ func ConvertUserWithEffectiveRole(u *User, roleFixed bool, authProviderName stri
 	}
 
 	groups := effectiveRole.Groups()
-	if authProviderName == "bootstrap" {
+	if authProviderName == system.BootstrapName {
 		groups = []string{types2.GroupOwner, types2.GroupAdmin, types2.GroupBasic, types2.GroupAuthenticated}
 	}
 

--- a/pkg/license/entitlements.go
+++ b/pkg/license/entitlements.go
@@ -3,12 +3,21 @@ package license
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/obot-platform/obot/apiclient/types"
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	enterpriseUserLimitEntitlementPrefix = "OBOT_ENTERPRISE_"
+	userLimitEntitlementUsersSuffix      = "_USERS"
 )
 
 var entitlementPathsToGate = []string{
@@ -100,6 +109,60 @@ func (p *Provider) missingEntitlements(requiredEntitlements []string) []string {
 		}
 	}
 	return missing
+}
+
+// UserLimit returns the maximum number of users allowed by the current license.
+// OBOT_ENTERPRISE_AUTH_PROVIDERS grants unlimited users unless one or more
+// OBOT_ENTERPRISE_<number>_USERS entitlements define an additive limit.
+func (p *Provider) UserLimit(ctx context.Context) (gatewayclient.UserLimit, error) {
+	if err := p.refresh(ctx, false); err != nil {
+		return gatewayclient.UserLimit{}, err
+	}
+
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	limit := gatewayclient.UserLimit{}
+	var isEnterpriseEdition bool
+	for entitlement := range p.entitlements {
+		code := string(entitlement)
+		if code == EnterpriseEditionEntitlement {
+			isEnterpriseEdition = true
+			continue
+		}
+
+		value, ok := strings.CutPrefix(code, enterpriseUserLimitEntitlementPrefix)
+		if !ok {
+			continue
+		}
+		value, ok = strings.CutSuffix(value, userLimitEntitlementUsersSuffix)
+		if !ok {
+			continue
+		}
+		if value == "" || strings.IndexFunc(value, func(r rune) bool {
+			return r < '0' || r > '9'
+		}) >= 0 {
+			continue
+		}
+
+		maximum, err := strconv.Atoi(value)
+		if err != nil || maximum <= 0 {
+			continue
+		}
+
+		if maximum > math.MaxInt-limit.Maximum {
+			limit.Maximum = math.MaxInt
+		} else {
+			limit.Maximum += maximum
+		}
+	}
+
+	limit.Unlimited = isEnterpriseEdition && limit.Maximum == 0
+	if limit.Maximum == 0 && !limit.Unlimited {
+		limit.Maximum = gatewayclient.DefaultUserLimit
+	}
+
+	return limit, nil
 }
 
 // RequireEntitlements returns Payment Required if any required entitlements are unavailable.

--- a/pkg/license/provider.go
+++ b/pkg/license/provider.go
@@ -29,6 +29,9 @@ const (
 	// EnterpriseAuthProvidersEntitlement is required to enable enterprise auth providers.
 	EnterpriseAuthProvidersEntitlement = "OBOT_ENTERPRISE_AUTH_PROVIDERS"
 
+	// EnterpriseEditionEntitlement is required to enable enterprise edition.
+	EnterpriseEditionEntitlement = "OBOT_ENTERPRISE_ENTERPRISE_EDITION"
+
 	// EnterpriseModelProvidersEntitlement is required to enable enterprise model providers.
 	EnterpriseModelProvidersEntitlement = "OBOT_ENTERPRISE_MODEL_PROVIDERS"
 

--- a/pkg/license/user_limit_test.go
+++ b/pkg/license/user_limit_test.go
@@ -1,0 +1,126 @@
+package license
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	keygen "github.com/keygen-sh/keygen-go/v3"
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+)
+
+func TestProviderUserLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		entitlements []string
+		want         gatewayclient.UserLimit
+	}{
+		{
+			name: "default",
+			want: gatewayclient.UserLimit{Maximum: gatewayclient.DefaultUserLimit},
+		},
+		{
+			name:         "unrelated entitlement",
+			entitlements: []string{EnterpriseModelProvidersEntitlement},
+			want:         gatewayclient.UserLimit{Maximum: gatewayclient.DefaultUserLimit},
+		},
+		{
+			name:         "enterprise edition grants unlimited users",
+			entitlements: []string{EnterpriseEditionEntitlement},
+			want:         gatewayclient.UserLimit{Unlimited: true},
+		},
+		{
+			name: "malformed user limit entitlements",
+			entitlements: []string{
+				"OBOT_ENTERPRISE_USERS",
+				"OBOT_ENTERPRISE_NOT_A_NUMBER_USERS",
+				"OBOT_ENTERPRISE_USER_LIMIT",
+				"OBOT_ENTERPRISE_NOT_A_NUMBER_USER_LIMIT",
+				"OBOT_ENTERPRISE_500_USER_LIMIT",
+				"OBOT_ENTERPRISE_+500_USERS",
+				"OBOT_ENTERPRISE_-1_USERS",
+				"OBOT_ENTERPRISE_500_USER",
+				"OBOT_ENTERPRISE_500_USERS_EXTRA",
+				"OBOT_ENTERPRISE_500_USER_LIMIT_EXTRA",
+				"OBOT_ENTERPRISE_0_USERS",
+			},
+			want: gatewayclient.UserLimit{Maximum: gatewayclient.DefaultUserLimit},
+		},
+		{
+			name:         "numeric users entitlement",
+			entitlements: []string{"OBOT_ENTERPRISE_500_USERS"},
+			want:         gatewayclient.UserLimit{Maximum: 500},
+		},
+		{
+			name: "numeric user entitlements are additive",
+			entitlements: []string{
+				"OBOT_ENTERPRISE_100_USERS",
+				"OBOT_ENTERPRISE_50_USERS",
+			},
+			want: gatewayclient.UserLimit{Maximum: 150},
+		},
+		{
+			name: "all numeric user entitlements are additive",
+			entitlements: []string{
+				"OBOT_ENTERPRISE_250_USERS",
+				"OBOT_ENTERPRISE_1000_USERS",
+				"OBOT_ENTERPRISE_500_USERS",
+			},
+			want: gatewayclient.UserLimit{Maximum: 1750},
+		},
+		{
+			name: "numeric user entitlements override enterprise edition unlimited users",
+			entitlements: []string{
+				EnterpriseEditionEntitlement,
+				"OBOT_ENTERPRISE_100_USERS",
+				"OBOT_ENTERPRISE_50_USERS",
+			},
+			want: gatewayclient.UserLimit{Maximum: 150},
+		},
+		{
+			name: "malformed numeric entitlements do not override enterprise edition unlimited users",
+			entitlements: []string{
+				EnterpriseEditionEntitlement,
+				"OBOT_ENTERPRISE_0_USERS",
+				"OBOT_ENTERPRISE_NOT_A_NUMBER_USERS",
+			},
+			want: gatewayclient.UserLimit{Unlimited: true},
+		},
+		{
+			name:         "removed custom user limit entitlement is ignored",
+			entitlements: []string{"OBOT_ENTERPRISE_CUSTOM_USER_LIMIT"},
+			want:         gatewayclient.UserLimit{Maximum: gatewayclient.DefaultUserLimit},
+		},
+		{
+			name:         "numeric entitlement replaces default",
+			entitlements: []string{"OBOT_ENTERPRISE_50_USERS"},
+			want:         gatewayclient.UserLimit{Maximum: 50},
+		},
+		{
+			name: "numeric entitlement sum saturates at maximum integer",
+			entitlements: []string{
+				"OBOT_ENTERPRISE_" + strconv.Itoa(math.MaxInt) + "_USERS",
+				"OBOT_ENTERPRISE_1_USERS",
+			},
+			want: gatewayclient.UserLimit{Maximum: math.MaxInt},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entitlements := make(map[keygen.EntitlementCode]struct{}, len(tt.entitlements))
+			for _, entitlement := range tt.entitlements {
+				entitlements[keygen.EntitlementCode(entitlement)] = struct{}{}
+			}
+
+			provider := &Provider{entitlements: entitlements}
+			got, err := provider.UserLimit(t.Context())
+			if err != nil {
+				t.Fatalf("UserLimit() error = %v, want nil", err)
+			}
+			if got != tt.want {
+				t.Fatalf("UserLimit() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -890,7 +890,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		// Token Auth + OAuth auth
 		authenticators = union.NewFailOnError(authenticators, proxyManager)
 		// Add gateway user info
-		authenticators = client.NewUserDecorator(authenticators, gatewayClient)
+		authenticators = client.NewUserDecorator(authenticators, gatewayClient, licenseProvider)
 		// Tunnel credentials are non-user principals and must be handled after
 		// the user decorator. Authorization restricts them to tunnel setup only.
 		authenticators = union.New(authenticators, tunnel.NewTunnelAuthenticator(storageClient))
@@ -939,7 +939,9 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		// "Authentication Disabled" flow
 
 		// Add gateway user info if token auth worked
-		authenticators = client.NewUserDecorator(authenticators, gatewayClient)
+		authenticators = client.NewUserDecorator(authenticators, gatewayClient, licenseProvider)
+
+		// Tunnel authenticator
 		authenticators = union.New(authenticators, tunnel.NewTunnelAuthenticator(storageClient))
 
 		// Persistent Token Auth

--- a/pkg/system/tools.go
+++ b/pkg/system/tools.go
@@ -15,6 +15,9 @@ const (
 	// pkg/localauth. It runs in-process instead of as a daemon from the provider registry.
 	LocalAuthProvider = "local-auth-provider"
 
+	// BootstrapName is the reserved name used for the bootstrap user and auth provider.
+	BootstrapName = "bootstrap"
+
 	OpenAIAPIKeyEnvVar    = "OPENAI_API_KEY"
 	AnthropicAPIKeyEnvVar = "ANTHROPIC_API_KEY"
 

--- a/ui/user/src/routes/admin/license/+page.svelte
+++ b/ui/user/src/routes/admin/license/+page.svelte
@@ -16,6 +16,8 @@
 	let { data } = $props();
 
 	const communityEntitlement = 'OBOT_COMMUNITY_EDITION';
+	const enterpriseEntitlement = 'OBOT_ENTERPRISE_ENTERPRISE_EDITION';
+	const editionEntitlements = new Set([communityEntitlement, enterpriseEntitlement]);
 	const lockedLicenseMessage = 'The license key is locked and cannot be updated.';
 
 	let license = $state(untrack(() => data.license));
@@ -33,6 +35,11 @@
 	let isAdminReadonly = $derived(profile.current.isAdminReadonly?.());
 	let hasValidLicense = $derived(Boolean(license?.enterprise));
 	let isCommunityEdition = $derived(license?.entitlements?.includes(communityEntitlement) ?? false);
+	let sortedEntitlements = $derived(
+		[...(license?.entitlements ?? [])].sort(
+			(a, b) => Number(!editionEntitlements.has(a)) - Number(!editionEntitlements.has(b))
+		)
+	);
 	let showEnterpriseCTA = $derived(!hasValidLicense || isCommunityEdition);
 	let showCommunityEnrollment = $derived(
 		Boolean(license && !hasValidLicense && !license.locked && !isAdminReadonly)
@@ -140,19 +147,17 @@
 		return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 	}
 
-	function convertUserFriendlyEntitlements(entitlements: string[]): string[] {
-		return entitlements.map((entitlement) => {
-			switch (entitlement) {
-				case communityEntitlement:
-					return 'Community Edition';
-				case 'OBOT_ENTERPRISE_AUTH_PROVIDERS':
-					return 'Auth Providers';
-				case 'OBOT_ENTERPRISE_MODEL_PROVIDERS':
-					return 'Model Providers';
-				default:
-					return entitlement;
-			}
-		});
+	function formatEntitlementName(entitlement: string): string {
+		if (entitlement === communityEntitlement) return 'Community Edition';
+		const name = entitlement.replace(/^OBOT_(?:ENTERPRISE_)?/, '');
+		if (name === entitlement) return entitlement;
+
+		const words = name.split('_').filter(Boolean);
+		if (words.length === 0) return entitlement;
+
+		return words
+			.map((word) => (word.length <= 3 ? word : word.charAt(0) + word.slice(1).toLowerCase()))
+			.join(' ');
 	}
 
 	const duration = PAGE_TRANSITION_DURATION;
@@ -332,8 +337,15 @@
 						<p class="text-sm font-light">License Entitlements</p>
 						{#if license.entitlements}
 							<ul class="flex flex-wrap gap-2">
-								{#each convertUserFriendlyEntitlements(license.entitlements ?? []) as entitlement (entitlement)}
-									<li class="badge badge-soft badge-sm">{entitlement}</li>
+								{#each sortedEntitlements as entitlement (entitlement)}
+									<li
+										class={twMerge(
+											'badge badge-soft badge-sm',
+											editionEntitlements.has(entitlement) && 'badge-primary'
+										)}
+									>
+										{formatEntitlementName(entitlement)}
+									</li>
 								{/each}
 							</ul>
 						{:else}


### PR DESCRIPTION
This change adds a default 100 user limit. This limit can be changed via the licensing entitlements. The entitlements are additive, meaning that two entitlements of OBOT_ENTERPRISE_100_USERS and
OBOT_ENTERPRISE_50_USERS grants an Obot instance 150 total users.

If an Obot instance has more than the default (100) users and the license becomes invalid, then the system works completely normally except that no new users can be added to the system.

Edit: https://github.com/obot-platform/obot/issues/7324