### PR TITLE
enhance(devices): add limits similar to users

### DIFF
--- a/pkg/api/handlers/deviceenroll.go
+++ b/pkg/api/handlers/deviceenroll.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/x509"
+	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -15,17 +17,21 @@ import (
 )
 
 // DeviceEnrollHandler serves device enrollment.
-type DeviceEnrollHandler struct{}
+type DeviceEnrollHandler struct {
+	deviceLimitProvider gateway.DeviceLimitProvider
+}
 
-func NewDeviceEnrollHandler() *DeviceEnrollHandler {
-	return nil
+func NewDeviceEnrollHandler(deviceLimitProvider gateway.DeviceLimitProvider) *DeviceEnrollHandler {
+	return &DeviceEnrollHandler{
+		deviceLimitProvider: deviceLimitProvider,
+	}
 }
 
 // Enroll handles POST /api/mdm/enroll. The caller is authenticated by an
 // enrollment credential (the DeviceEnroll principal carries the configuration id
 // in Extra). It registers the device's identity key (trust-on-first-use; a
 // different key for an existing device is rejected).
-func (*DeviceEnrollHandler) Enroll(req api.Context) error {
+func (h *DeviceEnrollHandler) Enroll(req api.Context) error {
 	configurationID, ok := uintFromExtra(req.User.GetExtra(), "mdm_configuration_id")
 	if !ok {
 		return types.NewErrBadRequest("enrollment requires a device enrollment credential")
@@ -59,6 +65,14 @@ func (*DeviceEnrollHandler) Enroll(req api.Context) error {
 		return types.NewErrBadRequest("unsupported public key type %T: publicKey must be an ECDSA P-256/P-384/P-521 or Ed25519 key", pub)
 	}
 
+	deviceLimit, err := h.deviceLimitProvider.DeviceLimit(req.Context())
+	if err != nil {
+		return fmt.Errorf("failed to resolve device limit: %w", err)
+	}
+	if !deviceLimit.Unlimited && deviceLimit.Maximum <= 0 {
+		return fmt.Errorf("invalid device limit %d", deviceLimit.Maximum)
+	}
+
 	device, err := req.GatewayClient.EnrollDevice(req.Context(), gateway.DeviceEnrollment{
 		DeviceID:           in.DeviceID,
 		MDMConfigurationID: configurationID,
@@ -66,8 +80,11 @@ func (*DeviceEnrollHandler) Enroll(req api.Context) error {
 		Hostname:           in.Hostname,
 		OS:                 in.OS,
 		OSVersion:          in.OSVersion,
-	})
+	}, deviceLimit)
 	if err != nil {
+		if httpErr, ok := errors.AsType[*types.ErrHTTP](err); ok {
+			return httpErr
+		}
 		return types.NewErrBadRequest("%v", err)
 	}
 

--- a/pkg/api/handlers/deviceenroll_test.go
+++ b/pkg/api/handlers/deviceenroll_test.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+type deviceLimitProviderFunc func(context.Context) (gatewayclient.DeviceLimit, error)
+
+func (f deviceLimitProviderFunc) DeviceLimit(ctx context.Context) (gatewayclient.DeviceLimit, error) {
+	return f(ctx)
+}
+
+func TestDeviceEnrollPreservesDeviceLimitForbiddenError(t *testing.T) {
+	gatewayClient := newEnforcementTestGatewayClient(t)
+	limit := gatewayclient.DeviceLimit{Maximum: 1}
+
+	firstPublicKey := deviceEnrollTestPublicKey(t)
+	if _, err := gatewayClient.EnrollDevice(t.Context(), gatewayclient.DeviceEnrollment{
+		DeviceID:           "device-1",
+		MDMConfigurationID: 1,
+		PublicKey:          firstPublicKey,
+	}, limit); err != nil {
+		t.Fatalf("enroll first device: %v", err)
+	}
+
+	body, err := json.Marshal(types.DeviceEnrollRequest{
+		DeviceID:  "device-2",
+		PublicKey: deviceEnrollTestPublicKey(t),
+	})
+	if err != nil {
+		t.Fatalf("marshal enrollment request: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/mdm/enroll", bytes.NewReader(body))
+	apiContext := api.Context{
+		ResponseWriter: recorder,
+		Request:        req,
+		GatewayClient:  gatewayClient,
+		User: &user.DefaultInfo{
+			Extra: map[string][]string{
+				"mdm_configuration_id": {"1"},
+			},
+		},
+	}
+	handler := NewDeviceEnrollHandler(deviceLimitProviderFunc(func(context.Context) (gatewayclient.DeviceLimit, error) {
+		return limit, nil
+	}))
+
+	err = handler.Enroll(apiContext)
+	var httpErr *types.ErrHTTP
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("Enroll() error = %T %v, want *types.ErrHTTP", err, err)
+	}
+	if httpErr.Code != http.StatusForbidden {
+		t.Fatalf("Enroll() HTTP code = %d, want %d", httpErr.Code, http.StatusForbidden)
+	}
+	if got, err := gatewayClient.DeviceCount(t.Context()); err != nil {
+		t.Fatalf("count devices: %v", err)
+	} else if got != limit.Maximum {
+		t.Fatalf("device count = %d, want %d", got, limit.Maximum)
+	}
+}
+
+func deviceEnrollTestPublicKey(t *testing.T) []byte {
+	t.Helper()
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate Ed25519 key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		t.Fatalf("marshal public key: %v", err)
+	}
+	return der
+}
+
+func TestDeviceEnrollRejectsInvalidDeviceLimit(t *testing.T) {
+	gatewayClient := newEnforcementTestGatewayClient(t)
+	body, err := json.Marshal(types.DeviceEnrollRequest{
+		DeviceID:  "device-1",
+		PublicKey: deviceEnrollTestPublicKey(t),
+	})
+	if err != nil {
+		t.Fatalf("marshal enrollment request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/mdm/enroll", bytes.NewReader(body))
+	apiContext := api.Context{
+		ResponseWriter: httptest.NewRecorder(),
+		Request:        req,
+		GatewayClient:  gatewayClient,
+		User: &user.DefaultInfo{
+			Extra: map[string][]string{
+				"mdm_configuration_id": {"1"},
+			},
+		},
+	}
+	handler := NewDeviceEnrollHandler(deviceLimitProviderFunc(func(context.Context) (gatewayclient.DeviceLimit, error) {
+		return gatewayclient.DeviceLimit{}, nil
+	}))
+
+	err = handler.Enroll(apiContext)
+	if err == nil || err.Error() != fmt.Sprintf("invalid device limit %d", 0) {
+		t.Fatalf("Enroll() error = %v, want invalid device limit", err)
+	}
+	if got, err := gatewayClient.DeviceCount(t.Context()); err != nil {
+		t.Fatalf("count devices: %v", err)
+	} else if got != 0 {
+		t.Fatalf("device count = %d, want 0", got)
+	}
+}

--- a/pkg/api/handlers/version.go
+++ b/pkg/api/handlers/version.go
@@ -121,6 +121,11 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 		return nil, err
 	}
 
+	deviceCount, err := v.GatewayClient.DeviceCount(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	values := map[string]any{
 		"upgradeAvailable":             upgradeAvailable,
 		"latestVersion":                latestVersion,
@@ -131,6 +136,7 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 		"community":                    slices.Contains(entitlements, license.CommunityEntitlement),
 		"licenseEntitlements":          entitlements,
 		"userCount":                    userCount,
+		"deviceCount":                  deviceCount,
 		"engine":                       engine,
 		"mcpNetworkPolicyEnabled":      v.MCPNetworkPolicyEnabled,
 		"mcpDefaultDenyAllEgress":      v.MCPDefaultDenyAllEgress,
@@ -147,6 +153,14 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 	}
 	if !userLimit.Unlimited {
 		values["userLimit"] = userLimit.Maximum
+	}
+
+	deviceLimit, err := v.LicenseProvider.DeviceLimit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !deviceLimit.Unlimited {
+		values["deviceLimit"] = deviceLimit.Maximum
 	}
 
 	if versions := os.Getenv("OBOT_SERVER_VERSIONS"); versions != "" {

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -103,7 +103,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mdmAssetSources := handlers.NewMDMAssetSourceHandler()
 	mdmAssets := handlers.NewMDMAssetHandler()
 	mdmConfigurations := handlers.NewMDMConfigurationsHandler(services.ServerURL)
-	deviceEnroll := handlers.NewDeviceEnrollHandler()
+	deviceEnroll := handlers.NewDeviceEnrollHandler(services.LicenseProvider)
 	authProviders := handlers.NewAuthProviderHandler(services.ProviderDispatcher, services.PostgresDSN, services.LicenseProvider)
 	localAuth := handlers.NewLocalAuthHandler(services.LocalAuthProvider)
 	defaultModelAliases := handlers.NewDefaultModelAliasHandler()

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -23,6 +23,10 @@ const (
 	// DefaultUserLimit is the maximum number of users allowed when no
 	// license-derived user-limit provider is configured.
 	DefaultUserLimit = 100
+
+	// DefaultDeviceLimit is the maximum number of devices allowed when no
+	// license-derived device-limit provider is configured.
+	DefaultDeviceLimit = 100
 )
 
 type Client struct {
@@ -45,6 +49,7 @@ type Client struct {
 	serviceAccountCacheLock sync.RWMutex
 	serviceAccountCache     map[[32]byte]serviceAccountValidationCacheEntry
 	serviceAccountCacheTTL  time.Duration
+	deviceCreationLock      sync.Mutex
 	auditLogCleanupInterval time.Duration
 	auditLogDeleteBatchSize int
 	oktaGroupMigrationMu    sync.Mutex

--- a/pkg/gateway/client/device.go
+++ b/pkg/gateway/client/device.go
@@ -5,11 +5,27 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
+	apitypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"gorm.io/gorm"
 )
+
+const deviceCreationAdvisoryLockID int64 = 0x6f626f7444657669 // "obotDevi"
+
+// DeviceLimit describes the maximum number of devices an installation may have.
+// Maximum is ignored when Unlimited is true.
+type DeviceLimit struct {
+	Maximum   int64
+	Unlimited bool
+}
+
+// DeviceLimitProvider resolves the current license-derived device limit.
+type DeviceLimitProvider interface {
+	DeviceLimit(context.Context) (DeviceLimit, error)
+}
 
 // DeviceEnrollment is the input to enrolling (or re-enrolling) a device.
 // PublicKey is DER SubjectPublicKeyInfo (PKIX) of the device identity key.
@@ -27,7 +43,28 @@ type DeviceEnrollment struct {
 //   - same device, same key      -> reactivate and rebind to the configuration
 //   - same device, different key  -> rejected (anti-takeover)
 //   - new device                  -> created
-func (c *Client) EnrollDevice(ctx context.Context, in DeviceEnrollment) (*types.Device, error) {
+func (c *Client) EnrollDevice(ctx context.Context, in DeviceEnrollment, deviceLimit DeviceLimit) (*types.Device, error) {
+	if !deviceLimit.Unlimited {
+		var existing types.Device
+		err := c.db.WithContext(ctx).Where("device_id = ?", in.DeviceID).First(&existing).Error
+		switch {
+		case err == nil:
+			return c.enrollDevice(ctx, in, deviceLimit)
+		case errors.Is(err, gorm.ErrRecordNotFound):
+			// SQLite transactions are deferred, and this flow does not write
+			// before counting devices. Serialize local allocations so concurrent
+			// count-and-create operations cannot both claim the same seat.
+			c.deviceCreationLock.Lock()
+			defer c.deviceCreationLock.Unlock()
+		default:
+			return nil, err
+		}
+	}
+
+	return c.enrollDevice(ctx, in, deviceLimit)
+}
+
+func (c *Client) enrollDevice(ctx context.Context, in DeviceEnrollment, deviceLimit DeviceLimit) (*types.Device, error) {
 	var device types.Device
 	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var existing types.Device
@@ -37,22 +74,43 @@ func (c *Client) EnrollDevice(ctx context.Context, in DeviceEnrollment) (*types.
 			if !bytes.Equal(existing.PublicKey, in.PublicKey) {
 				return fmt.Errorf("device %q is already enrolled with a different identity key", in.DeviceID)
 			}
-			updates := map[string]any{
-				"mdm_configuration_id": in.MDMConfigurationID,
-				"hostname":             in.Hostname,
-				"os":                   in.OS,
-				"os_version":           in.OSVersion,
+			if err := updateEnrolledDevice(tx, &existing, in); err != nil {
+				return err
 			}
-			if err := tx.Model(&existing).Updates(updates).Error; err != nil {
-				return fmt.Errorf("failed to re-enroll device: %w", err)
-			}
-			existing.MDMConfigurationID = in.MDMConfigurationID
-			existing.Hostname = in.Hostname
-			existing.OS = in.OS
-			existing.OSVersion = in.OSVersion
 			device = existing
 			return nil
 		case errors.Is(err, gorm.ErrRecordNotFound):
+			if !deviceLimit.Unlimited {
+				if err := lockDeviceCreation(tx); err != nil {
+					return err
+				}
+
+				// Another PostgreSQL replica may have enrolled this DeviceID
+				// while this transaction waited for the advisory lock.
+				err = tx.Where("device_id = ?", in.DeviceID).First(&existing).Error
+				switch {
+				case err == nil:
+					if !bytes.Equal(existing.PublicKey, in.PublicKey) {
+						return fmt.Errorf("device %q is already enrolled with a different identity key", in.DeviceID)
+					}
+					if err := updateEnrolledDevice(tx, &existing, in); err != nil {
+						return err
+					}
+					device = existing
+					return nil
+				case !errors.Is(err, gorm.ErrRecordNotFound):
+					return err
+				}
+
+				deviceCount, err := countDevices(tx)
+				if err != nil {
+					return fmt.Errorf("failed to count devices: %w", err)
+				}
+				if deviceCount >= deviceLimit.Maximum {
+					return newDeviceLimitError()
+				}
+			}
+
 			device = types.Device{
 				DeviceID:           in.DeviceID,
 				MDMConfigurationID: in.MDMConfigurationID,
@@ -73,6 +131,50 @@ func (c *Client) EnrollDevice(ctx context.Context, in DeviceEnrollment) (*types.
 		return nil, err
 	}
 	return &device, nil
+}
+
+func updateEnrolledDevice(tx *gorm.DB, existing *types.Device, in DeviceEnrollment) error {
+	updates := map[string]any{
+		"mdm_configuration_id": in.MDMConfigurationID,
+		"hostname":             in.Hostname,
+		"os":                   in.OS,
+		"os_version":           in.OSVersion,
+	}
+	if err := tx.Model(existing).Updates(updates).Error; err != nil {
+		return fmt.Errorf("failed to re-enroll device: %w", err)
+	}
+	existing.MDMConfigurationID = in.MDMConfigurationID
+	existing.Hostname = in.Hostname
+	existing.OS = in.OS
+	existing.OSVersion = in.OSVersion
+	return nil
+}
+
+func countDevices(tx *gorm.DB) (int64, error) {
+	var count int64
+	err := tx.Model(new(types.Device)).Count(&count).Error
+	return count, err
+}
+
+func lockDeviceCreation(tx *gorm.DB) error {
+	if tx.Name() == "postgres" {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", deviceCreationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to lock device creation: %w", err)
+		}
+	}
+	return nil
+}
+
+func newDeviceLimitError() error {
+	return apitypes.NewErrHTTP(
+		http.StatusForbidden,
+		"Unable to enroll your device. Please contact your administrator.",
+	)
+}
+
+// DeviceCount returns the total number of enrolled devices.
+func (c *Client) DeviceCount(ctx context.Context) (int64, error) {
+	return countDevices(c.db.WithContext(ctx))
 }
 
 // GetDeviceByDeviceID looks up an enrolled device by its client-computed ID.

--- a/pkg/gateway/client/device_limit_test.go
+++ b/pkg/gateway/client/device_limit_test.go
@@ -1,0 +1,210 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	apitypes "github.com/obot-platform/obot/apiclient/types"
+)
+
+func enrollDeviceLimitTestDevice(ctx context.Context, c *Client, deviceID string, deviceLimit DeviceLimit) error {
+	_, err := c.EnrollDevice(ctx, DeviceEnrollment{
+		DeviceID:           deviceID,
+		MDMConfigurationID: 1,
+		PublicKey:          []byte("key-" + deviceID),
+		Hostname:           "host-" + deviceID,
+	}, deviceLimit)
+	return err
+}
+
+func requireDeviceLimitForbiddenError(t *testing.T, err error) {
+	t.Helper()
+
+	var httpErr *apitypes.ErrHTTP
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error = %T %v, want *types.ErrHTTP", err, err)
+	}
+	if httpErr.Code != http.StatusForbidden {
+		t.Fatalf("HTTP status = %d, want %d", httpErr.Code, http.StatusForbidden)
+	}
+}
+
+func TestDefaultDeviceLimit(t *testing.T) {
+	if DefaultDeviceLimit != 100 {
+		t.Fatalf("DefaultDeviceLimit = %d, want 100", DefaultDeviceLimit)
+	}
+}
+
+func TestEnrollDeviceEnforcesDeviceLimit(t *testing.T) {
+	const maximum = 2
+	c := newTestClient(t)
+	deviceLimit := DeviceLimit{Maximum: maximum}
+
+	for i := 1; i <= maximum; i++ {
+		if err := enrollDeviceLimitTestDevice(t.Context(), c, fmt.Sprintf("device-%d", i), deviceLimit); err != nil {
+			t.Fatalf("enrolling device %d: %v", i, err)
+		}
+	}
+
+	err := enrollDeviceLimitTestDevice(t.Context(), c, "device-3", deviceLimit)
+	requireDeviceLimitForbiddenError(t, err)
+
+	count, err := c.DeviceCount(t.Context())
+	if err != nil {
+		t.Fatalf("counting devices: %v", err)
+	}
+	if count != maximum {
+		t.Fatalf("device count = %d, want %d", count, maximum)
+	}
+}
+
+func TestEnrollDeviceAllowsExistingDeviceWhenOverLimit(t *testing.T) {
+	c := newTestClient(t)
+	unlimited := DeviceLimit{Unlimited: true}
+
+	for i := 1; i <= 2; i++ {
+		if err := enrollDeviceLimitTestDevice(t.Context(), c, fmt.Sprintf("device-%d", i), unlimited); err != nil {
+			t.Fatalf("enrolling device %d: %v", i, err)
+		}
+	}
+
+	device, err := c.EnrollDevice(t.Context(), DeviceEnrollment{
+		DeviceID:           "device-1",
+		MDMConfigurationID: 2,
+		PublicKey:          []byte("key-device-1"),
+		Hostname:           "updated-host",
+		OS:                 "darwin",
+		OSVersion:          "42",
+	}, DeviceLimit{Maximum: 1})
+	if err != nil {
+		t.Fatalf("re-enrolling existing device while over limit: %v", err)
+	}
+	if device.MDMConfigurationID != 2 || device.Hostname != "updated-host" || device.OS != "darwin" || device.OSVersion != "42" {
+		t.Fatalf("re-enrolled device was not updated: %+v", device)
+	}
+
+	_, err = c.EnrollDevice(t.Context(), DeviceEnrollment{
+		DeviceID:           "device-1",
+		MDMConfigurationID: 2,
+		PublicKey:          []byte("different-key"),
+	}, DeviceLimit{Maximum: 1})
+	if err == nil {
+		t.Fatal("re-enrolling existing device with a different key succeeded")
+	}
+	var httpErr *apitypes.ErrHTTP
+	if errors.As(err, &httpErr) {
+		t.Fatalf("different-key error = HTTP %d, want identity-key error", httpErr.Code)
+	}
+
+	err = enrollDeviceLimitTestDevice(t.Context(), c, "device-3", DeviceLimit{Maximum: 1})
+	requireDeviceLimitForbiddenError(t, err)
+
+	count, err := c.DeviceCount(t.Context())
+	if err != nil {
+		t.Fatalf("counting devices: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("device count = %d, want 2", count)
+	}
+}
+
+func TestEnrollDeviceAllowsUnlimitedDevices(t *testing.T) {
+	c := newTestClient(t)
+	deviceLimit := DeviceLimit{Maximum: 1, Unlimited: true}
+
+	for i := 1; i <= 3; i++ {
+		if err := enrollDeviceLimitTestDevice(t.Context(), c, fmt.Sprintf("device-%d", i), deviceLimit); err != nil {
+			t.Fatalf("enrolling unlimited device %d: %v", i, err)
+		}
+	}
+
+	count, err := c.DeviceCount(t.Context())
+	if err != nil {
+		t.Fatalf("counting devices: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("device count = %d, want 3", count)
+	}
+}
+
+func TestDeviceCountIsGlobal(t *testing.T) {
+	c := newTestClient(t)
+	deviceLimit := DeviceLimit{Unlimited: true}
+
+	for i, configurationID := range []uint{1, 2, 2} {
+		_, err := c.EnrollDevice(t.Context(), DeviceEnrollment{
+			DeviceID:           fmt.Sprintf("device-%d", i),
+			MDMConfigurationID: configurationID,
+			PublicKey:          []byte(fmt.Sprintf("key-%d", i)),
+		}, deviceLimit)
+		if err != nil {
+			t.Fatalf("enrolling device %d: %v", i, err)
+		}
+	}
+
+	count, err := c.DeviceCount(t.Context())
+	if err != nil {
+		t.Fatalf("counting devices: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("device count = %d, want 3", count)
+	}
+}
+
+func TestEnrollDeviceEnforcesDeviceLimitConcurrently(t *testing.T) {
+	const (
+		maximum  = 2
+		attempts = 8
+	)
+	c := newTestClient(t)
+	deviceLimit := DeviceLimit{Maximum: maximum}
+
+	start := make(chan struct{})
+	errorsByAttempt := make(chan error, attempts)
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errorsByAttempt <- enrollDeviceLimitTestDevice(t.Context(), c, fmt.Sprintf("concurrent-device-%d", i), deviceLimit)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errorsByAttempt)
+
+	var succeeded, rejected int
+	for err := range errorsByAttempt {
+		if err == nil {
+			succeeded++
+			continue
+		}
+
+		var httpErr *apitypes.ErrHTTP
+		if errors.As(err, &httpErr) && httpErr.Code == http.StatusForbidden {
+			rejected++
+			continue
+		}
+		t.Fatalf("concurrent enrollment returned unexpected error: %v", err)
+	}
+
+	if succeeded != maximum {
+		t.Fatalf("successful concurrent enrollments = %d, want %d", succeeded, maximum)
+	}
+	if rejected != attempts-maximum {
+		t.Fatalf("rejected concurrent enrollments = %d, want %d", rejected, attempts-maximum)
+	}
+
+	count, err := c.DeviceCount(t.Context())
+	if err != nil {
+		t.Fatalf("counting devices: %v", err)
+	}
+	if count != maximum {
+		t.Fatalf("device count = %d, want %d", count, maximum)
+	}
+}

--- a/pkg/gateway/client/mdmconfiguration_test.go
+++ b/pkg/gateway/client/mdmconfiguration_test.go
@@ -382,7 +382,7 @@ func TestDeleteMDMConfigurationRemovesArtifactsAndKeysKeepsDevices(t *testing.T)
 		DeviceID:           "device-1",
 		MDMConfigurationID: configuration.ID,
 		PublicKey:          []byte("public-key"),
-	})
+	}, DeviceLimit{Unlimited: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/license/device_limit_test.go
+++ b/pkg/license/device_limit_test.go
@@ -1,0 +1,214 @@
+package license
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"testing"
+
+	keygen "github.com/keygen-sh/keygen-go/v3"
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	kfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestProviderDeviceLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		entitlements []string
+		want         gatewayclient.DeviceLimit
+	}{
+		{
+			name: "default",
+			want: gatewayclient.DeviceLimit{Maximum: gatewayclient.DefaultDeviceLimit},
+		},
+		{
+			name:         "unrelated entitlement",
+			entitlements: []string{EnterpriseModelProvidersEntitlement, "OBOT_ENTERPRISE_500_USERS"},
+			want:         gatewayclient.DeviceLimit{Maximum: gatewayclient.DefaultDeviceLimit},
+		},
+		{
+			name:         "enterprise edition grants unlimited devices",
+			entitlements: []string{EnterpriseEntitlement},
+			want:         gatewayclient.DeviceLimit{Unlimited: true},
+		},
+		{
+			name: "malformed device limit entitlements",
+			entitlements: []string{
+				"OBOT_ENTERPRISE_DEVICES",
+				"OBOT_ENTERPRISE_NOT_A_NUMBER_DEVICES",
+				"OBOT_ENTERPRISE_DEVICE_LIMIT",
+				"OBOT_ENTERPRISE_NOT_A_NUMBER_DEVICE_LIMIT",
+				"OBOT_ENTERPRISE_500_DEVICE_LIMIT",
+				"OBOT_ENTERPRISE_+500_DEVICES",
+				"OBOT_ENTERPRISE_-1_DEVICES",
+				"OBOT_ENTERPRISE_500_DEVICE",
+				"OBOT_ENTERPRISE_500_DEVICES_EXTRA",
+				"OBOT_ENTERPRISE_500_DEVICE_LIMIT_EXTRA",
+				"OBOT_ENTERPRISE_0_DEVICES",
+			},
+			want: gatewayclient.DeviceLimit{Maximum: gatewayclient.DefaultDeviceLimit},
+		},
+		{
+			name:         "numeric devices entitlement",
+			entitlements: []string{"OBOT_ENTERPRISE_500_DEVICES"},
+			want:         gatewayclient.DeviceLimit{Maximum: 500},
+		},
+		{
+			name: "numeric device entitlements are additive",
+			entitlements: []string{
+				"OBOT_ENTERPRISE_100_DEVICES",
+				"OBOT_ENTERPRISE_50_DEVICES",
+			},
+			want: gatewayclient.DeviceLimit{Maximum: 150},
+		},
+		{
+			name: "all numeric device entitlements are additive",
+			entitlements: []string{
+				"OBOT_ENTERPRISE_250_DEVICES",
+				"OBOT_ENTERPRISE_1000_DEVICES",
+				"OBOT_ENTERPRISE_500_DEVICES",
+			},
+			want: gatewayclient.DeviceLimit{Maximum: 1750},
+		},
+		{
+			name: "numeric device entitlements override enterprise edition unlimited devices",
+			entitlements: []string{
+				EnterpriseEntitlement,
+				"OBOT_ENTERPRISE_100_DEVICES",
+				"OBOT_ENTERPRISE_50_DEVICES",
+			},
+			want: gatewayclient.DeviceLimit{Maximum: 150},
+		},
+		{
+			name: "malformed numeric entitlements do not override enterprise edition unlimited devices",
+			entitlements: []string{
+				EnterpriseEntitlement,
+				"OBOT_ENTERPRISE_0_DEVICES",
+				"OBOT_ENTERPRISE_NOT_A_NUMBER_DEVICES",
+			},
+			want: gatewayclient.DeviceLimit{Unlimited: true},
+		},
+		{
+			name:         "removed custom device limit entitlement is ignored",
+			entitlements: []string{"OBOT_ENTERPRISE_CUSTOM_DEVICE_LIMIT"},
+			want:         gatewayclient.DeviceLimit{Maximum: gatewayclient.DefaultDeviceLimit},
+		},
+		{
+			name:         "numeric entitlement replaces default",
+			entitlements: []string{"OBOT_ENTERPRISE_50_DEVICES"},
+			want:         gatewayclient.DeviceLimit{Maximum: 50},
+		},
+		{
+			name: "numeric entitlement sum saturates at maximum integer",
+			entitlements: []string{
+				"OBOT_ENTERPRISE_" + strconv.FormatInt(math.MaxInt64, 10) + "_DEVICES",
+				"OBOT_ENTERPRISE_1_DEVICES",
+			},
+			want: gatewayclient.DeviceLimit{Maximum: math.MaxInt64},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entitlements := make(map[keygen.EntitlementCode]struct{}, len(tt.entitlements))
+			for _, entitlement := range tt.entitlements {
+				entitlements[keygen.EntitlementCode(entitlement)] = struct{}{}
+			}
+
+			provider := &Provider{entitlements: entitlements}
+			got, err := provider.DeviceLimit(t.Context())
+			if err != nil {
+				t.Fatalf("DeviceLimit() error = %v, want nil", err)
+			}
+			if got != tt.want {
+				t.Fatalf("DeviceLimit() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLicenseViolationsDeviceLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		entitlements []string
+		deviceCount  int
+		want         *Violation
+	}{
+		{
+			name:         "at limit",
+			entitlements: []string{"OBOT_ENTERPRISE_2_DEVICES"},
+			deviceCount:  2,
+		},
+		{
+			name:         "over limit",
+			entitlements: []string{"OBOT_ENTERPRISE_1_DEVICES"},
+			deviceCount:  2,
+			want: &Violation{
+				Type:    "deviceLimit",
+				Message: "device count (2) exceeds maximum limit (1)",
+			},
+		},
+		{
+			name:         "unlimited",
+			entitlements: []string{EnterpriseEntitlement},
+			deviceCount:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gatewayClient := newTestLicenseGatewayClient(t)
+			configuration, err := gatewayClient.CreateMDMConfiguration(t.Context(), 1, &gatewaytypes.MDMConfiguration{})
+			if err != nil {
+				t.Fatalf("creating MDM configuration: %v", err)
+			}
+			for i := range tt.deviceCount {
+				if _, err := gatewayClient.EnrollDevice(t.Context(), gatewayclient.DeviceEnrollment{
+					DeviceID:           fmt.Sprintf("device-%d", i),
+					MDMConfigurationID: configuration.ID,
+					PublicKey:          []byte{byte(i)},
+				}, gatewayclient.DeviceLimit{Unlimited: true}); err != nil {
+					t.Fatalf("enrolling device %d: %v", i, err)
+				}
+			}
+
+			entitlements := make(map[keygen.EntitlementCode]struct{}, len(tt.entitlements))
+			for _, entitlement := range tt.entitlements {
+				entitlements[keygen.EntitlementCode(entitlement)] = struct{}{}
+			}
+			provider := &Provider{
+				gatewayClient: gatewayClient,
+				entitlements:  entitlements,
+			}
+			storageClient := kfake.NewClientBuilder().WithScheme(storagescheme.Scheme).Build()
+
+			violations, err := provider.GetLicenseViolations(t.Context(), storageClient)
+			if err != nil {
+				t.Fatalf("GetLicenseViolations() error = %v", err)
+			}
+
+			var got *Violation
+			for _, violation := range violations {
+				if violation.Type == "deviceLimit" {
+					violation := violation
+					got = &violation
+					break
+				}
+			}
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("device limit violation = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("device limit violation = nil, want %+v", *tt.want)
+			}
+			if got.Type != tt.want.Type || got.Message != tt.want.Message {
+				t.Fatalf("device limit violation = %+v, want %+v", *got, *tt.want)
+			}
+		})
+	}
+}

--- a/pkg/license/entitlements.go
+++ b/pkg/license/entitlements.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	enterpriseUserLimitEntitlementPrefix = "OBOT_ENTERPRISE_"
-	userLimitEntitlementUsersSuffix      = "_USERS"
+	enterpriseLimitEntitlementPrefix    = "OBOT_ENTERPRISE_"
+	userLimitEntitlementUsersSuffix     = "_USERS"
+	deviceLimitEntitlementDevicesSuffix = "_DEVICES"
 )
 
 var entitlementPathsToGate = []string{
@@ -113,17 +114,42 @@ func (p *Provider) missingEntitlements(requiredEntitlements []string) []string {
 }
 
 // UserLimit returns the maximum number of users allowed by the current license.
-// OBOT_ENTERPRISE_AUTH_PROVIDERS grants unlimited users unless one or more
+// OBOT_ENTERPRISE grants unlimited users unless one or more
 // OBOT_ENTERPRISE_<number>_USERS entitlements define an additive limit.
 func (p *Provider) UserLimit(ctx context.Context) (gatewayclient.UserLimit, error) {
-	if err := p.refresh(ctx, false); err != nil {
+	maximum, unlimited, err := p.resourceLimit(ctx, userLimitEntitlementUsersSuffix, gatewayclient.DefaultUserLimit)
+	if err != nil {
 		return gatewayclient.UserLimit{}, err
+	}
+	return gatewayclient.UserLimit{
+		Maximum:   maximum,
+		Unlimited: unlimited,
+	}, nil
+}
+
+// DeviceLimit returns the maximum number of devices allowed by the current license.
+// OBOT_ENTERPRISE grants unlimited devices unless one or more
+// OBOT_ENTERPRISE_<number>_DEVICES entitlements define an additive limit.
+func (p *Provider) DeviceLimit(ctx context.Context) (gatewayclient.DeviceLimit, error) {
+	maximum, unlimited, err := p.resourceLimit(ctx, deviceLimitEntitlementDevicesSuffix, gatewayclient.DefaultDeviceLimit)
+	if err != nil {
+		return gatewayclient.DeviceLimit{}, err
+	}
+	return gatewayclient.DeviceLimit{
+		Maximum:   maximum,
+		Unlimited: unlimited,
+	}, nil
+}
+
+func (p *Provider) resourceLimit(ctx context.Context, entitlementSuffix string, defaultMaximum int64) (int64, bool, error) {
+	if err := p.refresh(ctx, false); err != nil {
+		return 0, false, err
 	}
 
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	limit := gatewayclient.UserLimit{}
+	var maximum int64
 	var isEnterpriseEdition bool
 	for entitlement := range p.entitlements {
 		code := string(entitlement)
@@ -132,11 +158,11 @@ func (p *Provider) UserLimit(ctx context.Context) (gatewayclient.UserLimit, erro
 			continue
 		}
 
-		value, ok := strings.CutPrefix(code, enterpriseUserLimitEntitlementPrefix)
+		value, ok := strings.CutPrefix(code, enterpriseLimitEntitlementPrefix)
 		if !ok {
 			continue
 		}
-		value, ok = strings.CutSuffix(value, userLimitEntitlementUsersSuffix)
+		value, ok = strings.CutSuffix(value, entitlementSuffix)
 		if !ok {
 			continue
 		}
@@ -146,24 +172,24 @@ func (p *Provider) UserLimit(ctx context.Context) (gatewayclient.UserLimit, erro
 			continue
 		}
 
-		maximum, err := strconv.ParseInt(value, 10, 64)
-		if err != nil || maximum <= 0 {
+		entitlementMaximum, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || entitlementMaximum <= 0 {
 			continue
 		}
 
-		if maximum > math.MaxInt64-limit.Maximum {
-			limit.Maximum = math.MaxInt64
+		if entitlementMaximum > math.MaxInt64-maximum {
+			maximum = math.MaxInt64
 		} else {
-			limit.Maximum += maximum
+			maximum += entitlementMaximum
 		}
 	}
 
-	limit.Unlimited = isEnterpriseEdition && limit.Maximum == 0
-	if limit.Maximum == 0 && !limit.Unlimited {
-		limit.Maximum = gatewayclient.DefaultUserLimit
+	unlimited := isEnterpriseEdition && maximum == 0
+	if maximum == 0 && !unlimited {
+		maximum = defaultMaximum
 	}
 
-	return limit, nil
+	return maximum, unlimited, nil
 }
 
 // RequireEntitlements returns Payment Required if any required entitlements are unavailable.
@@ -178,7 +204,7 @@ func (p *Provider) RequireEntitlements(ctx context.Context, requiredEntitlements
 	return types.NewErrHTTP(http.StatusPaymentRequired, fmt.Sprintf("missing required license entitlements: %v", missing))
 }
 
-// GetLicenseViolations returns all license violations for the configured auth/model providers and user limits.
+// GetLicenseViolations returns all license violations for the configured auth/model providers and resource limits.
 func (p *Provider) GetLicenseViolations(ctx context.Context, c kclient.Client) ([]Violation, error) {
 	violations, err := p.configuredProviderViolations(ctx, c)
 	if err != nil {
@@ -199,6 +225,24 @@ func (p *Provider) GetLicenseViolations(ctx context.Context, c kclient.Client) (
 			violations = append(violations, Violation{
 				Type:    "userLimit",
 				Message: fmt.Sprintf("user count (%d) exceeds maximum limit (%d)", userCount, userLimit.Maximum),
+			})
+		}
+	}
+
+	deviceLimit, err := p.DeviceLimit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check device limit: %w", err)
+	}
+	if !deviceLimit.Unlimited {
+		deviceCount, err := p.gatewayClient.DeviceCount(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check device count: %w", err)
+		}
+
+		if deviceCount > deviceLimit.Maximum {
+			violations = append(violations, Violation{
+				Type:    "deviceLimit",
+				Message: fmt.Sprintf("device count (%d) exceeds maximum limit (%d)", deviceCount, deviceLimit.Maximum),
 			})
 		}
 	}

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -881,6 +881,8 @@ export interface Version {
 	licenseEntitlements?: string[];
 	userCount?: number;
 	userLimit?: number;
+	deviceCount?: number;
+	deviceLimit?: number;
 	licenseEntitlementViolations?: LicenseEntitlementViolation[];
 	missingLicenseEntitlements?: string[];
 	upgradeAvailable?: boolean;


### PR DESCRIPTION
This change adds the same 100 device limit to free and community Obot instances as the user limits. If a new devices is attempted to be enrolled after the limit is hit, a 403 error will be returned.