### PR TITLE
enhance: provide config for client native overrides

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -238,6 +238,9 @@ config:
   # config.OBOT_SERVER_MCPOAUTH_CLIENT_EXPIRATION -- The expiration time for dynamically registered MCP OAuth clients. Must be a valid duration string and may include days, hours, or minutes. Defaults to 30d.
   OBOT_SERVER_MCPOAUTH_CLIENT_EXPIRATION: ""
 
+  # config.OBOT_SERVER_MCPOAUTH_CLIENT_NATIVE_EXCEPTIONS -- A comma-separated list of additional Client ID Metadata Document URLs that default to the native application type when application_type is omitted.
+  OBOT_SERVER_MCPOAUTH_CLIENT_NATIVE_EXCEPTIONS: ""
+
   # config.OBOT_SERVER_FORCE_DYNAMIC_CLIENT -- Force Dynamic Client Registration when Obot authenticates to remote MCP servers, even when the authorization server supports Client ID Metadata Documents. Defaults to false.
   OBOT_SERVER_FORCE_DYNAMIC_CLIENT: false
 

--- a/docs/docs/configuration/server-configuration.md
+++ b/docs/docs/configuration/server-configuration.md
@@ -83,6 +83,7 @@ The Obot server is configured via environment variables. The following configura
 | `OBOT_SERVER_DISABLE_UPDATE_CHECK` | Disable the Obot server update check. | `false` |
 | `OBOT_SERVER_HIDE_K8S_DETAILS` | Hide Kubernetes configuration details such as the Server Scheduling page from the UI. | `false` |
 | `OBOT_SERVER_MCPOAUTH_CLIENT_EXPIRATION` | The expiration time for dynamically registered MCP OAuth clients. Must be a valid duration string and may include days, hours, or minutes. | `30d` |
+| `OBOT_SERVER_MCPOAUTH_CLIENT_NATIVE_EXCEPTIONS` | A comma-separated list of additional Client ID Metadata Document URLs that default to the native application type when `application_type` is omitted. | - |
 | `OBOT_SERVER_FORCE_DYNAMIC_CLIENT` | Force Dynamic Client Registration when Obot authenticates to remote MCP servers, even when the authorization server supports Client ID Metadata Documents. | `false` |
 | `OBOT_SERVER_ENABLE_MESSAGE_POLICIES` | Enable Message Policies for LLM proxy content enforcement. When enabled, Obot exposes the Message Policies and Message Policy Violations admin views and evaluates configured policies on user messages and tool calls. | `false` |
 | `OBOT_SERVER_LICENSE_KEY` | A license key for Obot Enterprise. If set via configuration, the license key cannot be updated in the UI. | - |

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"mime"
 	"net/http"
 	"net/url"
