### PR TITLE
chore: add logging for oauth errors

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -36,14 +36,23 @@ const (
 	ErrInvalidClientMetadata   ErrorCode = "invalid_client_metadata"
 )
 
-// Error represents an OAuth 2.0 error response.
-type Error struct {
+// oauthError represents an OAuth 2.0 error response.
+type oauthError struct {
 	Code        ErrorCode `json:"error"`
 	Description string    `json:"error_description,omitempty"`
 	State       string    `json:"state,omitempty"`
 }
 
-func (e Error) Error() string {
+func newOAuthError(code ErrorCode, description, state string) oauthError {
+	log.Infof("OAuth error: code=%s description=%s state=%s", code, description, state)
+	return oauthError{
+		Code:        code,
+		Description: obotErrorPrefix + description,
+		State:       state,
+	}
+}
+
+func (e oauthError) Error() string {
 	b, err := json.Marshal(e)
 	if err != nil {
 		return string(e.Code) + ": " + e.Description
@@ -51,18 +60,15 @@ func (e Error) Error() string {
 	return string(b)
 }
 
-func newOAuthErrHTTP(statusCode int, oauthErr Error) *types.ErrHTTP {
+func newOAuthErrHTTP(statusCode int, oauthErr oauthError) *types.ErrHTTP {
 	return types.NewErrHTTP(statusCode, oauthErr.Error())
 }
 
 func newInvalidClientErr(statusCode int, description string) *types.ErrHTTP {
-	return newOAuthErrHTTP(statusCode, Error{
-		Code:        ErrInvalidClient,
-		Description: description,
-	})
+	return newOAuthErrHTTP(statusCode, newOAuthError(ErrInvalidClient, description, ""))
 }
 
-func (e Error) toQuery() url.Values {
+func (e oauthError) toQuery() url.Values {
 	q := url.Values{}
 	q.Set("error", string(e.Code))
 	if e.Description != "" {
@@ -83,50 +89,30 @@ func (h *handler) authorize(req api.Context) error {
 	codeChallenge := req.FormValue("code_challenge")
 	codeChallengeMethod := req.FormValue("code_challenge_method")
 	if codeChallenge != "" && (codeChallengeMethod == "" || !slices.Contains(h.oauthConfig.CodeChallengeMethodsSupported, codeChallengeMethod)) {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "code_challenge_method is invalid",
-			State:       state,
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "code_challenge_method is invalid", state))
 	}
 
 	clientID := req.FormValue("client_id")
 	if clientID == "" {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "client_id is required",
-			State:       state,
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "client_id is required", state))
 	}
 
 	redirectURI := req.FormValue("redirect_uri")
 	if redirectURI == "" {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "redirect_uri is required",
-			State:       state,
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "redirect_uri is required", state))
 	}
 
 	responseType := req.FormValue("response_type")
 	if responseType == "" {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "response_type is required",
-			State:       state,
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "response_type is required", state))
 	}
 	if !slices.Contains(h.oauthConfig.ResponseTypesSupported, responseType) {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "response_type is invalid",
-			State:       state,
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "response_type is invalid", state))
 	}
 
 	oauthClient, err := h.resolveOAuthClient(req.Context(), req.Storage, clientID)
 	if err != nil {
-		if oauthErr, ok := errors.AsType[Error](err); ok {
+		if oauthErr, ok := errors.AsType[oauthError](err); ok {
 			oauthErr.State = state
 			return types.NewErrBadRequest("%v", oauthErr)
 		}
@@ -134,27 +120,16 @@ func (h *handler) authorize(req api.Context) error {
 	}
 
 	if !isRedirectURIAllowed(oauthClient.Spec.Manifest, redirectURI) {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidClient,
-			Description: "redirect_uri is invalid for this client",
-			State:       state,
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidClient, "redirect_uri is invalid for this client", state))
 	}
 
 	if len(oauthClient.Spec.Manifest.ResponseTypes) > 0 && !slices.Contains(oauthClient.Spec.Manifest.ResponseTypes, responseType) || len(oauthClient.Spec.Manifest.ResponseTypes) == 0 && responseType != "code" {
-		redirectWithAuthorizeError(req, redirectURI, Error{
-			Code:        ErrUnsupportedResponseType,
-			Description: "response_type is not allowed for this client",
-			State:       state,
-		})
+		redirectWithAuthorizeError(req, redirectURI, newOAuthError(ErrUnsupportedResponseType, "response_type is not allowed for this client", state))
 		return nil
 	}
 
 	if oauthClient.Spec.Manifest.TokenEndpointAuthMethod == "none" && codeChallenge == "" {
-		redirectWithAuthorizeError(req, redirectURI, Error{
-			Code:        ErrInvalidRequest,
-			Description: "code_challenge is required when using token endpoint auth method none",
-		})
+		redirectWithAuthorizeError(req, redirectURI, newOAuthError(ErrInvalidRequest, "code_challenge is required when using token endpoint auth method none", state))
 		return nil
 	}
 
