### PR TITLE
feat: revoke API keys instead of delete

### DIFF
--- a/pkg/controller/handlers/cleanup/user.go
+++ b/pkg/controller/handlers/cleanup/user.go
@@ -92,7 +92,7 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 		return fmt.Errorf("failed to list API keys for user %d: %w", userDelete.Spec.UserID, err)
 	}
 	for _, key := range apiKeys {
-		if err := u.gatewayClient.DeleteAPIKey(req.Ctx, userDelete.Spec.UserID, key.ID); err != nil {
+		if err := u.gatewayClient.RevokeAPIKey(req.Ctx, userDelete.Spec.UserID, key.ID); err != nil {
 			return fmt.Errorf("failed to delete API key %d for user %d: %w", key.ID, userDelete.Spec.UserID, err)
 		}
 	}

--- a/pkg/controller/handlers/cleanup/user.go
+++ b/pkg/controller/handlers/cleanup/user.go
@@ -84,7 +84,7 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 	}
 	log.Infof("Deleted projects during user cleanup: userID=%s projects=%d", userID, len(projects.Items))
 
-	// Delete any API keys the user created. Nanobot-agent keys are handled by the
+	// Revoke any API keys the user created. Nanobot-agent keys are handled by the
 	// NanobotAgent delete flow above; this sweeps user-created keys plus anything
 	// the nanobot path missed.
 	apiKeys, err := u.gatewayClient.ListAPIKeys(req.Ctx, userDelete.Spec.UserID)
@@ -93,10 +93,10 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 	}
 	for _, key := range apiKeys {
 		if err := u.gatewayClient.RevokeAPIKey(req.Ctx, userDelete.Spec.UserID, key.ID); err != nil {
-			return fmt.Errorf("failed to delete API key %d for user %d: %w", key.ID, userDelete.Spec.UserID, err)
+			return fmt.Errorf("failed to revoke API key %d for user %d: %w", key.ID, userDelete.Spec.UserID, err)
 		}
 	}
