### PR TITLE
fix: compress device scan submissions on the wire

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
 )
@@ -142,6 +143,28 @@ func (c *Client) postJSON(ctx context.Context, path string, obj any, headerKV ..
 		headerKV = append(headerKV, "Content-Type", "application/json")
 	}
 	return c.doRequest(ctx, http.MethodPost, path, body, headerKV...)
+}
+
+// postCompressedJSON marshals obj and POSTs it zstd-compressed. Intended for
+// bodies big enough to be worth compressing on every call. The server must
+// decode Content-Encoding; there is no uncompressed fallback.
+func (c *Client) postCompressedJSON(ctx context.Context, path string, obj any, headerKV ...string) (*http.Request, *http.Response, error) {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Concurrency 1: no worker per CPU for a one-shot compression.
+	encoder, err := zstd.NewWriter(nil,
+		zstd.WithEncoderLevel(zstd.SpeedBetterCompression),
+		zstd.WithEncoderConcurrency(1))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer encoder.Close()
+
+	return c.doRequest(ctx, http.MethodPost, path, bytes.NewReader(encoder.EncodeAll(data, nil)),
+		slices.Concat(headerKV, []string{"Content-Type", "application/json", "Content-Encoding", "zstd"})...)
 }
 
 func (c *Client) doRequest(ctx context.Context, method, path string, body io.Reader, headerKV ...string) (*http.Request, *http.Response, error) {

--- a/apiclient/devicescan.go
+++ b/apiclient/devicescan.go
@@ -9,8 +9,11 @@ import (
 // SubmitDeviceScan posts a device scan submission manifest to the
 // server and returns the persisted scan envelope (with server-assigned
 // ID, ReceivedAt, SubmittedBy).
+//
+// Manifests are zstd-compressed, since they carry the raw text of every captured
+// config file. This requires a server that decodes Content-Encoding.
 func (c *Client) SubmitDeviceScan(ctx context.Context, manifest types.DeviceScanManifest) (*types.DeviceScan, error) {
-	_, resp, err := c.postJSON(ctx, "/devices/scans", manifest)
+	_, resp, err := c.postCompressedJSON(ctx, "/devices/scans", manifest)
 	if err != nil {
 		return nil, err
 	}

--- a/apiclient/go.mod
+++ b/apiclient/go.mod
@@ -3,6 +3,7 @@ module github.com/obot-platform/obot/apiclient
 go 1.26.5
 
 require (
+	github.com/klauspost/compress v1.18.6
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32
 	github.com/stretchr/testify v1.10.0
 )

--- a/apiclient/go.sum
+++ b/apiclient/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/keygen-sh/keygen-go/v3 v3.3.0
+	github.com/klauspost/compress v1.18.6
 	github.com/moby/moby/api v1.52.0-alpha.1
 	github.com/moby/moby/client v0.1.0-alpha.0
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037

--- a/pkg/api/request.go
+++ b/pkg/api/request.go
@@ -4,11 +4,14 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/auth"
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
@@ -63,12 +66,20 @@ func (r *Context) Read(obj any) error {
 }
 
 type BodyOptions struct {
+	// MaxBytes caps the body, applied to the compressed and decoded streams alike.
 	MaxBytes int64
 }
 
+const defaultMaxBodyBytes int64 = 8 * 1024 * 1024
+
+// maxDecoderWindowBytes caps the window a zstd frame may declare. The decoder
+// allocates it from the frame header, before any output the decoded cap could
+// bound.
+const maxDecoderWindowBytes = 64 * 1024 * 1024
+
 func (r *Context) Body(opts ...BodyOptions) (_ []byte, err error) {
 	defer func() {
-		if maxErr := (*http.MaxBytesError)(nil); errors.As(err, &maxErr) {
+		if _, isMaxBytes := errors.AsType[*http.MaxBytesError](err); isMaxBytes {
 			err = types.NewErrHTTP(http.StatusRequestEntityTooLarge, "request body too large")
 		}
 		_, _ = io.Copy(io.Discard, r.Request.Body)
@@ -80,9 +91,43 @@ func (r *Context) Body(opts ...BodyOptions) (_ []byte, err error) {
 		}
 	}
 	if opt.MaxBytes == 0 {
-		opt.MaxBytes = 8 * 1024 * 1024
+		opt.MaxBytes = defaultMaxBodyBytes
 	}
-	return io.ReadAll(http.MaxBytesReader(r.ResponseWriter, r.Request.Body, opt.MaxBytes))
+
+	body := io.Reader(http.MaxBytesReader(r.ResponseWriter, r.Request.Body, opt.MaxBytes))
+
+	// Device scans submit zstd. The decoded stream carries the same cap as the raw
+	// one, read one byte over so a body at the cap is distinguishable from one
+	// past it.
+	var compressed bool
+	if encoding := r.Request.Header.Get("Content-Encoding"); encoding != "" && !strings.EqualFold(encoding, "identity") {
+		if !strings.EqualFold(encoding, "zstd") {
+			return nil, types.NewErrHTTP(http.StatusUnsupportedMediaType, fmt.Sprintf("unsupported Content-Encoding %q", encoding))
+		}
+		zstdReader, zstdErr := zstd.NewReader(body,
+			zstd.WithDecoderConcurrency(1),
+			zstd.WithDecoderMaxMemory(maxDecoderWindowBytes))
+		if zstdErr != nil {
+			return nil, types.NewErrHTTP(http.StatusBadRequest, "unreadable zstd request body")
+		}
+		defer zstdReader.Close()
+		compressed, body = true, io.LimitReader(zstdReader, opt.MaxBytes+1)
+	}
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		// zstd validates nothing until the first read, so a malformed body lands
+		// here and would otherwise become a 500. A MaxBytesError is the cap, which
+		// the deferred mapping turns into a 413.
+		if _, isMaxBytes := errors.AsType[*http.MaxBytesError](err); compressed && !isMaxBytes {
+			return nil, types.NewErrHTTP(http.StatusBadRequest, "malformed compressed request body")
+		}
+		return nil, err
+	}
+	if int64(len(data)) > opt.MaxBytes {
+		return nil, types.NewErrHTTP(http.StatusRequestEntityTooLarge, "request body too large")
+	}
+	return data, nil
 }
 
 func (r *Context) WriteCreated(obj any) error {


### PR DESCRIPTION
Scan manifests carry the raw text of every captured config file and were
posted uncompressed, so large ones were rejected outright. SubmitDeviceScan
now zstd-compresses them -- a real 201-file scan drops from 2,005,646 to
553,094 bytes, 72% smaller. Other endpoints are unchanged.

api.Context.Body decodes Content-Encoding: zstd, capping the compressed and
decoded streams alike. A server without this parses the compressed bytes as
JSON and fails, so obot-sentry requires a server new enough to decode them.

Part of https://github.com/obot-platform/obot/issues/7434

