### PR TITLE
feat: run agent sandboxes on Kubernetes (3/11)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -233,6 +233,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/go.sum
+++ b/go.sum
@@ -477,6 +477,8 @@ github.com/moby/moby/api v1.52.0-alpha.1 h1:fzxPD0h6l4LmvPd/rySW7T3G45G8eFTo9qEA
 github.com/moby/moby/api v1.52.0-alpha.1/go.mod h1:MuA35dxT3DVZpImg0ORGCoZtT2dC1jgPjwH9/CQ/afQ=
 github.com/moby/moby/client v0.1.0-alpha.0 h1:1Q393KgwO8L3SznKE+xGZJVDdApgcSM0vIhAEff+acc=
 github.com/moby/moby/client v0.1.0-alpha.0/go.mod h1:pVMvmGeD4P9tbgBtEHZKW993Qkj4d1Nu6qhiW3GGJ6k=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/agentbackend/kubernetes/backend.go
+++ b/pkg/agentbackend/kubernetes/backend.go
@@ -1,0 +1,271 @@
+// Package kubernetes implements the agent runtime backend on top of a
+// Kubernetes cluster.
+//
+// The mapping is:
+//
+//	HostedAgentPool -> a PriorityClass, a ResourceQuota scoped to it, and
+//	                         one shared PersistentVolumeClaim
+//	HostedAgentInstance   -> a Deployment, a Service, and a Secret, with the
+//	                         pool volume mounted at a per-instance subPath
+//
+// ResourceQuota cannot select on labels, and PriorityClass is the only per-pod
+// attribute its scopeSelector understands. Tagging every sandbox with its
+// pool's PriorityClass is therefore what lets several pools share one
+// namespace. The PriorityClass carries no scheduling intent: every pool uses
+// the same value and never preempts.
+//
+// Sandboxes are Burstable. The quota's requests budget is the pool's
+// capacity, and its limits budget is that capacity multiplied by the overcommit
+// ratio. Co-location happens implicitly: the pool volume binds to whichever
+// node the first sandbox lands on, and the scheduler then confines the rest of
+// the pool to that node.
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/obot-platform/nah/pkg/name"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// revisionAnnotation carries the Obot-supplied desired revision. It is
+	// stored verbatim and reported back as the observed revision.
+	revisionAnnotation = "obot.ai/agent-revision"
+
+	instanceLabel = "obot.ai/hosted-agent-instance"
+	poolLabel     = "obot.ai/hosted-agent-pool"
+	userLabel     = "obot.ai/hosted-agent-user"
+	managedLabel  = "obot.ai/managed-by"
+	managedValue  = "obot-agent-backend"
+
+	// agentContainerName is the sandbox's only container. The terminal attaches
+	// to it by name rather than by position.
+	agentContainerName = "agent"
+
+	workspaceMountPath  = "/workspace"
+	workspaceVolumeName = "workspace"
+	filesVolumePrefix   = "files"
+
+	// poolPriorityValue is shared by every pool. Pools are accounting
+	// boundaries, not scheduling tiers, so they must not preempt one another.
+	poolPriorityValue = 1000
+
+	defaultContainerPort = 8099
+	defaultFSGroup       = 1000
+)
+
+// Options configures the backend. Everything here is deployment-wide; nothing
+// is per-agent or per-user.
+type Options struct {
+	// Namespace holds every sandbox and pool object. One namespace serves all
+	// pools; they are separated by PriorityClass, not by namespace.
+	Namespace string
+	// ClusterDomain is used to build in-cluster service URLs.
+	ClusterDomain string
+	// StorageClassName provisions pool volumes. It should use
+	// volumeBindingMode: WaitForFirstConsumer, which is what confines a pool to
+	// a single node.
+	StorageClassName string
+	// FSGroup owns the per-instance subdirectory on the shared volume.
+	FSGroup int64
+	// PodSecurityLevel must match the Pod Security Admission level enforced on
+	// Namespace. A sandbox that does not satisfy it is refused at admission,
+	// which surfaces as a Deployment whose pod never appears. Empty means
+	// restricted, which is what the Helm chart labels the namespace with.
+	PodSecurityLevel PodSecurityLevel
+	// ImagePullSecrets are attached to every sandbox pod.
+	ImagePullSecrets []string
+	// CleanupImage runs the per-instance volume cleanup job. It needs a shell
+	// and coreutils; any small base image will do.
+	CleanupImage string
+	// ImagePullPolicy controls whether a sandbox image is re-pulled on every
+	// start. Always is right for a mutable tag such as :latest, but refuses an
+	// image that was preloaded into the node rather than published to a
+	// registry -- which is how an air-gapped install, and a developer testing a
+	// locally built harness, supply one. Empty means Always.
+	ImagePullPolicy string
+	// RESTConfig enables live usage reporting through metrics.k8s.io. Without
+	// it, utilization reports committed requests instead of measured usage.
+	RESTConfig *rest.Config
+}
+
+type Backend struct {
+	client       kclient.Client
+	cachedClient kclient.Client
+	opts         Options
+	// usage measures live consumption. It is nil when no metrics source is
+	// configured, in which case utilization falls back to committed requests.
+	usage usageReader
+
+	namespaceOnce sync.Once
+	namespaceRef  *metav1.OwnerReference
+	namespaceErr  error
+}
+
+var (
+	_ agentbackend.Backend = (*Backend)(nil)
+)
+
+func New(client, cachedClient kclient.Client, opts Options) (*Backend, error) {
+	if opts.Namespace == "" {
+		return nil, fmt.Errorf("agent backend namespace is required")
+	}
+	if opts.ClusterDomain == "" {
+		opts.ClusterDomain = "cluster.local"
+	}
+	if opts.FSGroup == 0 {
+		opts.FSGroup = defaultFSGroup
+	}
+	if opts.CleanupImage == "" {
+		opts.CleanupImage = "busybox:1.36"
+	}
+	opts.PodSecurityLevel = ParsePodSecurityLevel(string(opts.PodSecurityLevel))
+	if cachedClient == nil {
+		cachedClient = client
+	}
+	// A missing or unusable metrics source is not fatal: utilization degrades
+	// to committed requests rather than the backend failing to start.
+	usage, err := newMetricsReader(opts.RESTConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Backend{
+		client:       client,
+		cachedClient: cachedClient,
+		opts:         opts,
+		usage:        usage,
+	}, nil
+}
+
+// poolName is the shared name of a pool's PriorityClass, ResourceQuota,
+// and volume. PriorityClasses are cluster-scoped, so this has to be unique
+// across the cluster, not just the namespace.
+func poolName(poolID string) string {
+	return name.SafeConcatName("obot-pool", sanitize(poolID))
+}
+
+func instanceName(instanceID string) string {
+	return name.SafeConcatName("obot-agent", sanitize(instanceID))
+}
+
+func cleanupJobName(instanceID string) string {
+	return name.SafeConcatName("obot-agent-cleanup", sanitize(instanceID))
+}
+
+// sandboxSubdirPattern is the only shape a sandbox's directory on the pool
+// volume may take: a single lowercase DNS label. It admits no dot, no slash and
+// no empty string.
+var sandboxSubdirPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+// sandboxSubdir is the per-instance directory within the shared pool volume.
+// It is the only supported way to derive that name, and every path built from
+// an instance ID must come through here rather than calling sanitize directly.
+//
+// sanitize alone is not enough, because it can return an empty string: an ID of
+// "", "..", "---" or anything else without an alphanumeric reduces to nothing.
+// Both uses of this value make that catastrophic rather than merely wrong. As a
+// mount subPath, empty mounts the pool root into the sandbox, handing one agent
+// every other agent's workspace. As the argument to the cleanup job's rm, empty
+// makes the target "/pool" itself, so deleting one sandbox would erase every
+// sandbox in the pool.
+//
+// A rejected ID therefore fails the operation loudly. That leaves an
+// undeletable instance for an operator to look at, which is the outcome we
+// want when the alternative is destroying a shared volume.
+func sandboxSubdir(instanceID string) (string, error) {
+	subdir := sanitize(instanceID)
+	if !sandboxSubdirPattern.MatchString(subdir) {
+		return "", fmt.Errorf("instance %q does not reduce to a usable pool directory name (got %q): refusing to touch the pool volume", instanceID, subdir)
+	}
+	return subdir, nil
+}
+
+// sanitize reduces an Obot identity to something usable as a DNS label. Obot
+// IDs are already UID- or name-shaped, so this normally only lowercases.
+//
+// It can return an empty string. Anything using the result as a path must go
+// through sandboxSubdir instead.
+func sanitize(id string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(id) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+// namespaceOwner returns an owner reference to the sandbox namespace. A
+// PriorityClass is cluster-scoped and so may only be owned by another
+// cluster-scoped object -- which a Namespace is. This is a backstop for someone
+// deleting the whole namespace; ordinary pool teardown goes through
+// DeletePool.
+func (b *Backend) namespaceOwner(ctx context.Context) (*metav1.OwnerReference, error) {
+	b.namespaceOnce.Do(func() {
+		var namespace corev1.Namespace
+		err := b.client.Get(ctx, kclient.ObjectKey{Name: b.opts.Namespace}, &namespace)
+		if apierrors.IsNotFound(err) {
+			// Hosted agents can be the only Kubernetes feature enabled, in which
+			// case nothing else has created this namespace.
+			created := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: b.opts.Namespace}}
+			if createErr := b.client.Create(ctx, created); createErr != nil && !apierrors.IsAlreadyExists(createErr) {
+				b.namespaceErr = fmt.Errorf("failed to create namespace %s: %w", b.opts.Namespace, createErr)
+				return
+			}
+			err = b.client.Get(ctx, kclient.ObjectKey{Name: b.opts.Namespace}, &namespace)
+		}
+		if err != nil {
+			b.namespaceErr = fmt.Errorf("failed to read namespace %s: %w", b.opts.Namespace, err)
+			return
+		}
+		b.namespaceRef = &metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Name:       namespace.Name,
+			UID:        namespace.UID,
+		}
+	})
+	if b.namespaceErr != nil {
+		// Don't cache a transient failure for the life of the process.
+		b.namespaceOnce = sync.Once{}
+		return nil, b.namespaceErr
+	}
+	return b.namespaceRef, nil
+}
+
+func cpuQuantity(vcpus float64) resource.Quantity {
+	return *resource.NewMilliQuantity(int64(vcpus*1000), resource.DecimalSI)
+}
+
+func memoryQuantity(bytes int64) resource.Quantity {
+	return *resource.NewQuantity(bytes, resource.BinarySI)
+}
+
+func poolLabels(poolID string) map[string]string {
+	return map[string]string{
+		managedLabel: managedValue,
+		poolLabel:    sanitize(poolID),
+	}
+}
+
+func ignoreNotFound(err error) error {
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/agentbackend/kubernetes/devproxy.go
+++ b/pkg/agentbackend/kubernetes/devproxy.go
@@ -1,0 +1,45 @@
+package kubernetes
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/client-go/rest"
+)
+
+// DevRoute returns an address and transport that reach a sandbox from outside
+// the cluster, by way of the API server's service proxy.
+//
+// A sandbox is only addressable at a cluster-internal name, which resolves
+// nowhere when Obot runs on a developer's machine. The API server will proxy to
+// a Service on our behalf, so a developer already holding cluster credentials
+// can reach their agent without a port-forward or a tunnel.
+//
+// This is for development only. Reaching a Service this way needs the
+// services/proxy permission, which grants access to every Service in the
+// cluster, not merely agent sandboxes. A production deployment runs Obot inside
+// the cluster where the internal address resolves directly, so it neither needs
+// nor should be granted that permission.
+//
+// The bool reports whether a route could be produced at all; callers fall back
+// to the sandbox's own address when it is false.
+func (b *Backend) DevRoute(backendID string) (string, http.RoundTripper, bool) {
+	if b == nil || b.opts.RESTConfig == nil || backendID == "" {
+		return "", nil, false
+	}
+
+	transport, err := rest.TransportFor(b.opts.RESTConfig)
+	if err != nil {
+		// Without the API server's credentials there is no route; the caller
+		// falls back and reports the real connection failure.
+		return "", nil, false
+	}
+
+	// The scheme prefix selects the Service port by name, which is how the
+	// sandbox Service declares it.
+	target := fmt.Sprintf("%s/api/v1/namespaces/%s/services/http:%s:80/proxy",
+		strings.TrimSuffix(b.opts.RESTConfig.Host, "/"), b.opts.Namespace, backendID)
+
+	return target, transport, true
+}

