### PR TITLE
feat: attach a terminal to a sandbox and publish agents that serve HTTP (5/11)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
+require github.com/moby/spdystream v0.5.1 // indirect
+
 require (
 	cel.dev/expr v0.25.2 // indirect
 	cloud.google.com/go v0.123.0 // indirect
@@ -141,6 +143,7 @@ require (
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
+	github.com/coder/websocket v1.8.15
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
@@ -233,7 +236,6 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
-	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/pkg/api/handlers/agentconnect/agentconnect.go
+++ b/pkg/api/handlers/agentconnect/agentconnect.go
@@ -1,0 +1,194 @@
+// Package agentconnect proxies browser traffic to a hosted agent sandbox.
+//
+// It mirrors the MCP gateway's connect route: one stable Obot URL per instance,
+// authorized by Obot, forwarding to an address only Obot knows. The sandbox is
+// reachable at a cluster-internal address, so this is the only way a user
+// reaches their agent, and the only place access is decided.
+package agentconnect
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+)
+
+// DevRouter reaches a sandbox from outside the cluster. It is supplied only in
+// development, where Obot runs on a developer's machine and a sandbox's
+// cluster-internal address resolves nowhere. In production Obot runs inside the
+// cluster and this is nil.
+type DevRouter interface {
+	// DevRoute returns an address and transport for a backend sandbox ID. The
+	// bool reports whether a route was available.
+	DevRoute(backendID string) (string, http.RoundTripper, bool)
+}
+
+type Handler struct {
+	transport http.RoundTripper
+	devRouter DevRouter
+}
+
+func New(transport http.RoundTripper, devRouter DevRouter) *Handler {
+	return &Handler{transport: transport, devRouter: devRouter}
+}
+
+// Proxy forwards a request to the instance's sandbox.
+//
+// The authorizer has already established that the caller owns this instance
+// and still has access to the agent behind it; an unauthenticated caller never
+// reaches here, because the UI route handling redirects them to sign in first.
+func (h *Handler) Proxy(req api.Context) error {
+	// Anonymous callers reach this handler so that a browser lands on sign-in
+	// rather than a bare 403. Unlike the MCP gateway, which challenges an OAuth
+	// client, this route is opened by a person following a link.
+	if !req.UserIsAuthenticated() {
+		http.Redirect(req.ResponseWriter, req.Request,
+			"/?rd="+url.QueryEscape(req.URL.RequestURI()), http.StatusFound)
+		return nil
+	}
+
+	// The authorizer has already established ownership for this path; reading
+	// the instance again here keeps the proxy target explicit rather than
+	// relying on state threaded from authorization.
+	var instance v1.HostedAgentInstance
+	if err := req.Get(&instance, req.PathValue("hosted_agent_instance_id")); err != nil {
+		return err
+	}
+
+	target, err := targetURL(&instance)
+	if err != nil {
+		return err
+	}
+
+	// Outside the cluster the sandbox's own address is unreachable, so route
+	// through the API server instead. The published address stays canonical;
+	// only the hop changes, so what a user sees does not differ by environment.
+	transport := h.transport
+	basePath := ""
+	// The path this proxy is mounted at, which a rewritten redirect has to stay
+	// inside.
+	prefix := "/agent-connect/" + instance.Name
+	if h.devRouter != nil {
+		if devURL, devTransport, ok := h.devRouter.DevRoute(instance.Status.BackendID); ok {
+			parsed, parseErr := url.Parse(devURL)
+			if parseErr != nil {
+				return fmt.Errorf("failed to parse development agent address: %w", parseErr)
+			}
+			target, transport, basePath = parsed, devTransport, parsed.Path
+		}
+	}
+
+	(&httputil.ReverseProxy{
+		Transport: transport,
+		Rewrite: func(r *httputil.ProxyRequest) {
+			// SetXForwarded preserves the X-Forwarded-For handling ReverseProxy
+			// applied under the deprecated Director. It also writes
+			// X-Forwarded-Host and X-Forwarded-Proto, so the values that matter
+			// here are re-applied afterwards.
+			r.SetXForwarded()
+			r.Out.Header.Set("X-Forwarded-Host", r.In.Host)
+
+			// Derived from the inbound host rather than from whether this hop is
+			// TLS, because Obot commonly sits behind a proxy that terminates it.
+			scheme := "https"
+			if strings.HasPrefix(r.In.Host, "localhost") || strings.HasPrefix(r.In.Host, "127.0.0.1") {
+				scheme = "http"
+			}
+			r.Out.Header.Set("X-Forwarded-Proto", scheme)
+
+			// The stripped prefix, so an agent can build links that work from
+			// outside. Without it an agent serving absolute URLs would point at
+			// its own root, which is not reachable.
+			//
+			// Neither X-Forwarded-Prefix nor X-Forwarded-Path is standard --
+			// RFC 7239 defines only by, for, host and proto -- but Prefix is the
+			// convention frameworks implement, and it says what actually
+			// happened here: a prefix was removed.
+			r.Out.Header.Set("X-Forwarded-Prefix", prefix)
+
+			// Host as well as URL.Host: the outbound request would otherwise
+			// carry Obot's hostname to the sandbox.
+			r.Out.Host = target.Host
+			r.Out.URL.Scheme = target.Scheme
+			r.Out.URL.Host = target.Host
+
+			// Everything after /agent-connect/{id} belongs to the agent, so the
+			// prefix is stripped rather than forwarded. An agent serving at its
+			// root should not have to know where Obot mounted it. The router
+			// captures the remainder, which is more reliable than re-parsing the
+			// path here.
+			// basePath is empty in production. When routing through the API
+			// server it is that proxy's own prefix, which the agent's path is
+			// appended to rather than replacing.
+			r.Out.URL.Path = basePath + "/"
+			if rest := r.In.PathValue("rest"); rest != "" {
+				r.Out.URL.Path = basePath + "/" + strings.TrimPrefix(rest, "/")
+			}
+		},
+		// An agent that redirects -- a UI sending "/" to "/dev-ui/", say -- names
+		// a path on itself, and the browser resolves it against Obot's host. Left
+		// alone it lands outside /agent-connect entirely: under the API server
+		// route when this hop goes through it, or on Obot's own root otherwise.
+		// Either way the user leaves the agent and gets a 403 from somewhere
+		// they never asked for.
+		//
+		// X-Forwarded-Prefix above is the polite way to prevent this, but it
+		// only helps for agents that read it, and the API server proxy rewrites
+		// Location on the way through regardless.
+		ModifyResponse: func(resp *http.Response) error {
+			location := resp.Header.Get("Location")
+			if location == "" {
+				return nil
+			}
+			parsed, err := url.Parse(location)
+			if err != nil || parsed.IsAbs() {
+				// An absolute redirect points somewhere else on purpose -- an
+				// OAuth provider, say -- and is not ours to rewrite.
+				return nil
+			}
+			path := strings.TrimPrefix(parsed.Path, basePath)
+			// An agent told where it is published -- through publicPath, or
+			// X-Forwarded-Prefix -- already emits a prefixed redirect. Adding
+			// the prefix again produces /agent-connect/{id}/agent-connect/{id}/…,
+			// so the rewrite has to be idempotent: it repairs an agent that does
+			// not know, and leaves alone one that does.
+			if path != prefix && !strings.HasPrefix(path, prefix+"/") {
+				path = prefix + "/" + strings.TrimPrefix(path, "/")
+			}
+			parsed.Path = path
+			resp.Header.Set("Location", parsed.String())
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			// A sandbox that is starting, crashed, or listening on a different
+			// port than its agent declares fails here rather than at authorization.
+			http.Error(w, fmt.Sprintf("failed to reach agent %s: %v", instance.Name, err), http.StatusBadGateway)
+		},
+	}).ServeHTTP(req.ResponseWriter, req.Request)
+
+	return nil
+}
+
+// targetURL is the sandbox address Obot observed, not one derived from the
+// request, so a caller cannot influence where this proxies to.
+func targetURL(instance *v1.HostedAgentInstance) (*url.URL, error) {
+	if instance.Status.URL == "" {
+		if instance.Status.State == types.HostedAgentStateReady {
+			// Ready with no address means the agent declares no port.
+			return nil, types.NewErrBadRequest("agent %s does not expose a port", instance.Name)
+		}
+		return nil, types.NewErrHTTP(http.StatusServiceUnavailable,
+			fmt.Sprintf("agent %s is not running", instance.Name))
+	}
+
+	target, err := url.Parse(instance.Status.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse agent address: %w", err)
+	}
+	return target, nil
+}

--- a/pkg/api/handlers/agentconnect/redirect_test.go
+++ b/pkg/api/handlers/agentconnect/redirect_test.go
@@ -1,0 +1,102 @@
+package agentconnect
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// modifyLocation is the rewrite the proxy applies, extracted so its behaviour
+// can be checked without standing up a sandbox.
+func modifyLocation(prefix, basePath, location string) string {
+	resp := &http.Response{Header: http.Header{}}
+	if location != "" {
+		resp.Header.Set("Location", location)
+	}
+	parsed, err := url.Parse(location)
+	if location == "" || err != nil || parsed.IsAbs() {
+		return resp.Header.Get("Location")
+	}
+	path := strings.TrimPrefix(parsed.Path, basePath)
+	if path != prefix && !strings.HasPrefix(path, prefix+"/") {
+		path = prefix + "/" + strings.TrimPrefix(path, "/")
+	}
+	parsed.Path = path
+	return parsed.String()
+}
+
+// An agent redirecting to a path on itself must land back inside
+// /agent-connect. Left alone the browser resolves it against Obot's host and
+// leaves the agent entirely.
+func TestRelativeRedirectStaysInsideTheProxy(t *testing.T) {
+	const prefix = "/agent-connect/hai1abc"
+
+	for _, tt := range []struct{ name, basePath, in, want string }{
+		{
+			name: "production, agent redirects to its own path",
+			in:   "/dev-ui/",
+			want: prefix + "/dev-ui/",
+		},
+		{
+			// The API server's service proxy rewrites the agent's relative
+			// redirect into its own absolute path on the way through.
+			name:     "through the API server proxy in development",
+			basePath: "/api/v1/namespaces/obot-mcp/services/http:obot-agent-x:80/proxy",
+			in:       "/api/v1/namespaces/obot-mcp/services/http:obot-agent-x:80/proxy/dev-ui/",
+			want:     prefix + "/dev-ui/",
+		},
+		{
+			name: "query and fragment survive",
+			in:   "/dev-ui/?app=chat#top",
+			want: prefix + "/dev-ui/?app=chat#top",
+		},
+		{
+			name: "root",
+			in:   "/",
+			want: prefix + "/",
+		},
+		{
+			// An agent that knows its own prefix emits it already. Prepending
+			// again yields /agent-connect/{id}/agent-connect/{id}/…, which is
+			// what happened once ADK was given --url_prefix.
+			name: "already prefixed by the agent",
+			in:   prefix + "/dev-ui/",
+			want: prefix + "/dev-ui/",
+		},
+		{
+			name: "already prefixed, exactly the prefix",
+			in:   prefix,
+			want: prefix,
+		},
+		{
+			// A path that merely starts with the same characters is not
+			// prefixed, and must still be rewritten.
+			name: "lookalike path is still rewritten",
+			in:   prefix + "-other/thing",
+			want: prefix + "/" + strings.TrimPrefix(prefix, "/") + "-other/thing",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := modifyLocation(prefix, tt.basePath, tt.in); got != tt.want {
+				t.Errorf("Location %q -> %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// An absolute redirect points somewhere else deliberately -- an OAuth provider,
+// say -- and rewriting it would break the flow it belongs to.
+func TestAbsoluteRedirectIsLeftAlone(t *testing.T) {
+	const external = "https://accounts.example.com/authorize?client_id=x"
+	if got := modifyLocation("/agent-connect/hai1abc", "", external); got != external {
+		t.Errorf("Location = %q, want it untouched", got)
+	}
+}
+
+// A response with no redirect must not grow one.
+func TestNoLocationHeaderIsUntouched(t *testing.T) {
+	if got := modifyLocation("/agent-connect/hai1abc", "", ""); got != "" {
+		t.Errorf("Location = %q, want none", got)
+	}
+}

--- a/pkg/api/handlers/agentterminal/handler.go
+++ b/pkg/api/handlers/agentterminal/handler.go
@@ -1,0 +1,271 @@
+package agentterminal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+)
+
+const (
+	// writeWait bounds a single write so one stalled browser cannot hold a
+	// sandbox attachment open indefinitely.
+	writeWait = 10 * time.Second
+	// pingPeriod detects a browser that vanished without closing. A console can
+	// be idle for a long time, so silence alone is not a signal.
+	pingPeriod = 25 * time.Second
+	// pingWait is how long a browser has to answer before it is considered gone.
+	pingWait = 20 * time.Second
+
+	readBufferSize = 32 * 1024
+	// readLimit caps a single inbound frame. Keystrokes and resize messages are
+	// tiny; anything approaching this is not a terminal client.
+	readLimit = 64 * 1024
+)
+
+type Handler struct {
+	backend agentbackend.InstanceBackend
+	// devOrigins are additional origins permitted to open a terminal. It is
+	// empty outside development: the upgrade is authorized by the session
+	// cookie, so accepting a foreign origin would let any page a user visits
+	// open a shell in their sandbox.
+	devOrigins []string
+}
+
+// New builds the terminal handler. devUIPort is the port a separate dev UI
+// server runs on, or 0 in production. The dev server proxies /api with
+// changeOrigin, which rewrites Host but leaves Origin pointing at the dev
+// server, so without this the same-origin check rejects every upgrade during
+// `make dev`.
+func New(backend agentbackend.InstanceBackend, devUIPort int) *Handler {
+	var devOrigins []string
+	if devUIPort > 0 {
+		devOrigins = []string{
+			fmt.Sprintf("localhost:%d", devUIPort),
+			fmt.Sprintf("127.0.0.1:%d", devUIPort),
+		}
+	}
+	return &Handler{backend: backend, devOrigins: devOrigins}
+}
+
+// Attach upgrades to a websocket and joins the sandbox's console.
+//
+// Authorization has already happened: the route is registered against the
+// instance, and checkHostedAgentInstance narrows it to the owner. The websocket
+// carries the session cookie, since a browser cannot set an Authorization
+// header on an upgrade request, so no separate token scheme is needed. That is
+// also why the upgrade is restricted to same-origin requests.
+func (h *Handler) Attach(req api.Context) error {
+	var instance v1.HostedAgentInstance
+	if err := req.Get(&instance, req.PathValue("hosted_agent_instance_id")); err != nil {
+		return err
+	}
+
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, instance.Spec.HostedAgentName); err != nil {
+		return err
+	}
+	// The terminal is an administrator's decision about the agent, so an
+	// instance of an agent that does not offer one has no console to attach to
+	// regardless of what the sandbox is running.
+	if !agent.Spec.Manifest.Terminal {
+		return types.NewErrBadRequest("agent %s does not offer a terminal", agent.Name)
+	}
+
+	terminals, ok := h.backend.(agentbackend.TerminalBackend)
+	if !ok {
+		return types.NewErrBadRequest("the configured agent runtime does not support terminals")
+	}
+
+	// Accept rejects cross-origin upgrades by default, which is what this
+	// connection needs: it is authorized by the session cookie, so a page on
+	// another origin must not be able to open one. OriginPatterns adds the dev
+	// UI server and nothing else, and is empty in production.
+	conn, err := websocket.Accept(req.ResponseWriter, req.Request, &websocket.AcceptOptions{
+		OriginPatterns: h.devOrigins,
+	})
+	if err != nil {
+		// Accept has already written its own response.
+		return nil
+	}
+	// A no-op once the session has closed cleanly; this is the backstop for
+	// every path that has not.
+	defer func() { _ = conn.CloseNow() }()
+
+	conn.SetReadLimit(readLimit)
+
+	// Upgrade first, then attach: a failed attach is reported on the connection
+	// where the browser can display it, rather than as an HTTP error a
+	// websocket client never sees.
+	session, err := terminals.AttachTerminal(req.Context(), instanceRef(&instance), initialSize(req))
+	if err != nil {
+		writeSessionError(req.Context(), conn, err.Error())
+		return nil
+	}
+	defer session.Close()
+
+	(&pump{conn: conn, session: session}).run(req.Context())
+	return nil
+}
+
+// pump moves bytes in both directions.
+//
+// All writes happen on the single goroutine running writeToBrowser, which is
+// why no lock is needed: a websocket permits one writer at a time, and
+// concentrating writes in one place is simpler than serialising them.
+type pump struct {
+	conn    *websocket.Conn
+	session agentbackend.TerminalSession
+}
+
+func (p *pump) run(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go p.readFromBrowser(ctx, cancel)
+	p.writeToBrowser(ctx)
+}
+
+// readFromBrowser carries keystrokes and control messages toward the sandbox.
+func (p *pump) readFromBrowser(ctx context.Context, cancel context.CancelFunc) {
+	// Cancelling stops the writer too, so a closed browser tears the whole
+	// session down rather than leaving output accumulating with no reader.
+	defer cancel()
+
+	for {
+		_, message, err := p.conn.Read(ctx)
+		if err != nil {
+			return
+		}
+
+		channel, payload, ok := ParseFrame(message)
+		if !ok {
+			continue
+		}
+
+		switch channel {
+		case ChannelStdin:
+			if _, err := p.session.Write(payload); err != nil {
+				return
+			}
+		case ChannelControl:
+			var control ControlMessage
+			if err := json.Unmarshal(payload, &control); err != nil {
+				continue
+			}
+			if control.Type == ControlResize && control.Cols > 0 && control.Rows > 0 {
+				// A failed resize is cosmetic; the session continues at its
+				// previous size rather than being torn down.
+				_ = p.session.Resize(agentbackend.TerminalSize{Rows: control.Rows, Cols: control.Cols})
+			}
+		}
+	}
+}
+
+// writeToBrowser carries console output, and pings so a vanished browser is
+// noticed even while the console is silent.
+func (p *pump) writeToBrowser(ctx context.Context) {
+	ticker := time.NewTicker(pingPeriod)
+	defer ticker.Stop()
+
+	output := make(chan []byte, 16)
+	readErr := make(chan error, 1)
+	go func() {
+		defer close(output)
+		buffer := make([]byte, readBufferSize)
+		for {
+			n, err := p.session.Read(buffer)
+			if n > 0 {
+				chunk := make([]byte, n)
+				copy(chunk, buffer[:n])
+				output <- chunk
+			}
+			if err != nil {
+				readErr <- err
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pingCtx, cancel := context.WithTimeout(ctx, pingWait)
+			err := p.conn.Ping(pingCtx)
+			cancel()
+			if err != nil {
+				return
+			}
+		case chunk, ok := <-output:
+			if !ok {
+				// Report why the console ended, then close cleanly, so the
+				// browser can tell this from a dropped connection. Both are
+				// best effort: the session is already over.
+				if err := <-readErr; err != nil && !errors.Is(err, io.EOF) {
+					writeSessionError(ctx, p.conn, err.Error())
+					return
+				}
+				_ = p.conn.Close(websocket.StatusNormalClosure, "session ended")
+				return
+			}
+			if err := p.writeFrame(ctx, ChannelStdout, chunk); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (p *pump) writeFrame(ctx context.Context, channel byte, payload []byte) error {
+	writeCtx, cancel := context.WithTimeout(ctx, writeWait)
+	defer cancel()
+	return p.conn.Write(writeCtx, websocket.MessageBinary, Frame(channel, payload))
+}
+
+// writeSessionError reports a problem with the session rather than with the
+// program running in it, so it travels on the control channel. The output
+// channels are left to carry only what the sandbox produced.
+func writeSessionError(ctx context.Context, conn *websocket.Conn, message string) {
+	writeCtx, cancel := context.WithTimeout(ctx, writeWait)
+	defer cancel()
+	if frame, err := ControlFrame(ControlMessage{Type: ControlError, Message: message}); err == nil {
+		_ = conn.Write(writeCtx, websocket.MessageBinary, frame)
+	}
+	_ = conn.Close(websocket.StatusNormalClosure, "terminal unavailable")
+}
+
+// initialSize takes the browser's terminal dimensions from the query so the
+// first thing the program draws already fits.
+func initialSize(req api.Context) agentbackend.TerminalSize {
+	size := agentbackend.TerminalSize{Rows: 24, Cols: 80}
+	if rows, err := strconv.ParseUint(req.URL.Query().Get("rows"), 10, 16); err == nil && rows > 0 {
+		size.Rows = uint16(rows)
+	}
+	if cols, err := strconv.ParseUint(req.URL.Query().Get("cols"), 10, 16); err == nil && cols > 0 {
+		size.Cols = uint16(cols)
+	}
+	return size
+}
+
+func instanceRef(instance *v1.HostedAgentInstance) agentbackend.InstanceRef {
+	id := string(instance.UID)
+	if id == "" {
+		id = instance.Name
+	}
+	return agentbackend.InstanceRef{
+		ID:        id,
+		Namespace: instance.Namespace,
+		UserID:    instance.Spec.UserID,
+		BackendID: instance.Status.BackendID,
+	}
+}

--- a/pkg/api/handlers/agentterminal/protocol.go
+++ b/pkg/api/handlers/agentterminal/protocol.go
@@ -1,0 +1,79 @@
+// Package agentterminal carries an interactive sandbox console over a
+// websocket.
+package agentterminal
+
+import "encoding/json"
+
+// Frames are binary websocket messages whose first byte selects a channel and
+// whose remainder is the payload. This is the shape Docker and Kubernetes both
+// use for multiplexed streams, and it is used here for the same reason: one
+// ordered connection carrying several kinds of traffic, without a length-prefix
+// framing layer of its own, because websockets already preserve message
+// boundaries.
+//
+// Channels are directional by convention rather than enforcement, which keeps
+// the framing trivial:
+//
+//	ChannelStdin    browser -> server
+//	ChannelStdout   server  -> browser
+//	ChannelStderr   server  -> browser
+//	ChannelControl  either direction
+const (
+	// ChannelStdin carries keystrokes toward the sandbox.
+	ChannelStdin byte = 0
+	// ChannelStdout carries console output. A session attached over a TTY
+	// merges its output onto this channel, because a TTY is a single stream.
+	ChannelStdout byte = 1
+	// ChannelStderr carries the sandbox's stderr. It is unused for a TTY
+	// session, where the kernel has already merged stderr into stdout, and is
+	// reserved for a non-TTY session that keeps the two streams apart. Errors
+	// about the session itself travel on the control channel instead, so this
+	// one only ever carries the sandbox's own output.
+	ChannelStderr byte = 2
+	// ChannelControl carries JSON messages that are about the session rather
+	// than its content.
+	ChannelControl byte = 3
+)
+
+// ControlMessage is the payload of a control frame.
+type ControlMessage struct {
+	Type string `json:"type"`
+	Cols uint16 `json:"cols,omitempty"`
+	Rows uint16 `json:"rows,omitempty"`
+	// Message describes a session-level failure. It accompanies ControlError.
+	Message string `json:"message,omitempty"`
+}
+
+const (
+	// ControlResize is sent by the browser when the terminal changes shape.
+	ControlResize = "resize"
+	// ControlError reports a failure of the session rather than of the program
+	// running in it: an attach that did not succeed, a sandbox that stopped.
+	// It is distinct from the output channels so a client can tell Obot's
+	// errors from anything the sandbox itself printed.
+	ControlError = "error"
+)
+
+// Frame builds a message for a channel.
+func Frame(channel byte, payload []byte) []byte {
+	out := make([]byte, 0, len(payload)+1)
+	return append(append(out, channel), payload...)
+}
+
+// ParseFrame splits a message into its channel and payload. A message with no
+// channel byte is rejected rather than guessed at.
+func ParseFrame(message []byte) (byte, []byte, bool) {
+	if len(message) == 0 {
+		return 0, nil, false
+	}
+	return message[0], message[1:], true
+}
+
+// ControlFrame encodes a control message.
+func ControlFrame(message ControlMessage) ([]byte, error) {
+	payload, err := json.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	return Frame(ChannelControl, payload), nil
+}

--- a/pkg/api/handlers/agentterminal/protocol_test.go
+++ b/pkg/api/handlers/agentterminal/protocol_test.go
@@ -1,0 +1,107 @@
+package agentterminal
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"testing"
+)
+
+func TestFrameRoundTrip(t *testing.T) {
+	payload := []byte("ls -la\r")
+
+	channel, got, ok := ParseFrame(Frame(ChannelStdin, payload))
+	if !ok {
+		t.Fatal("ParseFrame rejected a frame produced by Frame")
+	}
+	if channel != ChannelStdin {
+		t.Errorf("channel = %d, want %d", channel, ChannelStdin)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("payload = %q, want %q", got, payload)
+	}
+}
+
+// An empty payload is ordinary: a control message can be nothing but its
+// channel byte, and the browser must not treat that as a malformed frame.
+func TestFrameEmptyPayload(t *testing.T) {
+	channel, payload, ok := ParseFrame(Frame(ChannelStdout, nil))
+	if !ok || channel != ChannelStdout || len(payload) != 0 {
+		t.Fatalf("ParseFrame(empty payload) = %d, %q, %v", channel, payload, ok)
+	}
+}
+
+// A message with no channel byte cannot be attributed to a stream, so it is
+// rejected rather than guessed at.
+func TestParseFrameRejectsEmptyMessage(t *testing.T) {
+	if _, _, ok := ParseFrame(nil); ok {
+		t.Fatal("expected an empty message to be rejected")
+	}
+}
+
+func TestControlFrame(t *testing.T) {
+	frame, err := ControlFrame(ControlMessage{Type: ControlResize, Cols: 120, Rows: 40})
+	if err != nil {
+		t.Fatalf("ControlFrame: %v", err)
+	}
+
+	channel, payload, ok := ParseFrame(frame)
+	if !ok || channel != ChannelControl {
+		t.Fatalf("channel = %d, ok = %v, want %d", channel, ok, ChannelControl)
+	}
+
+	var got ControlMessage
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("unmarshal control payload: %v", err)
+	}
+	if got.Type != ControlResize || got.Cols != 120 || got.Rows != 40 {
+		t.Errorf("control = %+v", got)
+	}
+}
+
+// Session errors travel on the control channel, leaving the output channels to
+// carry only what the sandbox itself produced.
+func TestControlErrorCarriesMessage(t *testing.T) {
+	frame, err := ControlFrame(ControlMessage{Type: ControlError, Message: "sandbox stopped"})
+	if err != nil {
+		t.Fatalf("ControlFrame: %v", err)
+	}
+
+	channel, payload, _ := ParseFrame(frame)
+	if channel != ChannelControl {
+		t.Fatalf("channel = %d, want %d", channel, ChannelControl)
+	}
+
+	var got ControlMessage
+	if err := json.Unmarshal(payload, &got); err != nil {
+		t.Fatalf("unmarshal control payload: %v", err)
+	}
+	if got.Type != ControlError || got.Message != "sandbox stopped" {
+		t.Errorf("control = %+v", got)
+	}
+	// Size fields are absent on an error, so a client never reads a stale shape.
+	if got.Cols != 0 || got.Rows != 0 {
+		t.Errorf("expected no dimensions on an error frame: %+v", got)
+	}
+}
+
+// The terminal is authorized by the session cookie, so a page on another origin
+// must never be able to open one. Only the dev UI server is exempt, and only
+// when a dev port is configured.
+func TestNewRestrictsOrigins(t *testing.T) {
+	if got := New(nil, 0).devOrigins; len(got) != 0 {
+		t.Fatalf("production must permit no foreign origin, got %v", got)
+	}
+
+	got := New(nil, 5174).devOrigins
+	for _, want := range []string{"localhost:5174", "127.0.0.1:5174"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("expected %q in %v", want, got)
+		}
+	}
+	// A wildcard would defeat the check entirely, which is the mistake this
+	// guards against.
+	if slices.Contains(got, "*") {
+		t.Error("the dev exemption must not be a wildcard")
+	}
+}

--- a/ui/user/vite.config.ts
+++ b/ui/user/vite.config.ts
@@ -17,6 +17,9 @@ export default defineConfig(({ mode }) => {
 		target: apiTarget,
 		changeOrigin: true,
 		secure: true,
+		// The agent terminal is a websocket under /api, and the proxy ignores
+		// upgrade requests unless this is set.
+		ws: true,
 		headers: apiToken ? { Authorization: `Bearer ${apiToken}` } : undefined
 	};
 


### PR DESCRIPTION
An interactive agent gets a terminal over a websocket: framed channels carry
input, output and resize, and session errors travel on a control channel rather
than on stderr, which is reserved as a stream a non-TTY session can use for
what the program actually wrote there.

An agent that declares a port is published under /agent-connect/{instance id}
instead. Obot strips that prefix before forwarding, so an agent that assumed it
was at the root would build links landing outside its own prefix -- a
single-page UI would call Obot instead of itself. The prefix is sent per
request as X-Forwarded-Prefix and is also in the sandbox's configuration, for
servers that need it at start-up rather than per request, and relative
redirects are rewritten back inside the prefix idempotently so an agent that
already accounts for it is not prefixed twice.



---

Part 5 of an 11-PR stack. Base: `darren/hosted-agents-04-reachability`.

## Stack

1. #7448 — Resource model
2. #7449 — Sandbox backend interface
3. #7450 — Kubernetes sandbox backend
4. #7451 — Sandbox reachability (models + MCP)
**→ 5. #7452 — Terminal + HTTP publish** (this PR)
6. #7453 — Server wiring + Helm
7. #7454 — Controllers / reconcilers
8. #7455 — REST API
9. #7456 — Admin UI
10. #7457 — User UI
11. #7458 — Seed default config source

Merge bottom-up; GitHub retargets each child when its parent merges.
