### PR TITLE
fix(license): validate community email domains

### DIFF
--- a/pkg/api/handlers/communitylicense.go
+++ b/pkg/api/handlers/communitylicense.go
@@ -38,6 +38,9 @@ func (h *LicenseHandler) CreateCommunityLicense(req api.Context) error {
 	if err != nil {
 		return apitypes.NewErrBadRequest("a valid email address is required")
 	}
+	if !hasEmailDomainSuffix(parsedEmail.Address) {
+		return apitypes.NewErrBadRequest("a valid email address is required")
+	}
 	input.Email = parsedEmail.Address
 
 	if err := h.communityEligibilityError(req.Context()); err != nil {
@@ -76,6 +79,24 @@ func (h *LicenseHandler) CreateCommunityLicense(req api.Context) error {
 		return err
 	}
 	return req.Write(status)
+}
+
+func hasEmailDomainSuffix(address string) bool {
+	at := strings.LastIndexByte(address, '@')
+	if at <= 0 || at == len(address)-1 {
+		return false
+	}
+
+	labels := strings.Split(address[at+1:], ".")
+	if len(labels) < 2 {
+		return false
+	}
+	for _, label := range labels {
+		if label == "" {
+			return false
+		}
+	}
+	return true
 }
 
 func (h *LicenseHandler) communityEligibilityError(ctx context.Context) error {

--- a/pkg/api/handlers/communitylicense_test.go
+++ b/pkg/api/handlers/communitylicense_test.go
@@ -192,6 +192,10 @@ func TestCreateCommunityLicenseValidatesAndNormalizesInput(t *testing.T) {
 			name: "invalid email",
 			body: `{"name":"Ada","email":"not-an-email"}`,
 		},
+		{
+			name: "email without domain suffix",
+			body: `{"name":"Ada","email":"s@t"}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/ui/user/src/routes/admin/license/+page.svelte
+++ b/ui/user/src/routes/admin/license/+page.svelte
@@ -232,6 +232,8 @@
 								class="text-input-filled"
 								name="email"
 								type="email"
+								pattern="[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+"
+								title="Enter an email address with a valid domain, such as name@example.com."
 								autocomplete="email"
 								bind:value={communityEmail}
 								required


### PR DESCRIPTION
## Summary

- block community license form submission when the email domain has no suffix
- reject dotless email domains at the API boundary before calling the license issuer
- add regression coverage for `s@t`

Issue: #7321