### PR TITLE
Fix editing configuration for remote MCP deployments

### DIFF
--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -23,6 +23,7 @@
 		getMcpServerDeploymentStatus,
 		getServerTypeLabel,
 		getServerUrl,
+		hasEditableConfiguration,
 		hasMissingSecretBindingConfig,
 		isMultiUserServer,
 		supportsMCPBackendDetails
@@ -581,6 +582,15 @@
 	function isRestartableServer(d: MCPCatalogServer) {
 		return d.manifest.runtime !== 'remote' && d.manifest.runtime !== 'composite';
 	}
+
+	function canEditDeploymentConfiguration(d: MCPCatalogServer) {
+		return !d.compositeName && d.manifest.runtime !== 'composite';
+	}
+
+	function hasEditableDeploymentConfiguration(d: MCPCatalogServer) {
+		const entry = d.catalogEntryID ? entriesMap[d.catalogEntryID] : undefined;
+		return hasEditableConfiguration(entry ?? d);
+	}
 </script>
 
 <div class="flex flex-col gap-0.5">
@@ -756,7 +766,7 @@
 										{/if}
 									</span>
 								</a>
-								{#if (d.isMyServer || (hasAdminAccess && !readonly)) && supportsMCPBackendDetails(d)}
+								{#if (d.isMyServer || (hasAdminAccess && !readonly)) && canEditDeploymentConfiguration(d) && hasEditableDeploymentConfiguration(d)}
 									<button
 										class="menu-button"
 										onclick={(e) => {


### PR DESCRIPTION
## Summary

- restore the Edit Configuration action for Remote MCP deployments
- keep existing owner and writable-admin authorization
- continue excluding Composite deployments while preserving Hosted behavior
- reuse the existing deployment configuration dialog and save APIs

## Testing

- `pnpm run check`
- `pnpm run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment configuration editing controls.
  * Editing is now available for eligible non-composite deployments while remaining unavailable for composite deployments and runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->