### PR TITLE
feat: serve the hosted agent API (8/11)

### DIFF
--- a/pkg/agentcatalog/validate.go
+++ b/pkg/agentcatalog/validate.go
@@ -1,0 +1,78 @@
+// Package agentcatalog holds the server-side rules for an agent config source.
+//
+// The manifest validates its own shape, in apiclient/types, where the UI can
+// apply the same rules before submitting. What lives here is the part that
+// depends on how this server is running rather than on the data: a repository
+// on the local filesystem is a reasonable source when a developer is iterating
+// on a catalog, and is not one anywhere else. That is Obot's policy, not a
+// property of the manifest, so a client has no business knowing it.
+package agentcatalog
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+// Validate applies the manifest's own rules, additionally accepting a
+// repository on the local filesystem when allowLocalRepos is set -- which
+// callers must derive from Obot's development mode.
+func Validate(manifest types.AgentCatalogManifest, allowLocalRepos bool) error {
+	if !allowLocalRepos || !isLocalRepo(manifest.RepoURL) {
+		return manifest.Validate()
+	}
+
+	// The shape checks still apply; only the URL rule is relaxed.
+	if strings.TrimSpace(manifest.DisplayName) == "" {
+		return fmt.Errorf("displayName is required")
+	}
+	if err := validateLocalRepoURL(manifest.RepoURL); err != nil {
+		return err
+	}
+	// A local checkout is still cloned by ref, so relaxing where the repository
+	// may live must not relax what may be passed to git alongside it.
+	return types.ValidateGitRef(manifest.Ref)
+}
+
+// isLocalRepo reports whether a value is asking to be read off this machine, so
+// that anything else keeps failing with the ordinary error rather than the
+// local-path one.
+func isLocalRepo(repoURL string) bool {
+	repoURL = strings.TrimSpace(repoURL)
+	if filepath.IsAbs(repoURL) {
+		return true
+	}
+	u, err := url.Parse(repoURL)
+	return err == nil && u.Scheme == "file"
+}
+
+// validateLocalRepoURL accepts an absolute filesystem path or a file:// URL.
+// Relative paths stay invalid: their meaning would depend on the server
+// process's working directory, which is not something a catalog should rest on.
+func validateLocalRepoURL(repoURL string) error {
+	repoURL = strings.TrimSpace(repoURL)
+	if repoURL == "" {
+		return fmt.Errorf("repoURL is required")
+	}
+	if filepath.IsAbs(repoURL) {
+		return nil
+	}
+
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return fmt.Errorf("invalid repoURL: %v", err)
+	}
+	if u.Host != "" && u.Host != "localhost" {
+		return fmt.Errorf("file repoURL host must be empty or localhost")
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("file repoURL must not include user information, a query, or a fragment")
+	}
+	if !filepath.IsAbs(u.Path) {
+		return fmt.Errorf("file repoURL must contain an absolute path")
+	}
+	return nil
+}

--- a/pkg/agentcatalog/validate_test.go
+++ b/pkg/agentcatalog/validate_test.go
@@ -1,0 +1,55 @@
+package agentcatalog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+// Accepting a repository off the local filesystem is a development-mode
+// concession, so the same manifest has to be judged differently depending on
+// how this server is running -- which is the whole reason the rule lives here
+// rather than on the manifest.
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		repoURL     string
+		ref         string
+		development bool
+		wantError   string
+	}{
+		{name: "https production", repoURL: "https://example.com/obot/agents.git"},
+		{name: "https development", repoURL: "https://example.com/obot/agents.git", development: true},
+		{name: "absolute path development", repoURL: "/home/developer/src/obot-agents", development: true},
+		{name: "file URL development", repoURL: "file:///home/developer/src/obot-agents", development: true},
+		{name: "localhost file URL development", repoURL: "file://localhost/home/developer/src/obot-agents", development: true},
+		{name: "absolute path production", repoURL: "/home/developer/src/obot-agents", wantError: "must be an https URL"},
+		{name: "file URL production", repoURL: "file:///home/developer/src/obot-agents", wantError: "must be an https URL"},
+		{name: "relative path development", repoURL: "../obot-agents", development: true, wantError: "must be an https URL"},
+		{name: "remote file host development", repoURL: "file://example.com/repo", development: true, wantError: "host must be empty or localhost"},
+		{name: "file query development", repoURL: "file:///repo?ref=main", development: true, wantError: "must not include"},
+		{name: "displayName still required in development", repoURL: "/home/developer/src/obot-agents", development: true, wantError: "displayName is required"},
+		{name: "ref still validated in development", repoURL: "/home/developer/src/obot-agents", development: true, ref: "--upload-pack=evil", wantError: "must not begin with '-'"},
+		{name: "valid ref in development", repoURL: "/home/developer/src/obot-agents", development: true, ref: "main"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := types.AgentCatalogManifest{DisplayName: "Test agents", RepoURL: tt.repoURL, Ref: tt.ref}
+			if strings.Contains(tt.name, "displayName still required") {
+				manifest.DisplayName = ""
+			}
+			err := Validate(manifest, tt.development)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantError, err)
+			}
+		})
+	}
+}

