### PR TITLE
fix: restart auth provider daemons when configuration changes

### DIFF
--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -149,15 +149,7 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 			"only one authentication provider can be configured at a time. Please deconfigure %q first",
 			configuredProvider,
 		)
-
-		// Delete the credential we just configured, and publish a new sync revision so that every
-		// replica invalidates the daemon it may have started with the credential being deleted.
-		_, _ = req.GatewayClient.DeleteCredential(req.Context(), authProvider.Name, authProvider.Name)
-		if _, err := publishAuthProviderSyncRevision(req, authProvider.Name); err != nil {
-			return errors.Join(badRequest, err)
-		}
-
-		return badRequest
+		return ap.rollbackAuthProviderConfiguration(req, authProvider, badRequest)
 	}
 
 	setAuthProviderSyncRevision(&authProvider)
@@ -238,8 +230,16 @@ func (ap *AuthProviderHandler) Deconfigure(req api.Context) error {
 		return fmt.Errorf("failed to remove existing credential: %w", err)
 	}
 
+	// Publish the invalidation before any subsequent cleanup can fail so that every replica stops
+	// daemons that may still be running with the deleted credential. Do this even when the credential
+	// was already absent, since this request may be retrying an earlier partially completed deletion.
+	updatedAuthProvider, revisionErr := publishAuthProviderSyncRevision(req, authProvider.Name)
+
 	// Stop the auth provider so that the credential is completely removed from the system.
 	ap.dispatcher.StopAuthProvider(authProvider.Namespace, authProvider.Name)
+	if revisionErr != nil {
+		return revisionErr
+	}
 
 	// The local auth provider keeps its sessions in Obot's database rather than in the sessions
 	// table the block below drops, so clear them out here.
@@ -271,11 +271,6 @@ func (ap *AuthProviderHandler) Deconfigure(req api.Context) error {
 				return fmt.Errorf("failed to drop session_locks table: %w", err)
 			}
 		}
-	}
-
-	updatedAuthProvider, err := publishAuthProviderSyncRevision(req, authProvider.Name)
-	if err != nil {
-		return err
 	}
 
 	// Wait for the controllers to process to ensure the API will return correct configuration status.

--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"uuid"
 
 	"github.com/obot-platform/nah/pkg/name"
 	"github.com/obot-platform/obot/apiclient/types"
@@ -152,14 +153,7 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 		)
 	}
 
