### PR TITLE
fix(oauth): preserve MCP resource during token exchange

### DIFF
--- a/pkg/api/handlers/mcp_oauth_debugger.go
+++ b/pkg/api/handlers/mcp_oauth_debugger.go
@@ -84,6 +84,7 @@ func (m *MCPHandler) RegisterOAuthDebuggerClient(req api.Context) error {
 	state := strings.ToLower(rand.Text())
 
 	conf := oauthDebuggerConfig(clientID, clientSecret, authServer.AuthorizationEndpoint, authServer.TokenEndpoint, registration.TokenEndpointAuthMethod, firstString(registration.RedirectURIs), registration.Scope)
+	resourceURL := mcp.OAuthResourceURL(authServer.AuthorizationEndpoint, serverConfig.URL)
 	if err := req.GatewayClient.CreateMCPOAuthPendingState(
 		req.Context(),
 		req.User.GetUID(),
@@ -92,6 +93,7 @@ func (m *MCPHandler) RegisterOAuthDebuggerClient(req api.Context) error {
 		OAuthDebuggerPendingStateMarker,
 		state,
 		oauth2.GenerateVerifier(),
+		resourceURL,
 		conf,
 	); err != nil {
 		return err
@@ -105,7 +107,7 @@ func (m *MCPHandler) RegisterOAuthDebuggerClient(req api.Context) error {
 
 // GetOAuthDebuggerAuthorizationURL creates fresh pending OAuth state and returns the remote authorization URL.
 func (m *MCPHandler) GetOAuthDebuggerAuthorizationURL(req api.Context) error {
-	server, serverConfig, err := m.mcpSessionManager.ServerForAction(req.Context(), req.PathValue("mcp_server_id"), req.User.GetUID())
+	server, _, err := m.mcpSessionManager.ServerForAction(req.Context(), req.PathValue("mcp_server_id"), req.User.GetUID())
 	if err != nil {
 		return err
 	}
@@ -131,7 +133,7 @@ func (m *MCPHandler) GetOAuthDebuggerAuthorizationURL(req api.Context) error {
 	}
 
 	conf := oauthDebuggerConfigFromPendingState(storedClient)
-	authURL, err := mcp.AuthCodeURL(conf, storedClient.AuthURL, serverConfig.URL, input.State, storedClient.Verifier)
+	authURL, err := mcp.AuthCodeURL(conf, storedClient.AuthURL, storedClient.ResourceURL, input.State, storedClient.Verifier)
 	if err != nil {
 		return err
 	}
@@ -175,7 +177,11 @@ func (m *MCPHandler) ExchangeOAuthDebuggerToken(req api.Context) error {
 		return err
 	}
 	exchangeContext := context.WithValue(req.Context(), oauth2.HTTPClient, httpClient)
-	token, err := conf.Exchange(exchangeContext, input.Code, oauth2.VerifierOption(pendingState.Verifier))
+	exchangeOptions := []oauth2.AuthCodeOption{oauth2.VerifierOption(pendingState.Verifier)}
+	if pendingState.ResourceURL != "" {
+		exchangeOptions = append(exchangeOptions, oauth2.SetAuthURLParam("resource", pendingState.ResourceURL))
+	}
+	token, err := conf.Exchange(exchangeContext, input.Code, exchangeOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to exchange OAuth code: %w", err)
 	}

--- a/pkg/api/handlers/mcp_oauth_debugger.go
+++ b/pkg/api/handlers/mcp_oauth_debugger.go
@@ -34,7 +34,7 @@ func (m *MCPHandler) RegisterOAuthDebuggerClient(req api.Context) error {
 		return err
 	}
 
-	authServer, registration, err := m.oauthDebuggerMetadata(server)
+	authServer, registration, resourceURL, err := m.oauthDebuggerMetadata(server)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (m *MCPHandler) RegisterOAuthDebuggerClient(req api.Context) error {
 	state := strings.ToLower(rand.Text())
 
 	conf := oauthDebuggerConfig(clientID, clientSecret, authServer.AuthorizationEndpoint, authServer.TokenEndpoint, registration.TokenEndpointAuthMethod, firstString(registration.RedirectURIs), registration.Scope)
-	resourceURL := mcp.OAuthResourceURL(authServer.AuthorizationEndpoint, serverConfig.URL)
+	resourceURL = mcp.OAuthResourceURL(authServer.AuthorizationEndpoint, resourceURL)
 	if err := req.GatewayClient.CreateMCPOAuthPendingState(
 		req.Context(),
 		req.User.GetUID(),
@@ -226,29 +226,38 @@ func (m *MCPHandler) validateOAuthDebuggerServer(req api.Context, server v1.MCPS
 	return nil
 }
 
-func (m *MCPHandler) oauthDebuggerMetadata(server v1.MCPServer) (mcp.AuthorizationServerMetadata, mcp.ClientRegistrationMetadata, error) {
+func (m *MCPHandler) oauthDebuggerMetadata(server v1.MCPServer) (mcp.AuthorizationServerMetadata, mcp.ClientRegistrationMetadata, string, error) {
 	metadata := server.Status.OAuthMetadata
+	var resourceURL string
+	if len(metadata.ProtectedResourceMetadata.Raw) > 0 {
+		var err error
+		resourceURL, err = mcp.ParseOAuthResourceURL(metadata.ProtectedResourceMetadata.Raw)
+		if err != nil {
+			return mcp.AuthorizationServerMetadata{}, mcp.ClientRegistrationMetadata{}, "", fmt.Errorf("failed to parse OAuth protected resource metadata: %w", err)
+		}
+	}
+
 	var authServer mcp.AuthorizationServerMetadata
 	if len(metadata.AuthorizationServerMetadata.Raw) > 0 {
 		if err := json.Unmarshal(metadata.AuthorizationServerMetadata.Raw, &authServer); err != nil {
-			return authServer, mcp.ClientRegistrationMetadata{}, fmt.Errorf("failed to parse OAuth authorization server metadata: %w", err)
+			return authServer, mcp.ClientRegistrationMetadata{}, "", fmt.Errorf("failed to parse OAuth authorization server metadata: %w", err)
 		}
 	}
 	if authServer.AuthorizationEndpoint == "" {
-		return authServer, mcp.ClientRegistrationMetadata{}, types.NewErrBadRequest("OAuth metadata does not include authorization_endpoint")
+		return authServer, mcp.ClientRegistrationMetadata{}, "", types.NewErrBadRequest("OAuth metadata does not include authorization_endpoint")
 	}
 	if authServer.TokenEndpoint == "" {
-		return authServer, mcp.ClientRegistrationMetadata{}, types.NewErrBadRequest("OAuth metadata does not include token_endpoint")
+		return authServer, mcp.ClientRegistrationMetadata{}, "", types.NewErrBadRequest("OAuth metadata does not include token_endpoint")
 	}
 
 	var registration mcp.ClientRegistrationMetadata
 	if len(metadata.ClientRegistration.Raw) > 0 {
 		if err := json.Unmarshal(metadata.ClientRegistration.Raw, &registration); err != nil {
-			return authServer, registration, fmt.Errorf("failed to parse OAuth client registration metadata: %w", err)
+			return authServer, registration, "", fmt.Errorf("failed to parse OAuth client registration metadata: %w", err)
 		}
 	}
 
-	return authServer, mcp.AuthServerMetadataToClientRegistration(authServer, "Obot MCP OAuth Debugger", system.MCPOAuthCallbackURL(m.serverURL), registration.Scope), nil
+	return authServer, mcp.AuthServerMetadataToClientRegistration(authServer, "Obot MCP OAuth Debugger", system.MCPOAuthCallbackURL(m.serverURL), registration.Scope), resourceURL, nil
 }
 
 func registerOAuthDebuggerClient(ctx context.Context, httpClient *http.Client, registrationEndpoint string, registration mcp.ClientRegistrationMetadata) (types.OAuthClient, error) {

--- a/pkg/api/handlers/mcp_oauth_debugger.go
+++ b/pkg/api/handlers/mcp_oauth_debugger.go
@@ -84,7 +84,7 @@ func (m *MCPHandler) RegisterOAuthDebuggerClient(req api.Context) error {
 	state := strings.ToLower(rand.Text())
 
 	conf := oauthDebuggerConfig(clientID, clientSecret, authServer.AuthorizationEndpoint, authServer.TokenEndpoint, registration.TokenEndpointAuthMethod, firstString(registration.RedirectURIs), registration.Scope)
-	resourceURL = mcp.OAuthResourceURL(authServer.AuthorizationEndpoint, resourceURL)
+	resourceURL = mcp.ResolveOAuthResourceURL(authServer.AuthorizationEndpoint, resourceURL, serverConfig.URL)
 	if err := req.GatewayClient.CreateMCPOAuthPendingState(
 		req.Context(),
 		req.User.GetUID(),

--- a/pkg/api/handlers/mcp_oauth_debugger.go
+++ b/pkg/api/handlers/mcp_oauth_debugger.go
@@ -177,11 +177,7 @@ func (m *MCPHandler) ExchangeOAuthDebuggerToken(req api.Context) error {
 		return err
 	}
 	exchangeContext := context.WithValue(req.Context(), oauth2.HTTPClient, httpClient)
-	exchangeOptions := []oauth2.AuthCodeOption{oauth2.VerifierOption(pendingState.Verifier)}
-	if pendingState.ResourceURL != "" {
-		exchangeOptions = append(exchangeOptions, oauth2.SetAuthURLParam("resource", pendingState.ResourceURL))
-	}
-	token, err := conf.Exchange(exchangeContext, input.Code, exchangeOptions...)
+	token, err := mcp.ExchangeOAuthToken(exchangeContext, conf, input.Code, pendingState.Verifier, pendingState.ResourceURL)
 	if err != nil {
 		return fmt.Errorf("failed to exchange OAuth code: %w", err)
 	}

--- a/pkg/api/handlers/mcp_oauth_debugger_test.go
+++ b/pkg/api/handlers/mcp_oauth_debugger_test.go
@@ -38,10 +38,12 @@ func TestOAuthDebuggerMetadata(t *testing.T) {
 	registrationJSON := mustJSON(t, registration)
 
 	m := &MCPHandler{serverURL: "https://obot.example.com"}
-	parsedAuthServer, parsedRegistration, err := m.oauthDebuggerMetadata(v1.MCPServer{
+	const resourceURL = "https://resource.example.com/mcp"
+	parsedAuthServer, parsedRegistration, parsedResourceURL, err := m.oauthDebuggerMetadata(v1.MCPServer{
 		Status: v1.MCPServerStatus{
 			OAuthMetadata: &v1.OAuthMetadata{
 				AuthorizationServerURL:      authServer.Issuer,
+				ProtectedResourceMetadata:   runtime.RawExtension{Raw: json.RawMessage(`{"resource":["https://resource.example.com/mcp"]}`)},
 				AuthorizationServerMetadata: runtime.RawExtension{Raw: authServerJSON},
 				ClientRegistration:          runtime.RawExtension{Raw: registrationJSON},
 			},
@@ -65,6 +67,9 @@ func TestOAuthDebuggerMetadata(t *testing.T) {
 	if !reflect.DeepEqual(parsedRegistration, expectedRegistration) {
 		t.Fatalf("parsed registration mismatch:\nexpected: %#v\nactual:   %#v", expectedRegistration, parsedRegistration)
 	}
+	if parsedResourceURL != resourceURL {
+		t.Fatalf("parsed resource URL = %q, want %q", parsedResourceURL, resourceURL)
+	}
 }
 
 func TestOAuthDebuggerMetadataErrors(t *testing.T) {
@@ -73,6 +78,13 @@ func TestOAuthDebuggerMetadataErrors(t *testing.T) {
 		oauthMetadata    *v1.OAuthMetadata
 		expectedContains string
 	}{
+		{
+			name: "invalid protected resource metadata",
+			oauthMetadata: &v1.OAuthMetadata{
+				ProtectedResourceMetadata: runtime.RawExtension{Raw: json.RawMessage(`{`)},
+			},
+			expectedContains: "failed to parse OAuth protected resource metadata",
+		},
 		{
 			name: "invalid auth server metadata",
 			oauthMetadata: &v1.OAuthMetadata{
@@ -113,7 +125,7 @@ func TestOAuthDebuggerMetadataErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := (&MCPHandler{}).oauthDebuggerMetadata(v1.MCPServer{
+			_, _, _, err := (&MCPHandler{}).oauthDebuggerMetadata(v1.MCPServer{
 				Status: v1.MCPServerStatus{OAuthMetadata: tt.oauthMetadata},
 			})
 			if err == nil {

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -193,7 +193,7 @@ func (f *MCPOAuthHandlerFactory) staticOAuthURL(ctx context.Context, serverConfi
 		conf.Scopes = strings.Fields(registration.Scope)
 	}
 
-	authURL, _, _, err := mcp.GetOAuthAuthorizationURL(ctx, oauthHandler, conf, authorizationServer.AuthorizationEndpoint, serverConfig.URL)
+	authURL, _, _, err := mcp.GetOAuthAuthorizationURL(ctx, oauthHandler, conf, authorizationServer.AuthorizationEndpoint, metadata.ResourceURL)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -275,7 +275,7 @@ func (m *mcpOAuthHandler) HandleAuthURL(ctx context.Context, _ string, authURL s
 	}
 }
 
-func (m *mcpOAuthHandler) NewState(ctx context.Context, conf *oauth2.Config, verifier string) (string, <-chan mcp.CallbackPayload, error) {
+func (m *mcpOAuthHandler) NewState(ctx context.Context, conf *oauth2.Config, resourceURL, verifier string) (string, <-chan mcp.CallbackPayload, error) {
 	state := strings.ToLower(rand.Text())
 
 	// The channel is required by the nanobot CallbackHandler interface but is not used
@@ -283,7 +283,7 @@ func (m *mcpOAuthHandler) NewState(ctx context.Context, conf *oauth2.Config, ver
 	// callback arrives via a separate HTTP endpoint (oauthCallback) which looks up
 	// the pending state from the DB directly.
 	ch := make(chan mcp.CallbackPayload)
-	return state, ch, m.stateMgr.store(ctx, m.userID, m.mcpID, m.mcpURL, m.oauthAuthRequestID, state, verifier, conf)
+	return state, ch, m.stateMgr.store(ctx, m.userID, m.mcpID, m.mcpURL, m.oauthAuthRequestID, state, verifier, resourceURL, conf)
 }
 
 func (m *mcpOAuthHandler) Lookup(ctx context.Context, _ string) (string, string, error) {

--- a/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/mcpoauthhandler.go
@@ -193,7 +193,8 @@ func (f *MCPOAuthHandlerFactory) staticOAuthURL(ctx context.Context, serverConfi
 		conf.Scopes = strings.Fields(registration.Scope)
 	}
 
-	authURL, _, _, err := mcp.GetOAuthAuthorizationURL(ctx, oauthHandler, conf, authorizationServer.AuthorizationEndpoint, metadata.ResourceURL)
+	resourceURL := mcp.ResolveOAuthResourceURL(authorizationServer.AuthorizationEndpoint, metadata.ResourceURL, serverConfig.URL)
+	authURL, _, _, err := mcp.GetOAuthAuthorizationURL(ctx, oauthHandler, conf, authorizationServer.AuthorizationEndpoint, resourceURL)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/api/handlers/mcpgateway/oauth/statemanager.go
+++ b/pkg/api/handlers/mcpgateway/oauth/statemanager.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/mcp"
 	"golang.org/x/oauth2"
 )
 
@@ -49,11 +50,7 @@ func (sm *stateManager) createToken(ctx context.Context, state, code, errorStr, 
 		conf.Scopes = strings.Split(ps.Scopes, " ")
 	}
 
-	exchangeOptions := []oauth2.AuthCodeOption{oauth2.VerifierOption(ps.Verifier)}
-	if ps.ResourceURL != "" {
-		exchangeOptions = append(exchangeOptions, oauth2.SetAuthURLParam("resource", ps.ResourceURL))
-	}
-	token, err := conf.Exchange(ctx, code, exchangeOptions...)
+	token, err := mcp.ExchangeOAuthToken(ctx, conf, code, ps.Verifier, ps.ResourceURL)
 	if err != nil {
 		_ = sm.gatewayClient.DeleteMCPOAuthPendingState(ctx, ps.HashedState)
 		return "", "", fmt.Errorf("failed to exchange code: %w", err)

--- a/pkg/api/handlers/mcpgateway/oauth/statemanager.go
+++ b/pkg/api/handlers/mcpgateway/oauth/statemanager.go
@@ -19,8 +19,8 @@ func newStateManager(gatewayClient *client.Client) *stateManager {
 	}
 }
 
-func (sm *stateManager) store(ctx context.Context, userID, mcpID, mcpURL, oauthAuthRequestID, state, verifier string, conf *oauth2.Config) error {
-	return sm.gatewayClient.CreateMCPOAuthPendingState(ctx, userID, mcpID, mcpURL, oauthAuthRequestID, state, verifier, conf)
+func (sm *stateManager) store(ctx context.Context, userID, mcpID, mcpURL, oauthAuthRequestID, state, verifier, resourceURL string, conf *oauth2.Config) error {
+	return sm.gatewayClient.CreateMCPOAuthPendingState(ctx, userID, mcpID, mcpURL, oauthAuthRequestID, state, verifier, resourceURL, conf)
 }
 
 func (sm *stateManager) createToken(ctx context.Context, state, code, errorStr, errorDescription string) (string, string, error) {
@@ -49,7 +49,11 @@ func (sm *stateManager) createToken(ctx context.Context, state, code, errorStr, 
 		conf.Scopes = strings.Split(ps.Scopes, " ")
 	}
 
-	token, err := conf.Exchange(ctx, code, oauth2.SetAuthURLParam("code_verifier", ps.Verifier))
+	exchangeOptions := []oauth2.AuthCodeOption{oauth2.VerifierOption(ps.Verifier)}
+	if ps.ResourceURL != "" {
+		exchangeOptions = append(exchangeOptions, oauth2.SetAuthURLParam("resource", ps.ResourceURL))
+	}
+	token, err := conf.Exchange(ctx, code, exchangeOptions...)
 	if err != nil {
 		_ = sm.gatewayClient.DeleteMCPOAuthPendingState(ctx, ps.HashedState)
 		return "", "", fmt.Errorf("failed to exchange code: %w", err)

--- a/pkg/api/handlers/mcpgateway/oauth/statemanager_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/statemanager_test.go
@@ -1,0 +1,66 @@
+package oauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
+	sservices "github.com/obot-platform/obot/pkg/storage/services"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestStateManagerExchangesAuthorizationCodeWithStoredResource(t *testing.T) {
+	const (
+		resourceURL = "https://resource.example.com/mcp"
+		mcpURL      = "https://connection.example.com/mcp"
+		redirectURL = "https://obot.example.com/oauth/mcp/callback"
+		clientID    = "dynamic-client"
+		verifier    = "pkce-verifier"
+	)
+
+	tokenRequest := make(chan url.Values, 1)
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if err := req.ParseForm(); err != nil {
+			http.Error(rw, err.Error(), http.StatusBadRequest)
+			return
+		}
+		tokenRequest <- req.Form
+		rw.Header().Set("Content-Type", "application/json")
+		_, _ = rw.Write([]byte(`{"access_token":"access-token","token_type":"Bearer"}`))
+	}))
+	defer tokenServer.Close()
+
+	services, err := sservices.New(sservices.Config{DSN: "sqlite://:memory:"})
+	require.NoError(t, err)
+	db, err := gatewaydb.New(services.DB.DB, services.DB.SQLDB, true)
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate())
+
+	gatewayClient := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, true)
+	t.Cleanup(func() { require.NoError(t, gatewayClient.Close()) })
+	stateManager := newStateManager(gatewayClient)
+	conf := &oauth2.Config{
+		ClientID:    clientID,
+		RedirectURL: redirectURL,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://auth.example.com/authorize",
+			TokenURL:  tokenServer.URL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+
+	require.NoError(t, stateManager.store(t.Context(), "user", "mcp", mcpURL, "request", "state", verifier, resourceURL, conf))
+	_, _, err = stateManager.createToken(t.Context(), "state", "authorization-code", "", "")
+	require.NoError(t, err)
+
+	form := <-tokenRequest
+	require.Equal(t, resourceURL, form.Get("resource"))
+	require.Equal(t, clientID, form.Get("client_id"))
+	require.Equal(t, redirectURL, form.Get("redirect_uri"))
+	require.Equal(t, verifier, form.Get("code_verifier"))
+}

--- a/pkg/api/handlers/mcpgateway/oauth/statemanager_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/statemanager_test.go
@@ -41,7 +41,7 @@ func TestStateManagerExchangesAuthorizationCodeWithStoredResource(t *testing.T) 
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate())
 
-	gatewayClient := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, true)
+	gatewayClient := gatewayclient.New(t.Context(), db, nil, nil, nil, nil, nil, time.Hour, 10, 90, 90, 90, true)
 	t.Cleanup(func() { require.NoError(t, gatewayClient.Close()) })
 	stateManager := newStateManager(gatewayClient)
 	conf := &oauth2.Config{

--- a/pkg/api/handlers/mcpgateway/oauth/statemanager_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/statemanager_test.go
@@ -63,4 +63,10 @@ func TestStateManagerExchangesAuthorizationCodeWithStoredResource(t *testing.T) 
 	require.Equal(t, clientID, form.Get("client_id"))
 	require.Equal(t, redirectURL, form.Get("redirect_uri"))
 	require.Equal(t, verifier, form.Get("code_verifier"))
+
+	conf.Endpoint.AuthURL = "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize"
+	require.NoError(t, stateManager.store(t.Context(), "user", "mcp", mcpURL, "request", "entra-state", verifier, resourceURL, conf))
+	_, _, err = stateManager.createToken(t.Context(), "entra-state", "authorization-code", "", "")
+	require.NoError(t, err)
+	require.Empty(t, (<-tokenRequest).Get("resource"))
 }

--- a/pkg/gateway/client/mcpoauthtoken.go
+++ b/pkg/gateway/client/mcpoauthtoken.go
@@ -116,7 +116,7 @@ func (c *Client) triggerMCPOAuthTokenChange(ctx context.Context, mcpID string) e
 
 // Pending state methods
 
-func (c *Client) CreateMCPOAuthPendingState(ctx context.Context, userID, mcpID, mcpURL, oauthAuthRequestID, state, verifier string, oauthConf *oauth2.Config) error {
+func (c *Client) CreateMCPOAuthPendingState(ctx context.Context, userID, mcpID, mcpURL, oauthAuthRequestID, state, verifier, resourceURL string, oauthConf *oauth2.Config) error {
 	hashedState := fmt.Sprintf("%x", sha256.Sum256([]byte(state)))
 	ps := &types.MCPOAuthPendingState{
 		HashedState:        hashedState,
@@ -125,6 +125,7 @@ func (c *Client) CreateMCPOAuthPendingState(ctx context.Context, userID, mcpID, 
 		UserID:             userID,
 		MCPID:              mcpID,
 		URL:                mcpURL,
+		ResourceURL:        resourceURL,
 		OAuthAuthRequestID: oauthAuthRequestID,
 		ClientID:           oauthConf.ClientID,
 		ClientSecret:       oauthConf.ClientSecret,

--- a/pkg/gateway/types/tokens.go
+++ b/pkg/gateway/types/tokens.go
@@ -72,6 +72,7 @@ type MCPOAuthPendingState struct {
 	UserID             string `gorm:"index:idx_pending_user_mcp"`
 	MCPID              string `gorm:"index:idx_pending_user_mcp"`
 	URL                string
+	ResourceURL        string
 	OAuthAuthRequestID string
 	ClientID           string
 	ClientSecret       string

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -168,7 +168,7 @@ type AuthURLHandler interface {
 
 type CallbackHandler interface {
 	AuthURLHandler
-	NewState(context.Context, *oauth2.Config, string) (string, <-chan CallbackPayload, error)
+	NewState(context.Context, *oauth2.Config, string, string) (string, <-chan CallbackPayload, error)
 }
 
 type ClientCredLookup interface {
@@ -189,6 +189,7 @@ type oauth struct {
 
 type oauthMetadataDiscovery struct {
 	ProtectedResourceURL              string
+	ResourceURL                       string
 	ProtectedResourceMetadata         protectedResourceMetadata
 	ProtectedResourceMetadataJSON     json.RawMessage
 	AuthorizationServerURL            string
@@ -275,7 +276,7 @@ func (o *oauth) Authorize(ctx context.Context, req *http.Request, resp *http.Res
 		conf.Scopes = strings.Split(discovery.ClientRegistration.Scope, " ")
 	}
 	conf.Endpoint.AuthStyle = tokenEndpointAuthStyle(discovery.ClientRegistration.TokenEndpointAuthMethod, clientInfo.ClientSecret != "")
-	authURL, ch, verifier, err := GetOAuthAuthorizationURL(ctx, o.callbackHandler, conf, authorizationServerMetadata.AuthorizationEndpoint, connectURL)
+	authURL, ch, verifier, err := GetOAuthAuthorizationURL(ctx, o.callbackHandler, conf, authorizationServerMetadata.AuthorizationEndpoint, discovery.ResourceURL)
 	if err != nil {
 		return err
 	}
@@ -305,7 +306,7 @@ func (o *oauth) Authorize(ctx context.Context, req *http.Request, resp *http.Res
 		}
 	}
 
-	tok, err := ExchangeOAuthToken(ctx, conf, cb.Code, verifier)
+	tok, err := ExchangeOAuthToken(ctx, conf, cb.Code, verifier, discovery.ResourceURL)
 	if err != nil {
 		slog.Warn("oauth code exchange failed",
 			"server", o.serverName,
@@ -392,6 +393,7 @@ func discoverOAuthMetadata(ctx context.Context, client *http.Client, baseURL, au
 
 	return oauthMetadataDiscovery{
 		ProtectedResourceURL:              finalResourceMetadataURL.String(),
+		ResourceURL:                       string(protectedResourceMetadata.Resource),
 		ProtectedResourceMetadata:         protectedResourceMetadata,
 		ProtectedResourceMetadataJSON:     protectedResourceMetadataJSON,
 		AuthorizationServerURL:            authorizationServerURL,
@@ -591,17 +593,18 @@ func registerOAuthClient(ctx context.Context, client *http.Client, serverName st
 
 // GetOAuthAuthorizationURL constructs the OAuth authorization URL and callback
 // state for the authorization code flow.
-func GetOAuthAuthorizationURL(ctx context.Context, callbackHandler CallbackHandler, conf *oauth2.Config, authorizationEndpoint, connectURL string) (string, <-chan CallbackPayload, string, error) {
+func GetOAuthAuthorizationURL(ctx context.Context, callbackHandler CallbackHandler, conf *oauth2.Config, authorizationEndpoint, resourceURL string) (string, <-chan CallbackPayload, string, error) {
 	// use PKCE to protect against CSRF attacks
 	// https://www.ietf.org/archive/id/draft-ietf-oauth-security-topics-22.html#name-countermeasures-6
 	verifier := oauth2.GenerateVerifier()
 
-	state, ch, err := callbackHandler.NewState(ctx, conf, verifier)
+	resourceURL = OAuthResourceURL(authorizationEndpoint, resourceURL)
+	state, ch, err := callbackHandler.NewState(ctx, conf, resourceURL, verifier)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("failed to create state: %w", err)
 	}
 
-	authURL, err := AuthCodeURL(conf, authorizationEndpoint, connectURL, state, verifier)
+	authURL, err := AuthCodeURL(conf, authorizationEndpoint, resourceURL, state, verifier)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("failed to generate auth code URL: %w", err)
 	}
@@ -610,8 +613,12 @@ func GetOAuthAuthorizationURL(ctx context.Context, callbackHandler CallbackHandl
 }
 
 // ExchangeOAuthToken exchanges an OAuth authorization code for a token.
-func ExchangeOAuthToken(ctx context.Context, conf *oauth2.Config, code, verifier string) (*oauth2.Token, error) {
-	tok, err := conf.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+func ExchangeOAuthToken(ctx context.Context, conf *oauth2.Config, code, verifier, resourceURL string) (*oauth2.Token, error) {
+	options := []oauth2.AuthCodeOption{oauth2.VerifierOption(verifier)}
+	if resourceURL = OAuthResourceURL(conf.Endpoint.AuthURL, resourceURL); resourceURL != "" {
+		options = append(options, oauth2.SetAuthURLParam("resource", resourceURL))
+	}
+	tok, err := conf.Exchange(ctx, code, options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to exchange code for token: %w", err)
 	}
@@ -865,7 +872,7 @@ func AuthCodeURL(conf *oauth2.Config, urlFromMetadata, resourceURL, state, verif
 
 	// Redirect user to consent page to ask for permission for the scopes specified above.
 	authCodeURLOpts := []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(verifier)}
-	if authEndpoint.Host != "login.microsoftonline.com" {
+	if resourceURL = OAuthResourceURL(authEndpoint.String(), resourceURL); resourceURL != "" {
 		// Entra does not like the resource parameter, and including it will often cause things to fail.
 		// VSCode does something similar to this.
 		authCodeURLOpts = append(authCodeURLOpts, oauth2.SetAuthURLParam("resource", resourceURL))
@@ -876,6 +883,17 @@ func AuthCodeURL(conf *oauth2.Config, urlFromMetadata, resourceURL, state, verif
 	}
 
 	return conf.AuthCodeURL(state, authCodeURLOpts...), nil
+}
+
+// OAuthResourceURL returns the protected resource identifier when the
+// authorization server supports the RFC 8707 resource parameter. Microsoft
+// Entra rejects this parameter, so it must be omitted throughout the flow.
+func OAuthResourceURL(authorizationEndpoint, resourceURL string) string {
+	authEndpoint, err := url.Parse(authorizationEndpoint)
+	if err == nil && strings.EqualFold(authEndpoint.Hostname(), "login.microsoftonline.com") {
+		return ""
+	}
+	return resourceURL
 }
 
 type resourceIdentifier string

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -277,7 +277,8 @@ func (o *oauth) Authorize(ctx context.Context, req *http.Request, resp *http.Res
 		conf.Scopes = strings.Split(discovery.ClientRegistration.Scope, " ")
 	}
 	conf.Endpoint.AuthStyle = tokenEndpointAuthStyle(discovery.ClientRegistration.TokenEndpointAuthMethod, clientInfo.ClientSecret != "")
-	authURL, ch, verifier, err := GetOAuthAuthorizationURL(ctx, o.callbackHandler, conf, authorizationServerMetadata.AuthorizationEndpoint, discovery.ResourceURL)
+	resourceURL := ResolveOAuthResourceURL(authorizationServerMetadata.AuthorizationEndpoint, discovery.ResourceURL, connectURL)
+	authURL, ch, verifier, err := GetOAuthAuthorizationURL(ctx, o.callbackHandler, conf, authorizationServerMetadata.AuthorizationEndpoint, resourceURL)
 	if err != nil {
 		return err
 	}
@@ -307,7 +308,7 @@ func (o *oauth) Authorize(ctx context.Context, req *http.Request, resp *http.Res
 		}
 	}
 
-	tok, err := ExchangeOAuthToken(ctx, conf, cb.Code, verifier, discovery.ResourceURL)
+	tok, err := ExchangeOAuthToken(ctx, conf, cb.Code, verifier, resourceURL)
 	if err != nil {
 		slog.Warn("oauth code exchange failed",
 			"server", o.serverName,
@@ -908,6 +909,15 @@ func OAuthResourceURL(authorizationEndpoint, resourceURL string) string {
 		}
 	}
 	return resourceURL
+}
+
+// ResolveOAuthResourceURL prefers the discovered protected-resource identifier
+// and falls back to the MCP connection URL before applying provider-specific handling.
+func ResolveOAuthResourceURL(authorizationEndpoint, discoveredResourceURL, connectionURL string) string {
+	if discoveredResourceURL == "" {
+		discoveredResourceURL = connectionURL
+	}
+	return OAuthResourceURL(authorizationEndpoint, discoveredResourceURL)
 }
 
 type resourceIdentifier string

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -901,8 +901,11 @@ func AuthCodeURL(conf *oauth2.Config, urlFromMetadata, resourceURL, state, verif
 // Entra rejects this parameter, so it must be omitted throughout the flow.
 func OAuthResourceURL(authorizationEndpoint, resourceURL string) string {
 	authEndpoint, err := url.Parse(authorizationEndpoint)
-	if err == nil && strings.EqualFold(authEndpoint.Hostname(), "login.microsoftonline.com") {
-		return ""
+	if err == nil {
+		switch strings.ToLower(authEndpoint.Hostname()) {
+		case "login.microsoftonline.com", "login.microsoftonline.us", "login.partner.microsoftonline.cn":
+			return ""
+		}
 	}
 	return resourceURL
 }

--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -204,6 +204,7 @@ type oauthMetadataDiscovery struct {
 // OAuthMetadata contains discovered OAuth metadata for an MCP server.
 type OAuthMetadata struct {
 	ProtectedResourceMetadataURL      string          `json:"protectedResourceMetadataUrl,omitempty"`
+	ResourceURL                       string          `json:"resourceUrl,omitempty"`
 	AuthorizationServerMetadataURL    string          `json:"authorizationServerMetadataUrl,omitempty"`
 	ProtectedResourceMetadata         json.RawMessage `json:"protectedResourceMetadata,omitempty"`
 	AuthorizationServerMetadata       json.RawMessage `json:"authorizationServerMetadata,omitempty"`
@@ -542,6 +543,7 @@ func GetOAuthMetadataWithClient(ctx context.Context, httpClient *http.Client, se
 
 	return OAuthMetadata{
 		ProtectedResourceMetadataURL:      discovery.ProtectedResourceURL,
+		ResourceURL:                       discovery.ResourceURL,
 		AuthorizationServerMetadataURL:    discovery.AuthorizationServerMetadataURL,
 		ProtectedResourceMetadata:         discovery.ProtectedResourceMetadataJSON,
 		AuthorizationServerMetadata:       discovery.AuthorizationServerMetadataJSON,
@@ -837,6 +839,15 @@ func parseProtectedResourceMetadata(reader io.Reader) (protectedResourceMetadata
 	}
 
 	return metadata, nil
+}
+
+// ParseOAuthResourceURL returns the resource identifier from protected-resource metadata.
+func ParseOAuthResourceURL(metadata json.RawMessage) (string, error) {
+	parsed, err := parseProtectedResourceMetadata(bytes.NewReader(metadata))
+	if err != nil {
+		return "", err
+	}
+	return string(parsed.Resource), nil
 }
 
 // parseResourceMetadata extracts the resource_metadata URL from a Bearer authenticate header

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -115,6 +115,7 @@ func TestGetOAuthMetadataPathAndRootFallbackUsesMetadataScope(t *testing.T) {
 
 	metadata, err := GetOAuthMetadataWithClient(t.Context(), server.Client(), ServerConfig{URL: server.URL + "/mcp"}, clientName, redirectURL)
 	require.NoError(t, err)
+	require.Equal(t, server.URL, metadata.ResourceURL)
 	require.Equal(t, server.URL+"/.well-known/oauth-protected-resource", metadata.ProtectedResourceMetadataURL)
 	require.True(t, pathMetadataRequested.Load(), "expected path-specific metadata URL to be attempted")
 	require.True(t, rootMetadataRequested.Load(), "expected root metadata URL to be attempted")

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -530,6 +530,20 @@ func TestOAuthResourceHandlingByAuthorizationServer(t *testing.T) {
 	}
 }
 
+func TestResolveOAuthResourceURL(t *testing.T) {
+	require.Equal(t,
+		"https://connection.example.com/mcp",
+		ResolveOAuthResourceURL("https://auth.example.com/authorize", "", "https://connection.example.com/mcp"),
+	)
+	require.Equal(t,
+		"https://resource.example.com/mcp",
+		ResolveOAuthResourceURL("https://auth.example.com/authorize", "https://resource.example.com/mcp", "https://connection.example.com/mcp"),
+	)
+	require.Empty(t,
+		ResolveOAuthResourceURL("https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize", "", "https://connection.example.com/mcp"),
+	)
+}
+
 func TestStorageBackedTokenSourceDoesNotPersistUnchangedToken(t *testing.T) {
 	tok := &oauth2.Token{AccessToken: "access-token", RefreshToken: "refresh-token", Expiry: time.Now().Add(time.Hour)}
 	storage := &recordingTokenStorage{}
@@ -654,6 +668,54 @@ func TestOAuthAuthorizeDiscoversRegistersExchangesAndPersists(t *testing.T) {
 	require.Equal(t, "access-token", o.currentToken.AccessToken)
 	require.Equal(t, 1, storage.setCalls)
 	require.Equal(t, "access-token", storage.lastToken.AccessToken)
+}
+
+func TestOAuthAuthorizeFallsBackToConnectURLWithoutProtectedResourceMetadata(t *testing.T) {
+	var serverURL string
+	const redirectURL = "https://obot.example.com/callback"
+	callback := &oauthAuthorizeCallbackHandler{}
+	tokenRequest := make(chan url.Values, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/.well-known/oauth-protected-resource/mcp", "/.well-known/oauth-protected-resource":
+			http.NotFound(rw, req)
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(rw).Encode(map[string]any{
+				"issuer":                                serverURL,
+				"authorization_endpoint":                serverURL + "/authorize",
+				"token_endpoint":                        serverURL + "/token",
+				"response_types_supported":              []string{"code"},
+				"grant_types_supported":                 []string{"authorization_code"},
+				"token_endpoint_auth_methods_supported": []string{"none"},
+			})
+		case "/token":
+			require.NoError(t, req.ParseForm())
+			tokenRequest <- req.Form
+			rw.Header().Set("Content-Type", "application/json")
+			_, _ = rw.Write([]byte(`{"access_token":"access-token","token_type":"Bearer","expires_in":3600}`))
+		default:
+			http.NotFound(rw, req)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+	connectURL := server.URL + "/mcp"
+
+	request := httptest.NewRequest(http.MethodGet, connectURL, nil)
+	response := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+	o := newOAuth(server.Client(), callback, &oauthTestClientCredLookup{clientID: "static-client", clientSecret: "static-secret"}, nil, "test-server", "test-client", redirectURL, "")
+	require.NoError(t, o.Authorize(t.Context(), request, response))
+
+	authorizationRequest, err := http.NewRequest(http.MethodGet, callback.authURL, nil)
+	require.NoError(t, err)
+	require.Equal(t, connectURL, callback.resourceURL)
+	require.Equal(t, connectURL, authorizationRequest.URL.Query().Get("resource"))
+	require.Equal(t, connectURL, (<-tokenRequest).Get("resource"))
 }
 
 func hVerifier(callback *oauthAuthorizeCallbackHandler) string {

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -469,6 +470,37 @@ func TestStorageBackedTokenSourcePersistsRefreshedToken(t *testing.T) {
 	require.Same(t, tok, storage.lastToken)
 }
 
+func TestEntraOmitsResourceFromAuthorizationAndTokenRequests(t *testing.T) {
+	const resourceURL = "https://resource.example.com/mcp"
+	callback := &oauthAuthorizeCallbackHandler{}
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		require.NoError(t, req.ParseForm())
+		require.Empty(t, req.Form.Get("resource"))
+		rw.Header().Set("Content-Type", "application/json")
+		_, _ = rw.Write([]byte(`{"access_token":"access-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	conf := &oauth2.Config{
+		ClientID:    "client-id",
+		RedirectURL: "https://obot.example.com/callback",
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize",
+			TokenURL: tokenServer.URL,
+		},
+	}
+
+	authURL, _, verifier, err := GetOAuthAuthorizationURL(t.Context(), callback, conf, conf.Endpoint.AuthURL, resourceURL)
+	require.NoError(t, err)
+	parsedAuthURL, err := url.Parse(authURL)
+	require.NoError(t, err)
+	require.Empty(t, parsedAuthURL.Query().Get("resource"))
+	require.Empty(t, callback.resourceURL)
+
+	_, err = ExchangeOAuthToken(t.Context(), conf, "authorization-code", verifier, resourceURL)
+	require.NoError(t, err)
+}
+
 func TestStorageBackedTokenSourceDoesNotPersistUnchangedToken(t *testing.T) {
 	tok := &oauth2.Token{AccessToken: "access-token", RefreshToken: "refresh-token", Expiry: time.Now().Add(time.Hour)}
 	storage := &recordingTokenStorage{}
@@ -504,9 +536,10 @@ func TestStorageBackedTokenSourcePropagatesPersistenceError(t *testing.T) {
 }
 
 type oauthAuthorizeCallbackHandler struct {
-	authURL  string
-	verifier string
-	callback chan CallbackPayload
+	authURL     string
+	verifier    string
+	resourceURL string
+	callback    chan CallbackPayload
 }
 
 func (h *oauthAuthorizeCallbackHandler) HandleAuthURL(_ context.Context, _ string, authURL string) (bool, error) {
@@ -515,8 +548,9 @@ func (h *oauthAuthorizeCallbackHandler) HandleAuthURL(_ context.Context, _ strin
 	return true, nil
 }
 
-func (h *oauthAuthorizeCallbackHandler) NewState(_ context.Context, _ *oauth2.Config, verifier string) (string, <-chan CallbackPayload, error) {
+func (h *oauthAuthorizeCallbackHandler) NewState(_ context.Context, _ *oauth2.Config, resourceURL, verifier string) (string, <-chan CallbackPayload, error) {
 	h.verifier = verifier
+	h.resourceURL = resourceURL
 	h.callback = make(chan CallbackPayload, 1)
 	return "state", h.callback, nil
 }
@@ -524,6 +558,7 @@ func (h *oauthAuthorizeCallbackHandler) NewState(_ context.Context, _ *oauth2.Co
 func TestOAuthAuthorizeDiscoversRegistersExchangesAndPersists(t *testing.T) {
 	var serverURL string
 	var registrationCalled, tokenCalled atomic.Bool
+	const redirectURL = "https://obot.example.com/callback"
 	callback := &oauthAuthorizeCallbackHandler{}
 	storage := &recordingTokenStorage{}
 	lookup := &oauthTestClientCredLookup{}
@@ -532,7 +567,7 @@ func TestOAuthAuthorizeDiscoversRegistersExchangesAndPersists(t *testing.T) {
 		switch req.URL.Path {
 		case "/.well-known/oauth-protected-resource":
 			_ = json.NewEncoder(rw).Encode(map[string]any{
-				"resource":              serverURL + "/mcp",
+				"resource":              serverURL + "/protected-resource",
 				"authorization_servers": []string{serverURL},
 				"scopes_supported":      []string{"read"},
 			})
@@ -543,13 +578,14 @@ func TestOAuthAuthorizeDiscoversRegistersExchangesAndPersists(t *testing.T) {
 				"token_endpoint":                        serverURL + "/token",
 				"registration_endpoint":                 serverURL + "/register",
 				"response_types_supported":              []string{"code"},
-				"token_endpoint_auth_methods_supported": []string{"client_secret_post"},
+				"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+				"token_endpoint_auth_methods_supported": []string{"none"},
 			})
 		case "/register":
 			registrationCalled.Store(true)
 			require.Equal(t, http.MethodPost, req.Method)
 			rw.Header().Set("Content-Type", "application/json")
-			_, _ = rw.Write([]byte(`{"client_id":"dynamic-client","client_secret":"dynamic-secret"}`))
+			_, _ = rw.Write([]byte(`{"client_id":"dynamic-client"}`))
 		case "/token":
 			tokenCalled.Store(true)
 			require.Equal(t, http.MethodPost, req.Method)
@@ -557,7 +593,9 @@ func TestOAuthAuthorizeDiscoversRegistersExchangesAndPersists(t *testing.T) {
 			require.Equal(t, "authorization-code", req.Form.Get("code"))
 			require.Equal(t, hVerifier(callback), req.Form.Get("code_verifier"))
 			require.Equal(t, "dynamic-client", req.Form.Get("client_id"))
-			require.Equal(t, "dynamic-secret", req.Form.Get("client_secret"))
+			require.Equal(t, redirectURL, req.Form.Get("redirect_uri"))
+			require.Equal(t, serverURL+"/protected-resource", req.Form.Get("resource"))
+			require.Empty(t, req.Form.Get("client_secret"))
 			rw.Header().Set("Content-Type", "application/json")
 			_, _ = rw.Write([]byte(`{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","expires_in":3600}`))
 		default:
@@ -575,12 +613,15 @@ func TestOAuthAuthorizeDiscoversRegistersExchangesAndPersists(t *testing.T) {
 		},
 		Body: io.NopCloser(strings.NewReader("")),
 	}
-	o := newOAuth(server.Client(), callback, lookup, storage, "test-server", "test-client", "https://obot.example.com/callback", "")
+	o := newOAuth(server.Client(), callback, lookup, storage, "test-server", "test-client", redirectURL, "")
 	require.NoError(t, o.Authorize(t.Context(), request, response))
 	require.True(t, registrationCalled.Load())
 	require.True(t, tokenCalled.Load())
 	require.NotEmpty(t, callback.authURL)
 	require.Contains(t, callback.authURL, "code_challenge=")
+	authorizationRequest, err := http.NewRequest(http.MethodGet, callback.authURL, nil)
+	require.NoError(t, err)
+	require.Equal(t, serverURL+"/protected-resource", authorizationRequest.URL.Query().Get("resource"))
 	require.Equal(t, "access-token", o.currentToken.AccessToken)
 	require.Equal(t, 1, storage.setCalls)
 	require.Equal(t, "access-token", storage.lastToken.AccessToken)

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -471,35 +471,63 @@ func TestStorageBackedTokenSourcePersistsRefreshedToken(t *testing.T) {
 	require.Same(t, tok, storage.lastToken)
 }
 
-func TestEntraOmitsResourceFromAuthorizationAndTokenRequests(t *testing.T) {
+func TestOAuthResourceHandlingByAuthorizationServer(t *testing.T) {
 	const resourceURL = "https://resource.example.com/mcp"
-	callback := &oauthAuthorizeCallbackHandler{}
-	tokenServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		require.NoError(t, req.ParseForm())
-		require.Empty(t, req.Form.Get("resource"))
-		rw.Header().Set("Content-Type", "application/json")
-		_, _ = rw.Write([]byte(`{"access_token":"access-token","token_type":"Bearer","expires_in":3600}`))
-	}))
-	defer tokenServer.Close()
-
-	conf := &oauth2.Config{
-		ClientID:    "client-id",
-		RedirectURL: "https://obot.example.com/callback",
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize",
-			TokenURL: tokenServer.URL,
+	tests := []struct {
+		name             string
+		authorizationURL string
+		expectedResource string
+	}{
+		{
+			name:             "Entra global",
+			authorizationURL: "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize",
+		},
+		{
+			name:             "Entra US Government",
+			authorizationURL: "https://login.microsoftonline.us/tenant/oauth2/v2.0/authorize",
+		},
+		{
+			name:             "Entra China",
+			authorizationURL: "https://login.partner.microsoftonline.cn/tenant/oauth2/v2.0/authorize",
+		},
+		{
+			name:             "non-Entra China authority",
+			authorizationURL: "https://login.chinacloudapi.cn/tenant/oauth2/v2.0/authorize",
+			expectedResource: resourceURL,
 		},
 	}
 
-	authURL, _, verifier, err := GetOAuthAuthorizationURL(t.Context(), callback, conf, conf.Endpoint.AuthURL, resourceURL)
-	require.NoError(t, err)
-	parsedAuthURL, err := url.Parse(authURL)
-	require.NoError(t, err)
-	require.Empty(t, parsedAuthURL.Query().Get("resource"))
-	require.Empty(t, callback.resourceURL)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callback := &oauthAuthorizeCallbackHandler{}
+			tokenServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				require.NoError(t, req.ParseForm())
+				require.Equal(t, tt.expectedResource, req.Form.Get("resource"))
+				rw.Header().Set("Content-Type", "application/json")
+				_, _ = rw.Write([]byte(`{"access_token":"access-token","token_type":"Bearer","expires_in":3600}`))
+			}))
+			defer tokenServer.Close()
 
-	_, err = ExchangeOAuthToken(t.Context(), conf, "authorization-code", verifier, resourceURL)
-	require.NoError(t, err)
+			conf := &oauth2.Config{
+				ClientID:    "client-id",
+				RedirectURL: "https://obot.example.com/callback",
+				Endpoint: oauth2.Endpoint{
+					AuthURL:  tt.authorizationURL,
+					TokenURL: tokenServer.URL,
+				},
+			}
+
+			authURL, _, verifier, err := GetOAuthAuthorizationURL(t.Context(), callback, conf, conf.Endpoint.AuthURL, resourceURL)
+			require.NoError(t, err)
+			parsedAuthURL, err := url.Parse(authURL)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedResource, parsedAuthURL.Query().Get("resource"))
+			require.Equal(t, tt.expectedResource, callback.resourceURL)
+
+			_, err = ExchangeOAuthToken(t.Context(), conf, "authorization-code", verifier, resourceURL)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestStorageBackedTokenSourceDoesNotPersistUnchangedToken(t *testing.T) {


### PR DESCRIPTION
## Summary

This change is required for compatibility with AWS remote MCP server.

- Preserve the protected-resource identifier discovered from MCP OAuth metadata instead of substituting the MCP transport URL.
- Carry that resource through dynamic, static, and OAuth Debugger flows and include it in the authorization-code token exchange alongside the PKCE verifier.
- Continue omitting the `resource` parameter for Microsoft Entra authorization servers, including the documented U.S. Government and China endpoints.

## Why

AWS Managed MCP advertises a protected-resource identifier that can differ from the server connection URL. Obot previously discarded or replaced that value before the token exchange, causing AWS to reject an otherwise valid authorization code with `oauth2: "INVALID_REQUEST"`.

The resource is now discovered once, persisted with the pending OAuth state, and reused consistently for authorization and token requests. No MCP catalog or AWS DCR allowlist changes are required.

## Testing

- Added a regression test asserting the token request contains the matching `resource`, `client_id`, `redirect_uri`, and PKCE `code_verifier`.
- Added coverage for metadata fallback, static OAuth, and OAuth Debugger resource propagation.
- Added authorization and token request coverage for global and national-cloud Entra endpoints, while preserving RFC 8707 behavior for other providers.
- Verified the full Go test suite with `make test`.
