### PR TITLE
fix(ui): identify revoked keys in audit logs

### DIFF
--- a/apiclient/types/auditlogevent.go
+++ b/apiclient/types/auditlogevent.go
@@ -102,6 +102,8 @@ type AuditLogActor struct {
 	ID        string            `json:"id,omitempty"`
 	// CredentialID records authentication context when the actor itself is a known user.
 	CredentialID string `json:"credentialID,omitempty"`
+	// APIKeyID identifies the API key represented by CredentialID without relying on its display value.
+	APIKeyID uint `json:"apiKeyID,omitempty"`
 }
 
 // AuditLogAction describes what the actor attempted. Operation contains the protocol operation,

--- a/apiclient/types/auditlogevent.go
+++ b/apiclient/types/auditlogevent.go
@@ -102,7 +102,8 @@ type AuditLogActor struct {
 	ID        string            `json:"id,omitempty"`
 	// CredentialID records authentication context when the actor itself is a known user.
 	CredentialID string `json:"credentialID,omitempty"`
-	// APIKeyRevoked reports the current lifecycle state of the API key represented by CredentialID.
+	// APIKeyRevoked reports the current lifecycle state of the API key represented by CredentialID,
+	// or by ID when ActorType is AuditLogActorTypeCredential.
 	APIKeyRevoked bool `json:"apiKeyRevoked,omitempty"`
 }
 

--- a/apiclient/types/auditlogevent.go
+++ b/apiclient/types/auditlogevent.go
@@ -102,8 +102,8 @@ type AuditLogActor struct {
 	ID        string            `json:"id,omitempty"`
 	// CredentialID records authentication context when the actor itself is a known user.
 	CredentialID string `json:"credentialID,omitempty"`
-	// APIKeyID identifies the API key represented by CredentialID without relying on its display value.
-	APIKeyID uint `json:"apiKeyID,omitempty"`
+	// APIKeyRevoked reports the current lifecycle state of the API key represented by CredentialID.
+	APIKeyRevoked bool `json:"apiKeyRevoked,omitempty"`
 }
 
 // AuditLogAction describes what the actor attempted. Operation contains the protocol operation,