--- a/pkg/api/handlers/agentcatalogs.go
+++ b/pkg/api/handlers/agentcatalogs.go
@@ -1,0 +1,147 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentcatalog"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AgentCatalogHandler struct {
+	devMode bool
+}
+
+func NewAgentCatalogHandler(devMode bool) *AgentCatalogHandler {
+	return &AgentCatalogHandler{devMode: devMode}
+}
+
+func (*AgentCatalogHandler) List(req api.Context) error {
+	var list v1.AgentCatalogList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list agent catalogs: %w", err)
+	}
+
+	items := make([]types.AgentCatalog, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, convertAgentCatalog(item))
+	}
+
+	return req.Write(types.AgentCatalogList{Items: items})
+}
+
+func (*AgentCatalogHandler) Get(req api.Context) error {
+	var source v1.AgentCatalog
+	if err := req.Get(&source, req.PathValue("agent_catalog_id")); err != nil {
+		return fmt.Errorf("failed to get agent catalog: %w", err)
+	}
+
+	return req.Write(convertAgentCatalog(source))
+}
+
+func (h *AgentCatalogHandler) Create(req api.Context) error {
+	manifest, err := h.readAndValidateAgentCatalogManifest(req)
+	if err != nil {
+		return err
+	}
+
+	source := v1.AgentCatalog{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.AgentCatalogPrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.AgentCatalogSpec{
+			AgentCatalogManifest: *manifest,
+		},
+	}
+
+	if err := req.Create(&source); err != nil {
+		return fmt.Errorf("failed to create agent catalog: %w", err)
+	}
+
+	return req.WriteCreated(convertAgentCatalog(source))
+}
+
+func (h *AgentCatalogHandler) Update(req api.Context) error {
+	manifest, err := h.readAndValidateAgentCatalogManifest(req)
+	if err != nil {
+		return err
+	}
+
+	var source v1.AgentCatalog
+	if err := req.Get(&source, req.PathValue("agent_catalog_id")); err != nil {
+		return fmt.Errorf("failed to get agent catalog: %w", err)
+	}
+
+	source.Spec.AgentCatalogManifest = *manifest
+	if err := req.Update(&source); err != nil {
+		return fmt.Errorf("failed to update agent catalog: %w", err)
+	}
+
+	return req.Write(convertAgentCatalog(source))
+}
+
+func (*AgentCatalogHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.AgentCatalog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.PathValue("agent_catalog_id"),
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+// Refresh asks the controller to sync now by setting the force-sync annotation,
+// rather than doing any work itself.
+func (*AgentCatalogHandler) Refresh(req api.Context) error {
+	var source v1.AgentCatalog
+	if err := req.Get(&source, req.PathValue("agent_catalog_id")); err != nil {
+		return fmt.Errorf("failed to get agent catalog: %w", err)
+	}
+
+	if source.Annotations == nil {
+		source.Annotations = map[string]string{}
+	}
+	source.Annotations[v1.AgentCatalogSyncAnnotation] = "true"
+
+	if err := req.Update(&source); err != nil {
+		return fmt.Errorf("failed to refresh agent catalog: %w", err)
+	}
+
+	req.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
+func (h *AgentCatalogHandler) readAndValidateAgentCatalogManifest(req api.Context) (*types.AgentCatalogManifest, error) {
+	var manifest types.AgentCatalogManifest
+	if err := req.Read(&manifest); err != nil {
+		return nil, types.NewErrBadRequest("failed to read agent catalog manifest: %v", err)
+	}
+
+	manifest.DisplayName = strings.TrimSpace(manifest.DisplayName)
+	manifest.RepoURL = strings.TrimSpace(manifest.RepoURL)
+	manifest.Ref = strings.TrimSpace(manifest.Ref)
+
+	if err := agentcatalog.Validate(manifest, h.devMode); err != nil {
+		return nil, types.NewErrBadRequest("invalid agent catalog manifest: %v", err)
+	}
+
+	return &manifest, nil
+}
+
+func convertAgentCatalog(source v1.AgentCatalog) types.AgentCatalog {
+	return types.AgentCatalog{
+		Metadata:               MetadataFrom(&source),
+		AgentCatalogManifest:   source.Spec.AgentCatalogManifest,
+		LastSyncTime:           *types.NewTime(source.Status.LastSyncTime.Time),
+		IsSyncing:              source.Status.IsSyncing,
+		SyncError:              source.Status.SyncError,
+		ResolvedCommitSHA:      source.Status.ResolvedCommitSHA,
+		DiscoveredAgentCount:   source.Status.DiscoveredAgentCount,
+		DiscoveredHarnessCount: source.Status.DiscoveredHarnessCount,
+	}
+}

--- a/pkg/api/handlers/harnesses.go
+++ b/pkg/api/handlers/harnesses.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type HarnessHandler struct{}
+
+func NewHarnessHandler() *HarnessHandler {
+	return nil
+}
+
+func (*HarnessHandler) List(req api.Context) error {
+	var list v1.HarnessList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list harnesses: %w", err)
+	}
+
+	items := make([]types.Harness, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, convertHarness(item))
+	}
+
+	return req.Write(types.HarnessList{Items: items})
+}
+
+func (*HarnessHandler) Get(req api.Context) error {
+	var harness v1.Harness
+	if err := req.Get(&harness, req.PathValue("harness_id")); err != nil {
+		return fmt.Errorf("failed to get harness: %w", err)
+	}
+
+	return req.Write(convertHarness(harness))
+}
+
+func (*HarnessHandler) Create(req api.Context) error {
+	var manifest types.HarnessManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read harness manifest: %v", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid harness manifest: %v", err)
+	}
+
+	harness := v1.Harness{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.HarnessPrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HarnessSpec{
+			Manifest: manifest,
+		},
+	}
+
+	if err := req.Create(&harness); err != nil {
+		return fmt.Errorf("failed to create harness: %w", err)
+	}
+
+	return req.WriteCreated(convertHarness(harness))
+}
+
+func (*HarnessHandler) Update(req api.Context) error {
+	var manifest types.HarnessManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read harness manifest: %v", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid harness manifest: %v", err)
+	}
+
+	var harness v1.Harness
+	if err := req.Get(&harness, req.PathValue("harness_id")); err != nil {
+		return fmt.Errorf("failed to get harness: %w", err)
+	}
+
+	harness.Spec.Manifest = manifest
+	if err := req.Update(&harness); err != nil {
+		return fmt.Errorf("failed to update harness: %w", err)
+	}
+
+	return req.Write(convertHarness(harness))
+}
+
+// Delete refuses to remove a harness that agents still run on, rather than
+// leaving them pointing at nothing.
+func (*HarnessHandler) Delete(req api.Context) error {
+	id := req.PathValue("harness_id")
+
+	var agents v1.HostedAgentList
+	if err := req.List(&agents, kclient.MatchingFields{"spec.harnessID": id}); err != nil {
+		return fmt.Errorf("failed to list hosted agents for harness %s: %w", id, err)
+	}
+	if count := len(agents.Items); count > 0 {
+		return types.NewErrBadRequest("harness %s is in use by %d agent(s)", id, count)
+	}
+
+	return req.Delete(&v1.Harness{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+func convertHarness(harness v1.Harness) types.Harness {
+	return types.Harness{
+		Metadata:        MetadataFrom(&harness),
+		HarnessManifest: harness.Spec.Manifest,
+	}
+}

--- a/pkg/api/handlers/hostedagentaccessrules.go
+++ b/pkg/api/handlers/hostedagentaccessrules.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type HostedAgentAccessRuleHandler struct{}
+
+func NewHostedAgentAccessRuleHandler() *HostedAgentAccessRuleHandler {
+	return nil
+}
+
+func (*HostedAgentAccessRuleHandler) List(req api.Context) error {
+	var list v1.HostedAgentAccessRuleList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list hosted agent access rules: %w", err)
+	}
+
+	items := make([]types.HostedAgentAccessRule, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, convertHostedAgentAccessRule(item))
+	}
+
+	return req.Write(types.HostedAgentAccessRuleList{Items: items})
+}
+
+func (*HostedAgentAccessRuleHandler) Get(req api.Context) error {
+	var rule v1.HostedAgentAccessRule
+	if err := req.Get(&rule, req.PathValue("hosted_agent_access_rule_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent access rule: %w", err)
+	}
+
+	return req.Write(convertHostedAgentAccessRule(rule))
+}
+
+func (*HostedAgentAccessRuleHandler) Create(req api.Context) error {
+	manifest, err := readAndValidateHostedAgentAccessRuleManifest(req)
+	if err != nil {
+		return err
+	}
+
+	rule := v1.HostedAgentAccessRule{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.HostedAgentAccessRulePrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HostedAgentAccessRuleSpec{
+			Manifest: *manifest,
+		},
+	}
+
+	if err := req.Create(&rule); err != nil {
+		return fmt.Errorf("failed to create hosted agent access rule: %w", err)
+	}
+
+	return req.WriteCreated(convertHostedAgentAccessRule(rule))
+}
+
+func (*HostedAgentAccessRuleHandler) Update(req api.Context) error {
+	manifest, err := readAndValidateHostedAgentAccessRuleManifest(req)
+	if err != nil {
+		return err
+	}
+
+	var rule v1.HostedAgentAccessRule
+	if err := req.Get(&rule, req.PathValue("hosted_agent_access_rule_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent access rule: %w", err)
+	}
+
+	rule.Spec.Manifest = *manifest
+	if err := req.Update(&rule); err != nil {
+		return fmt.Errorf("failed to update hosted agent access rule: %w", err)
+	}
+
+	return req.Write(convertHostedAgentAccessRule(rule))
+}
+
+func (*HostedAgentAccessRuleHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.HostedAgentAccessRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.PathValue("hosted_agent_access_rule_id"),
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+func readAndValidateHostedAgentAccessRuleManifest(req api.Context) (*types.HostedAgentAccessRuleManifest, error) {
+	var manifest types.HostedAgentAccessRuleManifest
+	if err := req.Read(&manifest); err != nil {
+		return nil, types.NewErrBadRequest("failed to read hosted agent access rule manifest: %v", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return nil, types.NewErrBadRequest("invalid hosted agent access rule manifest: %v", err)
+	}
+
+	if err := validateReferencedHostedAgentResources(req, manifest.Resources); err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+func validateReferencedHostedAgentResources(req api.Context, resources []types.HostedAgentResource) error {
+	for _, resource := range resources {
+		switch resource.Type {
+		case types.HostedAgentResourceTypeHostedAgent:
+			if err := req.Get(&v1.HostedAgent{}, resource.ID); apierrors.IsNotFound(err) {
+				return types.NewErrBadRequest("hosted agent %s not found", resource.ID)
+			} else if err != nil {
+				return fmt.Errorf("failed to get hosted agent %s: %w", resource.ID, err)
+			}
+		case types.HostedAgentResourceTypeSelector:
+			// Wildcard selectors are validated by the manifest.
+		default:
+			return types.NewErrBadRequest("unsupported hosted agent resource type: %s", resource.Type)
+		}
+	}
+
+	return nil
+}
+
+func convertHostedAgentAccessRule(rule v1.HostedAgentAccessRule) types.HostedAgentAccessRule {
+	return types.HostedAgentAccessRule{
+		Metadata:                      MetadataFrom(&rule),
+		HostedAgentAccessRuleManifest: rule.Spec.Manifest,
+	}
+}

--- a/pkg/api/handlers/hostedagentavailability.go
+++ b/pkg/api/handlers/hostedagentavailability.go
@@ -1,0 +1,182 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/hostedagentmodels"
+	"github.com/obot-platform/obot/pkg/hostedagentrefs"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// agentAvailability reports why an agent cannot be launched on this
+// installation, empty when it can.
+//
+// A template is written once and used everywhere, so it names things that may
+// not exist here: a harness that speaks a protocol no configured provider
+// serves, or an MCP server that was never installed. Launching it anyway
+// produces a sandbox that fails at its first request, with an error the user
+// cannot act on. Saying so up front turns that into something an administrator
+// can fix.
+type agentAvailability struct {
+	client    kclient.Client
+	namespace string
+	harnesses map[string]types.HarnessManifest
+}
+
+func newAgentAvailability(ctx context.Context, client kclient.Client, namespace string) (*agentAvailability, error) {
+	var harnesses v1.HarnessList
+	if err := client.List(ctx, &harnesses, &kclient.ListOptions{Namespace: namespace}); err != nil {
+		return nil, fmt.Errorf("failed to list harnesses: %w", err)
+	}
+
+	availability := &agentAvailability{
+		client:    client,
+		namespace: namespace,
+		harnesses: make(map[string]types.HarnessManifest, len(harnesses.Items)),
+	}
+	for _, harness := range harnesses.Items {
+		availability.harnesses[harness.Name] = harness.Spec.Manifest
+	}
+	return availability, nil
+}
+
+// reasons returns every reason an agent cannot be launched, so an administrator
+// sees the whole list rather than fixing one and being told about the next.
+func (a *agentAvailability) reasons(ctx context.Context, manifest types.HostedAgentManifest) []string {
+	var reasons []string
+
+	if _, ok := a.harnesses[manifest.HarnessID]; !ok {
+		return []string{"its harness is not registered"}
+	}
+
+	if reason := a.modelReason(ctx, manifest); reason != "" {
+		reasons = append(reasons, reason)
+	}
+	reasons = append(reasons, a.mcpReasons(ctx, manifest)...)
+	reasons = append(reasons, a.skillReasons(ctx, manifest)...)
+	return reasons
+}
+
+func (a *agentAvailability) modelReason(ctx context.Context, manifest types.HostedAgentManifest) string {
+	models, err := hostedagentmodels.Resolve(ctx, a.client, a.namespace, manifest.Models, manifest.ModelProviders)
+	if err != nil {
+		// A failure to read models is not a statement about the agent, and
+		// blocking every agent on a transient error would be worse than
+		// letting one through.
+		return ""
+	}
+	if len(models) > 0 {
+		return ""
+	}
+
+	// Naming the provider is what makes this actionable: an administrator can
+	// go and configure it. "No models available" would not say which.
+	if len(manifest.ModelProviders) == 1 {
+		return fmt.Sprintf("the %s is not configured", manifest.ModelProviders[0])
+	}
+	if len(manifest.ModelProviders) > 1 {
+		return fmt.Sprintf("none of the model providers it needs are configured: %v", manifest.ModelProviders)
+	}
+	if len(manifest.Models) > 0 {
+		return "none of the models it is configured with are available"
+	}
+	return ""
+}
+
+// mcpReasons names the MCP servers the agent refers to that do not exist here.
+//
+// A reference is resolved against its source; a bare ID is looked up directly.
+func (a *agentAvailability) mcpReasons(ctx context.Context, manifest types.HostedAgentManifest) []string {
+	var missing []string
+	for _, id := range manifest.MCPServers {
+		if id == "" || id == "*" {
+			continue
+		}
+		if hostedagentrefs.IsReference(id) {
+			if _, err := hostedagentrefs.ResolveMCP(ctx, a.client, a.namespace, id); err != nil {
+				missing = append(missing, id)
+			}
+			continue
+		}
+		if !a.mcpExists(ctx, id) {
+			missing = append(missing, id)
+		}
+	}
+	return describeMissing("MCP server", missing)
+}
+
+// skillReasons names the skills the agent refers to that do not exist here.
+func (a *agentAvailability) skillReasons(ctx context.Context, manifest types.HostedAgentManifest) []string {
+	var missing []string
+	for _, id := range manifest.Skills {
+		if id == "" {
+			continue
+		}
+		if hostedagentrefs.IsReference(id) {
+			if _, err := hostedagentrefs.ResolveSkill(ctx, a.client, a.namespace, id); err != nil {
+				missing = append(missing, id)
+			}
+			continue
+		}
+		var skill v1.Skill
+		if !a.found(a.client.Get(ctx, kclient.ObjectKey{Namespace: a.namespace, Name: id}, &skill)) {
+			missing = append(missing, id)
+		}
+	}
+	return describeMissing("skill", missing)
+}
+
+// describeMissing phrases the absences so the reason names what to install.
+func describeMissing(kind string, missing []string) []string {
+	switch len(missing) {
+	case 0:
+		return nil
+	case 1:
+		return []string{fmt.Sprintf("the %s %s is not installed", kind, missing[0])}
+	default:
+		return []string{fmt.Sprintf("%d %ss it uses are not installed: %v", len(missing), kind, missing)}
+	}
+}
+
+// mcpExists reports whether an MCP gateway ID names something that is here.
+//
+// The ID is the same handle /mcp-connect accepts, which may be a server, an
+// instance of a multi-user server, or a catalog entry -- so each is tried
+// rather than inferring the kind from the ID's shape.
+func (a *agentAvailability) mcpExists(ctx context.Context, id string) bool {
+	key := kclient.ObjectKey{Namespace: a.namespace, Name: id}
+
+	switch {
+	case system.IsMCPServerInstanceID(id):
+		var instance v1.MCPServerInstance
+		return a.found(a.client.Get(ctx, key, &instance))
+	case system.IsMCPServerID(id):
+		var server v1.MCPServer
+		return a.found(a.client.Get(ctx, key, &server))
+	}
+
+	var entry v1.MCPServerCatalogEntry
+	if a.found(a.client.Get(ctx, key, &entry)) {
+		return true
+	}
+	var server v1.MCPServer
+	return a.found(a.client.Get(ctx, key, &server))
+}
+
+// found treats anything other than a definite absence as present. A read that
+// failed for another reason says nothing about whether the server exists, and
+// reporting it missing would block an agent over a transient error.
+func (a *agentAvailability) found(err error) bool {
+	return !apierrors.IsNotFound(err)
+}
+
+// applyTo annotates an agent with why it cannot be launched here.
+func (a *agentAvailability) applyTo(ctx context.Context, agent types.HostedAgent) types.HostedAgent {
+	agent.UnavailableReasons = a.reasons(ctx, agent.HostedAgentManifest)
+	return agent
+}

--- a/pkg/api/handlers/hostedagentavailability_test.go
+++ b/pkg/api/handlers/hostedagentavailability_test.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func availabilityFor(t *testing.T, objs ...kclient.Object) *agentAvailability {
+	t.Helper()
+	client := fakeclient.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(objs...).Build()
+	availability, err := newAgentAvailability(context.Background(), client, "obot")
+	if err != nil {
+		t.Fatalf("newAgentAvailability: %v", err)
+	}
+	return availability
+}
+
+func harnessObj(name string) *v1.Harness {
+	return &v1.Harness{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec:       v1.HarnessSpec{Manifest: types.HarnessManifest{Name: name, Image: "img"}},
+	}
+}
+
+func modelObj(name, provider string) *v1.Model {
+	return &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+			Name: name, TargetModel: name, ModelProvider: provider,
+			Active: true, Usage: types.ModelUsageLLM,
+		}},
+	}
+}
+
+// The case this exists for: Claude Code is written against Anthropic, so on an
+// installation with only OpenAI providers it can never work. Offering it
+// produces a sandbox that fails at start-up with an error the user cannot act
+// on. The template names the provider, and the reason names it back.
+func TestAgentNeedingAnAbsentProviderIsUnavailable(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1claude"),
+		modelObj("m1gpt", system.OpenAIModelProvider),
+	)
+
+	reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		Name: "Claude Code", HarnessID: "hrn1claude",
+		ModelProviders: []string{system.AnthropicModelProvider}, Models: []string{"*"},
+	})
+	if len(reasons) != 1 || !strings.Contains(reasons[0], system.AnthropicModelProvider) {
+		t.Fatalf("reasons = %v, want one naming the missing provider", reasons)
+	}
+}
+
+// The same agent is fine as soon as the provider exists, without the template
+// changing -- which is why this is computed rather than stored.
+func TestAgentIsAvailableOnceItsProviderExists(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1claude"),
+		modelObj("m1sonnet", system.AnthropicModelProvider),
+	)
+
+	if reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		HarnessID:      "hrn1claude",
+		ModelProviders: []string{system.AnthropicModelProvider}, Models: []string{"*"},
+	}); len(reasons) != 0 {
+		t.Fatalf("reasons = %v, want none", reasons)
+	}
+}
+
+// An agent naming no provider takes whatever is configured, and is restricted
+// by nothing.
+func TestAgentWithoutDeclaredProvidersAcceptsAnyModel(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1any"),
+		modelObj("m1gpt", system.OpenAIModelProvider),
+	)
+
+	if reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		HarnessID: "hrn1any", Models: []string{"*"},
+	}); len(reasons) != 0 {
+		t.Fatalf("reasons = %v, want none", reasons)
+	}
+}
+
+// An agent naming an MCP server that was never installed cannot work either.
+func TestMissingMCPServerMakesAnAgentUnavailable(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1any"),
+		modelObj("m1gpt", system.OpenAIModelProvider),
+		&v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "ms1here", Namespace: "obot"}},
+	)
+
+	reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		HarnessID: "hrn1any", Models: []string{"*"}, MCPServers: []string{"ms1here", "ms1gone"},
+	})
+	if len(reasons) != 1 || !strings.Contains(reasons[0], "ms1gone") {
+		t.Fatalf("reasons = %v, want one naming the missing server", reasons)
+	}
+	if strings.Contains(reasons[0], "ms1here") {
+		t.Errorf("a server that is installed should not be reported missing: %v", reasons)
+	}
+}
+
+// Every reason at once, so an administrator fixes the set rather than
+// discovering the next one after each fix.
+func TestAllReasonsAreReportedTogether(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1claude"),
+		modelObj("m1gpt", system.OpenAIModelProvider),
+	)
+
+	reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		HarnessID: "hrn1claude", Models: []string{"*"},
+		ModelProviders: []string{system.AnthropicModelProvider}, MCPServers: []string{"ms1gone"},
+	})
+	if len(reasons) != 2 {
+		t.Fatalf("reasons = %v, want both the model and the MCP server", reasons)
+	}
+}
+
+// An agent whose harness was removed cannot run, and saying so is more useful
+// than reporting a missing model on a harness that is not there.
+func TestUnregisteredHarnessIsItsOwnReason(t *testing.T) {
+	availability := availabilityFor(t, modelObj("m1gpt", system.OpenAIModelProvider))
+
+	reasons := availability.reasons(context.Background(), types.HostedAgentManifest{HarnessID: "hrn1gone"})
+	if len(reasons) != 1 || !strings.Contains(reasons[0], "harness") {
+		t.Fatalf("reasons = %v", reasons)
+	}
+}

