### PR TITLE
enhance: return user limit and user count in version API

### DIFF
--- a/pkg/api/handlers/version.go
+++ b/pkg/api/handlers/version.go
@@ -101,7 +101,7 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 		engine = mcp.RuntimeBackendKubernetes
 	}
 
-	violations, err := v.LicenseProvider.ConfiguredProviderViolations(ctx, v.StorageClient)
+	violations, err := v.LicenseProvider.GetLicenseViolations(ctx, v.StorageClient)
 	if err != nil {
 		return nil, err
 	}
@@ -111,23 +111,26 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 	latestVersion := v.latestVersion
 	v.upgradeLock.RUnlock()
 
-	hasValidLicense, err := v.LicenseProvider.HasValidLicense(ctx)
-	if err != nil {
-		return nil, err
-	}
 	entitlements, err := v.LicenseProvider.Entitlements(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	userCount, err := v.GatewayClient.UserCount(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	enterpriseLicense := slices.Contains(entitlements, license.EnterpriseEditionEntitlement)
 	values := map[string]any{
 		"upgradeAvailable":             upgradeAvailable,
 		"latestVersion":                latestVersion,
 		"obot":                         version.Get().String(),
 		"authEnabled":                  v.AuthEnabled,
 		"sessionStore":                 v.sessionStore,
-		"enterprise":                   hasValidLicense,
+		"enterprise":                   enterpriseLicense,
 		"licenseEntitlements":          entitlements,
+		"userCount":                    userCount,
 		"engine":                       engine,
 		"mcpNetworkPolicyEnabled":      v.MCPNetworkPolicyEnabled,
 		"mcpDefaultDenyAllEgress":      v.MCPDefaultDenyAllEgress,
@@ -136,6 +139,14 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 		"hideK8sDetails":               v.HideK8sDetails,
 		"licenseEntitlementViolations": violations,
 		"missingLicenseEntitlements":   missingEntitlements(violations),
+	}
+
+	userLimit, err := v.LicenseProvider.UserLimit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !userLimit.Unlimited {
+		values["userLimit"] = userLimit.Maximum
 	}
 
 	if versions := os.Getenv("OBOT_SERVER_VERSIONS"); versions != "" {
@@ -151,7 +162,7 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 	return values, nil
 }
 
-func missingEntitlements(violations []license.ProviderViolation) []string {
+func missingEntitlements(violations []license.Violation) []string {
 	seen := make(map[string]struct{})
 	for _, violation := range violations {
 		for _, entitlement := range violation.MissingEntitlements {

--- a/pkg/gateway/client/auth.go
+++ b/pkg/gateway/client/auth.go
@@ -97,7 +97,7 @@ func (u UserDecorator) resolveUserLimit(ctx context.Context) (UserLimit, error) 
 // UserLimit describes the maximum number of users an installation may have.
 // Maximum is ignored when Unlimited is true.
 type UserLimit struct {
-	Maximum   int
+	Maximum   int64
 	Unlimited bool
 }
 

--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -368,8 +368,8 @@ func (c *Client) createUser(tx *gorm.DB, user *types.User, userLimit UserLimit) 
 	if err != nil {
 		return fmt.Errorf("failed to count users: %w", err)
 	}
-	if userCount >= int64(userLimit.Maximum) {
-		return newUserLimitError(userLimit.Maximum)
+	if userCount >= userLimit.Maximum {
+		return newUserLimitError()
 	}
 
 	return tx.Create(user).Error
@@ -396,10 +396,10 @@ func lockUserCreation(tx *gorm.DB) error {
 	return nil
 }
 
-func newUserLimitError(maximum int) error {
+func newUserLimitError() error {
 	return types2.NewErrHTTP(
 		http.StatusPaymentRequired,
-		fmt.Sprintf("user limit of %d reached; delete an existing user or install a license that permits additional users", maximum),
+		"Unable to provision your account. Please contact your administrator.",
 	)
 }
 

--- a/pkg/gateway/client/identity_user_limit_postgres_test.go
+++ b/pkg/gateway/client/identity_user_limit_postgres_test.go
@@ -134,7 +134,7 @@ func TestEnsureIdentityWithRoleEnforcesUserLimitAcrossPostgresClients(t *testing
 	if rejected != 1 {
 		t.Fatalf("rejected concurrent PostgreSQL creations = %d, want 1", rejected)
 	}
-	requireIdentityUserLimitPaymentError(t, rejectErr, maximum)
+	requireIdentityUserLimitPaymentError(t, rejectErr)
 	if got := countIdentityUserLimitTestUsers(t, clientA, true); got != maximum {
 		t.Fatalf("users counted toward limit = %d, want %d", got, maximum)
 	}

--- a/pkg/gateway/client/identity_user_limit_test.go
+++ b/pkg/gateway/client/identity_user_limit_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 
@@ -84,7 +83,7 @@ func countIdentityUserLimitTestLocalAuthUsers(t *testing.T, c *Client) int64 {
 	return count
 }
 
-func requireIdentityUserLimitPaymentError(t *testing.T, err error, maximum int) {
+func requireIdentityUserLimitPaymentError(t *testing.T, err error) {
 	t.Helper()
 
 	var httpErr *apitypes.ErrHTTP
@@ -93,11 +92,6 @@ func requireIdentityUserLimitPaymentError(t *testing.T, err error, maximum int) 
 	}
 	if httpErr.Code != http.StatusPaymentRequired {
 		t.Fatalf("HTTP status = %d, want %d", httpErr.Code, http.StatusPaymentRequired)
-	}
-
-	message := strings.ToLower(httpErr.Message)
-	if !strings.Contains(message, "user") || !strings.Contains(message, "limit") || !strings.Contains(message, strconv.Itoa(maximum)) {
-		t.Fatalf("error message %q does not describe the user limit of %d", httpErr.Message, maximum)
 	}
 }
 
@@ -114,7 +108,7 @@ func TestEnsureIdentityWithRoleEnforcesUserLimit(t *testing.T) {
 	}
 
 	_, err := ensureUserLimitTestIdentity(t.Context(), c, "user-3", "user-3@example.com", userLimit)
-	requireIdentityUserLimitPaymentError(t, err, maximum)
+	requireIdentityUserLimitPaymentError(t, err)
 
 	if got := countIdentityUserLimitTestUsers(t, c, true); got != maximum {
 		t.Fatalf("users counted toward limit = %d, want %d", got, maximum)
@@ -151,7 +145,7 @@ func TestEnsureIdentityWithRoleAllowsExistingUserWhenOverLimit(t *testing.T) {
 	}
 
 	_, err = ensureUserLimitTestIdentity(t.Context(), c, "user-4", "user-4@example.com", limit)
-	requireIdentityUserLimitPaymentError(t, err, limit.Maximum)
+	requireIdentityUserLimitPaymentError(t, err)
 	if got := countIdentityUserLimitTestUsers(t, c, true); got != 3 {
 		t.Fatalf("users counted toward limit = %d, want 3", got)
 	}
@@ -207,7 +201,7 @@ func TestEnsureIdentityWithRoleRecoversAfterUserDeletion(t *testing.T) {
 	}
 
 	_, err = ensureUserLimitTestIdentity(t.Context(), c, "user-2", "user-2@example.com", userLimit)
-	requireIdentityUserLimitPaymentError(t, err, maximum)
+	requireIdentityUserLimitPaymentError(t, err)
 
 	if _, err := c.DeleteUser(t.Context(), strconv.FormatUint(uint64(first.ID), 10)); err != nil {
 		t.Fatalf("deleting first user: %v", err)
@@ -236,7 +230,7 @@ func TestEnsureIdentityWithRoleDoesNotCountBootstrapUser(t *testing.T) {
 	}
 
 	_, err := ensureUserLimitTestIdentity(t.Context(), c, "user-3", "user-3@example.com", userLimit)
-	requireIdentityUserLimitPaymentError(t, err, maximum)
+	requireIdentityUserLimitPaymentError(t, err)
 }
 
 func TestCreateLocalAuthUserDoesNotConsumeUserLimit(t *testing.T) {
@@ -272,7 +266,7 @@ func TestCreateLocalAuthUserDoesNotConsumeUserLimit(t *testing.T) {
 		ProviderUserID:        firstLocalEmail,
 		Email:                 firstLocalEmail,
 	}, "", apitypes.RoleBasic, userLimit)
-	requireIdentityUserLimitPaymentError(t, err, maximum)
+	requireIdentityUserLimitPaymentError(t, err)
 
 	if _, err := c.DeleteUser(t.Context(), strconv.FormatUint(uint64(activeUser.ID), 10)); err != nil {
 		t.Fatalf("deleting active user: %v", err)
@@ -299,7 +293,7 @@ func TestCreateLocalAuthUserDoesNotConsumeUserLimit(t *testing.T) {
 		ProviderUserID:        secondLocalEmail,
 		Email:                 secondLocalEmail,
 	}, "", apitypes.RoleBasic, userLimit)
-	requireIdentityUserLimitPaymentError(t, err, maximum)
+	requireIdentityUserLimitPaymentError(t, err)
 }
 
 func TestEnsureIdentityWithRoleAllowsUnlimitedUsers(t *testing.T) {

--- a/pkg/gateway/client/user.go
+++ b/pkg/gateway/client/user.go
@@ -78,6 +78,14 @@ func (c *Client) Users(ctx context.Context, query types.UserQuery) ([]types.User
 	return users, nil
 }
 
+func (c *Client) UserCount(ctx context.Context) (int64, error) {
+	var count int64
+	if err := c.db.WithContext(ctx).Model(&types.User{}).Where("deleted_at IS NULL").Where("hashed_username != ?", hash.String(system.BootstrapName)).Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 func (c *Client) User(ctx context.Context, username string) (*types.User, error) {
 	u := new(types.User)
 	if err := c.db.WithContext(ctx).Where("hashed_username = ? AND deleted_at IS NULL", hash.String(username)).First(u).Error; err != nil {

--- a/pkg/license/entitlements.go
+++ b/pkg/license/entitlements.go
@@ -38,14 +38,15 @@ var entitlementPathsToGate = []string{
 	"POST /api/devices/scans",
 }
 
-// ProviderViolation describes a configured provider that requires license entitlements
+// Violation describes a configured provider that requires license entitlements
 // that are not currently available.
-type ProviderViolation struct {
+type Violation struct {
 	Type                 string   `json:"type"`
 	Namespace            string   `json:"namespace"`
 	Name                 string   `json:"name"`
 	RequiredEntitlements []string `json:"requiredEntitlements"`
 	MissingEntitlements  []string `json:"missingEntitlements"`
+	Message              string   `json:"message"`
 }
 
 type ProviderMeta struct {
@@ -77,7 +78,7 @@ func (g *ProviderEntitlementGate) Check(req *http.Request) error {
 		return nil
 	}
 
-	violations, err := g.licenseProvider.ConfiguredProviderViolations(req.Context(), g.client)
+	violations, err := g.licenseProvider.configuredProviderViolations(req.Context(), g.client)
 	if err != nil {
 		return fmt.Errorf("failed to check provider license entitlements: %w", err)
 	}
@@ -145,13 +146,13 @@ func (p *Provider) UserLimit(ctx context.Context) (gatewayclient.UserLimit, erro
 			continue
 		}
 
-		maximum, err := strconv.Atoi(value)
+		maximum, err := strconv.ParseInt(value, 10, 64)
 		if err != nil || maximum <= 0 {
 			continue
 		}
 
-		if maximum > math.MaxInt-limit.Maximum {
-			limit.Maximum = math.MaxInt
+		if maximum > math.MaxInt64-limit.Maximum {
+			limit.Maximum = math.MaxInt64
 		} else {
 			limit.Maximum += maximum
 		}
@@ -177,9 +178,37 @@ func (p *Provider) RequireEntitlements(ctx context.Context, requiredEntitlements
 	return types.NewErrHTTP(http.StatusPaymentRequired, fmt.Sprintf("missing required license entitlements: %v", missing))
 }
 
-// ConfiguredProviderViolations returns any globally configured auth/model providers
+// GetLicenseViolations returns all license violations for the configured auth/model providers and user limits.
+func (p *Provider) GetLicenseViolations(ctx context.Context, c kclient.Client) ([]Violation, error) {
+	violations, err := p.configuredProviderViolations(ctx, c)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check configured provider license entitlements: %w", err)
+	}
+
+	userLimit, err := p.UserLimit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check user limit: %w", err)
+	}
+	if !userLimit.Unlimited {
+		userCount, err := p.gatewayClient.UserCount(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check user count: %w", err)
+		}
+
+		if userCount > userLimit.Maximum {
+			violations = append(violations, Violation{
+				Type:    "userLimit",
+				Message: fmt.Sprintf("user count (%d) exceeds maximum limit (%d)", userCount, userLimit.Maximum),
+			})
+		}
+	}
+
+	return violations, nil
+}
+
+// configuredProviderViolations returns any globally configured auth/model providers
 // that are currently missing required license entitlements.
-func (p *Provider) ConfiguredProviderViolations(ctx context.Context, c kclient.Client) ([]ProviderViolation, error) {
+func (p *Provider) configuredProviderViolations(ctx context.Context, c kclient.Client) ([]Violation, error) {
 	if err := p.refresh(ctx, false); err != nil {
 		return nil, fmt.Errorf("failed to refresh license entitlements: %w", err)
 	}
@@ -197,7 +226,7 @@ func (p *Provider) ConfiguredProviderViolations(ctx context.Context, c kclient.C
 	return append(modelProviderViolations, authProviderViolations...), nil
 }
 
-func (p *Provider) configuredModelProviderViolations(ctx context.Context, c kclient.Client) ([]ProviderViolation, error) {
+func (p *Provider) configuredModelProviderViolations(ctx context.Context, c kclient.Client) ([]Violation, error) {
 	var modelProviders v1.ModelProviderList
 	if err := c.List(ctx, &modelProviders, &kclient.ListOptions{
 		Namespace: system.DefaultNamespace,
@@ -205,17 +234,18 @@ func (p *Provider) configuredModelProviderViolations(ctx context.Context, c kcli
 		return nil, fmt.Errorf("failed to list model providers: %w", err)
 	}
 
-	var violations []ProviderViolation
+	var violations []Violation
 	for _, mp := range modelProviders.Items {
 		if mp.Status.Configured {
 			missingEntitlements := p.missingEntitlements(mp.Spec.RequiredEntitlements)
 			if len(missingEntitlements) > 0 {
-				violations = append(violations, ProviderViolation{
+				violations = append(violations, Violation{
 					Type:                 "modelProvider",
 					Namespace:            mp.Namespace,
 					Name:                 mp.Name,
 					RequiredEntitlements: mp.Spec.RequiredEntitlements,
 					MissingEntitlements:  missingEntitlements,
+					Message:              "missing required entitlements",
 				})
 			}
 		}
@@ -224,7 +254,7 @@ func (p *Provider) configuredModelProviderViolations(ctx context.Context, c kcli
 	return violations, nil
 }
 
-func (p *Provider) configuredAuthProviderViolations(ctx context.Context, c kclient.Client) ([]ProviderViolation, error) {
+func (p *Provider) configuredAuthProviderViolations(ctx context.Context, c kclient.Client) ([]Violation, error) {
 	var authProviders v1.AuthProviderList
 	if err := c.List(ctx, &authProviders, &kclient.ListOptions{
 		Namespace: system.DefaultNamespace,
@@ -232,12 +262,12 @@ func (p *Provider) configuredAuthProviderViolations(ctx context.Context, c kclie
 		return nil, fmt.Errorf("failed to list auth providers: %w", err)
 	}
 
-	var violations []ProviderViolation
+	var violations []Violation
 	for _, ap := range authProviders.Items {
 		if ap.Status.Configured {
 			missingEntitlements := p.missingEntitlements(ap.Spec.RequiredEntitlements)
 			if len(missingEntitlements) > 0 {
-				violations = append(violations, ProviderViolation{
+				violations = append(violations, Violation{
 					Type:                 "authProvider",
 					Namespace:            ap.Namespace,
 					Name:                 ap.Name,

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -478,6 +478,7 @@ export interface LicenseEntitlementViolation {
 	name: string;
 	requiredEntitlements: string[];
 	missingEntitlements: string[];
+	message?: string;
 }
 
 // MCP catalog servers
@@ -877,6 +878,8 @@ export interface Version {
 	authEnabled?: boolean;
 	enterprise?: boolean;
 	licenseEntitlements?: string[];
+	userCount?: number;
+	userLimit?: number;
 	licenseEntitlementViolations?: LicenseEntitlementViolation[];
 	missingLicenseEntitlements?: string[];
 	upgradeAvailable?: boolean;


### PR DESCRIPTION
We also return user limit violations in the `licenseEntitlementViolations`.

Since we now have the community license, this change also sets the "enterprise" flag to true only when an enterprise license is actually set.

This change also updates the error message displayed to a user when they can't create an account because the user limit has been reached.

Issue: https://github.com/obot-platform/obot/issues/7324