### PR TITLE
fix: disable interaction w/ "getting started" guides & add steps in obot-sentry guide

### DIFF
--- a/ui/user/src/lib/components/guides/GuidePanel.svelte
+++ b/ui/user/src/lib/components/guides/GuidePanel.svelte
@@ -80,6 +80,7 @@
 	onMount(() => {
 		highlighter = createGuideHighlighter({
 			allowClose: false,
+			disableActiveInteraction: true,
 			overlayClickBehavior: noop,
 			onObotVisibilityChange: (visible) => {
 				guide.showObotInPanel = visible;

--- a/ui/user/src/lib/components/guides/highlight.ts
+++ b/ui/user/src/lib/components/guides/highlight.ts
@@ -13,6 +13,7 @@ const ELEMENT_ANIMATION_WAIT_TIMEOUT_MS = 2000;
 
 export interface GuideHighlighterOptions {
 	allowClose?: boolean;
+	disableActiveInteraction?: boolean;
 	overlayClickBehavior?: Config['overlayClickBehavior'];
 	onDestroyed?: () => void;
 	onCloseClick?: () => void;
@@ -285,6 +286,7 @@ export function createGuideHighlighter(options: GuideHighlighterOptions = {}): G
 		// Skip stage animation so overlay/popover exist before we reparent into an open dialog.
 		animate: false,
 		allowClose: options.allowClose ?? true,
+		disableActiveInteraction: options.disableActiveInteraction ?? false,
 		overlayClickBehavior: options.overlayClickBehavior ?? 'close',
 		overlayColor: darkMode.isDark ? 'rgba(0, 0, 0, 1)' : 'rgba(0, 0, 0, 0.35)',
 		stagePadding: 12,
@@ -328,6 +330,18 @@ export function createGuideHighlighter(options: GuideHighlighterOptions = {}): G
 				onPopoverRender: (popover) => {
 					if (generation !== highlightGeneration) return;
 					destroyHighlightObot();
+
+					if (highlightConfig.experimental) {
+						popover.title.style.display = 'flex';
+						popover.title.style.flexWrap = 'wrap';
+						popover.title.style.alignItems = 'center';
+						popover.title.style.gap = '0.5rem';
+
+						const badge = document.createElement('span');
+						badge.className = 'badge badge-warning badge-xs font-normal';
+						badge.textContent = 'Experimental';
+						popover.title.appendChild(badge);
+					}
 
 					if (side === 'left' || side === 'right') {
 						options.onObotVisibilityChange?.(false);

--- a/ui/user/src/lib/constants.ts
+++ b/ui/user/src/lib/constants.ts
@@ -417,6 +417,7 @@ export const MCP_ACCESS_POLICY_FIELD_IDS = {
 
 export const MDM_DEVICES_CONFIGURATION_FIELD_IDS = {
 	devicesLink: 'sidebar-link-devices',
+	enforcementDecisionsLink: 'sidebar-link-enforcement-decisions',
 	configurationTab: 'devices-tab-configuration',
 	configurationDetails: 'devices-configuration-details',
 	getStartedButton: 'devices-configuration-get-started',
@@ -432,7 +433,8 @@ export const MDM_DEVICES_CONFIGURATION_FIELD_IDS = {
 	agentSettingsButton: 'devices-agent-settings',
 	checkForUpdatesButton: 'devices-check-for-updates-button',
 	devicesTabOverview: 'devices-tab-overview',
-	devicesTabDevices: 'devices-tab-devices'
+	devicesTabDevices: 'devices-tab-devices',
+	toolCallEnforcementSection: 'tool-call-enforcements-section'
 };
 
 export const MCP_FILTERS_FIELD_IDS = {

--- a/ui/user/src/lib/constants.ts
+++ b/ui/user/src/lib/constants.ts
@@ -434,7 +434,7 @@ export const MDM_DEVICES_CONFIGURATION_FIELD_IDS = {
 	checkForUpdatesButton: 'devices-check-for-updates-button',
 	devicesTabOverview: 'devices-tab-overview',
 	devicesTabDevices: 'devices-tab-devices',
-	toolCallEnforcementSection: 'tool-call-enforcements-section'
+	toolCallEnforcementSection: 'tool-call-enforcement-section'
 };
 
 export const MCP_FILTERS_FIELD_IDS = {

--- a/ui/user/src/lib/services/guides/accesspolicy/create.ts
+++ b/ui/user/src/lib/services/guides/accesspolicy/create.ts
@@ -73,7 +73,7 @@ export const steps: GuideStep[] = [
 								selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.addUserGroupBtn },
 								side: 'left',
 								title: 'Add User/Group',
-								description: 'You can add User & Groups here.'
+								description: 'You can add user and groups here.'
 							},
 							listener: {
 								id: MCP_ACCESS_POLICY_FIELD_IDS.addUserGroupBtn,

--- a/ui/user/src/lib/services/guides/accesspolicy/create.ts
+++ b/ui/user/src/lib/services/guides/accesspolicy/create.ts
@@ -29,7 +29,7 @@ export const steps: GuideStep[] = [
 	},
 	{
 		content: [
-			'Create and manage your MCP access policies here. To start creating a new access policy, click the "Add Access Policy" button.'
+			"Create and manage your MCP access policies here. We'll take you through creating a new MCP access policy."
 		],
 		action: {
 			routeContains: 'mcp-access-policies',
@@ -37,7 +37,7 @@ export const steps: GuideStep[] = [
 				selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.addPolicyBtn },
 				side: 'left',
 				title: 'Add Access Policy',
-				description: 'Click here to create a new MCP access policy.'
+				description: 'This is where you go to create a new MCP access policy.'
 			},
 			listener: {
 				id: MCP_ACCESS_POLICY_FIELD_IDS.addPolicyBtn,
@@ -52,7 +52,7 @@ export const steps: GuideStep[] = [
 				selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.name },
 				side: 'top',
 				title: 'Policy Name',
-				description: 'Enter a recognizable name for this access policy.'
+				description: 'This is where you enter a recognizable name for this access policy.'
 			},
 			listener: {
 				id: MCP_ACCESS_POLICY_FIELD_IDS.name,
@@ -62,7 +62,7 @@ export const steps: GuideStep[] = [
 						side: 'top',
 						title: 'Users & Groups',
 						description:
-							'Add the users and groups that should have access to the selected MCP servers.',
+							'Here is where you can add the users and groups that should have access to the selected MCP servers.',
 						noDescendantInteraction: true
 					},
 					listener: {
@@ -73,7 +73,7 @@ export const steps: GuideStep[] = [
 								selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.addUserGroupBtn },
 								side: 'left',
 								title: 'Add User/Group',
-								description: 'Click here to add to User & Groups.'
+								description: 'You can add User & Groups here.'
 							},
 							listener: {
 								id: MCP_ACCESS_POLICY_FIELD_IDS.addUserGroupBtn,
@@ -82,7 +82,7 @@ export const steps: GuideStep[] = [
 										selector: { id: 'add-user-group-dialog-content' },
 										title: 'Adding Users/Groups',
 										description:
-											'This is where you can add who will be able to access the MCP servers.',
+											'Clicking it will open this dialog, where you can search who or what groups you want to add to the access policy.',
 										noDescendantInteraction: true
 									},
 									listener: {
@@ -94,7 +94,7 @@ export const steps: GuideStep[] = [
 												side: 'right',
 												title: 'Select A User/Group',
 												description:
-													"For now, let's select All Obot Users. This will grant access to everyone."
+													"For now, we'll select All Obot Users. This will grant access to everyone."
 											},
 											listener: {
 												id: MCP_ACCESS_POLICY_FIELD_IDS.allUsersOption,
@@ -103,7 +103,7 @@ export const steps: GuideStep[] = [
 														selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.userGroupConfirmBtn },
 														side: 'top',
 														title: 'Confirm Selection',
-														description: 'Click here to apply your changes.'
+														description: 'Then you can apply your changes here.'
 													},
 													listener: {
 														id: MCP_ACCESS_POLICY_FIELD_IDS.userGroupConfirmBtn,
@@ -113,7 +113,7 @@ export const steps: GuideStep[] = [
 																side: 'top',
 																title: 'Servers',
 																description:
-																	'Select the servers that will be available to the selected users and groups.',
+																	'This is where you can select the servers that will be available to the selected users and groups.',
 																noDescendantInteraction: true
 															},
 															listener: {
@@ -124,7 +124,7 @@ export const steps: GuideStep[] = [
 																		selector: { id: MCP_ACCESS_POLICY_FIELD_IDS.addServerBtn },
 																		side: 'left',
 																		title: 'Add Server',
-																		description: 'Click here to begin adding a server.'
+																		description: 'You can add a server from here.'
 																	},
 																	listener: {
 																		id: MCP_ACCESS_POLICY_FIELD_IDS.addServerBtn,
@@ -133,7 +133,7 @@ export const steps: GuideStep[] = [
 																				selector: { id: 'search-mcp-servers-dialog-content' },
 																				title: 'Adding A Server',
 																				description:
-																					'From here, you can search and add any servers that you want to make available to the selected users and groups.',
+																					'Clicking it will open this dialog, where you can search and add any servers that you want to make available to the selected users and groups.',
 																				noDescendantInteraction: true
 																			},
 																			listener: {
@@ -147,7 +147,7 @@ export const steps: GuideStep[] = [
 																						side: 'right',
 																						title: 'Add a Server',
 																						description:
-																							"For this guide, let's go ahead and add everything. You can choose to modify this later."
+																							"For this guide, we'll go ahead and add everything. You can choose to modify this later."
 																					},
 																					listener: {
 																						id: MCP_ACCESS_POLICY_FIELD_IDS.everythingOption,
@@ -158,7 +158,7 @@ export const steps: GuideStep[] = [
 																								},
 																								side: 'top',
 																								title: 'Confirm Changes',
-																								description: 'Click here to apply your changes.'
+																								description: 'Then you can apply your changes here.'
 																							},
 																							listener: {
 																								id: MCP_ACCESS_POLICY_FIELD_IDS.serverConfirmBtn,

--- a/ui/user/src/lib/services/guides/devices/installsentry.ts
+++ b/ui/user/src/lib/services/guides/devices/installsentry.ts
@@ -7,7 +7,7 @@ const highlightDevicesLink = {
 		id: MDM_DEVICES_CONFIGURATION_FIELD_IDS.devicesLink
 	},
 	title: 'Devices',
-	description: 'Click here to manage devices and install Obot Sentry.'
+	description: 'This is where you can manage devices and install Obot Sentry.'
 };
 
 const listenDevicesLink = {
@@ -22,7 +22,7 @@ export const steps: GuideStep[] = [
 		content: [
 			'In order to discover shadow AI and enforce policies for unmanaged MCP servers, you will need to install Obot Sentry on your devices.',
 			'**What is Obot Sentry?** Obot Sentry is a lightweight program designed to be used by MDMs for device scanning and agent hook configuration. You can learn more about it [here](https://github.com/obot-platform/obot-sentry).',
-			'To get set up, head to the Devices page.'
+			"To get set up, let's head to the Devices page."
 		],
 		action: [
 			{
@@ -36,12 +36,12 @@ export const steps: GuideStep[] = [
 				listener: listenDevicesLink,
 				parentID: 'sidebar-collapse-device-management',
 				title: 'Expand Device Management',
-				description: 'Device Management is collapsed. Click here to expand it.'
+				description: 'This is the "Device Management" section. Let\'s expand it.'
 			})
 		]
 	},
 	{
-		content: ['Go to or set up the Obot Sentry configuration.'],
+		content: ['The "Configuration" tab contains all the information needed to set up Obot Sentry.'],
 		action: [
 			{
 				routeContains: '/admin/devices',
@@ -52,7 +52,7 @@ export const steps: GuideStep[] = [
 					},
 					side: 'left' as const,
 					title: 'Configure Managed Devices',
-					description: 'Click Get Started to create the initial managed-device configuration.'
+					description: 'Begin creating the initial managed-device configuration here.'
 				},
 				listener: {
 					id: MDM_DEVICES_CONFIGURATION_FIELD_IDS.getStartedButton,
@@ -83,7 +83,7 @@ export const steps: GuideStep[] = [
 		]
 	},
 	{
-		content: ['The Configuration tab contains the Install Obot Sentry workflow.'],
+		content: ["We'll take you through the installation steps."],
 		action: {
 			highlight: {
 				selector: {
@@ -119,7 +119,7 @@ export const steps: GuideStep[] = [
 								side: 'top',
 								title: 'Installation Method',
 								description:
-									'Select the appropriate installation method for your devices. Manual installation requires you to manually install the Obot Sentry agent on each device. Microsoft Intune installation allows you to deploy the agent to your devices using Microsoft Intune.'
+									'Select the appropriate installation method for your devices here. Manual installation requires you to manually install the Obot Sentry agent on each device. Microsoft Intune installation allows you to deploy the agent to multiple devices across your organization.'
 							},
 							listener: {
 								id: `${MDM_DEVICES_CONFIGURATION_FIELD_IDS.enrollmentConfigSetupStep}-2`,
@@ -131,7 +131,8 @@ export const steps: GuideStep[] = [
 										},
 										side: 'top',
 										title: 'Operating System',
-										description: 'Make sure to select the proper operating system for your devices.'
+										description:
+											'Make sure to select the proper operating system for your devices here.'
 									},
 									listener: {
 										id: `${MDM_DEVICES_CONFIGURATION_FIELD_IDS.enrollmentConfigSetupStep}-3`,
@@ -164,7 +165,7 @@ export const steps: GuideStep[] = [
 				side: 'top',
 				title: 'OS/Type Specific Instructions',
 				description:
-					'Depending on the installation type and OS selected, the instructions here will be different. Click here to go ahead and expand it.'
+					"Depending on the installation type and OS selected, the instructions here will be different. Let's expand it for you."
 			},
 			listener: {
 				id: `${MDM_DEVICES_CONFIGURATION_FIELD_IDS.enrollmentConfigSetupStep}-5`,
@@ -178,13 +179,37 @@ export const steps: GuideStep[] = [
 						description:
 							"Once you've set up an enrollment key, its information will be displayed here. Generally, you'll only need a single enrollment key to register devices with, but if you need to rotate keys, you can create new enrollment keys from here.",
 						noDescendantInteraction: true
+					},
+					listener: {
+						id: MDM_DEVICES_CONFIGURATION_FIELD_IDS.enrollmentKeysSection,
+						skipClickTargetOnNext: true,
+						action: {
+							highlight: {
+								selector: {
+									id: MDM_DEVICES_CONFIGURATION_FIELD_IDS.toolCallEnforcementSection
+								},
+								side: 'top',
+								title: 'Tool Call Enforcement',
+								description:
+									'Here is where you can control which tool calls can be executed for your enrolled devices. Make sure to save your changes to have them take effect; the installation guide in step 5 will update appropriately.',
+								experimental: true
+							},
+							listener: {
+								id: MDM_DEVICES_CONFIGURATION_FIELD_IDS.toolCallEnforcementSection,
+								action: {
+									success: true
+								}
+							}
+						}
 					}
 				}
 			}
 		}
 	},
 	{
-		content: ['Once scans have been sent through Obot Sentry, you can view the results here.'],
+		content: [
+			'Once Obot Sentry has been installed and configured on your devices, you can view the results and actions taken in these locations.'
+		],
 		action: {
 			highlight: {
 				selector: {
@@ -193,7 +218,7 @@ export const steps: GuideStep[] = [
 				title: 'See Overall Results',
 				side: 'left',
 				description:
-					'View an overall summary of all the scans sent through Obot Sentry over a given time period.'
+					'View an overall summary of all the scans sent through Obot Sentry over a given time period here.'
 			},
 			listener: {
 				id: MDM_DEVICES_CONFIGURATION_FIELD_IDS.devicesTabOverview,
@@ -212,7 +237,22 @@ export const steps: GuideStep[] = [
 						id: MDM_DEVICES_CONFIGURATION_FIELD_IDS.devicesTabDevices,
 						skipClickTargetOnNext: true,
 						action: {
-							success: true
+							highlight: {
+								selector: {
+									id: MDM_DEVICES_CONFIGURATION_FIELD_IDS.enforcementDecisionsLink
+								},
+								side: 'right',
+								title: 'Enforcement Decisions',
+								description:
+									'When enforcement is enabled and tool calls are made, any actions Obot Sentry takes against them will be recorded and viewable here.'
+							},
+							listener: {
+								id: MDM_DEVICES_CONFIGURATION_FIELD_IDS.enforcementDecisionsLink,
+								skipClickTargetOnNext: true,
+								action: {
+									success: true
+								}
+							}
 						}
 					}
 				}

--- a/ui/user/src/lib/services/guides/mcp/constants.ts
+++ b/ui/user/src/lib/services/guides/mcp/constants.ts
@@ -9,7 +9,7 @@ export const highlightMcpCatalogLink: GuideHighlight = {
 		id: SIDEBAR_MCP_CATALOG_LINK
 	},
 	title: 'MCP Catalog',
-	description: 'Click here to view MCP server catalog.'
+	description: 'This is where you can find MCP servers to use in your workflows.'
 };
 
 export const listenMcpCatalogLink: GuideListener = {
@@ -24,7 +24,7 @@ export const highlightMcpAccessPoliciesLink: GuideHighlight = {
 		id: SIDEBAR_MCP_ACCESS_POLICIES_LINK
 	},
 	title: 'MCP Access Policies',
-	description: 'Click here to view MCP access policies.'
+	description: 'This is where you can manage MCP access policies.'
 };
 
 export const listenMcpAccessPoliciesLink: GuideListener = {
@@ -45,9 +45,9 @@ export const addCatalogEntryDescriptions = {
 
 export const obotCatalogEntryDescriptions = {
 	hosted:
-		'A hosted catalog entry provides a simple way to deploy and host an MCP server on the Obot platform, where Obot manages its operation and lifecycle. Click here to get started.',
+		"A hosted catalog entry provides a simple way to deploy and host an MCP server on the Obot platform, where Obot manages its operation and lifecycle. Let's continue through here.",
 	remote:
-		"A remote catalog entry lets you proxy all traffic to a remote MCP server through Obot, enabling you to take advantage of Obot's access policies and audit logging. Click here to get started.",
+		"A remote catalog entry lets you proxy all traffic to a remote MCP server through Obot, enabling you to take advantage of Obot's access policies and audit logging. Let's continue through here.",
 	composite:
-		'A composite catalog entry lets you combine multiple MCP servers into a single remote MCP server and expose only the tools you want users to access.'
+		"A composite catalog entry lets you combine multiple MCP servers into a single remote MCP server and expose only the tools you want users to access. Let's continue through here."
 };

--- a/ui/user/src/lib/services/guides/mcp/customComposite.ts
+++ b/ui/user/src/lib/services/guides/mcp/customComposite.ts
@@ -38,7 +38,8 @@ export const steps: GuideStep[] = [
 						side: 'top',
 						align: 'center',
 						title: 'Add Component Entry',
-						description: 'Click here to begin adding a component entry to the composite server.'
+						description:
+							'This is where you can start adding a component entry to the composite server.'
 					},
 					listener: {
 						id: CATALOG_SERVER_FIELD_IDS.addCompositeEntryBtn,
@@ -50,7 +51,7 @@ export const steps: GuideStep[] = [
 								side: 'right',
 								title: 'Adding Component Entries',
 								description:
-									'Here you can search and select the component entries that you want to add to the composite server. Each component will have its own configuration and authentication requirements. Follow the wizard to complete the process.',
+									'After clicking "Add Component Entry", here is where you can search and select the component entries that you want to add to the composite server. Each component will have its own configuration and authentication requirements; simply follow the wizard to complete the process. Let\'s close this and continue.',
 								noDescendantInteraction: true
 							},
 							listener: {

--- a/ui/user/src/lib/services/guides/mcp/customRemote.ts
+++ b/ui/user/src/lib/services/guides/mcp/customRemote.ts
@@ -24,7 +24,7 @@ export const steps: GuideStep[] = [
 				side: 'top',
 				align: 'center',
 				title: 'Remote Server URL',
-				description: 'Enter the full URL of the remote MCP Server.'
+				description: 'This is where you enter the full URL of the remote MCP Server.'
 			},
 			listener: {
 				id: CATALOG_SERVER_FIELD_IDS.remoteURL,

--- a/ui/user/src/lib/services/guides/mcp/filters.ts
+++ b/ui/user/src/lib/services/guides/mcp/filters.ts
@@ -52,7 +52,7 @@ export const steps: GuideStep[] = [
 					id: MCP_FILTERS_FIELD_IDS.addFilterBtn
 				},
 				title: 'Add New Filter',
-				description: 'This where you can add a new MCP filter.',
+				description: 'This is where you can add a new MCP filter.',
 				side: 'left'
 			},
 			listener: {

--- a/ui/user/src/lib/services/guides/mcp/filters.ts
+++ b/ui/user/src/lib/services/guides/mcp/filters.ts
@@ -43,14 +43,16 @@ export const steps: GuideStep[] = [
 		]
 	},
 	{
-		content: ['Create and manage your MCP filters here. To start, click the "Add Filter" button.'],
+		content: [
+			"Create and manage your MCP filters here. We'll take you through creating a new MCP filter."
+		],
 		action: {
 			highlight: {
 				selector: {
 					id: MCP_FILTERS_FIELD_IDS.addFilterBtn
 				},
 				title: 'Add New Filter',
-				description: 'Click here to start adding a new MCP filter.',
+				description: 'This where you can add a new MCP filter.',
 				side: 'left'
 			},
 			listener: {
@@ -62,7 +64,7 @@ export const steps: GuideStep[] = [
 						},
 						title: 'Create Custom Filter',
 						description:
-							"Obot also supports out-of-the-box PII filtering, but for the sake of this guide, let's create a custom filter. Click here to get started.",
+							"Obot also supports out-of-the-box PII filtering, but for the sake of this guide, let's create a custom filter. Let's continue through here.",
 						side: 'left'
 					},
 					listener: {
@@ -85,7 +87,7 @@ export const steps: GuideStep[] = [
 				side: 'top',
 				align: 'center',
 				title: 'Basic Details',
-				description: 'Enter the basic details of the filter.'
+				description: 'This is where you can enter the basic details of the filter.'
 			},
 			listener: {
 				id: MCP_FILTERS_FIELD_IDS.basicDetails,
@@ -127,7 +129,7 @@ export const steps: GuideStep[] = [
 										align: 'center',
 										title: 'Selectors',
 										description:
-											'Specify which requests should be matched by this filter. These can be specified by methods or identifiers such as tool names.',
+											'This is where you specify which requests should be matched by this filter. These can be specified by methods or identifiers such as tool names.',
 										noDescendantInteraction: true
 									},
 									listener: {
@@ -142,7 +144,7 @@ export const steps: GuideStep[] = [
 												align: 'center',
 												title: 'MCP Servers',
 												description:
-													'Select the MCP servers that will be used to filter the tool calls.',
+													'Select the MCP servers that will be used to filter the tool calls here.',
 												noDescendantInteraction: true
 											},
 											listener: {

--- a/ui/user/src/lib/services/guides/mcp/steps.ts
+++ b/ui/user/src/lib/services/guides/mcp/steps.ts
@@ -62,7 +62,7 @@ export function getHighlightAddCatalogEntryStep(
 
 	return {
 		content: [
-			'Create and manage your MCP catalog entries here. To start, click the "Add Catalog Entry" button.'
+			`Create and manage your MCP catalog entries here. We'll take you through creating a new ${type} catalog entry.`
 		],
 		action: {
 			highlight: {
@@ -70,7 +70,8 @@ export function getHighlightAddCatalogEntryStep(
 					id: 'add-catalog-entry-button'
 				},
 				title: 'Add Catalog Entry',
-				description: 'Click here to start adding a new catalog entry.',
+				description:
+					'This is where you can create and select what type of catalog entry you want to create.',
 				side: 'left'
 			},
 			listener: {

--- a/ui/user/src/lib/services/guides/types.ts
+++ b/ui/user/src/lib/services/guides/types.ts
@@ -40,6 +40,7 @@ export interface GuideHighlight {
 	side?: 'top' | 'right' | 'bottom' | 'left';
 	align?: 'start' | 'center' | 'end';
 	noDescendantInteraction?: boolean;
+	experimental?: boolean;
 }
 
 export interface GuideAction {

--- a/ui/user/src/routes/admin/devices/EnforcementSettings.svelte
+++ b/ui/user/src/routes/admin/devices/EnforcementSettings.svelte
@@ -4,6 +4,7 @@
 	import DotDotDot from '$lib/components/DotDotDot.svelte';
 	import Toggle from '$lib/components/Toggle.svelte';
 	import Table from '$lib/components/table/Table.svelte';
+	import { MDM_DEVICES_CONFIGURATION_FIELD_IDS } from '$lib/constants';
 	import {
 		ALLOWLIST_SERVER_KIND_LABELS,
 		allowlistServerKind,
@@ -206,7 +207,7 @@
 	}
 </script>
 
-<section class="paper gap-4">
+<section class="paper gap-4" id={MDM_DEVICES_CONFIGURATION_FIELD_IDS.toolCallEnforcementSection}>
 	<div class="flex flex-col gap-1">
 		<div class="flex flex-wrap items-center gap-2">
 			<h3 class="text-lg font-semibold">Tool Call Enforcement</h3>


### PR DESCRIPTION
This addresses putting users even more "on-rails" for the getting started guide by disabling interaction with the highlighted items. As a result, wording for each guide was updated to avoid confusion that they can interact during the guide. It also adds additional steps to highlight the enforcement tools addition in Obot Sentry/Devices page.