--- a/pkg/api/handlers/hostedagentinstances.go
+++ b/pkg/api/handlers/hostedagentinstances.go
@@ -1,0 +1,455 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/adhocore/gronx"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/accesscontrolrule"
+	"github.com/obot-platform/obot/pkg/alias"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/obot-platform/obot/pkg/hostedagentaccessrule"
+	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
+	"github.com/obot-platform/obot/pkg/skillaccessrule"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type HostedAgentInstanceHandler struct {
+	accessRuleHelper *hostedagentaccessrule.Helper
+	// The three helpers below check the resources a user attaches to their own
+	// instance, one per kind. Each kind has its own access model, so there is no
+	// single helper to ask.
+	acrHelper   *accesscontrolrule.Helper
+	skillHelper *skillaccessrule.Helper
+	mapHelper   *modelaccesspolicy.Helper
+}
+
+func NewHostedAgentInstanceHandler(
+	accessRuleHelper *hostedagentaccessrule.Helper,
+	acrHelper *accesscontrolrule.Helper,
+	skillHelper *skillaccessrule.Helper,
+	mapHelper *modelaccesspolicy.Helper,
+) *HostedAgentInstanceHandler {
+	return &HostedAgentInstanceHandler{
+		accessRuleHelper: accessRuleHelper,
+		acrHelper:        acrHelper,
+		skillHelper:      skillHelper,
+		mapHelper:        mapHelper,
+	}
+}
+
+type hostedAgentInstanceRequest struct {
+	types.HostedAgentInstanceManifest `json:",inline"`
+	HostedAgentID                     string `json:"hostedAgentID,omitempty"`
+	PoolID                            string `json:"poolID,omitempty"`
+}
+
+// Validate checks the request as a whole, so a caller gets one answer about
+// whether what it sent is usable rather than two checks in sequence.
+//
+// hostedAgentID belongs to the request rather than to the manifest: an instance
+// names the agent it is created from once, at creation, and never carries it
+// afterwards. So it is checked here instead of in the manifest's own rules,
+// which apply equally to an update where it is absent by design.
+func (r hostedAgentInstanceRequest) Validate() error {
+	if r.HostedAgentID == "" {
+		return fmt.Errorf("hostedAgentID is required")
+	}
+	return r.HostedAgentInstanceManifest.Validate()
+}
+
+func (h *HostedAgentInstanceHandler) List(req api.Context) error {
+	selector := kclient.MatchingFields{"spec.userID": req.User.GetUID()}
+	if hostedAgentID := req.URL.Query().Get("hosted_agent_id"); hostedAgentID != "" {
+		selector["spec.hostedAgentName"] = hostedAgentID
+	}
+
+	var list v1.HostedAgentInstanceList
+	if err := req.List(&list, selector); err != nil {
+		return fmt.Errorf("failed to list hosted agent instances: %w", err)
+	}
+
+	icons, err := newIconResolver(req)
+	if err != nil {
+		return err
+	}
+
+	items := make([]types.HostedAgentInstance, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, icons.apply(convertHostedAgentInstance(item), item.Spec.HostedAgentName))
+	}
+
+	return req.Write(types.HostedAgentInstanceList{Items: items})
+}
+
+func (h *HostedAgentInstanceHandler) Get(req api.Context) error {
+	var instance v1.HostedAgentInstance
+	if err := req.Get(&instance, req.PathValue("hosted_agent_instance_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent instance: %w", err)
+	}
+
+	icons, err := newIconResolver(req)
+	if err != nil {
+		return err
+	}
+
+	return req.Write(icons.apply(convertHostedAgentInstance(instance), instance.Spec.HostedAgentName))
+}
+
+func (h *HostedAgentInstanceHandler) Create(req api.Context) error {
+	var body hostedAgentInstanceRequest
+	if err := req.Read(&body); err != nil {
+		return types.NewErrBadRequest("failed to read hosted agent instance manifest: %v", err)
+	}
+
+	if err := body.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid hosted agent instance request: %v", err)
+	}
+
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, body.HostedAgentID); apierrors.IsNotFound(err) {
+		return types.NewErrBadRequest("hosted agent %s not found", body.HostedAgentID)
+	} else if err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	// This route carries no hosted agent ID in its path, so the authorizer cannot
+	// gate it. Check access here instead.
+	hasAccess, err := h.accessRuleHelper.UserHasAccessToHostedAgent(req.User, &agent)
+	if err != nil {
+		return fmt.Errorf("failed to check access to hosted agent %s: %w", agent.Name, err)
+	}
+	if !hasAccess {
+		return types.NewErrNotFound("hosted agent %s not found", body.HostedAgentID)
+	}
+
+	// Checked here as well as reported on the agent, because the UI's decision
+	// not to offer a launch button is a courtesy and not a control: a direct
+	// request would otherwise produce a sandbox that cannot serve its first
+	// request, and an error the user has no way to act on.
+	availability, err := newAgentAvailability(req.Context(), req.Storage, req.Namespace())
+	if err != nil {
+		return err
+	}
+	if reasons := availability.reasons(req.Context(), agent.Spec.Manifest); len(reasons) > 0 {
+		return types.NewErrBadRequest("%s cannot be launched here: %s",
+			agent.Spec.Manifest.Name, strings.Join(reasons, "; "))
+	}
+
+	if body.PoolID != "" {
+		if err := requirePoolAccess(req, body.PoolID); err != nil {
+			return err
+		}
+	}
+
+	var existing v1.HostedAgentInstanceList
+	if err := req.List(&existing, kclient.MatchingFields{
+		"spec.userID":          req.User.GetUID(),
+		"spec.hostedAgentName": agent.Name,
+	}); err != nil {
+		return fmt.Errorf("failed to list hosted agent instances: %w", err)
+	}
+
+	if maxInstances := agent.Spec.Manifest.MaxInstancesPerUser; maxInstances > 0 && len(existing.Items) >= maxInstances {
+		return types.NewErrBadRequest("hosted agent %s allows at most %d instances per user", agent.Name, maxInstances)
+	}
+
+	manifest := body.HostedAgentInstanceManifest
+	manifest.Answers = agent.Spec.Manifest.ApplyAnswerDefaults(manifest.Answers)
+	if err := h.validateInstanceAgainstAgent(req, manifest, agent.Spec.Manifest); err != nil {
+		return err
+	}
+
+	instance := v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.HostedAgentInstancePrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HostedAgentInstanceSpec{
+			UserID:          req.User.GetUID(),
+			HostedAgentName: agent.Name,
+			PoolID:          body.PoolID,
+			Manifest:        manifest,
+		},
+	}
+
+	if err := req.Create(&instance); err != nil {
+		return fmt.Errorf("failed to create hosted agent instance: %w", err)
+	}
+
+	return req.WriteCreated(convertHostedAgentInstance(instance))
+}
+
+func (h *HostedAgentInstanceHandler) Update(req api.Context) error {
+	var manifest types.HostedAgentInstanceManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read hosted agent instance manifest: %v", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid hosted agent instance manifest: %v", err)
+	}
+
+	var instance v1.HostedAgentInstance
+	if err := req.Get(&instance, req.PathValue("hosted_agent_instance_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent instance: %w", err)
+	}
+
+	// Re-check against the agent, otherwise an update could smuggle in answers or
+	// resources that create would have rejected.
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, instance.Spec.HostedAgentName); apierrors.IsNotFound(err) {
+		return types.NewErrBadRequest("hosted agent %s not found", instance.Spec.HostedAgentName)
+	} else if err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	manifest.Answers = agent.Spec.Manifest.ApplyAnswerDefaults(manifest.Answers)
+	if err := h.validateInstanceAgainstAgent(req, manifest, agent.Spec.Manifest); err != nil {
+		return err
+	}
+
+	instance.Spec.Manifest = manifest
+	if err := req.Update(&instance); err != nil {
+		return fmt.Errorf("failed to update hosted agent instance: %w", err)
+	}
+
+	return req.Write(convertHostedAgentInstance(instance))
+}
+
+// validateInstanceAgainstAgent enforces the agent's question schema, its
+// user-defined resource toggles, and the user's access to every resource they
+// attached. Cron parsing happens here rather than in apiclient/types so that
+// module stays dependency free.
+//
+// Resources are checked rather than trusted: the UI only ever offers resources
+// the user can reach, but the API is reachable directly, so a request can name
+// any ID.
+//
+// Errors follow the two conventions already in the codebase: a missing resource
+// is a bad request naming the ID (as in accesscontrolrules.go), and a resource
+// the user cannot use is forbidden (as in llmproxy.go and mcp.go). Existence is
+// not hidden, matching how those same paths already behave.
+func (h *HostedAgentInstanceHandler) validateInstanceAgainstAgent(req api.Context, manifest types.HostedAgentInstanceManifest, agent types.HostedAgentManifest) error {
+	if err := manifest.ValidateAgainstAgent(agent); err != nil {
+		return types.NewErrBadRequest("%v", err)
+	}
+
+	for key, answer := range agent.ScheduleAnswers(manifest.Answers) {
+		if !gronx.IsValid(answer) {
+			return types.NewErrBadRequest("answer for %s: must be a valid cron expression", key)
+		}
+	}
+
+	// Only reached when the agent allows the kind, which ValidateAgainstAgent
+	// has already established.
+	if err := h.checkUserMCPServerAccess(req, manifest.MCPServers); err != nil {
+		return err
+	}
+	if err := h.checkUserSkillAccess(req, manifest.Skills); err != nil {
+		return err
+	}
+	return h.checkUserModelAccess(req, manifest.Models)
+}
+
+// checkUserMCPServerAccess validates MCP gateway IDs, which are polymorphic: an
+// ID may name a catalog entry, a server, a server instance, or a system server.
+// CheckMCPIDAccess is the same resolution the gateway itself applies at connect
+// time, so this cannot drift from it.
+func (h *HostedAgentInstanceHandler) checkUserMCPServerAccess(req api.Context, ids []string) error {
+	for _, id := range ids {
+		// CheckMCPIDAccess surfaces a missing object as a NotFound error rather
+		// than a false, so an unknown ID has to be mapped here or it would become
+		// a 500.
+		hasAccess, err := authz.CheckMCPIDAccess(req.Context(), req.Storage, h.acrHelper, req.User, id)
+		if apierrors.IsNotFound(err) {
+			return types.NewErrBadRequest("MCP server %s not found", id)
+		} else if err != nil {
+			return fmt.Errorf("failed to check access to MCP server %s: %w", id, err)
+		}
+		if !hasAccess {
+			return types.NewErrForbidden("you do not have access to MCP server %s", id)
+		}
+	}
+
+	return nil
+}
+
+// checkUserSkillAccess loads each skill so its repo ID is known. Passing an
+// empty repo ID to the helper would skip repository-granted access and wrongly
+// deny a user who was granted a whole repository.
+func (h *HostedAgentInstanceHandler) checkUserSkillAccess(req api.Context, ids []string) error {
+	for _, id := range ids {
+		var skill v1.Skill
+		if err := req.Get(&skill, id); apierrors.IsNotFound(err) {
+			return types.NewErrBadRequest("skill %s not found", id)
+		} else if err != nil {
+			return fmt.Errorf("failed to get skill %s: %w", id, err)
+		}
+
+		hasAccess, err := h.skillHelper.UserHasAccessToSkill(req.User, &skill)
+		if err != nil {
+			return fmt.Errorf("failed to check access to skill %s: %w", id, err)
+		}
+		if !hasAccess {
+			return types.NewErrForbidden("you do not have access to skill %s", id)
+		}
+	}
+
+	return nil
+}
+
+// checkUserModelAccess resolves each reference to a concrete model before
+// checking it. Model access policies are keyed by real model IDs, so an
+// obot://<alias> reference would never match and would always be denied.
+func (h *HostedAgentInstanceHandler) checkUserModelAccess(req api.Context, ids []string) error {
+	for _, id := range ids {
+		modelID, err := resolveModelReference(req, id)
+		if err != nil {
+			return err
+		}
+
+		hasAccess, err := h.mapHelper.UserHasAccessToModel(req.User, modelID)
+		if err != nil {
+			return fmt.Errorf("failed to check access to model %s: %w", id, err)
+		}
+		if !hasAccess {
+			return types.NewErrForbidden("you do not have access to model %s", id)
+		}
+	}
+
+	return nil
+}
+
+// resolveModelReference turns a model reference into a concrete model ID. It
+// accepts a model ID, an alias name, or an obot://<alias> reference, mirroring
+// what the LLM proxy accepts. Wildcards are rejected: they are a way to write a
+// policy, not a model an agent can be pointed at.
+func resolveModelReference(req api.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", types.NewErrBadRequest("model reference cannot be empty")
+	}
+	if strings.Contains(ref, "*") {
+		return "", types.NewErrBadRequest("model %s is a pattern; name a specific model", ref)
+	}
+
+	name := strings.TrimPrefix(ref, types.DefaultModelAliasRefPrefix)
+
+	obj, err := alias.GetFromScope(req.Context(), req.Storage, "Model", req.Namespace(), name)
+	if apierrors.IsNotFound(err) {
+		return "", types.NewErrBadRequest("model %s not found", ref)
+	} else if err != nil {
+		return "", fmt.Errorf("failed to resolve model %s: %w", ref, err)
+	}
+
+	switch m := obj.(type) {
+	case *v1.DefaultModelAlias:
+		if m.Spec.Manifest.Model == "" {
+			return "", types.NewErrBadRequest("model alias %s is not configured", ref)
+		}
+		var model v1.Model
+		if err := alias.Get(req.Context(), req.Storage, &model, req.Namespace(), m.Spec.Manifest.Model); apierrors.IsNotFound(err) {
+			return "", types.NewErrBadRequest("model alias %s points at a missing model", ref)
+		} else if err != nil {
+			return "", fmt.Errorf("failed to resolve model alias %s: %w", ref, err)
+		}
+		return model.Name, nil
+	case *v1.Model:
+		return m.Name, nil
+	}
+
+	return "", types.NewErrBadRequest("model %s not found", ref)
+}
+
+func (h *HostedAgentInstanceHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.PathValue("hosted_agent_instance_id"),
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+func convertHostedAgentInstance(instance v1.HostedAgentInstance) types.HostedAgentInstance {
+	return types.HostedAgentInstance{
+		Metadata:                    MetadataFrom(&instance),
+		HostedAgentInstanceManifest: instance.Spec.Manifest,
+		HostedAgentID:               instance.Spec.HostedAgentName,
+		UserID:                      instance.Spec.UserID,
+		PoolID:                      instance.Spec.PoolID,
+		Status: types.HostedAgentInstanceStatus{
+			State:             instance.Status.State,
+			URL:               instance.Status.URL,
+			Error:             instance.Status.Error,
+			Reason:            instance.Status.Reason,
+			Message:           instance.Status.Message,
+			ObservedRevision:  instance.Status.ObservedRevision,
+			LastObservedTime:  v1.NewTime(instance.Status.LastObservedTime),
+			BackendID:         instance.Status.BackendID,
+			BackendGeneration: instance.Status.BackendGeneration,
+		},
+	}
+}
+
+// iconResolver resolves an instance's icon through the chain a client would
+// otherwise have to walk itself: the instance, then its agent, then the
+// harness the agent runs on.
+//
+// Agents and harnesses are listed once rather than fetched per instance, so
+// rendering a page of instances costs two reads instead of two per row.
+type iconResolver struct {
+	agents    map[string]types.HostedAgentManifest
+	harnesses map[string]types.HarnessManifest
+}
+
+func newIconResolver(req api.Context) (*iconResolver, error) {
+	var agents v1.HostedAgentList
+	if err := req.List(&agents); err != nil {
+		return nil, fmt.Errorf("failed to list hosted agents: %w", err)
+	}
+	var harnesses v1.HarnessList
+	if err := req.List(&harnesses); err != nil {
+		return nil, fmt.Errorf("failed to list harnesses: %w", err)
+	}
+
+	resolver := &iconResolver{
+		agents:    make(map[string]types.HostedAgentManifest, len(agents.Items)),
+		harnesses: make(map[string]types.HarnessManifest, len(harnesses.Items)),
+	}
+	for _, agent := range agents.Items {
+		resolver.agents[agent.Name] = agent.Spec.Manifest
+	}
+	for _, harness := range harnesses.Items {
+		resolver.harnesses[harness.Name] = harness.Spec.Manifest
+	}
+	return resolver, nil
+}
+
+func (r *iconResolver) apply(instance types.HostedAgentInstance, agentID string) types.HostedAgentInstance {
+	// The instance's own icon wins: a user who chose one meant it.
+	instance.ResolvedIcon, instance.ResolvedIconDark = instance.Icon, instance.Icon
+
+	agent, ok := r.agents[agentID]
+	if !ok {
+		return instance
+	}
+	if instance.ResolvedIcon == "" {
+		instance.ResolvedIcon, instance.ResolvedIconDark = agent.Icon, agent.IconDark
+	}
+	if instance.ResolvedIcon == "" {
+		harness := r.harnesses[agent.HarnessID]
+		instance.ResolvedIcon, instance.ResolvedIconDark = harness.Icon, harness.IconDark
+	}
+	// A dark variant is optional everywhere; falling back keeps a client from
+	// having to repeat this rule.
+	if instance.ResolvedIconDark == "" {
+		instance.ResolvedIconDark = instance.ResolvedIcon
+	}
+	return instance
+}

--- a/pkg/api/handlers/hostedagentpools.go
+++ b/pkg/api/handlers/hostedagentpools.go
@@ -1,0 +1,475 @@
+package handlers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const hostedAgentPoolDefaultsName = "default"
+
+type HostedAgentPoolHandler struct {
+	utilization agentbackend.UtilizationReader
+}
+
+func NewHostedAgentPoolHandler(utilization agentbackend.UtilizationReader) *HostedAgentPoolHandler {
+	return &HostedAgentPoolHandler{utilization: utilization}
+}
+
+func (*HostedAgentPoolHandler) List(req api.Context) error {
+	var list v1.HostedAgentPoolList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list hosted agent pools: %w", err)
+	}
+
+	allowed := map[string]bool(nil)
+	if !req.UserIsAdmin() {
+		var err error
+		allowed, err = userPoolIDs(req)
+		if err != nil {
+			return err
+		}
+	}
+
+	items := make([]types.HostedAgentPool, 0, len(list.Items))
+	for _, item := range list.Items {
+		if !req.UserIsAdmin() && !allowed[item.Name] {
+			continue
+		}
+		items = append(items, convertHostedAgentPool(item))
+	}
+	return req.Write(types.HostedAgentPoolList{Items: items})
+}
+
+func (*HostedAgentPoolHandler) Get(req api.Context) error {
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, req.PathValue("hosted_agent_pool_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool: %w", err)
+	}
+	if err := requirePoolAccess(req, pool.Name); err != nil {
+		return err
+	}
+	return req.Write(convertHostedAgentPool(pool))
+}
+
+func (*HostedAgentPoolHandler) Create(req api.Context) error {
+	manifest, err := readHostedAgentPoolManifest(req)
+	if err != nil {
+		return err
+	}
+	pool := v1.HostedAgentPool{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "hp1",
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HostedAgentPoolSpec{Manifest: manifest},
+	}
+	if err := req.Create(&pool); err != nil {
+		return fmt.Errorf("failed to create hosted agent pool: %w", err)
+	}
+	return req.WriteCreated(convertHostedAgentPool(pool))
+}
+
+func (*HostedAgentPoolHandler) Update(req api.Context) error {
+	manifest, err := readHostedAgentPoolManifest(req)
+	if err != nil {
+		return err
+	}
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, req.PathValue("hosted_agent_pool_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool: %w", err)
+	}
+	pool.Spec.Manifest = manifest
+	if err := req.Update(&pool); err != nil {
+		return fmt.Errorf("failed to update hosted agent pool: %w", err)
+	}
+	return req.Write(convertHostedAgentPool(pool))
+}
+
+func (*HostedAgentPoolHandler) Delete(req api.Context) error {
+	poolID := req.PathValue("hosted_agent_pool_id")
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, kclient.MatchingFields{
+		"spec.poolID": poolID,
+	}); err != nil {
+		return fmt.Errorf("failed to find hosted agent pool assignments: %w", err)
+	}
+	if len(assignments.Items) > 0 {
+		return types.NewErrBadRequest("hosted agent pool %s is still assigned", poolID)
+	}
+	return req.Delete(&v1.HostedAgentPool{ObjectMeta: metav1.ObjectMeta{
+		Name:      poolID,
+		Namespace: req.Namespace(),
+	}})
+}
+
+func (h *HostedAgentPoolHandler) Utilization(req api.Context) error {
+	poolID := req.PathValue("hosted_agent_pool_id")
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, poolID); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool: %w", err)
+	}
+	if err := requirePoolAccess(req, pool.Name); err != nil {
+		return err
+	}
+	if h.utilization == nil {
+		return types.NewErrNotFound("hosted agent utilization is unavailable")
+	}
+
+	snapshot, err := h.utilization.GetPoolUtilization(req.Context(), agentbackend.PoolRef{
+		ID:        pool.Name,
+		BackendID: pool.Status.BackendPoolID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get hosted agent pool utilization: %w", err)
+	}
+
+	// A pool is shared by everyone assigned to it, so the totals
+	// describe other people's sandboxes as well as the caller's. The totals are
+	// what a user needs in order to understand why their pool is full, so they
+	// stay whole; the per-instance breakdown is narrowed to the caller, who has
+	// no business seeing a co-tenant's instance IDs or consumption.
+	selector := kclient.MatchingFields{"spec.poolID": poolID}
+	if !req.UserIsAdmin() {
+		selector["spec.userID"] = req.User.GetUID()
+	}
+	var instances v1.HostedAgentInstanceList
+	if err := req.List(&instances, selector); err != nil {
+		return fmt.Errorf("failed to map hosted agent instance utilization: %w", err)
+	}
+
+	snapshot.Instances = narrowInstanceUtilization(snapshot.Instances, instances.Items)
+
+	return req.Write(convertPoolUtilization(snapshot))
+}
+
+// narrowInstanceUtilization keeps only the usage entries belonging to instances
+// the caller may see, and rewrites their identity from the backend's stable UID
+// to the API resource ID so clients can join usage against instances they
+// already hold without learning backend identifiers.
+//
+// Anything the caller cannot see is dropped rather than anonymised: on a shared
+// pool the count and sizes of a co-tenant's sandboxes are themselves
+// worth withholding. The pool totals are reported separately and stay whole.
+func narrowInstanceUtilization(usages []agentbackend.InstanceUtilization, visible []v1.HostedAgentInstance) []agentbackend.InstanceUtilization {
+	ids := make(map[string]string, len(visible))
+	for _, instance := range visible {
+		ids[string(instance.UID)] = instance.Name
+	}
+
+	result := make([]agentbackend.InstanceUtilization, 0, len(usages))
+	for _, usage := range usages {
+		id, ok := ids[usage.Ref.ID]
+		if !ok {
+			continue
+		}
+		usage.Ref.ID = id
+		result = append(result, usage)
+	}
+	return result
+}
+
+func readHostedAgentPoolManifest(req api.Context) (types.HostedAgentPoolManifest, error) {
+	var manifest types.HostedAgentPoolManifest
+	if err := req.Read(&manifest); err != nil {
+		return manifest, types.NewErrBadRequest("failed to read hosted agent pool: %v", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return manifest, types.NewErrBadRequest("invalid hosted agent pool: %v", err)
+	}
+	return manifest, nil
+}
+
+func convertHostedAgentPool(pool v1.HostedAgentPool) types.HostedAgentPool {
+	return types.HostedAgentPool{
+		Metadata:                MetadataFrom(&pool),
+		HostedAgentPoolManifest: pool.Spec.Manifest,
+		Status:                  pool.Status.HostedAgentPoolStatus,
+	}
+}
+
+type HostedAgentPoolDefaultsHandler struct{}
+
+func NewHostedAgentPoolDefaultsHandler() *HostedAgentPoolDefaultsHandler {
+	return &HostedAgentPoolDefaultsHandler{}
+}
+
+func (*HostedAgentPoolDefaultsHandler) Get(req api.Context) error {
+	var defaults v1.HostedAgentPoolDefaults
+	if err := req.Get(&defaults, hostedAgentPoolDefaultsName); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool defaults: %w", err)
+	}
+	return req.Write(convertHostedAgentPoolDefaults(defaults))
+}
+
+func (*HostedAgentPoolDefaultsHandler) Create(req api.Context) error {
+	manifest, err := readHostedAgentPoolDefaultsManifest(req)
+	if err != nil {
+		return err
+	}
+	defaults := v1.HostedAgentPoolDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: hostedAgentPoolDefaultsName, Namespace: req.Namespace()},
+		Spec:       v1.HostedAgentPoolDefaultsSpec{Manifest: manifest},
+	}
+	if err := req.Create(&defaults); err != nil {
+		return fmt.Errorf("failed to create hosted agent pool defaults: %w", err)
+	}
+	return req.WriteCreated(convertHostedAgentPoolDefaults(defaults))
+}
+
+func (*HostedAgentPoolDefaultsHandler) Update(req api.Context) error {
+	manifest, err := readHostedAgentPoolDefaultsManifest(req)
+	if err != nil {
+		return err
+	}
+	var defaults v1.HostedAgentPoolDefaults
+	if err := req.Get(&defaults, hostedAgentPoolDefaultsName); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool defaults: %w", err)
+	}
+	defaults.Spec.Manifest = manifest
+	if err := req.Update(&defaults); err != nil {
+		return fmt.Errorf("failed to update hosted agent pool defaults: %w", err)
+	}
+	return req.Write(convertHostedAgentPoolDefaults(defaults))
+}
+
+func (*HostedAgentPoolDefaultsHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.HostedAgentPoolDefaults{ObjectMeta: metav1.ObjectMeta{
+		Name: hostedAgentPoolDefaultsName, Namespace: req.Namespace(),
+	}})
+}
+
+func readHostedAgentPoolDefaultsManifest(req api.Context) (types.HostedAgentPoolDefaultsManifest, error) {
+	var manifest types.HostedAgentPoolDefaultsManifest
+	if err := req.Read(&manifest); err != nil {
+		return manifest, types.NewErrBadRequest("failed to read hosted agent pool defaults: %v", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return manifest, types.NewErrBadRequest("invalid hosted agent pool defaults: %v", err)
+	}
+	return manifest, nil
+}
+
+func convertHostedAgentPoolDefaults(defaults v1.HostedAgentPoolDefaults) types.HostedAgentPoolDefaults {
+	return types.HostedAgentPoolDefaults{
+		Metadata:                        MetadataFrom(&defaults),
+		HostedAgentPoolDefaultsManifest: defaults.Spec.Manifest,
+	}
+}
+
+type HostedAgentPoolAssignmentHandler struct{}
+
+func NewHostedAgentPoolAssignmentHandler() *HostedAgentPoolAssignmentHandler {
+	return &HostedAgentPoolAssignmentHandler{}
+}
+
+func (*HostedAgentPoolAssignmentHandler) List(req api.Context) error {
+	options := []kclient.ListOption{}
+	if !req.UserIsAdmin() {
+		options = append(options, kclient.MatchingFields{"spec.userID": req.User.GetUID()})
+	}
+	var list v1.HostedAgentPoolAssignmentList
+	if err := req.List(&list, options...); err != nil {
+		return fmt.Errorf("failed to list hosted agent pool assignments: %w", err)
+	}
+	items := make([]types.HostedAgentPoolAssignment, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, convertHostedAgentPoolAssignment(item))
+	}
+	return req.Write(types.HostedAgentPoolAssignmentList{Items: items})
+}
+
+func (*HostedAgentPoolAssignmentHandler) Get(req api.Context) error {
+	var assignment v1.HostedAgentPoolAssignment
+	if err := req.Get(&assignment, req.PathValue("hosted_agent_pool_assignment_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool assignment: %w", err)
+	}
+	if !req.UserIsAdmin() && assignment.Spec.Manifest.UserID != req.User.GetUID() {
+		return types.NewErrNotFound("hosted agent pool assignment not found")
+	}
+	return req.Write(convertHostedAgentPoolAssignment(assignment))
+}
+
+func (*HostedAgentPoolAssignmentHandler) Create(req api.Context) error {
+	manifest, err := readHostedAgentPoolAssignmentManifest(req)
+	if err != nil {
+		return err
+	}
+	if err := validatePoolAssignment(req, manifest, ""); err != nil {
+		return err
+	}
+	assignment := v1.HostedAgentPoolAssignment{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "hpa1", Namespace: req.Namespace()},
+		Spec:       v1.HostedAgentPoolAssignmentSpec{Manifest: manifest},
+	}
+	if err := req.Create(&assignment); err != nil {
+		return fmt.Errorf("failed to create hosted agent pool assignment: %w", err)
+	}
+	return req.WriteCreated(convertHostedAgentPoolAssignment(assignment))
+}
+
+func (*HostedAgentPoolAssignmentHandler) Update(req api.Context) error {
+	manifest, err := readHostedAgentPoolAssignmentManifest(req)
+	if err != nil {
+		return err
+	}
+	var assignment v1.HostedAgentPoolAssignment
+	if err := req.Get(&assignment, req.PathValue("hosted_agent_pool_assignment_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool assignment: %w", err)
+	}
+	if err := validatePoolAssignment(req, manifest, assignment.Name); err != nil {
+		return err
+	}
+	assignment.Spec.Manifest = manifest
+	if err := req.Update(&assignment); err != nil {
+		return fmt.Errorf("failed to update hosted agent pool assignment: %w", err)
+	}
+	return req.Write(convertHostedAgentPoolAssignment(assignment))
+}
+
+func (*HostedAgentPoolAssignmentHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.HostedAgentPoolAssignment{ObjectMeta: metav1.ObjectMeta{
+		Name:      req.PathValue("hosted_agent_pool_assignment_id"),
+		Namespace: req.Namespace(),
+	}})
+}
+
+func readHostedAgentPoolAssignmentManifest(req api.Context) (types.HostedAgentPoolAssignmentManifest, error) {
+	var manifest types.HostedAgentPoolAssignmentManifest
+	if err := req.Read(&manifest); err != nil {
+		return manifest, types.NewErrBadRequest("failed to read hosted agent pool assignment: %v", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return manifest, types.NewErrBadRequest("invalid hosted agent pool assignment: %v", err)
+	}
+	return manifest, nil
+}
+
+func validatePoolAssignment(req api.Context, manifest types.HostedAgentPoolAssignmentManifest, currentID string) error {
+	if err := req.Get(&v1.HostedAgentPool{}, manifest.PoolID); apierrors.IsNotFound(err) {
+		return types.NewErrBadRequest("hosted agent pool %s not found", manifest.PoolID)
+	} else if err != nil {
+		return fmt.Errorf("failed to get hosted agent pool %s: %w", manifest.PoolID, err)
+	}
+	if !manifest.Default {
+		return nil
+	}
+
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, kclient.MatchingFields{
+		"spec.userID":  manifest.UserID,
+		"spec.default": "true",
+	}); err != nil {
+		return fmt.Errorf("failed to find default hosted agent pool assignment: %w", err)
+	}
+	for _, assignment := range assignments.Items {
+		if assignment.Name != currentID {
+			return types.NewErrBadRequest("user %s already has a default hosted agent pool", manifest.UserID)
+		}
+	}
+	return nil
+}
+
+func convertHostedAgentPoolAssignment(assignment v1.HostedAgentPoolAssignment) types.HostedAgentPoolAssignment {
+	return types.HostedAgentPoolAssignment{
+		Metadata:                          MetadataFrom(&assignment),
+		HostedAgentPoolAssignmentManifest: assignment.Spec.Manifest,
+	}
+}
+
+func userPoolIDs(req api.Context) (map[string]bool, error) {
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, kclient.MatchingFields{"spec.userID": req.User.GetUID()}); err != nil {
+		return nil, fmt.Errorf("failed to list hosted agent pool assignments: %w", err)
+	}
+	result := make(map[string]bool, len(assignments.Items))
+	for _, assignment := range assignments.Items {
+		result[assignment.Spec.Manifest.PoolID] = true
+	}
+	return result, nil
+}
+
+func requirePoolAccess(req api.Context, poolID string) error {
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, poolID); apierrors.IsNotFound(err) {
+		return types.NewErrNotFound("hosted agent pool %s not found", poolID)
+	} else if err != nil {
+		return fmt.Errorf("failed to get hosted agent pool %s: %w", poolID, err)
+	}
+	if req.UserIsAdmin() {
+		return nil
+	}
+	allowed, err := userPoolIDs(req)
+	if err != nil {
+		return err
+	}
+	if !allowed[poolID] {
+		return types.NewErrNotFound("hosted agent pool %s not found", poolID)
+	}
+	return nil
+}
+
+type hostedAgentPoolUtilization struct {
+	Timestamp time.Time                        `json:"timestamp"`
+	Pool      hostedAgentResourceUtilization   `json:"pool"`
+	Instances []hostedAgentInstanceUtilization `json:"instances"`
+	Pressure  hostedAgentPoolResourcePressure  `json:"pressure"`
+	// StorageMeasured distinguishes a pool using no disk from one whose disk
+	// cannot be measured. Without it a client cannot tell the two apart, and
+	// showing an empty disk bar for an unknown figure is worse than saying so.
+	StorageMeasured bool `json:"storageMeasured"`
+}
+
+type hostedAgentInstanceUtilization struct {
+	InstanceID string                         `json:"instanceID"`
+	State      agentbackend.State             `json:"state"`
+	Usage      hostedAgentResourceUtilization `json:"usage"`
+}
+
+// hostedAgentResourceUtilization is live usage. storageBytes is meaningful only
+// on the pool: sandboxes share one volume, so a sandbox's own disk usage is not
+// observable and is always reported as zero.
+type hostedAgentResourceUtilization struct {
+	CPUVCPUs     float64 `json:"cpuVcpus"`
+	MemoryBytes  int64   `json:"memoryBytes"`
+	StorageBytes int64   `json:"storageBytes"`
+}
+
+type hostedAgentPoolResourcePressure struct {
+	CPU     bool `json:"cpu"`
+	Memory  bool `json:"memory"`
+	Storage bool `json:"storage"`
+}
+
+func convertPoolUtilization(snapshot agentbackend.UtilizationSnapshot) hostedAgentPoolUtilization {
+	result := hostedAgentPoolUtilization{
+		Timestamp: snapshot.Timestamp,
+		Pool:      convertResourceUtilization(snapshot.Pool),
+		Instances: make([]hostedAgentInstanceUtilization, 0, len(snapshot.Instances)),
+		Pressure: hostedAgentPoolResourcePressure{
+			CPU: snapshot.Pressure.CPU, Memory: snapshot.Pressure.Memory, Storage: snapshot.Pressure.Storage,
+		},
+		StorageMeasured: snapshot.StorageMeasured,
+	}
+	for _, instance := range snapshot.Instances {
+		result.Instances = append(result.Instances, hostedAgentInstanceUtilization{
+			InstanceID: instance.Ref.ID,
+			State:      instance.State,
+			Usage:      convertResourceUtilization(instance.Utilization),
+		})
+	}
+	return result
+}
+
+func convertResourceUtilization(usage agentbackend.ResourceUtilization) hostedAgentResourceUtilization {
+	return hostedAgentResourceUtilization{
+		CPUVCPUs: usage.CPUVCPUs, MemoryBytes: usage.MemoryBytes, StorageBytes: usage.StorageBytes,
+	}
+}