-	log.Infof("Deleted API keys during user cleanup: userID=%s keys=%d", userID, len(apiKeys))
+	log.Infof("Revoked API keys during user cleanup: userID=%s keys=%d", userID, len(apiKeys))
 
 	var servers v1.MCPServerList
 	if err := req.List(&servers, &kclient.ListOptions{
@@ -112,7 +112,7 @@ func (u *UserCleanup) Cleanup(req router.Request, _ router.Response) error {
 	for _, server := range servers.Items {
 		// Skip multi-user servers in the default MCPCatalog — they should persist after user deletion.
 		// Also skip servers that are associated with an agent because we need the credential to stick
-		// around so we can delete the API key.
+		// around so we can revoke the API key.
 		if server.Spec.MCPCatalogID == system.DefaultCatalog || server.Spec.NanobotAgentID != "" {
 			continue
 		}

--- a/pkg/controller/handlers/hostedagent/credentials/credentials.go
+++ b/pkg/controller/handlers/hostedagent/credentials/credentials.go
@@ -89,8 +89,8 @@ func (i *Issuer) EnsureInstanceCredential(ctx context.Context, instanceID, owner
 	return created.Key, version, nil
 }
 
-// RevokeInstanceCredential removes both the key and its stored plaintext.
-// Revocation is a row delete, so a leaked credential stops working at once
+// RevokeInstanceCredential revokes the key and deletes its stored plaintext.
+// Revocation immediately invalidates a key, so a leaked credential stops working at once
 // rather than waiting for an expiry these keys deliberately do not have.
 func (i *Issuer) RevokeInstanceCredential(ctx context.Context, instanceID string) error {
 	if i == nil || i.gatewayClient == nil {
@@ -98,7 +98,7 @@ func (i *Issuer) RevokeInstanceCredential(ctx context.Context, instanceID string
 	}
 
 	var errs []error
-	if err := i.gatewayClient.DeleteHostedAgentAPIKeys(ctx, instanceID); err != nil {
+	if err := i.gatewayClient.RevokeHostedAgentAPIKeys(ctx, instanceID); err != nil {
 		errs = append(errs, err)
 	}
 	// DeleteCredential is idempotent, so a credential that is already gone is

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -310,9 +310,9 @@ func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, res
 		return fmt.Errorf("failed to get user: %w", err)
 	}
 
-	// Delete old API key if present.
-	// We're not deleting the key the container is currently using because it may take a few minutes for the volume
-	// to update with the new credentials. We delete the previously used key instead to ensure that we don't leave orphaned keys around.
+	// Revoke the old API key if present.
+	// We're not revoking the key the container is currently using because it may take a few minutes for the volume
+	// to update with the new credentials. We revoke the previously used key instead to ensure that we don't leave active orphaned keys around.
 	apiKeyIDStr := credEnvFileVars["MCP_API_KEY_ID_PREV"]
 	if apiKeyIDStr == "" {
 		// Backward compatibility while migrating old credentials.
@@ -321,7 +321,7 @@ func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, res
 	if apiKeyIDStr != "" {
 		if id, err := strconv.ParseUint(apiKeyIDStr, 10, 32); err == nil {
 			if err = h.gatewayClient.RevokeAPIKey(ctx, gatewayUser.ID, uint(id)); err != nil {
-				return fmt.Errorf("failed to delete old API key: %w", err)
+				return fmt.Errorf("failed to revoke old API key: %w", err)
 			}
 		}
 	}
@@ -593,7 +593,7 @@ func preferredModelsForAlias(aliasName types.DefaultModelAliasType) []string {
 	return preferred
 }
 
-// deleteTokens deletes the API key and MCP token associated with the MCP server.
+// deleteTokens revokes the API key and deletes the MCP token associated with the MCP server.
 func (h *Handler) deleteTokens(ctx context.Context, agent *v1.NanobotAgent, mcpServerName string) error {
 	credCtx := fmt.Sprintf("%s-%s", agent.Spec.UserID, mcpServerName)
 
@@ -607,7 +607,7 @@ func (h *Handler) deleteTokens(ctx context.Context, agent *v1.NanobotAgent, mcpS
 		return fmt.Errorf("failed to reveal credential: %w", err)
 	}
 
-	// Extract and delete the API key if present
+	// Extract and revoke the API key if present
 
 	if apiKeyIDStr := parseEnvFile(cred.Secrets["NANOBOT_ENV_FILE"])["MCP_API_KEY_ID"]; apiKeyIDStr != "" {
 		apiKeyID, err := strconv.ParseUint(apiKeyIDStr, 10, 32)
@@ -615,15 +615,15 @@ func (h *Handler) deleteTokens(ctx context.Context, agent *v1.NanobotAgent, mcpS
 			return fmt.Errorf("failed to parse API key ID: %w", err)
 		}
 
-		// Look up the gateway user to get the uint ID needed for API key deletion
+		// Look up the gateway user to get the uint ID needed for API key revocation
 		gatewayUser, err := h.gatewayClient.UserByIDIncludeDeleted(ctx, agent.Spec.UserID)
 		if err != nil {
 			return fmt.Errorf("failed to get user: %w", err)
 		}
 
-		// Delete the API key
+		// Revoke the API key
 		if err := h.gatewayClient.RevokeAPIKey(ctx, gatewayUser.ID, uint(apiKeyID)); err != nil {
-			return fmt.Errorf("failed to delete API key: %w", err)
+			return fmt.Errorf("failed to revoke API key: %w", err)
 		}
 	}
 

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -320,7 +320,7 @@ func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, res
 	}
 	if apiKeyIDStr != "" {
 		if id, err := strconv.ParseUint(apiKeyIDStr, 10, 32); err == nil {
-			if err = h.gatewayClient.DeleteAPIKey(ctx, gatewayUser.ID, uint(id)); err != nil {
+			if err = h.gatewayClient.RevokeAPIKey(ctx, gatewayUser.ID, uint(id)); err != nil {
 				return fmt.Errorf("failed to delete old API key: %w", err)
 			}
 		}
@@ -622,7 +622,7 @@ func (h *Handler) deleteTokens(ctx context.Context, agent *v1.NanobotAgent, mcpS
 		}
 
 		// Delete the API key
-		if err := h.gatewayClient.DeleteAPIKey(ctx, gatewayUser.ID, uint(apiKeyID)); err != nil {
+		if err := h.gatewayClient.RevokeAPIKey(ctx, gatewayUser.ID, uint(apiKeyID)); err != nil {
 			return fmt.Errorf("failed to delete API key: %w", err)
 		}
 	}

--- a/pkg/gateway/client/apikey.go
+++ b/pkg/gateway/client/apikey.go
@@ -473,12 +473,6 @@ func (c *Client) revokeAPIKey(ctx context.Context, keyID uint, userID *uint) err
 	return nil
 }
 
-// DeleteAPIKeyByID is retained for callers that still use the old lifecycle
-// name. It revokes the key and does not delete retained metadata.
-func (c *Client) DeleteAPIKeyByID(ctx context.Context, keyID uint) error {
-	return c.RevokeAPIKeyByID(ctx, keyID)
-}
-
 // UpdateAPIKeyLastUsed updates the last_used_at timestamp for an API key
 // if more than a minute has elapsed since the previous timestamp.
 func (c *Client) UpdateAPIKeyLastUsed(ctx context.Context, key *types.APIKey) error {

--- a/pkg/gateway/client/apikey.go
+++ b/pkg/gateway/client/apikey.go
@@ -41,6 +41,9 @@ func cloneAPIKey(apiKey types.APIKey) types.APIKey {
 	if apiKey.ExpiresAt != nil {
 		cloned.ExpiresAt = new(*apiKey.ExpiresAt)
 	}
+	if apiKey.RevokedAt != nil {
+		cloned.RevokedAt = new(*apiKey.RevokedAt)
+	}
 	return cloned
 }
 
@@ -63,7 +66,7 @@ func (c *Client) getValidatedAPIKeyFromCache(key string, now time.Time) (*types.
 	}
 
 	// Fast path: entry appears valid under the read lock.
-	entryExpired := now.After(entry.expiresAt) || (entry.apiKey.ExpiresAt != nil && entry.apiKey.ExpiresAt.Before(now))
+	entryExpired := entry.apiKey.RevokedAt != nil || now.After(entry.expiresAt) || (entry.apiKey.ExpiresAt != nil && entry.apiKey.ExpiresAt.Before(now))
 	if !entryExpired {
 		cachedAPIKey := entry.apiKey
 		c.apiKeyCacheLock.RUnlock()
@@ -81,7 +84,7 @@ func (c *Client) getValidatedAPIKeyFromCache(key string, now time.Time) (*types.
 		return nil, false
 	}
 
-	if now.After(entry.expiresAt) || (entry.apiKey.ExpiresAt != nil && entry.apiKey.ExpiresAt.Before(now)) {
+	if entry.apiKey.RevokedAt != nil || now.After(entry.expiresAt) || (entry.apiKey.ExpiresAt != nil && entry.apiKey.ExpiresAt.Before(now)) {
 		delete(c.apiKeyCache, fingerprint)
 		c.apiKeyCacheLock.Unlock()
 		return nil, false
@@ -112,7 +115,7 @@ func (c *Client) pruneExpiredValidatedAPIKeys(now time.Time) {
 	defer c.apiKeyCacheLock.Unlock()
 
 	for fingerprint, entry := range c.apiKeyCache {
-		if now.After(entry.expiresAt) || (entry.apiKey.ExpiresAt != nil && entry.apiKey.ExpiresAt.Before(now)) {
+		if entry.apiKey.RevokedAt != nil || now.After(entry.expiresAt) || (entry.apiKey.ExpiresAt != nil && entry.apiKey.ExpiresAt.Before(now)) {
 			delete(c.apiKeyCache, fingerprint)
 		}
 	}
@@ -200,16 +203,17 @@ func (c *Client) CreateHostedAgentAPIKey(ctx context.Context, instanceID string,
 	return resp, nil
 }
 
-// DeleteHostedAgentAPIKeys revokes every key bound to an instance. Revocation
-// is a row delete, so a leaked credential stops working immediately rather than
-// waiting for an expiry that hosted agent keys deliberately do not have.
-func (c *Client) DeleteHostedAgentAPIKeys(ctx context.Context, instanceID string) error {
+// RevokeHostedAgentAPIKeys immediately disables every key bound to an instance
+// while retaining the key metadata for audit history.
+func (c *Client) RevokeHostedAgentAPIKeys(ctx context.Context, instanceID string) error {
 	if instanceID == "" {
 		return nil
 	}
-	if err := c.db.WithContext(ctx).Where("hosted_agent_instance_id = ?", instanceID).
-		Delete(&types.APIKey{}).Error; err != nil {
-		return fmt.Errorf("failed to delete hosted agent API keys: %w", err)
+	if err := c.db.WithContext(ctx).Model(&types.APIKey{}).
+		Where("hosted_agent_instance_id = ?", instanceID).
+		Where("revoked_at IS NULL").
+		Update("revoked_at", time.Now().UTC()).Error; err != nil {
+		return fmt.Errorf("failed to revoke hosted agent API keys: %w", err)
 	}
 	return nil
 }
@@ -218,6 +222,7 @@ func (c *Client) DeleteHostedAgentAPIKeys(ctx context.Context, instanceID string
 func (c *Client) HostedAgentAPIKeys(ctx context.Context, instanceID string) ([]types.APIKey, error) {
 	var keys []types.APIKey
 	if err := c.db.WithContext(ctx).Where("hosted_agent_instance_id = ?", instanceID).
+		Where("revoked_at IS NULL").
 		Order("created_at DESC").Find(&keys).Error; err != nil {
 		return nil, fmt.Errorf("failed to list hosted agent API keys: %w", err)
 	}
@@ -270,10 +275,24 @@ func (c *Client) createAPIKeyFromTokenRequest(tx *gorm.DB, userID uint, tr *type
 	return resp, nil
 }
 
-// ListAPIKeys returns all API keys for a user (without the secrets).
+// APIKeyListOptions controls whether retained revoked keys are included.
+type APIKeyListOptions struct {
+	ShowRevoked bool
+}
+
+// ListAPIKeys returns active API keys for a user (without the secrets).
 func (c *Client) ListAPIKeys(ctx context.Context, userID uint) ([]types.APIKey, error) {
+	return c.ListAPIKeysWithOptions(ctx, userID, APIKeyListOptions{})
+}
+
+// ListAPIKeysWithOptions returns API keys for a user according to opts.
+func (c *Client) ListAPIKeysWithOptions(ctx context.Context, userID uint, opts APIKeyListOptions) ([]types.APIKey, error) {
 	var keys []types.APIKey
-	if err := c.db.WithContext(ctx).Where("user_id = ?", userID).Order("created_at DESC").Find(&keys).Error; err != nil {
+	db := c.db.WithContext(ctx).Where("user_id = ?", userID)
+	if !opts.ShowRevoked {
+		db = db.Where("revoked_at IS NULL")
+	}
+	if err := db.Order("created_at DESC").Find(&keys).Error; err != nil {
 		return nil, fmt.Errorf("failed to list API keys: %w", err)
 	}
 	return keys, nil
@@ -288,24 +307,41 @@ func (c *Client) GetAPIKey(ctx context.Context, userID uint, keyID uint) (*types
 	return &key, nil
 }
 
-// DeleteAPIKey removes an API key.
-func (c *Client) DeleteAPIKey(ctx context.Context, userID uint, keyID uint) error {
-	result := c.db.WithContext(ctx).Where("id = ?", keyID).Where("user_id = ?", userID).Delete(&types.APIKey{})
-	if result.Error != nil {
-		return fmt.Errorf("failed to delete API key: %w", result.Error)
-	}
-	c.invalidateValidatedAPIKeysByID(keyID)
-	return nil
+// RevokeAPIKey immediately disables an API key while retaining its metadata.
+// Repeated revocation is idempotent and preserves the original revocation time.
+func (c *Client) RevokeAPIKey(ctx context.Context, userID uint, keyID uint) error {
+	return c.revokeAPIKey(ctx, keyID, &userID)
 }
 
 // ValidateAPIKey validates an API key and returns the associated APIKey record.
 // The key format is: ok1-<user_id>-<key_id>-<secret>
 // Lookup is done by key ID, then bcrypt is used to verify the secret.
-// Cache hits return a previously validated key without touching the database.
+// Cache hits avoid repeating bcrypt but still check persisted lifecycle state so
+// revocation on one server replica takes effect on every replica immediately.
 // On cache misses, last_used_at is updated only if more than a minute has elapsed.
 func (c *Client) ValidateAPIKey(ctx context.Context, key string) (*types.APIKey, error) {
 	cacheNow := time.Now()
 	if cachedAPIKey, ok := c.getValidatedAPIKeyFromCache(key, cacheNow); ok {
+		var lifecycle struct {
+			ExpiresAt *time.Time
+			RevokedAt *time.Time
+		}
+		if err := c.db.WithContext(ctx).Model(&types.APIKey{}).
+			Select("expires_at", "revoked_at").
+			Where("id = ?", cachedAPIKey.ID).
+			Where("user_id = ?", cachedAPIKey.UserID).
+			First(&lifecycle).Error; err != nil {
+			c.invalidateValidatedAPIKeysByID(cachedAPIKey.ID)
+			return nil, err
+		}
+		if lifecycle.RevokedAt != nil {
+			c.invalidateValidatedAPIKeysByID(cachedAPIKey.ID)
+			return nil, fmt.Errorf("API key has been revoked")
+		}
+		if lifecycle.ExpiresAt != nil && lifecycle.ExpiresAt.Before(cacheNow) {
+			c.invalidateValidatedAPIKeysByID(cachedAPIKey.ID)
+			return nil, fmt.Errorf("API key has expired")
+		}
 		return cachedAPIKey, nil
 	}
 
@@ -330,6 +366,9 @@ func (c *Client) ValidateAPIKey(ctx context.Context, key string) (*types.APIKey,
 		// Check expiration
 		if apiKey.ExpiresAt != nil && apiKey.ExpiresAt.Before(time.Now()) {
 			return fmt.Errorf("API key has expired")
+		}
+		if apiKey.RevokedAt != nil {
+			return fmt.Errorf("API key has been revoked")
 		}
 
 		// Update last used timestamp if more than a minute has elapsed
@@ -393,10 +432,14 @@ func ParseRedactedAPIKey(key string) (userID uint, keyID uint, err error) {
 
 // Admin methods - no user filtering
 
-// ListAllAPIKeys returns all API keys in the system (for admin use).
-func (c *Client) ListAllAPIKeys(ctx context.Context) ([]types.APIKey, error) {
+// ListAllAPIKeys returns system API keys according to opts.
+func (c *Client) ListAllAPIKeys(ctx context.Context, opts APIKeyListOptions) ([]types.APIKey, error) {
 	var keys []types.APIKey
-	if err := c.db.WithContext(ctx).Order("created_at DESC").Find(&keys).Error; err != nil {
+	db := c.db.WithContext(ctx)
+	if !opts.ShowRevoked {
+		db = db.Where("revoked_at IS NULL")
+	}
+	if err := db.Order("created_at DESC").Find(&keys).Error; err != nil {
 		return nil, fmt.Errorf("failed to list API keys: %w", err)
 	}
 	return keys, nil
@@ -411,14 +454,29 @@ func (c *Client) GetAPIKeyByID(ctx context.Context, keyID uint) (*types.APIKey, 
 	return &key, nil
 }
 
-// DeleteAPIKeyByID removes an API key by ID without user filtering (for admin use).
-func (c *Client) DeleteAPIKeyByID(ctx context.Context, keyID uint) error {
-	result := c.db.WithContext(ctx).Where("id = ?", keyID).Delete(&types.APIKey{})
+// RevokeAPIKeyByID immediately disables an API key without user filtering
+// while retaining its metadata for audit history.
+func (c *Client) RevokeAPIKeyByID(ctx context.Context, keyID uint) error {
+	return c.revokeAPIKey(ctx, keyID, nil)
+}
+
+func (c *Client) revokeAPIKey(ctx context.Context, keyID uint, userID *uint) error {
+	db := c.db.WithContext(ctx).Model(&types.APIKey{}).Where("id = ?", keyID)
+	if userID != nil {
+		db = db.Where("user_id = ?", *userID)
+	}
+	result := db.Where("revoked_at IS NULL").Update("revoked_at", time.Now().UTC())
 	if result.Error != nil {
-		return fmt.Errorf("failed to delete API key: %w", result.Error)
+		return fmt.Errorf("failed to revoke API key: %w", result.Error)
 	}
 	c.invalidateValidatedAPIKeysByID(keyID)
 	return nil
+}
+
+// DeleteAPIKeyByID is retained for callers that still use the old lifecycle
+// name. It revokes the key and does not delete retained metadata.
+func (c *Client) DeleteAPIKeyByID(ctx context.Context, keyID uint) error {
+	return c.RevokeAPIKeyByID(ctx, keyID)
 }
 
 // UpdateAPIKeyLastUsed updates the last_used_at timestamp for an API key

--- a/pkg/gateway/client/apikey_revocation_test.go
+++ b/pkg/gateway/client/apikey_revocation_test.go
@@ -1,0 +1,181 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+func TestRevokeAPIKeyRetainsMetadataAndImmediatelyRejectsCachedCredential(t *testing.T) {
+	c := newTestClient(t)
+	c.apiKeyCache = make(map[[32]byte]apiKeyValidationCacheEntry)
+	c.apiKeyCacheTTL = time.Minute
+
+	created, err := c.CreateAPIKey(t.Context(), 7, "CLI token", "developer laptop", nil, types.APIKeyScopes{
+		CanAccessLLMProxy: true,
+		MCPServerIDs:      []string{"mcp-one"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.ValidateAPIKey(t.Context(), created.Key); err != nil {
+		t.Fatalf("validate created API key: %v", err)
+	}
+
+	if err := c.RevokeAPIKey(t.Context(), 7, created.ID); err != nil {
+		t.Fatalf("revoke API key: %v", err)
+	}
+
+	if _, err := c.ValidateAPIKey(t.Context(), created.Key); err == nil {
+		t.Fatal("revoked API key was still accepted")
+	}
+
+	retained, err := c.GetAPIKey(t.Context(), 7, created.ID)
+	if err != nil {
+		t.Fatalf("get revoked API key: %v", err)
+	}
+	if retained.RevokedAt == nil {
+		t.Fatal("revoked API key is missing revokedAt")
+	}
+	if retained.Name != "CLI token" || retained.Description != "developer laptop" {
+		t.Fatalf("revoked API key metadata was not retained: %+v", retained)
+	}
+	if !retained.CanAccessLLMProxy || len(retained.MCPServerIDs) != 1 || retained.MCPServerIDs[0] != "mcp-one" {
+		t.Fatalf("revoked API key scopes were not retained: %+v", retained.APIKeyScopes)
+	}
+
+	firstRevokedAt := *retained.RevokedAt
+	if err := c.RevokeAPIKey(t.Context(), 7, created.ID); err != nil {
+		t.Fatalf("revoke API key again: %v", err)
+	}
+	retained, err = c.GetAPIKey(t.Context(), 7, created.ID)
+	if err != nil {
+		t.Fatalf("get API key after second revocation: %v", err)
+	}
+	if retained.RevokedAt == nil || !retained.RevokedAt.Equal(firstRevokedAt) {
+		t.Fatalf("second revocation changed revokedAt: first=%s second=%v", firstRevokedAt, retained.RevokedAt)
+	}
+}
+
+func TestRevokeAPIKeyImmediatelyRejectsCredentialCachedByAnotherClient(t *testing.T) {
+	revoker := newTestClient(t)
+	revoker.apiKeyCache = make(map[[32]byte]apiKeyValidationCacheEntry)
+	revoker.apiKeyCacheTTL = time.Minute
+	validator := &Client{
+		db:             revoker.db,
+		apiKeyCache:    make(map[[32]byte]apiKeyValidationCacheEntry),
+		apiKeyCacheTTL: time.Minute,
+	}
+
+	created, err := revoker.CreateAPIKey(t.Context(), 7, "CLI token", "", nil, types.APIKeyScopes{CanAccessAPI: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := validator.ValidateAPIKey(t.Context(), created.Key); err != nil {
+		t.Fatalf("populate second client cache: %v", err)
+	}
+
+	if err := revoker.RevokeAPIKey(t.Context(), 7, created.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := validator.ValidateAPIKey(t.Context(), created.Key); err == nil {
+		t.Fatal("another client's cached API key remained valid after revocation")
+	}
+}
+
+func TestRevokedAPIKeysAreHiddenFromOperationalListsAndRetainedForAdmins(t *testing.T) {
+	c := newTestClient(t)
+
+	active, err := c.CreateAPIKey(t.Context(), 7, "active", "", nil, types.APIKeyScopes{CanAccessAPI: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	revoked, err := c.CreateAPIKey(t.Context(), 7, "revoked", "", nil, types.APIKeyScopes{CanAccessAPI: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RevokeAPIKey(t.Context(), 7, revoked.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	userKeys, err := c.ListAPIKeys(t.Context(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(userKeys) != 1 || userKeys[0].ID != active.ID {
+		t.Fatalf("user API key list = %+v, want only active key %d", userKeys, active.ID)
+	}
+
+	adminKeys, err := c.ListAllAPIKeys(t.Context(), APIKeyListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(adminKeys) != 1 || adminKeys[0].ID != active.ID {
+		t.Fatalf("default admin API key list = %+v, want only active key %d", adminKeys, active.ID)
+	}
+
+	adminKeys, err = c.ListAllAPIKeys(t.Context(), APIKeyListOptions{ShowRevoked: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(adminKeys) != 2 {
+		t.Fatalf("admin API key history list has %d keys, want 2", len(adminKeys))
+	}
+	var foundRevoked bool
+	for _, key := range adminKeys {
+		if key.ID == revoked.ID {
+			foundRevoked = key.RevokedAt != nil
+		}
+	}
+	if !foundRevoked {
+		t.Fatalf("admin API key list did not retain revoked key %d: %+v", revoked.ID, adminKeys)
+	}
+}
+
+func TestRevokeHostedAgentAPIKeysRetainsHistoryAndDisablesEveryCredential(t *testing.T) {
+	c := newTestClient(t)
+	c.apiKeyCache = make(map[[32]byte]apiKeyValidationCacheEntry)
+	c.apiKeyCacheTTL = time.Minute
+
+	first, err := c.CreateHostedAgentAPIKey(t.Context(), "hai-one", 7, "first")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := c.CreateHostedAgentAPIKey(t.Context(), "hai-one", 7, "second")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.ValidateAPIKey(t.Context(), first.Key); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.ValidateAPIKey(t.Context(), second.Key); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.RevokeHostedAgentAPIKeys(t.Context(), "hai-one"); err != nil {
+		t.Fatal(err)
+	}
+	for _, token := range []string{first.Key, second.Key} {
+		if _, err := c.ValidateAPIKey(t.Context(), token); err == nil {
+			t.Fatal("revoked hosted-agent API key was still accepted")
+		}
+	}
+
+	operational, err := c.HostedAgentAPIKeys(t.Context(), "hai-one")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(operational) != 0 {
+		t.Fatalf("hosted-agent operational list contains revoked keys: %+v", operational)
+	}
+
+	adminKeys, err := c.ListAllAPIKeys(t.Context(), APIKeyListOptions{ShowRevoked: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(adminKeys) != 2 || adminKeys[0].RevokedAt == nil || adminKeys[1].RevokedAt == nil {
+		t.Fatalf("admin history did not retain revoked hosted-agent keys: %+v", adminKeys)
+	}
+}

--- a/pkg/gateway/client/auditlogcleanup_test.go
+++ b/pkg/gateway/client/auditlogcleanup_test.go
@@ -75,6 +75,103 @@ func countLLMAuditLogs(t *testing.T, c *Client) int64 {
 	return count
 }
 
+func insertAPIKey(t *testing.T, c *Client, revokedAt *time.Time) uint {
+	t.Helper()
+	entry := types.APIKey{
+		UserID:    1,
+		Name:      "retention-test",
+		CreatedAt: time.Now().UTC().AddDate(0, 0, -200),
+		RevokedAt: revokedAt,
+	}
+	if err := c.db.WithContext(t.Context()).Create(&entry).Error; err != nil {
+		t.Fatalf("failed to insert API key: %v", err)
+	}
+	return entry.ID
+}
+
+func countAPIKeys(t *testing.T, c *Client) int64 {
+	t.Helper()
+	var count int64
+	if err := c.db.WithContext(t.Context()).Model(&types.APIKey{}).Count(&count).Error; err != nil {
+		t.Fatalf("failed to count API keys: %v", err)
+	}
+	return count
+}
+
+func TestAPIKeyRetentionDays(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		mcpDays       int
+		llmDays       int
+		wantRetention int
+	}{
+		{name: "MCP is longer", mcpDays: 90, llmDays: 30, wantRetention: 90},
+		{name: "LLM is longer", mcpDays: 30, llmDays: 90, wantRetention: 90},
+		{name: "equal", mcpDays: 90, llmDays: 90, wantRetention: 90},
+		{name: "MCP cleanup disabled", mcpDays: 0, llmDays: 90, wantRetention: 0},
+		{name: "LLM cleanup disabled", mcpDays: 90, llmDays: 0, wantRetention: 0},
+		{name: "negative disables cleanup", mcpDays: -1, llmDays: 90, wantRetention: 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := apiKeyRetentionDays(tt.mcpDays, tt.llmDays); got != tt.wantRetention {
+				t.Fatalf("apiKeyRetentionDays(%d, %d) = %d, want %d", tt.mcpDays, tt.llmDays, got, tt.wantRetention)
+			}
+		})
+	}
+}
+
+func TestDeleteOldRevokedAPIKeys(t *testing.T) {
+	c := newTestClient(t)
+	now := time.Now().UTC()
+	cutoff := now.Truncate(24*time.Hour).AddDate(0, 0, -90)
+	old := cutoff.Add(-time.Second)
+	atCutoff := cutoff
+	recent := cutoff.Add(time.Second)
+
+	insertAPIKey(t, c, nil)
+	insertAPIKey(t, c, &old)
+	insertAPIKey(t, c, &atCutoff)
+	insertAPIKey(t, c, &recent)
+
+	if err := c.deleteOldRevokedAPIKeys(t.Context(), now, 90); err != nil {
+		t.Fatalf("delete old revoked API keys: %v", err)
+	}
+	if got := countAPIKeys(t, c); got != 3 {
+		t.Fatalf("API keys after cleanup = %d, want 3", got)
+	}
+}
+
+func TestDeleteOldRevokedAPIKeysBatching(t *testing.T) {
+	c := newTestClient(t)
+	now := time.Now().UTC()
+	old := now.AddDate(0, 0, -100)
+	for range 7 {
+		insertAPIKey(t, c, &old)
+	}
+	recent := now.AddDate(0, 0, -1)
+	insertAPIKey(t, c, &recent)
+
+	if err := c.deleteOldRevokedAPIKeys(t.Context(), now, 90); err != nil {
+		t.Fatalf("delete old revoked API keys: %v", err)
+	}
+	if got := countAPIKeys(t, c); got != 1 {
+		t.Fatalf("API keys after batched cleanup = %d, want 1", got)
+	}
+}
+
+func TestDeleteOldRevokedAPIKeysDisabled(t *testing.T) {
+	c := newTestClient(t)
+	old := time.Now().UTC().AddDate(0, 0, -200)
+	insertAPIKey(t, c, &old)
+
+	if err := c.deleteOldRevokedAPIKeys(t.Context(), time.Now().UTC(), 0); err != nil {
+		t.Fatalf("disabled cleanup: %v", err)
+	}
+	if got := countAPIKeys(t, c); got != 1 {
+		t.Fatalf("API keys after disabled cleanup = %d, want 1", got)
+	}
+}
+
 func TestDeleteOldAuditLogs(t *testing.T) {
 	c := newTestClient(t)
 	ctx := t.Context()
@@ -140,24 +237,28 @@ func TestDeleteOldAuditLogsBatching(t *testing.T) {
 	}
 }
 
-func TestRunAuditLogCleanup(t *testing.T) {
+func TestRunRetentionCleanup(t *testing.T) {
 	c := newTestClient(t)
 
 	now := time.Now().UTC()
 	insertAuditLog(t, c, now.AddDate(0, 0, -100)) // old
 	insertAuditLog(t, c, now.AddDate(0, 0, -1))   // recent
+	insertLLMAuditLog(t, c, now.AddDate(0, 0, -100))
+	insertLLMAuditLog(t, c, now.AddDate(0, 0, -1))
+	oldRevocation := now.AddDate(0, 0, -100)
+	insertAPIKey(t, c, &oldRevocation)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	go c.runMCPAuditLogCleanup(ctx, 90)
+	go c.runRetentionCleanup(ctx, 90, 30)
 
 	// Wait until the cleanup has deleted old logs, or time out.
 	deadline := time.Now().Add(2 * time.Second)
 	var got int64
 	for {
 		got = countAuditLogs(t, c)
-		if got == 1 {
+		if got == 1 && countLLMAuditLogs(t, c) == 1 && countAPIKeys(t, c) == 0 {
 			break
 		}
 		if time.Now().After(deadline) {
@@ -173,19 +274,61 @@ func TestRunAuditLogCleanup(t *testing.T) {
 	}
 }
 
-func TestRunAuditLogCleanupDisabled(t *testing.T) {
+func TestRunRetentionCleanupDisabled(t *testing.T) {
 	c := newTestClient(t)
 
 	now := time.Now().UTC()
 	insertAuditLog(t, c, now.AddDate(0, 0, -100))
 	insertAuditLog(t, c, now.AddDate(0, 0, -1))
 
-	// retentionDays=0 means the function returns immediately without cleanup.
+	// Both retention periods disabled means the function returns immediately.
 	// Call synchronously — if it ever blocks, the test timeout will catch it.
-	c.runMCPAuditLogCleanup(t.Context(), 0)
+	c.runRetentionCleanup(t.Context(), 0, 0)
 
 	if got := countAuditLogs(t, c); got != 2 {
 		t.Errorf("expected 2 audit logs (cleanup disabled), got %d", got)
+	}
+}
+
+func TestRunRetentionCleanupRepeats(t *testing.T) {
+	c := newTestClient(t)
+	old := time.Now().UTC().AddDate(0, 0, -100)
+	insertAuditLog(t, c, old)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go c.runRetentionCleanup(ctx, 90, 30)
+
+	waitUntilEmpty := func(stage string) {
+		t.Helper()
+		deadline := time.Now().Add(2 * time.Second)
+		for countAuditLogs(t, c) != 0 {
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for %s cleanup", stage)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	waitUntilEmpty("initial")
+
+	insertAuditLog(t, c, old)
+	waitUntilEmpty("periodic")
+}
+
+func TestCleanupRetainedDataSkipsAPIKeysWhenAuditCleanupFails(t *testing.T) {
+	c := newTestClient(t)
+	now := time.Now().UTC()
+	oldRevocation := now.AddDate(0, 0, -100)
+	insertAPIKey(t, c, &oldRevocation)
+
+	if err := c.db.WithContext(t.Context()).Migrator().DropTable(&types.MCPAuditLog{}); err != nil {
+		t.Fatalf("drop MCP audit log table: %v", err)
+	}
+	if err := c.cleanupRetainedData(t.Context(), now, 90, 30); err == nil {
+		t.Fatal("cleanup succeeded despite missing MCP audit log table")
+	}
+	if got := countAPIKeys(t, c); got != 1 {
+		t.Fatalf("API keys after failed audit cleanup = %d, want 1", got)
 	}
 }
 

--- a/pkg/gateway/client/auditlogcleanup_test.go
+++ b/pkg/gateway/client/auditlogcleanup_test.go
@@ -332,6 +332,43 @@ func TestCleanupRetainedDataSkipsAPIKeysWhenAuditCleanupFails(t *testing.T) {
 	}
 }
 
+func TestRunAuditLogCleanupsDoesNotSerializeStreams(t *testing.T) {
+	mcpStarted := make(chan struct{})
+	releaseMCP := make(chan struct{})
+	llmFinished := make(chan struct{})
+	cleanupFinished := make(chan error, 1)
+
+	go func() {
+		cleanupFinished <- runAuditLogCleanups(
+			func() error {
+				close(mcpStarted)
+				<-releaseMCP
+				return nil
+			},
+			func() error {
+				close(llmFinished)
+				return nil
+			},
+		)
+	}()
+
+	select {
+	case <-mcpStarted:
+	case <-time.After(time.Second):
+		t.Fatal("MCP audit cleanup did not start")
+	}
+	select {
+	case <-llmFinished:
+	case <-time.After(time.Second):
+		t.Fatal("LLM audit cleanup was blocked by MCP audit cleanup")
+	}
+	close(releaseMCP)
+
+	if err := <-cleanupFinished; err != nil {
+		t.Fatalf("run audit-log cleanups: %v", err)
+	}
+}
+
 func TestDeleteOldLLMAuditLogs(t *testing.T) {
 	c := newTestClient(t)
 	ctx := t.Context()

--- a/pkg/gateway/client/auditlogcleanup_test.go
+++ b/pkg/gateway/client/auditlogcleanup_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -169,6 +170,28 @@ func TestDeleteOldRevokedAPIKeysDisabled(t *testing.T) {
 	}
 	if got := countAPIKeys(t, c); got != 1 {
 		t.Fatalf("API keys after disabled cleanup = %d, want 1", got)
+	}
+}
+
+func TestRetentionDeletesPropagateCanceledContext(t *testing.T) {
+	c := newTestClient(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	now := time.Now().UTC()
+
+	for _, tt := range []struct {
+		name   string
+		delete func() error
+	}{
+		{name: "MCP audit logs", delete: func() error { return c.deleteOldMCPAuditLogs(ctx, now, 90) }},
+		{name: "LLM audit logs", delete: func() error { return c.deleteOldLLMAuditLogs(ctx, now, 90) }},
+		{name: "revoked API keys", delete: func() error { return c.deleteOldRevokedAPIKeys(ctx, now, 90) }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.delete(); !errors.Is(err, context.Canceled) {
+				t.Fatalf("cleanup error = %v, want context.Canceled", err)
+			}
+		})
 	}
 }
 

--- a/pkg/gateway/client/auditlogpersister.go
+++ b/pkg/gateway/client/auditlogpersister.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/obot-platform/obot/logger"
@@ -59,32 +58,6 @@ func (c *Client) runMCPAuditLogPersistenceLoop(ctx context.Context, flushInterva
 		}
 
 		timer.Reset(flushInterval)
-	}
-}
-
-func (c *Client) runMCPAuditLogCleanup(ctx context.Context, retentionDays int) {
-	if retentionDays <= 0 {
-		return
-	}
-
-	err := c.deleteOldMCPAuditLogs(ctx, time.Now().UTC(), retentionDays)
-	if err != nil && !errors.Is(err, context.Canceled) {
-		log.Errorf("Failed to delete old audit logs: %v", err)
-	}
-
-	ticker := time.NewTicker(c.auditLogCleanupInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			err = c.deleteOldMCPAuditLogs(ctx, time.Now().UTC(), retentionDays)
-			if err != nil && !errors.Is(err, context.Canceled) {
-				log.Errorf("Failed to delete old audit logs: %v", err)
-			}
-		}
 	}
 }
 

--- a/pkg/gateway/client/auditlogpersister.go
+++ b/pkg/gateway/client/auditlogpersister.go
@@ -65,17 +65,10 @@ func (c *Client) deleteOldMCPAuditLogs(ctx context.Context, now time.Time, reten
 	if retentionDays <= 0 {
 		return nil
 	}
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 
 	cutoff := now.Truncate(24*time.Hour).AddDate(0, 0, -retentionDays)
 
 	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
 		result := c.db.WithContext(ctx).Exec(
 			"DELETE FROM mcp_audit_logs WHERE id IN (SELECT id FROM mcp_audit_logs WHERE created_at < ? LIMIT ?)",
 			cutoff, c.auditLogDeleteBatchSize,

--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -100,8 +100,7 @@ func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptio
 	go c.runPendingStateCleanup(ctx)
 	go c.runTokenCleanup(ctx)
 	go c.runAPIKeyCacheCleanup(ctx)
-	go c.runMCPAuditLogCleanup(ctx, auditLogRetentionDays)
-	go c.runLLMAuditLogCleanup(ctx, llmAuditLogRetentionDays)
+	go c.runRetentionCleanup(ctx, auditLogRetentionDays, llmAuditLogRetentionDays)
 	go c.runDeviceScanCleanup(ctx, deviceScanRetentionDays)
 	return c
 }

--- a/pkg/gateway/client/llmauditlog.go
+++ b/pkg/gateway/client/llmauditlog.go
@@ -363,32 +363,6 @@ func (c *Client) insertLLMAuditLogs(ctx context.Context, logs []types.LLMAuditLo
 	return c.db.WithContext(ctx).CreateInBatches(logs, batchSize).Error
 }
 
-func (c *Client) runLLMAuditLogCleanup(ctx context.Context, retentionDays int) {
-	if retentionDays <= 0 {
-		return
-	}
-
-	err := c.deleteOldLLMAuditLogs(ctx, time.Now().UTC(), retentionDays)
-	if err != nil && !errors.Is(err, context.Canceled) {
-		log.Errorf("Failed to delete old LLM audit logs: %v", err)
-	}
-
-	ticker := time.NewTicker(c.auditLogCleanupInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case now := <-ticker.C:
-			err = c.deleteOldLLMAuditLogs(ctx, now.UTC(), retentionDays)
-			if err != nil && !errors.Is(err, context.Canceled) {
-				log.Errorf("Failed to delete old LLM audit logs: %v", err)
-			}
-		}
-	}
-}
-
 func (c *Client) deleteOldLLMAuditLogs(ctx context.Context, now time.Time, retentionDays int) error {
 	if retentionDays <= 0 {
 		return nil

--- a/pkg/gateway/client/llmauditlog.go
+++ b/pkg/gateway/client/llmauditlog.go
@@ -367,17 +367,10 @@ func (c *Client) deleteOldLLMAuditLogs(ctx context.Context, now time.Time, reten
 	if retentionDays <= 0 {
 		return nil
 	}
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 
 	cutoff := now.Truncate(24*time.Hour).AddDate(0, 0, -retentionDays)
 
 	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
 		result := c.db.WithContext(ctx).Exec(
 			"DELETE FROM llm_audit_logs WHERE id IN (SELECT id FROM llm_audit_logs WHERE created_at < ? LIMIT ?)",
 			cutoff, c.auditLogDeleteBatchSize,

--- a/pkg/gateway/client/retention.go
+++ b/pkg/gateway/client/retention.go
@@ -69,15 +69,12 @@ func runAuditLogCleanups(mcpCleanup, llmCleanup func() error) error {
 		mcpErr    error
 		llmErr    error
 	)
-	waitGroup.Add(2)
-	go func() {
-		defer waitGroup.Done()
+	waitGroup.Go(func() {
 		mcpErr = mcpCleanup()
-	}()
-	go func() {
-		defer waitGroup.Done()
+	})
+	waitGroup.Go(func() {
 		llmErr = llmCleanup()
-	}()
+	})
 	waitGroup.Wait()
 	return errors.Join(mcpErr, llmErr)
 }

--- a/pkg/gateway/client/retention.go
+++ b/pkg/gateway/client/retention.go
@@ -1,0 +1,84 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+func apiKeyRetentionDays(mcpAuditLogRetentionDays, llmAuditLogRetentionDays int) int {
+	if mcpAuditLogRetentionDays <= 0 || llmAuditLogRetentionDays <= 0 {
+		return 0
+	}
+	return max(mcpAuditLogRetentionDays, llmAuditLogRetentionDays)
+}
+
+func (c *Client) runRetentionCleanup(ctx context.Context, mcpAuditLogRetentionDays, llmAuditLogRetentionDays int) {
+	if mcpAuditLogRetentionDays <= 0 && llmAuditLogRetentionDays <= 0 {
+		return
+	}
+
+	run := func(now time.Time) {
+		if err := c.cleanupRetainedData(ctx, now.UTC(), mcpAuditLogRetentionDays, llmAuditLogRetentionDays); err != nil && !errors.Is(err, context.Canceled) {
+			log.Errorf("Failed to clean up retained gateway data: %v", err)
+		}
+	}
+	run(time.Now())
+
+	ticker := time.NewTicker(c.auditLogCleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			run(now)
+		}
+	}
+}
+
+func (c *Client) cleanupRetainedData(ctx context.Context, now time.Time, mcpAuditLogRetentionDays, llmAuditLogRetentionDays int) error {
+	var auditLogErrors []error
+	if err := c.deleteOldMCPAuditLogs(ctx, now, mcpAuditLogRetentionDays); err != nil {
+		auditLogErrors = append(auditLogErrors, fmt.Errorf("delete old MCP audit logs: %w", err))
+	}
+	if err := c.deleteOldLLMAuditLogs(ctx, now, llmAuditLogRetentionDays); err != nil {
+		auditLogErrors = append(auditLogErrors, fmt.Errorf("delete old LLM audit logs: %w", err))
+	}
+	if err := errors.Join(auditLogErrors...); err != nil {
+		return err
+	}
+
+	if err := c.deleteOldRevokedAPIKeys(ctx, now, apiKeyRetentionDays(mcpAuditLogRetentionDays, llmAuditLogRetentionDays)); err != nil {
+		return fmt.Errorf("delete old revoked API keys: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) deleteOldRevokedAPIKeys(ctx context.Context, now time.Time, retentionDays int) error {
+	if retentionDays <= 0 {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	cutoff := now.Truncate(24*time.Hour).AddDate(0, 0, -retentionDays)
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		result := c.db.WithContext(ctx).Exec(
+			"DELETE FROM api_keys WHERE id IN (SELECT id FROM api_keys WHERE revoked_at IS NOT NULL AND revoked_at < ? LIMIT ?)",
+			cutoff, c.auditLogDeleteBatchSize,
+		)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected < int64(c.auditLogDeleteBatchSize) {
+			return nil
+		}
+	}
+}

--- a/pkg/gateway/client/retention.go
+++ b/pkg/gateway/client/retention.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -39,14 +40,20 @@ func (c *Client) runRetentionCleanup(ctx context.Context, mcpAuditLogRetentionDa
 }
 
 func (c *Client) cleanupRetainedData(ctx context.Context, now time.Time, mcpAuditLogRetentionDays, llmAuditLogRetentionDays int) error {
-	var auditLogErrors []error
-	if err := c.deleteOldMCPAuditLogs(ctx, now, mcpAuditLogRetentionDays); err != nil {
-		auditLogErrors = append(auditLogErrors, fmt.Errorf("delete old MCP audit logs: %w", err))
-	}
-	if err := c.deleteOldLLMAuditLogs(ctx, now, llmAuditLogRetentionDays); err != nil {
-		auditLogErrors = append(auditLogErrors, fmt.Errorf("delete old LLM audit logs: %w", err))
-	}
-	if err := errors.Join(auditLogErrors...); err != nil {
+	if err := runAuditLogCleanups(
+		func() error {
+			if err := c.deleteOldMCPAuditLogs(ctx, now, mcpAuditLogRetentionDays); err != nil {
+				return fmt.Errorf("delete old MCP audit logs: %w", err)
+			}
+			return nil
+		},
+		func() error {
+			if err := c.deleteOldLLMAuditLogs(ctx, now, llmAuditLogRetentionDays); err != nil {
+				return fmt.Errorf("delete old LLM audit logs: %w", err)
+			}
+			return nil
+		},
+	); err != nil {
 		return err
 	}
 
@@ -54,6 +61,25 @@ func (c *Client) cleanupRetainedData(ctx context.Context, now time.Time, mcpAudi
 		return fmt.Errorf("delete old revoked API keys: %w", err)
 	}
 	return nil
+}
+
+func runAuditLogCleanups(mcpCleanup, llmCleanup func() error) error {
+	var (
+		waitGroup sync.WaitGroup
+		mcpErr    error
+		llmErr    error
+	)
+	waitGroup.Add(2)
+	go func() {
+		defer waitGroup.Done()
+		mcpErr = mcpCleanup()
+	}()
+	go func() {
+		defer waitGroup.Done()
+		llmErr = llmCleanup()
+	}()
+	waitGroup.Wait()
+	return errors.Join(mcpErr, llmErr)
 }
 
 func (c *Client) deleteOldRevokedAPIKeys(ctx context.Context, now time.Time, retentionDays int) error {

--- a/pkg/gateway/client/retention.go
+++ b/pkg/gateway/client/retention.go
@@ -86,16 +86,9 @@ func (c *Client) deleteOldRevokedAPIKeys(ctx context.Context, now time.Time, ret
 	if retentionDays <= 0 {
 		return nil
 	}
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 
 	cutoff := now.Truncate(24*time.Hour).AddDate(0, 0, -retentionDays)
 	for {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
 		result := c.db.WithContext(ctx).Exec(
 			"DELETE FROM api_keys WHERE id IN (SELECT id FROM api_keys WHERE revoked_at IS NOT NULL AND revoked_at < ? LIMIT ?)",
 			cutoff, c.auditLogDeleteBatchSize,

--- a/pkg/gateway/server/apikey.go
+++ b/pkg/gateway/server/apikey.go
@@ -12,6 +12,7 @@ import (
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/api/authz"
+	"github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
@@ -116,7 +117,10 @@ func (s *Server) listAPIKeys(apiContext api.Context) error {
 		return types2.NewErrHTTP(http.StatusUnauthorized, "user not authenticated")
 	}
 
-	keys, err := apiContext.GatewayClient.ListAPIKeys(apiContext.Context(), userID)
+	showRevoked, _ := strconv.ParseBool(apiContext.Request.URL.Query().Get("show_revoked"))
+	keys, err := apiContext.GatewayClient.ListAPIKeysWithOptions(apiContext.Context(), userID, client.APIKeyListOptions{
+		ShowRevoked: showRevoked,
+	})
 	if err != nil {
 		return types2.NewErrHTTP(http.StatusInternalServerError, fmt.Sprintf("failed to list API keys: %v", err))
 	}
@@ -147,8 +151,8 @@ func (s *Server) getAPIKey(apiContext api.Context) error {
 	return apiContext.Write(key)
 }
 
-// deleteAPIKey deletes an API key for the authenticated user.
-func (s *Server) deleteAPIKey(apiContext api.Context) error {
+// revokeAPIKey revokes an API key for the authenticated user.
+func (s *Server) revokeAPIKey(apiContext api.Context) error {
 	userID := apiContext.UserID()
 	if userID == 0 {
 		return types2.NewErrHTTP(http.StatusUnauthorized, "user not authenticated")
@@ -159,10 +163,10 @@ func (s *Server) deleteAPIKey(apiContext api.Context) error {
 		return types2.NewErrBadRequest("invalid key ID")
 	}
 
-	if err := apiContext.GatewayClient.DeleteAPIKey(apiContext.Context(), userID, uint(keyID)); err != nil {
-		return types2.NewErrHTTP(http.StatusInternalServerError, fmt.Sprintf("failed to delete API key: %v", err))
+	if err := apiContext.GatewayClient.RevokeAPIKey(apiContext.Context(), userID, uint(keyID)); err != nil {
+		return types2.NewErrHTTP(http.StatusInternalServerError, fmt.Sprintf("failed to revoke API key: %v", err))
 	}
-	pkgLog.Infof("Deleted API key for user: userID=%d keyID=%d", userID, keyID)
+	pkgLog.Infof("Revoked API key for user: userID=%d keyID=%d", userID, keyID)
 
 	return apiContext.Write(map[string]any{"deleted": true})
 }
@@ -171,7 +175,10 @@ func (s *Server) deleteAPIKey(apiContext api.Context) error {
 
 // listAllAPIKeys lists all API keys in the system (admin/owner only).
 func (s *Server) listAllAPIKeys(apiContext api.Context) error {
-	keys, err := apiContext.GatewayClient.ListAllAPIKeys(apiContext.Context())
+	showRevoked, _ := strconv.ParseBool(apiContext.Request.URL.Query().Get("show_revoked"))
+	keys, err := apiContext.GatewayClient.ListAllAPIKeys(apiContext.Context(), client.APIKeyListOptions{
+		ShowRevoked: showRevoked,
+	})
 	if err != nil {
 		return types2.NewErrHTTP(http.StatusInternalServerError, fmt.Sprintf("failed to list API keys: %v", err))
 	}
@@ -197,15 +204,16 @@ func (s *Server) getAnyAPIKey(apiContext api.Context) error {
 	return apiContext.Write(key)
 }
 
-// deleteAnyAPIKey deletes any API key by ID (admin/owner only).
+// deleteAnyAPIKey revokes any API key by ID while preserving the DELETE route
+// for compatibility (admin/owner only).
 func (s *Server) deleteAnyAPIKey(apiContext api.Context) error {
 	keyID, err := strconv.ParseUint(apiContext.PathValue("id"), 10, 64)
 	if err != nil {
 		return types2.NewErrBadRequest("invalid key ID")
 	}
 
-	if err := apiContext.GatewayClient.DeleteAPIKeyByID(apiContext.Context(), uint(keyID)); err != nil {
-		return types2.NewErrHTTP(http.StatusInternalServerError, fmt.Sprintf("failed to delete API key: %v", err))
+	if err := apiContext.GatewayClient.RevokeAPIKeyByID(apiContext.Context(), uint(keyID)); err != nil {
+		return types2.NewErrHTTP(http.StatusInternalServerError, fmt.Sprintf("failed to revoke API key: %v", err))
 	}
 
 	return apiContext.Write(map[string]any{"deleted": true})

--- a/pkg/gateway/server/apikey_test.go
+++ b/pkg/gateway/server/apikey_test.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+
+	clienttypes "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/gateway/types"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestDeleteAPIKeyEndpointRevokesAndRetainsTheKey(t *testing.T) {
+	s, gatewayClient := newTokenRequestTestServer(t)
+	created, err := gatewayClient.CreateAPIKey(t.Context(), 7, "CLI token", "", nil, types.APIKeyScopes{CanAccessAPI: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userInfo := &user.DefaultInfo{UID: "7", Groups: []string{clienttypes.GroupAuthenticated}}
+	ctx, recorder := newTokenRequestAPIContext(t, gatewayClient, http.MethodDelete, "/api/api-keys/"+strconv.FormatUint(uint64(created.ID), 10), nil, userInfo)
+	ctx.SetPathValue("id", strconv.FormatUint(uint64(created.ID), 10))
+	if err := s.revokeAPIKey(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var response map[string]bool
+	decodeTokenRequestResponse(t, recorder, &response)
+	if !response["deleted"] {
+		t.Fatalf("response = %+v, want existing deleted=true contract", response)
+	}
+
+	retained, err := gatewayClient.GetAPIKey(t.Context(), 7, created.ID)
+	if err != nil {
+		t.Fatalf("get revoked API key: %v", err)
+	}
+	if retained.RevokedAt == nil {
+		t.Fatalf("DELETE endpoint did not retain a revoked API key: %+v", retained)
+	}
+}
+
+func TestAdminDeleteAPIKeyEndpointRevokesAndRetainsTheKey(t *testing.T) {
+	s, gatewayClient := newTokenRequestTestServer(t)
+	created, err := gatewayClient.CreateAPIKey(t.Context(), 7, "CLI token", "", nil, types.APIKeyScopes{CanAccessAPI: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, recorder := newTokenRequestAPIContext(t, gatewayClient, http.MethodDelete, "/api/admin-api-keys/"+strconv.FormatUint(uint64(created.ID), 10), nil, nil)
+	ctx.SetPathValue("id", strconv.FormatUint(uint64(created.ID), 10))
+	if err := s.deleteAnyAPIKey(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var response map[string]bool
+	decodeTokenRequestResponse(t, recorder, &response)
+	if !response["deleted"] {
+		t.Fatalf("response = %+v, want existing deleted=true contract", response)
+	}
+
+	retained, err := gatewayClient.GetAPIKeyByID(t.Context(), created.ID)
+	if err != nil {
+		t.Fatalf("get revoked API key: %v", err)
+	}
+	if retained.RevokedAt == nil {
+		t.Fatalf("admin DELETE endpoint did not retain a revoked API key: %+v", retained)
+	}
+}
+
+func TestAPIKeyListEndpointsHideRevokedKeysUnlessRequested(t *testing.T) {
+	s, gatewayClient := newTokenRequestTestServer(t)
+	active, err := gatewayClient.CreateAPIKey(t.Context(), 7, "active", "", nil, types.APIKeyScopes{CanAccessAPI: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	revoked, err := gatewayClient.CreateAPIKey(t.Context(), 7, "revoked", "", nil, types.APIKeyScopes{CanAccessAPI: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gatewayClient.RevokeAPIKey(t.Context(), 7, revoked.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	userInfo := &user.DefaultInfo{UID: "7", Groups: []string{clienttypes.GroupAuthenticated}}
+	for _, tt := range []struct {
+		name         string
+		path         string
+		admin        bool
+		wantKeyCount int
+	}{
+		{name: "user default", path: "/api/api-keys", wantKeyCount: 1},
+		{name: "user show revoked", path: "/api/api-keys?show_revoked=true", wantKeyCount: 2},
+		{name: "admin default", path: "/api/admin-api-keys", admin: true, wantKeyCount: 1},
+		{name: "admin show revoked", path: "/api/admin-api-keys?show_revoked=true", admin: true, wantKeyCount: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, recorder := newTokenRequestAPIContext(t, gatewayClient, http.MethodGet, tt.path, nil, userInfo)
+			if tt.admin {
+				err = s.listAllAPIKeys(ctx)
+			} else {
+				err = s.listAPIKeys(ctx)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			var response struct {
+				Items []types.APIKey `json:"items"`
+			}
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			if len(response.Items) != tt.wantKeyCount {
+				t.Fatalf("keys = %+v, want %d", response.Items, tt.wantKeyCount)
+			}
+			if response.Items[0].ID != active.ID && tt.wantKeyCount == 1 {
+				t.Fatalf("default list returned revoked key: %+v", response.Items)
+			}
+		})
+	}
+}

--- a/pkg/gateway/server/router.go
+++ b/pkg/gateway/server/router.go
@@ -78,7 +78,7 @@ func (s *Server) AddRoutes(mux *server.Server, tunnelBridge http.Handler) {
 	mux.HandleFunc("POST /api/api-keys", wrap(s.createAPIKey))
 	mux.HandleFunc("GET /api/api-keys", wrap(s.listAPIKeys))
 	mux.HandleFunc("GET /api/api-keys/{id}", wrap(s.getAPIKey))
-	mux.HandleFunc("DELETE /api/api-keys/{id}", wrap(s.deleteAPIKey))
+	mux.HandleFunc("DELETE /api/api-keys/{id}", wrap(s.revokeAPIKey))
 
 	// API Keys admin endpoints - for managing any user's keys (admin/owner only)
 	mux.HandleFunc("GET /api/admin-api-keys", wrap(s.listAllAPIKeys))

--- a/pkg/gateway/types/apikeys.go
+++ b/pkg/gateway/types/apikeys.go
@@ -34,7 +34,7 @@ type APIKey struct {
 	CreatedAt             time.Time  `json:"createdAt"`
 	LastUsedAt            *time.Time `json:"lastUsedAt,omitempty"`
 	ExpiresAt             *time.Time `json:"expiresAt,omitempty"` // nil means no expiration
-	RevokedAt             *time.Time `json:"revokedAt,omitempty"`
+	RevokedAt             *time.Time `json:"revokedAt,omitempty" gorm:"index"`
 }
 
 type APIKeyScopes struct {


### PR DESCRIPTION
This will allow audit tables to reference "deleted" keys and still retain necessary info

Related: #7537 