### PR TITLE
fix: authenticate device credentials when authentication is disabled

### DIFF
--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -1129,6 +1129,11 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		// Persistent Token Auth
 		authenticators = union.New(authenticators, persistentTokenServer)
 
+		// Device enrollment tokens (ode1-) and device access JWTs. Both yield
+		// non-user principals, so they must come after the UserDecorator.
+		authenticators = union.New(authenticators, gserver.NewDeviceEnrollmentAuthenticator(gatewayClient))
+		authenticators = union.New(authenticators, gserver.NewDeviceAuthenticator(gatewayClient))
+
 		// Add no auth authenticator
 		authenticators = union.New(authenticators, authn.NewNoAuth(gatewayClient))
 	}


### PR DESCRIPTION
The device enrollment and access-JWT authenticators were registered only in the
authentication-enabled chain. With authentication disabled -- the default --
NoAuth claimed every request as the "nobody" owner, whose groups never include
device-enroll, so obot-sentry enroll returned 403 for every enrollment key.

Register both in the authentication-disabled chain too, after the UserDecorator
and before NoAuth. This also restores scan attribution, enforcement decisions,
and local agent audit logs, which all key off the device principal's extras.

Addresses https://github.com/obot-platform/obot/issues/7644