@@ -182,32 +157,20 @@ func (h *handler) authorize(req api.Context) error {
 	if resource != "" {
 		u, err := url.Parse(resource)
 		if err != nil {
-			redirectWithAuthorizeError(req, redirectURI, Error{
-				Code:        ErrInvalidRequest,
-				Description: fmt.Sprintf("invalid resource URL: %s", resource),
-				State:       state,
-			})
+			redirectWithAuthorizeError(req, redirectURI, newOAuthError(ErrInvalidRequest, fmt.Sprintf("invalid resource URL: %s", resource), state))
 			return nil
 		}
 
 		if mcpID == "" {
 			mcpID = strings.TrimPrefix(u.Path, "/mcp-connect/")
 		} else if !strings.HasSuffix(u.Path, "/"+mcpID) {
-			redirectWithAuthorizeError(req, redirectURI, Error{
-				Code:        ErrInvalidRequest,
-				Description: fmt.Sprintf("resource doesn't match mcp_id: %s", mcpID),
-				State:       state,
-			})
+			redirectWithAuthorizeError(req, redirectURI, newOAuthError(ErrInvalidRequest, fmt.Sprintf("resource doesn't match mcp_id: %s", mcpID), state))
 			return nil
 		}
 	}
 
 	if mcpID == "" {
-		redirectWithAuthorizeError(req, redirectURI, Error{
-			Code:        ErrInvalidRequest,
-			Description: "cannot determine MCP server, resource parameter required",
-			State:       state,
-		})
+		redirectWithAuthorizeError(req, redirectURI, newOAuthError(ErrInvalidRequest, "cannot determine MCP server, resource parameter required", state))
 		return nil
 	}
 
@@ -230,11 +193,7 @@ func (h *handler) authorize(req api.Context) error {
 	}
 
 	if err := req.Create(&oauthAppAuthRequest); err != nil {
-		redirectWithAuthorizeError(req, redirectURI, Error{
-			Code:        ErrServerError,
-			Description: err.Error(),
-			State:       state,
-		})
+		redirectWithAuthorizeError(req, redirectURI, newOAuthError(ErrServerError, err.Error(), state))
 
 		return nil
 	}
@@ -262,17 +221,9 @@ func (h *handler) callback(req api.Context) error {
 		serverOrInstanceID, audience, err := h.oauthChecker.mcpSessionManager.IDAndAudienceFromConnectURL(req.Context(), mcpID, req.User.GetUID())
 		if err != nil {
 			if errHTTP := (*types.ErrHTTP)(nil); errors.As(err, &errHTTP) {
-				redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-					Code:        ErrInvalidRequest,
-					Description: errHTTP.Message,
-					State:       oauthAppAuthRequest.Spec.State,
-				})
+				redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrInvalidRequest, errHTTP.Message, oauthAppAuthRequest.Spec.State))
 			} else {
-				redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-					Code:        ErrServerError,
-					Description: fmt.Sprintf("failed to get MCP ID from connect URL: %v", err),
-					State:       oauthAppAuthRequest.Spec.State,
-				})
+				redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, fmt.Sprintf("failed to get MCP ID from connect URL: %v", err), oauthAppAuthRequest.Spec.State))
 			}
 			return nil
 		}
@@ -284,11 +235,7 @@ func (h *handler) callback(req api.Context) error {
 			oauthAppAuthRequest.Spec.Resource = fmt.Sprintf("%s/mcp-connect%s", h.baseURL, audience)
 			oauthAppAuthRequest.Spec.MCPID = mcpID
 			if err = req.Update(&oauthAppAuthRequest); err != nil {
-				redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-					Code:        ErrServerError,
-					Description: fmt.Sprintf("failed to update OAuth app auth request: %v", err),
-					State:       oauthAppAuthRequest.Spec.State,
-				})
+				redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, fmt.Sprintf("failed to update OAuth app auth request: %v", err), oauthAppAuthRequest.Spec.State))
 				return nil
 			}
 		}
@@ -299,19 +246,12 @@ func (h *handler) callback(req api.Context) error {
 	oauthAppAuthRequest.Spec.AuthProviderNamespace = authProviderNamespace
 	oauthAppAuthRequest.Spec.AuthProviderName = authProviderName
 	if err := req.Update(&oauthAppAuthRequest); err != nil {
-		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-			Code:        ErrServerError,
-			Description: err.Error(),
-		})
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, err.Error(), oauthAppAuthRequest.Spec.State))
 		return nil
 	}
 
 	if err := h.prepareOAuthConsent(req, &oauthAppAuthRequest); err != nil {
-		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-			Code:        ErrServerError,
-			Description: err.Error(),
-			State:       oauthAppAuthRequest.Spec.State,
-		})
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, err.Error(), oauthAppAuthRequest.Spec.State))
 		return nil
 	}
 
