### PR TITLE
fix(mcp): canonicalize remote header names

### DIFF
--- a/pkg/mcp/oauth.go
+++ b/pkg/mcp/oauth.go
@@ -73,13 +73,13 @@ func serverConfigHeaders(serverConfig ServerConfig) map[string][]string {
 	result := make(map[string][]string, len(serverConfig.PassthroughHeaderNames)+len(serverConfig.Headers))
 	for i, key := range serverConfig.PassthroughHeaderNames {
 		if i < len(serverConfig.PassthroughHeaderValues) {
-			result[key] = []string{serverConfig.PassthroughHeaderValues[i]}
+			result[http.CanonicalHeaderKey(key)] = []string{serverConfig.PassthroughHeaderValues[i]}
 		}
 	}
 	for _, header := range serverConfig.Headers {
 		key, value, ok := strings.Cut(header, "=")
 		if ok {
-			result[key] = []string{value}
+			result[http.CanonicalHeaderKey(key)] = []string{value}
 		}
 	}
 	return result

--- a/pkg/mcp/oauth_test.go
+++ b/pkg/mcp/oauth_test.go
@@ -39,6 +39,18 @@ func TestRequiresStaticOAuth(t *testing.T) {
 	require.False(t, RequiresStaticOAuth(server))
 }
 
+func TestServerConfigHeadersCanonicalizesNames(t *testing.T) {
+	headers := serverConfigHeaders(ServerConfig{
+		PassthroughHeaderNames:  []string{"x-request-id"},
+		PassthroughHeaderValues: []string{"request-1"},
+		Headers:                 []string{"AUTHORIZATION=Bearer token"},
+	})
+
+	require.Equal(t, []string{"Bearer token"}, headers["Authorization"])
+	require.Equal(t, []string{"request-1"}, headers["X-Request-Id"])
+	require.NotContains(t, headers, "AUTHORIZATION")
+}
+
 func TestGetOAuthMetadataAssumesOAuthAfterSuccessfulInitialize(t *testing.T) {
 	var initializeRequests atomic.Int32
 	var serverURL string


### PR DESCRIPTION
## Summary

- canonicalize static and passthrough remote MCP header names before storing them in http.Header
- prevent noncanonical Authorization keys from bypassing OAuth Set, Get, and Del operations
- add regression coverage for uppercase and lowercase configured header names

## Regression

PR #7569 moved non-composite MCP traffic from Nanobot to Obot's reverse-proxy HTTP transport. serverConfigHeaders copied the configured names directly into an http.Header map. OAuth handling continued to use the canonical Authorization key, so an uppercase AUTHORIZATION entry could be missed, duplicated, or retained incorrectly. This change restores the canonicalization previously provided by Nanobot in Obot's replacement transport path.

Nanobot reference: https://github.com/obot-platform/nanobot/blob/v0.0.92/pkg/mcp/httpclient.go#L310-L324

## Testing

- go test ./pkg/mcp -count=1
- git diff --check