### PR TITLE
enhance: use virtual session to track clients

### DIFF
--- a/pkg/api/handlers/mcpgateway/client_session.go
+++ b/pkg/api/handlers/mcpgateway/client_session.go
@@ -22,9 +22,9 @@ func mcpClientSessionName(metadata map[string]string, sessionID string) string {
 	}))
 }
 
-func saveMCPClientSession(ctx context.Context, client kclient.Client, entry *auditlogs.MCPAuditLog) error {
+func saveMCPClientSession(ctx context.Context, client kclient.Client, entry *auditlogs.MCPAuditLog, virtual bool) (bool, error) {
 	if entry.SessionID == "" {
-		return nil
+		return false, nil
 	}
 
 	key := kclient.ObjectKey{
@@ -35,7 +35,7 @@ func saveMCPClientSession(ctx context.Context, client kclient.Client, entry *aud
 	var session v1.MCPClientSession
 	if err := client.Get(ctx, key, &session); apierrors.IsNotFound(err) {
 		if entry.ClientName == "" && entry.ClientVersion == "" {
-			return nil
+			return false, nil
 		}
 		session = v1.MCPClientSession{
 			Namespace: key.Namespace,
@@ -45,37 +45,38 @@ func saveMCPClientSession(ctx context.Context, client kclient.Client, entry *aud
 				UserID:        entry.Metadata["userID"],
 				ClientName:    entry.ClientName,
 				ClientVersion: entry.ClientVersion,
+				Virtual:       virtual,
 			},
 		}
 		if err := client.Create(ctx, &session); err != nil && !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create client session: %w", err)
+			return false, fmt.Errorf("failed to create client session: %w", err)
 		} else if apierrors.IsAlreadyExists(err) {
 			if err := client.Get(ctx, key, &session); err != nil {
-				return fmt.Errorf("get concurrently created MCP client session: %w", err)
+				return false, fmt.Errorf("get concurrently created MCP client session: %w", err)
 			}
 		}
 	} else if err != nil {
-		return fmt.Errorf("get MCP client session: %w", err)
+		return false, fmt.Errorf("get MCP client session: %w", err)
 	}
 
 	if session.Spec.MCPServerID != entry.Metadata["mcpID"] || session.Spec.UserID != entry.Metadata["userID"] {
-		return fmt.Errorf("inconsistent MCP client session data")
+		return false, fmt.Errorf("inconsistent MCP client session data")
 	}
 	if entry.ClientName == "" {
 		entry.ClientName = session.Spec.ClientName
 	} else if session.Spec.ClientName != entry.ClientName {
-		return fmt.Errorf("inconsistent MCP client session data")
+		return false, fmt.Errorf("inconsistent MCP client session data")
 	}
 	if entry.ClientVersion == "" {
 		entry.ClientVersion = session.Spec.ClientVersion
 	} else if session.Spec.ClientVersion != entry.ClientVersion {
-		return fmt.Errorf("inconsistent MCP client session data")
+		return false, fmt.Errorf("inconsistent MCP client session data")
 	}
 	session.Status.LastUsed = metav1.Now()
 
 	// Ignore conflict errors. That just means the time was updated between get and update, and that's fine.
 	if err := client.Status().Update(ctx, &session); err != nil && !apierrors.IsConflict(err) {
-		return fmt.Errorf("update MCP client session: %w", err)
+		return false, fmt.Errorf("update MCP client session: %w", err)
 	}
-	return nil
+	return session.Spec.Virtual, nil
 }

--- a/pkg/api/handlers/mcpgateway/proxy_audit.go
+++ b/pkg/api/handlers/mcpgateway/proxy_audit.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/obot-platform/nanobot/pkg/mcp/auditlogs"
 	obotmcp "github.com/obot-platform/obot/pkg/mcp"
@@ -104,8 +105,14 @@ func newProxyAudit(req *http.Request, metadata map[string]string, collector prox
 	if kind == proxyMessageRequest {
 		audit.proxyExchangeID = rand.Text()
 	}
-	if err := saveMCPClientSession(audit.ctx, audit.storage, &audit.entry); err != nil {
+	virtualSession, err := saveMCPClientSession(audit.ctx, audit.storage, &audit.entry, false)
+	if err != nil {
 		slog.ErrorContext(req.Context(), "failed to load MCP client session for audit logging", "error", err)
+	}
+
+	// If this is a virtual session, then remove the session ID header from the request because the upstream server isn't expecting it.
+	if virtualSession {
+		req.Header.Del(mcpSessionHeader)
 	}
 
 	return audit, nil
@@ -291,10 +298,17 @@ func (a *proxyAudit) wrapResponse(resp *http.Response) error {
 	if a == nil {
 		return nil
 	}
+
+	var virtual bool
 	if sessionID := resp.Header.Get(mcpSessionHeader); sessionID != "" {
 		a.entry.SessionID = sessionID
+	} else if a.entry.CallType == "initialize" && resp.StatusCode == http.StatusOK {
+		a.entry.SessionID = uuid.New().String()
+		resp.Header.Set(mcpSessionHeader, a.entry.SessionID)
+		virtual = true
 	}
-	if err := saveMCPClientSession(a.ctx, a.storage, &a.entry); err != nil {
+
+	if _, err := saveMCPClientSession(a.ctx, a.storage, &a.entry, virtual); err != nil {
 		slog.Error("failed to save MCP client session for audit logging", "error", err)
 	}
 	responseHeaders, _ := json.Marshal(sanitizedMCPHeaders(resp.Header))

--- a/pkg/api/handlers/mcpgateway/proxy_audit_test.go
+++ b/pkg/api/handlers/mcpgateway/proxy_audit_test.go
@@ -209,6 +209,9 @@ func TestMCPProxyAuditPersistsAndLoadsClientInfoBySession(t *testing.T) {
 	if session.Spec.MCPServerID != "mcp-1" || session.Spec.UserID != "user-1" || session.Spec.ClientName != "Claude Desktop" || session.Spec.ClientVersion != "1.2.3" {
 		t.Fatalf("unexpected persisted client session: %#v", session.Spec)
 	}
+	if session.Spec.Virtual {
+		t.Fatal("upstream-provided session was marked virtual")
+	}
 	if session.Status.LastUsed.IsZero() {
 		t.Fatal("new client session did not record its initial last-used time")
 	}
@@ -230,11 +233,77 @@ func TestMCPProxyAuditPersistsAndLoadsClientInfoBySession(t *testing.T) {
 	if followupAuditor.entry.ClientName != "Claude Desktop" || followupAuditor.entry.ClientVersion != "1.2.3" {
 		t.Fatalf("client identity was not loaded from storage: name=%q version=%q", followupAuditor.entry.ClientName, followupAuditor.entry.ClientVersion)
 	}
+	if got := followup.Header.Get(mcpSessionHeader); got != "session-1" {
+		t.Fatalf("upstream-provided session header was changed: got %q", got)
+	}
 	if err := storageClient.Get(t.Context(), key, &session); err != nil {
 		t.Fatal(err)
 	}
 	if !session.Status.LastUsed.After(oldLastUsed.Time) {
 		t.Fatalf("last-used time was not updated: %v", session.Status.LastUsed)
+	}
+}
+
+func TestMCPProxyAuditCreatesAndReusesVirtualSession(t *testing.T) {
+	collector := new(recordingProxyAuditCollector)
+	storageClient := newMCPProxyTestStorage()
+	metadata := map[string]string{"mcpID": "mcp-1", "userID": "user-1"}
+	initialize, err := http.NewRequest(http.MethodPost, "http://obot.example/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"Stateless Client","version":"1.0.0"}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditor, err := newProxyAudit(initialize, metadata, collector, storageClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	auditor.recordRequest()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}`)),
+	}
+	consumeAuditResponse(t, auditor, resp)
+
+	virtualSessionID := resp.Header.Get(mcpSessionHeader)
+	if virtualSessionID == "" {
+		t.Fatal("initialize response without an upstream session did not receive a virtual session ID")
+	}
+	if len(collector.entries) != 2 || collector.entries[1].SessionID != virtualSessionID {
+		t.Fatalf("virtual session was not recorded on the initialize response: %#v", collector.entries)
+	}
+
+	key := kclient.ObjectKey{
+		Namespace: system.DefaultNamespace,
+		Name:      mcpClientSessionName(metadata, virtualSessionID),
+	}
+	var session v1.MCPClientSession
+	if err := storageClient.Get(t.Context(), key, &session); err != nil {
+		t.Fatalf("virtual client session was not persisted: %v", err)
+	}
+	if !session.Spec.Virtual {
+		t.Fatalf("generated session was not marked virtual: %#v", session.Spec)
+	}
+	if session.Spec.ClientName != "Stateless Client" || session.Spec.ClientVersion != "1.0.0" {
+		t.Fatalf("virtual session lost client identity: %#v", session.Spec)
+	}
+
+	followup, err := http.NewRequest(http.MethodPost, "http://obot.example/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	followup.Header.Set(mcpSessionHeader, virtualSessionID)
+	followupAuditor, err := newProxyAudit(followup, metadata, collector, storageClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := followup.Header.Get(mcpSessionHeader); got != "" {
+		t.Fatalf("virtual session header was forwarded upstream: %q", got)
+	}
+	if followupAuditor.entry.SessionID != virtualSessionID {
+		t.Fatalf("removing the upstream header also removed audit correlation: got %q, want %q", followupAuditor.entry.SessionID, virtualSessionID)
+	}
+	if followupAuditor.entry.ClientName != "Stateless Client" || followupAuditor.entry.ClientVersion != "1.0.0" {
+		t.Fatalf("virtual session did not restore client identity: name=%q version=%q", followupAuditor.entry.ClientName, followupAuditor.entry.ClientVersion)
 	}
 }
 

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpclientsession.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpclientsession.go
@@ -17,6 +17,9 @@ type MCPClientSessionSpec struct {
 	UserID        string `json:"userID"`
 	ClientName    string `json:"clientName"`
 	ClientVersion string `json:"clientVersion"`
+	// A Virtual session is one that doesn't come back from an MCP server,
+	// but is used by Obot to track clients.
+	Virtual bool `json:"virtual"`
 }
 
 type MCPClientSessionStatus struct {

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -21537,8 +21537,16 @@ func schema_storage_apis_obotobotai_v1_MCPClientSessionSpec(ref common.Reference
 							Format:  "",
 						},
 					},
+					"virtual": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A Virtual session is one that doesn't come back from an MCP server, but is used by Obot to track clients.",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"mcpServerID", "userID", "clientName", "clientVersion"},
+				Required: []string{"mcpServerID", "userID", "clientName", "clientVersion", "virtual"},
 			},
 		},
 	}


### PR DESCRIPTION
Now that the MCP gatewa is a pass-through, we loose the ability to track clients for servers that don't use session IDs. This change adds virtual sessions that are only returned to the client and removed before forwarding to the server so we can track clients throughout the use of a session.