@@ -374,21 +314,13 @@ func (h *handler) consent(req api.Context) error {
 
 	if !oauthAppAuthRequest.Spec.ConsentPrepared || oauthAppAuthRequest.Spec.ConsentMCPConfigRequired {
 		if err := h.prepareOAuthConsent(req, &oauthAppAuthRequest); err != nil {
-			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-				Code:        ErrServerError,
-				Description: err.Error(),
-				State:       oauthAppAuthRequest.Spec.State,
-			})
+			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, err.Error(), oauthAppAuthRequest.Spec.State))
 			return nil
 		}
 	}
 
 	if !oauthAppAuthRequest.Spec.ConsentPrepared {
-		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-			Code:        ErrInvalidRequest,
-			Description: "OAuth consent has not been prepared",
-			State:       oauthAppAuthRequest.Spec.State,
-		})
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrInvalidRequest, "OAuth consent has not been prepared", oauthAppAuthRequest.Spec.State))
 		return nil
 	}
 
@@ -399,16 +331,12 @@ func (h *handler) consent(req api.Context) error {
 
 	oauthClient, err := h.resolveOAuthClient(req.Context(), req.Storage, clientID)
 	if err != nil {
-		if oauthErr, ok := errors.AsType[Error](err); ok {
+		if oauthErr, ok := errors.AsType[oauthError](err); ok {
 			oauthErr.State = oauthAppAuthRequest.Spec.State
 			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, oauthErr)
 			return nil
 		}
-		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-			Code:        ErrServerError,
-			Description: fmt.Sprintf("failed to get OAuth client: %v", err),
-			State:       oauthAppAuthRequest.Spec.State,
-		})
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, fmt.Sprintf("failed to get OAuth client: %v", err), oauthAppAuthRequest.Spec.State))
 		return nil
 	}
 
@@ -420,11 +348,7 @@ func (h *handler) consent(req api.Context) error {
 	mcpServer, mcpServerInstance, err = handlers.ConfigurationTargetForConnectID(req, oauthAppAuthRequest.Spec.MCPID, h.baseURL, h.oauthChecker.secretBindingAllowedLabel, handlers.ValidationOptionsWithResourceMaximums(h.oauthChecker.mcpSessionManager))
 	if err != nil {
 		if oauthAppAuthRequest.Spec.ConsentMCPConfigRequired {
-			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-				Code:        ErrServerError,
-				Description: err.Error(),
-				State:       oauthAppAuthRequest.Spec.State,
-			})
+			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, err.Error(), oauthAppAuthRequest.Spec.State))
 			return nil
 		}
 		log.Warnf("Failed to load optional MCP configuration target for OAuth consent: authRequest=%s mcpID=%s error=%v", oauthAppAuthRequest.Name, oauthAppAuthRequest.Spec.MCPID, err)
@@ -441,29 +365,17 @@ func (h *handler) approveConsent(req api.Context) error {
 
 	oauthAppAuthRequest.Spec.ConsentApproved = true
 	if oauthAppAuthRequest.Spec.ConsentMCPConfigRequired {
-		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-			Code:        ErrInvalidRequest,
-			Description: "MCP server configuration is required before consent can be approved",
-			State:       oauthAppAuthRequest.Spec.State,
-		})
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrInvalidRequest, "MCP server configuration is required before consent can be approved", oauthAppAuthRequest.Spec.State))
 		return nil
 	}
 	if err := req.Update(&oauthAppAuthRequest); err != nil {
-		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-			Code:        ErrServerError,
-			Description: err.Error(),
-			State:       oauthAppAuthRequest.Spec.State,
-		})
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, err.Error(), oauthAppAuthRequest.Spec.State))
 		return nil
 	}
 
 	if oauthAppAuthRequest.Spec.ConsentMCPAuthRequired {
 		if oauthAppAuthRequest.Spec.ConsentMCPAuthURL == "" {
-			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-				Code:        ErrServerError,
-				Description: "MCP OAuth URL is missing from consent state",
-				State:       oauthAppAuthRequest.Spec.State,
-			})
+			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, "MCP OAuth URL is missing from consent state", oauthAppAuthRequest.Spec.State))
 			return nil
 		}
 
@@ -484,11 +396,7 @@ func (h *handler) cancelConsent(req api.Context) error {
 	}
 
 	log.Infof("User denied OAuth consent: authRequest=%s client=%s", oauthAppAuthRequest.Name, oauthAppAuthRequest.Spec.ClientID)