--- a/pkg/agentbackend/kubernetes/instance.go
+++ b/pkg/agentbackend/kubernetes/instance.go
@@ -1,0 +1,684 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"slices"
+
+	"github.com/obot-platform/nah/pkg/apply"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (b *Backend) ReconcileInstance(ctx context.Context, desired agentbackend.DesiredInstance) (agentbackend.InstanceObservation, error) {
+	if desired.Ref.ID == "" {
+		return agentbackend.InstanceObservation{}, fmt.Errorf("instance ID is required")
+	}
+	if desired.Pool.ID == "" {
+		return agentbackend.InstanceObservation{}, fmt.Errorf("pool ID is required")
+	}
+	if desired.Revision == "" {
+		return agentbackend.InstanceObservation{}, fmt.Errorf("instance revision is required")
+	}
+	if desired.Image == "" {
+		return agentbackend.InstanceObservation{}, fmt.Errorf("instance image is required")
+	}
+
+	// A sandbox cannot outlive its pool, and creating one against a missing or
+	// suspended pool would leave a Deployment that can never schedule a pod.
+	pool, err := b.ObservePool(ctx, desired.Pool)
+	if err != nil {
+		return agentbackend.InstanceObservation{}, err
+	}
+	if !pool.Exists {
+		return agentbackend.InstanceObservation{}, fmt.Errorf("pool %s does not exist", desired.Pool.ID)
+	}
+	if !pool.Schedulable {
+		return errorObservation(desired.Ref, "PoolSuspended", "the pool does not admit new sandboxes"), nil
+	}
+
+	objs, err := b.instanceObjects(desired)
+	if err != nil {
+		return agentbackend.InstanceObservation{}, err
+	}
+	if err := b.applyInstance(ctx, desired.Ref.ID, objs...); err != nil {
+		return agentbackend.InstanceObservation{}, err
+	}
+
+	return b.ObserveInstance(ctx, desired.Ref)
+}
+
+func (b *Backend) ObserveInstance(ctx context.Context, ref agentbackend.InstanceRef) (agentbackend.InstanceObservation, error) {
+	if ref.ID == "" {
+		return agentbackend.InstanceObservation{}, fmt.Errorf("instance ID is required")
+	}
+
+	observation := agentbackend.InstanceObservation{Ref: ref}
+	name := instanceName(ref.ID)
+
+	var deployment appsv1.Deployment
+	if err := b.cachedClient.Get(ctx, kclient.ObjectKey{Name: name, Namespace: b.opts.Namespace}, &deployment); apierrors.IsNotFound(err) {
+		observation.State = agentbackend.StatePending
+		return observation, nil
+	} else if err != nil {
+		return agentbackend.InstanceObservation{}, fmt.Errorf("failed to read sandbox %s: %w", ref.ID, err)
+	}
+
+	observation.Ref.BackendID = name
+	observation.Exists = true
+	// The applied revision is reported regardless of health. Obot compares it
+	// against the desired revision to decide whether it still needs to write,
+	// and reads State separately to decide whether the sandbox is usable.
+	observation.ObservedRevision = deployment.Annotations[revisionAnnotation]
+	observation.BackendGeneration = fmt.Sprintf("%d", deployment.Generation)
+	// An agent with no port serves nothing, so publishing an address for it
+	// would offer a link that cannot work.
+	if hasServicePort(&deployment) {
+		observation.URL = b.instanceURL(name)
+	}
+
+	pods, err := b.instancePods(ctx, ref.ID)
+	if err != nil {
+		return agentbackend.InstanceObservation{}, err
+	}
+
+	state, reason, message := classifyDeployment(&deployment, pods)
+	observation.State = state
+	observation.Reason = reason
+	observation.Message = message
+	if state != agentbackend.StateReady {
+		// Only advertise the URL once something is actually listening on it.
+		observation.URL = ""
+	}
+	return observation, nil
+}
+
+// DeleteInstance removes the sandbox and then erases its directory on the
+// shared pool volume. kubelet never cleans up a subPath directory, so without
+// this every deleted sandbox would leak its workspace.
+//
+// The cleanup job is created before the workload is pruned, because it is the
+// only place the pool identity survives: InstanceRef does not carry the
+// pool, and the Deployment that does is about to be deleted.
+func (b *Backend) DeleteInstance(ctx context.Context, ref agentbackend.InstanceRef) (agentbackend.DeleteResult, error) {
+	if ref.ID == "" {
+		return agentbackend.DeleteResult{}, fmt.Errorf("instance ID is required")
+	}
+
+	var job batchv1.Job
+	err := b.client.Get(ctx, kclient.ObjectKey{Name: cleanupJobName(ref.ID), Namespace: b.opts.Namespace}, &job)
+	switch {
+	case err == nil:
+		return b.finishCleanup(ctx, ref, &job)
+	case !apierrors.IsNotFound(err):
+		return agentbackend.DeleteResult{}, fmt.Errorf("failed to read cleanup job for sandbox %s: %w", ref.ID, err)
+	}
+
+	var deployment appsv1.Deployment
+	if err := b.client.Get(ctx, kclient.ObjectKey{Name: instanceName(ref.ID), Namespace: b.opts.Namespace}, &deployment); apierrors.IsNotFound(err) {
+		// Nothing left to identify a pool with. Prune anything that survived and
+		// treat an already absent sandbox as deleted.
+		return agentbackend.DeleteResult{Complete: true}, b.applyInstance(ctx, ref.ID)
+	} else if err != nil {
+		return agentbackend.DeleteResult{}, fmt.Errorf("failed to read sandbox %s: %w", ref.ID, err)
+	}
+
+	poolID := deployment.Labels[poolLabel]
+	if poolID == "" {
+		return agentbackend.DeleteResult{}, fmt.Errorf("sandbox %s has no pool label; cannot locate its pool volume", ref.ID)
+	}
+
+	cleanup, err := b.cleanupJob(ref.ID, poolID)
+	if err != nil {
+		return agentbackend.DeleteResult{}, err
+	}
+	if err := b.client.Create(ctx, cleanup); err != nil && !apierrors.IsAlreadyExists(err) {
+		return agentbackend.DeleteResult{}, fmt.Errorf("failed to create cleanup job for sandbox %s: %w", ref.ID, err)
+	}
+
+	// Stop the agent now that cleanup is recorded, so it is not writing to the
+	// directory the job is about to remove.
+	if err := b.applyInstance(ctx, ref.ID); err != nil {
+		return agentbackend.DeleteResult{}, err
+	}
+	return agentbackend.DeleteResult{}, nil
+}
+
+func (b *Backend) finishCleanup(ctx context.Context, ref agentbackend.InstanceRef, job *batchv1.Job) (agentbackend.DeleteResult, error) {
+	for _, condition := range job.Status.Conditions {
+		if condition.Status != corev1.ConditionTrue {
+			continue
+		}
+		switch condition.Type {
+		case batchv1.JobComplete:
+			if err := b.applyInstance(ctx, ref.ID); err != nil {
+				return agentbackend.DeleteResult{}, err
+			}
+			policy := metav1.DeletePropagationBackground
+			if err := ignoreNotFound(b.client.Delete(ctx, job, &kclient.DeleteOptions{PropagationPolicy: &policy})); err != nil {
+				return agentbackend.DeleteResult{}, fmt.Errorf("failed to remove cleanup job for sandbox %s: %w", ref.ID, err)
+			}
+			return agentbackend.DeleteResult{Complete: true}, nil
+		case batchv1.JobFailed:
+			// Keep the job so its logs remain available, and let the controller
+			// retry. Obot holds the finalizer, so nothing is orphaned meanwhile.
+			return agentbackend.DeleteResult{}, fmt.Errorf("cleanup job for sandbox %s failed: %s", ref.ID, condition.Message)
+		}
+	}
+	return agentbackend.DeleteResult{}, nil
+}
+
+func (b *Backend) applyInstance(ctx context.Context, instanceID string, objs ...kclient.Object) error {
+	err := apply.New(b.client).
+		WithNamespace(b.opts.Namespace).
+		WithOwnerSubContext("agent-instance-"+sanitize(instanceID)).
+		WithPruneTypes(
+			new(corev1.Secret),
+			new(appsv1.Deployment),
+			new(corev1.Service),
+		).
+		Apply(ctx, nil, objs...)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to apply sandbox objects for instance %s: %w", instanceID, err)
+	}
+	return nil
+}
+
+func (b *Backend) instancePods(ctx context.Context, instanceID string) ([]corev1.Pod, error) {
+	var pods corev1.PodList
+	if err := b.cachedClient.List(ctx, &pods, kclient.InNamespace(b.opts.Namespace), kclient.MatchingLabels{
+		instanceLabel: sanitize(instanceID),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list pods for sandbox %s: %w", instanceID, err)
+	}
+	return pods.Items, nil
+}
+
+func (b *Backend) instanceURL(name string) string {
+	return fmt.Sprintf("http://%s.%s.svc.%s", name, b.opts.Namespace, b.opts.ClusterDomain)
+}
+
+func (b *Backend) instanceObjects(desired agentbackend.DesiredInstance) ([]kclient.Object, error) {
+	var (
+		name   = instanceName(desired.Ref.ID)
+		pool   = poolName(desired.Pool.ID)
+		labels = map[string]string{
+			managedLabel:  managedValue,
+			instanceLabel: sanitize(desired.Ref.ID),
+			poolLabel:     sanitize(desired.Pool.ID),
+			userLabel:     sanitize(desired.Ref.UserID),
+		}
+		annotations = map[string]string{revisionAnnotation: desired.Revision}
+	)
+
+	// Refused before anything is built: this name is the sandbox's only
+	// separation from the rest of the pool's data.
+	subdir, err := sandboxSubdir(desired.Ref.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	secretData := make(map[string][]byte, len(desired.Env)+len(desired.Files))
+	for key, value := range desired.Env {
+		secretData[key] = []byte(value)
+	}
+	for key, value := range b.builtinEnv(desired) {
+		secretData[key] = []byte(value)
+	}
+
+	// Secret-backed files ride the same mechanism as rendered files, so a
+	// credential lands as a file rather than an environment variable. Agents run
+	// model-directed commands and every subprocess inherits the environment,
+	// which would expose the credential to everything the agent executes.
+	files := slices.Clone(desired.Files)
+	for _, ref := range desired.Secrets {
+		if ref.FilePath == "" {
+			continue
+		}
+		files = append(files, agentbackend.File{
+			Path:    ref.FilePath,
+			Content: []byte(ref.Value),
+			// Group-readable, not owner-only. Secret volume files are owned by
+			// root and the pod's fsGroup, and nothing here runs as root, so
+			// 0400 would leave the agent unable to read its own credential.
+			// Every process in the pod joins fsGroup as a supplementary group,
+			// which is what makes 0440 readable by the agent and no one else.
+			Mode: 0o440,
+		})
+	}
+
+	fileVolumes, fileMounts, err := renderFiles(name, files, secretData)
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := secretRefEnv(desired.Secrets)
+	if err != nil {
+		return nil, err
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   b.opts.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Data: secretData,
+	}
+
+	volumes := append([]corev1.Volume{{
+		Name: workspaceVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pool,
+			},
+		},
+	}}, fileVolumes...)
+
+	mounts := append([]corev1.VolumeMount{{
+		Name:      workspaceVolumeName,
+		MountPath: workspaceMountPath,
+		// Every sandbox in the pool shares one volume and is separated by
+		// subPath alone. This isolates names, not capacity. An empty subPath
+		// would mount the pool root, so the name is validated rather than
+		// sanitized.
+		SubPath: subdir,
+	}}, fileMounts...)
+
+	podLabels := make(map[string]string, len(labels))
+	for key, value := range labels {
+		podLabels[key] = value
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   b.opts.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{instanceLabel: sanitize(desired.Ref.ID)},
+			},
+			// The pool volume is ReadWriteOnce and the sandbox owns a subPath
+			// within it. A rolling update would briefly run two pods against the
+			// same directory.
+			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+					// Carried on the template as well as the Deployment so a
+					// revision change actually replaces the pod.
+					Annotations: annotations,
+				},
+				Spec: corev1.PodSpec{
+					// Ties the sandbox to its pool's quota. Every pool shares one
+					// priority value, so this expresses accounting, not urgency.
+					PriorityClassName: pool,
+					SecurityContext:   b.podSecurityContext(),
+					Volumes:           volumes,
+					Containers: []corev1.Container{{
+						Name:            agentContainerName,
+						Image:           desired.Image,
+						ImagePullPolicy: b.imagePullPolicy(),
+						WorkingDir:      workspaceMountPath,
+						// The equivalent of `docker run -it`. A shell entrypoint
+						// reads EOF on stdin and exits immediately without both of
+						// these, which surfaces as CrashLoopBackOff.
+						TTY:   desired.Harness.Interactive,
+						Stdin: desired.Harness.Interactive,
+						Ports: containerPorts(desired.Port),
+						Env:   env,
+						EnvFrom: []corev1.EnvFromSource{{
+							SecretRef: &corev1.SecretEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: name},
+							},
+						}},
+						VolumeMounts:    mounts,
+						Resources:       containerResources(desired.Requests, desired.Limits),
+						SecurityContext: b.containerSecurityContext(),
+					}},
+				},
+			},
+		},
+	}
+
+	for _, pullSecret := range b.opts.ImagePullSecrets {
+		deployment.Spec.Template.Spec.ImagePullSecrets = append(
+			deployment.Spec.Template.Spec.ImagePullSecrets,
+			corev1.LocalObjectReference{Name: pullSecret},
+		)
+	}
+
+	objects := []kclient.Object{secret, deployment}
+
+	// An agent that declares no port serves nothing, and a Service with no ports
+	// is rejected outright by the API server. Omitting it is therefore not an
+	// optimisation: including it makes every port-less agent unreconcilable, and
+	// because the Deployment is applied first, the sandbox comes up while its
+	// instance never leaves pending.
+	if len(servicePorts(desired.Port)) > 0 {
+		objects = append(objects, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   b.opts.Namespace,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: corev1.ServiceSpec{
+				Type:     corev1.ServiceTypeClusterIP,
+				Selector: map[string]string{instanceLabel: sanitize(desired.Ref.ID)},
+				Ports:    servicePorts(desired.Port),
+			},
+		})
+	}
+
+	return objects, nil
+}
+
+// containerResources makes the sandbox Burstable: it reserves an equal share of
+// its pool and may burst to the whole pool when neighbours are idle. Both
+// figures are computed from the pool by agentbackend.SandboxShare and carried in
+// desired state, so this only translates them.
+func containerResources(requests, limits agentbackend.InstanceResources) corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    cpuQuantity(requests.CPUVCPUs),
+			corev1.ResourceMemory: memoryQuantity(requests.MemoryBytes),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    cpuQuantity(limits.CPUVCPUs),
+			corev1.ResourceMemory: memoryQuantity(limits.MemoryBytes),
+		},
+	}
+}
+
+func (b *Backend) builtinEnv(desired agentbackend.DesiredInstance) map[string]string {
+	env := map[string]string{
+		"OBOT_AGENT_INSTANCE_ID": desired.Ref.ID,
+		"OBOT_AGENT_USER_ID":     desired.Ref.UserID,
+		"OBOT_AGENT_WORKSPACE":   workspaceMountPath,
+	}
+	if desired.Port > 0 {
+		env["OBOT_AGENT_LISTEN_PORT"] = fmt.Sprintf("%d", desired.Port)
+	}
+	if desired.Name != "" {
+		env["OBOT_AGENT_NAME"] = desired.Name
+	}
+	if desired.ServerURL != "" {
+		// The base every Obot endpoint the agent uses hangs off:
+		// /mcp-connect/{id} for its MCP servers and /api/llm-proxy/... for its
+		// models, both authenticated with the credential file.
+		env["OBOT_URL"] = desired.ServerURL
+	}
+	if desired.Harness.ID != "" {
+		env["OBOT_AGENT_HARNESS_ID"] = desired.Harness.ID
+	}
+	if desired.Source.URL != "" {
+		env["OBOT_AGENT_SOURCE_URL"] = desired.Source.URL
+	}
+	if desired.Source.Revision != "" {
+		env["OBOT_AGENT_SOURCE_REVISION"] = desired.Source.Revision
+	}
+	if desired.Source.Subdir != "" {
+		env["OBOT_AGENT_SOURCE_SUBDIR"] = desired.Source.Subdir
+	}
+	if desired.Model.ID != "" {
+		env["OBOT_AGENT_MODEL_ID"] = desired.Model.ID
+	}
+	if desired.Model.Endpoint != "" {
+		env["OBOT_AGENT_MODEL_ENDPOINT"] = desired.Model.Endpoint
+	}
+	if len(desired.Prompt) > 0 {
+		env["OBOT_AGENT_PROMPT"] = strings.Join(desired.Prompt, "\n")
+	}
+	return env
+}
+
+// renderFiles stores each file in the instance secret and mounts it back at its
+// absolute path. Files are grouped by directory because a secret volume mounts
+// a directory, not a single file.
+func renderFiles(secretName string, files []agentbackend.File, secretData map[string][]byte) ([]corev1.Volume, []corev1.VolumeMount, error) {
+	if len(files) == 0 {
+		return nil, nil, nil
+	}
+
+	byDir := map[string][]corev1.KeyToPath{}
+	for _, file := range files {
+		if !path.IsAbs(file.Path) {
+			return nil, nil, fmt.Errorf("file path %q must be absolute", file.Path)
+		}
+		key := secretKey(file.Path)
+		if _, exists := secretData[key]; exists {
+			return nil, nil, fmt.Errorf("file path %q collides with another file or environment variable", file.Path)
+		}
+		secretData[key] = file.Content
+
+		item := corev1.KeyToPath{Key: key, Path: path.Base(file.Path)}
+		if file.Mode != 0 {
+			item.Mode = ptr(int32(file.Mode))
+		}
+		dir := path.Dir(file.Path)
+		byDir[dir] = append(byDir[dir], item)
+	}
+
+	dirs := make([]string, 0, len(byDir))
+	for dir := range byDir {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	var (
+		volumes []corev1.Volume
+		mounts  []corev1.VolumeMount
+	)
+	for i, dir := range dirs {
+		items := byDir[dir]
+		sort.Slice(items, func(a, b int) bool { return items[a].Path < items[b].Path })
+		volumeName := fmt.Sprintf("%s-%d", filesVolumePrefix, i)
+		volumes = append(volumes, corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+					Items:      items,
+				},
+			},
+		})
+		mounts = append(mounts, corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: dir,
+			ReadOnly:  true,
+		})
+	}
+	return volumes, mounts, nil
+}
+
+// secretKey turns an absolute path into a secret key. Secret keys allow
+// alphanumerics, '-', '_' and '.', so the separator is the only substitution
+// and the mapping stays one-to-one.
+func secretKey(filePath string) string {
+	return strings.ReplaceAll(strings.TrimPrefix(filePath, "/"), "/", "_")
+}
+
+func secretRefEnv(refs []agentbackend.SecretRef) ([]corev1.EnvVar, error) {
+	var env []corev1.EnvVar
+	for _, ref := range refs {
+		if ref.FilePath != "" {
+			// Delivered as a file by instanceObjects.
+			continue
+		}
+		if ref.EnvName == "" {
+			return nil, fmt.Errorf("secret %q has neither a file path nor an environment variable name", ref.ID)
+		}
+		env = append(env, corev1.EnvVar{
+			Name: ref.EnvName,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: ref.ID},
+					Key:                  ref.EnvName,
+				},
+			},
+		})
+	}
+	return env, nil
+}
+
+// cleanupScript erases one sandbox's directory from the shared pool volume.
+//
+// The directory name arrives as an argument rather than interpolated into the
+// script, and is re-checked here even though sandboxSubdir has already
+// validated it. The command is an rm -rf against a volume shared by every
+// sandbox in the pool, so it is worth the cost of refusing to run rather than
+// trusting that no future caller reaches this with an empty or traversing name.
+const cleanupScript = `set -eu
+dir="$1"
+case "$dir" in
+  ''|.|..|*/*|*..*)
+    echo "refusing to remove pool directory: $dir" >&2
+    exit 1
+    ;;
+esac
+rm -rf "/pool/$dir"
+`
+
+func (b *Backend) cleanupJob(instanceID, poolID string) (*batchv1.Job, error) {
+	subdir, err := sandboxSubdir(instanceID)
+	if err != nil {
+		return nil, err
+	}
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cleanupJobName(instanceID),
+			Namespace: b.opts.Namespace,
+			Labels: map[string]string{
+				managedLabel:  managedValue,
+				instanceLabel: subdir,
+				poolLabel:     sanitize(poolID),
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: ptr(int32(4)),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						managedLabel: managedValue,
+						poolLabel:    sanitize(poolID),
+					},
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					// Runs in the pool, so it lands on the node the pool volume is
+					// attached to and counts against the pool's own budget.
+					PriorityClassName: poolName(poolID),
+					SecurityContext:   b.podSecurityContext(),
+					Volumes: []corev1.Volume{{
+						Name: workspaceVolumeName,
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: poolName(poolID),
+							},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name:    "cleanup",
+						Image:   b.opts.CleanupImage,
+						Command: []string{"/bin/sh", "-c"},
+						// The pool root is mounted rather than the subPath, because
+						// the directory itself has to be removed. The subdirectory is
+						// passed as $1 so that no part of it is ever parsed as shell.
+						Args: []string{cleanupScript, "obot-cleanup", subdir},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      workspaceVolumeName,
+							MountPath: "/pool",
+						}},
+						// Once a quota constrains a resource, every pod in its scope
+						// must declare both a request and a limit for it. This job
+						// runs in the pool, so omitting them makes the quota reject
+						// it forever and deletion never completes.
+						Resources:       cleanupResources(),
+						SecurityContext: b.containerSecurityContext(),
+					}},
+				},
+			},
+		},
+	}, nil
+}
+
+// cleanupResources keeps the job small and Guaranteed. Deleting a sandbox must
+// not be blocked by a pool that is close to its budget, so this asks for as
+// little as is practical.
+func cleanupResources() corev1.ResourceRequirements {
+	cpu := cpuQuantity(0.01)
+	memory := memoryQuantity(64 << 20)
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: cpu, corev1.ResourceMemory: memory},
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: cpu, corev1.ResourceMemory: memory},
+	}
+}
+
+// hasServicePort reports whether the sandbox declares an HTTP port, read back
+// from the applied Deployment so observation does not need desired state.
+func hasServicePort(deployment *appsv1.Deployment) bool {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if len(container.Ports) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// containerPorts declares the agent's HTTP port. An agent that serves nothing
+// declares no port, so nothing suggests it is reachable.
+func containerPorts(port int) []corev1.ContainerPort {
+	if port <= 0 {
+		return nil
+	}
+	return []corev1.ContainerPort{{Name: "http", ContainerPort: int32(port)}}
+}
+
+func servicePorts(port int) []corev1.ServicePort {
+	if port <= 0 {
+		return nil
+	}
+	return []corev1.ServicePort{{
+		Name:       "http",
+		Port:       80,
+		TargetPort: intstr.FromString("http"),
+	}}
+}
+
+func errorObservation(ref agentbackend.InstanceRef, reason, message string) agentbackend.InstanceObservation {
+	return agentbackend.InstanceObservation{
+		Ref:     ref,
+		State:   agentbackend.StateError,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
+// imagePullPolicy resolves the configured policy, defaulting to Always so a
+// mutable tag is re-pulled on every start.
+func (b *Backend) imagePullPolicy() corev1.PullPolicy {
+	switch corev1.PullPolicy(b.opts.ImagePullPolicy) {
+	case corev1.PullIfNotPresent:
+		return corev1.PullIfNotPresent
+	case corev1.PullNever:
+		return corev1.PullNever
+	default:
+		return corev1.PullAlways
+	}
+}

--- a/pkg/agentbackend/kubernetes/integration_test.go
+++ b/pkg/agentbackend/kubernetes/integration_test.go
@@ -1,0 +1,370 @@
+// These tests run against a real cluster. They skip unless
+// OBOT_AGENT_INTEGRATION_KUBECONFIG names one:
+//
+//	OBOT_AGENT_INTEGRATION_KUBECONFIG=~/.kube/config \
+//	  go test ./pkg/agentbackend/kubernetes/ -run TestIntegration -v
+//
+// A dedicated variable rather than KUBECONFIG is deliberate: these tests create
+// and delete a namespace, and must never fire against whatever cluster a
+// developer happens to have configured. They are not build-tagged so that they
+// keep compiling as part of the normal test run.
+//
+// They cover what a unit test cannot: whether apply handles a cluster-scoped
+// PriorityClass alongside namespaced objects, whether a Namespace owner
+// reference is accepted, and whether a quota scoped to a PriorityClass really
+// rejects an over-budget sandbox.
+package kubernetes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testNamespace = "obot-agent-integration"
+	// pause stays running with no arguments, which the contract needs because
+	// DesiredInstance carries an image but no command.
+	pauseImage = "registry.k8s.io/pause:3.9"
+)
+
+func testClient(t *testing.T) kclient.Client {
+	t.Helper()
+
+	kubeconfig := os.Getenv("OBOT_AGENT_INTEGRATION_KUBECONFIG")
+	if kubeconfig == "" {
+		t.Skip("set OBOT_AGENT_INTEGRATION_KUBECONFIG to a kubeconfig to run agent backend integration tests")
+	}
+	if strings.HasPrefix(kubeconfig, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Fatalf("locate home directory: %v", err)
+		}
+		kubeconfig = filepath.Join(home, kubeconfig[2:])
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("build rest config from %s: %v", kubeconfig, err)
+	}
+	client, err := kclient.New(config, kclient.Options{Scheme: k8sscheme.Scheme})
+	if err != nil {
+		t.Fatalf("build client: %v", err)
+	}
+	return client
+}
+
+func setup(t *testing.T, opts Options) (*Backend, kclient.Client, context.Context) {
+	t.Helper()
+
+	client := testClient(t)
+	ctx := t.Context()
+
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+	if err := client.Create(ctx, namespace); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create namespace: %v", err)
+	}
+
+	opts.Namespace = testNamespace
+	// The live client doubles as the cache here; informer behaviour is a
+	// separate concern from the object semantics these tests cover.
+	backend, err := New(client, client, opts)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return backend, client, ctx
+}
+
+func eventually(t *testing.T, timeout time.Duration, describe string, condition func() (bool, string)) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		ok, detail := condition()
+		if ok {
+			return
+		}
+		last = detail
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("timed out waiting for %s: %s", describe, last)
+}
+
+func smallPool(id string) agentbackend.DesiredPool {
+	return agentbackend.DesiredPool{
+		Ref:      agentbackend.PoolRef{ID: id},
+		Revision: "rev-1",
+		Capacity: agentbackend.ResourceQuantity{
+			CPUVCPUs:     2,
+			MemoryBytes:  2 << 30,
+			StorageBytes: 1 << 30,
+		},
+		MaxSandboxes: 4,
+	}
+}
+
+func TestIntegrationPoolLifecycle(t *testing.T) {
+	backend, client, ctx := setup(t, Options{})
+	desired := smallPool("alloc-lifecycle")
+	t.Cleanup(func() {
+		_, _ = backend.DeletePool(context.Background(), desired.Ref)
+	})
+
+	observation, err := backend.ReconcilePool(ctx, desired)
+	if err != nil {
+		t.Fatalf("ReconcilePool: %v", err)
+	}
+	if !observation.Exists {
+		t.Fatal("expected the pool to exist after reconcile")
+	}
+	if observation.ObservedRevision != desired.Revision {
+		t.Errorf("observed revision = %q, want %q", observation.ObservedRevision, desired.Revision)
+	}
+	if !observation.Schedulable {
+		t.Errorf("expected a fresh pool to be schedulable, got %s: %s", observation.Reason, observation.Message)
+	}
+
+	// A cluster-scoped PriorityClass owned by a Namespace is the load-bearing
+	// assumption behind sharing one namespace across pools. The API server
+	// rejects an invalid owner reference outright.
+	var priorityClass schedulingv1.PriorityClass
+	if err := client.Get(ctx, kclient.ObjectKey{Name: poolName(desired.Ref.ID)}, &priorityClass); err != nil {
+		t.Fatalf("read PriorityClass: %v", err)
+	}
+	if len(priorityClass.OwnerReferences) != 1 || priorityClass.OwnerReferences[0].Kind != "Namespace" {
+		t.Errorf("expected a Namespace owner reference, got %+v", priorityClass.OwnerReferences)
+	}
+	if priorityClass.PreemptionPolicy == nil || *priorityClass.PreemptionPolicy != corev1.PreemptNever {
+		t.Error("pool priority classes must never preempt")
+	}
+
+	var quota corev1.ResourceQuota
+	if err := client.Get(ctx, kclient.ObjectKey{Name: poolName(desired.Ref.ID), Namespace: testNamespace}, &quota); err != nil {
+		t.Fatalf("read ResourceQuota: %v", err)
+	}
+	if quota.Spec.ScopeSelector == nil || len(quota.Spec.ScopeSelector.MatchExpressions) != 1 {
+		t.Fatalf("expected a PriorityClass scope selector, got %+v", quota.Spec.ScopeSelector)
+	}
+
+	// Reconciling the same revision must not churn the objects.
+	generation := quota.Generation
+	if _, err := backend.ReconcilePool(ctx, desired); err != nil {
+		t.Fatalf("second ReconcilePool: %v", err)
+	}
+	if err := client.Get(ctx, kclient.ObjectKey{Name: poolName(desired.Ref.ID), Namespace: testNamespace}, &quota); err != nil {
+		t.Fatalf("re-read ResourceQuota: %v", err)
+	}
+	if quota.Generation != generation {
+		t.Errorf("reconcile is not idempotent: generation moved %d -> %d", generation, quota.Generation)
+	}
+
+	result, err := backend.DeletePool(ctx, desired.Ref)
+	if err != nil {
+		t.Fatalf("DeletePool: %v", err)
+	}
+	if !result.Complete {
+		t.Error("expected pool deletion to complete synchronously")
+	}
+	if err := client.Get(ctx, kclient.ObjectKey{Name: poolName(desired.Ref.ID)}, &priorityClass); !apierrors.IsNotFound(err) {
+		t.Errorf("expected the PriorityClass to be pruned, got %v", err)
+	}
+}
+
+func TestIntegrationInstanceReachesReady(t *testing.T) {
+	backend, client, ctx := setup(t, Options{})
+	pool := smallPool("alloc-ready")
+	instance := agentbackend.DesiredInstance{
+		Ref:      agentbackend.InstanceRef{ID: "inst-ready", UserID: "user-1"},
+		Pool:     pool.Ref,
+		Revision: "rev-1",
+		Image:    pauseImage,
+		Files: []agentbackend.File{
+			{Path: "/etc/obot/agent.json", Content: []byte(`{"version":"v1"}`), Mode: 0o644},
+		},
+	}
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		for range 60 {
+			result, err := backend.DeleteInstance(cleanupCtx, instance.Ref)
+			if err != nil || result.Complete {
+				break
+			}
+			time.Sleep(time.Second)
+		}
+		_, _ = backend.DeletePool(cleanupCtx, pool.Ref)
+	})
+
+	if _, err := backend.ReconcilePool(ctx, pool); err != nil {
+		t.Fatalf("ReconcilePool: %v", err)
+	}
+	if _, err := backend.ReconcileInstance(ctx, instance); err != nil {
+		t.Fatalf("ReconcileInstance: %v", err)
+	}
+
+	eventually(t, 3*time.Minute, "the sandbox to become ready", func() (bool, string) {
+		observation, err := backend.ObserveInstance(ctx, instance.Ref)
+		if err != nil {
+			return false, err.Error()
+		}
+		if observation.State == agentbackend.StateReady {
+			if observation.ObservedRevision != instance.Revision {
+				t.Errorf("ready with revision %q, want %q", observation.ObservedRevision, instance.Revision)
+			}
+			if observation.URL == "" {
+				t.Error("a ready sandbox must advertise a URL")
+			}
+			return true, ""
+		}
+		return false, string(observation.State) + " " + observation.Reason + ": " + observation.Message
+	})
+
+	// The sandbox has to actually be tagged into its pool, or it escapes quota.
+	var deployment appsv1.Deployment
+	if err := client.Get(ctx, kclient.ObjectKey{Name: instanceName(instance.Ref.ID), Namespace: testNamespace}, &deployment); err != nil {
+		t.Fatalf("read Deployment: %v", err)
+	}
+	if got := deployment.Spec.Template.Spec.PriorityClassName; got != poolName(pool.Ref.ID) {
+		t.Errorf("priorityClassName = %q, want %q", got, poolName(pool.Ref.ID))
+	}
+
+	// Deleting is asynchronous: the workspace directory is erased by a job, and
+	// the finalizer must be held until that finishes.
+	result, err := backend.DeleteInstance(ctx, instance.Ref)
+	if err != nil {
+		t.Fatalf("DeleteInstance: %v", err)
+	}
+	if result.Complete {
+		t.Error("expected deletion to be incomplete while the cleanup job runs")
+	}
+
+	eventually(t, 3*time.Minute, "the cleanup job to finish", func() (bool, string) {
+		result, err := backend.DeleteInstance(ctx, instance.Ref)
+		if err != nil {
+			return false, err.Error()
+		}
+		return result.Complete, "cleanup still running"
+	})
+
+	if err := client.Get(ctx, kclient.ObjectKey{Name: instanceName(instance.Ref.ID), Namespace: testNamespace}, &deployment); !apierrors.IsNotFound(err) {
+		t.Errorf("expected the Deployment to be pruned, got %v", err)
+	}
+}
+
+// A pool bounds how many sandboxes it holds. Sandboxes have no size of their
+// own, so nothing can be individually "too big" -- what the quota stops is the
+// pool being filled past its sandbox count. The rejection surfaces through
+// observation rather than the write, because it lands on the ReplicaSet.
+func TestIntegrationQuotaRejectsSandboxBeyondPoolCount(t *testing.T) {
+	backend, _, ctx := setup(t, Options{})
+	pool := agentbackend.DesiredPool{
+		Ref:      agentbackend.PoolRef{ID: "pool-full"},
+		Revision: "rev-1",
+		Capacity: agentbackend.ResourceQuantity{
+			CPUVCPUs:     1,
+			MemoryBytes:  1 << 30,
+			StorageBytes: 1 << 30,
+		},
+		MaxSandboxes: 1,
+	}
+	first := agentbackend.DesiredInstance{
+		Ref:      agentbackend.InstanceRef{ID: "inst-first", UserID: "user-1"},
+		Pool:     pool.Ref,
+		Revision: "rev-1",
+		Image:    pauseImage,
+	}
+	second := first
+	second.Ref = agentbackend.InstanceRef{ID: "inst-second", UserID: "user-1"}
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		for _, ref := range []agentbackend.InstanceRef{first.Ref, second.Ref} {
+			for range 30 {
+				result, err := backend.DeleteInstance(cleanupCtx, ref)
+				if err != nil || result.Complete {
+					break
+				}
+				time.Sleep(time.Second)
+			}
+		}
+		_, _ = backend.DeletePool(cleanupCtx, pool.Ref)
+	})
+
+	if _, err := backend.ReconcilePool(ctx, pool); err != nil {
+		t.Fatalf("ReconcilePool: %v", err)
+	}
+
+	// Both sandboxes are sized identically from the pool; only the count differs.
+	requests, limits, _ := agentbackend.SandboxShare(pool.Capacity, pool.MaxSandboxes)
+	first.Requests, first.Limits = requests, limits
+	second.Requests, second.Limits = requests, limits
+
+	if _, err := backend.ReconcileInstance(ctx, first); err != nil {
+		t.Fatalf("ReconcileInstance(first): %v", err)
+	}
+	eventually(t, 2*time.Minute, "the first sandbox to become ready", func() (bool, string) {
+		observation, err := backend.ObserveInstance(ctx, first.Ref)
+		if err != nil {
+			return false, err.Error()
+		}
+		return observation.State == agentbackend.StateReady, string(observation.State) + " " + observation.Reason
+	})
+
+	if _, err := backend.ReconcileInstance(ctx, second); err != nil {
+		t.Fatalf("ReconcileInstance(second): %v", err)
+	}
+	eventually(t, 2*time.Minute, "the pool to refuse a sandbox beyond its count", func() (bool, string) {
+		observation, err := backend.ObserveInstance(ctx, second.Ref)
+		if err != nil {
+			return false, err.Error()
+		}
+		if observation.State == agentbackend.StateError {
+			t.Logf("pool full surfaced as %s: %s", observation.Reason, observation.Message)
+			return true, ""
+		}
+		return false, string(observation.State) + " " + observation.Reason
+	})
+}
+
+// Suspending must stop new sandboxes without disturbing the pool's objects.
+func TestIntegrationSuspendedPoolRefusesSandboxes(t *testing.T) {
+	backend, _, ctx := setup(t, Options{})
+	pool := smallPool("alloc-suspended")
+	pool.Suspended = true
+	t.Cleanup(func() {
+		_, _ = backend.DeletePool(context.Background(), pool.Ref)
+	})
+
+	observation, err := backend.ReconcilePool(ctx, pool)
+	if err != nil {
+		t.Fatalf("ReconcilePool: %v", err)
+	}
+	if observation.Schedulable {
+		t.Fatal("a suspended pool must not be schedulable")
+	}
+
+	instanceObservation, err := backend.ReconcileInstance(ctx, agentbackend.DesiredInstance{
+		Ref:      agentbackend.InstanceRef{ID: "inst-suspended"},
+		Pool:     pool.Ref,
+		Revision: "rev-1",
+		Image:    pauseImage,
+	})
+	if err != nil {
+		t.Fatalf("ReconcileInstance: %v", err)
+	}
+	if instanceObservation.State != agentbackend.StateError || instanceObservation.Reason != "PoolSuspended" {
+		t.Fatalf("expected PoolSuspended, got %s/%s", instanceObservation.State, instanceObservation.Reason)
+	}
+}

