### PR TITLE
feat: wire the agent backend into the server (6/11)

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -108,6 +108,24 @@ Set name of namespace to use for mcp servers
 {{- end -}}
 
 {{/*
+Whether Obot runs workloads on Kubernetes.
+
+This gates the sandbox namespace, its RBAC and its network policy. Hosted agent
+sandboxes share that namespace with MCP servers and follow the same backend --
+the chart deliberately does not expose a separate agent backend setting, because
+a real deployment always wants the two to match. Overriding one without the
+other is a local development case, handled by setting the server flag directly.
+
+The k8s alias is accepted here because pkg/mcp accepts it: gating on the long
+spelling alone would leave a "k8s" deployment running on a cluster with no
+namespace and no permissions.
+*/}}
+{{- define "obot.mcpOnKubernetes" -}}
+{{- $backend := .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND | default "" | toString | lower -}}
+{{- if or (eq $backend "kubernetes") (eq $backend "k8s") -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Generate comma-separated list of MCP image pull secret names
 */}}
 {{- define "obot.config.mcpImagePullSecrets" -}}

--- a/chart/templates/internal-configmap.yaml
+++ b/chart/templates/internal-configmap.yaml
@@ -16,10 +16,20 @@ data:
   {{ $key }}: {{ toString $value | quote }}
   {{- end }}
   {{- end }}
