### PR TITLE
chore: bump go version to 1.27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lint: lint-go
 tidy:
 	go mod tidy
 
-GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT_VERSION ?= v2.13.0
 setup-env:
 	if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "Could not find golangci-lint, installing version $(GOLANGCI_LINT_VERSION)."; \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/obot-platform/obot
 
-go 1.26.5
+go 1.27
 
 replace (
 	github.com/obot-platform/obot/apiclient => ./apiclient

--- a/pkg/agentbackend/kubernetes/backend.go
+++ b/pkg/agentbackend/kubernetes/backend.go
@@ -284,7 +284,7 @@ func (b *Backend) namespaceOwner(ctx context.Context) (*metav1.OwnerReference, e
 			// and mirrors what pkg/mcp does for the same namespace rather than
 			// leaving hosted agents the only feature that cannot start without
 			// one being made for it.
-			created := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: b.opts.Namespace}}
+			created := &corev1.Namespace{Name: b.opts.Namespace}
 			if createErr := b.client.Create(ctx, created); createErr != nil && !apierrors.IsAlreadyExists(createErr) {
 				b.namespaceErr = fmt.Errorf("failed to create namespace %s: %w", b.opts.Namespace, createErr)
 				return

--- a/pkg/agentbackend/kubernetes/instance.go
+++ b/pkg/agentbackend/kubernetes/instance.go
@@ -272,21 +272,17 @@ func (b *Backend) instanceObjects(desired agentbackend.DesiredInstance) ([]kclie
 	}
 
 	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   b.opts.Namespace,
-			Labels:      labels,
-			Annotations: annotations,
-		},
-		Data: secretData,
+		Name:        name,
+		Namespace:   b.opts.Namespace,
+		Labels:      labels,
+		Annotations: annotations,
+		Data:        secretData,
 	}
 
 	volumes := append([]corev1.Volume{{
 		Name: workspaceVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: pool,
-			},
+		PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+			ClaimName: pool,
 		},
 	}}, fileVolumes...)
 
@@ -308,12 +304,10 @@ func (b *Backend) instanceObjects(desired agentbackend.DesiredInstance) ([]kclie
 	}
 
 	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   b.opts.Namespace,
-			Labels:      labels,
-			Annotations: annotations,
-		},
+		Name:        name,
+		Namespace:   b.opts.Namespace,
+		Labels:      labels,
+		Annotations: annotations,
 		Spec: appsv1.DeploymentSpec{
 			Replicas: new(int32(1)),
 			Selector: &metav1.LabelSelector{
@@ -350,7 +344,7 @@ func (b *Backend) instanceObjects(desired agentbackend.DesiredInstance) ([]kclie
 						Env:   env,
 						EnvFrom: []corev1.EnvFromSource{{
 							SecretRef: &corev1.SecretEnvSource{
-								LocalObjectReference: corev1.LocalObjectReference{Name: name},
+								Name: name,
 							},
 						}},
 						VolumeMounts:    mounts,
@@ -383,12 +377,10 @@ func (b *Backend) instanceObjects(desired agentbackend.DesiredInstance) ([]kclie
 	// instance never leaves pending.
 	if len(servicePorts(desired.Port)) > 0 {
 		objects = append(objects, &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        name,
-				Namespace:   b.opts.Namespace,
-				Labels:      labels,
-				Annotations: annotations,
-			},
+			Name:        name,
+			Namespace:   b.opts.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 			Spec: corev1.ServiceSpec{
 				Type:     corev1.ServiceTypeClusterIP,
 				Selector: map[string]string{instanceLabel: sanitize(desired.Ref.ID)},
@@ -460,11 +452,9 @@ func renderFiles(secretName string, files []agentbackend.File, secretData map[st
 		volumeName := fmt.Sprintf("%s-%d", filesVolumePrefix, i)
 		volumes = append(volumes, corev1.Volume{
 			Name: volumeName,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: secretName,
-					Items:      items,
-				},
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+				Items:      items,
 			},
 		})
 		mounts = append(mounts, corev1.VolumeMount{
@@ -497,8 +487,8 @@ func secretRefEnv(refs []agentbackend.SecretRef) ([]corev1.EnvVar, error) {
 			Name: ref.EnvName,
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: ref.ID},
-					Key:                  ref.EnvName,
+					Name: ref.ID,
+					Key:  ref.EnvName,
 				},
 			},
 		})
@@ -530,14 +520,12 @@ func (b *Backend) cleanupJob(instanceID, poolID string) (*batchv1.Job, error) {
 		return nil, err
 	}
 	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cleanupJobName(instanceID),
-			Namespace: b.opts.Namespace,
-			Labels: map[string]string{
-				managedLabel:  managedValue,
-				instanceLabel: subdir,
-				poolLabel:     sanitize(poolID),
-			},
+		Name:      cleanupJobName(instanceID),
+		Namespace: b.opts.Namespace,
+		Labels: map[string]string{
+			managedLabel:  managedValue,
+			instanceLabel: subdir,
+			poolLabel:     sanitize(poolID),
 		},
 		Spec: batchv1.JobSpec{
 			BackoffLimit: new(int32(4)),
@@ -556,10 +544,8 @@ func (b *Backend) cleanupJob(instanceID, poolID string) (*batchv1.Job, error) {
 					SecurityContext:   b.podSecurityContext(),
 					Volumes: []corev1.Volume{{
 						Name: workspaceVolumeName,
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: poolName(poolID),
-							},
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: poolName(poolID),
 						},
 					}},
 					Containers: []corev1.Container{{

--- a/pkg/agentbackend/kubernetes/integration_test.go
+++ b/pkg/agentbackend/kubernetes/integration_test.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,7 +72,7 @@ func setup(t *testing.T, opts Options) (*Backend, kclient.Client, context.Contex
 	client := testClient(t)
 	ctx := t.Context()
 
-	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+	namespace := &corev1.Namespace{Name: testNamespace}
 	if err := client.Create(ctx, namespace); err != nil && !apierrors.IsAlreadyExists(err) {
 		t.Fatalf("create namespace: %v", err)
 	}

--- a/pkg/agentbackend/kubernetes/objects_test.go
+++ b/pkg/agentbackend/kubernetes/objects_test.go
@@ -663,7 +663,7 @@ func TestVolumeIsDedicated(t *testing.T) {
 func TestPoolNodeIgnoresTerminatingPods(t *testing.T) {
 	now := metav1.Now()
 	pods := []corev1.Pod{
-		{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}, Spec: corev1.PodSpec{NodeName: "going-away"}},
+		{DeletionTimestamp: &now, Spec: corev1.PodSpec{NodeName: "going-away"}},
 		{Spec: corev1.PodSpec{NodeName: "live-node"}},
 	}
 

--- a/pkg/agentbackend/kubernetes/pool.go
+++ b/pkg/agentbackend/kubernetes/pool.go
@@ -136,14 +136,12 @@ func (b *Backend) poolObjects(ctx context.Context, desired agentbackend.DesiredP
 	}
 
 	priorityClass := &schedulingv1.PriorityClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        pool,
-			Labels:      labels,
-			Annotations: annotations,
-			// Cluster-scoped dependents may only name cluster-scoped owners, and
-			// a Namespace is cluster-scoped, so this is a valid reference.
-			OwnerReferences: []metav1.OwnerReference{*owner},
-		},
+		Name:        pool,
+		Labels:      labels,
+		Annotations: annotations,
+		// Cluster-scoped dependents may only name cluster-scoped owners, and
+		// a Namespace is cluster-scoped, so this is a valid reference.
+		OwnerReferences:  []metav1.OwnerReference{*owner},
 		Value:            poolPriorityValue,
 		GlobalDefault:    false,
 		PreemptionPolicy: new(corev1.PreemptNever),
@@ -151,12 +149,10 @@ func (b *Backend) poolObjects(ctx context.Context, desired agentbackend.DesiredP
 	}
 
 	quota := &corev1.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        pool,
-			Namespace:   b.opts.Namespace,
-			Labels:      labels,
-			Annotations: annotations,
-		},
+		Name:        pool,
+		Namespace:   b.opts.Namespace,
+		Labels:      labels,
+		Annotations: annotations,
 		Spec: corev1.ResourceQuotaSpec{
 			Hard: quotaHard(desired),
 			// PriorityClass is the only per-pod attribute a ResourceQuota can
@@ -176,12 +172,10 @@ func (b *Backend) poolObjects(ctx context.Context, desired agentbackend.DesiredP
 	// revision bump should attempt.
 	claimAnnotations[apply.AnnotationUpdate] = "false"
 	claim := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        pool,
-			Namespace:   b.opts.Namespace,
-			Labels:      labels,
-			Annotations: claimAnnotations,
-		},
+		Name:        pool,
+		Namespace:   b.opts.Namespace,
+		Labels:      labels,
+		Annotations: claimAnnotations,
 		Spec: corev1.PersistentVolumeClaimSpec{
 			// ReadWriteOnce is node-scoped, not pod-scoped: every sandbox in the
 			// pool mounts this claim from the same node. That co-location is the

--- a/pkg/agentbackend/kubernetes/reachable_test.go
+++ b/pkg/agentbackend/kubernetes/reachable_test.go
@@ -5,15 +5,14 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func nodeClient(addresses ...corev1.NodeAddress) *fake.ClientBuilder {
 	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(&corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
-		Status:     corev1.NodeStatus{Addresses: addresses},
+		Name:   "node-1",
+		Status: corev1.NodeStatus{Addresses: addresses},
 	})
 }
 

--- a/pkg/agentbackend/kubernetes/status_test.go
+++ b/pkg/agentbackend/kubernetes/status_test.go
@@ -11,7 +11,7 @@ import (
 
 func waitingPod(reason, message string) corev1.Pod {
 	return corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "sandbox"},
+		Name: "sandbox",
 		Status: corev1.PodStatus{
 			Phase: corev1.PodPending,
 			ContainerStatuses: []corev1.ContainerStatus{{
@@ -63,7 +63,7 @@ func TestClassifyDeploymentReportsQuotaRejection(t *testing.T) {
 // sandbox never recovers by moving. Reporting pending would hide a full pool.
 func TestClassifyDeploymentTreatsUnschedulableAsError(t *testing.T) {
 	pod := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "sandbox"},
+		Name: "sandbox",
 		Status: corev1.PodStatus{
 			Phase: corev1.PodPending,
 			Conditions: []corev1.PodCondition{{

--- a/pkg/api/authz/hostedagentmcp_test.go
+++ b/pkg/api/authz/hostedagentmcp_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/obot-platform/obot/pkg/principal"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -33,7 +32,7 @@ func agentUser(grants ...string) User {
 // was configured with.
 func TestHostedAgentReachesItsGrantedServer(t *testing.T) {
 	client := fakeclient.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
-		&v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "ms1github", Namespace: "obot"}},
+		&v1.MCPServer{Name: "ms1github", Namespace: "obot"},
 	).Build()
 	authorizer := &Authorizer{uncached: client}
 
@@ -50,7 +49,7 @@ func TestHostedAgentReachesItsGrantedServer(t *testing.T) {
 // The grant list is the whole authority, so a server absent from it is denied.
 func TestHostedAgentCannotReachAnUngrantedServer(t *testing.T) {
 	client := fakeclient.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
-		&v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "ms1secret", Namespace: "obot"}},
+		&v1.MCPServer{Name: "ms1secret", Namespace: "obot"},
 	).Build()
 	authorizer := &Authorizer{uncached: client}
 
@@ -65,7 +64,7 @@ func TestHostedAgentCannotReachAnUngrantedServer(t *testing.T) {
 // empty list is how a caller with no grants ends up with every grant.
 func TestHostedAgentWithNoGrantsReachesNothing(t *testing.T) {
 	client := fakeclient.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
-		&v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "ms1github", Namespace: "obot"}},
+		&v1.MCPServer{Name: "ms1github", Namespace: "obot"},
 	).Build()
 	authorizer := &Authorizer{uncached: client}
 

--- a/pkg/api/authz/mcpid_test.go
+++ b/pkg/api/authz/mcpid_test.go
@@ -10,7 +10,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	gocache "k8s.io/client-go/tools/cache"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,10 +45,8 @@ func TestCheckMCPIDDoesNotBypassNonMCPConnectForAnonymous(t *testing.T) {
 
 func TestCheckMCPIDChecksMCPServerInstanceOwner(t *testing.T) {
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServerInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "msi1test",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "msi1test",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerInstanceSpec{
 			UserID: "user-uid",
 		},
@@ -94,10 +91,8 @@ func TestCheckMCPIDChecksSystemMCPServerEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.SystemMCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sms1test",
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      "sms1test",
+				Namespace: system.DefaultNamespace,
 				Spec: v1.SystemMCPServerSpec{
 					Manifest: types.SystemMCPServerManifest{
 						Enabled: tt.enabled,
@@ -124,20 +119,16 @@ func TestCheckMCPIDChecksSystemMCPServerEnabled(t *testing.T) {
 
 func TestCheckMCPIDChecksMCPServerCatalogAccess(t *testing.T) {
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ms1catalog",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "ms1catalog",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerSpec{
 			MCPCatalogID: "catalog-a",
 			UserID:       "owner-uid",
 		},
 	}).Build()
 	authorizer := newMCPIDTestAuthorizer(t, storage, &v1.AccessControlRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "acr1server",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "acr1server",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.AccessControlRuleSpec{
 			MCPCatalogID: "catalog-a",
 			Manifest: types.AccessControlRuleManifest{
@@ -167,19 +158,15 @@ func TestCheckMCPIDChecksMCPServerCatalogAccess(t *testing.T) {
 
 func TestCheckMCPIDChecksCatalogEntryAccess(t *testing.T) {
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "entry-test",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "entry-test",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerCatalogEntrySpec{
 			MCPCatalogName: "catalog-a",
 		},
 	}).Build()
 	authorizer := newMCPIDTestAuthorizer(t, storage, &v1.AccessControlRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "acr1entry",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "acr1entry",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.AccessControlRuleSpec{
 			MCPCatalogID: "catalog-a",
 			Manifest: types.AccessControlRuleManifest{
@@ -210,39 +197,31 @@ func TestCheckMCPIDChecksCatalogEntryAccess(t *testing.T) {
 func TestCheckMCPIDChecksWorkspaceAccess(t *testing.T) {
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
 		&v1.MCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ms1workspace",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "ms1workspace",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerSpec{
 				PowerUserWorkspaceID: "puw1test",
 				UserID:               "owner-uid",
 			},
 		},
 		&v1.MCPServerCatalogEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "workspace-entry",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "workspace-entry",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerCatalogEntrySpec{
 				PowerUserWorkspaceID: "puw1test",
 			},
 		},
 		&v1.PowerUserWorkspace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "puw1test",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "puw1test",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.PowerUserWorkspaceSpec{
 				UserID: "owner-uid",
 			},
 		},
 	).Build()
 	authorizer := newMCPIDTestAuthorizer(t, storage, &v1.AccessControlRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "acr1workspace",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "acr1workspace",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.AccessControlRuleSpec{
 			PowerUserWorkspaceID: "puw1test",
 			Manifest: types.AccessControlRuleManifest{
@@ -308,10 +287,8 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 		{
 			name: "server composite parent allows component server",
 			objects: []kclient.Object{&v1.MCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ms1component",
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      "ms1component",
+				Namespace: system.DefaultNamespace,
 				Spec: v1.MCPServerSpec{
 					CompositeName: "ms1composite",
 				},
@@ -324,10 +301,8 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 		{
 			name: "server without authorized composite is denied",
 			objects: []kclient.Object{&v1.MCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ms1component",
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      "ms1component",
+				Namespace: system.DefaultNamespace,
 				Spec: v1.MCPServerSpec{
 					CompositeName: "ms1composite",
 				},
@@ -347,10 +322,8 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 		{
 			name: "instance direct ID allows without storage lookup",
 			objects: []kclient.Object{&v1.MCPServerInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "msi1instance",
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      "msi1instance",
+				Namespace: system.DefaultNamespace,
 			}},
 			authorized: []string{"msi1instance"},
 			userID:     "user-uid",
@@ -360,10 +333,8 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 		{
 			name: "instance composite parent allows component instance",
 			objects: []kclient.Object{&v1.MCPServerInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "msi1component",
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      "msi1component",
+				Namespace: system.DefaultNamespace,
 				Spec: v1.MCPServerInstanceSpec{
 					CompositeName: "ms1composite",
 				},
@@ -377,19 +348,15 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 			name: "instance checks associated server composite parent",
 			objects: []kclient.Object{
 				&v1.MCPServerInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "msi1instance",
-						Namespace: system.DefaultNamespace,
-					},
+					Name:      "msi1instance",
+					Namespace: system.DefaultNamespace,
 					Spec: v1.MCPServerInstanceSpec{
 						MCPServerName: "ms1component",
 					},
 				},
 				&v1.MCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "ms1component",
-						Namespace: system.DefaultNamespace,
-					},
+					Name:      "ms1component",
+					Namespace: system.DefaultNamespace,
 					Spec: v1.MCPServerSpec{
 						CompositeName: "ms1composite",
 					},
@@ -404,16 +371,12 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 			name: "catalog entry allows matching user server",
 			objects: []kclient.Object{
 				&v1.MCPServerCatalogEntry{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "entry-test",
-						Namespace: system.DefaultNamespace,
-					},
+					Name:      "entry-test",
+					Namespace: system.DefaultNamespace,
 				},
 				&v1.MCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "ms1fromentry",
-						Namespace: system.DefaultNamespace,
-					},
+					Name:      "ms1fromentry",
+					Namespace: system.DefaultNamespace,
 					Spec: v1.MCPServerSpec{
 						MCPServerCatalogEntryName: "entry-test",
 						UserID:                    "user-uid",
@@ -429,16 +392,12 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 			name: "catalog entry allows matching user server composite parent",
 			objects: []kclient.Object{
 				&v1.MCPServerCatalogEntry{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "entry-test",
-						Namespace: system.DefaultNamespace,
-					},
+					Name:      "entry-test",
+					Namespace: system.DefaultNamespace,
 				},
 				&v1.MCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "ms1fromentry",
-						Namespace: system.DefaultNamespace,
-					},
+					Name:      "ms1fromentry",
+					Namespace: system.DefaultNamespace,
 					Spec: v1.MCPServerSpec{
 						MCPServerCatalogEntryName: "entry-test",
 						UserID:                    "user-uid",
@@ -455,16 +414,12 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 			name: "catalog entry ignores matching server for different user",
 			objects: []kclient.Object{
 				&v1.MCPServerCatalogEntry{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "entry-test",
-						Namespace: system.DefaultNamespace,
-					},
+					Name:      "entry-test",
+					Namespace: system.DefaultNamespace,
 				},
 				&v1.MCPServer{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "ms1fromentry",
-						Namespace: system.DefaultNamespace,
-					},
+					Name:      "ms1fromentry",
+					Namespace: system.DefaultNamespace,
 					Spec: v1.MCPServerSpec{
 						MCPServerCatalogEntryName: "entry-test",
 						UserID:                    "other-uid",
@@ -503,37 +458,29 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 func TestMCPConnectSubtreeAuthorization(t *testing.T) {
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
 		&v1.MCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ms1test",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "ms1test",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerSpec{
 				UserID: "user-uid",
 			},
 		},
 		&v1.MCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ms1keytest",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "ms1keytest",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerSpec{
 				UserID: "key-user-uid",
 			},
 		},
 		&v1.MCPServerInstance{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "msi1test",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "msi1test",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerInstanceSpec{
 				UserID: "user-uid",
 			},
 		},
 		&v1.MCPServerInstance{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "msi1keytest",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "msi1keytest",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerInstanceSpec{
 				UserID: "key-user-uid",
 			},

--- a/pkg/api/authz/mcpoauth_test.go
+++ b/pkg/api/authz/mcpoauth_test.go
@@ -9,17 +9,14 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestMCPGroupAllowsMCPAndAnyGroupRoutes(t *testing.T) {
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServerInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "msi1test",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "msi1test",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerInstanceSpec{
 			UserID: "mcpoauth-user-uid",
 		},
@@ -65,10 +62,8 @@ func TestMCPGroupAllowsMCPAndAnyGroupRoutes(t *testing.T) {
 
 func TestDefaultAuthorizerAllowsMCPProxyRoutes(t *testing.T) {
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ms1test",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "ms1test",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerSpec{
 			UserID: "mcp-user-uid",
 		},

--- a/pkg/api/authz/mcpservercatalogentry_test.go
+++ b/pkg/api/authz/mcpservercatalogentry_test.go
@@ -10,7 +10,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	gocache "k8s.io/client-go/tools/cache"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,19 +18,15 @@ import (
 
 func TestAllMCPCatalogEntryAuthorizationUsesAccessControlRules(t *testing.T) {
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "entry-test",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "entry-test",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerCatalogEntrySpec{
 			MCPCatalogName: system.DefaultCatalog,
 		},
 	}).Build()
 	authorizer := newCatalogEntryTestAuthorizer(t, storage, &v1.AccessControlRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "entry-access",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "entry-access",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.AccessControlRuleSpec{
 			MCPCatalogID: system.DefaultCatalog,
 			Manifest: types.AccessControlRuleManifest{

--- a/pkg/api/authz/publishedartifact_test.go
+++ b/pkg/api/authz/publishedartifact_test.go
@@ -9,17 +9,14 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestPublishedArtifactAuthorization(t *testing.T) {
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.PublishedArtifact{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pa1test",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "pa1test",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.PublishedArtifactSpec{
 			AuthorID:      "owner",
 			LatestVersion: 2,

--- a/pkg/api/authz/skills_test.go
+++ b/pkg/api/authz/skills_test.go
@@ -11,7 +11,6 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	gocache "k8s.io/client-go/tools/cache"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -230,10 +229,8 @@ func TestSkillRouteAuthorization(t *testing.T) {
 func TestSkillGetAuthorizationUsesAccessRules(t *testing.T) {
 	authorizer := newSkillAccessRuleTestAuthorizer(t,
 		&v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "sk1",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "sk1",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.SkillSpec{
 				RepoID: "repo-1",
 			},
@@ -242,10 +239,8 @@ func TestSkillGetAuthorizationUsesAccessRules(t *testing.T) {
 			},
 		},
 		&v1.SkillAccessRule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "allow-user1-sk1",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "allow-user1-sk1",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.SkillAccessRuleSpec{
 				Manifest: types.SkillAccessRuleManifest{
 					Subjects:  []types.Subject{{Type: types.SubjectTypeUser, ID: "user1"}},
@@ -282,10 +277,8 @@ func newSkillRouteTestAuthorizer(t *testing.T) *Authorizer {
 	t.Helper()
 
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.Skill{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "some-skill-id",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "some-skill-id",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.SkillSpec{
 			RepoID: "repo-1",
 		},
@@ -307,10 +300,8 @@ func newSkillRouteTestAuthorizer(t *testing.T) *Authorizer {
 		},
 	})
 	_ = indexer.Add(&v1.SkillAccessRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "allow-all",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "allow-all",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.SkillAccessRuleSpec{
 			Manifest: types.SkillAccessRuleManifest{
 				Subjects:  []types.Subject{{Type: types.SubjectTypeSelector, ID: "*"}},

--- a/pkg/api/handlers/accesscontrolrules.go
+++ b/pkg/api/handlers/accesscontrolrules.go
@@ -7,7 +7,6 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type AccessControlRuleHandler struct{}
@@ -134,11 +133,9 @@ func (*AccessControlRuleHandler) Create(req api.Context) error {
 	}
 
 	rule := v1.AccessControlRule{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.AccessControlRulePrefix,
-			Namespace:    req.Namespace(),
-			Finalizers:   []string{v1.AccessControlRuleFinalizer},
-		},
+		GenerateName: system.AccessControlRulePrefix,
+		Namespace:    req.Namespace(),
+		Finalizers:   []string{v1.AccessControlRuleFinalizer},
 		Spec: v1.AccessControlRuleSpec{
 			Manifest:             manifest,
 			MCPCatalogID:         catalogID,
@@ -292,10 +289,8 @@ func (*AccessControlRuleHandler) Delete(req api.Context) error {
 	}
 
 	return req.Delete(&v1.AccessControlRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ruleID,
-			Namespace: req.Namespace(),
-		},
+		Name:      ruleID,
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/agentcatalogs.go
+++ b/pkg/api/handlers/agentcatalogs.go
@@ -10,7 +10,6 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type AgentCatalogHandler struct {
@@ -51,10 +50,8 @@ func (h *AgentCatalogHandler) Create(req api.Context) error {
 	}
 
 	source := v1.AgentCatalog{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.AgentCatalogPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.AgentCatalogPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.AgentCatalogSpec{
 			AgentCatalogManifest: *manifest,
 		},
@@ -88,10 +85,8 @@ func (h *AgentCatalogHandler) Update(req api.Context) error {
 
 func (*AgentCatalogHandler) Delete(req api.Context) error {
 	return req.Delete(&v1.AgentCatalog{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.PathValue("agent_catalog_id"),
-			Namespace: req.Namespace(),
-		},
+		Name:      req.PathValue("agent_catalog_id"),
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/appnotification.go
+++ b/pkg/api/handlers/appnotification.go
@@ -53,10 +53,8 @@ func (*AppNotificationHandler) Update(req api.Context) error {
 	if apierrors.IsNotFound(err) {
 		// Create new notification
 		notification = v1.AppNotification{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      system.AppNotificationName,
-				Namespace: req.Namespace(),
-			},
+			Name:      system.AppNotificationName,
+			Namespace: req.Namespace(),
 			Spec: v1.AppNotificationSpec{
 				Banner:  input.Banner,
 				Updated: metav1.Now(),

--- a/pkg/api/handlers/apppreferences.go
+++ b/pkg/api/handlers/apppreferences.go
@@ -6,7 +6,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,10 +46,8 @@ func (*AppPreferencesHandler) Update(req api.Context) error {
 	if apierrors.IsNotFound(err) {
 		// Create new preferences
 		prefs = v1.AppPreferences{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      system.AppPreferencesName,
-				Namespace: req.Namespace(),
-			},
+			Name:      system.AppPreferencesName,
+			Namespace: req.Namespace(),
 			Spec: v1.AppPreferencesSpec{
 				Logos: input.Logos,
 				Theme: input.Theme,

--- a/pkg/api/handlers/auditlogexport.go
+++ b/pkg/api/handlers/auditlogexport.go
@@ -43,10 +43,8 @@ func (h *AuditLogExportHandler) CreateAuditLogExport(req api.Context) error {
 
 	// Create the AuditLogExport resource
 	export := &v1.AuditLogExport{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.AuditLogExportPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.AuditLogExportPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.AuditLogExportSpec{
 			Name:                   createReq.Name,
 			Type:                   createReq.Type,
@@ -121,10 +119,8 @@ func (h *AuditLogExportHandler) DeleteAuditLogExport(req api.Context) error {
 	}
 
 	export := &v1.AuditLogExport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      exportName,
-			Namespace: req.Namespace(),
-		},
+		Name:      exportName,
+		Namespace: req.Namespace(),
 	}
 
 	return req.Storage.Delete(req.Context(), export)
@@ -144,10 +140,8 @@ func (h *AuditLogExportHandler) CreateScheduledAuditLogExport(req api.Context) e
 
 	// Create the ScheduledAuditLogExport resource
 	scheduledExport := &v1.ScheduledAuditLogExport{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.ScheduledAuditLogExportPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.ScheduledAuditLogExportPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.ScheduledAuditLogExportSpec{
 			Name:                   createReq.Name,
 			Type:                   createReq.Type,
@@ -301,10 +295,8 @@ func (h *AuditLogExportHandler) DeleteScheduledAuditLogExport(req api.Context) e
 	}
 
 	scheduledExport := &v1.ScheduledAuditLogExport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      exportName,
-			Namespace: req.Namespace(),
-		},
+		Name:      exportName,
+		Namespace: req.Namespace(),
 	}
 
 	return req.Storage.Delete(req.Context(), scheduledExport)

--- a/pkg/api/handlers/auditlogexport_test.go
+++ b/pkg/api/handlers/auditlogexport_test.go
@@ -138,7 +138,7 @@ func TestConvertLLMExportToAPI(t *testing.T) {
 	started := metav1.NewTime(time.Date(2026, 7, 1, 1, 0, 0, 0, time.UTC))
 	completed := metav1.NewTime(time.Date(2026, 7, 1, 1, 5, 0, 0, time.UTC))
 	export := &v1.AuditLogExport{
-		ObjectMeta: metav1.ObjectMeta{Name: "ael1abc", CreationTimestamp: metav1.NewTime(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC))},
+		Name: "ael1abc", CreationTimestamp: metav1.NewTime(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)),
 		Spec: v1.AuditLogExportSpec{
 			Name:       "daily",
 			Type:       types.AuditLogTypeLLM,

--- a/pkg/api/handlers/defaultmodelalias.go
+++ b/pkg/api/handlers/defaultmodelalias.go
@@ -5,7 +5,6 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type DefaultModelAliasHandler struct{}
@@ -21,10 +20,8 @@ func (*DefaultModelAliasHandler) Create(req api.Context) error {
 	}
 
 	dma := v1.DefaultModelAlias{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.DefaultModelAliasPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.DefaultModelAliasPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.DefaultModelAliasSpec{
 			Manifest: manifest,
 		},
@@ -79,10 +76,8 @@ func (*DefaultModelAliasHandler) Update(req api.Context) error {
 
 func (*DefaultModelAliasHandler) Delete(req api.Context) error {
 	return req.Delete(&v1.DefaultModelAlias{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.PathValue("id"),
-			Namespace: req.Namespace(),
-		},
+		Name:      req.PathValue("id"),
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/devicescans.go
+++ b/pkg/api/handlers/devicescans.go
@@ -83,10 +83,10 @@ func (*DeviceScansHandler) List(req api.Context) error {
 		items = append(items, gtypes.ConvertDeviceScan(s))
 	}
 	return req.Write(types.DeviceScanResponse{
-		DeviceScanList: types.DeviceScanList{Items: items},
-		Total:          total,
-		Limit:          opts.Limit,
-		Offset:         opts.Offset,
+		Items:  items,
+		Total:  total,
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
 	})
 }
 
@@ -233,10 +233,10 @@ func (*DeviceScansHandler) ListMCPServerOccurrences(req api.Context) error {
 		})
 	}
 	return req.Write(types.DeviceMCPServerOccurrenceResponse{
-		DeviceMCPServerOccurrenceList: types.DeviceMCPServerOccurrenceList{Items: items},
-		Total:                         total,
-		Limit:                         limit,
-		Offset:                        offset,
+		Items:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
 	})
 }
 
@@ -265,10 +265,10 @@ func (*DeviceScansHandler) ListSkills(req api.Context) error {
 		})
 	}
 	return req.Write(types.DeviceSkillStatResponse{
-		DeviceSkillStatList: types.DeviceSkillStatList{Items: items},
-		Total:               total,
-		Limit:               opts.Limit,
-		Offset:              opts.Offset,
+		Items:  items,
+		Total:  total,
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
 	})
 }
 
@@ -321,16 +321,14 @@ func (*DeviceScansHandler) GetSkill(req api.Context) error {
 		return err
 	}
 	return req.Write(types.DeviceSkillDetail{
-		DeviceSkillStat: types.DeviceSkillStat{
-			Name:             detail.Name,
-			DeviceCount:      detail.DeviceCount,
-			UserCount:        detail.UserCount,
-			ObservationCount: detail.ObservationCount,
-		},
-		Description:  detail.Description,
-		HasScripts:   detail.HasScripts,
-		GitRemoteURL: detail.GitRemoteURL,
-		Files:        detail.Files,
+		Name:             detail.Name,
+		DeviceCount:      detail.DeviceCount,
+		UserCount:        detail.UserCount,
+		ObservationCount: detail.ObservationCount,
+		Description:      detail.Description,
+		HasScripts:       detail.HasScripts,
+		GitRemoteURL:     detail.GitRemoteURL,
+		Files:            detail.Files,
 	})
 }
 
@@ -373,10 +371,10 @@ func (*DeviceScansHandler) ListSkillOccurrences(req api.Context) error {
 		})
 	}
 	return req.Write(types.DeviceSkillOccurrenceResponse{
-		DeviceSkillOccurrenceList: types.DeviceSkillOccurrenceList{Items: items},
-		Total:                     total,
-		Limit:                     limit,
-		Offset:                    offset,
+		Items:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
 	})
 }
 
@@ -509,10 +507,10 @@ func (*DeviceScansHandler) ListClients(req api.Context) error {
 		items = append(items, convertDeviceClientFleetSummary(r))
 	}
 	return req.Write(types.DeviceClientFleetSummaryResponse{
-		DeviceClientFleetSummaryList: types.DeviceClientFleetSummaryList{Items: items},
-		Total:                        total,
-		Limit:                        limit,
-		Offset:                       offset,
+		Items:  items,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
 	})
 }
 

--- a/pkg/api/handlers/enforcement.go
+++ b/pkg/api/handlers/enforcement.go
@@ -161,10 +161,10 @@ func (h *EnforcementHandler) ListDecisions(req api.Context) error {
 	}
 
 	return req.Write(types.EnforcementDecisionEventResponse{
-		EnforcementDecisionEventList: types.EnforcementDecisionEventList{Items: items},
-		Total:                        total,
-		Limit:                        opts.Limit,
-		Offset:                       opts.Offset,
+		Items:  items,
+		Total:  total,
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
 	})
 }
 

--- a/pkg/api/handlers/gitcredentials.go
+++ b/pkg/api/handlers/gitcredentials.go
@@ -10,7 +10,6 @@ import (
 	"github.com/obot-platform/obot/pkg/gitcredential"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type GitCredentialHandler struct{}
@@ -58,11 +57,9 @@ func (*GitCredentialHandler) Create(req api.Context) error {
 	}
 
 	credential := v1.GitCredential{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.GitCredentialPrefix,
-			Namespace:    req.Namespace(),
-			Finalizers:   []string{v1.GitCredentialFinalizer},
-		},
+		GenerateName: system.GitCredentialPrefix,
+		Namespace:    req.Namespace(),
+		Finalizers:   []string{v1.GitCredentialFinalizer},
 		Spec: v1.GitCredentialSpec{
 			DisplayName: manifest.DisplayName,
 			Host:        host,

--- a/pkg/api/handlers/gitcredentials_test.go
+++ b/pkg/api/handlers/gitcredentials_test.go
@@ -18,12 +18,11 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestConvertGitCredentialDoesNotExposeToken(t *testing.T) {
 	converted := convertGitCredential(v1.GitCredential{
-		ObjectMeta: metav1.ObjectMeta{Name: "gc1-test", Namespace: system.DefaultNamespace},
+		Name: "gc1-test", Namespace: system.DefaultNamespace,
 		Spec: v1.GitCredentialSpec{
 			DisplayName: "Shared GitHub",
 			Host:        "github.com",
@@ -74,21 +73,21 @@ func TestReadGitCredentialManifestTrimsToken(t *testing.T) {
 func TestGitCredentialReferences(t *testing.T) {
 	storage := newFakeStorage(t,
 		&v1.SkillRepository{
-			ObjectMeta: metav1.ObjectMeta{Name: "skills", Namespace: system.DefaultNamespace},
+			Name: "skills", Namespace: system.DefaultNamespace,
 			Spec: v1.SkillRepositorySpec{
 				DisplayName:     "Team Skills",
 				GitCredentialID: "gc1-test",
 			},
 		},
 		&v1.MCPCatalog{
-			ObjectMeta: metav1.ObjectMeta{Name: "catalog", Namespace: system.DefaultNamespace},
+			Name: "catalog", Namespace: system.DefaultNamespace,
 			Spec: v1.MCPCatalogSpec{SourceURLGitCredentialIDs: map[string]string{
 				"https://github.com/org/catalog": "gc1-test",
 				"https://github.com/org/other":   "gc1-test",
 			}},
 		},
 		&v1.SystemMCPCatalog{
-			ObjectMeta: metav1.ObjectMeta{Name: "system-catalog", Namespace: system.DefaultNamespace},
+			Name: "system-catalog", Namespace: system.DefaultNamespace,
 			Spec: v1.SystemMCPCatalogSpec{SourceURLGitCredentialIDs: map[string]string{
 				"https://github.com/org/system-catalog": "gc1-test",
 				"https://github.com/org/system-other":   "gc1-test",
@@ -136,16 +135,16 @@ func TestValidateCatalogGitCredentials(t *testing.T) {
 		Request: httptest.NewRequest(http.MethodPut, "/api/mcp-catalogs/default", nil),
 		Storage: newFakeStorage(t,
 			&v1.GitCredential{
-				ObjectMeta: metav1.ObjectMeta{Name: "gc1-github", Namespace: system.DefaultNamespace},
-				Spec:       v1.GitCredentialSpec{Host: "github.com"},
+				Name: "gc1-github", Namespace: system.DefaultNamespace,
+				Spec: v1.GitCredentialSpec{Host: "github.com"},
 			},
 			&v1.GitCredential{
-				ObjectMeta: metav1.ObjectMeta{Name: "gc1-gitlab", Namespace: system.DefaultNamespace},
-				Spec:       v1.GitCredentialSpec{Host: "gitlab.com"},
+				Name: "gc1-gitlab", Namespace: system.DefaultNamespace,
+				Spec: v1.GitCredentialSpec{Host: "gitlab.com"},
 			},
 			&v1.GitCredential{
-				ObjectMeta: metav1.ObjectMeta{Name: "gc1-empty", Namespace: system.DefaultNamespace},
-				Spec:       v1.GitCredentialSpec{Host: "github.com"},
+				Name: "gc1-empty", Namespace: system.DefaultNamespace,
+				Spec: v1.GitCredentialSpec{Host: "github.com"},
 			},
 		),
 		GatewayClient: gatewayClient,

--- a/pkg/api/handlers/harnesses.go
+++ b/pkg/api/handlers/harnesses.go
@@ -7,7 +7,6 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,10 +50,8 @@ func (*HarnessHandler) Create(req api.Context) error {
 	}
 
 	harness := v1.Harness{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.HarnessPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.HarnessPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.HarnessSpec{
 			Manifest: manifest,
 		},
@@ -104,10 +101,8 @@ func (*HarnessHandler) Delete(req api.Context) error {
 	}
 
 	return req.Delete(&v1.Harness{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      id,
-			Namespace: req.Namespace(),
-		},
+		Name:      id,
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/hostedagentaccessrules.go
+++ b/pkg/api/handlers/hostedagentaccessrules.go
@@ -8,7 +8,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type HostedAgentAccessRuleHandler struct{}
@@ -47,10 +46,8 @@ func (*HostedAgentAccessRuleHandler) Create(req api.Context) error {
 	}
 
 	rule := v1.HostedAgentAccessRule{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.HostedAgentAccessRulePrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.HostedAgentAccessRulePrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.HostedAgentAccessRuleSpec{
 			Manifest: *manifest,
 		},
@@ -84,10 +81,8 @@ func (*HostedAgentAccessRuleHandler) Update(req api.Context) error {
 
 func (*HostedAgentAccessRuleHandler) Delete(req api.Context) error {
 	return req.Delete(&v1.HostedAgentAccessRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.PathValue("hosted_agent_access_rule_id"),
-			Namespace: req.Namespace(),
-		},
+		Name:      req.PathValue("hosted_agent_access_rule_id"),
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/hostedagentavailability_test.go
+++ b/pkg/api/handlers/hostedagentavailability_test.go
@@ -9,7 +9,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -26,14 +25,14 @@ func availabilityFor(t *testing.T, objs ...kclient.Object) *agentAvailability {
 
 func harnessObj(name string) *v1.Harness {
 	return &v1.Harness{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
-		Spec:       v1.HarnessSpec{Manifest: types.HarnessManifest{Name: name, Image: "img"}},
+		Name: name, Namespace: "obot",
+		Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Name: name, Image: "img"}},
 	}
 }
 
 func modelObj(name, provider string) *v1.Model {
 	return &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Name: name, Namespace: "obot",
 		Spec: v1.ModelSpec{Manifest: types.ModelManifest{
 			Name: name, TargetModel: name, ModelProvider: provider,
 			Active: true, Usage: types.ModelUsageLLM,
@@ -96,7 +95,7 @@ func TestMissingMCPServerMakesAnAgentUnavailable(t *testing.T) {
 	availability := availabilityFor(t,
 		harnessObj("hrn1any"),
 		modelObj("m1gpt", system.OpenAIModelProvider),
-		&v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "ms1here", Namespace: "obot"}},
+		&v1.MCPServer{Name: "ms1here", Namespace: "obot"},
 	)
 
 	reasons := availability.reasons(context.Background(), types.HostedAgentManifest{

--- a/pkg/api/handlers/hostedagentinstances.go
+++ b/pkg/api/handlers/hostedagentinstances.go
@@ -16,7 +16,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -167,10 +166,8 @@ func (h *HostedAgentInstanceHandler) Create(req api.Context) error {
 	}
 
 	instance := v1.HostedAgentInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.HostedAgentInstancePrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.HostedAgentInstancePrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.HostedAgentInstanceSpec{
 			UserID:          req.User.GetUID(),
 			HostedAgentName: agent.Name,
@@ -369,10 +366,8 @@ func resolveModelReference(req api.Context, ref string) (string, error) {
 
 func (h *HostedAgentInstanceHandler) Delete(req api.Context) error {
 	return req.Delete(&v1.HostedAgentInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.PathValue("hosted_agent_instance_id"),
-			Namespace: req.Namespace(),
-		},
+		Name:      req.PathValue("hosted_agent_instance_id"),
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/hostedagentpools.go
+++ b/pkg/api/handlers/hostedagentpools.go
@@ -9,7 +9,6 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -65,11 +64,9 @@ func (*HostedAgentPoolHandler) Create(req api.Context) error {
 		return err
 	}
 	pool := v1.HostedAgentPool{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "hp1",
-			Namespace:    req.Namespace(),
-		},
-		Spec: v1.HostedAgentPoolSpec{Manifest: manifest},
+		GenerateName: "hp1",
+		Namespace:    req.Namespace(),
+		Spec:         v1.HostedAgentPoolSpec{Manifest: manifest},
 	}
 	if err := req.Create(&pool); err != nil {
 		return fmt.Errorf("failed to create hosted agent pool: %w", err)
@@ -104,10 +101,9 @@ func (*HostedAgentPoolHandler) Delete(req api.Context) error {
 	if len(assignments.Items) > 0 {
 		return types.NewErrBadRequest("hosted agent pool %s is still assigned", poolID)
 	}
-	return req.Delete(&v1.HostedAgentPool{ObjectMeta: metav1.ObjectMeta{
+	return req.Delete(&v1.HostedAgentPool{
 		Name:      poolID,
-		Namespace: req.Namespace(),
-	}})
+		Namespace: req.Namespace()})
 }
 
 func (h *HostedAgentPoolHandler) Utilization(req api.Context) error {
@@ -215,8 +211,8 @@ func (*HostedAgentPoolDefaultsHandler) Create(req api.Context) error {
 		return err
 	}
 	defaults := v1.HostedAgentPoolDefaults{
-		ObjectMeta: metav1.ObjectMeta{Name: hostedAgentPoolDefaultsName, Namespace: req.Namespace()},
-		Spec:       v1.HostedAgentPoolDefaultsSpec{Manifest: manifest},
+		Name: hostedAgentPoolDefaultsName, Namespace: req.Namespace(),
+		Spec: v1.HostedAgentPoolDefaultsSpec{Manifest: manifest},
 	}
 	if err := req.Create(&defaults); err != nil {
 		return fmt.Errorf("failed to create hosted agent pool defaults: %w", err)
@@ -241,9 +237,8 @@ func (*HostedAgentPoolDefaultsHandler) Update(req api.Context) error {
 }
 
 func (*HostedAgentPoolDefaultsHandler) Delete(req api.Context) error {
-	return req.Delete(&v1.HostedAgentPoolDefaults{ObjectMeta: metav1.ObjectMeta{
-		Name: hostedAgentPoolDefaultsName, Namespace: req.Namespace(),
-	}})
+	return req.Delete(&v1.HostedAgentPoolDefaults{
+		Name: hostedAgentPoolDefaultsName, Namespace: req.Namespace()})
 }
 
 func readHostedAgentPoolDefaultsManifest(req api.Context) (types.HostedAgentPoolDefaultsManifest, error) {
@@ -306,8 +301,8 @@ func (*HostedAgentPoolAssignmentHandler) Create(req api.Context) error {
 		return err
 	}
 	assignment := v1.HostedAgentPoolAssignment{
-		ObjectMeta: metav1.ObjectMeta{GenerateName: "hpa1", Namespace: req.Namespace()},
-		Spec:       v1.HostedAgentPoolAssignmentSpec{Manifest: manifest},
+		GenerateName: "hpa1", Namespace: req.Namespace(),
+		Spec: v1.HostedAgentPoolAssignmentSpec{Manifest: manifest},
 	}
 	if err := req.Create(&assignment); err != nil {
 		return fmt.Errorf("failed to create hosted agent pool assignment: %w", err)
@@ -335,10 +330,9 @@ func (*HostedAgentPoolAssignmentHandler) Update(req api.Context) error {
 }
 
 func (*HostedAgentPoolAssignmentHandler) Delete(req api.Context) error {
-	return req.Delete(&v1.HostedAgentPoolAssignment{ObjectMeta: metav1.ObjectMeta{
+	return req.Delete(&v1.HostedAgentPoolAssignment{
 		Name:      req.PathValue("hosted_agent_pool_assignment_id"),
-		Namespace: req.Namespace(),
-	}})
+		Namespace: req.Namespace()})
 }
 
 func readHostedAgentPoolAssignmentManifest(req api.Context) (types.HostedAgentPoolAssignmentManifest, error) {

--- a/pkg/api/handlers/hostedagentpools_test.go
+++ b/pkg/api/handlers/hostedagentpools_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/obot-platform/obot/pkg/agentbackend"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestConvertPoolUtilization(t *testing.T) {
@@ -38,7 +37,7 @@ func TestConvertPoolUtilization(t *testing.T) {
 
 func TestConvertHostedAgentInstanceIncludesPool(t *testing.T) {
 	got := convertHostedAgentInstance(v1.HostedAgentInstance{
-		ObjectMeta: metav1.ObjectMeta{Name: "instance-1"},
+		Name: "instance-1",
 		Spec: v1.HostedAgentInstanceSpec{
 			UserID:          "user-1",
 			HostedAgentName: "agent-1",
@@ -56,7 +55,7 @@ func TestConvertHostedAgentInstanceIncludesPool(t *testing.T) {
 // whole; the per-instance breakdown must not expose anyone else's instances.
 func TestNarrowInstanceUtilizationHidesOtherUsersInstances(t *testing.T) {
 	mine := v1.HostedAgentInstance{
-		ObjectMeta: metav1.ObjectMeta{Name: "hai-mine", UID: "uid-mine"},
+		Name: "hai-mine", UID: "uid-mine",
 	}
 	usages := []agentbackend.InstanceUtilization{
 		{Ref: agentbackend.InstanceRef{ID: "uid-theirs-1"}, Utilization: agentbackend.ResourceUtilization{CPUVCPUs: 1}},
@@ -81,8 +80,8 @@ func TestNarrowInstanceUtilizationHidesOtherUsersInstances(t *testing.T) {
 // An admin passes the full instance list, so nothing is dropped.
 func TestNarrowInstanceUtilizationKeepsEverythingVisible(t *testing.T) {
 	instances := []v1.HostedAgentInstance{
-		{ObjectMeta: metav1.ObjectMeta{Name: "hai-a", UID: "uid-a"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "hai-b", UID: "uid-b"}},
+		{Name: "hai-a", UID: "uid-a"},
+		{Name: "hai-b", UID: "uid-b"},
 	}
 	usages := []agentbackend.InstanceUtilization{
 		{Ref: agentbackend.InstanceRef{ID: "uid-a"}},

--- a/pkg/api/handlers/hostedagents.go
+++ b/pkg/api/handlers/hostedagents.go
@@ -13,7 +13,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type HostedAgentHandler struct {
@@ -86,10 +85,8 @@ func (h *HostedAgentHandler) Create(req api.Context) error {
 	secrets := extractHostedAgentSecrets(&manifest)
 
 	agent := v1.HostedAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.HostedAgentPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.HostedAgentPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.HostedAgentSpec{
 			Manifest: manifest,
 		},
@@ -181,10 +178,8 @@ func (h *HostedAgentHandler) Delete(req api.Context) error {
 	}
 
 	return req.Delete(&v1.HostedAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      agent.Name,
-			Namespace: req.Namespace(),
-		},
+		Name:      agent.Name,
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/iconresolver_test.go
+++ b/pkg/api/handlers/iconresolver_test.go
@@ -21,7 +21,7 @@ func TestIconResolutionOrder(t *testing.T) {
 
 	// The user's own choice wins.
 	got := resolverFor(agent, harness).apply(
-		types.HostedAgentInstance{HostedAgentInstanceManifest: types.HostedAgentInstanceManifest{Icon: "mine.svg"}}, "ha1")
+		types.HostedAgentInstance{Icon: "mine.svg"}, "ha1")
 	if got.ResolvedIcon != "mine.svg" {
 		t.Errorf("instance icon = %q, want the instance's own", got.ResolvedIcon)
 	}
@@ -62,7 +62,7 @@ func TestNoIconAnywhereResolvesEmpty(t *testing.T) {
 // An instance whose agent has been deleted still renders; it just has no icon.
 func TestUnknownAgentDoesNotPanic(t *testing.T) {
 	got := resolverFor(types.HostedAgentManifest{}, types.HarnessManifest{}).
-		apply(types.HostedAgentInstance{HostedAgentInstanceManifest: types.HostedAgentInstanceManifest{Icon: "mine.svg"}}, "gone")
+		apply(types.HostedAgentInstance{Icon: "mine.svg"}, "gone")
 	if got.ResolvedIcon != "mine.svg" {
 		t.Errorf("resolved = %q, want the instance's own icon", got.ResolvedIcon)
 	}

--- a/pkg/api/handlers/imagepullsecrets.go
+++ b/pkg/api/handlers/imagepullsecrets.go
@@ -112,11 +112,9 @@ func (h *ImagePullSecretHandler) Create(req api.Context) error {
 	}
 
 	secret := v1.ImagePullSecret{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.ImagePullSecretPrefix,
-			Namespace:    req.Namespace(),
-		},
-		Spec: spec,
+		GenerateName: system.ImagePullSecretPrefix,
+		Namespace:    req.Namespace(),
+		Spec:         spec,
 	}
 
 	if err := req.Create(&secret); err != nil {

--- a/pkg/api/handlers/llmauditlog.go
+++ b/pkg/api/handlers/llmauditlog.go
@@ -38,10 +38,10 @@ func (h *LLMAuditLogHandler) List(req api.Context) error {
 	}
 
 	return req.Write(types.LLMAuditLogResponse{
-		LLMAuditLogList: types.LLMAuditLogList{Items: items},
-		Total:           total,
-		Limit:           opts.Limit,
-		Offset:          opts.Offset,
+		Items:  items,
+		Total:  total,
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
 	})
 }
 

--- a/pkg/api/handlers/localauth.go
+++ b/pkg/api/handlers/localauth.go
@@ -14,7 +14,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type LocalAuthHandler struct {
@@ -52,11 +51,9 @@ func (h *LocalAuthHandler) List(req api.Context) error {
 	items := make([]LocalAuthUser, 0, len(users))
 	for _, user := range users {
 		items = append(items, LocalAuthUser{
-			Metadata: types.Metadata{
-				ID:      strconv.FormatUint(uint64(user.ID), 10),
-				Created: *types.NewTime(user.CreatedAt),
-			},
-			Email: user.Email,
+			ID:      strconv.FormatUint(uint64(user.ID), 10),
+			Created: *types.NewTime(user.CreatedAt),
+			Email:   user.Email,
 		})
 	}
 
@@ -83,11 +80,9 @@ func (h *LocalAuthHandler) Create(req api.Context) error {
 	}
 
 	return req.Write(LocalAuthUser{
-		Metadata: types.Metadata{
-			ID:      strconv.FormatUint(uint64(user.ID), 10),
-			Created: *types.NewTime(user.CreatedAt),
-		},
-		Email: user.Email,
+		ID:      strconv.FormatUint(uint64(user.ID), 10),
+		Created: *types.NewTime(user.CreatedAt),
+		Email:   user.Email,
 	})
 }
 
@@ -158,10 +153,8 @@ func (h *LocalAuthHandler) Delete(req api.Context) error {
 
 		if err == nil {
 			if err = req.Create(&v1.UserDelete{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: system.UserDeletePrefix,
-					Namespace:    req.Namespace(),
-				},
+				GenerateName: system.UserDeletePrefix,
+				Namespace:    req.Namespace(),
 				Spec: v1.UserDeleteSpec{
 					UserID: gatewayUser.ID,
 				},

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -31,7 +31,6 @@ import (
 	"github.com/obot-platform/obot/pkg/utils"
 	"github.com/obot-platform/obot/pkg/wait"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -753,9 +752,8 @@ func (m *MCPHandler) serverNeedsOAuth(ctx context.Context, server *v1.MCPServer,
 		return false, nil
 	}
 
-	var authRequired nmcp.AuthRequiredErr
 	if err := m.mcpSessionManager.PingServer(ctx, serverConfig); err != nil {
-		if errors.As(err, &authRequired) {
+		if _, ok := errors.AsType[nmcp.AuthRequiredErr](err); ok {
 			return true, nil
 		}
 		return false, fmt.Errorf("failed to ping MCP server %s: %w", server.Name, err)
@@ -857,8 +855,7 @@ func (m *MCPHandler) GetResources(req api.Context) error {
 			return types.NewErrHTTP(http.StatusBadRequest, nse.Error())
 		}
 
-		var are nmcp.AuthRequiredErr
-		if errors.As(err, &are) {
+		if _, ok := errors.AsType[nmcp.AuthRequiredErr](err); ok {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
 		}
 		return fmt.Errorf("failed to list resources: %w", err)
@@ -898,8 +895,7 @@ func (m *MCPHandler) ReadResource(req api.Context) error {
 			return types.NewErrHTTP(http.StatusBadRequest, nse.Error())
 		}
 
-		var are nmcp.AuthRequiredErr
-		if errors.As(err, &are) {
+		if _, ok := errors.AsType[nmcp.AuthRequiredErr](err); ok {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
 		}
 		return fmt.Errorf("failed to list resources: %w", err)
@@ -942,8 +938,7 @@ func (m *MCPHandler) GetPrompts(req api.Context) error {
 			return types.NewErrHTTP(http.StatusBadRequest, nse.Error())
 		}
 
-		var are nmcp.AuthRequiredErr
-		if errors.As(err, &are) {
+		if _, ok := errors.AsType[nmcp.AuthRequiredErr](err); ok {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
 		}
 		return fmt.Errorf("failed to list prompts: %w", err)
@@ -990,8 +985,7 @@ func (m *MCPHandler) GetPrompt(req api.Context) error {
 		if nse := (*mcp.ErrNotSupportedByBackend)(nil); errors.As(err, &nse) {
 			return types.NewErrHTTP(http.StatusBadRequest, nse.Error())
 		}
-		var are nmcp.AuthRequiredErr
-		if errors.As(err, &are) {
+		if _, ok := errors.AsType[nmcp.AuthRequiredErr](err); ok {
 			return types.NewErrHTTP(http.StatusPreconditionFailed, "MCP server requires authentication")
 		}
 		return fmt.Errorf("failed to get prompt: %w", err)
@@ -1031,10 +1025,8 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id, secretBindingAllowed
 			if len(instances.Items) == 0 {
 				// If none exist, then create one for the user.
 				instance := v1.MCPServerInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: system.MCPServerInstancePrefix,
-						Namespace:    server.Namespace,
-					},
+					GenerateName: system.MCPServerInstancePrefix,
+					Namespace:    server.Namespace,
 					Spec: v1.MCPServerInstanceSpec{
 						MCPServerName:             id,
 						MCPCatalogName:            server.Spec.MCPCatalogID,
@@ -1105,10 +1097,8 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id, secretBindingAllowed
 
 			// Create a new MCP server for the user.
 			server := v1.MCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: system.MCPServerPrefix,
-					Namespace:    req.Namespace(),
-				},
+				GenerateName: system.MCPServerPrefix,
+				Namespace:    req.Namespace(),
 				Spec: v1.MCPServerSpec{
 					Manifest:                  manifest,
 					UnsupportedTools:          entry.Spec.UnsupportedTools,
@@ -1607,11 +1597,9 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 	}
 
 	server := v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.MCPServerPrefix,
-			Namespace:    req.Namespace(),
-			Finalizers:   []string{v1.MCPServerFinalizer},
-		},
+		GenerateName: system.MCPServerPrefix,
+		Namespace:    req.Namespace(),
+		Finalizers:   []string{v1.MCPServerFinalizer},
 		Spec: v1.MCPServerSpec{
 			Alias:                     input.Alias,
 			MCPServerCatalogEntryName: input.CatalogEntryID,
@@ -2739,13 +2727,11 @@ func addExtractedEnvVars(server *v1.MCPServer) {
 		for _, env := range extractEnvVars(v) {
 			if _, exists := existing[env]; !exists {
 				server.Spec.Manifest.Env = append(server.Spec.Manifest.Env, types.MCPEnv{
-					MCPHeader: types.MCPHeader{
-						Name:        env,
-						Key:         env,
-						Description: "Automatically detected variable",
-						Sensitive:   true,
-						Required:    true,
-					},
+					Name:        env,
+					Key:         env,
+					Description: "Automatically detected variable",
+					Sensitive:   true,
+					Required:    true,
 				})
 			}
 		}
@@ -2812,13 +2798,11 @@ func addExtractedEnvVarsToCatalogEntryManifest(manifest *types.MCPServerCatalogE
 			if _, exists := existing[env]; !exists {
 				if manifest.Runtime != types.RuntimeRemote {
 					manifest.Env = append(manifest.Env, types.MCPEnv{
-						MCPHeader: types.MCPHeader{
-							Name:        env,
-							Key:         env,
-							Description: "Automatically detected variable",
-							Sensitive:   true,
-							Required:    true,
-						},
+						Name:        env,
+						Key:         env,
+						Description: "Automatically detected variable",
+						Sensitive:   true,
+						Required:    true,
 					})
 				} else if manifest.RemoteConfig != nil {
 					manifest.RemoteConfig.Headers = append(manifest.RemoteConfig.Headers, types.MCPHeader{

--- a/pkg/api/handlers/mcp_oauth_debugger.go
+++ b/pkg/api/handlers/mcp_oauth_debugger.go
@@ -312,18 +312,16 @@ func (m *MCPHandler) useOAuthDebuggerCIMD(server v1.MCPServer, clientID, clientS
 
 func (m *MCPHandler) oauthDebuggerCIMDClient(authServer mcp.AuthorizationServerMetadata, registration mcp.ClientRegistrationMetadata) types.OAuthClient {
 	return types.OAuthClient{
-		OAuthClientManifest: types.OAuthClientManifest{
-			RedirectURIs:            registration.RedirectURIs,
-			TokenEndpointAuthMethod: "none",
-			GrantTypes:              registration.GrantTypes,
-			ResponseTypes:           registration.ResponseTypes,
-			ClientName:              registration.ClientName,
-			ClientURI:               m.serverURL,
-			Scope:                   registration.Scope,
-		},
-		ClientID:     system.OAuthClientIDMetadataURL(m.serverURL),
-		AuthorizeURL: authServer.AuthorizationEndpoint,
-		TokenURL:     authServer.TokenEndpoint,
+		RedirectURIs:            registration.RedirectURIs,
+		TokenEndpointAuthMethod: "none",
+		GrantTypes:              registration.GrantTypes,
+		ResponseTypes:           registration.ResponseTypes,
+		ClientName:              registration.ClientName,
+		ClientURI:               m.serverURL,
+		Scope:                   registration.Scope,
+		ClientID:                system.OAuthClientIDMetadataURL(m.serverURL),
+		AuthorizeURL:            authServer.AuthorizationEndpoint,
+		TokenURL:                authServer.TokenEndpoint,
 	}
 }
 

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,11 +55,9 @@ func TestConvertMCPServer_StaticEnvIsConfigured(t *testing.T) {
 			Manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeNPX,
 				Env: []types.MCPEnv{{
-					MCPHeader: types.MCPHeader{
-						Key:      "CATALOG_TOKEN",
-						Value:    "catalog-value",
-						Required: true,
-					},
+					Key:      "CATALOG_TOKEN",
+					Value:    "catalog-value",
+					Required: true,
 				}},
 			},
 		},
@@ -79,7 +76,7 @@ func TestConvertMCPResources(t *testing.T) {
 	}
 
 	entry := ConvertMCPServerCatalogEntry(v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{Name: "entry"},
+		Name: "entry",
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Manifest: types.MCPServerCatalogEntryManifest{
 				Name:           "entry",
@@ -93,7 +90,7 @@ func TestConvertMCPResources(t *testing.T) {
 	assert.Equal(t, "https://example.com/mcp-connect/entry", entry.ConnectURL)
 
 	compositeEntry := ConvertMCPServerCatalogEntry(v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{Name: "composite-entry"},
+		Name: "composite-entry",
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Manifest: types.MCPServerCatalogEntryManifest{
 				Name:           "composite-entry",
@@ -110,7 +107,7 @@ func TestConvertMCPResources(t *testing.T) {
 	assert.Equal(t, "https://example.com/mcp-connect/composite-entry", compositeEntry.ConnectURL)
 
 	server := ConvertMCPServer(v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "server"},
+		Name: "server",
 		Spec: v1.MCPServerSpec{
 			Manifest: types.MCPServerManifest{
 				Name:      "server",
@@ -123,7 +120,7 @@ func TestConvertMCPResources(t *testing.T) {
 
 func TestConvertMCPServerCatalogEntryDetached(t *testing.T) {
 	entry := ConvertMCPServerCatalogEntry(v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{Name: "entry"},
+		Name: "entry",
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Editable:  true,
 			Detached:  true,
@@ -141,8 +138,8 @@ func TestValidationOptionsWithResourceMaximumsIgnoresPersistedMaximumForNonKuber
 	req := api.Context{
 		Request: httptest.NewRequest(http.MethodGet, "/", nil),
 		Storage: newFakeStorage(t, &v1.K8sSettings{
-			ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
-			Spec:       v1.K8sSettingsSpec{MaxCPURequest: &maximum},
+			Name: system.K8sSettingsName, Namespace: system.DefaultNamespace,
+			Spec: v1.K8sSettingsSpec{MaxCPURequest: &maximum},
 		}),
 	}
 
@@ -220,10 +217,8 @@ func TestHideMultiUserCatalogEntry(t *testing.T) {
 
 func TestUpdateServerAliasUnscopedSharedServer(t *testing.T) {
 	server := v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "server",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "server",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerSpec{
 			MCPCatalogID: "catalog-a",
 			Manifest: types.MCPServerManifest{
@@ -252,10 +247,8 @@ func TestUpdateServerAliasUnscopedSharedServer(t *testing.T) {
 
 func TestMCPServerOrInstanceFromConnectURLRejectsCatalogEntryResourcesAboveMaximum(t *testing.T) {
 	entry := v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "entry",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "entry",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Manifest: types.MCPServerCatalogEntryManifest{
 				Name:           "entry",
@@ -306,7 +299,7 @@ func TestTriggerUpdateScope(t *testing.T) {
 
 	baseEntry := func(workspaceID string) *v1.MCPServerCatalogEntry {
 		return &v1.MCPServerCatalogEntry{
-			ObjectMeta: metav1.ObjectMeta{Name: "entry"},
+			Name: "entry",
 			Spec: v1.MCPServerCatalogEntrySpec{
 				PowerUserWorkspaceID: workspaceID,
 				Manifest: types.MCPServerCatalogEntryManifest{
@@ -320,7 +313,7 @@ func TestTriggerUpdateScope(t *testing.T) {
 
 	baseServer := func(userID string) v1.MCPServer {
 		return v1.MCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: "server"},
+			Name: "server",
 			Spec: v1.MCPServerSpec{
 				UserID:                    userID,
 				MCPServerCatalogEntryName: "entry",
@@ -704,10 +697,9 @@ func TestApplyRemoteURLTemplate(t *testing.T) {
 	manifest := types.MCPServerManifest{
 		Name:    "OAuth Remote",
 		Runtime: types.RuntimeRemote,
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:   "HOST",
-			Value: "remote.example.com",
-		}}},
+			Value: "remote.example.com"}},
 		RemoteConfig: &types.RemoteRuntimeConfig{
 			IsTemplate:          true,
 			URLTemplate:         "https://${HOST}/mcp/${API_VERSION}/projects/${PROJECT_ID}",
@@ -733,7 +725,7 @@ func TestApplyRemoteURLTemplate(t *testing.T) {
 	require.Equal(t, "https://remote.example.com/mcp/v1/projects/project-123", manifest.RemoteConfig.URL)
 	require.True(t, manifest.RemoteConfig.StaticOAuthRequired)
 
-	server := v1.MCPServer{ObjectMeta: metav1.ObjectMeta{Name: "tool-preview"}, Spec: v1.MCPServerSpec{Manifest: manifest}}
+	server := v1.MCPServer{Name: "tool-preview", Spec: v1.MCPServerSpec{Manifest: manifest}}
 	serverConfig, missing, err := mcp.ServerToServerConfig(server, nil, "system", "temp", "default", nil, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, missing)
@@ -743,7 +735,7 @@ func TestApplyRemoteURLTemplate(t *testing.T) {
 func TestApplyURLTemplateStaticValuesOverrideSubmittedConfiguration(t *testing.T) {
 	result, err := applyURLTemplate(
 		"https://${HOST}/${VERSION}",
-		[]types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "HOST", Value: "catalog.example.com"}}},
+		[]types.MCPEnv{{Key: "HOST", Value: "catalog.example.com"}},
 		[]types.MCPHeader{{Key: "VERSION", Value: "v1"}},
 		map[string]string{
 			"HOST":    "forged.example.com",
@@ -936,7 +928,7 @@ func TestApplyURLTemplateRealWorldExamples(t *testing.T) {
 func TestSanitizeConfig(t *testing.T) {
 	manifest := types.MCPServerManifest{
 		Env: []types.MCPEnv{
-			{MCPHeader: types.MCPHeader{Key: "ENV_BOUND", SecretBinding: &types.MCPSecretBinding{Name: "secret", Key: "env"}}},
+			{Key: "ENV_BOUND", SecretBinding: &types.MCPSecretBinding{Name: "secret", Key: "env"}},
 		},
 		RemoteConfig: &types.RemoteRuntimeConfig{
 			Headers: []types.MCPHeader{
@@ -961,10 +953,9 @@ func TestMarkAdminAddedSecretBindingsDerivesOwnershipFromCurrentCatalog(t *testi
 	catalogBinding := &types.MCPSecretBinding{Name: "catalog-secret", Key: "token"}
 	existing := types.MCPServerManifest{
 		Runtime: types.RuntimeRemote,
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:           "API_TOKEN",
-			SecretBinding: catalogBinding,
-		}}},
+			SecretBinding: catalogBinding}},
 		RemoteConfig: &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{
 			Key:           "Authorization",
 			SecretBinding: catalogBinding,
@@ -973,7 +964,7 @@ func TestMarkAdminAddedSecretBindingsDerivesOwnershipFromCurrentCatalog(t *testi
 	updated := existing
 	source := &types.MCPServerCatalogEntryManifest{
 		Runtime:        types.RuntimeRemote,
-		Env:            []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_TOKEN"}}},
+		Env:            []types.MCPEnv{{Key: "API_TOKEN"}},
 		RemoteConfig:   &types.RemoteCatalogConfig{Headers: []types.MCPHeader{{Key: "Authorization"}}},
 		ServerUserType: types.ServerUserTypeMultiUser,
 	}
@@ -991,8 +982,8 @@ func TestMarkAdminAddedSecretBindingsRecordsOnlyAdminOwnedBindings(t *testing.T)
 	manifest := types.MCPServerManifest{
 		Runtime: types.RuntimeRemote,
 		Env: []types.MCPEnv{
-			{MCPHeader: types.MCPHeader{Key: "PINNED_ENV", SecretBinding: sourceBinding}},
-			{MCPHeader: types.MCPHeader{Key: "ADMIN_ENV", SecretBinding: adminBinding}},
+			{Key: "PINNED_ENV", SecretBinding: sourceBinding},
+			{Key: "ADMIN_ENV", SecretBinding: adminBinding},
 		},
 		RemoteConfig: &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{
 			{Key: "Pinned-Header", SecretBinding: sourceBinding},
@@ -1002,7 +993,7 @@ func TestMarkAdminAddedSecretBindingsRecordsOnlyAdminOwnedBindings(t *testing.T)
 	source := &types.MCPServerCatalogEntryManifest{
 		Runtime: types.RuntimeRemote,
 		Env: []types.MCPEnv{
-			{MCPHeader: types.MCPHeader{Key: "PINNED_ENV", SecretBinding: sourceBinding}},
+			{Key: "PINNED_ENV", SecretBinding: sourceBinding},
 		},
 		RemoteConfig: &types.RemoteCatalogConfig{Headers: []types.MCPHeader{
 			{Key: "Pinned-Header", SecretBinding: sourceBinding},
@@ -1021,17 +1012,15 @@ func TestMarkAdminAddedSecretBindingsRecordsOnlyAdminOwnedBindings(t *testing.T)
 func TestMarkAdminAddedSecretBindingsClearsClientSuppliedMetadata(t *testing.T) {
 	manifest := types.MCPServerManifest{
 		Runtime: types.RuntimeRemote,
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:           "PINNED_ENV",
-			SecretBinding: &types.MCPSecretBinding{Name: "source-secret", Key: "token", AdminAdded: true},
-		}}},
+			SecretBinding: &types.MCPSecretBinding{Name: "source-secret", Key: "token", AdminAdded: true}}},
 	}
 	source := &types.MCPServerCatalogEntryManifest{
 		Runtime: types.RuntimeRemote,
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:           "PINNED_ENV",
-			SecretBinding: &types.MCPSecretBinding{Name: "source-secret", Key: "token"},
-		}}},
+			SecretBinding: &types.MCPSecretBinding{Name: "source-secret", Key: "token"}}},
 	}
 
 	markAdminAddedSecretBindings(&manifest, source)
@@ -1052,14 +1041,13 @@ func TestServerFromMultiUserTemplateMarksAdminAddedSecretBinding(t *testing.T) {
 			Port:  8080,
 			Path:  "/mcp",
 		},
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "GREETING", Name: "GREETING"}}},
+		Env: []types.MCPEnv{{Key: "GREETING", Name: "GREETING"}},
 	}
 	// Admin selects a secret binding for GREETING at deploy time; the template has none.
 	input := types.MCPServerManifest{
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:           "GREETING",
-			SecretBinding: &types.MCPSecretBinding{Name: "test-secret-11", Key: "key1"},
-		}}},
+			SecretBinding: &types.MCPSecretBinding{Name: "test-secret-11", Key: "key1"}}},
 	}
 
 	manifest, err := serverManifestFromCatalogEntryManifest(false, false, entry, input)
@@ -1077,10 +1065,9 @@ func TestRejectCatalogSecretBindingOverrides(t *testing.T) {
 	sourceBinding := &types.MCPSecretBinding{Name: "source-secret", Key: "token"}
 	source := &types.MCPServerCatalogEntryManifest{
 		Runtime: types.RuntimeRemote,
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:           "PINNED_ENV",
-			SecretBinding: sourceBinding,
-		}}},
+			SecretBinding: sourceBinding}},
 		RemoteConfig: &types.RemoteCatalogConfig{Headers: []types.MCPHeader{{
 			Key:           "Pinned-Header",
 			SecretBinding: sourceBinding,
@@ -1090,10 +1077,9 @@ func TestRejectCatalogSecretBindingOverrides(t *testing.T) {
 	t.Run("allows matching catalog binding", func(t *testing.T) {
 		manifest := types.MCPServerManifest{
 			Runtime: types.RuntimeRemote,
-			Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+			Env: []types.MCPEnv{{
 				Key:           "PINNED_ENV",
-				SecretBinding: &types.MCPSecretBinding{Name: "source-secret", Key: "token", AdminAdded: true},
-			}}},
+				SecretBinding: &types.MCPSecretBinding{Name: "source-secret", Key: "token", AdminAdded: true}}},
 			RemoteConfig: &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{
 				Key:           "Pinned-Header",
 				SecretBinding: &types.MCPSecretBinding{Name: "source-secret", Key: "token"},
@@ -1106,10 +1092,9 @@ func TestRejectCatalogSecretBindingOverrides(t *testing.T) {
 	t.Run("rejects env override", func(t *testing.T) {
 		manifest := types.MCPServerManifest{
 			Runtime: types.RuntimeRemote,
-			Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+			Env: []types.MCPEnv{{
 				Key:           "PINNED_ENV",
-				SecretBinding: &types.MCPSecretBinding{Name: "admin-secret", Key: "token"},
-			}}},
+				SecretBinding: &types.MCPSecretBinding{Name: "admin-secret", Key: "token"}}},
 		}
 
 		err := rejectCatalogSecretBindingOverrides(manifest, source, true)
@@ -1121,9 +1106,8 @@ func TestRejectCatalogSecretBindingOverrides(t *testing.T) {
 	t.Run("rejects env binding clear", func(t *testing.T) {
 		manifest := types.MCPServerManifest{
 			Runtime: types.RuntimeRemote,
-			Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-				Key: "PINNED_ENV",
-			}}},
+			Env: []types.MCPEnv{{
+				Key: "PINNED_ENV"}},
 		}
 
 		err := rejectCatalogSecretBindingOverrides(manifest, source, true)
@@ -1150,10 +1134,9 @@ func TestRejectCatalogSecretBindingOverrides(t *testing.T) {
 	t.Run("rejects header override", func(t *testing.T) {
 		manifest := types.MCPServerManifest{
 			Runtime: types.RuntimeRemote,
-			Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+			Env: []types.MCPEnv{{
 				Key:           "PINNED_ENV",
-				SecretBinding: sourceBinding,
-			}}},
+				SecretBinding: sourceBinding}},
 			RemoteConfig: &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{
 				Key:           "Pinned-Header",
 				SecretBinding: &types.MCPSecretBinding{Name: "admin-secret", Key: "token"},
@@ -1172,7 +1155,7 @@ func TestApplySecretBindingOverlayOnlyMatchesExistingFields(t *testing.T) {
 	manifest := types.MCPServerManifest{
 		Runtime: types.RuntimeRemote,
 		Env: []types.MCPEnv{
-			{MCPHeader: types.MCPHeader{Key: "API_TOKEN", Value: "manual"}},
+			{Key: "API_TOKEN", Value: "manual"},
 		},
 		RemoteConfig: &types.RemoteRuntimeConfig{
 			URL: "https://example.com/mcp",
@@ -1183,8 +1166,8 @@ func TestApplySecretBindingOverlayOnlyMatchesExistingFields(t *testing.T) {
 	}
 	overlay := types.MCPServerManifest{
 		Env: []types.MCPEnv{
-			{MCPHeader: types.MCPHeader{Key: "API_TOKEN", SecretBinding: binding}},
-			{MCPHeader: types.MCPHeader{Key: "IGNORED", SecretBinding: binding}},
+			{Key: "API_TOKEN", SecretBinding: binding},
+			{Key: "IGNORED", SecretBinding: binding},
 		},
 		RemoteConfig: &types.RemoteRuntimeConfig{
 			Headers: []types.MCPHeader{
@@ -1207,14 +1190,12 @@ func TestApplySecretBindingOverlayOnlyMatchesExistingFields(t *testing.T) {
 
 func TestCreateServerWorkspaceSecretBindingRejected(t *testing.T) {
 	handler := newCreateServerSecretBindingTestHandler()
-	storage := newFakeStorage(t, &v1.PowerUserWorkspace{ObjectMeta: metav1.ObjectMeta{Name: "workspace-1", Namespace: system.DefaultNamespace}})
+	storage := newFakeStorage(t, &v1.PowerUserWorkspace{Name: "workspace-1", Namespace: system.DefaultNamespace})
 	localK8sClient := newCreateServerSecretBindingK8sClient(t, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "source-secret",
-			Namespace: system.DefaultNamespace,
-			Labels:    map[string]string{testSecretBindingAllowedLabel: "true"},
-		},
-		Data: map[string][]byte{"token": []byte("secret-token")},
+		Name:      "source-secret",
+		Namespace: system.DefaultNamespace,
+		Labels:    map[string]string{testSecretBindingAllowedLabel: "true"},
+		Data:      map[string][]byte{"token": []byte("secret-token")},
 	})
 
 	err := handler.CreateServer(newCreateServerSecretBindingRequest(t, storage, localK8sClient, "", "workspace-1", types.MCPServer{
@@ -1228,7 +1209,7 @@ func TestCreateServerWorkspaceSecretBindingRejected(t *testing.T) {
 func TestCreateServerRejectsMissingSecretBinding(t *testing.T) {
 	handler := newCreateServerSecretBindingTestHandler()
 	entry := v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{Name: "entry-1", Namespace: system.DefaultNamespace},
+		Name: "entry-1", Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerCatalogEntrySpec{
 			MCPCatalogName: "catalog-1",
 			Manifest: types.MCPServerCatalogEntryManifest{
@@ -1240,15 +1221,14 @@ func TestCreateServerRejectsMissingSecretBinding(t *testing.T) {
 					Port:  8080,
 					Path:  "/mcp",
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_TOKEN",
-					SecretBinding: &types.MCPSecretBinding{Name: "missing-secret", Key: "token"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "missing-secret", Key: "token"}}},
 			},
 		},
 	}
 	storage := newFakeStorage(t,
-		&v1.MCPCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1", Namespace: system.DefaultNamespace}},
+		&v1.MCPCatalog{Name: "catalog-1", Namespace: system.DefaultNamespace},
 		&entry,
 	)
 
@@ -1266,7 +1246,7 @@ func TestCreateServerRejectsMissingSecretBinding(t *testing.T) {
 
 func TestCreateServerRejectsMultiUserHeaderSecretBinding(t *testing.T) {
 	handler := newCreateServerSecretBindingTestHandler()
-	storage := newFakeStorage(t, &v1.MCPCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1", Namespace: system.DefaultNamespace}})
+	storage := newFakeStorage(t, &v1.MCPCatalog{Name: "catalog-1", Namespace: system.DefaultNamespace})
 	manifest := types.MCPServerManifest{
 		Name:    "multi-user-server",
 		Runtime: types.RuntimeContainerized,
@@ -1290,7 +1270,7 @@ func TestCreateServerRejectsMultiUserHeaderSecretBinding(t *testing.T) {
 }
 
 func TestCreateCatalogEntryRejectsMultiUserHeaderSecretBinding(t *testing.T) {
-	storage := newFakeStorage(t, &v1.MCPCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1", Namespace: system.DefaultNamespace}})
+	storage := newFakeStorage(t, &v1.MCPCatalog{Name: "catalog-1", Namespace: system.DefaultNamespace})
 	manifest := types.MCPServerCatalogEntryManifest{
 		Name:           "multi-user-entry",
 		Runtime:        types.RuntimeContainerized,
@@ -1322,7 +1302,7 @@ func TestCreateCatalogEntryRejectsMultiUserHeaderSecretBinding(t *testing.T) {
 }
 
 func TestCreateCatalogEntryAllowsConfigurationOptions(t *testing.T) {
-	storage := newFakeStorage(t, &v1.MCPCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1", Namespace: system.DefaultNamespace}})
+	storage := newFakeStorage(t, &v1.MCPCatalog{Name: "catalog-1", Namespace: system.DefaultNamespace})
 	options := []types.MCPConfigurationOption{
 		{Name: "United States", Value: "us", Description: "US endpoint"},
 		{Name: "Europe", Value: "eu", Description: "EU endpoint"},
@@ -1332,9 +1312,8 @@ func TestCreateCatalogEntryAllowsConfigurationOptions(t *testing.T) {
 		Runtime:        types.RuntimeNPX,
 		ServerUserType: types.ServerUserTypeSingleUser,
 		NPXConfig:      &types.NPXRuntimeConfig{Package: "test-server"},
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-			Key: "REGION", Name: "Region", Required: true, Options: options,
-		}}},
+		Env: []types.MCPEnv{{
+			Key: "REGION", Name: "Region", Required: true, Options: options}},
 	}
 	body, err := json.Marshal(manifest)
 	require.NoError(t, err)
@@ -1373,10 +1352,8 @@ func newCreateServerSecretBindingManifest(secretName, secretKey string) types.MC
 			Path:  "/mcp",
 		},
 		Env: []types.MCPEnv{{
-			MCPHeader: types.MCPHeader{
-				Key:           "API_TOKEN",
-				SecretBinding: &types.MCPSecretBinding{Name: secretName, Key: secretKey},
-			},
+			Key:           "API_TOKEN",
+			SecretBinding: &types.MCPSecretBinding{Name: secretName, Key: secretKey},
 		}},
 	}
 }
@@ -1424,8 +1401,8 @@ func TestConvertMCPServerCompositeAggregatesOnlySecretBoundMissingConfig(t *test
 			Manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeComposite,
 				Env: []types.MCPEnv{
-					{MCPHeader: types.MCPHeader{Key: "PARENT_BOUND", Required: true, SecretBinding: &types.MCPSecretBinding{Name: "secret", Key: "parent"}}},
-					{MCPHeader: types.MCPHeader{Key: "PARENT_USER", Required: true}},
+					{Key: "PARENT_BOUND", Required: true, SecretBinding: &types.MCPSecretBinding{Name: "secret", Key: "parent"}},
+					{Key: "PARENT_USER", Required: true},
 				},
 				CompositeConfig: &types.CompositeRuntimeConfig{
 					ComponentServers: []types.ComponentServer{{CatalogEntryID: "entry-bound"}, {CatalogEntryID: "entry-user"}},
@@ -1442,8 +1419,8 @@ func TestConvertMCPServerCompositeAggregatesOnlySecretBoundMissingConfig(t *test
 		MCPServerManifest: types.MCPServerManifest{
 			Runtime: types.RuntimeRemote,
 			Env: []types.MCPEnv{
-				{MCPHeader: types.MCPHeader{Key: "BOUND_ENV", SecretBinding: &types.MCPSecretBinding{Name: "secret", Key: "env"}}},
-				{MCPHeader: types.MCPHeader{Key: "USER_ENV"}},
+				{Key: "BOUND_ENV", SecretBinding: &types.MCPSecretBinding{Name: "secret", Key: "env"}},
+				{Key: "USER_ENV"},
 			},
 			RemoteConfig: &types.RemoteRuntimeConfig{
 				Headers: []types.MCPHeader{
@@ -1457,7 +1434,7 @@ func TestConvertMCPServerCompositeAggregatesOnlySecretBoundMissingConfig(t *test
 		Configured:             false,
 		MissingRequiredEnvVars: []string{"SHARED_KEY"},
 		MCPServerManifest: types.MCPServerManifest{
-			Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "SHARED_KEY"}}},
+			Env: []types.MCPEnv{{Key: "SHARED_KEY"}},
 		},
 	})
 
@@ -1486,7 +1463,7 @@ func TestConvertMCPServerCompositeSkipsDisabledAndConfiguredComponents(t *testin
 		Configured:             false,
 		MissingRequiredEnvVars: []string{"BOUND_DISABLED"},
 		MCPServerManifest: types.MCPServerManifest{
-			Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "BOUND_DISABLED", SecretBinding: &types.MCPSecretBinding{Name: "secret", Key: "env"}}}},
+			Env: []types.MCPEnv{{Key: "BOUND_DISABLED", SecretBinding: &types.MCPSecretBinding{Name: "secret", Key: "env"}}},
 		},
 	}, types.MCPServer{
 		CatalogEntryID: "entry-configured",
@@ -1675,7 +1652,7 @@ func TestEntryMissingAdminConfig(t *testing.T) {
 		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 	}
 	secret := func(name string, data map[string][]byte) *corev1.Secret {
-		return &corev1.Secret{Data: data, ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: map[string]string{"label": ""}}}
+		return &corev1.Secret{Data: data, Name: name, Namespace: ns, Labels: map[string]string{"label": ""}}
 	}
 
 	tests := []struct {
@@ -1691,11 +1668,9 @@ func TestEntryMissingAdminConfig(t *testing.T) {
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeNPX,
 				Env: []types.MCPEnv{{
-					MCPHeader: types.MCPHeader{
-						Key:           "TOKEN",
-						Required:      true,
-						SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
-					},
+					Key:           "TOKEN",
+					Required:      true,
+					SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
 				}},
 			},
 			client: newClient(t, secret("s", map[string][]byte{"k": []byte("v")})),
@@ -1705,11 +1680,9 @@ func TestEntryMissingAdminConfig(t *testing.T) {
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeNPX,
 				Env: []types.MCPEnv{{
-					MCPHeader: types.MCPHeader{
-						Key:           "TOKEN",
-						Required:      true,
-						SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
-					},
+					Key:           "TOKEN",
+					Required:      true,
+					SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
 				}},
 			},
 			client:     newClient(t),
@@ -1720,10 +1693,8 @@ func TestEntryMissingAdminConfig(t *testing.T) {
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeNPX,
 				Env: []types.MCPEnv{{
-					MCPHeader: types.MCPHeader{
-						Key:           "TOKEN",
-						SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
-					},
+					Key:           "TOKEN",
+					SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
 				}},
 			},
 			client:     newClient(t),
@@ -1734,11 +1705,9 @@ func TestEntryMissingAdminConfig(t *testing.T) {
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeNPX,
 				Env: []types.MCPEnv{{
-					MCPHeader: types.MCPHeader{
-						Key:           "TOKEN",
-						Required:      true,
-						SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
-					},
+					Key:           "TOKEN",
+					Required:      true,
+					SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
 				}},
 			},
 			client:     newClient(t, secret("s", map[string][]byte{"k": []byte("")})),
@@ -1789,11 +1758,9 @@ func TestEntryMissingAdminConfig(t *testing.T) {
 				Manifest: types.MCPServerCatalogEntryManifest{
 					Runtime: types.RuntimeNPX,
 					Env: []types.MCPEnv{{
-						MCPHeader: types.MCPHeader{
-							Key:           "TOKEN",
-							Required:      true,
-							SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
-						},
+						Key:           "TOKEN",
+						Required:      true,
+						SecretBinding: &types.MCPSecretBinding{Name: "s", Key: "k"},
 					}},
 				},
 			}),

--- a/pkg/api/handlers/mcpcapacity.go
+++ b/pkg/api/handlers/mcpcapacity.go
@@ -24,8 +24,7 @@ func (h *MCPCapacityHandler) GetCapacity(req api.Context) error {
 	info, err := h.mcpSessionManager.GetCapacityInfo(req.Context())
 	if err != nil {
 		// If backend doesn't support capacity info (e.g., Docker), return bad request.
-		var notSupported *mcp.ErrNotSupportedByBackend
-		if errors.As(err, &notSupported) {
+		if notSupported, ok := errors.AsType[*mcp.ErrNotSupportedByBackend](err); ok {
 			return types.NewErrBadRequest("%s", notSupported.Error())
 		}
 		return err

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -351,9 +351,7 @@ func (h *MCPCatalogHandler) CreateEntry(req api.Context) error {
 	cleanName := normalizeMCPCatalogEntryName(manifest.Name)
 
 	entry := v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: req.Namespace(),
-		},
+		Namespace: req.Namespace(),
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Editable: true,
 			Manifest: manifest,
@@ -624,8 +622,7 @@ func (h *MCPCatalogHandler) GetEntryCapacity(req api.Context) error {
 
 	info, err := h.capacityInfoProvider.GetCapacityInfoForServers(req.Context(), serverNames)
 	if err != nil {
-		var notSupported *mcp.ErrNotSupportedByBackend
-		if errors.As(err, &notSupported) {
+		if notSupported, ok := errors.AsType[*mcp.ErrNotSupportedByBackend](err); ok {
 			return types.NewErrBadRequest("%s", notSupported.Error())
 		}
 		return err
@@ -1322,10 +1319,8 @@ func (h *MCPCatalogHandler) GenerateComponentToolPreviews(req api.Context) error
 	// - it may no longer exist
 	// - we already have enough information to generate composite tool overrides for the component
 	entry := v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      component.CatalogEntryID,
-			Namespace: composite.Namespace,
-		},
+		Name:      component.CatalogEntryID,
+		Namespace: composite.Namespace,
 		Spec: v1.MCPServerCatalogEntrySpec{
 			MCPCatalogName: composite.Spec.MCPCatalogName,
 			Manifest:       component.Manifest,
@@ -1553,9 +1548,7 @@ func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, cli
 	// Create temporary MCPServer object to use existing conversion logic
 	tempName := "tool-preview-" + utils.Digest(serverManifest)[:16]
 	tempMCPServer := v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: tempName,
-		},
+		Name: tempName,
 		Spec: v1.MCPServerSpec{
 			Manifest:                  serverManifest,
 			MCPServerCatalogEntryName: entryName,
@@ -1583,11 +1576,9 @@ func tempServerAndConfig(ctx context.Context, gatewayClient *gclient.Client, cli
 	}
 
 	oauthClient := v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       clientID,
-			Namespace:  namespace,
-			Finalizers: []string{v1.OAuthClientFinalizer},
-		},
+		Name:       clientID,
+		Namespace:  namespace,
+		Finalizers: []string{v1.OAuthClientFinalizer},
 		Spec: v1.OAuthClientSpec{
 			Manifest: types.OAuthClientManifest{
 				GrantTypes: []string{"urn:ietf:params:oauth:grant-type:token-exchange"},
@@ -1688,16 +1679,14 @@ func revealCatalogTokens(req api.Context, catalogName string) (map[string]string
 
 func convertMCPCatalog(catalog v1.MCPCatalog, tokenEnv map[string]string) types.MCPCatalog {
 	return types.MCPCatalog{
-		Metadata: MetadataFrom(&catalog),
-		MCPCatalogManifest: types.MCPCatalogManifest{
-			DisplayName:               catalog.Spec.DisplayName,
-			SourceURLs:                catalog.Spec.SourceURLs,
-			SourceURLCredentials:      maskCatalogCredentials(catalog.Spec.SourceURLs, tokenEnv),
-			SourceURLGitCredentialIDs: catalog.Spec.SourceURLGitCredentialIDs,
-		},
-		LastSynced: *types.NewTime(catalog.Status.LastSyncTime.Time),
-		SyncErrors: catalog.Status.SyncErrors,
-		IsSyncing:  catalog.Status.IsSyncing || catalog.Annotations[v1.MCPCatalogSyncAnnotation] == "true",
+		Metadata:                  MetadataFrom(&catalog),
+		DisplayName:               catalog.Spec.DisplayName,
+		SourceURLs:                catalog.Spec.SourceURLs,
+		SourceURLCredentials:      maskCatalogCredentials(catalog.Spec.SourceURLs, tokenEnv),
+		SourceURLGitCredentialIDs: catalog.Spec.SourceURLGitCredentialIDs,
+		LastSynced:                *types.NewTime(catalog.Status.LastSyncTime.Time),
+		SyncErrors:                catalog.Status.SyncErrors,
+		IsSyncing:                 catalog.Status.IsSyncing || catalog.Annotations[v1.MCPCatalogSyncAnnotation] == "true",
 	}
 }
 

--- a/pkg/api/handlers/mcpcatalogs_test.go
+++ b/pkg/api/handlers/mcpcatalogs_test.go
@@ -18,17 +18,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestAcceptCatalogEntryOwnership(t *testing.T) {
 	entry := &v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				"example.com/keep": "true",
-			},
+		Annotations: map[string]string{
+			"example.com/keep": "true",
 		},
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Editable:  false,
@@ -77,8 +74,8 @@ func TestMCPCatalogHandlerGetEntryCapacity(t *testing.T) {
 			entryCatalogName: "catalog-1",
 			entryRuntime:     types.RuntimeContainerized,
 			servers: []v1.MCPServer{{
-				ObjectMeta: metav1.ObjectMeta{Name: "server-1", Namespace: system.DefaultNamespace},
-				Spec:       v1.MCPServerSpec{MCPServerCatalogEntryName: "entry-1"},
+				Name: "server-1", Namespace: system.DefaultNamespace,
+				Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "entry-1"},
 			}},
 			providerInfo:    types.MCPCapacityInfo{Source: types.CapacitySourceDeployments, ActiveDeployments: 1},
 			wantServerNames: []string{"server-1"},
@@ -89,8 +86,8 @@ func TestMCPCatalogHandlerGetEntryCapacity(t *testing.T) {
 			entryCatalogName: "catalog-1",
 			entryRuntime:     types.RuntimeContainerized,
 			servers: []v1.MCPServer{
-				{ObjectMeta: metav1.ObjectMeta{Name: "template-server", Namespace: system.DefaultNamespace}, Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "entry-1", Template: true}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "server-1", Namespace: system.DefaultNamespace}, Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "entry-1"}},
+				{Name: "template-server", Namespace: system.DefaultNamespace, Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "entry-1", Template: true}},
+				{Name: "server-1", Namespace: system.DefaultNamespace, Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "entry-1"}},
 			},
 			providerInfo:    types.MCPCapacityInfo{ActiveDeployments: 1},
 			wantServerNames: []string{"server-1"},
@@ -126,9 +123,9 @@ func TestMCPCatalogHandlerGetEntryCapacity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &fakeCapacityInfoProvider{info: tt.providerInfo, err: tt.providerErr}
 			objects := []kclient.Object{
-				&v1.MCPCatalog{ObjectMeta: metav1.ObjectMeta{Name: "catalog-1", Namespace: system.DefaultNamespace}},
+				&v1.MCPCatalog{Name: "catalog-1", Namespace: system.DefaultNamespace},
 				&v1.MCPServerCatalogEntry{
-					ObjectMeta: metav1.ObjectMeta{Name: "entry-1", Namespace: system.DefaultNamespace},
+					Name: "entry-1", Namespace: system.DefaultNamespace,
 					Spec: v1.MCPServerCatalogEntrySpec{
 						MCPCatalogName: tt.entryCatalogName,
 						Manifest:       types.MCPServerCatalogEntryManifest{Runtime: tt.entryRuntime},
@@ -451,14 +448,13 @@ func TestPrepareTempServerConfigDoesNotUseBoundSecretInURL(t *testing.T) {
 		key       = "WORKSPACE"
 	)
 	localK8sClient := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "remote-secret", Namespace: namespace, Labels: map[string]string{label: "true"}},
-		Data:       map[string][]byte{"token": []byte("secret-value")},
+		Name: "remote-secret", Namespace: namespace, Labels: map[string]string{label: "true"},
+		Data: map[string][]byte{"token": []byte("secret-value")},
 	}).Build()
 	manifest := types.MCPServerManifest{
 		Runtime: types.RuntimeRemote,
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-			Key: key, Required: true,
-		}}},
+		Env: []types.MCPEnv{{
+			Key: key, Required: true}},
 		RemoteConfig: &types.RemoteRuntimeConfig{
 			IsTemplate:  true,
 			URLTemplate: "https://example.com/mcp/${WORKSPACE}",
@@ -485,10 +481,9 @@ func TestPrepareTempServerConfigDoesNotUseBoundSecretInURL(t *testing.T) {
 func TestPrepareTempServerConfigRejectsUnknownOption(t *testing.T) {
 	manifest := types.MCPServerManifest{
 		Runtime: types.RuntimeRemote,
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key: "REGION", Required: true,
-			Options: []types.MCPConfigurationOption{{Name: "US", Value: "us"}},
-		}}},
+			Options: []types.MCPConfigurationOption{{Name: "US", Value: "us"}}}},
 		RemoteConfig: &types.RemoteRuntimeConfig{URL: "https://example.com/mcp"},
 	}
 	_, err := prepareTempServerConfig(t.Context(), fake.NewClientBuilder().Build(), "obot-ns", "allowed", &manifest, map[string]string{"REGION": "forged"}, false, mcp.ValidationOptions{})
@@ -501,7 +496,7 @@ func TestPrepareTempServerConfigRejectsUnknownOption(t *testing.T) {
 
 func TestPopulateComponentManifestsHydratesMCPServerID(t *testing.T) {
 	server := &v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "shared-server", Namespace: system.DefaultNamespace},
+		Name: "shared-server", Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerSpec{
 			MCPCatalogID: "default",
 			Manifest: types.MCPServerManifest{
@@ -539,7 +534,7 @@ func TestPopulateComponentManifestsHydratesMCPServerID(t *testing.T) {
 
 func TestPopulateComponentManifestsHydratesSameCatalogEntryID(t *testing.T) {
 	entry := &v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{Name: "component-entry", Namespace: system.DefaultNamespace},
+		Name: "component-entry", Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerCatalogEntrySpec{
 			MCPCatalogName: "custom",
 			Manifest: types.MCPServerCatalogEntryManifest{

--- a/pkg/api/handlers/mcpgateway/auditlog.go
+++ b/pkg/api/handlers/mcpgateway/auditlog.go
@@ -394,10 +394,10 @@ func (h *AuditLogHandler) ListAuditLogs(req api.Context) error {
 		// Return empty if no access scope
 		if len(opts.OwnServerMCPIDs) == 0 && len(opts.PowerUserWorkspaceID) == 0 {
 			return req.Write(types.AuditLogEventResponse{
-				AuditLogEventList: types.AuditLogEventList{Items: []types.AuditLogEvent{}},
-				Total:             0,
-				Limit:             opts.Limit,
-				Offset:            opts.Offset,
+				Items:  []types.AuditLogEvent{},
+				Total:  0,
+				Limit:  opts.Limit,
+				Offset: opts.Offset,
 			})
 		}
 	}
@@ -423,9 +423,7 @@ func (h *AuditLogHandler) ListAuditLogs(req api.Context) error {
 	}
 
 	return req.Write(types.AuditLogEventResponse{
-		AuditLogEventList: types.AuditLogEventList{
-			Items: result,
-		},
+		Items:  result,
 		Total:  total,
 		Limit:  opts.Limit,
 		Offset: opts.Offset,

--- a/pkg/api/handlers/mcpgateway/auditlog_attribution_test.go
+++ b/pkg/api/handlers/mcpgateway/auditlog_attribution_test.go
@@ -47,9 +47,9 @@ func TestCollectMCPAuditEntryPersistsWhenAPIKeyAttributionFails(t *testing.T) {
 
 func TestAttributeMCPAuditLogAPIKeyFallsBackOnlyWhenKeyIsMissing(t *testing.T) {
 	gatewayClient := newLocalAgentAuditLogTestGatewayClient(t)
-	input := auditLogInput{MCPAuditLog: gatewaytypes.MCPAuditLog{MCPFields: &gatewaytypes.MCPAuditLogFields{
+	input := auditLogInput{MCPFields: &gatewaytypes.MCPAuditLogFields{
 		APIKey: auditlogs.RedactAPIKey("ok1-7-42-abcdefghijklmnopqrstuvwxyz"),
-	}}}
+	}}
 
 	if err := NewAuditLogHandler(gatewayClient).attributeMCPAuditLogAPIKey(t.Context(), &input); err != nil {
 		t.Fatal(err)
@@ -62,9 +62,9 @@ func TestAttributeMCPAuditLogAPIKeyFallsBackOnlyWhenKeyIsMissing(t *testing.T) {
 
 func TestAttributeMCPAuditLogAPIKeyReturnsTransientLookupError(t *testing.T) {
 	gatewayClient := newLocalAgentAuditLogTestGatewayClient(t)
-	input := auditLogInput{MCPAuditLog: gatewaytypes.MCPAuditLog{MCPFields: &gatewaytypes.MCPAuditLogFields{
+	input := auditLogInput{MCPFields: &gatewaytypes.MCPAuditLogFields{
 		APIKey: auditlogs.RedactAPIKey("ok1-7-42-abcdefghijklmnopqrstuvwxyz"),
-	}}}
+	}}
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 

--- a/pkg/api/handlers/mcpgateway/auditlog_test.go
+++ b/pkg/api/handlers/mcpgateway/auditlog_test.go
@@ -25,7 +25,6 @@ import (
 	sservices "github.com/obot-platform/obot/pkg/storage/services"
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -141,9 +140,9 @@ func TestAttributeMCPAuditLogAPIKeyUsesMaskedUnnamedFallback(t *testing.T) {
 		t.Fatalf("create API key: %v", err)
 	}
 
-	input := auditLogInput{MCPAuditLog: gatewaytypes.MCPAuditLog{MCPFields: &gatewaytypes.MCPAuditLogFields{
+	input := auditLogInput{MCPFields: &gatewaytypes.MCPAuditLogFields{
 		APIKey: auditlogs.RedactAPIKey(created.Key),
-	}}}
+	}}
 	if err := NewAuditLogHandler(gatewayClient).attributeMCPAuditLogAPIKey(t.Context(), &input); err != nil {
 		t.Fatal(err)
 	}
@@ -157,11 +156,10 @@ func TestAttributeMCPAuditLogAPIKeyUsesMaskedUnnamedFallback(t *testing.T) {
 func TestAttributeMCPAuditLogAPIKeyPreservesPrincipalSnapshot(t *testing.T) {
 	gatewayClient := newLocalAgentAuditLogTestGatewayClient(t)
 	id := uint(42)
-	input := auditLogInput{MCPAuditLog: gatewaytypes.MCPAuditLog{
+	input := auditLogInput{
 		APIKeyID:   &id,
 		APIKeyName: "event-time name",
-		MCPFields:  &gatewaytypes.MCPAuditLogFields{APIKey: "ok1-7-1-"},
-	}}
+		MCPFields:  &gatewaytypes.MCPAuditLogFields{APIKey: "ok1-7-1-"}}
 
 	if err := NewAuditLogHandler(gatewayClient).attributeMCPAuditLogAPIKey(t.Context(), &input); err != nil {
 		t.Fatal(err)
@@ -846,19 +844,19 @@ func newAuditLogScopeTestFixture(t *testing.T, userID string) (storage.Client, [
 	workspaceID := system.GetPowerUserWorkspaceID(userID)
 	objects := []kclient.Object{
 		&v1.MCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: "mcp-owned", Namespace: system.DefaultNamespace},
-			Spec:       v1.MCPServerSpec{UserID: userID},
+			Name: "mcp-owned", Namespace: system.DefaultNamespace,
+			Spec: v1.MCPServerSpec{UserID: userID},
 		},
 		&v1.MCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: "mcp-workspace", Namespace: system.DefaultNamespace},
+			Name: "mcp-workspace", Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerSpec{
 				UserID:               userID,
 				PowerUserWorkspaceID: workspaceID,
 			},
 		},
 		&v1.MCPServer{
-			ObjectMeta: metav1.ObjectMeta{Name: "mcp-unrelated", Namespace: system.DefaultNamespace},
-			Spec:       v1.MCPServerSpec{UserID: "another-user"},
+			Name: "mcp-unrelated", Namespace: system.DefaultNamespace,
+			Spec: v1.MCPServerSpec{UserID: "another-user"},
 		},
 	}
 	storageClient := storage.Client(fake.NewClientBuilder().

--- a/pkg/api/handlers/mcpgateway/client_session.go
+++ b/pkg/api/handlers/mcpgateway/client_session.go
@@ -38,10 +38,8 @@ func saveMCPClientSession(ctx context.Context, client kclient.Client, entry *aud
 			return nil
 		}
 		session = v1.MCPClientSession{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: key.Namespace,
-				Name:      key.Name,
-			},
+			Namespace: key.Namespace,
+			Name:      key.Name,
 			Spec: v1.MCPClientSessionSpec{
 				MCPServerID:   entry.Metadata["mcpID"],
 				UserID:        entry.Metadata["userID"],

--- a/pkg/api/handlers/mcpgateway/hook_correlation.go
+++ b/pkg/api/handlers/mcpgateway/hook_correlation.go
@@ -53,7 +53,7 @@ func (s *hookCorrelationStore) save(ctx context.Context, sessionID, requestID st
 			Reasons: slices.Clone(mutation.Reasons),
 		}
 	}
-	correlation := &v1.MCPHookCorrelation{ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name}, Spec: spec}
+	correlation := &v1.MCPHookCorrelation{Namespace: key.Namespace, Name: key.Name, Spec: spec}
 	if err := s.client.Create(ctx, correlation); err == nil {
 		return nil
 	} else if !apierrors.IsAlreadyExists(err) {
@@ -106,7 +106,7 @@ func (s *hookCorrelationStore) delete(ctx context.Context, sessionID, requestID 
 	if s == nil || sessionID == "" || requestID == "" {
 		return
 	}
-	correlation := &v1.MCPHookCorrelation{ObjectMeta: metav1.ObjectMeta{Namespace: system.DefaultNamespace, Name: s.key(sessionID, requestID, origin).Name}}
+	correlation := &v1.MCPHookCorrelation{Namespace: system.DefaultNamespace, Name: s.key(sessionID, requestID, origin).Name}
 	_ = s.client.Delete(ctx, correlation)
 }
 

--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -19,7 +19,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/utils"
 	"gorm.io/gorm"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ErrorCode defines the set of OAuth 2.0 error codes as per RFC 6749.
@@ -199,10 +198,8 @@ func (h *handler) authorize(req api.Context) error {
 	}
 
 	oauthAppAuthRequest := v1.OAuthAuthRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.OAuthAuthRequestPrefix,
-			Namespace:    oauthClient.Namespace,
-		},
+		GenerateName: system.OAuthAuthRequestPrefix,
+		Namespace:    oauthClient.Namespace,
 		Spec: v1.OAuthAuthRequestSpec{
 			Scope:               scope,
 			Resource:            resource,

--- a/pkg/api/handlers/mcpgateway/oauth/client.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client.go
@@ -27,10 +27,8 @@ func (h *handler) register(req api.Context) error {
 	clientID := system.OAuthClientPrefix + strings.ToLower(rand.Text())
 
 	oauthClient := v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clientID,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      clientID,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.OAuthClientSpec{
 			Manifest: oauthClientManifest,
 		},
@@ -116,11 +114,9 @@ func (h *handler) deleteClient(req api.Context) error {
 
 	slog.Info("Deleting dynamic OAuth client registration", "clientNamespace", namespace, "clientName", name)
 	return req.Delete(&v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  namespace,
-			Finalizers: []string{v1.OAuthClientFinalizer},
-		},
+		Name:       name,
+		Namespace:  namespace,
+		Finalizers: []string{v1.OAuthClientFinalizer},
 	})
 }
 

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
@@ -17,7 +17,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -211,10 +210,8 @@ func (h *handler) oauthClientFromMetadataDocument(clientID string, doc clientIDM
 	}
 
 	client := v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: system.DefaultNamespace,
-			Name:      clientID,
-		},
+		Namespace: system.DefaultNamespace,
+		Name:      clientID,
 		Spec: v1.OAuthClientSpec{
 			Manifest: doc.OAuthClientManifest,
 		},

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api/handlers"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -242,11 +241,9 @@ func TestClientIDNativeExceptionsDefaultToNative(t *testing.T) {
 			t.Parallel()
 
 			client, err := h.oauthClientFromMetadataDocument(clientID, clientIDMetadataDocument{
-				OAuthClientManifest: types.OAuthClientManifest{
-					ClientName:   "Example Client",
-					RedirectURIs: []string{"http://127.0.0.1/callback"},
-				},
-				ClientID: clientID,
+				ClientName:   "Example Client",
+				RedirectURIs: []string{"http://127.0.0.1/callback"},
+				ClientID:     clientID,
 			})
 			if err != nil {
 				t.Fatalf("resolve metadata: %v", err)
@@ -319,7 +316,7 @@ func TestCacheClientMetadataEvictsOldestEntryAtLimit(t *testing.T) {
 
 	const oldestClientID = "https://client.example/client-0.json"
 	const newClientID = "https://client.example/new-client.json"
-	h.cacheClientMetadata(newClientID, v1.OAuthClient{ObjectMeta: metav1.ObjectMeta{Name: newClientID}}, now.Add(time.Hour))
+	h.cacheClientMetadata(newClientID, v1.OAuthClient{Name: newClientID}, now.Add(time.Hour))
 
 	if len(h.clientMetadataCache) != clientMetadataCacheMaxEntries {
 		t.Fatalf("expected cache size %d, got %d", clientMetadataCacheMaxEntries, len(h.clientMetadataCache))

--- a/pkg/api/handlers/mcpgateway/oauth/obot_client_metadata.go
+++ b/pkg/api/handlers/mcpgateway/oauth/obot_client_metadata.go
@@ -1,22 +1,19 @@
 package oauth
 
 import (
-	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/system"
 )
 
 func (h *handler) obotClientIDMetadata(req api.Context) error {
 	return req.Write(clientIDMetadataDocument{
-		ClientID: system.OAuthClientIDMetadataURL(h.baseURL),
-		OAuthClientManifest: types.OAuthClientManifest{
-			RedirectURIs:            []string{system.MCPOAuthCallbackURL(h.baseURL)},
-			TokenEndpointAuthMethod: "none",
-			GrantTypes:              []string{"authorization_code", "refresh_token"},
-			ResponseTypes:           []string{"code"},
-			ClientName:              "Obot MCP Gateway",
-			ClientURI:               h.baseURL,
-			SoftwareID:              "obot",
-		},
+		ClientID:                system.OAuthClientIDMetadataURL(h.baseURL),
+		RedirectURIs:            []string{system.MCPOAuthCallbackURL(h.baseURL)},
+		TokenEndpointAuthMethod: "none",
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		ClientName:              "Obot MCP Gateway",
+		ClientURI:               h.baseURL,
+		SoftwareID:              "obot",
 	})
 }

--- a/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/private_key_jwt_test.go
@@ -21,7 +21,6 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
 	"golang.org/x/crypto/bcrypt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -57,7 +56,7 @@ func TestValidatePrivateKeyJWT(t *testing.T) {
 		},
 	}
 	client := v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{Name: clientID},
+		Name: clientID,
 		Spec: v1.OAuthClientSpec{
 			Manifest: types.OAuthClientManifest{
 				RedirectURIs:            []string{"http://127.0.0.1/callback"},
@@ -127,10 +126,8 @@ func TestTokenExtractsClientIDFromClientAssertion(t *testing.T) {
 	const clientName = "test-client"
 	clientID := system.DefaultNamespace + ":" + clientName
 	storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: system.DefaultNamespace,
-			Name:      clientName,
-		},
+		Namespace: system.DefaultNamespace,
+		Name:      clientName,
 		Spec: v1.OAuthClientSpec{
 			Manifest: types.OAuthClientManifest{
 				RedirectURIs:            []string{"http://127.0.0.1/callback"},
@@ -223,10 +220,8 @@ func TestTokenInvalidClientErrors(t *testing.T) {
 		}
 		const clientName = "test-client"
 		storage := clientfake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.OAuthClient{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.DefaultNamespace,
-				Name:      clientName,
-			},
+			Namespace: system.DefaultNamespace,
+			Name:      clientName,
 			Spec: v1.OAuthClientSpec{
 				ClientSecretHash: secretHash,
 				Manifest: types.OAuthClientManifest{

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -27,7 +27,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -220,10 +219,8 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 	refreshToken := strings.ToLower(rand.Text() + rand.Text())
 
 	oauthToken := v1.OAuthToken{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: oauthClient.Namespace,
-			Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken))),
-		},
+		Namespace: oauthClient.Namespace,
+		Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken))),
 		Spec: v1.OAuthTokenSpec{
 			ClientID:              oauthClient.Name,
 			Resource:              oauthAuthRequest.Spec.Resource,
@@ -323,10 +320,8 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 	refreshToken = strings.ToLower(rand.Text() + rand.Text())
 
 	oauthToken = v1.OAuthToken{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: oauthClient.Namespace,
-			Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken))),
-		},
+		Namespace: oauthClient.Namespace,
+		Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken))),
 		Spec: v1.OAuthTokenSpec{
 			Scope:                 oauthToken.Spec.Scope,
 			Resource:              oauthToken.Spec.Resource,

--- a/pkg/api/handlers/mcpgateway/oauth/token_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -56,10 +55,8 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 	storage := clientfake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
 		WithObjects(&v1.SystemMCPServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.DefaultNamespace,
-				Name:      mcpID,
-			},
+			Namespace: system.DefaultNamespace,
+			Name:      mcpID,
 		}).
 		Build()
 
@@ -91,10 +88,8 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 
 	tokenName := fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken)))
 	storageToken := &v1.OAuthToken{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: system.DefaultNamespace,
-			Name:      tokenName,
-		},
+		Namespace: system.DefaultNamespace,
+		Name:      tokenName,
 		Spec: v1.OAuthTokenSpec{
 			ClientID: clientName,
 			Resource: baseURL,
@@ -115,10 +110,8 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 		GatewayClient:  gatewayClient,
 	}
 	oauthClient := v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: system.DefaultNamespace,
-			Name:      clientName,
-		},
+		Namespace: system.DefaultNamespace,
+		Name:      clientName,
 	}
 	h := &handler{tokenService: tokenService}
 	err = h.doRefreshToken(req, oauthClient, refreshToken)
@@ -151,10 +144,8 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 
 	staleRefreshToken := "deleted-server-refresh-token"
 	require.NoError(t, storage.Create(t.Context(), &v1.OAuthToken{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: system.DefaultNamespace,
-			Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(staleRefreshToken))),
-		},
+		Namespace: system.DefaultNamespace,
+		Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(staleRefreshToken))),
 		Spec: v1.OAuthTokenSpec{
 			ClientID: clientName,
 			Resource: baseURL,
@@ -182,10 +173,8 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 
 	racedRefreshToken := "concurrently-consumed-refresh-token"
 	require.NoError(t, storage.Create(t.Context(), &v1.OAuthToken{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: system.DefaultNamespace,
-			Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(racedRefreshToken))),
-		},
+		Namespace: system.DefaultNamespace,
+		Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(racedRefreshToken))),
 		Spec: v1.OAuthTokenSpec{
 			ClientID: clientName,
 			Resource: baseURL,

--- a/pkg/api/handlers/mcpsecretbindings_test.go
+++ b/pkg/api/handlers/mcpsecretbindings_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const testSecretBindingAllowedLabel = "test-secret-binding-label"
@@ -22,25 +21,19 @@ func TestListAllowedSecrets(t *testing.T) {
 	handler := NewMCPSecretBindingHandler(
 		mcp.RuntimeBackendKubernetes,
 		newCreateServerSecretBindingK8sClient(t, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "source-secret",
-				Namespace: system.DefaultNamespace,
-				Labels:    map[string]string{testSecretBindingAllowedLabel: "true"},
-			},
-			Data: map[string][]byte{"token": []byte("secret-token")},
+			Name:      "source-secret",
+			Namespace: system.DefaultNamespace,
+			Labels:    map[string]string{testSecretBindingAllowedLabel: "true"},
+			Data:      map[string][]byte{"token": []byte("secret-token")},
 		}, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "unlabeled-secret",
-				Namespace: system.DefaultNamespace,
-			},
-			Data: map[string][]byte{"token": []byte("secret-token")},
+			Name:      "unlabeled-secret",
+			Namespace: system.DefaultNamespace,
+			Data:      map[string][]byte{"token": []byte("secret-token")},
 		}, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "wrong-label-secret",
-				Namespace: system.DefaultNamespace,
-				Labels:    map[string]string{"custom-secret-binding-label": "true"},
-			},
-			Data: map[string][]byte{"token": []byte("secret-token")},
+			Name:      "wrong-label-secret",
+			Namespace: system.DefaultNamespace,
+			Labels:    map[string]string{"custom-secret-binding-label": "true"},
+			Data:      map[string][]byte{"token": []byte("secret-token")},
 		}),
 		system.DefaultNamespace,
 		testSecretBindingAllowedLabel,
@@ -65,12 +58,10 @@ func TestListAllowedSecretsReturnsEmptyForNonKubernetesBackend(t *testing.T) {
 	handler := NewMCPSecretBindingHandler(
 		"docker",
 		newCreateServerSecretBindingK8sClient(t, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "source-secret",
-				Namespace: system.DefaultNamespace,
-				Labels:    map[string]string{testSecretBindingAllowedLabel: "true"},
-			},
-			Data: map[string][]byte{"token": []byte("secret-token")},
+			Name:      "source-secret",
+			Namespace: system.DefaultNamespace,
+			Labels:    map[string]string{testSecretBindingAllowedLabel: "true"},
+			Data:      map[string][]byte{"token": []byte("secret-token")},
 		}),
 		system.DefaultNamespace,
 		testSecretBindingAllowedLabel,

--- a/pkg/api/handlers/mcptunnel.go
+++ b/pkg/api/handlers/mcptunnel.go
@@ -10,7 +10,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	tunnelpkg "github.com/obot-platform/obot/pkg/tunnel"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -73,10 +72,8 @@ func (*MCPTunnelHandler) Create(req api.Context) error {
 	}
 
 	tunnel := v1.MCPTunnel{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.MCPTunnelPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.MCPTunnelPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.MCPTunnelSpec{
 			Manifest:     manifest,
 			Credential:   credential,

--- a/pkg/api/handlers/mcptunnel_test.go
+++ b/pkg/api/handlers/mcptunnel_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	tunnelpkg "github.com/obot-platform/obot/pkg/tunnel"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -215,10 +214,8 @@ func TestMCPTunnelHandlerLifecycle(t *testing.T) {
 func TestMCPTunnelHandlerDeleteDoesNotDisconnectOnFailure(t *testing.T) {
 	const tunnelName = "mt1office"
 	baseStorage := newMCPTunnelTestStorage(&v1.MCPTunnel{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      tunnelName,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      tunnelName,
+		Namespace: system.DefaultNamespace,
 	})
 	storage := &failingMCPTunnelDeleteStorage{WithWatch: baseStorage.WithWatch}
 	closer := &mcpTunnelTestCloser{}
@@ -251,10 +248,8 @@ func TestMCPTunnelHandlerUpdatePreservesCatalogEntryTargets(t *testing.T) {
 	}
 	storage := newMCPTunnelTestStorage(
 		&v1.MCPTunnel{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      tunnelName,
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      tunnelName,
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPTunnelSpec{
 				Manifest: types.MCPTunnelManifest{
 					DisplayName: "Office",
@@ -268,10 +263,8 @@ func TestMCPTunnelHandlerUpdatePreservesCatalogEntryTargets(t *testing.T) {
 			},
 		},
 		&v1.MCPServerCatalogEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mcp1z-accounting",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "mcp1z-accounting",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerCatalogEntrySpec{
 				Manifest: types.MCPServerCatalogEntryManifest{
 					Name:    "Accounting MCP",
@@ -284,10 +277,8 @@ func TestMCPTunnelHandlerUpdatePreservesCatalogEntryTargets(t *testing.T) {
 			},
 		},
 		&v1.MCPServerCatalogEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mcp1a-composite",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "mcp1a-composite",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerCatalogEntrySpec{
 				Manifest: types.MCPServerCatalogEntryManifest{
 					Name:    "Operations Composite",
@@ -355,16 +346,12 @@ func TestMCPTunnelHandlerDeleteBlockedByCatalogEntries(t *testing.T) {
 	const tunnelName = "mt1office"
 	storage := newMCPTunnelTestStorage(
 		&v1.MCPTunnel{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      tunnelName,
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      tunnelName,
+			Namespace: system.DefaultNamespace,
 		},
 		&v1.MCPServerCatalogEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mcp1z-accounting",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "mcp1z-accounting",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerCatalogEntrySpec{
 				Manifest: types.MCPServerCatalogEntryManifest{
 					Name:    "Accounting MCP",
@@ -377,10 +364,8 @@ func TestMCPTunnelHandlerDeleteBlockedByCatalogEntries(t *testing.T) {
 			},
 		},
 		&v1.MCPServerCatalogEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mcp1a-composite",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "mcp1a-composite",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerCatalogEntrySpec{
 				Manifest: types.MCPServerCatalogEntryManifest{
 					Name:    "Operations Composite",
@@ -400,10 +385,8 @@ func TestMCPTunnelHandlerDeleteBlockedByCatalogEntries(t *testing.T) {
 			},
 		},
 		&v1.MCPServerCatalogEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mcp1unrelated",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "mcp1unrelated",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerCatalogEntrySpec{
 				Manifest: types.MCPServerCatalogEntryManifest{
 					Name:    "Unrelated MCP",

--- a/pkg/api/handlers/mcpwebhookvalidation.go
+++ b/pkg/api/handlers/mcpwebhookvalidation.go
@@ -87,10 +87,8 @@ func (m *MCPWebhookValidationHandler) Create(req api.Context) error {
 	}
 
 	webhookValidation := v1.MCPWebhookValidation{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.MCPWebhookValidationPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.MCPWebhookValidationPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.MCPWebhookValidationSpec{
 			Manifest: manifest,
 		},
@@ -298,10 +296,8 @@ func getCredentialsForWebhookValidation(ctx context.Context, gatewayClient *gate
 
 func (m *MCPWebhookValidationHandler) getSystemServerForWebhookValidation(req api.Context) (v1.SystemMCPServer, error) {
 	systemServer := &v1.SystemMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: req.Namespace(),
-			Name:      system.SystemMCPServerPrefix + req.PathValue("mcp_webhook_validation_id"),
-		},
+		Namespace: req.Namespace(),
+		Name:      system.SystemMCPServerPrefix + req.PathValue("mcp_webhook_validation_id"),
 	}
 
 	systemServer, err := wait.For(req.Context(), req.Storage, systemServer, func(s *v1.SystemMCPServer) (bool, error) {

--- a/pkg/api/handlers/mcpwebhookvalidation_test.go
+++ b/pkg/api/handlers/mcpwebhookvalidation_test.go
@@ -124,8 +124,8 @@ func TestApplyRemoteURLTemplateToWebhookValidation(t *testing.T) {
 					Name:    "validator",
 					Runtime: types.RuntimeRemote,
 					Env: []types.MCPEnv{
-						{MCPHeader: types.MCPHeader{Key: "HOST", Required: true}},
-						{MCPHeader: types.MCPHeader{Key: "SPACE", Required: true}},
+						{Key: "HOST", Required: true},
+						{Key: "SPACE", Required: true},
 					},
 					RemoteConfig: &types.RemoteRuntimeConfig{
 						IsTemplate:  true,
@@ -154,10 +154,9 @@ func TestApplyRemoteURLTemplateToWebhookValidationRejectsUnknownOption(t *testin
 	validation := &v1.MCPWebhookValidation{Spec: v1.MCPWebhookValidationSpec{Manifest: types.MCPWebhookValidationManifest{
 		SystemMCPServerManifest: &types.SystemMCPServerManifest{
 			Runtime: types.RuntimeRemote,
-			Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+			Env: []types.MCPEnv{{
 				Key: "REGION", Required: true,
-				Options: []types.MCPConfigurationOption{{Name: "US", Value: "us"}},
-			}}},
+				Options: []types.MCPConfigurationOption{{Name: "US", Value: "us"}}}},
 			RemoteConfig: &types.RemoteRuntimeConfig{IsTemplate: true, URLTemplate: "https://${REGION}.example.com/mcp"},
 		},
 	}}}

--- a/pkg/api/handlers/mdmassets.go
+++ b/pkg/api/handlers/mdmassets.go
@@ -69,10 +69,8 @@ func getMDMAssetSource(req api.Context) (*v1.MDMAssetSource, error) {
 
 func convertMDMAssetSource(source v1.MDMAssetSource) types.MDMAssetSource {
 	return types.MDMAssetSource{
-		Metadata: MetadataFrom(&source),
-		MDMAssetSourceManifest: types.MDMAssetSourceManifest{
-			Source: mdmassets.RedactSource(source.Spec.Source),
-		},
+		Metadata:     MetadataFrom(&source),
+		Source:       mdmassets.RedactSource(source.Spec.Source),
 		LastSyncTime: *types.NewTime(source.Status.LastSyncTime.Time),
 		IsSyncing:    source.Annotations[v1.MDMAssetSourceSyncAnnotation] == "true",
 		SyncError:    source.Status.SyncError,
@@ -82,14 +80,12 @@ func convertMDMAssetSource(source v1.MDMAssetSource) types.MDMAssetSource {
 
 func convertMDMAsset(asset v1.MDMAsset) types.MDMAsset {
 	return types.MDMAsset{
-		Metadata: MetadataFrom(&asset),
-		Digest:   asset.Spec.Digest,
-		MDMAssetManifest: types.MDMAssetManifest{
-			SchemaVersion:     asset.Spec.SchemaVersion,
-			ObotSentryVersion: asset.Spec.ObotSentryVersion,
-			Fields:            asset.Spec.Fields.Raw,
-			Platforms:         asset.Spec.Platforms,
-			Configurations:    asset.Spec.Configurations,
-		},
+		Metadata:          MetadataFrom(&asset),
+		Digest:            asset.Spec.Digest,
+		SchemaVersion:     asset.Spec.SchemaVersion,
+		ObotSentryVersion: asset.Spec.ObotSentryVersion,
+		Fields:            asset.Spec.Fields.Raw,
+		Platforms:         asset.Spec.Platforms,
+		Configurations:    asset.Spec.Configurations,
 	}
 }

--- a/pkg/api/handlers/mdmassets_test.go
+++ b/pkg/api/handlers/mdmassets_test.go
@@ -22,12 +22,10 @@ import (
 func TestMDMAssetSourceHandlerGetRedactsSourceAndReportsPendingRefresh(t *testing.T) {
 	lastSyncTime := metav1.NewTime(time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC))
 	storage := newFakeStorage(t, &v1.MDMAssetSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.DefaultMDMAssetSource,
-			Namespace: system.DefaultNamespace,
-			Annotations: map[string]string{
-				v1.MDMAssetSourceSyncAnnotation: "true",
-			},
+		Name:      system.DefaultMDMAssetSource,
+		Namespace: system.DefaultNamespace,
+		Annotations: map[string]string{
+			v1.MDMAssetSourceSyncAnnotation: "true",
 		},
 		Spec: v1.MDMAssetSourceSpec{
 			MDMAssetSourceManifest: apitypes.MDMAssetSourceManifest{
@@ -64,10 +62,8 @@ func TestMDMAssetSourceHandlerGetRedactsSourceAndReportsPendingRefresh(t *testin
 func TestMDMAssetSourceHandlerRefreshOnlyRequestsReconciliation(t *testing.T) {
 	const configuredSource = "/etc/obot/mdm-assets.tar.gz"
 	storage := newFakeStorage(t, &v1.MDMAssetSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.DefaultMDMAssetSource,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      system.DefaultMDMAssetSource,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MDMAssetSourceSpec{
 			MDMAssetSourceManifest: apitypes.MDMAssetSourceManifest{Source: configuredSource},
 		},
@@ -119,10 +115,8 @@ func TestMDMAssetHandlerListExposesManifestMetadata(t *testing.T) {
 		},
 	}
 	storage := newFakeStorage(t, &v1.MDMAsset{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      v1.MDMAssetName(digest),
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      v1.MDMAssetName(digest),
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MDMAssetSpec{
 			Digest:            digest,
 			SchemaVersion:     manifest.SchemaVersion,

--- a/pkg/api/handlers/mdmconfigurations.go
+++ b/pkg/api/handlers/mdmconfigurations.go
@@ -57,9 +57,7 @@ func (h *MDMConfigurationsHandler) Create(req api.Context) error {
 			source.Annotations[v1.MDMAssetSourceSyncAnnotation] != "true" &&
 			source.Status.LatestDigest != "" {
 			auto, err := h.mdmConfigurationFromInput(req, types.MDMConfiguration{
-				MDMConfigurationManifest: types.MDMConfigurationManifest{
-					AssetDigest: source.Status.LatestDigest,
-				},
+				AssetDigest: source.Status.LatestDigest,
 			}, nil, in.EnforcementEnabled)
 			if err == nil {
 				configuration = auto
@@ -461,13 +459,11 @@ func (h *MDMConfigurationsHandler) mdmConfigurationFromInput(req api.Context, in
 
 func convertMDMConfiguration(configuration gtypes.MDMConfiguration) (types.MDMConfiguration, error) {
 	result := types.MDMConfiguration{
-		ID:                configuration.ID,
-		IsDefault:         configuration.IsDefault,
-		CreatedAt:         *types.NewTime(configuration.CreatedAt),
-		ObotSentryVersion: configuration.ObotSentryVersion,
-		MDMConfigurationManifest: types.MDMConfigurationManifest{
-			AssetDigest: configuration.AssetDigest,
-		},
+		ID:                   configuration.ID,
+		IsDefault:            configuration.IsDefault,
+		CreatedAt:            *types.NewTime(configuration.CreatedAt),
+		ObotSentryVersion:    configuration.ObotSentryVersion,
+		AssetDigest:          configuration.AssetDigest,
 		Artifacts:            make([]types.MDMConfigurationArtifact, 0, len(configuration.Artifacts)),
 		EnforcementEnabled:   configuration.EnforcementEnabled,
 		EnforcementAllowlist: configuration.EnforcementAllowlist,

--- a/pkg/api/handlers/messagepolicy.go
+++ b/pkg/api/handlers/messagepolicy.go
@@ -7,7 +7,6 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type MessagePolicyHandler struct{}
@@ -57,10 +56,8 @@ func (*MessagePolicyHandler) Create(req api.Context) error {
 	}
 
 	policy := v1.MessagePolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.MessagePolicyPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.MessagePolicyPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.MessagePolicySpec{
 			Manifest: manifest,
 		},
@@ -104,10 +101,8 @@ func (*MessagePolicyHandler) Delete(req api.Context) error {
 	policyID := req.PathValue("id")
 
 	return req.Delete(&v1.MessagePolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      policyID,
-			Namespace: req.Namespace(),
-		},
+		Name:      policyID,
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/messagepolicyviolation.go
+++ b/pkg/api/handlers/messagepolicyviolation.go
@@ -47,10 +47,10 @@ func (*MessagePolicyViolationHandler) List(req api.Context) error {
 	}
 
 	return req.Write(types.MessagePolicyViolationResponse{
-		MessagePolicyViolationList: types.MessagePolicyViolationList{Items: result},
-		Total:                      total,
-		Limit:                      opts.Limit,
-		Offset:                     opts.Offset,
+		Items:  result,
+		Total:  total,
+		Limit:  opts.Limit,
+		Offset: opts.Offset,
 	})
 }
 

--- a/pkg/api/handlers/model.go
+++ b/pkg/api/handlers/model.go
@@ -10,7 +10,6 @@ import (
 	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -147,10 +146,8 @@ func (a *ModelHandler) Create(req api.Context) error {
 	}
 
 	model := &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.ModelPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.ModelPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.ModelSpec{
 			Manifest: modelManifest,
 		},
@@ -174,10 +171,8 @@ func (a *ModelHandler) Create(req api.Context) error {
 
 func (a *ModelHandler) Delete(req api.Context) error {
 	return req.Delete(&v1.Model{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.PathValue("id"),
-			Namespace: req.Namespace(),
-		},
+		Name:      req.PathValue("id"),
+		Namespace: req.Namespace(),
 	})
 }
 
@@ -188,15 +183,13 @@ func convertModel(model v1.Model, modelProvider v1.ModelProvider) (types.Model, 
 	}
 
 	return types.Model{
-		Metadata:      MetadataFrom(&model),
-		ModelManifest: model.Spec.Manifest,
-		ModelStatus: types.ModelStatus{
-			AliasAssigned:     aliasAssigned,
-			ModelProviderName: modelProvider.Name,
-			Icon:              modelProvider.Spec.Icon,
-			IconDark:          modelProvider.Spec.IconDark,
-			Cost:              model.Status.Cost,
-		},
+		Metadata:          MetadataFrom(&model),
+		ModelManifest:     model.Spec.Manifest,
+		AliasAssigned:     aliasAssigned,
+		ModelProviderName: modelProvider.Name,
+		Icon:              modelProvider.Spec.Icon,
+		IconDark:          modelProvider.Spec.IconDark,
+		Cost:              model.Status.Cost,
 	}, nil
 }
 

--- a/pkg/api/handlers/modelaccesspolicy.go
+++ b/pkg/api/handlers/modelaccesspolicy.go
@@ -8,7 +8,6 @@ import (
 	"github.com/obot-platform/obot/pkg/modelaccesspolicy"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ModelAccessPolicyHandler struct{}
@@ -54,10 +53,8 @@ func (*ModelAccessPolicyHandler) Create(req api.Context) error {
 	}
 
 	policy := v1.ModelAccessPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.ModelAccessPolicyPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.ModelAccessPolicyPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.ModelAccessPolicySpec{
 			Manifest: manifest,
 		},
@@ -97,10 +94,8 @@ func (*ModelAccessPolicyHandler) Delete(req api.Context) error {
 	policyID := req.PathValue("id")
 
 	return req.Delete(&v1.ModelAccessPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      policyID,
-			Namespace: req.Namespace(),
-		},
+		Name:      policyID,
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/modelaccesspolicy_test.go
+++ b/pkg/api/handlers/modelaccesspolicy_test.go
@@ -14,7 +14,6 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -85,10 +84,8 @@ func TestModelAccessPolicyHandlerUpdateRejectsPersistedNonLLMModel(t *testing.T)
 		WithObjects(
 			modelForAccessPolicyHandlerTest("m1-embedding", types.ModelUsageEmbedding),
 			&v1.ModelAccessPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      policyID,
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      policyID,
+				Namespace: system.DefaultNamespace,
 				Spec: v1.ModelAccessPolicySpec{
 					Manifest: initialManifest,
 				},
@@ -124,10 +121,8 @@ func TestModelAccessPolicyHandlerUpdateRejectsPersistedNonLLMModel(t *testing.T)
 
 func modelForAccessPolicyHandlerTest(name string, usage types.ModelUsage) *v1.Model {
 	return &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      name,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.ModelSpec{
 			Manifest: types.ModelManifest{
 				Usage: usage,

--- a/pkg/api/handlers/modelinfosource.go
+++ b/pkg/api/handlers/modelinfosource.go
@@ -42,10 +42,8 @@ func (*ModelInfoSourceHandler) Refresh(req api.Context) error {
 
 func convertModelInfoSource(source v1.ModelInfoSource) types.ModelInfoSource {
 	return types.ModelInfoSource{
-		Metadata: MetadataFrom(&source),
-		ModelInfoSourceManifest: types.ModelInfoSourceManifest{
-			URL: source.Spec.Manifest.URL,
-		},
+		Metadata:   MetadataFrom(&source),
+		URL:        source.Spec.Manifest.URL,
 		LastSynced: *types.NewTime(source.Status.LastSyncTime.Time),
 		SyncError:  source.Status.SyncError,
 		IsSyncing:  source.Annotations[v1.ModelInfoSourceSyncAnnotation] == "true",

--- a/pkg/api/handlers/nanobotagent.go
+++ b/pkg/api/handlers/nanobotagent.go
@@ -16,7 +16,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/wait"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -87,10 +86,8 @@ func (h *NanobotAgentHandler) Create(req api.Context) error {
 	}
 
 	agent := v1.NanobotAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.NanobotAgentPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.NanobotAgentPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.NanobotAgentSpec{
 			NanobotAgentManifest: manifest,
 			UserID:               req.User.GetUID(),
@@ -172,10 +169,8 @@ func (h *NanobotAgentHandler) Delete(req api.Context) error {
 	}
 
 	return req.Delete(&v1.NanobotAgent{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      id,
-			Namespace: req.Namespace(),
-		},
+		Name:      id,
+		Namespace: req.Namespace(),
 	})
 }
 
@@ -190,10 +185,8 @@ func (h *NanobotAgentHandler) Launch(req api.Context) error {
 	}
 
 	server := &v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: req.Namespace(),
-			Name:      system.MCPServerPrefix + req.PathValue("nanobot_agent_id"),
-		},
+		Namespace: req.Namespace(),
+		Name:      system.MCPServerPrefix + req.PathValue("nanobot_agent_id"),
 	}
 
 	ctx, cancel := context.WithTimeout(req.Context(), 15*time.Second)

--- a/pkg/api/handlers/oauthclients.go
+++ b/pkg/api/handlers/oauthclients.go
@@ -11,7 +11,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"golang.org/x/crypto/bcrypt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -70,10 +69,8 @@ func (h *OAuthClientsHandler) Create(req api.Context) error {
 	}
 
 	client := v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.OAuthClientPrefix + strings.ToLower(rand.Text()),
-			Namespace: req.Namespace(),
-		},
+		Name:      system.OAuthClientPrefix + strings.ToLower(rand.Text()),
+		Namespace: req.Namespace(),
 		Spec: v1.OAuthClientSpec{
 			Manifest: input,
 			Static:   true,
@@ -135,10 +132,8 @@ func (h *OAuthClientsHandler) Delete(req api.Context) error {
 		return types.NewErrBadRequest("invalid client ID: %s", req.PathValue("client_id"))
 	}
 	return req.Delete(&v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		Name:      name,
+		Namespace: namespace,
 	})
 }
 

--- a/pkg/api/handlers/project.go
+++ b/pkg/api/handlers/project.go
@@ -5,7 +5,6 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,10 +44,8 @@ func (*ProjectHandler) Create(req api.Context) error {
 	}
 
 	project := v1.Project{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.ProjectPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.ProjectPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.ProjectSpec{
 			ProjectManifest: manifest,
 			UserID:          req.User.GetUID(),
@@ -98,10 +95,8 @@ func (*ProjectHandler) Delete(req api.Context) error {
 	var id = req.PathValue("project_id")
 
 	return req.Delete(&v1.Project{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      id,
-			Namespace: req.Namespace(),
-		},
+		Name:      id,
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/providers/authproviders.go
+++ b/pkg/api/handlers/providers/authproviders.go
@@ -32,11 +32,9 @@ func AuthProviderStatus(ctx context.Context, authProvider v1.AuthProvider, cred 
 	}
 
 	return &types.AuthProviderStatus{
-		CommonProviderStatus: types.CommonProviderStatus{
-			Configured:                     len(missingEnvVars) == 0,
-			MissingEntitlements:            missingEntitlements,
-			MissingConfigurationParameters: missingEnvVars,
-		},
-		Namespace: authProvider.Namespace,
+		Configured:                     len(missingEnvVars) == 0,
+		MissingEntitlements:            missingEntitlements,
+		MissingConfigurationParameters: missingEnvVars,
+		Namespace:                      authProvider.Namespace,
 	}, nil
 }

--- a/pkg/api/handlers/providers/modelproviders.go
+++ b/pkg/api/handlers/providers/modelproviders.go
@@ -39,11 +39,9 @@ func ModelProviderStatus(ctx context.Context, modelProvider v1.ModelProvider, cr
 	}
 
 	return &types.ModelProviderStatus{
-		CommonProviderStatus: types.CommonProviderStatus{
-			Configured:                     len(missingEnvVars) == 0,
-			MissingEntitlements:            missingEntitlements,
-			MissingConfigurationParameters: missingEnvVars,
-		},
-		ModelsBackPopulated: modelsPopulated,
+		Configured:                     len(missingEnvVars) == 0,
+		MissingEntitlements:            missingEntitlements,
+		MissingConfigurationParameters: missingEnvVars,
+		ModelsBackPopulated:            modelsPopulated,
 	}, nil
 }

--- a/pkg/api/handlers/providers/providers_test.go
+++ b/pkg/api/handlers/providers/providers_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/license"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAuthProviderStatus(t *testing.T) {
@@ -266,9 +265,7 @@ func modelProvider(requiredConfig []types.ProviderConfigurationParameter, missin
 	statusPopulated := missingConfig != nil
 
 	return v1.ModelProvider{
-		ObjectMeta: metav1.ObjectMeta{
-			Generation: generation,
-		},
+		Generation: generation,
 		Spec: v1.ModelProviderSpec{
 			ModelProviderManifest: types.ModelProviderManifest{
 				CommonProviderMetadata: types.CommonProviderMetadata{

--- a/pkg/api/handlers/publishedartifact.go
+++ b/pkg/api/handlers/publishedartifact.go
@@ -28,7 +28,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/utils"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -202,10 +201,8 @@ func (h *PublishedArtifactHandler) createNewArtifact(req api.Context, data []byt
 	}
 
 	artifact := v1.PublishedArtifact{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      artifactName,
-			Namespace: req.Namespace(),
-		},
+		Name:      artifactName,
+		Namespace: req.Namespace(),
 		Spec: v1.PublishedArtifactSpec{
 			PublishedArtifactManifest: manifest,
 			AuthorID:                  authorID,

--- a/pkg/api/handlers/publishedartifact_test.go
+++ b/pkg/api/handlers/publishedartifact_test.go
@@ -336,9 +336,7 @@ func TestWithArtifactMetadata(t *testing.T) {
 
 func TestConvertPublishedArtifact(t *testing.T) {
 	input := &v1.PublishedArtifact{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pa1abc123",
-		},
+		Name: "pa1abc123",
 		Spec: v1.PublishedArtifactSpec{
 			PublishedArtifactManifest: types.PublishedArtifactManifest{
 				Name:         "my-workflow",
@@ -570,10 +568,8 @@ func TestPublishedArtifactCreate_InheritsSubjectsFromPreviousVersion(t *testing.
 	artifactName := system.PublishedArtifactPrefix + hash.String("owner" + string(types.PublishedArtifactTypeWorkflow) + "workflow-a")[:12]
 
 	storage := newPublishedArtifactTestStorage(t, &v1.PublishedArtifact{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      artifactName,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      artifactName,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.PublishedArtifactSpec{
 			PublishedArtifactManifest: types.PublishedArtifactManifest{
 				Name:         "workflow-a",

--- a/pkg/api/handlers/registry/convert_test.go
+++ b/pkg/api/handlers/registry/convert_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestConvertMCPServerCatalogEntryToRegistryRemoteFixedURLHasRemote(t *testing.T) {
@@ -99,9 +98,7 @@ func TestConvertMCPServerCatalogEntryToRegistryRemoteStaticOAuthRequiresConfigur
 
 func TestConvertMCPServerToRegistryNeedsURLRequiresConfiguration(t *testing.T) {
 	server := v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "ms1needsurl",
-		},
+		Name: "ms1needsurl",
 		Spec: v1.MCPServerSpec{
 			UserID:   "user-1",
 			NeedsURL: true,
@@ -130,9 +127,7 @@ func TestConvertMCPServerToRegistryNeedsURLRequiresConfiguration(t *testing.T) {
 
 func registryTestCatalogEntry(remoteConfig types.RemoteCatalogConfig) v1.MCPServerCatalogEntry {
 	return v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "remote-entry",
-		},
+		Name: "remote-entry",
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Manifest: types.MCPServerCatalogEntryManifest{
 				Name:        "Remote Entry",

--- a/pkg/api/handlers/serverinstances.go
+++ b/pkg/api/handlers/serverinstances.go
@@ -17,7 +17,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -141,11 +140,9 @@ func (h *ServerInstancesHandler) CreateServerInstance(req api.Context) error {
 	}
 
 	instance := v1.MCPServerInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       fmt.Sprintf("%s-%s-%s", system.MCPServerInstancePrefix, req.User.GetUID(), input.MCPServerID),
-			Namespace:  req.Namespace(),
-			Finalizers: []string{v1.MCPServerInstanceFinalizer},
-		},
+		Name:       fmt.Sprintf("%s-%s-%s", system.MCPServerInstancePrefix, req.User.GetUID(), input.MCPServerID),
+		Namespace:  req.Namespace(),
+		Finalizers: []string{v1.MCPServerInstanceFinalizer},
 		Spec: v1.MCPServerInstanceSpec{
 			UserID:                    req.User.GetUID(),
 			MCPServerName:             input.MCPServerID,
@@ -173,10 +170,8 @@ func (h *ServerInstancesHandler) CreateServerInstance(req api.Context) error {
 
 func (h *ServerInstancesHandler) DeleteServerInstance(req api.Context) error {
 	return req.Delete(&v1.MCPServerInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.PathValue("mcp_server_instance_id"),
-			Namespace: req.Namespace(),
-		},
+		Name:      req.PathValue("mcp_server_instance_id"),
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/setup/confirm_owner.go
+++ b/pkg/api/handlers/setup/confirm_owner.go
@@ -9,7 +9,6 @@ import (
 	"github.com/obot-platform/obot/pkg/api"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ConfirmOwnerRequest struct {
@@ -97,10 +96,8 @@ func (h *Handler) ConfirmOwner(req api.Context) error {
 
 	// Create the UserRoleChange
 	if err := req.Create(&v1.UserRoleChange{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.UserRoleChangePrefix,
-			Namespace:    system.DefaultNamespace,
-		},
+		GenerateName: system.UserRoleChangePrefix,
+		Namespace:    system.DefaultNamespace,
 		Spec: v1.UserRoleChangeSpec{
 			UserID: user.ID,
 		},

--- a/pkg/api/handlers/skillaccessrules.go
+++ b/pkg/api/handlers/skillaccessrules.go
@@ -8,7 +8,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type SkillAccessRuleHandler struct{}
@@ -47,10 +46,8 @@ func (*SkillAccessRuleHandler) Create(req api.Context) error {
 	}
 
 	rule := v1.SkillAccessRule{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.SkillAccessRulePrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.SkillAccessRulePrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.SkillAccessRuleSpec{
 			Manifest: *manifest,
 		},
@@ -84,10 +81,8 @@ func (*SkillAccessRuleHandler) Update(req api.Context) error {
 
 func (*SkillAccessRuleHandler) Delete(req api.Context) error {
 	return req.Delete(&v1.SkillAccessRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      req.PathValue("skill_access_rule_id"),
-			Namespace: req.Namespace(),
-		},
+		Name:      req.PathValue("skill_access_rule_id"),
+		Namespace: req.Namespace(),
 	})
 }
 

--- a/pkg/api/handlers/skillrepositories.go
+++ b/pkg/api/handlers/skillrepositories.go
@@ -13,7 +13,6 @@ import (
 	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -67,10 +66,8 @@ func (*SkillRepositoryHandler) Create(req api.Context) error {
 	}
 
 	repo := v1.SkillRepository{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.SkillRepositoryPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.SkillRepositoryPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.SkillRepositorySpec{
 			DisplayName:     manifest.DisplayName,
 			RepoURL:         manifest.RepoURL,
@@ -141,10 +138,8 @@ func (*SkillRepositoryHandler) Update(req api.Context) error {
 func (*SkillRepositoryHandler) Delete(req api.Context) error {
 	repoName := req.PathValue("skill_repository_id")
 	if err := req.Delete(&v1.SkillRepository{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      repoName,
-			Namespace: req.Namespace(),
-		},
+		Name:      repoName,
+		Namespace: req.Namespace(),
 	}); err != nil {
 		return err
 	}

--- a/pkg/api/handlers/skills_test.go
+++ b/pkg/api/handlers/skills_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	gocache "k8s.io/client-go/tools/cache"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -114,11 +113,11 @@ func TestParseSkillRepositoryRequest(t *testing.T) {
 func TestSkillAccessRuleHandlerReadAndValidateManifest(t *testing.T) {
 	storage := newFakeStorage(t,
 		&v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "sk1", Namespace: system.DefaultNamespace},
-			Spec:       v1.SkillSpec{RepoID: "skr1"},
+			Name: "sk1", Namespace: system.DefaultNamespace,
+			Spec: v1.SkillSpec{RepoID: "skr1"},
 		},
 		&v1.SkillRepository{
-			ObjectMeta: metav1.ObjectMeta{Name: "skr1", Namespace: system.DefaultNamespace},
+			Name: "skr1", Namespace: system.DefaultNamespace,
 		},
 	)
 
@@ -155,10 +154,8 @@ func TestSkillAccessRuleHandlerReadAndValidateManifest(t *testing.T) {
 
 func TestSkillRepositoryHandlerRefresh(t *testing.T) {
 	storage := newFakeStorage(t, &v1.SkillRepository{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "skr1",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "skr1",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.SkillRepositorySpec{
 			RepoURL: "https://github.com/example/repo",
 		},
@@ -200,7 +197,7 @@ func TestSkillRepositoryHandlerRejectsDuplicateNameAndURL(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			storage := newFakeStorage(t, &v1.SkillRepository{
-				ObjectMeta: metav1.ObjectMeta{Name: "skr-existing", Namespace: system.DefaultNamespace},
+				Name: "skr-existing", Namespace: system.DefaultNamespace,
 				Spec: v1.SkillRepositorySpec{
 					DisplayName: "Existing Source",
 					RepoURL:     "https://github.com/example/repo",
@@ -243,14 +240,14 @@ func TestSkillRepositoryHandlerUpdateRejectsAnotherSourceNameAndURL(t *testing.T
 		t.Run(test.name, func(t *testing.T) {
 			storage := newFakeStorage(t,
 				&v1.SkillRepository{
-					ObjectMeta: metav1.ObjectMeta{Name: "skr-existing", Namespace: system.DefaultNamespace},
+					Name: "skr-existing", Namespace: system.DefaultNamespace,
 					Spec: v1.SkillRepositorySpec{
 						DisplayName: "Existing Source",
 						RepoURL:     "https://github.com/example/repo",
 					},
 				},
 				&v1.SkillRepository{
-					ObjectMeta: metav1.ObjectMeta{Name: "skr-updating", Namespace: system.DefaultNamespace},
+					Name: "skr-updating", Namespace: system.DefaultNamespace,
 					Spec: v1.SkillRepositorySpec{
 						DisplayName: "Current Source",
 						RepoURL:     "https://github.com/example/current",
@@ -273,7 +270,7 @@ func TestSkillRepositoryHandlerUpdateRejectsAnotherSourceNameAndURL(t *testing.T
 
 func TestSkillRepositoryHandlerUpdateAllowsOwnNameAndURL(t *testing.T) {
 	storage := newFakeStorage(t, &v1.SkillRepository{
-		ObjectMeta: metav1.ObjectMeta{Name: "skr-existing", Namespace: system.DefaultNamespace},
+		Name: "skr-existing", Namespace: system.DefaultNamespace,
 		Spec: v1.SkillRepositorySpec{
 			DisplayName: "Existing Source",
 			RepoURL:     "https://github.com/example/repo",
@@ -296,7 +293,7 @@ func TestSkillRepositoryHandlerUpdateAllowsOwnNameAndURL(t *testing.T) {
 func TestSkillHandlerListFiltersByAccessAndValidity(t *testing.T) {
 	storage := newFakeStorage(t,
 		&v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "sk-allowed", Namespace: system.DefaultNamespace},
+			Name: "sk-allowed", Namespace: system.DefaultNamespace,
 			Spec: v1.SkillSpec{
 				SkillManifest: types.SkillManifest{
 					Name:        "postgres-helper",
@@ -308,7 +305,7 @@ func TestSkillHandlerListFiltersByAccessAndValidity(t *testing.T) {
 			Status: v1.SkillStatus{Valid: true},
 		},
 		&v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "sk-invalid", Namespace: system.DefaultNamespace},
+			Name: "sk-invalid", Namespace: system.DefaultNamespace,
 			Spec: v1.SkillSpec{
 				SkillManifest: types.SkillManifest{
 					Name: "broken-helper",
@@ -318,7 +315,7 @@ func TestSkillHandlerListFiltersByAccessAndValidity(t *testing.T) {
 			Status: v1.SkillStatus{Valid: false},
 		},
 		&v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "sk-direct", Namespace: system.DefaultNamespace},
+			Name: "sk-direct", Namespace: system.DefaultNamespace,
 			Spec: v1.SkillSpec{
 				SkillManifest: types.SkillManifest{
 					Name:        "redis-helper",
@@ -330,7 +327,7 @@ func TestSkillHandlerListFiltersByAccessAndValidity(t *testing.T) {
 			Status: v1.SkillStatus{Valid: true},
 		},
 		&v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "sk-denied", Namespace: system.DefaultNamespace},
+			Name: "sk-denied", Namespace: system.DefaultNamespace,
 			Spec: v1.SkillSpec{
 				SkillManifest: types.SkillManifest{
 					Name: "denied-helper",
@@ -381,7 +378,7 @@ func TestSkillHandlerListAllTrueScopeBypass(t *testing.T) {
 	// Skills in repo-1 (in scope for user1) and repo-3 (out of scope)
 	storage := newFakeStorage(t,
 		&v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "sk-in-scope", Namespace: system.DefaultNamespace},
+			Name: "sk-in-scope", Namespace: system.DefaultNamespace,
 			Spec: v1.SkillSpec{
 				SkillManifest: types.SkillManifest{Name: "in-scope-skill"},
 				RepoID:        "repo-1",
@@ -389,7 +386,7 @@ func TestSkillHandlerListAllTrueScopeBypass(t *testing.T) {
 			Status: v1.SkillStatus{Valid: true},
 		},
 		&v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "sk-out-scope", Namespace: system.DefaultNamespace},
+			Name: "sk-out-scope", Namespace: system.DefaultNamespace,
 			Spec: v1.SkillSpec{
 				SkillManifest: types.SkillManifest{Name: "out-of-scope-skill"},
 				RepoID:        "repo-3",
@@ -463,7 +460,7 @@ func TestSkillHandlerListAllTrueScopeBypass(t *testing.T) {
 
 func TestSkillHandlerDownloadPackagesMaterializedSkill(t *testing.T) {
 	skill := &v1.Skill{
-		ObjectMeta: metav1.ObjectMeta{Name: "sk1", Namespace: system.DefaultNamespace},
+		Name: "sk1", Namespace: system.DefaultNamespace,
 		Spec: v1.SkillSpec{
 			SkillManifest: types.SkillManifest{Name: "postgres-helper"},
 			RepoID:        "repo-1",
@@ -526,7 +523,7 @@ func TestSkillHandlerDownloadPackagesMaterializedSkill(t *testing.T) {
 func TestSkillHandlerPreviewReturnsSkillMD(t *testing.T) {
 	want := []byte("---\nname: postgres-helper\ndescription: Preview me\n---\n\n# Instructions\n")
 	skill := &v1.Skill{
-		ObjectMeta: metav1.ObjectMeta{Name: "sk1", Namespace: system.DefaultNamespace},
+		Name: "sk1", Namespace: system.DefaultNamespace,
 		Spec: v1.SkillSpec{
 			SkillManifest: types.SkillManifest{Name: "postgres-helper"},
 			RepoID:        "repo-1",
@@ -719,10 +716,8 @@ func newSkillAccessRuleHelper(t *testing.T, rules ...*v1.SkillAccessRule) *skill
 
 func newSkillRule(name string, subjects []types.Subject, resources []types.SkillResource) *v1.SkillAccessRule {
 	return &v1.SkillAccessRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      name,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.SkillAccessRuleSpec{
 			Manifest: types.SkillAccessRuleManifest{
 				Subjects:  subjects,

--- a/pkg/api/handlers/systemmcpcatalogs.go
+++ b/pkg/api/handlers/systemmcpcatalogs.go
@@ -16,7 +16,6 @@ import (
 	"github.com/obot-platform/obot/pkg/mcp"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -78,10 +77,8 @@ func (h *SystemMCPCatalogHandler) Create(req api.Context) error {
 	}
 
 	catalog := v1.SystemMCPCatalog{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.SystemCatalogPrefix,
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: system.SystemCatalogPrefix,
+		Namespace:    req.Namespace(),
 		Spec: v1.SystemMCPCatalogSpec{
 			DisplayName:               manifest.DisplayName,
 			SourceURLs:                manifest.SourceURLs,
@@ -204,10 +201,8 @@ func (h *SystemMCPCatalogHandler) CreateEntry(req api.Context) error {
 	}
 
 	entry := v1.SystemMCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: name.SafeHashConcatName(catalogName, normalizeMCPCatalogEntryName(manifest.Name)),
-			Namespace:    req.Namespace(),
-		},
+		GenerateName: name.SafeHashConcatName(catalogName, normalizeMCPCatalogEntryName(manifest.Name)),
+		Namespace:    req.Namespace(),
 		Spec: v1.SystemMCPServerCatalogEntrySpec{
 			SystemMCPCatalogName: catalogName,
 			Editable:             true,
@@ -402,16 +397,14 @@ func maskCatalogCredentials(sourceURLs []string, tokenEnv map[string]string) map
 
 func convertSystemMCPCatalog(catalog v1.SystemMCPCatalog, tokenEnv map[string]string) types.SystemMCPCatalog {
 	return types.SystemMCPCatalog{
-		Metadata: MetadataFrom(&catalog),
-		SystemMCPCatalogManifest: types.SystemMCPCatalogManifest{
-			DisplayName:               catalog.Spec.DisplayName,
-			SourceURLs:                catalog.Spec.SourceURLs,
-			SourceURLCredentials:      maskCatalogCredentials(catalog.Spec.SourceURLs, tokenEnv),
-			SourceURLGitCredentialIDs: catalog.Spec.SourceURLGitCredentialIDs,
-		},
-		LastSynced: *types.NewTime(catalog.Status.LastSyncTime.Time),
-		SyncErrors: catalog.Status.SyncErrors,
-		IsSyncing:  catalog.Status.IsSyncing || catalog.Annotations[v1.SystemMCPCatalogSyncAnnotation] == "true",
+		Metadata:                  MetadataFrom(&catalog),
+		DisplayName:               catalog.Spec.DisplayName,
+		SourceURLs:                catalog.Spec.SourceURLs,
+		SourceURLCredentials:      maskCatalogCredentials(catalog.Spec.SourceURLs, tokenEnv),
+		SourceURLGitCredentialIDs: catalog.Spec.SourceURLGitCredentialIDs,
+		LastSynced:                *types.NewTime(catalog.Status.LastSyncTime.Time),
+		SyncErrors:                catalog.Status.SyncErrors,
+		IsSyncing:                 catalog.Status.IsSyncing || catalog.Annotations[v1.SystemMCPCatalogSyncAnnotation] == "true",
 	}
 }
 

--- a/pkg/api/handlers/systemmcpcatalogs_test.go
+++ b/pkg/api/handlers/systemmcpcatalogs_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMaskCatalogCredential(t *testing.T) {
@@ -118,7 +117,7 @@ func TestConvertSystemMCPServerCatalogEntryResources(t *testing.T) {
 	}
 
 	entry := ConvertSystemMCPServerCatalogEntry(v1.SystemMCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{Name: "entry"},
+		Name: "entry",
 		Spec: v1.SystemMCPServerCatalogEntrySpec{
 			Manifest: types.SystemMCPServerCatalogEntryManifest{
 				Name:      "entry",

--- a/pkg/api/handlers/systemmcpserver.go
+++ b/pkg/api/handlers/systemmcpserver.go
@@ -82,11 +82,9 @@ func (h *SystemMCPServerHandler) Create(req api.Context) error {
 	}
 
 	systemServer := v1.SystemMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.SystemMCPServerPrefix,
-			Namespace:    req.Namespace(),
-			Finalizers:   []string{v1.SystemMCPServerFinalizer},
-		},
+		GenerateName: system.SystemMCPServerPrefix,
+		Namespace:    req.Namespace(),
+		Finalizers:   []string{v1.SystemMCPServerFinalizer},
 		Spec: v1.SystemMCPServerSpec{
 			Manifest: manifest,
 		},

--- a/pkg/api/handlers/systemmcpserver_test.go
+++ b/pkg/api/handlers/systemmcpserver_test.go
@@ -13,7 +13,7 @@ func TestConvertSystemMCPServerConfigurationStatus(t *testing.T) {
 	server := v1.SystemMCPServer{
 		Spec: v1.SystemMCPServerSpec{
 			Manifest: types.SystemMCPServerManifest{
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "REGION", Required: true, Options: options}}},
+				Env: []types.MCPEnv{{Key: "REGION", Required: true, Options: options}},
 				RemoteConfig: &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{
 					{Key: "TENANT", Required: true, Options: options},
 					{Key: "MODE", Options: options},

--- a/pkg/auditlog/presenter.go
+++ b/pkg/auditlog/presenter.go
@@ -215,10 +215,8 @@ func presentLocalAgent(event *api.AuditLogEvent, log gatewaytypes.MCPAuditLog, o
 		Kind:      local.ActionKind,
 	}
 	event.Target = api.AuditLogTarget{
-		AuditLogTargetRef: api.AuditLogTargetRef{
-			TargetType: local.TargetType,
-			Name:       local.TargetName,
-		},
+		TargetType: local.TargetType,
+		Name:       local.TargetName,
 	}
 	if local.TargetParentType != "" {
 		event.Target.Parent = &api.AuditLogTargetRef{

--- a/pkg/bootstrap/bootstrap_test.go
+++ b/pkg/bootstrap/bootstrap_test.go
@@ -13,7 +13,6 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	sservices "github.com/obot-platform/obot/pkg/storage/services"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -46,10 +45,8 @@ func newBootstrapTestClient(t *testing.T) (*client.Client, context.Context) {
 	storageClient := fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
 		WithObjects(&v1.UserDefaultRoleSetting{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.DefaultNamespace,
-				Name:      system.DefaultRoleSettingName,
-			},
+			Namespace: system.DefaultNamespace,
+			Name:      system.DefaultRoleSettingName,
 			Spec: v1.UserDefaultRoleSettingSpec{
 				Role: types2.RoleBasic,
 			},

--- a/pkg/cli/internal/token_test.go
+++ b/pkg/cli/internal/token_test.go
@@ -194,16 +194,10 @@ func TestTokenStoresNewTokenByAppURL(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(types.User{Username: "anonymous"})
 		case "/api/auth-providers":
 			_ = json.NewEncoder(w).Encode(types.AuthProviderList{Items: []types.AuthProvider{{
-				Metadata: types.Metadata{ID: "github"},
-				AuthProviderManifest: types.AuthProviderManifest{
-					CommonProviderMetadata: types.CommonProviderMetadata{
-						Name: "GitHub",
-					},
-				},
-				AuthProviderStatus: types.AuthProviderStatus{
-					CommonProviderStatus: types.CommonProviderStatus{Configured: true},
-					Namespace:            "default",
-				},
+				ID:         "github",
+				Name:       "GitHub",
+				Configured: true,
+				Namespace:  "default",
 			}}})
 		case "/api/token-request":
 			writeDeviceLoginResponse(t, w, "server-request-id")
@@ -303,16 +297,10 @@ func TestTokenRequestIncludesRequestedScopes(t *testing.T) {
 					_ = json.NewEncoder(w).Encode(types.User{Username: "anonymous"})
 				case "/api/auth-providers":
 					_ = json.NewEncoder(w).Encode(types.AuthProviderList{Items: []types.AuthProvider{{
-						Metadata: types.Metadata{ID: "github"},
-						AuthProviderManifest: types.AuthProviderManifest{
-							CommonProviderMetadata: types.CommonProviderMetadata{
-								Name: "GitHub",
-							},
-						},
-						AuthProviderStatus: types.AuthProviderStatus{
-							CommonProviderStatus: types.CommonProviderStatus{Configured: true},
-							Namespace:            "default",
-						},
+						ID:         "github",
+						Name:       "GitHub",
+						Configured: true,
+						Namespace:  "default",
 					}}})
 				case "/api/token-request":
 					if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
@@ -398,16 +386,10 @@ func TestTokenRefreshesValidKeyringTokenMissingRequestedScopes(t *testing.T) {
 			})
 		case "/api/auth-providers":
 			_ = json.NewEncoder(w).Encode(types.AuthProviderList{Items: []types.AuthProvider{{
-				Metadata: types.Metadata{ID: "github"},
-				AuthProviderManifest: types.AuthProviderManifest{
-					CommonProviderMetadata: types.CommonProviderMetadata{
-						Name: "GitHub",
-					},
-				},
-				AuthProviderStatus: types.AuthProviderStatus{
-					CommonProviderStatus: types.CommonProviderStatus{Configured: true},
-					Namespace:            "default",
-				},
+				ID:         "github",
+				Name:       "GitHub",
+				Configured: true,
+				Namespace:  "default",
 			}}})
 		case "/api/token-request":
 			if err := json.NewDecoder(r.Body).Decode(&createdRequest); err != nil {
@@ -527,16 +509,10 @@ func TestTokenRefreshesAPIKeyringTokenForMCPScope(t *testing.T) {
 			})
 		case "/api/auth-providers":
 			_ = json.NewEncoder(w).Encode(types.AuthProviderList{Items: []types.AuthProvider{{
-				Metadata: types.Metadata{ID: "github"},
-				AuthProviderManifest: types.AuthProviderManifest{
-					CommonProviderMetadata: types.CommonProviderMetadata{
-						Name: "GitHub",
-					},
-				},
-				AuthProviderStatus: types.AuthProviderStatus{
-					CommonProviderStatus: types.CommonProviderStatus{Configured: true},
-					Namespace:            "default",
-				},
+				ID:         "github",
+				Name:       "GitHub",
+				Configured: true,
+				Namespace:  "default",
 			}}})
 		case "/api/token-request":
 			if err := json.NewDecoder(r.Body).Decode(&createdRequest); err != nil {
@@ -587,16 +563,10 @@ func TestTokenNonInteractiveSkipsBrowserEnterGate(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(types.User{Username: "anonymous"})
 		case "/api/auth-providers":
 			_ = json.NewEncoder(w).Encode(types.AuthProviderList{Items: []types.AuthProvider{{
-				Metadata: types.Metadata{ID: "github"},
-				AuthProviderManifest: types.AuthProviderManifest{
-					CommonProviderMetadata: types.CommonProviderMetadata{
-						Name: "GitHub",
-					},
-				},
-				AuthProviderStatus: types.AuthProviderStatus{
-					CommonProviderStatus: types.CommonProviderStatus{Configured: true},
-					Namespace:            "default",
-				},
+				ID:         "github",
+				Name:       "GitHub",
+				Configured: true,
+				Namespace:  "default",
 			}}})
 		case "/api/token-request":
 			writeDeviceLoginResponse(t, w, "returned-request-id")

--- a/pkg/cli/setup_test.go
+++ b/pkg/cli/setup_test.go
@@ -137,11 +137,9 @@ func TestSetupNonInteractiveMissingURLFailsWithoutPrompt(t *testing.T) {
 		return "", nil
 	})
 	setup := &Setup{
-		PromptConfig: PromptConfig{
-			NonInteractive: true,
-		},
-		Clients: "agents",
-		root:    root,
+		NonInteractive: true,
+		Clients:        "agents",
+		root:           root,
 	}
 
 	var stdout bytes.Buffer
@@ -170,13 +168,11 @@ func TestSetupClientsNoneSkipsLocalClientInstall(t *testing.T) {
 		return "token", nil
 	})
 	setup := &Setup{
-		PromptConfig: PromptConfig{
-			NonInteractive: true,
-		},
-		URL:     "https://obot.example.com/",
-		Clients: "none",
-		Yes:     true,
-		root:    root,
+		NonInteractive: true,
+		URL:            "https://obot.example.com/",
+		Clients:        "none",
+		Yes:            true,
+		root:           root,
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -208,14 +204,12 @@ func TestSetupJSONProgressSuccessfulSequence(t *testing.T) {
 		return "token", nil
 	})
 	setup := &Setup{
-		PromptConfig: PromptConfig{
-			NonInteractive: true,
-		},
-		URL:     "https://obot.example.com/",
-		Clients: "claude-code",
-		Yes:     true,
-		Output:  "json",
-		root:    root,
+		NonInteractive: true,
+		URL:            "https://obot.example.com/",
+		Clients:        "claude-code",
+		Yes:            true,
+		Output:         "json",
+		root:           root,
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -259,12 +253,10 @@ func TestSetupJSONProgressStructuredError(t *testing.T) {
 		return "", nil
 	})
 	setup := &Setup{
-		PromptConfig: PromptConfig{
-			NonInteractive: true,
-		},
-		Clients: "none",
-		Output:  "json",
-		root:    root,
+		NonInteractive: true,
+		Clients:        "none",
+		Output:         "json",
+		root:           root,
 	}
 
 	var stdout bytes.Buffer
@@ -507,11 +499,9 @@ func TestSetupNonInteractiveRequiresClientsWhenOmitted(t *testing.T) {
 		return "token", nil
 	})
 	setup := &Setup{
-		PromptConfig: PromptConfig{
-			NonInteractive: true,
-		},
-		URL:  "https://obot.example.com/",
-		root: root,
+		NonInteractive: true,
+		URL:            "https://obot.example.com/",
+		root:           root,
 	}
 
 	err := setup.Run(setupTestCommand(t, nil, nil, nil), nil)

--- a/pkg/cli/skills_test.go
+++ b/pkg/cli/skills_test.go
@@ -37,14 +37,12 @@ func TestSkillsSearchCallsAPIWithQueryAndLimit(t *testing.T) {
 		}
 
 		_ = json.NewEncoder(w).Encode(types.SkillList{Items: []types.Skill{{
-			Metadata: types.Metadata{ID: "sk1"},
-			SkillManifest: types.SkillManifest{
-				Name:          "github-review",
-				DisplayName:   "GitHub Review",
-				Description:   "Review GitHub pull requests",
-				Compatibility: "claude-code",
-			},
-			RepoID: "default/github",
+			ID:            "sk1",
+			Name:          "github-review",
+			DisplayName:   "GitHub Review",
+			Description:   "Review GitHub pull requests",
+			Compatibility: "claude-code",
+			RepoID:        "default/github",
 		}}})
 	}))
 	defer server.Close()
@@ -81,8 +79,8 @@ func TestSkillsSearchEmptyResult(t *testing.T) {
 func TestSkillsSearchJSONMode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(types.SkillList{Items: []types.Skill{{
-			Metadata:      types.Metadata{ID: "sk1"},
-			SkillManifest: types.SkillManifest{Name: "github-review"},
+			ID:   "sk1",
+			Name: "github-review",
 		}}})
 	}))
 	defer server.Close()
@@ -289,13 +287,11 @@ func skillInstallTestServer(t *testing.T, skills []skillInstallTestResponse) *ht
 
 func skillTestType(skill skillInstallTestResponse) types.Skill {
 	return types.Skill{
-		Metadata: types.Metadata{ID: skill.ID},
-		SkillManifest: types.SkillManifest{
-			Name:        skill.Name,
-			DisplayName: skill.DisplayName,
-			Description: skill.Description,
-		},
-		RepoID: "default/test",
+		ID:          skill.ID,
+		Name:        skill.Name,
+		DisplayName: skill.DisplayName,
+		Description: skill.Description,
+		RepoID:      "default/test",
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -191,12 +190,10 @@ func (c *Controller) ensureObotMCPServer(ctx context.Context) error {
 		}
 		if !foundOBOTURLEntry {
 			existing.Spec.Manifest.Env = append(existing.Spec.Manifest.Env, types.MCPEnv{
-				MCPHeader: types.MCPHeader{
-					Name:     "OBOT_URL",
-					Key:      "OBOT_URL",
-					Required: true,
-					Value:    internalURL,
-				},
+				Name:     "OBOT_URL",
+				Key:      "OBOT_URL",
+				Required: true,
+				Value:    internalURL,
 			})
 			needsUpdate = true
 		}
@@ -214,11 +211,9 @@ func (c *Controller) ensureObotMCPServer(ctx context.Context) error {
 	// Create the SystemMCPServer
 	slog.Info("Creating obot MCP server", "image", image)
 	server := &v1.SystemMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       system.ObotMCPServerName,
-			Namespace:  system.DefaultNamespace,
-			Finalizers: []string{v1.SystemMCPServerFinalizer},
-		},
+		Name:       system.ObotMCPServerName,
+		Namespace:  system.DefaultNamespace,
+		Finalizers: []string{v1.SystemMCPServerFinalizer},
 		Spec: v1.SystemMCPServerSpec{
 			Manifest: types.SystemMCPServerManifest{
 				Name:             "Obot MCP Server",
@@ -231,12 +226,10 @@ func (c *Controller) ensureObotMCPServer(ctx context.Context) error {
 				},
 				Env: []types.MCPEnv{
 					{
-						MCPHeader: types.MCPHeader{
-							Name:     "OBOT_URL",
-							Key:      "OBOT_URL",
-							Required: true,
-							Value:    internalURL,
-						},
+						Name:     "OBOT_URL",
+						Key:      "OBOT_URL",
+						Required: true,
+						Value:    internalURL,
 					},
 				},
 			},
@@ -362,10 +355,8 @@ func ensureDefaultUserRoleSetting(ctx context.Context, client kclient.Client) er
 	var defaultRoleSetting v1.UserDefaultRoleSetting
 	if err := client.Get(ctx, kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: system.DefaultRoleSettingName}, &defaultRoleSetting); apierrors.IsNotFound(err) {
 		defaultRoleSetting = v1.UserDefaultRoleSetting{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      system.DefaultRoleSettingName,
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      system.DefaultRoleSettingName,
+			Namespace: system.DefaultNamespace,
 			Spec: v1.UserDefaultRoleSettingSpec{
 				Role: types.RoleBasic,
 			},
@@ -407,10 +398,8 @@ func ensureHostedAgentPoolDefaults(ctx context.Context, client kclient.Client) e
 	}
 
 	return client.Create(ctx, &v1.HostedAgentPoolDefaults{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      key.Name,
-			Namespace: key.Namespace,
-		},
+		Name:      key.Name,
+		Namespace: key.Namespace,
 		Spec: v1.HostedAgentPoolDefaultsSpec{
 			Manifest: types.HostedAgentPoolDefaultsManifest{
 				Capacity: types.HostedAgentResourceQuantity{
@@ -448,10 +437,8 @@ func ensureK8sSettings(ctx context.Context, client kclient.Client, podScheduling
 		// Create default settings
 		// SetViaHelm only applies to pod scheduling settings, not PSA
 		k8sSettings = v1.K8sSettings{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      system.K8sSettingsName,
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      system.K8sSettingsName,
+			Namespace: system.DefaultNamespace,
 			Spec: v1.K8sSettingsSpec{
 				SetViaHelm:         settingsSetViaHelm,
 				MaximumsSetViaHelm: maximumsSetViaHelm,
@@ -657,10 +644,8 @@ func ensureAppPreferences(ctx context.Context, client kclient.Client) error {
 	if apierrors.IsNotFound(err) {
 		// Create default preferences
 		appPrefs = v1.AppPreferences{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      system.AppPreferencesName,
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      system.AppPreferencesName,
+			Namespace: system.DefaultNamespace,
 		}
 		return kclient.IgnoreAlreadyExists(client.Create(ctx, &appPrefs))
 	}

--- a/pkg/controller/data/data.go
+++ b/pkg/controller/data/data.go
@@ -13,7 +13,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -75,10 +74,8 @@ func Data(ctx context.Context, c kclient.Client, defaults Defaults) error {
 		return err
 	} else if len(policies.Items) == 0 && len(defaultModelAccessPolicyResources) > 0 {
 		if err := kclient.IgnoreAlreadyExists(c.Create(ctx, &v1.ModelAccessPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      system.ModelAccessPolicyPrefix + "-default",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      system.ModelAccessPolicyPrefix + "-default",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.ModelAccessPolicySpec{
 				Manifest: types.ModelAccessPolicyManifest{
 					DisplayName: "Default Policy",
@@ -156,10 +153,8 @@ func createDefaultSkillRepository(ctx context.Context, c kclient.Client, repoURL
 	}
 
 	return kclient.IgnoreAlreadyExists(c.Create(ctx, &v1.SkillRepository{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.DefaultSkillRepository,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      system.DefaultSkillRepository,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.SkillRepositorySpec{
 			DisplayName: "Default",
 			RepoURL:     repoURL,
@@ -193,10 +188,8 @@ func createDefaultAgentCatalog(ctx context.Context, c kclient.Client, repoURL, r
 	}
 
 	return kclient.IgnoreAlreadyExists(c.Create(ctx, &v1.AgentCatalog{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.DefaultAgentCatalog,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      system.DefaultAgentCatalog,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.AgentCatalogSpec{
 			AgentCatalogManifest: manifest,
 		},

--- a/pkg/controller/data/data_test.go
+++ b/pkg/controller/data/data_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -244,10 +243,8 @@ func TestDataSeedsDefaultAgentCatalogOnFirstBoot(t *testing.T) {
 	// catalog an admin deleted is not resurrected.
 	t.Run("does not seed when catalogs already exist", func(t *testing.T) {
 		c := newFakeClient(t, &v1.MCPCatalog{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      system.DefaultCatalog,
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      system.DefaultCatalog,
+			Namespace: system.DefaultNamespace,
 		})
 		require.NoError(t, Data(ctx, c, Defaults{HostedAgentsCatalogURL: repoURL}))
 

--- a/pkg/controller/handlers/adminworkspace/adminworkspace.go
+++ b/pkg/controller/handlers/adminworkspace/adminworkspace.go
@@ -9,7 +9,6 @@ import (
 	types2 "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -71,10 +70,8 @@ func (h *Handler) ensureAdminOrOwnerWorkspace(ctx context.Context, client kclien
 
 	// Create PowerUserWorkspace directly for the user
 	workspace := &v1.PowerUserWorkspace{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      system.GetPowerUserWorkspaceID(userIDStr),
-		},
+		Namespace: namespace,
+		Name:      system.GetPowerUserWorkspaceID(userIDStr),
 		Spec: v1.PowerUserWorkspaceSpec{
 			UserID: userIDStr,
 			Role:   user.Role,

--- a/pkg/controller/handlers/agentcatalog/agentcatalog.go
+++ b/pkg/controller/handlers/agentcatalog/agentcatalog.go
@@ -187,14 +187,10 @@ func buildFromSource(repoRoot string, source *v1.AgentCatalog, commitSHA string)
 				return nil, fmt.Errorf("%s: invalid harness: %w", relPath, err)
 			}
 			result.Harnesses = append(result.Harnesses, &v1.Harness{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: v1.SchemeGroupVersion.String(),
-					Kind:       "Harness",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      harnessObjectName(source.Name, relPath),
-					Namespace: source.Namespace,
-				},
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "Harness",
+				Name:       harnessObjectName(source.Name, relPath),
+				Namespace:  source.Namespace,
 				Spec: v1.HarnessSpec{
 					Manifest:     manifest,
 					SourceID:     source.Name,
@@ -216,14 +212,10 @@ func buildFromSource(repoRoot string, source *v1.AgentCatalog, commitSHA string)
 				}
 			}
 			result.Agents = append(result.Agents, &v1.HostedAgent{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: v1.SchemeGroupVersion.String(),
-					Kind:       "HostedAgent",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      agentObjectName(source.Name, relPath),
-					Namespace: source.Namespace,
-				},
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "HostedAgent",
+				Name:       agentObjectName(source.Name, relPath),
+				Namespace:  source.Namespace,
 				Spec: v1.HostedAgentSpec{
 					Manifest:     manifest,
 					SourceID:     source.Name,

--- a/pkg/controller/handlers/agentcatalog/agentcatalog_test.go
+++ b/pkg/controller/handlers/agentcatalog/agentcatalog_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
@@ -37,7 +36,7 @@ questions:
 	require.NoError(t, os.WriteFile(filepath.Join(root, "ignored.yaml"), []byte("not: a definition"), 0o600))
 
 	source := &v1.AgentCatalog{
-		ObjectMeta: metav1.ObjectMeta{Name: "as1source", Namespace: "default"},
+		Name: "as1source", Namespace: "default",
 	}
 	found, err := buildFromSource(root, source, "abc123")
 	require.NoError(t, err)
@@ -69,7 +68,7 @@ unknown: value
 `), 0o600))
 
 		_, err := buildFromSource(root, &v1.AgentCatalog{
-			ObjectMeta: metav1.ObjectMeta{Name: "as1source"},
+			Name: "as1source",
 		}, "abc123")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), `unknown field "unknown"`)
@@ -87,7 +86,7 @@ env:
 `), 0o600))
 
 		_, err := buildFromSource(root, &v1.AgentCatalog{
-			ObjectMeta: metav1.ObjectMeta{Name: "as1source"},
+			Name: "as1source",
 		}, "abc123")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must not be stored in source control")
@@ -133,7 +132,7 @@ func TestGitSourceFetcherLocalRepository(t *testing.T) {
 
 func discoveredHarness(sourceID, relPath string) *v1.Harness {
 	return &v1.Harness{
-		ObjectMeta: metav1.ObjectMeta{Name: harnessObjectName(sourceID, relPath)},
+		Name: harnessObjectName(sourceID, relPath),
 		Spec: v1.HarnessSpec{
 			SourceID:     sourceID,
 			RelativePath: relPath,
@@ -143,7 +142,7 @@ func discoveredHarness(sourceID, relPath string) *v1.Harness {
 
 func discoveredAgent(sourceID, relPath, harnessRef string) *v1.HostedAgent {
 	agent := &v1.HostedAgent{
-		ObjectMeta: metav1.ObjectMeta{Name: agentObjectName(sourceID, relPath)},
+		Name: agentObjectName(sourceID, relPath),
 		Spec: v1.HostedAgentSpec{
 			SourceID:     sourceID,
 			RelativePath: relPath,

--- a/pkg/controller/handlers/alias/alias.go
+++ b/pkg/controller/handlers/alias/alias.go
@@ -10,7 +10,6 @@ import (
 	"github.com/obot-platform/obot/pkg/create"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,9 +54,7 @@ func AssignAlias(req router.Request, resp router.Response) (err error) {
 	}
 
 	alias := &v1.Alias{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: key,
-		},
+		Name: key,
 		Spec: v1.AliasSpec{
 			Name:            aliasable.GetAliasName(),
 			TargetName:      req.Object.GetName(),

--- a/pkg/controller/handlers/cleanup/user_test.go
+++ b/pkg/controller/handlers/cleanup/user_test.go
@@ -5,15 +5,12 @@ import (
 	"testing"
 
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSavedPoolIDs(t *testing.T) {
 	userDelete := &v1.UserDelete{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				hostedAgentPoolCleanupAnnotation: `["pool-a","pool-b"]`,
-			},
+		Annotations: map[string]string{
+			hostedAgentPoolCleanupAnnotation: `["pool-a","pool-b"]`,
 		},
 	}
 	got, err := savedPoolIDs(userDelete)
@@ -27,10 +24,8 @@ func TestSavedPoolIDs(t *testing.T) {
 
 func TestSavedPoolIDsRejectsInvalidCheckpoint(t *testing.T) {
 	userDelete := &v1.UserDelete{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				hostedAgentPoolCleanupAnnotation: "not-json",
-			},
+		Annotations: map[string]string{
+			hostedAgentPoolCleanupAnnotation: "not-json",
 		},
 	}
 	if _, err := savedPoolIDs(userDelete); err == nil {

--- a/pkg/controller/handlers/deployment/deployment_test.go
+++ b/pkg/controller/handlers/deployment/deployment_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -44,10 +43,8 @@ func TestUpdateMCPServerStatusUsesCurrentResourceMaximums(t *testing.T) {
 	require.NotEqual(t, oldHash, newHash)
 
 	server := &v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mcp-server",
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      "mcp-server",
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerSpec{
 			Manifest: types.MCPServerManifest{Runtime: types.RuntimeNPX},
 		},
@@ -57,11 +54,9 @@ func TestUpdateMCPServerStatusUsesCurrentResourceMaximums(t *testing.T) {
 		},
 	}
 	settings := &v1.K8sSettings{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.K8sSettingsName,
-			Namespace: system.DefaultNamespace,
-		},
-		Spec: newSettingsSpec,
+		Name:      system.K8sSettingsName,
+		Namespace: system.DefaultNamespace,
+		Spec:      newSettingsSpec,
 	}
 	storageClient := fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
@@ -77,11 +72,9 @@ func TestUpdateMCPServerStatusUsesCurrentResourceMaximums(t *testing.T) {
 		mcpSessionManager:      manager,
 	}
 	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        server.Name,
-			Annotations: map[string]string{"obot.ai/k8s-settings-hash": newHash},
-			Labels:      map[string]string{"app": server.Name},
-		},
+		Name:        server.Name,
+		Annotations: map[string]string{"obot.ai/k8s-settings-hash": newHash},
+		Labels:      map[string]string{"app": server.Name},
 	}
 
 	err := handler.UpdateMCPServerStatus(router.Request{

--- a/pkg/controller/handlers/gitcredential/gitcredential_test.go
+++ b/pkg/controller/handlers/gitcredential/gitcredential_test.go
@@ -8,30 +8,29 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestSyncReferences(t *testing.T) {
 	credential := &v1.GitCredential{
-		ObjectMeta: metav1.ObjectMeta{Name: "gc1-test", Namespace: "default"},
+		Name: "gc1-test", Namespace: "default",
 	}
 	storage := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
 		&v1.SkillRepository{
-			ObjectMeta: metav1.ObjectMeta{Name: "skills", Namespace: "default"},
+			Name: "skills", Namespace: "default",
 			Spec: v1.SkillRepositorySpec{
 				DisplayName:     "Team Skills",
 				GitCredentialID: credential.Name,
 			},
 		},
 		&v1.MCPCatalog{
-			ObjectMeta: metav1.ObjectMeta{Name: "catalog", Namespace: "default"},
+			Name: "catalog", Namespace: "default",
 			Spec: v1.MCPCatalogSpec{SourceURLGitCredentialIDs: map[string]string{
 				"https://github.com/obot-platform/catalog": credential.Name,
 			}},
 		},
 		&v1.SystemMCPCatalog{
-			ObjectMeta: metav1.ObjectMeta{Name: "system-catalog", Namespace: "default"},
+			Name: "system-catalog", Namespace: "default",
 			Spec: v1.SystemMCPCatalogSpec{SourceURLGitCredentialIDs: map[string]string{
 				"https://github.com/obot-platform/system-catalog": credential.Name,
 			}},
@@ -61,7 +60,7 @@ func TestSyncReferences(t *testing.T) {
 
 func TestSyncReferencesClearsRemovedReferences(t *testing.T) {
 	credential := &v1.GitCredential{
-		ObjectMeta: metav1.ObjectMeta{Name: "gc1-test", Namespace: "default"},
+		Name: "gc1-test", Namespace: "default",
 		Status: v1.GitCredentialStatus{References: v1.GitCredentialReferences{
 			SkillRepositories: []v1.GitCredentialReference{{ID: "removed"}},
 		}},

--- a/pkg/controller/handlers/hostedagent/configshape_test.go
+++ b/pkg/controller/handlers/hostedagent/configshape_test.go
@@ -12,7 +12,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -26,7 +25,7 @@ func TestAgentConfigShape(t *testing.T) {
 		WithScheme(storagescheme.Scheme).
 		WithObjects(
 			&v1.Model{
-				ObjectMeta: metav1.ObjectMeta{Name: "m1sonnet", Namespace: "obot"},
+				Name: "m1sonnet", Namespace: "obot",
 				Spec: v1.ModelSpec{Manifest: types.ModelManifest{
 					Name:          "claude-sonnet",
 					TargetModel:   "claude-sonnet-4-5",
@@ -36,7 +35,7 @@ func TestAgentConfigShape(t *testing.T) {
 				}},
 			},
 			&v1.Model{
-				ObjectMeta: metav1.ObjectMeta{Name: "m1gpt", Namespace: "obot"},
+				Name: "m1gpt", Namespace: "obot",
 				Spec: v1.ModelSpec{Manifest: types.ModelManifest{
 					Name:          "gpt",
 					TargetModel:   "gpt-5",
@@ -46,7 +45,7 @@ func TestAgentConfigShape(t *testing.T) {
 				}},
 			},
 			&v1.Model{
-				ObjectMeta: metav1.ObjectMeta{Name: "m1mini", Namespace: "obot"},
+				Name: "m1mini", Namespace: "obot",
 				Spec: v1.ModelSpec{Manifest: types.ModelManifest{
 					Name:          "gpt-mini",
 					TargetModel:   "gpt-5-mini",
@@ -56,18 +55,18 @@ func TestAgentConfigShape(t *testing.T) {
 				}},
 			},
 			&v1.DefaultModelAlias{
-				ObjectMeta: metav1.ObjectMeta{Name: "llm", Namespace: "obot"},
-				Spec:       v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: "llm", Model: "m1sonnet"}},
+				Name: "llm", Namespace: "obot",
+				Spec: v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: "llm", Model: "m1sonnet"}},
 			},
 			&v1.DefaultModelAlias{
-				ObjectMeta: metav1.ObjectMeta{Name: "llm-mini", Namespace: "obot"},
-				Spec:       v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: "llm-mini", Model: "m1mini"}},
+				Name: "llm-mini", Namespace: "obot",
+				Spec: v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: "llm-mini", Model: "m1mini"}},
 			},
 		).
 		Build()
 
 	instance := &v1.HostedAgentInstance{
-		ObjectMeta: metav1.ObjectMeta{Name: "hai1g26fc", Namespace: "obot", UID: "d47613e8-aede-42f6-a599-9a641f99d8b7"},
+		Name: "hai1g26fc", Namespace: "obot", UID: "d47613e8-aede-42f6-a599-9a641f99d8b7",
 		Spec: v1.HostedAgentInstanceSpec{
 			UserID: "3",
 			Manifest: types.HostedAgentInstanceManifest{
@@ -232,7 +231,7 @@ func TestAgentConfigShape(t *testing.T) {
 func TestCredentialsNeverReachTheRevision(t *testing.T) {
 	builder := defaultDesiredBuilder{ServerURL: "https://obot.example.com"}
 	desired, err := builder.Build(context.Background(), BuildInput{
-		Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}},
+		Instance: &v1.HostedAgentInstance{Name: "hai1", UID: "uid-1"},
 		Agent: &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{
 			MCPServers: []string{"ms1github"},
 		}}},
@@ -258,7 +257,7 @@ func TestConfigChangeChangesTheRevision(t *testing.T) {
 	build := func(servers ...string) string {
 		t.Helper()
 		desired, err := defaultDesiredBuilder{ServerURL: "https://obot.example.com"}.Build(context.Background(), BuildInput{
-			Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}},
+			Instance: &v1.HostedAgentInstance{Name: "hai1", UID: "uid-1"},
 			Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{MCPServers: servers}}},
 			Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
 		})
@@ -282,7 +281,7 @@ func TestPublishedAgentIsToldWhereItIsPublished(t *testing.T) {
 		t.Helper()
 		desired, err := (defaultDesiredBuilder{ServerURL: "https://obot.example.com"}).Build(
 			context.Background(), BuildInput{
-				Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1qhtrt", UID: "uid-1"}},
+				Instance: &v1.HostedAgentInstance{Name: "hai1qhtrt", UID: "uid-1"},
 				Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{Port: port}}},
 				Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
 			})
@@ -331,7 +330,7 @@ func TestSandboxEndpointsUseTheInternalAddress(t *testing.T) {
 
 	desired, err := (defaultDesiredBuilder{ServerURL: public, InternalURL: internal}).Build(
 		context.Background(), BuildInput{
-			Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1qhtrt", UID: "uid-1"}},
+			Instance: &v1.HostedAgentInstance{Name: "hai1qhtrt", UID: "uid-1"},
 			Agent: &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{
 				Port:       8000,
 				MCPServers: []string{"ms1github"},
@@ -373,7 +372,7 @@ func TestSandboxEndpointsUseTheInternalAddress(t *testing.T) {
 func TestInternalAddressFallsBackToPublic(t *testing.T) {
 	desired, err := (defaultDesiredBuilder{ServerURL: "https://obot.example.com"}).Build(
 		context.Background(), BuildInput{
-			Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1qhtrt", UID: "uid-1"}},
+			Instance: &v1.HostedAgentInstance{Name: "hai1qhtrt", UID: "uid-1"},
 			Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: types.HostedAgentManifest{MCPServers: []string{"ms1github"}}}},
 			Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
 		})

--- a/pkg/controller/handlers/hostedagent/gitref_test.go
+++ b/pkg/controller/handlers/hostedagent/gitref_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func buildSource(t *testing.T, agent types.HostedAgentManifest, instance types.HostedAgentInstanceManifest) (string, string) {
@@ -14,8 +13,8 @@ func buildSource(t *testing.T, agent types.HostedAgentManifest, instance types.H
 
 	desired, err := defaultDesiredBuilder{}.Build(context.Background(), BuildInput{
 		Instance: &v1.HostedAgentInstance{
-			ObjectMeta: metav1.ObjectMeta{Name: "hai1", Namespace: "n", UID: "uid-1"},
-			Spec:       v1.HostedAgentInstanceSpec{Manifest: instance, UserID: "u1"},
+			Name: "hai1", Namespace: "n", UID: "uid-1",
+			Spec: v1.HostedAgentInstanceSpec{Manifest: instance, UserID: "u1"},
 		},
 		Agent:   &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: agent}},
 		Harness: &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}},
@@ -69,7 +68,7 @@ func TestChangingTheRefChangesTheRevision(t *testing.T) {
 	instance := types.HostedAgentInstanceManifest{Name: "i"}
 
 	first, err := defaultDesiredBuilder{}.Build(context.Background(), BuildInput{
-		Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}, Spec: v1.HostedAgentInstanceSpec{Manifest: instance}},
+		Instance: &v1.HostedAgentInstance{Name: "hai1", UID: "uid-1", Spec: v1.HostedAgentInstanceSpec{Manifest: instance}},
 		Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: base}},
 		Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}}})
 	if err != nil {
@@ -78,7 +77,7 @@ func TestChangingTheRefChangesTheRevision(t *testing.T) {
 
 	base.GitRef = "v2"
 	second, err := defaultDesiredBuilder{}.Build(context.Background(), BuildInput{
-		Instance: &v1.HostedAgentInstance{ObjectMeta: metav1.ObjectMeta{Name: "hai1", UID: "uid-1"}, Spec: v1.HostedAgentInstanceSpec{Manifest: instance}},
+		Instance: &v1.HostedAgentInstance{Name: "hai1", UID: "uid-1", Spec: v1.HostedAgentInstanceSpec{Manifest: instance}},
 		Agent:    &v1.HostedAgent{Spec: v1.HostedAgentSpec{Manifest: base}},
 		Harness:  &v1.Harness{Spec: v1.HarnessSpec{Manifest: types.HarnessManifest{Image: "img"}}}})
 	if err != nil {

--- a/pkg/controller/handlers/hostedagent/hostedagent.go
+++ b/pkg/controller/handlers/hostedagent/hostedagent.go
@@ -141,10 +141,8 @@ func (h *Handler) EnsurePool(req router.Request, _ router.Response) error {
 
 	poolID, assignmentID := initialPoolNames(instance.Spec.UserID)
 	pool := &v1.HostedAgentPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      poolID,
-			Namespace: req.Namespace,
-		},
+		Name:      poolID,
+		Namespace: req.Namespace,
 		Spec: v1.HostedAgentPoolSpec{
 			Manifest: types.HostedAgentPoolManifest{
 				Capacity:     defaults.Spec.Manifest.Capacity,
@@ -158,10 +156,8 @@ func (h *Handler) EnsurePool(req router.Request, _ router.Response) error {
 	}
 
 	assignment := &v1.HostedAgentPoolAssignment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      assignmentID,
-			Namespace: req.Namespace,
-		},
+		Name:      assignmentID,
+		Namespace: req.Namespace,
 		Spec: v1.HostedAgentPoolAssignmentSpec{
 			Manifest: types.HostedAgentPoolAssignmentManifest{
 				UserID:  instance.Spec.UserID,

--- a/pkg/controller/handlers/hostedagent/hostedagent_test.go
+++ b/pkg/controller/handlers/hostedagent/hostedagent_test.go
@@ -15,11 +15,9 @@ import (
 
 func TestDefaultDesiredBuilder(t *testing.T) {
 	instance := &v1.HostedAgentInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "instance",
-			Namespace: "default",
-			UID:       ktypes.UID("instance-uid"),
-		},
+		Name:      "instance",
+		Namespace: "default",
+		UID:       ktypes.UID("instance-uid"),
 		Spec: v1.HostedAgentInstanceSpec{
 			UserID: "user-1",
 			PoolID: "pool-1",

--- a/pkg/controller/handlers/hostedagent/models_test.go
+++ b/pkg/controller/handlers/hostedagent/models_test.go
@@ -8,13 +8,12 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func modelObj(name, target, provider string) *v1.Model {
 	return &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Name: name, Namespace: "obot",
 		Spec: v1.ModelSpec{Manifest: types.ModelManifest{
 			Name:          name,
 			TargetModel:   target,
@@ -27,8 +26,8 @@ func modelObj(name, target, provider string) *v1.Model {
 
 func aliasObj(name, model string) *v1.DefaultModelAlias {
 	return &v1.DefaultModelAlias{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
-		Spec:       v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: name, Model: model}},
+		Name: name, Namespace: "obot",
+		Spec: v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{Alias: name, Model: model}},
 	}
 }
 

--- a/pkg/controller/handlers/hostedagent/skills_test.go
+++ b/pkg/controller/handlers/hostedagent/skills_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/obot-platform/obot/pkg/agentbackend"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -55,7 +54,7 @@ func TestSkillFilesArePlacedInTheSandbox(t *testing.T) {
 	fetcher := &skillFetcher{cache: map[string][]agentbackend.File{}, clone: clone}
 
 	client := skillClient(&v1.Skill{
-		ObjectMeta: metav1.ObjectMeta{Name: "sk1pdf", Namespace: "obot"},
+		Name: "sk1pdf", Namespace: "obot",
 		Spec: v1.SkillSpec{
 			SkillManifest: types.SkillManifest{Name: "pdf", Description: "Work with PDFs"},
 			RepoURL:       "https://example.com/skills.git",
@@ -109,8 +108,8 @@ func TestSkillNameCannotEscapeTheSkillsDirectory(t *testing.T) {
 		{"", "sk1"},
 	} {
 		skill := &v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "sk1"},
-			Spec:       v1.SkillSpec{SkillManifest: types.SkillManifest{Name: tt.name}},
+			Name: "sk1",
+			Spec: v1.SkillSpec{SkillManifest: types.SkillManifest{Name: tt.name}},
 		}
 		if got := skillDirName(skill); got != tt.want {
 			t.Errorf("skillDirName(%q) = %q, want %q", tt.name, got, tt.want)
@@ -122,8 +121,8 @@ func TestSkillNameCannotEscapeTheSkillsDirectory(t *testing.T) {
 func TestUnfetchableSkillIsSkipped(t *testing.T) {
 	fetcher := &skillFetcher{cache: map[string][]agentbackend.File{}}
 	client := skillClient(&v1.Skill{
-		ObjectMeta: metav1.ObjectMeta{Name: "sk1broken", Namespace: "obot"},
-		Spec:       v1.SkillSpec{SkillManifest: types.SkillManifest{Name: "broken"}},
+		Name: "sk1broken", Namespace: "obot",
+		Spec: v1.SkillSpec{SkillManifest: types.SkillManifest{Name: "broken"}},
 	}).Build()
 
 	files, entries := fetcher.skillFiles(context.Background(), client, "obot", []string{"sk1broken", "sk1missing"})

--- a/pkg/controller/handlers/hostedagentpool/hostedagentpool_test.go
+++ b/pkg/controller/handlers/hostedagentpool/hostedagentpool_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/agentbackend"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestDesiredPoolIsStableAndUsesObotID(t *testing.T) {
@@ -82,7 +81,7 @@ func TestApplyObservationRequiresMatchingReadyRevision(t *testing.T) {
 
 func validPool() *v1.HostedAgentPool {
 	return &v1.HostedAgentPool{
-		ObjectMeta: metav1.ObjectMeta{Name: "pool-1"},
+		Name: "pool-1",
 		Spec: v1.HostedAgentPoolSpec{
 			Manifest: types.HostedAgentPoolManifest{
 				Capacity: types.HostedAgentResourceQuantity{

--- a/pkg/controller/handlers/imagepullsecret/imagepullsecret.go
+++ b/pkg/controller/handlers/imagepullsecret/imagepullsecret.go
@@ -265,10 +265,8 @@ func (h *Handler) createECRServiceAccountToken(ctx context.Context, ecrSpec *api
 	expirationSeconds := int64(3600)
 
 	serviceAccount := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      h.serviceAccountName,
-			Namespace: h.serviceNamespace,
-		},
+		Name:      h.serviceAccountName,
+		Namespace: h.serviceNamespace,
 	}
 	tokenRequest := &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{
@@ -338,10 +336,8 @@ func (h *Handler) writeDockerConfigSecret(ctx context.Context, imagePullSecret *
 	err := h.runtimeClient.Get(ctx, types.NamespacedName{Namespace: h.mcpNamespace, Name: imagePullSecret.Name}, existing)
 	if apierrors.IsNotFound(err) {
 		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      imagePullSecret.Name,
-				Namespace: h.mcpNamespace,
-			},
+			Name:      imagePullSecret.Name,
+			Namespace: h.mcpNamespace,
 		}
 		apply(secret)
 		return h.runtimeClient.Create(ctx, secret)

--- a/pkg/controller/handlers/imagepullsecret/imagepullsecret_test.go
+++ b/pkg/controller/handlers/imagepullsecret/imagepullsecret_test.go
@@ -31,10 +31,8 @@ func TestShouldRefreshECRHonorsManualRequest(t *testing.T) {
 	lastSuccess := metav1.NewTime(now.Add(-time.Hour))
 	lastReconciled := metav1.NewTime(now.Add(-time.Minute))
 	secret := &obotv1.ImagePullSecret{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				imagepullsecrets.AnnotationECRRefreshRequestedAt: now.Format(time.RFC3339Nano),
-			},
+		Annotations: map[string]string{
+			imagepullsecrets.AnnotationECRRefreshRequestedAt: now.Format(time.RFC3339Nano),
 		},
 		Spec: obotv1.ImagePullSecretSpec{
 			ECR: &types.ECRImagePullSecretConfig{

--- a/pkg/controller/handlers/mcpcatalog/catalog_removal_test.go
+++ b/pkg/controller/handlers/mcpcatalog/catalog_removal_test.go
@@ -26,7 +26,7 @@ func TestRemovedEntryWithServerBecomesDetached(t *testing.T) {
 	entry.Labels["example.com/label"] = "keep"
 	entry.Annotations["example.com/annotation"] = "keep"
 	server := &v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "ms1context7", Namespace: catalog.Namespace},
+		Name: "ms1context7", Namespace: catalog.Namespace,
 		Spec: v1.MCPServerSpec{
 			MCPServerCatalogEntryName: entry.Name,
 		},
@@ -79,7 +79,7 @@ func TestEntriesFromRemovedSourceAreDeleted(t *testing.T) {
 	other.Spec.Detached = true
 	delete(other.Labels, apply.LabelHash)
 	server := &v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "ms1context7", Namespace: catalog.Namespace},
+		Name: "ms1context7", Namespace: catalog.Namespace,
 		Spec: v1.MCPServerSpec{
 			MCPServerCatalogEntryName: managed.Name,
 		},
@@ -141,11 +141,9 @@ func TestEntrySuppliedByRemainingSourceIsNotDeleted(t *testing.T) {
 
 func TestFilterConflictingCatalogEntriesReportsObotManagedConflict(t *testing.T) {
 	existing := &v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default-context7-12345678",
-			Namespace: "default",
-		},
-		Spec: v1.MCPServerCatalogEntrySpec{Editable: true},
+		Name:      "default-context7-12345678",
+		Namespace: "default",
+		Spec:      v1.MCPServerCatalogEntrySpec{Editable: true},
 	}
 	desired := existing.DeepCopy()
 	desired.Spec.Editable = false
@@ -161,11 +159,9 @@ func TestFilterConflictingCatalogEntriesReportsObotManagedConflict(t *testing.T)
 
 func TestFilterConflictingCatalogEntriesChecksExactEntryAfterStaleList(t *testing.T) {
 	existing := &v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default-context7-12345678",
-			Namespace: "default",
-		},
-		Spec: v1.MCPServerCatalogEntrySpec{Editable: true},
+		Name:      "default-context7-12345678",
+		Namespace: "default",
+		Spec:      v1.MCPServerCatalogEntrySpec{Editable: true},
 	}
 	desired := existing.DeepCopy()
 	desired.Spec.Editable = false
@@ -233,7 +229,7 @@ func TestFilterConflictingCatalogEntriesAllowsGitManagedEntry(t *testing.T) {
 }
 
 func TestFilterConflictingCatalogEntriesPreservesDuplicateOrder(t *testing.T) {
-	first := &v1.MCPServerCatalogEntry{ObjectMeta: metav1.ObjectMeta{Name: "same", Namespace: "default"}, Spec: v1.MCPServerCatalogEntrySpec{SourceURL: "first"}}
+	first := &v1.MCPServerCatalogEntry{Name: "same", Namespace: "default", Spec: v1.MCPServerCatalogEntrySpec{SourceURL: "first"}}
 	second := first.DeepCopy()
 	second.Spec.SourceURL = "second"
 	c := newCatalogFakeClient()
@@ -251,7 +247,7 @@ func TestReconcileRemovedEntriesListsServersOnce(t *testing.T) {
 	referenced := managedCatalogEntry(t, catalog, "default-referenced-12345678")
 	unused := managedCatalogEntry(t, catalog, "default-unused-12345678")
 	server := &v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "server", Namespace: catalog.Namespace},
+		Name: "server", Namespace: catalog.Namespace,
 		Spec: v1.MCPServerSpec{
 			MCPServerCatalogEntryName: referenced.Name,
 		},
@@ -279,13 +275,11 @@ func TestDetachCatalogEntryIgnoresNotFound(t *testing.T) {
 
 func testCatalog() *v1.MCPCatalog {
 	return &v1.MCPCatalog{
-		TypeMeta: metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.String(), Kind: "MCPCatalog"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default",
-			Namespace: "default",
-			UID:       ktypes.UID("catalog-uid"),
-		},
-		Spec: v1.MCPCatalogSpec{SourceURLs: []string{"github.com/obot-platform/catalog"}},
+		APIVersion: v1.SchemeGroupVersion.String(), Kind: "MCPCatalog",
+		Name:      "default",
+		Namespace: "default",
+		UID:       ktypes.UID("catalog-uid"),
+		Spec:      v1.MCPCatalogSpec{SourceURLs: []string{"github.com/obot-platform/catalog"}},
 	}
 }
 
@@ -294,18 +288,16 @@ func managedCatalogEntry(t *testing.T, catalog *v1.MCPCatalog, name string) *v1.
 	labels, annotations, err := apply.GetLabelsAndAnnotations(scheme.Scheme, "catalog-"+catalog.Name, catalog)
 	require.NoError(t, err)
 	return &v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   catalog.Namespace,
-			Labels:      labels,
-			Annotations: annotations,
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: v1.SchemeGroupVersion.String(),
-				Kind:       "MCPCatalog",
-				Name:       catalog.Name,
-				UID:        catalog.UID,
-			}},
-		},
+		Name:        name,
+		Namespace:   catalog.Namespace,
+		Labels:      labels,
+		Annotations: annotations,
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "MCPCatalog",
+			Name:       catalog.Name,
+			UID:        catalog.UID,
+		}},
 		Spec: v1.MCPServerCatalogEntrySpec{
 			MCPCatalogName: catalog.Name,
 			SourceURL:      "github.com/obot-platform/catalog",

--- a/pkg/controller/handlers/mcpcatalog/composite_refs_test.go
+++ b/pkg/controller/handlers/mcpcatalog/composite_refs_test.go
@@ -11,7 +11,6 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -420,7 +419,7 @@ func TestResolveCompositeSourceRefsSkipsMalformedRef(t *testing.T) {
 func testCatalogEntry(name, sourceID, entryKey string, manifest types.MCPServerCatalogEntryManifest) *v1.MCPServerCatalogEntry {
 	manifest.EntryKey = entryKey
 	return &v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Name: name,
 		Spec: v1.MCPServerCatalogEntrySpec{
 			SourceURL: sourceID,
 			Manifest:  manifest,
@@ -431,7 +430,7 @@ func testCatalogEntry(name, sourceID, entryKey string, manifest types.MCPServerC
 
 func testMCPServer(name, namespace string, manifest types.MCPServerManifest) *v1.MCPServer {
 	return &v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Name: name, Namespace: namespace,
 		Spec: v1.MCPServerSpec{
 			Manifest: manifest,
 		},

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -309,7 +309,7 @@ func reconcileRemovedEntries(ctx context.Context, c kclient.Client, catalog *v1.
 	}
 
 	for entryName := range missingNames {
-		entry := &v1.MCPServerCatalogEntry{ObjectMeta: metav1.ObjectMeta{Name: entryName, Namespace: catalog.Namespace}}
+		entry := &v1.MCPServerCatalogEntry{Name: entryName, Namespace: catalog.Namespace}
 		if err := c.Delete(ctx, entry); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete unused catalog entry %q: %w", entryName, err)
 		}
@@ -614,10 +614,8 @@ func (h *Handler) readSystemMCPCatalog(ctx context.Context, catalogName, sourceU
 		}
 
 		systemObjs = append(systemObjs, &v1.SystemMCPServerCatalogEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name.SafeHashConcatName(catalogName, cleanName),
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      name.SafeHashConcatName(catalogName, cleanName),
+			Namespace: system.DefaultNamespace,
 			Spec: v1.SystemMCPServerCatalogEntrySpec{
 				SystemMCPCatalogName: catalogName,
 				SourceURL:            sourceURL,
@@ -665,10 +663,8 @@ func (h *Handler) readMCPCatalog(ctx context.Context, catalogName, sourceURL, to
 		}
 
 		catalogEntry := v1.MCPServerCatalogEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      catalogEntryName,
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      catalogEntryName,
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPServerCatalogEntrySpec{
 				MCPCatalogName: catalogName,
 				SourceURL:      sourceURL,
@@ -811,10 +807,8 @@ func (h *Handler) SetUpDefaultMCPCatalog(ctx context.Context, c kclient.Client) 
 	}
 
 	if err := c.Create(ctx, &v1.MCPCatalog{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.DefaultCatalog,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      system.DefaultCatalog,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPCatalogSpec{
 			DisplayName: "Default",
 			SourceURLs:  sourceURLs,
@@ -839,10 +833,8 @@ func (h *Handler) SetUpDefaultSystemMCPCatalog(ctx context.Context, c kclient.Cl
 	}
 
 	if err := c.Create(ctx, &v1.SystemMCPCatalog{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.DefaultCatalog,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      system.DefaultCatalog,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.SystemMCPCatalogSpec{
 			DisplayName: "Default",
 			SourceURLs:  sourceURLs,

--- a/pkg/controller/handlers/mcpclientsession/mcpclientsession_test.go
+++ b/pkg/controller/handlers/mcpclientsession/mcpclientsession_test.go
@@ -62,8 +62,8 @@ func TestCleanup(t *testing.T) {
 
 func testSession(name string, lastUsed time.Time) *v1.MCPClientSession {
 	return &v1.MCPClientSession{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
-		Spec:       v1.MCPClientSessionSpec{},
+		Name: name, Namespace: "default",
+		Spec: v1.MCPClientSessionSpec{},
 		Status: v1.MCPClientSessionStatus{
 			LastUsed: metav1.NewTime(lastUsed),
 		},

--- a/pkg/controller/handlers/mcphookcorrelation/mcphookcorrelation_test.go
+++ b/pkg/controller/handlers/mcphookcorrelation/mcphookcorrelation_test.go
@@ -25,11 +25,11 @@ func TestCleanup(t *testing.T) {
 		{name: "deletes expired correlation", createdAt: now.Add(-25 * time.Hour), deleted: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			correlation := &v1.MCPHookCorrelation{ObjectMeta: metav1.ObjectMeta{
+			correlation := &v1.MCPHookCorrelation{
 				Namespace: "default", Name: "correlation",
-			}, Spec: v1.MCPHookCorrelationSpec{
-				ExpiresAt: metav1.NewTime(tt.createdAt.Add(v1.MCPHookCorrelationTTL)),
-			}}
+				Spec: v1.MCPHookCorrelationSpec{
+					ExpiresAt: metav1.NewTime(tt.createdAt.Add(v1.MCPHookCorrelationTTL)),
+				}}
 			client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(correlation).Build()
 			handler := &Handler{now: func() time.Time { return now }}
 			req := router.Request{Client: client, Object: correlation, Ctx: t.Context(), Namespace: correlation.Namespace, Name: correlation.Name}

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -145,10 +145,8 @@ func (h *Handler) EnsureMCPNetworkPolicy(req router.Request, _ router.Response) 
 
 	if len(policies.Items) == 0 {
 		return req.Client.Create(req.Ctx, &v1.MCPNetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: system.MCPNetworkPolicyPrefix,
-				Namespace:    server.Namespace,
-			},
+			GenerateName: system.MCPNetworkPolicyPrefix,
+			Namespace:    server.Namespace,
 			Spec: v1.MCPNetworkPolicySpec{
 				MCPServerName: server.Name,
 				PodSelector: map[string]string{
@@ -771,11 +769,9 @@ func (h *Handler) EnsureMCPServerSecretInfo(req router.Request, _ router.Respons
 	}
 
 	oauthClient := v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       clientID,
-			Namespace:  req.Namespace,
-			Finalizers: []string{v1.OAuthClientFinalizer},
-		},
+		Name:       clientID,
+		Namespace:  req.Namespace,
+		Finalizers: []string{v1.OAuthClientFinalizer},
 		Spec: v1.OAuthClientSpec{
 			Manifest: types.OAuthClientManifest{
 				GrantTypes: []string{"urn:ietf:params:oauth:grant-type:token-exchange"},
@@ -904,11 +900,9 @@ func (h *Handler) EnsureCompositeComponents(req router.Request, _ router.Respons
 				}
 
 				if err := req.Client.Create(req.Ctx, &v1.MCPServerInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: system.MCPServerInstancePrefix,
-						Namespace:    compositeServer.Namespace,
-						Finalizers:   []string{v1.MCPServerInstanceFinalizer},
-					},
+					GenerateName: system.MCPServerInstancePrefix,
+					Namespace:    compositeServer.Namespace,
+					Finalizers:   []string{v1.MCPServerInstanceFinalizer},
 					Spec: v1.MCPServerInstanceSpec{
 						MCPServerName:        component.MCPServerID,
 						MCPCatalogName:       multiUserServer.Spec.MCPCatalogID,
@@ -945,11 +939,9 @@ func (h *Handler) EnsureCompositeComponents(req router.Request, _ router.Respons
 		if existingServer, exists := existingServers[component.CatalogEntryID]; !exists {
 			// New server, create it
 			newServer := withNeedsURL(v1.MCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: system.MCPServerPrefix,
-					Namespace:    compositeServer.Namespace,
-					Finalizers:   []string{v1.MCPServerFinalizer},
-				},
+				GenerateName: system.MCPServerPrefix,
+				Namespace:    compositeServer.Namespace,
+				Finalizers:   []string{v1.MCPServerFinalizer},
 				Spec: v1.MCPServerSpec{
 					Manifest:                  component.Manifest,
 					MCPServerCatalogEntryName: component.CatalogEntryID,

--- a/pkg/controller/handlers/mcpserver/mcpserver_test.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver_test.go
@@ -39,7 +39,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 					Package: "test-package",
 					Args:    []string{"arg1", "arg2"},
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:        "test-server",
@@ -49,7 +49,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 					Package: "test-package",
 					Args:    []string{"arg1", "arg2"},
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			expectedDrift: false,
 			expectedError: false,
@@ -64,7 +64,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 					Package: "@test/package",
 					Args:    []string{"--port", "3000"},
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:        "test-server",
@@ -74,7 +74,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 					Package: "@test/package",
 					Args:    []string{"--port", "3000"},
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			expectedDrift: false,
 			expectedError: false,
@@ -92,7 +92,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 					Port:    8080,
 					Path:    "/mcp",
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:        "test-server",
@@ -105,7 +105,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 					Port:    8080,
 					Path:    "/mcp",
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			expectedDrift: false,
 			expectedError: false,
@@ -119,7 +119,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				RemoteConfig: &types.RemoteRuntimeConfig{
 					URL: "https://api.example.com/mcp",
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:        "test-server",
@@ -128,7 +128,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				RemoteConfig: &types.RemoteCatalogConfig{
 					FixedURL: "https://api.example.com/mcp",
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			expectedDrift: false,
 			expectedError: false,
@@ -143,7 +143,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 					Hostname: "api.example.com",
 					URL:      "https://api.example.com:8080/mcp/path",
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:        "test-server",
@@ -152,7 +152,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				RemoteConfig: &types.RemoteCatalogConfig{
 					Hostname: "api.example.com",
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			expectedDrift: false,
 			expectedError: false,
@@ -345,8 +345,8 @@ func TestConfigurationHasDrifted(t *testing.T) {
 					Package: "test-package",
 				},
 				Env: []types.MCPEnv{
-					{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}},
-					{MCPHeader: types.MCPHeader{Key: "KEY2", Name: "key2"}},
+					{Key: "KEY1", Name: "key1"},
+					{Key: "KEY2", Name: "key2"},
 				},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
@@ -357,8 +357,8 @@ func TestConfigurationHasDrifted(t *testing.T) {
 					Package: "test-package",
 				},
 				Env: []types.MCPEnv{
-					{MCPHeader: types.MCPHeader{Key: "KEY2", Name: "key2"}},
-					{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}},
+					{Key: "KEY2", Name: "key2"},
+					{Key: "KEY1", Name: "key1"},
 				},
 			},
 			expectedDrift: false,
@@ -370,19 +370,17 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
-					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key"}}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
-					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key"}}},
 			},
 			expectedDrift: false,
 			expectedError: false,
@@ -393,19 +391,17 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
-					SecretBinding: &types.MCPSecretBinding{Name: "old-secret", Key: "api-key"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "old-secret", Key: "api-key"}}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
-					SecretBinding: &types.MCPSecretBinding{Name: "new-secret", Key: "api-key"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "new-secret", Key: "api-key"}}},
 			},
 			expectedDrift: true,
 			expectedError: false,
@@ -416,19 +412,17 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
-					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "old-key"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "old-key"}}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
-					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "new-key"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "new-key"}}},
 			},
 			expectedDrift: true,
 			expectedError: false,
@@ -439,24 +433,22 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
 					Name:          "API Key",
 					Required:      true,
 					Sensitive:     true,
-					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key", AdminAdded: true},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key", AdminAdded: true}}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:       "API_KEY",
 					Name:      "API Key",
 					Required:  true,
-					Sensitive: true,
-				}}},
+					Sensitive: true}},
 			},
 			expectedDrift: false,
 			expectedError: false,
@@ -467,13 +459,12 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "ADMIN_API_KEY",
 					Name:          "Admin API Key",
 					Required:      true,
 					Sensitive:     true,
-					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key", AdminAdded: true},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key", AdminAdded: true}}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:      "test-server",
@@ -489,25 +480,23 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
 					Name:          "API Key",
 					Required:      true,
 					Sensitive:     true,
-					SecretBinding: &types.MCPSecretBinding{Name: "admin-secret", Key: "api-key", AdminAdded: true},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "admin-secret", Key: "api-key", AdminAdded: true}}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
 					Name:          "API Key",
 					Required:      true,
 					Sensitive:     true,
-					SecretBinding: &types.MCPSecretBinding{Name: "catalog-secret", Key: "api-key"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "catalog-secret", Key: "api-key"}}},
 			},
 			expectedDrift: true,
 			expectedError: false,
@@ -518,24 +507,22 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:       "API_KEY",
 					Name:      "API Key",
 					Required:  true,
-					Sensitive: true,
-				}}},
+					Sensitive: true}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
 					Name:          "API Key",
 					Required:      true,
 					Sensitive:     true,
-					SecretBinding: &types.MCPSecretBinding{Name: "admin-secret", Key: "api-key", AdminAdded: true},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "admin-secret", Key: "api-key", AdminAdded: true}}},
 			},
 			expectedDrift: false,
 			expectedError: false,
@@ -546,24 +533,22 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:       "API_KEY",
 					Name:      "API Key",
 					Required:  true,
-					Sensitive: true,
-				}}},
+					Sensitive: true}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
 					Name:          "API Key",
 					Required:      true,
 					Sensitive:     true,
-					SecretBinding: &types.MCPSecretBinding{Name: "catalog-secret", Key: "api-key"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "catalog-secret", Key: "api-key"}}},
 			},
 			expectedDrift: true,
 			expectedError: false,
@@ -574,24 +559,22 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:           "API_KEY",
 					Name:          "API Key",
 					Required:      true,
 					Sensitive:     true,
-					SecretBinding: &types.MCPSecretBinding{Name: "catalog-secret", Key: "api-key"},
-				}}},
+					SecretBinding: &types.MCPSecretBinding{Name: "catalog-secret", Key: "api-key"}}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:      "test-server",
 				Runtime:   types.RuntimeUVX,
 				UVXConfig: &types.UVXRuntimeConfig{Package: "test-package"},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+				Env: []types.MCPEnv{{
 					Key:       "API_KEY",
 					Name:      "API Key",
 					Required:  true,
-					Sensitive: true,
-				}}},
+					Sensitive: true}},
 			},
 			expectedDrift: true,
 			expectedError: false,
@@ -854,7 +837,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				UVXConfig: &types.UVXRuntimeConfig{
 					Package: "test-package",
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY1", Name: "key1"}}},
+				Env: []types.MCPEnv{{Key: "KEY1", Name: "key1"}},
 			},
 			entryManifest: types.MCPServerCatalogEntryManifest{
 				Name:        "test-server",
@@ -863,7 +846,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 				UVXConfig: &types.UVXRuntimeConfig{
 					Package: "test-package",
 				},
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "KEY2", Name: "key2"}}},
+				Env: []types.MCPEnv{{Key: "KEY2", Name: "key2"}},
 			},
 			expectedDrift: true,
 			expectedError: false,
@@ -1010,7 +993,7 @@ func TestConfigurationHasDrifted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := &v1.MCPServer{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-server"},
+				Name: "test-server",
 				Spec: v1.MCPServerSpec{
 					UserID:   "test-user",
 					Manifest: tt.serverManifest,
@@ -1040,8 +1023,8 @@ func TestConfigurationHasDriftedRestoresStaticValuesWithoutMutatingServer(t *tes
 	referenceManifest := types.MCPServerCatalogEntryManifest{
 		Runtime: types.RuntimeRemote,
 		Env: []types.MCPEnv{
-			{MCPHeader: types.MCPHeader{Key: "STATIC_ENV", Value: "stored-env"}},
-			{MCPHeader: types.MCPHeader{Key: "DYNAMIC_ENV"}},
+			{Key: "STATIC_ENV", Value: "stored-env"},
+			{Key: "DYNAMIC_ENV"},
 		},
 		RemoteConfig: &types.RemoteCatalogConfig{
 			FixedURL: "https://api.example.com/mcp",
@@ -1052,14 +1035,14 @@ func TestConfigurationHasDriftedRestoresStaticValuesWithoutMutatingServer(t *tes
 		},
 	}
 	server := &v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "shared-server"},
+		Name: "shared-server",
 		Spec: v1.MCPServerSpec{
 			MCPCatalogID: "default",
 			Manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeRemote,
 				Env: []types.MCPEnv{
-					{MCPHeader: types.MCPHeader{Key: "STATIC_ENV"}},
-					{MCPHeader: types.MCPHeader{Key: "DYNAMIC_ENV"}},
+					{Key: "STATIC_ENV"},
+					{Key: "DYNAMIC_ENV"},
 				},
 				RemoteConfig: &types.RemoteRuntimeConfig{
 					URL: "https://api.example.com/mcp",
@@ -1304,14 +1287,10 @@ func newFakeClient(t *testing.T, objects ...kclient.Object) kclient.WithWatch {
 
 func newMCPServer(name string) *v1.MCPServer {
 	return &v1.MCPServer{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "MCPServer",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "MCPServer",
+		Name:       name,
+		Namespace:  "default",
 	}
 }
 
@@ -1450,12 +1429,11 @@ func TestDetectDriftClearsMultiUserCatalogEntryDeploymentWithAdminAddedEnvBindin
 			Port:  8080,
 			Path:  "/mcp",
 		},
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:       "API_KEY",
 			Name:      "API Key",
 			Required:  true,
-			Sensitive: true,
-		}}},
+			Sensitive: true}},
 	})
 	server := newMCPServer("shared-server")
 	server.Spec.MCPCatalogID = "default"
@@ -1468,13 +1446,12 @@ func TestDetectDriftClearsMultiUserCatalogEntryDeploymentWithAdminAddedEnvBindin
 			Port:  8080,
 			Path:  "/mcp",
 		},
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:           "API_KEY",
 			Name:          "API Key",
 			Required:      true,
 			Sensitive:     true,
-			SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key", AdminAdded: true},
-		}}},
+			SecretBinding: &types.MCPSecretBinding{Name: "bound-secret", Key: "api-key", AdminAdded: true}}},
 	}
 	server.Status.NeedsUpdate = true
 
@@ -1512,14 +1489,10 @@ func TestDetectDriftReturnsConfigurationComparisonError(t *testing.T) {
 
 func newMCPServerCatalogEntry(name string, manifest types.MCPServerCatalogEntryManifest) *v1.MCPServerCatalogEntry {
 	return &v1.MCPServerCatalogEntry{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "MCPServerCatalogEntry",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "MCPServerCatalogEntry",
+		Name:       name,
+		Namespace:  "default",
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Manifest: manifest,
 		},
@@ -1788,10 +1761,8 @@ func TestEnsureMCPNetworkPolicyCreatesDenyAllPolicy(t *testing.T) {
 func TestEnsureMCPNetworkPolicyDeletesPolicyWhenProviderDisabled(t *testing.T) {
 	server := newMCPServer("no-provider-server")
 	existing := &v1.MCPNetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      server.Name,
-			Namespace: server.Namespace,
-		},
+		Name:      server.Name,
+		Namespace: server.Namespace,
 		Spec: v1.MCPNetworkPolicySpec{
 			MCPServerName: server.Name,
 		},
@@ -1850,10 +1821,8 @@ func TestEnsureMCPNetworkPolicyDeletesPolicyForUnsupportedRuntime(t *testing.T) 
 	server.Spec.Manifest.RemoteConfig = &types.RemoteRuntimeConfig{URL: "https://example.com/mcp"}
 
 	existing := &v1.MCPNetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      server.Name,
-			Namespace: server.Namespace,
-		},
+		Name:      server.Name,
+		Namespace: server.Namespace,
 		Spec: v1.MCPNetworkPolicySpec{
 			MCPServerName: server.Name,
 		},

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
@@ -9,7 +9,6 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -121,12 +120,11 @@ func TestDetectCompositeDriftIgnoresAdminAddedSecretBindings(t *testing.T) {
 			Port:  8080,
 			Path:  "/mcp",
 		},
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:       "API_KEY",
 			Name:      "API Key",
 			Required:  true,
-			Sensitive: true,
-		}}},
+			Sensitive: true}},
 	}
 	compositeEntry := newMCPServerCatalogEntry("composite-entry", types.MCPServerCatalogEntryManifest{
 		Name:    "Composite Entry",
@@ -147,13 +145,12 @@ func TestDetectCompositeDriftIgnoresAdminAddedSecretBindings(t *testing.T) {
 			Port:  8080,
 			Path:  "/mcp",
 		},
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:           "API_KEY",
 			Name:          "API Key",
 			Required:      true,
 			Sensitive:     true,
-			SecretBinding: binding,
-		}}},
+			SecretBinding: binding}},
 	})
 	client := newFakeClient(compositeEntry, sharedServer)
 	err := (&Handler{}).DetectCompositeDrift(router.Request{
@@ -236,14 +233,10 @@ func newFakeClient(objects ...kclient.Object) kclient.WithWatch {
 
 func newMCPServerCatalogEntry(name string, manifest types.MCPServerCatalogEntryManifest) *v1.MCPServerCatalogEntry {
 	return &v1.MCPServerCatalogEntry{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "MCPServerCatalogEntry",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "MCPServerCatalogEntry",
+		Name:       name,
+		Namespace:  "default",
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Manifest: manifest,
 		},
@@ -386,14 +379,10 @@ func TestEnsureUserCountSingleUserEntryCountsUniqueServerUsers(t *testing.T) {
 
 func newMCPServer(name string, manifest types.MCPServerManifest) *v1.MCPServer {
 	return &v1.MCPServer{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "MCPServer",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "MCPServer",
+		Name:       name,
+		Namespace:  "default",
 		Spec: v1.MCPServerSpec{
 			Manifest: manifest,
 		},

--- a/pkg/controller/handlers/mcpwebhookvalidation/mcpwebhookvalidation.go
+++ b/pkg/controller/handlers/mcpwebhookvalidation/mcpwebhookvalidation.go
@@ -14,7 +14,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Handler struct {
@@ -128,13 +127,13 @@ func desiredSystemServer(webhookValidation *v1.MCPWebhookValidation, image strin
 			},
 			Env: []types.MCPEnv{
 				{
-					MCPHeader: types.MCPHeader{Key: "WEBHOOK_URL", Value: webhookValidation.Spec.Manifest.URL},
+					Key: "WEBHOOK_URL", Value: webhookValidation.Spec.Manifest.URL,
 				},
 				{
-					MCPHeader: types.MCPHeader{Key: "WEBHOOK_SECRET", Sensitive: true},
+					Key: "WEBHOOK_SECRET", Sensitive: true,
 				},
 				{
-					MCPHeader: types.MCPHeader{Key: "PORT", Value: "8099"},
+					Key: "PORT", Value: "8099",
 				},
 			},
 		}
@@ -149,11 +148,9 @@ func desiredSystemServer(webhookValidation *v1.MCPWebhookValidation, image strin
 	}
 
 	return v1.SystemMCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       system.SystemMCPServerPrefix + webhookValidation.Name,
-			Namespace:  webhookValidation.Namespace,
-			Finalizers: []string{v1.SystemMCPServerFinalizer},
-		},
+		Name:       system.SystemMCPServerPrefix + webhookValidation.Name,
+		Namespace:  webhookValidation.Namespace,
+		Finalizers: []string{v1.SystemMCPServerFinalizer},
 		Spec: v1.SystemMCPServerSpec{
 			WebhookValidationName: webhookValidation.Name,
 			Manifest:              manifest,

--- a/pkg/controller/handlers/mcpwebhookvalidation/mcpwebhookvalidation_test.go
+++ b/pkg/controller/handlers/mcpwebhookvalidation/mcpwebhookvalidation_test.go
@@ -23,7 +23,7 @@ func TestDesiredSystemServer_CopiesProvidedManifest(t *testing.T) {
 			Path:  "/custom",
 		},
 		Env: []types.MCPEnv{{
-			MCPHeader: types.MCPHeader{Key: "CUSTOM", Value: "1"},
+			Key: "CUSTOM", Value: "1",
 		}},
 	}
 

--- a/pkg/controller/handlers/mdmassetsource/mdmassetsource.go
+++ b/pkg/controller/handlers/mdmassetsource/mdmassetsource.go
@@ -189,10 +189,8 @@ func (h *Handler) sync(ctx context.Context, c kclient.Client, source *v1.MDMAsse
 
 	manifest := loader.Manifest()
 	asset := &v1.MDMAsset{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      v1.MDMAssetName(digest),
-			Namespace: source.Namespace,
-		},
+		Name:      v1.MDMAssetName(digest),
+		Namespace: source.Namespace,
 		Spec: v1.MDMAssetSpec{
 			Digest:            digest,
 			SchemaVersion:     manifest.SchemaVersion,
@@ -282,10 +280,8 @@ func (h *Handler) pruneUnused(ctx context.Context, c kclient.Client, retainDiges
 // Changes to the default source value are picked up by `Handler.Sync` during normal reconciliation.
 func (h *Handler) SetUpDefaultMDMAssetSource(ctx context.Context, c kclient.Client) error {
 	source := v1.MDMAssetSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.DefaultMDMAssetSource,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      system.DefaultMDMAssetSource,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MDMAssetSourceSpec{
 			MDMAssetSourceManifest: types.MDMAssetSourceManifest{Source: h.defaultSource},
 		},

--- a/pkg/controller/handlers/mdmassetsource/mdmassetsource_test.go
+++ b/pkg/controller/handlers/mdmassetsource/mdmassetsource_test.go
@@ -334,14 +334,10 @@ func newTestGatewayClient(t *testing.T) *gatewayclient.Client {
 
 func newTestMDMAssetSource(source string) *v1.MDMAssetSource {
 	return &v1.MDMAssetSource{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "MDMAssetSource",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.DefaultMDMAssetSource,
-			Namespace: system.DefaultNamespace,
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "MDMAssetSource",
+		Name:       system.DefaultMDMAssetSource,
+		Namespace:  system.DefaultNamespace,
 		Spec: v1.MDMAssetSourceSpec{
 			MDMAssetSourceManifest: clienttypes.MDMAssetSourceManifest{Source: source},
 		},
@@ -350,11 +346,9 @@ func newTestMDMAssetSource(source string) *v1.MDMAssetSource {
 
 func newTestMDMAsset(digest string) *v1.MDMAsset {
 	return &v1.MDMAsset{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      v1.MDMAssetName(digest),
-			Namespace: system.DefaultNamespace,
-		},
-		Spec: v1.MDMAssetSpec{Digest: digest},
+		Name:      v1.MDMAssetName(digest),
+		Namespace: system.DefaultNamespace,
+		Spec:      v1.MDMAssetSpec{Digest: digest},
 	}
 }
 

--- a/pkg/controller/handlers/model/model_test.go
+++ b/pkg/controller/handlers/model/model_test.go
@@ -9,20 +9,18 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestRemoveApplyUpdateAnnotation(t *testing.T) {
-	model := &v1.Model{ObjectMeta: metav1.ObjectMeta{
+	model := &v1.Model{
 		Name:      "model",
 		Namespace: "default",
 		Annotations: map[string]string{
 			apply.AnnotationUpdate: "false",
 			"keep":                 "value",
-		},
-	}}
+		}}
 	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(model).Build()
 
 	if err := new(Handler).RemoveApplyUpdateAnnotation(router.Request{
@@ -47,17 +45,15 @@ func TestRemoveApplyUpdateAnnotation(t *testing.T) {
 
 func TestEnsureModelInfoUsesExactProviderAndTargetModel(t *testing.T) {
 	model := &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{Name: "gpt-4o", Namespace: system.DefaultNamespace},
+		Name: "gpt-4o", Namespace: system.DefaultNamespace,
 		Spec: v1.ModelSpec{Manifest: types.ModelManifest{
 			ModelProvider: system.AzureEntraModelProvider,
 			TargetModel:   "gpt-4o",
 		}},
 	}
 	modelInfo := &v1.ModelInfo{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      v1.ModelInfoName(system.AzureEntraModelProvider, "gpt-4o"),
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      v1.ModelInfoName(system.AzureEntraModelProvider, "gpt-4o"),
+		Namespace: system.DefaultNamespace,
 		Spec: v1.ModelInfoSpec{
 			Provider: system.AzureEntraModelProvider,
 			Model:    "gpt-4o",

--- a/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
+++ b/pkg/controller/handlers/modelaccesspolicy/modelaccesspolicy_test.go
@@ -10,17 +10,14 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestPruneDefaultPolicy(t *testing.T) {
 	existingModel := &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "m1-existing",
-			Namespace: "default",
-		},
+		Name:      "m1-existing",
+		Namespace: "default",
 		Spec: v1.ModelSpec{
 			Manifest: types.ModelManifest{
 				Usage: types.ModelUsageLLM,
@@ -28,10 +25,8 @@ func TestPruneDefaultPolicy(t *testing.T) {
 		},
 	}
 	embeddingModel := &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "m1-embedding",
-			Namespace: "default",
-		},
+		Name:      "m1-embedding",
+		Namespace: "default",
 		Spec: v1.ModelSpec{
 			Manifest: types.ModelManifest{
 				Usage: types.ModelUsageEmbedding,
@@ -139,10 +134,8 @@ func TestPruneDefaultPolicy(t *testing.T) {
 			client := fake.NewClientBuilder().
 				WithScheme(storagescheme.Scheme).
 				WithObjects(existingModel, embeddingModel, &v1.ModelAccessPolicy{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      policyName,
-						Namespace: system.DefaultNamespace,
-					},
+					Name:      policyName,
+					Namespace: system.DefaultNamespace,
 					Spec: v1.ModelAccessPolicySpec{
 						Manifest: types.ModelAccessPolicyManifest{
 							Subjects: []types.Subject{{Type: types.SubjectTypeUser, ID: "u1"}},

--- a/pkg/controller/handlers/modelinfosource/modelinfosource.go
+++ b/pkg/controller/handlers/modelinfosource/modelinfosource.go
@@ -82,10 +82,8 @@ func (h *Handler) Sync(req router.Request, resp router.Response) error {
 // SetUpDefaultModelInfoSource reconciles the default ModelInfoSource from config.
 func (h *Handler) SetUpDefaultModelInfoSource(ctx context.Context, c kclient.Client) error {
 	source := &v1.ModelInfoSource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.DefaultModelInfoSource,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      system.DefaultModelInfoSource,
+		Namespace: system.DefaultNamespace,
 	}
 	if h.defaultSourceURL == "" {
 		if err := c.Delete(ctx, source); apierrors.IsNotFound(err) {

--- a/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
+++ b/pkg/controller/handlers/modelinfosource/modelinfosource_test.go
@@ -174,14 +174,10 @@ func newFakeClient(t *testing.T, objects ...kclient.Object) kclient.WithWatch {
 
 func newModelInfoSource(sourceURL string) *v1.ModelInfoSource {
 	return &v1.ModelInfoSource{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "ModelInfoSource",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default",
-			Namespace: system.DefaultNamespace,
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "ModelInfoSource",
+		Name:       "default",
+		Namespace:  system.DefaultNamespace,
 		Spec: v1.ModelInfoSourceSpec{
 			Manifest: types.ModelInfoSourceManifest{URL: sourceURL},
 		},

--- a/pkg/controller/handlers/modelinfosource/modelsdev.go
+++ b/pkg/controller/handlers/modelinfosource/modelsdev.go
@@ -9,7 +9,6 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -91,10 +90,8 @@ func parseModelInfos(namespace, sourceName string, doc modelsDevDocument) ([]kcl
 
 		for modelID, m := range provider.Models {
 			infos = append(infos, &v1.ModelInfo{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-					Name:      v1.ModelInfoName(obotProvider, modelID),
-				},
+				Namespace: namespace,
+				Name:      v1.ModelInfoName(obotProvider, modelID),
 				Spec: v1.ModelInfoSpec{
 					ModelInfoSourceName: sourceName,
 					Provider:            obotProvider,

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -26,7 +26,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	sigsyaml "sigs.k8s.io/yaml"
 )
@@ -100,24 +99,20 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 
 		expectedEnv := []types.MCPEnv{
 			{
-				MCPHeader: types.MCPHeader{
-					Name:        "NANOBOT_ENV_FILE",
-					Description: "Environment variables file for Nanobot",
-					Key:         "NANOBOT_ENV_FILE",
-					Sensitive:   true,
-					Required:    true,
-				},
+				Name:        "NANOBOT_ENV_FILE",
+				Description: "Environment variables file for Nanobot",
+				Key:         "NANOBOT_ENV_FILE",
+				Sensitive:   true,
+				Required:    true,
 				File:        true,
 				DynamicFile: true,
 			},
 			{
-				MCPHeader: types.MCPHeader{
-					Name:        "NANOBOT_CONFIG_FILE",
-					Description: "Provider config YAML for Nanobot",
-					Key:         "NANOBOT_CONFIG_FILE",
-					Sensitive:   true,
-					Required:    true,
-				},
+				Name:        "NANOBOT_CONFIG_FILE",
+				Description: "Provider config YAML for Nanobot",
+				Key:         "NANOBOT_CONFIG_FILE",
+				Sensitive:   true,
+				Required:    true,
 				File:        true,
 				DynamicFile: true,
 			},
@@ -160,10 +155,8 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 	}
 
 	mcpServer := &v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      mcpServerName,
-			Namespace: agent.Namespace,
-		},
+		Name:      mcpServerName,
+		Namespace: agent.Namespace,
 		Spec: v1.MCPServerSpec{
 			UserID:         agent.Spec.UserID,
 			NanobotAgentID: agent.Name,
@@ -182,24 +175,20 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 				},
 				Env: []types.MCPEnv{
 					{
-						MCPHeader: types.MCPHeader{
-							Name:        "NANOBOT_ENV_FILE",
-							Description: "Environment variables file for Nanobot",
-							Key:         "NANOBOT_ENV_FILE",
-							Sensitive:   true,
-							Required:    true,
-						},
+						Name:        "NANOBOT_ENV_FILE",
+						Description: "Environment variables file for Nanobot",
+						Key:         "NANOBOT_ENV_FILE",
+						Sensitive:   true,
+						Required:    true,
 						File:        true,
 						DynamicFile: true,
 					},
 					{
-						MCPHeader: types.MCPHeader{
-							Name:        "NANOBOT_CONFIG_FILE",
-							Description: "Provider config YAML for Nanobot",
-							Key:         "NANOBOT_CONFIG_FILE",
-							Sensitive:   true,
-							Required:    true,
-						},
+						Name:        "NANOBOT_CONFIG_FILE",
+						Description: "Provider config YAML for Nanobot",
+						Key:         "NANOBOT_CONFIG_FILE",
+						Sensitive:   true,
+						Required:    true,
 						File:        true,
 						DynamicFile: true,
 					},

--- a/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent_test.go
@@ -8,7 +8,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	sigsyaml "sigs.k8s.io/yaml"
 )
@@ -16,7 +15,7 @@ import (
 func TestChooseModelPrefersKnownNames(t *testing.T) {
 	models := []v1.Model{
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "ollama-qwen3"},
+			Name: "ollama-qwen3",
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "other",
@@ -27,7 +26,7 @@ func TestChooseModelPrefersKnownNames(t *testing.T) {
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "openai-gpt-5.4"},
+			Name: "openai-gpt-5.4",
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "gpt-5.4",
@@ -52,7 +51,7 @@ func TestChooseModelPrefersKnownNames(t *testing.T) {
 func TestChooseModelFallsBackToFirstActiveModel(t *testing.T) {
 	models := []v1.Model{
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "groq-llama-3.1-70b-versatile"},
+			Name: "groq-llama-3.1-70b-versatile",
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "model-a",
@@ -77,7 +76,7 @@ func TestChooseModelFallsBackToFirstActiveModel(t *testing.T) {
 func TestChooseModelPrefersSuggestedOrder(t *testing.T) {
 	models := []v1.Model{
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "anthropic-claude-sonnet-4-6"},
+			Name: "anthropic-claude-sonnet-4-6",
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "claude-sonnet-4-6",
@@ -88,7 +87,7 @@ func TestChooseModelPrefersSuggestedOrder(t *testing.T) {
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "openai-gpt-5.4"},
+			Name: "openai-gpt-5.4",
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "gpt-5.4",
@@ -388,15 +387,15 @@ func TestResolveModelCarriesProviderAndDialect(t *testing.T) {
 		WithScheme(storagescheme.Scheme).
 		WithObjects(
 			&v1.DefaultModelAlias{
-				TypeMeta:   metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.String(), Kind: "DefaultModelAlias"},
-				ObjectMeta: metav1.ObjectMeta{Name: "llm"},
+				APIVersion: v1.SchemeGroupVersion.String(), Kind: "DefaultModelAlias",
+				Name: "llm",
 				Spec: v1.DefaultModelAliasSpec{
 					Manifest: types.DefaultModelAliasManifest{Alias: "llm", Model: "groq-llama"},
 				},
 			},
 			&v1.Model{
-				TypeMeta:   metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.String(), Kind: "Model"},
-				ObjectMeta: metav1.ObjectMeta{Name: "groq-llama"},
+				APIVersion: v1.SchemeGroupVersion.String(), Kind: "Model",
+				Name: "groq-llama",
 				Spec: v1.ModelSpec{
 					Manifest: types.ModelManifest{
 						Name:          "groq-llama",
@@ -482,13 +481,9 @@ func TestChooseModelMiniFallsBackToResolvedLLM(t *testing.T) {
 		WithScheme(storagescheme.Scheme).
 		WithObjects(
 			&v1.DefaultModelAlias{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: v1.SchemeGroupVersion.String(),
-					Kind:       "DefaultModelAlias",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "llm",
-				},
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "DefaultModelAlias",
+				Name:       "llm",
 				Spec: v1.DefaultModelAliasSpec{
 					Manifest: types.DefaultModelAliasManifest{
 						Alias: "llm",
@@ -497,13 +492,9 @@ func TestChooseModelMiniFallsBackToResolvedLLM(t *testing.T) {
 				},
 			},
 			&v1.Model{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: v1.SchemeGroupVersion.String(),
-					Kind:       "Model",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "openai-gpt-5.4",
-				},
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "Model",
+				Name:       "openai-gpt-5.4",
 				Spec: v1.ModelSpec{
 					Manifest: types.ModelManifest{
 						Name:        "gpt-5.4",
@@ -518,7 +509,7 @@ func TestChooseModelMiniFallsBackToResolvedLLM(t *testing.T) {
 
 	models := []v1.Model{
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "openai-gpt-5.4"},
+			Name: "openai-gpt-5.4",
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:        "gpt-5.4",

--- a/pkg/controller/handlers/poweruserworkspace/poweruserworkspace.go
+++ b/pkg/controller/handlers/poweruserworkspace/poweruserworkspace.go
@@ -15,7 +15,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -122,10 +121,8 @@ func (h *Handler) createWorkspaceWithRole(ctx context.Context, client kclient.Cl
 	userIDStr := strconv.Itoa(int(user.ID))
 
 	workspace := &v1.PowerUserWorkspace{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      system.GetPowerUserWorkspaceID(userIDStr),
-		},
+		Namespace: namespace,
+		Name:      system.GetPowerUserWorkspaceID(userIDStr),
 		Spec: v1.PowerUserWorkspaceSpec{
 			UserID: userIDStr,
 			Role:   role,
@@ -266,11 +263,9 @@ func (h *Handler) createDefaultAccessControlRule(ctx context.Context, client kcl
 
 	// For power user plus and admin, generate a rule that gives all users access
 	defaultACR := &v1.AccessControlRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    namespace,
-			GenerateName: system.AccessControlRulePrefix,
-			Finalizers:   []string{v1.AccessControlRuleFinalizer},
-		},
+		Namespace:    namespace,
+		GenerateName: system.AccessControlRulePrefix,
+		Finalizers:   []string{v1.AccessControlRuleFinalizer},
 		Spec: v1.AccessControlRuleSpec{
 			PowerUserWorkspaceID: workspace.Name,
 			Generated:            true,

--- a/pkg/controller/handlers/project/project.go
+++ b/pkg/controller/handlers/project/project.go
@@ -10,7 +10,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,14 +36,12 @@ func (h *Handler) MigrateProjectV2(req router.Request, _ router.Response) error 
 	}
 
 	project := &v1.Project{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.ProjectPrefix,
-			Namespace:    projectV2.Namespace,
-			Labels:       maps.Clone(projectV2.Labels),
-			Annotations:  maps.Clone(projectV2.Annotations),
-		},
-		Spec:   projectV2.Spec,
-		Status: projectV2.Status,
+		GenerateName: system.ProjectPrefix,
+		Namespace:    projectV2.Namespace,
+		Labels:       maps.Clone(projectV2.Labels),
+		Annotations:  maps.Clone(projectV2.Annotations),
+		Spec:         projectV2.Spec,
+		Status:       projectV2.Status,
 	}
 
 	if err := req.Client.Create(req.Ctx, project); err != nil {

--- a/pkg/controller/handlers/provider/provider.go
+++ b/pkg/controller/handlers/provider/provider.go
@@ -28,7 +28,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"go.yaml.in/yaml/v3"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -204,9 +203,7 @@ func appendProviders(registryPath string, authProviderManifests []providerFromFi
 		m.Manifest.Command = path.Join(registryPath, m.Manifest.Command)
 
 		objs = append(objs, &v1.ModelProvider{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: m.Name,
-			},
+			Name: m.Name,
 			Spec: v1.ModelProviderSpec{
 				ModelProviderManifest: m.Manifest,
 			},
@@ -222,9 +219,7 @@ func appendProviders(registryPath string, authProviderManifests []providerFromFi
 		a.Manifest.Command = path.Join(registryPath, a.Manifest.Command)
 
 		objs = append(objs, &v1.AuthProvider{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: a.Name,
-			},
+			Name: a.Name,
 			Spec: v1.AuthProviderSpec{
 				AuthProviderManifest: a.Manifest,
 			},
@@ -516,10 +511,8 @@ func BackPopulateModels(ctx context.Context, client kclient.Client, dispatcher *
 		}
 		dialect := modelDialect(model.Metadata, modelProvider.Spec.Dialect)
 		discovered := &v1.Model{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: modelProvider.Namespace,
-				Name:      modelName(modelProvider.Name, model.ID),
-			},
+			Namespace: modelProvider.Namespace,
+			Name:      modelName(modelProvider.Name, model.ID),
 			Spec: v1.ModelSpec{
 				Manifest: types.ModelManifest{
 					Name:          strings.ReplaceAll(model.ID, "/", "-"),

--- a/pkg/controller/handlers/scheduledauditlogexport/scheduledauditlogexport.go
+++ b/pkg/controller/handlers/scheduledauditlogexport/scheduledauditlogexport.go
@@ -55,10 +55,8 @@ func createExportFromSchedule(req router.Request, scheduledExport *v1.ScheduledA
 	}
 
 	export := &v1.AuditLogExport{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.AuditLogExportPrefix,
-			Namespace:    scheduledExport.Namespace,
-		},
+		GenerateName: system.AuditLogExportPrefix,
+		Namespace:    scheduledExport.Namespace,
 		Spec: v1.AuditLogExportSpec{
 			Name:                   fmt.Sprintf("%s-%d", scheduledExport.Spec.Name, scheduledExport.Status.TotalExportsCreated+1),
 			Type:                   scheduledExport.Spec.EffectiveType(),

--- a/pkg/controller/handlers/scheduledauditlogexport/scheduledauditlogexport_test.go
+++ b/pkg/controller/handlers/scheduledauditlogexport/scheduledauditlogexport_test.go
@@ -21,7 +21,7 @@ func TestCreateExportFromSchedule(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	next := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
 	scheduled := &v1.ScheduledAuditLogExport{
-		ObjectMeta: metav1.ObjectMeta{Name: "scheduled", Namespace: "default"},
+		Name: "scheduled", Namespace: "default",
 		Spec: v1.ScheduledAuditLogExportSpec{
 			Name:                   "weekly",
 			Type:                   types.AuditLogTypeLLM,
@@ -84,8 +84,8 @@ func TestGetScheduleAndTimezone(t *testing.T) {
 
 func TestCalculateNextRunTimeWithNilLastRunAt(t *testing.T) {
 	scheduledExport := &v1.ScheduledAuditLogExport{
-		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC))},
-		Spec:       v1.ScheduledAuditLogExportSpec{Schedule: v1.Schedule{Interval: "hourly", Minute: 30, TimeZone: "UTC"}},
+		CreationTimestamp: metav1.NewTime(time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)),
+		Spec:              v1.ScheduledAuditLogExportSpec{Schedule: v1.Schedule{Interval: "hourly", Minute: 30, TimeZone: "UTC"}},
 	}
 
 	next, err := calculateNextRunTime(scheduledExport)

--- a/pkg/controller/handlers/skillrepository/scan.go
+++ b/pkg/controller/handlers/skillrepository/scan.go
@@ -116,14 +116,10 @@ func buildSkill(dirPath, relPath string, repo *v1.SkillRepository, commitSHA str
 	}
 
 	skill := &v1.Skill{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "Skill",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      skillObjectName(repo.Name, relPath),
-			Namespace: repo.Namespace,
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "Skill",
+		Name:       skillObjectName(repo.Name, relPath),
+		Namespace:  repo.Namespace,
 		Spec: v1.SkillSpec{
 			SkillManifest: types.SkillManifest{
 				Name:           skillName,

--- a/pkg/controller/handlers/skillrepository/scan_test.go
+++ b/pkg/controller/handlers/skillrepository/scan_test.go
@@ -132,14 +132,10 @@ func TestDiscoverSkillDirectories(t *testing.T) {
 
 func testRepo(name, namespace string) *v1.SkillRepository {
 	return &v1.SkillRepository{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "SkillRepository",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "SkillRepository",
+		Name:       name,
+		Namespace:  namespace,
 		Spec: v1.SkillRepositorySpec{
 			RepoURL: "https://github.com/owner/repo",
 			Ref:     "main",

--- a/pkg/controller/handlers/skillrepository/skillrepository_test.go
+++ b/pkg/controller/handlers/skillrepository/skillrepository_test.go
@@ -54,14 +54,10 @@ func newFakeClient(t *testing.T, objects ...kclient.Object) kclient.WithWatch {
 // newSkillRepository creates a test SkillRepository resource.
 func newSkillRepository(name, namespace string) *v1.SkillRepository {
 	return &v1.SkillRepository{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "SkillRepository",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "SkillRepository",
+		Name:       name,
+		Namespace:  namespace,
 		Spec: v1.SkillRepositorySpec{
 			RepoURL:     "https://github.com/owner/repo",
 			Ref:         "main",
@@ -73,14 +69,10 @@ func newSkillRepository(name, namespace string) *v1.SkillRepository {
 // newSkill creates a test Skill resource for the given repo.
 func newSkill(name, namespace, repoID, description string) *v1.Skill {
 	return &v1.Skill{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1.SchemeGroupVersion.String(),
-			Kind:       "Skill",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
+		APIVersion: v1.SchemeGroupVersion.String(),
+		Kind:       "Skill",
+		Name:       name,
+		Namespace:  namespace,
 		Spec: v1.SkillSpec{
 			SkillManifest: types.SkillManifest{
 				Name:        name,
@@ -692,7 +684,7 @@ func TestMaterializeSkillSource(t *testing.T) {
 
 	t.Run("missing repoURL", func(t *testing.T) {
 		skill := &v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-skill"},
+			Name: "test-skill",
 			Spec: v1.SkillSpec{
 				CommitSHA:    "abc123",
 				RelativePath: "my-skill",
@@ -705,7 +697,7 @@ func TestMaterializeSkillSource(t *testing.T) {
 
 	t.Run("missing commitSHA", func(t *testing.T) {
 		skill := &v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-skill"},
+			Name: "test-skill",
 			Spec: v1.SkillSpec{
 				RepoURL:      "https://github.com/owner/repo",
 				RelativePath: "my-skill",
@@ -718,7 +710,7 @@ func TestMaterializeSkillSource(t *testing.T) {
 
 	t.Run("missing relativePath", func(t *testing.T) {
 		skill := &v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-skill"},
+			Name: "test-skill",
 			Spec: v1.SkillSpec{
 				RepoURL:   "https://github.com/owner/repo",
 				CommitSHA: "abc123",
@@ -749,7 +741,7 @@ func TestMaterializeSkillSource(t *testing.T) {
 		}
 
 		skill := &v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-skill"},
+			Name: "test-skill",
 			Spec: v1.SkillSpec{
 				RepoURL:      "https://github.com/owner/repo",
 				RepoRef:      "main",
@@ -783,7 +775,7 @@ func TestMaterializeSkillSource(t *testing.T) {
 		}
 
 		skill := &v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-skill"},
+			Name: "test-skill",
 			Spec: v1.SkillSpec{
 				RepoURL:      "https://github.com/owner/repo",
 				CommitSHA:    "abc123",
@@ -810,7 +802,7 @@ func TestMaterializeSkillSource(t *testing.T) {
 		}
 
 		skill := &v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-skill"},
+			Name: "test-skill",
 			Spec: v1.SkillSpec{
 				RepoURL:      "https://github.com/owner/repo",
 				CommitSHA:    "abc123",
@@ -843,7 +835,7 @@ func TestMaterializeSkillSource(t *testing.T) {
 		}
 
 		skill := &v1.Skill{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-skill"},
+			Name: "test-skill",
 			Spec: v1.SkillSpec{
 				RepoURL:      "https://github.com/owner/repo",
 				CommitSHA:    "abc123",

--- a/pkg/controller/handlers/systemmcpserver/systemmcpserver.go
+++ b/pkg/controller/handlers/systemmcpserver/systemmcpserver.go
@@ -20,7 +20,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/utils"
 	"golang.org/x/crypto/bcrypt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -106,11 +105,9 @@ func (h *Handler) EnsureSecretInfo(req router.Request, _ router.Response) error 
 	}
 
 	oauthClient := v1.OAuthClient{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       clientID,
-			Namespace:  req.Namespace,
-			Finalizers: []string{v1.OAuthClientFinalizer},
-		},
+		Name:       clientID,
+		Namespace:  req.Namespace,
+		Finalizers: []string{v1.OAuthClientFinalizer},
 		Spec: v1.OAuthClientSpec{
 			Manifest: types.OAuthClientManifest{
 				GrantTypes: []string{"urn:ietf:params:oauth:grant-type:token-exchange"},

--- a/pkg/controller/handlers/tunnelpeer/tunnelpeer_test.go
+++ b/pkg/controller/handlers/tunnelpeer/tunnelpeer_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/obot-platform/obot/pkg/tunnel"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -219,12 +218,10 @@ func endpointSlice(name string, addressType discoveryv1.AddressType, port int32,
 
 func endpointSliceWithPorts(name string, addressType discoveryv1.AddressType, ports []discoveryv1.EndpointPort, endpoints ...discoveryv1.Endpoint) *discoveryv1.EndpointSlice {
 	return &discoveryv1.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "obot-system",
-			Labels: map[string]string{
-				discoveryv1.LabelServiceName: "obot",
-			},
+		Name:      name,
+		Namespace: "obot-system",
+		Labels: map[string]string{
+			discoveryv1.LabelServiceName: "obot",
 		},
 		AddressType: addressType,
 		Ports:       ports,

--- a/pkg/controller/hostedagentpooldefaults_test.go
+++ b/pkg/controller/hostedagentpooldefaults_test.go
@@ -8,7 +8,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -54,7 +53,7 @@ func TestEnsureHostedAgentPoolDefaults(t *testing.T) {
 
 func TestEnsureHostedAgentPoolDefaultsPreservesExisting(t *testing.T) {
 	existing := &v1.HostedAgentPoolDefaults{
-		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: system.DefaultNamespace},
+		Name: "default", Namespace: system.DefaultNamespace,
 		Spec: v1.HostedAgentPoolDefaultsSpec{
 			Manifest: types.HostedAgentPoolDefaultsManifest{
 				Capacity: types.HostedAgentResourceQuantity{

--- a/pkg/controller/k8ssettings_test.go
+++ b/pkg/controller/k8ssettings_test.go
@@ -10,17 +10,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestEnsureK8sSettingsRejectsExistingConfiguredResourcesAboveStartupMaximum(t *testing.T) {
 	ctx := t.Context()
 	client := newFakeClient(t, &v1.K8sSettings{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.K8sSettingsName,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      system.K8sSettingsName,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.K8sSettingsSpec{
 			Resources: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -85,11 +82,9 @@ func TestEnsureK8sSettingsLocksMaximumsConfiguredThroughHelm(t *testing.T) {
 		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
 	}
 	client := newFakeClient(t, &v1.K8sSettings{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.K8sSettingsName,
-			Namespace: system.DefaultNamespace,
-		},
-		Spec: v1.K8sSettingsSpec{Resources: existingResources},
+		Name:      system.K8sSettingsName,
+		Namespace: system.DefaultNamespace,
+		Spec:      v1.K8sSettingsSpec{Resources: existingResources},
 	})
 	maximum := resource.MustParse("2Gi")
 

--- a/pkg/controller/migrate_test.go
+++ b/pkg/controller/migrate_test.go
@@ -40,10 +40,8 @@ func TestMigrateDefaultModelAccessPolicyModels(t *testing.T) {
 		}}
 		client := newFakeClient(t,
 			&v1.ModelAccessPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      defaultPolicyName,
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      defaultPolicyName,
+				Namespace: system.DefaultNamespace,
 				Spec: v1.ModelAccessPolicySpec{
 					Manifest: types.ModelAccessPolicyManifest{
 						DisplayName: "Customized Default Policy",
@@ -61,10 +59,8 @@ func TestMigrateDefaultModelAccessPolicyModels(t *testing.T) {
 				},
 			},
 			&v1.ModelAccessPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "custom-policy",
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      "custom-policy",
+				Namespace: system.DefaultNamespace,
 				Spec: v1.ModelAccessPolicySpec{
 					Manifest: types.ModelAccessPolicyManifest{
 						Subjects: subjects,
@@ -79,10 +75,8 @@ func TestMigrateDefaultModelAccessPolicyModels(t *testing.T) {
 				},
 			},
 			&v1.Model{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "m1-custom",
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      "m1-custom",
+				Namespace: system.DefaultNamespace,
 				Spec: v1.ModelSpec{
 					Manifest: types.ModelManifest{
 						Usage: types.ModelUsageLLM,
@@ -129,14 +123,10 @@ func TestMigratePublishedArtifactVisibility(t *testing.T) {
 	t.Run("migrates public and private artifacts", func(t *testing.T) {
 		client := newFakeClient(t,
 			&v1.PublishedArtifact{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: v1.SchemeGroupVersion.String(),
-					Kind:       "PublishedArtifact",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "public-artifact",
-					Namespace: system.DefaultNamespace,
-				},
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "PublishedArtifact",
+				Name:       "public-artifact",
+				Namespace:  system.DefaultNamespace,
 				Spec: v1.PublishedArtifactSpec{
 					LegacyVisibility: "public",
 				},
@@ -148,14 +138,10 @@ func TestMigratePublishedArtifactVisibility(t *testing.T) {
 				},
 			},
 			&v1.PublishedArtifact{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: v1.SchemeGroupVersion.String(),
-					Kind:       "PublishedArtifact",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "private-artifact",
-					Namespace: system.DefaultNamespace,
-				},
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "PublishedArtifact",
+				Name:       "private-artifact",
+				Namespace:  system.DefaultNamespace,
 				Spec: v1.PublishedArtifactSpec{
 					LegacyVisibility: "private",
 				},
@@ -196,14 +182,10 @@ func TestMigratePublishedArtifactVisibility(t *testing.T) {
 	t.Run("sets no subjects for invalid legacy visibility", func(t *testing.T) {
 		client := newFakeClient(t,
 			&v1.PublishedArtifact{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: v1.SchemeGroupVersion.String(),
-					Kind:       "PublishedArtifact",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bad-artifact",
-					Namespace: system.DefaultNamespace,
-				},
+				APIVersion: v1.SchemeGroupVersion.String(),
+				Kind:       "PublishedArtifact",
+				Name:       "bad-artifact",
+				Namespace:  system.DefaultNamespace,
 				Spec: v1.PublishedArtifactSpec{
 					LegacyVisibility: "friends-only",
 				},
@@ -231,30 +213,30 @@ func TestMigrateAuditLogExportSourceTypes(t *testing.T) {
 	ctx := t.Context()
 	client := newFakeClient(t,
 		&v1.ScheduledAuditLogExport{
-			ObjectMeta: metav1.ObjectMeta{Name: "legacy-with-filters", Namespace: system.DefaultNamespace},
+			Name: "legacy-with-filters", Namespace: system.DefaultNamespace,
 			Spec: v1.ScheduledAuditLogExportSpec{
 				Filters: &types.AuditLogExportFilters{MCPIDs: []string{"mcp-1"}},
 			},
 		},
 		&v1.ScheduledAuditLogExport{
-			ObjectMeta: metav1.ObjectMeta{Name: "legacy-without-filters", Namespace: system.DefaultNamespace},
+			Name: "legacy-without-filters", Namespace: system.DefaultNamespace,
 		},
 		&v1.ScheduledAuditLogExport{
-			ObjectMeta: metav1.ObjectMeta{Name: "already-explicit", Namespace: system.DefaultNamespace},
+			Name: "already-explicit", Namespace: system.DefaultNamespace,
 			Spec: v1.ScheduledAuditLogExportSpec{
 				Filters: &types.AuditLogExportFilters{SourceTypes: []types.AuditLogSourceType{types.AuditLogSourceTypeMCP}},
 			},
 		},
 		&v1.ScheduledAuditLogExport{
-			ObjectMeta: metav1.ObjectMeta{Name: "local-agent", Namespace: system.DefaultNamespace},
+			Name: "local-agent", Namespace: system.DefaultNamespace,
 			Spec: v1.ScheduledAuditLogExportSpec{
 				Type:    types.AuditLogTypeMCP,
 				Filters: &types.AuditLogExportFilters{SourceTypes: []types.AuditLogSourceType{types.AuditLogSourceTypeLocalAgentToolCall}},
 			},
 		},
 		&v1.ScheduledAuditLogExport{
-			ObjectMeta: metav1.ObjectMeta{Name: "llm", Namespace: system.DefaultNamespace},
-			Spec:       v1.ScheduledAuditLogExportSpec{Type: types.AuditLogTypeLLM},
+			Name: "llm", Namespace: system.DefaultNamespace,
+			Spec: v1.ScheduledAuditLogExportSpec{Type: types.AuditLogTypeLLM},
 		},
 	)
 
@@ -288,50 +270,38 @@ func TestDeleteToolReferenceOwnedModels(t *testing.T) {
 	ctx := t.Context()
 	client := newFakeClient(t,
 		&v1.Model{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: v1.SchemeGroupVersion.String(),
-				Kind:       "Model",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "tool-reference-owned",
-				Namespace: system.DefaultNamespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: v1.SchemeGroupVersion.String(),
-						Kind:       "ToolReference",
-						Name:       "tool",
-						UID:        ktypes.UID("tool-uid"),
-					},
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "Model",
+			Name:       "tool-reference-owned",
+			Namespace:  system.DefaultNamespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "ToolReference",
+					Name:       "tool",
+					UID:        ktypes.UID("tool-uid"),
 				},
 			},
 		},
 		&v1.Model{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: v1.SchemeGroupVersion.String(),
-				Kind:       "Model",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "model-provider-owned",
-				Namespace: system.DefaultNamespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion: v1.SchemeGroupVersion.String(),
-						Kind:       "ModelProvider",
-						Name:       "provider",
-						UID:        ktypes.UID("provider-uid"),
-					},
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "Model",
+			Name:       "model-provider-owned",
+			Namespace:  system.DefaultNamespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: v1.SchemeGroupVersion.String(),
+					Kind:       "ModelProvider",
+					Name:       "provider",
+					UID:        ktypes.UID("provider-uid"),
 				},
 			},
 		},
 		&v1.Model{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: v1.SchemeGroupVersion.String(),
-				Kind:       "Model",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "unowned",
-				Namespace: system.DefaultNamespace,
-			},
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       "Model",
+			Name:       "unowned",
+			Namespace:  system.DefaultNamespace,
 		},
 	)
 
@@ -358,20 +328,14 @@ func TestExtractAndClearMCPServerConfigValues(t *testing.T) {
 	manifest := types.MCPServerManifest{
 		Env: []types.MCPEnv{
 			{
-				MCPHeader: types.MCPHeader{
-					Key:   "TOKEN",
-					Value: "secret-token",
-				},
+				Key:   "TOKEN",
+				Value: "secret-token",
 			},
 			{
-				MCPHeader: types.MCPHeader{
-					Key: "EMPTY",
-				},
+				Key: "EMPTY",
 			},
 			{
-				MCPHeader: types.MCPHeader{
-					Value: "missing-key",
-				},
+				Value: "missing-key",
 			},
 		},
 		RemoteConfig: &types.RemoteRuntimeConfig{
@@ -405,9 +369,7 @@ func TestExtractAndClearMCPServerConfigValuesNoValues(t *testing.T) {
 	manifest := types.MCPServerManifest{
 		Env: []types.MCPEnv{
 			{
-				MCPHeader: types.MCPHeader{
-					Key: "TOKEN",
-				},
+				Key: "TOKEN",
 			},
 		},
 	}
@@ -420,20 +382,20 @@ func TestExtractAndClearMCPServerConfigValuesNoValues(t *testing.T) {
 
 func TestMCPServerCredentialContext(t *testing.T) {
 	assert.Equal(t, "default-server-1", mcpServerCredentialContext(v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "server-1"},
+		Name: "server-1",
 		Spec: v1.MCPServerSpec{
 			MCPCatalogID: "default",
 		},
 	}))
 
 	assert.Equal(t, "workspace-1-server-2", mcpServerCredentialContext(v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "server-2"},
+		Name: "server-2",
 		Spec: v1.MCPServerSpec{
 			PowerUserWorkspaceID: "workspace-1",
 		},
 	}))
 
 	assert.Empty(t, mcpServerCredentialContext(v1.MCPServer{
-		ObjectMeta: metav1.ObjectMeta{Name: "server-3"},
+		Name: "server-3",
 	}))
 }

--- a/pkg/gateway/client/apikey_cache_test.go
+++ b/pkg/gateway/client/apikey_cache_test.go
@@ -107,14 +107,12 @@ func TestValidatedAPIKeyCacheReturnsDeepCopy(t *testing.T) {
 	}
 
 	original := &types.APIKey{
-		ID:     1,
-		UserID: 7,
-		Name:   "cache-key",
-		APIKeyScopes: types.APIKeyScopes{
-			MCPServerIDs: []string{"server-a"},
-		},
-		LastUsedAt: &lastUsedAt,
-		ExpiresAt:  &expiresAt,
+		ID:           1,
+		UserID:       7,
+		Name:         "cache-key",
+		MCPServerIDs: []string{"server-a"},
+		LastUsedAt:   &lastUsedAt,
+		ExpiresAt:    &expiresAt,
 	}
 
 	now := time.Now()

--- a/pkg/gateway/client/device_limit_test.go
+++ b/pkg/gateway/client/device_limit_test.go
@@ -95,8 +95,7 @@ func TestEnrollDeviceAllowsExistingDeviceWhenOverLimit(t *testing.T) {
 	if err == nil {
 		t.Fatal("re-enrolling existing device with a different key succeeded")
 	}
-	var httpErr *apitypes.ErrHTTP
-	if errors.As(err, &httpErr) {
+	if httpErr, ok := errors.AsType[*apitypes.ErrHTTP](err); ok {
 		t.Fatalf("different-key error = HTTP %d, want identity-key error", httpErr.Code)
 	}
 

--- a/pkg/gateway/client/group.go
+++ b/pkg/gateway/client/group.go
@@ -18,7 +18,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -275,10 +274,8 @@ func (c *Client) persistGroups(ctx context.Context, identity *types.Identity) er
 	// If memberships changed, trigger reconciliation for this user
 	if membershipsChanged {
 		if err := c.storageClient.Create(ctx, &v1.UserRoleChange{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: system.UserRoleChangePrefix,
-				Namespace:    system.DefaultNamespace,
-			},
+			GenerateName: system.UserRoleChangePrefix,
+			Namespace:    system.DefaultNamespace,
 			Spec: v1.UserRoleChangeSpec{
 				UserID: identity.UserID,
 			},
@@ -291,10 +288,8 @@ func (c *Client) persistGroups(ctx context.Context, identity *types.Identity) er
 	// If user lost groups, trigger MCP server cleanup
 	if groupsLost {
 		if err := c.storageClient.Create(ctx, &v1.UserGroupChange{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: system.UserGroupChangePrefix,
-				Namespace:    system.DefaultNamespace,
-			},
+			GenerateName: system.UserGroupChangePrefix,
+			Namespace:    system.DefaultNamespace,
 			Spec: v1.UserGroupChangeSpec{
 				UserID: identity.UserID,
 			},

--- a/pkg/gateway/client/identity.go
+++ b/pkg/gateway/client/identity.go
@@ -19,7 +19,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/storage/value"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -565,10 +564,8 @@ func (c *Client) createUserRoleChangeForNewUser(ctx context.Context, user *types
 	// Always create UserRoleChange for new users to trigger reconciliation
 	// The handler will check effective role and create workspace if needed
 	if err := c.storageClient.Create(ctx, &v1.UserRoleChange{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.UserRoleChangePrefix,
-			Namespace:    system.DefaultNamespace,
-		},
+		GenerateName: system.UserRoleChangePrefix,
+		Namespace:    system.DefaultNamespace,
 		Spec: v1.UserRoleChangeSpec{
 			UserID: user.ID,
 		},

--- a/pkg/gateway/client/identity_user_limit_postgres_test.go
+++ b/pkg/gateway/client/identity_user_limit_postgres_test.go
@@ -20,7 +20,6 @@ import (
 	storageservices "github.com/obot-platform/obot/pkg/storage/services"
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -184,10 +183,8 @@ func newPostgresUserLimitTestClient(database *gatewaydb.DB) *Client {
 	storageClient := fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
 		WithObjects(&v1.UserDefaultRoleSetting{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.DefaultNamespace,
-				Name:      system.DefaultRoleSettingName,
-			},
+			Namespace: system.DefaultNamespace,
+			Name:      system.DefaultRoleSettingName,
 			Spec: v1.UserDefaultRoleSettingSpec{
 				Role: apitypes.RoleBasic,
 			},

--- a/pkg/gateway/client/identity_user_limit_test.go
+++ b/pkg/gateway/client/identity_user_limit_test.go
@@ -14,7 +14,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -25,10 +24,8 @@ func newIdentityUserLimitTestClient(t *testing.T) *Client {
 	c.storageClient = fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
 		WithObjects(&v1.UserDefaultRoleSetting{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.DefaultNamespace,
-				Name:      system.DefaultRoleSettingName,
-			},
+			Namespace: system.DefaultNamespace,
+			Name:      system.DefaultRoleSettingName,
 			Spec: v1.UserDefaultRoleSettingSpec{
 				Role: apitypes.RoleBasic,
 			},

--- a/pkg/gateway/client/okta_group_migration.go
+++ b/pkg/gateway/client/okta_group_migration.go
@@ -15,7 +15,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const oktaGroupMigrationName = "okta_group_id_migration"
@@ -170,11 +169,9 @@ func (c *Client) migrateOktaGroupIDs(ctx context.Context, authProviderURL, authP
 		// creates the object, and if creation fails the claim row is rolled back,
 		// allowing a retry on the next authentication request.
 		if err := c.storageClient.Create(ctx, &v1.OktaGroupMigration{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: system.OktaGroupMigrationPrefix,
-				Namespace:    system.DefaultNamespace,
-			},
-			Spec: v1.OktaGroupMigrationSpec{IDMapping: idMap},
+			GenerateName: system.OktaGroupMigrationPrefix,
+			Namespace:    system.DefaultNamespace,
+			Spec:         v1.OktaGroupMigrationSpec{IDMapping: idMap},
 		}); err != nil {
 			return fmt.Errorf("failed to create OktaGroupMigration task: %w", err)
 		}

--- a/pkg/gateway/server/apikey_auth_test.go
+++ b/pkg/gateway/server/apikey_auth_test.go
@@ -16,7 +16,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -143,7 +142,7 @@ func TestModelAllowedForAgent(t *testing.T) {
 
 func llmModel(name, target, provider string) *v1.Model {
 	return &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: system.DefaultNamespace},
+		Name: name, Namespace: system.DefaultNamespace,
 		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{
 			Name: name, TargetModel: target, ModelProvider: provider,
 			Active: true, Usage: types2.ModelUsageLLM,
@@ -174,8 +173,8 @@ func TestAgentModelAliasesAreExpandedForAuthorization(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
 		llmModel("m1sonnet", "claude-sonnet-4-5", "anthropic-model-provider"),
 		&v1.DefaultModelAlias{
-			ObjectMeta: metav1.ObjectMeta{Name: "llm", Namespace: system.DefaultNamespace},
-			Spec:       v1.DefaultModelAliasSpec{Manifest: types2.DefaultModelAliasManifest{Alias: "llm", Model: "m1sonnet"}},
+			Name: "llm", Namespace: system.DefaultNamespace,
+			Spec: v1.DefaultModelAliasSpec{Manifest: types2.DefaultModelAliasManifest{Alias: "llm", Model: "m1sonnet"}},
 		},
 	).Build()
 
@@ -198,8 +197,8 @@ func TestAgentModelAliasesAreExpandedForAuthorization(t *testing.T) {
 func TestUnboundAliasGrantsNothing(t *testing.T) {
 	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(
 		&v1.DefaultModelAlias{
-			ObjectMeta: metav1.ObjectMeta{Name: "llm", Namespace: system.DefaultNamespace},
-			Spec:       v1.DefaultModelAliasSpec{Manifest: types2.DefaultModelAliasManifest{Alias: "llm"}},
+			Name: "llm", Namespace: system.DefaultNamespace,
+			Spec: v1.DefaultModelAliasSpec{Manifest: types2.DefaultModelAliasManifest{Alias: "llm"}},
 		},
 	).Build()
 

--- a/pkg/gateway/server/grouproleassignment.go
+++ b/pkg/gateway/server/grouproleassignment.go
@@ -14,7 +14,6 @@ import (
 	"github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // getGroupRoleAssignments returns all group role assignments.
@@ -166,10 +165,8 @@ func (s *Server) deleteGroupRoleAssignment(apiContext api.Context) error {
 func (s *Server) triggerReconciliationForGroup(apiContext api.Context, groupName string) error {
 	// Create a single GroupRoleChange event that will trigger reconciliation for all users in the group
 	if err := apiContext.Create(&v1.GroupRoleChange{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.GroupRoleChangePrefix,
-			Namespace:    apiContext.Namespace(),
-		},
+		GenerateName: system.GroupRoleChangePrefix,
+		Namespace:    apiContext.Namespace(),
 		Spec: v1.GroupRoleChangeSpec{
 			GroupName: groupName,
 		},

--- a/pkg/gateway/server/llmproxy_test.go
+++ b/pkg/gateway/server/llmproxy_test.go
@@ -22,7 +22,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/tidwall/gjson"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -591,7 +590,7 @@ func TestAPIKeyTransportHeaders(t *testing.T) {
 func TestAPIKeyBackendTransportRequiresCredentialValue(t *testing.T) {
 	const apiKeyEnv = "OPENAI_MODEL_PROVIDER_API_KEY"
 	provider := v1.ModelProvider{
-		ObjectMeta: metav1.ObjectMeta{Name: system.OpenAIModelProvider},
+		Name: system.OpenAIModelProvider,
 		Spec: v1.ModelProviderSpec{ModelProviderManifest: types2.ModelProviderManifest{
 			CommonProviderMetadata: types2.CommonProviderMetadata{
 				RequiredConfigurationParameters: []types2.ProviderConfigurationParameter{{Name: apiKeyEnv}},

--- a/pkg/gateway/server/llmproxy_usage_test.go
+++ b/pkg/gateway/server/llmproxy_usage_test.go
@@ -200,11 +200,11 @@ func TestMessageTokenUsageTracker_CacheWriteSplitPricing(t *testing.T) {
 func TestEffectiveTokenCost_ContextTier(t *testing.T) {
 	size := 200000
 	cost := types2.ModelCost{
-		TokenUsageCost: types2.TokenUsageCost{Input: 2.5, Output: 15, CacheRead: 0.25},
+		Input: 2.5, Output: 15, CacheRead: 0.25,
 		Tiers: []types2.ModelCostTier{{
-			TokenUsageCost: types2.TokenUsageCost{Input: 5, Output: 22.5, CacheRead: 0.5},
-			Type:           types2.ModelCostTierTypeContext,
-			Size:           &size,
+			Input: 5, Output: 22.5, CacheRead: 0.5,
+			Type: types2.ModelCostTierTypeContext,
+			Size: &size,
 		}},
 	}
 
@@ -223,8 +223,8 @@ func TestEffectiveTokenCost_ContextTier(t *testing.T) {
 func TestMessageTokenUsageTracker_TierByContextSize(t *testing.T) {
 	size := 200000
 	cost := types2.ModelCost{
-		TokenUsageCost: types2.TokenUsageCost{Input: 5},
-		Tiers:          []types2.ModelCostTier{{TokenUsageCost: types2.TokenUsageCost{Input: 10}, Type: types2.ModelCostTierTypeContext, Size: &size}},
+		Input: 5,
+		Tiers: []types2.ModelCostTier{{Input: 10, Type: types2.ModelCostTierTypeContext, Size: &size}},
 	}
 	c := &messageTokenUsageTracker{cost: cost}
 	c.addTokenUsage([]byte(`{"usage":{"input_tokens":150000,"cache_read_input_tokens":60000,"output_tokens":0}}`))

--- a/pkg/gateway/server/token_test.go
+++ b/pkg/gateway/server/token_test.go
@@ -22,7 +22,6 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	sservices "github.com/obot-platform/obot/pkg/storage/services"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -282,12 +281,12 @@ func newTokenRequestTestServer(t *testing.T) (*Server, *client.Client) {
 	}
 
 	provider := &v1.AuthProvider{
-		ObjectMeta: metav1.ObjectMeta{Name: "github", Namespace: system.DefaultNamespace},
-		Status:     v1.AuthProviderStatus{Configured: true},
+		Name: "github", Namespace: system.DefaultNamespace,
+		Status: v1.AuthProviderStatus{Configured: true},
 	}
 	defaultRole := &v1.UserDefaultRoleSetting{
-		ObjectMeta: metav1.ObjectMeta{Name: system.DefaultRoleSettingName, Namespace: system.DefaultNamespace},
-		Spec:       v1.UserDefaultRoleSettingSpec{Role: clienttypes.RoleBasic},
+		Name: system.DefaultRoleSettingName, Namespace: system.DefaultNamespace,
+		Spec: v1.UserDefaultRoleSettingSpec{Role: clienttypes.RoleBasic},
 	}
 	storageClient := clientfake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -16,7 +16,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"gorm.io/gorm"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
@@ -73,9 +72,7 @@ func (s *Server) getUsers(apiContext api.Context) error {
 		trimmedUsers := make([]types2.User, 0, len(validUsers))
 		for _, u := range validUsers {
 			trimmedUsers = append(trimmedUsers, types2.User{
-				Metadata: types2.Metadata{
-					ID: fmt.Sprint(u.ID),
-				},
+				ID:          fmt.Sprint(u.ID),
 				DisplayName: u.DisplayName,
 			})
 		}
@@ -140,9 +137,7 @@ func (s *Server) getUser(apiContext api.Context) error {
 	// Basic and Power users are only allowed to access IDs and display names, so we have all the information needed for that.
 	if userIsBasicOrPower(apiContext.User) {
 		return apiContext.Write(types2.User{
-			Metadata: types2.Metadata{
-				ID: fmt.Sprint(user.ID),
-			},
+			ID:          fmt.Sprint(user.ID),
 			DisplayName: user.DisplayName,
 		})
 	}
@@ -229,10 +224,8 @@ func (s *Server) updateUser(apiContext api.Context) error {
 	if originalUser.Role != existingUser.Role {
 		slog.Info("User role changed via API", "userID", existingUser.ID, "oldRole", originalUser.Role, "newRole", existingUser.Role)
 		if err = apiContext.Create(&v1.UserRoleChange{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: system.UserRoleChangePrefix,
-				Namespace:    apiContext.Namespace(),
-			},
+			GenerateName: system.UserRoleChangePrefix,
+			Namespace:    apiContext.Namespace(),
 			Spec: v1.UserRoleChangeSpec{
 				UserID: existingUser.ID,
 			},
@@ -314,10 +307,8 @@ func (s *Server) deleteUser(apiContext api.Context) (err error) {
 	}
 
 	if err = apiContext.Create(&v1.UserDelete{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: system.UserDeletePrefix,
-			Namespace:    apiContext.Namespace(),
-		},
+		GenerateName: system.UserDeletePrefix,
+		Namespace:    apiContext.Namespace(),
 		Spec: v1.UserDeleteSpec{
 			UserID: existingUser.ID,
 		},

--- a/pkg/gateway/types/devicescan.go
+++ b/pkg/gateway/types/devicescan.go
@@ -130,18 +130,16 @@ type DeviceScanFile struct {
 // must already be loaded (via Preload) for them to appear in the result.
 func ConvertDeviceScan(s DeviceScan) types2.DeviceScan {
 	out := types2.DeviceScan{
-		ID:          s.ID,
-		ReceivedAt:  *types2.NewTime(s.CreatedAt),
-		SubmittedBy: s.SubmittedBy,
-		DeviceScanManifest: types2.DeviceScanManifest{
-			ScannerVersion: s.ScannerVersion,
-			ScannedAt:      *types2.NewTime(s.ScannedAt),
-			DeviceID:       s.DeviceID,
-			Hostname:       s.Hostname,
-			OS:             s.OS,
-			Arch:           s.Arch,
-			Username:       s.Username,
-		},
+		ID:             s.ID,
+		ReceivedAt:     *types2.NewTime(s.CreatedAt),
+		SubmittedBy:    s.SubmittedBy,
+		ScannerVersion: s.ScannerVersion,
+		ScannedAt:      *types2.NewTime(s.ScannedAt),
+		DeviceID:       s.DeviceID,
+		Hostname:       s.Hostname,
+		OS:             s.OS,
+		Arch:           s.Arch,
+		Username:       s.Username,
 	}
 	if len(s.Files) > 0 {
 		out.Files = make([]types2.DeviceScanFile, len(s.Files))

--- a/pkg/gateway/types/users.go
+++ b/pkg/gateway/types/users.go
@@ -53,10 +53,8 @@ func ConvertUserWithEffectiveRole(u *User, roleFixed bool, authProviderName stri
 	}
 
 	user := &types2.User{
-		Metadata: types2.Metadata{
-			ID:      fmt.Sprint(u.ID),
-			Created: *types2.NewTime(u.CreatedAt),
-		},
+		ID:                     fmt.Sprint(u.ID),
+		Created:                *types2.NewTime(u.CreatedAt),
 		DisplayName:            u.DisplayName,
 		Username:               u.Username,
 		Email:                  u.Email,

--- a/pkg/gitcredential/gitcredential_test.go
+++ b/pkg/gitcredential/gitcredential_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -84,8 +83,8 @@ func TestResolveSharedCredential(t *testing.T) {
 	ctx := context.Background()
 	gatewayClient := newTestGatewayClient(t)
 	repositoryClient := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.GitCredential{
-		ObjectMeta: metav1.ObjectMeta{Name: "gc1-test", Namespace: system.DefaultNamespace},
-		Spec:       v1.GitCredentialSpec{DisplayName: "Shared GitHub", Host: "github.com"},
+		Name: "gc1-test", Namespace: system.DefaultNamespace,
+		Spec: v1.GitCredentialSpec{DisplayName: "Shared GitHub", Host: "github.com"},
 	}).Build()
 
 	require.NoError(t, Store(ctx, gatewayClient, "gc1-test", "shared-token"))
@@ -107,8 +106,8 @@ func TestResolveRejectsCredentialWithoutToken(t *testing.T) {
 	ctx := context.Background()
 	gatewayClient := newTestGatewayClient(t)
 	repositoryClient := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.GitCredential{
-		ObjectMeta: metav1.ObjectMeta{Name: "gc1-empty", Namespace: system.DefaultNamespace},
-		Spec:       v1.GitCredentialSpec{DisplayName: "Empty GitHub", Host: "github.com"},
+		Name: "gc1-empty", Namespace: system.DefaultNamespace,
+		Spec: v1.GitCredentialSpec{DisplayName: "Empty GitHub", Host: "github.com"},
 	}).Build()
 	require.NoError(t, gatewayClient.UpsertCredential(ctx, gatewaytypes.Credential{
 		Context: credentialContext,
@@ -122,8 +121,8 @@ func TestResolveRejectsCredentialWithoutToken(t *testing.T) {
 func TestResolveOrReveal(t *testing.T) {
 	ctx := t.Context()
 	storageClient := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(&v1.GitCredential{
-		ObjectMeta: metav1.ObjectMeta{Name: "gc1-test", Namespace: system.DefaultNamespace},
-		Spec:       v1.GitCredentialSpec{DisplayName: "Shared GitHub", Host: "github.com"},
+		Name: "gc1-test", Namespace: system.DefaultNamespace,
+		Spec: v1.GitCredentialSpec{DisplayName: "Shared GitHub", Host: "github.com"},
 	}).Build()
 	const sourceURL = "https://github.com/obot-platform/skills"
 

--- a/pkg/hostedagentrefs/refs_test.go
+++ b/pkg/hostedagentrefs/refs_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -26,7 +25,7 @@ func clientWith(objs ...kclient.Object) kclient.Client {
 
 func entry(name, sourceURL, entryKey string) *v1.MCPServerCatalogEntry {
 	return &v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
+		Name: name, Namespace: "obot",
 		Spec: v1.MCPServerCatalogEntrySpec{
 			SourceURL: sourceURL,
 			Manifest:  types.MCPServerCatalogEntryManifest{EntryKey: entryKey},
@@ -36,8 +35,8 @@ func entry(name, sourceURL, entryKey string) *v1.MCPServerCatalogEntry {
 
 func skill(name, repoURL, relPath string) *v1.Skill {
 	return &v1.Skill{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "obot"},
-		Spec:       v1.SkillSpec{RepoURL: repoURL, RelativePath: relPath},
+		Name: name, Namespace: "obot",
+		Spec: v1.SkillSpec{RepoURL: repoURL, RelativePath: relPath},
 	}
 }
 

--- a/pkg/imagepullsecrets/imagepullsecrets_test.go
+++ b/pkg/imagepullsecrets/imagepullsecrets_test.go
@@ -441,13 +441,13 @@ func TestValidateSpec(t *testing.T) {
 func TestEffectiveSecretNames(t *testing.T) {
 	deletionTime := metav1.Now()
 	managed := []v1.ImagePullSecret{
-		{ObjectMeta: metav1.ObjectMeta{Name: "managed-b"}, Spec: v1.ImagePullSecretSpec{Enabled: true}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "disabled"}, Spec: v1.ImagePullSecretSpec{Enabled: false}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "managed-a"}, Spec: v1.ImagePullSecretSpec{Enabled: true}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "managed-a"}, Spec: v1.ImagePullSecretSpec{Enabled: true}},
+		{Name: "managed-b", Spec: v1.ImagePullSecretSpec{Enabled: true}},
+		{Name: "disabled", Spec: v1.ImagePullSecretSpec{Enabled: false}},
+		{Name: "managed-a", Spec: v1.ImagePullSecretSpec{Enabled: true}},
+		{Name: "managed-a", Spec: v1.ImagePullSecretSpec{Enabled: true}},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "deleting", DeletionTimestamp: &deletionTime},
-			Spec:       v1.ImagePullSecretSpec{Enabled: true},
+			Name: "deleting", DeletionTimestamp: &deletionTime,
+			Spec: v1.ImagePullSecretSpec{Enabled: true},
 		},
 	}
 

--- a/pkg/localauth/manifest.go
+++ b/pkg/localauth/manifest.go
@@ -4,7 +4,6 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // The icons are inlined so that the provider has no external dependencies, unlike the other
@@ -20,10 +19,8 @@ const (
 // a daemon for it.
 func AuthProvider() *v1.AuthProvider {
 	return &v1.AuthProvider{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      ProviderName,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      ProviderName,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.AuthProviderSpec{
 			AuthProviderManifest: types.AuthProviderManifest{
 				CommonProviderMetadata: types.CommonProviderMetadata{

--- a/pkg/mcp/action.go
+++ b/pkg/mcp/action.go
@@ -109,10 +109,8 @@ func (sm *SessionManager) serverOrInstanceFromConnectURL(ctx context.Context, id
 			}
 			if len(instances.Items) == 0 {
 				instance := v1.MCPServerInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: system.MCPServerInstancePrefix,
-						Namespace:    server.Namespace,
-					},
+					GenerateName: system.MCPServerInstancePrefix,
+					Namespace:    server.Namespace,
 					Spec: v1.MCPServerInstanceSpec{
 						MCPServerName:             id,
 						MCPCatalogName:            server.Spec.MCPCatalogID,
@@ -183,10 +181,8 @@ func (sm *SessionManager) serverOrInstanceFromConnectURL(ctx context.Context, id
 			}
 
 			server := v1.MCPServer{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: system.MCPServerPrefix,
-					Namespace:    system.DefaultNamespace,
-				},
+				GenerateName: system.MCPServerPrefix,
+				Namespace:    system.DefaultNamespace,
 				Spec: v1.MCPServerSpec{
 					Manifest:                  manifest,
 					UnsupportedTools:          entry.Spec.UnsupportedTools,
@@ -925,13 +921,11 @@ func addExtractedEnvVars(server *v1.MCPServer) {
 		for _, env := range extractEnvVars(v) {
 			if _, exists := existing[env]; !exists {
 				server.Spec.Manifest.Env = append(server.Spec.Manifest.Env, types.MCPEnv{
-					MCPHeader: types.MCPHeader{
-						Name:        env,
-						Key:         env,
-						Description: "Automatically detected variable",
-						Sensitive:   true,
-						Required:    true,
-					},
+					Name:        env,
+					Key:         env,
+					Description: "Automatically detected variable",
+					Sensitive:   true,
+					Required:    true,
 				})
 			}
 		}
@@ -992,13 +986,11 @@ func addExtractedEnvVarsToCatalogEntryManifest(manifest *types.MCPServerCatalogE
 			if _, exists := existing[env]; !exists {
 				if manifest.Runtime != types.RuntimeRemote {
 					manifest.Env = append(manifest.Env, types.MCPEnv{
-						MCPHeader: types.MCPHeader{
-							Name:        env,
-							Key:         env,
-							Description: "Automatically detected variable",
-							Sensitive:   true,
-							Required:    true,
-						},
+						Name:        env,
+						Key:         env,
+						Description: "Automatically detected variable",
+						Sensitive:   true,
+						Required:    true,
 					})
 				} else if manifest.RemoteConfig != nil {
 					manifest.RemoteConfig.Headers = append(manifest.RemoteConfig.Headers, types.MCPHeader{

--- a/pkg/mcp/action_test.go
+++ b/pkg/mcp/action_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -42,10 +41,8 @@ func TestServerOrInstanceFromConnectURLCreatesRemoteServerThatNeedsUserURL(t *te
 	)
 
 	entry := &v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      entryID,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      entryID,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Manifest: types.MCPServerCatalogEntryManifest{
 				ServerUserType: types.ServerUserTypeSingleUser,
@@ -95,7 +92,7 @@ func TestServerOrInstanceFromConnectURLRejectsResourcesAbovePersistedMaximum(t *
 
 	maximum := resource.MustParse("500m")
 	entry := &v1.MCPServerCatalogEntry{
-		ObjectMeta: metav1.ObjectMeta{Name: entryID, Namespace: system.DefaultNamespace},
+		Name: entryID, Namespace: system.DefaultNamespace,
 		Spec: v1.MCPServerCatalogEntrySpec{
 			Manifest: types.MCPServerCatalogEntryManifest{
 				ServerUserType: types.ServerUserTypeSingleUser,
@@ -108,8 +105,8 @@ func TestServerOrInstanceFromConnectURLRejectsResourcesAbovePersistedMaximum(t *
 		},
 	}
 	settings := &v1.K8sSettings{
-		ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
-		Spec:       v1.K8sSettingsSpec{MaxCPURequest: &maximum},
+		Name: system.K8sSettingsName, Namespace: system.DefaultNamespace,
+		Spec: v1.K8sSettingsSpec{MaxCPURequest: &maximum},
 	}
 
 	storageClient := fake.NewClientBuilder().

--- a/pkg/mcp/configurationoptions_test.go
+++ b/pkg/mcp/configurationoptions_test.go
@@ -19,9 +19,8 @@ func TestValidateCatalogEntryManifestConfigurationOptions(t *testing.T) {
 		ServerUserType: types.ServerUserTypeSingleUser,
 		Runtime:        types.RuntimeNPX,
 		NPXConfig:      &types.NPXRuntimeConfig{Package: "test-server"},
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-			Key: "REGION", Name: "Region", Required: true, Options: testConfigurationOptions(),
-		}}},
+		Env: []types.MCPEnv{{
+			Key: "REGION", Name: "Region", Required: true, Options: testConfigurationOptions()}},
 	}
 
 	require.NoError(t, ValidateCatalogEntryManifest(t.Context(), base, true, ValidationOptions{}))
@@ -71,7 +70,7 @@ func TestValidateCatalogEntryManifestConfigurationOptions(t *testing.T) {
 }
 
 func TestValidateConfiguredOptions(t *testing.T) {
-	field := types.MCPEnv{MCPHeader: types.MCPHeader{Key: "REGION", Required: true, Options: testConfigurationOptions()}}
+	field := types.MCPEnv{Key: "REGION", Required: true, Options: testConfigurationOptions()}
 
 	missing, err := ValidateConfiguredOptions([]types.MCPEnv{field}, nil, map[string]string{"REGION": "eu"})
 	require.NoError(t, err)
@@ -102,9 +101,8 @@ func TestValidateConfiguredOptions(t *testing.T) {
 func TestValidateCatalogConfigurationConstraints(t *testing.T) {
 	catalog := types.MCPServerCatalogEntryManifest{
 		Runtime: types.RuntimeRemote,
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-			Key: "REGION", Prefix: "region-", Required: true, Sensitive: true, Options: testConfigurationOptions(),
-		}}},
+		Env: []types.MCPEnv{{
+			Key: "REGION", Prefix: "region-", Required: true, Sensitive: true, Options: testConfigurationOptions()}},
 		RemoteConfig: &types.RemoteCatalogConfig{URLTemplate: "https://${REGION}.example.com/mcp"},
 	}
 	server, err := types.MapCatalogEntryToServer(catalog, "", false)
@@ -125,9 +123,8 @@ func TestValidateCatalogConfigurationConstraints(t *testing.T) {
 
 	t.Run("option field injected", func(t *testing.T) {
 		changed := *server.DeepCopy()
-		changed.Env = append(changed.Env, types.MCPEnv{MCPHeader: types.MCPHeader{
-			Key: "INJECTED", Options: []types.MCPConfigurationOption{{Name: "Injected", Value: "injected"}},
-		}})
+		changed.Env = append(changed.Env, types.MCPEnv{
+			Key: "INJECTED", Options: []types.MCPConfigurationOption{{Name: "Injected", Value: "injected"}}})
 		require.ErrorContains(t, ValidateCatalogConfigurationConstraints(changed, catalog), `env "INJECTED" configuration must match`)
 	})
 
@@ -143,7 +140,7 @@ func TestValidateCatalogConfigurationConstraintsCompositeOptions(t *testing.T) {
 	componentCatalog := types.MCPServerCatalogEntryManifest{
 		Runtime:   types.RuntimeNPX,
 		NPXConfig: &types.NPXRuntimeConfig{Package: "component"},
-		Env:       []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "REGION", Options: testConfigurationOptions()}}},
+		Env:       []types.MCPEnv{{Key: "REGION", Options: testConfigurationOptions()}},
 	}
 	matchingComponent, err := types.MapCatalogEntryToServer(componentCatalog, "", false)
 	require.NoError(t, err)
@@ -169,9 +166,8 @@ func TestValidateCatalogConfigurationConstraintsCompositeOptions(t *testing.T) {
 		Runtime: types.RuntimeComposite,
 		CompositeConfig: &types.CompositeRuntimeConfig{ComponentServers: []types.ComponentServer{{
 			CatalogEntryID: "injected",
-			Manifest: types.MCPServerManifest{Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-				Key: "REGION", Options: testConfigurationOptions(),
-			}}}},
+			Manifest: types.MCPServerManifest{Env: []types.MCPEnv{{
+				Key: "REGION", Options: testConfigurationOptions()}}},
 		}}},
 	}
 	require.ErrorContains(t, ValidateCatalogConfigurationConstraints(injected, types.MCPServerCatalogEntryManifest{}), `component "injected" configuration options must be defined by the source catalog entry`)

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -436,12 +436,10 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 	}
 
 	objs = append(objs, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name.SafeConcatName(server.MCPServerName, "mcp", "files"),
-			Namespace:   k.mcpNamespace,
-			Annotations: annotations,
-		},
-		Data: secretVolumeData,
+		Name:        name.SafeConcatName(server.MCPServerName, "mcp", "files"),
+		Namespace:   k.mcpNamespace,
+		Annotations: annotations,
+		Data:        secretVolumeData,
 	})
 
 	for _, env := range server.Env {
@@ -530,11 +528,9 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 		// Apply the annotation to prevent the PVC from being updated after creation.
 		pvcAnnotations[apply.AnnotationUpdate] = "false"
 		objs = append(objs, &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        workspacePVCName,
-				Namespace:   k.mcpNamespace,
-				Annotations: pvcAnnotations,
-			},
+			Name:        workspacePVCName,
+			Namespace:   k.mcpNamespace,
+			Annotations: pvcAnnotations,
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 				Resources: corev1.VolumeResourceRequirements{
@@ -559,12 +555,10 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 	}
 
 	objs = append(objs, &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name.SafeConcatName(server.MCPServerName, "mcp", "config"),
-			Namespace:   k.mcpNamespace,
-			Annotations: annotations,
-		},
-		Data: secretEnvData,
+		Name:        name.SafeConcatName(server.MCPServerName, "mcp", "config"),
+		Namespace:   k.mcpNamespace,
+		Annotations: annotations,
+		Data:        secretEnvData,
 	})
 
 	volumeMounts := []corev1.VolumeMount{
@@ -601,23 +595,19 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 		}(),
 		EnvFrom: []corev1.EnvFromSource{{
 			SecretRef: &corev1.SecretEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: name.SafeConcatName(server.MCPServerName, "mcp", "config"),
-				},
+				Name: name.SafeConcatName(server.MCPServerName, "mcp", "config"),
 			},
 		}},
 		VolumeMounts: volumeMounts,
 	})
 
 	dep := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        server.MCPServerName,
-			Namespace:   k.mcpNamespace,
-			Annotations: annotations,
-			Labels: map[string]string{
-				"app":         server.MCPServerName,
-				"mcp-user-id": server.OwnerUserID,
-			},
+		Name:        server.MCPServerName,
+		Namespace:   k.mcpNamespace,
+		Annotations: annotations,
+		Labels: map[string]string{
+			"app":         server.MCPServerName,
+			"mcp-user-id": server.OwnerUserID,
 		},
 		Spec: appsv1.DeploymentSpec{
 			ProgressDeadlineSeconds: new(int32(server.StartupTimeout.Seconds())),
@@ -643,10 +633,8 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 						volumes := []corev1.Volume{
 							{
 								Name: "files",
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{
-										SecretName: name.SafeConcatName(server.MCPServerName, "mcp", "files"),
-									},
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: name.SafeConcatName(server.MCPServerName, "mcp", "files"),
 								},
 							},
 						}
@@ -654,10 +642,8 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 						if server.Runtime != types.RuntimeContainerized {
 							volumes = append(volumes, corev1.Volume{
 								Name: "run-file",
-								VolumeSource: corev1.VolumeSource{
-									Secret: &corev1.SecretVolumeSource{
-										SecretName: name.SafeConcatName(server.MCPServerName, "mcp", "run"),
-									},
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: name.SafeConcatName(server.MCPServerName, "mcp", "run"),
 								},
 							})
 						}
@@ -665,10 +651,8 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 						if workspacePVCName != "" {
 							volumes = append(volumes, corev1.Volume{
 								Name: nanobotWorkspaceVolumeName,
-								VolumeSource: corev1.VolumeSource{
-									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-										ClaimName: workspacePVCName,
-									},
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: workspacePVCName,
 								},
 							})
 						}
@@ -698,11 +682,9 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 		}
 
 		objs = append(objs, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        name.SafeConcatName(server.MCPServerName, "mcp", "run"),
-				Namespace:   k.mcpNamespace,
-				Annotations: annotations,
-			},
+			Name:        name.SafeConcatName(server.MCPServerName, "mcp", "run"),
+			Namespace:   k.mcpNamespace,
+			Annotations: annotations,
 			Data: map[string][]byte{
 				"nanobot.yaml": nanobotFileString,
 			},
@@ -715,11 +697,9 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 		})
 
 		dep.Spec.Template.Spec.Containers[len(containers)-1].ReadinessProbe = &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/healthz",
-					Port: intstr.FromInt(port),
-				},
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/healthz",
+				Port: intstr.FromInt(port),
 			},
 		}
 	}
@@ -750,11 +730,9 @@ func (k *kubernetesBackend) k8sObjects(ctx context.Context, server ServerConfig)
 	}
 
 	objs = append(objs, &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        server.MCPServerName,
-			Namespace:   k.mcpNamespace,
-			Annotations: annotations,
-		},
+		Name:        server.MCPServerName,
+		Namespace:   k.mcpNamespace,
+		Annotations: annotations,
 		Spec: corev1.ServiceSpec{
 			Ports: servicePorts,
 			Selector: map[string]string{
@@ -877,7 +855,7 @@ func (k *kubernetesBackend) updatedMCPPodName(ctx context.Context, url, id strin
 	const watchTimeout = 5 * time.Second
 	start := time.Now()
 	for ; totalWatchDur < server.StartupTimeout; totalWatchDur, watchAttempt = time.Since(start), watchAttempt+1 {
-		_, err := wait.For(ctx, k.cachedClient, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: id, Namespace: k.mcpNamespace}},
+		_, err := wait.For(ctx, k.cachedClient, &appsv1.Deployment{Name: id, Namespace: k.mcpNamespace},
 			func(dep *appsv1.Deployment) (bool, error) {
 				if dep.Generation == dep.Status.ObservedGeneration && dep.Status.UpdatedReplicas == 1 && dep.Status.ReadyReplicas == 1 && dep.Status.AvailableReplicas == 1 {
 					return true, nil

--- a/pkg/mcp/kubernetes_test.go
+++ b/pkg/mcp/kubernetes_test.go
@@ -433,7 +433,7 @@ func TestK8sObjects_NanobotAgentExcludesAuditLogConfig(t *testing.T) {
 
 func TestK8sObjects_DoesNotCreateShimContainer(t *testing.T) {
 	k := newTestKubernetesBackend(t, &v1.K8sSettings{
-		ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+		Name: system.K8sSettingsName, Namespace: system.DefaultNamespace,
 		Spec: v1.K8sSettingsSpec{
 			Resources: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
@@ -599,7 +599,7 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 				Runtime: types.RuntimeContainerized,
 			},
 			settings: &v1.K8sSettings{
-				ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+				Name: system.K8sSettingsName, Namespace: system.DefaultNamespace,
 				Spec: v1.K8sSettingsSpec{
 					MaxCPURequest:    new(resource.MustParse("5m")),
 					MaxMemoryRequest: new(resource.MustParse("128Mi")),
@@ -623,7 +623,7 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 				NanobotAgentName: "agent-1",
 			},
 			settings: &v1.K8sSettings{
-				ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+				Name: system.K8sSettingsName, Namespace: system.DefaultNamespace,
 				Spec: v1.K8sSettingsSpec{
 					MaxCPURequest:    new(resource.MustParse("5m")),
 					MaxMemoryRequest: new(resource.MustParse("256Mi")),
@@ -639,7 +639,7 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 				NanobotAgentName: "agent-1",
 			},
 			settings: &v1.K8sSettings{
-				ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
+				Name: system.K8sSettingsName, Namespace: system.DefaultNamespace,
 				Spec: v1.K8sSettingsSpec{
 					Resources: &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("250Mi")},
@@ -716,11 +716,9 @@ func TestK8sObjects_MCPContainerResources(t *testing.T) {
 func TestK8sObjectsUsesStoredMaximums(t *testing.T) {
 	storedMaximum := resource.MustParse("20m")
 	settings := &v1.K8sSettings{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      system.K8sSettingsName,
-			Namespace: system.DefaultNamespace,
-		},
-		Spec: v1.K8sSettingsSpec{MaxCPURequest: &storedMaximum},
+		Name:      system.K8sSettingsName,
+		Namespace: system.DefaultNamespace,
+		Spec:      v1.K8sSettingsSpec{MaxCPURequest: &storedMaximum},
 	}
 	k := newTestKubernetesBackend(t, settings)
 	server := testK8sServerConfig()
@@ -1039,23 +1037,19 @@ func TestUpdatedMCPPodName_SucceededPodAgentRetryBehavior(t *testing.T) {
 			}
 
 			deployment := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-server",
-					Namespace: "obot-mcp",
-				},
+				Name:      "test-server",
+				Namespace: "obot-mcp",
 				Status: appsv1.DeploymentStatus{
 					ObservedGeneration: 1,
 					UpdatedReplicas:    1,
 				},
 			}
 			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-server-pod",
-					Namespace:         "obot-mcp",
-					CreationTimestamp: metav1.Now(),
-					Labels: map[string]string{
-						"app": "test-server",
-					},
+				Name:              "test-server-pod",
+				Namespace:         "obot-mcp",
+				CreationTimestamp: metav1.Now(),
+				Labels: map[string]string{
+					"app": "test-server",
 				},
 				Status: corev1.PodStatus{
 					Phase: corev1.PodSucceeded,
@@ -1105,23 +1099,19 @@ func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 
 	now := time.Now()
 	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-server",
-			Namespace: "obot-mcp",
-		},
+		Name:      "test-server",
+		Namespace: "obot-mcp",
 		Status: appsv1.DeploymentStatus{
 			ObservedGeneration: 1,
 			UpdatedReplicas:    1,
 		},
 	}
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "test-server-pod",
-			Namespace:         "obot-mcp",
-			CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
-			Labels: map[string]string{
-				"app": "test-server",
-			},
+		Name:              "test-server-pod",
+		Namespace:         "obot-mcp",
+		CreationTimestamp: metav1.NewTime(now.Add(-time.Minute)),
+		Labels: map[string]string{
+			"app": "test-server",
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
@@ -1138,7 +1128,7 @@ func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 
 	go func() {
 		watcher.Add(&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-server", Namespace: "obot-mcp"},
+			Name: "test-server", Namespace: "obot-mcp",
 		})
 		watcher.Stop()
 	}()
@@ -1169,16 +1159,16 @@ func TestUpdatedMCPPodName_ContainerStartupDeadlineExceeded(t *testing.T) {
 func TestK8sObjects_ManagedImagePullSecrets(t *testing.T) {
 	managedSecrets := []v1.ImagePullSecret{
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "managed-b", Namespace: system.DefaultNamespace},
-			Spec:       v1.ImagePullSecretSpec{Enabled: true},
+			Name: "managed-b", Namespace: system.DefaultNamespace,
+			Spec: v1.ImagePullSecretSpec{Enabled: true},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "disabled", Namespace: system.DefaultNamespace},
-			Spec:       v1.ImagePullSecretSpec{Enabled: false},
+			Name: "disabled", Namespace: system.DefaultNamespace,
+			Spec: v1.ImagePullSecretSpec{Enabled: false},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "managed-a", Namespace: system.DefaultNamespace},
-			Spec:       v1.ImagePullSecretSpec{Enabled: true},
+			Name: "managed-a", Namespace: system.DefaultNamespace,
+			Spec: v1.ImagePullSecretSpec{Enabled: true},
 		},
 	}
 
@@ -1222,8 +1212,8 @@ func TestK8sObjects_ManagedImagePullSecrets(t *testing.T) {
 func TestK8sObjects_StaticImagePullSecretsOverrideManaged(t *testing.T) {
 	k := newTestKubernetesBackend(t,
 		&v1.ImagePullSecret{
-			ObjectMeta: metav1.ObjectMeta{Name: "managed", Namespace: system.DefaultNamespace},
-			Spec:       v1.ImagePullSecretSpec{Enabled: true},
+			Name: "managed", Namespace: system.DefaultNamespace,
+			Spec: v1.ImagePullSecretSpec{Enabled: true},
 		},
 	)
 	k.imagePullSecrets = []string{"static-b", "static-a", "static-a"}
@@ -1251,8 +1241,8 @@ func TestK8sObjects_StaticImagePullSecretsOverrideManaged(t *testing.T) {
 func TestRestartServerAddsManagedImagePullSecretsToFreshDeployment(t *testing.T) {
 	k := newTestKubernetesBackend(t,
 		&v1.K8sSettings{
-			ObjectMeta: metav1.ObjectMeta{Name: system.K8sSettingsName, Namespace: system.DefaultNamespace},
-			Spec:       v1.K8sSettingsSpec{},
+			Name: system.K8sSettingsName, Namespace: system.DefaultNamespace,
+			Spec: v1.K8sSettingsSpec{},
 		},
 	)
 	server := ServerConfig{
@@ -1284,8 +1274,8 @@ func TestRestartServerAddsManagedImagePullSecretsToFreshDeployment(t *testing.T)
 	k.client = fake.NewClientBuilder().WithScheme(runtimeScheme).WithObjects(dep).Build()
 
 	if err := k.obotClient.Create(t.Context(), &v1.ImagePullSecret{
-		ObjectMeta: metav1.ObjectMeta{Name: "managed", Namespace: system.DefaultNamespace},
-		Spec:       v1.ImagePullSecretSpec{Enabled: true},
+		Name: "managed", Namespace: system.DefaultNamespace,
+		Spec: v1.ImagePullSecretSpec{Enabled: true},
 	}); err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -20,7 +20,6 @@ import (
 	"github.com/obot-platform/obot/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -140,9 +139,7 @@ func NewSessionManager(ctx context.Context, authEnabled bool, globalTokenStore G
 		}
 
 		namespace := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: opts.MCPNamespace,
-			},
+			Name: opts.MCPNamespace,
 		}
 
 		// Add Pod Security Admission labels if enabled

--- a/pkg/mcp/manager_test.go
+++ b/pkg/mcp/manager_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/obot-platform/obot/pkg/tunnel"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -22,11 +21,9 @@ func TestEffectiveKubernetesResourceMaximums(t *testing.T) {
 	storageClient := fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
 		WithObjects(&v1.K8sSettings{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      system.K8sSettingsName,
-				Namespace: system.DefaultNamespace,
-			},
-			Spec: v1.K8sSettingsSpec{MaxCPURequest: &maximum},
+			Name:      system.K8sSettingsName,
+			Namespace: system.DefaultNamespace,
+			Spec:      v1.K8sSettingsSpec{MaxCPURequest: &maximum},
 		}).
 		Build()
 

--- a/pkg/mcp/mcpvalidators_test.go
+++ b/pkg/mcp/mcpvalidators_test.go
@@ -954,8 +954,7 @@ func TestRemoteValidator_ValidateConfig_HeaderValidation(t *testing.T) {
 					return
 				}
 
-				var runtimeErr types.RuntimeValidationError
-				if errors.As(err, &runtimeErr) {
+				if runtimeErr, ok := errors.AsType[types.RuntimeValidationError](err); ok {
 					if runtimeErr.Field != tt.errorField {
 						t.Errorf("expected error field %q, got %q", tt.errorField, runtimeErr.Field)
 					}
@@ -1321,8 +1320,7 @@ func TestRemoteValidator_ValidateCatalogConfig_HeaderValidation(t *testing.T) {
 					return
 				}
 
-				var runtimeErr types.RuntimeValidationError
-				if errors.As(err, &runtimeErr) {
+				if runtimeErr, ok := errors.AsType[types.RuntimeValidationError](err); ok {
 					if runtimeErr.Field != tt.errorField {
 						t.Errorf("expected error field %q, got %q", tt.errorField, runtimeErr.Field)
 					}
@@ -2525,7 +2523,7 @@ func TestValidateSecretBindings(t *testing.T) {
 			name: "bound env accepted for admin-managed multi-user server",
 			manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeContainerized,
-				Env:     []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "DD_API_KEY", SecretBinding: binding}}},
+				Env:     []types.MCPEnv{{Key: "DD_API_KEY", SecretBinding: binding}},
 			},
 			adminManaged: true,
 			backend:      "kubernetes",
@@ -2582,7 +2580,7 @@ func TestValidateSecretBindings(t *testing.T) {
 			name: "bound env under remote runtime is rejected",
 			manifest: types.MCPServerManifest{
 				Runtime:      types.RuntimeRemote,
-				Env:          []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "DD_API_KEY", SecretBinding: binding}}},
+				Env:          []types.MCPEnv{{Key: "DD_API_KEY", SecretBinding: binding}},
 				RemoteConfig: &types.RemoteRuntimeConfig{},
 			},
 			gitManaged: true,
@@ -2593,7 +2591,7 @@ func TestValidateSecretBindings(t *testing.T) {
 			name: "file-backed env with secret binding is accepted",
 			manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeContainerized,
-				Env:     []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "DD_API_KEY", SecretBinding: binding}, File: true}},
+				Env:     []types.MCPEnv{{Key: "DD_API_KEY", SecretBinding: binding, File: true}},
 			},
 			gitManaged: true,
 			backend:    "kubernetes",
@@ -2602,7 +2600,7 @@ func TestValidateSecretBindings(t *testing.T) {
 			name: "bound env accepted for git-managed containerized",
 			manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeContainerized,
-				Env:     []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "DD_API_KEY", SecretBinding: binding}}},
+				Env:     []types.MCPEnv{{Key: "DD_API_KEY", SecretBinding: binding}},
 			},
 			gitManaged: true,
 			backend:    "kubernetes",
@@ -2612,7 +2610,7 @@ func TestValidateSecretBindings(t *testing.T) {
 			manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeNPX,
 				Env: []types.MCPEnv{{
-					MCPHeader:   types.MCPHeader{Key: "DD_API_KEY", SecretBinding: binding},
+					Key: "DD_API_KEY", SecretBinding: binding,
 					DynamicFile: true,
 				}},
 			},
@@ -2624,7 +2622,7 @@ func TestValidateSecretBindings(t *testing.T) {
 			manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeNPX,
 				Env: []types.MCPEnv{{
-					MCPHeader:   types.MCPHeader{Key: "DD_API_KEY"},
+					Key:         "DD_API_KEY",
 					File:        true,
 					DynamicFile: true,
 				}},
@@ -2659,9 +2657,8 @@ func TestValidateSecretBindingsCatalogEntry_URLTemplate(t *testing.T) {
 			name: "urlTemplate referencing non-bound env is allowed",
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeRemote,
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-					Key: "HOST", Required: true,
-				}}},
+				Env: []types.MCPEnv{{
+					Key: "HOST", Required: true}},
 				RemoteConfig: &types.RemoteCatalogConfig{
 					URLTemplate: "https://${HOST}/mcp",
 				},
@@ -2671,9 +2668,8 @@ func TestValidateSecretBindingsCatalogEntry_URLTemplate(t *testing.T) {
 			name: "urlTemplate referencing secret-bound env is rejected",
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeRemote,
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-					Key: "TOKEN", Required: true, SecretBinding: binding,
-				}}},
+				Env: []types.MCPEnv{{
+					Key: "TOKEN", Required: true, SecretBinding: binding}},
 				RemoteConfig: &types.RemoteCatalogConfig{
 					URLTemplate: "https://example.com/${TOKEN}/mcp",
 				},
@@ -2684,9 +2680,8 @@ func TestValidateSecretBindingsCatalogEntry_URLTemplate(t *testing.T) {
 			name: "no urlTemplate with bound env passes to core check",
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeNPX,
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-					Key: "TOKEN", Required: true, SecretBinding: binding,
-				}}},
+				Env: []types.MCPEnv{{
+					Key: "TOKEN", Required: true, SecretBinding: binding}},
 			},
 		},
 	}
@@ -2718,9 +2713,8 @@ func TestValidateSecretBindingsCatalogEntryMultiUser(t *testing.T) {
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime:        types.RuntimeNPX,
 				ServerUserType: types.ServerUserTypeMultiUser,
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-					Key: "TOKEN", SecretBinding: binding,
-				}}},
+				Env: []types.MCPEnv{{
+					Key: "TOKEN", SecretBinding: binding}},
 			},
 			adminManaged: true,
 		},
@@ -2729,9 +2723,8 @@ func TestValidateSecretBindingsCatalogEntryMultiUser(t *testing.T) {
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime:        types.RuntimeNPX,
 				ServerUserType: types.ServerUserTypeMultiUser,
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-					Key: "TOKEN", SecretBinding: binding,
-				}}},
+				Env: []types.MCPEnv{{
+					Key: "TOKEN", SecretBinding: binding}},
 			},
 			wantErr: "multi-user catalog entries",
 		},
@@ -2740,9 +2733,8 @@ func TestValidateSecretBindingsCatalogEntryMultiUser(t *testing.T) {
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime:        types.RuntimeNPX,
 				ServerUserType: types.ServerUserTypeSingleUser,
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-					Key: "TOKEN", SecretBinding: binding,
-				}}},
+				Env: []types.MCPEnv{{
+					Key: "TOKEN", SecretBinding: binding}},
 			},
 			adminManaged: true,
 			wantErr:      "multi-user catalog entries",
@@ -2785,9 +2777,8 @@ func TestValidateSecretBindingsCatalogEntryRejectsAdminAdded(t *testing.T) {
 			name: "env adminAdded rejected",
 			manifest: types.MCPServerCatalogEntryManifest{
 				Runtime: types.RuntimeNPX,
-				Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-					Key: "TOKEN", SecretBinding: binding,
-				}}},
+				Env: []types.MCPEnv{{
+					Key: "TOKEN", SecretBinding: binding}},
 			},
 			wantErr: "secretBinding.adminAdded is not valid for catalog entry",
 		},
@@ -2808,9 +2799,8 @@ func TestValidateSecretBindingsCatalogEntryRejectsAdminAdded(t *testing.T) {
 				CompositeConfig: &types.CompositeCatalogConfig{ComponentServers: []types.CatalogComponentServer{{
 					Manifest: types.MCPServerCatalogEntryManifest{
 						Runtime: types.RuntimeNPX,
-						Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
-							Key: "TOKEN", SecretBinding: binding,
-						}}},
+						Env: []types.MCPEnv{{
+							Key: "TOKEN", SecretBinding: binding}},
 					},
 				}}},
 			},
@@ -2844,8 +2834,8 @@ func TestValidateSecretBindingsCatalogEntryRejectsMultiUserHeaderBinding(t *test
 }
 
 func TestValidateTemplateReferences_Server(t *testing.T) {
-	required := types.MCPEnv{MCPHeader: types.MCPHeader{Key: "TAG", Required: true}}
-	optional := types.MCPEnv{MCPHeader: types.MCPHeader{Key: "TAG", Required: false}}
+	required := types.MCPEnv{Key: "TAG", Required: true}
+	optional := types.MCPEnv{Key: "TAG", Required: false}
 
 	tests := []struct {
 		name     string
@@ -2943,8 +2933,8 @@ func TestValidateTemplateReferences_Server(t *testing.T) {
 }
 
 func TestValidateTemplateReferences_CatalogEntry(t *testing.T) {
-	required := types.MCPEnv{MCPHeader: types.MCPHeader{Key: "TAG", Required: true}}
-	optional := types.MCPEnv{MCPHeader: types.MCPHeader{Key: "TAG", Required: false}}
+	required := types.MCPEnv{Key: "TAG", Required: true}
+	optional := types.MCPEnv{Key: "TAG", Required: false}
 
 	tests := []struct {
 		name     string

--- a/pkg/mcp/oauth_tunnel_test.go
+++ b/pkg/mcp/oauth_tunnel_test.go
@@ -16,7 +16,6 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/tunnel"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -78,10 +77,8 @@ func TestHTTPClientRoutesOAuthDiscoveryThroughTunnel(t *testing.T) {
 		t.Fatal(err)
 	}
 	tunnelConfig := &v1.MCPTunnel{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      tunnelName,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      tunnelName,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.MCPTunnelSpec{
 			Manifest: types.MCPTunnelManifest{
 				DisplayName: "Office",

--- a/pkg/mcp/secretbindings_test.go
+++ b/pkg/mcp/secretbindings_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -29,13 +28,13 @@ func TestMergeBoundCreds(t *testing.T) {
 	}
 
 	t.Run("does not mutate input cred map and overrides stale values", func(t *testing.T) {
-		manifestEnv := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", SecretBinding: binding("bound-secret", "api_key")}}}
+		manifestEnv := []types.MCPEnv{{Key: "API_KEY", SecretBinding: binding("bound-secret", "api_key")}}
 		input := map[string]string{"API_KEY": "stale", "UNCHANGED": "keep"}
 		inputBefore := map[string]string{"API_KEY": "stale", "UNCHANGED": "keep"}
 
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"api_key": []byte("fresh")},
-			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+			Data: map[string][]byte{"api_key": []byte("fresh")},
+			Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"},
 		})
 
 		out, err := MergeBoundCreds(t.Context(), c, ns, manifestEnv, nil, input, label)
@@ -46,7 +45,7 @@ func TestMergeBoundCreds(t *testing.T) {
 	})
 
 	t.Run("omits missing secret and missing key", func(t *testing.T) {
-		manifestEnv := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", SecretBinding: binding("missing-secret", "api_key")}}}
+		manifestEnv := []types.MCPEnv{{Key: "API_KEY", SecretBinding: binding("missing-secret", "api_key")}}
 		input := map[string]string{"API_KEY": "stale", "OTHER": "ok"}
 
 		out, err := MergeBoundCreds(t.Context(), newClient(t), ns, manifestEnv, nil, input, label)
@@ -56,8 +55,8 @@ func TestMergeBoundCreds(t *testing.T) {
 
 		manifestEnv[0].SecretBinding = binding("present-secret", "missing-key")
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"other": []byte("x")},
-			ObjectMeta: metav1.ObjectMeta{Name: "present-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+			Data: map[string][]byte{"other": []byte("x")},
+			Name: "present-secret", Namespace: ns, Labels: map[string]string{label: "true"},
 		})
 		out, err = MergeBoundCreds(t.Context(), c, ns, manifestEnv, nil, input, label)
 		require.NoError(t, err)
@@ -67,8 +66,8 @@ func TestMergeBoundCreds(t *testing.T) {
 	t.Run("merges remote header bindings", func(t *testing.T) {
 		remote := &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", SecretBinding: binding("auth-secret", "token")}}}
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"token": []byte("Bearer abc")},
-			ObjectMeta: metav1.ObjectMeta{Name: "auth-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+			Data: map[string][]byte{"token": []byte("Bearer abc")},
+			Name: "auth-secret", Namespace: ns, Labels: map[string]string{label: "true"},
 		})
 
 		out, err := MergeBoundCreds(t.Context(), c, ns, nil, remote, map[string]string{"Authorization": "stale"}, label)
@@ -77,7 +76,7 @@ func TestMergeBoundCreds(t *testing.T) {
 	})
 
 	t.Run("nil client strips bound keys and keeps others", func(t *testing.T) {
-		manifestEnv := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", SecretBinding: binding("s", "k")}}}
+		manifestEnv := []types.MCPEnv{{Key: "API_KEY", SecretBinding: binding("s", "k")}}
 		remote := &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", SecretBinding: binding("s", "token")}}}
 		in := map[string]string{"API_KEY": "x", "Authorization": "y", "OTHER": "ok"}
 
@@ -89,11 +88,11 @@ func TestMergeBoundCreds(t *testing.T) {
 	})
 
 	t.Run("empty secret value is treated as missing", func(t *testing.T) {
-		manifestEnv := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", SecretBinding: binding("bound-secret", "api_key")}}}
+		manifestEnv := []types.MCPEnv{{Key: "API_KEY", SecretBinding: binding("bound-secret", "api_key")}}
 		in := map[string]string{"API_KEY": "stale"}
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"api_key": []byte("")},
-			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+			Data: map[string][]byte{"api_key": []byte("")},
+			Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"},
 		})
 
 		out, err := MergeBoundCreds(t.Context(), c, ns, manifestEnv, nil, in, label)
@@ -102,11 +101,11 @@ func TestMergeBoundCreds(t *testing.T) {
 	})
 
 	t.Run("unlabeled secret is treated as missing", func(t *testing.T) {
-		manifestEnv := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", SecretBinding: binding("bound-secret", "api_key")}}}
+		manifestEnv := []types.MCPEnv{{Key: "API_KEY", SecretBinding: binding("bound-secret", "api_key")}}
 		in := map[string]string{"API_KEY": "stale", "OTHER": "ok"}
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"api_key": []byte("fresh")},
-			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns},
+			Data: map[string][]byte{"api_key": []byte("fresh")},
+			Name: "bound-secret", Namespace: ns,
 		})
 
 		out, err := MergeBoundCreds(t.Context(), c, ns, manifestEnv, nil, in, label)
@@ -127,12 +126,12 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 	}
 
-	requiredEnv := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", Required: true, SecretBinding: binding("bound-secret", "api_key")}}}
+	requiredEnv := []types.MCPEnv{{Key: "API_KEY", Required: true, SecretBinding: binding("bound-secret", "api_key")}}
 
 	t.Run("valid secret", func(t *testing.T) {
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"api_key": []byte("fresh")},
-			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+			Data: map[string][]byte{"api_key": []byte("fresh")},
+			Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"},
 		})
 
 		require.NoError(t, ValidateSecretBindingsAvailable(t.Context(), c, ns, requiredEnv, nil, label))
@@ -146,8 +145,8 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 
 	t.Run("missing key", func(t *testing.T) {
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"other": []byte("fresh")},
-			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+			Data: map[string][]byte{"other": []byte("fresh")},
+			Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"},
 		})
 
 		err := ValidateSecretBindingsAvailable(t.Context(), c, ns, requiredEnv, nil, label)
@@ -157,8 +156,8 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 
 	t.Run("empty value is treated as unavailable", func(t *testing.T) {
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"api_key": []byte("")},
-			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+			Data: map[string][]byte{"api_key": []byte("")},
+			Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"},
 		})
 
 		err := ValidateSecretBindingsAvailable(t.Context(), c, ns, requiredEnv, nil, label)
@@ -168,8 +167,8 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 
 	t.Run("unlabeled secret", func(t *testing.T) {
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"api_key": []byte("fresh")},
-			ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns},
+			Data: map[string][]byte{"api_key": []byte("fresh")},
+			Name: "bound-secret", Namespace: ns,
 		})
 
 		err := ValidateSecretBindingsAvailable(t.Context(), c, ns, requiredEnv, nil, label)
@@ -178,7 +177,7 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 	})
 
 	t.Run("binding is checked even when optional", func(t *testing.T) {
-		env := []types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "API_KEY", SecretBinding: binding("missing", "api_key")}}}
+		env := []types.MCPEnv{{Key: "API_KEY", SecretBinding: binding("missing", "api_key")}}
 
 		err := ValidateSecretBindingsAvailable(t.Context(), newClient(t), ns, env, nil, label)
 		require.Error(t, err)
@@ -188,8 +187,8 @@ func TestValidateSecretBindingsAvailable(t *testing.T) {
 	t.Run("remote header", func(t *testing.T) {
 		remote := &types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", Required: true, SecretBinding: binding("auth-secret", "token")}}}
 		c := newClient(t, &corev1.Secret{
-			Data:       map[string][]byte{"token": []byte("Bearer abc")},
-			ObjectMeta: metav1.ObjectMeta{Name: "auth-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+			Data: map[string][]byte{"token": []byte("Bearer abc")},
+			Name: "auth-secret", Namespace: ns, Labels: map[string]string{label: "true"},
 		})
 
 		require.NoError(t, ValidateSecretBindingsAvailable(t.Context(), c, ns, nil, remote, label))
@@ -211,12 +210,12 @@ func TestMissingSecretBindings(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.Secret{
-		Data:       map[string][]byte{"env_key": []byte("fresh")},
-		ObjectMeta: metav1.ObjectMeta{Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
+		Data: map[string][]byte{"env_key": []byte("fresh")},
+		Name: "bound-secret", Namespace: ns, Labels: map[string]string{label: "true"},
 	}).Build()
 
 	missing, err := MissingSecretBindings(t.Context(), c, ns,
-		[]types.MCPEnv{{MCPHeader: types.MCPHeader{Key: "ENV_KEY", SecretBinding: binding("bound-secret", "env_key")}}},
+		[]types.MCPEnv{{Key: "ENV_KEY", SecretBinding: binding("bound-secret", "env_key")}},
 		&types.RemoteRuntimeConfig{Headers: []types.MCPHeader{{Key: "Authorization", SecretBinding: binding("missing-secret", "token")}}},
 		label,
 	)
@@ -235,19 +234,19 @@ func TestListAllowedSecretBindingTargets(t *testing.T) {
 	require.NoError(t, corev1.AddToScheme(scheme))
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "z-secret", Namespace: ns, Labels: map[string]string{label: "false"}},
-			Data:       map[string][]byte{"b": []byte("value-b"), "a": []byte("value-a")},
+			Name: "z-secret", Namespace: ns, Labels: map[string]string{label: "false"},
+			Data: map[string][]byte{"b": []byte("value-b"), "a": []byte("value-a")},
 		},
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "a-secret", Namespace: ns, Labels: map[string]string{label: "true"}},
-			Data:       map[string][]byte{"token": []byte("secret-value")},
+			Name: "a-secret", Namespace: ns, Labels: map[string]string{label: "true"},
+			Data: map[string][]byte{"token": []byte("secret-value")},
 		},
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "empty", Namespace: ns, Labels: map[string]string{label: "true"}},
+			Name: "empty", Namespace: ns, Labels: map[string]string{label: "true"},
 		},
 		&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "unlabeled", Namespace: ns},
-			Data:       map[string][]byte{"token": []byte("hidden")},
+			Name: "unlabeled", Namespace: ns,
+			Data: map[string][]byte{"token": []byte("hidden")},
 		},
 	).Build()
 

--- a/pkg/mcp/systemmcpvalidators_test.go
+++ b/pkg/mcp/systemmcpvalidators_test.go
@@ -160,12 +160,10 @@ func TestValidateSystemMCPServerManifest(t *testing.T) {
 					Package: "@example/server",
 				},
 				Env: []types.MCPEnv{{
-					MCPHeader: types.MCPHeader{
-						Key: "API_KEY",
-						SecretBinding: &types.MCPSecretBinding{
-							Name: "my-secret",
-							Key:  "token",
-						},
+					Key: "API_KEY",
+					SecretBinding: &types.MCPSecretBinding{
+						Name: "my-secret",
+						Key:  "token",
 					},
 				}},
 			},

--- a/pkg/mcp/types_test.go
+++ b/pkg/mcp/types_test.go
@@ -74,6 +74,7 @@ func assertQuantityEqual(t *testing.T, got, want resource.Quantity, name string)
 func TestServerToServerConfig_ContainerizedHealthzPath(t *testing.T) {
 	baseURL := "http://localhost:8080"
 	mcpServer := v1.MCPServer{
+		Name: "test-server",
 		Spec: v1.MCPServerSpec{
 			Manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeContainerized,
@@ -86,8 +87,6 @@ func TestServerToServerConfig_ContainerizedHealthzPath(t *testing.T) {
 			},
 		},
 	}
-	mcpServer.Name = "test-server"
-
 	config, missing, err := ServerToServerConfig(mcpServer, mcpServer.ValidConnectURLs(baseURL), "test-user-id", "test-scope", "test-catalog", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -104,14 +103,12 @@ func TestServerToServerConfig_ConfigurationOptions(t *testing.T) {
 	manifest := types.MCPServerManifest{
 		Runtime:   types.RuntimeNPX,
 		NPXConfig: &types.NPXRuntimeConfig{Package: "example-server"},
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:      "REGION",
 			Required: true,
-			Options:  []types.MCPConfigurationOption{{Name: "US", Value: "us"}},
-		}}},
+			Options:  []types.MCPConfigurationOption{{Name: "US", Value: "us"}}}},
 	}
-	server := v1.MCPServer{Spec: v1.MCPServerSpec{Manifest: manifest}}
-	server.Name = "test-server"
+	server := v1.MCPServer{Name: "test-server", Spec: v1.MCPServerSpec{Manifest: manifest}}
 
 	_, missing, err := ServerToServerConfig(server, server.ValidConnectURLs("http://localhost:8080"), "test-user-id", "test-scope", "test-catalog", nil, nil, nil)
 	if err != nil {
@@ -131,14 +128,12 @@ func TestSystemServerToServerConfig_ConfigurationOptions(t *testing.T) {
 	manifest := types.SystemMCPServerManifest{
 		Runtime:   types.RuntimeNPX,
 		NPXConfig: &types.NPXRuntimeConfig{Package: "example-server"},
-		Env: []types.MCPEnv{{MCPHeader: types.MCPHeader{
+		Env: []types.MCPEnv{{
 			Key:      "REGION",
 			Required: true,
-			Options:  []types.MCPConfigurationOption{{Name: "US", Value: "us"}},
-		}}},
+			Options:  []types.MCPConfigurationOption{{Name: "US", Value: "us"}}}},
 	}
-	server := v1.SystemMCPServer{Spec: v1.SystemMCPServerSpec{Manifest: manifest}}
-	server.Name = "test-system-server"
+	server := v1.SystemMCPServer{Name: "test-system-server", Spec: v1.SystemMCPServerSpec{Manifest: manifest}}
 
 	_, missing, err := SystemServerToServerConfig(server, server.ValidConnectURLs("http://localhost:8080"), "test-user-id", nil, nil)
 	if err != nil {
@@ -157,6 +152,7 @@ func TestSystemServerToServerConfig_ConfigurationOptions(t *testing.T) {
 func TestServerToServerConfig_UsesStaticCatalogEnvValue(t *testing.T) {
 	baseURL := "http://localhost:8080"
 	mcpServer := v1.MCPServer{
+		Name: "test-server",
 		Spec: v1.MCPServerSpec{
 			Manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeNPX,
@@ -165,18 +161,14 @@ func TestServerToServerConfig_UsesStaticCatalogEnvValue(t *testing.T) {
 					Args:    []string{"--token=${CATALOG_TOKEN}"},
 				},
 				Env: []types.MCPEnv{{
-					MCPHeader: types.MCPHeader{
-						Key:      "CATALOG_TOKEN",
-						Value:    "catalog-value",
-						Prefix:   "Bearer ",
-						Required: true,
-					},
+					Key:      "CATALOG_TOKEN",
+					Value:    "catalog-value",
+					Prefix:   "Bearer ",
+					Required: true,
 				}},
 			},
 		},
 	}
-	mcpServer.Name = "test-server"
-
 	config, missing, err := ServerToServerConfig(
 		mcpServer,
 		mcpServer.ValidConnectURLs(baseURL),
@@ -204,6 +196,7 @@ func TestServerToServerConfig_UsesStaticCatalogEnvValue(t *testing.T) {
 func TestServerToServerConfig_StartupTimeoutFromRuntimeConfig(t *testing.T) {
 	baseURL := "http://localhost:8080"
 	mcpServer := v1.MCPServer{
+		Name: "test-server",
 		Spec: v1.MCPServerSpec{
 			Manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeContainerized,
@@ -216,8 +209,6 @@ func TestServerToServerConfig_StartupTimeoutFromRuntimeConfig(t *testing.T) {
 			},
 		},
 	}
-	mcpServer.Name = "test-server"
-
 	config, missing, err := ServerToServerConfig(mcpServer, mcpServer.ValidConnectURLs(baseURL), "test-user-id", "test-scope", "test-catalog", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -232,6 +223,7 @@ func TestServerToServerConfig_StartupTimeoutFromRuntimeConfig(t *testing.T) {
 
 func TestServerToServerConfig_StaticOAuthCredentials(t *testing.T) {
 	mcpServer := v1.MCPServer{
+		Name: "test-server",
 		Spec: v1.MCPServerSpec{
 			Manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeRemote,
@@ -241,8 +233,6 @@ func TestServerToServerConfig_StaticOAuthCredentials(t *testing.T) {
 			},
 		},
 	}
-	mcpServer.Name = "test-server"
-
 	config, missing, err := ServerToServerConfig(
 		mcpServer,
 		mcpServer.ValidConnectURLs("https://obot.example.com"),
@@ -296,6 +286,7 @@ func TestServerToServerConfig_MultiUserPassthroughHeaders(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mcpServer := v1.MCPServer{
+				Name: "test-server",
 				Spec: v1.MCPServerSpec{
 					Manifest: types.MCPServerManifest{
 						Runtime: types.RuntimeRemote,
@@ -306,8 +297,6 @@ func TestServerToServerConfig_MultiUserPassthroughHeaders(t *testing.T) {
 					},
 				},
 			}
-			mcpServer.Name = "test-server"
-
 			config, missing, err := ServerToServerConfig(mcpServer, mcpServer.ValidConnectURLs(baseURL), "test-user-id", "test-scope", "test-catalog", nil, nil, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -334,10 +323,10 @@ func TestCompositeServerToServerConfig_OmittedToolOverridesRemainNil(t *testing.
 				}},
 			},
 		},
-	}
-	mcpServer.Name = "composite"
-	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"}}
-	component.Name = "search-server"
+
+		Name: "composite"}
+	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"},
+		Name: "search-server"}
 
 	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), 8080, "test-user-id", "test-scope", "test-catalog", nil, nil)
 	if err != nil {
@@ -366,8 +355,8 @@ func TestCompositeServerToServerConfig_TokenExchangeConfig(t *testing.T) {
 				CompositeConfig: &types.CompositeRuntimeConfig{},
 			},
 		},
-	}
-	mcpServer.Name = "composite"
+
+		Name: "composite"}
 
 	config, missing, err := CompositeServerToServerConfig(
 		mcpServer,
@@ -411,10 +400,10 @@ func TestCompositeServerToServerConfig_AllDisabledToolOverridesSetNoTools(t *tes
 				}},
 			},
 		},
-	}
-	mcpServer.Name = "composite"
-	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"}}
-	component.Name = "search-server"
+
+		Name: "composite"}
+	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"},
+		Name: "search-server"}
 
 	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), 8080, "test-user-id", "test-scope", "test-catalog", nil, nil)
 	if err != nil {
@@ -445,10 +434,10 @@ func TestCompositeServerToServerConfig_ConnectCompositeURL(t *testing.T) {
 				}},
 			},
 		},
-	}
-	mcpServer.Name = "composite"
-	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"}}
-	component.Name = "search-server"
+
+		Name: "composite"}
+	component := v1.MCPServer{Spec: v1.MCPServerSpec{MCPServerCatalogEntryName: "search"},
+		Name: "search-server"}
 
 	config, missing, err := CompositeServerToServerConfig(mcpServer, []v1.MCPServer{component}, nil, mcpServer.ValidConnectURLs(baseURL), 8080, "test-user-id", "test-scope", "test-catalog", nil, nil)
 	if err != nil {
@@ -554,6 +543,7 @@ func TestServerToServerConfig_StaticHeaders_Remote(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mcpServer := v1.MCPServer{
+				Name: "test-server",
 				Spec: v1.MCPServerSpec{
 					Manifest: types.MCPServerManifest{
 						Runtime: types.RuntimeRemote,
@@ -564,8 +554,6 @@ func TestServerToServerConfig_StaticHeaders_Remote(t *testing.T) {
 					},
 				},
 			}
-			mcpServer.Name = "test-server"
-
 			config, missing, err := ServerToServerConfig(mcpServer, mcpServer.ValidConnectURLs(baseURL), "test-user-id", "test-scope", "test-catalog", tt.credEnv, nil, nil)
 
 			if err != nil {
@@ -621,6 +609,7 @@ func TestServerToServerConfig_StaticHeaders_Remote(t *testing.T) {
 
 func TestServerToServerConfig_RemoteTunnelName(t *testing.T) {
 	mcpServer := v1.MCPServer{
+		Name: "test-server",
 		Spec: v1.MCPServerSpec{
 			Manifest: types.MCPServerManifest{
 				Runtime: types.RuntimeRemote,
@@ -631,8 +620,6 @@ func TestServerToServerConfig_RemoteTunnelName(t *testing.T) {
 			},
 		},
 	}
-	mcpServer.Name = "test-server"
-
 	config, missing, err := ServerToServerConfig(mcpServer, nil, "test-user-id", "test-scope", "test-catalog", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -680,7 +667,7 @@ func TestServerToServerConfig_WithPrefix(t *testing.T) {
 		{
 			name: "env var with Bearer prefix",
 			env: []types.MCPEnv{
-				{MCPHeader: types.MCPHeader{Key: "API_KEY", Prefix: "Bearer ", Required: true}},
+				{Key: "API_KEY", Prefix: "Bearer ", Required: true},
 			},
 			credEnv:         map[string]string{"API_KEY": "secret-key-123"},
 			expectedEnv:     []string{"API_KEY=Bearer secret-key-123"},
@@ -689,7 +676,7 @@ func TestServerToServerConfig_WithPrefix(t *testing.T) {
 		{
 			name: "env var with sk- prefix (OpenAI style)",
 			env: []types.MCPEnv{
-				{MCPHeader: types.MCPHeader{Key: "OPENAI_API_KEY", Prefix: "sk-", Required: true}},
+				{Key: "OPENAI_API_KEY", Prefix: "sk-", Required: true},
 			},
 			credEnv:         map[string]string{"OPENAI_API_KEY": "proj-abc123xyz"},
 			expectedEnv:     []string{"OPENAI_API_KEY=sk-proj-abc123xyz"},
@@ -702,8 +689,8 @@ func TestServerToServerConfig_WithPrefix(t *testing.T) {
 				{Key: "X-API-Key", Prefix: "Key ", Required: true},
 			},
 			env: []types.MCPEnv{
-				{MCPHeader: types.MCPHeader{Key: "TOKEN", Prefix: "Token ", Required: true}},
-				{MCPHeader: types.MCPHeader{Key: "SECRET", Required: true}}, // No prefix
+				{Key: "TOKEN", Prefix: "Token ", Required: true},
+				{Key: "SECRET", Required: true}, // No prefix
 			},
 			credEnv: map[string]string{
 				"Authorization": "auth-token",
@@ -736,7 +723,7 @@ func TestServerToServerConfig_WithPrefix(t *testing.T) {
 		{
 			name: "prefix not duplicated when user already included it in env var",
 			env: []types.MCPEnv{
-				{MCPHeader: types.MCPHeader{Key: "API_KEY", Prefix: "sk-", Required: true}},
+				{Key: "API_KEY", Prefix: "sk-", Required: true},
 			},
 			credEnv:         map[string]string{"API_KEY": "sk-proj-abc123"},
 			expectedEnv:     []string{"API_KEY=sk-proj-abc123"},
@@ -748,8 +735,8 @@ func TestServerToServerConfig_WithPrefix(t *testing.T) {
 				{Key: "Authorization", Prefix: "Bearer ", Required: true},
 			},
 			env: []types.MCPEnv{
-				{MCPHeader: types.MCPHeader{Key: "API_KEY", Prefix: "sk-", Required: true}},
-				{MCPHeader: types.MCPHeader{Key: "TOKEN", Prefix: "Token ", Required: true}},
+				{Key: "API_KEY", Prefix: "sk-", Required: true},
+				{Key: "TOKEN", Prefix: "Token ", Required: true},
 			},
 			credEnv: map[string]string{
 				"Authorization": "Bearer already-has-it",
@@ -765,6 +752,7 @@ func TestServerToServerConfig_WithPrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mcpServer := v1.MCPServer{
+				Name: "test-server",
 				Spec: v1.MCPServerSpec{
 					Manifest: types.MCPServerManifest{
 						Runtime: types.RuntimeRemote,
@@ -776,8 +764,6 @@ func TestServerToServerConfig_WithPrefix(t *testing.T) {
 					},
 				},
 			}
-			mcpServer.Name = "test-server"
-
 			config, missing, err := ServerToServerConfig(mcpServer, mcpServer.ValidConnectURLs(baseURL), "test-user-id", "test-scope", "test-catalog", tt.credEnv, nil, nil)
 
 			if err != nil {
@@ -860,12 +846,11 @@ func TestServerToServerConfig_StaticHeaders_EdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mcpServer := v1.MCPServer{
+				Name: "test-server",
 				Spec: v1.MCPServerSpec{
 					Manifest: tt.manifest,
 				},
 			}
-			mcpServer.Name = "test-server"
-
 			config, missing, err := ServerToServerConfig(mcpServer, mcpServer.ValidConnectURLs(baseURL), "test-user-id", "test-scope", "test-catalog", tt.credEnv, nil, nil)
 
 			if tt.expectError {

--- a/pkg/mcpcatalog/walker_test.go
+++ b/pkg/mcpcatalog/walker_test.go
@@ -88,7 +88,7 @@ npxConfig:
 func TestNormalizeManifest(t *testing.T) {
 	entry := types.MCPServerCatalogEntryManifest{
 		Runtime:      types.RuntimeRemote,
-		Env:          []types.MCPEnv{{MCPHeader: types.MCPHeader{Name: "config-file.json"}}},
+		Env:          []types.MCPEnv{{Name: "config-file.json"}},
 		RemoteConfig: &types.RemoteCatalogConfig{Headers: []types.MCPHeader{{Name: "api_key"}}},
 	}
 
@@ -103,7 +103,7 @@ func TestNormalizeManifest(t *testing.T) {
 func TestNormalizeSystemManifest(t *testing.T) {
 	entry := types.SystemMCPServerCatalogEntryManifest{
 		Runtime:      types.RuntimeRemote,
-		Env:          []types.MCPEnv{{MCPHeader: types.MCPHeader{Name: "config-file.json"}}},
+		Env:          []types.MCPEnv{{Name: "config-file.json"}},
 		RemoteConfig: &types.RemoteCatalogConfig{Headers: []types.MCPHeader{{Name: "api_key"}}},
 	}
 

--- a/pkg/messagepolicy/helper_test.go
+++ b/pkg/messagepolicy/helper_test.go
@@ -171,10 +171,8 @@ func withDeleted() policyOpt {
 
 func newPolicy(name, definition string, direction types.PolicyDirection, subjects []types.Subject, opts ...policyOpt) *v1.MessagePolicy {
 	p := &v1.MessagePolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
+		Name:      name,
+		Namespace: "default",
 		Spec: v1.MessagePolicySpec{
 			Manifest: types.MessagePolicyManifest{
 				DisplayName: name,

--- a/pkg/modelaccesspolicy/helper_test.go
+++ b/pkg/modelaccesspolicy/helper_test.go
@@ -93,7 +93,7 @@ func TestGetUserAllowedTargetModels(t *testing.T) {
 			models = append(models, types2.ModelResource{ID: id})
 		}
 		return &v1.ModelAccessPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: "p-user", Namespace: "default"},
+			Name: "p-user", Namespace: "default",
 			Spec: v1.ModelAccessPolicySpec{Manifest: types2.ModelAccessPolicyManifest{
 				Subjects: []types2.Subject{{Type: types2.SubjectTypeUser, ID: userID}},
 				Models:   models,
@@ -103,7 +103,7 @@ func TestGetUserAllowedTargetModels(t *testing.T) {
 
 	// wildcardPolicy grants every eligible model to every user.
 	wildcardPolicy := &v1.ModelAccessPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "p-wildcard", Namespace: "default"},
+		Name: "p-wildcard", Namespace: "default",
 		Spec: v1.ModelAccessPolicySpec{Manifest: types2.ModelAccessPolicyManifest{
 			Subjects: []types2.Subject{{Type: types2.SubjectTypeSelector, ID: "*"}},
 			Models:   []types2.ModelResource{{ID: "*"}},
@@ -275,7 +275,7 @@ func TestUserHasAccessToModelWithWildcardSuffix(t *testing.T) {
 	}
 
 	policy := &v1.ModelAccessPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "p-pattern", Namespace: "default"},
+		Name: "p-pattern", Namespace: "default",
 		Spec: v1.ModelAccessPolicySpec{Manifest: types2.ModelAccessPolicyManifest{
 			Subjects: []types2.Subject{{Type: types2.SubjectTypeUser, ID: userID}},
 			Models:   []types2.ModelResource{{ID: "claude-haiku-4-5*"}},
@@ -347,10 +347,8 @@ func withUsage(usage types2.ModelUsage) modelOpt {
 
 func newModel(name, provider, targetModel string, active bool, opts ...modelOpt) *v1.Model {
 	m := &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
+		Name:      name,
+		Namespace: "default",
 		Spec: v1.ModelSpec{Manifest: types2.ModelManifest{
 			TargetModel:   targetModel,
 			ModelProvider: provider,
@@ -380,7 +378,7 @@ func TestGetAgentAllowedTargetModels(t *testing.T) {
 	// The owner is granted nothing, so any result drawn from policy is empty.
 	// That is what makes these cases prove the agent is not evaluated that way.
 	restrictive := &v1.ModelAccessPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "p-none", Namespace: "default"},
+		Name: "p-none", Namespace: "default",
 		Spec: v1.ModelAccessPolicySpec{Manifest: types2.ModelAccessPolicyManifest{
 			Subjects: []types2.Subject{{Type: types2.SubjectTypeUser, ID: "someone-else"}},
 			Models:   []types2.ModelResource{},

--- a/pkg/modelaccesspolicy/model_reference_test.go
+++ b/pkg/modelaccesspolicy/model_reference_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -23,14 +22,14 @@ func TestResolveModelReference(t *testing.T) {
 	model := newModel("openai-gpt-4o", provider, "openai/gpt-4o", true)
 	model.Spec.Manifest.Name = "catalog-model-name"
 	defaultAlias := &v1.DefaultModelAlias{
-		ObjectMeta: metav1.ObjectMeta{Name: "default-llm"},
+		Name: "default-llm",
 		Spec: v1.DefaultModelAliasSpec{Manifest: types.DefaultModelAliasManifest{
 			Alias: "llm",
 			Model: model.Name,
 		}},
 	}
 	modelAlias := &v1.Alias{
-		ObjectMeta: metav1.ObjectMeta{Name: alias.KeyFromScopeID("Model", "llm")},
+		Name: alias.KeyFromScopeID("Model", "llm"),
 		Spec: v1.AliasSpec{
 			TargetKind: "DefaultModelAlias",
 			TargetName: defaultAlias.Name,

--- a/pkg/modelaccesspolicy/validation_test.go
+++ b/pkg/modelaccesspolicy/validation_test.go
@@ -9,7 +9,6 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -101,10 +100,8 @@ func TestValidateModelResource(t *testing.T) {
 
 func modelForValidationTest(name string, usage types.ModelUsage) *v1.Model {
 	return &v1.Model{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      name,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.ModelSpec{
 			Manifest: types.ModelManifest{
 				Usage: usage,

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -65,7 +65,6 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apiserver/pkg/authentication/request/union"
 	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
@@ -1106,10 +1105,8 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		} else if id != 0 {
 			// Create this UserDelete object so that their stuff gets deleted.
 			if err = storageClient.Create(ctx, &v1.UserDelete{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace:    system.DefaultNamespace,
-					GenerateName: system.UserDeletePrefix,
-				},
+				Namespace:    system.DefaultNamespace,
+				GenerateName: system.UserDeletePrefix,
 				Spec: v1.UserDeleteSpec{
 					UserID: id,
 				},
@@ -1563,10 +1560,8 @@ func newHostedAgentsBackend(config Config, restConfig *rest.Config, client, cach
 
 func startDevMode(ctx context.Context, storageClient storage.Client) {
 	_ = storageClient.Delete(ctx, &coordinationv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "obot-controller",
-			Namespace: "kube-system",
-		},
+		Name:      "obot-controller",
+		Namespace: "kube-system",
 	})
 }
 

--- a/pkg/services/config_test.go
+++ b/pkg/services/config_test.go
@@ -48,8 +48,8 @@ func TestNewAgentBackend(t *testing.T) {
 			config := Config{
 				HostedAgentsBackend: tt.kind,
 				DevMode:             tt.devMode,
-			}
-			config.MCPRuntimeBackend = tt.mcpBackend
+
+				MCPRuntimeBackend: tt.mcpBackend}
 			kind, backend, err := newHostedAgentsBackend(config, nil, nil, nil)
 			if tt.wantErr {
 				if err == nil {

--- a/pkg/skillaccessrule/helper_test.go
+++ b/pkg/skillaccessrule/helper_test.go
@@ -126,8 +126,8 @@ func TestUserHasAccessToSkillUsesSkillObject(t *testing.T) {
 	)
 
 	hasAccess, err := helper.UserHasAccessToSkill(testUser("user1"), &v1.Skill{
-		ObjectMeta: metav1.ObjectMeta{Name: "sk1"},
-		Spec:       v1.SkillSpec{RepoID: "skr1"},
+		Name: "sk1",
+		Spec: v1.SkillSpec{RepoID: "skr1"},
 	})
 	require.NoError(t, err)
 	assert.True(t, hasAccess)
@@ -244,10 +244,8 @@ func newTestHelper(t *testing.T, rules ...*v1.SkillAccessRule) *Helper {
 
 func newRule(name string, subjects []types.Subject, resources []types.SkillResource, opts ...ruleOpt) *v1.SkillAccessRule {
 	rule := &v1.SkillAccessRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: system.DefaultNamespace,
-		},
+		Name:      name,
+		Namespace: system.DefaultNamespace,
 		Spec: v1.SkillAccessRuleSpec{
 			Manifest: types.SkillAccessRuleManifest{
 				Subjects:  subjects,

--- a/pkg/storage/tables/table/funcs.go
+++ b/pkg/storage/tables/table/funcs.go
@@ -112,7 +112,7 @@ func toKObject(obj any) (kclient.Object, bool) {
 	if !ok {
 		newObj := reflect.New(reflect.TypeOf(obj))
 		newObj.Elem().Set(reflect.ValueOf(obj))
-		ro, ok = newObj.Interface().(kclient.Object)
+		ro, ok = reflect.TypeAssert[kclient.Object](newObj)
 	}
 	return ro, ok
 }

--- a/pkg/tunnel/reference_validation_test.go
+++ b/pkg/tunnel/reference_validation_test.go
@@ -8,7 +8,6 @@ import (
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/obot-platform/obot/pkg/system"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -17,10 +16,8 @@ func TestValidateCatalogEntryTunnelReferences(t *testing.T) {
 		WithScheme(storagescheme.Scheme).
 		WithObjects(
 			&v1.MCPTunnel{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mcptunnel-office",
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      "mcptunnel-office",
+				Namespace: system.DefaultNamespace,
 				Spec: v1.MCPTunnelSpec{
 					Manifest: types.MCPTunnelManifest{
 						DisplayName: "Office",
@@ -32,10 +29,8 @@ func TestValidateCatalogEntryTunnelReferences(t *testing.T) {
 				},
 			},
 			&v1.MCPTunnel{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mcptunnel-legacy",
-					Namespace: system.DefaultNamespace,
-				},
+				Name:      "mcptunnel-legacy",
+				Namespace: system.DefaultNamespace,
 				Spec: v1.MCPTunnelSpec{
 					Manifest: types.MCPTunnelManifest{
 						AllowedURLs: []string{"https://fixed.example.com/mcp"},
@@ -147,10 +142,8 @@ func TestValidateServerTunnelReferences(t *testing.T) {
 	client := fake.NewClientBuilder().
 		WithScheme(storagescheme.Scheme).
 		WithObjects(&v1.MCPTunnel{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mcptunnel-office",
-				Namespace: system.DefaultNamespace,
-			},
+			Name:      "mcptunnel-office",
+			Namespace: system.DefaultNamespace,
 			Spec: v1.MCPTunnelSpec{
 				Manifest: types.MCPTunnelManifest{
 					DisplayName: "Office",

--- a/pkg/tunnel/tunnel_auth_test.go
+++ b/pkg/tunnel/tunnel_auth_test.go
@@ -74,8 +74,7 @@ func TestTunnelAuthenticator(t *testing.T) {
 	}
 
 	newStoredTunnel := func(name, storedCredential string) v1.MCPTunnel {
-		tunnel := v1.MCPTunnel{}
-		tunnel.Name = name
+		tunnel := v1.MCPTunnel{Name: name}
 		tunnel.Spec.Credential = storedCredential
 		credentialID, err := CredentialID(storedCredential)
 		if err != nil {

--- a/pkg/tunnel/tunnel_test.go
+++ b/pkg/tunnel/tunnel_test.go
@@ -1045,8 +1045,7 @@ func TestManagerServeConnectRechecksCredential(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	configuredTunnel := v1.MCPTunnel{}
-	configuredTunnel.Name = tunnelName
+	configuredTunnel := v1.MCPTunnel{Name: tunnelName}
 	configuredTunnel.Spec.Credential = currentCredential
 	reader := &staticTunnelTestReader{
 		tunnels: map[string]v1.MCPTunnel{tunnelName: configuredTunnel},
@@ -1501,9 +1500,7 @@ func testTunnelCredential(name string) string {
 func testConfiguredTunnel(name string) v1.MCPTunnel {
 	credential := testTunnelCredential(name)
 	credentialID, _ := CredentialID(credential)
-	tunnel := v1.MCPTunnel{}
-	tunnel.Name = name
-	tunnel.Namespace = system.DefaultNamespace
+	tunnel := v1.MCPTunnel{Name: name, Namespace: system.DefaultNamespace}
 	tunnel.Spec.Credential = credential
 	tunnel.Spec.CredentialID = credentialID
 	tunnel.Spec.Manifest.AllowedURLs = []string{"*"}


### PR DESCRIPTION
There are a bunch of new "modernize" lint errors that come with this change that are fixed here as well.