### PR TITLE
chore(ui): update MCP tunnels

### DIFF
--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -336,17 +336,6 @@
 								disabled: isBootStrapUser,
 								collapsible: false
 							},
-							...(profile.current.isAdmin?.()
-								? [
-										{
-											id: 'mcp-tunnels',
-											href: '/admin/mcp-tunnels',
-											label: 'MCP Tunnels',
-											disabled: isBootStrapUser,
-											collapsible: false
-										}
-									]
-								: []),
 							{
 								id: 'mcp-access-policies',
 								href: '/admin/mcp-access-policies',
@@ -396,7 +385,18 @@
 										disabled: isBootStrapUser,
 										collapsible: false
 									}
-								: undefined
+								: undefined,
+							...(profile.current.isAdmin?.()
+								? [
+										{
+											id: 'mcp-tunnels',
+											href: '/admin/mcp-tunnels',
+											label: 'MCP Tunnels',
+											disabled: isBootStrapUser,
+											collapsible: false
+										}
+									]
+								: [])
 						].filter(Boolean) as NavLink[]
 					},
 					{

--- a/ui/user/src/routes/admin/mcp-tunnels/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-tunnels/+page.svelte
@@ -130,7 +130,11 @@
 				<Cable class="text-muted-content size-24 opacity-25" />
 				<h2 class="text-muted-content text-lg font-semibold">No MCP tunnels</h2>
 				<p class="text-muted-content text-sm font-light">
-					Create a tunnel to let Obot reach remote MCP servers on another network.
+					MCP tunnels let Obot securely connect to private MCP servers that are not directly
+					reachable from Obot's network. You run a lightweight <code class="font-mono"
+						>obot tunnel</code
+					>
+					process on the private network and it opens an authenticated outbound connection to Obot.
 				</p>
 				{#if !isReadonly}
 					<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={createTunnel}>
@@ -140,49 +144,58 @@
 				{/if}
 			</div>
 		{:else}
-			<Table
-				data={tableData}
-				fields={['displayName', 'status', 'allowedURLs']}
-				headers={[
-					{ title: 'Name', property: 'displayName' },
-					{ title: 'Status', property: 'status' },
-					{ title: 'Allowed URLs', property: 'allowedURLs' }
-				]}
-				filterable={['displayName', 'status']}
-				sortable={['displayName', 'status']}
-				noAutoHideFields={['displayName', 'status']}
-				onClickRow={(tunnel, isCtrlClick) =>
-					openUrl(`/admin/mcp-tunnels/${tunnel.id}`, isCtrlClick)}
-			>
-				{#snippet actions(tunnel)}
-					{#if !isReadonly}
-						<IconButton
-							variant="danger"
-							onclick={(event) => {
-								event.stopPropagation();
-								tunnelToDelete = tunnel;
-							}}
-							tooltip={{ text: 'Delete Tunnel' }}
-						>
-							<Trash2 class="size-4" />
-						</IconButton>
-					{/if}
-				{/snippet}
-				{#snippet onRenderColumn(property, tunnel)}
-					{#if property === 'status'}
-						<MCPTunnelConnectionStatus
-							connection={tunnel.connection}
-							known={tunnelConnections !== undefined}
-						/>
-					{:else if property === 'allowedURLs'}
-						<span class="line-clamp-2 break-all" title={tunnel.allowedURLs}>
-							{tunnel.allowedURLs}
-						</span>
-					{:else}
-						{String(tunnel[property as keyof typeof tunnel])}
-					{/if}
-				{/snippet}
-			</Table>
+			<div class="flex flex-col gap-6">
+				<p class="text-base-content/80 text-base">
+					MCP tunnels let Obot securely connect to private MCP servers that are not directly
+					reachable from Obot's network. You run a lightweight <code class="font-mono"
+						>obot tunnel</code
+					>
+					process on the private network and it opens an authenticated outbound connection to Obot.
+				</p>
+				<Table
+					data={tableData}
+					fields={['displayName', 'status', 'allowedURLs']}
+					headers={[
+						{ title: 'Name', property: 'displayName' },
+						{ title: 'Status', property: 'status' },
+						{ title: 'Allowed URLs', property: 'allowedURLs' }
+					]}
+					filterable={['displayName', 'status']}
+					sortable={['displayName', 'status']}
+					noAutoHideFields={['displayName', 'status']}
+					onClickRow={(tunnel, isCtrlClick) =>
+						openUrl(`/admin/mcp-tunnels/${tunnel.id}`, isCtrlClick)}
+				>
+					{#snippet actions(tunnel)}
+						{#if !isReadonly}
+							<IconButton
+								variant="danger"
+								onclick={(event) => {
+									event.stopPropagation();
+									tunnelToDelete = tunnel;
+								}}
+								tooltip={{ text: 'Delete Tunnel' }}
+							>
+								<Trash2 class="size-4" />
+							</IconButton>
+						{/if}
+					{/snippet}
+					{#snippet onRenderColumn(property, tunnel)}
+						{#if property === 'status'}
+							<MCPTunnelConnectionStatus
+								connection={tunnel.connection}
+								known={tunnelConnections !== undefined}
+							/>
+						{:else if property === 'allowedURLs'}
+							<span class="line-clamp-2 break-all" title={tunnel.allowedURLs}>
+								{tunnel.allowedURLs}
+							</span>
+						{:else}
+							{String(tunnel[property as keyof typeof tunnel])}
+						{/if}
+					{/snippet}
+				</Table>
+			</div>
 		{/if}
 	</div>
 


### PR DESCRIPTION
This change moves the MCP Tunnels sidebar item to the bottom of its section. It also add some explainer text describing what tunnels are.

Here are the examples when there are no tunnels and when there is one.

<img width="2918" height="908" alt="image" src="https://github.com/user-attachments/assets/3e1be47a-64e7-4ff2-bff0-6568d6c3452f" />

<img width="2930" height="674" alt="image" src="https://github.com/user-attachments/assets/1c46b100-55bc-4050-b12a-21fc5240a862" />
