### PR TITLE
Coalesce auth provider group refreshes and back off after failures

### DIFF
--- a/pkg/gateway/client/client.go
+++ b/pkg/gateway/client/client.go
@@ -12,6 +12,7 @@ import (
 	types2 "github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/gateway/db"
 	"github.com/obot-platform/obot/pkg/gateway/types"
+	"golang.org/x/sync/singleflight"
 	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -58,6 +59,13 @@ type Client struct {
 	deviceScanCleanupInterval time.Duration
 	deviceScanDeleteBatchSize int
 	mcpOAuthTokenTrigger      func(context.Context, string) error
+
+	// groupRefresh collapses concurrent group fetches for one identity into a single call.
+	// groupBackoff holds identities whose last refresh failed, so a failing provider is left
+	// alone for a cooldown. Both are per-process; see ensureGroups.
+	groupRefresh     singleflight.Group
+	groupBackoffLock sync.Mutex
+	groupBackoff     map[string]time.Time
 }
 
 func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptionConfig *encryptionconfig.EncryptionConfiguration, mcpOAuthTokenTrigger func(context.Context, string) error, ownerEmails, adminEmails []string, auditLogPersistenceInterval time.Duration, auditLogBatchSize, auditLogRetentionDays, llmAuditLogRetentionDays, deviceScanRetentionDays int, llmAuditEnabled bool) *Client {
@@ -90,6 +98,7 @@ func New(ctx context.Context, db *db.DB, storageClient kclient.Client, encryptio
 		auditLogDeleteBatchSize:   defaultAuditLogDeleteBatchSize,
 		deviceScanCleanupInterval: defaultDeviceScanCleanupInterval,
 		deviceScanDeleteBatchSize: defaultDeviceScanDeleteBatchSize,
+		groupBackoff:              make(map[string]time.Time),
 	}
 
 	go c.runMCPAuditLogPersistenceLoop(ctx, auditLogPersistenceInterval)

--- a/pkg/gateway/client/group.go
+++ b/pkg/gateway/client/group.go
@@ -39,6 +39,13 @@ const (
 	// client gives up.
 	groupProviderTimeout = 30 * time.Second
 
+	// userGroupRefreshTimeout bounds a group refresh on the authentication path. It is much
+	// shorter than groupProviderTimeout because failing there is cheap: the cooldown then serves
+	// groups from the database, at most one check window old. Waiting longer mostly buys a retry
+	// that only lands if Okta's bucket happens to reset inside the timeout, and every request
+	// coalesced behind the refresh waits along with it.
+	userGroupRefreshTimeout = 10 * time.Second
+
 	// groupFailureCooldown is how long to leave the auth provider alone after a failed refresh.
 	// Only a successful refresh advances the check window, so without this a failing provider is
 	// called again by the very next request.
@@ -49,6 +56,9 @@ const (
 
 var (
 	groupProviderClient = &http.Client{Timeout: groupProviderTimeout}
+
+	// userGroupProviderClient serves the authentication path; see userGroupRefreshTimeout.
+	userGroupProviderClient = &http.Client{Timeout: userGroupRefreshTimeout}
 )
 
 // FetchUserGroupsError represents an error that occurs when fetching user groups from the auth provider.
@@ -655,7 +665,7 @@ func (c *Client) ensureGroups(ctx context.Context, identity *types.Identity) err
 
 	// Detached from the caller: the refresh is shared, so a leader whose client disconnects must
 	// not cancel it for everyone waiting. The timeout bounds it instead.
-	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), groupProviderTimeout)
+	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), userGroupRefreshTimeout)
 	defer cancel()
 
 	v, err, _ := c.groupRefresh.Do(key, func() (any, error) {
@@ -942,7 +952,7 @@ func (*Client) fetchGroups(ctx context.Context, authProviderURL, authProviderNam
 
 	// Not http.DefaultClient, which has no timeout: ensureGroups runs this on a context detached
 	// from the calling request, so an unbounded client would let a hung provider hold it open.
-	resp, err := groupProviderClient.Do(req)
+	resp, err := userGroupProviderClient.Do(req)
 	if err != nil {
 		return nil, &FetchUserGroupsError{
 			ProviderUserID: providerUserID,

--- a/pkg/gateway/client/group.go
+++ b/pkg/gateway/client/group.go
@@ -39,6 +39,11 @@ const (
 	// client gives up.
 	groupProviderTimeout = 30 * time.Second
 
+	// groupFailureCooldown is how long to leave the auth provider alone after a failed refresh.
+	// Only a successful refresh advances the check window, so without this a failing provider is
+	// called again by the very next request.
+	groupFailureCooldown = time.Minute
+
 	groupCursorVersion = 1
 )
 
@@ -602,6 +607,14 @@ func (c *Client) GetUserGroupMemberships(ctx context.Context, userIDs []uint) (m
 	return memberships, nil
 }
 
+// groupRefreshResult is what one refresh produces. Every request waiting on that refresh adopts
+// it, so a burst costs one call to the auth provider. A zero lastChecked means the groups came
+// from the database, so the identity's check timestamp should be left alone.
+type groupRefreshResult struct {
+	groups      []types.Group
+	lastChecked time.Time
+}
+
 // ensureGroups ensures the groups that the identity is a member of exist and are up to date.
 //
 // It MUST be called outside of any open database transaction: the group fetch it performs is an
@@ -609,6 +622,11 @@ func (c *Client) GetUserGroupMemberships(ctx context.Context, userIDs []uint) (m
 // deadlock in-process auth providers that share the single SQLite connection. The HTTP fetch and
 // the database persistence are therefore separated into distinct phases below, with the
 // persistence happening in its own short-lived transaction.
+//
+// This runs inside request authentication, so calls to the provider follow request volume rather
+// than user count. Concurrent requests for one identity therefore share a single refresh, and an
+// identity whose refresh just failed is served from the database until the cooldown passes. Both
+// are per-process: across replicas, each refreshes an identity at most once per check window.
 func (c *Client) ensureGroups(ctx context.Context, identity *types.Identity) error {
 	if identity.AuthProviderName == "" || identity.AuthProviderNamespace == "" {
 		// No auth provider info, so we can't fetch groups from the provider
@@ -623,27 +641,111 @@ func (c *Client) ensureGroups(ctx context.Context, identity *types.Identity) err
 
 	if nextGroupCheck.After(now) || providerURL == "" {
 		// Throttled (or no provider URL): just read the cached groups from the database.
-		groups, err := c.listUserGroups(ctx, c.db.WithContext(ctx), identity)
-		if err != nil {
-			return fmt.Errorf("failed to list user groups: %w", err)
-		}
-
-		identity.AuthProviderGroups = groups
-		return nil
+		return c.loadCachedGroups(ctx, identity)
 	}
 
-	// Fetch phase: call the auth provider over HTTP with no open transaction.
-	groupLookupID := identity.GroupLookupID()
-	providerGroups, err := c.fetchGroups(ctx, providerURL, identity.AuthProviderNamespace, identity.AuthProviderName, groupLookupID)
+	// Keyed on the ID sent to the provider, so the key and the outbound request are one to one.
+	key := identity.AuthProviderNamespace + "/" + identity.AuthProviderName + "/" + identity.GroupLookupID()
+
+	if c.inGroupFailureCooldown(key, now) {
+		// Serve what is stored rather than starting another attempt. These groups are at most one
+		// check window old, which is what this request would have been served anyway.
+		return c.loadCachedGroups(ctx, identity)
+	}
+
+	// Detached from the caller: the refresh is shared, so a leader whose client disconnects must
+	// not cancel it for everyone waiting. The timeout bounds it instead.
+	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), groupProviderTimeout)
+	defer cancel()
+
+	v, err, _ := c.groupRefresh.Do(key, func() (any, error) {
+		result, err := c.refreshGroups(refreshCtx, providerURL, *identity, now)
+		c.recordGroupRefresh(key, err)
+		return result, err
+	})
 	if err != nil {
 		return err
+	}
+
+	result := v.(groupRefreshResult)
+	identity.AuthProviderGroups = result.groups
+	if !result.lastChecked.IsZero() {
+		// The leader's timestamp, not this request's, so a shared refresh also shares one
+		// identity update in ensureIdentityProviderData.
+		identity.AuthProviderGroupsLastChecked = result.lastChecked
+	}
+
+	return nil
+}
+
+// refreshGroups fetches the identity's groups from the auth provider and persists them, once per
+// burst of concurrent requests; see ensureGroups. The identity is taken by value because this runs
+// on behalf of every waiting request and must not mutate the leader's struct.
+func (c *Client) refreshGroups(ctx context.Context, providerURL string, identity types.Identity, now time.Time) (groupRefreshResult, error) {
+	// Fetch phase: call the auth provider over HTTP with no open transaction.
+	providerGroups, err := c.fetchGroups(ctx, providerURL, identity.AuthProviderNamespace, identity.AuthProviderName, identity.GroupLookupID())
+	if err != nil {
+		return groupRefreshResult{}, err
 	}
 
 	identity.AuthProviderGroups = providerGroups
 	identity.AuthProviderGroupsLastChecked = now
 
 	// Persist phase: upsert groups and reconcile memberships in a short-lived transaction.
-	return c.persistGroups(ctx, identity)
+	if err := c.persistGroups(ctx, &identity); err != nil {
+		return groupRefreshResult{}, err
+	}
+
+	return groupRefreshResult{groups: providerGroups, lastChecked: now}, nil
+}
+
+// loadCachedGroups fills in the identity's groups from the database, for when the provider is not
+// called: the check window has not lapsed, there is no provider URL, or a recent refresh failed.
+func (c *Client) loadCachedGroups(ctx context.Context, identity *types.Identity) error {
+	groups, err := c.listUserGroups(ctx, c.db.WithContext(ctx), identity)
+	if err != nil {
+		return fmt.Errorf("failed to list user groups: %w", err)
+	}
+
+	identity.AuthProviderGroups = groups
+	return nil
+}
+
+// inGroupFailureCooldown reports whether a recent refresh for this identity failed. Expired
+// entries are dropped as they are read, which keeps the map from growing once a provider recovers.
+func (c *Client) inGroupFailureCooldown(key string, now time.Time) bool {
+	c.groupBackoffLock.Lock()
+	defer c.groupBackoffLock.Unlock()
+
+	failedAt, ok := c.groupBackoff[key]
+	if !ok {
+		return false
+	}
+
+	if now.Sub(failedAt) >= groupFailureCooldown {
+		delete(c.groupBackoff, key)
+		return false
+	}
+
+	return true
+}
+
+// recordGroupRefresh starts a cooldown for a failed refresh and ends one for a successful one.
+func (c *Client) recordGroupRefresh(key string, err error) {
+	c.groupBackoffLock.Lock()
+	defer c.groupBackoffLock.Unlock()
+
+	if err == nil {
+		delete(c.groupBackoff, key)
+		return
+	}
+
+	if c.groupBackoff == nil {
+		// Client is built by hand in tests, so don't depend on the constructor.
+		c.groupBackoff = make(map[string]time.Time)
+	}
+
+	c.groupBackoff[key] = time.Now()
 }
 
 // persistGroups persists the identity's freshly fetched AuthProviderGroups to the database and
@@ -838,7 +940,9 @@ func (*Client) fetchGroups(ctx context.Context, authProviderURL, authProviderNam
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	// Not http.DefaultClient, which has no timeout: ensureGroups runs this on a context detached
+	// from the calling request, so an unbounded client would let a hung provider hold it open.
+	resp, err := groupProviderClient.Do(req)
 	if err != nil {
 		return nil, &FetchUserGroupsError{
 			ProviderUserID: providerUserID,

--- a/pkg/gateway/client/group_refresh_test.go
+++ b/pkg/gateway/client/group_refresh_test.go
@@ -1,0 +1,232 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/pkg/auth"
+	"github.com/obot-platform/obot/pkg/gateway/types"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// userGroupProviderStub serves the /obot-list-user-auth-groups contract. It counts requests so
+// tests can assert how many reached the provider, and can hold each one open so a burst of callers
+// is still in flight when the assertion is made.
+type userGroupProviderStub struct {
+	lock     sync.Mutex
+	requests int
+
+	// block, when non-nil, holds every request until it is closed.
+	block chan struct{}
+
+	// arrived is signalled once per request, as it arrives.
+	arrived chan struct{}
+
+	// status, when non-zero, is returned instead of a group list.
+	status int
+
+	groups []auth.GroupInfo
+}
+
+func (s *userGroupProviderStub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/obot-list-user-auth-groups" {
+			http.NotFound(w, r)
+			return
+		}
+
+		s.lock.Lock()
+		s.requests++
+		s.lock.Unlock()
+
+		if s.arrived != nil {
+			s.arrived <- struct{}{}
+		}
+		if s.block != nil {
+			<-s.block
+		}
+
+		if s.status != 0 {
+			http.Error(w, "provider is rate limited", s.status)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(s.groups)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func (s *userGroupProviderStub) count() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.requests
+}
+
+// newGroupRefreshTestClient builds a client that can persist a refresh: persistGroups emits events
+// through the storage client whenever memberships change.
+func newGroupRefreshTestClient(t *testing.T) *Client {
+	t.Helper()
+
+	c := newTestClient(t)
+	c.groupBackoff = make(map[string]time.Time)
+	c.storageClient = fake.NewClientBuilder().WithScheme(storagescheme.Scheme).Build()
+	return c
+}
+
+// newGroupRefreshTestUser inserts a user for group memberships to hang off.
+func newGroupRefreshTestUser(t *testing.T, c *Client, username string) uint {
+	t.Helper()
+
+	user := types.User{Username: username, HashedUsername: username, Email: username + "@example.com"}
+	if err := c.db.WithContext(t.Context()).Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	return user.ID
+}
+
+func groupRefreshTestIdentity(userID uint) *types.Identity {
+	return &types.Identity{
+		AuthProviderName:      testAuthProviderName,
+		AuthProviderNamespace: testAuthProviderNamespace,
+		ProviderUserID:        "provider-user-id",
+		HashedProviderUserID:  "hashed-provider-user-id",
+		UserID:                userID,
+	}
+}
+
+// TestEnsureGroupsCoalescesConcurrentRefreshes covers the case that made an Okta org return 429s:
+// only a successful refresh advances the check window, so every request in flight when it lapses
+// would otherwise call the provider on its own.
+func TestEnsureGroupsCoalescesConcurrentRefreshes(t *testing.T) {
+	const callers = 20
+
+	stub := &userGroupProviderStub{
+		block:   make(chan struct{}),
+		arrived: make(chan struct{}, callers),
+		groups:  []auth.GroupInfo{{ID: "entra/0001", Name: "group-0001"}},
+	}
+	srv := stub.server(t)
+
+	c := newGroupRefreshTestClient(t)
+	userID := newGroupRefreshTestUser(t, c, "coalesce")
+	ctx := auth.ContextWithProviderURL(testGroupContext(t), srv.URL)
+
+	var (
+		wg      sync.WaitGroup
+		results = make([][]types.Group, callers)
+		errs    = make([]error, callers)
+	)
+	for i := range callers {
+		wg.Go(func() {
+			// Each caller gets its own identity, since ensureGroups writes to it.
+			identity := groupRefreshTestIdentity(userID)
+			errs[i] = c.ensureGroups(ctx, identity)
+			results[i] = identity.AuthProviderGroups
+		})
+	}
+
+	// Wait for the leader to reach the provider, then give the rest time to pile up behind it
+	// before letting it answer. Without coalescing, every caller's request would be counted.
+	<-stub.arrived
+	time.Sleep(250 * time.Millisecond)
+	close(stub.block)
+	wg.Wait()
+
+	if got := stub.count(); got != 1 {
+		t.Errorf("auth provider requests = %d, want 1", got)
+	}
+
+	for i := range callers {
+		if errs[i] != nil {
+			t.Fatalf("caller %d: ensureGroups() error = %v", i, errs[i])
+		}
+		if len(results[i]) != 1 || results[i][0].ID != "entra/0001" {
+			t.Errorf("caller %d: groups = %v, want the one group from the provider", i, results[i])
+		}
+	}
+}
+
+// TestEnsureGroupsBacksOffAfterFailedRefresh covers the other half of the same incident: with only
+// a successful refresh advancing the check window, a failing provider would otherwise be called
+// again by the very next request and never get to recover.
+func TestEnsureGroupsBacksOffAfterFailedRefresh(t *testing.T) {
+	stub := &userGroupProviderStub{status: http.StatusTooManyRequests}
+	srv := stub.server(t)
+
+	c := newGroupRefreshTestClient(t)
+	userID := newGroupRefreshTestUser(t, c, "backoff")
+	ctx := auth.ContextWithProviderURL(testGroupContext(t), srv.URL)
+
+	// Something is already known about this user, so the cooldown has groups to fall back on.
+	seedGroups(t, c, 1)
+	if err := c.db.WithContext(ctx).Create(&types.GroupMemberships{UserID: userID, GroupID: "entra/0000"}).Error; err != nil {
+		t.Fatalf("failed to seed membership: %v", err)
+	}
+
+	if err := c.ensureGroups(ctx, groupRefreshTestIdentity(userID)); err == nil {
+		t.Fatal("ensureGroups() error = nil, want the provider's failure to surface")
+	}
+	if got := stub.count(); got != 1 {
+		t.Fatalf("auth provider requests after first call = %d, want 1", got)
+	}
+
+	// Every later request inside the cooldown is served from the database instead.
+	for i := range 5 {
+		identity := groupRefreshTestIdentity(userID)
+		if err := c.ensureGroups(ctx, identity); err != nil {
+			t.Fatalf("call %d: ensureGroups() error = %v, want the cached groups", i, err)
+		}
+		if len(identity.AuthProviderGroups) != 1 || identity.AuthProviderGroups[0].ID != "entra/0000" {
+			t.Errorf("call %d: groups = %v, want the cached group", i, identity.AuthProviderGroups)
+		}
+	}
+
+	if got := stub.count(); got != 1 {
+		t.Errorf("auth provider requests = %d, want the cooldown to have stopped at 1", got)
+	}
+}
+
+// TestEnsureGroupsOutlivesCancelledLeader covers the hazard coalescing introduces: callers share
+// one refresh, so it must not be tied to the lifetime of whichever request leads it.
+func TestEnsureGroupsOutlivesCancelledLeader(t *testing.T) {
+	stub := &userGroupProviderStub{
+		block:   make(chan struct{}),
+		arrived: make(chan struct{}, 1),
+		groups:  []auth.GroupInfo{{ID: "entra/0001", Name: "group-0001"}},
+	}
+	srv := stub.server(t)
+
+	c := newGroupRefreshTestClient(t)
+	userID := newGroupRefreshTestUser(t, c, "cancelled")
+	ctx, cancel := context.WithCancel(auth.ContextWithProviderURL(testGroupContext(t), srv.URL))
+
+	identity := groupRefreshTestIdentity(userID)
+	done := make(chan error, 1)
+	go func() {
+		done <- c.ensureGroups(ctx, identity)
+	}()
+
+	// Cancel the caller mid-refresh, the way a client that disconnects would.
+	<-stub.arrived
+	cancel()
+	close(stub.block)
+
+	if err := <-done; err != nil {
+		t.Fatalf("ensureGroups() error = %v, want the refresh to complete despite the cancellation", err)
+	}
+	if len(identity.AuthProviderGroups) != 1 || identity.AuthProviderGroups[0].ID != "entra/0001" {
+		t.Errorf("groups = %v, want the one group from the provider", identity.AuthProviderGroups)
+	}
+}


### PR DESCRIPTION
## Problem

An Okta org started returning 429s for group lookups, which surfaced to users as a failed login rather than as stale group data.

`ensureGroups` runs inside request authentication, through `UserDecorator.AuthenticateRequest`, so it executes on **every authenticated request**. There is no background job involved. The 10 minute check window is the only thing standing between request volume and the auth provider, and `AuthProviderGroupsLastChecked` is only advanced by a refresh that **succeeds**. That leaves two ways to overload a provider:

1. **Bursts.** There was no deduplication, so every request in flight when the window lapsed called the provider on its own. A single page load fires enough parallel API requests to turn one user's group check into a burst of identical calls.
2. **A self-sustaining retry loop.** Once the provider started failing, the window never advanced, so every subsequent request retried immediately and the provider never got a chance to recover. Authentication failed outright throughout, since the error propagates out of `AuthenticateRequest`. There was no fallback to the groups already in the database, even though the throttled path already reads them.

## Change

**Coalescing.** Concurrent refreshes for one identity now share a single call through `singleflight`, keyed on the ID that is actually sent to the provider so the key and the outbound request are one to one.

**Failure cooldown.** An identity whose refresh just failed is served from the groups already in the database until `groupFailureCooldown` passes. That is the same data the request would have been served a moment earlier, so a rate limited provider degrades group freshness instead of blocking sign in.

Both are per-process. Across replicas each one refreshes an identity at most once per check window, which is a fixed multiple of one replica's calls rather than something that grows with traffic. A cross-replica claim on the identity row would collapse that further, but it would change what `AuthProviderGroupsLastChecked` means and introduce a first-login edge case, which did not seem worth it at this ratio.

**Context detachment.** The shared refresh runs on a context detached from the calling request. It is shared, so a leader whose client disconnects must not cancel it for everyone waiting behind it. That makes an explicit bound necessary, and `fetchGroups` was using `http.DefaultClient`, which has no timeout, unlike the two neighboring provider calls.

**A shorter timeout for this path.** `groupProviderTimeout` is 30 seconds, which suits the two admin group endpoints that already used it but is far too long here now that failing is cheap. The Okta SDK's retry budget is up to two waits of 30 seconds, so under a sustained limit it cannot finish inside 30 seconds anyway; the retry only helps when Okta's per-minute bucket happens to reset inside the timeout. Waiting the full 30 seconds first buys a coin flip, and every request coalesced behind the refresh waits along with it. `fetchGroups` now uses its own client at `userGroupRefreshTimeout` (10s), which keeps the case the retry is good at and cuts the bad case to a third. Obot disconnecting cancels the provider's request context, so the SDK's remaining retries stop rather than burning Okta quota nobody is waiting for.

## Effect

| | Before | After |
|---|---|---|
| Normal load | one provider call per API request | one per user per replica per 10 min |
| Rate limited | one call per request, indefinitely | one per user per replica per minute |
| User impact when limited | authentication fails, indefinitely | one 10s failure per user per minute, cached groups otherwise |

See [the comment below](https://github.com/obot-platform/obot/pull/7798#issuecomment-5608300477) for how the cooldown here and the SDK retry config in obot-platform/enterprise-providers#24 divide the work between them.

## Testing

Three tests in `group_refresh_test.go`. Each was checked against a mutation of the code it covers, not only against the fix:

| Test | Mutation | Result without the fix |
|---|---|---|
| `...CoalescesConcurrentRefreshes` | call `refreshGroups` directly | `requests = 20, want 1` |
| `...BacksOffAfterFailedRefresh` | disable the cooldown check | provider error surfaces instead of cached groups |
| `...OutlivesCancelledLeader` | drop `context.WithoutCancel` | `context canceled` |

Full package passes under `-race`. `go build ./...` and `go vet ./pkg/gateway/...` clean.

One caveat worth a reviewer's eye: the coalescing test holds the provider handler open, waits for the leader to arrive, then sleeps 250ms to let the other callers pile up before releasing. It is the conventional way to test `singleflight` and the window is wide, but it is the one timing dependency in the new tests.

## Related

obot-platform/enterprise-providers#24 fixes the Okta SDK side, where the first 429 was fatal because the SDK was created with no rate limit configuration. The two are independent and each is worth having on its own.

