### PR TITLE
fix: return invalid_grant for invalid refresh tokens

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -26,6 +26,7 @@ type ErrorCode string
 
 const (
 	ErrInvalidClient           ErrorCode = "invalid_client"
+	ErrInvalidGrant            ErrorCode = "invalid_grant"
 	ErrInvalidRequest          ErrorCode = "invalid_request"
 	ErrUnauthorizedClient      ErrorCode = "unauthorized_client"
 	ErrAccessDenied            ErrorCode = "access_denied"

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -257,13 +257,19 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 
 	var oauthToken v1.OAuthToken
 	if err := req.Storage.Get(req.Context(), kclient.ObjectKey{Namespace: oauthClient.Namespace, Name: fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken)))}, &oauthToken); err != nil {
+		if apierrors.IsNotFound(err) {
+			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidGrant, "refresh_token is invalid", ""))
+		}
 		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "refresh_token is invalid", ""))
 	}
 	if oauthToken.Spec.ClientID != oauthClient.Name {
-		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "refresh_token is invalid", ""))
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidGrant, "refresh_token is invalid", ""))
 	}
 
 	if err := req.Delete(&oauthToken); err != nil {
+		if apierrors.IsNotFound(err) {
+			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidGrant, "refresh_token is invalid", ""))
+		}
 		return fmt.Errorf("failed to refresh oauth token: %w", err)
 	}
 

--- a/pkg/api/handlers/mcpgateway/oauth/token_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -27,7 +28,7 @@ import (
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestDoRefreshTokenPreservesScope(t *testing.T) {
+func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 	const (
 		baseURL      = "https://obot.example.com"
 		clientName   = "oauth-client"
@@ -96,12 +97,14 @@ func TestDoRefreshTokenPreservesScope(t *testing.T) {
 		Storage:        storage,
 		GatewayClient:  gatewayClient,
 	}
-	err = (&handler{tokenService: tokenService}).doRefreshToken(req, v1.OAuthClient{
+	oauthClient := v1.OAuthClient{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: system.DefaultNamespace,
 			Name:      clientName,
 		},
-	}, refreshToken)
+	}
+	h := &handler{tokenService: tokenService}
+	err = h.doRefreshToken(req, oauthClient, refreshToken)
 	require.NoError(t, err)
 
 	var response types.OAuthToken
@@ -112,4 +115,20 @@ func TestDoRefreshTokenPreservesScope(t *testing.T) {
 	refreshedName := fmt.Sprintf("%x", sha256.Sum256([]byte(response.RefreshToken)))
 	require.NoError(t, storage.Get(t.Context(), kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: refreshedName}, &refreshed))
 	assert.Equal(t, "profile email", refreshed.Spec.Scope)
+
+	err = h.doRefreshToken(api.Context{
+		ResponseWriter: httptest.NewRecorder(),
+		Request:        httptest.NewRequest("POST", "/oauth/token", nil),
+		Storage:        storage,
+	}, oauthClient, refreshToken)
+	require.Error(t, err)
+
+	var errHTTP *types.ErrHTTP
+	require.ErrorAs(t, err, &errHTTP)
+	assert.Equal(t, http.StatusBadRequest, errHTTP.Code)
+
+	var oauthErr oauthError
+	require.NoError(t, json.Unmarshal([]byte(errHTTP.Message), &oauthErr))
+	assert.Equal(t, "invalid_grant", string(oauthErr.Code))
+	assert.Equal(t, "Obot: refresh_token is invalid", oauthErr.Description)
 }


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/7501

This responds with the correct `invalid_grant` according to [rfc6749](https://www.rfc-editor.org/info/rfc6749/#section-5.2)