### PR TITLE
fix: sticky audit log table headers when scrolling

### DIFF
--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
@@ -170,7 +170,7 @@
 {#snippet th(content: string, { class: klass = '', minWidth = '0ch' } = {})}
 	<th
 		class={twMerge(
-			'dark:bg-base-200 bg-base-300 text-muted-content sticky top-0 box-content w-[24ch] truncate text-left text-xs font-medium tracking-wider uppercase',
+			'dark:bg-base-200 bg-base-300 text-muted-content box-content w-[24ch] truncate text-left text-xs font-medium tracking-wider uppercase',
 			klass
 		)}
 		data-min-width={minWidth}
@@ -234,7 +234,7 @@
 <div
 	bind:this={tableContainer}
 	id="mcp-audit-logs-table"
-	class="dark:bg-base-300 bg-base-100 flex w-full min-w-full flex-1 divide-y divide-gray-200 overflow-x-auto overflow-y-visible rounded-lg border border-transparent shadow-sm"
+	class="dark:bg-base-300 bg-base-100 flex w-full min-w-full flex-1 divide-y divide-gray-200 rounded-lg border border-transparent shadow-sm"
 >
 	{#if data.length}
 		<VirtualPageTable class={twMerge('w-full flex-1 table-fixed border-collapse border-spacing-0')}>

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsTable.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsTable.svelte
@@ -110,7 +110,7 @@
 {#snippet th(content: string, { class: klass = '', minWidth = '0ch' } = {})}
 	<th
 		class={twMerge(
-			'dark:bg-base-200 bg-base-300 text-muted-content sticky top-0 box-content w-[24ch] truncate text-left text-xs font-medium tracking-wider uppercase',
+			'dark:bg-base-200 bg-base-300 text-muted-content box-content w-[24ch] truncate text-left text-xs font-medium tracking-wider uppercase',
 			klass
 		)}
 		data-min-width={minWidth}
@@ -158,7 +158,7 @@
 <!-- Data Table -->
 <div>
 	<div
-		class="dark:bg-base-300 bg-base-100 flex w-full min-w-full flex-1 divide-y divide-gray-200 overflow-x-auto overflow-y-visible rounded-lg border border-transparent shadow-sm"
+		class="dark:bg-base-300 bg-base-100 flex w-full min-w-full flex-1 divide-y divide-gray-200 rounded-lg border border-transparent shadow-sm"
 	>
 		<VirtualPageTable class={twMerge('w-full flex-1 table-fixed border-collapse border-spacing-0')}>
 			{#snippet header()}

--- a/ui/user/src/lib/components/admin/enforcement/EnforcementDecisionsTable.svelte
+++ b/ui/user/src/lib/components/admin/enforcement/EnforcementDecisionsTable.svelte
@@ -131,7 +131,7 @@
 {#snippet th(content: string, { class: klass = '', minWidth = '0ch' } = {})}
 	<th
 		class={twMerge(
-			'dark:bg-base-200 bg-base-300 text-muted-content sticky top-0 box-content w-[24ch] truncate text-left text-xs font-medium tracking-wider uppercase',
+			'dark:bg-base-200 bg-base-300 text-muted-content box-content w-[24ch] truncate text-left text-xs font-medium tracking-wider uppercase',
 			klass
 		)}
 		data-min-width={minWidth}
@@ -220,7 +220,7 @@
 <!-- Data Table -->
 <div>
 	<div
-		class="dark:bg-base-300 bg-base-100 flex w-full min-w-full flex-1 divide-y divide-gray-200 overflow-x-auto overflow-y-visible rounded-lg border border-transparent shadow-sm"
+		class="dark:bg-base-300 bg-base-100 flex w-full min-w-full flex-1 divide-y divide-gray-200 rounded-lg border border-transparent shadow-sm"
 	>
 		<VirtualPageTable class={twMerge('w-full flex-1 table-fixed border-collapse border-spacing-0')}>
 			{#snippet header()}

--- a/ui/user/src/lib/components/table/Table.svelte
+++ b/ui/user/src/lib/components/table/Table.svelte
@@ -5,6 +5,7 @@
 	import IconButton from '../primitives/IconButton.svelte';
 	import TableColumnFilter from './TableColumnFilter.svelte';
 	import TableHeader from './TableHeader.svelte';
+	import { calculateStickyTop } from './stickyOffset';
 	import {
 		ChevronDown,
 		ChevronsLeft,
@@ -530,70 +531,6 @@
 			}
 		}, PAGE_TRANSITION_DURATION + 50);
 	});
-
-	function findScrollContainer(element: HTMLElement): HTMLElement | null {
-		let parent: HTMLElement | null = element.parentElement;
-		while (parent) {
-			const style = getComputedStyle(parent);
-			if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
-				return parent;
-			}
-			parent = parent.parentElement;
-		}
-		return null;
-	}
-
-	function calculateStickyTop(wrapper: HTMLElement): number {
-		const scrollContainer = findScrollContainer(wrapper);
-		if (!scrollContainer) return 0;
-
-		let maxStickyBottom = 0;
-
-		// Traverse from wrapper up to scroll container, checking for sticky siblings
-		let current: HTMLElement | null = wrapper;
-
-		while (current && current !== scrollContainer) {
-			const parent: HTMLElement | null = current.parentElement;
-			if (!parent) break;
-
-			// Check all siblings that come before current element
-			for (const sibling of parent.children) {
-				if (sibling === current) break;
-
-				// Check if the sibling itself is sticky
-				const siblingStyle = getComputedStyle(sibling);
-				if (siblingStyle.position === 'sticky') {
-					const top = parseFloat(siblingStyle.top) || 0;
-					if (top >= 0 && top < 200) {
-						maxStickyBottom = Math.max(
-							maxStickyBottom,
-							top + (sibling as HTMLElement).offsetHeight
-						);
-					}
-				}
-
-				// Also check for sticky descendants within the sibling
-				const stickyDescendants = sibling.querySelectorAll('*');
-				for (const desc of stickyDescendants) {
-					const el = desc as HTMLElement;
-					const otherTableRoot = el.closest('[data-table-root]');
-					if (otherTableRoot && otherTableRoot !== wrapper) continue;
-
-					const descStyle = getComputedStyle(desc);
-					if (descStyle.position === 'sticky') {
-						const top = parseFloat(descStyle.top) || 0;
-						if (top >= 0 && top < 200) {
-							maxStickyBottom = Math.max(maxStickyBottom, top + el.offsetHeight);
-						}
-					}
-				}
-			}
-
-			current = parent;
-		}
-
-		return maxStickyBottom;
-	}
 
 	let isScrolling = false;
 

--- a/ui/user/src/lib/components/table/stickyOffset.ts
+++ b/ui/user/src/lib/components/table/stickyOffset.ts
@@ -1,0 +1,59 @@
+/** Find nearest ancestor that scrolls vertically. */
+export function findScrollContainer(element: HTMLElement): HTMLElement | null {
+	let parent: HTMLElement | null = element.parentElement;
+	while (parent) {
+		const style = getComputedStyle(parent);
+		if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
+			return parent;
+		}
+		parent = parent.parentElement;
+	}
+	return null;
+}
+
+/**
+ * Offset for a sticky table header so it sits below other sticky chrome
+ * (e.g. Layout navbar) within the same scroll container.
+ */
+export function calculateStickyTop(wrapper: HTMLElement): number {
+	const scrollContainer = findScrollContainer(wrapper);
+	if (!scrollContainer) return 0;
+
+	let maxStickyBottom = 0;
+	let current: HTMLElement | null = wrapper;
+
+	while (current && current !== scrollContainer) {
+		const parent: HTMLElement | null = current.parentElement;
+		if (!parent) break;
+
+		for (const sibling of parent.children) {
+			if (sibling === current) break;
+
+			const siblingStyle = getComputedStyle(sibling);
+			if (siblingStyle.position === 'sticky') {
+				const top = parseFloat(siblingStyle.top) || 0;
+				if (top >= 0 && top < 200) {
+					maxStickyBottom = Math.max(maxStickyBottom, top + (sibling as HTMLElement).offsetHeight);
+				}
+			}
+
+			for (const desc of sibling.querySelectorAll('*')) {
+				const el = desc as HTMLElement;
+				const otherTableRoot = el.closest('[data-table-root]');
+				if (otherTableRoot && otherTableRoot !== wrapper) continue;
+
+				const descStyle = getComputedStyle(desc);
+				if (descStyle.position === 'sticky') {
+					const top = parseFloat(descStyle.top) || 0;
+					if (top >= 0 && top < 200) {
+						maxStickyBottom = Math.max(maxStickyBottom, top + el.offsetHeight);
+					}
+				}
+			}
+		}
+
+		current = parent;
+	}
+
+	return maxStickyBottom;
+}

