### PR TITLE
feat: reconcile hosted agents, pools and config sources (7/11)

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -108,6 +108,24 @@ Set name of namespace to use for mcp servers
 {{- end -}}
 
 {{/*
+Whether Obot runs workloads on Kubernetes.
+
+This gates the sandbox namespace, its RBAC and its network policy. Hosted agent
+sandboxes share that namespace with MCP servers and follow the same backend --
+the chart deliberately does not expose a separate agent backend setting, because
+a real deployment always wants the two to match. Overriding one without the
+other is a local development case, handled by setting the server flag directly.
+
+The k8s alias is accepted here because pkg/mcp accepts it: gating on the long
+spelling alone would leave a "k8s" deployment running on a cluster with no
+namespace and no permissions.
+*/}}
+{{- define "obot.mcpOnKubernetes" -}}
+{{- $backend := .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND | default "" | toString | lower -}}
+{{- if or (eq $backend "kubernetes") (eq $backend "k8s") -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Generate comma-separated list of MCP image pull secret names
 */}}
 {{- define "obot.config.mcpImagePullSecrets" -}}

--- a/chart/templates/internal-configmap.yaml
+++ b/chart/templates/internal-configmap.yaml
@@ -16,10 +16,20 @@ data:
   {{ $key }}: {{ toString $value | quote }}
   {{- end }}
   {{- end }}
