### PR TITLE
fix: ensure caches are started before start the server

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,18 +39,16 @@ func Run(ctx context.Context, c services.Config) error {
 		}
 	}
 
-	go func() {
-		ctrl, err := controller.New(svcs)
-		if err != nil {
-			log.Fatalf("Failed to create controller: %v", err)
-		}
-		if err = ctrl.PreStart(ctx); err != nil {
-			log.Fatalf("Failed to start controller: %v", err)
-		}
-		if err = ctrl.Start(ctx); err != nil {
-			log.Fatalf("Failed to start controller: %v", err)
-		}
-	}()
+	ctrl, err := controller.New(svcs)
+	if err != nil {
+		return fmt.Errorf("failed to create controller: %v", err)
+	}
+	if err = ctrl.PreStart(ctx); err != nil {
+		return fmt.Errorf("failed to start controller: %v", err)
+	}
+	if err = ctrl.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start controller: %v", err)
+	}
 
 	if c.AllowedOrigin == "" {
 		c.AllowedOrigin = "*"


### PR DESCRIPTION
Certain APIs expect the controllers to be started. It has been reported that the controllers may be slow to start and cause issues with local auth startup.

This change ensures that the caches are started. It doesn't completely fix the issue, but makes it less likely to happen.

Related issue: https://github.com/obot-platform/obot/issues/7347