### PR TITLE
fix: limit models & model access policy to llm/llm-mini

### DIFF
--- a/pkg/api/handlers/modelaccesspolicy.go
+++ b/pkg/api/handlers/modelaccesspolicy.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,13 +48,9 @@ func (*ModelAccessPolicyHandler) Get(req api.Context) error {
 
 // Create creates a new model access policy.
 func (*ModelAccessPolicyHandler) Create(req api.Context) error {
-	var manifest types.ModelAccessPolicyManifest
-	if err := req.Read(&manifest); err != nil {
-		return types.NewErrBadRequest("failed to read model access policy manifest: %v", err)
-	}
-
-	if err := manifest.Validate(); err != nil {
-		return types.NewErrBadRequest("invalid model access policy manifest: %v", err)
+	manifest, err := readAndValidateModelAccessPolicyManifest(req)
+	if err != nil {
+		return err
 	}
 
 	policy := v1.ModelAccessPolicy{
@@ -77,13 +74,9 @@ func (*ModelAccessPolicyHandler) Create(req api.Context) error {
 func (*ModelAccessPolicyHandler) Update(req api.Context) error {
 	policyID := req.PathValue("id")
 
-	var manifest types.ModelAccessPolicyManifest
-	if err := req.Read(&manifest); err != nil {
-		return types.NewErrBadRequest("failed to read model access policy manifest: %v", err)
-	}
-
-	if err := manifest.Validate(); err != nil {
-		return types.NewErrBadRequest("invalid model access policy manifest: %v", err)
+	manifest, err := readAndValidateModelAccessPolicyManifest(req)
+	if err != nil {
+		return err
 	}
 
 	var existing v1.ModelAccessPolicy
@@ -109,6 +102,26 @@ func (*ModelAccessPolicyHandler) Delete(req api.Context) error {
 			Namespace: req.Namespace(),
 		},
 	})
+}
+
+func readAndValidateModelAccessPolicyManifest(req api.Context) (types.ModelAccessPolicyManifest, error) {
+	var manifest types.ModelAccessPolicyManifest
+	if err := req.Read(&manifest); err != nil {
+		return manifest, types.NewErrBadRequest("failed to read model access policy manifest: %v", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return manifest, types.NewErrBadRequest("invalid model access policy manifest: %v", err)
+	}
+	if err := modelaccesspolicy.ValidateModelResources(
+		req.Context(),
+		req.Storage,
+		req.Namespace(),
+		manifest.Models,
+	); err != nil {
+		return manifest, types.NewErrBadRequest("invalid model access policy manifest: %v", err)
+	}
+
+	return manifest, nil
 }
 
 func convertModelAccessPolicy(policy v1.ModelAccessPolicy) types.ModelAccessPolicy {

--- a/pkg/api/handlers/modelaccesspolicy_test.go
+++ b/pkg/api/handlers/modelaccesspolicy_test.go
@@ -40,12 +40,12 @@ func TestReadAndValidateModelAccessPolicyManifest(t *testing.T) {
 		{
 			name:     "rejects non-llm model",
 			modelIDs: []string{"m1-embedding"},
-			wantErr:  `model "m1-embedding" must have a usage type of "llm" or "llm-mini"`,
+			wantErr:  `model "m1-embedding" must have a usage type of "llm"`,
 		},
 		{
 			name:     "rejects non-llm alias",
 			modelIDs: []string{"obot://vision"},
-			wantErr:  `model "obot://vision" must have a usage type of "llm" or "llm-mini"`,
+			wantErr:  `model "obot://vision" must reference default model alias "llm" or "llm-mini"`,
 		},
 		{
 			name:     "allows selectors",
@@ -112,7 +112,7 @@ func TestModelAccessPolicyHandlerUpdateRejectsPersistedNonLLMModel(t *testing.T)
 		Request:        request,
 		Storage:        storageClient,
 	})
-	require.ErrorContains(t, err, `model "m1-embedding" must have a usage type of "llm" or "llm-mini"`)
+	require.ErrorContains(t, err, `model "m1-embedding" must have a usage type of "llm"`)
 
 	var policy v1.ModelAccessPolicy
 	require.NoError(t, storageClient.Get(t.Context(), kclient.ObjectKey{

--- a/pkg/api/handlers/modelaccesspolicy_test.go
+++ b/pkg/api/handlers/modelaccesspolicy_test.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/storage"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReadAndValidateModelAccessPolicyManifest(t *testing.T) {
+	storageClient := storage.Client(fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(
+			modelForAccessPolicyHandlerTest("m1-llm", types.ModelUsageLLM),
+			modelForAccessPolicyHandlerTest("m1-embedding", types.ModelUsageEmbedding),
+		).
+		Build())
+
+	tests := []struct {
+		name     string
+		modelIDs []string
+		wantErr  string
+	}{
+		{
+			name:     "allows llm model and aliases",
+			modelIDs: []string{"m1-llm", "obot://llm", "obot://llm-mini"},
+		},
+		{
+			name:     "rejects non-llm model",
+			modelIDs: []string{"m1-embedding"},
+			wantErr:  `model "m1-embedding" must have a usage type of "llm" or "llm-mini"`,
+		},
+		{
+			name:     "rejects non-llm alias",
+			modelIDs: []string{"obot://vision"},
+			wantErr:  `model "obot://vision" must have a usage type of "llm" or "llm-mini"`,
+		},
+		{
+			name:     "allows selectors",
+			modelIDs: []string{"model-prefix*"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := modelAccessPolicyManifestForHandlerTest(tt.modelIDs...)
+			body, err := json.Marshal(manifest)
+			require.NoError(t, err)
+
+			req := api.Context{
+				ResponseWriter: httptest.NewRecorder(),
+				Request:        httptest.NewRequest(http.MethodPost, "/api/model-access-policies", bytes.NewReader(body)),
+				Storage:        storageClient,
+			}
+			got, err := readAndValidateModelAccessPolicyManifest(req)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, manifest, got)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestModelAccessPolicyHandlerUpdateRejectsPersistedNonLLMModel(t *testing.T) {
+	const policyID = "map1-policy"
+
+	initialManifest := modelAccessPolicyManifestForHandlerTest("m1-embedding")
+	initialManifest.DisplayName = "Existing Policy"
+	storageClient := storage.Client(fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(
+			modelForAccessPolicyHandlerTest("m1-embedding", types.ModelUsageEmbedding),
+			&v1.ModelAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      policyID,
+					Namespace: system.DefaultNamespace,
+				},
+				Spec: v1.ModelAccessPolicySpec{
+					Manifest: initialManifest,
+				},
+			},
+		).
+		Build())
+
+	updatedManifest := initialManifest
+	updatedManifest.DisplayName = "Updated Policy"
+	body, err := json.Marshal(updatedManifest)
+	require.NoError(t, err)
+
+	request := httptest.NewRequest(
+		http.MethodPut,
+		"/api/model-access-policies/"+policyID,
+		bytes.NewReader(body),
+	)
+	request.SetPathValue("id", policyID)
+	err = new(ModelAccessPolicyHandler).Update(api.Context{
+		ResponseWriter: httptest.NewRecorder(),
+		Request:        request,
+		Storage:        storageClient,
+	})
+	require.ErrorContains(t, err, `model "m1-embedding" must have a usage type of "llm" or "llm-mini"`)
+
+	var policy v1.ModelAccessPolicy
+	require.NoError(t, storageClient.Get(t.Context(), kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      policyID,
+	}, &policy))
+	require.Equal(t, initialManifest, policy.Spec.Manifest)
+}
+
+func modelForAccessPolicyHandlerTest(name string, usage types.ModelUsage) *v1.Model {
+	return &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.ModelSpec{
+			Manifest: types.ModelManifest{
+				Usage: usage,
+			},
+		},
+	}
+}
+
+func modelAccessPolicyManifestForHandlerTest(modelIDs ...string) types.ModelAccessPolicyManifest {
+	models := make([]types.ModelResource, 0, len(modelIDs))
+	for _, modelID := range modelIDs {
+		models = append(models, types.ModelResource{ID: modelID})
+	}
+	return types.ModelAccessPolicyManifest{
+		Subjects: []types.Subject{{
+			Type: types.SubjectTypeUser,
+			ID:   "user",
+		}},
+		Models: models,
+	}
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -65,6 +65,10 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to apply data: %w", err)
 	}
 
+	if err := migrateDefaultModelAccessPolicyModels(ctx, c.services.StorageClient); err != nil {
+		return fmt.Errorf("failed to migrate default model access policy models: %w", err)
+	}
+
 	if err := ensureDefaultUserRoleSetting(ctx, c.services.StorageClient); err != nil {
 		return fmt.Errorf("failed to ensure default user role setting: %w", err)
 	}

--- a/pkg/controller/data/data.go
+++ b/pkg/controller/data/data.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/controller/handlers/skillrepository"
+	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +41,10 @@ func Data(ctx context.Context, c kclient.Client, defaultSkillRepoURL, defaultSki
 			}
 		} else if err != nil {
 			return err
+		}
+
+		if !modelaccesspolicy.IsAllowedDefaultModelAlias(alias.Name) {
+			continue
 		}
 
 		// Build the default model access policy dynamically from default model aliases

--- a/pkg/controller/data/data_test.go
+++ b/pkg/controller/data/data_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"testing"
 
+	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
@@ -18,6 +19,32 @@ func newFakeClient(t *testing.T, objects ...kclient.Object) kclient.Client {
 		WithScheme(storagescheme.Scheme).
 		WithObjects(objects...).
 		Build()
+}
+
+func TestDataCreatesDefaultModelAccessPolicyWithLLMAliases(t *testing.T) {
+	ctx := t.Context()
+	client := newFakeClient(t)
+
+	require.NoError(t, Data(ctx, client, "", ""))
+
+	var policy v1.ModelAccessPolicy
+	require.NoError(t, client.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      system.ModelAccessPolicyPrefix + "-default",
+	}, &policy))
+	assert.Equal(t, "Default Policy", policy.Spec.Manifest.DisplayName)
+	assert.Equal(t, []types.Subject{{
+		Type: types.SubjectTypeSelector,
+		ID:   "*",
+	}}, policy.Spec.Manifest.Subjects)
+	assert.Equal(t, []types.ModelResource{
+		{ID: "obot://llm"},
+		{ID: "obot://llm-mini"},
+	}, policy.Spec.Manifest.Models)
+
+	var aliases v1.DefaultModelAliasList
+	require.NoError(t, client.List(ctx, &aliases))
+	assert.Len(t, aliases.Items, 5)
 }
 
 func TestCreateDefaultSkillRepository(t *testing.T) {

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// PruneModels ensures invalid and ineffectual model resources are removed from
+// PruneDefaultPolicy ensures invalid and ineffectual model resources are removed from
 // the default ModelAccessPolicy. Custom policies are intentionally left intact
 // so their legacy resources remain visible for users to remediate.
 // This handler removes:
@@ -20,7 +20,7 @@ import (
 //
 // Wildcard suffix patterns (e.g. "claude-haiku-4-5*") are always kept, even when
 // they currently match no models, since they apply to future models as well.
-func PruneModels(req router.Request, _ router.Response) error {
+func PruneDefaultPolicy(req router.Request, _ router.Response) error {
 	policy := req.Object.(*v1.ModelAccessPolicy)
 	if policy.Namespace != system.DefaultNamespace ||
 		policy.Name != system.ModelAccessPolicyPrefix+"-default" {

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy.go
@@ -3,14 +3,18 @@ package modelaccesspolicy
 import (
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/apiclient/types"
+	accesspolicy "github.com/obot-platform/obot/pkg/modelaccesspolicy"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// PruneModels ensures invalid and ineffectual model resources are removed from ModelAccessPolicies.
+// PruneModels ensures invalid and ineffectual model resources are removed from
+// the default ModelAccessPolicy. Custom policies are intentionally left intact
+// so their legacy resources remain visible for users to remediate.
 // This handler removes:
 // - Models that no longer exist
+// - Models and default aliases that are not LLM usage types
 // - Duplicates
 // - Explicit model references when a wildcard is present
 //
@@ -18,6 +22,10 @@ import (
 // they currently match no models, since they apply to future models as well.
 func PruneModels(req router.Request, _ router.Response) error {
 	policy := req.Object.(*v1.ModelAccessPolicy)
+	if policy.Namespace != system.DefaultNamespace ||
+		policy.Name != system.ModelAccessPolicyPrefix+"-default" {
+		return nil
+	}
 
 	var (
 		resources = make([]types.ModelResource, 0, len(policy.Spec.Manifest.Models))
@@ -36,36 +44,20 @@ func PruneModels(req router.Request, _ router.Response) error {
 			break
 		}
 
-		if alias, isAlias := resource.IsDefaultModelAliasRef(); isAlias {
-			if types.DefaultModelAliasTypeFromString(alias) != types.DefaultModelAliasTypeUnknown {
-				// Valid model alias type, keep
-				resources = append(resources, resource)
-			}
-
-			continue
-		}
-
-		if _, isPattern := resource.IsWildcardSuffix(); isPattern {
-			// Keep wildcard suffix patterns unconditionally; they're forward-looking
-			// and may match models that don't exist yet.
+		err := accesspolicy.ValidateModelResource(
+			req.Ctx,
+			req.Client,
+			policy.Namespace,
+			resource,
+		)
+		if err == nil {
 			resources = append(resources, resource)
 			continue
 		}
-
-		if !system.IsModelID(resource.ID) {
-			// Prune invalid model ID
+		if accesspolicy.IsInvalidModelResource(err) || apierrors.IsNotFound(err) {
 			continue
 		}
-
-		var model v1.Model
-		if err := req.Get(&model, policy.Namespace, resource.ID); apierrors.IsNotFound(err) {
-			// Prune missing model
-			continue
-		} else if err != nil {
-			return err
-		}
-
-		resources = append(resources, resource)
+		return err
 	}
 
 	if len(resources) == len(policy.Spec.Manifest.Models) {

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +21,22 @@ func TestPruneModels(t *testing.T) {
 			Name:      "m1-existing",
 			Namespace: "default",
 		},
+		Spec: v1.ModelSpec{
+			Manifest: types.ModelManifest{
+				Usage: types.ModelUsageLLM,
+			},
+		},
+	}
+	embeddingModel := &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "m1-embedding",
+			Namespace: "default",
+		},
+		Spec: v1.ModelSpec{
+			Manifest: types.ModelManifest{
+				Usage: types.ModelUsageEmbedding,
+			},
+		},
 	}
 
 	tests := []struct {
@@ -27,6 +44,7 @@ func TestPruneModels(t *testing.T) {
 		modelIDs   []string
 		wantIDs    []string
 		wantUpdate bool
+		custom     bool
 	}{
 		{
 			name:       "keeps wildcard suffix pattern matching no models",
@@ -60,9 +78,49 @@ func TestPruneModels(t *testing.T) {
 		},
 		{
 			name:       "no update when nothing is pruned",
-			modelIDs:   []string{"m1-existing", "obot://llm", "gpt-4o*"},
-			wantIDs:    []string{"m1-existing", "obot://llm", "gpt-4o*"},
+			modelIDs:   []string{"m1-existing", "obot://llm", "obot://llm-mini", "gpt-4o*"},
+			wantIDs:    []string{"m1-existing", "obot://llm", "obot://llm-mini", "gpt-4o*"},
 			wantUpdate: false,
+		},
+		{
+			name: "custom policy preserves invalid and non-llm resources",
+			modelIDs: []string{
+				"m1-existing",
+				"m1-embedding",
+				"m1-missing",
+				"not-a-model",
+				"obot://llm",
+				"obot://text-embedding",
+				"obot://image-generation",
+				"obot://vision",
+				"obot://unknown",
+			},
+			wantIDs: []string{
+				"m1-existing",
+				"m1-embedding",
+				"m1-missing",
+				"not-a-model",
+				"obot://llm",
+				"obot://text-embedding",
+				"obot://image-generation",
+				"obot://vision",
+				"obot://unknown",
+			},
+			wantUpdate: false,
+			custom:     true,
+		},
+		{
+			name: "default policy prunes non-llm models and aliases",
+			modelIDs: []string{
+				"m1-existing",
+				"m1-embedding",
+				"obot://llm",
+				"obot://text-embedding",
+				"obot://image-generation",
+				"obot://vision",
+			},
+			wantIDs:    []string{"m1-existing", "obot://llm"},
+			wantUpdate: true,
 		},
 	}
 
@@ -73,12 +131,17 @@ func TestPruneModels(t *testing.T) {
 				models = append(models, types.ModelResource{ID: id})
 			}
 
+			policyName := system.ModelAccessPolicyPrefix + "-default"
+			if tt.custom {
+				policyName = "custom-policy"
+			}
+
 			client := fake.NewClientBuilder().
 				WithScheme(storagescheme.Scheme).
-				WithObjects(existingModel, &v1.ModelAccessPolicy{
+				WithObjects(existingModel, embeddingModel, &v1.ModelAccessPolicy{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-policy",
-						Namespace: "default",
+						Name:      policyName,
+						Namespace: system.DefaultNamespace,
 					},
 					Spec: v1.ModelAccessPolicySpec{
 						Manifest: types.ModelAccessPolicyManifest{
@@ -91,7 +154,7 @@ func TestPruneModels(t *testing.T) {
 
 			// Fetch the stored policy so the handler updates it with a valid resource version
 			var policy v1.ModelAccessPolicy
-			key := kclient.ObjectKey{Namespace: "default", Name: "test-policy"}
+			key := kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: policyName}
 			require.NoError(t, client.Get(t.Context(), key, &policy))
 
 			initialVersion := policy.ResourceVersion

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestPruneModels(t *testing.T) {
+func TestPruneDefaultPolicy(t *testing.T) {
 	existingModel := &v1.Model{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "m1-existing",
@@ -158,7 +158,7 @@ func TestPruneModels(t *testing.T) {
 			require.NoError(t, client.Get(t.Context(), key, &policy))
 
 			initialVersion := policy.ResourceVersion
-			err := PruneModels(router.Request{
+			err := PruneDefaultPolicy(router.Request{
 				Client:    client,
 				Ctx:       t.Context(),
 				Object:    &policy,

--- a/pkg/controller/migrate.go
+++ b/pkg/controller/migrate.go
@@ -5,10 +5,53 @@ import (
 	"fmt"
 
 	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func migrateDefaultModelAccessPolicyModels(ctx context.Context, client kclient.Client) error {
+	var policy v1.ModelAccessPolicy
+	if err := client.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      system.ModelAccessPolicyPrefix + "-default",
+	}, &policy); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get default model access policy: %w", err)
+	}
+
+	models := make([]types.ModelResource, 0, len(policy.Spec.Manifest.Models))
+	for _, model := range policy.Spec.Manifest.Models {
+		err := modelaccesspolicy.ValidateModelResource(
+			ctx,
+			client,
+			policy.Namespace,
+			model,
+		)
+		if err == nil {
+			models = append(models, model)
+			continue
+		}
+		if modelaccesspolicy.IsInvalidModelResource(err) || apierrors.IsNotFound(err) {
+			continue
+		}
+		return fmt.Errorf("failed to validate default model access policy: %w", err)
+	}
+
+	if len(models) == len(policy.Spec.Manifest.Models) {
+		return nil
+	}
+
+	policy.Spec.Manifest.Models = models
+	if err := client.Update(ctx, &policy); err != nil {
+		return fmt.Errorf("failed to update default model access policy: %w", err)
+	}
+
+	return nil
+}
 
 func addCatalogIDToAccessControlRules(ctx context.Context, client kclient.Client) error {
 	var acRules v1.AccessControlRuleList

--- a/pkg/controller/migrate_test.go
+++ b/pkg/controller/migrate_test.go
@@ -24,6 +24,105 @@ func newFakeClient(t *testing.T, objects ...kclient.Object) kclient.Client {
 		Build()
 }
 
+func TestMigrateDefaultModelAccessPolicyModels(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("missing default policy is a no-op", func(t *testing.T) {
+		client := newFakeClient(t)
+		require.NoError(t, migrateDefaultModelAccessPolicyModels(ctx, client))
+	})
+
+	t.Run("cleans only the default policy and preserves custom policies", func(t *testing.T) {
+		defaultPolicyName := system.ModelAccessPolicyPrefix + "-default"
+		subjects := []types.Subject{{
+			Type: types.SubjectTypeGroup,
+			ID:   "custom-group",
+		}}
+		client := newFakeClient(t,
+			&v1.ModelAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultPolicyName,
+					Namespace: system.DefaultNamespace,
+				},
+				Spec: v1.ModelAccessPolicySpec{
+					Manifest: types.ModelAccessPolicyManifest{
+						DisplayName: "Customized Default Policy",
+						Subjects:    subjects,
+						Models: []types.ModelResource{
+							{ID: "obot://llm"},
+							{ID: "obot://text-embedding"},
+							{ID: "m1-custom"},
+							{ID: "obot://image-generation"},
+							{ID: "obot://llm-mini"},
+							{ID: "obot://vision"},
+							{ID: "custom-*"},
+						},
+					},
+				},
+			},
+			&v1.ModelAccessPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "custom-policy",
+					Namespace: system.DefaultNamespace,
+				},
+				Spec: v1.ModelAccessPolicySpec{
+					Manifest: types.ModelAccessPolicyManifest{
+						Subjects: subjects,
+						Models: []types.ModelResource{
+							{ID: "obot://text-embedding"},
+							{ID: "obot://llm"},
+							{ID: "m1-missing"},
+							{ID: "not-a-model"},
+							{ID: "obot://unknown"},
+						},
+					},
+				},
+			},
+			&v1.Model{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "m1-custom",
+					Namespace: system.DefaultNamespace,
+				},
+				Spec: v1.ModelSpec{
+					Manifest: types.ModelManifest{
+						Usage: types.ModelUsageLLM,
+					},
+				},
+			},
+		)
+
+		require.NoError(t, migrateDefaultModelAccessPolicyModels(ctx, client))
+		require.NoError(t, migrateDefaultModelAccessPolicyModels(ctx, client))
+
+		var defaultPolicy v1.ModelAccessPolicy
+		require.NoError(t, client.Get(ctx, kclient.ObjectKey{
+			Namespace: system.DefaultNamespace,
+			Name:      defaultPolicyName,
+		}, &defaultPolicy))
+		assert.Equal(t, "Customized Default Policy", defaultPolicy.Spec.Manifest.DisplayName)
+		assert.Equal(t, subjects, defaultPolicy.Spec.Manifest.Subjects)
+		assert.Equal(t, []types.ModelResource{
+			{ID: "obot://llm"},
+			{ID: "m1-custom"},
+			{ID: "obot://llm-mini"},
+			{ID: "custom-*"},
+		}, defaultPolicy.Spec.Manifest.Models)
+
+		var customPolicy v1.ModelAccessPolicy
+		require.NoError(t, client.Get(ctx, kclient.ObjectKey{
+			Namespace: system.DefaultNamespace,
+			Name:      "custom-policy",
+		}, &customPolicy))
+		assert.Equal(t, []types.ModelResource{
+			{ID: "obot://text-embedding"},
+			{ID: "obot://llm"},
+			{ID: "m1-missing"},
+			{ID: "not-a-model"},
+			{ID: "obot://unknown"},
+		}, customPolicy.Spec.Manifest.Models)
+	})
+}
+
 func TestMigratePublishedArtifactVisibility(t *testing.T) {
 	ctx := t.Context()
 

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -170,7 +170,7 @@ func (c *Controller) setupRoutes() {
 	})
 
 	// ModelAccessPolicys
-	root.Type(&v1.ModelAccessPolicy{}).HandlerFunc(modelaccesspolicy.PruneModels)
+	root.Type(&v1.ModelAccessPolicy{}).HandlerFunc(modelaccesspolicy.PruneDefaultPolicy)
 
 	// OAuthClients
 	root.Type(&v1.OAuthClient{}).HandlerFunc(cleanup.OAuthClients)

--- a/pkg/modelaccesspolicy/helper.go
+++ b/pkg/modelaccesspolicy/helper.go
@@ -3,7 +3,6 @@ package modelaccesspolicy
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/obot-platform/nah/pkg/backend"
@@ -105,42 +104,59 @@ func (h *Helper) UserHasAccessToModel(user kuser.Info, modelID string) (bool, er
 	return allowAll || allowedModels[modelID], err
 }
 
-// getUserAllowedModels returns a set of model IDs that a user can access.
-// If a user is an owner/admin or has been granted access to all models via a wildcard model selector, this method returns nil and true.
+// GetUserAllowedModels returns the model IDs that a user can access.
+// Model access policies only grant models with an allowed usage, including when
+// a policy contains a wildcard or suffix selector.
 func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, error) {
 	var (
-		allowedModels = make(map[string]bool)
-		aliasModels   = h.getAliasModels()
+		allowedModels  = make(map[string]bool)
+		aliasModels    = h.getAliasModels()
+		eligibleModels = make(map[string]*v1.Model)
+	)
 
-		addAllowedModel = func(model types.ModelResource) bool {
-			if model.IsWildcard() {
-				return true
-			}
+	for _, obj := range h.modelIndexer.List() {
+		model, ok := obj.(*v1.Model)
+		if !ok || !IsAllowedModelUsage(model.Spec.Manifest.Usage) {
+			continue
+		}
+		eligibleModels[model.Name] = model
+	}
 
-			modelID := model.ID
-			if alias, isAlias := model.IsDefaultModelAliasRef(); isAlias {
-				// The model ID is a default model alias reference (e.g. 'obot://llm')
-				// Look up the current model ID and swap it out
-				// If we can't find it, modelID will be an empty string, which is handled by the model ID check below
-				modelID = aliasModels[alias]
-			} else if _, isPattern := model.IsWildcardSuffix(); isPattern {
-				// The model ID is a wildcard suffix pattern (e.g. 'claude-haiku-4-5*')
-				// Allow every model, from any provider, whose target model matches it
-				for _, obj := range h.modelIndexer.List() {
-					if m, ok := obj.(*v1.Model); ok && model.MatchesTargetModel(m.Spec.Manifest.TargetModel) {
-						allowedModels[m.Name] = true
-					}
-				}
-				return false
-			}
-
-			if system.IsModelID(modelID) {
+	addAllowedModel := func(resource types.ModelResource) {
+		if resource.IsWildcard() {
+			for modelID := range eligibleModels {
 				allowedModels[modelID] = true
 			}
-
-			return false
+			return
 		}
-	)
+
+		modelID := resource.ID
+		if alias, isAlias := resource.IsDefaultModelAliasRef(); isAlias {
+			if !IsAllowedDefaultModelAlias(alias) {
+				return
+			}
+			// Resolve allowed aliases to their current model. The eligibility
+			// check below also protects against a misconfigured alias.
+			modelID = aliasModels[alias]
+		} else if _, isPattern := resource.IsWildcardSuffix(); isPattern {
+			for id, model := range eligibleModels {
+				if resource.MatchesTargetModel(model.Spec.Manifest.TargetModel) {
+					allowedModels[id] = true
+				}
+			}
+			return
+		}
+
+		if system.IsModelID(modelID) && eligibleModels[modelID] != nil {
+			allowedModels[modelID] = true
+		}
+	}
+
+	addResources := func(resources []types.ModelResource) {
+		for _, resource := range resources {
+			addAllowedModel(resource)
+		}
+	}
 
 	// Check policies with wildcard subject selector (*)
 	wildcardUserPolicies, err := h.getWildcardUserPolicies()
@@ -148,9 +164,7 @@ func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, e
 		return nil, false, err
 	}
 	for _, policy := range wildcardUserPolicies {
-		if slices.ContainsFunc(policy.Spec.Manifest.Models, addAllowedModel) {
-			return nil, true, nil
-		}
+		addResources(policy.Spec.Manifest.Models)
 	}
 
 	// Check policies that the user is directly included in
@@ -160,9 +174,7 @@ func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, e
 	}
 
 	for _, policy := range userPolicies {
-		if slices.ContainsFunc(policy.Spec.Manifest.Models, addAllowedModel) {
-			return nil, true, nil
-		}
+		addResources(policy.Spec.Manifest.Models)
 	}
 
 	// Check policies based on group membership
@@ -173,9 +185,7 @@ func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, e
 		}
 
 		for _, policy := range groupPolicies {
-			if slices.ContainsFunc(policy.Spec.Manifest.Models, addAllowedModel) {
-				return nil, true, nil
-			}
+			addResources(policy.Spec.Manifest.Models)
 		}
 	}
 
@@ -189,11 +199,12 @@ func (h *Helper) GetUserAllowedModels(user kuser.Info) (map[string]bool, bool, e
 // the user is allowed that model. This mirrors the access check enforced by the
 // LLM passthrough: a target appears here iff a request for it would succeed.
 //
-// allowAll reports that the user may use every model (admin/owner or a wildcard
-// model selector). When dialect is empty, there is nothing to enumerate, so the
-// returned map is nil and callers should skip filtering entirely rather than
-// treat the nil map as "allow nothing". A dialect filter always returns an
-// enumerated target set and allowAll=false.
+// allowAll reports that the user may use every model without a usage
+// restriction. Policy wildcards are enumerated by GetUserAllowedModels instead,
+// so they only include eligible usages. When dialect is empty and allowAll is
+// true, there is nothing to enumerate, so the returned map is nil and callers
+// should skip filtering rather than treat the nil map as "allow nothing". A
+// dialect filter always returns an enumerated target set and allowAll=false.
 func (h *Helper) GetUserAllowedTargetModels(user kuser.Info, provider, dialect string) (allowed map[string]bool, allowAll bool, _ error) {
 	allowedModels, allowAll, err := h.GetUserAllowedModels(user)
 	if err != nil {

--- a/pkg/modelaccesspolicy/helper_test.go
+++ b/pkg/modelaccesspolicy/helper_test.go
@@ -101,7 +101,7 @@ func TestGetUserAllowedTargetModels(t *testing.T) {
 		}
 	}
 
-	// wildcardPolicy grants every model to every user.
+	// wildcardPolicy grants every eligible model to every user.
 	wildcardPolicy := &v1.ModelAccessPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "p-wildcard", Namespace: "default"},
 		Spec: v1.ModelAccessPolicySpec{Manifest: types2.ModelAccessPolicyManifest{
@@ -140,14 +140,23 @@ func TestGetUserAllowedTargetModels(t *testing.T) {
 			want:     map[string]bool{"gpt-4o": true},
 		},
 		{
-			name: "wildcard policy reports allowAll without enumerating",
+			name: "wildcard policy enumerates only eligible model usages",
 			models: []*v1.Model{
 				newModel("m1-gpt-4o", provider, "gpt-4o", true),
 				newModel("m1-gpt-4o-mini", provider, "gpt-4o-mini", true),
+				newModel(
+					"m1-text-embedding",
+					provider,
+					"text-embedding-3-small",
+					true,
+					withUsage(types2.ModelUsageEmbedding),
+				),
 			},
-			policies:     []*v1.ModelAccessPolicy{wildcardPolicy},
-			want:         nil,
-			wantAllowAll: true,
+			policies: []*v1.ModelAccessPolicy{wildcardPolicy},
+			want: map[string]bool{
+				"gpt-4o":      true,
+				"gpt-4o-mini": true,
+			},
 		},
 		{
 			name: "filters allowed models by dialect",
@@ -182,9 +191,30 @@ func TestGetUserAllowedTargetModels(t *testing.T) {
 				newModel("m1-gpt-4o", provider, "gpt-4o", true),
 				newModel("m1-gpt-4o-mini", provider, "gpt-4o-mini", true),
 				newModel("m1-gpt-5", provider, "gpt-5", true),
+				newModel(
+					"m1-gpt-4o-embedding",
+					provider,
+					"gpt-4o-embedding",
+					true,
+					withUsage(types2.ModelUsageEmbedding),
+				),
 			},
 			policies: []*v1.ModelAccessPolicy{userPolicy("gpt-4o*")},
 			want:     map[string]bool{"gpt-4o": true, "gpt-4o-mini": true},
+		},
+		{
+			name: "legacy explicit non-llm model grants no access",
+			models: []*v1.Model{
+				newModel(
+					"m1-text-embedding",
+					provider,
+					"text-embedding-3-small",
+					true,
+					withUsage(types2.ModelUsageEmbedding),
+				),
+			},
+			policies: []*v1.ModelAccessPolicy{userPolicy("m1-text-embedding")},
+			want:     map[string]bool{},
 		},
 		{
 			name: "wildcard suffix pattern is case-sensitive",
@@ -309,6 +339,12 @@ func withDialect(dialect string) modelOpt {
 	}
 }
 
+func withUsage(usage types2.ModelUsage) modelOpt {
+	return func(m *v1.Model) {
+		m.Spec.Manifest.Usage = usage
+	}
+}
+
 func newModel(name, provider, targetModel string, active bool, opts ...modelOpt) *v1.Model {
 	m := &v1.Model{
 		ObjectMeta: metav1.ObjectMeta{
@@ -319,6 +355,7 @@ func newModel(name, provider, targetModel string, active bool, opts ...modelOpt)
 			TargetModel:   targetModel,
 			ModelProvider: provider,
 			Active:        active,
+			Usage:         types2.ModelUsageLLM,
 		}},
 	}
 	for _, opt := range opts {

--- a/pkg/modelaccesspolicy/validation.go
+++ b/pkg/modelaccesspolicy/validation.go
@@ -28,7 +28,7 @@ func IsInvalidModelResource(err error) bool {
 
 // IsAllowedModelUsage reports whether usage can be granted by a model access policy.
 func IsAllowedModelUsage(usage types.ModelUsage) bool {
-	return usage == types.ModelUsageLLM || usage == types.ModelUsage(types.DefaultModelAliasTypeLLMMini)
+	return usage == types.ModelUsageLLM
 }
 
 // IsAllowedDefaultModelAlias reports whether alias can be granted by a model access policy.
@@ -65,7 +65,7 @@ func ValidateModelResource(
 		if IsAllowedDefaultModelAlias(alias) {
 			return nil
 		}
-		return invalidModelUsage(resource.ID)
+		return invalidDefaultModelAlias(resource.ID)
 	}
 
 	if resource.IsWildcard() {
@@ -97,7 +97,17 @@ func ValidateModelResource(
 func invalidModelUsage(modelID string) error {
 	return &invalidModelResourceError{
 		message: fmt.Sprintf(
-			"model %q must have a usage type of %q or %q",
+			"model %q must have a usage type of %q",
+			modelID,
+			types.ModelUsageLLM,
+		),
+	}
+}
+
+func invalidDefaultModelAlias(modelID string) error {
+	return &invalidModelResourceError{
+		message: fmt.Sprintf(
+			"model %q must reference default model alias %q or %q",
 			modelID,
 			types.DefaultModelAliasTypeLLM,
 			types.DefaultModelAliasTypeLLMMini,

--- a/pkg/modelaccesspolicy/validation.go
+++ b/pkg/modelaccesspolicy/validation.go
@@ -1,0 +1,106 @@
+package modelaccesspolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type invalidModelResourceError struct {
+	message string
+}
+
+func (e *invalidModelResourceError) Error() string {
+	return e.message
+}
+
+// IsInvalidModelResource reports whether err identifies a model resource that
+// cannot be used in a model access policy.
+func IsInvalidModelResource(err error) bool {
+	var target *invalidModelResourceError
+	return errors.As(err, &target)
+}
+
+// IsAllowedModelUsage reports whether usage can be granted by a model access policy.
+func IsAllowedModelUsage(usage types.ModelUsage) bool {
+	return usage == types.ModelUsageLLM || usage == types.ModelUsage(types.DefaultModelAliasTypeLLMMini)
+}
+
+// IsAllowedDefaultModelAlias reports whether alias can be granted by a model access policy.
+func IsAllowedDefaultModelAlias(alias string) bool {
+	aliasType := types.DefaultModelAliasTypeFromString(alias)
+	return aliasType == types.DefaultModelAliasTypeLLM || aliasType == types.DefaultModelAliasTypeLLMMini
+}
+
+// ValidateModelResources validates all explicit models and default aliases in a policy.
+// Wildcard selectors are allowed because they are selection rules rather than concrete
+// model additions.
+func ValidateModelResources(
+	ctx context.Context,
+	reader kclient.Reader,
+	namespace string,
+	resources []types.ModelResource,
+) error {
+	for _, resource := range resources {
+		if err := ValidateModelResource(ctx, reader, namespace, resource); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateModelResource validates one model access policy resource.
+func ValidateModelResource(
+	ctx context.Context,
+	reader kclient.Reader,
+	namespace string,
+	resource types.ModelResource,
+) error {
+	if alias, ok := resource.IsDefaultModelAliasRef(); ok {
+		if IsAllowedDefaultModelAlias(alias) {
+			return nil
+		}
+		return invalidModelUsage(resource.ID)
+	}
+
+	if resource.IsWildcard() {
+		return nil
+	}
+	if _, ok := resource.IsWildcardSuffix(); ok {
+		return nil
+	}
+	if !system.IsModelID(resource.ID) {
+		return &invalidModelResourceError{
+			message: fmt.Sprintf("model %q must reference a valid model ID", resource.ID),
+		}
+	}
+
+	var model v1.Model
+	if err := reader.Get(ctx, kclient.ObjectKey{
+		Namespace: namespace,
+		Name:      resource.ID,
+	}, &model); err != nil {
+		return fmt.Errorf("failed to get model %q: %w", resource.ID, err)
+	}
+	if !IsAllowedModelUsage(model.Spec.Manifest.Usage) {
+		return invalidModelUsage(resource.ID)
+	}
+
+	return nil
+}
+
+func invalidModelUsage(modelID string) error {
+	return &invalidModelResourceError{
+		message: fmt.Sprintf(
+			"model %q must have a usage type of %q or %q",
+			modelID,
+			types.DefaultModelAliasTypeLLM,
+			types.DefaultModelAliasTypeLLMMini,
+		),
+	}
+}

--- a/pkg/modelaccesspolicy/validation_test.go
+++ b/pkg/modelaccesspolicy/validation_test.go
@@ -34,14 +34,16 @@ func TestValidateModelResource(t *testing.T) {
 			resource: types.ModelResource{ID: "m1-llm"},
 		},
 		{
-			name:     "allows llm-mini model",
-			resource: types.ModelResource{ID: "m1-llm-mini"},
+			name:        "rejects llm-mini model usage",
+			resource:    types.ModelResource{ID: "m1-llm-mini"},
+			wantInvalid: true,
+			wantErr:     `model "m1-llm-mini" must have a usage type of "llm"`,
 		},
 		{
 			name:        "rejects embedding model",
 			resource:    types.ModelResource{ID: "m1-embedding"},
 			wantInvalid: true,
-			wantErr:     `model "m1-embedding" must have a usage type of "llm" or "llm-mini"`,
+			wantErr:     `model "m1-embedding" must have a usage type of "llm"`,
 		},
 		{
 			name:     "allows llm alias",
@@ -55,7 +57,7 @@ func TestValidateModelResource(t *testing.T) {
 			name:        "rejects embedding alias",
 			resource:    types.ModelResource{ID: "obot://text-embedding"},
 			wantInvalid: true,
-			wantErr:     `model "obot://text-embedding" must have a usage type of "llm" or "llm-mini"`,
+			wantErr:     `model "obot://text-embedding" must reference default model alias "llm" or "llm-mini"`,
 		},
 		{
 			name:     "allows wildcard",

--- a/pkg/modelaccesspolicy/validation_test.go
+++ b/pkg/modelaccesspolicy/validation_test.go
@@ -1,0 +1,112 @@
+package modelaccesspolicy
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/storage"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestValidateModelResource(t *testing.T) {
+	reader := storage.Client(fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(
+			modelForValidationTest("m1-llm", types.ModelUsageLLM),
+			modelForValidationTest("m1-llm-mini", types.ModelUsage("llm-mini")),
+			modelForValidationTest("m1-embedding", types.ModelUsageEmbedding),
+		).
+		Build())
+
+	tests := []struct {
+		name        string
+		resource    types.ModelResource
+		wantInvalid bool
+		wantErr     string
+	}{
+		{
+			name:     "allows llm model",
+			resource: types.ModelResource{ID: "m1-llm"},
+		},
+		{
+			name:     "allows llm-mini model",
+			resource: types.ModelResource{ID: "m1-llm-mini"},
+		},
+		{
+			name:        "rejects embedding model",
+			resource:    types.ModelResource{ID: "m1-embedding"},
+			wantInvalid: true,
+			wantErr:     `model "m1-embedding" must have a usage type of "llm" or "llm-mini"`,
+		},
+		{
+			name:     "allows llm alias",
+			resource: types.ModelResource{ID: "obot://llm"},
+		},
+		{
+			name:     "allows llm-mini alias",
+			resource: types.ModelResource{ID: "obot://llm-mini"},
+		},
+		{
+			name:        "rejects embedding alias",
+			resource:    types.ModelResource{ID: "obot://text-embedding"},
+			wantInvalid: true,
+			wantErr:     `model "obot://text-embedding" must have a usage type of "llm" or "llm-mini"`,
+		},
+		{
+			name:     "allows wildcard",
+			resource: types.ModelResource{ID: "*"},
+		},
+		{
+			name:     "allows wildcard suffix",
+			resource: types.ModelResource{ID: "claude-*"},
+		},
+		{
+			name:        "rejects malformed model ID",
+			resource:    types.ModelResource{ID: "not-a-model-id"},
+			wantInvalid: true,
+			wantErr:     `model "not-a-model-id" must reference a valid model ID`,
+		},
+		{
+			name:     "returns missing model error",
+			resource: types.ModelResource{ID: "m1-missing"},
+			wantErr:  `failed to get model "m1-missing"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateModelResource(
+				t.Context(),
+				reader,
+				system.DefaultNamespace,
+				tt.resource,
+			)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, tt.wantErr)
+			require.Equal(t, tt.wantInvalid, IsInvalidModelResource(err))
+		})
+	}
+}
+
+func modelForValidationTest(name string, usage types.ModelUsage) *v1.Model {
+	return &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.ModelSpec{
+			Manifest: types.ModelManifest{
+				Usage: usage,
+			},
+		},
+	}
+}

--- a/ui/user/src/lib/components/admin/ListModels.svelte
+++ b/ui/user/src/lib/components/admin/ListModels.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import { getAdminModels } from '$lib/context/admin/models.svelte';
-	import { AdminService, type ModelProvider } from '$lib/services';
-	import { ModelUsage, ModelUsageLabels, type Model } from '$lib/services';
+	import { AdminService, ModelUsageLabels, type ModelProvider } from '$lib/services';
+	import { ModelUsage, type Model } from '$lib/services';
 	import { darkMode, profile } from '$lib/stores';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
-	import Select from '../Select.svelte';
 	import Toggle from '../Toggle.svelte';
 	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
@@ -19,18 +18,20 @@
 	function filterOutModelsByProvider(models: Model[], providerID: string) {
 		return models
 			.filter((model) => model.modelProvider === providerID)
-			.sort((a, b) => a.name.localeCompare(b.name));
+			.sort((a, b) => {
+				const aIsLlm = a.usage === ModelUsage.LLM;
+				const bIsLlm = b.usage === ModelUsage.LLM;
+				if (aIsLlm !== bIsLlm) {
+					return aIsLlm ? -1 : 1;
+				}
+				return a.name.localeCompare(b.name);
+			});
 	}
 
 	const adminModels = getAdminModels();
 	const { provider, readonly }: Props = $props();
 	let modelsDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let modelsByProvider = $derived(filterOutModelsByProvider(adminModels.items ?? [], provider.id));
-
-	const usageOptions = Object.entries(ModelUsage).map(([_key, value]) => ({
-		label: ModelUsageLabels[value],
-		id: value
-	}));
 </script>
 
 <IconButton
@@ -69,11 +70,14 @@
 				class="hidden"
 				disabled={readonly}
 			/>
-			<div class="default-scrollbar-thin h-[500px] overflow-y-auto px-4">
+			<div class="default-scrollbar-thin h-125 overflow-y-auto px-4">
 				<Table
 					data={modelsByProvider}
 					fields={['name', 'usage', 'active']}
 					classes={{ root: 'dark:bg-base-200' }}
+					setRowClasses={(row) => {
+						return row.usage !== ModelUsage.LLM ? 'text-muted-content' : '';
+					}}
 				>
 					{#snippet onRenderColumn(field, columnData)}
 						{#if field === 'active'}
@@ -93,23 +97,9 @@
 								disabled={readonly}
 							/>
 						{:else if field === 'usage'}
-							<Select
-								classes={{ root: 'w-full' }}
-								class="bg-base-200 dark:bg-base-200 dark:border-base-400 border border-transparent shadow-inner"
-								options={usageOptions}
-								selected={columnData.usage}
-								onSelect={(option) => {
-									AdminService.updateModel(columnData.id, {
-										...columnData,
-										usage: option.id as ModelUsage
-									});
-									const index = modelsByProvider.findIndex((m) => m.id === columnData.id);
-									if (index !== -1) {
-										modelsByProvider[index].usage = option.id as ModelUsage;
-									}
-								}}
-								disabled={readonly}
-							/>
+							<span class="badge badge-xs badge-secondary">
+								{ModelUsageLabels[columnData.usage as ModelUsage]}
+							</span>
 						{:else if field === 'name'}
 							{columnData.displayName ? columnData.displayName : columnData.name}
 						{:else}

--- a/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
@@ -11,9 +11,9 @@
 		type OrgGroup,
 		ModelUsage,
 		ModelUsageLabels,
+		ModelAlias,
 		ModelAliasLabels,
 		type Model,
-		type ModelAlias,
 		UserService
 	} from '$lib/services';
 	import { defaultModelAliases as defaultModelAliasesStore } from '$lib/stores';
@@ -24,7 +24,7 @@
 	import Table from '../table/Table.svelte';
 	import SearchModels from './SearchModels.svelte';
 	import SearchUsers from './SearchUsers.svelte';
-	import { Plus, Trash2 } from '@lucide/svelte';
+	import { Plus, Trash2, TriangleAlert } from '@lucide/svelte';
 	import { onMount, untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
 
@@ -43,6 +43,7 @@
 	}: Props = $props();
 
 	const duration = PAGE_TRANSITION_DURATION;
+	const llmModelWarning = 'Only LLM models are allowed.';
 	let modelAccessPolicy = $state(
 		untrack(
 			() =>
@@ -87,7 +88,7 @@
 	onMount(async () => {
 		const fetchedModels = await AdminService.listModels({ all: true });
 
-		models = fetchedModels;
+		models = fetchedModels.filter((m) => m.usage === ModelUsage.LLM);
 		loadingModels = false;
 	});
 
@@ -119,6 +120,7 @@
 		return aliasResources.map((resource) => {
 			const aliasName = resource.id.replace('obot://', '');
 			const model = aliasToModelMap.get(aliasName as ModelAlias);
+			const isAllowed = aliasName === ModelAlias.Llm || aliasName === ModelAlias.LlmMini;
 
 			return {
 				id: resource.id,
@@ -126,7 +128,8 @@
 				aliasLabel: ModelAliasLabels[aliasName as ModelAlias] || aliasName,
 				usage: model?.usage,
 				effectiveModelName: model?.displayName || model?.targetModel || 'Not configured',
-				isConfigured: !!model
+				isConfigured: !!model,
+				warning: isAllowed ? undefined : llmModelWarning
 			};
 		});
 	});
@@ -154,7 +157,8 @@
 				isConfigured: alias.isConfigured,
 				usage: alias.usage,
 				isPattern: false,
-				matchCount: 0
+				matchCount: 0,
+				warning: alias.warning
 			};
 		});
 
@@ -168,11 +172,16 @@
 			isAlias: false,
 			isConfigured: true,
 			isPattern: model.isPattern,
-			matchCount: model.matchCount
+			matchCount: model.matchCount,
+			warning: model.warning
 		}));
 
 		return [...aliasRows, ...regularRows];
 	});
+
+	let invalidModelResourceCount = $derived(
+		combinedModelsTableData.filter((model) => model.warning).length
+	);
 
 	$effect(() => {
 		// Prevent loading users and groups if rule has no subjects
@@ -290,19 +299,30 @@
 			}
 
 			const m = modelsMap.get(model.id);
+			let warning: string | undefined;
+			if (!m) {
+				warning = 'This model no longer exists.';
+			} else if (m.usage !== ModelUsage.LLM && m.usage !== ModelAlias.LlmMini) {
+				warning = llmModelWarning;
+			}
 			return {
 				id: model.id,
 				name: m?.displayName || m?.name || model.id,
 				usage: m?.usage,
 				provider: m?.modelProviderName || '-',
 				isPattern: false,
-				matchCount: 0
+				matchCount: 0,
+				warning
 			};
 		});
 	}
 
 	function validate(policy: typeof modelAccessPolicy) {
 		if (!policy) return false;
+
+		if (invalidModelResourceCount > 0) {
+			return false;
+		}
 
 		return (
 			policy.displayName.length > 0 &&
@@ -435,6 +455,15 @@
 					<Loading class="size-6" />
 				</div>
 			{:else}
+				{#if invalidModelResourceCount > 0}
+					<div class="notification-alert flex items-start gap-1" role="alert">
+						<TriangleAlert class="text-warning size-4 shrink-0" />
+						<p class="text-xs">
+							This policy contains invalid model(s). To update the policy, remove the invalid
+							models.
+						</p>
+					</div>
+				{/if}
 				<Table
 					data={combinedModelsTableData}
 					fields={['name', 'provider']}
@@ -483,6 +512,12 @@
 											{ModelUsageLabels[d.usage as ModelUsage] || d.usage}
 										</span>
 									{/if}
+								</div>
+							{/if}
+							{#if d.warning}
+								<div class="ml-2 text-warning flex items-center gap-1 text-xs">
+									<TriangleAlert class="size-3 shrink-0" />
+									<span>{d.warning}</span>
 								</div>
 							{/if}
 						{:else}

--- a/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
@@ -61,6 +61,7 @@
 	let loadingUsersAndGroups = $state(false);
 	let models = $state<Model[]>([]);
 	let defaultModelAliases = $derived(defaultModelAliasesStore.current);
+	let llmModels = $derived(models.filter((m) => m.usage === ModelUsage.LLM));
 	let loadingModels = $state(true);
 
 	let addUserGroupDialog = $state<ReturnType<typeof SearchUsers>>();
@@ -87,8 +88,7 @@
 
 	onMount(async () => {
 		const fetchedModels = await AdminService.listModels({ all: true });
-
-		models = fetchedModels.filter((m) => m.usage === ModelUsage.LLM);
+		models = fetchedModels;
 		loadingModels = false;
 	});
 
@@ -636,7 +636,7 @@
 
 <SearchModels
 	bind:this={addModelDialog}
-	{models}
+	models={llmModels}
 	defaultAliases={defaultModelAliases}
 	exclude={modelAccessPolicy.models?.map((m) => m.id) ?? []}
 	onAdd={async (modelIds: string[]) => {

--- a/ui/user/src/lib/components/admin/SearchModels.svelte
+++ b/ui/user/src/lib/components/admin/SearchModels.svelte
@@ -6,7 +6,7 @@
 		ModelAlias,
 		type DefaultModelAlias
 	} from '$lib/services';
-	import { ModelUsageLabels, type ModelUsage, ModelAliasLabels } from '$lib/services/admin/types';
+	import { ModelUsage, ModelUsageLabels, ModelAliasLabels } from '$lib/services/admin/types';
 	import { sortModelProviders } from '$lib/sort';
 	import Logo from '../Logo.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
@@ -68,21 +68,20 @@
 
 	// Filter models based on exclude list and search
 	let filteredModels = $derived(
-		models
-			.filter((model) => !exclude?.includes(model.id))
-			.filter((model) => {
-				if (!search) return true;
-				if (patternPrefix !== null) {
-					// Preview exactly what the pattern grants: a case-sensitive prefix
-					// match on the provider-native target model, like the backend.
-					return (model.targetModel || '').startsWith(patternPrefix);
-				}
-				const lowerSearch = search.toLowerCase();
-				return (
-					(model.displayName || model.name).toLowerCase().includes(lowerSearch) ||
-					(model.modelProviderName || '').toLowerCase().includes(lowerSearch)
-				);
-			})
+		models.filter((model) => {
+			if (exclude?.includes(model.id)) return false;
+			if (!search) return true;
+			if (patternPrefix !== null) {
+				// Preview exactly what the pattern grants: a case-sensitive prefix
+				// match on the provider-native target model, like the backend.
+				return (model.targetModel || '').startsWith(patternPrefix);
+			}
+			const lowerSearch = search.toLowerCase();
+			return (
+				(model.displayName || model.name).toLowerCase().includes(lowerSearch) ||
+				(model.modelProviderName || '').toLowerCase().includes(lowerSearch)
+			);
+		})
 	);
 
 	// Group models by provider
@@ -124,7 +123,7 @@
 
 	// Prepare default aliases for display
 	let aliasDisplayData = $derived(
-		Object.values(ModelAlias).map((aliasName) => {
+		[ModelAlias.Llm, ModelAlias.LlmMini].map((aliasName) => {
 			const aliasId = `obot://${aliasName}`;
 			const aliasData = defaultModelAliases.find((a) => a.alias === aliasName);
 			const model = aliasData?.model ? modelsMap.get(aliasData.model) : undefined;
@@ -186,7 +185,7 @@
 	bind:this={addModelDialog}
 	{onClose}
 	{title}
-	class="h-full w-full overflow-visible md:h-[500px] md:max-w-md"
+	class="h-full w-full overflow-visible md:h-125 md:max-w-md"
 	classes={{ header: 'p-4 md:pb-0', content: 'min-h-inherit p-0' }}
 >
 	<div class="default-scrollbar-thin flex grow flex-col gap-4 overflow-y-auto pt-1">


### PR DESCRIPTION
This addresses limiting models to LLM-based models by removing the usage dropdown from the List Models in Model Providers as well as enforcing, for model access policies, that only LLM-based models can be added moving forward by pruning non-LLM models from the default model access policy, enforcing Create/Update for a model access policy & warning users to remove existing models from their custom model access policy if they've added a non-LLM based model. 

Addresses #7154 

custom access policy w/ invalid models:
<img width="1349" height="419" alt="Screenshot 2026-07-29 at 10 37 32 AM" src="https://github.com/user-attachments/assets/d3e2264d-50aa-4b28-87d6-cb5388ece6f0" />

removed usage dropdown and adjusted sorting by moving LLM-based models to top (then sort alphabetically)
<img width="910" height="604" alt="Screenshot 2026-07-29 at 10 37 41 AM" src="https://github.com/user-attachments/assets/7358485b-54b6-43c5-9d91-b9971357a27a" />
