### PR TITLE
fix: report spend for Bedrock and Azure Entra models

### DIFF
--- a/docs/docs/configuration/model-providers.md
+++ b/docs/docs/configuration/model-providers.md
@@ -75,6 +75,10 @@ In the Azure portal, find your API key and endpoint URL after setting up at leas
 
 You must also specify deployment names as a comma-separated list using `deployment[:usage[:dialect]]`. Usage defaults to `llm`. Dialect defaults to `openai`; specify `anthropic` for Claude deployments. For example: `my-gpt-deployment,my-claude-deployment:llm:anthropic`.
 
+:::note
+Obot reports token counts for the Azure API key provider, but does not report estimated spend. Azure API key requests use deployment names, which Obot cannot reliably map to the underlying model's price.
+:::
+
 ##### Microsoft Entra ID Authentication
 
 Use the **Azure (Entra ID)** provider for service principal authentication via Microsoft Entra ID. Deployments are discovered automatically from the Azure Management API.

--- a/docs/docs/functionality/obot-agent-management.md
+++ b/docs/docs/functionality/obot-agent-management.md
@@ -14,6 +14,10 @@ Obot Agent Management provides administrators with tools to configure default ag
 
 View token usage across users and models to monitor costs and identify optimization opportunities.
 
+:::note
+Token counts are reported for the Azure API key provider, but estimated spend is not available because Azure API key requests use deployment names, which Obot cannot reliably map to the underlying model's price.
+:::
+
 ## Model Providers
 
 Configure LLM providers and their available models. See [Model Providers](../configuration/model-providers.md) for setup details.