--- a/pkg/api/handlers/hostedagentpools_test.go
+++ b/pkg/api/handlers/hostedagentpools_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConvertPoolUtilization(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
+	got := convertPoolUtilization(agentbackend.UtilizationSnapshot{
+		Timestamp: now,
+		Pool:      agentbackend.ResourceUtilization{CPUVCPUs: 1.5, MemoryBytes: 2, StorageBytes: 3},
+		Instances: []agentbackend.InstanceUtilization{{
+			Ref:         agentbackend.InstanceRef{ID: "instance-1", BackendID: "backend-1"},
+			State:       agentbackend.StateReady,
+			Utilization: agentbackend.ResourceUtilization{CPUVCPUs: 0.5, MemoryBytes: 1, StorageBytes: 2},
+		}},
+		Pressure: agentbackend.Pressure{Memory: true},
+	})
+
+	if !got.Timestamp.Equal(now) {
+		t.Fatalf("Timestamp = %v, want %v", got.Timestamp, now)
+	}
+	if got.Pool.CPUVCPUs != 1.5 || got.Pool.MemoryBytes != 2 || got.Pool.StorageBytes != 3 {
+		t.Fatalf("Pool = %#v", got.Pool)
+	}
+	if len(got.Instances) != 1 || got.Instances[0].InstanceID != "instance-1" || got.Instances[0].State != agentbackend.StateReady {
+		t.Fatalf("Instances = %#v", got.Instances)
+	}
+	if !got.Pressure.Memory || got.Pressure.CPU || got.Pressure.Storage {
+		t.Fatalf("Pressure = %#v", got.Pressure)
+	}
+}
+
+func TestConvertHostedAgentInstanceIncludesPool(t *testing.T) {
+	got := convertHostedAgentInstance(v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "instance-1"},
+		Spec: v1.HostedAgentInstanceSpec{
+			UserID:          "user-1",
+			HostedAgentName: "agent-1",
+			PoolID:          "pool-1",
+		},
+	})
+
+	if got.PoolID != "pool-1" {
+		t.Fatalf("PoolID = %q, want pool-1", got.PoolID)
+	}
+}
+
+// A pool is shared across users, so its utilization describes
+// co-tenants' sandboxes too. Pool totals are reported separately and stay
+// whole; the per-instance breakdown must not expose anyone else's instances.
+func TestNarrowInstanceUtilizationHidesOtherUsersInstances(t *testing.T) {
+	mine := v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "hai-mine", UID: "uid-mine"},
+	}
+	usages := []agentbackend.InstanceUtilization{
+		{Ref: agentbackend.InstanceRef{ID: "uid-theirs-1"}, Utilization: agentbackend.ResourceUtilization{CPUVCPUs: 1}},
+		{Ref: agentbackend.InstanceRef{ID: "uid-mine"}, Utilization: agentbackend.ResourceUtilization{CPUVCPUs: 2}},
+		{Ref: agentbackend.InstanceRef{ID: "uid-theirs-2"}, Utilization: agentbackend.ResourceUtilization{CPUVCPUs: 3}},
+	}
+
+	got := narrowInstanceUtilization(usages, []v1.HostedAgentInstance{mine})
+
+	if len(got) != 1 {
+		t.Fatalf("expected only the caller's instance, got %d entries: %+v", len(got), got)
+	}
+	// Rewritten from the backend UID to the API resource ID.
+	if got[0].Ref.ID != "hai-mine" {
+		t.Errorf("instance ID = %q, want the API resource ID hai-mine", got[0].Ref.ID)
+	}
+	if got[0].Utilization.CPUVCPUs != 2 {
+		t.Errorf("kept the wrong entry: cpu = %v, want 2", got[0].Utilization.CPUVCPUs)
+	}
+}
+
+// An admin passes the full instance list, so nothing is dropped.
+func TestNarrowInstanceUtilizationKeepsEverythingVisible(t *testing.T) {
+	instances := []v1.HostedAgentInstance{
+		{ObjectMeta: metav1.ObjectMeta{Name: "hai-a", UID: "uid-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "hai-b", UID: "uid-b"}},
+	}
+	usages := []agentbackend.InstanceUtilization{
+		{Ref: agentbackend.InstanceRef{ID: "uid-a"}},
+		{Ref: agentbackend.InstanceRef{ID: "uid-b"}},
+	}
+
+	got := narrowInstanceUtilization(usages, instances)
+
+	if len(got) != 2 {
+		t.Fatalf("expected both instances, got %d", len(got))
+	}
+}
+
+// A sandbox the backend reports but Obot has no record of, such as one left
+// behind by a failed delete, must not surface with a raw backend identifier.
+func TestNarrowInstanceUtilizationDropsUnknownSandboxes(t *testing.T) {
+	usages := []agentbackend.InstanceUtilization{
+		{Ref: agentbackend.InstanceRef{ID: "uid-orphan"}},
+	}
+
+	if got := narrowInstanceUtilization(usages, nil); len(got) != 0 {
+		t.Fatalf("expected orphaned sandboxes to be dropped, got %+v", got)
+	}
+}

--- a/pkg/api/handlers/hostedagents.go
+++ b/pkg/api/handlers/hostedagents.go
@@ -1,0 +1,272 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/adhocore/gronx"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	gateway "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/hostedagentaccessrule"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type HostedAgentHandler struct {
+	accessRuleHelper *hostedagentaccessrule.Helper
+}
+
+func NewHostedAgentHandler(accessRuleHelper *hostedagentaccessrule.Helper) *HostedAgentHandler {
+	return &HostedAgentHandler{accessRuleHelper: accessRuleHelper}
+}
+
+func (h *HostedAgentHandler) List(req api.Context) error {
+	var list v1.HostedAgentList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list hosted agents: %w", err)
+	}
+
+	// Admins and auditors can see every agent with ?all=true. Everyone else,
+	// including admins without the flag, sees only what the access rules allow.
+	availability, err := newAgentAvailability(req.Context(), req.Storage, req.Namespace())
+	if err != nil {
+		return err
+	}
+
+	if (req.UserIsAdmin() || req.UserIsAuditor()) && req.URL.Query().Get("all") == "true" {
+		items := make([]types.HostedAgent, 0, len(list.Items))
+		for _, item := range list.Items {
+			items = append(items, availability.applyTo(req.Context(), convertHostedAgent(item)))
+		}
+		return req.Write(types.HostedAgentList{Items: items})
+	}
+
+	items := make([]types.HostedAgent, 0, len(list.Items))
+	for _, item := range list.Items {
+		hasAccess, err := h.accessRuleHelper.UserHasAccessToHostedAgent(req.User, &item)
+		if err != nil {
+			return fmt.Errorf("failed to check access to hosted agent %s: %w", item.Name, err)
+		}
+		if hasAccess {
+			items = append(items, availability.applyTo(req.Context(), convertHostedAgent(item)))
+		}
+	}
+
+	return req.Write(types.HostedAgentList{Items: items})
+}
+
+func (h *HostedAgentHandler) Get(req api.Context) error {
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.PathValue("hosted_agent_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	availability, err := newAgentAvailability(req.Context(), req.Storage, req.Namespace())
+	if err != nil {
+		return err
+	}
+
+	return req.Write(availability.applyTo(req.Context(), convertHostedAgent(agent)))
+}
+
+func (h *HostedAgentHandler) Create(req api.Context) error {
+	var manifest types.HostedAgentManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read hosted agent manifest: %v", err)
+	}
+
+	if err := validateHostedAgentManifest(req, manifest); err != nil {
+		return err
+	}
+
+	secrets := extractHostedAgentSecrets(&manifest)
+
+	agent := v1.HostedAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.HostedAgentPrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HostedAgentSpec{
+			Manifest: manifest,
+		},
+	}
+
+	if err := req.Create(&agent); err != nil {
+		return fmt.Errorf("failed to create hosted agent: %w", err)
+	}
+
+	if len(secrets) > 0 {
+		if err := req.GatewayClient.UpsertCredential(req.Context(), gatewaytypes.Credential{
+			Context: HostedAgentCredentialContext(agent),
+			Name:    agent.Name,
+			Secrets: secrets,
+		}); err != nil {
+			return fmt.Errorf("failed to store hosted agent credentials: %w", err)
+		}
+	}
+
+	return req.WriteCreated(convertHostedAgent(agent))
+}
+
+func (h *HostedAgentHandler) Update(req api.Context) error {
+	var manifest types.HostedAgentManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read hosted agent manifest: %v", err)
+	}
+
+	if err := validateHostedAgentManifest(req, manifest); err != nil {
+		return err
+	}
+
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.PathValue("hosted_agent_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	newSecrets := extractHostedAgentSecrets(&manifest)
+
+	existing, err := hostedAgentSecrets(req, agent)
+	if err != nil {
+		return err
+	}
+
+	// A blank value on a sensitive env var means "leave it as it was", so that
+	// clients can round-trip a manifest without ever seeing the secret.
+	secrets := make(map[string]string, len(newSecrets))
+	for _, env := range manifest.Env {
+		if !env.Sensitive {
+			continue
+		}
+		if value, ok := newSecrets[env.Key]; ok {
+			secrets[env.Key] = value
+		} else if value, ok := existing[env.Key]; ok {
+			secrets[env.Key] = value
+		}
+	}
+
+	agent.Spec.Manifest = manifest
+	if err := req.Update(&agent); err != nil {
+		return fmt.Errorf("failed to update hosted agent: %w", err)
+	}
+
+	if len(secrets) > 0 {
+		if err := req.GatewayClient.UpsertCredential(req.Context(), gatewaytypes.Credential{
+			Context: HostedAgentCredentialContext(agent),
+			Name:    agent.Name,
+			Secrets: secrets,
+		}); err != nil {
+			return fmt.Errorf("failed to store hosted agent credentials: %w", err)
+		}
+	} else if len(existing) > 0 {
+		if _, err := req.GatewayClient.DeleteCredential(req.Context(), HostedAgentCredentialContext(agent), agent.Name); err != nil {
+			return fmt.Errorf("failed to delete hosted agent credentials: %w", err)
+		}
+	}
+
+	return req.Write(convertHostedAgent(agent))
+}
+
+func (h *HostedAgentHandler) Delete(req api.Context) error {
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.PathValue("hosted_agent_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	if _, err := req.GatewayClient.DeleteCredential(req.Context(), HostedAgentCredentialContext(agent), agent.Name); err != nil {
+		return fmt.Errorf("failed to delete hosted agent credentials: %w", err)
+	}
+
+	return req.Delete(&v1.HostedAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agent.Name,
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+func (h *HostedAgentHandler) Reveal(req api.Context) error {
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.PathValue("hosted_agent_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	secrets, err := hostedAgentSecrets(req, agent)
+	if err != nil {
+		return err
+	}
+
+	if len(secrets) == 0 {
+		return req.Write(map[string]string{})
+	}
+
+	return req.Write(secrets)
+}
+
+// validateHostedAgentManifest runs the shared manifest validation, plus the
+// checks that apiclient/types deliberately leaves out: cron parsing (a
+// question's default is an answer like any other, so it gets the same
+// treatment) and that the referenced harness actually exists.
+func validateHostedAgentManifest(req api.Context, manifest types.HostedAgentManifest) error {
+	if err := manifest.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid hosted agent manifest: %v", err)
+	}
+
+	var harness v1.Harness
+	if err := req.Get(&harness, manifest.HarnessID); apierrors.IsNotFound(err) {
+		return types.NewErrBadRequest("harness %s not found", manifest.HarnessID)
+	} else if err != nil {
+		return fmt.Errorf("failed to get harness %s: %w", manifest.HarnessID, err)
+	}
+
+	for _, question := range manifest.Questions {
+		if question.Type != types.HostedAgentQuestionTypeSchedule || question.Default == "" {
+			continue
+		}
+		if !gronx.IsValid(question.Default) {
+			return types.NewErrBadRequest("invalid hosted agent manifest: question %s: default must be a valid cron expression", question.Key)
+		}
+	}
+
+	return nil
+}
+
+// extractHostedAgentSecrets pulls the values of sensitive env vars out of the
+// manifest and blanks them, so they are only ever persisted in the credential
+// store and never on the resource itself.
+func extractHostedAgentSecrets(manifest *types.HostedAgentManifest) map[string]string {
+	secrets := make(map[string]string)
+	for i, env := range manifest.Env {
+		if env.Sensitive && env.Value != "" {
+			secrets[env.Key] = env.Value
+			manifest.Env[i].Value = ""
+		}
+	}
+	return secrets
+}
+
+func hostedAgentSecrets(req api.Context, agent v1.HostedAgent) (map[string]string, error) {
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{HostedAgentCredentialContext(agent)}, agent.Name)
+	if err != nil {
+		if errors.As(err, &gateway.CredentialNotFoundError{}) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find hosted agent credential: %w", err)
+	}
+
+	return cred.Secrets, nil
+}
+
+func HostedAgentCredentialContext(agent v1.HostedAgent) string {
+	return fmt.Sprintf("hosted-agent-%s", agent.Name)
+}
+
+func convertHostedAgent(agent v1.HostedAgent) types.HostedAgent {
+	return types.HostedAgent{
+		Metadata:            MetadataFrom(&agent),
+		HostedAgentManifest: agent.Spec.Manifest,
+	}
+}

--- a/pkg/api/handlers/iconresolver_test.go
+++ b/pkg/api/handlers/iconresolver_test.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+func resolverFor(agent types.HostedAgentManifest, harness types.HarnessManifest) *iconResolver {
+	return &iconResolver{
+		agents:    map[string]types.HostedAgentManifest{"ha1": agent},
+		harnesses: map[string]types.HarnessManifest{"hrn1": harness},
+	}
+}
+
+// The chain exists so a client renders a row from one payload instead of
+// fetching the agent and its harness per instance.
+func TestIconResolutionOrder(t *testing.T) {
+	agent := types.HostedAgentManifest{HarnessID: "hrn1", Icon: "agent.svg", IconDark: "agent-dark.svg"}
+	harness := types.HarnessManifest{Icon: "harness.svg", IconDark: "harness-dark.svg"}
+
+	// The user's own choice wins.
+	got := resolverFor(agent, harness).apply(
+		types.HostedAgentInstance{HostedAgentInstanceManifest: types.HostedAgentInstanceManifest{Icon: "mine.svg"}}, "ha1")
+	if got.ResolvedIcon != "mine.svg" {
+		t.Errorf("instance icon = %q, want the instance's own", got.ResolvedIcon)
+	}
+
+	// Otherwise the agent's.
+	got = resolverFor(agent, harness).apply(types.HostedAgentInstance{}, "ha1")
+	if got.ResolvedIcon != "agent.svg" || got.ResolvedIconDark != "agent-dark.svg" {
+		t.Errorf("resolved = %q/%q, want the agent's", got.ResolvedIcon, got.ResolvedIconDark)
+	}
+
+	// Otherwise the harness's, which is where a config source's icon lives when
+	// only the harness declares one.
+	got = resolverFor(types.HostedAgentManifest{HarnessID: "hrn1"}, harness).apply(types.HostedAgentInstance{}, "ha1")
+	if got.ResolvedIcon != "harness.svg" || got.ResolvedIconDark != "harness-dark.svg" {
+		t.Errorf("resolved = %q/%q, want the harness's", got.ResolvedIcon, got.ResolvedIconDark)
+	}
+}
+
+// A dark variant is optional at every level, so a client should never have to
+// decide what to do when only the light one is set.
+func TestDarkIconFallsBackToLight(t *testing.T) {
+	got := resolverFor(types.HostedAgentManifest{HarnessID: "hrn1", Icon: "agent.svg"}, types.HarnessManifest{}).
+		apply(types.HostedAgentInstance{}, "ha1")
+	if got.ResolvedIconDark != "agent.svg" {
+		t.Errorf("dark icon = %q, want it to fall back to the light one", got.ResolvedIconDark)
+	}
+}
+
+// Nothing anywhere resolves to nothing, rather than to a broken image.
+func TestNoIconAnywhereResolvesEmpty(t *testing.T) {
+	got := resolverFor(types.HostedAgentManifest{HarnessID: "hrn1"}, types.HarnessManifest{}).
+		apply(types.HostedAgentInstance{}, "ha1")
+	if got.ResolvedIcon != "" || got.ResolvedIconDark != "" {
+		t.Errorf("resolved = %q/%q, want empty", got.ResolvedIcon, got.ResolvedIconDark)
+	}
+}
+
+// An instance whose agent has been deleted still renders; it just has no icon.
+func TestUnknownAgentDoesNotPanic(t *testing.T) {
+	got := resolverFor(types.HostedAgentManifest{}, types.HarnessManifest{}).
+		apply(types.HostedAgentInstance{HostedAgentInstanceManifest: types.HostedAgentInstanceManifest{Icon: "mine.svg"}}, "gone")
+	if got.ResolvedIcon != "mine.svg" {
+		t.Errorf("resolved = %q, want the instance's own icon", got.ResolvedIcon)
+	}
+}

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -22,6 +22,7 @@ import (
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
 	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/mcp"
+	"github.com/obot-platform/obot/pkg/principal"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	obottunnel "github.com/obot-platform/obot/pkg/tunnel"
@@ -961,7 +962,7 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id, secretBindingAllowed
 						MCPCatalogName:            server.Spec.MCPCatalogID,
 						MCPServerCatalogEntryName: server.Spec.MCPServerCatalogEntryName,
 						PowerUserWorkspaceID:      server.Spec.PowerUserWorkspaceID,
-						UserID:                    req.User.GetUID(),
+						UserID:                    principal.ResourceOwnerID(req.User),
 						MultiUserConfig:           server.Spec.Manifest.MultiUserConfig,
 					},
 				}

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/obot-platform/obot/pkg/controller/handlers/systemmcpserver"
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/mcp"
+	"github.com/obot-platform/obot/pkg/principal"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/tunnel"
@@ -211,7 +212,7 @@ func (h *Handler) ensureServerIsDeployed(req api.Context) (mcp.ServerConfig, err
 		return h.ensureSystemServerIsDeployed(req, mcpID)
 	}
 
