### PR TITLE
fix: prompt for access policy on multi-tenant catalog entry deployment

### DIFF
--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -158,7 +158,6 @@
 			const existingResourceIds = new Set(
 				accessControlRule.resources?.map((resource) => resource.id) ?? []
 			);
-
 			if (!existingResourceIds.has(initialAdditionId)) {
 				const entry = mcpEntriesMap.get(initialAdditionId);
 				if (entry) {
@@ -249,7 +248,7 @@
 				const server = mcpServersMap.get(resource.id);
 				return {
 					id: resource.id,
-					name: server?.manifest.name || '-',
+					name: server?.alias || server?.manifest.name || '-',
 					type: 'mcpserver'
 				};
 			}

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -679,7 +679,10 @@
 				(rule) =>
 					rule.subjects?.some((s) => s.id === '*') && rule.resources?.some((r) => r.id === '*')
 			);
-			if (isAtLeastPowerUserPlus && !entry && !hasEverythingEveryoneRule) {
+			const showSetAccessPolicy = isAtLeastPowerUserPlus && !entry && !hasEverythingEveryoneRule;
+			const isSingleTenantCatalogEntry =
+				'isCatalogEntry' in savedEntry && savedEntry.manifest.serverUserType === 'singleUser';
+			if (showSetAccessPolicy && isSingleTenantCatalogEntry) {
 				await selectRulesDialog?.open();
 				loading = false;
 			} else {

--- a/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
+++ b/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
@@ -112,7 +112,7 @@
 			sessionStorage.setItem(ADMIN_SESSION_STORAGE.ACCESS_CONTROL_RULE_CREATION, entry.id);
 		}
 
-		await mcpServersAndEntries.refreshEntries();
+		await mcpServersAndEntries.refreshAll();
 		updatingBeforeCreate = false;
 
 		goto(
@@ -129,10 +129,10 @@
 	class="overflow-visible md:w-2xl"
 >
 	{#if accessControlRules.length === 0}
-		<p class="text-md mb-4 font-light">Looks like you don't have any MCP access policies yet!</p>
-		<p class="text-md mb-8 font-light">Want to go ahead & create one now?</p>
+		<p class="text-md font-light">Looks like you don't have any MCP access policies yet!</p>
+		<p class="text-md mb-4 font-light">Want to go ahead & create one now?</p>
 	{:else}
-		<p class="text-md mb-8 font-light">
+		<p class="text-md mb-4 font-light">
 			Select the access policies you want to apply to this MCP server.
 		</p>
 	{/if}

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { dialogAnimation } from '$lib/actions/dialogAnimation';
+	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 	import {
 		AdminService,
 		UserService,
@@ -7,7 +8,8 @@
 		type MCPCatalogServer,
 		type MCPAllowedSecretBindingTarget,
 		type MCPSubField,
-		type MCPServerInstance
+		type MCPServerInstance,
+		Group
 	} from '$lib/services';
 	import { EventStreamService } from '$lib/services/admin/eventstream.svelte';
 	import {
@@ -28,6 +30,7 @@
 	import CopyField from '../CopyField.svelte';
 	import DotDotDot from '../DotDotDot.svelte';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import SelectMcpAccessControlRules from '../admin/SelectMcpAccessControlRules.svelte';
 	import IconButton from '../primitives/IconButton.svelte';
 	import CatalogConfigureForm, {
 		type CompositeLaunchFormData,
@@ -153,6 +156,8 @@
 	let oauthDialog = $state<HTMLDialogElement>();
 	let oauthURL = $state<string>('');
 	let oauthVerifying = $state(false);
+
+	let selectRulesDialog = $state<ReturnType<typeof SelectMcpAccessControlRules>>();
 
 	let existingServerNames = $derived(
 		userConfiguredServers
@@ -743,7 +748,27 @@
 
 			await new Promise((resolve) => setTimeout(resolve, 1000));
 			configDialog?.close();
-			onConnect?.({ server, entry });
+
+			if (isMultiUserCatalogEntry(entry)) {
+				const isAtLeastPowerUserPlus = profile.current?.groups.includes(Group.POWERUSER_PLUS);
+				if (isAtLeastPowerUserPlus) {
+					const existingRules = isAtLeastPowerUserPlus
+						? workspaceID
+							? await UserService.listWorkspaceAccessControlRules(workspaceID)
+							: await AdminService.listAccessControlRules()
+						: [];
+					const hasEverythingEveryoneRule = existingRules.some(
+						(rule) =>
+							rule.subjects?.some((s) => s.id === '*') && rule.resources?.some((r) => r.id === '*')
+					);
+					const showSetAccessPolicy = isAtLeastPowerUserPlus && !hasEverythingEveryoneRule;
+					if (showSetAccessPolicy) {
+						selectRulesDialog?.open();
+					}
+				}
+			} else {
+				onConnect?.({ server, entry });
+			}
 		} catch (err) {
 			launchError = err instanceof Error ? err.message : 'An unknown error occurred';
 			launchMissingSecretBinding = launchError.includes('secret binding');
@@ -1359,3 +1384,13 @@
 		<button type="button" aria-label="Close dialog" onclick={handleOauthClose}>close</button>
 	</form>
 </dialog>
+
+<SelectMcpAccessControlRules
+	bind:this={selectRulesDialog}
+	entry={isMultiUserCatalogEntry(entry) ? server : entry}
+	entity={workspaceID ? 'workspace' : 'catalog'}
+	id={workspaceID ?? DEFAULT_MCP_CATALOG_ID}
+	onSubmit={() => {
+		onConnect?.({ server, entry });
+	}}
+/>

--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -749,22 +749,22 @@
 			await new Promise((resolve) => setTimeout(resolve, 1000));
 			configDialog?.close();
 
-			if (isMultiUserCatalogEntry(entry)) {
-				const isAtLeastPowerUserPlus = profile.current?.groups.includes(Group.POWERUSER_PLUS);
-				if (isAtLeastPowerUserPlus) {
-					const existingRules = isAtLeastPowerUserPlus
-						? workspaceID
-							? await UserService.listWorkspaceAccessControlRules(workspaceID)
-							: await AdminService.listAccessControlRules()
-						: [];
-					const hasEverythingEveryoneRule = existingRules.some(
-						(rule) =>
-							rule.subjects?.some((s) => s.id === '*') && rule.resources?.some((r) => r.id === '*')
-					);
-					const showSetAccessPolicy = isAtLeastPowerUserPlus && !hasEverythingEveryoneRule;
-					if (showSetAccessPolicy) {
-						selectRulesDialog?.open();
-					}
+			const isAtLeastPowerUserPlus = profile.current?.groups.includes(Group.POWERUSER_PLUS);
+			if (isMultiUserCatalogEntry(entry) && isAtLeastPowerUserPlus) {
+				const existingRules = isAtLeastPowerUserPlus
+					? workspaceID
+						? await UserService.listWorkspaceAccessControlRules(workspaceID)
+						: await AdminService.listAccessControlRules()
+					: [];
+				const hasEverythingEveryoneRule = existingRules.some(
+					(rule) =>
+						rule.subjects?.some((s) => s.id === '*') && rule.resources?.some((r) => r.id === '*')
+				);
+				const showSetAccessPolicy = isAtLeastPowerUserPlus && !hasEverythingEveryoneRule;
+				if (showSetAccessPolicy) {
+					selectRulesDialog?.open();
+				} else {
+					onConnect?.({ server, entry });
 				}
 			} else {
 				onConnect?.({ server, entry });


### PR DESCRIPTION
This addresses moving the access policy prompt to only show when the user has deployed a multi-tenant server for a multi-tenant catalog entry (rather on catalog entry creation) and minor styling tweaks.

Addresses #7308 