### PR TITLE
fix: allow editing OAuth credentials for git entries

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -55,6 +55,7 @@
 		hideTitle?: boolean;
 		readonlyMessage?: Snippet;
 		onConfigureOAuth?: () => void;
+		canConfigureOAuthCredentials?: boolean;
 	}
 
 	let {
@@ -66,7 +67,8 @@
 		onCancel,
 		onSubmit,
 		readonlyMessage,
-		onConfigureOAuth
+		onConfigureOAuth,
+		canConfigureOAuthCredentials = true
 	}: Props = $props();
 	function getType(entry?: MCPCatalogEntry | MCPCatalogServer) {
 		if (!entry) return undefined;
@@ -985,6 +987,7 @@
 				onFieldChange={updateRequired}
 				isNewEntry={!entry}
 				{onConfigureOAuth}
+				{canConfigureOAuthCredentials}
 				secretBindingTargets={editableSecretBindingTargets}
 			>
 				{#snippet afterHeaders()}
@@ -1009,6 +1012,7 @@
 				onFieldChange={updateRequired}
 				isNewEntry={!entry}
 				{onConfigureOAuth}
+				{canConfigureOAuthCredentials}
 			>
 				{#snippet afterHeaders()}
 					{#if formData.remoteConfig?.urlTemplate !== undefined}

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -155,6 +155,9 @@
 		return tabs.some((t) => t.view === tab) ? tab : fallback;
 	});
 	let configurationReadonly = $derived(readonly || isCatalogEntryDeployedMultiUserServer(entry));
+	let canConfigureOAuthCredentials = $derived(
+		profile.current.isAdmin?.() || profile.current.groups.includes(Group.POWERUSER)
+	);
 
 	let oauthDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let oauthURL = $state<string>();
@@ -806,6 +809,7 @@
 			<button
 				class="btn btn-secondary flex items-center gap-1.5 font-normal"
 				onclick={handleConfigureOAuth}
+				disabled={!canConfigureOAuthCredentials}
 			>
 				<Settings class="size-4" />
 				Configure OAuth Credentials
@@ -953,6 +957,7 @@
 			onSubmit={handleSubmit}
 			hideTitle={Boolean(entry)}
 			onConfigureOAuth={handleConfigureOAuth}
+			{canConfigureOAuthCredentials}
 		>
 			{#snippet readonlyMessage()}
 				{#if entry && 'sourceURL' in entry && !!entry.sourceURL && !entry.detached}

--- a/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/RemoteRuntimeForm.svelte
@@ -26,6 +26,7 @@
 		onFieldChange?: (field: string) => void;
 		isNewEntry?: boolean;
 		onConfigureOAuth?: () => void;
+		canConfigureOAuthCredentials?: boolean;
 		disableStaticOAuth?: boolean;
 		disableHostnameOption?: boolean;
 		secretBindingTargets?: MCPAllowedSecretBindingTarget[];
@@ -42,6 +43,7 @@
 		onFieldChange,
 		isNewEntry,
 		onConfigureOAuth,
+		canConfigureOAuthCredentials = true,
 		disableStaticOAuth,
 		disableHostnameOption,
 		secretBindingTargets,
@@ -587,7 +589,7 @@
 						<button
 							class="btn btn-secondary flex w-fit items-center gap-2 text-sm"
 							onclick={onConfigureOAuth}
-							disabled={readonly}
+							disabled={!canConfigureOAuthCredentials}
 							type="button"
 						>
 							<Settings class="size-4" />


### PR DESCRIPTION
## Summary
- allow configuring static OAuth credentials for Git-sourced, read-only catalog entries
- keep the entry configuration itself read-only