### PR TITLE
refactor: move version checker to new package

### DIFF
--- a/apiclient/types/producttelemetry.go
+++ b/apiclient/types/producttelemetry.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	ProductTelemetryDistributionUnlicensed ProductTelemetryDistribution = "Unlicensed"
-	ProductTelemetryDistributionCommunity  ProductTelemetryDistribution = "Community"
-	ProductTelemetryDistributionEnterprise ProductTelemetryDistribution = "Enterprise"
-	ProductTelemetryDistributionCloud      ProductTelemetryDistribution = "Cloud"
+	ProductTelemetryDistributionUnregistered ProductTelemetryDistribution = "Unregistered"
+	ProductTelemetryDistributionRegistered   ProductTelemetryDistribution = "Registered"
+	ProductTelemetryDistributionEnterprise   ProductTelemetryDistribution = "Enterprise"
+	ProductTelemetryDistributionCloud        ProductTelemetryDistribution = "Cloud"
 )
 
 // ProductTelemetryDistribution identifies the Obot distribution sending telemetry.

--- a/pkg/api/handlers/version.go
+++ b/pkg/api/handlers/version.go
@@ -2,16 +2,9 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"log/slog"
-	"net/http"
 	"os"
 	"slices"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/gateway/client"
@@ -25,11 +18,13 @@ import (
 const (
 	SessionStoreDB     SessionStore = "db"
 	SessionStoreCookie SessionStore = "cookie"
-
-	updateCheckInterval = 24 * time.Hour
 )
 
 type SessionStore string
+
+type UpgradeStatusReader interface {
+	Status() upgrade.Status
+}
 
 type VersionHandlerOptions struct {
 	GatewayClient           *client.Client
@@ -40,29 +35,17 @@ type VersionHandlerOptions struct {
 	MCPNetworkPolicyEnabled bool
 	MCPDefaultDenyAllEgress bool
 	AuthEnabled             bool
-	DisableUpdateCheck      bool
 	MessagePoliciesEnabled  bool
 	AgentsEnabled           bool
 	HostedAgentsEnabled     bool
 	HideK8sDetails          bool
+	UpgradeStatusReader     UpgradeStatusReader
 }
 
 type VersionHandler struct {
 	VersionHandlerOptions
 
 	sessionStore SessionStore
-
-	upgradeServerURL string
-	upgradeAvailable bool
-	latestVersion    string
-
-	upgradeLock sync.RWMutex
-}
-
-type upgradeCheckResponse struct {
-	UpgradeAvailable bool   `json:"upgradeAvailable"`
-	LatestVersion    string `json:"latestVersion"`
-	CurrentVersion   string `json:"currentVersion"`
 }
 
 func sessionStoreFromPostgresDSN(postgresDSN string) SessionStore {
@@ -72,27 +55,11 @@ func sessionStoreFromPostgresDSN(postgresDSN string) SessionStore {
 	return SessionStoreCookie
 }
 
-func NewVersionHandler(ctx context.Context, opts VersionHandlerOptions) (*VersionHandler, error) {
-	v := &VersionHandler{
+func NewVersionHandler(opts VersionHandlerOptions) *VersionHandler {
+	return &VersionHandler{
 		VersionHandlerOptions: opts,
 		sessionStore:          sessionStoreFromPostgresDSN(opts.PostgresDSN),
-		upgradeServerURL:      upgrade.EndpointURL(upgrade.ServerBaseURL(), "check-upgrade"),
 	}
-
-	currentVersion, _, _ := strings.Cut(version.Get().String(), "+")
-	currentVersion, _, _ = strings.Cut(currentVersion, "-")
-
-	// Don't start the upgrade check if explicitly disabled or if this is a development version.
-	if !opts.DisableUpdateCheck && (!strings.HasPrefix(currentVersion, "v0.0.0") || os.Getenv("OBOT_FORCE_UPGRADE_CHECK") == "true") {
-		installationID, err := upgrade.GetInstallationID(ctx, opts.GatewayClient)
-		if err != nil {
-			return nil, err
-		}
-
-		go v.startUpgradeCheck(ctx, installationID, currentVersion, opts.Engine)
-	}
-
-	return v, nil
 }
 
 func (v *VersionHandler) GetVersion(req api.Context) error {
@@ -114,10 +81,7 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 		return nil, err
 	}
 
-	v.upgradeLock.RLock()
-	upgradeAvailable := v.upgradeAvailable
-	latestVersion := v.latestVersion
-	v.upgradeLock.RUnlock()
+	upgradeStatus := v.upgradeStatus()
 
 	entitlements, err := v.LicenseProvider.Entitlements(ctx)
 	if err != nil {
@@ -135,8 +99,8 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 	}
 
 	values := map[string]any{
-		"upgradeAvailable":             upgradeAvailable,
-		"latestVersion":                latestVersion,
+		"upgradeAvailable":             upgradeStatus.UpgradeAvailable,
+		"latestVersion":                upgradeStatus.LatestVersion,
 		"obot":                         version.Get().String(),
 		"authEnabled":                  v.AuthEnabled,
 		"sessionStore":                 v.sessionStore,
@@ -184,6 +148,13 @@ func (v *VersionHandler) getVersionResponse(ctx context.Context) (map[string]any
 	return values, nil
 }
 
+func (v *VersionHandler) upgradeStatus() upgrade.Status {
+	if v.UpgradeStatusReader == nil {
+		return upgrade.Status{}
+	}
+	return v.UpgradeStatusReader.Status()
+}
+
 func (v *VersionHandler) featureValues() map[string]bool {
 	return map[string]bool{
 		"messagePoliciesEnabled": v.MessagePoliciesEnabled,
@@ -206,78 +177,4 @@ func missingEntitlements(violations []license.Violation) []string {
 	}
 	slices.Sort(missing)
 	return missing
-}
-
-func (v *VersionHandler) startUpgradeCheck(ctx context.Context, installationID, currentVersion, engine string) {
-	timer := time.NewTimer(updateCheckInterval)
-	defer timer.Stop()
-
-	var err error
-	for {
-		distribution := "oss"
-		hasValidLicense, licenseErr := v.LicenseProvider.HasValidLicense(ctx)
-		if licenseErr != nil {
-			slog.Debug("failed to refresh license state for upgrade check", "error", licenseErr)
-		} else if hasValidLicense {
-			distribution = "enterprise"
-		}
-		if err = v.checkForUpgrade(ctx, installationID, currentVersion, engine, distribution); err != nil {
-			slog.Debug("failed to check for server upgrade", "error", err)
-		}
-
-		select {
-		case <-ctx.Done():
-			slog.Debug("upgrade check context cancelled, exiting")
-			return
-		case <-timer.C:
-			timer.Reset(updateCheckInterval)
-		}
-	}
-}
-
-func (v *VersionHandler) checkForUpgrade(ctx context.Context, installationID, currentVersion, engine, distribution string) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.upgradeServerURL, nil)
-	if err != nil {
-		return err
-	}
-
-	query := req.URL.Query()
-	query.Set("uid", installationID)
-	query.Set("engine", engine)
-	query.Set("distribution", distribution)
-	query.Set("current-version", currentVersion)
-	req.URL.RawQuery = query.Encode()
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
-	}
-
-	var upgradeInfo upgradeCheckResponse
-	if err := json.NewDecoder(resp.Body).Decode(&upgradeInfo); err != nil {
-		return err
-	}
-
-	v.upgradeLock.RLock()
-	currentUpgradeAvailable := v.upgradeAvailable
-	latestVersion := v.latestVersion
-	v.upgradeLock.RUnlock()
-
-	if currentUpgradeAvailable != upgradeInfo.UpgradeAvailable || latestVersion != upgradeInfo.LatestVersion {
-		v.upgradeLock.Lock()
-		v.upgradeAvailable = upgradeInfo.UpgradeAvailable
-		v.latestVersion = upgradeInfo.LatestVersion
-		v.upgradeLock.Unlock()
-	}
-
-	return nil
 }

--- a/pkg/api/handlers/version_test.go
+++ b/pkg/api/handlers/version_test.go
@@ -2,7 +2,17 @@ package handlers
 
 import (
 	"testing"
+
+	"github.com/obot-platform/obot/pkg/upgrade"
 )
+
+type fakeUpgradeStatusReader struct {
+	status upgrade.Status
+}
+
+func (f fakeUpgradeStatusReader) Status() upgrade.Status {
+	return f.status
+}
 
 func TestVersionFeatureValuesIncludesHostedAgentsState(t *testing.T) {
 	disabled := (&VersionHandler{}).featureValues()
@@ -15,5 +25,19 @@ func TestVersionFeatureValuesIncludesHostedAgentsState(t *testing.T) {
 	enabled := handler.featureValues()
 	if hostedAgentsEnabled := enabled["hostedAgentsEnabled"]; !hostedAgentsEnabled {
 		t.Fatal("expected Hosted Agents to be enabled")
+	}
+}
+
+func TestVersionHandlerReadsUpgradeStatus(t *testing.T) {
+	want := upgrade.Status{UpgradeAvailable: true, LatestVersion: "v1.2.3"}
+	handler := &VersionHandler{}
+	handler.UpgradeStatusReader = fakeUpgradeStatusReader{status: want}
+	if got := handler.upgradeStatus(); got != want {
+		t.Fatalf("upgradeStatus() = %#v, want %#v", got, want)
+	}
+
+	handler.UpgradeStatusReader = nil
+	if got := handler.upgradeStatus(); got != (upgrade.Status{}) {
+		t.Fatalf("upgradeStatus() without reader = %#v, want zero status", got)
 	}
 }

--- a/pkg/api/router/router.go
+++ b/pkg/api/router/router.go
@@ -36,7 +36,7 @@ func NewRouter(ctx context.Context, services *services.Services) (*Router, error
 		return nil, err
 	}
 
-	version, err := handlers.NewVersionHandler(ctx, handlers.VersionHandlerOptions{
+	version := handlers.NewVersionHandler(handlers.VersionHandlerOptions{
 		GatewayClient:           services.GatewayClient,
 		StorageClient:           services.StorageClient,
 		LicenseProvider:         services.LicenseProvider,
@@ -45,15 +45,12 @@ func NewRouter(ctx context.Context, services *services.Services) (*Router, error
 		MCPNetworkPolicyEnabled: services.MCPNetworkPolicyEnabled,
 		MCPDefaultDenyAllEgress: services.MCPDefaultDenyAllEgress,
 		AuthEnabled:             services.AuthEnabled,
-		DisableUpdateCheck:      services.DisableUpdateCheck,
 		MessagePoliciesEnabled:  services.MessagePoliciesEnabled,
 		AgentsEnabled:           agentsEnabled,
 		HostedAgentsEnabled:     services.HostedAgentsEnabled,
 		HideK8sDetails:          services.HideK8sDetails,
+		UpgradeStatusReader:     services.VersionChecker,
 	})
-	if err != nil {
-		return nil, err
-	}
 
 	mcpGateway, err := mcpgateway.NewHandler(
 		ctx,

--- a/pkg/license/provider.go
+++ b/pkg/license/provider.go
@@ -35,6 +35,9 @@ const (
 	// CommunityEntitlement is required to enable community edition.
 	CommunityEntitlement = "OBOT_COMMUNITY"
 
+	// CloudEntitlement identifies Obot Cloud deployments.
+	CloudEntitlement = "OBOT_CLOUD"
+
 	// EnterpriseModelProvidersEntitlement is required to enable enterprise model providers.
 	EnterpriseModelProvidersEntitlement = "OBOT_ENTERPRISE_MODEL_PROVIDERS"
 

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -61,6 +61,7 @@ import (
 	storageservices "github.com/obot-platform/obot/pkg/storage/services"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/tunnel"
+	"github.com/obot-platform/obot/pkg/upgrade"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -258,7 +259,6 @@ type Services struct {
 	// environment/Helm config and not modifiable via UI.
 	PSASettingsFromHelm *v1.PodSecurityAdmissionSettings
 
-	DisableUpdateCheck      bool
 	HideK8sDetails          bool
 	MCPRuntimeBackend       string
 	MCPImagePullSecrets     []string
@@ -291,6 +291,7 @@ type Services struct {
 
 	// License provider
 	LicenseProvider *license.Provider
+	VersionChecker  *upgrade.VersionChecker
 }
 
 type hostedAgentPodSchedulingSettings struct {
@@ -1348,7 +1349,6 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		StorageListenPort:                    config.StorageListenPort,
 		PodSchedulingSettingsFromHelm:        podSchedulingSettings,
 		PSASettingsFromHelm:                  psaSettings,
-		DisableUpdateCheck:                   config.DisableUpdateCheck,
 		HideK8sDetails:                       config.HideK8sDetails,
 		MCPRuntimeBackend:                    config.MCPRuntimeBackend,
 		MCPImagePullSecrets:                  config.MCPImagePullSecrets,
@@ -1400,6 +1400,17 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		svcs.ArtifactBlobStore = artifactBlobStore
 		svcs.ArtifactBlobBucket = "default"
 	}
+
+	versionChecker, err := upgrade.NewVersionChecker(ctx, upgrade.VersionCheckerOptions{
+		GatewayClient:      gatewayClient,
+		LicenseProvider:    licenseProvider,
+		Engine:             config.MCPRuntimeBackend,
+		DisableUpdateCheck: config.DisableUpdateCheck,
+	})
+	if err != nil {
+		return nil, err
+	}
+	svcs.VersionChecker = versionChecker
 
 	return svcs, nil
 }

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -1273,6 +1273,17 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	if mcp.IsKubernetesBackend(config.MCPRuntimeBackend) {
 		mcpLocalK8sClient = apiLocalK8sClient
 	}
+
+	versionChecker, err := upgrade.NewVersionChecker(ctx, upgrade.VersionCheckerOptions{
+		GatewayClient:      gatewayClient,
+		LicenseProvider:    licenseProvider,
+		Engine:             config.MCPRuntimeBackend,
+		DisableUpdateCheck: config.DisableUpdateCheck,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	// For now, always auto-migrate the gateway database
 	svcs := &Services{
 		EncryptionConfig:      encryptionConfig,
@@ -1374,6 +1385,7 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		MCPNetworkPolicyProviderValues:       config.MCPNetworkPolicyProviderValues,
 		ArtifactBlobBucket:                   config.ArtifactStorageBucket,
 		LicenseProvider:                      licenseProvider,
+		VersionChecker:                       versionChecker,
 	}
 
 	if (config.ArtifactStorageProvider == "") != (config.ArtifactStorageBucket == "") {
@@ -1400,17 +1412,6 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		svcs.ArtifactBlobStore = artifactBlobStore
 		svcs.ArtifactBlobBucket = "default"
 	}
-
-	versionChecker, err := upgrade.NewVersionChecker(ctx, upgrade.VersionCheckerOptions{
-		GatewayClient:      gatewayClient,
-		LicenseProvider:    licenseProvider,
-		Engine:             config.MCPRuntimeBackend,
-		DisableUpdateCheck: config.DisableUpdateCheck,
-	})
-	if err != nil {
-		return nil, err
-	}
-	svcs.VersionChecker = versionChecker
 
 	return svcs, nil
 }

--- a/pkg/upgrade/version_checker.go
+++ b/pkg/upgrade/version_checker.go
@@ -39,16 +39,6 @@ type validLicenseProvider interface {
 	HasValidLicense(context.Context) (bool, error)
 }
 
-type timer interface {
-	C() <-chan time.Time
-	Reset(time.Duration)
-	Stop()
-}
-
-type realTimer struct {
-	*time.Timer
-}
-
 type VersionChecker struct {
 	licenseProvider  validLicenseProvider
 	httpClient       *http.Client
@@ -58,7 +48,6 @@ type VersionChecker struct {
 	upgradeServerURL string
 	checkInterval    time.Duration
 	requestTimeout   time.Duration
-	newTimer         func(time.Duration) timer
 
 	statusLock sync.RWMutex
 	status     Status
@@ -72,18 +61,6 @@ type upgradeCheckResponse struct {
 	CurrentVersion   string `json:"currentVersion"`
 }
 
-func (t realTimer) C() <-chan time.Time {
-	return t.Timer.C
-}
-
-func (t realTimer) Reset(duration time.Duration) {
-	t.Timer.Reset(duration)
-}
-
-func (t realTimer) Stop() {
-	t.Timer.Stop()
-}
-
 func NewVersionChecker(ctx context.Context, opts VersionCheckerOptions) (*VersionChecker, error) {
 	checker := &VersionChecker{
 		licenseProvider:  opts.LicenseProvider,
@@ -93,10 +70,7 @@ func NewVersionChecker(ctx context.Context, opts VersionCheckerOptions) (*Versio
 		upgradeServerURL: EndpointURL(ServerBaseURL(), upgradeCheckEndpoint),
 		checkInterval:    upgradeCheckInterval,
 		requestTimeout:   upgradeCheckTimeout,
-		newTimer: func(duration time.Duration) timer {
-			return realTimer{Timer: time.NewTimer(duration)}
-		},
-		done: make(chan struct{}),
+		done:             make(chan struct{}),
 	}
 	if err := checker.start(ctx, opts.GatewayClient, opts.DisableUpdateCheck, os.Getenv("OBOT_FORCE_UPGRADE_CHECK") == "true"); err != nil {
 		return nil, err
@@ -138,7 +112,7 @@ func (c *VersionChecker) Status() Status {
 func (c *VersionChecker) run(ctx context.Context) {
 	defer close(c.done)
 
-	timer := c.newTimer(c.checkInterval)
+	timer := time.NewTimer(c.checkInterval)
 	defer timer.Stop()
 
 	for {
@@ -157,7 +131,7 @@ func (c *VersionChecker) run(ctx context.Context) {
 		case <-ctx.Done():
 			slog.Debug("upgrade check context cancelled, exiting")
 			return
-		case <-timer.C():
+		case <-timer.C:
 			timer.Reset(c.checkInterval)
 		}
 	}

--- a/pkg/upgrade/version_checker.go
+++ b/pkg/upgrade/version_checker.go
@@ -39,10 +39,6 @@ type validLicenseProvider interface {
 	HasValidLicense(context.Context) (bool, error)
 }
 
-type httpClient interface {
-	Do(*http.Request) (*http.Response, error)
-}
-
 type timer interface {
 	C() <-chan time.Time
 	Reset(time.Duration)
@@ -55,7 +51,7 @@ type realTimer struct {
 
 type VersionChecker struct {
 	licenseProvider  validLicenseProvider
-	httpClient       httpClient
+	httpClient       *http.Client
 	engine           string
 	installationID   string
 	currentVersion   string

--- a/pkg/upgrade/version_checker.go
+++ b/pkg/upgrade/version_checker.go
@@ -1,0 +1,210 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/gateway/client"
+	"github.com/obot-platform/obot/pkg/license"
+	"github.com/obot-platform/obot/pkg/version"
+)
+
+const (
+	upgradeCheckEndpoint = "check-upgrade"
+	upgradeCheckInterval = 24 * time.Hour
+	upgradeCheckTimeout  = 5 * time.Second
+)
+
+type Status struct {
+	UpgradeAvailable bool
+	LatestVersion    string
+}
+
+type VersionCheckerOptions struct {
+	GatewayClient      *client.Client
+	LicenseProvider    *license.Provider
+	Engine             string
+	DisableUpdateCheck bool
+}
+
+type validLicenseProvider interface {
+	HasValidLicense(context.Context) (bool, error)
+}
+
+type httpClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type timer interface {
+	C() <-chan time.Time
+	Reset(time.Duration)
+	Stop()
+}
+
+type realTimer struct {
+	*time.Timer
+}
+
+type VersionChecker struct {
+	licenseProvider  validLicenseProvider
+	httpClient       httpClient
+	engine           string
+	installationID   string
+	currentVersion   string
+	upgradeServerURL string
+	checkInterval    time.Duration
+	requestTimeout   time.Duration
+	newTimer         func(time.Duration) timer
+
+	statusLock sync.RWMutex
+	status     Status
+
+	done chan struct{}
+}
+
+type upgradeCheckResponse struct {
+	UpgradeAvailable bool   `json:"upgradeAvailable"`
+	LatestVersion    string `json:"latestVersion"`
+	CurrentVersion   string `json:"currentVersion"`
+}
+
+func (t realTimer) C() <-chan time.Time {
+	return t.Timer.C
+}
+
+func (t realTimer) Reset(duration time.Duration) {
+	t.Timer.Reset(duration)
+}
+
+func (t realTimer) Stop() {
+	t.Timer.Stop()
+}
+
+func NewVersionChecker(ctx context.Context, opts VersionCheckerOptions) (*VersionChecker, error) {
+	checker := &VersionChecker{
+		licenseProvider:  opts.LicenseProvider,
+		httpClient:       http.DefaultClient,
+		engine:           opts.Engine,
+		currentVersion:   version.Get().String(),
+		upgradeServerURL: EndpointURL(ServerBaseURL(), upgradeCheckEndpoint),
+		checkInterval:    upgradeCheckInterval,
+		requestTimeout:   upgradeCheckTimeout,
+		newTimer: func(duration time.Duration) timer {
+			return realTimer{Timer: time.NewTimer(duration)}
+		},
+		done: make(chan struct{}),
+	}
+	if err := checker.start(ctx, opts.GatewayClient, opts.DisableUpdateCheck, os.Getenv("OBOT_FORCE_UPGRADE_CHECK") == "true"); err != nil {
+		return nil, err
+	}
+	return checker, nil
+}
+
+func (c *VersionChecker) start(ctx context.Context, gatewayClient propertyClient, disableUpdateCheck, forceUpdateCheck bool) error {
+	c.currentVersion = normalizeVersion(c.currentVersion)
+
+	// Don't start the upgrade check if explicitly disabled or if this is a development version.
+	if disableUpdateCheck || (strings.HasPrefix(c.currentVersion, "v0.0.0") && !forceUpdateCheck) {
+		close(c.done)
+		return nil
+	}
+
+	installationID, err := GetInstallationID(ctx, gatewayClient)
+	if err != nil {
+		return err
+	}
+	c.installationID = installationID
+
+	go c.run(ctx)
+	return nil
+}
+
+func normalizeVersion(value string) string {
+	value, _, _ = strings.Cut(value, "+")
+	value, _, _ = strings.Cut(value, "-")
+	return value
+}
+
+func (c *VersionChecker) Status() Status {
+	c.statusLock.RLock()
+	defer c.statusLock.RUnlock()
+	return c.status
+}
+
+func (c *VersionChecker) run(ctx context.Context) {
+	defer close(c.done)
+
+	timer := c.newTimer(c.checkInterval)
+	defer timer.Stop()
+
+	for {
+		distribution := "oss"
+		hasValidLicense, err := c.licenseProvider.HasValidLicense(ctx)
+		if err != nil {
+			slog.Debug("failed to refresh license state for upgrade check", "error", err)
+		} else if hasValidLicense {
+			distribution = "enterprise"
+		}
+		if err := c.checkForUpgrade(ctx, distribution); err != nil {
+			slog.Debug("failed to check for server upgrade", "error", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			slog.Debug("upgrade check context cancelled, exiting")
+			return
+		case <-timer.C():
+			timer.Reset(c.checkInterval)
+		}
+	}
+}
+
+func (c *VersionChecker) checkForUpgrade(ctx context.Context, distribution string) error {
+	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.upgradeServerURL, nil)
+	if err != nil {
+		return err
+	}
+
+	query := req.URL.Query()
+	query.Set("uid", c.installationID)
+	query.Set("engine", c.engine)
+	query.Set("distribution", distribution)
+	query.Set("current-version", c.currentVersion)
+	req.URL.RawQuery = query.Encode()
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var status upgradeCheckResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		return err
+	}
+
+	c.statusLock.Lock()
+	c.status = Status{
+		UpgradeAvailable: status.UpgradeAvailable,
+		LatestVersion:    status.LatestVersion,
+	}
+	c.statusLock.Unlock()
+
+	return nil
+}

--- a/pkg/upgrade/version_checker.go
+++ b/pkg/upgrade/version_checker.go
@@ -118,7 +118,7 @@ func (c *VersionChecker) run(ctx context.Context) {
 	defer timer.Stop()
 
 	for {
-		distribution := clienttypes.ProductTelemetryDistributionUnlicensed
+		distribution := clienttypes.ProductTelemetryDistributionUnregistered
 		entitlements, err := c.licenseProvider.Entitlements(ctx)
 		switch {
 		case err != nil:
@@ -128,7 +128,7 @@ func (c *VersionChecker) run(ctx context.Context) {
 		case slices.Contains(entitlements, license.EnterpriseEntitlement):
 			distribution = clienttypes.ProductTelemetryDistributionEnterprise
 		case slices.Contains(entitlements, license.CommunityEntitlement):
-			distribution = clienttypes.ProductTelemetryDistributionCommunity
+			distribution = clienttypes.ProductTelemetryDistributionRegistered
 		}
 		if err := c.checkForUpgrade(ctx, distribution); err != nil {
 			slog.Debug("failed to check for server upgrade", "error", err)

--- a/pkg/upgrade/version_checker.go
+++ b/pkg/upgrade/version_checker.go
@@ -8,10 +8,12 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
+	clienttypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/gateway/client"
 	"github.com/obot-platform/obot/pkg/license"
 	"github.com/obot-platform/obot/pkg/version"
@@ -35,12 +37,12 @@ type VersionCheckerOptions struct {
 	DisableUpdateCheck bool
 }
 
-type validLicenseProvider interface {
-	HasValidLicense(context.Context) (bool, error)
+type entitlementProvider interface {
+	Entitlements(context.Context) ([]string, error)
 }
 
 type VersionChecker struct {
-	licenseProvider  validLicenseProvider
+	licenseProvider  entitlementProvider
 	httpClient       *http.Client
 	engine           string
 	installationID   string
@@ -116,12 +118,17 @@ func (c *VersionChecker) run(ctx context.Context) {
 	defer timer.Stop()
 
 	for {
-		distribution := "oss"
-		hasValidLicense, err := c.licenseProvider.HasValidLicense(ctx)
-		if err != nil {
+		distribution := clienttypes.ProductTelemetryDistributionUnlicensed
+		entitlements, err := c.licenseProvider.Entitlements(ctx)
+		switch {
+		case err != nil:
 			slog.Debug("failed to refresh license state for upgrade check", "error", err)
-		} else if hasValidLicense {
-			distribution = "enterprise"
+		case slices.Contains(entitlements, license.CloudEntitlement):
+			distribution = clienttypes.ProductTelemetryDistributionCloud
+		case slices.Contains(entitlements, license.EnterpriseEntitlement):
+			distribution = clienttypes.ProductTelemetryDistributionEnterprise
+		case slices.Contains(entitlements, license.CommunityEntitlement):
+			distribution = clienttypes.ProductTelemetryDistributionCommunity
 		}
 		if err := c.checkForUpgrade(ctx, distribution); err != nil {
 			slog.Debug("failed to check for server upgrade", "error", err)
@@ -137,7 +144,7 @@ func (c *VersionChecker) run(ctx context.Context) {
 	}
 }
 
-func (c *VersionChecker) checkForUpgrade(ctx context.Context, distribution string) error {
+func (c *VersionChecker) checkForUpgrade(ctx context.Context, distribution clienttypes.ProductTelemetryDistribution) error {
 	ctx, cancel := context.WithTimeout(ctx, c.requestTimeout)
 	defer cancel()
 
@@ -149,7 +156,7 @@ func (c *VersionChecker) checkForUpgrade(ctx context.Context, distribution strin
 	query := req.URL.Query()
 	query.Set("uid", c.installationID)
 	query.Set("engine", c.engine)
-	query.Set("distribution", distribution)
+	query.Set("distribution", string(distribution))
 	query.Set("current-version", c.currentVersion)
 	req.URL.RawQuery = query.Encode()
 

--- a/pkg/upgrade/version_checker_test.go
+++ b/pkg/upgrade/version_checker_test.go
@@ -1,0 +1,351 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+)
+
+type checkerPropertyClient struct {
+	lock  sync.Mutex
+	value string
+	calls int
+	err   error
+}
+
+type checkerLicenseProvider struct {
+	valid bool
+	err   error
+}
+
+type manualTimer struct {
+	c chan time.Time
+}
+
+func (c *checkerPropertyClient) GetOrCreateProperty(_ context.Context, key, value string) (gatewaytypes.Property, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.calls++
+	if c.err != nil {
+		return gatewaytypes.Property{}, c.err
+	}
+	if c.value == "" {
+		c.value = value
+	}
+	return gatewaytypes.Property{Key: key, Value: c.value}, nil
+}
+
+func (c *checkerPropertyClient) callCount() int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.calls
+}
+
+func (p checkerLicenseProvider) HasValidLicense(context.Context) (bool, error) {
+	return p.valid, p.err
+}
+
+func newManualTimer() *manualTimer {
+	return &manualTimer{c: make(chan time.Time, 1)}
+}
+
+func (t *manualTimer) C() <-chan time.Time { return t.c }
+func (t *manualTimer) Reset(time.Duration) {}
+func (t *manualTimer) Stop()               {}
+
+func testVersionChecker(licenseProvider validLicenseProvider, serverURL string, testTimer timer) *VersionChecker {
+	return &VersionChecker{
+		licenseProvider:  licenseProvider,
+		httpClient:       http.DefaultClient,
+		engine:           "docker",
+		currentVersion:   "v1.2.3",
+		upgradeServerURL: serverURL,
+		checkInterval:    upgradeCheckInterval,
+		requestTimeout:   upgradeCheckTimeout,
+		newTimer: func(time.Duration) timer {
+			return testTimer
+		},
+		done: make(chan struct{}),
+	}
+}
+
+func waitForRequest(t *testing.T, requests <-chan *http.Request) *http.Request {
+	t.Helper()
+	select {
+	case request := <-requests:
+		return request
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upgrade request")
+		return nil
+	}
+}
+
+func waitForDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for checker to stop")
+	}
+}
+
+func waitForStatus(t *testing.T, checker *VersionChecker, expected Status) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if checker.Status() == expected {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("Status() = %#v, want %#v", checker.Status(), expected)
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	for _, test := range []struct {
+		value string
+		want  string
+	}{
+		{value: "v1.2.3", want: "v1.2.3"},
+		{value: "v1.2.3+build.4", want: "v1.2.3"},
+		{value: "v1.2.3-rc.1", want: "v1.2.3"},
+		{value: "v1.2.3-rc.1+build.4", want: "v1.2.3"},
+	} {
+		t.Run(test.value, func(t *testing.T) {
+			if got := normalizeVersion(test.value); got != test.want {
+				t.Fatalf("normalizeVersion(%q) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestVersionCheckerDoesNotStartWhenDisabledOrDevelopment(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		disabled bool
+		version  string
+	}{
+		{name: "disabled", disabled: true, version: "v1.2.3"},
+		{name: "development", version: "v0.0.0-dev"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			propertyClient := &checkerPropertyClient{}
+			checker := &VersionChecker{currentVersion: test.version, done: make(chan struct{})}
+			if err := checker.start(t.Context(), propertyClient, test.disabled, false); err != nil {
+				t.Fatalf("start() error = %v", err)
+			}
+			if calls := propertyClient.callCount(); calls != 0 {
+				t.Fatalf("installation property calls = %d, want 0", calls)
+			}
+			waitForDone(t, checker.done)
+			if got := checker.Status(); got != (Status{}) {
+				t.Fatalf("Status() = %#v", got)
+			}
+		})
+	}
+}
+
+func TestVersionCheckerInstallationIDFailureIsSynchronous(t *testing.T) {
+	wantErr := errors.New("database unavailable")
+	checker := &VersionChecker{currentVersion: "v1.2.3", done: make(chan struct{})}
+	err := checker.start(t.Context(), &checkerPropertyClient{err: wantErr}, false, false)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("start() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestVersionCheckerChecksImmediatelyAndOnSchedule(t *testing.T) {
+	requests := make(chan *http.Request, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests <- request.Clone(request.Context())
+		_ = json.NewEncoder(w).Encode(upgradeCheckResponse{
+			UpgradeAvailable: true,
+			LatestVersion:    "v1.3.0",
+			CurrentVersion:   "v1.2.3",
+		})
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	propertyClient := &checkerPropertyClient{value: "installation-1"}
+	testTimer := newManualTimer()
+	checker := testVersionChecker(checkerLicenseProvider{valid: true}, server.URL+"/check-upgrade", testTimer)
+	checker.currentVersion = "v1.2.3-rc.1+build.4"
+	if err := checker.start(ctx, propertyClient, false, true); err != nil {
+		t.Fatalf("start() error = %v", err)
+	}
+
+	request := waitForRequest(t, requests)
+	if request.Method != http.MethodGet {
+		t.Fatalf("method = %q, want GET", request.Method)
+	}
+	if request.URL.Path != "/check-upgrade" {
+		t.Fatalf("path = %q", request.URL.Path)
+	}
+	query := request.URL.Query()
+	for key, want := range map[string]string{
+		"uid":             "installation-1",
+		"engine":          "docker",
+		"distribution":    "enterprise",
+		"current-version": "v1.2.3",
+	} {
+		if got := query.Get(key); got != want {
+			t.Errorf("query %q = %q, want %q", key, got, want)
+		}
+	}
+	waitForStatus(t, checker, Status{UpgradeAvailable: true, LatestVersion: "v1.3.0"})
+
+	testTimer.c <- time.Now()
+	waitForRequest(t, requests)
+
+	cancel()
+	waitForDone(t, checker.done)
+}
+
+func TestVersionCheckerDevelopmentVersionCanBeForced(t *testing.T) {
+	requests := make(chan *http.Request, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests <- request.Clone(request.Context())
+		_, _ = w.Write([]byte(`{"upgradeAvailable":false,"latestVersion":""}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	checker := testVersionChecker(checkerLicenseProvider{}, server.URL, newManualTimer())
+	checker.currentVersion = "v0.0.0-dev"
+	if err := checker.start(ctx, &checkerPropertyClient{value: "installation"}, false, true); err != nil {
+		t.Fatalf("start() error = %v", err)
+	}
+	waitForRequest(t, requests)
+	cancel()
+	waitForDone(t, checker.done)
+}
+
+func TestVersionCheckerDistribution(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		provider checkerLicenseProvider
+		want     string
+	}{
+		{name: "enterprise", provider: checkerLicenseProvider{valid: true}, want: "enterprise"},
+		{name: "oss", provider: checkerLicenseProvider{}, want: "oss"},
+		{name: "license error", provider: checkerLicenseProvider{err: errors.New("refresh failed")}, want: "oss"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			requests := make(chan *http.Request, 2)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				requests <- request.Clone(request.Context())
+				_, _ = w.Write([]byte(`{"upgradeAvailable":false,"latestVersion":""}`))
+			}))
+			defer server.Close()
+
+			ctx, cancel := context.WithCancel(t.Context())
+			checker := testVersionChecker(test.provider, server.URL, newManualTimer())
+			if err := checker.start(ctx, &checkerPropertyClient{value: "installation"}, false, false); err != nil {
+				t.Fatalf("start() error = %v", err)
+			}
+			request := waitForRequest(t, requests)
+			if got := request.URL.Query().Get("distribution"); got != test.want {
+				t.Fatalf("distribution = %q, want %q", got, test.want)
+			}
+			cancel()
+			waitForDone(t, checker.done)
+		})
+	}
+}
+
+func TestVersionCheckerResponseFailuresDoNotChangeStatusOrStopSchedule(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "non-OK", statusCode: http.StatusBadGateway, body: "upgrade server unavailable"},
+		{name: "malformed JSON", statusCode: http.StatusOK, body: `{"upgradeAvailable":`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			requests := make(chan *http.Request, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				requests <- request.Clone(request.Context())
+				w.WriteHeader(test.statusCode)
+				_, _ = w.Write([]byte(test.body))
+			}))
+			defer server.Close()
+
+			ctx, cancel := context.WithCancel(t.Context())
+			testTimer := newManualTimer()
+			checker := testVersionChecker(checkerLicenseProvider{}, server.URL, testTimer)
+			if err := checker.start(ctx, &checkerPropertyClient{value: "installation"}, false, false); err != nil {
+				t.Fatalf("start() error = %v", err)
+			}
+			waitForRequest(t, requests)
+			testTimer.c <- time.Now()
+			waitForRequest(t, requests)
+			if got := checker.Status(); got != (Status{}) {
+				t.Fatalf("Status() = %#v, want zero status", got)
+			}
+			select {
+			case <-checker.done:
+				t.Fatal("checker stopped after request failure")
+			default:
+			}
+			cancel()
+			waitForDone(t, checker.done)
+		})
+	}
+}
+
+func TestVersionCheckerRequestTimeoutDoesNotStopSchedule(t *testing.T) {
+	requests := make(chan struct{}, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		requests <- struct{}{}
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	testTimer := newManualTimer()
+	checker := testVersionChecker(checkerLicenseProvider{}, server.URL, testTimer)
+	checker.requestTimeout = 20 * time.Millisecond
+	if err := checker.start(ctx, &checkerPropertyClient{value: "installation"}, false, false); err != nil {
+		t.Fatalf("start() error = %v", err)
+	}
+	select {
+	case <-requests:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+	testTimer.c <- time.Now()
+	select {
+	case <-requests:
+	case <-time.After(2 * time.Second):
+		t.Fatal("checker did not run again after request timeout")
+	}
+	cancel()
+	waitForDone(t, checker.done)
+}
+
+func TestVersionCheckerStatusSupportsConcurrentReaders(_ *testing.T) {
+	checker := &VersionChecker{}
+	var readers sync.WaitGroup
+	for range 20 {
+		readers.Go(func() {
+			for range 100 {
+				_ = checker.Status()
+			}
+		})
+	}
+	for range 100 {
+		checker.statusLock.Lock()
+		checker.status = Status{UpgradeAvailable: true, LatestVersion: "v1.3.0"}
+		checker.statusLock.Unlock()
+	}
+	readers.Wait()
+}

--- a/pkg/upgrade/version_checker_test.go
+++ b/pkg/upgrade/version_checker_test.go
@@ -249,9 +249,9 @@ func TestVersionCheckerDistribution(t *testing.T) {
 			want:     clienttypes.ProductTelemetryDistributionEnterprise,
 		},
 		{
-			name:     "community",
+			name:     "registered",
 			provider: checkerLicenseProvider{entitlements: []string{license.CommunityEntitlement}},
-			want:     clienttypes.ProductTelemetryDistributionCommunity,
+			want:     clienttypes.ProductTelemetryDistributionRegistered,
 		},
 		{
 			name: "enterprise takes precedence",
@@ -271,14 +271,14 @@ func TestVersionCheckerDistribution(t *testing.T) {
 			want: clienttypes.ProductTelemetryDistributionCloud,
 		},
 		{
-			name:     "unlicensed",
+			name:     "unregistered",
 			provider: checkerLicenseProvider{},
-			want:     clienttypes.ProductTelemetryDistributionUnlicensed,
+			want:     clienttypes.ProductTelemetryDistributionUnregistered,
 		},
 		{
 			name:     "license error",
 			provider: checkerLicenseProvider{err: errors.New("refresh failed")},
-			want:     clienttypes.ProductTelemetryDistributionUnlicensed,
+			want:     clienttypes.ProductTelemetryDistributionUnregistered,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/upgrade/version_checker_test.go
+++ b/pkg/upgrade/version_checker_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	clienttypes "github.com/obot-platform/obot/apiclient/types"
 	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	"github.com/obot-platform/obot/pkg/license"
 )
 
 type checkerPropertyClient struct {
@@ -21,8 +23,8 @@ type checkerPropertyClient struct {
 }
 
 type checkerLicenseProvider struct {
-	valid bool
-	err   error
+	entitlements []string
+	err          error
 }
 
 func (c *checkerPropertyClient) GetOrCreateProperty(_ context.Context, key, value string) (gatewaytypes.Property, error) {
@@ -44,11 +46,11 @@ func (c *checkerPropertyClient) callCount() int {
 	return c.calls
 }
 
-func (p checkerLicenseProvider) HasValidLicense(context.Context) (bool, error) {
-	return p.valid, p.err
+func (p checkerLicenseProvider) Entitlements(context.Context) ([]string, error) {
+	return p.entitlements, p.err
 }
 
-func testVersionChecker(licenseProvider validLicenseProvider, serverURL string) *VersionChecker {
+func testVersionChecker(licenseProvider entitlementProvider, serverURL string) *VersionChecker {
 	return &VersionChecker{
 		licenseProvider:  licenseProvider,
 		httpClient:       http.DefaultClient,
@@ -179,7 +181,7 @@ func TestVersionCheckerChecksImmediatelyAndOnSchedule(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	propertyClient := &checkerPropertyClient{value: "installation-1"}
-	checker := testVersionChecker(checkerLicenseProvider{valid: true}, server.URL+"/check-upgrade")
+	checker := testVersionChecker(checkerLicenseProvider{entitlements: []string{license.EnterpriseEntitlement}}, server.URL+"/check-upgrade")
 	checker.currentVersion = "v1.2.3-rc.1+build.4"
 	if err := checker.start(ctx, propertyClient, false, true); err != nil {
 		t.Fatalf("start() error = %v", err)
@@ -196,7 +198,7 @@ func TestVersionCheckerChecksImmediatelyAndOnSchedule(t *testing.T) {
 	for key, want := range map[string]string{
 		"uid":             "installation-1",
 		"engine":          "docker",
-		"distribution":    "enterprise",
+		"distribution":    string(clienttypes.ProductTelemetryDistributionEnterprise),
 		"current-version": "v1.2.3",
 	} {
 		if got := query.Get(key); got != want {
@@ -234,22 +236,49 @@ func TestVersionCheckerDistribution(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		provider checkerLicenseProvider
-		want     string
+		want     clienttypes.ProductTelemetryDistribution
 	}{
 		{
-			name:     "enterprise",
-			provider: checkerLicenseProvider{valid: true},
-			want:     "enterprise",
+			name:     "cloud",
+			provider: checkerLicenseProvider{entitlements: []string{license.CloudEntitlement}},
+			want:     clienttypes.ProductTelemetryDistributionCloud,
 		},
 		{
-			name:     "oss",
+			name:     "enterprise",
+			provider: checkerLicenseProvider{entitlements: []string{license.EnterpriseEntitlement}},
+			want:     clienttypes.ProductTelemetryDistributionEnterprise,
+		},
+		{
+			name:     "community",
+			provider: checkerLicenseProvider{entitlements: []string{license.CommunityEntitlement}},
+			want:     clienttypes.ProductTelemetryDistributionCommunity,
+		},
+		{
+			name: "enterprise takes precedence",
+			provider: checkerLicenseProvider{entitlements: []string{
+				license.CommunityEntitlement,
+				license.EnterpriseEntitlement,
+			}},
+			want: clienttypes.ProductTelemetryDistributionEnterprise,
+		},
+		{
+			name: "cloud takes precedence",
+			provider: checkerLicenseProvider{entitlements: []string{
+				license.CommunityEntitlement,
+				license.EnterpriseEntitlement,
+				license.CloudEntitlement,
+			}},
+			want: clienttypes.ProductTelemetryDistributionCloud,
+		},
+		{
+			name:     "unlicensed",
 			provider: checkerLicenseProvider{},
-			want:     "oss",
+			want:     clienttypes.ProductTelemetryDistributionUnlicensed,
 		},
 		{
 			name:     "license error",
 			provider: checkerLicenseProvider{err: errors.New("refresh failed")},
-			want:     "oss",
+			want:     clienttypes.ProductTelemetryDistributionUnlicensed,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -266,7 +295,7 @@ func TestVersionCheckerDistribution(t *testing.T) {
 				t.Fatalf("start() error = %v", err)
 			}
 			request := waitForRequest(t, requests)
-			if got := request.URL.Query().Get("distribution"); got != test.want {
+			if got := request.URL.Query().Get("distribution"); got != string(test.want) {
 				t.Fatalf("distribution = %q, want %q", got, test.want)
 			}
 			cancel()

--- a/pkg/upgrade/version_checker_test.go
+++ b/pkg/upgrade/version_checker_test.go
@@ -113,10 +113,22 @@ func TestNormalizeVersion(t *testing.T) {
 		value string
 		want  string
 	}{
-		{value: "v1.2.3", want: "v1.2.3"},
-		{value: "v1.2.3+build.4", want: "v1.2.3"},
-		{value: "v1.2.3-rc.1", want: "v1.2.3"},
-		{value: "v1.2.3-rc.1+build.4", want: "v1.2.3"},
+		{
+			value: "v1.2.3",
+			want:  "v1.2.3",
+		},
+		{
+			value: "v1.2.3+build.4",
+			want:  "v1.2.3",
+		},
+		{
+			value: "v1.2.3-rc.1",
+			want:  "v1.2.3",
+		},
+		{
+			value: "v1.2.3-rc.1+build.4",
+			want:  "v1.2.3",
+		},
 	} {
 		t.Run(test.value, func(t *testing.T) {
 			if got := normalizeVersion(test.value); got != test.want {
@@ -132,8 +144,15 @@ func TestVersionCheckerDoesNotStartWhenDisabledOrDevelopment(t *testing.T) {
 		disabled bool
 		version  string
 	}{
-		{name: "disabled", disabled: true, version: "v1.2.3"},
-		{name: "development", version: "v0.0.0-dev"},
+		{
+			name:     "disabled",
+			disabled: true,
+			version:  "v1.2.3",
+		},
+		{
+			name:    "development",
+			version: "v0.0.0-dev",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			propertyClient := &checkerPropertyClient{}
@@ -234,9 +253,21 @@ func TestVersionCheckerDistribution(t *testing.T) {
 		provider checkerLicenseProvider
 		want     string
 	}{
-		{name: "enterprise", provider: checkerLicenseProvider{valid: true}, want: "enterprise"},
-		{name: "oss", provider: checkerLicenseProvider{}, want: "oss"},
-		{name: "license error", provider: checkerLicenseProvider{err: errors.New("refresh failed")}, want: "oss"},
+		{
+			name:     "enterprise",
+			provider: checkerLicenseProvider{valid: true},
+			want:     "enterprise",
+		},
+		{
+			name:     "oss",
+			provider: checkerLicenseProvider{},
+			want:     "oss",
+		},
+		{
+			name:     "license error",
+			provider: checkerLicenseProvider{err: errors.New("refresh failed")},
+			want:     "oss",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			requests := make(chan *http.Request, 2)
@@ -267,8 +298,16 @@ func TestVersionCheckerResponseFailuresDoNotChangeStatusOrStopSchedule(t *testin
 		statusCode int
 		body       string
 	}{
-		{name: "non-OK", statusCode: http.StatusBadGateway, body: "upgrade server unavailable"},
-		{name: "malformed JSON", statusCode: http.StatusOK, body: `{"upgradeAvailable":`},
+		{
+			name:       "non-OK",
+			statusCode: http.StatusBadGateway,
+			body:       "upgrade server unavailable",
+		},
+		{
+			name:       "malformed JSON",
+			statusCode: http.StatusOK,
+			body:       `{"upgradeAvailable":`,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			requests := make(chan *http.Request, 1)

--- a/pkg/upgrade/version_checker_test.go
+++ b/pkg/upgrade/version_checker_test.go
@@ -25,10 +25,6 @@ type checkerLicenseProvider struct {
 	err   error
 }
 
-type manualTimer struct {
-	c chan time.Time
-}
-
 func (c *checkerPropertyClient) GetOrCreateProperty(_ context.Context, key, value string) (gatewaytypes.Property, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -52,27 +48,16 @@ func (p checkerLicenseProvider) HasValidLicense(context.Context) (bool, error) {
 	return p.valid, p.err
 }
 
-func newManualTimer() *manualTimer {
-	return &manualTimer{c: make(chan time.Time, 1)}
-}
-
-func (t *manualTimer) C() <-chan time.Time { return t.c }
-func (t *manualTimer) Reset(time.Duration) {}
-func (t *manualTimer) Stop()               {}
-
-func testVersionChecker(licenseProvider validLicenseProvider, serverURL string, testTimer timer) *VersionChecker {
+func testVersionChecker(licenseProvider validLicenseProvider, serverURL string) *VersionChecker {
 	return &VersionChecker{
 		licenseProvider:  licenseProvider,
 		httpClient:       http.DefaultClient,
 		engine:           "docker",
 		currentVersion:   "v1.2.3",
 		upgradeServerURL: serverURL,
-		checkInterval:    upgradeCheckInterval,
+		checkInterval:    10 * time.Millisecond,
 		requestTimeout:   upgradeCheckTimeout,
-		newTimer: func(time.Duration) timer {
-			return testTimer
-		},
-		done: make(chan struct{}),
+		done:             make(chan struct{}),
 	}
 }
 
@@ -194,8 +179,7 @@ func TestVersionCheckerChecksImmediatelyAndOnSchedule(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	propertyClient := &checkerPropertyClient{value: "installation-1"}
-	testTimer := newManualTimer()
-	checker := testVersionChecker(checkerLicenseProvider{valid: true}, server.URL+"/check-upgrade", testTimer)
+	checker := testVersionChecker(checkerLicenseProvider{valid: true}, server.URL+"/check-upgrade")
 	checker.currentVersion = "v1.2.3-rc.1+build.4"
 	if err := checker.start(ctx, propertyClient, false, true); err != nil {
 		t.Fatalf("start() error = %v", err)
@@ -221,7 +205,6 @@ func TestVersionCheckerChecksImmediatelyAndOnSchedule(t *testing.T) {
 	}
 	waitForStatus(t, checker, Status{UpgradeAvailable: true, LatestVersion: "v1.3.0"})
 
-	testTimer.c <- time.Now()
 	waitForRequest(t, requests)
 
 	cancel()
@@ -237,7 +220,7 @@ func TestVersionCheckerDevelopmentVersionCanBeForced(t *testing.T) {
 	defer server.Close()
 
 	ctx, cancel := context.WithCancel(t.Context())
-	checker := testVersionChecker(checkerLicenseProvider{}, server.URL, newManualTimer())
+	checker := testVersionChecker(checkerLicenseProvider{}, server.URL)
 	checker.currentVersion = "v0.0.0-dev"
 	if err := checker.start(ctx, &checkerPropertyClient{value: "installation"}, false, true); err != nil {
 		t.Fatalf("start() error = %v", err)
@@ -278,7 +261,7 @@ func TestVersionCheckerDistribution(t *testing.T) {
 			defer server.Close()
 
 			ctx, cancel := context.WithCancel(t.Context())
-			checker := testVersionChecker(test.provider, server.URL, newManualTimer())
+			checker := testVersionChecker(test.provider, server.URL)
 			if err := checker.start(ctx, &checkerPropertyClient{value: "installation"}, false, false); err != nil {
 				t.Fatalf("start() error = %v", err)
 			}
@@ -319,13 +302,11 @@ func TestVersionCheckerResponseFailuresDoNotChangeStatusOrStopSchedule(t *testin
 			defer server.Close()
 
 			ctx, cancel := context.WithCancel(t.Context())
-			testTimer := newManualTimer()
-			checker := testVersionChecker(checkerLicenseProvider{}, server.URL, testTimer)
+			checker := testVersionChecker(checkerLicenseProvider{}, server.URL)
 			if err := checker.start(ctx, &checkerPropertyClient{value: "installation"}, false, false); err != nil {
 				t.Fatalf("start() error = %v", err)
 			}
 			waitForRequest(t, requests)
-			testTimer.c <- time.Now()
 			waitForRequest(t, requests)
 			if got := checker.Status(); got != (Status{}) {
 				t.Fatalf("Status() = %#v, want zero status", got)
@@ -350,8 +331,7 @@ func TestVersionCheckerRequestTimeoutDoesNotStopSchedule(t *testing.T) {
 	defer server.Close()
 
 	ctx, cancel := context.WithCancel(t.Context())
-	testTimer := newManualTimer()
-	checker := testVersionChecker(checkerLicenseProvider{}, server.URL, testTimer)
+	checker := testVersionChecker(checkerLicenseProvider{}, server.URL)
 	checker.requestTimeout = 20 * time.Millisecond
 	if err := checker.start(ctx, &checkerPropertyClient{value: "installation"}, false, false); err != nil {
 		t.Fatalf("start() error = %v", err)
@@ -361,7 +341,6 @@ func TestVersionCheckerRequestTimeoutDoesNotStopSchedule(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for request")
 	}
-	testTimer.c <- time.Now()
 	select {
 	case <-requests:
 	case <-time.After(2 * time.Second):


### PR DESCRIPTION
This change is not strictly necessary, but fixes an organization issue I saw while investigating implementation for a new feature. The background polling job for new Obot versions is not related to the `/version` route handler, so it's moved to a new package and tested more thoroughly.