### PR TITLE
fix: restart auth providers during authentication if configuration changed

### DIFF
--- a/adr/2026-08-26-acknowledge-auth-provider-daemon-configuration.md
+++ b/adr/2026-08-26-acknowledge-auth-provider-daemon-configuration.md
@@ -1,0 +1,48 @@
+# 2026-08-26: Acknowledge auth provider daemon configuration in shared status
+
+- **Status:** Accepted
+- **Date:** 2026-08-26
+- **Supersedes:** None
+- **Superseded by:** None
+
+## Related issues
+
+None.
+
+## Related ODPs
+
+None.
+
+## Context
+
+Each Obot replica launches auth provider daemons lazily and keeps their process state in memory. Auth provider credentials are shared, but a configuration save previously stopped only the daemon on the replica serving the API request. Other replicas could continue using stale credentials and a different OAuth cookie secret, causing intermittent cross-replica login failures.
+
+Credential storage and `AuthProvider` storage use separate persistence layers, and Obot does not otherwise require every replica to run a controller that invalidates local daemons.
+
+## Decision
+
+The leader-elected auth provider controller will calculate a SHA-256 hash over the provider UID, provider spec, and stored credential environment. It will publish that hash in internal `AuthProvider` status together with the credential mutation revision it observed.
+
+Credential mutations will assign an opaque UUID revision to the `AuthProvider`. The internal OAuth cookie secret will be generated only when missing and will be preserved across ordinary saves.
+
+Before forwarding an auth request, every replica will read the current `AuthProvider` and reconcile its process-local daemon under a provider-scoped lock. It will return a cached daemon only when its recorded hash matches acknowledged status. Unacknowledged revisions, generations, or credential hashes fail closed. Credential values are read and hashed only when a daemon must start or be replaced, and shared state is revalidated after daemon startup.
+
+## Rationale
+
+Acknowledged shared status gives all replicas one authoritative configuration without adding a distributed daemon registry or an every-replica watch controller. Per-request resource reads close the stale-serving window, while hash comparison keeps secrets off the normal cached-daemon path. Provider-scoped locking prevents duplicate local launches without allowing a slow provider to block unrelated providers.
+
+Preserving the cookie secret also prevents unrelated saves from invalidating OAuth flows already in progress and reduces risk during mixed-version rollouts.
+
+## Consequences
+
+- Auth provider URL resolution performs one current shared-storage read before using a local daemon.
+- A replica can retain an idle stale daemon, but it cannot forward another request to it without reconciliation.
+- Authentication is temporarily unavailable while a credential revision or spec generation is not yet acknowledged by the controller.
+- Daemon configuration changes are applied lazily on each replica's next auth request.
+- Model provider daemons remain outside this coordination protocol.
+
+## References
+
+- [`pkg/authprovider/configuration.go`](../pkg/authprovider/configuration.go)
+- [`pkg/controller/handlers/provider/provider.go`](../pkg/controller/handlers/provider/provider.go)
+- [`pkg/gateway/server/dispatcher/dispatcher.go`](../pkg/gateway/server/dispatcher/dispatcher.go)

--- a/adr/2026-08-26-acknowledge-auth-provider-daemon-configuration.md
+++ b/adr/2026-08-26-acknowledge-auth-provider-daemon-configuration.md
@@ -23,7 +23,7 @@ Credential storage and `AuthProvider` storage use separate persistence layers, a
 
 The leader-elected auth provider controller will calculate a SHA-256 hash over the provider UID, provider spec, and stored credential environment. It will publish that hash in internal `AuthProvider` status together with the credential mutation revision it observed.
 
-Credential mutations will assign an opaque UUID revision to the `AuthProvider`. The internal OAuth cookie secret will be generated only when missing and will be preserved across ordinary saves.
+Credential mutations will assign an opaque UUID revision to the `AuthProvider`. Every configuration save will generate a new internal OAuth cookie secret.
 
 Before forwarding an auth request, every replica will read the current `AuthProvider` and stored credential environment, then reconcile its process-local daemon under a provider-scoped lock. It will return a cached daemon only when its recorded hash matches both the hash computed from the current resource and credentials and the hash in acknowledged status. Unacknowledged revisions, generations, or configuration hashes fail closed, and shared state is revalidated after daemon startup.
 
