### PR TITLE
fix: avoid catalog status fanout to children

### DIFF
--- a/adr/2026-09-01-catalog-parent-owned-cleanup.md
+++ b/adr/2026-09-01-catalog-parent-owned-cleanup.md
@@ -29,8 +29,9 @@ pruning orphaned entries.
 
 Catalog children no longer register generic deletion references to their parent catalog. MCPCatalog
 and SystemMCPCatalog finalizers instead list and delete their children when the parent itself is
-deleted. Hourly catalog reconciliation, apply, drift repair, and system-catalog pruning remain
-unchanged.
+deleted. The finalizers remain until a follow-up pass confirms that no children remain, and entry
+or catalog-scoped server creation is rejected once a catalog begins terminating. Hourly catalog
+reconciliation, apply, drift repair, and system-catalog pruning remain unchanged.
 
 ## Rationale
 

--- a/adr/2026-09-01-catalog-parent-owned-cleanup.md
+++ b/adr/2026-09-01-catalog-parent-owned-cleanup.md
@@ -1,0 +1,49 @@
+# 2026-09-01: Clean up catalog children from the parent
+
+- **Status:** Accepted
+- **Date:** 2026-09-01
+- **Supersedes:** None
+- **Superseded by:** None
+
+## Related issues
+
+None.
+
+## Related ODPs
+
+None.
+
+## Context
+
+Catalog entries and catalog-scoped MCP servers used generic deletion references to watch their
+parent catalog. The controller's dependency tracking reacts to every parent update, including
+hourly sync-status updates. A catalog with hundreds of entries therefore reconciled every child at
+once even when the catalog contents had not changed, creating bursts of database work and
+connection-pool contention.
+
+Source revision or desired-object hashes could avoid some scheduled applies, but using source state
+alone as the reconciliation gate would stop the controller from repairing cluster-side drift and
+pruning orphaned entries.
+
+## Decision
+
+Catalog children no longer register generic deletion references to their parent catalog. MCPCatalog
+and SystemMCPCatalog finalizers instead list and delete their children when the parent itself is
+deleted. Hourly catalog reconciliation, apply, drift repair, and system-catalog pruning remain
+unchanged.
+
+## Rationale
+
+Parent-owned cleanup preserves deletion behavior while removing the dependency edge that turns an
+unrelated catalog status write into hundreds of child reconciliations. It addresses the observed
+fan-out without making source immutability an assumption of the reconciliation model.
+
+## Consequences
+
+Catalog deletion cleanup is now explicit in the catalog controller and must include any new child
+type that previously would have referenced a catalog through generic cleanup. In return, catalog
+status and annotation updates no longer requeue every catalog entry or catalog-scoped MCP server.
+
+## References
+
+N/A.

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1587,8 +1587,7 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 	}
 
 	if catalogID != "" {
-		var catalog v1.MCPCatalog
-		if err := req.Get(&catalog, catalogID); err != nil {
+		if err := ensureMCPCatalogAcceptsChildren(req, catalogID); err != nil {
 			return err
 		}
 
@@ -1707,6 +1706,11 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 	// (which would otherwise ship a literal "${VAR}" string at runtime).
 	if err := mcp.ValidateTemplateReferences(server.Spec.Manifest); err != nil {
 		return types.NewErrBadRequest("validation failed: %v", err)
+	}
+	if catalogID != "" {
+		if err := ensureMCPCatalogAcceptsChildren(req, catalogID); err != nil {
+			return err
+		}
 	}
 	if err := req.Create(&server); err != nil {
 		return err

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"regexp"
 	"slices"
 	"sort"
@@ -309,8 +310,8 @@ func (h *MCPCatalogHandler) CreateEntry(req api.Context) error {
 
 	// Verify the scope exists
 	if catalogName != "" {
-		if err := req.Get(&v1.MCPCatalog{}, catalogName); err != nil {
-			return fmt.Errorf("failed to get catalog: %w", err)
+		if err := ensureMCPCatalogAcceptsChildren(req, catalogName); err != nil {
+			return err
 		}
 	} else if workspaceID != "" {
 		if err := req.Get(&v1.PowerUserWorkspace{}, workspaceID); err != nil {
@@ -368,11 +369,29 @@ func (h *MCPCatalogHandler) CreateEntry(req api.Context) error {
 		entry.Spec.PowerUserWorkspaceID = workspaceID
 	}
 
+	// Check again immediately before creation so validation work does not leave a
+	// wide window for the catalog to begin terminating.
+	if catalogName != "" {
+		if err := ensureMCPCatalogAcceptsChildren(req, catalogName); err != nil {
+			return err
+		}
+	}
 	if err := req.Create(&entry); err != nil {
 		return fmt.Errorf("failed to create entry: %w", err)
 	}
 
 	return req.Write(ConvertMCPServerCatalogEntry(entry, h.serverURL))
+}
+
+func ensureMCPCatalogAcceptsChildren(req api.Context, catalogName string) error {
+	var catalog v1.MCPCatalog
+	if err := req.Get(&catalog, catalogName); err != nil {
+		return fmt.Errorf("failed to get catalog: %w", err)
+	}
+	if !catalog.DeletionTimestamp.IsZero() {
+		return types.NewErrHTTP(http.StatusConflict, fmt.Sprintf("catalog %q is being deleted", catalogName))
+	}
+	return nil
 }
 
 func (h *MCPCatalogHandler) UpdateEntry(req api.Context) error {

--- a/pkg/api/handlers/mcpcatalogs_test.go
+++ b/pkg/api/handlers/mcpcatalogs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -28,6 +29,59 @@ type fakeCapacityInfoProvider struct {
 	serverNames []string
 	info        types.MCPCapacityInfo
 	err         error
+}
+
+func TestCreateEntryRejectsDeletingMCPCatalog(t *testing.T) {
+	now := metav1.Now()
+	catalog := &v1.MCPCatalog{
+		Name:              "catalog-1",
+		Namespace:         system.DefaultNamespace,
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"test-finalizer"},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.SetPathValue("catalog_id", catalog.Name)
+
+	err := (&MCPCatalogHandler{}).CreateEntry(api.Context{
+		Request:        request,
+		ResponseWriter: httptest.NewRecorder(),
+		Storage: storage.Client(fake.NewClientBuilder().
+			WithScheme(storagescheme.Scheme).
+			WithObjects(catalog).
+			Build()),
+	})
+
+	var httpErr *types.ErrHTTP
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.Code)
+	assert.Contains(t, httpErr.Message, "being deleted")
+}
+
+func TestCreateServerRejectsDeletingMCPCatalog(t *testing.T) {
+	now := metav1.Now()
+	catalog := &v1.MCPCatalog{
+		Name:              "catalog-1",
+		Namespace:         system.DefaultNamespace,
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"test-finalizer"},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{}`))
+	request.SetPathValue("catalog_id", catalog.Name)
+
+	err := (&MCPHandler{}).CreateServer(api.Context{
+		Request:        request,
+		ResponseWriter: httptest.NewRecorder(),
+		Storage: storage.Client(fake.NewClientBuilder().
+			WithScheme(storagescheme.Scheme).
+			WithObjects(catalog).
+			Build()),
+		User: &kuser.DefaultInfo{UID: "user-1"},
+	})
+
+	var httpErr *types.ErrHTTP
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.Code)
+	assert.Contains(t, httpErr.Message, "being deleted")
 }
 
 func TestStaticOAuthCredentialSecrets(t *testing.T) {

--- a/pkg/api/handlers/systemmcpcatalogs.go
+++ b/pkg/api/handlers/systemmcpcatalogs.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"slices"
 	"strings"
@@ -193,8 +194,8 @@ func (*SystemMCPCatalogHandler) GetEntry(req api.Context) error {
 
 func (h *SystemMCPCatalogHandler) CreateEntry(req api.Context) error {
 	catalogName := req.PathValue("catalog_id")
-	if err := req.Get(&v1.SystemMCPCatalog{}, catalogName); err != nil {
-		return fmt.Errorf("failed to get system catalog: %w", err)
+	if err := ensureSystemMCPCatalogAcceptsEntries(req, catalogName); err != nil {
+		return err
 	}
 
 	var manifest types.SystemMCPServerCatalogEntryManifest
@@ -214,10 +215,26 @@ func (h *SystemMCPCatalogHandler) CreateEntry(req api.Context) error {
 			Manifest:             manifest,
 		},
 	}
+	// Check again immediately before creation so validation work does not leave a
+	// wide window for the catalog to begin terminating.
+	if err := ensureSystemMCPCatalogAcceptsEntries(req, catalogName); err != nil {
+		return err
+	}
 	if err := req.Create(&entry); err != nil {
 		return fmt.Errorf("failed to create system catalog entry: %w", err)
 	}
 	return req.Write(ConvertSystemMCPServerCatalogEntry(entry))
+}
+
+func ensureSystemMCPCatalogAcceptsEntries(req api.Context, catalogName string) error {
+	var catalog v1.SystemMCPCatalog
+	if err := req.Get(&catalog, catalogName); err != nil {
+		return fmt.Errorf("failed to get system catalog: %w", err)
+	}
+	if !catalog.DeletionTimestamp.IsZero() {
+		return types.NewErrHTTP(http.StatusConflict, fmt.Sprintf("system catalog %q is being deleted", catalogName))
+	}
+	return nil
 }
 
 func (h *SystemMCPCatalogHandler) UpdateEntry(req api.Context) error {

--- a/pkg/api/handlers/systemmcpcatalogs_test.go
+++ b/pkg/api/handlers/systemmcpcatalogs_test.go
@@ -1,12 +1,47 @@
 package handlers
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/storage"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestCreateEntryRejectsDeletingSystemMCPCatalog(t *testing.T) {
+	now := metav1.Now()
+	catalog := &v1.SystemMCPCatalog{
+		Name:              "catalog-1",
+		Namespace:         system.DefaultNamespace,
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"test-finalizer"},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/", nil)
+	request.SetPathValue("catalog_id", catalog.Name)
+
+	err := (&SystemMCPCatalogHandler{}).CreateEntry(api.Context{
+		Request:        request,
+		ResponseWriter: httptest.NewRecorder(),
+		Storage: storage.Client(fake.NewClientBuilder().
+			WithScheme(storagescheme.Scheme).
+			WithObjects(catalog).
+			Build()),
+	})
+
+	var httpErr *types.ErrHTTP
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.Code)
+	assert.Contains(t, httpErr.Message, "being deleted")
+}
 
 func TestMaskCatalogCredential(t *testing.T) {
 	assert.Equal(t, "****", maskCatalogCredential(""))

--- a/pkg/controller/handlers/mcpcatalog/catalog_removal_test.go
+++ b/pkg/controller/handlers/mcpcatalog/catalog_removal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/obot-platform/nah/pkg/apply"
+	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/storage/scheme"
@@ -282,6 +283,65 @@ func TestDetachCatalogEntryIgnoresNotFound(t *testing.T) {
 	require.NoError(t, detachCatalogEntry(t.Context(), newCatalogFakeClient(), catalog, "missing"))
 }
 
+func TestRemoveCatalogChildren(t *testing.T) {
+	catalog := testCatalog()
+	entry := managedCatalogEntry(t, catalog, "managed-entry")
+	server := &v1.MCPServer{
+		Name:      "catalog-server",
+		Namespace: catalog.Namespace,
+		Spec:      v1.MCPServerSpec{MCPCatalogID: catalog.Name},
+	}
+	unrelatedEntry := managedCatalogEntry(t, catalog, "unrelated-entry")
+	unrelatedEntry.Spec.MCPCatalogName = "other"
+	unrelatedServer := &v1.MCPServer{
+		Name:      "unrelated-server",
+		Namespace: catalog.Namespace,
+		Spec:      v1.MCPServerSpec{MCPCatalogID: "other"},
+	}
+	client := newCatalogFakeClient(catalog, entry, server, unrelatedEntry, unrelatedServer)
+
+	err := (&Handler{}).RemoveCatalogChildren(router.Request{
+		Client:    client,
+		Ctx:       t.Context(),
+		Object:    catalog,
+		Namespace: catalog.Namespace,
+		Name:      catalog.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	assert.True(t, apierrors.IsNotFound(client.Get(t.Context(), kclient.ObjectKeyFromObject(entry), &v1.MCPServerCatalogEntry{})))
+	assert.True(t, apierrors.IsNotFound(client.Get(t.Context(), kclient.ObjectKeyFromObject(server), &v1.MCPServer{})))
+	require.NoError(t, client.Get(t.Context(), kclient.ObjectKeyFromObject(unrelatedEntry), &v1.MCPServerCatalogEntry{}))
+	require.NoError(t, client.Get(t.Context(), kclient.ObjectKeyFromObject(unrelatedServer), &v1.MCPServer{}))
+}
+
+func TestRemoveSystemCatalogEntries(t *testing.T) {
+	catalog := &v1.SystemMCPCatalog{Name: "system-catalog", Namespace: "default"}
+	entry := &v1.SystemMCPServerCatalogEntry{
+		Name:      "system-entry",
+		Namespace: catalog.Namespace,
+		Spec:      v1.SystemMCPServerCatalogEntrySpec{SystemMCPCatalogName: catalog.Name},
+	}
+	unrelated := &v1.SystemMCPServerCatalogEntry{
+		Name:      "unrelated-system-entry",
+		Namespace: catalog.Namespace,
+		Spec:      v1.SystemMCPServerCatalogEntrySpec{SystemMCPCatalogName: "other"},
+	}
+	client := newCatalogFakeClient(catalog, entry, unrelated)
+
+	err := (&Handler{}).RemoveSystemCatalogEntries(router.Request{
+		Client:    client,
+		Ctx:       t.Context(),
+		Object:    catalog,
+		Namespace: catalog.Namespace,
+		Name:      catalog.Name,
+	}, &router.ResponseWrapper{})
+	require.NoError(t, err)
+
+	assert.True(t, apierrors.IsNotFound(client.Get(t.Context(), kclient.ObjectKeyFromObject(entry), &v1.SystemMCPServerCatalogEntry{})))
+	require.NoError(t, client.Get(t.Context(), kclient.ObjectKeyFromObject(unrelated), &v1.SystemMCPServerCatalogEntry{}))
+}
+
 func testCatalog() *v1.MCPCatalog {
 	return &v1.MCPCatalog{
 		APIVersion: v1.SchemeGroupVersion.String(), Kind: "MCPCatalog",
@@ -318,10 +378,13 @@ func managedCatalogEntry(t *testing.T, catalog *v1.MCPCatalog, name string) *v1.
 	}
 }
 
-func newCatalogFakeClient(objects ...kclient.Object) kclient.Client {
+func newCatalogFakeClient(objects ...kclient.Object) kclient.WithWatch {
 	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{v1.SchemeGroupVersion})
 	restMapper.Add(v1.SchemeGroupVersion.WithKind("MCPCatalog"), meta.RESTScopeNamespace)
 	restMapper.Add(v1.SchemeGroupVersion.WithKind("MCPServerCatalogEntry"), meta.RESTScopeNamespace)
+	restMapper.Add(v1.SchemeGroupVersion.WithKind("MCPServer"), meta.RESTScopeNamespace)
+	restMapper.Add(v1.SchemeGroupVersion.WithKind("SystemMCPCatalog"), meta.RESTScopeNamespace)
+	restMapper.Add(v1.SchemeGroupVersion.WithKind("SystemMCPServerCatalogEntry"), meta.RESTScopeNamespace)
 	return fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
 		WithRESTMapper(restMapper).
@@ -338,6 +401,20 @@ func newCatalogFakeClient(objects ...kclient.Object) kclient.Client {
 				return nil
 			}
 			return []string{server.Spec.MCPServerCatalogEntryName}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.mcpCatalogID", func(obj kclient.Object) []string {
+			server := obj.(*v1.MCPServer)
+			if server.Spec.MCPCatalogID == "" {
+				return nil
+			}
+			return []string{server.Spec.MCPCatalogID}
+		}).
+		WithIndex(&v1.SystemMCPServerCatalogEntry{}, "spec.systemMCPCatalogName", func(obj kclient.Object) []string {
+			entry := obj.(*v1.SystemMCPServerCatalogEntry)
+			if entry.Spec.SystemMCPCatalogName == "" {
+				return nil
+			}
+			return []string{entry.Spec.SystemMCPCatalogName}
 		}).
 		WithObjects(objects...).
 		Build()

--- a/pkg/controller/handlers/mcpcatalog/catalog_removal_test.go
+++ b/pkg/controller/handlers/mcpcatalog/catalog_removal_test.go
@@ -300,19 +300,26 @@ func TestRemoveCatalogChildren(t *testing.T) {
 	}
 	client := newCatalogFakeClient(catalog, entry, server, unrelatedEntry, unrelatedServer)
 
-	err := (&Handler{}).RemoveCatalogChildren(router.Request{
+	request := router.Request{
 		Client:    client,
 		Ctx:       t.Context(),
 		Object:    catalog,
 		Namespace: catalog.Namespace,
 		Name:      catalog.Name,
-	}, &router.ResponseWrapper{})
+	}
+	response := &router.ResponseWrapper{}
+	err := (&Handler{}).RemoveCatalogChildren(request, response)
 	require.NoError(t, err)
+	assert.Equal(t, catalogRemovalRetryInterval, response.Delay)
 
 	assert.True(t, apierrors.IsNotFound(client.Get(t.Context(), kclient.ObjectKeyFromObject(entry), &v1.MCPServerCatalogEntry{})))
 	assert.True(t, apierrors.IsNotFound(client.Get(t.Context(), kclient.ObjectKeyFromObject(server), &v1.MCPServer{})))
 	require.NoError(t, client.Get(t.Context(), kclient.ObjectKeyFromObject(unrelatedEntry), &v1.MCPServerCatalogEntry{}))
 	require.NoError(t, client.Get(t.Context(), kclient.ObjectKeyFromObject(unrelatedServer), &v1.MCPServer{}))
+
+	response = &router.ResponseWrapper{}
+	require.NoError(t, (&Handler{}).RemoveCatalogChildren(request, response))
+	assert.Zero(t, response.Delay)
 }
 
 func TestRemoveSystemCatalogEntries(t *testing.T) {
@@ -329,17 +336,24 @@ func TestRemoveSystemCatalogEntries(t *testing.T) {
 	}
 	client := newCatalogFakeClient(catalog, entry, unrelated)
 
-	err := (&Handler{}).RemoveSystemCatalogEntries(router.Request{
+	request := router.Request{
 		Client:    client,
 		Ctx:       t.Context(),
 		Object:    catalog,
 		Namespace: catalog.Namespace,
 		Name:      catalog.Name,
-	}, &router.ResponseWrapper{})
+	}
+	response := &router.ResponseWrapper{}
+	err := (&Handler{}).RemoveSystemCatalogEntries(request, response)
 	require.NoError(t, err)
+	assert.Equal(t, catalogRemovalRetryInterval, response.Delay)
 
 	assert.True(t, apierrors.IsNotFound(client.Get(t.Context(), kclient.ObjectKeyFromObject(entry), &v1.SystemMCPServerCatalogEntry{})))
 	require.NoError(t, client.Get(t.Context(), kclient.ObjectKeyFromObject(unrelated), &v1.SystemMCPServerCatalogEntry{}))
+
+	response = &router.ResponseWrapper{}
+	require.NoError(t, (&Handler{}).RemoveSystemCatalogEntries(request, response))
+	assert.Zero(t, response.Delay)
 }
 
 func testCatalog() *v1.MCPCatalog {

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -48,6 +48,8 @@ const (
 	forceSyncStartupAnnotation = "obot.ai/force-sync-startup"
 	// Bump this any time this functionality is needed.
 	startupSyncGeneration = "1"
+
+	catalogRemovalRetryInterval = time.Second
 )
 
 type Handler struct {
@@ -596,7 +598,7 @@ func (h *Handler) SyncSystem(req router.Request, resp router.Response) error {
 // RemoveCatalogChildren replaces child-side deletion watches with parent-side cleanup.
 // Watching an MCPCatalog from every catalog entry and catalog-scoped server causes any
 // catalog status update to reconcile every child at once.
-func (*Handler) RemoveCatalogChildren(req router.Request, _ router.Response) error {
+func (*Handler) RemoveCatalogChildren(req router.Request, resp router.Response) error {
 	catalog := req.Object.(*v1.MCPCatalog)
 
 	var entries v1.MCPServerCatalogEntryList
@@ -622,13 +624,16 @@ func (*Handler) RemoveCatalogChildren(req router.Request, _ router.Response) err
 			return fmt.Errorf("failed to delete server %q for catalog %q: %w", servers.Items[i].Name, catalog.Name, err)
 		}
 	}
+	if len(entries.Items) > 0 || len(servers.Items) > 0 {
+		resp.RetryAfter(catalogRemovalRetryInterval)
+	}
 
 	return nil
 }
 
 // RemoveSystemCatalogEntries performs the deletion cleanup previously provided by
 // every SystemMCPServerCatalogEntry watching its parent catalog.
-func (*Handler) RemoveSystemCatalogEntries(req router.Request, _ router.Response) error {
+func (*Handler) RemoveSystemCatalogEntries(req router.Request, resp router.Response) error {
 	catalog := req.Object.(*v1.SystemMCPCatalog)
 
 	var entries v1.SystemMCPServerCatalogEntryList
@@ -641,6 +646,9 @@ func (*Handler) RemoveSystemCatalogEntries(req router.Request, _ router.Response
 		if err := req.Client.Delete(req.Ctx, &entries.Items[i]); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete entry %q for system catalog %q: %w", entries.Items[i].Name, catalog.Name, err)
 		}
+	}
+	if len(entries.Items) > 0 {
+		resp.RetryAfter(catalogRemovalRetryInterval)
 	}
 
 	return nil

--- a/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
+++ b/pkg/controller/handlers/mcpcatalog/mcpcatalog.go
@@ -593,6 +593,59 @@ func (h *Handler) SyncSystem(req router.Request, resp router.Response) error {
 	return app.Apply(req.Ctx, systemCatalog, toAdd...)
 }
 
+// RemoveCatalogChildren replaces child-side deletion watches with parent-side cleanup.
+// Watching an MCPCatalog from every catalog entry and catalog-scoped server causes any
+// catalog status update to reconcile every child at once.
+func (*Handler) RemoveCatalogChildren(req router.Request, _ router.Response) error {
+	catalog := req.Object.(*v1.MCPCatalog)
+
+	var entries v1.MCPServerCatalogEntryList
+	if err := req.Client.List(req.Ctx, &entries,
+		kclient.InNamespace(catalog.Namespace),
+		kclient.MatchingFields{"spec.mcpCatalogName": catalog.Name}); err != nil {
+		return fmt.Errorf("failed to list entries for catalog %q: %w", catalog.Name, err)
+	}
+	for i := range entries.Items {
+		if err := req.Client.Delete(req.Ctx, &entries.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete entry %q for catalog %q: %w", entries.Items[i].Name, catalog.Name, err)
+		}
+	}
+
+	var servers v1.MCPServerList
+	if err := req.Client.List(req.Ctx, &servers,
+		kclient.InNamespace(catalog.Namespace),
+		kclient.MatchingFields{"spec.mcpCatalogID": catalog.Name}); err != nil {
+		return fmt.Errorf("failed to list servers for catalog %q: %w", catalog.Name, err)
+	}
+	for i := range servers.Items {
+		if err := req.Client.Delete(req.Ctx, &servers.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete server %q for catalog %q: %w", servers.Items[i].Name, catalog.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// RemoveSystemCatalogEntries performs the deletion cleanup previously provided by
+// every SystemMCPServerCatalogEntry watching its parent catalog.
+func (*Handler) RemoveSystemCatalogEntries(req router.Request, _ router.Response) error {
+	catalog := req.Object.(*v1.SystemMCPCatalog)
+
+	var entries v1.SystemMCPServerCatalogEntryList
+	if err := req.Client.List(req.Ctx, &entries,
+		kclient.InNamespace(catalog.Namespace),
+		kclient.MatchingFields{"spec.systemMCPCatalogName": catalog.Name}); err != nil {
+		return fmt.Errorf("failed to list entries for system catalog %q: %w", catalog.Name, err)
+	}
+	for i := range entries.Items {
+		if err := req.Client.Delete(req.Ctx, &entries.Items[i]); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete entry %q for system catalog %q: %w", entries.Items[i].Name, catalog.Name, err)
+		}
+	}
+
+	return nil
+}
+
 func (h *Handler) readSystemMCPCatalog(ctx context.Context, catalogName, sourceURL, token string) ([]kclient.Object, error) {
 	entries, err := readCatalogManifests[types.SystemMCPServerCatalogEntryManifest](ctx, h.httpClient, sourceURL, token)
 	if err != nil {

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -114,9 +114,11 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPCatalog{}).HandlerFunc(mcpCatalog.Sync)
 	root.Type(&v1.MCPCatalog{}).HandlerFunc(mcpCatalog.DeleteUnauthorizedMCPServersForCatalog)
 	root.Type(&v1.MCPCatalog{}).HandlerFunc(mcpCatalog.DeleteUnauthorizedMCPServerInstancesForCatalog)
+	root.Type(&v1.MCPCatalog{}).FinalizeFunc(v1.MCPCatalogFinalizer, mcpCatalog.RemoveCatalogChildren)
 
 	// SystemMCPCatalog
 	root.Type(&v1.SystemMCPCatalog{}).HandlerFunc(mcpCatalog.SyncSystem)
+	root.Type(&v1.SystemMCPCatalog{}).FinalizeFunc(v1.SystemMCPCatalogFinalizer, mcpCatalog.RemoveSystemCatalogEntries)
 
 	// SkillRepository
 	root.Type(&v1.SkillRepository{}).HandlerFunc(skillRepository.Sync)
@@ -163,7 +165,6 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPServerCatalogEntry{}).HandlerFunc(mcpServerCatalogEntryHandler.EnsureOAuthCredentialStatus)
 
 	// SystemMCPServerCatalogEntry
-	root.Type(&v1.SystemMCPServerCatalogEntry{}).HandlerFunc(cleanup.Cleanup)
 	root.Type(&v1.SystemMCPServerCatalogEntry{}).HandlerFunc(mcpServerCatalogEntryHandler.UpdateSystemManifestHashAndLastUpdated)
 
 	// MCPServer

--- a/pkg/storage/apis/obot.obot.ai/v1/catalog_delete_refs_test.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/catalog_delete_refs_test.go
@@ -1,0 +1,32 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogChildrenDoNotWatchCatalogForDeletion(t *testing.T) {
+	entry := &MCPServerCatalogEntry{Spec: MCPServerCatalogEntrySpec{
+		MCPCatalogName:       "default",
+		PowerUserWorkspaceID: "workspace",
+	}}
+	entryRefs := entry.DeleteRefs()
+	require.Len(t, entryRefs, 1)
+	assert.IsType(t, &PowerUserWorkspace{}, entryRefs[0].ObjType)
+	assert.Equal(t, "workspace", entryRefs[0].Name)
+
+	server := &MCPServer{Spec: MCPServerSpec{
+		MCPCatalogID:         "default",
+		PowerUserWorkspaceID: "workspace",
+		CompositeName:        "composite",
+	}}
+	for _, ref := range server.DeleteRefs() {
+		_, isCatalogRef := ref.ObjType.(*MCPCatalog)
+		assert.False(t, isCatalogRef)
+	}
+
+	_, implementsDeleteRefs := any(&SystemMCPServerCatalogEntry{}).(DeleteRefs)
+	assert.False(t, implementsDeleteRefs)
+}

--- a/pkg/storage/apis/obot.obot.ai/v1/constants.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/constants.go
@@ -12,6 +12,8 @@ const (
 	GitCredentialFinalizer         = "obot.obot.ai/git-credential"
 	HostedAgentInstanceFinalizer   = "obot.obot.ai/hosted-agent-instance"
 	HostedAgentPoolFinalizer       = "obot.obot.ai/hosted-agent-pool"
+	MCPCatalogFinalizer            = "obot.obot.ai/mcp-catalog"
+	SystemMCPCatalogFinalizer      = "obot.obot.ai/system-mcp-catalog"
 
 	ModelProviderSyncAnnotation         = "obot.ai/model-provider-sync"
 	MCPCatalogSyncAnnotation            = "obot.ai/mcp-catalog-sync"

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -172,7 +172,6 @@ func (in *MCPServer) FieldNames() []string {
 
 func (in *MCPServer) DeleteRefs() []Ref {
 	refs := []Ref{
-		{ObjType: &MCPCatalog{}, Name: in.Spec.MCPCatalogID},
 		{ObjType: &PowerUserWorkspace{}, Name: in.Spec.PowerUserWorkspaceID},
 		{ObjType: &MCPServer{}, Name: in.Spec.CompositeName},
 		{ObjType: &NanobotAgent{}, Name: in.Spec.NanobotAgentID},

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpservercatalogentry.go
@@ -100,7 +100,6 @@ func (in *MCPServerCatalogEntry) FieldNames() []string {
 
 func (in *MCPServerCatalogEntry) DeleteRefs() []Ref {
 	return []Ref{
-		{ObjType: &MCPCatalog{}, Name: in.Spec.MCPCatalogName},
 		{ObjType: &PowerUserWorkspace{}, Name: in.Spec.PowerUserWorkspaceID},
 	}
 }

--- a/pkg/storage/apis/obot.obot.ai/v1/systemmcpservercatalogentry.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/systemmcpservercatalogentry.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	_ DeleteRefs    = (*SystemMCPServerCatalogEntry)(nil)
 	_ fields.Fields = (*SystemMCPServerCatalogEntry)(nil)
 )
 
@@ -75,8 +74,4 @@ func (in *SystemMCPServerCatalogEntry) FieldNames() []string {
 		"spec.systemMCPCatalogName",
 		"spec.manifest.systemMCPServerType",
 	}
-}
-
-func (in *SystemMCPServerCatalogEntry) DeleteRefs() []Ref {
-	return []Ref{{ObjType: &SystemMCPCatalog{}, Name: in.Spec.SystemMCPCatalogName}}
 }


### PR DESCRIPTION
`sql slow query` is our number one log statement. im on a mission to eliminate it!

## Summary

- stop catalog status updates from re-enqueuing every catalog entry and catalog-scoped MCP server
- preserve catalog deletion cleanup with parent-owned finalizers
- retain scheduled source reads, apply, drift repair, and pruning
- document the ownership decision in an ADR

## Why

Catalog children used `DeleteRefs` to reference their parent catalog. Those references also became dependency watches, so routine `MCPCatalog` status writes during an unchanged refresh reconciled hundreds of children at once. The resulting credential queries saturated the database connection pool and appeared as slow SQL despite taking very little time inside PostgreSQL.

## Validation

- Local A/B test with 241 catalog entries, PostgreSQL, a five-connection pool, and 5 ms database latency
- Before: 1,328 credential deletes in a 16-second unchanged-refresh window; 13.21 ms total PostgreSQL execution time, with 200+ ms application timings from pool waiting
- After: zero credential deletes in the equivalent unchanged-refresh window
- Verified a real source change synchronized successfully
- Verified out-of-band drift was repaired
- Verified removing a source entry pruned it
- `go test ./pkg/controller/... ./pkg/storage/...`
- `make lint` (0 issues)
