### PR TITLE
fix: stop audit logging nanobot agent requests

### DIFF
--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -271,7 +271,7 @@ func (h *Handler) Proxy(req api.Context) error {
 			},
 			ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
 				audit.recordTransportError(err, http.StatusBadGateway)
-				if serverConfig.AgentName != "" {
+				if serverConfig.IsAgentServer() {
 					http.Error(w, fmt.Sprintf("failed to proxy request to Nanobot agent %s: %v", serverConfig.AgentName, err), http.StatusBadGateway)
 				} else {
 					mcpServerName := serverConfig.MCPServerDisplayName
@@ -361,7 +361,7 @@ func (h *Handler) ensureServerIsDeployed(req api.Context) (mcp.ServerConfig, err
 	}
 
 	// Add-hoc authorization for nanobot agents
-	if mcpServerConfig.AgentName != "" {
+	if mcpServerConfig.IsAgentServer() {
 		var agent v1.NanobotAgent
 		if err = req.Get(&agent, mcpServerConfig.AgentName); err != nil {
 			return mcp.ServerConfig{}, fmt.Errorf("failed to get nanobot agent %q: %w", mcpServerConfig.AgentName, err)

--- a/pkg/mcp/action.go
+++ b/pkg/mcp/action.go
@@ -389,7 +389,7 @@ func (sm *SessionManager) serverConfigForAction(ctx context.Context, server v1.M
 }
 
 func (sm *SessionManager) webhooksForServerConfig(serverConfig ServerConfig) ([]Webhook, error) {
-	if serverConfig.ComponentMCPServer || serverConfig.SystemMCPServer || sm.webhookHelper == nil {
+	if serverConfig.ComponentMCPServer || serverConfig.SystemMCPServer || serverConfig.IsAgentServer() || sm.webhookHelper == nil {
 		return nil, nil
 	}
 

--- a/pkg/mcp/kubernetes.go
+++ b/pkg/mcp/kubernetes.go
@@ -216,6 +216,7 @@ func (k *kubernetesBackend) ensureServerDeployment(ctx context.Context, server S
 			ContainerPort:        server.ContainerPort,
 			ContainerPath:        server.ContainerPath,
 			AgentName:            server.AgentName,
+			AuditLogMetadata:     server.AuditLogMetadata,
 			StartupTimeout:       server.StartupTimeout,
 		}, nil
 	}


### PR DESCRIPTION
We aren't supposed to audit log these at all.

Issues: https://github.com/obot-platform/obot/issues/7656, https://github.com/obot-platform/obot/issues/7657