--- a/pkg/agentbackend/kubernetes/metrics.go
+++ b/pkg/agentbackend/kubernetes/metrics.go
@@ -1,0 +1,171 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+// metricsAPIPath is the standard metrics.k8s.io endpoint, served by
+// metrics-server. It is queried through a raw REST call rather than the typed
+// k8s.io/metrics client so that live usage costs no extra module dependency.
+const metricsAPIPath = "/apis/metrics.k8s.io/v1beta1/namespaces/%s/pods"
+
+// podMetrics is the subset of PodMetrics this package reads.
+type podMetricsList struct {
+	Items []struct {
+		Metadata struct {
+			Name   string            `json:"name"`
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+		Containers []struct {
+			Name  string `json:"name"`
+			Usage struct {
+				CPU    string `json:"cpu"`
+				Memory string `json:"memory"`
+			} `json:"usage"`
+		} `json:"containers"`
+	} `json:"items"`
+}
+
+// usageReader reports live per-pod resource consumption.
+type usageReader interface {
+	// PodUsage returns measured usage keyed by pod name. A nil map with a nil
+	// error means measurement is unavailable, which callers treat as a reason
+	// to fall back rather than as a failure.
+	PodUsage(ctx context.Context, namespace, labelSelector string) (map[string]agentbackend.ResourceUtilization, error)
+	// PoolVolumeUsage returns bytes used on a pool's shared volume. The bool is
+	// false when the figure cannot be trusted to describe the pool alone.
+	PoolVolumeUsage(ctx context.Context, node, namespace, claimName string, claimCapacity int64) (int64, bool, error)
+}
+
+type metricsServerReader struct {
+	client rest.Interface
+}
+
+func newMetricsReader(config *rest.Config) (usageReader, error) {
+	if config == nil {
+		return nil, nil
+	}
+	// Copy: the metrics API is not the core group, and mutating the caller's
+	// config would affect every other client built from it.
+	metricsConfig := rest.CopyConfig(config)
+	metricsConfig.GroupVersion = &schema.GroupVersion{}
+	metricsConfig.APIPath = "/apis"
+	// Required even though every call here uses DoRaw and parses the bytes
+	// itself; UnversionedRESTClientFor refuses to build without one.
+	metricsConfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	client, err := rest.UnversionedRESTClientFor(metricsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("build metrics client: %w", err)
+	}
+	return &metricsServerReader{client: client}, nil
+}
+
+func (m *metricsServerReader) PodUsage(ctx context.Context, namespace, labelSelector string) (map[string]agentbackend.ResourceUtilization, error) {
+	raw, err := m.client.Get().
+		AbsPath(fmt.Sprintf(metricsAPIPath, namespace)).
+		Param("labelSelector", labelSelector).
+		DoRaw(ctx)
+	if err != nil {
+		// metrics-server is optional. Reporting an error here would make
+		// utilization unavailable on clusters that simply do not run it, so an
+		// unreachable metrics API is reported as "no measurement".
+		return nil, nil
+	}
+
+	var list podMetricsList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parse pod metrics: %w", err)
+	}
+
+	usage := make(map[string]agentbackend.ResourceUtilization, len(list.Items))
+	for _, item := range list.Items {
+		var total agentbackend.ResourceUtilization
+		for _, container := range item.Containers {
+			// Quantities arrive in whatever unit metrics-server chose, commonly
+			// nanocores for CPU, so they are parsed rather than assumed.
+			if cpu, err := resource.ParseQuantity(container.Usage.CPU); err == nil {
+				total.CPUVCPUs += float64(cpu.MilliValue()) / 1000
+			}
+			if memory, err := resource.ParseQuantity(container.Usage.Memory); err == nil {
+				total.MemoryBytes += memory.Value()
+			}
+		}
+		usage[item.Metadata.Name] = total
+	}
+	return usage, nil
+}
+
+// statsSummary is the subset of kubelet's /stats/summary this package reads.
+type statsSummary struct {
+	Pods []struct {
+		Volume []struct {
+			UsedBytes     int64 `json:"usedBytes"`
+			CapacityBytes int64 `json:"capacityBytes"`
+			PVCRef        struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"pvcRef"`
+		} `json:"volume"`
+	} `json:"pods"`
+}
+
+// PoolVolumeUsage reports bytes used on a pool's shared volume.
+//
+// Kubelet is the only source for this without deploying a node agent, and it
+// reports the filesystem the volume lives on. For a dedicated volume that is
+// the pool; for a hostPath-backed storage class such as local-path it is the
+// whole node disk, which would show every pool as permanently near-full.
+//
+// claimCapacity is the volume's own capacity, used to tell those apart: a
+// filesystem materially larger than the claim is shared with the host, and its
+// usage says nothing about the pool. Reporting nothing is better than reporting
+// a number that describes someone else's disk.
+func (m *metricsServerReader) PoolVolumeUsage(ctx context.Context, node, namespace, claimName string, claimCapacity int64) (int64, bool, error) {
+	if node == "" || claimName == "" {
+		return 0, false, nil
+	}
+
+	raw, err := m.client.Get().
+		AbsPath(fmt.Sprintf("/api/v1/nodes/%s/proxy/stats/summary", node)).
+		DoRaw(ctx)
+	if err != nil {
+		// Requires nodes/proxy, which a deployment may reasonably withhold.
+		return 0, false, nil
+	}
+
+	var summary statsSummary
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		return 0, false, fmt.Errorf("parse kubelet stats summary: %w", err)
+	}
+
+	for _, pod := range summary.Pods {
+		for _, volume := range pod.Volume {
+			if volume.PVCRef.Name != claimName || volume.PVCRef.Namespace != namespace {
+				continue
+			}
+			if !volumeIsDedicated(volume.CapacityBytes, claimCapacity) {
+				return 0, false, nil
+			}
+			return volume.UsedBytes, true, nil
+		}
+	}
+	return 0, false, nil
+}
+
+// volumeIsDedicated reports whether a filesystem's size is close enough to the
+// claim's to be that claim's own. Provisioners round, so this tolerates a
+// modest overshoot but rejects an order-of-magnitude difference.
+func volumeIsDedicated(filesystemBytes, claimBytes int64) bool {
+	if filesystemBytes <= 0 || claimBytes <= 0 {
+		return false
+	}
+	return filesystemBytes <= claimBytes*2
+}

--- a/pkg/agentbackend/kubernetes/objects_test.go
+++ b/pkg/agentbackend/kubernetes/objects_test.go
@@ -1,0 +1,551 @@
+package kubernetes
+
+import (
+	"encoding/json"
+
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func testBackend(t *testing.T) *Backend {
+	t.Helper()
+	backend, err := New(nil, nil, Options{
+		Namespace:     "obot-agents",
+		ClusterDomain: "cluster.local",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return backend
+}
+
+func desiredInstance() agentbackend.DesiredInstance {
+	return agentbackend.DesiredInstance{
+		Ref:      agentbackend.InstanceRef{ID: "inst-1", UserID: "user-1"},
+		Pool:     agentbackend.PoolRef{ID: "alloc-1"},
+		Revision: "sha256:abc",
+		Image:    "example.com/agent:v1",
+		Requests: agentbackend.InstanceResources{CPUVCPUs: 0.5, MemoryBytes: 1 << 30},
+		Limits:   agentbackend.InstanceResources{CPUVCPUs: 2, MemoryBytes: 4 << 30},
+	}
+}
+
+func deploymentFrom(t *testing.T, objs []kclient.Object) *appsv1.Deployment {
+	t.Helper()
+	for _, obj := range objs {
+		if deployment, ok := obj.(*appsv1.Deployment); ok {
+			return deployment
+		}
+	}
+	t.Fatal("no Deployment in object set")
+	return nil
+}
+
+// The PriorityClass is what ties a sandbox to its pool's ResourceQuota. Without
+// it the sandbox escapes pool accounting entirely, since a quota's scopeSelector
+// cannot match on labels.
+func TestInstanceObjectsTagSandboxWithPoolPriorityClass(t *testing.T) {
+	backend := testBackend(t)
+
+	objs, err := backend.instanceObjects(desiredInstance())
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	deployment := deploymentFrom(t, objs)
+
+	if got := deployment.Spec.Template.Spec.PriorityClassName; got != poolName("alloc-1") {
+		t.Errorf("priorityClassName = %q, want %q", got, poolName("alloc-1"))
+	}
+}
+
+// Sandboxes share one ReadWriteOnce volume and are separated only by subPath, so
+// a rolling update would put two pods on the same directory.
+func TestInstanceObjectsUseRecreateAndSubPath(t *testing.T) {
+	backend := testBackend(t)
+
+	objs, err := backend.instanceObjects(desiredInstance())
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	deployment := deploymentFrom(t, objs)
+
+	if deployment.Spec.Strategy.Type != appsv1.RecreateDeploymentStrategyType {
+		t.Errorf("strategy = %s, want Recreate", deployment.Spec.Strategy.Type)
+	}
+
+	var found bool
+	for _, mount := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if mount.Name == workspaceVolumeName {
+			found = true
+			if mount.SubPath == "" {
+				t.Error("the workspace mount must use a per-instance subPath")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a workspace mount from the pool volume")
+	}
+}
+
+// The revision has to reach the pod template, not just the Deployment, or a
+// configuration change would leave the running pod untouched.
+func TestInstanceObjectsPropagateRevisionToPodTemplate(t *testing.T) {
+	backend := testBackend(t)
+
+	objs, err := backend.instanceObjects(desiredInstance())
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	deployment := deploymentFrom(t, objs)
+
+	if got := deployment.Spec.Template.Annotations[revisionAnnotation]; got != "sha256:abc" {
+		t.Errorf("pod template revision = %q, want sha256:abc", got)
+	}
+	if got := deployment.Annotations[revisionAnnotation]; got != "sha256:abc" {
+		t.Errorf("deployment revision = %q, want sha256:abc", got)
+	}
+}
+
+// A sandbox reserves an equal share of its pool and may burst to the whole
+// pool. Both figures are computed from the pool, so this only translates them.
+func TestContainerResourcesAreBurstable(t *testing.T) {
+	resources := containerResources(
+		agentbackend.InstanceResources{CPUVCPUs: 0.5, MemoryBytes: 1 << 30},
+		agentbackend.InstanceResources{CPUVCPUs: 2, MemoryBytes: 4 << 30},
+	)
+
+	wantRequestCPU := resource.MustParse("500m")
+	if got := resources.Requests[corev1.ResourceCPU]; got.Cmp(wantRequestCPU) != 0 {
+		t.Errorf("request cpu = %s, want %s", got.String(), wantRequestCPU.String())
+	}
+	wantLimitCPU := resource.MustParse("2")
+	if got := resources.Limits[corev1.ResourceCPU]; got.Cmp(wantLimitCPU) != 0 {
+		t.Errorf("limit cpu = %s, want %s", got.String(), wantLimitCPU.String())
+	}
+	if got := resources.Requests[corev1.ResourceMemory]; got.Value() != 1<<30 {
+		t.Errorf("request memory = %d, want %d", got.Value(), int64(1<<30))
+	}
+	if got := resources.Limits[corev1.ResourceMemory]; got.Value() != 4<<30 {
+		t.Errorf("limit memory = %d, want %d", got.Value(), int64(4<<30))
+	}
+}
+
+// Only requests are bounded. Every sandbox may burst to the whole pool, so a
+// limits quota would either reject the second sandbox or enforce nothing.
+func TestQuotaHardBoundsRequestsAndCountOnly(t *testing.T) {
+	hard := quotaHard(agentbackend.DesiredPool{
+		Capacity:     agentbackend.ResourceQuantity{CPUVCPUs: 8, MemoryBytes: 16 << 30},
+		MaxSandboxes: 8,
+	})
+
+	requestCPU := hard[corev1.ResourceRequestsCPU]
+	if requestCPU.MilliValue() != 8000 {
+		t.Errorf("requests.cpu = %s, want 8", requestCPU.String())
+	}
+	if pods := hard[corev1.ResourcePods]; pods.Value() != 8 {
+		t.Errorf("count/pods = %s, want 8", pods.String())
+	}
+	if _, ok := hard[corev1.ResourceLimitsCPU]; ok {
+		t.Error("a limits budget cannot bound a pool whose sandboxes may each use all of it")
+	}
+	if _, ok := hard[corev1.ResourceLimitsMemory]; ok {
+		t.Error("a limits budget cannot bound a pool whose sandboxes may each use all of it")
+	}
+}
+
+// Suspending zeroes the budget so no new sandbox is admitted. Quota is an
+// admission check, so sandboxes already running are unaffected.
+func TestQuotaHardZeroesWhenSuspended(t *testing.T) {
+	hard := quotaHard(agentbackend.DesiredPool{
+		Capacity:     agentbackend.ResourceQuantity{CPUVCPUs: 8, MemoryBytes: 16 << 30},
+		MaxSandboxes: 8,
+		Suspended:    true,
+	})
+
+	for _, key := range []corev1.ResourceName{
+		corev1.ResourceRequestsCPU, corev1.ResourceRequestsMemory, corev1.ResourcePods,
+	} {
+		value := hard[key]
+		if !value.IsZero() {
+			t.Errorf("%s = %s, want 0", key, value.String())
+		}
+	}
+}
+
+func TestRenderFilesGroupsByDirectory(t *testing.T) {
+	secretData := map[string][]byte{}
+	volumes, mounts, err := renderFiles("obot-agent-inst-1", []agentbackend.File{
+		{Path: "/etc/obot/agent.json", Content: []byte("{}"), Mode: 0o644},
+		{Path: "/etc/obot/skills.json", Content: []byte("[]")},
+		{Path: "/opt/config.yaml", Content: []byte("a: b")},
+	}, secretData)
+	if err != nil {
+		t.Fatalf("renderFiles: %v", err)
+	}
+
+	if len(volumes) != 2 || len(mounts) != 2 {
+		t.Fatalf("expected one volume per directory, got %d volumes and %d mounts", len(volumes), len(mounts))
+	}
+	if mounts[0].MountPath != "/etc/obot" || mounts[1].MountPath != "/opt" {
+		t.Errorf("unexpected mount paths: %s, %s", mounts[0].MountPath, mounts[1].MountPath)
+	}
+	if len(volumes[0].Secret.Items) != 2 {
+		t.Errorf("expected both /etc/obot files in one volume, got %d", len(volumes[0].Secret.Items))
+	}
+	if string(secretData["etc_obot_agent.json"]) != "{}" {
+		t.Errorf("file content was not stored under its path-derived key: %v", secretData)
+	}
+	// A secret volume without a secretName is rejected by the API server, not by
+	// anything in this package.
+	for _, volume := range volumes {
+		if volume.Secret.SecretName != "obot-agent-inst-1" {
+			t.Errorf("volume %s has secretName %q, want the instance secret", volume.Name, volume.Secret.SecretName)
+		}
+	}
+}
+
+// A ResourceQuota requires every pod in its scope to declare both a request and
+// a limit for each constrained resource. The cleanup job runs inside the pool,
+// so omitting them makes the quota reject it forever and deletion never
+// completes.
+func TestCleanupJobDeclaresResources(t *testing.T) {
+	backend := testBackend(t)
+
+	job, err := backend.cleanupJob("inst-1", "alloc-1")
+	if err != nil {
+		t.Fatalf("cleanupJob: %v", err)
+	}
+
+	container := job.Spec.Template.Spec.Containers[0]
+	for _, name := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if _, ok := container.Resources.Requests[name]; !ok {
+			t.Errorf("cleanup job is missing a request for %s", name)
+		}
+		if _, ok := container.Resources.Limits[name]; !ok {
+			t.Errorf("cleanup job is missing a limit for %s", name)
+		}
+	}
+	if job.Spec.Template.Spec.PriorityClassName != poolName("alloc-1") {
+		t.Error("the cleanup job must run in the pool so it lands on the pool's node")
+	}
+}
+
+// Every mount must name a volume that exists, or the Deployment is invalid.
+func TestInstanceObjectsMountsResolveToVolumes(t *testing.T) {
+	backend := testBackend(t)
+	desired := desiredInstance()
+	desired.Files = []agentbackend.File{
+		{Path: "/etc/obot/agent.json", Content: []byte("{}")},
+		{Path: "/opt/extra.yaml", Content: []byte("a: b")},
+	}
+
+	objs, err := backend.instanceObjects(desired)
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	deployment := deploymentFrom(t, objs)
+
+	volumes := map[string]corev1.Volume{}
+	for _, volume := range deployment.Spec.Template.Spec.Volumes {
+		volumes[volume.Name] = volume
+	}
+	for _, mount := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		volume, ok := volumes[mount.Name]
+		if !ok {
+			t.Errorf("mount %q at %s has no matching volume", mount.Name, mount.MountPath)
+			continue
+		}
+		if volume.Secret != nil && volume.Secret.SecretName == "" {
+			t.Errorf("volume %q is a secret volume with no secretName", volume.Name)
+		}
+		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == "" {
+			t.Errorf("volume %q is a claim volume with no claimName", volume.Name)
+		}
+	}
+}
+
+func TestRenderFilesRejectsRelativePaths(t *testing.T) {
+	if _, _, err := renderFiles("obot-agent-inst-1", []agentbackend.File{{Path: "agent.json"}}, map[string][]byte{}); err == nil {
+		t.Fatal("expected a relative path to be rejected")
+	}
+}
+
+// A file whose derived key collides with an environment variable would silently
+// overwrite it in the shared secret.
+func TestRenderFilesRejectsCollisionWithEnv(t *testing.T) {
+	secretData := map[string][]byte{"etc_agent.json": []byte("env")}
+	if _, _, err := renderFiles("obot-agent-inst-1", []agentbackend.File{{Path: "/etc/agent.json"}}, secretData); err == nil {
+		t.Fatal("expected a collision with existing secret data to be rejected")
+	}
+}
+
+func TestPoolNamesAreStableAndDistinct(t *testing.T) {
+	if poolName("alloc-1") == poolName("alloc-2") {
+		t.Fatal("distinct pools must not share a pool name")
+	}
+	// Names are the correlation key across reconcile, observe and delete, so an
+	// identity must always map to the same object.
+	first, second := poolName("alloc-1"), poolName("alloc-1")
+	if first != second {
+		t.Fatalf("pool names must be stable: %q then %q", first, second)
+	}
+	// PriorityClasses are cluster-scoped, so pool names have to survive
+	// identities that are not already DNS-safe.
+	if got := poolName("Alloc_1/weird"); got == "" {
+		t.Fatal("expected a usable name from a non-DNS identity")
+	}
+}
+
+// An image whose entrypoint is a shell reads EOF and exits without both a TTY
+// and an open stdin, which surfaces as CrashLoopBackOff rather than as anything
+// pointing at the harness.
+func TestInstanceObjectsHonourInteractiveHarness(t *testing.T) {
+	backend := testBackend(t)
+
+	plain, err := backend.instanceObjects(desiredInstance())
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	container := deploymentFrom(t, plain).Spec.Template.Spec.Containers[0]
+	if container.TTY || container.Stdin {
+		t.Error("a non-interactive harness must not allocate a TTY")
+	}
+
+	desired := desiredInstance()
+	desired.Harness.Interactive = true
+	interactive, err := backend.instanceObjects(desired)
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	container = deploymentFrom(t, interactive).Spec.Template.Spec.Containers[0]
+	if !container.TTY || !container.Stdin {
+		t.Errorf("an interactive harness needs both tty and stdin, got tty=%v stdin=%v", container.TTY, container.Stdin)
+	}
+}
+
+// The identity credential must arrive as a file. Agents execute model-directed
+// commands and every subprocess inherits the environment, so an environment
+// variable would hand the credential to everything the agent runs.
+func TestInstanceObjectsDeliverSecretRefsAsFiles(t *testing.T) {
+	backend := testBackend(t)
+	desired := desiredInstance()
+	desired.Secrets = []agentbackend.SecretRef{{
+		ID:       "inst-1-credential",
+		Version:  "7",
+		Value:    "ok1-1-2-supersecret",
+		FilePath: "/etc/obot/credential",
+	}}
+
+	objs, err := backend.instanceObjects(desired)
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	deployment := deploymentFrom(t, objs)
+
+	for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "OBOT_API_KEY" {
+			t.Error("the credential must not be delivered as an environment variable")
+		}
+	}
+
+	var mounted bool
+	for _, mount := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if mount.MountPath == "/etc/obot" {
+			mounted = true
+		}
+	}
+	if !mounted {
+		t.Error("expected the credential's directory to be mounted")
+	}
+}
+
+// A rotated credential has to restart the sandbox, because agents read theirs
+// once at startup. The value must never reach the revision, but the version
+// must, or the rotation would not propagate.
+func TestRevisionTracksSecretVersionNotValue(t *testing.T) {
+	base := desiredInstance()
+	base.Secrets = []agentbackend.SecretRef{{ID: "c", Version: "1", Value: "secret-one"}}
+
+	sameVersionNewValue := desiredInstance()
+	sameVersionNewValue.Secrets = []agentbackend.SecretRef{{ID: "c", Version: "1", Value: "secret-two"}}
+
+	newVersion := desiredInstance()
+	newVersion.Secrets = []agentbackend.SecretRef{{ID: "c", Version: "2", Value: "secret-one"}}
+
+	if got := base.Redacted().Secrets[0].Value; got != "" {
+		t.Fatalf("Redacted left a secret value in place: %q", got)
+	}
+	if base.Redacted().Secrets[0].Version != "1" {
+		t.Error("Redacted must preserve the version")
+	}
+	// Redaction must not mutate the original, or the caller would lose the value
+	// it still has to deliver.
+	if base.Secrets[0].Value != "secret-one" {
+		t.Error("Redacted mutated its receiver")
+	}
+	if sameVersionNewValue.Redacted().Secrets[0] != base.Redacted().Secrets[0] {
+		t.Error("a value change without a version change must not alter the redacted form")
+	}
+	if newVersion.Redacted().Secrets[0] == base.Redacted().Secrets[0] {
+		t.Error("a version change must alter the redacted form so the revision changes")
+	}
+}
+
+// Live usage is measured per sandbox, but a pod too new to have been sampled --
+// or a cluster with no metrics-server -- must not report as using nothing. A
+// sandbox that exists has reserved its request, so that is the floor.
+func TestPodMetricsParsing(t *testing.T) {
+	reader := &metricsServerReader{}
+	_ = reader // parsing is exercised through the payload below
+
+	var list podMetricsList
+	payload := `{"items":[
+	  {"metadata":{"name":"pod-a"},"containers":[
+	    {"name":"agent","usage":{"cpu":"250m","memory":"128Mi"}}]},
+	  {"metadata":{"name":"pod-b"},"containers":[
+	    {"name":"agent","usage":{"cpu":"1500000000n","memory":"1Gi"}},
+	    {"name":"side","usage":{"cpu":"500m","memory":"64Mi"}}]}
+	]}`
+	if err := json.Unmarshal([]byte(payload), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got := map[string]agentbackend.ResourceUtilization{}
+	for _, item := range list.Items {
+		var total agentbackend.ResourceUtilization
+		for _, c := range item.Containers {
+			if cpu, err := resource.ParseQuantity(c.Usage.CPU); err == nil {
+				total.CPUVCPUs += float64(cpu.MilliValue()) / 1000
+			}
+			if mem, err := resource.ParseQuantity(c.Usage.Memory); err == nil {
+				total.MemoryBytes += mem.Value()
+			}
+		}
+		got[item.Metadata.Name] = total
+	}
+
+	if got["pod-a"].CPUVCPUs != 0.25 {
+		t.Errorf("pod-a cpu = %v, want 0.25", got["pod-a"].CPUVCPUs)
+	}
+	if got["pod-a"].MemoryBytes != 128<<20 {
+		t.Errorf("pod-a memory = %d, want %d", got["pod-a"].MemoryBytes, 128<<20)
+	}
+	// Nanocores are what metrics-server actually emits, and containers sum.
+	if got["pod-b"].CPUVCPUs != 2.0 {
+		t.Errorf("pod-b cpu = %v, want 2.0 (1.5 + 0.5, nanocores parsed)", got["pod-b"].CPUVCPUs)
+	}
+	if want := int64(1<<30) + 64<<20; got["pod-b"].MemoryBytes != want {
+		t.Errorf("pod-b memory = %d, want %d", got["pod-b"].MemoryBytes, want)
+	}
+}
+
+// Kubelet reports the filesystem a volume sits on, not the volume. For a
+// hostPath-backed class such as local-path that is the whole node disk, which
+// would show every pool as permanently near-full -- the same class of mistake
+// as reporting provisioned size as usage.
+func TestVolumeIsDedicated(t *testing.T) {
+	const claim = 20 << 30 // 20Gi
+
+	for _, tt := range []struct {
+		name       string
+		filesystem int64
+		want       bool
+	}{
+		{"exactly the claim", claim, true},
+		{"rounded up by the provisioner", claim + (1 << 30), true},
+		{"host filesystem dwarfs the claim", 1081101176832, false},
+		{"unknown filesystem size", 0, false},
+		{"unknown claim size", claim, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := volumeIsDedicated(tt.filesystem, claim); got != tt.want {
+				t.Errorf("volumeIsDedicated(%d, %d) = %v, want %v", tt.filesystem, claim, got, tt.want)
+			}
+		})
+	}
+
+	if volumeIsDedicated(claim, 0) {
+		t.Error("an unknown claim capacity cannot be judged dedicated")
+	}
+}
+
+// A pool is confined to one node by its ReadWriteOnce volume, so any running
+// pod identifies the node whose kubelet holds the volume stats.
+func TestPoolNodeIgnoresTerminatingPods(t *testing.T) {
+	now := metav1.Now()
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}, Spec: corev1.PodSpec{NodeName: "going-away"}},
+		{Spec: corev1.PodSpec{NodeName: "live-node"}},
+	}
+
+	if got := poolNode(pods); got != "live-node" {
+		t.Errorf("poolNode = %q, want live-node", got)
+	}
+	if got := poolNode(nil); got != "" {
+		t.Errorf("poolNode(nil) = %q, want empty", got)
+	}
+}
+
+func serviceFrom(objs []kclient.Object) *corev1.Service {
+	for _, obj := range objs {
+		if service, ok := obj.(*corev1.Service); ok {
+			return service
+		}
+	}
+	return nil
+}
+
+// A Service with no ports is rejected by the API server, and the Deployment is
+// applied before it -- so shipping one for a port-less agent leaves the sandbox
+// running while its instance never leaves pending, with nothing in status to
+// say why. Every agent that does not serve HTTP is affected, which is most of
+// them.
+func TestInstanceObjectsOmitServiceWithoutPort(t *testing.T) {
+	backend := testBackend(t)
+
+	desired := desiredInstance()
+	desired.Port = 0
+
+	objs, err := backend.instanceObjects(desired)
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	if service := serviceFrom(objs); service != nil {
+		t.Fatalf("expected no Service for a port-less agent, got %q with ports %v",
+			service.Name, service.Spec.Ports)
+	}
+}
+
+// The counterpart: an agent that does declare a port must still be reachable.
+func TestInstanceObjectsIncludeServiceWithPort(t *testing.T) {
+	backend := testBackend(t)
+
+	desired := desiredInstance()
+	desired.Port = 8080
+
+	objs, err := backend.instanceObjects(desired)
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	service := serviceFrom(objs)
+	if service == nil {
+		t.Fatal("expected a Service for an agent that declares a port")
+	}
+	if len(service.Spec.Ports) != 1 || service.Spec.Ports[0].Port != 80 {
+		t.Fatalf("service ports = %v", service.Spec.Ports)
+	}
+	// The Service targets the container port by name, so the two have to agree.
+	deployment := deploymentFrom(t, objs)
+	ports := deployment.Spec.Template.Spec.Containers[0].Ports
+	if len(ports) != 1 || ports[0].Name != service.Spec.Ports[0].TargetPort.StrVal {
+		t.Fatalf("container ports %v do not match service target %v",
+			ports, service.Spec.Ports[0].TargetPort)
+	}
+}

--- a/pkg/agentbackend/kubernetes/podsecurity.go
+++ b/pkg/agentbackend/kubernetes/podsecurity.go
@@ -1,0 +1,100 @@
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PodSecurityLevel is the Pod Security Admission level the sandbox namespace
+// enforces. Sandboxes share that namespace with MCP servers, so a sandbox that
+// does not satisfy the namespace's level is rejected at admission rather than
+// failing later -- the Deployment is created and no pod ever appears.
+//
+// This mirrors the levels the MCP Kubernetes backend applies, and defaults to
+// restricted for the same reason: it is what the Helm chart labels the
+// namespace with unless an operator lowers it.
+type PodSecurityLevel string
+
+const (
+	PodSecurityPrivileged PodSecurityLevel = "privileged"
+	PodSecurityBaseline   PodSecurityLevel = "baseline"
+	PodSecurityRestricted PodSecurityLevel = "restricted"
+
+	// sandboxRunAsUser owns the sandbox's directory on the pool volume. It
+	// matches defaultFSGroup so that a restricted sandbox can write to the
+	// subPath its pod security context makes it the group owner of.
+	sandboxRunAsUser = 1000
+)
+
+// ParsePodSecurityLevel maps configuration to a level, defaulting to
+// restricted. An unrecognized value is treated as restricted rather than
+// rejected: the strict reading is the safe one, and it is also the only one
+// that keeps working when the namespace really is restricted.
+func ParsePodSecurityLevel(level string) PodSecurityLevel {
+	switch PodSecurityLevel(level) {
+	case PodSecurityPrivileged:
+		return PodSecurityPrivileged
+	case PodSecurityBaseline:
+		return PodSecurityBaseline
+	default:
+		return PodSecurityRestricted
+	}
+}
+
+// podSecurityContext returns the pod-level context for the configured level.
+//
+// FSGroup and FSGroupChangePolicy are set at every level, including
+// privileged: they are not admission requirements but are what gives a sandbox
+// write access to its own subdirectory of the shared pool volume without
+// recursively chowning the whole volume on each start.
+func (b *Backend) podSecurityContext() *corev1.PodSecurityContext {
+	securityContext := &corev1.PodSecurityContext{
+		FSGroup:             ptr(b.opts.FSGroup),
+		FSGroupChangePolicy: ptr(corev1.FSGroupChangeOnRootMismatch),
+	}
+
+	switch b.opts.PodSecurityLevel {
+	case PodSecurityPrivileged:
+		return securityContext
+	case PodSecurityBaseline:
+		securityContext.SeccompProfile = &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		}
+		return securityContext
+	default:
+		securityContext.RunAsNonRoot = ptr(true)
+		securityContext.RunAsUser = ptr(int64(sandboxRunAsUser))
+		securityContext.RunAsGroup = ptr(int64(sandboxRunAsUser))
+		securityContext.SeccompProfile = &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		}
+		return securityContext
+	}
+}
+
+// containerSecurityContext returns the container-level context for the
+// configured level. Restricted refuses a container that can escalate
+// privileges or holds any capability, so both have to be stated explicitly --
+// leaving them unset is what a default sandbox would do, and it is rejected.
+func (b *Backend) containerSecurityContext() *corev1.SecurityContext {
+	switch b.opts.PodSecurityLevel {
+	case PodSecurityPrivileged:
+		return nil
+	case PodSecurityBaseline:
+		return &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr(false),
+		}
+	default:
+		return &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr(false),
+			RunAsNonRoot:             ptr(true),
+			RunAsUser:                ptr(int64(sandboxRunAsUser)),
+			RunAsGroup:               ptr(int64(sandboxRunAsUser)),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
+	}
+}

--- a/pkg/agentbackend/kubernetes/podsecurity_test.go
+++ b/pkg/agentbackend/kubernetes/podsecurity_test.go
@@ -1,0 +1,139 @@
+package kubernetes
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func backendWithPodSecurity(t *testing.T, level string) *Backend {
+	t.Helper()
+	backend, err := New(nil, nil, Options{
+		Namespace:        "obot-agents",
+		ClusterDomain:    "cluster.local",
+		PodSecurityLevel: PodSecurityLevel(level),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return backend
+}
+
+func TestParsePodSecurityLevelDefaultsToRestricted(t *testing.T) {
+	for _, level := range []string{"", "unknown", "Restricted"} {
+		if got := ParsePodSecurityLevel(level); got != PodSecurityRestricted {
+			t.Errorf("ParsePodSecurityLevel(%q) = %q, want restricted", level, got)
+		}
+	}
+	if got := ParsePodSecurityLevel("baseline"); got != PodSecurityBaseline {
+		t.Errorf("ParsePodSecurityLevel(baseline) = %q", got)
+	}
+	if got := ParsePodSecurityLevel("privileged"); got != PodSecurityPrivileged {
+		t.Errorf("ParsePodSecurityLevel(privileged) = %q", got)
+	}
+}
+
+// A sandbox that does not satisfy the namespace's Pod Security level is refused
+// at admission: the Deployment is created and no pod ever appears. The chart
+// labels that namespace restricted by default, so this is what a default
+// install requires of every field.
+func TestSandboxSatisfiesRestrictedPodSecurity(t *testing.T) {
+	backend := backendWithPodSecurity(t, "")
+	objects, err := backend.instanceObjects(desiredInstance())
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	spec := deploymentFrom(t, objects).Spec.Template.Spec
+
+	podSecurity := spec.SecurityContext
+	if podSecurity == nil {
+		t.Fatal("pod has no security context")
+	}
+	if podSecurity.RunAsNonRoot == nil || !*podSecurity.RunAsNonRoot {
+		t.Error("pod securityContext.runAsNonRoot is not true")
+	}
+	if podSecurity.SeccompProfile == nil || podSecurity.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Error("pod securityContext.seccompProfile is not RuntimeDefault")
+	}
+	// The pool volume is shared, and each sandbox owns a subPath within it.
+	// Dropping fsGroup to satisfy admission would cost the sandbox write access
+	// to its own directory.
+	if podSecurity.FSGroup == nil || *podSecurity.FSGroup != defaultFSGroup {
+		t.Errorf("pod securityContext.fsGroup = %v, want %d", podSecurity.FSGroup, defaultFSGroup)
+	}
+	if podSecurity.FSGroupChangePolicy == nil || *podSecurity.FSGroupChangePolicy != corev1.FSGroupChangeOnRootMismatch {
+		t.Error("pod securityContext.fsGroupChangePolicy is not OnRootMismatch")
+	}
+
+	container := spec.Containers[0].SecurityContext
+	if container == nil {
+		t.Fatal("container has no security context")
+	}
+	if container.AllowPrivilegeEscalation == nil || *container.AllowPrivilegeEscalation {
+		t.Error("container securityContext.allowPrivilegeEscalation is not false")
+	}
+	if container.Capabilities == nil || len(container.Capabilities.Drop) != 1 || container.Capabilities.Drop[0] != "ALL" {
+		t.Error("container securityContext does not drop ALL capabilities")
+	}
+	if container.RunAsNonRoot == nil || !*container.RunAsNonRoot {
+		t.Error("container securityContext.runAsNonRoot is not true")
+	}
+	if container.SeccompProfile == nil || container.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Error("container securityContext.seccompProfile is not RuntimeDefault")
+	}
+}
+
+// The cleanup job runs in the same namespace and is admitted by the same rules,
+// so a sandbox that deletes cleanly under restricted needs this too.
+func TestCleanupJobSatisfiesRestrictedPodSecurity(t *testing.T) {
+	backend := backendWithPodSecurity(t, "restricted")
+	job, err := backend.cleanupJob("inst-1", "alloc-1")
+	if err != nil {
+		t.Fatalf("cleanupJob: %v", err)
+	}
+	spec := job.Spec.Template.Spec
+
+	if spec.SecurityContext == nil || spec.SecurityContext.RunAsNonRoot == nil || !*spec.SecurityContext.RunAsNonRoot {
+		t.Error("cleanup pod securityContext.runAsNonRoot is not true")
+	}
+	container := spec.Containers[0].SecurityContext
+	if container == nil || container.AllowPrivilegeEscalation == nil || *container.AllowPrivilegeEscalation {
+		t.Error("cleanup container securityContext.allowPrivilegeEscalation is not false")
+	}
+}
+
+// An operator who lowers the namespace's level is telling us a harness needs
+// root; forcing runAsNonRoot anyway would break exactly the images the lower
+// level was chosen for.
+func TestLoweredPodSecurityLevelsRelaxTheSandbox(t *testing.T) {
+	baseline := backendWithPodSecurity(t, "baseline")
+	objects, err := baseline.instanceObjects(desiredInstance())
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	spec := deploymentFrom(t, objects).Spec.Template.Spec
+	if spec.SecurityContext.RunAsNonRoot != nil {
+		t.Error("baseline pod should not force runAsNonRoot")
+	}
+	if spec.SecurityContext.SeccompProfile == nil {
+		t.Error("baseline pod should still set a seccomp profile")
+	}
+	if container := spec.Containers[0].SecurityContext; container == nil || *container.AllowPrivilegeEscalation {
+		t.Error("baseline container should disallow privilege escalation")
+	}
+
+	privileged := backendWithPodSecurity(t, "privileged")
+	objects, err = privileged.instanceObjects(desiredInstance())
+	if err != nil {
+		t.Fatalf("instanceObjects: %v", err)
+	}
+	spec = deploymentFrom(t, objects).Spec.Template.Spec
+	if spec.Containers[0].SecurityContext != nil {
+		t.Error("privileged container should have no security context")
+	}
+	// fsGroup is not an admission requirement; it is how the sandbox reaches
+	// its own directory on the shared volume, so it survives every level.
+	if spec.SecurityContext == nil || spec.SecurityContext.FSGroup == nil {
+		t.Error("privileged pod should still set fsGroup for the pool volume")
+	}
+}

--- a/pkg/agentbackend/kubernetes/pool.go
+++ b/pkg/agentbackend/kubernetes/pool.go
@@ -1,0 +1,248 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obot-platform/nah/pkg/apply"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (b *Backend) ReconcilePool(ctx context.Context, desired agentbackend.DesiredPool) (agentbackend.PoolObservation, error) {
+	if desired.Ref.ID == "" {
+		return agentbackend.PoolObservation{}, fmt.Errorf("pool ID is required")
+	}
+	if desired.Revision == "" {
+		return agentbackend.PoolObservation{}, fmt.Errorf("pool revision is required")
+	}
+
+	objs, err := b.poolObjects(ctx, desired)
+	if err != nil {
+		return agentbackend.PoolObservation{}, err
+	}
+
+	if err := b.applyPool(ctx, desired.Ref.ID, objs...); err != nil {
+		return agentbackend.PoolObservation{}, err
+	}
+
+	return b.ObservePool(ctx, desired.Ref)
+}
+
+func (b *Backend) ObservePool(ctx context.Context, ref agentbackend.PoolRef) (agentbackend.PoolObservation, error) {
+	if ref.ID == "" {
+		return agentbackend.PoolObservation{}, fmt.Errorf("pool ID is required")
+	}
+
+	observation := agentbackend.PoolObservation{Ref: ref}
+
+	var quota corev1.ResourceQuota
+	if err := b.cachedClient.Get(ctx, kclient.ObjectKey{Name: poolName(ref.ID), Namespace: b.opts.Namespace}, &quota); apierrors.IsNotFound(err) {
+		return observation, nil
+	} else if err != nil {
+		return agentbackend.PoolObservation{}, fmt.Errorf("failed to read pool quota for pool %s: %w", ref.ID, err)
+	}
+
+	observation.Ref.BackendID = poolName(ref.ID)
+	observation.Exists = true
+	observation.ObservedRevision = quota.Annotations[revisionAnnotation]
+	observation.BackendGeneration = fmt.Sprintf("%d", quota.Generation)
+	observation.Capacity = capacityFromQuota(quota)
+
+	// The pool volume is provisioned lazily: with WaitForFirstConsumer it stays
+	// Pending until the first sandbox schedules, so a Pending claim is expected
+	// and is not a degraded pool.
+	var claim corev1.PersistentVolumeClaim
+	if err := b.cachedClient.Get(ctx, kclient.ObjectKey{Name: poolName(ref.ID), Namespace: b.opts.Namespace}, &claim); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return agentbackend.PoolObservation{}, fmt.Errorf("failed to read pool volume for pool %s: %w", ref.ID, err)
+		}
+		observation.State = agentbackend.StatePending
+		observation.Reason = "VolumeMissing"
+		observation.Message = "the pool volume has not been created yet"
+		return observation, nil
+	}
+	if claim.Status.Phase == corev1.ClaimLost {
+		observation.State = agentbackend.StateError
+		observation.Reason = "VolumeLost"
+		observation.Message = "the pool volume is no longer bound to a persistent volume"
+		return observation, nil
+	}
+
+	observation.State = agentbackend.StateReady
+	observation.Schedulable = !isSuspended(quota)
+	if !observation.Schedulable {
+		observation.Reason = "Suspended"
+		observation.Message = "the pool does not admit new sandboxes"
+	}
+	return observation, nil
+}
+
+func (b *Backend) DeletePool(ctx context.Context, ref agentbackend.PoolRef) (agentbackend.DeleteResult, error) {
+	if ref.ID == "" {
+		return agentbackend.DeleteResult{}, fmt.Errorf("pool ID is required")
+	}
+
+	// Refuse while sandboxes remain, so a pool volume is never removed out from
+	// under a running agent.
+	var deployments appsv1.DeploymentList
+	if err := b.cachedClient.List(ctx, &deployments, kclient.InNamespace(b.opts.Namespace), kclient.MatchingLabels{
+		poolLabel: sanitize(ref.ID),
+	}); err != nil {
+		return agentbackend.DeleteResult{}, fmt.Errorf("failed to list sandboxes for pool %s: %w", ref.ID, err)
+	}
+	if len(deployments.Items) > 0 {
+		return agentbackend.DeleteResult{}, fmt.Errorf("pool %s still has %d sandbox(es)", ref.ID, len(deployments.Items))
+	}
+
+	if err := b.applyPool(ctx, ref.ID); err != nil {
+		return agentbackend.DeleteResult{}, err
+	}
+	return agentbackend.DeleteResult{Complete: true}, nil
+}
+
+// applyPool reconciles the pool's object set. Passing no objects prunes
+// the set, which is how deletion works.
+func (b *Backend) applyPool(ctx context.Context, poolID string, objs ...kclient.Object) error {
+	err := apply.New(b.client).
+		WithNamespace(b.opts.Namespace).
+		WithOwnerSubContext("agent-pool-"+sanitize(poolID)).
+		WithPruneTypes(
+			new(schedulingv1.PriorityClass),
+			new(corev1.ResourceQuota),
+			new(corev1.PersistentVolumeClaim),
+		).
+		Apply(ctx, nil, objs...)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to apply pool objects for pool %s: %w", poolID, err)
+	}
+	return nil
+}
+
+func (b *Backend) poolObjects(ctx context.Context, desired agentbackend.DesiredPool) ([]kclient.Object, error) {
+	pool := poolName(desired.Ref.ID)
+	labels := poolLabels(desired.Ref.ID)
+	annotations := map[string]string{revisionAnnotation: desired.Revision}
+
+	owner, err := b.namespaceOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	priorityClass := &schedulingv1.PriorityClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        pool,
+			Labels:      labels,
+			Annotations: annotations,
+			// Cluster-scoped dependents may only name cluster-scoped owners, and
+			// a Namespace is cluster-scoped, so this is a valid reference.
+			OwnerReferences: []metav1.OwnerReference{*owner},
+		},
+		Value:            poolPriorityValue,
+		GlobalDefault:    false,
+		PreemptionPolicy: ptr(corev1.PreemptNever),
+		Description:      fmt.Sprintf("Obot hosted agent pool %s. Used to scope a ResourceQuota, not to order scheduling.", desired.Ref.ID),
+	}
+
+	quota := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        pool,
+			Namespace:   b.opts.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: corev1.ResourceQuotaSpec{
+			Hard: quotaHard(desired),
+			// PriorityClass is the only per-pod attribute a ResourceQuota can
+			// select on, which is what lets pools share a namespace.
+			ScopeSelector: &corev1.ScopeSelector{
+				MatchExpressions: []corev1.ScopedResourceSelectorRequirement{{
+					ScopeName: corev1.ResourceQuotaScopePriorityClass,
+					Operator:  corev1.ScopeSelectorOpIn,
+					Values:    []string{pool},
+				}},
+			},
+		},
+	}
+
+	claimAnnotations := map[string]string{revisionAnnotation: desired.Revision}
+	// A bound claim is largely immutable, and resizing it is not something a
+	// revision bump should attempt.
+	claimAnnotations[apply.AnnotationUpdate] = "false"
+	claim := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        pool,
+			Namespace:   b.opts.Namespace,
+			Labels:      labels,
+			Annotations: claimAnnotations,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			// ReadWriteOnce is node-scoped, not pod-scoped: every sandbox in the
+			// pool mounts this claim from the same node. That co-location is the
+			// point, and it is what makes the pool a physical boundary.
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: memoryQuantity(desired.Capacity.StorageBytes),
+				},
+			},
+		},
+	}
+	if b.opts.StorageClassName != "" {
+		claim.Spec.StorageClassName = ptr(b.opts.StorageClassName)
+	}
+
+	return []kclient.Object{priorityClass, quota, claim}, nil
+}
+
+// quotaHard expresses the pool budget.
+//
+// Only requests are bounded. Every sandbox may burst to the whole pool, so
+// sum(limits) is MaxSandboxes times the capacity by construction; a limits
+// quota would therefore either reject the second sandbox or be set so high it
+// enforces nothing. What bounds the pool is the reservation budget plus the
+// sandbox count.
+//
+// A suspended pool zeroes the budget, which stops new sandboxes being admitted.
+// Quota is an admission check, so pods already running keep running.
+func quotaHard(desired agentbackend.DesiredPool) corev1.ResourceList {
+	if desired.Suspended {
+		zero := *resource.NewQuantity(0, resource.DecimalSI)
+		return corev1.ResourceList{
+			corev1.ResourceRequestsCPU:    zero,
+			corev1.ResourceRequestsMemory: zero,
+			corev1.ResourcePods:           zero,
+		}
+	}
+
+	_, _, effectiveMax := agentbackend.SandboxShare(desired.Capacity, desired.MaxSandboxes)
+	return corev1.ResourceList{
+		corev1.ResourceRequestsCPU:    cpuQuantity(desired.Capacity.CPUVCPUs),
+		corev1.ResourceRequestsMemory: memoryQuantity(desired.Capacity.MemoryBytes),
+		corev1.ResourcePods:           *resource.NewQuantity(int64(effectiveMax), resource.DecimalSI),
+	}
+}
+
+func isSuspended(quota corev1.ResourceQuota) bool {
+	value, ok := quota.Spec.Hard[corev1.ResourceRequestsCPU]
+	return ok && value.IsZero()
+}
+
+func capacityFromQuota(quota corev1.ResourceQuota) agentbackend.ResourceQuantity {
+	cpu := quota.Spec.Hard[corev1.ResourceRequestsCPU]
+	memory := quota.Spec.Hard[corev1.ResourceRequestsMemory]
+	return agentbackend.ResourceQuantity{
+		CPUVCPUs:    float64(cpu.MilliValue()) / 1000,
+		MemoryBytes: memory.Value(),
+	}
+}
+
+func ptr[T any](value T) *T {
+	return &value
+}

--- a/pkg/agentbackend/kubernetes/reachable.go
+++ b/pkg/agentbackend/kubernetes/reachable.go
@@ -1,0 +1,81 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+
+	corev1 "k8s.io/api/core/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReachableServerURL rewrites Obot's own address into one a sandbox can use.
+//
+// A sandbox is told where to find Obot, and that address is resolved from
+// inside the cluster rather than on the machine Obot runs on. When Obot runs in
+// the cluster the two agree. When it does not -- which is what `make dev` does,
+// with Obot on the developer's machine and sandboxes in a cluster -- the
+// configured address is a loopback one, and loopback inside a pod is the pod
+// itself. An agent would then be handed a URL that resolves to nothing, with
+// every MCP call and model request failing on a connection refused that says
+// nothing about why.
+//
+// The node's address is used because the developer's machine is the node: Obot
+// listens on all interfaces, so a pod reaching the node on Obot's port reaches
+// Obot. Anything that is not a loopback address is returned untouched, since it
+// is already an address someone chose to be reachable.
+//
+// This is a development convenience. In production Obot runs in the cluster and
+// its own Service name resolves, so nothing here applies.
+func ReachableServerURL(ctx context.Context, client kclient.Client, serverURL string) (string, error) {
+	if serverURL == "" || client == nil {
+		return serverURL, nil
+	}
+
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		return serverURL, nil
+	}
+	host := parsed.Hostname()
+	if host == "" || !isLoopback(host) {
+		return serverURL, nil
+	}
+
+	nodeIP, err := anyNodeAddress(ctx, client)
+	if err != nil {
+		return "", fmt.Errorf("resolve an address for %s that a sandbox can reach: %w", serverURL, err)
+	}
+
+	if port := parsed.Port(); port != "" {
+		parsed.Host = net.JoinHostPort(nodeIP, port)
+	} else {
+		parsed.Host = nodeIP
+	}
+	return parsed.String(), nil
+}
+
+func isLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// anyNodeAddress returns a node's internal address. Any node will do: the
+// developer's machine is the cluster, so every node is the same host.
+func anyNodeAddress(ctx context.Context, client kclient.Client) (string, error) {
+	var nodes corev1.NodeList
+	if err := client.List(ctx, &nodes); err != nil {
+		return "", fmt.Errorf("list nodes: %w", err)
+	}
+	for _, node := range nodes.Items {
+		for _, address := range node.Status.Addresses {
+			if address.Type == corev1.NodeInternalIP && address.Address != "" {
+				return address.Address, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no node reports an internal address")
+}

--- a/pkg/agentbackend/kubernetes/reachable_test.go
+++ b/pkg/agentbackend/kubernetes/reachable_test.go
@@ -1,0 +1,71 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func nodeClient(addresses ...corev1.NodeAddress) *fake.ClientBuilder {
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Status:     corev1.NodeStatus{Addresses: addresses},
+	})
+}
+
+// A loopback address inside a pod is the pod itself, so an agent told to reach
+// Obot there fails on every request with a connection refused that says nothing
+// about why.
+func TestLoopbackIsRewrittenToTheNode(t *testing.T) {
+	client := nodeClient(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "172.26.119.21"}).Build()
+
+	for _, tt := range []struct{ in, want string }{
+		{"http://localhost:8080", "http://172.26.119.21:8080"},
+		{"http://127.0.0.1:8080", "http://172.26.119.21:8080"},
+		{"http://localhost:8080/", "http://172.26.119.21:8080/"},
+		// No port: the scheme's default is implied and must stay implied.
+		{"http://localhost", "http://172.26.119.21"},
+	} {
+		got, err := ReachableServerURL(context.Background(), client, tt.in)
+		if err != nil {
+			t.Fatalf("ReachableServerURL(%q): %v", tt.in, err)
+		}
+		if got != tt.want {
+			t.Errorf("ReachableServerURL(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// An address someone deliberately configured is already reachable; rewriting it
+// would break a production deployment whose Obot runs in the cluster.
+func TestRoutableAddressIsLeftAlone(t *testing.T) {
+	client := nodeClient(corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "172.26.119.21"}).Build()
+
+	for _, in := range []string{
+		"https://obot.example.com",
+		"http://obot.obot-system.svc.cluster.local:8080",
+		"https://10.0.0.5:8443",
+		"",
+	} {
+		got, err := ReachableServerURL(context.Background(), client, in)
+		if err != nil {
+			t.Fatalf("ReachableServerURL(%q): %v", in, err)
+		}
+		if got != in {
+			t.Errorf("ReachableServerURL(%q) = %q, want it untouched", in, got)
+		}
+	}
+}
+
+// Failing loudly beats handing every sandbox an address that cannot work.
+func TestNoNodeAddressIsAnError(t *testing.T) {
+	client := nodeClient(corev1.NodeAddress{Type: corev1.NodeHostName, Address: "node-1"}).Build()
+
+	if _, err := ReachableServerURL(context.Background(), client, "http://localhost:8080"); err == nil {
+		t.Fatal("expected an error when no node reports an internal address")
+	}
+}

--- a/pkg/agentbackend/kubernetes/status.go
+++ b/pkg/agentbackend/kubernetes/status.go
@@ -1,0 +1,127 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// classifyDeployment reduces Kubernetes workload status to the three states the
+// agent backend contract exposes. Everything a provider would otherwise want a
+// new state for is carried as a stable Reason plus a human-readable Message.
+//
+// "error" does not mean permanent. It means the runtime cannot currently
+// realize the desired configuration, which is the distinction the contract
+// draws. Obot keeps reconciling, so a transient image-pull failure recovers on
+// its own while still being visible to the user rather than sitting silently in
+// "pending".
+func classifyDeployment(deployment *appsv1.Deployment, pods []corev1.Pod) (agentbackend.State, string, string) {
+	// A quota rejection surfaces here rather than on the write that created the
+	// Deployment: the Deployment is admitted, and its ReplicaSet is what fails
+	// to create pods. Without this the sandbox would report "pending" forever
+	// against a full pool.
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentReplicaFailure && condition.Status == corev1.ConditionTrue {
+			return agentbackend.StateError, reasonOr(condition.Reason, "ReplicaFailure"), condition.Message
+		}
+	}
+
+	if state, reason, message, ok := classifyPods(pods); ok {
+		return state, reason, message
+	}
+
+	if deployment.Status.ReadyReplicas > 0 {
+		return agentbackend.StateReady, "", ""
+	}
+
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentProgressing &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == "ProgressDeadlineExceeded" {
+			return agentbackend.StateError, "ProgressDeadlineExceeded", condition.Message
+		}
+	}
+
+	return agentbackend.StatePending, "Starting", "the sandbox is starting"
+}
+
+// classifyPods reports the first pod condition worth surfacing. The bool
+// distinguishes "nothing notable" from a deliberate pending verdict.
+func classifyPods(pods []corev1.Pod) (agentbackend.State, string, string, bool) {
+	newest := newestPod(pods)
+	if newest == nil {
+		return "", "", "", false
+	}
+
+	if newest.Status.Reason == "Evicted" {
+		return agentbackend.StateError, "Evicted", messageOr(newest.Status.Message, "the sandbox was evicted from its node"), true
+	}
+
+	switch newest.Status.Phase {
+	case corev1.PodFailed:
+		return agentbackend.StateError, "PodFailed", messageOr(newest.Status.Message, "the sandbox pod failed"), true
+	case corev1.PodUnknown:
+		return agentbackend.StateError, "PodUnknown", "the sandbox pod state cannot be determined", true
+	}
+
+	for _, condition := range newest.Status.Conditions {
+		if condition.Type == corev1.PodScheduled &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == corev1.PodReasonUnschedulable {
+			// A pool is confined to one node by its shared volume, so an
+			// unschedulable sandbox cannot spill elsewhere and will stay pending
+			// indefinitely. Reporting it as an error is what makes a full pool
+			// visible instead of silent.
+			return agentbackend.StateError, "Unschedulable", messageOr(condition.Message, "the sandbox cannot be scheduled onto the pool's node"), true
+		}
+	}
+
+	for _, status := range newest.Status.ContainerStatuses {
+		if waiting := status.State.Waiting; waiting != nil {
+			switch waiting.Reason {
+			case "CrashLoopBackOff", "InvalidImageName", "CreateContainerConfigError",
+				"CreateContainerError", "RunContainerError", "ImagePullBackOff", "ErrImagePull":
+				return agentbackend.StateError, waiting.Reason, messageOr(waiting.Message, waiting.Reason), true
+			case "ContainerCreating", "PodInitializing":
+				return agentbackend.StatePending, waiting.Reason, "the sandbox container is starting", true
+			}
+		}
+
+		if terminated := status.State.Terminated; terminated != nil && terminated.ExitCode != 0 {
+			return agentbackend.StateError, "ContainerTerminated",
+				fmt.Sprintf("the sandbox exited with code %d after %d restart(s): %s",
+					terminated.ExitCode, status.RestartCount, terminated.Reason), true
+		}
+	}
+
+	return "", "", "", false
+}
+
+func newestPod(pods []corev1.Pod) *corev1.Pod {
+	var newest *corev1.Pod
+	for i := range pods {
+		if !pods[i].DeletionTimestamp.IsZero() {
+			continue
+		}
+		if newest == nil || pods[i].CreationTimestamp.After(newest.CreationTimestamp.Time) {
+			newest = &pods[i]
+		}
+	}
+	return newest
+}
+
+func reasonOr(reason, fallback string) string {
+	if reason == "" {
+		return fallback
+	}
+	return reason
+}
+
+func messageOr(message, fallback string) string {
+	if message == "" {
+		return fallback
+	}
+	return message
+}

--- a/pkg/agentbackend/kubernetes/status_test.go
+++ b/pkg/agentbackend/kubernetes/status_test.go
@@ -1,0 +1,141 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func waitingPod(reason, message string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "agent",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason, Message: message}},
+			}},
+		},
+	}
+}
+
+func TestClassifyDeploymentReadyWhenReplicaAvailable(t *testing.T) {
+	deployment := &appsv1.Deployment{Status: appsv1.DeploymentStatus{ReadyReplicas: 1}}
+
+	state, reason, message := classifyDeployment(deployment, nil)
+
+	if state != agentbackend.StateReady {
+		t.Fatalf("expected ready, got %s (%s: %s)", state, reason, message)
+	}
+}
+
+// A quota rejection never reaches the caller that created the Deployment; it
+// lands on the ReplicaSet and is surfaced as a Deployment condition.
+func TestClassifyDeploymentReportsQuotaRejection(t *testing.T) {
+	deployment := &appsv1.Deployment{
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:    appsv1.DeploymentReplicaFailure,
+				Status:  corev1.ConditionTrue,
+				Reason:  "FailedCreate",
+				Message: `pods "x" is forbidden: exceeded quota: obot-pool-a`,
+			}},
+		},
+	}
+
+	state, reason, message := classifyDeployment(deployment, nil)
+
+	if state != agentbackend.StateError {
+		t.Fatalf("expected error, got %s", state)
+	}
+	if reason != "FailedCreate" {
+		t.Errorf("expected FailedCreate reason, got %q", reason)
+	}
+	if message == "" {
+		t.Error("expected the quota message to be preserved")
+	}
+}
+
+// A pool is pinned to one node by its shared volume, so an unschedulable
+// sandbox never recovers by moving. Reporting pending would hide a full pool.
+func TestClassifyDeploymentTreatsUnschedulableAsError(t *testing.T) {
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type:    corev1.PodScheduled,
+				Status:  corev1.ConditionFalse,
+				Reason:  corev1.PodReasonUnschedulable,
+				Message: "0/1 nodes are available: insufficient memory",
+			}},
+		},
+	}
+
+	state, reason, _ := classifyDeployment(&appsv1.Deployment{}, []corev1.Pod{pod})
+
+	if state != agentbackend.StateError || reason != "Unschedulable" {
+		t.Fatalf("expected Unschedulable error, got %s/%s", state, reason)
+	}
+}
+
+func TestClassifyDeploymentPodReasons(t *testing.T) {
+	for _, tt := range []struct {
+		reason string
+		state  agentbackend.State
+	}{
+		{"CrashLoopBackOff", agentbackend.StateError},
+		{"ImagePullBackOff", agentbackend.StateError},
+		{"InvalidImageName", agentbackend.StateError},
+		{"CreateContainerConfigError", agentbackend.StateError},
+		{"ContainerCreating", agentbackend.StatePending},
+		{"PodInitializing", agentbackend.StatePending},
+	} {
+		t.Run(tt.reason, func(t *testing.T) {
+			pod := waitingPod(tt.reason, "detail")
+
+			state, reason, _ := classifyDeployment(&appsv1.Deployment{}, []corev1.Pod{pod})
+
+			if state != tt.state {
+				t.Fatalf("expected %s, got %s", tt.state, state)
+			}
+			if reason != tt.reason {
+				t.Errorf("expected reason %q, got %q", tt.reason, reason)
+			}
+		})
+	}
+}
+
+// A Recreate rollout leaves the outgoing pod behind briefly. The newest pod is
+// the one describing the revision being reconciled.
+func TestClassifyDeploymentUsesNewestPod(t *testing.T) {
+	old := waitingPod("CrashLoopBackOff", "old failure")
+	old.CreationTimestamp = metav1.Unix(100, 0)
+	current := waitingPod("ContainerCreating", "starting")
+	current.CreationTimestamp = metav1.Unix(200, 0)
+
+	state, reason, _ := classifyDeployment(&appsv1.Deployment{}, []corev1.Pod{old, current})
+
+	if state != agentbackend.StatePending || reason != "ContainerCreating" {
+		t.Fatalf("expected the newest pod to decide, got %s/%s", state, reason)
+	}
+}
+
+func TestClassifyDeploymentIgnoresTerminatingPods(t *testing.T) {
+	terminating := waitingPod("CrashLoopBackOff", "going away")
+	terminating.CreationTimestamp = metav1.Unix(300, 0)
+	now := metav1.Unix(400, 0)
+	terminating.DeletionTimestamp = &now
+
+	live := waitingPod("ContainerCreating", "starting")
+	live.CreationTimestamp = metav1.Unix(200, 0)
+
+	state, _, _ := classifyDeployment(&appsv1.Deployment{}, []corev1.Pod{terminating, live})
+
+	if state != agentbackend.StatePending {
+		t.Fatalf("expected pending from the live pod, got %s", state)
+	}
+}

--- a/pkg/agentbackend/kubernetes/subdir_test.go
+++ b/pkg/agentbackend/kubernetes/subdir_test.go
@@ -1,0 +1,126 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+)
+
+// The sandbox subdirectory is the only thing separating one agent's workspace
+// from every other agent's on a shared pool volume, and it is the argument to
+// an rm -rf. A name that reduces to nothing resolves to the pool root, so these
+// inputs must be refused rather than sanitized into something plausible.
+func TestSandboxSubdirRejectsAnythingThatResolvesToThePoolRoot(t *testing.T) {
+	for _, instanceID := range []string{
+		"",
+		" ",
+		".",
+		"..",
+		"../..",
+		"/",
+		"//",
+		"-",
+		"---",
+		"!!!",
+		"...",
+		"./",
+		"\x00",
+	} {
+		t.Run(strings.ReplaceAll(instanceID, "\x00", "NUL"), func(t *testing.T) {
+			subdir, err := sandboxSubdir(instanceID)
+			if err == nil {
+				t.Fatalf("sandboxSubdir(%q) = %q, want an error", instanceID, subdir)
+			}
+			if subdir != "" {
+				t.Errorf("a rejected ID must not yield a name, got %q", subdir)
+			}
+		})
+	}
+}
+
+func TestSandboxSubdirAcceptsRealInstanceIDs(t *testing.T) {
+	for instanceID, want := range map[string]string{
+		"inst-1":             "inst-1",
+		"hai1abc123":         "hai1abc123",
+		"HAI1ABC123":         "hai1abc123",
+		"hai1-abc-123":       "hai1-abc-123",
+		"a":                  "a",
+		"agent.instance/one": "agent-instance-one",
+		// Traversal and separators are destroyed by sanitize before the
+		// pattern ever sees them, leaving an ordinary label.
+		"/etc/passwd":                 "etc-passwd",
+		"../../escape":                "escape",
+		strings.Repeat("a", 63):       strings.Repeat("a", 63),
+		"-leading-and-trailing-dash-": "leading-and-trailing-dash",
+	} {
+		got, err := sandboxSubdir(instanceID)
+		if err != nil {
+			t.Errorf("sandboxSubdir(%q): %v", instanceID, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("sandboxSubdir(%q) = %q, want %q", instanceID, got, want)
+		}
+	}
+
+	// Longer than a DNS label. Kubernetes would reject the mount anyway, so
+	// failing here keeps the error next to its cause.
+	if _, err := sandboxSubdir(strings.Repeat("a", 64)); err == nil {
+		t.Error("a 64-character name should be rejected")
+	}
+}
+
+// Deleting a sandbox whose ID cannot be validated must fail rather than fall
+// back to a job that would remove the whole pool.
+func TestCleanupJobRefusesUnusableInstanceIDs(t *testing.T) {
+	backend := testBackend(t)
+	for _, instanceID := range []string{"", "..", "---"} {
+		if job, err := backend.cleanupJob(instanceID, "alloc-1"); err == nil {
+			t.Errorf("cleanupJob(%q) built a job targeting %v, want an error",
+				instanceID, job.Spec.Template.Spec.Containers[0].Args)
+		}
+	}
+}
+
+func TestInstanceObjectsRefuseUnusableInstanceIDs(t *testing.T) {
+	backend := testBackend(t)
+	for _, instanceID := range []string{"", "..", "---"} {
+		desired := desiredInstance()
+		desired.Ref.ID = instanceID
+		if _, err := backend.instanceObjects(desired); err == nil {
+			t.Errorf("instanceObjects(%q) should refuse to mount the pool root", instanceID)
+		}
+	}
+}
+
+// The subdirectory reaches the shell as an argument, never interpolated into
+// the script, and the script re-checks it before running rm.
+func TestCleanupJobPassesSubdirAsAnArgument(t *testing.T) {
+	backend := testBackend(t)
+	job, err := backend.cleanupJob("inst-1", "alloc-1")
+	if err != nil {
+		t.Fatalf("cleanupJob: %v", err)
+	}
+
+	args := job.Spec.Template.Spec.Containers[0].Args
+	if len(args) != 3 {
+		t.Fatalf("expected script, $0 and the subdirectory, got %v", args)
+	}
+	if args[0] != cleanupScript {
+		t.Error("the first argument must be the guarded script")
+	}
+	if args[2] != "inst-1" {
+		t.Errorf("subdirectory passed as %q, want inst-1", args[2])
+	}
+	if strings.Contains(args[0], "inst-1") {
+		t.Error("the subdirectory must not be interpolated into the script")
+	}
+	if !strings.Contains(args[0], `rm -rf "/pool/$dir"`) {
+		t.Error("the script must quote the target")
+	}
+	// Without the guard the script would happily run against the pool root.
+	for _, refusal := range []string{`''`, `*/*`, `*..*`} {
+		if !strings.Contains(args[0], refusal) {
+			t.Errorf("the script must refuse %s", refusal)
+		}
+	}
+}

--- a/pkg/agentbackend/kubernetes/terminal.go
+++ b/pkg/agentbackend/kubernetes/terminal.go
@@ -1,0 +1,194 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+var _ agentbackend.TerminalBackend = (*Backend)(nil)
+
+// AttachTerminal connects to the console of a sandbox's running process.
+//
+// This attaches rather than execs. Exec would start a second process with its
+// own TTY, which gives a shell beside the agent but not the agent's own
+// session; attach joins the console the container was started with, so an
+// operator sees exactly what the agent is doing. That console only exists
+// because the harness was marked interactive, which is why a terminal requires
+// one.
+func (b *Backend) AttachTerminal(ctx context.Context, ref agentbackend.InstanceRef, size agentbackend.TerminalSize) (agentbackend.TerminalSession, error) {
+	if b.opts.RESTConfig == nil {
+		return nil, fmt.Errorf("terminal requires a Kubernetes connection")
+	}
+
+	pod, err := b.runningPod(ctx, ref.ID)
+	if err != nil {
+		return nil, err
+	}
+	if !podHasTTY(pod) {
+		return nil, fmt.Errorf("sandbox %s was not started with a terminal; its harness is not interactive", ref.ID)
+	}
+
+	client, err := rest.RESTClientFor(attachConfig(b.opts.RESTConfig))
+	if err != nil {
+		return nil, fmt.Errorf("build attach client: %w", err)
+	}
+
+	request := client.Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("attach").
+		VersionedParams(&corev1.PodAttachOptions{
+			Container: agentContainerName,
+			Stdin:     true,
+			Stdout:    true,
+			// A TTY merges the two streams, so asking for stderr as well is
+			// rejected by the API server.
+			Stderr: false,
+			TTY:    true,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(b.opts.RESTConfig, "POST", request.URL())
+	if err != nil {
+		return nil, fmt.Errorf("build terminal executor: %w", err)
+	}
+
+	session := newTerminalSession(size)
+	go func() {
+		// StreamWithContext blocks until the console closes. Its error is
+		// delivered to the reader so the browser learns why the session ended
+		// rather than seeing the socket drop.
+		err := executor.StreamWithContext(ctx, remotecommand.StreamOptions{
+			Stdin:             session.inputReader,
+			Stdout:            session.outputWriter,
+			Tty:               true,
+			TerminalSizeQueue: session,
+		})
+		session.finish(err)
+	}()
+
+	return session, nil
+}
+
+// terminalSession adapts the streaming executor, which wants readers and
+// writers it can block on, to the ReadWriteCloser the caller wants.
+type terminalSession struct {
+	inputReader  *io.PipeReader
+	inputWriter  *io.PipeWriter
+	outputReader *io.PipeReader
+	outputWriter *io.PipeWriter
+
+	// resizes is consumed by the executor. It is buffered and lossy: only the
+	// most recent size matters, and a resize must never block the session.
+	resizes chan remotecommand.TerminalSize
+
+	closeOnce sync.Once
+}
+
+func newTerminalSession(size agentbackend.TerminalSize) *terminalSession {
+	inputReader, inputWriter := io.Pipe()
+	outputReader, outputWriter := io.Pipe()
+
+	session := &terminalSession{
+		inputReader:  inputReader,
+		inputWriter:  inputWriter,
+		outputReader: outputReader,
+		outputWriter: outputWriter,
+		resizes:      make(chan remotecommand.TerminalSize, 1),
+	}
+	// Seed the initial size so the first frame the program draws matches the
+	// browser rather than an 80x24 default it would have to redraw.
+	session.resizes <- remotecommand.TerminalSize{Width: size.Cols, Height: size.Rows}
+	return session
+}
+
+func (s *terminalSession) Read(p []byte) (int, error)  { return s.outputReader.Read(p) }
+func (s *terminalSession) Write(p []byte) (int, error) { return s.inputWriter.Write(p) }
+
+// Next implements remotecommand.TerminalSizeQueue. Returning nil ends the
+// queue, which the executor treats as "no more resizes".
+func (s *terminalSession) Next() *remotecommand.TerminalSize {
+	size, ok := <-s.resizes
+	if !ok {
+		return nil
+	}
+	return &size
+}
+
+func (s *terminalSession) Resize(size agentbackend.TerminalSize) error {
+	next := remotecommand.TerminalSize{Width: size.Cols, Height: size.Rows}
+	for {
+		select {
+		case s.resizes <- next:
+			return nil
+		default:
+			// Full: drop the pending size, which is now stale, and retry. A
+			// terminal only cares about its current dimensions.
+			select {
+			case <-s.resizes:
+			default:
+			}
+		}
+	}
+}
+
+func (s *terminalSession) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.resizes)
+		_ = s.inputWriter.Close()
+		_ = s.outputWriter.Close()
+	})
+	return nil
+}
+
+// finish ends the session, surfacing the reason to the reader.
+func (s *terminalSession) finish(err error) {
+	if err != nil {
+		_ = s.outputWriter.CloseWithError(err)
+	}
+	s.Close()
+}
+
+// attachConfig prepares a REST config for the pods/attach subresource, which is
+// a raw stream rather than an API object and so carries no codec of its own.
+func attachConfig(config *rest.Config) *rest.Config {
+	attach := rest.CopyConfig(config)
+	attach.GroupVersion = &corev1.SchemeGroupVersion
+	attach.APIPath = "/api"
+	attach.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	return attach
+}
+
+func podHasTTY(pod *corev1.Pod) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Name == agentContainerName {
+			return container.TTY && container.Stdin
+		}
+	}
+	return false
+}
+
+// runningPod returns the sandbox's current pod. A terminal needs a live
+// process, so a pod that is pending or terminating is reported as unavailable
+// rather than attached to.
+func (b *Backend) runningPod(ctx context.Context, instanceID string) (*corev1.Pod, error) {
+	pods, err := b.instancePods(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Status.Phase == corev1.PodRunning && pod.DeletionTimestamp.IsZero() {
+			return pod, nil
+		}
+	}
+	return nil, fmt.Errorf("sandbox %s has no running pod to attach to", instanceID)
+}

--- a/pkg/agentbackend/kubernetes/terminal_e2e_test.go
+++ b/pkg/agentbackend/kubernetes/terminal_e2e_test.go
@@ -1,0 +1,112 @@
+package kubernetes
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestAttachTerminalAgainstCluster attaches to a sandbox that is already
+// running in a real cluster.
+//
+// Attaching is the part of the terminal that unit tests cannot reach: it needs
+// an API server that will upgrade to SPDY, a pod started with a TTY, and a
+// shell on the other end. It is opt-in because it needs all three.
+//
+//	OBOT_E2E_KUBECONFIG=~/.kube/config \
+//	OBOT_E2E_NAMESPACE=obot-mcp \
+//	OBOT_E2E_INSTANCE_ID=<obot.ai/hosted-agent-instance label> \
+//	go test ./pkg/agentbackend/kubernetes -run TestAttachTerminalAgainstCluster -v
+func TestAttachTerminalAgainstCluster(t *testing.T) {
+	kubeconfig := os.Getenv("OBOT_E2E_KUBECONFIG")
+	namespace := os.Getenv("OBOT_E2E_NAMESPACE")
+	instanceID := os.Getenv("OBOT_E2E_INSTANCE_ID")
+	if kubeconfig == "" || namespace == "" || instanceID == "" {
+		t.Skip("set OBOT_E2E_KUBECONFIG, OBOT_E2E_NAMESPACE and OBOT_E2E_INSTANCE_ID to run")
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		t.Fatalf("load kubeconfig: %v", err)
+	}
+	client, err := kclient.New(restConfig, kclient.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		t.Fatalf("build client: %v", err)
+	}
+
+	backend, err := New(client, nil, Options{Namespace: namespace, RESTConfig: restConfig})
+	if err != nil {
+		t.Fatalf("build backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	session, err := backend.AttachTerminal(ctx,
+		agentbackend.InstanceRef{ID: instanceID, Namespace: namespace},
+		agentbackend.TerminalSize{Rows: 40, Cols: 120})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	defer session.Close()
+
+	// A marker rather than a fixed string: the shell echoes the command back
+	// over the TTY, so the output has to prove the command actually ran.
+	const marker = "obot-terminal-e2e-ok"
+	if _, err := session.Write([]byte("echo " + marker + "\n")); err != nil {
+		t.Fatalf("write to console: %v", err)
+	}
+
+	if err := session.Resize(agentbackend.TerminalSize{Rows: 24, Cols: 80}); err != nil {
+		t.Errorf("resize: %v", err)
+	}
+
+	output := readUntil(t, session, marker, 30*time.Second)
+	// Two occurrences: the echoed command line, then its output. One means the
+	// TTY is relaying keystrokes but the shell is not running them.
+	if strings.Count(output, marker) < 2 {
+		t.Fatalf("expected the command to be echoed and to run; got:\n%s", output)
+	}
+	t.Logf("console output:\n%s", output)
+}
+
+// readUntil collects console output until the marker has appeared twice or the
+// deadline passes, so a failure shows what the console actually said.
+func readUntil(t *testing.T, session agentbackend.TerminalSession, marker string, timeout time.Duration) string {
+	t.Helper()
+
+	var (
+		collected strings.Builder
+		done      = make(chan struct{})
+	)
+	go func() {
+		defer close(done)
+		buffer := make([]byte, 4096)
+		for {
+			n, err := session.Read(buffer)
+			if n > 0 {
+				collected.Write(buffer[:n])
+				if strings.Count(collected.String(), marker) >= 2 {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Error("timed out waiting for the console to echo the command")
+	}
+	return collected.String()
+}

--- a/pkg/agentbackend/kubernetes/utilization.go
+++ b/pkg/agentbackend/kubernetes/utilization.go
@@ -1,0 +1,185 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetPoolUtilization reports live resource consumption for a pool.
+//
+// Usage is measured per sandbox through metrics.k8s.io. Where measurement is
+// unavailable -- no metrics-server, or a pod too new to have been sampled --
+// that sandbox falls back to its committed request, so a pool always reports a
+// usable number rather than understating itself to zero. Falling back to the
+// request rather than to zero is deliberate: a sandbox that exists has
+// certainly reserved its request, so that is the floor of what it is using.
+func (b *Backend) GetPoolUtilization(ctx context.Context, ref agentbackend.PoolRef) (agentbackend.UtilizationSnapshot, error) {
+	if ref.ID == "" {
+		return agentbackend.UtilizationSnapshot{}, fmt.Errorf("pool ID is required")
+	}
+
+	var quota corev1.ResourceQuota
+	if err := b.cachedClient.Get(ctx, kclient.ObjectKey{Name: poolName(ref.ID), Namespace: b.opts.Namespace}, &quota); apierrors.IsNotFound(err) {
+		return agentbackend.UtilizationSnapshot{}, fmt.Errorf("pool %s does not exist", ref.ID)
+	} else if err != nil {
+		return agentbackend.UtilizationSnapshot{}, fmt.Errorf("failed to read pool quota for pool %s: %w", ref.ID, err)
+	}
+
+	var deployments appsv1.DeploymentList
+	if err := b.cachedClient.List(ctx, &deployments, kclient.InNamespace(b.opts.Namespace), kclient.MatchingLabels{
+		poolLabel: sanitize(ref.ID),
+	}); err != nil {
+		return agentbackend.UtilizationSnapshot{}, fmt.Errorf("failed to list sandboxes for pool %s: %w", ref.ID, err)
+	}
+
+	// Measured usage is keyed by pod, so the pods of this pool are needed to
+	// join it back to instances.
+	var pods corev1.PodList
+	if err := b.cachedClient.List(ctx, &pods, kclient.InNamespace(b.opts.Namespace), kclient.MatchingLabels{
+		poolLabel: sanitize(ref.ID),
+	}); err != nil {
+		return agentbackend.UtilizationSnapshot{}, fmt.Errorf("failed to list pods for pool %s: %w", ref.ID, err)
+	}
+
+	var measured map[string]agentbackend.ResourceUtilization
+	if b.usage != nil {
+		var err error
+		measured, err = b.usage.PodUsage(ctx, b.opts.Namespace, poolLabel+"="+sanitize(ref.ID))
+		if err != nil {
+			return agentbackend.UtilizationSnapshot{}, fmt.Errorf("failed to read pool usage for %s: %w", ref.ID, err)
+		}
+	}
+
+	// instanceID -> measured usage, summed over that instance's running pods.
+	byInstance := make(map[string]agentbackend.ResourceUtilization, len(pods.Items))
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		id := pod.Labels[instanceLabel]
+		if id == "" || !pod.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if usage, ok := measured[pod.Name]; ok {
+			current := byInstance[id]
+			current.CPUVCPUs += usage.CPUVCPUs
+			current.MemoryBytes += usage.MemoryBytes
+			byInstance[id] = current
+		}
+	}
+
+	snapshot := agentbackend.UtilizationSnapshot{Timestamp: time.Now()}
+	for i := range deployments.Items {
+		deployment := &deployments.Items[i]
+		instanceID := deployment.Labels[instanceLabel]
+		if instanceID == "" || !deployment.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		usage, ok := byInstance[instanceID]
+		if !ok {
+			usage = requestsOf(deployment)
+		}
+
+		snapshot.Instances = append(snapshot.Instances, agentbackend.InstanceUtilization{
+			Ref: agentbackend.InstanceRef{
+				ID:        instanceID,
+				Namespace: deployment.Namespace,
+				UserID:    deployment.Labels[userLabel],
+				BackendID: deployment.Name,
+			},
+			State:       stateOf(deployment),
+			Utilization: usage,
+		})
+		snapshot.Pool.CPUVCPUs += usage.CPUVCPUs
+		snapshot.Pool.MemoryBytes += usage.MemoryBytes
+	}
+	// Storage is reported for the pool only. Sandboxes share one volume and are
+	// separated by subPath, which kubelet does not measure individually, so
+	// per-instance disk needs a node agent running du. Pool-level usage is left
+	// at zero rather than guessed when it cannot be attributed to the pool.
+	if b.usage != nil {
+		var claim corev1.PersistentVolumeClaim
+		if err := b.cachedClient.Get(ctx, kclient.ObjectKey{Name: poolName(ref.ID), Namespace: b.opts.Namespace}, &claim); err != nil && !apierrors.IsNotFound(err) {
+			return agentbackend.UtilizationSnapshot{}, fmt.Errorf("failed to read pool volume for %s: %w", ref.ID, err)
+		}
+		if node := poolNode(pods.Items); node != "" {
+			used, trusted, err := b.usage.PoolVolumeUsage(ctx, node, b.opts.Namespace, poolName(ref.ID), claimCapacityBytes(&claim))
+			if err != nil {
+				return agentbackend.UtilizationSnapshot{}, fmt.Errorf("failed to read pool volume usage for %s: %w", ref.ID, err)
+			}
+			if trusted {
+				snapshot.Pool.StorageBytes = used
+				snapshot.StorageMeasured = true
+			}
+		}
+	}
+
+	sort.Slice(snapshot.Instances, func(i, j int) bool {
+		return snapshot.Instances[i].Ref.ID < snapshot.Instances[j].Ref.ID
+	})
+	return snapshot, nil
+}
+
+// requestsOf reports what a sandbox has actually reserved from the pool.
+//
+// Requests rather than limits, because a pool's Capacity is the requests
+// budget: the quota's limits budget is that capacity multiplied by the
+// overcommit ratio. Reporting limits against a requests-denominated capacity
+// makes any pool with sandboxes in it read as fully consumed, which is what the
+// admin UI showed before this was corrected.
+func requestsOf(deployment *appsv1.Deployment) agentbackend.ResourceUtilization {
+	var usage agentbackend.ResourceUtilization
+	replicas := int64(1)
+	if deployment.Spec.Replicas != nil {
+		replicas = int64(*deployment.Spec.Replicas)
+	}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if cpu, ok := container.Resources.Requests[corev1.ResourceCPU]; ok {
+			usage.CPUVCPUs += float64(cpu.MilliValue()) / 1000 * float64(replicas)
+		}
+		if memory, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
+			usage.MemoryBytes += memory.Value() * replicas
+		}
+	}
+	return usage
+}
+
+func stateOf(deployment *appsv1.Deployment) agentbackend.State {
+	if !deployment.DeletionTimestamp.IsZero() {
+		return agentbackend.StateDeleting
+	}
+	if deployment.Status.ReadyReplicas > 0 {
+		return agentbackend.StateReady
+	}
+	return agentbackend.StatePending
+}
+
+// poolNode returns the node a pool's sandboxes run on. A pool is confined to
+// one node by its ReadWriteOnce volume, so any running pod identifies it.
+func poolNode(pods []corev1.Pod) string {
+	for i := range pods {
+		if pods[i].Spec.NodeName != "" && pods[i].DeletionTimestamp.IsZero() {
+			return pods[i].Spec.NodeName
+		}
+	}
+	return ""
+}
+
+// claimCapacityBytes prefers the bound capacity over the request, since a
+// provisioner may round up and the bound value is what actually exists.
+func claimCapacityBytes(claim *corev1.PersistentVolumeClaim) int64 {
+	if capacity, ok := claim.Status.Capacity[corev1.ResourceStorage]; ok {
+		return capacity.Value()
+	}
+	if request, ok := claim.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+		return request.Value()
+	}
+	return 0
+}


### PR DESCRIPTION
An instance becomes a Deployment, and a pool becomes the volume and priority
class its instances share. Instances are separated by a subPath on the pool's
volume rather than by a volume each, so a pool is one claim however many
instances it holds.

A sandbox is told nothing about Kubernetes: it reads its configuration from
files and serves on a port. What is here is the translation -- desired state to
objects, object status back to instance status, and utilization from the
metrics API when it is available, degrading to requested resources when it is
not.

Two details exist because Obot usually runs outside the cluster in development.
ReachableServerURL rewrites a loopback address to the node's, since a sandbox
resolving "localhost" would find itself; and the dev proxy reaches a sandbox
through the API server, which is deliberately confined to development because
it grants access to every Service in the cluster.



---

Part 3 of an 11-PR stack. Base: `darren/hosted-agents-02-backend-interface`.

## Stack

1. #7448 — Resource model
2. #7449 — Sandbox backend interface
**→ 3. #7450 — Kubernetes sandbox backend** (this PR)
4. #7451 — Sandbox reachability (models + MCP)
5. #7452 — Terminal + HTTP publish
6. #7453 — Server wiring + Helm
7. #7454 — Controllers / reconcilers
8. #7455 — REST API
9. #7456 — Admin UI
10. #7457 — User UI
11. #7458 — Seed default config source

Merge bottom-up; GitHub retargets each child when its parent merges.
