### PR TITLE
fix: strip trailing newline when copying code snippets

### DIFF
--- a/ui/user/src/lib/actions/codeSnippetCopy.ts
+++ b/ui/user/src/lib/actions/codeSnippetCopy.ts
@@ -100,7 +100,9 @@ export function codeSnippetCopy(node: HTMLElement) {
 			code,
 			onClick: (event) => {
 				event.preventDefault();
-				const text = block.code.textContent ?? '';
+				// Rendered fenced code blocks always end with a newline (`<code>cmd\n</code>`),
+				// which would paste as an extra line break, so drop trailing newlines.
+				const text = (block.code.textContent ?? '').replace(/\n+$/, '');
 				if (!text) {
 					return;
 				}


### PR DESCRIPTION
The install instructions on Devices → Configuration are rendered from
markdown, and a fenced code block renders as `<code>cmd\n</code>`. The
copy action copied the code element's textContent verbatim, so the
trailing newline landed on the clipboard and pasting inserted an extra
line break.

Trim trailing newlines before writing to the clipboard. Displayed text
is unchanged.

Addresses https://github.com/obot-platform/obot/issues/7301