-	mcpID, mcpServer, mcpServerConfig, missingConfig, err := h.mcpSessionManager.ServerForActionWithConnectIDAllowMissingConfig(req.Context(), mcpID, req.User.GetUID())
+	mcpID, mcpServer, mcpServerConfig, missingConfig, err := h.mcpSessionManager.ServerForActionWithConnectIDAllowMissingConfig(req.Context(), mcpID, principal.ResourceOwnerID(req.User))
 	if err != nil {
 		return mcp.ServerConfig{}, fmt.Errorf("failed to get mcp server config: %w", err)
 	}
@@ -317,7 +318,9 @@ func (h *Handler) ensureSystemServerIsDeployed(req api.Context, mcpID string) (m
 	baseURL := strings.TrimSuffix(req.APIBaseURL, "/api")
 	audiences := systemServer.ValidConnectURLs(baseURL)
 
-	serverConfig, _, err := mcp.SystemServerToServerConfig(systemServer, audiences, req.User.GetUID(), credEnv, secretsCred)
+	// Ownership, not the acting identity: a system server deployed for an agent
+	// belongs to the person who created that agent.
+	serverConfig, _, err := mcp.SystemServerToServerConfig(systemServer, audiences, principal.ResourceOwnerID(req.User), credEnv, secretsCred)
 	if err != nil {
 		return mcp.ServerConfig{}, fmt.Errorf("failed to convert system server to config: %w", err)
 	}

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 
 	"github.com/obot-platform/obot/pkg/api/handlers"
+	"github.com/obot-platform/obot/pkg/api/handlers/agentconnect"
+	"github.com/obot-platform/obot/pkg/api/handlers/agentterminal"
 	"github.com/obot-platform/obot/pkg/api/handlers/mcpgateway"
 	"github.com/obot-platform/obot/pkg/api/handlers/mcpgateway/oauth"
 	"github.com/obot-platform/obot/pkg/api/handlers/registry"
@@ -81,6 +83,10 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 		return nil, err
 	}
 
