### PR TITLE
fix: revert premature removal of MCP Servers from Layout

### DIFF
--- a/ui/user/src/lib/components/Layout.svelte
+++ b/ui/user/src/lib/components/Layout.svelte
@@ -106,7 +106,8 @@
 		LayoutGrid,
 		KeyRound,
 		Menu,
-		X
+		X,
+		Server
 	} from '@lucide/svelte';
 	import { tick, untrack } from 'svelte';
 	import { fade, slide, type TransitionConfig } from 'svelte/transition';
@@ -255,6 +256,12 @@
 	const isNearUserLimit = $derived(validateVersionUserLimit(version.current));
 
 	let defaultLinks = $derived<NavLink[]>([
+		{
+			id: 'mcp-servers',
+			icon: Server,
+			label: 'MCP Servers',
+			href: '/mcp-servers'
+		},
 		{
 			id: 'mcp-skills',
 			icon: PencilRuler,

--- a/ui/user/src/lib/components/Layout.svelte.spec.ts
+++ b/ui/user/src/lib/components/Layout.svelte.spec.ts
@@ -127,7 +127,7 @@ describe('Layout.svelte', () => {
 	it('gives all users access to non-administrative sidebar navigation', async () => {
 		await renderLayout();
 
-		for (const name of ['Skills', 'Hosted Agents', 'Agent Identities']) {
+		for (const name of ['MCP Servers', 'Skills', 'Hosted Agents', 'Agent Identities']) {
 			await expect.element(page.getByRole('link', { name, exact: true })).toBeVisible();
 		}
 	});


### PR DESCRIPTION
Revert of prematurely removed MCP Servers from Layout. 🤦‍♀️ Apologies!