### PR TITLE
fix: reconcile OAuth credentials for catalog entries in one pass

### DIFF
--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -1979,6 +1979,17 @@ func (h *MCPCatalogHandler) DeleteOAuthCredentials(req api.Context) error {
 		return err
 	}
 
+	// Written before the credential is deleted. The controller decides whether an entry is worth a
+	// credential query from its status and this annotation, so a delete that lands without it
+	// leaves the status reading configured with nothing left to correct it.
+	if entry.Annotations == nil {
+		entry.Annotations = make(map[string]string, 1)
+	}
+	entry.Annotations[v1.MCPServerCatalogEntrySyncAnnotation] = "true"
+	if err := req.Update(entry); err != nil {
+		return fmt.Errorf("failed to trigger reconciliation: %w", err)
+	}
+
 	credName := system.MCPOAuthCredentialName(entry.Name)
 	deleted, err := req.GatewayClient.DeleteCredential(req.Context(), credName, system.StaticOAuthCredentialName)
 	if err != nil {
@@ -1995,15 +2006,6 @@ func (h *MCPCatalogHandler) DeleteOAuthCredentials(req api.Context) error {
 				slog.Warn("failed to delete OAuth tokens for MCP server", "serverName", server.Name, "catalogEntryName", entry.Name, "error", err)
 			}
 		}
