### PR TITLE
feat: add telemetry API client

### DIFF
--- a/apiclient/client.go
+++ b/apiclient/client.go
@@ -242,7 +242,7 @@ func (c *Client) doRequestWithBaseURL(ctx context.Context, method, baseURL, path
 		return nil, nil, err
 	}
 	if resp.StatusCode > 399 {
-		return nil, nil, errFromResponse(resp)
+		return nil, nil, ErrorFromResponse(resp)
 	}
 	if debug && !slices.Contains(headerKV, "text/event-stream") {
 		var data string
@@ -261,9 +261,9 @@ func (c *Client) doRequestWithBaseURL(ctx context.Context, method, baseURL, path
 	return req, resp, err
 }
 
-// errFromResponse builds the error for a non-2xx response and closes its body.
-// Callers get no response on this path, so nothing else can close it.
-func errFromResponse(resp *http.Response) error {
+// ErrorFromResponse builds a bounded HTTP error from a response, consuming and closing its body.
+// Callers should use it only after deciding that the response status represents an error.
+func ErrorFromResponse(resp *http.Response) error {
 	defer resp.Body.Close()
 
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes+1))

--- a/apiclient/errors_test.go
+++ b/apiclient/errors_test.go
@@ -23,7 +23,7 @@ func (b *trackedBody) Close() error {
 	return nil
 }
 
-func TestErrFromResponse(t *testing.T) {
+func TestErrorFromResponse(t *testing.T) {
 	const htmlPage = `<!doctype html><html><head><title>404</title></head><body>`
 
 	tests := []struct {
@@ -80,7 +80,7 @@ func TestErrFromResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			body := &trackedBody{Reader: strings.NewReader(tt.body)}
-			err := errFromResponse(&http.Response{
+			err := ErrorFromResponse(&http.Response{
 				StatusCode: tt.status,
 				// Shaped like net/http's own: "401 Unauthorized".
 				Status: fmt.Sprintf("%d %s", tt.status, http.StatusText(tt.status)),

--- a/apiclient/types/producttelemetry.go
+++ b/apiclient/types/producttelemetry.go
@@ -18,12 +18,15 @@ type ProductTelemetryDistribution string
 // +k8s:deepcopy-gen=false
 // +k8s:openapi-gen=false
 type ProductTelemetryRequest struct {
-	InstallationID string                       `json:"installationID"`
-	ReportedAt     time.Time                    `json:"reportedAt"`
-	Distribution   ProductTelemetryDistribution `json:"distribution"`
-	Engine         string                       `json:"engine"`
-	CurrentVersion string                       `json:"currentVersion"`
-	Metrics        *ProductTelemetryMetrics     `json:"metrics,omitempty"`
+	// InstallationID is the stable identifier used by Obot's upgrade service.
+	InstallationID string `json:"installationID"`
+	// LicenseMachineID is the persisted Keygen machine fingerprint.
+	LicenseMachineID string                       `json:"licenseMachineID"`
+	ReportedAt       time.Time                    `json:"reportedAt"`
+	Distribution     ProductTelemetryDistribution `json:"distribution"`
+	Engine           string                       `json:"engine"`
+	CurrentVersion   string                       `json:"currentVersion"`
+	Metrics          *ProductTelemetryMetrics     `json:"metrics,omitempty"`
 }
 
 // ProductTelemetryMetrics contains the aggregate metrics authorized for a report.

--- a/apiclient/types/producttelemetry.go
+++ b/apiclient/types/producttelemetry.go
@@ -1,0 +1,36 @@
+package types
+
+import "time"
+
+// ProductTelemetryRequest is the telemetry report Obot sends to Upgrade Server.
+// +k8s:deepcopy-gen=false
+// +k8s:openapi-gen=false
+type ProductTelemetryRequest struct {
+	InstallationID string                  `json:"installationID"`
+	ReportedAt     time.Time               `json:"reportedAt"`
+	Metrics        ProductTelemetryMetrics `json:"metrics"`
+}
+
+// ProductTelemetryMetrics contains the aggregate metrics authorized for a report.
+// Nil fields are encoded as null to distinguish unavailable values from measured zeroes.
+// +k8s:deepcopy-gen=false
+// +k8s:openapi-gen=false
+type ProductTelemetryMetrics struct {
+	TotalUsers         *int64                              `json:"totalUsers"`
+	ActiveUsers        *int64                              `json:"activeUsers"`
+	DeployedMCPServers *int64                              `json:"deployedMCPServers"`
+	BuiltInMCPServers  *[]ProductTelemetryBuiltInMCPServer `json:"builtInMCPServers"`
+	AuthProviderType   *string                             `json:"authProviderType"`
+	MCPAuditLogCount   *int64                              `json:"mcpAuditLogCount"`
+	LLMAuditLogCount   *int64                              `json:"llmAuditLogCount"`
+}
+
+// ProductTelemetryBuiltInMCPServer contains aggregate usage for a built-in MCP server.
+// +k8s:deepcopy-gen=false
+// +k8s:openapi-gen=false
+type ProductTelemetryBuiltInMCPServer struct {
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	DeploymentCount int64  `json:"deploymentCount"`
+	UserCount       int64  `json:"userCount"`
+}

--- a/apiclient/types/producttelemetry.go
+++ b/apiclient/types/producttelemetry.go
@@ -2,13 +2,26 @@ package types
 
 import "time"
 
+const (
+	ProductTelemetryDistributionUnlicensed ProductTelemetryDistribution = "Unlicensed"
+	ProductTelemetryDistributionCommunity  ProductTelemetryDistribution = "Community"
+	ProductTelemetryDistributionEnterprise ProductTelemetryDistribution = "Enterprise"
+	ProductTelemetryDistributionCloud      ProductTelemetryDistribution = "Cloud"
+)
+
+// ProductTelemetryDistribution identifies the Obot distribution sending telemetry.
+type ProductTelemetryDistribution string
+
 // ProductTelemetryRequest is the telemetry report Obot sends to Upgrade Server.
 // +k8s:deepcopy-gen=false
 // +k8s:openapi-gen=false
 type ProductTelemetryRequest struct {
-	InstallationID string                  `json:"installationID"`
-	ReportedAt     time.Time               `json:"reportedAt"`
-	Metrics        ProductTelemetryMetrics `json:"metrics"`
+	InstallationID string                       `json:"installationID"`
+	ReportedAt     time.Time                    `json:"reportedAt"`
+	Distribution   ProductTelemetryDistribution `json:"distribution"`
+	Engine         string                       `json:"engine"`
+	CurrentVersion string                       `json:"currentVersion"`
+	Metrics        *ProductTelemetryMetrics     `json:"metrics,omitempty"`
 }
 
 // ProductTelemetryMetrics contains the aggregate metrics authorized for a report.
@@ -16,13 +29,17 @@ type ProductTelemetryRequest struct {
 // +k8s:deepcopy-gen=false
 // +k8s:openapi-gen=false
 type ProductTelemetryMetrics struct {
-	TotalUsers         *int64                              `json:"totalUsers"`
-	ActiveUsers        *int64                              `json:"activeUsers"`
-	DeployedMCPServers *int64                              `json:"deployedMCPServers"`
-	BuiltInMCPServers  *[]ProductTelemetryBuiltInMCPServer `json:"builtInMCPServers"`
-	AuthProviderType   *string                             `json:"authProviderType"`
-	MCPAuditLogCount   *int64                              `json:"mcpAuditLogCount"`
-	LLMAuditLogCount   *int64                              `json:"llmAuditLogCount"`
+	TotalUsers                  *int64                              `json:"totalUsers"`
+	ActiveUsers                 *int64                              `json:"activeUsers"`
+	DeployedMCPServers          *int64                              `json:"deployedMCPServers"`
+	CustomMCPServerEntryCount   *int64                              `json:"customMCPServerEntryCount"`
+	BuiltInMCPServers           *[]ProductTelemetryBuiltInMCPServer `json:"builtInMCPServers"`
+	AuthProviderType            *string                             `json:"authProviderType"`
+	MCPAuditLogCount            *int64                              `json:"mcpAuditLogCount"`
+	LLMAuditLogCount            *int64                              `json:"llmAuditLogCount"`
+	SentryScanCount             *int64                              `json:"sentryScanCount"`
+	SentryEnforcementEventCount *int64                              `json:"sentryEnforcementEventCount"`
+	ManagedSkillCount           *int64                              `json:"managedSkillCount"`
 }
 
 // ProductTelemetryBuiltInMCPServer contains aggregate usage for a built-in MCP server.

--- a/apiclient/types/producttelemetry.go
+++ b/apiclient/types/producttelemetry.go
@@ -1,6 +1,8 @@
 package types
 
-import "time"
+import (
+	"time"
+)
 
 const (
 	ProductTelemetryDistributionUnlicensed ProductTelemetryDistribution = "Unlicensed"

--- a/pkg/producttelemetry/client.go
+++ b/pkg/producttelemetry/client.go
@@ -5,11 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"strings"
 	"time"
 
+	"github.com/obot-platform/obot/apiclient"
 	clienttypes "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/upgrade"
 )
@@ -18,7 +17,6 @@ const (
 	productTelemetryEndpoint = "product-telemetry"
 	requestTimeout           = 30 * time.Second
 	maxRequestAttempts       = 5
-	maxErrorResponseBytes    = 64 * 1024
 	initialRetryDelay        = time.Second
 )
 
@@ -94,36 +92,14 @@ func (c *Client) send(ctx context.Context, body []byte) (bool, error) {
 		}
 		return true, fmt.Errorf("send product telemetry request: %w", err)
 	}
-	defer response.Body.Close()
-
 	if response.StatusCode == http.StatusAccepted {
+		_ = response.Body.Close()
 		return false, nil
 	}
 
-	responseErr := responseError(response)
 	retry := response.StatusCode == http.StatusTooManyRequests ||
 		response.StatusCode >= http.StatusInternalServerError && response.StatusCode <= 599
-	return retry, responseErr
-}
-
-func responseError(response *http.Response) error {
-	body, err := io.ReadAll(io.LimitReader(response.Body, maxErrorResponseBytes+1))
-	if err != nil {
-		return fmt.Errorf("product telemetry request returned status %d; read response body: %w", response.StatusCode, err)
-	}
-
-	truncated := len(body) > maxErrorResponseBytes
-	if truncated {
-		body = body[:maxErrorResponseBytes]
-	}
-	message := strings.TrimSpace(string(body))
-	if message == "" {
-		return fmt.Errorf("product telemetry request returned status %d", response.StatusCode)
-	}
-	if truncated {
-		message += " [truncated]"
-	}
-	return fmt.Errorf("product telemetry request returned status %d: %s", response.StatusCode, message)
+	return retry, fmt.Errorf("product telemetry request failed: %w", apiclient.ErrorFromResponse(response))
 }
 
 func sleep(ctx context.Context, delay time.Duration) error {

--- a/pkg/producttelemetry/client.go
+++ b/pkg/producttelemetry/client.go
@@ -20,13 +20,9 @@ const (
 	initialRetryDelay        = time.Second
 )
 
-type httpClient interface {
-	Do(*http.Request) (*http.Response, error)
-}
-
 // Client sends product telemetry reports to Upgrade Server.
 type Client struct {
-	httpClient     httpClient
+	httpClient     *http.Client
 	requestURL     string
 	requestTimeout time.Duration
 	maxAttempts    int

--- a/pkg/producttelemetry/client.go
+++ b/pkg/producttelemetry/client.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/obot-platform/obot/apiclient"
@@ -40,10 +43,8 @@ func NewClient(baseURL string, client *http.Client) *Client {
 		requestURL:     upgrade.EndpointURL(baseURL, productTelemetryEndpoint),
 		requestTimeout: requestTimeout,
 		maxAttempts:    maxRequestAttempts,
-		retryDelay: func(attempt int) time.Duration {
-			return initialRetryDelay << attempt
-		},
-		sleep: sleep,
+		retryDelay:     retryDelay,
+		sleep:          sleep,
 	}
 }
 
@@ -56,14 +57,18 @@ func (c *Client) Send(ctx context.Context, request clienttypes.ProductTelemetryR
 	}
 
 	for attempt := range c.maxAttempts {
-		retry, err := c.send(ctx, body)
+		retry, retryAfter, err := c.send(ctx, body)
 		if err == nil {
 			return nil
 		}
 		if !retry || attempt == c.maxAttempts-1 {
 			return err
 		}
-		if err := c.sleep(ctx, c.retryDelay(attempt)); err != nil {
+		delay := c.retryDelay(attempt)
+		if retryAfter != nil {
+			delay = *retryAfter
+		}
+		if err := c.sleep(ctx, delay); err != nil {
 			return fmt.Errorf("send product telemetry request: %w", err)
 		}
 	}
@@ -71,31 +76,62 @@ func (c *Client) Send(ctx context.Context, request clienttypes.ProductTelemetryR
 	return nil
 }
 
-func (c *Client) send(ctx context.Context, body []byte) (bool, error) {
+func (c *Client) send(ctx context.Context, body []byte) (bool, *time.Duration, error) {
 	requestContext, cancel := context.WithTimeout(ctx, c.requestTimeout)
 	defer cancel()
 
 	request, err := http.NewRequestWithContext(requestContext, http.MethodPost, c.requestURL, bytes.NewReader(body))
 	if err != nil {
-		return false, fmt.Errorf("create product telemetry request: %w", err)
+		return false, nil, fmt.Errorf("create product telemetry request: %w", err)
 	}
 	request.Header.Set("Content-Type", "application/json")
 
 	response, err := c.httpClient.Do(request)
 	if err != nil {
 		if ctx.Err() != nil {
-			return false, fmt.Errorf("send product telemetry request: %w", ctx.Err())
+			return false, nil, fmt.Errorf("send product telemetry request: %w", ctx.Err())
 		}
-		return true, fmt.Errorf("send product telemetry request: %w", err)
+		return true, nil, fmt.Errorf("send product telemetry request: %w", err)
 	}
 	if response.StatusCode == http.StatusAccepted {
 		_ = response.Body.Close()
-		return false, nil
+		return false, nil, nil
 	}
 
 	retry := response.StatusCode == http.StatusTooManyRequests ||
 		response.StatusCode >= http.StatusInternalServerError && response.StatusCode <= 599
-	return retry, fmt.Errorf("product telemetry request failed: %w", apiclient.ErrorFromResponse(response))
+	var retryAfter *time.Duration
+	if retry {
+		if delay, ok := parseRetryAfter(response.Header.Get("Retry-After"), time.Now()); ok {
+			retryAfter = &delay
+		}
+	}
+	return retry, retryAfter, fmt.Errorf("product telemetry request failed: %w", apiclient.ErrorFromResponse(response))
+}
+
+func retryDelay(attempt int) time.Duration {
+	delay := initialRetryDelay << attempt
+	return delay/2 + time.Duration(rand.Int64N(int64(delay/2)+1))
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
+		if seconds < 0 || seconds > int64(time.Duration(1<<63-1)/time.Second) {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	retryAt, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	return max(retryAt.Sub(now), 0), true
 }
 
 func sleep(ctx context.Context, delay time.Duration) error {

--- a/pkg/producttelemetry/client.go
+++ b/pkg/producttelemetry/client.go
@@ -1,0 +1,139 @@
+package producttelemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	clienttypes "github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/upgrade"
+)
+
+const (
+	productTelemetryEndpoint = "product-telemetry"
+	requestTimeout           = 30 * time.Second
+	maxRequestAttempts       = 5
+	maxErrorResponseBytes    = 64 * 1024
+	initialRetryDelay        = time.Second
+)
+
+type httpClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Client sends product telemetry reports to Upgrade Server.
+type Client struct {
+	httpClient     httpClient
+	requestURL     string
+	requestTimeout time.Duration
+	maxAttempts    int
+	retryDelay     func(int) time.Duration
+	sleep          func(context.Context, time.Duration) error
+}
+
+// NewClient creates a product telemetry client for the supplied Upgrade Server base URL.
+func NewClient(baseURL string, client *http.Client) *Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Client{
+		httpClient:     client,
+		requestURL:     upgrade.EndpointURL(baseURL, productTelemetryEndpoint),
+		requestTimeout: requestTimeout,
+		maxAttempts:    maxRequestAttempts,
+		retryDelay: func(attempt int) time.Duration {
+			return initialRetryDelay << attempt
+		},
+		sleep: sleep,
+	}
+}
+
+// Send submits a product telemetry request. The request is encoded once so every retry sends
+// the same installation ID, reported time, and metrics.
+func (c *Client) Send(ctx context.Context, request clienttypes.ProductTelemetryRequest) error {
+	body, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("marshal product telemetry request: %w", err)
+	}
+
+	for attempt := range c.maxAttempts {
+		retry, err := c.send(ctx, body)
+		if err == nil {
+			return nil
+		}
+		if !retry || attempt == c.maxAttempts-1 {
+			return err
+		}
+		if err := c.sleep(ctx, c.retryDelay(attempt)); err != nil {
+			return fmt.Errorf("send product telemetry request: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) send(ctx context.Context, body []byte) (bool, error) {
+	requestContext, cancel := context.WithTimeout(ctx, c.requestTimeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(requestContext, http.MethodPost, c.requestURL, bytes.NewReader(body))
+	if err != nil {
+		return false, fmt.Errorf("create product telemetry request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		if ctx.Err() != nil {
+			return false, fmt.Errorf("send product telemetry request: %w", ctx.Err())
+		}
+		return true, fmt.Errorf("send product telemetry request: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusAccepted {
+		return false, nil
+	}
+
+	responseErr := responseError(response)
+	retry := response.StatusCode == http.StatusTooManyRequests ||
+		response.StatusCode >= http.StatusInternalServerError && response.StatusCode <= 599
+	return retry, responseErr
+}
+
+func responseError(response *http.Response) error {
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxErrorResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("product telemetry request returned status %d; read response body: %w", response.StatusCode, err)
+	}
+
+	truncated := len(body) > maxErrorResponseBytes
+	if truncated {
+		body = body[:maxErrorResponseBytes]
+	}
+	message := strings.TrimSpace(string(body))
+	if message == "" {
+		return fmt.Errorf("product telemetry request returned status %d", response.StatusCode)
+	}
+	if truncated {
+		message += " [truncated]"
+	}
+	return fmt.Errorf("product telemetry request returned status %d: %s", response.StatusCode, message)
+}
+
+func sleep(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/pkg/producttelemetry/client.go
+++ b/pkg/producttelemetry/client.go
@@ -109,6 +109,8 @@ func (c *Client) send(ctx context.Context, body []byte) (bool, *time.Duration, e
 	return retry, retryAfter, fmt.Errorf("product telemetry request failed: %w", apiclient.ErrorFromResponse(response))
 }
 
+// retryDelay applies equal jitter to exponential backoff: half of the delay is
+// fixed and the other half is randomized to keep clients from retrying in sync.
 func retryDelay(attempt int) time.Duration {
 	delay := initialRetryDelay << attempt
 	return delay/2 + time.Duration(rand.Int64N(int64(delay/2)+1))

--- a/pkg/producttelemetry/client.go
+++ b/pkg/producttelemetry/client.go
@@ -21,6 +21,7 @@ const (
 	requestTimeout           = 30 * time.Second
 	maxRequestAttempts       = 5
 	initialRetryDelay        = time.Second
+	maxRetryDelay            = 5 * time.Minute
 )
 
 // Client sends product telemetry reports to Upgrade Server.
@@ -123,8 +124,11 @@ func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
 	}
 
 	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
-		if seconds < 0 || seconds > int64(time.Duration(1<<63-1)/time.Second) {
+		if seconds < 0 {
 			return 0, false
+		}
+		if seconds > int64(maxRetryDelay/time.Second) {
+			return maxRetryDelay, true
 		}
 		return time.Duration(seconds) * time.Second, true
 	}
@@ -133,7 +137,7 @@ func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
 	if err != nil {
 		return 0, false
 	}
-	return max(retryAt.Sub(now), 0), true
+	return min(max(retryAt.Sub(now), 0), maxRetryDelay), true
 }
 
 func sleep(ctx context.Context, delay time.Duration) error {

--- a/pkg/producttelemetry/client.go
+++ b/pkg/producttelemetry/client.go
@@ -93,7 +93,7 @@ func (c *Client) send(ctx context.Context, body []byte) (bool, *time.Duration, e
 		}
 		return true, nil, fmt.Errorf("send product telemetry request: %w", err)
 	}
-	if response.StatusCode == http.StatusAccepted {
+	if response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices {
 		_ = response.Body.Close()
 		return false, nil, nil
 	}

--- a/pkg/producttelemetry/client_test.go
+++ b/pkg/producttelemetry/client_test.go
@@ -290,8 +290,10 @@ func TestParseRetryAfter(t *testing.T) {
 		wantOK    bool
 	}{
 		{name: "seconds", value: " 120 ", wantDelay: 2 * time.Minute, wantOK: true},
+		{name: "seconds clamped", value: "999999999", wantDelay: maxRetryDelay, wantOK: true},
 		{name: "zero seconds", value: "0", wantOK: true},
 		{name: "HTTP date", value: now.Add(3 * time.Minute).Format(http.TimeFormat), wantDelay: 3 * time.Minute, wantOK: true},
+		{name: "HTTP date clamped", value: now.Add(24 * time.Hour).Format(http.TimeFormat), wantDelay: maxRetryDelay, wantOK: true},
 		{name: "past HTTP date", value: now.Add(-time.Minute).Format(http.TimeFormat), wantOK: true},
 		{name: "negative seconds", value: "-1"},
 		{name: "invalid", value: "later"},

--- a/pkg/producttelemetry/client_test.go
+++ b/pkg/producttelemetry/client_test.go
@@ -29,11 +29,12 @@ func testRequest() clienttypes.ProductTelemetryRequest {
 		UserCount:       7,
 	}}
 	return clienttypes.ProductTelemetryRequest{
-		InstallationID: "7d7d83d8-2af0-4da8-ae2d-102d8eaa70be",
-		ReportedAt:     time.Date(2026, time.August, 31, 0, 4, 12, 0, time.UTC),
-		Distribution:   clienttypes.ProductTelemetryDistributionCloud,
-		Engine:         "kubernetes",
-		CurrentVersion: "v0.26.0",
+		InstallationID:   "7d7d83d8-2af0-4da8-ae2d-102d8eaa70be",
+		LicenseMachineID: "ab65c9ac-c012-4567-89ab-1b520aa26584",
+		ReportedAt:       time.Date(2026, time.August, 31, 0, 4, 12, 0, time.UTC),
+		Distribution:     clienttypes.ProductTelemetryDistributionCloud,
+		Engine:           "kubernetes",
+		CurrentVersion:   "v0.26.0",
 		Metrics: &clienttypes.ProductTelemetryMetrics{
 			TotalUsers:                  new(int64(42)),
 			DeployedMCPServers:          new(int64(0)),
@@ -62,13 +63,13 @@ func TestClientSend(t *testing.T) {
 		{
 			name:         "full report preserves null and zero metrics",
 			request:      fullRequest,
-			wantBody:     `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0","metrics":{"totalUsers":42,"activeUsers":null,"deployedMCPServers":0,"customMCPServerEntryCount":4,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":"github","mcpAuditLogCount":0,"llmAuditLogCount":null,"sentryScanCount":14,"sentryEnforcementEventCount":3,"managedSkillCount":27}}`,
+			wantBody:     `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","licenseMachineID":"ab65c9ac-c012-4567-89ab-1b520aa26584","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0","metrics":{"totalUsers":42,"activeUsers":null,"deployedMCPServers":0,"customMCPServerEntryCount":4,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":"github","mcpAuditLogCount":0,"llmAuditLogCount":null,"sentryScanCount":14,"sentryEnforcementEventCount":3,"managedSkillCount":27}}`,
 			responseBody: "ignored success body",
 		},
 		{
 			name:     "metadata-only report omits metrics",
 			request:  metadataOnlyRequest,
-			wantBody: `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0"}`,
+			wantBody: `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","licenseMachineID":"ab65c9ac-c012-4567-89ab-1b520aa26584","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0"}`,
 		},
 	}
 

--- a/pkg/producttelemetry/client_test.go
+++ b/pkg/producttelemetry/client_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -86,8 +85,9 @@ func TestClientDoesNotRetryNonRetryableResponse(t *testing.T) {
 			defer server.Close()
 
 			err := NewClient(server.URL, server.Client()).Send(t.Context(), testRequest())
-			if err == nil || !strings.Contains(err.Error(), "status "+strconv.Itoa(statusCode)) {
-				t.Fatalf("Send() error = %v, want status %d", err, statusCode)
+			var httpErr *clienttypes.ErrHTTP
+			if !errors.As(err, &httpErr) || httpErr.Code != statusCode {
+				t.Fatalf("Send() error = %v, want HTTP status %d", err, statusCode)
 			}
 			if !strings.Contains(err.Error(), "specific server error") {
 				t.Fatalf("Send() error = %v, want response body", err)
@@ -180,7 +180,9 @@ func TestClientRetryExhaustion(t *testing.T) {
 		}
 
 		err := client.Send(t.Context(), testRequest())
-		if err == nil || !strings.Contains(err.Error(), "status 503") || !strings.Contains(err.Error(), "still unavailable") {
+		var httpErr *clienttypes.ErrHTTP
+		if !errors.As(err, &httpErr) || httpErr.Code != http.StatusServiceUnavailable ||
+			!strings.Contains(err.Error(), "still unavailable") {
 			t.Fatalf("Send() error = %v, want final status and response body", err)
 		}
 		if attempts != maxRequestAttempts {
@@ -217,16 +219,17 @@ func TestClientRetryExhaustion(t *testing.T) {
 	})
 }
 
-func TestClientBoundsErrorResponseBody(t *testing.T) {
-	body := strings.Repeat("x", maxErrorResponseBytes) + "secret tail"
+func TestClientReturnsBoundedHTTPError(t *testing.T) {
+	body := strings.Repeat("x", 100_000) + "secret tail"
 	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return httpResponse(http.StatusBadRequest, body), nil
 	})
 	client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
 
 	err := client.Send(t.Context(), testRequest())
-	if err == nil || !strings.Contains(err.Error(), "[truncated]") {
-		t.Fatalf("Send() error = %v, want truncation marker", err)
+	var httpErr *clienttypes.ErrHTTP
+	if !errors.As(err, &httpErr) || httpErr.Code != http.StatusBadRequest || !strings.HasSuffix(httpErr.Message, "…") {
+		t.Fatalf("Send() error = %v, want bounded HTTP error", err)
 	}
 	if strings.Contains(err.Error(), "secret tail") {
 		t.Fatalf("Send() error included body beyond limit")

--- a/pkg/producttelemetry/client_test.go
+++ b/pkg/producttelemetry/client_test.go
@@ -1,0 +1,318 @@
+package producttelemetry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	clienttypes "github.com/obot-platform/obot/apiclient/types"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func testRequest() clienttypes.ProductTelemetryRequest {
+	servers := []clienttypes.ProductTelemetryBuiltInMCPServer{{
+		ID:              "github",
+		Name:            "GitHub",
+		DeploymentCount: 2,
+		UserCount:       7,
+	}}
+	return clienttypes.ProductTelemetryRequest{
+		InstallationID: "7d7d83d8-2af0-4da8-ae2d-102d8eaa70be",
+		ReportedAt:     time.Date(2026, time.August, 31, 0, 4, 12, 0, time.UTC),
+		Metrics: clienttypes.ProductTelemetryMetrics{
+			TotalUsers:        new(int64(42)),
+			ActiveUsers:       new(int64(10)),
+			BuiltInMCPServers: &servers,
+		},
+	}
+}
+
+func TestClientSend(t *testing.T) {
+	wantBody := `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","reportedAt":"2026-08-31T00:04:12Z","metrics":{"totalUsers":42,"activeUsers":10,"deployedMCPServers":null,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":null,"mcpAuditLogCount":null,"llmAuditLogCount":null}}`
+
+	for _, responseBody := range []string{"", "ignored success body"} {
+		t.Run(responseBody, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				if request.Method != http.MethodPost {
+					t.Errorf("method = %q, want POST", request.Method)
+				}
+				if request.URL.Path != "/root/product-telemetry" {
+					t.Errorf("path = %q", request.URL.Path)
+				}
+				if got := request.Header.Get("Content-Type"); got != "application/json" {
+					t.Errorf("Content-Type = %q, want application/json", got)
+				}
+				body, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Errorf("read request body: %v", err)
+				}
+				if string(body) != wantBody {
+					t.Errorf("body = %s, want %s", body, wantBody)
+				}
+				response.WriteHeader(http.StatusAccepted)
+				_, _ = io.WriteString(response, responseBody)
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL+"/root/", server.Client())
+			if err := client.Send(t.Context(), testRequest()); err != nil {
+				t.Fatalf("Send() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestClientDoesNotRetryNonRetryableResponse(t *testing.T) {
+	for _, statusCode := range []int{http.StatusBadRequest, http.StatusRequestEntityTooLarge, http.StatusUnsupportedMediaType} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			var attempts atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+				attempts.Add(1)
+				http.Error(response, "specific server error", statusCode)
+			}))
+			defer server.Close()
+
+			err := NewClient(server.URL, server.Client()).Send(t.Context(), testRequest())
+			if err == nil || !strings.Contains(err.Error(), "status "+strconv.Itoa(statusCode)) {
+				t.Fatalf("Send() error = %v, want status %d", err, statusCode)
+			}
+			if !strings.Contains(err.Error(), "specific server error") {
+				t.Fatalf("Send() error = %v, want response body", err)
+			}
+			if got := attempts.Load(); got != 1 {
+				t.Fatalf("attempts = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestClientRetriesTransientFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		firstRound roundTripFunc
+	}{
+		{
+			name: "transport error",
+			firstRound: func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("temporary network failure")
+			},
+		},
+		{
+			name: "rate limited",
+			firstRound: func(*http.Request) (*http.Response, error) {
+				return httpResponse(http.StatusTooManyRequests, "try later"), nil
+			},
+		},
+		{
+			name: "server error",
+			firstRound: func(*http.Request) (*http.Response, error) {
+				return httpResponse(http.StatusBadGateway, "try later"), nil
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			var attempts int
+			var bodies [][]byte
+			transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				body, err := io.ReadAll(request.Body)
+				if err != nil {
+					t.Fatalf("read request body: %v", err)
+				}
+				bodies = append(bodies, body)
+				attempts++
+				if attempts < 3 {
+					return testCase.firstRound(request)
+				}
+				return httpResponse(http.StatusAccepted, ""), nil
+			})
+			client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
+			var delays []time.Duration
+			client.sleep = func(_ context.Context, delay time.Duration) error {
+				delays = append(delays, delay)
+				return nil
+			}
+
+			if err := client.Send(t.Context(), testRequest()); err != nil {
+				t.Fatalf("Send() error = %v", err)
+			}
+			if attempts != 3 {
+				t.Fatalf("attempts = %d, want 3", attempts)
+			}
+			if len(delays) != 2 || delays[0] != time.Second || delays[1] != 2*time.Second {
+				t.Fatalf("delays = %v, want [1s 2s]", delays)
+			}
+			for index := 1; index < len(bodies); index++ {
+				if !bytes.Equal(bodies[0], bodies[index]) {
+					t.Fatalf("retry body %d changed", index+1)
+				}
+			}
+		})
+	}
+}
+
+func TestClientRetryExhaustion(t *testing.T) {
+	t.Run("response", func(t *testing.T) {
+		var attempts int
+		transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+			attempts++
+			return httpResponse(http.StatusServiceUnavailable, "still unavailable"), nil
+		})
+		client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
+		var delays []time.Duration
+		client.sleep = func(_ context.Context, delay time.Duration) error {
+			delays = append(delays, delay)
+			return nil
+		}
+
+		err := client.Send(t.Context(), testRequest())
+		if err == nil || !strings.Contains(err.Error(), "status 503") || !strings.Contains(err.Error(), "still unavailable") {
+			t.Fatalf("Send() error = %v, want final status and response body", err)
+		}
+		if attempts != maxRequestAttempts {
+			t.Fatalf("attempts = %d, want %d", attempts, maxRequestAttempts)
+		}
+		wantDelays := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second}
+		if len(delays) != len(wantDelays) {
+			t.Fatalf("delays = %v, want %v", delays, wantDelays)
+		}
+		for index := range wantDelays {
+			if delays[index] != wantDelays[index] {
+				t.Fatalf("delays = %v, want %v", delays, wantDelays)
+			}
+		}
+	})
+
+	t.Run("transport", func(t *testing.T) {
+		wantErr := errors.New("network unavailable")
+		var attempts int
+		transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+			attempts++
+			return nil, wantErr
+		})
+		client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
+		client.sleep = func(context.Context, time.Duration) error { return nil }
+
+		err := client.Send(t.Context(), testRequest())
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("Send() error = %v, want %v", err, wantErr)
+		}
+		if attempts != maxRequestAttempts {
+			t.Fatalf("attempts = %d, want %d", attempts, maxRequestAttempts)
+		}
+	})
+}
+
+func TestClientBoundsErrorResponseBody(t *testing.T) {
+	body := strings.Repeat("x", maxErrorResponseBytes) + "secret tail"
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return httpResponse(http.StatusBadRequest, body), nil
+	})
+	client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
+
+	err := client.Send(t.Context(), testRequest())
+	if err == nil || !strings.Contains(err.Error(), "[truncated]") {
+		t.Fatalf("Send() error = %v, want truncation marker", err)
+	}
+	if strings.Contains(err.Error(), "secret tail") {
+		t.Fatalf("Send() error included body beyond limit")
+	}
+}
+
+func TestClientCancellationStopsRequestAndBackoff(t *testing.T) {
+	t.Run("active request", func(t *testing.T) {
+		started := make(chan struct{})
+		transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			close(started)
+			<-request.Context().Done()
+			return nil, request.Context().Err()
+		})
+		client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan error, 1)
+		go func() { done <- client.Send(ctx, testRequest()) }()
+		<-started
+		cancel()
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("Send() error = %v, want context canceled", err)
+		}
+	})
+
+	t.Run("backoff", func(t *testing.T) {
+		attempted := make(chan struct{})
+		transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+			close(attempted)
+			return httpResponse(http.StatusServiceUnavailable, "retry"), nil
+		})
+		client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
+		client.retryDelay = func(int) time.Duration { return time.Hour }
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan error, 1)
+		go func() { done <- client.Send(ctx, testRequest()) }()
+		<-attempted
+		cancel()
+		if err := <-done; !errors.Is(err, context.Canceled) {
+			t.Fatalf("Send() error = %v, want context canceled", err)
+		}
+	})
+}
+
+func TestClientAttemptTimeout(t *testing.T) {
+	var attempts atomic.Int32
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		attempts.Add(1)
+		<-request.Context().Done()
+		return nil, request.Context().Err()
+	})
+	client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
+	client.requestTimeout = 20 * time.Millisecond
+	client.maxAttempts = 1
+
+	err := client.Send(t.Context(), testRequest())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Send() error = %v, want deadline exceeded", err)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+}
+
+func TestClientMarshalFailureDoesNotSend(t *testing.T) {
+	var attempts atomic.Int32
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts.Add(1)
+		return httpResponse(http.StatusAccepted, ""), nil
+	})
+	client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
+	request := testRequest()
+	request.ReportedAt = time.Date(10000, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := client.Send(t.Context(), request); err == nil || !strings.Contains(err.Error(), "marshal product telemetry request") {
+		t.Fatalf("Send() error = %v, want marshal error", err)
+	}
+	if got := attempts.Load(); got != 0 {
+		t.Fatalf("attempts = %d, want 0", got)
+	}
+}
+
+func httpResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/pkg/producttelemetry/client_test.go
+++ b/pkg/producttelemetry/client_test.go
@@ -35,18 +35,45 @@ func testRequest() clienttypes.ProductTelemetryRequest {
 		Engine:         "kubernetes",
 		CurrentVersion: "v0.26.0",
 		Metrics: &clienttypes.ProductTelemetryMetrics{
-			TotalUsers:        new(int64(42)),
-			ActiveUsers:       new(int64(10)),
-			BuiltInMCPServers: &servers,
+			TotalUsers:                  new(int64(42)),
+			DeployedMCPServers:          new(int64(0)),
+			CustomMCPServerEntryCount:   new(int64(4)),
+			BuiltInMCPServers:           &servers,
+			AuthProviderType:            new("github"),
+			MCPAuditLogCount:            new(int64(0)),
+			SentryScanCount:             new(int64(14)),
+			SentryEnforcementEventCount: new(int64(3)),
+			ManagedSkillCount:           new(int64(27)),
 		},
 	}
 }
 
 func TestClientSend(t *testing.T) {
-	wantBody := `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0","metrics":{"totalUsers":42,"activeUsers":10,"deployedMCPServers":null,"customMCPServerEntryCount":null,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":null,"mcpAuditLogCount":null,"llmAuditLogCount":null,"sentryScanCount":null,"sentryEnforcementEventCount":null,"managedSkillCount":null}}`
+	fullRequest := testRequest()
+	metadataOnlyRequest := testRequest()
+	metadataOnlyRequest.Metrics = nil
 
-	for _, responseBody := range []string{"", "ignored success body"} {
-		t.Run(responseBody, func(t *testing.T) {
+	tests := []struct {
+		name         string
+		request      clienttypes.ProductTelemetryRequest
+		wantBody     string
+		responseBody string
+	}{
+		{
+			name:         "full report preserves null and zero metrics",
+			request:      fullRequest,
+			wantBody:     `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0","metrics":{"totalUsers":42,"activeUsers":null,"deployedMCPServers":0,"customMCPServerEntryCount":4,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":"github","mcpAuditLogCount":0,"llmAuditLogCount":null,"sentryScanCount":14,"sentryEnforcementEventCount":3,"managedSkillCount":27}}`,
+			responseBody: "ignored success body",
+		},
+		{
+			name:     "metadata-only report omits metrics",
+			request:  metadataOnlyRequest,
+			wantBody: `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0"}`,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 				if request.Method != http.MethodPost {
 					t.Errorf("method = %q, want POST", request.Method)
@@ -61,16 +88,16 @@ func TestClientSend(t *testing.T) {
 				if err != nil {
 					t.Errorf("read request body: %v", err)
 				}
-				if string(body) != wantBody {
-					t.Errorf("body = %s, want %s", body, wantBody)
+				if string(body) != testCase.wantBody {
+					t.Errorf("body = %s, want %s", body, testCase.wantBody)
 				}
 				response.WriteHeader(http.StatusAccepted)
-				_, _ = io.WriteString(response, responseBody)
+				_, _ = io.WriteString(response, testCase.responseBody)
 			}))
 			defer server.Close()
 
 			client := NewClient(server.URL+"/root/", server.Client())
-			if err := client.Send(t.Context(), testRequest()); err != nil {
+			if err := client.Send(t.Context(), testCase.request); err != nil {
 				t.Fatalf("Send() error = %v", err)
 			}
 		})

--- a/pkg/producttelemetry/client_test.go
+++ b/pkg/producttelemetry/client_test.go
@@ -172,6 +172,7 @@ func TestClientRetriesTransientFailures(t *testing.T) {
 			})
 			client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
 			var delays []time.Duration
+			client.retryDelay = exponentialRetryDelay
 			client.sleep = func(_ context.Context, delay time.Duration) error {
 				delays = append(delays, delay)
 				return nil
@@ -204,6 +205,7 @@ func TestClientRetryExhaustion(t *testing.T) {
 		})
 		client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
 		var delays []time.Duration
+		client.retryDelay = exponentialRetryDelay
 		client.sleep = func(_ context.Context, delay time.Duration) error {
 			delays = append(delays, delay)
 			return nil
@@ -247,6 +249,63 @@ func TestClientRetryExhaustion(t *testing.T) {
 			t.Fatalf("attempts = %d, want %d", attempts, maxRequestAttempts)
 		}
 	})
+}
+
+func TestClientHonorsRetryAfter(t *testing.T) {
+	var attempts int
+	transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			response := httpResponse(http.StatusTooManyRequests, "rate limited")
+			response.Header.Set("Retry-After", "60")
+			return response, nil
+		}
+		return httpResponse(http.StatusAccepted, ""), nil
+	})
+	client := NewClient("https://upgrade.example.test", &http.Client{Transport: transport})
+	client.retryDelay = func(int) time.Duration { return time.Millisecond }
+	var delays []time.Duration
+	client.sleep = func(_ context.Context, delay time.Duration) error {
+		delays = append(delays, delay)
+		return nil
+	}
+
+	if err := client.Send(t.Context(), testRequest()); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if len(delays) != 1 || delays[0] != time.Minute {
+		t.Fatalf("delays = %v, want [1m0s]", delays)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, time.September, 1, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		value     string
+		wantDelay time.Duration
+		wantOK    bool
+	}{
+		{name: "seconds", value: " 120 ", wantDelay: 2 * time.Minute, wantOK: true},
+		{name: "zero seconds", value: "0", wantOK: true},
+		{name: "HTTP date", value: now.Add(3 * time.Minute).Format(http.TimeFormat), wantDelay: 3 * time.Minute, wantOK: true},
+		{name: "past HTTP date", value: now.Add(-time.Minute).Format(http.TimeFormat), wantOK: true},
+		{name: "negative seconds", value: "-1"},
+		{name: "invalid", value: "later"},
+		{name: "empty"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			delay, ok := parseRetryAfter(testCase.value, now)
+			if ok != testCase.wantOK || delay != testCase.wantDelay {
+				t.Fatalf("parseRetryAfter(%q) = (%v, %v), want (%v, %v)", testCase.value, delay, ok, testCase.wantDelay, testCase.wantOK)
+			}
+		})
+	}
 }
 
 func TestClientReturnsBoundedHTTPError(t *testing.T) {
@@ -348,4 +407,8 @@ func httpResponse(statusCode int, body string) *http.Response {
 		Header:     make(http.Header),
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
+}
+
+func exponentialRetryDelay(attempt int) time.Duration {
+	return initialRetryDelay << attempt
 }

--- a/pkg/producttelemetry/client_test.go
+++ b/pkg/producttelemetry/client_test.go
@@ -31,7 +31,10 @@ func testRequest() clienttypes.ProductTelemetryRequest {
 	return clienttypes.ProductTelemetryRequest{
 		InstallationID: "7d7d83d8-2af0-4da8-ae2d-102d8eaa70be",
 		ReportedAt:     time.Date(2026, time.August, 31, 0, 4, 12, 0, time.UTC),
-		Metrics: clienttypes.ProductTelemetryMetrics{
+		Distribution:   clienttypes.ProductTelemetryDistributionCloud,
+		Engine:         "kubernetes",
+		CurrentVersion: "v0.26.0",
+		Metrics: &clienttypes.ProductTelemetryMetrics{
 			TotalUsers:        new(int64(42)),
 			ActiveUsers:       new(int64(10)),
 			BuiltInMCPServers: &servers,
@@ -40,7 +43,7 @@ func testRequest() clienttypes.ProductTelemetryRequest {
 }
 
 func TestClientSend(t *testing.T) {
-	wantBody := `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","reportedAt":"2026-08-31T00:04:12Z","metrics":{"totalUsers":42,"activeUsers":10,"deployedMCPServers":null,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":null,"mcpAuditLogCount":null,"llmAuditLogCount":null}}`
+	wantBody := `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0","metrics":{"totalUsers":42,"activeUsers":10,"deployedMCPServers":null,"customMCPServerEntryCount":null,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":null,"mcpAuditLogCount":null,"llmAuditLogCount":null,"sentryScanCount":null,"sentryEnforcementEventCount":null,"managedSkillCount":null}}`
 
 	for _, responseBody := range []string{"", "ignored success body"} {
 		t.Run(responseBody, func(t *testing.T) {


### PR DESCRIPTION
Addresses https://github.com/obot-platform/obot/issues/7711

This adds the request type that will be imported by upgrade-server and includes the request client that Obot will use. Nothing is executed or sent yet.