### PR TITLE
enhance: gate catalog entry deletion on composites and add force delete

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -66,16 +66,18 @@ type MCPHandler struct {
 	shutdownMCPServer func(string) error
 }
 
-// compositeDeletionDependency represents a composite MCP server or catalog entry that depends
-// on a given multi-user server and must be deleted before the multi-user server can be deleted.
+// componentRef is the composite component reference to search for. Exactly one field is set.
+type componentRef struct {
+	catalogEntryID string
+	mcpServerID    string
+}
+
+// compositeDeletionDependency is a composite that references the object being deleted as a component,
+// and must drop that reference first.
 type compositeDeletionDependency struct {
-	// Name is the display name of the dependent composite MCP server.
-	Name string `json:"name"`
-	// Icon is the icon of the dependent composite MCP server.
-	Icon string `json:"icon"`
-	// MCPServerID is the ID of a running instance of a dependent composite MCP server.
-	MCPServerID string `json:"mcpServerID,omitempty"`
-	// CatalogEntryID is the catalog entry ID of the dependent composite MCP server.
+	Name           string `json:"name"`
+	Icon           string `json:"icon"`
+	MCPServerID    string `json:"mcpServerID,omitempty"`
 	CatalogEntryID string `json:"catalogEntryID"`
 }
 
@@ -474,6 +476,11 @@ func (m *MCPHandler) DeleteServer(req api.Context) error {
 		workspaceID = req.PathValue("workspace_id")
 	)
 
+	force, err := api.ParseBoolQuery(req.URL.Query().Get("force"))
+	if err != nil {
+		return types.NewErrBadRequest("invalid force query parameter: %v", err)
+	}
+
 	if err := req.Get(&server, id); err != nil {
 		return err
 	}
@@ -501,16 +508,18 @@ func (m *MCPHandler) DeleteServer(req api.Context) error {
 		)
 	}
 
