### PR TITLE
fix: seed hosted agents on installations that upgrade into the feature

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -61,7 +61,7 @@ func New(services *services.Services) (*Controller, error) {
 }
 
 func (c *Controller) PreStart(ctx context.Context) error {
-	if err := data.Data(ctx, c.services.StorageClient, data.Defaults{
+	if err := data.Data(ctx, c.services.StorageClient, c.services.GatewayClient, data.Defaults{
 		SkillRepoURL:           c.services.DefaultSkillRepoURL,
 		SkillRepoRef:           c.services.DefaultSkillRepoRef,
 		HostedAgentsCatalogURL: c.services.DefaultHostedAgentsCatalogURL,

--- a/pkg/controller/data/data.go
+++ b/pkg/controller/data/data.go
@@ -42,7 +42,18 @@ type Defaults struct {
 	AllowLocalRepos        bool
 }
 
-func Data(ctx context.Context, c kclient.Client, defaults Defaults) error {
+// seedHostedAgents names the one-time record for the hosted agent seed. It is
+// this seed's own name, so a later seed takes a new one rather than changing
+// what this record means.
+const seedHostedAgents = "seed_hosted_agents"
+
+// OnceRunner runs a named piece of work a single time per installation. It is
+// an interface so that seeding can be tested without a database.
+type OnceRunner interface {
+	RunOnce(ctx context.Context, name string, f func(context.Context) error) error
+}
+
+func Data(ctx context.Context, c kclient.Client, runner OnceRunner, defaults Defaults) error {
 	var defaultModelAliases v1.DefaultModelAliasList
 	if err := yaml.Unmarshal(defaultModelAliasesData, &defaultModelAliases); err != nil {
 		return fmt.Errorf("failed to unmarshal default model aliases: %w", err)
@@ -120,21 +131,32 @@ func Data(ctx context.Context, c kclient.Client, defaults Defaults) error {
 			return err
 		}
 
-		var everythingHostedAgentAccessRule v1.HostedAgentAccessRule
-		if err := yaml.Unmarshal(everythingHostedAgentAccessRuleData, &everythingHostedAgentAccessRule); err != nil {
-			return fmt.Errorf("failed to unmarshal everything hosted agent access rule: %w", err)
-		}
-
-		if err := kclient.IgnoreAlreadyExists(c.Create(ctx, &everythingHostedAgentAccessRule)); err != nil {
-			return err
-		}
-
 		if err := createDefaultSkillRepository(ctx, c, defaults.SkillRepoURL, defaults.SkillRepoRef); err != nil {
 			return err
 		}
+	}
 
-		if err := createDefaultAgentCatalog(ctx, c, defaults.HostedAgentsCatalogURL, defaults.HostedAgentsCatalogRef, defaults.AllowLocalRepos); err != nil {
-			return err
+	// Hosted agents are seeded on their own record rather than alongside the
+	// rules above. Those are gated on there being no MCP catalogs, which stands
+	// in for "this server has never started" -- true of a new installation, and
+	// false of every installation that upgrades into this feature. Seeded that
+	// way, hosted agents would arrive only on installations created after the
+	// release: an upgrade would show the feature with no harnesses, no
+	// templates, and nobody permitted to use them.
+	if runner != nil {
+		if err := runner.RunOnce(ctx, seedHostedAgents, func(ctx context.Context) error {
+			var everythingHostedAgentAccessRule v1.HostedAgentAccessRule
+			if err := yaml.Unmarshal(everythingHostedAgentAccessRuleData, &everythingHostedAgentAccessRule); err != nil {
+				return fmt.Errorf("failed to unmarshal everything hosted agent access rule: %w", err)
+			}
+
+			if err := kclient.IgnoreAlreadyExists(c.Create(ctx, &everythingHostedAgentAccessRule)); err != nil {
+				return err
+			}
+
+			return createDefaultAgentCatalog(ctx, c, defaults.HostedAgentsCatalogURL, defaults.HostedAgentsCatalogRef, defaults.AllowLocalRepos)
+		}); err != nil {
+			return fmt.Errorf("failed to seed hosted agents: %w", err)
 		}
 	}
 

--- a/pkg/controller/data/data_test.go
+++ b/pkg/controller/data/data_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"context"
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
@@ -22,11 +23,35 @@ func newFakeClient(t *testing.T, objects ...kclient.Object) kclient.Client {
 		Build()
 }
 
+// fakeOnce records which seeds have run, standing in for the row the gateway
+// keeps. Seeds are identified by name, so a test can start from "never seeded"
+// or from "already seeded" without a database.
+type fakeOnce struct{ done map[string]bool }
+
+func newFakeOnce(seeded ...string) *fakeOnce {
+	f := &fakeOnce{done: map[string]bool{}}
+	for _, name := range seeded {
+		f.done[name] = true
+	}
+	return f
+}
+
+func (f *fakeOnce) RunOnce(ctx context.Context, name string, fn func(context.Context) error) error {
+	if f.done[name] {
+		return nil
+	}
+	if err := fn(ctx); err != nil {
+		return err
+	}
+	f.done[name] = true
+	return nil
+}
+
 func TestDataCreatesDefaultModelAccessPolicyWithLLMAliases(t *testing.T) {
 	ctx := t.Context()
 	client := newFakeClient(t)
 
-	require.NoError(t, Data(ctx, client, Defaults{}))
+	require.NoError(t, Data(ctx, client, newFakeOnce(), Defaults{}))
 
 	var policy v1.ModelAccessPolicy
 	require.NoError(t, client.Get(ctx, kclient.ObjectKey{
@@ -224,32 +249,51 @@ func TestCreateDefaultAgentCatalog(t *testing.T) {
 	})
 }
 
-func TestDataSeedsDefaultAgentCatalogOnFirstBoot(t *testing.T) {
+func TestDataSeedsHostedAgents(t *testing.T) {
 	ctx := t.Context()
 	const repoURL = "https://github.com/obot-platform/hosted-agents-catalog"
 
-	t.Run("seeds on first boot", func(t *testing.T) {
-		c := newFakeClient(t)
-		require.NoError(t, Data(ctx, c, Defaults{HostedAgentsCatalogURL: repoURL}))
-
-		var source v1.AgentCatalog
+	seeded := func(t *testing.T, c kclient.Client) {
+		t.Helper()
+		var catalog v1.AgentCatalog
 		require.NoError(t, c.Get(ctx, kclient.ObjectKey{
 			Namespace: system.DefaultNamespace,
 			Name:      system.DefaultAgentCatalog,
-		}, &source))
-		assert.Equal(t, repoURL, source.Spec.RepoURL)
+		}, &catalog))
+		assert.Equal(t, repoURL, catalog.Spec.RepoURL)
+
+		var rules v1.HostedAgentAccessRuleList
+		require.NoError(t, c.List(ctx, &rules))
+		assert.NotEmpty(t, rules.Items, "seeding a catalog nobody may use leaves the feature unusable")
+	}
+
+	t.Run("seeds on a new installation", func(t *testing.T) {
+		c := newFakeClient(t)
+		require.NoError(t, Data(ctx, c, newFakeOnce(), Defaults{HostedAgentsCatalogURL: repoURL}))
+		seeded(t, c)
 	})
 
-	// An existing MCPCatalog stands in for "this server has booted before", so a
-	// catalog an admin deleted is not resurrected.
-	t.Run("does not seed when catalogs already exist", func(t *testing.T) {
+	// The case this seed used to miss entirely. An installation that upgrades
+	// into hosted agents already has MCP catalogs, which the surrounding seeds
+	// read as "this server has run before" -- true, and beside the point: it has
+	// never seen this feature. Gated that way it arrived with no harnesses, no
+	// templates and nobody permitted to use them.
+	t.Run("seeds on an installation that upgraded into the feature", func(t *testing.T) {
 		c := newFakeClient(t, &v1.MCPCatalog{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      system.DefaultCatalog,
 				Namespace: system.DefaultNamespace,
 			},
 		})
-		require.NoError(t, Data(ctx, c, Defaults{HostedAgentsCatalogURL: repoURL}))
+		require.NoError(t, Data(ctx, c, newFakeOnce(), Defaults{HostedAgentsCatalogURL: repoURL}))
+		seeded(t, c)
+	})
+
+	// The record outlives what it created, so an administrator who deletes the
+	// catalog does not find it back on the next start.
+	t.Run("does not seed again once it has", func(t *testing.T) {
+		c := newFakeClient(t)
+		require.NoError(t, Data(ctx, c, newFakeOnce(seedHostedAgents), Defaults{HostedAgentsCatalogURL: repoURL}))
 
 		var list v1.AgentCatalogList
 		require.NoError(t, c.List(ctx, &list))

--- a/pkg/gateway/client/runonce.go
+++ b/pkg/gateway/client/runonce.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	"gorm.io/gorm"
+)
+
+// RunOnce runs f the first time it is called for name on this installation, and
+// never again.
+//
+// Seeding cannot ask "is this a new installation" and get a useful answer. The
+// existing seeds infer it from another resource being absent, which conflates
+// two different things: an installation that has never run, and one that has
+// run for a year and is meeting this seed for the first time because it just
+// upgraded. An upgrade looks like neither a new installation nor a seeded one,
+// so seeds gated that way silently never run there.
+//
+// The name is that seed's own record, so adding one later is a new name rather
+// than a change to what an existing gate means. It is also what separates
+// "never seeded" from "seeded, and the administrator deleted it" -- the record
+// outlives the resource, so a deletion stays deleted.
+//
+// f and the record are written in one transaction: a seed that fails leaves no
+// record and is retried on the next start, and a record that fails to write
+// rolls the seed back with it.
+func (c *Client) RunOnce(ctx context.Context, name string, f func(context.Context) error) error {
+	db := c.db.WithContext(ctx)
+
+	var record gatewaytypes.Migration
+	if err := db.Where("name = ?", name).First(&record).Error; err == nil {
+		return nil
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := f(ctx); err != nil {
+			return err
+		}
+		return tx.Create(&gatewaytypes.Migration{Name: name}).Error
+	})
+}


### PR DESCRIPTION
## The bug

The hosted agent catalog, and the access rule permitting anyone to use it, were
seeded alongside rules gated on there being no `MCPCatalog`s — commented as a
proxy for *"has this server been started previously."*

```go
var catalogs v1.MCPCatalogList
// There being no catalogs is a proxy for "has this server been started previously."
if err := c.List(ctx, &catalogs); err != nil {
    return err
} else if len(catalogs.Items) == 0 {
    ... everythingHostedAgentAccessRule ...
    ... createDefaultAgentCatalog(...) ...
}
```

That is true of a new installation and false of every installation that
upgrades, which has had catalogs since its own first boot. So the seeds ran
only where the feature had shipped from the beginning.

**An upgraded installation gets the feature with no harnesses, no templates,
and nobody permitted to use them** — and no error, because from the seeding
code's point of view nothing went wrong.

## Why the proxy cannot be fixed in place

"Has this server run before" and "has this seed run before" are different
questions, and they diverge exactly at an upgrade — which is the case that
matters here. Any resource chosen as a stand-in for the first has the same
problem for the second, because it predates the seed being added.

Seeding now records its own name. A later seed takes a new name rather than
changing what an existing gate means for the seeds already relying on it.

The record also outlives what it created, which is the property the proxy was
protecting: an administrator who deletes the catalog does not find it back on
the next start. Seed and record are written in one transaction, so a seed that
fails leaves no record and is retried on the next start.

`RunOnce` is the existing migration table — which already did exactly this for
schema changes — exposed for seeds. Nothing new to operate.

Only the hosted agent seeds move; the surrounding rules keep their existing
gate, since changing when *those* run is a separate decision with its own
consequences for existing installations.

## Tests

`TestDataSeedsDefaultAgentCatalogOnFirstBoot` is replaced. Its second subtest
asserted *"does not seed when catalogs already exist"* — encoding this bug as
intended behaviour, which is why it did not catch it. The replacement covers:

- seeds on a new installation
- **seeds on an installation that upgraded into the feature** ← the regression
- does not seed again once it has

Verified non-vacuous: gated the old way, the new-install and upgrade subtests
both fail.

`go build ./...`, `go vet ./...`, `golangci-lint` (0 issues) and the full suite
pass.

## Draft because

The choice of where run-once seed records live is worth a second opinion. The
migration table fit cleanly and needs no new operational surface, but it was
built for schema migrations, and someone who owns the upgrade path may prefer
these were kept separate.

Also worth deciding: whether the sibling seeds above — the default skill
repository, the everything access-control rule — have the same gap. They are
older than the MCP catalog gate, so an upgrade would have received them at the
time; but any seed added to that block in future inherits this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)