### PR TITLE
enhance: add retention-based cleanup for submitted device scans

### DIFF
--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -41,6 +41,7 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_MCPAUDIT_LOGS_PERSIST_BATCH_SIZE` | The number of MCP audit log entries written to the database in a single batch. | `1000` |
 | `OBOT_SERVER_LLMAUDIT_LOG_RETENTION_DAYS` | The number of days to retain LLM audit logs before they are automatically deleted. Set to `0` to disable automatic cleanup. | `90` |
 | `OBOT_SERVER_DISABLE_LLMAUDIT_LOG` | Disables collection and persistence of new LLM gateway audit logs. Existing logs remain available. | `false` |
+| `OBOT_SERVER_DEVICE_SCAN_RETENTION_DAYS` | The number of days to retain submitted device scans before they are automatically deleted. Set to `0` to disable automatic cleanup. | `90` |
 | `OBOT_SERVER_DEFAULT_MCPCATALOG_PATH` | The path to the default MCP catalog (accessible to all users). | - |
 | `OBOT_SERVER_DEFAULT_SYSTEM_MCPCATALOG_PATH` | The path to the default System MCP catalog. | - |
 | `OBOT_SERVER_MDM_ASSET_SOURCE` | The source for MDM assets. Can be a local directory, a tar archive path, or an HTTP(S) tarball URL. | `https://github.com/obot-platform/obot-sentry/releases/download/v0.1.5/mdm-assets.tar.gz` |

--- a/pkg/api/handlers/enforcement_test.go
+++ b/pkg/api/handlers/enforcement_test.go
@@ -833,7 +833,7 @@ func newEnforcementTestGatewayClient(t *testing.T) *gatewayclient.Client {
 	if err := db.AutoMigrate(); err != nil {
 		t.Fatalf("migrate gateway db: %v", err)
 	}
-	c := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, 10*time.Millisecond, 10, 90, 90, true)
+	c := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, 10*time.Millisecond, 10, 90, 90, 90, true)
 	t.Cleanup(func() { _ = c.Close() })
 	return c
 }

--- a/pkg/api/handlers/gitcredentials_test.go
+++ b/pkg/api/handlers/gitcredentials_test.go
@@ -191,7 +191,7 @@ func newTestGitCredentialGatewayClient(t *testing.T) *gatewayclient.Client {
 	db, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate())
-	client := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, true)
+	client := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, 90, true)
 	t.Cleanup(func() { _ = client.Close() })
 	return client
 }

--- a/pkg/api/handlers/mcpgateway/auditlog_test.go
+++ b/pkg/api/handlers/mcpgateway/auditlog_test.go
@@ -693,7 +693,7 @@ func newLocalAgentAuditLogTestGatewayClient(t *testing.T) *gatewayclient.Client 
 		t.Fatalf("failed to migrate gateway db: %v", err)
 	}
 
-	c := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, 10*time.Millisecond, 10, 90, 90, true)
+	c := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, 10*time.Millisecond, 10, 90, 90, 90, true)
 	t.Cleanup(func() {
 		_ = c.Close()
 	})

--- a/pkg/api/handlers/mcpgateway/oauth/token_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token_test.go
@@ -69,7 +69,7 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate())
 
-	gatewayClient := gatewayclient.New(t.Context(), db, storage, nil, nil, nil, nil, time.Hour, 10, 90, 90, true)
+	gatewayClient := gatewayclient.New(t.Context(), db, storage, nil, nil, nil, nil, time.Hour, 10, 90, 90, 90, true)
 	t.Cleanup(func() { require.NoError(t, gatewayClient.Close()) })
 
 	require.NoError(t, db.WithContext(t.Context()).Create(&gatewaytypes.User{

--- a/pkg/api/handlers/skills_test.go
+++ b/pkg/api/handlers/skills_test.go
@@ -45,7 +45,7 @@ func newHandlerTestGateway(t *testing.T) *gclient.Client {
 	database, err := gatewaydb.New(services.DB.DB, services.DB.SQLDB, true)
 	require.NoError(t, err)
 	require.NoError(t, database.AutoMigrate())
-	gateway := gclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, false)
+	gateway := gclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, 0, false)
 	t.Cleanup(func() { _ = gateway.Close() })
 	return gateway
 }

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -56,7 +56,7 @@ func newBootstrapTestClient(t *testing.T) (*client.Client, context.Context) {
 		}).
 		Build()
 