-	// Prevent deletion of multi-user servers that are referenced by running composite MCP servers or catalog entries.
-	dependencies, err := listCompositeDeletionDependencies(req, server)
-	if err != nil {
-		return fmt.Errorf("failed to list composite deletion dependencies: %w", err)
-	}
-	if len(dependencies) > 0 {
-		return req.WriteCode(map[string]any{
-			"message":      "MCP server must be removed from all composite MCP servers before it can be deleted",
-			"dependencies": dependencies,
-		}, http.StatusConflict)
+	// Single-user servers cannot be composite components, so they are never gated.
+	if !force && !server.Spec.IsSingleUser() {
+		dependencies, err := listCompositeDeletionDependencies(req, server.Namespace, componentRef{mcpServerID: server.Name})
+		if err != nil {
+			return fmt.Errorf("failed to list composite deletion dependencies: %w", err)
+		}
+		if len(dependencies) > 0 {
+			return req.WriteCode(map[string]any{
+				"message":      "MCP server must be removed from all composite MCP servers and catalog entries before it can be deleted",
+				"dependencies": dependencies,
+			}, http.StatusConflict)
+		}
 	}
 
 	if err := req.Delete(&server); err != nil {
@@ -520,74 +529,65 @@ func (m *MCPHandler) DeleteServer(req api.Context) error {
 	return req.Write(ConvertMCPServer(server, nil, m.serverURL, slug))
 }
 
-// listCompositeDeletionDependencies lists the composite MCP servers and catalog entries that depend on the given multi-user server.
-func listCompositeDeletionDependencies(req api.Context, server v1.MCPServer) ([]compositeDeletionDependency, error) {
-	if server.Spec.IsSingleUser() {
-		// Single-user servers cannot be composite components; skip dependency check.
+func (r componentRef) matches(catalogEntryID, mcpServerID string) bool {
+	return r.catalogEntryID != "" && r.catalogEntryID == catalogEntryID ||
+		r.mcpServerID != "" && r.mcpServerID == mcpServerID
+}
+
+func (r componentRef) inCatalogConfig(cfg *types.CompositeCatalogConfig) bool {
+	return cfg != nil && slices.ContainsFunc(cfg.ComponentServers, func(c types.CatalogComponentServer) bool {
+		return r.matches(c.CatalogEntryID, c.MCPServerID)
+	})
+}
+
+func (r componentRef) inRuntimeConfig(cfg *types.CompositeRuntimeConfig) bool {
+	return cfg != nil && slices.ContainsFunc(cfg.ComponentServers, func(c types.ComponentServer) bool {
+		return r.matches(c.CatalogEntryID, c.MCPServerID)
+	})
+}
+
+// listCompositeDeletionDependencies lists the composite MCP servers and catalog entries that reference
+// ref as a component.
+func listCompositeDeletionDependencies(req api.Context, namespace string, ref componentRef) ([]compositeDeletionDependency, error) {
+	if ref == (componentRef{}) {
 		return nil, nil
 	}
 
+	composite := kclient.MatchingFields{"spec.manifest.runtime": string(types.RuntimeComposite)}
+
 	var compositeServers v1.MCPServerList
-	if err := req.List(&compositeServers,
-		kclient.InNamespace(server.Namespace),
-		kclient.MatchingFields{
-			"spec.manifest.runtime": string(types.RuntimeComposite),
-		},
-	); err != nil {
+	if err := req.List(&compositeServers, kclient.InNamespace(namespace), composite); err != nil {
 		return nil, fmt.Errorf("failed to list composite servers: %w", err)
 	}
 
 	var compositeEntries v1.MCPServerCatalogEntryList
-	if err := req.List(&compositeEntries,
-		kclient.InNamespace(server.Namespace),
-		kclient.MatchingFields{
-			"spec.manifest.runtime": string(types.RuntimeComposite),
-		},
-	); err != nil {
+	if err := req.List(&compositeEntries, kclient.InNamespace(namespace), composite); err != nil {
 		return nil, fmt.Errorf("failed to list composite catalog entries: %w", err)
 	}
 
 	var dependencies []compositeDeletionDependency
-	for _, compositeServer := range compositeServers.Items {
-		var compositeConfig types.CompositeRuntimeConfig
-		if cfg := compositeServer.Spec.Manifest.CompositeConfig; cfg != nil {
-			compositeConfig = *cfg
-		}
-
-		components := compositeConfig.ComponentServers
-		for _, component := range components {
-			if component.MCPServerID == server.Name {
-				dependencies = append(dependencies, compositeDeletionDependency{
-					Name:           compositeServer.Spec.Manifest.Name,
-					Icon:           compositeServer.Spec.Manifest.Icon,
-					MCPServerID:    compositeServer.Name,
-					CatalogEntryID: compositeServer.Spec.MCPServerCatalogEntryName,
-				})
-				break
-			}
+	for _, s := range compositeServers.Items {
+		// A composite already being deleted drops its reference on its own.
+		if s.DeletionTimestamp.IsZero() && ref.inRuntimeConfig(s.Spec.Manifest.CompositeConfig) {
+			dependencies = append(dependencies, compositeDeletionDependency{
+				Name:           s.Spec.Manifest.Name,
+				Icon:           s.Spec.Manifest.Icon,
+				MCPServerID:    s.Name,
+				CatalogEntryID: s.Spec.MCPServerCatalogEntryName,
+			})
 		}
 	}
 
-	for _, compositeEntry := range compositeEntries.Items {
-		var compositeConfig types.CompositeCatalogConfig
-		if cfg := compositeEntry.Spec.Manifest.CompositeConfig; cfg != nil {
-			compositeConfig = *cfg
-		}
-
-		components := compositeConfig.ComponentServers
-		for _, component := range components {
-			if component.MCPServerID == server.Name {
-				dependencies = append(dependencies, compositeDeletionDependency{
-					Name:           compositeEntry.Spec.Manifest.Name,
-					Icon:           compositeEntry.Spec.Manifest.Icon,
-					CatalogEntryID: compositeEntry.Name,
-				})
-				break
-			}
+	for _, e := range compositeEntries.Items {
+		if e.DeletionTimestamp.IsZero() && ref.inCatalogConfig(e.Spec.Manifest.CompositeConfig) {
+			dependencies = append(dependencies, compositeDeletionDependency{
+				Name:           e.Spec.Manifest.Name,
+				Icon:           e.Spec.Manifest.Icon,
+				CatalogEntryID: e.Name,
+			})
 		}
 	}
 
-	// Sort by catalog entry ID to ensure consistent ordering
 	slices.SortFunc(dependencies, func(a, b compositeDeletionDependency) int {
 		return strings.Compare(a.CatalogEntryID, b.CatalogEntryID)
 	})

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"regexp"
 	"slices"
 	"sort"
@@ -483,6 +484,11 @@ func (h *MCPCatalogHandler) DeleteEntry(req api.Context) error {
 	workspaceID := req.PathValue("workspace_id")
 	entryName := req.PathValue("entry_id")
 
+	force, err := api.ParseBoolQuery(req.URL.Query().Get("force"))
+	if err != nil {
+		return types.NewErrBadRequest("invalid force query parameter: %v", err)
+	}
+
 	// Verify the scope exists
 	if catalogName != "" {
 		if err := req.Get(&v1.MCPCatalog{}, catalogName); err != nil {
@@ -507,6 +513,20 @@ func (h *MCPCatalogHandler) DeleteEntry(req api.Context) error {
 
 	if !entry.Spec.Editable {
 		return types.NewErrBadRequest("entry is not editable and cannot be manually deleted")
+	}
+
+	// Workspaces do not support composites.
+	if !force && workspaceID == "" {
+		dependencies, err := listCompositeDeletionDependencies(req, entry.Namespace, componentRef{catalogEntryID: entry.Name})
+		if err != nil {
+			return fmt.Errorf("failed to list composite deletion dependencies: %w", err)
+		}
+		if len(dependencies) > 0 {
+			return req.WriteCode(map[string]any{
+				"message":      "catalog entry must be removed from all composite MCP servers and catalog entries before it can be deleted",
+				"dependencies": dependencies,
+			}, http.StatusConflict)
+		}
 	}
 
 	if err := req.Delete(&entry); err != nil {

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -19,3 +19,11 @@ func ParseUintList(values []string) []uint {
 	}
 	return result
 }
+
+// ParseBoolQuery parses a boolean query parameter, treating an empty value as false.
+func ParseBoolQuery(value string) (bool, error) {
+	if value == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(value)
+}

--- a/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
+++ b/ui/user/src/lib/components/admin/McpServerEntryForm.svelte
@@ -142,7 +142,48 @@
 	let source = $derived(entry ? getSource(entry, usersMap) : undefined);
 
 	let deleteServer = $state(false);
-	let deleteConflictError = $state<MCPCompositeDeletionDependencyError | undefined>();
+	let deleteConflict = $state<{
+		error: MCPCompositeDeletionDependencyError;
+		entity: 'server' | 'entry';
+	}>();
+	let forcingDelete = $state(false);
+
+	async function deleteEntryOrServer(force: boolean) {
+		if (!id || !entry) {
+			return;
+		}
+
+		if (!('isCatalogEntry' in entry)) {
+			const workspaceID = entry.powerUserWorkspaceID || (entity === 'workspace' ? id : undefined);
+			const deleteServerFn = workspaceID
+				? UserService.deleteWorkspaceMCPCatalogServer
+				: AdminService.deleteMCPCatalogServer;
+			await deleteServerFn(workspaceID || id, entry.id, { force });
+			return;
+		}
+
+		if (entity === 'workspace') {
+			await UserService.deleteWorkspaceMCPCatalogEntry(id, entry.id);
+			return;
+		}
+
+		await AdminService.deleteMCPCatalogEntry(id, entry.id, { force });
+	}
+
+	async function handleForceDelete() {
+		if (!deleteConflict) {
+			return;
+		}
+
+		forcingDelete = true;
+		try {
+			await deleteEntryOrServer(true);
+			deleteConflict = undefined;
+			goto(`${prefix}/mcp-catalog` as `/${string}`);
+		} finally {
+			forcingDelete = false;
+		}
+	}
 	let deleteResourceFromRule = $state<{
 		rule: AccessControlRule;
 		resourceId: string;
@@ -1358,39 +1399,32 @@
 	onsuccess={async () => {
 		if (!id || !entry) return;
 		const url = `${prefix}/mcp-catalog` as `/${string}`;
+		const conflictEntity = 'isCatalogEntry' in entry ? 'entry' : 'server';
 
-		if (!('isCatalogEntry' in entry)) {
-			const workspaceID = entry.powerUserWorkspaceID || (entity === 'workspace' ? id : undefined);
-			const deleteServerFn = workspaceID
-				? UserService.deleteWorkspaceMCPCatalogServer
-				: AdminService.deleteMCPCatalogServer;
-			try {
-				await deleteServerFn(workspaceID || id, entry.id);
-			} catch (error) {
-				if (error instanceof MCPCompositeDeletionDependencyError) {
-					deleteConflictError = error;
-					return;
-				}
-				throw error;
+		try {
+			await deleteEntryOrServer(false);
+		} catch (error) {
+			if (error instanceof MCPCompositeDeletionDependencyError) {
+				deleteConflict = { error, entity: conflictEntity };
+				deleteServer = false;
+				return;
 			}
-			goto(url);
-		} else {
-			const deleteCatalogEntryFn =
-				entity === 'workspace'
-					? UserService.deleteWorkspaceMCPCatalogEntry
-					: AdminService.deleteMCPCatalogEntry;
-			await deleteCatalogEntryFn(id, entry.id);
-			goto(url);
+			throw error;
 		}
+
+		goto(url);
 	}}
 	oncancel={() => (deleteServer = false)}
 />
 
 <McpMultiDeleteBlockedDialog
-	show={!!deleteConflictError}
-	error={deleteConflictError}
+	show={!!deleteConflict}
+	dependencies={deleteConflict?.error.dependencies}
+	entity={deleteConflict?.entity}
+	forcing={forcingDelete}
+	onForceDelete={handleForceDelete}
 	onClose={() => {
-		deleteConflictError = undefined;
+		deleteConflict = undefined;
 	}}
 />
 

--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -35,6 +35,7 @@
 		shouldShowMcpTunnelDisconnectedBadge
 	} from '$lib/services/user/mcpTunnel';
 	import { profile, mcpServersAndEntries, mcpTunnelConnections, version } from '$lib/stores';
+	import errors from '$lib/stores/errors.svelte';
 	import { formatTimeAgo } from '$lib/time';
 	import { getUserDisplayName, openUrl } from '$lib/utils';
 	import CapacityBanner from './CapacityBanner.svelte';
@@ -138,7 +139,47 @@
 	let deleting = $state(false);
 	let restarting = $state(false);
 
-	let deleteConflictError = $state<MCPCompositeDeletionDependencyError | undefined>();
+	// Servers whose delete was blocked by composites. A bulk delete can collect more than one.
+	let deleteConflicts = $state<
+		{ server: MCPCatalogServer; error: MCPCompositeDeletionDependencyError }[]
+	>([]);
+	let forcingDelete = $state(false);
+
+	// The union of every blocked server's dependencies, so one dialog shows them all.
+	let blockedDependencies = $derived.by(() => {
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const seen = new Set<string>();
+		return deleteConflicts.flatMap(({ error }) =>
+			error.dependencies.filter((dep) => {
+				const key = `${dep.catalogEntryID}:${dep.mcpServerID ?? ''}`;
+				if (seen.has(key)) return false;
+				seen.add(key);
+				return true;
+			})
+		);
+	});
+
+	async function handleForceDelete() {
+		// Snapshot, since handleSingleDelete writes to deleteConflicts.
+		const blocked = [...deleteConflicts];
+
+		forcingDelete = true;
+		try {
+			for (const { server } of blocked) {
+				await handleSingleDelete(server, true);
+				// Drop each as it succeeds, so a later failure leaves only what is outstanding.
+				deleteConflicts = deleteConflicts.filter((c) => c.server.id !== server.id);
+			}
+			await reload();
+		} catch (error) {
+			// Non-conflict failures already surface through the global error handler.
+			if (error instanceof MCPCompositeDeletionDependencyError) {
+				errors.append(error);
+			}
+		} finally {
+			forcingDelete = false;
+		}
+	}
 
 	let deployedCatalogEntryServers = $state<MCPCatalogServer[]>([]);
 	let deployedWorkspaceCatalogEntryServers = $state<MCPCatalogServer[]>([]);
@@ -489,7 +530,7 @@
 		return result;
 	}
 
-	async function handleSingleDelete(server: MCPCatalogServer) {
+	async function handleSingleDelete(server: MCPCatalogServer, force = false) {
 		if (server.compositeName) {
 			return;
 		}
@@ -504,9 +545,13 @@
 			// multi-user
 			try {
 				if (server.powerUserWorkspaceID) {
-					await UserService.deleteWorkspaceMCPCatalogServer(server.powerUserWorkspaceID, server.id);
+					await UserService.deleteWorkspaceMCPCatalogServer(
+						server.powerUserWorkspaceID,
+						server.id,
+						{ force }
+					);
 				} else if (profile.current.hasAdminAccess?.() && id) {
-					await AdminService.deleteMCPCatalogServer(id, server.id);
+					await AdminService.deleteMCPCatalogServer(id, server.id, { force });
 				}
 				// Remove server from list
 				mcpServersAndEntries.current.servers = mcpServersAndEntries.current.servers.filter(
@@ -516,7 +561,9 @@
 					mcpServersAndEntries.current.userConfiguredServers.filter((s) => s.id !== server.id);
 			} catch (error) {
 				if (error instanceof MCPCompositeDeletionDependencyError) {
-					deleteConflictError = error;
+					if (!deleteConflicts.some((c) => c.server.id === server.id)) {
+						deleteConflicts = [...deleteConflicts, { server, error }];
+					}
 					return;
 				}
 
@@ -1186,10 +1233,13 @@
 />
 
 <McpMultiDeleteBlockedDialog
-	show={!!deleteConflictError}
-	error={deleteConflictError}
+	show={deleteConflicts.length > 0}
+	dependencies={blockedDependencies}
+	blockedCount={deleteConflicts.length}
+	forcing={forcingDelete}
+	onForceDelete={handleForceDelete}
 	onClose={() => {
-		deleteConflictError = undefined;
+		deleteConflicts = [];
 	}}
 />
 

--- a/ui/user/src/lib/components/mcp/McpMultiDeleteBlockedDialog.svelte
+++ b/ui/user/src/lib/components/mcp/McpMultiDeleteBlockedDialog.svelte
@@ -1,34 +1,48 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import ResponsiveDialog from '$lib/components/ResponsiveDialog.svelte';
-	import type {
-		MCPCompositeDeletionDependency,
-		MCPCompositeDeletionDependencyError
-	} from '$lib/services';
-	import { TriangleAlert, Server } from '@lucide/svelte';
+	import type { MCPCompositeDeletionDependency } from '$lib/services';
+	import { TriangleAlert, Server, LoaderCircle } from '@lucide/svelte';
 
 	interface Props {
 		show: boolean;
-		error?: MCPCompositeDeletionDependencyError;
+		dependencies?: MCPCompositeDeletionDependency[];
 		onClose: () => void;
+		/** Provide to offer a force delete that bypasses the composite dependency check. */
+		onForceDelete?: () => void | Promise<void>;
+		forcing?: boolean;
+		entity?: 'server' | 'entry';
+		/** How many objects are blocked, when a bulk delete was blocked on more than one. */
+		blockedCount?: number;
 	}
 
-	let { show, error, onClose }: Props = $props();
+	let {
+		show,
+		dependencies = [],
+		onClose,
+		onForceDelete,
+		forcing = false,
+		entity = 'server',
+		blockedCount = 1
+	}: Props = $props();
 
 	let dialog = $state<ReturnType<typeof ResponsiveDialog>>();
 
-	const groupedLinks = $derived.by(() => {
-		const deps: MCPCompositeDeletionDependency[] = error?.dependencies ?? [];
+	const entityLabel = $derived(entity === 'entry' ? 'catalog entry' : 'server');
+	const subject = $derived(
+		blockedCount > 1 ? `${blockedCount} ${entityLabel}s are` : `This ${entityLabel} is`
+	);
+	const pronoun = $derived(blockedCount > 1 ? 'them' : 'it');
 
+	const groupedLinks = $derived.by(() => {
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
 		const grouped = new Map<string, { name: string; icon?: string; hasConfigDep: boolean }>();
 
-		for (const dep of deps) {
-			const id = dep.catalogEntryID;
-			let g = grouped.get(id);
+		for (const dep of dependencies) {
+			let g = grouped.get(dep.catalogEntryID);
 			if (!g) {
 				g = { name: dep.name, icon: dep.icon, hasConfigDep: false };
-				grouped.set(id, g);
+				grouped.set(dep.catalogEntryID, g);
 			}
 			if (!dep.mcpServerID) {
 				g.hasConfigDep = true;
@@ -37,23 +51,20 @@
 
 		return (
 			Array.from(grouped.entries())
-				.map(([catalogEntryID, g]) => {
-					const hasConfigDep = g.hasConfigDep;
-
-					const url = hasConfigDep
+				.map(([catalogEntryID, g]) => ({
+					catalogEntryID,
+					name: g.name,
+					icon: g.icon,
+					label: g.hasConfigDep ? 'Edit Configuration' : 'Update Instances',
+					url: g.hasConfigDep
 						? `/admin/mcp-catalog/c/${catalogEntryID}?view=configuration`
-						: `/admin/mcp-catalog/c/${catalogEntryID}?view=server-instances`;
-
-					const label = hasConfigDep ? 'Edit Configuration' : 'Update Instances';
-
-					return { catalogEntryID, name: g.name, icon: g.icon, url, label };
-				})
+						: `/admin/mcp-catalog/c/${catalogEntryID}?view=server-instances`
+				}))
 				// Show Edit Configuration links first, then Upgrade Instances
-				.sort((a, b) => {
-					const aIsEdit = a.label === 'Edit Configuration';
-					const bIsEdit = b.label === 'Edit Configuration';
-					return Number(bIsEdit) - Number(aIsEdit);
-				})
+				.sort(
+					(a, b) =>
+						Number(b.label === 'Edit Configuration') - Number(a.label === 'Edit Configuration')
+				)
 		);
 	});
 
@@ -74,8 +85,8 @@
 				<p class="my-0.5 flex flex-col text-sm font-semibold">Action Required</p>
 			</div>
 			<span class="text-left text-sm font-light wrap-break-word">
-				To delete this server, please remove it from the servers below and update all deployed
-				instances.
+				{subject} still used as a component by the composites below. Remove {pronoun} from each of them
+				and update all deployed instances.
 			</span>
 		</div>
 
@@ -104,6 +115,24 @@
 					</li>
 				{/each}
 			</ul>
+		{/if}
+
+		{#if onForceDelete}
+			<div class="flex flex-col gap-3 border-t border-gray-200 pt-4 dark:border-gray-700">
+				<span class="text-left text-xs font-light text-gray-500 dark:text-gray-400">
+					Deleting anyway leaves these references in place. Each composite keeps serving its current
+					component configuration and reports the component as missing until it is removed.
+				</span>
+				<div class="flex justify-end gap-2">
+					<button class="btn btn-ghost" disabled={forcing} onclick={onClose}>Cancel</button>
+					<button class="btn btn-error" disabled={forcing} onclick={() => onForceDelete?.()}>
+						{#if forcing}
+							<LoaderCircle class="size-4 animate-spin" />
+						{/if}
+						Delete Anyway
+					</button>
+				</div>
+			</div>
 		{/if}
 	</div>
 </ResponsiveDialog>

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -906,8 +906,14 @@ export async function acceptMCPCatalogEntryOwnership(
 	};
 }
 
-export async function deleteMCPCatalogEntry(catalogID: string, entryID: string): Promise<void> {
-	await doDelete(`/mcp-catalogs/${catalogID}/entries/${entryID}`);
+export async function deleteMCPCatalogEntry(
+	catalogID: string,
+	entryID: string,
+	opts?: { force?: boolean }
+): Promise<void> {
+	await doDelete(`/mcp-catalogs/${catalogID}/entries/${entryID}${forceQuery(opts)}`, {
+		responseHandler: mcpDeletionConflictResponseHandler
+	});
 }
 
 export async function getMCPCatalogEntryOAuthCredentials(
@@ -1144,7 +1150,7 @@ export async function updateMCPCatalogServer(
 	return response;
 }
 
-export async function mcpServerDeleteResponseHandler(
+export async function mcpDeletionConflictResponseHandler(
 	resp: Response,
 	path: string,
 	opts?: { dontLogErrors?: boolean }
@@ -1158,7 +1164,7 @@ export async function mcpServerDeleteResponseHandler(
 		if (body.dependencies && body.dependencies.length > 0) {
 			throw new MCPCompositeDeletionDependencyError(
 				body.message ??
-					'All dependencies on this MCP server must be removed before it can be deleted',
+					'This must be removed from all composite MCP servers and catalog entries before it can be deleted',
 				body.dependencies
 			);
 		}
@@ -1167,9 +1173,17 @@ export async function mcpServerDeleteResponseHandler(
 	return handleResponse(resp, path, opts);
 }
 
-export async function deleteMCPCatalogServer(catalogID: string, serverID: string): Promise<void> {
-	await doDelete(`/mcp-catalogs/${catalogID}/servers/${serverID}`, {
-		responseHandler: mcpServerDeleteResponseHandler
+export function forceQuery(opts?: { force?: boolean }): string {
+	return opts?.force ? '?force=true' : '';
+}
+
+export async function deleteMCPCatalogServer(
+	catalogID: string,
+	serverID: string,
+	opts?: { force?: boolean }
+): Promise<void> {
+	await doDelete(`/mcp-catalogs/${catalogID}/servers/${serverID}${forceQuery(opts)}`, {
+		responseHandler: mcpDeletionConflictResponseHandler
 	});
 }
 

--- a/ui/user/src/lib/services/admin/types.ts
+++ b/ui/user/src/lib/services/admin/types.ts
@@ -767,8 +767,8 @@ export interface MCPCatalogEntry {
 	connectURL?: string;
 }
 
-// Matches the backend compositeDeletionDependency struct used when preventing
-// deletion of multi-user MCP servers that are still referenced by composites.
+// Matches the backend compositeDeletionDependency struct: a composite that still references the
+// object being deleted as a component.
 export interface MCPCompositeDeletionDependency {
 	name: string;
 	icon: string;

--- a/ui/user/src/lib/services/user/mcp.ts
+++ b/ui/user/src/lib/services/user/mcp.ts
@@ -1143,17 +1143,22 @@ export async function restartMcpServer(
 
 export async function deleteMcpServerDeployment(
 	server: MCPCatalogServer,
-	catalogID?: string
+	catalogID?: string,
+	opts?: { force?: boolean }
 ): Promise<boolean> {
 	if (isMultiUserServer(server)) {
 		if (server.powerUserWorkspaceID) {
-			await UserService.deleteWorkspaceMCPCatalogServer(server.powerUserWorkspaceID, server.id);
+			await UserService.deleteWorkspaceMCPCatalogServer(
+				server.powerUserWorkspaceID,
+				server.id,
+				opts
+			);
 		} else {
 			const serverCatalogID = catalogID || server.mcpCatalogID;
 			if (!serverCatalogID) {
 				throw new Error('Catalog ID is required to delete this MCP server.');
 			}
-			await AdminService.deleteMCPCatalogServer(serverCatalogID, server.id);
+			await AdminService.deleteMCPCatalogServer(serverCatalogID, server.id, opts);
 		}
 		mcpServersAndEntries.removeServer(server.id);
 		return true;

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -1,6 +1,6 @@
 import { BOOTSTRAP_USER_ID } from '$lib/constants';
 import { HttpError } from '$lib/errors';
-import { mcpServerDeleteResponseHandler } from '$lib/services/admin/operations';
+import { forceQuery, mcpDeletionConflictResponseHandler } from '$lib/services/admin/operations';
 import { Group } from '$lib/services/admin/types';
 import { buildQueryString } from '$lib/url';
 import type {
@@ -1222,10 +1222,11 @@ export async function updateWorkspaceMCPCatalogServer(
 
 export async function deleteWorkspaceMCPCatalogServer(
 	workspaceID: string,
-	serverID: string
+	serverID: string,
+	opts?: { force?: boolean }
 ): Promise<void> {
-	await doDelete(`/workspaces/${workspaceID}/servers/${serverID}`, {
-		responseHandler: mcpServerDeleteResponseHandler
+	await doDelete(`/workspaces/${workspaceID}/servers/${serverID}${forceQuery(opts)}`, {
+		responseHandler: mcpDeletionConflictResponseHandler
 	});
 }
 

--- a/ui/user/src/routes/mcp-catalog/EntriesView.svelte
+++ b/ui/user/src/routes/mcp-catalog/EntriesView.svelte
@@ -39,6 +39,7 @@
 		isMcpTunnelDisconnected
 	} from '$lib/services/user/mcpTunnel';
 	import { mcpServersAndEntries, mcpTunnelConnections, profile } from '$lib/stores';
+	import errors from '$lib/stores/errors.svelte';
 	import { formatTimeAgo } from '$lib/time';
 	import { openUrl } from '$lib/utils';
 	import McpConnectUrlDialog from './McpConnectUrlDialog.svelte';
@@ -98,7 +99,12 @@
 	let selected = $state<Record<string, Item>>({});
 	let confirmBulkDelete = $state(false);
 	let loadingBulkDelete = $state(false);
-	let deleteConflictError = $state<MCPCompositeDeletionDependencyError | undefined>();
+	let deleteConflict = $state<{
+		error: MCPCompositeDeletionDependencyError;
+		entity: 'server' | 'entry';
+		retry: () => Promise<void>;
+	}>();
+	let forcingDelete = $state(false);
 
 	let connectToServerDialog = $state<ReturnType<typeof ConnectToServer>>();
 	let connectUrlDialog = $state<ReturnType<typeof McpConnectUrlDialog>>();
@@ -164,8 +170,36 @@
 		await mcpServersAndEntries.refreshAll();
 	}
 
-	async function deleteServerDeployment(server: MCPCatalogServer) {
-		await deleteMcpServerDeployment(server, catalog?.id);
+	async function deleteServerDeployment(server: MCPCatalogServer, force = false) {
+		await deleteMcpServerDeployment(server, catalog?.id, { force });
+	}
+
+	async function deleteCatalogEntry(entry: MCPCatalogEntry, force = false) {
+		if (entry.powerUserWorkspaceID) {
+			await UserService.deleteWorkspaceMCPCatalogEntry(entry.powerUserWorkspaceID, entry.id);
+		} else if (catalog) {
+			await AdminService.deleteMCPCatalogEntry(catalog.id, entry.id, { force });
+		}
+	}
+
+	async function handleForceDelete() {
+		if (!deleteConflict) {
+			return;
+		}
+
+		forcingDelete = true;
+		try {
+			await deleteConflict.retry();
+			await fetch();
+			deleteConflict = undefined;
+		} catch (error) {
+			// Non-conflict failures already surface through the global error handler.
+			if (error instanceof MCPCompositeDeletionDependencyError) {
+				errors.append(error);
+			}
+		} finally {
+			forcingDelete = false;
+		}
 	}
 
 	function handleConnectToServer({
@@ -505,13 +539,21 @@
 			return;
 		}
 
-		if (deletingEntry.powerUserWorkspaceID) {
-			await UserService.deleteWorkspaceMCPCatalogEntry(
-				deletingEntry.powerUserWorkspaceID,
-				deletingEntry.id
-			);
-		} else if (catalog) {
-			await AdminService.deleteMCPCatalogEntry(catalog.id, deletingEntry.id);
+		const entry = deletingEntry;
+		try {
+			await deleteCatalogEntry(entry);
+		} catch (error) {
+			if (error instanceof MCPCompositeDeletionDependencyError) {
+				deleteConflict = {
+					error,
+					entity: 'entry',
+					retry: () => deleteCatalogEntry(entry, true)
+				};
+				deletingEntry = undefined;
+				return;
+			}
+
+			throw error;
 		}
 
 		await fetch();
@@ -537,14 +579,20 @@
 			return;
 		}
 
+		const server = deletingServer;
 		try {
-			await deleteServerDeployment(deletingServer);
+			await deleteServerDeployment(server);
 
 			await fetch();
 			deletingServer = undefined;
 		} catch (error) {
 			if (error instanceof MCPCompositeDeletionDependencyError) {
-				deleteConflictError = error;
+				deleteConflict = {
+					error,
+					entity: 'server',
+					retry: () => deleteServerDeployment(server, true)
+				};
+				deletingServer = undefined;
 				return;
 			}
 
@@ -563,14 +611,7 @@
 		loadingBulkDelete = true;
 		try {
 			for (const item of Object.values(selected)) {
-				if (item.data.powerUserWorkspaceID) {
-					await UserService.deleteWorkspaceMCPCatalogEntry(
-						item.data.powerUserWorkspaceID,
-						item.data.id
-					);
-				} else if (catalog) {
-					await AdminService.deleteMCPCatalogEntry(catalog.id, item.data.id);
-				}
+				await deleteCatalogEntry(item.data);
 			}
 
 			await fetch();
@@ -586,10 +627,13 @@
 />
 
 <McpMultiDeleteBlockedDialog
-	show={!!deleteConflictError}
-	error={deleteConflictError}
+	show={!!deleteConflict}
+	dependencies={deleteConflict?.error.dependencies}
+	entity={deleteConflict?.entity}
+	forcing={forcingDelete}
+	onForceDelete={handleForceDelete}
 	onClose={() => {
-		deleteConflictError = undefined;
+		deleteConflict = undefined;
 	}}
 />
 


### PR DESCRIPTION
Deleting a multi-user MCP server referenced by a composite already returned 409
with its dependent composites. Catalog entries had no such check, and neither
path had a way through except editing each composite by hand.

- Apply the same gate to DeleteEntry, matching components by CatalogEntryID.
  Workspace-scoped entries are skipped, since workspaces have no composites.
- Accept ?force=true on both delete endpoints to skip the check. Force does not
  bypass the 403 on component servers or the editable check on Git entries.
- Add a "Delete Anyway" action to the blocked-deletion dialog, wire the conflict
  handler into entry deletes, and handle the conflict on the entry paths in
  EntriesView and McpServerEntryForm, which previously threw unhandled.

