### PR TITLE
enhance: add system mcp validate command

### DIFF
--- a/pkg/cli/mcp.go
+++ b/pkg/cli/mcp.go
@@ -34,6 +34,7 @@ func (m *MCP) Customize(c *cobra.Command) {
 	c.Args = cobra.NoArgs
 	c.AddCommand(cmd.Command(&MCPSearch{root: m.root}))
 	c.AddCommand(cmd.Command(&MCPValidateCatalogYAML{}))
+	c.AddCommand(cmd.Command(&MCPValidateSystemCatalogYAML{}))
 }
 
 func (m *MCP) Run(cmd *cobra.Command, _ []string) error {
@@ -60,9 +61,50 @@ func (m *MCPValidateCatalogYAML) Run(cmd *cobra.Command, args []string) error {
 }
 
 func validateMCPCatalogPaths(ctx context.Context, paths []string, requireEntryKey bool) (int, error) {
+	seenEntryKeys := make(map[string]string)
+	return validateCatalogPaths(paths, func(path string) error {
+		return validateMCPCatalogFile(ctx, path, requireEntryKey, seenEntryKeys)
+	})
+}
+
+type MCPValidateSystemCatalogYAML struct{}
+
+func (m *MCPValidateSystemCatalogYAML) Customize(cmd *cobra.Command) {
+	cmd.Use = "validate-system-catalog-yaml <path>..."
+	cmd.Short = "Validate system MCP catalog entry files"
+	cmd.Args = cobra.MinimumNArgs(1)
+}
+
+func (m *MCPValidateSystemCatalogYAML) Run(cmd *cobra.Command, args []string) error {
+	files, err := validateSystemMCPCatalogPaths(cmd.Context(), args)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "System catalog entries in %d files are valid.\n", files)
+	return nil
+}
+
+func validateSystemMCPCatalogPaths(ctx context.Context, paths []string) (int, error) {
+	seenSanitizedNames := make(map[string]string)
+	return validateCatalogPaths(paths, func(path string) error {
+		return validateSystemMCPCatalogFile(ctx, path, seenSanitizedNames)
+	})
+}
+
+func validateCatalogPaths(paths []string, validateFile func(string) error) (int, error) {
 	var validationErr error
 	seenFiles := make(map[string]struct{})
-	seenEntryKeys := make(map[string]string)
+	validateFileOnce := func(path string) error {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			absPath = filepath.Clean(path)
+		}
+		if _, ok := seenFiles[absPath]; ok {
+			return nil
+		}
+		seenFiles[absPath] = struct{}{}
+		return validateFile(path)
+	}
 
 	for _, input := range paths {
 		info, err := os.Stat(input)
@@ -71,7 +113,7 @@ func validateMCPCatalogPaths(ctx context.Context, paths []string, requireEntryKe
 			continue
 		}
 		if !info.IsDir() {
-			validationErr = errors.Join(validationErr, validateMCPCatalogFile(ctx, input, requireEntryKey, seenFiles, seenEntryKeys))
+			validationErr = errors.Join(validationErr, validateFileOnce(input))
 			continue
 		}
 
@@ -85,7 +127,7 @@ func validateMCPCatalogPaths(ctx context.Context, paths []string, requireEntryKe
 				validationErr = errors.Join(validationErr, fmt.Errorf("%s: %w", input, walkErr))
 				break
 			}
-			validationErr = errors.Join(validationErr, validateMCPCatalogFile(ctx, path, requireEntryKey, seenFiles, seenEntryKeys))
+			validationErr = errors.Join(validationErr, validateFileOnce(path))
 		}
 	}
 	if len(seenFiles) == 0 {
@@ -95,16 +137,7 @@ func validateMCPCatalogPaths(ctx context.Context, paths []string, requireEntryKe
 	return len(seenFiles), validationErr
 }
 
-func validateMCPCatalogFile(ctx context.Context, path string, requireEntryKey bool, seenFiles map[string]struct{}, seenEntryKeys map[string]string) error {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		absPath = filepath.Clean(path)
-	}
-	if _, ok := seenFiles[absPath]; ok {
-		return nil
-	}
-	seenFiles[absPath] = struct{}{}
-
+func validateMCPCatalogFile(ctx context.Context, path string, requireEntryKey bool, seenEntryKeys map[string]string) error {
 	entries, isArray, err := mcpcatalog.DecodeCatalogFile[types.MCPServerCatalogEntryManifest](path, true)
 	if err != nil {
 		return fmt.Errorf("%s: invalid catalog entry: %w", path, err)
@@ -144,6 +177,44 @@ func validateMCPCatalogFile(ctx context.Context, path string, requireEntryKey bo
 			}
 		}
 		if err := mcpcatalog.ValidateManifest(ctx, *entry, validationOptions); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", label, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateSystemMCPCatalogFile(ctx context.Context, path string, seenSanitizedNames map[string]string) error {
+	entries, isArray, err := mcpcatalog.DecodeCatalogFile[types.SystemMCPServerCatalogEntryManifest](path, true)
+	if err != nil {
+		return fmt.Errorf("%s: invalid system catalog entry: %w", path, err)
+	}
+
+	validationOptions := mcp.ValidationOptions{
+		RemoteMCPURLValidationConfig: mcp.RemoteMCPURLValidationConfig{
+			AllowLocalhostMCP: true,
+			AllowPrivateIPMCP: true,
+			AllowLinkLocalMCP: true,
+		},
+	}
+	var errs []error
+	for i := range entries {
+		entry := &entries[i]
+		label := path
+		if isArray {
+			label = fmt.Sprintf("%s[%d]", path, i)
+		}
+		mcpcatalog.NormalizeSystemManifest(entry)
+
+		sanitizedName := mcpcatalog.SanitizeName(entry.Name)
+		if sanitizedName == "" {
+			errs = append(errs, fmt.Errorf("%s: invalid system catalog entry name after sanitization: original=%q sanitized=%q", label, entry.Name, sanitizedName))
+		} else if previous, ok := seenSanitizedNames[sanitizedName]; ok {
+			errs = append(errs, fmt.Errorf("%s: duplicate sanitized system catalog entry name %q also used by %s", label, sanitizedName, previous))
+		} else {
+			seenSanitizedNames[sanitizedName] = label
+		}
+		if err := mcp.ValidateSystemMCPServerCatalogEntryManifest(ctx, *entry, validationOptions); err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", label, err))
 		}
 	}

--- a/pkg/cli/mcp_test.go
+++ b/pkg/cli/mcp_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -326,6 +327,128 @@ npxConfig:
 		if !strings.Contains(err.Error(), expected) {
 			t.Fatalf("error = %v, want %q", err, expected)
 		}
+	}
+}
+
+func TestMCPValidateSystemCatalogYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entries.yaml")
+	if err := os.WriteFile(path, []byte(`
+- name: Filter
+  shortDescription: Filter
+  description: Filter
+  icon: icon
+  systemMCPServerType: filter
+  filterConfig:
+    toolName: filter
+  runtime: npx
+  npxConfig:
+    package: filter
+- name: Remote
+  shortDescription: Remote
+  description: Remote
+  icon: icon
+  runtime: remote
+  remoteConfig:
+    fixedURL: https://does-not-resolve.invalid/mcp
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "ignored.yaml"), []byte("not: a system catalog entry\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".ignoreobotcatalogs"), []byte("ignored.yaml\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, err := executeMCPTestCommand(t, mcpTestRoot("http://unused.example"), "validate-system-catalog-yaml", dir, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "System catalog entries in 1 files are valid.") {
+		t.Fatalf("unexpected output: %s", stdout)
+	}
+}
+
+func TestMCPValidateSystemCatalogYAMLAggregatesErrors(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"unknown-field.yaml": `name: Unknown
+shortDescription: Unknown
+description: Unknown
+icon: icon
+runtime: npx
+npxConfig:
+  package: test
+unknownField: true`,
+		"missing-filter-config.yaml": `name: Missing Filter Config
+shortDescription: Missing
+description: Missing
+icon: icon
+systemMCPServerType: filter
+runtime: npx
+npxConfig:
+  package: test`,
+		"invalid-name.yaml": `name: "!!!"
+shortDescription: Invalid
+description: Invalid
+icon: icon
+runtime: npx
+npxConfig:
+  package: test`,
+	}
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(contents+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := executeMCPTestCommand(t, mcpTestRoot("http://unused.example"), "validate-system-catalog-yaml", dir)
+	if err == nil {
+		t.Fatal("expected validation errors")
+	}
+	for _, expected := range []string{
+		"unknown-field.yaml",
+		"unknown field \"unknownField\"",
+		"missing-filter-config.yaml",
+		"filterConfig is required",
+		"invalid-name.yaml",
+		"invalid system catalog entry name after sanitization",
+	} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("error = %v, want %q", err, expected)
+		}
+	}
+}
+
+func TestMCPValidateSystemCatalogYAMLRejectsDuplicateSanitizedNames(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "first.yaml")
+	secondPath := filepath.Join(dir, "second.yaml")
+	entry := func(name string) string {
+		return fmt.Sprintf(`name: %q
+shortDescription: Test
+description: Test
+icon: icon
+runtime: npx
+npxConfig:
+  package: test
+`, name)
+	}
+	if err := os.WriteFile(firstPath, []byte(entry("Shared Name")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secondPath, []byte(entry("shared-name")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := executeMCPTestCommand(t, mcpTestRoot("http://unused.example"), "validate-system-catalog-yaml", firstPath, secondPath)
+	if err == nil {
+		t.Fatal("expected duplicate sanitized name error")
+	}
+	want := fmt.Sprintf("%s: duplicate sanitized system catalog entry name %q also used by %s", secondPath, "shared-name", firstPath)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want %q", err, want)
 	}
 }
 

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -609,9 +609,7 @@ func (h *Handler) readSystemMCPCatalog(ctx context.Context, catalogName, sourceU
 			continue
 		}
 
-		mcpManifest := systemCatalogEntryManifestToMCP(entry)
-		catalogvalidation.NormalizeManifest(&mcpManifest)
-		entry = mcpCatalogEntryManifestToSystem(mcpManifest, entry.SystemMCPServerType, entry.FilterConfig)
+		catalogvalidation.NormalizeSystemManifest(&entry)
 		if err := mcp.ValidateSystemMCPServerCatalogEntryManifest(ctx, entry, mcp.ValidationOptions{}); err != nil {
 			errs = append(errs, fmt.Errorf("failed to validate system catalog entry %s: %w", entry.Name, err))
 			continue
@@ -632,47 +630,6 @@ func (h *Handler) readSystemMCPCatalog(ctx context.Context, catalogName, sourceU
 	}
 
 	return systemObjs, errors.Join(errs...)
-}
-
-func mcpCatalogEntryManifestToSystem(manifest types.MCPServerCatalogEntryManifest, systemMCPServerType types.SystemMCPServerType, filterConfig *types.FilterConfig) types.SystemMCPServerCatalogEntryManifest {
-	return types.SystemMCPServerCatalogEntryManifest{
-		Metadata:            manifest.Metadata,
-		Name:                manifest.Name,
-		ShortDescription:    manifest.ShortDescription,
-		Description:         manifest.Description,
-		Icon:                manifest.Icon,
-		RepoURL:             manifest.RepoURL,
-		ToolPreview:         manifest.ToolPreview,
-		SystemMCPServerType: systemMCPServerType,
-		ServerUserType:      manifest.ServerUserType,
-		FilterConfig:        filterConfig,
-		Runtime:             manifest.Runtime,
-		UVXConfig:           manifest.UVXConfig,
-		NPXConfig:           manifest.NPXConfig,
-		ContainerizedConfig: manifest.ContainerizedConfig,
-		RemoteConfig:        manifest.RemoteConfig,
-		Env:                 manifest.Env,
-		Resources:           manifest.Resources,
-	}
-}
-
-func systemCatalogEntryManifestToMCP(manifest types.SystemMCPServerCatalogEntryManifest) types.MCPServerCatalogEntryManifest {
-	return types.MCPServerCatalogEntryManifest{
-		Metadata:            manifest.Metadata,
-		Name:                manifest.Name,
-		ShortDescription:    manifest.ShortDescription,
-		Description:         manifest.Description,
-		Icon:                manifest.Icon,
-		RepoURL:             manifest.RepoURL,
-		ToolPreview:         manifest.ToolPreview,
-		Runtime:             manifest.Runtime,
-		UVXConfig:           manifest.UVXConfig,
-		NPXConfig:           manifest.NPXConfig,
-		ContainerizedConfig: manifest.ContainerizedConfig,
-		RemoteConfig:        manifest.RemoteConfig,
-		Env:                 manifest.Env,
-		Resources:           manifest.Resources,
-	}
 }
 
 func (h *Handler) readMCPCatalog(ctx context.Context, catalogName, sourceURL, token string, options ...mcp.ValidationOptions) ([]client.Object, error) {

--- a/pkg/mcpcatalog/validation.go
+++ b/pkg/mcpcatalog/validation.go
@@ -36,7 +36,21 @@ func SanitizeName(name string) string {
 // NormalizeManifest applies the same compatibility normalization used when
 // Obot imports a catalog source.
 func NormalizeManifest(entry *types.MCPServerCatalogEntryManifest) {
-	for i, env := range entry.Env {
+	normalizeEnv(entry.Env)
+	normalizeRemoteConfig(entry.Runtime, entry.RemoteConfig)
+	normalizeServerUserType(&entry.ServerUserType)
+}
+
+// NormalizeSystemManifest applies the same compatibility normalization used
+// when Obot imports a system catalog source.
+func NormalizeSystemManifest(entry *types.SystemMCPServerCatalogEntryManifest) {
+	normalizeEnv(entry.Env)
+	normalizeRemoteConfig(entry.Runtime, entry.RemoteConfig)
+	normalizeServerUserType(&entry.ServerUserType)
+}
+
+func normalizeEnv(envs []types.MCPEnv) {
+	for i, env := range envs {
 		if env.Key == "" {
 			env.Key = env.Name
 		}
@@ -45,21 +59,25 @@ func NormalizeManifest(entry *types.MCPServerCatalogEntryManifest) {
 			env.File = true
 		}
 		env.Key = strings.ReplaceAll(strings.ToUpper(env.Key), "-", "_")
-		entry.Env[i] = env
+		envs[i] = env
 	}
+}
 
-	if entry.Runtime == types.RuntimeRemote && entry.RemoteConfig != nil {
-		for i, header := range entry.RemoteConfig.Headers {
+func normalizeRemoteConfig(runtime types.Runtime, remoteConfig *types.RemoteCatalogConfig) {
+	if runtime == types.RuntimeRemote && remoteConfig != nil {
+		for i, header := range remoteConfig.Headers {
 			if header.Key == "" {
 				header.Key = header.Name
 			}
 			header.Key = strings.ReplaceAll(strings.ToUpper(header.Key), "_", "-")
-			entry.RemoteConfig.Headers[i] = header
+			remoteConfig.Headers[i] = header
 		}
 	}
+}
 
-	if entry.ServerUserType == "" {
-		entry.ServerUserType = types.ServerUserTypeSingleUser
+func normalizeServerUserType(serverUserType *types.ServerUserType) {
+	if *serverUserType == "" {
+		*serverUserType = types.ServerUserTypeSingleUser
 	}
 }
 

--- a/pkg/mcpcatalog/walker_test.go
+++ b/pkg/mcpcatalog/walker_test.go
@@ -99,3 +99,18 @@ func TestNormalizeManifest(t *testing.T) {
 	require.True(t, entry.Env[0].File)
 	require.Equal(t, "API-KEY", entry.RemoteConfig.Headers[0].Key)
 }
+
+func TestNormalizeSystemManifest(t *testing.T) {
+	entry := types.SystemMCPServerCatalogEntryManifest{
+		Runtime:      types.RuntimeRemote,
+		Env:          []types.MCPEnv{{MCPHeader: types.MCPHeader{Name: "config-file.json"}}},
+		RemoteConfig: &types.RemoteCatalogConfig{Headers: []types.MCPHeader{{Name: "api_key"}}},
+	}
+
+	NormalizeSystemManifest(&entry)
+
+	require.Equal(t, types.ServerUserTypeSingleUser, entry.ServerUserType)
+	require.Equal(t, "CONFIG_FILE_JSON", entry.Env[0].Key)
+	require.True(t, entry.Env[0].File)
+	require.Equal(t, "API-KEY", entry.RemoteConfig.Headers[0].Key)
+}


### PR DESCRIPTION
We can use this command in the build step of our system MCP catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `validate-system-catalog-yaml` for validating system MCP catalog files.
  * Supports filter and remote entries while ignoring excluded files and duplicate file paths.

* **Improvements**
  * Reports aggregated validation issues, including unknown fields, missing configuration, invalid names, and duplicate sanitized names.
  * System catalog entries are consistently normalized, including environment variables, remote headers, user settings, and file-based configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->