### PR TITLE
fix: rename MCP tool call telemetry field

### DIFF
--- a/apiclient/types/producttelemetry.go
+++ b/apiclient/types/producttelemetry.go
@@ -40,7 +40,7 @@ type ProductTelemetryMetrics struct {
 	CustomMCPServerEntryCount   *int64                              `json:"customMCPServerEntryCount"`
 	BuiltInMCPServers           *[]ProductTelemetryBuiltInMCPServer `json:"builtInMCPServers"`
 	AuthProviderType            *string                             `json:"authProviderType"`
-	MCPAuditLogCount            *int64                              `json:"mcpAuditLogCount"`
+	MCPToolCallCount            *int64                              `json:"mcpToolCallCount"`
 	LLMAuditLogCount            *int64                              `json:"llmAuditLogCount"`
 	SentryScanCount             *int64                              `json:"sentryScanCount"`
 	SentryEnforcementEventCount *int64                              `json:"sentryEnforcementEventCount"`

--- a/apiclient/types/producttelemetry.go
+++ b/apiclient/types/producttelemetry.go
@@ -52,7 +52,6 @@ type ProductTelemetryMetrics struct {
 // +k8s:openapi-gen=false
 type ProductTelemetryBuiltInMCPServer struct {
 	ID              string `json:"id"`
-	Name            string `json:"name"`
-	DeploymentCount int64  `json:"deploymentCount"`
-	UserCount       int64  `json:"userCount"`
+	DeploymentCount int64  `json:"deployments"`
+	UserCount       int64  `json:"users"`
 }

--- a/pkg/producttelemetry/client_test.go
+++ b/pkg/producttelemetry/client_test.go
@@ -41,7 +41,7 @@ func testRequest() clienttypes.ProductTelemetryRequest {
 			CustomMCPServerEntryCount:   new(int64(4)),
 			BuiltInMCPServers:           &servers,
 			AuthProviderType:            new("github"),
-			MCPAuditLogCount:            new(int64(0)),
+			MCPToolCallCount:            new(int64(0)),
 			SentryScanCount:             new(int64(14)),
 			SentryEnforcementEventCount: new(int64(3)),
 			ManagedSkillCount:           new(int64(27)),
@@ -63,7 +63,7 @@ func TestClientSend(t *testing.T) {
 		{
 			name:         "full report preserves null and zero metrics",
 			request:      fullRequest,
-			wantBody:     `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","licenseMachineID":"ab65c9ac-c012-4567-89ab-1b520aa26584","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0","metrics":{"totalUsers":42,"activeUsers":null,"deployedMCPServers":0,"customMCPServerEntryCount":4,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":"github","mcpAuditLogCount":0,"llmAuditLogCount":null,"sentryScanCount":14,"sentryEnforcementEventCount":3,"managedSkillCount":27}}`,
+			wantBody:     `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","licenseMachineID":"ab65c9ac-c012-4567-89ab-1b520aa26584","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0","metrics":{"totalUsers":42,"activeUsers":null,"deployedMCPServers":0,"customMCPServerEntryCount":4,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":"github","mcpToolCallCount":0,"llmAuditLogCount":null,"sentryScanCount":14,"sentryEnforcementEventCount":3,"managedSkillCount":27}}`,
 			responseBody: "ignored success body",
 		},
 		{

--- a/pkg/producttelemetry/client_test.go
+++ b/pkg/producttelemetry/client_test.go
@@ -24,7 +24,6 @@ func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) 
 func testRequest() clienttypes.ProductTelemetryRequest {
 	servers := []clienttypes.ProductTelemetryBuiltInMCPServer{{
 		ID:              "github",
-		Name:            "GitHub",
 		DeploymentCount: 2,
 		UserCount:       7,
 	}}
@@ -63,7 +62,7 @@ func TestClientSend(t *testing.T) {
 		{
 			name:         "full report preserves null and zero metrics",
 			request:      fullRequest,
-			wantBody:     `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","licenseMachineID":"ab65c9ac-c012-4567-89ab-1b520aa26584","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0","metrics":{"totalUsers":42,"activeUsers":null,"deployedMCPServers":0,"customMCPServerEntryCount":4,"builtInMCPServers":[{"id":"github","name":"GitHub","deploymentCount":2,"userCount":7}],"authProviderType":"github","mcpToolCallCount":0,"llmAuditLogCount":null,"sentryScanCount":14,"sentryEnforcementEventCount":3,"managedSkillCount":27}}`,
+			wantBody:     `{"installationID":"7d7d83d8-2af0-4da8-ae2d-102d8eaa70be","licenseMachineID":"ab65c9ac-c012-4567-89ab-1b520aa26584","reportedAt":"2026-08-31T00:04:12Z","distribution":"Cloud","engine":"kubernetes","currentVersion":"v0.26.0","metrics":{"totalUsers":42,"activeUsers":null,"deployedMCPServers":0,"customMCPServerEntryCount":4,"builtInMCPServers":[{"id":"github","deployments":2,"users":7}],"authProviderType":"github","mcpToolCallCount":0,"llmAuditLogCount":null,"sentryScanCount":14,"sentryEnforcementEventCount":3,"managedSkillCount":27}}`,
 			responseBody: "ignored success body",
 		},
 		{


### PR DESCRIPTION
## Summary

- rename `ProductTelemetryMetrics.MCPAuditLogCount` to `MCPToolCallCount` and its JSON field to `mcpToolCallCount`
- remove `Name` from built-in MCP server telemetry metrics
- shorten the built-in server JSON fields to `deployments` and `users`
- update serialization coverage without adding telemetry publishing or collection behavior

addresses #7739