+	// Sandboxes are plain in-cluster HTTP, so the default transport is enough.
+	agentConnect := agentconnect.New(http.DefaultTransport, services.AgentDevRouter)
+	agentTerminal := agentterminal.New(services.AgentBackend, services.DevUIPort)
+
 	oauthChecker := oauth.NewMCPOAuthHandlerFactory(services.ServerURL, services.MCPSessionManager, services.StorageClient, services.GatewayClient, services.MCPOAuthTokenStorage, services.MCPSecretBindingAllowedLabel, services.ForceDynamicClient)
 
 	models := handlers.NewModelHandler(services.ModelAccessPolicyHelper)
@@ -91,6 +97,19 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	skillRepositories := handlers.NewSkillRepositoryHandler()
 	gitCredentials := handlers.NewGitCredentialHandler()
 	skillAccessRules := handlers.NewSkillAccessRuleHandler()
+	agentCatalogs := handlers.NewAgentCatalogHandler(services.DevMode)
+	harnesses := handlers.NewHarnessHandler()
+	hostedAgents := handlers.NewHostedAgentHandler(services.HostedAgentAccessRuleHelper)
+	hostedAgentInstances := handlers.NewHostedAgentInstanceHandler(
+		services.HostedAgentAccessRuleHelper,
+		services.AccessControlRuleHelper,
+		services.SkillAccessRuleHelper,
+		services.ModelAccessPolicyHelper,
+	)
+	hostedAgentPools := handlers.NewHostedAgentPoolHandler(services.AgentBackend)
+	hostedAgentPoolDefaults := handlers.NewHostedAgentPoolDefaultsHandler()
+	hostedAgentPoolAssignments := handlers.NewHostedAgentPoolAssignmentHandler()
+	hostedAgentAccessRules := handlers.NewHostedAgentAccessRuleHandler()
 	skills := handlers.NewSkillHandler(services.SkillAccessRuleHelper)
 	powerUserWorkspaces := handlers.NewPowerUserWorkspaceHandler(services.ServerURL, services.AccessControlRuleHelper, services.MCPSecretBindingAllowedLabel)
 	mcpWebhookValidations := handlers.NewMCPWebhookValidationHandler(services.MCPSessionManager)