--- a/pkg/controller/handlers/model/model_test.go
+++ b/pkg/controller/handlers/model/model_test.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/obot-platform/nah/pkg/apply"
 	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -40,5 +42,41 @@ func TestRemoveApplyUpdateAnnotation(t *testing.T) {
 	}
 	if updated.Annotations["keep"] != "value" {
 		t.Fatalf("unrelated annotation = %q, want value", updated.Annotations["keep"])
+	}
+}
+
+func TestEnsureModelInfoUsesExactProviderAndTargetModel(t *testing.T) {
+	model := &v1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpt-4o", Namespace: system.DefaultNamespace},
+		Spec: v1.ModelSpec{Manifest: types.ModelManifest{
+			ModelProvider: system.AzureEntraModelProvider,
+			TargetModel:   "gpt-4o",
+		}},
+	}
+	modelInfo := &v1.ModelInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      v1.ModelInfoName(system.AzureEntraModelProvider, "gpt-4o"),
+			Namespace: system.DefaultNamespace,
+		},
+		Spec: v1.ModelInfoSpec{
+			Provider: system.AzureEntraModelProvider,
+			Model:    "gpt-4o",
+			Cost: types.ModelCost{TokenUsageCost: types.TokenUsageCost{
+				Input: 2.5, Output: 10, CacheRead: 1.25,
+			}},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(modelInfo).Build()
+
+	err := new(Handler).EnsureModelInfo(router.Request{
+		Ctx:    t.Context(),
+		Client: client,
+		Object: model,
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model.Status.Cost.Input != 2.5 || model.Status.Cost.Output != 10 || model.Status.Cost.CacheRead != 1.25 {
+		t.Fatalf("model cost = %#v, want Azure Entra ModelInfo cost", model.Status.Cost)
 	}
 }

--- a/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
+++ b/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
@@ -38,6 +38,11 @@ const sampleAPIJSON = `{
       ]}}
     }
   },
+  "amazon-bedrock": {
+    "models": {
+      "anthropic.claude-haiku-4-5": {"cost": {"input": 1, "output": 5, "cache_read": 0.1}}
+    }
+  },
   "cohere": {
     "models": {
       "command-r": {"cost": {"input": 0.5, "output": 1.5}}
@@ -55,18 +60,18 @@ func mustDecodeDoc(t *testing.T, raw string) modelsDevDocument {
 func TestParseModelInfos(t *testing.T) {
 	infos, err := parseModelInfos(system.DefaultNamespace, "default", mustDecodeDoc(t, sampleAPIJSON))
 	require.NoError(t, err)
-	require.Len(t, infos, 3, "anthropic + 2 openai, cohere dropped")
+	require.Len(t, infos, 5, "anthropic + 2 openai + 2 bedrock, cohere dropped")
 
-	byModel := map[string]v1.ModelInfoSpec{}
+	byProviderAndModel := map[string]v1.ModelInfoSpec{}
 	for _, info := range infos {
 		modelInfo := info.(*v1.ModelInfo)
 		assert.Equal(t, system.DefaultNamespace, modelInfo.Namespace)
 		assert.Equal(t, "default", modelInfo.Spec.ModelInfoSourceName)
 		assert.NotEmpty(t, modelInfo.Name)
-		byModel[modelInfo.Spec.Model] = modelInfo.Spec
+		byProviderAndModel[modelInfo.Spec.Provider+"/"+modelInfo.Spec.Model] = modelInfo.Spec
 	}
 
-	a := byModel["claude-opus-4-5"]
+	a := byProviderAndModel[system.AnthropicModelProvider+"/claude-opus-4-5"]
 	assert.Equal(t, system.AnthropicModelProvider, a.Provider)
 	assert.Equal(t, 5.0, a.Cost.Input)
 	assert.Equal(t, 25.0, a.Cost.Output)
@@ -74,18 +79,26 @@ func TestParseModelInfos(t *testing.T) {
 	assert.Equal(t, 10.0, a.Cost.CacheWrite1h, "anthropic 1h cache is 2x input")
 	assert.Empty(t, a.Cost.Tiers)
 
-	o := byModel["gpt-4o"]
+	o := byProviderAndModel[system.OpenAIModelProvider+"/gpt-4o"]
 	assert.Equal(t, system.OpenAIModelProvider, o.Provider)
 	assert.Zero(t, o.Cost.CacheWrite, "absent in source")
 	assert.Zero(t, o.Cost.CacheWrite1h, "non-anthropic gets no 1h cache")
 
-	g := byModel["gpt-5"]
+	g := byProviderAndModel[system.OpenAIModelProvider+"/gpt-5"]
 	require.Len(t, g.Cost.Tiers, 1, "only the context tier with a positive size is kept")
 	tier := g.Cost.Tiers[0]
 	assert.Equal(t, types.ModelCostTierTypeContext, tier.Type)
 	require.NotNil(t, tier.Size)
 	assert.Equal(t, 272000, *tier.Size)
 	assert.Equal(t, 5.0, tier.Input)
+
+	for _, provider := range []string{system.AmazonBedrockModelProvider, system.AmazonBedrockAPIKeyModelProvider} {
+		b := byProviderAndModel[provider+"/anthropic.claude-haiku-4-5"]
+		assert.Equal(t, provider, b.Provider)
+		assert.Equal(t, 1.0, b.Cost.Input)
+		assert.Equal(t, 5.0, b.Cost.Output)
+		assert.Equal(t, 0.1, b.Cost.CacheRead)
+	}
 }
 
 func TestParseModelInfos_NoKnownProviders(t *testing.T) {

--- a/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
+++ b/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
@@ -43,6 +43,11 @@ const sampleAPIJSON = `{
       "anthropic.claude-haiku-4-5": {"cost": {"input": 1, "output": 5, "cache_read": 0.1}}
     }
   },
+  "azure": {
+    "models": {
+      "gpt-4o": {"cost": {"input": 2.5, "output": 10, "cache_read": 1.25}}
+    }
+  },
   "cohere": {
     "models": {
       "command-r": {"cost": {"input": 0.5, "output": 1.5}}
@@ -60,7 +65,7 @@ func mustDecodeDoc(t *testing.T, raw string) modelsDevDocument {
 func TestParseModelInfos(t *testing.T) {
 	infos, err := parseModelInfos(system.DefaultNamespace, "default", mustDecodeDoc(t, sampleAPIJSON))
 	require.NoError(t, err)
-	require.Len(t, infos, 5, "anthropic + 2 openai + 2 bedrock, cohere dropped")
+	require.Len(t, infos, 6, "anthropic + 2 openai + 2 bedrock + Azure Entra, cohere dropped")
 
 	byProviderAndModel := map[string]v1.ModelInfoSpec{}
 	for _, info := range infos {
@@ -99,6 +104,12 @@ func TestParseModelInfos(t *testing.T) {
 		assert.Equal(t, 5.0, b.Cost.Output)
 		assert.Equal(t, 0.1, b.Cost.CacheRead)
 	}
+
+	azure := byProviderAndModel[system.AzureEntraModelProvider+"/gpt-4o"]
+	assert.Equal(t, system.AzureEntraModelProvider, azure.Provider)
+	assert.Equal(t, 2.5, azure.Cost.Input)
+	assert.Equal(t, 10.0, azure.Cost.Output)
+	assert.Equal(t, 1.25, azure.Cost.CacheRead)
 }
 
 func TestParseModelInfos_NoKnownProviders(t *testing.T) {

--- a/pkg/controller/handlers/modelinfosource/modelsdev.go
+++ b/pkg/controller/handlers/modelinfosource/modelsdev.go
@@ -13,10 +13,13 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// providerIDToObotProvider maps source provider IDs to Obot provider names.
-var providerIDToObotProvider = map[string]string{
-	"anthropic": system.AnthropicModelProvider,
-	"openai":    system.OpenAIModelProvider,
+// obotProviderToProviderID maps Obot provider names to their models.dev source
+// provider IDs. Both Bedrock authentication methods share Bedrock pricing.
+var obotProviderToProviderID = map[string]string{
+	system.AnthropicModelProvider:           "anthropic",
+	system.OpenAIModelProvider:              "openai",
+	system.AmazonBedrockModelProvider:       "amazon-bedrock",
+	system.AmazonBedrockAPIKeyModelProvider: "amazon-bedrock",
 }
 
 // fetchModelInfos GETs the models.dev document at the source URL and parses it
@@ -78,7 +81,7 @@ type modelsDevTier struct {
 // given namespace, owned by the named source.
 func parseModelInfos(namespace, sourceName string, doc modelsDevDocument) ([]kclient.Object, error) {
 	var infos []kclient.Object
-	for providerID, obotProvider := range providerIDToObotProvider {
+	for obotProvider, providerID := range obotProviderToProviderID {
 		provider, ok := doc[providerID]
 		if !ok {
 			continue

--- a/pkg/controller/handlers/modelinfosource/modelsdev.go
+++ b/pkg/controller/handlers/modelinfosource/modelsdev.go
@@ -20,6 +20,7 @@ var obotProviderToProviderID = map[string]string{
 	system.OpenAIModelProvider:              "openai",
 	system.AmazonBedrockModelProvider:       "amazon-bedrock",
 	system.AmazonBedrockAPIKeyModelProvider: "amazon-bedrock",
+	system.AzureEntraModelProvider:          "azure",
 }
 
 // fetchModelInfos GETs the models.dev document at the source URL and parses it


### PR DESCRIPTION
Addresses #7511

## Summary
- Sync models.dev Bedrock pricing for both Bedrock providers.
- Sync exact-match Azure pricing for the Azure Entra provider.
- Document that Azure API-key usage reports token counts but not estimated spend.

## Testing
- go test ./pkg/controller/handlers/modelinfosource ./pkg/controller/handlers/model
- go test ./pkg/gateway/server

## Manual pricing refresh

```sh
OBOT_TOKEN="$(obot login --url http://localhost:8080 --scope api --print-token)" curl -X POST http://localhost:8080/api/model-info-source/refresh -H "Authorization: Bearer $OBOT_TOKEN"
```