### PR TITLE
fix: prevent false MCP deployment diffs

### DIFF
--- a/ui/user/src/lib/components/mcp/DeploymentsView.svelte
+++ b/ui/user/src/lib/components/mcp/DeploymentsView.svelte
@@ -399,6 +399,19 @@
 		return prompted;
 	}
 
+	async function showDeploymentDiff(server: MCPCatalogServer) {
+		if (!server.catalogEntryID) return;
+
+		try {
+			const catalogEntry = await UserService.getMCP(server.catalogEntryID);
+			existingServer = server;
+			updatedServer = catalogEntry;
+			diffDialog?.open();
+		} catch (error) {
+			console.error('Failed to load catalog entry for deployment diff:', error);
+		}
+	}
+
 	function upgradeNotesForConfirmation() {
 		const servers =
 			showUpgradeConfirm?.type === 'single'
@@ -756,13 +769,11 @@
 									<button
 										class="menu-button-primary"
 										disabled={updating[d.id]?.inProgress || readonly}
-										onclick={(e) => {
+										onclick={async (e) => {
 											e.stopPropagation();
 											if (!d.catalogEntryID) return;
 
-											existingServer = d;
-											updatedServer = entriesMap[d.catalogEntryID];
-											diffDialog?.open();
+											await showDeploymentDiff(d);
 											toggle(false);
 										}}
 									>

--- a/ui/user/src/routes/mcp-servers/page.svelte.spec.ts
+++ b/ui/user/src/routes/mcp-servers/page.svelte.spec.ts
@@ -127,6 +127,31 @@ describe('MCP Servers Page', () => {
 		});
 
 		describe('ellipsis menu actions', () => {
+			it('loads the full catalog entry before showing a deployment diff', async () => {
+				const fullDescription = 'Full description loaded for the deployment diff';
+				const toolDescription = 'Full tool preview loaded for the deployment diff';
+				worker.use(
+					http.get('/api/all-mcps/entries/:entryID', ({ params }) => {
+						const entry = fixtures.entries.find((candidate) => candidate.id === params.entryID);
+						return HttpResponse.json({
+							...entry,
+							manifest: {
+								...entry?.manifest,
+								description: fullDescription,
+								toolPreview: [{ name: 'full_tool', description: toolDescription }]
+							}
+						});
+					})
+				);
+
+				await openRowActions(fixtures.serverSingleNeedsUpdate.manifest.name!);
+				await page.getByRole('button', { name: 'View Diff', exact: true }).click();
+
+				const diffDialog = page.getByRole('dialog').filter({ hasText: 'New Version' });
+				await expect.element(diffDialog).toHaveTextContent(fullDescription);
+				await expect.element(diffDialog).toHaveTextContent(toolDescription);
+			});
+
 			it('renders and sanitizes a catalog upgrade note in single confirmation', async () => {
 				await openRowActions(fixtures.serverSingleNeedsUpdate.manifest.name!);
 				await page.getByRole('button', { name: 'Update Server', exact: true }).click();


### PR DESCRIPTION
## Summary

- load the full catalog entry before rendering deployment diffs so fields omitted from minimal list responses are not shown as removals
- reject top-level environment variables on composite catalog entries because configuration must belong to an executable component server. This previously would always cause a drift to be detected because these values are not copied to the MCP Server. It is not a valid use-case anyways so it's disabled
- add regression coverage for both the full-detail diff request and the composite deployment drift chain

addresses #7768
