### PR TITLE
fix(mcp): strip gateway authorization upstream

### DIFF
--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -230,43 +230,7 @@ func (h *Handler) Proxy(req api.Context) error {
 		(&httputil.ReverseProxy{
 			Transport: client.Transport,
 			Rewrite: func(r *httputil.ProxyRequest) {
-				// SetXForwarded preserves the X-Forwarded-For handling that
-				// ReverseProxy applied automatically under the deprecated Director.
-				// It also writes X-Forwarded-Host and X-Forwarded-Proto, so the
-				// values this handler cares about are re-applied afterwards: the
-				// scheme is derived from the inbound host rather than from whether
-				// this hop happens to be TLS.
-				r.SetXForwarded()
-
-				r.Out.Header.Set("X-Forwarded-Host", r.In.Host)
-				scheme := "https"
-				if strings.HasPrefix(r.In.Host, "localhost") || strings.HasPrefix(r.In.Host, "127.0.0.1") || strings.HasPrefix(r.In.Host, "[::1]") {
-					scheme = "http"
-				}
-				r.Out.Header.Set("X-Forwarded-Proto", scheme)
-
-				r.Out.Host = u.Host
-				r.Out.URL.Scheme = u.Scheme
-				r.Out.URL.Host = u.Host
-				r.Out.URL.Path = u.Path
-				if rest := r.In.PathValue("rest"); rest != "" {
-					if strings.HasPrefix(rest, "/") {
-						r.Out.URL.Path = rest
-					} else {
-						r.Out.URL.Path = "/" + rest
-					}
-				}
-
-				// Merge query parameters from the incoming request and the upstream URL.
-				// Preserve all values; if a key exists in both, both values will be present.
-				upstreamQuery := u.Query()
-				origQuery := r.In.URL.Query()
-				for k, vs := range origQuery {
-					for _, v := range vs {
-						upstreamQuery.Add(k, v)
-					}
-				}
-				r.Out.URL.RawQuery = upstreamQuery.Encode()
+				rewriteProxyRequest(r, u)
 			},
 			ModifyResponse: func(resp *http.Response) error {
 				if err := hooks.filterResponse(resp); err != nil {
@@ -311,6 +275,50 @@ func (h *Handler) Proxy(req api.Context) error {
 
 	h.nanobot.ServeHTTP(req.ResponseWriter, req.WithContext(ctx))
 	return nil
+}
+
+func rewriteProxyRequest(r *httputil.ProxyRequest, upstreamURL *url.URL) {
+	// Authorization authenticates the client to Obot and must not be forwarded
+	// to the upstream MCP server. The transport adds any configured or OAuth
+	// Authorization header after this rewrite.
+	r.Out.Header.Del("Authorization")
+
+	// SetXForwarded preserves the X-Forwarded-For handling that ReverseProxy
+	// applied automatically under the deprecated Director. It also writes
+	// X-Forwarded-Host and X-Forwarded-Proto, so the values this handler cares
+	// about are re-applied afterwards: the scheme is derived from the inbound
+	// host rather than from whether this hop happens to be TLS.
+	r.SetXForwarded()
+
+	r.Out.Header.Set("X-Forwarded-Host", r.In.Host)
+	scheme := "https"
+	if strings.HasPrefix(r.In.Host, "localhost") || strings.HasPrefix(r.In.Host, "127.0.0.1") || strings.HasPrefix(r.In.Host, "[::1]") {
+		scheme = "http"
+	}
+	r.Out.Header.Set("X-Forwarded-Proto", scheme)
+
+	r.Out.Host = upstreamURL.Host
+	r.Out.URL.Scheme = upstreamURL.Scheme
+	r.Out.URL.Host = upstreamURL.Host
+	r.Out.URL.Path = upstreamURL.Path
+	if rest := r.In.PathValue("rest"); rest != "" {
+		if strings.HasPrefix(rest, "/") {
+			r.Out.URL.Path = rest
+		} else {
+			r.Out.URL.Path = "/" + rest
+		}
+	}
+
+	// Merge query parameters from the incoming request and the upstream URL.
+	// Preserve all values; if a key exists in both, both values will be present.
+	upstreamQuery := upstreamURL.Query()
+	origQuery := r.In.URL.Query()
+	for k, vs := range origQuery {
+		for _, v := range vs {
+			upstreamQuery.Add(k, v)
+		}
+	}
+	r.Out.URL.RawQuery = upstreamQuery.Encode()
 }
 
 func (h *Handler) ensureServerIsDeployed(req api.Context) (mcp.ServerConfig, error) {

--- a/pkg/api/handlers/mcpgateway/handler_test.go
+++ b/pkg/api/handlers/mcpgateway/handler_test.go
@@ -1,6 +1,97 @@
 package mcpgateway
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/safehttp"
+	"golang.org/x/oauth2"
+)
+
+func TestProxyStripsInboundGatewayAuthorization(t *testing.T) {
+	tests := []struct {
+		name                      string
+		configuredUpstreamHeaders http.Header
+		tokenSource               oauth2.TokenSource
+		wantAuthorization         string
+	}{
+		{
+			name: "non-authorization upstream credential",
+			configuredUpstreamHeaders: http.Header{
+				"X-Filesapi-Key": {"files-api-key"},
+			},
+		},
+		{
+			name: "configured upstream authorization",
+			configuredUpstreamHeaders: http.Header{
+				"Authorization":  {"Bearer configured-upstream-token"},
+				"X-Filesapi-Key": {"files-api-key"},
+			},
+			wantAuthorization: "Bearer configured-upstream-token",
+		},
+		{
+			name: "upstream OAuth authorization",
+			configuredUpstreamHeaders: http.Header{
+				"X-Filesapi-Key": {"files-api-key"},
+			},
+			tokenSource:       oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "oauth-upstream-token"}),
+			wantAuthorization: "Bearer oauth-upstream-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receivedHeaders := make(chan http.Header, 1)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				receivedHeaders <- req.Header.Clone()
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer upstream.Close()
+
+			upstreamURL, err := url.Parse(upstream.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			proxy := httptest.NewServer(&httputil.ReverseProxy{
+				Transport: safehttp.NewSafeTransport(safehttp.Options{
+					Headers:     tt.configuredUpstreamHeaders,
+					TokenSource: tt.tokenSource,
+				}),
+				Rewrite: func(req *httputil.ProxyRequest) {
+					rewriteProxyRequest(req, upstreamURL)
+				},
+			})
+			defer proxy.Close()
+
+			request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, proxy.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request.Header.Set("Authorization", "Bearer obot-gateway-jwt")
+
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response.Body.Close()
+			if response.StatusCode != http.StatusNoContent {
+				t.Fatalf("response status = %d, want %d", response.StatusCode, http.StatusNoContent)
+			}
+
+			got := <-receivedHeaders
+			if got.Get("X-FilesAPI-Key") != "files-api-key" {
+				t.Fatalf("X-FilesAPI-Key = %q, want files-api-key", got.Get("X-FilesAPI-Key"))
+			}
+			if got.Get("Authorization") != tt.wantAuthorization {
+				t.Fatalf("Authorization = %q, want %q", got.Get("Authorization"), tt.wantAuthorization)
+			}
+		})
+	}
+}
 
 func TestCompositeLoopbackURLsUsesBackendTargetAndPublicAudience(t *testing.T) {
 	const (


### PR DESCRIPTION
## Summary

- Remove the inbound Obot MCP gateway bearer token
- Continue applying explicitly configured upstream Authorization headers and upstream OAuth tokens through the existing transport.
- Add focused regression coverage for API-key-only, configured bearer, and OAuth credential paths.