### PR TITLE
fix: use creatable capabilities constant in agent auth scope details view

### DIFF
--- a/ui/user/src/lib/components/agent-auth-scope/AgentAuthScopeDetails.svelte
+++ b/ui/user/src/lib/components/agent-auth-scope/AgentAuthScopeDetails.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { stripMarkdownToText } from '$lib/markdown';
-	import { API_KEY_CAPABILITIES, type APIKey } from '$lib/services/api-keys/types';
+	import { API_KEY_CREATABLE_CAPABILITIES, type APIKey } from '$lib/services/api-keys/types';
 	import {
 		compileAvailableMcpServers,
 		getMCPDisplayName,
@@ -166,7 +166,7 @@
 			<section class="paper gap-2 p-4">
 				<p class="text-lg font-semibold" id="agent-auth-scope-scopes">API Scopes</p>
 				<div class="flex flex-col gap-2" role="group" aria-labelledby="agent-auth-scope-scopes">
-					{#each API_KEY_CAPABILITIES as capability (capability.key)}
+					{#each API_KEY_CREATABLE_CAPABILITIES as capability (capability.key)}
 						<label
 							class={twMerge(
 								'bg-base-200 flex items-center gap-3 rounded-lg border border-transparent p-3',

--- a/ui/user/src/routes/admin/agent-auth-scopes/+page.svelte
+++ b/ui/user/src/routes/admin/agent-auth-scopes/+page.svelte
@@ -96,7 +96,7 @@
 		</div>
 	{:else}
 		<div class="flex flex-col gap-4">
-			<p class="whitespace-pre-line text-sm mb-1">
+			<p class="whitespace-pre-line text-sm mb-1 text-muted-content">
 				{AUTH_SCOPE_DESCRIPTION}
 			</p>
 			{#if allApiKeys.length === 0}

--- a/ui/user/src/routes/admin/mcp-tunnels/+page.svelte
+++ b/ui/user/src/routes/admin/mcp-tunnels/+page.svelte
@@ -145,7 +145,7 @@
 			</div>
 		{:else}
 			<div class="flex flex-col gap-6">
-				<p class="text-base-content/80 text-base">
+				<p class="text-muted-content text-sm">
 					MCP tunnels let Obot securely connect to private MCP servers that are not directly
 					reachable from Obot's network. You run a lightweight <code class="font-mono"
 						>obot tunnel</code


### PR DESCRIPTION
This addresses detail view showing API Access by using API_KEY_CREATABLE_CAPABILITIES instead of API_KEY_CAPABILITIES (where API Access is not excluded). Also address minor styling consistency of descriptions in auth-auth-scope & tunnels routes.

Addresses Follow-up #7318 
