### PR TITLE
feat: let a sandbox reach the models and MCP servers it was granted (4/11)

### DIFF
--- a/pkg/api/authz/agentconnect_test.go
+++ b/pkg/api/authz/agentconnect_test.go
@@ -1,0 +1,65 @@
+package authz
+
+import (
+	"net/http"
+	"testing"
+
+	types "github.com/obot-platform/obot/apiclient/types"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func agentConnectRequest(path string) *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, path, nil)
+	return req
+}
+
+// An unauthenticated caller must reach the handler so a browser is redirected
+// to sign in. The handler redirects before reading anything, so this exposes
+// nothing -- not even whether the instance exists.
+func TestAllowAgentConnectSignInForUnauthenticated(t *testing.T) {
+	a := &Authorizer{}
+	anonymous := newUser(&user.DefaultInfo{Name: "anonymous", Groups: []string{UnauthenticatedGroup}})
+
+	if !a.allowAgentConnectSignIn(agentConnectRequest("/agent-connect/hai1abc"), anonymous) {
+		t.Error("an unauthenticated caller must reach the handler to be sent to sign in")
+	}
+	if !a.allowAgentConnectSignIn(agentConnectRequest("/agent-connect/hai1abc/some/path"), anonymous) {
+		t.Error("sub-paths must behave the same")
+	}
+}
+
+// The allowance must not become a way to reach anything else.
+func TestAllowAgentConnectSignInIsScopedToTheRoute(t *testing.T) {
+	a := &Authorizer{}
+	anonymous := newUser(&user.DefaultInfo{Name: "anonymous", Groups: []string{UnauthenticatedGroup}})
+
+	for _, path := range []string{
+		"/api/hosted-agent-instances",
+		"/api/hosted-agent-instances/hai1abc",
+		"/mcp-connect/ms1abc",
+		"/api/llm-proxy/openai/v1/chat/completions",
+		"/agent-connectX/hai1abc",
+		"/",
+	} {
+		if a.allowAgentConnectSignIn(agentConnectRequest(path), anonymous) {
+			t.Errorf("%s must not be reachable through the sign-in allowance", path)
+		}
+	}
+}
+
+// The branch is for unauthenticated callers only. An authenticated one must go
+// through apiResources, where checkHostedAgentInstance narrows to the owner --
+// otherwise any signed-in user could proxy to anyone's sandbox.
+func TestAllowAgentConnectSignInRejectsAuthenticatedCallers(t *testing.T) {
+	a := &Authorizer{}
+
+	for _, u := range []user.Info{
+		&user.DefaultInfo{Name: "someone@example.com", UID: "7", Groups: []string{types.GroupAuthenticated}},
+		&user.DefaultInfo{Name: "admin@example.com", UID: "1", Groups: []string{types.GroupAuthenticated, "admin"}},
+		&user.DefaultInfo{Name: "hosted-agent:hai1zzz", UID: "hosted-agent:hai1zzz", Groups: []string{types.GroupAuthenticated, "hosted-agent"}},
+	} {
+		if a.allowAgentConnectSignIn(agentConnectRequest("/agent-connect/hai1abc"), newUser(u)) {
+			t.Errorf("%s must be authorized against the instance, not waved through", u.GetName())
+		}
+	}
+}

--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"net/http"
 	"slices"
+	"strings"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
 	"github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/hostedagentaccessrule"
 	"github.com/obot-platform/obot/pkg/skillaccessrule"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -126,6 +128,19 @@ var (
 		"/api/skill-repositories/",
 		"/api/skill-access-rules",
 		"/api/skill-access-rules/",
+		"/api/agent-catalogs",
+		"/api/agent-catalogs/",
+		"/api/harnesses",
+		"/api/harnesses/",
+		"/api/hosted-agents",
+		"/api/hosted-agents/",
+		"/api/hosted-agent-access-rules",
+		"/api/hosted-agent-access-rules/",
+		"/api/hosted-agent-pools",
+		"/api/hosted-agent-pools/",
+		"/api/hosted-agent-pool-defaults",
+		"/api/hosted-agent-pool-assignments",
+		"/api/hosted-agent-pool-assignments/",
 		"GET /api/eula",
 		"PUT /api/eula",
 		"PUT /api/app-preferences",
@@ -194,6 +209,14 @@ var (
 			"GET /api/skill-repositories/",
 			"GET /api/skill-access-rules",
 			"GET /api/skill-access-rules/",
+			"GET /api/agent-catalogs",
+			"GET /api/agent-catalogs/",
+			"GET /api/harnesses",
+			"GET /api/harnesses/",
+			"GET /api/hosted-agents",
+			"GET /api/hosted-agents/",
+			"GET /api/hosted-agent-access-rules",
+			"GET /api/hosted-agent-access-rules/",
 			"GET /api/message-policy-violations",
 			"GET /api/message-policy-violations/",
 			"GET /api/message-policy-violation-stats",
@@ -378,31 +401,33 @@ var (
 )
 
 type Authorizer struct {
-	rules          []rule
-	cache          kclient.Client
-	uncached       kclient.Client
-	gatewayClient  *client.Client
-	apiResources   map[string]*pathMatcher
-	acrHelper      *accesscontrolrule.Helper
-	skillHelper    *skillaccessrule.Helper
-	registryNoAuth bool
+	rules             []rule
+	cache             kclient.Client
+	uncached          kclient.Client
+	gatewayClient     *client.Client
+	apiResources      map[string]*pathMatcher
+	acrHelper         *accesscontrolrule.Helper
+	skillHelper       *skillaccessrule.Helper
+	hostedAgentHelper *hostedagentaccessrule.Helper
+	registryNoAuth    bool
 }
 
-func NewAuthorizer(gatewayClient *client.Client, cache, uncached kclient.Client, devMode bool, acrHelper *accesscontrolrule.Helper, skillHelper *skillaccessrule.Helper, registryNoAuth bool) *Authorizer {
+func NewAuthorizer(gatewayClient *client.Client, cache, uncached kclient.Client, devMode bool, acrHelper *accesscontrolrule.Helper, skillHelper *skillaccessrule.Helper, hostedAgentHelper *hostedagentaccessrule.Helper, registryNoAuth bool) *Authorizer {
 	apiBasedResources := make(map[string]*pathMatcher, len(apiResources))
 	for group, resources := range apiResources {
 		apiBasedResources[group] = newPathMatcher(resources...)
 	}
 
 	return &Authorizer{
-		rules:          defaultRules(devMode, registryNoAuth),
-		cache:          cache,
-		uncached:       uncached,
-		gatewayClient:  gatewayClient,
-		apiResources:   apiBasedResources,
-		acrHelper:      acrHelper,
-		skillHelper:    skillHelper,
-		registryNoAuth: registryNoAuth,
+		rules:             defaultRules(devMode, registryNoAuth),
+		cache:             cache,
+		uncached:          uncached,
+		gatewayClient:     gatewayClient,
+		apiResources:      apiBasedResources,
+		acrHelper:         acrHelper,
+		skillHelper:       skillHelper,
+		hostedAgentHelper: hostedAgentHelper,
+		registryNoAuth:    registryNoAuth,
 	}
 }
 
@@ -442,7 +467,24 @@ func (a *Authorizer) Authorize(req *http.Request, userInfo user.Info) bool {
 		}
 	}
 
-	return a.authorizeAPIResources(req, user) || a.checkOAuthClient(req) || a.checkUI(req, user)
+	return a.authorizeAPIResources(req, user) || a.allowAgentConnectSignIn(req, user) || a.checkOAuthClient(req) || a.checkUI(req, user)
+}
+
+// allowAgentConnectSignIn lets an unauthenticated request reach the
+// agent-connect handler so a browser is sent to sign in rather than shown a
+// bare 401.
+//
+// This grants no access. The handler redirects as its first action, before
+// reading any instance, so the response is identical whether or not the
+// instance exists and nothing is proxied. It deliberately does not use the
+// static-rule path, which returns authorized without evaluating resources and
+// would therefore let any caller reach any sandbox.
+//
+// Authenticated callers never take this branch: they are matched against
+// apiResources and narrowed to the instance's owner by checkHostedAgentInstance.
+func (a *Authorizer) allowAgentConnectSignIn(req *http.Request, user User) bool {
+	return slices.Contains(user.GetGroups(), UnauthenticatedGroup) &&
+		strings.HasPrefix(req.URL.Path, "/agent-connect/")
 }
 
 func (a *Authorizer) get(ctx context.Context, key kclient.ObjectKey, obj kclient.Object, opts ...kclient.GetOption) error {

--- a/pkg/api/authz/hostedagent.go
+++ b/pkg/api/authz/hostedagent.go
@@ -1,0 +1,52 @@
+package authz
+
+import (
+	"net/http"
+
+	"github.com/obot-platform/nah/pkg/router"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+)
+
+func (a *Authorizer) checkHostedAgent(req *http.Request, resources *Resources, u User) (bool, error) {
+	if resources.HostedAgentID == "" || u.IsAdmin || u.IsAuditor {
+		return true, nil
+	}
+
+	var agent v1.HostedAgent
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.HostedAgentID), &agent); err != nil {
+		return false, err
+	}
+
+	return a.hostedAgentHelper.UserHasAccessToHostedAgent(u, &agent)
+}
+
+func (a *Authorizer) checkHostedAgentInstance(req *http.Request, resources *Resources, u User) (bool, error) {
+	if resources.HostedAgentInstanceID == "" {
+		return true, nil
+	}
+
+	var instance v1.HostedAgentInstance
+	if err := a.get(req.Context(), router.Key(system.DefaultNamespace, resources.HostedAgentInstanceID), &instance); err != nil {
+		return false, err
+	}
+
+	if u.IsAdmin || u.IsAuditor {
+		resources.Authorizated.HostedAgentInstance = &instance
+		return true, nil
+	}
+
+	// An instance is only reachable by its owner, and only for as long as they
+	// still have access to the agent it was created from.
+	if instance.Spec.UserID != u.GetUID() {
+		return false, nil
+	}
+
+	hasAccess, err := a.hostedAgentHelper.UserHasAccessToHostedAgentID(u, instance.Spec.HostedAgentName)
+	if err != nil || !hasAccess {
+		return false, err
+	}
+
+	resources.Authorizated.HostedAgentInstance = &instance
+	return true, nil
+}

