### PR TITLE
Require configured static OAuth before MCP use

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -671,17 +671,66 @@ func (m *MCPHandler) CheckOAuth(req api.Context) error {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
-	if serverConfig.Runtime == types.RuntimeRemote {
-		var are nmcp.AuthRequiredErr
-		if _, err = m.mcpSessionManager.PingServer(req.Context(), serverConfig); err != nil {
-			if !errors.As(err, &are) {
-				return fmt.Errorf("failed to ping MCP server: %w", err)
-			}
-			req.WriteHeader(http.StatusPreconditionFailed)
+	needsOAuth, err := m.serverNeedsOAuth(req.Context(), &server, serverConfig)
+	if err != nil {
+		return err
+	}
+	if !needsOAuth && server.Spec.Manifest.Runtime == types.RuntimeComposite {
+		var componentServers v1.MCPServerList
+		if err := req.Storage.List(req.Context(), &componentServers, &kclient.ListOptions{
+			Namespace:     server.Namespace,
+			FieldSelector: fields.OneTermEqualSelector("spec.compositeName", server.Name),
+		}); err != nil {
+			return fmt.Errorf("failed to list composite MCP component servers: %w", err)
 		}
+
+		disabled := make(map[string]bool)
+		if server.Spec.Manifest.CompositeConfig != nil {
+			for _, component := range server.Spec.Manifest.CompositeConfig.ComponentServers {
+				disabled[component.CatalogEntryID] = component.Disabled
+			}
+		}
+		for i := range componentServers.Items {
+			component := &componentServers.Items[i]
+			if disabled[component.Spec.MCPServerCatalogEntryName] || component.Spec.Manifest.Runtime != types.RuntimeRemote {
+				continue
+			}
+			_, componentConfig, err := m.mcpSessionManager.ServerForAction(req.Context(), component.Name, req.User.GetUID())
+			if err != nil {
+				return fmt.Errorf("failed to load composite MCP component server %s: %w", component.Name, err)
+			}
+			needsOAuth, err = m.serverNeedsOAuth(req.Context(), component, componentConfig)
+			if err != nil {
+				return err
+			}
+			if needsOAuth {
+				break
+			}
+		}
+	}
+	if needsOAuth {
+		req.WriteHeader(http.StatusPreconditionFailed)
 	}
 
 	return nil
+}
+
+func (m *MCPHandler) serverNeedsOAuth(ctx context.Context, server *v1.MCPServer, serverConfig mcp.ServerConfig) (bool, error) {
+	if mcp.RequiresStaticOAuth(*server) {
+		return true, nil
+	}
+	if serverConfig.Runtime != types.RuntimeRemote {
+		return false, nil
+	}
+
+	var authRequired nmcp.AuthRequiredErr
+	if _, err := m.mcpSessionManager.PingServer(ctx, serverConfig); err != nil {
+		if errors.As(err, &authRequired) {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to ping MCP server %s: %w", server.Name, err)
+	}
+	return false, nil
 }
 
 func (m *MCPHandler) GetOAuthURL(req api.Context) error {
@@ -1279,23 +1328,6 @@ func serverManifestFromCatalogEntryManifest(
 				inputComponent = inputComponents[entryComponent.ComponentID()]
 				userURL        string
 			)
-
-			// Check if the component has gained static OAuth.
-			// If so, reject the update - static OAuth components cannot be part of composites.
-			entryHasStaticOAuth := entryComponent.Manifest.Runtime == types.RuntimeRemote &&
-				entryComponent.Manifest.RemoteConfig != nil &&
-				entryComponent.Manifest.RemoteConfig.StaticOAuthRequired
-			inputHasStaticOAuth := inputComponent.Manifest.Runtime == types.RuntimeRemote &&
-				inputComponent.Manifest.RemoteConfig != nil &&
-				inputComponent.Manifest.RemoteConfig.StaticOAuthRequired
-
-			if entryHasStaticOAuth && !inputHasStaticOAuth {
-				// The component has gained static OAuth - reject the update.
-				return types.MCPServerManifest{}, types.NewErrBadRequest(
-					"cannot update composite server: component %s has been updated to require static OAuth, which is not allowed in composite servers",
-					entryComponent.ComponentID(),
-				)
-			}
 
 			if entryComponent.Manifest.Runtime == types.RuntimeRemote &&
 				entryComponent.Manifest.RemoteConfig != nil &&

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -27,6 +27,29 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func TestServerNeedsOAuthForPendingStaticOAuth(t *testing.T) {
+	handler := MCPHandler{}
+	server := v1.MCPServer{
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeRemote,
+				RemoteConfig: &types.RemoteRuntimeConfig{
+					StaticOAuthRequired: true,
+				},
+			},
+		},
+	}
+
+	needsOAuth, err := handler.serverNeedsOAuth(t.Context(), &server, mcp.ServerConfig{Runtime: types.RuntimeRemote})
+	require.NoError(t, err)
+	require.True(t, needsOAuth)
+
+	server.Status.UserHasAuthenticated = true
+	needsOAuth, err = handler.serverNeedsOAuth(t.Context(), &server, mcp.ServerConfig{Runtime: types.RuntimeUVX})
+	require.NoError(t, err)
+	require.False(t, needsOAuth)
+}
+
 func TestConvertMCPResources(t *testing.T) {
 	resources := &types.MCPResourceRequirements{
 		Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1640,13 +1640,6 @@ func (h *MCPCatalogHandler) populateComponentManifests(req api.Context, manifest
 				return types.NewErrBadRequest("multi-user catalog entry %s cannot be included in a composite server; use the multi-user MCP server instead", component.CatalogEntryID)
 			}
 
-			// Reject remote entries with static OAuth from being included in composites
-			if entry.Spec.Manifest.Runtime == types.RuntimeRemote &&
-				entry.Spec.Manifest.RemoteConfig != nil &&
-				entry.Spec.Manifest.RemoteConfig.StaticOAuthRequired {
-				return types.NewErrBadRequest("remote catalog entry %s with static OAuth cannot be included in a composite server", component.CatalogEntryID)
-			}
-
 			// Populate the manifest
 			component.Manifest = entry.Spec.Manifest
 			// Keep this component

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -169,7 +169,7 @@ func (f *MCPOAuthHandlerFactory) staticOAuthPending(ctx context.Context, mcpServ
 	if err != nil {
 		return false, fmt.Errorf("failed to check stored OAuth token for MCP server %s: %w", mcpServer.Name, err)
 	}
-	return conf == nil || token == nil, nil
+	return conf == nil || token == nil || token.AccessToken == "", nil
 }
 
 func (f *MCPOAuthHandlerFactory) staticOAuthURL(ctx context.Context, serverConfig mcp.ServerConfig, oauthHandler *mcpOAuthHandler) (string, error) {

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -82,6 +83,7 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(req api.Context, mcpServer v1.M
 				if req.Context().Err() != nil {
 					return "", fmt.Errorf("failed to check component server OAuth: %w", req.Context().Err())
 				}
+				return "", fmt.Errorf("failed to check component server %s OAuth: %w", componentServer.Name, err)
 			}
 
 			if u != "" {
@@ -111,6 +113,10 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(req api.Context, mcpServer v1.M
 
 	// Remote server, check for OAuth directly
 	oauthHandler := f.newMCPOAuthHandler(req.GatewayClient, userID, mcpID, mcpServerConfig.URL, oauthAppAuthRequestID)
+	staticOAuthPending, err := f.staticOAuthPending(req.Context(), mcpServer, oauthHandler)
+	if err != nil {
+		return "", err
+	}
 	errChan := make(chan error, 1)
 
 	go func() {
@@ -142,12 +148,99 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(req api.Context, mcpServer v1.M
 
 	select {
 	case err := <-errChan:
-		return "", err
+		if err != nil || !staticOAuthPending {
+			return "", err
+		}
+		return f.staticOAuthURL(req.Context(), mcpServerConfig, oauthHandler)
 	case <-req.Context().Done():
 		return "", fmt.Errorf("failed to check for MCP server OAuth: %w", req.Context().Err())
 	case u := <-oauthHandler.URLChan():
 		log.Infof("Remote MCP server requires OAuth authentication: mcpID=%s", mcpID)
 		return u, nil
+	}
+}
+
+func (f *MCPOAuthHandlerFactory) staticOAuthPending(ctx context.Context, mcpServer v1.MCPServer, oauthHandler *mcpOAuthHandler) (bool, error) {
+	if !mcp.RequiresStaticOAuth(mcpServer) {
+		return false, nil
+	}
+
+	conf, token, err := f.tokenStore.ForUserAndMCP(oauthHandler.userID, oauthHandler.mcpID).GetTokenConfig(ctx, oauthHandler.mcpURL)
+	if err != nil {
+		return false, fmt.Errorf("failed to check stored OAuth token for MCP server %s: %w", mcpServer.Name, err)
+	}
+	return conf == nil || token == nil, nil
+}
+
+func (f *MCPOAuthHandlerFactory) staticOAuthURL(ctx context.Context, serverConfig mcp.ServerConfig, oauthHandler *mcpOAuthHandler) (string, error) {
+	metadata, err := f.mcpSessionManager.GetOAuthMetadata(ctx, serverConfig,
+		"Obot MCP Gateway", system.MCPOAuthCallbackURL(f.baseURL), true)
+	if err != nil {
+		return "", fmt.Errorf("failed to discover OAuth metadata for static OAuth server: %w", err)
+	}
+
+	callbackURL := system.MCPOAuthCallbackURL(f.baseURL)
+	authorizationServer, registration, err := staticOAuthMetadata(metadata, callbackURL)
+	if err != nil {
+		return "", err
+	}
+
+	clientID, clientSecret, err := oauthHandler.Lookup(ctx, metadata.AuthorizationServerMetadataURL)
+	if err != nil {
+		return "", err
+	}
+	conf := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  callbackURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   authorizationServer.AuthorizationEndpoint,
+			TokenURL:  authorizationServer.TokenEndpoint,
+			AuthStyle: staticOAuthAuthStyle(registration.TokenEndpointAuthMethod),
+		},
+	}
+	if registration.Scope != "" {
+		conf.Scopes = strings.Fields(registration.Scope)
+	}
+
+	authURL, _, _, err := nmcp.GetOAuthAuthorizationURL(ctx, oauthHandler, conf, authorizationServer.AuthorizationEndpoint, serverConfig.URL)
+	if err != nil {
+		return "", err
+	}
+	log.Infof("Remote MCP server requires configured static OAuth authentication: mcpID=%s", oauthHandler.mcpID)
+	return authURL, nil
+}
+
+func staticOAuthMetadata(metadata nmcp.OAuthMetadata, redirectURL string) (nmcp.AuthorizationServerMetadata, nmcp.ClientRegistrationMetadata, error) {
+	var authorizationServer nmcp.AuthorizationServerMetadata
+	if len(metadata.AuthorizationServerMetadata) > 0 {
+		if err := json.Unmarshal(metadata.AuthorizationServerMetadata, &authorizationServer); err != nil {
+			return authorizationServer, nmcp.ClientRegistrationMetadata{}, fmt.Errorf("failed to parse authorization server metadata: %w", err)
+		}
+	}
+	if authorizationServer.AuthorizationEndpoint == "" || authorizationServer.TokenEndpoint == "" {
+		return authorizationServer, nmcp.ClientRegistrationMetadata{}, fmt.Errorf("static OAuth is required but authorization server metadata was not found")
+	}
+
+	var registration nmcp.ClientRegistrationMetadata
+	if len(metadata.ClientRegistration) > 0 {
+		if err := json.Unmarshal(metadata.ClientRegistration, &registration); err != nil {
+			return authorizationServer, registration, fmt.Errorf("failed to parse OAuth client registration metadata: %w", err)
+		}
+	}
+
+	return authorizationServer, nmcp.AuthServerMetadataToClientRegistration(authorizationServer,
+		"Obot MCP Gateway", redirectURL, registration.Scope), nil
+}
+
+func staticOAuthAuthStyle(method string) oauth2.AuthStyle {
+	switch method {
+	case "client_secret_basic":
+		return oauth2.AuthStyleInHeader
+	case "client_secret_post":
+		return oauth2.AuthStyleInParams
+	default:
+		return oauth2.AuthStyleAutoDetect
 	}
 }
 

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler_test.go
@@ -57,6 +57,11 @@ func TestStaticOAuthPendingUsesStoredAuthentication(t *testing.T) {
 	require.True(t, pending)
 
 	storage.config = &oauth2.Config{ClientID: "client"}
+	storage.token = &oauth2.Token{}
+	pending, err = factory.staticOAuthPending(t.Context(), server, handler)
+	require.NoError(t, err)
+	require.True(t, pending)
+
 	storage.token = &oauth2.Token{AccessToken: "token"}
 	pending, err = factory.staticOAuthPending(t.Context(), server, handler)
 	require.NoError(t, err)

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler_test.go
@@ -1,0 +1,95 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	nmcp "github.com/obot-platform/nanobot/pkg/mcp"
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+type staticOAuthTokenStorage struct {
+	config *oauth2.Config
+	token  *oauth2.Token
+}
+
+func (s *staticOAuthTokenStorage) GetTokenConfig(context.Context, string) (*oauth2.Config, *oauth2.Token, error) {
+	return s.config, s.token, nil
+}
+
+func (*staticOAuthTokenStorage) SetTokenConfig(context.Context, string, *oauth2.Config, *oauth2.Token) error {
+	return nil
+}
+
+func (*staticOAuthTokenStorage) DeleteTokenConfig(context.Context, string) error {
+	return nil
+}
+
+type staticOAuthGlobalTokenStore struct {
+	storage nmcp.TokenStorage
+}
+
+func (s staticOAuthGlobalTokenStore) ForUserAndMCP(string, string) nmcp.TokenStorage {
+	return s.storage
+}
+
+func TestStaticOAuthPendingUsesStoredAuthentication(t *testing.T) {
+	storage := &staticOAuthTokenStorage{}
+	factory := MCPOAuthHandlerFactory{tokenStore: staticOAuthGlobalTokenStore{storage: storage}}
+	handler := &mcpOAuthHandler{userID: "user", mcpID: "server", mcpURL: "https://example.com/mcp"}
+	server := v1.MCPServer{
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeRemote,
+				RemoteConfig: &types.RemoteRuntimeConfig{
+					StaticOAuthRequired: true,
+				},
+			},
+		},
+	}
+
+	pending, err := factory.staticOAuthPending(t.Context(), server, handler)
+	require.NoError(t, err)
+	require.True(t, pending)
+
+	storage.config = &oauth2.Config{ClientID: "client"}
+	storage.token = &oauth2.Token{AccessToken: "token"}
+	pending, err = factory.staticOAuthPending(t.Context(), server, handler)
+	require.NoError(t, err)
+	require.False(t, pending)
+}
+
+func TestStaticOAuthMetadataDefaultsMissingClientRegistration(t *testing.T) {
+	authorizationServer := nmcp.AuthorizationServerMetadata{
+		Issuer:                            "https://auth.example.com",
+		AuthorizationEndpoint:             "https://auth.example.com/authorize",
+		TokenEndpoint:                     "https://auth.example.com/token",
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		ResponseTypesSupported:            []string{"code"},
+		TokenEndpointAuthMethodsSupported: []string{"client_secret_post"},
+	}
+	authorizationServerJSON, err := json.Marshal(authorizationServer)
+	require.NoError(t, err)
+
+	parsedAuthorizationServer, registration, err := staticOAuthMetadata(nmcp.OAuthMetadata{
+		AuthorizationServerMetadata: authorizationServerJSON,
+	}, "https://obot.example.com/oauth/mcp/callback")
+	require.NoError(t, err)
+	require.Equal(t, authorizationServer, parsedAuthorizationServer)
+	require.Equal(t, nmcp.ClientRegistrationMetadata{
+		RedirectURIs:            []string{"https://obot.example.com/oauth/mcp/callback"},
+		TokenEndpointAuthMethod: "client_secret_post",
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		ClientName:              "Obot MCP Gateway",
+	}, registration)
+}
+
+func TestStaticOAuthMetadataReportsMissingAuthorizationServer(t *testing.T) {
+	_, _, err := staticOAuthMetadata(nmcp.OAuthMetadata{}, "https://obot.example.com/oauth/mcp/callback")
+	require.EqualError(t, err, "static OAuth is required but authorization server metadata was not found")
+}

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/nah/pkg/untriggered"
-	nmcp "github.com/obot-platform/nanobot/pkg/mcp"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
@@ -1099,23 +1098,8 @@ func (h *Handler) SyncOAuthMetadata(req router.Request, _ router.Response) error
 		return nil
 	}
 
-	oauthServer := nmcp.Server{
-		BaseURL: serverConfig.URL,
-		Headers: serverConfigHeaders(serverConfig),
-	}
-	var metadata nmcp.OAuthMetadata
-	if serverConfig.TunnelName != "" {
-		httpClient, clientErr := h.mcpSessionManager.HTTPClientForServer(serverConfig, 5*time.Second)
-		if clientErr != nil {
-			return clientErr
-		}
-		metadata, err = nmcp.GetOAuthMetadataWithClient(req.Ctx, httpClient, oauthServer,
-			"Obot Test MCP OAuth Client", system.MCPOAuthCallbackURL(h.baseURL))
-	} else {
-		metadata, err = nmcp.GetOAuthMetadataWithBlockingConfig(req.Ctx, oauthServer,
-			"Obot Test MCP OAuth Client", system.MCPOAuthCallbackURL(h.baseURL),
-			!blockingConfig.AllowLocalhostMCP, !blockingConfig.AllowPrivateIPMCP, !blockingConfig.AllowLinkLocalMCP)
-	}
+	metadata, err := h.mcpSessionManager.GetOAuthMetadata(req.Ctx, serverConfig,
+		"Obot Test MCP OAuth Client", system.MCPOAuthCallbackURL(h.baseURL), mcp.RequiresStaticOAuth(*server))
 	if err != nil {
 		return fmt.Errorf("failed to get OAuth metadata: %w", err)
 	}
@@ -1175,22 +1159,6 @@ func setOAuthMetadata(req router.Request, server *v1.MCPServer, statusMetadata *
 	}
 
 	return nil
-}
-
-func serverConfigHeaders(serverConfig mcp.ServerConfig) map[string]string {
-	result := make(map[string]string, len(serverConfig.PassthroughHeaderNames)+len(serverConfig.Headers))
-	for i, key := range serverConfig.PassthroughHeaderNames {
-		if i < len(serverConfig.PassthroughHeaderValues) {
-			result[key] = serverConfig.PassthroughHeaderValues[i]
-		}
-	}
-	for _, header := range serverConfig.Headers {
-		key, value, ok := strings.Cut(header, "=")
-		if ok {
-			result[key] = value
-		}
-	}
-	return result
 }
 
 func (h *Handler) ShutdownIdleServers(req router.Request, resp router.Response) error {

--- a/pkg/mcp/action.go
+++ b/pkg/mcp/action.go
@@ -738,19 +738,6 @@ func serverManifestFromCatalogEntryManifest(isAdmin, disableHostnameValidation b
 				userURL        string
 			)
 
-			entryHasStaticOAuth := entryComponent.Manifest.Runtime == types.RuntimeRemote &&
-				entryComponent.Manifest.RemoteConfig != nil &&
-				entryComponent.Manifest.RemoteConfig.StaticOAuthRequired
-			inputHasStaticOAuth := inputComponent.Manifest.Runtime == types.RuntimeRemote &&
-				inputComponent.Manifest.RemoteConfig != nil &&
-				inputComponent.Manifest.RemoteConfig.StaticOAuthRequired
-			if entryHasStaticOAuth && !inputHasStaticOAuth {
-				return types.MCPServerManifest{}, types.NewErrBadRequest(
-					"cannot update composite server: component %s has been updated to require static OAuth, which is not allowed in composite servers",
-					entryComponent.ComponentID(),
-				)
-			}
-
 			if entryComponent.Manifest.Runtime == types.RuntimeRemote &&
 				entryComponent.Manifest.RemoteConfig != nil &&
 				entryComponent.Manifest.RemoteConfig.Hostname != "" &&

--- a/pkg/mcp/mcpvalidators.go
+++ b/pkg/mcp/mcpvalidators.go
@@ -782,17 +782,6 @@ func (v CompositeValidator) ValidateConfig(_ context.Context, manifest types.MCP
 			}
 		}
 
-		// Prevent remote components with static OAuth from being included in composites
-		if component.Manifest.Runtime == types.RuntimeRemote &&
-			component.Manifest.RemoteConfig != nil &&
-			component.Manifest.RemoteConfig.StaticOAuthRequired {
-			return types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   fmt.Sprintf("compositeConfig.componentServers[%d]", i),
-				Message: "remote component with static OAuth cannot be included in a composite server",
-			}
-		}
-
 		// Validate the tool prefix
 		prefix := component.ToolPrefix
 		if prefix != "" {
@@ -941,17 +930,6 @@ func (v CompositeValidator) ValidateCatalogConfig(_ context.Context, manifest ty
 				Runtime: types.RuntimeComposite,
 				Field:   fmt.Sprintf("compositeConfig.componentServers[%d].manifest.runtime", i),
 				Message: "runtime cannot be composite",
-			}
-		}
-
-		// Prevent remote components with static OAuth from being included in composites
-		if component.Manifest.Runtime == types.RuntimeRemote &&
-			component.Manifest.RemoteConfig != nil &&
-			component.Manifest.RemoteConfig.StaticOAuthRequired {
-			return types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   fmt.Sprintf("compositeConfig.componentServers[%d]", i),
-				Message: "remote component with static OAuth cannot be included in a composite server",
 			}
 		}
 

--- a/pkg/mcp/mcpvalidators_test.go
+++ b/pkg/mcp/mcpvalidators_test.go
@@ -1558,7 +1558,7 @@ func TestCompositeValidator_ValidateCatalogConfig(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "remote component with static OAuth not allowed in catalog",
+			name: "remote component with static OAuth is allowed in catalog",
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeComposite,
 				CompositeConfig: &types.CompositeCatalogConfig{
@@ -1576,11 +1576,7 @@ func TestCompositeValidator_ValidateCatalogConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedError: types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   "compositeConfig.componentServers[0]",
-				Message: "remote component with static OAuth cannot be included in a composite server",
-			},
+			expectedError: nil,
 		},
 		{
 			name: "remote component without static OAuth is allowed in catalog",
@@ -1893,7 +1889,7 @@ func TestCompositeValidator_ValidateConfig_StaticOAuth(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name: "remote component with static OAuth not allowed",
+			name: "remote component with static OAuth is allowed",
 			manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeComposite,
 				CompositeConfig: &types.CompositeRuntimeConfig{
@@ -1911,11 +1907,7 @@ func TestCompositeValidator_ValidateConfig_StaticOAuth(t *testing.T) {
 					},
 				},
 			},
-			expectedError: types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   "compositeConfig.componentServers[0]",
-				Message: "remote component with static OAuth cannot be included in a composite server",
-			},
+			expectedError: nil,
 		},
 		{
 			name: "remote component without static OAuth is allowed",
@@ -1959,7 +1951,7 @@ func TestCompositeValidator_ValidateConfig_StaticOAuth(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "mixed components with one having static OAuth not allowed",
+			name: "mixed components with one having static OAuth is allowed",
 			manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeComposite,
 				CompositeConfig: &types.CompositeRuntimeConfig{
@@ -1987,11 +1979,7 @@ func TestCompositeValidator_ValidateConfig_StaticOAuth(t *testing.T) {
 					},
 				},
 			},
-			expectedError: types.RuntimeValidationError{
-				Runtime: types.RuntimeComposite,
-				Field:   "compositeConfig.componentServers[1]",
-				Message: "remote component with static OAuth cannot be included in a composite server",
-			},
+			expectedError: nil,
 		},
 	}
 

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	nmcp "github.com/obot-platform/nanobot/pkg/mcp"
+	"github.com/obot-platform/nanobot/pkg/safehttp"
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+)
+
+// RequiresStaticOAuth reports whether a remote MCP server is configured to
+// require static OAuth and has not yet been authenticated by the user.
+func RequiresStaticOAuth(server v1.MCPServer) bool {
+	return server.Spec.Manifest.Runtime == types.RuntimeRemote &&
+		server.Spec.Manifest.RemoteConfig != nil &&
+		server.Spec.Manifest.RemoteConfig.StaticOAuthRequired &&
+		!server.Status.UserHasAuthenticated
+}
+
+// GetOAuthMetadata discovers OAuth metadata for a remote MCP server. When
+// assumeOAuthRequired is true, discovery proceeds even if initialize succeeds.
+// This supports servers that defer their OAuth challenge until tools/call.
+func (m *SessionManager) GetOAuthMetadata(ctx context.Context, serverConfig ServerConfig, clientName, redirectURL string, assumeOAuthRequired bool) (nmcp.OAuthMetadata, error) {
+	var httpClient *http.Client
+	if serverConfig.TunnelName != "" {
+		var err error
+		httpClient, err = m.HTTPClientForServer(serverConfig, 5*time.Second)
+		if err != nil {
+			return nmcp.OAuthMetadata{}, err
+		}
+	} else {
+		blockingConfig := m.RemoteMCPURLValidationConfig()
+		httpClient = safehttp.NewClientWithTimeout(
+			!blockingConfig.AllowLocalhostMCP,
+			!blockingConfig.AllowPrivateIPMCP,
+			!blockingConfig.AllowLinkLocalMCP,
+			5*time.Second,
+		)
+	}
+
+	return getOAuthMetadataWithClient(ctx, httpClient, serverConfig, clientName, redirectURL, assumeOAuthRequired)
+}
+
+func getOAuthMetadataWithClient(ctx context.Context, httpClient *http.Client, serverConfig ServerConfig, clientName, redirectURL string, assumeOAuthRequired bool) (nmcp.OAuthMetadata, error) {
+	if assumeOAuthRequired {
+		cloned := *httpClient
+		transport := cloned.Transport
+		if transport == nil {
+			transport = http.DefaultTransport
+		}
+		cloned.Transport = &assumeOAuthRequiredTransport{base: transport}
+		httpClient = &cloned
+	}
+
+	return nmcp.GetOAuthMetadataWithClient(ctx, httpClient, nmcp.Server{
+		BaseURL: serverConfig.URL,
+		Headers: serverConfigHeaders(serverConfig),
+	}, clientName, redirectURL)
+}
+
+func serverConfigHeaders(serverConfig ServerConfig) map[string]string {
+	result := make(map[string]string, len(serverConfig.PassthroughHeaderNames)+len(serverConfig.Headers))
+	for i, key := range serverConfig.PassthroughHeaderNames {
+		if i < len(serverConfig.PassthroughHeaderValues) {
+			result[key] = serverConfig.PassthroughHeaderValues[i]
+		}
+	}
+	for _, header := range serverConfig.Headers {
+		key, value, ok := strings.Cut(header, "=")
+		if ok {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+// assumeOAuthRequiredTransport synthesizes the initialize challenge used to
+// begin standard OAuth metadata discovery. All subsequent metadata requests use
+// the original, policy-enforcing transport.
+type assumeOAuthRequiredTransport struct {
+	base http.RoundTripper
+	mu   sync.Mutex
+	done bool
+}
+
+func (t *assumeOAuthRequiredTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	if !t.done && req.Method == http.MethodPost {
+		t.done = true
+		t.mu.Unlock()
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+			Request:    req,
+		}, nil
+	}
+	t.mu.Unlock()
+	return t.base.RoundTrip(req)
+}

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -1,0 +1,69 @@
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequiresStaticOAuth(t *testing.T) {
+	server := v1.MCPServer{}
+	server.Spec.Manifest.Runtime = types.RuntimeRemote
+	server.Spec.Manifest.RemoteConfig = &types.RemoteRuntimeConfig{StaticOAuthRequired: true}
+
+	require.True(t, RequiresStaticOAuth(server))
+
+	server.Status.UserHasAuthenticated = true
+	require.False(t, RequiresStaticOAuth(server))
+
+	server.Status.UserHasAuthenticated = false
+	server.Spec.Manifest.RemoteConfig.StaticOAuthRequired = false
+	require.False(t, RequiresStaticOAuth(server))
+
+	server.Spec.Manifest.Runtime = types.RuntimeComposite
+	server.Spec.Manifest.RemoteConfig.StaticOAuthRequired = true
+	require.False(t, RequiresStaticOAuth(server))
+}
+
+func TestGetOAuthMetadataAssumesOAuthAfterSuccessfulInitialize(t *testing.T) {
+	var initializeRequests atomic.Int32
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch {
+		case req.Method == http.MethodPost && req.URL.Path == "/mcp":
+			initializeRequests.Add(1)
+			rw.Header().Set("Content-Type", "application/json")
+			_, _ = rw.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"test","version":"1"}}}`))
+		case strings.Contains(req.URL.Path, "oauth-protected-resource"):
+			rw.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(rw, `{"resource":%q,"authorization_servers":[%q]}`, serverURL+"/mcp", serverURL)
+		case req.URL.Path == "/.well-known/oauth-authorization-server":
+			rw.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(rw, `{"issuer":%q,"authorization_endpoint":%q,"token_endpoint":%q,"response_types_supported":["code"]}`, serverURL, serverURL+"/authorize", serverURL+"/token")
+		default:
+			http.NotFound(rw, req)
+		}
+	}))
+	serverURL = server.URL
+	t.Cleanup(server.Close)
+
+	config := ServerConfig{Runtime: types.RuntimeRemote, URL: server.URL + "/mcp"}
+	metadata, err := getOAuthMetadataWithClient(t.Context(), server.Client(), config, "test", "https://obot.example/oauth/mcp/callback", false)
+	require.NoError(t, err)
+	require.Empty(t, metadata.AuthorizationServerMetadata)
+	require.Equal(t, int32(1), initializeRequests.Load())
+
+	metadata, err = getOAuthMetadataWithClient(t.Context(), server.Client(), config, "test", "https://obot.example/oauth/mcp/callback", true)
+	require.NoError(t, err)
+	require.NotEmpty(t, metadata.AuthorizationServerMetadata)
+	require.NotEmpty(t, metadata.ClientRegistration)
+	// Forced discovery must not create a real MCP session as a side effect.
+	require.Equal(t, int32(1), initializeRequests.Load())
+}


### PR DESCRIPTION
Treat static OAuth as authoritative until a third-party token exists, so lazy-auth servers cannot bypass consent after a successful initialize.

Discover authorization metadata without creating an MCP session and apply the same behavior to enabled composite components.

Issue: https://github.com/obot-platform/obot/issues/7433