@@ -31,7 +31,7 @@ Before forwarding an auth request, every replica will read the current `AuthProv
 
 Acknowledged shared status gives all replicas one authoritative configuration without adding a distributed daemon registry or an every-replica watch controller. Per-request resource and credential reads close both the stale-serving window and the cross-store partial-write window, at the cost of an additional credential query, decryption, and hash calculation. Provider-scoped locking prevents duplicate local launches without allowing a slow provider to block unrelated providers.
 
-Preserving the cookie secret also prevents unrelated saves from invalidating OAuth flows already in progress and reduces risk during mixed-version rollouts.
+Continuing to rotate the cookie secret on every configuration save preserves the existing security behavior. The acknowledged revision and configuration hash ensure that replicas reconcile their daemons to the newly generated secret before serving subsequent authentication requests.
 
 ## Consequences
 
@@ -39,6 +39,7 @@ Preserving the cookie secret also prevents unrelated saves from invalidating OAu
 - A replica can retain an idle stale daemon, but it cannot forward another request to it without reconciliation.
 - Authentication is temporarily unavailable while a credential revision or spec generation is not yet acknowledged by the controller.
 - Daemon configuration changes are applied lazily on each replica's next auth request.
+- Saving an auth provider configuration invalidates OAuth flows that are already in progress.
 - Model provider daemons remain outside this coordination protocol.
 
 ## References

--- a/adr/2026-08-26-acknowledge-auth-provider-daemon-configuration.md
+++ b/adr/2026-08-26-acknowledge-auth-provider-daemon-configuration.md
@@ -25,17 +25,17 @@ The leader-elected auth provider controller will calculate a SHA-256 hash over t
 
 Credential mutations will assign an opaque UUID revision to the `AuthProvider`. The internal OAuth cookie secret will be generated only when missing and will be preserved across ordinary saves.
 
-Before forwarding an auth request, every replica will read the current `AuthProvider` and reconcile its process-local daemon under a provider-scoped lock. It will return a cached daemon only when its recorded hash matches acknowledged status. Unacknowledged revisions, generations, or credential hashes fail closed. Credential values are read and hashed only when a daemon must start or be replaced, and shared state is revalidated after daemon startup.
+Before forwarding an auth request, every replica will read the current `AuthProvider` and stored credential environment, then reconcile its process-local daemon under a provider-scoped lock. It will return a cached daemon only when its recorded hash matches both the hash computed from the current resource and credentials and the hash in acknowledged status. Unacknowledged revisions, generations, or configuration hashes fail closed, and shared state is revalidated after daemon startup.
 
 ## Rationale
 
-Acknowledged shared status gives all replicas one authoritative configuration without adding a distributed daemon registry or an every-replica watch controller. Per-request resource reads close the stale-serving window, while hash comparison keeps secrets off the normal cached-daemon path. Provider-scoped locking prevents duplicate local launches without allowing a slow provider to block unrelated providers.
+Acknowledged shared status gives all replicas one authoritative configuration without adding a distributed daemon registry or an every-replica watch controller. Per-request resource and credential reads close both the stale-serving window and the cross-store partial-write window, at the cost of an additional credential query, decryption, and hash calculation. Provider-scoped locking prevents duplicate local launches without allowing a slow provider to block unrelated providers.
 
 Preserving the cookie secret also prevents unrelated saves from invalidating OAuth flows already in progress and reduces risk during mixed-version rollouts.
 
 ## Consequences
 
-- Auth provider URL resolution performs one current shared-storage read before using a local daemon.
+- Auth provider URL resolution reads the current shared resource and stored credential environment before using a local daemon.
 - A replica can retain an idle stale daemon, but it cannot forward another request to it without reconciliation.
 - Authentication is temporarily unavailable while a credential revision or spec generation is not yet acknowledged by the controller.
 - Daemon configuration changes are applied lazily on each replica's next auth request.

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/jsonschema-go v0.4.3
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/keygen-sh/keygen-go/v3 v3.3.0
@@ -190,7 +191,6 @@ require (
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect

--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -114,7 +113,8 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 		envVars = make(map[string]string, 1)
 	}
 
-	if err := preserveAuthProviderCookieSecret(req.Context(), req.GatewayClient, authProvider.Name, envVars); err != nil {
+	envVars[CookieSecretEnvVar], err = generateCookieSecret()
+	if err != nil {
 		return err
 	}
 
@@ -399,23 +399,6 @@ func generateCookieSecret() (string, error) {
 	}
 
 	return base64.StdEncoding.EncodeToString(b), nil
-}
-
-func preserveAuthProviderCookieSecret(ctx context.Context, gatewayClient *gateway.Client, authProviderName string, envVars map[string]string) error {
-	credential, err := gatewayClient.RevealCredential(ctx, []string{authProviderName, system.GenericAuthProviderCredentialContext}, authProviderName)
-	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
-		return fmt.Errorf("failed to reveal credential for auth provider %q: %w", authProviderName, err)
-	}
-
-	cookieSecret := credential.Secrets[CookieSecretEnvVar]
-	if cookieSecret == "" {
-		cookieSecret, err = generateCookieSecret()
-		if err != nil {
-			return err
-		}
-	}
-	envVars[CookieSecretEnvVar] = cookieSecret
-	return nil
 }
 
 func authProviderStatusAcknowledged(authProvider *v1.AuthProvider) bool {

--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -269,7 +269,7 @@ func (ap *AuthProviderHandler) Deconfigure(req api.Context) error {
 		}
 	}
 
-	if cleanup != nil {
+	if cleanup != nil && len(deconfigureErrors) == 0 {
 		if err := markAuthProviderCleanupReady(req, cleanup); err != nil {
 			deconfigureErrors = append(deconfigureErrors, err)
 		}
@@ -419,5 +419,6 @@ func preserveAuthProviderCookieSecret(ctx context.Context, gatewayClient *gatewa
 }
 
 func authProviderStatusAcknowledged(authProvider *v1.AuthProvider) bool {
-	return authProvider.Status.ObservedSyncRevision == authProvider.Annotations[v1.AuthProviderSyncAnnotation]
+	return authProvider.Status.ObservedGeneration == authProvider.Generation &&
+		authProvider.Status.ObservedSyncRevision == authProvider.Annotations[v1.AuthProviderSyncAnnotation]
 }

--- a/pkg/api/handlers/authprovider.go
+++ b/pkg/api/handlers/authprovider.go
@@ -2,12 +2,14 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/obot-platform/nah/pkg/name"
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
@@ -112,8 +114,7 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 		envVars = make(map[string]string, 1)
 	}
 
-	envVars[CookieSecretEnvVar], err = generateCookieSecret()
-	if err != nil {
+	if err := preserveAuthProviderCookieSecret(req.Context(), req.GatewayClient, authProvider.Name, envVars); err != nil {
 		return err
 	}
 
@@ -130,44 +131,35 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 	}); err != nil {
 		return fmt.Errorf("failed to create credential for auth provider %q: %w", authProvider.Name, err)
 	}
+	updatedAuthProvider, err := updateAuthProviderSyncRevision(req, authProvider.Name)
+	if err != nil {
+		return fmt.Errorf("publish credential update for auth provider %q: %w", authProvider.Name, err)
+	}
+	if updatedAuthProvider == nil {
+		return ap.rollbackAuthProviderConfiguration(req, authProvider, fmt.Errorf("auth provider %q was deleted while it was being configured", authProvider.Name))
+	}
+	authProvider = *updatedAuthProvider
 	if err := ensureNoPendingAuthProviderCleanup(req, authProvider); err != nil {
 		return ap.rollbackAuthProviderConfiguration(req, authProvider, err)
 	}
-
-	ap.dispatcher.StopAuthProvider(authProvider.Namespace, authProvider.Name)
 
 	// Check to make sure that only this provider is configured.
 	// Deconfigure it if that is not the case, and return a 400.
 	configuredProvider, err = ap.dispatcher.GetConfiguredAuthProvider(req.Context())
 	if err != nil {
-		return fmt.Errorf("failed to get configured auth provider: %w", err)
+		return ap.rollbackAuthProviderConfiguration(req, authProvider, fmt.Errorf("failed to get configured auth provider: %w", err))
 	}
 
 	if configuredProvider != "" && configuredProvider != authProvider.Name {
-		// Delete the credential we just configured
-		_, _ = req.GatewayClient.DeleteCredential(req.Context(), authProvider.Name, authProvider.Name)
-		return types.NewErrBadRequest(
+		return ap.rollbackAuthProviderConfiguration(req, authProvider, types.NewErrBadRequest(
 			"only one authentication provider can be configured at a time. Please deconfigure %q first",
 			configuredProvider,
-		)
-	}
-
-	if authProvider.Annotations[v1.AuthProviderSyncAnnotation] == "" {
-		if authProvider.Annotations == nil {
-			authProvider.Annotations = make(map[string]string, 1)
-		}
-		authProvider.Annotations[v1.AuthProviderSyncAnnotation] = "true"
-	} else {
-		delete(authProvider.Annotations, v1.AuthProviderSyncAnnotation)
-	}
-
-	if err := req.Update(&authProvider); err != nil {
-		return fmt.Errorf("failed to update auth provider: %w", err)
+		))
 	}
 
 	// Wait for the controllers to process to ensure the API will return correct configuration status.
 	if _, err := wait.For(req.Context(), req.Storage, &authProvider, func(a *v1.AuthProvider) (bool, error) {
-		return a.Status.ObservedGeneration == a.Generation, nil
+		return authProviderStatusAcknowledged(a), nil
 	}, wait.Option{
 		Timeout: 10 * time.Second,
 	}); err != nil {
@@ -181,11 +173,11 @@ func (ap *AuthProviderHandler) Configure(req api.Context) error {
 }
 
 func (ap *AuthProviderHandler) rollbackAuthProviderConfiguration(req api.Context, authProvider v1.AuthProvider, cause error) error {
-	ap.dispatcher.StopAuthProvider(authProvider.Namespace, authProvider.Name)
 	if _, err := req.GatewayClient.DeleteCredential(req.Context(), authProvider.Name, authProvider.Name); err != nil {
 		return errors.Join(cause, fmt.Errorf("roll back credential for auth provider %q: %w", authProvider.Name, err))
 	}
-	return cause
+	_, err := updateAuthProviderSyncRevision(req, authProvider.Name)
+	return errors.Join(cause, err)
 }
 
 func ensureNoPendingAuthProviderCleanup(req api.Context, authProvider v1.AuthProvider) error {
@@ -216,9 +208,6 @@ func (ap *AuthProviderHandler) Deconfigure(req api.Context) error {
 		if err != nil {
 			return err
 		}
-		if cleanup.Spec.Ready {
-			return nil
-		}
 	}
 
 	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{authProvider.Name, system.GenericAuthProviderCredentialContext}, authProvider.Name)
@@ -230,14 +219,17 @@ func (ap *AuthProviderHandler) Deconfigure(req api.Context) error {
 		return fmt.Errorf("failed to remove existing credential: %w", err)
 	}
 
-	// Stop the auth provider so that the credential is completely removed from the system.
-	ap.dispatcher.StopAuthProvider(authProvider.Namespace, authProvider.Name)
+	updatedAuthProvider, syncErr := updateAuthProviderSyncRevision(req, authProvider.Name)
+	var deconfigureErrors []error
+	if syncErr != nil {
+		deconfigureErrors = append(deconfigureErrors, syncErr)
+	}
 
 	// The local auth provider keeps its sessions in Obot's database rather than in the sessions
 	// table the block below drops, so clear them out here.
 	if authProvider.Name == localauth.ProviderName {
 		if err := req.GatewayClient.DeleteAllLocalAuthSessions(req.Context()); err != nil {
-			return fmt.Errorf("failed to delete local auth sessions: %w", err)
+			deconfigureErrors = append(deconfigureErrors, fmt.Errorf("failed to delete local auth sessions: %w", err))
 		}
 	}
 
@@ -247,47 +239,43 @@ func (ap *AuthProviderHandler) Deconfigure(req api.Context) error {
 			Logger: logger.Default.LogMode(logger.Silent),
 		})
 		if err != nil {
-			return fmt.Errorf("failed to connect to postgres: %w", err)
-		}
-		sqlDB, err := db.DB()
-		if err != nil {
-			return fmt.Errorf("failed to get underlying sql.DB: %w", err)
-		}
-		defer sqlDB.Close()
-
-		if tablePrefix := authProvider.Spec.PostgresTablePrefix; tablePrefix != "" {
-			if err := db.Exec("DROP TABLE IF EXISTS " + tablePrefix + "sessions;").Error; err != nil {
-				return fmt.Errorf("failed to drop sessions table: %w", err)
+			deconfigureErrors = append(deconfigureErrors, fmt.Errorf("failed to connect to postgres: %w", err))
+		} else {
+			sqlDB, dbErr := db.DB()
+			if dbErr != nil {
+				deconfigureErrors = append(deconfigureErrors, fmt.Errorf("failed to get underlying sql.DB: %w", dbErr))
+			} else {
+				defer sqlDB.Close()
+				if tablePrefix := authProvider.Spec.PostgresTablePrefix; tablePrefix != "" {
+					if err := db.Exec("DROP TABLE IF EXISTS " + tablePrefix + "sessions;").Error; err != nil {
+						deconfigureErrors = append(deconfigureErrors, fmt.Errorf("failed to drop sessions table: %w", err))
+					}
+					if err := db.Exec("DROP TABLE IF EXISTS " + tablePrefix + "session_locks;").Error; err != nil {
+						deconfigureErrors = append(deconfigureErrors, fmt.Errorf("failed to drop session_locks table: %w", err))
+					}
+				}
 			}
-			if err := db.Exec("DROP TABLE IF EXISTS " + tablePrefix + "session_locks;").Error; err != nil {
-				return fmt.Errorf("failed to drop session_locks table: %w", err)
-			}
 		}
-	}
-
-	updatedAuthProvider, err := updateAuthProviderForDeconfiguration(req, authProvider.Name)
-	if err != nil {
-		return err
 	}
 
 	// Wait for the controllers to process to ensure the API will return correct configuration status.
 	if updatedAuthProvider != nil {
 		if _, err := wait.For(req.Context(), req.Storage, updatedAuthProvider, func(a *v1.AuthProvider) (bool, error) {
-			return a.Status.ObservedGeneration == a.Generation, nil
+			return authProviderStatusAcknowledged(a), nil
 		}, wait.Option{
 			Timeout: 10 * time.Second,
 		}); err != nil {
-			return fmt.Errorf("failed to wait for auth provider: %w", err)
+			deconfigureErrors = append(deconfigureErrors, fmt.Errorf("failed to wait for auth provider: %w", err))
 		}
 	}
 
 	if cleanup != nil {
 		if err := markAuthProviderCleanupReady(req, cleanup); err != nil {
-			return err
+			deconfigureErrors = append(deconfigureErrors, err)
 		}
 	}
 
-	return nil
+	return errors.Join(deconfigureErrors...)
 }
 
 func authProviderCleanupName(authProviderName string) string {
@@ -323,20 +311,24 @@ func ensureAuthProviderCleanup(req api.Context, authProvider v1.AuthProvider) (*
 	return cleanup, nil
 }
 
-func updateAuthProviderForDeconfiguration(req api.Context, authProviderName string) (*v1.AuthProvider, error) {
+func updateAuthProviderSyncRevision(req api.Context, authProviderName string) (*v1.AuthProvider, error) {
 	var authProvider v1.AuthProvider
+	revision := uuid.New().String()
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := req.Get(&authProvider, authProviderName); err != nil {
 			return err
 		}
-		toggleAuthProviderSyncAnnotation(&authProvider)
+		if authProvider.Annotations == nil {
+			authProvider.Annotations = make(map[string]string, 1)
+		}
+		authProvider.Annotations[v1.AuthProviderSyncAnnotation] = revision
 		return req.Update(&authProvider)
 	})
 	if apierrors.IsNotFound(err) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("update auth provider for deconfiguration: %w", err)
+		return nil, fmt.Errorf("update auth provider sync revision: %w", err)
 	}
 	return &authProvider, nil
 }
@@ -362,17 +354,6 @@ func markAuthProviderCleanupReady(req api.Context, cleanup *v1.AuthProviderClean
 		return fmt.Errorf("mark auth provider cleanup %q ready: %w", cleanup.Name, err)
 	}
 	return nil
-}
-
-func toggleAuthProviderSyncAnnotation(authProvider *v1.AuthProvider) {
-	if authProvider.Annotations[v1.AuthProviderSyncAnnotation] == "" {
-		if authProvider.Annotations == nil {
-			authProvider.Annotations = make(map[string]string, 1)
-		}
-		authProvider.Annotations[v1.AuthProviderSyncAnnotation] = "true"
-	} else {
-		delete(authProvider.Annotations, v1.AuthProviderSyncAnnotation)
-	}
 }
 
 func (ap *AuthProviderHandler) Reveal(req api.Context) error {
@@ -418,4 +399,25 @@ func generateCookieSecret() (string, error) {
 	}
 
 	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+func preserveAuthProviderCookieSecret(ctx context.Context, gatewayClient *gateway.Client, authProviderName string, envVars map[string]string) error {
+	credential, err := gatewayClient.RevealCredential(ctx, []string{authProviderName, system.GenericAuthProviderCredentialContext}, authProviderName)
+	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
+		return fmt.Errorf("failed to reveal credential for auth provider %q: %w", authProviderName, err)
+	}
+
+	cookieSecret := credential.Secrets[CookieSecretEnvVar]
+	if cookieSecret == "" {
+		cookieSecret, err = generateCookieSecret()
+		if err != nil {
+			return err
+		}
+	}
+	envVars[CookieSecretEnvVar] = cookieSecret
+	return nil
+}
+
+func authProviderStatusAcknowledged(authProvider *v1.AuthProvider) bool {
+	return authProvider.Status.ObservedSyncRevision == authProvider.Annotations[v1.AuthProviderSyncAnnotation]
 }

--- a/pkg/api/handlers/authprovider_test.go
+++ b/pkg/api/handlers/authprovider_test.go
@@ -285,6 +285,11 @@ func TestDeconfigureReturnsRevisionPublicationFailureAfterCredentialDeletion(t *
 	authProvider := &v1.AuthProvider{
 		Name:      authProviderName,
 		Namespace: system.DefaultNamespace,
+		Spec: v1.AuthProviderSpec{
+			AuthProviderManifest: clienttypes.AuthProviderManifest{
+				GroupIDPrefix: "entra/",
+			},
+		},
 	}
 	storage := &failAuthProviderUpdateStorage{
 		WithWatch: newFakeStorage(t, authProvider),
@@ -307,4 +312,25 @@ func TestDeconfigureReturnsRevisionPublicationFailureAfterCredentialDeletion(t *
 	require.ErrorContains(t, err, "update auth provider sync revision")
 	_, revealErr := gatewayClient.RevealCredential(t.Context(), []string{authProviderName}, authProviderName)
 	require.Error(t, revealErr)
+
+	var cleanup v1.AuthProviderCleanup
+	require.NoError(t, req.Get(&cleanup, authProviderCleanupName(authProviderName)))
+	require.False(t, cleanup.Spec.Ready)
+}
+
+func TestAuthProviderStatusAcknowledgedRequiresObservedGeneration(t *testing.T) {
+	authProvider := &v1.AuthProvider{
+		Generation: 2,
+		Annotations: map[string]string{
+			v1.AuthProviderSyncAnnotation: "revision-one",
+		},
+		Status: v1.AuthProviderStatus{
+			ObservedGeneration:   1,
+			ObservedSyncRevision: "revision-one",
+		},
+	}
+
+	require.False(t, authProviderStatusAcknowledged(authProvider))
+	authProvider.Status.ObservedGeneration = authProvider.Generation
+	require.True(t, authProviderStatusAcknowledged(authProvider))
 }

--- a/pkg/api/handlers/authprovider_test.go
+++ b/pkg/api/handlers/authprovider_test.go
@@ -160,41 +160,6 @@ func TestDeconfigurePersistsCleanupIntentBeforeSideEffects(t *testing.T) {
 	require.ErrorContains(t, err, "persist cleanup intent")
 }
 
-func TestPreserveAuthProviderCookieSecret(t *testing.T) {
-	gatewayClient := newHandlerTestGateway(t)
-	const authProviderName = "entra-auth-provider"
-
-	firstEnvironment := map[string]string{
-		CookieSecretEnvVar: "user-supplied-value",
-	}
-	require.NoError(t, preserveAuthProviderCookieSecret(t.Context(), gatewayClient, authProviderName, firstEnvironment))
-	firstSecret := firstEnvironment[CookieSecretEnvVar]
-	require.NotEmpty(t, firstSecret)
-	require.NotEqual(t, "user-supplied-value", firstSecret)
-
-	require.NoError(t, gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
-		Context: authProviderName,
-		Name:    authProviderName,
-		Secrets: map[string]string{
-			CookieSecretEnvVar: firstSecret,
-			"CLIENT_SECRET":    "client-secret",
-		},
-	}))
-
-	secondEnvironment := map[string]string{
-		CookieSecretEnvVar: "replacement-value",
-	}
-	require.NoError(t, preserveAuthProviderCookieSecret(t.Context(), gatewayClient, authProviderName, secondEnvironment))
-	require.Equal(t, firstSecret, secondEnvironment[CookieSecretEnvVar])
-
-	_, err := gatewayClient.DeleteCredential(t.Context(), authProviderName, authProviderName)
-	require.NoError(t, err)
-	thirdEnvironment := map[string]string{}
-	require.NoError(t, preserveAuthProviderCookieSecret(t.Context(), gatewayClient, authProviderName, thirdEnvironment))
-	require.NotEmpty(t, thirdEnvironment[CookieSecretEnvVar])
-	require.NotEqual(t, firstSecret, thirdEnvironment[CookieSecretEnvVar])
-}
-
 func TestUpdateAuthProviderSyncRevisionUsesUniqueUUIDs(t *testing.T) {
 	authProvider := &v1.AuthProvider{
 		Name:      "entra-auth-provider",

--- a/pkg/api/handlers/authprovider_test.go
+++ b/pkg/api/handlers/authprovider_test.go
@@ -7,8 +7,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/uuid"
 	clienttypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/require"
@@ -19,11 +21,30 @@ type failAuthProviderCleanupCreateStorage struct {
 	kclient.WithWatch
 }
 
+type acknowledgeAuthProviderRevisionStorage struct {
+	kclient.WithWatch
+}
+
+type failAuthProviderUpdateStorage struct {
+	kclient.WithWatch
+}
+
 func (f *failAuthProviderCleanupCreateStorage) Create(ctx context.Context, obj kclient.Object, opts ...kclient.CreateOption) error {
 	if _, ok := obj.(*v1.AuthProviderCleanup); ok {
 		return errors.New("injected cleanup create failure")
 	}
 	return f.WithWatch.Create(ctx, obj, opts...)
+}
+
+func (a *acknowledgeAuthProviderRevisionStorage) Update(ctx context.Context, obj kclient.Object, opts ...kclient.UpdateOption) error {
+	if authProvider, ok := obj.(*v1.AuthProvider); ok {
+		authProvider.Status.ObservedSyncRevision = authProvider.Annotations[v1.AuthProviderSyncAnnotation]
+	}
+	return a.WithWatch.Update(ctx, obj, opts...)
+}
+
+func (f *failAuthProviderUpdateStorage) Update(context.Context, kclient.Object, ...kclient.UpdateOption) error {
+	return errors.New("injected auth provider update failure")
 }
 
 func TestEnsureNoPendingAuthProviderCleanup(t *testing.T) {
@@ -137,4 +158,153 @@ func TestDeconfigurePersistsCleanupIntentBeforeSideEffects(t *testing.T) {
 
 	err := (&AuthProviderHandler{}).Deconfigure(req)
 	require.ErrorContains(t, err, "persist cleanup intent")
+}
+
+func TestPreserveAuthProviderCookieSecret(t *testing.T) {
+	gatewayClient := newHandlerTestGateway(t)
+	const authProviderName = "entra-auth-provider"
+
+	firstEnvironment := map[string]string{
+		CookieSecretEnvVar: "user-supplied-value",
+	}
+	require.NoError(t, preserveAuthProviderCookieSecret(t.Context(), gatewayClient, authProviderName, firstEnvironment))
+	firstSecret := firstEnvironment[CookieSecretEnvVar]
+	require.NotEmpty(t, firstSecret)
+	require.NotEqual(t, "user-supplied-value", firstSecret)
+
+	require.NoError(t, gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+		Context: authProviderName,
+		Name:    authProviderName,
+		Secrets: map[string]string{
+			CookieSecretEnvVar: firstSecret,
+			"CLIENT_SECRET":    "client-secret",
+		},
+	}))
+
+	secondEnvironment := map[string]string{
+		CookieSecretEnvVar: "replacement-value",
+	}
+	require.NoError(t, preserveAuthProviderCookieSecret(t.Context(), gatewayClient, authProviderName, secondEnvironment))
+	require.Equal(t, firstSecret, secondEnvironment[CookieSecretEnvVar])
+
+	_, err := gatewayClient.DeleteCredential(t.Context(), authProviderName, authProviderName)
+	require.NoError(t, err)
+	thirdEnvironment := map[string]string{}
+	require.NoError(t, preserveAuthProviderCookieSecret(t.Context(), gatewayClient, authProviderName, thirdEnvironment))
+	require.NotEmpty(t, thirdEnvironment[CookieSecretEnvVar])
+	require.NotEqual(t, firstSecret, thirdEnvironment[CookieSecretEnvVar])
+}
+
+func TestUpdateAuthProviderSyncRevisionUsesUniqueUUIDs(t *testing.T) {
+	authProvider := &v1.AuthProvider{
+		Name:      "entra-auth-provider",
+		Namespace: system.DefaultNamespace,
+	}
+	req := api.Context{
+		Request: httptest.NewRequest(http.MethodPost, "/api/auth-providers/entra-auth-provider/configure", nil),
+		Storage: newFakeStorage(t, authProvider),
+	}
+
+	first, err := updateAuthProviderSyncRevision(req, authProvider.Name)
+	require.NoError(t, err)
+	firstRevision := first.Annotations[v1.AuthProviderSyncAnnotation]
+	_, err = uuid.Parse(firstRevision)
+	require.NoError(t, err)
+
+	second, err := updateAuthProviderSyncRevision(req, authProvider.Name)
+	require.NoError(t, err)
+	secondRevision := second.Annotations[v1.AuthProviderSyncAnnotation]
+	_, err = uuid.Parse(secondRevision)
+	require.NoError(t, err)
+	require.NotEqual(t, firstRevision, secondRevision)
+}
+
+func TestRollbackAuthProviderConfigurationPublishesRevision(t *testing.T) {
+	const authProviderName = "entra-auth-provider"
+	authProvider := &v1.AuthProvider{
+		Name:      authProviderName,
+		Namespace: system.DefaultNamespace,
+	}
+	gatewayClient := newHandlerTestGateway(t)
+	require.NoError(t, gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+		Context: authProviderName,
+		Name:    authProviderName,
+		Secrets: map[string]string{"CLIENT_SECRET": "client-secret"},
+	}))
+	req := api.Context{
+		Request:       httptest.NewRequest(http.MethodPost, "/api/auth-providers/entra-auth-provider/configure", nil),
+		Storage:       newFakeStorage(t, authProvider),
+		GatewayClient: gatewayClient,
+	}
+
+	cause := errors.New("validation failed")
+	err := (&AuthProviderHandler{}).rollbackAuthProviderConfiguration(req, *authProvider, cause)
+	require.ErrorIs(t, err, cause)
+	_, revealErr := gatewayClient.RevealCredential(t.Context(), []string{authProviderName}, authProviderName)
+	require.Error(t, revealErr)
+
+	var updated v1.AuthProvider
+	require.NoError(t, req.Get(&updated, authProviderName))
+	require.NotEmpty(t, updated.Annotations[v1.AuthProviderSyncAnnotation])
+}
+
+func TestDeconfigurePublishesRevisionWhenCredentialIsAlreadyAbsent(t *testing.T) {
+	const authProviderName = "entra-auth-provider"
+	authProvider := &v1.AuthProvider{
+		Name:      authProviderName,
+		Namespace: system.DefaultNamespace,
+	}
+	storage := &acknowledgeAuthProviderRevisionStorage{
+		WithWatch: newFakeStorage(t, authProvider),
+	}
+	gatewayClient := newHandlerTestGateway(t)
+	request := httptest.NewRequest(http.MethodPost, "/api/auth-providers/entra-auth-provider/deconfigure", nil)
+	request.SetPathValue("id", authProviderName)
+	req := api.Context{
+		Request:       request,
+		Storage:       storage,
+		GatewayClient: gatewayClient,
+	}
+
+	require.NoError(t, (&AuthProviderHandler{}).Deconfigure(req))
+	var first v1.AuthProvider
+	require.NoError(t, req.Get(&first, authProviderName))
+	firstRevision := first.Annotations[v1.AuthProviderSyncAnnotation]
+	require.NotEmpty(t, firstRevision)
+
+	require.NoError(t, (&AuthProviderHandler{}).Deconfigure(req))
+	var second v1.AuthProvider
+	require.NoError(t, req.Get(&second, authProviderName))
+	secondRevision := second.Annotations[v1.AuthProviderSyncAnnotation]
+	require.NotEmpty(t, secondRevision)
+	require.NotEqual(t, firstRevision, secondRevision)
+}
+
+func TestDeconfigureReturnsRevisionPublicationFailureAfterCredentialDeletion(t *testing.T) {
+	const authProviderName = "entra-auth-provider"
+	authProvider := &v1.AuthProvider{
+		Name:      authProviderName,
+		Namespace: system.DefaultNamespace,
+	}
+	storage := &failAuthProviderUpdateStorage{
+		WithWatch: newFakeStorage(t, authProvider),
+	}
+	gatewayClient := newHandlerTestGateway(t)
+	require.NoError(t, gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+		Context: authProviderName,
+		Name:    authProviderName,
+		Secrets: map[string]string{"CLIENT_SECRET": "client-secret"},
+	}))
+	request := httptest.NewRequest(http.MethodPost, "/api/auth-providers/entra-auth-provider/deconfigure", nil)
+	request.SetPathValue("id", authProviderName)
+	req := api.Context{
+		Request:       request,
+		Storage:       storage,
+		GatewayClient: gatewayClient,
+	}
+
+	err := (&AuthProviderHandler{}).Deconfigure(req)
+	require.ErrorContains(t, err, "update auth provider sync revision")
+	_, revealErr := gatewayClient.RevealCredential(t.Context(), []string{authProviderName}, authProviderName)
+	require.Error(t, revealErr)
 }

--- a/pkg/authprovider/configuration.go
+++ b/pkg/authprovider/configuration.go
@@ -1,0 +1,37 @@
+package authprovider
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+)
+
+type daemonConfiguration struct {
+	UID                   string              `json:"uid"`
+	Spec                  v1.AuthProviderSpec `json:"spec"`
+	CredentialEnvironment map[string]string   `json:"credentialEnvironment"`
+}
+
+// DaemonConfigurationHash returns the canonical hash of all persisted inputs
+// that affect an auth provider daemon. Process-level environment is excluded
+// because changing it requires restarting Obot itself.
+func DaemonConfigurationHash(authProvider v1.AuthProvider, credentialEnvironment map[string]string) (string, error) {
+	if credentialEnvironment == nil {
+		credentialEnvironment = map[string]string{}
+	}
+
+	data, err := json.Marshal(daemonConfiguration{
+		UID:                   string(authProvider.UID),
+		Spec:                  authProvider.Spec,
+		CredentialEnvironment: credentialEnvironment,
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal auth provider daemon configuration: %w", err)
+	}
+
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:]), nil
+}

--- a/pkg/authprovider/configuration_test.go
+++ b/pkg/authprovider/configuration_test.go
@@ -1,0 +1,109 @@
+package authprovider
+
+import (
+	"testing"
+
+	clienttypes "github.com/obot-platform/obot/apiclient/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestDaemonConfigurationHash(t *testing.T) {
+	provider := v1.AuthProvider{
+		Name: "provider",
+		UID:  types.UID("uid-one"),
+		Spec: v1.AuthProviderSpec{
+			AuthProviderManifest: clienttypes.AuthProviderManifest{
+				CommonProviderMetadata: clienttypes.CommonProviderMetadata{
+					Command: "provider-command",
+					Args:    []string{"serve"},
+				},
+			},
+		},
+	}
+
+	base, err := DaemonConfigurationHash(provider, map[string]string{
+		"CLIENT_ID":     "client-id",
+		"CLIENT_SECRET": "client-secret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("map insertion order is stable", func(t *testing.T) {
+		got, err := DaemonConfigurationHash(provider, map[string]string{
+			"CLIENT_SECRET": "client-secret",
+			"CLIENT_ID":     "client-id",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != base {
+			t.Fatalf("hash = %q, want %q", got, base)
+		}
+	})
+
+	t.Run("status and unrelated metadata are excluded", func(t *testing.T) {
+		changed := *provider.DeepCopy()
+		changed.ResourceVersion = "new-version"
+		changed.Generation = 42
+		changed.Annotations = map[string]string{"unrelated": "value"}
+		changed.Status.Configured = true
+
+		got, err := DaemonConfigurationHash(changed, map[string]string{
+			"CLIENT_ID":     "client-id",
+			"CLIENT_SECRET": "client-secret",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != base {
+			t.Fatalf("hash = %q, want %q", got, base)
+		}
+	})
+
+	tests := []struct {
+		name       string
+		provider   v1.AuthProvider
+		credential map[string]string
+	}{
+		{
+			name:     "UID change",
+			provider: provider,
+			credential: map[string]string{
+				"CLIENT_ID":     "client-id",
+				"CLIENT_SECRET": "client-secret",
+			},
+		},
+		{
+			name:     "spec change",
+			provider: provider,
+			credential: map[string]string{
+				"CLIENT_ID":     "client-id",
+				"CLIENT_SECRET": "client-secret",
+			},
+		},
+		{
+			name:     "credential change",
+			provider: provider,
+			credential: map[string]string{
+				"CLIENT_ID":     "client-id",
+				"CLIENT_SECRET": "new-client-secret",
+			},
+		},
+	}
+	tests[0].provider.UID = types.UID("uid-two")
+	tests[1].provider.Spec.Args = []string{"serve", "--changed"}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DaemonConfigurationHash(tt.provider, tt.credential)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == base {
+				t.Fatalf("hash did not change from %q", base)
+			}
+		})
+	}
+}

--- a/pkg/controller/authprovider.go
+++ b/pkg/controller/authprovider.go
@@ -26,7 +26,9 @@ import (
 // transaction. This is not trivial, since the credential is outside of kinm and the
 // AuthProvider is inside.
 
-const authProviderReconciliationInterval = 30 * time.Second
+const (
+	authProviderReconciliationInterval = 30 * time.Second
+)
 
 func (c *Controller) runAuthProviderReconciliation(ctx context.Context, client kclient.Client) {
 	ticker := time.NewTicker(authProviderReconciliationInterval)

--- a/pkg/controller/authprovider.go
+++ b/pkg/controller/authprovider.go
@@ -1,0 +1,63 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/obot-platform/nah/pkg/backend"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// We need to reconcile the status fields on auth providers on a routine interval.
+// This is because the API route that handles auth provider reconfiguration could
+// successfully write the new credential to the database but then fail to add the sync
+// annotation to the AuthProvider kinm object, leaving the Status fields stale.
+// During the authentication process, the authenticator fetches the credential and
+// the AuthProvider object and makes sure that everything lines up before allowing
+// the user to authenticate. So it could be possible, due to an intermittent DB failure
+// at the worst time, for the AuthProvider Status fields to be stale and for
+// authentication to fail as a result.
+//
+// In the future, we could consider finding a way to wrap the reconciliation logic in a
+// transaction. This is not trivial, since the credential is outside of kinm and the
+// AuthProvider is inside.
+
+const authProviderReconciliationInterval = 30 * time.Second
+
+func (c *Controller) runAuthProviderReconciliation(ctx context.Context, client kclient.Client) {
+	ticker := time.NewTicker(authProviderReconciliationInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := reconcileAuthProviders(ctx, client, c.services.Router.Backend()); err != nil {
+				slog.Error("Failed to reconcile auth providers", "error", err)
+			}
+		}
+	}
+}
+
+func reconcileAuthProviders(ctx context.Context, client kclient.Client, trigger backend.Trigger) error {
+	var authProviders v1.AuthProviderList
+	if err := client.List(ctx, &authProviders); err != nil {
+		return fmt.Errorf("failed to list auth providers: %w", err)
+	}
+
+	var errs []error
+	for i := range authProviders.Items {
+		authProvider := &authProviders.Items[i]
+		key := kclient.ObjectKeyFromObject(authProvider).String()
+		if err := trigger.Trigger(ctx, v1.SchemeGroupVersion.WithKind("AuthProvider"), key, 0); err != nil {
+			errs = append(errs, fmt.Errorf("failed to trigger auth provider %q: %w", key, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/pkg/controller/authprovider_test.go
+++ b/pkg/controller/authprovider_test.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type authProviderTriggerCall struct {
+	gvk   schema.GroupVersionKind
+	key   string
+	delay time.Duration
+}
+
+type recordingAuthProviderTrigger struct {
+	calls       []authProviderTriggerCall
+	errorsByKey map[string]error
+}
+
+func (r *recordingAuthProviderTrigger) Trigger(_ context.Context, gvk schema.GroupVersionKind, key string, delay time.Duration) error {
+	r.calls = append(r.calls, authProviderTriggerCall{
+		gvk:   gvk,
+		key:   key,
+		delay: delay,
+	})
+	return r.errorsByKey[key]
+}
+
+func TestReconcileAuthProvidersTriggersEveryAuthProvider(t *testing.T) {
+	client := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(
+			&v1.AuthProvider{
+				Name:      "first",
+				Namespace: "default",
+			},
+			&v1.AuthProvider{
+				Name:      "second",
+				Namespace: "other",
+			},
+		).
+		Build()
+	trigger := &recordingAuthProviderTrigger{}
+
+	if err := reconcileAuthProviders(t.Context(), client, trigger); err != nil {
+		t.Fatalf("reconcileAuthProviders() error = %v", err)
+	}
+
+	if len(trigger.calls) != 2 {
+		t.Fatalf("trigger call count = %d, want 2", len(trigger.calls))
+	}
+	wantGVK := v1.SchemeGroupVersion.WithKind("AuthProvider")
+	wantKeys := map[string]bool{
+		"default/first": false,
+		"other/second":  false,
+	}
+	for _, call := range trigger.calls {
+		if call.gvk != wantGVK {
+			t.Errorf("trigger GVK = %v, want %v", call.gvk, wantGVK)
+		}
+		if call.delay != 0 {
+			t.Errorf("trigger delay = %v, want 0", call.delay)
+		}
+		if _, ok := wantKeys[call.key]; !ok {
+			t.Errorf("unexpected trigger key %q", call.key)
+		} else {
+			wantKeys[call.key] = true
+		}
+	}
+	for key, called := range wantKeys {
+		if !called {
+			t.Errorf("auth provider %q was not triggered", key)
+		}
+	}
+}
+
+func TestReconcileAuthProvidersContinuesAfterTriggerError(t *testing.T) {
+	client := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(
+			&v1.AuthProvider{
+				Name:      "first",
+				Namespace: "default",
+			},
+			&v1.AuthProvider{
+				Name:      "second",
+				Namespace: "default",
+			},
+		).
+		Build()
+	wantErr := errors.New("trigger failed")
+	trigger := &recordingAuthProviderTrigger{
+		errorsByKey: map[string]error{
+			"default/first": wantErr,
+		},
+	}
+
+	err := reconcileAuthProviders(t.Context(), client, trigger)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("reconcileAuthProviders() error = %v, want an error wrapping %v", err, wantErr)
+	}
+	if len(trigger.calls) != 2 {
+		t.Fatalf("trigger call count = %d, want 2", len(trigger.calls))
+	}
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -241,6 +241,7 @@ func (c *Controller) ensureObotMCPServer(ctx context.Context) error {
 
 func (c *Controller) PostStart(ctx context.Context, client kclient.Client) {
 	go c.providerHandler.PollRegistries(ctx, client)
+	go c.runAuthProviderReconciliation(ctx, client)
 	var err error
 	for range 3 {
 		err = c.providerHandler.EnsureOpenAIEnvCredentialAndDefaults(ctx, client)

--- a/pkg/controller/handlers/provider/provider.go
+++ b/pkg/controller/handlers/provider/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/api/handlers/providers"
 	"github.com/obot-platform/obot/pkg/auth"
+	authproviderconfig "github.com/obot-platform/obot/pkg/authprovider"
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/gateway/server/dispatcher"
 	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
@@ -409,33 +410,30 @@ func (h *Handler) SetAuthProviderConfiguredStatus(req router.Request, _ router.R
 }
 
 func SetAuthProviderConfiguredStatus(ctx context.Context, gatewayClient *gateway.Client, licenseProvider *license.Provider, authProvider *v1.AuthProvider) error {
-	var (
-		configured          = true
-		missingConfigParams []string
-	)
-	if len(authProvider.Spec.RequiredConfigurationParameters) > 0 {
-		cred, err := gatewayClient.RevealCredential(ctx, []string{authProvider.Name, system.GenericModelProviderCredentialContext}, authProvider.Name)
-		if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
-			return fmt.Errorf("failed to reveal credential for auth provider %q: %w", authProvider.Name, err)
-		}
-
-		if cred.Secrets == nil {
-			// Don't pass a nil map so that the provider status functions can distinguish between "no credential found" and "credential found but has no secrets"
-			cred.Secrets = make(map[string]string)
-		}
-
-		providerStatus, err := providers.AuthProviderStatus(ctx, *authProvider, cred.Secrets, licenseProvider)
-		if err != nil {
-			return err
-		}
-
-		configured = providerStatus.Configured
-		missingConfigParams = providerStatus.MissingConfigurationParameters
+	cred, err := gatewayClient.RevealCredential(ctx, []string{authProvider.Name, system.GenericAuthProviderCredentialContext}, authProvider.Name)
+	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
+		return fmt.Errorf("failed to reveal credential for auth provider %q: %w", authProvider.Name, err)
+	}
+	if cred.Secrets == nil {
+		// Don't pass a nil map so that the provider status functions can distinguish between "no credential found" and "credential found but has no secrets".
+		cred.Secrets = make(map[string]string)
 	}
 
-	authProvider.Status.MissingConfigurationParameters = missingConfigParams
-	authProvider.Status.Configured = configured
+	providerStatus, err := providers.AuthProviderStatus(ctx, *authProvider, cred.Secrets, licenseProvider)
+	if err != nil {
+		return err
+	}
+
+	configurationHash, err := authproviderconfig.DaemonConfigurationHash(*authProvider, cred.Secrets)
+	if err != nil {
+		return err
+	}
+
+	authProvider.Status.MissingConfigurationParameters = providerStatus.MissingConfigurationParameters
+	authProvider.Status.Configured = providerStatus.Configured
 	authProvider.Status.ObservedGeneration = authProvider.Generation
+	authProvider.Status.DaemonConfigurationHash = configurationHash
+	authProvider.Status.ObservedSyncRevision = authProvider.Annotations[v1.AuthProviderSyncAnnotation]
 
 	return nil
 }

--- a/pkg/controller/handlers/provider/provider_test.go
+++ b/pkg/controller/handlers/provider/provider_test.go
@@ -3,10 +3,20 @@ package provider
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/obot-platform/obot/apiclient/types"
+	authproviderconfig "github.com/obot-platform/obot/pkg/authprovider"
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/license"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storageservices "github.com/obot-platform/obot/pkg/storage/services"
+	"github.com/obot-platform/obot/pkg/system"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -244,4 +254,120 @@ func TestModelDialectPrefersMetadataDialect(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetAuthProviderConfiguredStatusAcknowledgesConfiguration(t *testing.T) {
+	gatewayClient := newProviderTestGatewayClient(t)
+	licenseProvider, err := license.NewProvider(t.Context(), nil, license.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authProvider := &v1.AuthProvider{
+		Name:       "entra-auth-provider",
+		Namespace:  system.DefaultNamespace,
+		UID:        k8stypes.UID("provider-uid"),
+		Generation: 3,
+		Annotations: map[string]string{
+			v1.AuthProviderSyncAnnotation: "revision-one",
+		},
+		Spec: v1.AuthProviderSpec{
+			AuthProviderManifest: types.AuthProviderManifest{
+				CommonProviderMetadata: types.CommonProviderMetadata{
+					Command: "provider-command",
+					RequiredConfigurationParameters: []types.ProviderConfigurationParameter{
+						{
+							Name: "CLIENT_SECRET",
+						},
+					},
+				},
+			},
+		},
+	}
+	credentialEnvironment := map[string]string{
+		"CLIENT_SECRET": "client-secret",
+	}
+	if err := gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+		Context: authProvider.Name,
+		Name:    authProvider.Name,
+		Secrets: credentialEnvironment,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SetAuthProviderConfiguredStatus(t.Context(), gatewayClient, licenseProvider, authProvider); err != nil {
+		t.Fatal(err)
+	}
+	wantHash, err := authproviderconfig.DaemonConfigurationHash(*authProvider, credentialEnvironment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authProvider.Status.Configured {
+		t.Fatal("auth provider was not configured")
+	}
+	if authProvider.Status.DaemonConfigurationHash != wantHash {
+		t.Fatalf("configuration hash = %q, want %q", authProvider.Status.DaemonConfigurationHash, wantHash)
+	}
+	if authProvider.Status.ObservedSyncRevision != "revision-one" {
+		t.Fatalf("observed sync revision = %q, want revision-one", authProvider.Status.ObservedSyncRevision)
+	}
+	if authProvider.Status.ObservedGeneration != authProvider.Generation {
+		t.Fatalf("observed generation = %d, want %d", authProvider.Status.ObservedGeneration, authProvider.Generation)
+	}
+
+	authProvider.Annotations[v1.AuthProviderSyncAnnotation] = "revision-two"
+	if err := SetAuthProviderConfiguredStatus(t.Context(), gatewayClient, licenseProvider, authProvider); err != nil {
+		t.Fatal(err)
+	}
+	if authProvider.Status.DaemonConfigurationHash != wantHash {
+		t.Fatalf("configuration hash changed to %q, want %q", authProvider.Status.DaemonConfigurationHash, wantHash)
+	}
+	if authProvider.Status.ObservedSyncRevision != "revision-two" {
+		t.Fatalf("observed sync revision = %q, want revision-two", authProvider.Status.ObservedSyncRevision)
+	}
+
+	unchangedStatus := *authProvider.Status.DeepCopy()
+	if err := SetAuthProviderConfiguredStatus(t.Context(), gatewayClient, licenseProvider, authProvider); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(authProvider.Status, unchangedStatus) {
+		t.Fatalf("unchanged reconciliation modified status: got %#v, want %#v", authProvider.Status, unchangedStatus)
+	}
+
+	if _, err := gatewayClient.DeleteCredential(t.Context(), authProvider.Name, authProvider.Name); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetAuthProviderConfiguredStatus(t.Context(), gatewayClient, licenseProvider, authProvider); err != nil {
+		t.Fatal(err)
+	}
+	if authProvider.Status.Configured {
+		t.Fatal("auth provider remained configured after credential deletion")
+	}
+	if len(authProvider.Status.MissingConfigurationParameters) != 1 || authProvider.Status.MissingConfigurationParameters[0] != "CLIENT_SECRET" {
+		t.Fatalf("missing configuration parameters = %#v, want CLIENT_SECRET", authProvider.Status.MissingConfigurationParameters)
+	}
+	if authProvider.Status.ObservedSyncRevision != "revision-two" {
+		t.Fatalf("observed sync revision = %q, want revision-two", authProvider.Status.ObservedSyncRevision)
+	}
+}
+
+func newProviderTestGatewayClient(t *testing.T) *gatewayclient.Client {
+	t.Helper()
+	storageServices, err := storageservices.New(storageservices.Config{DSN: "sqlite://:memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	database, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.AutoMigrate(); err != nil {
+		t.Fatal(err)
+	}
+	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, 0, false)
+	t.Cleanup(func() {
+		if err := gatewayClient.Close(); err != nil {
+			t.Errorf("close gateway client: %v", err)
+		}
+	})
+	return gatewayClient
 }

--- a/pkg/gateway/server/dispatcher/availablemodels.go
+++ b/pkg/gateway/server/dispatcher/availablemodels.go
@@ -12,7 +12,9 @@ import (
 )
 
 func (d *Dispatcher) ModelsForProvider(ctx context.Context, modelProvider v1.ModelProvider) (*openai.ModelsList, error) {
-	u, err := d.URLForModelProvider(ctx, modelProvider.Namespace, modelProvider.Name)
+	// The object can contain status updates from earlier handlers in the same reconciliation
+	// that have not been persisted yet.
+	u, err := d.urlForModelProviderObject(ctx, modelProvider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get URL for model provider %q: %w", modelProvider.Name, err)
 	}

--- a/pkg/gateway/server/dispatcher/availablemodels.go
+++ b/pkg/gateway/server/dispatcher/availablemodels.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (d *Dispatcher) ModelsForProvider(ctx context.Context, modelProvider v1.ModelProvider) (*openai.ModelsList, error) {
-	u, err := d.urlForModelProvider(ctx, providerKeyForModelProvider(modelProvider.Namespace, modelProvider.Name), modelProvider)
+	u, err := d.URLForModelProvider(ctx, modelProvider.Namespace, modelProvider.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get URL for model provider %q: %w", modelProvider.Name, err)
 	}

--- a/pkg/gateway/server/dispatcher/daemon.go
+++ b/pkg/gateway/server/dispatcher/daemon.go
@@ -22,9 +22,8 @@ import (
 )
 
 type ports struct {
-	daemonPorts    map[string]int64
-	daemonsRunning map[string]func()
-	daemonLock     sync.RWMutex
+	daemons    map[string]daemonState
+	daemonLock sync.RWMutex
 
 	startPort, endPort int64
 	usedPorts          map[int64]struct{}
@@ -33,13 +32,19 @@ type ports struct {
 	daemonWG           sync.WaitGroup
 }
 
+type daemonState struct {
+	port              int64
+	stop              func()
+	command           *exec.Cmd
+	configurationHash string
+}
+
 func newPorts() *ports {
 	daemonCtx, cancel := context.WithCancel(context.Background())
 	p := &ports{
-		daemonCtx:      daemonCtx,
-		daemonPorts:    map[string]int64{},
-		daemonsRunning: map[string]func(){},
-		usedPorts:      map[int64]struct{}{},
+		daemonCtx: daemonCtx,
+		daemons:   map[string]daemonState{},
+		usedPorts: map[int64]struct{}{},
 	}
 	p.daemonClose = func() {
 		cancel()
@@ -56,15 +61,38 @@ func (d *Dispatcher) closeDaemons() {
 
 func (d *Dispatcher) stopDaemon(id string) {
 	d.ports.daemonLock.Lock()
-	defer d.ports.daemonLock.Unlock()
-
-	if stop := d.ports.daemonsRunning[id]; stop != nil {
-		stop()
+	state, ok := d.ports.daemons[id]
+	if ok {
+		delete(d.ports.daemons, id)
 	}
+	d.ports.daemonLock.Unlock()
 
-	delete(d.ports.daemonsRunning, id)
-	delete(d.ports.usedPorts, d.ports.daemonPorts[id])
-	delete(d.ports.daemonPorts, id)
+	if ok {
+		state.stop()
+	}
+}
+
+func (d *Dispatcher) stopDaemonCommand(id string, command *exec.Cmd) {
+	d.ports.daemonLock.Lock()
+	state, ok := d.ports.daemons[id]
+	if ok && state.command == command {
+		delete(d.ports.daemons, id)
+	} else {
+		ok = false
+	}
+	d.ports.daemonLock.Unlock()
+
+	if ok {
+		state.stop()
+	}
+}
+
+func (d *Dispatcher) daemonState(id string) (daemonState, bool) {
+	d.ports.daemonLock.RLock()
+	defer d.ports.daemonLock.RUnlock()
+
+	state, ok := d.ports.daemons[id]
+	return state, ok
 }
 
 func (d *Dispatcher) nextPort() int64 {
@@ -94,29 +122,12 @@ func (d *Dispatcher) nextPort() int64 {
 	panic("Ran out of usable ports")
 }
 
-func (d *Dispatcher) startDaemon(env map[string]string, id, command string, args ...string) (url.URL, error) {
-	d.ports.daemonLock.RLock()
-	port, portExists := d.ports.daemonPorts[id]
-	_, isRunning := d.ports.daemonsRunning[id]
-	d.ports.daemonLock.RUnlock()
-
-	u := url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}
-	if portExists && isRunning {
-		return u, nil
-	}
-
+func (d *Dispatcher) startDaemon(env map[string]string, id, configurationHash, command string, args ...string) (url.URL, *exec.Cmd, error) {
 	d.ports.daemonLock.Lock()
-	defer d.ports.daemonLock.Unlock()
-
-	port, portExists = d.ports.daemonPorts[id]
-	_, isRunning = d.ports.daemonsRunning[id]
-	if portExists && isRunning {
-		return url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}, nil
-	}
-
 	ctx := d.ports.daemonCtx
-	port = d.nextPort()
-	u.Host = fmt.Sprintf("127.0.0.1:%d", port)
+	port := d.nextPort()
+	d.ports.daemonLock.Unlock()
+	u := url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}
 
 	if env == nil {
 		env = make(map[string]string, 3)
@@ -124,18 +135,29 @@ func (d *Dispatcher) startDaemon(env map[string]string, id, command string, args
 	env["PORT"] = fmt.Sprintf("%d", port)
 	cmd, stop, err := d.newCommand(ctx, env, command, args...)
 	if err != nil {
-		return u, err
+		d.ports.daemonLock.Lock()
+		delete(d.ports.usedPorts, port)
+		d.ports.daemonLock.Unlock()
+		return u, nil, err
 	}
 
 	slog.Info("Launched provider daemon", "command", command, "args", cmd.Args, "port", port)
 	if err := cmd.Start(); err != nil {
 		stop()
+		d.ports.daemonLock.Lock()
 		delete(d.ports.usedPorts, port)
-		return u, err
+		d.ports.daemonLock.Unlock()
+		return u, nil, err
 	}
 
-	d.ports.daemonPorts[id] = port
-	d.ports.daemonsRunning[id] = stop
+	d.ports.daemonLock.Lock()
+	d.ports.daemons[id] = daemonState{
+		port:              port,
+		stop:              stop,
+		command:           cmd,
+		configurationHash: configurationHash,
+	}
+	d.ports.daemonLock.Unlock()
 
 	killedCtx, killedCancel := context.WithCancelCause(ctx)
 	defer killedCancel(nil)
@@ -153,8 +175,9 @@ func (d *Dispatcher) startDaemon(env map[string]string, id, command string, args
 		defer d.ports.daemonLock.Unlock()
 
 		delete(d.ports.usedPorts, port)
-		delete(d.ports.daemonPorts, id)
-		delete(d.ports.daemonsRunning, id)
+		if state, ok := d.ports.daemons[id]; ok && state.command == cmd {
+			delete(d.ports.daemons, id)
+		}
 	})
 
 	client := &http.Client{Timeout: 2 * time.Second}
@@ -168,17 +191,19 @@ func (d *Dispatcher) startDaemon(env map[string]string, id, command string, args
 			}(resp.Body)
 
 			if resp.StatusCode == http.StatusOK {
-				return u, nil
+				return u, cmd, nil
 			}
 		}
 		select {
 		case <-killedCtx.Done():
-			return u, fmt.Errorf("daemon failed to start: %w", context.Cause(killedCtx))
+			d.stopDaemonCommand(id, cmd)
+			return u, nil, fmt.Errorf("daemon failed to start: %w", context.Cause(killedCtx))
 		case <-time.After(time.Second):
 		}
 	}
 
-	return u, fmt.Errorf("timeout waiting for 200 response from GET %s", u.String())
+	d.stopDaemonCommand(id, cmd)
+	return u, nil, fmt.Errorf("timeout waiting for 200 response from GET %s", u.String())
 }
 
 func (d *Dispatcher) runCommand(ctx context.Context, envMap map[string]string, command string, args ...string) error {
@@ -221,7 +246,11 @@ func (d *Dispatcher) newCommand(ctx context.Context, envMap map[string]string, c
 		envMap = make(map[string]string, 2)
 	}
 	envMap["OBOT_SERVER_PUBLIC_URL"] = d.serverURL
-	envMap["OBOT_SERVER_URL"] = d.sessionManager.TransformObotHostname(d.internalServerURL)
+	internalServerURL := d.internalServerURL
+	if d.sessionManager != nil {
+		internalServerURL = d.sessionManager.TransformObotHostname(internalServerURL)
+	}
+	envMap["OBOT_SERVER_URL"] = internalServerURL
 	cmd.Env = envAsSlice(envMap)
 
 	r, w, err := os.Pipe()

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"net/url"
 	"os"
@@ -111,7 +112,7 @@ func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProv
 
 		if !authProviderConfigurationAcknowledged(authProvider) {
 			// This happens when the auth provider's configuration has changed but the controller has not processed it yet.
-			d.stopDaemon(key)
+			d.stopStaleAuthProviderDaemon(key, namespace, authProviderName)
 			return url.URL{}, authProviderConfigurationUpdatingError(authProviderName)
 		}
 		if !authProvider.Status.Configured || len(authProvider.Status.MissingConfigurationParameters) > 0 {
@@ -133,7 +134,7 @@ func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProv
 			return url.URL{}, err
 		}
 		if configurationHash != authProvider.Status.DaemonConfigurationHash {
-			d.stopDaemon(key)
+			d.stopStaleAuthProviderDaemon(key, namespace, authProviderName)
 			return url.URL{}, authProviderConfigurationUpdatingError(authProviderName)
 		}
 		if state, ok := d.daemonState(key); ok && state.configurationHash == configurationHash {
@@ -144,7 +145,7 @@ func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProv
 		maps.Copy(daemonEnvironment, d.authProviderExtraEnv)
 		daemonEnvironment["LOG_LEVEL"] = providerLogLevel()
 
-		d.stopDaemon(key)
+		d.stopStaleAuthProviderDaemon(key, namespace, authProviderName)
 		u, command, err := d.startDaemon(daemonEnvironment, key, configurationHash, authProvider.Spec.Command, authProvider.Spec.Args...)
 		if err != nil {
 			return url.URL{}, err
@@ -162,8 +163,17 @@ func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProv
 			return url.URL{}, fmt.Errorf("provider %q daemon exited during startup", authProviderName)
 		}
 
-		d.stopDaemonCommand(key, command)
+		d.stopStaleAuthProviderDaemon(key, namespace, authProviderName)
 	}
+}
+
+func (d *Dispatcher) stopStaleAuthProviderDaemon(key, namespace, authProviderName string) {
+	if _, ok := d.daemonState(key); !ok {
+		return
+	}
+
+	slog.Info("Restarting auth provider daemon due to configuration change", "namespace", namespace, "authProvider", authProviderName)
+	d.stopDaemon(key)
 }
 
 func authProviderConfigurationAcknowledged(authProvider v1.AuthProvider) bool {

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -245,6 +245,18 @@ func (d *Dispatcher) URLForModelProvider(ctx context.Context, namespace, modelPr
 	return d.urlForModelProvider(ctx, key, modelProvider)
 }
 
+func (d *Dispatcher) urlForModelProviderObject(ctx context.Context, modelProvider v1.ModelProvider) (url.URL, error) {
+	key := providerKeyForModelProvider(modelProvider.Namespace, modelProvider.Name)
+	unlock := d.providerLocks.Lock(key)
+	defer unlock()
+
+	if state, ok := d.daemonState(key); ok {
+		return daemonURL(state.port), nil
+	}
+
+	return d.urlForModelProvider(ctx, key, modelProvider)
+}
+
 func (d *Dispatcher) ValidateModelProvider(ctx context.Context, namespace, modelProviderName string, env map[string]string) error {
 	var modelProvider v1.ModelProvider
 	if err := d.client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: modelProviderName}, &modelProvider); err != nil {

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/obot-platform/obot/logger"
+	authproviderconfig "github.com/obot-platform/obot/pkg/authprovider"
 	"github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/license"
 	"github.com/obot-platform/obot/pkg/mcp"
@@ -36,6 +37,7 @@ type Dispatcher struct {
 	internalServerURL    string
 	authProviderExtraEnv map[string]string
 	ports                *ports
+	providerLocks        *keyedMutex
 
 	builtinLock         sync.RWMutex
 	builtinAuthProvider map[string]url.URL
@@ -50,6 +52,7 @@ func New(sessionManager *mcp.SessionManager, c kclient.Client, gatewayClient *cl
 		serverURL:           serverURL,
 		internalServerURL:   internalServerURL,
 		ports:               newPorts(),
+		providerLocks:       newKeyedMutex(),
 		builtinAuthProvider: map[string]url.URL{},
 	}
 
@@ -93,37 +96,128 @@ func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProv
 		return u, nil
 	}
 
-	d.ports.daemonLock.RLock()
-	if port := d.ports.daemonPorts[key]; port != 0 {
-		d.ports.daemonLock.RUnlock()
-		return url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}, nil
-	}
-	d.ports.daemonLock.RUnlock()
+	unlock := d.providerLocks.Lock(key)
+	defer unlock()
 
-	var authProvider v1.AuthProvider
-	if err := d.client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: authProviderName}, &authProvider); err != nil {
-		return url.URL{}, fmt.Errorf("failed to get provider: %w", err)
-	}
-
-	if len(authProvider.Status.MissingConfigurationParameters) > 0 {
-		return url.URL{}, fmt.Errorf("provider %q is not configured, missing configuration parameters: %s", authProviderName, strings.Join(authProvider.Status.MissingConfigurationParameters, ", "))
-	}
-
-	credEnv := map[string]string{}
-	cred, err := d.gatewayClient.RevealCredential(ctx, []string{authProvider.Name, system.GenericAuthProviderCredentialContext}, authProvider.Name)
-	if err != nil {
-		if !errors.As(err, &client.CredentialNotFoundError{}) {
-			return url.URL{}, fmt.Errorf("failed to reveal provider credential: %w", err)
+	for {
+		if err := ctx.Err(); err != nil {
+			return url.URL{}, err
 		}
-	} else if cred.Secrets != nil {
-		credEnv = cred.Secrets
+
+		var authProvider v1.AuthProvider
+		if err := d.client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: authProviderName}, &authProvider); err != nil {
+			return url.URL{}, fmt.Errorf("failed to get provider: %w", err)
+		}
+
+		if !authProviderConfigurationAcknowledged(authProvider) {
+			// This happens when the auth provider's configuration has changed but the controller has not processed it yet.
+			d.stopDaemon(key)
+			return url.URL{}, authProviderConfigurationUpdatingError(authProviderName)
+		}
+		if !authProvider.Status.Configured || len(authProvider.Status.MissingConfigurationParameters) > 0 {
+			d.stopDaemon(key)
+			return url.URL{}, authProviderNotConfiguredError(authProvider)
+		}
+
+		if state, ok := d.daemonState(key); ok && state.configurationHash == authProvider.Status.DaemonConfigurationHash {
+			return daemonURL(state.port), nil
+		}
+
+		credentialEnvironment, err := credentialEnvironmentForAuthProvider(ctx, d.gatewayClient, authProvider)
+		if err != nil {
+			return url.URL{}, err
+		}
+		if missing := missingAuthProviderConfiguration(authProvider, credentialEnvironment); len(missing) > 0 {
+			d.stopDaemon(key)
+			return url.URL{}, fmt.Errorf("provider %q is not configured, missing configuration parameters: %s", authProviderName, strings.Join(missing, ", "))
+		}
+
+		configurationHash, err := authproviderconfig.DaemonConfigurationHash(authProvider, credentialEnvironment)
+		if err != nil {
+			return url.URL{}, err
+		}
+		if configurationHash != authProvider.Status.DaemonConfigurationHash {
+			d.stopDaemon(key)
+			return url.URL{}, authProviderConfigurationUpdatingError(authProviderName)
+		}
+
+		daemonEnvironment := maps.Clone(credentialEnvironment)
+		maps.Copy(daemonEnvironment, d.authProviderExtraEnv)
+		daemonEnvironment["LOG_LEVEL"] = providerLogLevel()
+
+		d.stopDaemon(key)
+		u, command, err := d.startDaemon(daemonEnvironment, key, configurationHash, authProvider.Spec.Command, authProvider.Spec.Args...)
+		if err != nil {
+			return url.URL{}, err
+		}
+
+		var current v1.AuthProvider
+		if err := d.client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: authProviderName}, &current); err != nil {
+			d.stopDaemonCommand(key, command)
+			return url.URL{}, fmt.Errorf("failed to revalidate provider: %w", err)
+		}
+		if authProviderConfigurationMatches(authProvider, current) {
+			if state, ok := d.daemonState(key); ok && state.command == command {
+				return u, nil
+			}
+			return url.URL{}, fmt.Errorf("provider %q daemon exited during startup", authProviderName)
+		}
+
+		d.stopDaemonCommand(key, command)
 	}
+}
 
-	maps.Copy(credEnv, d.authProviderExtraEnv)
+func authProviderConfigurationAcknowledged(authProvider v1.AuthProvider) bool {
+	return authProvider.Status.ObservedGeneration == authProvider.Generation &&
+		authProvider.Status.ObservedSyncRevision == authProvider.Annotations[v1.AuthProviderSyncAnnotation]
+}
 
-	credEnv["LOG_LEVEL"] = providerLogLevel()
+func authProviderConfigurationMatches(started, current v1.AuthProvider) bool {
+	return authProviderConfigurationAcknowledged(current) &&
+		current.Status.Configured &&
+		len(current.Status.MissingConfigurationParameters) == 0 &&
+		started.Annotations[v1.AuthProviderSyncAnnotation] == current.Annotations[v1.AuthProviderSyncAnnotation] &&
+		started.Status.ObservedSyncRevision == current.Status.ObservedSyncRevision &&
+		started.Status.DaemonConfigurationHash == current.Status.DaemonConfigurationHash
+}
 
-	return d.startDaemon(credEnv, key, authProvider.Spec.Command, authProvider.Spec.Args...)
+func authProviderConfigurationUpdatingError(authProviderName string) error {
+	return fmt.Errorf("provider %q configuration is updating", authProviderName)
+}
+
+func authProviderNotConfiguredError(authProvider v1.AuthProvider) error {
+	if len(authProvider.Status.MissingConfigurationParameters) == 0 {
+		return fmt.Errorf("provider %q is not configured", authProvider.Name)
+	}
+	return fmt.Errorf("provider %q is not configured, missing configuration parameters: %s", authProvider.Name, strings.Join(authProvider.Status.MissingConfigurationParameters, ", "))
+}
+
+func credentialEnvironmentForAuthProvider(ctx context.Context, gatewayClient *client.Client, authProvider v1.AuthProvider) (map[string]string, error) {
+	credential, err := gatewayClient.RevealCredential(ctx, []string{authProvider.Name, system.GenericAuthProviderCredentialContext}, authProvider.Name)
+	if err != nil {
+		if errors.As(err, &client.CredentialNotFoundError{}) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("failed to reveal provider credential: %w", err)
+	}
+	if credential.Secrets == nil {
+		return map[string]string{}, nil
+	}
+	return credential.Secrets, nil
+}
+
+func missingAuthProviderConfiguration(authProvider v1.AuthProvider, credentialEnvironment map[string]string) []string {
+	var missing []string
+	for _, parameter := range authProvider.Spec.RequiredConfigurationParameters {
+		if _, ok := credentialEnvironment[parameter.Name]; !ok {
+			missing = append(missing, parameter.Name)
+		}
+	}
+	return missing
+}
+
+func daemonURL(port int64) url.URL {
+	return url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}
 }
 
 // GroupIDPrefixForAuthProvider returns the group ID namespace declared by an auth provider.
@@ -137,13 +231,12 @@ func (d *Dispatcher) GroupIDPrefixForAuthProvider(ctx context.Context, namespace
 
 func (d *Dispatcher) URLForModelProvider(ctx context.Context, namespace, modelProviderName string) (url.URL, error) {
 	key := providerKeyForModelProvider(namespace, modelProviderName)
+	unlock := d.providerLocks.Lock(key)
+	defer unlock()
 
-	d.ports.daemonLock.RLock()
-	if port := d.ports.daemonPorts[key]; port != 0 {
-		d.ports.daemonLock.RUnlock()
-		return url.URL{Scheme: "http", Host: fmt.Sprintf("127.0.0.1:%d", port)}, nil
+	if state, ok := d.daemonState(key); ok {
+		return daemonURL(state.port), nil
 	}
-	d.ports.daemonLock.RUnlock()
 
 	var modelProvider v1.ModelProvider
 	if err := d.client.Get(ctx, kclient.ObjectKey{Namespace: namespace, Name: modelProviderName}, &modelProvider); err != nil {
@@ -179,7 +272,8 @@ func (d *Dispatcher) urlForModelProvider(ctx context.Context, key string, modelP
 
 	credEnv["LOG_LEVEL"] = providerLogLevel()
 
-	return d.startDaemon(credEnv, key, modelProvider.Spec.Command, modelProvider.Spec.Args...)
+	u, _, err := d.startDaemon(credEnv, key, "", modelProvider.Spec.Command, modelProvider.Spec.Args...)
+	return u, err
 }
 
 func providerLogLevel() string {
@@ -190,15 +284,17 @@ func providerLogLevel() string {
 }
 
 func (d *Dispatcher) StopModelProvider(namespace, modelProviderName string) {
-	d.stopProvider("model-provider", namespace, modelProviderName)
+	d.stopProvider(providerKeyForModelProvider(namespace, modelProviderName))
 }
 
 func (d *Dispatcher) StopAuthProvider(namespace, authProviderName string) {
-	d.stopProvider("auth-provider", namespace, authProviderName)
+	d.stopProvider(providerKeyForAuthProvider(namespace, authProviderName))
 }
 
-func (d *Dispatcher) stopProvider(providerType, namespace, providerName string) {
-	d.stopDaemon(providerKey(providerType, namespace, providerName))
+func (d *Dispatcher) stopProvider(key string) {
+	unlock := d.providerLocks.Lock(key)
+	defer unlock()
+	d.stopDaemon(key)
 }
 
 func (d *Dispatcher) GetConfiguredAuthProvider(ctx context.Context) (string, error) {

--- a/pkg/gateway/server/dispatcher/dispatcher.go
+++ b/pkg/gateway/server/dispatcher/dispatcher.go
@@ -119,10 +119,6 @@ func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProv
 			return url.URL{}, authProviderNotConfiguredError(authProvider)
 		}
 
-		if state, ok := d.daemonState(key); ok && state.configurationHash == authProvider.Status.DaemonConfigurationHash {
-			return daemonURL(state.port), nil
-		}
-
 		credentialEnvironment, err := credentialEnvironmentForAuthProvider(ctx, d.gatewayClient, authProvider)
 		if err != nil {
 			return url.URL{}, err
@@ -139,6 +135,9 @@ func (d *Dispatcher) URLForAuthProvider(ctx context.Context, namespace, authProv
 		if configurationHash != authProvider.Status.DaemonConfigurationHash {
 			d.stopDaemon(key)
 			return url.URL{}, authProviderConfigurationUpdatingError(authProviderName)
+		}
+		if state, ok := d.daemonState(key); ok && state.configurationHash == configurationHash {
+			return daemonURL(state.port), nil
 		}
 
 		daemonEnvironment := maps.Clone(credentialEnvironment)

--- a/pkg/gateway/server/dispatcher/dispatcher_test.go
+++ b/pkg/gateway/server/dispatcher/dispatcher_test.go
@@ -1,8 +1,13 @@
 package dispatcher
 
 import (
+	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os/exec"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -43,8 +48,17 @@ func TestProviderLogLevelEnv(t *testing.T) {
 }
 
 func TestURLForAuthProviderReturnsMatchingAcknowledgedDaemon(t *testing.T) {
-	authProvider := acknowledgedAuthProvider(t, map[string]string{"CLIENT_SECRET": "client-secret"})
-	dispatcher := New(nil, fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(authProvider).Build(), nil, nil, "", "", "")
+	credentialEnvironment := map[string]string{"CLIENT_SECRET": "client-secret"}
+	authProvider := acknowledgedAuthProvider(t, credentialEnvironment)
+	gatewayClient := newDispatcherTestGatewayClient(t)
+	if err := gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+		Context: authProvider.Name,
+		Name:    authProvider.Name,
+		Secrets: credentialEnvironment,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	dispatcher := New(nil, fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(authProvider).Build(), gatewayClient, nil, "", "", "")
 	t.Cleanup(dispatcher.Close)
 	key := providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)
 	dispatcher.ports.daemons[key] = daemonState{
@@ -99,13 +113,87 @@ func TestURLForAuthProviderRejectsUnacknowledgedCredentialChange(t *testing.T) {
 	}
 	dispatcher := New(nil, fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(authProvider).Build(), gatewayClient, nil, "", "", "")
 	t.Cleanup(dispatcher.Close)
+	key := providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)
+	stopped := false
+	dispatcher.ports.daemons[key] = daemonState{
+		port:              12345,
+		stop:              func() { stopped = true },
+		command:           &exec.Cmd{},
+		configurationHash: authProvider.Status.DaemonConfigurationHash,
+	}
 
 	_, err := dispatcher.URLForAuthProvider(t.Context(), authProvider.Namespace, authProvider.Name)
 	if err == nil {
 		t.Fatal("expected configuration updating error")
 	}
-	if _, ok := dispatcher.daemonState(providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)); ok {
+	if !stopped {
+		t.Fatal("stale daemon was not stopped")
+	}
+	if _, ok := dispatcher.daemonState(key); ok {
 		t.Fatal("daemon was launched from an unacknowledged credential")
+	}
+}
+
+func TestURLForAuthProviderRejectsDeletedCredentialWithCachedDaemon(t *testing.T) {
+	authProvider := acknowledgedAuthProvider(t, map[string]string{"CLIENT_SECRET": "old-secret"})
+	gatewayClient := newDispatcherTestGatewayClient(t)
+	dispatcher := New(nil, fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(authProvider).Build(), gatewayClient, nil, "", "", "")
+	t.Cleanup(dispatcher.Close)
+	key := providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)
+	stopped := false
+	dispatcher.ports.daemons[key] = daemonState{
+		port:              12345,
+		stop:              func() { stopped = true },
+		command:           &exec.Cmd{},
+		configurationHash: authProvider.Status.DaemonConfigurationHash,
+	}
+
+	_, err := dispatcher.URLForAuthProvider(t.Context(), authProvider.Namespace, authProvider.Name)
+	if err == nil {
+		t.Fatal("expected not configured error")
+	}
+	if !stopped {
+		t.Fatal("stale daemon was not stopped")
+	}
+	if _, ok := dispatcher.daemonState(key); ok {
+		t.Fatal("daemon using deleted credential was retained")
+	}
+}
+
+func TestModelsForProviderReusesDaemon(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"data":[]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	modelProvider := v1.ModelProvider{
+		Name:      "model-provider",
+		Namespace: "default",
+	}
+	dispatcher := New(nil, nil, nil, nil, "", "", "")
+	t.Cleanup(dispatcher.Close)
+	key := providerKeyForModelProvider(modelProvider.Namespace, modelProvider.Name)
+	command := &exec.Cmd{}
+	dispatcher.ports.daemons[key] = daemonState{
+		port:    int64(server.Listener.Addr().(*net.TCPAddr).Port),
+		stop:    func() {},
+		command: command,
+	}
+
+	for range 2 {
+		if _, err := dispatcher.ModelsForProvider(t.Context(), modelProvider); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("model requests = %d, want 2", requests.Load())
+	}
+	state, ok := dispatcher.daemonState(key)
+	if !ok || state.command != command {
+		t.Fatal("cached model provider daemon was replaced")
 	}
 }
 

--- a/pkg/gateway/server/dispatcher/dispatcher_test.go
+++ b/pkg/gateway/server/dispatcher/dispatcher_test.go
@@ -2,9 +2,21 @@ package dispatcher
 
 import (
 	"log/slog"
+	"os/exec"
 	"testing"
+	"time"
 
+	clienttypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/logger"
+	authproviderconfig "github.com/obot-platform/obot/pkg/authprovider"
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	storageservices "github.com/obot-platform/obot/pkg/storage/services"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestProviderLogLevelEnv(t *testing.T) {
@@ -28,4 +40,170 @@ func TestProviderLogLevelEnv(t *testing.T) {
 			t.Fatalf("providerLogLevel() = %q, want DEBUG", got)
 		}
 	})
+}
+
+func TestURLForAuthProviderReturnsMatchingAcknowledgedDaemon(t *testing.T) {
+	authProvider := acknowledgedAuthProvider(t, map[string]string{"CLIENT_SECRET": "client-secret"})
+	dispatcher := New(nil, fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(authProvider).Build(), nil, nil, "", "", "")
+	t.Cleanup(dispatcher.Close)
+	key := providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)
+	dispatcher.ports.daemons[key] = daemonState{
+		port:              12345,
+		stop:              func() {},
+		command:           &exec.Cmd{},
+		configurationHash: authProvider.Status.DaemonConfigurationHash,
+	}
+
+	u, err := dispatcher.URLForAuthProvider(t.Context(), authProvider.Namespace, authProvider.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.String() != "http://127.0.0.1:12345" {
+		t.Fatalf("URL = %q, want http://127.0.0.1:12345", u.String())
+	}
+}
+
+func TestURLForAuthProviderStopsDaemonForUnacknowledgedRevision(t *testing.T) {
+	authProvider := acknowledgedAuthProvider(t, map[string]string{"CLIENT_SECRET": "client-secret"})
+	authProvider.Annotations[v1.AuthProviderSyncAnnotation] = "new-revision"
+	dispatcher := New(nil, fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(authProvider).Build(), nil, nil, "", "", "")
+	t.Cleanup(dispatcher.Close)
+	key := providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)
+	stopped := false
+	dispatcher.ports.daemons[key] = daemonState{
+		port:              12345,
+		stop:              func() { stopped = true },
+		command:           &exec.Cmd{},
+		configurationHash: authProvider.Status.DaemonConfigurationHash,
+	}
+
+	_, err := dispatcher.URLForAuthProvider(t.Context(), authProvider.Namespace, authProvider.Name)
+	if err == nil || !stopped {
+		t.Fatalf("URLForAuthProvider() error = %v, stopped = %v; want updating error and stopped daemon", err, stopped)
+	}
+	if _, ok := dispatcher.daemonState(key); ok {
+		t.Fatal("stale daemon state was retained")
+	}
+}
+
+func TestURLForAuthProviderRejectsUnacknowledgedCredentialChange(t *testing.T) {
+	oldCredential := map[string]string{"CLIENT_SECRET": "old-secret"}
+	authProvider := acknowledgedAuthProvider(t, oldCredential)
+	gatewayClient := newDispatcherTestGatewayClient(t)
+	if err := gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+		Context: authProvider.Name,
+		Name:    authProvider.Name,
+		Secrets: map[string]string{"CLIENT_SECRET": "new-secret"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	dispatcher := New(nil, fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(authProvider).Build(), gatewayClient, nil, "", "", "")
+	t.Cleanup(dispatcher.Close)
+
+	_, err := dispatcher.URLForAuthProvider(t.Context(), authProvider.Namespace, authProvider.Name)
+	if err == nil {
+		t.Fatal("expected configuration updating error")
+	}
+	if _, ok := dispatcher.daemonState(providerKeyForAuthProvider(authProvider.Namespace, authProvider.Name)); ok {
+		t.Fatal("daemon was launched from an unacknowledged credential")
+	}
+}
+
+func TestStopDaemonCommandDoesNotRemoveReplacement(t *testing.T) {
+	dispatcher := New(nil, nil, nil, nil, "", "", "")
+	t.Cleanup(dispatcher.Close)
+	oldCommand := &exec.Cmd{}
+	replacementCommand := &exec.Cmd{}
+	replacementStopped := false
+	dispatcher.ports.daemons["provider"] = daemonState{
+		port:    12345,
+		stop:    func() { replacementStopped = true },
+		command: replacementCommand,
+	}
+
+	dispatcher.stopDaemonCommand("provider", oldCommand)
+	state, ok := dispatcher.daemonState("provider")
+	if !ok || state.command != replacementCommand {
+		t.Fatal("old command removed its replacement")
+	}
+	if replacementStopped {
+		t.Fatal("old command stopped its replacement")
+	}
+}
+
+func TestKeyedMutexDoesNotBlockAnotherProvider(t *testing.T) {
+	locks := newKeyedMutex()
+	unlockSlow := locks.Lock("slow-provider")
+	defer unlockSlow()
+
+	acquired := make(chan struct{})
+	go func() {
+		unlockFast := locks.Lock("fast-provider")
+		close(acquired)
+		unlockFast()
+	}()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("slow provider blocked another provider")
+	}
+}
+
+func acknowledgedAuthProvider(t *testing.T, credentialEnvironment map[string]string) *v1.AuthProvider {
+	t.Helper()
+	authProvider := &v1.AuthProvider{
+		Name:       "entra-auth-provider",
+		Namespace:  "default",
+		UID:        types.UID("provider-uid"),
+		Generation: 2,
+		Annotations: map[string]string{
+			v1.AuthProviderSyncAnnotation: "revision-one",
+		},
+		Spec: v1.AuthProviderSpec{
+			AuthProviderManifest: clienttypes.AuthProviderManifest{
+				CommonProviderMetadata: clienttypes.CommonProviderMetadata{
+					Command: "provider-command",
+					RequiredConfigurationParameters: []clienttypes.ProviderConfigurationParameter{
+						{
+							Name: "CLIENT_SECRET",
+						},
+					},
+				},
+			},
+		},
+	}
+	hash, err := authproviderconfig.DaemonConfigurationHash(*authProvider, credentialEnvironment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authProvider.Status = v1.AuthProviderStatus{
+		Configured:              true,
+		ObservedGeneration:      authProvider.Generation,
+		DaemonConfigurationHash: hash,
+		ObservedSyncRevision:    authProvider.Annotations[v1.AuthProviderSyncAnnotation],
+	}
+	return authProvider
+}
+
+func newDispatcherTestGatewayClient(t *testing.T) *gatewayclient.Client {
+	t.Helper()
+	storageServices, err := storageservices.New(storageservices.Config{DSN: "sqlite://:memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	database, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.AutoMigrate(); err != nil {
+		t.Fatal(err)
+	}
+	gatewayClient := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, 0, false)
+	t.Cleanup(func() {
+		if err := gatewayClient.Close(); err != nil {
+			t.Errorf("close gateway client: %v", err)
+		}
+	})
+	return gatewayClient
 }

--- a/pkg/gateway/server/dispatcher/dispatcher_test.go
+++ b/pkg/gateway/server/dispatcher/dispatcher_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -194,6 +195,30 @@ func TestModelsForProviderReusesDaemon(t *testing.T) {
 	state, ok := dispatcher.daemonState(key)
 	if !ok || state.command != command {
 		t.Fatal("cached model provider daemon was replaced")
+	}
+}
+
+func TestModelsForProviderUsesReconciledObject(t *testing.T) {
+	modelProvider := &v1.ModelProvider{
+		Name:      "model-provider",
+		Namespace: "default",
+		Status: v1.ModelProviderStatus{
+			MissingConfigurationParameters: []string{"RECONCILED_PARAMETER"},
+		},
+	}
+	persistedModelProvider := modelProvider.DeepCopy()
+	persistedModelProvider.Status = v1.ModelProviderStatus{
+		MissingConfigurationParameters: []string{"PERSISTED_PARAMETER"},
+	}
+	dispatcher := New(nil, fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(persistedModelProvider).Build(), nil, nil, "", "", "")
+	t.Cleanup(dispatcher.Close)
+
+	_, err := dispatcher.ModelsForProvider(t.Context(), *modelProvider)
+	if err == nil || !strings.Contains(err.Error(), "RECONCILED_PARAMETER") {
+		t.Fatalf("ModelsForProvider() error = %v, want reconciled object error", err)
+	}
+	if strings.Contains(err.Error(), "PERSISTED_PARAMETER") {
+		t.Fatalf("ModelsForProvider() used persisted object: %v", err)
 	}
 }
 

--- a/pkg/gateway/server/dispatcher/keyedmutex.go
+++ b/pkg/gateway/server/dispatcher/keyedmutex.go
@@ -1,0 +1,25 @@
+package dispatcher
+
+import "sync"
+
+type keyedMutex struct {
+	lock  sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func newKeyedMutex() *keyedMutex {
+	return &keyedMutex{locks: map[string]*sync.Mutex{}}
+}
+
+func (k *keyedMutex) Lock(key string) func() {
+	k.lock.Lock()
+	mutex := k.locks[key]
+	if mutex == nil {
+		mutex = &sync.Mutex{}
+		k.locks[key] = mutex
+	}
+	k.lock.Unlock()
+
+	mutex.Lock()
+	return mutex.Unlock
+}

--- a/pkg/gateway/server/dispatcher/keyedmutex.go
+++ b/pkg/gateway/server/dispatcher/keyedmutex.go
@@ -1,6 +1,8 @@
 package dispatcher
 
-import "sync"
+import (
+	"sync"
+)
 
 type keyedMutex struct {
 	lock  sync.Mutex

--- a/pkg/storage/apis/obot.obot.ai/v1/authprovider.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/authprovider.go
@@ -31,6 +31,8 @@ type AuthProviderStatus struct {
 	Configured                     bool     `json:"configured"`
 	MissingConfigurationParameters []string `json:"missingConfigurationParameters,omitempty"`
 	ObservedGeneration             int64    `json:"observedGeneration,omitempty"`
+	DaemonConfigurationHash        string   `json:"daemonConfigurationHash,omitempty"`
+	ObservedSyncRevision           string   `json:"observedSyncRevision,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -19468,6 +19468,18 @@ func schema_storage_apis_obotobotai_v1_AuthProviderStatus(ref common.ReferenceCa
 							Format: "int64",
 						},
 					},
+					"daemonConfigurationHash": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"observedSyncRevision": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"configured"},
 			},


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/7667

With these changes, during the authentication procedure, we compare the hash of the config of the currently running auth provider daemon to the hash of the config in the database. If they differ, we stop and restart the auth provider daemon with the new configuration.

An unfortunate side-effect of this is that we have to have the controller reconcile the auth providers every 30s. There is an explanation in the code comments (written by me, not an LLM!) to explain why.