### PR TITLE
fix(ci): authenticate Depot on same-repo PRs and run CI on feat/* branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'feat/*'
     paths:
       - "docs/**"
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'feat/*'
     paths-ignore:
       - chart/**
       - ui/user/**

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'feat/*'
     paths:
       - .github/workflows/helm.yml
       - chart/**

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -1,8 +1,14 @@
 name: Test Docker Build
+
+permissions:
+  contents: read
+  id-token: write
+
 on:
   pull_request:
     branches:
       - main
+      - 'feat/*'
     paths-ignore:
       - docs/**
       - chart/**

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'feat/*'
 
 jobs:
   test:

--- a/.github/workflows/user-ui.yml
+++ b/.github/workflows/user-ui.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'feat/*'
     paths:
       - ui/user/**
 


### PR DESCRIPTION
The `Test Docker Build` job fails on any pull request whose branch lives in this repository rather than in a fork:

```
Unable to exchange GitHub OIDC token for temporary Depot token:
  Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
unauthenticated: Invalid token
```

`test-docker-build.yml` declares no `permissions:` block, and GitHub never grants `id-token` implicitly — not even when the default workflow permissions are read-write, as they are here. The failing job's own permission list shows `Contents: write`, `PullRequests: write`, and no `id-token` at all.

This went unnoticed because every pull request so far has come from a fork, and `depot/build-push-action` takes a different path for those:

```
Attempting to acquire open-source pull request OIDC token
Using open-source pull request OIDC token for Depot authentication
```

That challenge flow needs no GitHub OIDC, so fork PRs never exercised the broken branch. The two sibling workflows that build with Depot outside of pull requests — `docker-build-and-push.yml` and `weekly-base-image.yml` — both already request `id-token: write`. This one was simply missing it.

### Also: CI on stacked PRs

Every `pull_request` trigger was filtered to `branches: [main]`, so a PR based on another branch gets **no CI at all** — only the bottom of a stack is tested. Widened to `[main, 'feat/*']` across `go.yml`, `test.yaml`, `test-docker-build.yml`, `user-ui.yml`, `docs.yml`, and `helm.yml`. Existing `paths`/`paths-ignore` filters are unchanged, as are all `push:` triggers.

Found while splitting #7447 into the stack at #7459–#7469, which is the first set of same-repo PRs this repo has had.