### PR TITLE
fix(ui): preserve MCP server descriptions with badges

### DIFF
--- a/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
+++ b/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
@@ -287,7 +287,7 @@
 				}}
 				onclick={(e) => handleSelect(d.data, e)}
 			>
-				<div class="text-sm font-light line-clamp-2">
+				<div class="text-sm font-light">
 					<div class="flex items-center gap-2">
 						<div class="icon">
 							{#if d.icon}
@@ -318,7 +318,7 @@
 							{/if}
 						</div>
 					</div>
-					<p class="text-xs text-muted-content min-h-8 mt-2">
+					<p class="text-xs text-muted-content min-h-8 mt-2 line-clamp-2">
 						{stripMarkdownToText(d.data.manifest.description ?? '')}
 					</p>
 				</div>

--- a/ui/user/src/routes/mcp-servers/ConnectorsView.svelte.spec.ts
+++ b/ui/user/src/routes/mcp-servers/ConnectorsView.svelte.spec.ts
@@ -1,0 +1,47 @@
+import { mcpServersAndEntries } from '$lib/stores';
+import { createMCPCatalogEntry, createMCPCatalogServer } from '../../tests/helpers/mcp';
+import ConnectorsView from './ConnectorsView.svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+const description = 'A description that remains visible when the server has status badges.';
+
+describe('MCP Servers ConnectorsView', () => {
+	beforeEach(() => {
+		const entry = createMCPCatalogEntry({
+			id: 'deprecated-connected-entry',
+			name: 'Deprecated Connected Server',
+			manifest: {
+				description,
+				metadata: { deprecated: 'true' }
+			}
+		});
+		const configuredServer = createMCPCatalogServer({
+			id: 'configured-server',
+			name: entry.manifest.name!,
+			catalogEntryID: entry.id,
+			userID: 'user-1'
+		});
+
+		mcpServersAndEntries.current = {
+			entries: [entry],
+			servers: [],
+			userInstances: [],
+			userConfiguredServers: [configuredServer],
+			loading: false,
+			lastFetched: null,
+			isInitialized: true
+		};
+	});
+
+	it('clamps the description independently from the title and status badges', async () => {
+		render(ConnectorsView, { query: 'Deprecated' });
+
+		const descriptionPreview = page.getByText(description, { exact: true });
+		await expect.element(page.getByText('Deprecated', { exact: true })).toBeVisible();
+		await expect.element(page.getByText('Connected', { exact: true })).toBeVisible();
+		await expect.element(descriptionPreview).toHaveClass(/line-clamp-2/);
+		await expect.element(descriptionPreview.locator('..')).not.toHaveClass(/line-clamp-2/);
+	});
+});


### PR DESCRIPTION
## Summary

- keep MCP server names and status badges outside the description truncation boundary
- apply the two-line clamp directly to the description preview
- add browser regression coverage for filtered rows showing both Deprecated and Connected badges

Addresses #7645