-	c := client.New(ctx, db, storageClient, nil, nil, nil, nil, time.Hour, 1, 90, 90, true)
+	c := client.New(ctx, db, storageClient, nil, nil, nil, nil, time.Hour, 1, 90, 90, 90, true)
 	t.Cleanup(func() {
 		cancel()
 		_ = c.Close()

--- a/pkg/controller/handlers/auditlogexport/auditlogexport_test.go
+++ b/pkg/controller/handlers/auditlogexport/auditlogexport_test.go
@@ -334,7 +334,7 @@ func newExportTestGatewayClient(t *testing.T) *gatewayclient.Client {
 	}
 
 	// Use a short persistence interval so LogMCPAuditEntry rows flush to the DB quickly.
-	c := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, 10*time.Millisecond, 10, 90, 90, true)
+	c := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, 10*time.Millisecond, 10, 90, 90, 90, true)
 	t.Cleanup(func() { _ = c.Close() })
 	return c
 }

--- a/pkg/controller/handlers/mcpserver/mcpserver_test.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver_test.go
@@ -1533,7 +1533,7 @@ func newTestGatewayClient(t *testing.T) *gatewayclient.Client {
 	database, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
 	require.NoError(t, err)
 	require.NoError(t, database.AutoMigrate())
-	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, true)
+	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, 90, true)
 	t.Cleanup(func() { _ = gatewayClient.Close() })
 	return gatewayClient
 }

--- a/pkg/controller/handlers/mdmassetsource/mdmassetsource_test.go
+++ b/pkg/controller/handlers/mdmassetsource/mdmassetsource_test.go
@@ -327,7 +327,7 @@ func newTestGatewayClient(t *testing.T) *gatewayclient.Client {
 	database, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
 	require.NoError(t, err)
 	require.NoError(t, database.AutoMigrate())
-	gateway := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, false)
+	gateway := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, 0, false)
 	t.Cleanup(func() { require.NoError(t, gateway.Close()) })
 	return gateway
 }

--- a/pkg/controller/handlers/skillrepository/skillrepository_test.go
+++ b/pkg/controller/handlers/skillrepository/skillrepository_test.go
@@ -561,7 +561,7 @@ func newTestGatewayClient(t *testing.T) *gatewayclient.Client {
 	database, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
 	require.NoError(t, err)
 	require.NoError(t, database.AutoMigrate())
-	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, true)
+	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, 90, true)
 	t.Cleanup(func() { _ = gatewayClient.Close() })
 	return gatewayClient
 }

--- a/pkg/controller/serviceaccount_test.go
+++ b/pkg/controller/serviceaccount_test.go
@@ -34,7 +34,7 @@ func newTestGatewayClient(t *testing.T) *gatewayclient.Client {
 		t.Fatalf("failed to migrate gateway db: %v", err)
 	}
 