--- a/pkg/api/authz/hostedagentmcp_test.go
+++ b/pkg/api/authz/hostedagentmcp_test.go
@@ -1,0 +1,84 @@
+package authz
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	types2 "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/principal"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func agentUser(grants ...string) User {
+	return User{Info: &kuser.DefaultInfo{
+		Name:   "hosted-agent:hai1",
+		UID:    "hosted-agent:hai1",
+		Groups: []string{types2.GroupHostedAgent, types2.GroupAuthenticated, types2.GroupMCP},
+		Extra: map[string][]string{
+			"authorized_mcp_ids":       grants,
+			"hosted_agent_instance_id": {"hai1"},
+		},
+	}}
+}
+
+// An agent is not a user, so every user-shaped access check denies it: it owns
+// no server, belongs to no catalog and matches no access control rule. Its
+// grant list is what authorizes it, or it can never reach the MCP servers it
+// was configured with.
+func TestHostedAgentReachesItsGrantedServer(t *testing.T) {
+	client := fakeclient.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		&v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "ms1github", Namespace: "obot"}},
+	).Build()
+	authorizer := &Authorizer{uncached: client}
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp-connect/ms1github", nil)
+	ok, err := authorizer.checkMCPID(req, &Resources{MCPID: "ms1github"}, agentUser("ms1github"))
+	if err != nil {
+		t.Fatalf("checkMCPID: %v", err)
+	}
+	if !ok {
+		t.Fatal("an agent was denied the MCP server it was granted")
+	}
+}
+
+// The grant list is the whole authority, so a server absent from it is denied.
+func TestHostedAgentCannotReachAnUngrantedServer(t *testing.T) {
+	client := fakeclient.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		&v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "ms1secret", Namespace: "obot"}},
+	).Build()
+	authorizer := &Authorizer{uncached: client}
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp-connect/ms1secret", nil)
+	ok, _ := authorizer.checkMCPID(req, &Resources{MCPID: "ms1secret"}, agentUser("ms1github"))
+	if ok {
+		t.Fatal("an agent reached a server it was never granted")
+	}
+}
+
+// An agent with no servers must reach none. Falling through to "allow" on an
+// empty list is how a caller with no grants ends up with every grant.
+func TestHostedAgentWithNoGrantsReachesNothing(t *testing.T) {
+	client := fakeclient.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		&v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "ms1github", Namespace: "obot"}},
+	).Build()
+	authorizer := &Authorizer{uncached: client}
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp-connect/ms1github", nil)
+	ok, _ := authorizer.checkMCPID(req, &Resources{MCPID: "ms1github"}, agentUser())
+	if ok {
+		t.Fatal("an agent with no granted servers reached one")
+	}
+}
+
+// The agent path must not weaken the user path: a real user is still checked
+// against catalogs, ownership and access rules.
+func TestOrdinaryUserStillGoesThroughAccessChecks(t *testing.T) {
+	if principal.IsHostedAgent(&kuser.DefaultInfo{Groups: []string{types2.GroupAuthenticated}}) {
+		t.Fatal("an ordinary user must not be treated as a hosted agent")
+	}
+}

--- a/pkg/api/authz/license_test.go
+++ b/pkg/api/authz/license_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLicenseRouteAuthorization(t *testing.T) {
-	authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, false)
+	authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, nil, false)
 	users := []struct {
 		name      string
 		info      user.Info

--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
+	"github.com/obot-platform/obot/pkg/principal"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +22,23 @@ func (a *Authorizer) checkMCPID(req *http.Request, resources *Resources, user Us
 		// The handler will catch this and support the WWW-Authenticate header to trigger the login flow.
 		return true, nil
 	}
+	// A hosted agent is authorized by what it was granted, not by what its
+	// owner can currently reach.
+	//
+	// The checks below ask whether the caller is a user with access to this
+	// server -- through a catalog, a workspace, or ownership. An agent is none
+	// of those: it is a principal of its own, so every one of them denies it and
+	// an agent could never reach the MCP servers it was configured with.
+	//
+	// Its grant list is the authority instead. That list is not self-asserted:
+	// servers on the template were granted by the administrator who published
+	// it, and servers on the instance were checked against the owner when they
+	// were attached.
+	if principal.IsHostedAgent(user.Info) {
+		return MCPIDIsAuthorized(req.Context(), a.uncached,
+			user.GetExtra()["authorized_mcp_ids"], user.GetUID(), resources.MCPID)
+	}
+
 	if authorized, err := CheckMCPIDAccess(req.Context(), a.uncached, a.acrHelper, user.Info, resources.MCPID); err != nil || !authorized {
 		return false, err
 	}

--- a/pkg/api/authz/mcpid_test.go
+++ b/pkg/api/authz/mcpid_test.go
@@ -539,7 +539,7 @@ func TestMCPConnectSubtreeAuthorization(t *testing.T) {
 			},
 		},
 	).Build()
-	authorizer := NewAuthorizer(nil, storage, storage, false, nil, nil, false)
+	authorizer := NewAuthorizer(nil, storage, storage, false, nil, nil, nil, false)
 
 	tests := []struct {
 		name    string

--- a/pkg/api/authz/mcpoauth_test.go
+++ b/pkg/api/authz/mcpoauth_test.go
@@ -24,7 +24,7 @@ func TestMCPGroupAllowsMCPAndAnyGroupRoutes(t *testing.T) {
 			UserID: "mcpoauth-user-uid",
 		},
 	}).Build()
-	authorizer := NewAuthorizer(nil, storage, storage, false, nil, nil, false)
+	authorizer := NewAuthorizer(nil, storage, storage, false, nil, nil, nil, false)
 	mcpUser := &user.DefaultInfo{
 		Name:   "mcp-user",
 		UID:    "mcpoauth-user-uid",
@@ -73,7 +73,7 @@ func TestDefaultAuthorizerAllowsMCPProxyRoutes(t *testing.T) {
 			UserID: "mcp-user-uid",
 		},
 	}).Build()
-	authorizer := NewAuthorizer(nil, storage, storage, false, nil, nil, false)
+	authorizer := NewAuthorizer(nil, storage, storage, false, nil, nil, nil, false)
 	mcpUser := &user.DefaultInfo{
 		Name:   "mcp-user",
 		UID:    "mcp-user-uid",
@@ -118,7 +118,7 @@ func TestDefaultAuthorizerAllowsMCPProxyRoutes(t *testing.T) {
 }
 
 func TestMCPGroupDeniesNonMCPAPIRoutes(t *testing.T) {
-	authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, false)
+	authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, nil, false)
 	mcpUser := &user.DefaultInfo{
 		Name:   "mcp-user",
 		UID:    "mcp-user-uid",

--- a/pkg/api/authz/mcpsecretbindings_test.go
+++ b/pkg/api/authz/mcpsecretbindings_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMCPSecretBindingRouteAuthorization(t *testing.T) {
-	authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, false)
+	authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, nil, false)
 
 	tests := []struct {
 		name    string

--- a/pkg/api/authz/mcpservercatalogentry_test.go
+++ b/pkg/api/authz/mcpservercatalogentry_test.go
@@ -111,5 +111,5 @@ func newCatalogEntryTestAuthorizer(t *testing.T, storage client.Client, acrs ...
 		}
 	}
 
-	return NewAuthorizer(nil, storage, storage, false, accesscontrolrule.NewAccessControlRuleHelper(indexer, storage), nil, false)
+	return NewAuthorizer(nil, storage, storage, false, accesscontrolrule.NewAccessControlRuleHelper(indexer, storage), nil, nil, false)
 }

--- a/pkg/api/authz/publishedartifact_test.go
+++ b/pkg/api/authz/publishedartifact_test.go
@@ -36,7 +36,7 @@ func TestPublishedArtifactAuthorization(t *testing.T) {
 			},
 		},
 	}).Build()
