### PR TITLE
fix: always set peer config in helm chart

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -132,7 +132,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
-            {{- if gt (int .Values.replicaCount) 1 }}
             - name: OBOT_SERVER_TUNNEL_PEER_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -142,7 +141,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.uid
-            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "obot.config.configMapName" . }}

--- a/chart/templates/tunnel-peer.yaml
+++ b/chart/templates/tunnel-peer.yaml
@@ -1,4 +1,3 @@
-{{- if gt (int .Values.replicaCount) 1 }}
 {{- $name := include "obot.tunnelPeerName" . -}}
 {{- if and .Values.tunnelPeer.existingSecret .Values.tunnelPeer.token -}}
 {{- fail "tunnelPeer.existingSecret and tunnelPeer.token cannot both be set" -}}
@@ -57,4 +56,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ $name }}
-{{- end }}


### PR DESCRIPTION
Not setting breaks Kubernetes deployments with only one replica.