### PR TITLE
fix: send an ETag for the embedded UI files

### DIFF
--- a/ui/handler.go
+++ b/ui/handler.go
@@ -1,8 +1,11 @@
 package ui
 
 import (
+	"crypto/sha256"
 	"embed"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"net/http/httputil"
@@ -28,10 +31,12 @@ type uiServer struct {
 	// fsys holds the built UI. It is a field so tests can supply a stub in place
 	// of the embedded build, which only exists after `make ui`.
 	fsys fs.FS
+	// etags maps a path in fsys to that file's content hash, used as its ETag.
+	etags map[string]string
 }
 
 func Handler(devPort, userOnlyPort int) http.Handler {
-	server := &uiServer{fsys: embedded}
+	server := newUIServer(embedded)
 
 	if userOnlyPort != 0 {
 		server.rp = newUIProxy(userOnlyPort)
@@ -41,6 +46,55 @@ func Handler(devPort, userOnlyPort int) http.Handler {
 	}
 
 	return server
+}
+
+func newUIServer(fsys fs.FS) *uiServer {
+	return &uiServer{fsys: fsys, etags: buildETags(fsys)}
+}
+
+// buildETags hashes every file in fsys once, at startup, so each one can be
+// served with an ETag. Nothing else gives these responses a validator, because
+// Go takes Last-Modified from FileInfo.ModTime, every file in an embed.FS
+// reports the zero time, and ServeContent omits the header for a zero time.
+// Without a validator a client that already holds a copy still has to download
+// the whole body to revalidate it, which is what the HTML pays on every
+// navigation, since no-cache makes it revalidate before each use.
+//
+// A content hash is the right validator here because it is the same on every
+// replica running the same build and changes only when the file changes. The
+// alternative is a timestamp, which would have to be invented, and process
+// start time would differ per replica and move on every restart even when the
+// file did not change.
+//
+// A file that cannot be read is left out of the map and served without an
+// ETag, which is how every file behaves today.
+func buildETags(fsys fs.FS) map[string]string {
+	etags := map[string]string{}
+
+	_ = fs.WalkDir(fsys, ".", func(name string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+
+		f, err := fsys.Open(name)
+		if err != nil {
+			return nil
+		}
+		defer f.Close()
+
+		h := sha256.New()
+		if _, err = io.Copy(h, f); err != nil {
+			return nil
+		}
+
+		// 128 bits is far more than enough to tell the files of one build apart,
+		// and it keeps the header short.
+		etags[name] = fmt.Sprintf("%q", base64.RawURLEncoding.EncodeToString(h.Sum(nil)[:16]))
+
+		return nil
+	})
+
+	return etags
 }
 
 // newUIProxy proxies to a UI server on localhost. SetXForwarded keeps the
@@ -63,6 +117,18 @@ func newUIProxy(port int) *httputil.ReverseProxy {
 // revalidation before it is used.
 func (s *uiServer) serveHTML(w http.ResponseWriter, r *http.Request, name string) {
 	w.Header().Set("Cache-Control", "no-cache")
+	s.serveFile(w, r, name)
+}
+
+// serveFile serves a file from the build tagged with its content hash, so a
+// client that already holds a copy can revalidate with If-None-Match and get a
+// 304 rather than the body again. http.ServeContent reads the ETag set here
+// when it checks preconditions, so it writes the 304 itself.
+func (s *uiServer) serveFile(w http.ResponseWriter, r *http.Request, name string) {
+	if etag, ok := s.etags[name]; ok {
+		w.Header().Set("ETag", etag)
+	}
+
 	http.ServeFileFS(w, r, s.fsys, name)
 }
 
@@ -104,7 +170,7 @@ func (s *uiServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// returns can never change and the client never has to ask again.
 			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 		}
-		http.ServeFileFS(w, r, s.fsys, userPath)
+		s.serveFile(w, r, userPath)
 	} else if !strings.Contains(strings.ToLower(r.UserAgent()), "mozilla") {
 		// Non-browser clients get a real 404 for unknown paths rather than the SPA
 		// fallback, so a mistyped API path doesn't return HTML with a 200. no-store

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -15,13 +15,28 @@ const (
 )
 
 func testUIServer() *uiServer {
-	return &uiServer{fsys: fstest.MapFS{
+	return newUIServer(fstest.MapFS{
 		"user/build/index.html":                       {Data: []byte("<html>index</html>")},
+		"user/build/admin.html":                       {Data: []byte("<html>admin</html>")},
 		"user/build/fallback.html":                    {Data: []byte("<html>fallback</html>")},
 		"user/build/mcp-servers.html":                 {Data: []byte("<html>mcp-servers</html>")},
 		"user/build/_app/immutable/nodes/0.abc123.js": {Data: []byte("export const x = 1")},
 		"user/build/favicon.ico":                      {Data: []byte("icon")},
-	}}
+	})
+}
+
+// serveConditional repeats a request with the ETag the first response carried,
+// which is what a browser does when it revalidates a copy it already holds.
+func serveConditional(t *testing.T, urlPath, etag string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "http://obot.example.com"+urlPath, nil)
+	req.Header.Set("User-Agent", chromeUA)
+	req.Header.Set("If-None-Match", etag)
+	rec := httptest.NewRecorder()
+	testUIServer().ServeHTTP(rec, req)
+
+	return rec
 }
 
 func serve(t *testing.T, urlPath, userAgent string) *httptest.ResponseRecorder {
@@ -157,5 +172,112 @@ func TestUIProxyForwardsToLocalhostWithXForwardedFor(t *testing.T) {
 	}
 	if gotProto != "http" {
 		t.Errorf("expected X-Forwarded-Proto http for a non-TLS hop, got %q", gotProto)
+	}
+}
+
+// Serving from an embed.FS leaves Go with no validator to send, because every
+// embedded file reports a zero ModTime and ServeContent omits Last-Modified for
+// one. Every file we serve needs an ETag so a client holding a copy can
+// revalidate it.
+func TestETagIsSetOnEveryServedFile(t *testing.T) {
+	for _, urlPath := range []string{
+		"/",
+		"/admin",
+		"/mcp-servers",
+		"/some/client/side/route",
+		"/_app/immutable/nodes/0.abc123.js",
+		"/favicon.ico",
+	} {
+		t.Run(urlPath, func(t *testing.T) {
+			rec := serve(t, urlPath, chromeUA)
+			if etag := rec.Header().Get("ETag"); etag == "" {
+				t.Error("expected an ETag so the client can revalidate, got none")
+			}
+		})
+	}
+}
+
+// Without a validator, no-cache means the client downloads the whole page again
+// on every navigation. With one, revalidation costs a 304 and no body.
+func TestRevalidationReturns304(t *testing.T) {
+	for _, urlPath := range []string{
+		"/",
+		"/some/client/side/route",
+		"/_app/immutable/nodes/0.abc123.js",
+	} {
+		t.Run(urlPath, func(t *testing.T) {
+			first := serve(t, urlPath, chromeUA)
+			if first.Code != http.StatusOK {
+				t.Fatalf("expected 200 on the first request, got %d", first.Code)
+			}
+
+			second := serveConditional(t, urlPath, first.Header().Get("ETag"))
+			if second.Code != http.StatusNotModified {
+				t.Errorf("expected 304 when the client already has this copy, got %d", second.Code)
+			}
+			if body := second.Body.String(); body != "" {
+				t.Errorf("expected no body on a 304, got %q", body)
+			}
+		})
+	}
+}
+
+// Cloudflare rewrites a strong ETag to a weak one when it compresses a
+// response, so the browser revalidates with the weak form against the strong
+// one we set. RFC 7232 uses weak comparison for If-None-Match, and this pins
+// that we get the 304 rather than the whole body.
+func TestRevalidationAcceptsAWeakenedETag(t *testing.T) {
+	first := serve(t, "/", chromeUA)
+
+	rec := serveConditional(t, "/", "W/"+first.Header().Get("ETag"))
+	if rec.Code != http.StatusNotModified {
+		t.Errorf("expected 304 for a weakened form of our own ETag, got %d", rec.Code)
+	}
+}
+
+// A 304 that drops Cache-Control would leave the client with a stored copy and
+// no instruction to revalidate it next time.
+func TestCacheControlSurvivesA304(t *testing.T) {
+	first := serve(t, "/", chromeUA)
+
+	rec := serveConditional(t, "/", first.Header().Get("ETag"))
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("expected Cache-Control no-cache on the 304, got %q", got)
+	}
+}
+
+// A stale ETag has to serve the new file, or a client keeps its old copy after
+// a deploy. This is the case that matters for the HTML, since each page names
+// the hashed assets of the build it came from.
+func TestChangedContentServesTheNewFile(t *testing.T) {
+	rec := serveConditional(t, "/", `"etag-from-an-older-build"`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 when the client's copy is stale, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); body != "<html>index</html>" {
+		t.Errorf("expected the current index body, got %q", body)
+	}
+}
+
+// The ETag has to identify the file, so that two different files never share
+// one and the same file keeps its ETag across replicas and restarts.
+func TestETagsIdentifyContent(t *testing.T) {
+	index := serve(t, "/", chromeUA).Header().Get("ETag")
+	asset := serve(t, "/_app/immutable/nodes/0.abc123.js", chromeUA).Header().Get("ETag")
+
+	if index == asset {
+		t.Error("expected different files to have different ETags")
+	}
+	if again := serve(t, "/", chromeUA).Header().Get("ETag"); again != index {
+		t.Errorf("expected a stable ETag for unchanged content, got %q then %q", index, again)
+	}
+}
+
+// A 404 is not a representation of anything, and it is already marked no-store
+// so that a deploy adding the path is not shadowed by a cached miss.
+func TestNoETagOn404(t *testing.T) {
+	rec := serve(t, "/api/definitely-not-a-route", "Go-http-client/2.0")
+	if etag := rec.Header().Get("ETag"); etag != "" {
+		t.Errorf("expected no ETag on a 404, got %q", etag)
 	}
 }


### PR DESCRIPTION
Follow-up to #7701, from the review question about why we return neither `ETag` nor `Last-Modified` for the HTML pages that carry `Cache-Control: no-cache`.

## Why there is no validator today

We serve the UI out of an `embed.FS`. Go takes `Last-Modified` from `FileInfo.ModTime`, every file in an `embed.FS` reports the zero time, and `ServeContent` omits the header for a zero time. Go never generates an `ETag` on its own, it only honors one the handler already set, and we did not set one.

## What that costs

`no-cache` tells a client to store the response and revalidate before every use. Revalidation is only cheap when origin can answer `If-None-Match` with a 304, and we gave it nothing to match on, so every navigation and every refresh comes back as a 200 with the whole page.

Checked against obot-qa, which is still on the pre-#7701 build:

| Request | cf-cache-status | Cache-Control | Last-Modified | ETag | Conditional GET |
|---|---|---|---|---|---|
| `/` and `/admin` | DYNAMIC | none | none | none | 200 |
| `/_app/immutable/...js` | MISS then HIT | `max-age=14400` | present | none | 304 |

Origin sends neither header on either path. Both headers on the asset are Cloudflare's, where `max-age=14400` is a 4 hour Browser Cache TTL setting and the `Last-Modified` is stamped when Cloudflare stored the object, not a build time. The asset revalidates against a validator Cloudflare invented at the edge. The HTML is DYNAMIC, so Cloudflare does not cache it and never invents one, which leaves the HTML with no validator anywhere. That is the 200 on refresh the reviewer saw.

## The change

Hash every embedded file once at startup and serve it with that hash as its `ETag`. `ServeContent` reads the `ETag` we set when it checks preconditions, so it answers a matching `If-None-Match` with a 304 itself and nothing else in the handler moves.

A content hash is the right validator here because it is identical on every replica running the same build and changes only when the file changes. `Last-Modified` would have to be invented, since the embedded files carry no timestamp, and process start time would differ per replica and move on every restart even when the file did not change. There is no reason to add both.

Verified on the wire against the real embedded build:

```
/                                      200 cc="no-cache"                              bytes=5140
                                       revalidate -> 304                              bytes=0
/_app/immutable/nodes/30.C7KYbbNh.js   200 cc="public, max-age=31536000, immutable"   bytes=15370
                                       revalidate -> 304                              bytes=0
/favicon.ico                           200 cc=""                                      bytes=15086
                                       revalidate -> 304                              bytes=0
```

## Cost

Hashing the current build is 675 files and about 22MB, measured at 42ms once during startup. If that is not wanted at startup it can be made lazy with a `sync.Map`, but 42ms seemed cheaper than the concurrency.

## Cloudflare

Cloudflare rewrites a strong `ETag` to a weak one when it compresses a response, so the browser revalidates with `W/"..."` against the strong form we set. `If-None-Match` uses weak comparison, so that still returns a 304. There is a test pinning it.

## Two things outside this PR

The Browser Cache TTL of 4 hours is overriding origin. Once #7701 deploys, `public, max-age=31536000, immutable` on the hashed assets gets downgraded to `max-age=14400` before it reaches the browser, so browsers revalidate them every 4 hours for no reason. Switching that setting to "Respect Existing Headers" is what makes the `immutable` header do anything.

Cloudflare is also storing 404s for asset URLs. I poisoned one on QA with a non-browser User-Agent and Cloudflare recorded it, though it expired quickly rather than persisting. The `no-store` on that 404 in #7701 is what stops it, and it is the part of that fix most worth confirming after deploy.

## Tests

- Every served file carries an `ETag`, covering the HTML entry points, the SPA fallback, a hashed asset, and `favicon.ico`.
- Revalidation returns 304 with no body.
- A weakened `W/` form of our own `ETag` still returns 304.
- `Cache-Control` survives the 304, so the client is still told to revalidate next time.
- A stale `ETag` serves the new file, which is the case that matters after a deploy.
- Different files get different `ETag`s, and unchanged content keeps the same one.
- No `ETag` on the 404, which stays `no-store`.

`ui/handler_test.go` also gains `admin.html` in the stub FS, which was missing, so `/admin` was 404ing in tests rather than serving.