### PR TITLE
fix(oauth): sanitize error redirect descriptions

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -71,13 +71,29 @@ func newInvalidClientErr(statusCode int, description string) *types.ErrHTTP {
 func (e oauthError) toQuery() url.Values {
 	q := url.Values{}
 	q.Set("error", string(e.Code))
-	if e.Description != "" {
-		q.Set("error_description", e.Description)
+	if description := sanitizeOAuthErrorDescription(e.Description); description != "" {
+		q.Set("error_description", description)
 	}
 	if e.State != "" {
 		q.Set("state", e.State)
 	}
 	return q
+}
+
+func sanitizeOAuthErrorDescription(description string) string {
+	description = strings.Map(func(r rune) rune {
+		switch {
+		case r == '"':
+			return '\''
+		case r == '\\':
+			return '/'
+		case r == 0x20 || r == 0x21 || r >= 0x23 && r <= 0x5B || r >= 0x5D && r <= 0x7E:
+			return r
+		default:
+			return ' '
+		}
+	}, description)
+	return strings.Join(strings.Fields(description), " ")
 }
 
 func (h *handler) authorize(req api.Context) error {

--- a/pkg/api/handlers/mcpgateway/oauth/authorize_error_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize_error_test.go
@@ -1,0 +1,29 @@
+package oauth
+
+import "testing"
+
+func TestOAuthErrorDescriptionQueryIsRFC6749Safe(t *testing.T) {
+	t.Parallel()
+
+	const description = "Obot: failed to get client: tunnel \"mt1vtsmx\" is not connected\n\n" +
+		"failed to connect to SSE server url http://127.0.0.1:8080/tunnel/bridge: " +
+		"503 Service Unavailable, tunnel \"mt1vtsmx\" is not connected\n"
+
+	got := (oauthError{
+		Code:        ErrServerError,
+		Description: description,
+	}).toQuery().Get("error_description")
+	want := "Obot: failed to get client: tunnel 'mt1vtsmx' is not connected " +
+		"failed to connect to SSE server url http://127.0.0.1:8080/tunnel/bridge: " +
+		"503 Service Unavailable, tunnel 'mt1vtsmx' is not connected"
+	if got != want {
+		t.Fatalf("error description = %q, want %q", got, want)
+	}
+
+	for _, r := range got {
+		if r == 0x20 || r == 0x21 || r >= 0x23 && r <= 0x5B || r >= 0x5D && r <= 0x7E {
+			continue
+		}
+		t.Fatalf("error description contains disallowed OAuth character %q", r)
+	}
+}


### PR DESCRIPTION
Normalize OAuth error descriptions before returning them to clients. This prevents invalid characters from breaking loopback callback response headers.

Issue: https://github.com/obot-platform/obot/issues/7330