### PR TITLE
enhance: paginate groups

### DIFF
--- a/pkg/gateway/client/group.go
+++ b/pkg/gateway/client/group.go
@@ -2,9 +2,11 @@ package client
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log/slog"
 	"net/http"
@@ -39,16 +41,106 @@ func (e *FetchUserGroupsError) Error() string {
 }
 
 type ListAuthGroupsOptions struct {
-	// NameFilter, when set, restricts results to groups whose name matches it.
 	NameFilter string
+	Limit      int
+	Cursor     string
+}
 
-	Limit  int
-	Offset int
+type ListAuthGroupsResult struct {
+	Groups     []types.Group
+	NextCursor string
+
+	// Source is where the items came from: types.GroupSourceProvider or types.GroupSourceCache.
+	Source string
+
+	// Degraded is true when the auth provider could not be listed and the response fell back to
+	// cached groups.
+	Degraded bool
 }
 
 type listAuthGroupsPage struct {
-	Items []auth.GroupInfo `json:"items"`
-	Total int              `json:"total"`
+	Items      []auth.GroupInfo `json:"items"`
+	NextCursor string           `json:"nextCursor"`
+}
+
+// groupCursor is the opaque position handed to callers. It wraps the auth provider's own cursor
+// rather than exposing it, because the cached fallback pages differently and a position from one
+// source is meaningless to the other. Recording which source minted it lets a caller that switches
+// sources mid-listing restart cleanly instead of replaying an uninterpretable token.
+//
+// The JSON names are single letters because the encoded cursor travels in a query string and the
+// auth provider cursor it wraps can already be long.
+type groupCursor struct {
+	Version           int    `json:"v"`
+	Source            string `json:"s"`
+	FilterFingerprint string `json:"f,omitempty"`
+
+	// ProviderCursor is the auth provider's cursor, carried verbatim.
+	ProviderCursor string `json:"p,omitempty"`
+
+	// LastName and LastID are the keyset position of the last row of the previous page, used when
+	// paging the cached listing out of the database.
+	LastName string `json:"n,omitempty"`
+	LastID   string `json:"i,omitempty"`
+}
+
+const groupCursorVersion = 1
+
+// encodeGroupCursor renders a position as an opaque token. An empty position stays empty, which is
+// what tells a caller it has reached the end.
+func encodeGroupCursor(cursor groupCursor) (string, error) {
+	if cursor.ProviderCursor == "" && cursor.LastName == "" && cursor.LastID == "" {
+		return "", nil
+	}
+
+	cursor.Version = groupCursorVersion
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode group cursor: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+// decodeGroupCursor reads a position back. A cursor that cannot be trusted is reported as absent
+// rather than as an error: the caller then starts over at the first page, which is always a
+// sensible answer and never surfaces a failure to someone who simply retyped a search.
+func decodeGroupCursor(encoded, nameFilter string) (groupCursor, bool) {
+	if encoded == "" {
+		return groupCursor{}, false
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return groupCursor{}, false
+	}
+
+	var cursor groupCursor
+	if err := json.Unmarshal(raw, &cursor); err != nil {
+		return groupCursor{}, false
+	}
+
+	if cursor.Version != groupCursorVersion || cursor.FilterFingerprint != groupFilterFingerprint(nameFilter) {
+		// Either the format moved on, or the caller changed the search between pages, which makes
+		// the recorded position meaningless.
+		return groupCursor{}, false
+	}
+
+	return cursor, true
+}
+
+// groupFilterFingerprint reduces a name filter to a short token, used to notice that a cursor is
+// being replayed against a different search. Hashing rather than storing the filter keeps
+// directory search terms out of URLs, which tend to end up in logs.
+func groupFilterFingerprint(nameFilter string) string {
+	if nameFilter == "" {
+		return ""
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(nameFilter))
+
+	return strconv.FormatUint(h.Sum64(), 16)
 }
 
 // ListAuthGroups returns one page of the auth provider's groups.
@@ -56,92 +148,96 @@ type listAuthGroupsPage struct {
 // The auth provider is the authoritative source. When it cannot be listed, the response falls back
 // to the groups table, which only ever contains groups observed during a user sign-in and is
 // therefore partial.
-func (c *Client) ListAuthGroups(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions) ([]types.Group, int, string, bool, error) {
+func (c *Client) ListAuthGroups(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions) (ListAuthGroupsResult, error) {
+	cursor, _ := decodeGroupCursor(opts.Cursor, opts.NameFilter)
+
 	if authProviderURL != "" {
-		groups, total, status, err := c.listAuthGroupsFromProvider(ctx, authProviderURL, authProviderNamespace, authProviderName, opts)
+		// A cursor minted by the cached listing cannot be replayed against the provider, so drop
+		// it and restart from the provider's first page.
+		providerCursor := ""
+		if cursor.Source == types.GroupSourceProvider {
+			providerCursor = cursor.ProviderCursor
+		}
+
+		result, status, err := c.listAuthGroupsFromProvider(ctx, authProviderURL, authProviderNamespace, authProviderName, opts, providerCursor)
 		switch {
 		case err == nil:
-			return groups, total, types.GroupSourceProvider, false, nil
+			return result, nil
 		case status == http.StatusNotFound:
 			// The provider does not implement group listing (e.g. github, google, local). The
 			// cached groups are all there has ever been, so this is not a degraded response.
 			slog.Debug("auth provider does not support group listing, using cached groups",
 				"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace)
+		case status == http.StatusBadRequest:
+			// The provider rejected the cursor, most often because its own continuation token
+			// expired. Retry from the first page rather than reporting an outage.
+			slog.Debug("auth provider rejected the group listing cursor, restarting from the first page",
+				"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace, "error", err)
+
+			result, _, retryErr := c.listAuthGroupsFromProvider(ctx, authProviderURL, authProviderNamespace, authProviderName, opts, "")
+			if retryErr == nil {
+				return result, nil
+			}
+
+			slog.Warn("failed to list groups from auth provider, falling back to cached groups",
+				"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace, "error", retryErr)
+
+			return c.listAuthGroupsFromCache(ctx, authProviderNamespace, authProviderName, opts, cursor, true)
 		default:
 			// Fall back to cached groups so the UI keeps working when the provider is unreachable
 			// or the credentials lack directory-wide read permission.
 			slog.Warn("failed to list groups from auth provider, falling back to cached groups",
 				"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace, "error", err)
 
-			cached, cachedTotal, cacheErr := c.listAuthGroupsFromCache(ctx, authProviderNamespace, authProviderName, opts)
-			if cacheErr != nil {
-				return nil, 0, "", false, cacheErr
-			}
-			return cached, cachedTotal, types.GroupSourceCache, true, nil
+			return c.listAuthGroupsFromCache(ctx, authProviderNamespace, authProviderName, opts, cursor, true)
 		}
 	}
 
-	cached, total, err := c.listAuthGroupsFromCache(ctx, authProviderNamespace, authProviderName, opts)
-	if err != nil {
-		return nil, 0, "", false, err
-	}
-
-	return cached, total, types.GroupSourceCache, false, nil
+	return c.listAuthGroupsFromCache(ctx, authProviderNamespace, authProviderName, opts, cursor, false)
 }
 
 // listAuthGroupsFromProvider asks the auth provider for a page of groups. It returns the provider's
-// HTTP status alongside the error so the caller can tell "not implemented" apart from a failure.
-func (c *Client) listAuthGroupsFromProvider(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions) ([]types.Group, int, int, error) {
+// HTTP status alongside the error so the caller can tell "not implemented" and "bad cursor" apart
+// from a failure.
+func (c *Client) listAuthGroupsFromProvider(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions, providerCursor string) (ListAuthGroupsResult, int, error) {
 	u, err := url.Parse(authProviderURL + "/obot-list-auth-groups")
 	if err != nil {
-		return nil, 0, 0, fmt.Errorf("failed to parse auth provider URL for group search: %w", err)
+		return ListAuthGroupsResult{}, 0, fmt.Errorf("failed to parse auth provider URL for group search: %w", err)
 	}
 
 	q := u.Query()
 	if opts.NameFilter != "" {
 		q.Set("name", opts.NameFilter)
 	}
-	// Always send a limit: it is what selects the paginated response shape, so a provider that
-	// predates pagination still answers with a plain array and is handled below.
 	q.Set("limit", strconv.Itoa(opts.Limit))
-	q.Set("offset", strconv.Itoa(opts.Offset))
+	if providerCursor != "" {
+		q.Set("cursor", providerCursor)
+	}
 	u.RawQuery = q.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
-		return nil, 0, 0, fmt.Errorf("failed to build group listing request: %w", err)
+		return ListAuthGroupsResult{}, 0, fmt.Errorf("failed to build group listing request: %w", err)
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, 0, 0, fmt.Errorf("failed to call auth provider group listing: %w", err)
+		return ListAuthGroupsResult{}, 0, fmt.Errorf("failed to call auth provider group listing: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		return nil, 0, resp.StatusCode, fmt.Errorf("auth provider group listing returned status %d: %s", resp.StatusCode, string(body))
+		return ListAuthGroupsResult{}, resp.StatusCode, fmt.Errorf("auth provider group listing returned status %d: %s", resp.StatusCode, string(body))
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, 0, resp.StatusCode, fmt.Errorf("failed to read auth provider group listing: %w", err)
+	var page listAuthGroupsPage
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return ListAuthGroupsResult{}, resp.StatusCode, fmt.Errorf("failed to decode auth provider group listing: %w", err)
 	}
 
-	var (
-		page      listAuthGroupsPage
-		infos     []auth.GroupInfo
-		total     int
-		paginated bool
-	)
-	if err := json.Unmarshal(body, &page); err == nil && page.Items != nil {
-		infos, total, paginated = page.Items, page.Total, true
-	} else if err := json.Unmarshal(body, &infos); err != nil {
-		return nil, 0, resp.StatusCode, fmt.Errorf("failed to decode auth provider group listing: %w", err)
-	}
-
-	groups := make([]types.Group, 0, len(infos))
-	for _, info := range infos {
+	groups := make([]types.Group, 0, len(page.Items))
+	for _, info := range page.Items {
 		if info.ID == "" {
 			continue
 		}
@@ -154,20 +250,36 @@ func (c *Client) listAuthGroupsFromProvider(ctx context.Context, authProviderURL
 		})
 	}
 
-	if !paginated {
-		// An older provider ignored the limit and returned everything, so page it here instead.
-		total = len(groups)
-		groups = pageGroups(groups, opts.Limit, opts.Offset)
+	nextCursor, err := encodeGroupCursor(groupCursor{
+		Source:            types.GroupSourceProvider,
+		FilterFingerprint: groupFilterFingerprint(opts.NameFilter),
+		ProviderCursor:    page.NextCursor,
+	})
+	if err != nil {
+		return ListAuthGroupsResult{}, resp.StatusCode, err
 	}
 
-	return groups, total, resp.StatusCode, nil
+	return ListAuthGroupsResult{
+		Groups:     groups,
+		NextCursor: nextCursor,
+		Source:     types.GroupSourceProvider,
+	}, resp.StatusCode, nil
 }
 
 // listAuthGroupsFromCache pages over the groups table, which holds the groups seen during previous
 // user sign-ins.
-func (c *Client) listAuthGroupsFromCache(ctx context.Context, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions) ([]types.Group, int, error) {
+//
+// It pages by keyset rather than by offset: there is no total to page against, and a keyset seek
+// stays on the (name, id) ordering index no matter how deep the listing goes.
+func (c *Client) listAuthGroupsFromCache(ctx context.Context, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions, cursor groupCursor, degraded bool) (ListAuthGroupsResult, error) {
+	result := ListAuthGroupsResult{
+		Groups:   []types.Group{},
+		Source:   types.GroupSourceCache,
+		Degraded: degraded,
+	}
+
 	if authProviderNamespace == "" || authProviderName == "" {
-		return []types.Group{}, 0, nil
+		return result, nil
 	}
 
 	query := c.db.WithContext(ctx).Model(&types.Group{}).
@@ -178,17 +290,40 @@ func (c *Client) listAuthGroupsFromCache(ctx context.Context, authProviderNamesp
 		query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+opts.NameFilter+"%")
 	}
 
-	var total int64
-	if err := query.Count(&total).Error; err != nil {
-		return nil, 0, fmt.Errorf("failed to count groups in database: %w", err)
+	// A cursor minted by the provider says nothing about a position in this table, so start over.
+	if cursor.Source == types.GroupSourceCache && (cursor.LastName != "" || cursor.LastID != "") {
+		// Written out rather than as a row-value comparison, which SQLite and PostgreSQL do not
+		// both support.
+		query = query.Where("(name > ? OR (name = ? AND id > ?))", cursor.LastName, cursor.LastName, cursor.LastID)
 	}
 
+	// One more than the page, so the presence of a further page is known without a second query.
 	var groups []types.Group
-	if err := query.Order("name").Limit(opts.Limit).Offset(opts.Offset).Find(&groups).Error; err != nil {
-		return nil, 0, fmt.Errorf("failed to fetch groups from database: %w", err)
+	if err := query.Order("name, id").Limit(opts.Limit + 1).Find(&groups).Error; err != nil {
+		return ListAuthGroupsResult{}, fmt.Errorf("failed to fetch groups from database: %w", err)
 	}
 
-	return groups, int(total), nil
+	var next groupCursor
+	if len(groups) > opts.Limit {
+		groups = groups[:opts.Limit]
+		last := groups[len(groups)-1]
+		next = groupCursor{
+			Source:            types.GroupSourceCache,
+			FilterFingerprint: groupFilterFingerprint(opts.NameFilter),
+			LastName:          last.Name,
+			LastID:            last.ID,
+		}
+	}
+
+	nextCursor, err := encodeGroupCursor(next)
+	if err != nil {
+		return ListAuthGroupsResult{}, err
+	}
+
+	result.Groups = groups
+	result.NextCursor = nextCursor
+
+	return result, nil
 }
 
 // ResolveAuthGroups looks up specific groups by ID, which is what the UI needs to render a name for
@@ -228,14 +363,6 @@ func (c *Client) ResolveAuthGroups(ctx context.Context, authProviderNamespace, a
 	}
 
 	return resolved, nil
-}
-
-// pageGroups returns the requested window of a listing.
-func pageGroups(groups []types.Group, limit, offset int) []types.Group {
-	if offset >= len(groups) {
-		return []types.Group{}
-	}
-	return groups[offset:min(offset+limit, len(groups))]
 }
 
 // ListGroupIDsForUser lists the group IDs that the given user is a member of.

--- a/pkg/gateway/client/group.go
+++ b/pkg/gateway/client/group.go
@@ -27,7 +27,21 @@ import (
 const (
 	// groupCheckPeriod defines how often the system checks for updates to group information from the auth provider.
 	groupCheckPeriod = time.Minute * 10
+
+	// DefaultGroupPageSize is the page size used when a caller does not ask for one.
+	DefaultGroupPageSize = 50
+
+	// MaxGroupPageSize matches the ceiling the auth providers enforce, which is set by the
+	// smallest page any of the identity providers will serve in a single request.
+	MaxGroupPageSize = 100
+
+	// groupProviderTimeout bounds a single call to the auth provider. The API server sets no
+	// request deadline, so without this an unresponsive provider holds the handler until the
+	// client gives up.
+	groupProviderTimeout = 30 * time.Second
 )
+
+var groupProviderClient = &http.Client{Timeout: groupProviderTimeout}
 
 // FetchUserGroupsError represents an error that occurs when fetching user groups from the auth provider.
 // This error indicates a configuration issue with the auth provider that requires administrator intervention.
@@ -51,11 +65,15 @@ type ListAuthGroupsResult struct {
 	NextCursor string
 
 	// Source is where the items came from: types.GroupSourceProvider or types.GroupSourceCache.
-	Source string
+	Source types.GroupSource
 
 	// Degraded is true when the auth provider could not be listed and the response fell back to
 	// cached groups.
 	Degraded bool
+
+	// Reset is true when the supplied cursor could not be honored and these groups are the first
+	// page of a fresh listing rather than the page that was asked for.
+	Reset bool
 }
 
 type listAuthGroupsPage struct {
@@ -71,9 +89,9 @@ type listAuthGroupsPage struct {
 // The JSON names are single letters because the encoded cursor travels in a query string and the
 // auth provider cursor it wraps can already be long.
 type groupCursor struct {
-	Version           int    `json:"v"`
-	Source            string `json:"s"`
-	FilterFingerprint string `json:"f,omitempty"`
+	Version           int               `json:"v"`
+	Source            types.GroupSource `json:"s"`
+	FilterFingerprint string            `json:"f,omitempty"`
 
 	// ProviderCursor is the auth provider's cursor, carried verbatim.
 	ProviderCursor string `json:"p,omitempty"`
@@ -130,8 +148,8 @@ func decodeGroupCursor(encoded, nameFilter string) (groupCursor, bool) {
 }
 
 // groupFilterFingerprint reduces a name filter to a short token, used to notice that a cursor is
-// being replayed against a different search. Hashing rather than storing the filter keeps
-// directory search terms out of URLs, which tend to end up in logs.
+// being replayed against a different search. Only equality matters, so a short non-cryptographic
+// hash is enough and keeps the cursor small. It is not a privacy control.
 func groupFilterFingerprint(nameFilter string) string {
 	if nameFilter == "" {
 		return ""
@@ -146,9 +164,14 @@ func groupFilterFingerprint(nameFilter string) string {
 // ListAuthGroups returns one page of the auth provider's groups.
 //
 // The auth provider is the authoritative source. When it cannot be listed, the response falls back
-// to the groups table, which only ever contains groups observed during a user sign-in and is
-// therefore partial.
+// to the groups table, which holds the groups observed during a user sign-in plus any resolved by
+// ID for a policy, and is therefore partial.
 func (c *Client) ListAuthGroups(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions) (ListAuthGroupsResult, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = DefaultGroupPageSize
+	}
+	opts.Limit = min(opts.Limit, MaxGroupPageSize)
+
 	cursor, _ := decodeGroupCursor(opts.Cursor, opts.NameFilter)
 
 	if authProviderURL != "" {
@@ -168,9 +191,7 @@ func (c *Client) ListAuthGroups(ctx context.Context, authProviderURL, authProvid
 			// cached groups are all there has ever been, so this is not a degraded response.
 			slog.Debug("auth provider does not support group listing, using cached groups",
 				"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace)
-		case status == http.StatusBadRequest:
-			// The provider rejected the cursor, most often because its own continuation token
-			// expired. Retry from the first page rather than reporting an outage.
+		case status == http.StatusBadRequest && providerCursor != "":
 			slog.Debug("auth provider rejected the group listing cursor, restarting from the first page",
 				"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace, "error", err)
 
@@ -220,7 +241,7 @@ func (c *Client) listAuthGroupsFromProvider(ctx context.Context, authProviderURL
 		return ListAuthGroupsResult{}, 0, fmt.Errorf("failed to build group listing request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := groupProviderClient.Do(req)
 	if err != nil {
 		return ListAuthGroupsResult{}, 0, fmt.Errorf("failed to call auth provider group listing: %w", err)
 	}
@@ -263,6 +284,7 @@ func (c *Client) listAuthGroupsFromProvider(ctx context.Context, authProviderURL
 		Groups:     groups,
 		NextCursor: nextCursor,
 		Source:     types.GroupSourceProvider,
+		Reset:      opts.Cursor != "" && providerCursor == "",
 	}, resp.StatusCode, nil
 }
 
@@ -291,11 +313,14 @@ func (c *Client) listAuthGroupsFromCache(ctx context.Context, authProviderNamesp
 	}
 
 	// A cursor minted by the provider says nothing about a position in this table, so start over.
-	if cursor.Source == types.GroupSourceCache && (cursor.LastName != "" || cursor.LastID != "") {
+	usedCursor := cursor.Source == types.GroupSourceCache && (cursor.LastName != "" || cursor.LastID != "")
+	if usedCursor {
 		// Written out rather than as a row-value comparison, which SQLite and PostgreSQL do not
 		// both support.
 		query = query.Where("(name > ? OR (name = ? AND id > ?))", cursor.LastName, cursor.LastName, cursor.LastID)
 	}
+
+	result.Reset = opts.Cursor != "" && !usedCursor
 
 	// One more than the page, so the presence of a further page is known without a second query.
 	var groups []types.Group
@@ -320,16 +345,21 @@ func (c *Client) listAuthGroupsFromCache(ctx context.Context, authProviderNamesp
 		return ListAuthGroupsResult{}, err
 	}
 
-	result.Groups = groups
+	if groups != nil {
+		result.Groups = groups
+	}
 	result.NextCursor = nextCursor
 
 	return result, nil
 }
 
 // ResolveAuthGroups looks up specific groups by ID, which is what the UI needs to render a name for
-// a group that already has a role or policy attached. Unknown IDs come back as a group whose name
-// is the ID itself, so a caller renders something identifiable instead of dropping the row.
-func (c *Client) ResolveAuthGroups(ctx context.Context, authProviderNamespace, authProviderName string, ids []string) ([]types.Group, error) {
+// a group that already has a role or policy attached.
+//
+// Note the shape: cache first, provider only for the remainder. Resolution runs on page loads, so
+// making it an unconditional provider call would put an identity provider round trip, and its rate
+// limit, in front of every admin screen.
+func (c *Client) ResolveAuthGroups(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName string, ids []string) ([]types.Group, error) {
 	if len(ids) == 0 {
 		return []types.Group{}, nil
 	}
@@ -343,9 +373,26 @@ func (c *Client) ResolveAuthGroups(ctx context.Context, authProviderNamespace, a
 		return nil, fmt.Errorf("failed to resolve groups from database: %w", err)
 	}
 
-	byID := make(map[string]types.Group, len(cached))
+	byID := make(map[string]types.Group, len(ids))
 	for _, group := range cached {
 		byID[group.ID] = group
+	}
+
+	if missing := missingGroupIDs(ids, byID); len(missing) > 0 && authProviderURL != "" {
+		fetched, err := c.resolveAuthGroupsFromProvider(ctx, authProviderURL, authProviderNamespace, authProviderName, missing)
+		if err != nil {
+			// Resolution is best effort. A missing name degrades to the ID, which is still
+			// identifiable, and failing the whole page over it would be worse.
+			slog.Warn("failed to resolve groups from auth provider, falling back to ids",
+				"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace,
+				"groups", len(missing), "error", err)
+		} else {
+			for _, group := range fetched {
+				byID[group.ID] = group
+			}
+
+			c.cacheResolvedGroups(ctx, fetched)
+		}
 	}
 
 	resolved := make([]types.Group, 0, len(ids))
@@ -363,6 +410,102 @@ func (c *Client) ResolveAuthGroups(ctx context.Context, authProviderNamespace, a
 	}
 
 	return resolved, nil
+}
+
+// missingGroupIDs returns the requested IDs that resolved is missing, in the order they were asked
+// for and without duplicates.
+func missingGroupIDs(ids []string, resolved map[string]types.Group) []string {
+	missing := make([]string, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+
+	for _, id := range ids {
+		if _, ok := resolved[id]; ok {
+			continue
+		}
+		if _, duplicate := seen[id]; duplicate {
+			continue
+		}
+		seen[id] = struct{}{}
+		missing = append(missing, id)
+	}
+
+	return missing
+}
+
+// resolveAuthGroupsFromProvider asks the auth provider to name the given group IDs.
+//
+// A provider that does not implement the route answers 404, which is reported as no results rather
+// than as an error: github, google and local have no directory to ask, and an Obot running against
+// an older provider image should degrade to IDs rather than log an outage on every page load.
+func (c *Client) resolveAuthGroupsFromProvider(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName string, ids []string) ([]types.Group, error) {
+	u, err := url.Parse(authProviderURL + "/obot-get-auth-groups")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse auth provider URL for group resolution: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("ids", strings.Join(ids, ","))
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build group resolution request: %w", err)
+	}
+
+	resp, err := groupProviderClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call auth provider group resolution: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		slog.Debug("auth provider does not support group resolution, using ids",
+			"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace)
+		return nil, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("auth provider group resolution returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var page struct {
+		Items []auth.GroupInfo `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return nil, fmt.Errorf("failed to decode auth provider group resolution: %w", err)
+	}
+
+	groups := make([]types.Group, 0, len(page.Items))
+	for _, info := range page.Items {
+		if info.ID == "" {
+			continue
+		}
+		groups = append(groups, types.Group{
+			ID:                    info.ID,
+			AuthProviderName:      authProviderName,
+			AuthProviderNamespace: authProviderNamespace,
+			Name:                  info.Name,
+			IconURL:               info.IconURL,
+		})
+	}
+
+	return groups, nil
+}
+
+// cacheResolvedGroups records groups resolved from the provider so the next caller is answered from
+// the database.
+func (c *Client) cacheResolvedGroups(ctx context.Context, groups []types.Group) {
+	if len(groups) == 0 {
+		return
+	}
+
+	if err := c.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"name", "icon_url"}),
+	}).Create(&groups).Error; err != nil {
+		slog.Warn("failed to cache groups resolved from the auth provider", "groups", len(groups), "error", err)
+	}
 }
 
 // ListGroupIDsForUser lists the group IDs that the given user is a member of.
@@ -466,10 +609,18 @@ func (c *Client) ensureGroups(ctx context.Context, identity *types.Identity) err
 func (c *Client) persistGroups(ctx context.Context, identity *types.Identity) error {
 	var membershipsChanged, groupsLost bool
 	if err := c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Get the groups from the database
+		ids := make([]string, 0, len(identity.AuthProviderGroups))
+		for _, group := range identity.AuthProviderGroups {
+			ids = append(ids, group.ID)
+		}
+
 		var groups []types.Group
-		if err := tx.WithContext(ctx).Where("auth_provider_name = ? AND auth_provider_namespace = ?", identity.AuthProviderName, identity.AuthProviderNamespace).Find(&groups).Error; err != nil {
-			return fmt.Errorf("failed to list auth provider groups: %w", err)
+		if len(ids) > 0 {
+			if err := tx.WithContext(ctx).
+				Where("auth_provider_name = ? AND auth_provider_namespace = ? AND id IN ?", identity.AuthProviderName, identity.AuthProviderNamespace, ids).
+				Find(&groups).Error; err != nil {
+				return fmt.Errorf("failed to list auth provider groups: %w", err)
+			}
 		}
 
 		existingGroups := make(map[string]types.Group, len(groups))

--- a/pkg/gateway/client/group.go
+++ b/pkg/gateway/client/group.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,96 +38,204 @@ func (e *FetchUserGroupsError) Error() string {
 	return fmt.Sprintf("auth provider failed to check groups for user with ID %s: %s", e.ProviderUserID, e.Message)
 }
 
-// ListAuthGroups lists the auth provider groups for the given auth provider.
+type ListAuthGroupsOptions struct {
+	// NameFilter, when set, restricts results to groups whose name matches it.
+	NameFilter string
+
+	Limit  int
+	Offset int
+}
+
+type listAuthGroupsPage struct {
+	Items []auth.GroupInfo `json:"items"`
+	Total int              `json:"total"`
+}
+
+// ListAuthGroups returns one page of the auth provider's groups.
 //
-// It supports fuzzy finding group names using on the given nameFilter.
-// It queries the auth provider for "live" group search from the auth provider, then combines the
-// results with cached groups from the database.
-// This allows admins to discover groups that authenticated users belong to for auth providers
-// limited group search capabilities.
-func (c *Client) ListAuthGroups(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName, nameFilter string) ([]types.Group, error) {
-	// Fetch groups from the auth provider
-	var providerGroups []auth.GroupInfo
+// The auth provider is the authoritative source. When it cannot be listed, the response falls back
+// to the groups table, which only ever contains groups observed during a user sign-in and is
+// therefore partial.
+func (c *Client) ListAuthGroups(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions) ([]types.Group, int, string, bool, error) {
 	if authProviderURL != "" {
-		u, err := url.Parse(authProviderURL + "/obot-list-auth-groups")
-		if err != nil {
-			slog.Warn("failed to parse auth provider URL for group search", "error", err)
-		} else {
-			// We ignore errors here so that clients can still search over cached groups where there
-			// are issues fetching them from the auth provider.
-			if nameFilter != "" {
-				q := u.Query()
-				q.Set("name", nameFilter)
-				u.RawQuery = q.Encode()
+		groups, total, status, err := c.listAuthGroupsFromProvider(ctx, authProviderURL, authProviderNamespace, authProviderName, opts)
+		switch {
+		case err == nil:
+			return groups, total, types.GroupSourceProvider, false, nil
+		case status == http.StatusNotFound:
+			// The provider does not implement group listing (e.g. github, google, local). The
+			// cached groups are all there has ever been, so this is not a degraded response.
+			slog.Debug("auth provider does not support group listing, using cached groups",
+				"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace)
+		default:
+			// Fall back to cached groups so the UI keeps working when the provider is unreachable
+			// or the credentials lack directory-wide read permission.
+			slog.Warn("failed to list groups from auth provider, falling back to cached groups",
+				"authProviderName", authProviderName, "authProviderNamespace", authProviderNamespace, "error", err)
+
+			cached, cachedTotal, cacheErr := c.listAuthGroupsFromCache(ctx, authProviderNamespace, authProviderName, opts)
+			if cacheErr != nil {
+				return nil, 0, "", false, cacheErr
 			}
-
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-			if err == nil {
-				resp, err := http.DefaultClient.Do(req)
-				if err == nil {
-					defer resp.Body.Close()
-					if resp.StatusCode == http.StatusOK {
-						_ = json.NewDecoder(resp.Body).Decode(&providerGroups)
-					}
-				}
-			}
+			return cached, cachedTotal, types.GroupSourceCache, true, nil
 		}
 	}
 
-	// Fetch groups from the database if we have auth provider info
-	var dbGroups []types.Group
-	if authProviderNamespace != "" && authProviderName != "" {
-		query := c.db.WithContext(ctx).Where("auth_provider_namespace = ? AND auth_provider_name = ?",
-			authProviderNamespace, authProviderName)
-
-		// Apply name filter if provided (case-insensitive, compatible with SQLite and PostgreSQL)
-		if nameFilter != "" {
-			query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+nameFilter+"%")
-		}
-
-		if err := query.Find(&dbGroups).Error; err != nil {
-			return nil, fmt.Errorf("failed to fetch groups from database: %w", err)
-		}
+	cached, total, err := c.listAuthGroupsFromCache(ctx, authProviderNamespace, authProviderName, opts)
+	if err != nil {
+		return nil, 0, "", false, err
 	}
 
-	groups := make(map[string]types.Group, len(dbGroups))
-	for _, group := range dbGroups {
-		groups[group.ID] = group
+	return cached, total, types.GroupSourceCache, false, nil
+}
+
+// listAuthGroupsFromProvider asks the auth provider for a page of groups. It returns the provider's
+// HTTP status alongside the error so the caller can tell "not implemented" apart from a failure.
+func (c *Client) listAuthGroupsFromProvider(ctx context.Context, authProviderURL, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions) ([]types.Group, int, int, error) {
+	u, err := url.Parse(authProviderURL + "/obot-list-auth-groups")
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("failed to parse auth provider URL for group search: %w", err)
 	}
 
-	// Add/merge provider groups
-	for _, providerGroup := range providerGroups {
-		if providerGroup.ID == "" {
+	q := u.Query()
+	if opts.NameFilter != "" {
+		q.Set("name", opts.NameFilter)
+	}
+	// Always send a limit: it is what selects the paginated response shape, so a provider that
+	// predates pagination still answers with a plain array and is handled below.
+	q.Set("limit", strconv.Itoa(opts.Limit))
+	q.Set("offset", strconv.Itoa(opts.Offset))
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("failed to build group listing request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("failed to call auth provider group listing: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, 0, resp.StatusCode, fmt.Errorf("auth provider group listing returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, resp.StatusCode, fmt.Errorf("failed to read auth provider group listing: %w", err)
+	}
+
+	var (
+		page      listAuthGroupsPage
+		infos     []auth.GroupInfo
+		total     int
+		paginated bool
+	)
+	if err := json.Unmarshal(body, &page); err == nil && page.Items != nil {
+		infos, total, paginated = page.Items, page.Total, true
+	} else if err := json.Unmarshal(body, &infos); err != nil {
+		return nil, 0, resp.StatusCode, fmt.Errorf("failed to decode auth provider group listing: %w", err)
+	}
+
+	groups := make([]types.Group, 0, len(infos))
+	for _, info := range infos {
+		if info.ID == "" {
 			continue
 		}
-
-		if existing, ok := groups[providerGroup.ID]; ok {
-			// Keep database timestamps but update other fields from provider
-			if providerGroup.Name != "" {
-				existing.Name = providerGroup.Name
-			}
-			if providerGroup.IconURL != nil {
-				existing.IconURL = providerGroup.IconURL
-			}
-			groups[providerGroup.ID] = existing
-			continue
-		}
-
-		groups[providerGroup.ID] = types.Group{
-			ID:                    providerGroup.ID,
+		groups = append(groups, types.Group{
+			ID:                    info.ID,
 			AuthProviderName:      authProviderName,
 			AuthProviderNamespace: authProviderNamespace,
-			Name:                  providerGroup.Name,
-			IconURL:               providerGroup.IconURL,
+			Name:                  info.Name,
+			IconURL:               info.IconURL,
+		})
+	}
+
+	if !paginated {
+		// An older provider ignored the limit and returned everything, so page it here instead.
+		total = len(groups)
+		groups = pageGroups(groups, opts.Limit, opts.Offset)
+	}
+
+	return groups, total, resp.StatusCode, nil
+}
+
+// listAuthGroupsFromCache pages over the groups table, which holds the groups seen during previous
+// user sign-ins.
+func (c *Client) listAuthGroupsFromCache(ctx context.Context, authProviderNamespace, authProviderName string, opts ListAuthGroupsOptions) ([]types.Group, int, error) {
+	if authProviderNamespace == "" || authProviderName == "" {
+		return []types.Group{}, 0, nil
+	}
+
+	query := c.db.WithContext(ctx).Model(&types.Group{}).
+		Where("auth_provider_namespace = ? AND auth_provider_name = ?", authProviderNamespace, authProviderName)
+
+	// Case-insensitive, compatible with SQLite and PostgreSQL.
+	if opts.NameFilter != "" {
+		query = query.Where("LOWER(name) LIKE LOWER(?)", "%"+opts.NameFilter+"%")
+	}
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to count groups in database: %w", err)
+	}
+
+	var groups []types.Group
+	if err := query.Order("name").Limit(opts.Limit).Offset(opts.Offset).Find(&groups).Error; err != nil {
+		return nil, 0, fmt.Errorf("failed to fetch groups from database: %w", err)
+	}
+
+	return groups, int(total), nil
+}
+
+// ResolveAuthGroups looks up specific groups by ID, which is what the UI needs to render a name for
+// a group that already has a role or policy attached. Unknown IDs come back as a group whose name
+// is the ID itself, so a caller renders something identifiable instead of dropping the row.
+func (c *Client) ResolveAuthGroups(ctx context.Context, authProviderNamespace, authProviderName string, ids []string) ([]types.Group, error) {
+	if len(ids) == 0 {
+		return []types.Group{}, nil
+	}
+
+	var cached []types.Group
+	query := c.db.WithContext(ctx).Where("id IN ?", ids)
+	if authProviderNamespace != "" && authProviderName != "" {
+		query = query.Where("auth_provider_namespace = ? AND auth_provider_name = ?", authProviderNamespace, authProviderName)
+	}
+	if err := query.Find(&cached).Error; err != nil {
+		return nil, fmt.Errorf("failed to resolve groups from database: %w", err)
+	}
+
+	byID := make(map[string]types.Group, len(cached))
+	for _, group := range cached {
+		byID[group.ID] = group
+	}
+
+	resolved := make([]types.Group, 0, len(ids))
+	for _, id := range ids {
+		if group, ok := byID[id]; ok {
+			resolved = append(resolved, group)
+			continue
 		}
+		resolved = append(resolved, types.Group{
+			ID:                    id,
+			AuthProviderName:      authProviderName,
+			AuthProviderNamespace: authProviderNamespace,
+			Name:                  id,
+		})
 	}
 
-	result := make([]types.Group, 0, len(groups))
-	for _, group := range groups {
-		result = append(result, group)
-	}
+	return resolved, nil
+}
 
-	return result, nil
+// pageGroups returns the requested window of a listing.
+func pageGroups(groups []types.Group, limit, offset int) []types.Group {
+	if offset >= len(groups) {
+		return []types.Group{}
+	}
+	return groups[offset:min(offset+limit, len(groups))]
 }
 
 // ListGroupIDsForUser lists the group IDs that the given user is a member of.

--- a/pkg/gateway/client/group_test.go
+++ b/pkg/gateway/client/group_test.go
@@ -1,0 +1,338 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/auth"
+	"github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+const (
+	testAuthProviderName      = "entra-auth-provider"
+	testAuthProviderNamespace = "default"
+)
+
+// seedGroups inserts n groups into the cache table, named so that name ordering matches ID
+// ordering.
+func seedGroups(t *testing.T, c *Client, n int) {
+	t.Helper()
+
+	groups := make([]types.Group, 0, n)
+	for i := range n {
+		groups = append(groups, types.Group{
+			ID:                    fmt.Sprintf("entra/%04d", i),
+			AuthProviderName:      testAuthProviderName,
+			AuthProviderNamespace: testAuthProviderNamespace,
+			Name:                  fmt.Sprintf("group-%04d", i),
+		})
+	}
+
+	if err := c.db.WithContext(t.Context()).Create(&groups).Error; err != nil {
+		t.Fatalf("failed to seed groups: %v", err)
+	}
+}
+
+// newProviderStub serves the paginated /obot-list-auth-groups contract over `total` groups.
+func newProviderStub(t *testing.T, total int) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/obot-list-auth-groups" {
+			http.NotFound(w, r)
+			return
+		}
+
+		all := make([]auth.GroupInfo, 0, total)
+		for i := range total {
+			all = append(all, auth.GroupInfo{
+				ID:   fmt.Sprintf("entra/%04d", i),
+				Name: fmt.Sprintf("group-%04d", i),
+			})
+		}
+
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+
+		items := []auth.GroupInfo{}
+		if offset < len(all) {
+			items = all[offset:min(offset+limit, len(all))]
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "total": len(all)})
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// TestListAuthGroupsPagesEntireDirectory is the regression guard for the reported bug: every group
+// in a large directory must be reachable through paging.
+func TestListAuthGroupsPagesEntireDirectory(t *testing.T) {
+	c := newTestClient(t)
+	srv := newProviderStub(t, 10000)
+
+	seen := make(map[string]struct{}, 10000)
+	for offset := 0; offset < 10000; offset += 50 {
+		groups, total, source, degraded, err := c.ListAuthGroups(
+			t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName,
+			ListAuthGroupsOptions{Limit: 50, Offset: offset},
+		)
+		if err != nil {
+			t.Fatalf("offset %d: unexpected error: %v", offset, err)
+		}
+		if total != 10000 {
+			t.Fatalf("offset %d: total = %d, want 10000", offset, total)
+		}
+		if source != types.GroupSourceProvider {
+			t.Fatalf("offset %d: source = %q, want %q", offset, source, types.GroupSourceProvider)
+		}
+		if degraded {
+			t.Fatalf("offset %d: degraded = true, want false", offset)
+		}
+
+		for _, group := range groups {
+			if _, dup := seen[group.ID]; dup {
+				t.Fatalf("group %s returned on more than one page", group.ID)
+			}
+			seen[group.ID] = struct{}{}
+		}
+	}
+
+	if len(seen) != 10000 {
+		t.Fatalf("paged over %d groups, want 10000", len(seen))
+	}
+}
+
+func TestListAuthGroupsFallsBackToCacheOnProviderError(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 120)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "directory read permission not granted", http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+
+	groups, total, source, degraded, err := c.ListAuthGroups(
+		t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName,
+		ListAuthGroupsOptions{Limit: 50, Offset: 0},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if source != types.GroupSourceCache {
+		t.Errorf("source = %q, want %q", source, types.GroupSourceCache)
+	}
+	if !degraded {
+		t.Error("degraded = false, want true when the provider fails")
+	}
+	if total != 120 {
+		t.Errorf("total = %d, want 120", total)
+	}
+	if len(groups) != 50 {
+		t.Errorf("len = %d, want 50", len(groups))
+	}
+}
+
+// A provider without group support 404s. That is not a degraded response: the cached groups are
+// all that has ever existed for it.
+func TestListAuthGroupsNotFoundIsNotDegraded(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 10)
+
+	srv := httptest.NewServer(http.HandlerFunc(http.NotFound))
+	t.Cleanup(srv.Close)
+
+	groups, total, source, degraded, err := c.ListAuthGroups(
+		t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName,
+		ListAuthGroupsOptions{Limit: 50, Offset: 0},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if source != types.GroupSourceCache {
+		t.Errorf("source = %q, want %q", source, types.GroupSourceCache)
+	}
+	if degraded {
+		t.Error("degraded = true, want false for a provider without group support")
+	}
+	if total != 10 || len(groups) != 10 {
+		t.Errorf("total/len = %d/%d, want 10/10", total, len(groups))
+	}
+}
+
+// A provider predating pagination ignores the limit and returns a bare array; Obot must page it.
+func TestListAuthGroupsHandlesUnpaginatedProvider(t *testing.T) {
+	c := newTestClient(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		all := make([]auth.GroupInfo, 0, 300)
+		for i := range 300 {
+			all = append(all, auth.GroupInfo{ID: fmt.Sprintf("entra/%04d", i), Name: fmt.Sprintf("group-%04d", i)})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(all)
+	}))
+	t.Cleanup(srv.Close)
+
+	groups, total, source, _, err := c.ListAuthGroups(
+		t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName,
+		ListAuthGroupsOptions{Limit: 25, Offset: 275},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if source != types.GroupSourceProvider {
+		t.Errorf("source = %q, want %q", source, types.GroupSourceProvider)
+	}
+	if total != 300 {
+		t.Errorf("total = %d, want 300", total)
+	}
+	if len(groups) != 25 {
+		t.Fatalf("len = %d, want 25", len(groups))
+	}
+	if groups[0].ID != "entra/0275" {
+		t.Errorf("first = %s, want entra/0275", groups[0].ID)
+	}
+}
+
+func TestListAuthGroupsCachePagingBoundaries(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 120)
+
+	tests := []struct {
+		name          string
+		limit, offset int
+		wantLen       int
+		wantFirst     string
+	}{
+		{
+			name:      "first page",
+			limit:     50,
+			offset:    0,
+			wantLen:   50,
+			wantFirst: "entra/0000",
+		},
+		{
+			name:      "partial last page",
+			limit:     50,
+			offset:    100,
+			wantLen:   20,
+			wantFirst: "entra/0100",
+		},
+		{
+			name:    "offset at end",
+			limit:   50,
+			offset:  120,
+			wantLen: 0,
+		},
+		{
+			name:    "offset past end",
+			limit:   50,
+			offset:  9999,
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups, total, _, _, err := c.ListAuthGroups(
+				t.Context(), "", testAuthProviderNamespace, testAuthProviderName,
+				ListAuthGroupsOptions{Limit: tt.limit, Offset: tt.offset},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if total != 120 {
+				t.Errorf("total = %d, want 120", total)
+			}
+			if len(groups) != tt.wantLen {
+				t.Fatalf("len = %d, want %d", len(groups), tt.wantLen)
+			}
+			if tt.wantLen > 0 && groups[0].ID != tt.wantFirst {
+				t.Errorf("first = %s, want %s", groups[0].ID, tt.wantFirst)
+			}
+		})
+	}
+}
+
+func TestListAuthGroupsCacheNameFilterAffectsTotal(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 120)
+
+	_, total, _, _, err := c.ListAuthGroups(
+		t.Context(), "", testAuthProviderNamespace, testAuthProviderName,
+		ListAuthGroupsOptions{NameFilter: "group-001", Limit: 50, Offset: 0},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// group-0010 through group-0019.
+	if total != 10 {
+		t.Errorf("total = %d, want 10 (the filtered count, not the full 120)", total)
+	}
+}
+
+func TestResolveAuthGroups(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 20)
+
+	t.Run("resolves known IDs to names", func(t *testing.T) {
+		groups, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName,
+			[]string{"entra/0003", "entra/0007"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(groups) != 2 {
+			t.Fatalf("len = %d, want 2", len(groups))
+		}
+		if groups[0].Name != "group-0003" || groups[1].Name != "group-0007" {
+			t.Errorf("names = %q/%q, want group-0003/group-0007", groups[0].Name, groups[1].Name)
+		}
+	})
+
+	// An assignment on a group the cache has never seen must still produce a row, otherwise it
+	// disappears from the Group Role Assignments table entirely.
+	t.Run("unknown IDs are returned rather than dropped", func(t *testing.T) {
+		groups, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName,
+			[]string{"entra/0003", "entra/9999"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(groups) != 2 {
+			t.Fatalf("len = %d, want 2", len(groups))
+		}
+		if groups[1].ID != "entra/9999" || groups[1].Name != "entra/9999" {
+			t.Errorf("unresolved group = %+v, want ID and Name both entra/9999", groups[1])
+		}
+	})
+
+	t.Run("preserves requested order", func(t *testing.T) {
+		want := []string{"entra/0005", "entra/0001", "entra/0009"}
+		groups, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName, want)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for i, id := range want {
+			if groups[i].ID != id {
+				t.Errorf("position %d = %s, want %s", i, groups[i].ID, id)
+			}
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		groups, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(groups) != 0 {
+			t.Errorf("len = %d, want 0", len(groups))
+		}
+	})
+}

--- a/pkg/gateway/client/group_test.go
+++ b/pkg/gateway/client/group_test.go
@@ -37,8 +37,16 @@ func seedGroups(t *testing.T, c *Client, n int) {
 	}
 }
 
-// newProviderStub serves the paginated /obot-list-auth-groups contract over `total` groups.
-func newProviderStub(t *testing.T, total int) *httptest.Server {
+// providerStub serves the cursor-based /obot-list-auth-groups contract over `total` groups, using
+// an offset as its cursor. It records the cursor of every request so tests can assert what the
+// client actually sent.
+type providerStub struct {
+	total    int
+	cursors  []string
+	requests int
+}
+
+func (p *providerStub) server(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,8 +55,12 @@ func newProviderStub(t *testing.T, total int) *httptest.Server {
 			return
 		}
 
-		all := make([]auth.GroupInfo, 0, total)
-		for i := range total {
+		p.requests++
+		cursor := r.URL.Query().Get("cursor")
+		p.cursors = append(p.cursors, cursor)
+
+		all := make([]auth.GroupInfo, 0, p.total)
+		for i := range p.total {
 			all = append(all, auth.GroupInfo{
 				ID:   fmt.Sprintf("entra/%04d", i),
 				Name: fmt.Sprintf("group-%04d", i),
@@ -56,283 +68,408 @@ func newProviderStub(t *testing.T, total int) *httptest.Server {
 		}
 
 		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
-		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		start := 0
+		if cursor != "" {
+			start, _ = strconv.Atoi(cursor)
+		}
+		start = min(start, len(all))
+		end := min(start+limit, len(all))
 
-		items := []auth.GroupInfo{}
-		if offset < len(all) {
-			items = all[offset:min(offset+limit, len(all))]
+		body := map[string]any{"items": all[start:end]}
+		if end < len(all) {
+			body["nextCursor"] = strconv.Itoa(end)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "total": len(all)})
+		_ = json.NewEncoder(w).Encode(body)
 	}))
 	t.Cleanup(srv.Close)
 
 	return srv
 }
 
+// walkAll pages the whole listing and returns the IDs it saw, failing on a repeat or a runaway.
+func walkAll(t *testing.T, c *Client, providerURL string, opts ListAuthGroupsOptions) ([]string, ListAuthGroupsResult) {
+	t.Helper()
+
+	var (
+		seen []string
+		last ListAuthGroupsResult
+	)
+	unique := map[string]struct{}{}
+
+	for pages := 0; ; pages++ {
+		if pages > 1000 {
+			t.Fatal("pagination did not terminate")
+		}
+
+		result, err := c.ListAuthGroups(t.Context(), providerURL, testAuthProviderNamespace, testAuthProviderName, opts)
+		if err != nil {
+			t.Fatalf("ListAuthGroups() error = %v", err)
+		}
+		last = result
+
+		for _, group := range result.Groups {
+			if _, ok := unique[group.ID]; ok {
+				t.Fatalf("group %s was returned more than once", group.ID)
+			}
+			unique[group.ID] = struct{}{}
+			seen = append(seen, group.ID)
+		}
+
+		if result.NextCursor == "" {
+			break
+		}
+		opts.Cursor = result.NextCursor
+	}
+
+	return seen, last
+}
+
 // TestListAuthGroupsPagesEntireDirectory is the regression guard for the reported bug: every group
 // in a large directory must be reachable through paging.
 func TestListAuthGroupsPagesEntireDirectory(t *testing.T) {
 	c := newTestClient(t)
-	srv := newProviderStub(t, 10000)
+	stub := &providerStub{total: 10000}
+	srv := stub.server(t)
 
-	seen := make(map[string]struct{}, 10000)
-	for offset := 0; offset < 10000; offset += 50 {
-		groups, total, source, degraded, err := c.ListAuthGroups(
-			t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName,
-			ListAuthGroupsOptions{Limit: 50, Offset: offset},
-		)
-		if err != nil {
-			t.Fatalf("offset %d: unexpected error: %v", offset, err)
-		}
-		if total != 10000 {
-			t.Fatalf("offset %d: total = %d, want 10000", offset, total)
-		}
-		if source != types.GroupSourceProvider {
-			t.Fatalf("offset %d: source = %q, want %q", offset, source, types.GroupSourceProvider)
-		}
-		if degraded {
-			t.Fatalf("offset %d: degraded = true, want false", offset)
-		}
-
-		for _, group := range groups {
-			if _, dup := seen[group.ID]; dup {
-				t.Fatalf("group %s returned on more than one page", group.ID)
-			}
-			seen[group.ID] = struct{}{}
-		}
-	}
+	seen, _ := walkAll(t, c, srv.URL, ListAuthGroupsOptions{Limit: 100})
 
 	if len(seen) != 10000 {
-		t.Fatalf("paged over %d groups, want 10000", len(seen))
+		t.Errorf("collected %d groups, want 10000", len(seen))
+	}
+	// One request per page and no more: the client must never enumerate on the provider's behalf.
+	if stub.requests != 100 {
+		t.Errorf("made %d provider requests, want 100", stub.requests)
+	}
+	if stub.cursors[0] != "" {
+		t.Errorf("the first request carried cursor %q, want none", stub.cursors[0])
+	}
+}
+
+func TestListAuthGroupsForwardsProviderCursor(t *testing.T) {
+	c := newTestClient(t)
+	stub := &providerStub{total: 500}
+	srv := stub.server(t)
+
+	first, err := c.ListAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+	if first.NextCursor == "" {
+		t.Fatal("NextCursor should be set when more groups remain")
+	}
+	// The provider's own cursor must not leak to callers unwrapped.
+	if first.NextCursor == "50" {
+		t.Error("the provider cursor should be wrapped, not passed through verbatim")
+	}
+
+	if _, err = c.ListAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50, Cursor: first.NextCursor}); err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+	if got := stub.cursors[1]; got != "50" {
+		t.Errorf("the provider received cursor %q, want %q", got, "50")
+	}
+}
+
+// A cursor is bound to the search it was minted for. Changing the filter restarts the listing
+// rather than returning a page from the wrong result set.
+func TestListAuthGroupsResetsWhenNameFilterChanges(t *testing.T) {
+	c := newTestClient(t)
+	stub := &providerStub{total: 500}
+	srv := stub.server(t)
+
+	first, err := c.ListAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50, NameFilter: "eng"})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+
+	if _, err = c.ListAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{
+		Limit:      50,
+		NameFilter: "sales",
+		Cursor:     first.NextCursor,
+	}); err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+
+	if got := stub.cursors[1]; got != "" {
+		t.Errorf("the provider received cursor %q after the filter changed, want none", got)
+	}
+}
+
+// A cursor minted while the provider was serving must not be replayed against the cache, and vice
+// versa, because neither can interpret the other's position.
+func TestListAuthGroupsIgnoresCursorFromTheOtherSource(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 120)
+	stub := &providerStub{total: 500}
+	srv := stub.server(t)
+
+	fromProvider, err := c.ListAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+
+	// Same cursor, but now there is no provider, so the cache answers.
+	fromCache, err := c.ListAuthGroups(t.Context(), "", testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50, Cursor: fromProvider.NextCursor})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+
+	if fromCache.Source != types.GroupSourceCache {
+		t.Fatalf("Source = %q, want %q", fromCache.Source, types.GroupSourceCache)
+	}
+	if len(fromCache.Groups) == 0 {
+		t.Fatal("expected a page of cached groups")
+	}
+	if got, want := fromCache.Groups[0].ID, "entra/0000"; got != want {
+		t.Errorf("first group = %q, want %q; a provider cursor should restart the cached listing", got, want)
 	}
 }
 
 func TestListAuthGroupsFallsBackToCacheOnProviderError(t *testing.T) {
 	c := newTestClient(t)
-	seedGroups(t, c, 120)
+	seedGroups(t, c, 10)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "directory read permission not granted", http.StatusForbidden)
+		http.Error(w, "boom", http.StatusInternalServerError)
 	}))
 	t.Cleanup(srv.Close)
 
-	groups, total, source, degraded, err := c.ListAuthGroups(
-		t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName,
-		ListAuthGroupsOptions{Limit: 50, Offset: 0},
-	)
+	result, err := c.ListAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("ListAuthGroups() error = %v", err)
 	}
-	if source != types.GroupSourceCache {
-		t.Errorf("source = %q, want %q", source, types.GroupSourceCache)
+
+	if result.Source != types.GroupSourceCache {
+		t.Errorf("Source = %q, want %q", result.Source, types.GroupSourceCache)
 	}
-	if !degraded {
-		t.Error("degraded = false, want true when the provider fails")
+	if !result.Degraded {
+		t.Error("Degraded should be true when the provider could not be listed")
 	}
-	if total != 120 {
-		t.Errorf("total = %d, want 120", total)
-	}
-	if len(groups) != 50 {
-		t.Errorf("len = %d, want 50", len(groups))
+	if len(result.Groups) != 10 {
+		t.Errorf("got %d groups, want 10", len(result.Groups))
 	}
 }
 
-// A provider without group support 404s. That is not a degraded response: the cached groups are
-// all that has ever existed for it.
-func TestListAuthGroupsNotFoundIsNotDegraded(t *testing.T) {
+// A provider that rejects the cursor has usually expired its own continuation token. That is a
+// restart, not an outage, so the listing must come back from the provider rather than the cache.
+func TestListAuthGroupsRetriesFromFirstPageOnRejectedCursor(t *testing.T) {
 	c := newTestClient(t)
 	seedGroups(t, c, 10)
 
-	srv := httptest.NewServer(http.HandlerFunc(http.NotFound))
-	t.Cleanup(srv.Close)
-
-	groups, total, source, degraded, err := c.ListAuthGroups(
-		t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName,
-		ListAuthGroupsOptions{Limit: 50, Offset: 0},
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if source != types.GroupSourceCache {
-		t.Errorf("source = %q, want %q", source, types.GroupSourceCache)
-	}
-	if degraded {
-		t.Error("degraded = true, want false for a provider without group support")
-	}
-	if total != 10 || len(groups) != 10 {
-		t.Errorf("total/len = %d/%d, want 10/10", total, len(groups))
-	}
-}
-
-// A provider predating pagination ignores the limit and returns a bare array; Obot must page it.
-func TestListAuthGroupsHandlesUnpaginatedProvider(t *testing.T) {
-	c := newTestClient(t)
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		all := make([]auth.GroupInfo, 0, 300)
-		for i := range 300 {
-			all = append(all, auth.GroupInfo{ID: fmt.Sprintf("entra/%04d", i), Name: fmt.Sprintf("group-%04d", i)})
+	var requests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Query().Get("cursor") != "" {
+			http.Error(w, "invalid cursor", http.StatusBadRequest)
+			return
 		}
+
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(all)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []auth.GroupInfo{{ID: "entra/0000", Name: "group-0000"}},
+		})
 	}))
 	t.Cleanup(srv.Close)
 
-	groups, total, source, _, err := c.ListAuthGroups(
-		t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName,
-		ListAuthGroupsOptions{Limit: 25, Offset: 275},
-	)
+	stale, err := encodeGroupCursor(groupCursor{Source: types.GroupSourceProvider, ProviderCursor: "999"})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("encodeGroupCursor() error = %v", err)
 	}
-	if source != types.GroupSourceProvider {
-		t.Errorf("source = %q, want %q", source, types.GroupSourceProvider)
+
+	result, err := c.ListAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50, Cursor: stale})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
 	}
-	if total != 300 {
-		t.Errorf("total = %d, want 300", total)
+
+	if result.Source != types.GroupSourceProvider {
+		t.Errorf("Source = %q, want %q; an expired cursor should restart, not degrade", result.Source, types.GroupSourceProvider)
 	}
-	if len(groups) != 25 {
-		t.Fatalf("len = %d, want 25", len(groups))
+	if result.Degraded {
+		t.Error("Degraded should be false when the retry succeeded")
 	}
-	if groups[0].ID != "entra/0275" {
-		t.Errorf("first = %s, want entra/0275", groups[0].ID)
+	if requests != 2 {
+		t.Errorf("made %d requests, want 2 (the rejected cursor then the restart)", requests)
 	}
 }
 
-func TestListAuthGroupsCachePagingBoundaries(t *testing.T) {
+func TestListAuthGroupsNotFoundIsNotDegraded(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 3)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	result, err := c.ListAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+
+	if result.Source != types.GroupSourceCache {
+		t.Errorf("Source = %q, want %q", result.Source, types.GroupSourceCache)
+	}
+	// A provider without group support has nothing to be degraded from.
+	if result.Degraded {
+		t.Error("Degraded should be false when the provider does not implement group listing")
+	}
+}
+
+func TestListAuthGroupsCachePagesEveryGroupExactlyOnce(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 250)
+
+	seen, _ := walkAll(t, c, "", ListAuthGroupsOptions{Limit: 50})
+
+	if len(seen) != 250 {
+		t.Errorf("collected %d groups, want 250", len(seen))
+	}
+	for i, id := range seen {
+		if want := fmt.Sprintf("entra/%04d", i); id != want {
+			t.Fatalf("group at position %d = %q, want %q", i, id, want)
+		}
+	}
+}
+
+// Keyset paging orders by (name, id), so groups sharing a name must not shadow one another.
+func TestListAuthGroupsCachePagesDuplicateNames(t *testing.T) {
+	c := newTestClient(t)
+
+	groups := []types.Group{
+		{ID: "entra/a", AuthProviderName: testAuthProviderName, AuthProviderNamespace: testAuthProviderNamespace, Name: "duplicate"},
+		{ID: "entra/b", AuthProviderName: testAuthProviderName, AuthProviderNamespace: testAuthProviderNamespace, Name: "duplicate"},
+		{ID: "entra/c", AuthProviderName: testAuthProviderName, AuthProviderNamespace: testAuthProviderNamespace, Name: "duplicate"},
+	}
+	if err := c.db.WithContext(t.Context()).Create(&groups).Error; err != nil {
+		t.Fatalf("failed to seed groups: %v", err)
+	}
+
+	// A page size of one forces the tiebreak to do the work.
+	seen, _ := walkAll(t, c, "", ListAuthGroupsOptions{Limit: 1})
+
+	if len(seen) != 3 {
+		t.Errorf("collected %d groups, want 3; the id tiebreak should separate identical names", len(seen))
+	}
+}
+
+func TestListAuthGroupsCacheLastPageHasNoCursor(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 50)
+
+	result, err := c.ListAuthGroups(t.Context(), "", testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+
+	if len(result.Groups) != 50 {
+		t.Errorf("got %d groups, want 50", len(result.Groups))
+	}
+	// Exactly one full page and nothing beyond it.
+	if result.NextCursor != "" {
+		t.Error("an exactly-full final page should not advertise a successor")
+	}
+}
+
+func TestListAuthGroupsCacheNameFilter(t *testing.T) {
 	c := newTestClient(t)
 	seedGroups(t, c, 120)
 
+	seen, _ := walkAll(t, c, "", ListAuthGroupsOptions{Limit: 50, NameFilter: "group-001"})
+
+	// group-0010 through group-0019, plus group-0011's siblings: ten matches in total.
+	if len(seen) != 10 {
+		t.Errorf("collected %d groups, want 10", len(seen))
+	}
+}
+
+func TestGroupCursorRoundTrip(t *testing.T) {
+	original := groupCursor{Source: types.GroupSourceCache, FilterFingerprint: groupFilterFingerprint("eng"), LastName: "group-0010", LastID: "entra/0010"}
+
+	encoded, err := encodeGroupCursor(original)
+	if err != nil {
+		t.Fatalf("encodeGroupCursor() error = %v", err)
+	}
+
+	decoded, ok := decodeGroupCursor(encoded, "eng")
+	if !ok {
+		t.Fatal("decodeGroupCursor() reported the cursor as unusable")
+	}
+	if decoded.LastName != original.LastName || decoded.LastID != original.LastID || decoded.Source != original.Source {
+		t.Errorf("decoded = %+v, want %+v", decoded, original)
+	}
+}
+
+func TestDecodeGroupCursorRejectsUnusableCursors(t *testing.T) {
+	valid, err := encodeGroupCursor(groupCursor{Source: types.GroupSourceCache, FilterFingerprint: groupFilterFingerprint("eng"), LastName: "n", LastID: "i"})
+	if err != nil {
+		t.Fatalf("encodeGroupCursor() error = %v", err)
+	}
+
 	tests := []struct {
-		name          string
-		limit, offset int
-		wantLen       int
-		wantFirst     string
+		name   string
+		cursor string
+		filter string
 	}{
 		{
-			name:      "first page",
-			limit:     50,
-			offset:    0,
-			wantLen:   50,
-			wantFirst: "entra/0000",
+			name:   "empty",
+			cursor: "",
+			filter: "eng",
 		},
 		{
-			name:      "partial last page",
-			limit:     50,
-			offset:    100,
-			wantLen:   20,
-			wantFirst: "entra/0100",
+			name:   "not base64",
+			cursor: "not!base64",
+			filter: "eng",
 		},
 		{
-			name:    "offset at end",
-			limit:   50,
-			offset:  120,
-			wantLen: 0,
+			name:   "filter changed",
+			cursor: valid,
+			filter: "sales",
 		},
 		{
-			name:    "offset past end",
-			limit:   50,
-			offset:  9999,
-			wantLen: 0,
+			name:   "filter dropped",
+			cursor: valid,
+			filter: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			groups, total, _, _, err := c.ListAuthGroups(
-				t.Context(), "", testAuthProviderNamespace, testAuthProviderName,
-				ListAuthGroupsOptions{Limit: tt.limit, Offset: tt.offset},
-			)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if total != 120 {
-				t.Errorf("total = %d, want 120", total)
-			}
-			if len(groups) != tt.wantLen {
-				t.Fatalf("len = %d, want %d", len(groups), tt.wantLen)
-			}
-			if tt.wantLen > 0 && groups[0].ID != tt.wantFirst {
-				t.Errorf("first = %s, want %s", groups[0].ID, tt.wantFirst)
+			if _, ok := decodeGroupCursor(tt.cursor, tt.filter); ok {
+				t.Error("decodeGroupCursor() accepted a cursor it should have rejected")
 			}
 		})
 	}
 }
 
-func TestListAuthGroupsCacheNameFilterAffectsTotal(t *testing.T) {
-	c := newTestClient(t)
-	seedGroups(t, c, 120)
-
-	_, total, _, _, err := c.ListAuthGroups(
-		t.Context(), "", testAuthProviderNamespace, testAuthProviderName,
-		ListAuthGroupsOptions{NameFilter: "group-001", Limit: 50, Offset: 0},
-	)
+func TestEncodeGroupCursorEmptyPositionIsEmpty(t *testing.T) {
+	encoded, err := encodeGroupCursor(groupCursor{Source: types.GroupSourceCache, FilterFingerprint: groupFilterFingerprint("eng")})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("encodeGroupCursor() error = %v", err)
 	}
-
-	// group-0010 through group-0019.
-	if total != 10 {
-		t.Errorf("total = %d, want 10 (the filtered count, not the full 120)", total)
+	if encoded != "" {
+		t.Errorf("encodeGroupCursor() = %q, want an empty cursor when there is no position", encoded)
 	}
 }
 
 func TestResolveAuthGroups(t *testing.T) {
 	c := newTestClient(t)
-	seedGroups(t, c, 20)
+	seedGroups(t, c, 5)
 
-	t.Run("resolves known IDs to names", func(t *testing.T) {
-		groups, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName,
-			[]string{"entra/0003", "entra/0007"})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(groups) != 2 {
-			t.Fatalf("len = %d, want 2", len(groups))
-		}
-		if groups[0].Name != "group-0003" || groups[1].Name != "group-0007" {
-			t.Errorf("names = %q/%q, want group-0003/group-0007", groups[0].Name, groups[1].Name)
-		}
-	})
+	resolved, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName, []string{"entra/0001", "entra/9999"})
+	if err != nil {
+		t.Fatalf("ResolveAuthGroups() error = %v", err)
+	}
 
-	// An assignment on a group the cache has never seen must still produce a row, otherwise it
-	// disappears from the Group Role Assignments table entirely.
-	t.Run("unknown IDs are returned rather than dropped", func(t *testing.T) {
-		groups, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName,
-			[]string{"entra/0003", "entra/9999"})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(groups) != 2 {
-			t.Fatalf("len = %d, want 2", len(groups))
-		}
-		if groups[1].ID != "entra/9999" || groups[1].Name != "entra/9999" {
-			t.Errorf("unresolved group = %+v, want ID and Name both entra/9999", groups[1])
-		}
-	})
-
-	t.Run("preserves requested order", func(t *testing.T) {
-		want := []string{"entra/0005", "entra/0001", "entra/0009"}
-		groups, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName, want)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		for i, id := range want {
-			if groups[i].ID != id {
-				t.Errorf("position %d = %s, want %s", i, groups[i].ID, id)
-			}
-		}
-	})
-
-	t.Run("empty input", func(t *testing.T) {
-		groups, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(groups) != 0 {
-			t.Errorf("len = %d, want 0", len(groups))
-		}
-	})
+	if len(resolved) != 2 {
+		t.Fatalf("got %d groups, want 2", len(resolved))
+	}
+	if resolved[0].Name != "group-0001" {
+		t.Errorf("known group name = %q, want %q", resolved[0].Name, "group-0001")
+	}
+	// An unknown ID renders as itself rather than being dropped.
+	if resolved[1].Name != "entra/9999" {
+		t.Errorf("unknown group name = %q, want the ID itself", resolved[1].Name)
+	}
 }

--- a/pkg/gateway/client/group_test.go
+++ b/pkg/gateway/client/group_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/obot-platform/obot/pkg/auth"
@@ -378,7 +379,7 @@ func TestListAuthGroupsCacheNameFilter(t *testing.T) {
 
 	seen, _ := walkAll(t, c, "", ListAuthGroupsOptions{Limit: 50, NameFilter: "group-001"})
 
-	// group-0010 through group-0019, plus group-0011's siblings: ten matches in total.
+	// group-0010 through group-0019: ten matches.
 	if len(seen) != 10 {
 		t.Errorf("collected %d groups, want 10", len(seen))
 	}
@@ -457,7 +458,7 @@ func TestResolveAuthGroups(t *testing.T) {
 	c := newTestClient(t)
 	seedGroups(t, c, 5)
 
-	resolved, err := c.ResolveAuthGroups(t.Context(), testAuthProviderNamespace, testAuthProviderName, []string{"entra/0001", "entra/9999"})
+	resolved, err := c.ResolveAuthGroups(t.Context(), "", testAuthProviderNamespace, testAuthProviderName, []string{"entra/0001", "entra/9999"})
 	if err != nil {
 		t.Fatalf("ResolveAuthGroups() error = %v", err)
 	}
@@ -471,5 +472,236 @@ func TestResolveAuthGroups(t *testing.T) {
 	// An unknown ID renders as itself rather than being dropped.
 	if resolved[1].Name != "entra/9999" {
 		t.Errorf("unknown group name = %q, want the ID itself", resolved[1].Name)
+	}
+}
+
+// resolverStub serves the /obot-get-auth-groups contract, naming every ID it is asked about except
+// those in unknown. It records each batch so tests can assert what the client actually sent.
+type resolverStub struct {
+	unknown  map[string]bool
+	requests [][]string
+	status   int
+}
+
+func (s *resolverStub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/obot-get-auth-groups" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if s.status != 0 {
+			w.WriteHeader(s.status)
+			return
+		}
+
+		ids := strings.Split(r.URL.Query().Get("ids"), ",")
+		s.requests = append(s.requests, ids)
+
+		items := make([]auth.GroupInfo, 0, len(ids))
+		for _, id := range ids {
+			if s.unknown[id] {
+				continue
+			}
+			items = append(items, auth.GroupInfo{ID: id, Name: "Directory " + id})
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func TestResolveAuthGroupsFallsBackToTheProvider(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 5)
+
+	stub := &resolverStub{}
+	srv := stub.server(t)
+
+	// entra/0001 is cached; entra/9999 has never been seen at sign-in and only the provider knows it.
+	resolved, err := c.ResolveAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, []string{"entra/0001", "entra/9999"})
+	if err != nil {
+		t.Fatalf("ResolveAuthGroups() error = %v", err)
+	}
+
+	if len(resolved) != 2 {
+		t.Fatalf("got %d groups, want 2", len(resolved))
+	}
+	if resolved[0].Name != "group-0001" {
+		t.Errorf("cached group name = %q, want %q", resolved[0].Name, "group-0001")
+	}
+	if resolved[1].Name != "Directory entra/9999" {
+		t.Errorf("provider-resolved name = %q, want the directory name", resolved[1].Name)
+	}
+
+	// Only the ID the cache could not answer for is worth asking about.
+	if len(stub.requests) != 1 {
+		t.Fatalf("made %d provider requests, want 1", len(stub.requests))
+	}
+	if len(stub.requests[0]) != 1 || stub.requests[0][0] != "entra/9999" {
+		t.Errorf("asked the provider for %v, want only the uncached id", stub.requests[0])
+	}
+}
+
+func TestResolveAuthGroupsCachesWhatTheProviderResolved(t *testing.T) {
+	c := newTestClient(t)
+
+	stub := &resolverStub{}
+	srv := stub.server(t)
+
+	if _, err := c.ResolveAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, []string{"entra/9999"}); err != nil {
+		t.Fatalf("ResolveAuthGroups() error = %v", err)
+	}
+
+	// The second call is served from the table, so the provider is not asked again.
+	resolved, err := c.ResolveAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, []string{"entra/9999"})
+	if err != nil {
+		t.Fatalf("ResolveAuthGroups() error = %v", err)
+	}
+
+	if resolved[0].Name != "Directory entra/9999" {
+		t.Errorf("name = %q, want the directory name to have been cached", resolved[0].Name)
+	}
+	if len(stub.requests) != 1 {
+		t.Errorf("made %d provider requests, want 1; the first answer should have been cached", len(stub.requests))
+	}
+}
+
+func TestResolveAuthGroupsDegradesToIDs(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{
+			name:   "provider does not implement resolution",
+			status: http.StatusNotFound,
+		},
+		{
+			name:   "provider is failing",
+			status: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestClient(t)
+
+			stub := &resolverStub{status: tt.status}
+			srv := stub.server(t)
+
+			resolved, err := c.ResolveAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, []string{"entra/9999"})
+			if err != nil {
+				t.Fatalf("resolution is best effort and should not fail the caller: %v", err)
+			}
+
+			if len(resolved) != 1 {
+				t.Fatalf("got %d groups, want 1", len(resolved))
+			}
+			if resolved[0].Name != "entra/9999" {
+				t.Errorf("name = %q, want the ID itself", resolved[0].Name)
+			}
+		})
+	}
+}
+
+func TestResolveAuthGroupsKeepsUnknownIDsWhenTheProviderHasNoAnswer(t *testing.T) {
+	c := newTestClient(t)
+
+	stub := &resolverStub{unknown: map[string]bool{"entra/deleted": true}}
+	srv := stub.server(t)
+
+	resolved, err := c.ResolveAuthGroups(t.Context(), srv.URL, testAuthProviderNamespace, testAuthProviderName, []string{"entra/deleted"})
+	if err != nil {
+		t.Fatalf("ResolveAuthGroups() error = %v", err)
+	}
+
+	// A group deleted in the directory still has a policy pointing at it, so the row has to render.
+	if len(resolved) != 1 || resolved[0].Name != "entra/deleted" {
+		t.Errorf("resolved = %+v, want the ID rendered as its own name", resolved)
+	}
+}
+
+func TestListAuthGroupsCacheEmptyPageIsNotNil(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 5)
+
+	result, err := c.ListAuthGroups(t.Context(), "", testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50, NameFilter: "nothing-matches-this"})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+
+	// Not just empty: non-nil, so that the response serializes items as [] rather than null.
+	if result.Groups == nil {
+		t.Error("an empty page should be an empty slice, not nil")
+	}
+	if len(result.Groups) != 0 {
+		t.Errorf("got %d groups, want 0", len(result.Groups))
+	}
+}
+
+func TestListAuthGroupsCacheDefaultsAnUnsetLimit(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 5)
+
+	// Limit is exported and a caller can leave it unset; the truncation below it must not run off
+	// the end of the slice.
+	result, err := c.ListAuthGroups(t.Context(), "", testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+
+	if len(result.Groups) != 5 {
+		t.Errorf("got %d groups, want 5", len(result.Groups))
+	}
+}
+
+func TestListAuthGroupsReportsACursorItCouldNotHonor(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 120)
+
+	// A cursor minted by the provider says nothing about a position in the cached table, so the
+	// cached listing starts over. The caller has to be told, or it labels page one as page two.
+	providerCursor, err := encodeGroupCursor(groupCursor{
+		Source:         types.GroupSourceProvider,
+		ProviderCursor: "some-provider-token",
+	})
+	if err != nil {
+		t.Fatalf("encodeGroupCursor() error = %v", err)
+	}
+
+	result, err := c.ListAuthGroups(t.Context(), "", testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50, Cursor: providerCursor})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+
+	if !result.Reset {
+		t.Error("a cursor that could not be honored should be reported as a reset")
+	}
+	if len(result.Groups) == 0 || result.Groups[0].Name != "group-0000" {
+		t.Error("the listing should have restarted at the first page")
+	}
+}
+
+func TestListAuthGroupsDoesNotReportAResetWhenTheCursorWasHonored(t *testing.T) {
+	c := newTestClient(t)
+	seedGroups(t, c, 120)
+
+	first, err := c.ListAuthGroups(t.Context(), "", testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+	if first.Reset {
+		t.Error("a first page was not asked to continue from anywhere and cannot be a reset")
+	}
+
+	second, err := c.ListAuthGroups(t.Context(), "", testAuthProviderNamespace, testAuthProviderName, ListAuthGroupsOptions{Limit: 50, Cursor: first.NextCursor})
+	if err != nil {
+		t.Fatalf("ListAuthGroups() error = %v", err)
+	}
+	if second.Reset {
+		t.Error("a cursor the cache minted itself should be honored, not reset")
 	}
 }

--- a/pkg/gateway/server/group_test.go
+++ b/pkg/gateway/server/group_test.go
@@ -10,30 +10,27 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
-func TestParseGroupPageParams(t *testing.T) {
+func TestParseGroupListParams(t *testing.T) {
 	tests := []struct {
 		name       string
 		query      string
 		wantLimit  int
-		wantOffset int
+		wantCursor string
 	}{
 		{
-			name:       "defaults when absent",
-			query:      "",
-			wantLimit:  defaultGroupPageSize,
-			wantOffset: 0,
+			name:      "defaults when absent",
+			query:     "",
+			wantLimit: defaultGroupPageSize,
 		},
 		{
-			name:       "explicit values",
-			query:      "limit=25&offset=100",
-			wantLimit:  25,
-			wantOffset: 100,
+			name:      "explicit limit",
+			query:     "limit=25",
+			wantLimit: 25,
 		},
 		{
-			name:       "limit capped",
-			query:      "limit=100000",
-			wantLimit:  maxGroupPageSize,
-			wantOffset: 0,
+			name:      "limit capped",
+			query:     "limit=100000",
+			wantLimit: maxGroupPageSize,
 		},
 		{
 			name:      "zero limit falls back to default",
@@ -51,16 +48,10 @@ func TestParseGroupPageParams(t *testing.T) {
 			wantLimit: defaultGroupPageSize,
 		},
 		{
-			name:       "negative offset clamps",
-			query:      "limit=10&offset=-5",
+			name:       "cursor is carried through opaquely",
+			query:      "limit=10&cursor=eyJ2IjoxfQ",
 			wantLimit:  10,
-			wantOffset: 0,
-		},
-		{
-			name:       "unparseable offset clamps",
-			query:      "limit=10&offset=abc",
-			wantLimit:  10,
-			wantOffset: 0,
+			wantCursor: "eyJ2IjoxfQ",
 		},
 	}
 
@@ -71,12 +62,12 @@ func TestParseGroupPageParams(t *testing.T) {
 				t.Fatalf("bad test query: %v", err)
 			}
 
-			limit, offset := parseGroupPageParams(query)
+			limit, cursor := parseGroupListParams(query)
 			if limit != tt.wantLimit {
 				t.Errorf("limit = %d, want %d", limit, tt.wantLimit)
 			}
-			if offset != tt.wantOffset {
-				t.Errorf("offset = %d, want %d", offset, tt.wantOffset)
+			if cursor != tt.wantCursor {
+				t.Errorf("cursor = %q, want %q", cursor, tt.wantCursor)
 			}
 		})
 	}

--- a/pkg/gateway/server/group_test.go
+++ b/pkg/gateway/server/group_test.go
@@ -1,0 +1,176 @@
+package server
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/gateway/types"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestParseGroupPageParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantLimit  int
+		wantOffset int
+	}{
+		{
+			name:       "defaults when absent",
+			query:      "",
+			wantLimit:  defaultGroupPageSize,
+			wantOffset: 0,
+		},
+		{
+			name:       "explicit values",
+			query:      "limit=25&offset=100",
+			wantLimit:  25,
+			wantOffset: 100,
+		},
+		{
+			name:       "limit capped",
+			query:      "limit=100000",
+			wantLimit:  maxGroupPageSize,
+			wantOffset: 0,
+		},
+		{
+			name:      "zero limit falls back to default",
+			query:     "limit=0",
+			wantLimit: defaultGroupPageSize,
+		},
+		{
+			name:      "negative limit falls back to default",
+			query:     "limit=-1",
+			wantLimit: defaultGroupPageSize,
+		},
+		{
+			name:      "unparseable limit falls back to default",
+			query:     "limit=many",
+			wantLimit: defaultGroupPageSize,
+		},
+		{
+			name:       "negative offset clamps",
+			query:      "limit=10&offset=-5",
+			wantLimit:  10,
+			wantOffset: 0,
+		},
+		{
+			name:       "unparseable offset clamps",
+			query:      "limit=10&offset=abc",
+			wantLimit:  10,
+			wantOffset: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, err := url.ParseQuery(tt.query)
+			if err != nil {
+				t.Fatalf("bad test query: %v", err)
+			}
+
+			limit, offset := parseGroupPageParams(query)
+			if limit != tt.wantLimit {
+				t.Errorf("limit = %d, want %d", limit, tt.wantLimit)
+			}
+			if offset != tt.wantOffset {
+				t.Errorf("offset = %d, want %d", offset, tt.wantOffset)
+			}
+		})
+	}
+}
+
+func TestSplitGroupIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "single",
+			raw:  "entra/a",
+			want: []string{"entra/a"},
+		},
+		{
+			name: "multiple",
+			raw:  "entra/a,entra/b",
+			want: []string{"entra/a", "entra/b"},
+		},
+		{
+			name: "trims whitespace",
+			raw:  " entra/a , entra/b ",
+			want: []string{"entra/a", "entra/b"},
+		},
+		{
+			name: "drops blanks",
+			raw:  "entra/a,,entra/b,",
+			want: []string{"entra/a", "entra/b"},
+		},
+		{
+			name: "drops duplicates",
+			raw:  "entra/a,entra/b,entra/a",
+			want: []string{"entra/a", "entra/b"},
+		},
+		{
+			name: "all blank",
+			raw:  ",,,",
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitGroupIDs(tt.raw)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("position %d = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitGroupIDsCapsBatchSize(t *testing.T) {
+	ids := make([]string, 0, maxGroupIDsPerRequest*2)
+	for i := range maxGroupIDsPerRequest * 2 {
+		ids = append(ids, fmt.Sprintf("entra/%d", i))
+	}
+
+	if got := splitGroupIDs(strings.Join(ids, ",")); len(got) != maxGroupIDsPerRequest {
+		t.Errorf("len = %d, want %d", len(got), maxGroupIDsPerRequest)
+	}
+}
+
+func TestTrimGroupsForUser(t *testing.T) {
+	groups := []types.Group{{
+		ID:                    "entra/a",
+		Name:                  "Engineering",
+		AuthProviderName:      "entra-auth-provider",
+		AuthProviderNamespace: "default",
+	}}
+
+	t.Run("basic users only see id and name", func(t *testing.T) {
+		got := trimGroupsForUser(&user.DefaultInfo{Groups: []string{"basic"}}, groups)
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		if got[0].ID != "entra/a" || got[0].Name != "Engineering" {
+			t.Errorf("id/name = %q/%q, want entra/a/Engineering", got[0].ID, got[0].Name)
+		}
+		if got[0].AuthProviderName != "" || got[0].AuthProviderNamespace != "" {
+			t.Errorf("auth provider fields leaked: %+v", got[0])
+		}
+	})
+
+	t.Run("admins see everything", func(t *testing.T) {
+		got := trimGroupsForUser(&user.DefaultInfo{Groups: []string{"admin"}}, groups)
+		if got[0].AuthProviderName != "entra-auth-provider" {
+			t.Errorf("AuthProviderName = %q, want entra-auth-provider", got[0].AuthProviderName)
+		}
+	})
+}

--- a/pkg/gateway/server/group_test.go
+++ b/pkg/gateway/server/group_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	types2 "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
@@ -20,7 +22,7 @@ func TestParseGroupListParams(t *testing.T) {
 		{
 			name:      "defaults when absent",
 			query:     "",
-			wantLimit: defaultGroupPageSize,
+			wantLimit: client.DefaultGroupPageSize,
 		},
 		{
 			name:      "explicit limit",
@@ -30,22 +32,22 @@ func TestParseGroupListParams(t *testing.T) {
 		{
 			name:      "limit capped",
 			query:     "limit=100000",
-			wantLimit: maxGroupPageSize,
+			wantLimit: client.MaxGroupPageSize,
 		},
 		{
 			name:      "zero limit falls back to default",
 			query:     "limit=0",
-			wantLimit: defaultGroupPageSize,
+			wantLimit: client.DefaultGroupPageSize,
 		},
 		{
 			name:      "negative limit falls back to default",
 			query:     "limit=-1",
-			wantLimit: defaultGroupPageSize,
+			wantLimit: client.DefaultGroupPageSize,
 		},
 		{
 			name:      "unparseable limit falls back to default",
 			query:     "limit=many",
-			wantLimit: defaultGroupPageSize,
+			wantLimit: client.DefaultGroupPageSize,
 		},
 		{
 			name:       "cursor is carried through opaquely",
@@ -113,7 +115,10 @@ func TestSplitGroupIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := splitGroupIDs(tt.raw)
+			got, err := splitGroupIDs(tt.raw)
+			if err != nil {
+				t.Fatalf("splitGroupIDs() error = %v", err)
+			}
 			if len(got) != len(tt.want) {
 				t.Fatalf("len = %d, want %d (%v)", len(got), len(tt.want), got)
 			}
@@ -126,13 +131,30 @@ func TestSplitGroupIDs(t *testing.T) {
 	}
 }
 
-func TestSplitGroupIDsCapsBatchSize(t *testing.T) {
-	ids := make([]string, 0, maxGroupIDsPerRequest*2)
-	for i := range maxGroupIDsPerRequest * 2 {
+func TestSplitGroupIDsRejectsAnOversizedBatch(t *testing.T) {
+	ids := make([]string, 0, maxGroupIDsPerRequest+1)
+	for i := range maxGroupIDsPerRequest + 1 {
 		ids = append(ids, fmt.Sprintf("entra/%d", i))
 	}
 
-	if got := splitGroupIDs(strings.Join(ids, ",")); len(got) != maxGroupIDsPerRequest {
+	// Silently answering for the first N would leave the caller rendering raw IDs for the rest with
+	// nothing to say why, so the caller has to chunk instead.
+	if _, err := splitGroupIDs(strings.Join(ids, ",")); err == nil {
+		t.Error("expected an error for a batch over the limit")
+	}
+}
+
+func TestSplitGroupIDsAcceptsAFullBatch(t *testing.T) {
+	ids := make([]string, 0, maxGroupIDsPerRequest)
+	for i := range maxGroupIDsPerRequest {
+		ids = append(ids, fmt.Sprintf("entra/%d", i))
+	}
+
+	got, err := splitGroupIDs(strings.Join(ids, ","))
+	if err != nil {
+		t.Fatalf("splitGroupIDs() error = %v", err)
+	}
+	if len(got) != maxGroupIDsPerRequest {
 		t.Errorf("len = %d, want %d", len(got), maxGroupIDsPerRequest)
 	}
 }
@@ -146,7 +168,7 @@ func TestTrimGroupsForUser(t *testing.T) {
 	}}
 
 	t.Run("basic users only see id and name", func(t *testing.T) {
-		got := trimGroupsForUser(&user.DefaultInfo{Groups: []string{"basic"}}, groups)
+		got := trimGroupsForUser(&user.DefaultInfo{Groups: []string{types2.GroupBasic}}, groups)
 		if len(got) != 1 {
 			t.Fatalf("len = %d, want 1", len(got))
 		}
@@ -159,7 +181,15 @@ func TestTrimGroupsForUser(t *testing.T) {
 	})
 
 	t.Run("admins see everything", func(t *testing.T) {
-		got := trimGroupsForUser(&user.DefaultInfo{Groups: []string{"admin"}}, groups)
+		got := trimGroupsForUser(&user.DefaultInfo{Groups: []string{types2.GroupAdmin}}, groups)
+		if got[0].AuthProviderName != "entra-auth-provider" {
+			t.Errorf("AuthProviderName = %q, want entra-auth-provider", got[0].AuthProviderName)
+		}
+	})
+
+	// userIsBasicOrPower counts power-user-plus as privileged, so it sees the untrimmed group.
+	t.Run("power users plus see everything", func(t *testing.T) {
+		got := trimGroupsForUser(&user.DefaultInfo{Groups: []string{types2.GroupPowerUserPlus}}, groups)
 		if got[0].AuthProviderName != "entra-auth-provider" {
 			t.Errorf("AuthProviderName = %q, want entra-auth-provider", got[0].AuthProviderName)
 		}

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,7 +36,7 @@ func (s *Server) getCurrentUser(apiContext api.Context) error {
 	if name != "" && namespace != "" {
 		providerURL, err := s.dispatcher.URLForAuthProvider(apiContext.Context(), namespace, name)
 		if err != nil {
-			return fmt.Errorf("failed to get auth provider URL: %v", err)
+			return fmt.Errorf("failed to get auth provider URL: %w", err)
 		}
 		if err = apiContext.GatewayClient.UpdateProfileIfNeeded(apiContext.Context(), user, name, namespace, providerURL.String()); err != nil {
 			slog.Warn("failed to update profile icon for user", "username", user.Username, "error", err)
@@ -342,41 +344,132 @@ func (s *Server) deleteUser(apiContext api.Context) (err error) {
 	return apiContext.Write(types.ConvertUser(existingUser, apiContext.GatewayClient.HasExplicitRole(existingUser.Email) != types2.RoleUnknown, ""))
 }
 
+// GET /api/groups?name=&limit=&offset=&ids=
+// Returns one page of the auth provider's groups, optionally filtered by name. Passing ids instead
+// resolves those specific group IDs to their display names.
 func (s *Server) listAuthGroups(apiContext api.Context) error {
 	name, namespace := apiContext.AuthProviderNameAndNamespace()
 	if name == "" || namespace == "" {
-		return apiContext.Write([]types.Group{})
+		return apiContext.Write(types.GroupListResponse{
+			Items:  []types.Group{},
+			Source: types.GroupSourceCache,
+		})
+	}
+
+	query := apiContext.URL.Query()
+
+	// Resolving specific IDs never needs the provider directory, so handle it before paying for a
+	// provider URL lookup.
+	if rawIDs := query.Get("ids"); rawIDs != "" {
+		ids := splitGroupIDs(rawIDs)
+		groups, err := apiContext.GatewayClient.ResolveAuthGroups(apiContext.Context(), namespace, name, ids)
+		if err != nil {
+			return fmt.Errorf("failed to resolve auth groups: %w", err)
+		}
+
+		return apiContext.Write(types.GroupListResponse{
+			Items:  trimGroupsForUser(apiContext.User, groups),
+			Total:  len(groups),
+			Limit:  len(groups),
+			Source: types.GroupSourceCache,
+		})
 	}
 
 	providerURL, err := s.dispatcher.URLForAuthProvider(apiContext.Context(), namespace, name)
 	if err != nil {
-		return fmt.Errorf("failed to get auth provider URL: %v", err)
+		return fmt.Errorf("failed to get auth provider URL: %w", err)
 	}
-	groups, err := apiContext.GatewayClient.ListAuthGroups(
+
+	limit, offset := parseGroupPageParams(query)
+	groups, total, source, degraded, err := apiContext.GatewayClient.ListAuthGroups(
 		apiContext.Context(),
 		providerURL.String(),
 		namespace,
 		name,
-		apiContext.URL.Query().Get("name"),
+		client.ListAuthGroupsOptions{
+			NameFilter: query.Get("name"),
+			Limit:      limit,
+			Offset:     offset,
+		},
 	)
 	if err != nil {
-		return fmt.Errorf("failed to list auth groups: %v", err)
+		return fmt.Errorf("failed to list auth groups: %w", err)
 	}
 
-	slog.Info("Listed auth provider groups", "providerNamespace", namespace, "providerName", name, "groups", len(groups))
+	slog.Info("Listed auth provider groups",
+		"providerNamespace", namespace, "providerName", name,
+		"groups", len(groups), "total", total, "source", source, "degraded", degraded)
 
-	if userIsBasicOrPower(apiContext.User) {
-		trimmedGroups := make([]types.Group, 0, len(groups))
-		for _, group := range groups {
-			trimmedGroups = append(trimmedGroups, types.Group{
-				ID:   group.ID,
-				Name: group.Name,
-			})
+	return apiContext.Write(types.GroupListResponse{
+		Items:    trimGroupsForUser(apiContext.User, groups),
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
+		Source:   source,
+		Degraded: degraded,
+	})
+}
+
+const (
+	defaultGroupPageSize  = 50
+	maxGroupPageSize      = 500
+	maxGroupIDsPerRequest = 500
+)
+
+func parseGroupPageParams(query url.Values) (limit int, offset int) {
+	limit, err := strconv.Atoi(query.Get("limit"))
+	if err != nil || limit <= 0 {
+		limit = defaultGroupPageSize
+	}
+	limit = min(limit, maxGroupPageSize)
+
+	if offset, err = strconv.Atoi(query.Get("offset")); err != nil || offset < 0 {
+		offset = 0
+	}
+
+	return limit, offset
+}
+
+// splitGroupIDs parses the comma-separated ids parameter, dropping blanks and duplicates.
+func splitGroupIDs(raw string) []string {
+	parts := strings.Split(raw, ",")
+	ids := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+
+	for _, part := range parts {
+		id := strings.TrimSpace(part)
+		if id == "" {
+			continue
 		}
-		return apiContext.Write(trimmedGroups)
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		if ids = append(ids, id); len(ids) >= maxGroupIDsPerRequest {
+			break
+		}
 	}
 
-	return apiContext.Write(groups)
+	return ids
+}
+
+// trimGroupsForUser strips everything but the ID and name for users who should not see which auth
+// provider a group belongs to.
+func trimGroupsForUser(u user.Info, groups []types.Group) []types.Group {
+	if !userIsBasicOrPower(u) {
+		return groups
+	}
+
+	trimmed := make([]types.Group, 0, len(groups))
+	for _, group := range groups {
+		trimmed = append(trimmed, types.Group{
+			ID:   group.ID,
+			Name: group.Name,
+		})
+	}
+
+	return trimmed
 }
 
 func userIsBasicOrPower(u user.Info) bool {

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -359,11 +359,18 @@ func (s *Server) listAuthGroups(apiContext api.Context) error {
 
 	query := apiContext.URL.Query()
 
-	// Resolving specific IDs never needs the provider directory, so handle it before paying for a
-	// provider URL lookup.
+	providerURL, err := s.dispatcher.URLForAuthProvider(apiContext.Context(), namespace, name)
+	if err != nil {
+		return fmt.Errorf("failed to get auth provider URL: %w", err)
+	}
+
 	if rawIDs := query.Get("ids"); rawIDs != "" {
-		ids := splitGroupIDs(rawIDs)
-		groups, err := apiContext.GatewayClient.ResolveAuthGroups(apiContext.Context(), namespace, name, ids)
+		ids, err := splitGroupIDs(rawIDs)
+		if err != nil {
+			return types2.NewErrHTTP(http.StatusBadRequest, err.Error())
+		}
+
+		groups, err := apiContext.GatewayClient.ResolveAuthGroups(apiContext.Context(), providerURL.String(), namespace, name, ids)
 		if err != nil {
 			return fmt.Errorf("failed to resolve auth groups: %w", err)
 		}
@@ -372,11 +379,6 @@ func (s *Server) listAuthGroups(apiContext api.Context) error {
 			Items:  trimGroupsForUser(apiContext.User, groups),
 			Source: types.GroupSourceCache,
 		})
-	}
-
-	providerURL, err := s.dispatcher.URLForAuthProvider(apiContext.Context(), namespace, name)
-	if err != nil {
-		return fmt.Errorf("failed to get auth provider URL: %w", err)
 	}
 
 	limit, cursor := parseGroupListParams(query)
@@ -395,41 +397,38 @@ func (s *Server) listAuthGroups(apiContext api.Context) error {
 		return fmt.Errorf("failed to list auth groups: %w", err)
 	}
 
-	slog.Info("Listed auth provider groups",
+	slog.Debug("Listed auth provider groups",
 		"providerNamespace", namespace, "providerName", name,
 		"groups", len(result.Groups), "hasMore", result.NextCursor != "",
-		"source", result.Source, "degraded", result.Degraded)
+		"source", result.Source, "degraded", result.Degraded, "reset", result.Reset)
 
 	return apiContext.Write(types.GroupListResponse{
 		Items:      trimGroupsForUser(apiContext.User, result.Groups),
 		NextCursor: result.NextCursor,
 		Source:     result.Source,
 		Degraded:   result.Degraded,
+		Reset:      result.Reset,
 	})
 }
 
-const (
-	defaultGroupPageSize = 50
-
-	// maxGroupPageSize matches the ceiling the auth providers enforce, which is set by the
-	// smallest page any of the identity providers will serve in a single request.
-	maxGroupPageSize = 100
-
-	maxGroupIDsPerRequest = 500
-)
+const maxGroupIDsPerRequest = 100
 
 func parseGroupListParams(query url.Values) (limit int, cursor string) {
 	limit, err := strconv.Atoi(query.Get("limit"))
 	if err != nil || limit <= 0 {
-		limit = defaultGroupPageSize
+		limit = client.DefaultGroupPageSize
 	}
 
-	return min(limit, maxGroupPageSize), query.Get("cursor")
+	return min(limit, client.MaxGroupPageSize), query.Get("cursor")
 }
 
 // splitGroupIDs parses the comma-separated ids parameter, dropping blanks and duplicates.
-func splitGroupIDs(raw string) []string {
+func splitGroupIDs(raw string) ([]string, error) {
 	parts := strings.Split(raw, ",")
+	if len(parts) > maxGroupIDsPerRequest {
+		return nil, fmt.Errorf("too many group ids: %d, limit is %d", len(parts), maxGroupIDsPerRequest)
+	}
+
 	ids := make([]string, 0, len(parts))
 	seen := make(map[string]struct{}, len(parts))
 
@@ -441,14 +440,12 @@ func splitGroupIDs(raw string) []string {
 		if _, ok := seen[id]; ok {
 			continue
 		}
-		seen[id] = struct{}{}
 
-		if ids = append(ids, id); len(ids) >= maxGroupIDsPerRequest {
-			break
-		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
 	}
 
-	return ids
+	return ids, nil
 }
 
 // trimGroupsForUser strips everything but the ID and name for users who should not see which auth

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -344,9 +344,10 @@ func (s *Server) deleteUser(apiContext api.Context) (err error) {
 	return apiContext.Write(types.ConvertUser(existingUser, apiContext.GatewayClient.HasExplicitRole(existingUser.Email) != types2.RoleUnknown, ""))
 }
 
-// GET /api/groups?name=&limit=&offset=&ids=
-// Returns one page of the auth provider's groups, optionally filtered by name. Passing ids instead
-// resolves those specific group IDs to their display names.
+// GET /api/groups?name=&limit=&cursor=&ids=
+// Returns one page of the auth provider's groups, optionally filtered by name. Paging is by opaque
+// cursor: the response carries the position of the next page, or nothing when there are no more.
+// Passing ids instead resolves those specific group IDs to their display names.
 func (s *Server) listAuthGroups(apiContext api.Context) error {
 	name, namespace := apiContext.AuthProviderNameAndNamespace()
 	if name == "" || namespace == "" {
@@ -369,8 +370,6 @@ func (s *Server) listAuthGroups(apiContext api.Context) error {
 
 		return apiContext.Write(types.GroupListResponse{
 			Items:  trimGroupsForUser(apiContext.User, groups),
-			Total:  len(groups),
-			Limit:  len(groups),
 			Source: types.GroupSourceCache,
 		})
 	}
@@ -380,8 +379,8 @@ func (s *Server) listAuthGroups(apiContext api.Context) error {
 		return fmt.Errorf("failed to get auth provider URL: %w", err)
 	}
 
-	limit, offset := parseGroupPageParams(query)
-	groups, total, source, degraded, err := apiContext.GatewayClient.ListAuthGroups(
+	limit, cursor := parseGroupListParams(query)
+	result, err := apiContext.GatewayClient.ListAuthGroups(
 		apiContext.Context(),
 		providerURL.String(),
 		namespace,
@@ -389,7 +388,7 @@ func (s *Server) listAuthGroups(apiContext api.Context) error {
 		client.ListAuthGroupsOptions{
 			NameFilter: query.Get("name"),
 			Limit:      limit,
-			Offset:     offset,
+			Cursor:     cursor,
 		},
 	)
 	if err != nil {
@@ -398,36 +397,34 @@ func (s *Server) listAuthGroups(apiContext api.Context) error {
 
 	slog.Info("Listed auth provider groups",
 		"providerNamespace", namespace, "providerName", name,
-		"groups", len(groups), "total", total, "source", source, "degraded", degraded)
+		"groups", len(result.Groups), "hasMore", result.NextCursor != "",
+		"source", result.Source, "degraded", result.Degraded)
 
 	return apiContext.Write(types.GroupListResponse{
-		Items:    trimGroupsForUser(apiContext.User, groups),
-		Total:    total,
-		Limit:    limit,
-		Offset:   offset,
-		Source:   source,
-		Degraded: degraded,
+		Items:      trimGroupsForUser(apiContext.User, result.Groups),
+		NextCursor: result.NextCursor,
+		Source:     result.Source,
+		Degraded:   result.Degraded,
 	})
 }
 
 const (
-	defaultGroupPageSize  = 50
-	maxGroupPageSize      = 500
+	defaultGroupPageSize = 50
+
+	// maxGroupPageSize matches the ceiling the auth providers enforce, which is set by the
+	// smallest page any of the identity providers will serve in a single request.
+	maxGroupPageSize = 100
+
 	maxGroupIDsPerRequest = 500
 )
 
-func parseGroupPageParams(query url.Values) (limit int, offset int) {
+func parseGroupListParams(query url.Values) (limit int, cursor string) {
 	limit, err := strconv.Atoi(query.Get("limit"))
 	if err != nil || limit <= 0 {
 		limit = defaultGroupPageSize
 	}
-	limit = min(limit, maxGroupPageSize)
 
-	if offset, err = strconv.Atoi(query.Get("offset")); err != nil || offset < 0 {
-		offset = 0
-	}
-
-	return limit, offset
+	return min(limit, maxGroupPageSize), query.Get("cursor")
 }
 
 // splitGroupIDs parses the comma-separated ids parameter, dropping blanks and duplicates.

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -429,7 +431,6 @@ func splitGroupIDs(raw string) ([]string, error) {
 		return nil, fmt.Errorf("too many group ids: %d, limit is %d", len(parts), maxGroupIDsPerRequest)
 	}
 
-	ids := make([]string, 0, len(parts))
 	seen := make(map[string]struct{}, len(parts))
 
 	for _, part := range parts {
@@ -442,10 +443,9 @@ func splitGroupIDs(raw string) ([]string, error) {
 		}
 
 		seen[id] = struct{}{}
-		ids = append(ids, id)
 	}
 
-	return ids, nil
+	return slices.Collect(maps.Keys(seen)), nil
 }
 
 // trimGroupsForUser strips everything but the ID and name for users who should not see which auth

--- a/pkg/gateway/types/group.go
+++ b/pkg/gateway/types/group.go
@@ -11,17 +11,44 @@ type Group struct {
 
 	// AuthProviderName is the name of the auth provider that the group belongs to.
 	// This is used to identify the auth provider that the group belongs to.
-	AuthProviderName string `json:"authProviderName" gorm:"primaryKey;index:idx_group_auth_provider"`
+	AuthProviderName string `json:"authProviderName" gorm:"primaryKey;index:idx_group_auth_provider;index:idx_group_auth_provider_name,priority:1"`
 
 	// AuthProviderNamespace is the namespace of the auth provider that the group belongs to.
 	// Note: This is pretty much always "default", but we're keeping it here for parity with the Identity type.
-	AuthProviderNamespace string `json:"authProviderNamespace" gorm:"primaryKey;index:idx_group_auth_provider"`
+	AuthProviderNamespace string `json:"authProviderNamespace" gorm:"primaryKey;index:idx_group_auth_provider;index:idx_group_auth_provider_name,priority:2"`
 
 	// Name is the display name of the group.
-	Name string `json:"name"`
+	// Indexed because cached group listings are paged in name order.
+	Name string `json:"name" gorm:"index:idx_group_auth_provider_name,priority:3"`
 
 	// IconURL is the URL of the group's icon.
 	IconURL *string `json:"iconURL"`
+}
+
+// Group listing sources, reported on GroupListResponse so callers can tell a live directory
+// listing apart from the partial view built up from previous sign-ins.
+const (
+	// GroupSourceProvider means the listing came from the auth provider and is complete.
+	GroupSourceProvider = "provider"
+
+	// GroupSourceCache means the listing came from the groups table, which only ever contains
+	// groups observed during a user sign-in and is therefore partial.
+	GroupSourceCache = "cache"
+)
+
+// GroupListResponse is the paginated response for a group listing.
+type GroupListResponse struct {
+	Items  []Group `json:"items"`
+	Total  int     `json:"total"`
+	Limit  int     `json:"limit"`
+	Offset int     `json:"offset"`
+
+	// Source is where the items came from: GroupSourceProvider or GroupSourceCache.
+	Source string `json:"source"`
+
+	// Degraded is true when the auth provider could not be listed and the response fell back to
+	// cached groups. It distinguishes a real failure from a provider that has no group support.
+	Degraded bool `json:"degraded"`
 }
 
 // GroupMemberships represents a user's membership in a group.

--- a/pkg/gateway/types/group.go
+++ b/pkg/gateway/types/group.go
@@ -25,15 +25,17 @@ type Group struct {
 	IconURL *string `json:"iconURL"`
 }
 
-// Group listing sources, reported on GroupListResponse so callers can tell a live directory
-// listing apart from the partial view built up from previous sign-ins.
+// GroupSource names where a group listing came from.
+type GroupSource string
+
 const (
 	// GroupSourceProvider means the listing came from the auth provider and is complete.
-	GroupSourceProvider = "provider"
+	GroupSourceProvider GroupSource = "provider"
 
-	// GroupSourceCache means the listing came from the groups table, which only ever contains
-	// groups observed during a user sign-in and is therefore partial.
-	GroupSourceCache = "cache"
+	// GroupSourceCache means the listing came from the groups table, which holds the groups
+	// observed during a user sign-in plus any resolved by ID for a policy, and is therefore
+	// partial.
+	GroupSourceCache GroupSource = "cache"
 )
 
 // GroupListResponse is the paginated response for a group listing.
@@ -45,11 +47,15 @@ type GroupListResponse struct {
 	NextCursor string `json:"nextCursor,omitempty"`
 
 	// Source is where the items came from: GroupSourceProvider or GroupSourceCache.
-	Source string `json:"source"`
+	Source GroupSource `json:"source"`
 
 	// Degraded is true when the auth provider could not be listed and the response fell back to
 	// cached groups. It distinguishes a real failure from a provider that has no group support.
 	Degraded bool `json:"degraded"`
+
+	// Reset is true when the caller supplied a cursor that could not be honored, so these items are
+	// the first page of a fresh listing rather than the page that was asked for.
+	Reset bool `json:"reset,omitempty"`
 }
 
 // GroupMemberships represents a user's membership in a group.

--- a/pkg/gateway/types/group.go
+++ b/pkg/gateway/types/group.go
@@ -7,7 +7,7 @@ import "time"
 type Group struct {
 	// ID is the globally unique identifier for the group.
 	// Each auth provider should use a different prefix for their groups to avoid collisions with other providers.
-	ID string `json:"id" gorm:"primaryKey;unique"`
+	ID string `json:"id" gorm:"primaryKey;unique;index:idx_group_auth_provider_name,priority:4"`
 
 	// AuthProviderName is the name of the auth provider that the group belongs to.
 	// This is used to identify the auth provider that the group belongs to.
@@ -18,7 +18,7 @@ type Group struct {
 	AuthProviderNamespace string `json:"authProviderNamespace" gorm:"primaryKey;index:idx_group_auth_provider;index:idx_group_auth_provider_name,priority:2"`
 
 	// Name is the display name of the group.
-	// Indexed because cached group listings are paged in name order.
+	// Indexed because cached group listings are paged by keyset in (name, id) order.
 	Name string `json:"name" gorm:"index:idx_group_auth_provider_name,priority:3"`
 
 	// IconURL is the URL of the group's icon.
@@ -38,10 +38,11 @@ const (
 
 // GroupListResponse is the paginated response for a group listing.
 type GroupListResponse struct {
-	Items  []Group `json:"items"`
-	Total  int     `json:"total"`
-	Limit  int     `json:"limit"`
-	Offset int     `json:"offset"`
+	Items []Group `json:"items"`
+
+	// NextCursor is the opaque position to pass back to fetch the following page. It is absent on
+	// the last page, and its presence is the only indication that more results exist.
+	NextCursor string `json:"nextCursor,omitempty"`
 
 	// Source is where the items came from: GroupSourceProvider or GroupSourceCache.
 	Source string `json:"source"`

--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -113,7 +113,10 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
-		resolveSubjects(accessControlRule.subjects, usersAndGroups)
+		resolveSubjects(
+			accessControlRule.subjects,
+			untrack(() => usersAndGroups)
+		)
 			.then((resolved) => {
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;

--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -28,6 +28,7 @@
 	import Table from '../table/Table.svelte';
 	import SearchMcpServers from './SearchMcpServers.svelte';
 	import SearchUsers from './SearchUsers.svelte';
+	import { resolveSubjects } from './subjectResolver';
 	import { Plus, Trash2 } from '@lucide/svelte';
 	import { untrack, type Snippet } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -110,33 +111,11 @@
 
 		loadingUsersAndGroups = true;
 
-		// Prevent refetching when adding new users or groups
-		const promises: [Promise<OrgUser[] | undefined>, Promise<OrgGroup[] | undefined>] = [
-			Promise.resolve(undefined),
-			Promise.resolve(undefined)
-		];
-
-		if (!usersAndGroups?.users) {
-			promises[0] = UserService.listUsers();
-		}
-		if (!usersAndGroups?.groups) {
-			promises[1] = UserService.listGroups();
-		}
-
-		Promise.all(promises)
-			.then(([users, groups]) => {
-				if (!usersAndGroups) {
-					usersAndGroups = { users: [], groups: [] };
-				}
-
-				if (users) {
-					usersAndGroups!.users = users;
-				}
-
-				if (groups) {
-					usersAndGroups!.groups = groups;
-				}
-
+		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
+		// only the ones attached here are needed.
+		resolveSubjects(accessControlRule.subjects, usersAndGroups)
+			.then((resolved) => {
+				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {

--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -113,18 +113,25 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
+		const controller = new AbortController();
+
 		resolveSubjects(
 			accessControlRule.subjects,
-			untrack(() => usersAndGroups)
+			untrack(() => usersAndGroups),
+			{ signal: controller.signal }
 		)
 			.then((resolved) => {
+				if (controller.signal.aborted) return;
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {
+				if (controller.signal.aborted) return;
 				console.error('Failed to load users and groups:', error);
 				loadingUsersAndGroups = false;
 			});
+
+		return () => controller.abort();
 	});
 
 	$effect(() => {

--- a/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
+++ b/ui/user/src/lib/components/admin/AccessControlRuleForm.svelte
@@ -106,6 +106,7 @@
 	$effect(() => {
 		// Prevent loading users and groups if acr has no subjects
 		if (!accessControlRule.subjects || accessControlRule.subjects?.length === 0) {
+			loadingUsersAndGroups = false;
 			return;
 		}
 

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte
@@ -40,6 +40,8 @@
 	// server. Only the current page is ever held here.
 	let inFlight: AbortController | undefined;
 
+	let skipNextLoad = false;
+
 	async function load() {
 		inFlight?.abort();
 		const controller = new AbortController();
@@ -55,6 +57,14 @@
 				signal: controller.signal
 			});
 			if (controller.signal.aborted) return;
+
+			if (page.reset) {
+				cursorStack = [undefined];
+				if (pageIndex !== 0) {
+					skipNextLoad = true;
+					pageIndex = 0;
+				}
+			}
 
 			groups = page.items;
 			nextCursor = page.nextCursor;
@@ -76,6 +86,12 @@
 		// Re-runs whenever the query or page changes.
 		void query;
 		void pageIndex;
+
+		if (skipNextLoad) {
+			skipNextLoad = false;
+			return;
+		}
+
 		load();
 	});
 
@@ -107,8 +123,8 @@
 		>
 			<TriangleAlert class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
 			<span>
-				Showing only groups seen from previous sign-ins. Obot could not list your identity
-				provider's directory &mdash; directory-wide group read permission may not be granted.
+				Showing only groups Obot has already recorded. Obot could not list your identity provider's
+				directory &mdash; directory-wide group read permission may not be granted.
 			</span>
 		</div>
 	{/if}

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte
@@ -74,6 +74,7 @@
 			console.error('Failed to load groups:', error);
 			groups = [];
 			nextCursor = undefined;
+			degraded = false;
 			errored = true;
 		} finally {
 			if (!controller.signal.aborted) {

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte
@@ -93,6 +93,7 @@
 		}
 
 		load();
+		return () => inFlight?.abort();
 	});
 
 	const excluded = $derived(new Set(excludeIds ?? []));

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte
@@ -2,7 +2,7 @@
 	import Loading from '$lib/icons/Loading.svelte';
 	import { UserService, type OrgGroup } from '$lib/services';
 	import Search from '../Search.svelte';
-	import Pagination from '../table/Pagination.svelte';
+	import CursorPagination from '../table/CursorPagination.svelte';
 	import { Check, TriangleAlert } from '@lucide/svelte';
 	import { twMerge } from 'tailwind-merge';
 
@@ -26,8 +26,12 @@
 
 	let query = $state('');
 	let pageIndex = $state(0);
+	// One cursor per visited page: the first page has none, and every Next pushes the cursor that
+	// reaches the following page. Going back needs the stack rather than a single saved cursor,
+	// because a cursor only ever points forwards.
+	let cursorStack = $state<(string | undefined)[]>([undefined]);
+	let nextCursor = $state<string | undefined>(undefined);
 	let groups = $state<OrgGroup[]>([]);
-	let total = $state(0);
 	let degraded = $state(false);
 	let loading = $state(false);
 	let errored = $state(false);
@@ -47,19 +51,19 @@
 			const page = await UserService.listGroups({
 				query,
 				limit: pageSize,
-				offset: pageIndex * pageSize,
+				cursor: cursorStack[pageIndex],
 				signal: controller.signal
 			});
 			if (controller.signal.aborted) return;
 
 			groups = page.items;
-			total = page.total;
+			nextCursor = page.nextCursor;
 			degraded = page.degraded;
 		} catch (error) {
 			if (controller.signal.aborted) return;
 			console.error('Failed to load groups:', error);
 			groups = [];
-			total = 0;
+			nextCursor = undefined;
 			errored = true;
 		} finally {
 			if (!controller.signal.aborted) {
@@ -77,11 +81,17 @@
 
 	const excluded = $derived(new Set(excludeIds ?? []));
 	const visibleGroups = $derived(groups.filter((group) => !excluded.has(group.id)));
-	const lastPageIndex = $derived(Math.max(0, Math.ceil(total / pageSize) - 1));
 
 	function handleSearch(value: string) {
 		query = value;
+		// A cursor belongs to the search it was created for, so a new search starts over.
+		cursorStack = [undefined];
 		pageIndex = 0;
+	}
+
+	function goToNextPage() {
+		cursorStack = [...cursorStack.slice(0, pageIndex + 1), nextCursor];
+		pageIndex += 1;
 	}
 
 	export function refresh() {
@@ -149,15 +159,15 @@
 		{/if}
 	</div>
 
-	{#if total > pageSize}
+	{#if pageIndex > 0 || nextCursor}
 		<div class="shrink-0">
-			<Pagination
+			<CursorPagination
 				{pageIndex}
-				{lastPageIndex}
-				{total}
+				hasPrevious={pageIndex > 0}
+				hasNext={Boolean(nextCursor)}
 				{loading}
-				itemLabelSingular="group"
-				onPageChange={(idx) => (pageIndex = idx)}
+				onPrevious={() => (pageIndex -= 1)}
+				onNext={goToNextPage}
 			/>
 		</div>
 	{/if}

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	import Loading from '$lib/icons/Loading.svelte';
+	import { UserService, type OrgGroup } from '$lib/services';
+	import Search from '../Search.svelte';
+	import Pagination from '../table/Pagination.svelte';
+	import { Check, TriangleAlert } from '@lucide/svelte';
+	import { twMerge } from 'tailwind-merge';
+
+	interface Props {
+		onSelect: (group: OrgGroup) => void;
+		selectedId?: string;
+		excludeIds?: string[];
+		subtitle?: (group: OrgGroup) => string | undefined;
+		pageSize?: number;
+		placeholder?: string;
+	}
+
+	let {
+		onSelect,
+		selectedId,
+		excludeIds,
+		subtitle,
+		pageSize = 50,
+		placeholder = 'Search groups...'
+	}: Props = $props();
+
+	let query = $state('');
+	let pageIndex = $state(0);
+	let groups = $state<OrgGroup[]>([]);
+	let total = $state(0);
+	let degraded = $state(false);
+	let loading = $state(false);
+	let errored = $state(false);
+
+	// A directory can hold tens of thousands of groups, so searching and paging both happen on the
+	// server. Only the current page is ever held here.
+	let inFlight: AbortController | undefined;
+
+	async function load() {
+		inFlight?.abort();
+		const controller = new AbortController();
+		inFlight = controller;
+
+		loading = true;
+		errored = false;
+		try {
+			const page = await UserService.listGroups({
+				query,
+				limit: pageSize,
+				offset: pageIndex * pageSize,
+				signal: controller.signal
+			});
+			if (controller.signal.aborted) return;
+
+			groups = page.items;
+			total = page.total;
+			degraded = page.degraded;
+		} catch (error) {
+			if (controller.signal.aborted) return;
+			console.error('Failed to load groups:', error);
+			groups = [];
+			total = 0;
+			errored = true;
+		} finally {
+			if (!controller.signal.aborted) {
+				loading = false;
+			}
+		}
+	}
+
+	$effect(() => {
+		// Re-runs whenever the query or page changes.
+		void query;
+		void pageIndex;
+		load();
+	});
+
+	const excluded = $derived(new Set(excludeIds ?? []));
+	const visibleGroups = $derived(groups.filter((group) => !excluded.has(group.id)));
+	const lastPageIndex = $derived(Math.max(0, Math.ceil(total / pageSize) - 1));
+
+	function handleSearch(value: string) {
+		query = value;
+		pageIndex = 0;
+	}
+
+	export function refresh() {
+		load();
+	}
+</script>
+
+<div class="flex h-full flex-col gap-4 overflow-hidden">
+	{#if degraded}
+		<div
+			class="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs"
+			role="status"
+		>
+			<TriangleAlert class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+			<span>
+				Showing only groups seen from previous sign-ins. Obot could not list your identity
+				provider's directory &mdash; directory-wide group read permission may not be granted.
+			</span>
+		</div>
+	{/if}
+
+	<div class="shrink-0">
+		<Search
+			class="dark:bg-base-200 dark:border-base-400 shadow-inner dark:border"
+			value={query}
+			onChange={handleSearch}
+			{placeholder}
+		/>
+	</div>
+
+	<div class="default-scrollbar-thin flex grow flex-col overflow-y-auto">
+		{#if loading}
+			<div class="flex grow items-center justify-center py-8">
+				<Loading class="size-6" />
+			</div>
+		{:else if errored}
+			<p class="text-muted-content py-8 text-center text-sm">Failed to load groups. Try again.</p>
+		{:else if visibleGroups.length === 0}
+			<p class="text-muted-content py-8 text-center text-sm">
+				{query ? 'No groups found matching your search.' : 'No groups available.'}
+			</p>
+		{:else}
+			<div class="flex flex-col gap-2">
+				{#each visibleGroups as group (group.id)}
+					{@const groupSubtitle = subtitle?.(group)}
+					<button
+						class={twMerge(
+							'border-base-400 hover:bg-base-100/5 flex items-center gap-3 rounded-lg border p-3 text-left transition-colors',
+							selectedId === group.id && 'bg-primary/10 border-primary'
+						)}
+						onclick={() => onSelect(group)}
+					>
+						<div class="flex grow flex-col">
+							<span class="font-medium">{group.name}</span>
+							{#if groupSubtitle}
+								<span class="text-muted-content text-xs">{groupSubtitle}</span>
+							{/if}
+						</div>
+						{#if selectedId === group.id}
+							<Check class="text-primary size-5 shrink-0" />
+						{/if}
+					</button>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	{#if total > pageSize}
+		<div class="shrink-0">
+			<Pagination
+				{pageIndex}
+				{lastPageIndex}
+				{total}
+				{loading}
+				itemLabelSingular="group"
+				onPageChange={(idx) => (pageIndex = idx)}
+			/>
+		</div>
+	{/if}
+</div>

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
@@ -1,0 +1,143 @@
+import { worker } from '../../../tests/mocks/worker';
+import GroupPicker from './GroupPicker.svelte';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+interface GroupPageOverrides {
+	total?: number;
+	degraded?: boolean;
+}
+
+function mockGroups(overrides: GroupPageOverrides = {}) {
+	const total = overrides.total ?? 3;
+	const requests = vi.fn();
+
+	worker.use(
+		http.get('/api/groups', ({ request }) => {
+			const url = new URL(request.url);
+			const name = url.searchParams.get('name') ?? '';
+			const limit = Number(url.searchParams.get('limit') ?? 50);
+			const offset = Number(url.searchParams.get('offset') ?? 0);
+			requests({ name, limit, offset });
+
+			const all = Array.from({ length: total }, (_, i) => ({
+				id: `entra/${String(i).padStart(4, '0')}`,
+				name: `group-${String(i).padStart(4, '0')}`
+			}));
+			const matched = name ? all.filter((g) => g.name.includes(name)) : all;
+
+			return HttpResponse.json({
+				items: matched.slice(offset, offset + limit),
+				total: matched.length,
+				limit,
+				offset,
+				source: overrides.degraded ? 'cache' : 'provider',
+				degraded: overrides.degraded ?? false
+			});
+		})
+	);
+
+	return requests;
+}
+
+describe('GroupPicker', () => {
+	it('renders the first page of groups', async () => {
+		mockGroups({ total: 3 });
+		render(GroupPicker, { onSelect: vi.fn() });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await expect.element(page.getByText('group-0002')).toBeInTheDocument();
+	});
+
+	it('calls onSelect with the chosen group', async () => {
+		mockGroups({ total: 3 });
+		const onSelect = vi.fn();
+		render(GroupPicker, { onSelect });
+
+		await page.getByRole('button', { name: /group-0001/ }).click();
+
+		expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'entra/0001' }));
+	});
+
+	it('requests a bounded page rather than the whole directory', async () => {
+		const requests = mockGroups({ total: 10000 });
+		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		expect(requests).toHaveBeenCalledWith(expect.objectContaining({ limit: 50, offset: 0 }));
+	});
+
+	it('pages forward through a large directory', async () => {
+		const requests = mockGroups({ total: 10000 });
+		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await page.getByRole('button', { name: /Next/ }).click();
+
+		await expect.element(page.getByText('group-0050')).toBeInTheDocument();
+		expect(requests).toHaveBeenCalledWith(expect.objectContaining({ limit: 50, offset: 50 }));
+	});
+
+	it('hides pagination when everything fits on one page', async () => {
+		mockGroups({ total: 3 });
+		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await expect.element(page.getByRole('button', { name: /Next/ })).not.toBeInTheDocument();
+	});
+
+	it('sends the search query to the server', async () => {
+		const requests = mockGroups({ total: 10000 });
+		render(GroupPicker, { onSelect: vi.fn() });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await page.getByRole('textbox').fill('group-0123');
+
+		await vi.waitFor(() =>
+			expect(requests).toHaveBeenCalledWith(expect.objectContaining({ name: 'group-0123' }))
+		);
+	});
+
+	it('excludes ids the caller asked to hide', async () => {
+		mockGroups({ total: 3 });
+		render(GroupPicker, { onSelect: vi.fn(), excludeIds: ['entra/0001'] });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await expect.element(page.getByText('group-0001')).not.toBeInTheDocument();
+	});
+
+	it('renders the subtitle a caller provides', async () => {
+		mockGroups({ total: 1 });
+		render(GroupPicker, { onSelect: vi.fn(), subtitle: () => 'Admin' });
+
+		await expect.element(page.getByText('Admin')).toBeInTheDocument();
+	});
+
+	it('warns when results fell back to cached groups', async () => {
+		mockGroups({ total: 2, degraded: true });
+		render(GroupPicker, { onSelect: vi.fn() });
+
+		await expect
+			.element(page.getByText(/groups seen from previous sign-ins/i))
+			.toBeInTheDocument();
+	});
+
+	it('does not warn when the provider answered', async () => {
+		mockGroups({ total: 2, degraded: false });
+		render(GroupPicker, { onSelect: vi.fn() });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await expect
+			.element(page.getByText(/groups seen from previous sign-ins/i))
+			.not.toBeInTheDocument();
+	});
+
+	it('reports an empty search rather than looking broken', async () => {
+		mockGroups({ total: 0 });
+		render(GroupPicker, { onSelect: vi.fn() });
+
+		await expect.element(page.getByText('No groups available.')).toBeInTheDocument();
+	});
+});

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
@@ -10,6 +10,7 @@ interface GroupPageOverrides {
 	degraded?: boolean;
 }
 
+// The server hands out opaque cursors; a stringified offset is enough to stand in for one here.
 function mockGroups(overrides: GroupPageOverrides = {}) {
 	const total = overrides.total ?? 3;
 	const requests = vi.fn();
@@ -19,8 +20,8 @@ function mockGroups(overrides: GroupPageOverrides = {}) {
 			const url = new URL(request.url);
 			const name = url.searchParams.get('name') ?? '';
 			const limit = Number(url.searchParams.get('limit') ?? 50);
-			const offset = Number(url.searchParams.get('offset') ?? 0);
-			requests({ name, limit, offset });
+			const cursor = url.searchParams.get('cursor');
+			requests({ name, limit, cursor });
 
 			const all = Array.from({ length: total }, (_, i) => ({
 				id: `entra/${String(i).padStart(4, '0')}`,
@@ -28,11 +29,12 @@ function mockGroups(overrides: GroupPageOverrides = {}) {
 			}));
 			const matched = name ? all.filter((g) => g.name.includes(name)) : all;
 
+			const start = cursor ? Number(cursor) : 0;
+			const end = Math.min(start + limit, matched.length);
+
 			return HttpResponse.json({
-				items: matched.slice(offset, offset + limit),
-				total: matched.length,
-				limit,
-				offset,
+				items: matched.slice(start, end),
+				nextCursor: end < matched.length ? String(end) : undefined,
 				source: overrides.degraded ? 'cache' : 'provider',
 				degraded: overrides.degraded ?? false
 			});
@@ -66,7 +68,7 @@ describe('GroupPicker', () => {
 		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
 
 		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
-		expect(requests).toHaveBeenCalledWith(expect.objectContaining({ limit: 50, offset: 0 }));
+		expect(requests).toHaveBeenCalledWith(expect.objectContaining({ limit: 50, cursor: null }));
 	});
 
 	it('pages forward through a large directory', async () => {
@@ -77,7 +79,49 @@ describe('GroupPicker', () => {
 		await page.getByRole('button', { name: /Next/ }).click();
 
 		await expect.element(page.getByText('group-0050')).toBeInTheDocument();
-		expect(requests).toHaveBeenCalledWith(expect.objectContaining({ limit: 50, offset: 50 }));
+		// The cursor the first page returned has to come back on the next request.
+		expect(requests).toHaveBeenCalledWith(expect.objectContaining({ limit: 50, cursor: '50' }));
+	});
+
+	it('pages backward to the page it came from', async () => {
+		mockGroups({ total: 10000 });
+		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await page.getByRole('button', { name: /Next/ }).click();
+		await expect.element(page.getByText('group-0050')).toBeInTheDocument();
+
+		await page.getByRole('button', { name: /Previous/ }).click();
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+	});
+
+	it('starts over when the search changes mid-listing', async () => {
+		const requests = mockGroups({ total: 10000 });
+		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await page.getByRole('button', { name: /Next/ }).click();
+		await expect.element(page.getByText('group-0050')).toBeInTheDocument();
+
+		// A cursor belongs to the search it was minted for, so a new search must not reuse it.
+		await page.getByRole('textbox').fill('group-01');
+
+		await vi.waitFor(() =>
+			expect(requests).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'group-01', cursor: null })
+			)
+		);
+	});
+
+	it('hides Next on the last page', async () => {
+		mockGroups({ total: 60 });
+		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await page.getByRole('button', { name: /Next/ }).click();
+
+		await expect.element(page.getByText('group-0050')).toBeInTheDocument();
+		await expect.element(page.getByRole('button', { name: /Next/ })).toBeDisabled();
 	});
 
 	it('hides pagination when everything fits on one page', async () => {

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
@@ -119,9 +119,7 @@ describe('GroupPicker', () => {
 		mockGroups({ total: 2, degraded: true });
 		render(GroupPicker, { onSelect: vi.fn() });
 
-		await expect
-			.element(page.getByText(/groups seen from previous sign-ins/i))
-			.toBeInTheDocument();
+		await expect.element(page.getByText(/groups seen from previous sign-ins/i)).toBeInTheDocument();
 	});
 
 	it('does not warn when the provider answered', async () => {

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
@@ -8,6 +8,8 @@ import { page } from 'vitest/browser';
 interface GroupPageOverrides {
 	total?: number;
 	degraded?: boolean;
+	/** When set, any request carrying a cursor is answered with the first page and reset: true. */
+	resetOnCursor?: boolean;
 }
 
 // The server hands out opaque cursors; a stringified offset is enough to stand in for one here.
@@ -29,14 +31,19 @@ function mockGroups(overrides: GroupPageOverrides = {}) {
 			}));
 			const matched = name ? all.filter((g) => g.name.includes(name)) : all;
 
-			const start = cursor ? Number(cursor) : 0;
+			// The server could not honor the cursor and restarted the listing: the caller is handed
+			// the first page and told its page number no longer means anything.
+			const didReset = Boolean(overrides.resetOnCursor && cursor);
+
+			const start = didReset || !cursor ? 0 : Number(cursor);
 			const end = Math.min(start + limit, matched.length);
 
 			return HttpResponse.json({
 				items: matched.slice(start, end),
 				nextCursor: end < matched.length ? String(end) : undefined,
 				source: overrides.degraded ? 'cache' : 'provider',
-				degraded: overrides.degraded ?? false
+				degraded: overrides.degraded ?? false,
+				reset: didReset
 			});
 		})
 	);
@@ -113,6 +120,23 @@ describe('GroupPicker', () => {
 		);
 	});
 
+	it('rewinds to the first page when the server could not honor the cursor', async () => {
+		const requests = mockGroups({ total: 10000, resetOnCursor: true });
+		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
+
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await page.getByRole('button', { name: /Next/ }).click();
+
+		// The server restarted the listing, so this is page one again. Leaving the page number where
+		// it was would label it page two and repeat every page after it.
+		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
+		await expect.element(page.getByRole('button', { name: /Previous/ })).toBeDisabled();
+
+		// Rewinding must not cost an extra round trip for a page already in hand.
+		const cursorRequests = requests.mock.calls.filter(([call]) => call.cursor !== null);
+		expect(cursorRequests).toHaveLength(1);
+	});
+
 	it('hides Next on the last page', async () => {
 		mockGroups({ total: 60 });
 		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
@@ -163,7 +187,7 @@ describe('GroupPicker', () => {
 		mockGroups({ total: 2, degraded: true });
 		render(GroupPicker, { onSelect: vi.fn() });
 
-		await expect.element(page.getByText(/groups seen from previous sign-ins/i)).toBeInTheDocument();
+		await expect.element(page.getByText(/groups Obot has already recorded/i)).toBeInTheDocument();
 	});
 
 	it('does not warn when the provider answered', async () => {
@@ -172,7 +196,7 @@ describe('GroupPicker', () => {
 
 		await expect.element(page.getByText('group-0000')).toBeInTheDocument();
 		await expect
-			.element(page.getByText(/groups seen from previous sign-ins/i))
+			.element(page.getByText(/groups Obot has already recorded/i))
 			.not.toBeInTheDocument();
 	});
 

--- a/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/GroupPicker.svelte.spec.ts
@@ -10,6 +10,8 @@ interface GroupPageOverrides {
 	degraded?: boolean;
 	/** When set, any request carrying a cursor is answered with the first page and reset: true. */
 	resetOnCursor?: boolean;
+	/** When set, any request carrying a cursor fails, standing in for the directory going away. */
+	failOnCursor?: boolean;
 }
 
 // The server hands out opaque cursors; a stringified offset is enough to stand in for one here.
@@ -24,6 +26,10 @@ function mockGroups(overrides: GroupPageOverrides = {}) {
 			const limit = Number(url.searchParams.get('limit') ?? 50);
 			const cursor = url.searchParams.get('cursor');
 			requests({ name, limit, cursor });
+
+			if (overrides.failOnCursor && cursor) {
+				return new HttpResponse(null, { status: 500 });
+			}
 
 			const all = Array.from({ length: total }, (_, i) => ({
 				id: `entra/${String(i).padStart(4, '0')}`,
@@ -188,6 +194,21 @@ describe('GroupPicker', () => {
 		render(GroupPicker, { onSelect: vi.fn() });
 
 		await expect.element(page.getByText(/groups Obot has already recorded/i)).toBeInTheDocument();
+	});
+
+	it('drops the cached-directory warning when the next page fails to load', async () => {
+		mockGroups({ total: 100, degraded: true, failOnCursor: true });
+		render(GroupPicker, { onSelect: vi.fn(), pageSize: 50 });
+
+		await expect.element(page.getByText(/groups Obot has already recorded/i)).toBeInTheDocument();
+		await page.getByRole('button', { name: /Next/ }).click();
+
+		await expect.element(page.getByText(/Failed to load groups/i)).toBeInTheDocument();
+		// The warning describes where the listed groups came from, and the failure listed none, so
+		// showing it next to "Failed to load groups" would claim cached groups are on screen.
+		await expect
+			.element(page.getByText(/groups Obot has already recorded/i))
+			.not.toBeInTheDocument();
 	});
 
 	it('does not warn when the provider answered', async () => {

--- a/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
@@ -3,7 +3,6 @@
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
-		UserService,
 		type AccessControlRuleSubject,
 		type OrgUser,
 		type OrgGroup,
@@ -19,6 +18,7 @@
 	import Table from '../table/Table.svelte';
 	import SearchHostedAgents from './SearchHostedAgents.svelte';
 	import SearchUsers from './SearchUsers.svelte';
+	import { resolveSubjects } from './subjectResolver';
 	import { Plus, Trash2 } from '@lucide/svelte';
 	import { onMount, untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -98,33 +98,11 @@
 
 		loadingUsersAndGroups = true;
 
-		// Prevent refetching when adding new users or groups
-		const promises: [Promise<OrgUser[] | undefined>, Promise<OrgGroup[] | undefined>] = [
-			Promise.resolve(undefined),
-			Promise.resolve(undefined)
-		];
-
-		if (!usersAndGroups?.users) {
-			promises[0] = UserService.listUsers();
-		}
-		if (!usersAndGroups?.groups) {
-			promises[1] = UserService.listGroups();
-		}
-
-		Promise.all(promises)
-			.then(([users, groups]) => {
-				if (!usersAndGroups) {
-					usersAndGroups = { users: [], groups: [] };
-				}
-
-				if (users) {
-					usersAndGroups!.users = users;
-				}
-
-				if (groups) {
-					usersAndGroups!.groups = groups;
-				}
-
+		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
+		// only the ones attached here are needed.
+		resolveSubjects(policy.subjects, usersAndGroups)
+			.then((resolved) => {
+				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {

--- a/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
@@ -93,6 +93,7 @@
 	$effect(() => {
 		// Prevent loading users and groups if the policy has no subjects
 		if (!policy.subjects || policy.subjects?.length === 0) {
+			loadingUsersAndGroups = false;
 			return;
 		}
 

--- a/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
@@ -100,18 +100,25 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
+		const controller = new AbortController();
+
 		resolveSubjects(
 			policy.subjects,
-			untrack(() => usersAndGroups)
+			untrack(() => usersAndGroups),
+			{ signal: controller.signal }
 		)
 			.then((resolved) => {
+				if (controller.signal.aborted) return;
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {
+				if (controller.signal.aborted) return;
 				console.error('Failed to load users and groups:', error);
 				loadingUsersAndGroups = false;
 			});
+
+		return () => controller.abort();
 	});
 
 	function convertResourcesToTableData(resources: HostedAgentAccessPolicyResource[]) {

--- a/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/HostedAgentAccessPolicyForm.svelte
@@ -100,7 +100,10 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
-		resolveSubjects(policy.subjects, usersAndGroups)
+		resolveSubjects(
+			policy.subjects,
+			untrack(() => usersAndGroups)
+		)
 			.then((resolved) => {
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;

--- a/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
@@ -4,7 +4,6 @@
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
-		UserService,
 		type MessagePolicy,
 		type MessagePolicyManifest,
 		type AccessControlRuleSubject,
@@ -20,6 +19,7 @@
 	import IconButton from '../primitives/IconButton.svelte';
 	import Table from '../table/Table.svelte';
 	import SearchUsers from './SearchUsers.svelte';
+	import { resolveSubjects } from './subjectResolver';
 	import { CircleQuestionMark, Plus, Trash2 } from '@lucide/svelte';
 	import { untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -83,32 +83,11 @@
 
 		loadingUsersAndGroups = true;
 
-		const promises: [Promise<OrgUser[] | undefined>, Promise<OrgGroup[] | undefined>] = [
-			Promise.resolve(undefined),
-			Promise.resolve(undefined)
-		];
-
-		if (!usersAndGroups?.users) {
-			promises[0] = UserService.listUsers();
-		}
-		if (!usersAndGroups?.groups) {
-			promises[1] = UserService.listGroups();
-		}
-
-		Promise.all(promises)
-			.then(([users, groups]) => {
-				if (!usersAndGroups) {
-					usersAndGroups = { users: [], groups: [] };
-				}
-
-				if (users) {
-					usersAndGroups!.users = users;
-				}
-
-				if (groups) {
-					usersAndGroups!.groups = groups;
-				}
-
+		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
+		// only the ones attached here are needed.
+		resolveSubjects(messagePolicy.subjects, usersAndGroups)
+			.then((resolved) => {
+				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {

--- a/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
@@ -85,7 +85,10 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
-		resolveSubjects(messagePolicy.subjects, usersAndGroups)
+		resolveSubjects(
+			messagePolicy.subjects,
+			untrack(() => usersAndGroups)
+		)
 			.then((resolved) => {
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;

--- a/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
@@ -85,18 +85,25 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
+		const controller = new AbortController();
+
 		resolveSubjects(
 			messagePolicy.subjects,
-			untrack(() => usersAndGroups)
+			untrack(() => usersAndGroups),
+			{ signal: controller.signal }
 		)
 			.then((resolved) => {
+				if (controller.signal.aborted) return;
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {
+				if (controller.signal.aborted) return;
 				console.error('Failed to load users and groups:', error);
 				loadingUsersAndGroups = false;
 			});
+
+		return () => controller.abort();
 	});
 
 	function convertSubjectsToTableData(

--- a/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/MessagePolicyForm.svelte
@@ -78,6 +78,7 @@
 
 	$effect(() => {
 		if (!messagePolicy.subjects || messagePolicy.subjects?.length === 0) {
+			loadingUsersAndGroups = false;
 			return;
 		}
 

--- a/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
@@ -193,7 +193,10 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
-		resolveSubjects(modelAccessPolicy.subjects, usersAndGroups)
+		resolveSubjects(
+			modelAccessPolicy.subjects,
+			untrack(() => usersAndGroups)
+		)
 			.then((resolved) => {
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;

--- a/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
@@ -13,8 +13,7 @@
 		ModelUsageLabels,
 		ModelAlias,
 		ModelAliasLabels,
-		type Model,
-		UserService
+		type Model
 	} from '$lib/services';
 	import { defaultModelAliases as defaultModelAliasesStore } from '$lib/stores';
 	import { goto } from '$lib/url';
@@ -24,6 +23,7 @@
 	import Table from '../table/Table.svelte';
 	import SearchModels from './SearchModels.svelte';
 	import SearchUsers from './SearchUsers.svelte';
+	import { resolveSubjects } from './subjectResolver';
 	import { Plus, Trash2, TriangleAlert } from '@lucide/svelte';
 	import { onMount, untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -191,34 +191,11 @@
 
 		loadingUsersAndGroups = true;
 
-		// Prevent refetching when adding new users or groups
-		const promises: [Promise<OrgUser[] | undefined>, Promise<OrgGroup[] | undefined>] = [
-			Promise.resolve(undefined),
-			Promise.resolve(undefined)
-		];
-
-		if (!usersAndGroups?.users) {
-			promises[0] = UserService.listUsers();
-		}
-		if (!usersAndGroups?.groups) {
-			// Load groups when they have not already been fetched.
-			promises[1] = UserService.listGroups();
-		}
-
-		Promise.all(promises)
-			.then(([users, groups]) => {
-				if (!usersAndGroups) {
-					usersAndGroups = { users: [], groups: [] };
-				}
-
-				if (users) {
-					usersAndGroups!.users = users;
-				}
-
-				if (groups) {
-					usersAndGroups!.groups = groups;
-				}
-
+		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
+		// only the ones attached here are needed.
+		resolveSubjects(modelAccessPolicy.subjects, usersAndGroups)
+			.then((resolved) => {
+				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {

--- a/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
@@ -186,6 +186,7 @@
 	$effect(() => {
 		// Prevent loading users and groups if rule has no subjects
 		if (!modelAccessPolicy.subjects || modelAccessPolicy.subjects?.length === 0) {
+			loadingUsersAndGroups = false;
 			return;
 		}
 

--- a/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/ModelAccessPolicyForm.svelte
@@ -193,18 +193,25 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
+		const controller = new AbortController();
+
 		resolveSubjects(
 			modelAccessPolicy.subjects,
-			untrack(() => usersAndGroups)
+			untrack(() => usersAndGroups),
+			{ signal: controller.signal }
 		)
 			.then((resolved) => {
+				if (controller.signal.aborted) return;
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {
+				if (controller.signal.aborted) return;
 				console.error('Failed to load users and groups:', error);
 				loadingUsersAndGroups = false;
 			});
+
+		return () => controller.abort();
 	});
 
 	function convertSubjectsToTableData(

--- a/ui/user/src/lib/components/admin/SearchUsers.svelte
+++ b/ui/user/src/lib/components/admin/SearchUsers.svelte
@@ -25,7 +25,7 @@
 	let selectedUsersMap = $derived(new Set(selectedUsers.map((user) => user.id)));
 	let filteredUsers = $state<OrgUser[]>([]);
 	let filteredGroups = $state<OrgGroup[]>([]);
-	let groupsTotal = $state(0);
+	let groupsHasMore = $state(false);
 	let groupsDegraded = $state(false);
 
 	// Only the first page of groups is fetched; the search box narrows it server-side.
@@ -75,7 +75,7 @@
 			});
 
 			filteredGroups = [...page.items].sort((a, b) => a.name.localeCompare(b.name));
-			groupsTotal = page.total;
+			groupsHasMore = Boolean(page.nextCursor);
 			groupsDegraded = page.degraded;
 		} catch (error) {
 			console.error('Error loading groups:', error);
@@ -117,7 +117,7 @@
 		selectedUsers = [];
 		filteredUsers = [];
 		filteredGroups = [];
-		groupsTotal = 0;
+		groupsHasMore = false;
 		groupsDegraded = false;
 	}
 </script>
@@ -154,9 +154,9 @@
 					permission may not be granted.
 				</span>
 			</div>
-		{:else if groupsTotal > filteredGroups.length}
+		{:else if groupsHasMore}
 			<p class="text-muted-content px-4 text-xs">
-				Showing {filteredGroups.length} of {groupsTotal} groups. Refine your search to narrow the list.
+				Showing the first {filteredGroups.length} groups. Refine your search to narrow the list.
 			</p>
 		{/if}
 		{#if loading}

--- a/ui/user/src/lib/components/admin/SearchUsers.svelte
+++ b/ui/user/src/lib/components/admin/SearchUsers.svelte
@@ -5,7 +5,7 @@
 	import { getUserRoleLabel } from '$lib/utils';
 	import ResponsiveDialog from '../ResponsiveDialog.svelte';
 	import Search from '../Search.svelte';
-	import { Check, User, Users } from '@lucide/svelte';
+	import { Check, TriangleAlert, User, Users } from '@lucide/svelte';
 	import { debounce } from 'es-toolkit';
 	import { twMerge } from 'tailwind-merge';
 
@@ -13,27 +13,27 @@
 		onAdd: (users: OrgUser[], groups: OrgGroup[]) => void;
 		filterIds?: string[];
 		initialUsers?: OrgUser[];
-		initialGroups?: OrgGroup[];
 	}
 
-	let { onAdd, filterIds, initialUsers = [], initialGroups = [] }: Props = $props();
+	let { onAdd, filterIds, initialUsers = [] }: Props = $props();
 
 	let addUserGroupDialog = $state<ReturnType<typeof ResponsiveDialog>>();
 	let users = $state<OrgUser[]>([]);
-	let groups = $state<OrgGroup[]>([]);
 	let loading = $state(false);
 	let searchNames = $state('');
 	let selectedUsers = $state<(OrgUser | OrgGroup)[]>([]);
 	let selectedUsersMap = $derived(new Set(selectedUsers.map((user) => user.id)));
 	let filteredUsers = $state<OrgUser[]>([]);
 	let filteredGroups = $state<OrgGroup[]>([]);
+	let groupsTotal = $state(0);
+	let groupsDegraded = $state(false);
+
+	// Only the first page of groups is fetched; the search box narrows it server-side.
+	const GROUP_PAGE_SIZE = 50;
 
 	$effect(() => {
 		if (initialUsers.length > 0) {
 			users = initialUsers;
-		}
-		if (initialGroups.length > 0) {
-			groups = initialGroups;
 		}
 	});
 
@@ -67,18 +67,16 @@
 				: users;
 
 		try {
-			// Fetch groups with server-side search
-			filteredGroups =
-				searchNames.length === 0 && groups.length > 0
-					? [...groups].sort((a, b) => a.name.localeCompare(b.name))
-					: (
-							await UserService.listGroups(
-								searchNames.length > 0 ? { query: searchNames } : undefined
-							)
-						).sort((a, b) => a.name.localeCompare(b.name));
-			if (searchNames.length === 0) {
-				groups = filteredGroups;
-			}
+			// Groups are searched and paged server-side: a directory can hold far more than can be
+			// listed at once, so only the first page is fetched and the user narrows with the query.
+			const page = await UserService.listGroups({
+				query: searchNames.length > 0 ? searchNames : undefined,
+				limit: GROUP_PAGE_SIZE
+			});
+
+			filteredGroups = [...page.items].sort((a, b) => a.name.localeCompare(b.name));
+			groupsTotal = page.total;
+			groupsDegraded = page.degraded;
 		} catch (error) {
 			console.error('Error loading groups:', error);
 		} finally {
@@ -119,6 +117,8 @@
 		selectedUsers = [];
 		filteredUsers = [];
 		filteredGroups = [];
+		groupsTotal = 0;
+		groupsDegraded = false;
 	}
 </script>
 
@@ -143,6 +143,22 @@
 				placeholder="Search by user name, email, or group name..."
 			/>
 		</div>
+		{#if groupsDegraded}
+			<div
+				class="mx-4 flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs"
+				role="status"
+			>
+				<TriangleAlert class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+				<span>
+					Showing only groups seen from previous sign-ins &mdash; directory-wide group read
+					permission may not be granted.
+				</span>
+			</div>
+		{:else if groupsTotal > filteredGroups.length}
+			<p class="text-muted-content px-4 text-xs">
+				Showing {filteredGroups.length} of {groupsTotal} groups. Refine your search to narrow the list.
+			</p>
+		{/if}
 		{#if loading}
 			<div class="flex grow items-center justify-center">
 				<Loading class="size-6" />

--- a/ui/user/src/lib/components/admin/SearchUsers.svelte
+++ b/ui/user/src/lib/components/admin/SearchUsers.svelte
@@ -35,6 +35,8 @@
 	// after a fast one for a later query. Only the newest request is allowed to write state.
 	let inFlight: AbortController | undefined;
 
+	let dialogOpen = false;
+
 	$effect(() => {
 		if (initialUsers.length > 0) {
 			users = initialUsers;
@@ -58,6 +60,10 @@
 	});
 
 	async function search() {
+		if (!dialogOpen) {
+			return;
+		}
+
 		inFlight?.abort();
 		const controller = new AbortController();
 		inFlight = controller;
@@ -82,7 +88,7 @@
 				limit: GROUP_PAGE_SIZE,
 				signal: controller.signal
 			});
-			if (controller.signal.aborted) return;
+			if (controller.signal.aborted || !dialogOpen) return;
 
 			filteredGroups = [...page.items].sort((a, b) => a.name.localeCompare(b.name));
 			groupsHasMore = Boolean(page.nextCursor);
@@ -108,11 +114,13 @@
 	}
 
 	async function onOpen() {
+		dialogOpen = true;
 		loading = true;
 
+		let loaded: OrgUser[] | undefined;
 		try {
 			if (users.length === 0) {
-				users = await UserService.listUsers();
+				loaded = await UserService.listUsers();
 			}
 		} catch (error) {
 			console.error('Error loading initial users:', error);
@@ -120,12 +128,21 @@
 			loading = false;
 		}
 
+		// The dialog can be closed while the user list is still loading.
+		if (!dialogOpen) {
+			return;
+		}
+		if (loaded) {
+			users = loaded;
+		}
+
 		// Now search to populate filtered data
 		await search();
 	}
 
 	function onClose() {
-		// A response landing after the dialog closed would repopulate the list behind it.
+		dialogOpen = false;
+		handleSearch.cancel();
 		inFlight?.abort();
 		inFlight = undefined;
 

--- a/ui/user/src/lib/components/admin/SearchUsers.svelte
+++ b/ui/user/src/lib/components/admin/SearchUsers.svelte
@@ -31,6 +31,10 @@
 	// Only the first page of groups is fetched; the search box narrows it server-side.
 	const GROUP_PAGE_SIZE = 50;
 
+	// Searches are debounced but not serialized, so a slow request for an earlier query can land
+	// after a fast one for a later query. Only the newest request is allowed to write state.
+	let inFlight: AbortController | undefined;
+
 	$effect(() => {
 		if (initialUsers.length > 0) {
 			users = initialUsers;
@@ -54,6 +58,10 @@
 	});
 
 	async function search() {
+		inFlight?.abort();
+		const controller = new AbortController();
+		inFlight = controller;
+
 		loading = true;
 
 		filteredUsers =
@@ -71,16 +79,21 @@
 			// listed at once, so only the first page is fetched and the user narrows with the query.
 			const page = await UserService.listGroups({
 				query: searchNames.length > 0 ? searchNames : undefined,
-				limit: GROUP_PAGE_SIZE
+				limit: GROUP_PAGE_SIZE,
+				signal: controller.signal
 			});
+			if (controller.signal.aborted) return;
 
 			filteredGroups = [...page.items].sort((a, b) => a.name.localeCompare(b.name));
 			groupsHasMore = Boolean(page.nextCursor);
 			groupsDegraded = page.degraded;
 		} catch (error) {
+			if (controller.signal.aborted) return;
 			console.error('Error loading groups:', error);
 		} finally {
-			loading = false;
+			if (!controller.signal.aborted) {
+				loading = false;
+			}
 		}
 	}
 
@@ -112,6 +125,10 @@
 	}
 
 	function onClose() {
+		// A response landing after the dialog closed would repopulate the list behind it.
+		inFlight?.abort();
+		inFlight = undefined;
+
 		loading = false;
 		searchNames = '';
 		selectedUsers = [];
@@ -150,8 +167,8 @@
 			>
 				<TriangleAlert class="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
 				<span>
-					Showing only groups seen from previous sign-ins &mdash; directory-wide group read
-					permission may not be granted.
+					Showing only groups Obot has already recorded &mdash; directory-wide group read permission
+					may not be granted.
 				</span>
 			</div>
 		{:else if groupsHasMore}

--- a/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
+++ b/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
@@ -112,7 +112,7 @@
 			return user.displayName ?? user.email ?? user.username ?? id;
 		} else if (subject.type === 'group') {
 			const group = groupMap.get(subject.id);
-			if (!group) return '';
+			if (!group) return subject.id;
 			return group.name ?? group.id ?? subject.id;
 		}
 

--- a/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
+++ b/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
@@ -47,14 +47,19 @@
 		users = await UserService.listUsers();
 		// Resolve only the groups these rules actually reference; the directory may hold tens of
 		// thousands and this dialog just needs their display names.
-		groups = await UserService.resolveGroups([
-			...new Set(
-				accessControlRules
-					.flatMap((rule) => rule.subjects ?? [])
-					.filter((subject) => subject.type === 'group' && subject.id !== '*')
-					.map((subject) => subject.id)
-			)
-		]);
+		try {
+			groups = await UserService.resolveGroups([
+				...new Set(
+					accessControlRules
+						.flatMap((rule) => rule.subjects ?? [])
+						.filter((subject) => subject.type === 'group' && subject.id !== '*')
+						.map((subject) => subject.id)
+				)
+			]);
+		} catch (error) {
+			console.error('Failed to resolve group names:', error);
+		}
+
 		dialog?.open();
 	}
 

--- a/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
+++ b/ui/user/src/lib/components/admin/SelectMcpAccessControlRules.svelte
@@ -45,7 +45,16 @@
 				? await UserService.listWorkspaceAccessControlRules(id)
 				: await AdminService.listAccessControlRules();
 		users = await UserService.listUsers();
-		groups = await UserService.listGroups();
+		// Resolve only the groups these rules actually reference; the directory may hold tens of
+		// thousands and this dialog just needs their display names.
+		groups = await UserService.resolveGroups([
+			...new Set(
+				accessControlRules
+					.flatMap((rule) => rule.subjects ?? [])
+					.filter((subject) => subject.type === 'group' && subject.id !== '*')
+					.map((subject) => subject.id)
+			)
+		]);
 		dialog?.open();
 	}
 

--- a/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
@@ -104,7 +104,10 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
-		resolveSubjects(skillAccessPolicy.subjects, usersAndGroups)
+		resolveSubjects(
+			skillAccessPolicy.subjects,
+			untrack(() => usersAndGroups)
+		)
 			.then((resolved) => {
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;

--- a/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
@@ -97,6 +97,7 @@
 	$effect(() => {
 		// Prevent loading users and groups if rule has no subjects
 		if (!skillAccessPolicy.subjects || skillAccessPolicy.subjects?.length === 0) {
+			loadingUsersAndGroups = false;
 			return;
 		}
 

--- a/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
@@ -104,18 +104,25 @@
 
 		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
 		// only the ones attached here are needed.
+		const controller = new AbortController();
+
 		resolveSubjects(
 			skillAccessPolicy.subjects,
-			untrack(() => usersAndGroups)
+			untrack(() => usersAndGroups),
+			{ signal: controller.signal }
 		)
 			.then((resolved) => {
+				if (controller.signal.aborted) return;
 				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {
+				if (controller.signal.aborted) return;
 				console.error('Failed to load users and groups:', error);
 				loadingUsersAndGroups = false;
 			});
+
+		return () => controller.abort();
 	});
 
 	function convertResourcesToTableData(resources: SkillAccessPolicyResource[]) {

--- a/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
+++ b/ui/user/src/lib/components/admin/SkillAccessPolicyForm.svelte
@@ -3,7 +3,6 @@
 	import Loading from '$lib/icons/Loading.svelte';
 	import {
 		AdminService,
-		UserService,
 		type AccessControlRuleSubject,
 		type OrgUser,
 		type OrgGroup,
@@ -20,6 +19,7 @@
 	import Table from '../table/Table.svelte';
 	import SearchSkills from './SearchSkills.svelte';
 	import SearchUsers from './SearchUsers.svelte';
+	import { resolveSubjects } from './subjectResolver';
 	import { Plus, Trash2 } from '@lucide/svelte';
 	import { onMount, untrack } from 'svelte';
 	import { fly } from 'svelte/transition';
@@ -102,33 +102,11 @@
 
 		loadingUsersAndGroups = true;
 
-		// Prevent refetching when adding new users or groups
-		const promises: [Promise<OrgUser[] | undefined>, Promise<OrgGroup[] | undefined>] = [
-			Promise.resolve(undefined),
-			Promise.resolve(undefined)
-		];
-
-		if (!usersAndGroups?.users) {
-			promises[0] = UserService.listUsers();
-		}
-		if (!usersAndGroups?.groups) {
-			promises[1] = UserService.listGroups();
-		}
-
-		Promise.all(promises)
-			.then(([users, groups]) => {
-				if (!usersAndGroups) {
-					usersAndGroups = { users: [], groups: [] };
-				}
-
-				if (users) {
-					usersAndGroups!.users = users;
-				}
-
-				if (groups) {
-					usersAndGroups!.groups = groups;
-				}
-
+		// Groups are resolved by ID, not listed: the directory can hold tens of thousands of them and
+		// only the ones attached here are needed.
+		resolveSubjects(skillAccessPolicy.subjects, usersAndGroups)
+			.then((resolved) => {
+				usersAndGroups = resolved;
 				loadingUsersAndGroups = false;
 			})
 			.catch((error) => {

--- a/ui/user/src/lib/components/admin/subjectResolver.ts
+++ b/ui/user/src/lib/components/admin/subjectResolver.ts
@@ -19,10 +19,14 @@ export interface ResolvedSubjects {
  *
  * `existing` lets a caller keep whatever it already has: users are fetched only once, and groups
  * only for IDs that are not already known.
+ *
+ * Pass `signal` from a caller that can ask again before the first answer arrives, so that a
+ * superseded request is dropped rather than left to land last and overwrite current state.
  */
 export async function resolveSubjects(
 	subjects: AccessControlRuleSubject[] | undefined,
-	existing?: Partial<ResolvedSubjects>
+	existing?: Partial<ResolvedSubjects>,
+	opts?: { signal?: AbortSignal }
 ): Promise<ResolvedSubjects> {
 	const resolved: ResolvedSubjects = {
 		users: existing?.users ?? [],
@@ -45,8 +49,10 @@ export async function resolveSubjects(
 	];
 
 	const [users, groups] = await Promise.all([
-		existing?.users?.length ? Promise.resolve(undefined) : UserService.listUsers(),
-		missingGroupIds.length > 0 ? UserService.resolveGroups(missingGroupIds) : Promise.resolve([])
+		existing?.users?.length ? Promise.resolve(undefined) : UserService.listUsers(opts),
+		missingGroupIds.length > 0
+			? UserService.resolveGroups(missingGroupIds, opts)
+			: Promise.resolve([])
 	]);
 
 	if (users) {

--- a/ui/user/src/lib/components/admin/subjectResolver.ts
+++ b/ui/user/src/lib/components/admin/subjectResolver.ts
@@ -1,0 +1,60 @@
+import {
+	UserService,
+	type AccessControlRuleSubject,
+	type OrgGroup,
+	type OrgUser
+} from '$lib/services';
+
+export interface ResolvedSubjects {
+	users: OrgUser[];
+	groups: OrgGroup[];
+}
+
+/**
+ * Loads the users and groups needed to render a policy's or rule's subjects.
+ *
+ * Groups are resolved by ID rather than listed. A directory can hold tens of thousands of groups,
+ * so fetching the whole collection to build a lookup map would both be wasteful and silently drop
+ * any subject whose group fell outside the first page.
+ *
+ * `existing` lets a caller keep whatever it already has: users are fetched only once, and groups
+ * only for IDs that are not already known.
+ */
+export async function resolveSubjects(
+	subjects: AccessControlRuleSubject[] | undefined,
+	existing?: Partial<ResolvedSubjects>
+): Promise<ResolvedSubjects> {
+	const resolved: ResolvedSubjects = {
+		users: existing?.users ?? [],
+		groups: existing?.groups ?? []
+	};
+
+	if (!subjects || subjects.length === 0) {
+		return resolved;
+	}
+
+	const known = new Set(resolved.groups.map((group) => group.id));
+	const missingGroupIds = [
+		...new Set(
+			subjects
+				.filter((subject) => subject.type === 'group')
+				.map((subject) => subject.id)
+				// The "all users" pseudo-group is client-side only and has no directory entry.
+				.filter((id) => id !== '*' && !known.has(id))
+		)
+	];
+
+	const [users, groups] = await Promise.all([
+		existing?.users?.length ? Promise.resolve(undefined) : UserService.listUsers(),
+		missingGroupIds.length > 0 ? UserService.resolveGroups(missingGroupIds) : Promise.resolve([])
+	]);
+
+	if (users) {
+		resolved.users = users;
+	}
+	if (groups.length > 0) {
+		resolved.groups = [...resolved.groups, ...groups];
+	}
+
+	return resolved;
+}

--- a/ui/user/src/lib/components/admin/subjectResolver.ts
+++ b/ui/user/src/lib/components/admin/subjectResolver.ts
@@ -49,7 +49,7 @@ export async function resolveSubjects(
 	];
 
 	const [users, groups] = await Promise.all([
-		existing?.users?.length ? Promise.resolve(undefined) : UserService.listUsers(opts),
+		existing?.users ? Promise.resolve(undefined) : UserService.listUsers(opts),
 		missingGroupIds.length > 0
 			? UserService.resolveGroups(missingGroupIds, opts)
 			: Promise.resolve([])

--- a/ui/user/src/lib/components/nanobot/PublishedWorkflowVersionDialog.svelte
+++ b/ui/user/src/lib/components/nanobot/PublishedWorkflowVersionDialog.svelte
@@ -58,9 +58,19 @@
 	let activeSubjects = $derived(activeVersion?.subjects ?? []);
 
 	$effect(() => {
+		// Groups are resolved by ID rather than listed: only the ones attached to this version are
+		// needed, and the directory can be far too large to fetch whole.
+		const groupIds = [
+			...new Set(
+				activeSubjects
+					.filter((subject) => subject.type === 'group' && subject.id !== '*')
+					.map((subject) => subject.id)
+			)
+		];
+
 		Promise.all([
 			UserService.listUsers().catch(() => []),
-			UserService.listGroups().catch(() => [])
+			UserService.resolveGroups(groupIds).catch(() => [])
 		]).then(([loadedUsers, loadedGroups]) => {
 			users = loadedUsers;
 			groups = loadedGroups;
@@ -316,7 +326,6 @@
 	bind:this={addUserGroupDialog}
 	filterIds={activeSubjects.map((subject) => subject.id)}
 	initialUsers={users}
-	initialGroups={groups}
 	onAdd={(addedUsers: OrgUser[], addedGroups: OrgGroup[]) => {
 		const existingSubjectIds = new Set(activeSubjects.map((subject) => subject.id));
 		const nextSubjects = addedGroups.some((entry) => entry.id === '*')

--- a/ui/user/src/lib/components/nanobot/PublishedWorkflowVersionDialog.svelte
+++ b/ui/user/src/lib/components/nanobot/PublishedWorkflowVersionDialog.svelte
@@ -68,13 +68,19 @@
 			)
 		];
 
+		const controller = new AbortController();
+		const opts = { signal: controller.signal };
+
 		Promise.all([
-			UserService.listUsers().catch(() => []),
-			UserService.resolveGroups(groupIds).catch(() => [])
+			UserService.listUsers(opts).catch(() => []),
+			UserService.resolveGroups(groupIds, opts).catch(() => [])
 		]).then(([loadedUsers, loadedGroups]) => {
+			if (controller.signal.aborted) return;
 			users = loadedUsers;
 			groups = loadedGroups;
 		});
+
+		return () => controller.abort();
 	});
 
 	async function fetchVersionContents(selectedVersion: PublishedArtifactVersion) {

--- a/ui/user/src/lib/components/table/CursorPagination.svelte
+++ b/ui/user/src/lib/components/table/CursorPagination.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { ChevronsLeft, ChevronsRight } from '@lucide/svelte';
+
+	/**
+	 * Previous/next pager for listings that page by cursor.
+	 *
+	 * Unlike `Pagination.svelte`, this one has no total and no last page: a cursor-paged source
+	 * knows only whether another page exists, so the page count cannot be shown and an arbitrary
+	 * page cannot be jumped to.
+	 */
+	interface Props {
+		pageIndex: number;
+		hasPrevious: boolean;
+		hasNext: boolean;
+		loading?: boolean;
+		onPrevious: () => void;
+		onNext: () => void;
+	}
+
+	let { pageIndex, hasPrevious, hasNext, loading = false, onPrevious, onNext }: Props = $props();
+</script>
+
+<div class="flex items-center justify-center gap-4 pt-2">
+	<button
+		class="button-text flex items-center gap-1 text-xs disabled:cursor-default disabled:opacity-50"
+		disabled={!hasPrevious || loading}
+		onclick={onPrevious}
+	>
+		<ChevronsLeft class="size-4" /> Previous
+	</button>
+	<p class="text-muted-content text-xs">
+		Page {pageIndex + 1}
+	</p>
+	<button
+		class="button-text flex items-center gap-1 text-xs disabled:cursor-default disabled:opacity-50"
+		disabled={!hasNext || loading}
+		onclick={onNext}
+	>
+		Next <ChevronsRight class="size-4" />
+	</button>
+</div>

--- a/ui/user/src/lib/components/table/CursorPagination.svelte.spec.ts
+++ b/ui/user/src/lib/components/table/CursorPagination.svelte.spec.ts
@@ -69,10 +69,10 @@ describe('CursorPagination', () => {
 
 		const previous = page.getByRole('button', { name: /Previous/ });
 		await expect.element(previous).toBeDisabled();
-		expect(getComputedStyle((await previous.element()) as HTMLElement).opacity).toBe('0.5');
+		await expect.element(previous).toHaveStyle({ opacity: '0.5' });
 
 		const next = page.getByRole('button', { name: /Next/ });
-		expect(getComputedStyle((await next.element()) as HTMLElement).opacity).toBe('1');
+		await expect.element(next).toHaveStyle({ opacity: '1' });
 	});
 
 	it('reports which direction was clicked', async () => {

--- a/ui/user/src/lib/components/table/CursorPagination.svelte.spec.ts
+++ b/ui/user/src/lib/components/table/CursorPagination.svelte.spec.ts
@@ -1,0 +1,95 @@
+import CursorPagination from './CursorPagination.svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+describe('CursorPagination', () => {
+	it('shows a one-based page number', async () => {
+		render(CursorPagination, {
+			pageIndex: 2,
+			hasPrevious: true,
+			hasNext: true,
+			onPrevious: vi.fn(),
+			onNext: vi.fn()
+		});
+
+		await expect.element(page.getByText('Page 3')).toBeInTheDocument();
+	});
+
+	it('disables Previous on the first page', async () => {
+		render(CursorPagination, {
+			pageIndex: 0,
+			hasPrevious: false,
+			hasNext: true,
+			onPrevious: vi.fn(),
+			onNext: vi.fn()
+		});
+
+		await expect.element(page.getByRole('button', { name: /Previous/ })).toBeDisabled();
+		await expect.element(page.getByRole('button', { name: /Next/ })).not.toBeDisabled();
+	});
+
+	// Without a total, the absence of a next cursor is the only way to know this is the last page.
+	it('disables Next on the last page', async () => {
+		render(CursorPagination, {
+			pageIndex: 3,
+			hasPrevious: true,
+			hasNext: false,
+			onPrevious: vi.fn(),
+			onNext: vi.fn()
+		});
+
+		await expect.element(page.getByRole('button', { name: /Next/ })).toBeDisabled();
+		await expect.element(page.getByRole('button', { name: /Previous/ })).not.toBeDisabled();
+	});
+
+	it('disables both controls while a page is loading', async () => {
+		render(CursorPagination, {
+			pageIndex: 1,
+			hasPrevious: true,
+			hasNext: true,
+			loading: true,
+			onPrevious: vi.fn(),
+			onNext: vi.fn()
+		});
+
+		await expect.element(page.getByRole('button', { name: /Previous/ })).toBeDisabled();
+		await expect.element(page.getByRole('button', { name: /Next/ })).toBeDisabled();
+	});
+
+	// A disabled control has to look disabled, not just refuse the click.
+	it('dims the control it disables', async () => {
+		render(CursorPagination, {
+			pageIndex: 0,
+			hasPrevious: false,
+			hasNext: true,
+			onPrevious: vi.fn(),
+			onNext: vi.fn()
+		});
+
+		const previous = page.getByRole('button', { name: /Previous/ });
+		await expect.element(previous).toBeDisabled();
+		expect(getComputedStyle((await previous.element()) as HTMLElement).opacity).toBe('0.5');
+
+		const next = page.getByRole('button', { name: /Next/ });
+		expect(getComputedStyle((await next.element()) as HTMLElement).opacity).toBe('1');
+	});
+
+	it('reports which direction was clicked', async () => {
+		const onPrevious = vi.fn();
+		const onNext = vi.fn();
+		render(CursorPagination, {
+			pageIndex: 1,
+			hasPrevious: true,
+			hasNext: true,
+			onPrevious,
+			onNext
+		});
+
+		await page.getByRole('button', { name: /Next/ }).click();
+		expect(onNext).toHaveBeenCalledOnce();
+
+		await page.getByRole('button', { name: /Previous/ }).click();
+		expect(onPrevious).toHaveBeenCalledOnce();
+	});
+});

--- a/ui/user/src/lib/components/table/Pagination.svelte
+++ b/ui/user/src/lib/components/table/Pagination.svelte
@@ -22,7 +22,7 @@
 
 <div class="flex items-center justify-center gap-4 pt-2">
 	<button
-		class="button-text flex items-center gap-1 text-xs"
+		class="button-text flex items-center gap-1 text-xs disabled:cursor-default disabled:opacity-50"
 		disabled={pageIndex === 0 || loading}
 		onclick={() => onPageChange(pageIndex - 1)}
 	>
@@ -34,7 +34,7 @@
 			{itemLabelSingular}{total === 1 ? '' : 's'}{/if}
 	</p>
 	<button
-		class="button-text flex items-center gap-1 text-xs"
+		class="button-text flex items-center gap-1 text-xs disabled:cursor-default disabled:opacity-50"
 		disabled={pageIndex >= lastPageIndex || loading}
 		onclick={() => onPageChange(pageIndex + 1)}
 	>

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -663,6 +663,7 @@ export async function listGroups(opts?: {
 }
 
 const RESOLVE_GROUPS_CHUNK_SIZE = 100;
+const RESOLVE_GROUPS_MAX_CONCURRENCY = 4;
 
 /**
  * Resolves specific group IDs to their display names.
@@ -681,10 +682,23 @@ export async function resolveGroups(
 		batches.push(ids.slice(i, i + RESOLVE_GROUPS_CHUNK_SIZE));
 	}
 
-	const pages = await Promise.all(
-		batches.map(
-			(batch) => doGet(`/groups?${buildQueryString({ ids: batch })}`, opts) as Promise<OrgGroupPage>
-		)
+	// Indexed rather than appended, so the result stays in the order the IDs were asked for however
+	// the requests interleave.
+	const pages: OrgGroupPage[] = new Array(batches.length);
+	let next = 0;
+
+	async function worker() {
+		while (next < batches.length) {
+			const index = next++;
+			pages[index] = (await doGet(
+				`/groups?${buildQueryString({ ids: batches[index] })}`,
+				opts
+			)) as OrgGroupPage;
+		}
+	}
+
+	await Promise.all(
+		Array.from({ length: Math.min(RESOLVE_GROUPS_MAX_CONCURRENCY, batches.length) }, () => worker())
 	);
 
 	return pages.flatMap((page) => page?.items ?? []);

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -632,19 +632,21 @@ export async function listGlobalModelProviders(opts?: {
  * Fetches one page of the auth provider's groups.
  *
  * A directory can hold tens of thousands of groups, so callers must page rather than expect the
- * whole collection. Use `resolveGroups` instead when you already know which group IDs you need.
+ * whole collection. Paging is by opaque cursor, forwarded to the identity provider, so there is no
+ * total and no way to jump to an arbitrary page. Use `resolveGroups` instead when you already know
+ * which group IDs you need.
  */
 export async function listGroups(opts?: {
 	fetch?: Fetcher;
 	query?: string;
 	limit?: number;
-	offset?: number;
+	cursor?: string;
 	signal?: AbortSignal;
 }): Promise<OrgGroupPage> {
 	const queryString = buildQueryString({
 		name: opts?.query,
 		limit: opts?.limit,
-		offset: opts?.offset
+		cursor: opts?.cursor
 	});
 	const response = (await doGet(
 		`/groups${queryString ? `?${queryString}` : ''}`,
@@ -653,9 +655,7 @@ export async function listGroups(opts?: {
 
 	return {
 		items: response?.items ?? [],
-		total: response?.total ?? 0,
-		limit: response?.limit ?? 0,
-		offset: response?.offset ?? 0,
+		nextCursor: response?.nextCursor || undefined,
 		source: response?.source ?? 'provider',
 		degraded: response?.degraded ?? false
 	};

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -49,6 +49,7 @@ import {
 	type Model,
 	type ModelProviderList,
 	type OrgGroup,
+	type OrgGroupPage,
 	type OrgUser,
 	type Profile,
 	type McpServerOrInstanceAuditLogStatsFilters,
@@ -627,14 +628,51 @@ export async function listGlobalModelProviders(opts?: {
 
 // Organization
 
-export async function listGroups(opts?: { fetch?: Fetcher; query?: string }): Promise<OrgGroup[]> {
-	const params: string[] = [];
-	if (opts?.query !== undefined) {
-		params.push(`name=${encodeURIComponent(opts.query)}`);
-	}
-	const queryString = params.length ? `?${params.join('&')}` : '';
-	const response = (await doGet(`/groups${queryString}`, opts)) as OrgGroup[];
-	return response ?? [];
+/**
+ * Fetches one page of the auth provider's groups.
+ *
+ * A directory can hold tens of thousands of groups, so callers must page rather than expect the
+ * whole collection. Use `resolveGroups` instead when you already know which group IDs you need.
+ */
+export async function listGroups(opts?: {
+	fetch?: Fetcher;
+	query?: string;
+	limit?: number;
+	offset?: number;
+	signal?: AbortSignal;
+}): Promise<OrgGroupPage> {
+	const queryString = buildQueryString({
+		name: opts?.query,
+		limit: opts?.limit,
+		offset: opts?.offset
+	});
+	const response = (await doGet(
+		`/groups${queryString ? `?${queryString}` : ''}`,
+		opts
+	)) as OrgGroupPage;
+
+	return {
+		items: response?.items ?? [],
+		total: response?.total ?? 0,
+		limit: response?.limit ?? 0,
+		offset: response?.offset ?? 0,
+		source: response?.source ?? 'provider',
+		degraded: response?.degraded ?? false
+	};
+}
+
+/**
+ * Resolves specific group IDs to their display names.
+ */
+export async function resolveGroups(
+	ids: string[],
+	opts?: { fetch?: Fetcher; signal?: AbortSignal }
+): Promise<OrgGroup[]> {
+	if (ids.length === 0) return [];
+
+	const queryString = buildQueryString({ ids });
+	const response = (await doGet(`/groups?${queryString}`, opts)) as OrgGroupPage;
+	return response?.items ?? [];
 }
 
 export async function listUsers(opts?: { fetch?: Fetcher }): Promise<OrgUser[]> {

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -657,12 +657,18 @@ export async function listGroups(opts?: {
 		items: response?.items ?? [],
 		nextCursor: response?.nextCursor || undefined,
 		source: response?.source ?? 'provider',
-		degraded: response?.degraded ?? false
+		degraded: response?.degraded ?? false,
+		reset: response?.reset ?? false
 	};
 }
 
+const RESOLVE_GROUPS_CHUNK_SIZE = 100;
+
 /**
  * Resolves specific group IDs to their display names.
+ *
+ * Larger inputs are split across several requests and recombined, so a caller never has to think
+ * about the batch limit. IDs that cannot be resolved come back named after themselves.
  */
 export async function resolveGroups(
 	ids: string[],
@@ -670,12 +676,24 @@ export async function resolveGroups(
 ): Promise<OrgGroup[]> {
 	if (ids.length === 0) return [];
 
-	const queryString = buildQueryString({ ids });
-	const response = (await doGet(`/groups?${queryString}`, opts)) as OrgGroupPage;
-	return response?.items ?? [];
+	const batches: string[][] = [];
+	for (let i = 0; i < ids.length; i += RESOLVE_GROUPS_CHUNK_SIZE) {
+		batches.push(ids.slice(i, i + RESOLVE_GROUPS_CHUNK_SIZE));
+	}
+
+	const pages = await Promise.all(
+		batches.map(
+			(batch) => doGet(`/groups?${buildQueryString({ ids: batch })}`, opts) as Promise<OrgGroupPage>
+		)
+	);
+
+	return pages.flatMap((page) => page?.items ?? []);
 }
 
-export async function listUsers(opts?: { fetch?: Fetcher }): Promise<OrgUser[]> {
+export async function listUsers(opts?: {
+	fetch?: Fetcher;
+	signal?: AbortSignal;
+}): Promise<OrgUser[]> {
 	const response = (await doGet('/users', opts)) as ItemsResponse<OrgUser>;
 	return response.items ?? [];
 }

--- a/ui/user/src/lib/services/user/resolveGroups.spec.ts
+++ b/ui/user/src/lib/services/user/resolveGroups.spec.ts
@@ -1,0 +1,130 @@
+import { resolveGroups } from './operations';
+import { describe, expect, it } from 'vitest';
+
+interface FetchRecorder {
+	fetch: typeof fetch;
+	/** The `ids` parameter of every request, in dispatch order. */
+	batches: string[][];
+	peakConcurrency: number;
+}
+
+/**
+ * Builds a fetch that answers the group resolution endpoint, naming every ID it is asked about
+ * except those in `unknown`, and records how many requests overlap.
+ */
+function recordingFetch(options: { unknown?: string[]; delayMs?: number } = {}): FetchRecorder {
+	const unknown = new Set(options.unknown ?? []);
+	const recorder: Partial<FetchRecorder> = { batches: [], peakConcurrency: 0 };
+
+	let inFlight = 0;
+
+	recorder.fetch = (async (url: string) => {
+		const ids = (new URL(url).searchParams.get('ids') ?? '').split(',').filter(Boolean);
+		recorder.batches!.push(ids);
+
+		inFlight++;
+		recorder.peakConcurrency = Math.max(recorder.peakConcurrency!, inFlight);
+
+		// Yielding lets the other workers start before this one settles, so the peak reflects real
+		// overlap rather than the order the promises happen to resolve in.
+		await new Promise((resolve) => setTimeout(resolve, options.delayMs ?? 5));
+		inFlight--;
+
+		return {
+			ok: true,
+			status: 200,
+			json: async () => ({
+				items: ids.filter((id) => !unknown.has(id)).map((id) => ({ id, name: `Group ${id}` })),
+				source: 'cache',
+				degraded: false
+			})
+		} as unknown as Response;
+	}) as unknown as typeof fetch;
+
+	return recorder as FetchRecorder;
+}
+
+function idsOfLength(n: number): string[] {
+	return Array.from({ length: n }, (_, i) => `entra/${String(i).padStart(4, '0')}`);
+}
+
+describe('resolveGroups', () => {
+	it('makes no request for an empty input', async () => {
+		const recorder = recordingFetch();
+
+		expect(await resolveGroups([], { fetch: recorder.fetch })).toEqual([]);
+		expect(recorder.batches).toHaveLength(0);
+	});
+
+	it('sends a single request when the ids fit in one batch', async () => {
+		const recorder = recordingFetch();
+
+		const resolved = await resolveGroups(idsOfLength(100), { fetch: recorder.fetch });
+
+		expect(recorder.batches).toHaveLength(1);
+		expect(resolved).toHaveLength(100);
+	});
+
+	it('splits a larger input across batches', async () => {
+		const recorder = recordingFetch();
+
+		const resolved = await resolveGroups(idsOfLength(250), { fetch: recorder.fetch });
+
+		// The server rejects a batch over its limit outright rather than truncating, so the chunking
+		// is what keeps a large assignment set resolvable at all.
+		expect(recorder.batches).toHaveLength(3);
+		expect(recorder.batches.every((batch) => batch.length <= 100)).toBe(true);
+		expect(resolved).toHaveLength(250);
+	});
+
+	it('bounds how many requests are in flight at once', async () => {
+		const recorder = recordingFetch();
+
+		// Twenty batches: dispatching them all at once would multiply through the server into far
+		// more identity-provider calls than the directory will serve.
+		await resolveGroups(idsOfLength(2000), { fetch: recorder.fetch });
+
+		expect(recorder.batches).toHaveLength(20);
+		expect(recorder.peakConcurrency).toBeGreaterThan(1);
+		expect(recorder.peakConcurrency).toBeLessThanOrEqual(4);
+	});
+
+	it('returns groups in the order the ids were asked for', async () => {
+		// Later batches answer faster than earlier ones, so anything that appended results as they
+		// arrived would come back out of order.
+		const recorder = recordingFetch();
+		let call = 0;
+		const slowFirst = (async (url: string) => {
+			const delay = call++ === 0 ? 40 : 1;
+			await new Promise((resolve) => setTimeout(resolve, delay));
+			return recorder.fetch(url as unknown as URL);
+		}) as unknown as typeof fetch;
+
+		const ids = idsOfLength(250);
+		const resolved = await resolveGroups(ids, { fetch: slowFirst });
+
+		expect(resolved.map((group) => group.id)).toEqual(ids);
+	});
+
+	it('omits ids the server could not resolve', async () => {
+		// The server names unresolvable ids after themselves, but a group can also be absent
+		// entirely; the caller must not get a hole in the list.
+		const recorder = recordingFetch({ unknown: ['entra/0005'] });
+
+		const resolved = await resolveGroups(idsOfLength(10), { fetch: recorder.fetch });
+
+		expect(resolved).toHaveLength(9);
+		expect(resolved.some((group) => group.id === 'entra/0005')).toBe(false);
+	});
+
+	it('rejects when a batch fails', async () => {
+		// The page load catches this so that a failed name lookup does not discard the assignments
+		// themselves; resolveGroups itself must still report the failure rather than silently
+		// returning a partial list.
+		const failing = (async () => {
+			throw new Error('network down');
+		}) as unknown as typeof fetch;
+
+		await expect(resolveGroups(idsOfLength(250), { fetch: failing })).rejects.toThrow();
+	});
+});

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -805,7 +805,10 @@ export interface OrgGroup {
 	iconURL?: string;
 }
 
-/** Where a group listing came from. `cache` only contains groups seen during previous sign-ins. */
+/**
+ * Where a group listing came from. `cache` is Obot's own record of groups, which holds the ones seen
+ * during previous sign-ins plus any resolved by ID for a policy, and is therefore partial.
+ */
 export type OrgGroupSource = 'provider' | 'cache';
 
 export interface OrgGroupPage {
@@ -814,6 +817,11 @@ export interface OrgGroupPage {
 	source: OrgGroupSource;
 	/** True when the auth provider could not be listed and this fell back to cached groups. */
 	degraded: boolean;
+	/**
+	 * True when the cursor that was sent could not be honored, so these items are the first page of
+	 * a fresh listing rather than the page that was asked for.
+	 */
+	reset: boolean;
 }
 
 // Profile

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -810,9 +810,7 @@ export type OrgGroupSource = 'provider' | 'cache';
 
 export interface OrgGroupPage {
 	items: OrgGroup[];
-	total: number;
-	limit: number;
-	offset: number;
+	nextCursor?: string;
 	source: OrgGroupSource;
 	/** True when the auth provider could not be listed and this fell back to cached groups. */
 	degraded: boolean;

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -805,6 +805,19 @@ export interface OrgGroup {
 	iconURL?: string;
 }
 
+/** Where a group listing came from. `cache` only contains groups seen during previous sign-ins. */
+export type OrgGroupSource = 'provider' | 'cache';
+
+export interface OrgGroupPage {
+	items: OrgGroup[];
+	total: number;
+	limit: number;
+	offset: number;
+	source: OrgGroupSource;
+	/** True when the auth provider could not be listed and this fell back to cached groups. */
+	degraded: boolean;
+}
+
 // Profile
 
 export interface Profile {

--- a/ui/user/src/routes/admin/groups/+page.svelte
+++ b/ui/user/src/routes/admin/groups/+page.svelte
@@ -49,24 +49,32 @@
 	let urlFilters = $derived(getTableUrlParamsFilters());
 	let initSort = $derived(getTableUrlParamsSort());
 
+	const groupNameMap = $derived(
+		groups.reduce(
+			(acc, group) => {
+				acc[group.id] = group.name;
+				return acc;
+			},
+			{} as Record<string, string>
+		)
+	);
+
 	const preparedGroups = $derived(
-		groups.map((group) => {
-			const assignment = groupRoleMap[group.id];
-			const role = assignment?.role ?? 0;
+		groupRoleAssignments.map((assignment) => {
+			const role = assignment.role ?? 0;
 			return {
-				...group,
+				id: assignment.groupName,
+				name: groupNameMap[assignment.groupName] ?? assignment.groupName,
 				assignment,
 				role: role ? getUserRoleLabel(role).split(',') : [],
 				roleId: getRoleId(role),
-				description: assignment?.description || ''
+				description: assignment.description || ''
 			};
 		})
 	);
 
 	const filteredGroups = $derived(
-		preparedGroups.filter(
-			(group) => group.name.toLowerCase().includes(query.toLowerCase()) && group.assignment
-		)
+		preparedGroups.filter((group) => group.name.toLowerCase().includes(query.toLowerCase()))
 	);
 
 	type TableItem = (typeof filteredGroups)[0];
@@ -104,8 +112,9 @@
 			confirmUserImpersonationAdditionToGroup = undefined;
 			confirmOwnerGroupAssignment = undefined;
 
-			// Refresh data
+			// Refresh data, resolving names for any newly assigned group.
 			groupRoleAssignments = await AdminService.listGroupRoleAssignments();
+			groups = await UserService.resolveGroups(groupRoleAssignments.map((a) => a.groupName));
 
 			// Refresh user's profile if they're in the affected group
 			if (profile.current.groups.includes(groupName)) {
@@ -241,7 +250,6 @@
 <AddGroupAssignmentDialog
 	bind:this={addGroupAssignmentDialog}
 	open={showAddAssignment}
-	{groups}
 	{groupRoleMap}
 	{loading}
 	onClose={() => (showAddAssignment = false)}
@@ -261,7 +269,7 @@
 	open={showAssignGroupRoleDialog}
 	groupAssignment={updatingRole
 		? {
-				group: { id: updatingRole.id, name: updatingRole.name, iconURL: updatingRole.iconURL },
+				group: { id: updatingRole.id, name: updatingRole.name },
 				assignment: updatingRole.assignment || { groupName: updatingRole.id, role: 0 }
 			}
 		: undefined}

--- a/ui/user/src/routes/admin/groups/+page.svelte
+++ b/ui/user/src/routes/admin/groups/+page.svelte
@@ -114,7 +114,12 @@
 
 			// Refresh data, resolving names for any newly assigned group.
 			groupRoleAssignments = await AdminService.listGroupRoleAssignments();
-			groups = await UserService.resolveGroups(groupRoleAssignments.map((a) => a.groupName));
+
+			try {
+				groups = await UserService.resolveGroups(groupRoleAssignments.map((a) => a.groupName));
+			} catch (error) {
+				console.error('Failed to resolve group names:', error);
+			}
 
 			// Refresh user's profile if they're in the affected group
 			if (profile.current.groups.includes(groupName)) {

--- a/ui/user/src/routes/admin/groups/+page.ts
+++ b/ui/user/src/routes/admin/groups/+page.ts
@@ -4,19 +4,24 @@ import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch }) => {
-	const allGroupsPromise = await UserService.listGroups({ fetch });
-
 	try {
-		return {
-			groups: await allGroupsPromise,
-			groupRoleAssignments: await AdminService.listGroupRoleAssignments({ fetch })
-		};
+		const groupRoleAssignments = await AdminService.listGroupRoleAssignments({ fetch });
+
+		// Resolve names only for the groups that actually have an assignment. Listing the whole
+		// directory would both be needlessly large and drop any assignment whose group fell outside
+		// the page that came back.
+		const groups = await UserService.resolveGroups(
+			groupRoleAssignments.map((assignment) => assignment.groupName),
+			{ fetch }
+		);
+
+		return { groups, groupRoleAssignments };
 	} catch (err) {
 		handleRouteError(err, `/admin/groups`, profile.current);
 
 		return {
-			groups: await Promise.resolve([]),
-			groupRoleAssignments: await Promise.resolve([])
+			groups: [],
+			groupRoleAssignments: []
 		};
 	}
 };

--- a/ui/user/src/routes/admin/groups/+page.ts
+++ b/ui/user/src/routes/admin/groups/+page.ts
@@ -1,5 +1,5 @@
 import { handleRouteError } from '$lib/errors';
-import { AdminService, UserService } from '$lib/services';
+import { AdminService, UserService, type OrgGroup } from '$lib/services';
 import { profile } from '$lib/stores';
 import type { PageLoad } from './$types';
 
@@ -10,10 +10,15 @@ export const load: PageLoad = async ({ fetch }) => {
 		// Resolve names only for the groups that actually have an assignment. Listing the whole
 		// directory would both be needlessly large and drop any assignment whose group fell outside
 		// the page that came back.
-		const groups = await UserService.resolveGroups(
-			groupRoleAssignments.map((assignment) => assignment.groupName),
-			{ fetch }
-		);
+		let groups: OrgGroup[] = [];
+		try {
+			groups = await UserService.resolveGroups(
+				groupRoleAssignments.map((assignment) => assignment.groupName),
+				{ fetch }
+			);
+		} catch (err) {
+			console.error('Failed to resolve group names:', err);
+		}
 
 		return { groups, groupRoleAssignments };
 	} catch (err) {

--- a/ui/user/src/routes/admin/groups/AddGroupAssignmentDialog.svelte
+++ b/ui/user/src/routes/admin/groups/AddGroupAssignmentDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
-	import Search from '$lib/components/Search.svelte';
+	import GroupPicker from '$lib/components/admin/GroupPicker.svelte';
 	import IconButton from '$lib/components/primitives/IconButton.svelte';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { Role, type OrgGroup, type GroupRoleAssignment } from '$lib/services';
@@ -9,12 +9,10 @@
 	import GroupRoleForm from './GroupRoleForm.svelte';
 	import type { GroupAssignment } from './types';
 	import { ChevronLeft } from '@lucide/svelte';
-	import { debounce } from 'es-toolkit';
 	import { twMerge } from 'tailwind-merge';
 
 	interface Props {
 		open?: boolean;
-		groups: OrgGroup[];
 		groupRoleMap: Record<string, GroupRoleAssignment>;
 		loading?: boolean;
 		onClose: () => void;
@@ -42,7 +40,6 @@
 
 	let {
 		open,
-		groups,
 		groupRoleMap,
 		loading = false,
 		onClose,
@@ -53,7 +50,6 @@
 	}: Props = $props();
 
 	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
-	let searchQuery = $state('');
 	let selectedGroup = $state<OrgGroup | undefined>();
 	let draftRoleId = $state(0);
 	let draftHaveAuditorPrivilege = $state(false);
@@ -61,13 +57,7 @@
 
 	let isSmallScreen = $derived(responsive.isMobile);
 
-	// Filter groups by search query
-	const availableGroups = $derived(
-		groups.filter((group) => group.name.toLowerCase().includes(searchQuery.toLowerCase()))
-	);
-
 	function resetForm() {
-		searchQuery = '';
 		selectedGroup = undefined;
 		draftRoleId = 0;
 		draftHaveAuditorPrivilege = false;
@@ -149,50 +139,21 @@
 		handleClose();
 	}
 
-	const updateSearch = debounce((value: string) => {
-		searchQuery = value;
-	}, 100);
-
 	export function clear() {
 		resetForm();
 	}
 </script>
 
 {#snippet groupList()}
-	<div class="flex h-full flex-col gap-4 overflow-y-auto px-1 pr-2">
-		<div class="bg-base-100 dark:bg-base-300 sticky top-0 w-full pt-1">
-			<Search value={searchQuery} onChange={updateSearch} />
-		</div>
-
-		<div class="flex flex-col gap-2">
-			{#if availableGroups.length === 0}
-				<p class="text-muted-content py-8 text-center text-sm">
-					{searchQuery ? 'No groups found matching your search.' : 'No groups available.'}
-				</p>
-			{:else}
-				{#each availableGroups as group (group.id)}
-					{@const hasAssignment = !!groupRoleMap[group.id]}
-					{@const assignedRole = groupRoleMap[group.id]?.role}
-					<button
-						onclick={() => handleGroupSelect(group)}
-						class={twMerge(
-							'border-base-400 hover:bg-base-100/5 flex items-center gap-3 rounded-lg border p-3 text-left transition-colors',
-							selectedGroup?.id === group.id && 'bg-primary/10 border-primary'
-						)}
-					>
-						<div class="flex flex-1 items-center gap-3">
-							<div class="flex flex-1 flex-col">
-								<span class="font-medium">{group.name}</span>
-								{#if hasAssignment && assignedRole}
-									<span class="text-muted-content text-xs">{getUserRoleLabel(assignedRole)}</span>
-								{/if}
-							</div>
-						</div>
-					</button>
-				{/each}
-			{/if}
-		</div>
-	</div>
+	<GroupPicker
+		onSelect={handleGroupSelect}
+		selectedId={selectedGroup?.id}
+		subtitle={(group) => {
+			const role = groupRoleMap[group.id]?.role;
+			return role ? getUserRoleLabel(role) : undefined;
+		}}
+		placeholder="Search groups..."
+	/>
 {/snippet}
 
 {#snippet roleForm()}


### PR DESCRIPTION
This adds pagination for groups coming from the auth provider. This is cursor-based pagination, not limit+offset.

One thing of note: with these changes, we start saving groups in the `groups` table if they are assigned a GroupRoleAssignment or if they are part of some access policy (i.e. AccessControlRules, SkillAccessRules). Previously, this table only held info about groups that at least one user belongs to. (It still holds those groups as well, with these changes.)