-  {{- if eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes" }}
+  {{- if include "obot.mcpOnKubernetes" . }}
+  # Hosted agent sandboxes share this namespace, so leaving it unset would send
+  # the agent backend to its own default namespace, which this chart never
+  # creates and grants no permissions on.
   OBOT_SERVER_MCPNAMESPACE: {{ include "obot.config.mcpNamespace" . | quote }}
   OBOT_SERVER_SERVICE_NAME: {{ include "obot.fullname" . | quote }}
   OBOT_SERVER_SERVICE_NAMESPACE: {{ .Release.Namespace | quote }}
+  {{- if not .Values.config.OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL }}
+  # Sandboxes are admitted against the namespace's Pod Security level, so the
+  # backend is told what that level is rather than being configured separately
+  # and left to drift out of agreement with the label above. Setting
+  # config.OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL explicitly overrides this.
+  OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL: {{ if .Values.mcpNamespace.podSecurity.enabled }}{{ .Values.mcpNamespace.podSecurity.enforce | quote }}{{ else }}"privileged"{{ end }}
+  {{- end }}
   {{- end }}
   {{- if .Values.mcpServerDefaults.affinity }}
   OBOT_SERVER_MCPK8S_SETTINGS_AFFINITY: {{ .Values.mcpServerDefaults.affinity | toJson | quote }}

--- a/chart/templates/mcp.yaml
+++ b/chart/templates/mcp.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes" }}
+{{- if include "obot.mcpOnKubernetes" . }}
 {{- include "obot.validatePodSecurityLevels" . -}}
 apiVersion: v1
 kind: Namespace
@@ -54,6 +54,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list", "watch"]
+  # The hosted agent terminal joins a sandbox's console. It attaches to the
+  # container the harness was started with rather than exec'ing a second
+  # process, so this is pods/attach and not pods/exec.
+  - apiGroups: [""]
+    resources: ["pods/attach"]
+    verbs: ["create", "get"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
@@ -63,10 +69,71 @@ rules:
   - apiGroups: ["networking.aviatrix.com"]
     resources: ["firewallpolicies"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # ResourceQuota access for capacity info
+  # ResourceQuota access for capacity info, and for hosted agent pools,
+  # whose pool budgets are ResourceQuotas scoped to a per-pool PriorityClass.
   - apiGroups: [""]
     resources: ["resourcequotas"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  # Hosted agent sandbox volume cleanup runs as a Job.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+
+---
+# PriorityClasses are cluster-scoped, so the per-pool objects backing hosted
+# agent pools cannot live in a namespaced Role. Each one is created with
+# an owner reference to the sandbox namespace, so deleting that namespace
+# collects them.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-obot-agent-clusterrole
+  labels:
+    {{- include "obot.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  # Needed to read the sandbox namespace's UID when building those owner
+  # references, and to create it when hosted agents are the only Kubernetes
+  # feature enabled.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "get", "list", "watch"]
+  # Only read when Obot's own hostname is a loopback address, which is a
+  # developer running outside the cluster: a sandbox cannot reach 127.0.0.1, so
+  # a node address is substituted. Harmless to omit in production, where the
+  # configured hostname already resolves.
+  - apiGroups: [""]
+    resources: ["nodes"]
     verbs: ["get", "list"]
+  # Live per-sandbox CPU and memory for hosted agent pools.
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # Pool volume usage comes from kubelet's stats summary, reached through the
+  # API server proxy. This grant is broader than it looks -- nodes/proxy can
+  # reach other kubelet endpoints too -- so withhold it if pool disk reporting
+  # is not wanted. The backend degrades to omitting disk rather than failing.
+  - apiGroups: [""]
+    resources: ["nodes/proxy", "nodes/stats"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-obot-agent-clusterrolebinding
+  labels:
+    {{- include "obot.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "obot.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-obot-agent-clusterrole
+  apiGroup: rbac.authorization.k8s.io
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes") .Values.mcpNamespace.networkPolicy.enabled }}
+{{- if and (include "obot.mcpOnKubernetes" .) .Values.mcpNamespace.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.serviceAccount.create (eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes") }}
+{{- if or .Values.serviceAccount.create (include "obot.mcpOnKubernetes" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,6 +73,10 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure default user role setting: %w", err)
 	}
 
+	if err := ensureHostedAgentPoolDefaults(ctx, c.services.StorageClient); err != nil {
+		return fmt.Errorf("failed to ensure hosted agent pool defaults: %w", err)
+	}
+
 	resourceMaximums := c.services.MCPSessionManager.KubernetesResourceMaximums()
 	if err := ensureK8sSettings(ctx, c.services.StorageClient, c.services.PodSchedulingSettingsFromHelm, c.services.PSASettingsFromHelm, resourceMaximums); err != nil {
 		return fmt.Errorf("failed to ensure K8s settings: %w", err)
@@ -386,6 +390,40 @@ func ensureDefaultUserRoleSetting(ctx context.Context, client kclient.Client) er
 	return client.Update(ctx, &defaultRoleSetting)
 }
 
+func ensureHostedAgentPoolDefaults(ctx context.Context, client kclient.Client) error {
+	const gibibyte = int64(1024 * 1024 * 1024)
+
+	var defaults v1.HostedAgentPoolDefaults
+	key := kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: "default"}
+	if err := client.Get(ctx, key, &defaults); err == nil {
+		// Defaults are administrator-owned after creation.
+		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return client.Create(ctx, &v1.HostedAgentPoolDefaults{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+		Spec: v1.HostedAgentPoolDefaultsSpec{
+			Manifest: types.HostedAgentPoolDefaultsManifest{
+				Capacity: types.HostedAgentResourceQuantity{
+					CPUVCPUs:     1,
+					MemoryBytes:  4 * gibibyte,
+					StorageBytes: 20 * gibibyte,
+				},
+				// Seeded explicitly rather than left to the fallback, so an
+				// administrator opening the defaults sees the number that is
+				// actually in force. With the capacity above this gives each
+				// sandbox 250m CPU and 1GiB guaranteed.
+				MaxSandboxes: 4,
+			},
+		},
+	})
+}
+
 // ensureK8sSettings ensures the K8sSettings resource exists with proper configuration.
 // podSchedulingSettings: affinity, tolerations, resources, runtimeClassName - can be managed via Helm OR UI.
 //
@@ -572,7 +610,10 @@ func ensureAppPreferences(ctx context.Context, client kclient.Client) error {
 
 // setupLocalK8sRoutes sets up routes for the local Kubernetes router
 func (c *Controller) setupLocalK8sRoutes() {
-	if c.services.LocalRouter != nil {
+	// The local router now also exists when only hosted agents run on
+	// Kubernetes, so these are gated on the MCP backend rather than on the
+	// router: every one of them reconciles MCP state from cluster objects.
+	if c.services.LocalRouter != nil && mcp.IsKubernetesBackend(c.services.MCPRuntimeBackend) {
 		resourceMaximums := c.services.MCPSessionManager.KubernetesResourceMaximums()
 		deploymentHandler := deployment.New(c.services.MCPServerNamespace, c.services.Router.Backend(), c.services.MCPRuntimeBackend, resourceMaximums, c.services.MCPImagePullSecrets)
 		c.services.LocalRouter.Type(&appsv1.Deployment{}).IncludeRemoved().HandlerFunc(deploymentHandler.UpdateMCPServerStatus)
@@ -584,7 +625,6 @@ func (c *Controller) setupLocalK8sRoutes() {
 		// instead of waiting for the periodic service-account key rotation loop.
 		c.services.LocalRouter.Type(&corev1.Secret{}).Namespace(c.services.ServiceNamespace).Name(serviceaccounts.NetworkPolicySecretName).IncludeRemoved().HandlerFunc(c.reconcileServiceAccountSecretChange)
 	}
-
 	if c.services.EveryReplicaRouter != nil {
 		peerHandler := tunnelpeer.New(c.services.TunnelManager.ID, c.services.TunnelManager)
 		c.services.EveryReplicaRouter.Type(&corev1.Service{}).Namespace(c.services.TunnelManager.ServiceNamespace).Name(c.services.TunnelManager.ServiceName).HandlerFunc(peerHandler.Reconcile)

--- a/pkg/controller/data/data.go
+++ b/pkg/controller/data/data.go
@@ -26,6 +26,9 @@ var everythingAccessControlRuleData []byte
 //go:embed everything-skill-access-rule.yaml
 var everythingSkillAccessRuleData []byte
 
+//go:embed everything-hosted-agent-access-rule.yaml
+var everythingHostedAgentAccessRuleData []byte
+
 func Data(ctx context.Context, c kclient.Client, defaultSkillRepoURL, defaultSkillRepoRef string) error {
 	var defaultModelAliases v1.DefaultModelAliasList
 	if err := yaml.Unmarshal(defaultModelAliasesData, &defaultModelAliases); err != nil {
@@ -100,6 +103,15 @@ func Data(ctx context.Context, c kclient.Client, defaultSkillRepoURL, defaultSki
 		}
 
 		if err := kclient.IgnoreAlreadyExists(c.Create(ctx, &everythingSkillAccessRule)); err != nil {
+			return err
+		}
+
+		var everythingHostedAgentAccessRule v1.HostedAgentAccessRule
+		if err := yaml.Unmarshal(everythingHostedAgentAccessRuleData, &everythingHostedAgentAccessRule); err != nil {
+			return fmt.Errorf("failed to unmarshal everything hosted agent access rule: %w", err)
+		}
+
+		if err := kclient.IgnoreAlreadyExists(c.Create(ctx, &everythingHostedAgentAccessRule)); err != nil {
 			return err
 		}
 

--- a/pkg/controller/data/everything-hosted-agent-access-rule.yaml
+++ b/pkg/controller/data/everything-hosted-agent-access-rule.yaml
@@ -1,0 +1,14 @@
+apiVersion: obot.obot.ai/v1
+kind: HostedAgentAccessRule
+metadata:
+  name: haar1-everything
+  namespace: default
+spec:
+  manifest:
+    displayName: Everything
+    resources:
+      - id: '*'
+        type: selector
+    subjects:
+      - id: '*'
+        type: selector

--- a/pkg/controller/handlers/agentcatalog/agentcatalog.go
+++ b/pkg/controller/handlers/agentcatalog/agentcatalog.go
@@ -1,0 +1,655 @@
+// Package agentcatalog syncs hosted agents and harnesses from a git repository,
+// mirroring the skillrepository package for skills.
+//
+// ID alignment: a repository cannot know the generated resource names its
+// harnesses will be stored under, so discovered agents reference harnesses by
+// the harness's relative path within the same source. Stored object names are
+// deterministic (harnessObjectName), and resolveHarnessReferences rewrites
+// each path reference to that name before anything is persisted. A reference
+// that already carries the harness ID prefix is passed through untouched — it
+// names a harness registered outside the source.
+package agentcatalog
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/obot-platform/nah/pkg/name"
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/logger"
+	gitpkg "github.com/obot-platform/obot/pkg/git"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+var log = logger.Package()
+
+const (
+	syncInterval       = time.Hour
+	harnessDefinition  = "harness.yaml"
+	agentDefinition    = "agent.yaml"
+	maxDefinitionBytes = 1024 * 1024
+	maxDefinitions     = 1000
+)
+
+// fetchedSource is what a real fetcher would hand back: a checked out copy of
+// the repository plus the commit it resolved to.
+type fetchedSource struct {
+	RepoRoot  string
+	CommitSHA string
+	Cleanup   func()
+}
+
+type sourceFetcher interface {
+	Fetch(ctx context.Context, repoURL, ref string) (*fetchedSource, error)
+}
+
+type gitSourceFetcher struct{}
+
+func (gitSourceFetcher) Fetch(ctx context.Context, repoURL, ref string) (*fetchedSource, error) {
+	if localPath, ok, err := localRepositoryPath(repoURL); err != nil {
+		return nil, err
+	} else if ok {
+		return fetchLocalRepository(localPath, ref)
+	}
+
+	dir, commitSHA, cleanup, err := gitpkg.Clone(ctx, repoURL, "", ref)
+	if err != nil {
+		return nil, err
+	}
+	return &fetchedSource{
+		RepoRoot:  dir,
+		CommitSHA: commitSHA,
+		Cleanup:   cleanup,
+	}, nil
+}
+
+type Handler struct {
+	fetcher sourceFetcher
+	now     func() time.Time
+}
+
+func New() *Handler {
+	return &Handler{
+		fetcher: gitSourceFetcher{},
+		now:     time.Now,
+	}
+}
+
+func (h *Handler) Sync(req router.Request, resp router.Response) error {
+	source := req.Object.(*v1.AgentCatalog)
+	namespace := source.Namespace
+
+	forceSync := source.Annotations[v1.AgentCatalogSyncAnnotation] == "true"
+	// A source observed by the former placeholder fetcher has a sync time but
+	// no resolved commit. Do not throttle it after upgrading to the real
+	// backend; reconcile it immediately.
+	if !forceSync && source.Status.ResolvedCommitSHA != "" && !source.Status.LastSyncTime.IsZero() {
+		timeSinceLastSync := h.now().Sub(source.Status.LastSyncTime.Time)
+		if timeSinceLastSync < syncInterval {
+			resp.RetryAfter(syncInterval - timeSinceLastSync)
+			return nil
+		}
+	}
+
+	source.Status.IsSyncing = true
+	if err := req.Client.Status().Update(req.Ctx, source); err != nil {
+		return fmt.Errorf("failed to mark agent catalog syncing: %w", err)
+	}
+
+	defer h.clearIsSyncing(req.Ctx, req.Client, namespace, source.Name)
+
+	fetched, err := h.fetcher.Fetch(req.Ctx, source.Spec.RepoURL, source.Spec.Ref)
+	if err != nil {
+		if statusErr := h.recordFailure(req.Ctx, req.Client, namespace, source.Name, err); statusErr != nil {
+			return statusErr
+		}
+		resp.RetryAfter(syncInterval)
+		return nil
+	}
+	defer fetched.Cleanup()
+
+	found, err := buildFromSource(fetched.RepoRoot, source, fetched.CommitSHA)
+	if err == nil {
+		err = resolveHarnessReferences(found.Agents, found.Harnesses)
+	}
+	if err == nil {
+		err = syncDiscovered(req.Ctx, req.Client, namespace, source.Name, found)
+	}
+	if err != nil {
+		if statusErr := h.recordFailure(req.Ctx, req.Client, namespace, source.Name, err); statusErr != nil {
+			return statusErr
+		}
+		resp.RetryAfter(syncInterval)
+		return nil
+	}
+
+	if err := h.recordSuccess(req.Ctx, req.Client, namespace, source.Name, fetched.CommitSHA, len(found.Agents), len(found.Harnesses)); err != nil {
+		return err
+	}
+
+	if forceSync {
+		if err := clearSyncAnnotation(req.Ctx, req.Client, namespace, source.Name); err != nil {
+			return err
+		}
+	}
+
+	resp.RetryAfter(syncInterval)
+	return nil
+}
+
+// discovered is everything one sync of a source yields: harnesses and the
+// agents built on them.
+type discovered struct {
+	Harnesses []*v1.Harness
+	Agents    []*v1.HostedAgent
+}
+
+// buildFromSource recursively discovers strict YAML manifests. Symlinks and
+// .git metadata are ignored so definitions cannot escape the checked-out
+// repository or accidentally ingest Git internals.
+func buildFromSource(repoRoot string, source *v1.AgentCatalog, commitSHA string) (*discovered, error) {
+	definitions, err := discoverDefinitions(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &discovered{}
+	for _, definition := range definitions {
+		relPath, err := filepath.Rel(repoRoot, definition.path)
+		if err != nil {
+			return nil, fmt.Errorf("determine repository-relative definition path: %w", err)
+		}
+		relPath = filepath.ToSlash(relPath)
+
+		switch definition.kind {
+		case harnessDefinition:
+			var manifest types.HarnessManifest
+			if err := readDefinition(definition.path, &manifest); err != nil {
+				return nil, fmt.Errorf("%s: %w", relPath, err)
+			}
+			if err := manifest.Validate(); err != nil {
+				return nil, fmt.Errorf("%s: invalid harness: %w", relPath, err)
+			}
+			result.Harnesses = append(result.Harnesses, &v1.Harness{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "Harness",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      harnessObjectName(source.Name, relPath),
+					Namespace: source.Namespace,
+				},
+				Spec: v1.HarnessSpec{
+					Manifest:     manifest,
+					SourceID:     source.Name,
+					RelativePath: relPath,
+					CommitSHA:    commitSHA,
+				},
+			})
+		case agentDefinition:
+			var manifest types.HostedAgentManifest
+			if err := readDefinition(definition.path, &manifest); err != nil {
+				return nil, fmt.Errorf("%s: %w", relPath, err)
+			}
+			if err := manifest.Validate(); err != nil {
+				return nil, fmt.Errorf("%s: invalid hosted agent: %w", relPath, err)
+			}
+			for _, env := range manifest.Env {
+				if env.Sensitive && env.Value != "" {
+					return nil, fmt.Errorf("%s: sensitive environment value %s must not be stored in source control", relPath, env.Key)
+				}
+			}
+			result.Agents = append(result.Agents, &v1.HostedAgent{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "HostedAgent",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      agentObjectName(source.Name, relPath),
+					Namespace: source.Namespace,
+				},
+				Spec: v1.HostedAgentSpec{
+					Manifest:     manifest,
+					SourceID:     source.Name,
+					RelativePath: relPath,
+					CommitSHA:    commitSHA,
+				},
+			})
+		}
+	}
+
+	return result, nil
+}
+
+type sourceDefinition struct {
+	path string
+	kind string
+}
+
+func discoverDefinitions(repoRoot string) ([]sourceDefinition, error) {
+	var result []sourceDefinition
+	err := filepath.WalkDir(repoRoot, func(currentPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() && entry.Name() == ".git" {
+			return filepath.SkipDir
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		switch entry.Name() {
+		case harnessDefinition, agentDefinition:
+			if len(result) >= maxDefinitions {
+				return fmt.Errorf("too many agent catalog definitions (limit: %d)", maxDefinitions)
+			}
+			result = append(result, sourceDefinition{path: currentPath, kind: entry.Name()})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discover agent catalog definitions: %w", err)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].path < result[j].path
+	})
+	return result, nil
+}
+
+func readDefinition(path string, target any) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open definition: %w", err)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxDefinitionBytes+1))
+	if err != nil {
+		return fmt.Errorf("read definition: %w", err)
+	}
+	if len(content) > maxDefinitionBytes {
+		return fmt.Errorf("definition exceeds maximum size of %d bytes", maxDefinitionBytes)
+	}
+	if err := yaml.UnmarshalStrict(content, target); err != nil {
+		return fmt.Errorf("parse definition: %w", err)
+	}
+	return nil
+}
+
+func localRepositoryPath(repoURL string) (string, bool, error) {
+	repoURL = strings.TrimSpace(repoURL)
+	if filepath.IsAbs(repoURL) {
+		return filepath.Clean(repoURL), true, nil
+	}
+	parsed, err := url.Parse(repoURL)
+	if err != nil {
+		return "", false, fmt.Errorf("parse agent catalog URL: %w", err)
+	}
+	if parsed.Scheme != "file" {
+		return "", false, nil
+	}
+	if parsed.Host != "" && parsed.Host != "localhost" {
+		return "", false, fmt.Errorf("file repository host must be empty or localhost")
+	}
+	path, err := url.PathUnescape(parsed.Path)
+	if err != nil {
+		return "", false, fmt.Errorf("decode file repository path: %w", err)
+	}
+	if !filepath.IsAbs(path) {
+		return "", false, fmt.Errorf("file repository path must be absolute")
+	}
+	return filepath.Clean(path), true, nil
+}
+
+func fetchLocalRepository(repoRoot, ref string) (*fetchedSource, error) {
+	info, err := os.Stat(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("inspect local repository: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("local repository %s is not a directory", repoRoot)
+	}
+
+	repository, err := gogit.PlainOpen(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open local Git repository: %w", err)
+	}
+	head, err := repository.Head()
+	if err != nil {
+		return nil, fmt.Errorf("resolve local repository HEAD: %w", err)
+	}
+	if ref != "" {
+		hash, err := resolveLocalRef(repository, ref)
+		if err != nil {
+			return nil, err
+		}
+		if hash != head.Hash() {
+			return nil, fmt.Errorf("local repository ref %q resolves to %s but the checked-out worktree is at %s; check out the requested ref first", ref, hash, head.Hash())
+		}
+	}
+
+	return &fetchedSource{
+		RepoRoot:  repoRoot,
+		CommitSHA: head.Hash().String(),
+		Cleanup:   func() {},
+	}, nil
+}
+
+func resolveLocalRef(repository *gogit.Repository, ref string) (plumbing.Hash, error) {
+	if plumbing.IsHash(ref) {
+		hash := plumbing.NewHash(ref)
+		if _, err := repository.CommitObject(hash); err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("resolve local repository commit %q: %w", ref, err)
+		}
+		return hash, nil
+	}
+	for _, candidate := range []plumbing.ReferenceName{
+		plumbing.NewBranchReferenceName(ref),
+		plumbing.NewTagReferenceName(ref),
+		plumbing.ReferenceName(ref),
+	} {
+		reference, err := repository.Reference(candidate, true)
+		if err == nil {
+			return reference.Hash(), nil
+		}
+	}
+	return plumbing.ZeroHash, fmt.Errorf("local repository ref %q was not found", ref)
+}
+
+// resolveHarnessReferences rewrites each discovered agent's harness reference
+// to the object name of the harness discovered alongside it. This is the ID
+// alignment step: repositories reference harnesses by relative path because
+// they cannot know generated resource names, and object names are
+// deterministic, so the same path resolves to the same resource on every
+// sync. An unknown reference fails the whole sync — better a visible sync
+// error than a stored agent pointing at nothing.
+func resolveHarnessReferences(agents []*v1.HostedAgent, harnesses []*v1.Harness) error {
+	byPath := make(map[string]string, len(harnesses))
+	for _, harness := range harnesses {
+		byPath[harness.Spec.RelativePath] = harness.Name
+	}
+
+	for _, agent := range agents {
+		ref := agent.Spec.Manifest.HarnessID
+		if ref == "" {
+			return fmt.Errorf("agent %s does not name a harness", agent.Spec.RelativePath)
+		}
+		if strings.HasPrefix(ref, system.HarnessPrefix) {
+			continue
+		}
+		resolved, ok := byPath[ref]
+		if !ok {
+			return fmt.Errorf("agent %s references harness %q, which this source does not contain", agent.Spec.RelativePath, ref)
+		}
+		agent.Spec.Manifest.HarnessID = resolved
+	}
+
+	return nil
+}
+
+// syncDiscovered reconciles both kinds in an order that keeps references
+// intact at every step: new harnesses are stored before the agents that
+// reference them, and stale agents are removed before the harnesses they
+// referenced.
+func syncDiscovered(ctx context.Context, c client.Client, namespace, sourceID string, found *discovered) error {
+	staleHarnesses, err := upsertHarnesses(ctx, c, namespace, sourceID, found.Harnesses)
+	if err != nil {
+		return err
+	}
+
+	if err := upsertAgents(ctx, c, namespace, sourceID, found.Agents); err != nil {
+		return err
+	}
+
+	for _, harness := range staleHarnesses {
+		// A harness the source dropped can still be referenced by an agent
+		// registered outside it. Leave it in place rather than dangling that
+		// agent; it keeps its SourceID, so a later sync retries once the
+		// reference is gone.
+		var agents v1.HostedAgentList
+		if err := c.List(ctx, &agents, client.InNamespace(namespace), client.MatchingFields{"spec.harnessID": harness.Name}); err != nil {
+			return fmt.Errorf("failed to list agents for harness %s: %w", harness.Name, err)
+		}
+		if len(agents.Items) > 0 {
+			log.Infof("keeping harness %s dropped by source %s: still referenced by %d agent(s)", harness.Name, sourceID, len(agents.Items))
+			continue
+		}
+
+		if err := c.Delete(ctx, harness); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete harness %s: %w", harness.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// upsertHarnesses creates and updates the harnesses a source claims. Stale
+// ones — stored for this source but no longer listed by it — are returned
+// rather than deleted, so the caller can remove them after the agents that
+// referenced them are gone. Harnesses registered by hand carry no SourceID
+// and are never listed here, so they are untouched.
+func upsertHarnesses(ctx context.Context, c client.Client, namespace, sourceID string, harnesses []*v1.Harness) ([]*v1.Harness, error) {
+	var list v1.HarnessList
+	if err := c.List(ctx, &list, client.InNamespace(namespace), client.MatchingFields{"spec.sourceID": sourceID}); err != nil {
+		return nil, fmt.Errorf("failed to list harnesses for source: %w", err)
+	}
+
+	existing := make(map[string]*v1.Harness, len(list.Items))
+	for i := range list.Items {
+		existing[list.Items[i].Name] = &list.Items[i]
+	}
+
+	desired := make(map[string]struct{}, len(harnesses))
+	for _, harness := range harnesses {
+		desired[harness.Name] = struct{}{}
+
+		current, ok := existing[harness.Name]
+		if !ok {
+			if err := c.Create(ctx, harness); err != nil {
+				return nil, fmt.Errorf("failed to create harness %s: %w", harness.Name, err)
+			}
+			continue
+		}
+
+		current.Spec = harness.Spec
+		if err := c.Update(ctx, current); err != nil {
+			return nil, fmt.Errorf("failed to update harness %s: %w", harness.Name, err)
+		}
+	}
+
+	var stale []*v1.Harness
+	for objectName, current := range existing {
+		if _, ok := desired[objectName]; !ok {
+			stale = append(stale, current)
+		}
+	}
+	return stale, nil
+}
+
+// harnessObjectName and agentObjectName give discovered resources stable,
+// deterministic names, copying the skillrepository scheme: the visible
+// portion is sanitized for RFC 1123, and a hash over the raw inputs keeps
+// paths that sanitize identically from colliding.
+func harnessObjectName(sourceID, relPath string) string {
+	return sourceObjectName(system.HarnessPrefix, sourceID, relPath)
+}
+
+func agentObjectName(sourceID, relPath string) string {
+	return sourceObjectName(system.HostedAgentPrefix, sourceID, relPath)
+}
+
+func sourceObjectName(prefix, sourceID, relPath string) string {
+	fragment := sanitizeNameFragment(relPath)
+	if fragment == "" {
+		fragment = "item"
+	}
+	d := sha256.New()
+	for _, part := range []string{prefix, sourceID, fragment, relPath} {
+		d.Write([]byte(part))
+		d.Write([]byte{0})
+	}
+	suffix := hex.EncodeToString(d.Sum(nil))[:8]
+	return name.SafeConcatName(prefix, sourceID, fragment, suffix)
+}
+
+func sanitizeNameFragment(value string) string {
+	replacer := strings.NewReplacer("/", "-", "_", "-", ".", "-", " ", "-")
+	value = strings.ToLower(replacer.Replace(value))
+
+	var b strings.Builder
+	lastDash := false
+	for _, ch := range value {
+		valid := (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')
+		if valid {
+			b.WriteRune(ch)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	return strings.Trim(b.String(), "-")
+}
+
+// upsertAgents reconciles the agents a source claims against the ones already
+// stored for it: create what is new, update what changed, delete what the source
+// no longer lists. Agents registered by hand carry no SourceID and are never
+// listed here, so they are untouched.
+func upsertAgents(ctx context.Context, c client.Client, namespace, sourceID string, agents []*v1.HostedAgent) error {
+	existing, err := listAgentsForSource(ctx, c, namespace, sourceID)
+	if err != nil {
+		return err
+	}
+
+	desired := make(map[string]*v1.HostedAgent, len(agents))
+	for _, agent := range agents {
+		desired[agent.Name] = agent
+	}
+
+	for _, agent := range agents {
+		current, ok := existing[agent.Name]
+		if !ok {
+			if err := c.Create(ctx, agent); err != nil {
+				return fmt.Errorf("failed to create hosted agent %s: %w", agent.Name, err)
+			}
+			continue
+		}
+
+		current.Spec = agent.Spec
+		if err := c.Update(ctx, current); err != nil {
+			return fmt.Errorf("failed to update hosted agent %s: %w", agent.Name, err)
+		}
+	}
+
+	for objectName, current := range existing {
+		if _, ok := desired[objectName]; ok {
+			continue
+		}
+		if err := c.Delete(ctx, current); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete hosted agent %s: %w", objectName, err)
+		}
+	}
+
+	return nil
+}
+
+func listAgentsForSource(ctx context.Context, c client.Client, namespace, sourceID string) (map[string]*v1.HostedAgent, error) {
+	var list v1.HostedAgentList
+	if err := c.List(ctx, &list, client.InNamespace(namespace), client.MatchingFields{"spec.sourceID": sourceID}); err != nil {
+		return nil, fmt.Errorf("failed to list agents for source: %w", err)
+	}
+
+	result := make(map[string]*v1.HostedAgent, len(list.Items))
+	for i := range list.Items {
+		result[list.Items[i].Name] = &list.Items[i]
+	}
+	return result, nil
+}
+
+func (h *Handler) recordFailure(ctx context.Context, c client.Client, namespace, name string, syncErr error) error {
+	var source v1.AgentCatalog
+	if err := c.Get(ctx, router.Key(namespace, name), &source); err != nil {
+		return fmt.Errorf("failed to reload agent catalog: %w", err)
+	}
+
+	source.Status.LastSyncTime = metav1.NewTime(h.now())
+	source.Status.SyncError = syncErr.Error()
+	return c.Status().Update(ctx, &source)
+}
+
+func (h *Handler) recordSuccess(ctx context.Context, c client.Client, namespace, sourceName, commitSHA string, agentCount, harnessCount int) error {
+	var source v1.AgentCatalog
+	if err := c.Get(ctx, router.Key(namespace, sourceName), &source); err != nil {
+		return fmt.Errorf("failed to reload agent catalog: %w", err)
+	}
+
+	source.Status.LastSyncTime = metav1.NewTime(h.now())
+	source.Status.SyncError = ""
+	source.Status.ResolvedCommitSHA = commitSHA
+	source.Status.DiscoveredAgentCount = agentCount
+	source.Status.DiscoveredHarnessCount = harnessCount
+	return c.Status().Update(ctx, &source)
+}
+
+func (h *Handler) clearIsSyncing(ctx context.Context, c client.Client, namespace, name string) {
+	var source v1.AgentCatalog
+	if err := c.Get(ctx, router.Key(namespace, name), &source); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Errorf("failed to reload agent catalog %s to clear syncing bit: %v", name, err)
+		}
+		return
+	}
+
+	if !source.Status.IsSyncing {
+		return
+	}
+
+	source.Status.IsSyncing = false
+	if err := c.Status().Update(ctx, &source); err != nil && !apierrors.IsNotFound(err) {
+		log.Errorf("failed to clear syncing bit for agent catalog %s: %v", name, err)
+	}
+}
+
+func clearSyncAnnotation(ctx context.Context, c client.Client, namespace, name string) error {
+	var source v1.AgentCatalog
+	if err := c.Get(ctx, router.Key(namespace, name), &source); err != nil {
+		return fmt.Errorf("failed to reload agent catalog for annotation cleanup: %w", err)
+	}
+
+	if source.Annotations == nil {
+		return nil
+	}
+	if _, ok := source.Annotations[v1.AgentCatalogSyncAnnotation]; !ok {
+		return nil
+	}
+
+	delete(source.Annotations, v1.AgentCatalogSyncAnnotation)
+	return c.Update(ctx, &source)
+}

--- a/pkg/controller/handlers/agentcatalog/agentcatalog_test.go
+++ b/pkg/controller/handlers/agentcatalog/agentcatalog_test.go
@@ -1,0 +1,225 @@
+package agentcatalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestBuildFromSource(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "harnesses", "basic"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "agents", "reviewer"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "harnesses", "basic", harnessDefinition), []byte(`
+name: Basic
+description: Test harness
+image: ubuntu:24.04
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "agents", "reviewer", agentDefinition), []byte(`
+name: Reviewer
+description: Reviews code
+harnessID: harnesses/basic/harness.yaml
+questions:
+  - key: focus
+    type: string
+`), 0o600))
+	// Other YAML files are not agent-catalog definitions, matching the explicit
+	// filename convention while retaining MCP catalog-style recursive loading.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ignored.yaml"), []byte("not: a definition"), 0o600))
+
+	source := &v1.AgentCatalog{
+		ObjectMeta: metav1.ObjectMeta{Name: "as1source", Namespace: "default"},
+	}
+	found, err := buildFromSource(root, source, "abc123")
+	require.NoError(t, err)
+	require.Len(t, found.Harnesses, 1)
+	require.Len(t, found.Agents, 1)
+
+	harness := found.Harnesses[0]
+	assert.Equal(t, "Basic", harness.Spec.Manifest.Name)
+	assert.Equal(t, "harnesses/basic/harness.yaml", harness.Spec.RelativePath)
+	assert.Equal(t, "abc123", harness.Spec.CommitSHA)
+	assert.Equal(t, source.Name, harness.Spec.SourceID)
+
+	agent := found.Agents[0]
+	assert.Equal(t, "Reviewer", agent.Spec.Manifest.Name)
+	assert.Equal(t, "agents/reviewer/agent.yaml", agent.Spec.RelativePath)
+	assert.Equal(t, "harnesses/basic/harness.yaml", agent.Spec.Manifest.HarnessID)
+
+	require.NoError(t, resolveHarnessReferences(found.Agents, found.Harnesses))
+	assert.Equal(t, harness.Name, agent.Spec.Manifest.HarnessID)
+}
+
+func TestBuildFromSourceRejectsInvalidDefinitions(t *testing.T) {
+	t.Run("unknown field", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, harnessDefinition), []byte(`
+name: Basic
+image: ubuntu:24.04
+unknown: value
+`), 0o600))
+
+		_, err := buildFromSource(root, &v1.AgentCatalog{
+			ObjectMeta: metav1.ObjectMeta{Name: "as1source"},
+		}, "abc123")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unknown"`)
+	})
+
+	t.Run("sensitive value", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, agentDefinition), []byte(`
+name: Unsafe
+harnessID: hrn1external
+env:
+  - key: TOKEN
+    sensitive: true
+    value: do-not-commit
+`), 0o600))
+
+		_, err := buildFromSource(root, &v1.AgentCatalog{
+			ObjectMeta: metav1.ObjectMeta{Name: "as1source"},
+		}, "abc123")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not be stored in source control")
+	})
+}
+
+func TestDiscoverDefinitionsSkipsGitAndSymlinks(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".git", agentDefinition), []byte("name: ignored"), 0o600))
+	target := filepath.Join(root, "outside.yaml")
+	require.NoError(t, os.WriteFile(target, []byte("name: ignored"), 0o600))
+	require.NoError(t, os.Symlink(target, filepath.Join(root, harnessDefinition)))
+
+	definitions, err := discoverDefinitions(root)
+	require.NoError(t, err)
+	assert.Empty(t, definitions)
+}
+
+func TestGitSourceFetcherLocalRepository(t *testing.T) {
+	root := t.TempDir()
+	repository, err := gogit.PlainInit(root, false)
+	require.NoError(t, err)
+	worktree, err := repository.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(root, harnessDefinition), []byte("name: Basic\nimage: ubuntu:24.04\n"), 0o600))
+	_, err = worktree.Add(harnessDefinition)
+	require.NoError(t, err)
+	commit, err := worktree.Commit("initial", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com"},
+	})
+	require.NoError(t, err)
+
+	fetcher := gitSourceFetcher{}
+	for _, repoURL := range []string{root, "file://" + filepath.ToSlash(root)} {
+		fetched, err := fetcher.Fetch(t.Context(), repoURL, "")
+		require.NoError(t, err)
+		assert.Equal(t, root, fetched.RepoRoot)
+		assert.Equal(t, commit.String(), fetched.CommitSHA)
+		fetched.Cleanup()
+	}
+}
+
+func discoveredHarness(sourceID, relPath string) *v1.Harness {
+	return &v1.Harness{
+		ObjectMeta: metav1.ObjectMeta{Name: harnessObjectName(sourceID, relPath)},
+		Spec: v1.HarnessSpec{
+			SourceID:     sourceID,
+			RelativePath: relPath,
+		},
+	}
+}
+
+func discoveredAgent(sourceID, relPath, harnessRef string) *v1.HostedAgent {
+	agent := &v1.HostedAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: agentObjectName(sourceID, relPath)},
+		Spec: v1.HostedAgentSpec{
+			SourceID:     sourceID,
+			RelativePath: relPath,
+		},
+	}
+	agent.Spec.Manifest.HarnessID = harnessRef
+	return agent
+}
+
+func TestResolveHarnessReferences(t *testing.T) {
+	t.Run("path reference resolves to the harness object name", func(t *testing.T) {
+		harness := discoveredHarness("as1src", "harnesses/claude-code")
+		agent := discoveredAgent("as1src", "agents/reviewer", "harnesses/claude-code")
+
+		require.NoError(t, resolveHarnessReferences([]*v1.HostedAgent{agent}, []*v1.Harness{harness}))
+		assert.Equal(t, harness.Name, agent.Spec.Manifest.HarnessID)
+	})
+
+	t.Run("full harness ID passes through untouched", func(t *testing.T) {
+		ref := system.HarnessPrefix + "abcdef"
+		agent := discoveredAgent("as1src", "agents/reviewer", ref)
+
+		require.NoError(t, resolveHarnessReferences([]*v1.HostedAgent{agent}, nil))
+		assert.Equal(t, ref, agent.Spec.Manifest.HarnessID)
+	})
+
+	t.Run("unknown path reference fails the sync", func(t *testing.T) {
+		harness := discoveredHarness("as1src", "harnesses/claude-code")
+		agent := discoveredAgent("as1src", "agents/reviewer", "harnesses/missing")
+
+		err := resolveHarnessReferences([]*v1.HostedAgent{agent}, []*v1.Harness{harness})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "harnesses/missing")
+		assert.Contains(t, err.Error(), "agents/reviewer")
+	})
+
+	t.Run("missing reference fails the sync", func(t *testing.T) {
+		agent := discoveredAgent("as1src", "agents/reviewer", "")
+
+		err := resolveHarnessReferences([]*v1.HostedAgent{agent}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not name a harness")
+	})
+}
+
+func TestSourceObjectNames(t *testing.T) {
+	t.Run("deterministic across syncs", func(t *testing.T) {
+		assert.Equal(t,
+			harnessObjectName("as1src", "harnesses/claude-code"),
+			harnessObjectName("as1src", "harnesses/claude-code"),
+			"the same definition must map to the same resource on every sync")
+	})
+
+	t.Run("kinds and paths do not collide", func(t *testing.T) {
+		names := []string{
+			harnessObjectName("as1src", "tools/my_thing"),
+			// Sanitizes to the same visible fragment; the hash must separate them.
+			harnessObjectName("as1src", "tools/my-thing"),
+			harnessObjectName("as1other", "tools/my_thing"),
+			agentObjectName("as1src", "tools/my_thing"),
+		}
+		seen := make(map[string]struct{}, len(names))
+		for _, n := range names {
+			if _, ok := seen[n]; ok {
+				t.Fatalf("duplicate object name %q", n)
+			}
+			seen[n] = struct{}{}
+		}
+	})
+
+	t.Run("names carry the kind prefix and are valid", func(t *testing.T) {
+		harnessName := harnessObjectName("as1src", "härness/…weird path")
+		agentName := agentObjectName("as1src", "härness/…weird path")
+		assert.True(t, len(harnessName) > len(system.HarnessPrefix) && harnessName[:len(system.HarnessPrefix)] == system.HarnessPrefix)
+		assert.True(t, len(agentName) > len(system.HostedAgentPrefix) && agentName[:len(system.HostedAgentPrefix)] == system.HostedAgentPrefix)
+		assert.Empty(t, validation.IsDNS1123Subdomain(harnessName))
+		assert.Empty(t, validation.IsDNS1123Subdomain(agentName))
+	})
+}

--- a/pkg/controller/handlers/auditlogexport/auditlogexport_test.go
+++ b/pkg/controller/handlers/auditlogexport/auditlogexport_test.go
@@ -389,7 +389,7 @@ func TestAuditLogOptionsDefaultsToMCPOnly(t *testing.T) {
 	}
 }
 
-// TestAuditLogOptionsMapsLocalAgentFilters proves local-agent source type and filters are passed
+// TestAuditLogOptionsMapsLocalAgentFilters proves local-agent catalog type and filters are passed
 // through to the gateway query when a caller explicitly opts in.
 func TestAuditLogOptionsMapsLocalAgentFilters(t *testing.T) {
 	opts := mcpAuditLogOptionsFromExport(exportWithFilters(types.AuditLogExportFilters{
@@ -402,7 +402,7 @@ func TestAuditLogOptionsMapsLocalAgentFilters(t *testing.T) {
 	}, true), 100, 0)
 
 	if len(opts.SourceTypes) != 1 || opts.SourceTypes[0] != types.AuditLogSourceTypeLocalAgentToolCall {
-		t.Fatalf("expected local-agent source type, got %v", opts.SourceTypes)
+		t.Fatalf("expected local-agent catalog type, got %v", opts.SourceTypes)
 	}
 	if len(opts.AgentProvider) != 1 || opts.AgentProvider[0] != string(types.LocalAgentProviderClaudeCode) {
 		t.Fatalf("expected agent provider filter to pass through, got %v", opts.AgentProvider)

--- a/pkg/controller/handlers/cleanup/user.go
+++ b/pkg/controller/handlers/cleanup/user.go
@@ -1,9 +1,11 @@
 package cleanup
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 
 	"github.com/obot-platform/nah/pkg/router"
@@ -12,8 +14,13 @@ import (
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	hostedAgentPoolCleanupAnnotation = "obot.obot.ai/user-delete-hosted-agent-pools"
 )
 
 type UserCleanup struct {
@@ -32,6 +39,14 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 	userDelete := req.Object.(*v1.UserDelete)
 	userID := strconv.FormatUint(uint64(userDelete.Spec.UserID), 10)
 	log.Infof("Starting user cleanup: userID=%s", userID)
+
+	complete, err := cleanupHostedAgents(req, userDelete, userID)
+	if err != nil {
+		return err
+	}
+	if !complete {
+		return nil
+	}
 
 	// Delete identities first so that the user can login again.
 	identities, err := u.gatewayClient.FindIdentitiesForUser(req.Ctx, userDelete.Spec.UserID)
@@ -173,4 +188,124 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 	// If everything is cleaned up successfully, then delete this object because we don't need it.
 	log.Infof("Completed user cleanup: userID=%s", userID)
 	return req.Delete(userDelete)
+}
+
+// cleanupHostedAgents orders deletion so backend finalizers have all of the
+// references they need: instances, assignments, then exclusively owned
+// pools. Pool IDs are checkpointed on UserDelete metadata before
+// assignments are removed, allowing cleanup to wait across reconciliations
+// until asynchronous pool deletion has actually completed.
+func cleanupHostedAgents(req router.Request, userDelete *v1.UserDelete, userID string) (bool, error) {
+	var instances v1.HostedAgentInstanceList
+	if err := req.List(&instances, &kclient.ListOptions{
+		Namespace: req.Namespace,
+		FieldSelector: fields.SelectorFromSet(map[string]string{
+			"spec.userID": userID,
+		}),
+	}); err != nil {
+		return false, err
+	}
+	if len(instances.Items) > 0 {
+		for i := range instances.Items {
+			if err := req.Delete(&instances.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+				return false, err
+			}
+		}
+		log.Infof("Waiting for hosted agent instance cleanup: userID=%s instances=%d", userID, len(instances.Items))
+		return false, nil
+	}
+
+	poolIDs, err := savedPoolIDs(userDelete)
+	if err != nil {
+		return false, err
+	}
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, &kclient.ListOptions{
+		Namespace: req.Namespace,
+		FieldSelector: fields.SelectorFromSet(map[string]string{
+			"spec.userID": userID,
+		}),
+	}); err != nil {
+		return false, err
+	}
+
+	changed := false
+	for _, assignment := range assignments.Items {
+		if !slices.Contains(poolIDs, assignment.Spec.Manifest.PoolID) {
+			poolIDs = append(poolIDs, assignment.Spec.Manifest.PoolID)
+			changed = true
+		}
+	}
+	if changed {
+		sort.Strings(poolIDs)
+		data, err := json.Marshal(poolIDs)
+		if err != nil {
+			return false, fmt.Errorf("marshal hosted agent pool cleanup checkpoint: %w", err)
+		}
+		if userDelete.Annotations == nil {
+			userDelete.Annotations = map[string]string{}
+		}
+		userDelete.Annotations[hostedAgentPoolCleanupAnnotation] = string(data)
+		if err := req.Client.Update(req.Ctx, userDelete); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	if len(assignments.Items) > 0 {
+		for i := range assignments.Items {
+			if err := req.Delete(&assignments.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+				return false, err
+			}
+		}
+		log.Infof("Waiting for hosted agent pool assignment cleanup: userID=%s assignments=%d", userID, len(assignments.Items))
+		return false, nil
+	}
+
+	waiting := false
+	for _, poolID := range poolIDs {
+		var remainingAssignments v1.HostedAgentPoolAssignmentList
+		if err := req.List(&remainingAssignments, &kclient.ListOptions{
+			Namespace: req.Namespace,
+			FieldSelector: fields.SelectorFromSet(map[string]string{
+				"spec.poolID": poolID,
+			}),
+		}); err != nil {
+			return false, err
+		}
+		if len(remainingAssignments.Items) > 0 {
+			// Another user still references this pool. Ownership is
+			// shared, so this user's deletion must leave it intact.
+			continue
+		}
+
+		var pool v1.HostedAgentPool
+		if err := req.Get(&pool, req.Namespace, poolID); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, err
+		}
+		waiting = true
+		if err := req.Delete(&pool); err != nil && !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+	if waiting {
+		log.Infof("Waiting for hosted agent pool cleanup: userID=%s pools=%d", userID, len(poolIDs))
+		return false, nil
+	}
+	return true, nil
+}
+
+func savedPoolIDs(userDelete *v1.UserDelete) ([]string, error) {
+	value := userDelete.Annotations[hostedAgentPoolCleanupAnnotation]
+	if value == "" {
+		return nil, nil
+	}
+	var result []string
+	if err := json.Unmarshal([]byte(value), &result); err != nil {
+		return nil, fmt.Errorf("parse hosted agent pool cleanup checkpoint: %w", err)
+	}
+	return result, nil
 }

--- a/pkg/controller/handlers/cleanup/user_test.go
+++ b/pkg/controller/handlers/cleanup/user_test.go
@@ -1,0 +1,39 @@
+package cleanup
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSavedPoolIDs(t *testing.T) {
+	userDelete := &v1.UserDelete{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				hostedAgentPoolCleanupAnnotation: `["pool-a","pool-b"]`,
+			},
+		},
+	}
+	got, err := savedPoolIDs(userDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"pool-a", "pool-b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("pool IDs = %#v, want %#v", got, want)
+	}
+}
+
+func TestSavedPoolIDsRejectsInvalidCheckpoint(t *testing.T) {
+	userDelete := &v1.UserDelete{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				hostedAgentPoolCleanupAnnotation: "not-json",
+			},
+		},
+	}
+	if _, err := savedPoolIDs(userDelete); err == nil {
+		t.Fatal("expected invalid cleanup checkpoint to fail")
+	}
+}

--- a/pkg/controller/handlers/hostedagent/README.md
+++ b/pkg/controller/handlers/hostedagent/README.md
@@ -1,0 +1,28 @@
+# Hosted agent instance reconciliation
+
+`HostedAgentInstance` resources are reconciled through `pkg/agentbackend`.
+The controller owns Obot-specific resolution and passes only normalized,
+runtime-ready configuration to the selected backend.
+
+The controller:
+
+- validates an explicitly selected pool against the user's assignments;
+- selects the user's default assignment, or lazily creates a deterministic
+  pool and default assignment from the deployment-wide `default`
+  `HostedAgentPoolDefaults`;
+- uses the instance UID as the stable backend identity;
+- installs a finalizer before creating backend resources;
+- calculates an Obot-owned revision from desired runtime configuration;
+- reports an instance ready only when the backend has applied that revision;
+- retains the first healthy runtime URL across later state changes;
+- polls transitional instances every ten seconds and ready instances every
+  five minutes, so backend events are an optimization rather than a
+  correctness requirement; and
+- removes its finalizer only after the backend confirms deletion is complete.
+
+The default builder currently renders the versioned
+`/etc/obot/agent.json`, non-sensitive environment, harness image, and source
+repository. Sensitive values are deliberately excluded. Resolution of MCP
+gateway endpoints, model proxy endpoints, skill file trees, and backend secret
+references belongs in the builder and can be added without changing the
+backend interface or lifecycle controller.

--- a/pkg/controller/handlers/hostedagent/config.go
+++ b/pkg/controller/handlers/hostedagent/config.go
@@ -1,0 +1,242 @@
+package hostedagent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/obot-platform/obot/pkg/hostedagentmodels"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// agentConfig is the whole of what a sandbox is told, written to
+// /etc/obot/agent.json at start-up.
+//
+// Every endpoint in it is a complete URL, so an image boots by reading this
+// file and needs to know nothing about Obot -- not its address, not its
+// routing, not that it is Obot at all. An image that had to assemble a URL from
+// a base and an ID would be coupled to Obot's routes and would break the moment
+// they changed.
+//
+// It carries no credentials. Those live in a second file, named by SecretsFile
+// and readable only by the agent, so that this one can be world-readable and
+// safely inspected, logged or copied without leaking a token.
+type agentConfig struct {
+	Version  string          `json:"version"`
+	Instance agentConfigMeta `json:"instance"`
+
+	// SecretsFile is where the credentials for the endpoints below are kept.
+	// An agent merges the two by ID; see agentSecrets.
+	SecretsFile string `json:"secretsFile,omitempty"`
+
+	// Workspace is the writable directory that survives a restart.
+	Workspace string `json:"workspace,omitempty"`
+	// Source is the repository to check out, if the agent or user chose one.
+	Source *agentConfigSource `json:"source,omitempty"`
+	// ListenPort is set when the agent is expected to serve HTTP.
+	ListenPort int `json:"listenPort,omitempty"`
+	// PublicPath is the path prefix the agent is published under, and PublicURL
+	// the whole address. Both are set only when the agent serves HTTP.
+	//
+	// An agent is not reached at its own root: Obot mounts it under a prefix and
+	// strips that prefix before forwarding. A server that does not know this
+	// builds links and API calls against the root, which land outside its own
+	// prefix -- a single-page UI ends up calling Obot instead of itself.
+	// X-Forwarded-Prefix says the same thing per request, but a server that
+	// needs it at start-up, to bake into the page it serves, cannot use a header.
+	PublicPath string `json:"publicPath,omitempty"`
+	PublicURL  string `json:"publicURL,omitempty"`
+
+	// ObotURL is Obot itself, at the address this sandbox reaches it on. The
+	// endpoints below are already absolute, so an agent needs this only for
+	// what they do not cover -- calling Obot's API directly with the credential
+	// it was issued.
+	//
+	// It is deliberately not PublicURL's host: the public address is the one a
+	// browser uses, and is commonly not routable from inside the cluster.
+	// Answering "where is Obot" with the browser's answer is what breaks a
+	// sandbox that then cannot reach its own models.
+	ObotURL string `json:"obotURL,omitempty"`
+
+	MCPServers []agentConfigMCPServer `json:"mcpServers,omitempty"`
+	Models     []agentConfigModel     `json:"models,omitempty"`
+	Skills     []agentConfigSkill     `json:"skills,omitempty"`
+
+	// Answers are the user's responses to the agent's questions. Sensitive
+	// answers are excluded.
+	Answers map[string]string `json:"answers,omitempty"`
+}
+
+type agentConfigMeta struct {
+	ID     string `json:"id"`
+	UserID string `json:"userID"`
+	Name   string `json:"name,omitempty"`
+}
+
+type agentConfigSource struct {
+	URL string `json:"url"`
+	// Ref is a branch, tag or commit. Empty means the default branch.
+	Ref    string `json:"ref,omitempty"`
+	Subdir string `json:"subdir,omitempty"`
+}
+
+type agentConfigMCPServer struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+	// URL is complete and ready to connect to.
+	URL string `json:"url"`
+	// Transport names the wire protocol so a client can configure itself
+	// without guessing from the URL shape.
+	Transport string `json:"transport"`
+	// Headers holds only non-sensitive headers. Anything carrying a credential
+	// is in the secrets file under the same ID.
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type agentConfigModel struct {
+	// ID is Obot's identifier; Model is the name to send on the wire.
+	ID    string `json:"id,omitempty"`
+	Model string `json:"model"`
+	// APIs are the wire protocols this model accepts: "anthropic",
+	// "openai-responses", "openai-chat-completions". An image picks a model it
+	// can speak to; a client written for one format cannot use another, and a
+	// model is often reachable over more than one. Provider is the underlying
+	// Obot model provider, present for diagnostics rather than for dispatch.
+	APIs     []string `json:"apis"`
+	Provider string   `json:"provider,omitempty"`
+	// BaseURL is the root of Obot's proxy for this provider, carrying no API
+	// version. The version belongs to the protocol the client speaks, not to
+	// the routing: an Anthropic client appends /v1/messages to it, while an
+	// OpenAI one treats /v1 as part of its base and appends /responses. Naming
+	// a version here would pick one of those conventions for every client, and
+	// could not express a provider moving to /v2 without a new field.
+	BaseURL string `json:"baseURL"`
+	// There is deliberately no API key here: it is in the secrets file, keyed by
+	// Provider, since that is what decides the endpoint the key is sent to.
+
+	// Default marks the model to reach for when an image wants one. It is a
+	// hint, not a restriction: the agent may use any model listed here, and it
+	// exists because a bare list gives an image no way to choose.
+	Default bool `json:"default,omitempty"`
+}
+
+type agentConfigSkill struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+	// Path is a directory in the sandbox holding the skill's files.
+	Path        string `json:"path"`
+	Description string `json:"description,omitempty"`
+}
+
+// agentSecrets is the credential half of the contract, keyed by the same IDs
+// used in agentConfig so the two merge without further lookup.
+//
+// It is a separate file so that the configuration an agent needs to read --
+// endpoints, skills, answers -- carries no secret, and only this one has to be
+// protected.
+type agentSecrets struct {
+	Version    string                    `json:"version"`
+	MCPServers map[string]agentSecretMCP `json:"mcpServers,omitempty"`
+	// ModelProviders is keyed by model provider, not by model. A credential
+	// belongs to the endpoint it is sent to, and every model from one provider
+	// shares an endpoint -- keying by model repeated the same value once per
+	// model, which on an installation with a large catalogue meant hundreds of
+	// copies of one string.
+	ModelProviders map[string]agentSecretModelProvider `json:"modelProviders,omitempty"`
+}
+
+type agentSecretMCP struct {
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type agentSecretModelProvider struct {
+	APIKey string `json:"apiKey,omitempty"`
+}
+
+// transportStreamableHTTP is what the MCP gateway speaks.
+const transportStreamableHTTP = "streamable-http"
+
+// mcpServerConfig builds a ready-to-use connection for each MCP server the
+// agent was granted.
+func mcpServerConfigs(serverURL string, ids []string) []agentConfigMCPServer {
+	servers := make([]agentConfigMCPServer, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		servers = append(servers, agentConfigMCPServer{
+			ID:        id,
+			Name:      id,
+			URL:       fmt.Sprintf("%s/mcp-connect/%s", strings.TrimSuffix(serverURL, "/"), id),
+			Transport: transportStreamableHTTP,
+		})
+	}
+	return servers
+}
+
+// modelConfigs resolves what the agent may use into complete endpoints.
+//
+// Resolution is shared with the API, which uses the same answer to decide
+// whether an agent can be launched at all. If the two disagreed, a user could
+// be offered an agent that then resolves no models.
+func modelConfigs(ctx context.Context, client kclient.Client, namespace, serverURL string, selections, providers []string) ([]agentConfigModel, error) {
+	resolved, err := hostedagentmodels.Resolve(ctx, client, namespace, selections, providers)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultID := hostedagentmodels.Default(ctx, client, namespace, resolved)
+	models := make([]agentConfigModel, 0, len(resolved))
+	for _, model := range resolved {
+		path, ok := hostedagentmodels.ProxyPath(model.Provider)
+		if !ok {
+			continue
+		}
+		models = append(models, agentConfigModel{
+			ID:       model.ID,
+			Model:    model.Model,
+			APIs:     model.APIs,
+			Provider: model.Provider,
+			BaseURL:  fmt.Sprintf("%s/api/llm-proxy/%s", strings.TrimSuffix(serverURL, "/"), path),
+			Default:  model.ID == defaultID,
+		})
+	}
+	return models, nil
+}
+
+// buildSecrets pairs every endpoint in the config with the credential it needs.
+//
+// Today all of them use the agent's own credential; keying by ID rather than
+// emitting one shared token means a per-server credential later changes only
+// what is written here, not the contract an image reads.
+func buildSecrets(config agentConfig, credential string) agentSecrets {
+	secrets := agentSecrets{Version: config.Version}
+	if credential == "" {
+		return secrets
+	}
+
+	if len(config.MCPServers) > 0 {
+		secrets.MCPServers = make(map[string]agentSecretMCP, len(config.MCPServers))
+		for _, server := range config.MCPServers {
+			secrets.MCPServers[server.ID] = agentSecretMCP{
+				Headers: map[string]string{"Authorization": "Bearer " + credential},
+			}
+		}
+	}
+	for _, model := range config.Models {
+		if model.Provider == "" {
+			continue
+		}
+		if secrets.ModelProviders == nil {
+			secrets.ModelProviders = map[string]agentSecretModelProvider{}
+		}
+		secrets.ModelProviders[model.Provider] = agentSecretModelProvider{APIKey: credential}
+	}
+	return secrets
+}

--- a/pkg/controller/handlers/hostedagent/configshape_test.go
+++ b/pkg/controller/handlers/hostedagent/configshape_test.go
@@ -1,0 +1,401 @@
+package hostedagent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestAgentConfigShape renders the file a sandbox is actually handed.
+//
+// It doubles as the documented example of the contract: run it with -v to see
+// the full config. Every endpoint in it is absolute and carries its own
+// credential, which is what lets an image boot from this file alone.
+func TestAgentConfigShape(t *testing.T) {
+	client := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(
+			&v1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "m1sonnet", Namespace: "obot"},
+				Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+					Name:          "claude-sonnet",
+					TargetModel:   "claude-sonnet-4-5",
+					ModelProvider: system.AnthropicModelProvider,
+					Active:        true,
+					Usage:         types.ModelUsageLLM,
+				}},
+			},
+			&v1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "m1gpt", Namespace: "obot"},
+				Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+					Name:          "gpt",
+					TargetModel:   "gpt-5",
+					ModelProvider: system.OpenAIModelProvider,
+					Active:        true,
+					Usage:         types.ModelUsageLLM,
+				}},
+			},
+			&v1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "m1mini", Namespace: "obot"},
+				Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+					Name:          "gpt-mini",
+					TargetModel:   "gpt-5-mini",
+					ModelProvider: system.OpenAIModelProvider,
+					Active:        true,
+					Usage:         types.ModelUsageLLM,
+				}},
+			},
+			&v1.DefaultModelAlias{
+				ObjectMeta: metav1.ObjectMeta{Name: "llm", Namespace: "obot"},
+				Spec:       v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: "llm", Model: "m1sonnet"}},
+			},
+			&v1.DefaultModelAlias{
+				ObjectMeta: metav1.ObjectMeta{Name: "llm-mini", Namespace: "obot"},
+				Spec:       v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: "llm-mini", Model: "m1mini"}},
+			},
+		).
+		Build()
+
+	instance := &v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "hai1g26fc", Namespace: "obot", UID: "d47613e8-aede-42f6-a599-9a641f99d8b7"},
+		Spec: v1.HostedAgentInstanceSpec{
+			UserID: "3",
+			Manifest: types.HostedAgentInstanceManifest{
+				Name:    "my-coding-agent",
+				GitRepo: "https://github.com/example/service.git",
+				GitRef:  "main",
+				Answers: map[string]string{"instruction": "Follow the house style.", "token": "must-not-leak"},
+			},
+		},
+	}
+	agent := &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{
+		Name:             "Claude Code",
+		HarnessID:        "hrn1abc",
+		AllowUserGitRepo: true,
+		MCPServers:       []string{"ms1github", "ms1slack"},
+		Models:           []string{"*"},
+		Terminal:         true,
+		Questions: []types.HostedAgentQuestion{
+			{Key: "instruction"},
+			{Key: "token", Sensitive: true},
+		},
+	}}}
+	harness := &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{
+		Image: "ghcr.io/obot-platform/agent-claude-code:latest", Interactive: true,
+	}}}
+
+	builder := defaultDesiredBuilder{ServerURL: "https://obot.example.com"}
+	desired, err := builder.Build(context.Background(), BuildInput{
+		Client:     client,
+		Namespace:  "obot",
+		Instance:   instance,
+		Agent:      agent,
+		Harness:    harness,
+		Credential: "ok1-3-7-EXAMPLECREDENTIAL",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	var raw, secretsRaw string
+	for _, file := range desired.Files {
+		if file.Path == agentConfigPath {
+			raw = string(file.Content)
+			if file.Mode != 0o444 {
+				t.Errorf("config mode = %o, want 0444: it carries no secret", file.Mode)
+			}
+		}
+	}
+	for _, ref := range desired.Secrets {
+		if ref.FilePath == agentSecretsPath {
+			secretsRaw = ref.Value
+		}
+	}
+	if raw == "" {
+		t.Fatal("no config was delivered")
+	}
+	if secretsRaw == "" {
+		t.Fatal("no secrets file was delivered")
+	}
+
+	// The whole point of the split: nothing in the readable config is a secret.
+	if strings.Contains(raw, "EXAMPLECREDENTIAL") {
+		t.Fatalf("a credential leaked into the world-readable config:\n%s", raw)
+	}
+
+	var pretty2 bytes.Buffer
+	if err := json.Indent(&pretty2, []byte(secretsRaw), "", "  "); err != nil {
+		t.Fatalf("secrets file is not valid JSON: %v", err)
+	}
+	t.Logf("%s\n%s", agentSecretsPath, pretty2.String())
+
+	var secrets agentSecrets
+	if err := json.Unmarshal([]byte(secretsRaw), &secrets); err != nil {
+		t.Fatalf("unmarshal secrets: %v", err)
+	}
+	if secrets.MCPServers["ms1github"].Headers["Authorization"] != "Bearer ok1-3-7-EXAMPLECREDENTIAL" {
+		t.Errorf("mcp credential missing: %+v", secrets.MCPServers)
+	}
+	if secrets.ModelProviders[system.AnthropicModelProvider].APIKey != "ok1-3-7-EXAMPLECREDENTIAL" {
+		t.Errorf("model provider credential missing: %+v", secrets.ModelProviders)
+	}
+	// One entry per provider, not per model. Every model from a provider shares
+	// an endpoint, so a per-model key stored the same string once per model --
+	// 118 copies on this installation's catalogue.
+	if len(secrets.ModelProviders) != 2 {
+		t.Errorf("model provider entries = %d, want 2 (anthropic and openai): %+v",
+			len(secrets.ModelProviders), secrets.ModelProviders)
+	}
+
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, []byte(raw), "", "  "); err != nil {
+		t.Fatalf("config is not valid JSON: %v", err)
+	}
+	t.Logf("%s\n%s", agentConfigPath, pretty.String())
+	if dir := os.Getenv("WRITE_CONFIG_SAMPLE_DIR"); dir != "" {
+		if err := os.WriteFile(dir+"/agent.json", pretty.Bytes(), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dir+"/secrets.json", []byte(secretsRaw), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var config agentConfig
+	if err := json.Unmarshal([]byte(raw), &config); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Endpoints are complete: an image joins nothing together.
+	if len(config.MCPServers) != 2 {
+		t.Fatalf("mcpServers = %d, want 2", len(config.MCPServers))
+	}
+	for _, server := range config.MCPServers {
+		if !strings.HasPrefix(server.URL, "https://obot.example.com/mcp-connect/") {
+			t.Errorf("%s: url %q is not absolute", server.ID, server.URL)
+		}
+	}
+
+	// Models are resolved to a wire protocol and a base URL, since an
+	// Anthropic-native client and an OpenAI-compatible one are different
+	// clients and nothing in the URL says which.
+	// A "*" grant lists the whole catalogue, so the agent can choose rather
+	// than being held to whatever the template author happened to name.
+	if len(config.Models) != 3 {
+		t.Fatalf("models = %d, want 3 (every model the agent was granted)", len(config.Models))
+	}
+	defaults := 0
+	for _, model := range config.Models {
+		if model.Default {
+			defaults++
+		}
+	}
+	// Exactly one: an image asking for "the default" must get an answer, and
+	// must not have to choose between two.
+	if defaults != 1 {
+		t.Errorf("models marked default = %d, want 1: %+v", defaults, config.Models)
+	}
+	for _, model := range config.Models {
+		if !strings.HasPrefix(model.BaseURL, "https://obot.example.com/api/llm-proxy/") {
+			t.Errorf("%s: incomplete endpoint %+v", model.Model, model)
+		}
+	}
+
+	if config.Source == nil || config.Source.Ref != "main" {
+		t.Errorf("source = %+v", config.Source)
+	}
+	if config.Workspace != workspacePath {
+		t.Errorf("workspace = %q", config.Workspace)
+	}
+	// A sensitive answer is collected from the user but never written into the
+	// sandbox alongside everything else.
+	if _, ok := config.Answers["token"]; ok {
+		t.Error("a sensitive answer reached the sandbox config")
+	}
+	if config.Answers["instruction"] == "" {
+		t.Error("a non-sensitive answer was dropped")
+	}
+}
+
+// The config holds live credentials, so it must be redacted from the desired
+// revision -- which is stored on the instance and visible wherever status is.
+func TestCredentialsNeverReachTheRevision(t *testing.T) {
+	builder := defaultDesiredBuilder{ServerURL: "https://obot.example.com"}
+	desired, err := builder.Build(context.Background(), BuildInput{
+		Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}},
+		Agent: &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{
+			MCPServers: []string{"ms1github"},
+		}}},
+		Harness:    &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+		Credential: "ok1-3-7-EXAMPLECREDENTIAL",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	redacted, err := json.Marshal(desired.Redacted())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(redacted), "EXAMPLECREDENTIAL") {
+		t.Fatalf("the credential survived redaction: %s", redacted)
+	}
+}
+
+// A changed config has to restart the sandbox, or an agent granted a new MCP
+// server keeps running without it.
+func TestConfigChangeChangesTheRevision(t *testing.T) {
+	build := func(servers ...string) string {
+		t.Helper()
+		desired, err := defaultDesiredBuilder{ServerURL: "https://obot.example.com"}.Build(context.Background(), BuildInput{
+			Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}},
+			Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{MCPServers: servers}}},
+			Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return desired.Revision
+	}
+
+	if build("ms1github") == build("ms1github", "ms1slack") {
+		t.Fatal("adding an MCP server left the revision unchanged, so the sandbox would not restart")
+	}
+}
+
+// An agent behind a path prefix has to know it. Obot strips the prefix before
+// forwarding, so a server told nothing builds links and API calls against its
+// own root -- which is not where anyone reaches it. A single-page UI ends up
+// calling Obot instead of itself and reports that it cannot find its agent.
+func TestPublishedAgentIsToldWhereItIsPublished(t *testing.T) {
+	build := func(port int) agentConfig {
+		t.Helper()
+		desired, err := (defaultDesiredBuilder{ServerURL: "https://obot.example.com"}).Build(
+			context.Background(), BuildInput{
+				Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1qhtrt", UID: "uid-1"}},
+				Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{Port: port}}},
+				Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+			})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var config agentConfig
+		for _, file := range desired.Files {
+			if file.Path == agentConfigPath {
+				if err := json.Unmarshal(file.Content, &config); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		return config
+	}
+
+	served := build(8000)
+	// The resource ID, not the backend identifier: that is what the route is
+	// keyed on.
+	if served.PublicPath != "/agent-connect/hai1qhtrt" {
+		t.Errorf("publicPath = %q", served.PublicPath)
+	}
+	if served.PublicURL != "https://obot.example.com/agent-connect/hai1qhtrt" {
+		t.Errorf("publicURL = %q", served.PublicURL)
+	}
+
+	// An agent that serves nothing is published nowhere, and saying otherwise
+	// would offer an address that 400s.
+	quiet := build(0)
+	if quiet.PublicPath != "" || quiet.PublicURL != "" {
+		t.Errorf("a port-less agent should be published nowhere: %q %q", quiet.PublicPath, quiet.PublicURL)
+	}
+}
+
+// The browser and the sandbox do not reach Obot at the same address, and the
+// config carries both. Writing the public one into the sandbox's endpoints is
+// what leaves an agent unable to reach its own models: the chart's egress
+// policy excludes private ranges, so a public hostname resolving to an internal
+// load balancer or a node is refused even though it resolves.
+func TestSandboxEndpointsUseTheInternalAddress(t *testing.T) {
+	const (
+		public   = "https://obot.example.com"
+		internal = "http://obot.obot.svc.cluster.local"
+	)
+
+	desired, err := (defaultDesiredBuilder{ServerURL: public, InternalURL: internal}).Build(
+		context.Background(), BuildInput{
+			Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1qhtrt", UID: "uid-1"}},
+			Agent: &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{
+				Port:       8000,
+				MCPServers: []string{"ms1github"},
+			}}},
+			Harness: &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+		})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	var config agentConfig
+	for _, file := range desired.Files {
+		if file.Path == agentConfigPath {
+			if err := json.Unmarshal(file.Content, &config); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Called by the sandbox, so reached at the internal address.
+	if config.ObotURL != internal {
+		t.Errorf("obotURL = %q, want the internal address", config.ObotURL)
+	}
+	for _, server := range config.MCPServers {
+		if !strings.HasPrefix(server.URL, internal) {
+			t.Errorf("mcp server URL = %q, want the internal address", server.URL)
+		}
+	}
+
+	// Followed by a browser, so it has to stay the public address -- the
+	// internal one names a Service no browser can resolve.
+	if config.PublicURL != public+"/agent-connect/hai1qhtrt" {
+		t.Errorf("publicURL = %q, want the public address", config.PublicURL)
+	}
+}
+
+// A caller that knows of only one address still has to produce a usable config,
+// rather than one whose endpoints are rooted at the empty string.
+func TestInternalAddressFallsBackToPublic(t *testing.T) {
+	desired, err := (defaultDesiredBuilder{ServerURL: "https://obot.example.com"}).Build(
+		context.Background(), BuildInput{
+			Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1qhtrt", UID: "uid-1"}},
+			Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{MCPServers: []string{"ms1github"}}}},
+			Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+		})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	var config agentConfig
+	for _, file := range desired.Files {
+		if file.Path == agentConfigPath {
+			if err := json.Unmarshal(file.Content, &config); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	if config.ObotURL != "https://obot.example.com" {
+		t.Errorf("obotURL = %q, want the public address", config.ObotURL)
+	}
+	for _, server := range config.MCPServers {
+		if !strings.HasPrefix(server.URL, "https://obot.example.com") {
+			t.Errorf("mcp server URL = %q, want the public address", server.URL)
+		}
+	}
+}

--- a/pkg/controller/handlers/hostedagent/credentials/credentials.go
+++ b/pkg/controller/handlers/hostedagent/credentials/credentials.go
@@ -1,0 +1,117 @@
+// Package credentials issues the credential a hosted agent sandbox uses to
+// authenticate to Obot.
+//
+// The credential authenticates as the agent rather than as its owner, so a
+// compromised sandbox reaches only what that one instance was configured with
+// instead of everything its owner can reach.
+package credentials
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+const (
+	credentialContext = "hosted-agent-credential"
+	keyValue          = "OBOT_API_KEY"
+	keyID             = "OBOT_API_KEY_ID"
+)
+
+type Issuer struct {
+	gatewayClient *client.Client
+}
+
+func New(gatewayClient *client.Client) *Issuer {
+	return &Issuer{gatewayClient: gatewayClient}
+}
+
+// EnsureInstanceCredential returns the instance's credential, minting one only
+// when none exists.
+//
+// The plaintext is kept in Obot's encrypted credential store, mirroring what
+// nanobot agents do, because an API key's secret is not recoverable from its
+// database row. Every reconcile therefore returns the same value and the same
+// version, which is what keeps the desired revision stable; reissuing would
+// change the version and restart the sandbox.
+func (i *Issuer) EnsureInstanceCredential(ctx context.Context, instanceID, ownerUserID string) (string, string, error) {
+	if i == nil || i.gatewayClient == nil {
+		return "", "", nil
+	}
+	if instanceID == "" {
+		return "", "", fmt.Errorf("instance ID is required")
+	}
+
+	stored, err := i.gatewayClient.RevealCredential(ctx, []string{credentialContext}, instanceID)
+	if err == nil && stored.Secrets[keyValue] != "" {
+		if valid, err := i.stillValid(ctx, stored.Secrets[keyValue]); err != nil {
+			return "", "", err
+		} else if valid {
+			return stored.Secrets[keyValue], stored.Secrets[keyID], nil
+		}
+		// The key was revoked out of band. Fall through and mint a new one; the
+		// changed version restarts the sandbox, which is the only way it will
+		// pick the new credential up.
+	} else if err != nil {
+		if _, ok := errors.AsType[client.CredentialNotFoundError](err); !ok {
+			return "", "", fmt.Errorf("reveal hosted agent credential: %w", err)
+		}
+	}
+
+	// The owner is recorded for attribution and cleanup. It confers none of
+	// that user's access: authentication resolves the instance, not the user.
+	var owner uint64
+	if ownerUserID != "" {
+		owner, _ = strconv.ParseUint(ownerUserID, 10, 64)
+	}
+
+	created, err := i.gatewayClient.CreateHostedAgentAPIKey(ctx, instanceID, uint(owner), "hosted-agent-"+instanceID)
+	if err != nil {
+		return "", "", fmt.Errorf("create hosted agent credential: %w", err)
+	}
+
+	version := strconv.FormatUint(uint64(created.ID), 10)
+	if err := i.gatewayClient.UpsertCredential(ctx, gatewaytypes.Credential{
+		Context: credentialContext,
+		Name:    instanceID,
+		Secrets: map[string]string{
+			keyValue: created.Key,
+			keyID:    version,
+		},
+	}); err != nil {
+		return "", "", fmt.Errorf("store hosted agent credential: %w", err)
+	}
+
+	return created.Key, version, nil
+}
+
+// RevokeInstanceCredential removes both the key and its stored plaintext.
+// Revocation is a row delete, so a leaked credential stops working at once
+// rather than waiting for an expiry these keys deliberately do not have.
+func (i *Issuer) RevokeInstanceCredential(ctx context.Context, instanceID string) error {
+	if i == nil || i.gatewayClient == nil {
+		return nil
+	}
+
+	var errs []error
+	if err := i.gatewayClient.DeleteHostedAgentAPIKeys(ctx, instanceID); err != nil {
+		errs = append(errs, err)
+	}
+	// DeleteCredential is idempotent, so a credential that is already gone is
+	// not an error to filter out.
+	if _, err := i.gatewayClient.DeleteCredential(ctx, credentialContext, instanceID); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (i *Issuer) stillValid(ctx context.Context, value string) (bool, error) {
+	if _, err := i.gatewayClient.ValidateAPIKey(ctx, value); err != nil {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/controller/handlers/hostedagent/gitref_test.go
+++ b/pkg/controller/handlers/hostedagent/gitref_test.go
@@ -1,0 +1,91 @@
+package hostedagent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func buildSource(t *testing.T, agent types.HostedAgentManifest, instance types.HostedAgentInstanceManifest) (string, string) {
+	t.Helper()
+
+	desired, err := defaultDesiredBuilder{}.Build(context.Background(), BuildInput{
+		Instance: &v1.HostedAgentInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "hai1", Namespace: "n", UID: "uid-1"},
+			Spec:       v1.HostedAgentInstanceSpec{Manifest: instance, UserID: "u1"},
+		},
+		Agent:   &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: agent}},
+		Harness: &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return desired.Source.URL, desired.Source.Revision
+}
+
+func TestAgentGitRefReachesTheSandbox(t *testing.T) {
+	url, ref := buildSource(t,
+		types.HostedAgentManifest{GitRepo: "https://example.com/a.git", GitRef: "v1.2.3"},
+		types.HostedAgentInstanceManifest{Name: "i"})
+
+	if url != "https://example.com/a.git" || ref != "v1.2.3" {
+		t.Fatalf("source = %q @ %q", url, ref)
+	}
+}
+
+// A ref names a revision of one specific repository. Carrying the agent's ref
+// onto a repository the user supplied would check out someone else's revision
+// -- or more likely fail to resolve, with an error pointing at the wrong repo.
+func TestUserRepoDoesNotInheritTheAgentRef(t *testing.T) {
+	url, ref := buildSource(t,
+		types.HostedAgentManifest{GitRepo: "https://example.com/a.git", GitRef: "v1.2.3", AllowUserGitRepo: true},
+		types.HostedAgentInstanceManifest{Name: "i", GitRepo: "https://example.com/mine.git"})
+
+	if url != "https://example.com/mine.git" {
+		t.Fatalf("url = %q, want the user's repository", url)
+	}
+	if ref != "" {
+		t.Fatalf("ref = %q, want the user's repository to use its default branch", ref)
+	}
+}
+
+func TestUserRefIsUsedWithTheUserRepo(t *testing.T) {
+	url, ref := buildSource(t,
+		types.HostedAgentManifest{GitRepo: "https://example.com/a.git", GitRef: "v1.2.3", AllowUserGitRepo: true},
+		types.HostedAgentInstanceManifest{Name: "i", GitRepo: "https://example.com/mine.git", GitRef: "my-branch"})
+
+	if url != "https://example.com/mine.git" || ref != "my-branch" {
+		t.Fatalf("source = %q @ %q", url, ref)
+	}
+}
+
+// The ref participates in desired state, so changing it has to restart the
+// sandbox; otherwise a repinned agent keeps running the old revision.
+func TestChangingTheRefChangesTheRevision(t *testing.T) {
+	base := types.HostedAgentManifest{GitRepo: "https://example.com/a.git", GitRef: "v1"}
+	instance := types.HostedAgentInstanceManifest{Name: "i"}
+
+	first, err := defaultDesiredBuilder{}.Build(context.Background(), BuildInput{
+		Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}, Spec: v1.HostedAgentInstanceSpec{Manifest: instance}},
+		Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: base}},
+		Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	base.GitRef = "v2"
+	second, err := defaultDesiredBuilder{}.Build(context.Background(), BuildInput{
+		Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}, Spec: v1.HostedAgentInstanceSpec{Manifest: instance}},
+		Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: base}},
+		Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if first.Revision == second.Revision {
+		t.Fatal("repinning the ref left the revision unchanged, so the sandbox would not restart")
+	}
+}

