### PR TITLE
fix: stop dropping skill metadata on the way through the API

### DIFF
--- a/apiclient/types/skill.go
+++ b/apiclient/types/skill.go
@@ -15,13 +15,16 @@ type Skill struct {
 }
 
 type SkillManifest struct {
-	Name           string            `json:"name,omitempty"`
-	Description    string            `json:"description,omitempty"`
-	DisplayName    string            `json:"displayName,omitempty"`
-	License        string            `json:"license,omitempty"`
-	Compatibility  string            `json:"compatibility,omitempty"`
-	AllowedTools   string            `json:"allowedTools,omitempty"`
-	MetadataValues map[string]string `json:"metadata,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Description   string `json:"description,omitempty"`
+	DisplayName   string `json:"displayName,omitempty"`
+	License       string `json:"license,omitempty"`
+	Compatibility string `json:"compatibility,omitempty"`
+	AllowedTools  string `json:"allowedTools,omitempty"`
+	// Tagged metadataValues rather than metadata: Skill embeds both Metadata and
+	// SkillManifest, and two promoted fields sharing the "metadata" tag made
+	// encoding/json drop both, so skills serialized no metadata at all.
+	MetadataValues map[string]string `json:"metadataValues,omitempty"`
 }
 
 type SkillList List[Skill]

--- a/apiclient/types/skill_test.go
+++ b/apiclient/types/skill_test.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Skill embeds both Metadata (field Metadata, tag "metadata") and SkillManifest.
+// When SkillManifest.MetadataValues was also tagged "metadata", the two promoted
+// fields collided at equal depth and encoding/json dropped both, so a skill's
+// metadata never reached clients. This pins the fix.
+func TestSkillSerializesMetadataValues(t *testing.T) {
+	s := Skill{}
+	s.ID = "sk1abc"
+	s.SkillManifest.Name = "my-skill"
+	s.SkillManifest.MetadataValues = map[string]string{"author": "tester"}
+
+	b, err := json.Marshal(s)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	require.Contains(t, got, "metadataValues",
+		"skill metadata must serialize; a json tag collision silently dropped it before")
+	assert.Equal(t, map[string]any{"author": "tester"}, got["metadataValues"])
+	assert.Equal(t, "sk1abc", got["id"])
+	assert.Equal(t, "my-skill", got["name"])
+}
+
+func TestSkillOmitsEmptyMetadataValues(t *testing.T) {
+	b, err := json.Marshal(Skill{})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	assert.NotContains(t, got, "metadataValues", "empty metadata should be omitted, not sent as null")
+}

--- a/ui/user/src/lib/services/nanobot/types.ts
+++ b/ui/user/src/lib/services/nanobot/types.ts
@@ -554,7 +554,9 @@ export interface Skill {
 	license?: string;
 	compatibility?: string;
 	allowedTools?: string;
-	metadata?: Record<string, unknown>;
+	// Metadata from the skill's frontmatter. Named metadataValues on the wire to
+	// avoid colliding with the resource envelope's own metadata field.
+	metadataValues?: Record<string, string>;
 	repoID?: string;
 	repoURL?: string;
 	repoRef?: string;


### PR DESCRIPTION
`Skill` embeds both `Metadata` (field tagged `metadata`) and `SkillManifest`, whose `MetadataValues` was tagged `metadata` as well. Two promoted fields at equal depth carrying one JSON name is a conflict, and `encoding/json` resolves it by **dropping both** — so no skill ever serialized its metadata, and the frontmatter a repository supplies reached clients as nothing at all.

The manifest field is tagged `metadataValues` instead, which is the name it now carries on the wire. Nothing can be relying on the old name, since it never appeared in a response.

The UI type follows; it was wrong twice over, declaring the colliding name and typing the values as `unknown` rather than strings.

Two tests pin the behaviour: that metadata serializes, and that it is omitted rather than sent as `null` when empty.

Found while working on hosted agents, but unrelated to it — sending separately.