### PR TITLE
chore: bump mmmcp to pick up sqlite file parsing changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/obot-platform/chat-completion-client v0.0.0-20260529163740-88dd50945c18
 	github.com/obot-platform/cmd v0.0.0-20260707150346-5103d461ab67
 	github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e
-	github.com/obot-platform/mmmcp v0.1.2-0.20260821162538-5051c7d8d37f
+	github.com/obot-platform/mmmcp v0.1.2-0.20260824201730-2214c6cc710f
 	github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f
 	github.com/obot-platform/obot/apiclient v0.0.0-20250813183905-ade719c1e8bf
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32

--- a/go.sum
+++ b/go.sum
@@ -492,8 +492,8 @@ github.com/obot-platform/cmd v0.0.0-20260707150346-5103d461ab67 h1:QGhIjCb7NuBsI
 github.com/obot-platform/cmd v0.0.0-20260707150346-5103d461ab67/go.mod h1:zj/4glDORtg3DKkLvTN2RUpm1gZnRU3dlbr3dZ4Pc2Q=
 github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e h1:o439PMKepm2yIrx+2TmCZFCnFXRWObpo3zbK/Z+BUqk=
 github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e/go.mod h1:mJ2Mx/FzMK2WmfxamD2V9N7TeakulKdmGHw4qvMjzUs=
-github.com/obot-platform/mmmcp v0.1.2-0.20260821162538-5051c7d8d37f h1:KknPtmy0+kNU+6WhM78wNmFrvEbievlNdu9hgE+RUe4=
-github.com/obot-platform/mmmcp v0.1.2-0.20260821162538-5051c7d8d37f/go.mod h1:em5e1fztvv4Rfuzt+wDGDAdsxJhzr3lj8ME6dEbcniY=
+github.com/obot-platform/mmmcp v0.1.2-0.20260824201730-2214c6cc710f h1:K/SrpycDPVhrJ1PlzsghcYvl+E7PDeEHpHSttlar2nE=
+github.com/obot-platform/mmmcp v0.1.2-0.20260824201730-2214c6cc710f/go.mod h1:em5e1fztvv4Rfuzt+wDGDAdsxJhzr3lj8ME6dEbcniY=
 github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f h1:yoMKu8I8gFlsBOSPs+guQdsSWscaipIjDIBIIl2a7ho=
 github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f/go.mod h1:m3e3C4G/Y/ZYRc6CdMj9n8JfVRCzIc7N8FUvjemsVtY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
This fixes `make dev` with the default sqlite file/dsn.

