### PR TITLE
fix(mcp): apply backend URL validation to clients

### DIFF
--- a/pkg/mcp/http.go
+++ b/pkg/mcp/http.go
@@ -12,10 +12,13 @@ import (
 // configured network path, including its tunnel when present.
 func (sm *SessionManager) HTTPClientForServer(server ServerConfig, allowHosts []string, headers http.Header, timeout time.Duration) (*http.Client, error) {
 	if server.TunnelName == "" {
+		remoteURLValidationConfig, backendAllowHosts := sm.RemoteConfigForBackend()
+		allowHosts = append(allowHosts, backendAllowHosts...)
+
 		return safehttp.NewClient(safehttp.ClientOptions{
-			BlockLoopback:  !sm.remoteURLValidationConfig.AllowLocalhostMCP,
-			BlockPrivateIP: !sm.remoteURLValidationConfig.AllowPrivateIPMCP,
-			BlockLinkLocal: !sm.remoteURLValidationConfig.AllowLinkLocalMCP,
+			BlockLoopback:  !remoteURLValidationConfig.AllowLocalhostMCP,
+			BlockPrivateIP: !remoteURLValidationConfig.AllowPrivateIPMCP,
+			BlockLinkLocal: !remoteURLValidationConfig.AllowLinkLocalMCP,
 			AllowList:      allowHosts,
 			Timeout:        timeout,
 			Headers:        headers,

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -13,9 +13,15 @@ import (
 
 func TestHTTPClientForServer(t *testing.T) {
 	const timeout = 3 * time.Second
+	backend := &kubernetesBackend{
+		httpListenPort:   8080,
+		mcpNamespace:     "obot-mcp",
+		mcpClusterDomain: "cluster.local",
+		serviceFQDN:      "obot.obot-system.svc.cluster.local",
+	}
 
 	t.Run("direct server", func(t *testing.T) {
-		httpClient, err := (&SessionManager{}).HTTPClientForServer(ServerConfig{}, nil, nil, timeout)
+		httpClient, err := (&SessionManager{backend: backend}).HTTPClientForServer(ServerConfig{}, nil, nil, timeout)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -40,7 +46,7 @@ func TestHTTPClientForServer(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		httpClient, err := (&SessionManager{}).HTTPClientForServer(
+		httpClient, err := (&SessionManager{backend: backend}).HTTPClientForServer(
 			ServerConfig{},
 			[]string{serverURL.Host},
 			http.Header{"X-MCP-Test": {"injected"}},

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -60,6 +60,36 @@ func TestHTTPClientForServer(t *testing.T) {
 		}
 	})
 
+	t.Run("direct server uses Kubernetes backend allow list", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		serverURL, err := url.Parse(server.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		httpClient, err := (&SessionManager{
+			backend: &kubernetesBackend{
+				serviceFQDN: serverURL.Host,
+			},
+		}).HTTPClientForServer(ServerConfig{}, nil, nil, timeout)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		response, err := httpClient.Get(server.URL)
+		if err != nil {
+			t.Fatalf("request to backend-allowlisted server failed: %v", err)
+		}
+		defer response.Body.Close()
+		if response.StatusCode != http.StatusNoContent {
+			t.Fatalf("response status = %d, want %d", response.StatusCode, http.StatusNoContent)
+		}
+	})
+
 	t.Run("tunnel manager required", func(t *testing.T) {
 		_, err := (&SessionManager{}).HTTPClientForServer(ServerConfig{TunnelName: "office"}, nil, nil, timeout)
 		if err == nil {


### PR DESCRIPTION
Use each runtime backend’s URL validation overrides and host allowlist when creating direct MCP HTTP clients. This lets Kubernetes-hosted temporary servers resolve to cluster-private addresses without weakening validation for unrelated remote hosts.

Issue: https://github.com/obot-platform/obot/issues/7518