### PR TITLE
fix: stop re-sweeping the legacy audit log credential on every reconcile

### DIFF
--- a/pkg/controller/handlers/cleanup/credentials.go
+++ b/pkg/controller/handlers/cleanup/credentials.go
@@ -2,6 +2,7 @@ package cleanup
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/obot-platform/nah/pkg/router"
 	"github.com/obot-platform/obot/pkg/api/handlers"
@@ -83,11 +84,42 @@ func (c *Credentials) RemoveMCPInstanceCredentials(req router.Request, _ router.
 	return nil
 }
 
+// RemoveAuditLogCred removes the credential an older Obot stored per server for token exchange
+// and external audit log submitting, at context and name both equal to the server's name. That
+// credential was written by EnsureOAuthClient, which no longer exists, so a server only ever needs
+// sweeping once.
+//
+// The sweep cannot be a migration, because Obot is deployed by others and an upgrade arrives
+// whenever a deployer takes it. So it stays a handler, and an annotation on the server records
+// that it has run. Without that annotation it is a DELETE against the credentials table on every
+// reconcile of every server, matching no rows, which is one of the largest sources of slow query
+// log lines in a busy deployment.
 func (c *Credentials) RemoveAuditLogCred(req router.Request, _ router.Response) error {
+	if _, swept := req.Object.GetAnnotations()[v1.AuditLogCredentialRemovedAnnotation]; swept {
+		return nil
+	}
+
 	credentialName := req.Name
 	if _, ok := req.Object.(*v1.SystemMCPServer); ok {
 		credentialName += "-secret-info"
 	}
-	_, err := c.gatewayClient.DeleteCredential(req.Ctx, req.Name, credentialName)
-	return err
+
+	deleted, err := c.gatewayClient.DeleteCredential(req.Ctx, req.Name, credentialName)
+	if err != nil {
+		return err
+	}
+	if deleted {
+		slog.Info("Removed legacy token exchange and audit log credential", "server", req.Name)
+	}
+
+	// Recorded only after the delete succeeds, so a failure leaves the sweep pending rather than
+	// marking a server clean that still holds the credential.
+	annotations := req.Object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string, 1)
+	}
+	annotations[v1.AuditLogCredentialRemovedAnnotation] = "true"
+	req.Object.SetAnnotations(annotations)
+
+	return req.Client.Update(req.Ctx, req.Object)
 }

--- a/pkg/controller/handlers/cleanup/credentials.go
+++ b/pkg/controller/handlers/cleanup/credentials.go
@@ -85,15 +85,8 @@ func (c *Credentials) RemoveMCPInstanceCredentials(req router.Request, _ router.
 }
 
 // RemoveAuditLogCred removes the credential an older Obot stored per server for token exchange
-// and external audit log submitting, at context and name both equal to the server's name. That
-// credential was written by EnsureOAuthClient, which no longer exists, so a server only ever needs
-// sweeping once.
-//
-// The sweep cannot be a migration, because Obot is deployed by others and an upgrade arrives
-// whenever a deployer takes it. So it stays a handler, and an annotation on the server records
-// that it has run. Without that annotation it is a DELETE against the credentials table on every
-// reconcile of every server, matching no rows, which is one of the largest sources of slow query
-// log lines in a busy deployment.
+// and external audit log submitting. Nothing creates it any more, so a server is swept once and
+// the annotation records that it has been.
 func (c *Credentials) RemoveAuditLogCred(req router.Request, _ router.Response) error {
 	if _, swept := req.Object.GetAnnotations()[v1.AuditLogCredentialRemovedAnnotation]; swept {
 		return nil
@@ -112,8 +105,7 @@ func (c *Credentials) RemoveAuditLogCred(req router.Request, _ router.Response) 
 		slog.Info("Removed legacy token exchange and audit log credential", "server", req.Name)
 	}
 
-	// Recorded only after the delete succeeds, so a failure leaves the sweep pending rather than
-	// marking a server clean that still holds the credential.
+	// Recorded only after the delete succeeds, so a failure retries.
 	annotations := req.Object.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string, 1)

