### PR TITLE
fix: send spec-ful issuer

### DIFF
--- a/logger/log.go
+++ b/logger/log.go
@@ -33,8 +33,13 @@ func Package() Logger {
 }
 
 func NewWithFields(fields logrus.Fields) Logger {
+	return NewWithLogger(logrus.StandardLogger(), fields)
+}
+
+// NewWithLogger creates a Logger backed by the provided logrus logger.
+func NewWithLogger(log *logrus.Logger, fields logrus.Fields) Logger {
 	return Logger{
-		log:    logrus.StandardLogger(),
+		log:    log,
 		fields: fields,
 	}
 }

--- a/pkg/api/handlers/wellknown/oauth.go
+++ b/pkg/api/handlers/wellknown/oauth.go
@@ -13,6 +13,7 @@ import (
 func (h *handler) oauthAuthorization(req api.Context) error {
 	config := h.config
 	if mcpID := req.PathValue("mcp_id"); mcpID != "" {
+		config.Issuer = appendPathSegment(config.Issuer, mcpID)
 		config.AuthorizationEndpoint = appendPathSegment(config.AuthorizationEndpoint, mcpID)
 		config.RegistrationEndpoint = appendPathSegment(config.RegistrationEndpoint, mcpID)
 		config.TokenEndpoint = appendPathSegment(config.TokenEndpoint, mcpID)

--- a/pkg/api/handlers/wellknown/oauth_test.go
+++ b/pkg/api/handlers/wellknown/oauth_test.go
@@ -46,7 +46,7 @@ func TestOAuthAuthorizationAppendsMCPIDToOAuthEndpoints(t *testing.T) {
 	if got.RegistrationEndpoint != "https://obot.example.com/oauth/register/test-mcp" {
 		t.Fatalf("registration_endpoint = %q", got.RegistrationEndpoint)
 	}
-	if got.Issuer != h.config.Issuer {
+	if got.Issuer != "https://obot.example.com/test-mcp" {
 		t.Fatalf("issuer = %q", got.Issuer)
 	}
 	if got.JWKSURI != h.config.JWKSURI {

--- a/pkg/tunnel/tunnel_test.go
+++ b/pkg/tunnel/tunnel_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	apitypes "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/logger"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/rancher/remotedialer"
@@ -321,21 +322,16 @@ func TestTunnelLogsCorrelatedRequestAndResponse(t *testing.T) {
 	}))
 	defer target.Close()
 
+	testLogger, hook := logrustest.NewNullLogger()
+	testLogger.SetLevel(logrus.InfoLevel)
+	previousTunnelLog := tunnelLog
+	tunnelLog = logger.NewWithLogger(testLogger, nil)
+	defer func() {
+		tunnelLog = previousTunnelLog
+	}()
+
 	manager, bridgeClient, cleanup := newConnectedTestTunnel(t, "office")
 	defer cleanup()
-
-	standardLogger := logrus.StandardLogger()
-	previousHooks := standardLogger.ReplaceHooks(make(logrus.LevelHooks))
-	previousOutput := standardLogger.Out
-	previousLevel := standardLogger.GetLevel()
-	standardLogger.SetOutput(io.Discard)
-	standardLogger.SetLevel(logrus.InfoLevel)
-	hook := logrustest.NewGlobal()
-	defer func() {
-		standardLogger.ReplaceHooks(previousHooks)
-		standardLogger.SetOutput(previousOutput)
-		standardLogger.SetLevel(previousLevel)
-	}()
 
 	bridgeURL, err := manager.BridgeURL("office", target.URL+"/mcp?token=secret")
 	if err != nil {
@@ -1040,7 +1036,16 @@ func newConnectedTestTunnel(t *testing.T, name string) (*Manager, *http.Client, 
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	manager, server := newManagerTestServer(ctx, t)
-	connection, _, err := dial(ctx, server.URL, testTunnelToken(name))
+	token := testTunnelToken(name)
+	matcher, ok := newCredentialMatcher(token)
+	if !ok {
+		server.Close()
+		manager.Close()
+		cancel()
+		t.Fatalf("test tunnel token is invalid")
+	}
+	sessionKey := tunnelSessionKey(name, matcher.credentialID)
+	connection, _, err := dial(ctx, server.URL, token)
 	if err != nil {
 		server.Close()
 		manager.Close()
@@ -1051,13 +1056,9 @@ func newConnectedTestTunnel(t *testing.T, name string) (*Manager, *http.Client, 
 	go func() { serveErrors <- serveConnection(ctx, connection, name) }()
 
 	deadline := time.Now().Add(2 * time.Second)
-	for {
-		connected := localTunnelConnectionCount(manager, name) > 0
-		if connected {
-			break
-		}
+	for !manager.remoteDialer.HasSession(sessionKey) {
 		if time.Now().After(deadline) {
-			t.Fatal("tunnel did not register")
+			t.Fatal("tunnel session did not become ready")
 		}
 		time.Sleep(time.Millisecond)
 	}


### PR DESCRIPTION
The new inspector validates that we send this issuer back in our oauth server metadata.