### PR TITLE
docs: correct provider availability, encryption, and MCP architecture

### DIFF
--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -42,4 +42,4 @@ Obot uses cloud KMS systems to encrypt data at rest. See [Encryption Providers](
 
 ## LLMs
 
-Obot operates with a bring-your-own-model philosophy. Multiple providers can be configured to meet organizational requirements. See [Model Providers](../configuration/model-providers.md) for details.
+Obot supports multiple model providers, available without Community registration or an Enterprise license. Configure upstream credentials and models for your organization. See [Model Providers](../configuration/model-providers.md).

--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -4,37 +4,87 @@ title: Architecture
 
 # Architecture
 
-Obot is designed to enable organizations to consume MCP servers in an enterprise setting. It consists of four core components: MCP Hosting for running servers, MCP Registry for discovery, MCP Gateway for access control, and Obot Agent for user interaction.
+Obot connects AI clients and user devices with hosted services and external providers. It provides MCP and LLM gateways, hosting, identity and access control, audit logs, and MCP and Skills registries.
 
-![Obot Platform Architecture](/img/obot-mcp-mgmt.png)
+![Obot Platform Architecture](/img/obot-platform-architecture.png)
 
 ## Key Concepts
 
-- **MCP Clients**: Tools that interact with LLMs and consume MCP servers. These include agents, desktop tools like Cursor, Claude Desktop, VS Code, and Obot Agent.
-
-- **MCP Servers**: Code that implements the MCP specification (tools, prompts, resources) for consumption by clients.
-
+- **MCP Clients**: Agents and applications that consume MCP tools, prompts, and resources, including desktop clients and Obot Agent.
 - **MCP Registry**: An index of MCP servers with metadata about how to run them and where to find them.
-
-- **MCP Gateway**: A reverse-proxy that authenticates users, ensures servers are deployed, and forwards requests. See [MCP Gateway](../concepts/mcp-gateway.md) for details.
-
-- **MCP Hosting**: Infrastructure for running MCP server containers (Docker or Kubernetes).
-
-- **LLM Gateway**: A proxy between chat clients and LLMs that enables monitoring and control of LLM communications.
+- **MCP Gateway**: The proxy inside Obot that authenticates and authorizes requests, records audit data, invokes filters, enforces their responses, and forwards allowed traffic. See [MCP Gateway](./mcp-gateway.md).
+- **MCP Hosting**: Obot manages separate Docker containers or Kubernetes workloads for hosted servers. Remote servers remain on external infrastructure. See [MCP Hosting](./mcp-hosting.md).
+- **Filters**: Hosted or remote MCP servers that expose a filter tool, or external HTTP webhooks reached through a hosted adapter. Filter code runs separately from Obot; Obot calls it and applies the result. See [Filters](../functionality/filters.md).
+- **LLM Gateway**: A proxy between chat clients and LLM providers for monitoring and controlling model communications.
 
 ## Authentication Flow
 
-All clients first authenticate with Obot via the configured identity provider. The gateway validates and authorizes the user, obtains the user's stored upstream OAuth token when the target server requires one, and proxies the request to the MCP server.
+Obot handles two separate authorizations: the user's permission for an MCP client to access Obot, and, when needed, permission for Obot to access an upstream MCP service on the user's behalf.
 
-Key security properties:
-- **Gateway**: Handles user authentication, authorization, audit logging, and webhook filters
-- **Secret isolation**: Stored OAuth credentials are applied by the gateway and are never exposed as MCP server configuration.
+### Connecting an MCP Client
+
+The user initiates a connection to an Obot MCP endpoint from their MCP client. The following flow shows a public client using OAuth with PKCE. The user signs in with the configured [auth provider](../configuration/auth-providers.md), then approves the client's access. Obot checks the user's permission to access the requested MCP server; approving the client does not grant additional server access.
+
+```mermaid
+sequenceDiagram
+    actor U as User / browser
+    participant C as MCP client
+    participant O as Obot
+    participant A as Upstream OAuth service
+    U->>C: Initiate connection to Obot MCP endpoint
+    C->>O: Connect without an access token
+    O-->>C: Authentication required and OAuth discovery
+    C->>U: Open Obot authorization page
+    U->>O: Sign in through configured auth provider
+    O->>O: Check access to the requested MCP server
+    O-->>U: Request permission for this client
+    U->>O: Approve client access
+    opt Upstream service authorization needed
+        O-->>U: Redirect to upstream sign-in
+        U->>A: Sign in and authorize Obot
+        A-->>O: Authorization code via browser
+        O->>A: Exchange code for upstream tokens
+        A-->>O: Upstream tokens
+        O->>O: Store upstream credentials
+    end
+    O-->>C: Obot authorization code via browser
+    C->>O: Exchange code with PKCE verifier
+    O-->>C: Obot access and refresh tokens
+```
+
+The upstream authorization step is skipped when it is unnecessary or an existing authorization is usable. The client receives Obot tokens; upstream credentials remain with Obot.
+
+### Authorizing MCP Requests
+
+Once connected, the client sends its Obot access token with MCP requests. Obot validates the token, identifies the user, and checks both the user's current server access and the token's permitted servers. Access checks use ownership and applicable [MCP access policies](../functionality/mcp-access-policies.md), including user and group rules.
+
+```mermaid
+sequenceDiagram
+    participant C as MCP client
+    participant O as Obot gateway
+    participant S as MCP server
+    C->>O: MCP request with Obot access token
+    O->>O: Validate token and identify user
+    O->>O: Check server access and token restrictions
+    alt Authentication or authorization fails
+        O-->>C: Authentication required or access denied
+    else Access allowed
+        opt Upstream OAuth required
+            O->>O: Retrieve or refresh stored upstream token
+        end
+        O->>S: Forward request with upstream credentials as needed
+        S-->>O: MCP response
+        O-->>C: MCP response
+    end
+```
+
+Clients using an existing Obot token or MCP API key begin with authenticated requests. Obot credentials authorize access to the gateway; upstream credentials authorize Obot's connection to the MCP service.
 
 ## Data Persistence
 
-- **Database**: Postgres for storing configuration and metadata. In production, this should be hosted independently of the Obot deployment.
+- **Database**: Postgres stores configuration, metadata, and audit data. In production, host it independently of the Obot deployment.
 - **Published Workflow Storage**: Optional S3, GCS, Azure Blob Storage, or S3-compatible storage for published workflows. If unset, Obot stores published workflows on local disk.
-- **Agent State**: Used to store files and other data for Obot Agent. Can be configured to use external volumes for persistence.
+- **Agent State**: Stores files and other data for Obot Agent. External volumes can provide persistence.
 
 ## Encryption
 

--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -38,7 +38,7 @@ Key security properties:
 
 ## Encryption
 
-Obot uses cloud KMS systems to encrypt data at rest. See [Encryption Providers](../configuration/encryption-providers/overview.md) for configuration options.
+Application-level encryption is disabled by default. When configured, an encryption provider protects selected database fields and credential values, including sensitive audit payloads; it does not encrypt entire records or automatically backfill all historical data. Local passwords are hashed independently of this setting. See [Encryption Providers](../configuration/encryption-providers/overview.md) for field coverage and existing-data considerations.
 
 ## LLMs
 

--- a/docs/docs/concepts/mcp-gateway.md
+++ b/docs/docs/concepts/mcp-gateway.md
@@ -4,30 +4,32 @@ title: MCP Gateway
 
 # MCP Gateway
 
-The MCP Gateway is a reverse-proxy passthrough that sits between MCP clients and MCP servers. It authenticates users, ensures servers are deployed, and forwards requests without modifying the MCP protocol.
+The MCP Gateway runs inside Obot and proxies traffic between MCP clients and hosted or remote MCP servers. It authenticates users, checks authorization, ensures hosted servers are running, records audit data, and invokes filters before forwarding allowed messages. Filters can reject traffic or modify it when mutation is allowed.
 
 ## Gateway Architecture
 
-The gateway is intentionally simple. It handles three things:
-
-1. **Authentication**: Validates users against the configured identity provider
-2. **Server Deployment**: Ensures the target MCP server is running (via Docker or Kubernetes)
-3. **Proxy**: Forwards requests to the MCP server and returns responses
-
 ![Gateway Architecture](/img/gateway-architecture.webp)
 
-Authorization, audit logging, and webhook filters are applied while the gateway proxies MCP traffic.
+Obot owns proxying, authentication, authorization, auditing, and filter enforcement. Hosted server code and filter code execute in separate workloads.
+
+Obot handles OAuth token exchange and refresh to access upstream MCP servers on the user's behalf. See the [authentication flow](./architecture.md#authentication-flow).
 
 ### Deployment
 
-- **Kubernetes**: Each MCP server runs in its own pod
-- **Docker**: Containers communicate via `host.docker.internal` or local IP
+- **Kubernetes**: Hosted MCP servers and hosted filters run in separate workloads from the Obot pod and from one another.
+- **Docker**: Hosted servers and filters run in separate containers alongside Obot.
+- **Remote**: Obot connects to an externally hosted MCP endpoint.
+- **STDIO runtimes**: Hosted `npx` and `uvx` servers use a transport adapter in their workload to expose HTTP. Proxy filters run through Obot, not through that adapter.
 
 ## Filters
 
-Filters allow inspection and modification of MCP traffic. They can be implemented as MCP filter servers or as HTTP webhook filters.
+Obot selects matching filters, calls them, and enforces their accept, reject, or permitted mutation responses. Filter implementations run outside the Obot process:
 
-MCP filter servers are deployed like other MCP servers in Obot, with one additional setting: the filter configuration must identify the tool name that Obot calls for filtering. Existing HTTP webhooks are automatically converted to MCP servers that run as their own deployments.
+- **Hosted MCP filters** use `npx`, `uvx`, or `containerized` runtimes and run as separate workloads managed by Obot.
+- **Remote MCP filters** expose a filter tool at an external MCP endpoint; Obot connects to that endpoint instead of deploying the filter implementation.
+- **HTTP webhook filters** use a separately hosted MCP-to-HTTP adapter that calls the external webhook endpoint. The adapter is not a sidecar attached to each target MCP server.
+
+See [Filters](../functionality/filters.md) for selectors and contracts.
 
 ## Connecting to the Gateway
 
@@ -37,7 +39,7 @@ Obot Agent connects through the gateway automatically. Users select which MCP se
 
 ### With External Clients
 
-External MCP clients (Claude Desktop, Cursor, VS Code) can connect using the gateway endpoint:
+External MCP clients can connect using the gateway endpoint:
 
 ```
 https://your-obot-instance/mcp-connect/{server-id}

--- a/docs/docs/concepts/mcp-hosting.md
+++ b/docs/docs/concepts/mcp-hosting.md
@@ -42,7 +42,7 @@ For production deployments, Obot can deploy MCP servers to Kubernetes:
 
 Obot handles OAuth 2.1 flows for MCP servers that require authentication:
 
-- OAuth credentials stored securely with encryption at rest
+- OAuth credentials encrypted at rest when an [encryption provider](../configuration/encryption-providers/overview.md) is configured; encryption is disabled by default
 - Automatic token refresh
 - Per-user credential isolation
 - Supports custom OAuth configurations

--- a/docs/docs/concepts/mcp-hosting.md
+++ b/docs/docs/concepts/mcp-hosting.md
@@ -17,7 +17,12 @@ Obot deploys and manages hosted MCP server workloads on the underlying Kubernete
 - **[Single-user](../functionality/mcp-servers.md#single-user-server)**: Each user gets their own isolated instance with separate credentials
 - **[Multi-user](../functionality/mcp-servers.md#multi-user-server)**: A shared instance serves multiple users with shared or per-user credentials
 - **[Remote](../functionality/mcp-servers.md#remote-server)**: External MCP servers accessed via HTTP, not hosted by Obot
-- **Composite**: Combines multiple servers into a single virtual server with curated tools
+
+## Virtual MCPs (vMCPs)
+
+Clients connect to new MCP endpoints through a virtual MCP (vMCP), which exposes tools from one or more catalog components through a single endpoint. A vMCP controls which tools users can access, while its backing servers use shared or per-user runtimes according to the component configuration.
+
+vMCPs replace the legacy composite server model. New catalog entries cannot use the `composite` runtime; existing standalone and composite endpoints remain available for migration compatibility.
 
 ## Deployment Environments
 

--- a/docs/docs/concepts/mcp-hosting.md
+++ b/docs/docs/concepts/mcp-hosting.md
@@ -4,7 +4,7 @@ title: MCP Hosting
 
 # MCP Hosting
 
-The MCP Hosting layer runs and manages MCP servers directly within Obot. It handles deployment, lifecycle management, and runtime isolation for MCP servers.
+Obot deploys and manages hosted MCP server workloads on the underlying Kubernetes or Docker runtime.
 
 ## Runtime Types
 
@@ -17,7 +17,7 @@ The MCP Hosting layer runs and manages MCP servers directly within Obot. It hand
 - **[Single-user](../functionality/mcp-servers.md#single-user-server)**: Each user gets their own isolated instance with separate credentials
 - **[Multi-user](../functionality/mcp-servers.md#multi-user-server)**: A shared instance serves multiple users with shared or per-user credentials
 - **[Remote](../functionality/mcp-servers.md#remote-server)**: External MCP servers accessed via HTTP, not hosted by Obot
-- **[Composite](../functionality/mcp-servers.md#composite-server)**: Combines multiple servers into a single virtual server with curated tools
+- **Composite**: Combines multiple servers into a single virtual server with curated tools
 
 ## Deployment Environments
 

--- a/docs/docs/configuration/auth-providers.md
+++ b/docs/docs/configuration/auth-providers.md
@@ -1,8 +1,7 @@
 # Auth Providers
 
 Authentication providers allow your Obot installation to authenticate users with the identity provider of your choice.
-Administrators must configure at least one authentication provider before users can log in.
-Multiple providers can be configured and available for login at the same time.
+Administrators must configure an authentication provider before users can log in. Only one authentication provider can be configured at a time.
 
 :::note
 In order for authentication to be enabled, the Obot server must be run with the environment variable set:
@@ -63,6 +62,13 @@ You can:
 
 ## Available Auth Providers
 
+| Providers | Availability |
+|-----------|--------------|
+| Local, GitHub, Google | Included in the default Obot edition without registration |
+| Entra, Okta, JumpCloud, Auth0 | Require free Community registration or an Enterprise license |
+
+To register for Community or configure an Enterprise license, use the **License** page in the admin UI. See [Obot Editions](../enterprise/overview.md).
+
 Obot supports the built-in [Local](#local) provider, as well as the following providers that authenticate against an external identity provider using OAuth2. For the OAuth2 providers, you will need to follow the instructions in the auth provider for setting up a new app before getting started. You can get the callback URL from the Obot Admin -> Auth Providers -> \<Auth Provider> -> Configure page. The configuration form will also have fields for the data required.
 
 ### Local
@@ -95,7 +101,7 @@ Follow the instructions [here](https://developers.google.com/identity/protocols/
 
 You can view the source code for Google provider in this [repo](https://github.com/obot-platform/tools).
 
-### Entra (Enterprise Only)
+### Entra
 
 Within the [Microsoft Entra admin center](https://entra.microsoft.com), go to App registrations and click New registration.
 
@@ -159,7 +165,7 @@ You can restrict login access to specific Entra users and groups by taking the f
 
 For more details, [see Entra's docs](https://learn.microsoft.com/en-us/entra/identity-platform/howto-restrict-your-app-to-a-set-of-users).
 
-### Okta (Enterprise Only)
+### Okta
 
 :::note
 Only the org-level authorization server is supported (no custom authorization servers).
@@ -191,7 +197,7 @@ You can restrict login access to specific Okta users and groups by taking the fo
 4. Select `Assign` on groups you want to allow Obot access to
 5. Once you've made your selections, click `Done`
 
-### JumpCloud (Enterprise Only)
+### JumpCloud
 
 Create a **Custom OIDC App** in the [JumpCloud Admin Portal](https://console.jumpcloud.com/). When configuring the app:
 
@@ -242,7 +248,7 @@ You can now return to Obot and finish configuring JumpCloud. Use the table below
 The JumpCloud user must resolve to an active, non-suspended JumpCloud system user. Suspended or inactive users will be blocked from logging in.
 :::
 
-### Auth0 (Enterprise Only)
+### Auth0
 
 Create a **Regular Web Application** in the [Auth0 Dashboard](https://manage.auth0.com) by navigating to Applications > Applications > Create Application.
 
@@ -356,7 +362,7 @@ Ensure the following environment variable is set in your Obot installation:
 
 ![screenshot of setup entra](/img/setup_entra.png)
 
-4. Follow the documentation to create and configure the Entra application from [Entra Instructions](#entra-enterprise-only).
+4. Follow the documentation to create and configure the Entra application from [Entra Instructions](#entra).
 5. Enter the required details:
 - Client ID
 - Client Secret

--- a/docs/docs/configuration/auth-providers.md
+++ b/docs/docs/configuration/auth-providers.md
@@ -73,6 +73,8 @@ Obot supports the built-in [Local](#local) provider, as well as the following pr
 
 ### Local
 
+Local passwords are stored as salted Argon2id hashes, independently of optional [database field encryption](./encryption-providers/overview.md#local-passwords).
+
 The Local provider authenticates users with an email address and password stored in Obot's own database. It requires no external identity provider, which makes it a good fit for evaluations, air-gapped installations, and small deployments.
 
 Passwords are hashed with [argon2id](https://en.wikipedia.org/wiki/Argon2) and are never stored, logged, or returned by the API.

--- a/docs/docs/configuration/encryption-providers/custom-provider.md
+++ b/docs/docs/configuration/encryption-providers/custom-provider.md
@@ -32,9 +32,54 @@ Kj8fH2lP9mQ4nR6tV8xZ0bC3dE5gF7hI9jK1lM3nO5p=
 
 > **Security Warning**: Keep this key secret and secure. Anyone with access to this key can decrypt your data. Store it in a secure location such as a password manager or secrets management system.
 
-### Obot environment variables
+### 2. Configure Your Deployment
 
-Make sure the following environment variables are set on Obot when you run it:
+#### Helm
 
-- `OBOT_SERVER_ENCRYPTION_PROVIDER="custom"`
-- `OBOT_SERVER_ENCRYPTION_KEY="<your-base64-key>"`
+Set the provider under `config` and the key under `secret` in your values file:
+
+```yaml
+config:
+  OBOT_SERVER_ENCRYPTION_PROVIDER: custom
+secret:
+  OBOT_SERVER_ENCRYPTION_KEY: "<your-base64-key>"
+```
+
+The Helm chart generates an AES-GCM encryption configuration covering the [supported resources](./overview.md#encrypted-resources-and-fields), mounts it into Obot, and sets the configuration-file path.
+
+#### Standalone Server or Docker
+
+Create an `EncryptionConfiguration` file with your generated key:
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - credentials.obot.obot.ai
+      - users.obot.obot.ai
+      - identities.obot.obot.ai
+      - mcpoauthtokens.obot.obot.ai
+      - mcpoauthpendingstates.obot.obot.ai
+      - mcpauditlogs.obot.obot.ai
+      - llmauditlogs.obot.obot.ai
+      - policyviolations.obot.obot.ai
+      - properties.obot.obot.ai
+    providers:
+      - aesgcm:
+          keys:
+            - name: key0
+              secret: "<your-base64-key>"
+      - identity: {}
+```
+
+Make the file available to the Obot process, for example by mounting it read-only at `/config/encryption.yaml` in Docker. Restrict access because the file contains your encryption key. Set:
+
+```text
+OBOT_SERVER_ENCRYPTION_PROVIDER=custom
+OBOT_SERVER_ENCRYPTION_CONFIG_FILE=/config/encryption.yaml
+```
+
+`OBOT_SERVER_ENCRYPTION_KEY` alone is insufficient for a standalone server; the chart performs the file-generation step.
+
+For existing data, see [enabling encryption on an existing installation](./overview.md#enabling-encryption-on-an-existing-installation).

--- a/docs/docs/configuration/encryption-providers/custom-provider.md
+++ b/docs/docs/configuration/encryption-providers/custom-provider.md
@@ -36,7 +36,7 @@ Kj8fH2lP9mQ4nR6tV8xZ0bC3dE5gF7hI9jK1lM3nO5p=
 
 #### Helm
 
-Set the provider under `config` and the key under `secret` in your values file:
+Set the provider under `config` and the key you generated in step 1 under `secret` in your values file:
 
 ```yaml
 config:
@@ -45,7 +45,7 @@ secret:
   OBOT_SERVER_ENCRYPTION_KEY: "<your-base64-key>"
 ```
 
-The Helm chart generates an AES-GCM encryption configuration covering the [supported resources](./overview.md#encrypted-resources-and-fields), mounts it into Obot, and sets the configuration-file path.
+The Helm chart uses this key to enable encryption for the [supported resources](./overview.md#encrypted-resources-and-fields).
 
 #### Standalone Server or Docker
 

--- a/docs/docs/configuration/encryption-providers/overview.md
+++ b/docs/docs/configuration/encryption-providers/overview.md
@@ -1,89 +1,46 @@
 # Overview
 
-Obot supports encrypting sensitive data at rest in the database using industry-standard encryption providers. When enabled, encryption protects user data, credentials, OAuth tokens, session information, and other sensitive fields using external Key Management Services (KMS).
+Obot can encrypt selected sensitive fields in its database and credential store. **Application-level encryption is disabled by default** (`OBOT_SERVER_ENCRYPTION_PROVIDER=none`). Configure a provider to enable it. This protects the fields listed below, not entire records, database files, backups, or exported audit logs.
 
 ## Supported Encryption Providers
-
-Obot supports the following encryption providers:
 
 1. [AWS KMS](./aws-kms.md)
 2. [Azure Key Vault](./azure-key-vault.md)
 3. [Google Cloud KMS](./google-cloud-kms.md)
-4. [Custom](./custom-provider.md)
+4. [Custom](./custom-provider.md), including a local AES-GCM key
 
 ## How Encryption Works
 
-Obot uses the Kubernetes EncryptionConfiguration format to encrypt data at rest. The encryption provider:
+Obot uses the Kubernetes `EncryptionConfiguration` format. Each configured resource has a transformer that encrypts selected fields before storage and decrypts them on retrieval. Cloud KMS providers use a local provider process over a Unix socket; a custom AES-GCM configuration uses the supplied key. Encrypted field values are base64-encoded for storage.
 
-1. Receives data to encrypt via a Unix socket connection
-2. Encrypts the data using the configured KMS provider
-3. Returns the encrypted data to be stored in the database
-4. On retrieval, decrypts the data before returning it to the application
+The built-in cloud configurations include the resources below. A custom configuration must include the corresponding resource names to protect those fields.
 
-All encrypted string fields are base64-encoded after encryption for safe storage.
+## Encrypted Resources and Fields
 
-## Encrypted Resources
+These names identify encryption transformers; they do not mean every field in the resource is encrypted. IDs, timestamps, and other metadata can remain readable.
 
-When you enable an encryption provider, the following resource types are automatically encrypted:
+| Resource | Selected fields protected when configured |
+|----------|-------------------------------------------|
+| `credentials.obot.obot.ai` | Serialized credential secret values, such as API keys and upstream access tokens; credential names and context metadata are not included |
+| `users.obot.obot.ai` | `username`, `email`, `displayName`, `iconURL`, `originalEmail`, `originalUsername`; local-auth user `email` also uses this transformer |
+| `identities.obot.obot.ai` | `providerUsername`, `email`, `providerUserID`, `providerGroupLookupID`, `iconURL` |
+| `mcpoauthtokens.obot.obot.ai` | `accessToken`, `refreshToken`, `clientID`, `clientSecret` |
+| `mcpoauthpendingstates.obot.obot.ai` | `state`, `verifier`, `clientID`, `clientSecret` |
+| `mcpauditlogs.obot.obot.ai` | MCP request and response bodies and headers, including mutated requests and original responses; local-agent details listed below |
+| `llmauditlogs.obot.obot.ai` | Request and response headers and bodies, including `policyModifiedRequestBody` |
+| `policyviolations.obot.obot.ai` | `blockedContent` |
+| `properties.obot.obot.ai` | Stored property `value` |
 
-| Resource Type | Description |
-|---------------|-------------|
-| `credentials` | Credential store data |
-| `users.obot.obot.ai` | User account information |
-| `identities.obot.obot.ai` | Identity provider data |
-| `mcpoauthtokens.obot.obot.ai` | MCP OAuth tokens |
-| `mcpoauthpendingstates.obot.obot.ai` | MCP OAuth pending authorization states |
-| `mcpauditlogs.obot.obot.ai` | MCP audit log data |
-| `sessioncookies.obot.obot.ai` | Session cookie data |
+### MCP and Local-Agent Audit Details
 
-## Complete List of Encrypted Fields
+For MCP traffic, the audit transformer encrypts `requestBody`, `mutatedRequestBody`, `responseBody`, `originalResponseBody`, `requestHeaders`, and `responseHeaders`.
 
-### User Data (`users.obot.obot.ai`)
-All personal user information is encrypted:
-- `username` - User's username
-- `email` - User's email address
-- `displayName` - User's display name
-- `iconURL` - User's profile icon URL
-- `originalEmail` - Original email for a deleted user from identity provider
-- `originalUsername` - Original username for a deleted user from identity provider
+For local-agent tool calls in the same audit store, it encrypts the outcome error, hostname, local username, reported user email, working directory, Git root, Git remotes, Git branch, transcript path, request body, response body, and raw event. Other audit metadata, such as timestamps and tool names, is outside this field-level protection.
 
-### Identity Data (`identities.obot.obot.ai`)
-Identity provider information is encrypted:
-- `providerUsername` - Username from identity provider
-- `email` - Email from identity provider
-- `providerUserID` - User ID from identity provider
-- `iconURL` - Icon URL from identity provider
+### Local Passwords
 
-### MCP OAuth Tokens (`mcpoauthtokens.obot.obot.ai`)
-All OAuth-related secrets are encrypted:
-- `accessToken` - OAuth access token
-- `refreshToken` - OAuth refresh token
-- `clientID` - OAuth client ID
-- `clientSecret` - OAuth client secret
+Local-auth passwords are stored as salted Argon2id hashes regardless of whether an encryption provider is configured. The password hash is not reversibly encrypted. This differs from upstream passwords stored as credential secret values, which must be recoverable for use.
 
-### MCP OAuth Pending States (`mcpoauthpendingstates.obot.obot.ai`)
-Pending OAuth authorization state data is encrypted:
-- `state` - OAuth state parameter
-- `verifier` - PKCE verifier
-- `clientID` - OAuth client ID
-- `clientSecret` - OAuth client secret
+## Enabling Encryption on an Existing Installation
 
-### Session Cookies (`sessioncookies.obot.obot.ai`)
-Session authentication data is encrypted:
-- `cookie` - Session cookie value
-
-### MCP Audit Logs (`mcpauditlogs.obot.obot.ai`)
-Complete request/response data in audit logs is encrypted:
-- `requestBody` - HTTP request body (JSON)
-- `responseBody` - HTTP response body (JSON)
-- `requestHeaders` - HTTP request headers (JSON)
-- `responseHeaders` - HTTP response headers (JSON)
-
-### Credentials (`credentials`)
-All credential data stored via the credential store system (SQLite or PostgreSQL backend) is encrypted.
-
-The credential store is configured with the encryption provider and automatically encrypts all stored credentials, including:
-- API keys
-- Access tokens
-- Passwords
-- Any other sensitive credential or configuration data
+Enabling encryption does not automatically encrypt all existing data. Existing installations may require a separate migration to protect previously stored data.

--- a/docs/docs/configuration/model-providers.md
+++ b/docs/docs/configuration/model-providers.md
@@ -6,21 +6,16 @@ The Model Providers page allows administrators to configure and manage various A
 
 Obot supports a variety of model providers, including:
 
-**Community**
 - OpenAI
 - Anthropic
 - [Generic Responses Compatible Provider](#generic-responses-compatible-provider)
-
-**Enterprise**
-- [Azure OpenAI / Microsoft Foundry](#azure-enterprise-only)
-- [Amazon Bedrock](#amazon-bedrock-enterprise-only)
+- [Azure OpenAI / Microsoft Foundry](#azure)
+- [Amazon Bedrock](#amazon-bedrock)
 - Google Vertex (Gemini models)
 
 The UI will indicate whether each provider has been configured. If a provider is configured you will have the ability to modify or deconfigure it.
 
-:::note
-Our Enterprise release adds support for additional Enterprise-grade model providers. [See here](../enterprise/overview.md) for more details.
-:::
+All listed model providers are available in the default Obot edition without Community registration or an Enterprise license. You still need credentials and access to the upstream model service.
 
 #### Configuring and enabling a provider
 
@@ -63,7 +58,7 @@ Setting a default model here does not automatically grant users access to it. Us
 
 ### Instructions for configuring specific providers
 
-#### Azure (Enterprise only)
+#### Azure
 
 Obot supports two Azure providers, each with a different authentication method. These are compatible with both Azure OpenAI deployments and Foundry deployments.
 
@@ -124,7 +119,7 @@ Official references:
 - [Claude Code on Microsoft Foundry](https://code.claude.com/docs/en/microsoft-foundry#azure-rbac-configuration) — Claude Code RBAC requirements
 - [Assign Azure roles using the Azure portal](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) — portal instructions and role-assignment permissions
 
-#### Amazon Bedrock (Enterprise only)
+#### Amazon Bedrock
 
 Obot supports two Amazon Bedrock providers, each with a different authentication method.
 

--- a/docs/docs/enterprise/overview.md
+++ b/docs/docs/enterprise/overview.md
@@ -10,7 +10,7 @@ what usage limits apply.
 
 ## Obot
 
-The default edition. It supports up to 100 users and 100 devices and does not include enterprise-grade auth providers like Entra, Okta, JumpCloud, or Auth0.
+The default edition supports up to 100 users and 100 devices. It includes Local, GitHub, and Google authentication and all [model providers](../configuration/model-providers.md), including Azure OpenAI, Amazon Bedrock, and Google Vertex, without registration. Entra, Okta, JumpCloud, and Auth0 authentication require Community registration or an Enterprise license.
 
 ## Obot Community
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -16,10 +16,7 @@ Currently, users must log in at least once before roles can be assigned. To pre-
 
 ### What are the differences between the open source and enterprise versions of Obot?
 
-Both use the same core codebase, but the enterprise version includes additional closed-source plugins for:
-
-- enterprise authentication (Entra, Okta) 
-- model providers (Azure OpenAI, Amazon Bedrock)
+All editions use the same container image. The default edition includes all model providers without registration, plus Local, GitHub, and Google authentication. Entra, Okta, JumpCloud, and Auth0 authentication require free Community registration or an Enterprise license. Enterprise adds unlimited users and devices and enterprise support. See [Obot Editions](./enterprise/overview.md).
 
 ## Integration & Troubleshooting
 

--- a/docs/docs/functionality/filters.md
+++ b/docs/docs/functionality/filters.md
@@ -8,19 +8,22 @@ Filters are a powerful mechanism for inspecting and controlling tool calls and t
 
 Filters can be implemented in two ways:
 
-- **MCP filter servers**: MCP servers that expose a filter tool. Obot deploys and calls the configured tool when matching MCP traffic is processed.
-- **HTTP webhook filters**: HTTP endpoints that receive MCP messages from the gateway.
+- **MCP filter servers**: Hosted or remote MCP servers that expose a filter tool. Hosted filters run as separate Docker containers or Kubernetes workloads. Remote filters run at an external MCP endpoint. Obot calls the configured tool when matching MCP traffic is processed.
+- **HTTP webhook filters**: HTTP endpoints that receive MCP messages and return a decision to allow or reject them.
 
 When you configure a filter, you can narrow when it runs using selectors that target particular tool calls or MCP (Model Context Protocol) tool functions.
+
+Filter implementations run outside the Obot process. Obot handles proxying, calls the filter, and enforces its response; the target MCP server does not host or enforce the filter. See the [gateway architecture](../concepts/mcp-gateway.md#gateway-architecture).
 
 ## How Filters Work
 
 1. **MCP Request Interception**: When a request is made to an MCP server, the gateway intercepts it and sends the details to your configured filter
-2. **Payload Inspection**: Your filter receives the payload and can perform any custom logic or validation
+2. **Payload Inspection**: The separate filter server or webhook receives the payload and performs its validation
 3. **Response Decision**: Your filter returns one of the following decisions:
    - Accept: Allow the tool call to proceed
    - Reject: Block execution and return an error to the user
    - Mutate: Return a modified MCP message, if mutation is allowed for the filter
+4. **Enforcement**: Obot applies the filter response before forwarding the request or returning the response to the client.
 
 ## Gateway Configuration
 
@@ -36,6 +39,8 @@ All filter types support selectors to control when your filter is triggered:
 ## MCP Filter Servers
 
 MCP filters can be deployed as MCP servers. Their deployment configuration is similar to other MCP servers in Obot: choose a runtime such as `remote`, `containerized`, `npx`, or `uvx`, then provide the runtime-specific configuration and any required environment variables.
+
+With `remote`, Obot connects to the configured endpoint and does not deploy the filter implementation. The other runtimes deploy a separate workload; a hosted filter does not run inside Obot or inside the target MCP server.
 
 The additional requirement for an MCP filter server is a filter tool name. Obot needs this value so it knows which tool to call when the filter runs.
 
@@ -64,25 +69,23 @@ The default built-in filter catalog is maintained in the [obot-platform/system-m
 
 ## HTTP-based Filters
 
-You can also use HTTP-based webhooks for filtering. In this case, the HTTP server would have to be deployed outside of Obot. You can then provide the following information to Obot:
+Deploy a webhook service that accepts MCP messages over HTTP. Configure its URL in Obot, which sends matching messages to the webhook and uses its response to allow or reject them.
+
+Provide the following information to Obot:
 
 ### Required Configuration
 
 - **Name**: A descriptive name for your filter
-- **URL**: The webhook endpoint URL where the gateway will send payloads
+- **URL**: The webhook endpoint that receives MCP messages
 - **Secret** (optional): A shared secret with the webhook receiver for payload signature verification
 
 ### Security with Secrets
 
-If you configure a secret, the gateway will sign each payload using this shared secret. This allows both sides (the gateway and your webhook service) to verify the authenticity of the communication:
-
-- The gateway signs outgoing payloads with the secret
-- Your webhook service can verify the signature to ensure the payload is legitimate
-- This prevents unauthorized or tampered requests from being processed
+Configure the same shared secret in Obot and your webhook service. When a secret is configured, webhook requests include a signature in the `X-Obot-Signature-256` header. Your service should verify this signature before processing the request.
 
 ### Webhook Receiver
 
-To implement a filter, you need to create a web service that can handle POST requests from the gateway.
+Your webhook endpoint must accept HTTP POST requests containing MCP messages.
 
 ### Payload Structure
 
@@ -124,7 +127,7 @@ PORT=8000 WEBHOOK_SECRET=somethingsecret uv run simple_webhook_example.py
 
 The filter target url will be `http://<host>:8000/webhook`
 
-The Webhook Secret will also need to be configured in the gateway.
+Set the Webhook Secret in Obot to the same value as `WEBHOOK_SECRET` in this example.
 
 ```python
 #!/usr/bin/env python3
@@ -154,7 +157,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-
 def validate_signature(body: bytes, signature: str, secret: str) -> bool:
     """
     Validate HMAC-SHA256 signature for webhook security.
@@ -181,9 +183,6 @@ def validate_signature(body: bytes, signature: str, secret: str) -> bool:
     # Secure comparison
     return hmac.compare_digest(signature, expected)
 
-
-
-
 class WebhookMessage(BaseModel):
     """JSON-RPC message structure for webhook payloads."""
     jsonrpc: str
@@ -193,14 +192,12 @@ class WebhookMessage(BaseModel):
     result: Optional[Dict[str, Any]] = None
     error: Optional[Dict[str, Any]] = None
 
-
 # Initialize app
 app = FastAPI(title="Simple Webhook with Filtering")
 
 # Configuration
 SECRET = os.getenv("WEBHOOK_SECRET", "test_secret")
 PORT = int(os.getenv("PORT", "8000"))
-
 
 @app.post("/webhook")
 async def webhook_endpoint(
@@ -240,7 +237,6 @@ async def webhook_endpoint(
         logger.error(f"Error processing webhook: {e}")
         raise HTTPException(status_code=400, detail=f"Invalid payload: {str(e)}")
 
-
 def check_message_for_threats(message: WebhookMessage) -> None:
     """
     Check DuckDuckGo search requests for unsafe query content.
@@ -275,7 +271,6 @@ def check_message_for_threats(message: WebhookMessage) -> None:
                 logger.info(f"✅ Safe search query: '{query}'")
     
     logger.debug(f"✅ Clean message: {message.method}")
-
 
 def is_unsafe_search_query(query: str) -> bool:
     """
@@ -316,12 +311,10 @@ def is_unsafe_search_query(query: str) -> bool:
     
     return False
 
-
 @app.get("/health")
 async def health_check():
     """Simple health check endpoint."""
     return {"status": "healthy", "filter": "ready"}
-
 
 @app.get("/")
 async def root():
@@ -335,7 +328,6 @@ async def root():
         },
         "note": "Send JSON-RPC messages to /webhook with proper signatures. Suspicious content will result in 403 responses."
     }
-
 
 def main():
     """Start the webhook server."""
@@ -356,7 +348,6 @@ def main():
         port=PORT,
         log_level="info"
     )
-
 
 if __name__ == "__main__":
     main()

--- a/docs/docs/functionality/llm-gateway.md
+++ b/docs/docs/functionality/llm-gateway.md
@@ -249,7 +249,7 @@ The Azure models endpoint uses Azure's OpenAI-compatible Models API and returns 
 An administrator configures one of these providers under **Model Providers**:
 
 - **Azure** requires the Azure resource endpoint (for example, `https://my-resource.services.ai.azure.com`) and an API key.
-- **Azure Entra** requires the Azure resource endpoint plus tenant ID, client ID, and client secret for a service principal. Obot requests tokens for the `https://ai.azure.com/.default` scope. Assign the service principal **Cognitive Services User** or **Foundry User** (formerly Azure AI User) on the specific Foundry resource. **Cognitive Services OpenAI User** may allow OpenAI requests but does not provide all permissions needed for Anthropic requests. See [Azure provider configuration](../configuration/model-providers.md#azure-enterprise-only) for portal instructions and official references.
+- **Azure Entra** requires the Azure resource endpoint plus tenant ID, client ID, and client secret for a service principal. Obot requests tokens for the `https://ai.azure.com/.default` scope. Assign the service principal **Cognitive Services User** or **Foundry User** (formerly Azure AI User) on the specific Foundry resource. **Cognitive Services OpenAI User** may allow OpenAI requests but does not provide all permissions needed for Anthropic requests. See [Azure provider configuration](../configuration/model-providers.md#azure) for portal instructions and official references.
 
 Configure each model's target model as its Azure deployment name. The provider's model metadata must expose either `AnthropicMessages` or `OpenAIResponses` as the dialect. The Models page groups models by that dialect, even if deployment names are arbitrary or misleading.
 

--- a/docs/docs/installation/cli-setup.md
+++ b/docs/docs/installation/cli-setup.md
@@ -129,7 +129,7 @@ obot setup status --json
 
 ### `auth_unavailable`
 
-The Obot server did not report exactly one usable configured authentication provider. Configure an auth provider first, or use an interactive setup flow if multiple providers are configured and you need to choose one.
+The Obot server did not report exactly one usable configured authentication provider. Configure an auth provider first.
 
 ### `server_unreachable`
 

--- a/docs/docs/installation/enabling-authentication.md
+++ b/docs/docs/installation/enabling-authentication.md
@@ -3,7 +3,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This guide covers the step-by-step process to enable and configure authentication in Obot. Authentication must be setup to use one of the external providers in order to function properly. The bootstrap user is not implemented to operate as a regular user.
+This guide covers the step-by-step process to enable and configure authentication in Obot. Configure either the built-in Local provider or an external identity provider to enable user login. The bootstrap user is not implemented to operate as a regular user.
 
 :::note
 If any MCP servers were created with authentication disabled, they will be deleted when authentication is enabled.
@@ -64,7 +64,7 @@ Start (or restart) your Obot deployment with the new environment variables. Navi
 ## Step 3: Configure Authentication Provider
 
 1. Go to **Auth Providers** under the **User Management** section in the left navigation
-2. Click **Configure** on your desired provider (GitHub, Google, Entra, Okta)
+2. Click **Configure** on your desired provider. Local, GitHub, and Google are available without registration; Entra, Okta, JumpCloud, and Auth0 require Community registration or an Enterprise license.
 3. Follow the provider-specific configuration steps
 
 For detailed provider configuration, see the [Auth Providers](../configuration/auth-providers.md) documentation.

--- a/docs/versioned_docs/version-v0.24.0/configuration/auth-providers.md
+++ b/docs/versioned_docs/version-v0.24.0/configuration/auth-providers.md
@@ -2,7 +2,6 @@
 
 Authentication providers allow your Obot installation to authenticate users with the identity provider of your choice.
 Administrators must configure at least one authentication provider before users can log in.
-Multiple providers can be configured and available for login at the same time.
 
 :::note
 In order for authentication to be enabled, the Obot server must be run with the environment variable set:

--- a/docs/versioned_docs/version-v0.24.0/installation/cli-setup.md
+++ b/docs/versioned_docs/version-v0.24.0/installation/cli-setup.md
@@ -129,7 +129,7 @@ obot setup status --json
 
 ### `auth_unavailable`
 
-The Obot server did not report exactly one usable configured authentication provider. Configure an auth provider first, or use an interactive setup flow if multiple providers are configured and you need to choose one.
+The Obot server did not report exactly one usable configured authentication provider. Configure an auth provider first.
 
 ### `server_unreachable`
 

--- a/docs/versioned_docs/version-v0.25.0/concepts/architecture.md
+++ b/docs/versioned_docs/version-v0.25.0/concepts/architecture.md
@@ -4,42 +4,87 @@ title: Architecture
 
 # Architecture
 
-Obot is designed to enable organizations to consume MCP servers in an enterprise setting. It consists of four core components: MCP Hosting for running servers, MCP Registry for discovery, MCP Gateway for access control, and Obot Agent for user interaction.
+Obot connects AI clients and user devices with hosted services and external providers. It provides MCP and LLM gateways, hosting, identity and access control, audit logs, and MCP and Skills registries.
 
-![Obot Platform Architecture](/img/obot-mcp-mgmt.png)
+![Obot Platform Architecture](/img/obot-platform-architecture.png)
 
 ## Key Concepts
 
-- **MCP Clients**: Tools that interact with LLMs and consume MCP servers. These include agents, desktop tools like Cursor, Claude Desktop, VS Code, and Obot Agent.
-
-- **MCP Servers**: Code that implements the MCP specification (tools, prompts, resources) for consumption by clients.
-
+- **MCP Clients**: Agents and applications that consume MCP tools, prompts, and resources, including desktop clients and Obot Agent.
 - **MCP Registry**: An index of MCP servers with metadata about how to run them and where to find them.
-
-- **MCP Gateway**: A reverse-proxy that authenticates users, ensures servers are deployed, and forwards requests. See [MCP Gateway](../concepts/mcp-gateway.md) for details.
-
-- **MCP Server Shim**: A protocol-aware sidecar that runs alongside each MCP server, handling authorization, audit logging, webhook filters, and token exchange.
-
-- **MCP Hosting**: Infrastructure for running MCP server containers (Docker or Kubernetes).
-
-- **LLM Gateway**: A proxy between chat clients and LLMs that enables monitoring and control of LLM communications.
+- **MCP Gateway**: The proxy inside Obot that authenticates and authorizes requests, records audit data, invokes filters, enforces their responses, and forwards allowed traffic. See [MCP Gateway](./mcp-gateway.md).
+- **MCP Hosting**: Obot manages separate Docker containers or Kubernetes workloads for hosted servers. Remote servers remain on external infrastructure. See [MCP Hosting](./mcp-hosting.md).
+- **Filters**: Hosted or remote MCP servers that expose a filter tool, or external HTTP webhooks reached through a hosted adapter. Filter code runs separately from Obot; Obot calls it and applies the result. See [Filters](../functionality/filters.md).
+- **LLM Gateway**: A proxy between chat clients and LLM providers for monitoring and controlling model communications.
 
 ## Authentication Flow
 
-All clients first authenticate with Obot via the configured identity provider. The gateway validates the user and proxies the request to the MCP Server Shim. The shim then handles authorization checks and, if the MCP server requires it, performs OAuth token exchange (RFC 8693) to obtain a third-party access token.
+Obot handles two separate authorizations: the user's permission for an MCP client to access Obot, and, when needed, permission for Obot to access an upstream MCP service on the user's behalf.
 
-![Authentication and Token Exchange Flow](/img/token-exchange-flow.webp)
+### Connecting an MCP Client
 
-Key security properties:
-- **Gateway**: Handles user authentication only
-- **MCP Server Shim**: Handles authorization, audit logging, and token exchange
-- **Secret isolation**: Credentials for token exchange live in the MCP Server Shim, never exposed to the MCP server. MCP server configuration is never exposed to the MCP Server Shim.
+The user initiates a connection to an Obot MCP endpoint from their MCP client. The following flow shows a public client using OAuth with PKCE. The user signs in with the configured [auth provider](../configuration/auth-providers.md), then approves the client's access. Obot checks the user's permission to access the requested MCP server; approving the client does not grant additional server access.
+
+```mermaid
+sequenceDiagram
+    actor U as User / browser
+    participant C as MCP client
+    participant O as Obot
+    participant A as Upstream OAuth service
+    U->>C: Initiate connection to Obot MCP endpoint
+    C->>O: Connect without an access token
+    O-->>C: Authentication required and OAuth discovery
+    C->>U: Open Obot authorization page
+    U->>O: Sign in through configured auth provider
+    O->>O: Check access to the requested MCP server
+    O-->>U: Request permission for this client
+    U->>O: Approve client access
+    opt Upstream service authorization needed
+        O-->>U: Redirect to upstream sign-in
+        U->>A: Sign in and authorize Obot
+        A-->>O: Authorization code via browser
+        O->>A: Exchange code for upstream tokens
+        A-->>O: Upstream tokens
+        O->>O: Store upstream credentials
+    end
+    O-->>C: Obot authorization code via browser
+    C->>O: Exchange code with PKCE verifier
+    O-->>C: Obot access and refresh tokens
+```
+
+The upstream authorization step is skipped when it is unnecessary or an existing authorization is usable. The client receives Obot tokens; upstream credentials remain with Obot.
+
+### Authorizing MCP Requests
+
+Once connected, the client sends its Obot access token with MCP requests. Obot validates the token, identifies the user, and checks both the user's current server access and the token's permitted servers. Access checks use ownership and applicable [MCP access policies](../functionality/mcp-access-policies.md), including user and group rules.
+
+```mermaid
+sequenceDiagram
+    participant C as MCP client
+    participant O as Obot gateway
+    participant S as MCP server
+    C->>O: MCP request with Obot access token
+    O->>O: Validate token and identify user
+    O->>O: Check server access and token restrictions
+    alt Authentication or authorization fails
+        O-->>C: Authentication required or access denied
+    else Access allowed
+        opt Upstream OAuth required
+            O->>O: Retrieve or refresh stored upstream token
+        end
+        O->>S: Forward request with upstream credentials as needed
+        S-->>O: MCP response
+        O-->>C: MCP response
+    end
+```
+
+Clients using an existing Obot token or MCP API key begin with authenticated requests. Obot credentials authorize access to the gateway; upstream credentials authorize Obot's connection to the MCP service.
 
 ## Data Persistence
 
-- **Database**: Postgres for storing configuration and metadata. In production, this should be hosted independently of the Obot deployment.
+- **Database**: Postgres stores configuration, metadata, and audit data. In production, host it independently of the Obot deployment.
 - **Published Workflow Storage**: Optional S3, GCS, Azure Blob Storage, or S3-compatible storage for published workflows. If unset, Obot stores published workflows on local disk.
-- **Agent State**: Used to store files and other data for Obot Agent. Can be configured to use external volumes for persistence.
+- **Agent State**: Stores files and other data for Obot Agent. External volumes can provide persistence.
 
 ## Encryption
 

--- a/docs/versioned_docs/version-v0.25.0/concepts/architecture.md
+++ b/docs/versioned_docs/version-v0.25.0/concepts/architecture.md
@@ -43,7 +43,7 @@ Key security properties:
 
 ## Encryption
 
-Obot uses cloud KMS systems to encrypt data at rest. See [Encryption Providers](../configuration/encryption-providers/overview.md) for configuration options.
+Application-level encryption is disabled by default. When configured, an encryption provider protects selected database fields and credential values, including sensitive audit payloads; it does not encrypt entire records or automatically backfill all historical data. Local passwords are hashed independently of this setting. See [Encryption Providers](../configuration/encryption-providers/overview.md) for field coverage and existing-data considerations.
 
 ## LLMs
 

--- a/docs/versioned_docs/version-v0.25.0/concepts/architecture.md
+++ b/docs/versioned_docs/version-v0.25.0/concepts/architecture.md
@@ -47,4 +47,4 @@ Obot uses cloud KMS systems to encrypt data at rest. See [Encryption Providers](
 
 ## LLMs
 
-Obot operates with a bring-your-own-model philosophy. Multiple providers can be configured to meet organizational requirements. See [Model Providers](../configuration/model-providers.md) for details.
+Obot supports multiple model providers, available without Community registration or an Enterprise license. Configure upstream credentials and models for your organization. See [Model Providers](../configuration/model-providers.md).

--- a/docs/versioned_docs/version-v0.25.0/concepts/mcp-gateway.md
+++ b/docs/versioned_docs/version-v0.25.0/concepts/mcp-gateway.md
@@ -4,52 +4,32 @@ title: MCP Gateway
 
 # MCP Gateway
 
-The MCP Gateway is a reverse-proxy passthrough that sits between MCP clients and MCP servers. It authenticates users, ensures servers are deployed, and forwards requests without modifying the MCP protocol.
+The MCP Gateway runs inside Obot and proxies traffic between MCP clients and hosted or remote MCP servers. It authenticates users, checks authorization, ensures hosted servers are running, records audit data, and invokes filters before forwarding allowed messages. Filters can reject traffic or modify it when mutation is allowed.
 
 ## Gateway Architecture
 
-The gateway is intentionally simple. It handles three things:
-
-1. **Authentication**: Validates users against the configured identity provider
-2. **Server Deployment**: Ensures the target MCP server is running (via Docker or Kubernetes)
-3. **Proxy**: Forwards requests to the MCP server and returns responses
-
 ![Gateway Architecture](/img/gateway-architecture.webp)
 
-All other functionality (authorization, audit logging, webhook filters, token exchange) is handled by the MCP Server Shim that runs alongside each MCP server.
+Obot owns proxying, authentication, authorization, auditing, and filter enforcement. Hosted server code and filter code execute in separate workloads.
 
-## The MCP Server Shim
-
-Every MCP server runs with a shim. This includes servers deployed by Obot and remote MCP servers. The shim is protocol-aware and handles:
-
-- **Authorization**: Checking access control rules
-- **Audit Logging**: Recording request/response metadata
-- **Webhook Filters**: Invoking configured filters on requests and responses
-- **Token Exchange**: Exchanging tokens for OAuth-protected servers
-
-Secrets (client credentials, token exchange secrets, audit tokens) live in the shim and are never exposed to the MCP server itself. Similarly, MCP server configuration is never exposed to the shim.
+Obot handles OAuth token exchange and refresh to access upstream MCP servers on the user's behalf. See the [authentication flow](./architecture.md#authentication-flow).
 
 ### Deployment
 
-- **Kubernetes**: All containers (MCP server, shim, webhook converters) run in a single pod and communicate over localhost
-- **Docker**: Containers communicate via `host.docker.internal` or local IP
-
-## Token Exchange
-
-For OAuth-protected MCP servers, the gateway forwards the original bearer token unchanged. The shim then performs a token exchange using the OAuth 2.0 Token Exchange standard (RFC 8693).
-
-![Token Exchange Flow](/img/token-exchange-flow.webp)
-
-This approach provides:
-
-- **Standards compliance**: Token exchange is a well-defined OAuth extension
-- **Flexibility**: Additional credentials can be passed to MCP servers without changing the gateway
+- **Kubernetes**: Hosted MCP servers and hosted filters run in separate workloads from the Obot pod and from one another.
+- **Docker**: Hosted servers and filters run in separate containers alongside Obot.
+- **Remote**: Obot connects to an externally hosted MCP endpoint.
+- **STDIO runtimes**: Hosted `npx` and `uvx` servers use a transport adapter in their workload to expose HTTP. Proxy filters run through Obot, not through that adapter.
 
 ## Filters
 
-Filters allow inspection and modification of MCP traffic. They can be implemented as MCP filter servers or as HTTP webhook filters.
+Obot selects matching filters, calls them, and enforces their accept, reject, or permitted mutation responses. Filter implementations run outside the Obot process:
 
-MCP filter servers are deployed like other MCP servers in Obot, with one additional setting: the filter configuration must identify the tool name that Obot calls for filtering. Existing HTTP webhooks are automatically converted to MCP servers that run alongside the shim.
+- **Hosted MCP filters** use `npx`, `uvx`, or `containerized` runtimes and run as separate workloads managed by Obot.
+- **Remote MCP filters** expose a filter tool at an external MCP endpoint; Obot connects to that endpoint instead of deploying the filter implementation.
+- **HTTP webhook filters** use a separately hosted MCP-to-HTTP adapter that calls the external webhook endpoint. The adapter is not a sidecar attached to each target MCP server.
+
+See [Filters](../functionality/filters.md) for selectors and contracts.
 
 ## Connecting to the Gateway
 
@@ -59,7 +39,7 @@ Obot Agent connects through the gateway automatically. Users select which MCP se
 
 ### With External Clients
 
-External MCP clients (Claude Desktop, Cursor, VS Code) can connect using the gateway endpoint:
+External MCP clients can connect using the gateway endpoint:
 
 ```
 https://your-obot-instance/mcp-connect/{server-id}

--- a/docs/versioned_docs/version-v0.25.0/concepts/mcp-hosting.md
+++ b/docs/versioned_docs/version-v0.25.0/concepts/mcp-hosting.md
@@ -42,7 +42,7 @@ For production deployments, Obot can deploy MCP servers to Kubernetes:
 
 Obot handles OAuth 2.1 flows for MCP servers that require authentication:
 
-- OAuth credentials stored securely with encryption at rest
+- OAuth credentials encrypted at rest when an [encryption provider](../configuration/encryption-providers/overview.md) is configured; encryption is disabled by default
 - Automatic token refresh
 - Per-user credential isolation
 - Supports custom OAuth configurations

--- a/docs/versioned_docs/version-v0.25.0/concepts/mcp-hosting.md
+++ b/docs/versioned_docs/version-v0.25.0/concepts/mcp-hosting.md
@@ -4,7 +4,7 @@ title: MCP Hosting
 
 # MCP Hosting
 
-The MCP Hosting layer runs and manages MCP servers directly within Obot. It handles deployment, lifecycle management, and runtime isolation for MCP servers.
+Obot deploys and manages hosted MCP server workloads on the underlying Kubernetes or Docker runtime.
 
 ## Runtime Types
 

--- a/docs/versioned_docs/version-v0.25.0/configuration/auth-providers.md
+++ b/docs/versioned_docs/version-v0.25.0/configuration/auth-providers.md
@@ -1,8 +1,7 @@
 # Auth Providers
 
 Authentication providers allow your Obot installation to authenticate users with the identity provider of your choice.
-Administrators must configure at least one authentication provider before users can log in.
-Multiple providers can be configured and available for login at the same time.
+Administrators must configure an authentication provider before users can log in. Only one authentication provider can be configured at a time.
 
 :::note
 In order for authentication to be enabled, the Obot server must be run with the environment variable set:
@@ -63,6 +62,13 @@ You can:
 
 ## Available Auth Providers
 
+| Providers | Availability |
+|-----------|--------------|
+| Local, GitHub, Google | Included in the default Obot edition without registration |
+| Entra, Okta, JumpCloud, Auth0 | Require free Community registration or an Enterprise license |
+
+To register for Community or configure an Enterprise license, use the **License** page in the admin UI. See [Obot Editions](../enterprise/overview.md).
+
 Obot supports the built-in [Local](#local) provider, as well as the following providers that authenticate against an external identity provider using OAuth2. For the OAuth2 providers, you will need to follow the instructions in the auth provider for setting up a new app before getting started. You can get the callback URL from the Obot Admin -> Auth Providers -> \<Auth Provider> -> Configure page. The configuration form will also have fields for the data required.
 
 ### Local
@@ -95,7 +101,7 @@ Follow the instructions [here](https://developers.google.com/identity/protocols/
 
 You can view the source code for Google provider in this [repo](https://github.com/obot-platform/tools).
 
-### Entra (Enterprise Only)
+### Entra
 
 Within the [Microsoft Entra admin center](https://entra.microsoft.com), go to App registrations and click New registration.
 
@@ -159,7 +165,7 @@ You can restrict login access to specific Entra users and groups by taking the f
 
 For more details, [see Entra's docs](https://learn.microsoft.com/en-us/entra/identity-platform/howto-restrict-your-app-to-a-set-of-users).
 
-### Okta (Enterprise Only)
+### Okta
 
 :::note
 Only the org-level authorization server is supported (no custom authorization servers).
@@ -191,7 +197,7 @@ You can restrict login access to specific Okta users and groups by taking the fo
 4. Select `Assign` on groups you want to allow Obot access to
 5. Once you've made your selections, click `Done`
 
-### JumpCloud (Enterprise Only)
+### JumpCloud
 
 Create a **Custom OIDC App** in the [JumpCloud Admin Portal](https://console.jumpcloud.com/). When configuring the app:
 
@@ -242,7 +248,7 @@ You can now return to Obot and finish configuring JumpCloud. Use the table below
 The JumpCloud user must resolve to an active, non-suspended JumpCloud system user. Suspended or inactive users will be blocked from logging in.
 :::
 
-### Auth0 (Enterprise Only)
+### Auth0
 
 Create a **Regular Web Application** in the [Auth0 Dashboard](https://manage.auth0.com) by navigating to Applications > Applications > Create Application.
 
@@ -356,7 +362,7 @@ Ensure the following environment variable is set in your Obot installation:
 
 ![screenshot of setup entra](/img/setup_entra.png)
 
-4. Follow the documentation to create and configure the Entra application from [Entra Instructions](#entra-enterprise-only).
+4. Follow the documentation to create and configure the Entra application from [Entra Instructions](#entra).
 5. Enter the required details:
 - Client ID
 - Client Secret

--- a/docs/versioned_docs/version-v0.25.0/configuration/auth-providers.md
+++ b/docs/versioned_docs/version-v0.25.0/configuration/auth-providers.md
@@ -73,6 +73,8 @@ Obot supports the built-in [Local](#local) provider, as well as the following pr
 
 ### Local
 
+Local passwords are stored as salted Argon2id hashes, independently of optional [database field encryption](./encryption-providers/overview.md#local-passwords).
+
 The Local provider authenticates users with an email address and password stored in Obot's own database. It requires no external identity provider, which makes it a good fit for evaluations, air-gapped installations, and small deployments.
 
 Passwords are hashed with [argon2id](https://en.wikipedia.org/wiki/Argon2) and are never stored, logged, or returned by the API.

--- a/docs/versioned_docs/version-v0.25.0/configuration/encryption-providers/custom-provider.md
+++ b/docs/versioned_docs/version-v0.25.0/configuration/encryption-providers/custom-provider.md
@@ -32,9 +32,54 @@ Kj8fH2lP9mQ4nR6tV8xZ0bC3dE5gF7hI9jK1lM3nO5p=
 
 > **Security Warning**: Keep this key secret and secure. Anyone with access to this key can decrypt your data. Store it in a secure location such as a password manager or secrets management system.
 
-### Obot environment variables
+### 2. Configure Your Deployment
 
-Make sure the following environment variables are set on Obot when you run it:
+#### Helm
 
-- `OBOT_SERVER_ENCRYPTION_PROVIDER="custom"`
-- `OBOT_SERVER_ENCRYPTION_KEY="<your-base64-key>"`
+Set the provider under `config` and the key under `secret` in your values file:
+
+```yaml
+config:
+  OBOT_SERVER_ENCRYPTION_PROVIDER: custom
+secret:
+  OBOT_SERVER_ENCRYPTION_KEY: "<your-base64-key>"
+```
+
+The Helm chart generates an AES-GCM encryption configuration covering the [supported resources](./overview.md#encrypted-resources-and-fields), mounts it into Obot, and sets the configuration-file path.
+
+#### Standalone Server or Docker
+
+Create an `EncryptionConfiguration` file with your generated key:
+
+```yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - credentials.obot.obot.ai
+      - users.obot.obot.ai
+      - identities.obot.obot.ai
+      - mcpoauthtokens.obot.obot.ai
+      - mcpoauthpendingstates.obot.obot.ai
+      - mcpauditlogs.obot.obot.ai
+      - llmauditlogs.obot.obot.ai
+      - policyviolations.obot.obot.ai
+      - properties.obot.obot.ai
+    providers:
+      - aesgcm:
+          keys:
+            - name: key0
+              secret: "<your-base64-key>"
+      - identity: {}
+```
+
+Make the file available to the Obot process, for example by mounting it read-only at `/config/encryption.yaml` in Docker. Restrict access because the file contains your encryption key. Set:
+
+```text
+OBOT_SERVER_ENCRYPTION_PROVIDER=custom
+OBOT_SERVER_ENCRYPTION_CONFIG_FILE=/config/encryption.yaml
+```
+
+`OBOT_SERVER_ENCRYPTION_KEY` alone is insufficient for a standalone server; the chart performs the file-generation step.
+
+For existing data, see [enabling encryption on an existing installation](./overview.md#enabling-encryption-on-an-existing-installation).

--- a/docs/versioned_docs/version-v0.25.0/configuration/encryption-providers/overview.md
+++ b/docs/versioned_docs/version-v0.25.0/configuration/encryption-providers/overview.md
@@ -1,89 +1,46 @@
 # Overview
 
-Obot supports encrypting sensitive data at rest in the database using industry-standard encryption providers. When enabled, encryption protects user data, credentials, OAuth tokens, session information, and other sensitive fields using external Key Management Services (KMS).
+Obot can encrypt selected sensitive fields in its database and credential store. **Application-level encryption is disabled by default** (`OBOT_SERVER_ENCRYPTION_PROVIDER=none`). Configure a provider to enable it. This protects the fields listed below, not entire records, database files, backups, or exported audit logs.
 
 ## Supported Encryption Providers
-
-Obot supports the following encryption providers:
 
 1. [AWS KMS](./aws-kms.md)
 2. [Azure Key Vault](./azure-key-vault.md)
 3. [Google Cloud KMS](./google-cloud-kms.md)
-4. [Custom](./custom-provider.md)
+4. [Custom](./custom-provider.md), including a local AES-GCM key
 
 ## How Encryption Works
 
-Obot uses the Kubernetes EncryptionConfiguration format to encrypt data at rest. The encryption provider:
+Obot uses the Kubernetes `EncryptionConfiguration` format. Each configured resource has a transformer that encrypts selected fields before storage and decrypts them on retrieval. Cloud KMS providers use a local provider process over a Unix socket; a custom AES-GCM configuration uses the supplied key. Encrypted field values are base64-encoded for storage.
 
-1. Receives data to encrypt via a Unix socket connection
-2. Encrypts the data using the configured KMS provider
-3. Returns the encrypted data to be stored in the database
-4. On retrieval, decrypts the data before returning it to the application
+The built-in cloud configurations include the resources below. A custom configuration must include the corresponding resource names to protect those fields.
 
-All encrypted string fields are base64-encoded after encryption for safe storage.
+## Encrypted Resources and Fields
 
-## Encrypted Resources
+These names identify encryption transformers; they do not mean every field in the resource is encrypted. IDs, timestamps, and other metadata can remain readable.
 
-When you enable an encryption provider, the following resource types are automatically encrypted:
+| Resource | Selected fields protected when configured |
+|----------|-------------------------------------------|
+| `credentials.obot.obot.ai` | Serialized credential secret values, such as API keys and upstream access tokens; credential names and context metadata are not included |
+| `users.obot.obot.ai` | `username`, `email`, `displayName`, `iconURL`, `originalEmail`, `originalUsername`; local-auth user `email` also uses this transformer |
+| `identities.obot.obot.ai` | `providerUsername`, `email`, `providerUserID`, `providerGroupLookupID`, `iconURL` |
+| `mcpoauthtokens.obot.obot.ai` | `accessToken`, `refreshToken`, `clientID`, `clientSecret` |
+| `mcpoauthpendingstates.obot.obot.ai` | `state`, `verifier`, `clientID`, `clientSecret` |
+| `mcpauditlogs.obot.obot.ai` | MCP request and response bodies and headers, including mutated requests and original responses; local-agent details listed below |
+| `llmauditlogs.obot.obot.ai` | Request and response headers and bodies, including `policyModifiedRequestBody` |
+| `policyviolations.obot.obot.ai` | `blockedContent` |
+| `properties.obot.obot.ai` | Stored property `value` |
 
-| Resource Type | Description |
-|---------------|-------------|
-| `credentials` | Credential store data |
-| `users.obot.obot.ai` | User account information |
-| `identities.obot.obot.ai` | Identity provider data |
-| `mcpoauthtokens.obot.obot.ai` | MCP OAuth tokens |
-| `mcpoauthpendingstates.obot.obot.ai` | MCP OAuth pending authorization states |
-| `mcpauditlogs.obot.obot.ai` | MCP audit log data |
-| `sessioncookies.obot.obot.ai` | Session cookie data |
+### MCP and Local-Agent Audit Details
 
-## Complete List of Encrypted Fields
+For MCP traffic, the audit transformer encrypts `requestBody`, `mutatedRequestBody`, `responseBody`, `originalResponseBody`, `requestHeaders`, and `responseHeaders`.
 
-### User Data (`users.obot.obot.ai`)
-All personal user information is encrypted:
-- `username` - User's username
-- `email` - User's email address
-- `displayName` - User's display name
-- `iconURL` - User's profile icon URL
-- `originalEmail` - Original email for a deleted user from identity provider
-- `originalUsername` - Original username for a deleted user from identity provider
+For local-agent tool calls in the same audit store, it encrypts the outcome error, hostname, local username, reported user email, working directory, Git root, Git remotes, Git branch, transcript path, request body, response body, and raw event. Other audit metadata, such as timestamps and tool names, is outside this field-level protection.
 
-### Identity Data (`identities.obot.obot.ai`)
-Identity provider information is encrypted:
-- `providerUsername` - Username from identity provider
-- `email` - Email from identity provider
-- `providerUserID` - User ID from identity provider
-- `iconURL` - Icon URL from identity provider
+### Local Passwords
 
-### MCP OAuth Tokens (`mcpoauthtokens.obot.obot.ai`)
-All OAuth-related secrets are encrypted:
-- `accessToken` - OAuth access token
-- `refreshToken` - OAuth refresh token
-- `clientID` - OAuth client ID
-- `clientSecret` - OAuth client secret
+Local-auth passwords are stored as salted Argon2id hashes regardless of whether an encryption provider is configured. The password hash is not reversibly encrypted. This differs from upstream passwords stored as credential secret values, which must be recoverable for use.
 
-### MCP OAuth Pending States (`mcpoauthpendingstates.obot.obot.ai`)
-Pending OAuth authorization state data is encrypted:
-- `state` - OAuth state parameter
-- `verifier` - PKCE verifier
-- `clientID` - OAuth client ID
-- `clientSecret` - OAuth client secret
+## Enabling Encryption on an Existing Installation
 
-### Session Cookies (`sessioncookies.obot.obot.ai`)
-Session authentication data is encrypted:
-- `cookie` - Session cookie value
-
-### MCP Audit Logs (`mcpauditlogs.obot.obot.ai`)
-Complete request/response data in audit logs is encrypted:
-- `requestBody` - HTTP request body (JSON)
-- `responseBody` - HTTP response body (JSON)
-- `requestHeaders` - HTTP request headers (JSON)
-- `responseHeaders` - HTTP response headers (JSON)
-
-### Credentials (`credentials`)
-All credential data stored via the credential store system (SQLite or PostgreSQL backend) is encrypted.
-
-The credential store is configured with the encryption provider and automatically encrypts all stored credentials, including:
-- API keys
-- Access tokens
-- Passwords
-- Any other sensitive credential or configuration data
+Enabling encryption does not automatically encrypt all existing data. Existing installations may require a separate migration to protect previously stored data.

--- a/docs/versioned_docs/version-v0.25.0/configuration/model-providers.md
+++ b/docs/versioned_docs/version-v0.25.0/configuration/model-providers.md
@@ -6,21 +6,16 @@ The Model Providers page allows administrators to configure and manage various A
 
 Obot supports a variety of model providers, including:
 
-**Community**
 - OpenAI
 - Anthropic
 - [Generic Responses Compatible Provider](#generic-responses-compatible-provider)
-
-**Enterprise**
-- [Azure OpenAI / Microsoft Foundry](#azure-enterprise-only)
-- [Amazon Bedrock](#amazon-bedrock-enterprise-only)
+- [Azure OpenAI / Microsoft Foundry](#azure)
+- [Amazon Bedrock](#amazon-bedrock)
 - Google Vertex (Gemini models)
 
 The UI will indicate whether each provider has been configured. If a provider is configured you will have the ability to modify or deconfigure it.
 
-:::note
-Our Enterprise release adds support for additional Enterprise-grade model providers. [See here](../enterprise/overview.md) for more details.
-:::
+All listed model providers are available in the default Obot edition without Community registration or an Enterprise license. You still need credentials and access to the upstream model service.
 
 #### Configuring and enabling a provider
 
@@ -63,7 +58,7 @@ Setting a default model here does not automatically grant users access to it. Us
 
 ### Instructions for configuring specific providers
 
-#### Azure (Enterprise only)
+#### Azure
 
 Obot supports two Azure providers, each with a different authentication method. These are compatible with both Azure OpenAI deployments and Foundry deployments.
 
@@ -120,7 +115,7 @@ Official references:
 - [Claude Code on Microsoft Foundry](https://code.claude.com/docs/en/microsoft-foundry#azure-rbac-configuration) — Claude Code RBAC requirements
 - [Assign Azure roles using the Azure portal](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) — portal instructions and role-assignment permissions
 
-#### Amazon Bedrock (Enterprise only)
+#### Amazon Bedrock
 
 Obot supports two Amazon Bedrock providers, each with a different authentication method.
 

--- a/docs/versioned_docs/version-v0.25.0/enterprise/overview.md
+++ b/docs/versioned_docs/version-v0.25.0/enterprise/overview.md
@@ -10,7 +10,7 @@ what usage limits apply.
 
 ## Obot
 
-The default edition. It supports up to 100 users and 100 devices and does not include enterprise-grade auth providers like Entra, Okta, JumpCloud, or Auth0.
+The default edition supports up to 100 users and 100 devices. It includes Local, GitHub, and Google authentication and all [model providers](../configuration/model-providers.md), including Azure OpenAI, Amazon Bedrock, and Google Vertex, without registration. Entra, Okta, JumpCloud, and Auth0 authentication require Community registration or an Enterprise license.
 
 ## Obot Community
 

--- a/docs/versioned_docs/version-v0.25.0/faq.md
+++ b/docs/versioned_docs/version-v0.25.0/faq.md
@@ -16,10 +16,7 @@ Currently, users must log in at least once before roles can be assigned. To pre-
 
 ### What are the differences between the open source and enterprise versions of Obot?
 
-Both use the same core codebase, but the enterprise version includes additional closed-source plugins for:
-
-- enterprise authentication (Entra, Okta) 
-- model providers (Azure OpenAI, Amazon Bedrock)
+All editions use the same container image. The default edition includes all model providers without registration, plus Local, GitHub, and Google authentication. Entra, Okta, JumpCloud, and Auth0 authentication require free Community registration or an Enterprise license. Enterprise adds unlimited users and devices and enterprise support. See [Obot Editions](./enterprise/overview.md).
 
 ## Integration & Troubleshooting
 

--- a/docs/versioned_docs/version-v0.25.0/functionality/filters.md
+++ b/docs/versioned_docs/version-v0.25.0/functionality/filters.md
@@ -8,19 +8,22 @@ Filters are a powerful mechanism for inspecting and controlling tool calls and t
 
 Filters can be implemented in two ways:
 
-- **MCP filter servers**: MCP servers that expose a filter tool. Obot deploys and calls the configured tool when matching MCP traffic is processed.
-- **HTTP webhook filters**: HTTP endpoints that receive MCP messages from the gateway.
+- **MCP filter servers**: Hosted or remote MCP servers that expose a filter tool. Hosted filters run as separate Docker containers or Kubernetes workloads. Remote filters run at an external MCP endpoint. Obot calls the configured tool when matching MCP traffic is processed.
+- **HTTP webhook filters**: HTTP endpoints that receive MCP messages and return a decision to allow or reject them.
 
 When you configure a filter, you can narrow when it runs using selectors that target particular tool calls or MCP (Model Context Protocol) tool functions.
+
+Filter implementations run outside the Obot process. Obot handles proxying, calls the filter, and enforces its response; the target MCP server does not host or enforce the filter. See the [gateway architecture](../concepts/mcp-gateway.md#gateway-architecture).
 
 ## How Filters Work
 
 1. **MCP Request Interception**: When a request is made to an MCP server, the gateway intercepts it and sends the details to your configured filter
-2. **Payload Inspection**: Your filter receives the payload and can perform any custom logic or validation
+2. **Payload Inspection**: The separate filter server or webhook receives the payload and performs its validation
 3. **Response Decision**: Your filter returns one of the following decisions:
    - Accept: Allow the tool call to proceed
    - Reject: Block execution and return an error to the user
    - Mutate: Return a modified MCP message, if mutation is allowed for the filter
+4. **Enforcement**: Obot applies the filter response before forwarding the request or returning the response to the client.
 
 ## Gateway Configuration
 
@@ -36,6 +39,8 @@ All filter types support selectors to control when your filter is triggered:
 ## MCP Filter Servers
 
 MCP filters can be deployed as MCP servers. Their deployment configuration is similar to other MCP servers in Obot: choose a runtime such as `remote`, `containerized`, `npx`, or `uvx`, then provide the runtime-specific configuration and any required environment variables.
+
+With `remote`, Obot connects to the configured endpoint and does not deploy the filter implementation. The other runtimes deploy a separate workload; a hosted filter does not run inside Obot or inside the target MCP server.
 
 The additional requirement for an MCP filter server is a filter tool name. Obot needs this value so it knows which tool to call when the filter runs.
 
@@ -64,25 +69,23 @@ The default built-in filter catalog is maintained in the [obot-platform/system-m
 
 ## HTTP-based Filters
 
-You can also use HTTP-based webhooks for filtering. In this case, the HTTP server would have to be deployed outside of Obot. You can then provide the following information to Obot:
+Deploy a webhook service that accepts MCP messages over HTTP. Configure its URL in Obot, which sends matching messages to the webhook and uses its response to allow or reject them.
+
+Provide the following information to Obot:
 
 ### Required Configuration
 
 - **Name**: A descriptive name for your filter
-- **URL**: The webhook endpoint URL where the gateway will send payloads
+- **URL**: The webhook endpoint that receives MCP messages
 - **Secret** (optional): A shared secret with the webhook receiver for payload signature verification
 
 ### Security with Secrets
 
-If you configure a secret, the gateway will sign each payload using this shared secret. This allows both sides (the gateway and your webhook service) to verify the authenticity of the communication:
-
-- The gateway signs outgoing payloads with the secret
-- Your webhook service can verify the signature to ensure the payload is legitimate
-- This prevents unauthorized or tampered requests from being processed
+Configure the same shared secret in Obot and your webhook service. When a secret is configured, webhook requests include a signature in the `X-Obot-Signature-256` header. Your service should verify this signature before processing the request.
 
 ### Webhook Receiver
 
-To implement a filter, you need to create a web service that can handle POST requests from the gateway.
+Your webhook endpoint must accept HTTP POST requests containing MCP messages.
 
 ### Payload Structure
 
@@ -124,7 +127,7 @@ PORT=8000 WEBHOOK_SECRET=somethingsecret uv run simple_webhook_example.py
 
 The filter target url will be `http://<host>:8000/webhook`
 
-The Webhook Secret will also need to be configured in the gateway.
+Set the Webhook Secret in Obot to the same value as `WEBHOOK_SECRET` in this example.
 
 ```python
 #!/usr/bin/env python3
@@ -154,7 +157,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-
 def validate_signature(body: bytes, signature: str, secret: str) -> bool:
     """
     Validate HMAC-SHA256 signature for webhook security.
@@ -181,9 +183,6 @@ def validate_signature(body: bytes, signature: str, secret: str) -> bool:
     # Secure comparison
     return hmac.compare_digest(signature, expected)
 
-
-
-
 class WebhookMessage(BaseModel):
     """JSON-RPC message structure for webhook payloads."""
     jsonrpc: str
@@ -193,14 +192,12 @@ class WebhookMessage(BaseModel):
     result: Optional[Dict[str, Any]] = None
     error: Optional[Dict[str, Any]] = None
 
-
 # Initialize app
 app = FastAPI(title="Simple Webhook with Filtering")
 
 # Configuration
 SECRET = os.getenv("WEBHOOK_SECRET", "test_secret")
 PORT = int(os.getenv("PORT", "8000"))
-
 
 @app.post("/webhook")
 async def webhook_endpoint(
@@ -240,7 +237,6 @@ async def webhook_endpoint(
         logger.error(f"Error processing webhook: {e}")
         raise HTTPException(status_code=400, detail=f"Invalid payload: {str(e)}")
 
-
 def check_message_for_threats(message: WebhookMessage) -> None:
     """
     Check DuckDuckGo search requests for unsafe query content.
@@ -275,7 +271,6 @@ def check_message_for_threats(message: WebhookMessage) -> None:
                 logger.info(f"✅ Safe search query: '{query}'")
     
     logger.debug(f"✅ Clean message: {message.method}")
-
 
 def is_unsafe_search_query(query: str) -> bool:
     """
@@ -316,12 +311,10 @@ def is_unsafe_search_query(query: str) -> bool:
     
     return False
 
-
 @app.get("/health")
 async def health_check():
     """Simple health check endpoint."""
     return {"status": "healthy", "filter": "ready"}
-
 
 @app.get("/")
 async def root():
@@ -335,7 +328,6 @@ async def root():
         },
         "note": "Send JSON-RPC messages to /webhook with proper signatures. Suspicious content will result in 403 responses."
     }
-
 
 def main():
     """Start the webhook server."""
@@ -356,7 +348,6 @@ def main():
         port=PORT,
         log_level="info"
     )
-
 
 if __name__ == "__main__":
     main()

--- a/docs/versioned_docs/version-v0.25.0/functionality/llm-gateway.md
+++ b/docs/versioned_docs/version-v0.25.0/functionality/llm-gateway.md
@@ -249,7 +249,7 @@ The Azure models endpoint uses Azure's OpenAI-compatible Models API and returns 
 An administrator configures one of these providers under **Model Providers**:
 
 - **Azure** requires the Azure resource endpoint (for example, `https://my-resource.services.ai.azure.com`) and an API key.
-- **Azure Entra** requires the Azure resource endpoint plus tenant ID, client ID, and client secret for a service principal. Obot requests tokens for the `https://ai.azure.com/.default` scope. Assign the service principal **Cognitive Services User** or **Foundry User** (formerly Azure AI User) on the specific Foundry resource. **Cognitive Services OpenAI User** may allow OpenAI requests but does not provide all permissions needed for Anthropic requests. See [Azure provider configuration](../configuration/model-providers.md#azure-enterprise-only) for portal instructions and official references.
+- **Azure Entra** requires the Azure resource endpoint plus tenant ID, client ID, and client secret for a service principal. Obot requests tokens for the `https://ai.azure.com/.default` scope. Assign the service principal **Cognitive Services User** or **Foundry User** (formerly Azure AI User) on the specific Foundry resource. **Cognitive Services OpenAI User** may allow OpenAI requests but does not provide all permissions needed for Anthropic requests. See [Azure provider configuration](../configuration/model-providers.md#azure) for portal instructions and official references.
 
 Configure each model's target model as its Azure deployment name. The provider's model metadata must expose either `AnthropicMessages` or `OpenAIResponses` as the dialect. The Models page groups models by that dialect, even if deployment names are arbitrary or misleading.
 

--- a/docs/versioned_docs/version-v0.25.0/installation/cli-setup.md
+++ b/docs/versioned_docs/version-v0.25.0/installation/cli-setup.md
@@ -129,7 +129,7 @@ obot setup status --json
 
 ### `auth_unavailable`
 
-The Obot server did not report exactly one usable configured authentication provider. Configure an auth provider first, or use an interactive setup flow if multiple providers are configured and you need to choose one.
+The Obot server did not report exactly one usable configured authentication provider. Configure an auth provider first.
 
 ### `server_unreachable`
 

--- a/docs/versioned_docs/version-v0.25.0/installation/enabling-authentication.md
+++ b/docs/versioned_docs/version-v0.25.0/installation/enabling-authentication.md
@@ -3,7 +3,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This guide covers the step-by-step process to enable and configure authentication in Obot. Authentication must be setup to use one of the external providers in order to function properly. The bootstrap user is not implemented to operate as a regular user.
+This guide covers the step-by-step process to enable and configure authentication in Obot. Configure either the built-in Local provider or an external identity provider to enable user login. The bootstrap user is not implemented to operate as a regular user.
 
 :::note
 If any MCP servers were created with authentication disabled, they will be deleted when authentication is enabled.
@@ -60,7 +60,7 @@ Start (or restart) your Obot deployment with the new environment variables. Navi
 ## Step 3: Configure Authentication Provider
 
 1. Go to **Auth Providers** under the **User Management** section in the left navigation
-2. Click **Configure** on your desired provider (GitHub, Google, Entra, Okta)
+2. Click **Configure** on your desired provider. Local, GitHub, and Google are available without registration; Entra, Okta, JumpCloud, and Auth0 require Community registration or an Enterprise license.
 3. Follow the provider-specific configuration steps
 
 For detailed provider configuration, see the [Auth Providers](../configuration/auth-providers.md) documentation.


### PR DESCRIPTION
Correct documentation that misstates provider availability, encryption defaults, and how MCP traffic and authentication are handled.

  - Clarify auth provider registration requirements, availability of all model providers, and the single auth provider restriction.
  - Document optional field-level encryption, its coverage and existing-data limitations, with configuration examples for Helm and standalone deployments.
  - Explain gateway responsibilities, separate server and filter workloads, and client versus upstream OAuth flows with sequence diagrams.
  - Apply the corrections across current and v0.25.0 docs, with targeted fixes to older versions.

  Documentation only; no runtime changes.