### PR TITLE
feat(mcp): add Cloud Foundry runtime backend (wind-down WIP)

### DIFF
--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -26,6 +26,7 @@ const (
 	runtimeBackendDocker          = "docker"
 	RuntimeBackendKubernetes      = "kubernetes"
 	runtimeBackendKubernetesShort = "k8s"
+	RuntimeBackendCloudFoundry    = "cloudfoundry"
 )
 
 var (

--- a/pkg/mcp/cloudfoundry.go
+++ b/pkg/mcp/cloudfoundry.go
@@ -1,0 +1,116 @@
+package mcp
+
+import (
+	"context"
+	"io"
+
+	otypes "github.com/obot-platform/obot/apiclient/types"
+)
+
+// cloudFoundryBackend runs Obot as a Cloud Foundry application without a
+// container-orchestration runtime for MCP servers.
+//
+// Cloud Foundry has no equivalent of the docker or Kubernetes runtimes that the
+// other backends drive, so this backend supports exactly the runtimes that need
+// no orchestration: RuntimeRemote and RuntimeComposite, which are served by
+// Obot's own gateway process. Every runtime that requires Obot to start a
+// workload (uvx, npx, containerized) reports ErrNotSupportedByBackend, which the
+// API handlers translate into a 404 rather than a 500.
+//
+// Deploying MCP servers as Cloud Foundry applications through the Cloud
+// Controller v3 API is deliberately out of scope here; streamServerLogs,
+// restartServer, and getServerDetails are the seams that work would grow into.
+type cloudFoundryBackend struct {
+	authEnabled    bool
+	httpListenPort int
+}
+
+func newCloudFoundryBackend(authEnabled bool, httpListenPort int, _ Options) backend {
+	return &cloudFoundryBackend{
+		authEnabled:    authEnabled,
+		httpListenPort: httpListenPort,
+	}
+}
+
+// runtimeIsGatewayServed reports whether a runtime is served by Obot's own
+// process and therefore needs no deployment of any kind.
+func runtimeIsGatewayServed(runtime otypes.Runtime) bool {
+	return runtime == otypes.RuntimeRemote || runtime == otypes.RuntimeComposite
+}
+
+func (c *cloudFoundryBackend) ensureServerDeployment(_ context.Context, server ServerConfig) (ServerConfig, error) {
+	for i, component := range server.Components {
+		component.URL = c.transformObotHostname(component.URL)
+		server.Components[i] = component
+	}
+
+	for i, webhook := range server.Webhooks {
+		webhook.URL = c.transformObotHostname(webhook.URL)
+		server.Webhooks[i] = webhook
+	}
+
+	if runtimeIsGatewayServed(server.Runtime) {
+		return server, nil
+	}
+
+	return ServerConfig{}, &ErrNotSupportedByBackend{
+		Feature: "deploying " + string(server.Runtime) + " MCP servers",
+		Backend: RuntimeBackendCloudFoundry,
+	}
+}
+
+func (c *cloudFoundryBackend) deployServer(_ context.Context, server ServerConfig) error {
+	if runtimeIsGatewayServed(server.Runtime) {
+		return nil
+	}
+
+	return &ErrNotSupportedByBackend{
+		Feature: "deploying " + string(server.Runtime) + " MCP servers",
+		Backend: RuntimeBackendCloudFoundry,
+	}
+}
+
+func (c *cloudFoundryBackend) getServerDetails(_ context.Context, _ string) (otypes.MCPServerDetails, error) {
+	return otypes.MCPServerDetails{}, &ErrNotSupportedByBackend{
+		Feature: "server details",
+		Backend: RuntimeBackendCloudFoundry,
+	}
+}
+
+func (c *cloudFoundryBackend) streamServerLogs(_ context.Context, _ string) (io.ReadCloser, error) {
+	return nil, &ErrNotSupportedByBackend{
+		Feature: "server logs",
+		Backend: RuntimeBackendCloudFoundry,
+	}
+}
+
+func (c *cloudFoundryBackend) restartServer(_ context.Context, _ ServerConfig) error {
+	return &ErrNotSupportedByBackend{
+		Feature: "restarting servers",
+		Backend: RuntimeBackendCloudFoundry,
+	}
+}
+
+// shutdownServer must succeed for every runtime, including the ones this backend
+// cannot deploy. It is called from delete and finalizer paths as well as the
+// idle-disable path, and returning an error there wedges the finalizer instead
+// of degrading. Nothing is ever deployed, so there is nothing to shut down.
+func (c *cloudFoundryBackend) shutdownServer(_ context.Context, _ string, _ bool) error {
+	return nil
+}
+
+// transformObotHostname is the identity function. Obot is reachable at its
+// external route, and no MCP workload runs anywhere that needs a rewritten
+// hostname. Routing over the Cloud Foundry internal domain would change this.
+func (c *cloudFoundryBackend) transformObotHostname(url string) string {
+	return url
+}
+
+// remoteConfig returns the global validation config untouched, which keeps
+// localhost, private-IP, and link-local blocking exactly as the operator
+// configured it. The docker backend has to relax private-IP blocking because it
+// talks to MCP containers over a bridge network; this backend talks to nothing
+// internal, so it grants no exceptions and returns an empty allowlist.
+func (c *cloudFoundryBackend) remoteConfig(globalConfig RemoteMCPURLValidationConfig) (RemoteMCPURLValidationConfig, []string) {
+	return globalConfig, nil
+}

--- a/pkg/mcp/manager.go
+++ b/pkg/mcp/manager.go
@@ -49,7 +49,7 @@ type Options struct {
 	DisallowLocalhostMCP              bool     `usage:"Disallow MCP containers from connecting to localhost" default:"true"`
 	DisallowPrivateIPMCP              bool     `usage:"Disallow MCP containers from connecting to private IPs" default:"true"`
 	DisallowLinkLocalMCP              bool     `usage:"Disallow MCP containers from connecting to link-local addresses" default:"true"`
-	MCPRuntimeBackend                 string   `usage:"The runtime backend to use for running MCP servers: docker, kubernetes, or k8s. Defaults to docker" default:"docker"`
+	MCPRuntimeBackend                 string   `usage:"The runtime backend to use for running MCP servers: docker, kubernetes, k8s, or cloudfoundry. Defaults to docker" default:"docker"`
 	MCPSecretBindingAllowedLabel      string   `usage:"Kubernetes Secret label key required for admin UI secret-binding lookup and save-time validation" default:"obot.obot.ai/allow-secret-binding"`
 	MCPImagePullSecrets               []string `usage:"The name of the image pull secret to use for pulling MCP images"`
 	SingleUserIdleServerShutdownHours int      `usage:"The interval in hours to check for idle MCP servers designated to a single user and shut them down, set to -1 to disable shutdown" default:"24"`
@@ -175,6 +175,8 @@ func NewSessionManager(ctx context.Context, authEnabled bool, globalTokenStore G
 			obotStorageClient,
 			opts,
 		)
+	case RuntimeBackendCloudFoundry:
+		backend = newCloudFoundryBackend(authEnabled, httpListenPort, opts)
 	default:
 		return nil, fmt.Errorf("unknown runtime backend: %s", opts.MCPRuntimeBackend)
 	}


### PR DESCRIPTION
## Context

Part of the MCP Server Hub project wind-down. This preserves work-in-progress
that was previously uncommitted/local-only so the approach and its scope
boundaries survive for any future developer who picks the effort back up.

The goal was to let Obot run as a Cloud Foundry application (cloud.gov) without
a container-orchestration runtime for MCP servers. See
`mcp-server-hub/planning/cloud_gov_plan.md` and `cloud_gov_roadmap.md` for the
full plan and resume points.

## Plan / What changed

Adds a new `cloudfoundry` MCP runtime backend:

- `pkg/mcp/backend.go` — register the `RuntimeBackendCloudFoundry` constant
- `pkg/mcp/manager.go` — wire the backend into `NewSessionManager` and update
  the `MCPRuntimeBackend` usage string
- `pkg/mcp/cloudfoundry.go` — new backend implementation (116 lines)

**Scope (deliberately minimal WIP):**
- Supports only gateway-served runtimes (`RuntimeRemote`, `RuntimeComposite`).
- `uvx` / `npx` / `containerized` return `ErrNotSupportedByBackend`, which the
  API handlers translate to HTTP 404.
- Deploying MCP servers as Cloud Foundry apps via the Cloud Controller v3 API is
  **out of scope**. `getServerDetails`, `streamServerLogs`, and `restartServer`
  are intentional stubs — the seams that work would grow into.
- `shutdownServer` is a no-op (nothing is ever deployed); `transformObotHostname`
  is identity; `remoteConfig` returns global config unchanged with an empty
  allowlist.

## Verification

- `go build ./pkg/mcp/` — passes
- No new tests added (WIP backend of stubs); no behavior change to existing
  backends (docker remains the default).

## Rollback

Revert this PR / delete the `cloudfoundry-backend` branch. No config, schema, or
default-behavior changes; `docker` stays the default runtime backend, so
existing deployments are unaffected.

## Security Impact

- No change to auth, secrets handling, or default behavior.
- The backend intentionally does **not** relax localhost/private-IP/link-local
  blocking (`remoteConfig` grants no exceptions), so it does not widen network
  reachability relative to the docker backend.
- No new external dependencies.

## Known gaps / follow-ups (not in this PR)

- No Cloud Foundry `manifest.yml` yet.
- No ADR for the backend (an ADR is planned as part of wind-down docs).
- Actual CF app deployment (Cloud Controller v3) is unimplemented by design.

🤖 Assisted by OpenCode Agent. Requires human review before any deployment.
