### PR TITLE
docs: drop OPENAI_API_KEY from Docker install examples

### DIFF
--- a/docs/docs/installation/docker-deployment.md
+++ b/docs/docs/installation/docker-deployment.md
@@ -31,7 +31,6 @@ docker run -d \
   -v obot-data:/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 8080:8080 \
-  -e OPENAI_API_KEY=your-openai-key \
   ghcr.io/obot-platform/obot:latest
 ```
 
@@ -53,7 +52,6 @@ docker run -d \
   -v obot-data:/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 8080:8080 \
-  -e OPENAI_API_KEY=your-openai-key \
   -e OBOT_SERVER_ENABLE_AUTHENTICATION=true \
   -e OBOT_BOOTSTRAP_TOKEN=your-bootstrap-token \
   ghcr.io/obot-platform/obot:latest
@@ -69,7 +67,6 @@ docker run -d \
   -v obot-data:/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 9999:8080 \
-  -e OPENAI_API_KEY=your-openai-key \
   -e OBOT_SERVER_HOSTNAME=localhost:9999 \
   -e OBOT_SERVER_ENABLE_AUTHENTICATION=true \
   -e OBOT_BOOTSTRAP_TOKEN=your-bootstrap-token \

--- a/docs/versioned_docs/version-v0.25.0/installation/docker-deployment.md
+++ b/docs/versioned_docs/version-v0.25.0/installation/docker-deployment.md
@@ -31,7 +31,6 @@ docker run -d \
   -v obot-data:/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 8080:8080 \
-  -e OPENAI_API_KEY=your-openai-key \
   ghcr.io/obot-platform/obot:latest
 ```
 
@@ -53,7 +52,6 @@ docker run -d \
   -v obot-data:/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 8080:8080 \
-  -e OPENAI_API_KEY=your-openai-key \
   -e OBOT_SERVER_ENABLE_AUTHENTICATION=true \
   -e OBOT_BOOTSTRAP_TOKEN=your-bootstrap-token \
   ghcr.io/obot-platform/obot:latest
@@ -69,7 +67,6 @@ docker run -d \
   -v obot-data:/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 9999:8080 \
-  -e OPENAI_API_KEY=your-openai-key \
   -e OBOT_SERVER_HOSTNAME=localhost:9999 \
   -e OBOT_SERVER_ENABLE_AUTHENTICATION=true \
   -e OBOT_BOOTSTRAP_TOKEN=your-bootstrap-token \


### PR DESCRIPTION
The quickstart in the overview no longer presents a model provider key as required setup, but the Docker deployment page still passed `OPENAI_API_KEY` in all three `docker run` examples.

This removes it from those examples in the current docs and in the v0.25.0 snapshot, since that page is what people copy from when they install.

Setting the key is still supported. It just should not be shown as part of the required install configuration. The Kubernetes install docs and the reference architectures still mention it, but they already label it optional, so they are unchanged.