@@ -29,6 +30,7 @@ const (
 var (
 	clientIDNativeExceptions = map[string]struct{}{
 		"https://claude.ai/oauth/claude-code-client-metadata": {},
+		"https://goose-docs.ai/oauth/client-metadata.json":    {},
 	}
 )
 
@@ -42,6 +44,18 @@ type clientIDMetadataDocument struct {
 	types.OAuthClientManifest
 	ClientID string          `json:"client_id"`
 	JWKS     json.RawMessage `json:"jwks,omitempty"`
+}
+
+func newClientIDNativeExceptions(additional []string) map[string]struct{} {
+	exceptions := make(map[string]struct{}, len(clientIDNativeExceptions)+len(additional))
+	maps.Copy(exceptions, clientIDNativeExceptions)
+
+	for _, clientID := range additional {
+		if clientID = strings.TrimSpace(clientID); clientID != "" {
+			exceptions[clientID] = struct{}{}
+		}
+	}
+	return exceptions
 }
 
 func (h *handler) resolveOAuthClient(ctx context.Context, c kclient.Client, clientID string) (v1.OAuthClient, error) {
@@ -189,7 +203,7 @@ func (h *handler) oauthClientFromMetadataDocument(clientID string, doc clientIDM
 		return v1.OAuthClient{}, fmt.Errorf("client metadata document must include redirect_uris")
 	}
 	if doc.ApplicationType == "" {
-		if _, ok := clientIDNativeExceptions[clientID]; ok {
+		if _, ok := h.clientIDNativeExceptions[clientID]; ok {
 			doc.ApplicationType = "native"
 		} else {
 			doc.ApplicationType = "web"

--- a/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/client_id_metadata_test.go
@@ -30,6 +30,7 @@ func newTestCIMDHandler(rt roundTripFunc) *handler {
 		},
 		clientMetadataHTTPClient: &http.Client{Transport: rt},
 		clientMetadataCache:      map[string]clientMetadataCacheEntry{},
+		clientIDNativeExceptions: newClientIDNativeExceptions(nil),
 	}
 }
 
@@ -236,7 +237,10 @@ func TestClientIDNativeExceptionsDefaultToNative(t *testing.T) {
 	t.Parallel()
 
 	h := newTestCIMDHandler(nil)
-	for clientID := range clientIDNativeExceptions {
+	for _, clientID := range []string{
+		"https://claude.ai/oauth/claude-code-client-metadata",
+		"https://goose-docs.ai/oauth/client-metadata.json",
+	} {
 		t.Run(clientID, func(t *testing.T) {
 			t.Parallel()
 
@@ -252,6 +256,26 @@ func TestClientIDNativeExceptionsDefaultToNative(t *testing.T) {
 				t.Fatalf("expected native application type, got %q", client.Spec.Manifest.ApplicationType)
 			}
 		})
+	}
+}
+
+func TestAdditionalClientIDNativeExceptionsDefaultToNative(t *testing.T) {
+	t.Parallel()
+
+	const clientID = "https://client.example/oauth/client.json"
+	h := newTestCIMDHandler(nil)
+	h.clientIDNativeExceptions = newClientIDNativeExceptions([]string{clientID})
+
+	client, err := h.oauthClientFromMetadataDocument(clientID, clientIDMetadataDocument{
+		ClientName:   "Example Client",
+		RedirectURIs: []string{"http://127.0.0.1/callback"},
+		ClientID:     clientID,
+	})
+	if err != nil {
+		t.Fatalf("resolve metadata: %v", err)
+	}
+	if client.Spec.Manifest.ApplicationType != "native" {
+		t.Fatalf("expected native application type, got %q", client.Spec.Manifest.ApplicationType)
 	}
 }
 

--- a/pkg/api/handlers/mcpgateway/oauth/handler.go
+++ b/pkg/api/handlers/mcpgateway/oauth/handler.go
@@ -26,9 +26,10 @@ type handler struct {
 	clientMetadataHTTPClient *http.Client
 	clientMetadataCache      map[string]clientMetadataCacheEntry
 	clientMetadataCacheLock  sync.Mutex
+	clientIDNativeExceptions map[string]struct{}
 }
 
-func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTokenStore, tokenService *persistent.TokenService, oauthConfig handlers.OAuthAuthorizationServerConfig, mcpSessionManager *mcp.SessionManager, acrHelper *accesscontrolrule.Helper, baseURL string, clientSecretExpiration time.Duration, mux *server.Server) {
+func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTokenStore, tokenService *persistent.TokenService, oauthConfig handlers.OAuthAuthorizationServerConfig, mcpSessionManager *mcp.SessionManager, acrHelper *accesscontrolrule.Helper, baseURL string, clientSecretExpiration time.Duration, additionalClientIDNativeExceptions []string, mux *server.Server) {
 	remoteURLValidationConfig := mcpSessionManager.RemoteMCPURLValidationConfig()
 	h := &handler{
 		tokenStore:   tokenStore,
@@ -40,11 +41,12 @@ func SetupHandlers(oauthChecker *MCPOAuthHandlerFactory, tokenStore mcp.GlobalTo
 			BlockLinkLocal: !remoteURLValidationConfig.AllowLinkLocalMCP,
 			Timeout:        clientMetadataFetchTimeout,
 		}),
-		baseURL:             baseURL,
-		oauthChecker:        oauthChecker,
-		acrHelper:           acrHelper,
-		clientExpiration:    clientSecretExpiration,
-		clientMetadataCache: map[string]clientMetadataCacheEntry{},
+		baseURL:                  baseURL,
+		oauthChecker:             oauthChecker,
+		acrHelper:                acrHelper,
+		clientExpiration:         clientSecretExpiration,
+		clientMetadataCache:      map[string]clientMetadataCacheEntry{},
+		clientIDNativeExceptions: newClientIDNativeExceptions(additionalClientIDNativeExceptions),
 	}
 
 	// Expose two sets of endpoints: one for clients that look at the oauth-protected-resource metadata and one for clients that don't.

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -780,7 +780,7 @@ func NewRouter(ctx context.Context, services *services.Services) (*Router, error
 	// Well-known
 	wellknown.SetupHandlers(services.ServerURL, services.OAuthServerConfig, services.RegistryNoAuth, mux)
 	// Obot OAuth
-	oauth.SetupHandlers(oauthChecker, services.MCPOAuthTokenStorage, services.PersistentTokenServer, services.OAuthServerConfig, services.MCPSessionManager, services.AccessControlRuleHelper, services.ServerURL, services.MCPOAuthClientSecretExpiration, mux)
+	oauth.SetupHandlers(oauthChecker, services.MCPOAuthTokenStorage, services.PersistentTokenServer, services.OAuthServerConfig, services.MCPSessionManager, services.AccessControlRuleHelper, services.ServerURL, services.MCPOAuthClientSecretExpiration, services.MCPOAuthClientNativeExceptions, mux)
 
 	mux.HTTPHandle("/", ui.Handler(services.DevUIPort, services.UserUIPort))
 

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -100,8 +100,9 @@ type Config struct {
 	TunnelPeerID         string   `usage:"Unique Pod UID of this Obot replica for tunnel peering"`
 	TunnelPeerToken      string   `usage:"Shared internal credential for tunnel peering"`
 
-	MCPOAuthClientExpiration string `usage:"The expiration time in dynamically registered MCP OAuth clients, must be a valid duration string and may include days, hours, or minutes" default:"30d"`
-	ForceDynamicClient       bool   `usage:"Force Dynamic Client Registration for MCP OAuth instead of Client ID Metadata Documents"`
+	MCPOAuthClientExpiration       string   `usage:"The expiration time in dynamically registered MCP OAuth clients, must be a valid duration string and may include days, hours, or minutes" default:"30d"`
+	MCPOAuthClientNativeExceptions []string `usage:"Additional Client ID Metadata Document URLs that default to the native application type when application_type is omitted"`
+	ForceDynamicClient             bool     `usage:"Force Dynamic Client Registration for MCP OAuth instead of Client ID Metadata Documents"`
 
 	DevMode              bool   `usage:"Enable development mode" default:"false" name:"dev-mode" env:"OBOT_DEV_MODE"`
 	DevUIPort            int    `usage:"The port on localhost running the dev instance of the UI" default:"5174"`
@@ -222,6 +223,7 @@ type Services struct {
 	HostedAgentAccessRuleHelper *hostedagentaccessrule.Helper
 
 	MCPOAuthClientSecretExpiration time.Duration
+	MCPOAuthClientNativeExceptions []string
 	ForceDynamicClient             bool
 
 	// LocalK8sClient is a kclient for the local Kubernetes cluster — the
@@ -1300,6 +1302,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		DefaultHostedAgentsCatalogRef:  config.DefaultHostedAgentsCatalogRef,
 		ModelInfoSourceURL:             config.ModelInfoSourceURL,
 		MCPOAuthClientSecretExpiration: oauthClientExpiration,
+		MCPOAuthClientNativeExceptions: config.MCPOAuthClientNativeExceptions,
 		ForceDynamicClient:             config.ForceDynamicClient,
 		AccessControlRuleHelper:        acrHelper,
 		ModelAccessPolicyHelper:        mapHelper,


### PR DESCRIPTION
When using a local agent that supports CIMD, like claude and goose, their redirect URI often contains a port and the CIMD does not. The fix is for the CIMD document to state that the application is "native" but they don't do that. For this reason, we created a "native override" that contains the CIMD URLs for claude code and goose.

This change also provides configuration so that users can add additional CIMD URLs that will be treated the same way.