### PR TITLE
fix: avoid exposing encrypted user data in API key filters

### DIFF
--- a/pkg/gateway/client/audit_api_key_filter.go
+++ b/pkg/gateway/client/audit_api_key_filter.go
@@ -12,13 +12,10 @@ import (
 )
 
 type auditLogAPIKeyOptionRow struct {
-	APIKeyID        uint
-	APIKeyName      string
-	UserID          uint
-	Revoked         bool
-	UserDisplayName string
-	Username        string
-	Email           string
+	APIKeyID   uint
+	APIKeyName string
+	UserID     uint
+	Revoked    bool
 }
 
 // GetMCPAuditLogAPIKeyFilterOptions returns the API keys present in the
@@ -65,12 +62,8 @@ func (c *Client) scanAuditLogAPIKeyFilterOptions(ctx context.Context, db *gorm.D
 		Select(`audit_key_snapshots.api_key_id,
 			audit_key_snapshots.api_key_name,
 			COALESCE(api_keys.user_id, 0) AS user_id,
-			(api_keys.revoked_at IS NOT NULL) AS revoked,
-			COALESCE(users.display_name, '') AS user_display_name,
-			COALESCE(users.username, '') AS username,
-			COALESCE(users.email, '') AS email`).
+			(api_keys.revoked_at IS NOT NULL) AS revoked`).
 		Joins("LEFT JOIN api_keys ON api_keys.id = audit_key_snapshots.api_key_id").
-		Joins("LEFT JOIN users ON users.id = api_keys.user_id").
 		Order("audit_key_snapshots.api_key_name, audit_key_snapshots.api_key_id")
 	if limit > 0 {
 		query = query.Limit(limit)
@@ -91,23 +84,8 @@ func (c *Client) scanAuditLogAPIKeyFilterOptions(ctx context.Context, db *gorm.D
 		if row.UserID != 0 {
 			option.UserID = strconv.FormatUint(uint64(row.UserID), 10)
 			option.MaskedKey = principal.MaskedAPIKeyName(option.UserID, row.APIKeyID)
-			option.UserDisplayName = auditLogAPIKeyUserDisplayName(
-				row.UserDisplayName, row.Username, row.Email, option.UserID)
 		}
 		options = append(options, option)
 	}
 	return options, nil
-}
-
-func auditLogAPIKeyUserDisplayName(displayName, username, email, fallback string) string {
-	if displayName != "" {
-		return displayName
-	}
-	if username != "" {
-		return username
-	}
-	if email != "" {
-		return email
-	}
-	return fallback
 }

--- a/pkg/gateway/client/audit_api_key_filter_test.go
+++ b/pkg/gateway/client/audit_api_key_filter_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/google/uuid"
 	apitypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/gateway/types"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
+	"k8s.io/apiserver/pkg/storage/value"
 )
 
 func TestAuditLogAPIKeyFilterOptions(t *testing.T) {
@@ -88,6 +91,18 @@ func TestAuditLogAPIKeyFilterOptions(t *testing.T) {
 		t.Fatalf("insert local-agent audit log: %v", err)
 	}
 
+	c.encryptionConfig = &encryptionconfig.EncryptionConfiguration{
+		Transformers: map[schema.GroupResource]value.Transformer{
+			userGroupResource: testTransformer{},
+		},
+	}
+	if err := c.encryptUser(ctx, &user); err != nil {
+		t.Fatalf("encrypt user: %v", err)
+	}
+	if err := c.db.WithContext(ctx).Save(&user).Error; err != nil {
+		t.Fatalf("save encrypted user: %v", err)
+	}
+
 	assertOptions := func(t *testing.T, options []apitypes.AuditLogAPIKeyFilterOption) {
 		t.Helper()
 		if len(options) != 4 {
@@ -106,8 +121,8 @@ func TestAuditLogAPIKeyFilterOptions(t *testing.T) {
 			if option.Value == fmt.Sprint(missingKeyID) {
 				continue
 			}
-			if option.UserID != "7" || option.UserDisplayName != "Calvin McLean" {
-				t.Fatalf("missing owner context: %#v", option)
+			if option.UserID != "7" || option.UserDisplayName != "" {
+				t.Fatalf("unexpected owner metadata: %#v", option)
 			}
 			if option.MaskedKey != fmt.Sprintf("ok1-7-%s-*****", option.Value) {
 				t.Fatalf("unexpected masked key: %#v", option)

--- a/ui/user/src/lib/auditlogs.ts
+++ b/ui/user/src/lib/auditlogs.ts
@@ -13,9 +13,15 @@ export function isAuditLogAPIKeyFilterOption(
 	);
 }
 
-export function getAuditLogAPIKeyFilterOptionLabel(option: AuditLogAPIKeyFilterOption): string {
+export function getAuditLogAPIKeyFilterOptionLabel(
+	option: AuditLogAPIKeyFilterOption,
+	getUserDisplayName?: (userID: string) => string
+): string {
 	const key = formatAuditLogAPIKeyName(option.name, option.maskedKey);
-	const owner = option.userDisplayName || option.userID;
+	const owner =
+		(option.userID && getUserDisplayName?.(option.userID)) ||
+		option.userDisplayName ||
+		option.userID;
 	return [key, owner, option.revoked ? 'Revoked' : ''].filter(Boolean).join(' · ');
 }
 
@@ -29,12 +35,15 @@ export function getAuditLogAPIKeyMaskedKey(userID: string, apiKeyID: number | un
 		: '';
 }
 
-export function toAuditLogFilterSelectOption(option: AuditLogFilterOption): {
+export function toAuditLogFilterSelectOption(
+	option: AuditLogFilterOption,
+	getUserDisplayName?: (userID: string) => string
+): {
 	id: string;
 	label: string;
 } {
 	return isAuditLogAPIKeyFilterOption(option)
-		? { id: option.value, label: getAuditLogAPIKeyFilterOptionLabel(option) }
+		? { id: option.value, label: getAuditLogAPIKeyFilterOptionLabel(option, getUserDisplayName) }
 		: { id: option, label: option };
 }
 

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte
@@ -672,7 +672,7 @@
 			return toStringFilterSelectOptions(opts, (id) => usersMap.get(id)?.displayName ?? id);
 		}
 		return opts.map((d) => {
-			const option = toAuditLogFilterSelectOption(d);
+			const option = toAuditLogFilterSelectOption(d, (id) => usersMap.get(id)?.displayName ?? id);
 			return typeof d === 'string' && field.getOptionLabel
 				? { ...option, label: field.getOptionLabel(d) }
 				: option;

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte
@@ -27,6 +27,7 @@
 		type AuditLogURLFilters
 	} from '$lib/services';
 	import { profile } from '$lib/stores';
+	import { getUserDisplayName } from '$lib/utils';
 	import { TriangleAlert, ChevronDown, ChevronUp } from '@lucide/svelte';
 	import { subDays, set } from 'date-fns';
 	import { onMount } from 'svelte';
@@ -467,7 +468,7 @@
 	});
 
 	$effect(() => {
-		UserService.listUsers().then((res) => {
+		UserService.listUsersIncludeDeleted().then((res) => {
 			res.forEach((user) => {
 				usersMap.set(user.id, user);
 			});
@@ -668,11 +669,13 @@
 	): { id: string; label: string }[] {
 		const opts = filtersOptions[field.filterKey];
 		if (!opts?.map) return [];
+		const resolveUserDisplayName = (id: string) =>
+			usersMap.has(id) ? getUserDisplayName(usersMap, id) : id;
 		if (field.useUserDisplayNames) {
-			return toStringFilterSelectOptions(opts, (id) => usersMap.get(id)?.displayName ?? id);
+			return toStringFilterSelectOptions(opts, resolveUserDisplayName);
 		}
 		return opts.map((d) => {
-			const option = toAuditLogFilterSelectOption(d, (id) => usersMap.get(id)?.displayName ?? id);
+			const option = toAuditLogFilterSelectOption(d, resolveUserDisplayName);
 			return typeof d === 'string' && field.getOptionLabel
 				? { ...option, label: field.getOptionLabel(d) }
 				: option;

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte
@@ -25,6 +25,7 @@
 		type AuditLogURLFilters
 	} from '$lib/services';
 	import { profile } from '$lib/stores';
+	import { getUserDisplayName } from '$lib/utils';
 	import { TriangleAlert, GlobeIcon, ChevronDown, ChevronUp } from '@lucide/svelte';
 	import { onMount } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
@@ -293,7 +294,7 @@
 	let filtersOptions: Record<string, AuditLogFilterOption[]> = $state({});
 
 	$effect(() => {
-		UserService.listUsers().then((res) => {
+		UserService.listUsersIncludeDeleted().then((res) => {
 			res.forEach((user) => {
 				usersMap.set(user.id, user);
 			});
@@ -362,9 +363,10 @@
 	};
 
 	let auditScheduleAdvancedFilterRows = $derived.by((): AuditScheduleAdvancedFilterRow[] => {
-		const getUserDisplayName = (id: string) => usersMap.get(id)?.displayName ?? id;
+		const resolveUserDisplayName = (id: string) =>
+			usersMap.has(id) ? getUserDisplayName(usersMap, id) : id;
 		const sameLabel = (d: AuditLogFilterOption) =>
-			toAuditLogFilterSelectOption(d, getUserDisplayName);
+			toAuditLogFilterSelectOption(d, resolveUserDisplayName);
 		if (logType === 'llm') {
 			return [
 				{
@@ -379,7 +381,7 @@
 					filterKey: 'user_id',
 					label: 'Users',
 					description: 'Comma-separated user IDs',
-					options: toStringFilterSelectOptions(filtersOptions['user_id'], getUserDisplayName)
+					options: toStringFilterSelectOptions(filtersOptions['user_id'], resolveUserDisplayName)
 				},
 				{
 					fieldId: 'model_provider',
@@ -450,7 +452,7 @@
 				filterKey: 'actor',
 				label: 'Actors',
 				description: 'Users and enrolled devices',
-				options: toStringFilterSelectOptions(filtersOptions['actor'], getUserDisplayName)
+				options: toStringFilterSelectOptions(filtersOptions['actor'], resolveUserDisplayName)
 			},
 			{
 				fieldId: 'tool',
@@ -536,7 +538,7 @@
 				filterKey: 'user_id',
 				label: 'User IDs',
 				description: 'Comma-separated user IDs',
-				options: toStringFilterSelectOptions(filtersOptions['user_id'], getUserDisplayName)
+				options: toStringFilterSelectOptions(filtersOptions['user_id'], resolveUserDisplayName)
 			},
 			{
 				fieldId: 'mcp_id',

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte
@@ -362,8 +362,9 @@
 	};
 
 	let auditScheduleAdvancedFilterRows = $derived.by((): AuditScheduleAdvancedFilterRow[] => {
-		const sameLabel = (d: AuditLogFilterOption) => toAuditLogFilterSelectOption(d);
 		const getUserDisplayName = (id: string) => usersMap.get(id)?.displayName ?? id;
+		const sameLabel = (d: AuditLogFilterOption) =>
+			toAuditLogFilterSelectOption(d, getUserDisplayName);
 		if (logType === 'llm') {
 			return [
 				{

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -208,7 +208,9 @@
 	function formatSingleFilterValue(key: string, value: string): string {
 		if (key === 'api_key_id') {
 			const option = apiKeyFilterOptions.get(value);
-			return option ? getAuditLogAPIKeyFilterOptionLabel(option) : value;
+			return option
+				? getAuditLogAPIKeyFilterOptionLabel(option, (id) => getUserDisplayName(users, id))
+				: value;
 		}
 		if (key === 'actor') return actorDisplay(value);
 		if (key === 'duration') return durationBucketLabel(value);

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -268,7 +268,9 @@
 	function getFilterValue(label: keyof LLMAuditLogURLFilters, value: string | number) {
 		if (label === 'api_key_id') {
 			const option = apiKeyFilterOptions[value.toString()];
-			return option ? getAuditLogAPIKeyFilterOptionLabel(option) : value.toString();
+			return option
+				? getAuditLogAPIKeyFilterOptionLabel(option, (id) => getUserDisplayName(usersMap, id))
+				: value.toString();
 		}
 		if (label === 'user_id') {
 			return getUserDisplayName(usersMap, value + '');

--- a/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
@@ -93,7 +93,37 @@
 	}
 
 	type FilterOptions = Record<FilterKey, FilterOption[]>;
-	let filtersOptions: FilterOptions = $state({} as FilterOptions);
+	type RawFilterOptions = Record<FilterKey, AuditLogFilterOption[]>;
+	let rawFilterOptions: RawFilterOptions = $state({} as RawFilterOptions);
+
+	function formatFilterOptions(filterId: FilterKey, options: AuditLogFilterOption[]) {
+		if (['user_id', 'user_ids'].includes(filterId)) {
+			return options
+				.filter((d): d is string => typeof d === 'string')
+				.filter((d) => filterOptions?.(d, filterId) ?? true)
+				.map((d) => ({
+					id: d,
+					label: getUserDisplayName(d, () => options.some((id) => id === d))
+				}));
+		}
+
+		return options
+			.filter((d) => isAuditLogAPIKeyFilterOption(d) || (filterOptions?.(d, filterId) ?? true))
+			.map((d) => {
+				const option = toAuditLogFilterSelectOption(d, getUserDisplayName);
+				return isAuditLogAPIKeyFilterOption(d)
+					? option
+					: { ...option, label: getFilterOptionLabel?.(filterId, d) ?? option.label };
+			});
+	}
+
+	let filtersOptions: FilterOptions = $derived.by(() => {
+		const formatted = {} as FilterOptions;
+		for (const [filterId, options] of Object.entries(rawFilterOptions)) {
+			formatted[filterId as FilterKey] = formatFilterOptions(filterId as FilterKey, options);
+		}
+		return formatted;
+	});
 
 	type FilterInputs = Record<FilterKey, FilterInput>;
 	let filterInputs = $derived(
@@ -145,30 +175,7 @@
 			const otherFilters = Object.fromEntries(
 				Object.entries(filters ?? {}).filter(([k]) => k !== filterId)
 			) as Partial<T>;
-			const response = await endpoint(filterId, otherFilters);
-
-			if (['user_id', 'user_ids'].includes(filterId)) {
-				return (
-					response?.options
-						?.filter((d): d is string => typeof d === 'string')
-						?.filter((d) => filterOptions?.(d, filterId) ?? true)
-						?.map((d) => ({
-							id: d,
-							label: getUserDisplayName(d, () => response.options.some((id) => id === d))
-						})) ?? []
-				);
-			}
-
-			return (
-				response?.options
-					?.filter((d) => isAuditLogAPIKeyFilterOption(d) || (filterOptions?.(d, filterId) ?? true))
-					?.map((d) => {
-						const option = toAuditLogFilterSelectOption(d, getUserDisplayName);
-						return isAuditLogAPIKeyFilterOption(d)
-							? option
-							: { ...option, label: getFilterOptionLabel?.(filterId, d) ?? option.label };
-					}) ?? []
-			);
+			return (await endpoint(filterId, otherFilters))?.options ?? [];
 		};
 
 		const filterInputKeys = Object.keys(filterInputs) as FilterKey[];
@@ -176,7 +183,7 @@
 		filterInputKeys.forEach((id) => {
 			processLog(id).then((options) => {
 				untrack(() => {
-					filtersOptions[id] = options;
+					rawFilterOptions[id] = options;
 				});
 			});
 		});

--- a/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte
@@ -163,7 +163,7 @@
 				response?.options
 					?.filter((d) => isAuditLogAPIKeyFilterOption(d) || (filterOptions?.(d, filterId) ?? true))
 					?.map((d) => {
-						const option = toAuditLogFilterSelectOption(d);
+						const option = toAuditLogFilterSelectOption(d, getUserDisplayName);
 						return isAuditLogAPIKeyFilterOption(d)
 							? option
 							: { ...option, label: getFilterOptionLabel?.(filterId, d) ?? option.label };

--- a/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.svelte.spec.ts
@@ -1,0 +1,60 @@
+import type { AuditLogAPIKeyFilterOption, OrgUser } from '$lib/services';
+import { getUserDisplayName } from '$lib/utils';
+import FiltersDrawer from './FiltersDrawer.svelte';
+import { SvelteMap } from 'svelte/reactivity';
+import { expect, test } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+test('recomputes API key owner labels when users load after filter options', async () => {
+	const users = new SvelteMap<string, OrgUser>();
+	const options: AuditLogAPIKeyFilterOption[] = [
+		{
+			value: '11',
+			name: 'Active key',
+			maskedKey: 'ok1-1-11-*****',
+			userID: '1',
+			userDisplayName: '',
+			revoked: false
+		},
+		{
+			value: '22',
+			name: 'Deleted key',
+			maskedKey: 'ok1-2-22-*****',
+			userID: '2',
+			userDisplayName: '',
+			revoked: true
+		}
+	];
+
+	await render(FiltersDrawer, {
+		filters: { api_key_id: null },
+		onClose: () => undefined,
+		getFilterDisplayLabel: () => 'API Key',
+		getUserDisplayName: (id: string) => getUserDisplayName(users, id),
+		endpoint: async () => ({ options })
+	});
+
+	await page.getByCSS('#filter-api_key_id').click();
+	await expect
+		.element(page.getByText('Active key (ok1-1-11-*****) · Unknown User', { exact: true }))
+		.toBeVisible();
+
+	users.set('1', { id: '1', displayName: 'Active Owner' } as OrgUser);
+	users.set('2', {
+		id: '2',
+		originalUsername: 'deleted-owner',
+		deletedAt: '2026-08-20T00:00:00Z'
+	} as OrgUser);
+
+	await expect
+		.element(page.getByText('Active key (ok1-1-11-*****) · Active Owner', { exact: true }))
+		.toBeVisible();
+	await expect
+		.element(
+			page.getByText('Deleted key (ok1-2-22-*****) · deleted-owner (Deleted) · Revoked', {
+				exact: true
+			})
+		)
+		.toBeVisible();
+});


### PR DESCRIPTION
## Summary

Addresses https://github.com/obot-platform/obot/issues/7602

- stop joining encrypted user profile fields into audit-log API key filter options
- resolve API key owner labels from the already-loaded user map used by the Actor column
- cover encrypted users and preserve owner labels across audit log pages and export forms
