### PR TITLE
fix: best-effort token spend estimation for Azure API-key

### DIFF
--- a/docs/docs/configuration/model-providers.md
+++ b/docs/docs/configuration/model-providers.md
@@ -76,7 +76,7 @@ In the Azure portal, find your API key and endpoint URL after setting up at leas
 You must also specify deployment names as a comma-separated list using `deployment[:usage[:dialect]]`. Usage defaults to `llm`. Dialect defaults to `openai`; specify `anthropic` for Claude deployments. For example: `my-gpt-deployment,my-claude-deployment:llm:anthropic`.
 
 :::note
-Obot reports token counts for the Azure API key provider, but does not report estimated spend. Azure API key requests use deployment names, which Obot cannot reliably map to the underlying model's price.
+Obot reports token counts for the Azure API key provider and estimates spend when a deployment name exactly matches a model in its pricing catalog. Azure API key requests use deployment names, so deployments with different names cannot be reliably mapped to an underlying model and do not have estimated spend.
 :::
 
 ##### Microsoft Entra ID Authentication

--- a/docs/docs/functionality/obot-agent-management.md
+++ b/docs/docs/functionality/obot-agent-management.md
@@ -15,7 +15,7 @@ Obot Agent Management provides administrators with tools to configure default ag
 View token usage across users and models to monitor costs and identify optimization opportunities.
 
 :::note
-Token counts are reported for the Azure API key provider, but estimated spend is not available because Azure API key requests use deployment names, which Obot cannot reliably map to the underlying model's price.
+Token counts are reported for the Azure API key provider. Obot estimates spend when a deployment name exactly matches a model in its pricing catalog; deployments with different names cannot be reliably mapped to the underlying model and do not have estimated spend.
 :::
 
 ## Model Providers

--- a/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
+++ b/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
@@ -65,7 +65,7 @@ func mustDecodeDoc(t *testing.T, raw string) modelsDevDocument {
 func TestParseModelInfos(t *testing.T) {
 	infos, err := parseModelInfos(system.DefaultNamespace, "default", mustDecodeDoc(t, sampleAPIJSON))
 	require.NoError(t, err)
-	require.Len(t, infos, 6, "anthropic + 2 openai + 2 bedrock + Azure Entra, cohere dropped")
+	require.Len(t, infos, 7, "anthropic + 2 openai + 2 bedrock + Azure API key + Azure Entra, cohere dropped")
 
 	byProviderAndModel := map[string]v1.ModelInfoSpec{}
 	for _, info := range infos {
@@ -105,11 +105,13 @@ func TestParseModelInfos(t *testing.T) {
 		assert.Equal(t, 0.1, b.Cost.CacheRead)
 	}
 
-	azure := byProviderAndModel[system.AzureEntraModelProvider+"/gpt-4o"]
-	assert.Equal(t, system.AzureEntraModelProvider, azure.Provider)
-	assert.Equal(t, 2.5, azure.Cost.Input)
-	assert.Equal(t, 10.0, azure.Cost.Output)
-	assert.Equal(t, 1.25, azure.Cost.CacheRead)
+	for _, provider := range []string{system.AzureModelProvider, system.AzureEntraModelProvider} {
+		azure := byProviderAndModel[provider+"/gpt-4o"]
+		assert.Equal(t, provider, azure.Provider)
+		assert.Equal(t, 2.5, azure.Cost.Input)
+		assert.Equal(t, 10.0, azure.Cost.Output)
+		assert.Equal(t, 1.25, azure.Cost.CacheRead)
+	}
 }
 
 func TestParseModelInfos_NoKnownProviders(t *testing.T) {

--- a/pkg/controller/handlers/modelinfosource/modelsdev.go
+++ b/pkg/controller/handlers/modelinfosource/modelsdev.go
@@ -20,6 +20,7 @@ var obotProviderToProviderID = map[string]string{
 	system.OpenAIModelProvider:              "openai",
 	system.AmazonBedrockModelProvider:       "amazon-bedrock",
 	system.AmazonBedrockAPIKeyModelProvider: "amazon-bedrock",
+	system.AzureModelProvider:               "azure",
 	system.AzureEntraModelProvider:          "azure",
 }
 


### PR DESCRIPTION
Azure identifies models with user-defined deployment names. Therefore, it is not a reliable way to get spend data. This adds a best-effort check in case users decide to use the canonical model name

Addresses https://github.com/obot-platform/obot/issues/7557