--- a/ui/user/src/lib/components/ui/virtual-page/virtual-page-table.svelte
+++ b/ui/user/src/lib/components/ui/virtual-page/virtual-page-table.svelte
@@ -103,36 +103,47 @@
 		) as HTMLElement | undefined;
 		if (!wrapperRef) return;
 
-		let resizeTimeout: ReturnType<typeof setTimeout> | undefined;
-		const debouncedMeasure = () => {
-			clearTimeout(resizeTimeout);
-			resizeTimeout = setTimeout(() => {
+		let measureRaf: number | undefined;
+		let layoutTimeout: ReturnType<typeof setTimeout> | undefined;
+
+		const scheduleColumnMeasure = () => {
+			if (measureRaf !== undefined) return;
+			measureRaf = requestAnimationFrame(() => {
+				measureRaf = undefined;
 				measureColumnWidths();
-				updateStickyTop();
-			}, 100);
+			});
 		};
 
-		const resizeObserver = new ResizeObserver(debouncedMeasure);
-		if (parentContainer) resizeObserver.observe(parentContainer);
-		if (headerTableRef) resizeObserver.observe(headerTableRef);
+		const debouncedLayoutMeasure = () => {
+			scheduleColumnMeasure();
+			clearTimeout(layoutTimeout);
+			layoutTimeout = setTimeout(updateStickyTop, 100);
+		};
+
+		const cellResizeObserver = new ResizeObserver(scheduleColumnMeasure);
+		const layoutResizeObserver = new ResizeObserver(debouncedLayoutMeasure);
+
+		if (parentContainer) layoutResizeObserver.observe(parentContainer);
+		if (headerTableRef) cellResizeObserver.observe(headerTableRef);
 
 		const headerCells = headerTableRef?.tHead?.rows[0]?.cells;
 		if (headerCells) {
 			for (const cell of headerCells) {
-				resizeObserver.observe(cell);
+				cellResizeObserver.observe(cell);
 			}
 		}
 
-		let initialMeasureTimeout: ReturnType<typeof setTimeout> | undefined = $state();
-		initialMeasureTimeout = setTimeout(() => {
+		const initialMeasureTimeout = setTimeout(() => {
 			measureColumnWidths();
 			updateStickyTop();
 		}, PAGE_TRANSITION_DURATION + 50);
 
 		return () => {
-			clearTimeout(resizeTimeout);
+			if (measureRaf !== undefined) cancelAnimationFrame(measureRaf);
+			clearTimeout(layoutTimeout);
 			clearTimeout(initialMeasureTimeout);
-			resizeObserver.disconnect();
+			cellResizeObserver.disconnect();
+			layoutResizeObserver.disconnect();
 		};
 	});
 

--- a/ui/user/src/lib/components/ui/virtual-page/virtual-page-table.svelte
+++ b/ui/user/src/lib/components/ui/virtual-page/virtual-page-table.svelte
@@ -13,8 +13,10 @@
 </script>
 
 <script lang="ts" generics="T">
+	import { calculateStickyTop, findScrollContainer } from '$lib/components/table/stickyOffset';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
 	import { getVirtualPageContext, type VirtualPageContext } from './context';
-	import { type Snippet } from 'svelte';
+	import { onMount, type Snippet } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	const context: VirtualPageContext<T> | undefined = getVirtualPageContext();
@@ -29,32 +31,206 @@
 
 	let { class: klass = '', children, header, ...restProps }: VirtualListViewportProps<T> = $props();
 
-	let tableElement: HTMLTableElement | undefined = $state();
-	const columnCount = $derived(Math.max(1, tableElement?.tHead?.rows[0]?.cells.length ?? 1));
+	let wrapperRef: HTMLDivElement | undefined = $state();
+	let sentinelRef: HTMLDivElement | undefined = $state();
+	let headerScrollRef: HTMLDivElement | undefined = $state();
+	let bodyScrollRef: HTMLDivElement | undefined = $state();
+	let headerTableRef: HTMLTableElement | undefined = $state();
+	let bodyTableRef: HTMLTableElement | undefined = $state();
+
+	let stickyTop = $state(0);
+	let isStuck = $state(false);
+	let colWidths = $state<number[]>([]);
+	let headerLabels = $state<string[]>([]);
+	let isScrolling = false;
+
+	const columnCount = $derived(
+		Math.max(1, colWidths.length || (headerTableRef?.tHead?.rows[0]?.cells.length ?? 1))
+	);
+
+	const tableClass = $derived(twMerge('h-min w-full border-collapse', klass));
+	// Header width is driven by <th> (incl. resize); body mirrors measured widths via colgroup.
+	const headerTableStyle = 'table-layout: fixed; min-width: 100%;';
+	const bodyTableStyle = $derived(
+		colWidths.length > 0
+			? `table-layout: fixed; min-width: 100%; width: ${colWidths.reduce((a, b) => a + b, 0)}px;`
+			: 'table-layout: fixed; width: 100%;'
+	);
+
+	function syncScroll(source: HTMLDivElement, target: HTMLDivElement) {
+		if (isScrolling) return;
+		isScrolling = true;
+		target.scrollLeft = source.scrollLeft;
+		requestAnimationFrame(() => {
+			isScrolling = false;
+		});
+	}
+
+	function measureColumnWidths() {
+		const cells = headerTableRef?.tHead?.rows[0]?.cells;
+		if (!cells?.length) return;
+		colWidths = Array.from(cells).map((cell) => cell.getBoundingClientRect().width);
+		// Labels for the body table's visually-hidden thead (associates columns for AT).
+		headerLabels = Array.from(cells).map((cell) =>
+			(cell.textContent ?? '').replace(/\s+/g, ' ').trim()
+		);
+	}
+
+	function updateStickyTop() {
+		if (wrapperRef) {
+			stickyTop = calculateStickyTop(wrapperRef);
+		}
+	}
+
+	onMount(() => {
+		if (!headerScrollRef || !bodyScrollRef) return;
+
+		const handleHeaderScroll = () => syncScroll(headerScrollRef!, bodyScrollRef!);
+		const handleBodyScroll = () => syncScroll(bodyScrollRef!, headerScrollRef!);
+
+		headerScrollRef.addEventListener('scroll', handleHeaderScroll);
+		bodyScrollRef.addEventListener('scroll', handleBodyScroll);
+
+		return () => {
+			headerScrollRef?.removeEventListener('scroll', handleHeaderScroll);
+			bodyScrollRef?.removeEventListener('scroll', handleBodyScroll);
+		};
+	});
+
+	onMount(() => {
+		const parentContainer = wrapperRef?.closest(
+			'.default-scrollbar-thin, .virtual-page-viewport'
+		) as HTMLElement | undefined;
+		if (!wrapperRef) return;
+
+		let resizeTimeout: ReturnType<typeof setTimeout> | undefined;
+		const debouncedMeasure = () => {
+			clearTimeout(resizeTimeout);
+			resizeTimeout = setTimeout(() => {
+				measureColumnWidths();
+				updateStickyTop();
+			}, 100);
+		};
+
+		const resizeObserver = new ResizeObserver(debouncedMeasure);
+		if (parentContainer) resizeObserver.observe(parentContainer);
+		if (headerTableRef) resizeObserver.observe(headerTableRef);
+
+		const headerCells = headerTableRef?.tHead?.rows[0]?.cells;
+		if (headerCells) {
+			for (const cell of headerCells) {
+				resizeObserver.observe(cell);
+			}
+		}
+
+		let initialMeasureTimeout: ReturnType<typeof setTimeout> | undefined = $state();
+		initialMeasureTimeout = setTimeout(() => {
+			measureColumnWidths();
+			updateStickyTop();
+		}, PAGE_TRANSITION_DURATION + 50);
+
+		return () => {
+			clearTimeout(resizeTimeout);
+			clearTimeout(initialMeasureTimeout);
+			resizeObserver.disconnect();
+		};
+	});
+
+	// Drop top rounding while stuck so row content can't show through corner gaps.
+	$effect(() => {
+		const sentinel = sentinelRef;
+		const topOffset = stickyTop;
+		if (!sentinel) return;
+
+		const root = findScrollContainer(sentinel);
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				isStuck = !entry.isIntersecting;
+			},
+			{
+				root,
+				threshold: 0,
+				rootMargin: `-${topOffset + 1}px 0px 0px 0px`
+			}
+		);
+		observer.observe(sentinel);
+
+		return () => observer.disconnect();
+	});
 </script>
 
