### PR TITLE
fix: skip invalid components on composite migration

### DIFF
--- a/pkg/controller/handlers/compositemigration/migration.go
+++ b/pkg/controller/handlers/compositemigration/migration.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"slices"
 	"uuid"
@@ -204,6 +205,13 @@ func (h *Handler) buildVMCP(req router.Request, entry *v1.MCPServerCatalogEntry,
 	for _, old := range legacy.CompositeConfig.ComponentServers {
 		manifest := old.Manifest.flattened()
 		id, catalogID := old.CatalogEntryID, entry.Spec.MCPCatalogName
+
+		// We have seen instances where this is an MCPServer ID, which is wrong. Skip such things.
+		if system.IsMCPServerID(id) {
+			slog.WarnContext(req.Ctx, "catalog entry ID is actually an MCP server ID, skipping component", "id", id, "entry_name", entry.Name)
+			continue
+		}
+
 		values := map[string]string{}
 		var shared *v1.MCPServer
 		if old.MCPServerID != "" {
@@ -327,6 +335,11 @@ func (h *Handler) migrateInstance(req router.Request, target v1.VMCP, parent *v1
 	configuration := map[string]string{}
 	for _, old := range parent.Spec.Manifest.CompositeConfig.ComponentServers {
 		id := old.CatalogEntryID
+		if system.IsMCPServerID(id) {
+			slog.WarnContext(req.Ctx, "invalid catalog entry ID", "id", id, "parent", parent.Name)
+			continue
+		}
+
 		if old.MCPServerID != "" {
 			id = old.MCPServerID
 		}

--- a/pkg/controller/handlers/compositemigration/migration_test.go
+++ b/pkg/controller/handlers/compositemigration/migration_test.go
@@ -26,6 +26,22 @@ func TestMigrationNamePreservesUUID(t *testing.T) {
 	require.Equal(t, "vmcp150241b93-4d53-5183-abcc-f9645245cdd7", migrationName("vmcp1", "default", "catalog"))
 }
 
+func TestBuildVMCPSkipsMCPServerCatalogEntryID(t *testing.T) {
+	entry := migrationEntry(t)
+	var legacy legacyManifest
+	require.NoError(t, json.Unmarshal(entry.Spec.LegacyCompositeManifest, &legacy)) //nolint:staticcheck // Exercise the legacy migration input.
+	legacy.CompositeConfig.ComponentServers[0].CatalogEntryID = system.MCPServerPrefix + "invalid"
+
+	target, _, err := (&Handler{}).buildVMCP(router.Request{
+		Ctx:    t.Context(),
+		Client: migrationClient(),
+	}, entry, legacy)
+	require.NoError(t, err)
+	require.Len(t, target.Spec.Manifest.Components, 1)
+	require.Equal(t, "remote", target.Spec.Manifest.Components[0].ID)
+	require.Equal(t, "remote", target.Spec.Manifest.Components[0].MCPServerCatalogEntryID)
+}
+
 func TestMigrateAll(t *testing.T) {
 	entry := migrationEntry(t)
 	parent := migrationParent(t, "connection")


### PR DESCRIPTION
We have seen invalid composite component IDs that block startup. This change ignores these invalid components during migration.