### PR TITLE
Add an ADR for the SQL-backed controller leader lock, and bump nah for its startup logging

### DIFF
--- a/adr/2026-09-02-sql-leader-lock.md
+++ b/adr/2026-09-02-sql-leader-lock.md
@@ -1,0 +1,93 @@
+# 2026-09-02: Hold the controller leader lock in a SQL table instead of a Lease
+
+- **Status:** Accepted
+- **Date:** 2026-09-02
+- **Supersedes:** None
+- **Superseded by:** None
+
+## Related issues
+
+None. Implemented in https://github.com/obot-platform/obot/pull/7727 and
+https://github.com/obot-platform/nah/pull/32.
+
+## Related ODPs
+
+None.
+
+## Context
+
+Obot runs its controllers on one replica at a time, chosen by leader election. The
+election is client-go's, and until this change its lock was a `coordination.k8s.io`
+Lease object stored in kinm, Obot's own API server backed by Postgres.
+
+kinm stores objects in versioned, append-only tables. A lock is rewritten every
+renew period, two seconds, so between compactions the Lease accumulated hundreds
+of row versions, and every read of it sorted through all of them. Both replicas of
+an HA environment paid that cost once per period, the follower through its poll and
+the leader through the read inside its renew. When every Obot Cloud environment
+moved to two replicas on 2026-08-20, database CPU on the shared instance rose and
+stayed up, and the Lease became the single largest consumer of database time there.
+Its cost grew with the renew period, the compaction interval, and the replica count.
+
+## Decision
+
+nah gains a `sql` `ResourceLockType`: the leader election record lives in one row
+of a plain `leader_lock` table, read by primary key and updated in place with a
+version check, exactly the contract client-go's `LeaseLock` provides. Obot's
+`obot-controller` election uses it against the same database kinm uses, through
+`leader.NewSQLElectionConfig`. The election algorithm, TTL, and retry period are
+unchanged.
+
+The `obot-local-controller` election, which manages resources in the real
+Kubernetes cluster, keeps using a real Lease in that cluster.
+
+The release that introduces the change carries a bridge, `WithLegacyLeaseLock`.
+While the `leader_lock` table has no row, a replica follows the Lease that replicas
+on the previous release still hold, and creates the row only after the last of them
+has released it and a five second grace period has passed. Once the row exists the
+Lease is never read again. The bridge is removed in the release after this one.
+
+## Rationale
+
+The cost was structural: a lock that is rewritten every two seconds does not belong
+in an append-only versioned store. Making that store cheaper per read (an index on
+the latest-version lookup, a shorter compaction interval) reduces the constant but
+leaves the cost proportional to replicas and poll rate, and leaves the Lease as the
+top query. Slowing the election trades away failover speed that nah's hot-standby
+design was built for. A plain table makes a read a point lookup and a renew a
+single-row update, so the cost no longer depends on replicas, poll period, or
+compaction. Keeping the lock pluggable in nah, next to the existing file lock, keeps
+nah generic and leaves the real-cluster election on the tool that suits it.
+
+The bridge exists because the switch ships through a rolling update in which old and
+new replicas overlap, and without it each side would elect a leader on its own lock.
+
+## Consequences
+
+The database cost of the election is now constant and small. Failover behavior is
+unchanged: the lock is released within about 100 ms of SIGTERM, a follower takes over
+within one to three seconds, and a crashed leader is replaced after the 60 second TTL.
+
+The `leader_lock` table sits outside kinm's object model and is created by the lock
+on first use, so it is not visible through the Kubernetes-style API. The old Lease
+object remains in kinm's `lease` table until the leases API group is removed in a
+later release; it is no longer read or written, and its compaction cost is negligible.
+
+During the one rolling update that introduces the change, the grace period is a
+timing argument rather than a guarantee: an old follower stalled for more than five
+seconds at the moment the last old leader releases could lead alongside a new
+replica until the rollout terminates it. This was accepted knowingly. Running that
+one deploy with a `Recreate` strategy would remove the window.
+
+Operators can read the state from the logs. Each replica logs which lock its election
+uses at startup, and the bridge logs, once per transition, that it is following a
+legacy leader, that the grace period started, and that the takeover happened.
+
+## References
+
+- nah SQL lock: `pkg/leader/locks/sql.go` and `pkg/leader/leader.go` in
+  https://github.com/obot-platform/nah
+- Obot wiring: `pkg/services/config.go`
+- Related kinm changes considered alongside this one:
+  https://github.com/obot-platform/kinm/pull/24 (index) and
+  https://github.com/obot-platform/kinm/pull/25 (compaction interval)

