### PR TITLE
fix: multi-tenant deployment check fix for Server Activity in dashboard

### DIFF
--- a/ui/user/src/lib/components/table/Table.svelte
+++ b/ui/user/src/lib/components/table/Table.svelte
@@ -298,7 +298,8 @@
 	function getColumnMinWidth(width: number, index: number, columnCount: number): number {
 		if (index === 0 && tableSelectActions) return 57;
 		if (actions && index === columnCount - 1) return Math.max(width, ACTIONS_MIN_WIDTH);
-		return Math.max(width * 0.3, 100);
+		// if filterable fields are present, add width to account for filter button
+		return Math.max(width * 0.3, 100) + (filterableFields.size > 0 ? 36 : 0);
 	}
 
 	function calculateConstrainedWidths(naturalWidths: number[], availableWidth: number): number[] {

--- a/ui/user/src/lib/services/dashboard/utils.ts
+++ b/ui/user/src/lib/services/dashboard/utils.ts
@@ -51,7 +51,7 @@ export function catalogServerEntryKind(
 	if (!server.catalogEntryID) return 'multi';
 	if (server.manifest.runtime === 'composite') return 'composite';
 	if (server.manifest.runtime === 'remote') return 'remote';
-	return 'single';
+	return server.serverUserType === 'singleUser' ? 'single' : 'multi';
 }
 
 export function normalizeServerDeploymentStatus(server: MCPCatalogServer): string {
@@ -59,7 +59,7 @@ export function normalizeServerDeploymentStatus(server: MCPCatalogServer): strin
 	if (raw && DEPLOYMENT_STATUS_ORDER.includes(raw as (typeof DEPLOYMENT_STATUS_ORDER)[number]))
 		return raw;
 	if (raw) return raw;
-	return 'Unknown';
+	return '--';
 }
 
 /** 12-column grid: 3× col-span-4 per full row; last row fills width (6+6 or 12). */

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -86,15 +86,24 @@
 
 	let deployedCatalogEntryServers = $state<MCPCatalogServer[]>([]);
 	let deployedWorkspaceCatalogEntryServers = $state<MCPCatalogServer[]>([]);
-	let serversData = $derived(
-		mcpServersAndEntries.current.loading || loading
-			? []
-			: [
-					...deployedCatalogEntryServers.filter((server) => !server.deleted),
-					...deployedWorkspaceCatalogEntryServers.filter((server) => !server.deleted),
-					...mcpServersAndEntries.current.servers.filter((server) => !server.deleted)
-				]
-	);
+	let serversData = $derived.by(() => {
+		if (mcpServersAndEntries.current.loading || loading) return [];
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const seen = new Set<string>();
+		const result: MCPCatalogServer[] = [];
+		for (const list of [
+			deployedCatalogEntryServers,
+			deployedWorkspaceCatalogEntryServers,
+			mcpServersAndEntries.current.servers
+		]) {
+			for (const server of list) {
+				if (server.deleted || seen.has(server.id)) continue;
+				seen.add(server.id);
+				result.push(server);
+			}
+		}
+		return result;
+	});
 
 	const serverAndEntries = $derived(mcpServersAndEntries.current);
 	const { graphData, popularServers, totalServers, deploymentStatusBreakdown } = $derived(


### PR DESCRIPTION
This addresses the issue of a multi-tenant deployment not properly showing up in Server Activity under Dashboard, as well as general fix for column headers overlapping seen in Deployments table.

Addresses #7430 
Addresses #7178 Follow-Up