### PR TITLE
fix: stop serving the page shell in place of a missing UI asset

### DIFF
--- a/ui/handler.go
+++ b/ui/handler.go
@@ -15,6 +15,23 @@ import (
 //go:embed all:user/*build
 var embedded embed.FS
 
+// assets is the built UI. It is a variable, and an fs.FS rather than the
+// embed.FS directly, so that a test can supply a build: the real one is only
+// present after the UI has been compiled, which would otherwise make these
+// tests pass or fail depending on whether someone had run make.
+var assets fs.FS = embedded
+
+// buildAssetPrefix is where the UI build puts its output. Everything under it
+// is an asset, and nothing under it is a route.
+//
+// immutableAssetPrefix is the part of that named by content hash. The rest --
+// version.json, say -- keeps its name across builds and so must not be cached
+// as though it were fixed.
+const (
+	buildAssetPrefix     = "/_app/"
+	immutableAssetPrefix = "/_app/immutable/"
+)
+
 func Handler(devPort, userOnlyPort int) http.Handler {
 	server := &uiServer{}
 
@@ -61,28 +78,64 @@ func (s *uiServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Said here rather than left to whatever CDN sits in front. Obot set no
+	// policy for the UI at all, so the edge applied its own default -- four
+	// hours -- to everything, including a page shell served in place of a
+	// missing asset. Stating it keeps that decision where the meaning of each
+	// response is known.
+	if strings.HasPrefix(r.URL.Path, immutableAssetPrefix) {
+		// A change to one of these is a change to its name, so there is nothing
+		// a client can hold that will ever be wrong.
+		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	} else {
+		// Everything else keeps its name across builds -- the shell above all,
+		// which names the assets for the build it came from. Cached, it goes on
+		// asking for files that a later build no longer has.
+		w.Header().Set("Cache-Control", "no-cache")
+	}
+
 	userPath := path.Join("user/build/", r.URL.Path)
 
 	if r.URL.Path == "/" {
-		http.ServeFileFS(w, r, embedded, "user/build/index.html")
+		http.ServeFileFS(w, r, assets, "user/build/index.html")
 	} else if r.URL.Path == "/admin" {
-		http.ServeFileFS(w, r, embedded, "user/build/admin.html")
+		http.ServeFileFS(w, r, assets, "user/build/admin.html")
 	} else if r.URL.Path == "/admin/" {
 		// we have to redirect to /admin instead of serving the index.html file because ending slash will laod a different route for js files
 		http.Redirect(w, r, "/admin", http.StatusFound)
 	} else if r.URL.Path == "/mcp-servers/" {
 		http.Redirect(w, r, "/mcp-servers", http.StatusFound)
 	} else if r.URL.Path == "/mcp-servers" {
-		http.ServeFileFS(w, r, embedded, "user/build/mcp-servers.html")
+		http.ServeFileFS(w, r, assets, "user/build/mcp-servers.html")
 	} else if strings.HasSuffix(r.URL.Path, "/") {
 		// Paths with trailing slashes should redirect to without slash to avoid directory listings
 		http.Redirect(w, r, strings.TrimSuffix(r.URL.Path, "/"), http.StatusFound)
-	} else if _, err := fs.Stat(embedded, userPath+".html"); err == nil {
+	} else if _, err := fs.Stat(assets, userPath+".html"); err == nil {
 		// Try .html version first (for SvelteKit prerendered pages)
-		http.ServeFileFS(w, r, embedded, userPath+".html")
-	} else if _, err := fs.Stat(embedded, userPath); err == nil {
-		http.ServeFileFS(w, r, embedded, userPath)
+		http.ServeFileFS(w, r, assets, userPath+".html")
+	} else if _, err := fs.Stat(assets, userPath); err == nil {
+		http.ServeFileFS(w, r, assets, userPath)
+	} else if strings.HasPrefix(r.URL.Path, buildAssetPrefix) {
+		// A build asset is named by a hash of its own contents, so it is never a
+		// route to fall back to: if it is not here, the only true answer is that
+		// it does not exist.
+		//
+		// Falling back served the page shell instead, as 200 text/html with the
+		// asset's own cache lifetime. Browsers refuse that under strict MIME
+		// checking, and -- because it is a 200 -- every cache in the path stores
+		// it: the CDN edge, and then each visitor's browser. A rolling deploy is
+		// enough to produce it, since for a few seconds one replica serves an
+		// index.html naming hashes another replica does not have yet. That
+		// window is short; the caching of it is not, and clearing it means
+		// purging the CDN and every affected browser.
+		//
+		// A 404 leaves nothing to cache and lets the next request succeed --
+		// but only if it is not itself cached. An edge will store a 404 by
+		// default, briefly, which is long enough to outlive the deploy that
+		// caused it, so this says not to.
+		w.Header().Set("Cache-Control", "no-store")
+		http.NotFound(w, r)
 	} else {
-		http.ServeFileFS(w, r, embedded, "user/build/fallback.html")
+		http.ServeFileFS(w, r, assets, "user/build/fallback.html")
 	}
 }

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -1,0 +1,127 @@
+package ui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+const browserUA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0 Safari/537.36"
+
+// hashedAsset is named the way the build names a file whose contents decide its
+// name. Nothing else in the tree is safe to cache for a year.
+const hashedAsset = "/_app/immutable/entry/app.D4Z7Uh6d.js"
+
+// withBuild swaps in a stand-in for the compiled UI. The real one exists only
+// after the UI has been built, so without this these tests would report on
+// whether someone had run make rather than on the handler.
+func withBuild(t *testing.T) {
+	t.Helper()
+	previous := assets
+	t.Cleanup(func() { assets = previous })
+
+	assets = fstest.MapFS{
+		"user/build/index.html":                           {Data: []byte("<html>shell</html>")},
+		"user/build/fallback.html":                        {Data: []byte("<html>fallback</html>")},
+		"user/build/_app/version.json":                    {Data: []byte(`{"version":"1"}`)},
+		"user/build/_app/immutable/entry/app.D4Z7Uh6d.js": {Data: []byte("export default 1")},
+	}
+}
+
+func get(t *testing.T, path string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("User-Agent", browserUA)
+	rec := httptest.NewRecorder()
+	Handler(0, 0).ServeHTTP(rec, req)
+	return rec.Result()
+}
+
+// A build asset is named by a hash of its own contents, so a request for one
+// that is not here is asking for something that does not exist. Answering with
+// the page shell instead returns 200 text/html, which every cache in the path
+// then stores -- the CDN edge, and each visitor's browser. A rolling deploy is
+// enough to produce the miss, because for a few seconds one replica serves a
+// shell naming hashes another replica does not have yet. That window is short;
+// what it leaves behind is not, and clearing it means purging the CDN and every
+// browser that saw it.
+func TestMissingBuildAssetIsNotFound(t *testing.T) {
+	withBuild(t)
+
+	for _, path := range []string{
+		"/_app/immutable/entry/app.NOTREAL.js",
+		"/_app/immutable/chunks/NOTREAL.js",
+		"/_app/immutable/assets/0.NOTREAL.css",
+	} {
+		t.Run(path, func(t *testing.T) {
+			resp := get(t, path)
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusNotFound {
+				t.Errorf("status = %d, want 404 -- a 200 here is cacheable and outlives the deploy that caused it", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// A real asset is still served, so the 404 above is about absence rather than
+// about the prefix.
+func TestPresentBuildAssetIsServed(t *testing.T) {
+	withBuild(t)
+
+	resp := get(t, hashedAsset)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// Everything outside the build directory is a client-side route, resolved by
+// the shell once it loads. Those must keep falling back, or every deep link
+// breaks.
+func TestUnknownRouteStillFallsBack(t *testing.T) {
+	withBuild(t)
+
+	resp := get(t, "/admin/dashboard")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 so the shell can route it", resp.StatusCode)
+	}
+}
+
+// Obot stated no cache policy for the UI, so whatever CDN sat in front applied
+// its own -- four hours, in the case that went on serving a page shell in place
+// of an asset long after the deploy that caused it. Saying it here keeps the
+// decision where the meaning of each response is known.
+func TestCachePolicy(t *testing.T) {
+	withBuild(t)
+
+	for _, tt := range []struct {
+		name, path, want string
+	}{
+		// A change to one of these is a change to its name, so nothing a client
+		// holds can ever be wrong.
+		{"hashed asset", hashedAsset, "public, max-age=31536000, immutable"},
+		// Names the assets of the build it came from, so a cached copy goes on
+		// asking for files a later build no longer has.
+		{"page shell", "/", "no-cache"},
+		// Reached through the same fallback, and carries the same references.
+		{"client-side route", "/admin/dashboard", "no-cache"},
+		// Under the build directory, but keeps its name across builds.
+		{"version.json", "/_app/version.json", "no-cache"},
+		// Storing this is what turns seconds of rollout skew into hours of it.
+		{"missing asset", "/_app/immutable/chunks/NOTREAL.js", "no-store"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := get(t, tt.path)
+			defer resp.Body.Close()
+
+			if got := resp.Header.Get("Cache-Control"); got != tt.want {
+				t.Errorf("Cache-Control = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Found deploying to a real environment: the site came back from a deploy with a
blank page and a wall of

> Failed to load module script: Expected a JavaScript-or-Wasm module script but
> the server responded with a MIME type of "text/html".

## What was happening

A request for a build asset that is not present fell through to
`fallback.html` — `200`, `text/html`, and no cache policy of its own. Browsers
refuse that under strict MIME checking, and because it is a `200`, **every
cache in the path stores it**: the CDN edge, and then each visitor's browser.

A rolling deploy is enough to produce the miss. For a few seconds one replica
serves a shell naming hashes another replica does not have yet. The window is
seconds; what it leaves behind is not — recovering took a full CDN purge *and*
a browser cache clear, while the origin had been healthy throughout. The MIME
error says nothing about any of that.

Content-hashed names made it slower to read: chunks whose contents had not
changed kept the same name and loaded fine, so only *some* assets failed, which
looks like corruption rather than absence.

## What changed

**Missing assets under `/_app/` return `404`.** A name derived from a file's
contents is never a route, so falling back could only ever be wrong there.
Everything else still falls back — resolving a client-side route is what the
shell is for.

**Obot states its own cache policy.** It set none for the UI (`server.go`
covers `/api/` only), so whichever CDN sat in front applied its default —
4 hours, in the case this fixes:

| | |
|---|---|
| `/_app/immutable/…` | `public, max-age=31536000, immutable` |
| shell, fallback, `/_app/version.json` | `no-cache` |
| missing asset (404) | `no-store` |

`no-cache` on the shell is the point: it names the assets of the build it came
from, so a cached copy goes on requesting files a later build no longer has —
the same failure, self-inflicted. `no-store` on the 404 because an edge caches
404s briefly by default, which is long enough to outlive the deploy.

## Tests

`ui` had none; it now has 5 tests / 9 subtests. Verified non-vacuous — reverting
the fix fails 9 of them.

The embedded build is reached through a variable so a test can supply one. The
real build exists only after `make ui`, so the first version of these tests
passed on my machine and **failed in a clean checkout** — they were reporting on
whether someone had run make. They now run against an `fstest.MapFS` and pass
with no build present, which is the CI condition.

## Verified live

| Path | Before | After |
|---|---|---|
| `/_app/immutable/entry/app.NOTREAL.js` | `200 text/html` | `404`, `no-store` |
| a real hashed asset | `200`, no cache policy | `200`, `immutable` |
| `/some/deep/client/route` | `200 text/html` | unchanged, `no-cache` |

Draft for review of the cache values themselves — particularly `no-cache`
rather than `no-store` on the shell. They behave identically today because the
embedded FS has no modtime and so emits no validators; `no-cache` leaves room
for `ETag`s later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)