-	}
-
-	// Trigger reconciliation to update the status
-	if entry.Annotations == nil {
-		entry.Annotations = make(map[string]string, 1)
-	}
-	entry.Annotations[v1.MCPServerCatalogEntrySyncAnnotation] = "true"
-	if err := req.Update(entry); err != nil {
-		return fmt.Errorf("failed to trigger reconciliation: %w", err)
 	}
 
 	return req.Write(map[string]bool{"deleted": deleted})

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -269,11 +269,11 @@ func requiresStaticOAuth(entry *v1.MCPServerCatalogEntry) bool {
 // The delete and the status update must stay in one handler. nah runs every handler for a type
 // even after an earlier one errors, so as two handlers a failed delete did not stop the status
 // being cleared, and a cleared status meant the entry was never queried again.
-func (h *Handler) ReconcileOAuthCredential(req router.Request, resp router.Response) error {
-	return reconcileOAuthCredential(req, resp, h.gatewayClient)
+func (h *Handler) ReconcileOAuthCredential(req router.Request, _ router.Response) error {
+	return reconcileOAuthCredential(req, h.gatewayClient)
 }
 
-func reconcileOAuthCredential(req router.Request, _ router.Response, creds credentialClient) error {
+func reconcileOAuthCredential(req router.Request, creds credentialClient) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
 
 	// Set by the API after it writes or deletes a credential.

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -346,17 +346,17 @@ func syncOAuthCredential(ctx context.Context, creds credentialClient, entry *v1.
 }
 
 // RemoveOAuthCredentials removes OAuth credentials when a catalog entry is deleted.
-func (h *Handler) RemoveOAuthCredentials(req router.Request, resp router.Response) error {
-	return removeOAuthCredentials(req, resp, h.gatewayClient)
+func (h *Handler) RemoveOAuthCredentials(req router.Request, _ router.Response) error {
+	return removeOAuthCredentials(req, h.gatewayClient)
 }
 
-func removeOAuthCredentials(req router.Request, _ router.Response, creds credentialClient) error {
+func removeOAuthCredentials(req router.Request, creds credentialClient) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
 
-	// Always sweep a remote entry, since being wrong on the way out strands the credential. Sweep
-	// any other runtime only when the status or a pending annotation says one may still exist.
+	// An entry on its way out is always swept, since being wrong there strands the credential. The
+	// rest of the guard only matters if this is ever called outside the deletion path.
 	_, recheck := entry.Annotations[v1.MCPServerCatalogEntrySyncAnnotation]
-	if entry.Spec.Manifest.Runtime != types.RuntimeRemote && !entry.Status.OAuthCredentialConfigured && !recheck {
+	if entry.Spec.Manifest.Runtime != types.RuntimeRemote && !entry.Status.OAuthCredentialConfigured && !recheck && entry.DeletionTimestamp.IsZero() {
 		return nil
 	}
 

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -1,6 +1,7 @@
 package mcpservercatalogentry
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,6 +11,7 @@ import (
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/controller/handlers/mcpserver"
 	gclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/obot-platform/obot/pkg/utils"
@@ -18,6 +20,14 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// credentialClient is the slice of the gateway client the OAuth reconcile uses. Taking it as a
+// parameter rather than storing it keeps the reconcile exercisable without a database behind it,
+// and leaves the Handler holding the concrete client the rest of its methods need.
+type credentialClient interface {
+	RevealCredential(ctx context.Context, contexts []string, name string) (gatewaytypes.Credential, error)
+	DeleteCredential(ctx context.Context, credentialContext, name string) (bool, error)
+}
 
 // Handler handles operations for MCP server catalog entries
 type Handler struct {
@@ -247,93 +257,147 @@ func (*Handler) CleanupNestedCompositeEntries(req router.Request, _ router.Respo
 	return kclient.IgnoreNotFound(req.Client.Update(req.Ctx, entry))
 }
 
-// CleanupUnusedOAuthCredentials removes OAuth credentials for remote catalog entries
-// that no longer require static OAuth configuration.
-func (h *Handler) CleanupUnusedOAuthCredentials(req router.Request, _ router.Response) error {
-	entry := req.Object.(*v1.MCPServerCatalogEntry)
-
-	// Only process remote entries
-	if entry.Spec.Manifest.Runtime != types.RuntimeRemote {
-		return nil
-	}
-
-	// Only cleanup if RemoteConfig exists and StaticOAuthRequired is false
-	if entry.Spec.Manifest.RemoteConfig != nil && entry.Spec.Manifest.RemoteConfig.StaticOAuthRequired {
-		return nil
-	}
-
-	deleted, err := h.gatewayClient.DeleteCredential(req.Ctx, system.MCPOAuthCredentialName(entry.Name), system.StaticOAuthCredentialName)
-	if err != nil {
-		return fmt.Errorf("failed to delete OAuth credential: %w", err)
-	}
-	if deleted {
-		slog.Info("Deleted unused static OAuth credential for MCP catalog entry", "entry", entry.Name)
-	}
-
-	return nil
+// requiresStaticOAuth reports whether entry is configured to use a static OAuth client. Only
+// entries in that shape ever have a static OAuth credential.
+func requiresStaticOAuth(entry *v1.MCPServerCatalogEntry) bool {
+	return entry.Spec.Manifest.Runtime == types.RuntimeRemote &&
+		entry.Spec.Manifest.RemoteConfig != nil &&
+		entry.Spec.Manifest.RemoteConfig.StaticOAuthRequired
 }
 
-// EnsureOAuthCredentialStatus updates the OAuthCredentialConfigured status field
-// for remote catalog entries that require static OAuth.
-func (h *Handler) EnsureOAuthCredentialStatus(req router.Request, _ router.Response) error {
+// ReconcileOAuthCredential keeps an entry's static OAuth credential and the
+// Status.OAuthCredentialConfigured record of it in agreement.
+//
+// The status is what lets this handler stay quiet. It queries the credential store only in the
+// states where that record could be wrong:
+//
+//   - An entry that requires static OAuth but is not recorded as configured is re-read on every
+//     pass. A credential can appear without the controller being told, because the API writes the
+//     credential first and sets the sync annotation second, so a failure in between leaves a
+//     credential with nothing pointing at it. This is the path that repairs such a status.
+//   - An entry already recorded as configured is trusted. Every path that removes a credential
+//     either sets the sync annotation or deletes the entry outright, so the record cannot go stale
+//     without one of those firing. If the annotation write of a removal fails, the status reads
+//     configured until the API is used again, which shows a stale value but cannot orphan a
+//     credential.
+//   - Everything else is left alone, which is most of a catalog. This used to be the expensive
+//     case: every remote entry that does not require static OAuth issued a DELETE matching zero
+//     rows on every reconcile, 168 of the 207 entries in the default catalog, in a burst of one
+//     query per entry through a connection pool of five.
+//
+// Deleting a credential and clearing the status have to happen in that order and in one handler.
+// nah runs every handler registered for a type even after an earlier one returns an error, so
+// while these were two handlers a failed delete did not stop the status from being cleared, and
+// an entry that lost its status that way would never be looked at again.
+func (h *Handler) ReconcileOAuthCredential(req router.Request, resp router.Response) error {
+	return reconcileOAuthCredential(req, resp, h.gatewayClient)
+}
+
+func reconcileOAuthCredential(req router.Request, _ router.Response, creds credentialClient) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
 
-	// Clear sync annotation if present
-	if _, exists := entry.Annotations[v1.MCPServerCatalogEntrySyncAnnotation]; exists {
-		delete(entry.Annotations, v1.MCPServerCatalogEntrySyncAnnotation)
-		if err := req.Client.Update(req.Ctx, entry); err != nil {
-			return fmt.Errorf("failed to clear sync annotation: %w", err)
-		}
-		slog.Info("Cleared sync annotation for MCP catalog entry", "entry", entry.Name)
-	}
+	// Set by the API after it writes or deletes a credential, so this pass reads the store
+	// instead of trusting a status that predates the write.
+	_, recheck := entry.Annotations[v1.MCPServerCatalogEntrySyncAnnotation]
 
-	// Only process remote entries that require static OAuth
-	if entry.Spec.Manifest.Runtime != types.RuntimeRemote ||
-		entry.Spec.Manifest.RemoteConfig == nil ||
-		!entry.Spec.Manifest.RemoteConfig.StaticOAuthRequired {
-		// Clear status if not applicable
-		if entry.Status.OAuthCredentialConfigured {
-			entry.Status.OAuthCredentialConfigured = false
-			slog.Info("Cleared static OAuth credential status for MCP catalog entry", "entry", entry.Name)
-			return req.Client.Status().Update(req.Ctx, entry)
-		}
-
-		return nil
-	}
-
-	// Check if credentials exist
-	credName := system.MCPOAuthCredentialName(entry.Name)
-	_, err := h.gatewayClient.RevealCredential(req.Ctx, []string{credName}, system.StaticOAuthCredentialName)
-
-	var configured bool
-	if err == nil {
-		configured = true
-	} else if !errors.As(err, &gclient.CredentialNotFoundError{}) {
-		return fmt.Errorf("failed to check credential status: %w", err)
+	configured, err := syncOAuthCredential(req.Ctx, creds, entry, recheck)
+	if err != nil {
+		return err
 	}
 
 	if entry.Status.OAuthCredentialConfigured != configured {
 		entry.Status.OAuthCredentialConfigured = configured
 		slog.Info("Updated static OAuth credential status for MCP catalog entry", "entry", entry.Name, "configured", configured)
-		return req.Client.Status().Update(req.Ctx, entry)
+		if err := req.Client.Status().Update(req.Ctx, entry); err != nil {
+			return fmt.Errorf("failed to update OAuth credential status: %w", err)
+		}
 	}
+
+	if !recheck {
+		return nil
+	}
+
+	// Cleared last, so that a failure anywhere above leaves the recheck pending for the next pass.
+	delete(entry.Annotations, v1.MCPServerCatalogEntrySyncAnnotation)
+	if err := req.Client.Update(req.Ctx, entry); err != nil {
+		return fmt.Errorf("failed to clear sync annotation: %w", err)
+	}
+	slog.Info("Cleared sync annotation for MCP catalog entry", "entry", entry.Name)
 
 	return nil
 }
 
+// syncOAuthCredential brings the credential store in line with entry and reports whether a static
+// OAuth credential exists for it afterwards.
+func syncOAuthCredential(ctx context.Context, creds credentialClient, entry *v1.MCPServerCatalogEntry, recheck bool) (bool, error) {
+	credName := system.MCPOAuthCredentialName(entry.Name)
+
+	if requiresStaticOAuth(entry) {
+		if entry.Status.OAuthCredentialConfigured && !recheck {
+			return true, nil
+		}
+
+		_, err := creds.RevealCredential(ctx, []string{credName}, system.StaticOAuthCredentialName)
+		if err == nil {
+			return true, nil
+		}
+		if !errors.As(err, &gclient.CredentialNotFoundError{}) {
+			return false, fmt.Errorf("failed to check OAuth credential status: %w", err)
+		}
+
+		return false, nil
+	}
+
+	// The entry does not use a static OAuth client, so any credential it holds is left over from
+	// when it did. The runtime is deliberately not checked here: an entry converted away from
+	// remote keeps its credential under the same name, and nothing else would ever remove it.
+	//
+	// recheck is what makes a credential the status does not know about visible here, for the case
+	// where the manifest stops requiring static OAuth between the API writing a credential and this
+	// handler observing it. The status is still clear at that point, so the annotation is the only
+	// sign that there is anything to delete.
+	//
+	// A credential written by an API call whose annotation update then failed reaches the same
+	// state with no annotation to go on, and this guard skips it. That needs the entry to lose
+	// staticOAuthRequired before the reconcile the failed update queued, and it leaves a credential
+	// only removable by hand.
+	if !entry.Status.OAuthCredentialConfigured && !recheck {
+		return false, nil
+	}
+
+	deleted, err := creds.DeleteCredential(ctx, credName, system.StaticOAuthCredentialName)
+	if err != nil {
+		return false, fmt.Errorf("failed to delete OAuth credential: %w", err)
+	}
+	if deleted {
+		slog.Info("Deleted unused static OAuth credential for MCP catalog entry", "entry", entry.Name)
+	}
+
+	return false, nil
+}
+
 // RemoveOAuthCredentials removes OAuth credentials when a catalog entry is deleted.
-func (h *Handler) RemoveOAuthCredentials(req router.Request, _ router.Response) error {
+func (h *Handler) RemoveOAuthCredentials(req router.Request, resp router.Response) error {
+	return removeOAuthCredentials(req, resp, h.gatewayClient)
+}
+
+func removeOAuthCredentials(req router.Request, _ router.Response, creds credentialClient) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
 
-	// Only process remote entries
-	if entry.Spec.Manifest.Runtime != types.RuntimeRemote {
+	// A remote entry is always swept, because getting this wrong on the way out leaves a credential
+	// nothing will ever look at again. Any other runtime is swept only when something says it may
+	// still hold a credential from back when it was remote, which keeps the deletion of an ordinary
+	// entry query-free. The sync annotation counts as well as the status, since it is the only sign
+	// left when the API wrote a credential that no reconcile has observed yet.
+	_, recheck := entry.Annotations[v1.MCPServerCatalogEntrySyncAnnotation]
+	if entry.Spec.Manifest.Runtime != types.RuntimeRemote && !entry.Status.OAuthCredentialConfigured && !recheck {
 		return nil
 	}
 
 	// Build the credential name for this entry
 	credName := system.MCPOAuthCredentialName(entry.Name)
 
-	deleted, err := h.gatewayClient.DeleteCredential(req.Ctx, credName, system.StaticOAuthCredentialName)
+	deleted, err := creds.DeleteCredential(req.Ctx, credName, system.StaticOAuthCredentialName)
 	if err != nil {
 		return fmt.Errorf("failed to delete OAuth credential: %w", err)
 	}

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry.go
@@ -21,9 +21,6 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// credentialClient is the slice of the gateway client the OAuth reconcile uses. Taking it as a
-// parameter rather than storing it keeps the reconcile exercisable without a database behind it,
-// and leaves the Handler holding the concrete client the rest of its methods need.
 type credentialClient interface {
 	RevealCredential(ctx context.Context, contexts []string, name string) (gatewaytypes.Credential, error)
 	DeleteCredential(ctx context.Context, credentialContext, name string) (bool, error)
@@ -265,30 +262,13 @@ func requiresStaticOAuth(entry *v1.MCPServerCatalogEntry) bool {
 		entry.Spec.Manifest.RemoteConfig.StaticOAuthRequired
 }
 
-// ReconcileOAuthCredential keeps an entry's static OAuth credential and the
-// Status.OAuthCredentialConfigured record of it in agreement.
+// ReconcileOAuthCredential keeps an entry's static OAuth credential and
+// Status.OAuthCredentialConfigured in agreement, querying the credential store only when that
+// status could be wrong.
 //
-// The status is what lets this handler stay quiet. It queries the credential store only in the
-// states where that record could be wrong:
-//
-//   - An entry that requires static OAuth but is not recorded as configured is re-read on every
-//     pass. A credential can appear without the controller being told, because the API writes the
-//     credential first and sets the sync annotation second, so a failure in between leaves a
-//     credential with nothing pointing at it. This is the path that repairs such a status.
-//   - An entry already recorded as configured is trusted. Every path that removes a credential
-//     either sets the sync annotation or deletes the entry outright, so the record cannot go stale
-//     without one of those firing. If the annotation write of a removal fails, the status reads
-//     configured until the API is used again, which shows a stale value but cannot orphan a
-//     credential.
-//   - Everything else is left alone, which is most of a catalog. This used to be the expensive
-//     case: every remote entry that does not require static OAuth issued a DELETE matching zero
-//     rows on every reconcile, 168 of the 207 entries in the default catalog, in a burst of one
-//     query per entry through a connection pool of five.
-//
-// Deleting a credential and clearing the status have to happen in that order and in one handler.
-// nah runs every handler registered for a type even after an earlier one returns an error, so
-// while these were two handlers a failed delete did not stop the status from being cleared, and
-// an entry that lost its status that way would never be looked at again.
+// The delete and the status update must stay in one handler. nah runs every handler for a type
+// even after an earlier one errors, so as two handlers a failed delete did not stop the status
+// being cleared, and a cleared status meant the entry was never queried again.
 func (h *Handler) ReconcileOAuthCredential(req router.Request, resp router.Response) error {
 	return reconcileOAuthCredential(req, resp, h.gatewayClient)
 }
@@ -296,8 +276,7 @@ func (h *Handler) ReconcileOAuthCredential(req router.Request, resp router.Respo
 func reconcileOAuthCredential(req router.Request, _ router.Response, creds credentialClient) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
 
-	// Set by the API after it writes or deletes a credential, so this pass reads the store
-	// instead of trusting a status that predates the write.
+	// Set by the API after it writes or deletes a credential.
 	_, recheck := entry.Annotations[v1.MCPServerCatalogEntrySyncAnnotation]
 
 	configured, err := syncOAuthCredential(req.Ctx, creds, entry, recheck)
@@ -317,7 +296,7 @@ func reconcileOAuthCredential(req router.Request, _ router.Response, creds crede
 		return nil
 	}
 
-	// Cleared last, so that a failure anywhere above leaves the recheck pending for the next pass.
+	// Cleared last, so a failure above leaves the recheck pending.
 	delete(entry.Annotations, v1.MCPServerCatalogEntrySyncAnnotation)
 	if err := req.Client.Update(req.Ctx, entry); err != nil {
 		return fmt.Errorf("failed to clear sync annotation: %w", err)
@@ -327,8 +306,8 @@ func reconcileOAuthCredential(req router.Request, _ router.Response, creds crede
 	return nil
 }
 
-// syncOAuthCredential brings the credential store in line with entry and reports whether a static
-// OAuth credential exists for it afterwards.
+// syncOAuthCredential brings the credential store in line with entry and reports whether a
+// credential exists for it afterwards.
 func syncOAuthCredential(ctx context.Context, creds credentialClient, entry *v1.MCPServerCatalogEntry, recheck bool) (bool, error) {
 	credName := system.MCPOAuthCredentialName(entry.Name)
 
@@ -348,19 +327,9 @@ func syncOAuthCredential(ctx context.Context, creds credentialClient, entry *v1.
 		return false, nil
 	}
 
-	// The entry does not use a static OAuth client, so any credential it holds is left over from
-	// when it did. The runtime is deliberately not checked here: an entry converted away from
-	// remote keeps its credential under the same name, and nothing else would ever remove it.
-	//
-	// recheck is what makes a credential the status does not know about visible here, for the case
-	// where the manifest stops requiring static OAuth between the API writing a credential and this
-	// handler observing it. The status is still clear at that point, so the annotation is the only
-	// sign that there is anything to delete.
-	//
-	// A credential written by an API call whose annotation update then failed reaches the same
-	// state with no annotation to go on, and this guard skips it. That needs the entry to lose
-	// staticOAuthRequired before the reconcile the failed update queued, and it leaves a credential
-	// only removable by hand.
+	// Any credential here is left over from when the entry did use static OAuth. The runtime is
+	// not checked, because an entry changed away from remote keeps its credential under the same
+	// name and nothing else would remove it.
 	if !entry.Status.OAuthCredentialConfigured && !recheck {
 		return false, nil
 	}
@@ -384,11 +353,8 @@ func (h *Handler) RemoveOAuthCredentials(req router.Request, resp router.Respons
 func removeOAuthCredentials(req router.Request, _ router.Response, creds credentialClient) error {
 	entry := req.Object.(*v1.MCPServerCatalogEntry)
 
-	// A remote entry is always swept, because getting this wrong on the way out leaves a credential
-	// nothing will ever look at again. Any other runtime is swept only when something says it may
-	// still hold a credential from back when it was remote, which keeps the deletion of an ordinary
-	// entry query-free. The sync annotation counts as well as the status, since it is the only sign
-	// left when the API wrote a credential that no reconcile has observed yet.
+	// Always sweep a remote entry, since being wrong on the way out strands the credential. Sweep
+	// any other runtime only when the status or a pending annotation says one may still exist.
 	_, recheck := entry.Annotations[v1.MCPServerCatalogEntrySyncAnnotation]
 	if entry.Spec.Manifest.Runtime != types.RuntimeRemote && !entry.Status.OAuthCredentialConfigured && !recheck {
 		return nil

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
@@ -1,10 +1,14 @@
 package mcpservercatalogentry
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/apiclient/types"
+	gclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/stretchr/testify/assert"
@@ -12,6 +16,18 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+// fakeCredentialClient counts the queries a reconcile issues, so that "this entry costs nothing
+// to reconcile" is an assertion rather than something inferred from the absence of a panic.
+type fakeCredentialClient struct {
+	// exists is whether the store holds a credential for the entry under test.
+	exists    bool
+	revealErr error
+	deleteErr error
+
+	reveals int
+	deletes int
+}
 
 func TestDetectCompositeDriftMarksEntryNeedingUpdateWhenMultiUserComponentDrifts(t *testing.T) {
 	componentSnapshot := types.MCPServerCatalogEntryManifest{
@@ -424,5 +440,276 @@ func newMCPServer(name string, manifest types.MCPServerManifest) *v1.MCPServer {
 		Spec: v1.MCPServerSpec{
 			Manifest: manifest,
 		},
+	}
+}
+
+func (f *fakeCredentialClient) RevealCredential(_ context.Context, contexts []string, name string) (gatewaytypes.Credential, error) {
+	f.reveals++
+	if f.revealErr != nil {
+		return gatewaytypes.Credential{}, f.revealErr
+	}
+	if !f.exists {
+		return gatewaytypes.Credential{}, gclient.CredentialNotFoundError{Contexts: contexts, Name: name}
+	}
+	return gatewaytypes.Credential{Context: contexts[0], Name: name}, nil
+}
+
+func (f *fakeCredentialClient) DeleteCredential(_ context.Context, _, _ string) (bool, error) {
+	f.deletes++
+	if f.deleteErr != nil {
+		return false, f.deleteErr
+	}
+	deleted := f.exists
+	f.exists = false
+	return deleted, nil
+}
+
+func remoteEntry(staticOAuthRequired bool) *v1.MCPServerCatalogEntry {
+	return newMCPServerCatalogEntry("remote-entry", types.MCPServerCatalogEntryManifest{
+		Name:    "Remote Template",
+		Runtime: types.RuntimeRemote,
+		RemoteConfig: &types.RemoteCatalogConfig{
+			FixedURL:            "https://example.com/mcp",
+			StaticOAuthRequired: staticOAuthRequired,
+		},
+	})
+}
+
+// runOAuthReconcile runs the handler against a fake API and returns the entry as it was
+// left in storage.
+func runOAuthReconcile(t *testing.T, creds *fakeCredentialClient, entry *v1.MCPServerCatalogEntry) (v1.MCPServerCatalogEntry, error) {
+	t.Helper()
+
+	client := newFakeClient(entry)
+	err := reconcileOAuthCredential(router.Request{
+		Client:    client,
+		Ctx:       t.Context(),
+		Object:    entry,
+		Namespace: entry.Namespace,
+		Name:      entry.Name,
+	}, &router.ResponseWrapper{}, creds)
+
+	var stored v1.MCPServerCatalogEntry
+	require.NoError(t, client.Get(t.Context(), router.Key(entry.Namespace, entry.Name), &stored))
+	return stored, err
+}
+
+func TestReconcileOAuthCredential(t *testing.T) {
+	tests := []struct {
+		name string
+		// entry is the object as the controller sees it at the start of the pass.
+		entry func() *v1.MCPServerCatalogEntry
+		// exists is whether the credential store already holds a credential for it.
+		exists         bool
+		wantReveals    int
+		wantDeletes    int
+		wantConfigured bool
+	}{
+		{
+			// The steady state for most of a catalog, and the case this handler exists to keep
+			// free: a remote entry that never had a static OAuth credential.
+			name:  "entry with no credential recorded is left alone",
+			entry: func() *v1.MCPServerCatalogEntry { return remoteEntry(false) },
+		},
+		{
+			// The other steady state: a configured entry that still requires static OAuth. The
+			// status already answers the question, so the store is not read.
+			name: "configured entry that still requires static OAuth is left alone",
+			entry: func() *v1.MCPServerCatalogEntry {
+				e := remoteEntry(true)
+				e.Status.OAuthCredentialConfigured = true
+				return e
+			},
+			exists:         true,
+			wantConfigured: true,
+		},
+		{
+			name: "credential is deleted once the entry stops requiring static OAuth",
+			entry: func() *v1.MCPServerCatalogEntry {
+				e := remoteEntry(false)
+				e.Status.OAuthCredentialConfigured = true
+				return e
+			},
+			exists:      true,
+			wantDeletes: 1,
+		},
+		{
+			// An entry converted away from the remote runtime keeps its credential under the same
+			// name, and nothing else would ever remove it.
+			name: "credential is deleted once the entry stops being remote",
+			entry: func() *v1.MCPServerCatalogEntry {
+				e := newMCPServerCatalogEntry("converted-entry", types.MCPServerCatalogEntryManifest{
+					Name:    "Converted Template",
+					Runtime: types.RuntimeContainerized,
+					ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+						Image: "example/mcp:1.0.0",
+					},
+				})
+				e.Status.OAuthCredentialConfigured = true
+				return e
+			},
+			exists:      true,
+			wantDeletes: 1,
+		},
+		{
+			// SetOAuthCredentials writes the credential before it sets the annotation, so a
+			// failure in between leaves a credential the controller has no record of. Reading the
+			// store whenever the status is clear is what repairs that.
+			name:           "credential written without the annotation landing is recorded",
+			entry:          func() *v1.MCPServerCatalogEntry { return remoteEntry(true) },
+			exists:         true,
+			wantReveals:    1,
+			wantConfigured: true,
+		},
+		{
+			name:        "entry that requires static OAuth but has no credential stays unconfigured",
+			entry:       func() *v1.MCPServerCatalogEntry { return remoteEntry(true) },
+			wantReveals: 1,
+		},
+		{
+			// How a delete through the API reaches the status: the annotation forces a read of a
+			// store the status would otherwise be trusted for.
+			name: "sync annotation rechecks an entry recorded as configured",
+			entry: func() *v1.MCPServerCatalogEntry {
+				e := remoteEntry(true)
+				e.Status.OAuthCredentialConfigured = true
+				e.Annotations = map[string]string{v1.MCPServerCatalogEntrySyncAnnotation: "true"}
+				return e
+			},
+			wantReveals: 1,
+		},
+		{
+			// The race the annotation covers on the cleanup side: the manifest stops requiring
+			// static OAuth between the API writing a credential and this handler observing it, so
+			// the status is clear even though a credential exists.
+			name: "sync annotation cleans up a credential the status never recorded",
+			entry: func() *v1.MCPServerCatalogEntry {
+				e := remoteEntry(false)
+				e.Annotations = map[string]string{v1.MCPServerCatalogEntrySyncAnnotation: "true"}
+				return e
+			},
+			exists:      true,
+			wantDeletes: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := tt.entry()
+			_, hadAnnotation := entry.Annotations[v1.MCPServerCatalogEntrySyncAnnotation]
+			creds := &fakeCredentialClient{exists: tt.exists}
+
+			stored, err := runOAuthReconcile(t, creds, entry)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantReveals, creds.reveals, "credential reads")
+			assert.Equal(t, tt.wantDeletes, creds.deletes, "credential deletes")
+			assert.Equal(t, tt.wantConfigured, stored.Status.OAuthCredentialConfigured)
+			if hadAnnotation {
+				assert.NotContains(t, stored.Annotations, v1.MCPServerCatalogEntrySyncAnnotation,
+					"a completed recheck should clear the annotation")
+			}
+		})
+	}
+}
+
+// The status is the only record that a credential exists, so it must not be cleared on a pass
+// where the delete did not happen. nah runs every handler registered for a type even after an
+// earlier one returns an error, which is why the delete and the status update have to be one
+// handler rather than two.
+func TestReconcileOAuthCredentialKeepsStatusWhenDeleteFails(t *testing.T) {
+	entry := remoteEntry(false)
+	entry.Status.OAuthCredentialConfigured = true
+	creds := &fakeCredentialClient{exists: true, deleteErr: errors.New("connection refused")}
+
+	stored, err := runOAuthReconcile(t, creds, entry)
+
+	require.ErrorContains(t, err, "connection refused")
+	assert.Equal(t, 1, creds.deletes)
+	assert.True(t, stored.Status.OAuthCredentialConfigured,
+		"status must survive a failed delete so the next pass retries it")
+}
+
+// Same reasoning for the annotation: it is the only signal that the status cannot be trusted, so
+// a pass that fails has to leave it in place.
+func TestReconcileOAuthCredentialKeepsSyncAnnotationWhenRecheckFails(t *testing.T) {
+	entry := remoteEntry(true)
+	entry.Status.OAuthCredentialConfigured = true
+	entry.Annotations = map[string]string{v1.MCPServerCatalogEntrySyncAnnotation: "true"}
+	creds := &fakeCredentialClient{revealErr: errors.New("connection refused")}
+
+	stored, err := runOAuthReconcile(t, creds, entry)
+
+	require.ErrorContains(t, err, "connection refused")
+	assert.Contains(t, stored.Annotations, v1.MCPServerCatalogEntrySyncAnnotation,
+		"annotation must survive a failed recheck so the next pass retries it")
+}
+
+// The sync annotation is the only sign a credential exists on an entry the controller has not
+// reconciled since the API wrote one, so the finalizer has to honor it too. Otherwise an entry
+// that is set up, converted away from remote, and deleted before any reconcile runs takes its
+// credential with it and nothing is left to delete it.
+func TestRemoveOAuthCredentialsOnDeletedEntry(t *testing.T) {
+	converted := func() *v1.MCPServerCatalogEntry {
+		return newMCPServerCatalogEntry("converted-entry", types.MCPServerCatalogEntryManifest{
+			Name:    "Converted Template",
+			Runtime: types.RuntimeContainerized,
+			ContainerizedConfig: &types.ContainerizedRuntimeConfig{
+				Image: "example/mcp:1.0.0",
+			},
+		})
+	}
+
+	tests := []struct {
+		name        string
+		entry       func() *v1.MCPServerCatalogEntry
+		wantDeletes int
+	}{
+		{
+			name:        "remote entry is always swept",
+			entry:       func() *v1.MCPServerCatalogEntry { return remoteEntry(false) },
+			wantDeletes: 1,
+		},
+		{
+			name:        "ordinary entry of another runtime is left alone",
+			entry:       converted,
+			wantDeletes: 0,
+		},
+		{
+			name: "entry of another runtime recorded as configured is swept",
+			entry: func() *v1.MCPServerCatalogEntry {
+				e := converted()
+				e.Status.OAuthCredentialConfigured = true
+				return e
+			},
+			wantDeletes: 1,
+		},
+		{
+			name: "entry of another runtime with a pending recheck is swept",
+			entry: func() *v1.MCPServerCatalogEntry {
+				e := converted()
+				e.Annotations = map[string]string{v1.MCPServerCatalogEntrySyncAnnotation: "true"}
+				return e
+			},
+			wantDeletes: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := tt.entry()
+			creds := &fakeCredentialClient{exists: true}
+
+			err := removeOAuthCredentials(router.Request{
+				Client:    newFakeClient(entry),
+				Ctx:       t.Context(),
+				Object:    entry,
+				Namespace: entry.Namespace,
+				Name:      entry.Name,
+			}, &router.ResponseWrapper{}, creds)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDeletes, creds.deletes)
+		})
 	}
 }

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/apiclient/types"
@@ -13,6 +14,7 @@ import (
 	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -685,6 +687,16 @@ func TestRemoveOAuthCredentialsOnDeletedEntry(t *testing.T) {
 			wantDeletes: 1,
 		},
 		{
+			name: "entry of another runtime being deleted is swept",
+			entry: func() *v1.MCPServerCatalogEntry {
+				e := converted()
+				e.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				e.Finalizers = []string{v1.MCPServerCatalogEntryFinalizer}
+				return e
+			},
+			wantDeletes: 1,
+		},
+		{
 			name: "entry of another runtime with a pending recheck is swept",
 			entry: func() *v1.MCPServerCatalogEntry {
 				e := converted()
@@ -706,7 +718,7 @@ func TestRemoveOAuthCredentialsOnDeletedEntry(t *testing.T) {
 				Object:    entry,
 				Namespace: entry.Namespace,
 				Name:      entry.Name,
-			}, &router.ResponseWrapper{}, creds)
+			}, creds)
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantDeletes, creds.deletes)

--- a/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
+++ b/pkg/controller/handlers/mcpservercatalogentry/mcpservercatalogentry_test.go
@@ -489,7 +489,7 @@ func runOAuthReconcile(t *testing.T, creds *fakeCredentialClient, entry *v1.MCPS
 		Object:    entry,
 		Namespace: entry.Namespace,
 		Name:      entry.Name,
-	}, &router.ResponseWrapper{}, creds)
+	}, creds)
 
 	var stored v1.MCPServerCatalogEntry
 	require.NoError(t, client.Get(t.Context(), router.Key(entry.Namespace, entry.Name), &stored))

--- a/pkg/controller/routes.go
+++ b/pkg/controller/routes.go
@@ -159,8 +159,7 @@ func (c *Controller) setupRoutes() {
 	root.Type(&v1.MCPServerCatalogEntry{}).HandlerFunc(mcpServerCatalogEntryHandler.CleanupNestedCompositeEntries)
 	root.Type(&v1.MCPServerCatalogEntry{}).HandlerFunc(mcpServerCatalogEntryHandler.DetectCompositeDrift)
 	root.Type(&v1.MCPServerCatalogEntry{}).HandlerFunc(mcpServerCatalogEntryHandler.EnsureUserCount)
-	root.Type(&v1.MCPServerCatalogEntry{}).HandlerFunc(mcpServerCatalogEntryHandler.CleanupUnusedOAuthCredentials)
-	root.Type(&v1.MCPServerCatalogEntry{}).HandlerFunc(mcpServerCatalogEntryHandler.EnsureOAuthCredentialStatus)
+	root.Type(&v1.MCPServerCatalogEntry{}).HandlerFunc(mcpServerCatalogEntryHandler.ReconcileOAuthCredential)
 
 	// SystemMCPServerCatalogEntry
 	root.Type(&v1.SystemMCPServerCatalogEntry{}).HandlerFunc(cleanup.Cleanup)


### PR DESCRIPTION
## Why

These handlers are the largest single source of slow query log lines, and the point of this change is to eliminate that noise.

kinm logs any statement over 200ms as `sql query slow`, and the time it measures includes waiting for a connection from a pool of five. The shared environment logs 59,057 of those lines in 24 hours. In the main deployment, which is quieter, the same log holds 2,860 lines, and 801 of them are the single delete this change removes, at a median of 355ms across 194 distinct catalog entries.

None of that is database work. Query Insights puts the mean execution time of the statement itself at about 50 microseconds, and the entries carry `affected=0`, so these are cheap queries that matched nothing and spent their time queueing for a connection.

I want to also explicitly note that I'm trying to keep this PR as small as possible to just get the win we want. There are some pre-existing edge case bugs mentioned at the bottom that I am intentionally not addressing. This pr doesnt make any of them worse; it only makes things better. 

## Where the queries come from

Two controller handlers each queried the credentials table on every reconcile of every catalog entry, and neither checked first whether a credential could exist for the entry it was looking at.

`CleanupUnusedOAuthCredentials` ran a DELETE for every remote entry that does not require static OAuth. In the default catalog that is 168 of 207 entries, so each sweep sent 168 deletes that matched no rows, one query per entry. `EnsureOAuthCredentialStatus` did the same thing with a RevealCredential for every entry that does require static OAuth.

## What changed

`Status.OAuthCredentialConfigured` already records whether a credential exists for an entry, so both queries can be skipped whenever that record cannot be wrong. The two handlers are now one handler, `ReconcileOAuthCredential`, which reads the credential store in two cases.

- The entry requires static OAuth and is not recorded as configured. Reading the store here is also how a wrong record gets corrected, because `SetOAuthCredentials` writes the credential before it sets the sync annotation, and a failure in between leaves a credential the controller has no record of.
- The entry carries the sync annotation, which the API sets after it writes or deletes a credential.

Every other entry, which is most of a catalog, is left alone and no query is sent for it. An entry already recorded as configured is trusted, because every path that removes a credential either sets the sync annotation or deletes the entry outright.

Measured on postgres with `log_statement=all` against a catalog of 45 entries, the statements against the credentials table per full reconcile pass went from 40 to 4.

## Why the two handlers had to become one

nah runs every handler registered for a type even after an earlier one returns an error, because `handlers.Handle` collects errors and keeps looping. While the delete and the status update lived in two handlers, a failed delete did not stop the status from being cleared on the same pass, and once the status was cleared the new guard would never query that entry again, so the OAuth client id and secret stayed in the table with nothing left to remove them.

As one handler the delete has to succeed before the status is cleared, and the sync annotation is cleared last, so a failure anywhere leaves the recheck pending for the next pass.

I checked that this is real rather than theoretical, by adding a row level `BEFORE DELETE` trigger on `credentials` that raises, so a delete matching no rows still succeeds and a delete that would remove a credential fails. With the two separate handlers, flipping an entry off static OAuth logged `failed to delete OAuth credential` and cleared the status anyway, and after removing the trigger no further delete was ever attempted while the client id and secret were still in the table. With the merged handler the status survives the failed delete and the credential is removed on the next pass.

## Why the runtime checks came out

A static OAuth credential is stored under the entry's name, `mcp-oauth-<entry name>`. The runtime is not part of that key, so checking the runtime before deleting is wrong.

Both the cleanup and the finalizer used to return early for any entry whose runtime is not remote. That means an entry which was remote, had a credential configured, and was later changed to another runtime keeps that credential forever. The cleanup skips it for not being remote, the status handler clears its status for the same reason, and nothing else deletes it. That is a leak today, not one this change introduces.

The cleanup now decides from the status instead of the runtime, so the credential is deleted on the pass where the conversion happens, while the entry still records that it had one. An ordinary containerized entry has a false status and still gets no query.

The finalizer had the same hole on the deletion path. It now sweeps a remote entry always, and an entry of any other runtime only when its status says a credential is configured or a sync annotation is still pending. The annotation is in that condition because `SetOAuthCredentials` writes the credential first and sets the annotation second, so in between the entry holds a credential its status knows nothing about, and if it is deleted in that window the annotation is the only thing left pointing at it.

Neither change adds a query in steady state. An entry of another runtime with a clear status is skipped just as it was before, on both paths. The only entries that newly issue a query are the leaked ones, at one delete each, after which their status is false and they go quiet, so the cost is a single small burst on the first reconcile after this deploys.

## Testing

The reconcile is covered as a table of entry states, asserting the number of reads and deletes issued through a fake credential client rather than inferring it from the absence of a panic. Two separate tests cover the ordering, one that a failed delete leaves the status set and one that a failed recheck leaves the sync annotation in place. The finalizer has its own table over runtime, status and a pending annotation.

I confirmed the tests bite by removing each of the two skip guards and the delete error return in turn, and checking that exactly the intended test failed each time.

## Notes

- An entry converted to another runtime before this ships keeps its orphaned credential, the same as today. Repairing those needs a pass over the credential store, which belongs in its own change.
- `RemoveAuditLogCred` has the same unguarded delete on every `MCPServer` reconcile, and is worth a follow up.