### PR TITLE
fix(ui): avoid duplicate tunnel disconnected status

### DIFF
--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -28,7 +28,7 @@
 	} from '$lib/services/user/mcp';
 	import {
 		getMcpTunnelConnectionsKey,
-		getMcpTunnelDeploymentHealth
+		isMcpTunnelDisconnected
 	} from '$lib/services/user/mcpTunnel';
 	import { profile, mcpServersAndEntries, mcpTunnelConnections, version } from '$lib/stores';
 	import { formatTimeAgo } from '$lib/time';
@@ -192,6 +192,10 @@
 				const compositeParentName = compositeParent ? getMCPDisplayName(compositeParent) : '';
 
 				const instance = instancesMap.get(deployment.id);
+				const tunnelDisconnected = isMcpTunnelDisconnected(
+					deployment,
+					mcpTunnelConnections.current.connections
+				);
 				const { updateStatus, updatesAvailable, updateStatusTooltip } =
 					instance?.configured === false
 						? {
@@ -221,11 +225,9 @@
 					updateStatus,
 					updatesAvailable,
 					updateStatusTooltip,
-					deploymentStatus: getMcpTunnelDeploymentHealth(
-						deployment,
-						mcpTunnelConnections.current.connections,
-						deployment.deploymentStatus
-					),
+					deploymentStatus: tunnelDisconnected
+						? 'Tunnel Disconnected'
+						: deployment.deploymentStatus,
 					missingKubernetesSecret: hasMissingSecretBindingConfig(
 						deployment.manifest,
 						deployment.missingRequiredEnvVars,

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -6,6 +6,7 @@
 	import DiffDialog from '$lib/components/admin/DiffDialog.svelte';
 	import McpConfirmDelete from '$lib/components/mcp/McpConfirmDelete.svelte';
 	import McpMultiDeleteBlockedDialog from '$lib/components/mcp/McpMultiDeleteBlockedDialog.svelte';
+	import McpTunnelDisconnectedStatus from '$lib/components/mcp/McpTunnelDisconnectedStatus.svelte';
 	import Table, { type InitSort, type InitSortFn } from '$lib/components/table/Table.svelte';
 	import { ADMIN_SESSION_STORAGE } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
@@ -28,7 +29,8 @@
 	} from '$lib/services/user/mcp';
 	import {
 		getMcpTunnelConnectionsKey,
-		isMcpTunnelDisconnected
+		isMcpTunnelDisconnected,
+		shouldShowMcpTunnelDisconnectedBadge
 	} from '$lib/services/user/mcpTunnel';
 	import { profile, mcpServersAndEntries, mcpTunnelConnections, version } from '$lib/stores';
 	import { formatTimeAgo } from '$lib/time';
@@ -225,6 +227,7 @@
 					updateStatus,
 					updatesAvailable,
 					updateStatusTooltip,
+					tunnelDisconnected,
 					deploymentStatus: tunnelDisconnected
 						? 'Tunnel Disconnected'
 						: deployment.deploymentStatus,
@@ -677,6 +680,9 @@
 								{/if}
 							</p>
 							<McpDeprecatedNotice item={d} />
+							{#if shouldShowMcpTunnelDisconnectedBadge(d.tunnelDisconnected, doesSupportK8sUpdates)}
+								<McpTunnelDisconnectedStatus />
+							{/if}
 							{#if 'missingKubernetesSecret' in d && d.missingKubernetesSecret}
 								<div
 									class="text-warning"

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -6,7 +6,6 @@
 	import DiffDialog from '$lib/components/admin/DiffDialog.svelte';
 	import McpConfirmDelete from '$lib/components/mcp/McpConfirmDelete.svelte';
 	import McpMultiDeleteBlockedDialog from '$lib/components/mcp/McpMultiDeleteBlockedDialog.svelte';
-	import McpTunnelDisconnectedStatus from '$lib/components/mcp/McpTunnelDisconnectedStatus.svelte';
 	import Table, { type InitSort, type InitSortFn } from '$lib/components/table/Table.svelte';
 	import { ADMIN_SESSION_STORAGE } from '$lib/constants';
 	import Loading from '$lib/icons/Loading.svelte';
@@ -29,7 +28,7 @@
 	} from '$lib/services/user/mcp';
 	import {
 		getMcpTunnelConnectionsKey,
-		isMcpTunnelDisconnected
+		getMcpTunnelDeploymentHealth
 	} from '$lib/services/user/mcpTunnel';
 	import { profile, mcpServersAndEntries, mcpTunnelConnections, version } from '$lib/stores';
 	import { formatTimeAgo } from '$lib/time';
@@ -193,10 +192,6 @@
 				const compositeParentName = compositeParent ? getMCPDisplayName(compositeParent) : '';
 
 				const instance = instancesMap.get(deployment.id);
-				const tunnelDisconnected = isMcpTunnelDisconnected(
-					deployment,
-					mcpTunnelConnections.current.connections
-				);
 				const { updateStatus, updatesAvailable, updateStatusTooltip } =
 					instance?.configured === false
 						? {
@@ -226,10 +221,11 @@
 					updateStatus,
 					updatesAvailable,
 					updateStatusTooltip,
-					tunnelDisconnected,
-					deploymentStatus: tunnelDisconnected
-						? 'Tunnel Disconnected'
-						: deployment.deploymentStatus,
+					deploymentStatus: getMcpTunnelDeploymentHealth(
+						deployment,
+						mcpTunnelConnections.current.connections,
+						deployment.deploymentStatus
+					),
 					missingKubernetesSecret: hasMissingSecretBindingConfig(
 						deployment.manifest,
 						deployment.missingRequiredEnvVars,
@@ -645,10 +641,6 @@
 					thead: classes?.tableHeader
 				}}
 				setRowClasses={(d) => {
-					if (d.tunnelDisconnected) {
-						return 'bg-error/5 hover:bg-error/10 border-error/20';
-					}
-
 					if (d.needsUpdate && d.needsK8sUpdate) {
 						return 'bg-orange-500/5 hover:bg-orange-500/10 border-orange-500/20';
 					}
@@ -683,9 +675,6 @@
 								{/if}
 							</p>
 							<McpDeprecatedNotice item={d} />
-							{#if d.tunnelDisconnected}
-								<McpTunnelDisconnectedStatus />
-							{/if}
 							{#if 'missingKubernetesSecret' in d && d.missingKubernetesSecret}
 								<div
 									class="text-warning"

--- a/ui/user/src/lib/services/user/mcpTunnel.test.mjs
+++ b/ui/user/src/lib/services/user/mcpTunnel.test.mjs
@@ -1,4 +1,8 @@
-import { getMcpTunnelConnectionsKey, isMcpTunnelDisconnected } from './mcpTunnel.ts';
+import {
+	getMcpTunnelConnectionsKey,
+	isMcpTunnelDisconnected,
+	shouldShowMcpTunnelDisconnectedBadge
+} from './mcpTunnel.ts';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
@@ -53,4 +57,10 @@ test('changes the table remeasurement key only when tunnel connectivity changes'
 		getMcpTunnelConnectionsKey([{ name: 'mt1office' }]),
 		getMcpTunnelConnectionsKey([])
 	);
+});
+
+test('shows the disconnected badge only when the health column is unavailable', () => {
+	assert.equal(shouldShowMcpTunnelDisconnectedBadge(true, false), true);
+	assert.equal(shouldShowMcpTunnelDisconnectedBadge(true, true), false);
+	assert.equal(shouldShowMcpTunnelDisconnectedBadge(false, false), false);
 });

--- a/ui/user/src/lib/services/user/mcpTunnel.test.mjs
+++ b/ui/user/src/lib/services/user/mcpTunnel.test.mjs
@@ -1,8 +1,4 @@
-import {
-	getMcpTunnelConnectionsKey,
-	getMcpTunnelDeploymentHealth,
-	isMcpTunnelDisconnected
-} from './mcpTunnel.ts';
+import { getMcpTunnelConnectionsKey, isMcpTunnelDisconnected } from './mcpTunnel.ts';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
@@ -56,13 +52,5 @@ test('changes the table remeasurement key only when tunnel connectivity changes'
 	assert.notEqual(
 		getMcpTunnelConnectionsKey([{ name: 'mt1office' }]),
 		getMcpTunnelConnectionsKey([])
-	);
-});
-
-test('presents a disconnected deployment only through its health field', () => {
-	assert.equal(getMcpTunnelDeploymentHealth(remoteServer, [], 'Available'), 'Tunnel Disconnected');
-	assert.equal(
-		getMcpTunnelDeploymentHealth(remoteServer, [{ name: 'mt1office' }], 'Available'),
-		'Available'
 	);
 });

--- a/ui/user/src/lib/services/user/mcpTunnel.test.mjs
+++ b/ui/user/src/lib/services/user/mcpTunnel.test.mjs
@@ -1,4 +1,8 @@
-import { getMcpTunnelConnectionsKey, isMcpTunnelDisconnected } from './mcpTunnel.ts';
+import {
+	getMcpTunnelConnectionsKey,
+	getMcpTunnelDeploymentHealth,
+	isMcpTunnelDisconnected
+} from './mcpTunnel.ts';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
@@ -52,5 +56,13 @@ test('changes the table remeasurement key only when tunnel connectivity changes'
 	assert.notEqual(
 		getMcpTunnelConnectionsKey([{ name: 'mt1office' }]),
 		getMcpTunnelConnectionsKey([])
+	);
+});
+
+test('presents a disconnected deployment only through its health field', () => {
+	assert.equal(getMcpTunnelDeploymentHealth(remoteServer, [], 'Available'), 'Tunnel Disconnected');
+	assert.equal(
+		getMcpTunnelDeploymentHealth(remoteServer, [{ name: 'mt1office' }], 'Available'),
+		'Available'
 	);
 });

--- a/ui/user/src/lib/services/user/mcpTunnel.ts
+++ b/ui/user/src/lib/services/user/mcpTunnel.ts
@@ -28,3 +28,10 @@ export function isMcpTunnelDisconnected(
 
 	return !connections.some((connection) => connection.name === tunnelName);
 }
+
+export function shouldShowMcpTunnelDisconnectedBadge(
+	tunnelDisconnected: boolean,
+	hasHealthColumn: boolean
+): boolean {
+	return tunnelDisconnected && !hasHealthColumn;
+}

--- a/ui/user/src/lib/services/user/mcpTunnel.ts
+++ b/ui/user/src/lib/services/user/mcpTunnel.ts
@@ -28,3 +28,11 @@ export function isMcpTunnelDisconnected(
 
 	return !connections.some((connection) => connection.name === tunnelName);
 }
+
+export function getMcpTunnelDeploymentHealth(
+	item: TunnelAwareMCP | undefined,
+	connections: TunnelConnection[] | undefined,
+	deploymentStatus: string | undefined
+): string | undefined {
+	return isMcpTunnelDisconnected(item, connections) ? 'Tunnel Disconnected' : deploymentStatus;
+}

--- a/ui/user/src/lib/services/user/mcpTunnel.ts
+++ b/ui/user/src/lib/services/user/mcpTunnel.ts
@@ -28,11 +28,3 @@ export function isMcpTunnelDisconnected(
 
 	return !connections.some((connection) => connection.name === tunnelName);
 }
-
-export function getMcpTunnelDeploymentHealth(
-	item: TunnelAwareMCP | undefined,
-	connections: TunnelConnection[] | undefined,
-	deploymentStatus: string | undefined
-): string | undefined {
-	return isMcpTunnelDisconnected(item, connections) ? 'Tunnel Disconnected' : deploymentStatus;
-}


### PR DESCRIPTION
Keep disconnected tunnel information in the deployment health field while removing the redundant name badge and error row tint. This keeps management views clear without hiding tunnel availability.

Issue: https://github.com/obot-platform/obot/issues/7353