-	authorizer := NewAuthorizer(nil, storage, storage, false, nil, nil, false)
+	authorizer := NewAuthorizer(nil, storage, storage, false, nil, nil, nil, false)
 
 	tests := []struct {
 		name    string

--- a/pkg/api/authz/registry_test.go
+++ b/pkg/api/authz/registry_test.go
@@ -50,7 +50,7 @@ func TestRegistryRouteAuthorization(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, tt.registryNoAuth)
+			authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, nil, tt.registryNoAuth)
 			req := httptest.NewRequest(http.MethodGet, "/v0.1/servers", nil)
 
 			if allowed := authorizer.Authorize(req, tt.user); allowed != tt.allowed {

--- a/pkg/api/authz/resources.go
+++ b/pkg/api/authz/resources.go
@@ -9,6 +9,19 @@ import (
 
 var apiResources = map[string][]string{
 	types.GroupAPI: {
+		"GET    /api/hosted-agents",
+		"GET    /api/hosted-agents/{hosted_agent_id}",
+		"GET    /api/hosted-agent-instances",
+		"POST   /api/hosted-agent-instances",
+		"GET    /api/hosted-agent-instances/{hosted_agent_instance_id}",
+		"PUT    /api/hosted-agent-instances/{hosted_agent_instance_id}",
+		"DELETE /api/hosted-agent-instances/{hosted_agent_instance_id}",
+		"GET    /api/hosted-agent-instances/{hosted_agent_instance_id}/terminal",
+		"GET    /api/hosted-agent-pools",
+		"GET    /api/hosted-agent-pools/{hosted_agent_pool_id}",
+		"GET    /api/hosted-agent-pools/{hosted_agent_pool_id}/utilization",
+		"GET    /api/hosted-agent-pool-assignments",
+		"GET    /api/hosted-agent-pool-assignments/{hosted_agent_pool_assignment_id}",
 		"GET    /api/all-mcps/servers/{mcpserver_id}",
 		"GET    /api/all-mcps/servers/{mcpserver_id}/tools",
 		"GET    /api/all-mcps/servers/{mcpserver_id}/resources",
@@ -116,6 +129,14 @@ var apiResources = map[string][]string{
 		"GET    /api/workspaces/{workspace_id}/access-control-rules/{access_control_rule_id}",
 		"PUT    /api/workspaces/{workspace_id}/access-control-rules/{access_control_rule_id}",
 	},
+	types.GroupAuthenticated: {
+		// Reaching an agent's own HTTP port. Any authenticated user may match
+		// this route; checkHostedAgentInstance then narrows it to the instance's
+		// owner. No method is given because the agent behind it serves whatever
+		// it likes.
+		"/agent-connect/{hosted_agent_instance_id}",
+		"/agent-connect/{hosted_agent_instance_id}/{rest...}",
+	},
 	types.GroupMCP: {
 		"GET    /mcp-connect/{mcp_id}",
 		"POST   /mcp-connect/{mcp_id}",
@@ -156,16 +177,18 @@ type Resources struct {
 	MCPServerInstanceID     string
 	MCPServerCatalogEntryID string
 	// MCPID can be the ID of an MCPServer, an MCPServerInstance, or MCPServerCatalogEntry. It is used for interaction with the MCP gateway.
-	MCPID               string
-	WorkspaceID         string
-	NanobotAgentID      string
-	ProjectID           string
-	PublishedArtifactID string
-	ArtifactVersion     string
-	SkillID             string
-	DeviceScanID        string
-	OAuthAuthRequestID  string
-	Authorizated        ResourcesAuthorized
+	MCPID                 string
+	WorkspaceID           string
+	NanobotAgentID        string
+	ProjectID             string
+	PublishedArtifactID   string
+	ArtifactVersion       string
+	SkillID               string
+	DeviceScanID          string
+	OAuthAuthRequestID    string
+	HostedAgentID         string
+	HostedAgentInstanceID string
+	Authorizated          ResourcesAuthorized
 }
 
 type ResourcesAuthorized struct {
@@ -177,6 +200,8 @@ type ResourcesAuthorized struct {
 	Project               *v1.Project
 	PublishedArtifact     *v1.PublishedArtifact
 	Skill                 *v1.Skill
+	HostedAgent           *v1.HostedAgent
+	HostedAgentInstance   *v1.HostedAgentInstance
 }
 
 func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user User) (bool, error) {
@@ -193,6 +218,8 @@ func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user User
 		SkillID:                 vars("skill_id"),
 		DeviceScanID:            vars("scan_id"),
 		OAuthAuthRequestID:      vars("oauth_request_id"),
+		HostedAgentID:           vars("hosted_agent_id"),
+		HostedAgentInstanceID:   vars("hosted_agent_instance_id"),
 	}
 
 	if !a.checkUser(user, vars("user_id")) {
@@ -232,6 +259,14 @@ func (a *Authorizer) evaluateResources(req *http.Request, vars GetVar, user User
 	}
 
 	if ok, err := a.checkSkill(req, &resources, user); !ok || err != nil {
+		return false, err
+	}
+
+	if ok, err := a.checkHostedAgent(req, &resources, user); !ok || err != nil {
+		return false, err
+	}
+
+	if ok, err := a.checkHostedAgentInstance(req, &resources, user); !ok || err != nil {
 		return false, err
 	}
 

--- a/pkg/api/authz/skills_test.go
+++ b/pkg/api/authz/skills_test.go
@@ -319,7 +319,7 @@ func newSkillRouteTestAuthorizer(t *testing.T) *Authorizer {
 		},
 	})
 
-	return NewAuthorizer(nil, storage, storage, false, nil, skillaccessrule.NewHelper(indexer), false)
+	return NewAuthorizer(nil, storage, storage, false, nil, skillaccessrule.NewHelper(indexer), nil, false)
 }
 
 func newSkillAccessRuleTestAuthorizer(t *testing.T, skill *v1.Skill, rules ...*v1.SkillAccessRule) *Authorizer {
@@ -364,7 +364,7 @@ func newSkillAccessRuleTestAuthorizer(t *testing.T, skill *v1.Skill, rules ...*v
 		}
 	}
 
-	return NewAuthorizer(nil, storage, storage, false, nil, skillaccessrule.NewHelper(indexer), false)
+	return NewAuthorizer(nil, storage, storage, false, nil, skillaccessrule.NewHelper(indexer), nil, false)
 }
 
 func skillUser(uid string) user.Info {

--- a/pkg/api/authz/tunnel_test.go
+++ b/pkg/api/authz/tunnel_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTunnelAuthorization(t *testing.T) {
-	authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, false)
+	authorizer := NewAuthorizer(nil, nil, nil, false, nil, nil, nil, false)
 
 	tests := []struct {
 		name    string

--- a/pkg/gateway/client/apikey.go
+++ b/pkg/gateway/client/apikey.go
@@ -158,6 +158,70 @@ func (c *Client) CreateAPIKey(ctx context.Context, userID uint, name, descriptio
 	return resp, nil
 }
 
+// CreateHostedAgentAPIKey issues the credential a hosted agent sandbox uses to
+// reach the MCP gateway and the model proxy.
+//
+// The key authenticates as the agent, not as its owner, so ownerUserID is
+// recorded for attribution and cleanup only and confers none of that user's
+// access. Scopes are deliberately limited to the gateway and the proxy: an
+// agent must never reach the Obot API, or an exfiltrated credential could
+// enumerate or modify resources.
+//
+// MCPServerIDs is left empty on purpose. Authentication resolves the instance
+// and fills the authorized servers from its live configuration, so narrowing an
+// agent takes effect without reissuing this key.
+//
+// The key does not expire. Agents read their credential once at startup and
+// cannot reload it, so expiry would strand a running sandbox.
+func (c *Client) CreateHostedAgentAPIKey(ctx context.Context, instanceID string, ownerUserID uint, name string) (*types.APIKeyCreateResponse, error) {
+	if instanceID == "" {
+		return nil, fmt.Errorf("hosted agent instance ID is required")
+	}
+
+	var resp *types.APIKeyCreateResponse
+	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var err error
+		resp, err = c.createAPIKey(tx, ownerUserID, name, "Hosted agent sandbox credential", nil, types.APIKeyScopes{
+			CanAccessLLMProxy: true,
+			CanAccessSkills:   true,
+		})
+		if err != nil {
+			return err
+		}
+		resp.HostedAgentInstanceID = &instanceID
+		return tx.Model(&types.APIKey{}).Where("id = ?", resp.ID).
+			Update("hosted_agent_instance_id", instanceID).Error
+	}); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// DeleteHostedAgentAPIKeys revokes every key bound to an instance. Revocation
+// is a row delete, so a leaked credential stops working immediately rather than
+// waiting for an expiry that hosted agent keys deliberately do not have.
+func (c *Client) DeleteHostedAgentAPIKeys(ctx context.Context, instanceID string) error {
+	if instanceID == "" {
+		return nil
+	}
+	if err := c.db.WithContext(ctx).Where("hosted_agent_instance_id = ?", instanceID).
+		Delete(&types.APIKey{}).Error; err != nil {
+		return fmt.Errorf("failed to delete hosted agent API keys: %w", err)
+	}
+	return nil
+}
+
+// HostedAgentAPIKeys returns the keys bound to an instance, without secrets.
+func (c *Client) HostedAgentAPIKeys(ctx context.Context, instanceID string) ([]types.APIKey, error) {
+	var keys []types.APIKey
+	if err := c.db.WithContext(ctx).Where("hosted_agent_instance_id = ?", instanceID).
+		Order("created_at DESC").Find(&keys).Error; err != nil {
+		return nil, fmt.Errorf("failed to list hosted agent API keys: %w", err)
+	}
+	return keys, nil
+}
+
 // CreateAPIKeyFromTokenRequest creates an API key from a token request.
 func (c *Client) CreateAPIKeyFromTokenRequest(ctx context.Context, userID uint, tr *types.TokenRequest) (*types.APIKeyCreateResponse, error) {
 	var expiresAt *time.Time

--- a/pkg/gateway/client/mcpauditlog.go
+++ b/pkg/gateway/client/mcpauditlog.go
@@ -1063,7 +1063,7 @@ func (c *Client) GetMCPUsageStats(ctx context.Context, opts MCPUsageStatsOptions
 	}, nil
 }
 
-// MCPAuditLogOptions configures audit-row queries across MCP and local-agent sources. Common
+// MCPAuditLogOptions configures audit-row queries across MCP and local-agent catalogs. Common
 // filters apply to every selected source. MCP-only and local-agent-only filters are mutually
 // exclusive; ValidateAuditLogOptions enforces those rules before a query runs.
 type MCPAuditLogOptions struct {

--- a/pkg/gateway/client/mcpauditlog_test.go
+++ b/pkg/gateway/client/mcpauditlog_test.go
@@ -151,7 +151,7 @@ func TestInsertLocalAgentAuditLogsCompletedSuccess(t *testing.T) {
 		t.Fatalf("load stored audit log: %v", err)
 	}
 	if stored.SourceType != types2.AuditLogSourceTypeLocalAgentToolCall {
-		t.Fatalf("expected local-agent source type, got %q", stored.SourceType)
+		t.Fatalf("expected local-agent catalog type, got %q", stored.SourceType)
 	}
 	if stored.MCPFields != nil && (stored.MCPFields.MCPID != "" || len(stored.MCPFields.RequestBody) > 0 || len(stored.MCPFields.ResponseBody) > 0) {
 		t.Fatalf("expected no populated MCP fields, got %#v", stored.MCPFields)
@@ -379,7 +379,7 @@ func TestGetLocalAgentAuditLogsFiltersBySourceTypeAndBlanksPayloads(t *testing.T
 	}
 	got := logs[0]
 	if got.SourceType != types2.AuditLogSourceTypeLocalAgentToolCall {
-		t.Fatalf("expected local-agent source type, got %q", got.SourceType)
+		t.Fatalf("expected local-agent catalog type, got %q", got.SourceType)
 	}
 	if got.MCPFields != nil {
 		t.Fatalf("expected MCP fields to be nil for local-agent list row, got %#v", got.MCPFields)

--- a/pkg/gateway/server/apikey_auth.go
+++ b/pkg/gateway/server/apikey_auth.go
@@ -1,13 +1,21 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
+	types2 "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/alias"
 	"github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/principal"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const apiKeyAuthPrefix = "ok1-"
@@ -17,11 +25,95 @@ const apiKeyAuthPrefix = "ok1-"
 // not the full authenticated user groups.
 type APIKeyAuthenticator struct {
 	client *client.Client
+	// storage resolves hosted agent instances for agent-bound keys. Those keys
+	// carry no permissions of their own, so the instance has to be read on each
+	// request.
+	storage kclient.Client
 }
 
 // NewAPIKeyAuthenticator creates a new API key authenticator.
-func NewAPIKeyAuthenticator(client *client.Client) *APIKeyAuthenticator {
-	return &APIKeyAuthenticator{client: client}
+func NewAPIKeyAuthenticator(client *client.Client, storage kclient.Client) *APIKeyAuthenticator {
+	return &APIKeyAuthenticator{client: client, storage: storage}
+}
+
+// hostedAgentGroups is the complete group set a sandbox principal carries.
+//
+// GroupAPI is deliberately absent and must stay absent: it is the only thing
+// keeping an exfiltrated agent credential away from the Obot API, since
+// authorization elsewhere decides which servers and models an agent may use but
+// nothing else restricts which endpoints accept it.
+func hostedAgentGroups(hasMCPServers bool) []string {
+	groups := []string{
+		types2.GroupHostedAgent,
+		types2.GroupAuthenticated,
+		types2.GroupLLM,
+		types2.GroupSkills,
+	}
+	if hasMCPServers {
+		groups = append(groups, types2.GroupMCP)
+	}
+	return groups
+}
+
+// authenticateHostedAgent builds a principal for a sandbox.
+//
+// The agent's authorized MCP servers are read from the instance every time
+// rather than from the key, which is what lets an administrator withdraw access
+// and have it take effect at once — even while the sandbox is still running
+// with stale configuration, and even if the restart that would replace it
+// cannot be scheduled.
+//
+// The principal never carries GroupAPI, so an exfiltrated agent credential
+// cannot reach the Obot API.
+func (a *APIKeyAuthenticator) authenticateHostedAgent(req *http.Request, instanceID string) (*authenticator.Response, bool, error) {
+	if a.storage == nil {
+		return nil, false, nil
+	}
+
+	var instance v1.HostedAgentInstance
+	if err := a.storage.Get(req.Context(), kclient.ObjectKey{
+		Name:      instanceID,
+		Namespace: system.DefaultNamespace,
+	}, &instance); err != nil {
+		// A key outliving its instance authenticates as nothing.
+		return nil, false, nil
+	}
+	if !instance.DeletionTimestamp.IsZero() {
+		return nil, false, nil
+	}
+
+	var agent v1.HostedAgent
+	if err := a.storage.Get(req.Context(), kclient.ObjectKey{
+		Name:      instance.Spec.HostedAgentName,
+		Namespace: system.DefaultNamespace,
+	}, &agent); err != nil {
+		return nil, false, nil
+	}
+
+	// Template resources are granted by the administrator who published the
+	// agent; instance resources were checked against the owner when they were
+	// attached. Neither is re-checked against the owner here, by design.
+	mcpIDs := slices.Concat(agent.Spec.Manifest.MCPServers, instance.Spec.Manifest.MCPServers)
+	modelIDs := a.resolveAgentModelIDs(req.Context(),
+		slices.Concat(agent.Spec.Manifest.Models, instance.Spec.Manifest.Models))
+
+	groups := hostedAgentGroups(len(mcpIDs) > 0)
+
+	return &authenticator.Response{
+		User: &user.DefaultInfo{
+			Name:   "hosted-agent:" + instance.Name,
+			UID:    "hosted-agent:" + instance.Name,
+			Groups: groups,
+			Extra: map[string][]string{
+				// The same key a user API key populates, so downstream
+				// authorization needs no agent-specific branch.
+				"authorized_mcp_ids":            mcpIDs,
+				"authorized_model_ids":          modelIDs,
+				"hosted_agent_instance_id":      {instance.Name},
+				principal.HostedAgentOwnerExtra: {instance.Spec.UserID},
+			},
+		},
+	}, true, nil
 }
 
 // AuthenticateRequest implements authenticator.Request.
@@ -45,6 +137,13 @@ func (a *APIKeyAuthenticator) AuthenticateRequest(req *http.Request) (*authentic
 		// Return false, nil to let other authenticators try
 		// This allows the chain to continue if the key is invalid
 		return nil, false, nil
+	}
+
+	// A key bound to a hosted agent authenticates as that agent, never as the
+	// user who created it, so it must not pick up the owner's identity, groups
+	// or role below.
+	if apiKey.HostedAgentInstanceID != nil && *apiKey.HostedAgentInstanceID != "" {
+		return a.authenticateHostedAgent(req, *apiKey.HostedAgentInstanceID)
 	}
 
 	// Get the user from the database
@@ -73,4 +172,43 @@ func (a *APIKeyAuthenticator) AuthenticateRequest(req *http.Request) (*authentic
 			Extra:  extra,
 		},
 	}, true, nil
+}
+
+// resolveAgentModelIDs turns an agent's configured model references into the
+// concrete model IDs the proxy compares against.
+//
+// A reference may be an "obot://<alias>" pointer to a default model alias, and
+// the proxy's check is a literal match against the model being requested. An
+// unexpanded alias therefore matches nothing, so an agent configured only with
+// aliases -- which is how the bundled templates are written, since an alias is
+// the only model reference that works on any installation -- would be denied
+// every model it was granted.
+//
+// Non-alias entries pass through untouched, including the "*" wildcard, which
+// the proxy understands directly. An alias that resolves to nothing is dropped:
+// it grants no access, and keeping it would only ever deny.
+func (a *APIKeyAuthenticator) resolveAgentModelIDs(ctx context.Context, refs []string) []string {
+	resolved := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		aliasName, isAlias := strings.CutPrefix(ref, types2.DefaultModelAliasRefPrefix)
+		if !isAlias {
+			resolved = append(resolved, ref)
+			continue
+		}
+
+		var defaultAlias v1.DefaultModelAlias
+		if err := a.storage.Get(ctx, kclient.ObjectKey{
+			Name:      aliasName,
+			Namespace: system.DefaultNamespace,
+		}, &defaultAlias); err != nil || defaultAlias.Spec.Manifest.Model == "" {
+			continue
+		}
+
+		var model v1.Model
+		if err := alias.Get(ctx, a.storage, &model, system.DefaultNamespace, defaultAlias.Spec.Manifest.Model); err != nil {
+			continue
+		}
+		resolved = append(resolved, model.Name)
+	}
+	return resolved
 }

--- a/pkg/gateway/server/apikey_auth_test.go
+++ b/pkg/gateway/server/apikey_auth_test.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	types2 "github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// A hosted agent must never reach the Obot API. Live authorization decides
+// which MCP servers it may use, but nothing narrows the API surface except the
+// absence of this group, so an exfiltrated credential would otherwise be able
+// to enumerate and modify Obot resources.
+func TestHostedAgentPrincipalNeverCarriesAPIGroup(t *testing.T) {
+	groups := hostedAgentGroups(true)
+
+	if slices.Contains(groups, types2.GroupAPI) {
+		t.Fatalf("a hosted agent principal must not carry %q: %v", types2.GroupAPI, groups)
+	}
+	if !slices.Contains(groups, types2.GroupHostedAgent) {
+		t.Errorf("expected %q, got %v", types2.GroupHostedAgent, groups)
+	}
+	for _, want := range []string{types2.GroupAuthenticated, types2.GroupLLM, types2.GroupSkills, types2.GroupMCP} {
+		if !slices.Contains(groups, want) {
+			t.Errorf("expected %q in %v", want, groups)
+		}
+	}
+}
+
+// An agent with no MCP servers should not present as an MCP client at all.
+func TestHostedAgentWithoutServersOmitsMCPGroup(t *testing.T) {
+	groups := hostedAgentGroups(false)
+
+	if slices.Contains(groups, types2.GroupMCP) {
+		t.Fatalf("expected no %q group when the agent has no servers: %v", types2.GroupMCP, groups)
+	}
+}
+
+// An agent's model access is what its instance was configured with, not what
+// its owner may currently reach.
+func TestModelAllowedForAgent(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		configured []string
+		modelID    string
+		want       bool
+	}{
+		{"exact match", []string{"m1-abc", "m1-def"}, "m1-abc", true},
+		{"not configured", []string{"m1-abc"}, "m1-def", false},
+		{"wildcard", []string{"*"}, "m1-anything", true},
+		{"nothing configured denies", nil, "m1-abc", false},
+		// Documented gap: alias references are not resolved yet, and denying is
+		// the safe direction while that is true.
+		{"alias reference is not expanded", []string{"obot://llm"}, "m1-abc", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := modelAllowedForAgent(tt.configured, tt.modelID); got != tt.want {
+				t.Errorf("modelAllowedForAgent(%v, %q) = %v, want %v", tt.configured, tt.modelID, got, tt.want)
+			}
+		})
+	}
+}
+
+// An agent configured with an alias must reach the model that alias points at.
+//
+// authorized_model_ids is compared literally against the model being requested,
+// so an unexpanded "obot://llm" matches nothing: an agent granted a model
+// through an alias -- which is how a template works on any installation, since
+// no specific model ID exists everywhere -- would be denied every request.
+func TestAgentModelAliasesAreExpandedForAuthorization(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		&v1.Model{
+			ObjectMeta: metav1.ObjectMeta{Name: "m1sonnet", Namespace: system.DefaultNamespace},
+			Spec: v1.ModelSpec{Manifest: types2.ModelManifest{
+				Name: "m1sonnet", TargetModel: "claude-sonnet-4-5", Active: true, Usage: types2.ModelUsageLLM,
+			}},
+		},
+		&v1.DefaultModelAlias{
+			ObjectMeta: metav1.ObjectMeta{Name: "llm", Namespace: system.DefaultNamespace},
+			Spec:       v1.DefaultModelAliasSpec{Manifest: types2.DefaultModelAliasManifest{Alias: "llm", Model: "m1sonnet"}},
+		},
+	).Build()
+
+	authenticator := &APIKeyAuthenticator{storage: client}
+	got := authenticator.resolveAgentModelIDs(context.Background(),
+		[]string{types2.DefaultModelAliasRefPrefix + "llm", "m1explicit", "*"})
+
+	if !slices.Contains(got, "m1sonnet") {
+		t.Errorf("the alias did not expand to its model: %v", got)
+	}
+	if slices.Contains(got, types2.DefaultModelAliasRefPrefix+"llm") {
+		t.Errorf("the unexpanded alias survived and would match nothing: %v", got)
+	}
+	// Everything else passes through: "*" is understood by the proxy directly,
+	// and a concrete ID needs no resolution.
+	for _, want := range []string{"m1explicit", "*"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("expected %q to pass through: %v", want, got)
+		}
+	}
+
+	// The end-to-end property: the proxy's own check now admits the model.
+	if !modelAllowedForAgent(got, "m1sonnet") {
+		t.Error("the agent is still denied the model its alias points at")
+	}
+}
+
+// An alias bound to nothing grants nothing, and must not be carried through as
+// a literal that could never match anyway.
+func TestUnboundAliasGrantsNothing(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		&v1.DefaultModelAlias{
+			ObjectMeta: metav1.ObjectMeta{Name: "llm", Namespace: system.DefaultNamespace},
+			Spec:       v1.DefaultModelAliasSpec{Manifest: types2.DefaultModelAliasManifest{Alias: "llm"}},
+		},
+	).Build()
+
+	authenticator := &APIKeyAuthenticator{storage: client}
+	got := authenticator.resolveAgentModelIDs(context.Background(), []string{types2.DefaultModelAliasRefPrefix + "llm"})
+	if len(got) != 0 {
+		t.Fatalf("an unbound alias should grant nothing, got %v", got)
+	}
+}