-	redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-		Code:        ErrAccessDenied,
-		Description: "user denied OAuth consent",
-		State:       oauthAppAuthRequest.Spec.State,
-	})
+	redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrAccessDenied, "user denied OAuth consent", oauthAppAuthRequest.Spec.State))
 	return nil
 }
 
@@ -506,11 +414,7 @@ func (h *handler) oauthConsentRequest(req api.Context, phase string) (v1.OAuthAu
 	}
 
 	if !oauthAppAuthRequest.Spec.ConsentPrepared {
-		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-			Code:        ErrInvalidRequest,
-			Description: "OAuth consent has not been prepared",
-			State:       oauthAppAuthRequest.Spec.State,
-		})
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrInvalidRequest, "OAuth consent has not been prepared", oauthAppAuthRequest.Spec.State))
 		return oauthAppAuthRequest, false, nil
 	}
 
@@ -595,20 +499,14 @@ func (h *handler) oauthCallback(req api.Context) error {
 	if !req.UserIsAuthenticated() || req.User.GetName() == "bootstrap" || authProviderName == "bootstrap" || authProviderNamespace == "bootstrap" {
 		// The user is either not authenticated or is authenticated as the bootstrap user.
 		log.Infof("Denied MCP OAuth callback because user is not authenticated with a non-bootstrap identity: authRequest=%s", oauthAppAuthRequest.Name)
-		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-			Code:        ErrAccessDenied,
-			Description: "user is not authenticated",
-		})
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrAccessDenied, "user is not authenticated", ""))
 		return nil
 	}
 
 	// Check if the MCP server is a component of a composite; only finalize if it's not
 	var server v1.MCPServer
 	if err := req.Get(&server, mcpServerID); err != nil {
-		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-			Code:        ErrServerError,
-			Description: err.Error(),
-		})
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, err.Error(), oauthAppAuthRequest.Spec.State))
 		return nil
 	}
 
@@ -638,11 +536,7 @@ func authenticatedOAuthUser(req api.Context, oauthAppAuthRequest v1.OAuthAuthReq
 	}
 
 	log.Infof("Denied %s because user is not authenticated with a non-bootstrap identity: authRequest=%s", phase, oauthAppAuthRequest.Name)
-	redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-		Code:        ErrAccessDenied,
-		Description: "user is not authenticated",
-		State:       oauthAppAuthRequest.Spec.State,
-	})
+	redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrAccessDenied, "user is not authenticated", oauthAppAuthRequest.Spec.State))
 	return "", "", false
 }
 
@@ -652,11 +546,7 @@ func authenticatedOAuthConsentUser(req api.Context, oauthAppAuthRequest v1.OAuth
 	}
 
 	log.Infof("Denied OAuth consent because authenticated user does not match auth request user: authRequest=%s", oauthAppAuthRequest.Name)
-	redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, Error{
-		Code:        ErrAccessDenied,
-		Description: "user is not authorized for this OAuth request",
-		State:       oauthAppAuthRequest.Spec.State,
-	})
+	redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrAccessDenied, "user is not authorized for this OAuth request", oauthAppAuthRequest.Spec.State))
 	return false
 }
 
@@ -775,7 +665,7 @@ func (h *handler) maybeHandleDebuggerCallback(req api.Context) (bool, error) {
 	return true, nil
 }
 
-func redirectWithAuthorizeError(req api.Context, redirectURI string, err Error) {
+func redirectWithAuthorizeError(req api.Context, redirectURI string, err oauthError) {
 	http.Redirect(req.ResponseWriter, req.Request, authorizeErrorURL(redirectURI, err), http.StatusFound)
 }
 
@@ -790,7 +680,7 @@ func oauthCompletionURL(oauthAuthRequestID string) string {
 	return "/auth/oauth/complete/" + url.PathEscape(oauthAuthRequestID)
 }
 
-func authorizeErrorURL(redirectURI string, err Error) string {
+func authorizeErrorURL(redirectURI string, err oauthError) string {
 	return redirectURI + "?" + err.toQuery().Encode()
 }
 

--- a/pkg/api/handlers/mcpgateway/oauth/client.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client.go
@@ -36,10 +36,7 @@ func (h *handler) register(req api.Context) error {
 	}
 
 	if err := handlers.ValidateClientConfig(&oauthClient, h.oauthConfig); err != nil {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidClientMetadata,
-			Description: err.Error(),
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidClientMetadata, err.Error(), ""))
 	}
 
 	clientSecret, registrationToken, err := h.ensureTokenAndSecret(&oauthClient)
