### PR TITLE
fix: reopen a staged auth provider switch and unstage it with a button

### DIFF
--- a/ui/user/src/routes/identity-access/AuthProvidersView.svelte
+++ b/ui/user/src/routes/identity-access/AuthProvidersView.svelte
@@ -185,18 +185,17 @@
 		}
 	});
 
-	// Returning from the verification lands here with nothing in the URL to say so, and the switch
-	// is then one click from done. Only the owner can finish it, so nobody else is interrupted by a
-	// dialog they cannot act on. Guarded so closing it is respected for the rest of the page's life.
-	let autoOpenedVerifiedSwitch = $state(false);
+	// Reopens the switch dialog for a staged provider without waiting for a click, so an owner who
+	// left mid-switch or is returning from the verification sign-in lands back in it. Owners only,
+	// since the switch routes are owner-only. Guarded so closing it sticks for the rest of the page's
+	// life.
+	let autoOpenedStagedSwitch = $state(false);
 	$effect(() => {
-		if (autoOpenedVerifiedSwitch || !isOwner || isBootstrapUser || localAuthConfigureOpen) return;
+		if (autoOpenedStagedSwitch || !isOwner || isBootstrapUser || localAuthConfigureOpen) return;
+		if (!stagedProvider) return;
 
-		const verified = authProviders.find((provider) => provider.staged && provider.verifiedEmail);
-		if (!verified) return;
-
-		autoOpenedVerifiedSwitch = true;
-		handleClickConfigure(verified);
+		autoOpenedStagedSwitch = true;
+		handleClickConfigure(stagedProvider);
 	});
 
 	function getDocumentationUrl(authProviderId?: string) {
@@ -333,7 +332,7 @@
 		}
 	}
 
-	async function handleDiscardStagedProvider() {
+	async function handleUnstageProvider() {
 		if (!stagedProvider) return;
 		switching = true;
 		switchError = undefined;
@@ -587,13 +586,7 @@
 
 {#snippet switchFooter(submit: () => void)}
 	{#if switchStep !== 'configure'}
-		<button
-			class="btn btn-link text-muted-content px-0"
-			disabled={switching}
-			onclick={handleDiscardStagedProvider}
-		>
-			Discard switch
-		</button>
+		<button class="btn" disabled={switching} onclick={handleUnstageProvider}> Unstage </button>
 	{/if}
 	<div class="grow"></div>
 	{#if switchStep === 'configure'}

--- a/ui/user/src/routes/identity-access/page.svelte.spec.ts
+++ b/ui/user/src/routes/identity-access/page.svelte.spec.ts
@@ -283,12 +283,6 @@ describe('Identity & Access Page', () => {
 			const renderAsOwner = (authProviders: AuthProvider[]) =>
 				renderIdentityAccessPage({ authProviders, groups: [Group.ADMIN, Group.OWNER] });
 
-			// The switch lives in the provider's own dialog now, so every case below opens it the way an
-			// owner would: from the card of the provider being switched to.
-			async function openSwitchDialog(name: string) {
-				await providerCard(name).getByRole('button').last().click();
-			}
-
 			// Deconfiguring the provider serving logins is refused by the server, since it would leave
 			// nobody able to sign in, so the card must not offer it either.
 			it('does not offer to deconfigure the provider that is serving logins', async () => {
@@ -316,11 +310,12 @@ describe('Identity & Access Page', () => {
 			it('asks for a sign-in before offering to complete the switch', async () => {
 				await renderAsOwner([localConfigured, stagedGoogle]);
 
-				await openSwitchDialog('Google');
-
 				await expect.element(page.getByText(/becomes the owner of Obot/)).toBeVisible();
 				await expect
 					.element(page.getByRole('button', { name: /^Sign in with/, exact: false }))
+					.toBeVisible();
+				await expect
+					.element(page.getByRole('button', { name: 'Unstage', exact: true }))
 					.toBeVisible();
 				// Completing the switch is not reachable until a sign-in has been recorded.
 				await expect
@@ -360,23 +355,19 @@ describe('Identity & Access Page', () => {
 
 				await renderAsOwner([googleActive, stagedLocal]);
 
-				await openSwitchDialog('Local');
-
 				await expect.element(page.getByText(/becomes the owner of Obot/)).toBeVisible();
 				await expect
 					.element(page.getByRole('button', { name: /^Sign in with/, exact: false }))
 					.toBeVisible();
 			});
 
-			// A switch still waiting on its sign-in is not one click from done, so it must not take over
-			// the page for an administrator who came here to do something else.
-			it('leaves a staged switch alone until it has been verified', async () => {
+			it('reopens a staged switch', async () => {
 				await renderAsOwner([localConfigured, stagedGoogle]);
 
 				await expect
 					.element(providerCard('Google').getByText('Staged', { exact: true }))
 					.toBeVisible();
-				await expect.element(page.getByText(/becomes the owner of Obot/)).not.toBeInTheDocument();
+				await expect.element(page.getByText(/becomes the owner of Obot/)).toBeVisible();
 			});
 
 			it('does not offer an administrator the switch', async () => {
@@ -387,6 +378,7 @@ describe('Identity & Access Page', () => {
 						providerCard('Google').getByRole('button', { name: 'Resume switch', exact: true })
 					)
 					.toBeDisabled();
+				await expect.element(page.getByText(/becomes the owner of Obot/)).not.toBeInTheDocument();
 			});
 
 			it('warns that users will not transfer before completing the switch', async () => {


### PR DESCRIPTION
An owner who closed the switch dialog before signing in had to find
"Resume switch" on the card to get back to it, and the only way out of
the switch was an easily missed link labeled "Discard switch".

Open the dialog on its own whenever a provider is staged, not only
after the sign-in has been verified, and present the exit as an
"Unstage" button.

Addresses: https://github.com/obot-platform/obot/issues/7777
