### PR TITLE
fix: resolve remote URL templates for tool previews

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1952,20 +1952,8 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 		if catalogEntry.Spec.Manifest.Runtime == types.RuntimeRemote &&
 			catalogEntry.Spec.Manifest.RemoteConfig != nil &&
 			catalogEntry.Spec.Manifest.RemoteConfig.URLTemplate != "" {
-			// Apply the URL template with environment variables
-			finalURL, err := applyURLTemplate(catalogEntry.Spec.Manifest.RemoteConfig.URLTemplate, envVars)
-			if err != nil {
-				return fmt.Errorf("failed to apply URL template: %w", err)
-			}
-
-			// Update the server's remote config URL with the processed template
-			if mcpServer.Spec.Manifest.RemoteConfig == nil {
-				mcpServer.Spec.Manifest.RemoteConfig = &types.RemoteRuntimeConfig{}
-			}
-			mcpServer.Spec.Manifest.RemoteConfig.URL = finalURL
-
-			if err := mcp.ValidateServerManifest(req.Context(), mcpServer.Spec.Manifest, !mcpServer.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
-				return types.NewErrBadRequest("validation failed: %v", err)
+			if err := applyRemoteURLTemplate(req.Context(), &mcpServer.Spec.Manifest, envVars, !mcpServer.Spec.IsSingleUser(), ValidationOptionsWithResourceMaximums(m.mcpSessionManager)); err != nil {
+				return err
 			}
 			if err := obottunnel.ValidateServerTunnelReferences(req.Context(), req.Storage, mcpServer.Spec.Manifest); err != nil {
 				return types.NewErrBadRequest("validation failed: %v", err)
@@ -2293,6 +2281,25 @@ func applyURLTemplate(templateStr string, envVars map[string]string) (string, er
 	}
 
 	return result, nil
+}
+
+// applyRemoteURLTemplate renders and validates a remote URL template before the server is used.
+func applyRemoteURLTemplate(ctx context.Context, manifest *types.MCPServerManifest, envVars map[string]string, isMultiUser bool, options mcp.ValidationOptions) error {
+	if manifest.Runtime != types.RuntimeRemote || manifest.RemoteConfig == nil || manifest.RemoteConfig.URLTemplate == "" {
+		return nil
+	}
+
+	finalURL, err := applyURLTemplate(manifest.RemoteConfig.URLTemplate, envVars)
+	if err != nil {
+		return fmt.Errorf("failed to apply URL template: %w", err)
+	}
+
+	manifest.RemoteConfig.URL = finalURL
+	if err := mcp.ValidateServerManifest(ctx, *manifest, isMultiUser, options); err != nil {
+		return types.NewErrBadRequest("validation failed: %v", err)
+	}
+
+	return nil
 }
 
 func (m *MCPHandler) DeconfigureServer(req api.Context) error {

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -653,6 +653,53 @@ func TestApplyURLTemplate(t *testing.T) {
 	}
 }
 
+func TestApplyRemoteURLTemplate(t *testing.T) {
+	manifest := types.MCPServerManifest{
+		Name:    "OAuth Remote",
+		Runtime: types.RuntimeRemote,
+		RemoteConfig: &types.RemoteRuntimeConfig{
+			IsTemplate:          true,
+			URLTemplate:         "https://${HOST}/mcp/projects/${PROJECT_ID}",
+			StaticOAuthRequired: true,
+		},
+	}
+	options := mcp.ValidationOptions{
+		RemoteMCPURLValidationConfig: mcp.RemoteMCPURLValidationConfig{
+			AllowLocalhostMCP: true,
+			AllowPrivateIPMCP: true,
+			AllowLinkLocalMCP: true,
+		},
+	}
+
+	err := applyRemoteURLTemplate(t.Context(), &manifest, map[string]string{
+		"HOST":       "remote.example.com",
+		"PROJECT_ID": "project-123",
+	}, false, options)
+	require.NoError(t, err)
+	require.Equal(t, "https://remote.example.com/mcp/projects/project-123", manifest.RemoteConfig.URL)
+	require.True(t, manifest.RemoteConfig.StaticOAuthRequired)
+
+	server := v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "tool-preview"}, Spec: v1.MCPServerSpec{Manifest: manifest}}
+	serverConfig, missing, err := mcp.ServerToServerConfig(server, nil, "system", "temp", "default", nil, nil)
+	require.NoError(t, err)
+	require.Empty(t, missing)
+	require.Equal(t, manifest.RemoteConfig.URL, serverConfig.URL)
+}
+
+func TestApplyRemoteURLTemplateRejectsInvalidRenderedURL(t *testing.T) {
+	manifest := types.MCPServerManifest{
+		Runtime: types.RuntimeRemote,
+		RemoteConfig: &types.RemoteRuntimeConfig{
+			IsTemplate:  true,
+			URLTemplate: "${SCHEME}://remote.example.com/mcp",
+		},
+	}
+
+	err := applyRemoteURLTemplate(t.Context(), &manifest, map[string]string{"SCHEME": "ftp"}, false, mcp.ValidationOptions{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "URL scheme must be either https or http")
+}
+
 func TestApplyURLTemplateEdgeCases(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1469,7 +1469,7 @@ func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, cli
 	if err != nil {
 		return v1.MCPServer{}, mcp.ServerConfig{}, fmt.Errorf("failed to resolve secret bindings: %w", err)
 	}
-	if err := applyRemoteURLTemplate(ctx, &serverManifest, config, false, validationOptions); err != nil {
+	if err := applyRemoteURLTemplate(ctx, &serverManifest, config, !entryManifest.ServerUserType.IsSingleUser(), validationOptions); err != nil {
 		return v1.MCPServer{}, mcp.ServerConfig{}, err
 	}
 	if err := tunnel.ValidateServerTunnelReferences(ctx, client, serverManifest); err != nil {

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1462,14 +1462,8 @@ func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, cli
 		return v1.MCPServer{}, mcp.ServerConfig{}, fmt.Errorf("failed to convert catalog entry to server config: %w", err)
 	}
 
-	// Merge any secretBinding-resolved values into the user-supplied
-	// config so URL-template substitution and ServerToServerConfig see
-	// them. The caller's config map is not mutated.
-	config, err = mcp.MergeBoundCreds(ctx, localK8sClient, obotNamespace, serverManifest.Env, serverManifest.RemoteConfig, config, secretBindingAllowedLabel)
+	config, err = prepareTempServerConfig(ctx, localK8sClient, obotNamespace, secretBindingAllowedLabel, &serverManifest, config, !entryManifest.ServerUserType.IsSingleUser(), validationOptions)
 	if err != nil {
-		return v1.MCPServer{}, mcp.ServerConfig{}, fmt.Errorf("failed to resolve secret bindings: %w", err)
-	}
-	if err := applyRemoteURLTemplate(ctx, &serverManifest, config, !entryManifest.ServerUserType.IsSingleUser(), validationOptions); err != nil {
 		return v1.MCPServer{}, mcp.ServerConfig{}, err
 	}
 	if err := tunnel.ValidateServerTunnelReferences(ctx, client, serverManifest); err != nil {
@@ -1536,6 +1530,20 @@ func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, cli
 	}
 
 	return tempMCPServer, serverConfig, nil
+}
+
+func prepareTempServerConfig(ctx context.Context, localK8sClient client.Client, obotNamespace, secretBindingAllowedLabel string, serverManifest *types.MCPServerManifest, config map[string]string, isMultiUser bool, validationOptions mcp.ValidationOptions) (map[string]string, error) {
+	// Render templates before resolving bindings so Secret values can only be
+	// used by runtime fields such as headers, never embedded in the URL.
+	if err := applyRemoteURLTemplate(ctx, serverManifest, config, isMultiUser, validationOptions); err != nil {
+		return nil, err
+	}
+
+	mergedConfig, err := mcp.MergeBoundCreds(ctx, localK8sClient, obotNamespace, serverManifest.Env, serverManifest.RemoteConfig, config, secretBindingAllowedLabel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve secret bindings: %w", err)
+	}
+	return mergedConfig, nil
 }
 
 // ListCategoriesForCatalog returns all unique categories from entries in a catalog

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -877,6 +877,7 @@ func (h *MCPCatalogHandler) GenerateToolPreviews(req api.Context) error {
 		configRequest.Config,
 		configRequest.URL,
 		h.serverURL,
+		ValidationOptionsWithResourceMaximums(h.sessionManager),
 	)
 	if err != nil {
 		return types.NewErrBadRequest("failed to create temporary server and config: %v", err)
@@ -1002,6 +1003,7 @@ func (h *MCPCatalogHandler) generateCompositeToolPreviews(req api.Context, entry
 			config.Config,
 			config.URL,
 			h.serverURL,
+			ValidationOptionsWithResourceMaximums(h.sessionManager),
 		)
 		if err != nil {
 			return err
@@ -1121,7 +1123,7 @@ func (h *MCPCatalogHandler) GenerateToolPreviewsOAuthURL(req api.Context) error 
 	if catalogName == "" {
 		catalogName = entry.Spec.PowerUserWorkspaceID
 	}
-	server, serverConfig, err := tempServerAndConfig(req.Context(), req.GatewayClient, req.Storage, req.LocalK8sClient, req.ObotNamespace, h.secretBindingAllowedLabel, entry.Namespace, catalogName, entry.Spec.Manifest, configRequest.Config, configRequest.URL, h.serverURL)
+	server, serverConfig, err := tempServerAndConfig(req.Context(), req.GatewayClient, req.Storage, req.LocalK8sClient, req.ObotNamespace, h.secretBindingAllowedLabel, entry.Namespace, catalogName, entry.Spec.Manifest, configRequest.Config, configRequest.URL, h.serverURL, ValidationOptionsWithResourceMaximums(h.sessionManager))
 	if err != nil {
 		return types.NewErrBadRequest("failed to create temporary server and config: %v", err)
 	}
@@ -1219,6 +1221,7 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviews(req api.Context) error
 		configRequest.Config,
 		configRequest.URL,
 		h.serverURL,
+		ValidationOptionsWithResourceMaximums(h.sessionManager),
 	)
 	if err != nil {
 		return types.NewErrBadRequest("failed to create temporary server and config: %v", err)
@@ -1344,6 +1347,7 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviewsOAuthURL(req api.Contex
 		configRequest.Config,
 		configRequest.URL,
 		h.serverURL,
+		ValidationOptionsWithResourceMaximums(h.sessionManager),
 	)
 	if err != nil {
 		return types.NewErrBadRequest("failed to create temporary server and config: %v", err)
@@ -1428,6 +1432,7 @@ func (h *MCPCatalogHandler) generateCompositeOAuthURLs(req api.Context, entry v1
 			config.Config,
 			config.URL,
 			h.serverURL,
+			ValidationOptionsWithResourceMaximums(h.sessionManager),
 		)
 		if err != nil {
 			// If we can't create server config, skip this component
@@ -1450,7 +1455,7 @@ func (h *MCPCatalogHandler) generateCompositeOAuthURLs(req api.Context, entry v1
 	return req.Write(oauthURLs)
 }
 
-func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, client client.Client, localK8sClient client.Client, obotNamespace, secretBindingAllowedLabel, namespace, catalogName string, entryManifest types.MCPServerCatalogEntryManifest, config map[string]string, url, baseURL string) (v1.MCPServer, mcp.ServerConfig, error) {
+func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, client client.Client, localK8sClient client.Client, obotNamespace, secretBindingAllowedLabel, namespace, catalogName string, entryManifest types.MCPServerCatalogEntryManifest, config map[string]string, url, baseURL string, validationOptions mcp.ValidationOptions) (v1.MCPServer, mcp.ServerConfig, error) {
 	// Convert catalog entry to server manifest
 	serverManifest, err := types.MapCatalogEntryToServer(entryManifest, url, false)
 	if err != nil {
@@ -1463,6 +1468,12 @@ func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, cli
 	config, err = mcp.MergeBoundCreds(ctx, localK8sClient, obotNamespace, serverManifest.Env, serverManifest.RemoteConfig, config, secretBindingAllowedLabel)
 	if err != nil {
 		return v1.MCPServer{}, mcp.ServerConfig{}, fmt.Errorf("failed to resolve secret bindings: %w", err)
+	}
+	if err := applyRemoteURLTemplate(ctx, &serverManifest, config, false, validationOptions); err != nil {
+		return v1.MCPServer{}, mcp.ServerConfig{}, err
+	}
+	if err := tunnel.ValidateServerTunnelReferences(ctx, client, serverManifest); err != nil {
+		return v1.MCPServer{}, mcp.ServerConfig{}, types.NewErrBadRequest("validation failed: %v", err)
 	}
 
 	// Create temporary MCPServer object to use existing conversion logic

--- a/pkg/api/handlers/mcpcatalogs_test.go
+++ b/pkg/api/handlers/mcpcatalogs_test.go
@@ -7,12 +7,14 @@ import (
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/mcp"
 	"github.com/obot-platform/obot/pkg/storage"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -320,6 +322,44 @@ func TestValidateEntryVisibleFromScope(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrepareTempServerConfigDoesNotUseBoundSecretInURL(t *testing.T) {
+	const (
+		namespace = "obot-ns"
+		label     = "allowed-secret"
+		key       = "WORKSPACE"
+	)
+	localK8sClient := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "remote-secret", Namespace: namespace, Labels: map[string]string{label: "true"}},
+		Data:       map[string][]byte{"token": []byte("secret-value")},
+	}).Build()
+	manifest := types.MCPServerManifest{
+		Runtime: types.RuntimeRemote,
+		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+			Key: key, Required: true,
+		}}},
+		RemoteConfig: &types.RemoteRuntimeConfig{
+			IsTemplate:  true,
+			URLTemplate: "https://example.com/mcp/${WORKSPACE}",
+			Headers: []types.MCPHeader{{
+				Key: key, SecretBinding: &types.MCPSecretBinding{Name: "remote-secret", Key: "token"},
+			}},
+		},
+	}
+	input := map[string]string{key: "user-value"}
+	options := mcp.ValidationOptions{RemoteMCPURLValidationConfig: mcp.RemoteMCPURLValidationConfig{
+		AllowLocalhostMCP: true,
+		AllowPrivateIPMCP: true,
+		AllowLinkLocalMCP: true,
+	}}
+
+	merged, err := prepareTempServerConfig(t.Context(), localK8sClient, namespace, label, &manifest, input, false, options)
+	require.NoError(t, err)
+	require.Equal(t, "https://example.com/mcp/user-value", manifest.RemoteConfig.URL)
+	require.NotContains(t, manifest.RemoteConfig.URL, "secret-value")
+	require.Equal(t, "secret-value", merged[key])
+	require.Equal(t, "user-value", input[key])
 }
 
 func TestPopulateComponentManifestsHydratesMCPServerID(t *testing.T) {

--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -1011,13 +1011,13 @@
 				{onConfigureOAuth}
 			>
 				{#snippet afterHeaders()}
-					{#if secretBoundHeaders.length > 0}
+					{#if formData.remoteConfig?.urlTemplate !== undefined}
 						<CustomConfigurationForm
 							bind:config={formData.env}
 							{readonly}
 							serverUserType={formData.serverUserType}
-							{secretBoundHeaders}
 							showRequired={showRequired.env}
+							urlTemplateVariables
 						/>
 					{/if}
 				{/snippet}

--- a/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
@@ -55,13 +55,14 @@
 	let missingValue = $derived(showRequired && !data.value?.trim());
 
 	$effect(() => {
-		if (data && usesSecretBindingSource(data)) {
-			data.sensitive = true;
-		}
 		if (urlTemplateVariable) {
+			data.secretBinding = undefined;
+			data.secretBindingSource = 'value';
 			data.required = true;
 			data.sensitive = false;
 			data.file = false;
+		} else if (data && usesSecretBindingSource(data)) {
+			data.sensitive = true;
 		}
 	});
 </script>

--- a/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationFieldset.svelte
@@ -18,6 +18,7 @@
 			input?: string;
 		};
 		showRequired?: boolean;
+		urlTemplateVariable?: boolean;
 	}
 
 	let {
@@ -28,7 +29,8 @@
 		isPrebuiltEntry,
 		secretBindingTargets,
 		classes,
-		showRequired
+		showRequired,
+		urlTemplateVariable = false
 	}: Props = $props();
 
 	function usesSecretBindingSource(field: {
@@ -40,7 +42,11 @@
 
 	let selectedType = $state(
 		untrack(() =>
-			(data.value?.length ?? 0) > 0 || usesSecretBindingSource(data) ? 'static' : 'user_supplied'
+			urlTemplateVariable
+				? 'user_supplied'
+				: (data.value?.length ?? 0) > 0 || usesSecretBindingSource(data)
+					? 'static'
+					: 'user_supplied'
 		)
 	);
 
@@ -51,6 +57,11 @@
 	$effect(() => {
 		if (data && usesSecretBindingSource(data)) {
 			data.sensitive = true;
+		}
+		if (urlTemplateVariable) {
+			data.required = true;
+			data.sensitive = false;
+			data.file = false;
 		}
 	});
 </script>
@@ -63,16 +74,26 @@
 
 	{@render keyInput()}
 	{@render nameAndDescriptionInputs()}
-	<div class="flex gap-8">
-		<label class="flex items-center gap-2">
-			<input type="checkbox" bind:checked={data.sensitive} disabled={readonly || isPrebuiltEntry} />
-			<span class="text-sm">Sensitive</span>
-		</label>
-		<label class="flex items-center gap-2">
-			<input type="checkbox" bind:checked={data.required} disabled={readonly || isPrebuiltEntry} />
-			<span class="text-sm">Required</span>
-		</label>
-	</div>
+	{#if !urlTemplateVariable}
+		<div class="flex gap-8">
+			<label class="flex items-center gap-2">
+				<input
+					type="checkbox"
+					bind:checked={data.sensitive}
+					disabled={readonly || isPrebuiltEntry}
+				/>
+				<span class="text-sm">Sensitive</span>
+			</label>
+			<label class="flex items-center gap-2">
+				<input
+					type="checkbox"
+					bind:checked={data.required}
+					disabled={readonly || isPrebuiltEntry}
+				/>
+				<span class="text-sm">Required</span>
+			</label>
+		</div>
+	{/if}
 {:else}
 	<div class="flex w-full flex-col gap-1">
 		{@render keyInput()}
@@ -84,38 +105,40 @@
 		{/if}
 	</div>
 
-	<div class="flex w-full flex-col gap-1" id={`${id}-value-type-container`}>
-		{@render label('Value', `env-value-type-${id}`)}
-		<Select
-			class="bg-base-100 dark:border-base-400 border border-transparent shadow-none"
-			classes={{
-				root: 'flex grow'
-			}}
-			options={[
-				{ label: 'Static', id: 'static' },
-				{ label: 'User-Supplied', id: 'user_supplied' }
-			]}
-			selected={selectedType}
-			onSelect={(option) => {
-				if (!data) return;
-				selectedType = option.id;
+	{#if !urlTemplateVariable}
+		<div class="flex w-full flex-col gap-1" id={`${id}-value-type-container`}>
+			{@render label('Value', `env-value-type-${id}`)}
+			<Select
+				class="bg-base-100 dark:border-base-400 border border-transparent shadow-none"
+				classes={{
+					root: 'flex grow'
+				}}
+				options={[
+					{ label: 'Static', id: 'static' },
+					{ label: 'User-Supplied', id: 'user_supplied' }
+				]}
+				selected={selectedType}
+				onSelect={(option) => {
+					if (!data) return;
+					selectedType = option.id;
 
-				// Reset state when switching between static and user-supplied modes.
-				data.required = option.id === 'static';
-				data.name = '';
-				data.value = '';
-				data.description = '';
-				data.sensitive = false;
+					// Reset state when switching between static and user-supplied modes.
+					data.required = option.id === 'static';
+					data.name = '';
+					data.value = '';
+					data.description = '';
+					data.sensitive = false;
 
-				if (option.id === 'user_supplied') {
-					data.secretBinding = undefined;
-					data.secretBindingSource = 'value';
-				}
-			}}
-			readonly={readonly || isPrebuiltEntry}
-			id={`env-value-type-${id}`}
-		/>
-	</div>
+					if (option.id === 'user_supplied') {
+						data.secretBinding = undefined;
+						data.secretBindingSource = 'value';
+					}
+				}}
+				readonly={readonly || isPrebuiltEntry}
+				id={`env-value-type-${id}`}
+			/>
+		</div>
+	{/if}
 
 	{#if !isPrebuiltEntry && selectedType === 'user_supplied'}
 		{@render nameAndDescriptionInputs()}
@@ -155,39 +178,41 @@
 			</div>
 		{/if}
 	{/if}
-	<div class="flex w-full">
-		{#if !usesSecretBindingSource(data)}
-			<Toggle
-				classes={{ label: 'text-sm text-inherit' }}
-				disabled={readonly || isPrebuiltEntry}
-				label="Sensitive"
-				labelInline
-				checked={!!data.sensitive}
-				onChange={(checked) => {
-					if (data) {
-						data.sensitive = checked;
-					}
-				}}
-			/>
-			{#if selectedType !== 'static'}
-				<div class="divider divider-horizontal"></div>
+	{#if !urlTemplateVariable}
+		<div class="flex w-full">
+			{#if !usesSecretBindingSource(data)}
+				<Toggle
+					classes={{ label: 'text-sm text-inherit' }}
+					disabled={readonly || isPrebuiltEntry}
+					label="Sensitive"
+					labelInline
+					checked={!!data.sensitive}
+					onChange={(checked) => {
+						if (data) {
+							data.sensitive = checked;
+						}
+					}}
+				/>
+				{#if selectedType !== 'static'}
+					<div class="divider divider-horizontal"></div>
+				{/if}
 			{/if}
-		{/if}
-		{#if selectedType !== 'static'}
-			<Toggle
-				classes={{ label: 'text-sm text-inherit' }}
-				disabled={readonly || isPrebuiltEntry}
-				label="Required"
-				labelInline
-				checked={!!data.required}
-				onChange={(checked) => {
-					if (data) {
-						data.required = checked;
-					}
-				}}
-			/>
-		{/if}
-	</div>
+			{#if selectedType !== 'static'}
+				<Toggle
+					classes={{ label: 'text-sm text-inherit' }}
+					disabled={readonly || isPrebuiltEntry}
+					label="Required"
+					labelInline
+					checked={!!data.required}
+					onChange={(checked) => {
+						if (data) {
+							data.required = checked;
+						}
+					}}
+				/>
+			{/if}
+		</div>
+	{/if}
 {/if}
 
 {#snippet label(title: string, forInput: string, required?: boolean, showError?: boolean)}

--- a/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
@@ -19,6 +19,7 @@
 		overrideEnvField?: string[];
 		overrideEnvTemplate?: Snippet<[{ config: MCPCatalogEntryFieldManifest; index: number }]>;
 		showRequired?: boolean;
+		urlTemplateVariables?: boolean;
 	}
 
 	let {
@@ -30,7 +31,8 @@
 		secretBindingTargets,
 		overrideEnvField,
 		overrideEnvTemplate,
-		showRequired
+		showRequired,
+		urlTemplateVariables = false
 	}: Props = $props();
 
 	// Separate secret-bound fields from user-configurable fields, preserving
@@ -58,8 +60,18 @@
 		id={CATALOG_SERVER_FIELD_IDS.configuration}
 	>
 		<h4 class="text-sm font-semibold">
-			{serverUserType === 'singleUser' ? 'User Supplied Configuration' : 'Configuration'}
+			{urlTemplateVariables
+				? 'URL Template Variables'
+				: serverUserType === 'singleUser'
+					? 'User Supplied Configuration'
+					: 'Configuration'}
 		</h4>
+		{#if urlTemplateVariables}
+			<p class="text-muted-content text-xs font-light">
+				Define the ${'{VARIABLE}'} placeholders in the URL template. Users provide a value for each variable
+				during setup.
+			</p>
+		{/if}
 
 		{#each userConfig as { item, index: i } (i)}
 			{#if overrideEnvField?.includes(item.key) && overrideEnvTemplate}
@@ -69,45 +81,47 @@
 					class="dark:border-base-400 bg-base-300 flex w-full items-center gap-4 rounded-lg border border-transparent p-4"
 				>
 					<div class="flex w-full flex-col gap-4">
-						<div class="flex w-full flex-col gap-1">
-							<label for={`env-type-${i}`} class="text-sm font-light">Type</label>
-							<Select
-								class="dark:border-base-400 bg-base-100 border border-transparent"
-								classes={{
-									root: 'flex grow'
-								}}
-								options={[
-									{ label: 'Environment Variable', id: 'environment_variable_type' },
-									{ label: 'File', id: 'file_type' }
-								]}
-								disabled={readonly || isPrebuiltEntry}
-								selected={config![i].file ? 'file_type' : 'environment_variable_type'}
-								onSelect={(option) => {
-									if (option.id === 'file_type') {
-										config![i].file = true;
-									} else {
-										config![i].file = false;
-									}
-								}}
-								id={`env-type-${i}`}
-							/>
-						</div>
+						{#if !urlTemplateVariables}
+							<div class="flex w-full flex-col gap-1">
+								<label for={`env-type-${i}`} class="text-sm font-light">Type</label>
+								<Select
+									class="dark:border-base-400 bg-base-100 border border-transparent"
+									classes={{
+										root: 'flex grow'
+									}}
+									options={[
+										{ label: 'Environment Variable', id: 'environment_variable_type' },
+										{ label: 'File', id: 'file_type' }
+									]}
+									disabled={readonly || isPrebuiltEntry}
+									selected={config![i].file ? 'file_type' : 'environment_variable_type'}
+									onSelect={(option) => {
+										if (option.id === 'file_type') {
+											config![i].file = true;
+										} else {
+											config![i].file = false;
+										}
+									}}
+									id={`env-type-${i}`}
+								/>
+							</div>
 
-						<p class="text-muted-content text-xs font-light">
-							{#if config![i].file}
-								The value {serverUserType === 'singleUser' ? 'the user supplies' : 'you provide'} will
-								be written to a file. An environment variable will be created using the name you specify
-								in the Key field and its value will be the path to that file. This environment variable
-								will be set inside your deployment and you can reference it in the arguments section above
-								using the syntax ${'{KEY_NAME}'}.
-							{:else}
-								{serverUserType === 'singleUser'
-									? 'The value the user supplies'
-									: 'The value you provide'} will be set as an environment variable using the name you
-								specify in the Key field. This environment variable will be set inside your deployment
-								and you can reference it in the arguments section above using the syntax ${'{KEY_NAME}'}.
-							{/if}
-						</p>
+							<p class="text-muted-content text-xs font-light">
+								{#if config![i].file}
+									The value {serverUserType === 'singleUser' ? 'the user supplies' : 'you provide'} will
+									be written to a file. An environment variable will be created using the name you specify
+									in the Key field and its value will be the path to that file. This environment variable
+									will be set inside your deployment and you can reference it in the arguments section
+									above using the syntax ${'{KEY_NAME}'}.
+								{:else}
+									{serverUserType === 'singleUser'
+										? 'The value the user supplies'
+										: 'The value you provide'} will be set as an environment variable using the name you
+									specify in the Key field. This environment variable will be set inside your deployment
+									and you can reference it in the arguments section above using the syntax ${'{KEY_NAME}'}.
+								{/if}
+							</p>
+						{/if}
 
 						<CustomConfigurationFieldset
 							id={`${CATALOG_SERVER_FIELD_IDS.env}-${i}`}
@@ -120,6 +134,7 @@
 								input: inputClass
 							}}
 							{showRequired}
+							urlTemplateVariable={urlTemplateVariables}
 						/>
 					</div>
 					{#if !readonly && !isPrebuiltEntry}
@@ -151,7 +166,7 @@
 								description: '',
 								name: '',
 								value: '',
-								required: false,
+								required: urlTemplateVariables,
 								sensitive: false,
 								file: false
 							});
@@ -159,7 +174,11 @@
 					}}
 				>
 					<Plus class="size-4" />
-					{serverUserType === 'singleUser' ? 'User Configuration' : 'Configuration'}
+					{urlTemplateVariables
+						? 'URL Variable'
+						: serverUserType === 'singleUser'
+							? 'User Configuration'
+							: 'Configuration'}
 				</button>
 			</div>
 		{/if}

--- a/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
+++ b/ui/user/src/lib/components/mcp/CustomConfigurationForm.svelte
@@ -40,10 +40,16 @@
 	const indexedConfig = $derived((config ?? []).map((item, i) => ({ item, index: i })));
 	const canBindSecrets = $derived(secretBindingTargets !== undefined);
 	const userConfig = $derived(
-		canBindSecrets ? indexedConfig : indexedConfig.filter(({ item }) => !hasSecretBinding(item))
+		urlTemplateVariables
+			? indexedConfig
+			: canBindSecrets
+				? indexedConfig
+				: indexedConfig.filter(({ item }) => !hasSecretBinding(item))
 	);
 	const secretBoundEnvs = $derived(
-		canBindSecrets ? [] : indexedConfig.filter(({ item }) => hasSecretBinding(item))
+		urlTemplateVariables || canBindSecrets
+			? []
+			: indexedConfig.filter(({ item }) => hasSecretBinding(item))
 	);
 	const allSecretBound = $derived([
 		...secretBoundEnvs.map(({ item }) => ({ item, source: 'env' as const })),

--- a/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
@@ -134,7 +134,7 @@
 								</div>
 								<div class="flex w-full flex-col gap-1">
 									{#if variant === 'catalog'}
-										<label for={`env-type-${i}`} class="text-sm font-light">Value</label>
+										<label for={`header-value-type-${i}`} class="text-sm font-light">Value</label>
 										<Select
 											class="bg-base-100 dark:border-base-400 border border-transparent shadow-none"
 											classes={{
@@ -157,7 +157,7 @@
 												}
 												config.headers[i].value = '';
 											}}
-											id={`env-type-${i}`}
+											id={`header-value-type-${i}`}
 										/>
 									{/if}
 								</div>
@@ -457,8 +457,8 @@
 								<p class="font-semibold">Variable Interpolation</p>
 								<p>
 									Use <code class="rounded bg-base-300 px-1 py-0.5">${'{VARIABLE_NAME}'}</code> syntax
-									in your URL template. Variables can be populated from header values that users provide
-									during setup.
+									in your URL template. Declare each variable under URL Template Variables below. Users
+									provide the values during setup.
 								</p>
 								<p class="text-xs">
 									Example: <code class="rounded bg-base-300 px-1 py-0.5 text-xs"


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/7498 and https://github.com/obot-platform/obot/issues/7289

This now renders the URL template before generating tool preview so it can be done successfully.

Then, this also updates the UI for creating a remote server with URL template by allowing inputs for the template variables in a clear presentation.

<img width="1007" height="1290" alt="Screenshot 2026-08-06 at 12 58 30" src="https://github.com/user-attachments/assets/4c2b0732-41b1-49f9-8db3-56f8d5ee7e92" />