@@ -94,10 +91,7 @@ func (h *handler) updateClient(req api.Context) error {
 	oauthClient.Spec.Manifest = oauthClientManifest
 
 	if err := handlers.ValidateClientConfig(&oauthClient, h.oauthConfig); err != nil {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidClientMetadata,
-			Description: err.Error(),
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidClientMetadata, err.Error(), ""))
 	}
 
 	clientSecret, registrationToken, err := h.updateClientIfNecessary(req.Context(), req.Storage, &oauthClient)

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
@@ -50,23 +50,14 @@ func (h *handler) resolveOAuthClient(ctx context.Context, c kclient.Client, clie
 
 	clientNamespace, clientName, ok := strings.Cut(clientID, ":")
 	if !ok {
-		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidClient,
-			Description: "client_id is invalid",
-		}
+		return v1.OAuthClient{}, newOAuthError(ErrInvalidClient, "client_id is invalid", "")
 	}
 
 	var oauthClient v1.OAuthClient
 	if err := c.Get(ctx, kclient.ObjectKey{Namespace: clientNamespace, Name: clientName}, &oauthClient); apierrors.IsNotFound(err) {
-		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidClient,
-			Description: fmt.Sprintf("client_id does not exist: %s", clientID),
-		}
+		return v1.OAuthClient{}, newOAuthError(ErrInvalidClient, fmt.Sprintf("client_id does not exist: %s", clientID), "")
 	} else if err != nil {
-		return v1.OAuthClient{}, Error{
-			Code:        ErrServerError,
-			Description: fmt.Sprintf("failed to get OAuth client: %v", err),
-		}
+		return v1.OAuthClient{}, newOAuthError(ErrServerError, fmt.Sprintf("failed to get OAuth client: %v", err), "")
 	}
 
 	return oauthClient, nil
