### PR TITLE
docs(installation): fix Helm secrets and ingress examples

### DIFF
--- a/docs/docs/installation/enabling-authentication.md
+++ b/docs/docs/installation/enabling-authentication.md
@@ -33,14 +33,15 @@ config:
   # Required: Enable authentication
   OBOT_SERVER_ENABLE_AUTHENTICATION: "true"
 
-  # Required: Set a bootstrap token for initial login
-  OBOT_BOOTSTRAP_TOKEN: "your-secret-token"
-
   # Required: Set the owner email (can also be configured in the UI later)
   OBOT_SERVER_AUTH_OWNER_EMAILS: "owner@company.com"
 
   # Optional: Set additional admin emails
   OBOT_SERVER_AUTH_ADMIN_EMAILS: "admin1@company.com,admin2@company.com"
+
+secret:
+  # Optional: generated automatically when omitted from the chart-managed Secret
+  OBOT_BOOTSTRAP_TOKEN: "your-secret-token"
 ```
 
   </TabItem>

--- a/docs/docs/installation/reference-architectures/01-gcp-gke.md
+++ b/docs/docs/installation/reference-architectures/01-gcp-gke.md
@@ -85,31 +85,36 @@ service:
 ingress:
   enabled: true
   hosts:
-    - host: <your hostname>
+    - <your hostname>
 
 serviceAccount:
   # This is important for configuring Google Workload Identity, which we use for Google Cloud KMS access
   create: true
   name: "<name of the service account to be created and used by obot>"
 
+# Sensitive values belong under secret; the chart rejects them under config.
+secret:
+  # database configuration for external db
+  OBOT_SERVER_DSN: "postgresql://<db user>:<db password>@<db host>:<db port>/<db name>?sslmode=<ssl mode>"
+
+  # Optional: generated automatically when omitted from the chart-managed Secret
+  OBOT_BOOTSTRAP_TOKEN: "<bootstrap password>"
+
+  # Optionally configure model providers
+  OPENAI_API_KEY: "<your openai api key>"
+
+# Non-sensitive configuration
 config:
   # configures encryption with Google Cloud KMS. optional, but recommended for production
   OBOT_SERVER_ENCRYPTION_PROVIDER: "GCP"
   OBOT_GCP_KMS_KEY_URI: "projects/<your project>/locations/<your location>/keyRings/<your key ring>/cryptoKeys/<your key>"
 
-  # database configuration for external db
-  OBOT_SERVER_DSN: "postgresql://<db user>:<db password>@<db host>:<db port>/<db name>?sslmode=<ssl mode>"
-
   # Enable authentication
   OBOT_SERVER_ENABLE_AUTHENTICATION: true
-  OBOT_BOOTSTRAP_TOKEN: "<bootstrap password>"
 
   # Optionally Preseed admin and owner users
   OBOT_SERVER_AUTH_ADMIN_EMAILS: "<comma separated list of admin emails>"
   OBOT_SERVER_AUTH_OWNER_EMAILS: "<comma separated list of owner emails>"
-
-  # Optionally configure model providers
-  OPENAI_API_KEY: "<your openai api key>"
 
 mcpServerDefaults:
   storageClassName: hyperdisk # replace with the name of your StorageClass

--- a/docs/docs/installation/reference-architectures/02-aws-eks.md
+++ b/docs/docs/installation/reference-architectures/02-aws-eks.md
@@ -73,7 +73,7 @@ ingress:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
   hosts:
-    - host: <your hostname>
+    - <your hostname>
 
 serviceAccount:
   # This is important for configuring IAM roles for service accounts (IRSA), which we use for AWS KMS access
@@ -82,25 +82,30 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: "<arn of the IAM role to be assumed by obot>"
 
+# Sensitive values belong under secret; the chart rejects them under config.
+secret:
+  # database configuration for external db
+  OBOT_SERVER_DSN: "postgresql://<db user>:<db password>@<db host>:<db port>/<db name>?sslmode=<ssl mode>"
+
+  # Optional: generated automatically when omitted from the chart-managed Secret
+  OBOT_BOOTSTRAP_TOKEN: "<bootstrap password>"
+
+  # Optionally configure model providers
+  OPENAI_API_KEY: "<your openai api key>"
+
+# Non-sensitive configuration
 config:
   # configures encryption with AWS KMS. optional, but recommended for production
   OBOT_SERVER_ENCRYPTION_PROVIDER: "aws"
   OBOT_AWS_KMS_KEY_ARN: "arn:aws:kms:<region>:<account-id>:key/<key-id>"
 
-  # database configuration for external db
-  OBOT_SERVER_DSN: "postgresql://<db user>:<db password>@<db host>:<db port>/<db name>?sslmode=<ssl mode>"
-
   # Enable authentication
   OBOT_SERVER_ENABLE_AUTHENTICATION: true
-  OBOT_BOOTSTRAP_TOKEN: "<bootstrap password>"
 
   # Optionally Preseed admin and owner users
   OBOT_SERVER_AUTH_ADMIN_EMAILS: "<comma separated list of admin emails>"
   OBOT_SERVER_AUTH_OWNER_EMAILS: "<comma separated list of owner emails>"
 
-  # Optionally configure model providers
-  OPENAI_API_KEY: "<your openai api key>"
-  
 mcpServerDefaults:
   storageClassName: ebs # replace with the name of your StorageClass
   nanobotWorkspaceSize: 1Gi # Some disk types have a minimum size, read the documentation for the storage type you select.

--- a/docs/docs/installation/reference-architectures/03-azure-aks.md
+++ b/docs/docs/installation/reference-architectures/03-azure-aks.md
@@ -94,7 +94,7 @@ ingress:
   annotations:
     appgw.ingress.kubernetes.io/backend-path-prefix: "/"
   hosts:
-    - host: <your hostname>
+    - <your hostname>
 
 serviceAccount:
   # This is important for configuring Azure Workload Identity, which we use for Azure Key Vault access
@@ -103,6 +103,18 @@ serviceAccount:
   annotations:
     azure.workload.identity/client-id: "<client id of the managed identity>"
 
+# Sensitive values belong under secret; the chart rejects them under config.
+secret:
+  # database configuration for external db
+  OBOT_SERVER_DSN: "postgresql://<db user>:<db password>@<db host>:<db port>/<db name>?sslmode=<ssl mode>"
+
+  # Optional: generated automatically when omitted from the chart-managed Secret
+  OBOT_BOOTSTRAP_TOKEN: "<bootstrap password>"
+
+  # Optionally configure model providers
+  OPENAI_API_KEY: "<your openai api key>"
+
+# Non-sensitive configuration
 config:
   # configures encryption with Azure Key Vault. optional, but recommended for production
   OBOT_SERVER_ENCRYPTION_PROVIDER: "azure"
@@ -110,19 +122,12 @@ config:
   OBOT_AZURE_KEY_NAME: "<your-key-name>"
   OBOT_AZURE_KEY_VERSION: "<your-key-version>"
 
-  # database configuration for external db
-  OBOT_SERVER_DSN: "postgresql://<db user>:<db password>@<db host>:<db port>/<db name>?sslmode=<ssl mode>"
-
   # Enable authentication
   OBOT_SERVER_ENABLE_AUTHENTICATION: true
-  OBOT_BOOTSTRAP_TOKEN: "<bootstrap password>"
 
   # Optionally Preseed admin and owner users
   OBOT_SERVER_AUTH_ADMIN_EMAILS: "<comma separated list of admin emails>"
   OBOT_SERVER_AUTH_OWNER_EMAILS: "<comma separated list of owner emails>"
-
-  # Optionally configure model providers
-  OPENAI_API_KEY: "<your openai api key>"
 
 mcpServerDefaults:
   storageClassName: azure-disk # replace with the name of your StorageClass


### PR DESCRIPTION
Move credentials under secret in the EKS, GKE, and AKS examples. Correct ingress hosts to use strings.
Fix bootstrap token placement and optionality in authentication setup.