### PR TITLE
fix: show reauthenticate only if oauthmetadata and no configurations

### DIFF
--- a/ui/user/src/lib/components/mcp/ConnectToServer.svelte
+++ b/ui/user/src/lib/components/mcp/ConnectToServer.svelte
@@ -128,7 +128,9 @@
 			(server && instance && hasMultiUserInstanceConfiguration(server))
 	);
 	let isReauthenticatable = $derived(
-		server?.manifest.runtime === 'remote' && Object.keys(server.oauthMetadata ?? {}).length > 0
+		server?.manifest.runtime === 'remote' &&
+			Object.keys(server.oauthMetadata ?? {}).length > 0 &&
+			!hasEditableConfiguration(server)
 	);
 
 	let showIntroDialog = $state(false);

--- a/ui/user/src/lib/components/mcp/HowToConnect.svelte
+++ b/ui/user/src/lib/components/mcp/HowToConnect.svelte
@@ -200,8 +200,7 @@
 						aria-label="Edit configuration"
 						onclick={onEdit}>click here</button
 					>.
-				{/if}
-				{#if onReauthenticate}
+				{:else if onReauthenticate}
 					If you need to reauthenticate, <button
 						class="text-blue-500 underline hover:text-blue-400"
 						aria-label="Reauthenticate"

--- a/ui/user/src/lib/components/mcp/McpServerActions.svelte
+++ b/ui/user/src/lib/components/mcp/McpServerActions.svelte
@@ -126,7 +126,9 @@
 	let isMultiUserCatalogEntryRow = $derived(isMultiUserCatalogEntry(entry) && !server);
 	let requiresUpdate = $derived(server && requiresUserUpdate(server));
 	let canReauthenticate = $derived(
-		server?.manifest.runtime === 'remote' && Object.keys(server.oauthMetadata ?? {}).length > 0
+		server?.manifest.runtime === 'remote' &&
+			Object.keys(server.oauthMetadata ?? {}).length > 0 &&
+			!hasEditableConfiguration(server)
 	);
 	let canDebugOauth = $derived(canReauthenticate && profile.current?.hasAdminAccess?.());
 	let belongsToComposite = $derived(Boolean(server && server.compositeName));


### PR DESCRIPTION
This addresses only showing Reauthenticate/Debug Oauthmeta IFF oauthmetadata is supplied and no editable configurations.