@@ -74,10 +65,7 @@ func (h *handler) resolveOAuthClient(ctx context.Context, c kclient.Client, clie
 
 func (h *handler) resolveClientIDMetadataDocument(ctx context.Context, clientID string) (v1.OAuthClient, error) {
 	if err := validateClientIDMetadataDocumentURL(clientID); err != nil {
-		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidClient,
-			Description: err.Error(),
-		}
+		return v1.OAuthClient{}, newOAuthError(ErrInvalidClient, err.Error(), "")
 	}
 
 	if client, ok := h.getCachedClientMetadata(clientID); ok {
@@ -86,18 +74,12 @@ func (h *handler) resolveClientIDMetadataDocument(ctx context.Context, clientID 
 
 	doc, expiresAt, err := h.fetchClientIDMetadataDocument(ctx, clientID)
 	if err != nil {
-		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidClient,
-			Description: err.Error(),
-		}
+		return v1.OAuthClient{}, newOAuthError(ErrInvalidClient, err.Error(), "")
 	}
 
 	client, err := h.oauthClientFromMetadataDocument(clientID, doc)
 	if err != nil {
-		return v1.OAuthClient{}, Error{
-			Code:        ErrInvalidClient,
-			Description: err.Error(),
-		}
+		return v1.OAuthClient{}, newOAuthError(ErrInvalidClient, err.Error(), "")
 	}
 
 	h.cacheClientMetadata(clientID, client, expiresAt)

--- a/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
@@ -272,6 +272,13 @@ func assertInvalidClientErr(t *testing.T, err error) {
 	if !strings.Contains(errHTTP.Message, `"error":"invalid_client"`) {
 		t.Fatalf("expected invalid_client error, got %s", errHTTP.Message)
 	}
+	var oauthErr oauthError
+	if err := json.Unmarshal([]byte(errHTTP.Message), &oauthErr); err != nil {
+		t.Fatalf("expected valid OAuth error JSON, got %q: %v", errHTTP.Message, err)
+	}
+	if !strings.HasPrefix(oauthErr.Description, obotErrorPrefix) {
+		t.Fatalf("expected Obot error marker, got %q", oauthErr.Description)
+	}
 }
 
 func signClientAssertion(t *testing.T, key *rsa.PrivateKey, kid, clientID, audience string) string {

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -38,6 +38,8 @@ const (
 	tokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"
 	tokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
 	tokenTypeAPIKey      = "urn:obot:token-type:api-key"
+	obotErrorSource      = "Obot"
+	obotErrorPrefix      = obotErrorSource + ": "
 
 	ErrUnsupportedGrantType = ErrorCode("unsupported_grant_type")
 )
@@ -50,7 +52,7 @@ type TokenExchangeResponse struct {
 	ExpiresIn       int    `json:"expires_in"`
 }
 
-func (h *handler) token(req api.Context) error {
+func (h *handler) token(req api.Context) (err error) {
 	if err := req.ParseForm(); err != nil {
 		return types.NewErrBadRequest("failed to parse request body: %v", err)
 	}
@@ -79,10 +81,7 @@ func (h *handler) token(req api.Context) error {
 
 			clientID, err = url.QueryUnescape(clientID)
 			if err != nil {
-				return newOAuthErrHTTP(http.StatusBadRequest, Error{
-					Code:        ErrInvalidClient,
-					Description: "client_id is invalid",
-				})
+				return newOAuthErrHTTP(http.StatusBadRequest, newOAuthError(ErrInvalidClient, "client_id is invalid", ""))
 			}
 		}
 	} else {
@@ -104,7 +103,7 @@ func (h *handler) token(req api.Context) error {
 
 	client, err := h.resolveOAuthClient(req.Context(), req.Storage, clientID)
 	if err != nil {
-		if oauthErr, ok := errors.AsType[Error](err); ok {
+		if oauthErr, ok := errors.AsType[oauthError](err); ok {
 			if oauthErr.Code == ErrInvalidClient {
 				return newOAuthErrHTTP(http.StatusUnauthorized, oauthErr)
 			}
@@ -128,17 +127,11 @@ func (h *handler) token(req api.Context) error {
 
 	grantType := req.FormValue("grant_type")
 	if !slices.Contains(h.oauthConfig.GrantTypesSupported, grantType) {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: fmt.Sprintf("grant_type must be one of %s, not %s", strings.Join(h.oauthConfig.GrantTypesSupported, ", "), grantType),
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, fmt.Sprintf("grant_type must be one of %s, not %s", strings.Join(h.oauthConfig.GrantTypesSupported, ", "), grantType), ""))
 	}
 
 	if len(client.Spec.Manifest.GrantTypes) > 0 && !slices.Contains(client.Spec.Manifest.GrantTypes, grantType) || len(client.Spec.Manifest.GrantTypes) == 0 && grantType != "authorization_code" {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidClient,
-			Description: "client is not allowed to use authorization_code grant type",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidClient, "client is not allowed to use authorization_code grant type", ""))
 	}
 	log.Debugf("Processing OAuth token request: client=%s/%s grantType=%s", client.Namespace, client.Name, grantType)
 
@@ -150,19 +143,13 @@ func (h *handler) token(req api.Context) error {
 	case "urn:ietf:params:oauth:grant-type:token-exchange":
 		return h.doTokenExchange(req, client, req.FormValue("resource"), req.FormValue("subject_token"), req.FormValue("subject_token_type"), req.FormValue("requested_token_type"))
 	default:
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: fmt.Sprintf("grant_type must be one of %s, not %s", strings.Join(h.oauthConfig.GrantTypesSupported, ", "), grantType),
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, fmt.Sprintf("grant_type must be one of %s, not %s", strings.Join(h.oauthConfig.GrantTypesSupported, ", "), grantType), ""))
 	}
 }
 
 func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClient, code, codeVerifier string) error {
 	if code == "" {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "code is required",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "code is required", ""))
 	}
 
 	var oauthAuthRequestList v1.OAuthAuthRequestList
@@ -174,18 +161,12 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 		return err
 	}
 	if len(oauthAuthRequestList.Items) != 1 {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "code is invalid",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "code is invalid", ""))
 	}
 
 	oauthAuthRequest := oauthAuthRequestList.Items[0]
 	if oauthAuthRequest.Spec.ClientID != oauthClient.Name {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "code is invalid",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "code is invalid", ""))
 	}
 
 	// Authorization codes are one-time use
@@ -199,33 +180,21 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 		case "S256":
 			hashedCodeVerifier := sha256.Sum256([]byte(codeVerifier))
 			if oauthAuthRequest.Spec.CodeChallenge != base64.RawURLEncoding.EncodeToString(hashedCodeVerifier[:]) {
-				return types.NewErrBadRequest("%v", Error{
-					Code:        ErrInvalidRequest,
-					Description: "code_verifier is invalid",
-				})
+				return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "code_verifier is invalid", ""))
 			}
 		case "plain":
 			if oauthAuthRequest.Spec.CodeChallenge != codeVerifier {
-				return types.NewErrBadRequest("%v", Error{
-					Code:        ErrInvalidRequest,
-					Description: "code_verifier is invalid",
-				})
+				return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "code_verifier is invalid", ""))
 			}
 		default:
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: "code_challenge_method must be S256 or plain. ",
-			})
+			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "code_challenge_method must be S256 or plain.", ""))
 		}
 	}
 
 	userID := fmt.Sprintf("%d", oauthAuthRequest.Spec.UserID)
 	user, err := req.GatewayClient.UserByID(req.Context(), userID)
 	if err != nil {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "invalid user",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid user", ""))
 	}
 
 	now := time.Now()
