### PR TITLE
ui asset 404 user agent gate

### DIFF
--- a/ui/handler.go
+++ b/ui/handler.go
@@ -20,10 +20,13 @@ var (
 type uiServer struct {
 	rp       *httputil.ReverseProxy
 	userOnly bool
+	// fsys holds the built UI. It is a field so tests can supply a stub in place
+	// of the embedded build, which only exists after `make ui`.
+	fsys fs.FS
 }
 
 func Handler(devPort, userOnlyPort int) http.Handler {
-	server := &uiServer{}
+	server := &uiServer{fsys: embedded}
 
 	if userOnlyPort != 0 {
 		server.rp = newUIProxy(userOnlyPort)
@@ -61,33 +64,35 @@ func (s *uiServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !strings.Contains(strings.ToLower(r.UserAgent()), "mozilla") {
-		http.NotFound(w, r)
-		return
-	}
-
 	userPath := path.Join("user/build/", r.URL.Path)
 
 	if r.URL.Path == "/" {
-		http.ServeFileFS(w, r, embedded, "user/build/index.html")
+		http.ServeFileFS(w, r, s.fsys, "user/build/index.html")
 	} else if r.URL.Path == "/admin" {
-		http.ServeFileFS(w, r, embedded, "user/build/admin.html")
+		http.ServeFileFS(w, r, s.fsys, "user/build/admin.html")
 	} else if r.URL.Path == "/admin/" {
 		// we have to redirect to /admin instead of serving the index.html file because ending slash will laod a different route for js files
 		http.Redirect(w, r, "/admin", http.StatusFound)
 	} else if r.URL.Path == "/mcp-servers/" {
 		http.Redirect(w, r, "/mcp-servers", http.StatusFound)
 	} else if r.URL.Path == "/mcp-servers" {
-		http.ServeFileFS(w, r, embedded, "user/build/mcp-servers.html")
+		http.ServeFileFS(w, r, s.fsys, "user/build/mcp-servers.html")
 	} else if pathWithoutTrailingSlash, ok := strings.CutSuffix(r.URL.Path, "/"); ok {
 		// Paths with trailing slashes should redirect to without slash to avoid directory listings
 		http.Redirect(w, r, pathWithoutTrailingSlash, http.StatusFound)
-	} else if _, err := fs.Stat(embedded, userPath+".html"); err == nil {
+	} else if _, err := fs.Stat(s.fsys, userPath+".html"); err == nil {
 		// Try .html version first (for SvelteKit prerendered pages)
-		http.ServeFileFS(w, r, embedded, userPath+".html")
-	} else if _, err := fs.Stat(embedded, userPath); err == nil {
-		http.ServeFileFS(w, r, embedded, userPath)
+		http.ServeFileFS(w, r, s.fsys, userPath+".html")
+	} else if _, err := fs.Stat(s.fsys, userPath); err == nil {
+		http.ServeFileFS(w, r, s.fsys, userPath)
+	} else if !strings.Contains(strings.ToLower(r.UserAgent()), "mozilla") {
+		// Non-browser clients get a real 404 for unknown paths rather than the SPA
+		// fallback, so a mistyped API path doesn't return HTML with a 200. no-store
+		// keeps CDNs and browsers from caching this against a URL that may exist on
+		// the next deploy.
+		w.Header().Set("Cache-Control", "no-store")
+		http.NotFound(w, r)
 	} else {
-		http.ServeFileFS(w, r, embedded, "user/build/fallback.html")
+		http.ServeFileFS(w, r, s.fsys, "user/build/fallback.html")
 	}
 }

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -17,6 +17,9 @@ var (
 	embedded embed.FS
 )
 
+// immutablePrefix is where the UI build puts its content-hashed assets.
+const immutablePrefix = "/_app/immutable/"
+
 type uiServer struct {
 	rp       *httputil.ReverseProxy
 	userOnly bool
@@ -51,6 +54,16 @@ func newUIProxy(port int) *httputil.ReverseProxy {
 	}
 }
 
+// serveHTML serves one of the UI's HTML entry points. Each one names the
+// content-hashed assets of the build it came from, and those assets only exist
+// in that build's binary, so a stale copy asks for chunks the running binary
+// does not have. no-cache still lets a client hold onto it, but forces a
+// revalidation before it is used.
+func (s *uiServer) serveHTML(w http.ResponseWriter, r *http.Request, name string) {
+	w.Header().Set("Cache-Control", "no-cache")
+	http.ServeFileFS(w, r, s.fsys, name)
+}
+
 func (s *uiServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Always include the X-Frame-Options header
 	w.Header().Set("X-Frame-Options", "DENY")
@@ -67,23 +80,28 @@ func (s *uiServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	userPath := path.Join("user/build/", r.URL.Path)
 
 	if r.URL.Path == "/" {
-		http.ServeFileFS(w, r, s.fsys, "user/build/index.html")
+		s.serveHTML(w, r, "user/build/index.html")
 	} else if r.URL.Path == "/admin" {
-		http.ServeFileFS(w, r, s.fsys, "user/build/admin.html")
+		s.serveHTML(w, r, "user/build/admin.html")
 	} else if r.URL.Path == "/admin/" {
 		// we have to redirect to /admin instead of serving the index.html file because ending slash will laod a different route for js files
 		http.Redirect(w, r, "/admin", http.StatusFound)
 	} else if r.URL.Path == "/mcp-servers/" {
 		http.Redirect(w, r, "/mcp-servers", http.StatusFound)
 	} else if r.URL.Path == "/mcp-servers" {
-		http.ServeFileFS(w, r, s.fsys, "user/build/mcp-servers.html")
+		s.serveHTML(w, r, "user/build/mcp-servers.html")
 	} else if pathWithoutTrailingSlash, ok := strings.CutSuffix(r.URL.Path, "/"); ok {
 		// Paths with trailing slashes should redirect to without slash to avoid directory listings
 		http.Redirect(w, r, pathWithoutTrailingSlash, http.StatusFound)
 	} else if _, err := fs.Stat(s.fsys, userPath+".html"); err == nil {
 		// Try .html version first (for SvelteKit prerendered pages)
-		http.ServeFileFS(w, r, s.fsys, userPath+".html")
+		s.serveHTML(w, r, userPath+".html")
 	} else if _, err := fs.Stat(s.fsys, userPath); err == nil {
+		if strings.HasPrefix(r.URL.Path, immutablePrefix) {
+			// These filenames carry a hash of their contents, so what a given URL
+			// returns can never change and the client never has to ask again.
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		}
 		http.ServeFileFS(w, r, s.fsys, userPath)
 	} else if !strings.Contains(strings.ToLower(r.UserAgent()), "mozilla") {
 		// Non-browser clients get a real 404 for unknown paths rather than the SPA
@@ -93,6 +111,6 @@ func (s *uiServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
 		http.NotFound(w, r)
 	} else {
-		http.ServeFileFS(w, r, s.fsys, "user/build/fallback.html")
+		s.serveHTML(w, r, "user/build/fallback.html")
 	}
 }

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -12,13 +12,15 @@ import (
 	"github.com/obot-platform/obot/pkg/oauth"
 )
 
+const (
+	// immutablePrefix is where the UI build puts its content-hashed assets.
+	immutablePrefix = "/_app/immutable/"
+)
+
 var (
 	//go:embed all:user/*build
 	embedded embed.FS
 )
-
-// immutablePrefix is where the UI build puts its content-hashed assets.
-const immutablePrefix = "/_app/immutable/"
 
 type uiServer struct {
 	rp       *httputil.ReverseProxy

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -10,7 +10,9 @@ import (
 	"testing/fstest"
 )
 
-const chromeUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+const (
+	chromeUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+)
 
 func testUIServer() *uiServer {
 	return &uiServer{fsys: fstest.MapFS{

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -7,7 +7,69 @@ import (
 	"net/url"
 	"strconv"
 	"testing"
+	"testing/fstest"
 )
+
+const chromeUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+
+func testUIServer() *uiServer {
+	return &uiServer{fsys: fstest.MapFS{
+		"user/build/index.html":                       {Data: []byte("<html>index</html>")},
+		"user/build/fallback.html":                    {Data: []byte("<html>fallback</html>")},
+		"user/build/_app/immutable/nodes/0.abc123.js": {Data: []byte("export const x = 1")},
+	}}
+}
+
+func serve(t *testing.T, urlPath, userAgent string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "http://obot.example.com"+urlPath, nil)
+	if userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+	rec := httptest.NewRecorder()
+	testUIServer().ServeHTTP(rec, req)
+	return rec
+}
+
+// A cached 404 for a hashed asset breaks the app for every client behind that
+// cache, so files that exist must serve regardless of User-Agent.
+func TestExistingAssetsServeToNonBrowserClients(t *testing.T) {
+	for _, ua := range []string{
+		"Python/3.12 aiohttp/3.14.3",
+		"curl/8.7.1",
+		"Go-http-client/2.0",
+		"", // no User-Agent header at all
+		chromeUA,
+	} {
+		rec := serve(t, "/_app/immutable/nodes/0.abc123.js", ua)
+		if rec.Code != http.StatusOK {
+			t.Errorf("User-Agent %q: expected 200 for an asset that exists, got %d", ua, rec.Code)
+		}
+	}
+}
+
+// Unknown paths must not hand programmatic clients the SPA fallback, or a
+// mistyped API path looks like a 200 full of HTML.
+func TestUnknownPathReturns404ForNonBrowsers(t *testing.T) {
+	rec := serve(t, "/api/definitely-not-a-route", "Go-http-client/2.0")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for a non-browser client, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("expected Cache-Control no-store so the 404 is never cached, got %q", got)
+	}
+}
+
+// Browsers still get the SPA fallback so client-side routes survive a refresh.
+func TestUnknownPathServesFallbackForBrowsers(t *testing.T) {
+	rec := serve(t, "/some/client/side/route", chromeUA)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 fallback for a browser, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); body != "<html>fallback</html>" {
+		t.Errorf("expected the SPA fallback body, got %q", body)
+	}
+}
 
 // The proxy was migrated from the deprecated ReverseProxy.Director to Rewrite.
 // Director made ReverseProxy set X-Forwarded-For automatically; Rewrite does not

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -16,7 +16,9 @@ func testUIServer() *uiServer {
 	return &uiServer{fsys: fstest.MapFS{
 		"user/build/index.html":                       {Data: []byte("<html>index</html>")},
 		"user/build/fallback.html":                    {Data: []byte("<html>fallback</html>")},
+		"user/build/mcp-servers.html":                 {Data: []byte("<html>mcp-servers</html>")},
 		"user/build/_app/immutable/nodes/0.abc123.js": {Data: []byte("export const x = 1")},
+		"user/build/favicon.ico":                      {Data: []byte("icon")},
 	}}
 }
 
@@ -68,6 +70,31 @@ func TestUnknownPathServesFallbackForBrowsers(t *testing.T) {
 	}
 	if body := rec.Body.String(); body != "<html>fallback</html>" {
 		t.Errorf("expected the SPA fallback body, got %q", body)
+	}
+}
+
+// Hashed assets can be cached forever; the HTML that names them must not be, or
+// a client keeps asking for chunks from a build that is no longer deployed.
+func TestCacheHeaders(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		urlPath  string
+		expected string
+	}{
+		{"hashed asset", "/_app/immutable/nodes/0.abc123.js", "public, max-age=31536000, immutable"},
+		{"index", "/", "no-cache"},
+		{"mcp-servers entry point", "/mcp-servers", "no-cache"},
+		{"SPA fallback", "/some/client/side/route", "no-cache"},
+		// Not content-hashed, so it must not be marked immutable. Left without a
+		// directive rather than forced to revalidate on every request.
+		{"favicon", "/favicon.ico", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := serve(t, tt.urlPath, chromeUA)
+			if got := rec.Header().Get("Cache-Control"); got != tt.expected {
+				t.Errorf("expected Cache-Control %q, got %q", tt.expected, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
- **fix: serve UI assets regardless of User-Agent**
- **fix: set cache headers on the UI's assets and entry points**
