### PR TITLE
fix: return group ids in the order they were given when splitting

### DIFF
--- a/pkg/gateway/server/group_test.go
+++ b/pkg/gateway/server/group_test.go
@@ -107,6 +107,13 @@ func TestSplitGroupIDs(t *testing.T) {
 			want: []string{"entra/a", "entra/b"},
 		},
 		{
+			// Deduplication keeps the first occurrence, so the result follows input
+			// order rather than sorted order.
+			name: "keeps input order when deduplicating",
+			raw:  "entra/b,entra/a,entra/b",
+			want: []string{"entra/b", "entra/a"},
+		},
+		{
 			name: "all blank",
 			raw:  ",,,",
 			want: []string{},

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -416,7 +416,7 @@ func parseGroupListParams(query url.Values) (limit int, cursor string) {
 }
 
 // splitGroupIDs parses the comma-separated ids parameter, dropping blanks and duplicates.
-// Ids are returned in the order they first appear in raw.
+// IDs are returned in the order they first appear in raw.
 func splitGroupIDs(raw string) ([]string, error) {
 	parts := strings.Split(raw, ",")
 	if len(parts) > maxGroupIDsPerRequest {

--- a/pkg/gateway/server/user.go
+++ b/pkg/gateway/server/user.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"maps"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -418,6 +416,7 @@ func parseGroupListParams(query url.Values) (limit int, cursor string) {
 }
 
 // splitGroupIDs parses the comma-separated ids parameter, dropping blanks and duplicates.
+// Ids are returned in the order they first appear in raw.
 func splitGroupIDs(raw string) ([]string, error) {
 	parts := strings.Split(raw, ",")
 	if len(parts) > maxGroupIDsPerRequest {
@@ -425,6 +424,7 @@ func splitGroupIDs(raw string) ([]string, error) {
 	}
 
 	seen := make(map[string]struct{}, len(parts))
+	ids := make([]string, 0, len(parts))
 
 	for _, part := range parts {
 		id := strings.TrimSpace(part)
@@ -436,9 +436,10 @@ func splitGroupIDs(raw string) ([]string, error) {
 		}
 
 		seen[id] = struct{}{}
+		ids = append(ids, id)
 	}
 
-	return slices.Collect(maps.Keys(seen)), nil
+	return ids, nil
 }
 
 // trimGroupsForUser strips everything but the ID and name for users who should not see which auth


### PR DESCRIPTION
Group ID splitting was returning IDs in a non-deterministic order.

Return group IDs in the order they were parsed from the input string.

Note: This fixes a test flake.