@@ -283,24 +252,15 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 
 func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, refreshToken string) error {
 	if refreshToken == "" {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "refresh_token is required",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "refresh_token is required", ""))
 	}
 
 	var oauthToken v1.OAuthToken
 	if err := req.Storage.Get(req.Context(), kclient.ObjectKey{Namespace: oauthClient.Namespace, Name: fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken)))}, &oauthToken); err != nil {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "refresh_token is invalid",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "refresh_token is invalid", ""))
 	}
 	if oauthToken.Spec.ClientID != oauthClient.Name {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "refresh_token is invalid",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "refresh_token is invalid", ""))
 	}
 
 	if err := req.Delete(&oauthToken); err != nil {
@@ -309,29 +269,17 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 
 	user, err := req.GatewayClient.UserInfoByID(req.Context(), oauthToken.Spec.UserID)
 	if err != nil {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "invalid user",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid user", ""))
 	}
 
 	allowed, err := authz.CheckMCPIDAccess(req.Context(), req.Storage, h.acrHelper, user, oauthToken.Spec.MCPID)
 	if apierrors.IsNotFound(err) {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "invalid MCP server",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid MCP server", ""))
 	} else if err != nil {
-		return Error{
-			Code:        ErrServerError,
-			Description: fmt.Sprintf("failed to check access to MCP server: %v", err),
-		}
+		return newOAuthError(ErrServerError, fmt.Sprintf("failed to check access to MCP server: %v", err), "")
 	}
 	if !allowed {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "invalid MCP server",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid MCP server", ""))
 	}
 
 	now := time.Now()
@@ -388,32 +336,20 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 
 func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, resource, subjectToken, subjectTokenType, requestedTokenType string) error {
 	if subjectToken == "" {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "subject_token is required",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "subject_token is required", ""))
 	}
 
 	if subjectTokenType != tokenTypeJWT && subjectTokenType != tokenTypeAPIKey {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "subject_token_type must be urn:ietf:params:oauth:token-type:jwt or urn:obot:token-type:api-key",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "subject_token_type must be urn:ietf:params:oauth:token-type:jwt or urn:obot:token-type:api-key", ""))
 	}
 
 	// Validate optional requested_token_type parameter
 	if requestedTokenType != "" && requestedTokenType != tokenTypeAccessToken {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "requested_token_type must be urn:ietf:params:oauth:token-type:access_token",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "requested_token_type must be urn:ietf:params:oauth:token-type:access_token", ""))
 	}
 
 	if resource == "" {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "resource is required",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "resource is required", ""))
 	}
 
 	var (
@@ -432,28 +368,19 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 		apiKey, err = req.GatewayClient.ValidateAPIKey(req.Context(), subjectToken)
 		if err != nil {
 			log.Infof("Denied token exchange due to invalid API key subject token: client=%s", oauthClient.Name)
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: "invalid API key",
-			})
+			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid API key", ""))
 		}
 
 		// Get the MCP ID from the OAuth client
 		mcpID = oauthClient.Spec.MCPServerName
 		if mcpID == "" {
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: "OAuth client not associated with an MCP server",
-			})
+			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "OAuth client not associated with an MCP server", ""))
 		}
 
 		// Check if API key has access to this MCP server
 		if err := validateAPIKeyAccess(req, apiKey, mcpID); err != nil {
 			log.Infof("Denied token exchange due to API key access restrictions: client=%s mcpID=%s", oauthClient.Name, mcpID)
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrAccessDenied,
-				Description: err.Error(),
-			})
+			return types.NewErrBadRequest("%v", newOAuthError(ErrAccessDenied, err.Error(), ""))
 		}
 
 		userID = fmt.Sprintf("%d", apiKey.UserID)
@@ -463,26 +390,17 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 		var err error
 		tokenCtx, err = h.tokenService.DecodeToken(req.Context(), subjectToken)
 		if err != nil {
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: "invalid subject_token",
-			})
+			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid subject_token", ""))
 		}
 
 		mcpID = tokenCtx.MCPID
 		if mcpID == "" {
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: "subject_token missing mcp_id claim",
-			})
+			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "subject_token missing mcp_id claim", ""))
 		}
 
 		userID = tokenCtx.UserID
 		if userID == "" {
-			return types.NewErrBadRequest("%v", Error{
-				Code:        ErrInvalidRequest,
-				Description: "subject_token missing sub claim",
-			})
+			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "subject_token missing sub claim", ""))
 		}
 	}
 
@@ -491,18 +409,12 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 		case system.IsMCPServerID(mcpID):
 			mcpServer = new(v1.MCPServer)
 			if err := req.Get(mcpServer, mcpID); err != nil {
-				return types.NewErrBadRequest("%v", Error{
-					Code:        ErrInvalidRequest,
-					Description: "failed to retrieve MCP server " + mcpID,
-				})
+				return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "failed to retrieve MCP server "+mcpID, ""))
 			}
 		case system.IsMCPServerInstanceID(mcpID):
 			mcpServerInstance = new(v1.MCPServerInstance)
 			if err := req.Get(mcpServerInstance, mcpID); err != nil {
-				return types.NewErrBadRequest("%v", Error{
-					Code:        ErrInvalidRequest,
-					Description: "failed to retrieve MCP server instance " + mcpID,
-				})
+				return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "failed to retrieve MCP server instance "+mcpID, ""))
 			}
 		}
 	}