--- a/adr/2026-09-02-sql-leader-lock.md
+++ b/adr/2026-09-02-sql-leader-lock.md
@@ -16,78 +16,82 @@ None.
 
 ## Context
 
-Obot runs its controllers on one replica at a time, chosen by leader election. The
-election is client-go's, and until this change its lock was a `coordination.k8s.io`
-Lease object stored in kinm, Obot's own API server backed by Postgres.
+Obot ran its controllers on one replica at a time, chosen by client-go leader
+election. The lock was a `coordination.k8s.io` Lease object stored in kinm, Obot's
+own API server backed by Postgres.
 
-kinm stores objects in versioned, append-only tables. A lock is rewritten every
-renew period, two seconds, so between compactions the Lease accumulated hundreds
-of row versions, and every read of it sorted through all of them. Both replicas of
-an HA environment paid that cost once per period, the follower through its poll and
-the leader through the read inside its renew. When every Obot Cloud environment
-moved to two replicas on 2026-08-20, database CPU on the shared instance rose and
-stayed up, and the Lease became the single largest consumer of database time there.
-Its cost grew with the renew period, the compaction interval, and the replica count.
+kinm stored objects in versioned, append-only tables. The leader rewrote the Lease
+every two seconds, so between compactions, which ran every fifteen minutes, the Lease
+had about 450 row versions, and Postgres sorted all of them on every read. Each
+replica read the Lease once every two seconds: the follower on its poll, and the
+leader inside its renew. When every Obot Cloud environment moved from one replica to
+two on 2026-08-20, database CPU on the shared instance rose and stayed up, and the
+Lease was the query with the most execution time on that instance.
 
 ## Decision
 
-nah gains a `sql` `ResourceLockType`: the leader election record lives in one row
-of a plain `leader_lock` table, read by primary key and updated in place with a
-version check, exactly the contract client-go's `LeaseLock` provides. Obot's
-`obot-controller` election uses it against the same database kinm uses, through
-`leader.NewSQLElectionConfig`. The election algorithm, TTL, and retry period are
-unchanged.
+Change where the `obot-controller` election stores its lock, from a Lease in kinm's
+versioned tables to one row in a `leader_lock` table in the same Postgres database.
+Read the row by primary key and update it in place with a version check. Keep
+client-go's election algorithm, TTL, and retry period as they are. The lock type is
+selectable in nah as `ResourceLockType` `sql`, next to the existing file lock.
 
-The `obot-local-controller` election, which manages resources in the real
-Kubernetes cluster, keeps using a real Lease in that cluster.
+Keep the `obot-local-controller` election on a Lease in the Kubernetes cluster it
+manages.
 
-The release that introduces the change carries a bridge, `WithLegacyLeaseLock`.
-While the `leader_lock` table has no row, a replica follows the Lease that replicas
-on the previous release still hold, and creates the row only after the last of them
-has released it and a five second grace period has passed. Once the row exists the
-Lease is never read again. The bridge is removed in the release after this one.
+In the release that introduces the change, enable `WithLegacyLeaseLock`. While the
+`leader_lock` table has no row, a replica follows the Lease that replicas on the
+previous release still hold. After the last of them releases the Lease and five
+seconds pass, one replica creates the row, and from then on no replica reads the
+Lease. Remove the option in the release after this one.
 
 ## Rationale
 
-The cost was structural: a lock that is rewritten every two seconds does not belong
-in an append-only versioned store. Making that store cheaper per read (an index on
-the latest-version lookup, a shorter compaction interval) reduces the constant but
-leaves the cost proportional to replicas and poll rate, and leaves the Lease as the
-top query. Slowing the election trades away failover speed that nah's hot-standby
-design was built for. A plain table makes a read a point lookup and a renew a
-single-row update, so the cost no longer depends on replicas, poll period, or
-compaction. Keeping the lock pluggable in nah, next to the existing file lock, keeps
-nah generic and leaves the real-cluster election on the tool that suits it.
+A row read by primary key and updated in place has one version, so the cost of each
+read is the same on every poll and does not grow between compactions. The version
+check on update gives the same guarantee client-go's Lease lock gives: a replica can
+only write over a record it has read, so two replicas cannot both hold the lock.
 
