### PR TITLE
Add architecture decision record process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,25 +63,9 @@ make serve-docs       # Start local docs server
 
 ## Design Proposals and Architecture Decisions
 
-- Significant or architecturally important changes are designed first in the
-  [Obot Design Proposals repository](https://github.com/obot-platform/obot-design-proposals).
-  A merged ODP is the signal that implementation may proceed.
-- When an implementation introduces a meaningful architectural decision,
-  include an ADR in the implementation pull request. Follow
-  [`adr/README.md`](adr/README.md) and start from
-  [`adr/template.md`](adr/template.md).
-- An ODP records the design considered before implementation. An ADR records
-  the concise, durable decision that actually shipped; do not duplicate the
-  entire proposal in the ADR.
-- Link the ADR to every related GitHub issue and to its ODP when applicable. If
-  implementation differs materially from the accepted ODP, resolve that design
-  change through a follow-up ODP rather than documenting the surprise only in
-  the ADR.
-- Do not mark an ADR superseded or deprecated unless a human has made that
-  decision.
-- When one ADR supersedes another, update both records in the same change: the
-  new ADR links to the old one through `Supersedes`, and the old ADR is marked
-  `Superseded` and links back through `Superseded by`.
+- Design significant or architecturally important changes first in the [Obot Design Proposals repository](https://github.com/obot-platform/obot-design-proposals). A merged ODP is the signal that implementation may proceed.
+- When an implementation introduces a meaningful architectural decision, include an ADR in the implementation pull request and follow the [`adr/README.md`](adr/README.md) guidance. The ADR records the decision that shipped and links to its related issues and ODP when applicable.
+- If implementation differs materially from the accepted ODP, resolve the change through a follow-up ODP rather than documenting the surprise only in the ADR.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,28 @@ pnpm run ci           # Run format, lint, and check
 make serve-docs       # Start local docs server
 ```
 
+## Design Proposals and Architecture Decisions
+
+- Significant or architecturally important changes are designed first in the
+  [Obot Design Proposals repository](https://github.com/obot-platform/obot-design-proposals).
+  A merged ODP is the signal that implementation may proceed.
+- When an implementation introduces a meaningful architectural decision,
+  include an ADR in the implementation pull request. Follow
+  [`adr/README.md`](adr/README.md) and start from
+  [`adr/template.md`](adr/template.md).
+- An ODP records the design considered before implementation. An ADR records
+  the concise, durable decision that actually shipped; do not duplicate the
+  entire proposal in the ADR.
+- Link the ADR to every related GitHub issue and to its ODP when applicable. If
+  implementation differs materially from the accepted ODP, resolve that design
+  change through a follow-up ODP rather than documenting the surprise only in
+  the ADR.
+- Do not mark an ADR superseded or deprecated unless a human has made that
+  decision.
+- When one ADR supersedes another, update both records in the same change: the
+  new ADR links to the old one through `Supersedes`, and the old ADR is marked
+  `Superseded` and links back through `Superseded by`.
+
 ## Architecture
 
 ### Entry Points

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ This Docker configuration mounts the host Docker socket so Obot can launch hoste
 
 See the [Installation Guide](https://docs.obot.ai/installation/overview) for Kubernetes, external PostgreSQL, encryption, authentication, and production configuration.
 
+## Design and architecture
+
+Significant changes begin as [Obot Design Proposals](https://github.com/obot-platform/obot-design-proposals) so the architecture can be discussed before implementation. Architectural decisions that ship are recorded as concise [Architecture Decision Records](adr/README.md) in this repository.
+
+An ODP captures the proposed design and the discussion that shaped it. An ADR records the durable decision reflected in the implementation.
+
 ## Documentation and Community
 
 - Documentation: [https://docs.obot.ai](https://docs.obot.ai)

--- a/adr/README.md
+++ b/adr/README.md
@@ -13,10 +13,11 @@ Small, local, and easily reversible implementation choices generally do not need
 ## Creating an ADR
 
 1. Copy [`template.md`](template.md) to `NNNN-short-name.md` using the next available four-digit number and a concise kebab-case name.
-2. Describe the decision implemented by the pull request, including material differences from the original proposal.
-3. Link every GitHub issue related to the decision and the related ODP when applicable.
-4. If the ADR supersedes an earlier decision, link both records: set `Supersedes` in the new ADR, then mark the old ADR `Superseded` and set its `Superseded by` field.
-5. Include the ADR in the implementation pull request so it merges with the code whose architecture it records.
+2. Describe the decision reflected in the implementation.
+3. If the implementation differs materially from an accepted ODP, complete a follow-up ODP before proceeding and link both ODPs from the ADR.
+4. Link every GitHub issue related to the decision and the related ODP when applicable.
+5. If the ADR supersedes an earlier decision, link both records: set `Supersedes` in the new ADR, then mark the old ADR `Superseded` and set its `Superseded by` field.
+6. Include the ADR in the implementation pull request so it merges with the code whose architecture it records.
 
 Keep ADRs short. Link to relevant source or documentation for detail that does not need to be repeated.
 

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,51 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for Obot. An ADR
+is the concise, durable record of a meaningful architectural decision reflected
+in the implementation.
+
+ADRs answer the question: "Why do we do it this way?" They are not complete
+implementation documentation and should not repeat the full design discussion.
+Significant designs are discussed before implementation as
+[Obot Design Proposals](https://github.com/obot-platform/obot-design-proposals).
+
+## When to write an ADR
+
+Include an ADR when an implementation introduces or changes a decision that is
+likely to constrain future work, such as a significant component boundary,
+interface, data model, persistence strategy, security model, or operational
+approach.
+
+Small, local, and easily reversible implementation choices generally do not
+need an ADR.
+
+## Creating an ADR
+
+1. Copy [`template.md`](template.md) to `NNNN-short-name.md` using the next
+   available four-digit number and a concise kebab-case name.
+2. Describe the decision implemented by the pull request, including material
+   differences from the original proposal.
+3. Link every GitHub issue related to the decision and the related ODP when
+   applicable.
+4. If the ADR supersedes an earlier decision, link both records: set
+   `Supersedes` in the new ADR, then mark the old ADR `Superseded` and set its
+   `Superseded by` field.
+5. Include the ADR in the implementation pull request so it merges with the
+   code whose architecture it records.
+
+Keep ADRs short. Link to relevant source or documentation for detail that does
+not need to be repeated.
+
+## Statuses
+
+- **Accepted:** The decision currently governs the architecture.
+- **Superseded:** Another ADR replaces this decision. Link both ADRs.
+- **Deprecated:** The decision is being retired and should not be used for new
+  work, but no ADR directly replaces it.
+
+Use `Superseded` when a replacement ADR exists. Otherwise, use `Deprecated`.
+
+Do not rewrite an accepted ADR to describe a materially different decision.
+Create a new ADR and update the old ADR in the same change so their `Supersedes`
+and `Superseded by` links are bidirectional. Small corrections and additional
+references may be added in place.

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,51 +1,31 @@
 # Architecture Decision Records
 
-This directory contains Architecture Decision Records (ADRs) for Obot. An ADR
-is the concise, durable record of a meaningful architectural decision reflected
-in the implementation.
+This directory contains Architecture Decision Records (ADRs) for Obot. An ADR is the concise, durable record of a meaningful architectural decision reflected in the implementation.
 
-ADRs answer the question: "Why do we do it this way?" They are not complete
-implementation documentation and should not repeat the full design discussion.
-Significant designs are discussed before implementation as
-[Obot Design Proposals](https://github.com/obot-platform/obot-design-proposals).
+ADRs answer the question: "Why do we do it this way?" They are not complete implementation documentation and should not repeat the full design discussion. Significant designs are discussed before implementation as [Obot Design Proposals](https://github.com/obot-platform/obot-design-proposals).
 
 ## When to write an ADR
 
-Include an ADR when an implementation introduces or changes a decision that is
-likely to constrain future work, such as a significant component boundary,
-interface, data model, persistence strategy, security model, or operational
-approach.
+Include an ADR when an implementation introduces or changes a decision that is likely to constrain future work, such as a significant component boundary, interface, data model, persistence strategy, security model, or operational approach.
 
-Small, local, and easily reversible implementation choices generally do not
-need an ADR.
+Small, local, and easily reversible implementation choices generally do not need an ADR.
 
 ## Creating an ADR
 
-1. Copy [`template.md`](template.md) to `NNNN-short-name.md` using the next
-   available four-digit number and a concise kebab-case name.
-2. Describe the decision implemented by the pull request, including material
-   differences from the original proposal.
-3. Link every GitHub issue related to the decision and the related ODP when
-   applicable.
-4. If the ADR supersedes an earlier decision, link both records: set
-   `Supersedes` in the new ADR, then mark the old ADR `Superseded` and set its
-   `Superseded by` field.
-5. Include the ADR in the implementation pull request so it merges with the
-   code whose architecture it records.
+1. Copy [`template.md`](template.md) to `NNNN-short-name.md` using the next available four-digit number and a concise kebab-case name.
+2. Describe the decision implemented by the pull request, including material differences from the original proposal.
+3. Link every GitHub issue related to the decision and the related ODP when applicable.
+4. If the ADR supersedes an earlier decision, link both records: set `Supersedes` in the new ADR, then mark the old ADR `Superseded` and set its `Superseded by` field.
+5. Include the ADR in the implementation pull request so it merges with the code whose architecture it records.
 
-Keep ADRs short. Link to relevant source or documentation for detail that does
-not need to be repeated.
+Keep ADRs short. Link to relevant source or documentation for detail that does not need to be repeated.
 
 ## Statuses
 
 - **Accepted:** The decision currently governs the architecture.
 - **Superseded:** Another ADR replaces this decision. Link both ADRs.
-- **Deprecated:** The decision is being retired and should not be used for new
-  work, but no ADR directly replaces it.
+- **Deprecated:** The decision is being retired and should not be used for new work, but no ADR directly replaces it.
 
 Use `Superseded` when a replacement ADR exists. Otherwise, use `Deprecated`.
 
-Do not rewrite an accepted ADR to describe a materially different decision.
-Create a new ADR and update the old ADR in the same change so their `Supersedes`
-and `Superseded by` links are bidirectional. Small corrections and additional
-references may be added in place.
+Do not rewrite an accepted ADR to describe a materially different decision. Create a new ADR and update the old ADR in the same change so their `Supersedes` and `Superseded by` links are bidirectional. Small corrections and additional references may be added in place.

--- a/adr/template.md
+++ b/adr/template.md
@@ -1,0 +1,34 @@
+# NNNN: Decision title
+
+- **Status:** Accepted
+- **Date:** YYYY-MM-DD
+- **Supersedes:** None
+- **Superseded by:** None
+
+## Related issues
+
+<!-- Link the GitHub issue(s) related to this decision. -->
+
+## Related ODPs
+
+<!-- Link related Obot Design Proposals, or write "None." -->
+
+## Context
+
+<!-- What situation or constraint required an architectural decision? -->
+
+## Decision
+
+<!-- What did we decide? Describe the decision that is reflected in the implementation. -->
+
+## Rationale
+
+<!-- Why was this approach chosen over the important alternatives? -->
+
+## Consequences
+
+<!-- What becomes easier or harder? What constraints does this create for future work? -->
+
+## References
+
+<!-- Link relevant source or documentation. -->


### PR DESCRIPTION
## Summary

- add an ADR guide and reusable template
- document how ADRs relate to Obot Design Proposals and implementation work
- add ADR guidance for agents and link the process from the project README

## Validation

- `git diff --check`
- verified `AGENTS.md` resolves to `CLAUDE.md`