### PR TITLE
feat: add an interface for running agent sandboxes (2/11)

### DIFF
--- a/pkg/agentbackend/backend.go
+++ b/pkg/agentbackend/backend.go
@@ -1,0 +1,264 @@
+// Package agentbackend defines the implementation-neutral contract between
+// Obot's hosted-agent controllers and an agent runtime provider.
+package agentbackend
+
+import (
+	"context"
+	"time"
+)
+
+// Backend is the complete desired-state and observation contract required by
+// hosted agents. Implementations must make every operation idempotent.
+type Backend interface {
+	InstanceBackend
+	PoolBackend
+	UtilizationReader
+}
+
+type InstanceBackend interface {
+	ReconcileInstance(context.Context, DesiredInstance) (InstanceObservation, error)
+	ObserveInstance(context.Context, InstanceRef) (InstanceObservation, error)
+	DeleteInstance(context.Context, InstanceRef) (DeleteResult, error)
+}
+
+type PoolBackend interface {
+	ReconcilePool(context.Context, DesiredPool) (PoolObservation, error)
+	ObservePool(context.Context, PoolRef) (PoolObservation, error)
+	DeletePool(context.Context, PoolRef) (DeleteResult, error)
+}
+
+type UtilizationReader interface {
+	GetPoolUtilization(context.Context, PoolRef) (UtilizationSnapshot, error)
+}
+
+// Subscriber is an optional fast path for lifecycle changes. Events are hints;
+// callers must observe the referenced resource before persisting status.
+type Subscriber interface {
+	Subscribe(context.Context, func(context.Context, Event) error) error
+}
+
+type Event struct {
+	Kind     ResourceKind
+	Instance InstanceRef
+	Pool     PoolRef
+}
+
+type ResourceKind string
+
+const (
+	ResourceKindInstance ResourceKind = "instance"
+	ResourceKindPool     ResourceKind = "pool"
+)
+
+type InstanceRef struct {
+	ID        string
+	Namespace string
+	UserID    string
+	BackendID string
+}
+
+type PoolRef struct {
+	ID        string
+	BackendID string
+}
+
+type DesiredInstance struct {
+	Ref      InstanceRef
+	Pool     PoolRef
+	Revision string
+
+	Name        string
+	Description string
+	// ServerURL is the address of the Obot API as seen from inside the sandbox.
+	// An agent is issued a credential but has nowhere to spend it without this:
+	// its MCP servers, its models and its skills are all reached through Obot.
+	ServerURL string
+	Harness   Harness
+	Image     string
+	Source    Source
+	Model     Model
+	Prompt    []string
+	Env       map[string]string
+	Files     []File
+	Secrets   []SecretRef
+
+	// Requests is what this sandbox is guaranteed, and Limits is what it may
+	// burst to. Both are derived from the pool rather than declared by the
+	// agent: a pool is a shared bucket, and an agent has no inherent size.
+	//
+	// They are carried here, rather than computed by a backend, so that they
+	// participate in the desired revision. Resizing a pool therefore changes
+	// every sandbox's revision and restarts it, which is the only way a running
+	// sandbox picks up new limits.
+	Requests InstanceResources
+	Limits   InstanceResources
+
+	// Port is the HTTP port the agent serves on. Zero means it serves nothing,
+	// and a backend should publish no address for it.
+	Port int
+	// Terminal asks the backend to keep the sandbox attachable for an
+	// interactive session.
+	Terminal bool
+}
+
+// InstanceResources is a sandbox's share of its pool, in plain units so the
+// contract stays independent of any backend's resource model.
+//
+// These are plain numbers on purpose. Quantity-style types serialize equal
+// values to different strings ("1" and "1000m"), which would make the desired
+// revision hash unstable and trigger redeploys that change nothing.
+type InstanceResources struct {
+	CPUVCPUs    float64
+	MemoryBytes int64
+}
+
+func (r InstanceResources) IsZero() bool {
+	return r.CPUVCPUs == 0 && r.MemoryBytes == 0
+}
+
+type Harness struct {
+	ID string
+	// Interactive asks the backend to allocate a TTY and keep stdin open, the
+	// equivalent of `docker run -it`. Without it an image whose entrypoint is a
+	// shell exits as soon as it starts.
+	Interactive bool
+}
+
+type Source struct {
+	URL      string
+	Revision string
+	Subdir   string
+}
+
+type Model struct {
+	ID       string
+	Endpoint string
+}
+
+type File struct {
+	Path    string
+	Content []byte
+	Mode    uint32
+}
+
+// SecretRef contains routing metadata only. Secret values are managed through
+// the provider's secret channel and must never enter this persisted contract.
+type SecretRef struct {
+	ID       string
+	EnvName  string
+	FilePath string
+
+	// Version changes whenever the value behind ID changes. It participates in
+	// the desired revision so that a rotated secret restarts the sandbox.
+	//
+	// Agents read their credentials once at startup and cannot reload them, so
+	// a sandbox left running across a rotation would hold a credential that no
+	// longer works. Versioning the reference propagates the rotation while
+	// keeping the value itself out of desired state, status and the revision.
+	Version string
+
+	// Value is the secret itself, passed transiently so a backend can write it
+	// wherever that backend keeps secrets. It is excluded from the desired
+	// revision by DesiredInstance.Redacted, and must never be persisted to
+	// instance spec or status, or logged.
+	Value string
+}
+
+// Redacted returns a copy with every secret value cleared, for hashing into the
+// desired revision or for logging. Version still varies with the value, so a
+// rotation changes the revision without the revision ever containing a secret.
+func (d DesiredInstance) Redacted() DesiredInstance {
+	d.Secrets = append([]SecretRef(nil), d.Secrets...)
+	for i := range d.Secrets {
+		d.Secrets[i].Value = ""
+	}
+	return d
+}
+
+type DesiredPool struct {
+	Ref      PoolRef
+	Revision string
+	Capacity ResourceQuantity
+	// MaxSandboxes bounds how many sandboxes share the pool, and so determines
+	// each one's guaranteed share.
+	MaxSandboxes int
+	Suspended    bool
+}
+
+type ResourceQuantity struct {
+	CPUVCPUs     float64
+	MemoryBytes  int64
+	StorageBytes int64
+}
+
+type State string
+
+const (
+	StatePending  State = "pending"
+	StateReady    State = "ready"
+	StateError    State = "error"
+	StateDeleting State = "deleting"
+)
+
+type InstanceObservation struct {
+	Ref               InstanceRef
+	Exists            bool
+	ObservedRevision  string
+	State             State
+	URL               string
+	Reason            string
+	Message           string
+	BackendGeneration string
+}
+
+type PoolObservation struct {
+	Ref               PoolRef
+	Exists            bool
+	ObservedRevision  string
+	State             State
+	Schedulable       bool
+	Capacity          ResourceQuantity
+	Reason            string
+	Message           string
+	BackendGeneration string
+}
+
+type DeleteResult struct {
+	Complete bool
+}
+
+// UtilizationSnapshot is a live point-in-time sample, not desired state or
+// historical accounting.
+type UtilizationSnapshot struct {
+	Timestamp time.Time
+	Pool      ResourceUtilization
+	Instances []InstanceUtilization
+	Pressure  Pressure
+	// StorageMeasured reports whether Pool.StorageBytes is a real measurement.
+	// A backend that cannot attribute disk usage to this pool alone leaves it
+	// false, so a caller can say so rather than draw an empty disk that is
+	// really an unknown one.
+	StorageMeasured bool
+}
+
+type InstanceUtilization struct {
+	Ref         InstanceRef
+	State       State
+	Utilization ResourceUtilization
+}
+
+// ResourceUtilization is live usage. StorageBytes is only ever set on a pool:
+// sandboxes share one volume separated by subPath, which the kubelet does not
+// measure per directory, so a sandbox's own disk usage is not observable
+// without a node agent.
+type ResourceUtilization struct {
+	CPUVCPUs     float64
+	MemoryBytes  int64
+	StorageBytes int64
+}
+
+type Pressure struct {
+	CPU     bool
+	Memory  bool
+	Storage bool
+}