-The bridge exists because the switch ships through a rolling update in which old and
-new replicas overlap, and without it each side would elect a leader on its own lock.
+In the Kubernetes cluster, a Lease is a single object in etcd, read and written in
+one round trip, and the local controller has the cluster access it needs already.
+
+A rolling update runs replicas on the old release and the new release side by side.
+If the new replicas did not read the Lease, each release would elect its own leader
+and the controllers would run twice until the last old replica was gone. Replicas on
+the old release poll every two seconds and take a released Lease on their next poll,
+so a five second wait lets them win any race and keeps the election on one lock until
+they are gone.
 
 ## Consequences
 
-The database cost of the election is now constant and small. Failover behavior is
-unchanged: the lock is released within about 100 ms of SIGTERM, a follower takes over
-within one to three seconds, and a crashed leader is replaced after the 60 second TTL.
+Every two seconds the election costs one primary key read per replica, plus one
+single-row update by the leader. On the first environment to receive the change, the
+two Lease queries went from 10% of sampled query execution time to none.
 
-The `leader_lock` table sits outside kinm's object model and is created by the lock
-on first use, so it is not visible through the Kubernetes-style API. The old Lease
-object remains in kinm's `lease` table until the leases API group is removed in a
-later release; it is no longer read or written, and its compaction cost is negligible.
+Failover is unchanged. In local runs against Postgres, the leader released the lock
+84 to 95 ms after SIGTERM, a follower took over within three seconds, and a crashed
+leader was replaced 60 to 63 seconds after it died, once the 60 second TTL passed.
 
-During the one rolling update that introduces the change, the grace period is a
-timing argument rather than a guarantee: an old follower stalled for more than five
-seconds at the moment the last old leader releases could lead alongside a new
-replica until the rollout terminates it. This was accepted knowingly. Running that
-one deploy with a `Recreate` strategy would remove the window.
+The `leader_lock` table is not one of kinm's objects and is not visible through the
+Kubernetes-style API. The lock creates the table at startup if it is missing.
 
-Operators can read the state from the logs. Each replica logs which lock its election
-uses at startup, and the bridge logs, once per transition, that it is following a
-legacy leader, that the grace period started, and that the takeover happened.
+The old Lease object remains in kinm's `lease` table. Nothing reads or writes it, and
+kinm continues to compact that table at two statements per fifteen minutes per
+replica, until a later release removes the leases API group.
+
+During the one rolling update that introduces the change, the five second wait is a
+timing argument, not a guarantee. A replica on the old release that stalls for more
+than five seconds at the moment the last old leader releases can take the Lease after
+a new replica has created the row, and both lead until the rollout terminates the old
+replica. The team accepted the window. Running that one deploy with a `Recreate`
+strategy removes it.
+
+Each replica logs at startup which lock its election uses. While it follows a Lease,
+it logs once who holds it, once when the five second wait starts, and once when it
+creates the row.
 
 ## References
 
 - nah SQL lock: `pkg/leader/locks/sql.go` and `pkg/leader/leader.go` in
   https://github.com/obot-platform/nah
 - Obot wiring: `pkg/services/config.go`
-- Related kinm changes considered alongside this one:
-  https://github.com/obot-platform/kinm/pull/24 (index) and
-  https://github.com/obot-platform/kinm/pull/25 (compaction interval)

--- a/adr/2026-09-02-sql-leader-lock.md
+++ b/adr/2026-09-02-sql-leader-lock.md
@@ -22,11 +22,10 @@ own API server backed by Postgres.
 
 kinm stored objects in versioned, append-only tables. The leader rewrote the Lease
 every two seconds, so between compactions, which ran every fifteen minutes, the Lease
-had about 450 row versions, and Postgres sorted all of them on every read. Each
-replica read the Lease once every two seconds: the follower on its poll, and the
-leader inside its renew. When every Obot Cloud environment moved from one replica to
-two on 2026-08-20, database CPU on the shared instance rose and stayed up, and the
-Lease was the query with the most execution time on that instance.
+had about 450 row versions, and Postgres sorted all of them on every read. When every
+Obot Cloud environment moved from one replica to two on 2026-08-20, database CPU on
+the shared instance rose and stayed up, and reading the Lease was the query with
+the most execution time on that instance.
 
 ## Decision
 
@@ -36,53 +35,46 @@ Read the row by primary key and update it in place with a version check. Keep
 client-go's election algorithm, TTL, and retry period as they are. The lock type is
 selectable in nah as `ResourceLockType` `sql`, next to the existing file lock.
 