-	return gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, time.Minute, 10, 90, 90, true)
+	return gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, time.Minute, 10, 90, 90, 90, true)
 }
 
 func newRuntimeSecretClient() kclient.Client {

--- a/pkg/gateway/client/auditlogcleanup_test.go
+++ b/pkg/gateway/client/auditlogcleanup_test.go
@@ -30,12 +30,14 @@ func newTestClient(t *testing.T) *Client {
 	}
 
 	return &Client{
-		db:                      db,
-		llmAuditEntries:         make(chan llmAuditEntry, 6),
-		llmAuditBatchSize:       3,
-		llmAuditEnabled:         true,
-		auditLogCleanupInterval: 50 * time.Millisecond,
-		auditLogDeleteBatchSize: 3,
+		db:                        db,
+		llmAuditEntries:           make(chan llmAuditEntry, 6),
+		llmAuditBatchSize:         3,
+		llmAuditEnabled:           true,
+		auditLogCleanupInterval:   50 * time.Millisecond,
+		auditLogDeleteBatchSize:   3,
+		deviceScanCleanupInterval: 50 * time.Millisecond,
+		deviceScanDeleteBatchSize: 3,
 	}
 }
 

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -20,6 +20,9 @@ const (
 	defaultAuditLogCleanupInterval = 24 * time.Hour
 	defaultAuditLogDeleteBatchSize = 1000
 
+	defaultDeviceScanCleanupInterval = 24 * time.Hour
+	defaultDeviceScanDeleteBatchSize = 100
+
 	// DefaultUserLimit is the maximum number of users allowed when no
 	// license-derived user-limit provider is configured.
 	DefaultUserLimit = 100
@@ -30,34 +33,36 @@ const (
 )
 
 type Client struct {
-	db                      *db.DB
-	encryptionConfig        *encryptionconfig.EncryptionConfiguration
-	emailsWithExplicitRoles map[string]types2.Role
-	auditLock               sync.Mutex
-	auditBuffer             []types.MCPAuditLog
-	kickAuditPersist        chan struct{}
-	enforcementLock         sync.Mutex
-	enforcementBuffer       []types.EnforcementDecisionLog
-	kickEnforcementPersist  chan struct{}
-	llmAuditEntries         chan llmAuditEntry
-	llmAuditBatchSize       int
-	llmAuditEnabled         bool
-	storageClient           kclient.Client
-	apiKeyCacheLock         sync.RWMutex
-	apiKeyCache             map[[32]byte]apiKeyValidationCacheEntry
-	apiKeyCacheTTL          time.Duration
-	serviceAccountCacheLock sync.RWMutex
-	serviceAccountCache     map[[32]byte]serviceAccountValidationCacheEntry
-	serviceAccountCacheTTL  time.Duration
-	deviceCreationLock      sync.Mutex
-	auditLogCleanupInterval time.Duration
-	auditLogDeleteBatchSize int
-	oktaGroupMigrationMu    sync.Mutex
-	oktaGroupMigrationDone  bool
-	mcpOAuthTokenTrigger    func(context.Context, string) error
+	db                        *db.DB
+	encryptionConfig          *encryptionconfig.EncryptionConfiguration
+	emailsWithExplicitRoles   map[string]types2.Role
+	auditLock                 sync.Mutex
+	auditBuffer               []types.MCPAuditLog
+	kickAuditPersist          chan struct{}
+	enforcementLock           sync.Mutex
+	enforcementBuffer         []types.EnforcementDecisionLog
+	kickEnforcementPersist    chan struct{}
+	llmAuditEntries           chan llmAuditEntry
+	llmAuditBatchSize         int
+	llmAuditEnabled           bool
+	storageClient             kclient.Client
+	apiKeyCacheLock           sync.RWMutex
+	apiKeyCache               map[[32]byte]apiKeyValidationCacheEntry
+	apiKeyCacheTTL            time.Duration
+	serviceAccountCacheLock   sync.RWMutex
+	serviceAccountCache       map[[32]byte]serviceAccountValidationCacheEntry
+	serviceAccountCacheTTL    time.Duration
+	deviceCreationLock        sync.Mutex
+	auditLogCleanupInterval   time.Duration
+	auditLogDeleteBatchSize   int
+	deviceScanCleanupInterval time.Duration
+	deviceScanDeleteBatchSize int
+	oktaGroupMigrationMu      sync.Mutex
+	oktaGroupMigrationDone    bool
+	mcpOAuthTokenTrigger      func(context.Context, string) error
 }
 
-func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptionConfig *encryptionconfig.EncryptionConfiguration, mcpOAuthTokenTrigger func(context.Context, string) error, ownerEmails, adminEmails []string, auditLogPersistenceInterval time.Duration, auditLogBatchSize, auditLogRetentionDays, llmAuditLogRetentionDays int, llmAuditEnabled bool) *Client {
+func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptionConfig *encryptionconfig.EncryptionConfiguration, mcpOAuthTokenTrigger func(context.Context, string) error, ownerEmails, adminEmails []string, auditLogPersistenceInterval time.Duration, auditLogBatchSize, auditLogRetentionDays, llmAuditLogRetentionDays, deviceScanRetentionDays int, llmAuditEnabled bool) *Client {
 	explicitRoleEmailsSet := make(map[string]types2.Role, len(ownerEmails)+len(adminEmails))
 	for _, email := range adminEmails {
 		explicitRoleEmailsSet[strings.ToLower(email)] = types2.RoleAdmin
@@ -67,24 +72,26 @@ func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptio
 		explicitRoleEmailsSet[strings.ToLower(email)] = types2.RoleOwner
 	}
 	c := &Client{
-		db:                      db,
-		encryptionConfig:        encryptionConfig,
-		emailsWithExplicitRoles: explicitRoleEmailsSet,
-		auditBuffer:             make([]types.MCPAuditLog, 0, 2*auditLogBatchSize),
-		kickAuditPersist:        make(chan struct{}),
-		enforcementBuffer:       make([]types.EnforcementDecisionLog, 0, 2*auditLogBatchSize),
-		kickEnforcementPersist:  make(chan struct{}),
-		storageClient:           storageClient,
-		mcpOAuthTokenTrigger:    mcpOAuthTokenTrigger,
-		apiKeyCache:             make(map[[32]byte]apiKeyValidationCacheEntry),
-		apiKeyCacheTTL:          apiKeyValidationCacheTTL,
-		serviceAccountCache:     make(map[[32]byte]serviceAccountValidationCacheEntry),
-		serviceAccountCacheTTL:  serviceAccountValidationCacheTTL,
-		llmAuditEntries:         make(chan llmAuditEntry, defaultLLMAuditLogBufferSize),
-		llmAuditBatchSize:       defaultLLMAuditLogBatchSize,
-		llmAuditEnabled:         llmAuditEnabled,
-		auditLogCleanupInterval: defaultAuditLogCleanupInterval,
-		auditLogDeleteBatchSize: defaultAuditLogDeleteBatchSize,
+		db:                        db,
+		encryptionConfig:          encryptionConfig,
+		emailsWithExplicitRoles:   explicitRoleEmailsSet,
+		auditBuffer:               make([]types.MCPAuditLog, 0, 2*auditLogBatchSize),
+		kickAuditPersist:          make(chan struct{}),
+		enforcementBuffer:         make([]types.EnforcementDecisionLog, 0, 2*auditLogBatchSize),
+		kickEnforcementPersist:    make(chan struct{}),
+		storageClient:             storageClient,
+		mcpOAuthTokenTrigger:      mcpOAuthTokenTrigger,
+		apiKeyCache:               make(map[[32]byte]apiKeyValidationCacheEntry),
+		apiKeyCacheTTL:            apiKeyValidationCacheTTL,
+		serviceAccountCache:       make(map[[32]byte]serviceAccountValidationCacheEntry),
+		serviceAccountCacheTTL:    serviceAccountValidationCacheTTL,
+		llmAuditEntries:           make(chan llmAuditEntry, defaultLLMAuditLogBufferSize),
+		llmAuditBatchSize:         defaultLLMAuditLogBatchSize,
+		llmAuditEnabled:           llmAuditEnabled,
+		auditLogCleanupInterval:   defaultAuditLogCleanupInterval,
+		auditLogDeleteBatchSize:   defaultAuditLogDeleteBatchSize,
+		deviceScanCleanupInterval: defaultDeviceScanCleanupInterval,
+		deviceScanDeleteBatchSize: defaultDeviceScanDeleteBatchSize,
 	}
 
 	go c.runMCPAuditLogPersistenceLoop(ctx, auditLogPersistenceInterval)
@@ -95,6 +102,7 @@ func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptio
 	go c.runAPIKeyCacheCleanup(ctx)
 	go c.runMCPAuditLogCleanup(ctx, auditLogRetentionDays)
 	go c.runLLMAuditLogCleanup(ctx, llmAuditLogRetentionDays)
+	go c.runDeviceScanCleanup(ctx, deviceScanRetentionDays)
 	return c
 }
 

