### PR TITLE
fix: honor static catalog env in connect flow

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2747,8 +2747,10 @@ func ConvertMCPServer(server v1.MCPServer, credEnv map[string]string, serverURL,
 			continue
 		}
 
-		if _, ok := credEnv[env.Key]; !ok {
-			missingEnvVars = append(missingEnvVars, env.Key)
+		if env.Value == "" {
+			if _, ok := credEnv[env.Key]; !ok {
+				missingEnvVars = append(missingEnvVars, env.Key)
+			}
 		}
 	}
 

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -50,6 +50,28 @@ func TestServerNeedsOAuthForPendingStaticOAuth(t *testing.T) {
 	require.False(t, needsOAuth)
 }
 
+func TestConvertMCPServer_StaticEnvIsConfigured(t *testing.T) {
+	server := v1.MCPServer{
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeNPX,
+				Env: []types.MCPEnv{{
+					MCPHeader: types.MCPHeader{
+						Key:      "CATALOG_TOKEN",
+						Value:    "catalog-value",
+						Required: true,
+					},
+				}},
+			},
+		},
+	}
+
+	converted := ConvertMCPServer(server, nil, "", "")
+
+	assert.True(t, converted.Configured)
+	assert.Empty(t, converted.MissingRequiredEnvVars)
+}
+
 func TestConvertMCPResources(t *testing.T) {
 	resources := &types.MCPResourceRequirements{
 		Requests: types.MCPResourceRequests{CPU: "250m", Memory: "512Mi"},

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"strconv"
@@ -349,6 +350,17 @@ func CompositeServerToServerConfig(mcpServer v1.MCPServer, components []v1.MCPSe
 }
 
 func ServerToServerConfig(mcpServer v1.MCPServer, audiences []string, userID, scope, mcpCatalogName string, credEnv, secretsCred, staticOAuthCred map[string]string) (ServerConfig, []string, error) {
+	// Catalog-managed literal values are static configuration, not user credentials.
+	// Make them available while expanding runtime arguments, but keep them separate
+	// from credEnv so they are never persisted or exposed as user-supplied secrets.
+	runtimeCredEnv := make(map[string]string, len(credEnv)+len(mcpServer.Spec.Manifest.Env))
+	maps.Copy(runtimeCredEnv, credEnv)
+	for _, env := range mcpServer.Spec.Manifest.Env {
+		if env.Value != "" {
+			runtimeCredEnv[env.Key] = env.Value
+		}
+	}
+
 	fileEnvVars := make(map[string]struct{})
 	for _, file := range mcpServer.Spec.Manifest.Env {
 		if file.File {
@@ -430,16 +442,16 @@ func ServerToServerConfig(mcpServer v1.MCPServer, audiences []string, userID, sc
 	// Handle runtime-specific configuration
 	switch mcpServer.Spec.Manifest.Runtime {
 	case types.RuntimeUVX:
-		if err := configureUVXRuntime(&serverConfig, mcpServer.Spec.Manifest.UVXConfig, credEnv, fileEnvVars); err != nil {
+		if err := configureUVXRuntime(&serverConfig, mcpServer.Spec.Manifest.UVXConfig, runtimeCredEnv, fileEnvVars); err != nil {
 			return serverConfig, missingRequiredNames, err
 		}
 	case types.RuntimeNPX:
-		if err := configureNPXRuntime(&serverConfig, mcpServer.Spec.Manifest.NPXConfig, credEnv, fileEnvVars); err != nil {
+		if err := configureNPXRuntime(&serverConfig, mcpServer.Spec.Manifest.NPXConfig, runtimeCredEnv, fileEnvVars); err != nil {
 			return serverConfig, missingRequiredNames, err
 		}
 	case types.RuntimeContainerized:
 		serverConfig.Args = make([]string, 0, len(mcpServer.Spec.Manifest.ContainerizedConfig.Args))
-		if err := configureContainerizedRuntime(&serverConfig, mcpServer.Spec.Manifest.ContainerizedConfig, credEnv, fileEnvVars, true); err != nil {
+		if err := configureContainerizedRuntime(&serverConfig, mcpServer.Spec.Manifest.ContainerizedConfig, runtimeCredEnv, fileEnvVars, true); err != nil {
 			return serverConfig, missingRequiredNames, err
 		}
 	case types.RuntimeRemote:
@@ -455,16 +467,22 @@ func ServerToServerConfig(mcpServer v1.MCPServer, audiences []string, userID, sc
 	}
 
 	for _, env := range mcpServer.Spec.Manifest.Env {
-		val, ok := credEnv[env.Key]
-		if !ok || val == "" {
+		val := env.Value
+		isStatic := val != ""
+		if !isStatic {
+			val = runtimeCredEnv[env.Key]
+		}
+		if val == "" {
 			if env.Required {
 				missingRequiredNames = append(missingRequiredNames, env.Key)
 			}
 			continue
 		}
 
-		// Apply prefix if specified (e.g., "Bearer ", "sk-")
-		val = applyPrefix(val, env.Prefix)
+		// Static catalog values are already fully configured, like static headers.
+		if !isStatic {
+			val = applyPrefix(val, env.Prefix)
+		}
 
 		if !env.File {
 			serverConfig.Env = append(serverConfig.Env, fmt.Sprintf("%s=%s", env.Key, val))

--- a/pkg/mcp/types_test.go
+++ b/pkg/mcp/types_test.go
@@ -100,6 +100,53 @@ func TestServerToServerConfig_ContainerizedHealthzPath(t *testing.T) {
 	}
 }
 
+func TestServerToServerConfig_UsesStaticCatalogEnvValue(t *testing.T) {
+	baseURL := "http://localhost:8080"
+	mcpServer := v1.MCPServer{
+		Spec: v1.MCPServerSpec{
+			Manifest: types.MCPServerManifest{
+				Runtime: types.RuntimeNPX,
+				NPXConfig: &types.NPXRuntimeConfig{
+					Package: "example-server",
+					Args:    []string{"--token=${CATALOG_TOKEN}"},
+				},
+				Env: []types.MCPEnv{{
+					MCPHeader: types.MCPHeader{
+						Key:      "CATALOG_TOKEN",
+						Value:    "catalog-value",
+						Prefix:   "Bearer ",
+						Required: true,
+					},
+				}},
+			},
+		},
+	}
+	mcpServer.Name = "test-server"
+
+	config, missing, err := ServerToServerConfig(
+		mcpServer,
+		mcpServer.ValidConnectURLs(baseURL),
+		"test-user-id",
+		"test-scope",
+		"test-catalog",
+		nil,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(missing) > 0 {
+		t.Fatalf("expected no missing config, got %v", missing)
+	}
+	if !slices.Equal(config.Env, []string{"CATALOG_TOKEN=catalog-value"}) {
+		t.Fatalf("expected static env value, got %v", config.Env)
+	}
+	if !slices.Equal(config.Args, []string{"example-server", "--token=catalog-value"}) {
+		t.Fatalf("expected static env value to expand runtime arguments, got %v", config.Args)
+	}
+}
+
 func TestServerToServerConfig_StartupTimeoutFromRuntimeConfig(t *testing.T) {
 	baseURL := "http://localhost:8080"
 	mcpServer := v1.MCPServer{

--- a/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
+++ b/ui/user/src/routes/auth/oauth/consent/[oauth_auth_request]/+page.svelte
@@ -179,7 +179,8 @@
 				configureForm = {
 					envs: nextConsent.mcpServer.manifest.env?.map((env) => ({
 						...env,
-						value: values[env.key] ?? ''
+						value: values[env.key] ?? '',
+						isStatic: Boolean(env.value)
 					})),
 					headers: nextConsent.mcpServer.manifest.remoteConfig?.headers?.map((header) => ({
 						...header,


### PR DESCRIPTION
When a catalog entry has static env values, the connect flow would still prompt to fill them and override the static value.

Addresses https://github.com/obot-platform/obot/issues/7367