--- a/pkg/agentbackend/disabled.go
+++ b/pkg/agentbackend/disabled.go
@@ -1,0 +1,43 @@
+package agentbackend
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrDisabled = errors.New("agent runtime backend is disabled")
+
+// Disabled is a Backend that consistently reports that hosted-agent runtime
+// management is unavailable. It lets service wiring inject a non-nil backend
+// without giving disabled mode any synthetic behavior.
+type Disabled struct{}
+
+var _ Backend = Disabled{}
+
+func (Disabled) ReconcileInstance(context.Context, DesiredInstance) (InstanceObservation, error) {
+	return InstanceObservation{}, ErrDisabled
+}
+
+func (Disabled) ObserveInstance(context.Context, InstanceRef) (InstanceObservation, error) {
+	return InstanceObservation{}, ErrDisabled
+}
+
+func (Disabled) DeleteInstance(context.Context, InstanceRef) (DeleteResult, error) {
+	return DeleteResult{}, ErrDisabled
+}
+
+func (Disabled) ReconcilePool(context.Context, DesiredPool) (PoolObservation, error) {
+	return PoolObservation{}, ErrDisabled
+}
+
+func (Disabled) ObservePool(context.Context, PoolRef) (PoolObservation, error) {
+	return PoolObservation{}, ErrDisabled
+}
+
+func (Disabled) DeletePool(context.Context, PoolRef) (DeleteResult, error) {
+	return DeleteResult{}, ErrDisabled
+}
+
+func (Disabled) GetPoolUtilization(context.Context, PoolRef) (UtilizationSnapshot, error) {
+	return UtilizationSnapshot{}, ErrDisabled
+}