-In the release that introduces the change, enable `WithLegacyLeaseLock`. While the
-`leader_lock` table has no row, a replica follows the Lease that replicas on the
-previous release still hold. After the last of them releases the Lease and five
-seconds pass, one replica creates the row, and from then on no replica reads the
-Lease. Remove the option in the release after this one.
+Until we deem it safe to remove, we are also introducing a `WithLegacyLeaseLock` option
+on the election config, which points the new lock at the Lease the election used
+before. While the `leader_lock` table has no row, a replica follows that legacy Lease,
+which replicas on the previous release still hold. After the last of them releases the
+Lease and five seconds pass, one replica creates the row, and from then on no replica
+reads the Lease. This is to make the rolling upgrade that transitions from the old to
+the new paradigm smooth. The option can be removed in a future release.
 
 ## Rationale
 
-A row read by primary key and updated in place has one version, so the cost of each
-read is the same on every poll and does not grow between compactions. The version
-check on update gives the same guarantee client-go's Lease lock gives: a replica can
-only write over a record it has read, so two replicas cannot both hold the lock.
+This is one effort in a series of efforts to reduce the load an idle Obot puts on its
+database. Metrics show that the query that reads the Lease is by far the busiest query in
+most Obot Cloud environments. This eliminates that and is objectively a better fit for
+leader election in general. We already had a file based locking mechanism, so this was
+an easy extension to the existing framework.
 
-A rolling update runs replicas on the old release and the new release side by side.
-If the new replicas did not read the Lease, each release would elect its own leader
-and the controllers would run twice until the last old replica was gone. Replicas on
-the old release poll every two seconds and take a released Lease on their next poll,
-so a five second wait lets them win any race and keeps the election on one lock until
-they are gone.
+While this will remove the most expensive query (by volume and execution time) in the Cloud
+environment, it won't solve the broader DB CPU consumption problem in general as that
+is largely a factor of the sheer volume of queries kinm makes in order to watch all of
+Obot's types.
 
 ## Consequences
 
-Every two seconds the election costs one primary key read per replica, plus one
-single-row update by the leader. On the first environment to receive the change, the
-two Lease queries went from 10% of sampled query execution time to none.
+As mentioned above, this will cut out the reads and writes of the Lease kinm object.
 
-Failover is unchanged. In local runs against Postgres, the leader released the lock
-84 to 95 ms after SIGTERM, a follower took over within three seconds, and a crashed
-leader was replaced 60 to 63 seconds after it died, once the 60 second TTL passed.
+The lock creates the `leader_lock` table at startup if it is missing. The old Lease
+row stays behind in the `lease` table, unread and unwritten, until a later release
+removes the leases API group.
 
-The `leader_lock` table is not one of kinm's objects and is not visible through the
-Kubernetes-style API. The lock creates the table at startup if it is missing.
+Failover behavior is unchanged, which we verified locally against Postgres and in the
+main environment.
 
-The old Lease object remains in kinm's `lease` table. Nothing reads or writes it, and
-kinm continues to compact that table at two statements per fifteen minutes per
-replica, until a later release removes the leases API group.
-
-During the one rolling update that introduces the change, the five second wait is a
-timing argument, not a guarantee. A replica on the old release that stalls for more
-than five seconds at the moment the last old leader releases can take the Lease after
-a new replica has created the row, and both lead until the rollout terminates the old
-replica. The team accepted the window. Running that one deploy with a `Recreate`
-strategy removes it.
-
-Each replica logs at startup which lock its election uses. While it follows a Lease,
-it logs once who holds it, once when the five second wait starts, and once when it
-creates the row.
+During the transition we have a five second grace period, so a replica on the new
+release does not create the row the instant the legacy Lease is released. Replicas
+still on the old release poll every two seconds, so the wait gives them a chance to
+claim the Lease first and keeps the election on one lock while any of them is still
+running. If one of them is stalled longer than that at the moment the last old leader
+releases, it can take the Lease after the row already exists, and both lead until the
+rollout terminates it. We accepted that window rather than deploying the one release
+with a `Recreate` strategy.
 
 ## References
 

--- a/adr/2026-09-02-sql-leader-lock.md
+++ b/adr/2026-09-02-sql-leader-lock.md
@@ -36,9 +36,6 @@ Read the row by primary key and update it in place with a version check. Keep
 client-go's election algorithm, TTL, and retry period as they are. The lock type is
 selectable in nah as `ResourceLockType` `sql`, next to the existing file lock.
 
