### PR TITLE
chore: ui dompurify/nanoid dependabot bumps

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14083,9 +14083,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/ui/user/package.json
+++ b/ui/user/package.json
@@ -45,7 +45,7 @@
 		"@milkdown/kit": "^7.21.2",
 		"@sveltejs/adapter-node": "^5.5.4",
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@sveltejs/kit": "^2.69.1",
+		"@sveltejs/kit": "^2.70.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/postcss": "^4.2.2",
 		"@trivago/prettier-plugin-sort-imports": "^6.0.2",

--- a/ui/user/pnpm-lock.yaml
+++ b/ui/user/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   cookie: 0.7.0
   ip-address: 10.4.0
   esbuild: 0.28.1
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   fast-uri: 3.1.5
   hono: 4.12.34
 
@@ -146,13 +146,13 @@ importers:
         version: 7.21.2(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)(typescript@6.0.2)
       '@sveltejs/adapter-node':
         specifier: ^5.5.4
-        version: 5.5.4(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))
+        version: 5.5.4(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))
+        version: 3.0.10(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))
       '@sveltejs/kit':
-        specifier: ^2.69.1
-        version: 2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0))
+        specifier: ^2.70.2
+        version: 2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
         version: 6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0))
@@ -184,8 +184,8 @@ importers:
         specifier: ^4.25.9
         version: 4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)
       dompurify:
-        specifier: 3.4.12
-        version: 3.4.12
+        specifier: 3.4.13
+        version: 3.4.13
       eslint:
         specifier: ^10.5.0
         version: 10.5.0(jiti@2.6.1)
@@ -1115,8 +1115,8 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/kit@2.69.1':
-    resolution: {integrity: sha512-+nz8Fx/cElzb2ZPHC+6Ll3y3NEVIe4Na75PeplLlyTmd1dBXAjz2KR14y1ZgNjb2ThfAYzulu+PFy1UE3RCUzA==}
+  '@sveltejs/kit@2.70.2':
+    resolution: {integrity: sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -1851,8 +1851,8 @@ packages:
   docx-preview@0.3.7:
     resolution: {integrity: sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   driver.js@1.4.0:
     resolution: {integrity: sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==}
@@ -2512,18 +2512,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -3768,9 +3763,9 @@ snapshots:
       '@milkdown/utils': 7.21.2
       '@types/lodash-es': 4.17.12
       clsx: 2.1.1
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       lodash-es: 4.18.1
-      nanoid: 5.1.7
+      nanoid: 5.1.16
       unist-util-visit: 5.1.0
       vue: 3.5.32(typescript@6.0.2)
     transitivePeerDependencies:
@@ -3801,7 +3796,7 @@ snapshots:
       '@types/lodash-es': 4.17.12
       clsx: 2.1.1
       codemirror: 6.0.2
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       katex: 0.17.0
       lodash-es: 4.18.1
       prosemirror-virtual-cursor: 0.4.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
@@ -4029,7 +4024,7 @@ snapshots:
       '@milkdown/exception': 7.21.2
       '@milkdown/prose': 7.21.2
       '@milkdown/transformer': 7.21.2
-      nanoid: 5.1.7
+      nanoid: 5.1.16
     transitivePeerDependencies:
       - supports-color
 
@@ -4282,19 +4277,19 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.60.1)
       '@rollup/plugin-json': 6.1.0(rollup@4.60.1)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.1)
-      '@sveltejs/kit': 2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0))
       rollup: 4.60.1
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))':
     dependencies:
-      '@sveltejs/kit': 2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0))
 
-  '@sveltejs/kit@2.69.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.7)(typescript@6.0.2)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.11(acorn@8.17.0)
@@ -5088,7 +5083,7 @@ snapshots:
     dependencies:
       jszip: 3.10.1
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5932,11 +5927,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
-
   nanoid@3.3.18: {}
 
-  nanoid@5.1.7: {}
+  nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -6021,7 +6014,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/ui/user/pnpm-workspace.yaml
+++ b/ui/user/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ overrides:
   cookie: 0.7.0
   ip-address: 10.4.0
   esbuild: 0.28.1
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   fast-uri: 3.1.5
   hono: 4.12.34
 engineStrict: true


### PR DESCRIPTION
This addresses dompurify/nanoid high CVES as well as a medium one related to sveltejs/kit.

As for the image-size (no longer maintained) transitive dependency due to docusaurus: https://github.com/facebook/docusaurus/issues/12231 Keeping an eye on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SvelteKit framework version.
  * Updated the DOM sanitization package version for improved maintenance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->