### PR TITLE
fix: use static OAuth credentials when generating tool previews

### DIFF
--- a/pkg/api/handlers/mcp_oauth_debugger.go
+++ b/pkg/api/handlers/mcp_oauth_debugger.go
@@ -279,7 +279,7 @@ func registerOAuthDebuggerClient(ctx context.Context, httpClient *http.Client, r
 func (m *MCPHandler) lookupStaticOAuthClient(req api.Context, server v1.MCPServer) (string, string, error) {
 	if server.Spec.MCPServerCatalogEntryName != "" {
 		credName := system.MCPOAuthCredentialName(server.Spec.MCPServerCatalogEntryName)
-		cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credName}, "oauth")
+		cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credName}, system.StaticOAuthCredentialName)
 		if err == nil && cred.Secrets["CLIENT_ID"] != "" && cred.Secrets["CLIENT_SECRET"] != "" {
 			return cred.Secrets["CLIENT_ID"], cred.Secrets["CLIENT_SECRET"], nil
 		}

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1038,12 +1038,7 @@ func (h *MCPCatalogHandler) generateCompositeToolPreviews(req api.Context, entry
 		}
 
 		// CatalogEntry-based components still use a temporary server with the supplied config.
-		componentID := componentEntry.CatalogEntryID
-		if componentID == "" {
-			componentID = componentEntry.MCPServerID
-		}
-
-		config, ok := configRequest.ComponentConfigs[componentID]
+		config, ok := configRequest.ComponentConfigs[componentEntry.ComponentID()]
 		if !ok {
 			// No config provided for this component, skip it
 			continue
@@ -1062,7 +1057,7 @@ func (h *MCPCatalogHandler) generateCompositeToolPreviews(req api.Context, entry
 			req.ObotNamespace,
 			h.secretBindingAllowedLabel,
 			entry.Namespace,
-			entry.Name,
+			componentEntry.CatalogEntryID,
 			catalogName,
 			componentEntry.Manifest,
 			config.Config,
@@ -1289,7 +1284,7 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviews(req api.Context) error
 		req.ObotNamespace,
 		h.secretBindingAllowedLabel,
 		composite.Namespace,
-		composite.Name,
+		component.CatalogEntryID,
 		catalogName,
 		component.Manifest,
 		configRequest.Config,
@@ -1420,7 +1415,7 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviewsOAuthURL(req api.Contex
 		req.ObotNamespace,
 		h.secretBindingAllowedLabel,
 		composite.Namespace,
-		composite.Name,
+		component.CatalogEntryID,
 		catalogName,
 		component.Manifest,
 		configRequest.Config,
@@ -1510,7 +1505,7 @@ func (h *MCPCatalogHandler) generateCompositeOAuthURLs(req api.Context, entry v1
 			req.ObotNamespace,
 			h.secretBindingAllowedLabel,
 			entry.Namespace,
-			entry.Name,
+			componentEntry.CatalogEntryID,
 			catalogName,
 			componentEntry.Manifest,
 			config.Config,
@@ -1561,7 +1556,8 @@ func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, cli
 			Name: tempName,
 		},
 		Spec: v1.MCPServerSpec{
-			Manifest: serverManifest,
+			Manifest:                  serverManifest,
+			MCPServerCatalogEntryName: entryName,
 		},
 	}
 
@@ -1604,7 +1600,7 @@ func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, cli
 		return v1.MCPServer{}, mcp.ServerConfig{}, fmt.Errorf("failed to create OAuth client: %w", err)
 	}
 
-	staticOAuthCred, err := gatewayClient.RevealCredential(ctx, []string{system.MCPOAuthCredentialName(entryName)}, entryName)
+	staticOAuthCred, err := gatewayClient.RevealCredential(ctx, []string{system.MCPOAuthCredentialName(entryName)}, system.StaticOAuthCredentialName)
 	if err != nil && !errors.As(err, &gclient.CredentialNotFoundError{}) {
 		return v1.MCPServer{}, mcp.ServerConfig{}, fmt.Errorf("failed to reveal credential: %w", err)
 	}
@@ -1926,7 +1922,7 @@ func (h *MCPCatalogHandler) GetOAuthCredentials(req api.Context) error {
 
 	// Check if credentials exist
 	credName := system.MCPOAuthCredentialName(entry.Name)
-	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credName}, "oauth")
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credName}, system.StaticOAuthCredentialName)
 	configured := err == nil
 
 	var clientID string