--- a/pkg/controller/handlers/cleanup/credentials_test.go
+++ b/pkg/controller/handlers/cleanup/credentials_test.go
@@ -1,0 +1,154 @@
+package cleanup
+
+import (
+	"testing"
+	"time"
+
+	"github.com/obot-platform/nah/pkg/router"
+	gatewayclient "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	storageservices "github.com/obot-platform/obot/pkg/storage/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newCredentialsCleanupGatewayClient(t *testing.T) *gatewayclient.Client {
+	t.Helper()
+
+	storageServices, err := storageservices.New(storageservices.Config{DSN: "sqlite://:memory:"})
+	require.NoError(t, err)
+
+	database, err := gatewaydb.New(storageServices.DB.DB, storageServices.DB.SQLDB, true)
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate())
+
+	client := gatewayclient.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, 0, false)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close gateway client: %v", err)
+		}
+	})
+	return client
+}
+
+func credentialExists(t *testing.T, client *gatewayclient.Client, credentialContext, name string) bool {
+	t.Helper()
+
+	creds, err := client.ListCredentials(t.Context(), gatewayclient.ListCredentialsOptions{
+		CredentialContexts: []string{credentialContext},
+	})
+	require.NoError(t, err)
+	for _, cred := range creds {
+		if cred.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// The credential this sweeps was written per server by EnsureOAuthClient, which no longer exists.
+// Nothing recreates it, so a server should be swept once and then never queried again.
+func TestRemoveAuditLogCred(t *testing.T) {
+	tests := []struct {
+		name string
+		// object is the server as the controller sees it at the start of the pass.
+		object func() kclient.Object
+		// credentialName is the credential seeded in the store for that server.
+		credentialName string
+		// wantDeleted is whether the seeded credential should be gone afterwards.
+		wantDeleted bool
+	}{
+		{
+			name: "server that has not been swept loses the credential",
+			object: func() kclient.Object {
+				return &v1.MCPServer{
+					Name:      "ms1abcdef",
+					Namespace: "default",
+				}
+			},
+			credentialName: "ms1abcdef",
+			wantDeleted:    true,
+		},
+		{
+			name: "system server uses the secret info name",
+			object: func() kclient.Object {
+				return &v1.SystemMCPServer{
+					Name:      "sms1obot-mcp-server",
+					Namespace: "default",
+				}
+			},
+			credentialName: "sms1obot-mcp-server-secret-info",
+			wantDeleted:    true,
+		},
+		{
+			name: "server already recorded as swept is left alone",
+			object: func() kclient.Object {
+				return &v1.MCPServer{
+					Name:      "ms1abcdef",
+					Namespace: "default",
+					Annotations: map[string]string{
+						v1.AuditLogCredentialRemovedAnnotation: "true",
+					},
+				}
+			},
+			credentialName: "ms1abcdef",
+			wantDeleted:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			object := tt.object()
+			gatewayClient := newCredentialsCleanupGatewayClient(t)
+			require.NoError(t, gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+				Context: object.GetName(),
+				Name:    tt.credentialName,
+				Secrets: map[string]string{"AUDIT_LOG_TOKEN": "legacy"},
+			}))
+
+			client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(object).Build()
+			err := NewCredentials(nil, gatewayClient, "").RemoveAuditLogCred(router.Request{
+				Client:    client,
+				Ctx:       t.Context(),
+				Object:    object,
+				Namespace: object.GetNamespace(),
+				Name:      object.GetName(),
+			}, &router.ResponseWrapper{})
+			require.NoError(t, err)
+
+			assert.Equal(t, !tt.wantDeleted, credentialExists(t, gatewayClient, object.GetName(), tt.credentialName))
+			assert.Contains(t, object.GetAnnotations(), v1.AuditLogCredentialRemovedAnnotation,
+				"the server should be recorded as swept either way, so it is never queried again")
+		})
+	}
+}
+
+// The annotation is the only thing that stops the sweep running again, so it must not be written
+// on a pass where the delete did not happen.
+func TestRemoveAuditLogCredKeepsSweepPendingWhenDeleteFails(t *testing.T) {
+	server := &v1.MCPServer{
+		Name:      "ms1abcdef",
+		Namespace: "default",
+	}
+
+	gatewayClient := newCredentialsCleanupGatewayClient(t)
+	require.NoError(t, gatewayClient.Close())
+
+	client := fake.NewClientBuilder().WithScheme(storagescheme.Scheme).WithObjects(server).Build()
+	err := NewCredentials(nil, gatewayClient, "").RemoveAuditLogCred(router.Request{
+		Client:    client,
+		Ctx:       t.Context(),
+		Object:    server,
+		Namespace: server.Namespace,
+		Name:      server.Name,
+	}, &router.ResponseWrapper{})
+
+	require.Error(t, err)
+	assert.NotContains(t, server.GetAnnotations(), v1.AuditLogCredentialRemovedAnnotation,
+		"a failed delete must leave the sweep pending for the next pass")
+}

--- a/pkg/controller/handlers/cleanup/credentials_test.go
+++ b/pkg/controller/handlers/cleanup/credentials_test.go
@@ -51,17 +51,12 @@ func credentialExists(t *testing.T, client *gatewayclient.Client, credentialCont
 	return false
 }
 
-// The credential this sweeps was written per server by EnsureOAuthClient, which no longer exists.
-// Nothing recreates it, so a server should be swept once and then never queried again.
 func TestRemoveAuditLogCred(t *testing.T) {
 	tests := []struct {
-		name string
-		// object is the server as the controller sees it at the start of the pass.
-		object func() kclient.Object
-		// credentialName is the credential seeded in the store for that server.
+		name           string
+		object         func() kclient.Object
 		credentialName string
-		// wantDeleted is whether the seeded credential should be gone afterwards.
-		wantDeleted bool
+		wantDeleted    bool
 	}{
 		{
 			name: "server that has not been swept loses the credential",
@@ -123,13 +118,11 @@ func TestRemoveAuditLogCred(t *testing.T) {
 
 			assert.Equal(t, !tt.wantDeleted, credentialExists(t, gatewayClient, object.GetName(), tt.credentialName))
 			assert.Contains(t, object.GetAnnotations(), v1.AuditLogCredentialRemovedAnnotation,
-				"the server should be recorded as swept either way, so it is never queried again")
+				"a swept server must be recorded so it is never queried again")
 		})
 	}
 }
 
