### PR TITLE
fix: ignore description whitespace when detecting composite tool overrides

### DIFF
--- a/ui/user/src/lib/components/admin/CatalogServerForm.svelte
+++ b/ui/user/src/lib/components/admin/CatalogServerForm.svelte
@@ -25,6 +25,7 @@
 		isKubernetesRuntimeBackend,
 		sanitizeEgressDomains,
 		sanitizeResourceRuntimeConfig,
+		toolOverrideValue,
 		validateRuntimeForm
 	} from '$lib/services/user/mcp';
 	import { errors, profile, version } from '$lib/stores';
@@ -529,7 +530,14 @@
 			case 'composite':
 				if (baseData.compositeConfig) {
 					manifest.compositeConfig = {
-						componentServers: baseData.compositeConfig.componentServers
+						componentServers: baseData.compositeConfig.componentServers.map((component) => ({
+							...component,
+							toolOverrides: component.toolOverrides?.map((tool) => ({
+								...tool,
+								overrideName: toolOverrideValue(tool.overrideName, tool.name),
+								overrideDescription: toolOverrideValue(tool.overrideDescription, tool.description)
+							}))
+						}))
 					};
 				}
 				break;

--- a/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
@@ -17,6 +17,7 @@
 		TOOL_NAME_CHARSET_REGEX,
 		TOOL_NAME_SPECIAL_CHAR_WARNING,
 		isDeprecatedMCPServer,
+		isToolCustomized,
 		toolNameIssue,
 		type ToolNameIssue
 	} from '$lib/services/user/mcp';
@@ -501,8 +502,7 @@
 										{@const currentName = (tool.overrideName || '').trim() || tool.name}
 										{@const currentDescription =
 											(tool.overrideDescription || '').trim() || tool.description}