--- a/pkg/gateway/client/devicescancleanup.go
+++ b/pkg/gateway/client/devicescancleanup.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+func (c *Client) runDeviceScanCleanup(ctx context.Context, retentionDays int) {
+	if retentionDays <= 0 {
+		return
+	}
+
+	err := c.deleteOldDeviceScans(ctx, time.Now().UTC(), retentionDays)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		log.Errorf("Failed to delete old device scans: %v", err)
+	}
+
+	ticker := time.NewTicker(c.deviceScanCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			err = c.deleteOldDeviceScans(ctx, now.UTC(), retentionDays)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				log.Errorf("Failed to delete old device scans: %v", err)
+			}
+		}
+	}
+}
+
+// The scans' child rows go with them via the ON DELETE CASCADE
+// constraints on device_scan_*.device_scan_id.
+func (c *Client) deleteOldDeviceScans(ctx context.Context, now time.Time, retentionDays int) error {
+	if retentionDays <= 0 {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	cutoff := now.Truncate(24*time.Hour).AddDate(0, 0, -retentionDays)
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		result := c.db.WithContext(ctx).Exec(
+			"DELETE FROM device_scans WHERE id IN (SELECT id FROM device_scans WHERE created_at < ? LIMIT ?)",
+			cutoff, c.deviceScanDeleteBatchSize,
+		)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected < int64(c.deviceScanDeleteBatchSize) {
+			return nil
+		}
+	}
+}

