### PR TITLE
Improve dashboard loading performance

### DIFF
--- a/ui/user/src/lib/components/admin/token-usage/TokenUsageTimelineCard.svelte
+++ b/ui/user/src/lib/components/admin/token-usage/TokenUsageTimelineCard.svelte
@@ -53,8 +53,8 @@
 		endDate,
 		data: externalData,
 		loading: externalLoading = false,
-		users: externalUsers = [],
-		models: externalModels = [],
+		users: externalUsers,
+		models: externalModels,
 		selectedTokenType: externalTokenType,
 		groupBy: externalGroupBy,
 		onTokenTypeChange,
@@ -71,8 +71,8 @@
 
 	const selfFetch = $derived(externalData === undefined);
 	const data = $derived(externalData ?? fetchedData);
-	const users = $derived(externalUsers.length > 0 ? externalUsers : fetchedUsers);
-	const models = $derived(externalModels.length > 0 ? externalModels : fetchedModels);
+	const users = $derived(externalUsers ?? fetchedUsers);
+	const models = $derived(externalModels ?? fetchedModels);
 	const loading = $derived(selfFetch ? fetchLoading : externalLoading);
 
 	const selectedTokenType = $derived(externalTokenType ?? internalTokenType);
@@ -101,17 +101,17 @@
 		try {
 			const [tokenUsage, usersList, modelsList] = await Promise.all([
 				AdminService.listTokenUsage(timeRange, { signal }),
-				externalUsers.length > 0
+				externalUsers !== undefined
 					? Promise.resolve(externalUsers)
 					: UserService.listUsersIncludeDeleted(),
-				externalModels.length > 0
+				externalModels !== undefined
 					? Promise.resolve(externalModels)
 					: AdminService.listModels({ all: true })
 			]);
 			if (signal.aborted) return;
 			fetchedData = tokenUsage;
-			if (externalUsers.length === 0) fetchedUsers = usersList;
-			if (externalModels.length === 0) fetchedModels = modelsList;
+			if (externalUsers === undefined) fetchedUsers = usersList;
+			if (externalModels === undefined) fetchedModels = modelsList;
 		} catch (error) {
 			if ((error as Error)?.name === 'AbortError') return;
 			errors.append(error);

--- a/ui/user/src/lib/components/admin/token-usage/TokenUsageTimelineCard.svelte
+++ b/ui/user/src/lib/components/admin/token-usage/TokenUsageTimelineCard.svelte
@@ -32,6 +32,7 @@
 		TIMELINE_AGGREGATE_THRESHOLD,
 		type TokenUsageTimelineItem
 	} from './tokenUsageTimeline';
+	import { untrack } from 'svelte';
 	import { twMerge } from 'tailwind-merge';
 
 	type Props = {
@@ -74,6 +75,9 @@
 	const users = $derived(externalUsers ?? fetchedUsers);
 	const models = $derived(externalModels ?? fetchedModels);
 	const loading = $derived(selfFetch ? fetchLoading : externalLoading);
+	const fetchRangeKey = $derived(
+		selfFetch ? `${startDate.getTime()}:${endDate.getTime()}` : undefined
+	);
 
 	const selectedTokenType = $derived(externalTokenType ?? internalTokenType);
 	const groupBy = $derived(externalGroupBy ?? internalGroupBy);
@@ -121,8 +125,9 @@
 	}
 
 	$effect(() => {
-		if (!selfFetch) return;
-		fetchData(startDate, endDate);
+		if (fetchRangeKey === undefined) return;
+		const [start, end] = untrack(() => [startDate, endDate]);
+		untrack(() => fetchData(start, end));
 		return () => fetchAbortController?.abort();
 	});
 