--- a/pkg/agentbackend/fake/backend.go
+++ b/pkg/agentbackend/fake/backend.go
@@ -1,0 +1,337 @@
+// Package fake provides a process-local agent backend for development and
+// provider contract tests. It deliberately stores no secret values.
+package fake
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+)
+
+var ErrInvalidDesiredState = errors.New("invalid desired state")
+
+type Config struct {
+	TransitionDelay time.Duration
+	Now             func() time.Time
+}
+
+type Backend struct {
+	mu        sync.Mutex
+	delay     time.Duration
+	now       func() time.Time
+	pools     map[string]*pool
+	instances map[string]*instance
+	events    chan agentbackend.Event
+}
+
+type pool struct {
+	desired    agentbackend.DesiredPool
+	generation int64
+	state      agentbackend.State
+	readyAt    time.Time
+	deleteAt   time.Time
+}
+
+type instance struct {
+	desired    agentbackend.DesiredInstance
+	generation int64
+	state      agentbackend.State
+	readyAt    time.Time
+	deleteAt   time.Time
+	url        string
+	urlReady   bool
+}
+
+var _ agentbackend.Backend = (*Backend)(nil)
+var _ agentbackend.Subscriber = (*Backend)(nil)
+
+func New(config Config) *Backend {
+	now := config.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Backend{
+		delay:     config.TransitionDelay,
+		now:       now,
+		pools:     map[string]*pool{},
+		instances: map[string]*instance{},
+		events:    make(chan agentbackend.Event, 128),
+	}
+}
+
+func (b *Backend) ReconcilePool(_ context.Context, desired agentbackend.DesiredPool) (agentbackend.PoolObservation, error) {
+	if desired.Ref.ID == "" || desired.Revision == "" || desired.Capacity.CPUVCPUs <= 0 ||
+		desired.Capacity.MemoryBytes <= 0 || desired.Capacity.StorageBytes <= 0 {
+		return agentbackend.PoolObservation{}, fmt.Errorf("%w: pool ID, revision, CPU, memory, and storage are required", ErrInvalidDesiredState)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.progressLocked()
+
+	current, ok := b.pools[desired.Ref.ID]
+	if !ok {
+		current = &pool{}
+		b.pools[desired.Ref.ID] = current
+	}
+	desired.Ref.BackendID = backendID("pool", desired.Ref.ID)
+	if !ok || !reflect.DeepEqual(current.desired, desired) {
+		current.desired = clonePool(desired)
+		current.generation++
+		current.state = agentbackend.StatePending
+		current.readyAt = b.now().Add(b.delay)
+		b.emitLocked(poolEvent(desired.Ref))
+	}
+	return poolObservation(current), nil
+}
+
+func (b *Backend) ObservePool(_ context.Context, ref agentbackend.PoolRef) (agentbackend.PoolObservation, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.progressLocked()
+	current := b.pools[ref.ID]
+	if current == nil {
+		return agentbackend.PoolObservation{Ref: ref}, nil
+	}
+	return poolObservation(current), nil
+}
+
+func (b *Backend) DeletePool(_ context.Context, ref agentbackend.PoolRef) (agentbackend.DeleteResult, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.progressLocked()
+	current := b.pools[ref.ID]
+	if current == nil {
+		return agentbackend.DeleteResult{Complete: true}, nil
+	}
+	for _, sandbox := range b.instances {
+		if sandbox.desired.Pool.ID == ref.ID {
+			return agentbackend.DeleteResult{}, fmt.Errorf("%w: pool still has instances", ErrInvalidDesiredState)
+		}
+	}
+	if current.state != agentbackend.StateDeleting {
+		current.state = agentbackend.StateDeleting
+		current.deleteAt = b.now().Add(b.delay)
+		b.emitLocked(poolEvent(current.desired.Ref))
+	}
+	return agentbackend.DeleteResult{}, nil
+}
+
+func (b *Backend) ReconcileInstance(_ context.Context, desired agentbackend.DesiredInstance) (agentbackend.InstanceObservation, error) {
+	if desired.Ref.ID == "" || desired.Pool.ID == "" || desired.Revision == "" {
+		return agentbackend.InstanceObservation{}, fmt.Errorf("%w: instance ID, pool ID, and revision are required", ErrInvalidDesiredState)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.progressLocked()
+	pool := b.pools[desired.Pool.ID]
+	if pool == nil || pool.state == agentbackend.StateDeleting {
+		return agentbackend.InstanceObservation{}, fmt.Errorf("%w: pool %q does not exist", ErrInvalidDesiredState, desired.Pool.ID)
+	}
+
+	current, ok := b.instances[desired.Ref.ID]
+	if !ok && pool.desired.Suspended {
+		return errorInstanceObservation(desired.Ref, "PoolSuspended", "the pool does not permit new instances"), nil
+	}
+	desired.Ref.BackendID = backendID("instance", desired.Ref.ID)
+	desired.Pool.BackendID = pool.desired.Ref.BackendID
+	if !ok {
+		current = &instance{url: "fake://hosted-agent/" + desired.Ref.ID}
+		b.instances[desired.Ref.ID] = current
+	}
+	if !ok || !reflect.DeepEqual(current.desired, desired) {
+		if pool.desired.Suspended {
+			if !ok || current.state != agentbackend.StateReady {
+				return errorInstanceObservation(desired.Ref, "PoolSuspended", "the pool does not permit instance starts"), nil
+			}
+			// Preserve the running sandbox without restarting it. Its observed
+			// revision remains old until the pool is resumed.
+			return instanceObservation(current), nil
+		}
+		current.desired = cloneInstance(desired)
+		current.generation++
+		current.state = agentbackend.StatePending
+		current.readyAt = b.now().Add(b.delay)
+		b.emitLocked(instanceEvent(desired.Ref))
+	}
+	return instanceObservation(current), nil
+}
+
+func (b *Backend) ObserveInstance(_ context.Context, ref agentbackend.InstanceRef) (agentbackend.InstanceObservation, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.progressLocked()
+	current := b.instances[ref.ID]
+	if current == nil {
+		return agentbackend.InstanceObservation{Ref: ref}, nil
+	}
+	return instanceObservation(current), nil
+}
+
+func (b *Backend) DeleteInstance(_ context.Context, ref agentbackend.InstanceRef) (agentbackend.DeleteResult, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.progressLocked()
+	current := b.instances[ref.ID]
+	if current == nil {
+		return agentbackend.DeleteResult{Complete: true}, nil
+	}
+	if current.state != agentbackend.StateDeleting {
+		current.state = agentbackend.StateDeleting
+		current.deleteAt = b.now().Add(b.delay)
+		b.emitLocked(instanceEvent(current.desired.Ref))
+	}
+	return agentbackend.DeleteResult{}, nil
+}
+
+func (b *Backend) GetPoolUtilization(_ context.Context, ref agentbackend.PoolRef) (agentbackend.UtilizationSnapshot, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.progressLocked()
+	pool := b.pools[ref.ID]
+	if pool == nil {
+		return agentbackend.UtilizationSnapshot{}, fmt.Errorf("%w: pool %q does not exist", ErrInvalidDesiredState, ref.ID)
+	}
+	var result agentbackend.UtilizationSnapshot
+	result.Timestamp = b.now()
+	for _, sandbox := range b.instances {
+		if sandbox.desired.Pool.ID != ref.ID || sandbox.state == agentbackend.StateDeleting {
+			continue
+		}
+		ordinal := float64((sandbox.generation%5)+1) / 10
+		usage := agentbackend.ResourceUtilization{
+			CPUVCPUs:     min(pool.desired.Capacity.CPUVCPUs, ordinal),
+			MemoryBytes:  min(pool.desired.Capacity.MemoryBytes, int64(ordinal*float64(pool.desired.Capacity.MemoryBytes))),
+			StorageBytes: min(pool.desired.Capacity.StorageBytes, int64(ordinal*float64(pool.desired.Capacity.StorageBytes))),
+		}
+		result.Instances = append(result.Instances, agentbackend.InstanceUtilization{
+			Ref: sandbox.desired.Ref, State: sandbox.state, Utilization: usage,
+		})
+		result.Pool.CPUVCPUs += usage.CPUVCPUs
+		result.Pool.MemoryBytes += usage.MemoryBytes
+		result.Pool.StorageBytes += usage.StorageBytes
+	}
+	result.Pool.CPUVCPUs = min(result.Pool.CPUVCPUs, pool.desired.Capacity.CPUVCPUs)
+	result.Pool.MemoryBytes = min(result.Pool.MemoryBytes, pool.desired.Capacity.MemoryBytes)
+	result.Pool.StorageBytes = min(result.Pool.StorageBytes, pool.desired.Capacity.StorageBytes)
+	sort.Slice(result.Instances, func(i, j int) bool { return result.Instances[i].Ref.ID < result.Instances[j].Ref.ID })
+	return result, nil
+}
+
+func (b *Backend) Subscribe(ctx context.Context, handler func(context.Context, agentbackend.Event) error) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event := <-b.events:
+			if err := handler(ctx, event); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (b *Backend) progressLocked() {
+	now := b.now()
+	for id, current := range b.instances {
+		switch {
+		case current.state == agentbackend.StateDeleting && !now.Before(current.deleteAt):
+			delete(b.instances, id)
+			b.emitLocked(instanceEvent(current.desired.Ref))
+		case current.state == agentbackend.StatePending && !now.Before(current.readyAt):
+			current.state = agentbackend.StateReady
+			current.urlReady = true
+			b.emitLocked(instanceEvent(current.desired.Ref))
+		}
+	}
+	for id, current := range b.pools {
+		switch {
+		case current.state == agentbackend.StateDeleting && !now.Before(current.deleteAt):
+			delete(b.pools, id)
+			b.emitLocked(poolEvent(current.desired.Ref))
+		case current.state == agentbackend.StatePending && !now.Before(current.readyAt):
+			current.state = agentbackend.StateReady
+			b.emitLocked(poolEvent(current.desired.Ref))
+		}
+	}
+}
+
+func (b *Backend) emitLocked(event agentbackend.Event) {
+	select {
+	case b.events <- event:
+	default:
+		// Events are hints; polling remains the reliability path.
+	}
+}
+
+func backendID(kind, id string) string { return "fake-" + kind + "-" + id }
+func generation(value int64) string    { return strconv.FormatInt(value, 10) }
+
+func poolObservation(value *pool) agentbackend.PoolObservation {
+	return agentbackend.PoolObservation{
+		Ref: value.desired.Ref, Exists: true, ObservedRevision: observedRevision(value.state, value.desired.Revision),
+		State: value.state, Schedulable: value.state == agentbackend.StateReady && !value.desired.Suspended,
+		Capacity: value.desired.Capacity, BackendGeneration: generation(value.generation),
+	}
+}
+
+func instanceObservation(value *instance) agentbackend.InstanceObservation {
+	url := ""
+	if value.urlReady {
+		url = value.url
+	}
+	return agentbackend.InstanceObservation{
+		Ref: value.desired.Ref, Exists: true, ObservedRevision: observedRevision(value.state, value.desired.Revision),
+		State: value.state, URL: url, BackendGeneration: generation(value.generation),
+	}
+}
+
+func errorInstanceObservation(ref agentbackend.InstanceRef, reason, message string) agentbackend.InstanceObservation {
+	return agentbackend.InstanceObservation{
+		Ref: ref, State: agentbackend.StateError, Reason: reason, Message: message,
+	}
+}
+
+func observedRevision(state agentbackend.State, revision string) string {
+	if state == agentbackend.StateReady {
+		return revision
+	}
+	return ""
+}
+
+func poolEvent(ref agentbackend.PoolRef) agentbackend.Event {
+	return agentbackend.Event{Kind: agentbackend.ResourceKindPool, Pool: ref}
+}
+
+func instanceEvent(ref agentbackend.InstanceRef) agentbackend.Event {
+	return agentbackend.Event{Kind: agentbackend.ResourceKindInstance, Instance: ref}
+}
+
+func clonePool(value agentbackend.DesiredPool) agentbackend.DesiredPool {
+	return value
+}
+
+func cloneInstance(value agentbackend.DesiredInstance) agentbackend.DesiredInstance {
+	value.Prompt = append([]string(nil), value.Prompt...)
+	value.Files = append([]agentbackend.File(nil), value.Files...)
+	for i := range value.Files {
+		value.Files[i].Content = append([]byte(nil), value.Files[i].Content...)
+	}
+	value.Secrets = append([]agentbackend.SecretRef(nil), value.Secrets...)
+	if value.Env != nil {
+		env := make(map[string]string, len(value.Env))
+		for key, item := range value.Env {
+			env[key] = item
+		}
+		value.Env = env
+	}
+	return value
+}

--- a/pkg/agentbackend/fake/backend_test.go
+++ b/pkg/agentbackend/fake/backend_test.go
@@ -1,0 +1,167 @@
+package fake
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+)
+
+func TestBackendLifecycleAndOpaqueRevision(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	backend := New(Config{TransitionDelay: time.Second, Now: func() time.Time { return now }})
+	ctx := context.Background()
+	pool := desiredPool()
+
+	observed, err := backend.ReconcilePool(ctx, pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.State != agentbackend.StatePending || observed.Ref.BackendID != "fake-pool-a1" {
+		t.Fatalf("unexpected pool observation: %#v", observed)
+	}
+	now = now.Add(time.Second)
+	observed, err = backend.ObservePool(ctx, pool.Ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.State != agentbackend.StateReady || observed.ObservedRevision != "same-key" {
+		t.Fatalf("pool did not become ready: %#v", observed)
+	}
+
+	instance := desiredInstance()
+	instanceObserved, err := backend.ReconcileInstance(ctx, instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instanceObserved.State != agentbackend.StatePending || instanceObserved.Ref.BackendID != "fake-instance-i1" {
+		t.Fatalf("unexpected instance observation: %#v", instanceObserved)
+	}
+	now = now.Add(time.Second)
+	instanceObserved, err = backend.ObserveInstance(ctx, instance.Ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instanceObserved.State != agentbackend.StateReady || instanceObserved.ObservedRevision != "same-key" {
+		t.Fatalf("instance did not become ready: %#v", instanceObserved)
+	}
+
+	// A revision is opaque correlation metadata: changed content with the same
+	// key is accepted and advances the backend generation.
+	instance.Name = "changed"
+	instanceObserved, err = backend.ReconcileInstance(ctx, instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if instanceObserved.State != agentbackend.StatePending || instanceObserved.BackendGeneration != "2" {
+		t.Fatalf("same-key update was not accepted: %#v", instanceObserved)
+	}
+}
+
+func TestBackendAsyncDeletion(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	backend := New(Config{TransitionDelay: time.Second, Now: func() time.Time { return now }})
+	ctx := context.Background()
+	if _, err := backend.ReconcilePool(ctx, desiredPool()); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Second)
+	if _, err := backend.ReconcileInstance(ctx, desiredInstance()); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Second)
+
+	deleted, err := backend.DeleteInstance(ctx, agentbackend.InstanceRef{ID: "i1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted.Complete {
+		t.Fatal("delete completed before the backend resource was gone")
+	}
+	now = now.Add(time.Second)
+	deleted, err = backend.DeleteInstance(ctx, agentbackend.InstanceRef{ID: "i1"})
+	if err != nil || !deleted.Complete {
+		t.Fatalf("instance deletion did not complete: %#v, %v", deleted, err)
+	}
+	deleted, err = backend.DeletePool(ctx, agentbackend.PoolRef{ID: "a1"})
+	if err != nil || deleted.Complete {
+		t.Fatalf("unexpected pool delete result: %#v, %v", deleted, err)
+	}
+	now = now.Add(time.Second)
+	deleted, err = backend.DeletePool(ctx, agentbackend.PoolRef{ID: "a1"})
+	if err != nil || !deleted.Complete {
+		t.Fatalf("pool deletion did not complete: %#v, %v", deleted, err)
+	}
+}
+
+func TestSuspensionAndSyntheticUtilization(t *testing.T) {
+	backend := New(Config{})
+	ctx := context.Background()
+	pool := desiredPool()
+	pool.Suspended = true
+	if _, err := backend.ReconcilePool(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.ObservePool(ctx, pool.Ref); err != nil {
+		t.Fatal(err)
+	}
+	observed, err := backend.ReconcileInstance(ctx, desiredInstance())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.State != agentbackend.StateError || observed.Reason != "PoolSuspended" {
+		t.Fatalf("suspended pool accepted a new instance: %#v", observed)
+	}
+
+	pool.Suspended = false
+	if _, err := backend.ReconcilePool(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.ReconcileInstance(ctx, desiredInstance()); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := backend.GetPoolUtilization(ctx, pool.Ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Instances) != 1 || snapshot.Timestamp.IsZero() ||
+		snapshot.Pool.MemoryBytes > pool.Capacity.MemoryBytes {
+		t.Fatalf("unexpected utilization: %#v", snapshot)
+	}
+}
+
+func TestSecretReferencesAreCopiedWithoutValues(t *testing.T) {
+	backend := New(Config{})
+	ctx := context.Background()
+	pool := desiredPool()
+	if _, err := backend.ReconcilePool(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	instance := desiredInstance()
+	instance.Secrets = []agentbackend.SecretRef{{ID: "secret-1", EnvName: "TOKEN"}}
+	if _, err := backend.ReconcileInstance(ctx, instance); err != nil {
+		t.Fatal(err)
+	}
+	instance.Secrets[0].ID = "mutated"
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if got := backend.instances["i1"].desired.Secrets[0].ID; got != "secret-1" {
+		t.Fatalf("fake backend retained caller-owned secret slice: %q", got)
+	}
+}
+
+func desiredPool() agentbackend.DesiredPool {
+	return agentbackend.DesiredPool{
+		Ref: agentbackend.PoolRef{ID: "a1"}, Revision: "same-key",
+		Capacity: agentbackend.ResourceQuantity{CPUVCPUs: 2, MemoryBytes: 1024, StorageBytes: 2048},
+	}
+}
+
+func desiredInstance() agentbackend.DesiredInstance {
+	return agentbackend.DesiredInstance{
+		Ref:      agentbackend.InstanceRef{ID: "i1", UserID: "u1"},
+		Pool:     agentbackend.PoolRef{ID: "a1"},
+		Revision: "same-key", Name: "agent",
+	}
+}

--- a/pkg/agentbackend/sizing.go
+++ b/pkg/agentbackend/sizing.go
@@ -1,0 +1,73 @@
+package agentbackend
+
+const (
+	// MinSandboxMemoryBytes is the smallest memory reservation a sandbox may be
+	// given. Dividing a pool between many sandboxes can produce a share below
+	// what any real agent image needs to start, and such a sandbox schedules
+	// successfully and then dies immediately, which reads as a broken agent
+	// rather than an over-subscribed pool.
+	MinSandboxMemoryBytes int64 = 200 << 20 // 200MB
+
+	// MinSandboxCPUVCPUs keeps a reservation from rounding to zero. CPU is
+	// compressible, so a small share only means a slow sandbox, but a zero
+	// request means no guarantee at all.
+	MinSandboxCPUVCPUs = 0.01
+
+	// DefaultMaxSandboxes applies when a pool does not say. It is a capacity
+	// planning decision, so there is no good universal answer; this only keeps
+	// an unconfigured pool usable.
+	DefaultMaxSandboxes = 10
+)
+
+// SandboxShare divides a pool between its sandboxes.
+//
+// A pool is a shared bucket. Each sandbox reserves an equal fraction of it, so
+// that it can always be scheduled, and may burst to the whole pool when its
+// neighbours are idle. Agents therefore have no size of their own: raising a
+// pool's sandbox count shrinks everyone's guaranteed share and nothing else.
+//
+// This is an approximation of a single shared cgroup, which Kubernetes cannot
+// express across pods. The difference that remains is that reservations are
+// summed against the node, so a pool cannot be oversubscribed as freely as one
+// cgroup would allow.
+//
+// The floors mean effectiveMax can be lower than the configured maximum: once a
+// share would fall below a floor, the pool holds fewer sandboxes than asked
+// for. Returning that, rather than silently admitting sandboxes that cannot
+// run, lets the caller bound the pool by a number that is actually true.
+func SandboxShare(capacity ResourceQuantity, maxSandboxes int) (requests, limits InstanceResources, effectiveMax int) {
+	if maxSandboxes <= 0 {
+		maxSandboxes = DefaultMaxSandboxes
+	}
+
+	limits = InstanceResources{
+		CPUVCPUs:    capacity.CPUVCPUs,
+		MemoryBytes: capacity.MemoryBytes,
+	}
+
+	requests = InstanceResources{
+		CPUVCPUs:    capacity.CPUVCPUs / float64(maxSandboxes),
+		MemoryBytes: capacity.MemoryBytes / int64(maxSandboxes),
+	}
+
+	effectiveMax = maxSandboxes
+	if requests.MemoryBytes < MinSandboxMemoryBytes {
+		requests.MemoryBytes = MinSandboxMemoryBytes
+		effectiveMax = min(effectiveMax, int(capacity.MemoryBytes/MinSandboxMemoryBytes))
+	}
+	if requests.CPUVCPUs < MinSandboxCPUVCPUs {
+		requests.CPUVCPUs = MinSandboxCPUVCPUs
+		effectiveMax = min(effectiveMax, int(capacity.CPUVCPUs/MinSandboxCPUVCPUs))
+	}
+
+	// A pool too small to hold even one sandbox at the floor still reports one,
+	// so the failure surfaces as that sandbox failing to schedule against the
+	// quota rather than as a pool that silently accepts nothing.
+	effectiveMax = max(effectiveMax, 1)
+
+	// A sandbox may never be limited below what it reserves.
+	limits.CPUVCPUs = max(limits.CPUVCPUs, requests.CPUVCPUs)
+	limits.MemoryBytes = max(limits.MemoryBytes, requests.MemoryBytes)
+
+	return requests, limits, effectiveMax
+}

--- a/pkg/agentbackend/sizing_test.go
+++ b/pkg/agentbackend/sizing_test.go
@@ -1,0 +1,80 @@
+package agentbackend
+
+import "testing"
+
+// A pool is a shared bucket: every sandbox reserves an equal fraction and may
+// burst to the whole pool. Agents have no size of their own.
+func TestSandboxShareDividesThePool(t *testing.T) {
+	capacity := ResourceQuantity{CPUVCPUs: 4, MemoryBytes: 16 << 30}
+
+	requests, limits, effectiveMax := SandboxShare(capacity, 8)
+
+	if requests.CPUVCPUs != 0.5 {
+		t.Errorf("request cpu = %v, want 0.5", requests.CPUVCPUs)
+	}
+	if requests.MemoryBytes != 2<<30 {
+		t.Errorf("request memory = %d, want %d", requests.MemoryBytes, int64(2)<<30)
+	}
+	// The ceiling is the whole pool, which is what makes it shared rather than
+	// a set of fixed-size slots.
+	if limits.CPUVCPUs != 4 || limits.MemoryBytes != 16<<30 {
+		t.Errorf("limits = %+v, want the whole pool", limits)
+	}
+	if effectiveMax != 8 {
+		t.Errorf("effectiveMax = %d, want 8", effectiveMax)
+	}
+}
+
+// Dividing a pool too far produces a share below what any agent image needs to
+// start. Such a sandbox schedules and then dies, which reads as a broken agent
+// rather than an oversubscribed pool.
+func TestSandboxShareAppliesMemoryFloor(t *testing.T) {
+	// 4Gi across 100 would be ~41MB each.
+	capacity := ResourceQuantity{CPUVCPUs: 4, MemoryBytes: 4 << 30}
+
+	requests, _, effectiveMax := SandboxShare(capacity, 100)
+
+	if requests.MemoryBytes != MinSandboxMemoryBytes {
+		t.Errorf("request memory = %d, want the floor %d", requests.MemoryBytes, MinSandboxMemoryBytes)
+	}
+	// Once the floor applies, the pool genuinely holds fewer sandboxes than
+	// asked for, and the caller needs the true number to bound the pool by.
+	if want := int((4 << 30) / MinSandboxMemoryBytes); effectiveMax != want {
+		t.Errorf("effectiveMax = %d, want %d", effectiveMax, want)
+	}
+	if effectiveMax >= 100 {
+		t.Error("the floor must reduce how many sandboxes the pool admits")
+	}
+}
+
+func TestSandboxShareNeverReservesMoreThanItAllows(t *testing.T) {
+	// A pool smaller than one floor's worth of memory.
+	capacity := ResourceQuantity{CPUVCPUs: 0.001, MemoryBytes: 50 << 20}
+
+	requests, limits, effectiveMax := SandboxShare(capacity, 4)
+
+	if limits.MemoryBytes < requests.MemoryBytes {
+		t.Errorf("limit %d is below request %d", limits.MemoryBytes, requests.MemoryBytes)
+	}
+	if limits.CPUVCPUs < requests.CPUVCPUs {
+		t.Errorf("limit %v is below request %v", limits.CPUVCPUs, requests.CPUVCPUs)
+	}
+	// Reporting zero would make the pool silently accept nothing; one sandbox
+	// surfaces the problem as a scheduling failure instead.
+	if effectiveMax < 1 {
+		t.Errorf("effectiveMax = %d, want at least 1", effectiveMax)
+	}
+}
+
+func TestSandboxShareDefaultsMaxSandboxes(t *testing.T) {
+	capacity := ResourceQuantity{CPUVCPUs: 10, MemoryBytes: 100 << 30}
+
+	requests, _, effectiveMax := SandboxShare(capacity, 0)
+
+	if effectiveMax != DefaultMaxSandboxes {
+		t.Errorf("effectiveMax = %d, want %d", effectiveMax, DefaultMaxSandboxes)
+	}
+	if requests.CPUVCPUs != 1 {
+		t.Errorf("request cpu = %v, want 1", requests.CPUVCPUs)
+	}
+}

--- a/pkg/agentbackend/terminal.go
+++ b/pkg/agentbackend/terminal.go
@@ -1,0 +1,45 @@
+package agentbackend
+
+import (
+	"context"
+	"io"
+)
+
+// TerminalBackend is an optional capability: a backend that can attach an
+// interactive session to a running sandbox.
+//
+// It is separate from Backend so that a runtime without a console -- or one
+// that has not implemented it yet -- simply does not satisfy it, and callers
+// discover that with a type assertion rather than through a method that returns
+// "unsupported" at runtime.
+type TerminalBackend interface {
+	// AttachTerminal connects to a sandbox's existing console. It attaches to
+	// the process the sandbox is already running rather than starting a new
+	// one, so an operator sees the same session the agent is driving.
+	//
+	// This requires the sandbox to have been started with a TTY, which is what
+	// a harness marks by being interactive. Attaching to one that was not is an
+	// error rather than a silently empty session.
+	AttachTerminal(ctx context.Context, ref InstanceRef, size TerminalSize) (TerminalSession, error)
+}
+
+// TerminalSize is measured in character cells.
+type TerminalSize struct {
+	Rows uint16
+	Cols uint16
+}
+
+// TerminalSession is a live console.
+//
+// Read yields console output and Write sends input. A console multiplexes what
+// would otherwise be stdout and stderr onto one stream, because that is what a
+// TTY does: the terminal is the process's controlling terminal, and both
+// descriptors point at it. Callers that distinguish the two are reporting their
+// own errors, not the sandbox's.
+type TerminalSession interface {
+	io.ReadWriteCloser
+
+	// Resize tells the sandbox its terminal changed shape. Without it a program
+	// drawing a full-screen interface keeps using the size it saw at startup.
+	Resize(size TerminalSize) error
+}


### PR DESCRIPTION
The rest of Obot asks for a sandbox and gets back its state; where it actually
runs is behind this interface. That keeps Kubernetes types out of the
controllers and the API, so a second backend is a new implementation rather
than a change to everything that calls one.

Three implementations ship: disabled, which is the default and refuses
politely; fake, which transitions on a timer so the UI and the controllers can
be developed and tested without a cluster; and the Kubernetes one that follows.

Sizing is here rather than in a backend because it is policy, not mechanism: a
pool's capacity and an instance's share of it mean the same thing wherever the
sandbox runs.



---

Part 2 of an 11-PR stack. Base: `darren/hosted-agents-01-resource-model`.

## Stack

1. #7448 — Resource model
**→ 2. #7449 — Sandbox backend interface** (this PR)
3. #7450 — Kubernetes sandbox backend
4. #7451 — Sandbox reachability (models + MCP)
5. #7452 — Terminal + HTTP publish
6. #7453 — Server wiring + Helm
7. #7454 — Controllers / reconcilers
8. #7455 — REST API
9. #7456 — Admin UI
10. #7457 — User UI
11. #7458 — Seed default config source

Merge bottom-up; GitHub retargets each child when its parent merges.