-										{@const isCustomized =
-											currentName !== tool.name || currentDescription !== tool.description}
+										{@const isCustomized = isToolCustomized(tool)}
 										{@const effectiveName = effectiveToolName(
 											tool.name,
 											tool.overrideName,

--- a/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
+++ b/ui/user/src/lib/components/mcp/CompositeRuntimeForm.svelte
@@ -556,14 +556,6 @@
 															disabled={readonly}
 															onclick={() => {
 																const toolKey = `${componentId}-${tool.name}`;
-																// When expanding, initialize inputs with current effective values
-																if (!expandedTools[toolKey]) {
-																	tool.overrideName = (tool.overrideName || '').trim() || tool.name;
-																	tool.overrideDescription =
-																		(tool.overrideDescription || '').trim() ||
-																		tool.description ||
-																		'';
-																}
 																expandedTools[toolKey] = !expandedTools[toolKey];
 															}}
 														>
@@ -591,7 +583,10 @@
 															<input
 																class="text-input-filled flex-1 text-sm"
 																disabled={readonly}
-																bind:value={tool.overrideName}
+																bind:value={
+																	() => tool.overrideName ?? tool.name,
+																	(v) => (tool.overrideName = v)
+																}
 															/>
 														</div>
 
@@ -600,7 +595,10 @@
 															<textarea
 																class="text-input-filled h-24 resize-none text-xs"
 																disabled={readonly}
-																bind:value={tool.overrideDescription}
+																bind:value={
+																	() => tool.overrideDescription ?? tool.description ?? '',
+																	(v) => (tool.overrideDescription = v)
+																}
 																placeholder="Enter tool description..."
 															></textarea>
 														</div>
@@ -611,8 +609,8 @@
 																class="btn btn-sm btn-secondary text-xs"
 																disabled={readonly}
 																onclick={() => {
-																	tool.overrideName = tool.name;
-																	tool.overrideDescription = tool.description;
+																	tool.overrideName = undefined;
+																	tool.overrideDescription = undefined;
 																}}
 															>
 																Reset to default

--- a/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeEditTools.svelte
@@ -9,6 +9,7 @@
 		duplicateToolNames,
 		effectiveToolName,
 		isDeprecatedMCPServer,
+		isToolCustomized,
 		MAX_TOOL_PREFIX_LENGTH,
 		TOOL_NAME_CHARSET_REGEX,
 		TOOL_NAME_SPECIAL_CHAR_WARNING,
@@ -233,13 +234,9 @@
 			placeholder="Search tools..."
 		/>
 		{#each visibleTools as tool (tool.id)}
-			{@const overrideName = (tool.overrideName || '').trim()}
-			{@const overrideDescription = (tool.overrideDescription || '').trim()}
-			{@const currentName = overrideName || tool.name}
-			{@const currentDescription = overrideDescription || tool.description}
-			{@const isCustomized =
-				(overrideName !== '' && overrideName !== tool.name) ||
-				(overrideDescription !== '' && overrideDescription !== tool.description)}
+			{@const currentName = (tool.overrideName || '').trim() || tool.name}
+			{@const currentDescription = (tool.overrideDescription || '').trim() || tool.description}
+			{@const isCustomized = isToolCustomized(tool)}
 
 			{@const effectiveName = effectiveToolName(tool.name, tool.overrideName, toolPrefix)}
 			{@const conflict = tool.enabled ? conflictIssue(effectiveName, conflictSet) : undefined}

--- a/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
+++ b/ui/user/src/lib/components/mcp/composite/CompositeSelectServerAndToolsSetup.svelte
@@ -18,7 +18,8 @@
 		getSecretBindingEngineError,
 		isKubernetesRuntimeBackend,
 		hasEditableConfiguration,
-		isDeprecatedMCPServer
+		isDeprecatedMCPServer,
+		toolOverrideValue
 	} from '$lib/services/user/mcp';
 	import { mcpServersAndEntries, version } from '$lib/stores';
 	import CatalogConfigureForm, { type LaunchFormData } from '../CatalogConfigureForm.svelte';
@@ -526,22 +527,14 @@
 		onSuccess?.(
 			{
 				...componentConfig,
-				toolOverrides: tools.map((t) => {
-					const overrideName = (t.overrideName || '').trim() || t.overrideName;
-					const overrideDescription = (t.overrideDescription || '').trim() || t.overrideDescription;
-
-					return {
-						name: t.name,
-						// Persist the description snapshot for display in future edits.
-						description: t.description,
-						// Only store an override name if it differs from the original.
-						overrideName: overrideName !== t.name ? overrideName : undefined,
-						// Only store an override description if it differs from the original snapshot.
-						overrideDescription:
-							overrideDescription !== t.description ? overrideDescription : undefined,
-						enabled: t.enabled
-					};
-				})
+				toolOverrides: tools.map((t) => ({
+					name: t.name,
+					// Persist the description snapshot for display in future edits.
+					description: t.description,
+					overrideName: toolOverrideValue(t.overrideName, t.name),
+					overrideDescription: toolOverrideValue(t.overrideDescription, t.description),
+					enabled: t.enabled
+				}))
 			},
 			configuringEntry,
 			tools

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -977,6 +977,29 @@ export function effectiveToolName(
 	return (toolPrefix ?? '') + base;
 }
 
+// toolOverrideValue returns the override to persist, or undefined when it only
+// differs from the server's own value by surrounding whitespace.
+export function toolOverrideValue(
+	override: string | undefined,
+	original: string | undefined
+): string | undefined {
+	const normalized = (override ?? '').trim();
+	if (!normalized || normalized === (original ?? '').trim()) return undefined;
+	return normalized;
+}
+
+export function isToolCustomized(tool: {
+	name: string;
+	description?: string;
+	overrideName?: string;
+	overrideDescription?: string;
+}): boolean {
+	return (
+		toolOverrideValue(tool.overrideName, tool.name) !== undefined ||
+		toolOverrideValue(tool.overrideDescription, tool.description) !== undefined
+	);
+}
+
 // toolNameIssue returns the highest-priority interop issue with an effective
 // tool name, or undefined if the name is clean. Callers pass the FINAL name
 // (prefix + override || original). Errors are checked before warnings; within


### PR DESCRIPTION
The composite tool edit form seeds its override inputs with the component
server's own name and description, then compared the trimmed override against
the untrimmed original. Any tool whose description carries surrounding
whitespace — common for remote servers such as GitHub Copilot and Gmail — was
reported as customized, and confirming the dialog persisted an
overrideDescription that was only the trimmed original, pinning the description
snapshot at runtime.

Compare and store overrides through shared helpers that normalize both sides,
so an override differing only by surrounding whitespace is dropped rather than
persisted. Applied to the edit dialog, the component card, and the catalog
entry save path.

Addresses #7577