--- a/ui/user/src/lib/components/admin/token-usage/TokenUsageTimelineCard.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/token-usage/TokenUsageTimelineCard.svelte.spec.ts
@@ -1,0 +1,25 @@
+import { AdminService, UserService } from '$lib/services';
+import TokenUsageTimelineCard from './TokenUsageTimelineCard.svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+
+describe('TokenUsageTimelineCard', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		vi.spyOn(AdminService, 'listTokenUsage').mockResolvedValue([]);
+		vi.spyOn(AdminService, 'listModels').mockResolvedValue([]);
+	});
+
+	it('does not refetch users when an empty users collection is supplied', async () => {
+		const listUsers = vi.spyOn(UserService, 'listUsersIncludeDeleted').mockResolvedValue([]);
+
+		render(TokenUsageTimelineCard, {
+			startDate: new Date('2026-07-27T00:00:00Z'),
+			endDate: new Date('2026-08-27T00:00:00Z'),
+			users: []
+		});
+
+		await vi.waitFor(() => expect(AdminService.listTokenUsage).toHaveBeenCalledOnce());
+		expect(listUsers).not.toHaveBeenCalled();
+	});
+});

--- a/ui/user/src/lib/components/admin/token-usage/TokenUsageTimelineCard.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/token-usage/TokenUsageTimelineCard.svelte.spec.ts
@@ -1,4 +1,4 @@
-import { AdminService, UserService } from '$lib/services';
+import { AdminService, UserService, type OrgUser } from '$lib/services';
 import TokenUsageTimelineCard from './TokenUsageTimelineCard.svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
@@ -21,5 +21,45 @@ describe('TokenUsageTimelineCard', () => {
 
 		await vi.waitFor(() => expect(AdminService.listTokenUsage).toHaveBeenCalledOnce());
 		expect(listUsers).not.toHaveBeenCalled();
+	});
+
+	it('does not refetch token usage or models when supplied users change', async () => {
+		vi.spyOn(UserService, 'listUsersIncludeDeleted').mockResolvedValue([]);
+		const startDate = new Date('2026-07-27T00:00:00Z');
+		const endDate = new Date('2026-08-27T00:00:00Z');
+		const result = await render(TokenUsageTimelineCard, {
+			startDate,
+			endDate,
+			users: []
+		});
+		await vi.waitFor(() => expect(AdminService.listTokenUsage).toHaveBeenCalledOnce());
+
+		await result.rerender({
+			startDate,
+			endDate,
+			users: [{ id: 'user-1' } as OrgUser]
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(AdminService.listTokenUsage).toHaveBeenCalledOnce();
+		expect(AdminService.listModels).toHaveBeenCalledOnce();
+	});
+
+	it('refetches when the time range changes', async () => {
+		const result = await render(TokenUsageTimelineCard, {
+			startDate: new Date('2026-07-27T00:00:00Z'),
+			endDate: new Date('2026-08-27T00:00:00Z'),
+			users: []
+		});
+		await vi.waitFor(() => expect(AdminService.listTokenUsage).toHaveBeenCalledOnce());
+
+		await result.rerender({
+			startDate: new Date('2026-08-20T00:00:00Z'),
+			endDate: new Date('2026-08-27T00:00:00Z'),
+			users: []
+		});
+
+		await vi.waitFor(() => expect(AdminService.listTokenUsage).toHaveBeenCalledTimes(2));
+		expect(AdminService.listModels).toHaveBeenCalledTimes(2);
 	});
 });

--- a/ui/user/src/lib/services/admin/operations.spec.ts
+++ b/ui/user/src/lib/services/admin/operations.spec.ts
@@ -1,0 +1,20 @@
+import { listMCPCatalogEntries } from './operations';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('listMCPCatalogEntries', () => {
+	it('combines all and minimal list options', async () => {
+		const fetcher = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ items: [] }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			})
+		);
+
+		await listMCPCatalogEntries('default', { fetch: fetcher, all: true, minimal: true });
+
+		expect(fetcher).toHaveBeenCalledOnce();
+		expect(fetcher.mock.calls[0][0]).toMatch(
+			/\/api\/mcp-catalogs\/default\/entries\?all=true&minimal=true$/
+		);
+	});
+});

