### PR TITLE
enhance: add setting max caps for request/limits cpu/memory in server-scheduling in ui

### DIFF
--- a/apiclient/types/k8ssettings.go
+++ b/apiclient/types/k8ssettings.go
@@ -11,6 +11,18 @@ type K8sSettings struct {
 	// Resources configuration (JSON/YAML blob)
 	Resources string `json:"resources,omitempty"`
 
+	// MaxCPURequest is the startup-configured maximum CPU request for MCP server pods.
+	MaxCPURequest string `json:"maxCpuRequest,omitempty"`
+
+	// MaxCPULimit is the startup-configured maximum CPU limit for MCP server pods.
+	MaxCPULimit string `json:"maxCpuLimit,omitempty"`
+
+	// MaxMemoryRequest is the startup-configured maximum memory request for MCP server pods.
+	MaxMemoryRequest string `json:"maxMemoryRequest,omitempty"`
+
+	// MaxMemoryLimit is the startup-configured maximum memory limit for MCP server pods.
+	MaxMemoryLimit string `json:"maxMemoryLimit,omitempty"`
+
 	// RuntimeClassName specifies the RuntimeClass for MCP server pods
 	// This allows running MCP servers with specific container runtimes (e.g., gVisor, Kata)
 	RuntimeClassName string `json:"runtimeClassName,omitempty"`
@@ -29,6 +41,9 @@ type K8sSettings struct {
 
 	// SetViaHelm indicates settings are from Helm (cannot be updated via API)
 	SetViaHelm bool `json:"setViaHelm,omitempty"`
+
+	// MaximumsSetViaHelm indicates resource maximums are from Helm (cannot be updated via API)
+	MaximumsSetViaHelm bool `json:"maximumsSetViaHelm,omitempty"`
 
 	Metadata Metadata `json:"metadata,omitempty"`
 }

--- a/apiclient/types/k8ssettings.go
+++ b/apiclient/types/k8ssettings.go
@@ -11,16 +11,16 @@ type K8sSettings struct {
 	// Resources configuration (JSON/YAML blob)
 	Resources string `json:"resources,omitempty"`
 
-	// MaxCPURequest is the startup-configured maximum CPU request for MCP server pods.
+	// MaxCPURequest is the configured maximum CPU request for MCP server pods.
 	MaxCPURequest string `json:"maxCpuRequest,omitempty"`
 
-	// MaxCPULimit is the startup-configured maximum CPU limit for MCP server pods.
+	// MaxCPULimit is the configured maximum CPU limit for MCP server pods.
 	MaxCPULimit string `json:"maxCpuLimit,omitempty"`
 
-	// MaxMemoryRequest is the startup-configured maximum memory request for MCP server pods.
+	// MaxMemoryRequest is the configured maximum memory request for MCP server pods.
 	MaxMemoryRequest string `json:"maxMemoryRequest,omitempty"`
 
-	// MaxMemoryLimit is the startup-configured maximum memory limit for MCP server pods.
+	// MaxMemoryLimit is the configured maximum memory limit for MCP server pods.
 	MaxMemoryLimit string `json:"maxMemoryLimit,omitempty"`
 
 	// RuntimeClassName specifies the RuntimeClass for MCP server pods

--- a/pkg/api/handlers/k8ssettings.go
+++ b/pkg/api/handlers/k8ssettings.go
@@ -153,6 +153,23 @@ func (h *K8sSettingsHandler) Update(req api.Context) error {
 		errs                  []error
 	)
 
+	maxCPURequest, err := parseResourceMaximumField("maxCpuRequest", input.MaxCPURequest)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	maxCPULimit, err := parseResourceMaximumField("maxCpuLimit", input.MaxCPULimit)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	maxMemoryRequest, err := parseResourceMaximumField("maxMemoryRequest", input.MaxMemoryRequest)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	maxMemoryLimit, err := parseResourceMaximumField("maxMemoryLimit", input.MaxMemoryLimit)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
 	if input.Affinity != "" {
 		if err := yaml.UnmarshalStrict([]byte(input.Affinity), &affinity); err != nil {
 			errs = append(errs, fmt.Errorf("invalid affinity YAML: %v", err))
@@ -200,8 +217,8 @@ func (h *K8sSettingsHandler) Update(req api.Context) error {
 			return err
 		}
 
-		// Don't allow updates if set via Helm
-		if settings.Spec.SetViaHelm {
+		// Don't allow updates when every editable group is managed via Helm.
+		if settings.Spec.SetViaHelm && settings.Spec.MaximumsSetViaHelm {
 			return types.NewErrBadRequest("K8s settings are managed via Helm and cannot be updated through the API")
 		}
 
@@ -215,47 +232,56 @@ func (h *K8sSettingsHandler) Update(req api.Context) error {
 		// unchanged and continue to be enforced by the system.
 		// Note: input.PodSecurityAdmission is intentionally not processed here.
 
-		// Update the settings object
-		if input.Affinity != "" {
-			settings.Spec.Affinity = &affinity
-		} else {
-			settings.Spec.Affinity = nil
+		// Update only groups that are not managed via Helm.
+		if !settings.Spec.SetViaHelm {
+			if input.Affinity != "" {
+				settings.Spec.Affinity = &affinity
+			} else {
+				settings.Spec.Affinity = nil
+			}
+
+			if input.Tolerations != "" {
+				settings.Spec.Tolerations = tolerations
+			} else {
+				settings.Spec.Tolerations = nil
+			}
+
+			if input.Resources != "" {
+				settings.Spec.Resources = &resources
+			} else {
+				settings.Spec.Resources = nil
+			}
+
+			if input.RuntimeClassName != "" {
+				settings.Spec.RuntimeClassName = &input.RuntimeClassName
+			} else {
+				settings.Spec.RuntimeClassName = nil
+			}
+
+			if input.StorageClassName != "" {
+				settings.Spec.StorageClassName = &input.StorageClassName
+			} else {
+				settings.Spec.StorageClassName = nil
+			}
+
+			if input.NanobotWorkspaceSize != "" {
+				settings.Spec.NanobotWorkspaceSize = input.NanobotWorkspaceSize
+			} else {
+				settings.Spec.NanobotWorkspaceSize = ""
+			}
+
+			if input.NanobotAgentResources != "" {
+				settings.Spec.NanobotAgentResources = &nanobotAgentResources
+			} else {
+				settings.Spec.NanobotAgentResources = nil
+			}
 		}
 
-		if input.Tolerations != "" {
-			settings.Spec.Tolerations = tolerations
-		} else {
-			settings.Spec.Tolerations = nil
-		}
-
-		if input.Resources != "" {
-			settings.Spec.Resources = &resources
-		} else {
-			settings.Spec.Resources = nil
-		}
-
-		if input.RuntimeClassName != "" {
-			settings.Spec.RuntimeClassName = &input.RuntimeClassName
-		} else {
-			settings.Spec.RuntimeClassName = nil
-		}
-
-		if input.StorageClassName != "" {
-			settings.Spec.StorageClassName = &input.StorageClassName
-		} else {
-			settings.Spec.StorageClassName = nil
-		}
-
-		if input.NanobotWorkspaceSize != "" {
-			settings.Spec.NanobotWorkspaceSize = input.NanobotWorkspaceSize
-		} else {
-			settings.Spec.NanobotWorkspaceSize = ""
-		}
-
-		if input.NanobotAgentResources != "" {
-			settings.Spec.NanobotAgentResources = &nanobotAgentResources
-		} else {
-			settings.Spec.NanobotAgentResources = nil
+		if !settings.Spec.MaximumsSetViaHelm {
+			settings.Spec.MaxCPURequest = maxCPURequest
+			settings.Spec.MaxCPULimit = maxCPULimit
+			settings.Spec.MaxMemoryRequest = maxMemoryRequest
+			settings.Spec.MaxMemoryLimit = maxMemoryLimit
 		}
 
 		if err := validateK8sSettingsResourceMaximums(h.mcpSessionManager, settings.Spec); err != nil {
@@ -294,8 +320,9 @@ func convertResourceRequirements(resources corev1.ResourceRequirements) *types.M
 
 func convertK8sSettings(settings v1.K8sSettings) (types.K8sSettings, error) {
 	result := types.K8sSettings{
-		SetViaHelm: settings.Spec.SetViaHelm,
-		Metadata:   MetadataFrom(&settings),
+		SetViaHelm:         settings.Spec.SetViaHelm,
+		MaximumsSetViaHelm: settings.Spec.MaximumsSetViaHelm,
+		Metadata:           MetadataFrom(&settings),
 	}
 
 	formatted, err := FormatPodSchedulingYAML(
@@ -311,6 +338,10 @@ func convertK8sSettings(settings v1.K8sSettings) (types.K8sSettings, error) {
 	result.Tolerations = formatted.Tolerations
 	result.Resources = formatted.Resources
 	result.RuntimeClassName = formatted.RuntimeClassName
+	result.MaxCPURequest = resourceMaximumString(settings.Spec.MaxCPURequest)
+	result.MaxCPULimit = resourceMaximumString(settings.Spec.MaxCPULimit)
+	result.MaxMemoryRequest = resourceMaximumString(settings.Spec.MaxMemoryRequest)
+	result.MaxMemoryLimit = resourceMaximumString(settings.Spec.MaxMemoryLimit)
 
 	if settings.Spec.StorageClassName != nil {
 		result.StorageClassName = *settings.Spec.StorageClassName
@@ -390,4 +421,25 @@ func FormatPodSchedulingYAML(
 	}
 
 	return result, nil
+}
+
+func parseResourceMaximumField(name, value string) (*resource.Quantity, error) {
+	if value == "" {
+		return nil, nil
+	}
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	if quantity.Sign() < 0 {
+		return nil, fmt.Errorf("invalid %s: must be non-negative", name)
+	}
+	return &quantity, nil
+}
+
+func resourceMaximumString(maximum *resource.Quantity) string {
+	if maximum == nil {
+		return ""
+	}
+	return maximum.String()
 }

--- a/pkg/api/handlers/k8ssettings.go
+++ b/pkg/api/handlers/k8ssettings.go
@@ -136,7 +136,8 @@ func (h *K8sSettingsHandler) Defaults(req api.Context) error {
 
 	// Match the resources the Kubernetes backend will actually use when no
 	// explicit defaults are configured. Resource maximums cap implicit fallbacks.
-	return req.Write(convertResourceRequirements(mcp.EffectiveDefaultMCPResourceRequirementsWithMaximums(settings.Spec, h.mcpSessionManager.KubernetesResourceMaximums())))
+	maximums := h.mcpSessionManager.EffectiveKubernetesResourceMaximumsForSettings(settings.Spec)
+	return req.Write(convertResourceRequirements(mcp.EffectiveDefaultMCPResourceRequirementsWithMaximums(settings.Spec, maximums)))
 }
 
 func (h *K8sSettingsHandler) Update(req api.Context) error {

--- a/pkg/api/handlers/k8ssettings.go
+++ b/pkg/api/handlers/k8ssettings.go
@@ -136,8 +136,7 @@ func (h *K8sSettingsHandler) Defaults(req api.Context) error {
 
 	// Match the resources the Kubernetes backend will actually use when no
 	// explicit defaults are configured. Resource maximums cap implicit fallbacks.
-	maximums := h.mcpSessionManager.EffectiveKubernetesResourceMaximumsForSettings(settings.Spec)
-	return req.Write(convertResourceRequirements(mcp.EffectiveDefaultMCPResourceRequirementsWithMaximums(settings.Spec, maximums)))
+	return req.Write(convertResourceRequirements(mcp.EffectiveDefaultMCPResourceRequirements(settings.Spec)))
 }
 
 func (h *K8sSettingsHandler) Update(req api.Context) error {

--- a/pkg/api/handlers/k8ssettings_test.go
+++ b/pkg/api/handlers/k8ssettings_test.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestParseResourceMaximumField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    *resource.Quantity
+		wantErr bool
+	}{
+		{name: "empty"},
+		{name: "CPU", value: "500m", want: new(resource.MustParse("500m"))},
+		{name: "memory", value: "2Gi", want: new(resource.MustParse("2Gi"))},
+		{name: "invalid", value: "invalid", wantErr: true},
+		{name: "negative", value: "-1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseResourceMaximumField("maximum", tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseResourceMaximumField() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("parseResourceMaximumField() = %s, want nil", got)
+				}
+				return
+			}
+			if got == nil || got.Cmp(*tt.want) != 0 {
+				t.Fatalf("parseResourceMaximumField() = %v, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -131,8 +131,13 @@ func (m *MCPHandler) currentK8sSettingsHashWithImagePullSecrets(settings v1.K8sS
 	if err != nil {
 		return "", fmt.Errorf("failed to compute core resource requirements: %w", err)
 	}
-	maximums := m.mcpSessionManager.EffectiveKubernetesResourceMaximumsForSettings(settings)
-	return mcp.ComputeK8sSettingsHash(settings, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", maximums, imagePullSecretNames), nil
+	return mcp.ComputeK8sSettingsHash(
+		settings,
+		resources,
+		mcpServer.Spec.Manifest.Runtime,
+		mcpServer.Spec.NanobotAgentID != "",
+		imagePullSecretNames,
+	), nil
 }
 
 func (m *MCPHandler) GetEntryFromAllSources(req api.Context) error {

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -84,14 +84,34 @@ func validationOptions(remoteValidationConfig mcp.RemoteMCPURLValidationConfig) 
 	}
 }
 
-// ValidationOptionsWithResourceMaximums builds MCP manifest validation options from the active MCP session manager.
-func ValidationOptionsWithResourceMaximums(sessionManager *mcp.SessionManager) mcp.ValidationOptions {
+// ValidationOptionsWithResourceMaximums builds MCP manifest validation options from startup and persisted settings.
+func ValidationOptionsWithResourceMaximums(req api.Context, sessionManager *mcp.SessionManager) (mcp.ValidationOptions, error) {
 	if sessionManager == nil {
-		return mcp.ValidationOptions{}
+		return mcp.ValidationOptions{}, nil
 	}
 	options := validationOptions(sessionManager.RemoteMCPURLValidationConfig())
-	options.ResourceMaximums = sessionManager.KubernetesResourceMaximums()
-	return options
+	maximums, err := sessionManager.EffectiveKubernetesResourceMaximums(req.Context(), req.Storage)
+	if err != nil {
+		return mcp.ValidationOptions{}, err
+	}
+	options.ResourceMaximums = maximums
+	return options, nil
+}
+
+func validateServerManifestWithResourceMaximums(req api.Context, manifest types.MCPServerManifest, isMultiUser bool, sessionManager *mcp.SessionManager) error {
+	options, err := ValidationOptionsWithResourceMaximums(req, sessionManager)
+	if err != nil {
+		return err
+	}
+	return mcp.ValidateServerManifest(req.Context(), manifest, isMultiUser, options)
+}
+
+func validateCatalogEntryManifestWithResourceMaximums(req api.Context, manifest types.MCPServerCatalogEntryManifest, gitManaged bool, sessionManager *mcp.SessionManager) error {
+	options, err := ValidationOptionsWithResourceMaximums(req, sessionManager)
+	if err != nil {
+		return err
+	}
+	return mcp.ValidateCatalogEntryManifest(req.Context(), manifest, gitManaged, options)
 }
 
 func (m *MCPHandler) currentImagePullSecretNames(req api.Context) ([]string, error) {
@@ -1682,7 +1702,7 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 		return types.NewErrBadRequest("catalogEntryID is required")
 	}
 
-	if err := mcp.ValidateServerManifest(req.Context(), server.Spec.Manifest, !server.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	if err := validateServerManifestWithResourceMaximums(req, server.Spec.Manifest, !server.Spec.IsSingleUser(), m.mcpSessionManager); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 	if err := obottunnel.ValidateServerTunnelReferences(req.Context(), req.Storage, server.Spec.Manifest); err != nil {
@@ -1783,7 +1803,7 @@ func (m *MCPHandler) UpdateServer(req api.Context) error {
 		return fmt.Errorf("failed to find credential: %w", err)
 	}
 
-	if err := mcp.ValidateServerManifest(req.Context(), updated, !existing.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	if err := validateServerManifestWithResourceMaximums(req, updated, !existing.Spec.IsSingleUser(), m.mcpSessionManager); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 	if err := obottunnel.ValidateServerTunnelReferences(req.Context(), req.Storage, updated); err != nil {
@@ -1938,7 +1958,11 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 
 		var updateServer bool
 		if url := envVars[configURLKey]; url != "" {
-			if err := updateMCPServerURLFromCatalogEntry(req.Context(), req.Storage, &mcpServer, catalogEntry, url, ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+			validationOptions, err := ValidationOptionsWithResourceMaximums(req, m.mcpSessionManager)
+			if err != nil {
+				return err
+			}
+			if err := updateMCPServerURLFromCatalogEntry(req.Context(), req.Storage, &mcpServer, catalogEntry, url, validationOptions); err != nil {
 				return err
 			}
 
@@ -1953,7 +1977,11 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 		if catalogEntry.Spec.Manifest.Runtime == types.RuntimeRemote &&
 			catalogEntry.Spec.Manifest.RemoteConfig != nil &&
 			catalogEntry.Spec.Manifest.RemoteConfig.URLTemplate != "" {
-			if err := applyRemoteURLTemplate(req.Context(), &mcpServer.Spec.Manifest, envVars, !mcpServer.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+			validationOptions, err := ValidationOptionsWithResourceMaximums(req, m.mcpSessionManager)
+			if err != nil {
+				return err
+			}
+			if err := applyRemoteURLTemplate(req.Context(), &mcpServer.Spec.Manifest, envVars, !mcpServer.Spec.IsSingleUser(), validationOptions); err != nil {
 				return err
 			}
 			if err := obottunnel.ValidateServerTunnelReferences(req.Context(), req.Storage, mcpServer.Spec.Manifest); err != nil {
@@ -2121,7 +2149,7 @@ func (m *MCPHandler) configureCompositeServer(req api.Context, compositeServer v
 				if remoteConfig.URL != originalURL {
 					// Capture and validate the changes
 					component.Manifest.RemoteConfig = remoteConfig
-					if err := mcp.ValidateServerManifest(req.Context(), component.Manifest, false, ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+					if err := validateServerManifestWithResourceMaximums(req, component.Manifest, false, m.mcpSessionManager); err != nil {
 						return fmt.Errorf("failed to validate server manifest %w", err)
 					}
 					if err := obottunnel.ValidateServerTunnelReferences(req.Context(), req.Storage, component.Manifest); err != nil {
@@ -3834,7 +3862,11 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 		return fmt.Errorf("failed to read input: %w", err)
 	}
 
-	if err := updateMCPServerURLFromCatalogEntry(req.Context(), req.Storage, &mcpServer, entry, input.URL, ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	validationOptions, err := ValidationOptionsWithResourceMaximums(req, m.mcpSessionManager)
+	if err != nil {
+		return err
+	}
+	if err := updateMCPServerURLFromCatalogEntry(req.Context(), req.Storage, &mcpServer, entry, input.URL, validationOptions); err != nil {
 		return err
 	}
 
@@ -3952,7 +3984,7 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 
 	candidate := server.DeepCopy()
 	updateServerFromCatalogEntry(candidate, entry)
-	if err := mcp.ValidateServerManifest(req.Context(), candidate.Spec.Manifest, !candidate.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	if err := validateServerManifestWithResourceMaximums(req, candidate.Spec.Manifest, !candidate.Spec.IsSingleUser(), m.mcpSessionManager); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 	if err := obottunnel.ValidateServerTunnelReferences(req.Context(), req.Storage, candidate.Spec.Manifest); err != nil {
@@ -3981,7 +4013,7 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 		updateServerFromCatalogEntry(&latest, entry)
 
 		// Validate again in case the catalog entry changed between retries.
-		if err := mcp.ValidateServerManifest(req.Context(), latest.Spec.Manifest, !latest.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+		if err := validateServerManifestWithResourceMaximums(req, latest.Spec.Manifest, !latest.Spec.IsSingleUser(), m.mcpSessionManager); err != nil {
 			return types.NewErrBadRequest("validation failed: %v", err)
 		}
 		if err := obottunnel.ValidateServerTunnelReferences(req.Context(), req.Storage, latest.Spec.Manifest); err != nil {
@@ -4081,7 +4113,7 @@ func (m *MCPHandler) triggerCompositeUpdate(req api.Context, compositeServer v1.
 	if err != nil {
 		return err
 	}
-	if err := mcp.ValidateServerManifest(req.Context(), updatedManifest, !compositeServer.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+	if err := validateServerManifestWithResourceMaximums(req, updatedManifest, !compositeServer.Spec.IsSingleUser(), m.mcpSessionManager); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
 	}
 	if err := obottunnel.ValidateServerTunnelReferences(req.Context(), req.Storage, updatedManifest); err != nil {

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -131,7 +131,8 @@ func (m *MCPHandler) currentK8sSettingsHashWithImagePullSecrets(settings v1.K8sS
 	if err != nil {
 		return "", fmt.Errorf("failed to compute core resource requirements: %w", err)
 	}
-	return mcp.ComputeK8sSettingsHash(settings, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", m.mcpSessionManager.KubernetesResourceMaximums(), imagePullSecretNames), nil
+	maximums := m.mcpSessionManager.EffectiveKubernetesResourceMaximumsForSettings(settings)
+	return mcp.ComputeK8sSettingsHash(settings, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", maximums, imagePullSecretNames), nil
 }
 
 func (m *MCPHandler) GetEntryFromAllSources(req api.Context) error {

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -136,7 +136,7 @@ func TestConvertMCPServerCatalogEntryDetached(t *testing.T) {
 	assert.Equal(t, "https://github.com/obot-platform/mcp-catalog", entry.SourceURL)
 }
 
-func TestValidationOptionsWithResourceMaximumsUsesPersistedMaximum(t *testing.T) {
+func TestValidationOptionsWithResourceMaximumsIgnoresPersistedMaximumForNonKubernetesBackend(t *testing.T) {
 	maximum := resource.MustParse("500m")
 	req := api.Context{
 		Request: httptest.NewRequest(http.MethodGet, "/", nil),
@@ -148,8 +148,7 @@ func TestValidationOptionsWithResourceMaximumsUsesPersistedMaximum(t *testing.T)
 
 	options, err := ValidationOptionsWithResourceMaximums(req, &mcp.SessionManager{})
 	require.NoError(t, err)
-	require.NotNil(t, options.ResourceMaximums.CPURequest)
-	require.Zero(t, options.ResourceMaximums.CPURequest.Cmp(maximum))
+	require.Nil(t, options.ResourceMaximums.CPURequest)
 
 	err = mcp.ValidateServerManifest(t.Context(), types.MCPServerManifest{
 		Runtime: types.RuntimeNPX,
@@ -160,7 +159,7 @@ func TestValidationOptionsWithResourceMaximumsUsesPersistedMaximum(t *testing.T)
 			Requests: types.MCPResourceRequests{CPU: "1"},
 		},
 	}, false, options)
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 func TestHideMultiUserCatalogEntry(t *testing.T) {

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -136,6 +136,33 @@ func TestConvertMCPServerCatalogEntryDetached(t *testing.T) {
 	assert.Equal(t, "https://github.com/obot-platform/mcp-catalog", entry.SourceURL)
 }
 
+func TestValidationOptionsWithResourceMaximumsUsesPersistedMaximum(t *testing.T) {
+	maximum := resource.MustParse("500m")
+	req := api.Context{
+		Request: httptest.NewRequest(http.MethodGet, "/", nil),
+		Storage: newFakeStorage(t, &v1.K8sSettings{
+			ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+			Spec:       v1.K8sSettingsSpec{MaxCPURequest: &maximum},
+		}),
+	}
+
+	options, err := ValidationOptionsWithResourceMaximums(req, &mcp.SessionManager{})
+	require.NoError(t, err)
+	require.NotNil(t, options.ResourceMaximums.CPURequest)
+	require.Zero(t, options.ResourceMaximums.CPURequest.Cmp(maximum))
+
+	err = mcp.ValidateServerManifest(t.Context(), types.MCPServerManifest{
+		Runtime: types.RuntimeNPX,
+		NPXConfig: &types.NPXRuntimeConfig{
+			Package: "example",
+		},
+		Resources: &types.MCPResourceRequirements{
+			Requests: types.MCPResourceRequests{CPU: "1"},
+		},
+	}, false, options)
+	require.Error(t, err)
+}
+
 func TestHideMultiUserCatalogEntry(t *testing.T) {
 	multiUserEntry := v1.MCPServerCatalogEntry{
 		Spec: v1.MCPServerCatalogEntrySpec{

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -864,6 +864,10 @@ func (h *MCPCatalogHandler) GenerateToolPreviews(req api.Context) error {
 	if catalogName == "" {
 		catalogName = entry.Spec.PowerUserWorkspaceID
 	}
+	validationOptions, err := ValidationOptionsWithResourceMaximums(req, h.sessionManager)
+	if err != nil {
+		return err
+	}
 	server, serverConfig, err := tempServerAndConfig(
 		req.Context(),
 		req.GatewayClient,
@@ -878,7 +882,7 @@ func (h *MCPCatalogHandler) GenerateToolPreviews(req api.Context) error {
 		configRequest.Config,
 		configRequest.URL,
 		h.serverURL,
-		ValidationOptionsWithResourceMaximums(h.sessionManager),
+		validationOptions,
 	)
 	if err != nil {
 		return types.NewErrBadRequest("failed to create temporary server and config: %v", err)
@@ -948,6 +952,10 @@ func (h *MCPCatalogHandler) generateCompositeToolPreviews(req api.Context, entry
 	if catalogName == "" {
 		catalogName = entry.Spec.PowerUserWorkspaceID
 	}
+	validationOptions, err := ValidationOptionsWithResourceMaximums(req, h.sessionManager)
+	if err != nil {
+		return err
+	}
 
 	compositeToolPreviews := make([]types.MCPServerTool, 0, len(compositeConfig.ComponentServers))
 	for _, componentEntry := range compositeConfig.ComponentServers {
@@ -1005,7 +1013,7 @@ func (h *MCPCatalogHandler) generateCompositeToolPreviews(req api.Context, entry
 			config.Config,
 			config.URL,
 			h.serverURL,
-			ValidationOptionsWithResourceMaximums(h.sessionManager),
+			validationOptions,
 		)
 		if err != nil {
 			return err
@@ -1125,7 +1133,11 @@ func (h *MCPCatalogHandler) GenerateToolPreviewsOAuthURL(req api.Context) error 
 	if catalogName == "" {
 		catalogName = entry.Spec.PowerUserWorkspaceID
 	}
-	server, serverConfig, err := tempServerAndConfig(req.Context(), req.GatewayClient, req.Storage, req.LocalK8sClient, req.ObotNamespace, h.secretBindingAllowedLabel, entry.Namespace, entry.Name, catalogName, entry.Spec.Manifest, configRequest.Config, configRequest.URL, h.serverURL, ValidationOptionsWithResourceMaximums(h.sessionManager))
+	validationOptions, err := ValidationOptionsWithResourceMaximums(req, h.sessionManager)
+	if err != nil {
+		return err
+	}
+	server, serverConfig, err := tempServerAndConfig(req.Context(), req.GatewayClient, req.Storage, req.LocalK8sClient, req.ObotNamespace, h.secretBindingAllowedLabel, entry.Namespace, entry.Name, catalogName, entry.Spec.Manifest, configRequest.Config, configRequest.URL, h.serverURL, validationOptions)
 	if err != nil {
 		return types.NewErrBadRequest("failed to create temporary server and config: %v", err)
 	}
@@ -1208,6 +1220,10 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviews(req api.Context) error
 	if catalogName == "" {
 		catalogName = composite.Spec.PowerUserWorkspaceID
 	}
+	validationOptions, err := ValidationOptionsWithResourceMaximums(req, h.sessionManager)
+	if err != nil {
+		return err
+	}
 
 	// Use the manifest snapshot embedded in the composite entry for this component.
 	server, serverConfig, err := tempServerAndConfig(
@@ -1224,7 +1240,7 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviews(req api.Context) error
 		configRequest.Config,
 		configRequest.URL,
 		h.serverURL,
-		ValidationOptionsWithResourceMaximums(h.sessionManager),
+		validationOptions,
 	)
 	if err != nil {
 		return types.NewErrBadRequest("failed to create temporary server and config: %v", err)
@@ -1336,6 +1352,10 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviewsOAuthURL(req api.Contex
 	if catalogName == "" {
 		catalogName = composite.Spec.PowerUserWorkspaceID
 	}
+	validationOptions, err := ValidationOptionsWithResourceMaximums(req, h.sessionManager)
+	if err != nil {
+		return err
+	}
 
 	server, serverConfig, err := tempServerAndConfig(
 		req.Context(),
@@ -1351,7 +1371,7 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviewsOAuthURL(req api.Contex
 		configRequest.Config,
 		configRequest.URL,
 		h.serverURL,
-		ValidationOptionsWithResourceMaximums(h.sessionManager),
+		validationOptions,
 	)
 	if err != nil {
 		return types.NewErrBadRequest("failed to create temporary server and config: %v", err)
@@ -1393,6 +1413,10 @@ func (h *MCPCatalogHandler) generateCompositeOAuthURLs(req api.Context, entry v1
 	catalogName := entry.Spec.MCPCatalogName
 	if catalogName == "" {
 		catalogName = entry.Spec.PowerUserWorkspaceID
+	}
+	validationOptions, err := ValidationOptionsWithResourceMaximums(req, h.sessionManager)
+	if err != nil {
+		return err
 	}
 
 	for _, componentEntry := range compositeConfig.ComponentServers {
@@ -1437,7 +1461,7 @@ func (h *MCPCatalogHandler) generateCompositeOAuthURLs(req api.Context, entry v1
 			config.Config,
 			config.URL,
 			h.serverURL,
-			ValidationOptionsWithResourceMaximums(h.sessionManager),
+			validationOptions,
 		)
 		if err != nil {
 			// If we can't create server config, skip this component

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -326,7 +326,7 @@ func (h *MCPCatalogHandler) CreateEntry(req api.Context) error {
 			return err
 		}
 	}
-	if err := mcp.ValidateCatalogEntryManifest(req.Context(), manifest, false, ValidationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
+	if err := validateCatalogEntryManifestWithResourceMaximums(req, manifest, false, h.sessionManager); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
 	}
 	if err := tunnel.ValidateCatalogEntryTunnelReferences(req.Context(), req.Storage, manifest); err != nil {
@@ -408,7 +408,7 @@ func (h *MCPCatalogHandler) UpdateEntry(req api.Context) error {
 	if manifest.ServerUserType == "" {
 		manifest.ServerUserType = types.ServerUserTypeSingleUser
 	}
-	if err := mcp.ValidateCatalogEntryManifest(req.Context(), manifest, false, ValidationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
+	if err := validateCatalogEntryManifestWithResourceMaximums(req, manifest, false, h.sessionManager); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
 	}
 	if err := tunnel.ValidateCatalogEntryTunnelReferences(req.Context(), req.Storage, manifest); err != nil {
@@ -1762,7 +1762,7 @@ func (h *MCPCatalogHandler) RefreshCompositeComponents(req api.Context) error {
 
 	// Validate the refreshed manifest to ensure it's still valid
 	entryGitManaged := entry.IsGitManaged()
-	if err := mcp.ValidateCatalogEntryManifest(req.Context(), entry.Spec.Manifest, entryGitManaged, ValidationOptionsWithResourceMaximums(h.sessionManager)); err != nil {
+	if err := validateCatalogEntryManifestWithResourceMaximums(req, entry.Spec.Manifest, entryGitManaged, h.sessionManager); err != nil {
 		return types.NewErrBadRequest("failed to validate entry manifest: %v", err)
 	}
 	if err := tunnel.ValidateCatalogEntryTunnelReferences(req.Context(), req.Storage, entry.Spec.Manifest); err != nil {

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -368,7 +368,12 @@ func (h *handler) consent(req api.Context) error {
 		mcpServer         *types.MCPServer
 		mcpServerInstance *types.MCPServerInstance
 	)
-	mcpServer, mcpServerInstance, err = handlers.ConfigurationTargetForConnectID(req, oauthAppAuthRequest.Spec.MCPID, h.baseURL, h.oauthChecker.secretBindingAllowedLabel, handlers.ValidationOptionsWithResourceMaximums(h.oauthChecker.mcpSessionManager))
+	validationOptions, err := handlers.ValidationOptionsWithResourceMaximums(req, h.oauthChecker.mcpSessionManager)
+	if err != nil {
+		redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, err.Error(), oauthAppAuthRequest.Spec.State))
+		return nil
+	}
+	mcpServer, mcpServerInstance, err = handlers.ConfigurationTargetForConnectID(req, oauthAppAuthRequest.Spec.MCPID, h.baseURL, h.oauthChecker.secretBindingAllowedLabel, validationOptions)
 	if err != nil {
 		if oauthAppAuthRequest.Spec.ConsentMCPConfigRequired {
 			redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, err.Error(), oauthAppAuthRequest.Spec.State))

--- a/pkg/api/handlers/mcpresourcemaximums.go
+++ b/pkg/api/handlers/mcpresourcemaximums.go
@@ -8,9 +8,6 @@ import (
 
 func validateK8sSettingsResourceMaximums(sessionManager *mcp.SessionManager, settings v1.K8sSettingsSpec) error {
 	maximums := sessionManager.KubernetesResourceMaximums()
-	if maximums.Empty() {
-		return nil
-	}
 	if err := mcp.ValidateK8sSettingsResourceMaximums(settings, maximums); err != nil {
 		return types.NewErrBadRequest("resource maximum validation failed: %v", err)
 	}

--- a/pkg/api/handlers/mcpresourcemaximums.go
+++ b/pkg/api/handlers/mcpresourcemaximums.go
@@ -7,7 +7,7 @@ import (
 )
 
 func validateK8sSettingsResourceMaximums(sessionManager *mcp.SessionManager, settings v1.K8sSettingsSpec) error {
-	maximums := sessionManager.KubernetesResourceMaximums()
+	maximums := sessionManager.EffectiveKubernetesResourceMaximumsForSettings(settings)
 	if err := mcp.ValidateK8sSettingsResourceMaximums(settings, maximums); err != nil {
 		return types.NewErrBadRequest("resource maximum validation failed: %v", err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -439,6 +440,9 @@ func ensureHostedAgentPoolDefaults(ctx context.Context, client kclient.Client) e
 //
 //	These are always applied regardless of SetViaHelm flag and cannot be modified via UI.
 func ensureK8sSettings(ctx context.Context, client kclient.Client, podSchedulingSettings *v1.K8sSettingsSpec, psaSettings *v1.PodSecurityAdmissionSettings, resourceMaximums mcp.ResourceMaximums) error {
+	settingsSetViaHelm := hasHelmPodSchedulingSettings(podSchedulingSettings)
+	maximumsSetViaHelm := podSchedulingSettings != nil && podSchedulingSettings.MaximumsSetViaHelm
+
 	var k8sSettings v1.K8sSettings
 	if err := client.Get(ctx, kclient.ObjectKey{
 		Namespace: system.DefaultNamespace,
@@ -452,18 +456,21 @@ func ensureK8sSettings(ctx context.Context, client kclient.Client, podScheduling
 				Namespace: system.DefaultNamespace,
 			},
 			Spec: v1.K8sSettingsSpec{
-				SetViaHelm: podSchedulingSettings != nil,
+				SetViaHelm:         settingsSetViaHelm,
+				MaximumsSetViaHelm: maximumsSetViaHelm,
 			},
 		}
 
-		// If pod scheduling settings provided via Helm, use them
-		if podSchedulingSettings != nil {
+		if settingsSetViaHelm {
 			k8sSettings.Spec.Affinity = podSchedulingSettings.Affinity
 			k8sSettings.Spec.Tolerations = podSchedulingSettings.Tolerations
 			k8sSettings.Spec.Resources = podSchedulingSettings.Resources
 			k8sSettings.Spec.RuntimeClassName = podSchedulingSettings.RuntimeClassName
 			k8sSettings.Spec.StorageClassName = podSchedulingSettings.StorageClassName
 			k8sSettings.Spec.NanobotWorkspaceSize = podSchedulingSettings.NanobotWorkspaceSize
+		}
+		if maximumsSetViaHelm {
+			setK8sSettingsMaximums(&k8sSettings.Spec, podSchedulingSettings)
 		}
 
 		// PSA settings are always applied from environment/Helm (independent of SetViaHelm)
@@ -481,8 +488,7 @@ func ensureK8sSettings(ctx context.Context, client kclient.Client, podScheduling
 	// Determine if we need to update
 	needsUpdate := false
 
-	// Handle pod scheduling settings from Helm
-	if podSchedulingSettings != nil {
+	if settingsSetViaHelm {
 		// Pod scheduling settings provided via Helm - lock them
 		if !k8sSettings.Spec.SetViaHelm ||
 			!affinityEqual(k8sSettings.Spec.Affinity, podSchedulingSettings.Affinity) ||
@@ -510,6 +516,18 @@ func ensureK8sSettings(ctx context.Context, client kclient.Client, podScheduling
 		k8sSettings.Spec.RuntimeClassName = nil
 		k8sSettings.Spec.StorageClassName = nil
 		k8sSettings.Spec.NanobotWorkspaceSize = ""
+		needsUpdate = true
+	}
+
+	if maximumsSetViaHelm {
+		if !k8sSettings.Spec.MaximumsSetViaHelm || !resourceMaximumsEqual(k8sSettings.Spec, *podSchedulingSettings) {
+			k8sSettings.Spec.MaximumsSetViaHelm = true
+			setK8sSettingsMaximums(&k8sSettings.Spec, podSchedulingSettings)
+			needsUpdate = true
+		}
+	} else if k8sSettings.Spec.MaximumsSetViaHelm {
+		k8sSettings.Spec.MaximumsSetViaHelm = false
+		setK8sSettingsMaximums(&k8sSettings.Spec, nil)
 		needsUpdate = true
 	}
 
@@ -563,6 +581,44 @@ func resourcesEqual(a, b *corev1.ResourceRequirements) bool {
 		return false
 	}
 	return equality.Semantic.DeepEqual(a, b)
+}
+
+func quantityEqual(a, b *resource.Quantity) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Cmp(*b) == 0
+}
+
+func hasHelmPodSchedulingSettings(settings *v1.K8sSettingsSpec) bool {
+	if settings == nil {
+		return false
+	}
+	return settings.SetViaHelm || settings.Affinity != nil || len(settings.Tolerations) > 0 ||
+		settings.Resources != nil || settings.NanobotAgentResources != nil ||
+		settings.RuntimeClassName != nil || settings.StorageClassName != nil ||
+		settings.NanobotWorkspaceSize != ""
+}
+
+func resourceMaximumsEqual(a, b v1.K8sSettingsSpec) bool {
+	return quantityEqual(a.MaxCPURequest, b.MaxCPURequest) &&
+		quantityEqual(a.MaxCPULimit, b.MaxCPULimit) &&
+		quantityEqual(a.MaxMemoryRequest, b.MaxMemoryRequest) &&
+		quantityEqual(a.MaxMemoryLimit, b.MaxMemoryLimit)
+}
+
+func setK8sSettingsMaximums(settings *v1.K8sSettingsSpec, maximums *v1.K8sSettingsSpec) {
+	if maximums == nil {
+		settings.MaxCPURequest = nil
+		settings.MaxCPULimit = nil
+		settings.MaxMemoryRequest = nil
+		settings.MaxMemoryLimit = nil
+		return
+	}
+	settings.MaxCPURequest = maximums.MaxCPURequest
+	settings.MaxCPULimit = maximums.MaxCPULimit
+	settings.MaxMemoryRequest = maximums.MaxMemoryRequest
+	settings.MaxMemoryLimit = maximums.MaxMemoryLimit
 }
 
 func classNameEqual(a, b *string) bool {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -84,11 +84,13 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure hosted agent pool defaults: %w", err)
 	}
 
-	resourceMaximums := c.services.MCPSessionManager.KubernetesResourceMaximums()
+	resourceMaximums, err := c.services.MCPSessionManager.EffectiveKubernetesResourceMaximums(ctx, c.services.StorageClient)
+	if err != nil {
+		return fmt.Errorf("failed to get effective K8s resource maximums: %w", err)
+	}
 	if err := ensureK8sSettings(ctx, c.services.StorageClient, c.services.PodSchedulingSettingsFromHelm, c.services.PSASettingsFromHelm, resourceMaximums); err != nil {
 		return fmt.Errorf("failed to ensure K8s settings: %w", err)
 	}
-
 	if err := ensureAppPreferences(ctx, c.services.StorageClient); err != nil {
 		return fmt.Errorf("failed to ensure app preferences: %w", err)
 	}
@@ -676,8 +678,12 @@ func (c *Controller) setupLocalK8sRoutes() {
 	// Kubernetes, so these are gated on the MCP backend rather than on the
 	// router: every one of them reconciles MCP state from cluster objects.
 	if c.services.LocalRouter != nil && mcp.IsKubernetesBackend(c.services.MCPRuntimeBackend) {
-		resourceMaximums := c.services.MCPSessionManager.KubernetesResourceMaximums()
-		deploymentHandler := deployment.New(c.services.MCPServerNamespace, c.services.Router.Backend(), c.services.MCPRuntimeBackend, resourceMaximums, c.services.MCPImagePullSecrets)
+		deploymentHandler := deployment.New(
+			c.services.MCPServerNamespace,
+			c.services.Router.Backend(),
+			c.services.MCPSessionManager,
+			c.services.MCPImagePullSecrets,
+		)
 		c.services.LocalRouter.Type(&appsv1.Deployment{}).IncludeRemoved().HandlerFunc(deploymentHandler.UpdateMCPServerStatus)
 		c.services.LocalRouter.Type(&appsv1.Deployment{}).HandlerFunc(deploymentHandler.CleanupOldIDs)
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -84,7 +84,7 @@ func (c *Controller) PreStart(ctx context.Context) error {
 		return fmt.Errorf("failed to ensure hosted agent pool defaults: %w", err)
 	}
 
-	resourceMaximums, err := c.services.MCPSessionManager.EffectiveKubernetesResourceMaximums(ctx, c.services.StorageClient)
+	resourceMaximums, err := c.services.MCPSessionManager.StartupKubernetesResourceMaximums(ctx, c.services.StorageClient)
 	if err != nil {
 		return fmt.Errorf("failed to get effective K8s resource maximums: %w", err)
 	}

--- a/pkg/controller/handlers/deployment/deployment.go
+++ b/pkg/controller/handlers/deployment/deployment.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -19,7 +18,6 @@ import (
 
 type sessionManager interface {
 	MCPRuntimeBackend() string
-	EffectiveKubernetesResourceMaximums(context.Context, kclient.Client) (mcp.ResourceMaximums, error)
 }
 
 type Handler struct {
@@ -145,16 +143,11 @@ func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) e
 			return fmt.Errorf("failed to compute core resource requirements: %w", err)
 		}
 
-		resourceMaximums, err := h.mcpSessionManager.EffectiveKubernetesResourceMaximums(req.Ctx, h.storageClient)
-		if err != nil {
-			return fmt.Errorf("failed to get effective Kubernetes resource maximums: %w", err)
-		}
 		currentHash := mcp.ComputeK8sSettingsHash(
 			k8sSettings.Spec,
 			resources,
 			mcpServer.Spec.Manifest.Runtime,
 			mcpServer.Spec.NanobotAgentID != "",
-			resourceMaximums,
 			imagePullSecretNames,
 		)
 

--- a/pkg/controller/handlers/deployment/deployment.go
+++ b/pkg/controller/handlers/deployment/deployment.go
@@ -1,6 +1,7 @@
 package deployment
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -16,22 +17,32 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type sessionManager interface {
+	MCPRuntimeBackend() string
+	EffectiveKubernetesResourceMaximums(context.Context, kclient.Client) (mcp.ResourceMaximums, error)
+}
+
 type Handler struct {
 	mcpDeploymentNamespace string
 	mcpNamespace           string
 	storageClient          kclient.Client
 	mcpRuntimeBackend      string
-	resourceMaximums       mcp.ResourceMaximums
+	mcpSessionManager      sessionManager
 	mcpImagePullSecrets    []string
 }
 
-func New(mcpNamespace string, storageClient kclient.Client, mcpRuntimeBackend string, resourceMaximums mcp.ResourceMaximums, mcpImagePullSecrets []string) *Handler {
+func New(
+	mcpNamespace string,
+	storageClient kclient.Client,
+	mcpSessionManager *mcp.SessionManager,
+	mcpImagePullSecrets []string,
+) *Handler {
 	return &Handler{
 		mcpDeploymentNamespace: mcpNamespace,
 		mcpNamespace:           system.DefaultNamespace,
 		storageClient:          storageClient,
-		mcpRuntimeBackend:      mcpRuntimeBackend,
-		resourceMaximums:       resourceMaximums,
+		mcpRuntimeBackend:      mcpSessionManager.MCPRuntimeBackend(),
+		mcpSessionManager:      mcpSessionManager,
 		mcpImagePullSecrets:    mcpImagePullSecrets,
 	}
 }
@@ -134,7 +145,18 @@ func (h *Handler) UpdateMCPServerStatus(req router.Request, _ router.Response) e
 			return fmt.Errorf("failed to compute core resource requirements: %w", err)
 		}
 
-		currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, mcpServer.Spec.Manifest.Runtime, mcpServer.Spec.NanobotAgentID != "", h.resourceMaximums, imagePullSecretNames)
+		resourceMaximums, err := h.mcpSessionManager.EffectiveKubernetesResourceMaximums(req.Ctx, h.storageClient)
+		if err != nil {
+			return fmt.Errorf("failed to get effective Kubernetes resource maximums: %w", err)
+		}
+		currentHash := mcp.ComputeK8sSettingsHash(
+			k8sSettings.Spec,
+			resources,
+			mcpServer.Spec.Manifest.Runtime,
+			mcpServer.Spec.NanobotAgentID != "",
+			resourceMaximums,
+			imagePullSecretNames,
+		)
 
 		if k8sUpdateNeeded := mcpServer.Status.K8sSettingsHash != currentHash; k8sUpdateNeeded != mcpServer.Status.NeedsK8sUpdate {
 			mcpServer.Status.NeedsK8sUpdate = k8sUpdateNeeded

--- a/pkg/controller/handlers/deployment/deployment_test.go
+++ b/pkg/controller/handlers/deployment/deployment_test.go
@@ -1,0 +1,115 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/mcp"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type liveSessionManager struct {
+	calls    int
+	maximums mcp.ResourceMaximums
+}
+
+func (*liveSessionManager) MCPRuntimeBackend() string {
+	return mcp.RuntimeBackendKubernetes
+}
+
+func (m *liveSessionManager) EffectiveKubernetesResourceMaximums(
+	context.Context,
+	kclient.Client,
+) (mcp.ResourceMaximums, error) {
+	m.calls++
+	return m.maximums, nil
+}
+
+func TestUpdateMCPServerStatusUsesCurrentResourceMaximums(t *testing.T) {
+	oldMaximum := resource.MustParse("5m")
+	newMaximum := resource.MustParse("10m")
+	settingsSpec := v1.K8sSettingsSpec{}
+	oldMaximums := mcp.ResourceMaximums{CPURequest: &oldMaximum}
+	newMaximums := mcp.ResourceMaximums{CPURequest: &newMaximum}
+	oldHash := mcp.ComputeK8sSettingsHash(
+		settingsSpec,
+		nil,
+		types.RuntimeNPX,
+		false,
+		oldMaximums,
+		nil,
+	)
+	newHash := mcp.ComputeK8sSettingsHash(
+		settingsSpec,
+		nil,
+		types.RuntimeNPX,
+		false,
+		newMaximums,
+		nil,
+	)
+	require.NotEqual(t, oldHash, newHash)
+
+	server := &v1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mcp-server",
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{Runtime: types.RuntimeNPX},
+		},
+		Status: v1.MCPServerStatus{
+			K8sSettingsHash: oldHash,
+			NeedsK8sUpdate:  true,
+		},
+	}
+	settings := &v1.K8sSettings{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      system.K8sSettingsName,
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: settingsSpec,
+	}
+	storageClient := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithStatusSubresource(&v1.MCPServer{}).
+		WithObjects(server, settings).
+		Build()
+	manager := &liveSessionManager{maximums: newMaximums}
+	handler := &Handler{
+		mcpDeploymentNamespace: "obot-mcp",
+		mcpNamespace:           system.DefaultNamespace,
+		storageClient:          storageClient,
+		mcpRuntimeBackend:      mcp.RuntimeBackendKubernetes,
+		mcpSessionManager:      manager,
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        server.Name,
+			Annotations: map[string]string{"obot.ai/k8s-settings-hash": newHash},
+			Labels:      map[string]string{"app": server.Name},
+		},
+	}
+
+	err := handler.UpdateMCPServerStatus(router.Request{
+		Client: storageClient,
+		Ctx:    t.Context(),
+		Object: deployment,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+	require.Equal(t, 1, manager.calls)
+
+	var updated v1.MCPServer
+	require.NoError(t, storageClient.Get(t.Context(), router.Key(server.Namespace, server.Name), &updated))
+	require.Equal(t, newHash, updated.Status.K8sSettingsHash)
+	require.False(t, updated.Status.NeedsK8sUpdate)
+}

--- a/pkg/controller/handlers/deployment/deployment_test.go
+++ b/pkg/controller/handlers/deployment/deployment_test.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"context"
 	"testing"
 
 	"github.com/obot-platform/nah/pkg/router"
@@ -14,47 +13,32 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-type liveSessionManager struct {
-	calls    int
-	maximums mcp.ResourceMaximums
-}
+type liveSessionManager struct{}
 
 func (*liveSessionManager) MCPRuntimeBackend() string {
 	return mcp.RuntimeBackendKubernetes
 }
 
-func (m *liveSessionManager) EffectiveKubernetesResourceMaximums(
-	context.Context,
-	kclient.Client,
-) (mcp.ResourceMaximums, error) {
-	m.calls++
-	return m.maximums, nil
-}
-
 func TestUpdateMCPServerStatusUsesCurrentResourceMaximums(t *testing.T) {
 	oldMaximum := resource.MustParse("5m")
 	newMaximum := resource.MustParse("10m")
-	settingsSpec := v1.K8sSettingsSpec{}
-	oldMaximums := mcp.ResourceMaximums{CPURequest: &oldMaximum}
-	newMaximums := mcp.ResourceMaximums{CPURequest: &newMaximum}
+	oldSettingsSpec := v1.K8sSettingsSpec{MaxCPURequest: &oldMaximum}
+	newSettingsSpec := v1.K8sSettingsSpec{MaxCPURequest: &newMaximum}
 	oldHash := mcp.ComputeK8sSettingsHash(
-		settingsSpec,
+		oldSettingsSpec,
 		nil,
 		types.RuntimeNPX,
 		false,
-		oldMaximums,
 		nil,
 	)
 	newHash := mcp.ComputeK8sSettingsHash(
-		settingsSpec,
+		newSettingsSpec,
 		nil,
 		types.RuntimeNPX,
 		false,
-		newMaximums,
 		nil,
 	)
 	require.NotEqual(t, oldHash, newHash)
@@ -77,14 +61,14 @@ func TestUpdateMCPServerStatusUsesCurrentResourceMaximums(t *testing.T) {
 			Name:      system.K8sSettingsName,
 			Namespace: system.DefaultNamespace,
 		},
-		Spec: settingsSpec,
+		Spec: newSettingsSpec,
 	}
 	storageClient := fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
 		WithStatusSubresource(&v1.MCPServer{}).
 		WithObjects(server, settings).
 		Build()
-	manager := &liveSessionManager{maximums: newMaximums}
+	manager := &liveSessionManager{}
 	handler := &Handler{
 		mcpDeploymentNamespace: "obot-mcp",
 		mcpNamespace:           system.DefaultNamespace,
@@ -106,7 +90,6 @@ func TestUpdateMCPServerStatusUsesCurrentResourceMaximums(t *testing.T) {
 		Object: deployment,
 	}, &router.ResponseWrapper{})
 	require.NoError(t, err)
-	require.Equal(t, 1, manager.calls)
 
 	var updated v1.MCPServer
 	require.NoError(t, storageClient.Get(t.Context(), router.Key(server.Namespace, server.Name), &updated))

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -60,6 +60,7 @@ type Handler struct {
 	accessControlRuleHelper   *accesscontrolrule.Helper
 	remoteURLValidationConfig mcp.ValidationOptions
 	mcpBackend                string
+	mcpSessionManager         *mcp.SessionManager
 }
 
 func New(defaultCatalogPath, defaultSystemCatalogPath string, gatewayClient *gclient.Client, accessControlRuleHelper *accesscontrolrule.Helper, mcpSessionManager *mcp.SessionManager) *Handler {
@@ -67,7 +68,6 @@ func New(defaultCatalogPath, defaultSystemCatalogPath string, gatewayClient *gcl
 	validationOptions := mcp.ValidationOptions{
 		RemoteMCPURLValidationConfig: remoteURLValidationConfig,
 	}
-	validationOptions.ResourceMaximums = mcpSessionManager.KubernetesResourceMaximums()
 
 	return &Handler{
 		defaultCatalogPath:       defaultCatalogPath,
@@ -81,11 +81,18 @@ func New(defaultCatalogPath, defaultSystemCatalogPath string, gatewayClient *gcl
 		accessControlRuleHelper:   accessControlRuleHelper,
 		remoteURLValidationConfig: validationOptions,
 		mcpBackend:                mcpSessionManager.MCPRuntimeBackend(),
+		mcpSessionManager:         mcpSessionManager,
 	}
 }
 
 func (h *Handler) Sync(req router.Request, resp router.Response) error {
 	mcpCatalog := req.Object.(*v1.MCPCatalog)
+	maximums, err := h.mcpSessionManager.EffectiveKubernetesResourceMaximums(req.Ctx, req.Client)
+	if err != nil {
+		return fmt.Errorf("failed to get effective resource maximums: %w", err)
+	}
+	validationOptions := h.remoteURLValidationConfig
+	validationOptions.ResourceMaximums = maximums
 
 	forceSync := mcpCatalog.Annotations[v1.MCPCatalogSyncAnnotation] == "true" || mcpCatalog.Annotations[forceSyncStartupAnnotation] != startupSyncGeneration
 	if !forceSync && !mcpCatalog.Status.LastSyncTime.IsZero() {
@@ -129,7 +136,7 @@ func (h *Handler) Sync(req router.Request, resp router.Response) error {
 			mcpCatalog.Status.SyncErrors[sourceURL] = err.Error()
 			continue
 		}
-		objs, err := h.readMCPCatalog(req.Ctx, mcpCatalog.Name, sourceURL, token)
+		objs, err := h.readMCPCatalog(req.Ctx, mcpCatalog.Name, sourceURL, token, validationOptions)
 		if err != nil {
 			log.Errorf("failed to read catalog %s: %v", sourceURL, err)
 			mcpCatalog.Status.SyncErrors[sourceURL] = err.Error()
@@ -149,7 +156,7 @@ func (h *Handler) Sync(req router.Request, resp router.Response) error {
 		addSyncError(mcpCatalog.Status.SyncErrors, sourceURL, errMsg)
 	}
 
-	toAdd, compositeRefErrors := h.resolveCompositeSourceRefs(req.Ctx, req.Client, mcpCatalog.Namespace, mcpCatalog.Name, toAdd)
+	toAdd, compositeRefErrors := h.resolveCompositeSourceRefs(req.Ctx, req.Client, mcpCatalog.Namespace, mcpCatalog.Name, toAdd, validationOptions)
 	for sourceURL, errMsg := range compositeRefErrors {
 		addSyncError(mcpCatalog.Status.SyncErrors, sourceURL, errMsg)
 	}
@@ -354,7 +361,11 @@ func detachCatalogEntry(ctx context.Context, c client.Client, catalog *v1.MCPCat
 // resolveCompositeSourceRefs rewrites GitOps portable component refs to stored
 // catalog entry names and snapshots the target manifests. Entries with invalid
 // portable refs are skipped so bad composites do not get applied.
-func (h *Handler) resolveCompositeSourceRefs(ctx context.Context, c client.Client, namespace, catalogName string, objs []client.Object) ([]client.Object, map[string]string) {
+func (h *Handler) resolveCompositeSourceRefs(ctx context.Context, c client.Client, namespace, catalogName string, objs []client.Object, options ...mcp.ValidationOptions) ([]client.Object, map[string]string) {
+	validationOptions := h.remoteURLValidationConfig
+	if len(options) > 0 {
+		validationOptions = options[0]
+	}
 	refs := make(map[string]*v1.MCPServerCatalogEntry)
 	entriesByName := make(map[string]*v1.MCPServerCatalogEntry)
 	for _, obj := range objs {
@@ -441,7 +452,7 @@ func (h *Handler) resolveCompositeSourceRefs(ctx context.Context, c client.Clien
 
 		if changed {
 			if err := catalogvalidation.ValidateManifest(ctx, entry.Spec.Manifest, catalogvalidation.ValidationOptions{
-				MCP:        h.remoteURLValidationConfig,
+				MCP:        validationOptions,
 				MCPBackend: h.mcpBackend,
 				GitManaged: entry.IsGitManaged(),
 			}); err != nil {
@@ -664,7 +675,11 @@ func systemCatalogEntryManifestToMCP(manifest types.SystemMCPServerCatalogEntryM
 	}
 }
 
-func (h *Handler) readMCPCatalog(ctx context.Context, catalogName, sourceURL, token string) ([]client.Object, error) {
+func (h *Handler) readMCPCatalog(ctx context.Context, catalogName, sourceURL, token string, options ...mcp.ValidationOptions) ([]client.Object, error) {
+	validationOptions := h.remoteURLValidationConfig
+	if len(options) > 0 {
+		validationOptions = options[0]
+	}
 	entries, err := readCatalogManifests[types.MCPServerCatalogEntryManifest](ctx, h.httpClient, sourceURL, token)
 	if err != nil {
 		return nil, err
@@ -713,7 +728,7 @@ func (h *Handler) readMCPCatalog(ctx context.Context, catalogName, sourceURL, to
 
 		catalogvalidation.NormalizeManifest(&entry)
 		if err := catalogvalidation.ValidateManifest(ctx, entry, catalogvalidation.ValidationOptions{
-			MCP:        h.remoteURLValidationConfig,
+			MCP:        validationOptions,
 			MCPBackend: h.mcpBackend,
 			GitManaged: catalogEntry.IsGitManaged(),
 		}); err != nil {

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -247,8 +247,13 @@ func (h *Handler) DetectK8sSettingsDrift(req router.Request, _ router.Response) 
 		return fmt.Errorf("failed to compute core resource requirements: %w", err)
 	}
 
-	resourceMaximums := h.mcpSessionManager.EffectiveKubernetesResourceMaximumsForSettings(k8sSettings.Spec)
-	currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "", resourceMaximums, imagePullSecretNames)
+	currentHash := mcp.ComputeK8sSettingsHash(
+		k8sSettings.Spec,
+		resources,
+		server.Spec.Manifest.Runtime,
+		server.Spec.NanobotAgentID != "",
+		imagePullSecretNames,
+	)
 	shouldSetNeedsK8sUpdate := server.Status.K8sSettingsHash != currentHash && !server.Status.NeedsK8sUpdate
 
 	if shouldSetNeedsK8sUpdate {

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -247,7 +247,7 @@ func (h *Handler) DetectK8sSettingsDrift(req router.Request, _ router.Response) 
 		return fmt.Errorf("failed to compute core resource requirements: %w", err)
 	}
 
-	resourceMaximums := h.mcpSessionManager.KubernetesResourceMaximums()
+	resourceMaximums := h.mcpSessionManager.EffectiveKubernetesResourceMaximumsForSettings(k8sSettings.Spec)
 	currentHash := mcp.ComputeK8sSettingsHash(k8sSettings.Spec, resources, server.Spec.Manifest.Runtime, server.Spec.NanobotAgentID != "", resourceMaximums, imagePullSecretNames)
 	shouldSetNeedsK8sUpdate := server.Status.K8sSettingsHash != currentHash && !server.Status.NeedsK8sUpdate
 

--- a/pkg/controller/k8ssettings_test.go
+++ b/pkg/controller/k8ssettings_test.go
@@ -78,3 +78,43 @@ func TestEnsureK8sSettingsAllowsStartupMaximumsWithoutConfiguredResources(t *tes
 	require.Nil(t, settings.Spec.Resources)
 	require.Nil(t, settings.Spec.NanobotAgentResources)
 }
+
+func TestEnsureK8sSettingsLocksMaximumsConfiguredThroughHelm(t *testing.T) {
+	ctx := t.Context()
+	existingResources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+	}
+	client := newFakeClient(t, &v1.K8sSettings{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      system.K8sSettingsName,
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.K8sSettingsSpec{Resources: existingResources},
+	})
+	maximum := resource.MustParse("2Gi")
+
+	require.NoError(t, ensureK8sSettings(ctx, client, &v1.K8sSettingsSpec{
+		MaximumsSetViaHelm: true,
+		MaxMemoryLimit:     &maximum,
+	}, nil, mcp.ResourceMaximums{MemoryLimit: &maximum}))
+
+	var settings v1.K8sSettings
+	require.NoError(t, client.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      system.K8sSettingsName,
+	}, &settings))
+	require.False(t, settings.Spec.SetViaHelm)
+	require.True(t, settings.Spec.MaximumsSetViaHelm)
+	require.Equal(t, existingResources, settings.Spec.Resources)
+	require.NotNil(t, settings.Spec.MaxMemoryLimit)
+	require.Zero(t, settings.Spec.MaxMemoryLimit.Cmp(maximum))
+
+	require.NoError(t, ensureK8sSettings(ctx, client, nil, nil, mcp.ResourceMaximums{}))
+	require.NoError(t, client.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      system.K8sSettingsName,
+	}, &settings))
+	require.False(t, settings.Spec.MaximumsSetViaHelm)
+	require.Nil(t, settings.Spec.MaxMemoryLimit)
+	require.Equal(t, existingResources, settings.Spec.Resources)
+}

--- a/pkg/mcp/action.go
+++ b/pkg/mcp/action.go
@@ -169,10 +169,14 @@ func (sm *SessionManager) serverOrInstanceFromConnectURL(ctx context.Context, id
 			if err != nil {
 				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrBadRequest("catalog entry %s cannot be connected because it could not be converted to an MCP server: %v", id, err)
 			}
+			resourceMaximums, err := sm.EffectiveKubernetesResourceMaximums(ctx, sm.storageClient)
+			if err != nil {
+				return v1.MCPServer{}, v1.MCPServerInstance{}, err
+			}
 			if err := ValidateServerManifest(ctx, manifest, false, ValidationOptions{
 				AllowMissingURL:              allowMissingURL,
 				RemoteMCPURLValidationConfig: sm.remoteURLValidationConfig,
-				ResourceMaximums:             sm.resourceMaximums,
+				ResourceMaximums:             resourceMaximums,
 			}); err != nil {
 				return v1.MCPServer{}, v1.MCPServerInstance{}, types.NewErrBadRequest("catalog entry %s cannot be connected because its MCP server manifest is invalid: %v", id, err)
 			}

--- a/pkg/mcp/action_test.go
+++ b/pkg/mcp/action_test.go
@@ -9,6 +9,7 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -64,4 +65,60 @@ func TestServerOrInstanceFromConnectURLCreatesRemoteServerThatNeedsUserURL(t *te
 	require.NotNil(t, server.Spec.Manifest.RemoteConfig)
 	require.Equal(t, "api.example.com", server.Spec.Manifest.RemoteConfig.Hostname)
 	require.Empty(t, server.Spec.Manifest.RemoteConfig.URL)
+}
+
+func TestServerOrInstanceFromConnectURLRejectsResourcesAbovePersistedMaximum(t *testing.T) {
+	const (
+		entryID = "catalog-entry"
+		userID  = "user-1"
+	)
+
+	maximum := resource.MustParse("500m")
+	entry := &v1.MCPServerCatalogEntry{
+		ObjectMeta: metav1.ObjectMeta{Name: entryID, Namespace: system.DefaultNamespace},
+		Spec: v1.MCPServerCatalogEntrySpec{
+			Manifest: types.MCPServerCatalogEntryManifest{
+				ServerUserType: types.ServerUserTypeSingleUser,
+				Runtime:        types.RuntimeNPX,
+				NPXConfig:      &types.NPXRuntimeConfig{Package: "example"},
+				Resources: &types.MCPResourceRequirements{
+					Requests: types.MCPResourceRequests{CPU: "1"},
+				},
+			},
+		},
+	}
+	settings := &v1.K8sSettings{
+		ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+		Spec:       v1.K8sSettingsSpec{MaxCPURequest: &maximum},
+	}
+
+	storageClient := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(entry, settings).
+		WithIndex(&v1.MCPServer{}, "spec.mcpServerCatalogEntryName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.MCPServerCatalogEntryName}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.userID", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.UserID}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.template", func(obj kclient.Object) []string {
+			return []string{strconv.FormatBool(obj.(*v1.MCPServer).Spec.Template)}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.compositeName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.CompositeName}
+		}).
+		Build()
+
+	manager := SessionManager{
+		runtimeBackend: RuntimeBackendKubernetes,
+		storageClient:  storageClient,
+	}
+	server, instance, err := manager.serverOrInstanceFromConnectURL(t.Context(), entryID, userID)
+	require.ErrorContains(t, err, "resources.requests.cpu 1 exceeds configured maximum 500m")
+	require.Empty(t, server.Name)
+	require.Empty(t, instance.Name)
+
+	var servers v1.MCPServerList
+	require.NoError(t, storageClient.List(t.Context(), &servers))
+	require.Empty(t, servers.Items)
 }

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -988,6 +988,7 @@ func mcpContainerResources(serverSpecificResources *corev1.ResourceRequirements,
 }
 
 func mcpContainerResourcesWithMaximums(serverSpecificResources *corev1.ResourceRequirements, runtime types.Runtime, nanobotAgent bool, k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) corev1.ResourceRequirements {
+	maximums = ResourceMaximumsFromK8sSettings(k8sSettings, maximums)
 	defaults, implicitMemoryRequest := mcpContainerDefaultResources(runtime, nanobotAgent, k8sSettings)
 	defaults = withImplicitResourceMaximums(defaults, implicitMemoryRequest, maximums)
 	return withServerResourceOverrides(defaults, serverSpecificResources)

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -60,7 +60,6 @@ type kubernetesBackend struct {
 	imagePullSecrets  []string
 	authEnabled       bool
 	obotClient        kclient.Client
-	resourceMaximums  ResourceMaximums
 	deploymentCacheMu sync.RWMutex
 	deploymentCache   map[string]*kubernetesDeploymentCacheEntry
 }
@@ -70,7 +69,15 @@ type kubernetesDeploymentCacheEntry struct {
 	podName string
 }
 
-func newKubernetesBackend(httpListenPort int, authEnabled bool, clientset *kubernetes.Clientset, client, cachedClient, obotClient kclient.WithWatch, opts Options, resourceMaximums ResourceMaximums) backend {
+func newKubernetesBackend(
+	httpListenPort int,
+	authEnabled bool,
+	clientset *kubernetes.Clientset,
+	client kclient.WithWatch,
+	cachedClient kclient.WithWatch,
+	obotClient kclient.WithWatch,
+	opts Options,
+) backend {
 	var serviceFQDN string
 	if opts.ServiceName != "" && opts.ServiceNamespace != "" {
 		serviceFQDN = fmt.Sprintf("%s.%s.svc.%s", opts.ServiceName, opts.ServiceNamespace, opts.MCPClusterDomain)
@@ -88,7 +95,6 @@ func newKubernetesBackend(httpListenPort int, authEnabled bool, clientset *kuber
 		authEnabled:      authEnabled,
 		imagePullSecrets: opts.MCPImagePullSecrets,
 		obotClient:       obotClient,
-		resourceMaximums: resourceMaximums,
 		deploymentCache:  map[string]*kubernetesDeploymentCacheEntry{},
 	}
 }
@@ -486,15 +492,25 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 	// Fetch K8s settings
 	k8sSettings := k.getK8sSettings(ctx)
 
-	maximums := ResourceMaximumsFromK8sSettings(k8sSettings, k.resourceMaximums)
-	mcpResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, maximums)
+	mcpResources := mcpContainerResources(
+		server.Resources,
+		server.Runtime,
+		server.NanobotAgentName != "",
+		k8sSettings,
+	)
 
 	effectiveImagePullSecrets, err := k.effectiveImagePullSecretNames(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get effective image pull secrets: %w", err)
 	}
 
-	annotations["obot.ai/k8s-settings-hash"] = ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", k.resourceMaximums, effectiveImagePullSecrets)
+	annotations["obot.ai/k8s-settings-hash"] = ComputeK8sSettingsHash(
+		k8sSettings,
+		server.Resources,
+		server.Runtime,
+		server.NanobotAgentName != "",
+		effectiveImagePullSecrets,
+	)
 
 	// Get PSA enforce level for security context decisions
 	psaLevel := GetPSAEnforceLevelFromSpec(k8sSettings)
@@ -985,7 +1001,7 @@ func (k *kubernetesBackend) deleteDeploymentCache(mcpServerName string) {
 }
 
 func mcpContainerResources(serverSpecificResources *corev1.ResourceRequirements, runtime types.Runtime, nanobotAgent bool, k8sSettings v1.K8sSettingsSpec) corev1.ResourceRequirements {
-	maximums := ResourceMaximumsFromK8sSettings(k8sSettings, ResourceMaximums{})
+	maximums := EffectiveResourceMaximums(k8sSettings, ResourceMaximums{})
 	return mcpContainerResourcesWithMaximums(serverSpecificResources, runtime, nanobotAgent, k8sSettings, maximums)
 }
 
@@ -1031,10 +1047,6 @@ func withImplicitResourceMaximums(resources corev1.ResourceRequirements, implici
 
 func EffectiveDefaultMCPResourceRequirements(k8sSettings v1.K8sSettingsSpec) corev1.ResourceRequirements {
 	return mcpContainerResources(nil, types.RuntimeNPX, false, k8sSettings)
-}
-
-func EffectiveDefaultMCPResourceRequirementsWithMaximums(k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) corev1.ResourceRequirements {
-	return mcpContainerResourcesWithMaximums(nil, types.RuntimeNPX, false, k8sSettings, maximums)
 }
 
 func withServerResourceOverrides(defaults corev1.ResourceRequirements, overrides *corev1.ResourceRequirements) corev1.ResourceRequirements {
@@ -1096,9 +1108,19 @@ func (k *kubernetesBackend) restartServer(ctx context.Context, server ServerConf
 	}
 
 	// Compute K8s settings hash
-	k8sSettingsHash := ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", k.resourceMaximums, effectiveImagePullSecrets)
-	maximums := ResourceMaximumsFromK8sSettings(k8sSettings, k.resourceMaximums)
-	desiredResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, maximums)
+	k8sSettingsHash := ComputeK8sSettingsHash(
+		k8sSettings,
+		server.Resources,
+		server.Runtime,
+		server.NanobotAgentName != "",
+		effectiveImagePullSecrets,
+	)
+	desiredResources := mcpContainerResources(
+		server.Resources,
+		server.Runtime,
+		server.NanobotAgentName != "",
+		k8sSettings,
+	)
 
 	// Get PSA enforce level for security context decisions
 	psaLevel := GetPSAEnforceLevelFromSpec(k8sSettings)
@@ -1696,7 +1718,13 @@ func getPodSecurityContextPatch(psaLevel PSAEnforceLevel) map[string]any {
 // MCP Deployment needs to be updated. The API/status field is still named
 // K8sSettingsHash, but managed image pull secret names are part of the same
 // v1 drift path.
-func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverSpecificResources *corev1.ResourceRequirements, serverRuntime types.Runtime, nanobotAgentServer bool, maximums ResourceMaximums, imagePullSecretNames []string) string {
+func ComputeK8sSettingsHash(
+	settings v1.K8sSettingsSpec,
+	serverSpecificResources *corev1.ResourceRequirements,
+	serverRuntime types.Runtime,
+	nanobotAgentServer bool,
+	imagePullSecretNames []string,
+) string {
 	var buf bytes.Buffer
 
 	// Hash affinity
@@ -1712,11 +1740,10 @@ func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverSpecificResources
 	}
 
 	// Resources are server specific. Hash the same effective resources that are
-	// applied to the Deployment, including ResourceMaximums capping implicit
-	// built-in defaults.
+	// applied to the Deployment, including maximums from K8sSettings capping
+	// implicit built-in defaults.
 	// Ignoring errors from JSON encoding since the inputs are well-defined structs that should always marshal successfully
-	effectiveMaximums := ResourceMaximumsFromK8sSettings(settings, maximums)
-	_ = json.NewEncoder(&buf).Encode(mcpContainerResourcesWithMaximums(serverSpecificResources, serverRuntime, nanobotAgentServer, settings, effectiveMaximums))
+	_ = json.NewEncoder(&buf).Encode(mcpContainerResources(serverSpecificResources, serverRuntime, nanobotAgentServer, settings))
 
 	// Hash runtimeClassName
 	if settings.RuntimeClassName != nil && *settings.RuntimeClassName != "" {
@@ -1942,8 +1969,12 @@ func (k *kubernetesBackend) CheckCapacity(ctx context.Context, server ServerConf
 
 	memoryRequest := resource.MustParse("0")
 	cpuRequest := resource.MustParse("0")
-	maximums := ResourceMaximumsFromK8sSettings(k8sSettings, k.resourceMaximums)
-	resources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, maximums)
+	resources := mcpContainerResources(
+		server.Resources,
+		server.Runtime,
+		server.NanobotAgentName != "",
+		k8sSettings,
+	)
 	if mem, ok := resources.Requests[corev1.ResourceMemory]; ok {
 		memoryRequest = mem
 	}

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -486,7 +486,8 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 	// Fetch K8s settings
 	k8sSettings := k.getK8sSettings(ctx)
 
-	mcpResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, k.resourceMaximums)
+	maximums := ResourceMaximumsFromK8sSettings(k8sSettings, k.resourceMaximums)
+	mcpResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, maximums)
 
 	effectiveImagePullSecrets, err := k.effectiveImagePullSecretNames(ctx)
 	if err != nil {
@@ -984,11 +985,11 @@ func (k *kubernetesBackend) deleteDeploymentCache(mcpServerName string) {
 }
 
 func mcpContainerResources(serverSpecificResources *corev1.ResourceRequirements, runtime types.Runtime, nanobotAgent bool, k8sSettings v1.K8sSettingsSpec) corev1.ResourceRequirements {
-	return mcpContainerResourcesWithMaximums(serverSpecificResources, runtime, nanobotAgent, k8sSettings, ResourceMaximums{})
+	maximums := ResourceMaximumsFromK8sSettings(k8sSettings, ResourceMaximums{})
+	return mcpContainerResourcesWithMaximums(serverSpecificResources, runtime, nanobotAgent, k8sSettings, maximums)
 }
 
 func mcpContainerResourcesWithMaximums(serverSpecificResources *corev1.ResourceRequirements, runtime types.Runtime, nanobotAgent bool, k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) corev1.ResourceRequirements {
-	maximums = ResourceMaximumsFromK8sSettings(k8sSettings, maximums)
 	defaults, implicitMemoryRequest := mcpContainerDefaultResources(runtime, nanobotAgent, k8sSettings)
 	defaults = withImplicitResourceMaximums(defaults, implicitMemoryRequest, maximums)
 	return withServerResourceOverrides(defaults, serverSpecificResources)
@@ -1096,7 +1097,8 @@ func (k *kubernetesBackend) restartServer(ctx context.Context, server ServerConf
 
 	// Compute K8s settings hash
 	k8sSettingsHash := ComputeK8sSettingsHash(k8sSettings, server.Resources, server.Runtime, server.NanobotAgentName != "", k.resourceMaximums, effectiveImagePullSecrets)
-	desiredResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, k.resourceMaximums)
+	maximums := ResourceMaximumsFromK8sSettings(k8sSettings, k.resourceMaximums)
+	desiredResources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, maximums)
 
 	// Get PSA enforce level for security context decisions
 	psaLevel := GetPSAEnforceLevelFromSpec(k8sSettings)
@@ -1713,7 +1715,8 @@ func ComputeK8sSettingsHash(settings v1.K8sSettingsSpec, serverSpecificResources
 	// applied to the Deployment, including ResourceMaximums capping implicit
 	// built-in defaults.
 	// Ignoring errors from JSON encoding since the inputs are well-defined structs that should always marshal successfully
-	_ = json.NewEncoder(&buf).Encode(mcpContainerResourcesWithMaximums(serverSpecificResources, serverRuntime, nanobotAgentServer, settings, maximums))
+	effectiveMaximums := ResourceMaximumsFromK8sSettings(settings, maximums)
+	_ = json.NewEncoder(&buf).Encode(mcpContainerResourcesWithMaximums(serverSpecificResources, serverRuntime, nanobotAgentServer, settings, effectiveMaximums))
 
 	// Hash runtimeClassName
 	if settings.RuntimeClassName != nil && *settings.RuntimeClassName != "" {
@@ -1939,7 +1942,8 @@ func (k *kubernetesBackend) CheckCapacity(ctx context.Context, server ServerConf
 
 	memoryRequest := resource.MustParse("0")
 	cpuRequest := resource.MustParse("0")
-	resources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, k.resourceMaximums)
+	maximums := ResourceMaximumsFromK8sSettings(k8sSettings, k.resourceMaximums)
+	resources := mcpContainerResourcesWithMaximums(server.Resources, server.Runtime, server.NanobotAgentName != "", k8sSettings, maximums)
 	if mem, ok := resources.Requests[corev1.ResourceMemory]; ok {
 		memoryRequest = mem
 	}

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -44,32 +44,99 @@ func TestComputeK8sSettingsHashUsesServerSpecificResources(t *testing.T) {
 		},
 	}
 
-	baseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil)
-	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil); got == baseHash {
+	baseHash := ComputeK8sSettingsHash(
+		baseSettings,
+		nil,
+		types.RuntimeNPX,
+		false,
+		nil,
+	)
+	if got := ComputeK8sSettingsHash(
+		resourceSettings,
+		nil,
+		types.RuntimeNPX,
+		false,
+		nil,
+	); got == baseHash {
 		t.Fatalf("regular server hash = %s, want it to differ when default resources are set", got)
 	}
 
-	remoteBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeRemote, false, ResourceMaximums{}, nil)
-	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeRemote, false, ResourceMaximums{}, nil); got != remoteBaseHash {
+	remoteBaseHash := ComputeK8sSettingsHash(
+		baseSettings,
+		nil,
+		types.RuntimeRemote,
+		false,
+		nil,
+	)
+	if got := ComputeK8sSettingsHash(
+		resourceSettings,
+		nil,
+		types.RuntimeRemote,
+		false,
+		nil,
+	); got != remoteBaseHash {
 		t.Fatalf("remote server hash = %s, want %s", got, remoteBaseHash)
 	}
 
-	compositeBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeComposite, false, ResourceMaximums{}, nil)
-	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeComposite, false, ResourceMaximums{}, nil); got != compositeBaseHash {
+	compositeBaseHash := ComputeK8sSettingsHash(
+		baseSettings,
+		nil,
+		types.RuntimeComposite,
+		false,
+		nil,
+	)
+	if got := ComputeK8sSettingsHash(
+		resourceSettings,
+		nil,
+		types.RuntimeComposite,
+		false,
+		nil,
+	); got != compositeBaseHash {
 		t.Fatalf("composite server hash = %s, want %s", got, compositeBaseHash)
 	}
 	if compositeBaseHash != remoteBaseHash {
 		t.Fatalf("composite base hash = %s, want remote base hash %s", compositeBaseHash, remoteBaseHash)
 	}
 
-	nanobotBaseHash := ComputeK8sSettingsHash(baseSettings, nil, types.RuntimeNPX, true, ResourceMaximums{}, nil)
-	if got := ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, true, ResourceMaximums{}, nil); got != nanobotBaseHash {
+	nanobotBaseHash := ComputeK8sSettingsHash(
+		baseSettings,
+		nil,
+		types.RuntimeNPX,
+		true,
+		nil,
+	)
+	if got := ComputeK8sSettingsHash(
+		resourceSettings,
+		nil,
+		types.RuntimeNPX,
+		true,
+		nil,
+	); got != nanobotBaseHash {
 		t.Fatalf("nanobot agent server hash = %s, want %s before nanobot-only settings are set", got, nanobotBaseHash)
 	}
-	if got := ComputeK8sSettingsHash(nanobotSettings, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil); got != ComputeK8sSettingsHash(resourceSettings, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil) {
+	regularHash := ComputeK8sSettingsHash(
+		resourceSettings,
+		nil,
+		types.RuntimeNPX,
+		false,
+		nil,
+	)
+	if got := ComputeK8sSettingsHash(
+		nanobotSettings,
+		nil,
+		types.RuntimeNPX,
+		false,
+		nil,
+	); got != regularHash {
 		t.Fatalf("non-nanobot hash = %s, want nanobot-only settings ignored", got)
 	}
-	if got := ComputeK8sSettingsHash(nanobotSettings, nil, types.RuntimeNPX, true, ResourceMaximums{}, nil); got == nanobotBaseHash {
+	if got := ComputeK8sSettingsHash(
+		nanobotSettings,
+		nil,
+		types.RuntimeNPX,
+		true,
+		nil,
+	); got == nanobotBaseHash {
 		t.Fatalf("nanobot hash = %s, want it to differ when nanobot-only settings are set", got)
 	}
 
@@ -78,17 +145,35 @@ func TestComputeK8sSettingsHashUsesServerSpecificResources(t *testing.T) {
 			corev1.ResourceMemory: resource.MustParse("768Mi"),
 		},
 	}
-	if got := ComputeK8sSettingsHash(baseSettings, serverResources, types.RuntimeNPX, false, ResourceMaximums{}, nil); got == baseHash {
+	if got := ComputeK8sSettingsHash(
+		baseSettings,
+		serverResources,
+		types.RuntimeNPX,
+		false,
+		nil,
+	); got == baseHash {
 		t.Fatalf("server-specific resources hash = %s, want it to differ from default resource hash", got)
 	}
 }
 
-func TestComputeK8sSettingsHashUsesImplicitResourceMaximums(t *testing.T) {
-	baseHash := ComputeK8sSettingsHash(v1.K8sSettingsSpec{}, nil, types.RuntimeNPX, false, ResourceMaximums{}, nil)
-	cappedHash := ComputeK8sSettingsHash(v1.K8sSettingsSpec{}, nil, types.RuntimeNPX, false, ResourceMaximums{
-		CPURequest:    new(resource.MustParse("5m")),
-		MemoryRequest: new(resource.MustParse("128Mi")),
-	}, nil)
+func TestComputeK8sSettingsHashUsesSettingsResourceMaximums(t *testing.T) {
+	baseHash := ComputeK8sSettingsHash(
+		v1.K8sSettingsSpec{},
+		nil,
+		types.RuntimeNPX,
+		false,
+		nil,
+	)
+	cappedHash := ComputeK8sSettingsHash(
+		v1.K8sSettingsSpec{
+			MaxCPURequest:    new(resource.MustParse("5m")),
+			MaxMemoryRequest: new(resource.MustParse("128Mi")),
+		},
+		nil,
+		types.RuntimeNPX,
+		false,
+		nil,
+	)
 	if cappedHash == baseHash {
 		t.Fatalf("capped hash = %s, want it to differ from uncapped implicit defaults", cappedHash)
 	}
@@ -300,7 +385,19 @@ func TestNewKubernetesBackend_ServiceFQDN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			backend := newKubernetesBackend(0, true, nil, nil, nil, nil, Options{ServiceName: tt.serviceName, ServiceNamespace: tt.serviceNamespace, MCPClusterDomain: tt.clusterDomain}, ResourceMaximums{})
+			backend := newKubernetesBackend(
+				0,
+				true,
+				nil,
+				nil,
+				nil,
+				nil,
+				Options{
+					ServiceName:      tt.serviceName,
+					ServiceNamespace: tt.serviceNamespace,
+					MCPClusterDomain: tt.clusterDomain,
+				},
+			)
 			k := backend.(*kubernetesBackend)
 			if k.serviceFQDN != tt.expectedFQDN {
 				t.Errorf("newKubernetesBackend() serviceFQDN = %v, want %v", k.serviceFQDN, tt.expectedFQDN)
@@ -485,7 +582,6 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 		name              string
 		server            ServerConfig
 		settings          *v1.K8sSettings
-		resourceMaximums  ResourceMaximums
 		wantCPURequest    string
 		wantMemoryRequest string
 		wantMemoryLimit   string
@@ -502,9 +598,12 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 			server: ServerConfig{
 				Runtime: types.RuntimeContainerized,
 			},
-			resourceMaximums: ResourceMaximums{
-				CPURequest:    new(resource.MustParse("5m")),
-				MemoryRequest: new(resource.MustParse("128Mi")),
+			settings: &v1.K8sSettings{
+				ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+				Spec: v1.K8sSettingsSpec{
+					MaxCPURequest:    new(resource.MustParse("5m")),
+					MaxMemoryRequest: new(resource.MustParse("128Mi")),
+				},
 			},
 			wantCPURequest:    "5m",
 			wantMemoryRequest: "128Mi",
@@ -523,9 +622,12 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 				Runtime:          types.RuntimeContainerized,
 				NanobotAgentName: "agent-1",
 			},
-			resourceMaximums: ResourceMaximums{
-				CPURequest:    new(resource.MustParse("5m")),
-				MemoryRequest: new(resource.MustParse("256Mi")),
+			settings: &v1.K8sSettings{
+				ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+				Spec: v1.K8sSettingsSpec{
+					MaxCPURequest:    new(resource.MustParse("5m")),
+					MaxMemoryRequest: new(resource.MustParse("256Mi")),
+				},
 			},
 			wantCPURequest:    "5m",
 			wantMemoryRequest: "256Mi",
@@ -563,7 +665,6 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			k := newTestKubernetesBackend(t)
-			k.resourceMaximums = tt.resourceMaximums
 			if tt.settings != nil {
 				scheme := runtime.NewScheme()
 				if err := v1.AddToScheme(scheme); err != nil {
@@ -612,20 +713,38 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 	}
 }
 
-func TestK8sObjectsAllowsSystemServerResourcesAboveMaximum(t *testing.T) {
-	k := newTestKubernetesBackend(t)
-	k.resourceMaximums = ResourceMaximums{CPURequest: new(resource.MustParse("100m"))}
-
-	server := testK8sServerConfig()
-	server.SystemMCPServer = true
-	server.Resources = &corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceCPU: resource.MustParse("250m"),
+func TestK8sObjectsUsesStoredMaximums(t *testing.T) {
+	storedMaximum := resource.MustParse("20m")
+	settings := &v1.K8sSettings{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      system.K8sSettingsName,
+			Namespace: system.DefaultNamespace,
 		},
+		Spec: v1.K8sSettingsSpec{MaxCPURequest: &storedMaximum},
+	}
+	k := newTestKubernetesBackend(t, settings)
+	server := testK8sServerConfig()
+
+	objects, err := k.k8sObjects(t.Context(), server)
+	if err != nil {
+		t.Fatalf("k8sObjects() error = %v", err)
 	}
 
-	if _, err := k.k8sObjects(t.Context(), server); err != nil {
-		t.Fatalf("expected system MCP server resources to bypass maximums: %v", err)
+	deployment := findDeployment(t, objects, server.MCPServerName)
+	container := findContainer(t, deployment, "mcp")
+	if got := container.Resources.Requests[corev1.ResourceCPU]; got.Cmp(defaultCPURequest) != 0 {
+		t.Fatalf("CPU request = %s, want stored-settings result %s", got.String(), defaultCPURequest.String())
+	}
+
+	wantHash := ComputeK8sSettingsHash(
+		settings.Spec,
+		server.Resources,
+		server.Runtime,
+		server.NanobotAgentName != "",
+		nil,
+	)
+	if got := deployment.Annotations["obot.ai/k8s-settings-hash"]; got != wantHash {
+		t.Fatalf("K8s settings hash = %q, want %q", got, wantHash)
 	}
 }
 
@@ -1088,7 +1207,13 @@ func TestK8sObjects_ManagedImagePullSecrets(t *testing.T) {
 	dep := findDeployment(t, objs, "test-server")
 	assertImagePullSecrets(t, dep, []string{"managed-a", "managed-b"})
 
-	expectedHash := ComputeK8sSettingsHash(v1.K8sSettingsSpec{}, nil, types.RuntimeContainerized, false, ResourceMaximums{}, []string{"managed-b", "managed-a"})
+	expectedHash := ComputeK8sSettingsHash(
+		v1.K8sSettingsSpec{},
+		nil,
+		types.RuntimeContainerized,
+		false,
+		[]string{"managed-b", "managed-a"},
+	)
 	if dep.Annotations["obot.ai/k8s-settings-hash"] != expectedHash {
 		t.Fatalf("k8s settings hash = %q, want %q", dep.Annotations["obot.ai/k8s-settings-hash"], expectedHash)
 	}

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -212,15 +212,10 @@ func (sm *SessionManager) ResourceMaximums() ResourceMaximums {
 	return sm.resourceMaximums
 }
 
-func (sm *SessionManager) KubernetesResourceMaximums() ResourceMaximums {
-	if sm == nil || !IsKubernetesBackend(sm.runtimeBackend) {
-		return ResourceMaximums{}
-	}
-	return sm.resourceMaximums
-}
-
 func (sm *SessionManager) EffectiveKubernetesResourceMaximums(ctx context.Context, storageClient kclient.Client) (ResourceMaximums, error) {
-	maximums := sm.KubernetesResourceMaximums()
+	if sm == nil || !IsKubernetesBackend(sm.runtimeBackend) {
+		return ResourceMaximums{}, nil
+	}
 
 	var settings v1.K8sSettings
 	if err := storageClient.Get(ctx, kclient.ObjectKey{
@@ -228,12 +223,19 @@ func (sm *SessionManager) EffectiveKubernetesResourceMaximums(ctx context.Contex
 		Name:      system.K8sSettingsName,
 	}, &settings); err != nil {
 		if apierrors.IsNotFound(err) {
-			return maximums, nil
+			return ResourceMaximumsFromK8sSettings(v1.K8sSettingsSpec{}, sm.resourceMaximums), nil
 		}
 		return ResourceMaximums{}, fmt.Errorf("failed to get Kubernetes settings: %w", err)
 	}
 
-	return ResourceMaximumsFromK8sSettings(settings.Spec, maximums), nil
+	return ResourceMaximumsFromK8sSettings(settings.Spec, sm.resourceMaximums), nil
+}
+
+func (sm *SessionManager) EffectiveKubernetesResourceMaximumsForSettings(settings v1.K8sSettingsSpec) ResourceMaximums {
+	if sm == nil || !IsKubernetesBackend(sm.runtimeBackend) {
+		return ResourceMaximums{}
+	}
+	return ResourceMaximumsFromK8sSettings(settings, sm.resourceMaximums)
 }
 
 func (sm *SessionManager) TransformObotHostname(hostname string) string {

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -169,7 +169,15 @@ func NewSessionManager(ctx context.Context, authEnabled bool, globalTokenStore G
 			return nil, err
 		}
 
-		backend = newKubernetesBackend(httpListenPort, authEnabled, clientset, client, cachedClient, obotStorageClient, opts, resourceMaximums)
+		backend = newKubernetesBackend(
+			httpListenPort,
+			authEnabled,
+			clientset,
+			client,
+			cachedClient,
+			obotStorageClient,
+			opts,
+		)
 	default:
 		return nil, fmt.Errorf("unknown runtime backend: %s", opts.MCPRuntimeBackend)
 	}
@@ -212,7 +220,28 @@ func (sm *SessionManager) ResourceMaximums() ResourceMaximums {
 	return sm.resourceMaximums
 }
 
-func (sm *SessionManager) EffectiveKubernetesResourceMaximums(ctx context.Context, storageClient kclient.Client) (ResourceMaximums, error) {
+func (sm *SessionManager) EffectiveKubernetesResourceMaximums(
+	ctx context.Context,
+	storageClient kclient.Client,
+) (ResourceMaximums, error) {
+	return sm.kubernetesResourceMaximums(ctx, storageClient, ResourceMaximums{})
+}
+
+func (sm *SessionManager) StartupKubernetesResourceMaximums(
+	ctx context.Context,
+	storageClient kclient.Client,
+) (ResourceMaximums, error) {
+	if sm == nil {
+		return ResourceMaximums{}, nil
+	}
+	return sm.kubernetesResourceMaximums(ctx, storageClient, sm.resourceMaximums)
+}
+
+func (sm *SessionManager) kubernetesResourceMaximums(
+	ctx context.Context,
+	storageClient kclient.Client,
+	fallback ResourceMaximums,
+) (ResourceMaximums, error) {
 	if sm == nil || !IsKubernetesBackend(sm.runtimeBackend) {
 		return ResourceMaximums{}, nil
 	}
@@ -223,19 +252,21 @@ func (sm *SessionManager) EffectiveKubernetesResourceMaximums(ctx context.Contex
 		Name:      system.K8sSettingsName,
 	}, &settings); err != nil {
 		if apierrors.IsNotFound(err) {
-			return ResourceMaximumsFromK8sSettings(v1.K8sSettingsSpec{}, sm.resourceMaximums), nil
+			return fallback, nil
 		}
 		return ResourceMaximums{}, fmt.Errorf("failed to get Kubernetes settings: %w", err)
 	}
 
-	return ResourceMaximumsFromK8sSettings(settings.Spec, sm.resourceMaximums), nil
+	return EffectiveResourceMaximums(settings.Spec, fallback), nil
 }
 
-func (sm *SessionManager) EffectiveKubernetesResourceMaximumsForSettings(settings v1.K8sSettingsSpec) ResourceMaximums {
+func (sm *SessionManager) EffectiveKubernetesResourceMaximumsForSettings(
+	settings v1.K8sSettingsSpec,
+) ResourceMaximums {
 	if sm == nil || !IsKubernetesBackend(sm.runtimeBackend) {
 		return ResourceMaximums{}
 	}
-	return ResourceMaximumsFromK8sSettings(settings, sm.resourceMaximums)
+	return EffectiveResourceMaximums(settings, ResourceMaximums{})
 }
 
 func (sm *SessionManager) TransformObotHostname(hostname string) string {

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -15,9 +15,11 @@ import (
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/jwt/persistent"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/tunnel"
 	"github.com/obot-platform/obot/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -215,6 +217,23 @@ func (sm *SessionManager) KubernetesResourceMaximums() ResourceMaximums {
 		return ResourceMaximums{}
 	}
 	return sm.resourceMaximums
+}
+
+func (sm *SessionManager) EffectiveKubernetesResourceMaximums(ctx context.Context, storageClient kclient.Client) (ResourceMaximums, error) {
+	maximums := sm.KubernetesResourceMaximums()
+
+	var settings v1.K8sSettings
+	if err := storageClient.Get(ctx, kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      system.K8sSettingsName,
+	}, &settings); err != nil {
+		if apierrors.IsNotFound(err) {
+			return maximums, nil
+		}
+		return ResourceMaximums{}, fmt.Errorf("failed to get Kubernetes settings: %w", err)
+	}
+
+	return ResourceMaximumsFromK8sSettings(settings.Spec, maximums), nil
 }
 
 func (sm *SessionManager) TransformObotHostname(hostname string) string {

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -7,9 +7,44 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/tunnel"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestEffectiveKubernetesResourceMaximums(t *testing.T) {
+	maximum := resource.MustParse("500m")
+	storageClient := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(&v1.K8sSettings{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      system.K8sSettingsName,
+				Namespace: system.DefaultNamespace,
+			},
+			Spec: v1.K8sSettingsSpec{MaxCPURequest: &maximum},
+		}).
+		Build()
+
+	t.Run("Kubernetes backend uses persisted maximum", func(t *testing.T) {
+		manager := &SessionManager{runtimeBackend: RuntimeBackendKubernetes}
+		got, err := manager.EffectiveKubernetesResourceMaximums(t.Context(), storageClient)
+		require.NoError(t, err)
+		require.NotNil(t, got.CPURequest)
+		require.Zero(t, got.CPURequest.Cmp(maximum))
+	})
+
+	t.Run("non-Kubernetes backend ignores persisted maximum", func(t *testing.T) {
+		manager := &SessionManager{runtimeBackend: runtimeBackendDocker}
+		got, err := manager.EffectiveKubernetesResourceMaximums(t.Context(), nil)
+		require.NoError(t, err)
+		require.True(t, got.Empty())
+	})
+}
 
 func TestHTTPClientForServer(t *testing.T) {
 	const timeout = 3 * time.Second

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -38,6 +38,43 @@ func TestEffectiveKubernetesResourceMaximums(t *testing.T) {
 		require.Zero(t, got.CPURequest.Cmp(maximum))
 	})
 
+	t.Run("runtime ignores startup maximum", func(t *testing.T) {
+		startupMaximum := resource.MustParse("100m")
+		manager := &SessionManager{
+			runtimeBackend:   RuntimeBackendKubernetes,
+			resourceMaximums: ResourceMaximums{CPURequest: &startupMaximum},
+		}
+		got, err := manager.EffectiveKubernetesResourceMaximums(t.Context(), storageClient)
+		require.NoError(t, err)
+		require.NotNil(t, got.CPURequest)
+		require.Zero(t, got.CPURequest.Cmp(maximum))
+	})
+
+	t.Run("startup uses strictest persisted and configured maximum", func(t *testing.T) {
+		startupMaximum := resource.MustParse("100m")
+		manager := &SessionManager{
+			runtimeBackend:   RuntimeBackendKubernetes,
+			resourceMaximums: ResourceMaximums{CPURequest: &startupMaximum},
+		}
+		got, err := manager.StartupKubernetesResourceMaximums(t.Context(), storageClient)
+		require.NoError(t, err)
+		require.NotNil(t, got.CPURequest)
+		require.Zero(t, got.CPURequest.Cmp(startupMaximum))
+	})
+
+	t.Run("startup uses configured maximum before settings exist", func(t *testing.T) {
+		startupMaximum := resource.MustParse("100m")
+		manager := &SessionManager{
+			runtimeBackend:   RuntimeBackendKubernetes,
+			resourceMaximums: ResourceMaximums{CPURequest: &startupMaximum},
+		}
+		emptyStorageClient := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).Build()
+		got, err := manager.StartupKubernetesResourceMaximums(t.Context(), emptyStorageClient)
+		require.NoError(t, err)
+		require.NotNil(t, got.CPURequest)
+		require.Zero(t, got.CPURequest.Cmp(startupMaximum))
+	})
+
 	t.Run("non-Kubernetes backend ignores persisted maximum", func(t *testing.T) {
 		manager := &SessionManager{runtimeBackend: runtimeBackendDocker}
 		got, err := manager.EffectiveKubernetesResourceMaximums(t.Context(), nil)

--- a/pkg/mcp/resource_maximums.go
+++ b/pkg/mcp/resource_maximums.go
@@ -22,6 +22,24 @@ type ResourceMaximumExceededError struct {
 	Maximum resource.Quantity
 }
 
+func ResourceMaximumsFromK8sSettings(settings v1.K8sSettingsSpec, fallback ResourceMaximums) ResourceMaximums {
+	fallback.CPURequest = stricterResourceMaximum(fallback.CPURequest, settings.MaxCPURequest)
+	fallback.CPULimit = stricterResourceMaximum(fallback.CPULimit, settings.MaxCPULimit)
+	fallback.MemoryRequest = stricterResourceMaximum(fallback.MemoryRequest, settings.MaxMemoryRequest)
+	fallback.MemoryLimit = stricterResourceMaximum(fallback.MemoryLimit, settings.MaxMemoryLimit)
+	return fallback
+}
+
+func stricterResourceMaximum(a, b *resource.Quantity) *resource.Quantity {
+	if a == nil {
+		return b
+	}
+	if b == nil || a.Cmp(*b) <= 0 {
+		return a
+	}
+	return b
+}
+
 func (e *ResourceMaximumExceededError) Error() string {
 	return fmt.Sprintf("%s %s exceeds configured maximum %s", e.Field, e.Actual.String(), e.Maximum.String())
 }
@@ -105,6 +123,7 @@ func validateResourceMaximum(field string, resources corev1.ResourceList, resour
 }
 
 func ValidateK8sSettingsResourceMaximums(k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) error {
+	maximums = ResourceMaximumsFromK8sSettings(k8sSettings, maximums)
 	// Use the same capped default calculation as deployment so empty settings
 	// are allowed even when built-in fallback defaults are higher than maximums.
 	if err := maximums.Validate(mcpContainerResourcesWithMaximums(nil, types.RuntimeNPX, false, k8sSettings, maximums)); err != nil {
@@ -117,6 +136,7 @@ func ValidateK8sSettingsResourceMaximums(k8sSettings v1.K8sSettingsSpec, maximum
 }
 
 func ValidateConfiguredK8sSettingsResourceMaximums(k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) error {
+	maximums = ResourceMaximumsFromK8sSettings(k8sSettings, maximums)
 	if maximums.Empty() {
 		return nil
 	}

--- a/pkg/mcp/resource_maximums.go
+++ b/pkg/mcp/resource_maximums.go
@@ -123,7 +123,6 @@ func validateResourceMaximum(field string, resources corev1.ResourceList, resour
 }
 
 func ValidateK8sSettingsResourceMaximums(k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) error {
-	maximums = ResourceMaximumsFromK8sSettings(k8sSettings, maximums)
 	// Use the same capped default calculation as deployment so empty settings
 	// are allowed even when built-in fallback defaults are higher than maximums.
 	if err := maximums.Validate(mcpContainerResourcesWithMaximums(nil, types.RuntimeNPX, false, k8sSettings, maximums)); err != nil {
@@ -136,7 +135,6 @@ func ValidateK8sSettingsResourceMaximums(k8sSettings v1.K8sSettingsSpec, maximum
 }
 
 func ValidateConfiguredK8sSettingsResourceMaximums(k8sSettings v1.K8sSettingsSpec, maximums ResourceMaximums) error {
-	maximums = ResourceMaximumsFromK8sSettings(k8sSettings, maximums)
 	if maximums.Empty() {
 		return nil
 	}

--- a/pkg/mcp/resource_maximums.go
+++ b/pkg/mcp/resource_maximums.go
@@ -22,7 +22,7 @@ type ResourceMaximumExceededError struct {
 	Maximum resource.Quantity
 }
 
-func ResourceMaximumsFromK8sSettings(settings v1.K8sSettingsSpec, fallback ResourceMaximums) ResourceMaximums {
+func EffectiveResourceMaximums(settings v1.K8sSettingsSpec, fallback ResourceMaximums) ResourceMaximums {
 	fallback.CPURequest = stricterResourceMaximum(fallback.CPURequest, settings.MaxCPURequest)
 	fallback.CPULimit = stricterResourceMaximum(fallback.CPULimit, settings.MaxCPULimit)
 	fallback.MemoryRequest = stricterResourceMaximum(fallback.MemoryRequest, settings.MaxMemoryRequest)

--- a/pkg/mcp/resource_maximums_test.go
+++ b/pkg/mcp/resource_maximums_test.go
@@ -8,12 +8,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func TestResourceMaximumsFromK8sSettingsUsesStrictestMaximum(t *testing.T) {
+func TestEffectiveResourceMaximumsUsesStrictestMaximum(t *testing.T) {
 	t.Parallel()
 
 	startupCPU := resource.MustParse("2")
 	uiCPU := resource.MustParse("1")
-	got := ResourceMaximumsFromK8sSettings(v1.K8sSettingsSpec{
+	got := EffectiveResourceMaximums(v1.K8sSettingsSpec{
 		MaxCPURequest: &uiCPU,
 	}, ResourceMaximums{
 		CPURequest: &startupCPU,
@@ -25,7 +25,7 @@ func TestResourceMaximumsFromK8sSettingsUsesStrictestMaximum(t *testing.T) {
 
 	startupCPU = resource.MustParse("500m")
 	uiCPU = resource.MustParse("1")
-	got = ResourceMaximumsFromK8sSettings(v1.K8sSettingsSpec{
+	got = EffectiveResourceMaximums(v1.K8sSettingsSpec{
 		MaxCPURequest: &uiCPU,
 	}, ResourceMaximums{
 		CPURequest: &startupCPU,

--- a/pkg/mcp/resource_maximums_test.go
+++ b/pkg/mcp/resource_maximums_test.go
@@ -8,6 +8,33 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+func TestResourceMaximumsFromK8sSettingsUsesStrictestMaximum(t *testing.T) {
+	t.Parallel()
+
+	startupCPU := resource.MustParse("2")
+	uiCPU := resource.MustParse("1")
+	got := ResourceMaximumsFromK8sSettings(v1.K8sSettingsSpec{
+		MaxCPURequest: &uiCPU,
+	}, ResourceMaximums{
+		CPURequest: &startupCPU,
+	})
+
+	if got.CPURequest == nil || got.CPURequest.Cmp(uiCPU) != 0 {
+		t.Fatalf("CPU request maximum = %v, want %s", got.CPURequest, uiCPU.String())
+	}
+
+	startupCPU = resource.MustParse("500m")
+	uiCPU = resource.MustParse("1")
+	got = ResourceMaximumsFromK8sSettings(v1.K8sSettingsSpec{
+		MaxCPURequest: &uiCPU,
+	}, ResourceMaximums{
+		CPURequest: &startupCPU,
+	})
+	if got.CPURequest == nil || got.CPURequest.Cmp(startupCPU) != 0 {
+		t.Fatalf("CPU request maximum = %v, want startup ceiling %s", got.CPURequest, startupCPU.String())
+	}
+}
+
 func TestParseResourceMaximums(t *testing.T) {
 	maximums, err := ParseResourceMaximums(Options{
 		MCPK8sMaxCPURequest:    "500m",

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -351,8 +351,12 @@ func parsePodSchedulingSettingsFromHelm(opts mcp.Options) (*v1.K8sSettingsSpec, 
 		opts.MCPK8sSettingsRuntimeClassName != "" ||
 		opts.MCPK8sSettingsStorageClassName != "" ||
 		opts.MCPK8sSettingsNanobotWorkspaceSize != ""
+	hasMaximums := opts.MCPK8sMaxCPURequest != "" ||
+		opts.MCPK8sMaxCPULimit != "" ||
+		opts.MCPK8sMaxMemoryRequest != "" ||
+		opts.MCPK8sMaxMemoryLimit != ""
 
-	if !hasPodSettings {
+	if !hasPodSettings && !hasMaximums {
 		return nil, nil
 	}
 
@@ -367,11 +371,21 @@ func parsePodSchedulingSettingsFromHelm(opts mcp.Options) (*v1.K8sSettingsSpec, 
 	}
 
 	spec := &v1.K8sSettingsSpec{
-		Affinity:         affinity,
-		Tolerations:      tolerations,
-		Resources:        resources,
-		RuntimeClassName: runtimeClassName,
+		Affinity:           affinity,
+		Tolerations:        tolerations,
+		Resources:          resources,
+		RuntimeClassName:   runtimeClassName,
+		SetViaHelm:         hasPodSettings,
+		MaximumsSetViaHelm: hasMaximums,
 	}
+	maximums, err := mcp.ParseResourceMaximums(opts)
+	if err != nil {
+		return nil, err
+	}
+	spec.MaxCPURequest = maximums.CPURequest
+	spec.MaxCPULimit = maximums.CPULimit
+	spec.MaxMemoryRequest = maximums.MemoryRequest
+	spec.MaxMemoryLimit = maximums.MemoryLimit
 
 	if opts.MCPK8sSettingsNanobotAgentResources != "" && opts.MCPK8sSettingsNanobotAgentResources != "{}" {
 		var nanobotAgentResources corev1.ResourceRequirements

--- a/pkg/services/config_test.go
+++ b/pkg/services/config_test.go
@@ -176,6 +176,30 @@ func TestParsePodSchedulingSettingsFromHelm(t *testing.T) {
 			},
 		},
 		{
+			name: "resource maximums are independently Helm managed",
+			opts: mcp.Options{
+				MCPK8sMaxCPURequest:    "500m",
+				MCPK8sMaxCPULimit:      "2",
+				MCPK8sMaxMemoryRequest: "512Mi",
+				MCPK8sMaxMemoryLimit:   "2Gi",
+			},
+			validateResult: func(t *testing.T, spec *v1.K8sSettingsSpec) {
+				t.Helper()
+				if spec.SetViaHelm {
+					t.Error("expected scheduling settings to remain UI managed")
+				}
+				if !spec.MaximumsSetViaHelm {
+					t.Error("expected resource maximums to be Helm managed")
+				}
+				if spec.MaxCPURequest == nil || spec.MaxCPURequest.String() != "500m" {
+					t.Errorf("expected max CPU request 500m, got %v", spec.MaxCPURequest)
+				}
+				if spec.MaxMemoryLimit == nil || spec.MaxMemoryLimit.String() != "2Gi" {
+					t.Errorf("expected max memory limit 2Gi, got %v", spec.MaxMemoryLimit)
+				}
+			},
+		},
+		{
 			name: "valid nanobot agent resources only",
 			opts: mcp.Options{
 				MCPK8sSettingsNanobotAgentResources: `{"limits":{"memory":"1Gi"},"requests":{"memory":"512Mi"}}`,

--- a/pkg/storage/apis/obot.obot.ai/v1/k8ssetting.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/k8ssetting.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -28,6 +29,12 @@ type K8sSettingsSpec struct {
 	// +k8s:openapi-gen=false
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// Maximum resource requests and limits for MCP server pods
+	MaxCPURequest    *resource.Quantity `json:"maxCPURequest,omitempty"`
+	MaxCPULimit      *resource.Quantity `json:"maxCPULimit,omitempty"`
+	MaxMemoryRequest *resource.Quantity `json:"maxMemoryRequest,omitempty"`
+	MaxMemoryLimit   *resource.Quantity `json:"maxMemoryLimit,omitempty"`
+
 	// Resource requests and limits for NanobotAgent pods
 	// +k8s:openapi-gen=false
 	NanobotAgentResources *corev1.ResourceRequirements `json:"nanobotAgentResources,omitempty"`
@@ -48,6 +55,9 @@ type K8sSettingsSpec struct {
 
 	// SetViaHelm indicates if these settings came from Helm (cannot be updated via API)
 	SetViaHelm bool `json:"setViaHelm,omitempty"`
+
+	// MaximumsSetViaHelm indicates if resource maximums came from Helm (cannot be updated via API)
+	MaximumsSetViaHelm bool `json:"maximumsSetViaHelm,omitempty"`
 }
 
 // PodSecurityAdmissionSettings contains Pod Security Admission configuration

--- a/pkg/storage/apis/obot.obot.ai/v1/zz_generated.deepcopy.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/zz_generated.deepcopy.go
@@ -1749,6 +1749,26 @@ func (in *K8sSettingsSpec) DeepCopyInto(out *K8sSettingsSpec) {
 		*out = new(corev1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MaxCPURequest != nil {
+		in, out := &in.MaxCPURequest, &out.MaxCPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MaxCPULimit != nil {
+		in, out := &in.MaxCPULimit, &out.MaxCPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MaxMemoryRequest != nil {
+		in, out := &in.MaxMemoryRequest, &out.MaxMemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.MaxMemoryLimit != nil {
+		in, out := &in.MaxMemoryLimit, &out.MaxMemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	if in.NanobotAgentResources != nil {
 		in, out := &in.NanobotAgentResources, &out.NanobotAgentResources
 		*out = new(corev1.ResourceRequirements)

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -8348,6 +8348,34 @@ func schema_obot_platform_obot_apiclient_types_K8sSettings(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"maxCpuRequest": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaxCPURequest is the startup-configured maximum CPU request for MCP server pods.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"maxCpuLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaxCPULimit is the startup-configured maximum CPU limit for MCP server pods.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"maxMemoryRequest": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaxMemoryRequest is the startup-configured maximum memory request for MCP server pods.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"maxMemoryLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaxMemoryLimit is the startup-configured maximum memory limit for MCP server pods.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"runtimeClassName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RuntimeClassName specifies the RuntimeClass for MCP server pods This allows running MCP servers with specific container runtimes (e.g., gVisor, Kata)",
@@ -8385,6 +8413,13 @@ func schema_obot_platform_obot_apiclient_types_K8sSettings(ref common.ReferenceC
 					"setViaHelm": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SetViaHelm indicates settings are from Helm (cannot be updated via API)",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"maximumsSetViaHelm": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaximumsSetViaHelm indicates resource maximums are from Helm (cannot be updated via API)",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -20942,6 +20977,27 @@ func schema_storage_apis_obotobotai_v1_K8sSettingsSpec(ref common.ReferenceCallb
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"maxCPURequest": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Maximum resource requests and limits for MCP server pods",
+							Ref:         ref(resource.Quantity{}.OpenAPIModelName()),
+						},
+					},
+					"maxCPULimit": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref(resource.Quantity{}.OpenAPIModelName()),
+						},
+					},
+					"maxMemoryRequest": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref(resource.Quantity{}.OpenAPIModelName()),
+						},
+					},
+					"maxMemoryLimit": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref(resource.Quantity{}.OpenAPIModelName()),
+						},
+					},
 					"storageClassName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "StorageClassName specifies the StorageClass for nanobot workspace volumes",
@@ -20969,11 +21025,18 @@ func schema_storage_apis_obotobotai_v1_K8sSettingsSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"maximumsSetViaHelm": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MaximumsSetViaHelm indicates if resource maximums came from Helm (cannot be updated via API)",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			v1.PodSecurityAdmissionSettings{}.OpenAPIModelName()},
+			v1.PodSecurityAdmissionSettings{}.OpenAPIModelName(), resource.Quantity{}.OpenAPIModelName()},
 	}
 }
 

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -8350,28 +8350,28 @@ func schema_obot_platform_obot_apiclient_types_K8sSettings(ref common.ReferenceC
 					},
 					"maxCpuRequest": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxCPURequest is the startup-configured maximum CPU request for MCP server pods.",
+							Description: "MaxCPURequest is the configured maximum CPU request for MCP server pods.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"maxCpuLimit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxCPULimit is the startup-configured maximum CPU limit for MCP server pods.",
+							Description: "MaxCPULimit is the configured maximum CPU limit for MCP server pods.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"maxMemoryRequest": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxMemoryRequest is the startup-configured maximum memory request for MCP server pods.",
+							Description: "MaxMemoryRequest is the configured maximum memory request for MCP server pods.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"maxMemoryLimit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxMemoryLimit is the startup-configured maximum memory limit for MCP server pods.",
+							Description: "MaxMemoryLimit is the configured maximum memory limit for MCP server pods.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/ui/user/src/lib/components/admin/SchedulingForm.svelte
+++ b/ui/user/src/lib/components/admin/SchedulingForm.svelte
@@ -9,12 +9,14 @@
 	interface Props {
 		readonly?: boolean;
 		locked?: boolean;
+		maximumsLocked?: boolean;
 		affinity?: string;
 		tolerations?: string;
 		runtimeClassName?: string;
 		resourceInfo: SchedulingResources;
 		children?: Snippet;
 		notes?: Snippet;
+		maximumResources?: Snippet;
 		type: 'app' | 'mcpserver';
 	}
 
@@ -27,19 +29,21 @@
 		runtimeClassName = $bindable(),
 		children,
 		notes,
-		type
+		type,
+		maximumResources,
+		maximumsLocked
 	}: Props = $props();
 </script>
 
 <div class="flex flex-col gap-2">
-	{#if locked}
+	{#if locked || maximumsLocked}
 		<div class="notification-info p-3 text-sm font-light">
 			<div class="flex items-center gap-3">
 				<Info class="size-6" />
 				<div>
-					These settings are currently managed by your Helm chart and are <b class="font-semibold"
-						>read-only</b
-					> in the UI. To edit them, update your Helm values and redeploy.
+					{maximumsLocked && !locked ? 'Maximum resources' : 'These settings'} are currently managed by
+					your Helm chart and are <b class="font-semibold">read-only</b> in the UI. To edit them, update
+					your Helm values and redeploy.
 				</div>
 			</div>
 		</div>
@@ -122,7 +126,7 @@
 		</p>
 	</div>
 
-	<h3 class="text-lg font-semibold">CPU Settings</h3>
+	<h3 class="text-base font-semibold">CPU Settings</h3>
 	<div class="flex gap-4">
 		<div class="flex flex-1 flex-col gap-1">
 			<label class="input-label" for="cpu-request">Request</label>
@@ -147,7 +151,7 @@
 			/>
 		</div>
 	</div>
-	<h3 class="text-lg font-semibold">Memory Settings</h3>
+	<h3 class="text-base font-semibold">Memory Settings</h3>
 	<div class="flex gap-4">
 		<div class="flex flex-1 flex-col gap-1">
 			<label class="input-label" for="memory-request">Request</label>
@@ -172,6 +176,11 @@
 			/>
 		</div>
 	</div>
+
+	{#if maximumResources}
+		<div class="divider my-0"></div>
+		{@render maximumResources()}
+	{/if}
 </div>
 <div class="paper mt-1">
 	<div>

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -536,6 +536,11 @@ export interface K8sSettings {
 	created: string;
 	deleted?: string;
 	links?: Record<string, string>;
+	maxCpuLimit?: string;
+	maxCpuRequest?: string;
+	maxMemoryLimit?: string;
+	maxMemoryRequest?: string;
+	maximumsSetViaHelm?: boolean;
 	metadata?: Record<string, string>;
 	type: string;
 	affinity?: string;
@@ -556,6 +561,10 @@ export interface AppK8sSettings {
 
 export interface K8sSettingsManifest {
 	affinity?: string;
+	maxCpuLimit?: string;
+	maxCpuRequest?: string;
+	maxMemoryLimit?: string;
+	maxMemoryRequest?: string;
 	tolerations?: string;
 	resources?: string;
 	runtimeClassName?: string;

--- a/ui/user/src/routes/admin/server-scheduling/+page.svelte
+++ b/ui/user/src/routes/admin/server-scheduling/+page.svelte
@@ -103,6 +103,7 @@
 				<SchedulingForm
 					readonly={schedulingReadonly}
 					locked={k8sSettings.setViaHelm}
+					maximumsLocked={k8sSettings.maximumsSetViaHelm}
 					bind:resourceInfo
 					bind:affinity={k8sSettings.affinity}
 					bind:tolerations={k8sSettings.tolerations}
@@ -126,6 +127,71 @@
 								<li>Invalid YAML/JSON will be rejected during validation.</li>
 							</ul>
 						</div>
+					{/snippet}
+					{#snippet maximumResources()}
+						{#if k8sSettings}
+							<div>
+								{@render headerContent('Maximum Settings', true)}
+								<p class="text-sm">
+									Define the maximum allowed values for CPU and memory requests and limits for
+									hosted MCP server pods. Leave a value empty to allow no maximum.
+								</p>
+							</div>
+							<div class="flex flex-col gap-1">
+								<h3 class="text-base font-semibold">CPU Settings</h3>
+								<div class="grid grid-cols-2 gap-4">
+									<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
+										<label class="input-label" for="max-cpu-request">Max Request</label>
+										<input
+											type="text"
+											id="max-cpu-request"
+											bind:value={k8sSettings.maxCpuRequest}
+											class="text-input-filled dark:bg-base-100"
+											disabled={maximumsReadonly}
+											placeholder="example: 500m"
+										/>
+									</div>
+									<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
+										<label class="input-label" for="max-cpu-limit">Max Limit</label>
+										<input
+											type="text"
+											id="max-cpu-limit"
+											bind:value={k8sSettings.maxCpuLimit}
+											class="text-input-filled dark:bg-base-100"
+											disabled={maximumsReadonly}
+											placeholder="example: 1"
+										/>
+									</div>
+								</div>
+							</div>
+							<div class="flex flex-col gap-1">
+								<h3 class="text-base font-semibold">Memory Settings</h3>
+								<div class="grid grid-cols-2 gap-4">
+									<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
+										<label class="input-label" for="max-memory-request">Max Request</label>
+										<input
+											type="text"
+											id="max-memory-request"
+											bind:value={k8sSettings.maxMemoryRequest}
+											class="text-input-filled dark:bg-base-100"
+											disabled={maximumsReadonly}
+											placeholder="example: 512Mi"
+										/>
+									</div>
+									<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
+										<label class="input-label" for="max-memory-limit">Max Limit</label>
+										<input
+											type="text"
+											id="max-memory-limit"
+											bind:value={k8sSettings.maxMemoryLimit}
+											class="text-input-filled dark:bg-base-100"
+											disabled={maximumsReadonly}
+											placeholder="example: 1Gi"
+										/>
+									</div>
+								</div>
+							</div>
+						{/if}
 					{/snippet}
 					<div class="paper mt-1">
 						<div>
@@ -174,70 +240,6 @@
 						</div>
 					</div>
 				</SchedulingForm>
-
-				<div class="paper mt-1">
-					<div>
-						{@render headerContent('Maximum Settings', true)}
-						<p class="text-sm">
-							Define the maximum allowed values for CPU and memory requests and limits for hosted
-							MCP server pods. Leave a value empty to allow no maximum.
-						</p>
-					</div>
-					<div class="flex flex-col gap-1">
-						<h3 class="text-base font-semibold">CPU Settings</h3>
-						<div class="grid grid-cols-2 gap-4">
-							<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
-								<label class="input-label" for="max-cpu-request">Max Request</label>
-								<input
-									type="text"
-									id="max-cpu-request"
-									bind:value={k8sSettings.maxCpuRequest}
-									class="text-input-filled dark:bg-base-100"
-									disabled={maximumsReadonly}
-									placeholder="example: 500m"
-								/>
-							</div>
-							<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
-								<label class="input-label" for="max-cpu-limit">Max Limit</label>
-								<input
-									type="text"
-									id="max-cpu-limit"
-									bind:value={k8sSettings.maxCpuLimit}
-									class="text-input-filled dark:bg-base-100"
-									disabled={maximumsReadonly}
-									placeholder="example: 1"
-								/>
-							</div>
-						</div>
-					</div>
-					<div class="flex flex-col gap-1">
-						<h3 class="text-base font-semibold">Memory Settings</h3>
-						<div class="grid grid-cols-2 gap-4">
-							<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
-								<label class="input-label" for="max-memory-request">Max Request</label>
-								<input
-									type="text"
-									id="max-memory-request"
-									bind:value={k8sSettings.maxMemoryRequest}
-									class="text-input-filled dark:bg-base-100"
-									disabled={maximumsReadonly}
-									placeholder="example: 512Mi"
-								/>
-							</div>
-							<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
-								<label class="input-label" for="max-memory-limit">Max Limit</label>
-								<input
-									type="text"
-									id="max-memory-limit"
-									bind:value={k8sSettings.maxMemoryLimit}
-									class="text-input-filled dark:bg-base-100"
-									disabled={maximumsReadonly}
-									placeholder="example: 1Gi"
-								/>
-							</div>
-						</div>
-					</div>
-				</div>
 
 				{#if !readonly}
 					<div

--- a/ui/user/src/routes/admin/server-scheduling/+page.svelte
+++ b/ui/user/src/routes/admin/server-scheduling/+page.svelte
@@ -21,11 +21,16 @@
 			type: data.k8sSettings?.type ?? '',
 			resources: data.k8sSettings?.resources ?? '',
 			setViaHelm: data.k8sSettings?.setViaHelm ?? false,
+			maximumsSetViaHelm: data.k8sSettings?.maximumsSetViaHelm ?? false,
 			affinity: data.k8sSettings?.affinity ?? '',
 			tolerations: data.k8sSettings?.tolerations ?? '',
 			runtimeClassName: data.k8sSettings?.runtimeClassName ?? '',
 			storageClassName: data.k8sSettings?.storageClassName ?? '',
-			nanobotWorkspaceSize: data.k8sSettings?.nanobotWorkspaceSize ?? ''
+			nanobotWorkspaceSize: data.k8sSettings?.nanobotWorkspaceSize ?? '',
+			maxCpuRequest: data.k8sSettings?.maxCpuRequest ?? '',
+			maxMemoryRequest: data.k8sSettings?.maxMemoryRequest ?? '',
+			maxCpuLimit: data.k8sSettings?.maxCpuLimit ?? '',
+			maxMemoryLimit: data.k8sSettings?.maxMemoryLimit ?? ''
 		}))
 	);
 	let saving = $state(false);
@@ -59,7 +64,9 @@
 	}
 
 	let isAdminReadonly = $derived(profile.current.isAdminReadonly?.());
-	let readonly = $derived(k8sSettings?.setViaHelm || isAdminReadonly);
+	let schedulingReadonly = $derived(Boolean(k8sSettings?.setViaHelm || isAdminReadonly));
+	let maximumsReadonly = $derived(Boolean(k8sSettings?.maximumsSetViaHelm || isAdminReadonly));
+	let readonly = $derived(schedulingReadonly && maximumsReadonly);
 
 	async function handleSave() {
 		if (!k8sSettings) return;
@@ -94,7 +101,7 @@
 		{#if k8sSettings}
 			<div class="flex flex-col gap-8">
 				<SchedulingForm
-					{readonly}
+					readonly={schedulingReadonly}
 					locked={k8sSettings.setViaHelm}
 					bind:resourceInfo
 					bind:affinity={k8sSettings.affinity}
@@ -142,7 +149,7 @@
 									id="storage-class-name"
 									bind:value={k8sSettings.storageClassName}
 									class="text-input-filled dark:bg-base-100"
-									disabled={readonly}
+									disabled={schedulingReadonly}
 									placeholder="example: fast-ssd"
 								/>
 								<p class="text-xs font-light text-muted-content">
@@ -157,7 +164,7 @@
 									id="nanobot-workspace-size"
 									bind:value={k8sSettings.nanobotWorkspaceSize}
 									class="text-input-filled dark:bg-base-100"
-									disabled={readonly}
+									disabled={schedulingReadonly}
 									placeholder="example: 10Gi"
 								/>
 								<p class="text-xs font-light text-muted-content">
@@ -167,6 +174,69 @@
 						</div>
 					</div>
 				</SchedulingForm>
+
+				<div class="paper mt-1">
+					<div>
+						<h2 class="text-lg font-semibold">
+							Resource Maximums
+							{#if k8sSettings.maximumsSetViaHelm}
+								<span class="pill-rounded nowrap font-light">
+									<Lock class="size-3" /> Helm-Deployed
+								</span>
+							{/if}
+						</h2>
+						<p class="text-sm">
+							Set the largest CPU and memory requests and limits users may configure for hosted MCP
+							server pods. Leave a value empty to allow no maximum.
+						</p>
+					</div>
+					<div class="grid grid-cols-2 gap-4">
+						<div class="col-span-2 flex flex-col gap-1 md:col-span-1">
+							<label class="input-label" for="max-cpu-request">Maximum CPU Request</label>
+							<input
+								type="text"
+								id="max-cpu-request"
+								bind:value={k8sSettings.maxCpuRequest}
+								class="text-input-filled dark:bg-base-100"
+								disabled={maximumsReadonly}
+								placeholder="example: 500m"
+							/>
+						</div>
+						<div class="col-span-2 flex flex-col gap-1 md:col-span-1">
+							<label class="input-label" for="max-cpu-limit">Maximum CPU Limit</label>
+							<input
+								type="text"
+								id="max-cpu-limit"
+								bind:value={k8sSettings.maxCpuLimit}
+								class="text-input-filled dark:bg-base-100"
+								disabled={maximumsReadonly}
+								placeholder="example: 1"
+							/>
+						</div>
+						<div class="col-span-2 flex flex-col gap-1 md:col-span-1">
+							<label class="input-label" for="max-memory-request">Maximum Memory Request</label>
+							<input
+								type="text"
+								id="max-memory-request"
+								bind:value={k8sSettings.maxMemoryRequest}
+								class="text-input-filled dark:bg-base-100"
+								disabled={maximumsReadonly}
+								placeholder="example: 512Mi"
+							/>
+						</div>
+						<div class="col-span-2 flex flex-col gap-1 md:col-span-1">
+							<label class="input-label" for="max-memory-limit">Maximum Memory Limit</label>
+							<input
+								type="text"
+								id="max-memory-limit"
+								bind:value={k8sSettings.maxMemoryLimit}
+								class="text-input-filled dark:bg-base-100"
+								disabled={maximumsReadonly}
+								placeholder="example: 1Gi"
+							/>
+						</div>
+					</div>
+				</div>
 
 				{#if !readonly}
 					<div

--- a/ui/user/src/routes/admin/server-scheduling/+page.svelte
+++ b/ui/user/src/routes/admin/server-scheduling/+page.svelte
@@ -177,63 +177,64 @@
 
 				<div class="paper mt-1">
 					<div>
-						<h2 class="text-lg font-semibold">
-							Resource Maximums
-							{#if k8sSettings.maximumsSetViaHelm}
-								<span class="pill-rounded nowrap font-light">
-									<Lock class="size-3" /> Helm-Deployed
-								</span>
-							{/if}
-						</h2>
+						{@render headerContent('Maximum Settings', true)}
 						<p class="text-sm">
-							Set the largest CPU and memory requests and limits users may configure for hosted MCP
-							server pods. Leave a value empty to allow no maximum.
+							Define the maximum allowed values for CPU and memory requests and limits for hosted
+							MCP server pods. Leave a value empty to allow no maximum.
 						</p>
 					</div>
-					<div class="grid grid-cols-2 gap-4">
-						<div class="col-span-2 flex flex-col gap-1 md:col-span-1">
-							<label class="input-label" for="max-cpu-request">Maximum CPU Request</label>
-							<input
-								type="text"
-								id="max-cpu-request"
-								bind:value={k8sSettings.maxCpuRequest}
-								class="text-input-filled dark:bg-base-100"
-								disabled={maximumsReadonly}
-								placeholder="example: 500m"
-							/>
+					<div class="flex flex-col gap-1">
+						<h3 class="text-base font-semibold">CPU Settings</h3>
+						<div class="grid grid-cols-2 gap-4">
+							<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
+								<label class="input-label" for="max-cpu-request">Max Request</label>
+								<input
+									type="text"
+									id="max-cpu-request"
+									bind:value={k8sSettings.maxCpuRequest}
+									class="text-input-filled dark:bg-base-100"
+									disabled={maximumsReadonly}
+									placeholder="example: 500m"
+								/>
+							</div>
+							<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
+								<label class="input-label" for="max-cpu-limit">Max Limit</label>
+								<input
+									type="text"
+									id="max-cpu-limit"
+									bind:value={k8sSettings.maxCpuLimit}
+									class="text-input-filled dark:bg-base-100"
+									disabled={maximumsReadonly}
+									placeholder="example: 1"
+								/>
+							</div>
 						</div>
-						<div class="col-span-2 flex flex-col gap-1 md:col-span-1">
-							<label class="input-label" for="max-cpu-limit">Maximum CPU Limit</label>
-							<input
-								type="text"
-								id="max-cpu-limit"
-								bind:value={k8sSettings.maxCpuLimit}
-								class="text-input-filled dark:bg-base-100"
-								disabled={maximumsReadonly}
-								placeholder="example: 1"
-							/>
-						</div>
-						<div class="col-span-2 flex flex-col gap-1 md:col-span-1">
-							<label class="input-label" for="max-memory-request">Maximum Memory Request</label>
-							<input
-								type="text"
-								id="max-memory-request"
-								bind:value={k8sSettings.maxMemoryRequest}
-								class="text-input-filled dark:bg-base-100"
-								disabled={maximumsReadonly}
-								placeholder="example: 512Mi"
-							/>
-						</div>
-						<div class="col-span-2 flex flex-col gap-1 md:col-span-1">
-							<label class="input-label" for="max-memory-limit">Maximum Memory Limit</label>
-							<input
-								type="text"
-								id="max-memory-limit"
-								bind:value={k8sSettings.maxMemoryLimit}
-								class="text-input-filled dark:bg-base-100"
-								disabled={maximumsReadonly}
-								placeholder="example: 1Gi"
-							/>
+					</div>
+					<div class="flex flex-col gap-1">
+						<h3 class="text-base font-semibold">Memory Settings</h3>
+						<div class="grid grid-cols-2 gap-4">
+							<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
+								<label class="input-label" for="max-memory-request">Max Request</label>
+								<input
+									type="text"
+									id="max-memory-request"
+									bind:value={k8sSettings.maxMemoryRequest}
+									class="text-input-filled dark:bg-base-100"
+									disabled={maximumsReadonly}
+									placeholder="example: 512Mi"
+								/>
+							</div>
+							<div class="flex flex-1 flex-col gap-1 col-span-2 md:col-span-1">
+								<label class="input-label" for="max-memory-limit">Max Limit</label>
+								<input
+									type="text"
+									id="max-memory-limit"
+									bind:value={k8sSettings.maxMemoryLimit}
+									class="text-input-filled dark:bg-base-100"
+									disabled={maximumsReadonly}
+									placeholder="example: 1Gi"
+								/>
+							</div>
 						</div>
 					</div>
 				</div>
@@ -280,10 +281,13 @@
 	</div>
 </Layout>
 
-{#snippet headerContent(title: string)}
+{#snippet headerContent(title: string, isMaximumSetViaHelm?: boolean)}
+	{@const isHelmDeployed = isMaximumSetViaHelm
+		? k8sSettings?.maximumsSetViaHelm
+		: k8sSettings?.setViaHelm}
 	<h2 class="text-lg font-semibold">
 		{title}
-		{#if k8sSettings?.setViaHelm}
+		{#if isHelmDeployed}
 			<span class="pill-rounded nowrap font-light">
 				<Lock class="size-3" /> Helm-Deployed
 			</span>


### PR DESCRIPTION
This addresses allowing a user to set maximums for request/limits in cpu/memory if maximums haven't been set via helm chart. 

`MaximumsSetViaHelm` was created as a separate check for the maximums to avoid regression of existing behavior -- maximums could be set via helm chart but not trigger setViaHelm and allow users to continue modifying, via UI, other configurations such as resources, affinity, runtimeClass, etc. 

Addresses #7135 

<img width="1308" height="714" alt="Screenshot 2026-08-10 at 11 06 36 AM" src="https://github.com/user-attachments/assets/ea7fed6f-7f31-4b32-982d-3d9a0b2b2292" />