-  {{- if eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes" }}
+  {{- if include "obot.mcpOnKubernetes" . }}
+  # Hosted agent sandboxes share this namespace, so leaving it unset would send
+  # the agent backend to its own default namespace, which this chart never
+  # creates and grants no permissions on.
   OBOT_SERVER_MCPNAMESPACE: {{ include "obot.config.mcpNamespace" . | quote }}
   OBOT_SERVER_SERVICE_NAME: {{ include "obot.fullname" . | quote }}
   OBOT_SERVER_SERVICE_NAMESPACE: {{ .Release.Namespace | quote }}
+  {{- if not .Values.config.OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL }}
+  # Sandboxes are admitted against the namespace's Pod Security level, so the
+  # backend is told what that level is rather than being configured separately
+  # and left to drift out of agreement with the label above. Setting
+  # config.OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL explicitly overrides this.
+  OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL: {{ if .Values.mcpNamespace.podSecurity.enabled }}{{ .Values.mcpNamespace.podSecurity.enforce | quote }}{{ else }}"privileged"{{ end }}
+  {{- end }}
   {{- end }}
   {{- if .Values.mcpServerDefaults.affinity }}
   OBOT_SERVER_MCPK8S_SETTINGS_AFFINITY: {{ .Values.mcpServerDefaults.affinity | toJson | quote }}

--- a/chart/templates/mcp.yaml
+++ b/chart/templates/mcp.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes" }}
+{{- if include "obot.mcpOnKubernetes" . }}
 {{- include "obot.validatePodSecurityLevels" . -}}
 apiVersion: v1
 kind: Namespace
@@ -54,6 +54,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list", "watch"]
+  # The hosted agent terminal joins a sandbox's console. It attaches to the
+  # container the harness was started with rather than exec'ing a second
+  # process, so this is pods/attach and not pods/exec.
+  - apiGroups: [""]
+    resources: ["pods/attach"]
+    verbs: ["create", "get"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
@@ -63,10 +69,71 @@ rules:
   - apiGroups: ["networking.aviatrix.com"]
     resources: ["firewallpolicies"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # ResourceQuota access for capacity info
+  # ResourceQuota access for capacity info, and for hosted agent pools,
+  # whose pool budgets are ResourceQuotas scoped to a per-pool PriorityClass.
   - apiGroups: [""]
     resources: ["resourcequotas"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  # Hosted agent sandbox volume cleanup runs as a Job.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+
+---
+# PriorityClasses are cluster-scoped, so the per-pool objects backing hosted
+# agent pools cannot live in a namespaced Role. Each one is created with
+# an owner reference to the sandbox namespace, so deleting that namespace
+# collects them.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-obot-agent-clusterrole
+  labels:
+    {{- include "obot.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  # Needed to read the sandbox namespace's UID when building those owner
+  # references, and to create it when hosted agents are the only Kubernetes
+  # feature enabled.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "get", "list", "watch"]
+  # Only read when Obot's own hostname is a loopback address, which is a
+  # developer running outside the cluster: a sandbox cannot reach 127.0.0.1, so
+  # a node address is substituted. Harmless to omit in production, where the
+  # configured hostname already resolves.
+  - apiGroups: [""]
+    resources: ["nodes"]
     verbs: ["get", "list"]
+  # Live per-sandbox CPU and memory for hosted agent pools.
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # Pool volume usage comes from kubelet's stats summary, reached through the
+  # API server proxy. This grant is broader than it looks -- nodes/proxy can
+  # reach other kubelet endpoints too -- so withhold it if pool disk reporting
+  # is not wanted. The backend degrades to omitting disk rather than failing.
+  - apiGroups: [""]
+    resources: ["nodes/proxy", "nodes/stats"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-obot-agent-clusterrolebinding
+  labels:
+    {{- include "obot.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "obot.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-obot-agent-clusterrole
+  apiGroup: rbac.authorization.k8s.io
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes") .Values.mcpNamespace.networkPolicy.enabled }}
+{{- if and (include "obot.mcpOnKubernetes" .) .Values.mcpNamespace.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.serviceAccount.create (eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes") }}
+{{- if or .Values.serviceAccount.create (include "obot.mcpOnKubernetes" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -20,9 +20,13 @@ import (
 	apiclienttypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	agentbackendfake "github.com/obot-platform/obot/pkg/agentbackend/fake"
+	agentbackendkubernetes "github.com/obot-platform/obot/pkg/agentbackend/kubernetes"
 	"github.com/obot-platform/obot/pkg/api/authn"
 	"github.com/obot-platform/obot/pkg/api/authz"
 	"github.com/obot-platform/obot/pkg/api/handlers"
+	"github.com/obot-platform/obot/pkg/api/handlers/agentconnect"
 	"github.com/obot-platform/obot/pkg/api/handlers/mcpgateway"
 	"github.com/obot-platform/obot/pkg/api/server"
 	"github.com/obot-platform/obot/pkg/api/server/audit"
@@ -80,6 +84,8 @@ import (
 
 var pkgLog = logger.Package()
 
+const leaderElectionRequestTimeout = 15 * time.Second
+
 type (
 	GatewayConfig     gserver.Options
 	AuditConfig       audit.Options
@@ -115,6 +121,8 @@ type Config struct {
 	MDMAssetSource                       string `usage:"The source for MDM assets (a local directory, a tar archive path, or an HTTP(S) tarball URL)" default:"https://github.com/obot-platform/obot-sentry/releases/download/v0.1.4/mdm-assets.tar.gz" env:"OBOT_SERVER_MDM_ASSET_SOURCE"`
 	DefaultSkillRepoURL                  string `usage:"The default skill repository URL (must be HTTPS GitHub URL)" default:"https://github.com/obot-platform/skills" env:"OBOT_DEFAULT_SKILL_REPO_URL"`
 	DefaultSkillRepoRef                  string `usage:"The ref (branch/tag) for the default skill repository" default:"" env:"OBOT_DEFAULT_SKILL_REPO_REF"`
+	DefaultHostedAgentsCatalogURL        string `usage:"The default hosted agent catalog repository URL (must be HTTPS)" default:"https://github.com/obot-platform/hosted-agents-catalog" env:"OBOT_DEFAULT_HOSTED_AGENTS_CATALOG_URL"`
+	DefaultHostedAgentsCatalogRef        string `usage:"The ref (branch/tag) for the default hosted agent catalog repository" default:"" env:"OBOT_DEFAULT_HOSTED_AGENTS_CATALOG_REF"`
 	ModelInfoSourceURL                   string `usage:"Authoritative URL for the model info (pricing) source synced into model costs; changes take effect on restart, empty disables it" default:"https://models.dev/api.json"`
 	DisableUpdateCheck                   bool   `usage:"Disable Obot server update checks"`
 	HideK8sDetails                       bool   `usage:"Hide Kubernetes configuration details such as the Server Scheduling page from the UI" default:"false"`
@@ -123,6 +131,11 @@ type Config struct {
 	LLMAuditLogRetentionDays             int    `usage:"Number of days to retain LLM audit logs (0 to disable cleanup)." default:"90"`
 	DisableLLMAuditLog                   bool   `usage:"Disable LLM gateway audit logging" default:"false"`
 	EnableAgents                         *bool  `usage:"Enable Obot Agent features. When unset, agents are disabled for new deployments but grandfathered in for deployments that already have agents. Explicitly set to true to force-enable, or false to force-disable, regardless of grandfathering." env:"OBOT_ENABLE_AGENTS"`
+	HostedAgentsBackend                  string `usage:"Hosted agent runtime backend (disabled, fake, or kubernetes). Defaults to the MCP runtime backend: kubernetes when MCP servers run on Kubernetes, and otherwise fake, since there is no docker agent backend." name:"hosted-agents-backend" env:"OBOT_HOSTED_AGENTS_BACKEND"`
+	HostedAgentsStorageClassName         string `usage:"StorageClass for hosted agent pool volumes. It should use volumeBindingMode WaitForFirstConsumer, which is what keeps a pool on one node." name:"hosted-agents-storage-class-name"`
+	HostedAgentsPodSecurityLevel         string `usage:"Pod Security Admission level enforced on the namespace hosted agent sandboxes run in (privileged, baseline, or restricted). Must match the namespace's own label or sandboxes are refused at admission. Empty means restricted." name:"hosted-agents-pod-security-level" env:"OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL"`
+	HostedAgentsImagePullPolicy          string `usage:"Pull policy for hosted agent sandbox images (Always, IfNotPresent, Never)" default:"" name:"hosted-agents-image-pull-policy" env:"OBOT_HOSTED_AGENTS_IMAGE_PULL_POLICY"`
+	HostedAgentsCleanupImage             string `usage:"Image used to erase a deleted sandbox's directory from its pool volume. Needs a shell and coreutils." name:"hosted-agents-cleanup-image" default:"busybox:1.36"`
 	MCPServerSearchImage                 string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.2.0"`
 	NanobotAgentImage                    string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/obot-platform/nanobot-agent:v0.0.91"`
 	MCPNetworkPolicyProviderChartRepo    string `usage:"Helm repository URL for the network policy provider chart"`
@@ -167,29 +180,35 @@ type Services struct {
 	AuditLogger           audit.Logger
 	DSN                   string
 	ServerURL             string
-	MCPSessionManager     *mcp.SessionManager
-	TunnelManager         *tunnel.Manager
-	OAuthServerConfig     handlers.OAuthAuthorizationServerConfig
+	// AgentServerURL is Obot's address as a sandbox can reach it, which differs
+	// from ServerURL when Obot runs outside the cluster its sandboxes run in.
+	AgentServerURL    string
+	MCPSessionManager *mcp.SessionManager
+	TunnelManager     *tunnel.Manager
+	OAuthServerConfig handlers.OAuthAuthorizationServerConfig
 
 	// Global token storage client for MCP OAuth
 	MCPOAuthTokenStorage         mcp.GlobalTokenStore
 	MCPSecretBindingAllowedLabel string
 	RegistryNoAuth               bool
 
-	PostgresDSN                 string
-	ProviderRegistryPaths       []string
-	DevUIPort                   int
-	UserUIPort                  int
-	GatewayServer               *gserver.Server
-	Bootstrapper                *bootstrap.Bootstrap
-	LocalAuthProvider           *localauth.Provider
-	AuthEnabled                 bool
-	DefaultMCPCatalogPath       string
-	DefaultSystemMCPCatalogPath string
-	MDMAssetSource              string
-	DefaultSkillRepoURL         string
-	DefaultSkillRepoRef         string
-	ModelInfoSourceURL          string
+	PostgresDSN                   string
+	ProviderRegistryPaths         []string
+	DevUIPort                     int
+	DevMode                       bool
+	UserUIPort                    int
+	GatewayServer                 *gserver.Server
+	Bootstrapper                  *bootstrap.Bootstrap
+	LocalAuthProvider             *localauth.Provider
+	AuthEnabled                   bool
+	DefaultMCPCatalogPath         string
+	DefaultSystemMCPCatalogPath   string
+	MDMAssetSource                string
+	DefaultSkillRepoURL           string
+	DefaultSkillRepoRef           string
+	DefaultHostedAgentsCatalogURL string
+	DefaultHostedAgentsCatalogRef string
+	ModelInfoSourceURL            string
 
 	// Used for indexed lookups of access control rules.
 	AccessControlRuleHelper *accesscontrolrule.Helper
@@ -199,6 +218,9 @@ type Services struct {
 
 	// Used for indexed lookups of skill access rules.
 	SkillAccessRuleHelper *skillaccessrule.Helper
+
+	// Used for indexed lookups of hosted agent access rules.
+	HostedAgentAccessRuleHelper *hostedagentaccessrule.Helper
 
 	MCPOAuthClientSecretExpiration time.Duration
 	ForceDynamicClient             bool
@@ -230,13 +252,19 @@ type Services struct {
 	// environment/Helm config and not modifiable via UI.
 	PSASettingsFromHelm *v1.PodSecurityAdmissionSettings
 
-	DisableUpdateCheck                   bool
-	HideK8sDetails                       bool
-	MCPRuntimeBackend                    string
-	MCPImagePullSecrets                  []string
-	MCPHTTPWebhookBaseImage              string
-	MessagePoliciesEnabled               bool
-	EnableAgents                         *bool
+	DisableUpdateCheck      bool
+	HideK8sDetails          bool
+	MCPRuntimeBackend       string
+	MCPImagePullSecrets     []string
+	MCPHTTPWebhookBaseImage string
+	MessagePoliciesEnabled  bool
+	EnableAgents            *bool
+	AgentBackend            agentbackend.Backend
+	AgentBackendKind        string
+	// AgentDevRouter reaches sandboxes from outside the cluster. It is set only
+	// in development; in production Obot runs in-cluster and the sandbox address
+	// resolves directly.
+	AgentDevRouter                       agentconnect.DevRouter
 	MCPNetworkPolicyEnabled              bool
 	MCPDefaultDenyAllEgress              bool
 	MCPServerSearchImage                 string
@@ -488,7 +516,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	if config.ElectionFile != "" {
 		electionConfig = leader.NewFileElectionConfig(config.ElectionFile)
 	} else {
-		electionConfig = leader.NewDefaultElectionConfig("", "obot-controller", restConfig)
+		electionConfig = leader.NewDefaultElectionConfig("", "obot-controller", leaderElectionRESTConfig(restConfig))
 	}
 	r, err := nah.NewRouter("obot-controller", &nah.Options{
 		RESTConfig:     restConfig,
@@ -547,11 +575,17 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		serviceAccountIssuerURL   string
 		serviceAccountIssuerError string
 	)
-	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+	// Hosted agents can require a cluster independently of how MCP servers run,
+	// so either feature is reason enough to build a local config.
+	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) || hostedAgentsNeedK8s(config) {
 		localK8sConfig, err = BuildLocalK8sConfig()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build local Kubernetes config: %w", err)
 		}
+	}
+	if localK8sConfig != nil && mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+		// Image pull secret issuance is an MCP concern and has no bearing on
+		// hosted agents.
 		serviceAccountIssuerURL, err = imagepullsecrets.DiscoverServiceAccountIssuer(ctx, localK8sConfig)
 		if err != nil {
 			serviceAccountIssuerError = err.Error()
@@ -673,7 +707,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 			// The router is scoped to the MCP namespace, but the managed provider token
 			// secret lives in Obot's runtime namespace.
 			ByObject:       localK8sCacheByObject(config.MCPNamespace, config.ServiceNamespace),
-			ElectionConfig: leader.NewDefaultElectionConfig(config.MCPNamespace, "obot-local-controller", localK8sConfig),
+			ElectionConfig: leader.NewDefaultElectionConfig(config.MCPNamespace, "obot-local-controller", leaderElectionRESTConfig(localK8sConfig)),
 			HealthzPort:    -1, // Disable healthz port
 		})
 		if err != nil {
@@ -1061,6 +1095,81 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	}
 
 	authorizer := authz.NewAuthorizer(gatewayClient, r.Backend(), storageClient, config.DevMode, acrHelper, skillAccessRuleHelper, hostedAgentAccessRuleHelper, registryNoAuth)
+
+	// The kubernetes agent backend needs a client to the local cluster even when
+	// MCP servers do not run there -- the "hosted agents get the client
+	// directly" case the comment further down anticipates. It reuses the MCP
+	// client when one exists, and otherwise builds its own from the same
+	// config, so hosted agents work with a docker MCP backend without switching
+	// on the MCP-scoped router and its handlers.
+	agentLocalK8sClient := apiLocalK8sClient
+	if agentLocalK8sClient == nil && hostedAgentsNeedK8s(config) {
+		agentLocalK8sClient, err = kclient.NewWithWatch(localK8sConfig, kclient.Options{Scheme: k8sscheme.Scheme})
+		if err != nil {
+			return nil, fmt.Errorf("failed to build local k8s client for the agent backend: %w", err)
+		}
+	}
+	agentBackendKind, agentBackend, err := newHostedAgentsBackend(config, localK8sConfig, agentLocalK8sClient, localCacheClient)
+	if err != nil {
+		return nil, err
+	}
+
+	// Where a sandbox finds Obot depends on where Obot itself is running, and
+	// the two cases need different answers.
+	//
+	// In the cluster, the configured hostname resolving is not enough: it has to
+	// resolve somewhere a sandbox is permitted to reach, and the egress policy
+	// shipped with the chart excludes private ranges, so a hostname pointing at
+	// an internal load balancer or a node is refused even though it resolves.
+	// MCP servers have always answered this by addressing Obot's Service, and a
+	// sandbox reaches Obot for the same things, so TransformObotHostname gives
+	// it the same address rather than inventing a second mechanism.
+	//
+	// Outside the cluster -- a developer running Obot on their own machine --
+	// that method cannot answer at all: it substitutes Obot's Service, and there
+	// is no Service, so ServiceName is unset and it returns the hostname
+	// untouched. The hostname is a loopback address, which inside a sandbox
+	// means the sandbox. A node stands in for the developer's machine, since
+	// Obot listens on all of its interfaces, which is what ReachableServerURL
+	// resolves. It leaves any non-loopback hostname alone, so the in-cluster
+	// case falls through to the method above.
+	agentServerURL := config.Hostname
+	if agentBackendKind == "kubernetes" && agentLocalK8sClient != nil {
+		reachable, err := agentbackendkubernetes.ReachableServerURL(ctx, agentLocalK8sClient, config.Hostname)
+		if err != nil {
+			return nil, err
+		}
+		if reachable != config.Hostname {
+			agentServerURL = reachable
+		} else {
+			agentServerURL = mcpSessionManager.TransformObotHostname(config.Hostname)
+		}
+		if agentServerURL != config.Hostname {
+			pkgLog.Infof("hosted agent sandboxes will reach Obot at %s", agentServerURL)
+		}
+	}
+
+	// Running outside the cluster is what makes a sandbox unreachable, and it is
+	// exactly what falling back to a kubeconfig means. Reaching one through the
+	// API server needs services/proxy, which grants access to every Service in
+	// the cluster, so this is deliberately confined to development rather than
+	// something a production deployment is granted.
+	var agentDevRouter agentconnect.DevRouter
+	if router, ok := agentBackend.(agentconnect.DevRouter); ok && config.DevMode {
+		if _, inClusterErr := rest.InClusterConfig(); inClusterErr != nil {
+			agentDevRouter = router
+		}
+	}
+
+	// LocalK8sClient drives MCP-side cluster features: service account key
+	// rotation, image pull secret issuance, network policies. Hosted agents get
+	// the client directly, so this stays nil when MCP does not run on
+	// Kubernetes. Otherwise enabling hosted agents alone would switch on MCP
+	// machinery that needs configuration the deployment has no reason to set.
+	var mcpLocalK8sClient kclient.WithWatch
+	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+		mcpLocalK8sClient = apiLocalK8sClient
+	}
 	// For now, always auto-migrate the gateway database
 	svcs := &Services{
 		EncryptionConfig:      encryptionConfig,
@@ -1098,6 +1207,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		PostgresDSN:                  postgresDSN,
 		ObotNamespace:                config.ServiceNamespace,
 		DevUIPort:                    devPort,
+		DevMode:                      config.DevMode,
 		UserUIPort:                   config.UserUIPort,
 		ProviderRegistryPaths:        config.ProviderRegistries,
 		GatewayServer:                gatewayServer,
@@ -1110,6 +1220,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		DefaultSystemMCPCatalogPath:    config.DefaultSystemMCPCatalogPath,
 		DefaultSkillRepoURL:            config.DefaultSkillRepoURL,
 		DefaultSkillRepoRef:            config.DefaultSkillRepoRef,
+		DefaultHostedAgentsCatalogURL:  config.DefaultHostedAgentsCatalogURL,
+		DefaultHostedAgentsCatalogRef:  config.DefaultHostedAgentsCatalogRef,
 		ModelInfoSourceURL:             config.ModelInfoSourceURL,
 		MCPOAuthClientSecretExpiration: oauthClientExpiration,
 		ForceDynamicClient:             config.ForceDynamicClient,
@@ -1117,7 +1229,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		ModelAccessPolicyHelper:        mapHelper,
 
 		SkillAccessRuleHelper:                skillAccessRuleHelper,
-		LocalK8sClient:                       apiLocalK8sClient,
+		HostedAgentAccessRuleHelper:          hostedAgentAccessRuleHelper,
+		LocalK8sClient:                       mcpLocalK8sClient,
 		LocalRouter:                          localRouter,
 		EveryReplicaRouter:                   tunnelPeerRouter,
 		MCPServerNamespace:                   config.MCPNamespace,
@@ -1140,6 +1253,10 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		AgentIdleServerShutdownInterval:      time.Duration(config.IdleAgentShutdownHours) * time.Hour,
 		MessagePoliciesEnabled:               config.EnableMessagePolicies,
 		EnableAgents:                         config.EnableAgents,
+		AgentBackend:                         agentBackend,
+		AgentServerURL:                       agentServerURL,
+		AgentBackendKind:                     agentBackendKind,
+		AgentDevRouter:                       agentDevRouter,
 		MCPNetworkPolicyEnabled:              mcpNetworkPolicyEnabled,
 		MCPDefaultDenyAllEgress:              config.MCPDefaultDenyAllEgress,
 		MCPServerSearchImage:                 config.MCPServerSearchImage,
@@ -1280,6 +1397,82 @@ func configureDevMode(config Config) (int, Config) {
 	_ = os.Setenv("NAH_DEV_MODE", "true")
 	_ = os.Setenv("WORKSPACE_PROVIDER_IGNORE_WORKSPACE_NOT_FOUND", "true")
 	return config.DevUIPort, config
+}
+
+func leaderElectionRESTConfig(config *rest.Config) *rest.Config {
+	config = rest.CopyConfig(config)
+	if config.Timeout == 0 || config.Timeout > leaderElectionRequestTimeout {
+		config.Timeout = leaderElectionRequestTimeout
+	}
+	return config
+}
+
+// resolveHostedAgentsBackendKind applies the default so that callers which need to know
+// the backend before it is constructed agree with newHostedAgentsBackend.
+//
+// Unset follows the MCP runtime, because a deployment that already runs MCP
+// servers on a cluster has everything hosted agents need and would otherwise
+// have to name the same backend twice.
+//
+// A docker MCP runtime resolves to the fake backend for now, because there is
+// no docker agent backend yet. When one lands, this is where it goes: the
+// docker case becomes "docker" and the fallback stops being a placeholder.
+func resolveHostedAgentsBackendKind(config Config) string {
+	kind := strings.ToLower(strings.TrimSpace(config.HostedAgentsBackend))
+	if kind != "" {
+		return kind
+	}
+	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+		return "kubernetes"
+	}
+	return "fake"
+}
+
+func hostedAgentsNeedK8s(config Config) bool {
+	switch resolveHostedAgentsBackendKind(config) {
+	case "kubernetes", "k8s":
+		return true
+	default:
+		return false
+	}
+}
+
+func newHostedAgentsBackend(config Config, restConfig *rest.Config, client, cachedClient kclient.Client) (string, agentbackend.Backend, error) {
+	kind := resolveHostedAgentsBackendKind(config)
+
+	switch kind {
+	case "disabled":
+		return kind, agentbackend.Disabled{}, nil
+	case "fake":
+		return kind, agentbackendfake.New(agentbackendfake.Config{
+			TransitionDelay: time.Second,
+		}), nil
+	case "kubernetes", "k8s":
+		if client == nil {
+			return "", nil, fmt.Errorf("agent backend %q requires a local Kubernetes cluster, but no local K8s config is available", kind)
+		}
+		backend, err := agentbackendkubernetes.New(client, cachedClient, agentbackendkubernetes.Options{
+			// Sandboxes share the MCP namespace so that the existing local
+			// cluster router, which is scoped to it, sees them. Pools are
+			// separated by PriorityClass rather than by namespace.
+			Namespace:        config.MCPNamespace,
+			ClusterDomain:    config.MCPClusterDomain,
+			StorageClassName: config.HostedAgentsStorageClassName,
+			// Sandboxes share the MCP namespace, so they are admitted against
+			// whatever Pod Security level that namespace carries.
+			PodSecurityLevel: agentbackendkubernetes.ParsePodSecurityLevel(config.HostedAgentsPodSecurityLevel),
+			ImagePullSecrets: config.MCPImagePullSecrets,
+			CleanupImage:     config.HostedAgentsCleanupImage,
+			ImagePullPolicy:  config.HostedAgentsImagePullPolicy,
+			RESTConfig:       restConfig,
+		})
+		if err != nil {
+			return "", nil, err
+		}
+		return "kubernetes", backend, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported agent backend %q (expected disabled, fake, or kubernetes)", kind)
+	}
 }
 
 func startDevMode(ctx context.Context, storageClient storage.Client) {

--- a/pkg/services/config_test.go
+++ b/pkg/services/config_test.go
@@ -1,13 +1,107 @@
 package services
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/obot-platform/obot/pkg/agentbackend"
 	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
 )
+
+func TestNewAgentBackend(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       string
+		mcpBackend string
+		devMode    bool
+		wantKind   string
+		wantErr    bool
+		wantActive bool
+	}{
+		// Unset follows the MCP runtime rather than defaulting on its own, so a
+		// deployment names its backend once. There is no docker agent backend,
+		// so a docker MCP runtime lands on fake.
+		{name: "unset follows a docker MCP runtime", mcpBackend: "docker", wantKind: "fake", wantActive: true},
+		{name: "unset with no MCP runtime configured", wantKind: "fake", wantActive: true},
+		{name: "unset follows a kubernetes MCP runtime", mcpBackend: "kubernetes", wantErr: true},
+		{name: "unset follows the k8s alias", mcpBackend: "k8s", wantErr: true},
+		{name: "development defaults fake", devMode: true, wantKind: "fake", wantActive: true},
+		// An explicit value always wins over the MCP runtime, in both directions.
+		{name: "explicit disabled under a kubernetes MCP runtime", kind: "disabled", mcpBackend: "kubernetes", wantKind: "disabled"},
+		{name: "explicit disabled in development", kind: "disabled", devMode: true, wantKind: "disabled"},
+		{name: "explicit fake", kind: "FAKE", wantKind: "fake", wantActive: true},
+		// The Kubernetes backend needs a cluster, so selecting it without one
+		// has to fail at startup rather than at the first reconcile.
+		{name: "kubernetes without a cluster", kind: "kubernetes", wantErr: true},
+		{name: "explicit kubernetes under a docker MCP runtime", kind: "kubernetes", mcpBackend: "docker", wantErr: true},
+		{name: "discobox removed", kind: "discobox", wantErr: true},
+		{name: "unknown", kind: "other", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := Config{
+				HostedAgentsBackend: tt.kind,
+				DevMode:             tt.devMode,
+			}
+			config.MCPRuntimeBackend = tt.mcpBackend
+			kind, backend, err := newHostedAgentsBackend(config, nil, nil, nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if kind != tt.wantKind {
+				t.Fatalf("expected kind %q, got %q", tt.wantKind, kind)
+			}
+			_, err = backend.ObserveInstance(t.Context(), agentbackend.InstanceRef{ID: "test"})
+			if tt.wantActive && errors.Is(err, agentbackend.ErrDisabled) {
+				t.Fatal("expected an active backend")
+			}
+			if !tt.wantActive && !errors.Is(err, agentbackend.ErrDisabled) {
+				t.Fatalf("expected disabled backend, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLeaderElectionRESTConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeout  time.Duration
+		expected time.Duration
+	}{
+		{name: "unset", expected: leaderElectionRequestTimeout},
+		{name: "longer", timeout: time.Minute, expected: leaderElectionRequestTimeout},
+		{name: "shorter", timeout: time.Second, expected: time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := &rest.Config{Timeout: tt.timeout}
+			result := leaderElectionRESTConfig(original)
+
+			if result == original {
+				t.Fatal("expected the REST config to be copied")
+			}
+			if result.Timeout != tt.expected {
+				t.Fatalf("expected timeout %s, got %s", tt.expected, result.Timeout)
+			}
+			if original.Timeout != tt.timeout {
+				t.Fatalf("original timeout changed from %s to %s", tt.timeout, original.Timeout)
+			}
+		})
+	}
+}
 
 func TestParsePodSchedulingSettingsFromHelm(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
The backend is selected by configuration: disabled unless asked for, fake in
development, and Kubernetes when a cluster is available.

The Kubernetes backend needs a client for the local cluster even when MCP
servers do not run there, which is the case a developer hits first: hosted
agents on a cluster, MCP servers on Docker. It builds its own client from the
same config rather than borrowing the MCP one, so enabling hosted agents does
not switch on MCP machinery a deployment has no reason to configure.



---

Part 6 of an 11-PR stack. Base: `feat/hosted-agents-05-terminal-connect`.

## Stack

1. #7459 — Resource model
2. #7460 — Sandbox backend interface
3. #7461 — Kubernetes sandbox backend
4. #7462 — Sandbox reachability (models + MCP)
5. #7463 — Terminal + HTTP publish
**→ 6. #7464 — Server wiring + Helm** (this PR)
7. #7465 — Controllers / reconcilers
8. #7466 — REST API
9. #7467 — Admin UI
10. #7468 — User UI
11. #7469 — Seed default config source

Merge bottom-up; GitHub retargets each child when its parent merges.
