### PR TITLE
fix(ui): more general ui cleanup

### DIFF
--- a/ui/user/src/app.css
+++ b/ui/user/src/app.css
@@ -234,8 +234,6 @@
 	pre {
 		overflow-wrap: break-word;
 		white-space: pre-wrap;
-		color: var(--tw-prose-pre-code);
-		background-color: var(--tw-prose-pre-bg);
 		overflow-x: auto;
 		font-weight: 400;
 		font-size: 0.875em;
@@ -243,11 +241,16 @@
 		margin-top: 1.7142857em;
 		margin-bottom: 1.7142857em;
 		border-radius: 0.375rem;
+		font-family: var(--font-mono);
+		color: var(--color-base-content);
+		background-color: var(--color-base-200);
+
+		.dark & {
+			background-color: var(--color-base-300);
+		}
 
 		& code,
 		& code * {
-			background-color: transparent !important;
-			color: var(--tw-prose-pre-code) !important;
 			border-width: 0;
 			border-radius: 0;
 			padding: 0;

--- a/ui/user/src/lib/components/CopyField.svelte
+++ b/ui/user/src/lib/components/CopyField.svelte
@@ -55,7 +55,7 @@
 		<div
 			class={twMerge(
 				'label px-2.5 flex items-center gap-2 text-xs text-base-content/75 shrink-0 ml-1 mr-0 ',
-				variant === 'code' && 'mt-0.5',
+				variant === 'code' && 'pl-0 pr-2.5 mt-0.5',
 				classes?.inputLabel
 			)}
 		>
@@ -96,9 +96,3 @@
 		/>
 	</div>
 </div>
-
-<style>
-	.copy-field-input pre {
-		background-color: transparent;
-	}
-</style>

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -1031,46 +1031,26 @@
 {/snippet}
 
 {#snippet navLink(link: NavLink)}
-	{@const isActive = link.href && (link.href === pathname || pathname.startsWith(`${link.href}/`))}
 	<div class="flex">
-		<div class="flex w-full items-center" id={link.id}>
-			{#if link.disabled}
-				<div class="sidebar-link disabled">
-					{@render linkContent(link)}
-				</div>
-			{:else if link.href}
-				<a
-					id={`sidebar-link-${link.id}`}
-					href={resolve(link.href as `/${string}`)}
-					class={twMerge('sidebar-link', isActive && 'bg-base-300')}
-					onclick={saveSidebarScroll}
-				>
-					{@render linkContent(link)}
-				</a>
-			{:else}
-				<div class="sidebar-link no-link">
-					{@render linkContent(link)}
-				</div>
-			{/if}
-
-			{#if link.noteIcon && link.note}
-				<InfoTooltip icon={link.noteIcon} interactive>
-					{@render link.note()}
-				</InfoTooltip>
-			{/if}
-		</div>
-		{#if link.collapsible}
+		{#if link.collapsible && !link.href}
 			<button
-				id={`sidebar-collapse-${link.id}`}
-				class="px-2"
+				class="flex w-full items-center"
 				onclick={() => toggleNavCollapsed(link.id)}
+				id={`sidebar-collapse-${link.id}`}
 			>
-				{#if isNavCollapsed(link.id)}
-					<ChevronDown class="size-5" />
-				{:else}
-					<ChevronUp class="size-5" />
-				{/if}
+				{@render rootLinkContent(link)}
+				<div class="px-2">
+					{#if isNavCollapsed(link.id)}
+						<ChevronDown class="size-5" />
+					{:else}
+						<ChevronUp class="size-5" />
+					{/if}
+				</div>
 			</button>
+		{:else}
+			<div class="flex w-full items-center" id={link.id}>
+				{@render rootLinkContent(link)}
+			</div>
 		{/if}
 	</div>
 	{#if !isNavCollapsed(link.id)}
@@ -1126,6 +1106,34 @@
 	{/if}
 {/snippet}
 
+{#snippet rootLinkContent(link: NavLink)}
+	{@const isActive = link.href && (link.href === pathname || pathname.startsWith(`${link.href}/`))}
+	{#if link.disabled}
+		<div class="sidebar-link disabled">
+			{@render linkContent(link)}
+		</div>
+	{:else if link.href}
+		<a
+			id={`sidebar-link-${link.id}`}
+			href={resolve(link.href as `/${string}`)}
+			class={twMerge('sidebar-link', isActive && 'bg-base-300')}
+			onclick={saveSidebarScroll}
+		>
+			{@render linkContent(link)}
+		</a>
+	{:else}
+		<div class="sidebar-link no-link">
+			{@render linkContent(link)}
+		</div>
+	{/if}
+
+	{#if link.noteIcon && link.note}
+		<InfoTooltip icon={link.noteIcon} interactive>
+			{@render link.note()}
+		</InfoTooltip>
+	{/if}
+{/snippet}
+
 {#snippet linkContent(link: NavLink)}
 	{#if link.icon}
 		<link.icon class="size-5" />
@@ -1152,6 +1160,7 @@
 		&.disabled {
 			opacity: 0.5;
 			cursor: default;
+			width: fit-content;
 			&:hover {
 				background-color: transparent;
 			}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -558,9 +558,10 @@
 	</div>
 	{#if hasFilterPills || showAuditExportActions}
 		<div
-			class="{showAuditExportActions
-				? 'mt-4'
-				: ''} flex flex-col flex-nowrap gap-4 @min-[768px]:flex-row"
+			class={twMerge(
+				showAuditExportActions && '@min-[768px]:mt-4',
+				'flex flex-col flex-nowrap gap-4 @min-[768px]:flex-row'
+			)}
 		>
 			<div class="min-w-0 grow hidden @min-[768px]:block">
 				{@render filters()}

--- a/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
+++ b/ui/user/src/lib/components/admin/usage/UsageGraphs.svelte
@@ -567,7 +567,7 @@
 {/if}
 
 <div class="flex flex-col gap-8">
-	<div class="flex gap-4 justify-between">
+	<div class="flex flex-wrap md:flex-nowrap gap-4 justify-between">
 		<!-- Summary with filter button -->
 		<div class="flex shrink-0 items-center justify-between gap-4">
 			<div class="flex-1">
@@ -625,7 +625,7 @@
 					</h3>
 
 					<div class="p-4">
-						<div class="text-muted-content h-[300px] min-h-[300px]">
+						<div class="text-muted-content h-72 min-h-72">
 							{#if paginated.length > 0}
 								<HorizontalBarGraph
 									data={paginated}
@@ -647,7 +647,7 @@
 								</HorizontalBarGraph>
 							{:else if !showLoadingSpinner}
 								<div
-									class="text-muted-content flex h-[300px] items-center justify-center text-sm font-light"
+									class="text-muted-content flex h-72 items-center justify-center text-sm font-light"
 								>
 									No data available
 								</div>

--- a/ui/user/src/lib/components/llm-gateway/LLMGatewayCodeBlock.svelte
+++ b/ui/user/src/lib/components/llm-gateway/LLMGatewayCodeBlock.svelte
@@ -28,7 +28,7 @@
 			/>
 		</div>
 		<pre class="default-scrollbar-thin overflow-x-auto p-3 pr-12 text-xs leading-relaxed my-0"><code
-				class="font-mono">{block.code}</code
+				>{block.code}</code
 			></pre>
 	</div>
 </div>

--- a/ui/user/src/lib/components/mcp/OAuthMetadataDebug.svelte
+++ b/ui/user/src/lib/components/mcp/OAuthMetadataDebug.svelte
@@ -73,8 +73,7 @@
 			{#if metadata.protectedResourceMetadata}
 				<div class="grid gap-1">
 					<p class="font-medium">Protected Resource Metadata</p>
-					<pre
-						class="bg-base-200 dark:bg-base-300 mt-1 overflow-auto rounded-md p-3 text-xs text-base-content">{formatJSON(
+					<pre class="mt-1 overflow-auto rounded-md p-3 text-xs">{formatJSON(
 							metadata.protectedResourceMetadata
 						)}</pre>
 				</div>
@@ -83,8 +82,7 @@
 			{#if metadata.authorizationServerMetadata}
 				<div class="grid gap-1">
 					<p class="font-medium">Authorization Server Metadata</p>
-					<pre
-						class="bg-base-200 dark:bg-base-300 mt-1 overflow-auto rounded-md p-3 text-xs text-base-content">{formatJSON(
+					<pre class="mt-1 overflow-auto rounded-md p-3 text-xs">{formatJSON(
 							metadata.authorizationServerMetadata
 						)}</pre>
 				</div>
@@ -93,8 +91,7 @@
 			{#if metadata.clientRegistration}
 				<div class="grid gap-1">
 					<p class="font-medium">Client Registration</p>
-					<pre
-						class="bg-base-200 dark:bg-base-300 mt-1 overflow-auto rounded-md p-3 text-xs text-base-content">{formatJSON(
+					<pre class="mt-1 overflow-auto rounded-md p-3 text-xs">{formatJSON(
 							metadata.clientRegistration
 						)}</pre>
 				</div>

--- a/ui/user/src/lib/components/mcp/oauth/DebugOauthFlow.svelte
+++ b/ui/user/src/lib/components/mcp/oauth/DebugOauthFlow.svelte
@@ -232,8 +232,7 @@
 		errors={errors.clientRegistration}
 		hasResults={Boolean(results.clientRegistration)}
 	>
-		<pre
-			class="bg-base-300 p-2 rounded-md overflow-x-auto text-xs my-0 text-base-content">{JSON.stringify(
+		<pre class="p-2 rounded-md overflow-x-auto text-xs my-0">{JSON.stringify(
 				results.clientRegistration,
 				null,
 				2
@@ -251,8 +250,7 @@
 			{@const authorizationURL = (results.preparingAuthorization as OAuthDebuggerAuthorizationURL)
 				.oauthURL}
 			<div class="flex flex-col gap-2">
-				<pre
-					class="bg-base-300 p-2 rounded-md overflow-x-auto text-xs my-0 text-base-content">{JSON.stringify(
+				<pre class="p-2 rounded-md overflow-x-auto text-xs my-0">{JSON.stringify(
 						results.preparingAuthorization,
 						null,
 						2
@@ -289,8 +287,7 @@
 		showContent={currentStep === DEBUG_FLOW_STEPS.preparingAuthorization}
 	>
 		{#if results.authorizationCode}
-			<pre
-				class="bg-base-300 p-2 rounded-md overflow-x-auto text-xs my-0 text-base-content">{JSON.stringify(
+			<pre class="p-2 rounded-md overflow-x-auto text-xs my-0">{JSON.stringify(
 					results.authorizationCode,
 					null,
 					2
@@ -324,8 +321,7 @@
 		errors={errors.tokenRequest}
 		hasResults={Boolean(results.tokenRequest)}
 	>
-		<pre
-			class="bg-base-300 p-2 rounded-md overflow-x-auto text-xs my-0 text-base-content">{JSON.stringify(
+		<pre class="p-2 rounded-md overflow-x-auto text-xs my-0">{JSON.stringify(
 				results.tokenRequest,
 				null,
 				2

--- a/ui/user/src/lib/services/guides/actions.ts
+++ b/ui/user/src/lib/services/guides/actions.ts
@@ -24,7 +24,7 @@ export function getExpandAdvancedPaneAction({
 				id: parentID
 			},
 			title: title || 'Expand MCP Management',
-			description: description || 'MCP Management is collapsed. Click here to expand it.'
+			description: description || "Let's expand this section to continue."
 		},
 		listener: {
 			id: parentID,

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/mcp/[id]/+page.svelte
@@ -178,7 +178,7 @@
 				</div>
 				<div class="dark:bg-base-300 bg-base-100 flex flex-col gap-2 rounded-md p-3 shadow-sm">
 					<pre
-						class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs mb-0 mt-2">{renderConfig(
+						class="dark:bg-base-400 bg-base-200 max-h-96 overflow-auto rounded p-2 font-mono text-xs mb-0 mt-2">{renderConfig(
 							server
 						)}</pre>
 					<p class="text-muted-content text-xs">

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/plugins/[id]/+page.svelte
@@ -131,7 +131,7 @@
 								</div>
 								{#if file?.content}
 									<pre
-										class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs mb-0 mt-2">{file.content}</pre>
+										class="dark:bg-base-400 bg-base-200 max-h-96 overflow-auto rounded p-2 font-mono text-xs mb-0 mt-2">{file.content}</pre>
 								{/if}
 							</div>
 						{/each}

--- a/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/devices/[device_id]/scans/[scan_id]/skills/[id]/+page.svelte
@@ -120,7 +120,7 @@
 								</div>
 								{#if file?.content}
 									<pre
-										class="dark:bg-base-400 bg-base-200 text-base-content max-h-96 overflow-auto rounded p-2 font-mono text-xs mb-0 mt-2">{file.content}</pre>
+										class="dark:bg-base-400 bg-base-200 max-h-96 overflow-auto rounded p-2 text-xs mb-0 mt-2">{file.content}</pre>
 								{/if}
 							</div>
 						{/each}

--- a/ui/user/src/routes/admin/image-pull-secrets/ECRSetupGuide.svelte
+++ b/ui/user/src/routes/admin/image-pull-secrets/ECRSetupGuide.svelte
@@ -100,7 +100,7 @@
 			<CopyButton showTextLeft text={value} />
 		</div>
 		<pre
-			class="default-scrollbar-thin dark:bg-base-400 bg-base-200 text-base-content max-h-80 overflow-auto rounded-md p-3 font-mono text-xs">{value ||
+			class="default-scrollbar-thin dark:bg-base-400 bg-base-200 max-h-80 overflow-auto rounded-md p-3 text-xs">{value ||
 				'-'}</pre>
 	</div>
 {/snippet}

--- a/ui/user/src/routes/agent-auth-scopes/+page.svelte
+++ b/ui/user/src/routes/agent-auth-scopes/+page.svelte
@@ -111,7 +111,7 @@
 					</div>
 				</div>
 			{:else}
-				<p class="text-muted whitespace-pre-line text-sm mb-1">{AUTH_SCOPE_DESCRIPTION}</p>
+				<p class="text-muted-content whitespace-pre-line text-sm mb-1">{AUTH_SCOPE_DESCRIPTION}</p>
 
 				<Table
 					data={tableData}

--- a/ui/user/src/routes/install-cli/+page.svelte
+++ b/ui/user/src/routes/install-cli/+page.svelte
@@ -210,7 +210,7 @@
 
 {#snippet codesnippet(step: string, command: string, id: string)}
 	<p class="text-sm">{step}</p>
-	<div class="relative mt-0.5 mb-4">
+	<div class="relative mt-0.5 mb-4 code-snippet">
 		<pre class="pl-4 pr-22 py-2 m-0" {id}><code>{command}</code></pre>
 		<div class="absolute top-1/2 right-2 -translate-y-1/2">
 			<CopyButton
@@ -285,6 +285,13 @@
 		margin-top: 0;
 		margin-bottom: 0;
 		border-radius: 0;
+		background-color: var(--tw-prose-pre-bg);
+		color: var(--tw-prose-pre-code);
+	}
+
+	.code-snippet pre {
+		background-color: var(--tw-prose-pre-bg);
+		color: var(--tw-prose-pre-code);
 	}
 
 	.mockup-code pre[data-prefix] {

--- a/ui/user/src/routes/oauth-debugger/callback/+page.svelte
+++ b/ui/user/src/routes/oauth-debugger/callback/+page.svelte
@@ -69,7 +69,7 @@
 						/>
 					</div>
 					<pre
-						class="bg-transparent my-0 max-w-full min-w-0 flex-1 overflow-x-auto font-mono text-sm break-all text-base-content">{code}</pre>
+						class="bg-transparent my-0 max-w-full min-w-0 flex-1 overflow-x-auto text-sm break-all">{code}</pre>
 				</div>
 			{/if}
 		</div>


### PR DESCRIPTION
This addresses pre code styling annoyances due to important tags on app.css, some styling/spacing tweaks whether desktop/mobile, and has the entire parent link in sidebar be clickable to collapse rather than just the up/down arrow.

The `<pre><code>` nonsense with the text color was bugging me so addressed and checked in following areas:
- CopyField component
- LLM Gateway code block
- Oauth metadata debugging & getting authorization code
- devices routes (/[scan_id]/mcp/[id], /[scan_id]/plugins/[id], /[scan_id]/skills/[id])
- image pull secrets setup guide
- Install CLI page

Addresses #7178 