@@ -529,10 +441,7 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 				ExpiresIn:       max(int(time.Until(expiresAt).Seconds()), 0),
 			})
 		} else if !apierrors.IsNotFound(err) {
-			return Error{
-				Code:        ErrInvalidRequest,
-				Description: fmt.Sprintf("failed to retrieve system MCP server %s: %v", resourceMCPID, err),
-			}
+			return newOAuthError(ErrInvalidRequest, fmt.Sprintf("failed to retrieve system MCP server %s: %v", resourceMCPID, err), "")
 		}
 	}
 
@@ -552,10 +461,7 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 					// Ensure this MCP server instance belongs to this composite MCP server.
 					var component v1.MCPServerInstance
 					if err := req.Get(&component, resourceMCPID); err != nil || component.Spec.CompositeName != mcpServer.Name {
-						return types.NewErrBadRequest("%v", Error{
-							Code:        ErrInvalidRequest,
-							Description: "failed to retrieve composite MCP server " + resourceMCPID,
-						})
+						return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "failed to retrieve composite MCP server "+resourceMCPID, ""))
 					}
 
 					audienceID = component.Spec.MCPServerName
@@ -563,10 +469,7 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 					// Ensure this MCP server belongs to this composite MCP server.
 					var component v1.MCPServer
 					if err := req.Get(&component, resourceMCPID); err != nil || component.Spec.CompositeName != mcpServer.Name {
-						return types.NewErrBadRequest("%v", Error{
-							Code:        ErrInvalidRequest,
-							Description: "failed to retrieve composite MCP server " + resourceMCPID,
-						})
+						return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "failed to retrieve composite MCP server "+resourceMCPID, ""))
 					}
 				}
 
@@ -578,19 +481,13 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 				// Ensure this MCP server exists and is a composite MCP server.
 				var server v1.MCPServer
 				if err := req.Get(&server, audienceID); err != nil || server.Spec.Manifest.Runtime != types.RuntimeComposite {
-					return types.NewErrBadRequest("%v", Error{
-						Code:        ErrInvalidRequest,
-						Description: "failed to retrieve composite MCP server " + audienceID,
-					})
+					return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "failed to retrieve composite MCP server "+audienceID, ""))
 				}
 
 				if apiKey != nil {
 					user, err := req.GatewayClient.UserByID(req.Context(), userID)
 					if err != nil {
-						return types.NewErrBadRequest("%v", Error{
-							Code:        ErrInvalidRequest,
-							Description: "invalid user",
-						})
+						return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid user", ""))
 					}
 
 					expiresAt := time.Now().Add(tokenExpiration)
@@ -667,10 +564,7 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 	// Retrieve the OAuth configuration and token
 	config, token, err := store.GetTokenConfig(req.Context(), resource)
 	if err != nil {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "failed to retrieve token configuration",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "failed to retrieve token configuration", ""))
 	}
 
 	if config == nil || token == nil {
@@ -680,10 +574,7 @@ func (h *handler) doTokenExchange(req api.Context, oauthClient v1.OAuthClient, r
 	// Refresh the token if needed
 	tok, err := config.TokenSource(req.Context(), token).Token()
 	if err != nil {
-		return types.NewErrBadRequest("%v", Error{
-			Code:        ErrInvalidRequest,
-			Description: "failed to refresh token",
-		})
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "failed to refresh token", ""))
 	}
 
 	// Store the refreshed token if it changed
@@ -739,11 +630,8 @@ func (h *handler) getTokenForMCPConnectResource(ctx context.Context, subjectToke
 
 	_, token, err := h.tokenService.NewToken(ctx, *tokenCtx)
 	if err != nil {
-		log.Errorf("failed to create token for component MCP server %s: %v", resourceMCPID, err)
-		return "", time.Time{}, types.NewErrBadRequest("%v", Error{
-			Code:        ErrServerError,
-			Description: "failed to create token",
-		})
+		log.Infof("Failed to create token for component MCP server: mcpID=%s error=%v", resourceMCPID, err)
+		return "", time.Time{}, types.NewErrBadRequest("%v", newOAuthError(ErrServerError, "failed to create token", ""))
 	}
 
 	return token, tokenCtx.ExpiresAt.Time, nil


### PR DESCRIPTION
This is supposed to help with identifying when errors are from Obot's OAuth process versus the second-level. To that end, we also add a prefix to the OAuth errors so that it is easier to identify the errors on the client side.