--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/messagepolicy"
 	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
+	"github.com/obot-platform/obot/pkg/principal"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -674,8 +675,11 @@ func (r *responseModifier) Close() error {
 	if r.tokenUsageTracker != nil {
 		usage := r.tokenUsageTracker.getTokenUsage()
 		r.audit.setTokenUsage(usage)
+		// Recorded against the owner for the same reason the limit is checked
+		// against them: an agent has no user row of its own, and its usage
+		// should still land on whoever created it.
 		activity := &types.RunTokenActivity{
-			UserID: r.user.GetUID(),
+			UserID: principal.ResourceOwnerID(r.user),
 			Model:  r.model,
 			Usage:  usage,
 		}
@@ -938,12 +942,22 @@ func (l *llmProviderProxy) proxy(req api.Context) (retErr error) {
 		prepared.model = model.Spec.Manifest.TargetModel
 		audit.setModel(modelProvider.Name, model.Name, prepared.model)
 
-		hasAccess, err := l.mapHelper.UserHasAccessToModel(req.User, model.Name)
-		if err != nil {
-			return fmt.Errorf("failed to check user access to model %q: %w", model.Name, err)
-		}
-		if !hasAccess {
-			return types2.NewErrForbidden("user does not have permission to use model %q", targetModel)
+		// A hosted agent's authority was fixed when its instance was created, so
+		// it is limited to the models configured on it rather than re-evaluated
+		// against access policies, which describe people and would not match a
+		// principal that is not one.
+		if agentModels, isAgent := req.User.GetExtra()["authorized_model_ids"]; isAgent || principal.IsHostedAgent(req.User) {
+			if !modelAllowedForAgent(agentModels, model.Name) {
+				return types2.NewErrForbidden("agent is not configured to use model %q", targetModel)
+			}
+		} else {
+			hasAccess, err := l.mapHelper.UserHasAccessToModel(req.User, model.Name)
+			if err != nil {
+				return fmt.Errorf("failed to check user access to model %q: %w", model.Name, err)
+			}
+			if !hasAccess {
+				return types2.NewErrForbidden("user does not have permission to use model %q", targetModel)
+			}
 		}
 
 		prepared.tokenUsageTracker = newTokenUsageTracker(*model)
@@ -986,9 +1000,15 @@ func (l *llmProviderProxy) proxy(req api.Context) (retErr error) {
 	req.Request.Body = io.NopCloser(bytes.NewReader(prepared.body))
 	req.ContentLength = int64(len(prepared.body))
 
+	// Daily token limits are a per-person quota, and a hosted agent is not a
+	// person: its UID identifies an instance, so a user lookup would fail. Bill
+	// the owner instead, so an agent still counts against whoever created it
+	// rather than escaping accounting altogether.
+	usageUserID := principal.ResourceOwnerID(req.User)
+
 	if remainingUsage, err := req.GatewayClient.RemainingTokenUsageForUser(
 		req.Context(),
-		req.User.GetUID(),
+		usageUserID,
 		tokenUsageTimePeriod,
 		l.dailyUserInputTokenLimit,
 		l.dailyUserOutputTokenLimit,
@@ -1112,4 +1132,18 @@ func shouldSkipMessagePolicyEnforcement(req *http.Request) bool {
 	}
 
 	return req.Header.Get(internalRequestTypeHeader) == threadTitleRequestType
+}
+
+// modelAllowedForAgent matches a model against an agent's configured list.
+//
+// The match is literal. Alias references are expanded into concrete model IDs
+// when the agent principal is built, so anything still carrying an "obot://"
+// prefix here failed to resolve and correctly grants nothing.
+//
+// Only exact IDs and the "*" wildcard are understood. Alias references such as
+// obot://llm and wildcard suffixes are not expanded here, so an agent
+// configured solely with those cannot yet reach a model through this proxy.
+// Denying is the safe direction while that resolution is missing.
+func modelAllowedForAgent(configured []string, modelID string) bool {
+	return slices.Contains(configured, "*") || slices.Contains(configured, modelID)
 }

--- a/pkg/gateway/types/apikeys.go
+++ b/pkg/gateway/types/apikeys.go
@@ -14,14 +14,26 @@ import (
 type APIKey struct {
 	APIKeyScopes `json:",inline"`
 
-	ID           uint       `json:"id" gorm:"primaryKey;autoIncrement"`
-	UserID       uint       `json:"userId" gorm:"index"`
-	Name         string     `json:"name"`                  // User-provided name for the key
-	Description  string     `json:"description,omitempty"` // Optional description
-	HashedSecret string     `json:"-"`                     // bcrypt hash of the secret portion only
-	CreatedAt    time.Time  `json:"createdAt"`
-	LastUsedAt   *time.Time `json:"lastUsedAt,omitempty"`
-	ExpiresAt    *time.Time `json:"expiresAt,omitempty"` // nil means no expiration
+	ID     uint `json:"id" gorm:"primaryKey;autoIncrement"`
+	UserID uint `json:"userId" gorm:"index"`
+
+	// HostedAgentInstanceID binds this key to a hosted agent rather than to a
+	// user. When set, the key authenticates as the agent: the principal
+	// identifies the instance, and its authorized MCP servers and models are
+	// resolved from the instance's live configuration rather than from the
+	// scopes stored here.
+	//
+	// An agent's authority is deliberately its own. A key that authenticated as
+	// its owner would turn a prompt injection or a compromised harness into
+	// full user-level access, whereas an agent key reaches only what that one
+	// instance was configured with.
+	HostedAgentInstanceID *string    `json:"hostedAgentInstanceID,omitempty" gorm:"index"`
+	Name                  string     `json:"name"`                  // User-provided name for the key
+	Description           string     `json:"description,omitempty"` // Optional description
+	HashedSecret          string     `json:"-"`                     // bcrypt hash of the secret portion only
+	CreatedAt             time.Time  `json:"createdAt"`
+	LastUsedAt            *time.Time `json:"lastUsedAt,omitempty"`
+	ExpiresAt             *time.Time `json:"expiresAt,omitempty"` // nil means no expiration
 }
 
 type APIKeyScopes struct {

--- a/pkg/gateway/types/mcpauditlog_test.go
+++ b/pkg/gateway/types/mcpauditlog_test.go
@@ -272,7 +272,7 @@ func TestNewLocalAgentToolCallAuditLogFromInput(t *testing.T) {
 	}, types2.AuditLogActorTypeUser, "user-1", "127.0.0.1", 0, createdAt)
 
 	if log.SourceType != types2.AuditLogSourceTypeLocalAgentToolCall {
-		t.Fatalf("expected local-agent source type, got %q", log.SourceType)
+		t.Fatalf("expected local-agent catalog type, got %q", log.SourceType)
 	}
 	if log.UserID != "user-1" || log.ClientIP != "127.0.0.1" || !log.CreatedAt.Equal(createdAt) {
 		t.Fatalf("server-owned fields were not populated correctly: %#v", log)

--- a/pkg/hostedagentaccessrule/helper.go
+++ b/pkg/hostedagentaccessrule/helper.go
@@ -1,0 +1,208 @@
+package hostedagentaccessrule
+
+import (
+	"fmt"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+	gocache "k8s.io/client-go/tools/cache"
+)
+
+const (
+	HostedAgentIDIndex    = "hosted-agent-ids"
+	ResourceSelectorIndex = "selectors"
+	UserIDIndex           = "user-ids"
+	GroupIDIndex          = "group-ids"
+	SubjectSelectorIndex  = "subject-selectors"
+)
+
+type Helper struct {
+	haarIndexer gocache.Indexer
+}
+
+func NewHelper(haarIndexer gocache.Indexer) *Helper {
+	return &Helper{
+		haarIndexer: haarIndexer,
+	}
+}
+
+func (h *Helper) GetHostedAgentAccessRulesForHostedAgent(namespace, hostedAgentID string) ([]v1.HostedAgentAccessRule, error) {
+	return h.getIndexedRules(namespace, HostedAgentIDIndex, hostedAgentID, "hosted agent")
+}
+
+func (h *Helper) GetHostedAgentAccessRulesForSelector(namespace, selector string) ([]v1.HostedAgentAccessRule, error) {
+	return h.getIndexedRules(namespace, ResourceSelectorIndex, selector, "selector")
+}
+
+func (h *Helper) GetHostedAgentAccessRulesForUser(namespace, userID string) ([]v1.HostedAgentAccessRule, error) {
+	return h.getIndexedRules(namespace, UserIDIndex, userID, "user")
+}
+
+func (h *Helper) GetHostedAgentAccessRulesForGroup(namespace, groupID string) ([]v1.HostedAgentAccessRule, error) {
+	return h.getIndexedRules(namespace, GroupIDIndex, groupID, "group")
+}
+
+func (h *Helper) GetHostedAgentAccessRulesForSubjectSelector(namespace, selector string) ([]v1.HostedAgentAccessRule, error) {
+	return h.getIndexedRules(namespace, SubjectSelectorIndex, selector, "subject selector")
+}
+
+func (h *Helper) UserHasAccessToHostedAgent(user kuser.Info, agent *v1.HostedAgent) (bool, error) {
+	if agent == nil {
+		return false, nil
+	}
+
+	return h.UserHasAccessToHostedAgentID(user, agent.Name)
+}
+
+func (h *Helper) UserHasAccessToHostedAgentID(user kuser.Info, hostedAgentID string) (bool, error) {
+	if hostedAgentID == "" {
+		return false, nil
+	}
+
+	var (
+		userID string
+		groups = authGroupSet(user)
+	)
+	if user != nil {
+		userID = user.GetUID()
+	}
+
+	selectorRules, err := h.GetHostedAgentAccessRulesForSelector(system.DefaultNamespace, "*")
+	if err != nil {
+		return false, err
+	}
+	if hasMatchingSubject(selectorRules, userID, groups) {
+		return true, nil
+	}
+
+	agentRules, err := h.GetHostedAgentAccessRulesForHostedAgent(system.DefaultNamespace, hostedAgentID)
+	if err != nil {
+		return false, err
+	}
+	if hasMatchingSubject(agentRules, userID, groups) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// GetUserHostedAgentAccessScope returns whether the user has wildcard access to
+// all hosted agents, and if not, the set of hosted agent IDs they can reach.
+func (h *Helper) GetUserHostedAgentAccessScope(user kuser.Info) (bool, map[string]struct{}, error) {
+	hostedAgentIDs := map[string]struct{}{}
+
+	rules, err := h.getRulesForUser(system.DefaultNamespace, user)
+	if err != nil {
+		return false, nil, err
+	}
+
+	for _, rule := range rules {
+		for _, resource := range rule.Spec.Manifest.Resources {
+			switch resource.Type {
+			case types.HostedAgentResourceTypeSelector:
+				if resource.ID == "*" {
+					return true, hostedAgentIDs, nil
+				}
+			case types.HostedAgentResourceTypeHostedAgent:
+				if resource.ID != "" {
+					hostedAgentIDs[resource.ID] = struct{}{}
+				}
+			}
+		}
+	}
+
+	return false, hostedAgentIDs, nil
+}
+
+func (h *Helper) getRulesForUser(namespace string, user kuser.Info) ([]v1.HostedAgentAccessRule, error) {
+	result := make([]v1.HostedAgentAccessRule, 0)
+	seen := map[string]struct{}{}
+
+	addRules := func(rules []v1.HostedAgentAccessRule) {
+		for _, rule := range rules {
+			if _, ok := seen[rule.Name]; ok {
+				continue
+			}
+			seen[rule.Name] = struct{}{}
+			result = append(result, rule)
+		}
+	}
+
+	selectorRules, err := h.GetHostedAgentAccessRulesForSubjectSelector(namespace, "*")
+	if err != nil {
+		return nil, err
+	}
+	addRules(selectorRules)
+
+	if user != nil && user.GetUID() != "" {
+		userRules, err := h.GetHostedAgentAccessRulesForUser(namespace, user.GetUID())
+		if err != nil {
+			return nil, err
+		}
+		addRules(userRules)
+	}
+
+	for groupID := range authGroupSet(user) {
+		groupRules, err := h.GetHostedAgentAccessRulesForGroup(namespace, groupID)
+		if err != nil {
+			return nil, err
+		}
+		addRules(groupRules)
+	}
+
+	return result, nil
+}
+
+func (h *Helper) getIndexedRules(namespace, indexName, key, target string) ([]v1.HostedAgentAccessRule, error) {
+	rules, err := h.haarIndexer.ByIndex(indexName, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hosted agent access rules for %s: %w", target, err)
+	}
+
+	result := make([]v1.HostedAgentAccessRule, 0, len(rules))
+	for _, rule := range rules {
+		res, ok := rule.(*v1.HostedAgentAccessRule)
+		if ok && res.Namespace == namespace && res.DeletionTimestamp == nil {
+			result = append(result, *res)
+		}
+	}
+
+	return result, nil
+}
+
+func hasMatchingSubject(rules []v1.HostedAgentAccessRule, userID string, groups map[string]struct{}) bool {
+	for _, rule := range rules {
+		for _, subject := range rule.Spec.Manifest.Subjects {
+			switch subject.Type {
+			case types.SubjectTypeUser:
+				if subject.ID == userID {
+					return true
+				}
+			case types.SubjectTypeGroup:
+				if _, ok := groups[subject.ID]; ok {
+					return true
+				}
+			case types.SubjectTypeSelector:
+				if subject.ID == "*" {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func authGroupSet(user kuser.Info) map[string]struct{} {
+	if user == nil {
+		return map[string]struct{}{}
+	}
+	groups := user.GetExtra()["auth_provider_groups"]
+	set := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		set[group] = struct{}{}
+	}
+	return set
+}

--- a/pkg/hostedagentmodels/models.go
+++ b/pkg/hostedagentmodels/models.go
@@ -1,0 +1,259 @@
+// Package hostedagentmodels resolves the models a hosted agent may use.
+//
+// It exists because two callers need the same answer and must not disagree:
+// the controller, which writes the resolved endpoints into a sandbox's config,
+// and the API, which decides whether an agent can be launched at all. If the
+// API said an agent was launchable and the controller then resolved no models,
+// the user would get a sandbox that cannot do anything.
+package hostedagentmodels
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Wire protocols a model can be reached over.
+//
+// These are distinct request and response formats, not vendors: a client
+// written for the Responses API cannot talk to a chat-completions endpoint, and
+// neither can talk to Anthropic's Messages API. Codex speaks Responses, Claude
+// Code speaks Messages, and a library such as LiteLLM speaks chat completions --
+// so this is what decides whether a given harness can use a given model.
+const (
+	APIAnthropic             = "anthropic"
+	APIOpenAIResponses       = "openai-responses"
+	APIOpenAIChatCompletions = "openai-chat-completions"
+)
+
+// AllAPIs is every protocol a harness may declare.
+var AllAPIs = []string{APIAnthropic, APIOpenAIResponses, APIOpenAIChatCompletions}
+
+// Model is one usable model: resolved to a concrete target, a provider, and the
+// protocols it can be reached over.
+type Model struct {
+	ID       string
+	Model    string
+	Provider string
+	// APIs is every protocol this model accepts. A model is usually reachable
+	// over more than one -- an OpenAI endpoint serves both Responses and chat
+	// completions -- so a single value would exclude clients that would work.
+	APIs []string
+	// Dialect is what the model declares, empty when it declares nothing.
+	Dialect string
+}
+
+// Speaks reports whether this model accepts the given protocol. An empty
+// protocol means the caller has no requirement, which nothing fails.
+func (m Model) Speaks(api string) bool {
+	return api == "" || slices.Contains(m.APIs, api)
+}
+
+// Resolve turns an agent's model selections into the models it can actually
+// use. A selection is a model ID, an "obot://<alias>" reference, or "*" for
+// everything the installation has.
+//
+// providers, when non-empty, restricts the result to models from those model
+// providers, named by their stable identifier.
+//
+// A selection that resolves to nothing is skipped rather than failing: an agent
+// may have several, and an alias can be unbound on a fresh install. The result
+// is therefore what is genuinely usable, which is what both callers need.
+func Resolve(ctx context.Context, client kclient.Client, namespace string, selections, providers []string) ([]Model, error) {
+	var (
+		models   []Model
+		seen     = map[string]struct{}{}
+		wildcard bool
+	)
+
+	add := func(model *Model) {
+		if model == nil {
+			return
+		}
+		// An agent that names its providers is restricted to them. This is what
+		// makes "Claude Code needs Anthropic" expressible without inventing a
+		// separate notion of protocol: the template names the provider it was
+		// written against.
+		if len(providers) > 0 && !slices.Contains(providers, model.Provider) {
+			return
+		}
+		if _, ok := seen[model.ID]; ok {
+			return
+		}
+		apis := APIsFor(model.Provider, model.Dialect)
+		if len(apis) == 0 {
+			// No proxy route serves this provider, so the model cannot be
+			// reached however it was selected.
+			return
+		}
+		seen[model.ID] = struct{}{}
+		model.APIs = apis
+		models = append(models, *model)
+	}
+
+	for _, selection := range selections {
+		switch selection = strings.TrimSpace(selection); selection {
+		case "":
+			continue
+		case "*":
+			wildcard = true
+			continue
+		}
+
+		model, err := resolveOne(ctx, client, namespace, selection)
+		if err != nil {
+			continue
+		}
+		add(model)
+	}
+
+	if wildcard {
+		all, err := listUsable(ctx, client, namespace)
+		if err != nil {
+			return nil, err
+		}
+		for i := range all {
+			add(&all[i])
+		}
+	}
+	return models, nil
+}
+
+// Default returns the model to reach for, following the installation's llm
+// alias and falling back to the first listed.
+func Default(ctx context.Context, client kclient.Client, namespace string, models []Model) string {
+	if len(models) == 0 {
+		return ""
+	}
+	if resolved, err := resolveOne(ctx, client, namespace,
+		types.DefaultModelAliasRefPrefix+string(types.DefaultModelAliasTypeLLM)); err == nil && resolved != nil {
+		for _, model := range models {
+			if model.ID == resolved.ID {
+				return model.ID
+			}
+		}
+	}
+	return models[0].ID
+}
+
+// APIsFor reports the protocols a model accepts.
+//
+// A declared dialect is authoritative and narrows the model to exactly one
+// protocol, which is how an administrator states that an endpoint serves only
+// one. Without a declaration the provider decides, and OpenAI-shaped providers
+// are credited with both OpenAI protocols: their endpoints generally serve both,
+// and being too narrow here would hide a model that works. Being too broad
+// fails later at the endpoint, with an error naming the format -- which is the
+// better failure of the two.
+func APIsFor(provider, dialect string) []string {
+	switch dialect {
+	case "AnthropicMessages":
+		return []string{APIAnthropic}
+	case "OpenAIResponses", "OpenResponses":
+		return []string{APIOpenAIResponses}
+	case "OpenAIChatCompletions":
+		return []string{APIOpenAIChatCompletions}
+	}
+
+	switch provider {
+	case system.AnthropicModelProvider:
+		return []string{APIAnthropic}
+	case system.OpenAIModelProvider,
+		system.GenericResponsesModelProvider,
+		system.AmazonBedrockModelProvider,
+		system.AmazonBedrockAPIKeyModelProvider,
+		system.AzureModelProvider,
+		system.AzureEntraModelProvider:
+		return []string{APIOpenAIResponses, APIOpenAIChatCompletions}
+	default:
+		return nil
+	}
+}
+
+// ProxyPath is the segment of Obot's LLM proxy route that serves a provider.
+func ProxyPath(provider string) (string, bool) {
+	switch provider {
+	case system.AnthropicModelProvider:
+		return "anthropic", true
+	case system.OpenAIModelProvider:
+		return "openai", true
+	case system.GenericResponsesModelProvider:
+		return "generic-responses", true
+	case system.AmazonBedrockModelProvider:
+		return "aws-bedrock", true
+	case system.AmazonBedrockAPIKeyModelProvider:
+		return "aws-bedrock-api-key", true
+	case system.AzureModelProvider:
+		return "azure", true
+	case system.AzureEntraModelProvider:
+		return "azure-entra", true
+	default:
+		return "", false
+	}
+}
+
+func resolveOne(ctx context.Context, client kclient.Client, namespace, selection string) (*Model, error) {
+	if alias, ok := strings.CutPrefix(selection, types.DefaultModelAliasRefPrefix); ok {
+		var defaultAlias v1.DefaultModelAlias
+		if err := client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: alias}, &defaultAlias); err != nil {
+			return nil, fmt.Errorf("resolve alias %q: %w", alias, err)
+		}
+		if defaultAlias.Spec.Manifest.Model == "" {
+			return nil, fmt.Errorf("alias %q is not bound to a model", alias)
+		}
+		return lookup(ctx, client, namespace, defaultAlias.Spec.Manifest.Model)
+	}
+	return lookup(ctx, client, namespace, selection)
+}
+
+func lookup(ctx context.Context, client kclient.Client, namespace, name string) (*Model, error) {
+	var model v1.Model
+	if err := client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: name}, &model); err != nil {
+		return nil, fmt.Errorf("read model %q: %w", name, err)
+	}
+	target := strings.TrimSpace(model.Spec.Manifest.TargetModel)
+	if target == "" {
+		return nil, fmt.Errorf("model %q has no target model", name)
+	}
+	return &Model{
+		ID:       model.Name,
+		Model:    target,
+		Provider: model.Spec.Manifest.ModelProvider,
+		Dialect:  model.Spec.Manifest.Dialect,
+	}, nil
+}
+
+func listUsable(ctx context.Context, client kclient.Client, namespace string) ([]Model, error) {
+	var list v1.ModelList
+	if err := client.List(ctx, &list, &kclient.ListOptions{Namespace: namespace}); err != nil {
+		return nil, fmt.Errorf("list models: %w", err)
+	}
+
+	result := make([]Model, 0, len(list.Items))
+	for _, model := range list.Items {
+		manifest := model.Spec.Manifest
+		if !manifest.Active || manifest.Usage != types.ModelUsageLLM {
+			continue
+		}
+		if strings.TrimSpace(manifest.TargetModel) == "" {
+			continue
+		}
+		result = append(result, Model{
+			ID:       model.Name,
+			Model:    manifest.TargetModel,
+			Provider: manifest.ModelProvider,
+			Dialect:  manifest.Dialect,
+		})
+	}
+	// Stable order: this feeds a sandbox's config, which feeds its revision, and
+	// a walk that reordered itself would restart every sandbox for nothing.
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result, nil
+}

--- a/pkg/hostedagentrefs/refs.go
+++ b/pkg/hostedagentrefs/refs.go
@@ -1,0 +1,145 @@
+// Package hostedagentrefs resolves the portable references a hosted agent
+// template uses to name MCP servers and skills.
+//
+// A template is written once and synced into many installations, so it cannot
+// name things by the IDs those installations generate. It names them by
+// something stable instead -- the source they came from, and their key within
+// it -- and this resolves that to whatever the local ID happens to be.
+//
+// References are resolved where they are used, not rewritten into the stored
+// template at sync time. A template naming a server that is not installed
+// therefore syncs, appears, and is reported unavailable with the reason;
+// installing the server later makes it work with no resync and no edit. Sync
+// rewriting would instead fail the whole source over one reference and freeze
+// the answer.
+package hostedagentrefs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/obot-platform/obot/pkg/mcp"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Separator divides the source from the key within it. It matches what the MCP
+// catalog already reserves and validates entry keys against, so a reference
+// written here is the same string that catalog builds internally.
+const Separator = "::"
+
+// IsReference reports whether a value is a portable reference rather than an
+// ID. Anything without the separator is passed through untouched, so templates
+// and agents that name IDs directly keep working.
+func IsReference(value string) bool {
+	return strings.Contains(value, Separator)
+}
+
+// Split divides a reference into its source and key.
+func Split(ref string) (source, key string, ok bool) {
+	source, key, ok = strings.Cut(ref, Separator)
+	source, key = strings.TrimSpace(source), strings.TrimSpace(key)
+	return source, key, ok && source != "" && key != ""
+}
+
+// ResolveMCP turns "<source>::<entryKey>" into the local catalog entry ID.
+//
+// The source is a catalog's URL without its scheme, which is how the MCP
+// catalog itself identifies a source, and the key is the entry key that
+// catalog supplies. An entry key is unique only within its source, so both
+// halves are required.
+func ResolveMCP(ctx context.Context, client kclient.Client, namespace, ref string) (string, error) {
+	if !IsReference(ref) {
+		return ref, nil
+	}
+	source, key, ok := Split(ref)
+	if !ok {
+		return "", fmt.Errorf("malformed MCP server reference %q, expected <source>%s<entryKey>", ref, Separator)
+	}
+
+	var entries v1.MCPServerCatalogEntryList
+	if err := client.List(ctx, &entries, &kclient.ListOptions{Namespace: namespace}); err != nil {
+		return "", fmt.Errorf("list catalog entries: %w", err)
+	}
+	for _, entry := range entries.Items {
+		if entry.Spec.Manifest.EntryKey != key {
+			continue
+		}
+		if mcp.SourceIDForURL(entry.Spec.SourceURL) == source {
+			return entry.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no MCP server %q from %s is installed", key, source)
+}
+
+// ResolveSkill turns "<repoURL>::<relativePath>" into the local skill ID.
+//
+// The path rather than the skill's name: a path is unique within a repository
+// by construction, whereas two skills in different directories may share a
+// name.
+func ResolveSkill(ctx context.Context, client kclient.Client, namespace, ref string) (string, error) {
+	if !IsReference(ref) {
+		return ref, nil
+	}
+	source, path, ok := Split(ref)
+	if !ok {
+		return "", fmt.Errorf("malformed skill reference %q, expected <repoURL>%s<path>", ref, Separator)
+	}
+
+	var skills v1.SkillList
+	// Indexed on the path, so this reads the few skills sharing it rather than
+	// every skill the installation has.
+	if err := client.List(ctx, &skills, &kclient.ListOptions{Namespace: namespace},
+		kclient.MatchingFields{"spec.relativePath": path}); err != nil {
+		return "", fmt.Errorf("list skills: %w", err)
+	}
+	for _, skill := range skills.Items {
+		if mcp.SourceIDForURL(skill.Spec.RepoURL) == mcp.SourceIDForURL(source) {
+			return skill.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no skill %q from %s is installed", path, source)
+}
+
+// Resolver resolves many references, remembering what failed.
+//
+// Callers want both halves: the IDs that did resolve, so an agent gets what it
+// can have, and the references that did not, so it can be said why the agent is
+// incomplete.
+type Resolver struct {
+	client    kclient.Client
+	namespace string
+}
+
+func New(client kclient.Client, namespace string) *Resolver {
+	return &Resolver{client: client, namespace: namespace}
+}
+
+// MCPServers resolves each reference, returning the resolved IDs and the
+// references that named nothing installed here.
+func (r *Resolver) MCPServers(ctx context.Context, refs []string) (resolved []string, unresolved []string) {
+	return r.each(ctx, refs, ResolveMCP)
+}
+
+// Skills resolves each reference the same way.
+func (r *Resolver) Skills(ctx context.Context, refs []string) (resolved []string, unresolved []string) {
+	return r.each(ctx, refs, ResolveSkill)
+}
+
+func (r *Resolver) each(ctx context.Context, refs []string,
+	resolve func(context.Context, kclient.Client, string, string) (string, error),
+) (resolved []string, unresolved []string) {
+	for _, ref := range refs {
+		if ref == "" {
+			continue
+		}
+		id, err := resolve(ctx, r.client, r.namespace, ref)
+		if err != nil {
+			unresolved = append(unresolved, ref)
+			continue
+		}
+		resolved = append(resolved, id)
+	}
+	return resolved, unresolved
+}

--- a/pkg/hostedagentrefs/refs_test.go
+++ b/pkg/hostedagentrefs/refs_test.go
@@ -1,0 +1,156 @@
+package hostedagentrefs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func clientWith(objs ...kclient.Object) kclient.Client {
+	return fakeclient.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		// The skill lookup reads by path, which needs the same index the real
+		// storage provides.
+		WithIndex(&v1.Skill{}, "spec.relativePath", func(o kclient.Object) []string {
+			return []string{o.(*v1.Skill).Spec.RelativePath}
+		}).
+		WithObjects(objs...).
+		Build()
+}
+
+func entry(name, sourceURL, entryKey string) *v1.MCPServerCatalogEntry {
+	return &v1.MCPServerCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			SourceURL: sourceURL,
+			Manifest:  types.MCPServerCatalogEntryManifest{EntryKey: entryKey},
+		},
+	}
+}
+
+func skill(name, repoURL, relPath string) *v1.Skill {
+	return &v1.Skill{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec:       v1.SkillSpec{RepoURL: repoURL, RelativePath: relPath},
+	}
+}
+
+// The point of a reference: a template names something by its source and key,
+// which is the same on every installation, and resolution finds whatever ID
+// this one generated.
+func TestMCPReferenceResolvesToTheLocalID(t *testing.T) {
+	client := clientWith(entry("default-atlassian-ad9a4f19",
+		"https://github.com/obot-platform/mcp-catalog", "obot-atlassian"))
+
+	got, err := ResolveMCP(context.Background(), client, "obot",
+		"github.com/obot-platform/mcp-catalog"+Separator+"obot-atlassian")
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	if got != "default-atlassian-ad9a4f19" {
+		t.Errorf("resolved to %q", got)
+	}
+}
+
+// An entry key is unique only within its source, so the source half decides.
+func TestMCPReferenceIsScopedToItsSource(t *testing.T) {
+	client := clientWith(
+		entry("a-atlassian", "https://github.com/obot-platform/mcp-catalog", "obot-atlassian"),
+		entry("b-atlassian", "https://example.com/other-catalog", "obot-atlassian"),
+	)
+
+	got, err := ResolveMCP(context.Background(), client, "obot",
+		"example.com/other-catalog"+Separator+"obot-atlassian")
+	if err != nil {
+		t.Fatalf("ResolveMCP: %v", err)
+	}
+	if got != "b-atlassian" {
+		t.Errorf("resolved to %q, want the entry from the named source", got)
+	}
+}
+
+// A bare ID is not a reference and must pass through, so templates and agents
+// that name IDs directly keep working.
+func TestPlainIDsPassThrough(t *testing.T) {
+	client := clientWith()
+	for _, id := range []string{"ms1abc", "default-atlassian-ad9a4f19", "sk1-default-doc-1234"} {
+		if got, err := ResolveMCP(context.Background(), client, "obot", id); err != nil || got != id {
+			t.Errorf("ResolveMCP(%q) = %q, %v; want it untouched", id, got, err)
+		}
+		if got, err := ResolveSkill(context.Background(), client, "obot", id); err != nil || got != id {
+			t.Errorf("ResolveSkill(%q) = %q, %v; want it untouched", id, got, err)
+		}
+	}
+}
+
+func TestSkillReferenceResolvesByPath(t *testing.T) {
+	client := clientWith(
+		skill("sk1-default-doc-167641d7", "https://github.com/obot-platform/skills", "skills/doc"),
+		skill("sk1-other-doc-99999999", "https://example.com/other-skills", "skills/doc"),
+	)
+
+	got, err := ResolveSkill(context.Background(), client, "obot",
+		"github.com/obot-platform/skills"+Separator+"skills/doc")
+	if err != nil {
+		t.Fatalf("ResolveSkill: %v", err)
+	}
+	if got != "sk1-default-doc-167641d7" {
+		t.Errorf("resolved to %q, want the skill from the named repository", got)
+	}
+}
+
+// The scheme is not part of a source's identity, so a reference written either
+// way resolves.
+func TestSourceSchemeIsIgnored(t *testing.T) {
+	client := clientWith(skill("sk1doc", "https://github.com/obot-platform/skills", "skills/doc"))
+
+	for _, ref := range []string{
+		"github.com/obot-platform/skills" + Separator + "skills/doc",
+		"https://github.com/obot-platform/skills" + Separator + "skills/doc",
+	} {
+		if _, err := ResolveSkill(context.Background(), client, "obot", ref); err != nil {
+			t.Errorf("ResolveSkill(%q): %v", ref, err)
+		}
+	}
+}
+
+// A reference naming nothing is an error rather than a silent miss, so the
+// caller can say which reference failed.
+func TestUnresolvableReferencesAreReported(t *testing.T) {
+	client := clientWith()
+
+	if _, err := ResolveMCP(context.Background(), client, "obot", "some.catalog"+Separator+"nope"); err == nil {
+		t.Error("expected an error for an MCP reference naming nothing")
+	}
+	if _, err := ResolveSkill(context.Background(), client, "obot", "some.repo"+Separator+"nope"); err == nil {
+		t.Error("expected an error for a skill reference naming nothing")
+	}
+	if _, err := ResolveMCP(context.Background(), client, "obot", "half"+Separator); err == nil {
+		t.Error("expected an error for a malformed reference")
+	}
+}
+
+// The resolver keeps what resolved and reports what did not, so an agent gets
+// what it can have while the rest is explained.
+func TestResolverSeparatesResolvedFromMissing(t *testing.T) {
+	client := clientWith(entry("here", "https://cat.example.com", "present"))
+	resolver := New(client, "obot")
+
+	resolved, unresolved := resolver.MCPServers(context.Background(), []string{
+		"cat.example.com" + Separator + "present",
+		"cat.example.com" + Separator + "absent",
+		"ms1literal",
+	})
+	if len(resolved) != 2 || resolved[0] != "here" || resolved[1] != "ms1literal" {
+		t.Errorf("resolved = %v", resolved)
+	}
+	if len(unresolved) != 1 || unresolved[0] != "cat.example.com"+Separator+"absent" {
+		t.Errorf("unresolved = %v", unresolved)
+	}
+}

--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -157,6 +157,9 @@ func ensureServerReady(ctx context.Context, url string, server ServerConfig) err
 					}
 				}
 			}
+			if err := scanner.Err(); err != nil {
+				lastErr = fmt.Errorf("failed reading SSE stream: %w", err)
+			}
 			resp.Body.Close()
 			cancel()
 		}

--- a/pkg/mcp/secretbindings.go
+++ b/pkg/mcp/secretbindings.go
@@ -38,7 +38,7 @@ import (
 // ServerToServerConfig / ConvertMCPServer only.
 //
 // If there are no secretBindings, MergeBoundCreds returns credEnv unchanged
-// (no allocation). If c is nil (docker backend), bindings cannot be resolved
+// (no pool). If c is nil (docker backend), bindings cannot be resolved
 // and the returned map omits them — the downstream missing-required gate
 // then fires for required bindings.
 //

--- a/pkg/principal/principal.go
+++ b/pkg/principal/principal.go
@@ -1,0 +1,46 @@
+// Package principal interprets who an authenticated caller is.
+//
+// Obot authenticates people and hosted agents. They are not interchangeable: an
+// agent authenticates as itself so that a compromised sandbox reaches only what
+// that one instance was configured with, which means its identity is an
+// instance rather than a row in the users table. Code that needs "the user who
+// owns this" therefore cannot use the caller's ID directly.
+package principal
+
+import (
+	"slices"
+
+	types "github.com/obot-platform/obot/apiclient/types"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+)
+
+// HostedAgentOwnerExtra carries the user a hosted agent was created by. It is
+// set on the principal at authentication time.
+const HostedAgentOwnerExtra = "hosted_agent_owner_id"
+
+// ResourceOwnerID returns the user that owns what a caller creates, and that
+// usage is attributed to.
+//
+// For a person this is their own ID. For a hosted agent it is the user who
+// created it, because the resources an agent touches belong to that person and
+// the usage it incurs is theirs. Using the agent's own ID here produces records
+// pointing at a user that does not exist, which fails lookups and, in a
+// controller, requeues forever.
+//
+// This is distinct from authorization, which uses the caller's real identity:
+// an agent may only reach what its own configuration allows, regardless of what
+// its owner can reach.
+func ResourceOwnerID(user kuser.Info) string {
+	if user == nil {
+		return ""
+	}
+	if owner := user.GetExtra()[HostedAgentOwnerExtra]; len(owner) > 0 && owner[0] != "" {
+		return owner[0]
+	}
+	return user.GetUID()
+}
+
+// IsHostedAgent reports whether a caller is a sandbox rather than a person.
+func IsHostedAgent(user kuser.Info) bool {
+	return user != nil && slices.Contains(user.GetGroups(), types.GroupHostedAgent)
+}

--- a/pkg/principal/principal_test.go
+++ b/pkg/principal/principal_test.go
@@ -1,0 +1,62 @@
+package principal
+
+import (
+	"testing"
+
+	types "github.com/obot-platform/obot/apiclient/types"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+)
+
+// A hosted agent's ID identifies an instance, not a row in the users table.
+// Using it as an owner produces records pointing at a user that does not exist,
+// which fails lookups and requeues forever in a controller.
+func TestResourceOwnerIDResolvesAgentToItsOwner(t *testing.T) {
+	agent := &kuser.DefaultInfo{
+		Name:  "hosted-agent:hai1abc",
+		UID:   "hosted-agent:hai1abc",
+		Extra: map[string][]string{HostedAgentOwnerExtra: {"3"}},
+	}
+
+	if got := ResourceOwnerID(agent); got != "3" {
+		t.Errorf("ResourceOwnerID = %q, want the owner 3", got)
+	}
+}
+
+func TestResourceOwnerIDLeavesPeopleUnchanged(t *testing.T) {
+	person := &kuser.DefaultInfo{Name: "someone@example.com", UID: "7"}
+
+	if got := ResourceOwnerID(person); got != "7" {
+		t.Errorf("ResourceOwnerID = %q, want 7", got)
+	}
+	if got := ResourceOwnerID(nil); got != "" {
+		t.Errorf("ResourceOwnerID(nil) = %q, want empty", got)
+	}
+}
+
+// An agent whose owner is somehow unrecorded must not silently resolve to
+// something that looks like a different user.
+func TestResourceOwnerIDFallsBackToTheCallerWhenOwnerMissing(t *testing.T) {
+	agent := &kuser.DefaultInfo{
+		UID:   "hosted-agent:hai1abc",
+		Extra: map[string][]string{HostedAgentOwnerExtra: {""}},
+	}
+
+	if got := ResourceOwnerID(agent); got != "hosted-agent:hai1abc" {
+		t.Errorf("ResourceOwnerID = %q, want the caller ID unchanged", got)
+	}
+}
+
+func TestIsHostedAgent(t *testing.T) {
+	agent := &kuser.DefaultInfo{Groups: []string{types.GroupAuthenticated, types.GroupHostedAgent}}
+	if !IsHostedAgent(agent) {
+		t.Error("expected an agent principal to be recognised")
+	}
+
+	person := &kuser.DefaultInfo{Groups: []string{types.GroupAuthenticated, types.GroupAPI}}
+	if IsHostedAgent(person) {
+		t.Error("a user principal must not be mistaken for an agent")
+	}
+	if IsHostedAgent(nil) {
+		t.Error("a nil principal is not an agent")
+	}
+}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -36,6 +36,7 @@ import (
 	otime "github.com/obot-platform/obot/pkg/gateway/time"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/hostedagentaccessrule"
 	"github.com/obot-platform/obot/pkg/imagepullsecrets"
 	"github.com/obot-platform/obot/pkg/jwt/persistent"
 	"github.com/obot-platform/obot/pkg/license"
@@ -836,6 +837,73 @@ func New(ctx context.Context, config Config) (*Services, error) {
 
 	skillAccessRuleHelper := skillaccessrule.NewHelper(skillAccessRuleInformer.GetIndexer())
 
+	hostedAgentAccessRuleGVK, err := r.Backend().GroupVersionKindFor(&v1.HostedAgentAccessRule{})
+	if err != nil {
+		return nil, err
+	}
+
+	hostedAgentAccessRuleInformer, err := r.Backend().GetInformerForKind(ctx, hostedAgentAccessRuleGVK)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = hostedAgentAccessRuleInformer.AddIndexers(map[string]gocache.IndexFunc{
+		hostedagentaccessrule.HostedAgentIDIndex: func(obj any) ([]string, error) {
+			rule := obj.(*v1.HostedAgentAccessRule)
+			var results []string
+			for _, resource := range rule.Spec.Manifest.Resources {
+				if resource.Type == apiclienttypes.HostedAgentResourceTypeHostedAgent {
+					results = append(results, resource.ID)
+				}
+			}
+			return results, nil
+		},
+		hostedagentaccessrule.ResourceSelectorIndex: func(obj any) ([]string, error) {
+			rule := obj.(*v1.HostedAgentAccessRule)
+			var results []string
+			for _, resource := range rule.Spec.Manifest.Resources {
+				if resource.Type == apiclienttypes.HostedAgentResourceTypeSelector {
+					results = append(results, resource.ID)
+				}
+			}
+			return results, nil
+		},
+		hostedagentaccessrule.UserIDIndex: func(obj any) ([]string, error) {
+			rule := obj.(*v1.HostedAgentAccessRule)
+			var results []string
+			for _, subject := range rule.Spec.Manifest.Subjects {
+				if subject.Type == apiclienttypes.SubjectTypeUser {
+					results = append(results, subject.ID)
+				}
+			}
+			return results, nil
+		},
+		hostedagentaccessrule.GroupIDIndex: func(obj any) ([]string, error) {
+			rule := obj.(*v1.HostedAgentAccessRule)
+			var results []string
+			for _, subject := range rule.Spec.Manifest.Subjects {
+				if subject.Type == apiclienttypes.SubjectTypeGroup {
+					results = append(results, subject.ID)
+				}
+			}
+			return results, nil
+		},
+		hostedagentaccessrule.SubjectSelectorIndex: func(obj any) ([]string, error) {
+			rule := obj.(*v1.HostedAgentAccessRule)
+			var results []string
+			for _, subject := range rule.Spec.Manifest.Subjects {
+				if subject.Type == apiclienttypes.SubjectTypeSelector {
+					results = append(results, subject.ID)
+				}
+			}
+			return results, nil
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	hostedAgentAccessRuleHelper := hostedagentaccessrule.NewHelper(hostedAgentAccessRuleInformer.GetIndexer())
+
 	mapHelper, err := modelaccesspolicy.NewHelper(ctx, r.Backend())
 	if err != nil {
 		return nil, err
@@ -898,7 +966,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		authenticators = union.New(authenticators, tunnel.NewTunnelAuthenticator(storageClient))
 		// API Key authentication (for MCP server access) - restricted to GroupAPIKey only
 		// Must come after UserDecorator since it handles its own user lookup
-		authenticators = union.New(authenticators, gserver.NewAPIKeyAuthenticator(gatewayClient))
+		authenticators = union.New(authenticators, gserver.NewAPIKeyAuthenticator(gatewayClient, storageClient))
 		// Device enrollment tokens (ode1-) and device access JWTs. Both yield
 		// non-user principals, so they must come after the UserDecorator.
 		authenticators = union.New(authenticators, gserver.NewDeviceEnrollmentAuthenticator(gatewayClient))
@@ -992,7 +1060,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		ClientIDMetadataDocumentSupported: true,
 	}
 
-	authorizer := authz.NewAuthorizer(gatewayClient, r.Backend(), storageClient, config.DevMode, acrHelper, skillAccessRuleHelper, registryNoAuth)
+	authorizer := authz.NewAuthorizer(gatewayClient, r.Backend(), storageClient, config.DevMode, acrHelper, skillAccessRuleHelper, hostedAgentAccessRuleHelper, registryNoAuth)
 	// For now, always auto-migrate the gateway database
 	svcs := &Services{
 		EncryptionConfig:      encryptionConfig,


### PR DESCRIPTION
A sandbox authenticates as itself. Its credential carries a group that marks it
as a hosted agent rather than a person, and that group reaches the MCP gateway
and the model proxy and nothing else -- so a credential taken out of a sandbox
cannot enumerate or modify Obot resources.

An agent is authorized against the servers its template was granted rather than
against a user's access, because the agent is not acting as the user: the
template says what it may use, and that list is the whole of it.

Model resolution is shared between the API, which decides whether an agent can
be launched, and the controller, which writes the endpoints into a sandbox's
configuration. If those two disagreed a user would be offered an agent that
then resolves no models. Portable references resolve a template's "<source>::
<key>" naming to whatever local ID an installation generated, which is what
lets one template work everywhere.



---

Part 4 of an 11-PR stack. Base: `darren/hosted-agents-03-kubernetes-backend`.

## Stack

1. #7448 — Resource model
2. #7449 — Sandbox backend interface
3. #7450 — Kubernetes sandbox backend
**→ 4. #7451 — Sandbox reachability (models + MCP)** (this PR)
5. #7452 — Terminal + HTTP publish
6. #7453 — Server wiring + Helm
7. #7454 — Controllers / reconcilers
8. #7455 — REST API
9. #7456 — Admin UI
10. #7457 — User UI
11. #7458 — Seed default config source

Merge bottom-up; GitHub retargets each child when its parent merges.
