### PR TITLE
fix: allow admins to delete device scans

### DIFF
--- a/pkg/api/authz/authz.go
+++ b/pkg/api/authz/authz.go
@@ -79,6 +79,7 @@ var (
 		"/api/message-policy-violations",
 		"/api/message-policy-violations/",
 		"GET /api/message-policy-violation-stats",
+		"DELETE /api/devices/scans/{scan_id}",
 		"/api/devices/scan-stats",
 		"/api/devices/mcp-servers/",
 		"/api/devices/skills",


### PR DESCRIPTION
Fixes a regression that prevents admins from deleting individual scans

