### PR TITLE
feat: add the hosted agents admin UI (9/11)

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -108,6 +108,24 @@ Set name of namespace to use for mcp servers
 {{- end -}}
 
 {{/*
+Whether Obot runs workloads on Kubernetes.
+
+This gates the sandbox namespace, its RBAC and its network policy. Hosted agent
+sandboxes share that namespace with MCP servers and follow the same backend --
+the chart deliberately does not expose a separate agent backend setting, because
+a real deployment always wants the two to match. Overriding one without the
+other is a local development case, handled by setting the server flag directly.
+
+The k8s alias is accepted here because pkg/mcp accepts it: gating on the long
+spelling alone would leave a "k8s" deployment running on a cluster with no
+namespace and no permissions.
+*/}}
+{{- define "obot.mcpOnKubernetes" -}}
+{{- $backend := .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND | default "" | toString | lower -}}
+{{- if or (eq $backend "kubernetes") (eq $backend "k8s") -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Generate comma-separated list of MCP image pull secret names
 */}}
 {{- define "obot.config.mcpImagePullSecrets" -}}

--- a/chart/templates/internal-configmap.yaml
+++ b/chart/templates/internal-configmap.yaml
@@ -16,10 +16,20 @@ data:
   {{ $key }}: {{ toString $value | quote }}
   {{- end }}
   {{- end }}
-  {{- if eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes" }}
+  {{- if include "obot.mcpOnKubernetes" . }}
+  # Hosted agent sandboxes share this namespace, so leaving it unset would send
+  # the agent backend to its own default namespace, which this chart never
+  # creates and grants no permissions on.
   OBOT_SERVER_MCPNAMESPACE: {{ include "obot.config.mcpNamespace" . | quote }}
   OBOT_SERVER_SERVICE_NAME: {{ include "obot.fullname" . | quote }}
   OBOT_SERVER_SERVICE_NAMESPACE: {{ .Release.Namespace | quote }}
+  {{- if not .Values.config.OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL }}
+  # Sandboxes are admitted against the namespace's Pod Security level, so the
+  # backend is told what that level is rather than being configured separately
+  # and left to drift out of agreement with the label above. Setting
+  # config.OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL explicitly overrides this.
+  OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL: {{ if .Values.mcpNamespace.podSecurity.enabled }}{{ .Values.mcpNamespace.podSecurity.enforce | quote }}{{ else }}"privileged"{{ end }}
+  {{- end }}
   {{- end }}
   {{- if .Values.mcpServerDefaults.affinity }}
   OBOT_SERVER_MCPK8S_SETTINGS_AFFINITY: {{ .Values.mcpServerDefaults.affinity | toJson | quote }}

--- a/chart/templates/mcp.yaml
+++ b/chart/templates/mcp.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes" }}
+{{- if include "obot.mcpOnKubernetes" . }}
 {{- include "obot.validatePodSecurityLevels" . -}}
 apiVersion: v1
 kind: Namespace
@@ -54,6 +54,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list", "watch"]
+  # The hosted agent terminal joins a sandbox's console. It attaches to the
+  # container the harness was started with rather than exec'ing a second
+  # process, so this is pods/attach and not pods/exec.
+  - apiGroups: [""]
+    resources: ["pods/attach"]
+    verbs: ["create", "get"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
@@ -63,10 +69,71 @@ rules:
   - apiGroups: ["networking.aviatrix.com"]
     resources: ["firewallpolicies"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # ResourceQuota access for capacity info
+  # ResourceQuota access for capacity info, and for hosted agent pools,
+  # whose pool budgets are ResourceQuotas scoped to a per-pool PriorityClass.
   - apiGroups: [""]
     resources: ["resourcequotas"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  # Hosted agent sandbox volume cleanup runs as a Job.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+
+---
+# PriorityClasses are cluster-scoped, so the per-pool objects backing hosted
+# agent pools cannot live in a namespaced Role. Each one is created with
+# an owner reference to the sandbox namespace, so deleting that namespace
+# collects them.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-obot-agent-clusterrole
+  labels:
+    {{- include "obot.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  # Needed to read the sandbox namespace's UID when building those owner
+  # references, and to create it when hosted agents are the only Kubernetes
+  # feature enabled.
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "get", "list", "watch"]
+  # Only read when Obot's own hostname is a loopback address, which is a
+  # developer running outside the cluster: a sandbox cannot reach 127.0.0.1, so
+  # a node address is substituted. Harmless to omit in production, where the
+  # configured hostname already resolves.
+  - apiGroups: [""]
+    resources: ["nodes"]
     verbs: ["get", "list"]
+  # Live per-sandbox CPU and memory for hosted agent pools.
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # Pool volume usage comes from kubelet's stats summary, reached through the
+  # API server proxy. This grant is broader than it looks -- nodes/proxy can
+  # reach other kubelet endpoints too -- so withhold it if pool disk reporting
+  # is not wanted. The backend degrades to omitting disk rather than failing.
+  - apiGroups: [""]
+    resources: ["nodes/proxy", "nodes/stats"]
+    verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-obot-agent-clusterrolebinding
+  labels:
+    {{- include "obot.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "obot.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-obot-agent-clusterrole
+  apiGroup: rbac.authorization.k8s.io
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes") .Values.mcpNamespace.networkPolicy.enabled }}
+{{- if and (include "obot.mcpOnKubernetes" .) .Values.mcpNamespace.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.serviceAccount.create (eq .Values.config.OBOT_SERVER_MCPRUNTIME_BACKEND "kubernetes") }}
+{{- if or .Values.serviceAccount.create (include "obot.mcpOnKubernetes" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/pkg/agentcatalog/validate.go
+++ b/pkg/agentcatalog/validate.go
@@ -1,0 +1,78 @@
+// Package agentcatalog holds the server-side rules for an agent config source.
+//
+// The manifest validates its own shape, in apiclient/types, where the UI can
+// apply the same rules before submitting. What lives here is the part that
+// depends on how this server is running rather than on the data: a repository
+// on the local filesystem is a reasonable source when a developer is iterating
+// on a catalog, and is not one anywhere else. That is Obot's policy, not a
+// property of the manifest, so a client has no business knowing it.
+package agentcatalog
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+// Validate applies the manifest's own rules, additionally accepting a
+// repository on the local filesystem when allowLocalRepos is set -- which
+// callers must derive from Obot's development mode.
+func Validate(manifest types.AgentCatalogManifest, allowLocalRepos bool) error {
+	if !allowLocalRepos || !isLocalRepo(manifest.RepoURL) {
+		return manifest.Validate()
+	}
+
+	// The shape checks still apply; only the URL rule is relaxed.
+	if strings.TrimSpace(manifest.DisplayName) == "" {
+		return fmt.Errorf("displayName is required")
+	}
+	if err := validateLocalRepoURL(manifest.RepoURL); err != nil {
+		return err
+	}
+	// A local checkout is still cloned by ref, so relaxing where the repository
+	// may live must not relax what may be passed to git alongside it.
+	return types.ValidateGitRef(manifest.Ref)
+}
+
+// isLocalRepo reports whether a value is asking to be read off this machine, so
+// that anything else keeps failing with the ordinary error rather than the
+// local-path one.
+func isLocalRepo(repoURL string) bool {
+	repoURL = strings.TrimSpace(repoURL)
+	if filepath.IsAbs(repoURL) {
+		return true
+	}
+	u, err := url.Parse(repoURL)
+	return err == nil && u.Scheme == "file"
+}
+
+// validateLocalRepoURL accepts an absolute filesystem path or a file:// URL.
+// Relative paths stay invalid: their meaning would depend on the server
+// process's working directory, which is not something a catalog should rest on.
+func validateLocalRepoURL(repoURL string) error {
+	repoURL = strings.TrimSpace(repoURL)
+	if repoURL == "" {
+		return fmt.Errorf("repoURL is required")
+	}
+	if filepath.IsAbs(repoURL) {
+		return nil
+	}
+
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return fmt.Errorf("invalid repoURL: %v", err)
+	}
+	if u.Host != "" && u.Host != "localhost" {
+		return fmt.Errorf("file repoURL host must be empty or localhost")
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("file repoURL must not include user information, a query, or a fragment")
+	}
+	if !filepath.IsAbs(u.Path) {
+		return fmt.Errorf("file repoURL must contain an absolute path")
+	}
+	return nil
+}

--- a/pkg/agentcatalog/validate_test.go
+++ b/pkg/agentcatalog/validate_test.go
@@ -1,0 +1,55 @@
+package agentcatalog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+// Accepting a repository off the local filesystem is a development-mode
+// concession, so the same manifest has to be judged differently depending on
+// how this server is running -- which is the whole reason the rule lives here
+// rather than on the manifest.
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		repoURL     string
+		ref         string
+		development bool
+		wantError   string
+	}{
+		{name: "https production", repoURL: "https://example.com/obot/agents.git"},
+		{name: "https development", repoURL: "https://example.com/obot/agents.git", development: true},
+		{name: "absolute path development", repoURL: "/home/developer/src/obot-agents", development: true},
+		{name: "file URL development", repoURL: "file:///home/developer/src/obot-agents", development: true},
+		{name: "localhost file URL development", repoURL: "file://localhost/home/developer/src/obot-agents", development: true},
+		{name: "absolute path production", repoURL: "/home/developer/src/obot-agents", wantError: "must be an https URL"},
+		{name: "file URL production", repoURL: "file:///home/developer/src/obot-agents", wantError: "must be an https URL"},
+		{name: "relative path development", repoURL: "../obot-agents", development: true, wantError: "must be an https URL"},
+		{name: "remote file host development", repoURL: "file://example.com/repo", development: true, wantError: "host must be empty or localhost"},
+		{name: "file query development", repoURL: "file:///repo?ref=main", development: true, wantError: "must not include"},
+		{name: "displayName still required in development", repoURL: "/home/developer/src/obot-agents", development: true, wantError: "displayName is required"},
+		{name: "ref still validated in development", repoURL: "/home/developer/src/obot-agents", development: true, ref: "--upload-pack=evil", wantError: "must not begin with '-'"},
+		{name: "valid ref in development", repoURL: "/home/developer/src/obot-agents", development: true, ref: "main"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := types.AgentCatalogManifest{DisplayName: "Test agents", RepoURL: tt.repoURL, Ref: tt.ref}
+			if strings.Contains(tt.name, "displayName still required") {
+				manifest.DisplayName = ""
+			}
+			err := Validate(manifest, tt.development)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantError, err)
+			}
+		})
+	}
+}

--- a/pkg/api/handlers/agentcatalogs.go
+++ b/pkg/api/handlers/agentcatalogs.go
@@ -1,0 +1,147 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentcatalog"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AgentCatalogHandler struct {
+	devMode bool
+}
+
+func NewAgentCatalogHandler(devMode bool) *AgentCatalogHandler {
+	return &AgentCatalogHandler{devMode: devMode}
+}
+
+func (*AgentCatalogHandler) List(req api.Context) error {
+	var list v1.AgentCatalogList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list agent catalogs: %w", err)
+	}
+
+	items := make([]types.AgentCatalog, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, convertAgentCatalog(item))
+	}
+
+	return req.Write(types.AgentCatalogList{Items: items})
+}
+
+func (*AgentCatalogHandler) Get(req api.Context) error {
+	var source v1.AgentCatalog
+	if err := req.Get(&source, req.PathValue("agent_catalog_id")); err != nil {
+		return fmt.Errorf("failed to get agent catalog: %w", err)
+	}
+
+	return req.Write(convertAgentCatalog(source))
+}
+
+func (h *AgentCatalogHandler) Create(req api.Context) error {
+	manifest, err := h.readAndValidateAgentCatalogManifest(req)
+	if err != nil {
+		return err
+	}
+
+	source := v1.AgentCatalog{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.AgentCatalogPrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.AgentCatalogSpec{
+			AgentCatalogManifest: *manifest,
+		},
+	}
+
+	if err := req.Create(&source); err != nil {
+		return fmt.Errorf("failed to create agent catalog: %w", err)
+	}
+
+	return req.WriteCreated(convertAgentCatalog(source))
+}
+
+func (h *AgentCatalogHandler) Update(req api.Context) error {
+	manifest, err := h.readAndValidateAgentCatalogManifest(req)
+	if err != nil {
+		return err
+	}
+
+	var source v1.AgentCatalog
+	if err := req.Get(&source, req.PathValue("agent_catalog_id")); err != nil {
+		return fmt.Errorf("failed to get agent catalog: %w", err)
+	}
+
+	source.Spec.AgentCatalogManifest = *manifest
+	if err := req.Update(&source); err != nil {
+		return fmt.Errorf("failed to update agent catalog: %w", err)
+	}
+
+	return req.Write(convertAgentCatalog(source))
+}
+
+func (*AgentCatalogHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.AgentCatalog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.PathValue("agent_catalog_id"),
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+// Refresh asks the controller to sync now by setting the force-sync annotation,
+// rather than doing any work itself.
+func (*AgentCatalogHandler) Refresh(req api.Context) error {
+	var source v1.AgentCatalog
+	if err := req.Get(&source, req.PathValue("agent_catalog_id")); err != nil {
+		return fmt.Errorf("failed to get agent catalog: %w", err)
+	}
+
+	if source.Annotations == nil {
+		source.Annotations = map[string]string{}
+	}
+	source.Annotations[v1.AgentCatalogSyncAnnotation] = "true"
+
+	if err := req.Update(&source); err != nil {
+		return fmt.Errorf("failed to refresh agent catalog: %w", err)
+	}
+
+	req.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
+func (h *AgentCatalogHandler) readAndValidateAgentCatalogManifest(req api.Context) (*types.AgentCatalogManifest, error) {
+	var manifest types.AgentCatalogManifest
+	if err := req.Read(&manifest); err != nil {
+		return nil, types.NewErrBadRequest("failed to read agent catalog manifest: %v", err)
+	}
+
+	manifest.DisplayName = strings.TrimSpace(manifest.DisplayName)
+	manifest.RepoURL = strings.TrimSpace(manifest.RepoURL)
+	manifest.Ref = strings.TrimSpace(manifest.Ref)
+
+	if err := agentcatalog.Validate(manifest, h.devMode); err != nil {
+		return nil, types.NewErrBadRequest("invalid agent catalog manifest: %v", err)
+	}
+
+	return &manifest, nil
+}
+
+func convertAgentCatalog(source v1.AgentCatalog) types.AgentCatalog {
+	return types.AgentCatalog{
+		Metadata:               MetadataFrom(&source),
+		AgentCatalogManifest:   source.Spec.AgentCatalogManifest,
+		LastSyncTime:           *types.NewTime(source.Status.LastSyncTime.Time),
+		IsSyncing:              source.Status.IsSyncing,
+		SyncError:              source.Status.SyncError,
+		ResolvedCommitSHA:      source.Status.ResolvedCommitSHA,
+		DiscoveredAgentCount:   source.Status.DiscoveredAgentCount,
+		DiscoveredHarnessCount: source.Status.DiscoveredHarnessCount,
+	}
+}

--- a/pkg/api/handlers/harnesses.go
+++ b/pkg/api/handlers/harnesses.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type HarnessHandler struct{}
+
+func NewHarnessHandler() *HarnessHandler {
+	return nil
+}
+
+func (*HarnessHandler) List(req api.Context) error {
+	var list v1.HarnessList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list harnesses: %w", err)
+	}
+
+	items := make([]types.Harness, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, convertHarness(item))
+	}
+
+	return req.Write(types.HarnessList{Items: items})
+}
+
+func (*HarnessHandler) Get(req api.Context) error {
+	var harness v1.Harness
+	if err := req.Get(&harness, req.PathValue("harness_id")); err != nil {
+		return fmt.Errorf("failed to get harness: %w", err)
+	}
+
+	return req.Write(convertHarness(harness))
+}
+
+func (*HarnessHandler) Create(req api.Context) error {
+	var manifest types.HarnessManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read harness manifest: %v", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid harness manifest: %v", err)
+	}
+
+	harness := v1.Harness{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.HarnessPrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HarnessSpec{
+			Manifest: manifest,
+		},
+	}
+
+	if err := req.Create(&harness); err != nil {
+		return fmt.Errorf("failed to create harness: %w", err)
+	}
+
+	return req.WriteCreated(convertHarness(harness))
+}
+
+func (*HarnessHandler) Update(req api.Context) error {
+	var manifest types.HarnessManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read harness manifest: %v", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid harness manifest: %v", err)
+	}
+
+	var harness v1.Harness
+	if err := req.Get(&harness, req.PathValue("harness_id")); err != nil {
+		return fmt.Errorf("failed to get harness: %w", err)
+	}
+
+	harness.Spec.Manifest = manifest
+	if err := req.Update(&harness); err != nil {
+		return fmt.Errorf("failed to update harness: %w", err)
+	}
+
+	return req.Write(convertHarness(harness))
+}
+
+// Delete refuses to remove a harness that agents still run on, rather than
+// leaving them pointing at nothing.
+func (*HarnessHandler) Delete(req api.Context) error {
+	id := req.PathValue("harness_id")
+
+	var agents v1.HostedAgentList
+	if err := req.List(&agents, kclient.MatchingFields{"spec.harnessID": id}); err != nil {
+		return fmt.Errorf("failed to list hosted agents for harness %s: %w", id, err)
+	}
+	if count := len(agents.Items); count > 0 {
+		return types.NewErrBadRequest("harness %s is in use by %d agent(s)", id, count)
+	}
+
+	return req.Delete(&v1.Harness{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+func convertHarness(harness v1.Harness) types.Harness {
+	return types.Harness{
+		Metadata:        MetadataFrom(&harness),
+		HarnessManifest: harness.Spec.Manifest,
+	}
+}

--- a/pkg/api/handlers/hostedagentaccessrules.go
+++ b/pkg/api/handlers/hostedagentaccessrules.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type HostedAgentAccessRuleHandler struct{}
+
+func NewHostedAgentAccessRuleHandler() *HostedAgentAccessRuleHandler {
+	return nil
+}
+
+func (*HostedAgentAccessRuleHandler) List(req api.Context) error {
+	var list v1.HostedAgentAccessRuleList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list hosted agent access rules: %w", err)
+	}
+
+	items := make([]types.HostedAgentAccessRule, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, convertHostedAgentAccessRule(item))
+	}
+
+	return req.Write(types.HostedAgentAccessRuleList{Items: items})
+}
+
+func (*HostedAgentAccessRuleHandler) Get(req api.Context) error {
+	var rule v1.HostedAgentAccessRule
+	if err := req.Get(&rule, req.PathValue("hosted_agent_access_rule_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent access rule: %w", err)
+	}
+
+	return req.Write(convertHostedAgentAccessRule(rule))
+}
+
+func (*HostedAgentAccessRuleHandler) Create(req api.Context) error {
+	manifest, err := readAndValidateHostedAgentAccessRuleManifest(req)
+	if err != nil {
+		return err
+	}
+
+	rule := v1.HostedAgentAccessRule{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.HostedAgentAccessRulePrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HostedAgentAccessRuleSpec{
+			Manifest: *manifest,
+		},
+	}
+
+	if err := req.Create(&rule); err != nil {
+		return fmt.Errorf("failed to create hosted agent access rule: %w", err)
+	}
+
+	return req.WriteCreated(convertHostedAgentAccessRule(rule))
+}
+
+func (*HostedAgentAccessRuleHandler) Update(req api.Context) error {
+	manifest, err := readAndValidateHostedAgentAccessRuleManifest(req)
+	if err != nil {
+		return err
+	}
+
+	var rule v1.HostedAgentAccessRule
+	if err := req.Get(&rule, req.PathValue("hosted_agent_access_rule_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent access rule: %w", err)
+	}
+
+	rule.Spec.Manifest = *manifest
+	if err := req.Update(&rule); err != nil {
+		return fmt.Errorf("failed to update hosted agent access rule: %w", err)
+	}
+
+	return req.Write(convertHostedAgentAccessRule(rule))
+}
+
+func (*HostedAgentAccessRuleHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.HostedAgentAccessRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.PathValue("hosted_agent_access_rule_id"),
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+func readAndValidateHostedAgentAccessRuleManifest(req api.Context) (*types.HostedAgentAccessRuleManifest, error) {
+	var manifest types.HostedAgentAccessRuleManifest
+	if err := req.Read(&manifest); err != nil {
+		return nil, types.NewErrBadRequest("failed to read hosted agent access rule manifest: %v", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return nil, types.NewErrBadRequest("invalid hosted agent access rule manifest: %v", err)
+	}
+
+	if err := validateReferencedHostedAgentResources(req, manifest.Resources); err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+func validateReferencedHostedAgentResources(req api.Context, resources []types.HostedAgentResource) error {
+	for _, resource := range resources {
+		switch resource.Type {
+		case types.HostedAgentResourceTypeHostedAgent:
+			if err := req.Get(&v1.HostedAgent{}, resource.ID); apierrors.IsNotFound(err) {
+				return types.NewErrBadRequest("hosted agent %s not found", resource.ID)
+			} else if err != nil {
+				return fmt.Errorf("failed to get hosted agent %s: %w", resource.ID, err)
+			}
+		case types.HostedAgentResourceTypeSelector:
+			// Wildcard selectors are validated by the manifest.
+		default:
+			return types.NewErrBadRequest("unsupported hosted agent resource type: %s", resource.Type)
+		}
+	}
+
+	return nil
+}
+
+func convertHostedAgentAccessRule(rule v1.HostedAgentAccessRule) types.HostedAgentAccessRule {
+	return types.HostedAgentAccessRule{
+		Metadata:                      MetadataFrom(&rule),
+		HostedAgentAccessRuleManifest: rule.Spec.Manifest,
+	}
+}

--- a/pkg/api/handlers/hostedagentavailability.go
+++ b/pkg/api/handlers/hostedagentavailability.go
@@ -1,0 +1,182 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/hostedagentmodels"
+	"github.com/obot-platform/obot/pkg/hostedagentrefs"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// agentAvailability reports why an agent cannot be launched on this
+// installation, empty when it can.
+//
+// A template is written once and used everywhere, so it names things that may
+// not exist here: a harness that speaks a protocol no configured provider
+// serves, or an MCP server that was never installed. Launching it anyway
+// produces a sandbox that fails at its first request, with an error the user
+// cannot act on. Saying so up front turns that into something an administrator
+// can fix.
+type agentAvailability struct {
+	client    kclient.Client
+	namespace string
+	harnesses map[string]types.HarnessManifest
+}
+
+func newAgentAvailability(ctx context.Context, client kclient.Client, namespace string) (*agentAvailability, error) {
+	var harnesses v1.HarnessList
+	if err := client.List(ctx, &harnesses, &kclient.ListOptions{Namespace: namespace}); err != nil {
+		return nil, fmt.Errorf("failed to list harnesses: %w", err)
+	}
+
+	availability := &agentAvailability{
+		client:    client,
+		namespace: namespace,
+		harnesses: make(map[string]types.HarnessManifest, len(harnesses.Items)),
+	}
+	for _, harness := range harnesses.Items {
+		availability.harnesses[harness.Name] = harness.Spec.Manifest
+	}
+	return availability, nil
+}
+
+// reasons returns every reason an agent cannot be launched, so an administrator
+// sees the whole list rather than fixing one and being told about the next.
+func (a *agentAvailability) reasons(ctx context.Context, manifest types.HostedAgentManifest) []string {
+	var reasons []string
+
+	if _, ok := a.harnesses[manifest.HarnessID]; !ok {
+		return []string{"its harness is not registered"}
+	}
+
+	if reason := a.modelReason(ctx, manifest); reason != "" {
+		reasons = append(reasons, reason)
+	}
+	reasons = append(reasons, a.mcpReasons(ctx, manifest)...)
+	reasons = append(reasons, a.skillReasons(ctx, manifest)...)
+	return reasons
+}
+
+func (a *agentAvailability) modelReason(ctx context.Context, manifest types.HostedAgentManifest) string {
+	models, err := hostedagentmodels.Resolve(ctx, a.client, a.namespace, manifest.Models, manifest.ModelProviders)
+	if err != nil {
+		// A failure to read models is not a statement about the agent, and
+		// blocking every agent on a transient error would be worse than
+		// letting one through.
+		return ""
+	}
+	if len(models) > 0 {
+		return ""
+	}
+
+	// Naming the provider is what makes this actionable: an administrator can
+	// go and configure it. "No models available" would not say which.
+	if len(manifest.ModelProviders) == 1 {
+		return fmt.Sprintf("the %s is not configured", manifest.ModelProviders[0])
+	}
+	if len(manifest.ModelProviders) > 1 {
+		return fmt.Sprintf("none of the model providers it needs are configured: %v", manifest.ModelProviders)
+	}
+	if len(manifest.Models) > 0 {
+		return "none of the models it is configured with are available"
+	}
+	return ""
+}
+
+// mcpReasons names the MCP servers the agent refers to that do not exist here.
+//
+// A reference is resolved against its source; a bare ID is looked up directly.
+func (a *agentAvailability) mcpReasons(ctx context.Context, manifest types.HostedAgentManifest) []string {
+	var missing []string
+	for _, id := range manifest.MCPServers {
+		if id == "" || id == "*" {
+			continue
+		}
+		if hostedagentrefs.IsReference(id) {
+			if _, err := hostedagentrefs.ResolveMCP(ctx, a.client, a.namespace, id); err != nil {
+				missing = append(missing, id)
+			}
+			continue
+		}
+		if !a.mcpExists(ctx, id) {
+			missing = append(missing, id)
+		}
+	}
+	return describeMissing("MCP server", missing)
+}
+
+// skillReasons names the skills the agent refers to that do not exist here.
+func (a *agentAvailability) skillReasons(ctx context.Context, manifest types.HostedAgentManifest) []string {
+	var missing []string
+	for _, id := range manifest.Skills {
+		if id == "" {
+			continue
+		}
+		if hostedagentrefs.IsReference(id) {
+			if _, err := hostedagentrefs.ResolveSkill(ctx, a.client, a.namespace, id); err != nil {
+				missing = append(missing, id)
+			}
+			continue
+		}
+		var skill v1.Skill
+		if !a.found(a.client.Get(ctx, kclient.ObjectKey{Namespace: a.namespace, Name: id}, &skill)) {
+			missing = append(missing, id)
+		}
+	}
+	return describeMissing("skill", missing)
+}
+
+// describeMissing phrases the absences so the reason names what to install.
+func describeMissing(kind string, missing []string) []string {
+	switch len(missing) {
+	case 0:
+		return nil
+	case 1:
+		return []string{fmt.Sprintf("the %s %s is not installed", kind, missing[0])}
+	default:
+		return []string{fmt.Sprintf("%d %ss it uses are not installed: %v", len(missing), kind, missing)}
+	}
+}
+
+// mcpExists reports whether an MCP gateway ID names something that is here.
+//
+// The ID is the same handle /mcp-connect accepts, which may be a server, an
+// instance of a multi-user server, or a catalog entry -- so each is tried
+// rather than inferring the kind from the ID's shape.
+func (a *agentAvailability) mcpExists(ctx context.Context, id string) bool {
+	key := kclient.ObjectKey{Namespace: a.namespace, Name: id}
+
+	switch {
+	case system.IsMCPServerInstanceID(id):
+		var instance v1.MCPServerInstance
+		return a.found(a.client.Get(ctx, key, &instance))
+	case system.IsMCPServerID(id):
+		var server v1.MCPServer
+		return a.found(a.client.Get(ctx, key, &server))
+	}
+
+	var entry v1.MCPServerCatalogEntry
+	if a.found(a.client.Get(ctx, key, &entry)) {
+		return true
+	}
+	var server v1.MCPServer
+	return a.found(a.client.Get(ctx, key, &server))
+}
+
+// found treats anything other than a definite absence as present. A read that
+// failed for another reason says nothing about whether the server exists, and
+// reporting it missing would block an agent over a transient error.
+func (a *agentAvailability) found(err error) bool {
+	return !apierrors.IsNotFound(err)
+}
+
+// applyTo annotates an agent with why it cannot be launched here.
+func (a *agentAvailability) applyTo(ctx context.Context, agent types.HostedAgent) types.HostedAgent {
+	agent.UnavailableReasons = a.reasons(ctx, agent.HostedAgentManifest)
+	return agent
+}

--- a/pkg/api/handlers/hostedagentavailability_test.go
+++ b/pkg/api/handlers/hostedagentavailability_test.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func availabilityFor(t *testing.T, objs ...kclient.Object) *agentAvailability {
+	t.Helper()
+	client := fakeclient.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(objs...).Build()
+	availability, err := newAgentAvailability(context.Background(), client, "obot")
+	if err != nil {
+		t.Fatalf("newAgentAvailability: %v", err)
+	}
+	return availability
+}
+
+func harnessObj(name string) *v1.Harness {
+	return &v1.Harness{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec:       v1.HarnessSpec{Manifest: types.HarnessManifest{Name: name, Image: "img"}},
+	}
+}
+
+func modelObj(name, provider string) *v1.Model {
+	return &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+			Name: name, TargetModel: name, ModelProvider: provider,
+			Active: true, Usage: types.ModelUsageLLM,
+		}},
+	}
+}
+
+// The case this exists for: Claude Code is written against Anthropic, so on an
+// installation with only OpenAI providers it can never work. Offering it
+// produces a sandbox that fails at start-up with an error the user cannot act
+// on. The template names the provider, and the reason names it back.
+func TestAgentNeedingAnAbsentProviderIsUnavailable(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1claude"),
+		modelObj("m1gpt", system.OpenAIModelProvider),
+	)
+
+	reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		Name: "Claude Code", HarnessID: "hrn1claude",
+		ModelProviders: []string{system.AnthropicModelProvider}, Models: []string{"*"},
+	})
+	if len(reasons) != 1 || !strings.Contains(reasons[0], system.AnthropicModelProvider) {
+		t.Fatalf("reasons = %v, want one naming the missing provider", reasons)
+	}
+}
+
+// The same agent is fine as soon as the provider exists, without the template
+// changing -- which is why this is computed rather than stored.
+func TestAgentIsAvailableOnceItsProviderExists(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1claude"),
+		modelObj("m1sonnet", system.AnthropicModelProvider),
+	)
+
+	if reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		HarnessID:      "hrn1claude",
+		ModelProviders: []string{system.AnthropicModelProvider}, Models: []string{"*"},
+	}); len(reasons) != 0 {
+		t.Fatalf("reasons = %v, want none", reasons)
+	}
+}
+
+// An agent naming no provider takes whatever is configured, and is restricted
+// by nothing.
+func TestAgentWithoutDeclaredProvidersAcceptsAnyModel(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1any"),
+		modelObj("m1gpt", system.OpenAIModelProvider),
+	)
+
+	if reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		HarnessID: "hrn1any", Models: []string{"*"},
+	}); len(reasons) != 0 {
+		t.Fatalf("reasons = %v, want none", reasons)
+	}
+}
+
+// An agent naming an MCP server that was never installed cannot work either.
+func TestMissingMCPServerMakesAnAgentUnavailable(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1any"),
+		modelObj("m1gpt", system.OpenAIModelProvider),
+		&v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "ms1here", Namespace: "obot"}},
+	)
+
+	reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		HarnessID: "hrn1any", Models: []string{"*"}, MCPServers: []string{"ms1here", "ms1gone"},
+	})
+	if len(reasons) != 1 || !strings.Contains(reasons[0], "ms1gone") {
+		t.Fatalf("reasons = %v, want one naming the missing server", reasons)
+	}
+	if strings.Contains(reasons[0], "ms1here") {
+		t.Errorf("a server that is installed should not be reported missing: %v", reasons)
+	}
+}
+
+// Every reason at once, so an administrator fixes the set rather than
+// discovering the next one after each fix.
+func TestAllReasonsAreReportedTogether(t *testing.T) {
+	availability := availabilityFor(t,
+		harnessObj("hrn1claude"),
+		modelObj("m1gpt", system.OpenAIModelProvider),
+	)
+
+	reasons := availability.reasons(context.Background(), types.HostedAgentManifest{
+		HarnessID: "hrn1claude", Models: []string{"*"},
+		ModelProviders: []string{system.AnthropicModelProvider}, MCPServers: []string{"ms1gone"},
+	})
+	if len(reasons) != 2 {
+		t.Fatalf("reasons = %v, want both the model and the MCP server", reasons)
+	}
+}
+
+// An agent whose harness was removed cannot run, and saying so is more useful
+// than reporting a missing model on a harness that is not there.
+func TestUnregisteredHarnessIsItsOwnReason(t *testing.T) {
+	availability := availabilityFor(t, modelObj("m1gpt", system.OpenAIModelProvider))
+
+	reasons := availability.reasons(context.Background(), types.HostedAgentManifest{HarnessID: "hrn1gone"})
+	if len(reasons) != 1 || !strings.Contains(reasons[0], "harness") {
+		t.Fatalf("reasons = %v", reasons)
+	}
+}

--- a/pkg/api/handlers/hostedagentinstances.go
+++ b/pkg/api/handlers/hostedagentinstances.go
@@ -1,0 +1,455 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/adhocore/gronx"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/accesscontrolrule"
+	"github.com/obot-platform/obot/pkg/alias"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/obot-platform/obot/pkg/hostedagentaccessrule"
+	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
+	"github.com/obot-platform/obot/pkg/skillaccessrule"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type HostedAgentInstanceHandler struct {
+	accessRuleHelper *hostedagentaccessrule.Helper
+	// The three helpers below check the resources a user attaches to their own
+	// instance, one per kind. Each kind has its own access model, so there is no
+	// single helper to ask.
+	acrHelper   *accesscontrolrule.Helper
+	skillHelper *skillaccessrule.Helper
+	mapHelper   *modelaccesspolicy.Helper
+}
+
+func NewHostedAgentInstanceHandler(
+	accessRuleHelper *hostedagentaccessrule.Helper,
+	acrHelper *accesscontrolrule.Helper,
+	skillHelper *skillaccessrule.Helper,
+	mapHelper *modelaccesspolicy.Helper,
+) *HostedAgentInstanceHandler {
+	return &HostedAgentInstanceHandler{
+		accessRuleHelper: accessRuleHelper,
+		acrHelper:        acrHelper,
+		skillHelper:      skillHelper,
+		mapHelper:        mapHelper,
+	}
+}
+
+type hostedAgentInstanceRequest struct {
+	types.HostedAgentInstanceManifest `json:",inline"`
+	HostedAgentID                     string `json:"hostedAgentID,omitempty"`
+	PoolID                            string `json:"poolID,omitempty"`
+}
+
+// Validate checks the request as a whole, so a caller gets one answer about
+// whether what it sent is usable rather than two checks in sequence.
+//
+// hostedAgentID belongs to the request rather than to the manifest: an instance
+// names the agent it is created from once, at creation, and never carries it
+// afterwards. So it is checked here instead of in the manifest's own rules,
+// which apply equally to an update where it is absent by design.
+func (r hostedAgentInstanceRequest) Validate() error {
+	if r.HostedAgentID == "" {
+		return fmt.Errorf("hostedAgentID is required")
+	}
+	return r.HostedAgentInstanceManifest.Validate()
+}
+
+func (h *HostedAgentInstanceHandler) List(req api.Context) error {
+	selector := kclient.MatchingFields{"spec.userID": req.User.GetUID()}
+	if hostedAgentID := req.URL.Query().Get("hosted_agent_id"); hostedAgentID != "" {
+		selector["spec.hostedAgentName"] = hostedAgentID
+	}
+
+	var list v1.HostedAgentInstanceList
+	if err := req.List(&list, selector); err != nil {
+		return fmt.Errorf("failed to list hosted agent instances: %w", err)
+	}
+
+	icons, err := newIconResolver(req)
+	if err != nil {
+		return err
+	}
+
+	items := make([]types.HostedAgentInstance, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, icons.apply(convertHostedAgentInstance(item), item.Spec.HostedAgentName))
+	}
+
+	return req.Write(types.HostedAgentInstanceList{Items: items})
+}
+
+func (h *HostedAgentInstanceHandler) Get(req api.Context) error {
+	var instance v1.HostedAgentInstance
+	if err := req.Get(&instance, req.PathValue("hosted_agent_instance_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent instance: %w", err)
+	}
+
+	icons, err := newIconResolver(req)
+	if err != nil {
+		return err
+	}
+
+	return req.Write(icons.apply(convertHostedAgentInstance(instance), instance.Spec.HostedAgentName))
+}
+
+func (h *HostedAgentInstanceHandler) Create(req api.Context) error {
+	var body hostedAgentInstanceRequest
+	if err := req.Read(&body); err != nil {
+		return types.NewErrBadRequest("failed to read hosted agent instance manifest: %v", err)
+	}
+
+	if err := body.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid hosted agent instance request: %v", err)
+	}
+
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, body.HostedAgentID); apierrors.IsNotFound(err) {
+		return types.NewErrBadRequest("hosted agent %s not found", body.HostedAgentID)
+	} else if err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	// This route carries no hosted agent ID in its path, so the authorizer cannot
+	// gate it. Check access here instead.
+	hasAccess, err := h.accessRuleHelper.UserHasAccessToHostedAgent(req.User, &agent)
+	if err != nil {
+		return fmt.Errorf("failed to check access to hosted agent %s: %w", agent.Name, err)
+	}
+	if !hasAccess {
+		return types.NewErrNotFound("hosted agent %s not found", body.HostedAgentID)
+	}
+
+	// Checked here as well as reported on the agent, because the UI's decision
+	// not to offer a launch button is a courtesy and not a control: a direct
+	// request would otherwise produce a sandbox that cannot serve its first
+	// request, and an error the user has no way to act on.
+	availability, err := newAgentAvailability(req.Context(), req.Storage, req.Namespace())
+	if err != nil {
+		return err
+	}
+	if reasons := availability.reasons(req.Context(), agent.Spec.Manifest); len(reasons) > 0 {
+		return types.NewErrBadRequest("%s cannot be launched here: %s",
+			agent.Spec.Manifest.Name, strings.Join(reasons, "; "))
+	}
+
+	if body.PoolID != "" {
+		if err := requirePoolAccess(req, body.PoolID); err != nil {
+			return err
+		}
+	}
+
+	var existing v1.HostedAgentInstanceList
+	if err := req.List(&existing, kclient.MatchingFields{
+		"spec.userID":          req.User.GetUID(),
+		"spec.hostedAgentName": agent.Name,
+	}); err != nil {
+		return fmt.Errorf("failed to list hosted agent instances: %w", err)
+	}
+
+	if maxInstances := agent.Spec.Manifest.MaxInstancesPerUser; maxInstances > 0 && len(existing.Items) >= maxInstances {
+		return types.NewErrBadRequest("hosted agent %s allows at most %d instances per user", agent.Name, maxInstances)
+	}
+
+	manifest := body.HostedAgentInstanceManifest
+	manifest.Answers = agent.Spec.Manifest.ApplyAnswerDefaults(manifest.Answers)
+	if err := h.validateInstanceAgainstAgent(req, manifest, agent.Spec.Manifest); err != nil {
+		return err
+	}
+
+	instance := v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.HostedAgentInstancePrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HostedAgentInstanceSpec{
+			UserID:          req.User.GetUID(),
+			HostedAgentName: agent.Name,
+			PoolID:          body.PoolID,
+			Manifest:        manifest,
+		},
+	}
+
+	if err := req.Create(&instance); err != nil {
+		return fmt.Errorf("failed to create hosted agent instance: %w", err)
+	}
+
+	return req.WriteCreated(convertHostedAgentInstance(instance))
+}
+
+func (h *HostedAgentInstanceHandler) Update(req api.Context) error {
+	var manifest types.HostedAgentInstanceManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read hosted agent instance manifest: %v", err)
+	}
+
+	if err := manifest.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid hosted agent instance manifest: %v", err)
+	}
+
+	var instance v1.HostedAgentInstance
+	if err := req.Get(&instance, req.PathValue("hosted_agent_instance_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent instance: %w", err)
+	}
+
+	// Re-check against the agent, otherwise an update could smuggle in answers or
+	// resources that create would have rejected.
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, instance.Spec.HostedAgentName); apierrors.IsNotFound(err) {
+		return types.NewErrBadRequest("hosted agent %s not found", instance.Spec.HostedAgentName)
+	} else if err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	manifest.Answers = agent.Spec.Manifest.ApplyAnswerDefaults(manifest.Answers)
+	if err := h.validateInstanceAgainstAgent(req, manifest, agent.Spec.Manifest); err != nil {
+		return err
+	}
+
+	instance.Spec.Manifest = manifest
+	if err := req.Update(&instance); err != nil {
+		return fmt.Errorf("failed to update hosted agent instance: %w", err)
+	}
+
+	return req.Write(convertHostedAgentInstance(instance))
+}
+
+// validateInstanceAgainstAgent enforces the agent's question schema, its
+// user-defined resource toggles, and the user's access to every resource they
+// attached. Cron parsing happens here rather than in apiclient/types so that
+// module stays dependency free.
+//
+// Resources are checked rather than trusted: the UI only ever offers resources
+// the user can reach, but the API is reachable directly, so a request can name
+// any ID.
+//
+// Errors follow the two conventions already in the codebase: a missing resource
+// is a bad request naming the ID (as in accesscontrolrules.go), and a resource
+// the user cannot use is forbidden (as in llmproxy.go and mcp.go). Existence is
+// not hidden, matching how those same paths already behave.
+func (h *HostedAgentInstanceHandler) validateInstanceAgainstAgent(req api.Context, manifest types.HostedAgentInstanceManifest, agent types.HostedAgentManifest) error {
+	if err := manifest.ValidateAgainstAgent(agent); err != nil {
+		return types.NewErrBadRequest("%v", err)
+	}
+
+	for key, answer := range agent.ScheduleAnswers(manifest.Answers) {
+		if !gronx.IsValid(answer) {
+			return types.NewErrBadRequest("answer for %s: must be a valid cron expression", key)
+		}
+	}
+
+	// Only reached when the agent allows the kind, which ValidateAgainstAgent
+	// has already established.
+	if err := h.checkUserMCPServerAccess(req, manifest.MCPServers); err != nil {
+		return err
+	}
+	if err := h.checkUserSkillAccess(req, manifest.Skills); err != nil {
+		return err
+	}
+	return h.checkUserModelAccess(req, manifest.Models)
+}
+
+// checkUserMCPServerAccess validates MCP gateway IDs, which are polymorphic: an
+// ID may name a catalog entry, a server, a server instance, or a system server.
+// CheckMCPIDAccess is the same resolution the gateway itself applies at connect
+// time, so this cannot drift from it.
+func (h *HostedAgentInstanceHandler) checkUserMCPServerAccess(req api.Context, ids []string) error {
+	for _, id := range ids {
+		// CheckMCPIDAccess surfaces a missing object as a NotFound error rather
+		// than a false, so an unknown ID has to be mapped here or it would become
+		// a 500.
+		hasAccess, err := authz.CheckMCPIDAccess(req.Context(), req.Storage, h.acrHelper, req.User, id)
+		if apierrors.IsNotFound(err) {
+			return types.NewErrBadRequest("MCP server %s not found", id)
+		} else if err != nil {
+			return fmt.Errorf("failed to check access to MCP server %s: %w", id, err)
+		}
+		if !hasAccess {
+			return types.NewErrForbidden("you do not have access to MCP server %s", id)
+		}
+	}
+
+	return nil
+}
+
+// checkUserSkillAccess loads each skill so its repo ID is known. Passing an
+// empty repo ID to the helper would skip repository-granted access and wrongly
+// deny a user who was granted a whole repository.
+func (h *HostedAgentInstanceHandler) checkUserSkillAccess(req api.Context, ids []string) error {
+	for _, id := range ids {
+		var skill v1.Skill
+		if err := req.Get(&skill, id); apierrors.IsNotFound(err) {
+			return types.NewErrBadRequest("skill %s not found", id)
+		} else if err != nil {
+			return fmt.Errorf("failed to get skill %s: %w", id, err)
+		}
+
+		hasAccess, err := h.skillHelper.UserHasAccessToSkill(req.User, &skill)
+		if err != nil {
+			return fmt.Errorf("failed to check access to skill %s: %w", id, err)
+		}
+		if !hasAccess {
+			return types.NewErrForbidden("you do not have access to skill %s", id)
+		}
+	}
+
+	return nil
+}
+
+// checkUserModelAccess resolves each reference to a concrete model before
+// checking it. Model access policies are keyed by real model IDs, so an
+// obot://<alias> reference would never match and would always be denied.
+func (h *HostedAgentInstanceHandler) checkUserModelAccess(req api.Context, ids []string) error {
+	for _, id := range ids {
+		modelID, err := resolveModelReference(req, id)
+		if err != nil {
+			return err
+		}
+
+		hasAccess, err := h.mapHelper.UserHasAccessToModel(req.User, modelID)
+		if err != nil {
+			return fmt.Errorf("failed to check access to model %s: %w", id, err)
+		}
+		if !hasAccess {
+			return types.NewErrForbidden("you do not have access to model %s", id)
+		}
+	}
+
+	return nil
+}
+
+// resolveModelReference turns a model reference into a concrete model ID. It
+// accepts a model ID, an alias name, or an obot://<alias> reference, mirroring
+// what the LLM proxy accepts. Wildcards are rejected: they are a way to write a
+// policy, not a model an agent can be pointed at.
+func resolveModelReference(req api.Context, ref string) (string, error) {
+	if ref == "" {
+		return "", types.NewErrBadRequest("model reference cannot be empty")
+	}
+	if strings.Contains(ref, "*") {
+		return "", types.NewErrBadRequest("model %s is a pattern; name a specific model", ref)
+	}
+
+	name := strings.TrimPrefix(ref, types.DefaultModelAliasRefPrefix)
+
+	obj, err := alias.GetFromScope(req.Context(), req.Storage, "Model", req.Namespace(), name)
+	if apierrors.IsNotFound(err) {
+		return "", types.NewErrBadRequest("model %s not found", ref)
+	} else if err != nil {
+		return "", fmt.Errorf("failed to resolve model %s: %w", ref, err)
+	}
+
+	switch m := obj.(type) {
+	case *v1.DefaultModelAlias:
+		if m.Spec.Manifest.Model == "" {
+			return "", types.NewErrBadRequest("model alias %s is not configured", ref)
+		}
+		var model v1.Model
+		if err := alias.Get(req.Context(), req.Storage, &model, req.Namespace(), m.Spec.Manifest.Model); apierrors.IsNotFound(err) {
+			return "", types.NewErrBadRequest("model alias %s points at a missing model", ref)
+		} else if err != nil {
+			return "", fmt.Errorf("failed to resolve model alias %s: %w", ref, err)
+		}
+		return model.Name, nil
+	case *v1.Model:
+		return m.Name, nil
+	}
+
+	return "", types.NewErrBadRequest("model %s not found", ref)
+}
+
+func (h *HostedAgentInstanceHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.PathValue("hosted_agent_instance_id"),
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+func convertHostedAgentInstance(instance v1.HostedAgentInstance) types.HostedAgentInstance {
+	return types.HostedAgentInstance{
+		Metadata:                    MetadataFrom(&instance),
+		HostedAgentInstanceManifest: instance.Spec.Manifest,
+		HostedAgentID:               instance.Spec.HostedAgentName,
+		UserID:                      instance.Spec.UserID,
+		PoolID:                      instance.Spec.PoolID,
+		Status: types.HostedAgentInstanceStatus{
+			State:             instance.Status.State,
+			URL:               instance.Status.URL,
+			Error:             instance.Status.Error,
+			Reason:            instance.Status.Reason,
+			Message:           instance.Status.Message,
+			ObservedRevision:  instance.Status.ObservedRevision,
+			LastObservedTime:  v1.NewTime(instance.Status.LastObservedTime),
+			BackendID:         instance.Status.BackendID,
+			BackendGeneration: instance.Status.BackendGeneration,
+		},
+	}
+}
+
+// iconResolver resolves an instance's icon through the chain a client would
+// otherwise have to walk itself: the instance, then its agent, then the
+// harness the agent runs on.
+//
+// Agents and harnesses are listed once rather than fetched per instance, so
+// rendering a page of instances costs two reads instead of two per row.
+type iconResolver struct {
+	agents    map[string]types.HostedAgentManifest
+	harnesses map[string]types.HarnessManifest
+}
+
+func newIconResolver(req api.Context) (*iconResolver, error) {
+	var agents v1.HostedAgentList
+	if err := req.List(&agents); err != nil {
+		return nil, fmt.Errorf("failed to list hosted agents: %w", err)
+	}
+	var harnesses v1.HarnessList
+	if err := req.List(&harnesses); err != nil {
+		return nil, fmt.Errorf("failed to list harnesses: %w", err)
+	}
+
+	resolver := &iconResolver{
+		agents:    make(map[string]types.HostedAgentManifest, len(agents.Items)),
+		harnesses: make(map[string]types.HarnessManifest, len(harnesses.Items)),
+	}
+	for _, agent := range agents.Items {
+		resolver.agents[agent.Name] = agent.Spec.Manifest
+	}
+	for _, harness := range harnesses.Items {
+		resolver.harnesses[harness.Name] = harness.Spec.Manifest
+	}
+	return resolver, nil
+}
+
+func (r *iconResolver) apply(instance types.HostedAgentInstance, agentID string) types.HostedAgentInstance {
+	// The instance's own icon wins: a user who chose one meant it.
+	instance.ResolvedIcon, instance.ResolvedIconDark = instance.Icon, instance.Icon
+
+	agent, ok := r.agents[agentID]
+	if !ok {
+		return instance
+	}
+	if instance.ResolvedIcon == "" {
+		instance.ResolvedIcon, instance.ResolvedIconDark = agent.Icon, agent.IconDark
+	}
+	if instance.ResolvedIcon == "" {
+		harness := r.harnesses[agent.HarnessID]
+		instance.ResolvedIcon, instance.ResolvedIconDark = harness.Icon, harness.IconDark
+	}
+	// A dark variant is optional everywhere; falling back keeps a client from
+	// having to repeat this rule.
+	if instance.ResolvedIconDark == "" {
+		instance.ResolvedIconDark = instance.ResolvedIcon
+	}
+	return instance
+}

--- a/pkg/api/handlers/hostedagentpools.go
+++ b/pkg/api/handlers/hostedagentpools.go
@@ -1,0 +1,475 @@
+package handlers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const hostedAgentPoolDefaultsName = "default"
+
+type HostedAgentPoolHandler struct {
+	utilization agentbackend.UtilizationReader
+}
+
+func NewHostedAgentPoolHandler(utilization agentbackend.UtilizationReader) *HostedAgentPoolHandler {
+	return &HostedAgentPoolHandler{utilization: utilization}
+}
+
+func (*HostedAgentPoolHandler) List(req api.Context) error {
+	var list v1.HostedAgentPoolList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list hosted agent pools: %w", err)
+	}
+
+	allowed := map[string]bool(nil)
+	if !req.UserIsAdmin() {
+		var err error
+		allowed, err = userPoolIDs(req)
+		if err != nil {
+			return err
+		}
+	}
+
+	items := make([]types.HostedAgentPool, 0, len(list.Items))
+	for _, item := range list.Items {
+		if !req.UserIsAdmin() && !allowed[item.Name] {
+			continue
+		}
+		items = append(items, convertHostedAgentPool(item))
+	}
+	return req.Write(types.HostedAgentPoolList{Items: items})
+}
+
+func (*HostedAgentPoolHandler) Get(req api.Context) error {
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, req.PathValue("hosted_agent_pool_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool: %w", err)
+	}
+	if err := requirePoolAccess(req, pool.Name); err != nil {
+		return err
+	}
+	return req.Write(convertHostedAgentPool(pool))
+}
+
+func (*HostedAgentPoolHandler) Create(req api.Context) error {
+	manifest, err := readHostedAgentPoolManifest(req)
+	if err != nil {
+		return err
+	}
+	pool := v1.HostedAgentPool{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "hp1",
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HostedAgentPoolSpec{Manifest: manifest},
+	}
+	if err := req.Create(&pool); err != nil {
+		return fmt.Errorf("failed to create hosted agent pool: %w", err)
+	}
+	return req.WriteCreated(convertHostedAgentPool(pool))
+}
+
+func (*HostedAgentPoolHandler) Update(req api.Context) error {
+	manifest, err := readHostedAgentPoolManifest(req)
+	if err != nil {
+		return err
+	}
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, req.PathValue("hosted_agent_pool_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool: %w", err)
+	}
+	pool.Spec.Manifest = manifest
+	if err := req.Update(&pool); err != nil {
+		return fmt.Errorf("failed to update hosted agent pool: %w", err)
+	}
+	return req.Write(convertHostedAgentPool(pool))
+}
+
+func (*HostedAgentPoolHandler) Delete(req api.Context) error {
+	poolID := req.PathValue("hosted_agent_pool_id")
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, kclient.MatchingFields{
+		"spec.poolID": poolID,
+	}); err != nil {
+		return fmt.Errorf("failed to find hosted agent pool assignments: %w", err)
+	}
+	if len(assignments.Items) > 0 {
+		return types.NewErrBadRequest("hosted agent pool %s is still assigned", poolID)
+	}
+	return req.Delete(&v1.HostedAgentPool{ObjectMeta: metav1.ObjectMeta{
+		Name:      poolID,
+		Namespace: req.Namespace(),
+	}})
+}
+
+func (h *HostedAgentPoolHandler) Utilization(req api.Context) error {
+	poolID := req.PathValue("hosted_agent_pool_id")
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, poolID); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool: %w", err)
+	}
+	if err := requirePoolAccess(req, pool.Name); err != nil {
+		return err
+	}
+	if h.utilization == nil {
+		return types.NewErrNotFound("hosted agent utilization is unavailable")
+	}
+
+	snapshot, err := h.utilization.GetPoolUtilization(req.Context(), agentbackend.PoolRef{
+		ID:        pool.Name,
+		BackendID: pool.Status.BackendPoolID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get hosted agent pool utilization: %w", err)
+	}
+
+	// A pool is shared by everyone assigned to it, so the totals
+	// describe other people's sandboxes as well as the caller's. The totals are
+	// what a user needs in order to understand why their pool is full, so they
+	// stay whole; the per-instance breakdown is narrowed to the caller, who has
+	// no business seeing a co-tenant's instance IDs or consumption.
+	selector := kclient.MatchingFields{"spec.poolID": poolID}
+	if !req.UserIsAdmin() {
+		selector["spec.userID"] = req.User.GetUID()
+	}
+	var instances v1.HostedAgentInstanceList
+	if err := req.List(&instances, selector); err != nil {
+		return fmt.Errorf("failed to map hosted agent instance utilization: %w", err)
+	}
+
+	snapshot.Instances = narrowInstanceUtilization(snapshot.Instances, instances.Items)
+
+	return req.Write(convertPoolUtilization(snapshot))
+}
+
+// narrowInstanceUtilization keeps only the usage entries belonging to instances
+// the caller may see, and rewrites their identity from the backend's stable UID
+// to the API resource ID so clients can join usage against instances they
+// already hold without learning backend identifiers.
+//
+// Anything the caller cannot see is dropped rather than anonymised: on a shared
+// pool the count and sizes of a co-tenant's sandboxes are themselves
+// worth withholding. The pool totals are reported separately and stay whole.
+func narrowInstanceUtilization(usages []agentbackend.InstanceUtilization, visible []v1.HostedAgentInstance) []agentbackend.InstanceUtilization {
+	ids := make(map[string]string, len(visible))
+	for _, instance := range visible {
+		ids[string(instance.UID)] = instance.Name
+	}
+
+	result := make([]agentbackend.InstanceUtilization, 0, len(usages))
+	for _, usage := range usages {
+		id, ok := ids[usage.Ref.ID]
+		if !ok {
+			continue
+		}
+		usage.Ref.ID = id
+		result = append(result, usage)
+	}
+	return result
+}
+
+func readHostedAgentPoolManifest(req api.Context) (types.HostedAgentPoolManifest, error) {
+	var manifest types.HostedAgentPoolManifest
+	if err := req.Read(&manifest); err != nil {
+		return manifest, types.NewErrBadRequest("failed to read hosted agent pool: %v", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return manifest, types.NewErrBadRequest("invalid hosted agent pool: %v", err)
+	}
+	return manifest, nil
+}
+
+func convertHostedAgentPool(pool v1.HostedAgentPool) types.HostedAgentPool {
+	return types.HostedAgentPool{
+		Metadata:                MetadataFrom(&pool),
+		HostedAgentPoolManifest: pool.Spec.Manifest,
+		Status:                  pool.Status.HostedAgentPoolStatus,
+	}
+}
+
+type HostedAgentPoolDefaultsHandler struct{}
+
+func NewHostedAgentPoolDefaultsHandler() *HostedAgentPoolDefaultsHandler {
+	return &HostedAgentPoolDefaultsHandler{}
+}
+
+func (*HostedAgentPoolDefaultsHandler) Get(req api.Context) error {
+	var defaults v1.HostedAgentPoolDefaults
+	if err := req.Get(&defaults, hostedAgentPoolDefaultsName); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool defaults: %w", err)
+	}
+	return req.Write(convertHostedAgentPoolDefaults(defaults))
+}
+
+func (*HostedAgentPoolDefaultsHandler) Create(req api.Context) error {
+	manifest, err := readHostedAgentPoolDefaultsManifest(req)
+	if err != nil {
+		return err
+	}
+	defaults := v1.HostedAgentPoolDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: hostedAgentPoolDefaultsName, Namespace: req.Namespace()},
+		Spec:       v1.HostedAgentPoolDefaultsSpec{Manifest: manifest},
+	}
+	if err := req.Create(&defaults); err != nil {
+		return fmt.Errorf("failed to create hosted agent pool defaults: %w", err)
+	}
+	return req.WriteCreated(convertHostedAgentPoolDefaults(defaults))
+}
+
+func (*HostedAgentPoolDefaultsHandler) Update(req api.Context) error {
+	manifest, err := readHostedAgentPoolDefaultsManifest(req)
+	if err != nil {
+		return err
+	}
+	var defaults v1.HostedAgentPoolDefaults
+	if err := req.Get(&defaults, hostedAgentPoolDefaultsName); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool defaults: %w", err)
+	}
+	defaults.Spec.Manifest = manifest
+	if err := req.Update(&defaults); err != nil {
+		return fmt.Errorf("failed to update hosted agent pool defaults: %w", err)
+	}
+	return req.Write(convertHostedAgentPoolDefaults(defaults))
+}
+
+func (*HostedAgentPoolDefaultsHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.HostedAgentPoolDefaults{ObjectMeta: metav1.ObjectMeta{
+		Name: hostedAgentPoolDefaultsName, Namespace: req.Namespace(),
+	}})
+}
+
+func readHostedAgentPoolDefaultsManifest(req api.Context) (types.HostedAgentPoolDefaultsManifest, error) {
+	var manifest types.HostedAgentPoolDefaultsManifest
+	if err := req.Read(&manifest); err != nil {
+		return manifest, types.NewErrBadRequest("failed to read hosted agent pool defaults: %v", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return manifest, types.NewErrBadRequest("invalid hosted agent pool defaults: %v", err)
+	}
+	return manifest, nil
+}
+
+func convertHostedAgentPoolDefaults(defaults v1.HostedAgentPoolDefaults) types.HostedAgentPoolDefaults {
+	return types.HostedAgentPoolDefaults{
+		Metadata:                        MetadataFrom(&defaults),
+		HostedAgentPoolDefaultsManifest: defaults.Spec.Manifest,
+	}
+}
+
+type HostedAgentPoolAssignmentHandler struct{}
+
+func NewHostedAgentPoolAssignmentHandler() *HostedAgentPoolAssignmentHandler {
+	return &HostedAgentPoolAssignmentHandler{}
+}
+
+func (*HostedAgentPoolAssignmentHandler) List(req api.Context) error {
+	options := []kclient.ListOption{}
+	if !req.UserIsAdmin() {
+		options = append(options, kclient.MatchingFields{"spec.userID": req.User.GetUID()})
+	}
+	var list v1.HostedAgentPoolAssignmentList
+	if err := req.List(&list, options...); err != nil {
+		return fmt.Errorf("failed to list hosted agent pool assignments: %w", err)
+	}
+	items := make([]types.HostedAgentPoolAssignment, 0, len(list.Items))
+	for _, item := range list.Items {
+		items = append(items, convertHostedAgentPoolAssignment(item))
+	}
+	return req.Write(types.HostedAgentPoolAssignmentList{Items: items})
+}
+
+func (*HostedAgentPoolAssignmentHandler) Get(req api.Context) error {
+	var assignment v1.HostedAgentPoolAssignment
+	if err := req.Get(&assignment, req.PathValue("hosted_agent_pool_assignment_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool assignment: %w", err)
+	}
+	if !req.UserIsAdmin() && assignment.Spec.Manifest.UserID != req.User.GetUID() {
+		return types.NewErrNotFound("hosted agent pool assignment not found")
+	}
+	return req.Write(convertHostedAgentPoolAssignment(assignment))
+}
+
+func (*HostedAgentPoolAssignmentHandler) Create(req api.Context) error {
+	manifest, err := readHostedAgentPoolAssignmentManifest(req)
+	if err != nil {
+		return err
+	}
+	if err := validatePoolAssignment(req, manifest, ""); err != nil {
+		return err
+	}
+	assignment := v1.HostedAgentPoolAssignment{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "hpa1", Namespace: req.Namespace()},
+		Spec:       v1.HostedAgentPoolAssignmentSpec{Manifest: manifest},
+	}
+	if err := req.Create(&assignment); err != nil {
+		return fmt.Errorf("failed to create hosted agent pool assignment: %w", err)
+	}
+	return req.WriteCreated(convertHostedAgentPoolAssignment(assignment))
+}
+
+func (*HostedAgentPoolAssignmentHandler) Update(req api.Context) error {
+	manifest, err := readHostedAgentPoolAssignmentManifest(req)
+	if err != nil {
+		return err
+	}
+	var assignment v1.HostedAgentPoolAssignment
+	if err := req.Get(&assignment, req.PathValue("hosted_agent_pool_assignment_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent pool assignment: %w", err)
+	}
+	if err := validatePoolAssignment(req, manifest, assignment.Name); err != nil {
+		return err
+	}
+	assignment.Spec.Manifest = manifest
+	if err := req.Update(&assignment); err != nil {
+		return fmt.Errorf("failed to update hosted agent pool assignment: %w", err)
+	}
+	return req.Write(convertHostedAgentPoolAssignment(assignment))
+}
+
+func (*HostedAgentPoolAssignmentHandler) Delete(req api.Context) error {
+	return req.Delete(&v1.HostedAgentPoolAssignment{ObjectMeta: metav1.ObjectMeta{
+		Name:      req.PathValue("hosted_agent_pool_assignment_id"),
+		Namespace: req.Namespace(),
+	}})
+}
+
+func readHostedAgentPoolAssignmentManifest(req api.Context) (types.HostedAgentPoolAssignmentManifest, error) {
+	var manifest types.HostedAgentPoolAssignmentManifest
+	if err := req.Read(&manifest); err != nil {
+		return manifest, types.NewErrBadRequest("failed to read hosted agent pool assignment: %v", err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return manifest, types.NewErrBadRequest("invalid hosted agent pool assignment: %v", err)
+	}
+	return manifest, nil
+}
+
+func validatePoolAssignment(req api.Context, manifest types.HostedAgentPoolAssignmentManifest, currentID string) error {
+	if err := req.Get(&v1.HostedAgentPool{}, manifest.PoolID); apierrors.IsNotFound(err) {
+		return types.NewErrBadRequest("hosted agent pool %s not found", manifest.PoolID)
+	} else if err != nil {
+		return fmt.Errorf("failed to get hosted agent pool %s: %w", manifest.PoolID, err)
+	}
+	if !manifest.Default {
+		return nil
+	}
+
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, kclient.MatchingFields{
+		"spec.userID":  manifest.UserID,
+		"spec.default": "true",
+	}); err != nil {
+		return fmt.Errorf("failed to find default hosted agent pool assignment: %w", err)
+	}
+	for _, assignment := range assignments.Items {
+		if assignment.Name != currentID {
+			return types.NewErrBadRequest("user %s already has a default hosted agent pool", manifest.UserID)
+		}
+	}
+	return nil
+}
+
+func convertHostedAgentPoolAssignment(assignment v1.HostedAgentPoolAssignment) types.HostedAgentPoolAssignment {
+	return types.HostedAgentPoolAssignment{
+		Metadata:                          MetadataFrom(&assignment),
+		HostedAgentPoolAssignmentManifest: assignment.Spec.Manifest,
+	}
+}
+
+func userPoolIDs(req api.Context) (map[string]bool, error) {
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, kclient.MatchingFields{"spec.userID": req.User.GetUID()}); err != nil {
+		return nil, fmt.Errorf("failed to list hosted agent pool assignments: %w", err)
+	}
+	result := make(map[string]bool, len(assignments.Items))
+	for _, assignment := range assignments.Items {
+		result[assignment.Spec.Manifest.PoolID] = true
+	}
+	return result, nil
+}
+
+func requirePoolAccess(req api.Context, poolID string) error {
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, poolID); apierrors.IsNotFound(err) {
+		return types.NewErrNotFound("hosted agent pool %s not found", poolID)
+	} else if err != nil {
+		return fmt.Errorf("failed to get hosted agent pool %s: %w", poolID, err)
+	}
+	if req.UserIsAdmin() {
+		return nil
+	}
+	allowed, err := userPoolIDs(req)
+	if err != nil {
+		return err
+	}
+	if !allowed[poolID] {
+		return types.NewErrNotFound("hosted agent pool %s not found", poolID)
+	}
+	return nil
+}
+
+type hostedAgentPoolUtilization struct {
+	Timestamp time.Time                        `json:"timestamp"`
+	Pool      hostedAgentResourceUtilization   `json:"pool"`
+	Instances []hostedAgentInstanceUtilization `json:"instances"`
+	Pressure  hostedAgentPoolResourcePressure  `json:"pressure"`
+	// StorageMeasured distinguishes a pool using no disk from one whose disk
+	// cannot be measured. Without it a client cannot tell the two apart, and
+	// showing an empty disk bar for an unknown figure is worse than saying so.
+	StorageMeasured bool `json:"storageMeasured"`
+}
+
+type hostedAgentInstanceUtilization struct {
+	InstanceID string                         `json:"instanceID"`
+	State      agentbackend.State             `json:"state"`
+	Usage      hostedAgentResourceUtilization `json:"usage"`
+}
+
+// hostedAgentResourceUtilization is live usage. storageBytes is meaningful only
+// on the pool: sandboxes share one volume, so a sandbox's own disk usage is not
+// observable and is always reported as zero.
+type hostedAgentResourceUtilization struct {
+	CPUVCPUs     float64 `json:"cpuVcpus"`
+	MemoryBytes  int64   `json:"memoryBytes"`
+	StorageBytes int64   `json:"storageBytes"`
+}
+
+type hostedAgentPoolResourcePressure struct {
+	CPU     bool `json:"cpu"`
+	Memory  bool `json:"memory"`
+	Storage bool `json:"storage"`
+}
+
+func convertPoolUtilization(snapshot agentbackend.UtilizationSnapshot) hostedAgentPoolUtilization {
+	result := hostedAgentPoolUtilization{
+		Timestamp: snapshot.Timestamp,
+		Pool:      convertResourceUtilization(snapshot.Pool),
+		Instances: make([]hostedAgentInstanceUtilization, 0, len(snapshot.Instances)),
+		Pressure: hostedAgentPoolResourcePressure{
+			CPU: snapshot.Pressure.CPU, Memory: snapshot.Pressure.Memory, Storage: snapshot.Pressure.Storage,
+		},
+		StorageMeasured: snapshot.StorageMeasured,
+	}
+	for _, instance := range snapshot.Instances {
+		result.Instances = append(result.Instances, hostedAgentInstanceUtilization{
+			InstanceID: instance.Ref.ID,
+			State:      instance.State,
+			Usage:      convertResourceUtilization(instance.Utilization),
+		})
+	}
+	return result
+}
+
+func convertResourceUtilization(usage agentbackend.ResourceUtilization) hostedAgentResourceUtilization {
+	return hostedAgentResourceUtilization{
+		CPUVCPUs: usage.CPUVCPUs, MemoryBytes: usage.MemoryBytes, StorageBytes: usage.StorageBytes,
+	}
+}

--- a/pkg/api/handlers/hostedagentpools_test.go
+++ b/pkg/api/handlers/hostedagentpools_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConvertPoolUtilization(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
+	got := convertPoolUtilization(agentbackend.UtilizationSnapshot{
+		Timestamp: now,
+		Pool:      agentbackend.ResourceUtilization{CPUVCPUs: 1.5, MemoryBytes: 2, StorageBytes: 3},
+		Instances: []agentbackend.InstanceUtilization{{
+			Ref:         agentbackend.InstanceRef{ID: "instance-1", BackendID: "backend-1"},
+			State:       agentbackend.StateReady,
+			Utilization: agentbackend.ResourceUtilization{CPUVCPUs: 0.5, MemoryBytes: 1, StorageBytes: 2},
+		}},
+		Pressure: agentbackend.Pressure{Memory: true},
+	})
+
+	if !got.Timestamp.Equal(now) {
+		t.Fatalf("Timestamp = %v, want %v", got.Timestamp, now)
+	}
+	if got.Pool.CPUVCPUs != 1.5 || got.Pool.MemoryBytes != 2 || got.Pool.StorageBytes != 3 {
+		t.Fatalf("Pool = %#v", got.Pool)
+	}
+	if len(got.Instances) != 1 || got.Instances[0].InstanceID != "instance-1" || got.Instances[0].State != agentbackend.StateReady {
+		t.Fatalf("Instances = %#v", got.Instances)
+	}
+	if !got.Pressure.Memory || got.Pressure.CPU || got.Pressure.Storage {
+		t.Fatalf("Pressure = %#v", got.Pressure)
+	}
+}
+
+func TestConvertHostedAgentInstanceIncludesPool(t *testing.T) {
+	got := convertHostedAgentInstance(v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "instance-1"},
+		Spec: v1.HostedAgentInstanceSpec{
+			UserID:          "user-1",
+			HostedAgentName: "agent-1",
+			PoolID:          "pool-1",
+		},
+	})
+
+	if got.PoolID != "pool-1" {
+		t.Fatalf("PoolID = %q, want pool-1", got.PoolID)
+	}
+}
+
+// A pool is shared across users, so its utilization describes
+// co-tenants' sandboxes too. Pool totals are reported separately and stay
+// whole; the per-instance breakdown must not expose anyone else's instances.
+func TestNarrowInstanceUtilizationHidesOtherUsersInstances(t *testing.T) {
+	mine := v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "hai-mine", UID: "uid-mine"},
+	}
+	usages := []agentbackend.InstanceUtilization{
+		{Ref: agentbackend.InstanceRef{ID: "uid-theirs-1"}, Utilization: agentbackend.ResourceUtilization{CPUVCPUs: 1}},
+		{Ref: agentbackend.InstanceRef{ID: "uid-mine"}, Utilization: agentbackend.ResourceUtilization{CPUVCPUs: 2}},
+		{Ref: agentbackend.InstanceRef{ID: "uid-theirs-2"}, Utilization: agentbackend.ResourceUtilization{CPUVCPUs: 3}},
+	}
+
+	got := narrowInstanceUtilization(usages, []v1.HostedAgentInstance{mine})
+
+	if len(got) != 1 {
+		t.Fatalf("expected only the caller's instance, got %d entries: %+v", len(got), got)
+	}
+	// Rewritten from the backend UID to the API resource ID.
+	if got[0].Ref.ID != "hai-mine" {
+		t.Errorf("instance ID = %q, want the API resource ID hai-mine", got[0].Ref.ID)
+	}
+	if got[0].Utilization.CPUVCPUs != 2 {
+		t.Errorf("kept the wrong entry: cpu = %v, want 2", got[0].Utilization.CPUVCPUs)
+	}
+}
+
+// An admin passes the full instance list, so nothing is dropped.
+func TestNarrowInstanceUtilizationKeepsEverythingVisible(t *testing.T) {
+	instances := []v1.HostedAgentInstance{
+		{ObjectMeta: metav1.ObjectMeta{Name: "hai-a", UID: "uid-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "hai-b", UID: "uid-b"}},
+	}
+	usages := []agentbackend.InstanceUtilization{
+		{Ref: agentbackend.InstanceRef{ID: "uid-a"}},
+		{Ref: agentbackend.InstanceRef{ID: "uid-b"}},
+	}
+
+	got := narrowInstanceUtilization(usages, instances)
+
+	if len(got) != 2 {
+		t.Fatalf("expected both instances, got %d", len(got))
+	}
+}
+
+// A sandbox the backend reports but Obot has no record of, such as one left
+// behind by a failed delete, must not surface with a raw backend identifier.
+func TestNarrowInstanceUtilizationDropsUnknownSandboxes(t *testing.T) {
+	usages := []agentbackend.InstanceUtilization{
+		{Ref: agentbackend.InstanceRef{ID: "uid-orphan"}},
+	}
+
+	if got := narrowInstanceUtilization(usages, nil); len(got) != 0 {
+		t.Fatalf("expected orphaned sandboxes to be dropped, got %+v", got)
+	}
+}

--- a/pkg/api/handlers/hostedagents.go
+++ b/pkg/api/handlers/hostedagents.go
@@ -1,0 +1,272 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/adhocore/gronx"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	gateway "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/hostedagentaccessrule"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type HostedAgentHandler struct {
+	accessRuleHelper *hostedagentaccessrule.Helper
+}
+
+func NewHostedAgentHandler(accessRuleHelper *hostedagentaccessrule.Helper) *HostedAgentHandler {
+	return &HostedAgentHandler{accessRuleHelper: accessRuleHelper}
+}
+
+func (h *HostedAgentHandler) List(req api.Context) error {
+	var list v1.HostedAgentList
+	if err := req.List(&list); err != nil {
+		return fmt.Errorf("failed to list hosted agents: %w", err)
+	}
+
+	// Admins and auditors can see every agent with ?all=true. Everyone else,
+	// including admins without the flag, sees only what the access rules allow.
+	availability, err := newAgentAvailability(req.Context(), req.Storage, req.Namespace())
+	if err != nil {
+		return err
+	}
+
+	if (req.UserIsAdmin() || req.UserIsAuditor()) && req.URL.Query().Get("all") == "true" {
+		items := make([]types.HostedAgent, 0, len(list.Items))
+		for _, item := range list.Items {
+			items = append(items, availability.applyTo(req.Context(), convertHostedAgent(item)))
+		}
+		return req.Write(types.HostedAgentList{Items: items})
+	}
+
+	items := make([]types.HostedAgent, 0, len(list.Items))
+	for _, item := range list.Items {
+		hasAccess, err := h.accessRuleHelper.UserHasAccessToHostedAgent(req.User, &item)
+		if err != nil {
+			return fmt.Errorf("failed to check access to hosted agent %s: %w", item.Name, err)
+		}
+		if hasAccess {
+			items = append(items, availability.applyTo(req.Context(), convertHostedAgent(item)))
+		}
+	}
+
+	return req.Write(types.HostedAgentList{Items: items})
+}
+
+func (h *HostedAgentHandler) Get(req api.Context) error {
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.PathValue("hosted_agent_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	availability, err := newAgentAvailability(req.Context(), req.Storage, req.Namespace())
+	if err != nil {
+		return err
+	}
+
+	return req.Write(availability.applyTo(req.Context(), convertHostedAgent(agent)))
+}
+
+func (h *HostedAgentHandler) Create(req api.Context) error {
+	var manifest types.HostedAgentManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read hosted agent manifest: %v", err)
+	}
+
+	if err := validateHostedAgentManifest(req, manifest); err != nil {
+		return err
+	}
+
+	secrets := extractHostedAgentSecrets(&manifest)
+
+	agent := v1.HostedAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: system.HostedAgentPrefix,
+			Namespace:    req.Namespace(),
+		},
+		Spec: v1.HostedAgentSpec{
+			Manifest: manifest,
+		},
+	}
+
+	if err := req.Create(&agent); err != nil {
+		return fmt.Errorf("failed to create hosted agent: %w", err)
+	}
+
+	if len(secrets) > 0 {
+		if err := req.GatewayClient.UpsertCredential(req.Context(), gatewaytypes.Credential{
+			Context: HostedAgentCredentialContext(agent),
+			Name:    agent.Name,
+			Secrets: secrets,
+		}); err != nil {
+			return fmt.Errorf("failed to store hosted agent credentials: %w", err)
+		}
+	}
+
+	return req.WriteCreated(convertHostedAgent(agent))
+}
+
+func (h *HostedAgentHandler) Update(req api.Context) error {
+	var manifest types.HostedAgentManifest
+	if err := req.Read(&manifest); err != nil {
+		return types.NewErrBadRequest("failed to read hosted agent manifest: %v", err)
+	}
+
+	if err := validateHostedAgentManifest(req, manifest); err != nil {
+		return err
+	}
+
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.PathValue("hosted_agent_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	newSecrets := extractHostedAgentSecrets(&manifest)
+
+	existing, err := hostedAgentSecrets(req, agent)
+	if err != nil {
+		return err
+	}
+
+	// A blank value on a sensitive env var means "leave it as it was", so that
+	// clients can round-trip a manifest without ever seeing the secret.
+	secrets := make(map[string]string, len(newSecrets))
+	for _, env := range manifest.Env {
+		if !env.Sensitive {
+			continue
+		}
+		if value, ok := newSecrets[env.Key]; ok {
+			secrets[env.Key] = value
+		} else if value, ok := existing[env.Key]; ok {
+			secrets[env.Key] = value
+		}
+	}
+
+	agent.Spec.Manifest = manifest
+	if err := req.Update(&agent); err != nil {
+		return fmt.Errorf("failed to update hosted agent: %w", err)
+	}
+
+	if len(secrets) > 0 {
+		if err := req.GatewayClient.UpsertCredential(req.Context(), gatewaytypes.Credential{
+			Context: HostedAgentCredentialContext(agent),
+			Name:    agent.Name,
+			Secrets: secrets,
+		}); err != nil {
+			return fmt.Errorf("failed to store hosted agent credentials: %w", err)
+		}
+	} else if len(existing) > 0 {
+		if _, err := req.GatewayClient.DeleteCredential(req.Context(), HostedAgentCredentialContext(agent), agent.Name); err != nil {
+			return fmt.Errorf("failed to delete hosted agent credentials: %w", err)
+		}
+	}
+
+	return req.Write(convertHostedAgent(agent))
+}
+
+func (h *HostedAgentHandler) Delete(req api.Context) error {
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.PathValue("hosted_agent_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	if _, err := req.GatewayClient.DeleteCredential(req.Context(), HostedAgentCredentialContext(agent), agent.Name); err != nil {
+		return fmt.Errorf("failed to delete hosted agent credentials: %w", err)
+	}
+
+	return req.Delete(&v1.HostedAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agent.Name,
+			Namespace: req.Namespace(),
+		},
+	})
+}
+
+func (h *HostedAgentHandler) Reveal(req api.Context) error {
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.PathValue("hosted_agent_id")); err != nil {
+		return fmt.Errorf("failed to get hosted agent: %w", err)
+	}
+
+	secrets, err := hostedAgentSecrets(req, agent)
+	if err != nil {
+		return err
+	}
+
+	if len(secrets) == 0 {
+		return req.Write(map[string]string{})
+	}
+
+	return req.Write(secrets)
+}
+
+// validateHostedAgentManifest runs the shared manifest validation, plus the
+// checks that apiclient/types deliberately leaves out: cron parsing (a
+// question's default is an answer like any other, so it gets the same
+// treatment) and that the referenced harness actually exists.
+func validateHostedAgentManifest(req api.Context, manifest types.HostedAgentManifest) error {
+	if err := manifest.Validate(); err != nil {
+		return types.NewErrBadRequest("invalid hosted agent manifest: %v", err)
+	}
+
+	var harness v1.Harness
+	if err := req.Get(&harness, manifest.HarnessID); apierrors.IsNotFound(err) {
+		return types.NewErrBadRequest("harness %s not found", manifest.HarnessID)
+	} else if err != nil {
+		return fmt.Errorf("failed to get harness %s: %w", manifest.HarnessID, err)
+	}
+
+	for _, question := range manifest.Questions {
+		if question.Type != types.HostedAgentQuestionTypeSchedule || question.Default == "" {
+			continue
+		}
+		if !gronx.IsValid(question.Default) {
+			return types.NewErrBadRequest("invalid hosted agent manifest: question %s: default must be a valid cron expression", question.Key)
+		}
+	}
+
+	return nil
+}
+
+// extractHostedAgentSecrets pulls the values of sensitive env vars out of the
+// manifest and blanks them, so they are only ever persisted in the credential
+// store and never on the resource itself.
+func extractHostedAgentSecrets(manifest *types.HostedAgentManifest) map[string]string {
+	secrets := make(map[string]string)
+	for i, env := range manifest.Env {
+		if env.Sensitive && env.Value != "" {
+			secrets[env.Key] = env.Value
+			manifest.Env[i].Value = ""
+		}
+	}
+	return secrets
+}
+
+func hostedAgentSecrets(req api.Context, agent v1.HostedAgent) (map[string]string, error) {
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{HostedAgentCredentialContext(agent)}, agent.Name)
+	if err != nil {
+		if errors.As(err, &gateway.CredentialNotFoundError{}) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find hosted agent credential: %w", err)
+	}
+
+	return cred.Secrets, nil
+}
+
+func HostedAgentCredentialContext(agent v1.HostedAgent) string {
+	return fmt.Sprintf("hosted-agent-%s", agent.Name)
+}
+
+func convertHostedAgent(agent v1.HostedAgent) types.HostedAgent {
+	return types.HostedAgent{
+		Metadata:            MetadataFrom(&agent),
+		HostedAgentManifest: agent.Spec.Manifest,
+	}
+}

--- a/pkg/api/handlers/iconresolver_test.go
+++ b/pkg/api/handlers/iconresolver_test.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+)
+
+func resolverFor(agent types.HostedAgentManifest, harness types.HarnessManifest) *iconResolver {
+	return &iconResolver{
+		agents:    map[string]types.HostedAgentManifest{"ha1": agent},
+		harnesses: map[string]types.HarnessManifest{"hrn1": harness},
+	}
+}
+
+// The chain exists so a client renders a row from one payload instead of
+// fetching the agent and its harness per instance.
+func TestIconResolutionOrder(t *testing.T) {
+	agent := types.HostedAgentManifest{HarnessID: "hrn1", Icon: "agent.svg", IconDark: "agent-dark.svg"}
+	harness := types.HarnessManifest{Icon: "harness.svg", IconDark: "harness-dark.svg"}
+
+	// The user's own choice wins.
+	got := resolverFor(agent, harness).apply(
+		types.HostedAgentInstance{HostedAgentInstanceManifest: types.HostedAgentInstanceManifest{Icon: "mine.svg"}}, "ha1")
+	if got.ResolvedIcon != "mine.svg" {
+		t.Errorf("instance icon = %q, want the instance's own", got.ResolvedIcon)
+	}
+
+	// Otherwise the agent's.
+	got = resolverFor(agent, harness).apply(types.HostedAgentInstance{}, "ha1")
+	if got.ResolvedIcon != "agent.svg" || got.ResolvedIconDark != "agent-dark.svg" {
+		t.Errorf("resolved = %q/%q, want the agent's", got.ResolvedIcon, got.ResolvedIconDark)
+	}
+
+	// Otherwise the harness's, which is where a config source's icon lives when
+	// only the harness declares one.
+	got = resolverFor(types.HostedAgentManifest{HarnessID: "hrn1"}, harness).apply(types.HostedAgentInstance{}, "ha1")
+	if got.ResolvedIcon != "harness.svg" || got.ResolvedIconDark != "harness-dark.svg" {
+		t.Errorf("resolved = %q/%q, want the harness's", got.ResolvedIcon, got.ResolvedIconDark)
+	}
+}
+
+// A dark variant is optional at every level, so a client should never have to
+// decide what to do when only the light one is set.
+func TestDarkIconFallsBackToLight(t *testing.T) {
+	got := resolverFor(types.HostedAgentManifest{HarnessID: "hrn1", Icon: "agent.svg"}, types.HarnessManifest{}).
+		apply(types.HostedAgentInstance{}, "ha1")
+	if got.ResolvedIconDark != "agent.svg" {
+		t.Errorf("dark icon = %q, want it to fall back to the light one", got.ResolvedIconDark)
+	}
+}
+
+// Nothing anywhere resolves to nothing, rather than to a broken image.
+func TestNoIconAnywhereResolvesEmpty(t *testing.T) {
+	got := resolverFor(types.HostedAgentManifest{HarnessID: "hrn1"}, types.HarnessManifest{}).
+		apply(types.HostedAgentInstance{}, "ha1")
+	if got.ResolvedIcon != "" || got.ResolvedIconDark != "" {
+		t.Errorf("resolved = %q/%q, want empty", got.ResolvedIcon, got.ResolvedIconDark)
+	}
+}
+
+// An instance whose agent has been deleted still renders; it just has no icon.
+func TestUnknownAgentDoesNotPanic(t *testing.T) {
+	got := resolverFor(types.HostedAgentManifest{}, types.HarnessManifest{}).
+		apply(types.HostedAgentInstance{HostedAgentInstanceManifest: types.HostedAgentInstanceManifest{Icon: "mine.svg"}}, "gone")
+	if got.ResolvedIcon != "mine.svg" {
+		t.Errorf("resolved = %q, want the instance's own icon", got.ResolvedIcon)
+	}
+}

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -22,6 +22,7 @@ import (
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
 	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/mcp"
+	"github.com/obot-platform/obot/pkg/principal"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	obottunnel "github.com/obot-platform/obot/pkg/tunnel"
@@ -961,7 +962,7 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id, secretBindingAllowed
 						MCPCatalogName:            server.Spec.MCPCatalogID,
 						MCPServerCatalogEntryName: server.Spec.MCPServerCatalogEntryName,
 						PowerUserWorkspaceID:      server.Spec.PowerUserWorkspaceID,
-						UserID:                    req.User.GetUID(),
+						UserID:                    principal.ResourceOwnerID(req.User),
 						MultiUserConfig:           server.Spec.Manifest.MultiUserConfig,
 					},
 				}

--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/obot-platform/obot/pkg/controller/handlers/systemmcpserver"
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/mcp"
+	"github.com/obot-platform/obot/pkg/principal"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/tunnel"
@@ -211,7 +212,7 @@ func (h *Handler) ensureServerIsDeployed(req api.Context) (mcp.ServerConfig, err
 		return h.ensureSystemServerIsDeployed(req, mcpID)
 	}
 
-	mcpID, mcpServer, mcpServerConfig, missingConfig, err := h.mcpSessionManager.ServerForActionWithConnectIDAllowMissingConfig(req.Context(), mcpID, req.User.GetUID())
+	mcpID, mcpServer, mcpServerConfig, missingConfig, err := h.mcpSessionManager.ServerForActionWithConnectIDAllowMissingConfig(req.Context(), mcpID, principal.ResourceOwnerID(req.User))
 	if err != nil {
 		return mcp.ServerConfig{}, fmt.Errorf("failed to get mcp server config: %w", err)
 	}
@@ -317,7 +318,9 @@ func (h *Handler) ensureSystemServerIsDeployed(req api.Context, mcpID string) (m
 	baseURL := strings.TrimSuffix(req.APIBaseURL, "/api")
 	audiences := systemServer.ValidConnectURLs(baseURL)
 
-	serverConfig, _, err := mcp.SystemServerToServerConfig(systemServer, audiences, req.User.GetUID(), credEnv, secretsCred)
+	// Ownership, not the acting identity: a system server deployed for an agent
+	// belongs to the person who created that agent.
+	serverConfig, _, err := mcp.SystemServerToServerConfig(systemServer, audiences, principal.ResourceOwnerID(req.User), credEnv, secretsCred)
 	if err != nil {
 		return mcp.ServerConfig{}, fmt.Errorf("failed to convert system server to config: %w", err)
 	}

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 
 	"github.com/obot-platform/obot/pkg/api/handlers"
+	"github.com/obot-platform/obot/pkg/api/handlers/agentconnect"
+	"github.com/obot-platform/obot/pkg/api/handlers/agentterminal"
 	"github.com/obot-platform/obot/pkg/api/handlers/mcpgateway"
 	"github.com/obot-platform/obot/pkg/api/handlers/mcpgateway/oauth"
 	"github.com/obot-platform/obot/pkg/api/handlers/registry"
@@ -81,6 +83,10 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 		return nil, err
 	}
 
+	// Sandboxes are plain in-cluster HTTP, so the default transport is enough.
+	agentConnect := agentconnect.New(http.DefaultTransport, services.AgentDevRouter)
+	agentTerminal := agentterminal.New(services.AgentBackend, services.DevUIPort)
+
 	oauthChecker := oauth.NewMCPOAuthHandlerFactory(services.ServerURL, services.MCPSessionManager, services.StorageClient, services.GatewayClient, services.MCPOAuthTokenStorage, services.MCPSecretBindingAllowedLabel, services.ForceDynamicClient)
 
 	models := handlers.NewModelHandler(services.ModelAccessPolicyHelper)
@@ -91,6 +97,19 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	skillRepositories := handlers.NewSkillRepositoryHandler()
 	gitCredentials := handlers.NewGitCredentialHandler()
 	skillAccessRules := handlers.NewSkillAccessRuleHandler()
+	agentCatalogs := handlers.NewAgentCatalogHandler(services.DevMode)
+	harnesses := handlers.NewHarnessHandler()
+	hostedAgents := handlers.NewHostedAgentHandler(services.HostedAgentAccessRuleHelper)
+	hostedAgentInstances := handlers.NewHostedAgentInstanceHandler(
+		services.HostedAgentAccessRuleHelper,
+		services.AccessControlRuleHelper,
+		services.SkillAccessRuleHelper,
+		services.ModelAccessPolicyHelper,
+	)
+	hostedAgentPools := handlers.NewHostedAgentPoolHandler(services.AgentBackend)
+	hostedAgentPoolDefaults := handlers.NewHostedAgentPoolDefaultsHandler()
+	hostedAgentPoolAssignments := handlers.NewHostedAgentPoolAssignmentHandler()
+	hostedAgentAccessRules := handlers.NewHostedAgentAccessRuleHandler()
 	skills := handlers.NewSkillHandler(services.SkillAccessRuleHelper)
 	powerUserWorkspaces := handlers.NewPowerUserWorkspaceHandler(services.ServerURL, services.AccessControlRuleHelper, services.MCPSecretBindingAllowedLabel)
 	mcpWebhookValidations := handlers.NewMCPWebhookValidationHandler(services.MCPSessionManager)
@@ -457,6 +476,65 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mux.HandleFunc("PUT /api/skill-access-rules/{skill_access_rule_id}", skillAccessRules.Update)
 	mux.HandleFunc("DELETE /api/skill-access-rules/{skill_access_rule_id}", skillAccessRules.Delete)
 
+	// Agent sources (admin only)
+	mux.HandleFunc("GET /api/agent-catalogs", agentCatalogs.List)
+	mux.HandleFunc("POST /api/agent-catalogs", agentCatalogs.Create)
+	mux.HandleFunc("GET /api/agent-catalogs/{agent_catalog_id}", agentCatalogs.Get)
+	mux.HandleFunc("PUT /api/agent-catalogs/{agent_catalog_id}", agentCatalogs.Update)
+	mux.HandleFunc("DELETE /api/agent-catalogs/{agent_catalog_id}", agentCatalogs.Delete)
+	mux.HandleFunc("POST /api/agent-catalogs/{agent_catalog_id}/refresh", agentCatalogs.Refresh)
+
+	// Harnesses (admin only) — the runtimes hosted agents are built on
+	mux.HandleFunc("GET /api/harnesses", harnesses.List)
+	mux.HandleFunc("POST /api/harnesses", harnesses.Create)
+	mux.HandleFunc("GET /api/harnesses/{harness_id}", harnesses.Get)
+	mux.HandleFunc("PUT /api/harnesses/{harness_id}", harnesses.Update)
+	mux.HandleFunc("DELETE /api/harnesses/{harness_id}", harnesses.Delete)
+
+	// Hosted agents (admin manages; users get an access-rule-filtered read-only view)
+	mux.HandleFunc("GET /api/hosted-agents", hostedAgents.List)
+	mux.HandleFunc("POST /api/hosted-agents", hostedAgents.Create)
+	mux.HandleFunc("GET /api/hosted-agents/{hosted_agent_id}", hostedAgents.Get)
+	mux.HandleFunc("PUT /api/hosted-agents/{hosted_agent_id}", hostedAgents.Update)
+	mux.HandleFunc("DELETE /api/hosted-agents/{hosted_agent_id}", hostedAgents.Delete)
+	mux.HandleFunc("POST /api/hosted-agents/{hosted_agent_id}/reveal", hostedAgents.Reveal)
+
+	// Hosted agent instances (per-user)
+	mux.HandleFunc("GET /api/hosted-agent-instances", hostedAgentInstances.List)
+	mux.HandleFunc("POST /api/hosted-agent-instances", hostedAgentInstances.Create)
+	mux.HandleFunc("GET /api/hosted-agent-instances/{hosted_agent_instance_id}", hostedAgentInstances.Get)
+	mux.HandleFunc("PUT /api/hosted-agent-instances/{hosted_agent_instance_id}", hostedAgentInstances.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-instances/{hosted_agent_instance_id}", hostedAgentInstances.Delete)
+	mux.HandleFunc("GET /api/hosted-agent-instances/{hosted_agent_instance_id}/terminal", agentTerminal.Attach)
+
+	// Hosted agent pools (users have assigned read-only access; admins manage)
+	mux.HandleFunc("GET /api/hosted-agent-pools", hostedAgentPools.List)
+	mux.HandleFunc("POST /api/hosted-agent-pools", hostedAgentPools.Create)
+	mux.HandleFunc("GET /api/hosted-agent-pools/{hosted_agent_pool_id}", hostedAgentPools.Get)
+	mux.HandleFunc("PUT /api/hosted-agent-pools/{hosted_agent_pool_id}", hostedAgentPools.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-pools/{hosted_agent_pool_id}", hostedAgentPools.Delete)
+	mux.HandleFunc("GET /api/hosted-agent-pools/{hosted_agent_pool_id}/utilization", hostedAgentPools.Utilization)
+
+	// Deployment-wide hosted agent pool defaults (admin only)
+	mux.HandleFunc("GET /api/hosted-agent-pool-defaults", hostedAgentPoolDefaults.Get)
+	mux.HandleFunc("POST /api/hosted-agent-pool-defaults", hostedAgentPoolDefaults.Create)
+	mux.HandleFunc("PUT /api/hosted-agent-pool-defaults", hostedAgentPoolDefaults.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-pool-defaults", hostedAgentPoolDefaults.Delete)
+
+	// User-to-pool assignments (users can read their own; admins manage)
+	mux.HandleFunc("GET /api/hosted-agent-pool-assignments", hostedAgentPoolAssignments.List)
+	mux.HandleFunc("POST /api/hosted-agent-pool-assignments", hostedAgentPoolAssignments.Create)
+	mux.HandleFunc("GET /api/hosted-agent-pool-assignments/{hosted_agent_pool_assignment_id}", hostedAgentPoolAssignments.Get)
+	mux.HandleFunc("PUT /api/hosted-agent-pool-assignments/{hosted_agent_pool_assignment_id}", hostedAgentPoolAssignments.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-pool-assignments/{hosted_agent_pool_assignment_id}", hostedAgentPoolAssignments.Delete)
+
+	// Hosted agent access rules (admin only)
+	mux.HandleFunc("GET /api/hosted-agent-access-rules", hostedAgentAccessRules.List)
+	mux.HandleFunc("POST /api/hosted-agent-access-rules", hostedAgentAccessRules.Create)
+	mux.HandleFunc("GET /api/hosted-agent-access-rules/{hosted_agent_access_rule_id}", hostedAgentAccessRules.Get)
+	mux.HandleFunc("PUT /api/hosted-agent-access-rules/{hosted_agent_access_rule_id}", hostedAgentAccessRules.Update)
+	mux.HandleFunc("DELETE /api/hosted-agent-access-rules/{hosted_agent_access_rule_id}", hostedAgentAccessRules.Delete)
+
 	// OAuthClients
 	mux.HandleFunc("GET /api/oauth-clients", oauthClients.List)
 	mux.HandleFunc("POST /api/oauth-clients", oauthClients.Create)
@@ -666,6 +744,11 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 
 	// MCP Gateway Endpoints
 	// The first pattern handles the root path, the second handles all sub-paths.
+	// Hosted agent sandboxes are only reachable in-cluster, so this is the one
+	// address a user has for their agent, and the one place access is decided.
+	mux.HandleFunc("/agent-connect/{hosted_agent_instance_id}", agentConnect.Proxy)
+	mux.HandleFunc("/agent-connect/{hosted_agent_instance_id}/{rest...}", agentConnect.Proxy)
+
 	mux.HandleFunc("/mcp-connect/{mcp_id}", mcpGateway.Proxy)
 	mux.HandleFunc("/mcp-connect/{mcp_id}/{rest...}", mcpGateway.Proxy)
 	// This is a special path for internal MCP composite requests.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,6 +73,10 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure default user role setting: %w", err)
 	}
 
+	if err := ensureHostedAgentPoolDefaults(ctx, c.services.StorageClient); err != nil {
+		return fmt.Errorf("failed to ensure hosted agent pool defaults: %w", err)
+	}
+
 	resourceMaximums := c.services.MCPSessionManager.KubernetesResourceMaximums()
 	if err := ensureK8sSettings(ctx, c.services.StorageClient, c.services.PodSchedulingSettingsFromHelm, c.services.PSASettingsFromHelm, resourceMaximums); err != nil {
 		return fmt.Errorf("failed to ensure K8s settings: %w", err)
@@ -386,6 +390,40 @@ func ensureDefaultUserRoleSetting(ctx context.Context, client kclient.Client) er
 	return client.Update(ctx, &defaultRoleSetting)
 }
 
+func ensureHostedAgentPoolDefaults(ctx context.Context, client kclient.Client) error {
+	const gibibyte = int64(1024 * 1024 * 1024)
+
+	var defaults v1.HostedAgentPoolDefaults
+	key := kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: "default"}
+	if err := client.Get(ctx, key, &defaults); err == nil {
+		// Defaults are administrator-owned after creation.
+		return nil
+	} else if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return client.Create(ctx, &v1.HostedAgentPoolDefaults{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+		Spec: v1.HostedAgentPoolDefaultsSpec{
+			Manifest: types.HostedAgentPoolDefaultsManifest{
+				Capacity: types.HostedAgentResourceQuantity{
+					CPUVCPUs:     1,
+					MemoryBytes:  4 * gibibyte,
+					StorageBytes: 20 * gibibyte,
+				},
+				// Seeded explicitly rather than left to the fallback, so an
+				// administrator opening the defaults sees the number that is
+				// actually in force. With the capacity above this gives each
+				// sandbox 250m CPU and 1GiB guaranteed.
+				MaxSandboxes: 4,
+			},
+		},
+	})
+}
+
 // ensureK8sSettings ensures the K8sSettings resource exists with proper configuration.
 // podSchedulingSettings: affinity, tolerations, resources, runtimeClassName - can be managed via Helm OR UI.
 //
@@ -572,7 +610,10 @@ func ensureAppPreferences(ctx context.Context, client kclient.Client) error {
 
 // setupLocalK8sRoutes sets up routes for the local Kubernetes router
 func (c *Controller) setupLocalK8sRoutes() {
-	if c.services.LocalRouter != nil {
+	// The local router now also exists when only hosted agents run on
+	// Kubernetes, so these are gated on the MCP backend rather than on the
+	// router: every one of them reconciles MCP state from cluster objects.
+	if c.services.LocalRouter != nil && mcp.IsKubernetesBackend(c.services.MCPRuntimeBackend) {
 		resourceMaximums := c.services.MCPSessionManager.KubernetesResourceMaximums()
 		deploymentHandler := deployment.New(c.services.MCPServerNamespace, c.services.Router.Backend(), c.services.MCPRuntimeBackend, resourceMaximums, c.services.MCPImagePullSecrets)
 		c.services.LocalRouter.Type(&appsv1.Deployment{}).IncludeRemoved().HandlerFunc(deploymentHandler.UpdateMCPServerStatus)
@@ -584,7 +625,6 @@ func (c *Controller) setupLocalK8sRoutes() {
 		// instead of waiting for the periodic service-account key rotation loop.
 		c.services.LocalRouter.Type(&corev1.Secret{}).Namespace(c.services.ServiceNamespace).Name(serviceaccounts.NetworkPolicySecretName).IncludeRemoved().HandlerFunc(c.reconcileServiceAccountSecretChange)
 	}
-
 	if c.services.EveryReplicaRouter != nil {
 		peerHandler := tunnelpeer.New(c.services.TunnelManager.ID, c.services.TunnelManager)
 		c.services.EveryReplicaRouter.Type(&corev1.Service{}).Namespace(c.services.TunnelManager.ServiceNamespace).Name(c.services.TunnelManager.ServiceName).HandlerFunc(peerHandler.Reconcile)

--- a/pkg/controller/data/data.go
+++ b/pkg/controller/data/data.go
@@ -26,6 +26,9 @@ var everythingAccessControlRuleData []byte
 //go:embed everything-skill-access-rule.yaml
 var everythingSkillAccessRuleData []byte
 
+//go:embed everything-hosted-agent-access-rule.yaml
+var everythingHostedAgentAccessRuleData []byte
+
 func Data(ctx context.Context, c kclient.Client, defaultSkillRepoURL, defaultSkillRepoRef string) error {
 	var defaultModelAliases v1.DefaultModelAliasList
 	if err := yaml.Unmarshal(defaultModelAliasesData, &defaultModelAliases); err != nil {
@@ -100,6 +103,15 @@ func Data(ctx context.Context, c kclient.Client, defaultSkillRepoURL, defaultSki
 		}
 
 		if err := kclient.IgnoreAlreadyExists(c.Create(ctx, &everythingSkillAccessRule)); err != nil {
+			return err
+		}
+
+		var everythingHostedAgentAccessRule v1.HostedAgentAccessRule
+		if err := yaml.Unmarshal(everythingHostedAgentAccessRuleData, &everythingHostedAgentAccessRule); err != nil {
+			return fmt.Errorf("failed to unmarshal everything hosted agent access rule: %w", err)
+		}
+
+		if err := kclient.IgnoreAlreadyExists(c.Create(ctx, &everythingHostedAgentAccessRule)); err != nil {
 			return err
 		}
 

--- a/pkg/controller/data/everything-hosted-agent-access-rule.yaml
+++ b/pkg/controller/data/everything-hosted-agent-access-rule.yaml
@@ -1,0 +1,14 @@
+apiVersion: obot.obot.ai/v1
+kind: HostedAgentAccessRule
+metadata:
+  name: haar1-everything
+  namespace: default
+spec:
+  manifest:
+    displayName: Everything
+    resources:
+      - id: '*'
+        type: selector
+    subjects:
+      - id: '*'
+        type: selector

--- a/pkg/controller/handlers/agentcatalog/agentcatalog.go
+++ b/pkg/controller/handlers/agentcatalog/agentcatalog.go
@@ -1,0 +1,655 @@
+// Package agentcatalog syncs hosted agents and harnesses from a git repository,
+// mirroring the skillrepository package for skills.
+//
+// ID alignment: a repository cannot know the generated resource names its
+// harnesses will be stored under, so discovered agents reference harnesses by
+// the harness's relative path within the same source. Stored object names are
+// deterministic (harnessObjectName), and resolveHarnessReferences rewrites
+// each path reference to that name before anything is persisted. A reference
+// that already carries the harness ID prefix is passed through untouched — it
+// names a harness registered outside the source.
+package agentcatalog
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/obot-platform/nah/pkg/name"
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/logger"
+	gitpkg "github.com/obot-platform/obot/pkg/git"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+var log = logger.Package()
+
+const (
+	syncInterval       = time.Hour
+	harnessDefinition  = "harness.yaml"
+	agentDefinition    = "agent.yaml"
+	maxDefinitionBytes = 1024 * 1024
+	maxDefinitions     = 1000
+)
+
+// fetchedSource is what a real fetcher would hand back: a checked out copy of
+// the repository plus the commit it resolved to.
+type fetchedSource struct {
+	RepoRoot  string
+	CommitSHA string
+	Cleanup   func()
+}
+
+type sourceFetcher interface {
+	Fetch(ctx context.Context, repoURL, ref string) (*fetchedSource, error)
+}
+
+type gitSourceFetcher struct{}
+
+func (gitSourceFetcher) Fetch(ctx context.Context, repoURL, ref string) (*fetchedSource, error) {
+	if localPath, ok, err := localRepositoryPath(repoURL); err != nil {
+		return nil, err
+	} else if ok {
+		return fetchLocalRepository(localPath, ref)
+	}
+
+	dir, commitSHA, cleanup, err := gitpkg.Clone(ctx, repoURL, "", ref)
+	if err != nil {
+		return nil, err
+	}
+	return &fetchedSource{
+		RepoRoot:  dir,
+		CommitSHA: commitSHA,
+		Cleanup:   cleanup,
+	}, nil
+}
+
+type Handler struct {
+	fetcher sourceFetcher
+	now     func() time.Time
+}
+
+func New() *Handler {
+	return &Handler{
+		fetcher: gitSourceFetcher{},
+		now:     time.Now,
+	}
+}
+
+func (h *Handler) Sync(req router.Request, resp router.Response) error {
+	source := req.Object.(*v1.AgentCatalog)
+	namespace := source.Namespace
+
+	forceSync := source.Annotations[v1.AgentCatalogSyncAnnotation] == "true"
+	// A source observed by the former placeholder fetcher has a sync time but
+	// no resolved commit. Do not throttle it after upgrading to the real
+	// backend; reconcile it immediately.
+	if !forceSync && source.Status.ResolvedCommitSHA != "" && !source.Status.LastSyncTime.IsZero() {
+		timeSinceLastSync := h.now().Sub(source.Status.LastSyncTime.Time)
+		if timeSinceLastSync < syncInterval {
+			resp.RetryAfter(syncInterval - timeSinceLastSync)
+			return nil
+		}
+	}
+
+	source.Status.IsSyncing = true
+	if err := req.Client.Status().Update(req.Ctx, source); err != nil {
+		return fmt.Errorf("failed to mark agent catalog syncing: %w", err)
+	}
+
+	defer h.clearIsSyncing(req.Ctx, req.Client, namespace, source.Name)
+
+	fetched, err := h.fetcher.Fetch(req.Ctx, source.Spec.RepoURL, source.Spec.Ref)
+	if err != nil {
+		if statusErr := h.recordFailure(req.Ctx, req.Client, namespace, source.Name, err); statusErr != nil {
+			return statusErr
+		}
+		resp.RetryAfter(syncInterval)
+		return nil
+	}
+	defer fetched.Cleanup()
+
+	found, err := buildFromSource(fetched.RepoRoot, source, fetched.CommitSHA)
+	if err == nil {
+		err = resolveHarnessReferences(found.Agents, found.Harnesses)
+	}
+	if err == nil {
+		err = syncDiscovered(req.Ctx, req.Client, namespace, source.Name, found)
+	}
+	if err != nil {
+		if statusErr := h.recordFailure(req.Ctx, req.Client, namespace, source.Name, err); statusErr != nil {
+			return statusErr
+		}
+		resp.RetryAfter(syncInterval)
+		return nil
+	}
+
+	if err := h.recordSuccess(req.Ctx, req.Client, namespace, source.Name, fetched.CommitSHA, len(found.Agents), len(found.Harnesses)); err != nil {
+		return err
+	}
+
+	if forceSync {
+		if err := clearSyncAnnotation(req.Ctx, req.Client, namespace, source.Name); err != nil {
+			return err
+		}
+	}
+
+	resp.RetryAfter(syncInterval)
+	return nil
+}
+
+// discovered is everything one sync of a source yields: harnesses and the
+// agents built on them.
+type discovered struct {
+	Harnesses []*v1.Harness
+	Agents    []*v1.HostedAgent
+}
+
+// buildFromSource recursively discovers strict YAML manifests. Symlinks and
+// .git metadata are ignored so definitions cannot escape the checked-out
+// repository or accidentally ingest Git internals.
+func buildFromSource(repoRoot string, source *v1.AgentCatalog, commitSHA string) (*discovered, error) {
+	definitions, err := discoverDefinitions(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &discovered{}
+	for _, definition := range definitions {
+		relPath, err := filepath.Rel(repoRoot, definition.path)
+		if err != nil {
+			return nil, fmt.Errorf("determine repository-relative definition path: %w", err)
+		}
+		relPath = filepath.ToSlash(relPath)
+
+		switch definition.kind {
+		case harnessDefinition:
+			var manifest types.HarnessManifest
+			if err := readDefinition(definition.path, &manifest); err != nil {
+				return nil, fmt.Errorf("%s: %w", relPath, err)
+			}
+			if err := manifest.Validate(); err != nil {
+				return nil, fmt.Errorf("%s: invalid harness: %w", relPath, err)
+			}
+			result.Harnesses = append(result.Harnesses, &v1.Harness{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "Harness",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      harnessObjectName(source.Name, relPath),
+					Namespace: source.Namespace,
+				},
+				Spec: v1.HarnessSpec{
+					Manifest:     manifest,
+					SourceID:     source.Name,
+					RelativePath: relPath,
+					CommitSHA:    commitSHA,
+				},
+			})
+		case agentDefinition:
+			var manifest types.HostedAgentManifest
+			if err := readDefinition(definition.path, &manifest); err != nil {
+				return nil, fmt.Errorf("%s: %w", relPath, err)
+			}
+			if err := manifest.Validate(); err != nil {
+				return nil, fmt.Errorf("%s: invalid hosted agent: %w", relPath, err)
+			}
+			for _, env := range manifest.Env {
+				if env.Sensitive && env.Value != "" {
+					return nil, fmt.Errorf("%s: sensitive environment value %s must not be stored in source control", relPath, env.Key)
+				}
+			}
+			result.Agents = append(result.Agents, &v1.HostedAgent{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "HostedAgent",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      agentObjectName(source.Name, relPath),
+					Namespace: source.Namespace,
+				},
+				Spec: v1.HostedAgentSpec{
+					Manifest:     manifest,
+					SourceID:     source.Name,
+					RelativePath: relPath,
+					CommitSHA:    commitSHA,
+				},
+			})
+		}
+	}
+
+	return result, nil
+}
+
+type sourceDefinition struct {
+	path string
+	kind string
+}
+
+func discoverDefinitions(repoRoot string) ([]sourceDefinition, error) {
+	var result []sourceDefinition
+	err := filepath.WalkDir(repoRoot, func(currentPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() && entry.Name() == ".git" {
+			return filepath.SkipDir
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		switch entry.Name() {
+		case harnessDefinition, agentDefinition:
+			if len(result) >= maxDefinitions {
+				return fmt.Errorf("too many agent catalog definitions (limit: %d)", maxDefinitions)
+			}
+			result = append(result, sourceDefinition{path: currentPath, kind: entry.Name()})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discover agent catalog definitions: %w", err)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].path < result[j].path
+	})
+	return result, nil
+}
+
+func readDefinition(path string, target any) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open definition: %w", err)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxDefinitionBytes+1))
+	if err != nil {
+		return fmt.Errorf("read definition: %w", err)
+	}
+	if len(content) > maxDefinitionBytes {
+		return fmt.Errorf("definition exceeds maximum size of %d bytes", maxDefinitionBytes)
+	}
+	if err := yaml.UnmarshalStrict(content, target); err != nil {
+		return fmt.Errorf("parse definition: %w", err)
+	}
+	return nil
+}
+
+func localRepositoryPath(repoURL string) (string, bool, error) {
+	repoURL = strings.TrimSpace(repoURL)
+	if filepath.IsAbs(repoURL) {
+		return filepath.Clean(repoURL), true, nil
+	}
+	parsed, err := url.Parse(repoURL)
+	if err != nil {
+		return "", false, fmt.Errorf("parse agent catalog URL: %w", err)
+	}
+	if parsed.Scheme != "file" {
+		return "", false, nil
+	}
+	if parsed.Host != "" && parsed.Host != "localhost" {
+		return "", false, fmt.Errorf("file repository host must be empty or localhost")
+	}
+	path, err := url.PathUnescape(parsed.Path)
+	if err != nil {
+		return "", false, fmt.Errorf("decode file repository path: %w", err)
+	}
+	if !filepath.IsAbs(path) {
+		return "", false, fmt.Errorf("file repository path must be absolute")
+	}
+	return filepath.Clean(path), true, nil
+}
+
+func fetchLocalRepository(repoRoot, ref string) (*fetchedSource, error) {
+	info, err := os.Stat(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("inspect local repository: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("local repository %s is not a directory", repoRoot)
+	}
+
+	repository, err := gogit.PlainOpen(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open local Git repository: %w", err)
+	}
+	head, err := repository.Head()
+	if err != nil {
+		return nil, fmt.Errorf("resolve local repository HEAD: %w", err)
+	}
+	if ref != "" {
+		hash, err := resolveLocalRef(repository, ref)
+		if err != nil {
+			return nil, err
+		}
+		if hash != head.Hash() {
+			return nil, fmt.Errorf("local repository ref %q resolves to %s but the checked-out worktree is at %s; check out the requested ref first", ref, hash, head.Hash())
+		}
+	}
+
+	return &fetchedSource{
+		RepoRoot:  repoRoot,
+		CommitSHA: head.Hash().String(),
+		Cleanup:   func() {},
+	}, nil
+}
+
+func resolveLocalRef(repository *gogit.Repository, ref string) (plumbing.Hash, error) {
+	if plumbing.IsHash(ref) {
+		hash := plumbing.NewHash(ref)
+		if _, err := repository.CommitObject(hash); err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("resolve local repository commit %q: %w", ref, err)
+		}
+		return hash, nil
+	}
+	for _, candidate := range []plumbing.ReferenceName{
+		plumbing.NewBranchReferenceName(ref),
+		plumbing.NewTagReferenceName(ref),
+		plumbing.ReferenceName(ref),
+	} {
+		reference, err := repository.Reference(candidate, true)
+		if err == nil {
+			return reference.Hash(), nil
+		}
+	}
+	return plumbing.ZeroHash, fmt.Errorf("local repository ref %q was not found", ref)
+}
+
+// resolveHarnessReferences rewrites each discovered agent's harness reference
+// to the object name of the harness discovered alongside it. This is the ID
+// alignment step: repositories reference harnesses by relative path because
+// they cannot know generated resource names, and object names are
+// deterministic, so the same path resolves to the same resource on every
+// sync. An unknown reference fails the whole sync — better a visible sync
+// error than a stored agent pointing at nothing.
+func resolveHarnessReferences(agents []*v1.HostedAgent, harnesses []*v1.Harness) error {
+	byPath := make(map[string]string, len(harnesses))
+	for _, harness := range harnesses {
+		byPath[harness.Spec.RelativePath] = harness.Name
+	}
+
+	for _, agent := range agents {
+		ref := agent.Spec.Manifest.HarnessID
+		if ref == "" {
+			return fmt.Errorf("agent %s does not name a harness", agent.Spec.RelativePath)
+		}
+		if strings.HasPrefix(ref, system.HarnessPrefix) {
+			continue
+		}
+		resolved, ok := byPath[ref]
+		if !ok {
+			return fmt.Errorf("agent %s references harness %q, which this source does not contain", agent.Spec.RelativePath, ref)
+		}
+		agent.Spec.Manifest.HarnessID = resolved
+	}
+
+	return nil
+}
+
+// syncDiscovered reconciles both kinds in an order that keeps references
+// intact at every step: new harnesses are stored before the agents that
+// reference them, and stale agents are removed before the harnesses they
+// referenced.
+func syncDiscovered(ctx context.Context, c client.Client, namespace, sourceID string, found *discovered) error {
+	staleHarnesses, err := upsertHarnesses(ctx, c, namespace, sourceID, found.Harnesses)
+	if err != nil {
+		return err
+	}
+
+	if err := upsertAgents(ctx, c, namespace, sourceID, found.Agents); err != nil {
+		return err
+	}
+
+	for _, harness := range staleHarnesses {
+		// A harness the source dropped can still be referenced by an agent
+		// registered outside it. Leave it in place rather than dangling that
+		// agent; it keeps its SourceID, so a later sync retries once the
+		// reference is gone.
+		var agents v1.HostedAgentList
+		if err := c.List(ctx, &agents, client.InNamespace(namespace), client.MatchingFields{"spec.harnessID": harness.Name}); err != nil {
+			return fmt.Errorf("failed to list agents for harness %s: %w", harness.Name, err)
+		}
+		if len(agents.Items) > 0 {
+			log.Infof("keeping harness %s dropped by source %s: still referenced by %d agent(s)", harness.Name, sourceID, len(agents.Items))
+			continue
+		}
+
+		if err := c.Delete(ctx, harness); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete harness %s: %w", harness.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// upsertHarnesses creates and updates the harnesses a source claims. Stale
+// ones — stored for this source but no longer listed by it — are returned
+// rather than deleted, so the caller can remove them after the agents that
+// referenced them are gone. Harnesses registered by hand carry no SourceID
+// and are never listed here, so they are untouched.
+func upsertHarnesses(ctx context.Context, c client.Client, namespace, sourceID string, harnesses []*v1.Harness) ([]*v1.Harness, error) {
+	var list v1.HarnessList
+	if err := c.List(ctx, &list, client.InNamespace(namespace), client.MatchingFields{"spec.sourceID": sourceID}); err != nil {
+		return nil, fmt.Errorf("failed to list harnesses for source: %w", err)
+	}
+
+	existing := make(map[string]*v1.Harness, len(list.Items))
+	for i := range list.Items {
+		existing[list.Items[i].Name] = &list.Items[i]
+	}
+
+	desired := make(map[string]struct{}, len(harnesses))
+	for _, harness := range harnesses {
+		desired[harness.Name] = struct{}{}
+
+		current, ok := existing[harness.Name]
+		if !ok {
+			if err := c.Create(ctx, harness); err != nil {
+				return nil, fmt.Errorf("failed to create harness %s: %w", harness.Name, err)
+			}
+			continue
+		}
+
+		current.Spec = harness.Spec
+		if err := c.Update(ctx, current); err != nil {
+			return nil, fmt.Errorf("failed to update harness %s: %w", harness.Name, err)
+		}
+	}
+
+	var stale []*v1.Harness
+	for objectName, current := range existing {
+		if _, ok := desired[objectName]; !ok {
+			stale = append(stale, current)
+		}
+	}
+	return stale, nil
+}
+
+// harnessObjectName and agentObjectName give discovered resources stable,
+// deterministic names, copying the skillrepository scheme: the visible
+// portion is sanitized for RFC 1123, and a hash over the raw inputs keeps
+// paths that sanitize identically from colliding.
+func harnessObjectName(sourceID, relPath string) string {
+	return sourceObjectName(system.HarnessPrefix, sourceID, relPath)
+}
+
+func agentObjectName(sourceID, relPath string) string {
+	return sourceObjectName(system.HostedAgentPrefix, sourceID, relPath)
+}
+
+func sourceObjectName(prefix, sourceID, relPath string) string {
+	fragment := sanitizeNameFragment(relPath)
+	if fragment == "" {
+		fragment = "item"
+	}
+	d := sha256.New()
+	for _, part := range []string{prefix, sourceID, fragment, relPath} {
+		d.Write([]byte(part))
+		d.Write([]byte{0})
+	}
+	suffix := hex.EncodeToString(d.Sum(nil))[:8]
+	return name.SafeConcatName(prefix, sourceID, fragment, suffix)
+}
+
+func sanitizeNameFragment(value string) string {
+	replacer := strings.NewReplacer("/", "-", "_", "-", ".", "-", " ", "-")
+	value = strings.ToLower(replacer.Replace(value))
+
+	var b strings.Builder
+	lastDash := false
+	for _, ch := range value {
+		valid := (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')
+		if valid {
+			b.WriteRune(ch)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	return strings.Trim(b.String(), "-")
+}
+
+// upsertAgents reconciles the agents a source claims against the ones already
+// stored for it: create what is new, update what changed, delete what the source
+// no longer lists. Agents registered by hand carry no SourceID and are never
+// listed here, so they are untouched.
+func upsertAgents(ctx context.Context, c client.Client, namespace, sourceID string, agents []*v1.HostedAgent) error {
+	existing, err := listAgentsForSource(ctx, c, namespace, sourceID)
+	if err != nil {
+		return err
+	}
+
+	desired := make(map[string]*v1.HostedAgent, len(agents))
+	for _, agent := range agents {
+		desired[agent.Name] = agent
+	}
+
+	for _, agent := range agents {
+		current, ok := existing[agent.Name]
+		if !ok {
+			if err := c.Create(ctx, agent); err != nil {
+				return fmt.Errorf("failed to create hosted agent %s: %w", agent.Name, err)
+			}
+			continue
+		}
+
+		current.Spec = agent.Spec
+		if err := c.Update(ctx, current); err != nil {
+			return fmt.Errorf("failed to update hosted agent %s: %w", agent.Name, err)
+		}
+	}
+
+	for objectName, current := range existing {
+		if _, ok := desired[objectName]; ok {
+			continue
+		}
+		if err := c.Delete(ctx, current); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete hosted agent %s: %w", objectName, err)
+		}
+	}
+
+	return nil
+}
+
+func listAgentsForSource(ctx context.Context, c client.Client, namespace, sourceID string) (map[string]*v1.HostedAgent, error) {
+	var list v1.HostedAgentList
+	if err := c.List(ctx, &list, client.InNamespace(namespace), client.MatchingFields{"spec.sourceID": sourceID}); err != nil {
+		return nil, fmt.Errorf("failed to list agents for source: %w", err)
+	}
+
+	result := make(map[string]*v1.HostedAgent, len(list.Items))
+	for i := range list.Items {
+		result[list.Items[i].Name] = &list.Items[i]
+	}
+	return result, nil
+}
+
+func (h *Handler) recordFailure(ctx context.Context, c client.Client, namespace, name string, syncErr error) error {
+	var source v1.AgentCatalog
+	if err := c.Get(ctx, router.Key(namespace, name), &source); err != nil {
+		return fmt.Errorf("failed to reload agent catalog: %w", err)
+	}
+
+	source.Status.LastSyncTime = metav1.NewTime(h.now())
+	source.Status.SyncError = syncErr.Error()
+	return c.Status().Update(ctx, &source)
+}
+
+func (h *Handler) recordSuccess(ctx context.Context, c client.Client, namespace, sourceName, commitSHA string, agentCount, harnessCount int) error {
+	var source v1.AgentCatalog
+	if err := c.Get(ctx, router.Key(namespace, sourceName), &source); err != nil {
+		return fmt.Errorf("failed to reload agent catalog: %w", err)
+	}
+
+	source.Status.LastSyncTime = metav1.NewTime(h.now())
+	source.Status.SyncError = ""
+	source.Status.ResolvedCommitSHA = commitSHA
+	source.Status.DiscoveredAgentCount = agentCount
+	source.Status.DiscoveredHarnessCount = harnessCount
+	return c.Status().Update(ctx, &source)
+}
+
+func (h *Handler) clearIsSyncing(ctx context.Context, c client.Client, namespace, name string) {
+	var source v1.AgentCatalog
+	if err := c.Get(ctx, router.Key(namespace, name), &source); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Errorf("failed to reload agent catalog %s to clear syncing bit: %v", name, err)
+		}
+		return
+	}
+
+	if !source.Status.IsSyncing {
+		return
+	}
+
+	source.Status.IsSyncing = false
+	if err := c.Status().Update(ctx, &source); err != nil && !apierrors.IsNotFound(err) {
+		log.Errorf("failed to clear syncing bit for agent catalog %s: %v", name, err)
+	}
+}
+
+func clearSyncAnnotation(ctx context.Context, c client.Client, namespace, name string) error {
+	var source v1.AgentCatalog
+	if err := c.Get(ctx, router.Key(namespace, name), &source); err != nil {
+		return fmt.Errorf("failed to reload agent catalog for annotation cleanup: %w", err)
+	}
+
+	if source.Annotations == nil {
+		return nil
+	}
+	if _, ok := source.Annotations[v1.AgentCatalogSyncAnnotation]; !ok {
+		return nil
+	}
+
+	delete(source.Annotations, v1.AgentCatalogSyncAnnotation)
+	return c.Update(ctx, &source)
+}

--- a/pkg/controller/handlers/agentcatalog/agentcatalog_test.go
+++ b/pkg/controller/handlers/agentcatalog/agentcatalog_test.go
@@ -1,0 +1,225 @@
+package agentcatalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestBuildFromSource(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "harnesses", "basic"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "agents", "reviewer"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "harnesses", "basic", harnessDefinition), []byte(`
+name: Basic
+description: Test harness
+image: ubuntu:24.04
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "agents", "reviewer", agentDefinition), []byte(`
+name: Reviewer
+description: Reviews code
+harnessID: harnesses/basic/harness.yaml
+questions:
+  - key: focus
+    type: string
+`), 0o600))
+	// Other YAML files are not agent-catalog definitions, matching the explicit
+	// filename convention while retaining MCP catalog-style recursive loading.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ignored.yaml"), []byte("not: a definition"), 0o600))
+
+	source := &v1.AgentCatalog{
+		ObjectMeta: metav1.ObjectMeta{Name: "as1source", Namespace: "default"},
+	}
+	found, err := buildFromSource(root, source, "abc123")
+	require.NoError(t, err)
+	require.Len(t, found.Harnesses, 1)
+	require.Len(t, found.Agents, 1)
+
+	harness := found.Harnesses[0]
+	assert.Equal(t, "Basic", harness.Spec.Manifest.Name)
+	assert.Equal(t, "harnesses/basic/harness.yaml", harness.Spec.RelativePath)
+	assert.Equal(t, "abc123", harness.Spec.CommitSHA)
+	assert.Equal(t, source.Name, harness.Spec.SourceID)
+
+	agent := found.Agents[0]
+	assert.Equal(t, "Reviewer", agent.Spec.Manifest.Name)
+	assert.Equal(t, "agents/reviewer/agent.yaml", agent.Spec.RelativePath)
+	assert.Equal(t, "harnesses/basic/harness.yaml", agent.Spec.Manifest.HarnessID)
+
+	require.NoError(t, resolveHarnessReferences(found.Agents, found.Harnesses))
+	assert.Equal(t, harness.Name, agent.Spec.Manifest.HarnessID)
+}
+
+func TestBuildFromSourceRejectsInvalidDefinitions(t *testing.T) {
+	t.Run("unknown field", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, harnessDefinition), []byte(`
+name: Basic
+image: ubuntu:24.04
+unknown: value
+`), 0o600))
+
+		_, err := buildFromSource(root, &v1.AgentCatalog{
+			ObjectMeta: metav1.ObjectMeta{Name: "as1source"},
+		}, "abc123")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown field "unknown"`)
+	})
+
+	t.Run("sensitive value", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, agentDefinition), []byte(`
+name: Unsafe
+harnessID: hrn1external
+env:
+  - key: TOKEN
+    sensitive: true
+    value: do-not-commit
+`), 0o600))
+
+		_, err := buildFromSource(root, &v1.AgentCatalog{
+			ObjectMeta: metav1.ObjectMeta{Name: "as1source"},
+		}, "abc123")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not be stored in source control")
+	})
+}
+
+func TestDiscoverDefinitionsSkipsGitAndSymlinks(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".git", agentDefinition), []byte("name: ignored"), 0o600))
+	target := filepath.Join(root, "outside.yaml")
+	require.NoError(t, os.WriteFile(target, []byte("name: ignored"), 0o600))
+	require.NoError(t, os.Symlink(target, filepath.Join(root, harnessDefinition)))
+
+	definitions, err := discoverDefinitions(root)
+	require.NoError(t, err)
+	assert.Empty(t, definitions)
+}
+
+func TestGitSourceFetcherLocalRepository(t *testing.T) {
+	root := t.TempDir()
+	repository, err := gogit.PlainInit(root, false)
+	require.NoError(t, err)
+	worktree, err := repository.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(root, harnessDefinition), []byte("name: Basic\nimage: ubuntu:24.04\n"), 0o600))
+	_, err = worktree.Add(harnessDefinition)
+	require.NoError(t, err)
+	commit, err := worktree.Commit("initial", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com"},
+	})
+	require.NoError(t, err)
+
+	fetcher := gitSourceFetcher{}
+	for _, repoURL := range []string{root, "file://" + filepath.ToSlash(root)} {
+		fetched, err := fetcher.Fetch(t.Context(), repoURL, "")
+		require.NoError(t, err)
+		assert.Equal(t, root, fetched.RepoRoot)
+		assert.Equal(t, commit.String(), fetched.CommitSHA)
+		fetched.Cleanup()
+	}
+}
+
+func discoveredHarness(sourceID, relPath string) *v1.Harness {
+	return &v1.Harness{
+		ObjectMeta: metav1.ObjectMeta{Name: harnessObjectName(sourceID, relPath)},
+		Spec: v1.HarnessSpec{
+			SourceID:     sourceID,
+			RelativePath: relPath,
+		},
+	}
+}
+
+func discoveredAgent(sourceID, relPath, harnessRef string) *v1.HostedAgent {
+	agent := &v1.HostedAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: agentObjectName(sourceID, relPath)},
+		Spec: v1.HostedAgentSpec{
+			SourceID:     sourceID,
+			RelativePath: relPath,
+		},
+	}
+	agent.Spec.Manifest.HarnessID = harnessRef
+	return agent
+}
+
+func TestResolveHarnessReferences(t *testing.T) {
+	t.Run("path reference resolves to the harness object name", func(t *testing.T) {
+		harness := discoveredHarness("as1src", "harnesses/claude-code")
+		agent := discoveredAgent("as1src", "agents/reviewer", "harnesses/claude-code")
+
+		require.NoError(t, resolveHarnessReferences([]*v1.HostedAgent{agent}, []*v1.Harness{harness}))
+		assert.Equal(t, harness.Name, agent.Spec.Manifest.HarnessID)
+	})
+
+	t.Run("full harness ID passes through untouched", func(t *testing.T) {
+		ref := system.HarnessPrefix + "abcdef"
+		agent := discoveredAgent("as1src", "agents/reviewer", ref)
+
+		require.NoError(t, resolveHarnessReferences([]*v1.HostedAgent{agent}, nil))
+		assert.Equal(t, ref, agent.Spec.Manifest.HarnessID)
+	})
+
+	t.Run("unknown path reference fails the sync", func(t *testing.T) {
+		harness := discoveredHarness("as1src", "harnesses/claude-code")
+		agent := discoveredAgent("as1src", "agents/reviewer", "harnesses/missing")
+
+		err := resolveHarnessReferences([]*v1.HostedAgent{agent}, []*v1.Harness{harness})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "harnesses/missing")
+		assert.Contains(t, err.Error(), "agents/reviewer")
+	})
+
+	t.Run("missing reference fails the sync", func(t *testing.T) {
+		agent := discoveredAgent("as1src", "agents/reviewer", "")
+
+		err := resolveHarnessReferences([]*v1.HostedAgent{agent}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not name a harness")
+	})
+}
+
+func TestSourceObjectNames(t *testing.T) {
+	t.Run("deterministic across syncs", func(t *testing.T) {
+		assert.Equal(t,
+			harnessObjectName("as1src", "harnesses/claude-code"),
+			harnessObjectName("as1src", "harnesses/claude-code"),
+			"the same definition must map to the same resource on every sync")
+	})
+
+	t.Run("kinds and paths do not collide", func(t *testing.T) {
+		names := []string{
+			harnessObjectName("as1src", "tools/my_thing"),
+			// Sanitizes to the same visible fragment; the hash must separate them.
+			harnessObjectName("as1src", "tools/my-thing"),
+			harnessObjectName("as1other", "tools/my_thing"),
+			agentObjectName("as1src", "tools/my_thing"),
+		}
+		seen := make(map[string]struct{}, len(names))
+		for _, n := range names {
+			if _, ok := seen[n]; ok {
+				t.Fatalf("duplicate object name %q", n)
+			}
+			seen[n] = struct{}{}
+		}
+	})
+
+	t.Run("names carry the kind prefix and are valid", func(t *testing.T) {
+		harnessName := harnessObjectName("as1src", "härness/…weird path")
+		agentName := agentObjectName("as1src", "härness/…weird path")
+		assert.True(t, len(harnessName) > len(system.HarnessPrefix) && harnessName[:len(system.HarnessPrefix)] == system.HarnessPrefix)
+		assert.True(t, len(agentName) > len(system.HostedAgentPrefix) && agentName[:len(system.HostedAgentPrefix)] == system.HostedAgentPrefix)
+		assert.Empty(t, validation.IsDNS1123Subdomain(harnessName))
+		assert.Empty(t, validation.IsDNS1123Subdomain(agentName))
+	})
+}

--- a/pkg/controller/handlers/auditlogexport/auditlogexport_test.go
+++ b/pkg/controller/handlers/auditlogexport/auditlogexport_test.go
@@ -389,7 +389,7 @@ func TestAuditLogOptionsDefaultsToMCPOnly(t *testing.T) {
 	}
 }
 
-// TestAuditLogOptionsMapsLocalAgentFilters proves local-agent source type and filters are passed
+// TestAuditLogOptionsMapsLocalAgentFilters proves local-agent catalog type and filters are passed
 // through to the gateway query when a caller explicitly opts in.
 func TestAuditLogOptionsMapsLocalAgentFilters(t *testing.T) {
 	opts := mcpAuditLogOptionsFromExport(exportWithFilters(types.AuditLogExportFilters{
@@ -402,7 +402,7 @@ func TestAuditLogOptionsMapsLocalAgentFilters(t *testing.T) {
 	}, true), 100, 0)
 
 	if len(opts.SourceTypes) != 1 || opts.SourceTypes[0] != types.AuditLogSourceTypeLocalAgentToolCall {
-		t.Fatalf("expected local-agent source type, got %v", opts.SourceTypes)
+		t.Fatalf("expected local-agent catalog type, got %v", opts.SourceTypes)
 	}
 	if len(opts.AgentProvider) != 1 || opts.AgentProvider[0] != string(types.LocalAgentProviderClaudeCode) {
 		t.Fatalf("expected agent provider filter to pass through, got %v", opts.AgentProvider)

--- a/pkg/controller/handlers/cleanup/user.go
+++ b/pkg/controller/handlers/cleanup/user.go
@@ -1,9 +1,11 @@
 package cleanup
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 
 	"github.com/obot-platform/nah/pkg/router"
@@ -12,8 +14,13 @@ import (
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	hostedAgentPoolCleanupAnnotation = "obot.obot.ai/user-delete-hosted-agent-pools"
 )
 
 type UserCleanup struct {
@@ -32,6 +39,14 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 	userDelete := req.Object.(*v1.UserDelete)
 	userID := strconv.FormatUint(uint64(userDelete.Spec.UserID), 10)
 	log.Infof("Starting user cleanup: userID=%s", userID)
+
+	complete, err := cleanupHostedAgents(req, userDelete, userID)
+	if err != nil {
+		return err
+	}
+	if !complete {
+		return nil
+	}
 
 	// Delete identities first so that the user can login again.
 	identities, err := u.gatewayClient.FindIdentitiesForUser(req.Ctx, userDelete.Spec.UserID)
@@ -173,4 +188,124 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 	// If everything is cleaned up successfully, then delete this object because we don't need it.
 	log.Infof("Completed user cleanup: userID=%s", userID)
 	return req.Delete(userDelete)
+}
+
+// cleanupHostedAgents orders deletion so backend finalizers have all of the
+// references they need: instances, assignments, then exclusively owned
+// pools. Pool IDs are checkpointed on UserDelete metadata before
+// assignments are removed, allowing cleanup to wait across reconciliations
+// until asynchronous pool deletion has actually completed.
+func cleanupHostedAgents(req router.Request, userDelete *v1.UserDelete, userID string) (bool, error) {
+	var instances v1.HostedAgentInstanceList
+	if err := req.List(&instances, &kclient.ListOptions{
+		Namespace: req.Namespace,
+		FieldSelector: fields.SelectorFromSet(map[string]string{
+			"spec.userID": userID,
+		}),
+	}); err != nil {
+		return false, err
+	}
+	if len(instances.Items) > 0 {
+		for i := range instances.Items {
+			if err := req.Delete(&instances.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+				return false, err
+			}
+		}
+		log.Infof("Waiting for hosted agent instance cleanup: userID=%s instances=%d", userID, len(instances.Items))
+		return false, nil
+	}
+
+	poolIDs, err := savedPoolIDs(userDelete)
+	if err != nil {
+		return false, err
+	}
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, &kclient.ListOptions{
+		Namespace: req.Namespace,
+		FieldSelector: fields.SelectorFromSet(map[string]string{
+			"spec.userID": userID,
+		}),
+	}); err != nil {
+		return false, err
+	}
+
+	changed := false
+	for _, assignment := range assignments.Items {
+		if !slices.Contains(poolIDs, assignment.Spec.Manifest.PoolID) {
+			poolIDs = append(poolIDs, assignment.Spec.Manifest.PoolID)
+			changed = true
+		}
+	}
+	if changed {
+		sort.Strings(poolIDs)
+		data, err := json.Marshal(poolIDs)
+		if err != nil {
+			return false, fmt.Errorf("marshal hosted agent pool cleanup checkpoint: %w", err)
+		}
+		if userDelete.Annotations == nil {
+			userDelete.Annotations = map[string]string{}
+		}
+		userDelete.Annotations[hostedAgentPoolCleanupAnnotation] = string(data)
+		if err := req.Client.Update(req.Ctx, userDelete); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	if len(assignments.Items) > 0 {
+		for i := range assignments.Items {
+			if err := req.Delete(&assignments.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+				return false, err
+			}
+		}
+		log.Infof("Waiting for hosted agent pool assignment cleanup: userID=%s assignments=%d", userID, len(assignments.Items))
+		return false, nil
+	}
+
+	waiting := false
+	for _, poolID := range poolIDs {
+		var remainingAssignments v1.HostedAgentPoolAssignmentList
+		if err := req.List(&remainingAssignments, &kclient.ListOptions{
+			Namespace: req.Namespace,
+			FieldSelector: fields.SelectorFromSet(map[string]string{
+				"spec.poolID": poolID,
+			}),
+		}); err != nil {
+			return false, err
+		}
+		if len(remainingAssignments.Items) > 0 {
+			// Another user still references this pool. Ownership is
+			// shared, so this user's deletion must leave it intact.
+			continue
+		}
+
+		var pool v1.HostedAgentPool
+		if err := req.Get(&pool, req.Namespace, poolID); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return false, err
+		}
+		waiting = true
+		if err := req.Delete(&pool); err != nil && !apierrors.IsNotFound(err) {
+			return false, err
+		}
+	}
+	if waiting {
+		log.Infof("Waiting for hosted agent pool cleanup: userID=%s pools=%d", userID, len(poolIDs))
+		return false, nil
+	}
+	return true, nil
+}
+
+func savedPoolIDs(userDelete *v1.UserDelete) ([]string, error) {
+	value := userDelete.Annotations[hostedAgentPoolCleanupAnnotation]
+	if value == "" {
+		return nil, nil
+	}
+	var result []string
+	if err := json.Unmarshal([]byte(value), &result); err != nil {
+		return nil, fmt.Errorf("parse hosted agent pool cleanup checkpoint: %w", err)
+	}
+	return result, nil
 }

--- a/pkg/controller/handlers/cleanup/user_test.go
+++ b/pkg/controller/handlers/cleanup/user_test.go
@@ -1,0 +1,39 @@
+package cleanup
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSavedPoolIDs(t *testing.T) {
+	userDelete := &v1.UserDelete{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				hostedAgentPoolCleanupAnnotation: `["pool-a","pool-b"]`,
+			},
+		},
+	}
+	got, err := savedPoolIDs(userDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"pool-a", "pool-b"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("pool IDs = %#v, want %#v", got, want)
+	}
+}
+
+func TestSavedPoolIDsRejectsInvalidCheckpoint(t *testing.T) {
+	userDelete := &v1.UserDelete{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				hostedAgentPoolCleanupAnnotation: "not-json",
+			},
+		},
+	}
+	if _, err := savedPoolIDs(userDelete); err == nil {
+		t.Fatal("expected invalid cleanup checkpoint to fail")
+	}
+}

--- a/pkg/controller/handlers/hostedagent/README.md
+++ b/pkg/controller/handlers/hostedagent/README.md
@@ -1,0 +1,28 @@
+# Hosted agent instance reconciliation
+
+`HostedAgentInstance` resources are reconciled through `pkg/agentbackend`.
+The controller owns Obot-specific resolution and passes only normalized,
+runtime-ready configuration to the selected backend.
+
+The controller:
+
+- validates an explicitly selected pool against the user's assignments;
+- selects the user's default assignment, or lazily creates a deterministic
+  pool and default assignment from the deployment-wide `default`
+  `HostedAgentPoolDefaults`;
+- uses the instance UID as the stable backend identity;
+- installs a finalizer before creating backend resources;
+- calculates an Obot-owned revision from desired runtime configuration;
+- reports an instance ready only when the backend has applied that revision;
+- retains the first healthy runtime URL across later state changes;
+- polls transitional instances every ten seconds and ready instances every
+  five minutes, so backend events are an optimization rather than a
+  correctness requirement; and
+- removes its finalizer only after the backend confirms deletion is complete.
+
+The default builder currently renders the versioned
+`/etc/obot/agent.json`, non-sensitive environment, harness image, and source
+repository. Sensitive values are deliberately excluded. Resolution of MCP
+gateway endpoints, model proxy endpoints, skill file trees, and backend secret
+references belongs in the builder and can be added without changing the
+backend interface or lifecycle controller.

--- a/pkg/controller/handlers/hostedagent/config.go
+++ b/pkg/controller/handlers/hostedagent/config.go
@@ -1,0 +1,242 @@
+package hostedagent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/obot-platform/obot/pkg/hostedagentmodels"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// agentConfig is the whole of what a sandbox is told, written to
+// /etc/obot/agent.json at start-up.
+//
+// Every endpoint in it is a complete URL, so an image boots by reading this
+// file and needs to know nothing about Obot -- not its address, not its
+// routing, not that it is Obot at all. An image that had to assemble a URL from
+// a base and an ID would be coupled to Obot's routes and would break the moment
+// they changed.
+//
+// It carries no credentials. Those live in a second file, named by SecretsFile
+// and readable only by the agent, so that this one can be world-readable and
+// safely inspected, logged or copied without leaking a token.
+type agentConfig struct {
+	Version  string          `json:"version"`
+	Instance agentConfigMeta `json:"instance"`
+
+	// SecretsFile is where the credentials for the endpoints below are kept.
+	// An agent merges the two by ID; see agentSecrets.
+	SecretsFile string `json:"secretsFile,omitempty"`
+
+	// Workspace is the writable directory that survives a restart.
+	Workspace string `json:"workspace,omitempty"`
+	// Source is the repository to check out, if the agent or user chose one.
+	Source *agentConfigSource `json:"source,omitempty"`
+	// ListenPort is set when the agent is expected to serve HTTP.
+	ListenPort int `json:"listenPort,omitempty"`
+	// PublicPath is the path prefix the agent is published under, and PublicURL
+	// the whole address. Both are set only when the agent serves HTTP.
+	//
+	// An agent is not reached at its own root: Obot mounts it under a prefix and
+	// strips that prefix before forwarding. A server that does not know this
+	// builds links and API calls against the root, which land outside its own
+	// prefix -- a single-page UI ends up calling Obot instead of itself.
+	// X-Forwarded-Prefix says the same thing per request, but a server that
+	// needs it at start-up, to bake into the page it serves, cannot use a header.
+	PublicPath string `json:"publicPath,omitempty"`
+	PublicURL  string `json:"publicURL,omitempty"`
+
+	// ObotURL is Obot itself, at the address this sandbox reaches it on. The
+	// endpoints below are already absolute, so an agent needs this only for
+	// what they do not cover -- calling Obot's API directly with the credential
+	// it was issued.
+	//
+	// It is deliberately not PublicURL's host: the public address is the one a
+	// browser uses, and is commonly not routable from inside the cluster.
+	// Answering "where is Obot" with the browser's answer is what breaks a
+	// sandbox that then cannot reach its own models.
+	ObotURL string `json:"obotURL,omitempty"`
+
+	MCPServers []agentConfigMCPServer `json:"mcpServers,omitempty"`
+	Models     []agentConfigModel     `json:"models,omitempty"`
+	Skills     []agentConfigSkill     `json:"skills,omitempty"`
+
+	// Answers are the user's responses to the agent's questions. Sensitive
+	// answers are excluded.
+	Answers map[string]string `json:"answers,omitempty"`
+}
+
+type agentConfigMeta struct {
+	ID     string `json:"id"`
+	UserID string `json:"userID"`
+	Name   string `json:"name,omitempty"`
+}
+
+type agentConfigSource struct {
+	URL string `json:"url"`
+	// Ref is a branch, tag or commit. Empty means the default branch.
+	Ref    string `json:"ref,omitempty"`
+	Subdir string `json:"subdir,omitempty"`
+}
+
+type agentConfigMCPServer struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+	// URL is complete and ready to connect to.
+	URL string `json:"url"`
+	// Transport names the wire protocol so a client can configure itself
+	// without guessing from the URL shape.
+	Transport string `json:"transport"`
+	// Headers holds only non-sensitive headers. Anything carrying a credential
+	// is in the secrets file under the same ID.
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type agentConfigModel struct {
+	// ID is Obot's identifier; Model is the name to send on the wire.
+	ID    string `json:"id,omitempty"`
+	Model string `json:"model"`
+	// APIs are the wire protocols this model accepts: "anthropic",
+	// "openai-responses", "openai-chat-completions". An image picks a model it
+	// can speak to; a client written for one format cannot use another, and a
+	// model is often reachable over more than one. Provider is the underlying
+	// Obot model provider, present for diagnostics rather than for dispatch.
+	APIs     []string `json:"apis"`
+	Provider string   `json:"provider,omitempty"`
+	// BaseURL is the root of Obot's proxy for this provider, carrying no API
+	// version. The version belongs to the protocol the client speaks, not to
+	// the routing: an Anthropic client appends /v1/messages to it, while an
+	// OpenAI one treats /v1 as part of its base and appends /responses. Naming
+	// a version here would pick one of those conventions for every client, and
+	// could not express a provider moving to /v2 without a new field.
+	BaseURL string `json:"baseURL"`
+	// There is deliberately no API key here: it is in the secrets file, keyed by
+	// Provider, since that is what decides the endpoint the key is sent to.
+
+	// Default marks the model to reach for when an image wants one. It is a
+	// hint, not a restriction: the agent may use any model listed here, and it
+	// exists because a bare list gives an image no way to choose.
+	Default bool `json:"default,omitempty"`
+}
+
+type agentConfigSkill struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+	// Path is a directory in the sandbox holding the skill's files.
+	Path        string `json:"path"`
+	Description string `json:"description,omitempty"`
+}
+
+// agentSecrets is the credential half of the contract, keyed by the same IDs
+// used in agentConfig so the two merge without further lookup.
+//
+// It is a separate file so that the configuration an agent needs to read --
+// endpoints, skills, answers -- carries no secret, and only this one has to be
+// protected.
+type agentSecrets struct {
+	Version    string                    `json:"version"`
+	MCPServers map[string]agentSecretMCP `json:"mcpServers,omitempty"`
+	// ModelProviders is keyed by model provider, not by model. A credential
+	// belongs to the endpoint it is sent to, and every model from one provider
+	// shares an endpoint -- keying by model repeated the same value once per
+	// model, which on an installation with a large catalogue meant hundreds of
+	// copies of one string.
+	ModelProviders map[string]agentSecretModelProvider `json:"modelProviders,omitempty"`
+}
+
+type agentSecretMCP struct {
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+type agentSecretModelProvider struct {
+	APIKey string `json:"apiKey,omitempty"`
+}
+
+// transportStreamableHTTP is what the MCP gateway speaks.
+const transportStreamableHTTP = "streamable-http"
+
+// mcpServerConfig builds a ready-to-use connection for each MCP server the
+// agent was granted.
+func mcpServerConfigs(serverURL string, ids []string) []agentConfigMCPServer {
+	servers := make([]agentConfigMCPServer, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		servers = append(servers, agentConfigMCPServer{
+			ID:        id,
+			Name:      id,
+			URL:       fmt.Sprintf("%s/mcp-connect/%s", strings.TrimSuffix(serverURL, "/"), id),
+			Transport: transportStreamableHTTP,
+		})
+	}
+	return servers
+}
+
+// modelConfigs resolves what the agent may use into complete endpoints.
+//
+// Resolution is shared with the API, which uses the same answer to decide
+// whether an agent can be launched at all. If the two disagreed, a user could
+// be offered an agent that then resolves no models.
+func modelConfigs(ctx context.Context, client kclient.Client, namespace, serverURL string, selections, providers []string) ([]agentConfigModel, error) {
+	resolved, err := hostedagentmodels.Resolve(ctx, client, namespace, selections, providers)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultID := hostedagentmodels.Default(ctx, client, namespace, resolved)
+	models := make([]agentConfigModel, 0, len(resolved))
+	for _, model := range resolved {
+		path, ok := hostedagentmodels.ProxyPath(model.Provider)
+		if !ok {
+			continue
+		}
+		models = append(models, agentConfigModel{
+			ID:       model.ID,
+			Model:    model.Model,
+			APIs:     model.APIs,
+			Provider: model.Provider,
+			BaseURL:  fmt.Sprintf("%s/api/llm-proxy/%s", strings.TrimSuffix(serverURL, "/"), path),
+			Default:  model.ID == defaultID,
+		})
+	}
+	return models, nil
+}
+
+// buildSecrets pairs every endpoint in the config with the credential it needs.
+//
+// Today all of them use the agent's own credential; keying by ID rather than
+// emitting one shared token means a per-server credential later changes only
+// what is written here, not the contract an image reads.
+func buildSecrets(config agentConfig, credential string) agentSecrets {
+	secrets := agentSecrets{Version: config.Version}
+	if credential == "" {
+		return secrets
+	}
+
+	if len(config.MCPServers) > 0 {
+		secrets.MCPServers = make(map[string]agentSecretMCP, len(config.MCPServers))
+		for _, server := range config.MCPServers {
+			secrets.MCPServers[server.ID] = agentSecretMCP{
+				Headers: map[string]string{"Authorization": "Bearer " + credential},
+			}
+		}
+	}
+	for _, model := range config.Models {
+		if model.Provider == "" {
+			continue
+		}
+		if secrets.ModelProviders == nil {
+			secrets.ModelProviders = map[string]agentSecretModelProvider{}
+		}
+		secrets.ModelProviders[model.Provider] = agentSecretModelProvider{APIKey: credential}
+	}
+	return secrets
+}

--- a/pkg/controller/handlers/hostedagent/configshape_test.go
+++ b/pkg/controller/handlers/hostedagent/configshape_test.go
@@ -1,0 +1,401 @@
+package hostedagent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestAgentConfigShape renders the file a sandbox is actually handed.
+//
+// It doubles as the documented example of the contract: run it with -v to see
+// the full config. Every endpoint in it is absolute and carries its own
+// credential, which is what lets an image boot from this file alone.
+func TestAgentConfigShape(t *testing.T) {
+	client := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(
+			&v1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "m1sonnet", Namespace: "obot"},
+				Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+					Name:          "claude-sonnet",
+					TargetModel:   "claude-sonnet-4-5",
+					ModelProvider: system.AnthropicModelProvider,
+					Active:        true,
+					Usage:         types.ModelUsageLLM,
+				}},
+			},
+			&v1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "m1gpt", Namespace: "obot"},
+				Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+					Name:          "gpt",
+					TargetModel:   "gpt-5",
+					ModelProvider: system.OpenAIModelProvider,
+					Active:        true,
+					Usage:         types.ModelUsageLLM,
+				}},
+			},
+			&v1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: "m1mini", Namespace: "obot"},
+				Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+					Name:          "gpt-mini",
+					TargetModel:   "gpt-5-mini",
+					ModelProvider: system.OpenAIModelProvider,
+					Active:        true,
+					Usage:         types.ModelUsageLLM,
+				}},
+			},
+			&v1.DefaultModelAlias{
+				ObjectMeta: metav1.ObjectMeta{Name: "llm", Namespace: "obot"},
+				Spec:       v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: "llm", Model: "m1sonnet"}},
+			},
+			&v1.DefaultModelAlias{
+				ObjectMeta: metav1.ObjectMeta{Name: "llm-mini", Namespace: "obot"},
+				Spec:       v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: "llm-mini", Model: "m1mini"}},
+			},
+		).
+		Build()
+
+	instance := &v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "hai1g26fc", Namespace: "obot", UID: "d47613e8-aede-42f6-a599-9a641f99d8b7"},
+		Spec: v1.HostedAgentInstanceSpec{
+			UserID: "3",
+			Manifest: types.HostedAgentInstanceManifest{
+				Name:    "my-coding-agent",
+				GitRepo: "https://github.com/example/service.git",
+				GitRef:  "main",
+				Answers: map[string]string{"instruction": "Follow the house style.", "token": "must-not-leak"},
+			},
+		},
+	}
+	agent := &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{
+		Name:             "Claude Code",
+		HarnessID:        "hrn1abc",
+		AllowUserGitRepo: true,
+		MCPServers:       []string{"ms1github", "ms1slack"},
+		Models:           []string{"*"},
+		Terminal:         true,
+		Questions: []types.HostedAgentQuestion{
+			{Key: "instruction"},
+			{Key: "token", Sensitive: true},
+		},
+	}}}
+	harness := &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{
+		Image: "ghcr.io/obot-platform/agent-claude-code:latest", Interactive: true,
+	}}}
+
+	builder := defaultDesiredBuilder{ServerURL: "https://obot.example.com"}
+	desired, err := builder.Build(context.Background(), BuildInput{
+		Client:     client,
+		Namespace:  "obot",
+		Instance:   instance,
+		Agent:      agent,
+		Harness:    harness,
+		Credential: "ok1-3-7-EXAMPLECREDENTIAL",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	var raw, secretsRaw string
+	for _, file := range desired.Files {
+		if file.Path == agentConfigPath {
+			raw = string(file.Content)
+			if file.Mode != 0o444 {
+				t.Errorf("config mode = %o, want 0444: it carries no secret", file.Mode)
+			}
+		}
+	}
+	for _, ref := range desired.Secrets {
+		if ref.FilePath == agentSecretsPath {
+			secretsRaw = ref.Value
+		}
+	}
+	if raw == "" {
+		t.Fatal("no config was delivered")
+	}
+	if secretsRaw == "" {
+		t.Fatal("no secrets file was delivered")
+	}
+
+	// The whole point of the split: nothing in the readable config is a secret.
+	if strings.Contains(raw, "EXAMPLECREDENTIAL") {
+		t.Fatalf("a credential leaked into the world-readable config:\n%s", raw)
+	}
+
+	var pretty2 bytes.Buffer
+	if err := json.Indent(&pretty2, []byte(secretsRaw), "", "  "); err != nil {
+		t.Fatalf("secrets file is not valid JSON: %v", err)
+	}
+	t.Logf("%s\n%s", agentSecretsPath, pretty2.String())
+
+	var secrets agentSecrets
+	if err := json.Unmarshal([]byte(secretsRaw), &secrets); err != nil {
+		t.Fatalf("unmarshal secrets: %v", err)
+	}
+	if secrets.MCPServers["ms1github"].Headers["Authorization"] != "Bearer ok1-3-7-EXAMPLECREDENTIAL" {
+		t.Errorf("mcp credential missing: %+v", secrets.MCPServers)
+	}
+	if secrets.ModelProviders[system.AnthropicModelProvider].APIKey != "ok1-3-7-EXAMPLECREDENTIAL" {
+		t.Errorf("model provider credential missing: %+v", secrets.ModelProviders)
+	}
+	// One entry per provider, not per model. Every model from a provider shares
+	// an endpoint, so a per-model key stored the same string once per model --
+	// 118 copies on this installation's catalogue.
+	if len(secrets.ModelProviders) != 2 {
+		t.Errorf("model provider entries = %d, want 2 (anthropic and openai): %+v",
+			len(secrets.ModelProviders), secrets.ModelProviders)
+	}
+
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, []byte(raw), "", "  "); err != nil {
+		t.Fatalf("config is not valid JSON: %v", err)
+	}
+	t.Logf("%s\n%s", agentConfigPath, pretty.String())
+	if dir := os.Getenv("WRITE_CONFIG_SAMPLE_DIR"); dir != "" {
+		if err := os.WriteFile(dir+"/agent.json", pretty.Bytes(), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(dir+"/secrets.json", []byte(secretsRaw), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var config agentConfig
+	if err := json.Unmarshal([]byte(raw), &config); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Endpoints are complete: an image joins nothing together.
+	if len(config.MCPServers) != 2 {
+		t.Fatalf("mcpServers = %d, want 2", len(config.MCPServers))
+	}
+	for _, server := range config.MCPServers {
+		if !strings.HasPrefix(server.URL, "https://obot.example.com/mcp-connect/") {
+			t.Errorf("%s: url %q is not absolute", server.ID, server.URL)
+		}
+	}
+
+	// Models are resolved to a wire protocol and a base URL, since an
+	// Anthropic-native client and an OpenAI-compatible one are different
+	// clients and nothing in the URL says which.
+	// A "*" grant lists the whole catalogue, so the agent can choose rather
+	// than being held to whatever the template author happened to name.
+	if len(config.Models) != 3 {
+		t.Fatalf("models = %d, want 3 (every model the agent was granted)", len(config.Models))
+	}
+	defaults := 0
+	for _, model := range config.Models {
+		if model.Default {
+			defaults++
+		}
+	}
+	// Exactly one: an image asking for "the default" must get an answer, and
+	// must not have to choose between two.
+	if defaults != 1 {
+		t.Errorf("models marked default = %d, want 1: %+v", defaults, config.Models)
+	}
+	for _, model := range config.Models {
+		if !strings.HasPrefix(model.BaseURL, "https://obot.example.com/api/llm-proxy/") {
+			t.Errorf("%s: incomplete endpoint %+v", model.Model, model)
+		}
+	}
+
+	if config.Source == nil || config.Source.Ref != "main" {
+		t.Errorf("source = %+v", config.Source)
+	}
+	if config.Workspace != workspacePath {
+		t.Errorf("workspace = %q", config.Workspace)
+	}
+	// A sensitive answer is collected from the user but never written into the
+	// sandbox alongside everything else.
+	if _, ok := config.Answers["token"]; ok {
+		t.Error("a sensitive answer reached the sandbox config")
+	}
+	if config.Answers["instruction"] == "" {
+		t.Error("a non-sensitive answer was dropped")
+	}
+}
+
+// The config holds live credentials, so it must be redacted from the desired
+// revision -- which is stored on the instance and visible wherever status is.
+func TestCredentialsNeverReachTheRevision(t *testing.T) {
+	builder := defaultDesiredBuilder{ServerURL: "https://obot.example.com"}
+	desired, err := builder.Build(context.Background(), BuildInput{
+		Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}},
+		Agent: &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{
+			MCPServers: []string{"ms1github"},
+		}}},
+		Harness:    &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+		Credential: "ok1-3-7-EXAMPLECREDENTIAL",
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	redacted, err := json.Marshal(desired.Redacted())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(redacted), "EXAMPLECREDENTIAL") {
+		t.Fatalf("the credential survived redaction: %s", redacted)
+	}
+}
+
+// A changed config has to restart the sandbox, or an agent granted a new MCP
+// server keeps running without it.
+func TestConfigChangeChangesTheRevision(t *testing.T) {
+	build := func(servers ...string) string {
+		t.Helper()
+		desired, err := defaultDesiredBuilder{ServerURL: "https://obot.example.com"}.Build(context.Background(), BuildInput{
+			Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}},
+			Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{MCPServers: servers}}},
+			Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return desired.Revision
+	}
+
+	if build("ms1github") == build("ms1github", "ms1slack") {
+		t.Fatal("adding an MCP server left the revision unchanged, so the sandbox would not restart")
+	}
+}
+
+// An agent behind a path prefix has to know it. Obot strips the prefix before
+// forwarding, so a server told nothing builds links and API calls against its
+// own root -- which is not where anyone reaches it. A single-page UI ends up
+// calling Obot instead of itself and reports that it cannot find its agent.
+func TestPublishedAgentIsToldWhereItIsPublished(t *testing.T) {
+	build := func(port int) agentConfig {
+		t.Helper()
+		desired, err := (defaultDesiredBuilder{ServerURL: "https://obot.example.com"}).Build(
+			context.Background(), BuildInput{
+				Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1qhtrt", UID: "uid-1"}},
+				Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{Port: port}}},
+				Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+			})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var config agentConfig
+		for _, file := range desired.Files {
+			if file.Path == agentConfigPath {
+				if err := json.Unmarshal(file.Content, &config); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		return config
+	}
+
+	served := build(8000)
+	// The resource ID, not the backend identifier: that is what the route is
+	// keyed on.
+	if served.PublicPath != "/agent-connect/hai1qhtrt" {
+		t.Errorf("publicPath = %q", served.PublicPath)
+	}
+	if served.PublicURL != "https://obot.example.com/agent-connect/hai1qhtrt" {
+		t.Errorf("publicURL = %q", served.PublicURL)
+	}
+
+	// An agent that serves nothing is published nowhere, and saying otherwise
+	// would offer an address that 400s.
+	quiet := build(0)
+	if quiet.PublicPath != "" || quiet.PublicURL != "" {
+		t.Errorf("a port-less agent should be published nowhere: %q %q", quiet.PublicPath, quiet.PublicURL)
+	}
+}
+
+// The browser and the sandbox do not reach Obot at the same address, and the
+// config carries both. Writing the public one into the sandbox's endpoints is
+// what leaves an agent unable to reach its own models: the chart's egress
+// policy excludes private ranges, so a public hostname resolving to an internal
+// load balancer or a node is refused even though it resolves.
+func TestSandboxEndpointsUseTheInternalAddress(t *testing.T) {
+	const (
+		public   = "https://obot.example.com"
+		internal = "http://obot.obot.svc.cluster.local"
+	)
+
+	desired, err := (defaultDesiredBuilder{ServerURL: public, InternalURL: internal}).Build(
+		context.Background(), BuildInput{
+			Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1qhtrt", UID: "uid-1"}},
+			Agent: &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{
+				Port:       8000,
+				MCPServers: []string{"ms1github"},
+			}}},
+			Harness: &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+		})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	var config agentConfig
+	for _, file := range desired.Files {
+		if file.Path == agentConfigPath {
+			if err := json.Unmarshal(file.Content, &config); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// Called by the sandbox, so reached at the internal address.
+	if config.ObotURL != internal {
+		t.Errorf("obotURL = %q, want the internal address", config.ObotURL)
+	}
+	for _, server := range config.MCPServers {
+		if !strings.HasPrefix(server.URL, internal) {
+			t.Errorf("mcp server URL = %q, want the internal address", server.URL)
+		}
+	}
+
+	// Followed by a browser, so it has to stay the public address -- the
+	// internal one names a Service no browser can resolve.
+	if config.PublicURL != public+"/agent-connect/hai1qhtrt" {
+		t.Errorf("publicURL = %q, want the public address", config.PublicURL)
+	}
+}
+
+// A caller that knows of only one address still has to produce a usable config,
+// rather than one whose endpoints are rooted at the empty string.
+func TestInternalAddressFallsBackToPublic(t *testing.T) {
+	desired, err := (defaultDesiredBuilder{ServerURL: "https://obot.example.com"}).Build(
+		context.Background(), BuildInput{
+			Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1qhtrt", UID: "uid-1"}},
+			Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{MCPServers: []string{"ms1github"}}}},
+			Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+		})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	var config agentConfig
+	for _, file := range desired.Files {
+		if file.Path == agentConfigPath {
+			if err := json.Unmarshal(file.Content, &config); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	if config.ObotURL != "https://obot.example.com" {
+		t.Errorf("obotURL = %q, want the public address", config.ObotURL)
+	}
+	for _, server := range config.MCPServers {
+		if !strings.HasPrefix(server.URL, "https://obot.example.com") {
+			t.Errorf("mcp server URL = %q, want the public address", server.URL)
+		}
+	}
+}

--- a/pkg/controller/handlers/hostedagent/credentials/credentials.go
+++ b/pkg/controller/handlers/hostedagent/credentials/credentials.go
@@ -1,0 +1,117 @@
+// Package credentials issues the credential a hosted agent sandbox uses to
+// authenticate to Obot.
+//
+// The credential authenticates as the agent rather than as its owner, so a
+// compromised sandbox reaches only what that one instance was configured with
+// instead of everything its owner can reach.
+package credentials
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+const (
+	credentialContext = "hosted-agent-credential"
+	keyValue          = "OBOT_API_KEY"
+	keyID             = "OBOT_API_KEY_ID"
+)
+
+type Issuer struct {
+	gatewayClient *client.Client
+}
+
+func New(gatewayClient *client.Client) *Issuer {
+	return &Issuer{gatewayClient: gatewayClient}
+}
+
+// EnsureInstanceCredential returns the instance's credential, minting one only
+// when none exists.
+//
+// The plaintext is kept in Obot's encrypted credential store, mirroring what
+// nanobot agents do, because an API key's secret is not recoverable from its
+// database row. Every reconcile therefore returns the same value and the same
+// version, which is what keeps the desired revision stable; reissuing would
+// change the version and restart the sandbox.
+func (i *Issuer) EnsureInstanceCredential(ctx context.Context, instanceID, ownerUserID string) (string, string, error) {
+	if i == nil || i.gatewayClient == nil {
+		return "", "", nil
+	}
+	if instanceID == "" {
+		return "", "", fmt.Errorf("instance ID is required")
+	}
+
+	stored, err := i.gatewayClient.RevealCredential(ctx, []string{credentialContext}, instanceID)
+	if err == nil && stored.Secrets[keyValue] != "" {
+		if valid, err := i.stillValid(ctx, stored.Secrets[keyValue]); err != nil {
+			return "", "", err
+		} else if valid {
+			return stored.Secrets[keyValue], stored.Secrets[keyID], nil
+		}
+		// The key was revoked out of band. Fall through and mint a new one; the
+		// changed version restarts the sandbox, which is the only way it will
+		// pick the new credential up.
+	} else if err != nil {
+		if _, ok := errors.AsType[client.CredentialNotFoundError](err); !ok {
+			return "", "", fmt.Errorf("reveal hosted agent credential: %w", err)
+		}
+	}
+
+	// The owner is recorded for attribution and cleanup. It confers none of
+	// that user's access: authentication resolves the instance, not the user.
+	var owner uint64
+	if ownerUserID != "" {
+		owner, _ = strconv.ParseUint(ownerUserID, 10, 64)
+	}
+
+	created, err := i.gatewayClient.CreateHostedAgentAPIKey(ctx, instanceID, uint(owner), "hosted-agent-"+instanceID)
+	if err != nil {
+		return "", "", fmt.Errorf("create hosted agent credential: %w", err)
+	}
+
+	version := strconv.FormatUint(uint64(created.ID), 10)
+	if err := i.gatewayClient.UpsertCredential(ctx, gatewaytypes.Credential{
+		Context: credentialContext,
+		Name:    instanceID,
+		Secrets: map[string]string{
+			keyValue: created.Key,
+			keyID:    version,
+		},
+	}); err != nil {
+		return "", "", fmt.Errorf("store hosted agent credential: %w", err)
+	}
+
+	return created.Key, version, nil
+}
+
+// RevokeInstanceCredential removes both the key and its stored plaintext.
+// Revocation is a row delete, so a leaked credential stops working at once
+// rather than waiting for an expiry these keys deliberately do not have.
+func (i *Issuer) RevokeInstanceCredential(ctx context.Context, instanceID string) error {
+	if i == nil || i.gatewayClient == nil {
+		return nil
+	}
+
+	var errs []error
+	if err := i.gatewayClient.DeleteHostedAgentAPIKeys(ctx, instanceID); err != nil {
+		errs = append(errs, err)
+	}
+	// DeleteCredential is idempotent, so a credential that is already gone is
+	// not an error to filter out.
+	if _, err := i.gatewayClient.DeleteCredential(ctx, credentialContext, instanceID); err != nil {
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (i *Issuer) stillValid(ctx context.Context, value string) (bool, error) {
+	if _, err := i.gatewayClient.ValidateAPIKey(ctx, value); err != nil {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/controller/handlers/hostedagent/gitref_test.go
+++ b/pkg/controller/handlers/hostedagent/gitref_test.go
@@ -1,0 +1,91 @@
+package hostedagent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func buildSource(t *testing.T, agent types.HostedAgentManifest, instance types.HostedAgentInstanceManifest) (string, string) {
+	t.Helper()
+
+	desired, err := defaultDesiredBuilder{}.Build(context.Background(), BuildInput{
+		Instance: &v1.HostedAgentInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "hai1", Namespace: "n", UID: "uid-1"},
+			Spec:       v1.HostedAgentInstanceSpec{Manifest: instance, UserID: "u1"},
+		},
+		Agent:   &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: agent}},
+		Harness: &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	return desired.Source.URL, desired.Source.Revision
+}
+
+func TestAgentGitRefReachesTheSandbox(t *testing.T) {
+	url, ref := buildSource(t,
+		types.HostedAgentManifest{GitRepo: "https://example.com/a.git", GitRef: "v1.2.3"},
+		types.HostedAgentInstanceManifest{Name: "i"})
+
+	if url != "https://example.com/a.git" || ref != "v1.2.3" {
+		t.Fatalf("source = %q @ %q", url, ref)
+	}
+}
+
+// A ref names a revision of one specific repository. Carrying the agent's ref
+// onto a repository the user supplied would check out someone else's revision
+// -- or more likely fail to resolve, with an error pointing at the wrong repo.
+func TestUserRepoDoesNotInheritTheAgentRef(t *testing.T) {
+	url, ref := buildSource(t,
+		types.HostedAgentManifest{GitRepo: "https://example.com/a.git", GitRef: "v1.2.3", AllowUserGitRepo: true},
+		types.HostedAgentInstanceManifest{Name: "i", GitRepo: "https://example.com/mine.git"})
+
+	if url != "https://example.com/mine.git" {
+		t.Fatalf("url = %q, want the user's repository", url)
+	}
+	if ref != "" {
+		t.Fatalf("ref = %q, want the user's repository to use its default branch", ref)
+	}
+}
+
+func TestUserRefIsUsedWithTheUserRepo(t *testing.T) {
+	url, ref := buildSource(t,
+		types.HostedAgentManifest{GitRepo: "https://example.com/a.git", GitRef: "v1.2.3", AllowUserGitRepo: true},
+		types.HostedAgentInstanceManifest{Name: "i", GitRepo: "https://example.com/mine.git", GitRef: "my-branch"})
+
+	if url != "https://example.com/mine.git" || ref != "my-branch" {
+		t.Fatalf("source = %q @ %q", url, ref)
+	}
+}
+
+// The ref participates in desired state, so changing it has to restart the
+// sandbox; otherwise a repinned agent keeps running the old revision.
+func TestChangingTheRefChangesTheRevision(t *testing.T) {
+	base := types.HostedAgentManifest{GitRepo: "https://example.com/a.git", GitRef: "v1"}
+	instance := types.HostedAgentInstanceManifest{Name: "i"}
+
+	first, err := defaultDesiredBuilder{}.Build(context.Background(), BuildInput{
+		Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}, Spec: v1.HostedAgentInstanceSpec{Manifest: instance}},
+		Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: base}},
+		Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	base.GitRef = "v2"
+	second, err := defaultDesiredBuilder{}.Build(context.Background(), BuildInput{
+		Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}, Spec: v1.HostedAgentInstanceSpec{Manifest: instance}},
+		Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: base}},
+		Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if first.Revision == second.Revision {
+		t.Fatal("repinning the ref left the revision unchanged, so the sandbox would not restart")
+	}
+}

--- a/pkg/controller/handlers/hostedagent/hostedagent.go
+++ b/pkg/controller/handlers/hostedagent/hostedagent.go
@@ -1,0 +1,675 @@
+// Package hostedagent reconciles hosted agent instances through the
+// implementation-neutral agent backend contract.
+package hostedagent
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/logger"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	"github.com/obot-platform/obot/pkg/hash"
+	"github.com/obot-platform/obot/pkg/hostedagentrefs"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kfields "k8s.io/apimachinery/pkg/fields"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var log = logger.Package()
+
+const (
+	transitionalPollInterval = 10 * time.Second
+	readyPollInterval        = 5 * time.Minute
+	agentConfigPath          = "/etc/obot/agent.json"
+	// agentSecretsPath holds the credentials for the endpoints named in the
+	// config. It is a separate file so the config itself needs no protection.
+	agentSecretsPath = "/etc/obot/secrets.json"
+	// workspacePath mirrors where backends mount the pool volume. It is told to
+	// the agent so the writable, surviving directory does not have to be
+	// guessed.
+	workspacePath      = "/workspace"
+	credentialFilePath = "/etc/obot/credential"
+	poolDefaultsName   = "default"
+)
+
+// DesiredBuilder converts Obot resources into the runtime-ready backend
+// contract. Keeping this boundary injectable lets resource and credential
+// resolution evolve without coupling a backend adapter to Obot storage types.
+type DesiredBuilder interface {
+	Build(context.Context, BuildInput) (agentbackend.DesiredInstance, error)
+}
+
+// BuildInput is everything needed to render a sandbox's runtime contract.
+//
+// Client is here because the sandbox config resolves models and skills into
+// complete endpoints and files, which means reading them; Credential is here
+// because those endpoints carry it.
+type BuildInput struct {
+	Client     kclient.Client
+	Namespace  string
+	Instance   *v1.HostedAgentInstance
+	Agent      *v1.HostedAgent
+	Harness    *v1.Harness
+	Credential string
+}
+
+// CredentialIssuer mints and revokes the credential a sandbox authenticates
+// with. It is an interface so the controller can be tested without a database,
+// and so the credential store stays replaceable.
+type CredentialIssuer interface {
+	// EnsureInstanceCredential returns the sandbox credential and an opaque
+	// version that changes whenever the value does. It must be idempotent:
+	// reconciles are frequent, and reissuing on every pass would restart the
+	// sandbox on every pass.
+	EnsureInstanceCredential(ctx context.Context, instanceID, ownerUserID string) (value string, version string, err error)
+	// RevokeInstanceCredential is called during deletion and must tolerate a
+	// credential that is already gone.
+	RevokeInstanceCredential(ctx context.Context, instanceID string) error
+}
+
+type Handler struct {
+	backend     agentbackend.InstanceBackend
+	builder     DesiredBuilder
+	credentials CredentialIssuer
+	now         func() time.Time
+}
+
+func New(backend agentbackend.InstanceBackend, credentials CredentialIssuer, serverURL, internalURL string) *Handler {
+	return NewWithBuilder(backend, credentials, defaultDesiredBuilder{
+		ServerURL:   serverURL,
+		InternalURL: internalURL,
+		Skills:      newSkillFetcher(),
+	})
+}
+
+func NewWithBuilder(backend agentbackend.InstanceBackend, credentials CredentialIssuer, builder DesiredBuilder) *Handler {
+	return &Handler{
+		backend:     backend,
+		builder:     builder,
+		credentials: credentials,
+		now:         time.Now,
+	}
+}
+
+// EnsurePool resolves the instance's pool before backend
+// reconciliation. The deterministic names make concurrent first-instance
+// reconciles for one user converge on the same pool and assignment.
+func (h *Handler) EnsurePool(req router.Request, _ router.Response) error {
+	instance := req.Object.(*v1.HostedAgentInstance)
+	if instance.Spec.UserID == "" {
+		return fmt.Errorf("hosted agent instance %q has no user ID", instance.Name)
+	}
+
+	if instance.Spec.PoolID != "" {
+		assignments, err := assignmentsForUser(req, instance.Spec.UserID)
+		if err != nil {
+			return err
+		}
+		if isAssigned(assignments, instance.Spec.PoolID) {
+			return nil
+		}
+		return fmt.Errorf("user %q is not assigned to hosted agent pool %q", instance.Spec.UserID, instance.Spec.PoolID)
+	}
+
+	assignments, err := assignmentsForUser(req, instance.Spec.UserID)
+	if err != nil {
+		return err
+	}
+	if poolID := defaultPool(assignments); poolID != "" {
+		instance.Spec.PoolID = poolID
+		return req.Client.Update(req.Ctx, instance)
+	}
+
+	var defaults v1.HostedAgentPoolDefaults
+	if err := req.Get(&defaults, req.Namespace, poolDefaultsName); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("hosted agent pool defaults %q are not configured: %w", poolDefaultsName, err)
+		}
+		return err
+	}
+	if err := defaults.Spec.Manifest.Validate(); err != nil {
+		return fmt.Errorf("hosted agent pool defaults %q are invalid: %w", poolDefaultsName, err)
+	}
+
+	poolID, assignmentID := initialPoolNames(instance.Spec.UserID)
+	pool := &v1.HostedAgentPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolID,
+			Namespace: req.Namespace,
+		},
+		Spec: v1.HostedAgentPoolSpec{
+			Manifest: types.HostedAgentPoolManifest{
+				Capacity:     defaults.Spec.Manifest.Capacity,
+				MaxSandboxes: defaults.Spec.Manifest.MaxSandboxes,
+				Suspended:    defaults.Spec.Manifest.Suspended,
+			},
+		},
+	}
+	if err := req.Client.Create(req.Ctx, pool); err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create hosted agent pool: %w", err)
+	}
+
+	assignment := &v1.HostedAgentPoolAssignment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      assignmentID,
+			Namespace: req.Namespace,
+		},
+		Spec: v1.HostedAgentPoolAssignmentSpec{
+			Manifest: types.HostedAgentPoolAssignmentManifest{
+				UserID:  instance.Spec.UserID,
+				PoolID:  poolID,
+				Default: true,
+			},
+		},
+	}
+	err = req.Client.Create(req.Ctx, assignment)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create hosted agent pool assignment: %w", err)
+	}
+	if apierrors.IsAlreadyExists(err) {
+		var persistedAssignment v1.HostedAgentPoolAssignment
+		if err := req.Client.Get(req.Ctx, router.Key(req.Namespace, assignmentID), &persistedAssignment); err != nil {
+			return fmt.Errorf("read hosted agent pool assignment after conflict: %w", err)
+		}
+		if persistedAssignment.Spec.Manifest.UserID != instance.Spec.UserID ||
+			persistedAssignment.Spec.Manifest.PoolID != poolID ||
+			!persistedAssignment.Spec.Manifest.Default {
+			return fmt.Errorf("hosted agent pool assignment %q conflicts with the default assignment for user %q", assignmentID, instance.Spec.UserID)
+		}
+	}
+
+	instance.Spec.PoolID = poolID
+	return req.Client.Update(req.Ctx, instance)
+}
+
+func isAssigned(assignments []v1.HostedAgentPoolAssignment, poolID string) bool {
+	for _, assignment := range assignments {
+		if assignment.Spec.Manifest.PoolID == poolID {
+			return true
+		}
+	}
+	return false
+}
+
+func defaultPool(assignments []v1.HostedAgentPoolAssignment) string {
+	for _, assignment := range assignments {
+		if assignment.Spec.Manifest.Default {
+			return assignment.Spec.Manifest.PoolID
+		}
+	}
+	return ""
+}
+
+func initialPoolNames(userID string) (string, string) {
+	suffix := hash.String(userID)[:16]
+	return "hp-" + suffix, "hps-" + suffix
+}
+
+func assignmentsForUser(req router.Request, userID string) ([]v1.HostedAgentPoolAssignment, error) {
+	var assignments v1.HostedAgentPoolAssignmentList
+	if err := req.List(&assignments, &kclient.ListOptions{
+		Namespace: req.Namespace,
+		FieldSelector: kfields.SelectorFromSet(map[string]string{
+			"spec.userID": userID,
+		}),
+	}); err != nil {
+		return nil, fmt.Errorf("list hosted agent pool assignments: %w", err)
+	}
+	result := make([]v1.HostedAgentPoolAssignment, 0, len(assignments.Items))
+	for _, assignment := range assignments.Items {
+		if assignment.Spec.Manifest.UserID == userID {
+			result = append(result, assignment)
+		}
+	}
+	return result, nil
+}
+
+// OrchestrateInstance converges one HostedAgentInstance and periodically
+// observes it so out-of-band backend changes are reflected in Obot.
+func (h *Handler) OrchestrateInstance(req router.Request, resp router.Response) error {
+	instance := req.Object.(*v1.HostedAgentInstance)
+	if h.backend == nil {
+		return fmt.Errorf("hosted agent backend is not configured")
+	}
+
+	ref := instanceRef(instance)
+	// EnsurePool is registered immediately before this handler. nah can
+	// aggregate errors from handlers in one reconciliation pass, so do not try
+	// to construct backend desired state when pool resolution failed.
+	// The pool handler's actionable error is sufficient and a later
+	// reconcile will continue once defaults or an assignment are configured.
+	if instance.Spec.PoolID == "" {
+		return nil
+	}
+
+	var agent v1.HostedAgent
+	if err := req.Get(&agent, req.Namespace, instance.Spec.HostedAgentName); err != nil {
+		return err
+	}
+
+	var harness v1.Harness
+	if err := req.Get(&harness, req.Namespace, agent.Spec.Manifest.HarnessID); err != nil {
+		return err
+	}
+
+	// The credential is resolved before the config rather than attached after
+	// it, because the config embeds it: every MCP header and model key in there
+	// is this credential, so it has to exist before the config is rendered.
+	credential, credentialVersion, err := h.instanceCredential(req.Ctx, instance)
+	if err != nil {
+		return err
+	}
+
+	desired, err := h.builder.Build(req.Ctx, BuildInput{
+		Client:     req.Client,
+		Namespace:  req.Namespace,
+		Instance:   instance,
+		Agent:      &agent,
+		Harness:    &harness,
+		Credential: credential,
+	})
+	if err != nil {
+		return err
+	}
+	desired.Ref = ref
+	desired.Pool.ID = instance.Spec.PoolID
+	attachCredential(&desired, instance.Name, credential, credentialVersion)
+
+	// A sandbox has no size of its own: it takes an equal share of its pool.
+	// Carrying the result in desired state means resizing a pool changes every
+	// sandbox's revision and restarts it, which is the only way a running
+	// sandbox picks up new limits.
+	var pool v1.HostedAgentPool
+	if err := req.Get(&pool, req.Namespace, instance.Spec.PoolID); err != nil {
+		return err
+	}
+	desired.Requests, desired.Limits, _ = agentbackend.SandboxShare(agentbackend.ResourceQuantity{
+		CPUVCPUs:     pool.Spec.Manifest.Capacity.CPUVCPUs,
+		MemoryBytes:  pool.Spec.Manifest.Capacity.MemoryBytes,
+		StorageBytes: pool.Spec.Manifest.Capacity.StorageBytes,
+	}, pool.Spec.Manifest.MaxSandboxes)
+
+	var observation agentbackend.InstanceObservation
+	if instance.Status.ObservedRevision == desired.Revision {
+		observation, err = h.backend.ObserveInstance(req.Ctx, ref)
+	} else {
+		observation, err = h.backend.ReconcileInstance(req.Ctx, desired)
+	}
+	if err != nil {
+		return err
+	}
+	previous := instance.Status
+	h.applyObservation(instance, desired.Revision, observation)
+	interval := pollInterval(instance.Status.State)
+	resp.RetryAfter(interval)
+
+	// A status write emits a change event, which reconciles this instance again
+	// straight away. Writing unconditionally therefore means the controller
+	// triggers its own next pass and RetryAfter never applies, spinning as fast
+	// as storage allows. Only write when something actually moved, refreshing
+	// the heartbeat at most once per poll interval so the timestamp stays
+	// meaningful without driving the loop.
+	if statusUnchanged(previous, instance.Status) && !heartbeatDue(previous.LastObservedTime, h.now(), interval) {
+		instance.Status.LastObservedTime = previous.LastObservedTime
+		return nil
+	}
+	return req.Client.Status().Update(req.Ctx, instance)
+}
+
+// statusUnchanged compares everything an observation can set except the
+// heartbeat, which moves on every pass and so cannot be part of the decision to
+// write.
+func statusUnchanged(a, b v1.HostedAgentInstanceStatus) bool {
+	return a.State == b.State &&
+		a.URL == b.URL &&
+		a.Error == b.Error &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message &&
+		a.ObservedRevision == b.ObservedRevision &&
+		a.BackendID == b.BackendID &&
+		a.BackendGeneration == b.BackendGeneration
+}
+
+func heartbeatDue(last *metav1.Time, now time.Time, interval time.Duration) bool {
+	return last == nil || !now.Before(last.Add(interval))
+}
+
+// RemoveInstance asks the backend to remove an instance. The router retains
+// the finalizer while this handler requests a retry.
+func (h *Handler) RemoveInstance(req router.Request, resp router.Response) error {
+	instance := req.Object.(*v1.HostedAgentInstance)
+	if h.backend == nil {
+		return fmt.Errorf("hosted agent backend is not configured")
+	}
+	ref := instanceRef(instance)
+	result, err := h.backend.DeleteInstance(req.Ctx, ref)
+	if err != nil {
+		return err
+	}
+	if !result.Complete {
+		resp.RetryAfter(transitionalPollInterval)
+		return nil
+	}
+
+	// Revoke last. The credential outliving a failed teardown is recoverable;
+	// revoking before the sandbox is gone would leave a live agent holding a
+	// credential that no longer authenticates, which looks like a broken agent
+	// rather than a deletion in progress.
+	if h.credentials != nil {
+		if err := h.credentials.RevokeInstanceCredential(req.Ctx, instance.Name); err != nil {
+			return fmt.Errorf("revoke hosted agent credential: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// instanceCredential returns the sandbox's own credential and an opaque version
+// that changes when it is rotated.
+func (h *Handler) instanceCredential(ctx context.Context, instance *v1.HostedAgentInstance) (string, string, error) {
+	if h.credentials == nil {
+		return "", "", nil
+	}
+	value, version, err := h.credentials.EnsureInstanceCredential(ctx, instance.Name, instance.Spec.UserID)
+	if err != nil {
+		return "", "", fmt.Errorf("issue hosted agent credential: %w", err)
+	}
+	return value, version, nil
+}
+
+// attachCredential also places the raw credential in the sandbox.
+//
+// The config already carries it inside each endpoint, but an agent that needs
+// to call Obot for something the config does not describe would otherwise have
+// no token at all. It is a file rather than an environment variable: agents run
+// model-directed commands, and every subprocess inherits the environment.
+func attachCredential(desired *agentbackend.DesiredInstance, instanceName, value, version string) {
+	if value == "" {
+		return
+	}
+	desired.Secrets = append(desired.Secrets, agentbackend.SecretRef{
+		ID:       instanceName + "-credential",
+		Version:  version,
+		Value:    value,
+		FilePath: credentialFilePath,
+	})
+}
+
+func (h *Handler) applyObservation(instance *v1.HostedAgentInstance, desiredRevision string, observation agentbackend.InstanceObservation) {
+	instance.Status.ObservedRevision = observation.ObservedRevision
+	instance.Status.Reason = observation.Reason
+	instance.Status.Message = observation.Message
+	instance.Status.Error = ""
+	instance.Status.BackendGeneration = observation.BackendGeneration
+	now := metav1.NewTime(h.now())
+	instance.Status.LastObservedTime = &now
+
+	if observation.Ref.BackendID != "" {
+		instance.Status.BackendID = observation.Ref.BackendID
+	}
+	// The URL is intentionally sticky after the backend first advertises it.
+	if observation.URL != "" {
+		instance.Status.URL = observation.URL
+	}
+
+	switch {
+	case observation.ObservedRevision != desiredRevision:
+		instance.Status.State = types.HostedAgentStatePending
+	case observation.State == agentbackend.StateError:
+		instance.Status.State = types.HostedAgentStateError
+		instance.Status.Error = observation.Message
+	case observation.Exists &&
+		observation.State == agentbackend.StateReady &&
+		observation.ObservedRevision == desiredRevision:
+		instance.Status.State = types.HostedAgentStateReady
+	default:
+		instance.Status.State = types.HostedAgentStatePending
+	}
+}
+
+func instanceRef(instance *v1.HostedAgentInstance) agentbackend.InstanceRef {
+	id := string(instance.UID)
+	if id == "" {
+		// Objects normally have a UID before a controller sees them. The name is
+		// a deterministic fallback for storage implementations that assign it
+		// after the initial controller pass.
+		id = instance.Name
+	}
+	return agentbackend.InstanceRef{
+		ID:        id,
+		Namespace: instance.Namespace,
+		UserID:    instance.Spec.UserID,
+		BackendID: instance.Status.BackendID,
+	}
+}
+
+func pollInterval(state types.HostedAgentState) time.Duration {
+	if state == types.HostedAgentStateReady {
+		return readyPollInterval
+	}
+	return transitionalPollInterval
+}
+
+// defaultDesiredBuilder renders the sandbox's runtime contract.
+//
+// It holds the server URL because every endpoint it writes into the config is
+// absolute: the sandbox is told where to connect, never how to work it out.
+//
+// Two addresses, because the sandbox and the browser do not reach Obot the same
+// way. Writing one into both roles breaks whichever it is not: the public
+// address is commonly unroutable from inside the cluster, and the internal one
+// is meaningless to a browser.
+type defaultDesiredBuilder struct {
+	// ServerURL is Obot's public address, and so the only one a published
+	// agent can build links from.
+	ServerURL string
+	// InternalURL is Obot's address as a sandbox reaches it -- its models, its
+	// MCP servers, its own API. Empty means the two are the same.
+	InternalURL string
+	Skills      *skillFetcher
+}
+
+// internal is the address the sandbox calls back on, falling back to the public
+// one so a caller that knows of only a single address still builds a usable
+// config.
+func (b defaultDesiredBuilder) internal() string {
+	if b.InternalURL != "" {
+		return b.InternalURL
+	}
+	return b.ServerURL
+}
+
+// contentVersion identifies a config by its content, so that any change to it
+// -- a new MCP server, a rotated credential, an edited skill -- changes the
+// desired revision and restarts the sandbox, without the content itself ever
+// entering the revision.
+func contentVersion(content []byte) string {
+	sum := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func (b defaultDesiredBuilder) Build(ctx context.Context, in BuildInput) (agentbackend.DesiredInstance, error) {
+	instance, agent, harness := in.Instance, in.Agent, in.Harness
+	manifest := agent.Spec.Manifest
+	instanceManifest := instance.Spec.Manifest
+
+	answers := make(map[string]string, len(instanceManifest.Answers))
+	for key, value := range instanceManifest.Answers {
+		if !sensitiveQuestion(manifest.Questions, key) {
+			answers[key] = value
+		}
+	}
+
+	source := agentSource(manifest, instanceManifest)
+
+	// A template names MCP servers and skills portably, by their source and key,
+	// because the IDs an installation generates differ. Resolution happens here
+	// rather than being rewritten into the template at sync, so a reference that
+	// names nothing today resolves on its own once it is installed.
+	//
+	// Anything unresolved is dropped rather than failing the sandbox: the API
+	// reports the agent unavailable for the same reason, and a sandbox that
+	// starts with what it does have beats one that will not start at all.
+	mcpIDs := append(slices.Clone(manifest.MCPServers), instanceManifest.MCPServers...)
+	skillIDs := append(slices.Clone(manifest.Skills), instanceManifest.Skills...)
+	if in.Client != nil {
+		resolver := hostedagentrefs.New(in.Client, in.Namespace)
+		var unresolvedMCP, unresolvedSkills []string
+		mcpIDs, unresolvedMCP = resolver.MCPServers(ctx, mcpIDs)
+		skillIDs, unresolvedSkills = resolver.Skills(ctx, skillIDs)
+		for _, ref := range append(unresolvedMCP, unresolvedSkills...) {
+			log.Warnf("hosted agent %s: %q names nothing installed here; leaving it out", instance.Name, ref)
+		}
+	}
+
+	// Only an agent that serves HTTP is published, and only it needs to know
+	// where. The path uses the instance's resource ID because that is what the
+	// route is keyed on, not the backend identifier the config reports.
+	var publicPath, publicURL string
+	if manifest.Port > 0 {
+		publicPath = "/agent-connect/" + instance.Name
+		publicURL = strings.TrimSuffix(b.ServerURL, "/") + publicPath
+	}
+
+	config := agentConfig{
+		Version: "v1",
+		Instance: agentConfigMeta{
+			ID:     instanceRef(instance).ID,
+			UserID: instance.Spec.UserID,
+			Name:   instanceManifest.Name,
+		},
+		SecretsFile: agentSecretsPath,
+		Workspace:   workspacePath,
+		ListenPort:  manifest.Port,
+		PublicPath:  publicPath,
+		PublicURL:   publicURL,
+		ObotURL:     b.internal(),
+		MCPServers:  mcpServerConfigs(b.internal(), mcpIDs),
+		Answers:     answers,
+	}
+	if source.URL != "" {
+		config.Source = &agentConfigSource{URL: source.URL, Ref: source.Revision, Subdir: source.Subdir}
+	}
+
+	if in.Client != nil {
+		models, err := modelConfigs(ctx, in.Client, in.Namespace, b.internal(),
+			append(slices.Clone(manifest.Models), instanceManifest.Models...),
+			manifest.ModelProviders)
+		if err != nil {
+			return agentbackend.DesiredInstance{}, err
+		}
+		config.Models = models
+	}
+
+	// Skill files are placed in the sandbox rather than described to it: an
+	// agent should find its skills on disk, not go and fetch them.
+	var skillFiles []agentbackend.File
+	if in.Client != nil && b.Skills != nil {
+		skillFiles, config.Skills = b.Skills.skillFiles(ctx, in.Client, in.Namespace, skillIDs)
+	}
+
+	configBytes, err := json.Marshal(config)
+	if err != nil {
+		return agentbackend.DesiredInstance{}, fmt.Errorf("render agent config: %w", err)
+	}
+
+	secretsBytes, err := json.Marshal(buildSecrets(config, in.Credential))
+	if err != nil {
+		return agentbackend.DesiredInstance{}, fmt.Errorf("render agent secrets: %w", err)
+	}
+
+	env := make(map[string]string)
+	for _, value := range manifest.Env {
+		if !value.Sensitive {
+			env[value.Key] = value.Value
+		}
+	}
+
+	desired := agentbackend.DesiredInstance{
+		Ref:         instanceRef(instance),
+		Pool:        agentbackend.PoolRef{ID: instance.Spec.PoolID},
+		Name:        instanceManifest.Name,
+		Description: instanceManifest.Description,
+		Harness: agentbackend.Harness{
+			ID:          manifest.HarnessID,
+			Interactive: harness.Spec.Manifest.Interactive,
+		},
+		Image:    harness.Spec.Manifest.Image,
+		Source:   source,
+		Port:     manifest.Port,
+		Terminal: manifest.Terminal,
+		Env:      env,
+		// The configuration itself carries no credential, so it is an ordinary
+		// world-readable file: it can be inspected, logged or copied without
+		// leaking anything.
+		Files: append(skillFiles, agentbackend.File{
+			Path:    agentConfigPath,
+			Content: configBytes,
+			Mode:    0o444,
+		}),
+		// The credentials travel separately as a secret, which keeps them out
+		// of the desired revision. The version is the content hash, so a
+		// rotated credential still restarts the sandbox.
+		Secrets: []agentbackend.SecretRef{{
+			ID:       instance.Name + "-secrets",
+			Version:  contentVersion(secretsBytes),
+			Value:    string(secretsBytes),
+			FilePath: agentSecretsPath,
+		}},
+	}
+
+	revision, err := desiredRevision(desired)
+	if err != nil {
+		return agentbackend.DesiredInstance{}, err
+	}
+	desired.Revision = revision
+	return desired, nil
+}
+
+func desiredRevision(desired agentbackend.DesiredInstance) (string, error) {
+	// Secret values must never reach the revision. Their version markers still
+	// do, so a rotation changes the revision and restarts the sandbox without
+	// the revision ever containing a credential.
+	desired = desired.Redacted()
+	// Backend IDs are observations and must not perturb desired configuration.
+	desired.Ref.BackendID = ""
+	desired.Revision = ""
+	content, err := json.Marshal(desired)
+	if err != nil {
+		return "", fmt.Errorf("calculate hosted agent revision: %w", err)
+	}
+	sum := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func sensitiveQuestion(questions []types.HostedAgentQuestion, key string) bool {
+	for _, question := range questions {
+		if question.Key == key {
+			return question.Sensitive
+		}
+	}
+	return false
+}
+
+// agentSource picks the repository the sandbox clones.
+//
+// The ref travels with its own repository rather than being resolved
+// separately: a user who supplies their own repository picks the ref for that
+// repository, and the agent's ref -- which names a revision of a different
+// repository -- must not be applied to it.
+func agentSource(agent types.HostedAgentManifest, instance types.HostedAgentInstanceManifest) agentbackend.Source {
+	if instance.GitRepo != "" {
+		return agentbackend.Source{URL: instance.GitRepo, Revision: instance.GitRef}
+	}
+	return agentbackend.Source{URL: agent.GitRepo, Revision: agent.GitRef}
+}

--- a/pkg/controller/handlers/hostedagent/hostedagent_test.go
+++ b/pkg/controller/handlers/hostedagent/hostedagent_test.go
@@ -1,0 +1,234 @@
+package hostedagent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	types2 "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+)
+
+func TestDefaultDesiredBuilder(t *testing.T) {
+	instance := &v1.HostedAgentInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "instance",
+			Namespace: "default",
+			UID:       ktypes.UID("instance-uid"),
+		},
+		Spec: v1.HostedAgentInstanceSpec{
+			UserID: "user-1",
+			PoolID: "pool-1",
+			Manifest: types2.HostedAgentInstanceManifest{
+				Name:    "My agent",
+				Answers: map[string]string{"public": "yes", "secret": "no"},
+				Skills:  []string{"personal"},
+			},
+		},
+	}
+	agent := &v1.HostedAgent{
+		Spec: v1.HostedAgentSpec{
+			Manifest: types2.HostedAgentManifest{
+				HarnessID:  "harness-1",
+				GitRepo:    "https://example.com/repo.git",
+				MCPServers: []string{"mcp-1"},
+				Models:     []string{"model-1"},
+				Skills:     []string{"shared"},
+				Env: []types2.HostedAgentEnv{
+					{Key: "PUBLIC", Value: "value"},
+					{Key: "SECRET", Value: "must-not-leak", Sensitive: true},
+				},
+				Questions: []types2.HostedAgentQuestion{
+					{Key: "public"},
+					{Key: "secret", Sensitive: true},
+				},
+			},
+		},
+	}
+	harness := &v1.Harness{
+		Spec: v1.HarnessSpec{
+			Manifest: types2.HarnessManifest{Image: "example/image:latest"},
+		},
+	}
+
+	desired, err := (defaultDesiredBuilder{}).Build(context.Background(), BuildInput{
+		Instance: instance, Agent: agent, Harness: harness,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if desired.Image != "example/image:latest" {
+		t.Fatalf("unexpected image %q", desired.Image)
+	}
+	if desired.Source.URL != "https://example.com/repo.git" {
+		t.Fatalf("unexpected source %q", desired.Source.URL)
+	}
+	if desired.Env["PUBLIC"] != "value" {
+		t.Fatalf("public environment was not rendered: %#v", desired.Env)
+	}
+	if _, ok := desired.Env["SECRET"]; ok {
+		t.Fatal("sensitive environment leaked into desired configuration")
+	}
+	// The config is an ordinary readable file; only the credentials that go
+	// with it are a secret.
+	config := ""
+	for _, file := range desired.Files {
+		if file.Path == agentConfigPath {
+			config = string(file.Content)
+		}
+	}
+	if config == "" {
+		t.Fatalf("no agent config was delivered: %#v", desired.Files)
+	}
+	for _, expected := range []string{"mcp-1", `"public":"yes"`} {
+		if !strings.Contains(config, expected) {
+			t.Errorf("agent config %q does not contain %q", config, expected)
+		}
+	}
+	for _, excluded := range []string{"must-not-leak", `"secret":"no"`} {
+		if strings.Contains(config, excluded) {
+			t.Errorf("agent config contains sensitive value %q", excluded)
+		}
+	}
+	if !strings.HasPrefix(desired.Revision, "sha256:") {
+		t.Fatalf("unexpected revision %q", desired.Revision)
+	}
+}
+
+func TestApplyObservationRequiresCurrentRevisionAndKeepsURL(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	handler := &Handler{now: func() time.Time { return now }}
+	instance := &v1.HostedAgentInstance{}
+
+	handler.applyObservation(instance, "wanted", agentbackend.InstanceObservation{
+		Exists:           true,
+		State:            agentbackend.StateReady,
+		ObservedRevision: "old",
+		URL:              "https://agent.example",
+		Ref:              agentbackend.InstanceRef{BackendID: "backend-1"},
+	})
+	if instance.Status.State != types2.HostedAgentStatePending {
+		t.Fatalf("stale revision must remain pending, got %q", instance.Status.State)
+	}
+
+	handler.applyObservation(instance, "wanted", agentbackend.InstanceObservation{
+		Exists:           true,
+		State:            agentbackend.StateReady,
+		ObservedRevision: "wanted",
+	})
+	if instance.Status.State != types2.HostedAgentStateReady {
+		t.Fatalf("current ready revision was %q", instance.Status.State)
+	}
+	if instance.Status.URL != "https://agent.example" {
+		t.Fatalf("URL was not sticky: %q", instance.Status.URL)
+	}
+	if instance.Status.BackendID != "backend-1" {
+		t.Fatalf("backend ID was not retained: %q", instance.Status.BackendID)
+	}
+	if instance.Status.LastObservedTime == nil || !instance.Status.LastObservedTime.Time.Equal(now) {
+		t.Fatalf("unexpected observation time %#v", instance.Status.LastObservedTime)
+	}
+}
+
+func TestDesiredRevisionIgnoresBackendID(t *testing.T) {
+	desired := agentbackend.DesiredInstance{
+		Ref:   agentbackend.InstanceRef{ID: "instance", BackendID: "first"},
+		Image: "image",
+	}
+	first, err := desiredRevision(desired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	desired.Ref.BackendID = "second"
+	second, err := desiredRevision(desired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("backend ID changed revision: %q != %q", first, second)
+	}
+}
+
+func TestPoolSelectionAndNames(t *testing.T) {
+	assignments := []v1.HostedAgentPoolAssignment{
+		{Spec: v1.HostedAgentPoolAssignmentSpec{
+			Manifest: types2.HostedAgentPoolAssignmentManifest{
+				UserID: "user-1",
+				PoolID: "secondary",
+			},
+		}},
+		{Spec: v1.HostedAgentPoolAssignmentSpec{
+			Manifest: types2.HostedAgentPoolAssignmentManifest{
+				UserID:  "user-1",
+				PoolID:  "primary",
+				Default: true,
+			},
+		}},
+	}
+	if got := defaultPool(assignments); got != "primary" {
+		t.Fatalf("unexpected default pool %q", got)
+	}
+	if !isAssigned(assignments, "secondary") || isAssigned(assignments, "missing") {
+		t.Fatal("assignment membership was evaluated incorrectly")
+	}
+
+	pool1, assignment1 := initialPoolNames("user-1")
+	pool2, assignment2 := initialPoolNames("user-1")
+	otherPool, _ := initialPoolNames("user-2")
+	if pool1 != pool2 || assignment1 != assignment2 {
+		t.Fatal("initial pool names are not deterministic")
+	}
+	if pool1 == otherPool {
+		t.Fatal("different users received the same pool name")
+	}
+	if !strings.HasPrefix(pool1, "hp-") || !strings.HasPrefix(assignment1, "hps-") {
+		t.Fatalf("unexpected names %q and %q", pool1, assignment1)
+	}
+}
+
+// A status write emits a change event that reconciles the instance again at
+// once. Rewriting an identical status therefore makes the controller drive its
+// own next pass, which pegs a CPU rather than honouring the poll interval.
+func TestStatusUnchangedIgnoresHeartbeatOnly(t *testing.T) {
+	earlier := metav1.NewTime(time.Unix(1000, 0))
+	later := metav1.NewTime(time.Unix(2000, 0))
+
+	base := v1.HostedAgentInstanceStatus{
+		State:            types2.HostedAgentStateReady,
+		URL:              "http://sandbox",
+		ObservedRevision: "sha256:abc",
+		BackendID:        "obot-agent-1",
+		LastObservedTime: &earlier,
+	}
+	same := base
+	same.LastObservedTime = &later
+
+	if !statusUnchanged(base, same) {
+		t.Error("a moved heartbeat alone must not count as a status change")
+	}
+
+	changed := base
+	changed.State = types2.HostedAgentStateError
+	if statusUnchanged(base, changed) {
+		t.Error("a state change must count as a status change")
+	}
+}
+
+func TestHeartbeatDue(t *testing.T) {
+	last := metav1.NewTime(time.Unix(1000, 0))
+
+	if heartbeatDue(&last, time.Unix(1000, 0).Add(time.Second), time.Minute) {
+		t.Error("the heartbeat is not due before the poll interval has elapsed")
+	}
+	if !heartbeatDue(&last, time.Unix(1000, 0).Add(time.Minute), time.Minute) {
+		t.Error("the heartbeat is due once the poll interval has elapsed")
+	}
+	if !heartbeatDue(nil, time.Unix(1000, 0), time.Minute) {
+		t.Error("an instance that has never been observed is always due")
+	}
+}

--- a/pkg/controller/handlers/hostedagent/models_test.go
+++ b/pkg/controller/handlers/hostedagent/models_test.go
@@ -1,0 +1,215 @@
+package hostedagent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func modelObj(name, target, provider string) *v1.Model {
+	return &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+			Name:          name,
+			TargetModel:   target,
+			ModelProvider: provider,
+			Active:        true,
+			Usage:         types.ModelUsageLLM,
+		}},
+	}
+}
+
+func aliasObj(name, model string) *v1.DefaultModelAlias {
+	return &v1.DefaultModelAlias{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Spec:       v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: name, Model: model}},
+	}
+}
+
+// A wildcard grants every model. Telling the sandbox about none of them leaves
+// an agent unable to use what it was granted, with no way to discover it.
+func TestWildcardListsEveryModel(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1sonnet", "claude-sonnet-4-5", system.AnthropicModelProvider),
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+		modelObj("m1mini", "gpt-5-mini", system.OpenAIModelProvider),
+		aliasObj("llm", "m1sonnet"),
+		aliasObj("llm-mini", "m1mini"),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com", []string{"*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 3 {
+		t.Fatalf("models = %d, want 3: %+v", len(models), models)
+	}
+
+	var gotDefault string
+	defaults := 0
+	for _, model := range models {
+		if model.BaseURL == "" || len(model.APIs) == 0 {
+			t.Errorf("%s: incomplete endpoint %+v", model.ID, model)
+		}
+		if model.Default {
+			gotDefault = model.ID
+			defaults++
+		}
+	}
+	// The default follows the installation's own llm alias.
+	if gotDefault != "m1sonnet" {
+		t.Errorf("default = %q, want m1sonnet (what obot://llm points at)", gotDefault)
+	}
+	// Exactly one: an image asking for "the default" must not have to choose.
+	if defaults != 1 {
+		t.Errorf("models marked default = %d, want 1", defaults)
+	}
+}
+
+// An alias names one model, and that is all the agent gets.
+func TestAliasSelectionResolvesToOneModel(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1sonnet", "claude-sonnet-4-5", system.AnthropicModelProvider),
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+		aliasObj("llm", "m1sonnet"),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{types.DefaultModelAliasRefPrefix + "llm"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "m1sonnet" || !models[0].Default {
+		t.Fatalf("models = %+v", models)
+	}
+}
+
+// With no alias bound there is still a model to reach for; an image that wants
+// one should not have to choose arbitrarily.
+func TestSomethingIsAlwaysDefault(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com", []string{"*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || !models[0].Default {
+		t.Fatalf("expected a default even with no aliases bound: %+v", models)
+	}
+}
+
+// A model whose provider has no proxy route cannot be reached, so listing it
+// would offer an endpoint that does not exist.
+func TestUnroutableProviderIsSkipped(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1weird", "some-model", "not-a-real-provider"),
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com", []string{"*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "m1gpt" {
+		t.Fatalf("models = %+v", models)
+	}
+}
+
+// A template is copied to every installation, where a model's resource id is a
+// different hash. Naming a model the way its provider does is the only
+// preference that survives that copy, so it has to resolve.
+func TestProviderNativeIDSelectsAModel(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1aaa", "claude-haiku-4-5", system.AnthropicModelProvider),
+		modelObj("m1zzz", "claude-opus-4-8", system.AnthropicModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{"claude-opus-4-8", "*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+
+	// Named first, so it leads the list and is what Default falls back to --
+	// rather than m1aaa, which merely sorts first.
+	if models[0].Model != "claude-opus-4-8" || !models[0].Default {
+		t.Fatalf("expected the named model to lead and be default: %+v", models)
+	}
+	// The wildcard still contributes the rest, so a preference narrows nothing.
+	if len(models) != 2 {
+		t.Fatalf("expected the wildcard to still add the others: %+v", models)
+	}
+}
+
+// The point of listing preferences: without them the fallback is whichever
+// resource id sorts first, which has nothing to do with what the agent needs.
+// This is the Claude Code case -- a coding agent that was landing on the small
+// fast model because the installation's llm alias names a provider it cannot use.
+func TestPreferenceBeatsSortOrderWhenTheAliasDoesNotApply(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1aaa", "claude-haiku-4-5", system.AnthropicModelProvider),
+		modelObj("m1zzz", "claude-opus-4-8", system.AnthropicModelProvider),
+		modelObj("m1gpt", "gpt-5", system.OpenAIModelProvider),
+		// Bound to a model this agent may not use, so it cannot decide.
+		aliasObj("llm", "m1gpt"),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{"claude-opus-4-8", "*"}, []string{system.AnthropicModelProvider})
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	for _, model := range models {
+		if model.Default && model.Model != "claude-opus-4-8" {
+			t.Fatalf("default is %q, want the stated preference", model.Model)
+		}
+	}
+	if models[0].Model != "claude-opus-4-8" {
+		t.Fatalf("models = %+v", models)
+	}
+}
+
+// An installation that has the named model is the easy case; one that does not
+// still has to produce a working agent, or a template pinning a model would
+// break every installation without it.
+func TestUnknownPreferenceFallsBackToTheWildcard(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1aaa", "claude-haiku-4-5", system.AnthropicModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{"claude-opus-4-8", "*"}, nil)
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || models[0].Model != "claude-haiku-4-5" || !models[0].Default {
+		t.Fatalf("expected the wildcard to carry the agent: %+v", models)
+	}
+}
+
+// The same provider-native id can be served by more than one provider. Honouring
+// a preference from a provider the agent may not use would drop it later, and
+// the template would look configured while changing nothing.
+func TestPreferenceRespectsTheAgentsProviders(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
+		modelObj("m1bedrock", "claude-opus-4-8", "bedrock-model-provider"),
+		modelObj("m1anthropic", "claude-opus-4-8", system.AnthropicModelProvider),
+	).Build()
+
+	models, err := modelConfigs(context.Background(), client, "obot", "https://obot.example.com",
+		[]string{"claude-opus-4-8"}, []string{system.AnthropicModelProvider})
+	if err != nil {
+		t.Fatalf("modelConfigs: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "m1anthropic" {
+		t.Fatalf("models = %+v", models)
+	}
+}

--- a/pkg/controller/handlers/hostedagent/skills.go
+++ b/pkg/controller/handlers/hostedagent/skills.go
@@ -1,0 +1,244 @@
+package hostedagent
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	gitpkg "github.com/obot-platform/obot/pkg/git"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// skillsMountRoot is where an agent finds its skills. Each skill gets a
+	// directory named after the skill.
+	skillsMountRoot = "/etc/obot/skills"
+
+	// maxSkillFileBytes and maxSkillBytes bound what one skill can contribute.
+	// Skill files land in a Kubernetes Secret, which is capped at 1MiB in
+	// total, so a single oversized skill would otherwise make the whole sandbox
+	// unschedulable with an error that says nothing about skills.
+	maxSkillFileBytes = 256 << 10
+	maxSkillBytes     = 512 << 10
+)
+
+// skillFetcher reads a skill's files out of the repository it was indexed from.
+//
+// Obot stores only the coordinates of a skill, never its content, so the files
+// have to be fetched. Results are cached by commit: a skill pinned to a commit
+// cannot change, and reconciliation is frequent enough that cloning every pass
+// would be untenable.
+type skillFetcher struct {
+	mu    sync.Mutex
+	cache map[string][]agentbackend.File
+
+	// clone is injectable so tests do not need a git server.
+	clone func(ctx context.Context, repoURL, token, ref string) (string, string, func(), error)
+}
+
+func newSkillFetcher() *skillFetcher {
+	return &skillFetcher{
+		cache: map[string][]agentbackend.File{},
+		clone: gitpkg.Clone,
+	}
+}
+
+// skillFiles returns the files for each skill and the config entries describing
+// where they were placed.
+//
+// A skill that cannot be fetched is skipped rather than failing the sandbox: an
+// agent usually has several, and one unreachable repository should not stop it
+// from starting.
+func (f *skillFetcher) skillFiles(ctx context.Context, client kclient.Client, namespace string, ids []string) ([]agentbackend.File, []agentConfigSkill) {
+	var (
+		files   []agentbackend.File
+		entries []agentConfigSkill
+		seen    = map[string]struct{}{}
+	)
+
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		var skill v1.Skill
+		if err := client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: id}, &skill); err != nil {
+			log.Warnf("hosted agent: skipping skill %q: %v", id, err)
+			continue
+		}
+
+		name := skillDirName(&skill)
+		mount := path.Join(skillsMountRoot, name)
+
+		skillFiles, err := f.fetch(ctx, &skill, mount)
+		if err != nil {
+			log.Warnf("hosted agent: skipping skill %q: %v", id, err)
+			continue
+		}
+
+		files = append(files, skillFiles...)
+		entries = append(entries, agentConfigSkill{
+			ID:          skill.Name,
+			Name:        name,
+			Path:        mount,
+			Description: skill.Spec.Description,
+		})
+	}
+	return files, entries
+}
+
+// skillDirName is the directory a skill is installed under. The manifest name
+// is preferred over the generated ID because an agent reads these paths.
+func skillDirName(skill *v1.Skill) string {
+	name := strings.TrimSpace(skill.Spec.Name)
+	if name == "" {
+		name = skill.Name
+	}
+	return sanitizeSkillName(name)
+}
+
+// sanitizeSkillName keeps a skill name usable as a single path segment. A name
+// comes from a third-party repository, so "../" must not be able to place files
+// outside the skills directory.
+func sanitizeSkillName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	result := strings.Trim(b.String(), ".-")
+	if result == "" {
+		return "skill"
+	}
+	return result
+}
+
+func (f *skillFetcher) fetch(ctx context.Context, skill *v1.Skill, mount string) ([]agentbackend.File, error) {
+	if skill.Spec.RepoURL == "" {
+		return nil, fmt.Errorf("skill has no repository")
+	}
+
+	key := skill.Spec.RepoURL + "@" + skill.Spec.CommitSHA + "#" + skill.Spec.RelativePath + "->" + mount
+	// Only a commit-pinned skill is cacheable. Without a commit the repository
+	// could have moved, and serving a stale checkout would silently pin the
+	// agent to an old version of the skill.
+	cacheable := skill.Spec.CommitSHA != ""
+
+	if cacheable {
+		f.mu.Lock()
+		cached, ok := f.cache[key]
+		f.mu.Unlock()
+		if ok {
+			return cached, nil
+		}
+	}
+
+	ref := skill.Spec.CommitSHA
+	if ref == "" {
+		ref = skill.Spec.RepoRef
+	}
+	dir, _, cleanup, err := f.clone(ctx, skill.Spec.RepoURL, "", ref)
+	if err != nil {
+		return nil, fmt.Errorf("clone %s: %w", skill.Spec.RepoURL, err)
+	}
+	defer cleanup()
+
+	root := dir
+	if skill.Spec.RelativePath != "" {
+		root = filepath.Join(dir, filepath.FromSlash(skill.Spec.RelativePath))
+	}
+	// The skill's own directory is what gets installed, not the file naming it.
+	if info, err := os.Stat(root); err == nil && !info.IsDir() {
+		root = filepath.Dir(root)
+	}
+
+	files, err := readSkillDir(root, mount)
+	if err != nil {
+		return nil, err
+	}
+
+	if cacheable {
+		f.mu.Lock()
+		f.cache[key] = files
+		f.mu.Unlock()
+	}
+	return files, nil
+}
+
+// readSkillDir collects a skill's files, rooted at the mount point it will be
+// installed under.
+func readSkillDir(root, mount string) ([]agentbackend.File, error) {
+	var (
+		files []agentbackend.File
+		total int
+	)
+
+	err := filepath.WalkDir(root, func(current string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// A symlink could point anywhere in the checkout, or out of it.
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Size() > maxSkillFileBytes {
+			return fmt.Errorf("%s is larger than the %d byte per-file limit", entry.Name(), maxSkillFileBytes)
+		}
+		total += int(info.Size())
+		if total > maxSkillBytes {
+			return fmt.Errorf("skill exceeds the %d byte limit", maxSkillBytes)
+		}
+
+		rel, err := filepath.Rel(root, current)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(current)
+		if err != nil {
+			return err
+		}
+		files = append(files, agentbackend.File{
+			Path:    path.Join(mount, filepath.ToSlash(rel)),
+			Content: content,
+			Mode:    0o444,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Stable order: the file set feeds the desired revision, and a walk that
+	// reordered itself would restart every sandbox for no reason.
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, nil
+}

--- a/pkg/controller/handlers/hostedagent/skills_test.go
+++ b/pkg/controller/handlers/hostedagent/skills_test.go
@@ -1,0 +1,133 @@
+package hostedagent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// fakeRepo writes a skill directory and returns a clone function serving it.
+func fakeRepo(t *testing.T, files map[string]string) (func(context.Context, string, string, string) (string, string, func(), error), *int) {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		full := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	calls := 0
+	return func(context.Context, string, string, string) (string, string, func(), error) {
+		calls++
+		return dir, "sha", func() {}, nil
+	}, &calls
+}
+
+func skillClient(skills ...*v1.Skill) *fake.ClientBuilder {
+	builder := fake.NewClientBuilder().WithScheme(storagescheme.Scheme)
+	for _, skill := range skills {
+		builder = builder.WithObjects(skill)
+	}
+	return builder
+}
+
+// Obot stores only a skill's coordinates, so the files have to be fetched and
+// placed in the sandbox. An agent should find its skills on disk rather than
+// being told where to go and get them.
+func TestSkillFilesArePlacedInTheSandbox(t *testing.T) {
+	clone, calls := fakeRepo(t, map[string]string{
+		"SKILL.md":           "# PDF skill",
+		"scripts/extract.py": "print('hi')",
+		".git/config":        "should not be copied",
+	})
+	fetcher := &skillFetcher{cache: map[string][]agentbackend.File{}, clone: clone}
+
+	client := skillClient(&v1.Skill{
+		ObjectMeta: metav1.ObjectMeta{Name: "sk1pdf", Namespace: "obot"},
+		Spec: v1.SkillSpec{
+			SkillManifest: types.SkillManifest{Name: "pdf", Description: "Work with PDFs"},
+			RepoURL:       "https://example.com/skills.git",
+			CommitSHA:     "abc123",
+		},
+	}).Build()
+
+	files, entries := fetcher.skillFiles(context.Background(), client, "obot", []string{"sk1pdf"})
+
+	if len(entries) != 1 || entries[0].Path != "/etc/obot/skills/pdf" {
+		t.Fatalf("entries = %+v", entries)
+	}
+	if entries[0].Description != "Work with PDFs" {
+		t.Errorf("description = %q", entries[0].Description)
+	}
+
+	paths := map[string]string{}
+	for _, file := range files {
+		paths[file.Path] = string(file.Content)
+	}
+	if paths["/etc/obot/skills/pdf/SKILL.md"] != "# PDF skill" {
+		t.Errorf("SKILL.md missing or wrong: %v", paths)
+	}
+	if paths["/etc/obot/skills/pdf/scripts/extract.py"] == "" {
+		t.Errorf("nested file missing: %v", paths)
+	}
+	for path := range paths {
+		if strings.Contains(path, ".git") {
+			t.Errorf("git metadata was copied: %s", path)
+		}
+	}
+
+	// A pinned skill cannot change, so it is fetched once however often the
+	// instance reconciles.
+	fetcher.skillFiles(context.Background(), client, "obot", []string{"sk1pdf"})
+	if *calls != 1 {
+		t.Errorf("clone calls = %d, want 1 (the result should be cached)", *calls)
+	}
+}
+
+// A skill name comes from a third-party repository, so it must not be able to
+// place files outside the skills directory.
+func TestSkillNameCannotEscapeTheSkillsDirectory(t *testing.T) {
+	for _, tt := range []struct{ name, want string }{
+		{"pdf", "pdf"},
+		{"../../etc/passwd", "etc-passwd"},
+		{"a/b", "a-b"},
+		{"..", "skill"},
+		// With no manifest name the object name is used, which is still a
+		// stable, unique directory.
+		{"", "sk1"},
+	} {
+		skill := &v1.Skill{
+			ObjectMeta: metav1.ObjectMeta{Name: "sk1"},
+			Spec:       v1.SkillSpec{SkillManifest: types.SkillManifest{Name: tt.name}},
+		}
+		if got := skillDirName(skill); got != tt.want {
+			t.Errorf("skillDirName(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+// One unreachable skill repository should not stop an agent that has others.
+func TestUnfetchableSkillIsSkipped(t *testing.T) {
+	fetcher := &skillFetcher{cache: map[string][]agentbackend.File{}}
+	client := skillClient(&v1.Skill{
+		ObjectMeta: metav1.ObjectMeta{Name: "sk1broken", Namespace: "obot"},
+		Spec:       v1.SkillSpec{SkillManifest: types.SkillManifest{Name: "broken"}},
+	}).Build()
+
+	files, entries := fetcher.skillFiles(context.Background(), client, "obot", []string{"sk1broken", "sk1missing"})
+	if len(files) != 0 || len(entries) != 0 {
+		t.Fatalf("expected nothing for unfetchable skills: %v %v", files, entries)
+	}
+}

--- a/pkg/controller/handlers/hostedagentpool/hostedagentpool.go
+++ b/pkg/controller/handlers/hostedagentpool/hostedagentpool.go
@@ -1,0 +1,130 @@
+// Package hostedagentpool reconciles hosted-agent capacity pools
+// through the implementation-neutral agent backend contract.
+package hostedagentpool
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+)
+
+const pollInterval = 10 * time.Second
+
+type Handler struct {
+	backend agentbackend.PoolBackend
+}
+
+func New(backend agentbackend.PoolBackend) *Handler {
+	return &Handler{backend: backend}
+}
+
+// Orchestrate converges one pool with its backend pool.
+func (h *Handler) Orchestrate(req router.Request, resp router.Response) error {
+	pool := req.Object.(*v1.HostedAgentPool)
+	if h.backend == nil {
+		return fmt.Errorf("hosted agent backend is not configured")
+	}
+
+	ref := poolRef(pool)
+	desired, err := desiredPool(pool, ref)
+	if err != nil {
+		return err
+	}
+	observation, err := h.backend.ReconcilePool(req.Ctx, desired)
+	if err != nil {
+		return err
+	}
+	previous := pool.Status
+	applyObservation(pool, desired.Revision, observation)
+	resp.RetryAfter(pollInterval)
+
+	// Writing an unchanged status still emits a change event, which reconciles
+	// this pool again immediately and defeats RetryAfter. The status has
+	// no heartbeat field, so an exact comparison is enough.
+	if pool.Status == previous {
+		return nil
+	}
+	return req.Client.Status().Update(req.Ctx, pool)
+}
+
+// Remove asks the backend to remove a pool. The router retains the
+// finalizer while this handler requests a retry.
+func (h *Handler) Remove(req router.Request, resp router.Response) error {
+	pool := req.Object.(*v1.HostedAgentPool)
+	if h.backend == nil {
+		return fmt.Errorf("hosted agent backend is not configured")
+	}
+	ref := poolRef(pool)
+	result, err := h.backend.DeletePool(req.Ctx, ref)
+	if err != nil {
+		return err
+	}
+	if !result.Complete {
+		resp.RetryAfter(pollInterval)
+		return nil
+	}
+	return nil
+}
+
+func desiredPool(pool *v1.HostedAgentPool, ref agentbackend.PoolRef) (agentbackend.DesiredPool, error) {
+	if err := pool.Spec.Manifest.Validate(); err != nil {
+		return agentbackend.DesiredPool{}, fmt.Errorf("invalid hosted agent pool: %w", err)
+	}
+	desired := agentbackend.DesiredPool{
+		Ref:          ref,
+		MaxSandboxes: pool.Spec.Manifest.MaxSandboxes,
+		Capacity: agentbackend.ResourceQuantity{
+			CPUVCPUs:     pool.Spec.Manifest.Capacity.CPUVCPUs,
+			MemoryBytes:  pool.Spec.Manifest.Capacity.MemoryBytes,
+			StorageBytes: pool.Spec.Manifest.Capacity.StorageBytes,
+		},
+		Suspended: pool.Spec.Manifest.Suspended,
+	}
+	revisionValue := struct {
+		Capacity  agentbackend.ResourceQuantity `json:"capacity"`
+		Suspended bool                          `json:"suspended"`
+	}{
+		Capacity:  desired.Capacity,
+		Suspended: desired.Suspended,
+	}
+	data, err := json.Marshal(revisionValue)
+	if err != nil {
+		return agentbackend.DesiredPool{}, fmt.Errorf("marshal pool revision input: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	desired.Revision = hex.EncodeToString(sum[:])
+	return desired, nil
+}
+
+func poolRef(pool *v1.HostedAgentPool) agentbackend.PoolRef {
+	return agentbackend.PoolRef{
+		// Pool assignments and HostedAgentInstance.PoolID refer to
+		// the pool resource ID (its storage name), so the backend's
+		// managed pool identity must use that same stable value.
+		ID:        pool.Name,
+		BackendID: pool.Status.BackendPoolID,
+	}
+}
+
+func applyObservation(pool *v1.HostedAgentPool, desiredRevision string, observation agentbackend.PoolObservation) {
+	if observation.Ref.BackendID != "" {
+		pool.Status.BackendPoolID = observation.Ref.BackendID
+	}
+	pool.Status.ObservedRevision = observation.ObservedRevision
+	pool.Status.Schedulable = observation.Schedulable
+	pool.Status.Reason = observation.Reason
+	pool.Status.Message = observation.Message
+	pool.Status.Capacity.CPUVCPUs = observation.Capacity.CPUVCPUs
+	pool.Status.Capacity.MemoryBytes = observation.Capacity.MemoryBytes
+	pool.Status.Capacity.StorageBytes = observation.Capacity.StorageBytes
+	pool.Status.Ready = observation.Exists &&
+		observation.State == agentbackend.StateReady &&
+		observation.ObservedRevision == desiredRevision
+	pool.Status.Degraded = observation.State == agentbackend.StateError
+}

--- a/pkg/controller/handlers/hostedagentpool/hostedagentpool_test.go
+++ b/pkg/controller/handlers/hostedagentpool/hostedagentpool_test.go
@@ -1,0 +1,94 @@
+package hostedagentpool
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDesiredPoolIsStableAndUsesObotID(t *testing.T) {
+	pool := validPool()
+
+	first, err := desiredPool(pool, poolRef(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := desiredPool(pool, poolRef(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Revision == "" || first.Revision != second.Revision {
+		t.Fatalf("revision is not deterministic: %q, %q", first.Revision, second.Revision)
+	}
+	if first.Ref.ID != "pool-1" {
+		t.Fatalf("backend did not receive Obot-managed ID: %q", first.Ref.ID)
+	}
+
+	pool.Spec.Manifest.Suspended = true
+	changed, err := desiredPool(pool, poolRef(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed.Revision == first.Revision {
+		t.Fatal("suspension did not change desired revision")
+	}
+}
+
+func TestDesiredPoolRejectsZeroCapacity(t *testing.T) {
+	pool := validPool()
+	pool.Spec.Manifest.Capacity.MemoryBytes = 0
+	if _, err := desiredPool(pool, poolRef(pool)); err == nil {
+		t.Fatal("expected zero memory capacity to be rejected")
+	}
+}
+
+func TestApplyObservationRequiresMatchingReadyRevision(t *testing.T) {
+	pool := validPool()
+	observation := agentbackend.PoolObservation{
+		Ref:               agentbackend.PoolRef{ID: "a1", BackendID: "pool-1"},
+		Exists:            true,
+		ObservedRevision:  "old",
+		State:             agentbackend.StateReady,
+		Schedulable:       true,
+		BackendGeneration: 3,
+		Capacity: agentbackend.ResourceQuantity{
+			CPUVCPUs: 2, MemoryBytes: 1024, StorageBytes: 2048,
+		},
+	}
+	applyObservation(pool, "wanted", observation)
+	if pool.Status.Ready {
+		t.Fatal("pool was ready with a stale revision")
+	}
+	if pool.Status.BackendPoolID != "pool-1" || !pool.Status.Schedulable {
+		t.Fatalf("backend observation was not retained: %#v", pool.Status)
+	}
+
+	observation.ObservedRevision = "wanted"
+	applyObservation(pool, "wanted", observation)
+	if !pool.Status.Ready || pool.Status.Degraded {
+		t.Fatalf("matching observation was not ready: %#v", pool.Status)
+	}
+
+	observation.State = agentbackend.StateError
+	observation.Reason = "PoolFailed"
+	applyObservation(pool, "wanted", observation)
+	if !pool.Status.Degraded || pool.Status.Ready {
+		t.Fatalf("error observation was not degraded: %#v", pool.Status)
+	}
+}
+
+func validPool() *v1.HostedAgentPool {
+	return &v1.HostedAgentPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+		Spec: v1.HostedAgentPoolSpec{
+			Manifest: types.HostedAgentPoolManifest{
+				Capacity: types.HostedAgentResourceQuantity{
+					CPUVCPUs: 2, MemoryBytes: 1024, StorageBytes: 2048,
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/hostedagentpooldefaults_test.go
+++ b/pkg/controller/hostedagentpooldefaults_test.go
@@ -1,0 +1,105 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEnsureHostedAgentPoolDefaults(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).Build()
+
+	if err := ensureHostedAgentPoolDefaults(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+
+	var defaults v1.HostedAgentPoolDefaults
+	key := kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: "default"}
+	if err := client.Get(ctx, key, &defaults); err != nil {
+		t.Fatal(err)
+	}
+	if err := defaults.Spec.Manifest.Validate(); err != nil {
+		t.Fatalf("created invalid defaults: %v", err)
+	}
+
+	defaults.Spec.Manifest = types.HostedAgentPoolDefaultsManifest{
+		Capacity: types.HostedAgentResourceQuantity{
+			CPUVCPUs:     8,
+			MemoryBytes:  16,
+			StorageBytes: 32,
+		},
+		Suspended: true,
+	}
+	if err := client.Update(ctx, &defaults); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureHostedAgentPoolDefaults(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Get(ctx, key, &defaults); err != nil {
+		t.Fatal(err)
+	}
+	if defaults.Spec.Manifest.Capacity.CPUVCPUs != 8 || !defaults.Spec.Manifest.Suspended {
+		t.Fatalf("existing administrator defaults were changed: %#v", defaults.Spec.Manifest)
+	}
+}
+
+func TestEnsureHostedAgentPoolDefaultsPreservesExisting(t *testing.T) {
+	existing := &v1.HostedAgentPoolDefaults{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: system.DefaultNamespace},
+		Spec: v1.HostedAgentPoolDefaultsSpec{
+			Manifest: types.HostedAgentPoolDefaultsManifest{
+				Capacity: types.HostedAgentResourceQuantity{
+					CPUVCPUs:     2,
+					MemoryBytes:  1,
+					StorageBytes: 1,
+				},
+			},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(existing).Build()
+	if err := ensureHostedAgentPoolDefaults(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+
+	var got v1.HostedAgentPoolDefaults
+	if err := client.Get(context.Background(), kclient.ObjectKeyFromObject(existing), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Spec.Manifest.Capacity.CPUVCPUs != 2 {
+		t.Fatalf("existing defaults were overwritten: %#v", got.Spec.Manifest)
+	}
+}
+
+// The seeded defaults must state the sandbox count rather than leaving it to
+// the fallback, or an administrator opening the defaults sees a blank field
+// while a different number is actually in force.
+func TestEnsureHostedAgentPoolDefaultsSeedsMaxSandboxes(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).Build()
+
+	if err := ensureHostedAgentPoolDefaults(context.Background(), client); err != nil {
+		t.Fatalf("ensureHostedAgentPoolDefaults: %v", err)
+	}
+
+	var defaults v1.HostedAgentPoolDefaults
+	if err := client.Get(context.Background(), kclient.ObjectKey{
+		Namespace: system.DefaultNamespace, Name: "default",
+	}, &defaults); err != nil {
+		t.Fatalf("get defaults: %v", err)
+	}
+
+	if defaults.Spec.Manifest.MaxSandboxes <= 0 {
+		t.Errorf("maxSandboxes = %d, want a positive seeded value", defaults.Spec.Manifest.MaxSandboxes)
+	}
+	if err := defaults.Spec.Manifest.Validate(); err != nil {
+		t.Errorf("seeded defaults are invalid: %v", err)
+	}
+}

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -5,10 +5,14 @@ import (
 	"github.com/obot-platform/obot/pkg/controller/generationed"
 	"github.com/obot-platform/obot/pkg/controller/handlers/accesscontrolrule"
 	"github.com/obot-platform/obot/pkg/controller/handlers/adminworkspace"
+	"github.com/obot-platform/obot/pkg/controller/handlers/agentcatalog"
 	"github.com/obot-platform/obot/pkg/controller/handlers/alias"
 	"github.com/obot-platform/obot/pkg/controller/handlers/auditlogexport"
 	"github.com/obot-platform/obot/pkg/controller/handlers/cleanup"
 	gitcredentialhandler "github.com/obot-platform/obot/pkg/controller/handlers/gitcredential"
+	"github.com/obot-platform/obot/pkg/controller/handlers/hostedagent"
+	hostedagentcreds "github.com/obot-platform/obot/pkg/controller/handlers/hostedagent/credentials"
+	"github.com/obot-platform/obot/pkg/controller/handlers/hostedagentpool"
 	"github.com/obot-platform/obot/pkg/controller/handlers/imagepullsecret"
 	"github.com/obot-platform/obot/pkg/controller/handlers/mcpcatalog"
 	"github.com/obot-platform/obot/pkg/controller/handlers/mcpserver"
@@ -54,6 +58,9 @@ func (c *Controller) setupRoutes() {
 	oauthclients := oauthclients.NewHandler(c.services.GatewayClient)
 	systemMCPServerHandler := systemmcpserver.New(c.services.GatewayClient, c.services.MCPSessionManager, c.services.ServerURL)
 	nanobotAgentHandler := nanobotagent.New(c.services.GatewayClient, c.services.LocalRouter, c.services.NanobotAgentImage, c.services.ServerURL, c.services.MCPServerNamespace, c.services.MCPSessionManager)
+	agentCatalogHandler := agentcatalog.New()
+	hostedAgentHandler := hostedagent.New(c.services.AgentBackend, hostedagentcreds.New(c.services.GatewayClient), c.services.ServerURL, c.services.AgentServerURL)
+	hostedAgentPoolHandler := hostedagentpool.New(c.services.AgentBackend)
 	oktaGroupMigrationHandler := oktagroupmigration.New()
 	projectHandler := project.New(c.services.GatewayClient)
 	imagePullSecretHandler := imagepullsecret.New(c.services.GatewayClient, c.services.LocalK8sClient, c.services.MCPRuntimeBackend, c.services.MCPServerNamespace, c.services.ServiceNamespace, c.services.ServiceAccountName, c.services.MCPImagePullSecrets, c.services.ServiceAccountIssuerURL)
@@ -105,6 +112,24 @@ func (c *Controller) setupRoutes() {
 
 	// Skill
 	root.Type(&v1.Skill{}).HandlerFunc(cleanup.Cleanup)
+
+	// AgentCatalog
+	root.Type(&v1.AgentCatalog{}).HandlerFunc(agentCatalogHandler.Sync)
+
+	// HostedAgent
+	// cleanup.Cleanup honors DeleteRefs, which removes agents whose AgentCatalog
+	// is gone. Hand-registered agents have no SourceID and are left alone.
+	root.Type(&v1.HostedAgent{}).HandlerFunc(cleanup.Cleanup)
+
+	// HostedAgentInstance
+	root.Type(&v1.HostedAgentInstance{}).HandlerFunc(cleanup.Cleanup)
+	root.Type(&v1.HostedAgentInstance{}).HandlerFunc(hostedAgentHandler.EnsurePool)
+	root.Type(&v1.HostedAgentInstance{}).FinalizeFunc(v1.HostedAgentInstanceFinalizer, hostedAgentHandler.RemoveInstance)
+	root.Type(&v1.HostedAgentInstance{}).HandlerFunc(hostedAgentHandler.OrchestrateInstance)
+
+	// HostedAgentPool
+	root.Type(&v1.HostedAgentPool{}).FinalizeFunc(v1.HostedAgentPoolFinalizer, hostedAgentPoolHandler.Remove)
+	root.Type(&v1.HostedAgentPool{}).HandlerFunc(hostedAgentPoolHandler.Orchestrate)
 
 	// ImagePullSecret
 	root.Type(&v1.ImagePullSecret{}).FinalizeFunc(v1.ImagePullSecretFinalizer, imagePullSecretHandler.Cleanup)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -20,9 +20,13 @@ import (
 	apiclienttypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
+	"github.com/obot-platform/obot/pkg/agentbackend"
+	agentbackendfake "github.com/obot-platform/obot/pkg/agentbackend/fake"
+	agentbackendkubernetes "github.com/obot-platform/obot/pkg/agentbackend/kubernetes"
 	"github.com/obot-platform/obot/pkg/api/authn"
 	"github.com/obot-platform/obot/pkg/api/authz"
 	"github.com/obot-platform/obot/pkg/api/handlers"
+	"github.com/obot-platform/obot/pkg/api/handlers/agentconnect"
 	"github.com/obot-platform/obot/pkg/api/handlers/mcpgateway"
 	"github.com/obot-platform/obot/pkg/api/server"
 	"github.com/obot-platform/obot/pkg/api/server/audit"
@@ -80,6 +84,8 @@ import (
 
 var pkgLog = logger.Package()
 
+const leaderElectionRequestTimeout = 15 * time.Second
+
 type (
 	GatewayConfig     gserver.Options
 	AuditConfig       audit.Options
@@ -115,6 +121,8 @@ type Config struct {
 	MDMAssetSource                       string `usage:"The source for MDM assets (a local directory, a tar archive path, or an HTTP(S) tarball URL)" default:"https://github.com/obot-platform/obot-sentry/releases/download/v0.1.4/mdm-assets.tar.gz" env:"OBOT_SERVER_MDM_ASSET_SOURCE"`
 	DefaultSkillRepoURL                  string `usage:"The default skill repository URL (must be HTTPS GitHub URL)" default:"https://github.com/obot-platform/skills" env:"OBOT_DEFAULT_SKILL_REPO_URL"`
 	DefaultSkillRepoRef                  string `usage:"The ref (branch/tag) for the default skill repository" default:"" env:"OBOT_DEFAULT_SKILL_REPO_REF"`
+	DefaultHostedAgentsCatalogURL        string `usage:"The default hosted agent catalog repository URL (must be HTTPS)" default:"https://github.com/obot-platform/hosted-agents-catalog" env:"OBOT_DEFAULT_HOSTED_AGENTS_CATALOG_URL"`
+	DefaultHostedAgentsCatalogRef        string `usage:"The ref (branch/tag) for the default hosted agent catalog repository" default:"" env:"OBOT_DEFAULT_HOSTED_AGENTS_CATALOG_REF"`
 	ModelInfoSourceURL                   string `usage:"Authoritative URL for the model info (pricing) source synced into model costs; changes take effect on restart, empty disables it" default:"https://models.dev/api.json"`
 	DisableUpdateCheck                   bool   `usage:"Disable Obot server update checks"`
 	HideK8sDetails                       bool   `usage:"Hide Kubernetes configuration details such as the Server Scheduling page from the UI" default:"false"`
@@ -123,6 +131,11 @@ type Config struct {
 	LLMAuditLogRetentionDays             int    `usage:"Number of days to retain LLM audit logs (0 to disable cleanup)." default:"90"`
 	DisableLLMAuditLog                   bool   `usage:"Disable LLM gateway audit logging" default:"false"`
 	EnableAgents                         *bool  `usage:"Enable Obot Agent features. When unset, agents are disabled for new deployments but grandfathered in for deployments that already have agents. Explicitly set to true to force-enable, or false to force-disable, regardless of grandfathering." env:"OBOT_ENABLE_AGENTS"`
+	HostedAgentsBackend                  string `usage:"Hosted agent runtime backend (disabled, fake, or kubernetes). Defaults to the MCP runtime backend: kubernetes when MCP servers run on Kubernetes, and otherwise fake, since there is no docker agent backend." name:"hosted-agents-backend" env:"OBOT_HOSTED_AGENTS_BACKEND"`
+	HostedAgentsStorageClassName         string `usage:"StorageClass for hosted agent pool volumes. It should use volumeBindingMode WaitForFirstConsumer, which is what keeps a pool on one node." name:"hosted-agents-storage-class-name"`
+	HostedAgentsPodSecurityLevel         string `usage:"Pod Security Admission level enforced on the namespace hosted agent sandboxes run in (privileged, baseline, or restricted). Must match the namespace's own label or sandboxes are refused at admission. Empty means restricted." name:"hosted-agents-pod-security-level" env:"OBOT_HOSTED_AGENTS_POD_SECURITY_LEVEL"`
+	HostedAgentsImagePullPolicy          string `usage:"Pull policy for hosted agent sandbox images (Always, IfNotPresent, Never)" default:"" name:"hosted-agents-image-pull-policy" env:"OBOT_HOSTED_AGENTS_IMAGE_PULL_POLICY"`
+	HostedAgentsCleanupImage             string `usage:"Image used to erase a deleted sandbox's directory from its pool volume. Needs a shell and coreutils." name:"hosted-agents-cleanup-image" default:"busybox:1.36"`
 	MCPServerSearchImage                 string `usage:"Container image for the obot MCP server" default:"ghcr.io/obot-platform/obot-mcp-server:v0.2.0"`
 	NanobotAgentImage                    string `usage:"Container image for the Nanobot agent MCP server" default:"ghcr.io/obot-platform/nanobot-agent:v0.0.91"`
 	MCPNetworkPolicyProviderChartRepo    string `usage:"Helm repository URL for the network policy provider chart"`
@@ -167,29 +180,35 @@ type Services struct {
 	AuditLogger           audit.Logger
 	DSN                   string
 	ServerURL             string
-	MCPSessionManager     *mcp.SessionManager
-	TunnelManager         *tunnel.Manager
-	OAuthServerConfig     handlers.OAuthAuthorizationServerConfig
+	// AgentServerURL is Obot's address as a sandbox can reach it, which differs
+	// from ServerURL when Obot runs outside the cluster its sandboxes run in.
+	AgentServerURL    string
+	MCPSessionManager *mcp.SessionManager
+	TunnelManager     *tunnel.Manager
+	OAuthServerConfig handlers.OAuthAuthorizationServerConfig
 
 	// Global token storage client for MCP OAuth
 	MCPOAuthTokenStorage         mcp.GlobalTokenStore
 	MCPSecretBindingAllowedLabel string
 	RegistryNoAuth               bool
 
-	PostgresDSN                 string
-	ProviderRegistryPaths       []string
-	DevUIPort                   int
-	UserUIPort                  int
-	GatewayServer               *gserver.Server
-	Bootstrapper                *bootstrap.Bootstrap
-	LocalAuthProvider           *localauth.Provider
-	AuthEnabled                 bool
-	DefaultMCPCatalogPath       string
-	DefaultSystemMCPCatalogPath string
-	MDMAssetSource              string
-	DefaultSkillRepoURL         string
-	DefaultSkillRepoRef         string
-	ModelInfoSourceURL          string
+	PostgresDSN                   string
+	ProviderRegistryPaths         []string
+	DevUIPort                     int
+	DevMode                       bool
+	UserUIPort                    int
+	GatewayServer                 *gserver.Server
+	Bootstrapper                  *bootstrap.Bootstrap
+	LocalAuthProvider             *localauth.Provider
+	AuthEnabled                   bool
+	DefaultMCPCatalogPath         string
+	DefaultSystemMCPCatalogPath   string
+	MDMAssetSource                string
+	DefaultSkillRepoURL           string
+	DefaultSkillRepoRef           string
+	DefaultHostedAgentsCatalogURL string
+	DefaultHostedAgentsCatalogRef string
+	ModelInfoSourceURL            string
 
 	// Used for indexed lookups of access control rules.
 	AccessControlRuleHelper *accesscontrolrule.Helper
@@ -199,6 +218,9 @@ type Services struct {
 
 	// Used for indexed lookups of skill access rules.
 	SkillAccessRuleHelper *skillaccessrule.Helper
+
+	// Used for indexed lookups of hosted agent access rules.
+	HostedAgentAccessRuleHelper *hostedagentaccessrule.Helper
 
 	MCPOAuthClientSecretExpiration time.Duration
 	ForceDynamicClient             bool
@@ -230,13 +252,19 @@ type Services struct {
 	// environment/Helm config and not modifiable via UI.
 	PSASettingsFromHelm *v1.PodSecurityAdmissionSettings
 
-	DisableUpdateCheck                   bool
-	HideK8sDetails                       bool
-	MCPRuntimeBackend                    string
-	MCPImagePullSecrets                  []string
-	MCPHTTPWebhookBaseImage              string
-	MessagePoliciesEnabled               bool
-	EnableAgents                         *bool
+	DisableUpdateCheck      bool
+	HideK8sDetails          bool
+	MCPRuntimeBackend       string
+	MCPImagePullSecrets     []string
+	MCPHTTPWebhookBaseImage string
+	MessagePoliciesEnabled  bool
+	EnableAgents            *bool
+	AgentBackend            agentbackend.Backend
+	AgentBackendKind        string
+	// AgentDevRouter reaches sandboxes from outside the cluster. It is set only
+	// in development; in production Obot runs in-cluster and the sandbox address
+	// resolves directly.
+	AgentDevRouter                       agentconnect.DevRouter
 	MCPNetworkPolicyEnabled              bool
 	MCPDefaultDenyAllEgress              bool
 	MCPServerSearchImage                 string
@@ -488,7 +516,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	if config.ElectionFile != "" {
 		electionConfig = leader.NewFileElectionConfig(config.ElectionFile)
 	} else {
-		electionConfig = leader.NewDefaultElectionConfig("", "obot-controller", restConfig)
+		electionConfig = leader.NewDefaultElectionConfig("", "obot-controller", leaderElectionRESTConfig(restConfig))
 	}
 	r, err := nah.NewRouter("obot-controller", &nah.Options{
 		RESTConfig:     restConfig,
@@ -547,11 +575,17 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		serviceAccountIssuerURL   string
 		serviceAccountIssuerError string
 	)
-	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+	// Hosted agents can require a cluster independently of how MCP servers run,
+	// so either feature is reason enough to build a local config.
+	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) || hostedAgentsNeedK8s(config) {
 		localK8sConfig, err = BuildLocalK8sConfig()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build local Kubernetes config: %w", err)
 		}
+	}
+	if localK8sConfig != nil && mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+		// Image pull secret issuance is an MCP concern and has no bearing on
+		// hosted agents.
 		serviceAccountIssuerURL, err = imagepullsecrets.DiscoverServiceAccountIssuer(ctx, localK8sConfig)
 		if err != nil {
 			serviceAccountIssuerError = err.Error()
@@ -673,7 +707,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 			// The router is scoped to the MCP namespace, but the managed provider token
 			// secret lives in Obot's runtime namespace.
 			ByObject:       localK8sCacheByObject(config.MCPNamespace, config.ServiceNamespace),
-			ElectionConfig: leader.NewDefaultElectionConfig(config.MCPNamespace, "obot-local-controller", localK8sConfig),
+			ElectionConfig: leader.NewDefaultElectionConfig(config.MCPNamespace, "obot-local-controller", leaderElectionRESTConfig(localK8sConfig)),
 			HealthzPort:    -1, // Disable healthz port
 		})
 		if err != nil {
@@ -1061,6 +1095,81 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	}
 
 	authorizer := authz.NewAuthorizer(gatewayClient, r.Backend(), storageClient, config.DevMode, acrHelper, skillAccessRuleHelper, hostedAgentAccessRuleHelper, registryNoAuth)
+
+	// The kubernetes agent backend needs a client to the local cluster even when
+	// MCP servers do not run there -- the "hosted agents get the client
+	// directly" case the comment further down anticipates. It reuses the MCP
+	// client when one exists, and otherwise builds its own from the same
+	// config, so hosted agents work with a docker MCP backend without switching
+	// on the MCP-scoped router and its handlers.
+	agentLocalK8sClient := apiLocalK8sClient
+	if agentLocalK8sClient == nil && hostedAgentsNeedK8s(config) {
+		agentLocalK8sClient, err = kclient.NewWithWatch(localK8sConfig, kclient.Options{Scheme: k8sscheme.Scheme})
+		if err != nil {
+			return nil, fmt.Errorf("failed to build local k8s client for the agent backend: %w", err)
+		}
+	}
+	agentBackendKind, agentBackend, err := newHostedAgentsBackend(config, localK8sConfig, agentLocalK8sClient, localCacheClient)
+	if err != nil {
+		return nil, err
+	}
+
+	// Where a sandbox finds Obot depends on where Obot itself is running, and
+	// the two cases need different answers.
+	//
+	// In the cluster, the configured hostname resolving is not enough: it has to
+	// resolve somewhere a sandbox is permitted to reach, and the egress policy
+	// shipped with the chart excludes private ranges, so a hostname pointing at
+	// an internal load balancer or a node is refused even though it resolves.
+	// MCP servers have always answered this by addressing Obot's Service, and a
+	// sandbox reaches Obot for the same things, so TransformObotHostname gives
+	// it the same address rather than inventing a second mechanism.
+	//
+	// Outside the cluster -- a developer running Obot on their own machine --
+	// that method cannot answer at all: it substitutes Obot's Service, and there
+	// is no Service, so ServiceName is unset and it returns the hostname
+	// untouched. The hostname is a loopback address, which inside a sandbox
+	// means the sandbox. A node stands in for the developer's machine, since
+	// Obot listens on all of its interfaces, which is what ReachableServerURL
+	// resolves. It leaves any non-loopback hostname alone, so the in-cluster
+	// case falls through to the method above.
+	agentServerURL := config.Hostname
+	if agentBackendKind == "kubernetes" && agentLocalK8sClient != nil {
+		reachable, err := agentbackendkubernetes.ReachableServerURL(ctx, agentLocalK8sClient, config.Hostname)
+		if err != nil {
+			return nil, err
+		}
+		if reachable != config.Hostname {
+			agentServerURL = reachable
+		} else {
+			agentServerURL = mcpSessionManager.TransformObotHostname(config.Hostname)
+		}
+		if agentServerURL != config.Hostname {
+			pkgLog.Infof("hosted agent sandboxes will reach Obot at %s", agentServerURL)
+		}
+	}
+
+	// Running outside the cluster is what makes a sandbox unreachable, and it is
+	// exactly what falling back to a kubeconfig means. Reaching one through the
+	// API server needs services/proxy, which grants access to every Service in
+	// the cluster, so this is deliberately confined to development rather than
+	// something a production deployment is granted.
+	var agentDevRouter agentconnect.DevRouter
+	if router, ok := agentBackend.(agentconnect.DevRouter); ok && config.DevMode {
+		if _, inClusterErr := rest.InClusterConfig(); inClusterErr != nil {
+			agentDevRouter = router
+		}
+	}
+
+	// LocalK8sClient drives MCP-side cluster features: service account key
+	// rotation, image pull secret issuance, network policies. Hosted agents get
+	// the client directly, so this stays nil when MCP does not run on
+	// Kubernetes. Otherwise enabling hosted agents alone would switch on MCP
+	// machinery that needs configuration the deployment has no reason to set.
+	var mcpLocalK8sClient kclient.WithWatch
+	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+		mcpLocalK8sClient = apiLocalK8sClient
+	}
 	// For now, always auto-migrate the gateway database
 	svcs := &Services{
 		EncryptionConfig:      encryptionConfig,
@@ -1098,6 +1207,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		PostgresDSN:                  postgresDSN,
 		ObotNamespace:                config.ServiceNamespace,
 		DevUIPort:                    devPort,
+		DevMode:                      config.DevMode,
 		UserUIPort:                   config.UserUIPort,
 		ProviderRegistryPaths:        config.ProviderRegistries,
 		GatewayServer:                gatewayServer,
@@ -1110,6 +1220,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		DefaultSystemMCPCatalogPath:    config.DefaultSystemMCPCatalogPath,
 		DefaultSkillRepoURL:            config.DefaultSkillRepoURL,
 		DefaultSkillRepoRef:            config.DefaultSkillRepoRef,
+		DefaultHostedAgentsCatalogURL:  config.DefaultHostedAgentsCatalogURL,
+		DefaultHostedAgentsCatalogRef:  config.DefaultHostedAgentsCatalogRef,
 		ModelInfoSourceURL:             config.ModelInfoSourceURL,
 		MCPOAuthClientSecretExpiration: oauthClientExpiration,
 		ForceDynamicClient:             config.ForceDynamicClient,
@@ -1117,7 +1229,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		ModelAccessPolicyHelper:        mapHelper,
 
 		SkillAccessRuleHelper:                skillAccessRuleHelper,
-		LocalK8sClient:                       apiLocalK8sClient,
+		HostedAgentAccessRuleHelper:          hostedAgentAccessRuleHelper,
+		LocalK8sClient:                       mcpLocalK8sClient,
 		LocalRouter:                          localRouter,
 		EveryReplicaRouter:                   tunnelPeerRouter,
 		MCPServerNamespace:                   config.MCPNamespace,
@@ -1140,6 +1253,10 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		AgentIdleServerShutdownInterval:      time.Duration(config.IdleAgentShutdownHours) * time.Hour,
 		MessagePoliciesEnabled:               config.EnableMessagePolicies,
 		EnableAgents:                         config.EnableAgents,
+		AgentBackend:                         agentBackend,
+		AgentServerURL:                       agentServerURL,
+		AgentBackendKind:                     agentBackendKind,
+		AgentDevRouter:                       agentDevRouter,
 		MCPNetworkPolicyEnabled:              mcpNetworkPolicyEnabled,
 		MCPDefaultDenyAllEgress:              config.MCPDefaultDenyAllEgress,
 		MCPServerSearchImage:                 config.MCPServerSearchImage,
@@ -1280,6 +1397,82 @@ func configureDevMode(config Config) (int, Config) {
 	_ = os.Setenv("NAH_DEV_MODE", "true")
 	_ = os.Setenv("WORKSPACE_PROVIDER_IGNORE_WORKSPACE_NOT_FOUND", "true")
 	return config.DevUIPort, config
+}
+
+func leaderElectionRESTConfig(config *rest.Config) *rest.Config {
+	config = rest.CopyConfig(config)
+	if config.Timeout == 0 || config.Timeout > leaderElectionRequestTimeout {
+		config.Timeout = leaderElectionRequestTimeout
+	}
+	return config
+}
+
+// resolveHostedAgentsBackendKind applies the default so that callers which need to know
+// the backend before it is constructed agree with newHostedAgentsBackend.
+//
+// Unset follows the MCP runtime, because a deployment that already runs MCP
+// servers on a cluster has everything hosted agents need and would otherwise
+// have to name the same backend twice.
+//
+// A docker MCP runtime resolves to the fake backend for now, because there is
+// no docker agent backend yet. When one lands, this is where it goes: the
+// docker case becomes "docker" and the fallback stops being a placeholder.
+func resolveHostedAgentsBackendKind(config Config) string {
+	kind := strings.ToLower(strings.TrimSpace(config.HostedAgentsBackend))
+	if kind != "" {
+		return kind
+	}
+	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
+		return "kubernetes"
+	}
+	return "fake"
+}
+
+func hostedAgentsNeedK8s(config Config) bool {
+	switch resolveHostedAgentsBackendKind(config) {
+	case "kubernetes", "k8s":
+		return true
+	default:
+		return false
+	}
+}
+
+func newHostedAgentsBackend(config Config, restConfig *rest.Config, client, cachedClient kclient.Client) (string, agentbackend.Backend, error) {
+	kind := resolveHostedAgentsBackendKind(config)
+
+	switch kind {
+	case "disabled":
+		return kind, agentbackend.Disabled{}, nil
+	case "fake":
+		return kind, agentbackendfake.New(agentbackendfake.Config{
+			TransitionDelay: time.Second,
+		}), nil
+	case "kubernetes", "k8s":
+		if client == nil {
+			return "", nil, fmt.Errorf("agent backend %q requires a local Kubernetes cluster, but no local K8s config is available", kind)
+		}
+		backend, err := agentbackendkubernetes.New(client, cachedClient, agentbackendkubernetes.Options{
+			// Sandboxes share the MCP namespace so that the existing local
+			// cluster router, which is scoped to it, sees them. Pools are
+			// separated by PriorityClass rather than by namespace.
+			Namespace:        config.MCPNamespace,
+			ClusterDomain:    config.MCPClusterDomain,
+			StorageClassName: config.HostedAgentsStorageClassName,
+			// Sandboxes share the MCP namespace, so they are admitted against
+			// whatever Pod Security level that namespace carries.
+			PodSecurityLevel: agentbackendkubernetes.ParsePodSecurityLevel(config.HostedAgentsPodSecurityLevel),
+			ImagePullSecrets: config.MCPImagePullSecrets,
+			CleanupImage:     config.HostedAgentsCleanupImage,
+			ImagePullPolicy:  config.HostedAgentsImagePullPolicy,
+			RESTConfig:       restConfig,
+		})
+		if err != nil {
+			return "", nil, err
+		}
+		return "kubernetes", backend, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported agent backend %q (expected disabled, fake, or kubernetes)", kind)
+	}
 }
 
 func startDevMode(ctx context.Context, storageClient storage.Client) {

--- a/pkg/services/config_test.go
+++ b/pkg/services/config_test.go
@@ -1,13 +1,107 @@
 package services
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/obot-platform/obot/pkg/agentbackend"
 	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
 )
+
+func TestNewAgentBackend(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       string
+		mcpBackend string
+		devMode    bool
+		wantKind   string
+		wantErr    bool
+		wantActive bool
+	}{
+		// Unset follows the MCP runtime rather than defaulting on its own, so a
+		// deployment names its backend once. There is no docker agent backend,
+		// so a docker MCP runtime lands on fake.
+		{name: "unset follows a docker MCP runtime", mcpBackend: "docker", wantKind: "fake", wantActive: true},
+		{name: "unset with no MCP runtime configured", wantKind: "fake", wantActive: true},
+		{name: "unset follows a kubernetes MCP runtime", mcpBackend: "kubernetes", wantErr: true},
+		{name: "unset follows the k8s alias", mcpBackend: "k8s", wantErr: true},
+		{name: "development defaults fake", devMode: true, wantKind: "fake", wantActive: true},
+		// An explicit value always wins over the MCP runtime, in both directions.
+		{name: "explicit disabled under a kubernetes MCP runtime", kind: "disabled", mcpBackend: "kubernetes", wantKind: "disabled"},
+		{name: "explicit disabled in development", kind: "disabled", devMode: true, wantKind: "disabled"},
+		{name: "explicit fake", kind: "FAKE", wantKind: "fake", wantActive: true},
+		// The Kubernetes backend needs a cluster, so selecting it without one
+		// has to fail at startup rather than at the first reconcile.
+		{name: "kubernetes without a cluster", kind: "kubernetes", wantErr: true},
+		{name: "explicit kubernetes under a docker MCP runtime", kind: "kubernetes", mcpBackend: "docker", wantErr: true},
+		{name: "discobox removed", kind: "discobox", wantErr: true},
+		{name: "unknown", kind: "other", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := Config{
+				HostedAgentsBackend: tt.kind,
+				DevMode:             tt.devMode,
+			}
+			config.MCPRuntimeBackend = tt.mcpBackend
+			kind, backend, err := newHostedAgentsBackend(config, nil, nil, nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if kind != tt.wantKind {
+				t.Fatalf("expected kind %q, got %q", tt.wantKind, kind)
+			}
+			_, err = backend.ObserveInstance(t.Context(), agentbackend.InstanceRef{ID: "test"})
+			if tt.wantActive && errors.Is(err, agentbackend.ErrDisabled) {
+				t.Fatal("expected an active backend")
+			}
+			if !tt.wantActive && !errors.Is(err, agentbackend.ErrDisabled) {
+				t.Fatalf("expected disabled backend, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLeaderElectionRESTConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeout  time.Duration
+		expected time.Duration
+	}{
+		{name: "unset", expected: leaderElectionRequestTimeout},
+		{name: "longer", timeout: time.Minute, expected: leaderElectionRequestTimeout},
+		{name: "shorter", timeout: time.Second, expected: time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := &rest.Config{Timeout: tt.timeout}
+			result := leaderElectionRESTConfig(original)
+
+			if result == original {
+				t.Fatal("expected the REST config to be copied")
+			}
+			if result.Timeout != tt.expected {
+				t.Fatalf("expected timeout %s, got %s", tt.expected, result.Timeout)
+			}
+			if original.Timeout != tt.timeout {
+				t.Fatalf("original timeout changed from %s to %s", tt.timeout, original.Timeout)
+			}
+		})
+	}
+}
 
 func TestParsePodSchedulingSettingsFromHelm(t *testing.T) {
 	tests := []struct {

--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -20,6 +20,7 @@
 		'agent-management': true,
 		'mcp-server-management': true,
 		'skills-management': true,
+		'hosted-agent-management': true,
 		'device-management': true,
 		'user-management': true,
 		'llm-gateway': true,
@@ -102,6 +103,7 @@
 		Settings,
 		PanelLeftClose,
 		Brain,
+		Container,
 		LayoutGrid,
 		KeyRound,
 		Menu,
@@ -422,6 +424,29 @@
 								id: 'skill-access-policies',
 								href: '/admin/skill-access-policies',
 								label: 'Skill Access Policies',
+								collapsible: false
+							}
+						]
+					},
+					{
+						id: 'hosted-agent-management',
+						icon: Container,
+						// "Management" is dropped deliberately: the section's items already
+						// say what they are, and the longer label wrapped to two lines in a
+						// narrow sidebar.
+						label: 'Hosted Agents',
+						collapsible: true,
+						items: [
+							{
+								id: 'hosted-agents',
+								href: '/admin/hosted-agents',
+								label: 'Templates',
+								collapsible: false
+							},
+							{
+								id: 'hosted-agent-access-policies',
+								href: '/admin/hosted-agent-access-policies',
+								label: 'Access Policies',
 								collapsible: false
 							}
 						]

--- a/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
@@ -1,0 +1,481 @@
+<script lang="ts">
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
+	import {
+		AdminService,
+		UserService,
+		type AccessControlRuleSubject,
+		type OrgUser,
+		type OrgGroup,
+		type HostedAgent,
+		type HostedAgentAccessPolicy,
+		type HostedAgentAccessPolicyResource
+	} from '$lib/services';
+	import { errors } from '$lib/stores';
+	import { goto } from '$lib/url';
+	import { getUserDisplayName } from '$lib/utils';
+	import Confirm from '../Confirm.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
+	import Table from '../table/Table.svelte';
+	import SearchHostedAgents from './SearchHostedAgents.svelte';
+	import SearchUsers from './SearchUsers.svelte';
+	import { Plus, Trash2 } from '@lucide/svelte';
+	import { onMount, untrack } from 'svelte';
+	import { fly } from 'svelte/transition';
+
+	interface Props {
+		hostedAgentAccessPolicy?: HostedAgentAccessPolicy;
+		onCreate?: (hostedAgentAccessPolicy: HostedAgentAccessPolicy) => void;
+		onUpdate?: (hostedAgentAccessPolicy: HostedAgentAccessPolicy) => void;
+		readonly?: boolean;
+	}
+
+	let {
+		hostedAgentAccessPolicy: initialHostedAgentAccessPolicy,
+		onCreate,
+		onUpdate,
+		readonly
+	}: Props = $props();
+
+	const duration = PAGE_TRANSITION_DURATION;
+	let policy = $state(
+		untrack(
+			() =>
+				initialHostedAgentAccessPolicy ?? {
+					id: undefined,
+					displayName: '',
+					subjects: [],
+					resources: []
+				}
+		)
+	);
+
+	let saving = $state<boolean | undefined>();
+	let usersAndGroups = $state<{ users: OrgUser[]; groups: OrgGroup[] }>();
+	let loadingUsersAndGroups = $state(false);
+	let loadingHostedAgents = $state(true);
+	let hostedAgents = $state<HostedAgent[]>([]);
+
+	let addUserGroupDialog = $state<ReturnType<typeof SearchUsers>>();
+	let addHostedAgentDialog = $state<ReturnType<typeof SearchHostedAgents>>();
+
+	let deletingPolicy = $state(false);
+
+	let initialPolicyJson = $derived(
+		initialHostedAgentAccessPolicy
+			? JSON.stringify({
+					subjects: initialHostedAgentAccessPolicy.subjects,
+					resources: initialHostedAgentAccessPolicy.resources
+				})
+			: ''
+	);
+
+	let hasChanges = $derived(
+		!initialPolicyJson ||
+			JSON.stringify({
+				subjects: policy.subjects,
+				resources: policy.resources
+			}) !== initialPolicyJson
+	);
+
+	onMount(async () => {
+		try {
+			hostedAgents = await AdminService.listHostedAgents();
+		} catch (error) {
+			errors.append(`Failed to load templates: ${error}`);
+		} finally {
+			loadingHostedAgents = false;
+		}
+	});
+
+	let hostedAgentsMap = $derived(new Map(hostedAgents.map((a) => [a.id, a])));
+
+	$effect(() => {
+		// Prevent loading users and groups if the policy has no subjects
+		if (!policy.subjects || policy.subjects?.length === 0) {
+			return;
+		}
+
+		loadingUsersAndGroups = true;
+
+		// Prevent refetching when adding new users or groups
+		const promises: [Promise<OrgUser[] | undefined>, Promise<OrgGroup[] | undefined>] = [
+			Promise.resolve(undefined),
+			Promise.resolve(undefined)
+		];
+
+		if (!usersAndGroups?.users) {
+			promises[0] = UserService.listUsers();
+		}
+		if (!usersAndGroups?.groups) {
+			promises[1] = UserService.listGroups();
+		}
+
+		Promise.all(promises)
+			.then(([users, groups]) => {
+				if (!usersAndGroups) {
+					usersAndGroups = { users: [], groups: [] };
+				}
+
+				if (users) {
+					usersAndGroups!.users = users;
+				}
+
+				if (groups) {
+					usersAndGroups!.groups = groups;
+				}
+
+				loadingUsersAndGroups = false;
+			})
+			.catch((error) => {
+				console.error('Failed to load users and groups:', error);
+				loadingUsersAndGroups = false;
+			});
+	});
+
+	function convertResourcesToTableData(resources: HostedAgentAccessPolicyResource[]) {
+		return (
+			resources
+				.map((resource) => {
+					if (resource.type === 'hostedAgent') {
+						const match = hostedAgentsMap.get(resource.id);
+						return {
+							id: resource.id,
+							name: match?.name || '-',
+							description: match?.description || '-',
+							type: 'Template'
+						};
+					} else if (resource.type === 'selector') {
+						return {
+							id: resource.id,
+							name: resource.id === '*' ? 'All Templates' : resource.id,
+							description: '',
+							type: 'Selector'
+						};
+					}
+					return undefined;
+				})
+				.filter((resource) => resource !== undefined) ?? []
+		);
+	}
+
+	function convertSubjectsToTableData(
+		subjects: AccessControlRuleSubject[],
+		users: OrgUser[],
+		groups: OrgGroup[]
+	) {
+		const userMap = new Map(users?.map((user) => [user.id, user]));
+		const groupMap = new Map(groups?.map((group) => [group.id, group]));
+
+		return (
+			subjects
+				.map((subject) => {
+					if (subject.type === 'user') {
+						return {
+							id: subject.id,
+							displayName: getUserDisplayName(userMap, subject.id),
+							type: 'User'
+						};
+					}
+
+					if (subject.type === 'group') {
+						const group = groupMap.get(subject.id);
+						if (!group) {
+							return undefined;
+						}
+
+						return {
+							id: subject.id,
+							displayName: group.name,
+							type: 'Group'
+						};
+					}
+
+					return {
+						id: subject.id,
+						displayName: subject.id === '*' ? 'All Obot Users' : subject.id,
+						type: 'Selector'
+					};
+				})
+				.filter((subject) => subject !== undefined) ?? []
+		);
+	}
+
+	function validate(p: typeof policy) {
+		if (!p) return false;
+
+		return (
+			p.displayName.length > 0 && (p.subjects?.length ?? 0) > 0 && (p.resources?.length ?? 0) > 0
+		);
+	}
+
+	const subjectTableData = $derived(
+		convertSubjectsToTableData(
+			policy.subjects ?? [],
+			usersAndGroups?.users ?? [],
+			usersAndGroups?.groups ?? []
+		)
+	);
+	const resourceTableData = $derived(convertResourcesToTableData(policy.resources ?? []));
+</script>
+
+<div
+	class="flex h-full w-full flex-col gap-4"
+	out:fly={{ x: 100, duration }}
+	in:fly={{ x: 100, delay: duration }}
+>
+	<div class="flex grow flex-col gap-4" out:fly={{ x: -100, duration }} in:fly={{ x: -100 }}>
+		{#if policy.id}
+			<div class="flex w-full items-center justify-between gap-4">
+				<div class="flex items-center gap-2">
+					<h1 class="flex items-center gap-4 text-2xl font-semibold">
+						{policy.displayName}
+					</h1>
+				</div>
+				{#if !readonly}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete Policy' }}
+						onclick={() => {
+							deletingPolicy = true;
+						}}
+					>
+						<Trash2 class="size-4" />
+					</IconButton>
+				{/if}
+			</div>
+		{/if}
+
+		{#if !policy.id}
+			<div
+				class="dark:bg-base-400 dark:border-base-400 bg-base-100 rounded-lg border border-transparent p-4"
+			>
+				<div class="flex flex-col gap-6">
+					<div class="flex flex-col gap-2">
+						<label
+							for="hosted-agent-access-policy-name"
+							class="flex-1 text-sm font-light capitalize"
+						>
+							Name
+						</label>
+						<input
+							id="hosted-agent-access-policy-name"
+							bind:value={policy.displayName}
+							class="text-input-filled mt-0.5"
+							disabled={readonly}
+						/>
+					</div>
+				</div>
+			</div>
+		{/if}
+
+		<div class="flex flex-col gap-2">
+			<div class="mb-2 flex items-center justify-between">
+				<h2 class="text-lg font-semibold">Users & Groups</h2>
+				{#if !readonly}
+					<div class="relative flex items-center gap-4">
+						<button
+							class="btn btn-primary flex items-center gap-1 text-sm"
+							disabled={loadingUsersAndGroups}
+							onclick={() => {
+								addUserGroupDialog?.open();
+							}}
+						>
+							<Plus class="size-4" /> Add User/Group
+						</button>
+					</div>
+				{/if}
+			</div>
+			{#if loadingUsersAndGroups}
+				<div class="my-2 flex items-center justify-center">
+					<Loading class="size-6" />
+				</div>
+			{:else}
+				<Table
+					data={subjectTableData}
+					fields={['displayName', 'type']}
+					headers={[{ property: 'displayName', title: 'Name' }]}
+					noDataMessage="No users or groups added."
+				>
+					{#snippet actions(d)}
+						{#if !readonly}
+							<IconButton
+								variant="danger"
+								onclick={() => {
+									policy.subjects = policy.subjects?.filter((subject) => subject.id !== d.id);
+								}}
+								tooltip={{ text: 'Delete User/Group' }}
+							>
+								<Trash2 class="size-4" />
+							</IconButton>
+						{/if}
+					{/snippet}
+				</Table>
+			{/if}
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<div class="mb-2 flex items-center justify-between">
+				<h2 class="text-lg font-semibold">Templates</h2>
+				{#if !readonly}
+					<button
+						class="btn btn-primary flex items-center gap-1 text-sm"
+						onclick={() => {
+							addHostedAgentDialog?.open();
+						}}
+					>
+						<Plus class="size-4" /> Add Template
+					</button>
+				{/if}
+			</div>
+			{#if loadingHostedAgents}
+				<div class="my-2 flex items-center justify-center">
+					<Loading class="size-6" />
+				</div>
+			{:else}
+				<Table
+					data={resourceTableData}
+					fields={['name', 'description']}
+					headers={[
+						{ property: 'name', title: 'Template' },
+						{ property: 'description', title: 'Description' }
+					]}
+					noDataMessage="No templates added."
+				>
+					{#snippet onRenderColumn(field, d)}
+						{#if field === 'name'}
+							<span class="font-light">{d.name}</span>
+						{:else}
+							{d[field as keyof typeof d]}
+						{/if}
+					{/snippet}
+					{#snippet actions(d)}
+						{#if !readonly}
+							<IconButton
+								variant="danger"
+								onclick={() => {
+									policy.resources = policy.resources?.filter((r) => r.id !== d.id) ?? [];
+								}}
+								tooltip={{ text: 'Remove Template' }}
+							>
+								<Trash2 class="size-4" />
+							</IconButton>
+						{/if}
+					{/snippet}
+				</Table>
+			{/if}
+		</div>
+	</div>
+	{#if !readonly}
+		<div
+			class="bg-base-200 text-muted-content dark:bg-base-100 sticky bottom-0 left-0 z-50 flex w-full justify-end gap-2 py-4"
+			out:fly={{ x: -100, duration }}
+			in:fly={{ x: -100 }}
+		>
+			<div class="flex w-full justify-end gap-2">
+				{#if !policy.id}
+					<button
+						class="btn btn-secondary text-sm"
+						onclick={() => {
+							goto('/admin/hosted-agent-access-policies');
+						}}
+					>
+						Cancel
+					</button>
+					<button
+						class="btn btn-primary text-sm"
+						disabled={!validate(policy) || saving}
+						onclick={async () => {
+							saving = true;
+							try {
+								const response = await AdminService.createHostedAgentAccessPolicy(policy);
+								policy = response;
+								onCreate?.(response);
+							} finally {
+								saving = false;
+							}
+						}}
+					>
+						{#if saving}
+							<Loading class="size-4" />
+						{:else}
+							Save
+						{/if}
+					</button>
+				{:else}
+					<button
+						class="btn btn-primary text-sm"
+						disabled={!validate(policy) || !hasChanges || saving}
+						onclick={async () => {
+							if (!policy.id) return;
+							saving = true;
+							try {
+								const response = await AdminService.updateHostedAgentAccessPolicy(
+									policy.id,
+									policy
+								);
+								policy = response;
+								onUpdate?.(response);
+							} finally {
+								saving = false;
+							}
+						}}
+					>
+						{#if saving}
+							<Loading class="size-4" />
+						{:else}
+							Update
+						{/if}
+					</button>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<SearchHostedAgents
+	bind:this={addHostedAgentDialog}
+	{hostedAgents}
+	onAdd={(resources: HostedAgentAccessPolicyResource[]) => {
+		policy.resources = [
+			...(policy.resources ?? []),
+			...resources.filter((resource) => !policy.resources?.some((r) => r.id === resource.id))
+		];
+	}}
+	exclude={policy.resources?.map((resource) => resource.id) ?? []}
+/>
+
+<SearchUsers
+	bind:this={addUserGroupDialog}
+	filterIds={policy.subjects?.map((subject) => subject.id) ?? []}
+	onAdd={async (users: OrgUser[], groups: OrgGroup[]) => {
+		const existingSubjectIds = new Set(policy.subjects?.map((subject) => subject.id) ?? []);
+		const newSubjects = [
+			...users
+				.filter((user: OrgUser) => !existingSubjectIds.has(user.id))
+				.map((user: OrgUser) => ({
+					type: 'user' as const,
+					id: user.id
+				})),
+			...groups
+				.filter((group: OrgGroup) => !existingSubjectIds.has(group.id))
+				.map((group: OrgGroup) => ({
+					type: group.id === '*' ? ('selector' as const) : ('group' as const),
+					id: group.id
+				}))
+		];
+		policy.subjects = [...(policy.subjects ?? []), ...newSubjects];
+	}}
+/>
+
+<Confirm
+	msg={`Delete ${policy.displayName || 'this policy'}?`}
+	show={deletingPolicy}
+	onsuccess={async () => {
+		if (!policy.id) return;
+		saving = true;
+		await AdminService.deleteHostedAgentAccessPolicy(policy.id);
+		goto('/admin/hosted-agent-access-policies');
+	}}
+	oncancel={() => (deletingPolicy = false)}
+/>

--- a/ui/user/src/lib/components/admin/HostedAgentEnvEditor.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentEnvEditor.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+	import type { HostedAgentEnv } from '$lib/services/admin/types';
+	import IconButton from '../primitives/IconButton.svelte';
+	import { Eye, EyeOff, Plus, Trash2 } from '@lucide/svelte';
+
+	interface Props {
+		env: HostedAgentEnv[];
+		readonly?: boolean;
+		onReveal?: () => Promise<Record<string, string>>;
+	}
+
+	let { env = $bindable([]), readonly, onReveal }: Props = $props();
+
+	// Keys that look like credentials default to sensitive.
+	const SENSITIVE_KEY_RE = /PASS|TOKEN|KEY/i;
+
+	// Tracks which rows the user has toggled by hand, so the heuristic never
+	// overrides an explicit choice. Local only: never sent to the API.
+	let touchedSensitive = $state<Set<number>>(new Set());
+	let revealed = $state(false);
+	let revealing = $state(false);
+
+	function onKeyInput(index: number, key: string) {
+		env[index].key = key;
+		if (!touchedSensitive.has(index)) {
+			env[index].sensitive = SENSITIVE_KEY_RE.test(key);
+		}
+	}
+
+	function toggleSensitive(index: number) {
+		touchedSensitive.add(index);
+		touchedSensitive = touchedSensitive;
+		env[index].sensitive = !env[index].sensitive;
+	}
+
+	function addRow() {
+		env = [
+			...env,
+			{ key: '', value: '', name: '', description: '', sensitive: false, required: false }
+		];
+	}
+
+	function removeRow(index: number) {
+		env = env.filter((_, i) => i !== index);
+		touchedSensitive.delete(index);
+		touchedSensitive = touchedSensitive;
+	}
+
+	async function reveal() {
+		if (!onReveal) return;
+		revealing = true;
+		try {
+			const secrets = await onReveal();
+			for (const item of env) {
+				if (item.sensitive && secrets[item.key] !== undefined) {
+					item.value = secrets[item.key];
+				}
+			}
+			revealed = true;
+		} finally {
+			revealing = false;
+		}
+	}
+</script>
+
+<div class="flex flex-col gap-2">
+	<div class="mb-2 flex items-center justify-between">
+		<div class="flex flex-col">
+			<h2 class="text-lg font-semibold">Environment</h2>
+			<span class="text-muted-content text-xs">
+				Values marked sensitive are stored separately and are not shown after saving.
+			</span>
+		</div>
+		<div class="flex items-center gap-2">
+			{#if onReveal && env.some((e) => e.sensitive) && !readonly}
+				<button
+					class="btn btn-secondary flex items-center gap-1 text-sm"
+					disabled={revealing || revealed}
+					onclick={reveal}
+				>
+					{#if revealed}
+						<EyeOff class="size-4" /> Revealed
+					{:else}
+						<Eye class="size-4" /> Reveal
+					{/if}
+				</button>
+			{/if}
+			{#if !readonly}
+				<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={addRow}>
+					<Plus class="size-4" /> Add Variable
+				</button>
+			{/if}
+		</div>
+	</div>
+
+	{#if env.length === 0}
+		<p class="text-muted-content py-4 text-center text-sm">No environment variables added.</p>
+	{:else}
+		<div class="flex flex-col gap-3">
+			{#each env as item, i (i)}
+				<div
+					class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-3 rounded-lg border border-transparent p-4"
+				>
+					<div class="flex items-end gap-3">
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="env-key-{i}" class="text-sm font-light">Key</label>
+							<input
+								id="env-key-{i}"
+								value={item.key}
+								oninput={(e) => onKeyInput(i, e.currentTarget.value)}
+								class="text-input-filled"
+								placeholder="API_TOKEN"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="env-value-{i}" class="text-sm font-light">Value</label>
+							<input
+								id="env-value-{i}"
+								bind:value={item.value}
+								type={item.sensitive && !revealed ? 'password' : 'text'}
+								class="text-input-filled"
+								placeholder={item.sensitive ? 'Stored securely' : ''}
+								disabled={readonly}
+							/>
+						</div>
+						{#if !readonly}
+							<IconButton
+								variant="danger"
+								onclick={() => removeRow(i)}
+								tooltip={{ text: 'Remove' }}
+							>
+								<Trash2 class="size-4" />
+							</IconButton>
+						{/if}
+					</div>
+
+					<div class="flex items-end gap-3">
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="env-desc-{i}" class="text-sm font-light">Description</label>
+							<input
+								id="env-desc-{i}"
+								bind:value={item.description}
+								class="text-input-filled"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex items-center gap-4 pb-2">
+							<label class="flex items-center gap-2 text-sm font-light">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm"
+									checked={item.sensitive}
+									onchange={() => toggleSensitive(i)}
+									disabled={readonly}
+								/>
+								Sensitive
+							</label>
+							<label class="flex items-center gap-2 text-sm font-light">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm"
+									bind:checked={item.required}
+									disabled={readonly}
+								/>
+								Required
+							</label>
+						</div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/ui/user/src/lib/components/admin/HostedAgentForm.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentForm.svelte
@@ -1,0 +1,704 @@
+<script lang="ts">
+	import { DEFAULT_MCP_CATALOG_ID, PAGE_TRANSITION_DURATION } from '$lib/constants';
+	import Loading from '$lib/icons/Loading.svelte';
+	import {
+		AdminService,
+		type Harness,
+		type HostedAgent,
+		type HostedAgentManifest,
+		type MCPCatalogEntry,
+		type MCPCatalogServer,
+		type Model,
+		type ModelProvider,
+		type SkillAccessPolicyResource,
+		type SkillRepository
+	} from '$lib/services';
+	import type { Skill } from '$lib/services/nanobot/types';
+	import { defaultModelAliases as defaultModelAliasesStore, errors } from '$lib/stores';
+	import { goto } from '$lib/url';
+	import Confirm from '../Confirm.svelte';
+	import Search from '../Search.svelte';
+	import IconButton from '../primitives/IconButton.svelte';
+	import HostedAgentEnvEditor from './HostedAgentEnvEditor.svelte';
+	import HostedAgentQuestionsEditor from './HostedAgentQuestionsEditor.svelte';
+	import SearchModels from './SearchModels.svelte';
+	import SearchSkills from './SearchSkills.svelte';
+	import { Plus, Trash2 } from '@lucide/svelte';
+	import { onMount, untrack } from 'svelte';
+	import { fly } from 'svelte/transition';
+
+	interface Props {
+		hostedAgent?: HostedAgent;
+		onCreate?: (hostedAgent: HostedAgent) => void;
+		onUpdate?: (hostedAgent: HostedAgent) => void;
+		readonly?: boolean;
+	}
+
+	let { hostedAgent: initialHostedAgent, onCreate, onUpdate, readonly }: Props = $props();
+
+	const duration = PAGE_TRANSITION_DURATION;
+
+	function emptyAgent(): HostedAgentManifest & { id?: string } {
+		return {
+			id: undefined,
+			name: '',
+			description: '',
+			icon: '',
+			iconDark: '',
+			harnessID: '',
+			gitRepo: '',
+			gitRef: '',
+			modelProviders: [],
+			models: [],
+			mcpServers: [],
+			skills: [],
+			env: [],
+			questions: [],
+			allowUserMCPServers: false,
+			allowUserSkills: false,
+			allowUserModels: false,
+			allowUserGitRepo: false,
+			maxInstancesPerUser: 0,
+			port: undefined,
+			terminal: false
+		};
+	}
+
+	let agent = $state(untrack(() => ({ ...emptyAgent(), ...(initialHostedAgent ?? {}) })));
+
+	let saving = $state(false);
+	let deleting = $state(false);
+	let loadingServices = $state(true);
+	let harnesses = $state<Harness[]>([]);
+	let modelProviders = $state<ModelProvider[]>([]);
+	let mcpEntries = $state<MCPCatalogEntry[]>([]);
+	let mcpCatalogServers = $state<MCPCatalogServer[]>([]);
+	let models = $state<Model[]>([]);
+	let defaultModelAliases = $derived(defaultModelAliasesStore.current);
+	let skills = $state<Skill[]>([]);
+	let skillRepositories = $state<SkillRepository[]>([]);
+
+	let addModelDialog = $state<ReturnType<typeof SearchModels>>();
+	let addSkillDialog = $state<ReturnType<typeof SearchSkills>>();
+
+	let modelsMap = $derived(new Map(models.map((m) => [m.id, m])));
+	let skillsMap = $derived(new Map(skills.map((s) => [s.id, s])));
+
+	// Model IDs may be a real model, obot://<alias>, or a wildcard prefix, so
+	// resolve a label rather than assuming a lookup hit.
+	function modelLabel(id: string) {
+		if (id.startsWith('obot://')) return `${id.slice('obot://'.length)} (default alias)`;
+		if (id === '*') return 'All models';
+		if (id.endsWith('*')) return `${id} (prefix match)`;
+		const match = modelsMap.get(id);
+		return match ? match.displayName || match.name || id : id;
+	}
+
+	function skillLabel(id: string) {
+		const match = skillsMap.get(id);
+		return match ? match.displayName || match.name || id : id;
+	}
+
+	// Admin-configured MCP servers live as catalog entries (npx/uvx/containerized/remote
+	// templates) as well as multi-user servers, so both have to be listed here.
+	let mcpServerOptions = $derived([
+		...mcpEntries.map((entry) => ({
+			id: entry.id,
+			name: entry.manifest?.name || entry.id,
+			detail: entry.manifest?.serverUserType === 'multiUser' ? 'Multi-user' : 'Single-user'
+		})),
+		...mcpCatalogServers.map((server) => ({
+			id: server.id,
+			name: server.manifest?.name || server.alias || server.id,
+			detail: 'Server'
+		}))
+	]);
+
+	let mcpQuery = $state('');
+	let filteredMcpServerOptions = $derived(
+		mcpQuery
+			? mcpServerOptions.filter((o) => o.name.toLowerCase().includes(mcpQuery.toLowerCase()))
+			: mcpServerOptions
+	);
+	let selectedMcpServers = $derived(agent.mcpServers ?? []);
+
+	onMount(async () => {
+		try {
+			const [harnessList, providers, entries, servers, modelList, skillList, repos] =
+				await Promise.all([
+					AdminService.listHarnesses(),
+					AdminService.listModelProviders(),
+					AdminService.listMCPCatalogEntries(DEFAULT_MCP_CATALOG_ID, { all: true }),
+					AdminService.listMCPCatalogServers(DEFAULT_MCP_CATALOG_ID, { all: true }),
+					AdminService.listModels({ all: true }),
+					AdminService.listAllSkills(),
+					AdminService.listSkillRepositories()
+				]);
+			harnesses = harnessList;
+			modelProviders = providers.filter((p) => p.configured);
+			mcpEntries = entries;
+			mcpCatalogServers = servers;
+			models = modelList;
+			skills = skillList;
+			skillRepositories = repos;
+		} catch (error) {
+			errors.append(`Failed to load services: ${error}`);
+		} finally {
+			loadingServices = false;
+		}
+	});
+
+	function toggleModelProvider(id: string) {
+		const current = agent.modelProviders ?? [];
+		agent.modelProviders = current.includes(id)
+			? current.filter((p) => p !== id)
+			: [...current, id];
+	}
+
+	function toggleMcpServer(id: string) {
+		const current = agent.mcpServers ?? [];
+		agent.mcpServers = current.includes(id) ? current.filter((s) => s !== id) : [...current, id];
+	}
+
+	function toManifest(a: typeof agent): HostedAgentManifest {
+		return {
+			name: a.name,
+			description: a.description,
+			icon: a.icon,
+			iconDark: a.iconDark,
+			harnessID: a.harnessID,
+			gitRepo: a.gitRepo,
+			gitRef: a.gitRef,
+			modelProviders: a.modelProviders,
+			models: a.models,
+			mcpServers: a.mcpServers,
+			skills: a.skills,
+			env: a.env,
+			questions: a.questions,
+			allowUserMCPServers: a.allowUserMCPServers,
+			allowUserSkills: a.allowUserSkills,
+			allowUserModels: a.allowUserModels,
+			allowUserGitRepo: a.allowUserGitRepo,
+			maxInstancesPerUser: a.maxInstancesPerUser,
+			port: a.port,
+			terminal: a.terminal
+		};
+	}
+
+	function validate(a: typeof agent) {
+		if (!a.name || !a.harnessID) return false;
+		if ((a.env ?? []).some((e) => !e.key)) return false;
+		if ((a.maxInstancesPerUser ?? 0) < 0) return false;
+		if (a.port !== undefined && (a.port < 0 || a.port > 65535)) return false;
+		const questions = a.questions ?? [];
+		if (questions.some((q) => !q.key)) return false;
+		if (questions.some((q) => q.type === 'select' && (q.options ?? []).length === 0)) return false;
+		const keys = questions.map((q) => q.key);
+		if (new Set(keys).size !== keys.length) return false;
+		return true;
+	}
+
+	async function revealSecrets(): Promise<Record<string, string>> {
+		if (!agent.id) return {};
+		return AdminService.revealHostedAgent(agent.id);
+	}
+</script>
+
+<div
+	class="flex h-full w-full flex-col gap-4"
+	out:fly={{ x: 100, duration }}
+	in:fly={{ x: 100, delay: duration }}
+>
+	<div class="flex grow flex-col gap-4" out:fly={{ x: -100, duration }} in:fly={{ x: -100 }}>
+		{#if agent.id}
+			<div class="flex w-full items-center justify-between gap-4">
+				<h1 class="flex items-center gap-4 text-2xl font-semibold">{agent.name}</h1>
+				{#if !readonly}
+					<IconButton
+						variant="danger2"
+						tooltip={{ text: 'Delete Agent' }}
+						onclick={() => (deleting = true)}
+					>
+						<Trash2 class="size-4" />
+					</IconButton>
+				{/if}
+			</div>
+		{/if}
+
+		<div
+			class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-6 rounded-lg border border-transparent p-4"
+		>
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-name" class="text-sm font-light">Name</label>
+				<input
+					id="hosted-agent-name"
+					bind:value={agent.name}
+					class="text-input-filled"
+					disabled={readonly}
+				/>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-description" class="text-sm font-light">Description</label>
+				<textarea
+					id="hosted-agent-description"
+					bind:value={agent.description}
+					class="text-input-filled"
+					rows="3"
+					disabled={readonly}
+				></textarea>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-harness" class="text-sm font-light">Harness</label>
+				<select
+					id="hosted-agent-harness"
+					bind:value={agent.harnessID}
+					class="text-input-filled"
+					disabled={readonly || loadingServices}
+				>
+					<option value="" disabled>Select a harness...</option>
+					{#each harnesses as harness (harness.id)}
+						<option value={harness.id}>{harness.name}</option>
+					{/each}
+				</select>
+				{#if !loadingServices && harnesses.length === 0}
+					<span class="text-muted-content text-xs">
+						No harnesses configured. Add one in the Harnesses tab first.
+					</span>
+				{/if}
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-git-repo" class="text-sm font-light">Git Repository</label>
+				<input
+					id="hosted-agent-git-repo"
+					bind:value={agent.gitRepo}
+					class="text-input-filled"
+					placeholder="https://github.com/example/repo (optional)"
+					disabled={readonly}
+					inputmode="url"
+					autocomplete="off"
+				/>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-git-ref" class="text-sm font-light">Branch, Tag or Commit</label>
+				<input
+					id="hosted-agent-git-ref"
+					bind:value={agent.gitRef}
+					class="text-input-filled"
+					placeholder="main (optional)"
+					disabled={readonly || !agent.gitRepo}
+					autocomplete="off"
+				/>
+				<span class="text-muted-content text-xs">
+					Leave blank to track the repository's default branch. Pin a tag or commit when the agent
+					must run against a known revision.
+				</span>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-icon" class="text-sm font-light">Icon URL</label>
+				<div class="flex items-center gap-3">
+					{#if agent.icon}
+						<img src={agent.icon} alt="" class="size-10 shrink-0 rounded-md object-contain" />
+					{/if}
+					<input
+						type="text"
+						id="hosted-agent-icon"
+						name="icon"
+						bind:value={agent.icon}
+						class="text-input-filled grow"
+						disabled={readonly}
+						inputmode="url"
+						autocomplete="off"
+					/>
+				</div>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<label for="hosted-agent-icon-dark" class="text-sm font-light">Icon URL (Dark)</label>
+				<div class="flex items-center gap-3">
+					{#if agent.iconDark}
+						<img
+							src={agent.iconDark}
+							alt=""
+							class="bg-base-300 size-10 shrink-0 rounded-md object-contain"
+						/>
+					{/if}
+					<input
+						type="text"
+						id="hosted-agent-icon-dark"
+						name="iconDark"
+						bind:value={agent.iconDark}
+						class="text-input-filled grow"
+						disabled={readonly}
+						inputmode="url"
+						autocomplete="off"
+					/>
+				</div>
+			</div>
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<div class="mb-2 flex flex-col">
+				<h2 class="text-lg font-semibold">Services</h2>
+				<span class="text-muted-content text-xs">
+					Model providers, models, MCP servers, and skills made available to the agent.
+				</span>
+			</div>
+			{#if loadingServices}
+				<div class="my-2 flex items-center justify-center">
+					<Loading class="size-6" />
+				</div>
+			{:else}
+				<div
+					class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-6 rounded-lg border border-transparent p-4"
+				>
+					<div class="flex flex-col gap-2">
+						<span class="text-sm font-light">Model Providers</span>
+						{#if modelProviders.length === 0}
+							<p class="text-muted-content text-sm">No configured model providers.</p>
+						{:else}
+							<div class="flex flex-col gap-1">
+								{#each modelProviders as provider (provider.id)}
+									<label class="flex items-center gap-2 text-sm font-light">
+										<input
+											type="checkbox"
+											class="checkbox checkbox-sm"
+											checked={agent.modelProviders?.includes(provider.id)}
+											onchange={() => toggleModelProvider(provider.id)}
+											disabled={readonly}
+										/>
+										{provider.name}
+									</label>
+								{/each}
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col gap-2">
+						<div class="flex items-center justify-between">
+							<span class="text-sm font-light">Models</span>
+							{#if !readonly}
+								<button
+									class="btn btn-secondary flex items-center gap-1 text-xs"
+									onclick={() => addModelDialog?.open()}
+								>
+									<Plus class="size-3" /> Add Models
+								</button>
+							{/if}
+						</div>
+						{#if (agent.models ?? []).length === 0}
+							<p class="text-muted-content text-sm">No models added.</p>
+						{:else}
+							<div class="flex flex-col gap-1">
+								{#each agent.models ?? [] as id (id)}
+									<div class="flex items-center justify-between gap-2 text-sm font-light">
+										<span class="truncate">{modelLabel(id)}</span>
+										{#if !readonly}
+											<IconButton
+												variant="danger"
+												onclick={() => {
+													agent.models = (agent.models ?? []).filter((m) => m !== id);
+												}}
+												tooltip={{ text: 'Remove Model' }}
+											>
+												<Trash2 class="size-4" />
+											</IconButton>
+										{/if}
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col gap-2">
+						<div class="flex items-center justify-between">
+							<span class="text-sm font-light">Skills</span>
+							{#if !readonly}
+								<button
+									class="btn btn-secondary flex items-center gap-1 text-xs"
+									onclick={() => addSkillDialog?.open()}
+								>
+									<Plus class="size-3" /> Add Skills
+								</button>
+							{/if}
+						</div>
+						{#if (agent.skills ?? []).length === 0}
+							<p class="text-muted-content text-sm">No skills added.</p>
+						{:else}
+							<div class="flex flex-col gap-1">
+								{#each agent.skills ?? [] as id (id)}
+									<div class="flex items-center justify-between gap-2 text-sm font-light">
+										<span class="truncate">{skillLabel(id)}</span>
+										{#if !readonly}
+											<IconButton
+												variant="danger"
+												onclick={() => {
+													agent.skills = (agent.skills ?? []).filter((s) => s !== id);
+												}}
+												tooltip={{ text: 'Remove Skill' }}
+											>
+												<Trash2 class="size-4" />
+											</IconButton>
+										{/if}
+									</div>
+								{/each}
+							</div>
+						{/if}
+					</div>
+
+					<div class="flex flex-col gap-2">
+						<div class="flex items-center justify-between">
+							<span class="text-sm font-light">MCP Servers</span>
+							{#if selectedMcpServers.length > 0}
+								<span class="text-muted-content text-xs">{selectedMcpServers.length} selected</span>
+							{/if}
+						</div>
+
+						{#if mcpServerOptions.length === 0}
+							<p class="text-muted-content text-sm">No configured MCP servers.</p>
+						{:else}
+							<Search
+								class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
+								onChange={(val) => (mcpQuery = val)}
+								value={mcpQuery}
+								placeholder="Search MCP servers..."
+							/>
+							<div class="default-scrollbar-thin flex max-h-64 flex-col gap-1 overflow-y-auto">
+								{#each filteredMcpServerOptions as option (option.id)}
+									<label class="flex items-center gap-2 text-sm font-light">
+										<input
+											type="checkbox"
+											class="checkbox checkbox-sm shrink-0"
+											checked={agent.mcpServers?.includes(option.id)}
+											onchange={() => toggleMcpServer(option.id)}
+											disabled={readonly}
+										/>
+										<span class="truncate">{option.name}</span>
+										<span class="badge badge-secondary badge-xs shrink-0">{option.detail}</span>
+									</label>
+								{/each}
+								{#if filteredMcpServerOptions.length === 0}
+									<p class="text-muted-content py-2 text-sm">No servers match "{mcpQuery}".</p>
+								{/if}
+							</div>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<HostedAgentEnvEditor
+			bind:env={agent.env as NonNullable<typeof agent.env>}
+			{readonly}
+			onReveal={agent.id ? revealSecrets : undefined}
+		/>
+
+		<div class="flex flex-col gap-2">
+			<div class="mb-2 flex flex-col">
+				<h2 class="text-lg font-semibold">Instances</h2>
+				<span class="text-muted-content text-xs">
+					Each user creates their own instances of this agent.
+				</span>
+			</div>
+			<div
+				class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-4 rounded-lg border border-transparent p-4"
+			>
+				<div class="flex flex-col gap-2">
+					<label for="hosted-agent-max-instances" class="text-sm font-light">
+						Max instances per user
+					</label>
+					<input
+						id="hosted-agent-max-instances"
+						type="number"
+						min="0"
+						bind:value={agent.maxInstancesPerUser}
+						class="text-input-filled w-40"
+						disabled={readonly}
+					/>
+					<span class="text-muted-content text-xs">0 means unlimited.</span>
+				</div>
+
+				<div class="flex flex-col gap-2 pt-2">
+					<label for="hosted-agent-port" class="text-sm font-light">HTTP port</label>
+					<input
+						id="hosted-agent-port"
+						type="number"
+						min="0"
+						max="65535"
+						placeholder="None"
+						value={agent.port ?? ''}
+						oninput={(e) =>
+							(agent.port =
+								e.currentTarget.value === '' ? undefined : Number(e.currentTarget.value))}
+						class="text-input-filled w-40"
+						disabled={readonly}
+					/>
+					<span class="text-muted-content text-xs">
+						The port this agent's image serves HTTP on. Set it to publish an Open link on each
+						instance. Leave blank if the agent serves nothing.
+					</span>
+				</div>
+
+				<div class="flex flex-col gap-2 pt-2">
+					<label class="flex items-center gap-2 text-sm font-light">
+						<input type="checkbox" bind:checked={agent.terminal} disabled={readonly} />
+						Offer a terminal
+					</label>
+					<span class="text-muted-content text-xs">
+						Adds an interactive shell attached to the running sandbox. Requires a harness marked
+						interactive, since without a TTY there is no session to attach to.
+					</span>
+				</div>
+
+				<div class="flex flex-col gap-2 pt-2">
+					<span class="text-sm font-light">User-defined resources</span>
+					<span class="text-muted-content text-xs">
+						Let users attach their own resources to an instance, on top of the ones configured
+						above. Users can only pick from what they already have access to.
+					</span>
+					<label class="flex items-center gap-2 pt-1 text-sm font-light">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							bind:checked={agent.allowUserMCPServers}
+							disabled={readonly}
+						/>
+						Allow user-defined MCP servers
+					</label>
+					<label class="flex items-center gap-2 text-sm font-light">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							bind:checked={agent.allowUserSkills}
+							disabled={readonly}
+						/>
+						Allow user-defined skills
+					</label>
+					<label class="flex items-center gap-2 text-sm font-light">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							bind:checked={agent.allowUserModels}
+							disabled={readonly}
+						/>
+						Allow user-defined models
+					</label>
+					<label class="flex items-center gap-2 text-sm font-light">
+						<input
+							type="checkbox"
+							class="checkbox checkbox-sm"
+							bind:checked={agent.allowUserGitRepo}
+							disabled={readonly}
+						/>
+						Allow user-specified git repository
+					</label>
+				</div>
+			</div>
+		</div>
+
+		<HostedAgentQuestionsEditor
+			bind:questions={agent.questions as NonNullable<typeof agent.questions>}
+			{readonly}
+		/>
+	</div>
+
+	{#if !readonly}
+		<div
+			class="bg-base-200 text-muted-content dark:bg-base-100 sticky bottom-0 left-0 z-50 flex w-full justify-end gap-2 py-4"
+		>
+			<div class="flex w-full justify-end gap-2">
+				{#if !agent.id}
+					<button class="btn btn-secondary text-sm" onclick={() => goto('/admin/hosted-agents')}>
+						Cancel
+					</button>
+					<button
+						class="btn btn-primary text-sm"
+						disabled={!validate(agent) || saving}
+						onclick={async () => {
+							saving = true;
+							try {
+								const response = await AdminService.createHostedAgent(toManifest(agent));
+								agent = { ...emptyAgent(), ...response };
+								onCreate?.(response);
+							} finally {
+								saving = false;
+							}
+						}}
+					>
+						{#if saving}
+							<Loading class="size-4" />
+						{:else}
+							Save
+						{/if}
+					</button>
+				{:else}
+					<button
+						class="btn btn-primary text-sm"
+						disabled={!validate(agent) || saving}
+						onclick={async () => {
+							if (!agent.id) return;
+							saving = true;
+							try {
+								const response = await AdminService.updateHostedAgent(agent.id, toManifest(agent));
+								agent = { ...emptyAgent(), ...response };
+								onUpdate?.(response);
+							} finally {
+								saving = false;
+							}
+						}}
+					>
+						{#if saving}
+							<Loading class="size-4" />
+						{:else}
+							Update
+						{/if}
+					</button>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>
+
+<SearchModels
+	bind:this={addModelDialog}
+	{models}
+	defaultAliases={defaultModelAliases}
+	exclude={agent.models ?? []}
+	onAdd={(modelIds: string[]) => {
+		const existing = new Set(agent.models ?? []);
+		agent.models = [...(agent.models ?? []), ...modelIds.filter((id) => !existing.has(id))];
+	}}
+/>
+
+<SearchSkills
+	bind:this={addSkillDialog}
+	{skills}
+	{skillRepositories}
+	wildcardAvailable={false}
+	exclude={agent.skills ?? []}
+	onAdd={(resources: SkillAccessPolicyResource[]) => {
+		// The agent references individual skills, so ignore repository-level picks.
+		const existing = new Set(agent.skills ?? []);
+		const picked = resources
+			.filter((r) => r.type === 'skill')
+			.map((r) => r.id)
+			.filter((id) => !existing.has(id));
+		agent.skills = [...(agent.skills ?? []), ...picked];
+	}}
+/>
+
+<Confirm
+	msg={`Delete ${agent.name || 'this agent'}?`}
+	show={deleting}
+	onsuccess={async () => {
+		if (!agent.id) return;
+		saving = true;
+		await AdminService.deleteHostedAgent(agent.id);
+		goto('/admin/hosted-agents');
+	}}
+	oncancel={() => (deleting = false)}
+/>

--- a/ui/user/src/lib/components/admin/HostedAgentPools.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentPools.svelte
@@ -1,0 +1,511 @@
+<script lang="ts">
+	import Confirm from '$lib/components/Confirm.svelte';
+	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
+	import Loading from '$lib/icons/Loading.svelte';
+	import { AdminService, UserService, type OrgUser } from '$lib/services';
+	import type {
+		HostedAgentPool,
+		HostedAgentPoolAssignment,
+		HostedAgentPoolDefaults,
+		HostedAgentPoolUtilization
+	} from '$lib/services/admin/types';
+	import { errors } from '$lib/stores';
+	import { Activity, Pencil, Plus, Trash2 } from '@lucide/svelte';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		pools: HostedAgentPool[];
+		defaults?: HostedAgentPoolDefaults;
+		assignments: HostedAgentPoolAssignment[];
+		readonly?: boolean;
+	}
+
+	let {
+		pools = $bindable(),
+		defaults = $bindable(),
+		assignments = $bindable(),
+		readonly = false
+	}: Props = $props();
+
+	let poolDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let assignmentDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let usageDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let editing = $state<HostedAgentPool>();
+	let deleting = $state<HostedAgentPool>();
+	let deletingAssignment = $state<HostedAgentPoolAssignment>();
+	let saving = $state(false);
+	let usage = $state<HostedAgentPoolUtilization>();
+	let usagePool = $state<HostedAgentPool>();
+	let users = $state<OrgUser[]>([]);
+	let usersByID = $derived(new Map(users.map((u) => [u.id, u])));
+
+	// A pool's ID says nothing an administrator can act on. Its members do, so
+	// resolve them to people and let the pool be recognised by who is in it.
+	function userLabel(id: string) {
+		const user = usersByID.get(id);
+		if (!user) return `User ${id}`;
+		return user.displayName || user.email || user.username || `User ${id}`;
+	}
+
+	function membersOf(poolID: string) {
+		return assignments.filter((a) => a.poolID === poolID);
+	}
+
+	let form = $state({ cpu: 1, memory: 4, storage: 20, maxSandboxes: 10, suspended: false });
+	let assignmentForm = $state({ userID: '', poolID: '', default: true });
+	let defaultsForm = $state({ cpu: 1, memory: 4, storage: 20, maxSandboxes: 10 });
+	const fastPollInterval = 2_000;
+	const slowPollInterval = 30_000;
+	let pollTimer: ReturnType<typeof setTimeout> | undefined;
+	let destroyed = false;
+
+	$effect(() => {
+		if (defaults) {
+			defaultsForm = {
+				cpu: defaults.capacity.cpuVcpus,
+				memory: toGiB(defaults.capacity.memoryBytes),
+				storage: toGiB(defaults.capacity.storageBytes),
+				maxSandboxes: defaults.maxSandboxes ?? 10
+			};
+		}
+	});
+
+	const toGiB = (bytes: number) => Math.round((bytes / 1024 ** 3) * 10) / 10;
+	const quantity = (cpu: number, memory: number, storage: number) => ({
+		cpuVcpus: Number(cpu),
+		memoryBytes: Math.round(Number(memory) * 1024 ** 3),
+		storageBytes: Math.round(Number(storage) * 1024 ** 3)
+	});
+	const formatQuantity = (q?: { cpuVcpus: number; memoryBytes: number; storageBytes: number }) =>
+		q
+			? `${q.cpuVcpus} vCPU · ${toGiB(q.memoryBytes)} GiB RAM · ${toGiB(q.storageBytes)} GiB disk`
+			: '—';
+
+	async function reload() {
+		[pools, assignments] = await Promise.all([
+			AdminService.listHostedAgentPools(),
+			AdminService.listHostedAgentPoolAssignments()
+		]);
+	}
+
+	onMount(async () => {
+		try {
+			users = await UserService.listUsers();
+		} catch {
+			// Names are a nicety; without them members still render by ID.
+		}
+	});
+
+	function hasTransitionalPools() {
+		return pools.some(
+			(pool) =>
+				Boolean(pool.deleted) ||
+				(!pool.status?.observedRevision && !pool.status?.ready && !pool.status?.degraded)
+		);
+	}
+
+	function scheduleRefresh(delay = hasTransitionalPools() ? fastPollInterval : slowPollInterval) {
+		clearTimeout(pollTimer);
+		if (destroyed) return;
+		pollTimer = setTimeout(poll, delay);
+	}
+
+	async function poll() {
+		if (document.visibilityState === 'hidden') {
+			scheduleRefresh(slowPollInterval);
+			return;
+		}
+		try {
+			await reload();
+			if (usagePool) {
+				usage = await AdminService.getHostedAgentPoolUtilization(usagePool.id);
+			}
+		} catch {
+			// Background status observation retries without producing recurring
+			// administrator notifications.
+		}
+		scheduleRefresh();
+	}
+
+	function openPool(value?: HostedAgentPool) {
+		editing = value;
+		form = value
+			? {
+					cpu: value.capacity.cpuVcpus,
+					memory: toGiB(value.capacity.memoryBytes),
+					storage: toGiB(value.capacity.storageBytes),
+					maxSandboxes: value.maxSandboxes ?? 10,
+					suspended: Boolean(value.suspended)
+				}
+			: { cpu: 1, memory: 4, storage: 20, maxSandboxes: 10, suspended: false };
+		poolDialog?.open();
+	}
+
+	async function savePool() {
+		saving = true;
+		try {
+			const manifest = {
+				capacity: quantity(form.cpu, form.memory, form.storage),
+				maxSandboxes: Number(form.maxSandboxes),
+				suspended: form.suspended
+			};
+			if (editing) await AdminService.updateHostedAgentPool(editing.id, manifest);
+			else await AdminService.createHostedAgentPool(manifest);
+			await reload();
+			scheduleRefresh();
+			poolDialog?.close();
+		} catch (error) {
+			errors.append(`Failed to save pool: ${error}`);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function saveDefaults() {
+		saving = true;
+		try {
+			const manifest = {
+				capacity: quantity(defaultsForm.cpu, defaultsForm.memory, defaultsForm.storage),
+				maxSandboxes: Number(defaultsForm.maxSandboxes)
+			};
+			defaults = defaults
+				? await AdminService.updateHostedAgentPoolDefaults(manifest)
+				: await AdminService.createHostedAgentPoolDefaults(manifest);
+		} catch (error) {
+			errors.append(`Failed to save pool defaults: ${error}`);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function saveAssignment() {
+		saving = true;
+		try {
+			await AdminService.createHostedAgentPoolAssignment(assignmentForm);
+			await reload();
+			scheduleRefresh();
+			assignmentDialog?.close();
+		} catch (error) {
+			errors.append(`Failed to assign pool: ${error}`);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function showUsage(pool: HostedAgentPool) {
+		usagePool = pool;
+		usage = undefined;
+		usageDialog?.open();
+		try {
+			usage = await AdminService.getHostedAgentPoolUtilization(pool.id);
+		} catch (error) {
+			errors.append(`Failed to load utilization: ${error}`);
+		}
+	}
+
+	onMount(() => {
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === 'visible') scheduleRefresh(0);
+			else scheduleRefresh(slowPollInterval);
+		};
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+		scheduleRefresh(0);
+		return () => {
+			destroyed = true;
+			clearTimeout(pollTimer);
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
+		};
+	});
+</script>
+
+<div class="flex flex-col gap-6">
+	<section class="dark:bg-base-300 border-base-400 rounded-lg border bg-white p-4 shadow-sm">
+		<!-- Four small numbers and a button on one row: they are read together and
+		     each is a couple of characters wide, so stacking them wasted the row. -->
+		<div class="flex flex-wrap items-end gap-x-4 gap-y-3">
+			<div class="mr-auto">
+				<h2 class="font-semibold">Deployment defaults</h2>
+				<p class="text-muted-content text-xs">Applied when a pool is created on demand.</p>
+			</div>
+			<label class="text-muted-content flex flex-col text-xs"
+				>vCPU<input
+					type="number"
+					min="0.1"
+					step="0.1"
+					class="text-input-filled mt-0.5 w-20"
+					disabled={readonly}
+					bind:value={defaultsForm.cpu}
+				/></label
+			>
+			<label class="text-muted-content flex flex-col text-xs"
+				>Memory (GiB)<input
+					type="number"
+					min="0.1"
+					step="0.1"
+					class="text-input-filled mt-0.5 w-20"
+					disabled={readonly}
+					bind:value={defaultsForm.memory}
+				/></label
+			>
+			<label class="text-muted-content flex flex-col text-xs"
+				>Storage (GiB)<input
+					type="number"
+					min="0.1"
+					step="0.1"
+					class="text-input-filled mt-0.5 w-20"
+					disabled={readonly}
+					bind:value={defaultsForm.storage}
+				/></label
+			>
+			<label class="text-muted-content flex flex-col text-xs"
+				>Max sandboxes<input
+					type="number"
+					min="1"
+					step="1"
+					class="text-input-filled mt-0.5 w-20"
+					disabled={readonly}
+					bind:value={defaultsForm.maxSandboxes}
+				/></label
+			>
+			{#if !readonly}
+				<button
+					class="btn btn-primary text-sm"
+					disabled={saving || !defaultsForm.cpu || !defaultsForm.memory || !defaultsForm.storage}
+					onclick={saveDefaults}>Save</button
+				>
+			{/if}
+		</div>
+	</section>
+
+	<section>
+		<div class="mb-3 flex items-center justify-between">
+			<div>
+				<h2 class="font-semibold">Pools</h2>
+				<p class="text-muted-content text-sm">
+					Shared CPU, memory and disk. Every member's sandboxes draw from the same pool.
+				</p>
+			</div>
+			<div class="flex gap-2">
+				{#if !readonly}
+					<button class="btn btn-secondary text-sm" onclick={() => assignmentDialog?.open()}
+						><Plus class="size-4" /> Assign user</button
+					>
+					<button class="btn btn-primary text-sm" onclick={() => openPool()}
+						><Plus class="size-4" /> Add pool</button
+					>
+				{/if}
+			</div>
+		</div>
+		<div class="grid gap-3">
+			{#each pools as pool (pool.id)}
+				{@const members = membersOf(pool.id)}
+				<div class="dark:bg-base-300 border-base-400 rounded-lg border bg-white p-4 shadow-sm">
+					<div class="flex justify-between gap-4">
+						<div class="min-w-0">
+							<div class="flex flex-wrap items-center gap-2">
+								<!-- A pool is recognised by who is in it, not by its identifier. -->
+								<span class="font-medium">
+									{#if members.length === 1}
+										{userLabel(members[0].userID)}
+									{:else if members.length > 1}
+										{userLabel(members[0].userID)} +{members.length - 1}
+									{:else}
+										Unassigned pool
+									{/if}
+								</span>
+								<span
+									class="badge badge-sm {pool.suspended
+										? 'badge-warning'
+										: pool.status?.ready
+											? 'badge-success'
+											: 'badge-secondary'}"
+									>{pool.suspended ? 'Suspended' : pool.status?.ready ? 'Ready' : 'Pending'}</span
+								>
+							</div>
+							<p class="text-muted-content mt-1 text-sm">
+								{formatQuantity(pool.capacity)} · up to {pool.maxSandboxes ?? 10} sandboxes
+							</p>
+							{#if pool.status?.message}<p class="text-warning mt-1 text-xs">
+									{pool.status.message}
+								</p>{/if}
+							<p class="text-muted-content mt-1 font-mono text-xs opacity-60">{pool.id}</p>
+						</div>
+						<div class="flex shrink-0">
+							<button class="btn btn-ghost btn-sm" onclick={() => showUsage(pool)}
+								><Activity class="size-4" /> Usage</button
+							>
+							{#if !readonly}
+								<button
+									class="btn btn-ghost btn-sm"
+									aria-label="Edit pool"
+									onclick={() => openPool(pool)}><Pencil class="size-4" /></button
+								>
+								<button
+									class="btn btn-ghost btn-sm text-error"
+									aria-label="Delete pool"
+									onclick={() => (deleting = pool)}><Trash2 class="size-4" /></button
+								>
+							{/if}
+						</div>
+					</div>
+
+					<!-- Members inline, so a pool and its people are one thing rather than
+					     two lists cross-referenced by ID. -->
+					<div class="border-base-400 mt-3 flex flex-wrap items-center gap-2 border-t pt-3">
+						{#each members as member (member.id)}
+							<span
+								class="border-base-400 flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs"
+							>
+								{userLabel(member.userID)}
+								{#if member.default}<span class="text-muted-content">· default</span>{/if}
+								{#if !readonly}
+									<button
+										class="text-muted-content hover:text-error"
+										aria-label="Remove {userLabel(member.userID)} from pool"
+										onclick={() => (deletingAssignment = member)}><Trash2 class="size-3" /></button
+									>
+								{/if}
+							</span>
+						{:else}
+							<span class="text-muted-content text-xs">No users assigned.</span>
+						{/each}
+					</div>
+				</div>
+			{:else}
+				<p class="text-muted-content py-6 text-center text-sm">No pools yet.</p>
+			{/each}
+		</div>
+	</section>
+</div>
+
+<ResponsiveDialog
+	bind:this={poolDialog}
+	title={editing ? 'Edit pool' : 'Add pool'}
+	class="md:max-w-md"
+>
+	<div class="grid gap-3">
+		<label class="text-sm"
+			>vCPU<input
+				type="number"
+				min="0.1"
+				step="0.1"
+				class="text-input-filled mt-1"
+				bind:value={form.cpu}
+			/></label
+		>
+		<label class="text-sm"
+			>Memory (GiB)<input
+				type="number"
+				min="0.1"
+				step="0.1"
+				class="text-input-filled mt-1"
+				bind:value={form.memory}
+			/></label
+		>
+		<label class="text-sm"
+			>Storage (GiB)<input
+				type="number"
+				min="0.1"
+				step="0.1"
+				class="text-input-filled mt-1"
+				bind:value={form.storage}
+			/></label
+		>
+		<label class="text-sm"
+			>Max sandboxes<input
+				type="number"
+				min="1"
+				step="1"
+				class="text-input-filled mt-1"
+				bind:value={form.maxSandboxes}
+			/><span class="text-muted-content mt-1 block text-xs">
+				Sandboxes share this pool. Each is guaranteed capacity ÷ this number and may burst to the
+				whole pool, so a higher number means smaller guaranteed shares.
+			</span></label
+		>
+		<label class="flex items-center gap-2 text-sm"
+			><input type="checkbox" bind:checked={form.suspended} /> Suspend new starts</label
+		>
+		<button
+			class="btn btn-primary mt-2"
+			disabled={saving || !form.cpu || !form.memory || !form.storage}
+			onclick={savePool}
+			>{#if saving}<Loading class="size-4" />{:else}Save{/if}</button
+		>
+	</div>
+</ResponsiveDialog>
+
+<ResponsiveDialog bind:this={assignmentDialog} title="Assign pool" class="md:max-w-md">
+	<div class="grid gap-3">
+		<label class="text-sm"
+			>User ID<input class="text-input-filled mt-1" bind:value={assignmentForm.userID} /></label
+		>
+		<label class="text-sm"
+			>Pool<select class="text-input-filled mt-1" bind:value={assignmentForm.poolID}
+				><option value="">Select a pool</option>{#each pools as pool (pool.id)}<option
+						value={pool.id}>{pool.id}</option
+					>{/each}</select
+			></label
+		>
+		<label class="flex items-center gap-2 text-sm"
+			><input type="checkbox" bind:checked={assignmentForm.default} /> Default pool</label
+		>
+		<button
+			class="btn btn-primary"
+			disabled={saving || !assignmentForm.userID || !assignmentForm.poolID}
+			onclick={saveAssignment}>Assign</button
+		>
+	</div>
+</ResponsiveDialog>
+
+<ResponsiveDialog bind:this={usageDialog} title="Live utilization" class="md:max-w-lg">
+	{#if !usage}<div class="flex justify-center p-8"><Loading class="size-6" /></div>
+	{:else}
+		<div class="grid gap-3">
+			<p class="text-sm">
+				<strong>{usagePool?.id}</strong> · snapshot {new Date(usage.timestamp).toLocaleString()}
+			</p>
+			<p class="text-sm">Used: {formatQuantity(usage.pool)}</p>
+			<p class="text-muted-content text-xs">
+				Pressure: CPU {usage.pressure.cpu ?? 'unknown'} · memory {usage.pressure.memory ??
+					'unknown'} · storage {usage.pressure.storage ?? 'unknown'}
+			</p>
+			<p class="text-muted-content text-xs">
+				Totals cover every member of this pool. Disk is not reported per instance, because members
+				share one volume.
+			</p>
+			{#each usage.instances as instance (instance.instanceID)}<div
+					class="border-base-400 rounded border p-2 text-xs"
+				>
+					{instance.instanceID} · {instance.state ?? 'unknown'} · {formatQuantity(instance.usage)}
+				</div>{/each}
+		</div>
+	{/if}
+</ResponsiveDialog>
+
+{#if deleting}
+	<Confirm
+		msg="Delete this pool? Deletion completes only after the backend resources are gone."
+		show
+		onsuccess={async () => {
+			await AdminService.deleteHostedAgentPool(deleting!.id);
+			deleting = undefined;
+			await reload();
+			scheduleRefresh();
+		}}
+		oncancel={() => (deleting = undefined)}
+	/>
+{/if}
+{#if deletingAssignment}
+	<Confirm
+		msg="Remove this assignment? The user will no longer be able to select the pool."
+		show
+		onsuccess={async () => {
+			await AdminService.deleteHostedAgentPoolAssignment(deletingAssignment!.id);
+			deletingAssignment = undefined;
+			await reload();
+			scheduleRefresh();
+		}}
+		oncancel={() => (deletingAssignment = undefined)}
+	/>
+{/if}

--- a/ui/user/src/lib/components/admin/HostedAgentQuestionsEditor.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentQuestionsEditor.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+	import type { HostedAgentQuestion, HostedAgentQuestionType } from '$lib/services/admin/types';
+	import IconButton from '../primitives/IconButton.svelte';
+	import { Plus, Trash2 } from '@lucide/svelte';
+
+	interface Props {
+		questions: HostedAgentQuestion[];
+		readonly?: boolean;
+	}
+
+	let { questions = $bindable([]), readonly }: Props = $props();
+
+	const TYPES: { value: HostedAgentQuestionType; label: string; hint: string }[] = [
+		{ value: 'string', label: 'Text', hint: '' },
+		{ value: 'number', label: 'Number', hint: '' },
+		{ value: 'boolean', label: 'Yes / No', hint: 'true or false' },
+		{ value: 'select', label: 'Choice', hint: 'One of the options below' },
+		{ value: 'schedule', label: 'Schedule', hint: 'Cron expression, e.g. 0 3 * * *' }
+	];
+
+	function addQuestion() {
+		questions = [
+			...questions,
+			{ key: '', name: '', description: '', type: 'string', required: false, default: '' }
+		];
+	}
+
+	function removeQuestion(index: number) {
+		questions = questions.filter((_, i) => i !== index);
+	}
+
+	// Options are only meaningful for a choice, and the API rejects them on any
+	// other type, so drop them when the type changes away from select.
+	function onTypeChange(index: number, type: HostedAgentQuestionType) {
+		questions[index].type = type;
+		if (type !== 'select') {
+			questions[index].options = undefined;
+		} else if (!questions[index].options) {
+			questions[index].options = [''];
+		}
+		questions[index].default = '';
+	}
+
+	function addOption(index: number) {
+		questions[index].options = [...(questions[index].options ?? []), ''];
+	}
+
+	function removeOption(qIndex: number, oIndex: number) {
+		questions[qIndex].options = (questions[qIndex].options ?? []).filter((_, i) => i !== oIndex);
+	}
+
+	function typeHint(type: HostedAgentQuestionType | undefined) {
+		return TYPES.find((t) => t.value === (type ?? 'string'))?.hint ?? '';
+	}
+</script>
+
+<div class="flex flex-col gap-2">
+	<div class="mb-2 flex items-center justify-between">
+		<div class="flex flex-col">
+			<h2 class="text-lg font-semibold">Questions</h2>
+			<span class="text-muted-content text-xs">
+				Asked when a user creates an instance of this agent.
+			</span>
+		</div>
+		{#if !readonly}
+			<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={addQuestion}>
+				<Plus class="size-4" /> Add Question
+			</button>
+		{/if}
+	</div>
+
+	{#if questions.length === 0}
+		<p class="text-muted-content py-4 text-center text-sm">No questions added.</p>
+	{:else}
+		<div class="flex flex-col gap-3">
+			{#each questions as question, i (i)}
+				<div
+					class="dark:bg-base-400 dark:border-base-400 bg-base-100 flex flex-col gap-3 rounded-lg border border-transparent p-4"
+				>
+					<div class="flex items-end gap-3">
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="q-key-{i}" class="text-sm font-light">Key</label>
+							<input
+								id="q-key-{i}"
+								bind:value={question.key}
+								class="text-input-filled"
+								placeholder="schedule"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="q-name-{i}" class="text-sm font-light">Label</label>
+							<input
+								id="q-name-{i}"
+								bind:value={question.name}
+								class="text-input-filled"
+								placeholder="Schedule"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex flex-col gap-2">
+							<label for="q-type-{i}" class="text-sm font-light">Type</label>
+							<select
+								id="q-type-{i}"
+								class="text-input-filled"
+								value={question.type ?? 'string'}
+								onchange={(e) => onTypeChange(i, e.currentTarget.value as HostedAgentQuestionType)}
+								disabled={readonly}
+							>
+								{#each TYPES as t (t.value)}
+									<option value={t.value}>{t.label}</option>
+								{/each}
+							</select>
+						</div>
+						{#if !readonly}
+							<IconButton
+								variant="danger"
+								onclick={() => removeQuestion(i)}
+								tooltip={{ text: 'Remove Question' }}
+							>
+								<Trash2 class="size-4" />
+							</IconButton>
+						{/if}
+					</div>
+
+					<div class="flex items-end gap-3">
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="q-desc-{i}" class="text-sm font-light">Description</label>
+							<input
+								id="q-desc-{i}"
+								bind:value={question.description}
+								class="text-input-filled"
+								disabled={readonly}
+							/>
+						</div>
+						<div class="flex flex-1 flex-col gap-2">
+							<label for="q-default-{i}" class="text-sm font-light">Default</label>
+							{#if question.type === 'select'}
+								<select
+									id="q-default-{i}"
+									class="text-input-filled"
+									bind:value={question.default}
+									disabled={readonly}
+								>
+									<option value="">(none)</option>
+									{#each (question.options ?? []).filter((o) => o) as option (option)}
+										<option value={option}>{option}</option>
+									{/each}
+								</select>
+							{:else if question.type === 'boolean'}
+								<select
+									id="q-default-{i}"
+									class="text-input-filled"
+									bind:value={question.default}
+									disabled={readonly}
+								>
+									<option value="">(none)</option>
+									<option value="true">true</option>
+									<option value="false">false</option>
+								</select>
+							{:else}
+								<input
+									id="q-default-{i}"
+									bind:value={question.default}
+									class="text-input-filled"
+									placeholder={question.type === 'schedule' ? '0 3 * * *' : ''}
+									disabled={readonly}
+								/>
+							{/if}
+						</div>
+						<div class="flex items-center gap-4 pb-2">
+							<label class="flex items-center gap-2 text-sm font-light">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm"
+									bind:checked={question.required}
+									disabled={readonly}
+								/>
+								Required
+							</label>
+							<label class="flex items-center gap-2 text-sm font-light">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm"
+									bind:checked={question.sensitive}
+									disabled={readonly}
+								/>
+								Sensitive
+							</label>
+						</div>
+					</div>
+
+					{#if typeHint(question.type)}
+						<span class="text-muted-content text-xs">{typeHint(question.type)}</span>
+					{/if}
+
+					{#if question.type === 'select'}
+						<div class="flex flex-col gap-2">
+							<div class="flex items-center justify-between">
+								<span class="text-sm font-light">Options</span>
+								{#if !readonly}
+									<button
+										class="btn btn-secondary flex items-center gap-1 text-xs"
+										onclick={() => addOption(i)}
+									>
+										<Plus class="size-3" /> Add Option
+									</button>
+								{/if}
+							</div>
+							{#each question.options ?? [] as _, oi (oi)}
+								<div class="flex items-center gap-2">
+									<input
+										bind:value={question.options![oi]}
+										class="text-input-filled grow"
+										placeholder="Option value"
+										disabled={readonly}
+										aria-label="Option {oi + 1}"
+									/>
+									{#if !readonly}
+										<IconButton
+											variant="danger"
+											onclick={() => removeOption(i, oi)}
+											tooltip={{ text: 'Remove Option' }}
+										>
+											<Trash2 class="size-4" />
+										</IconButton>
+									{/if}
+								</div>
+							{/each}
+							{#if (question.options ?? []).length === 0}
+								<p class="text-muted-content text-xs">A choice needs at least one option.</p>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/ui/user/src/lib/components/admin/SearchHostedAgents.svelte
+++ b/ui/user/src/lib/components/admin/SearchHostedAgents.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import type { HostedAgent, HostedAgentAccessPolicyResource } from '$lib/services/admin/types';
+	import ResponsiveDialog from '../ResponsiveDialog.svelte';
+	import Search from '../Search.svelte';
+	import { Bot, Check } from '@lucide/svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	interface Props {
+		hostedAgents: HostedAgent[];
+		onAdd: (resources: HostedAgentAccessPolicyResource[]) => void;
+		exclude?: string[];
+		title?: string;
+		wildcardAvailable?: boolean;
+	}
+
+	let {
+		hostedAgents,
+		onAdd,
+		exclude = [],
+		title = 'Add Templates',
+		wildcardAvailable = true
+	}: Props = $props();
+
+	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let query = $state('');
+	let selected = $state<HostedAgentAccessPolicyResource[]>([]);
+	let selectedSet = $derived(new Set(selected.map((item) => item.id)));
+
+	const filteredAgents = $derived.by(() => {
+		const items = hostedAgents.filter((agent) => !exclude.includes(agent.id));
+		return query
+			? items.filter(
+					(agent) =>
+						agent.name?.toLowerCase().includes(query.toLowerCase()) ||
+						agent.description?.toLowerCase().includes(query.toLowerCase())
+				)
+			: items;
+	});
+
+	function toggleSelection(item: HostedAgentAccessPolicyResource) {
+		if (selectedSet.has(item.id)) {
+			selected = selected.filter((existing) => existing.id !== item.id);
+		} else {
+			selected = [...selected, item];
+		}
+	}
+
+	function handleAdd() {
+		onAdd(selected);
+		dialog?.close();
+	}
+
+	export function open() {
+		selected = [];
+		query = '';
+		dialog?.open();
+	}
+
+	export function close() {
+		dialog?.close();
+	}
+</script>
+
+<ResponsiveDialog
+	bind:this={dialog}
+	{title}
+	class="h-full w-full overflow-visible md:h-[500px] md:max-w-md"
+	classes={{ header: 'p-4 md:pb-0', content: 'min-h-inherit p-0' }}
+>
+	<div class="default-scrollbar-thin flex grow flex-col gap-4 overflow-y-auto pt-1">
+		<div class="flex flex-col gap-2">
+			<div class="px-4">
+				<Search
+					class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
+					onChange={(val) => (query = val)}
+					value={query}
+					placeholder="Search templates..."
+				/>
+			</div>
+
+			<div class="flex flex-col">
+				{#if wildcardAvailable && !exclude?.includes('*')}
+					<button
+						class={twMerge(
+							'hover:bg-base-300 dark:hover:bg-base-200 flex items-center justify-between gap-4 px-4 py-3 text-left',
+							selectedSet.has('*') && 'bg-base-200/50'
+						)}
+						onclick={() => toggleSelection({ type: 'selector', id: '*' })}
+					>
+						<div class="flex items-center gap-2">
+							<div class="flex flex-col">
+								<p class="font-medium">All Templates</p>
+								<span class="text-muted-content text-xs">
+									Grants access to all current and future templates
+								</span>
+							</div>
+						</div>
+						<div class="flex size-6 items-center justify-center">
+							{#if selectedSet.has('*')}
+								<Check class="text-primary size-6" />
+							{/if}
+						</div>
+					</button>
+				{/if}
+
+				{#each filteredAgents as agent (agent.id)}
+					<button
+						class={twMerge(
+							'hover:bg-base-300 dark:hover:bg-base-200 flex items-center justify-between gap-4 px-4 py-3 text-left',
+							selectedSet.has(agent.id) && 'bg-base-200/50'
+						)}
+						onclick={() => toggleSelection({ type: 'hostedAgent', id: agent.id })}
+					>
+						<div class="flex items-center gap-2">
+							<div class="flex flex-col">
+								<p class="font-medium">{agent.name}</p>
+								<span class="text-muted-content line-clamp-1 text-xs">
+									{agent.description || agent.id}
+								</span>
+							</div>
+						</div>
+						<div class="flex size-6 items-center justify-center">
+							{#if selectedSet.has(agent.id)}
+								<Check class="text-primary size-6" />
+							{/if}
+						</div>
+					</button>
+				{/each}
+			</div>
+		</div>
+	</div>
+	<div class="flex w-full flex-col justify-between gap-4 p-4 md:flex-row">
+		<div class="flex items-center gap-1 font-light">
+			{#if selected.length > 0}
+				<Bot class="size-4" />
+				{selected.length} Selected
+			{/if}
+		</div>
+		<div class="flex items-center gap-2">
+			<button class="btn btn-secondary w-full md:w-fit" onclick={() => dialog?.close()}>
+				Cancel
+			</button>
+			<button class="btn btn-primary w-full md:w-fit" onclick={handleAdd}> Confirm </button>
+		</div>
+	</div>
+</ResponsiveDialog>

--- a/ui/user/src/lib/components/hosted-agents/AgentIcon.svelte
+++ b/ui/user/src/lib/components/hosted-agents/AgentIcon.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { darkMode } from '$lib/stores';
+	import { Bot } from '@lucide/svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	interface Props {
+		icon?: string;
+		iconDark?: string;
+		alt?: string;
+		class?: string;
+	}
+
+	let { icon, iconDark, alt = '', class: klass }: Props = $props();
+
+	// A dark variant is optional at every level, so fall back rather than
+	// rendering nothing on a dark page.
+	let src = $derived(darkMode.isDark ? iconDark || icon : icon);
+</script>
+
+{#if src}
+	<img {src} {alt} class={twMerge('size-5 shrink-0 rounded-sm object-contain', klass)} />
+{:else}
+	<!-- A placeholder rather than a gap: rows stay aligned whether or not a
+	     template declares an icon. -->
+	<Bot class={twMerge('text-muted-content size-5 shrink-0 opacity-40', klass)} />
+{/if}

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -11,6 +11,7 @@ import {
 	doPut,
 	handleResponse,
 	type Fetcher,
+	type ErrorHandler,
 	type PaginatedResponse
 } from '../http';
 import { AUDIT_LOG_FILTER_OPTIONS_LIMIT } from '../user/constants';
@@ -75,6 +76,22 @@ import type {
 	SkillRepositoryManifest,
 	SkillAccessPolicy,
 	SkillAccessPolicyManifest,
+	AgentCatalog,
+	AgentCatalogManifest,
+	Harness,
+	HarnessManifest,
+	HostedAgent,
+	HostedAgentManifest,
+	HostedAgentPool,
+	HostedAgentPoolManifest,
+	HostedAgentPoolDefaults,
+	HostedAgentPoolAssignment,
+	HostedAgentPoolAssignmentManifest,
+	HostedAgentPoolUtilization,
+	HostedAgentInstance,
+	HostedAgentInstanceManifest,
+	HostedAgentAccessPolicy,
+	HostedAgentAccessPolicyManifest,
 	MessagePolicy,
 	MessagePolicyManifest,
 	MessagePolicyViolation,
@@ -1760,6 +1777,312 @@ export async function deleteSkillAccessPolicy(
 	opts?: { signal?: AbortSignal }
 ): Promise<void> {
 	await doDelete(`/skill-access-rules/${id}`, opts);
+}
+
+// Agent sources
+
+export async function listAgentCatalogs(opts?: { fetch?: Fetcher }): Promise<AgentCatalog[]> {
+	const response = (await doGet('/agent-catalogs', opts)) as ItemsResponse<AgentCatalog>;
+	return response.items ?? [];
+}
+
+export async function getAgentCatalog(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<AgentCatalog> {
+	return (await doGet(`/agent-catalogs/${id}`, opts)) as AgentCatalog;
+}
+
+export async function createAgentCatalog(
+	request: AgentCatalogManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<AgentCatalog> {
+	return (await doPost('/agent-catalogs', request, opts)) as AgentCatalog;
+}
+
+export async function updateAgentCatalog(
+	id: string,
+	request: AgentCatalogManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<AgentCatalog> {
+	return (await doPut(`/agent-catalogs/${id}`, request, opts)) as AgentCatalog;
+}
+
+export async function deleteAgentCatalog(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/agent-catalogs/${id}`, opts);
+}
+
+// refreshAgentCatalog asks the controller to sync now; poll getAgentCatalog until
+// isSyncing clears to see the result.
+export async function refreshAgentCatalog(id: string, opts?: { fetch?: Fetcher }): Promise<void> {
+	await doPost(`/agent-catalogs/${id}/refresh`, {}, opts);
+}
+
+// Harnesses
+
+export async function listHarnesses(opts?: { fetch?: Fetcher }): Promise<Harness[]> {
+	const response = (await doGet('/harnesses', opts)) as ItemsResponse<Harness>;
+	return response.items ?? [];
+}
+
+export async function getHarness(id: string, opts?: { fetch?: Fetcher }): Promise<Harness> {
+	return (await doGet(`/harnesses/${id}`, opts)) as Harness;
+}
+
+export async function createHarness(
+	request: HarnessManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<Harness> {
+	return (await doPost('/harnesses', request, opts)) as Harness;
+}
+
+export async function updateHarness(
+	id: string,
+	request: HarnessManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<Harness> {
+	return (await doPut(`/harnesses/${id}`, request, opts)) as Harness;
+}
+
+export async function deleteHarness(id: string, opts?: { signal?: AbortSignal }): Promise<void> {
+	await doDelete(`/harnesses/${id}`, opts);
+}
+
+// Hosted agents
+
+// Pass all: true as an admin to bypass access-policy filtering.
+export async function listHostedAgents(opts?: {
+	fetch?: Fetcher;
+	all?: boolean;
+}): Promise<HostedAgent[]> {
+	const url = opts?.all ? '/hosted-agents?all=true' : '/hosted-agents';
+	const response = (await doGet(url, opts)) as ItemsResponse<HostedAgent>;
+	return response.items ?? [];
+}
+
+export async function getHostedAgent(id: string, opts?: { fetch?: Fetcher }): Promise<HostedAgent> {
+	return (await doGet(`/hosted-agents/${id}`, opts)) as HostedAgent;
+}
+
+export async function createHostedAgent(
+	request: HostedAgentManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgent> {
+	return (await doPost('/hosted-agents', request, opts)) as HostedAgent;
+}
+
+export async function updateHostedAgent(
+	id: string,
+	request: HostedAgentManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgent> {
+	return (await doPut(`/hosted-agents/${id}`, request, opts)) as HostedAgent;
+}
+
+export async function deleteHostedAgent(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agents/${id}`, opts);
+}
+
+// Hosted agent pools
+
+export async function listHostedAgentPools(opts?: { fetch?: Fetcher }): Promise<HostedAgentPool[]> {
+	const response = (await doGet('/hosted-agent-pools', opts)) as ItemsResponse<HostedAgentPool>;
+	return response.items ?? [];
+}
+
+export async function createHostedAgentPool(
+	request: HostedAgentPoolManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPool> {
+	return (await doPost('/hosted-agent-pools', request, opts)) as HostedAgentPool;
+}
+
+export async function updateHostedAgentPool(
+	id: string,
+	request: HostedAgentPoolManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPool> {
+	return (await doPut(`/hosted-agent-pools/${id}`, request, opts)) as HostedAgentPool;
+}
+
+export async function deleteHostedAgentPool(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agent-pools/${id}`, opts);
+}
+
+export async function getHostedAgentPoolUtilization(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolUtilization> {
+	return (await doGet(`/hosted-agent-pools/${id}/utilization`, opts)) as HostedAgentPoolUtilization;
+}
+
+export async function getHostedAgentPoolDefaults(opts?: {
+	fetch?: Fetcher;
+}): Promise<HostedAgentPoolDefaults> {
+	return (await doGet('/hosted-agent-pool-defaults', opts)) as HostedAgentPoolDefaults;
+}
+
+export async function createHostedAgentPoolDefaults(
+	request: HostedAgentPoolManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolDefaults> {
+	return (await doPost('/hosted-agent-pool-defaults', request, opts)) as HostedAgentPoolDefaults;
+}
+
+export async function updateHostedAgentPoolDefaults(
+	request: HostedAgentPoolManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolDefaults> {
+	return (await doPut('/hosted-agent-pool-defaults', request, opts)) as HostedAgentPoolDefaults;
+}
+
+export async function listHostedAgentPoolAssignments(opts?: {
+	fetch?: Fetcher;
+}): Promise<HostedAgentPoolAssignment[]> {
+	const response = (await doGet(
+		'/hosted-agent-pool-assignments',
+		opts
+	)) as ItemsResponse<HostedAgentPoolAssignment>;
+	return response.items ?? [];
+}
+
+export async function createHostedAgentPoolAssignment(
+	request: HostedAgentPoolAssignmentManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolAssignment> {
+	return (await doPost(
+		'/hosted-agent-pool-assignments',
+		request,
+		opts
+	)) as HostedAgentPoolAssignment;
+}
+
+export async function updateHostedAgentPoolAssignment(
+	id: string,
+	request: HostedAgentPoolAssignmentManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentPoolAssignment> {
+	return (await doPut(
+		`/hosted-agent-pool-assignments/${id}`,
+		request,
+		opts
+	)) as HostedAgentPoolAssignment;
+}
+
+export async function deleteHostedAgentPoolAssignment(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agent-pool-assignments/${id}`, opts);
+}
+
+// revealHostedAgent returns the values of env vars marked sensitive, which are
+// never included in the agent itself.
+export async function revealHostedAgent(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<Record<string, string>> {
+	return (await doPost(`/hosted-agents/${id}/reveal`, {}, opts)) as Record<string, string>;
+}
+
+// Hosted agent instances
+
+export async function listHostedAgentInstances(
+	hostedAgentID?: string,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentInstance[]> {
+	const queryString = hostedAgentID ? buildQueryString({ hosted_agent_id: hostedAgentID }) : '';
+	const response = (await doGet(
+		`/hosted-agent-instances${queryString ? `?${queryString}` : ''}`,
+		opts
+	)) as ItemsResponse<HostedAgentInstance>;
+	return response.items ?? [];
+}
+
+export async function getHostedAgentInstance(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentInstance> {
+	return (await doGet(`/hosted-agent-instances/${id}`, opts)) as HostedAgentInstance;
+}
+
+export async function createHostedAgentInstance(
+	request: HostedAgentInstanceManifest & { hostedAgentID: string; poolID?: string },
+	opts?: { fetch?: Fetcher; errorHandler?: ErrorHandler }
+): Promise<HostedAgentInstance> {
+	return (await doPost('/hosted-agent-instances', request, opts)) as HostedAgentInstance;
+}
+
+export async function updateHostedAgentInstance(
+	id: string,
+	request: HostedAgentInstanceManifest,
+	opts?: { fetch?: Fetcher; errorHandler?: ErrorHandler }
+): Promise<HostedAgentInstance> {
+	return (await doPut(`/hosted-agent-instances/${id}`, request, opts)) as HostedAgentInstance;
+}
+
+export async function deleteHostedAgentInstance(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agent-instances/${id}`, opts);
+}
+
+// Hosted agent access policies
+//
+// The UI calls these "Access Policies"; the API resource is
+// hosted-agent-access-rules. This mirrors the skill access policy naming.
+
+export async function listHostedAgentAccessPolicies(opts?: {
+	fetch?: Fetcher;
+}): Promise<HostedAgentAccessPolicy[]> {
+	const response = (await doGet(
+		'/hosted-agent-access-rules',
+		opts
+	)) as ItemsResponse<HostedAgentAccessPolicy>;
+	return response.items ?? [];
+}
+
+export async function getHostedAgentAccessPolicy(
+	id: string,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentAccessPolicy> {
+	return (await doGet(`/hosted-agent-access-rules/${id}`, opts)) as HostedAgentAccessPolicy;
+}
+
+export async function createHostedAgentAccessPolicy(
+	request: HostedAgentAccessPolicyManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentAccessPolicy> {
+	return (await doPost('/hosted-agent-access-rules', request, opts)) as HostedAgentAccessPolicy;
+}
+
+export async function updateHostedAgentAccessPolicy(
+	id: string,
+	request: HostedAgentAccessPolicyManifest,
+	opts?: { fetch?: Fetcher }
+): Promise<HostedAgentAccessPolicy> {
+	return (await doPut(
+		`/hosted-agent-access-rules/${id}`,
+		request,
+		opts
+	)) as HostedAgentAccessPolicy;
+}
+
+export async function deleteHostedAgentAccessPolicy(
+	id: string,
+	opts?: { signal?: AbortSignal }
+): Promise<void> {
+	await doDelete(`/hosted-agent-access-rules/${id}`, opts);
 }
 
 // Storage credentials

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -1133,6 +1133,254 @@ export interface SkillAccessPolicyManifest {
 	resources: SkillAccessPolicyResource[];
 }
 
+// Agent sources
+
+export interface AgentCatalogManifest {
+	displayName: string;
+	repoURL: string;
+	ref?: string;
+}
+
+export interface AgentCatalog extends AgentCatalogManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+	lastSyncTime?: string;
+	isSyncing?: boolean;
+	syncError?: string;
+	resolvedCommitSHA?: string;
+	discoveredAgentCount: number;
+	discoveredHarnessCount: number;
+}
+
+// Harnesses — the runtimes hosted agents are built on (e.g. "Claude Code",
+// "Codex", "Custom Python"). The harness supplies the docker image; the agent
+// supplies configuration.
+
+export interface HarnessManifest {
+	name: string;
+	description?: string;
+	icon?: string;
+	iconDark?: string;
+	image: string;
+}
+
+export interface Harness extends HarnessManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+}
+
+// Hosted agents
+
+export type HostedAgentState = 'pending' | 'ready' | 'error' | 'removing';
+
+// Agents are templates and carry no status; only instances run.
+export interface HostedAgentInstanceStatus {
+	state?: HostedAgentState;
+	url?: string;
+	error?: string;
+	reason?: string;
+	message?: string;
+	observedRevision?: string;
+	lastObservedTime?: string;
+	backendID?: string;
+	backendGeneration?: string;
+}
+
+export interface HostedAgentEnv {
+	name?: string;
+	description?: string;
+	key: string;
+	value?: string;
+	sensitive?: boolean;
+	required?: boolean;
+}
+
+export type HostedAgentQuestionType = 'string' | 'number' | 'boolean' | 'select' | 'schedule';
+
+export interface HostedAgentQuestion {
+	key: string;
+	name?: string;
+	description?: string;
+	type?: HostedAgentQuestionType;
+	required?: boolean;
+	sensitive?: boolean;
+	default?: string;
+	// Only valid for type 'select'.
+	options?: string[];
+}
+
+export interface HostedAgentManifest {
+	name: string;
+	description?: string;
+	icon?: string;
+	iconDark?: string;
+	// The Harness this agent runs on; the harness supplies the docker image.
+	harnessID: string;
+	// Optional git repository made available to the agent.
+	gitRepo?: string;
+	// Branch, tag or commit SHA. Blank checks out the default branch.
+	gitRef?: string;
+	modelProviders?: string[];
+	// Model IDs, obot://<alias> references, or wildcard prefixes.
+	models?: string[];
+	// MCP gateway IDs — the same handles used by /mcp-connect/{mcp_id}.
+	mcpServers?: string[];
+	skills?: string[];
+	env?: HostedAgentEnv[];
+	questions?: HostedAgentQuestion[];
+	allowUserMCPServers?: boolean;
+	allowUserSkills?: boolean;
+	allowUserModels?: boolean;
+	// Lets a user set their own git repository on an instance, overriding the
+	// agent's gitRepo if one is configured.
+	allowUserGitRepo?: boolean;
+	maxInstancesPerUser?: number;
+	// The HTTP port the agent serves on inside its sandbox. When set, instances
+	// are reachable at /agent-connect/{instance id}.
+	port?: number;
+	// Offers an interactive shell attached to the sandbox. Requires an
+	// interactive harness, since without a TTY there is no session to attach to.
+	terminal?: boolean;
+}
+
+export interface HostedAgent extends HostedAgentManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+	// Why this agent cannot be launched on this installation — a model its
+	// harness can use is not configured, or an MCP server it names is missing.
+	// Empty or absent means it can be launched.
+	unavailableReasons?: string[];
+}
+
+export interface HostedAgentInstanceManifest {
+	name: string;
+	description?: string;
+	icon?: string;
+	// Answers to the agent's questions, keyed by question key. Values are strings
+	// regardless of the question's type.
+	answers?: Record<string, string>;
+	// Git repository the user supplied; only accepted when the agent sets
+	// allowUserGitRepo.
+	gitRepo?: string;
+	// Branch, tag or commit for gitRepo. It belongs to the repository beside it:
+	// the agent's ref is not applied to a repository the user supplied.
+	gitRef?: string;
+	// Resources the user attached themselves; only accepted when the agent's
+	// corresponding allowUser* flag is set.
+	mcpServers?: string[];
+	skills?: string[];
+	models?: string[];
+}
+
+export interface HostedAgentInstance extends HostedAgentInstanceManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+	hostedAgentID: string;
+	userID?: string;
+	poolID?: string;
+	// The icon to show, already resolved by the server through instance ->
+	// agent -> harness, so a client renders a row from this payload alone.
+	resolvedIcon?: string;
+	resolvedIconDark?: string;
+	status?: HostedAgentInstanceStatus;
+}
+
+export interface HostedAgentResourceQuantity {
+	cpuVcpus: number;
+	memoryBytes: number;
+	storageBytes: number;
+}
+
+export interface HostedAgentPoolManifest {
+	// How many sandboxes share this pool. Each reserves capacity/maxSandboxes
+	// and may burst to the whole pool, so raising it shrinks everyone's share.
+	maxSandboxes?: number;
+	capacity: HostedAgentResourceQuantity;
+	suspended?: boolean;
+}
+
+export interface HostedAgentPoolStatus {
+	backendProjectID?: string;
+	backendPoolID?: string;
+	ready?: boolean;
+	schedulable?: boolean;
+	degraded?: boolean;
+	capacity?: HostedAgentResourceQuantity;
+	observedRevision?: string;
+	reason?: string;
+	message?: string;
+}
+
+export interface HostedAgentPool extends HostedAgentPoolManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+	status?: HostedAgentPoolStatus;
+}
+
+export interface HostedAgentPoolDefaults extends HostedAgentPoolManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+}
+
+export interface HostedAgentPoolAssignmentManifest {
+	userID: string;
+	poolID: string;
+	default?: boolean;
+}
+
+export interface HostedAgentPoolAssignment extends HostedAgentPoolAssignmentManifest {
+	id: string;
+	created: string;
+	deleted?: string;
+}
+
+export interface HostedAgentInstanceUtilization {
+	instanceID: string;
+	state?: string;
+	usage: HostedAgentResourceQuantity;
+}
+
+export interface HostedAgentPoolUtilization {
+	timestamp: string;
+	pool: HostedAgentResourceQuantity;
+	instances: HostedAgentInstanceUtilization[];
+	pressure: {
+		cpu?: boolean;
+		memory?: boolean;
+		storage?: boolean;
+	};
+	// Distinguishes a pool using no disk from one whose disk cannot be measured.
+	// Sandboxes share one volume, so disk is only ever reported for the pool —
+	// never per instance.
+	storageMeasured?: boolean;
+}
+
+// The UI calls these "Access Policies"; the API resource is
+// hosted-agent-access-rules. See operations.ts for the rename shim.
+export interface HostedAgentAccessPolicyResource {
+	type: 'hostedAgent' | 'selector';
+	id: string;
+}
+export interface HostedAgentAccessPolicy {
+	id: string;
+	created: string;
+	deleted?: string;
+	displayName: string;
+	subjects: AccessControlRuleSubject[];
+	resources: HostedAgentAccessPolicyResource[];
+}
+export interface HostedAgentAccessPolicyManifest {
+	displayName: string;
+	subjects: AccessControlRuleSubject[];
+	resources: HostedAgentAccessPolicyResource[];
+}
+
 // Storage credentials
 
 export interface StorageCredentials {

--- a/ui/user/src/lib/services/http.ts
+++ b/ui/user/src/lib/services/http.ts
@@ -104,6 +104,8 @@ type ResponseHandler = (
 	opts?: { dontLogErrors?: boolean }
 ) => Promise<unknown>;
 
+export type ErrorHandler = (error: unknown) => void;
+
 export async function doDelete(
 	path: string,
 	opts?: {
@@ -132,6 +134,7 @@ export async function doPut(
 	input?: string | object | Blob,
 	opts?: {
 		dontLogErrors?: boolean;
+		errorHandler?: ErrorHandler;
 		fetch?: typeof fetch;
 		signal?: AbortSignal;
 	}
@@ -144,12 +147,13 @@ export async function handleResponse(
 	path: string,
 	opts?: {
 		dontLogErrors?: boolean;
+		errorHandler?: ErrorHandler;
 	}
 ): Promise<unknown> {
 	if (!resp.ok) {
 		const body = await resp.text();
 		const e = createHttpError(resp.status, path, body);
-		if (opts?.dontLogErrors) {
+		if (opts?.dontLogErrors || opts?.errorHandler) {
 			throw e;
 		}
 		errors.items.push(e);
@@ -167,6 +171,7 @@ export async function doWithBody(
 	input?: string | object | Blob | FormData,
 	opts?: {
 		dontLogErrors?: boolean;
+		errorHandler?: ErrorHandler;
 		fetch?: typeof fetch;
 		headers?: Record<string, string>;
 		signal?: AbortSignal;
@@ -204,6 +209,10 @@ export async function doWithBody(
 		}
 		return handleResponse(resp, path, opts);
 	} catch (e) {
+		if (opts?.errorHandler) {
+			opts.errorHandler(e);
+			throw e;
+		}
 		if (opts?.dontLogErrors) {
 			throw e;
 		}
@@ -217,6 +226,7 @@ export async function doPost(
 	input: string | object | Blob,
 	opts?: {
 		dontLogErrors?: boolean;
+		errorHandler?: ErrorHandler;
 		fetch?: typeof fetch;
 		headers?: Record<string, string>;
 		signal?: AbortSignal;

--- a/ui/user/src/routes/admin/hosted-agent-access-policies/+page.svelte
+++ b/ui/user/src/routes/admin/hosted-agent-access-policies/+page.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import Confirm from '$lib/components/Confirm.svelte';
+	import Layout from '$lib/components/Layout.svelte';
+	import HostedAgentAccessPolicyForm from '$lib/components/admin/HostedAgentAccessPolicyForm.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
+	import Table from '$lib/components/table/Table.svelte';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import { type HostedAgentAccessPolicy } from '$lib/services/admin/types';
+	import { AdminService } from '$lib/services/index.js';
+	import { profile } from '$lib/stores/index.js';
+	import { clearUrlParams, goto } from '$lib/url';
+	import { openUrl } from '$lib/utils.js';
+	import { Plus, Trash2, Vault } from '@lucide/svelte';
+	import { untrack } from 'svelte';
+	import { fly } from 'svelte/transition';
+
+	let { data } = $props();
+	let hostedAgentAccessPolicies = $state(untrack(() => data.hostedAgentAccessPolicies));
+	let policyToDelete = $state<HostedAgentAccessPolicy>();
+
+	let isReadonly = $derived(profile.current.isAdminReadonly?.());
+	let showCreateNew = $derived(page.url.searchParams.has('new'));
+
+	async function navigateToCreated(policy: HostedAgentAccessPolicy) {
+		clearUrlParams(['new']);
+		goto(`/admin/hosted-agent-access-policies/${policy.id}`, { replaceState: false });
+	}
+
+	const duration = PAGE_TRANSITION_DURATION;
+
+	let title = $derived(
+		showCreateNew ? 'Create Hosted Agent Access Policy' : 'Hosted Agent Access Policies'
+	);
+</script>
+
+<Layout {title} showBackButton={showCreateNew}>
+	<div
+		class="h-full w-full"
+		in:fly={{ x: 100, duration, delay: duration }}
+		out:fly={{ x: -100, duration }}
+	>
+		{#if showCreateNew}
+			{@render createPolicyScreen()}
+		{:else}
+			<div
+				class="flex flex-col gap-8"
+				in:fly={{ x: 100, delay: duration, duration }}
+				out:fly={{ x: -100, duration }}
+			>
+				{#if hostedAgentAccessPolicies.length === 0}
+					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+						<Vault class="text-muted-content size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">
+							No hosted agent access policies
+						</h4>
+						<p class="text-muted-content text-sm font-light">
+							Looks like you don't have any hosted agent access policies created yet. <br />
+							{#if !isReadonly}
+								Click the button below to get started.
+							{/if}
+						</p>
+
+						{@render addPolicyButton()}
+					</div>
+				{:else}
+					<div class="flex flex-col gap-2">
+						{@render policyTable()}
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	{#snippet rightNavActions()}
+		{#if !showCreateNew}
+			<div class="relative flex items-center gap-4">
+				{@render addPolicyButton()}
+			</div>
+		{/if}
+	{/snippet}
+</Layout>
+
+{#snippet policyTable()}
+	<Table
+		data={hostedAgentAccessPolicies}
+		fields={['displayName']}
+		headers={[{ property: 'displayName', title: 'Name' }]}
+		onClickRow={(d, isCtrlClick) => {
+			openUrl(`/admin/hosted-agent-access-policies/${d.id}`, isCtrlClick);
+		}}
+		sortable={['displayName']}
+	>
+		{#snippet actions(d)}
+			{#if !isReadonly}
+				<IconButton
+					variant="danger"
+					onclick={(e) => {
+						e.stopPropagation();
+						policyToDelete = d;
+					}}
+					tooltip={{ text: 'Delete Policy' }}
+				>
+					<Trash2 class="size-4" />
+				</IconButton>
+			{/if}
+		{/snippet}
+		{#snippet onRenderColumn(property, d)}
+			{d[property as keyof typeof d]}
+		{/snippet}
+	</Table>
+{/snippet}
+
+{#snippet addPolicyButton()}
+	{#if !profile.current.isAdminReadonly?.()}
+		<button
+			class="btn btn-primary flex items-center gap-1 text-sm"
+			onclick={() => {
+				goto(`/admin/hosted-agent-access-policies?new=true`);
+			}}
+		>
+			<Plus class="size-4" /> Add Access Policy
+		</button>
+	{/if}
+{/snippet}
+
+{#snippet createPolicyScreen()}
+	<div
+		class="h-full w-full"
+		in:fly={{ x: 100, delay: duration, duration }}
+		out:fly={{ x: -100, duration }}
+	>
+		<HostedAgentAccessPolicyForm onCreate={navigateToCreated} readonly={isReadonly} />
+	</div>
+{/snippet}
+
+<Confirm
+	msg={`Delete ${policyToDelete?.displayName || 'this policy'}?`}
+	show={Boolean(policyToDelete)}
+	onsuccess={async () => {
+		if (!policyToDelete) return;
+		await AdminService.deleteHostedAgentAccessPolicy(policyToDelete.id);
+		hostedAgentAccessPolicies = await AdminService.listHostedAgentAccessPolicies();
+		policyToDelete = undefined;
+	}}
+	oncancel={() => (policyToDelete = undefined)}
+/>
+
+<svelte:head>
+	<title>Obot | Hosted Agent Access Policies</title>
+</svelte:head>

--- a/ui/user/src/routes/admin/hosted-agent-access-policies/+page.ts
+++ b/ui/user/src/routes/admin/hosted-agent-access-policies/+page.ts
@@ -1,0 +1,19 @@
+import { handleRouteError } from '$lib/errors';
+import { AdminService } from '$lib/services';
+import type { HostedAgentAccessPolicy } from '$lib/services/admin/types';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, parent }) => {
+	const { profile } = await parent();
+	let hostedAgentAccessPolicies: HostedAgentAccessPolicy[] = [];
+
+	try {
+		hostedAgentAccessPolicies = await AdminService.listHostedAgentAccessPolicies({ fetch });
+	} catch (err) {
+		handleRouteError(err, '/admin/hosted-agent-access-policies', profile);
+	}
+
+	return {
+		hostedAgentAccessPolicies
+	};
+};

--- a/ui/user/src/routes/admin/hosted-agent-access-policies/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/hosted-agent-access-policies/[id]/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import Layout from '$lib/components/Layout.svelte';
+	import HostedAgentAccessPolicyForm from '$lib/components/admin/HostedAgentAccessPolicyForm.svelte';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import { profile } from '$lib/stores/index.js';
+	import { goto } from '$lib/url';
+	import { fly } from 'svelte/transition';
+
+	let { data } = $props();
+	const { hostedAgentAccessPolicy } = $derived(data);
+	const duration = PAGE_TRANSITION_DURATION;
+
+	let title = $derived(hostedAgentAccessPolicy?.displayName ?? 'Hosted Agent Access Policy');
+</script>
+
+<Layout {title} showBackButton>
+	<div class="h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
+		<HostedAgentAccessPolicyForm
+			{hostedAgentAccessPolicy}
+			onUpdate={() => {
+				goto('/admin/hosted-agent-access-policies');
+			}}
+			readonly={profile.current.isAdminReadonly?.()}
+		/>
+	</div>
+</Layout>
+
+<svelte:head>
+	<title>Obot | {title}</title>
+</svelte:head>

--- a/ui/user/src/routes/admin/hosted-agent-access-policies/[id]/+page.ts
+++ b/ui/user/src/routes/admin/hosted-agent-access-policies/[id]/+page.ts
@@ -1,0 +1,19 @@
+import { handleRouteError } from '$lib/errors';
+import { AdminService, type HostedAgentAccessPolicy } from '$lib/services';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ params, fetch, parent }) => {
+	const { id } = params;
+	const { profile } = await parent();
+
+	let hostedAgentAccessPolicy: HostedAgentAccessPolicy | undefined;
+	try {
+		hostedAgentAccessPolicy = await AdminService.getHostedAgentAccessPolicy(id, { fetch });
+	} catch (err) {
+		handleRouteError(err, `/admin/hosted-agent-access-policies/${id}`, profile);
+	}
+
+	return {
+		hostedAgentAccessPolicy
+	};
+};

--- a/ui/user/src/routes/admin/hosted-agents/+page.svelte
+++ b/ui/user/src/routes/admin/hosted-agents/+page.svelte
@@ -1,0 +1,746 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import Confirm from '$lib/components/Confirm.svelte';
+	import Layout from '$lib/components/Layout.svelte';
+	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
+	import HostedAgentForm from '$lib/components/admin/HostedAgentForm.svelte';
+	import HostedAgentPools from '$lib/components/admin/HostedAgentPools.svelte';
+	import AgentIcon from '$lib/components/hosted-agents/AgentIcon.svelte';
+	import IconButton from '$lib/components/primitives/IconButton.svelte';
+	import Table from '$lib/components/table/Table.svelte';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import Loading from '$lib/icons/Loading.svelte';
+	import { type AgentCatalog, type Harness, type HostedAgent } from '$lib/services/admin/types';
+	import { AdminService } from '$lib/services/index.js';
+	import { errors, profile } from '$lib/stores/index.js';
+	import { clearUrlParams, goto } from '$lib/url';
+	import { openUrl } from '$lib/utils.js';
+	import { Bot, Cpu, GitBranch, Pencil, Plus, RefreshCcw, Trash2 } from '@lucide/svelte';
+	import { onDestroy, untrack } from 'svelte';
+	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+	import { fly } from 'svelte/transition';
+	import { twMerge } from 'tailwind-merge';
+
+	let { data } = $props();
+	let hostedAgents = $state(untrack(() => data.hostedAgents));
+	let agentCatalogs = $state(untrack(() => data.agentCatalogs));
+	let harnesses = $state(untrack(() => data.harnesses));
+	let pools = $state(untrack(() => data.pools));
+	let assignments = $state(untrack(() => data.assignments));
+	let poolDefaults = $state(untrack(() => data.poolDefaults));
+	let agentToDelete = $state<HostedAgent>();
+	let catalogToDelete = $state<AgentCatalog>();
+	let harnessToDelete = $state<Harness>();
+
+	let isReadonly = $derived(profile.current.isAdminReadonly?.());
+	let showCreateNew = $derived(page.url.searchParams.has('new'));
+	let view = $derived<'agents' | 'catalogs' | 'harnesses' | 'pools'>(
+		page.url.searchParams.get('view') === 'catalogs'
+			? 'catalogs'
+			: page.url.searchParams.get('view') === 'harnesses'
+				? 'harnesses'
+				: page.url.searchParams.get('view') === 'pools'
+					? 'pools'
+					: 'agents'
+	);
+
+	// Source form
+	let catalogDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let editingCatalog = $state<AgentCatalog | undefined>();
+	let savingCatalog = $state(false);
+	let catalogForm = $state({ displayName: '', repoURL: '', ref: '' });
+
+	// Sync tracking, mirroring the Skill Sources page: refresh sets an annotation
+	// and the controller does the work, so poll until isSyncing clears.
+	let syncing = new SvelteSet<string>();
+	let syncIntervals = new SvelteMap<string, ReturnType<typeof setInterval>>();
+
+	function clearSyncInterval(id: string) {
+		const interval = syncIntervals.get(id);
+		if (interval) clearInterval(interval);
+		syncIntervals.delete(id);
+	}
+
+	onDestroy(() => {
+		for (const interval of syncIntervals.values()) clearInterval(interval);
+	});
+
+	function pollTillSyncComplete(id: string) {
+		clearSyncInterval(id);
+		syncIntervals.set(
+			id,
+			setInterval(async () => {
+				try {
+					const response = await AdminService.getAgentCatalog(id);
+					if (response && !response.isSyncing) {
+						clearSyncInterval(id);
+						agentCatalogs = await AdminService.listAgentCatalogs();
+						hostedAgents = await AdminService.listHostedAgents({ all: true });
+						harnesses = await AdminService.listHarnesses();
+						syncing.delete(id);
+					}
+				} catch (err) {
+					errors.append(`Failed to sync config source: ${err}`);
+					clearSyncInterval(id);
+					syncing.delete(id);
+				}
+			}, 3000)
+		);
+	}
+
+	async function sync(id: string) {
+		syncing.add(id);
+		try {
+			await AdminService.refreshAgentCatalog(id);
+			pollTillSyncComplete(id);
+		} catch (err) {
+			errors.append(`Failed to refresh config source: ${err}`);
+			syncing.delete(id);
+		}
+	}
+
+	function switchView(newView: 'agents' | 'catalogs' | 'harnesses' | 'pools') {
+		goto(newView === 'agents' ? '/admin/hosted-agents' : `/admin/hosted-agents?view=${newView}`);
+	}
+
+	async function navigateToCreated(agent: HostedAgent) {
+		clearUrlParams(['new']);
+		goto(`/admin/hosted-agents/${agent.id}`, { replaceState: false });
+	}
+
+	const duration = PAGE_TRANSITION_DURATION;
+
+	let title = $derived(showCreateNew ? 'Create Agent Template' : 'Hosted Agents');
+
+	const viewDescriptions = {
+		agents:
+			'A template describes an agent someone can launch: the harness it runs on, the MCP servers, skills and models it may use, and anything the user is asked when they create one.',
+		harnesses:
+			'A harness is the container image an agent runs inside — its runtime and preinstalled tooling, such as Claude Code. Templates pick a harness; the harness decides the image and whether the agent gets an interactive shell.',
+		pools:
+			'A pool is a shared bucket of CPU and memory. Every agent placed in it draws from the same budget and can borrow whatever its neighbours are not using, so agents have no fixed size of their own.',
+		catalogs:
+			'A config source is a Git repository Obot syncs templates and harnesses from, so they are defined in version control rather than added by hand here.'
+	};
+	let viewDescription = $derived(viewDescriptions[view]);
+
+	let harnessesById = $derived(new Map(harnesses.map((h) => [h.id, h])));
+
+	// A template's own icon, falling back to its harness's: a config source
+	// often gives the harness the brand mark and leaves the template plain.
+	let tableData = $derived(
+		hostedAgents.map((agent) => ({
+			id: agent.id,
+			name: agent.name,
+			harness: harnessesById.get(agent.harnessID)?.name ?? agent.harnessID,
+			icon: agent.icon || harnessesById.get(agent.harnessID)?.icon || '',
+			iconDark: agent.iconDark || harnessesById.get(agent.harnessID)?.iconDark || ''
+		}))
+	);
+
+	let harnessTableData = $derived(
+		harnesses.map((harness) => ({
+			id: harness.id,
+			name: harness.name,
+			description: harness.description ?? '',
+			image: harness.image,
+			icon: harness.icon ?? '',
+			iconDark: harness.iconDark ?? ''
+		}))
+	);
+
+	let catalogTableData = $derived(
+		agentCatalogs.map((source) => ({
+			id: source.id,
+			displayName: source.displayName,
+			repoURL: source.repoURL,
+			ref: source.ref || '(default branch)',
+			discoveredAgentCount: source.discoveredAgentCount ?? 0,
+			discoveredHarnessCount: source.discoveredHarnessCount ?? 0,
+			syncError: source.syncError ?? '',
+			isSyncing: syncing.has(source.id) || Boolean(source.isSyncing)
+		}))
+	);
+
+	function openCreateCatalog() {
+		editingCatalog = undefined;
+		catalogForm = { displayName: '', repoURL: '', ref: '' };
+		catalogDialog?.open();
+	}
+
+	function openEditCatalog(source: AgentCatalog) {
+		editingCatalog = source;
+		catalogForm = {
+			displayName: source.displayName,
+			repoURL: source.repoURL,
+			ref: source.ref ?? ''
+		};
+		catalogDialog?.open();
+	}
+
+	async function saveCatalog() {
+		savingCatalog = true;
+		try {
+			const manifest = {
+				displayName: catalogForm.displayName,
+				repoURL: catalogForm.repoURL,
+				ref: catalogForm.ref
+			};
+			if (editingCatalog) {
+				await AdminService.updateAgentCatalog(editingCatalog.id, manifest);
+			} else {
+				await AdminService.createAgentCatalog(manifest);
+			}
+			agentCatalogs = await AdminService.listAgentCatalogs();
+			catalogDialog?.close();
+		} catch (err) {
+			errors.append(`Failed to save config source: ${err}`);
+		} finally {
+			savingCatalog = false;
+		}
+	}
+
+	let canSaveCatalog = $derived(Boolean(catalogForm.displayName && catalogForm.repoURL));
+
+	// Harness form
+	let harnessDialog = $state<ReturnType<typeof ResponsiveDialog>>();
+	let editingHarness = $state<Harness | undefined>();
+	let savingHarness = $state(false);
+	let harnessForm = $state({ name: '', description: '', icon: '', iconDark: '', image: '' });
+
+	function openCreateHarness() {
+		editingHarness = undefined;
+		harnessForm = { name: '', description: '', icon: '', iconDark: '', image: '' };
+		harnessDialog?.open();
+	}
+
+	function openEditHarness(harness: Harness) {
+		editingHarness = harness;
+		harnessForm = {
+			name: harness.name,
+			description: harness.description ?? '',
+			icon: harness.icon ?? '',
+			iconDark: harness.iconDark ?? '',
+			image: harness.image
+		};
+		harnessDialog?.open();
+	}
+
+	async function saveHarness() {
+		savingHarness = true;
+		try {
+			const manifest = {
+				name: harnessForm.name,
+				description: harnessForm.description,
+				icon: harnessForm.icon,
+				iconDark: harnessForm.iconDark,
+				image: harnessForm.image
+			};
+			if (editingHarness) {
+				await AdminService.updateHarness(editingHarness.id, manifest);
+			} else {
+				await AdminService.createHarness(manifest);
+			}
+			harnesses = await AdminService.listHarnesses();
+			harnessDialog?.close();
+		} catch (err) {
+			errors.append(`Failed to save harness: ${err}`);
+		} finally {
+			savingHarness = false;
+		}
+	}
+
+	let canSaveHarness = $derived(Boolean(harnessForm.name && harnessForm.image));
+</script>
+
+<Layout {title} showBackButton={showCreateNew}>
+	<div
+		class="h-full w-full"
+		in:fly={{ x: 100, duration, delay: duration }}
+		out:fly={{ x: -100, duration }}
+	>
+		{#if showCreateNew}
+			{@render createAgentScreen()}
+		{:else}
+			<div
+				class="flex flex-col gap-4"
+				in:fly={{ x: 100, delay: duration, duration }}
+				out:fly={{ x: -100, duration }}
+			>
+				<div class="flex w-full">
+					<button
+						class={twMerge('page-tab max-w-1/2', view === 'agents' && 'page-tab-active')}
+						onclick={() => switchView('agents')}
+					>
+						Templates
+					</button>
+					<button
+						class={twMerge('page-tab max-w-1/2', view === 'harnesses' && 'page-tab-active')}
+						onclick={() => switchView('harnesses')}
+					>
+						Harnesses
+					</button>
+					<button
+						class={twMerge('page-tab max-w-1/2', view === 'pools' && 'page-tab-active')}
+						onclick={() => switchView('pools')}
+					>
+						Pools
+					</button>
+					<button
+						class={twMerge('page-tab max-w-1/2', view === 'catalogs' && 'page-tab-active')}
+						onclick={() => switchView('catalogs')}
+					>
+						Config Sources
+					</button>
+				</div>
+
+				<!-- These four words mean nothing on first contact, and the empty-state
+				     copy that explains them disappears as soon as there is one row --
+				     which for a prepopulated install is immediately. Keeping the
+				     definition beside the tab costs one line and is always there. -->
+				<p class="text-muted-content -mt-1 text-sm font-light">{viewDescription}</p>
+
+				{#if view === 'agents'}
+					{#if hostedAgents.length === 0}
+						<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+							<Bot class="text-muted-content size-24 opacity-25" />
+							<h4 class="text-muted-content text-lg font-semibold">No agent templates</h4>
+							{#if !isReadonly}
+								<p class="text-muted-content text-sm font-light">
+									Add one directly, or sync them from a config source.
+								</p>
+							{/if}
+							{@render addAgentButton()}
+						</div>
+					{:else}
+						{@render agentTable()}
+					{/if}
+				{:else if view === 'catalogs'}
+					{#if agentCatalogs.length === 0}
+						<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+							<GitBranch class="text-muted-content size-24 opacity-25" />
+							<h4 class="text-muted-content text-lg font-semibold">No config sources</h4>
+							{#if !isReadonly}
+								<p class="text-muted-content text-sm font-light">
+									Add a Git repository to sync templates and harnesses from.
+								</p>
+							{/if}
+							{@render addSourceButton()}
+						</div>
+					{:else}
+						{@render sourceTable()}
+					{/if}
+				{:else if view === 'pools'}
+					<HostedAgentPools
+						bind:pools
+						bind:assignments
+						bind:defaults={poolDefaults}
+						readonly={isReadonly}
+					/>
+				{:else if harnesses.length === 0}
+					<div class="mt-12 flex w-md flex-col items-center gap-4 self-center text-center">
+						<Cpu class="text-muted-content size-24 opacity-25" />
+						<h4 class="text-muted-content text-lg font-semibold">No harnesses</h4>
+						{#if !isReadonly}
+							<p class="text-muted-content text-sm font-light">
+								Add one before registering a template, which has to pick a harness.
+							</p>
+						{/if}
+						{@render addHarnessButton()}
+					</div>
+				{:else if view === 'harnesses'}
+					{@render harnessTable()}
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	{#snippet rightNavActions()}
+		{#if !showCreateNew}
+			<div class="relative flex items-center gap-4">
+				{#if view === 'agents'}
+					{@render addAgentButton()}
+				{:else if view === 'catalogs'}
+					{@render addSourceButton()}
+				{:else if view === 'harnesses'}
+					{@render addHarnessButton()}
+				{/if}
+			</div>
+		{/if}
+	{/snippet}
+</Layout>
+
+{#snippet agentTable()}
+	<Table
+		data={tableData}
+		fields={['name', 'harness']}
+		headers={[
+			{ property: 'name', title: 'Name' },
+			{ property: 'harness', title: 'Harness' }
+		]}
+		onClickRow={(d, isCtrlClick) => {
+			openUrl(`/admin/hosted-agents/${d.id}`, isCtrlClick);
+		}}
+		sortable={['name', 'harness']}
+	>
+		{#snippet onRenderColumn(property, d)}
+			{#if property === 'name'}
+				<div class="flex items-center gap-2">
+					<AgentIcon icon={d.icon} iconDark={d.iconDark} alt="" />
+					<span class="truncate">{d.name}</span>
+				</div>
+			{:else}
+				{d[property as keyof typeof d]}
+			{/if}
+		{/snippet}
+		{#snippet actions(d)}
+			{#if !isReadonly}
+				<IconButton
+					variant="danger"
+					onclick={(e) => {
+						e.stopPropagation();
+						agentToDelete = hostedAgents.find((a) => a.id === d.id);
+					}}
+					tooltip={{ text: 'Delete Agent' }}
+				>
+					<Trash2 class="size-4" />
+				</IconButton>
+			{/if}
+		{/snippet}
+	</Table>
+{/snippet}
+
+{#snippet sourceTable()}
+	<Table
+		data={catalogTableData}
+		fields={['displayName', 'repoURL', 'ref', 'discoveredAgentCount', 'discoveredHarnessCount']}
+		headers={[
+			{ property: 'displayName', title: 'Name' },
+			{ property: 'repoURL', title: 'Repository' },
+			{ property: 'ref', title: 'Ref' },
+			{ property: 'discoveredAgentCount', title: 'Agents' },
+			{ property: 'discoveredHarnessCount', title: 'Harnesses' }
+		]}
+		sortable={['displayName', 'repoURL']}
+		noDataMessage="No sources added."
+	>
+		{#snippet onRenderColumn(property, d)}
+			{#if property === 'displayName'}
+				<div class="flex items-center gap-2">
+					<span>{d.displayName}</span>
+					{#if d.isSyncing}
+						<Loading class="size-3" />
+					{:else if d.syncError}
+						<span class="badge badge-error badge-xs" title={d.syncError}>sync error</span>
+					{/if}
+				</div>
+			{:else}
+				{d[property as keyof typeof d]}
+			{/if}
+		{/snippet}
+		{#snippet actions(d)}
+			{#if !isReadonly}
+				<IconButton
+					onclick={(e) => {
+						e.stopPropagation();
+						sync(d.id);
+					}}
+					disabled={d.isSyncing}
+					tooltip={{ text: 'Sync Now' }}
+				>
+					<RefreshCcw class="size-4" />
+				</IconButton>
+				<IconButton
+					onclick={(e) => {
+						e.stopPropagation();
+						const source = agentCatalogs.find((s) => s.id === d.id);
+						if (source) openEditCatalog(source);
+					}}
+					tooltip={{ text: 'Edit Config Source' }}
+				>
+					<Pencil class="size-4" />
+				</IconButton>
+				<IconButton
+					variant="danger"
+					onclick={(e) => {
+						e.stopPropagation();
+						catalogToDelete = agentCatalogs.find((s) => s.id === d.id);
+					}}
+					tooltip={{ text: 'Delete Source' }}
+				>
+					<Trash2 class="size-4" />
+				</IconButton>
+			{/if}
+		{/snippet}
+	</Table>
+{/snippet}
+
+{#snippet harnessTable()}
+	<Table
+		data={harnessTableData}
+		fields={['name', 'description', 'image']}
+		headers={[
+			{ property: 'name', title: 'Name' },
+			{ property: 'description', title: 'Description' },
+			{ property: 'image', title: 'Image' }
+		]}
+		sortable={['name', 'image']}
+		noDataMessage="No harnesses added."
+	>
+		{#snippet onRenderColumn(property, d)}
+			{#if property === 'name'}
+				<div class="flex items-center gap-2">
+					<AgentIcon icon={d.icon} iconDark={d.iconDark} alt="" />
+					<span class="truncate">{d.name}</span>
+				</div>
+			{:else}
+				{d[property as keyof typeof d]}
+			{/if}
+		{/snippet}
+		{#snippet actions(d)}
+			{#if !isReadonly}
+				<IconButton
+					onclick={(e) => {
+						e.stopPropagation();
+						const harness = harnesses.find((h) => h.id === d.id);
+						if (harness) openEditHarness(harness);
+					}}
+					tooltip={{ text: 'Edit Harness' }}
+				>
+					<Pencil class="size-4" />
+				</IconButton>
+				<IconButton
+					variant="danger"
+					onclick={(e) => {
+						e.stopPropagation();
+						harnessToDelete = harnesses.find((h) => h.id === d.id);
+					}}
+					tooltip={{ text: 'Delete Harness' }}
+				>
+					<Trash2 class="size-4" />
+				</IconButton>
+			{/if}
+		{/snippet}
+	</Table>
+{/snippet}
+
+{#snippet addAgentButton()}
+	{#if !isReadonly}
+		<button
+			class="btn btn-primary flex items-center gap-1 text-sm"
+			onclick={() => goto(`/admin/hosted-agents?new=true`)}
+		>
+			<Plus class="size-4" /> Add Template
+		</button>
+	{/if}
+{/snippet}
+
+{#snippet addSourceButton()}
+	{#if !isReadonly}
+		<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={openCreateCatalog}>
+			<Plus class="size-4" /> Add Config Source
+		</button>
+	{/if}
+{/snippet}
+
+{#snippet addHarnessButton()}
+	{#if !isReadonly}
+		<button class="btn btn-primary flex items-center gap-1 text-sm" onclick={openCreateHarness}>
+			<Plus class="size-4" /> Add Harness
+		</button>
+	{/if}
+{/snippet}
+
+{#snippet createAgentScreen()}
+	<div
+		class="h-full w-full"
+		in:fly={{ x: 100, delay: duration, duration }}
+		out:fly={{ x: -100, duration }}
+	>
+		<HostedAgentForm onCreate={navigateToCreated} readonly={isReadonly} />
+	</div>
+{/snippet}
+
+<ResponsiveDialog
+	bind:this={catalogDialog}
+	title={editingCatalog ? 'Edit Config Source' : 'Add Config Source'}
+	class="md:max-w-md"
+>
+	<div class="flex flex-col gap-4">
+		<div class="flex flex-col gap-2">
+			<label for="source-name" class="text-sm font-light">Name</label>
+			<input id="source-name" bind:value={catalogForm.displayName} class="text-input-filled" />
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="source-repo" class="text-sm font-light">Repository URL</label>
+			<input
+				id="source-repo"
+				bind:value={catalogForm.repoURL}
+				class="text-input-filled"
+				placeholder="https://github.com/obot-platform/agents"
+				inputmode="url"
+				autocomplete="off"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="source-ref" class="text-sm font-light">Ref</label>
+			<input
+				id="source-ref"
+				bind:value={catalogForm.ref}
+				class="text-input-filled"
+				placeholder="(default branch)"
+				autocomplete="off"
+			/>
+			<span class="text-muted-content text-xs">Branch or tag. Leave blank for the default.</span>
+		</div>
+	</div>
+	<div class="flex justify-end gap-2 pt-4">
+		<button class="btn btn-secondary text-sm" onclick={() => catalogDialog?.close()}>Cancel</button>
+		<button
+			class="btn btn-primary text-sm"
+			disabled={!canSaveCatalog || savingCatalog}
+			onclick={saveCatalog}
+		>
+			{#if savingCatalog}
+				<Loading class="size-4" />
+			{:else}
+				{editingCatalog ? 'Update' : 'Add'}
+			{/if}
+		</button>
+	</div>
+</ResponsiveDialog>
+
+<ResponsiveDialog
+	bind:this={harnessDialog}
+	title={editingHarness ? 'Edit Harness' : 'Add Harness'}
+	class="md:max-w-md"
+>
+	<div class="flex flex-col gap-4">
+		<div class="flex flex-col gap-2">
+			<label for="harness-name" class="text-sm font-light">Name</label>
+			<input
+				id="harness-name"
+				bind:value={harnessForm.name}
+				class="text-input-filled"
+				placeholder="Claude Code"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="harness-description" class="text-sm font-light">Description</label>
+			<textarea
+				id="harness-description"
+				bind:value={harnessForm.description}
+				class="text-input-filled"
+				rows="2"
+			></textarea>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="harness-image" class="text-sm font-light">Docker Image</label>
+			<input
+				id="harness-image"
+				bind:value={harnessForm.image}
+				class="text-input-filled"
+				placeholder="ghcr.io/example/claude-code:latest"
+				autocomplete="off"
+			/>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="harness-icon" class="text-sm font-light">Icon URL</label>
+			<div class="flex items-center gap-3">
+				{#if harnessForm.icon}
+					<img src={harnessForm.icon} alt="" class="size-10 shrink-0 rounded-md object-contain" />
+				{/if}
+				<input
+					type="text"
+					id="harness-icon"
+					bind:value={harnessForm.icon}
+					class="text-input-filled grow"
+					inputmode="url"
+					autocomplete="off"
+				/>
+			</div>
+		</div>
+		<div class="flex flex-col gap-2">
+			<label for="harness-icon-dark" class="text-sm font-light">Icon URL (Dark)</label>
+			<div class="flex items-center gap-3">
+				{#if harnessForm.iconDark}
+					<img
+						src={harnessForm.iconDark}
+						alt=""
+						class="bg-base-300 size-10 shrink-0 rounded-md object-contain"
+					/>
+				{/if}
+				<input
+					type="text"
+					id="harness-icon-dark"
+					bind:value={harnessForm.iconDark}
+					class="text-input-filled grow"
+					inputmode="url"
+					autocomplete="off"
+				/>
+			</div>
+		</div>
+	</div>
+	<div class="flex justify-end gap-2 pt-4">
+		<button class="btn btn-secondary text-sm" onclick={() => harnessDialog?.close()}>Cancel</button>
+		<button
+			class="btn btn-primary text-sm"
+			disabled={!canSaveHarness || savingHarness}
+			onclick={saveHarness}
+		>
+			{#if savingHarness}
+				<Loading class="size-4" />
+			{:else}
+				{editingHarness ? 'Update' : 'Add'}
+			{/if}
+		</button>
+	</div>
+</ResponsiveDialog>
+
+<Confirm
+	msg={`Delete ${agentToDelete?.name || 'this agent'}?`}
+	show={Boolean(agentToDelete)}
+	onsuccess={async () => {
+		if (!agentToDelete) return;
+		await AdminService.deleteHostedAgent(agentToDelete.id);
+		hostedAgents = await AdminService.listHostedAgents({ all: true });
+		agentToDelete = undefined;
+	}}
+	oncancel={() => (agentToDelete = undefined)}
+/>
+
+<Confirm
+	msg={`Delete ${catalogToDelete?.displayName || 'this source'}?`}
+	note="Agents and harnesses discovered from this source will be removed."
+	show={Boolean(catalogToDelete)}
+	onsuccess={async () => {
+		if (!catalogToDelete) return;
+		await AdminService.deleteAgentCatalog(catalogToDelete.id);
+		agentCatalogs = await AdminService.listAgentCatalogs();
+		hostedAgents = await AdminService.listHostedAgents({ all: true });
+		harnesses = await AdminService.listHarnesses();
+		catalogToDelete = undefined;
+	}}
+	oncancel={() => (catalogToDelete = undefined)}
+/>
+
+<Confirm
+	msg={`Delete ${harnessToDelete?.name || 'this harness'}?`}
+	note="A harness that agents still run on cannot be deleted."
+	show={Boolean(harnessToDelete)}
+	onsuccess={async () => {
+		if (!harnessToDelete) return;
+		try {
+			await AdminService.deleteHarness(harnessToDelete.id);
+			harnesses = await AdminService.listHarnesses();
+		} catch (err) {
+			errors.append(`Failed to delete harness: ${err}`);
+		}
+		harnessToDelete = undefined;
+	}}
+	oncancel={() => (harnessToDelete = undefined)}
+/>
+
+<svelte:head>
+	<title>Obot | Hosted Agents</title>
+</svelte:head>

--- a/ui/user/src/routes/admin/hosted-agents/+page.ts
+++ b/ui/user/src/routes/admin/hosted-agents/+page.ts
@@ -1,0 +1,48 @@
+import { handleRouteError } from '$lib/errors';
+import { AdminService } from '$lib/services';
+import type {
+	AgentCatalog,
+	Harness,
+	HostedAgent,
+	HostedAgentPool,
+	HostedAgentPoolAssignment,
+	HostedAgentPoolDefaults
+} from '$lib/services/admin/types';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, parent }) => {
+	const { profile } = await parent();
+	let hostedAgents: HostedAgent[] = [];
+	let agentCatalogs: AgentCatalog[] = [];
+	let harnesses: Harness[] = [];
+	let pools: HostedAgentPool[] = [];
+	let assignments: HostedAgentPoolAssignment[] = [];
+	let poolDefaults: HostedAgentPoolDefaults | undefined;
+
+	try {
+		// Admins get the unfiltered list; the default view is access-rule filtered.
+		[hostedAgents, agentCatalogs, harnesses, pools, assignments] = await Promise.all([
+			AdminService.listHostedAgents({ fetch, all: true }),
+			AdminService.listAgentCatalogs({ fetch }),
+			AdminService.listHarnesses({ fetch }),
+			AdminService.listHostedAgentPools({ fetch }),
+			AdminService.listHostedAgentPoolAssignments({ fetch })
+		]);
+		try {
+			poolDefaults = await AdminService.getHostedAgentPoolDefaults({ fetch });
+		} catch {
+			// Defaults do not exist until an administrator configures them.
+		}
+	} catch (err) {
+		handleRouteError(err, '/admin/hosted-agents', profile);
+	}
+
+	return {
+		hostedAgents,
+		agentCatalogs,
+		harnesses,
+		pools,
+		assignments,
+		poolDefaults
+	};
+};

--- a/ui/user/src/routes/admin/hosted-agents/[id]/+page.svelte
+++ b/ui/user/src/routes/admin/hosted-agents/[id]/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import Layout from '$lib/components/Layout.svelte';
+	import HostedAgentForm from '$lib/components/admin/HostedAgentForm.svelte';
+	import { PAGE_TRANSITION_DURATION } from '$lib/constants.js';
+	import { profile } from '$lib/stores/index.js';
+	import { goto } from '$lib/url';
+	import { fly } from 'svelte/transition';
+
+	let { data } = $props();
+	const { hostedAgent } = $derived(data);
+	const duration = PAGE_TRANSITION_DURATION;
+
+	let title = $derived(hostedAgent?.name ?? 'Agent Template');
+</script>
+
+<Layout {title} showBackButton>
+	<div class="h-full w-full" in:fly={{ x: 100, duration }} out:fly={{ x: -100, duration }}>
+		<HostedAgentForm
+			{hostedAgent}
+			onUpdate={() => {
+				goto('/admin/hosted-agents');
+			}}
+			readonly={profile.current.isAdminReadonly?.()}
+		/>
+	</div>
+</Layout>
+
+<svelte:head>
+	<title>Obot | {title}</title>
+</svelte:head>

--- a/ui/user/src/routes/admin/hosted-agents/[id]/+page.ts
+++ b/ui/user/src/routes/admin/hosted-agents/[id]/+page.ts
@@ -1,0 +1,19 @@
+import { handleRouteError } from '$lib/errors';
+import { AdminService, type HostedAgent } from '$lib/services';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ params, fetch, parent }) => {
+	const { id } = params;
+	const { profile } = await parent();
+
+	let hostedAgent: HostedAgent | undefined;
+	try {
+		hostedAgent = await AdminService.getHostedAgent(id, { fetch });
+	} catch (err) {
+		handleRouteError(err, `/admin/hosted-agents/${id}`, profile);
+	}
+
+	return {
+		hostedAgent
+	};
+};


### PR DESCRIPTION
An admin section for templates, harnesses, pools and config sources, plus the
API client the whole feature is built on.

Rows carry the icon the server resolved, so the UI does not walk the
instance-template-harness chain itself and cannot disagree with the answer the
API gives. A template that cannot run here is shown with the reason and cannot
be launched, which is the same answer the API enforces rather than a second copy
of the rule.



---

Part 9 of an 11-PR stack. Base: `feat/hosted-agents-08-rest-api`.

## Stack

1. #7459 — Resource model
2. #7460 — Sandbox backend interface
3. #7461 — Kubernetes sandbox backend
4. #7462 — Sandbox reachability (models + MCP)
5. #7463 — Terminal + HTTP publish
6. #7464 — Server wiring + Helm
7. #7465 — Controllers / reconcilers
8. #7466 — REST API
**→ 9. #7467 — Admin UI** (this PR)
10. #7468 — User UI
11. #7469 — Seed default config source

Merge bottom-up; GitHub retargets each child when its parent merges.
