### PR TITLE
fix: track usage in formatted LLM responses

### DIFF
--- a/pkg/gateway/server/llmproxy.go
+++ b/pkg/gateway/server/llmproxy.go
@@ -119,6 +119,9 @@ type responseModifier struct {
 	c                   io.Closer
 	stream              bool
 	leftover            []byte
+	// Non-streaming JSON is accumulated while forwarded, then parsed once at EOF or Close.
+	nonStreamResponse bytes.Buffer
+	nonStreamParsed   bool
 
 	// Token usage and model access gating
 	tokenUsageTracker *threadSafeTokenUsageTracker
@@ -292,6 +295,18 @@ func (r *responseModifier) Read(p []byte) (int, error) {
 		return n, err
 	}
 
+	if !r.stream {
+		n, err := r.b.Read(p)
+		if n > 0 {
+			_, _ = r.nonStreamResponse.Write(p[:n])
+			r.audit.captureResponseChunk(p[:n])
+		}
+		if errors.Is(err, io.EOF) {
+			r.parseNonStreamTokenUsage()
+		}
+		return n, err
+	}
+
 	if len(r.leftover) > 0 {
 		n := copy(p, r.leftover)
 		r.leftover = r.leftover[n:]
@@ -340,6 +355,14 @@ func (r *responseModifier) Read(p []byte) (int, error) {
 
 	r.audit.captureResponseChunk(p[:n])
 	return n, nil
+}
+
+func (r *responseModifier) parseNonStreamTokenUsage() {
+	if r.stream || r.pipeReader != nil || r.nonStreamParsed {
+		return
+	}
+	r.tokenUsageTracker.addTokenUsage(r.nonStreamResponse.Bytes())
+	r.nonStreamParsed = true
 }
 
 // streamAndEvaluateToolCalls reads the upstream response, streams text through immediately,
@@ -671,6 +694,7 @@ func buildToolCallTargetMessage(toolCalls []messagepolicy.ToolCallInfo) string {
 }
 
 func (r *responseModifier) Close() error {
+	r.parseNonStreamTokenUsage()
 	if r.tokenUsageTracker != nil {
 		usage := r.tokenUsageTracker.getTokenUsage()
 		r.audit.setTokenUsage(usage)

--- a/pkg/gateway/server/llmproxy_test.go
+++ b/pkg/gateway/server/llmproxy_test.go
@@ -176,6 +176,62 @@ func TestResponseModifier_OpenAIResponsesAPI(t *testing.T) {
 	}
 }
 
+func TestResponseModifier_NonStreamingPrettyPrintedResponseTracksUsage(t *testing.T) {
+	tracker := newTokenUsageTracker(v1.Model{
+		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{
+			Dialect: string(nanobottypes.DialectOpenAIResponses),
+		}},
+	})
+	recorder := newLLMAuditRecorder(
+		httptest.NewRequest(http.MethodPost, "/v1/responses", nil),
+		nil,
+		5<<20,
+	)
+	body := `{
+  "id": "resp_1",
+  "object": "response",
+  "status": "completed",
+  "model": "gpt-5.4-2026-03-05",
+  "usage": {
+    "input_tokens": 7,
+    "input_tokens_details": {
+      "cache_write_tokens": 0,
+      "cached_tokens": 0
+    },
+    "output_tokens": 11,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 18
+  }
+}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    httptest.NewRequest(http.MethodPost, "/v1/responses", nil),
+	}
+	r := &responseModifier{
+		tokenUsageTracker: tracker,
+		audit:             recorder,
+	}
+
+	if err := r.modifyResponse(resp); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := recorder.responseStream.String(); got != body {
+		t.Fatalf("audit response = %q, want %q", got, body)
+	}
+	usage := tracker.getTokenUsage()
+	if usage.InputTokens != 7 || usage.OutputTokens != 11 || usage.TotalTokens != 18 {
+		t.Fatalf("token usage = %+v, want 7 input, 11 output, 18 total", usage)
+	}
+}
+
 func TestResponseModifier_NonStreamingResponse(t *testing.T) {
 	body := "{\"model\":\"gpt-4o\",\"usage\":{\"input_tokens\":5,\"output_tokens\":10,\"total_tokens\":15}}\n"
 
@@ -186,8 +242,7 @@ func TestResponseModifier_NonStreamingResponse(t *testing.T) {
 		c:                 io.NopCloser(strings.NewReader("")),
 	}
 
-	buf := make([]byte, 4096)
-	if _, err := r.Read(buf); err != nil {
+	if _, err := io.ReadAll(r); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary

This fixes an issue where a non-streaming pretty-printed response is not parsed properly to get the token usage details.

- accumulate non-streaming LLM response bytes while forwarding them
- parse token usage from the complete JSON body at EOF or response close
- add regression coverage for pretty-printed Responses API payloads