@@ -457,6 +476,65 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mux.HandleFunc("PUT /api/skill-access-rules/{skill_access_rule_id}", skillAccessRules.Update)
 	mux.HandleFunc("DELETE /api/skill-access-rules/{skill_access_rule_id}", skillAccessRules.Delete)
 
+	// Agent sources (admin only)
+	mux.HandleFunc("GET /api/agent-catalogs", agentCatalogs.List)
+	mux.HandleFunc("POST /api/agent-catalogs", agentCatalogs.Create)
+	mux.HandleFunc("GET /api/agent-catalogs/{agent_catalog_id}", agentCatalogs.Get)
+	mux.HandleFunc("PUT /api/agent-catalogs/{agent_catalog_id}", agentCatalogs.Update)
+	mux.HandleFunc("DELETE /api/agent-catalogs/{agent_catalog_id}", agentCatalogs.Delete)
+	mux.HandleFunc("POST /api/agent-catalogs/{agent_catalog_id}/refresh", agentCatalogs.Refresh)
+
+	// Harnesses (admin only) — the runtimes hosted agents are built on
+	mux.HandleFunc("GET /api/harnesses", harnesses.List)
+	mux.HandleFunc("POST /api/harnesses", harnesses.Create)
+	mux.HandleFunc("GET /api/harnesses/{harness_id}", harnesses.Get)
+	mux.HandleFunc("PUT /api/harnesses/{harness_id}", harnesses.Update)
+	mux.HandleFunc("DELETE /api/harnesses/{harness_id}", harnesses.Delete)
+
+	// Hosted agents (admin manages; users get an access-rule-filtered read-only view)
+	mux.HandleFunc("GET /api/hosted-agents", hostedAgents.List)
+	mux.HandleFunc("POST /api/hosted-agents", hostedAgents.Create)
+	mux.HandleFunc("GET /api/hosted-agents/{hosted_agent_id}", hostedAgents.Get)
+	mux.HandleFunc("PUT /api/hosted-agents/{hosted_agent_id}", hostedAgents.Update)
+	mux.HandleFunc("DELETE /api/hosted-agents/{hosted_agent_id}", hostedAgents.Delete)
+	mux.HandleFunc("POST /api/hosted-agents/{hosted_agent_id}/reveal", hostedAgents.Reveal)
+
+	// Hosted agent instances (per-user)
+	mux.HandleFunc("GET /api/hosted-agent-instances", hostedAgentInstances.List)
+	mux.HandleFunc("POST /api/hosted-agent-instances", hostedAgentInstances.Create)
+	mux.HandleFunc("GET /api/hosted-agent-instances/{hosted_agent_instance_id}", hostedAgentInstances.Get)
+	mux.HandleFunc("PUT /api/hosted-agent-instances/{hosted_agent_instance_id}", hostedAgentInstances.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-instances/{hosted_agent_instance_id}", hostedAgentInstances.Delete)
+	mux.HandleFunc("GET /api/hosted-agent-instances/{hosted_agent_instance_id}/terminal", agentTerminal.Attach)
+
+	// Hosted agent pools (users have assigned read-only access; admins manage)
+	mux.HandleFunc("GET /api/hosted-agent-pools", hostedAgentPools.List)
+	mux.HandleFunc("POST /api/hosted-agent-pools", hostedAgentPools.Create)
+	mux.HandleFunc("GET /api/hosted-agent-pools/{hosted_agent_pool_id}", hostedAgentPools.Get)
+	mux.HandleFunc("PUT /api/hosted-agent-pools/{hosted_agent_pool_id}", hostedAgentPools.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-pools/{hosted_agent_pool_id}", hostedAgentPools.Delete)
+	mux.HandleFunc("GET /api/hosted-agent-pools/{hosted_agent_pool_id}/utilization", hostedAgentPools.Utilization)
+
+	// Deployment-wide hosted agent pool defaults (admin only)
+	mux.HandleFunc("GET /api/hosted-agent-pool-defaults", hostedAgentPoolDefaults.Get)
+	mux.HandleFunc("POST /api/hosted-agent-pool-defaults", hostedAgentPoolDefaults.Create)
+	mux.HandleFunc("PUT /api/hosted-agent-pool-defaults", hostedAgentPoolDefaults.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-pool-defaults", hostedAgentPoolDefaults.Delete)
+
+	// User-to-pool assignments (users can read their own; admins manage)
+	mux.HandleFunc("GET /api/hosted-agent-pool-assignments", hostedAgentPoolAssignments.List)
+	mux.HandleFunc("POST /api/hosted-agent-pool-assignments", hostedAgentPoolAssignments.Create)
+	mux.HandleFunc("GET /api/hosted-agent-pool-assignments/{hosted_agent_pool_assignment_id}", hostedAgentPoolAssignments.Get)
+	mux.HandleFunc("PUT /api/hosted-agent-pool-assignments/{hosted_agent_pool_assignment_id}", hostedAgentPoolAssignments.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-pool-assignments/{hosted_agent_pool_assignment_id}", hostedAgentPoolAssignments.Delete)
+
+	// Hosted agent access rules (admin only)
+	mux.HandleFunc("GET /api/hosted-agent-access-rules", hostedAgentAccessRules.List)
+	mux.HandleFunc("POST /api/hosted-agent-access-rules", hostedAgentAccessRules.Create)
+	mux.HandleFunc("GET /api/hosted-agent-access-rules/{hosted_agent_access_rule_id}", hostedAgentAccessRules.Get)
+	mux.HandleFunc("PUT /api/hosted-agent-access-rules/{hosted_agent_access_rule_id}", hostedAgentAccessRules.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-access-rules/{hosted_agent_access_rule_id}", hostedAgentAccessRules.Delete)
+
 	// OAuthClients
 	mux.HandleFunc("GET /api/oauth-clients", oauthClients.List)
 	mux.HandleFunc("POST /api/oauth-clients", oauthClients.Create)
@@ -666,6 +744,11 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 
 	// MCP Gateway Endpoints
 	// The first pattern handles the root path, the second handles all sub-paths.
+	// Hosted agent sandboxes are only reachable in-cluster, so this is the one
+	// address a user has for their agent, and the one place access is decided.
+	mux.HandleFunc("/agent-connect/{hosted_agent_instance_id}", agentConnect.Proxy)
+	mux.HandleFunc("/agent-connect/{hosted_agent_instance_id}/{rest...}", agentConnect.Proxy)
+
 	mux.HandleFunc("/mcp-connect/{mcp_id}", mcpGateway.Proxy)
 	mux.HandleFunc("/mcp-connect/{mcp_id}/{rest...}", mcpGateway.Proxy)
 	// This is a special path for internal MCP composite requests.


### PR DESCRIPTION
Endpoints for harnesses, templates, instances, pools, config sources and access
rules, authorized the same way the rest of Obot is: templates and pools are
administrator-owned, an instance belongs to its user, and access rules decide
who may launch what.

Two things are computed on read rather than stored. Availability reports why a
template cannot be launched here -- an unconfigured model provider, an MCP
server that was never installed -- so an administrator sees the whole list
rather than fixing one and being told about the next; it is also enforced when
an instance is created, so the answer cannot be bypassed. The icon shown for an
instance resolves through the template to the harness. Storing either would
mean rewriting every row when a harness changes its icon or a provider is
configured, and leave the stored copy wrong until something did.



---

Part 8 of an 11-PR stack. Base: `feat/hosted-agents-07-controllers`.

## Stack

1. #7459 — Resource model
2. #7460 — Sandbox backend interface
3. #7461 — Kubernetes sandbox backend
4. #7462 — Sandbox reachability (models + MCP)
5. #7463 — Terminal + HTTP publish
6. #7464 — Server wiring + Helm
7. #7465 — Controllers / reconcilers
**→ 8. #7466 — REST API** (this PR)
9. #7467 — Admin UI
10. #7468 — User UI
11. #7469 — Seed default config source

Merge bottom-up; GitHub retargets each child when its parent merges.