--- a/pkg/gateway/client/devicescancleanup.go
+++ b/pkg/gateway/client/devicescancleanup.go
@@ -38,17 +38,10 @@ func (c *Client) deleteOldDeviceScans(ctx context.Context, now time.Time, retent
 	if retentionDays <= 0 {
 		return nil
 	}
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 
 	cutoff := now.Truncate(24*time.Hour).AddDate(0, 0, -retentionDays)
 
 	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
 		result := c.db.WithContext(ctx).Exec(
 			"DELETE FROM device_scans WHERE id IN (SELECT id FROM device_scans WHERE created_at < ? LIMIT ?)",
 			cutoff, c.deviceScanDeleteBatchSize,

--- a/pkg/gateway/client/devicescancleanup_test.go
+++ b/pkg/gateway/client/devicescancleanup_test.go
@@ -1,0 +1,152 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+// insertScanAt creates a scan with children, overriding the GORM-managed
+// CreatedAt so it lands on the requested side of the retention cutoff.
+func insertScanAt(t *testing.T, c *Client, createdAt time.Time) types.DeviceScan {
+	t.Helper()
+	scan := insertScan(t, c, types.DeviceScan{
+		SubmittedBy: "user-a",
+		DeviceID:    "device-a",
+		ScannedAt:   createdAt,
+		MCPServers:  []types.DeviceScanMCPServer{{Client: "claude-code", Name: "srv", ConfigHash: "hash"}},
+		Skills:      []types.DeviceScanSkill{{Client: "claude-code", Name: "skill"}},
+		Plugins:     []types.DeviceScanPlugin{{Client: "claude-code", Name: "plugin"}},
+		Files:       []types.DeviceScanFile{{Path: "/a", Content: "x"}},
+		Clients:     []types.DeviceScanClient{{Name: "claude-code"}},
+	})
+	if err := c.db.WithContext(t.Context()).
+		Model(&types.DeviceScan{}).
+		Where("id = ?", scan.ID).
+		Update("created_at", createdAt).Error; err != nil {
+		t.Fatalf("failed to backdate scan: %v", err)
+	}
+	scan.CreatedAt = createdAt
+	return scan
+}
+
+func countScans(t *testing.T, c *Client) int64 {
+	t.Helper()
+	var count int64
+	if err := c.db.WithContext(t.Context()).Model(&types.DeviceScan{}).Count(&count).Error; err != nil {
+		t.Fatalf("failed to count device scans: %v", err)
+	}
+	return count
+}
+
+func TestDeleteOldDeviceScans(t *testing.T) {
+	c := newTestClient(t)
+	ctx := t.Context()
+
+	now := time.Now().UTC()
+	cutoff := now.Truncate(24*time.Hour).AddDate(0, 0, -90)
+
+	insertScanAt(t, c, now.AddDate(0, 0, -100))  // old - should be deleted
+	insertScanAt(t, c, cutoff.Add(-time.Second)) // one second before cutoff - should be deleted
+	insertScanAt(t, c, cutoff)                   // exactly at cutoff boundary - should be kept (< not <=)
+	insertScanAt(t, c, now.AddDate(0, 0, -89))   // recent - should be kept
+	insertScanAt(t, c, now)                      // recent - should be kept
+
+	if err := c.deleteOldDeviceScans(ctx, now, 90); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := countScans(t, c); got != 3 {
+		t.Errorf("expected 3 device scans after cleanup, got %d", got)
+	}
+}
+
+func TestDeleteOldDeviceScansDisabled(t *testing.T) {
+	c := newTestClient(t)
+	ctx := t.Context()
+
+	now := time.Now().UTC()
+	insertScanAt(t, c, now.AddDate(0, 0, -200))
+	insertScanAt(t, c, now.AddDate(0, 0, -100))
+
+	// retentionDays=0 should be a no-op
+	if err := c.deleteOldDeviceScans(ctx, now, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := countScans(t, c); got != 2 {
+		t.Errorf("expected 2 device scans (cleanup disabled), got %d", got)
+	}
+}
+
+func TestDeleteOldDeviceScansBatching(t *testing.T) {
+	c := newTestClient(t) // deviceScanDeleteBatchSize = 3
+	ctx := t.Context()
+
+	now := time.Now().UTC()
+	// Insert 7 old scans (requires 3 batches: 3+3+1) and 2 recent ones.
+	for range 7 {
+		insertScanAt(t, c, now.AddDate(0, 0, -100))
+	}
+	insertScanAt(t, c, now.AddDate(0, 0, -1))
+	insertScanAt(t, c, now)
+
+	if err := c.deleteOldDeviceScans(ctx, now, 90); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := countScans(t, c); got != 2 {
+		t.Errorf("expected 2 device scans after batched cleanup, got %d", got)
+	}
+}
+
+func TestRunDeviceScanCleanup(t *testing.T) {
+	c := newTestClient(t)
+
+	now := time.Now().UTC()
+	insertScanAt(t, c, now.AddDate(0, 0, -100)) // old
+	insertScanAt(t, c, now.AddDate(0, 0, -1))   // recent
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go c.runDeviceScanCleanup(ctx, 90)
+
+	// Wait until the cleanup has deleted old scans, or time out.
+	deadline := time.Now().Add(2 * time.Second)
+	var got int64
+	for {
+		got = countScans(t, c)
+		if got == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for device scan cleanup, got %d scans", got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+
+	if got != 1 {
+		t.Errorf("expected 1 device scan after cleanup loop, got %d", got)
+	}
+}
+
+func TestRunDeviceScanCleanupDisabled(t *testing.T) {
+	c := newTestClient(t)
+
+	now := time.Now().UTC()
+	insertScanAt(t, c, now.AddDate(0, 0, -100))
+	insertScanAt(t, c, now.AddDate(0, 0, -1))
+
+	// retentionDays=0 means the function returns immediately without cleanup.
+	// Call synchronously — if it ever blocks, the test timeout will catch it.
+	c.runDeviceScanCleanup(t.Context(), 0)
+
+	if got := countScans(t, c); got != 2 {
+		t.Errorf("expected 2 device scans (cleanup disabled), got %d", got)
+	}
+}

--- a/pkg/gateway/server/token_test.go
+++ b/pkg/gateway/server/token_test.go
@@ -292,7 +292,7 @@ func newTokenRequestTestServer(t *testing.T) (*Server, *client.Client) {
 			return []string{strconv.FormatBool(obj.(*v1.AuthProvider).Status.Configured)}
 		}).
 		Build()
-	gatewayClient := client.New(t.Context(), db, storageClient, nil, nil, nil, nil, time.Hour, 10, 90, 90, false)
+	gatewayClient := client.New(t.Context(), db, storageClient, nil, nil, nil, nil, time.Hour, 10, 90, 90, 90, false)
 	t.Cleanup(func() { _ = gatewayClient.Close() })
 	if err := gatewayClient.UpsertCredential(t.Context(), types.Credential{
 		Context: provider.Name,

--- a/pkg/gateway/types/devicescan.go
+++ b/pkg/gateway/types/devicescan.go
@@ -15,9 +15,13 @@ import (
 // Composite indexes:
 //   - idx_ds_user_time   (submitted_by, created_at) — list scans for a user
 //   - idx_ds_device_time (device_id, created_at)    — list scans for a device
+//
+// CreatedAt also carries a standalone index. Retention cleanup filters on
+// it alone, which neither composite can serve without a leading
+// submitted_by or device_id value.
 type DeviceScan struct {
 	ID             uint      `json:"id" gorm:"primaryKey"`
-	CreatedAt      time.Time `json:"createdAt" gorm:"index:idx_ds_user_time,priority:2;index:idx_ds_device_time,priority:2"`
+	CreatedAt      time.Time `json:"createdAt" gorm:"index;index:idx_ds_user_time,priority:2;index:idx_ds_device_time,priority:2"`
 	SubmittedBy    string    `json:"submittedBy" gorm:"index:idx_ds_user_time,priority:1"`
 	DeviceID       string    `json:"deviceID" gorm:"index:idx_ds_device_time,priority:1"`
 	Hostname       string    `json:"hostname"`

--- a/pkg/gitcredential/gitcredential_test.go
+++ b/pkg/gitcredential/gitcredential_test.go
@@ -171,7 +171,7 @@ func newTestGatewayClient(t *testing.T) *gatewayclient.Client {
 	db, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate())
-	client := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, true)
+	client := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, 90, true)
 	t.Cleanup(func() { _ = client.Close() })
 	return client
 }

--- a/pkg/license/provider_test.go
+++ b/pkg/license/provider_test.go
@@ -540,7 +540,7 @@ func newTestLicenseGatewayClient(t *testing.T) *gatewayclient.Client {
 		t.Fatalf("failed to migrate gateway database: %v", err)
 	}
 
-	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, false)
+	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, 0, false)
 	t.Cleanup(func() {
 		if err := gatewayClient.Close(); err != nil {
 			t.Errorf("failed to close gateway client: %v", err)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -129,6 +129,7 @@ type Config struct {
 	EnableMessagePolicies                bool   `usage:"Enable message policies for LLM proxy content enforcement" default:"false"`
 	LLMAuditLogRetentionDays             int    `usage:"Number of days to retain LLM audit logs (0 to disable cleanup)." default:"90"`
 	DisableLLMAuditLog                   bool   `usage:"Disable LLM gateway audit logging" default:"false"`
+	DeviceScanRetentionDays              int    `usage:"Number of days to retain submitted device scans (0 to disable cleanup)." default:"90"`
 	EnableAgents                         *bool  `usage:"Enable Obot Agent features. When unset, agents are disabled for new deployments but grandfathered in for deployments that already have agents. Explicitly set to true to force-enable, or false to force-disable, regardless of grandfathering." env:"OBOT_ENABLE_AGENTS"`
 	HostedAgentsBackend                  string `usage:"Hosted agent runtime backend (disabled, fake, or kubernetes). Defaults to the MCP runtime backend: kubernetes when MCP servers run on Kubernetes, and otherwise fake, since there is no docker agent backend." name:"hosted-agents-backend" env:"OBOT_HOSTED_AGENTS_BACKEND"`
 	HostedAgentsStorageClassName         string `usage:"StorageClass for hosted agent pool volumes. It should use volumeBindingMode WaitForFirstConsumer, which is what keeps a pool on one node." name:"hosted-agents-storage-class-name"`
@@ -569,6 +570,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		config.MCPAuditLogsPersistBatchSize,
 		config.MCPAuditLogRetentionDays,
 		config.LLMAuditLogRetentionDays,
+		config.DeviceScanRetentionDays,
 		!config.DisableLLMAuditLog,
 	)
 


### PR DESCRIPTION
Submitted device scans and their child rows accumulated indefinitely with
no way to reclaim the space. Add a periodic cleanup loop that deletes
scans older than a configurable retention window, mirroring the existing
MCP and LLM audit log cleanup in the gateway client.

OBOT_SERVER_DEVICE_SCAN_RETENTION_DAYS defaults to 90 days; set it to 0
to disable cleanup, matching the convention used by the audit log
retention settings. Deletion runs once a day in batches so a large
backlog doesn't become a single oversized transaction. Child rows are
removed by the ON DELETE CASCADE constraints on
device_scan_*.device_scan_id.