### PR TITLE
chore: bump remaining modules to go 1.27

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Build
         run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Install Quill
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Install Dependencies
         run: |

--- a/apiclient/go.mod
+++ b/apiclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/obot-platform/obot/apiclient
 
-go 1.26.5
+go 1.27
 
 require (
 	github.com/klauspost/compress v1.18.6

--- a/apiclient/skill_test.go
+++ b/apiclient/skill_test.go
@@ -22,8 +22,8 @@ func TestListSkillsEncodesQueryParameters(t *testing.T) {
 		require.Equal(t, "25", r.URL.Query().Get("limit"))
 		require.NoError(t, json.NewEncoder(w).Encode(types.SkillList{
 			Items: []types.Skill{{
-				Metadata:      types.Metadata{ID: "sk1"},
-				SkillManifest: types.SkillManifest{Name: "github-review"},
+				ID:   "sk1",
+				Name: "github-review",
 			}},
 		}))
 	}))
@@ -51,8 +51,8 @@ func TestGetSkillEscapesIDAndDecodesResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/skills/skill%2Fwith%20space", r.URL.EscapedPath())
 		require.NoError(t, json.NewEncoder(w).Encode(types.Skill{
-			Metadata:      types.Metadata{ID: "skill/with space"},
-			SkillManifest: types.SkillManifest{Name: "reviewer"},
+			ID:   "skill/with space",
+			Name: "reviewer",
 		}))
 	}))
 	defer server.Close()

--- a/apiclient/types/mcpserver_test.go
+++ b/apiclient/types/mcpserver_test.go
@@ -29,7 +29,7 @@ func TestMapCatalogEntryToServerPreservesConfigurationOptions(t *testing.T) {
 	options := []MCPConfigurationOption{{Name: "US", Value: "us", Description: "US endpoint"}}
 	catalogEntry := MCPServerCatalogEntryManifest{
 		Runtime: RuntimeRemote,
-		Env:     []MCPEnv{{MCPHeader: MCPHeader{Key: "REGION", Options: options}}},
+		Env:     []MCPEnv{{Key: "REGION", Options: options}},
 		RemoteConfig: &RemoteCatalogConfig{
 			FixedURL: "https://example.com/mcp",
 			Headers:  []MCPHeader{{Key: "TIER", Options: options}},

--- a/logger/go.mod
+++ b/logger/go.mod
@@ -1,3 +1,3 @@
 module github.com/obot-platform/obot/logger
 
-go 1.26.5
+go 1.27


### PR DESCRIPTION
- Bump apiclient and logger to go 1.27
- Use go 1.27 promoted-field struct literals in apiclient tests
- Derive the CI go version from go.mod instead of pinning 1.26

