### PR TITLE
Hold the controller leader lock in a SQL table instead of a Lease

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/obot-platform/cmd v0.0.0-20260707150346-5103d461ab67
 	github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e
 	github.com/obot-platform/mmmcp v0.1.2
-	github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f
+	github.com/obot-platform/nah v0.0.0-20260902222426-636420908be9
 	github.com/obot-platform/obot/apiclient v0.0.0-20250813183905-ade719c1e8bf
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e h1:o439PMKepm2y
 github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e/go.mod h1:mJ2Mx/FzMK2WmfxamD2V9N7TeakulKdmGHw4qvMjzUs=
 github.com/obot-platform/mmmcp v0.1.2 h1:M0IQlmnF73bZfbLT8ArZ/mFVSMRoH+bFmqCe/YwvDtk=
 github.com/obot-platform/mmmcp v0.1.2/go.mod h1:IM+X47ERoflOPn9ZEtrKki5zp4mAz9J6Ov5wvZBot+M=
-github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f h1:yoMKu8I8gFlsBOSPs+guQdsSWscaipIjDIBIIl2a7ho=
-github.com/obot-platform/nah v0.0.0-20260707163210-8bdf0035e79f/go.mod h1:m3e3C4G/Y/ZYRc6CdMj9n8JfVRCzIc7N8FUvjemsVtY=
+github.com/obot-platform/nah v0.0.0-20260902222426-636420908be9 h1:ghr7sLW3yg5fBoCuHGOz9ZVa3xcv0JuYUtFAq2plZnw=
+github.com/obot-platform/nah v0.0.0-20260902222426-636420908be9/go.mod h1:XYTsRgyYAHyKS9yAy3j5LFdWGJM48EmneZ1otits+dU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -594,18 +594,12 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	if config.ElectionFile != "" {
 		electionConfig = leader.NewFileElectionConfig(config.ElectionFile)
 	} else {
-		// Hold the controller lock in a plain table instead of as a Lease in the
-		// versioned store. A Lease is rewritten every renew period, and in an
-		// append-only store that made it the most expensive object in the database:
-		// hundreds of row versions of a single row, sorted on every read, by every
-		// replica. The local Kubernetes election further down is unchanged; it runs
-		// against a real cluster, where a Lease is the right tool.
-		//
-		// WithLegacyLeaseLock covers the rolling update that introduces this change:
-		// while the leader_lock table has no row, a replica defers to the Lease that
-		// replicas on the previous release still hold, so old and new replicas never
-		// run two leaders. The Lease is no longer read once the first row exists.
-		// Remove the call in the release after this one ships everywhere.
+		// Hold the controller lock in a plain table rather than as a Lease in the
+		// versioned store, where every renew appended a row version and made the
+		// Lease the most expensive object in the database. The local Kubernetes
+		// election below still uses a real Lease. WithLegacyLeaseLock keeps one
+		// leader during the rolling update that introduces this change; remove it in
+		// the release after.
 		electionConfig = leader.NewSQLElectionConfig("obot-controller", dbAccess.SQLDB).
 			WithLegacyLeaseLock("", leaderElectionRESTConfig(restConfig))
 	}

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -594,7 +594,13 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	if config.ElectionFile != "" {
 		electionConfig = leader.NewFileElectionConfig(config.ElectionFile)
 	} else {
-		electionConfig = leader.NewDefaultElectionConfig("", "obot-controller", leaderElectionRESTConfig(restConfig))
+		// Hold the controller lock in a plain table instead of as a Lease in the
+		// versioned store. A Lease is rewritten every renew period, and in an
+		// append-only store that made it the most expensive object in the database:
+		// hundreds of row versions of a single row, sorted on every read, by every
+		// replica. The local Kubernetes election further down is unchanged; it runs
+		// against a real cluster, where a Lease is the right tool.
+		electionConfig = leader.NewSQLElectionConfig("obot-controller", dbAccess.SQLDB)
 	}
 	r, err := nah.NewRouter("obot-controller", &nah.Options{
 		RESTConfig:     restConfig,

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -600,7 +600,14 @@ func New(ctx context.Context, config Config) (*Services, error) {
 		// hundreds of row versions of a single row, sorted on every read, by every
 		// replica. The local Kubernetes election further down is unchanged; it runs
 		// against a real cluster, where a Lease is the right tool.
-		electionConfig = leader.NewSQLElectionConfig("obot-controller", dbAccess.SQLDB)
+		//
+		// WithLegacyLeaseLock covers the rolling update that introduces this change:
+		// while the leader_lock table has no row, a replica defers to the Lease that
+		// replicas on the previous release still hold, so old and new replicas never
+		// run two leaders. The Lease is no longer read once the first row exists.
+		// Remove the call in the release after this one ships everywhere.
+		electionConfig = leader.NewSQLElectionConfig("obot-controller", dbAccess.SQLDB).
+			WithLegacyLeaseLock("", leaderElectionRESTConfig(restConfig))
 	}
 	r, err := nah.NewRouter("obot-controller", &nah.Options{
 		RESTConfig:     restConfig,

--- a/pkg/services/config.go
+++ b/pkg/services/config.go
@@ -594,12 +594,6 @@ func New(ctx context.Context, config Config) (*Services, error) {
 	if config.ElectionFile != "" {
 		electionConfig = leader.NewFileElectionConfig(config.ElectionFile)
 	} else {
-		// Hold the controller lock in a plain table rather than as a Lease in the
-		// versioned store, where every renew appended a row version and made the
-		// Lease the most expensive object in the database. The local Kubernetes
-		// election below still uses a real Lease. WithLegacyLeaseLock keeps one
-		// leader during the rolling update that introduces this change; remove it in
-		// the release after.
 		electionConfig = leader.NewSQLElectionConfig("obot-controller", dbAccess.SQLDB).
 			WithLegacyLeaseLock("", leaderElectionRESTConfig(restConfig))
 	}


### PR DESCRIPTION
## What changes

The `obot-controller` election switches from a `coordination.k8s.io` Lease stored in kinm's versioned object tables to nah's SQL lock (obot-platform/nah#32, merged): one row in a plain table, read by primary key and updated in place, selected as a `ResourceLockType` the same way the file lock is.

```go
electionConfig = leader.NewSQLElectionConfig("obot-controller", dbAccess.SQLDB).
    WithLegacyLeaseLock("", leaderElectionRESTConfig(restConfig))
```

The election algorithm, TTL, and retry period are unchanged. Only what the lock is stored in differs.

## What does not change

- The `--election-file` dev path still uses the file lock.
- The `obot-local-controller` election is untouched. It runs against a real Kubernetes cluster, where a Lease is a point lookup and the right tool. This is why the lock is pluggable rather than a kinm-only code path.

## Why

After the environments in a shared multi-tenant deployment went HA, the lease became the single largest consumer of database time:

- A lock is rewritten every renew period, one write per 2s that differs only in `renewTime`.
- kinm's store is append-only, so that produced about 450 row versions of one 735-byte object between compactions (measured live).
- `list.sql`, which also backs every `Get`, sorts all of them to return the current one, about 1.4ms and 57 buffers per read.
- Both replicas pay it once per period: the follower via `Get`, the leader via `Update`, which does an internal `Get`.
- Result: 52 to 62% of sampled execution time in Cloud SQL Query Insights (20 to 31% by exact statement timing in a local harness), 94.5% of all compaction work, and a clean 2x the day HA rolled out.

The lock's cost was proportional to the retry period, the compaction interval, and the replica count. With this change it is two single-row statements per period regardless of all three. obot-platform/kinm#24 (index) and #25 (compaction interval) make the versioned-store path cheaper; this change takes the lease out of that path entirely.

## Dependencies

nah is bumped to `636420908be9`, the merge of obot-platform/nah#32. That is the only `go.mod` change.

## Rolling update

The election config calls `WithLegacyLeaseLock`, so while the `leader_lock` table has no row a replica on this release follows the Lease that replicas on the previous release still hold, and creates the row only after the last old replica has released it and a five second grace period has passed. Old replicas poll every two seconds, so the grace lets them win any race and keeps the election on one lock until they are gone. Once the row exists the Lease is never read again. The call should be removed in the release after this one has shipped everywhere.

Verified locally with two replicas on the current release and two on this branch walked through a rolling update: the new replicas stayed followers behind the old leader; when the old leader terminated, the old follower took the released Lease (2.7s) and the new replicas backed off; when the last old replica terminated, one new replica created the row 6.8s later while the other stayed a follower, and the Lease stayed released. An old leader killed with SIGKILL while a new follower waited was replaced 66s later (60s TTL plus the grace), with no takeover at 30s. Each new replica logs its mode at startup and each bridge transition once at info level.

Known limit, accepted: the grace period is a timing argument, not a proof. An old follower stalled for more than five seconds at the exact moment the last old leader releases could take the Lease after a new replica has created the row, and both would lead until the rollout terminates that pod. Deploying that one release with `updateStrategy: Recreate` would remove even that window.