--- a/ui/user/src/lib/services/admin/operations.ts
+++ b/ui/user/src/lib/services/admin/operations.ts
@@ -829,11 +829,13 @@ export async function listAllCatalogDeployedSingleRemoteServers(
 
 export async function listMCPCatalogEntries(
 	catalogID: string,
-	opts?: { fetch?: Fetcher; all?: boolean }
+	opts?: { fetch?: Fetcher; all?: boolean; minimal?: boolean }
 ): Promise<MCPCatalogEntry[]> {
-	const url = opts?.all
-		? `/mcp-catalogs/${catalogID}/entries?all=true`
-		: `/mcp-catalogs/${catalogID}/entries`;
+	const params = new URLSearchParams();
+	if (opts?.all) params.set('all', 'true');
+	if (opts?.minimal) params.set('minimal', 'true');
+	const query = params.size > 0 ? `?${params}` : '';
+	const url = `/mcp-catalogs/${catalogID}/entries${query}`;
 	const response = (await doGet(url, opts)) as ItemsResponse<MCPCatalogEntry>;
 	return (
 		response.items?.map((item) => {

--- a/ui/user/src/lib/stores/mcpServersAndEntries.svelte.spec.ts
+++ b/ui/user/src/lib/stores/mcpServersAndEntries.svelte.spec.ts
@@ -149,7 +149,7 @@ describe('mcpServersAndEntries', () => {
 		expect(requests.adminServers).toHaveBeenCalledOnce();
 		expect(requests.workspaceEntries).toHaveBeenCalledOnce();
 		expect(requests.workspaceServers).toHaveBeenCalledOnce();
-		expect(requests.configuredServers).toHaveBeenCalledOnce();
+		expect(requests.configuredServers).not.toHaveBeenCalled();
 		expect(requests.userEntries).not.toHaveBeenCalled();
 		expect(requests.userServers).not.toHaveBeenCalled();
 		expect(requests.instances).not.toHaveBeenCalled();

--- a/ui/user/src/lib/stores/mcpServersAndEntries.svelte.spec.ts
+++ b/ui/user/src/lib/stores/mcpServersAndEntries.svelte.spec.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 import {
 	AdminService,
 	UserService,
@@ -134,5 +135,38 @@ describe('mcpServersAndEntries', () => {
 		expect(requests.adminServers).toHaveBeenCalledTimes(2);
 		expect(requests.workspaceEntries).toHaveBeenCalledOnce();
 		expect(requests.workspaceServers).toHaveBeenCalledOnce();
+	});
+
+	it('loads only dashboard MCP data for an admin dashboard', async () => {
+		const requests = mockMcpRequests();
+
+		await mcpServersAndEntries.fetchData({ forceRefresh: true, scope: 'dashboard' });
+
+		expect(requests.adminEntries).toHaveBeenCalledWith(DEFAULT_MCP_CATALOG_ID, {
+			all: true,
+			minimal: true
+		});
+		expect(requests.adminServers).toHaveBeenCalledOnce();
+		expect(requests.workspaceEntries).toHaveBeenCalledOnce();
+		expect(requests.workspaceServers).toHaveBeenCalledOnce();
+		expect(requests.configuredServers).toHaveBeenCalledOnce();
+		expect(requests.userEntries).not.toHaveBeenCalled();
+		expect(requests.userServers).not.toHaveBeenCalled();
+		expect(requests.instances).not.toHaveBeenCalled();
+	});
+
+	it('preserves the minimal dashboard scope when refreshing entries', async () => {
+		const requests = mockMcpRequests();
+		await mcpServersAndEntries.fetchData({ forceRefresh: true, scope: 'dashboard' });
+		vi.clearAllMocks();
+
+		await mcpServersAndEntries.refreshEntries();
+
+		expect(requests.adminEntries).toHaveBeenCalledWith(DEFAULT_MCP_CATALOG_ID, {
+			all: true,
+			minimal: true
+		});
+		expect(requests.workspaceEntries).toHaveBeenCalledOnce();
+		expect(requests.userEntries).not.toHaveBeenCalled();
 	});
 });

--- a/ui/user/src/lib/stores/mcpServersAndEntries.svelte.ts
+++ b/ui/user/src/lib/stores/mcpServersAndEntries.svelte.ts
@@ -19,7 +19,7 @@ interface McpServerAndEntries {
 	isInitialized: boolean;
 }
 
-type MCPDataScope = 'user' | 'admin';
+type MCPDataScope = 'user' | 'admin' | 'dashboard';
 
 interface MCPDataOptions {
 	forceRefresh?: boolean;
@@ -102,7 +102,23 @@ async function fetchData({ forceRefresh = false, scope = 'admin' }: MCPDataOptio
 		let userConfiguredServers: MCPCatalogServer[] = [];
 		let userInstances: MCPServerInstance[] = [];
 
-		if (scope === 'admin' && profile.current.hasAdminAccess?.()) {
+		if (scope === 'dashboard' && profile.current.hasAdminAccess?.()) {
+			const [adminEntries, adminServers, workspaceEntries, workspaceServers, ownConfiguredServers] =
+				await Promise.all([
+					AdminService.listMCPCatalogEntries(DEFAULT_MCP_CATALOG_ID, {
+						all: true,
+						minimal: true
+					}),
+					AdminService.listMCPCatalogServers(DEFAULT_MCP_CATALOG_ID, { all: true }),
+					AdminService.listAllUserWorkspaceCatalogEntries(),
+					AdminService.listAllUserWorkspaceMCPServers(),
+					UserService.listSingleOrRemoteMcpServers()
+				]);
+
+			entries = [...adminEntries, ...workspaceEntries].filter((entry) => !entry.deleted);
+			servers = [...adminServers, ...workspaceServers];
+			userConfiguredServers = filterOutDuplicateAndDeleted([...servers, ...ownConfiguredServers]);
+		} else if (scope === 'admin' && profile.current.hasAdminAccess?.()) {
 			const [
 				adminEntries,
 				adminServers,
@@ -189,7 +205,19 @@ async function initialize(options: MCPDataOptions = {}) {
 
 async function refreshEntries() {
 	try {
-		if (loadedScope !== 'user' && profile.current.hasAdminAccess?.()) {
+		if (loadedScope === 'dashboard' && profile.current.hasAdminAccess?.()) {
+			const [adminEntries, workspaceEntries] = await Promise.all([
+				AdminService.listMCPCatalogEntries(DEFAULT_MCP_CATALOG_ID, {
+					all: true,
+					minimal: true
+				}),
+				AdminService.listAllUserWorkspaceCatalogEntries()
+			]);
+			store.current = {
+				...store.current,
+				entries: [...adminEntries, ...workspaceEntries].filter((entry) => !entry.deleted)
+			};
+		} else if (loadedScope !== 'user' && profile.current.hasAdminAccess?.()) {
 			const [adminEntries, workspaceEntries, userScopedEntries] = await Promise.all([
 				AdminService.listMCPCatalogEntries(DEFAULT_MCP_CATALOG_ID, { all: true }),
 				AdminService.listAllUserWorkspaceCatalogEntries(),

--- a/ui/user/src/lib/stores/mcpServersAndEntries.svelte.ts
+++ b/ui/user/src/lib/stores/mcpServersAndEntries.svelte.ts
@@ -103,21 +103,19 @@ async function fetchData({ forceRefresh = false, scope = 'admin' }: MCPDataOptio
 		let userInstances: MCPServerInstance[] = [];
 
 		if (scope === 'dashboard' && profile.current.hasAdminAccess?.()) {
-			const [adminEntries, adminServers, workspaceEntries, workspaceServers, ownConfiguredServers] =
-				await Promise.all([
-					AdminService.listMCPCatalogEntries(DEFAULT_MCP_CATALOG_ID, {
-						all: true,
-						minimal: true
-					}),
-					AdminService.listMCPCatalogServers(DEFAULT_MCP_CATALOG_ID, { all: true }),
-					AdminService.listAllUserWorkspaceCatalogEntries(),
-					AdminService.listAllUserWorkspaceMCPServers(),
-					UserService.listSingleOrRemoteMcpServers()
-				]);
+			const [adminEntries, adminServers, workspaceEntries, workspaceServers] = await Promise.all([
+				AdminService.listMCPCatalogEntries(DEFAULT_MCP_CATALOG_ID, {
+					all: true,
+					minimal: true
+				}),
+				AdminService.listMCPCatalogServers(DEFAULT_MCP_CATALOG_ID, { all: true }),
+				AdminService.listAllUserWorkspaceCatalogEntries(),
+				AdminService.listAllUserWorkspaceMCPServers()
+			]);
 
 			entries = [...adminEntries, ...workspaceEntries].filter((entry) => !entry.deleted);
 			servers = [...adminServers, ...workspaceServers];
-			userConfiguredServers = filterOutDuplicateAndDeleted([...servers, ...ownConfiguredServers]);
+			userConfiguredServers = filterOutDuplicateAndDeleted(servers);
 		} else if (scope === 'admin' && profile.current.hasAdminAccess?.()) {
 			const [
 				adminEntries,

--- a/ui/user/src/routes/+layout.svelte
+++ b/ui/user/src/routes/+layout.svelte
@@ -92,7 +92,12 @@
 
 	$effect(() => {
 		const pathname = page.url.pathname;
-		const scope = pathname.startsWith('/mcp-servers') ? 'user' : 'admin';
+		const scope =
+			pathname === '/admin/dashboard'
+				? 'dashboard'
+				: pathname.startsWith('/mcp-servers')
+					? 'user'
+					: 'admin';
 		const isMcpCatalogRoute =
 			pathname === '/mcp-catalog' ||
 			pathname === '/admin/mcp-catalog' ||

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -10,7 +10,6 @@
 	import { formatTokenUsageUSD } from '$lib/components/admin/token-usage/tokenUsageTimeline';
 	import DonutGraph from '$lib/components/graph/DonutGraph.svelte';
 	import HorizontalBarGraph from '$lib/components/graph/HorizontalBarGraph.svelte';
-	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 	import { formatNumber } from '$lib/format';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
@@ -87,25 +86,9 @@
 		).length
 	);
 
-	let deployedCatalogEntryServers = $state<MCPCatalogServer[]>([]);
-	let deployedWorkspaceCatalogEntryServers = $state<MCPCatalogServer[]>([]);
 	let serversData = $derived.by(() => {
 		if (mcpServersAndEntries.current.loading || loading) return [];
-		// eslint-disable-next-line svelte/prefer-svelte-reactivity
-		const seen = new Set<string>();
-		const result: MCPCatalogServer[] = [];
-		for (const list of [
-			deployedCatalogEntryServers,
-			deployedWorkspaceCatalogEntryServers,
-			mcpServersAndEntries.current.servers
-		]) {
-			for (const server of list) {
-				if (server.deleted || seen.has(server.id)) continue;
-				seen.add(server.id);
-				result.push(server);
-			}
-		}
-		return result;
+		return mcpServersAndEntries.current.userConfiguredServers;
 	});
 
 	const serverAndEntries = $derived(mcpServersAndEntries.current);
@@ -155,17 +138,13 @@
 				loadingDeviceScanStats = false;
 			});
 
-		const [users, tokens, catalogServers, workspaceServers] = await Promise.all([
+		const [users, tokens] = await Promise.all([
 			UserService.listUsersIncludeDeleted(),
-			AdminService.listTotalTokenUsage({ start, end }),
-			AdminService.listAllCatalogDeployedSingleRemoteServers(DEFAULT_MCP_CATALOG_ID),
-			AdminService.listAllWorkspaceDeployedSingleRemoteServers()
+			AdminService.listTotalTokenUsage({ start, end })
 		]);
 
 		usersData = users;
 		totalTokensData = tokens;
-		deployedCatalogEntryServers = catalogServers;
-		deployedWorkspaceCatalogEntryServers = workspaceServers;
 		loading = false;
 	});
 
@@ -406,7 +385,7 @@
 			</div>
 
 			<div class="col-span-12">
-				<TokenUsageTimelineCard startDate={start} endDate={end} />
+				<TokenUsageTimelineCard startDate={start} endDate={end} users={usersData} />
 			</div>
 
 			<div class="col-span-12 grid grid-cols-1 items-stretch gap-4 @3xl:grid-cols-2">
@@ -415,7 +394,7 @@
 			</div>
 		{:else}
 			<div class="col-span-12">
-				<TokenUsageTimelineCard startDate={start} endDate={end} />
+				<TokenUsageTimelineCard startDate={start} endDate={end} users={usersData} />
 			</div>
 			<div class="col-span-12 grid grid-cols-1 items-stretch gap-4 @3xl:grid-cols-2">
 				{@render toolUsageGraph()}

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -10,6 +10,7 @@
 	import { formatTokenUsageUSD } from '$lib/components/admin/token-usage/tokenUsageTimeline';
 	import DonutGraph from '$lib/components/graph/DonutGraph.svelte';
 	import HorizontalBarGraph from '$lib/components/graph/HorizontalBarGraph.svelte';
+	import { DEFAULT_MCP_CATALOG_ID } from '$lib/constants';
 	import { formatNumber } from '$lib/format';
 	import Loading from '$lib/icons/Loading.svelte';
 	import { stripMarkdownToText } from '$lib/markdown';
@@ -86,9 +87,25 @@
 		).length
 	);
 
+	let deployedCatalogEntryServers = $state<MCPCatalogServer[]>([]);
+	let deployedWorkspaceCatalogEntryServers = $state<MCPCatalogServer[]>([]);
 	let serversData = $derived.by(() => {
 		if (mcpServersAndEntries.current.loading || loading) return [];
-		return mcpServersAndEntries.current.userConfiguredServers;
+		// eslint-disable-next-line svelte/prefer-svelte-reactivity
+		const seen = new Set<string>();
+		const result: MCPCatalogServer[] = [];
+		for (const list of [
+			deployedCatalogEntryServers,
+			deployedWorkspaceCatalogEntryServers,
+			mcpServersAndEntries.current.servers
+		]) {
+			for (const server of list) {
+				if (server.deleted || seen.has(server.id)) continue;
+				seen.add(server.id);
+				result.push(server);
+			}
+		}
+		return result;
 	});
 
 	const serverAndEntries = $derived(mcpServersAndEntries.current);
@@ -142,13 +159,17 @@
 			loadingDeviceScanStats = false;
 		}
 
-		const [users, tokens] = await Promise.all([
+		const [users, tokens, catalogServers, workspaceServers] = await Promise.all([
 			UserService.listUsersIncludeDeleted(),
-			AdminService.listTotalTokenUsage({ start, end })
+			AdminService.listTotalTokenUsage({ start, end }),
+			AdminService.listAllCatalogDeployedSingleRemoteServers(DEFAULT_MCP_CATALOG_ID),
+			AdminService.listAllWorkspaceDeployedSingleRemoteServers()
 		]);
 
 		usersData = users;
 		totalTokensData = tokens;
+		deployedCatalogEntryServers = catalogServers;
+		deployedWorkspaceCatalogEntryServers = workspaceServers;
 		loading = false;
 	});
 
@@ -537,7 +558,9 @@
 					{@const displayName =
 						'server' in info ? getMCPDisplayName(info.server) : info.entry?.manifest.name}
 					{@const description =
-						'server' in info ? info.server?.manifest.description : info.entry?.manifest.description}
+						'server' in info
+							? info.server?.manifest.description
+							: info.entry?.manifest.shortDescription}
 					{@const url = info.server
 						? getServerUrl(info.server)
 						: info.entry

--- a/ui/user/src/routes/admin/dashboard/+page.svelte
+++ b/ui/user/src/routes/admin/dashboard/+page.svelte
@@ -126,17 +126,21 @@
 				loadingToolUsage = false;
 			});
 
-		AdminService.getDeviceScanStats({ start: start.toISOString(), end: end.toISOString() })
-			.then((stats) => {
-				deviceScanStats = stats;
-			})
-			.catch((error) => {
-				if (error?.name === 'AbortError') return;
-				errors.append(error);
-			})
-			.finally(() => {
-				loadingDeviceScanStats = false;
-			});
+		if (hasDeviceScans) {
+			AdminService.getDeviceScanStats({ start: start.toISOString(), end: end.toISOString() })
+				.then((stats) => {
+					deviceScanStats = stats;
+				})
+				.catch((error) => {
+					if (error?.name === 'AbortError') return;
+					errors.append(error);
+				})
+				.finally(() => {
+					loadingDeviceScanStats = false;
+				});
+		} else {
+			loadingDeviceScanStats = false;
+		}
 
 		const [users, tokens] = await Promise.all([
 			UserService.listUsersIncludeDeleted(),

--- a/ui/user/src/routes/admin/dashboard/+page.ts
+++ b/ui/user/src/routes/admin/dashboard/+page.ts
@@ -3,13 +3,18 @@ import { UserService } from '$lib/services';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { profile } = await parent();
 	let hasDeviceScans = false;
-	try {
-		const response = await UserService.listDeviceScans({ limit: 1 }, { fetch });
-		hasDeviceScans = response.total > 0;
-	} catch (err) {
-		handleRouteError(err, '/admin/dashboard', profile);
+	const [parentData, scansResult] = await Promise.all([
+		parent(),
+		UserService.listDeviceScans({ limit: 1 }, { fetch })
+			.then((response) => ({ response }))
+			.catch((error: unknown) => ({ error }))
+	]);
+
+	if ('response' in scansResult) {
+		hasDeviceScans = scansResult.response.total > 0;
+	} else {
+		handleRouteError(scansResult.error, '/admin/dashboard', parentData.profile);
 	}
 
 	return {

--- a/ui/user/src/routes/admin/dashboard/page.spec.ts
+++ b/ui/user/src/routes/admin/dashboard/page.spec.ts
@@ -1,0 +1,34 @@
+import { UserService, type Profile } from '$lib/services';
+import { load } from './+page';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+describe('admin dashboard page load', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('starts the device scan request while parent data is still loading', async () => {
+		const parentData = deferred<{ profile: Profile }>();
+		const listDeviceScans = vi
+			.spyOn(UserService, 'listDeviceScans')
+			.mockResolvedValue({ items: [], total: 0, limit: 1, offset: 0 });
+
+		const resultPromise = load({
+			fetch,
+			parent: () => parentData.promise
+		} as Parameters<typeof load>[0]);
+
+		expect(listDeviceScans).toHaveBeenCalledOnce();
+
+		parentData.resolve({ profile: { unauthorized: false } as Profile });
+		await expect(resultPromise).resolves.toEqual({ hasDeviceScans: false });
+	});
+});


### PR DESCRIPTION
## Summary

- add a dashboard-specific MCP data scope that skips access-control and instance data the dashboard does not use
- request minimal catalog entries and reuse configured server data instead of issuing duplicate deployment queries
- overlap the device-scan existence probe with parent layout loading and skip scan statistics when no scans exist
- share dashboard user data with the token usage chart and refetch chart data only when its time range changes

## Performance

The optimized HAR captured after the primary request-flow changes showed:

- API requests reduced from 29 to 24
- API response data reduced from 2.43 MB to 580 KB
- API loading phase reduced from approximately 2.13 seconds to 1.00 second

The final follow-up also removes a duplicate token-usage/model request pair and an unnecessary device scan statistics request when no scans exist.
