### PR TITLE
fix: let websocket handlers under /api hijack the connection

### DIFF
--- a/pkg/api/server/hijack_test.go
+++ b/pkg/api/server/hijack_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// hijackableRecorder stands in for the connection the http server provides,
+// which httptest.ResponseRecorder alone cannot hijack.
+type hijackableRecorder struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (r *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	r.hijacked = true
+	return nil, nil, nil
+}
+
+// The terminal is a websocket under /api/, so it passes through both response
+// writer wrappers before it upgrades. A wrapper that hides the Hijacker breaks
+// the upgrade outright, and only at runtime -- nothing about the types says so.
+func TestResponseWritersStayHijackable(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		wrap func(http.ResponseWriter) http.ResponseWriter
+	}{
+		{"headers", func(rw http.ResponseWriter) http.ResponseWriter {
+			return &headersResponseWriter{ResponseWriter: rw}
+		}},
+		{"audit", func(rw http.ResponseWriter) http.ResponseWriter {
+			return &responseWriter{ResponseWriter: rw}
+		}},
+		{"audit over headers", func(rw http.ResponseWriter) http.ResponseWriter {
+			return &responseWriter{ResponseWriter: &headersResponseWriter{ResponseWriter: rw}}
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &hijackableRecorder{ResponseRecorder: httptest.NewRecorder()}
+
+			if _, _, err := http.NewResponseController(tt.wrap(recorder)).Hijack(); err != nil {
+				t.Fatalf("Hijack through the wrapper: %v", err)
+			}
+			if !recorder.hijacked {
+				t.Error("the hijack did not reach the underlying writer")
+			}
+		})
+	}
+}

--- a/pkg/api/server/server.go
+++ b/pkg/api/server/server.go
@@ -250,10 +250,6 @@ type headersResponseWriter struct {
 	wroteHeader bool
 }
 
-func (w *headersResponseWriter) Unwrap() http.ResponseWriter {
-	return w.ResponseWriter
-}
-
 func (w *headersResponseWriter) ensureHeaders(status int) {
 	// Always set nosniff; harmless for non-browser clients.
 	w.Header().Set("X-Content-Type-Options", "nosniff")
@@ -309,6 +305,13 @@ func (w *headersResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return h.Hijack()
 }
 
+// Unwrap lets http.ResponseController reach the writer underneath, which is how
+// anything needing a capability not forwarded here -- read and write deadlines,
+// notably -- gets at it.
+func (w *headersResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 func (w *headersResponseWriter) Push(target string, opts *http.PushOptions) error {
 	if p, ok := w.ResponseWriter.(http.Pusher); ok {
 		return p.Push(target, opts)
@@ -341,4 +344,11 @@ func (rw *responseWriter) Flush() {
 	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+// Unwrap exposes the writer underneath to http.ResponseController. Without it a
+// websocket handler under /api/ cannot hijack the connection, because this
+// wrapper hides the Hijacker the server provides.
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
 }


### PR DESCRIPTION
Requests under `/api` are wrapped so the audit log can record the status and size of the response. That wrapper implements neither `Hijacker` nor `Unwrap`, so `http.ResponseController` cannot reach the writer underneath and **any websocket handler mounted under `/api` fails its upgrade** — the connection cannot be taken over through a wrapper that hides it.

It now implements `Unwrap`, the documented way to expose a capability a wrapper does not itself implement. That is why nothing here enumerates `Hijacker`, `Flusher` and the deadline setters one by one: the controller finds them. The header wrapper alongside it already did this; only the comment saying why is new.

Test covers an `/api` request being hijacked through the wrapper.

Found while working on hosted agents (whose terminal is a websocket under `/api`), but it affects any such handler — sending separately.