### PR TITLE
fix: use existing fixed config on vMCP update

### DIFF
--- a/pkg/api/handlers/vmcp.go
+++ b/pkg/api/handlers/vmcp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
 	"github.com/obot-platform/obot/pkg/api"
 	"github.com/obot-platform/obot/pkg/api/authz"
+	gclient "github.com/obot-platform/obot/pkg/gateway/client"
 	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	"github.com/obot-platform/obot/pkg/system"
@@ -69,7 +70,7 @@ func (h *VMCPHandler) Create(req api.Context) error {
 	if err := vmcpconfig.InitializeComponentIDs(&manifest); err != nil {
 		return types.NewErrBadRequest("invalid VMCP manifest: %v", err)
 	}
-	staticConfiguration := vmcpconfig.ExtractStaticConfiguration(&manifest)
+	staticConfiguration := vmcpconfig.ExtractStaticConfiguration(&manifest, nil)
 
 	vmcp := v1.VMCP{
 		Finalizers:   []string{v1.VMCPFinalizer},
@@ -122,9 +123,17 @@ func (h *VMCPHandler) Update(req api.Context) error {
 	if err := manifest.Validate(); err != nil {
 		return types.NewErrBadRequest("invalid VMCP manifest: %v", err)
 	}
-	staticConfiguration := vmcpconfig.ExtractStaticConfiguration(&manifest)
+
 	credentialContext := vmcpconfig.StaticConfigurationCredentialContext(vmcp.Name)
 	credentialName := vmcpconfig.ConfigurationCredentialName()
+
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credentialContext}, credentialName)
+	if err != nil && !errors.As(err, &gclient.CredentialNotFoundError{}) {
+		return fmt.Errorf("failed to reveal VMCP static configuration: %w", err)
+	}
+
+	staticConfiguration := vmcpconfig.ExtractStaticConfiguration(&manifest, cred.Secrets)
+
 	if err := req.GatewayClient.UpsertCredential(req.Context(), gatewaytypes.Credential{
 		Context: credentialContext,
 		Name:    credentialName,

--- a/pkg/api/handlers/vmcp_test.go
+++ b/pkg/api/handlers/vmcp_test.go
@@ -268,7 +268,7 @@ func TestVMCPHandlerCreateStoresStaticConfigurationInCredential(t *testing.T) {
 	}
 }
 
-func TestVMCPHandlerUpdateReplacesStaticConfiguration(t *testing.T) {
+func TestVMCPHandlerUpdatePreservesStaticConfiguration(t *testing.T) {
 	storage := newVMCPTestStorage(vmcpCatalogEntryForTest("entry"))
 	gatewayClient := newHandlerTestGateway(t)
 	handler := NewVMCPHandler(nil)
@@ -284,6 +284,10 @@ func TestVMCPHandlerUpdateReplacesStaticConfiguration(t *testing.T) {
 			Key:    "REGION",
 			Policy: types.VMCPConfigurationPolicyFixed,
 			Value:  "old-region",
+		},
+		{
+			Key:    "USER",
+			Policy: types.VMCPConfigurationPolicyFixed,
 		},
 	}
 	created := callVMCPCreate(t, storage, gatewayClient, handler, manifest, admin)
@@ -317,9 +321,9 @@ func TestVMCPHandlerUpdateReplacesStaticConfiguration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		want := map[string]string{}
-		if token != "" {
-			want[vmcpconfig.ConfigurationKey(manifest.Components[0].ID, "TOKEN")] = token
+		want := map[string]string{
+			vmcpconfig.ConfigurationKey(manifest.Components[0].ID, "TOKEN"):  "new-token",
+			vmcpconfig.ConfigurationKey(manifest.Components[0].ID, "REGION"): "old-region",
 		}
 		if !reflect.DeepEqual(credential.Secrets, want) {
 			t.Fatalf("static configuration = %v, want %v", credential.Secrets, want)
@@ -328,7 +332,7 @@ func TestVMCPHandlerUpdateReplacesStaticConfiguration(t *testing.T) {
 			t.Fatal(err)
 		}
 		if stored.Spec.StaticConfigurationHash != utils.Digest(want) {
-			t.Fatal("static configuration hash does not reflect replacement values")
+			t.Fatal("static configuration hash does not reflect preserved values")
 		}
 	}
 }

--- a/pkg/vmcp/credential.go
+++ b/pkg/vmcp/credential.go
@@ -110,14 +110,20 @@ func ReconcileComponentIDs(existing types.VMCPManifest, desired *types.VMCPManif
 // ExtractStaticConfiguration removes fixed values from a manifest and returns
 // them in the flat representation used by the credential store. Empty values
 // are omitted because they represent missing configuration.
-func ExtractStaticConfiguration(manifest *types.VMCPManifest) map[string]string {
+func ExtractStaticConfiguration(manifest *types.VMCPManifest, existingConfig map[string]string) map[string]string {
 	configuration := map[string]string{}
 	for componentIndex := range manifest.Components {
 		component := &manifest.Components[componentIndex]
 		for policyIndex := range component.Configuration {
 			policy := &component.Configuration[policyIndex]
-			if policy.Policy == types.VMCPConfigurationPolicyFixed && policy.Value != "" {
-				configuration[ConfigurationKey(component.ID, policy.Key)] = policy.Value
+			if policy.Policy == types.VMCPConfigurationPolicyFixed {
+				val := existingConfig[ConfigurationKey(component.ID, policy.Key)]
+				if policy.Value != "" {
+					val = policy.Value
+				}
+				if val != "" {
+					configuration[ConfigurationKey(component.ID, policy.Key)] = val
+				}
 			}
 			policy.Value = ""
 		}

--- a/pkg/vmcp/credential_test.go
+++ b/pkg/vmcp/credential_test.go
@@ -1,10 +1,40 @@
 package vmcp
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/obot-platform/obot/apiclient/types"
 )
+
+func TestExtractStaticConfigurationPreservesExistingValues(t *testing.T) {
+	manifest := types.VMCPManifest{Components: []types.VMCPComponent{{
+		ID: "component-id",
+		Configuration: []types.VMCPConfigurationPolicy{
+			{Key: "TOKEN", Policy: types.VMCPConfigurationPolicyFixed, Value: "new-token"},
+			{Key: "REGION", Policy: types.VMCPConfigurationPolicyFixed},
+			{Key: "USER", Policy: types.VMCPConfigurationPolicyUserAllowed, Value: "ignored"},
+		},
+	}}}
+
+	got := ExtractStaticConfiguration(&manifest, map[string]string{
+		ConfigurationKey("component-id", "TOKEN"):   "old-token",
+		ConfigurationKey("component-id", "REGION"):  "old-region",
+		ConfigurationKey("component-id", "REMOVED"): "old-removed",
+	})
+	want := map[string]string{
+		ConfigurationKey("component-id", "TOKEN"):  "new-token",
+		ConfigurationKey("component-id", "REGION"): "old-region",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExtractStaticConfiguration() = %v, want %v", got, want)
+	}
+	for _, policy := range manifest.Components[0].Configuration {
+		if policy.Value != "" {
+			t.Fatalf("configuration %q value was not cleared", policy.Key)
+		}
+	}
+}
 
 func TestConfigurationKeyRoundTrip(t *testing.T) {
 	key := ConfigurationKey("component-id", "HEADER.with.periods")


### PR DESCRIPTION
Before this change any fixed configuration that was put on a vMCP was erased on an update. Instead, this change copies an fixed configuration values that were not set in the update request from the existing configuration.