### PR TITLE
Route OAuth debugger requests through MCP tunnels

### DIFF
--- a/pkg/api/handlers/mcp_oauth_debugger.go
+++ b/pkg/api/handlers/mcp_oauth_debugger.go
@@ -58,7 +58,11 @@ func (m *MCPHandler) RegisterOAuthDebuggerClient(req api.Context) error {
 			return types.NewErrBadRequest("OAuth metadata does not include a dynamic client registration endpoint, must configure static client ID and secret")
 		}
 
-		registered, err = registerOAuthDebuggerClient(req.Context(), authServer.RegistrationEndpoint, registration)
+		httpClient, err := m.mcpSessionManager.HTTPClientForServer(serverConfig, 10*time.Second)
+		if err != nil {
+			return err
+		}
+		registered, err = registerOAuthDebuggerClient(req.Context(), httpClient, authServer.RegistrationEndpoint, registration)
 		if err != nil {
 			return err
 		}
@@ -166,7 +170,12 @@ func (m *MCPHandler) ExchangeOAuthDebuggerToken(req api.Context) error {
 
 	conf := oauthDebuggerConfigFromPendingState(pendingState)
 
-	token, err := conf.Exchange(req.Context(), input.Code, oauth2.VerifierOption(pendingState.Verifier))
+	httpClient, err := m.mcpSessionManager.HTTPClientForServer(serverConfig, 10*time.Second)
+	if err != nil {
+		return err
+	}
+	exchangeContext := context.WithValue(req.Context(), oauth2.HTTPClient, httpClient)
+	token, err := conf.Exchange(exchangeContext, input.Code, oauth2.VerifierOption(pendingState.Verifier))
 	if err != nil {
 		return fmt.Errorf("failed to exchange OAuth code: %w", err)
 	}
@@ -236,13 +245,12 @@ func (m *MCPHandler) oauthDebuggerMetadata(server v1.MCPServer) (nmcp.Authorizat
 	return authServer, nmcp.AuthServerMetadataToClientRegistration(authServer, "Obot MCP OAuth Debugger", system.MCPOAuthCallbackURL(m.serverURL), registration.Scope), nil
 }
 
-func registerOAuthDebuggerClient(ctx context.Context, registrationEndpoint string, registration nmcp.ClientRegistrationMetadata) (types.OAuthClient, error) {
+func registerOAuthDebuggerClient(ctx context.Context, httpClient *http.Client, registrationEndpoint string, registration nmcp.ClientRegistrationMetadata) (types.OAuthClient, error) {
 	b, err := json.Marshal(registration)
 	if err != nil {
 		return types.OAuthClient{}, err
 	}
 
-	httpClient := &http.Client{Timeout: 10 * time.Second}
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, registrationEndpoint, bytes.NewReader(b))
 	if err != nil {
 		return types.OAuthClient{}, err

--- a/pkg/api/handlers/mcp_oauth_debugger_test.go
+++ b/pkg/api/handlers/mcp_oauth_debugger_test.go
@@ -2,16 +2,25 @@ package handlers
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
 
 	nmcp "github.com/obot-platform/nanobot/pkg/mcp"
+	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"golang.org/x/oauth2"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+type oauthDebuggerRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f oauthDebuggerRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
 
 func TestOAuthDebuggerMetadata(t *testing.T) {
 	authServer := nmcp.AuthorizationServerMetadata{
@@ -244,6 +253,52 @@ func TestOAuthDebuggerCIMDClient(t *testing.T) {
 	}
 	if !reflect.DeepEqual(client.RedirectURIs, registration.RedirectURIs) {
 		t.Fatalf("expected redirect URIs %#v, got %#v", registration.RedirectURIs, client.RedirectURIs)
+	}
+}
+
+func TestRegisterOAuthDebuggerClientUsesProvidedHTTPClient(t *testing.T) {
+	registration := nmcp.ClientRegistrationMetadata{
+		ClientName:   "Obot MCP OAuth Debugger",
+		RedirectURIs: []string{"https://obot.example.com/oauth/mcp/callback"},
+	}
+	expected := types.OAuthClient{
+		ClientID:     "registered-client",
+		ClientSecret: "registered-secret",
+	}
+	called := false
+	httpClient := &http.Client{Transport: oauthDebuggerRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		called = true
+		if request.Method != http.MethodPost || request.URL.String() != "https://auth.internal.test/register" {
+			t.Errorf("registration request = %s %s", request.Method, request.URL)
+		}
+		if request.Header.Get("Content-Type") != "application/json" || request.Header.Get("Accept") != "application/json" {
+			t.Errorf("registration request headers = %#v", request.Header)
+		}
+		var actual nmcp.ClientRegistrationMetadata
+		if err := json.NewDecoder(request.Body).Decode(&actual); err != nil {
+			t.Errorf("decode registration request: %v", err)
+		} else if !reflect.DeepEqual(actual, registration) {
+			t.Errorf("registration request = %#v, want %#v", actual, registration)
+		}
+
+		body := strings.NewReader(string(mustJSON(t, expected)))
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(body),
+			Request:    request,
+		}, nil
+	})}
+
+	actual, err := registerOAuthDebuggerClient(t.Context(), httpClient, "https://auth.internal.test/register", registration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("provided HTTP client was not used")
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("registered client = %#v, want %#v", actual, expected)
 	}
 }
 

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -1064,20 +1064,15 @@ func (h *Handler) SyncOAuthMetadata(req router.Request, _ router.Response) error
 	if server.Spec.Manifest.Runtime != types.RuntimeRemote || server.Spec.Manifest.RemoteConfig == nil {
 		return setOAuthMetadata(req, server, new(v1.OAuthMetadata), nil)
 	}
-	// OAuth metadata URLs can point back at the private target and bypass the
-	// tunnel. Leave discovery disabled for tunneled servers; ordinary MCP
-	// requests (including servers that do not require OAuth) still use the
-	// tunnel bridge.
-	if server.Spec.Manifest.RemoteConfig.TunnelName != "" {
-		return setOAuthMetadata(req, server, new(v1.OAuthMetadata), nil)
-	}
 
 	blockingConfig := h.mcpSessionManager.RemoteMCPURLValidationConfig()
 
-	if err := mcp.ValidateRemoteMCPURL(req.Ctx, server.Spec.Manifest.RemoteConfig.URL, blockingConfig); err != nil {
-		// If the URL doesn't pass validation, then don't do anything so that we sync as soon as the configuration is updated.
-		log.Infof("Remote MCP URL validation failed, not checking OAuth metadata: server=%s error=%v", server.Name, err)
-		return nil
+	if server.Spec.Manifest.RemoteConfig.TunnelName == "" {
+		if err := mcp.ValidateRemoteMCPURL(req.Ctx, server.Spec.Manifest.RemoteConfig.URL, blockingConfig); err != nil {
+			// If the URL doesn't pass validation, then don't do anything so that we sync as soon as the configuration is updated.
+			log.Infof("Remote MCP URL validation failed, not checking OAuth metadata: server=%s error=%v", server.Name, err)
+			return nil
+		}
 	}
 
 	if !shouldSyncOAuthMetadata(server, time.Now()) {
@@ -1104,12 +1099,23 @@ func (h *Handler) SyncOAuthMetadata(req router.Request, _ router.Response) error
 		return nil
 	}
 
-	metadata, err := nmcp.GetOAuthMetadataWithBlockingConfig(req.Ctx, nmcp.Server{
+	oauthServer := nmcp.Server{
 		BaseURL: serverConfig.URL,
 		Headers: serverConfigHeaders(serverConfig),
-	}, "Obot Test MCP OAuth Client", system.MCPOAuthCallbackURL(h.baseURL),
-		!blockingConfig.AllowLocalhostMCP, !blockingConfig.AllowPrivateIPMCP, !blockingConfig.AllowLinkLocalMCP,
-	)
+	}
+	var metadata nmcp.OAuthMetadata
+	if serverConfig.TunnelName != "" {
+		httpClient, clientErr := h.mcpSessionManager.HTTPClientForServer(serverConfig, 5*time.Second)
+		if clientErr != nil {
+			return clientErr
+		}
+		metadata, err = nmcp.GetOAuthMetadataWithClient(req.Ctx, httpClient, oauthServer,
+			"Obot Test MCP OAuth Client", system.MCPOAuthCallbackURL(h.baseURL))
+	} else {
+		metadata, err = nmcp.GetOAuthMetadataWithBlockingConfig(req.Ctx, oauthServer,
+			"Obot Test MCP OAuth Client", system.MCPOAuthCallbackURL(h.baseURL),
+			!blockingConfig.AllowLocalhostMCP, !blockingConfig.AllowPrivateIPMCP, !blockingConfig.AllowLinkLocalMCP)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to get OAuth metadata: %w", err)
 	}

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"strings"
 	"sync"
@@ -201,6 +202,18 @@ func (sm *SessionManager) MCPRuntimeBackend() string {
 
 func (sm *SessionManager) RemoteMCPURLValidationConfig() RemoteMCPURLValidationConfig {
 	return sm.remoteURLValidationConfig
+}
+
+// HTTPClientForServer returns an HTTP client that follows the server's
+// configured network path, including its tunnel when present.
+func (sm *SessionManager) HTTPClientForServer(server ServerConfig, timeout time.Duration) (*http.Client, error) {
+	if server.TunnelName == "" {
+		return &http.Client{Timeout: timeout}, nil
+	}
+	if sm.tunnelManager == nil {
+		return nil, fmt.Errorf("tunnel manager is not configured")
+	}
+	return sm.tunnelManager.HTTPClient(server.TunnelName, timeout)
 }
 
 func (sm *SessionManager) ResourceMaximums() ResourceMaximums {

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/tunnel"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestHTTPClientForServer(t *testing.T) {
+	const timeout = 3 * time.Second
+
+	t.Run("direct server", func(t *testing.T) {
+		httpClient, err := (&SessionManager{}).HTTPClientForServer(ServerConfig{}, timeout)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if httpClient.Timeout != timeout {
+			t.Fatalf("client timeout = %v, want %v", httpClient.Timeout, timeout)
+		}
+		if httpClient.Transport != nil {
+			t.Fatalf("direct client transport = %#v, want default transport", httpClient.Transport)
+		}
+	})
+
+	t.Run("tunnel manager required", func(t *testing.T) {
+		_, err := (&SessionManager{}).HTTPClientForServer(ServerConfig{TunnelName: "office"}, timeout)
+		if err == nil {
+			t.Fatal("tunneled server without tunnel manager returned no error")
+		}
+	})
+
+	t.Run("tunneled server", func(t *testing.T) {
+		tunnelManager, err := tunnel.NewManager(t.Context(), "http://127.0.0.1:8080", fake.NewClientBuilder().Build(), tunnel.PeerConfig{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tunnelManager.Close()
+
+		httpClient, err := (&SessionManager{tunnelManager: tunnelManager}).HTTPClientForServer(
+			ServerConfig{TunnelName: "office"},
+			timeout,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if httpClient.Timeout != timeout {
+			t.Fatalf("client timeout = %v, want %v", httpClient.Timeout, timeout)
+		}
+		if httpClient.Transport == nil {
+			t.Fatal("tunneled client uses the default transport")
+		}
+	})
+
+	t.Run("invalid tunnel name", func(t *testing.T) {
+		tunnelManager, err := tunnel.NewManager(t.Context(), "http://127.0.0.1:8080", fake.NewClientBuilder().Build(), tunnel.PeerConfig{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tunnelManager.Close()
+
+		_, err = (&SessionManager{tunnelManager: tunnelManager}).HTTPClientForServer(
+			ServerConfig{TunnelName: "Office"},
+			timeout,
+		)
+		if err == nil {
+			t.Fatal("invalid tunnel name returned no error")
+		}
+	})
+}

--- a/pkg/tunnel/manager.go
+++ b/pkg/tunnel/manager.go
@@ -203,6 +203,78 @@ type bridgeTarget struct {
 	URL        string `json:"url"`
 }
 
+type bridgeRoundTripper struct {
+	manager    *Manager
+	tunnelName string
+	transport  http.RoundTripper
+}
+
+func (b *bridgeRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request == nil || request.URL == nil {
+		return nil, errors.New("tunnel bridge request URL is required")
+	}
+
+	outbound := request.Clone(request.Context())
+	outbound.Header = request.Header.Clone()
+	if outbound.Header == nil {
+		outbound.Header = make(http.Header)
+	}
+
+	if !b.manager.isBridgeURLForTunnel(outbound.URL, b.tunnelName) {
+		bridgeURL, err := b.manager.BridgeURL(b.tunnelName, outbound.URL.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare tunneled HTTP request: %w", err)
+		}
+		outbound.URL, err = url.Parse(bridgeURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse tunnel bridge URL: %w", err)
+		}
+		outbound.Host = ""
+	}
+
+	name, value := b.manager.BridgeAuthorization()
+	outbound.Header.Set(name, value)
+	return b.transport.RoundTrip(outbound)
+}
+
+// HTTPClient returns an HTTP client that routes every request through the
+// named tunnel. Redirects rewritten by the bridge remain on the same tunnel.
+func (m *Manager) HTTPClient(tunnelName string, timeout time.Duration) (*http.Client, error) {
+	if m == nil {
+		return nil, errors.New("tunnel manager is not configured")
+	}
+	if err := apitypes.ValidateTunnelName(tunnelName); err != nil {
+		return nil, err
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &bridgeRoundTripper{
+			manager:    m,
+			tunnelName: tunnelName,
+			transport:  http.DefaultTransport,
+		},
+	}, nil
+}
+
+func (m *Manager) isBridgeURLForTunnel(targetURL *url.URL, tunnelName string) bool {
+	if targetURL == nil ||
+		!strings.EqualFold(targetURL.Scheme+"://"+targetURL.Host, m.bridgeBaseURL) ||
+		!strings.HasPrefix(targetURL.Path, bridgePathPrefix) {
+		return false
+	}
+
+	encoded := strings.TrimPrefix(targetURL.Path, bridgePathPrefix)
+	if encoded == "" || strings.Contains(encoded, "/") {
+		return false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return false
+	}
+	var target bridgeTarget
+	return json.Unmarshal(payload, &target) == nil && target.TunnelName == tunnelName
+}
+
 // BridgeURL converts an ordinary HTTP(S) target and MCPTunnel name into an
 // internal URL on the gateway bridge.
 func (m *Manager) BridgeURL(tunnelName, rawURL string) (string, error) {

--- a/pkg/tunnel/tunnel_test.go
+++ b/pkg/tunnel/tunnel_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	nmcp "github.com/obot-platform/nanobot/pkg/mcp"
 	apitypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -564,6 +565,226 @@ func TestTunnelRoutesRequestsByName(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("named tunnel client did not stop")
 		}
+	}
+}
+
+func TestHTTPClientRoutesOAuthDiscoveryThroughTunnel(t *testing.T) {
+	const targetBaseURL = "http://oauth.internal.test"
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	manager, server := newManagerTestServer(ctx, t)
+	defer manager.Close()
+	defer server.Close()
+
+	connection, _, err := dial(ctx, server.URL, testTunnelToken("office"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		requestsMu sync.Mutex
+		requests   = make(map[string]int)
+	)
+	forwardClient := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requestsMu.Lock()
+		requests[request.Method+" "+request.URL.Path]++
+		requestsMu.Unlock()
+
+		status := http.StatusOK
+		header := make(http.Header)
+		body := ""
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == "/mcp":
+			status = http.StatusUnauthorized
+			header.Set("WWW-Authenticate", "Bearer")
+			body = "unauthorized"
+		case request.Method == http.MethodGet && request.URL.Path == "/.well-known/oauth-protected-resource/mcp":
+			status = http.StatusNotFound
+		case request.Method == http.MethodGet && request.URL.Path == "/.well-known/oauth-protected-resource":
+			body = `{"resource":"` + targetBaseURL + `","authorization_servers":["` + targetBaseURL + `/issuer"]}`
+		case request.Method == http.MethodGet && request.URL.Path == "/.well-known/oauth-authorization-server/issuer":
+			body = `{"issuer":"` + targetBaseURL + `/issuer","authorization_endpoint":"` + targetBaseURL +
+				`/authorize","token_endpoint":"` + targetBaseURL + `/token","registration_endpoint":"` +
+				targetBaseURL + `/register","response_types_supported":["code"]}`
+		default:
+			status = http.StatusNotFound
+		}
+		if body != "" {
+			header.Set("Content-Type", "application/json")
+		}
+		return &http.Response{
+			StatusCode:    status,
+			Header:        header,
+			Body:          io.NopCloser(strings.NewReader(body)),
+			ContentLength: int64(len(body)),
+			Request:       request,
+		}, nil
+	})}
+
+	serveErrors := make(chan error, 1)
+	go func() {
+		serveErrors <- serveConnectionWithClient(ctx, connection, "office", forwardClient)
+	}()
+	waitForTestCondition(t, 2*time.Second, func() bool {
+		return localTunnelConnectionCount(manager, "office") == 1
+	}, "tunnel session did not connect")
+
+	httpClient, err := manager.HTTPClient("office", 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := nmcp.GetOAuthMetadataWithClient(t.Context(), httpClient, nmcp.Server{
+		BaseURL: targetBaseURL + "/mcp",
+	}, "Obot Test MCP OAuth Client", "https://obot.example.com/oauth/mcp/callback")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var authServer nmcp.AuthorizationServerMetadata
+	if err := json.Unmarshal(metadata.AuthorizationServerMetadata, &authServer); err != nil {
+		t.Fatal(err)
+	}
+	if authServer.AuthorizationEndpoint != targetBaseURL+"/authorize" ||
+		authServer.TokenEndpoint != targetBaseURL+"/token" ||
+		authServer.RegistrationEndpoint != targetBaseURL+"/register" {
+		t.Fatalf("unexpected authorization server metadata: %#v", authServer)
+	}
+
+	requestsMu.Lock()
+	defer requestsMu.Unlock()
+	for _, request := range []string{
+		"POST /mcp",
+		"GET /.well-known/oauth-protected-resource/mcp",
+		"GET /.well-known/oauth-protected-resource",
+		"GET /.well-known/oauth-authorization-server/issuer",
+	} {
+		if requests[request] == 0 {
+			t.Errorf("OAuth discovery did not send %s through the tunnel", request)
+		}
+	}
+
+	cancel()
+	select {
+	case <-serveErrors:
+	case <-time.After(time.Second):
+		t.Fatal("tunnel client did not stop")
+	}
+}
+
+func TestHTTPClientRoutesRequestsAndRedirectsThroughBridge(t *testing.T) {
+	const (
+		tunnelName    = "office"
+		initialTarget = "https://oauth.internal.test/start"
+		finalTarget   = "https://oauth.internal.test/finish"
+	)
+
+	var (
+		manager     *Manager
+		seenTargets []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		name, value := manager.BridgeAuthorization()
+		if request.Header.Get(name) != value {
+			t.Errorf("bridge authorization header = %q, want %q", request.Header.Get(name), value)
+		}
+		if request.Header.Get("X-Test") != "preserved" {
+			t.Errorf("original request header was not preserved: %#v", request.Header)
+		}
+		if !strings.HasPrefix(request.URL.Path, bridgePathPrefix) {
+			t.Errorf("request path = %q, want bridge path", request.URL.Path)
+			http.Error(w, "not a bridge request", http.StatusBadRequest)
+			return
+		}
+
+		payload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(request.URL.Path, bridgePathPrefix))
+		if err != nil {
+			t.Errorf("decode bridge target: %v", err)
+			http.Error(w, "invalid bridge target", http.StatusBadRequest)
+			return
+		}
+		var target bridgeTarget
+		if err := json.Unmarshal(payload, &target); err != nil {
+			t.Errorf("unmarshal bridge target: %v", err)
+			http.Error(w, "invalid bridge target", http.StatusBadRequest)
+			return
+		}
+		if target.TunnelName != tunnelName {
+			t.Errorf("tunnel name = %q, want %q", target.TunnelName, tunnelName)
+		}
+		seenTargets = append(seenTargets, target.URL)
+
+		switch target.URL {
+		case initialTarget:
+			redirectURL, err := manager.BridgeURL(tunnelName, finalTarget)
+			if err != nil {
+				t.Errorf("build redirect bridge URL: %v", err)
+				http.Error(w, "failed to redirect", http.StatusInternalServerError)
+				return
+			}
+			http.Redirect(w, request, redirectURL, http.StatusFound)
+		case finalTarget:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected target", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	var err error
+	manager, err = NewManager(t.Context(), server.URL, allowAllTunnelReader{}, PeerConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Close()
+
+	httpClient, err := manager.HTTPClient(tunnelName, 3*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if httpClient.Timeout != 3*time.Second {
+		t.Fatalf("client timeout = %v, want %v", httpClient.Timeout, 3*time.Second)
+	}
+
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, initialTarget, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("X-Test", "preserved")
+	response, err := httpClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("response status = %d, want %d", response.StatusCode, http.StatusNoContent)
+	}
+	if !slices.Equal(seenTargets, []string{initialTarget, finalTarget}) {
+		t.Fatalf("bridge targets = %#v, want initial and final targets", seenTargets)
+	}
+	if request.URL.String() != initialTarget {
+		t.Fatalf("original request URL mutated to %q", request.URL)
+	}
+	name, _ := manager.BridgeAuthorization()
+	if request.Header.Get(name) != "" {
+		t.Fatal("bridge authorization was added to original request")
+	}
+}
+
+func TestHTTPClientRejectsInvalidConfiguration(t *testing.T) {
+	var manager *Manager
+	if _, err := manager.HTTPClient("office", time.Second); err == nil {
+		t.Fatal("nil manager returned no error")
+	}
+
+	validManager, err := NewManager(t.Context(), "http://127.0.0.1:8080", allowAllTunnelReader{}, PeerConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer validManager.Close()
+	if _, err := validManager.HTTPClient("Office", time.Second); err == nil {
+		t.Fatal("invalid tunnel name returned no error")
 	}
 }
 


### PR DESCRIPTION
OAuth metadata and debugger requests now honor a remote server’s configured tunnel.

This lets administrators complete OAuth troubleshooting for private MCP servers without bypassing the tunnel’s access controls.

Issue: https://github.com/obot-platform/obot/issues/7336