--- a/pkg/controller/handlers/hostedagent/hostedagent.go
+++ b/pkg/controller/handlers/hostedagent/hostedagent.go
@@ -1,0 +1,675 @@
+// Package hostedagent reconciles hosted agent instances through the
+// implementation-neutral agent backend contract.
+package hostedagent
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/logger"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/hostedagentrefs"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kfields "k8s.io/apimachinery/pkg/fields"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var log = logger.Package()
+
+const (
+	transitionalPollInterval = 10 * time.Second
+	readyPollInterval        = 5 * time.Minute
+	agentConfigPath          = "/etc/obot/agent.json"
+	// agentSecretsPath holds the credentials for the endpoints named in the
+	// config. It is a separate file so the config itself needs no protection.
+	agentSecretsPath = "/etc/obot/secrets.json"
+	// workspacePath mirrors where backends mount the pool volume. It is told to
+	// the agent so the writable, surviving directory does not have to be
+	// guessed.
+	workspacePath      = "/workspace"
+	credentialFilePath = "/etc/obot/credential"
+	poolDefaultsName   = "default"
+)
+
+// DesiredBuilder converts Obot resources into the runtime-ready backend
+// contract. Keeping this boundary injectable lets resource and credential
+// resolution evolve without coupling a backend adapter to Obot storage types.
+type DesiredBuilder interface {
+	Build(context.Context, BuildInput) (agentbackend.DesiredInstance, error)
+}
+
+// BuildInput is everything needed to render a sandbox's runtime contract.
+//
+// Client is here because the sandbox config resolves models and skills into
+// complete endpoints and files, which means reading them; Credential is here
+// because those endpoints carry it.
+type BuildInput struct {
+	Client     kclient.Client
+	Namespace  string
+	Instance   *v1.HostedAgentInstance
+	Agent      *v1.HostedAgent
+	Harness    *v1.Harness
+	Credential string
+}
+
+// CredentialIssuer mints and revokes the credential a sandbox authenticates
+// with. It is an interface so the controller can be tested without a database,
+// and so the credential store stays replaceable.
+type CredentialIssuer interface {
+	// EnsureInstanceCredential returns the sandbox credential and an opaque
+	// version that changes whenever the value does. It must be idempotent:
+	// reconciles are frequent, and reissuing on every pass would restart the
+	// sandbox on every pass.
+	EnsureInstanceCredential(ctx context.Context, instanceID, ownerUserID string) (value string, version string, err error)
+	// RevokeInstanceCredential is called during deletion and must tolerate a
+	// credential that is already gone.
+	RevokeInstanceCredential(ctx context.Context, instanceID string) error
+}
+
+type Handler struct {
+	backend     agentbackend.InstanceBackend
+	builder     DesiredBuilder
+	credentials CredentialIssuer
+	now         func() time.Time
+}
+
+func New(backend agentbackend.InstanceBackend, credentials CredentialIssuer, serverURL, internalURL string) *Handler {
+	return NewWithBuilder(backend, credentials, defaultDesiredBuilder{
+		ServerURL:   serverURL,
+		InternalURL: internalURL,
+		Skills:      newSkillFetcher(),
+	})
+}
+
+func NewWithBuilder(backend agentbackend.InstanceBackend, credentials CredentialIssuer, builder DesiredBuilder) *Handler {
+	return &Handler{
+		backend:     backend,
+		builder:     builder,
+		credentials: credentials,
+		now:         time.Now,
+	}
+}
+
+// EnsurePool resolves the instance's pool before backend
+// reconciliation. The deterministic names make concurrent first-instance
+// reconciles for one user converge on the same pool and assignment.
+func (h *Handler) EnsurePool(req router.Request, _ router.Response) error {
+	instance := req.Object.(*v1.HostedAgentInstance)
+	if instance.Spec.UserID == "" {
+		return fmt.Errorf("hosted agent instance %q has no user ID", instance.Name)
+	}
+
+	if instance.Spec.PoolID != "" {
+		assignments, err := assignmentsForUser(req, instance.Spec.UserID)
+		if err != nil {
+			return err
+		}
+		if isAssigned(assignments, instance.Spec.PoolID) {
+			return nil
+		}
+		return fmt.Errorf("user %q is not assigned to hosted agent pool %q", instance.Spec.UserID, instance.Spec.PoolID)
+	}
+
+	assignments, err := assignmentsForUser(req, instance.Spec.UserID)
+	if err != nil {
+		return err
+	}
+	if poolID := defaultPool(assignments); poolID != "" {
+		instance.Spec.PoolID = poolID
+		return req.Client.Update(req.Ctx, instance)
+	}
+
+	var defaults v1.HostedAgentPoolDefaults
+	if err := req.Get(&defaults, req.Namespace, poolDefaultsName); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("hosted agent pool defaults %q are not configured: %w", poolDefaultsName, err)
+		}
+		return err
+	}
+	if err := defaults.Spec.Manifest.Validate(); err != nil {
+		return fmt.Errorf("hosted agent pool defaults %q are invalid: %w", poolDefaultsName, err)
+	}
+
+	poolID, assignmentID := initialPoolNames(instance.Spec.UserID)
+	pool := &v1.HostedAgentPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolID,
+			Namespace: req.Namespace,
+		},
+		Spec: v1.HostedAgentPoolSpec{
+			Manifest: types.HostedAgentPoolManifest{
+				Capacity:     defaults.Spec.Manifest.Capacity,
+				MaxSandboxes: defaults.Spec.Manifest.MaxSandboxes,
+				Suspended:    defaults.Spec.Manifest.Suspended,
+			},
+		},
+	}
+	if err := req.Client.Create(req.Ctx, pool); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create hosted agent pool: %w", err)
+	}
+
+	assignment := &v1.HostedAgentPoolAssignment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      assignmentID,
+			Namespace: req.Namespace,
+		},
+		Spec: v1.HostedAgentPoolAssignmentSpec{
+			Manifest: types.HostedAgentPoolAssignmentManifest{
+				UserID:  instance.Spec.UserID,
+				PoolID:  poolID,
+				Default: true,
+			},
+		},
+	}
+	err = req.Client.Create(req.Ctx, assignment)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create hosted agent pool assignment: %w", err)
+	}
+	if apierrors.IsAlreadyExists(err) {
+		var persistedAssignment v1.HostedAgentPoolAssignment
+		if err := req.Client.Get(req.Ctx, router.Key(req.Namespace, assignmentID), &persistedAssignment); err != nil {
+			return fmt.Errorf("read hosted agent pool assignment after conflict: %w", err)
+		}
+		if persistedAssignment.Spec.Manifest.UserID != instance.Spec.UserID ||
+			persistedAssignment.Spec.Manifest.PoolID != poolID ||
+			!persistedAssignment.Spec.Manifest.Default {
+			return fmt.Errorf("hosted agent pool assignment %q conflicts with the default assignment for user %q", assignmentID, instance.Spec.UserID)
+		}
+	}
+
+	instance.Spec.PoolID = poolID
+	return req.Client.Update(req.Ctx, instance)
+}
+
+func isAssigned(assignments []v1.HostedAgentPoolAssignment, poolID string) bool {
+	for _, assignment := range assignments {
+		if assignment.Spec.Manifest.PoolID == poolID {
+			return true
+		}
+	}
+	return false
+}
+
+func defaultPool(assignments []v1.HostedAgentPoolAssignment) string {
+	for _, assignment := range assignments {
+		if assignment.Spec.Manifest.Default {
+			return assignment.Spec.Manifest.PoolID
+		}
+	}
+	return ""
+}
+
+func initialPoolNames(userID string) (string, string) {
+	suffix := hash.String(userID)[:16]
+	return "hp-" + suffix, "hps-" + suffix
+}
+
+func assignmentsForUser(req router.Request, userID string) ([]v1.HostedAgentPoolAssignment, error) {
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, &kclient.ListOptions{
+		Namespace: req.Namespace,
+		FieldSelector: kfields.SelectorFromSet(map[string]string{
+			"spec.userID": userID,
+		}),
+	}); err != nil {
+		return nil, fmt.Errorf("list hosted agent pool assignments: %w", err)
+	}
+	result := make([]v1.HostedAgentPoolAssignment, 0, len(assignments.Items))
+	for _, assignment := range assignments.Items {
+		if assignment.Spec.Manifest.UserID == userID {
+			result = append(result, assignment)
+		}
+	}
+	return result, nil
+}
+
+// OrchestrateInstance converges one HostedAgentInstance and periodically
+// observes it so out-of-band backend changes are reflected in Obot.
+func (h *Handler) OrchestrateInstance(req router.Request, resp router.Response) error {
+	instance := req.Object.(*v1.HostedAgentInstance)
+	if h.backend == nil {
+		return fmt.Errorf("hosted agent backend is not configured")
+	}
+
+	ref := instanceRef(instance)
+	// EnsurePool is registered immediately before this handler. nah can
+	// aggregate errors from handlers in one reconciliation pass, so do not try
+	// to construct backend desired state when pool resolution failed.
+	// The pool handler's actionable error is sufficient and a later
+	// reconcile will continue once defaults or an assignment are configured.
+	if instance.Spec.PoolID == "" {
+		return nil
+	}
+
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.Namespace, instance.Spec.HostedAgentName); err != nil {
+		return err
+	}
+
+	var harness v1.Harness
+	if err := req.Get(&harness, req.Namespace, agent.Spec.Manifest.HarnessID); err != nil {
+		return err
+	}
+
+	// The credential is resolved before the config rather than attached after
+	// it, because the config embeds it: every MCP header and model key in there
+	// is this credential, so it has to exist before the config is rendered.
+	credential, credentialVersion, err := h.instanceCredential(req.Ctx, instance)
+	if err != nil {
+		return err
+	}
+
+	desired, err := h.builder.Build(req.Ctx, BuildInput{
+		Client:     req.Client,
+		Namespace:  req.Namespace,
+		Instance:   instance,
+		Agent:      &agent,
+		Harness:    &harness,
+		Credential: credential,
+	})
+	if err != nil {
+		return err
+	}
+	desired.Ref = ref
+	desired.Pool.ID = instance.Spec.PoolID
+	attachCredential(&desired, instance.Name, credential, credentialVersion)
+
+	// A sandbox has no size of its own: it takes an equal share of its pool.
+	// Carrying the result in desired state means resizing a pool changes every
+	// sandbox's revision and restarts it, which is the only way a running
+	// sandbox picks up new limits.
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, req.Namespace, instance.Spec.PoolID); err != nil {
+		return err
+	}
+	desired.Requests, desired.Limits, _ = agentbackend.SandboxShare(agentbackend.ResourceQuantity{
+		CPUVCPUs:     pool.Spec.Manifest.Capacity.CPUVCPUs,
+		MemoryBytes:  pool.Spec.Manifest.Capacity.MemoryBytes,
+		StorageBytes: pool.Spec.Manifest.Capacity.StorageBytes,
+	}, pool.Spec.Manifest.MaxSandboxes)
+
+	var observation agentbackend.InstanceObservation
+	if instance.Status.ObservedRevision == desired.Revision {
+		observation, err = h.backend.ObserveInstance(req.Ctx, ref)
+	} else {
+		observation, err = h.backend.ReconcileInstance(req.Ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	previous := instance.Status
+	h.applyObservation(instance, desired.Revision, observation)
+	interval := pollInterval(instance.Status.State)
+	resp.RetryAfter(interval)
+
+	// A status write emits a change event, which reconciles this instance again
+	// straight away. Writing unconditionally therefore means the controller
+	// triggers its own next pass and RetryAfter never applies, spinning as fast
+	// as storage allows. Only write when something actually moved, refreshing
+	// the heartbeat at most once per poll interval so the timestamp stays
+	// meaningful without driving the loop.
+	if statusUnchanged(previous, instance.Status) && !heartbeatDue(previous.LastObservedTime, h.now(), interval) {
+		instance.Status.LastObservedTime = previous.LastObservedTime
+		return nil
+	}
+	return req.Client.Status().Update(req.Ctx, instance)
+}
+
+// statusUnchanged compares everything an observation can set except the
+// heartbeat, which moves on every pass and so cannot be part of the decision to
+// write.
+func statusUnchanged(a, b v1.HostedAgentInstanceStatus) bool {
+	return a.State == b.State &&
+		a.URL == b.URL &&
+		a.Error == b.Error &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message &&
+		a.ObservedRevision == b.ObservedRevision &&
+		a.BackendID == b.BackendID &&
+		a.BackendGeneration == b.BackendGeneration
+}
+
+func heartbeatDue(last *metav1.Time, now time.Time, interval time.Duration) bool {
+	return last == nil || !now.Before(last.Add(interval))
+}
+
+// RemoveInstance asks the backend to remove an instance. The router retains
+// the finalizer while this handler requests a retry.
+func (h *Handler) RemoveInstance(req router.Request, resp router.Response) error {
+	instance := req.Object.(*v1.HostedAgentInstance)
+	if h.backend == nil {
+		return fmt.Errorf("hosted agent backend is not configured")
+	}
+	ref := instanceRef(instance)
+	result, err := h.backend.DeleteInstance(req.Ctx, ref)
+	if err != nil {
+		return err
+	}
+	if !result.Complete {
+		resp.RetryAfter(transitionalPollInterval)
+		return nil
+	}
+
+	// Revoke last. The credential outliving a failed teardown is recoverable;
+	// revoking before the sandbox is gone would leave a live agent holding a
+	// credential that no longer authenticates, which looks like a broken agent
+	// rather than a deletion in progress.
+	if h.credentials != nil {
+		if err := h.credentials.RevokeInstanceCredential(req.Ctx, instance.Name); err != nil {
+			return fmt.Errorf("revoke hosted agent credential: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// instanceCredential returns the sandbox's own credential and an opaque version
+// that changes when it is rotated.
+func (h *Handler) instanceCredential(ctx context.Context, instance *v1.HostedAgentInstance) (string, string, error) {
+	if h.credentials == nil {
+		return "", "", nil
+	}
+	value, version, err := h.credentials.EnsureInstanceCredential(ctx, instance.Name, instance.Spec.UserID)
+	if err != nil {
+		return "", "", fmt.Errorf("issue hosted agent credential: %w", err)
+	}
+	return value, version, nil
+}
+
+// attachCredential also places the raw credential in the sandbox.
+//
+// The config already carries it inside each endpoint, but an agent that needs
+// to call Obot for something the config does not describe would otherwise have
+// no token at all. It is a file rather than an environment variable: agents run
+// model-directed commands, and every subprocess inherits the environment.
+func attachCredential(desired *agentbackend.DesiredInstance, instanceName, value, version string) {
+	if value == "" {
+		return
+	}
+	desired.Secrets = append(desired.Secrets, agentbackend.SecretRef{
+		ID:       instanceName + "-credential",
+		Version:  version,
+		Value:    value,
+		FilePath: credentialFilePath,
+	})
+}
+
+func (h *Handler) applyObservation(instance *v1.HostedAgentInstance, desiredRevision string, observation agentbackend.InstanceObservation) {
+	instance.Status.ObservedRevision = observation.ObservedRevision
+	instance.Status.Reason = observation.Reason
+	instance.Status.Message = observation.Message
+	instance.Status.Error = ""
+	instance.Status.BackendGeneration = observation.BackendGeneration
+	now := metav1.NewTime(h.now())
+	instance.Status.LastObservedTime = &now
+
+	if observation.Ref.BackendID != "" {
+		instance.Status.BackendID = observation.Ref.BackendID
+	}
+	// The URL is intentionally sticky after the backend first advertises it.
+	if observation.URL != "" {
+		instance.Status.URL = observation.URL
+	}
+
+	switch {
+	case observation.ObservedRevision != desiredRevision:
+		instance.Status.State = types.HostedAgentStatePending
+	case observation.State == agentbackend.StateError:
+		instance.Status.State = types.HostedAgentStateError
+		instance.Status.Error = observation.Message
+	case observation.Exists &&
+		observation.State == agentbackend.StateReady &&
+		observation.ObservedRevision == desiredRevision:
+		instance.Status.State = types.HostedAgentStateReady
+	default:
+		instance.Status.State = types.HostedAgentStatePending
+	}
+}
+
+func instanceRef(instance *v1.HostedAgentInstance) agentbackend.InstanceRef {
+	id := string(instance.UID)
+	if id == "" {
+		// Objects normally have a UID before a controller sees them. The name is
+		// a deterministic fallback for storage implementations that assign it
+		// after the initial controller pass.
+		id = instance.Name
+	}
+	return agentbackend.InstanceRef{
+		ID:        id,
+		Namespace: instance.Namespace,
+		UserID:    instance.Spec.UserID,
+		BackendID: instance.Status.BackendID,
+	}
+}
+
+func pollInterval(state types.HostedAgentState) time.Duration {
+	if state == types.HostedAgentStateReady {
+		return readyPollInterval
+	}
+	return transitionalPollInterval
+}
+
+// defaultDesiredBuilder renders the sandbox's runtime contract.
+//
+// It holds the server URL because every endpoint it writes into the config is
+// absolute: the sandbox is told where to connect, never how to work it out.
+//
+// Two addresses, because the sandbox and the browser do not reach Obot the same
+// way. Writing one into both roles breaks whichever it is not: the public
+// address is commonly unroutable from inside the cluster, and the internal one
+// is meaningless to a browser.
+type defaultDesiredBuilder struct {
+	// ServerURL is Obot's public address, and so the only one a published
+	// agent can build links from.
+	ServerURL string
+	// InternalURL is Obot's address as a sandbox reaches it -- its models, its
+	// MCP servers, its own API. Empty means the two are the same.
+	InternalURL string
+	Skills      *skillFetcher
+}
+
+// internal is the address the sandbox calls back on, falling back to the public
+// one so a caller that knows of only a single address still builds a usable
+// config.
+func (b defaultDesiredBuilder) internal() string {
+	if b.InternalURL != "" {
+		return b.InternalURL
+	}
+	return b.ServerURL
+}
+
+// contentVersion identifies a config by its content, so that any change to it
+// -- a new MCP server, a rotated credential, an edited skill -- changes the
+// desired revision and restarts the sandbox, without the content itself ever
+// entering the revision.
+func contentVersion(content []byte) string {
+	sum := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func (b defaultDesiredBuilder) Build(ctx context.Context, in BuildInput) (agentbackend.DesiredInstance, error) {
+	instance, agent, harness := in.Instance, in.Agent, in.Harness
+	manifest := agent.Spec.Manifest
+	instanceManifest := instance.Spec.Manifest
+
+	answers := make(map[string]string, len(instanceManifest.Answers))
+	for key, value := range instanceManifest.Answers {
+		if !sensitiveQuestion(manifest.Questions, key) {
+			answers[key] = value
+		}
+	}
+
+	source := agentSource(manifest, instanceManifest)
+
+	// A template names MCP servers and skills portably, by their source and key,
+	// because the IDs an installation generates differ. Resolution happens here
+	// rather than being rewritten into the template at sync, so a reference that
+	// names nothing today resolves on its own once it is installed.
+	//
+	// Anything unresolved is dropped rather than failing the sandbox: the API
+	// reports the agent unavailable for the same reason, and a sandbox that
+	// starts with what it does have beats one that will not start at all.
+	mcpIDs := append(slices.Clone(manifest.MCPServers), instanceManifest.MCPServers...)
+	skillIDs := append(slices.Clone(manifest.Skills), instanceManifest.Skills...)
+	if in.Client != nil {
+		resolver := hostedagentrefs.New(in.Client, in.Namespace)
+		var unresolvedMCP, unresolvedSkills []string
+		mcpIDs, unresolvedMCP = resolver.MCPServers(ctx, mcpIDs)
+		skillIDs, unresolvedSkills = resolver.Skills(ctx, skillIDs)
+		for _, ref := range append(unresolvedMCP, unresolvedSkills...) {
+			log.Warnf("hosted agent %s: %q names nothing installed here; leaving it out", instance.Name, ref)
+		}
+	}
+
+	// Only an agent that serves HTTP is published, and only it needs to know
+	// where. The path uses the instance's resource ID because that is what the
+	// route is keyed on, not the backend identifier the config reports.
+	var publicPath, publicURL string
+	if manifest.Port > 0 {
+		publicPath = "/agent-connect/" + instance.Name
+		publicURL = strings.TrimSuffix(b.ServerURL, "/") + publicPath
+	}
+
+	config := agentConfig{
+		Version: "v1",
+		Instance: agentConfigMeta{
+			ID:     instanceRef(instance).ID,
+			UserID: instance.Spec.UserID,
+			Name:   instanceManifest.Name,
+		},
+		SecretsFile: agentSecretsPath,
+		Workspace:   workspacePath,
+		ListenPort:  manifest.Port,
+		PublicPath:  publicPath,
+		PublicURL:   publicURL,
+		ObotURL:     b.internal(),
+		MCPServers:  mcpServerConfigs(b.internal(), mcpIDs),
+		Answers:     answers,
+	}
+	if source.URL != "" {
+		config.Source = &agentConfigSource{URL: source.URL, Ref: source.Revision, Subdir: source.Subdir}
+	}
+
+	if in.Client != nil {
+		models, err := modelConfigs(ctx, in.Client, in.Namespace, b.internal(),
+			append(slices.Clone(manifest.Models), instanceManifest.Models...),
+			manifest.ModelProviders)
+		if err != nil {
+			return agentbackend.DesiredInstance{}, err
+		}
+		config.Models = models
+	}
+
+	// Skill files are placed in the sandbox rather than described to it: an
+	// agent should find its skills on disk, not go and fetch them.
+	var skillFiles []agentbackend.File
+	if in.Client != nil && b.Skills != nil {
+		skillFiles, config.Skills = b.Skills.skillFiles(ctx, in.Client, in.Namespace, skillIDs)
+	}
+
+	configBytes, err := json.Marshal(config)
+	if err != nil {
+		return agentbackend.DesiredInstance{}, fmt.Errorf("render agent config: %w", err)
+	}
+
+	secretsBytes, err := json.Marshal(buildSecrets(config, in.Credential))
+	if err != nil {
+		return agentbackend.DesiredInstance{}, fmt.Errorf("render agent secrets: %w", err)
+	}
+
+	env := make(map[string]string)
+	for _, value := range manifest.Env {
+		if !value.Sensitive {
+			env[value.Key] = value.Value
+		}
+	}
+
+	desired := agentbackend.DesiredInstance{
+		Ref:         instanceRef(instance),
+		Pool:        agentbackend.PoolRef{ID: instance.Spec.PoolID},
+		Name:        instanceManifest.Name,
+		Description: instanceManifest.Description,
+		Harness: agentbackend.Harness{
+			ID:          manifest.HarnessID,
+			Interactive: harness.Spec.Manifest.Interactive,
+		},
+		Image:    harness.Spec.Manifest.Image,
+		Source:   source,
+		Port:     manifest.Port,
+		Terminal: manifest.Terminal,
+		Env:      env,
+		// The configuration itself carries no credential, so it is an ordinary
+		// world-readable file: it can be inspected, logged or copied without
+		// leaking anything.
+		Files: append(skillFiles, agentbackend.File{
+			Path:    agentConfigPath,
+			Content: configBytes,
+			Mode:    0o444,
+		}),
+		// The credentials travel separately as a secret, which keeps them out
+		// of the desired revision. The version is the content hash, so a
+		// rotated credential still restarts the sandbox.
+		Secrets: []agentbackend.SecretRef{{
+			ID:       instance.Name + "-secrets",
+			Version:  contentVersion(secretsBytes),
+			Value:    string(secretsBytes),
+			FilePath: agentSecretsPath,
+		}},
+	}
+
+	revision, err := desiredRevision(desired)
+	if err != nil {
+		return agentbackend.DesiredInstance{}, err
+	}
+	desired.Revision = revision
+	return desired, nil
+}
+
+func desiredRevision(desired agentbackend.DesiredInstance) (string, error) {
+	// Secret values must never reach the revision. Their version markers still
+	// do, so a rotation changes the revision and restarts the sandbox without
+	// the revision ever containing a credential.
+	desired = desired.Redacted()
+	// Backend IDs are observations and must not perturb desired configuration.
+	desired.Ref.BackendID = ""
+	desired.Revision = ""
+	content, err := json.Marshal(desired)
+	if err != nil {
+		return "", fmt.Errorf("calculate hosted agent revision: %w", err)
+	}
+	sum := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func sensitiveQuestion(questions []types.HostedAgentQuestion, key string) bool {
+	for _, question := range questions {
+		if question.Key == key {
+			return question.Sensitive
+		}
+	}
+	return false
+}
+
+// agentSource picks the repository the sandbox clones.
+//
+// The ref travels with its own repository rather than being resolved
+// separately: a user who supplies their own repository picks the ref for that
+// repository, and the agent's ref -- which names a revision of a different
+// repository -- must not be applied to it.
+func agentSource(agent types.HostedAgentManifest, instance types.HostedAgentInstanceManifest) agentbackend.Source {
+	if instance.GitRepo != "" {
+		return agentbackend.Source{URL: instance.GitRepo, Revision: instance.GitRef}
+	}
+	return agentbackend.Source{URL: agent.GitRepo, Revision: agent.GitRef}
+}

--- a/pkg/controller/handlers/hostedagent/hostedagent_test.go
+++ b/pkg/controller/handlers/hostedagent/hostedagent_test.go
@@ -1,0 +1,234 @@
+package hostedagent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	types2 "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+)
+
+func TestDefaultDesiredBuilder(t *testing.T) {
+	instance := &v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "instance",
+			Namespace: "default",
+			UID:       ktypes.UID("instance-uid"),
+		},
+		Spec: v1.HostedAgentInstanceSpec{
+			UserID: "user-1",
+			PoolID: "pool-1",
+			Manifest: types2.HostedAgentInstanceManifest{
+				Name:    "My agent",
+				Answers: map[string]string{"public": "yes", "secret": "no"},
+				Skills:  []string{"personal"},
+			},
+		},
+	}
+	agent := &v1.HostedAgent{
+		Spec: v1.HostedAgentSpec{
+			Manifest: types2.HostedAgentManifest{
+				HarnessID:  "harness-1",
+				GitRepo:    "https://example.com/repo.git",
+				MCPServers: []string{"mcp-1"},
+				Models:     []string{"model-1"},
+				Skills:     []string{"shared"},
+				Env: []types2.HostedAgentEnv{
+					{Key: "PUBLIC", Value: "value"},
+					{Key: "SECRET", Value: "must-not-leak", Sensitive: true},
+				},
+				Questions: []types2.HostedAgentQuestion{
+					{Key: "public"},
+					{Key: "secret", Sensitive: true},
+				},
+			},
+		},
+	}
+	harness := &v1.Harness{
+		Spec: v1.HarnessSpec{
+			Manifest: types2.HarnessManifest{Image: "example/image:latest"},
+		},
+	}
+
+	desired, err := (defaultDesiredBuilder{}).Build(context.Background(), BuildInput{
+		Instance: instance, Agent: agent, Harness: harness,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if desired.Image != "example/image:latest" {
+		t.Fatalf("unexpected image %q", desired.Image)
+	}
+	if desired.Source.URL != "https://example.com/repo.git" {
+		t.Fatalf("unexpected source %q", desired.Source.URL)
+	}
+	if desired.Env["PUBLIC"] != "value" {
+		t.Fatalf("public environment was not rendered: %#v", desired.Env)
+	}
+	if _, ok := desired.Env["SECRET"]; ok {
+		t.Fatal("sensitive environment leaked into desired configuration")
+	}
+	// The config is an ordinary readable file; only the credentials that go
+	// with it are a secret.
+	config := ""
+	for _, file := range desired.Files {
+		if file.Path == agentConfigPath {
+			config = string(file.Content)
+		}
+	}
+	if config == "" {
+		t.Fatalf("no agent config was delivered: %#v", desired.Files)
+	}
+	for _, expected := range []string{"mcp-1", `"public":"yes"`} {
+		if !strings.Contains(config, expected) {
+			t.Errorf("agent config %q does not contain %q", config, expected)
+		}
+	}
+	for _, excluded := range []string{"must-not-leak", `"secret":"no"`} {
+		if strings.Contains(config, excluded) {
+			t.Errorf("agent config contains sensitive value %q", excluded)
+		}
+	}
+	if !strings.HasPrefix(desired.Revision, "sha256:") {
+		t.Fatalf("unexpected revision %q", desired.Revision)
+	}
+}
+
+func TestApplyObservationRequiresCurrentRevisionAndKeepsURL(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	handler := &Handler{now: func() time.Time { return now }}
+	instance := &v1.HostedAgentInstance{}
+
+	handler.applyObservation(instance, "wanted", agentbackend.InstanceObservation{
+		Exists:           true,
+		State:            agentbackend.StateReady,
+		ObservedRevision: "old",
+		URL:              "https://agent.example",
+		Ref:              agentbackend.InstanceRef{BackendID: "backend-1"},
+	})
+	if instance.Status.State != types2.HostedAgentStatePending {
+		t.Fatalf("stale revision must remain pending, got %q", instance.Status.State)
+	}
+
+	handler.applyObservation(instance, "wanted", agentbackend.InstanceObservation{
+		Exists:           true,
+		State:            agentbackend.StateReady,
+		ObservedRevision: "wanted",
+	})
+	if instance.Status.State != types2.HostedAgentStateReady {
+		t.Fatalf("current ready revision was %q", instance.Status.State)
+	}
+	if instance.Status.URL != "https://agent.example" {
+		t.Fatalf("URL was not sticky: %q", instance.Status.URL)
+	}
+	if instance.Status.BackendID != "backend-1" {
+		t.Fatalf("backend ID was not retained: %q", instance.Status.BackendID)
+	}
+	if instance.Status.LastObservedTime == nil || !instance.Status.LastObservedTime.Time.Equal(now) {
+		t.Fatalf("unexpected observation time %#v", instance.Status.LastObservedTime)
+	}
+}
+
+func TestDesiredRevisionIgnoresBackendID(t *testing.T) {
+	desired := agentbackend.DesiredInstance{
+		Ref:   agentbackend.InstanceRef{ID: "instance", BackendID: "first"},
+		Image: "image",
+	}
+	first, err := desiredRevision(desired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desired.Ref.BackendID = "second"
+	second, err := desiredRevision(desired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("backend ID changed revision: %q != %q", first, second)
+	}
+}
+
+func TestPoolSelectionAndNames(t *testing.T) {
+	assignments := []v1.HostedAgentPoolAssignment{
+		{Spec: v1.HostedAgentPoolAssignmentSpec{
+			Manifest: types2.HostedAgentPoolAssignmentManifest{
+				UserID: "user-1",
+				PoolID: "secondary",
+			},
+		}},
+		{Spec: v1.HostedAgentPoolAssignmentSpec{
+			Manifest: types2.HostedAgentPoolAssignmentManifest{
+				UserID:  "user-1",
+				PoolID:  "primary",
+				Default: true,
+			},
+		}},
+	}
+	if got := defaultPool(assignments); got != "primary" {
+		t.Fatalf("unexpected default pool %q", got)
+	}
+	if !isAssigned(assignments, "secondary") || isAssigned(assignments, "missing") {
+		t.Fatal("assignment membership was evaluated incorrectly")
+	}
+
+	pool1, assignment1 := initialPoolNames("user-1")
+	pool2, assignment2 := initialPoolNames("user-1")
+	otherPool, _ := initialPoolNames("user-2")
+	if pool1 != pool2 || assignment1 != assignment2 {
+		t.Fatal("initial pool names are not deterministic")
+	}
+	if pool1 == otherPool {
+		t.Fatal("different users received the same pool name")
+	}
+	if !strings.HasPrefix(pool1, "hp-") || !strings.HasPrefix(assignment1, "hps-") {
+		t.Fatalf("unexpected names %q and %q", pool1, assignment1)
+	}
+}
+
+// A status write emits a change event that reconciles the instance again at
+// once. Rewriting an identical status therefore makes the controller drive its
+// own next pass, which pegs a CPU rather than honouring the poll interval.
+func TestStatusUnchangedIgnoresHeartbeatOnly(t *testing.T) {
+	earlier := metav1.NewTime(time.Unix(1000, 0))
+	later := metav1.NewTime(time.Unix(2000, 0))
+
+	base := v1.HostedAgentInstanceStatus{
+		State:            types2.HostedAgentStateReady,
+		URL:              "http://sandbox",
+		ObservedRevision: "sha256:abc",
+		BackendID:        "obot-agent-1",
+		LastObservedTime: &earlier,
+	}
+	same := base
+	same.LastObservedTime = &later
+
+	if !statusUnchanged(base, same) {
+		t.Error("a moved heartbeat alone must not count as a status change")
+	}
+
+	changed := base
+	changed.State = types2.HostedAgentStateError
+	if statusUnchanged(base, changed) {
+		t.Error("a state change must count as a status change")
+	}
+}
+
+func TestHeartbeatDue(t *testing.T) {
+	last := metav1.NewTime(time.Unix(1000, 0))
+
+	if heartbeatDue(&last, time.Unix(1000, 0).Add(time.Second), time.Minute) {
+		t.Error("the heartbeat is not due before the poll interval has elapsed")
+	}
+	if !heartbeatDue(&last, time.Unix(1000, 0).Add(time.Minute), time.Minute) {
+		t.Error("the heartbeat is due once the poll interval has elapsed")
+	}
+	if !heartbeatDue(nil, time.Unix(1000, 0), time.Minute) {
+		t.Error("an instance that has never been observed is always due")
+	}
+}

--- a/pkg/controller/handlers/hostedagent/models_test.go
+++ b/pkg/controller/handlers/hostedagent/models_test.go
@@ -1,0 +1,215 @@
+package hostedagent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func modelObj(name, target, provider string) *v1.Model {
+	return &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+			Name:          name,
+			TargetModel:   target,
+			ModelProvider: provider,
+			Active:        true,
+			Usage:         types.ModelUsageLLM,
+		}},
+	}
+}
+
+func aliasObj(name, model string) *v1.DefaultModelAlias {
+	return &v1.DefaultModelAlias{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec:       v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: name, Model: model}},
+	}
+}
+
+// A wildcard grants every model. Telling the sandbox about none of them leaves
+// an agent unable to use what it was granted, with no way to discover it.
+func TestWildcardListsEveryModel(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1sonnet", "claude-sonnet-4-5", system.AnthropicModelProvider),
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+		modelObj("m1mini", "gpt-5-mini", system.OpenAIModelProvider),
+		aliasObj("llm", "m1sonnet"),
+		aliasObj("llm-mini", "m1mini"),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com", []string{"*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 3 {
+		t.Fatalf("models = %d, want 3: %+v", len(models), models)
+	}
+
+	var gotDefault string
+	defaults := 0
+	for _, model := range models {
+		if model.BaseURL == "" || len(model.APIs) == 0 {
+			t.Errorf("%s: incomplete endpoint %+v", model.ID, model)
+		}
+		if model.Default {
+			gotDefault = model.ID
+			defaults++
+		}
+	}
+	// The default follows the installation's own llm alias.
+	if gotDefault != "m1sonnet" {
+		t.Errorf("default = %q, want m1sonnet (what obot://llm points at)", gotDefault)
+	}
+	// Exactly one: an image asking for "the default" must not have to choose.
+	if defaults != 1 {
+		t.Errorf("models marked default = %d, want 1", defaults)
+	}
+}
+
+// An alias names one model, and that is all the agent gets.
+func TestAliasSelectionResolvesToOneModel(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1sonnet", "claude-sonnet-4-5", system.AnthropicModelProvider),
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+		aliasObj("llm", "m1sonnet"),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{types.DefaultModelAliasRefPrefix + "llm"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "m1sonnet" || !models[0].Default {
+		t.Fatalf("models = %+v", models)
+	}
+}
+
+// With no alias bound there is still a model to reach for; an image that wants
+// one should not have to choose arbitrarily.
+func TestSomethingIsAlwaysDefault(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com", []string{"*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || !models[0].Default {
+		t.Fatalf("expected a default even with no aliases bound: %+v", models)
+	}
+}
+
+// A model whose provider has no proxy route cannot be reached, so listing it
+// would offer an endpoint that does not exist.
+func TestUnroutableProviderIsSkipped(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1weird", "some-model", "not-a-real-provider"),
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com", []string{"*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "m1gpt" {
+		t.Fatalf("models = %+v", models)
+	}
+}
+
+// A template is copied to every installation, where a model's resource id is a
+// different hash. Naming a model the way its provider does is the only
+// preference that survives that copy, so it has to resolve.
+func TestProviderNativeIDSelectsAModel(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1aaa", "claude-haiku-4-5", system.AnthropicModelProvider),
+		modelObj("m1zzz", "claude-opus-4-8", system.AnthropicModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{"claude-opus-4-8", "*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+
+	// Named first, so it leads the list and is what Default falls back to --
+	// rather than m1aaa, which merely sorts first.
+	if models[0].Model != "claude-opus-4-8" || !models[0].Default {
+		t.Fatalf("expected the named model to lead and be default: %+v", models)
+	}
+	// The wildcard still contributes the rest, so a preference narrows nothing.
+	if len(models) != 2 {
+		t.Fatalf("expected the wildcard to still add the others: %+v", models)
+	}
+}
+
+// The point of listing preferences: without them the fallback is whichever
+// resource id sorts first, which has nothing to do with what the agent needs.
+// This is the Claude Code case -- a coding agent that was landing on the small
+// fast model because the installation's llm alias names a provider it cannot use.
+func TestPreferenceBeatsSortOrderWhenTheAliasDoesNotApply(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1aaa", "claude-haiku-4-5", system.AnthropicModelProvider),
+		modelObj("m1zzz", "claude-opus-4-8", system.AnthropicModelProvider),
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+		// Bound to a model this agent may not use, so it cannot decide.
+		aliasObj("llm", "m1gpt"),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{"claude-opus-4-8", "*"}, []string{system.AnthropicModelProvider})
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	for _, model := range models {
+		if model.Default && model.Model != "claude-opus-4-8" {
+			t.Fatalf("default is %q, want the stated preference", model.Model)
+		}
+	}
+	if models[0].Model != "claude-opus-4-8" {
+		t.Fatalf("models = %+v", models)
+	}
+}
+
+// An installation that has the named model is the easy case; one that does not
+// still has to produce a working agent, or a template pinning a model would
+// break every installation without it.
+func TestUnknownPreferenceFallsBackToTheWildcard(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1aaa", "claude-haiku-4-5", system.AnthropicModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{"claude-opus-4-8", "*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || models[0].Model != "claude-haiku-4-5" || !models[0].Default {
+		t.Fatalf("expected the wildcard to carry the agent: %+v", models)
+	}
+}
+
+// The same provider-native id can be served by more than one provider. Honouring
+// a preference from a provider the agent may not use would drop it later, and
+// the template would look configured while changing nothing.
+func TestPreferenceRespectsTheAgentsProviders(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1bedrock", "claude-opus-4-8", "bedrock-model-provider"),
+		modelObj("m1anthropic", "claude-opus-4-8", system.AnthropicModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{"claude-opus-4-8"}, []string{system.AnthropicModelProvider})
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "m1anthropic" {
+		t.Fatalf("models = %+v", models)
+	}
+}

--- a/pkg/controller/handlers/hostedagent/skills.go
+++ b/pkg/controller/handlers/hostedagent/skills.go
@@ -1,0 +1,244 @@
+package hostedagent
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	gitpkg "github.com/obot-platform/obot/pkg/git"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// skillsMountRoot is where an agent finds its skills. Each skill gets a
+	// directory named after the skill.
+	skillsMountRoot = "/etc/obot/skills"
+
+	// maxSkillFileBytes and maxSkillBytes bound what one skill can contribute.
+	// Skill files land in a Kubernetes Secret, which is capped at 1MiB in
+	// total, so a single oversized skill would otherwise make the whole sandbox
+	// unschedulable with an error that says nothing about skills.
+	maxSkillFileBytes = 256 << 10
+	maxSkillBytes     = 512 << 10
+)
+
+// skillFetcher reads a skill's files out of the repository it was indexed from.
+//
+// Obot stores only the coordinates of a skill, never its content, so the files
+// have to be fetched. Results are cached by commit: a skill pinned to a commit
+// cannot change, and reconciliation is frequent enough that cloning every pass
+// would be untenable.
+type skillFetcher struct {
+	mu    sync.Mutex
+	cache map[string][]agentbackend.File
+
+	// clone is injectable so tests do not need a git server.
+	clone func(ctx context.Context, repoURL, token, ref string) (string, string, func(), error)
+}
+
+func newSkillFetcher() *skillFetcher {
+	return &skillFetcher{
+		cache: map[string][]agentbackend.File{},
+		clone: gitpkg.Clone,
+	}
+}
+
+// skillFiles returns the files for each skill and the config entries describing
+// where they were placed.
+//
+// A skill that cannot be fetched is skipped rather than failing the sandbox: an
+// agent usually has several, and one unreachable repository should not stop it
+// from starting.
+func (f *skillFetcher) skillFiles(ctx context.Context, client kclient.Client, namespace string, ids []string) ([]agentbackend.File, []agentConfigSkill) {
+	var (
+		files   []agentbackend.File
+		entries []agentConfigSkill
+		seen    = map[string]struct{}{}
+	)
+
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		var skill v1.Skill
+		if err := client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: id}, &skill); err != nil {
+			log.Warnf("hosted agent: skipping skill %q: %v", id, err)
+			continue
+		}
+
+		name := skillDirName(&skill)
+		mount := path.Join(skillsMountRoot, name)
+
+		skillFiles, err := f.fetch(ctx, &skill, mount)
+		if err != nil {
+			log.Warnf("hosted agent: skipping skill %q: %v", id, err)
+			continue
+		}
+
+		files = append(files, skillFiles...)
+		entries = append(entries, agentConfigSkill{
+			ID:          skill.Name,
+			Name:        name,
+			Path:        mount,
+			Description: skill.Spec.Description,
+		})
+	}
+	return files, entries
+}
+
+// skillDirName is the directory a skill is installed under. The manifest name
+// is preferred over the generated ID because an agent reads these paths.
+func skillDirName(skill *v1.Skill) string {
+	name := strings.TrimSpace(skill.Spec.Name)
+	if name == "" {
+		name = skill.Name
+	}
+	return sanitizeSkillName(name)
+}
+
+// sanitizeSkillName keeps a skill name usable as a single path segment. A name
+// comes from a third-party repository, so "../" must not be able to place files
+// outside the skills directory.
+func sanitizeSkillName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	result := strings.Trim(b.String(), ".-")
+	if result == "" {
+		return "skill"
+	}
+	return result
+}
+
+func (f *skillFetcher) fetch(ctx context.Context, skill *v1.Skill, mount string) ([]agentbackend.File, error) {
+	if skill.Spec.RepoURL == "" {
+		return nil, fmt.Errorf("skill has no repository")
+	}
+
+	key := skill.Spec.RepoURL + "@" + skill.Spec.CommitSHA + "#" + skill.Spec.RelativePath + "->" + mount
+	// Only a commit-pinned skill is cacheable. Without a commit the repository
+	// could have moved, and serving a stale checkout would silently pin the
+	// agent to an old version of the skill.
+	cacheable := skill.Spec.CommitSHA != ""
+
+	if cacheable {
+		f.mu.Lock()
+		cached, ok := f.cache[key]
+		f.mu.Unlock()
+		if ok {
+			return cached, nil
+		}
+	}
+
+	ref := skill.Spec.CommitSHA
+	if ref == "" {
+		ref = skill.Spec.RepoRef
+	}
+	dir, _, cleanup, err := f.clone(ctx, skill.Spec.RepoURL, "", ref)
+	if err != nil {
+		return nil, fmt.Errorf("clone %s: %w", skill.Spec.RepoURL, err)
+	}
+	defer cleanup()
+
+	root := dir
+	if skill.Spec.RelativePath != "" {
+		root = filepath.Join(dir, filepath.FromSlash(skill.Spec.RelativePath))
+	}
+	// The skill's own directory is what gets installed, not the file naming it.
+	if info, err := os.Stat(root); err == nil && !info.IsDir() {
+		root = filepath.Dir(root)
+	}
+
+	files, err := readSkillDir(root, mount)
+	if err != nil {
+		return nil, err
+	}
+
+	if cacheable {
+		f.mu.Lock()
+		f.cache[key] = files
+		f.mu.Unlock()
+	}
+	return files, nil
+}
+
+// readSkillDir collects a skill's files, rooted at the mount point it will be
+// installed under.
+func readSkillDir(root, mount string) ([]agentbackend.File, error) {
+	var (
+		files []agentbackend.File
+		total int
+	)
+
+	err := filepath.WalkDir(root, func(current string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// A symlink could point anywhere in the checkout, or out of it.
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Size() > maxSkillFileBytes {
+			return fmt.Errorf("%s is larger than the %d byte per-file limit", entry.Name(), maxSkillFileBytes)
+		}
+		total += int(info.Size())
+		if total > maxSkillBytes {
+			return fmt.Errorf("skill exceeds the %d byte limit", maxSkillBytes)
+		}
+
+		rel, err := filepath.Rel(root, current)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(current)
+		if err != nil {
+			return err
+		}
+		files = append(files, agentbackend.File{
+			Path:    path.Join(mount, filepath.ToSlash(rel)),
+			Content: content,
+			Mode:    0o444,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Stable order: the file set feeds the desired revision, and a walk that
+	// reordered itself would restart every sandbox for no reason.
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, nil
+}

--- a/pkg/controller/handlers/hostedagent/skills_test.go
+++ b/pkg/controller/handlers/hostedagent/skills_test.go
@@ -1,0 +1,133 @@
+package hostedagent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// fakeRepo writes a skill directory and returns a clone function serving it.
+func fakeRepo(t *testing.T, files map[string]string) (func(context.Context, string, string, string) (string, string, func(), error), *int) {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		full := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	calls := 0
+	return func(context.Context, string, string, string) (string, string, func(), error) {
+		calls++
+		return dir, "sha", func() {}, nil
+	}, &calls
+}
+
+func skillClient(skills ...*v1.Skill) *fake.ClientBuilder {
+	builder := fake.NewClientBuilder().WithScheme(storagescheme.Scheme)
+	for _, skill := range skills {
+		builder = builder.WithObjects(skill)
+	}
+	return builder
+}
+
+// Obot stores only a skill's coordinates, so the files have to be fetched and
+// placed in the sandbox. An agent should find its skills on disk rather than
+// being told where to go and get them.
+func TestSkillFilesArePlacedInTheSandbox(t *testing.T) {
+	clone, calls := fakeRepo(t, map[string]string{
+		"SKILL.md":           "# PDF skill",
+		"scripts/extract.py": "print('hi')",
+		".git/config":        "should not be copied",
+	})
+	fetcher := &skillFetcher{cache: map[string][]agentbackend.File{}, clone: clone}
+
+	client := skillClient(&v1.Skill{
+		ObjectMeta: metav1.ObjectMeta{Name: "sk1pdf", Namespace: "obot"},
+		Spec: v1.SkillSpec{
+			SkillManifest: types.SkillManifest{Name: "pdf", Description: "Work with PDFs"},
+			RepoURL:       "https://example.com/skills.git",
+			CommitSHA:     "abc123",
+		},
+	}).Build()
+
+	files, entries := fetcher.skillFiles(context.Background(), client, "obot", []string{"sk1pdf"})
+
+	if len(entries) != 1 || entries[0].Path != "/etc/obot/skills/pdf" {
+		t.Fatalf("entries = %+v", entries)
+	}
+	if entries[0].Description != "Work with PDFs" {
+		t.Errorf("description = %q", entries[0].Description)
+	}
+
+	paths := map[string]string{}
+	for _, file := range files {
+		paths[file.Path] = string(file.Content)
+	}
+	if paths["/etc/obot/skills/pdf/SKILL.md"] != "# PDF skill" {
+		t.Errorf("SKILL.md missing or wrong: %v", paths)
+	}
+	if paths["/etc/obot/skills/pdf/scripts/extract.py"] == "" {
+		t.Errorf("nested file missing: %v", paths)
+	}
+	for path := range paths {
+		if strings.Contains(path, ".git") {
+			t.Errorf("git metadata was copied: %s", path)
+		}
+	}
+
+	// A pinned skill cannot change, so it is fetched once however often the
+	// instance reconciles.
+	fetcher.skillFiles(context.Background(), client, "obot", []string{"sk1pdf"})
+	if *calls != 1 {
+		t.Errorf("clone calls = %d, want 1 (the result should be cached)", *calls)
+	}
+}
+
+// A skill name comes from a third-party repository, so it must not be able to
+// place files outside the skills directory.
+func TestSkillNameCannotEscapeTheSkillsDirectory(t *testing.T) {
+	for _, tt := range []struct{ name, want string }{
+		{"pdf", "pdf"},
+		{"../../etc/passwd", "etc-passwd"},
+		{"a/b", "a-b"},
+		{"..", "skill"},
+		// With no manifest name the object name is used, which is still a
+		// stable, unique directory.
+		{"", "sk1"},
+	} {
+		skill := &v1.Skill{
+			ObjectMeta: metav1.ObjectMeta{Name: "sk1"},
+			Spec:       v1.SkillSpec{SkillManifest: types.SkillManifest{Name: tt.name}},
+		}
+		if got := skillDirName(skill); got != tt.want {
+			t.Errorf("skillDirName(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+// One unreachable skill repository should not stop an agent that has others.
+func TestUnfetchableSkillIsSkipped(t *testing.T) {
+	fetcher := &skillFetcher{cache: map[string][]agentbackend.File{}}
+	client := skillClient(&v1.Skill{
+		ObjectMeta: metav1.ObjectMeta{Name: "sk1broken", Namespace: "obot"},
+		Spec:       v1.SkillSpec{SkillManifest: types.SkillManifest{Name: "broken"}},
+	}).Build()
+
+	files, entries := fetcher.skillFiles(context.Background(), client, "obot", []string{"sk1broken", "sk1missing"})
+	if len(files) != 0 || len(entries) != 0 {
+		t.Fatalf("expected nothing for unfetchable skills: %v %v", files, entries)
+	}
+}

--- a/pkg/controller/handlers/hostedagentpool/hostedagentpool.go
+++ b/pkg/controller/handlers/hostedagentpool/hostedagentpool.go
@@ -1,0 +1,130 @@
+// Package hostedagentpool reconciles hosted-agent capacity pools
+// through the implementation-neutral agent backend contract.
+package hostedagentpool
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+)
+
+const pollInterval = 10 * time.Second
+
+type Handler struct {
+	backend agentbackend.PoolBackend
+}
+
+func New(backend agentbackend.PoolBackend) *Handler {
+	return &Handler{backend: backend}
+}
+
+// Orchestrate converges one pool with its backend pool.
+func (h *Handler) Orchestrate(req router.Request, resp router.Response) error {
+	pool := req.Object.(*v1.HostedAgentPool)
+	if h.backend == nil {
+		return fmt.Errorf("hosted agent backend is not configured")
+	}
+
+	ref := poolRef(pool)
+	desired, err := desiredPool(pool, ref)
+	if err != nil {
+		return err
+	}
+	observation, err := h.backend.ReconcilePool(req.Ctx, desired)
+	if err != nil {
+		return err
+	}
+	previous := pool.Status
+	applyObservation(pool, desired.Revision, observation)
+	resp.RetryAfter(pollInterval)
+
+	// Writing an unchanged status still emits a change event, which reconciles
+	// this pool again immediately and defeats RetryAfter. The status has
+	// no heartbeat field, so an exact comparison is enough.
+	if pool.Status == previous {
+		return nil
+	}
+	return req.Client.Status().Update(req.Ctx, pool)
+}
+
+// Remove asks the backend to remove a pool. The router retains the
+// finalizer while this handler requests a retry.
+func (h *Handler) Remove(req router.Request, resp router.Response) error {
+	pool := req.Object.(*v1.HostedAgentPool)
+	if h.backend == nil {
+		return fmt.Errorf("hosted agent backend is not configured")
+	}
+	ref := poolRef(pool)
+	result, err := h.backend.DeletePool(req.Ctx, ref)
+	if err != nil {
+		return err
+	}
+	if !result.Complete {
+		resp.RetryAfter(pollInterval)
+		return nil
+	}
+	return nil
+}
+
+func desiredPool(pool *v1.HostedAgentPool, ref agentbackend.PoolRef) (agentbackend.DesiredPool, error) {
+	if err := pool.Spec.Manifest.Validate(); err != nil {
+		return agentbackend.DesiredPool{}, fmt.Errorf("invalid hosted agent pool: %w", err)
+	}
+	desired := agentbackend.DesiredPool{
+		Ref:          ref,
+		MaxSandboxes: pool.Spec.Manifest.MaxSandboxes,
+		Capacity: agentbackend.ResourceQuantity{
+			CPUVCPUs:     pool.Spec.Manifest.Capacity.CPUVCPUs,
+			MemoryBytes:  pool.Spec.Manifest.Capacity.MemoryBytes,
+			StorageBytes: pool.Spec.Manifest.Capacity.StorageBytes,
+		},
+		Suspended: pool.Spec.Manifest.Suspended,
+	}
+	revisionValue := struct {
+		Capacity  agentbackend.ResourceQuantity `json:"capacity"`
+		Suspended bool                          `json:"suspended"`
+	}{
+		Capacity:  desired.Capacity,
+		Suspended: desired.Suspended,
+	}
+	data, err := json.Marshal(revisionValue)
+	if err != nil {
+		return agentbackend.DesiredPool{}, fmt.Errorf("marshal pool revision input: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	desired.Revision = hex.EncodeToString(sum[:])
+	return desired, nil
+}
+
+func poolRef(pool *v1.HostedAgentPool) agentbackend.PoolRef {
+	return agentbackend.PoolRef{
+		// Pool assignments and HostedAgentInstance.PoolID refer to
+		// the pool resource ID (its storage name), so the backend's
+		// managed pool identity must use that same stable value.
+		ID:        pool.Name,
+		BackendID: pool.Status.BackendPoolID,
+	}
+}
+
+func applyObservation(pool *v1.HostedAgentPool, desiredRevision string, observation agentbackend.PoolObservation) {
+	if observation.Ref.BackendID != "" {
+		pool.Status.BackendPoolID = observation.Ref.BackendID
+	}
+	pool.Status.ObservedRevision = observation.ObservedRevision
+	pool.Status.Schedulable = observation.Schedulable
+	pool.Status.Reason = observation.Reason
+	pool.Status.Message = observation.Message
+	pool.Status.Capacity.CPUVCPUs = observation.Capacity.CPUVCPUs
+	pool.Status.Capacity.MemoryBytes = observation.Capacity.MemoryBytes
+	pool.Status.Capacity.StorageBytes = observation.Capacity.StorageBytes
+	pool.Status.Ready = observation.Exists &&
+		observation.State == agentbackend.StateReady &&
+		observation.ObservedRevision == desiredRevision
+	pool.Status.Degraded = observation.State == agentbackend.StateError
+}

--- a/pkg/controller/handlers/hostedagentpool/hostedagentpool_test.go
+++ b/pkg/controller/handlers/hostedagentpool/hostedagentpool_test.go
@@ -1,0 +1,94 @@
+package hostedagentpool
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDesiredPoolIsStableAndUsesObotID(t *testing.T) {
+	pool := validPool()
+
+	first, err := desiredPool(pool, poolRef(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := desiredPool(pool, poolRef(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Revision == "" || first.Revision != second.Revision {
+		t.Fatalf("revision is not deterministic: %q, %q", first.Revision, second.Revision)
+	}
+	if first.Ref.ID != "pool-1" {
+		t.Fatalf("backend did not receive Obot-managed ID: %q", first.Ref.ID)
+	}
+
+	pool.Spec.Manifest.Suspended = true
+	changed, err := desiredPool(pool, poolRef(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.Revision == first.Revision {
+		t.Fatal("suspension did not change desired revision")
+	}
+}
+
+func TestDesiredPoolRejectsZeroCapacity(t *testing.T) {
+	pool := validPool()
+	pool.Spec.Manifest.Capacity.MemoryBytes = 0
+	if _, err := desiredPool(pool, poolRef(pool)); err == nil {
+		t.Fatal("expected zero memory capacity to be rejected")
+	}
+}
+
+func TestApplyObservationRequiresMatchingReadyRevision(t *testing.T) {
+	pool := validPool()
+	observation := agentbackend.PoolObservation{
+		Ref:               agentbackend.PoolRef{ID: "a1", BackendID: "pool-1"},
+		Exists:            true,
+		ObservedRevision:  "old",
+		State:             agentbackend.StateReady,
+		Schedulable:       true,
+		BackendGeneration: 3,
+		Capacity: agentbackend.ResourceQuantity{
+			CPUVCPUs: 2, MemoryBytes: 1024, StorageBytes: 2048,
+		},
+	}
+	applyObservation(pool, "wanted", observation)
+	if pool.Status.Ready {
+		t.Fatal("pool was ready with a stale revision")
+	}
+	if pool.Status.BackendPoolID != "pool-1" || !pool.Status.Schedulable {
+		t.Fatalf("backend observation was not retained: %#v", pool.Status)
+	}
+
+	observation.ObservedRevision = "wanted"
+	applyObservation(pool, "wanted", observation)
+	if !pool.Status.Ready || pool.Status.Degraded {
+		t.Fatalf("matching observation was not ready: %#v", pool.Status)
+	}
+
+	observation.State = agentbackend.StateError
+	observation.Reason = "PoolFailed"
+	applyObservation(pool, "wanted", observation)
+	if !pool.Status.Degraded || pool.Status.Ready {
+		t.Fatalf("error observation was not degraded: %#v", pool.Status)
+	}
+}
+
+func validPool() *v1.HostedAgentPool {
+	return &v1.HostedAgentPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+		Spec: v1.HostedAgentPoolSpec{
+			Manifest: types.HostedAgentPoolManifest{
+				Capacity: types.HostedAgentResourceQuantity{
+					CPUVCPUs: 2, MemoryBytes: 1024, StorageBytes: 2048,
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/hostedagentpooldefaults_test.go
+++ b/pkg/controller/hostedagentpooldefaults_test.go
@@ -1,0 +1,105 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEnsureHostedAgentPoolDefaults(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).Build()
+
+	if err := ensureHostedAgentPoolDefaults(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+
+	var defaults v1.HostedAgentPoolDefaults
+	key := kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: "default"}
+	if err := client.Get(ctx, key, &defaults); err != nil {
+		t.Fatal(err)
+	}
+	if err := defaults.Spec.Manifest.Validate(); err != nil {
+		t.Fatalf("created invalid defaults: %v", err)
+	}
+
+	defaults.Spec.Manifest = types.HostedAgentPoolDefaultsManifest{
+		Capacity: types.HostedAgentResourceQuantity{
+			CPUVCPUs:     8,
+			MemoryBytes:  16,
+			StorageBytes: 32,
+		},
+		Suspended: true,
+	}
+	if err := client.Update(ctx, &defaults); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureHostedAgentPoolDefaults(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Get(ctx, key, &defaults); err != nil {
+		t.Fatal(err)
+	}
+	if defaults.Spec.Manifest.Capacity.CPUVCPUs != 8 || !defaults.Spec.Manifest.Suspended {
+		t.Fatalf("existing administrator defaults were changed: %#v", defaults.Spec.Manifest)
+	}
+}
+
+func TestEnsureHostedAgentPoolDefaultsPreservesExisting(t *testing.T) {
+	existing := &v1.HostedAgentPoolDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: system.DefaultNamespace},
+		Spec: v1.HostedAgentPoolDefaultsSpec{
+			Manifest: types.HostedAgentPoolDefaultsManifest{
+				Capacity: types.HostedAgentResourceQuantity{
+					CPUVCPUs:     2,
+					MemoryBytes:  1,
+					StorageBytes: 1,
+				},
+			},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(existing).Build()
+	if err := ensureHostedAgentPoolDefaults(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+
+	var got v1.HostedAgentPoolDefaults
+	if err := client.Get(context.Background(), kclient.ObjectKeyFromObject(existing), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.Manifest.Capacity.CPUVCPUs != 2 {
+		t.Fatalf("existing defaults were overwritten: %#v", got.Spec.Manifest)
+	}
+}
+
+// The seeded defaults must state the sandbox count rather than leaving it to
+// the fallback, or an administrator opening the defaults sees a blank field
+// while a different number is actually in force.
+func TestEnsureHostedAgentPoolDefaultsSeedsMaxSandboxes(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).Build()
+
+	if err := ensureHostedAgentPoolDefaults(context.Background(), client); err != nil {
+		t.Fatalf("ensureHostedAgentPoolDefaults: %v", err)
+	}
+
+	var defaults v1.HostedAgentPoolDefaults
+	if err := client.Get(context.Background(), kclient.ObjectKey{
+		Namespace: system.DefaultNamespace, Name: "default",
+	}, &defaults); err != nil {
+		t.Fatalf("get defaults: %v", err)
+	}
+
+	if defaults.Spec.Manifest.MaxSandboxes <= 0 {
+		t.Errorf("maxSandboxes = %d, want a positive seeded value", defaults.Spec.Manifest.MaxSandboxes)
+	}
+	if err := defaults.Spec.Manifest.Validate(); err != nil {
+		t.Errorf("seeded defaults are invalid: %v", err)
+	}
+}

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -5,10 +5,14 @@ import (
 	"github.com/obot-platform/obot/pkg/controller/generationed"
 	"github.com/obot-platform/obot/pkg/controller/handlers/accesscontrolrule"
 	"github.com/obot-platform/obot/pkg/controller/handlers/adminworkspace"
+	"github.com/obot-platform/obot/pkg/controller/handlers/agentcatalog"
 	"github.com/obot-platform/obot/pkg/controller/handlers/alias"
 	"github.com/obot-platform/obot/pkg/controller/handlers/auditlogexport"
 	"github.com/obot-platform/obot/pkg/controller/handlers/cleanup"
 	gitcredentialhandler "github.com/obot-platform/obot/pkg/controller/handlers/gitcredential"
+	"github.com/obot-platform/obot/pkg/controller/handlers/hostedagent"
+	hostedagentcreds "github.com/obot-platform/obot/pkg/controller/handlers/hostedagent/credentials"
+	"github.com/obot-platform/obot/pkg/controller/handlers/hostedagentpool"
 	"github.com/obot-platform/obot/pkg/controller/handlers/imagepullsecret"
 	"github.com/obot-platform/obot/pkg/controller/handlers/mcpcatalog"
 	"github.com/obot-platform/obot/pkg/controller/handlers/mcpserver"
@@ -54,6 +58,9 @@ func (c *Controller) setupRoutes() {
 	oauthclients := oauthclients.NewHandler(c.services.GatewayClient)
 	systemMCPServerHandler := systemmcpserver.New(c.services.GatewayClient, c.services.MCPSessionManager, c.services.ServerURL)
 	nanobotAgentHandler := nanobotagent.New(c.services.GatewayClient, c.services.LocalRouter, c.services.NanobotAgentImage, c.services.ServerURL, c.services.MCPServerNamespace, c.services.MCPSessionManager)
+	agentCatalogHandler := agentcatalog.New()
+	hostedAgentHandler := hostedagent.New(c.services.AgentBackend, hostedagentcreds.New(c.services.GatewayClient), c.services.ServerURL, c.services.AgentServerURL)
+	hostedAgentPoolHandler := hostedagentpool.New(c.services.AgentBackend)
 	oktaGroupMigrationHandler := oktagroupmigration.New()
 	projectHandler := project.New(c.services.GatewayClient)
 	imagePullSecretHandler := imagepullsecret.New(c.services.GatewayClient, c.services.LocalK8sClient, c.services.MCPRuntimeBackend, c.services.MCPServerNamespace, c.services.ServiceNamespace, c.services.ServiceAccountName, c.services.MCPImagePullSecrets, c.services.ServiceAccountIssuerURL)
@@ -105,6 +112,24 @@ func (c *Controller) setupRoutes() {
 
 	// Skill
 	root.Type(&v1.Skill{}).HandlerFunc(cleanup.Cleanup)
+
+	// AgentCatalog
+	root.Type(&v1.AgentCatalog{}).HandlerFunc(agentCatalogHandler.Sync)
+
+	// HostedAgent
+	// cleanup.Cleanup honors DeleteRefs, which removes agents whose AgentCatalog
+	// is gone. Hand-registered agents have no SourceID and are left alone.
+	root.Type(&v1.HostedAgent{}).HandlerFunc(cleanup.Cleanup)
+
+	// HostedAgentInstance
+	root.Type(&v1.HostedAgentInstance{}).HandlerFunc(cleanup.Cleanup)
+	root.Type(&v1.HostedAgentInstance{}).HandlerFunc(hostedAgentHandler.EnsurePool)
+	root.Type(&v1.HostedAgentInstance{}).FinalizeFunc(v1.HostedAgentInstanceFinalizer, hostedAgentHandler.RemoveInstance)
+	root.Type(&v1.HostedAgentInstance{}).HandlerFunc(hostedAgentHandler.OrchestrateInstance)
+
+	// HostedAgentPool
+	root.Type(&v1.HostedAgentPool{}).FinalizeFunc(v1.HostedAgentPoolFinalizer, hostedAgentPoolHandler.Remove)
+	root.Type(&v1.HostedAgentPool{}).HandlerFunc(hostedAgentPoolHandler.Orchestrate)
 
 	// ImagePullSecret
 	root.Type(&v1.ImagePullSecret{}).FinalizeFunc(v1.ImagePullSecretFinalizer, imagePullSecretHandler.Cleanup)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -20,9 +20,13 @@ import (
 	apiclienttypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	agentbackendfake "github.com/obot-platform/obot/pkg/agentbackend/fake"
+	agentbackendkubernetes "github.com/obot-platform/obot/pkg/agentbackend/kubernetes"
 	"github.com/obot-platform/obot/pkg/api/authn"
 	"github.com/obot-platform/obot/pkg/api/authz"
 	"github.com/obot-platform/obot/pkg/api/handlers"
+	"github.com/obot-platform/obot/pkg/api/handlers/agentconnect"
 	"github.com/obot-platform/obot/pkg/api/handlers/mcpgateway"
 	"github.com/obot-platform/obot/pkg/api/server"
 	"github.com/obot-platform/obot/pkg/api/server/audit"
@@ -80,6 +84,8 @@ import (
 
 var pkgLog = logger.Package()
 
+const leaderElectionRequestTimeout = 15 * time.Second
+
 type (
 	GatewayConfig     gserver.Options
 	AuditConfig       audit.Options
@@ -115,6 +121,8 @@ type Config struct {
 	MDMAssetSource                       string `usage:"The source for MDM assets (a local directory, a tar archive path, or an HTTP(S) tarball URL)" default:"https://github.com/obot-platform/obot-sentry/releases/download/v0.1.4/mdm-assets.tar.gz" env:"OBOT_SERVER_MDM_ASSET_SOURCE"`
 	DefaultSkillRepoURL                  string `usage:"The default skill repository URL (must be HTTPS GitHub URL)" default:"https://github.com/obot-platform/skills" env:"OBOT_DEFAULT_SKILL_REPO_URL"`
 	DefaultSkillRepoRef                  string `usage:"The ref (branch/tag) for the default skill repository" default:"" env:"OBOT_DEFAULT_SKILL_REPO_REF"`
+	DefaultHostedAgentsCatalogURL        string `usage:"The default hosted agent catalog repository URL (must be HTTPS)" default:"https://github.com/obot-platform/hosted-agents-catalog" env:"OBOT_DEFAULT_HOSTED_AGENTS_CATALOG_URL"`
+	DefaultHostedAgentsCatalogRef        string `usage:"The ref (branch/tag) for the default hosted agent catalog repository" default:"" env:"OBOT_DEFAULT_HOSTED_AGENTS_CATALOG_REF"`
 	ModelInfoSourceURL                   string `usage:"Authoritative URL for the model info (pricing) source synced into model costs; changes take effect on restart, empty disables it" default:"https://models.dev/api.json"`
 	DisableUpdateCheck                   bool   `usage:"Disable Obot server update checks"`
 	HideK8sDetails                       bool   `usage:"Hide Kubernetes configuration details such as the Server Scheduling page from the UI" default:"false"`
@@ -123,6 +131,11 @@ type Config struct {
 	LLMAuditLogRetentionDays             int    `usage:"Number of days to retain LLM audit logs (0 to disable cleanup)." default:"90"`
 	DisableLLMAuditLog                   bool   `usage:"Disable LLM gateway audit logging" default:"false"`
 	EnableAgents                         *bool  `usage:"Enable Obot Agent features. When unset, agents are disabled for new deployments but grandfathered in for deployments that already have agents. Explicitly set to true to force-enable, or false to force-disable, regardless of grandfathering." env:"OBOT_ENABLE_AGENTS"`
+	HostedAgentsBackend                  string `usage:"Hosted agent runtime backend (disabled, fake, or kubernetes). Defaults to the MCP runtime backend: kubernetes when MCP servers run on Kubernetes, and otherwise fake, since there is no docker agent backend." name:"hosted-agents-backend" env:"OBOT_HOSTED_AGENTS_BACKEND"`
+	HostedAgentsStorageClassName         string `usage:"StorageClass for hosted agent pool volumes. It should use volumeBindingMode WaitForFirstConsumer, which is what keeps a pool on one node." name:"hosted-agents-storage-class-name"`
+	HostedAgentsPodSecurityLevel         string `usage:"Pod Security Admission level enforced on the namespace hosted agent sandboxes run in (privileged, baseline, or restricted). Must match the namespace's own label or sandboxes are refused at admission. Empty means restricted." name:"hosted-agents-pod-security-level" env:"OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL"`
+	HostedAgentsImagePullPolicy          string `usage:"Pull policy for hosted agent sandbox images (Always, IfNotPresent, Never)" default:"" name:"hosted-agents-image-pull-policy" env:"OBOT_HOSTED_AGENTS_IMAGE_PULL_POLICY"`
+	HostedAgentsCleanupImage             string `usage:"Image used to erase a deleted sandbox's directory from its pool volume. Needs a shell and coreutils." name:"hosted-agents-cleanup-image" default:"busybox:1.36"`
 	MCPServerSearchImage                 string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.2.0"`
 	NanobotAgentImage                    string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/obot-platform/nanobot-agent:v0.0.91"`
 	MCPNetworkPolicyProviderChartRepo    string `usage:"Helm repository URL for the network policy provider chart"`
@@ -167,29 +180,35 @@ type Services struct {
 	AuditLogger           audit.Logger
 	DSN                   string
 	ServerURL             string
-	MCPSessionManager     *mcp.SessionManager
-	TunnelManager         *tunnel.Manager
-	OAuthServerConfig     handlers.OAuthAuthorizationServerConfig
+	// AgentServerURL is Obot's address as a sandbox can reach it, which differs
+	// from ServerURL when Obot runs outside the cluster its sandboxes run in.
+	AgentServerURL    string
+	MCPSessionManager *mcp.SessionManager
+	TunnelManager     *tunnel.Manager
+	OAuthServerConfig handlers.OAuthAuthorizationServerConfig
 
 	// Global token storage client for MCP OAuth
 	MCPOAuthTokenStorage         mcp.GlobalTokenStore
 	MCPSecretBindingAllowedLabel string
 	RegistryNoAuth               bool
 
-	PostgresDSN                 string
-	ProviderRegistryPaths       []string
-	DevUIPort                   int
-	UserUIPort                  int
-	GatewayServer               *gserver.Server
-	Bootstrapper                *bootstrap.Bootstrap
-	LocalAuthProvider           *localauth.Provider
-	AuthEnabled                 bool
-	DefaultMCPCatalogPath       string
-	DefaultSystemMCPCatalogPath string
-	MDMAssetSource              string
-	DefaultSkillRepoURL         string
-	DefaultSkillRepoRef         string
-	ModelInfoSourceURL          string
+	PostgresDSN                   string
+	ProviderRegistryPaths         []string
+	DevUIPort                     int
+	DevMode                       bool
+	UserUIPort                    int
+	GatewayServer                 *gserver.Server
+	Bootstrapper                  *bootstrap.Bootstrap
+	LocalAuthProvider             *localauth.Provider
+	AuthEnabled                   bool
+	DefaultMCPCatalogPath         string
+	DefaultSystemMCPCatalogPath   string
+	MDMAssetSource                string
+	DefaultSkillRepoURL           string
+	DefaultSkillRepoRef           string
+	DefaultHostedAgentsCatalogURL string
+	DefaultHostedAgentsCatalogRef string
+	ModelInfoSourceURL            string
 
 	// Used for indexed lookups of access control rules.
 	AccessControlRuleHelper *accesscontrolrule.Helper
@@ -199,6 +218,9 @@ type Services struct {
 
 	// Used for indexed lookups of skill access rules.
 	SkillAccessRuleHelper *skillaccessrule.Helper
+
+	// Used for indexed lookups of hosted agent access rules.
+	HostedAgentAccessRuleHelper *hostedagentaccessrule.Helper
 
 	MCPOAuthClientSecretExpiration time.Duration
 	ForceDynamicClient             bool
@@ -230,13 +252,19 @@ type Services struct {
 	// environment/Helm config and not modifiable via UI.
 	PSASettingsFromHelm *v1.PodSecurityAdmissionSettings
 
-	DisableUpdateCheck                   bool
-	HideK8sDetails                       bool
-	MCPRuntimeBackend                    string
-	MCPImagePullSecrets                  []string
-	MCPHTTPWebhookBaseImage              string
-	MessagePoliciesEnabled               bool
-	EnableAgents                         *bool
+	DisableUpdateCheck      bool
+	HideK8sDetails          bool
+	MCPRuntimeBackend       string
+	MCPImagePullSecrets     []string
+	MCPHTTPWebhookBaseImage string
+	MessagePoliciesEnabled  bool
+	EnableAgents            *bool
+	AgentBackend            agentbackend.Backend
+	AgentBackendKind        string
+	// AgentDevRouter reaches sandboxes from outside the cluster. It is set only
+	// in development; in production Obot runs in-cluster and the sandbox address
+	// resolves directly.
+	AgentDevRouter                       agentconnect.DevRouter
 	MCPNetworkPolicyEnabled              bool
 	MCPDefaultDenyAllEgress              bool
 	MCPServerSearchImage                 string
@@ -488,7 +516,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	if config.ElectionFile != "" {
 		electionConfig = leader.NewFileElectionConfig(config.ElectionFile)
 	} else {
-		electionConfig = leader.NewDefaultElectionConfig("", "obot-controller", restConfig)
+		electionConfig = leader.NewDefaultElectionConfig("", "obot-controller", leaderElectionRESTConfig(restConfig))
 	}
 	r, err := nah.NewRouter("obot-controller", &nah.Options{
 		RESTConfig:     restConfig,
@@ -547,11 +575,17 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		serviceAccountIssuerURL   string
 		serviceAccountIssuerError string
 	)
-	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+	// Hosted agents can require a cluster independently of how MCP servers run,
+	// so either feature is reason enough to build a local config.
+	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) || hostedAgentsNeedK8s(config) {
 		localK8sConfig, err = BuildLocalK8sConfig()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build local Kubernetes config: %w", err)
 		}
+	}
+	if localK8sConfig != nil && mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+		// Image pull secret issuance is an MCP concern and has no bearing on
+		// hosted agents.
 		serviceAccountIssuerURL, err = imagepullsecrets.DiscoverServiceAccountIssuer(ctx, localK8sConfig)
 		if err != nil {
 			serviceAccountIssuerError = err.Error()
@@ -673,7 +707,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 			// The router is scoped to the MCP namespace, but the managed provider token
 			// secret lives in Obot's runtime namespace.
 			ByObject:       localK8sCacheByObject(config.MCPNamespace, config.ServiceNamespace),
-			ElectionConfig: leader.NewDefaultElectionConfig(config.MCPNamespace, "obot-local-controller", localK8sConfig),
+			ElectionConfig: leader.NewDefaultElectionConfig(config.MCPNamespace, "obot-local-controller", leaderElectionRESTConfig(localK8sConfig)),
 			HealthzPort:    -1, // Disable healthz port
 		})
 		if err != nil {
@@ -1061,6 +1095,81 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	}
 
 	authorizer := authz.NewAuthorizer(gatewayClient, r.Backend(), storageClient, config.DevMode, acrHelper, skillAccessRuleHelper, hostedAgentAccessRuleHelper, registryNoAuth)
+
+	// The kubernetes agent backend needs a client to the local cluster even when
+	// MCP servers do not run there -- the "hosted agents get the client
+	// directly" case the comment further down anticipates. It reuses the MCP
+	// client when one exists, and otherwise builds its own from the same
+	// config, so hosted agents work with a docker MCP backend without switching
+	// on the MCP-scoped router and its handlers.
+	agentLocalK8sClient := apiLocalK8sClient
+	if agentLocalK8sClient == nil && hostedAgentsNeedK8s(config) {
+		agentLocalK8sClient, err = kclient.NewWithWatch(localK8sConfig, kclient.Options{Scheme: k8sscheme.Scheme})
+		if err != nil {
+			return nil, fmt.Errorf("failed to build local k8s client for the agent backend: %w", err)
+		}
+	}
+	agentBackendKind, agentBackend, err := newHostedAgentsBackend(config, localK8sConfig, agentLocalK8sClient, localCacheClient)
+	if err != nil {
+		return nil, err
+	}
+
+	// Where a sandbox finds Obot depends on where Obot itself is running, and
+	// the two cases need different answers.
+	//
+	// In the cluster, the configured hostname resolving is not enough: it has to
+	// resolve somewhere a sandbox is permitted to reach, and the egress policy
+	// shipped with the chart excludes private ranges, so a hostname pointing at
+	// an internal load balancer or a node is refused even though it resolves.
+	// MCP servers have always answered this by addressing Obot's Service, and a
+	// sandbox reaches Obot for the same things, so TransformObotHostname gives
+	// it the same address rather than inventing a second mechanism.
+	//
+	// Outside the cluster -- a developer running Obot on their own machine --
+	// that method cannot answer at all: it substitutes Obot's Service, and there
+	// is no Service, so ServiceName is unset and it returns the hostname
+	// untouched. The hostname is a loopback address, which inside a sandbox
+	// means the sandbox. A node stands in for the developer's machine, since
+	// Obot listens on all of its interfaces, which is what ReachableServerURL
+	// resolves. It leaves any non-loopback hostname alone, so the in-cluster
+	// case falls through to the method above.
+	agentServerURL := config.Hostname
+	if agentBackendKind == "kubernetes" && agentLocalK8sClient != nil {
+		reachable, err := agentbackendkubernetes.ReachableServerURL(ctx, agentLocalK8sClient, config.Hostname)
+		if err != nil {
+			return nil, err
+		}
+		if reachable != config.Hostname {
+			agentServerURL = reachable
+		} else {
+			agentServerURL = mcpSessionManager.TransformObotHostname(config.Hostname)
+		}
+		if agentServerURL != config.Hostname {
+			pkgLog.Infof("hosted agent sandboxes will reach Obot at %s", agentServerURL)
+		}
+	}
+
+	// Running outside the cluster is what makes a sandbox unreachable, and it is
+	// exactly what falling back to a kubeconfig means. Reaching one through the
+	// API server needs services/proxy, which grants access to every Service in
+	// the cluster, so this is deliberately confined to development rather than
+	// something a production deployment is granted.
+	var agentDevRouter agentconnect.DevRouter
+	if router, ok := agentBackend.(agentconnect.DevRouter); ok && config.DevMode {
+		if _, inClusterErr := rest.InClusterConfig(); inClusterErr != nil {
+			agentDevRouter = router
+		}
+	}
+
+	// LocalK8sClient drives MCP-side cluster features: service account key
+	// rotation, image pull secret issuance, network policies. Hosted agents get
+	// the client directly, so this stays nil when MCP does not run on
+	// Kubernetes. Otherwise enabling hosted agents alone would switch on MCP
+	// machinery that needs configuration the deployment has no reason to set.
+	var mcpLocalK8sClient kclient.WithWatch
+	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+		mcpLocalK8sClient = apiLocalK8sClient
+	}
 	// For now, always auto-migrate the gateway database
 	svcs := &Services{
 		EncryptionConfig:      encryptionConfig,
@@ -1098,6 +1207,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		PostgresDSN:                  postgresDSN,
 		ObotNamespace:                config.ServiceNamespace,
 		DevUIPort:                    devPort,
+		DevMode:                      config.DevMode,
 		UserUIPort:                   config.UserUIPort,
 		ProviderRegistryPaths:        config.ProviderRegistries,
 		GatewayServer:                gatewayServer,
@@ -1110,6 +1220,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		DefaultSystemMCPCatalogPath:    config.DefaultSystemMCPCatalogPath,
 		DefaultSkillRepoURL:            config.DefaultSkillRepoURL,
 		DefaultSkillRepoRef:            config.DefaultSkillRepoRef,
+		DefaultHostedAgentsCatalogURL:  config.DefaultHostedAgentsCatalogURL,
+		DefaultHostedAgentsCatalogRef:  config.DefaultHostedAgentsCatalogRef,
 		ModelInfoSourceURL:             config.ModelInfoSourceURL,
 		MCPOAuthClientSecretExpiration: oauthClientExpiration,
 		ForceDynamicClient:             config.ForceDynamicClient,
@@ -1117,7 +1229,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		ModelAccessPolicyHelper:        mapHelper,
 
 		SkillAccessRuleHelper:                skillAccessRuleHelper,
-		LocalK8sClient:                       apiLocalK8sClient,
+		HostedAgentAccessRuleHelper:          hostedAgentAccessRuleHelper,
+		LocalK8sClient:                       mcpLocalK8sClient,
 		LocalRouter:                          localRouter,
 		EveryReplicaRouter:                   tunnelPeerRouter,
 		MCPServerNamespace:                   config.MCPNamespace,
@@ -1140,6 +1253,10 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		AgentIdleServerShutdownInterval:      time.Duration(config.IdleAgentShutdownHours) * time.Hour,
 		MessagePoliciesEnabled:               config.EnableMessagePolicies,
 		EnableAgents:                         config.EnableAgents,
+		AgentBackend:                         agentBackend,
+		AgentServerURL:                       agentServerURL,
+		AgentBackendKind:                     agentBackendKind,
+		AgentDevRouter:                       agentDevRouter,
 		MCPNetworkPolicyEnabled:              mcpNetworkPolicyEnabled,
 		MCPDefaultDenyAllEgress:              config.MCPDefaultDenyAllEgress,
 		MCPServerSearchImage:                 config.MCPServerSearchImage,
@@ -1280,6 +1397,82 @@ func configureDevMode(config Config) (int, Config) {
 	_ = os.Setenv("NAH_DEV_MODE", "true")
 	_ = os.Setenv("WORKSPACE_PROVIDER_IGNORE_WORKSPACE_NOT_FOUND", "true")
 	return config.DevUIPort, config
+}
+
+func leaderElectionRESTConfig(config *rest.Config) *rest.Config {
+	config = rest.CopyConfig(config)
+	if config.Timeout == 0 || config.Timeout > leaderElectionRequestTimeout {
+		config.Timeout = leaderElectionRequestTimeout
+	}
+	return config
+}
+
+// resolveHostedAgentsBackendKind applies the default so that callers which need to know
+// the backend before it is constructed agree with newHostedAgentsBackend.
+//
+// Unset follows the MCP runtime, because a deployment that already runs MCP
+// servers on a cluster has everything hosted agents need and would otherwise
+// have to name the same backend twice.
+//
+// A docker MCP runtime resolves to the fake backend for now, because there is
+// no docker agent backend yet. When one lands, this is where it goes: the
+// docker case becomes "docker" and the fallback stops being a placeholder.
+func resolveHostedAgentsBackendKind(config Config) string {
+	kind := strings.ToLower(strings.TrimSpace(config.HostedAgentsBackend))
+	if kind != "" {
+		return kind
+	}
+	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+		return "kubernetes"
+	}
+	return "fake"
+}
+
+func hostedAgentsNeedK8s(config Config) bool {
+	switch resolveHostedAgentsBackendKind(config) {
+	case "kubernetes", "k8s":
+		return true
+	default:
+		return false
+	}
+}
+
+func newHostedAgentsBackend(config Config, restConfig *rest.Config, client, cachedClient kclient.Client) (string, agentbackend.Backend, error) {
+	kind := resolveHostedAgentsBackendKind(config)
+
+	switch kind {
+	case "disabled":
+		return kind, agentbackend.Disabled{}, nil
+	case "fake":
+		return kind, agentbackendfake.New(agentbackendfake.Config{
+			TransitionDelay: time.Second,
+		}), nil
+	case "kubernetes", "k8s":
+		if client == nil {
+			return "", nil, fmt.Errorf("agent backend %q requires a local Kubernetes cluster, but no local K8s config is available", kind)
+		}
+		backend, err := agentbackendkubernetes.New(client, cachedClient, agentbackendkubernetes.Options{
+			// Sandboxes share the MCP namespace so that the existing local
+			// cluster router, which is scoped to it, sees them. Pools are
+			// separated by PriorityClass rather than by namespace.
+			Namespace:        config.MCPNamespace,
+			ClusterDomain:    config.MCPClusterDomain,
+			StorageClassName: config.HostedAgentsStorageClassName,
+			// Sandboxes share the MCP namespace, so they are admitted against
+			// whatever Pod Security level that namespace carries.
+			PodSecurityLevel: agentbackendkubernetes.ParsePodSecurityLevel(config.HostedAgentsPodSecurityLevel),
+			ImagePullSecrets: config.MCPImagePullSecrets,
+			CleanupImage:     config.HostedAgentsCleanupImage,
+			ImagePullPolicy:  config.HostedAgentsImagePullPolicy,
+			RESTConfig:       restConfig,
+		})
+		if err != nil {
+			return "", nil, err
+		}
+		return "kubernetes", backend, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported agent backend %q (expected disabled, fake, or kubernetes)", kind)
+	}
 }
 
 func startDevMode(ctx context.Context, storageClient storage.Client) {

--- a/pkg/services/config_test.go
+++ b/pkg/services/config_test.go
@@ -1,13 +1,107 @@
 package services
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/obot-platform/obot/pkg/agentbackend"
 	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
 )
+
+func TestNewAgentBackend(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       string
+		mcpBackend string
+		devMode    bool
+		wantKind   string
+		wantErr    bool
+		wantActive bool
+	}{
+		// Unset follows the MCP runtime rather than defaulting on its own, so a
+		// deployment names its backend once. There is no docker agent backend,
+		// so a docker MCP runtime lands on fake.
+		{name: "unset follows a docker MCP runtime", mcpBackend: "docker", wantKind: "fake", wantActive: true},
+		{name: "unset with no MCP runtime configured", wantKind: "fake", wantActive: true},
+		{name: "unset follows a kubernetes MCP runtime", mcpBackend: "kubernetes", wantErr: true},
+		{name: "unset follows the k8s alias", mcpBackend: "k8s", wantErr: true},
+		{name: "development defaults fake", devMode: true, wantKind: "fake", wantActive: true},
+		// An explicit value always wins over the MCP runtime, in both directions.
+		{name: "explicit disabled under a kubernetes MCP runtime", kind: "disabled", mcpBackend: "kubernetes", wantKind: "disabled"},
+		{name: "explicit disabled in development", kind: "disabled", devMode: true, wantKind: "disabled"},
+		{name: "explicit fake", kind: "FAKE", wantKind: "fake", wantActive: true},
+		// The Kubernetes backend needs a cluster, so selecting it without one
+		// has to fail at startup rather than at the first reconcile.
+		{name: "kubernetes without a cluster", kind: "kubernetes", wantErr: true},
+		{name: "explicit kubernetes under a docker MCP runtime", kind: "kubernetes", mcpBackend: "docker", wantErr: true},
+		{name: "discobox removed", kind: "discobox", wantErr: true},
+		{name: "unknown", kind: "other", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := Config{
+				HostedAgentsBackend: tt.kind,
+				DevMode:             tt.devMode,
+			}
+			config.MCPRuntimeBackend = tt.mcpBackend
+			kind, backend, err := newHostedAgentsBackend(config, nil, nil, nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if kind != tt.wantKind {
+				t.Fatalf("expected kind %q, got %q", tt.wantKind, kind)
+			}
+			_, err = backend.ObserveInstance(t.Context(), agentbackend.InstanceRef{ID: "test"})
+			if tt.wantActive && errors.Is(err, agentbackend.ErrDisabled) {
+				t.Fatal("expected an active backend")
+			}
+			if !tt.wantActive && !errors.Is(err, agentbackend.ErrDisabled) {
+				t.Fatalf("expected disabled backend, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLeaderElectionRESTConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeout  time.Duration
+		expected time.Duration
+	}{
+		{name: "unset", expected: leaderElectionRequestTimeout},
+		{name: "longer", timeout: time.Minute, expected: leaderElectionRequestTimeout},
+		{name: "shorter", timeout: time.Second, expected: time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := &rest.Config{Timeout: tt.timeout}
+			result := leaderElectionRESTConfig(original)
+
+			if result == original {
+				t.Fatal("expected the REST config to be copied")
+			}
+			if result.Timeout != tt.expected {
+				t.Fatalf("expected timeout %s, got %s", tt.expected, result.Timeout)
+			}
+			if original.Timeout != tt.timeout {
+				t.Fatalf("original timeout changed from %s to %s", tt.timeout, original.Timeout)
+			}
+		})
+	}
+}
 
 func TestParsePodSchedulingSettingsFromHelm(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
The controllers turn the resources into running sandboxes: an instance is
placed in a pool, given a credential and a configuration, and handed to the
backend; a pool is created before anything needs it and removed with its last
instance; a user's instances go when the user does.

The configuration a sandbox receives is built here, and it is the contract the
images depend on. Every endpoint in it is absolute and every skill is already
on disk, so an image boots by reading a file and needs to know nothing about
Obot -- not its address, not its routes. Credentials are written to a second,
tighter-permissioned file so the configuration itself can be world-readable and
carries no secret.

A config source is a git repository of harness and template definitions, synced
on an interval. Sync does not rewrite the references a template makes: a
template naming a server that is not installed still syncs and is reported
unavailable, and installing the server later makes it work with no resync.



---

Part 7 of an 11-PR stack. Base: `feat/hosted-agents-06-server-wiring`.

## Stack

1. #7459 — Resource model
2. #7460 — Sandbox backend interface
3. #7461 — Kubernetes sandbox backend
4. #7462 — Sandbox reachability (models + MCP)
5. #7463 — Terminal + HTTP publish
6. #7464 — Server wiring + Helm
**→ 7. #7465 — Controllers / reconcilers** (this PR)
8. #7466 — REST API
9. #7467 — Admin UI
10. #7468 — User UI
11. #7469 — Seed default config source

Merge bottom-up; GitHub retargets each child when its parent merges.
