### PR TITLE
fix(mcp): prevent forwarding gateway credentials

### DIFF
--- a/pkg/api/handlers/mcpgateway/handler.go
+++ b/pkg/api/handlers/mcpgateway/handler.go
@@ -298,10 +298,12 @@ func (h *Handler) Proxy(req api.Context) error {
 }
 
 func rewriteProxyRequest(r *httputil.ProxyRequest, upstreamURL *url.URL) {
-	// Authorization authenticates the client to Obot and must not be forwarded
-	// to the upstream MCP server. The transport adds any configured or OAuth
-	// Authorization header after this rewrite.
-	r.Out.Header.Del("Authorization")
+	// These headers may authenticate the client to Obot and must not cross the
+	// trust boundary to the upstream MCP server. The transport adds any
+	// explicitly configured upstream credentials after this rewrite.
+	for _, header := range []string{"Authorization", "Cookie", "Proxy-Authorization", "X-API-Key"} {
+		r.Out.Header.Del(header)
+	}
 
 	// SetXForwarded preserves the X-Forwarded-For handling that ReverseProxy
 	// applied automatically under the deprecated Director. It also writes

--- a/pkg/api/handlers/mcpgateway/handler_test.go
+++ b/pkg/api/handlers/mcpgateway/handler_test.go
@@ -14,12 +14,13 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func TestProxyStripsInboundGatewayAuthorization(t *testing.T) {
+func TestProxyStripsInboundGatewayCredentials(t *testing.T) {
 	tests := []struct {
 		name                      string
 		configuredUpstreamHeaders http.Header
 		tokenSource               oauth2.TokenSource
 		wantAuthorization         string
+		wantAPIKey                string
 	}{
 		{
 			name: "non-authorization upstream credential",
@@ -31,9 +32,11 @@ func TestProxyStripsInboundGatewayAuthorization(t *testing.T) {
 			name: "configured upstream authorization",
 			configuredUpstreamHeaders: http.Header{
 				"Authorization":  {"Bearer configured-upstream-token"},
+				"X-API-Key":      {"configured-upstream-api-key"},
 				"X-Filesapi-Key": {"files-api-key"},
 			},
 			wantAuthorization: "Bearer configured-upstream-token",
+			wantAPIKey:        "configured-upstream-api-key",
 		},
 		{
 			name: "upstream OAuth authorization",
@@ -75,6 +78,9 @@ func TestProxyStripsInboundGatewayAuthorization(t *testing.T) {
 				t.Fatal(err)
 			}
 			request.Header.Set("Authorization", "Bearer obot-gateway-jwt")
+			request.Header.Set("Cookie", "obot_access_token=local-session-secret")
+			request.Header.Set("Proxy-Authorization", "Bearer obot-proxy-token")
+			request.Header.Set("X-API-Key", "obot-api-key")
 
 			response, err := http.DefaultClient.Do(request)
 			if err != nil {
@@ -91,6 +97,15 @@ func TestProxyStripsInboundGatewayAuthorization(t *testing.T) {
 			}
 			if got.Get("Authorization") != tt.wantAuthorization {
 				t.Fatalf("Authorization = %q, want %q", got.Get("Authorization"), tt.wantAuthorization)
+			}
+			if got.Get("Cookie") != "" {
+				t.Fatalf("Cookie = %q, want empty", got.Get("Cookie"))
+			}
+			if got.Get("Proxy-Authorization") != "" {
+				t.Fatalf("Proxy-Authorization = %q, want empty", got.Get("Proxy-Authorization"))
+			}
+			if got.Get("X-API-Key") != tt.wantAPIKey {
+				t.Fatalf("X-API-Key = %q, want %q", got.Get("X-API-Key"), tt.wantAPIKey)
 			}
 		})
 	}


### PR DESCRIPTION
### Motivation

- The reverse proxy used for non-composite MCP servers forwarded inbound Obot credentials (session cookies, Authorization, X-API-Key, Proxy-Authorization) to upstream MCP servers, introducing a credential disclosure across the MCP trust boundary.
- The intent is to preserve the safe transport behavior that applies any configured upstream credentials while preventing arbitrary client-supplied gateway credentials from crossing to untrusted upstream servers.

### Description

- Strip sensitive inbound headers (`Authorization`, `Cookie`, `Proxy-Authorization`, `X-API-Key`) in `rewriteProxyRequest` before proxying to the upstream MCP server so client-supplied gateway credentials cannot be forwarded.
- Leave existing behavior that allows the safe transport to apply explicitly configured upstream credentials or OAuth tokens after the rewrite.
- Rename and expand the existing proxy regression test to `TestProxyStripsInboundGatewayCredentials` and add assertions to validate cookies, proxy authorization, and API key handling as well as configured-upstream and OAuth authorization behavior.
- Keep the existing X-Forwarded header handling and URL/query merging semantics intact while tightening credential forwarding rules.

### Testing

- Ran the focused unit test `go test ./pkg/api/handlers/mcpgateway -run '^TestProxyStripsInboundGatewayCredentials$' -count=1 -timeout=2m` and it passed.
- Ran the package tests `go test ./pkg/api/handlers/mcpgateway -count=1 -timeout=5m` and they passed.
- Verified formatting and no linter-format failures with `gofmt` and local checks (no test failures resulted from these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8f4f24fcf083218674fb3821dddcbd)