### PR TITLE
fix: add reauthenticate option in preconfigure for MCP Servers

### DIFF
--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -64,6 +64,13 @@
 			entry?: MCPCatalogEntry;
 			instance?: MCPServerInstance;
 		}) => void;
+		onReauthenticate?: ({
+			server,
+			entry
+		}: {
+			server?: MCPCatalogServer;
+			entry?: MCPCatalogEntry;
+		}) => void;
 		onClose?: () => void;
 		skipConnectDialog?: boolean;
 		renderIntroText?: ({
@@ -82,6 +89,7 @@
 		onConnect,
 		onClose,
 		onEdit,
+		onReauthenticate,
 		skipConnectDialog,
 		renderIntroText,
 		introTitle
@@ -116,8 +124,11 @@
 			(!instance && server && hasMultiUserInstanceConfiguration(server))
 	);
 	let isEditable = $derived(
-		(entry && !isMultiUserCatalogEntry(entry) && server) ||
+		(entry && !isMultiUserCatalogEntry(entry) && hasEditableConfiguration(entry) && server) ||
 			(server && instance && hasMultiUserInstanceConfiguration(server))
+	);
+	let isReauthenticatable = $derived(
+		server?.manifest.runtime === 'remote' && Object.keys(server.oauthMetadata ?? {}).length > 0
 	);
 
 	let showIntroDialog = $state(false);
@@ -1142,6 +1153,12 @@
 					? () => {
 							connectDialog?.close();
 							onEdit({ entry, server, instance });
+						}
+					: undefined}
+				onReauthenticate={onReauthenticate && isReauthenticatable
+					? () => {
+							connectDialog?.close();
+							onReauthenticate({ server, entry });
 						}
 					: undefined}
 			/>

--- a/ui/user/src/lib/components/mcp/HowToConnect.svelte
+++ b/ui/user/src/lib/components/mcp/HowToConnect.svelte
@@ -17,9 +17,10 @@
 		url: string;
 		onLaunch?: () => void;
 		onEdit?: () => void;
+		onReauthenticate?: () => void;
 	}
 
-	let { id, displayName, url, onLaunch, onEdit }: Props = $props();
+	let { id, displayName, url, onLaunch, onEdit, onReauthenticate }: Props = $props();
 
 	let aiClientsMap = $derived(new Map(COMMON_AI_CLIENTS.map((client) => [client.id, client])));
 	let magicLinks = $derived(generateMcpLinks(displayName, url));
@@ -174,7 +175,7 @@
 		</div>
 	{/if}
 
-	{#if onLaunch || onEdit}
+	{#if onLaunch || onEdit || onReauthenticate}
 		{#if onLaunch}
 			<div class={twMerge('divider', commands.length > 0 ? 'mt-8' : '')}>Preconfigure</div>
 			<p class="text-xs text-center">
@@ -184,19 +185,29 @@
 					onclick={onLaunch}>click here</button
 				>.
 			</p>
-		{:else if onEdit}
+		{:else if onEdit || onReauthenticate}
 			<div class={twMerge('divider', commands.length > 0 ? 'mt-8' : '')}>
 				<span>
 					Preconfigure <CircleCheckBig class="size-4 text-primary shrink-0 inline-block" />
 				</span>
 			</div>
 			<div role="status" class="notification-info text-xs text-center">
-				This server has already been configured. If you need to update the configuration,
-				<button
-					class="text-blue-500 underline hover:text-blue-400"
-					aria-label="Edit configuration"
-					onclick={onEdit}>click here</button
-				>.
+				This server has already been configured.
+				{#if onEdit}
+					If you need to update the configuration,
+					<button
+						class="text-blue-500 underline hover:text-blue-400"
+						aria-label="Edit configuration"
+						onclick={onEdit}>click here</button
+					>.
+				{/if}
+				{#if onReauthenticate}
+					If you need to reauthenticate, <button
+						class="text-blue-500 underline hover:text-blue-400"
+						aria-label="Reauthenticate"
+						onclick={onReauthenticate}>click here</button
+					>.
+				{/if}
 			</div>
 		{/if}
 	{/if}

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -402,6 +402,11 @@
 			});
 		}
 	}}
+	onReauthenticate={({ server }) => {
+		if (server) {
+			reauthenticateServer(server);
+		}
+	}}
 />
 
 <EditExistingDeployment bind:this={editExistingDialog} onUpdateConfigure={refresh} />

--- a/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
+++ b/ui/user/src/routes/mcp-servers/ConnectorsView.svelte
@@ -361,6 +361,11 @@
 			});
 		}
 	}}
+	onReauthenticate={({ server }) => {
+		if (server) {
+			reauthenticateServer(server);
+		}
+	}}
 />
 
 <McpSelectServerDeployment

--- a/ui/user/src/routes/mcp-servers/ConnectorsView.svelte.spec.ts
+++ b/ui/user/src/routes/mcp-servers/ConnectorsView.svelte.spec.ts
@@ -44,4 +44,40 @@ describe('MCP Servers ConnectorsView', () => {
 		await expect.element(descriptionPreview).toHaveClass(/line-clamp-2/);
 		await expect.element(descriptionPreview.locator('..')).not.toHaveClass(/line-clamp-2/);
 	});
+
+	it('shows the reauthenticate option for configured remote OAuth servers', async () => {
+		const entry = createMCPCatalogEntry({
+			id: 'remote-entry',
+			name: 'Remote OAuth Server',
+			runtime: 'remote',
+			manifest: {
+				remoteConfig: { fixedURL: 'https://example.com/mcp' }
+			}
+		});
+		const server = createMCPCatalogServer({
+			id: 'remote-server',
+			name: entry.manifest.name!,
+			runtime: 'remote',
+			catalogEntryID: entry.id,
+			userID: 'user-1',
+			connectURL: 'https://obot.example.com/mcp/remote-server',
+			oauthMetadata: {
+				protectedResourceUrl: 'https://example.com/.well-known/oauth-protected-resource'
+			}
+		});
+		mcpServersAndEntries.current = {
+			entries: [entry],
+			servers: [],
+			userInstances: [],
+			userConfiguredServers: [server],
+			loading: false,
+			lastFetched: null,
+			isInitialized: true
+		};
+
+		render(ConnectorsView);
+
+		await page.getByRole('button', { name: 'Connect', exact: true }).click();
+		await expect.element(page.getByRole('button', { name: 'Reauthenticate' })).toBeVisible();
+	});
 });


### PR DESCRIPTION
This addresses adding the 'Reauthenticate' option in Preconfigure for MCP Servers if it is available.

Add-on to #7678 