--- a/apiclient/types/llmauditlog.go
+++ b/apiclient/types/llmauditlog.go
@@ -11,6 +11,8 @@ type LLMAuditLog struct {
 	Duration  int64  `json:"duration"`
 	UserID    string `json:"userID"`
 	APIKeyID  *uint  `json:"apiKeyID,omitempty"`
+	// APIKeyRevoked reports the API key's current lifecycle state.
+	APIKeyRevoked bool `json:"apiKeyRevoked,omitempty"`
 	// APIKeyName is the event-time display value and is a masked identifier for unnamed keys.
 	APIKeyName                string          `json:"apiKeyName,omitempty"`
 	ModelProvider             string          `json:"modelProvider"`

--- a/pkg/auditlog/presenter.go
+++ b/pkg/auditlog/presenter.go
@@ -70,7 +70,7 @@ func presentMCP(event *api.AuditLogEvent, log gatewaytypes.MCPAuditLog, opts Pre
 	event.EventType = api.AuditLogEventTypeMCPCall
 	// MCPFields.APIKey is a legacy field that may contain the bearer token. Only expose the
 	// event-time, non-secret display snapshot through the normalized audit-log API.
-	event.Actor = mcpActor(log.UserID, apiKeyDisplayName(log.UserID, log.APIKeyID, log.APIKeyName), apiKeyID(log.APIKeyID))
+	event.Actor = mcpActor(log.UserID, apiKeyDisplayName(log.UserID, log.APIKeyID, log.APIKeyName), log.APIKeyRevoked)
 	event.Action = api.AuditLogAction{
 		Operation: mcp.CallType,
 		Name:      mcp.CallIdentifier,
@@ -145,27 +145,20 @@ func apiKeyDisplayName(userID string, apiKeyID *uint, name string) string {
 	return fmt.Sprintf("%s (%s)", name, maskedKey)
 }
 
-func apiKeyID(id *uint) uint {
-	if id == nil {
-		return 0
-	}
-	return *id
-}
-
-func mcpActor(userID, credentialID string, credentialAPIKeyID uint) api.AuditLogActor {
+func mcpActor(userID, credentialID string, apiKeyRevoked bool) api.AuditLogActor {
 	if userID != "" {
 		return api.AuditLogActor{
-			ActorType:    api.AuditLogActorTypeUser,
-			ID:           userID,
-			CredentialID: credentialID,
-			APIKeyID:     credentialAPIKeyID,
+			ActorType:     api.AuditLogActorTypeUser,
+			ID:            userID,
+			CredentialID:  credentialID,
+			APIKeyRevoked: apiKeyRevoked,
 		}
 	}
 	if credentialID != "" {
 		return api.AuditLogActor{
-			ActorType: api.AuditLogActorTypeCredential,
-			ID:        credentialID,
-			APIKeyID:  credentialAPIKeyID,
+			ActorType:     api.AuditLogActorTypeCredential,
+			ID:            credentialID,
+			APIKeyRevoked: apiKeyRevoked,
 		}
 	}
 	return api.AuditLogActor{ActorType: api.AuditLogActorTypeUnknown}
@@ -214,10 +207,10 @@ func presentLocalAgent(event *api.AuditLogEvent, log gatewaytypes.MCPAuditLog, o
 	event.Timestamp.Source = api.AuditLogTimestampSourceClientReported
 	event.Timestamp.OccurredAt = *api.NewTime(local.OccurredAt)
 	event.Actor = api.AuditLogActor{
-		ActorType:    local.ActorType,
-		ID:           local.ActorID,
-		CredentialID: apiKeyDisplayName(log.UserID, log.APIKeyID, log.APIKeyName),
-		APIKeyID:     apiKeyID(log.APIKeyID),
+		ActorType:     local.ActorType,
+		ID:            local.ActorID,
+		CredentialID:  apiKeyDisplayName(log.UserID, log.APIKeyID, log.APIKeyName),
+		APIKeyRevoked: log.APIKeyRevoked,
 	}
 	event.Action = api.AuditLogAction{
 		Operation: "tools/call",

--- a/pkg/auditlog/presenter.go
+++ b/pkg/auditlog/presenter.go
@@ -70,7 +70,7 @@ func presentMCP(event *api.AuditLogEvent, log gatewaytypes.MCPAuditLog, opts Pre
 	event.EventType = api.AuditLogEventTypeMCPCall
 	// MCPFields.APIKey is a legacy field that may contain the bearer token. Only expose the
 	// event-time, non-secret display snapshot through the normalized audit-log API.
-	event.Actor = mcpActor(log.UserID, apiKeyDisplayName(log.UserID, log.APIKeyID, log.APIKeyName))
+	event.Actor = mcpActor(log.UserID, apiKeyDisplayName(log.UserID, log.APIKeyID, log.APIKeyName), apiKeyID(log.APIKeyID))
 	event.Action = api.AuditLogAction{
 		Operation: mcp.CallType,
 		Name:      mcp.CallIdentifier,
@@ -145,18 +145,27 @@ func apiKeyDisplayName(userID string, apiKeyID *uint, name string) string {
 	return fmt.Sprintf("%s (%s)", name, maskedKey)
 }
 
-func mcpActor(userID, credentialID string) api.AuditLogActor {
+func apiKeyID(id *uint) uint {
+	if id == nil {
+		return 0
+	}
+	return *id
+}
+
+func mcpActor(userID, credentialID string, credentialAPIKeyID uint) api.AuditLogActor {
 	if userID != "" {
 		return api.AuditLogActor{
 			ActorType:    api.AuditLogActorTypeUser,
 			ID:           userID,
 			CredentialID: credentialID,
+			APIKeyID:     credentialAPIKeyID,
 		}
 	}
 	if credentialID != "" {
 		return api.AuditLogActor{
 			ActorType: api.AuditLogActorTypeCredential,
 			ID:        credentialID,
+			APIKeyID:  credentialAPIKeyID,
 		}
 	}
 	return api.AuditLogActor{ActorType: api.AuditLogActorTypeUnknown}
@@ -208,6 +217,7 @@ func presentLocalAgent(event *api.AuditLogEvent, log gatewaytypes.MCPAuditLog, o
 		ActorType:    local.ActorType,
 		ID:           local.ActorID,
 		CredentialID: apiKeyDisplayName(log.UserID, log.APIKeyID, log.APIKeyName),
+		APIKeyID:     apiKeyID(log.APIKeyID),
 	}
 	event.Action = api.AuditLogAction{
 		Operation: "tools/call",

--- a/pkg/auditlog/presenter_test.go
+++ b/pkg/auditlog/presenter_test.go
@@ -170,8 +170,8 @@ func TestPresentLocalAgentIncludesAPIKeyCredential(t *testing.T) {
 }
 
 func TestPresentUnknownActors(t *testing.T) {
-	mcp := gatewaytypes.MCPAuditLog{SourceType: api.AuditLogSourceTypeMCP, APIKeyName: "credential", MCPFields: &gatewaytypes.MCPAuditLogFields{}}
-	if actor := Present(mcp, PresentOptions{}).Actor; actor.ActorType != api.AuditLogActorTypeCredential || actor.ID != "credential" {
+	mcp := gatewaytypes.MCPAuditLog{SourceType: api.AuditLogSourceTypeMCP, APIKeyName: "credential", APIKeyRevoked: true, MCPFields: &gatewaytypes.MCPAuditLogFields{}}
+	if actor := Present(mcp, PresentOptions{}).Actor; actor.ActorType != api.AuditLogActorTypeCredential || actor.ID != "credential" || !actor.APIKeyRevoked {
 		t.Fatalf("unexpected credential actor: %#v", actor)
 	}
 	legacyMCP := gatewaytypes.MCPAuditLog{SourceType: api.AuditLogSourceTypeMCP, MCPFields: &gatewaytypes.MCPAuditLogFields{APIKey: "ok1-user-1-17-super-secret"}}

--- a/pkg/auditlog/presenter_test.go
+++ b/pkg/auditlog/presenter_test.go
@@ -39,7 +39,7 @@ func TestPresentMCPNormalizesSummaryAndDetails(t *testing.T) {
 	log := gatewaytypes.MCPAuditLog{
 		ID: 7, CreatedAt: created, SourceType: api.AuditLogSourceTypeMCP,
 		UserID: "user-1", APIKeyID: &apiKeyID, ClientIP: "127.0.0.1",
-		APIKeyName: "CLI token",
+		APIKeyName: "CLI token", APIKeyRevoked: true,
 		MCPFields: &gatewaytypes.MCPAuditLogFields{
 			APIKey: "ok1-user-1-17-super-secret", MCPID: "mcp-1", MCPServerDisplayName: "GitHub",
 			CallType: "tools/call", CallIdentifier: "search", ResponseStatus: 200,
@@ -52,7 +52,7 @@ func TestPresentMCPNormalizesSummaryAndDetails(t *testing.T) {
 	if summary.Details != nil || summary.EventType != api.AuditLogEventTypeMCPCall {
 		t.Fatalf("unexpected summary: %#v", summary)
 	}
-	if summary.Actor.ActorType != api.AuditLogActorTypeUser || summary.Actor.ID != "user-1" || summary.Actor.CredentialID != "CLI token (ok1-user-1-17-*****)" || summary.Actor.APIKeyID != apiKeyID {
+	if summary.Actor.ActorType != api.AuditLogActorTypeUser || summary.Actor.ID != "user-1" || summary.Actor.CredentialID != "CLI token (ok1-user-1-17-*****)" || !summary.Actor.APIKeyRevoked {
 		t.Fatalf("unexpected actor: %#v", summary.Actor)
 	}
 	if summary.Target.TargetType != api.AuditLogTargetTypeMCPTool || summary.Target.Parent == nil {
@@ -104,15 +104,16 @@ func TestPresentMCPDoesNotDeriveAPIKeyMaskFromHostedAgentActor(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			log := gatewaytypes.MCPAuditLog{
-				SourceType: api.AuditLogSourceTypeMCP,
-				UserID:     "hosted-agent:hai1abc",
-				APIKeyID:   &apiKeyID,
-				APIKeyName: test.apiKeyName,
-				MCPFields:  &gatewaytypes.MCPAuditLogFields{},
+				SourceType:    api.AuditLogSourceTypeMCP,
+				UserID:        "hosted-agent:hai1abc",
+				APIKeyID:      &apiKeyID,
+				APIKeyName:    test.apiKeyName,
+				APIKeyRevoked: true,
+				MCPFields:     &gatewaytypes.MCPAuditLogFields{},
 			}
 
 			actor := Present(log, PresentOptions{}).Actor
-			if actor.CredentialID != test.apiKeyName || actor.APIKeyID != apiKeyID {
+			if actor.CredentialID != test.apiKeyName || !actor.APIKeyRevoked {
 				t.Fatalf("credential display = %q, want %q", actor.CredentialID, test.apiKeyName)
 			}
 		})
@@ -151,10 +152,11 @@ func TestPresentLocalAgentIdentityTargetAndTimestamp(t *testing.T) {
 func TestPresentLocalAgentIncludesAPIKeyCredential(t *testing.T) {
 	apiKeyID := uint(17)
 	log := gatewaytypes.MCPAuditLog{
-		SourceType: api.AuditLogSourceTypeLocalAgentToolCall,
-		UserID:     "42",
-		APIKeyID:   &apiKeyID,
-		APIKeyName: "Local CLI",
+		SourceType:    api.AuditLogSourceTypeLocalAgentToolCall,
+		UserID:        "42",
+		APIKeyID:      &apiKeyID,
+		APIKeyName:    "Local CLI",
+		APIKeyRevoked: true,
 		LocalAgentToolCallFields: &gatewaytypes.LocalAgentToolCallAuditLogFields{
 			ActorType: api.AuditLogActorTypeUser,
 			ActorID:   "42",
@@ -162,7 +164,7 @@ func TestPresentLocalAgentIncludesAPIKeyCredential(t *testing.T) {
 	}
 
 	actor := Present(log, PresentOptions{}).Actor
-	if actor.CredentialID != "Local CLI (ok1-42-17-*****)" || actor.APIKeyID != apiKeyID {
+	if actor.CredentialID != "Local CLI (ok1-42-17-*****)" || !actor.APIKeyRevoked {
 		t.Fatalf("unexpected API-key credential: %#v", actor)
 	}
 }

--- a/pkg/auditlog/presenter_test.go
+++ b/pkg/auditlog/presenter_test.go
@@ -52,7 +52,7 @@ func TestPresentMCPNormalizesSummaryAndDetails(t *testing.T) {
 	if summary.Details != nil || summary.EventType != api.AuditLogEventTypeMCPCall {
 		t.Fatalf("unexpected summary: %#v", summary)
 	}
-	if summary.Actor.ActorType != api.AuditLogActorTypeUser || summary.Actor.ID != "user-1" || summary.Actor.CredentialID != "CLI token (ok1-user-1-17-*****)" {
+	if summary.Actor.ActorType != api.AuditLogActorTypeUser || summary.Actor.ID != "user-1" || summary.Actor.CredentialID != "CLI token (ok1-user-1-17-*****)" || summary.Actor.APIKeyID != apiKeyID {
 		t.Fatalf("unexpected actor: %#v", summary.Actor)
 	}
 	if summary.Target.TargetType != api.AuditLogTargetTypeMCPTool || summary.Target.Parent == nil {
@@ -112,7 +112,7 @@ func TestPresentMCPDoesNotDeriveAPIKeyMaskFromHostedAgentActor(t *testing.T) {
 			}
 
 			actor := Present(log, PresentOptions{}).Actor
-			if actor.CredentialID != test.apiKeyName {
+			if actor.CredentialID != test.apiKeyName || actor.APIKeyID != apiKeyID {
 				t.Fatalf("credential display = %q, want %q", actor.CredentialID, test.apiKeyName)
 			}
 		})
@@ -162,7 +162,7 @@ func TestPresentLocalAgentIncludesAPIKeyCredential(t *testing.T) {
 	}
 
 	actor := Present(log, PresentOptions{}).Actor
-	if actor.CredentialID != "Local CLI (ok1-42-17-*****)" {
+	if actor.CredentialID != "Local CLI (ok1-42-17-*****)" || actor.APIKeyID != apiKeyID {
 		t.Fatalf("unexpected API-key credential: %#v", actor)
 	}
 }

--- a/pkg/gateway/client/audit_api_key_filter.go
+++ b/pkg/gateway/client/audit_api_key_filter.go
@@ -18,6 +18,63 @@ type auditLogAPIKeyOptionRow struct {
 	Revoked    bool
 }
 
+const auditLogAPIKeyLookupBatchSize = 1000
+
+type auditLogWithAPIKey interface {
+	AuditLogAPIKeyID() *uint
+	SetAuditLogAPIKeyRevoked(bool)
+}
+
+func enrichAuditLogAPIKeyRevocation[T any](ctx context.Context, c *Client, logs []T, asAuditLog func(*T) auditLogWithAPIKey) error {
+	ids := make([]uint, 0, len(logs))
+	for i := range logs {
+		if id := asAuditLog(&logs[i]).AuditLogAPIKeyID(); id != nil {
+			ids = append(ids, *id)
+		}
+	}
+	revoked, err := c.revokedAPIKeyIDs(ctx, ids)
+	if err != nil {
+		return err
+	}
+	for i := range logs {
+		log := asAuditLog(&logs[i])
+		if id := log.AuditLogAPIKeyID(); id != nil {
+			_, isRevoked := revoked[*id]
+			log.SetAuditLogAPIKeyRevoked(isRevoked)
+		}
+	}
+	return nil
+}
+
+func (c *Client) revokedAPIKeyIDs(ctx context.Context, ids []uint) (map[uint]struct{}, error) {
+	unique := make(map[uint]struct{}, len(ids))
+	for _, id := range ids {
+		if id != 0 {
+			unique[id] = struct{}{}
+		}
+	}
+	uniqueIDs := make([]uint, 0, len(unique))
+	for id := range unique {
+		uniqueIDs = append(uniqueIDs, id)
+	}
+
+	revoked := make(map[uint]struct{})
+	for offset := 0; offset < len(uniqueIDs); offset += auditLogAPIKeyLookupBatchSize {
+		end := min(offset+auditLogAPIKeyLookupBatchSize, len(uniqueIDs))
+		var batch []uint
+		if err := c.db.WithContext(ctx).
+			Model(&types.APIKey{}).
+			Where("id IN ? AND revoked_at IS NOT NULL", uniqueIDs[offset:end]).
+			Pluck("id", &batch).Error; err != nil {
+			return nil, err
+		}
+		for _, id := range batch {
+			revoked[id] = struct{}{}
+		}
+	}
+	return revoked, nil
+}
+
 // GetMCPAuditLogAPIKeyFilterOptions returns the API keys present in the
 // currently filtered and authorized MCP and local-agent audit-log result set.
 func (c *Client) GetMCPAuditLogAPIKeyFilterOptions(ctx context.Context, opts MCPAuditLogOptions) ([]apitypes.AuditLogAPIKeyFilterOption, error) {

--- a/pkg/gateway/client/audit_api_key_filter.go
+++ b/pkg/gateway/client/audit_api_key_filter.go
@@ -11,14 +11,16 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	auditLogAPIKeyLookupBatchSize = 1000
+)
+
 type auditLogAPIKeyOptionRow struct {
 	APIKeyID   uint
 	APIKeyName string
 	UserID     uint
 	Revoked    bool
 }
-
-const auditLogAPIKeyLookupBatchSize = 1000
 
 func (c *Client) enrichLLMAuditLogAPIKeyRevocation(ctx context.Context, logs []types.LLMAuditLog) error {
 	ids := make([]uint, 0, len(logs))

--- a/pkg/gateway/client/audit_api_key_filter.go
+++ b/pkg/gateway/client/audit_api_key_filter.go
@@ -20,16 +20,11 @@ type auditLogAPIKeyOptionRow struct {
 
 const auditLogAPIKeyLookupBatchSize = 1000
 
-type auditLogWithAPIKey interface {
-	AuditLogAPIKeyID() *uint
-	SetAuditLogAPIKeyRevoked(bool)
-}
-
-func enrichAuditLogAPIKeyRevocation[T any](ctx context.Context, c *Client, logs []T, asAuditLog func(*T) auditLogWithAPIKey) error {
+func (c *Client) enrichLLMAuditLogAPIKeyRevocation(ctx context.Context, logs []types.LLMAuditLog) error {
 	ids := make([]uint, 0, len(logs))
-	for i := range logs {
-		if id := asAuditLog(&logs[i]).AuditLogAPIKeyID(); id != nil {
-			ids = append(ids, *id)
+	for _, log := range logs {
+		if log.APIKeyID != nil {
+			ids = append(ids, *log.APIKeyID)
 		}
 	}
 	revoked, err := c.revokedAPIKeyIDs(ctx, ids)
@@ -37,10 +32,27 @@ func enrichAuditLogAPIKeyRevocation[T any](ctx context.Context, c *Client, logs 
 		return err
 	}
 	for i := range logs {
-		log := asAuditLog(&logs[i])
-		if id := log.AuditLogAPIKeyID(); id != nil {
-			_, isRevoked := revoked[*id]
-			log.SetAuditLogAPIKeyRevoked(isRevoked)
+		if logs[i].APIKeyID != nil {
+			_, logs[i].APIKeyRevoked = revoked[*logs[i].APIKeyID]
+		}
+	}
+	return nil
+}
+
+func (c *Client) enrichMCPAuditLogAPIKeyRevocation(ctx context.Context, logs []types.MCPAuditLog) error {
+	ids := make([]uint, 0, len(logs))
+	for _, log := range logs {
+		if log.APIKeyID != nil {
+			ids = append(ids, *log.APIKeyID)
+		}
+	}
+	revoked, err := c.revokedAPIKeyIDs(ctx, ids)
+	if err != nil {
+		return err
+	}
+	for i := range logs {
+		if logs[i].APIKeyID != nil {
+			_, logs[i].APIKeyRevoked = revoked[*logs[i].APIKeyID]
 		}
 	}
 	return nil

--- a/pkg/gateway/client/audit_api_key_filter_test.go
+++ b/pkg/gateway/client/audit_api_key_filter_test.go
@@ -103,6 +103,64 @@ func TestAuditLogAPIKeyFilterOptions(t *testing.T) {
 		t.Fatalf("save encrypted user: %v", err)
 	}
 
+	mcpLogs, _, err := c.GetMCPAuditLogs(ctx, MCPAuditLogOptions{
+		SourceTypes: []apitypes.AuditLogSourceType{apitypes.AuditLogSourceTypeMCP},
+	})
+	if err != nil {
+		t.Fatalf("get enriched MCP audit logs: %v", err)
+	}
+	var revokedMCPLogID uint
+	for _, log := range mcpLogs {
+		if log.APIKeyID == nil {
+			continue
+		}
+		wantRevoked := *log.APIKeyID == duplicateName.ID
+		if log.APIKeyRevoked != wantRevoked {
+			t.Fatalf("MCP key %d revoked = %v, want %v", *log.APIKeyID, log.APIKeyRevoked, wantRevoked)
+		}
+		if wantRevoked {
+			revokedMCPLogID = log.ID
+		}
+	}
+	if revokedMCPLogID == 0 {
+		t.Fatal("revoked MCP audit log not found")
+	}
+	mcpDetail, err := c.GetMCPAuditLog(ctx, revokedMCPLogID, false)
+	if err != nil {
+		t.Fatalf("get enriched MCP audit log detail: %v", err)
+	}
+	if !mcpDetail.APIKeyRevoked {
+		t.Fatal("revoked MCP audit log detail was not enriched")
+	}
+
+	llmLogs, _, err := c.GetLLMAuditLogs(ctx, LLMAuditLogOptions{})
+	if err != nil {
+		t.Fatalf("get enriched LLM audit logs: %v", err)
+	}
+	var revokedLLMLogID string
+	for _, log := range llmLogs {
+		if log.APIKeyID == nil {
+			continue
+		}
+		wantRevoked := *log.APIKeyID == duplicateName.ID
+		if log.APIKeyRevoked != wantRevoked {
+			t.Fatalf("LLM key %d revoked = %v, want %v", *log.APIKeyID, log.APIKeyRevoked, wantRevoked)
+		}
+		if wantRevoked {
+			revokedLLMLogID = log.ID
+		}
+	}
+	if revokedLLMLogID == "" {
+		t.Fatal("revoked LLM audit log not found")
+	}
+	llmDetail, err := c.GetLLMAuditLog(ctx, revokedLLMLogID, false)
+	if err != nil {
+		t.Fatalf("get enriched LLM audit log detail: %v", err)
+	}
+	if !llmDetail.APIKeyRevoked {
+		t.Fatal("revoked LLM audit log detail was not enriched")
+	}
+
 	assertOptions := func(t *testing.T, options []apitypes.AuditLogAPIKeyFilterOption) {
 		t.Helper()
 		if len(options) != 4 {

--- a/pkg/gateway/client/llmauditlog.go
+++ b/pkg/gateway/client/llmauditlog.go
@@ -128,6 +128,9 @@ func (c *Client) GetLLMAuditLogs(ctx context.Context, opts LLMAuditLogOptions) (
 	if err := db.Find(&logs).Error; err != nil {
 		return nil, 0, err
 	}
+	if err := enrichAuditLogAPIKeyRevocation(ctx, c, logs, func(log *types.LLMAuditLog) auditLogWithAPIKey { return log }); err != nil {
+		return nil, 0, err
+	}
 	for i := range logs {
 		if err := c.prepareLLMAuditLog(ctx, &logs[i], opts.WithSensitiveFields); err != nil {
 			return nil, 0, err
@@ -146,6 +149,11 @@ func (c *Client) GetLLMAuditLog(ctx context.Context, id string, withSensitiveFie
 	if err := db.First(&log, "id = ?", id).Error; err != nil {
 		return nil, err
 	}
+	logs := []types.LLMAuditLog{log}
+	if err := enrichAuditLogAPIKeyRevocation(ctx, c, logs, func(log *types.LLMAuditLog) auditLogWithAPIKey { return log }); err != nil {
+		return nil, err
+	}
+	log = logs[0]
 	if err := c.prepareLLMAuditLog(ctx, &log, withSensitiveFields); err != nil {
 		return nil, err
 	}

--- a/pkg/gateway/client/llmauditlog.go
+++ b/pkg/gateway/client/llmauditlog.go
@@ -128,7 +128,7 @@ func (c *Client) GetLLMAuditLogs(ctx context.Context, opts LLMAuditLogOptions) (
 	if err := db.Find(&logs).Error; err != nil {
 		return nil, 0, err
 	}
-	if err := enrichAuditLogAPIKeyRevocation(ctx, c, logs, func(log *types.LLMAuditLog) auditLogWithAPIKey { return log }); err != nil {
+	if err := c.enrichLLMAuditLogAPIKeyRevocation(ctx, logs); err != nil {
 		return nil, 0, err
 	}
 	for i := range logs {
@@ -150,7 +150,7 @@ func (c *Client) GetLLMAuditLog(ctx context.Context, id string, withSensitiveFie
 		return nil, err
 	}
 	logs := []types.LLMAuditLog{log}
-	if err := enrichAuditLogAPIKeyRevocation(ctx, c, logs, func(log *types.LLMAuditLog) auditLogWithAPIKey { return log }); err != nil {
+	if err := c.enrichLLMAuditLogAPIKeyRevocation(ctx, logs); err != nil {
 		return nil, err
 	}
 	log = logs[0]

--- a/pkg/gateway/client/mcpauditlog.go
+++ b/pkg/gateway/client/mcpauditlog.go
@@ -396,7 +396,7 @@ func (c *Client) GetMCPAuditLogs(ctx context.Context, opts MCPAuditLogOptions) (
 	if err := db.Find(&logs).Error; err != nil {
 		return nil, 0, err
 	}
-	if err := enrichAuditLogAPIKeyRevocation(ctx, c, logs, func(log *types.MCPAuditLog) auditLogWithAPIKey { return log }); err != nil {
+	if err := c.enrichMCPAuditLogAPIKeyRevocation(ctx, logs); err != nil {
 		return nil, 0, err
 	}
 	for i := range logs {
@@ -774,7 +774,7 @@ func (c *Client) GetMCPAuditLog(ctx context.Context, id uint, withRequestAndResp
 		return nil, err
 	}
 	logs := []types.MCPAuditLog{log}
-	if err := enrichAuditLogAPIKeyRevocation(ctx, c, logs, func(log *types.MCPAuditLog) auditLogWithAPIKey { return log }); err != nil {
+	if err := c.enrichMCPAuditLogAPIKeyRevocation(ctx, logs); err != nil {
 		return nil, err
 	}
 	log = logs[0]

--- a/pkg/gateway/client/mcpauditlog.go
+++ b/pkg/gateway/client/mcpauditlog.go
@@ -396,6 +396,9 @@ func (c *Client) GetMCPAuditLogs(ctx context.Context, opts MCPAuditLogOptions) (
 	if err := db.Find(&logs).Error; err != nil {
 		return nil, 0, err
 	}
+	if err := enrichAuditLogAPIKeyRevocation(ctx, c, logs, func(log *types.MCPAuditLog) auditLogWithAPIKey { return log }); err != nil {
+		return nil, 0, err
+	}
 	for i := range logs {
 		if err := c.prepareAuditLogPayload(ctx, &logs[i], opts.WithRequestAndResponse); err != nil {
 			return nil, 0, err
@@ -770,6 +773,11 @@ func (c *Client) GetMCPAuditLog(ctx context.Context, id uint, withRequestAndResp
 	if err := db.Where("id = ?", id).First(&log).Error; err != nil {
 		return nil, err
 	}
+	logs := []types.MCPAuditLog{log}
+	if err := enrichAuditLogAPIKeyRevocation(ctx, c, logs, func(log *types.MCPAuditLog) auditLogWithAPIKey { return log }); err != nil {
+		return nil, err
+	}
+	log = logs[0]
 	if log.SourceType == types2.AuditLogSourceTypeLocalAgentToolCall {
 		log.MCPFields = nil
 	} else {

--- a/pkg/gateway/types/llmauditlog.go
+++ b/pkg/gateway/types/llmauditlog.go
@@ -54,16 +54,6 @@ func (LLMAuditLog) TableName() string {
 	return "llm_audit_logs"
 }
 
-// AuditLogAPIKeyID returns the API key associated with this audit event.
-func (a *LLMAuditLog) AuditLogAPIKeyID() *uint {
-	return a.APIKeyID
-}
-
-// SetAuditLogAPIKeyRevoked sets the API key's current revocation state.
-func (a *LLMAuditLog) SetAuditLogAPIKeyRevoked(revoked bool) {
-	a.APIKeyRevoked = revoked
-}
-
 func ConvertLLMAuditLog(a LLMAuditLog) types2.LLMAuditLog {
 	return types2.LLMAuditLog{
 		ID:                        a.ID,

--- a/pkg/gateway/types/llmauditlog.go
+++ b/pkg/gateway/types/llmauditlog.go
@@ -19,6 +19,9 @@ type LLMAuditLog struct {
 	Duration  int64
 	UserID    string `gorm:"type:text;index:idx_llm_audit_user_created,priority:1"`
 	APIKeyID  *uint  `gorm:"index:idx_llm_audit_api_key_created,priority:1"`
+	// APIKeyRevoked is current lifecycle metadata populated when audit logs are read.
+	// It is not persisted as part of the historical event snapshot.
+	APIKeyRevoked bool `gorm:"-"`
 	// APIKeyName is the event-time display value. Unnamed keys snapshot their
 	// non-secret masked identifier instead of requiring an API-key table join.
 	APIKeyName                string `gorm:"type:text"`
@@ -51,6 +54,16 @@ func (LLMAuditLog) TableName() string {
 	return "llm_audit_logs"
 }
 
+// AuditLogAPIKeyID returns the API key associated with this audit event.
+func (a *LLMAuditLog) AuditLogAPIKeyID() *uint {
+	return a.APIKeyID
+}
+
+// SetAuditLogAPIKeyRevoked sets the API key's current revocation state.
+func (a *LLMAuditLog) SetAuditLogAPIKeyRevoked(revoked bool) {
+	a.APIKeyRevoked = revoked
+}
+
 func ConvertLLMAuditLog(a LLMAuditLog) types2.LLMAuditLog {
 	return types2.LLMAuditLog{
 		ID:                        a.ID,
@@ -58,6 +71,7 @@ func ConvertLLMAuditLog(a LLMAuditLog) types2.LLMAuditLog {
 		Duration:                  a.Duration,
 		UserID:                    a.UserID,
 		APIKeyID:                  a.APIKeyID,
+		APIKeyRevoked:             a.APIKeyRevoked,
 		APIKeyName:                a.APIKeyName,
 		ModelProvider:             a.ModelProvider,
 		ModelID:                   a.ModelID,

--- a/pkg/gateway/types/mcpauditlog.go
+++ b/pkg/gateway/types/mcpauditlog.go
@@ -26,6 +26,9 @@ type MCPAuditLog struct {
 	SourceType types2.AuditLogSourceType `json:"sourceType" gorm:"index;default:mcp"`
 	UserID     string                    `json:"userID" gorm:"index"`
 	APIKeyID   *uint                     `json:"apiKeyID,omitempty" gorm:"index:idx_mcp_audit_api_key_created,priority:1"`
+	// APIKeyRevoked is current lifecycle metadata populated when audit logs are read.
+	// It is not persisted as part of the historical event snapshot.
+	APIKeyRevoked bool `json:"apiKeyRevoked,omitempty" gorm:"-"`
 	// APIKeyName is the event-time display value. Unnamed keys snapshot their
 	// non-secret masked identifier instead of requiring an API-key table join.
 	APIKeyName string `json:"apiKeyName,omitempty"`
@@ -34,6 +37,16 @@ type MCPAuditLog struct {
 	MCPFields                *MCPAuditLogFields                `json:"mcpFields,omitempty" gorm:"embedded"`
 	LocalAgentToolCallFields *LocalAgentToolCallAuditLogFields `json:"localAgentToolCallFields,omitempty" gorm:"embedded"`
 	Encrypted                bool                              `json:"encrypted"`
+}
+
+// AuditLogAPIKeyID returns the API key associated with this audit event.
+func (a *MCPAuditLog) AuditLogAPIKeyID() *uint {
+	return a.APIKeyID
+}
+
+// SetAuditLogAPIKeyRevoked sets the API key's current revocation state.
+func (a *MCPAuditLog) SetAuditLogAPIKeyRevoked(revoked bool) {
+	a.APIKeyRevoked = revoked
 }
 
 type MCPAuditLogFields struct {

--- a/pkg/gateway/types/mcpauditlog.go
+++ b/pkg/gateway/types/mcpauditlog.go
@@ -39,16 +39,6 @@ type MCPAuditLog struct {
 	Encrypted                bool                              `json:"encrypted"`
 }
 
-// AuditLogAPIKeyID returns the API key associated with this audit event.
-func (a *MCPAuditLog) AuditLogAPIKeyID() *uint {
-	return a.APIKeyID
-}
-
-// SetAuditLogAPIKeyRevoked sets the API key's current revocation state.
-func (a *MCPAuditLog) SetAuditLogAPIKeyRevoked(revoked bool) {
-	a.APIKeyRevoked = revoked
-}
-
 type MCPAuditLogFields struct {
 	APIKey                    string                                `json:"apiKey,omitempty"`
 	MCPID                     string                                `json:"mcpID" gorm:"index"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -1355,6 +1355,13 @@ func schema_obot_platform_obot_apiclient_types_AuditLogActor(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"apiKeyID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIKeyID identifies the API key represented by CredentialID without relying on its display value.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"actorType"},
 			},

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -1357,7 +1357,7 @@ func schema_obot_platform_obot_apiclient_types_AuditLogActor(ref common.Referenc
 					},
 					"apiKeyRevoked": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIKeyRevoked reports the current lifecycle state of the API key represented by CredentialID.",
+							Description: "APIKeyRevoked reports the current lifecycle state of the API key represented by CredentialID, or by ID when ActorType is AuditLogActorTypeCredential.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -1355,11 +1355,11 @@ func schema_obot_platform_obot_apiclient_types_AuditLogActor(ref common.Referenc
 							Format:      "",
 						},
 					},
-					"apiKeyID": {
+					"apiKeyRevoked": {
 						SchemaProps: spec.SchemaProps{
-							Description: "APIKeyID identifies the API key represented by CredentialID without relying on its display value.",
-							Type:        []string{"integer"},
-							Format:      "int32",
+							Description: "APIKeyRevoked reports the current lifecycle state of the API key represented by CredentialID.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 				},
@@ -8599,6 +8599,13 @@ func schema_obot_platform_obot_apiclient_types_LLMAuditLog(ref common.ReferenceC
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},
 							Format: "int32",
+						},
+					},
+					"apiKeyRevoked": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIKeyRevoked reports the API key's current lifecycle state.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"apiKeyName": {

--- a/ui/user/src/lib/auditlogs.spec.ts
+++ b/ui/user/src/lib/auditlogs.spec.ts
@@ -1,0 +1,16 @@
+import { formatAuditLogCredentialLabel } from './auditlogs';
+import { describe, expect, it } from 'vitest';
+
+describe('formatAuditLogCredentialLabel', () => {
+	it('leaves active API-key credentials unchanged', () => {
+		expect(formatAuditLogCredentialLabel('Claude Code (ok1-7-42-*****)', false)).toBe(
+			'Claude Code (ok1-7-42-*****)'
+		);
+	});
+
+	it('identifies revoked API-key credentials', () => {
+		expect(formatAuditLogCredentialLabel('Claude Code (ok1-7-42-*****)', true)).toBe(
+			'Claude Code (ok1-7-42-*****) · Revoked'
+		);
+	});
+});

--- a/ui/user/src/lib/auditlogs.spec.ts
+++ b/ui/user/src/lib/auditlogs.spec.ts
@@ -1,4 +1,4 @@
-import { formatAuditLogCredentialLabel } from './auditlogs';
+import { batchAuditLogAPIKeyIDs, formatAuditLogCredentialLabel } from './auditlogs';
 import { describe, expect, it } from 'vitest';
 
 describe('formatAuditLogCredentialLabel', () => {
@@ -12,5 +12,15 @@ describe('formatAuditLogCredentialLabel', () => {
 		expect(formatAuditLogCredentialLabel('Claude Code (ok1-7-42-*****)', true)).toBe(
 			'Claude Code (ok1-7-42-*****) · Revoked'
 		);
+	});
+});
+
+describe('batchAuditLogAPIKeyIDs', () => {
+	it('deduplicates IDs and omits missing attribution', () => {
+		expect(batchAuditLogAPIKeyIDs([42, undefined, 17, 42])).toEqual(['42,17']);
+	});
+
+	it('batches IDs at the filter-options endpoint limit', () => {
+		expect(batchAuditLogAPIKeyIDs([1, 2, 3, 4, 5], 2)).toEqual(['1,2', '3,4', '5']);
 	});
 });

--- a/ui/user/src/lib/auditlogs.spec.ts
+++ b/ui/user/src/lib/auditlogs.spec.ts
@@ -23,4 +23,10 @@ describe('batchAuditLogAPIKeyIDs', () => {
 	it('batches IDs at the filter-options endpoint limit', () => {
 		expect(batchAuditLogAPIKeyIDs([1, 2, 3, 4, 5], 2)).toEqual(['1,2', '3,4', '5']);
 	});
+
+	it.each([0, -1, 1.5, Number.POSITIVE_INFINITY])('rejects invalid limit %s', (limit) => {
+		expect(() => batchAuditLogAPIKeyIDs([1], limit)).toThrow(
+			new RangeError('limit must be a positive integer')
+		);
+	});
 });

--- a/ui/user/src/lib/auditlogs.spec.ts
+++ b/ui/user/src/lib/auditlogs.spec.ts
@@ -1,4 +1,4 @@
-import { batchAuditLogAPIKeyIDs, formatAuditLogCredentialLabel } from './auditlogs';
+import { formatAuditLogCredentialLabel } from './auditlogs';
 import { describe, expect, it } from 'vitest';
 
 describe('formatAuditLogCredentialLabel', () => {
@@ -11,22 +11,6 @@ describe('formatAuditLogCredentialLabel', () => {
 	it('identifies revoked API-key credentials', () => {
 		expect(formatAuditLogCredentialLabel('Claude Code (ok1-7-42-*****)', true)).toBe(
 			'Claude Code (ok1-7-42-*****) · Revoked'
-		);
-	});
-});
-
-describe('batchAuditLogAPIKeyIDs', () => {
-	it('deduplicates IDs and omits missing attribution', () => {
-		expect(batchAuditLogAPIKeyIDs([42, undefined, 17, 42])).toEqual(['42,17']);
-	});
-
-	it('batches IDs at the filter-options endpoint limit', () => {
-		expect(batchAuditLogAPIKeyIDs([1, 2, 3, 4, 5], 2)).toEqual(['1,2', '3,4', '5']);
-	});
-
-	it.each([0, -1, 1.5, Number.POSITIVE_INFINITY])('rejects invalid limit %s', (limit) => {
-		expect(() => batchAuditLogAPIKeyIDs([1], limit)).toThrow(
-			new RangeError('limit must be a positive integer')
 		);
 	});
 });

--- a/ui/user/src/lib/auditlogs.ts
+++ b/ui/user/src/lib/auditlogs.ts
@@ -29,6 +29,10 @@ export function formatAuditLogAPIKeyName(name: string, maskedKey: string): strin
 	return name && maskedKey && name !== maskedKey ? `${name} (${maskedKey})` : maskedKey || name;
 }
 
+export function formatAuditLogCredentialLabel(credential: string, revoked: boolean): string {
+	return [credential, revoked ? 'Revoked' : ''].filter(Boolean).join(' · ');
+}
+
 export function getAuditLogAPIKeyMaskedKey(userID: string, apiKeyID: number | undefined): string {
 	return userID && !userID.startsWith('hosted-agent:') && apiKeyID !== undefined
 		? `ok1-${userID}-${apiKeyID}-*****`

--- a/ui/user/src/lib/auditlogs.ts
+++ b/ui/user/src/lib/auditlogs.ts
@@ -33,21 +33,6 @@ export function formatAuditLogCredentialLabel(credential: string, revoked: boole
 	return [credential, revoked ? 'Revoked' : ''].filter(Boolean).join(' · ');
 }
 
-export function batchAuditLogAPIKeyIDs(
-	apiKeyIDs: readonly (number | undefined)[],
-	limit = 1000
-): string[] {
-	if (!Number.isInteger(limit) || limit <= 0) {
-		throw new RangeError('limit must be a positive integer');
-	}
-	const uniqueIDs = [...new Set(apiKeyIDs.filter((id): id is number => id !== undefined))];
-	const batches: string[] = [];
-	for (let offset = 0; offset < uniqueIDs.length; offset += limit) {
-		batches.push(uniqueIDs.slice(offset, offset + limit).join(','));
-	}
-	return batches;
-}
-
 export function getAuditLogAPIKeyMaskedKey(userID: string, apiKeyID: number | undefined): string {
 	return userID && !userID.startsWith('hosted-agent:') && apiKeyID !== undefined
 		? `ok1-${userID}-${apiKeyID}-*****`

--- a/ui/user/src/lib/auditlogs.ts
+++ b/ui/user/src/lib/auditlogs.ts
@@ -33,6 +33,18 @@ export function formatAuditLogCredentialLabel(credential: string, revoked: boole
 	return [credential, revoked ? 'Revoked' : ''].filter(Boolean).join(' · ');
 }
 
+export function batchAuditLogAPIKeyIDs(
+	apiKeyIDs: readonly (number | undefined)[],
+	limit = 1000
+): string[] {
+	const uniqueIDs = [...new Set(apiKeyIDs.filter((id): id is number => id !== undefined))];
+	const batches: string[] = [];
+	for (let offset = 0; offset < uniqueIDs.length; offset += limit) {
+		batches.push(uniqueIDs.slice(offset, offset + limit).join(','));
+	}
+	return batches;
+}
+
 export function getAuditLogAPIKeyMaskedKey(userID: string, apiKeyID: number | undefined): string {
 	return userID && !userID.startsWith('hosted-agent:') && apiKeyID !== undefined
 		? `ok1-${userID}-${apiKeyID}-*****`

--- a/ui/user/src/lib/auditlogs.ts
+++ b/ui/user/src/lib/auditlogs.ts
@@ -37,6 +37,9 @@ export function batchAuditLogAPIKeyIDs(
 	apiKeyIDs: readonly (number | undefined)[],
 	limit = 1000
 ): string[] {
+	if (!Number.isInteger(limit) || limit <= 0) {
+		throw new RangeError('limit must be a positive integer');
+	}
 	const uniqueIDs = [...new Set(apiKeyIDs.filter((id): id is number => id !== undefined))];
 	const batches: string[] = [];
 	for (let offset = 0; offset < uniqueIDs.length; offset += limit) {

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -5,6 +5,7 @@
 	import {
 		buildPillSearchParamFilters,
 		buildSearchParamFiltersArray,
+		formatAuditLogAPIKeyName,
 		getAuditLogAPIKeyFilterOptionLabel,
 		isAuditLogAPIKeyFilterOption
 	} from '$lib/auditlogs';
@@ -130,6 +131,13 @@
 
 	const users = new SvelteMap<string, OrgUser>();
 	const apiKeyFilterOptions = new SvelteMap<string, AuditLogAPIKeyFilterOption>();
+	const revokedAPIKeyCredentials = $derived(
+		new Set(
+			[...apiKeyFilterOptions.values()]
+				.filter((option) => option.revoked)
+				.map((option) => formatAuditLogAPIKeyName(option.name, option.maskedKey))
+		)
+	);
 
 	let showLoadingSpinner = $state(true);
 	let showFilters = $state(false);
@@ -764,6 +772,7 @@
 			}}
 			getUserDisplayName={(userId: string, hasConflict?: () => boolean) =>
 				getUserDisplayName(users, userId, hasConflict)}
+			isCredentialRevoked={(credential: string) => revokedAPIKeyCredentials.has(credential)}
 			{emptyContent}
 		/>
 	{:else if remoteAuditLogs.length > 0}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -3,7 +3,6 @@
 	import { page } from '$app/state';
 	import { columnResize } from '$lib/actions/resize';
 	import {
-		batchAuditLogAPIKeyIDs,
 		buildPillSearchParamFilters,
 		buildSearchParamFiltersArray,
 		getAuditLogAPIKeyFilterOptionLabel,
@@ -373,27 +372,21 @@
 
 	$effect(() => {
 		const controller = new AbortController();
-		const apiKeyIDBatches = batchAuditLogAPIKeyIDs(
-			remoteAuditLogs.map((auditLog) => auditLog.actor.apiKeyID)
-		);
-		if (apiKeyIDBatches.length === 0) {
+		if (!allFilters.api_key_id) {
 			apiKeyFilterOptions.clear();
 			return;
 		}
 		apiKeyFilterOptions.clear();
-		for (const apiKeyID of apiKeyIDBatches) {
-			UserService.listAuditLogFilterOptions('api_key_id', {
-				...allFilters,
-				api_key_id: apiKeyID,
-				offset: null,
-				signal: controller.signal
-			})
-				.then((response) => rememberAPIKeyFilterOptions(response.options ?? []))
-				.catch((error) => {
-					if (!controller.signal.aborted)
-						console.error('Failed to fetch API key filter options:', error);
-				});
-		}
+		UserService.listAuditLogFilterOptions('api_key_id', {
+			...allFilters,
+			offset: null,
+			signal: controller.signal
+		})
+			.then((response) => rememberAPIKeyFilterOptions(response.options ?? []))
+			.catch((error) => {
+				if (!controller.signal.aborted)
+					console.error('Failed to fetch API key filter options:', error);
+			});
 		return () => controller.abort();
 	});
 
@@ -775,8 +768,6 @@
 			}}
 			getUserDisplayName={(userId: string, hasConflict?: () => boolean) =>
 				getUserDisplayName(users, userId, hasConflict)}
-			isCredentialRevoked={(apiKeyID: number | undefined) =>
-				apiKeyID !== undefined && apiKeyFilterOptions.get(apiKeyID.toString())?.revoked === true}
 			{emptyContent}
 		/>
 	{:else if remoteAuditLogs.length > 0}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -3,9 +3,9 @@
 	import { page } from '$app/state';
 	import { columnResize } from '$lib/actions/resize';
 	import {
+		batchAuditLogAPIKeyIDs,
 		buildPillSearchParamFilters,
 		buildSearchParamFiltersArray,
-		formatAuditLogAPIKeyName,
 		getAuditLogAPIKeyFilterOptionLabel,
 		isAuditLogAPIKeyFilterOption
 	} from '$lib/auditlogs';
@@ -131,13 +131,6 @@
 
 	const users = new SvelteMap<string, OrgUser>();
 	const apiKeyFilterOptions = new SvelteMap<string, AuditLogAPIKeyFilterOption>();
-	const revokedAPIKeyCredentials = $derived(
-		new Set(
-			[...apiKeyFilterOptions.values()]
-				.filter((option) => option.revoked)
-				.map((option) => formatAuditLogAPIKeyName(option.name, option.maskedKey))
-		)
-	);
 
 	let showLoadingSpinner = $state(true);
 	let showFilters = $state(false);
@@ -360,22 +353,6 @@
 
 	let query = $derived(page.url.searchParams.get('query') ?? '');
 
-	$effect(() => {
-		const otherFilters = { ...auditLogsSlideoverFilters };
-		const duration = otherFilters.duration;
-		delete otherFilters.duration;
-		UserService.listAuditLogFilterOptions('api_key_id', {
-			...otherFilters,
-			...(forcedEventType ? { event_type: forcedEventType } : {}),
-			...(duration ? durationToProcessingParams(String(duration)) : {}),
-			start_time: timeRangeFilters.startTime.toISOString(),
-			end_time: timeRangeFilters.endTime?.toISOString(),
-			query
-		})
-			.then((response) => rememberAPIKeyFilterOptions(response.options ?? []))
-			.catch((error) => console.error('Failed to fetch API key filter options:', error));
-	});
-
 	// Base filters with time filters and query and pagination
 	const allFilters = $derived.by(() => {
 		// `duration` is a UI-only preset; translate it to the processing_time_min/max params the
@@ -392,6 +369,36 @@
 			offset: pageOffset,
 			query: query
 		};
+	});
+
+	$effect(() => {
+		const controller = new AbortController();
+		const apiKeyIDBatches = batchAuditLogAPIKeyIDs(
+			remoteAuditLogs.map((auditLog) => auditLog.actor.apiKeyID)
+		);
+		if (apiKeyIDBatches.length === 0) {
+			apiKeyFilterOptions.clear();
+			return;
+		}
+		Promise.all(
+			apiKeyIDBatches.map((apiKeyID) =>
+				UserService.listAuditLogFilterOptions('api_key_id', {
+					...allFilters,
+					api_key_id: apiKeyID,
+					offset: null,
+					signal: controller.signal
+				})
+			)
+		)
+			.then((responses) => {
+				apiKeyFilterOptions.clear();
+				for (const response of responses) rememberAPIKeyFilterOptions(response.options ?? []);
+			})
+			.catch((error) => {
+				if (!controller.signal.aborted)
+					console.error('Failed to fetch API key filter options:', error);
+			});
+		return () => controller.abort();
 	});
 
 	afterNavigate(() => {
@@ -772,7 +779,8 @@
 			}}
 			getUserDisplayName={(userId: string, hasConflict?: () => boolean) =>
 				getUserDisplayName(users, userId, hasConflict)}
-			isCredentialRevoked={(credential: string) => revokedAPIKeyCredentials.has(credential)}
+			isCredentialRevoked={(apiKeyID: number | undefined) =>
+				apiKeyID !== undefined && apiKeyFilterOptions.get(apiKeyID.toString())?.revoked === true}
 			{emptyContent}
 		/>
 	{:else if remoteAuditLogs.length > 0}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -380,24 +380,20 @@
 			apiKeyFilterOptions.clear();
 			return;
 		}
-		Promise.all(
-			apiKeyIDBatches.map((apiKeyID) =>
-				UserService.listAuditLogFilterOptions('api_key_id', {
-					...allFilters,
-					api_key_id: apiKeyID,
-					offset: null,
-					signal: controller.signal
-				})
-			)
-		)
-			.then((responses) => {
-				apiKeyFilterOptions.clear();
-				for (const response of responses) rememberAPIKeyFilterOptions(response.options ?? []);
+		apiKeyFilterOptions.clear();
+		for (const apiKeyID of apiKeyIDBatches) {
+			UserService.listAuditLogFilterOptions('api_key_id', {
+				...allFilters,
+				api_key_id: apiKeyID,
+				offset: null,
+				signal: controller.signal
 			})
-			.catch((error) => {
-				if (!controller.signal.aborted)
-					console.error('Failed to fetch API key filter options:', error);
-			});
+				.then((response) => rememberAPIKeyFilterOptions(response.options ?? []))
+				.catch((error) => {
+					if (!controller.signal.aborted)
+						console.error('Failed to fetch API key filter options:', error);
+				});
+		}
 		return () => controller.abort();
 	});
 

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
@@ -259,7 +259,8 @@
 					{@const d = item.data}
 					{@const identifier = identifierParts(d)}
 					{@const actor = actorLabel(d.actor)}
-					{@const credential = d.actor.credentialID}
+					{@const credential =
+						d.actor.credentialID ?? (d.actor.actorType === 'credential' ? d.actor.id : undefined)}
 					{@const credentialLabel = credential
 						? formatAuditLogCredentialLabel(credential, d.actor.apiKeyRevoked === true)
 						: undefined}
@@ -274,7 +275,10 @@
 					>
 						{@render td(formatAuditLogTableTimestamp(d.timestamp.occurredAt))}
 						{@render td(eventTypeLabel(d.eventType))}
-						{@render twoLine(credentialLabel || actor, credential ? actor : d.actor.actorType)}
+						{@render twoLine(
+							credentialLabel || actor,
+							d.actor.credentialID ? actor : d.actor.actorType
+						)}
 						{@render td(d.action.operation)}
 						{@render twoLine(identifier.primary, identifier.secondary)}
 						{@render outcomeCell(d.outcome)}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
@@ -14,7 +14,7 @@
 		onSelectRow?: (auditLog: AuditLogEvent) => void;
 		emptyContent?: Snippet;
 		getUserDisplayName: (userId: string, hasConflict?: () => boolean) => string;
-		isCredentialRevoked: (credential: string) => boolean;
+		isCredentialRevoked: (apiKeyID: number | undefined) => boolean;
 	}
 
 	let {
@@ -268,7 +268,7 @@
 					{@const actor = actorLabel(d.actor)}
 					{@const credential = d.actor.credentialID}
 					{@const credentialLabel = credential
-						? formatAuditLogCredentialLabel(credential, isCredentialRevoked(credential))
+						? formatAuditLogCredentialLabel(credential, isCredentialRevoked(d.actor.apiKeyID))
 						: undefined}
 
 					<tr

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { formatAuditLogCredentialLabel } from '$lib/auditlogs';
 	import { VirtualPageTable } from '$lib/components/ui';
 	import type { AuditLogEvent } from '$lib/services';
 	import { mcpServersAndEntries } from '$lib/stores';
@@ -13,9 +14,16 @@
 		onSelectRow?: (auditLog: AuditLogEvent) => void;
 		emptyContent?: Snippet;
 		getUserDisplayName: (userId: string, hasConflict?: () => boolean) => string;
+		isCredentialRevoked: (credential: string) => boolean;
 	}
 
-	let { data = [], onSelectRow, emptyContent, getUserDisplayName }: Props = $props();
+	let {
+		data = [],
+		onSelectRow,
+		emptyContent,
+		getUserDisplayName,
+		isCredentialRevoked
+	}: Props = $props();
 
 	let startX = 0;
 	let startWidth = 0;
@@ -259,6 +267,9 @@
 					{@const identifier = identifierParts(d)}
 					{@const actor = actorLabel(d.actor)}
 					{@const credential = d.actor.credentialID}
+					{@const credentialLabel = credential
+						? formatAuditLogCredentialLabel(credential, isCredentialRevoked(credential))
+						: undefined}
 
 					<tr
 						id={`mcp-audit-log-${item.index}`}
@@ -270,7 +281,7 @@
 					>
 						{@render td(formatAuditLogTableTimestamp(d.timestamp.occurredAt))}
 						{@render td(eventTypeLabel(d.eventType))}
-						{@render twoLine(credential || actor, credential ? actor : d.actor.actorType)}
+						{@render twoLine(credentialLabel || actor, credential ? actor : d.actor.actorType)}
 						{@render td(d.action.operation)}
 						{@render twoLine(identifier.primary, identifier.secondary)}
 						{@render outcomeCell(d.outcome)}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsTable.svelte
@@ -14,16 +14,9 @@
 		onSelectRow?: (auditLog: AuditLogEvent) => void;
 		emptyContent?: Snippet;
 		getUserDisplayName: (userId: string, hasConflict?: () => boolean) => string;
-		isCredentialRevoked: (apiKeyID: number | undefined) => boolean;
 	}
 
-	let {
-		data = [],
-		onSelectRow,
-		emptyContent,
-		getUserDisplayName,
-		isCredentialRevoked
-	}: Props = $props();
+	let { data = [], onSelectRow, emptyContent, getUserDisplayName }: Props = $props();
 
 	let startX = 0;
 	let startWidth = 0;
@@ -268,7 +261,7 @@
 					{@const actor = actorLabel(d.actor)}
 					{@const credential = d.actor.credentialID}
 					{@const credentialLabel = credential
-						? formatAuditLogCredentialLabel(credential, isCredentialRevoked(d.actor.apiKeyID))
+						? formatAuditLogCredentialLabel(credential, d.actor.apiKeyRevoked === true)
 						: undefined}
 
 					<tr

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -3,7 +3,6 @@
 	import { page } from '$app/state';
 	import { columnResize } from '$lib/actions/resize';
 	import {
-		batchAuditLogAPIKeyIDs,
 		buildPillSearchParamFilters,
 		buildSearchParamFiltersArray,
 		getAuditLogAPIKeyFilterOptionLabel,
@@ -196,26 +195,18 @@
 
 	$effect(() => {
 		const controller = new AbortController();
-		const apiKeyIDBatches = batchAuditLogAPIKeyIDs(
-			(response?.items ?? []).map((auditLog) => auditLog.apiKeyID)
-		);
-		if (apiKeyIDBatches.length === 0) {
+		if (!filters.api_key_id) {
 			apiKeyFilterOptions = {};
 			return;
 		}
-		Promise.all(
-			apiKeyIDBatches.map((apiKeyID) =>
-				AdminService.listLLMAuditLogFilterOptions('api_key_id', {
-					...filters,
-					api_key_id: apiKeyID,
-					offset: null,
-					signal: controller.signal
-				})
-			)
-		)
-			.then((results) => {
+		AdminService.listLLMAuditLogFilterOptions('api_key_id', {
+			...filters,
+			offset: null,
+			signal: controller.signal
+		})
+			.then((result) => {
 				apiKeyFilterOptions = {};
-				for (const result of results) rememberAPIKeyFilterOptions(result.options ?? []);
+				rememberAPIKeyFilterOptions(result.options ?? []);
 			})
 			.catch((error) => {
 				if (!isAbortError(error) && !controller.signal.aborted) {
@@ -466,8 +457,6 @@
 			rightSidebar?.showPopover();
 		}}
 		getUserDisplayName={(id: string) => getUserDisplayName(usersMap, id)}
-		isAPIKeyRevoked={(apiKeyID: number | undefined) =>
-			apiKeyID !== undefined && apiKeyFilterOptions[apiKeyID]?.revoked === true}
 	/>
 {:else}
 	<div class="flex flex-col items-center justify-center gap-4 px-6 py-16 text-center w-full">

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import { columnResize } from '$lib/actions/resize';
 	import {
+		batchAuditLogAPIKeyIDs,
 		buildPillSearchParamFilters,
 		buildSearchParamFiltersArray,
 		getAuditLogAPIKeyFilterOptionLabel,
@@ -195,13 +196,27 @@
 
 	$effect(() => {
 		const controller = new AbortController();
-		const otherFilters = { ...filters };
-		AdminService.listLLMAuditLogFilterOptions('api_key_id', {
-			...otherFilters,
-			offset: null,
-			signal: controller.signal
-		})
-			.then((result) => rememberAPIKeyFilterOptions(result.options ?? []))
+		const apiKeyIDBatches = batchAuditLogAPIKeyIDs(
+			(response?.items ?? []).map((auditLog) => auditLog.apiKeyID)
+		);
+		if (apiKeyIDBatches.length === 0) {
+			apiKeyFilterOptions = {};
+			return;
+		}
+		Promise.all(
+			apiKeyIDBatches.map((apiKeyID) =>
+				AdminService.listLLMAuditLogFilterOptions('api_key_id', {
+					...filters,
+					api_key_id: apiKeyID,
+					offset: null,
+					signal: controller.signal
+				})
+			)
+		)
+			.then((results) => {
+				apiKeyFilterOptions = {};
+				for (const result of results) rememberAPIKeyFilterOptions(result.options ?? []);
+			})
 			.catch((error) => {
 				if (!isAbortError(error) && !controller.signal.aborted) {
 					console.error('Failed to fetch API key filter options:', error);

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsContent.svelte
@@ -451,6 +451,8 @@
 			rightSidebar?.showPopover();
 		}}
 		getUserDisplayName={(id: string) => getUserDisplayName(usersMap, id)}
+		isAPIKeyRevoked={(apiKeyID: number | undefined) =>
+			apiKeyID !== undefined && apiKeyFilterOptions[apiKeyID]?.revoked === true}
 	/>
 {:else}
 	<div class="flex flex-col items-center justify-center gap-4 px-6 py-16 text-center w-full">

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsTable.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsTable.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { tooltip } from '$lib/actions/tooltip.svelte';
-	import { formatAuditLogAPIKeyName, getAuditLogAPIKeyMaskedKey } from '$lib/auditlogs';
+	import {
+		formatAuditLogAPIKeyName,
+		formatAuditLogCredentialLabel,
+		getAuditLogAPIKeyMaskedKey
+	} from '$lib/auditlogs';
 	import { VirtualPageTable } from '$lib/components/ui';
 	import { type LLMAuditLog } from '$lib/services';
 	import { formatAuditLogTableTimestamp } from '$lib/time';
@@ -9,7 +13,7 @@
 	import { tick } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
-	let { onSelectRow, getUserDisplayName } = $props();
+	let { onSelectRow, getUserDisplayName, isAPIKeyRevoked } = $props();
 
 	let startX = 0;
 	let startWidth = 0;
@@ -202,6 +206,10 @@
 						d.apiKeyName ?? '',
 						getAuditLogAPIKeyMaskedKey(d.userID, d.apiKeyID)
 					)}
+					{@const apiKeyLabel = formatAuditLogCredentialLabel(
+						apiKey,
+						apiKey ? isAPIKeyRevoked(d.apiKeyID) : false
+					)}
 					<tr
 						class={twMerge(
 							'group m-0 h-14 text-sm leading-0 text-[0] transition-colors duration-300',
@@ -213,7 +221,7 @@
 							formatAuditLogTableTimestamp(d.createdAt),
 							d.messagePolicyTriggered
 						)}
-						{@render twoLine(apiKey || actor, apiKey ? actor : undefined)}
+						{@render twoLine(apiKeyLabel || actor, apiKey ? actor : undefined)}
 						{@render td(d.modelProvider)}
 						{@render td(d.targetModel)}
 						{@render td(d.responseStatus || '')}

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsTable.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsTable.svelte
@@ -13,7 +13,13 @@
 	import { tick } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
-	let { onSelectRow, getUserDisplayName, isAPIKeyRevoked } = $props();
+	interface Props {
+		onSelectRow?: (auditLog: LLMAuditLog) => void;
+		getUserDisplayName: (userID: string) => string;
+		isAPIKeyRevoked: (apiKeyID: number | undefined) => boolean;
+	}
+
+	let { onSelectRow, getUserDisplayName, isAPIKeyRevoked }: Props = $props();
 
 	let startX = 0;
 	let startWidth = 0;

--- a/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsTable.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/LlmAuditLogsTable.svelte
@@ -16,10 +16,9 @@
 	interface Props {
 		onSelectRow?: (auditLog: LLMAuditLog) => void;
 		getUserDisplayName: (userID: string) => string;
-		isAPIKeyRevoked: (apiKeyID: number | undefined) => boolean;
 	}
 
-	let { onSelectRow, getUserDisplayName, isAPIKeyRevoked }: Props = $props();
+	let { onSelectRow, getUserDisplayName }: Props = $props();
 
 	let startX = 0;
 	let startWidth = 0;
@@ -214,7 +213,7 @@
 					)}
 					{@const apiKeyLabel = formatAuditLogCredentialLabel(
 						apiKey,
-						apiKey ? isAPIKeyRevoked(d.apiKeyID) : false
+						apiKey ? d.apiKeyRevoked === true : false
 					)}
 					<tr
 						class={twMerge(

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -606,6 +606,7 @@ export interface CommunityLicenseEnrollment {
 export interface LLMAuditLog {
 	apiKeyID?: number;
 	apiKeyName?: string;
+	apiKeyRevoked?: boolean;
 	clientIP: string;
 	clientSessionID: string;
 	userAgent: string;

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -191,13 +191,13 @@ export async function getAuditLog(id: string | number, opts?: { fetch?: Fetcher 
 
 export async function listAuditLogFilterOptions(
 	filterId: string,
-	opts?: { fetch?: Fetcher } & Partial<AuditLogURLFilters>
+	opts?: { fetch?: Fetcher; signal?: AbortSignal } & Partial<AuditLogURLFilters>
 ) {
-	const { fetch: fetchFn, ...filters } = opts ?? {};
+	const { fetch: fetchFn, signal, ...filters } = opts ?? {};
 	const queryString = buildQueryString({ ...filters, limit: AUDIT_LOG_FILTER_OPTIONS_LIMIT });
 	const response = (await doGet(
 		`/mcp-audit-logs/filter-options/${filterId}${queryString ? `?${queryString}` : ''}`,
-		{ fetch: fetchFn }
+		{ fetch: fetchFn, signal }
 	)) as {
 		options: AuditLogFilterOption[];
 	};

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -211,7 +211,7 @@ export interface AuditLogEvent {
 		id?: string;
 		/** Redacted authentication credential identifier when the actor is a known user. */
 		credentialID?: string;
-		/** Current lifecycle state of the API key represented by credentialID. */
+		/** Current lifecycle state of the API key represented by credentialID, or by id for credential actors. */
 		apiKeyRevoked?: boolean;
 	};
 	action: { operation: string; name?: string; kind?: string };

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -209,6 +209,8 @@ export interface AuditLogEvent {
 	actor: {
 		actorType: AuditLogActorType;
 		id?: string;
+		/** Stable identifier for the API key represented by credentialID. */
+		apiKeyID?: number;
 		/** Redacted authentication credential identifier when the actor is a known user. */
 		credentialID?: string;
 	};

--- a/ui/user/src/lib/services/user/types.ts
+++ b/ui/user/src/lib/services/user/types.ts
@@ -209,10 +209,10 @@ export interface AuditLogEvent {
 	actor: {
 		actorType: AuditLogActorType;
 		id?: string;
-		/** Stable identifier for the API key represented by credentialID. */
-		apiKeyID?: number;
 		/** Redacted authentication credential identifier when the actor is a known user. */
 		credentialID?: string;
+		/** Current lifecycle state of the API key represented by credentialID. */
+		apiKeyRevoked?: boolean;
 	};
 	action: { operation: string; name?: string; kind?: string };
 	target: AuditLogTargetRef & { parent?: AuditLogTargetRef };


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/7607 by showing revoked status of keys in the column