### PR TITLE
fix: invalidate refresh grants for deleted MCP servers

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -25,6 +25,7 @@ import (
 	"github.com/obot-platform/obot/pkg/storage/selectors"
 	"github.com/obot-platform/obot/pkg/system"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -266,26 +267,37 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidGrant, "refresh_token is invalid", ""))
 	}
 
+	// Consume terminally invalid grants so they cannot become usable again if the referenced resource is recreated.
+	invalidGrant := func(description string) error {
+		if err := req.Delete(&oauthToken); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to invalidate oauth token: %w", err)
+		}
+		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidGrant, description, ""))
+	}
+
+	user, err := req.GatewayClient.UserInfoByID(req.Context(), oauthToken.Spec.UserID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return invalidGrant("invalid user")
+		}
+		return newOAuthError(ErrServerError, fmt.Sprintf("failed to retrieve user: %v", err), "")
+	}
+
+	allowed, err := authz.CheckMCPIDAccess(req.Context(), req.Storage, h.acrHelper, user, oauthToken.Spec.MCPID)
+	if apierrors.IsNotFound(err) {
+		return invalidGrant("invalid MCP server")
+	} else if err != nil {
+		return newOAuthError(ErrServerError, fmt.Sprintf("failed to check access to MCP server: %v", err), "")
+	}
+	if !allowed {
+		return invalidGrant("invalid MCP server")
+	}
+
 	if err := req.Delete(&oauthToken); err != nil {
 		if apierrors.IsNotFound(err) {
 			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidGrant, "refresh_token is invalid", ""))
 		}
 		return fmt.Errorf("failed to refresh oauth token: %w", err)
-	}
-
-	user, err := req.GatewayClient.UserInfoByID(req.Context(), oauthToken.Spec.UserID)
-	if err != nil {
-		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid user", ""))
-	}
-
-	allowed, err := authz.CheckMCPIDAccess(req.Context(), req.Storage, h.acrHelper, user, oauthToken.Spec.MCPID)
-	if apierrors.IsNotFound(err) {
-		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid MCP server", ""))
-	} else if err != nil {
-		return newOAuthError(ErrServerError, fmt.Sprintf("failed to check access to MCP server: %v", err), "")
-	}
-	if !allowed {
-		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidRequest, "invalid MCP server", ""))
 	}
 
 	now := time.Now()

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -269,7 +269,9 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 
 	// Consume terminally invalid grants so they cannot become usable again if the referenced resource is recreated.
 	invalidGrant := func(description string) error {
-		if err := req.Delete(&oauthToken); err != nil && !apierrors.IsNotFound(err) {
+		if err := req.Storage.Delete(req.Context(), &oauthToken); apierrors.IsNotFound(err) {
+			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidGrant, "refresh_token is invalid", ""))
+		} else if err != nil {
 			return fmt.Errorf("failed to invalidate oauth token: %w", err)
 		}
 		return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidGrant, description, ""))
@@ -293,7 +295,7 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 		return invalidGrant("invalid MCP server")
 	}
 