-Keep the `obot-local-controller` election on a Lease in the Kubernetes cluster it
-manages.
-
 In the release that introduces the change, enable `WithLegacyLeaseLock`. While the
 `leader_lock` table has no row, a replica follows the Lease that replicas on the
 previous release still hold. After the last of them releases the Lease and five
@@ -51,9 +48,6 @@ A row read by primary key and updated in place has one version, so the cost of e
 read is the same on every poll and does not grow between compactions. The version
 check on update gives the same guarantee client-go's Lease lock gives: a replica can
 only write over a record it has read, so two replicas cannot both hold the lock.
-
-In the Kubernetes cluster, a Lease is a single object in etcd, read and written in
-one round trip, and the local controller has the cluster access it needs already.
 
 A rolling update runs replicas on the old release and the new release side by side.
 If the new replicas did not read the Lease, each release would elect its own leader

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/obot-platform/cmd v0.0.0-20260707150346-5103d461ab67
 	github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e
 	github.com/obot-platform/mmmcp v0.1.2
-	github.com/obot-platform/nah v0.0.0-20260902222426-636420908be9
+	github.com/obot-platform/nah v0.0.0-20260903153505-fafe94344bbd
 	github.com/obot-platform/obot/apiclient v0.0.0-20250813183905-ade719c1e8bf
 	github.com/obot-platform/obot/logger v0.0.0-20241217130503-4004a5c69f32
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e h1:o439PMKepm2y
 github.com/obot-platform/kinm v0.0.0-20260717005812-cd2688a2a64e/go.mod h1:mJ2Mx/FzMK2WmfxamD2V9N7TeakulKdmGHw4qvMjzUs=
 github.com/obot-platform/mmmcp v0.1.2 h1:M0IQlmnF73bZfbLT8ArZ/mFVSMRoH+bFmqCe/YwvDtk=
 github.com/obot-platform/mmmcp v0.1.2/go.mod h1:IM+X47ERoflOPn9ZEtrKki5zp4mAz9J6Ov5wvZBot+M=
-github.com/obot-platform/nah v0.0.0-20260902222426-636420908be9 h1:ghr7sLW3yg5fBoCuHGOz9ZVa3xcv0JuYUtFAq2plZnw=
-github.com/obot-platform/nah v0.0.0-20260902222426-636420908be9/go.mod h1:XYTsRgyYAHyKS9yAy3j5LFdWGJM48EmneZ1otits+dU=
+github.com/obot-platform/nah v0.0.0-20260903153505-fafe94344bbd h1:Ox8sHDspOi8JFucGu4V65j7Agx/tZaauvFn8bPkoM0c=
+github.com/obot-platform/nah v0.0.0-20260903153505-fafe94344bbd/go.mod h1:XYTsRgyYAHyKS9yAy3j5LFdWGJM48EmneZ1otits+dU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=


### PR DESCRIPTION
Two things, both follow-ups to #7727.

## The ADR

The record that should have accompanied #7727. It covers the decision that shipped there with obot-platform/nah#32: the `obot-controller` election moved from a Lease in kinm's versioned store to one row in a `leader_lock` table, plus the `WithLegacyLeaseLock` option that keeps a single leader through the rolling update that introduces the change.

Written from `adr/template.md` per `adr/README.md`. No related issue exists; the work came out of the shared database CPU investigation. No ODP was written for it either, which the README asks for on significant designs, noted here rather than left implied.

## The nah bump

Picks up obot-platform/nah#33, which fixes what the election logs at startup. The old line said the election was deferring to the legacy Lease whenever the option was set, regardless of whether there was anything to defer to. In the main environment, which had already migrated, both replicas logged this and neither read the Lease even once:

```
leader election obot-controller: lock leader_lock/obot-controller, deferring to the legacy Lease kube-system/obot-controller until the first row exists
```

Now the election logs the lock it uses, and the SQL lock separately reports whether it has a row yet:

```
leader_lock/obot-controller has no row; deferring to the legacy lock kube-system/obot-controller until one exists
leader_lock/obot-controller already has a row; the legacy lock kube-system/obot-controller is configured but will not be read
```

That makes the logs distinguish a migration in progress from one that has finished, which matters while the fleet rolls over.

Note that v0.25.5-rc3 was built before nah#33 merged, so environments upgrading to rc3 still show the misleading line. The corrected logging arrives in the build after this merges.