-// The annotation is the only thing that stops the sweep running again, so it must not be written
-// on a pass where the delete did not happen.
 func TestRemoveAuditLogCredKeepsSweepPendingWhenDeleteFails(t *testing.T) {
 	server := &v1.MCPServer{
 		Name:      "ms1abcdef",
@@ -150,5 +143,5 @@ func TestRemoveAuditLogCredKeepsSweepPendingWhenDeleteFails(t *testing.T) {
 
 	require.Error(t, err)
 	assert.NotContains(t, server.GetAnnotations(), v1.AuditLogCredentialRemovedAnnotation,
-		"a failed delete must leave the sweep pending for the next pass")
+		"a failed delete must leave the sweep pending")
 }

--- a/pkg/storage/apis/obot.obot.ai/v1/constants.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/constants.go
@@ -22,9 +22,7 @@ const (
 	MCPServerCatalogEntrySyncAnnotation = "obot.ai/mcp-server-catalog-entry-sync"
 	ModelInfoSourceSyncAnnotation       = "obot.ai/model-info-source-sync"
 
-	// AuditLogCredentialRemovedAnnotation records that the token exchange and audit log
-	// credential an older Obot stored for this server has been removed. Nothing creates that
-	// credential any more, so the sweep only needs to run once per server, and this annotation
-	// is what stops it running on every reconcile forever.
+	// AuditLogCredentialRemovedAnnotation records that a server's legacy token exchange and
+	// audit log credential has been removed, so the sweep runs once and not on every reconcile.
 	AuditLogCredentialRemovedAnnotation = "obot.ai/audit-log-credential-removed"
 )

--- a/pkg/storage/apis/obot.obot.ai/v1/constants.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/constants.go
@@ -21,4 +21,10 @@ const (
 	AgentCatalogSyncAnnotation          = "obot.ai/agent-catalog-sync"
 	MCPServerCatalogEntrySyncAnnotation = "obot.ai/mcp-server-catalog-entry-sync"
 	ModelInfoSourceSyncAnnotation       = "obot.ai/model-info-source-sync"
+
+	// AuditLogCredentialRemovedAnnotation records that the token exchange and audit log
+	// credential an older Obot stored for this server has been removed. Nothing creates that
+	// credential any more, so the sweep only needs to run once per server, and this annotation
+	// is what stops it running on every reconcile forever.
+	AuditLogCredentialRemovedAnnotation = "obot.ai/audit-log-credential-removed"
 )


### PR DESCRIPTION
## Why

`RemoveAuditLogCred` is one of the two largest sources of slow query log lines in the main deployment. Over 24 hours it issues 757 deletes across 141 servers, and every one of them matches no rows.

```
credential DELETEs in 24h: 1,662
  catalog entry OAuth cleanup   905   affected=0: 905   (#7726)
  RemoveAuditLogCred            757   affected=0: 757   (this PR)
```

kinm logs any statement over 200ms as `sql query slow`, and the time it measures includes waiting for a connection from a pool of five. These deletes are individually cheap, around 50 microseconds of actual execution, and there are simply far too many of them.

## What the credential is

An older Obot stored one credential per server holding the token exchange client id and secret and the audit log token, written by `EnsureOAuthClient`:

```go
Context:  server.Name,
ToolName: server.Name,
Env: {TOKEN_EXCHANGE_CLIENT_ID, TOKEN_EXCHANGE_CLIENT_SECRET, AUDIT_LOG_TOKEN}
```

#7629 removed token exchange and external audit log submitting along with the `oauthclients` handler that wrote it, and added `RemoveAuditLogCred` to sweep what was left behind. For a SystemMCPServer the equivalent credential is named `<server>-secret-info`.

Nothing recreates either one, so a server only ever needs sweeping once.

## Why it keeps running

It is registered as a plain handler rather than a finalizer, unlike its two siblings in the same file:

```go
root.Type(&v1.MCPServer{}).HandlerFunc(credentialCleanup.RemoveAuditLogCred)
root.Type(&v1.SystemMCPServer{}).HandlerFunc(credentialCleanup.RemoveAuditLogCred)
```

So instead of running once when a server is deleted, it runs on every reconcile of every server that exists.

## What changed

The handler  records that it has run in an annotation on the server:

```
obot.ai/audit-log-credential-removed
```

The handler returns immediately when that annotation is present, so a server costs one delete and one update, once, and nothing after that.

The annotation is written only after the delete succeeds. A failed delete leaves the sweep pending for the next pass rather than marking a server clean while it still holds the credential.

## Testing

A table covers the MCPServer and SystemMCPServer credential names and the already swept case, which asserts that a seeded credential survives untouched. A separate test closes the gateway client to force the delete to fail and asserts the annotation is not written. These run against a real sqlite backed credential store rather than a fake, using the same helper pattern as the existing tests in this package.