-	if err := req.Delete(&oauthToken); err != nil {
+	if err := req.Storage.Delete(req.Context(), &oauthToken); err != nil {
 		if apierrors.IsNotFound(err) {
 			return types.NewErrBadRequest("%v", newOAuthError(ErrInvalidGrant, "refresh_token is invalid", ""))
 		}

--- a/pkg/api/handlers/mcpgateway/oauth/token_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token_test.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/base64"
@@ -17,16 +18,32 @@ import (
 	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
 	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	"github.com/obot-platform/obot/pkg/jwt/persistent"
+	"github.com/obot-platform/obot/pkg/storage"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/storage/scheme"
 	sservices "github.com/obot-platform/obot/pkg/storage/services"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+type consumeOAuthTokenAfterGetStorage struct {
+	storage.Client
+}
+
+func (s *consumeOAuthTokenAfterGetStorage) Get(ctx context.Context, key kclient.ObjectKey, obj kclient.Object, opts ...kclient.GetOption) error {
+	if err := s.Client.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	if _, ok := obj.(*v1.OAuthToken); ok {
+		return s.Delete(ctx, obj)
+	}
+	return nil
+}
 
 func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 	const (
@@ -157,8 +174,35 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(errHTTP.Message), &oauthErr))
 	assert.Equal(t, "invalid_grant", string(oauthErr.Code))
 	assert.Equal(t, "Obot: invalid MCP server", oauthErr.Description)
-	require.Error(t, storage.Get(t.Context(), kclient.ObjectKey{
+	err = storage.Get(t.Context(), kclient.ObjectKey{
 		Namespace: system.DefaultNamespace,
 		Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(staleRefreshToken))),
-	}, &v1.OAuthToken{}))
+	}, &v1.OAuthToken{})
+	require.True(t, apierrors.IsNotFound(err), "expected NotFound after consuming stale refresh token, got %v", err)
+
+	racedRefreshToken := "concurrently-consumed-refresh-token"
+	require.NoError(t, storage.Create(t.Context(), &v1.OAuthToken{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.DefaultNamespace,
+			Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(racedRefreshToken))),
+		},
+		Spec: v1.OAuthTokenSpec{
+			ClientID: clientName,
+			Resource: baseURL,
+			UserID:   42,
+			MCPID:    system.MCPServerPrefix + "deleted",
+		},
+	}))
+
+	err = h.doRefreshToken(api.Context{
+		ResponseWriter: httptest.NewRecorder(),
+		Request:        httptest.NewRequest("POST", "/oauth/token", nil),
+		Storage:        &consumeOAuthTokenAfterGetStorage{Client: storage},
+		GatewayClient:  gatewayClient,
+	}, oauthClient, racedRefreshToken)
+	require.Error(t, err)
+	require.ErrorAs(t, err, &errHTTP)
+	require.NoError(t, json.Unmarshal([]byte(errHTTP.Message), &oauthErr))
+	assert.Equal(t, "invalid_grant", string(oauthErr.Code))
+	assert.Equal(t, "Obot: refresh_token is invalid", oauthErr.Description)
 }

--- a/pkg/api/handlers/mcpgateway/oauth/token_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token_test.go
@@ -131,4 +131,34 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(errHTTP.Message), &oauthErr))
 	assert.Equal(t, "invalid_grant", string(oauthErr.Code))
 	assert.Equal(t, "Obot: refresh_token is invalid", oauthErr.Description)
+
+	staleRefreshToken := "deleted-server-refresh-token"
+	require.NoError(t, storage.Create(t.Context(), &v1.OAuthToken{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.DefaultNamespace,
+			Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(staleRefreshToken))),
+		},
+		Spec: v1.OAuthTokenSpec{
+			ClientID: clientName,
+			Resource: baseURL,
+			UserID:   42,
+			MCPID:    system.MCPServerPrefix + "deleted",
+		},
+	}))
+
+	err = h.doRefreshToken(api.Context{
+		ResponseWriter: httptest.NewRecorder(),
+		Request:        httptest.NewRequest("POST", "/oauth/token", nil),
+		Storage:        storage,
+		GatewayClient:  gatewayClient,
+	}, oauthClient, staleRefreshToken)
+	require.Error(t, err)
+	require.ErrorAs(t, err, &errHTTP)
+	require.NoError(t, json.Unmarshal([]byte(errHTTP.Message), &oauthErr))
+	assert.Equal(t, "invalid_grant", string(oauthErr.Code))
+	assert.Equal(t, "Obot: invalid MCP server", oauthErr.Description)
+	require.Error(t, storage.Get(t.Context(), kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(staleRefreshToken))),
+	}, &v1.OAuthToken{}))
 }


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/7507

Validate the user and MCP server referenced by a refresh grant before rotating its token. Treat deleted users, missing MCP servers, and revoked MCP access as terminal invalid_grant failures so clients can reauthorize on their first reconnect attempt.

Consume terminally invalid grants to prevent replay if their referenced resource is recreated, while retaining grants when validation fails because of a transient internal error. Preserve single-use rotation semantics by returning invalid_grant when a concurrent refresh already consumed the token.

Add regression coverage for a refresh token whose MCP server was deleted, including the first-attempt invalid_grant response and stale-token cleanup.