### PR TITLE
fix: deployment k8s details & devices sorted fixes

### DIFF
--- a/apiclient/types/mcpserver.go
+++ b/apiclient/types/mcpserver.go
@@ -347,7 +347,7 @@ type MCPServer struct {
 	// This is only set for multi-user servers.
 	MCPServerInstanceUserCount *int `json:"mcpServerInstanceUserCount,omitempty"`
 
-	// DeploymentStatus indicates the overall status of the MCP server deployment (Ready, Progressing, Failed).
+	// DeploymentStatus indicates the overall status of the MCP server deployment (Available, Progressing, Unavailable, Needs Attention, Shutdown, Unknown).
 	DeploymentStatus string `json:"deploymentStatus,omitempty"`
 
 	// DeploymentAvailableReplicas is the number of available replicas in the deployment.

--- a/pkg/api/handlers/mcpcapacity.go
+++ b/pkg/api/handlers/mcpcapacity.go
@@ -23,12 +23,10 @@ func NewMCPCapacityHandler(mcpSessionManager *mcp.SessionManager) *MCPCapacityHa
 func (h *MCPCapacityHandler) GetCapacity(req api.Context) error {
 	info, err := h.mcpSessionManager.GetCapacityInfo(req.Context())
 	if err != nil {
-		// If backend doesn't support capacity info (e.g., Docker), return empty info
+		// If backend doesn't support capacity info (e.g., Docker), return bad request.
 		var notSupported *mcp.ErrNotSupportedByBackend
 		if errors.As(err, &notSupported) {
-			return req.Write(types.MCPCapacityInfo{
-				Error: notSupported.Error(),
-			})
+			return types.NewErrBadRequest("%s", notSupported.Error())
 		}
 		return err
 	}

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -578,6 +578,54 @@ func (h *MCPCatalogHandler) AdminListServersForEntryInCatalog(req api.Context) e
 	return req.Write(types.MCPServerList{Items: items})
 }
 
+// GetEntryCapacity returns MCP capacity info for deployments tied to a catalog entry.
+func (h *MCPCatalogHandler) GetEntryCapacity(req api.Context) error {
+	catalogName := req.PathValue("catalog_id")
+	entryName := req.PathValue("entry_id")
+
+	var catalog v1.MCPCatalog
+	if err := req.Get(&catalog, catalogName); err != nil {
+		return fmt.Errorf("failed to get catalog: %w", err)
+	}
+
+	var entry v1.MCPServerCatalogEntry
+	if err := req.Get(&entry, entryName); err != nil {
+		return fmt.Errorf("failed to get entry: %w", err)
+	}
+
+	if entry.Spec.MCPCatalogName != catalogName {
+		return types.NewErrBadRequest("entry does not belong to catalog")
+	}
+
+	var list v1.MCPServerList
+	if err := req.List(&list, client.MatchingFields{
+		"spec.mcpServerCatalogEntryName": entryName,
+	}); err != nil {
+		return fmt.Errorf("failed to list servers: %w", err)
+	}
+
+	serverNames := make([]string, 0, len(list.Items))
+	for _, server := range list.Items {
+		if server.Spec.Template {
+			continue
+		}
+		serverNames = append(serverNames, server.Name)
+	}
+
+	info, err := h.sessionManager.GetCapacityInfoForServers(req.Context(), serverNames)
+	if err != nil {
+		var notSupported *mcp.ErrNotSupportedByBackend
+		if errors.As(err, &notSupported) {
+			return req.Write(types.MCPCapacityInfo{
+				Error: notSupported.Error(),
+			})
+		}
+		return err
+	}
+
+	return req.Write(info)
+}
+
 // AdminListServersForAllEntriesInCatalog returns all servers for all entries in a catalog.
 func (h *MCPCatalogHandler) AdminListServersForAllEntriesInCatalog(req api.Context) error {
 	catalogName := req.PathValue("catalog_id")

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -625,9 +625,7 @@ func (h *MCPCatalogHandler) GetEntryCapacity(req api.Context) error {
 	if err != nil {
 		var notSupported *mcp.ErrNotSupportedByBackend
 		if errors.As(err, &notSupported) {
-			return req.Write(types.MCPCapacityInfo{
-				Error: notSupported.Error(),
-			})
+			return types.NewErrBadRequest("%s", notSupported.Error())
 		}
 		return err
 	}

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -35,10 +35,15 @@ type MCPCatalogHandler struct {
 	serverURL                 string
 	mcpBackend                string
 	sessionManager            *mcp.SessionManager
+	capacityInfoProvider      capacityInfoProvider
 	oauthChecker              MCPOAuthChecker
 	gatewayClient             *gclient.Client
 	acrHelper                 *accesscontrolrule.Helper
 	secretBindingAllowedLabel string
+}
+
+type capacityInfoProvider interface {
+	GetCapacityInfoForServers(context.Context, []string) (types.MCPCapacityInfo, error)
 }
 
 func NewMCPCatalogHandler(defaultCatalogPath string, serverURL string, mcpBackend string, sessionManager *mcp.SessionManager, oauthChecker MCPOAuthChecker, gatewayClient *gclient.Client, acrHelper *accesscontrolrule.Helper, secretBindingAllowedLabel string) *MCPCatalogHandler {
@@ -47,6 +52,7 @@ func NewMCPCatalogHandler(defaultCatalogPath string, serverURL string, mcpBacken
 		serverURL:                 serverURL,
 		mcpBackend:                mcpBackend,
 		sessionManager:            sessionManager,
+		capacityInfoProvider:      sessionManager,
 		oauthChecker:              oauthChecker,
 		gatewayClient:             gatewayClient,
 		acrHelper:                 acrHelper,
@@ -596,6 +602,9 @@ func (h *MCPCatalogHandler) GetEntryCapacity(req api.Context) error {
 	if entry.Spec.MCPCatalogName != catalogName {
 		return types.NewErrBadRequest("entry does not belong to catalog")
 	}
+	if entry.Spec.Manifest.Runtime == types.RuntimeRemote || entry.Spec.Manifest.Runtime == types.RuntimeComposite {
+		return types.NewErrBadRequest("capacity is only supported for hosted catalog entries")
+	}
 
 	var list v1.MCPServerList
 	if err := req.List(&list, client.MatchingFields{
@@ -612,7 +621,7 @@ func (h *MCPCatalogHandler) GetEntryCapacity(req api.Context) error {
 		serverNames = append(serverNames, server.Name)
 	}
 
-	info, err := h.sessionManager.GetCapacityInfoForServers(req.Context(), serverNames)
+	info, err := h.capacityInfoProvider.GetCapacityInfoForServers(req.Context(), serverNames)
 	if err != nil {
 		var notSupported *mcp.ErrNotSupportedByBackend
 		if errors.As(err, &notSupported) {

--- a/pkg/api/handlers/mcpcatalogs_test.go
+++ b/pkg/api/handlers/mcpcatalogs_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,6 +46,123 @@ func TestAcceptCatalogEntryOwnership(t *testing.T) {
 	assert.Empty(t, entry.Spec.Manifest.EntryKey)
 	assert.False(t, entry.Spec.Detached)
 	assert.Equal(t, "true", entry.Annotations["example.com/keep"])
+}
+
+type fakeCapacityInfoProvider struct {
+	serverNames []string
+	info        types.MCPCapacityInfo
+	err         error
+}
+
+func (f *fakeCapacityInfoProvider) GetCapacityInfoForServers(_ context.Context, serverNames []string) (types.MCPCapacityInfo, error) {
+	f.serverNames = append([]string(nil), serverNames...)
+	return f.info, f.err
+}
+
+func TestMCPCatalogHandlerGetEntryCapacity(t *testing.T) {
+	tests := []struct {
+		name             string
+		entryCatalogName string
+		entryRuntime     types.Runtime
+		servers          []v1.MCPServer
+		providerInfo     types.MCPCapacityInfo
+		providerErr      error
+		wantServerNames  []string
+		wantErr          string
+		wantResponse     types.MCPCapacityInfo
+	}{
+		{
+			name:             "returns capacity for matching deployments",
+			entryCatalogName: "catalog-1",
+			entryRuntime:     types.RuntimeContainerized,
+			servers: []v1.MCPServer{{
+				ObjectMeta: metav1.ObjectMeta{Name: "server-1", Namespace: system.DefaultNamespace},
+				Spec:       v1.MCPServerSpec{MCPServerCatalogEntryName: "entry-1"},
+			}},
+			providerInfo:    types.MCPCapacityInfo{Source: types.CapacitySourceDeployments, ActiveDeployments: 1},
+			wantServerNames: []string{"server-1"},
+			wantResponse:    types.MCPCapacityInfo{Source: types.CapacitySourceDeployments, ActiveDeployments: 1},
+		},
+		{
+			name:             "excludes template deployments",
+			entryCatalogName: "catalog-1",
+			entryRuntime:     types.RuntimeContainerized,
+			servers: []v1.MCPServer{
+				{ObjectMeta: metav1.ObjectMeta{Name: "template-server", Namespace: system.DefaultNamespace}, Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "entry-1", Template: true}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "server-1", Namespace: system.DefaultNamespace}, Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "entry-1"}},
+			},
+			providerInfo:    types.MCPCapacityInfo{ActiveDeployments: 1},
+			wantServerNames: []string{"server-1"},
+			wantResponse:    types.MCPCapacityInfo{ActiveDeployments: 1},
+		},
+		{
+			name:             "rejects composite catalog entry",
+			entryCatalogName: "catalog-1",
+			entryRuntime:     types.RuntimeComposite,
+			wantErr:          "capacity is only supported for hosted catalog entries",
+		},
+		{
+			name:             "rejects remote catalog entry",
+			entryCatalogName: "catalog-1",
+			entryRuntime:     types.RuntimeRemote,
+			wantErr:          "capacity is only supported for hosted catalog entries",
+		},
+		{
+			name:             "rejects entry from another catalog",
+			entryCatalogName: "catalog-2",
+			wantErr:          "entry does not belong to catalog",
+		},
+		{
+			name:             "returns backend not supported as capacity error",
+			entryCatalogName: "catalog-1",
+			entryRuntime:     types.RuntimeContainerized,
+			providerErr:      &mcp.ErrNotSupportedByBackend{Feature: "capacity info", Backend: "docker"},
+			wantResponse:     types.MCPCapacityInfo{Error: "feature capacity info is not supported by docker backend"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &fakeCapacityInfoProvider{info: tt.providerInfo, err: tt.providerErr}
+			objects := []client.Object{
+				&v1.MCPCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1", Namespace: system.DefaultNamespace}},
+				&v1.MCPServerCatalogEntry{
+					ObjectMeta: metav1.ObjectMeta{Name: "entry-1", Namespace: system.DefaultNamespace},
+					Spec: v1.MCPServerCatalogEntrySpec{
+						MCPCatalogName: tt.entryCatalogName,
+						Manifest:       types.MCPServerCatalogEntryManifest{Runtime: tt.entryRuntime},
+					},
+				},
+			}
+			for i := range tt.servers {
+				server := tt.servers[i]
+				objects = append(objects, &server)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/mcp-catalogs/catalog-1/entries/entry-1/mcp-capacity", nil)
+			req.SetPathValue("catalog_id", "catalog-1")
+			req.SetPathValue("entry_id", "entry-1")
+			rec := httptest.NewRecorder()
+			err := (&MCPCatalogHandler{capacityInfoProvider: provider}).GetEntryCapacity(api.Context{
+				ResponseWriter: rec,
+				Request:        req,
+				Storage:        newFakeStorage(t, objects...),
+			})
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Empty(t, provider.serverNames)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantServerNames, provider.serverNames)
+
+			var got types.MCPCapacityInfo
+			require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+			assert.Equal(t, tt.wantResponse, got)
+		})
+	}
 }
 
 func TestNormalizeName(t *testing.T) {

--- a/pkg/api/handlers/mcpcatalogs_test.go
+++ b/pkg/api/handlers/mcpcatalogs_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
@@ -55,7 +56,7 @@ type fakeCapacityInfoProvider struct {
 }
 
 func (f *fakeCapacityInfoProvider) GetCapacityInfoForServers(_ context.Context, serverNames []string) (types.MCPCapacityInfo, error) {
-	f.serverNames = append([]string(nil), serverNames...)
+	f.serverNames = slices.Clone(serverNames)
 	return f.info, f.err
 }
 
@@ -113,11 +114,11 @@ func TestMCPCatalogHandlerGetEntryCapacity(t *testing.T) {
 			wantErr:          "entry does not belong to catalog",
 		},
 		{
-			name:             "returns backend not supported as capacity error",
+			name:             "rejects unsupported backend",
 			entryCatalogName: "catalog-1",
 			entryRuntime:     types.RuntimeContainerized,
 			providerErr:      &mcp.ErrNotSupportedByBackend{Feature: "capacity info", Backend: "docker"},
-			wantResponse:     types.MCPCapacityInfo{Error: "feature capacity info is not supported by docker backend"},
+			wantErr:          "feature capacity info is not supported by docker backend",
 		},
 	}
 

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -254,6 +254,7 @@ func Router(ctx context.Context, services *services.Services) (http.Handler, err
 	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/entries/{entry_id}/accept-ownership", mcpCatalogs.AcceptEntryOwnership)
 	mux.HandleFunc("DELETE /api/mcp-catalogs/{catalog_id}/entries/{entry_id}", mcpCatalogs.DeleteEntry)
 	mux.HandleFunc("GET /api/mcp-catalogs/{catalog_id}/entries/{entry_id}/servers", mcpCatalogs.AdminListServersForEntryInCatalog)
+	mux.HandleFunc("GET /api/mcp-catalogs/{catalog_id}/entries/{entry_id}/mcp-capacity", mcpCatalogs.GetEntryCapacity)
 	mux.HandleFunc("GET /api/mcp-catalogs/{catalog_id}/entries/{entry_id}/servers/{mcp_server_id}/k8s-settings-status", mcp.CheckK8sSettingsStatus)
 	mux.HandleFunc("POST /api/mcp-catalogs/{catalog_id}/entries/{entry_id}/servers/{mcp_server_id}/redeploy-with-k8s-settings", mcp.RedeployWithK8sSettings)
 	mux.HandleFunc("GET /api/mcp-catalogs/{catalog_id}/entries/all-servers", mcpCatalogs.AdminListServersForAllEntriesInCatalog)

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -2124,6 +2124,8 @@ func (k *kubernetesBackend) getResourceQuotaCapacity(ctx context.Context, allowe
 		info.CPURequested = formatCPU(totalCPUUsed)
 		info.MemoryRequested = formatMemory(totalMemoryUsed)
 		info.ActiveDeployments = k.countActiveDeployments(ctx)
+	} else {
+		info.Error = "failed to list deployments"
 	}
 
 	return info, true

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -2045,17 +2045,31 @@ func (k *kubernetesBackend) checkResourceQuotaCapacity(ctx context.Context, memo
 // Used by the admin capacity endpoint.
 func (k *kubernetesBackend) GetCapacityInfo(ctx context.Context) types.MCPCapacityInfo {
 	// Try ResourceQuota first - this is the only accurate source
-	if info, ok := k.getResourceQuotaCapacity(ctx); ok {
+	if info, ok := k.getResourceQuotaCapacity(ctx, nil); ok {
 		return info
 	}
 
 	// Fallback to deployment aggregation only (no limits, just totals)
 	// Node metrics are intentionally not used because they don't account for
 	// taints, affinity, or other scheduling constraints.
-	return k.getDeploymentCapacity(ctx)
+	return k.getDeploymentCapacity(ctx, nil)
 }
 
-func (k *kubernetesBackend) getResourceQuotaCapacity(ctx context.Context) (types.MCPCapacityInfo, bool) {
+func (k *kubernetesBackend) GetCapacityInfoForServers(ctx context.Context, serverNames []string) types.MCPCapacityInfo {
+	allowed := make(map[string]struct{}, len(serverNames))
+	for _, name := range serverNames {
+		if name != "" {
+			allowed[name] = struct{}{}
+		}
+	}
+
+	if info, ok := k.getResourceQuotaCapacity(ctx, allowed); ok {
+		return info
+	}
+	return k.getDeploymentCapacity(ctx, allowed)
+}
+
+func (k *kubernetesBackend) getResourceQuotaCapacity(ctx context.Context, allowed map[string]struct{}) (types.MCPCapacityInfo, bool) {
 	quotas, err := k.clientset.CoreV1().ResourceQuotas(k.mcpNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil || len(quotas.Items) == 0 {
 		return types.MCPCapacityInfo{}, false
@@ -2083,29 +2097,21 @@ func (k *kubernetesBackend) getResourceQuotaCapacity(ctx context.Context) (types
 	deployments, err := k.clientset.AppsV1().Deployments(k.mcpNamespace).List(ctx, metav1.ListOptions{})
 	if err == nil {
 		var totalCPU, totalMemory resource.Quantity
+		active := 0
 		for _, deployment := range deployments.Items {
-			replicas := int64(1)
-			if deployment.Spec.Replicas != nil {
-				replicas = int64(*deployment.Spec.Replicas)
-			}
-			for _, container := range deployment.Spec.Template.Spec.Containers {
-				if cpu, ok := container.Resources.Requests[corev1.ResourceCPU]; ok {
-					scaled := cpu.DeepCopy()
-					scaled.SetMilli(scaled.MilliValue() * replicas)
-					totalCPU.Add(scaled)
-				}
-				if mem, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
-					scaled := mem.DeepCopy()
-					scaled.Set(scaled.Value() * replicas)
-					totalMemory.Add(scaled)
+			if allowed != nil {
+				if _, ok := allowed[deployment.Name]; !ok {
+					continue
 				}
 			}
+			addDeploymentResourceRequests(deployment, &totalCPU, &totalMemory)
+			active++
 		}
 		info.CPURequested = formatCPU(totalCPU)
 		info.MemoryRequested = formatMemory(totalMemory)
-		info.ActiveDeployments = len(deployments.Items)
-	} else {
-		// Fallback to ResourceQuota status if deployment list fails
+		info.ActiveDeployments = active
+	} else if allowed == nil {
+		// Fallback to ResourceQuota status if deployment list fails (namespace-wide only)
 		var totalCPUUsed, totalMemoryUsed resource.Quantity
 		for _, quota := range quotas.Items {
 			if used, ok := quota.Status.Used[corev1.ResourceRequestsCPU]; ok {
@@ -2123,7 +2129,7 @@ func (k *kubernetesBackend) getResourceQuotaCapacity(ctx context.Context) (types
 	return info, true
 }
 
-func (k *kubernetesBackend) getDeploymentCapacity(ctx context.Context) types.MCPCapacityInfo {
+func (k *kubernetesBackend) getDeploymentCapacity(ctx context.Context, allowed map[string]struct{}) types.MCPCapacityInfo {
 	info := types.MCPCapacityInfo{
 		Source: types.CapacitySourceDeployments,
 	}
@@ -2135,30 +2141,41 @@ func (k *kubernetesBackend) getDeploymentCapacity(ctx context.Context) types.MCP
 	}
 
 	var totalCPU, totalMemory resource.Quantity
+	active := 0
 	for _, deployment := range deployments.Items {
-		replicas := int64(1)
-		if deployment.Spec.Replicas != nil {
-			replicas = int64(*deployment.Spec.Replicas)
-		}
-		for _, container := range deployment.Spec.Template.Spec.Containers {
-			if cpu, ok := container.Resources.Requests[corev1.ResourceCPU]; ok {
-				scaled := cpu.DeepCopy()
-				scaled.SetMilli(scaled.MilliValue() * replicas)
-				totalCPU.Add(scaled)
-			}
-			if mem, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
-				scaled := mem.DeepCopy()
-				scaled.Set(scaled.Value() * replicas)
-				totalMemory.Add(scaled)
+		if allowed != nil {
+			if _, ok := allowed[deployment.Name]; !ok {
+				continue
 			}
 		}
+		addDeploymentResourceRequests(deployment, &totalCPU, &totalMemory)
+		active++
 	}
 
 	info.CPURequested = formatCPU(totalCPU)
 	info.MemoryRequested = formatMemory(totalMemory)
-	info.ActiveDeployments = len(deployments.Items)
+	info.ActiveDeployments = active
 
 	return info
+}
+
+func addDeploymentResourceRequests(deployment appsv1.Deployment, totalCPU, totalMemory *resource.Quantity) {
+	replicas := int64(1)
+	if deployment.Spec.Replicas != nil {
+		replicas = int64(*deployment.Spec.Replicas)
+	}
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if cpu, ok := container.Resources.Requests[corev1.ResourceCPU]; ok {
+			scaled := cpu.DeepCopy()
+			scaled.SetMilli(scaled.MilliValue() * replicas)
+			totalCPU.Add(scaled)
+		}
+		if mem, ok := container.Resources.Requests[corev1.ResourceMemory]; ok {
+			scaled := mem.DeepCopy()
+			scaled.Set(scaled.Value() * replicas)
+			totalMemory.Add(scaled)
+		}
+	}
 }
 
 func (k *kubernetesBackend) countActiveDeployments(ctx context.Context) int {

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -523,17 +523,17 @@ func (sm *SessionManager) GenerateToolPreviews(ctx context.Context, tempMCPServe
 // GetCapacityInfo returns capacity information for the MCP namespace.
 // Only available when using the Kubernetes backend.
 func (sm *SessionManager) GetCapacityInfo(ctx context.Context) (types.MCPCapacityInfo, error) {
-	if k8sBackend, ok := sm.backend.(*kubernetesBackend); ok {
-		return k8sBackend.GetCapacityInfo(ctx), nil
+	if sm == nil || !IsKubernetesBackend(sm.runtimeBackend) {
+		return types.MCPCapacityInfo{}, &ErrNotSupportedByBackend{Feature: "capacity info", Backend: "docker"}
 	}
-	return types.MCPCapacityInfo{}, &ErrNotSupportedByBackend{Feature: "capacity info", Backend: "docker"}
+	return sm.backend.(*kubernetesBackend).GetCapacityInfo(ctx), nil
 }
 
 // GetCapacityInfoForServers returns capacity information for the given MCP server deployments.
 // Only available when using the Kubernetes backend.
 func (sm *SessionManager) GetCapacityInfoForServers(ctx context.Context, serverNames []string) (types.MCPCapacityInfo, error) {
-	if k8sBackend, ok := sm.backend.(*kubernetesBackend); ok {
-		return k8sBackend.GetCapacityInfoForServers(ctx, serverNames), nil
+	if sm == nil || !IsKubernetesBackend(sm.runtimeBackend) {
+		return types.MCPCapacityInfo{}, &ErrNotSupportedByBackend{Feature: "capacity info", Backend: "docker"}
 	}
-	return types.MCPCapacityInfo{}, &ErrNotSupportedByBackend{Feature: "capacity info", Backend: "docker"}
+	return sm.backend.(*kubernetesBackend).GetCapacityInfoForServers(ctx, serverNames), nil
 }

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -528,3 +528,12 @@ func (sm *SessionManager) GetCapacityInfo(ctx context.Context) (types.MCPCapacit
 	}
 	return types.MCPCapacityInfo{}, &ErrNotSupportedByBackend{Feature: "capacity info", Backend: "docker"}
 }
+
+// GetCapacityInfoForServers returns capacity information for the given MCP server deployments.
+// Only available when using the Kubernetes backend.
+func (sm *SessionManager) GetCapacityInfoForServers(ctx context.Context, serverNames []string) (types.MCPCapacityInfo, error) {
+	if k8sBackend, ok := sm.backend.(*kubernetesBackend); ok {
+		return k8sBackend.GetCapacityInfoForServers(ctx, serverNames), nil
+	}
+	return types.MCPCapacityInfo{}, &ErrNotSupportedByBackend{Feature: "capacity info", Backend: "docker"}
+}

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -10160,7 +10160,7 @@ func schema_obot_platform_obot_apiclient_types_MCPServer(ref common.ReferenceCal
 					},
 					"deploymentStatus": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DeploymentStatus indicates the overall status of the MCP server deployment (Ready, Progressing, Failed).",
+							Description: "DeploymentStatus indicates the overall status of the MCP server deployment (Available, Progressing, Unavailable, Needs Attention, Shutdown, Unknown).",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/ui/user/src/lib/components/admin/McpServerInstances.svelte
+++ b/ui/user/src/lib/components/admin/McpServerInstances.svelte
@@ -108,6 +108,7 @@
 			{usersMap}
 			{onReload}
 			skipLoadOnMount
+			catalogEntryId={entry?.id}
 		/>
 	{:else}
 		{@render emptyInstancesContent()}

--- a/ui/user/src/lib/components/admin/McpServerInstances.svelte
+++ b/ui/user/src/lib/components/admin/McpServerInstances.svelte
@@ -108,7 +108,7 @@
 			{usersMap}
 			{onReload}
 			skipLoadOnMount
-			catalogEntryId={entry?.id}
+			{entry}
 		/>
 	{:else}
 		{@render emptyInstancesContent()}

--- a/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
+++ b/ui/user/src/lib/components/admin/McpServerK8sInfo.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
+	import { parseErrorContent } from '$lib/errors';
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
@@ -621,20 +622,21 @@
 	{/if}
 
 	{#if hasAdminAccess}
+		{@const status = isPending
+			? 'Pending'
+			: missingSecretBindings.length > 0
+				? 'Missing Kubernetes Secret'
+				: needsUpdate
+					? 'Configuration Required'
+					: 'Error'}
 		<div class="flex flex-col gap-2">
 			<div
 				class="dark:bg-base-200 dark:border-base-400 bg-base-100 flex flex-col rounded-lg border border-transparent p-4 shadow-sm"
 			>
-				<div class="grid grid-cols-2 gap-4">
-					<p class="text-sm font-semibold">Status</p>
-					<p class="text-sm font-light">
-						{isPending
-							? 'Pending'
-							: missingSecretBindings.length > 0
-								? 'Missing Kubernetes Secret'
-								: needsUpdate
-									? 'Configuration Required'
-									: 'Error'}
+				<div class="grid grid-cols-2 gap-1 md:gap-4">
+					<p class="text-sm font-semibold col-span-2 md:col-span-1">Status</p>
+					<p class="text-sm font-light col-span-2 md:col-span-1">
+						{status}{status === 'Error' ? `: ${parseErrorContent(error).message}` : ''}
 					</p>
 				</div>
 			</div>

--- a/ui/user/src/lib/components/admin/devices/Devices.svelte
+++ b/ui/user/src/lib/components/admin/devices/Devices.svelte
@@ -192,7 +192,16 @@
 			{ title: 'Clients', property: 'client_count' },
 			{ title: 'Last Scanned', property: 'scannedAt' }
 		]}
-		sortable={['short_device_id', 'os_arch', 'username', 'scannedAt']}
+		sortable={[
+			'short_device_id',
+			'os_arch',
+			'username',
+			'mcp_count',
+			'skill_count',
+			'plugin_count',
+			'client_count',
+			'scannedAt'
+		]}
 		{filterable}
 		onClickRow={(d, isCtrlClick) => {
 			openUrl(resolve(`/admin/devices/${d.deviceID}`), isCtrlClick);

--- a/ui/user/src/lib/components/mcp/CapacityBanner.svelte
+++ b/ui/user/src/lib/components/mcp/CapacityBanner.svelte
@@ -16,11 +16,12 @@
 	let loading = $state(true);
 
 	async function fetchCapacity() {
+		const opts = { dontLogErrors: true };
 		try {
 			capacityInfo =
 				catalogId && catalogEntryId
-					? await AdminService.getMCPCatalogEntryCapacity(catalogId, catalogEntryId)
-					: await AdminService.getMCPCapacity();
+					? await AdminService.getMCPCatalogEntryCapacity(catalogId, catalogEntryId, opts)
+					: await AdminService.getMCPCapacity(opts);
 		} catch {
 			// Silently fail - banner just won't show
 			capacityInfo = null;

--- a/ui/user/src/lib/components/mcp/CapacityBanner.svelte
+++ b/ui/user/src/lib/components/mcp/CapacityBanner.svelte
@@ -6,12 +6,21 @@
 	import { Info } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 
+	interface Props {
+		catalogId?: string;
+		catalogEntryId?: string;
+	}
+
+	let { catalogId, catalogEntryId }: Props = $props();
 	let capacityInfo = $state<MCPCapacityInfo | null>(null);
 	let loading = $state(true);
 
 	async function fetchCapacity() {
 		try {
-			capacityInfo = await AdminService.getMCPCapacity();
+			capacityInfo =
+				catalogId && catalogEntryId
+					? await AdminService.getMCPCatalogEntryCapacity(catalogId, catalogEntryId)
+					: await AdminService.getMCPCapacity();
 		} catch {
 			// Silently fail - banner just won't show
 			capacityInfo = null;

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -76,7 +76,7 @@
 		servers?: MCPCatalogServer[];
 		skipLoadOnMount?: boolean;
 		serverPrefixPath?: string;
-		catalogEntryId?: string;
+		entry?: MCPCatalogEntry | MCPCatalogServer;
 	}
 
 	let {
@@ -97,10 +97,20 @@
 		servers: initialServers,
 		skipLoadOnMount,
 		serverPrefixPath,
-		catalogEntryId
+		entry
 	}: Props = $props();
 
 	const doesSupportK8sUpdates = $derived(version.current.engine === 'kubernetes');
+	const supportsCapacity = $derived.by(() => {
+		if (entity !== 'catalog' || !doesSupportK8sUpdates || !profile.current.hasAdminAccess?.())
+			return false;
+
+		return entry
+			? 'isCatalogEntry' in entry &&
+					entry.manifest.runtime !== 'composite' &&
+					entry.manifest.runtime !== 'remote'
+			: true;
+	});
 
 	const hasAdminAccess = $derived(profile.current.hasAdminAccess?.() ?? false);
 
@@ -601,8 +611,8 @@
 			<Loading class="size-6" />
 		</div>
 	{:else}
-		{#if entity === 'catalog' && profile.current.hasAdminAccess?.() && doesSupportK8sUpdates}
-			<CapacityBanner bind:this={capacityBanner} catalogId={id} {catalogEntryId} />
+		{#if supportsCapacity}
+			<CapacityBanner bind:this={capacityBanner} catalogId={id} catalogEntryId={entry?.id} />
 		{/if}
 		{#if tableData.length > 0}
 			<Table

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -76,6 +76,7 @@
 		servers?: MCPCatalogServer[];
 		skipLoadOnMount?: boolean;
 		serverPrefixPath?: string;
+		catalogEntryId?: string;
 	}
 
 	let {
@@ -95,7 +96,8 @@
 		onlyMyServers,
 		servers: initialServers,
 		skipLoadOnMount,
-		serverPrefixPath
+		serverPrefixPath,
+		catalogEntryId
 	}: Props = $props();
 
 	const doesSupportK8sUpdates = $derived(version.current.engine === 'kubernetes');
@@ -599,8 +601,8 @@
 			<Loading class="size-6" />
 		</div>
 	{:else}
-		{#if entity === 'catalog' && profile.current.hasAdminAccess?.()}
-			<CapacityBanner bind:this={capacityBanner} />
+		{#if entity === 'catalog' && profile.current.hasAdminAccess?.() && doesSupportK8sUpdates}
+			<CapacityBanner bind:this={capacityBanner} catalogId={id} {catalogEntryId} />
 		{/if}
 		{#if tableData.length > 0}
 			<Table

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -763,6 +763,18 @@ export async function getMCPCapacity(opts?: { fetch?: Fetcher }): Promise<MCPCap
 	return response;
 }
 
+export async function getMCPCatalogEntryCapacity(
+	catalogID: string,
+	entryID: string,
+	opts?: { fetch?: Fetcher }
+): Promise<MCPCapacityInfo> {
+	const response = (await doGet(
+		`/mcp-catalogs/${catalogID}/entries/${entryID}/mcp-capacity`,
+		opts
+	)) as MCPCapacityInfo;
+	return response;
+}
+
 // MCP catalogs
 
 export async function listMCPCatalogs(opts?: { fetch?: Fetcher }): Promise<MCPCatalog[]> {

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -758,7 +758,10 @@ export async function redeployMCPCatalogServerWithK8sSettings(
 
 // MCP capacity
 
-export async function getMCPCapacity(opts?: { fetch?: Fetcher }): Promise<MCPCapacityInfo> {
+export async function getMCPCapacity(opts?: {
+	fetch?: Fetcher;
+	dontLogErrors?: boolean;
+}): Promise<MCPCapacityInfo> {
 	const response = (await doGet('/mcp-capacity', opts)) as MCPCapacityInfo;
 	return response;
 }
@@ -766,7 +769,7 @@ export async function getMCPCapacity(opts?: { fetch?: Fetcher }): Promise<MCPCap
 export async function getMCPCatalogEntryCapacity(
 	catalogID: string,
 	entryID: string,
-	opts?: { fetch?: Fetcher }
+	opts?: { fetch?: Fetcher; dontLogErrors?: boolean }
 ): Promise<MCPCapacityInfo> {
 	const response = (await doGet(
 		`/mcp-catalogs/${catalogID}/entries/${entryID}/mcp-capacity`,

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -649,7 +649,6 @@ export type LLMAuditLogURLFilters = {
 };
 
 // MCP capacity
-// Returned by GET /mcp-capacity and GET /mcp-catalogs/{catalog_id}/entries/{entry_id}/mcp-capacity
 
 export type CapacitySource = 'resourceQuota' | 'deployments';
 export interface MCPCapacityInfo {

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -649,6 +649,7 @@ export type LLMAuditLogURLFilters = {
 };
 
 // MCP capacity
+// Returned by GET /mcp-capacity and GET /mcp-catalogs/{catalog_id}/entries/{entry_id}/mcp-capacity
 
 export type CapacitySource = 'resourceQuota' | 'deployments';
 export interface MCPCapacityInfo {

--- a/ui/user/src/lib/services/dashboard/utils.ts
+++ b/ui/user/src/lib/services/dashboard/utils.ts
@@ -59,7 +59,7 @@ export function normalizeServerDeploymentStatus(server: MCPCatalogServer): strin
 	if (raw && DEPLOYMENT_STATUS_ORDER.includes(raw as (typeof DEPLOYMENT_STATUS_ORDER)[number]))
 		return raw;
 	if (raw) return raw;
-	return '--';
+	return 'Pending'; // on demand pod has not yet been activated
 }
 
 /** 12-column grid: 3× col-span-4 per full row; last row fills width (6+6 or 12). */


### PR DESCRIPTION
Addresses #7080
Addresses #7066
Addresses #6729 
Addresses quick follow-on for #7430 

This addresses showing capacity relevant to a catalog entry instead of showing overall capacity when viewing a catalog entry's deployments view, addresses error displaying in k8s info when status === Error, and a quick sortable addition for the Devices page.