### PR TITLE
feat: add the hosted agents admin UI (9/11)

### DIFF
--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -20,6 +20,7 @@
 		'agent-management': true,
 		'mcp-server-management': true,
 		'skills-management': true,
+		'hosted-agent-management': true,
 		'device-management': true,
 		'user-management': true,
 		'llm-gateway': true,
@@ -102,6 +103,7 @@
 		Settings,
 		PanelLeftClose,
 		Brain,
+		Container,
 		LayoutGrid,
 		KeyRound,
 		Menu,
@@ -422,6 +424,29 @@
 								id: 'skill-access-policies',
 								href: '/admin/skill-access-policies',
 								label: 'Skill Access Policies',
+								collapsible: false
+							}
+						]
+					},
+					{
+						id: 'hosted-agent-management',
+						icon: Container,
+						// "Management" is dropped deliberately: the section's items already
+						// say what they are, and the longer label wrapped to two lines in a
+						// narrow sidebar.
+						label: 'Hosted Agents',
+						collapsible: true,
+						items: [
+							{
+								id: 'hosted-agents',
+								href: '/admin/hosted-agents',
+								label: 'Templates',
+								collapsible: false
+							},
+							{
+								id: 'hosted-agent-access-policies',
+								href: '/admin/hosted-agent-access-policies',
+								label: 'Access Policies',
 								collapsible: false
 							}
 						]

--- a/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
@@ -1,0 +1,481 @@
+<script lang="ts">
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
+	import {
+		AdminService,
+		UserService,
+		type AccessControlRuleSubject,
+		type OrgUser,
+		type OrgGroup,
+		type HostedAgent,
+		type HostedAgentAccessPolicy,
+		type HostedAgentAccessPolicyResource
+	} from '$lib/services';
+	import { errors } from '$lib/stores';
+	import { goto } from '$lib/url';
+	import { getUserDisplayName } from '$lib/utils';
+	import Confirm from '../Confirm.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
+	import Table from '../table/Table.svelte';
+	import SearchHostedAgents from './SearchHostedAgents.svelte';
+	import SearchUsers from './SearchUsers.svelte';
+	import { Plus, Trash2 } from '@lucide/svelte';
+	import { onMount, untrack } from 'svelte';
+	import { fly } from 'svelte/transition';
+
+	interface Props {
+		hostedAgentAccessPolicy?: HostedAgentAccessPolicy;
+		onCreate?: (hostedAgentAccessPolicy: HostedAgentAccessPolicy) => void;
+		onUpdate?: (hostedAgentAccessPolicy: HostedAgentAccessPolicy) => void;
+		readonly?: boolean;
+	}
+
+	let {
+		hostedAgentAccessPolicy: initialHostedAgentAccessPolicy,
+		onCreate,
+		onUpdate,
+		readonly
+	}: Props = $props();
+
+	const duration = PAGE_TRANSITION_DURATION;
+	let policy = $state(
+		untrack(
+			() =>
+				initialHostedAgentAccessPolicy ?? {
+					id: undefined,
+					displayName: '',
+					subjects: [],
+					resources: []
+				}
+		)
+	);
+
+	let saving = $state<boolean | undefined>();
+	let usersAndGroups = $state<{ users: OrgUser[]; groups: OrgGroup[] }>();
+	let loadingUsersAndGroups = $state(false);
+	let loadingHostedAgents = $state(true);
+	let hostedAgents = $state<HostedAgent[]>([]);
+
+	let addUserGroupDialog = $state<ReturnType<typeof SearchUsers>>();
+	let addHostedAgentDialog = $state<ReturnType<typeof SearchHostedAgents>>();
+
+	let deletingPolicy = $state(false);
+
+	let initialPolicyJson = $derived(
+		initialHostedAgentAccessPolicy
+			? JSON.stringify({
+					subjects: initialHostedAgentAccessPolicy.subjects,
+					resources: initialHostedAgentAccessPolicy.resources
+				})
+			: ''
+	);
+
+	let hasChanges = $derived(
+		!initialPolicyJson ||
+			JSON.stringify({
+				subjects: policy.subjects,
+				resources: policy.resources
+			}) !== initialPolicyJson
+	);
+
+	onMount(async () => {
+		try {
+			hostedAgents = await AdminService.listHostedAgents();
+		} catch (error) {
+			errors.append(`Failed to load templates: ${error}`);
+		} finally {
+			loadingHostedAgents = false;
+		}
+	});
+
+	let hostedAgentsMap = $derived(new Map(hostedAgents.map((a) => [a.id, a])));
+
+	$effect(() => {
+		// Prevent loading users and groups if the policy has no subjects
+		if (!policy.subjects || policy.subjects?.length === 0) {
+			return;
+		}
+
+		loadingUsersAndGroups = true;
+
+		// Prevent refetching when adding new users or groups
+		const promises: [Promise<OrgUser[] | undefined>, Promise<OrgGroup[] | undefined>] = [
+			Promise.resolve(undefined),
+			Promise.resolve(undefined)
+		];
+
+		if (!usersAndGroups?.users) {
+			promises[0] = UserService.listUsers();
+		}
+		if (!usersAndGroups?.groups) {
+			promises[1] = UserService.listGroups();
+		}
+
+		Promise.all(promises)
+			.then(([users, groups]) => {
+				if (!usersAndGroups) {
+					usersAndGroups = { users: [], groups: [] };
+				}
+
+				if (users) {
+					usersAndGroups!.users = users;
+				}
+
+				if (groups) {
+					usersAndGroups!.groups = groups;
+				}
+
+				loadingUsersAndGroups = false;
+			})
+			.catch((error) => {
+				console.error('Failed to load users and groups:', error);
+				loadingUsersAndGroups = false;
+			});
+	});
+
+	function convertResourcesToTableData(resources: HostedAgentAccessPolicyResource[]) {
+		return (
+			resources
+				.map((resource) => {
+					if (resource.type === 'hostedAgent') {
+						const match = hostedAgentsMap.get(resource.id);
+						return {
+							id: resource.id,
+							name: match?.name || '-',
+							description: match?.description || '-',
+							type: 'Template'
+						};
+					} else if (resource.type === 'selector') {
+						return {
+							id: resource.id,
+							name: resource.id === '*' ? 'All Templates' : resource.id,
+							description: '',
+							type: 'Selector'
+						};
+					}
+					return undefined;
+				})
+				.filter((resource) => resource !== undefined) ?? []
+		);
+	}
+
+	function convertSubjectsToTableData(
+		subjects: AccessControlRuleSubject[],
+		users: OrgUser[],
+		groups: OrgGroup[]
+	) {
+		const userMap = new Map(users?.map((user) => [user.id, user]));
+		const groupMap = new Map(groups?.map((group) => [group.id, group]));
+
+		return (
+			subjects
+				.map((subject) => {
+					if (subject.type === 'user') {
+						return {
+							id: subject.id,
+							displayName: getUserDisplayName(userMap, subject.id),
+							type: 'User'
+						};
+					}
+
+					if (subject.type === 'group') {
+						const group = groupMap.get(subject.id);
+						if (!group) {
+							return undefined;
+						}
+
+						return {
+							id: subject.id,
+							displayName: group.name,
+							type: 'Group'
+						};
+					}
+
+					return {
+						id: subject.id,
+						displayName: subject.id === '*' ? 'All Obot Users' : subject.id,
+						type: 'Selector'
+					};
+				})
+				.filter((subject) => subject !== undefined) ?? []
+		);
+	}
+
+	function validate(p: typeof policy) {
+		if (!p) return false;
+
+		return (
+			p.displayName.length > 0 && (p.subjects?.length ?? 0) > 0 && (p.resources?.length ?? 0) > 0
+		);
+	}
+
+	const subjectTableData = $derived(
+		convertSubjectsToTableData(
+			policy.subjects ?? [],
+			usersAndGroups?.users ?? [],
+			usersAndGroups?.groups ?? []
+		)
+	);
+	const resourceTableData = $derived(convertResourcesToTableData(policy.resources ?? []));
+</script>
+
+<div
+	class="flex h-full w-full flex-col gap-4"
+	out:fly={{ x: 100, duration }}
+	in:fly={{ x: 100, delay: duration }}
+>
+	<div class="flex grow flex-col gap-4" out:fly={{ x: -100, duration }} in:fly={{ x: -100 }}>
+		{#if policy.id}
+			<div class="flex w-full items-center justify-between gap-4">
+				<div class="flex items-center gap-2">
+					<h1 class="flex items-center gap-4 text-2xl font-semibold">
+						{policy.displayName}
+					</h1>
+				</div>
+				{#if !readonly}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete Policy' }}
+						onclick={() => {
+							deletingPolicy = true;
+						}}
+					>
+						<Trash2 class="size-4" />
+					</IconButton>
+				{/if}
+			</div>
+		{/if}
+
+		{#if !policy.id}
+			<div
+				class="dark:bg-base-400 dark:border-base-400 bg-base-100 rounded-lg border border-transparent p-4"
+			>
+				<div class="flex flex-col gap-6">
+					<div class="flex flex-col gap-2">
+						<label
+							for="hosted-agent-access-policy-name"
+							class="flex-1 text-sm font-light capitalize"
+						>
+							Name
+						</label>
+						<input
+							id="hosted-agent-access-policy-name"
+							bind:value={policy.displayName}
+							class="text-input-filled mt-0.5"
+							disabled={readonly}
+						/>
+					</div>
+				</div>
+			</div>
+		{/if}
+
+		<div class="flex flex-col gap-2">
+			<div class="mb-2 flex items-center justify-between">
+				<h2 class="text-lg font-semibold">Users & Groups</h2>
+				{#if !readonly}
+					<div class="relative flex items-center gap-4">
+						<button
+							class="btn btn-primary flex items-center gap-1 text-sm"
+							disabled={loadingUsersAndGroups}
+							onclick={() => {
+								addUserGroupDialog?.open();
+							}}
+						>
+							<Plus class="size-4" /> Add User/Group
+						</button>
+					</div>
+				{/if}
+			</div>
+			{#if loadingUsersAndGroups}
+				<div class="my-2 flex items-center justify-center">
+					<Loading class="size-6" />
+				</div>
+			{:else}
+				<Table
+					data={subjectTableData}
+					fields={['displayName', 'type']}
+					headers={[{ property: 'displayName', title: 'Name' }]}
+					noDataMessage="No users or groups added."
+				>
+					{#snippet actions(d)}
+						{#if !readonly}
+							<IconButton
+								variant="danger"
+								onclick={() => {
+									policy.subjects = policy.subjects?.filter((subject) => subject.id !== d.id);
+								}}
+								tooltip={{ text: 'Delete User/Group' }}
+							>
+								<Trash2 class="size-4" />
+							</IconButton>
+						{/if}
+					{/snippet}
+				</Table>
+			{/if}
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<div class="mb-2 flex items-center justify-between">
+				<h2 class="text-lg font-semibold">Templates</h2>
+				{#if !readonly}
+					<button
+						class="btn btn-primary flex items-center gap-1 text-sm"
+						onclick={() => {
+							addHostedAgentDialog?.open();
+						}}
+					>
+						<Plus class="size-4" /> Add Template
+					</button>
+				{/if}
+			</div>
+			{#if loadingHostedAgents}
+				<div class="my-2 flex items-center justify-center">
+					<Loading class="size-6" />
+				</div>
+			{:else}
+				<Table
+					data={resourceTableData}
+					fields={['name', 'description']}
+					headers={[
+						{ property: 'name', title: 'Template' },
+						{ property: 'description', title: 'Description' }
+					]}
+					noDataMessage="No templates added."
+				>
+					{#snippet onRenderColumn(field, d)}
+						{#if field === 'name'}
+							<span class="font-light">{d.name}</span>
+						{:else}
+							{d[field as keyof typeof d]}
+						{/if}
+					{/snippet}
+					{#snippet actions(d)}
+						{#if !readonly}
+							<IconButton
+								variant="danger"
+								onclick={() => {
+									policy.resources = policy.resources?.filter((r) => r.id !== d.id) ?? [];
+								}}
+								tooltip={{ text: 'Remove Template' }}
+							>
+								<Trash2 class="size-4" />
+							</IconButton>
+						{/if}
+					{/snippet}
+				</Table>
+			{/if}
+		</div>
+	</div>
+	{#if !readonly}
+		<div
+			class="bg-base-200 text-muted-content dark:bg-base-100 sticky bottom-0 left-0 z-50 flex w-full justify-end gap-2 py-4"
+			out:fly={{ x: -100, duration }}
+			in:fly={{ x: -100 }}
+		>
+			<div class="flex w-full justify-end gap-2">
+				{#if !policy.id}
+					<button
+						class="btn btn-secondary text-sm"
+						onclick={() => {
+							goto('/admin/hosted-agent-access-policies');
+						}}
+					>
+						Cancel
+					</button>
+					<button
+						class="btn btn-primary text-sm"
+						disabled={!validate(policy) || saving}
+						onclick={async () => {
+							saving = true;
+							try {
+								const response = await AdminService.createHostedAgentAccessPolicy(policy);
+								policy = response;
+								onCreate?.(response);
+							} finally {
+								saving = false;
+							}
+						}}
+					>
+						{#if saving}
+							<Loading class="size-4" />
+						{:else}
+							Save
+						{/if}
+					</button>
+				{:else}
+					<button
+						class="btn btn-primary text-sm"
+						disabled={!validate(policy) || !hasChanges || saving}
+						onclick={async () => {
+							if (!policy.id) return;
+							saving = true;
+							try {
+								const response = await AdminService.updateHostedAgentAccessPolicy(
+									policy.id,
+									policy
+								);
+								policy = response;
+								onUpdate?.(response);
+							} finally {
+								saving = false;
+							}
+						}}
+					>
+						{#if saving}
+							<Loading class="size-4" />
+						{:else}
+							Update
+						{/if}
+					</button>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<SearchHostedAgents
+	bind:this={addHostedAgentDialog}
+	{hostedAgents}
+	onAdd={(resources: HostedAgentAccessPolicyResource[]) => {
+		policy.resources = [
+			...(policy.resources ?? []),
+			...resources.filter((resource) => !policy.resources?.some((r) => r.id === resource.id))
+		];
+	}}
+	exclude={policy.resources?.map((resource) => resource.id) ?? []}
+/>
+
+<SearchUsers
+	bind:this={addUserGroupDialog}
+	filterIds={policy.subjects?.map((subject) => subject.id) ?? []}
+	onAdd={async (users: OrgUser[], groups: OrgGroup[]) => {
+		const existingSubjectIds = new Set(policy.subjects?.map((subject) => subject.id) ?? []);
+		const newSubjects = [
+			...users
+				.filter((user: OrgUser) => !existingSubjectIds.has(user.id))
+				.map((user: OrgUser) => ({
+					type: 'user' as const,
+					id: user.id
+				})),
+			...groups
+				.filter((group: OrgGroup) => !existingSubjectIds.has(group.id))
+				.map((group: OrgGroup) => ({
+					type: group.id === '*' ? ('selector' as const) : ('group' as const),
+					id: group.id
+				}))
+		];
+		policy.subjects = [...(policy.subjects ?? []), ...newSubjects];
+	}}
+/>
+
+<Confirm
+	msg={`Delete ${policy.displayName || 'this policy'}?`}
+	show={deletingPolicy}
+	onsuccess={async () => {
+		if (!policy.id) return;
+		saving = true;
+		await AdminService.deleteHostedAgentAccessPolicy(policy.id);
+		goto('/admin/hosted-agent-access-policies');
+	}}
+	oncancel={() => (deletingPolicy = false)}
+/>

--- a/ui/user/src/lib/components/admin/HostedAgentEnvEditor.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentEnvEditor.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+	import type { HostedAgentEnv } from '$lib/services/admin/types';
+	import IconButton from '../primitives/IconButton.svelte';
+	import { Eye, EyeOff, Plus, Trash2 } from '@lucide/svelte';
+
+	interface Props {
+		env: HostedAgentEnv[];
+		readonly?: boolean;
+		onReveal?: () => Promise<Record<string, string>>;
+	}
+
+	let { env = $bindable([]), readonly, onReveal }: Props = $props();
+
+	// Keys that look like credentials default to sensitive.
+	const SENSITIVE_KEY_RE = /PASS|TOKEN|KEY/i;
+
+	// Tracks which rows the user has toggled by hand, so the heuristic never
+	// overrides an explicit choice. Local only: never sent to the API.
+	let touchedSensitive = $state<Set<number>>(new Set());
+	let revealed = $state(false);
+	let revealing = $state(false);
+
+	function onKeyInput(index: number, key: string) {
+		env[index].key = key;
+		if (!touchedSensitive.has(index)) {
+			env[index].sensitive = SENSITIVE_KEY_RE.test(key);
+		}
+	}
+
+	function toggleSensitive(index: number) {
+		touchedSensitive.add(index);
+		touchedSensitive = touchedSensitive;
+		env[index].sensitive = !env[index].sensitive;
+	}
+
+	function addRow() {
+		env = [
+			...env,
+			{ key: '', value: '', name: '', description: '', sensitive: false, required: false }
+		];
+	}
+
+	function removeRow(index: number) {
+		env = env.filter((_, i) => i !== index);
+		touchedSensitive.delete(index);
+		touchedSensitive = touchedSensitive;
+	}
+
+	async function reveal() {
+		if (!onReveal) return;
+		revealing = true;
+		try {
+			const secrets = await onReveal();
+			for (const item of env) {
+				if (item.sensitive && secrets[item.key] !== undefined) {
+					item.value = secrets[item.key];
+				}
+			}
+			revealed = true;
+		} finally {
+			revealing = false;
+		}
+	}
+</script>
+
+<div class="flex flex-col gap-2">
+	<div class="mb-2 flex items-center justify-between">
+		<div class="flex flex-col">
+			<h2 class="text-lg font-semibold">Environment</h2>
+			<span class="text-muted-content text-xs">
+				Values marked sensitive are stored separately and are not shown after saving.
+			</span>
+		</div>
+		<div class="flex items-center gap-2">
+			{#if onReveal && env.some((e) => e.sensitive) && !readonly}
+				<button
+					class="btn btn-secondary flex items-center gap-1 text-sm"
+					disabled={revealing || revealed}
+					onclick={reveal}
+				>
+					{#if revealed}
+						<EyeOff class="size-4" /> Revealed
+					{:else}
+						<Eye class="size-4" /> Reveal
+					{/if}
+				</button>
+			{/if}
+			{#if !readonly}
+				<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={addRow}>
+					<Plus class="size-4" /> Add Variable
+				</button>
+			{/if}
+		</div>
+	</div>
+
+	{#if env.length === 0}
+		<p class="text-muted-content py-4 text-center text-sm">No environment variables added.</p>
+	{:else}
+		<div class="flex flex-col gap-3">
+			{#each env as item, i (i)}
+				<div
+					class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-3 rounded-lg border border-transparent p-4"
+				>
+					<div class="flex items-end gap-3">
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="env-key-{i}" class="text-sm font-light">Key</label>
+							<input
+								id="env-key-{i}"
+								value={item.key}
+								oninput={(e) => onKeyInput(i, e.currentTarget.value)}
+								class="text-input-filled"
+								placeholder="API_TOKEN"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="env-value-{i}" class="text-sm font-light">Value</label>
+							<input
+								id="env-value-{i}"
+								bind:value={item.value}
+								type={item.sensitive && !revealed ? 'password' : 'text'}
+								class="text-input-filled"
+								placeholder={item.sensitive ? 'Stored securely' : ''}
+								disabled={readonly}
+							/>
+						</div>
+						{#if !readonly}
+							<IconButton
+								variant="danger"
+								onclick={() => removeRow(i)}
+								tooltip={{ text: 'Remove' }}
+							>
+								<Trash2 class="size-4" />
+							</IconButton>
+						{/if}
+					</div>
+
+					<div class="flex items-end gap-3">
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="env-desc-{i}" class="text-sm font-light">Description</label>
+							<input
+								id="env-desc-{i}"
+								bind:value={item.description}
+								class="text-input-filled"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex items-center gap-4 pb-2">
+							<label class="flex items-center gap-2 text-sm font-light">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm"
+									checked={item.sensitive}
+									onchange={() => toggleSensitive(i)}
+									disabled={readonly}
+								/>
+								Sensitive
+							</label>
+							<label class="flex items-center gap-2 text-sm font-light">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm"
+									bind:checked={item.required}
+									disabled={readonly}
+								/>
+								Required
+							</label>
+						</div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/ui/user/src/lib/components/admin/HostedAgentForm.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentForm.svelte
@@ -1,0 +1,704 @@
+<script lang="ts">
+	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
+	import {
+		AdminService,
+		type Harness,
+		type HostedAgent,
+		type HostedAgentManifest,
+		type MCPCatalogEntry,
+		type MCPCatalogServer,
+		type Model,
+		type ModelProvider,
+		type SkillAccessPolicyResource,
+		type SkillRepository
+	} from '$lib/services';
+	import type { Skill } from '$lib/services/nanobot/types';
+	import { defaultModelAliases as defaultModelAliasesStore, errors } from '$lib/stores';
+	import { goto } from '$lib/url';
+	import Confirm from '../Confirm.svelte';
+	import Search from '../Search.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
+	import HostedAgentEnvEditor from './HostedAgentEnvEditor.svelte';
+	import HostedAgentQuestionsEditor from './HostedAgentQuestionsEditor.svelte';
+	import SearchModels from './SearchModels.svelte';
+	import SearchSkills from './SearchSkills.svelte';
+	import { Plus, Trash2 } from '@lucide/svelte';
+	import { onMount, untrack } from 'svelte';
+	import { fly } from 'svelte/transition';
+
+	interface Props {
+		hostedAgent?: HostedAgent;
+		onCreate?: (hostedAgent: HostedAgent) => void;
+		onUpdate?: (hostedAgent: HostedAgent) => void;
+		readonly?: boolean;
+	}
+
+	let { hostedAgent: initialHostedAgent, onCreate, onUpdate, readonly }: Props = $props();
+
+	const duration = PAGE_TRANSITION_DURATION;
+
+	function emptyAgent(): HostedAgentManifest & { id?: string } {
+		return {
+			id: undefined,
+			name: '',
+			description: '',
+			icon: '',
+			iconDark: '',
+			harnessID: '',
+			gitRepo: '',
+			gitRef: '',
+			modelProviders: [],
+			models: [],
+			mcpServers: [],
+			skills: [],
+			env: [],
+			questions: [],
+			allowUserMCPServers: false,
+			allowUserSkills: false,
+			allowUserModels: false,
+			allowUserGitRepo: false,
+			maxInstancesPerUser: 0,
+			port: undefined,
+			terminal: false
+		};
+	}
+
+	let agent = $state(untrack(() => ({ ...emptyAgent(), ...(initialHostedAgent ?? {}) })));
+
+	let saving = $state(false);
+	let deleting = $state(false);
+	let loadingServices = $state(true);
+	let harnesses = $state<Harness[]>([]);
+	let modelProviders = $state<ModelProvider[]>([]);
+	let mcpEntries = $state<MCPCatalogEntry[]>([]);
+	let mcpCatalogServers = $state<MCPCatalogServer[]>([]);
+	let models = $state<Model[]>([]);
+	let defaultModelAliases = $derived(defaultModelAliasesStore.current);
+	let skills = $state<Skill[]>([]);
+	let skillRepositories = $state<SkillRepository[]>([]);
+
+	let addModelDialog = $state<ReturnType<typeof SearchModels>>();
+	let addSkillDialog = $state<ReturnType<typeof SearchSkills>>();
+
+	let modelsMap = $derived(new Map(models.map((m) => [m.id, m])));
+	let skillsMap = $derived(new Map(skills.map((s) => [s.id, s])));
+
+	// Model IDs may be a real model, obot://<alias>, or a wildcard prefix, so
+	// resolve a label rather than assuming a lookup hit.
+	function modelLabel(id: string) {
+		if (id.startsWith('obot://')) return `${id.slice('obot://'.length)} (default alias)`;
+		if (id === '*') return 'All models';
+		if (id.endsWith('*')) return `${id} (prefix match)`;
+		const match = modelsMap.get(id);
+		return match ? match.displayName || match.name || id : id;
+	}
+
+	function skillLabel(id: string) {
+		const match = skillsMap.get(id);
+		return match ? match.displayName || match.name || id : id;
+	}
+
+	// Admin-configured MCP servers live as catalog entries (npx/uvx/containerized/remote
+	// templates) as well as multi-user servers, so both have to be listed here.
+	let mcpServerOptions = $derived([
+		...mcpEntries.map((entry) => ({
+			id: entry.id,
+			name: entry.manifest?.name || entry.id,
+			detail: entry.manifest?.serverUserType === 'multiUser' ? 'Multi-user' : 'Single-user'
+		})),
+		...mcpCatalogServers.map((server) => ({
+			id: server.id,
+			name: server.manifest?.name || server.alias || server.id,
+			detail: 'Server'
+		}))
+	]);
+
+	let mcpQuery = $state('');
+	let filteredMcpServerOptions = $derived(
+		mcpQuery
+			? mcpServerOptions.filter((o) => o.name.toLowerCase().includes(mcpQuery.toLowerCase()))
+			: mcpServerOptions
+	);
+	let selectedMcpServers = $derived(agent.mcpServers ?? []);
+
+	onMount(async () => {
+		try {
+			const [harnessList, providers, entries, servers, modelList, skillList, repos] =
+				await Promise.all([
+					AdminService.listHarnesses(),
+					AdminService.listModelProviders(),
+					AdminService.listMCPCatalogEntries(DEFAULT_MCP_CATALOG_ID, { all: true }),
+					AdminService.listMCPCatalogServers(DEFAULT_MCP_CATALOG_ID, { all: true }),
+					AdminService.listModels({ all: true }),
+					AdminService.listAllSkills(),
+					AdminService.listSkillRepositories()
+				]);
+			harnesses = harnessList;
+			modelProviders = providers.filter((p) => p.configured);
+			mcpEntries = entries;
+			mcpCatalogServers = servers;
+			models = modelList;
+			skills = skillList;
+			skillRepositories = repos;
+		} catch (error) {
+			errors.append(`Failed to load services: ${error}`);
+		} finally {
+			loadingServices = false;
+		}
+	});
+
+	function toggleModelProvider(id: string) {
+		const current = agent.modelProviders ?? [];
+		agent.modelProviders = current.includes(id)
+			? current.filter((p) => p !== id)
+			: [...current, id];
+	}
+
+	function toggleMcpServer(id: string) {
+		const current = agent.mcpServers ?? [];
+		agent.mcpServers = current.includes(id) ? current.filter((s) => s !== id) : [...current, id];
+	}
+
+	function toManifest(a: typeof agent): HostedAgentManifest {
+		return {
+			name: a.name,
+			description: a.description,
+			icon: a.icon,
+			iconDark: a.iconDark,
+			harnessID: a.harnessID,
+			gitRepo: a.gitRepo,
+			gitRef: a.gitRef,
+			modelProviders: a.modelProviders,
+			models: a.models,
+			mcpServers: a.mcpServers,
+			skills: a.skills,
+			env: a.env,
+			questions: a.questions,
+			allowUserMCPServers: a.allowUserMCPServers,
+			allowUserSkills: a.allowUserSkills,
+			allowUserModels: a.allowUserModels,
+			allowUserGitRepo: a.allowUserGitRepo,
+			maxInstancesPerUser: a.maxInstancesPerUser,
+			port: a.port,
+			terminal: a.terminal
+		};
+	}
+
+	function validate(a: typeof agent) {
+		if (!a.name || !a.harnessID) return false;
+		if ((a.env ?? []).some((e) => !e.key)) return false;
+		if ((a.maxInstancesPerUser ?? 0) < 0) return false;
+		if (a.port !== undefined && (a.port < 0 || a.port > 65535)) return false;
+		const questions = a.questions ?? [];
+		if (questions.some((q) => !q.key)) return false;
+		if (questions.some((q) => q.type === 'select' && (q.options ?? []).length === 0)) return false;
+		const keys = questions.map((q) => q.key);
+		if (new Set(keys).size !== keys.length) return false;
+		return true;
+	}
+
+	async function revealSecrets(): Promise<Record<string, string>> {
+		if (!agent.id) return {};
+		return AdminService.revealHostedAgent(agent.id);
+	}
+</script>
+
+<div
+	class="flex h-full w-full flex-col gap-4"
+	out:fly={{ x: 100, duration }}
+	in:fly={{ x: 100, delay: duration }}
+>
+	<div class="flex grow flex-col gap-4" out:fly={{ x: -100, duration }} in:fly={{ x: -100 }}>
+		{#if agent.id}
+			<div class="flex w-full items-center justify-between gap-4">
+				<h1 class="flex items-center gap-4 text-2xl font-semibold">{agent.name}</h1>
+				{#if !readonly}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete Agent' }}
+						onclick={() => (deleting = true)}
+					>
+						<Trash2 class="size-4" />
+					</IconButton>
+				{/if}
+			</div>
+		{/if}
+
+		<div
+			class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-6 rounded-lg border border-transparent p-4"
+		>
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-name" class="text-sm font-light">Name</label>
+				<input
+					id="hosted-agent-name"
+					bind:value={agent.name}
+					class="text-input-filled"
+					disabled={readonly}
+				/>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-description" class="text-sm font-light">Description</label>
+				<textarea
+					id="hosted-agent-description"
+					bind:value={agent.description}
+					class="text-input-filled"
+					rows="3"
+					disabled={readonly}
+				></textarea>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-harness" class="text-sm font-light">Harness</label>
+				<select
+					id="hosted-agent-harness"
+					bind:value={agent.harnessID}
+					class="text-input-filled"
+					disabled={readonly || loadingServices}
+				>
+					<option value="" disabled>Select a harness...</option>
+					{#each harnesses as harness (harness.id)}
+						<option value={harness.id}>{harness.name}</option>
+					{/each}
+				</select>
+				{#if !loadingServices && harnesses.length === 0}
+					<span class="text-muted-content text-xs">
+						No harnesses configured. Add one in the Harnesses tab first.
+					</span>
+				{/if}
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-git-repo" class="text-sm font-light">Git Repository</label>
+				<input
+					id="hosted-agent-git-repo"
+					bind:value={agent.gitRepo}
+					class="text-input-filled"
+					placeholder="https://github.com/example/repo (optional)"
+					disabled={readonly}
+					inputmode="url"
+					autocomplete="off"
+				/>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-git-ref" class="text-sm font-light">Branch, Tag or Commit</label>
+				<input
+					id="hosted-agent-git-ref"
+					bind:value={agent.gitRef}
+					class="text-input-filled"
+					placeholder="main (optional)"
+					disabled={readonly || !agent.gitRepo}
+					autocomplete="off"
+				/>
+				<span class="text-muted-content text-xs">
+					Leave blank to track the repository's default branch. Pin a tag or commit when the agent
+					must run against a known revision.
+				</span>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-icon" class="text-sm font-light">Icon URL</label>
+				<div class="flex items-center gap-3">
+					{#if agent.icon}
+						<img src={agent.icon} alt="" class="size-10 shrink-0 rounded-md object-contain" />
+					{/if}
+					<input
+						type="text"
+						id="hosted-agent-icon"
+						name="icon"
+						bind:value={agent.icon}
+						class="text-input-filled grow"
+						disabled={readonly}
+						inputmode="url"
+						autocomplete="off"
+					/>
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-icon-dark" class="text-sm font-light">Icon URL (Dark)</label>
+				<div class="flex items-center gap-3">
+					{#if agent.iconDark}
+						<img
+							src={agent.iconDark}
+							alt=""
+							class="bg-base-300 size-10 shrink-0 rounded-md object-contain"
+						/>
+					{/if}
+					<input
+						type="text"
+						id="hosted-agent-icon-dark"
+						name="iconDark"
+						bind:value={agent.iconDark}
+						class="text-input-filled grow"
+						disabled={readonly}
+						inputmode="url"
+						autocomplete="off"
+					/>
+				</div>
+			</div>
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<div class="mb-2 flex flex-col">
+				<h2 class="text-lg font-semibold">Services</h2>
+				<span class="text-muted-content text-xs">
+					Model providers, models, MCP servers, and skills made available to the agent.
+				</span>
+			</div>
+			{#if loadingServices}
+				<div class="my-2 flex items-center justify-center">
+					<Loading class="size-6" />
+				</div>
+			{:else}
+				<div
+					class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-6 rounded-lg border border-transparent p-4"
+				>
+					<div class="flex flex-col gap-2">
+						<span class="text-sm font-light">Model Providers</span>
+						{#if modelProviders.length === 0}
+							<p class="text-muted-content text-sm">No configured model providers.</p>
+						{:else}
+							<div class="flex flex-col gap-1">
+								{#each modelProviders as provider (provider.id)}
+									<label class="flex items-center gap-2 text-sm font-light">
+										<input
+											type="checkbox"
+											class="checkbox checkbox-sm"
+											checked={agent.modelProviders?.includes(provider.id)}
+											onchange={() => toggleModelProvider(provider.id)}
+											disabled={readonly}
+										/>
+										{provider.name}
+									</label>
+								{/each}
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col gap-2">
+						<div class="flex items-center justify-between">
+							<span class="text-sm font-light">Models</span>
+							{#if !readonly}
+								<button
+									class="btn btn-secondary flex items-center gap-1 text-xs"
+									onclick={() => addModelDialog?.open()}
+								>
+									<Plus class="size-3" /> Add Models
+								</button>
+							{/if}
+						</div>
+						{#if (agent.models ?? []).length === 0}
+							<p class="text-muted-content text-sm">No models added.</p>
+						{:else}
+							<div class="flex flex-col gap-1">
+								{#each agent.models ?? [] as id (id)}
+									<div class="flex items-center justify-between gap-2 text-sm font-light">
+										<span class="truncate">{modelLabel(id)}</span>
+										{#if !readonly}
+											<IconButton
+												variant="danger"
+												onclick={() => {
+													agent.models = (agent.models ?? []).filter((m) => m !== id);
+												}}
+												tooltip={{ text: 'Remove Model' }}
+											>
+												<Trash2 class="size-4" />
+											</IconButton>
+										{/if}
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col gap-2">
+						<div class="flex items-center justify-between">
+							<span class="text-sm font-light">Skills</span>
+							{#if !readonly}
+								<button
+									class="btn btn-secondary flex items-center gap-1 text-xs"
+									onclick={() => addSkillDialog?.open()}
+								>
+									<Plus class="size-3" /> Add Skills
+								</button>
+							{/if}
+						</div>
+						{#if (agent.skills ?? []).length === 0}
+							<p class="text-muted-content text-sm">No skills added.</p>
+						{:else}
+							<div class="flex flex-col gap-1">
+								{#each agent.skills ?? [] as id (id)}
+									<div class="flex items-center justify-between gap-2 text-sm font-light">
+										<span class="truncate">{skillLabel(id)}</span>
+										{#if !readonly}
+											<IconButton
+												variant="danger"
+												onclick={() => {
+													agent.skills = (agent.skills ?? []).filter((s) => s !== id);
+												}}
+												tooltip={{ text: 'Remove Skill' }}
+											>
+												<Trash2 class="size-4" />
+											</IconButton>
+										{/if}
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col gap-2">
+						<div class="flex items-center justify-between">
+							<span class="text-sm font-light">MCP Servers</span>
+							{#if selectedMcpServers.length > 0}
+								<span class="text-muted-content text-xs">{selectedMcpServers.length} selected</span>
+							{/if}
+						</div>
+
+						{#if mcpServerOptions.length === 0}
+							<p class="text-muted-content text-sm">No configured MCP servers.</p>
+						{:else}
+							<Search
+								class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
+								onChange={(val) => (mcpQuery = val)}
+								value={mcpQuery}
+								placeholder="Search MCP servers..."
+							/>
+							<div class="default-scrollbar-thin flex max-h-64 flex-col gap-1 overflow-y-auto">
+								{#each filteredMcpServerOptions as option (option.id)}
+									<label class="flex items-center gap-2 text-sm font-light">
+										<input
+											type="checkbox"
+											class="checkbox checkbox-sm shrink-0"
+											checked={agent.mcpServers?.includes(option.id)}
+											onchange={() => toggleMcpServer(option.id)}
+											disabled={readonly}
+										/>
+										<span class="truncate">{option.name}</span>
+										<span class="badge badge-secondary badge-xs shrink-0">{option.detail}</span>
+									</label>
+								{/each}
+								{#if filteredMcpServerOptions.length === 0}
+									<p class="text-muted-content py-2 text-sm">No servers match "{mcpQuery}".</p>
+								{/if}
+							</div>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<HostedAgentEnvEditor
+			bind:env={agent.env as NonNullable<typeof agent.env>}
+			{readonly}
+			onReveal={agent.id ? revealSecrets : undefined}
+		/>
+
+		<div class="flex flex-col gap-2">
+			<div class="mb-2 flex flex-col">
+				<h2 class="text-lg font-semibold">Instances</h2>
+				<span class="text-muted-content text-xs">
+					Each user creates their own instances of this agent.
+				</span>
+			</div>
+			<div
+				class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4"
+			>
+				<div class="flex flex-col gap-2">
+					<label for="hosted-agent-max-instances" class="text-sm font-light">
+						Max instances per user
+					</label>
+					<input
+						id="hosted-agent-max-instances"
+						type="number"
+						min="0"
+						bind:value={agent.maxInstancesPerUser}
+						class="text-input-filled w-40"
+						disabled={readonly}
+					/>
+					<span class="text-muted-content text-xs">0 means unlimited.</span>
+				</div>
+
+				<div class="flex flex-col gap-2 pt-2">
+					<label for="hosted-agent-port" class="text-sm font-light">HTTP port</label>
+					<input
+						id="hosted-agent-port"
+						type="number"
+						min="0"
+						max="65535"
+						placeholder="None"
+						value={agent.port ?? ''}
+						oninput={(e) =>
+							(agent.port =
+								e.currentTarget.value === '' ? undefined : Number(e.currentTarget.value))}
+						class="text-input-filled w-40"
+						disabled={readonly}
+					/>
+					<span class="text-muted-content text-xs">
+						The port this agent's image serves HTTP on. Set it to publish an Open link on each
+						instance. Leave blank if the agent serves nothing.
+					</span>
+				</div>
+
+				<div class="flex flex-col gap-2 pt-2">
+					<label class="flex items-center gap-2 text-sm font-light">
+						<input type="checkbox" bind:checked={agent.terminal} disabled={readonly} />
+						Offer a terminal
+					</label>
+					<span class="text-muted-content text-xs">
+						Adds an interactive shell attached to the running sandbox. Requires a harness marked
+						interactive, since without a TTY there is no session to attach to.
+					</span>
+				</div>
+
+				<div class="flex flex-col gap-2 pt-2">
+					<span class="text-sm font-light">User-defined resources</span>
+					<span class="text-muted-content text-xs">
+						Let users attach their own resources to an instance, on top of the ones configured
+						above. Users can only pick from what they already have access to.
+					</span>
+					<label class="flex items-center gap-2 pt-1 text-sm font-light">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							bind:checked={agent.allowUserMCPServers}
+							disabled={readonly}
+						/>
+						Allow user-defined MCP servers
+					</label>
+					<label class="flex items-center gap-2 text-sm font-light">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							bind:checked={agent.allowUserSkills}
+							disabled={readonly}
+						/>
+						Allow user-defined skills
+					</label>
+					<label class="flex items-center gap-2 text-sm font-light">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							bind:checked={agent.allowUserModels}
+							disabled={readonly}
+						/>
+						Allow user-defined models
+					</label>
+					<label class="flex items-center gap-2 text-sm font-light">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							bind:checked={agent.allowUserGitRepo}
+							disabled={readonly}
+						/>
+						Allow user-specified git repository
+					</label>
+				</div>
+			</div>
+		</div>
+
+		<HostedAgentQuestionsEditor
+			bind:questions={agent.questions as NonNullable<typeof agent.questions>}
+			{readonly}
+		/>
+	</div>
+
+	{#if !readonly}
+		<div
+			class="bg-base-200 text-muted-content dark:bg-base-100 sticky bottom-0 left-0 z-50 flex w-full justify-end gap-2 py-4"
+		>
+			<div class="flex w-full justify-end gap-2">
+				{#if !agent.id}
+					<button class="btn btn-secondary text-sm" onclick={() => goto('/admin/hosted-agents')}>
+						Cancel
+					</button>
+					<button
+						class="btn btn-primary text-sm"
+						disabled={!validate(agent) || saving}
+						onclick={async () => {
+							saving = true;
+							try {
+								const response = await AdminService.createHostedAgent(toManifest(agent));
+								agent = { ...emptyAgent(), ...response };
+								onCreate?.(response);
+							} finally {
+								saving = false;
+							}
+						}}
+					>
+						{#if saving}
+							<Loading class="size-4" />
+						{:else}
+							Save
+						{/if}
+					</button>
+				{:else}
+					<button
+						class="btn btn-primary text-sm"
+						disabled={!validate(agent) || saving}
+						onclick={async () => {
+							if (!agent.id) return;
+							saving = true;
+							try {
+								const response = await AdminService.updateHostedAgent(agent.id, toManifest(agent));
+								agent = { ...emptyAgent(), ...response };
+								onUpdate?.(response);
+							} finally {
+								saving = false;
+							}
+						}}
+					>
+						{#if saving}
+							<Loading class="size-4" />
+						{:else}
+							Update
+						{/if}
+					</button>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<SearchModels
+	bind:this={addModelDialog}
+	{models}
+	defaultAliases={defaultModelAliases}
+	exclude={agent.models ?? []}
+	onAdd={(modelIds: string[]) => {
+		const existing = new Set(agent.models ?? []);
+		agent.models = [...(agent.models ?? []), ...modelIds.filter((id) => !existing.has(id))];
+	}}
+/>
+
+<SearchSkills
+	bind:this={addSkillDialog}
+	{skills}
+	{skillRepositories}
+	wildcardAvailable={false}
+	exclude={agent.skills ?? []}
+	onAdd={(resources: SkillAccessPolicyResource[]) => {
+		// The agent references individual skills, so ignore repository-level picks.
+		const existing = new Set(agent.skills ?? []);
+		const picked = resources
+			.filter((r) => r.type === 'skill')
+			.map((r) => r.id)
+			.filter((id) => !existing.has(id));
+		agent.skills = [...(agent.skills ?? []), ...picked];
+	}}
+/>
+
+<Confirm
+	msg={`Delete ${agent.name || 'this agent'}?`}
+	show={deleting}
+	onsuccess={async () => {
+		if (!agent.id) return;
+		saving = true;
+		await AdminService.deleteHostedAgent(agent.id);
+		goto('/admin/hosted-agents');
+	}}
+	oncancel={() => (deleting = false)}
+/>

--- a/ui/user/src/lib/components/admin/HostedAgentPools.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentPools.svelte
@@ -1,0 +1,511 @@
+<script lang="ts">
+	import Confirm from '$lib/components/Confirm.svelte';
+	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
+	import { AdminService, UserService, type OrgUser } from '$lib/services';
+	import type {
+		HostedAgentPool,
+		HostedAgentPoolAssignment,
+		HostedAgentPoolDefaults,
+		HostedAgentPoolUtilization
+	} from '$lib/services/admin/types';
+	import { errors } from '$lib/stores';
+	import { Activity, Pencil, Plus, Trash2 } from '@lucide/svelte';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		pools: HostedAgentPool[];
+		defaults?: HostedAgentPoolDefaults;
+		assignments: HostedAgentPoolAssignment[];
+		readonly?: boolean;
+	}
+
+	let {
+		pools = $bindable(),
+		defaults = $bindable(),
+		assignments = $bindable(),
+		readonly = false
+	}: Props = $props();
+
+	let poolDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let assignmentDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let usageDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let editing = $state<HostedAgentPool>();
+	let deleting = $state<HostedAgentPool>();
+	let deletingAssignment = $state<HostedAgentPoolAssignment>();
+	let saving = $state(false);
+	let usage = $state<HostedAgentPoolUtilization>();
+	let usagePool = $state<HostedAgentPool>();
+	let users = $state<OrgUser[]>([]);
+	let usersByID = $derived(new Map(users.map((u) => [u.id, u])));
+
+	// A pool's ID says nothing an administrator can act on. Its members do, so
+	// resolve them to people and let the pool be recognised by who is in it.
+	function userLabel(id: string) {
+		const user = usersByID.get(id);
+		if (!user) return `User ${id}`;
+		return user.displayName || user.email || user.username || `User ${id}`;
+	}
+
+	function membersOf(poolID: string) {
+		return assignments.filter((a) => a.poolID === poolID);
+	}
+
+	let form = $state({ cpu: 1, memory: 4, storage: 20, maxSandboxes: 10, suspended: false });
+	let assignmentForm = $state({ userID: '', poolID: '', default: true });
+	let defaultsForm = $state({ cpu: 1, memory: 4, storage: 20, maxSandboxes: 10 });
+	const fastPollInterval = 2_000;
+	const slowPollInterval = 30_000;
+	let pollTimer: ReturnType<typeof setTimeout> | undefined;
+	let destroyed = false;
+
+	$effect(() => {
+		if (defaults) {
+			defaultsForm = {
+				cpu: defaults.capacity.cpuVcpus,
+				memory: toGiB(defaults.capacity.memoryBytes),
+				storage: toGiB(defaults.capacity.storageBytes),
+				maxSandboxes: defaults.maxSandboxes ?? 10
+			};
+		}
+	});
+
+	const toGiB = (bytes: number) => Math.round((bytes / 1024 ** 3) * 10) / 10;
+	const quantity = (cpu: number, memory: number, storage: number) => ({
+		cpuVcpus: Number(cpu),
+		memoryBytes: Math.round(Number(memory) * 1024 ** 3),
+		storageBytes: Math.round(Number(storage) * 1024 ** 3)
+	});
+	const formatQuantity = (q?: { cpuVcpus: number; memoryBytes: number; storageBytes: number }) =>
+		q
+			? `${q.cpuVcpus} vCPU · ${toGiB(q.memoryBytes)} GiB RAM · ${toGiB(q.storageBytes)} GiB disk`
+			: '—';
+
+	async function reload() {
+		[pools, assignments] = await Promise.all([
+			AdminService.listHostedAgentPools(),
+			AdminService.listHostedAgentPoolAssignments()
+		]);
+	}
+
+	onMount(async () => {
+		try {
+			users = await UserService.listUsers();
+		} catch {
+			// Names are a nicety; without them members still render by ID.
+		}
+	});
+
+	function hasTransitionalPools() {
+		return pools.some(
+			(pool) =>
+				Boolean(pool.deleted) ||
+				(!pool.status?.observedRevision && !pool.status?.ready && !pool.status?.degraded)
+		);
+	}
+
+	function scheduleRefresh(delay = hasTransitionalPools() ? fastPollInterval : slowPollInterval) {
+		clearTimeout(pollTimer);
+		if (destroyed) return;
+		pollTimer = setTimeout(poll, delay);
+	}
+
+	async function poll() {
+		if (document.visibilityState === 'hidden') {
+			scheduleRefresh(slowPollInterval);
+			return;
+		}
+		try {
+			await reload();
+			if (usagePool) {
+				usage = await AdminService.getHostedAgentPoolUtilization(usagePool.id);
+			}
+		} catch {
+			// Background status observation retries without producing recurring
+			// administrator notifications.
+		}
+		scheduleRefresh();
+	}
+
+	function openPool(value?: HostedAgentPool) {
+		editing = value;
+		form = value
+			? {
+					cpu: value.capacity.cpuVcpus,
+					memory: toGiB(value.capacity.memoryBytes),
+					storage: toGiB(value.capacity.storageBytes),
+					maxSandboxes: value.maxSandboxes ?? 10,
+					suspended: Boolean(value.suspended)
+				}
+			: { cpu: 1, memory: 4, storage: 20, maxSandboxes: 10, suspended: false };
+		poolDialog?.open();
+	}
+
+	async function savePool() {
+		saving = true;
+		try {
+			const manifest = {
+				capacity: quantity(form.cpu, form.memory, form.storage),
+				maxSandboxes: Number(form.maxSandboxes),
+				suspended: form.suspended
+			};
+			if (editing) await AdminService.updateHostedAgentPool(editing.id, manifest);
+			else await AdminService.createHostedAgentPool(manifest);
+			await reload();
+			scheduleRefresh();
+			poolDialog?.close();
+		} catch (error) {
+			errors.append(`Failed to save pool: ${error}`);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function saveDefaults() {
+		saving = true;
+		try {
+			const manifest = {
+				capacity: quantity(defaultsForm.cpu, defaultsForm.memory, defaultsForm.storage),
+				maxSandboxes: Number(defaultsForm.maxSandboxes)
+			};
+			defaults = defaults
+				? await AdminService.updateHostedAgentPoolDefaults(manifest)
+				: await AdminService.createHostedAgentPoolDefaults(manifest);
+		} catch (error) {
+			errors.append(`Failed to save pool defaults: ${error}`);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function saveAssignment() {
+		saving = true;
+		try {
+			await AdminService.createHostedAgentPoolAssignment(assignmentForm);
+			await reload();
+			scheduleRefresh();
+			assignmentDialog?.close();
+		} catch (error) {
+			errors.append(`Failed to assign pool: ${error}`);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function showUsage(pool: HostedAgentPool) {
+		usagePool = pool;
+		usage = undefined;
+		usageDialog?.open();
+		try {
+			usage = await AdminService.getHostedAgentPoolUtilization(pool.id);
+		} catch (error) {
+			errors.append(`Failed to load utilization: ${error}`);
+		}
+	}
+
+	onMount(() => {
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === 'visible') scheduleRefresh(0);
+			else scheduleRefresh(slowPollInterval);
+		};
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+		scheduleRefresh(0);
+		return () => {
+			destroyed = true;
+			clearTimeout(pollTimer);
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
+		};
+	});
+</script>
+
+<div class="flex flex-col gap-6">
+	<section class="dark:bg-surface2 border-surface3 rounded-lg border bg-white p-4 shadow-sm">
+		<!-- Four small numbers and a button on one row: they are read together and
+		     each is a couple of characters wide, so stacking them wasted the row. -->
+		<div class="flex flex-wrap items-end gap-x-4 gap-y-3">
+			<div class="mr-auto">
+				<h2 class="font-semibold">Deployment defaults</h2>
+				<p class="text-muted-content text-xs">Applied when a pool is created on demand.</p>
+			</div>
+			<label class="text-muted-content flex flex-col text-xs"
+				>vCPU<input
+					type="number"
+					min="0.1"
+					step="0.1"
+					class="text-input-filled mt-0.5 w-20"
+					disabled={readonly}
+					bind:value={defaultsForm.cpu}
+				/></label
+			>
+			<label class="text-muted-content flex flex-col text-xs"
+				>Memory (GiB)<input
+					type="number"
+					min="0.1"
+					step="0.1"
+					class="text-input-filled mt-0.5 w-20"
+					disabled={readonly}
+					bind:value={defaultsForm.memory}
+				/></label
+			>
+			<label class="text-muted-content flex flex-col text-xs"
+				>Storage (GiB)<input
+					type="number"
+					min="0.1"
+					step="0.1"
+					class="text-input-filled mt-0.5 w-20"
+					disabled={readonly}
+					bind:value={defaultsForm.storage}
+				/></label
+			>
+			<label class="text-muted-content flex flex-col text-xs"
+				>Max sandboxes<input
+					type="number"
+					min="1"
+					step="1"
+					class="text-input-filled mt-0.5 w-20"
+					disabled={readonly}
+					bind:value={defaultsForm.maxSandboxes}
+				/></label
+			>
+			{#if !readonly}
+				<button
+					class="btn btn-primary text-sm"
+					disabled={saving || !defaultsForm.cpu || !defaultsForm.memory || !defaultsForm.storage}
+					onclick={saveDefaults}>Save</button
+				>
+			{/if}
+		</div>
+	</section>
+
+	<section>
+		<div class="mb-3 flex items-center justify-between">
+			<div>
+				<h2 class="font-semibold">Pools</h2>
+				<p class="text-muted-content text-sm">
+					Shared CPU, memory and disk. Every member's sandboxes draw from the same pool.
+				</p>
+			</div>
+			<div class="flex gap-2">
+				{#if !readonly}
+					<button class="btn btn-secondary text-sm" onclick={() => assignmentDialog?.open()}
+						><Plus class="size-4" /> Assign user</button
+					>
+					<button class="btn btn-primary text-sm" onclick={() => openPool()}
+						><Plus class="size-4" /> Add pool</button
+					>
+				{/if}
+			</div>
+		</div>
+		<div class="grid gap-3">
+			{#each pools as pool (pool.id)}
+				{@const members = membersOf(pool.id)}
+				<div class="dark:bg-surface2 border-surface3 rounded-lg border bg-white p-4 shadow-sm">
+					<div class="flex justify-between gap-4">
+						<div class="min-w-0">
+							<div class="flex flex-wrap items-center gap-2">
+								<!-- A pool is recognised by who is in it, not by its identifier. -->
+								<span class="font-medium">
+									{#if members.length === 1}
+										{userLabel(members[0].userID)}
+									{:else if members.length > 1}
+										{userLabel(members[0].userID)} +{members.length - 1}
+									{:else}
+										Unassigned pool
+									{/if}
+								</span>
+								<span
+									class="badge badge-sm {pool.suspended
+										? 'badge-warning'
+										: pool.status?.ready
+											? 'badge-success'
+											: 'badge-secondary'}"
+									>{pool.suspended ? 'Suspended' : pool.status?.ready ? 'Ready' : 'Pending'}</span
+								>
+							</div>
+							<p class="text-muted-content mt-1 text-sm">
+								{formatQuantity(pool.capacity)} · up to {pool.maxSandboxes ?? 10} sandboxes
+							</p>
+							{#if pool.status?.message}<p class="text-warning mt-1 text-xs">
+									{pool.status.message}
+								</p>{/if}
+							<p class="text-muted-content mt-1 font-mono text-xs opacity-60">{pool.id}</p>
+						</div>
+						<div class="flex shrink-0">
+							<button class="btn btn-ghost btn-sm" onclick={() => showUsage(pool)}
+								><Activity class="size-4" /> Usage</button
+							>
+							{#if !readonly}
+								<button
+									class="btn btn-ghost btn-sm"
+									aria-label="Edit pool"
+									onclick={() => openPool(pool)}><Pencil class="size-4" /></button
+								>
+								<button
+									class="btn btn-ghost btn-sm text-error"
+									aria-label="Delete pool"
+									onclick={() => (deleting = pool)}><Trash2 class="size-4" /></button
+								>
+							{/if}
+						</div>
+					</div>
+
+					<!-- Members inline, so a pool and its people are one thing rather than
+					     two lists cross-referenced by ID. -->
+					<div class="border-surface3 mt-3 flex flex-wrap items-center gap-2 border-t pt-3">
+						{#each members as member (member.id)}
+							<span
+								class="border-surface3 flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
+							>
+								{userLabel(member.userID)}
+								{#if member.default}<span class="text-muted-content">· default</span>{/if}
+								{#if !readonly}
+									<button
+										class="text-muted-content hover:text-error"
+										aria-label="Remove {userLabel(member.userID)} from pool"
+										onclick={() => (deletingAssignment = member)}><Trash2 class="size-3" /></button
+									>
+								{/if}
+							</span>
+						{:else}
+							<span class="text-muted-content text-xs">No users assigned.</span>
+						{/each}
+					</div>
+				</div>
+			{:else}
+				<p class="text-muted-content py-6 text-center text-sm">No pools yet.</p>
+			{/each}
+		</div>
+	</section>
+</div>
+
+<ResponsiveDialog
+	bind:this={poolDialog}
+	title={editing ? 'Edit pool' : 'Add pool'}
+	class="md:max-w-md"
+>
+	<div class="grid gap-3">
+		<label class="text-sm"
+			>vCPU<input
+				type="number"
+				min="0.1"
+				step="0.1"
+				class="text-input-filled mt-1"
+				bind:value={form.cpu}
+			/></label
+		>
+		<label class="text-sm"
+			>Memory (GiB)<input
+				type="number"
+				min="0.1"
+				step="0.1"
+				class="text-input-filled mt-1"
+				bind:value={form.memory}
+			/></label
+		>
+		<label class="text-sm"
+			>Storage (GiB)<input
+				type="number"
+				min="0.1"
+				step="0.1"
+				class="text-input-filled mt-1"
+				bind:value={form.storage}
+			/></label
+		>
+		<label class="text-sm"
+			>Max sandboxes<input
+				type="number"
+				min="1"
+				step="1"
+				class="text-input-filled mt-1"
+				bind:value={form.maxSandboxes}
+			/><span class="text-muted-content mt-1 block text-xs">
+				Sandboxes share this pool. Each is guaranteed capacity ÷ this number and may burst to the
+				whole pool, so a higher number means smaller guaranteed shares.
+			</span></label
+		>
+		<label class="flex items-center gap-2 text-sm"
+			><input type="checkbox" bind:checked={form.suspended} /> Suspend new starts</label
+		>
+		<button
+			class="btn btn-primary mt-2"
+			disabled={saving || !form.cpu || !form.memory || !form.storage}
+			onclick={savePool}
+			>{#if saving}<Loading class="size-4" />{:else}Save{/if}</button
+		>
+	</div>
+</ResponsiveDialog>
+
+<ResponsiveDialog bind:this={assignmentDialog} title="Assign pool" class="md:max-w-md">
+	<div class="grid gap-3">
+		<label class="text-sm"
+			>User ID<input class="text-input-filled mt-1" bind:value={assignmentForm.userID} /></label
+		>
+		<label class="text-sm"
+			>Pool<select class="text-input-filled mt-1" bind:value={assignmentForm.poolID}
+				><option value="">Select a pool</option>{#each pools as pool (pool.id)}<option
+						value={pool.id}>{pool.id}</option
+					>{/each}</select
+			></label
+		>
+		<label class="flex items-center gap-2 text-sm"
+			><input type="checkbox" bind:checked={assignmentForm.default} /> Default pool</label
+		>
+		<button
+			class="btn btn-primary"
+			disabled={saving || !assignmentForm.userID || !assignmentForm.poolID}
+			onclick={saveAssignment}>Assign</button
+		>
+	</div>
+</ResponsiveDialog>
+
+<ResponsiveDialog bind:this={usageDialog} title="Live utilization" class="md:max-w-lg">
+	{#if !usage}<div class="flex justify-center p-8"><Loading class="size-6" /></div>
+	{:else}
+		<div class="grid gap-3">
+			<p class="text-sm">
+				<strong>{usagePool?.id}</strong> · snapshot {new Date(usage.timestamp).toLocaleString()}
+			</p>
+			<p class="text-sm">Used: {formatQuantity(usage.pool)}</p>
+			<p class="text-muted-content text-xs">
+				Pressure: CPU {usage.pressure.cpu ?? 'unknown'} · memory {usage.pressure.memory ??
+					'unknown'} · storage {usage.pressure.storage ?? 'unknown'}
+			</p>
+			<p class="text-muted-content text-xs">
+				Totals cover every member of this pool. Disk is not reported per instance, because members
+				share one volume.
+			</p>
+			{#each usage.instances as instance (instance.instanceID)}<div
+					class="border-surface3 rounded border p-2 text-xs"
+				>
+					{instance.instanceID} · {instance.state ?? 'unknown'} · {formatQuantity(instance.usage)}
+				</div>{/each}
+		</div>
+	{/if}
+</ResponsiveDialog>
+
+{#if deleting}
+	<Confirm
+		msg="Delete this pool? Deletion completes only after the backend resources are gone."
+		show
+		onsuccess={async () => {
+			await AdminService.deleteHostedAgentPool(deleting!.id);
+			deleting = undefined;
+			await reload();
+			scheduleRefresh();
+		}}
+		oncancel={() => (deleting = undefined)}
+	/>
+{/if}
+{#if deletingAssignment}
+	<Confirm
+		msg="Remove this assignment? The user will no longer be able to select the pool."
+		show
+		onsuccess={async () => {
+			await AdminService.deleteHostedAgentPoolAssignment(deletingAssignment!.id);
+			deletingAssignment = undefined;
+			await reload();
+			scheduleRefresh();
+		}}
+		oncancel={() => (deletingAssignment = undefined)}
+	/>
+{/if}

--- a/ui/user/src/lib/components/admin/HostedAgentQuestionsEditor.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentQuestionsEditor.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+	import type { HostedAgentQuestion, HostedAgentQuestionType } from '$lib/services/admin/types';
+	import IconButton from '../primitives/IconButton.svelte';
+	import { Plus, Trash2 } from '@lucide/svelte';
+
+	interface Props {
+		questions: HostedAgentQuestion[];
+		readonly?: boolean;
+	}
+
+	let { questions = $bindable([]), readonly }: Props = $props();
+
+	const TYPES: { value: HostedAgentQuestionType; label: string; hint: string }[] = [
+		{ value: 'string', label: 'Text', hint: '' },
+		{ value: 'number', label: 'Number', hint: '' },
+		{ value: 'boolean', label: 'Yes / No', hint: 'true or false' },
+		{ value: 'select', label: 'Choice', hint: 'One of the options below' },
+		{ value: 'schedule', label: 'Schedule', hint: 'Cron expression, e.g. 0 3 * * *' }
+	];
+
+	function addQuestion() {
+		questions = [
+			...questions,
+			{ key: '', name: '', description: '', type: 'string', required: false, default: '' }
+		];
+	}
+
+	function removeQuestion(index: number) {
+		questions = questions.filter((_, i) => i !== index);
+	}
+
+	// Options are only meaningful for a choice, and the API rejects them on any
+	// other type, so drop them when the type changes away from select.
+	function onTypeChange(index: number, type: HostedAgentQuestionType) {
+		questions[index].type = type;
+		if (type !== 'select') {
+			questions[index].options = undefined;
+		} else if (!questions[index].options) {
+			questions[index].options = [''];
+		}
+		questions[index].default = '';
+	}
+
+	function addOption(index: number) {
+		questions[index].options = [...(questions[index].options ?? []), ''];
+	}
+
+	function removeOption(qIndex: number, oIndex: number) {
+		questions[qIndex].options = (questions[qIndex].options ?? []).filter((_, i) => i !== oIndex);
+	}
+
+	function typeHint(type: HostedAgentQuestionType | undefined) {
+		return TYPES.find((t) => t.value === (type ?? 'string'))?.hint ?? '';
+	}
+</script>
+
+<div class="flex flex-col gap-2">
+	<div class="mb-2 flex items-center justify-between">
+		<div class="flex flex-col">
+			<h2 class="text-lg font-semibold">Questions</h2>
+			<span class="text-muted-content text-xs">
+				Asked when a user creates an instance of this agent.
+			</span>
+		</div>
+		{#if !readonly}
+			<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={addQuestion}>
+				<Plus class="size-4" /> Add Question
+			</button>
+		{/if}
+	</div>
+
+	{#if questions.length === 0}
+		<p class="text-muted-content py-4 text-center text-sm">No questions added.</p>
+	{:else}
+		<div class="flex flex-col gap-3">
+			{#each questions as question, i (i)}
+				<div
+					class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-3 rounded-lg border border-transparent p-4"
+				>
+					<div class="flex items-end gap-3">
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="q-key-{i}" class="text-sm font-light">Key</label>
+							<input
+								id="q-key-{i}"
+								bind:value={question.key}
+								class="text-input-filled"
+								placeholder="schedule"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="q-name-{i}" class="text-sm font-light">Label</label>
+							<input
+								id="q-name-{i}"
+								bind:value={question.name}
+								class="text-input-filled"
+								placeholder="Schedule"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex flex-col gap-2">
+							<label for="q-type-{i}" class="text-sm font-light">Type</label>
+							<select
+								id="q-type-{i}"
+								class="text-input-filled"
+								value={question.type ?? 'string'}
+								onchange={(e) => onTypeChange(i, e.currentTarget.value as HostedAgentQuestionType)}
+								disabled={readonly}
+							>
+								{#each TYPES as t (t.value)}
+									<option value={t.value}>{t.label}</option>
+								{/each}
+							</select>
+						</div>
+						{#if !readonly}
+							<IconButton
+								variant="danger"
+								onclick={() => removeQuestion(i)}
+								tooltip={{ text: 'Remove Question' }}
+							>
+								<Trash2 class="size-4" />
+							</IconButton>
+						{/if}
+					</div>
+
+					<div class="flex items-end gap-3">
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="q-desc-{i}" class="text-sm font-light">Description</label>
+							<input
+								id="q-desc-{i}"
+								bind:value={question.description}
+								class="text-input-filled"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="q-default-{i}" class="text-sm font-light">Default</label>
+							{#if question.type === 'select'}
+								<select
+									id="q-default-{i}"
+									class="text-input-filled"
+									bind:value={question.default}
+									disabled={readonly}
+								>
+									<option value="">(none)</option>
+									{#each (question.options ?? []).filter((o) => o) as option (option)}
+										<option value={option}>{option}</option>
+									{/each}
+								</select>
+							{:else if question.type === 'boolean'}
+								<select
+									id="q-default-{i}"
+									class="text-input-filled"
+									bind:value={question.default}
+									disabled={readonly}
+								>
+									<option value="">(none)</option>
+									<option value="true">true</option>
+									<option value="false">false</option>
+								</select>
+							{:else}
+								<input
+									id="q-default-{i}"
+									bind:value={question.default}
+									class="text-input-filled"
+									placeholder={question.type === 'schedule' ? '0 3 * * *' : ''}
+									disabled={readonly}
+								/>
+							{/if}
+						</div>
+						<div class="flex items-center gap-4 pb-2">
+							<label class="flex items-center gap-2 text-sm font-light">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm"
+									bind:checked={question.required}
+									disabled={readonly}
+								/>
+								Required
+							</label>
+							<label class="flex items-center gap-2 text-sm font-light">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm"
+									bind:checked={question.sensitive}
+									disabled={readonly}
+								/>
+								Sensitive
+							</label>
+						</div>
+					</div>
+
+					{#if typeHint(question.type)}
+						<span class="text-muted-content text-xs">{typeHint(question.type)}</span>
+					{/if}
+
+					{#if question.type === 'select'}
+						<div class="flex flex-col gap-2">
+							<div class="flex items-center justify-between">
+								<span class="text-sm font-light">Options</span>
+								{#if !readonly}
+									<button
+										class="btn btn-secondary flex items-center gap-1 text-xs"
+										onclick={() => addOption(i)}
+									>
+										<Plus class="size-3" /> Add Option
+									</button>
+								{/if}
+							</div>
+							{#each question.options ?? [] as _, oi (oi)}
+								<div class="flex items-center gap-2">
+									<input
+										bind:value={question.options![oi]}
+										class="text-input-filled grow"
+										placeholder="Option value"
+										disabled={readonly}
+										aria-label="Option {oi + 1}"
+									/>
+									{#if !readonly}
+										<IconButton
+											variant="danger"
+											onclick={() => removeOption(i, oi)}
+											tooltip={{ text: 'Remove Option' }}
+										>
+											<Trash2 class="size-4" />
+										</IconButton>
+									{/if}
+								</div>
+							{/each}
+							{#if (question.options ?? []).length === 0}
+								<p class="text-muted-content text-xs">A choice needs at least one option.</p>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/ui/user/src/lib/components/admin/SearchHostedAgents.svelte
+++ b/ui/user/src/lib/components/admin/SearchHostedAgents.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import type { HostedAgent, HostedAgentAccessPolicyResource } from '$lib/services/admin/types';
+	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import Search from '../Search.svelte';
+	import { Bot, Check } from '@lucide/svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	interface Props {
+		hostedAgents: HostedAgent[];
+		onAdd: (resources: HostedAgentAccessPolicyResource[]) => void;
+		exclude?: string[];
+		title?: string;
+		wildcardAvailable?: boolean;
+	}
+
+	let {
+		hostedAgents,
+		onAdd,
+		exclude = [],
+		title = 'Add Templates',
+		wildcardAvailable = true
+	}: Props = $props();
+
+	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let query = $state('');
+	let selected = $state<HostedAgentAccessPolicyResource[]>([]);
+	let selectedSet = $derived(new Set(selected.map((item) => item.id)));
+
+	const filteredAgents = $derived.by(() => {
+		const items = hostedAgents.filter((agent) => !exclude.includes(agent.id));
+		return query
+			? items.filter(
+					(agent) =>
+						agent.name?.toLowerCase().includes(query.toLowerCase()) ||
+						agent.description?.toLowerCase().includes(query.toLowerCase())
+				)
+			: items;
+	});
+
+	function toggleSelection(item: HostedAgentAccessPolicyResource) {
+		if (selectedSet.has(item.id)) {
+			selected = selected.filter((existing) => existing.id !== item.id);
+		} else {
+			selected = [...selected, item];
+		}
+	}
+
+	function handleAdd() {
+		onAdd(selected);
+		dialog?.close();
+	}
+
+	export function open() {
+		selected = [];
+		query = '';
+		dialog?.open();
+	}
+
+	export function close() {
+		dialog?.close();
+	}
+</script>
+
+<ResponsiveDialog
+	bind:this={dialog}
+	{title}
+	class="h-full w-full overflow-visible md:h-[500px] md:max-w-md"
+	classes={{ header: 'p-4 md:pb-0', content: 'min-h-inherit p-0' }}
+>
+	<div class="default-scrollbar-thin flex grow flex-col gap-4 overflow-y-auto pt-1">
+		<div class="flex flex-col gap-2">
+			<div class="px-4">
+				<Search
+					class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
+					onChange={(val) => (query = val)}
+					value={query}
+					placeholder="Search templates..."
+				/>
+			</div>
+
+			<div class="flex flex-col">
+				{#if wildcardAvailable && !exclude?.includes('*')}
+					<button
+						class={twMerge(
+							'hover:bg-base-300 dark:hover:bg-base-200 flex items-center justify-between gap-4 px-4 py-3 text-left',
+							selectedSet.has('*') && 'bg-base-200/50'
+						)}
+						onclick={() => toggleSelection({ type: 'selector', id: '*' })}
+					>
+						<div class="flex items-center gap-2">
+							<div class="flex flex-col">
+								<p class="font-medium">All Templates</p>
+								<span class="text-muted-content text-xs">
+									Grants access to all current and future templates
+								</span>
+							</div>
+						</div>
+						<div class="flex size-6 items-center justify-center">
+							{#if selectedSet.has('*')}
+								<Check class="text-primary size-6" />
+							{/if}
+						</div>
+					</button>
+				{/if}
+
+				{#each filteredAgents as agent (agent.id)}
+					<button
+						class={twMerge(
+							'hover:bg-base-300 dark:hover:bg-base-200 flex items-center justify-between gap-4 px-4 py-3 text-left',
+							selectedSet.has(agent.id) && 'bg-base-200/50'
+						)}
+						onclick={() => toggleSelection({ type: 'hostedAgent', id: agent.id })}
+					>
+						<div class="flex items-center gap-2">
+							<div class="flex flex-col">
+								<p class="font-medium">{agent.name}</p>
+								<span class="text-muted-content line-clamp-1 text-xs">
+									{agent.description || agent.id}
+								</span>
+							</div>
+						</div>
+						<div class="flex size-6 items-center justify-center">
+							{#if selectedSet.has(agent.id)}
+								<Check class="text-primary size-6" />
+							{/if}
+						</div>
+					</button>
+				{/each}
+			</div>
+		</div>
+	</div>
+	<div class="flex w-full flex-col justify-between gap-4 p-4 md:flex-row">
+		<div class="flex items-center gap-1 font-light">
+			{#if selected.length > 0}
+				<Bot class="size-4" />
+				{selected.length} Selected
+			{/if}
+		</div>
+		<div class="flex items-center gap-2">
+			<button class="btn btn-secondary w-full md:w-fit" onclick={() => dialog?.close()}>
+				Cancel
+			</button>
+			<button class="btn btn-primary w-full md:w-fit" onclick={handleAdd}> Confirm </button>
+		</div>
+	</div>
+</ResponsiveDialog>

--- a/ui/user/src/lib/components/hosted-agents/AgentIcon.svelte
+++ b/ui/user/src/lib/components/hosted-agents/AgentIcon.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { darkMode } from '$lib/stores';
+	import { Bot } from '@lucide/svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	interface Props {
+		icon?: string;
+		iconDark?: string;
+		alt?: string;
+		class?: string;
+	}
+
+	let { icon, iconDark, alt = '', class: klass }: Props = $props();
+
+	// A dark variant is optional at every level, so fall back rather than
+	// rendering nothing on a dark page.
+	let src = $derived(darkMode.isDark ? iconDark || icon : icon);
+</script>
+
+{#if src}
+	<img {src} {alt} class={twMerge('size-5 shrink-0 rounded-sm object-contain', klass)} />
+{:else}
+	<!-- A placeholder rather than a gap: rows stay aligned whether or not a
+	     template declares an icon. -->
+	<Bot class={twMerge('text-muted-content size-5 shrink-0 opacity-40', klass)} />
+{/if}

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -11,6 +11,7 @@ import {
 	doPut,
 	handleResponse,
 	type Fetcher,
+	type ErrorHandler,
 	type PaginatedResponse
 } from '../http';
 import { AUDIT_LOG_FILTER_OPTIONS_LIMIT } from '../user/constants';
@@ -75,6 +76,22 @@ import type {
 	SkillRepositoryManifest,
 	SkillAccessPolicy,
 	SkillAccessPolicyManifest,
+	AgentCatalog,
+	AgentCatalogManifest,
+	Harness,
+	HarnessManifest,
+	HostedAgent,
+	HostedAgentManifest,
+	HostedAgentPool,
+	HostedAgentPoolManifest,
+	HostedAgentPoolDefaults,
+	HostedAgentPoolAssignment,
+	HostedAgentPoolAssignmentManifest,
+	HostedAgentPoolUtilization,
+	HostedAgentInstance,
+	HostedAgentInstanceManifest,
+	HostedAgentAccessPolicy,
+	HostedAgentAccessPolicyManifest,
 	MessagePolicy,
 	MessagePolicyManifest,
 	MessagePolicyViolation,
@@ -1760,6 +1777,312 @@ export async function deleteSkillAccessPolicy(
 	opts?: { signal?: AbortSignal }
 ): Promise<void> {
 	await doDelete(`/skill-access-rules/${id}`, opts);
+}
+
+// Agent sources
+
+export async function listAgentCatalogs(opts?: { fetch?: Fetcher }): Promise<AgentCatalog[]> {
+	const response = (await doGet('/agent-catalogs', opts)) as ItemsResponse<AgentCatalog>;
+	return response.items ?? [];
+}
+
+export async function getAgentCatalog(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<AgentCatalog> {
+	return (await doGet(`/agent-catalogs/${id}`, opts)) as AgentCatalog;
+}
+
+export async function createAgentCatalog(
+	request: AgentCatalogManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<AgentCatalog> {
+	return (await doPost('/agent-catalogs', request, opts)) as AgentCatalog;
+}
+
+export async function updateAgentCatalog(
+	id: string,
+	request: AgentCatalogManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<AgentCatalog> {
+	return (await doPut(`/agent-catalogs/${id}`, request, opts)) as AgentCatalog;
+}
+
+export async function deleteAgentCatalog(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/agent-catalogs/${id}`, opts);
+}
+
+// refreshAgentCatalog asks the controller to sync now; poll getAgentCatalog until
+// isSyncing clears to see the result.
+export async function refreshAgentCatalog(id: string, opts?: { fetch?: Fetcher }): Promise<void> {
+	await doPost(`/agent-catalogs/${id}/refresh`, {}, opts);
+}
+
+// Harnesses
+
+export async function listHarnesses(opts?: { fetch?: Fetcher }): Promise<Harness[]> {
+	const response = (await doGet('/harnesses', opts)) as ItemsResponse<Harness>;
+	return response.items ?? [];
+}
+
+export async function getHarness(id: string, opts?: { fetch?: Fetcher }): Promise<Harness> {
+	return (await doGet(`/harnesses/${id}`, opts)) as Harness;
+}
+
+export async function createHarness(
+	request: HarnessManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<Harness> {
+	return (await doPost('/harnesses', request, opts)) as Harness;
+}
+
+export async function updateHarness(
+	id: string,
+	request: HarnessManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<Harness> {
+	return (await doPut(`/harnesses/${id}`, request, opts)) as Harness;
+}
+
+export async function deleteHarness(id: string, opts?: { signal?: AbortSignal }): Promise<void> {
+	await doDelete(`/harnesses/${id}`, opts);
+}
+
+// Hosted agents
+
+// Pass all: true as an admin to bypass access-policy filtering.
+export async function listHostedAgents(opts?: {
+	fetch?: Fetcher;
+	all?: boolean;
+}): Promise<HostedAgent[]> {
+	const url = opts?.all ? '/hosted-agents?all=true' : '/hosted-agents';
+	const response = (await doGet(url, opts)) as ItemsResponse<HostedAgent>;
+	return response.items ?? [];
+}
+
+export async function getHostedAgent(id: string, opts?: { fetch?: Fetcher }): Promise<HostedAgent> {
+	return (await doGet(`/hosted-agents/${id}`, opts)) as HostedAgent;
+}
+
+export async function createHostedAgent(
+	request: HostedAgentManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgent> {
+	return (await doPost('/hosted-agents', request, opts)) as HostedAgent;
+}
+
+export async function updateHostedAgent(
+	id: string,
+	request: HostedAgentManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgent> {
+	return (await doPut(`/hosted-agents/${id}`, request, opts)) as HostedAgent;
+}
+
+export async function deleteHostedAgent(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agents/${id}`, opts);
+}
+
+// Hosted agent pools
+
+export async function listHostedAgentPools(opts?: { fetch?: Fetcher }): Promise<HostedAgentPool[]> {
+	const response = (await doGet('/hosted-agent-pools', opts)) as ItemsResponse<HostedAgentPool>;
+	return response.items ?? [];
+}
+
+export async function createHostedAgentPool(
+	request: HostedAgentPoolManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPool> {
+	return (await doPost('/hosted-agent-pools', request, opts)) as HostedAgentPool;
+}
+
+export async function updateHostedAgentPool(
+	id: string,
+	request: HostedAgentPoolManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPool> {
+	return (await doPut(`/hosted-agent-pools/${id}`, request, opts)) as HostedAgentPool;
+}
+
+export async function deleteHostedAgentPool(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agent-pools/${id}`, opts);
+}
+
+export async function getHostedAgentPoolUtilization(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolUtilization> {
+	return (await doGet(`/hosted-agent-pools/${id}/utilization`, opts)) as HostedAgentPoolUtilization;
+}
+
+export async function getHostedAgentPoolDefaults(opts?: {
+	fetch?: Fetcher;
+}): Promise<HostedAgentPoolDefaults> {
+	return (await doGet('/hosted-agent-pool-defaults', opts)) as HostedAgentPoolDefaults;
+}
+
+export async function createHostedAgentPoolDefaults(
+	request: HostedAgentPoolManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolDefaults> {
+	return (await doPost('/hosted-agent-pool-defaults', request, opts)) as HostedAgentPoolDefaults;
+}
+
+export async function updateHostedAgentPoolDefaults(
+	request: HostedAgentPoolManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolDefaults> {
+	return (await doPut('/hosted-agent-pool-defaults', request, opts)) as HostedAgentPoolDefaults;
+}
+
+export async function listHostedAgentPoolAssignments(opts?: {
+	fetch?: Fetcher;
+}): Promise<HostedAgentPoolAssignment[]> {
+	const response = (await doGet(
+		'/hosted-agent-pool-assignments',
+		opts
+	)) as ItemsResponse<HostedAgentPoolAssignment>;
+	return response.items ?? [];
+}
+
+export async function createHostedAgentPoolAssignment(
+	request: HostedAgentPoolAssignmentManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolAssignment> {
+	return (await doPost(
+		'/hosted-agent-pool-assignments',
+		request,
+		opts
+	)) as HostedAgentPoolAssignment;
+}
+
+export async function updateHostedAgentPoolAssignment(
+	id: string,
+	request: HostedAgentPoolAssignmentManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolAssignment> {
+	return (await doPut(
+		`/hosted-agent-pool-assignments/${id}`,
+		request,
+		opts
+	)) as HostedAgentPoolAssignment;
+}
+
+export async function deleteHostedAgentPoolAssignment(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agent-pool-assignments/${id}`, opts);
+}
+
+// revealHostedAgent returns the values of env vars marked sensitive, which are
+// never included in the agent itself.
+export async function revealHostedAgent(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<Record<string, string>> {
+	return (await doPost(`/hosted-agents/${id}/reveal`, {}, opts)) as Record<string, string>;
+}
+
+// Hosted agent instances
+
+export async function listHostedAgentInstances(
+	hostedAgentID?: string,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentInstance[]> {
+	const queryString = hostedAgentID ? buildQueryString({ hosted_agent_id: hostedAgentID }) : '';
+	const response = (await doGet(
+		`/hosted-agent-instances${queryString ? `?${queryString}` : ''}`,
+		opts
+	)) as ItemsResponse<HostedAgentInstance>;
+	return response.items ?? [];
+}
+
+export async function getHostedAgentInstance(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentInstance> {
+	return (await doGet(`/hosted-agent-instances/${id}`, opts)) as HostedAgentInstance;
+}
+
+export async function createHostedAgentInstance(
+	request: HostedAgentInstanceManifest & { hostedAgentID: string; poolID?: string },
+	opts?: { fetch?: Fetcher; errorHandler?: ErrorHandler }
+): Promise<HostedAgentInstance> {
+	return (await doPost('/hosted-agent-instances', request, opts)) as HostedAgentInstance;
+}
+
+export async function updateHostedAgentInstance(
+	id: string,
+	request: HostedAgentInstanceManifest,
+	opts?: { fetch?: Fetcher; errorHandler?: ErrorHandler }
+): Promise<HostedAgentInstance> {
+	return (await doPut(`/hosted-agent-instances/${id}`, request, opts)) as HostedAgentInstance;
+}
+
+export async function deleteHostedAgentInstance(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agent-instances/${id}`, opts);
+}
+
+// Hosted agent access policies
+//
+// The UI calls these "Access Policies"; the API resource is
+// hosted-agent-access-rules. This mirrors the skill access policy naming.
+
+export async function listHostedAgentAccessPolicies(opts?: {
+	fetch?: Fetcher;
+}): Promise<HostedAgentAccessPolicy[]> {
+	const response = (await doGet(
+		'/hosted-agent-access-rules',
+		opts
+	)) as ItemsResponse<HostedAgentAccessPolicy>;
+	return response.items ?? [];
+}
+
+export async function getHostedAgentAccessPolicy(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentAccessPolicy> {
+	return (await doGet(`/hosted-agent-access-rules/${id}`, opts)) as HostedAgentAccessPolicy;
+}
+
+export async function createHostedAgentAccessPolicy(
+	request: HostedAgentAccessPolicyManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentAccessPolicy> {
+	return (await doPost('/hosted-agent-access-rules', request, opts)) as HostedAgentAccessPolicy;
+}
+
+export async function updateHostedAgentAccessPolicy(
+	id: string,
+	request: HostedAgentAccessPolicyManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentAccessPolicy> {
+	return (await doPut(
+		`/hosted-agent-access-rules/${id}`,
+		request,
+		opts
+	)) as HostedAgentAccessPolicy;
+}
+
+export async function deleteHostedAgentAccessPolicy(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agent-access-rules/${id}`, opts);
 }
 
 // Storage credentials

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -1133,6 +1133,254 @@ export interface SkillAccessPolicyManifest {
 	resources: SkillAccessPolicyResource[];
 }
 
+// Agent sources
+
+export interface AgentCatalogManifest {
+	displayName: string;
+	repoURL: string;
+	ref?: string;
+}
+
+export interface AgentCatalog extends AgentCatalogManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+	lastSyncTime?: string;
+	isSyncing?: boolean;
+	syncError?: string;
+	resolvedCommitSHA?: string;
+	discoveredAgentCount: number;
+	discoveredHarnessCount: number;
+}
+
+// Harnesses — the runtimes hosted agents are built on (e.g. "Claude Code",
+// "Codex", "Custom Python"). The harness supplies the docker image; the agent
+// supplies configuration.
+
+export interface HarnessManifest {
+	name: string;
+	description?: string;
+	icon?: string;
+	iconDark?: string;
+	image: string;
+}
+
+export interface Harness extends HarnessManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+}
+
+// Hosted agents
+
+export type HostedAgentState = 'pending' | 'ready' | 'error' | 'removing';
+
+// Agents are templates and carry no status; only instances run.
+export interface HostedAgentInstanceStatus {
+	state?: HostedAgentState;
+	url?: string;
+	error?: string;
+	reason?: string;
+	message?: string;
+	observedRevision?: string;
+	lastObservedTime?: string;
+	backendID?: string;
+	backendGeneration?: string;
+}
+
+export interface HostedAgentEnv {
+	name?: string;
+	description?: string;
+	key: string;
+	value?: string;
+	sensitive?: boolean;
+	required?: boolean;
+}
+
+export type HostedAgentQuestionType = 'string' | 'number' | 'boolean' | 'select' | 'schedule';
+
+export interface HostedAgentQuestion {
+	key: string;
+	name?: string;
+	description?: string;
+	type?: HostedAgentQuestionType;
+	required?: boolean;
+	sensitive?: boolean;
+	default?: string;
+	// Only valid for type 'select'.
+	options?: string[];
+}
+
+export interface HostedAgentManifest {
+	name: string;
+	description?: string;
+	icon?: string;
+	iconDark?: string;
+	// The Harness this agent runs on; the harness supplies the docker image.
+	harnessID: string;
+	// Optional git repository made available to the agent.
+	gitRepo?: string;
+	// Branch, tag or commit SHA. Blank checks out the default branch.
+	gitRef?: string;
+	modelProviders?: string[];
+	// Model IDs, obot://<alias> references, or wildcard prefixes.
+	models?: string[];
+	// MCP gateway IDs — the same handles used by /mcp-connect/{mcp_id}.
+	mcpServers?: string[];
+	skills?: string[];
+	env?: HostedAgentEnv[];
+	questions?: HostedAgentQuestion[];
+	allowUserMCPServers?: boolean;
+	allowUserSkills?: boolean;
+	allowUserModels?: boolean;
+	// Lets a user set their own git repository on an instance, overriding the
+	// agent's gitRepo if one is configured.
+	allowUserGitRepo?: boolean;
+	maxInstancesPerUser?: number;
+	// The HTTP port the agent serves on inside its sandbox. When set, instances
+	// are reachable at /agent-connect/{instance id}.
+	port?: number;
+	// Offers an interactive shell attached to the sandbox. Requires an
+	// interactive harness, since without a TTY there is no session to attach to.
+	terminal?: boolean;
+}
+
+export interface HostedAgent extends HostedAgentManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+	// Why this agent cannot be launched on this installation — a model its
+	// harness can use is not configured, or an MCP server it names is missing.
+	// Empty or absent means it can be launched.
+	unavailableReasons?: string[];
+}
+
+export interface HostedAgentInstanceManifest {
+	name: string;
+	description?: string;
+	icon?: string;
+	// Answers to the agent's questions, keyed by question key. Values are strings
+	// regardless of the question's type.
+	answers?: Record<string, string>;
+	// Git repository the user supplied; only accepted when the agent sets
+	// allowUserGitRepo.
+	gitRepo?: string;
+	// Branch, tag or commit for gitRepo. It belongs to the repository beside it:
+	// the agent's ref is not applied to a repository the user supplied.
+	gitRef?: string;
+	// Resources the user attached themselves; only accepted when the agent's
+	// corresponding allowUser* flag is set.
+	mcpServers?: string[];
+	skills?: string[];
+	models?: string[];
+}
+
+export interface HostedAgentInstance extends HostedAgentInstanceManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+	hostedAgentID: string;
+	userID?: string;
+	poolID?: string;
+	// The icon to show, already resolved by the server through instance ->
+	// agent -> harness, so a client renders a row from this payload alone.
+	resolvedIcon?: string;
+	resolvedIconDark?: string;
+	status?: HostedAgentInstanceStatus;
+}
+
+export interface HostedAgentResourceQuantity {
+	cpuVcpus: number;
+	memoryBytes: number;
+	storageBytes: number;
+}
+
+export interface HostedAgentPoolManifest {
+	// How many sandboxes share this pool. Each reserves capacity/maxSandboxes
+	// and may burst to the whole pool, so raising it shrinks everyone's share.
+	maxSandboxes?: number;
+	capacity: HostedAgentResourceQuantity;
+	suspended?: boolean;
+}
+
+export interface HostedAgentPoolStatus {
+	backendProjectID?: string;
+	backendPoolID?: string;
+	ready?: boolean;
+	schedulable?: boolean;
+	degraded?: boolean;
+	capacity?: HostedAgentResourceQuantity;
+	observedRevision?: string;
+	reason?: string;
+	message?: string;
+}
+
+export interface HostedAgentPool extends HostedAgentPoolManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+	status?: HostedAgentPoolStatus;
+}
+
+export interface HostedAgentPoolDefaults extends HostedAgentPoolManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+}
+
+export interface HostedAgentPoolAssignmentManifest {
+	userID: string;
+	poolID: string;
+	default?: boolean;
+}
+
+export interface HostedAgentPoolAssignment extends HostedAgentPoolAssignmentManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+}
+
+export interface HostedAgentInstanceUtilization {
+	instanceID: string;
+	state?: string;
+	usage: HostedAgentResourceQuantity;
+}
+
+export interface HostedAgentPoolUtilization {
+	timestamp: string;
+	pool: HostedAgentResourceQuantity;
+	instances: HostedAgentInstanceUtilization[];
+	pressure: {
+		cpu?: boolean;
+		memory?: boolean;
+		storage?: boolean;
+	};
+	// Distinguishes a pool using no disk from one whose disk cannot be measured.
+	// Sandboxes share one volume, so disk is only ever reported for the pool —
+	// never per instance.
+	storageMeasured?: boolean;
+}
+
+// The UI calls these "Access Policies"; the API resource is
+// hosted-agent-access-rules. See operations.ts for the rename shim.
+export interface HostedAgentAccessPolicyResource {
+	type: 'hostedAgent' | 'selector';
+	id: string;
+}
+export interface HostedAgentAccessPolicy {
+	id: string;
+	created: string;
+	deleted?: string;
+	displayName: string;
+	subjects: AccessControlRuleSubject[];
+	resources: HostedAgentAccessPolicyResource[];
+}
+export interface HostedAgentAccessPolicyManifest {
+	displayName: string;
+	subjects: AccessControlRuleSubject[];
+	resources: HostedAgentAccessPolicyResource[];
+}
+
 // Storage credentials
 
 export interface StorageCredentials {

--- a/ui/user/src/lib/services/http.ts
+++ b/ui/user/src/lib/services/http.ts
@@ -104,6 +104,8 @@ type ResponseHandler = (
 	opts?: { dontLogErrors?: boolean }
 ) => Promise<unknown>;
 
+export type ErrorHandler = (error: unknown) => void;
+
 export async function doDelete(
 	path: string,
 	opts?: {
@@ -132,6 +134,7 @@ export async function doPut(
 	input?: string | object | Blob,
 	opts?: {
 		dontLogErrors?: boolean;
+		errorHandler?: ErrorHandler;
 		fetch?: typeof fetch;
 		signal?: AbortSignal;
 	}
@@ -144,12 +147,13 @@ export async function handleResponse(
 	path: string,
 	opts?: {
 		dontLogErrors?: boolean;
+		errorHandler?: ErrorHandler;
 	}
 ): Promise<unknown> {
 	if (!resp.ok) {
 		const body = await resp.text();
 		const e = createHttpError(resp.status, path, body);
-		if (opts?.dontLogErrors) {
+		if (opts?.dontLogErrors || opts?.errorHandler) {
 			throw e;
 		}
 		errors.items.push(e);
@@ -167,6 +171,7 @@ export async function doWithBody(
 	input?: string | object | Blob | FormData,
 	opts?: {
 		dontLogErrors?: boolean;
+		errorHandler?: ErrorHandler;
 		fetch?: typeof fetch;
 		headers?: Record<string, string>;
 		signal?: AbortSignal;
@@ -204,6 +209,10 @@ export async function doWithBody(
 		}
 		return handleResponse(resp, path, opts);
 	} catch (e) {
+		if (opts?.errorHandler) {
+			opts.errorHandler(e);
+			throw e;
+		}
 		if (opts?.dontLogErrors) {
 			throw e;
 		}
@@ -217,6 +226,7 @@ export async function doPost(
 	input: string | object | Blob,
 	opts?: {
 		dontLogErrors?: boolean;
+		errorHandler?: ErrorHandler;
 		fetch?: typeof fetch;
 		headers?: Record<string, string>;
 		signal?: AbortSignal;

--- a/ui/user/src/routes/admin/hosted-agent-access-policies/+page.svelte
+++ b/ui/user/src/routes/admin/hosted-agent-access-policies/+page.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import Confirm from '$lib/components/Confirm.svelte';
+	import Layout from '$lib/components/Layout.svelte';
+	import HostedAgentAccessPolicyForm from '$lib/components/admin/HostedAgentAccessPolicyForm.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
+	import Table from '$lib/components/table/Table.svelte';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import { type HostedAgentAccessPolicy } from '$lib/services/admin/types';
+	import { AdminService } from '$lib/services/index.js';
+	import { profile } from '$lib/stores/index.js';
+	import { clearUrlParams, goto } from '$lib/url';
+	import { openUrl } from '$lib/utils.js';
+	import { Plus, Trash2, Vault } from '@lucide/svelte';
+	import { untrack } from 'svelte';
+	import { fly } from 'svelte/transition';
+
+	let { data } = $props();
+	let hostedAgentAccessPolicies = $state(untrack(() => data.hostedAgentAccessPolicies));
+	let policyToDelete = $state<HostedAgentAccessPolicy>();
+
+	let isReadonly = $derived(profile.current.isAdminReadonly?.());
+	let showCreateNew = $derived(page.url.searchParams.has('new'));
+
+	async function navigateToCreated(policy: HostedAgentAccessPolicy) {
+		clearUrlParams(['new']);
+		goto(`/admin/hosted-agent-access-policies/${policy.id}`, { replaceState: false });
+	}
+
+	const duration = PAGE_TRANSITION_DURATION;
+
+	let title = $derived(
+		showCreateNew ? 'Create Hosted Agent Access Policy' : 'Hosted Agent Access Policies'
+	);
+</script>
+
+<Layout {title} showBackButton={showCreateNew}>
+	<div
+		class="h-full w-full"
+		in:fly={{ x: 100, duration, delay: duration }}
+		out:fly={{ x: -100, duration }}
+	>
+		{#if showCreateNew}
+			{@render createPolicyScreen()}
+		{:else}
+			<div
+				class="flex flex-col gap-8"
+				in:fly={{ x: 100, delay: duration, duration }}
+				out:fly={{ x: -100, duration }}
+			>
+				{#if hostedAgentAccessPolicies.length === 0}
+					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+						<Vault class="text-muted-content size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">
+							No hosted agent access policies
+						</h4>
+						<p class="text-muted-content text-sm font-light">
+							Looks like you don't have any hosted agent access policies created yet. <br />
+							{#if !isReadonly}
+								Click the button below to get started.
+							{/if}
+						</p>
+
+						{@render addPolicyButton()}
+					</div>
+				{:else}
+					<div class="flex flex-col gap-2">
+						{@render policyTable()}
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	{#snippet rightNavActions()}
+		{#if !showCreateNew}
+			<div class="relative flex items-center gap-4">
+				{@render addPolicyButton()}
+			</div>
+		{/if}
+	{/snippet}
+</Layout>
+
+{#snippet policyTable()}
+	<Table
+		data={hostedAgentAccessPolicies}
+		fields={['displayName']}
+		headers={[{ property: 'displayName', title: 'Name' }]}
+		onClickRow={(d, isCtrlClick) => {
+			openUrl(`/admin/hosted-agent-access-policies/${d.id}`, isCtrlClick);
+		}}
+		sortable={['displayName']}
+	>
+		{#snippet actions(d)}
+			{#if !isReadonly}
+				<IconButton
+					variant="danger"
+					onclick={(e) => {
+						e.stopPropagation();
+						policyToDelete = d;
+					}}
+					tooltip={{ text: 'Delete Policy' }}
+				>
+					<Trash2 class="size-4" />
+				</IconButton>
+			{/if}
+		{/snippet}
+		{#snippet onRenderColumn(property, d)}
+			{d[property as keyof typeof d]}
+		{/snippet}
+	</Table>
+{/snippet}
+
+{#snippet addPolicyButton()}
+	{#if !profile.current.isAdminReadonly?.()}
+		<button
+			class="btn btn-primary flex items-center gap-1 text-sm"
+			onclick={() => {
+				goto(`/admin/hosted-agent-access-policies?new=true`);
+			}}
+		>
+			<Plus class="size-4" /> Add Access Policy
+		</button>
+	{/if}
+{/snippet}
+
+{#snippet createPolicyScreen()}
+	<div
+		class="h-full w-full"
+		in:fly={{ x: 100, delay: duration, duration }}
+		out:fly={{ x: -100, duration }}
+	>
+		<HostedAgentAccessPolicyForm onCreate={navigateToCreated} readonly={isReadonly} />
+	</div>
+{/snippet}
+
+<Confirm
+	msg={`Delete ${policyToDelete?.displayName || 'this policy'}?`}
+	show={Boolean(policyToDelete)}
+	onsuccess={async () => {
+		if (!policyToDelete) return;
+		await AdminService.deleteHostedAgentAccessPolicy(policyToDelete.id);
+		hostedAgentAccessPolicies = await AdminService.listHostedAgentAccessPolicies();
+		policyToDelete = undefined;
+	}}
+	oncancel={() => (policyToDelete = undefined)}
+/>
+
+<svelte:head>
+	<title>Obot | Hosted Agent Access Policies</title>
+</svelte:head>

--- a/ui/user/src/routes/admin/hosted-agent-access-policies/+page.ts
+++ b/ui/user/src/routes/admin/hosted-agent-access-policies/+page.ts
@@ -1,0 +1,19 @@
+import { handleRouteError } from '$lib/errors';
+import { AdminService } from '$lib/services';
+import type { HostedAgentAccessPolicy } from '$lib/services/admin/types';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, parent }) => {
+	const { profile } = await parent();
+	let hostedAgentAccessPolicies: HostedAgentAccessPolicy[] = [];
+
+	try {
+		hostedAgentAccessPolicies = await AdminService.listHostedAgentAccessPolicies({ fetch });
+	} catch (err) {
+		handleRouteError(err, '/admin/hosted-agent-access-policies', profile);
+	}
+
+	return {
+		hostedAgentAccessPolicies
+	};
+};

--- a/ui/user/src/routes/admin/hosted-agent-access-policies/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/hosted-agent-access-policies/[id]/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import Layout from '$lib/components/Layout.svelte';
+	import HostedAgentAccessPolicyForm from '$lib/components/admin/HostedAgentAccessPolicyForm.svelte';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import { profile } from '$lib/stores/index.js';
+	import { goto } from '$lib/url';
+	import { fly } from 'svelte/transition';
+
+	let { data } = $props();
+	const { hostedAgentAccessPolicy } = $derived(data);
+	const duration = PAGE_TRANSITION_DURATION;
+
+	let title = $derived(hostedAgentAccessPolicy?.displayName ?? 'Hosted Agent Access Policy');
+</script>
+
+<Layout {title} showBackButton>
+	<div class="h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
+		<HostedAgentAccessPolicyForm
+			{hostedAgentAccessPolicy}
+			onUpdate={() => {
+				goto('/admin/hosted-agent-access-policies');
+			}}
+			readonly={profile.current.isAdminReadonly?.()}
+		/>
+	</div>
+</Layout>
+
+<svelte:head>
+	<title>Obot | {title}</title>
+</svelte:head>

--- a/ui/user/src/routes/admin/hosted-agent-access-policies/[id]/+page.ts
+++ b/ui/user/src/routes/admin/hosted-agent-access-policies/[id]/+page.ts
@@ -1,0 +1,19 @@
+import { handleRouteError } from '$lib/errors';
+import { AdminService, type HostedAgentAccessPolicy } from '$lib/services';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ params, fetch, parent }) => {
+	const { id } = params;
+	const { profile } = await parent();
+
+	let hostedAgentAccessPolicy: HostedAgentAccessPolicy | undefined;
+	try {
+		hostedAgentAccessPolicy = await AdminService.getHostedAgentAccessPolicy(id, { fetch });
+	} catch (err) {
+		handleRouteError(err, `/admin/hosted-agent-access-policies/${id}`, profile);
+	}
+
+	return {
+		hostedAgentAccessPolicy
+	};
+};

--- a/ui/user/src/routes/admin/hosted-agents/+page.svelte
+++ b/ui/user/src/routes/admin/hosted-agents/+page.svelte
@@ -1,0 +1,746 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import Confirm from '$lib/components/Confirm.svelte';
+	import Layout from '$lib/components/Layout.svelte';
+	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
+	import HostedAgentForm from '$lib/components/admin/HostedAgentForm.svelte';
+	import HostedAgentPools from '$lib/components/admin/HostedAgentPools.svelte';
+	import AgentIcon from '$lib/components/hosted-agents/AgentIcon.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
+	import Table from '$lib/components/table/Table.svelte';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import Loading from '$lib/icons/Loading.svelte';
+	import { type AgentCatalog, type Harness, type HostedAgent } from '$lib/services/admin/types';
+	import { AdminService } from '$lib/services/index.js';
+	import { errors, profile } from '$lib/stores/index.js';
+	import { clearUrlParams, goto } from '$lib/url';
+	import { openUrl } from '$lib/utils.js';
+	import { Bot, Cpu, GitBranch, Pencil, Plus, RefreshCcw, Trash2 } from '@lucide/svelte';
+	import { onDestroy, untrack } from 'svelte';
+	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+	import { fly } from 'svelte/transition';
+	import { twMerge } from 'tailwind-merge';
+
+	let { data } = $props();
+	let hostedAgents = $state(untrack(() => data.hostedAgents));
+	let agentCatalogs = $state(untrack(() => data.agentCatalogs));
+	let harnesses = $state(untrack(() => data.harnesses));
+	let pools = $state(untrack(() => data.pools));
+	let assignments = $state(untrack(() => data.assignments));
+	let poolDefaults = $state(untrack(() => data.poolDefaults));
+	let agentToDelete = $state<HostedAgent>();
+	let catalogToDelete = $state<AgentCatalog>();
+	let harnessToDelete = $state<Harness>();
+
+	let isReadonly = $derived(profile.current.isAdminReadonly?.());
+	let showCreateNew = $derived(page.url.searchParams.has('new'));
+	let view = $derived<'agents' | 'catalogs' | 'harnesses' | 'pools'>(
+		page.url.searchParams.get('view') === 'catalogs'
+			? 'catalogs'
+			: page.url.searchParams.get('view') === 'harnesses'
+				? 'harnesses'
+				: page.url.searchParams.get('view') === 'pools'
+					? 'pools'
+					: 'agents'
+	);
+
+	// Source form
+	let catalogDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let editingCatalog = $state<AgentCatalog | undefined>();
+	let savingCatalog = $state(false);
+	let catalogForm = $state({ displayName: '', repoURL: '', ref: '' });
+
+	// Sync tracking, mirroring the Skill Sources page: refresh sets an annotation
+	// and the controller does the work, so poll until isSyncing clears.
+	let syncing = new SvelteSet<string>();
+	let syncIntervals = new SvelteMap<string, ReturnType<typeof setInterval>>();
+
+	function clearSyncInterval(id: string) {
+		const interval = syncIntervals.get(id);
+		if (interval) clearInterval(interval);
+		syncIntervals.delete(id);
+	}
+
+	onDestroy(() => {
+		for (const interval of syncIntervals.values()) clearInterval(interval);
+	});
+
+	function pollTillSyncComplete(id: string) {
+		clearSyncInterval(id);
+		syncIntervals.set(
+			id,
+			setInterval(async () => {
+				try {
+					const response = await AdminService.getAgentCatalog(id);
+					if (response && !response.isSyncing) {
+						clearSyncInterval(id);
+						agentCatalogs = await AdminService.listAgentCatalogs();
+						hostedAgents = await AdminService.listHostedAgents({ all: true });
+						harnesses = await AdminService.listHarnesses();
+						syncing.delete(id);
+					}
+				} catch (err) {
+					errors.append(`Failed to sync config source: ${err}`);
+					clearSyncInterval(id);
+					syncing.delete(id);
+				}
+			}, 3000)
+		);
+	}
+
+	async function sync(id: string) {
+		syncing.add(id);
+		try {
+			await AdminService.refreshAgentCatalog(id);
+			pollTillSyncComplete(id);
+		} catch (err) {
+			errors.append(`Failed to refresh config source: ${err}`);
+			syncing.delete(id);
+		}
+	}
+
+	function switchView(newView: 'agents' | 'catalogs' | 'harnesses' | 'pools') {
+		goto(newView === 'agents' ? '/admin/hosted-agents' : `/admin/hosted-agents?view=${newView}`);
+	}
+
+	async function navigateToCreated(agent: HostedAgent) {
+		clearUrlParams(['new']);
+		goto(`/admin/hosted-agents/${agent.id}`, { replaceState: false });
+	}
+
+	const duration = PAGE_TRANSITION_DURATION;
+
+	let title = $derived(showCreateNew ? 'Create Agent Template' : 'Hosted Agents');
+
+	const viewDescriptions = {
+		agents:
+			'A template describes an agent someone can launch: the harness it runs on, the MCP servers, skills and models it may use, and anything the user is asked when they create one.',
+		harnesses:
+			'A harness is the container image an agent runs inside — its runtime and preinstalled tooling, such as Claude Code. Templates pick a harness; the harness decides the image and whether the agent gets an interactive shell.',
+		pools:
+			'A pool is a shared bucket of CPU and memory. Every agent placed in it draws from the same budget and can borrow whatever its neighbours are not using, so agents have no fixed size of their own.',
+		catalogs:
+			'A config source is a Git repository Obot syncs templates and harnesses from, so they are defined in version control rather than added by hand here.'
+	};
+	let viewDescription = $derived(viewDescriptions[view]);
+
+	let harnessesById = $derived(new Map(harnesses.map((h) => [h.id, h])));
+
+	// A template's own icon, falling back to its harness's: a config source
+	// often gives the harness the brand mark and leaves the template plain.
+	let tableData = $derived(
+		hostedAgents.map((agent) => ({
+			id: agent.id,
+			name: agent.name,
+			harness: harnessesById.get(agent.harnessID)?.name ?? agent.harnessID,
+			icon: agent.icon || harnessesById.get(agent.harnessID)?.icon || '',
+			iconDark: agent.iconDark || harnessesById.get(agent.harnessID)?.iconDark || ''
+		}))
+	);
+
+	let harnessTableData = $derived(
+		harnesses.map((harness) => ({
+			id: harness.id,
+			name: harness.name,
+			description: harness.description ?? '',
+			image: harness.image,
+			icon: harness.icon ?? '',
+			iconDark: harness.iconDark ?? ''
+		}))
+	);
+
+	let catalogTableData = $derived(
+		agentCatalogs.map((source) => ({
+			id: source.id,
+			displayName: source.displayName,
+			repoURL: source.repoURL,
+			ref: source.ref || '(default branch)',
+			discoveredAgentCount: source.discoveredAgentCount ?? 0,
+			discoveredHarnessCount: source.discoveredHarnessCount ?? 0,
+			syncError: source.syncError ?? '',
+			isSyncing: syncing.has(source.id) || Boolean(source.isSyncing)
+		}))
+	);
+
+	function openCreateCatalog() {
+		editingCatalog = undefined;
+		catalogForm = { displayName: '', repoURL: '', ref: '' };
+		catalogDialog?.open();
+	}
+
+	function openEditCatalog(source: AgentCatalog) {
+		editingCatalog = source;
+		catalogForm = {
+			displayName: source.displayName,
+			repoURL: source.repoURL,
+			ref: source.ref ?? ''
+		};
+		catalogDialog?.open();
+	}
+
+	async function saveCatalog() {
+		savingCatalog = true;
+		try {
+			const manifest = {
+				displayName: catalogForm.displayName,
+				repoURL: catalogForm.repoURL,
+				ref: catalogForm.ref
+			};
+			if (editingCatalog) {
+				await AdminService.updateAgentCatalog(editingCatalog.id, manifest);
+			} else {
+				await AdminService.createAgentCatalog(manifest);
+			}
+			agentCatalogs = await AdminService.listAgentCatalogs();
+			catalogDialog?.close();
+		} catch (err) {
+			errors.append(`Failed to save config source: ${err}`);
+		} finally {
+			savingCatalog = false;
+		}
+	}
+
+	let canSaveCatalog = $derived(Boolean(catalogForm.displayName && catalogForm.repoURL));
+
+	// Harness form
+	let harnessDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let editingHarness = $state<Harness | undefined>();
+	let savingHarness = $state(false);
+	let harnessForm = $state({ name: '', description: '', icon: '', iconDark: '', image: '' });
+
+	function openCreateHarness() {
+		editingHarness = undefined;
+		harnessForm = { name: '', description: '', icon: '', iconDark: '', image: '' };
+		harnessDialog?.open();
+	}
+
+	function openEditHarness(harness: Harness) {
+		editingHarness = harness;
+		harnessForm = {
+			name: harness.name,
+			description: harness.description ?? '',
+			icon: harness.icon ?? '',
+			iconDark: harness.iconDark ?? '',
+			image: harness.image
+		};
+		harnessDialog?.open();
+	}
+
+	async function saveHarness() {
+		savingHarness = true;
+		try {
+			const manifest = {
+				name: harnessForm.name,
+				description: harnessForm.description,
+				icon: harnessForm.icon,
+				iconDark: harnessForm.iconDark,
+				image: harnessForm.image
+			};
+			if (editingHarness) {
+				await AdminService.updateHarness(editingHarness.id, manifest);
+			} else {
+				await AdminService.createHarness(manifest);
+			}
+			harnesses = await AdminService.listHarnesses();
+			harnessDialog?.close();
+		} catch (err) {
+			errors.append(`Failed to save harness: ${err}`);
+		} finally {
+			savingHarness = false;
+		}
+	}
+
+	let canSaveHarness = $derived(Boolean(harnessForm.name && harnessForm.image));
+</script>
+
+<Layout {title} showBackButton={showCreateNew}>
+	<div
+		class="h-full w-full"
+		in:fly={{ x: 100, duration, delay: duration }}
+		out:fly={{ x: -100, duration }}
+	>
+		{#if showCreateNew}
+			{@render createAgentScreen()}
+		{:else}
+			<div
+				class="flex flex-col gap-4"
+				in:fly={{ x: 100, delay: duration, duration }}
+				out:fly={{ x: -100, duration }}
+			>
+				<div class="flex w-full">
+					<button
+						class={twMerge('page-tab max-w-1/2', view === 'agents' && 'page-tab-active')}
+						onclick={() => switchView('agents')}
+					>
+						Templates
+					</button>
+					<button
+						class={twMerge('page-tab max-w-1/2', view === 'harnesses' && 'page-tab-active')}
+						onclick={() => switchView('harnesses')}
+					>
+						Harnesses
+					</button>
+					<button
+						class={twMerge('page-tab max-w-1/2', view === 'pools' && 'page-tab-active')}
+						onclick={() => switchView('pools')}
+					>
+						Pools
+					</button>
+					<button
+						class={twMerge('page-tab max-w-1/2', view === 'catalogs' && 'page-tab-active')}
+						onclick={() => switchView('catalogs')}
+					>
+						Config Sources
+					</button>
+				</div>
+
+				<!-- These four words mean nothing on first contact, and the empty-state
+				     copy that explains them disappears as soon as there is one row --
+				     which for a prepopulated install is immediately. Keeping the
+				     definition beside the tab costs one line and is always there. -->
+				<p class="text-muted-content -mt-1 text-sm font-light">{viewDescription}</p>
+
+				{#if view === 'agents'}
+					{#if hostedAgents.length === 0}
+						<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+							<Bot class="text-muted-content size-24 opacity-25" />
+							<h4 class="text-muted-content text-lg font-semibold">No agent templates</h4>
+							{#if !isReadonly}
+								<p class="text-muted-content text-sm font-light">
+									Add one directly, or sync them from a config source.
+								</p>
+							{/if}
+							{@render addAgentButton()}
+						</div>
+					{:else}
+						{@render agentTable()}
+					{/if}
+				{:else if view === 'catalogs'}
+					{#if agentCatalogs.length === 0}
+						<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+							<GitBranch class="text-muted-content size-24 opacity-25" />
+							<h4 class="text-muted-content text-lg font-semibold">No config sources</h4>
+							{#if !isReadonly}
+								<p class="text-muted-content text-sm font-light">
+									Add a Git repository to sync templates and harnesses from.
+								</p>
+							{/if}
+							{@render addSourceButton()}
+						</div>
+					{:else}
+						{@render sourceTable()}
+					{/if}
+				{:else if view === 'pools'}
+					<HostedAgentPools
+						bind:pools
+						bind:assignments
+						bind:defaults={poolDefaults}
+						readonly={isReadonly}
+					/>
+				{:else if harnesses.length === 0}
+					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+						<Cpu class="text-muted-content size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">No harnesses</h4>
+						{#if !isReadonly}
+							<p class="text-muted-content text-sm font-light">
+								Add one before registering a template, which has to pick a harness.
+							</p>
+						{/if}
+						{@render addHarnessButton()}
+					</div>
+				{:else if view === 'harnesses'}
+					{@render harnessTable()}
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	{#snippet rightNavActions()}
+		{#if !showCreateNew}
+			<div class="relative flex items-center gap-4">
+				{#if view === 'agents'}
+					{@render addAgentButton()}
+				{:else if view === 'catalogs'}
+					{@render addSourceButton()}
+				{:else if view === 'harnesses'}
+					{@render addHarnessButton()}
+				{/if}
+			</div>
+		{/if}
+	{/snippet}
+</Layout>
+
+{#snippet agentTable()}
+	<Table
+		data={tableData}
+		fields={['name', 'harness']}
+		headers={[
+			{ property: 'name', title: 'Name' },
+			{ property: 'harness', title: 'Harness' }
+		]}
+		onClickRow={(d, isCtrlClick) => {
+			openUrl(`/admin/hosted-agents/${d.id}`, isCtrlClick);
+		}}
+		sortable={['name', 'harness']}
+	>
+		{#snippet onRenderColumn(property, d)}
+			{#if property === 'name'}
+				<div class="flex items-center gap-2">
+					<AgentIcon icon={d.icon} iconDark={d.iconDark} alt="" />
+					<span class="truncate">{d.name}</span>
+				</div>
+			{:else}
+				{d[property as keyof typeof d]}
+			{/if}
+		{/snippet}
+		{#snippet actions(d)}
+			{#if !isReadonly}
+				<IconButton
+					variant="danger"
+					onclick={(e) => {
+						e.stopPropagation();
+						agentToDelete = hostedAgents.find((a) => a.id === d.id);
+					}}
+					tooltip={{ text: 'Delete Agent' }}
+				>
+					<Trash2 class="size-4" />
+				</IconButton>
+			{/if}
+		{/snippet}
+	</Table>
+{/snippet}
+
+{#snippet sourceTable()}
+	<Table
+		data={catalogTableData}
+		fields={['displayName', 'repoURL', 'ref', 'discoveredAgentCount', 'discoveredHarnessCount']}
+		headers={[
+			{ property: 'displayName', title: 'Name' },
+			{ property: 'repoURL', title: 'Repository' },
+			{ property: 'ref', title: 'Ref' },
+			{ property: 'discoveredAgentCount', title: 'Agents' },
+			{ property: 'discoveredHarnessCount', title: 'Harnesses' }
+		]}
+		sortable={['displayName', 'repoURL']}
+		noDataMessage="No sources added."
+	>
+		{#snippet onRenderColumn(property, d)}
+			{#if property === 'displayName'}
+				<div class="flex items-center gap-2">
+					<span>{d.displayName}</span>
+					{#if d.isSyncing}
+						<Loading class="size-3" />
+					{:else if d.syncError}
+						<span class="badge badge-error badge-xs" title={d.syncError}>sync error</span>
+					{/if}
+				</div>
+			{:else}
+				{d[property as keyof typeof d]}
+			{/if}
+		{/snippet}
+		{#snippet actions(d)}
+			{#if !isReadonly}
+				<IconButton
+					onclick={(e) => {
+						e.stopPropagation();
+						sync(d.id);
+					}}
+					disabled={d.isSyncing}
+					tooltip={{ text: 'Sync Now' }}
+				>
+					<RefreshCcw class="size-4" />
+				</IconButton>
+				<IconButton
+					onclick={(e) => {
+						e.stopPropagation();
+						const source = agentCatalogs.find((s) => s.id === d.id);
+						if (source) openEditCatalog(source);
+					}}
+					tooltip={{ text: 'Edit Config Source' }}
+				>
+					<Pencil class="size-4" />
+				</IconButton>
+				<IconButton
+					variant="danger"
+					onclick={(e) => {
+						e.stopPropagation();
+						catalogToDelete = agentCatalogs.find((s) => s.id === d.id);
+					}}
+					tooltip={{ text: 'Delete Source' }}
+				>
+					<Trash2 class="size-4" />
+				</IconButton>
+			{/if}
+		{/snippet}
+	</Table>
+{/snippet}
+
+{#snippet harnessTable()}
+	<Table
+		data={harnessTableData}
+		fields={['name', 'description', 'image']}
+		headers={[
+			{ property: 'name', title: 'Name' },
+			{ property: 'description', title: 'Description' },
+			{ property: 'image', title: 'Image' }
+		]}
+		sortable={['name', 'image']}
+		noDataMessage="No harnesses added."
+	>
+		{#snippet onRenderColumn(property, d)}
+			{#if property === 'name'}
+				<div class="flex items-center gap-2">
+					<AgentIcon icon={d.icon} iconDark={d.iconDark} alt="" />
+					<span class="truncate">{d.name}</span>
+				</div>
+			{:else}
+				{d[property as keyof typeof d]}
+			{/if}
+		{/snippet}
+		{#snippet actions(d)}
+			{#if !isReadonly}
+				<IconButton
+					onclick={(e) => {
+						e.stopPropagation();
+						const harness = harnesses.find((h) => h.id === d.id);
+						if (harness) openEditHarness(harness);
+					}}
+					tooltip={{ text: 'Edit Harness' }}
+				>
+					<Pencil class="size-4" />
+				</IconButton>
+				<IconButton
+					variant="danger"
+					onclick={(e) => {
+						e.stopPropagation();
+						harnessToDelete = harnesses.find((h) => h.id === d.id);
+					}}
+					tooltip={{ text: 'Delete Harness' }}
+				>
+					<Trash2 class="size-4" />
+				</IconButton>
+			{/if}
+		{/snippet}
+	</Table>
+{/snippet}
+
+{#snippet addAgentButton()}
+	{#if !isReadonly}
+		<button
+			class="btn btn-primary flex items-center gap-1 text-sm"
+			onclick={() => goto(`/admin/hosted-agents?new=true`)}
+		>
+			<Plus class="size-4" /> Add Template
+		</button>
+	{/if}
+{/snippet}
+
+{#snippet addSourceButton()}
+	{#if !isReadonly}
+		<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={openCreateCatalog}>
+			<Plus class="size-4" /> Add Config Source
+		</button>
+	{/if}
+{/snippet}
+
+{#snippet addHarnessButton()}
+	{#if !isReadonly}
+		<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={openCreateHarness}>
+			<Plus class="size-4" /> Add Harness
+		</button>
+	{/if}
+{/snippet}
+
+{#snippet createAgentScreen()}
+	<div
+		class="h-full w-full"
+		in:fly={{ x: 100, delay: duration, duration }}
+		out:fly={{ x: -100, duration }}
+	>
+		<HostedAgentForm onCreate={navigateToCreated} readonly={isReadonly} />
+	</div>
+{/snippet}
+
+<ResponsiveDialog
+	bind:this={catalogDialog}
+	title={editingCatalog ? 'Edit Config Source' : 'Add Config Source'}
+	class="md:max-w-md"
+>
+	<div class="flex flex-col gap-4">
+		<div class="flex flex-col gap-2">
+			<label for="source-name" class="text-sm font-light">Name</label>
+			<input id="source-name" bind:value={catalogForm.displayName} class="text-input-filled" />
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="source-repo" class="text-sm font-light">Repository URL</label>
+			<input
+				id="source-repo"
+				bind:value={catalogForm.repoURL}
+				class="text-input-filled"
+				placeholder="https://github.com/obot-platform/agents"
+				inputmode="url"
+				autocomplete="off"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="source-ref" class="text-sm font-light">Ref</label>
+			<input
+				id="source-ref"
+				bind:value={catalogForm.ref}
+				class="text-input-filled"
+				placeholder="(default branch)"
+				autocomplete="off"
+			/>
+			<span class="text-muted-content text-xs">Branch or tag. Leave blank for the default.</span>
+		</div>
+	</div>
+	<div class="flex justify-end gap-2 pt-4">
+		<button class="btn btn-secondary text-sm" onclick={() => catalogDialog?.close()}>Cancel</button>
+		<button
+			class="btn btn-primary text-sm"
+			disabled={!canSaveCatalog || savingCatalog}
+			onclick={saveCatalog}
+		>
+			{#if savingCatalog}
+				<Loading class="size-4" />
+			{:else}
+				{editingCatalog ? 'Update' : 'Add'}
+			{/if}
+		</button>
+	</div>
+</ResponsiveDialog>
+
+<ResponsiveDialog
+	bind:this={harnessDialog}
+	title={editingHarness ? 'Edit Harness' : 'Add Harness'}
+	class="md:max-w-md"
+>
+	<div class="flex flex-col gap-4">
+		<div class="flex flex-col gap-2">
+			<label for="harness-name" class="text-sm font-light">Name</label>
+			<input
+				id="harness-name"
+				bind:value={harnessForm.name}
+				class="text-input-filled"
+				placeholder="Claude Code"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="harness-description" class="text-sm font-light">Description</label>
+			<textarea
+				id="harness-description"
+				bind:value={harnessForm.description}
+				class="text-input-filled"
+				rows="2"
+			></textarea>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="harness-image" class="text-sm font-light">Docker Image</label>
+			<input
+				id="harness-image"
+				bind:value={harnessForm.image}
+				class="text-input-filled"
+				placeholder="ghcr.io/example/claude-code:latest"
+				autocomplete="off"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="harness-icon" class="text-sm font-light">Icon URL</label>
+			<div class="flex items-center gap-3">
+				{#if harnessForm.icon}
+					<img src={harnessForm.icon} alt="" class="size-10 shrink-0 rounded-md object-contain" />
+				{/if}
+				<input
+					type="text"
+					id="harness-icon"
+					bind:value={harnessForm.icon}
+					class="text-input-filled grow"
+					inputmode="url"
+					autocomplete="off"
+				/>
+			</div>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="harness-icon-dark" class="text-sm font-light">Icon URL (Dark)</label>
+			<div class="flex items-center gap-3">
+				{#if harnessForm.iconDark}
+					<img
+						src={harnessForm.iconDark}
+						alt=""
+						class="bg-base-300 size-10 shrink-0 rounded-md object-contain"
+					/>
+				{/if}
+				<input
+					type="text"
+					id="harness-icon-dark"
+					bind:value={harnessForm.iconDark}
+					class="text-input-filled grow"
+					inputmode="url"
+					autocomplete="off"
+				/>
+			</div>
+		</div>
+	</div>
+	<div class="flex justify-end gap-2 pt-4">
+		<button class="btn btn-secondary text-sm" onclick={() => harnessDialog?.close()}>Cancel</button>
+		<button
+			class="btn btn-primary text-sm"
+			disabled={!canSaveHarness || savingHarness}
+			onclick={saveHarness}
+		>
+			{#if savingHarness}
+				<Loading class="size-4" />
+			{:else}
+				{editingHarness ? 'Update' : 'Add'}
+			{/if}
+		</button>
+	</div>
+</ResponsiveDialog>
+
+<Confirm
+	msg={`Delete ${agentToDelete?.name || 'this agent'}?`}
+	show={Boolean(agentToDelete)}
+	onsuccess={async () => {
+		if (!agentToDelete) return;
+		await AdminService.deleteHostedAgent(agentToDelete.id);
+		hostedAgents = await AdminService.listHostedAgents({ all: true });
+		agentToDelete = undefined;
+	}}
+	oncancel={() => (agentToDelete = undefined)}
+/>
+
+<Confirm
+	msg={`Delete ${catalogToDelete?.displayName || 'this source'}?`}
+	note="Agents and harnesses discovered from this source will be removed."
+	show={Boolean(catalogToDelete)}
+	onsuccess={async () => {
+		if (!catalogToDelete) return;
+		await AdminService.deleteAgentCatalog(catalogToDelete.id);
+		agentCatalogs = await AdminService.listAgentCatalogs();
+		hostedAgents = await AdminService.listHostedAgents({ all: true });
+		harnesses = await AdminService.listHarnesses();
+		catalogToDelete = undefined;
+	}}
+	oncancel={() => (catalogToDelete = undefined)}
+/>
+
+<Confirm
+	msg={`Delete ${harnessToDelete?.name || 'this harness'}?`}
+	note="A harness that agents still run on cannot be deleted."
+	show={Boolean(harnessToDelete)}
+	onsuccess={async () => {
+		if (!harnessToDelete) return;
+		try {
+			await AdminService.deleteHarness(harnessToDelete.id);
+			harnesses = await AdminService.listHarnesses();
+		} catch (err) {
+			errors.append(`Failed to delete harness: ${err}`);
+		}
+		harnessToDelete = undefined;
+	}}
+	oncancel={() => (harnessToDelete = undefined)}
+/>
+
+<svelte:head>
+	<title>Obot | Hosted Agents</title>
+</svelte:head>

--- a/ui/user/src/routes/admin/hosted-agents/+page.ts
+++ b/ui/user/src/routes/admin/hosted-agents/+page.ts
@@ -1,0 +1,48 @@
+import { handleRouteError } from '$lib/errors';
+import { AdminService } from '$lib/services';
+import type {
+	AgentCatalog,
+	Harness,
+	HostedAgent,
+	HostedAgentPool,
+	HostedAgentPoolAssignment,
+	HostedAgentPoolDefaults
+} from '$lib/services/admin/types';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, parent }) => {
+	const { profile } = await parent();
+	let hostedAgents: HostedAgent[] = [];
+	let agentCatalogs: AgentCatalog[] = [];
+	let harnesses: Harness[] = [];
+	let pools: HostedAgentPool[] = [];
+	let assignments: HostedAgentPoolAssignment[] = [];
+	let poolDefaults: HostedAgentPoolDefaults | undefined;
+
+	try {
+		// Admins get the unfiltered list; the default view is access-rule filtered.
+		[hostedAgents, agentCatalogs, harnesses, pools, assignments] = await Promise.all([
+			AdminService.listHostedAgents({ fetch, all: true }),
+			AdminService.listAgentCatalogs({ fetch }),
+			AdminService.listHarnesses({ fetch }),
+			AdminService.listHostedAgentPools({ fetch }),
+			AdminService.listHostedAgentPoolAssignments({ fetch })
+		]);
+		try {
+			poolDefaults = await AdminService.getHostedAgentPoolDefaults({ fetch });
+		} catch {
+			// Defaults do not exist until an administrator configures them.
+		}
+	} catch (err) {
+		handleRouteError(err, '/admin/hosted-agents', profile);
+	}
+
+	return {
+		hostedAgents,
+		agentCatalogs,
+		harnesses,
+		pools,
+		assignments,
+		poolDefaults
+	};
+};

--- a/ui/user/src/routes/admin/hosted-agents/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/hosted-agents/[id]/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import Layout from '$lib/components/Layout.svelte';
+	import HostedAgentForm from '$lib/components/admin/HostedAgentForm.svelte';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import { profile } from '$lib/stores/index.js';
+	import { goto } from '$lib/url';
+	import { fly } from 'svelte/transition';
+
+	let { data } = $props();
+	const { hostedAgent } = $derived(data);
+	const duration = PAGE_TRANSITION_DURATION;
+
+	let title = $derived(hostedAgent?.name ?? 'Agent Template');
+</script>
+
+<Layout {title} showBackButton>
+	<div class="h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
+		<HostedAgentForm
+			{hostedAgent}
+			onUpdate={() => {
+				goto('/admin/hosted-agents');
+			}}
+			readonly={profile.current.isAdminReadonly?.()}
+		/>
+	</div>
+</Layout>
+
+<svelte:head>
+	<title>Obot | {title}</title>
+</svelte:head>

--- a/ui/user/src/routes/admin/hosted-agents/[id]/+page.ts
+++ b/ui/user/src/routes/admin/hosted-agents/[id]/+page.ts
@@ -1,0 +1,19 @@
+import { handleRouteError } from '$lib/errors';
+import { AdminService, type HostedAgent } from '$lib/services';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ params, fetch, parent }) => {
+	const { id } = params;
+	const { profile } = await parent();
+
+	let hostedAgent: HostedAgent | undefined;
+	try {
+		hostedAgent = await AdminService.getHostedAgent(id, { fetch });
+	} catch (err) {
+		handleRouteError(err, `/admin/hosted-agents/${id}`, profile);
+	}
+
+	return {
+		hostedAgent
+	};
+};


### PR DESCRIPTION
An admin section for templates, harnesses, pools and config sources, plus the
API client the whole feature is built on.

Rows carry the icon the server resolved, so the UI does not walk the
instance-template-harness chain itself and cannot disagree with the answer the
API gives. A template that cannot run here is shown with the reason and cannot
be launched, which is the same answer the API enforces rather than a second copy
of the rule.



---

Part 9 of an 11-PR stack. Base: `darren/hosted-agents-08-rest-api`.

## Stack

1. #7448 — Resource model
2. #7449 — Sandbox backend interface
3. #7450 — Kubernetes sandbox backend
4. #7451 — Sandbox reachability (models + MCP)
5. #7452 — Terminal + HTTP publish
6. #7453 — Server wiring + Helm
7. #7454 — Controllers / reconcilers
8. #7455 — REST API
**→ 9. #7456 — Admin UI** (this PR)
10. #7457 — User UI
11. #7458 — Seed default config source

Merge bottom-up; GitHub retargets each child when its parent merges.