-	if authProvider.Annotations[v1.AuthProviderSyncAnnotation] == "" {
-		if authProvider.Annotations == nil {
-			authProvider.Annotations = make(map[string]string, 1)
-		}
-		authProvider.Annotations[v1.AuthProviderSyncAnnotation] = "true"
-	} else {
-		delete(authProvider.Annotations, v1.AuthProviderSyncAnnotation)
-	}
+	setAuthProviderSyncRevision(&authProvider)
 
 	if err := req.Update(&authProvider); err != nil {
 		return fmt.Errorf("failed to update auth provider: %w", err)
@@ -329,7 +323,7 @@ func updateAuthProviderForDeconfiguration(req api.Context, authProviderName stri
 		if err := req.Get(&authProvider, authProviderName); err != nil {
 			return err
 		}
-		toggleAuthProviderSyncAnnotation(&authProvider)
+		setAuthProviderSyncRevision(&authProvider)
 		return req.Update(&authProvider)
 	})
 	if apierrors.IsNotFound(err) {
@@ -364,15 +358,11 @@ func markAuthProviderCleanupReady(req api.Context, cleanup *v1.AuthProviderClean
 	return nil
 }
 
-func toggleAuthProviderSyncAnnotation(authProvider *v1.AuthProvider) {
-	if authProvider.Annotations[v1.AuthProviderSyncAnnotation] == "" {
-		if authProvider.Annotations == nil {
-			authProvider.Annotations = make(map[string]string, 1)
-		}
-		authProvider.Annotations[v1.AuthProviderSyncAnnotation] = "true"
-	} else {
-		delete(authProvider.Annotations, v1.AuthProviderSyncAnnotation)
+func setAuthProviderSyncRevision(authProvider *v1.AuthProvider) {
+	if authProvider.Annotations == nil {
+		authProvider.Annotations = make(map[string]string, 1)
 	}
+	authProvider.Annotations[v1.AuthProviderSyncAnnotation] = uuid.New().String()
 }
 
 func (ap *AuthProviderHandler) Reveal(req api.Context) error {

--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -145,12 +145,19 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 	}
 
 	if configuredProvider != "" && configuredProvider != authProvider.Name {
-		// Delete the credential we just configured
-		_, _ = req.GatewayClient.DeleteCredential(req.Context(), authProvider.Name, authProvider.Name)
-		return types.NewErrBadRequest(
+		badRequest := types.NewErrBadRequest(
 			"only one authentication provider can be configured at a time. Please deconfigure %q first",
 			configuredProvider,
 		)
+
+		// Delete the credential we just configured, and publish a new sync revision so that every
+		// replica invalidates the daemon it may have started with the credential being deleted.
+		_, _ = req.GatewayClient.DeleteCredential(req.Context(), authProvider.Name, authProvider.Name)
+		if _, err := publishAuthProviderSyncRevision(req, authProvider.Name); err != nil {
+			return errors.Join(badRequest, err)
+		}
+
+		return badRequest
 	}
 
 	setAuthProviderSyncRevision(&authProvider)
@@ -179,6 +186,13 @@ func (ap *AuthProviderHandler) rollbackAuthProviderConfiguration(req api.Context
 	if _, err := req.GatewayClient.DeleteCredential(req.Context(), authProvider.Name, authProvider.Name); err != nil {
 		return errors.Join(cause, fmt.Errorf("roll back credential for auth provider %q: %w", authProvider.Name, err))
 	}
+
+	// StopAuthProvider only stops the daemon in this process, so publish a new sync revision to
+	// invalidate the daemons that other replicas may have started with the rolled back credential.
+	if _, err := publishAuthProviderSyncRevision(req, authProvider.Name); err != nil {
+		return errors.Join(cause, err)
+	}
+
 	return cause
 }
 
@@ -259,7 +273,7 @@ func (ap *AuthProviderHandler) Deconfigure(req api.Context) error {
 		}
 	}
 
-	updatedAuthProvider, err := updateAuthProviderForDeconfiguration(req, authProvider.Name)
+	updatedAuthProvider, err := publishAuthProviderSyncRevision(req, authProvider.Name)
 	if err != nil {
 		return err
 	}
@@ -317,7 +331,7 @@ func ensureAuthProviderCleanup(req api.Context, authProvider v1.AuthProvider) (*
 	return cleanup, nil
 }
 
-func updateAuthProviderForDeconfiguration(req api.Context, authProviderName string) (*v1.AuthProvider, error) {
+func publishAuthProviderSyncRevision(req api.Context, authProviderName string) (*v1.AuthProvider, error) {
 	var authProvider v1.AuthProvider
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := req.Get(&authProvider, authProviderName); err != nil {
@@ -330,7 +344,7 @@ func updateAuthProviderForDeconfiguration(req api.Context, authProviderName stri
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("update auth provider for deconfiguration: %w", err)
+		return nil, fmt.Errorf("publish sync revision for auth provider %q: %w", authProviderName, err)
 	}
 	return &authProvider, nil
 }

--- a/pkg/api/handlers/authprovider_test.go
+++ b/pkg/api/handlers/authprovider_test.go
@@ -9,6 +9,8 @@ import (
 
 	clienttypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/require"
@@ -137,6 +139,76 @@ func TestDeconfigurePersistsCleanupIntentBeforeSideEffects(t *testing.T) {
 
 	err := (&AuthProviderHandler{}).Deconfigure(req)
 	require.ErrorContains(t, err, "persist cleanup intent")
+}
+
+func TestDeconfigurePublishesRevisionBeforeLaterCleanupFailure(t *testing.T) {
+	authProvider := &v1.AuthProvider{
+		Name:      "entra-auth-provider",
+		Namespace: system.DefaultNamespace,
+		Annotations: map[string]string{
+			v1.AuthProviderSyncAnnotation: "existing-revision",
+		},
+	}
+	storage := newFakeStorage(t, authProvider)
+	gatewayClient := newHandlerTestGateway(t)
+	require.NoError(t, gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+		Context: authProvider.Name,
+		Name:    authProvider.Name,
+		Secrets: map[string]string{
+			"CLIENT_SECRET": "secret",
+		},
+	}))
+	providerDispatcher := dispatcher.New(nil, storage, gatewayClient, nil, "", "", "")
+	t.Cleanup(providerDispatcher.Close)
+	handler := &AuthProviderHandler{
+		dispatcher:  providerDispatcher,
+		postgresDSN: "://invalid-postgres-dsn",
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/auth-providers/entra-auth-provider/deconfigure", nil)
+	request.SetPathValue("id", authProvider.Name)
+	req := api.Context{
+		Request:       request,
+		Storage:       storage,
+		GatewayClient: gatewayClient,
+	}
+
+	err := handler.Deconfigure(req)
+	require.ErrorContains(t, err, "failed to connect to postgres")
+
+	var persisted v1.AuthProvider
+	require.NoError(t, req.Get(&persisted, authProvider.Name))
+	require.NotEqual(t, "existing-revision", persisted.Annotations[v1.AuthProviderSyncAnnotation])
+}
+
+func TestRollbackAuthProviderConfigurationDoesNotPublishWhenCredentialDeletionFails(t *testing.T) {
+	authProvider := v1.AuthProvider{
+		Name:      "entra-auth-provider",
+		Namespace: system.DefaultNamespace,
+		Annotations: map[string]string{
+			v1.AuthProviderSyncAnnotation: "existing-revision",
+		},
+	}
+	storage := newFakeStorage(t, &authProvider)
+	gatewayClient := newHandlerTestGateway(t)
+	require.NoError(t, gatewayClient.Close())
+	providerDispatcher := dispatcher.New(nil, storage, gatewayClient, nil, "", "", "")
+	t.Cleanup(providerDispatcher.Close)
+	handler := &AuthProviderHandler{
+		dispatcher: providerDispatcher,
+	}
+	req := api.Context{
+		Request:       httptest.NewRequest(http.MethodPost, "/api/auth-providers/entra-auth-provider/configure", nil),
+		Storage:       storage,
+		GatewayClient: gatewayClient,
+	}
+
+	err := handler.rollbackAuthProviderConfiguration(req, authProvider, errors.New("configuration rejected"))
+	require.ErrorContains(t, err, "configuration rejected")
+	require.ErrorContains(t, err, "roll back credential")
+
+	var persisted v1.AuthProvider
+	require.NoError(t, req.Get(&persisted, authProvider.Name))
+	require.Equal(t, "existing-revision", persisted.Annotations[v1.AuthProviderSyncAnnotation])
 }
 
 func TestSetAuthProviderSyncRevisionAlwaysChanges(t *testing.T) {

--- a/pkg/api/handlers/authprovider_test.go
+++ b/pkg/api/handlers/authprovider_test.go
@@ -151,3 +151,31 @@ func TestSetAuthProviderSyncRevisionAlwaysChanges(t *testing.T) {
 	require.NotEmpty(t, second)
 	require.NotEqual(t, first, second)
 }
+
+func TestPublishAuthProviderSyncRevisionPersistsNewRevision(t *testing.T) {
+	authProvider := &v1.AuthProvider{
+		Name:      "entra-auth-provider",
+		Namespace: system.DefaultNamespace,
+		Annotations: map[string]string{
+			v1.AuthProviderSyncAnnotation: "existing-revision",
+		},
+	}
+	req := api.Context{
+		Request: httptest.NewRequest(http.MethodPost, "/api/auth-providers/entra-auth-provider/configure", nil),
+		Storage: newFakeStorage(t, authProvider),
+	}
+
+	updated, err := publishAuthProviderSyncRevision(req, authProvider.Name)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	require.NotEqual(t, "existing-revision", updated.Annotations[v1.AuthProviderSyncAnnotation])
+
+	var persisted v1.AuthProvider
+	require.NoError(t, req.Get(&persisted, authProvider.Name))
+	require.Equal(t, updated.Annotations[v1.AuthProviderSyncAnnotation], persisted.Annotations[v1.AuthProviderSyncAnnotation])
+
+	// A deleted provider has no daemon to invalidate, so this is not an error.
+	missing, err := publishAuthProviderSyncRevision(req, "does-not-exist")
+	require.NoError(t, err)
+	require.Nil(t, missing)
+}

--- a/pkg/api/handlers/authprovider_test.go
+++ b/pkg/api/handlers/authprovider_test.go
@@ -138,3 +138,16 @@ func TestDeconfigurePersistsCleanupIntentBeforeSideEffects(t *testing.T) {
 	err := (&AuthProviderHandler{}).Deconfigure(req)
 	require.ErrorContains(t, err, "persist cleanup intent")
 }
+
+func TestSetAuthProviderSyncRevisionAlwaysChanges(t *testing.T) {
+	authProvider := &v1.AuthProvider{}
+
+	setAuthProviderSyncRevision(authProvider)
+	first := authProvider.Annotations[v1.AuthProviderSyncAnnotation]
+	setAuthProviderSyncRevision(authProvider)
+	second := authProvider.Annotations[v1.AuthProviderSyncAnnotation]
+
+	require.NotEmpty(t, first)
+	require.NotEmpty(t, second)
+	require.NotEqual(t, first, second)
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -48,6 +48,7 @@ func New(services *services.Services) (*Controller, error) {
 	}
 
 	c.setupRoutes()
+	c.setupStorageReplicaRoutes()
 	c.setupLocalK8sRoutes()
 
 	services.Router.PosStart(c.PostStart)
@@ -333,6 +334,13 @@ func (c *Controller) Start(ctx context.Context) error {
 	if err := c.services.Router.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start router: %w", err)
 	}
+	// Auth provider daemons are process-local, so this router intentionally has
+	// no leader election and observes shared storage changes on every replica.
+	if c.services.StorageReplicaRouter != nil {
+		if err := c.services.StorageReplicaRouter.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start every-replica storage router: %w", err)
+		}
+	}
 
 	// Start the local Kubernetes router if it exists
 	if c.services.LocalRouter != nil {
@@ -349,6 +357,16 @@ func (c *Controller) Start(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (c *Controller) setupStorageReplicaRoutes() {
+	if c.services.StorageReplicaRouter == nil {
+		return
+	}
+
+	c.services.StorageReplicaRouter.Type(&v1.AuthProvider{}).
+		IncludeRemoved().
+		HandlerFunc(c.providerHandler.ObserveAuthProviderDaemon)
 }
 
 func ensureDefaultUserRoleSetting(ctx context.Context, client kclient.Client) error {

--- a/pkg/controller/handlers/provider/provider.go
+++ b/pkg/controller/handlers/provider/provider.go
@@ -408,6 +408,18 @@ func (h *Handler) SetAuthProviderConfiguredStatus(req router.Request, _ router.R
 	return SetAuthProviderConfiguredStatus(req.Ctx, h.gatewayClient, h.licenseProvider, authProvider)
 }
 
+// ObserveAuthProviderDaemon runs on every Obot replica. It reconciles the
+// process-local daemon cache with the configuration revision stored in the
+// shared AuthProvider resource.
+func (h *Handler) ObserveAuthProviderDaemon(req router.Request, _ router.Response) error {
+	if req.Object == nil {
+		h.dispatcher.ForgetAuthProvider(req.Namespace, req.Name)
+		return nil
+	}
+
+	return h.dispatcher.ObserveAuthProvider(*req.Object.(*v1.AuthProvider))
+}
+
 func SetAuthProviderConfiguredStatus(ctx context.Context, gatewayClient *gateway.Client, licenseProvider *license.Provider, authProvider *v1.AuthProvider) error {
 	var (
 		configured          = true

--- a/pkg/gateway/server/dispatcher/daemon.go
+++ b/pkg/gateway/server/dispatcher/daemon.go
@@ -42,13 +42,15 @@ type ports struct {
 }
 
 type daemonRevision struct {
-	instance   string
-	generation int64
-	value      string
+	instance        string
+	generation      int64
+	resourceVersion int64
+	value           string
+	forgotten       bool
 }
 
 func (d daemonRevision) sameConfiguration(other daemonRevision) bool {
-	return d.instance == other.instance && d.value == other.value
+	return !d.forgotten && !other.forgotten && d.instance == other.instance && d.value == other.value
 }
 
 func newPorts() *ports {
@@ -81,6 +83,18 @@ func (d *Dispatcher) stopDaemon(id string) {
 	d.stopDaemonLocked(id)
 }
 
+func (d *Dispatcher) stopDaemonIfRevision(id string, revision daemonRevision) {
+	d.ports.daemonLock.Lock()
+	defer d.ports.daemonLock.Unlock()
+
+	desired, desiredOK := d.ports.desiredDaemonRevisions[id]
+	running, runningOK := d.ports.daemonRevisions[id]
+	if !desiredOK || desired != revision || !runningOK || running != revision {
+		return
+	}
+	d.stopDaemonLocked(id)
+}
+
 func (d *Dispatcher) stopDaemonLocked(id string) {
 	if stop := d.ports.daemonsRunning[id]; stop != nil {
 		stop()
@@ -96,9 +110,19 @@ func (d *Dispatcher) observeDaemonRevision(id string, revision daemonRevision) b
 	d.ports.daemonLock.Lock()
 	defer d.ports.daemonLock.Unlock()
 
-	if desired, ok := d.ports.desiredDaemonRevisions[id]; ok &&
-		desired.instance == revision.instance && desired.generation > revision.generation {
-		return desired.sameConfiguration(revision)
+	if desired, ok := d.ports.desiredDaemonRevisions[id]; ok {
+		if desired.forgotten {
+			if desired.instance == revision.instance ||
+				desired.resourceVersion > 0 && revision.resourceVersion > 0 && desired.resourceVersion >= revision.resourceVersion {
+				return false
+			}
+		} else if desired.resourceVersion > 0 && revision.resourceVersion > 0 {
+			if desired.resourceVersion > revision.resourceVersion {
+				return desired.sameConfiguration(revision)
+			}
+		} else if desired.instance == revision.instance && desired.generation > revision.generation {
+			return desired.sameConfiguration(revision)
+		}
 	}
 	d.ports.desiredDaemonRevisions[id] = revision
 
@@ -121,7 +145,10 @@ func (d *Dispatcher) forgetDaemon(id string) {
 	defer d.ports.daemonLock.Unlock()
 
 	d.stopDaemonLocked(id)
-	delete(d.ports.desiredDaemonRevisions, id)
+	if desired, ok := d.ports.desiredDaemonRevisions[id]; ok {
+		desired.forgotten = true
+		d.ports.desiredDaemonRevisions[id] = desired
+	}
 }
 
 func (d *Dispatcher) daemonURL(id string, revision daemonRevision) (url.URL, bool) {

--- a/pkg/gateway/server/dispatcher/daemon.go
+++ b/pkg/gateway/server/dispatcher/daemon.go
@@ -3,6 +3,7 @@ package dispatcher
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -22,9 +23,12 @@ import (
 )
 
 type ports struct {
-	daemonPorts    map[string]int64
-	daemonsRunning map[string]func()
-	daemonLock     sync.RWMutex
+	daemonPorts            map[string]int64
+	daemonsRunning         map[string]func()
+	daemonCommands         map[string]*exec.Cmd
+	daemonRevisions        map[string]daemonRevision
+	desiredDaemonRevisions map[string]daemonRevision
+	daemonLock             sync.RWMutex
 
 	startPort, endPort int64
 	usedPorts          map[int64]struct{}
@@ -33,13 +37,28 @@ type ports struct {
 	daemonWG           sync.WaitGroup
 }
 
+type daemonRevision struct {
+	instance   string
+	generation int64
+	value      string
+}
+
+func (d daemonRevision) sameConfiguration(other daemonRevision) bool {
+	return d.instance == other.instance && d.value == other.value
+}
+
+var errDaemonRevisionChanged = errors.New("daemon revision changed")
+
 func newPorts() *ports {
 	daemonCtx, cancel := context.WithCancel(context.Background())
 	p := &ports{
-		daemonCtx:      daemonCtx,
-		daemonPorts:    map[string]int64{},
-		daemonsRunning: map[string]func(){},
-		usedPorts:      map[int64]struct{}{},
+		daemonCtx:              daemonCtx,
+		daemonPorts:            map[string]int64{},
+		daemonsRunning:         map[string]func(){},
+		daemonCommands:         map[string]*exec.Cmd{},
+		daemonRevisions:        map[string]daemonRevision{},
+		desiredDaemonRevisions: map[string]daemonRevision{},
+		usedPorts:              map[int64]struct{}{},
 	}
 	p.daemonClose = func() {
 		cancel()
@@ -57,14 +76,56 @@ func (d *Dispatcher) closeDaemons() {
 func (d *Dispatcher) stopDaemon(id string) {
 	d.ports.daemonLock.Lock()
 	defer d.ports.daemonLock.Unlock()
+	d.stopDaemonLocked(id)
+}
 
+func (d *Dispatcher) stopDaemonLocked(id string) {
 	if stop := d.ports.daemonsRunning[id]; stop != nil {
 		stop()
 	}
 
 	delete(d.ports.daemonsRunning, id)
-	delete(d.ports.usedPorts, d.ports.daemonPorts[id])
+	delete(d.ports.daemonCommands, id)
+	delete(d.ports.daemonRevisions, id)
 	delete(d.ports.daemonPorts, id)
+}
+
+func (d *Dispatcher) observeDaemonRevision(id string, revision daemonRevision) bool {
+	d.ports.daemonLock.Lock()
+	defer d.ports.daemonLock.Unlock()
+
+	if desired, ok := d.ports.desiredDaemonRevisions[id]; ok &&
+		desired.instance == revision.instance && desired.generation > revision.generation {
+		return desired.sameConfiguration(revision)
+	}
+	d.ports.desiredDaemonRevisions[id] = revision
+
+	if runningRevision, ok := d.ports.daemonRevisions[id]; ok {
+		if !runningRevision.sameConfiguration(revision) {
+			d.stopDaemonLocked(id)
+		} else {
+			d.ports.daemonRevisions[id] = revision
+		}
+	}
+	return true
+}
+
+func (d *Dispatcher) forgetDaemon(id string) {
+	d.ports.daemonLock.Lock()
+	defer d.ports.daemonLock.Unlock()
+
+	d.stopDaemonLocked(id)
+	delete(d.ports.desiredDaemonRevisions, id)
+}
+
+func (d *Dispatcher) daemonURL(id string, revision daemonRevision) (url.URL, bool) {
+	d.ports.daemonLock.RLock()
+	defer d.ports.daemonLock.RUnlock()
+
+	port := d.ports.daemonPorts[id]
+	_, running := d.ports.daemonsRunning[id]
+	return url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)},
+		port != 0 && running && d.ports.daemonRevisions[id].sameConfiguration(revision)
 }
 
 func (d *Dispatcher) nextPort() int64 {
@@ -94,14 +155,17 @@ func (d *Dispatcher) nextPort() int64 {
 	panic("Ran out of usable ports")
 }
 
-func (d *Dispatcher) startDaemon(env map[string]string, id, command string, args ...string) (url.URL, error) {
+func (d *Dispatcher) startDaemon(env map[string]string, id string, revision daemonRevision, command string, args ...string) (url.URL, error) {
 	d.ports.daemonLock.RLock()
 	port, portExists := d.ports.daemonPorts[id]
 	_, isRunning := d.ports.daemonsRunning[id]
+	runningRevision := d.ports.daemonRevisions[id]
+	desiredRevision, hasDesiredRevision := d.ports.desiredDaemonRevisions[id]
 	d.ports.daemonLock.RUnlock()
 
 	u := url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}
-	if portExists && isRunning {
+	if portExists && isRunning && runningRevision.sameConfiguration(revision) &&
+		(!hasDesiredRevision || desiredRevision.sameConfiguration(revision)) {
 		return u, nil
 	}
 
@@ -110,8 +174,18 @@ func (d *Dispatcher) startDaemon(env map[string]string, id, command string, args
 
 	port, portExists = d.ports.daemonPorts[id]
 	_, isRunning = d.ports.daemonsRunning[id]
-	if portExists && isRunning {
+	runningRevision = d.ports.daemonRevisions[id]
+	if desired, ok := d.ports.desiredDaemonRevisions[id]; ok {
+		if !desired.sameConfiguration(revision) {
+			return u, errDaemonRevisionChanged
+		}
+		revision = desired
+	}
+	if portExists && isRunning && runningRevision.sameConfiguration(revision) {
 		return url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}, nil
+	}
+	if portExists || isRunning {
+		d.stopDaemonLocked(id)
 	}
 
 	ctx := d.ports.daemonCtx
@@ -136,6 +210,8 @@ func (d *Dispatcher) startDaemon(env map[string]string, id, command string, args
 
 	d.ports.daemonPorts[id] = port
 	d.ports.daemonsRunning[id] = stop
+	d.ports.daemonCommands[id] = cmd
+	d.ports.daemonRevisions[id] = revision
 
 	killedCtx, killedCancel := context.WithCancelCause(ctx)
 	defer killedCancel(nil)
@@ -153,8 +229,13 @@ func (d *Dispatcher) startDaemon(env map[string]string, id, command string, args
 		defer d.ports.daemonLock.Unlock()
 
 		delete(d.ports.usedPorts, port)
+		if d.ports.daemonCommands[id] != cmd {
+			return
+		}
 		delete(d.ports.daemonPorts, id)
 		delete(d.ports.daemonsRunning, id)
+		delete(d.ports.daemonCommands, id)
+		delete(d.ports.daemonRevisions, id)
 	})
 
 	client := &http.Client{Timeout: 2 * time.Second}

--- a/pkg/gateway/server/dispatcher/daemon.go
+++ b/pkg/gateway/server/dispatcher/daemon.go
@@ -22,6 +22,10 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 )
 
+var (
+	errDaemonRevisionChanged = errors.New("daemon revision changed")
+)
+
 type ports struct {
 	daemonPorts            map[string]int64
 	daemonsRunning         map[string]func()
@@ -46,8 +50,6 @@ type daemonRevision struct {
 func (d daemonRevision) sameConfiguration(other daemonRevision) bool {
 	return d.instance == other.instance && d.value == other.value
 }
-
-var errDaemonRevisionChanged = errors.New("daemon revision changed")
 
 func newPorts() *ports {
 	daemonCtx, cancel := context.WithCancel(context.Background())

--- a/pkg/gateway/server/dispatcher/daemon.go
+++ b/pkg/gateway/server/dispatcher/daemon.go
@@ -103,6 +103,10 @@ func (d *Dispatcher) observeDaemonRevision(id string, revision daemonRevision) b
 	if runningRevision, ok := d.ports.daemonRevisions[id]; ok {
 		if !runningRevision.sameConfiguration(revision) {
 			d.stopDaemonLocked(id)
+			slog.Info("Stopped provider daemon because its configuration revision changed",
+				"provider", id,
+				"oldGeneration", runningRevision.generation,
+				"newGeneration", revision.generation)
 		} else {
 			d.ports.daemonRevisions[id] = revision
 		}

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -124,7 +125,7 @@ func (d *Dispatcher) urlForAuthProvider(ctx context.Context, key, namespace, aut
 	}
 
 	if len(authProvider.Status.MissingConfigurationParameters) > 0 {
-		d.stopDaemon(key)
+		d.stopDaemonIfRevision(key, revision)
 		return url.URL{}, fmt.Errorf("provider %q is not configured, missing configuration parameters: %s", authProviderName, strings.Join(authProvider.Status.MissingConfigurationParameters, ", "))
 	}
 	if u, ok := d.daemonURL(key, revision); ok {
@@ -147,7 +148,7 @@ func (d *Dispatcher) urlForAuthProvider(ctx context.Context, key, namespace, aut
 		}
 	}
 	if len(missingConfigParams) > 0 {
-		d.stopDaemon(key)
+		d.stopDaemonIfRevision(key, revision)
 		return url.URL{}, fmt.Errorf("provider %q is not configured, missing configuration parameters: %s", authProviderName, strings.Join(missingConfigParams, ", "))
 	}
 
@@ -167,12 +168,21 @@ func (d *Dispatcher) ObserveAuthProvider(authProvider v1.AuthProvider) error {
 	}
 	key := providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)
 	if current := d.observeDaemonRevision(key, revision); current && len(authProvider.Status.MissingConfigurationParameters) > 0 {
-		d.stopDaemon(key)
+		d.stopDaemonIfRevision(key, revision)
 	}
 	return nil
 }
 
 func authProviderRevision(authProvider v1.AuthProvider) (daemonRevision, error) {
+	var resourceVersion int64
+	if authProvider.ResourceVersion != "" {
+		var err error
+		resourceVersion, err = strconv.ParseInt(authProvider.ResourceVersion, 10, 64)
+		if err != nil {
+			return daemonRevision{}, fmt.Errorf("parse auth provider resource version %q: %w", authProvider.ResourceVersion, err)
+		}
+	}
+
 	payload := struct {
 		Spec         v1.AuthProviderSpec `json:"spec"`
 		SyncRevision string              `json:"syncRevision"`
@@ -186,9 +196,10 @@ func authProviderRevision(authProvider v1.AuthProvider) (daemonRevision, error) 
 	}
 	digest := sha256.Sum256(b)
 	return daemonRevision{
-		instance:   string(authProvider.UID),
-		generation: authProvider.Generation,
-		value:      hex.EncodeToString(digest[:]),
+		instance:        string(authProvider.UID),
+		generation:      authProvider.Generation,
+		resourceVersion: resourceVersion,
+		value:           hex.EncodeToString(digest[:]),
 	}, nil
 }
 
@@ -263,8 +274,8 @@ func (d *Dispatcher) StopAuthProvider(namespace, authProviderName string) {
 	d.stopProvider("auth-provider", namespace, authProviderName)
 }
 
-// ForgetAuthProvider stops a local daemon and removes the desired revision for
-// a deleted AuthProvider so a newly created resource with the same name can start.
+// ForgetAuthProvider stops a local daemon and remembers the deleted instance so
+// in-flight requests cannot restart it.
 func (d *Dispatcher) ForgetAuthProvider(namespace, authProviderName string) {
 	d.forgetDaemon(providerKeyForAuthProvider(namespace, authProviderName))
 }

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -122,12 +122,13 @@ func (d *Dispatcher) urlForAuthProvider(ctx context.Context, key, namespace, aut
 	if current := d.observeDaemonRevision(key, revision); !current {
 		return url.URL{}, errDaemonRevisionChanged
 	}
-	if u, ok := d.daemonURL(key, revision); ok {
-		return u, nil
-	}
 
 	if len(authProvider.Status.MissingConfigurationParameters) > 0 {
+		d.stopDaemon(key)
 		return url.URL{}, fmt.Errorf("provider %q is not configured, missing configuration parameters: %s", authProviderName, strings.Join(authProvider.Status.MissingConfigurationParameters, ", "))
+	}
+	if u, ok := d.daemonURL(key, revision); ok {
+		return u, nil
 	}
 
 	credEnv := map[string]string{}
@@ -138,6 +139,16 @@ func (d *Dispatcher) urlForAuthProvider(ctx context.Context, key, namespace, aut
 		}
 	} else if cred.Secrets != nil {
 		credEnv = cred.Secrets
+	}
+	var missingConfigParams []string
+	for _, required := range authProvider.Spec.RequiredConfigurationParameters {
+		if _, ok := credEnv[required.Name]; !ok {
+			missingConfigParams = append(missingConfigParams, required.Name)
+		}
+	}
+	if len(missingConfigParams) > 0 {
+		d.stopDaemon(key)
+		return url.URL{}, fmt.Errorf("provider %q is not configured, missing configuration parameters: %s", authProviderName, strings.Join(missingConfigParams, ", "))
 	}
 
 	maps.Copy(credEnv, d.authProviderExtraEnv)
@@ -154,7 +165,10 @@ func (d *Dispatcher) ObserveAuthProvider(authProvider v1.AuthProvider) error {
 	if err != nil {
 		return err
 	}
-	d.observeDaemonRevision(providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name), revision)
+	key := providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)
+	if current := d.observeDaemonRevision(key, revision); current && len(authProvider.Status.MissingConfigurationParameters) > 0 {
+		d.stopDaemon(key)
+	}
 	return nil
 }
 

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -2,6 +2,9 @@ package dispatcher
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -93,16 +96,34 @@ func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProv
 		return u, nil
 	}
 
-	d.ports.daemonLock.RLock()
-	if port := d.ports.daemonPorts[key]; port != 0 {
-		d.ports.daemonLock.RUnlock()
-		return url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}, nil
-	}
-	d.ports.daemonLock.RUnlock()
+	for {
+		if err := ctx.Err(); err != nil {
+			return url.URL{}, err
+		}
 
+		u, err := d.urlForAuthProvider(ctx, key, namespace, authProviderName)
+		if errors.Is(err, errDaemonRevisionChanged) {
+			continue
+		}
+		return u, err
+	}
+}
+
+func (d *Dispatcher) urlForAuthProvider(ctx context.Context, key, namespace, authProviderName string) (url.URL, error) {
 	var authProvider v1.AuthProvider
 	if err := d.client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: authProviderName}, &authProvider); err != nil {
 		return url.URL{}, fmt.Errorf("failed to get provider: %w", err)
+	}
+
+	revision, err := authProviderRevision(authProvider)
+	if err != nil {
+		return url.URL{}, err
+	}
+	if current := d.observeDaemonRevision(key, revision); !current {
+		return url.URL{}, errDaemonRevisionChanged
+	}
+	if u, ok := d.daemonURL(key, revision); ok {
+		return u, nil
 	}
 
 	if len(authProvider.Status.MissingConfigurationParameters) > 0 {
@@ -123,7 +144,38 @@ func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProv
 
 	credEnv["LOG_LEVEL"] = providerLogLevel()
 
-	return d.startDaemon(credEnv, key, authProvider.Spec.Command, authProvider.Spec.Args...)
+	return d.startDaemon(credEnv, key, revision, authProvider.Spec.Command, authProvider.Spec.Args...)
+}
+
+// ObserveAuthProvider invalidates the process-local daemon when the shared AuthProvider
+// resource describes a newer configuration than the daemon was launched with.
+func (d *Dispatcher) ObserveAuthProvider(authProvider v1.AuthProvider) error {
+	revision, err := authProviderRevision(authProvider)
+	if err != nil {
+		return err
+	}
+	d.observeDaemonRevision(providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name), revision)
+	return nil
+}
+
+func authProviderRevision(authProvider v1.AuthProvider) (daemonRevision, error) {
+	payload := struct {
+		Spec         v1.AuthProviderSpec `json:"spec"`
+		SyncRevision string              `json:"syncRevision"`
+	}{
+		Spec:         authProvider.Spec,
+		SyncRevision: authProvider.Annotations[v1.AuthProviderSyncAnnotation],
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return daemonRevision{}, fmt.Errorf("failed to calculate auth provider revision: %w", err)
+	}
+	digest := sha256.Sum256(b)
+	return daemonRevision{
+		instance:   string(authProvider.UID),
+		generation: authProvider.Generation,
+		value:      hex.EncodeToString(digest[:]),
+	}, nil
 }
 
 // GroupIDPrefixForAuthProvider returns the group ID namespace declared by an auth provider.
@@ -179,7 +231,7 @@ func (d *Dispatcher) urlForModelProvider(ctx context.Context, key string, modelP
 
 	credEnv["LOG_LEVEL"] = providerLogLevel()
 
-	return d.startDaemon(credEnv, key, modelProvider.Spec.Command, modelProvider.Spec.Args...)
+	return d.startDaemon(credEnv, key, daemonRevision{}, modelProvider.Spec.Command, modelProvider.Spec.Args...)
 }
 
 func providerLogLevel() string {
@@ -195,6 +247,12 @@ func (d *Dispatcher) StopModelProvider(namespace, modelProviderName string) {
 
 func (d *Dispatcher) StopAuthProvider(namespace, authProviderName string) {
 	d.stopProvider("auth-provider", namespace, authProviderName)
+}
+
+// ForgetAuthProvider stops a local daemon and removes the desired revision for
+// a deleted AuthProvider so a newly created resource with the same name can start.
+func (d *Dispatcher) ForgetAuthProvider(namespace, authProviderName string) {
+	d.forgetDaemon(providerKeyForAuthProvider(namespace, authProviderName))
 }
 
 func (d *Dispatcher) stopProvider(providerType, namespace, providerName string) {

--- a/pkg/gateway/server/dispatcher/dispatcher_test.go
+++ b/pkg/gateway/server/dispatcher/dispatcher_test.go
@@ -35,9 +35,10 @@ func TestProviderLogLevelEnv(t *testing.T) {
 
 func TestAuthProviderRevisionTracksOnlyDaemonConfiguration(t *testing.T) {
 	authProvider := v1.AuthProvider{
-		Name:       "entra",
-		Namespace:  "default",
-		Generation: 4,
+		Name:            "entra",
+		Namespace:       "default",
+		Generation:      4,
+		ResourceVersion: "10",
 		Annotations: map[string]string{
 			v1.AuthProviderSyncAnnotation: "revision-one",
 		},
@@ -53,6 +54,9 @@ func TestAuthProviderRevisionTracksOnlyDaemonConfiguration(t *testing.T) {
 	original, err := authProviderRevision(authProvider)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if original.resourceVersion != 10 {
+		t.Fatalf("resource version = %d, want 10", original.resourceVersion)
 	}
 
 	statusUpdate := authProvider.DeepCopy()
@@ -216,6 +220,39 @@ func TestObserveAuthProviderDoesNotStopNewerDaemonForStaleMissingStatus(t *testi
 	}
 }
 
+func TestStopDaemonIfRevisionDoesNotStopNewerDaemon(t *testing.T) {
+	d := &Dispatcher{ports: newPorts()}
+	t.Cleanup(d.ports.daemonClose)
+	key := providerKeyForAuthProvider("default", "entra")
+	oldRevision := daemonRevision{
+		instance:        "instance",
+		generation:      1,
+		resourceVersion: 10,
+		value:           "old",
+	}
+	newRevision := daemonRevision{
+		instance:        "instance",
+		generation:      2,
+		resourceVersion: 11,
+		value:           "new",
+	}
+	stopCalls := 0
+	d.ports.desiredDaemonRevisions[key] = newRevision
+	d.ports.daemonPorts[key] = 10443
+	d.ports.daemonsRunning[key] = func() {
+		stopCalls++
+	}
+	d.ports.daemonRevisions[key] = newRevision
+
+	d.stopDaemonIfRevision(key, oldRevision)
+	if stopCalls != 0 {
+		t.Fatalf("daemon stop calls = %d, want 0", stopCalls)
+	}
+	if _, running := d.ports.daemonsRunning[key]; !running {
+		t.Fatal("newer daemon was removed from registry")
+	}
+}
+
 func TestStartDaemonRejectsSupersededRevision(t *testing.T) {
 	d := &Dispatcher{ports: newPorts()}
 	t.Cleanup(d.ports.daemonClose)
@@ -238,22 +275,35 @@ func TestForgetAuthProviderAllowsLowerGenerationAfterRecreation(t *testing.T) {
 	d := &Dispatcher{ports: newPorts()}
 	t.Cleanup(d.ports.daemonClose)
 	key := providerKeyForAuthProvider("default", "entra")
-	d.ports.desiredDaemonRevisions[key] = daemonRevision{
-		instance:   "old-instance",
-		generation: 10,
-		value:      "old",
+	oldRevision := daemonRevision{
+		instance:        "old-instance",
+		generation:      10,
+		resourceVersion: 20,
+		value:           "old",
 	}
+	d.ports.desiredDaemonRevisions[key] = oldRevision
 
 	d.ForgetAuthProvider("default", "entra")
-	if _, ok := d.ports.desiredDaemonRevisions[key]; ok {
-		t.Fatal("deleted auth provider revision remains in registry")
+	if desired := d.ports.desiredDaemonRevisions[key]; !desired.forgotten {
+		t.Fatal("deleted auth provider revision was not marked forgotten")
+	}
+	if current := d.observeDaemonRevision(key, oldRevision); current {
+		t.Fatal("forgotten auth provider instance was accepted")
 	}
 
-	if current := d.observeDaemonRevision(key, daemonRevision{
-		instance:   "new-instance",
-		generation: 1,
-		value:      "new",
-	}); !current {
+	newRevision := daemonRevision{
+		instance:        "new-instance",
+		generation:      1,
+		resourceVersion: 21,
+		value:           "new",
+	}
+	if current := d.observeDaemonRevision(key, newRevision); !current {
 		t.Fatal("recreated auth provider revision was rejected")
+	}
+	if current := d.observeDaemonRevision(key, oldRevision); current {
+		t.Fatal("old instance superseded recreated auth provider")
+	}
+	if desired := d.ports.desiredDaemonRevisions[key]; desired != newRevision {
+		t.Fatalf("desired revision = %#v, want %#v", desired, newRevision)
 	}
 }

--- a/pkg/gateway/server/dispatcher/dispatcher_test.go
+++ b/pkg/gateway/server/dispatcher/dispatcher_test.go
@@ -1,10 +1,13 @@
 package dispatcher
 
 import (
+	"errors"
 	"log/slog"
 	"testing"
 
+	clienttypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 )
 
 func TestProviderLogLevelEnv(t *testing.T) {
@@ -28,4 +31,161 @@ func TestProviderLogLevelEnv(t *testing.T) {
 			t.Fatalf("providerLogLevel() = %q, want DEBUG", got)
 		}
 	})
+}
+
+func TestAuthProviderRevisionTracksOnlyDaemonConfiguration(t *testing.T) {
+	authProvider := v1.AuthProvider{
+		Name:       "entra",
+		Namespace:  "default",
+		Generation: 4,
+		Annotations: map[string]string{
+			v1.AuthProviderSyncAnnotation: "revision-one",
+		},
+		Spec: v1.AuthProviderSpec{
+			AuthProviderManifest: clienttypes.AuthProviderManifest{
+				CommonProviderMetadata: clienttypes.CommonProviderMetadata{
+					Command: "entra-auth-provider",
+				},
+			},
+		},
+	}
+
+	original, err := authProviderRevision(authProvider)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	statusUpdate := authProvider.DeepCopy()
+	statusUpdate.Status.Configured = true
+	statusRevision, err := authProviderRevision(*statusUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statusRevision != original {
+		t.Fatalf("status update changed daemon revision: got %#v, want %#v", statusRevision, original)
+	}
+
+	metadataUpdate := authProvider.DeepCopy()
+	metadataUpdate.Generation++
+	metadataUpdate.Annotations["unrelated"] = "value"
+	metadataRevision, err := authProviderRevision(*metadataUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !metadataRevision.sameConfiguration(original) {
+		t.Fatal("unrelated metadata update changed daemon configuration revision")
+	}
+
+	credentialUpdate := authProvider.DeepCopy()
+	credentialUpdate.Generation++
+	credentialUpdate.Annotations[v1.AuthProviderSyncAnnotation] = "revision-two"
+	credentialRevision, err := authProviderRevision(*credentialUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credentialRevision == original {
+		t.Fatal("credential sync revision did not change daemon revision")
+	}
+
+	specUpdate := authProvider.DeepCopy()
+	specUpdate.Generation++
+	specUpdate.Spec.Command = "new-entra-auth-provider"
+	specRevision, err := authProviderRevision(*specUpdate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if specRevision == original {
+		t.Fatal("provider spec did not change daemon revision")
+	}
+}
+
+func TestObserveDaemonRevisionStopsOnlyStaleDaemon(t *testing.T) {
+	d := &Dispatcher{ports: newPorts()}
+	t.Cleanup(d.ports.daemonClose)
+	key := providerKeyForAuthProvider("default", "entra")
+	oldRevision := daemonRevision{
+		generation: 1,
+		value:      "old",
+	}
+	newRevision := daemonRevision{
+		generation: 2,
+		value:      "new",
+	}
+	stopCalls := 0
+	d.ports.daemonPorts[key] = 10443
+	d.ports.daemonsRunning[key] = func() {
+		stopCalls++
+	}
+	d.ports.daemonRevisions[key] = oldRevision
+
+	if current := d.observeDaemonRevision(key, oldRevision); !current {
+		t.Fatal("current revision was rejected")
+	}
+	if stopCalls != 0 {
+		t.Fatalf("matching daemon stop calls = %d, want 0", stopCalls)
+	}
+
+	if current := d.observeDaemonRevision(key, newRevision); !current {
+		t.Fatal("new revision was rejected")
+	}
+	if stopCalls != 1 {
+		t.Fatalf("stale daemon stop calls = %d, want 1", stopCalls)
+	}
+	if _, running := d.ports.daemonsRunning[key]; running {
+		t.Fatal("stale daemon remains in registry")
+	}
+
+	d.ports.daemonPorts[key] = 10444
+	d.ports.daemonsRunning[key] = func() {
+		stopCalls++
+	}
+	d.ports.daemonRevisions[key] = newRevision
+	if current := d.observeDaemonRevision(key, oldRevision); current {
+		t.Fatal("older revision superseded newer desired revision")
+	}
+	if stopCalls != 1 {
+		t.Fatalf("new daemon stop calls after stale event = %d, want 1", stopCalls)
+	}
+}
+
+func TestStartDaemonRejectsSupersededRevision(t *testing.T) {
+	d := &Dispatcher{ports: newPorts()}
+	t.Cleanup(d.ports.daemonClose)
+	key := providerKeyForAuthProvider("default", "entra")
+	d.ports.desiredDaemonRevisions[key] = daemonRevision{
+		generation: 2,
+		value:      "new",
+	}
+
+	_, err := d.startDaemon(nil, key, daemonRevision{
+		generation: 1,
+		value:      "old",
+	}, "command-that-must-not-run")
+	if !errors.Is(err, errDaemonRevisionChanged) {
+		t.Fatalf("startDaemon error = %v, want %v", err, errDaemonRevisionChanged)
+	}
+}
+
+func TestForgetAuthProviderAllowsLowerGenerationAfterRecreation(t *testing.T) {
+	d := &Dispatcher{ports: newPorts()}
+	t.Cleanup(d.ports.daemonClose)
+	key := providerKeyForAuthProvider("default", "entra")
+	d.ports.desiredDaemonRevisions[key] = daemonRevision{
+		instance:   "old-instance",
+		generation: 10,
+		value:      "old",
+	}
+
+	d.ForgetAuthProvider("default", "entra")
+	if _, ok := d.ports.desiredDaemonRevisions[key]; ok {
+		t.Fatal("deleted auth provider revision remains in registry")
+	}
+
+	if current := d.observeDaemonRevision(key, daemonRevision{
+		instance:   "new-instance",
+		generation: 1,
+		value:      "new",
+	}); !current {
+		t.Fatal("recreated auth provider revision was rejected")
+	}
 }

--- a/pkg/gateway/server/dispatcher/dispatcher_test.go
+++ b/pkg/gateway/server/dispatcher/dispatcher_test.go
@@ -148,6 +148,74 @@ func TestObserveDaemonRevisionStopsOnlyStaleDaemon(t *testing.T) {
 	}
 }
 
+func TestObserveAuthProviderStopsDaemonWhenConfigurationIsMissing(t *testing.T) {
+	d := &Dispatcher{ports: newPorts()}
+	t.Cleanup(d.ports.daemonClose)
+	authProvider := v1.AuthProvider{
+		Name:       "entra",
+		Namespace:  "default",
+		Generation: 2,
+		Annotations: map[string]string{
+			v1.AuthProviderSyncAnnotation: "current",
+		},
+	}
+	authProvider.Status.MissingConfigurationParameters = []string{"CLIENT_SECRET"}
+	revision, err := authProviderRevision(authProvider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)
+	stopCalls := 0
+	d.ports.daemonPorts[key] = 10443
+	d.ports.daemonsRunning[key] = func() {
+		stopCalls++
+	}
+	d.ports.daemonRevisions[key] = revision
+
+	if err := d.ObserveAuthProvider(authProvider); err != nil {
+		t.Fatal(err)
+	}
+	if stopCalls != 1 {
+		t.Fatalf("daemon stop calls = %d, want 1", stopCalls)
+	}
+	if _, running := d.ports.daemonsRunning[key]; running {
+		t.Fatal("unconfigured daemon remains in registry")
+	}
+}
+
+func TestObserveAuthProviderDoesNotStopNewerDaemonForStaleMissingStatus(t *testing.T) {
+	d := &Dispatcher{ports: newPorts()}
+	t.Cleanup(d.ports.daemonClose)
+	key := providerKeyForAuthProvider("default", "entra")
+	newRevision := daemonRevision{
+		generation: 2,
+		value:      "new",
+	}
+	stopCalls := 0
+	d.ports.desiredDaemonRevisions[key] = newRevision
+	d.ports.daemonPorts[key] = 10443
+	d.ports.daemonsRunning[key] = func() {
+		stopCalls++
+	}
+	d.ports.daemonRevisions[key] = newRevision
+	staleAuthProvider := v1.AuthProvider{
+		Name:       "entra",
+		Namespace:  "default",
+		Generation: 1,
+		Annotations: map[string]string{
+			v1.AuthProviderSyncAnnotation: "old",
+		},
+	}
+	staleAuthProvider.Status.MissingConfigurationParameters = []string{"CLIENT_SECRET"}
+
+	if err := d.ObserveAuthProvider(staleAuthProvider); err != nil {
+		t.Fatal(err)
+	}
+	if stopCalls != 0 {
+		t.Fatalf("daemon stop calls = %d, want 0", stopCalls)
+	}
+}
+
 func TestStartDaemonRejectsSupersededRevision(t *testing.T) {
 	d := &Dispatcher{ports: newPorts()}
 	t.Cleanup(d.ports.daemonClose)

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -170,6 +170,7 @@ type Services struct {
 	EncryptionConfig      *encryptionconfig.EncryptionConfiguration
 	StorageClient         storage.Client
 	Router                *router.Router
+	StorageReplicaRouter  *router.Router
 	PersistentTokenServer *persistent.TokenService
 	APIServer             *server.Server
 	GatewayClient         *client.Client
@@ -599,6 +600,17 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// storageReplicaRouter is a controller that runs on all Obot replicas.
+	storageReplicaRouter, err := nah.NewRouter("obot-storage-replica", &nah.Options{
+		RESTConfig:     restConfig,
+		Scheme:         scheme.Scheme,
+		ElectionConfig: nil,
+		HealthzPort:    -1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create every-replica storage router: %w", err)
 	}
 
 	gatewayClient := client.New(
@@ -1252,6 +1264,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		ServerURL:             config.Hostname,
 		StorageClient:         storageClient,
 		Router:                r,
+		StorageReplicaRouter:  storageReplicaRouter,
 		PersistentTokenServer: persistentTokenServer,
 		APIServer: server.NewServer(
 			storageClient,


### PR DESCRIPTION
There was a bug that could manifest in a multi-replica Obot setup where changing the auth provider configuration only caused the auth provider daemon to restart on the replica that handled the API call that made the configuration change. Other replicas would continue running the old configuration of the auth provider until their pods got restarted.

This adds the concept of revisions to auth provider configuration by generating a UUID and storing it on an annotation on the AuthProvider kinm object. I introduced a new controller without leader election (so it runs across all replicas) that watches this and stops the auth provider daemons when the revision changes.