-<table bind:this={tableElement} class={twMerge('h-min w-full', klass)} {...restProps}>
-	{@render header?.()}
+<div bind:this={wrapperRef} data-table-root class="w-full min-w-0">
+	<div bind:this={sentinelRef} class="h-px w-full" aria-hidden="true"></div>
+	<div
+		class={twMerge(
+			'dark:bg-base-200 bg-base-300 sticky left-0 z-40 w-full overflow-hidden',
+			!isStuck && 'rounded-t-lg'
+		)}
+		style="top: {stickyTop}px;"
+	>
+		<div class="sticky-table-header-scroll w-full overflow-x-auto" bind:this={headerScrollRef}>
+			<!-- Visual sticky header only; hidden from AT so the body table owns semantics. -->
+			<table
+				bind:this={headerTableRef}
+				class={tableClass}
+				style={headerTableStyle}
+				aria-hidden="true"
+			>
+				{@render header?.()}
+			</table>
+		</div>
+	</div>
 
-	<tbody bind:this={context.elements.content}>
-		<!-- Top spacer row -->
-		{#if top > 0}
-			<tr aria-hidden="true" class="pointer-events-none">
-				<td colspan={columnCount} style="height: {top}px; padding: 0; border: none; line-height: 0;"
-				></td>
-			</tr>
-		{/if}
+	<div class="w-full overflow-x-auto rounded-b-lg" bind:this={bodyScrollRef}>
+		<table bind:this={bodyTableRef} class={tableClass} style={bodyTableStyle} {...restProps}>
+			{#if colWidths.length > 0}
+				<colgroup>
+					{#each colWidths as width, i (i)}
+						<col style="width: {width}px;" />
+					{/each}
+				</colgroup>
+			{/if}
 
-		{@render children?.({ items: rows })}
+			{#if headerLabels.length > 0}
+				<thead class="sr-only">
+					<tr>
+						{#each headerLabels as label, i (i)}
+							<th scope="col">{label}</th>
+						{/each}
+					</tr>
+				</thead>
+			{/if}
 
-		<!-- Bottom spacer row -->
-		{#if bottom > 0}
-			<tr aria-hidden="true" class="pointer-events-none">
-				<td
-					colspan={columnCount}
-					style="height: {bottom}px; padding: 0; border: none; line-height: 0;"
-				></td>
-			</tr>
-		{/if}
-	</tbody>
-</table>
+			<tbody bind:this={context.elements.content}>
+				{#if top > 0}
+					<tr aria-hidden="true" class="pointer-events-none">
+						<td
+							colspan={columnCount}
+							style="height: {top}px; padding: 0; border: none; line-height: 0;"
+						></td>
+					</tr>
+				{/if}
+
+				{@render children?.({ items: rows })}
+
+				{#if bottom > 0}
+					<tr aria-hidden="true" class="pointer-events-none">
+						<td
+							colspan={columnCount}
+							style="height: {bottom}px; padding: 0; border: none; line-height: 0;"
+						></td>
+					</tr>
+				{/if}
+			</tbody>
+		</table>
+	</div>
+</div>
+
+<style>
+	.sticky-table-header-scroll {
+		scrollbar-width: none;
+	}
+	.sticky-table-header-scroll::-webkit-scrollbar {
+		display: none;
+	}
+</style>


### PR DESCRIPTION
Addresses #7178 

This addresses adding stickiness to the audit log table header so the table header is always in view when scrolling. 

Checked desktop/mobile. 
Checked chrome/safari.