@@ -1960,7 +1956,7 @@ func (h *MCPCatalogHandler) SetOAuthCredentials(req api.Context) error {
 
 	// Check if credentials already exist
 	credName := system.MCPOAuthCredentialName(entry.Name)
-	_, err = req.GatewayClient.RevealCredential(req.Context(), []string{credName}, "oauth")
+	_, err = req.GatewayClient.RevealCredential(req.Context(), []string{credName}, system.StaticOAuthCredentialName)
 	credentialsExist := err == nil
 
 	var clientID, clientSecret string
@@ -1984,7 +1980,7 @@ func (h *MCPCatalogHandler) SetOAuthCredentials(req api.Context) error {
 	// Store new credential
 	cred := gatewaytypes.Credential{
 		Context: credName,
-		Name:    "oauth",
+		Name:    system.StaticOAuthCredentialName,
 		Secrets: map[string]string{
 			"CLIENT_ID":     clientID,
 			"CLIENT_SECRET": clientSecret,
@@ -2023,7 +2019,7 @@ func (h *MCPCatalogHandler) DeleteOAuthCredentials(req api.Context) error {
 	}
 
 	credName := system.MCPOAuthCredentialName(entry.Name)
-	deleted, err := req.GatewayClient.DeleteCredential(req.Context(), credName, "oauth")
+	deleted, err := req.GatewayClient.DeleteCredential(req.Context(), credName, system.StaticOAuthCredentialName)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -111,7 +111,7 @@ func (f *MCPOAuthHandlerFactory) CheckForMCPAuth(req api.Context, mcpServer v1.M
 	}
 
 	// Remote server, check for OAuth directly
-	oauthHandler := f.newMCPOAuthHandler(req.GatewayClient, userID, mcpID, mcpServerConfig.URL, oauthAppAuthRequestID)
+	oauthHandler := f.newMCPOAuthHandler(req.GatewayClient, userID, mcpID, mcpServerConfig.URL, oauthAppAuthRequestID, mcpServerConfig.MCPCatalogEntryName)
 	staticOAuthPending, err := f.staticOAuthPending(req.Context(), mcpServer, oauthHandler)
 	if err != nil {
 		return "", err
@@ -234,7 +234,6 @@ func staticOAuthAuthStyle(method string) oauth2.AuthStyle {
 }
 
 type mcpOAuthHandler struct {
-	client             kclient.Client
 	gatewayClient      *client.Client
 	stateMgr           *stateManager
 	mcpID              string
@@ -242,17 +241,20 @@ type mcpOAuthHandler struct {
 	userID             string
 	oauthAuthRequestID string
 	urlChan            chan string
+
+	// catalogEntryName is the name of the catalog entry to fetch static OAuth credentials for.
+	catalogEntryName string
 }
 
-func (f *MCPOAuthHandlerFactory) newMCPOAuthHandler(gatewayClient *client.Client, userID, mcpID, mcpURL, oauthAuthRequestID string) *mcpOAuthHandler {
+func (f *MCPOAuthHandlerFactory) newMCPOAuthHandler(gatewayClient *client.Client, userID, mcpID, mcpURL, oauthAuthRequestID, catalogEntryName string) *mcpOAuthHandler {
 	return &mcpOAuthHandler{
-		client:             f.client,
 		gatewayClient:      gatewayClient,
 		stateMgr:           f.stateMgr,
 		userID:             userID,
 		mcpID:              mcpID,
 		mcpURL:             mcpURL,
 		oauthAuthRequestID: oauthAuthRequestID,
+		catalogEntryName:   catalogEntryName,
 		urlChan:            make(chan string, 1),
 	}
 }
@@ -284,20 +286,14 @@ func (m *mcpOAuthHandler) NewState(ctx context.Context, conf *oauth2.Config, ver
 }
 
 func (m *mcpOAuthHandler) Lookup(ctx context.Context, _ string) (string, string, error) {
-	if m.mcpID != "" {
-		var server v1.MCPServer
-		if err := m.client.Get(ctx, kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: m.mcpID}, &server); err == nil {
-			// If the server was created from a catalog entry, look up OAuth credentials by catalog entry name
-			if server.Spec.MCPServerCatalogEntryName != "" {
-				credName := system.MCPOAuthCredentialName(server.Spec.MCPServerCatalogEntryName)
-				cred, err := m.gatewayClient.RevealCredential(ctx, []string{credName}, "oauth")
-				if err == nil {
-					clientID := cred.Secrets["CLIENT_ID"]
-					clientSecret := cred.Secrets["CLIENT_SECRET"]
-					if clientID != "" && clientSecret != "" {
-						return clientID, clientSecret, nil
-					}
-				}
+	// If the server was created from a catalog entry, look up OAuth credentials by catalog entry name
+	if m.catalogEntryName != "" {
+		cred, err := m.gatewayClient.RevealCredential(ctx, []string{system.MCPOAuthCredentialName(m.catalogEntryName)}, system.StaticOAuthCredentialName)
+		if err == nil {
+			clientID := cred.Secrets["CLIENT_ID"]
+			clientSecret := cred.Secrets["CLIENT_SECRET"]
+			if clientID != "" && clientSecret != "" {
+				return clientID, clientSecret, nil
 			}
 		}
 	}

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler_test.go
@@ -72,6 +72,15 @@ func TestStaticOAuthPendingUsesStoredAuthentication(t *testing.T) {
 	require.False(t, pending)
 }
 
+func TestNewMCPOAuthHandlerCarriesCatalogEntry(t *testing.T) {
+	factory := &MCPOAuthHandlerFactory{}
+
+	// Tool preview servers are never written to storage, so the catalog entry name is the
+	// only thing tying them back to the credentials the admin configured.
+	handler := factory.newMCPOAuthHandler(nil, "user", "tool-preview-63cb5f4336ed0dcf", "https://example.com/mcp", "", "slack-entry")
+	require.Equal(t, "slack-entry", handler.catalogEntryName)
+}
+
 func TestStaticOAuthMetadataDefaultsMissingClientRegistration(t *testing.T) {
 	authorizationServer := mcp.AuthorizationServerMetadata{
 		Issuer:                            "https://auth.example.com",

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -1098,7 +1098,7 @@ func (h *Handler) SyncOAuthMetadata(req router.Request, _ router.Response) error
 
 	var staticOAuthCred gatewaytypes.Credential
 	if server.Spec.MCPServerCatalogEntryName != "" {
-		staticOAuthCred, err = h.gatewayClient.RevealCredential(req.Ctx, []string{system.MCPOAuthCredentialName(server.Spec.MCPServerCatalogEntryName)}, server.Spec.MCPServerCatalogEntryName)
+		staticOAuthCred, err = h.gatewayClient.RevealCredential(req.Ctx, []string{system.MCPOAuthCredentialName(server.Spec.MCPServerCatalogEntryName)}, system.StaticOAuthCredentialName)
 		if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 			return fmt.Errorf("failed to reveal credential: %w", err)
 		}

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -260,7 +260,7 @@ func (h *Handler) CleanupUnusedOAuthCredentials(req router.Request, _ router.Res
 		return nil
 	}
 
-	deleted, err := h.gatewayClient.DeleteCredential(req.Ctx, system.MCPOAuthCredentialName(entry.Name), "oauth")
+	deleted, err := h.gatewayClient.DeleteCredential(req.Ctx, system.MCPOAuthCredentialName(entry.Name), system.StaticOAuthCredentialName)
 	if err != nil {
 		return fmt.Errorf("failed to delete OAuth credential: %w", err)
 	}
@@ -301,7 +301,7 @@ func (h *Handler) EnsureOAuthCredentialStatus(req router.Request, _ router.Respo
 
 	// Check if credentials exist
 	credName := system.MCPOAuthCredentialName(entry.Name)
-	_, err := h.gatewayClient.RevealCredential(req.Ctx, []string{credName}, "oauth")
+	_, err := h.gatewayClient.RevealCredential(req.Ctx, []string{credName}, system.StaticOAuthCredentialName)
 
 	var configured bool
 	if err == nil {
@@ -331,7 +331,7 @@ func (h *Handler) RemoveOAuthCredentials(req router.Request, _ router.Response) 
 	// Build the credential name for this entry
 	credName := system.MCPOAuthCredentialName(entry.Name)
 
-	deleted, err := h.gatewayClient.DeleteCredential(req.Ctx, credName, "oauth")
+	deleted, err := h.gatewayClient.DeleteCredential(req.Ctx, credName, system.StaticOAuthCredentialName)
 	if err != nil {
 		return fmt.Errorf("failed to delete OAuth credential: %w", err)
 	}

--- a/pkg/mcp/action.go
+++ b/pkg/mcp/action.go
@@ -259,7 +259,7 @@ func (sm *SessionManager) serverFromMCPServerInstance(ctx context.Context, insta
 
 	var staticOauthCred gatewaytypes.Credential
 	if server.Spec.MCPServerCatalogEntryName != "" {
-		staticOauthCred, err = sm.gatewayClient.RevealCredential(ctx, []string{system.MCPOAuthCredentialName(server.Spec.MCPServerCatalogEntryName)}, "oauth")
+		staticOauthCred, err = sm.gatewayClient.RevealCredential(ctx, []string{system.MCPOAuthCredentialName(server.Spec.MCPServerCatalogEntryName)}, system.StaticOAuthCredentialName)
 		if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 			return server, ServerConfig{}, nil, fmt.Errorf("failed to find static oauth credential: %w", err)
 		}
@@ -368,7 +368,7 @@ func (sm *SessionManager) serverConfigForAction(ctx context.Context, server v1.M
 	}
 
 	if server.Spec.MCPServerCatalogEntryName != "" {
-		staticOauthCred, err = sm.gatewayClient.RevealCredential(ctx, []string{system.MCPOAuthCredentialName(server.Spec.MCPServerCatalogEntryName)}, "oauth")
+		staticOauthCred, err = sm.gatewayClient.RevealCredential(ctx, []string{system.MCPOAuthCredentialName(server.Spec.MCPServerCatalogEntryName)}, system.StaticOAuthCredentialName)
 		if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 			return ServerConfig{}, nil, fmt.Errorf("failed to find static oauth credential: %w", err)
 		}

--- a/pkg/system/mcp.go
+++ b/pkg/system/mcp.go
@@ -8,7 +8,10 @@ import (
 const (
 	// MCPOAuthCredentialContextPrefix is the credential context prefix for MCP OAuth credentials
 	MCPOAuthCredentialContextPrefix = "mcp-oauth"
-	OAuthClientIDMetadataPath       = "/oauth/client-metadata.json"
+	// StaticOAuthCredentialName is the credential name for an MCP server's static OAuth client, stored
+	// in the context returned by MCPOAuthCredentialName.
+	StaticOAuthCredentialName = "oauth"
+	OAuthClientIDMetadataPath = "/oauth/client-metadata.json"
 )
 
 // MCPOAuthCredentialName returns the credential name for an MCP server's OAuth credentials


### PR DESCRIPTION
The OAuth handler needs a server's catalog entry name to resolve
static OAuth credentials. It does this by fetching the `v1.MCPServer`
from storage and reading its spec. This doesn't work for the ephemeral
MCP servers used to generate tool previews, since they are never
persisted to storage.

To fix this, add a `catalogEntryName` field to the OAuth handler so that
it can resolve credentials without fetching the server from storage.

Addresses https://github.com/obot-platform/obot/issues/7563
