### PR TITLE
fix: skip the npx audit when launching NPX MCP servers

### DIFF
--- a/pkg/mcp/backend.go
+++ b/pkg/mcp/backend.go
@@ -315,6 +315,13 @@ func MMMCPConfig(server ServerConfig, env map[string][]byte) *mmmcpconfig.Config
 		completeEnv[k] = string(v)
 	}
 
+	if server.Runtime == types.RuntimeNPX {
+		// npx audits the installed tree against the registry before it execs the server. The
+		// result is only logged, nothing here can act on it, and the audit endpoint is
+		// intermittently unresponsive.
+		completeEnv["NPM_CONFIG_AUDIT"] = "false"
+	}
+
 	componentName := replacer.Replace(serverName)
 
 	config.Servers = []mmmcpconfig.Server{{

--- a/pkg/mcp/backend_test.go
+++ b/pkg/mcp/backend_test.go
@@ -220,22 +220,23 @@ func TestMMMCPConfigDisablesNPXAudit(t *testing.T) {
 	tests := []struct {
 		name    string
 		runtime types.Runtime
-		want    bool
+		// want is the expected NPM_CONFIG_AUDIT value, empty when it should not be set at all.
+		want string
 	}{
 		{
 			name:    "npx",
 			runtime: types.RuntimeNPX,
-			want:    true,
+			want:    "false",
 		},
 		{
 			name:    "uvx",
 			runtime: types.RuntimeUVX,
-			want:    false,
+			want:    "",
 		},
 		{
 			name:    "containerized",
 			runtime: types.RuntimeContainerized,
-			want:    false,
+			want:    "",
 		},
 	}
 
@@ -246,9 +247,8 @@ func TestMMMCPConfigDisablesNPXAudit(t *testing.T) {
 				Runtime:       tt.runtime,
 			}, nil)
 
-			_, got := config.Servers[0].Env["NPM_CONFIG_AUDIT"]
-			if got != tt.want {
-				t.Fatalf("NPM_CONFIG_AUDIT present = %v, want %v", got, tt.want)
+			if got := config.Servers[0].Env["NPM_CONFIG_AUDIT"]; got != tt.want {
+				t.Fatalf("NPM_CONFIG_AUDIT = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/pkg/mcp/backend_test.go
+++ b/pkg/mcp/backend_test.go
@@ -215,3 +215,41 @@ func TestEnsureServerReadyHealthzPathWaitsForOK(t *testing.T) {
 		t.Fatalf("expected two healthz calls, got %d", calls)
 	}
 }
+
+func TestMMMCPConfigDisablesNPXAudit(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime types.Runtime
+		want    bool
+	}{
+		{
+			name:    "npx",
+			runtime: types.RuntimeNPX,
+			want:    true,
+		},
+		{
+			name:    "uvx",
+			runtime: types.RuntimeUVX,
+			want:    false,
+		},
+		{
+			name:    "containerized",
+			runtime: types.RuntimeContainerized,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := MMMCPConfig(ServerConfig{
+				MCPServerName: "test-server",
+				Runtime:       tt.runtime,
+			}, nil)
+
+			_, got := config.Servers[0].Env["NPM_CONFIG_AUDIT"]
+			if got != tt.want {
+				t.Fatalf("NPM_CONFIG_AUDIT present = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

NPX MCP servers intermittently fail to launch, in CI and in QA, with:

```
failed to launch MCP server: failed to connect MCP client: context deadline exceeded
```

The launch dies at exactly 60s, which is `defaultStartupTimeoutSeconds`.

`npx` audits the installed tree against the registry before it execs the server, and that audit is where the time goes. Measured in `stdio-wrapper:v0.26.0`:

| step | time |
| --- | --- |
| `npm install` of the package | 2s |
| running the installed binary directly | 1s |
| `npx <package> stdio` | >100s |
| `npx <package> stdio` with the audit disabled | 3s |

npm's own log shows the audit request going out and then no further output for the rest of the stall. The `_npx` directory reaches its full 31MB within 5 seconds and never grows again, so the download is long finished while the process sits.

The audit endpoint is unresponsive intermittently rather than always, which is why this passes on some runs and fails on others. It is not specific to a package or an npm version: a 3 package tree took 300s while the 107 package tree took 167s, and stock `node:22-alpine` stalls the same way as our image.

Through the full path obot actually uses, mmmcp in the stdio-wrapper image with obot's generated config, readiness goes from **187s to 8s**.

## What changed

Set `NPM_CONFIG_AUDIT=false` in the environment mmmcp gives the child process, for the NPX runtime only.

Both the docker and kubernetes backends build that config through `MMMCPConfig`, so one place covers both.

## What we give up

Nothing we were using. The audit is a report, not a gate: it does not change what gets installed, and with it enabled the server still starts, just minutes later. Its output goes to the container log at the one moment nobody can act on it, for a dependency tree the catalog entry has already pinned. It also sends the full dependency list to npmjs.org on every server start.

Scanning belongs at catalog curation time, where a human can respond to it, not on the hot path of every launch.
