### PR TITLE
fix: docs navbar on mobile not showing

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -68,6 +68,10 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
+.navbar.navbar-sidebar--show {
+  height: 100dvh;
+}
+
 [data-theme='dark'] .navbar {
   background: rgba(15, 23, 42, 0.9);
 }

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -69,6 +69,7 @@
 }
 
 .navbar.navbar-sidebar--show {
+  height: 100vh;
   height: 100dvh;
 }
 


### PR DESCRIPTION
Quick fix! This addresses issue where the docusaurus mobile nav does not show anything after clicking the hamburger to expand. This is due to the `height: var(--ifm-navbar-height);` set on the navbar class and it doesn't change when the navbar open class is applied so anything below gets cut off. To address, added a css height enforcement when the navbar is open. 

Seems like small bug on docusaurus end -- we're only changing minor things like backdrop blur or border/background color for the navbar.