### PR TITLE
fix: keep hosted agent sandboxes out of other users' pools

### DIFF
--- a/pkg/api/handlers/hostedagentinstances.go
+++ b/pkg/api/handlers/hostedagentinstances.go
@@ -142,8 +142,12 @@ func (h *HostedAgentInstanceHandler) Create(req api.Context) error {
 			agent.Spec.Manifest.Name, strings.Join(reasons, "; "))
 	}
 
+	// Assignment rather than access: an admin may manage every pool, but the
+	// sandbox they are creating here is their own and draws from the budget of a
+	// pool they were assigned to. Leaving an empty pool ID is the normal case;
+	// the controller then resolves the caller's default pool or creates it.
 	if body.PoolID != "" {
-		if err := requirePoolAccess(req, body.PoolID); err != nil {
+		if err := requirePoolAssignment(req, body.PoolID); err != nil {
 			return err
 		}
 	}

--- a/pkg/api/handlers/hostedagentpools.go
+++ b/pkg/api/handlers/hostedagentpools.go
@@ -29,8 +29,14 @@ func (*HostedAgentPoolHandler) List(req api.Context) error {
 		return fmt.Errorf("failed to list hosted agent pools: %w", err)
 	}
 
+	// An admin manages every pool, so the unfiltered list is what the admin
+	// screens need. A client asking where the caller may launch is asking a
+	// different question — ?assigned=true answers that one, for admins too,
+	// because administration is not membership.
+	onlyAssigned := req.URL.Query().Get("assigned") == "true"
+
 	allowed := map[string]bool(nil)
-	if !req.UserIsAdmin() {
+	if onlyAssigned || !req.UserIsAdmin() {
 		var err error
 		allowed, err = userPoolIDs(req)
 		if err != nil {
@@ -40,7 +46,7 @@ func (*HostedAgentPoolHandler) List(req api.Context) error {
 
 	items := make([]types.HostedAgentPool, 0, len(list.Items))
 	for _, item := range list.Items {
-		if !req.UserIsAdmin() && !allowed[item.Name] {
+		if allowed != nil && !allowed[item.Name] {
 			continue
 		}
 		items = append(items, convertHostedAgentPool(item))
@@ -412,6 +418,31 @@ func requirePoolAccess(req api.Context, poolID string) error {
 	}
 	if !allowed[poolID] {
 		return types.NewErrNotFound("hosted agent pool %s not found", poolID)
+	}
+	return nil
+}
+
+// requirePoolAssignment reports whether the caller may place their own sandbox
+// in a pool, which is a narrower question than whether they may look at it.
+//
+// Administration is not membership: an admin manages every pool, but their own
+// sandbox still draws from the budget of a pool somebody assigned them to.
+// Without this distinction an admin launching an agent lands in whichever pool
+// their client happened to name — in practice another user's personal pool,
+// silently spending capacity that was never theirs.
+func requirePoolAssignment(req api.Context, poolID string) error {
+	if err := requirePoolAccess(req, poolID); err != nil {
+		return err
+	}
+	allowed, err := userPoolIDs(req)
+	if err != nil {
+		return err
+	}
+	if !allowed[poolID] {
+		// Only an admin reaches this: requirePoolAccess already answered
+		// not-found for everybody else, and an admin can see the pool anyway,
+		// so naming it plainly leaks nothing.
+		return types.NewErrBadRequest("you are not assigned to hosted agent pool %s", poolID)
 	}
 	return nil
 }

--- a/pkg/controller/handlers/hostedagent/hostedagent.go
+++ b/pkg/controller/handlers/hostedagent/hostedagent.go
@@ -243,12 +243,22 @@ func (h *Handler) OrchestrateInstance(req router.Request, resp router.Response) 
 	}
 
 	ref := instanceRef(instance)
-	// EnsurePool is registered immediately before this handler. nah can
-	// aggregate errors from handlers in one reconciliation pass, so do not try
-	// to construct backend desired state when pool resolution failed.
-	// The pool handler's actionable error is sufficient and a later
-	// reconcile will continue once defaults or an assignment are configured.
+	// EnsurePool is registered immediately before this handler, but nah runs
+	// every handler for a type and aggregates their errors, so EnsurePool
+	// failing does not stop this one. Repeat its conclusion rather than trust
+	// it: a pool ID that survived EnsurePool's rejection would otherwise be
+	// deployed into anyway, putting this sandbox in a pool whose capacity
+	// belongs to somebody else. The pool handler's error is the actionable one,
+	// so bail out quietly and let a later reconcile continue once defaults or
+	// an assignment are configured.
 	if instance.Spec.PoolID == "" {
+		return nil
+	}
+	assignments, err := assignmentsForUser(req, instance.Spec.UserID)
+	if err != nil {
+		return err
+	}
+	if !isAssigned(assignments, instance.Spec.PoolID) {
 		return nil
 	}
 

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -1891,8 +1891,19 @@ export async function deleteHostedAgent(
 
 // Hosted agent pools
 
-export async function listHostedAgentPools(opts?: { fetch?: Fetcher }): Promise<HostedAgentPool[]> {
-	const response = (await doGet('/hosted-agent-pools', opts)) as ItemsResponse<HostedAgentPool>;
+// listHostedAgentPools returns every pool, which is what the admin screens
+// manage. Pass assigned: true to ask the narrower question of where the caller
+// may launch an agent — an admin manages pools they are not a member of, and
+// launching into one of those spends somebody else's capacity.
+export async function listHostedAgentPools(opts?: {
+	fetch?: Fetcher;
+	assigned?: boolean;
+}): Promise<HostedAgentPool[]> {
+	const queryString = opts?.assigned ? buildQueryString({ assigned: 'true' }) : '';
+	const response = (await doGet(
+		`/hosted-agent-pools${queryString ? `?${queryString}` : ''}`,
+		opts
+	)) as ItemsResponse<HostedAgentPool>;
 	return response.items ?? [];
 }
 

--- a/ui/user/src/routes/hosted-agents/+page.svelte
+++ b/ui/user/src/routes/hosted-agents/+page.svelte
@@ -211,7 +211,7 @@
 	async function refresh() {
 		try {
 			instances = await AdminService.listHostedAgentInstances();
-			pools = await AdminService.listHostedAgentPools();
+			pools = await AdminService.listHostedAgentPools({ assigned: true });
 			await Promise.all(
 				pools.map(async (pool) => {
 					try {

--- a/ui/user/src/routes/hosted-agents/+page.ts
+++ b/ui/user/src/routes/hosted-agents/+page.ts
@@ -20,7 +20,9 @@ export const load: PageLoad = async ({ fetch, parent }) => {
 		[hostedAgents, instances, pools, assignments] = await Promise.all([
 			AdminService.listHostedAgents({ fetch }),
 			AdminService.listHostedAgentInstances(undefined, { fetch }),
-			AdminService.listHostedAgentPools({ fetch }),
+			// Assigned only: this page launches agents, and a pool the user is not
+			// a member of is not theirs to spend, however much of it they can see.
+			AdminService.listHostedAgentPools({ fetch, assigned: true }),
 			AdminService.listHostedAgentPoolAssignments({ fetch })
 		]);
 	} catch (err) {


### PR DESCRIPTION
## The bug

On a deployment where most users are admins, hosted agent sandboxes from several different users all ended up in a single pool — one user's auto-created personal pool — silently spending capacity assigned to somebody else.

Observed on a live deployment: exactly one pool existed (`hp-<sha256(userID)[:16]>` for user A) with exactly one assignment (user A, default), yet its utilization listed six sandboxes, only four of which belonged to user A. No other user had ever gotten their own pool.

## Root cause

Three defects lined up:

1. **The launch page listed everyone's pools.** `ui/user/src/routes/hosted-agents/+page.*` populates its pool cards from `GET /api/hosted-agent-pools`, which returns *every* pool to an admin. Each admin therefore saw another user's personal pool as the only pool card and launched into it.
2. **`requirePoolAccess` waved admins through on create.** Instance creation accepted any `poolID` from an admin without checking assignments.
3. **The controller caught it and deployed anyway.** `EnsurePool` rejects an unassigned pool, but nah runs every handler registered for a type and aggregates their errors, so `OrchestrateInstance` — which only guarded `PoolID == ""` — still built the sandbox into the foreign pool while the rejection retried forever.

## The fix

- `GET /api/hosted-agent-pools` accepts `?assigned=true`, which restricts the list to the caller's assignments for admins too. The user-facing launch page asks for it; the admin management screens are unchanged.
- Instance creation uses a new `requirePoolAssignment` instead of `requirePoolAccess`. Read/manage paths keep the admin bypass and the not-found response that avoids leaking pool existence.
- `OrchestrateInstance` repeats the membership check rather than trusting a non-empty pool ID.

Non-admins were never affected: they got an empty pool list, sent no `poolID`, and the controller created their own pool as intended.

## Testing

`go build ./...`, `go test ./pkg/api/handlers/ ./pkg/controller/handlers/hostedagent/`, and `pnpm run lint` in `ui/user` all pass. Draft because it has no new regression test yet — I was mid-way through adding one for the `OrchestrateInstance` guard.

## Follow-up not covered here

The sandboxes already misplaced into another user's pool need reassigning or deleting; this PR only stops new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTABNod9tSz4CmwpiuJutQ