### PR TITLE
fix: add information to vMCP MCP servers for tracking

### DIFF
--- a/apiclient/types/vmcp.go
+++ b/apiclient/types/vmcp.go
@@ -260,7 +260,7 @@ func (m VMCPManifest) Validate() error {
 			return fmt.Errorf("component %q mcpServerCatalogEntryID is required", component.Name)
 		}
 
-		configurationKeys := make(map[string]struct{}, len(component.Configuration))
+		configurationKeys := make(map[string]VMCPConfigurationPolicyType, len(component.Configuration))
 		for _, policy := range component.Configuration {
 			if policy.Key == "" {
 				return fmt.Errorf("component %q configuration key is required", component.Name)
@@ -268,7 +268,7 @@ func (m VMCPManifest) Validate() error {
 			if _, ok := configurationKeys[policy.Key]; ok {
 				return fmt.Errorf("component %q has duplicate configuration key %q", component.Name, policy.Key)
 			}
-			configurationKeys[policy.Key] = struct{}{}
+			configurationKeys[policy.Key] = policy.Policy
 			switch policy.Policy {
 			case "", VMCPConfigurationPolicyProhibited, VMCPConfigurationPolicyFixed, VMCPConfigurationPolicyUserAllowed:
 			default:
@@ -276,6 +276,13 @@ func (m VMCPManifest) Validate() error {
 			}
 			if policy.Policy != VMCPConfigurationPolicyFixed && policy.Value != "" {
 				return fmt.Errorf("component %q configuration %q may only set value with fixed policy", component.Name, policy.Key)
+			}
+		}
+		for _, config := range component.CatalogEntry.Manifest.Config {
+			if config.Required && config.Value == "" && config.SecretBinding == nil {
+				if policy := configurationKeys[config.Key]; policy == "" || policy == VMCPConfigurationPolicyProhibited {
+					return fmt.Errorf("component %q required configuration %q cannot be prohibited", component.Name, config.Key)
+				}
 			}
 		}
 	}

--- a/apiclient/types/vmcp_test.go
+++ b/apiclient/types/vmcp_test.go
@@ -164,3 +164,72 @@ func validVMCPManifest() VMCPManifest {
 		}},
 	}
 }
+
+func TestVMCPManifestRequiredConfigurationPolicy(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		policy        VMCPConfigurationPolicyType
+		omitPolicy    bool
+		optional      bool
+		value         string
+		secretBinding *MCPSecretBinding
+		wantError     bool
+	}{
+		{
+			name:      "prohibited",
+			policy:    VMCPConfigurationPolicyProhibited,
+			wantError: true,
+		},
+		{
+			name:      "empty policy",
+			wantError: true,
+		},
+		{
+			name:       "omitted policy",
+			omitPolicy: true,
+			wantError:  true,
+		},
+		{
+			name:   "fixed",
+			policy: VMCPConfigurationPolicyFixed,
+		},
+		{
+			name:   "user allowed",
+			policy: VMCPConfigurationPolicyUserAllowed,
+		},
+		{
+			name:     "optional prohibited",
+			policy:   VMCPConfigurationPolicyProhibited,
+			optional: true,
+		},
+		{
+			name:   "catalog value",
+			policy: VMCPConfigurationPolicyProhibited,
+			value:  "supplied",
+		},
+		{
+			name:          "secret binding",
+			policy:        VMCPConfigurationPolicyProhibited,
+			secretBinding: &MCPSecretBinding{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := validVMCPManifest()
+			manifest.Components[0].CatalogEntry.Manifest.Config = []MCPConfig{{
+				Key:           "TOKEN",
+				Required:      !tc.optional,
+				Value:         tc.value,
+				SecretBinding: tc.secretBinding,
+			}}
+			if !tc.omitPolicy {
+				manifest.Components[0].Configuration = []VMCPConfigurationPolicy{{
+					Key:    "TOKEN",
+					Policy: tc.policy,
+				}}
+			}
+			if err := manifest.Validate(); (err != nil) != tc.wantError {
+				t.Fatalf("Validate() = %v, want error %v", err, tc.wantError)
+			}
+		})
+	}
+}

--- a/pkg/api/authz/mcpid.go
+++ b/pkg/api/authz/mcpid.go
@@ -274,7 +274,7 @@ func mcpIDIsAuthorized(ctx context.Context, client kclient.Client, authorizedMCP
 		return slices.Contains(authorizedMCPServers, mcpServer.Name) ||
 			mcpServer.Spec.VMCPID != "" && slices.Contains(authorizedMCPServers, mcpServer.Spec.VMCPID) ||
 			mcpServer.Spec.CompositeName != "" && slices.Contains(authorizedMCPServers, mcpServer.Spec.CompositeName) ||
-			mcpServer.Spec.MCPServerCatalogEntryName != "" && userID == mcpServer.Spec.UserID && slices.Contains(authorizedMCPServers, mcpServer.Spec.MCPServerCatalogEntryName), nil
+			mcpServer.Spec.VMCPID == "" && mcpServer.Spec.MCPServerCatalogEntryName != "" && userID == mcpServer.Spec.UserID && slices.Contains(authorizedMCPServers, mcpServer.Spec.MCPServerCatalogEntryName), nil
 	case system.IsVMCPID(mcpID):
 		// Only an explicit vMCP scope (or wildcard above) grants its endpoint.
 		return false, nil
@@ -292,6 +292,9 @@ func mcpIDIsAuthorized(ctx context.Context, client kclient.Client, authorizedMCP
 		}
 
 		for _, mcpServer := range mcpServers.Items {
+			if mcpServer.Spec.VMCPID != "" || mcpServer.Spec.VMCPInstanceID != "" {
+				continue
+			}
 			if slices.Contains(authorizedMCPServers, mcpServer.Name) || mcpServer.Spec.CompositeName != "" && slices.Contains(authorizedMCPServers, mcpServer.Spec.CompositeName) {
 				return true, nil
 			}

--- a/pkg/api/authz/mcpid_test.go
+++ b/pkg/api/authz/mcpid_test.go
@@ -621,6 +621,66 @@ func TestMCPIDIsAuthorized(t *testing.T) {
 			want:       false,
 		},
 		{
+			name: "catalog entry ignores vMCP component server scope",
+			objects: []kclient.Object{
+				&v1.MCPServerCatalogEntry{
+					Name:      "entry-test",
+					Namespace: system.DefaultNamespace,
+				},
+				&v1.MCPServer{
+					Name:      "ms1-vmcp-component",
+					Namespace: system.DefaultNamespace,
+					Spec: v1.MCPServerSpec{
+						MCPServerCatalogEntryName: "entry-test",
+						UserID:                    "user-uid",
+						VMCPID:                    "vmcp1-test",
+					},
+				},
+			},
+			authorized: []string{"ms1-vmcp-component"},
+			userID:     "user-uid",
+			mcpID:      "entry-test",
+			want:       false,
+		},
+		{
+			name: "vMCP component server does not inherit catalog entry scope",
+			objects: []kclient.Object{&v1.MCPServer{
+				Name:      "ms1-vmcp-component",
+				Namespace: system.DefaultNamespace,
+				Spec: v1.MCPServerSpec{
+					MCPServerCatalogEntryName: "entry-test",
+					UserID:                    "user-uid",
+					VMCPID:                    "vmcp1-test",
+				},
+			}},
+			authorized: []string{"entry-test"},
+			userID:     "user-uid",
+			mcpID:      "ms1-vmcp-component",
+			want:       false,
+		},
+		{
+			name: "catalog entry ignores vMCP instance component server scope",
+			objects: []kclient.Object{
+				&v1.MCPServerCatalogEntry{
+					Name:      "entry-test",
+					Namespace: system.DefaultNamespace,
+				},
+				&v1.MCPServer{
+					Name:      "ms1-vmcp-instance-component",
+					Namespace: system.DefaultNamespace,
+					Spec: v1.MCPServerSpec{
+						MCPServerCatalogEntryName: "entry-test",
+						UserID:                    "user-uid",
+						VMCPInstanceID:            "vmcpi1-test",
+					},
+				},
+			},
+			authorized: []string{"ms1-vmcp-instance-component"},
+			userID:     "user-uid",
+			mcpID:      "entry-test",
+			want:       false,
+		},
+		{
 			name:       "missing catalog entry denies without error",
 			authorized: []string{"ms1fromentry"},
 			userID:     "user-uid",

--- a/pkg/api/handlers/component_delete_test.go
+++ b/pkg/api/handlers/component_delete_test.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDeleteServerProtectsComponents(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		spec   v1.MCPServerSpec
+		parent string
+	}{
+		{
+			name: "standalone",
+		},
+		{
+			name:   "composite component",
+			spec:   v1.MCPServerSpec{CompositeName: "ms1composite"},
+			parent: "ms1composite",
+		},
+		{
+			name: "shared vMCP component",
+			spec: v1.MCPServerSpec{
+				VMCPID:          "vmcp1shared",
+				VMCPComponentID: "one",
+			},
+			parent: "vmcp1shared",
+		},
+		{
+			name: "dedicated vMCP component",
+			spec: v1.MCPServerSpec{
+				VMCPInstanceID:  "vmcpi1dedicated",
+				VMCPComponentID: "one",
+			},
+			parent: "vmcpi1dedicated",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := &v1.MCPServer{Name: "ms1test", Namespace: system.DefaultNamespace, Spec: tc.spec}
+			server.Spec.UserID = "1"
+			client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(server).Build()
+			request := httptest.NewRequest(http.MethodDelete, "/", nil)
+			request.SetPathValue("mcp_server_id", server.Name)
+			err := (&MCPHandler{}).DeleteServer(api.Context{
+				Request:        request,
+				ResponseWriter: httptest.NewRecorder(),
+				Storage:        client,
+				User:           &kuser.DefaultInfo{UID: "1"},
+			})
+			if tc.parent != "" {
+				var httpErr *types.ErrHTTP
+				require.ErrorAs(t, err, &httpErr)
+				require.Equal(t, http.StatusForbidden, httpErr.Code)
+				require.ErrorContains(t, err, tc.parent)
+				require.NoError(t, client.Get(t.Context(), kclient.ObjectKeyFromObject(server), &v1.MCPServer{}))
+			} else {
+				require.NoError(t, err)
+				require.True(t, apierrors.IsNotFound(client.Get(t.Context(), kclient.ObjectKeyFromObject(server), &v1.MCPServer{})))
+			}
+		})
+	}
+}
+
+func TestDeleteServerInstanceProtectsCompositeComponents(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		composite string
+		missing   bool
+	}{
+		{
+			name: "standalone",
+		},
+		{
+			name:      "composite component",
+			composite: "ms1composite",
+		},
+		{
+			name:    "already deleted",
+			missing: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := &v1.MCPServerInstance{
+				Name:      "msi1test",
+				Namespace: system.DefaultNamespace,
+				Spec:      v1.MCPServerInstanceSpec{CompositeName: tc.composite},
+			}
+			client := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+			if !tc.missing {
+				require.NoError(t, client.Create(t.Context(), instance))
+			}
+			request := httptest.NewRequest(http.MethodDelete, "/", nil)
+			request.SetPathValue("mcp_server_instance_id", instance.Name)
+			err := (&ServerInstancesHandler{}).DeleteServerInstance(api.Context{Request: request, Storage: client})
+			if tc.composite != "" {
+				var httpErr *types.ErrHTTP
+				require.ErrorAs(t, err, &httpErr)
+				require.Equal(t, http.StatusBadRequest, httpErr.Code)
+				require.ErrorContains(t, err, tc.composite)
+				require.NoError(t, client.Get(t.Context(), kclient.ObjectKeyFromObject(instance), &v1.MCPServerInstance{}))
+			} else {
+				require.NoError(t, err)
+				require.True(t, apierrors.IsNotFound(client.Get(t.Context(), kclient.ObjectKeyFromObject(instance), &v1.MCPServerInstance{})))
+			}
+		})
+	}
+}

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -293,18 +293,8 @@ func (m *MCPHandler) ListServer(req api.Context) error {
 	}
 
 	credCtxs := make([]string, 0, len(servers.Items))
-	if catalogID != "" {
-		for _, server := range servers.Items {
-			credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", catalogID, server.Name))
-		}
-	} else if workspaceID != "" {
-		for _, server := range servers.Items {
-			credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", workspaceID, server.Name))
-		}
-	} else {
-		for _, server := range servers.Items {
-			credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", req.User.GetUID(), server.Name))
-		}
+	for _, server := range servers.Items {
+		credCtxs = append(credCtxs, server.CredentialContext(req.User.GetUID()))
 	}
 
 	creds, err := req.GatewayClient.ListCredentials(req.Context(), gateway.ListCredentialsOptions{
@@ -406,16 +396,7 @@ func (m *MCPHandler) GetServer(req api.Context) error {
 	// Add extracted env vars to the server definition
 	addExtractedEnvVars(&server)
 
-	var credCtxs []string
-	if catalogID != "" {
-		credCtxs = []string{fmt.Sprintf("%s-%s", catalogID, server.Name)}
-	} else if workspaceID != "" {
-		credCtxs = []string{fmt.Sprintf("%s-%s", workspaceID, server.Name)}
-	} else {
-		credCtxs = []string{fmt.Sprintf("%s-%s", req.User.GetUID(), server.Name)}
-	}
-
-	cred, err := req.GatewayClient.RevealCredential(req.Context(), credCtxs, server.Name)
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(req.User.GetUID())}, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 		return fmt.Errorf("failed to find credential: %w", err)
 	}
@@ -465,6 +446,17 @@ func (m *MCPHandler) DeleteServer(req api.Context) error {
 		return types.NewErrForbidden(
 			"cannot delete component of composite %q; delete the composite server instead",
 			server.Spec.CompositeName,
+		)
+	}
+	// Same for vMCPs
+	if server.Spec.VMCPComponentID != "" {
+		name := server.Spec.VMCPID
+		if name == "" {
+			name = server.Spec.VMCPInstanceID
+		}
+		return types.NewErrForbidden(
+			"cannot delete component of vMCP %q; delete the vMCP server instead",
+			name,
 		)
 	}
 
@@ -906,6 +898,9 @@ func mcpServerOrInstanceFromConnectURL(req api.Context, id, secretBindingAllowed
 		}); err != nil {
 			return v1.MCPServer{}, v1.MCPServerInstance{}, err
 		}
+		servers.Items = slices.DeleteFunc(servers.Items, func(server v1.MCPServer) bool {
+			return server.Spec.VMCPID != "" || server.Spec.VMCPInstanceID != ""
+		})
 		if len(servers.Items) == 0 {
 			// If the user has not configured an MCP server for the catalog entry, create a server for the user.
 			missingAdminConfig, err := entryMissingAdminConfig(req.Context(), req.LocalK8sClient, req.ObotNamespace, entry, secretBindingAllowedLabel)
@@ -1410,17 +1405,7 @@ func (m *MCPHandler) CreateServer(req api.Context) error {
 		return err
 	}
 
-	var (
-		cred gatewaytypes.Credential
-		err  error
-	)
-	if catalogID != "" {
-		cred, err = req.GatewayClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", catalogID, server.Name)}, server.Name)
-	} else if workspaceID != "" {
-		cred, err = req.GatewayClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", workspaceID, server.Name)}, server.Name)
-	} else {
-		cred, err = req.GatewayClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", req.User.GetUID(), server.Name)}, server.Name)
-	}
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(req.User.GetUID())}, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 		return fmt.Errorf("failed to find credential: %w", err)
 	}
@@ -1461,6 +1446,10 @@ func (m *MCPHandler) UpdateServer(req api.Context) error {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
+	if existing.Spec.VMCPComponentID != "" {
+		return types.NewErrBadRequest("cannot update a server that is bound to a vMCP component")
+	}
+
 	if err = req.Read(&updated); err != nil {
 		return err
 	}
@@ -1469,14 +1458,7 @@ func (m *MCPHandler) UpdateServer(req api.Context) error {
 	}
 
 	// Shutdown any server that is using the default credentials.
-	var cred gatewaytypes.Credential
-	if catalogID != "" {
-		cred, err = req.GatewayClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", catalogID, existing.Name)}, existing.Name)
-	} else if workspaceID != "" {
-		cred, err = req.GatewayClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", workspaceID, existing.Name)}, existing.Name)
-	} else {
-		cred, err = req.GatewayClient.RevealCredential(req.Context(), []string{fmt.Sprintf("%s-%s", req.User.GetUID(), existing.Name)}, existing.Name)
-	}
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{existing.CredentialContext(req.User.GetUID())}, existing.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 		return fmt.Errorf("failed to find credential: %w", err)
 	}
@@ -1623,6 +1605,10 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 		return types.NewErrBadRequest("composite servers are no longer supported; use the migrated vMCP instance")
 	}
 
+	if mcpServer.Spec.VMCPComponentID != "" {
+		return types.NewErrBadRequest("cannot configure a server associated to a vMCP component")
+	}
+
 	// Add extracted env vars to the server definition
 	addExtractedEnvVars(&mcpServer)
 
@@ -1690,14 +1676,7 @@ func (m *MCPHandler) ConfigureServer(req api.Context) error {
 		}
 	}
 
-	var credCtx string
-	if catalogID != "" {
-		credCtx = fmt.Sprintf("%s-%s", catalogID, mcpServer.Name)
-	} else if workspaceID != "" {
-		credCtx = fmt.Sprintf("%s-%s", workspaceID, mcpServer.Name)
-	} else {
-		credCtx = fmt.Sprintf("%s-%s", req.User.GetUID(), mcpServer.Name)
-	}
+	credCtx := mcpServer.CredentialContext(req.User.GetUID())
 
 	// Allow for updating credentials. The only way to update a credential is to delete the existing one and recreate it.
 	if err := m.removeMCPServerAndCred(req.Context(), req.GatewayClient, mcpServer, []string{credCtx}); err != nil {
@@ -1848,17 +1827,14 @@ func (m *MCPHandler) DeconfigureServer(req api.Context) error {
 		return types.NewErrBadRequest("composite servers are no longer supported; use the migrated vMCP instance")
 	}
 
+	if mcpServer.Spec.VMCPComponentID != "" {
+		return types.NewErrBadRequest("cannot deconfigure server associated to vMCP component")
+	}
+
 	// Add extracted env vars to the server definition
 	addExtractedEnvVars(&mcpServer)
 
-	var credCtx string
-	if catalogID != "" {
-		credCtx = fmt.Sprintf("%s-%s", catalogID, mcpServer.Name)
-	} else if workspaceID != "" {
-		credCtx = fmt.Sprintf("%s-%s", workspaceID, mcpServer.Name)
-	} else {
-		credCtx = fmt.Sprintf("%s-%s", req.User.GetUID(), mcpServer.Name)
-	}
+	credCtx := mcpServer.CredentialContext(req.User.GetUID())
 
 	if err := m.removeMCPServerAndCred(req.Context(), req.GatewayClient, mcpServer, []string{credCtx}); err != nil {
 		return err
@@ -1888,14 +1864,7 @@ func (m *MCPHandler) Reveal(req api.Context) error {
 		return types.NewErrNotFound("MCP server not found")
 	}
 
-	var credCtx string
-	if catalogID != "" {
-		credCtx = fmt.Sprintf("%s-%s", catalogID, mcpServer.Name)
-	} else if workspaceID != "" {
-		credCtx = fmt.Sprintf("%s-%s", workspaceID, mcpServer.Name)
-	} else {
-		credCtx = fmt.Sprintf("%s-%s", req.User.GetUID(), mcpServer.Name)
-	}
+	credCtx := mcpServer.CredentialContext(req.User.GetUID())
 
 	// Return flat configuration
 	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credCtx}, mcpServer.Name)
@@ -2209,19 +2178,9 @@ func ConfigurationTargetForConnectID(req api.Context, id, serverURL, secretBindi
 }
 
 func credentialEnvForMCPServer(req api.Context, server v1.MCPServer, secretBindingAllowedLabel string) (map[string]string, error) {
-	var credCtxs []string
-	switch {
-	case server.Spec.MCPCatalogID != "":
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name))
-	case server.Spec.PowerUserWorkspaceID != "":
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name))
-	default:
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name))
-	}
-
 	addExtractedEnvVars(&server)
 
-	cred, err := req.GatewayClient.RevealCredential(req.Context(), credCtxs, server.Name)
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 		return nil, fmt.Errorf("failed to find credential: %w", err)
 	}
@@ -2256,6 +2215,9 @@ func convertOAuthMetadata(metadata *v1.OAuthMetadata) *types.OAuthMetadata {
 }
 
 func SlugForMCPServer(ctx context.Context, client kclient.Client, server v1.MCPServer, userID, catalogID, workspaceID string) (string, error) {
+	if server.Spec.VMCPID != "" || server.Spec.VMCPInstanceID != "" {
+		return server.Name, nil
+	}
 	var shouldHaveUnique bool
 	if workspaceID == "" && catalogID == "" && server.Spec.MCPServerCatalogEntryName != "" {
 		var serversWithEntryName v1.MCPServerList
@@ -2269,6 +2231,9 @@ func SlugForMCPServer(ctx context.Context, client kclient.Client, server v1.MCPS
 		}); err != nil {
 			return "", fmt.Errorf("failed to find MCP server catalog entry for server: %w", err)
 		}
+		serversWithEntryName.Items = slices.DeleteFunc(serversWithEntryName.Items, func(server v1.MCPServer) bool {
+			return server.Spec.VMCPID != "" || server.Spec.VMCPInstanceID != ""
+		})
 
 		slices.SortFunc(serversWithEntryName.Items, func(a, b v1.MCPServer) int {
 			return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
@@ -2323,11 +2288,7 @@ func (m *MCPHandler) ListServersFromAllSources(req api.Context) error {
 
 	var credCtxs []string
 	for _, server := range allowedServers {
-		if server.Spec.IsCatalogServer() {
-			credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name))
-		} else if server.Spec.IsPowerUserWorkspaceServer() {
-			credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name))
-		}
+		credCtxs = append(credCtxs, server.CredentialContext(server.Spec.UserID))
 	}
 
 	creds, err := req.GatewayClient.ListCredentials(req.Context(), gateway.ListCredentialsOptions{
@@ -2403,14 +2364,7 @@ func (m *MCPHandler) GetServerFromAllSources(req api.Context) error {
 	}
 
 	// Get credential context based on server scoping
-	var credCtxs []string
-	if server.Spec.IsCatalogServer() {
-		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)}
-	} else if server.Spec.IsPowerUserWorkspaceServer() {
-		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)}
-	}
-
-	cred, err := req.GatewayClient.RevealCredential(req.Context(), credCtxs, server.Name)
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 		return fmt.Errorf("failed to find credential: %w", err)
 	}
@@ -2776,16 +2730,7 @@ func (m *MCPHandler) RedeployWithK8sSettings(req api.Context) error {
 	}
 
 	// Get credential for server
-	var credCtxs []string
-	if server.Spec.MCPCatalogID != "" {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name))
-	} else if server.Spec.PowerUserWorkspaceID != "" {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name))
-	} else {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name))
-	}
-
-	cred, err := req.GatewayClient.RevealCredential(req.Context(), credCtxs, server.Name)
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 		return fmt.Errorf("failed to find credential: %w", err)
 	}
@@ -3008,6 +2953,10 @@ func (m *MCPHandler) UpdateURL(req api.Context) error {
 		return types.NewErrBadRequest("cannot update the URL for a multi-user MCP server; use the UpdateServer endpoint instead")
 	}
 
+	if mcpServer.Spec.VMCPComponentID != "" {
+		return types.NewErrBadRequest("cannot update the URL for a VMCP component")
+	}
+
 	if mcpServer.Spec.MCPServerCatalogEntryName == "" {
 		return types.NewErrBadRequest("this server does not have a catalog entry")
 	}
@@ -3112,6 +3061,9 @@ func (m *MCPHandler) TriggerUpdate(req api.Context) error {
 
 	if err := req.Get(&server, req.PathValue("mcp_server_id")); err != nil {
 		return err
+	}
+	if server.Spec.VMCPID != "" || server.Spec.VMCPInstanceID != "" {
+		return types.NewErrBadRequest("cannot trigger update for a vMCP component server; update the vMCP instead")
 	}
 
 	if !server.Spec.IsSingleUser() {

--- a/pkg/api/handlers/mcp_connect_resolution_test.go
+++ b/pkg/api/handlers/mcp_connect_resolution_test.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	"github.com/obot-platform/obot/pkg/mcp"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCatalogConnectIDExcludesVMCPComponents(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec v1.MCPServerSpec
+	}{
+		{
+			name: "vMCP",
+			spec: v1.MCPServerSpec{VMCPID: "vmcp1parent"},
+		},
+		{
+			name: "vMCP instance",
+			spec: v1.MCPServerSpec{VMCPInstanceID: "vmcpi1parent"},
+		},
+	} {
+		for _, existing := range []bool{false, true} {
+			name := "creates standalone"
+			if existing {
+				name = "selects standalone"
+			}
+			t.Run(tc.name+"/"+name, func(t *testing.T) {
+				entry := &v1.MCPServerCatalogEntry{
+					Name:      "entry",
+					Namespace: system.DefaultNamespace,
+					Spec: v1.MCPServerCatalogEntrySpec{Manifest: types.MCPServerCatalogEntryManifest{
+						Runtime:   types.RuntimeNPX,
+						NPXConfig: &types.NPXRuntimeConfig{Package: "test-package"},
+					}},
+				}
+				component := &v1.MCPServer{
+					Name:              "ms1component",
+					Namespace:         system.DefaultNamespace,
+					CreationTimestamp: metav1.NewTime(time.Unix(1, 0)),
+					Spec:              tc.spec,
+				}
+				component.Spec.UserID = "user"
+				component.Spec.MCPServerCatalogEntryName = entry.Name
+				standalone := &v1.MCPServer{
+					Name:              "ms1standalone",
+					Namespace:         system.DefaultNamespace,
+					CreationTimestamp: metav1.NewTime(time.Unix(2, 0)),
+					Spec: v1.MCPServerSpec{
+						UserID:                    "user",
+						MCPServerCatalogEntryName: entry.Name,
+					},
+				}
+				objects := []kclient.Object{entry, component}
+				if existing {
+					objects = append(objects, standalone)
+				}
+				storage := newFakeStorage(t, objects...)
+				ctx := api.Context{
+					Request: httptest.NewRequest(http.MethodGet, "/mcp-connect/entry", nil),
+					Storage: storage,
+					User:    testUser("user"),
+				}
+				server, instance, err := mcpServerOrInstanceFromConnectURL(ctx, entry.Name, "", mcp.ValidationOptions{})
+				require.NoError(t, err)
+				require.Empty(t, instance.Name)
+				require.NotEmpty(t, server.Name)
+				require.NotEqual(t, component.Name, server.Name)
+				require.Empty(t, server.Spec.VMCPID)
+				require.Empty(t, server.Spec.VMCPInstanceID)
+				if existing {
+					require.Equal(t, standalone.Name, server.Name)
+				}
+				slug, err := SlugForMCPServer(t.Context(), storage, server, "user", "", "")
+				require.NoError(t, err)
+				require.Equal(t, entry.Name, slug)
+				slug, err = SlugForMCPServer(t.Context(), storage, *component, "user", "", "")
+				require.NoError(t, err)
+				require.Equal(t, component.Name, slug)
+				require.Equal(t, []string{system.MCPConnectURL("https://obot.example.com", component.Name)}, component.ValidConnectURLs("https://obot.example.com"))
+			})
+		}
+	}
+}

--- a/pkg/api/handlers/mcp_credential_context_test.go
+++ b/pkg/api/handlers/mcp_credential_context_test.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/api"
+	gatewaytypes "github.com/obot-platform/obot/pkg/gateway/types"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/system"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func TestMCPServerCredentialScopeSelection(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		spec           v1.MCPServerSpec
+		wantRevealed   string
+		wantConfigured string
+	}{
+		{
+			name:           "personal",
+			wantRevealed:   "requester-token",
+			wantConfigured: "owner-token",
+		},
+		{
+			name: "vMCP from catalog",
+			spec: v1.MCPServerSpec{
+				MCPCatalogID: "catalog",
+				VMCPID:       "vmcp",
+			},
+			wantRevealed:   "vmcp-token",
+			wantConfigured: "vmcp-token",
+		},
+		{
+			name: "vMCP instance from catalog",
+			spec: v1.MCPServerSpec{
+				MCPCatalogID:   "catalog",
+				VMCPInstanceID: "instance",
+			},
+			wantRevealed:   "instance-token",
+			wantConfigured: "instance-token",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := v1.MCPServer{
+				Name:      "server",
+				Namespace: system.DefaultNamespace,
+				Spec:      tc.spec,
+			}
+			server.Spec.UserID = "owner"
+			server.Spec.Manifest.Config = []types.MCPConfig{{Key: "TOKEN"}}
+			gatewayClient := newHandlerTestGateway(t)
+			for _, owner := range []string{"owner", "requester", "catalog", "vmcp", "instance"} {
+				if err := gatewayClient.UpsertCredential(t.Context(), gatewaytypes.Credential{
+					Context: owner + "-server",
+					Name:    server.Name,
+					Secrets: map[string]string{"TOKEN": owner + "-token"},
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			request := httptest.NewRequest(http.MethodPost, "/api/mcp-servers/server/reveal", nil)
+			request.SetPathValue("mcp_server_id", server.Name)
+			request.SetPathValue("catalog_id", server.Spec.MCPCatalogID)
+			recorder := httptest.NewRecorder()
+			ctx := api.Context{
+				Request:        request,
+				ResponseWriter: recorder,
+				Storage:        newVMCPTestStorage(&server),
+				GatewayClient:  gatewayClient,
+				User:           &user.DefaultInfo{UID: "requester"},
+			}
+			if err := (&MCPHandler{}).Reveal(ctx); err != nil {
+				t.Fatal(err)
+			}
+			var revealed map[string]string
+			if err := json.NewDecoder(recorder.Body).Decode(&revealed); err != nil {
+				t.Fatal(err)
+			}
+			if revealed["TOKEN"] != tc.wantRevealed {
+				t.Fatalf("Reveal returned %v, want TOKEN=%q", revealed, tc.wantRevealed)
+			}
+			configured, err := credentialEnvForMCPServer(ctx, server, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if configured["TOKEN"] != tc.wantConfigured {
+				t.Fatalf("server configuration = %v, want TOKEN=%q", configured, tc.wantConfigured)
+			}
+		})
+	}
+}

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -225,6 +225,7 @@ func TestTriggerUpdateScope(t *testing.T) {
 		workspaceID     string
 		wantShutdown    bool
 		wantErrContains string
+		wantStatus      int
 	}
 
 	baseEntry := func(workspaceID string) *v1.MCPServerCatalogEntry {
@@ -310,6 +311,11 @@ func TestTriggerUpdateScope(t *testing.T) {
 				if tt.wantErrContains != "" {
 					require.Error(t, err)
 					assert.Contains(t, err.Error(), tt.wantErrContains)
+					if tt.wantStatus != 0 {
+						var httpErr *types.ErrHTTP
+						require.ErrorAs(t, err, &httpErr)
+						assert.Equal(t, tt.wantStatus, httpErr.Code)
+					}
 					return
 				}
 				require.NoError(t, err)
@@ -379,6 +385,28 @@ func TestTriggerUpdateScope(t *testing.T) {
 				}(),
 				entry:           baseEntry(""),
 				wantErrContains: "cannot trigger update on a component server",
+			},
+			{
+				name: "vMCP component server is rejected",
+				user: testUserWithRole("admin", types.GroupAdmin),
+				server: func() v1.MCPServer {
+					server := baseServer("creator")
+					server.Spec.VMCPID = "vmcp"
+					return server
+				}(),
+				wantErrContains: "update the vMCP instead",
+				wantStatus:      http.StatusBadRequest,
+			},
+			{
+				name: "vMCP instance component server is rejected",
+				user: testUser("owner"),
+				server: func() v1.MCPServer {
+					server := baseServer("owner")
+					server.Spec.VMCPInstanceID = "vmcp-instance"
+					return server
+				}(),
+				wantErrContains: "update the vMCP instead",
+				wantStatus:      http.StatusBadRequest,
 			},
 			{
 				name: "server without catalog entry is a no-op",

--- a/pkg/api/handlers/mcpcatalogs.go
+++ b/pkg/api/handlers/mcpcatalogs.go
@@ -539,15 +539,7 @@ func (h *MCPCatalogHandler) AdminListServersForEntryInCatalog(req api.Context) e
 			continue
 		}
 
-		var credCtx string
-		if server.Spec.IsCatalogServer() {
-			credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
-		} else if server.Spec.IsPowerUserWorkspaceServer() {
-			credCtx = fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
-		} else {
-			credCtx = fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)
-		}
-		cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credCtx}, server.Name)
+		cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 		if err != nil && !errors.As(err, &gclient.CredentialNotFoundError{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
 		}
@@ -665,15 +657,7 @@ func (h *MCPCatalogHandler) AdminListServersForAllEntriesInCatalog(req api.Conte
 
 	var items []types.MCPServer
 	for _, server := range filteredServers {
-		var credCtx string
-		if server.Spec.IsCatalogServer() {
-			credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
-		} else if server.Spec.IsPowerUserWorkspaceServer() {
-			credCtx = fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
-		} else {
-			credCtx = fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)
-		}
-		cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credCtx}, server.Name)
+		cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 		if err != nil && !errors.As(err, &gclient.CredentialNotFoundError{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
 		}
@@ -736,15 +720,7 @@ func (h *MCPCatalogHandler) ListServersForEntry(req api.Context) error {
 			continue
 		}
 
-		var credCtx string
-		if server.Spec.IsCatalogServer() {
-			credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
-		} else if server.Spec.IsPowerUserWorkspaceServer() {
-			credCtx = fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
-		} else {
-			credCtx = fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)
-		}
-		cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credCtx}, server.Name)
+		cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 		if err != nil && !errors.As(err, &gclient.CredentialNotFoundError{}) {
 			return fmt.Errorf("failed to find credential: %w", err)
 		}
@@ -798,15 +774,7 @@ func (h *MCPCatalogHandler) GetServerFromEntry(req api.Context) error {
 		return fmt.Errorf("failed to list servers: %w", err)
 	}
 
-	var credCtx string
-	if server.Spec.IsCatalogServer() {
-		credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
-	} else if server.Spec.IsPowerUserWorkspaceServer() {
-		credCtx = fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
-	} else {
-		credCtx = fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)
-	}
-	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{credCtx}, server.Name)
+	cred, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 	if err != nil && !errors.As(err, &gclient.CredentialNotFoundError{}) {
 		return fmt.Errorf("failed to find credential: %w", err)
 	}

--- a/pkg/api/handlers/poweruserworkspace.go
+++ b/pkg/api/handlers/poweruserworkspace.go
@@ -109,7 +109,7 @@ func (p *PowerUserWorkspaceHandler) ListAllServers(req api.Context) error {
 	// Build credential contexts for all filtered servers
 	credCtxs := make([]string, 0, len(filteredServers))
 	for _, server := range filteredServers {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name))
+		credCtxs = append(credCtxs, server.CredentialContext(server.Spec.UserID))
 	}
 
 	var credMap map[string]map[string]string
@@ -214,7 +214,7 @@ func (p *PowerUserWorkspaceHandler) ListAllServersForAllEntries(req api.Context)
 	// Build credential contexts for all filtered servers
 	credCtxs := make([]string, 0, len(filteredServers))
 	for _, server := range filteredServers {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name))
+		credCtxs = append(credCtxs, server.CredentialContext(server.Spec.UserID))
 	}
 
 	var credMap map[string]map[string]string

--- a/pkg/api/handlers/registry/handler.go
+++ b/pkg/api/handlers/registry/handler.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"cmp"
 	"fmt"
 	"net/http"
 	"slices"
@@ -249,7 +250,7 @@ func (h *Handler) collectAccessibleServersNoAuth(req api.Context, reverseDNS str
 	// Filter for wildcard ACR access and non-templates
 	for _, server := range serverList.Items {
 		// Skip templates and components
-		if server.Spec.Template || server.Spec.CompositeName != "" {
+		if server.Spec.Template || server.Spec.CompositeName != "" || server.Spec.VMCPComponentID != "" {
 			continue
 		}
 
@@ -269,7 +270,7 @@ func (h *Handler) collectAccessibleServersNoAuth(req api.Context, reverseDNS str
 		}
 
 		// Get credentials
-		credEnv := h.getCredentialsForServer(req, server, "", system.DefaultCatalog, "")
+		credEnv := h.getCredentialsForServer(req, server, server.Spec.UserID)
 
 		mergedCredEnv, err := mcp.MergeBoundCreds(req.Context(), req.LocalK8sClient, req.ObotNamespace, server.Spec.Manifest.Config, credEnv, h.secretBindingAllowedLabel)
 		if err != nil {
@@ -306,13 +307,13 @@ func (h *Handler) listPersonalServers(req api.Context, userID string) ([]v1.MCPS
 	// Filter out template and component servers
 	var servers []v1.MCPServer
 	for _, server := range serverList.Items {
-		if !server.Spec.Template && server.Spec.CompositeName == "" {
+		if !server.Spec.Template && server.Spec.CompositeName == "" && server.Spec.VMCPComponentID == "" {
 			servers = append(servers, server)
 		}
 	}
 
 	// Get credentials for all servers
-	credMap, err := h.getCredentialsForServers(req, servers, userID, "", "")
+	credMap, err := h.getCredentialsForServers(req, servers, userID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -377,7 +378,7 @@ func (h *Handler) listServersInCatalog(
 	var result []v1.MCPServer
 	for _, server := range serverList.Items {
 		// Skip templates and components
-		if server.Spec.Template || server.Spec.CompositeName != "" {
+		if server.Spec.Template || server.Spec.CompositeName != "" || server.Spec.VMCPComponentID != "" {
 			continue
 		}
 
@@ -395,7 +396,7 @@ func (h *Handler) listServersInCatalog(
 	}
 
 	// Get credentials
-	credMap, err := h.getCredentialsForServers(req, result, "", catalogID, "")
+	credMap, err := h.getCredentialsForServers(req, result, "")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -482,7 +483,7 @@ func (h *Handler) listServersInWorkspaces(
 
 		for _, server := range serverList.Items {
 			// Skip templates and components
-			if server.Spec.Template || server.Spec.CompositeName != "" {
+			if server.Spec.Template || server.Spec.CompositeName != "" || server.Spec.VMCPComponentID != "" {
 				continue
 			}
 
@@ -501,10 +502,10 @@ func (h *Handler) listServersInWorkspaces(
 		}
 	}
 
-	// Get credentials - for workspace servers, we need to pass workspace context
+	// Get credentials for each server.
 	credMap := make(map[string]map[string]string)
 	for _, server := range result {
-		credMap[server.Name] = h.getCredentialsForServer(req, server, "", "", server.Spec.PowerUserWorkspaceID)
+		credMap[server.Name] = h.getCredentialsForServer(req, server, server.Spec.UserID)
 	}
 
 	return result, credMap, nil
@@ -515,7 +516,7 @@ func (h *Handler) listServersInWorkspaces(
 func (h *Handler) getCredentialsForServers(
 	req api.Context,
 	servers []v1.MCPServer,
-	userID, catalogID, workspaceID string,
+	userID string,
 ) (map[string]map[string]string, error) {
 	if len(servers) == 0 {
 		return make(map[string]map[string]string), nil
@@ -524,8 +525,7 @@ func (h *Handler) getCredentialsForServers(
 	// Build credential contexts
 	credCtxs := make([]string, 0, len(servers))
 	for _, server := range servers {
-		ctx := h.buildCredentialContext(server, userID, catalogID, workspaceID)
-		credCtxs = append(credCtxs, ctx)
+		credCtxs = append(credCtxs, server.CredentialContext(cmp.Or(userID, server.Spec.UserID)))
 	}
 
 	// List credentials
@@ -555,34 +555,15 @@ func (h *Handler) getCredentialsForServers(
 func (h *Handler) getCredentialsForServer(
 	req api.Context,
 	server v1.MCPServer,
-	userID, catalogID, workspaceID string,
+	userID string,
 ) map[string]string {
-	ctx := h.buildCredentialContext(server, userID, catalogID, workspaceID)
-
-	revealed, err := req.GatewayClient.RevealCredential(req.Context(), []string{ctx}, server.Name)
+	revealed, err := req.GatewayClient.RevealCredential(req.Context(), []string{server.CredentialContext(userID)}, server.Name)
 	if err != nil {
 		// Return empty map if not found
 		return make(map[string]string)
 	}
 
 	return revealed.Secrets
-}
-
-func (h *Handler) buildCredentialContext(
-	server v1.MCPServer,
-	userID, catalogID, workspaceID string,
-) string {
-	// Follow pattern from pkg/api/handlers/mcp.go
-	if catalogID != "" {
-		return fmt.Sprintf("%s-%s", catalogID, server.Name)
-	}
-	if workspaceID != "" {
-		return fmt.Sprintf("%s-%s", workspaceID, server.Name)
-	}
-	if userID != "" {
-		return fmt.Sprintf("%s-%s", userID, server.Name)
-	}
-	return fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)
 }
 
 // Pagination and filtering helpers
@@ -752,7 +733,7 @@ func (h *Handler) findMCPServer(req api.Context, serverName, reverseDNS string) 
 	}
 
 	// Skip templates and components
-	if server.Spec.Template || server.Spec.CompositeName != "" {
+	if server.Spec.Template || server.Spec.CompositeName != "" || server.Spec.VMCPComponentID != "" {
 		return types.RegistryServerResponse{}, fmt.Errorf("server not found")
 	}
 
@@ -771,7 +752,7 @@ func (h *Handler) findMCPServer(req api.Context, serverName, reverseDNS string) 
 		if err != nil {
 			return types.RegistryServerResponse{}, fmt.Errorf("failed to generate slug")
 		}
-		credEnv = h.getCredentialsForServer(req, server, req.User.GetUID(), "", "")
+		credEnv = h.getCredentialsForServer(req, server, req.User.GetUID())
 	} else if server.Spec.MCPCatalogID != "" {
 		// Catalog server - check ACR
 		hasAccess, err := h.acrHelper.UserHasAccessToMCPServerInCatalog(
@@ -786,7 +767,7 @@ func (h *Handler) findMCPServer(req api.Context, serverName, reverseDNS string) 
 		if err != nil {
 			return types.RegistryServerResponse{}, fmt.Errorf("failed to generate slug")
 		}
-		credEnv = h.getCredentialsForServer(req, server, "", server.Spec.MCPCatalogID, "")
+		credEnv = h.getCredentialsForServer(req, server, server.Spec.UserID)
 	} else if server.Spec.PowerUserWorkspaceID != "" {
 		// Workspace server - check ACR
 		hasAccess, err := h.acrHelper.UserHasAccessToMCPServerInWorkspace(
@@ -802,7 +783,7 @@ func (h *Handler) findMCPServer(req api.Context, serverName, reverseDNS string) 
 		if err != nil {
 			return types.RegistryServerResponse{}, fmt.Errorf("failed to generate slug")
 		}
-		credEnv = h.getCredentialsForServer(req, server, "", "", server.Spec.PowerUserWorkspaceID)
+		credEnv = h.getCredentialsForServer(req, server, server.Spec.UserID)
 	} else {
 		return types.RegistryServerResponse{}, fmt.Errorf("server not found")
 	}

--- a/pkg/api/handlers/registry/vmcp_test.go
+++ b/pkg/api/handlers/registry/vmcp_test.go
@@ -1,0 +1,209 @@
+package registry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/obot-platform/obot/apiclient/types"
+	"github.com/obot-platform/obot/pkg/accesscontrolrule"
+	"github.com/obot-platform/obot/pkg/api"
+	gateway "github.com/obot-platform/obot/pkg/gateway/client"
+	gatewaydb "github.com/obot-platform/obot/pkg/gateway/db"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	storagescheme "github.com/obot-platform/obot/pkg/storage/scheme"
+	storageservices "github.com/obot-platform/obot/pkg/storage/services"
+	"github.com/obot-platform/obot/pkg/system"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	gocache "k8s.io/client-go/tools/cache"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type registryTestStorage struct{ kclient.WithWatch }
+
+func TestVMCPComponentsAreExcludedFromPersonalRegistryServers(t *testing.T) {
+	storage := newRegistryTestStorage(
+		registryOrdinaryServer("ms1ordinary", v1.MCPServerSpec{UserID: "user-1"}),
+		registryVMCPComponent("ms1shared", true, v1.MCPServerSpec{UserID: "user-1"}),
+		registryVMCPComponent("ms1dedicated", false, v1.MCPServerSpec{UserID: "user-1"}),
+	)
+
+	_, ctx := registryTestHandlerAndContext(t, storage)
+	servers, _, err := NewHandler(nil, "https://obot.example.com", false, "").listPersonalServers(ctx, "user-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 || servers[0].Name != "ms1ordinary" {
+		t.Fatalf("listPersonalServers() = %#v, want only ordinary server", servers)
+	}
+}
+
+func TestVMCPComponentsAreExcludedFromCatalogRegistryServers(t *testing.T) {
+	storage := newRegistryTestStorage(
+		registryOrdinaryServer("ms1ordinary", v1.MCPServerSpec{MCPCatalogID: system.DefaultCatalog}),
+		registryVMCPComponent("ms1shared", true, v1.MCPServerSpec{MCPCatalogID: system.DefaultCatalog}),
+		registryVMCPComponent("ms1dedicated", false, v1.MCPServerSpec{MCPCatalogID: system.DefaultCatalog}),
+	)
+
+	h, ctx := registryTestHandlerAndContext(t, storage)
+	servers, _, err := h.listServersInCatalog(ctx, system.DefaultCatalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 || servers[0].Name != "ms1ordinary" {
+		t.Fatalf("listServersInCatalog() = %#v, want only ordinary server", servers)
+	}
+}
+
+func TestVMCPComponentsAreExcludedFromWorkspaceRegistryServers(t *testing.T) {
+	const workspaceID = "puw1workspace"
+	storage := newRegistryTestStorage(
+		&v1.PowerUserWorkspace{ObjectMeta: registryObjectMeta(workspaceID)},
+		registryOrdinaryServer("ms1ordinary", v1.MCPServerSpec{PowerUserWorkspaceID: workspaceID, UserID: "user-1"}),
+		registryVMCPComponent("ms1shared", true, v1.MCPServerSpec{PowerUserWorkspaceID: workspaceID, UserID: "user-1"}),
+		registryVMCPComponent("ms1dedicated", false, v1.MCPServerSpec{PowerUserWorkspaceID: workspaceID, UserID: "user-1"}),
+	)
+
+	_, ctx := registryTestHandlerAndContext(t, storage)
+	servers, _, err := NewHandler(nil, "https://obot.example.com", false, "").listServersInWorkspaces(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 || servers[0].Name != "ms1ordinary" {
+		t.Fatalf("listServersInWorkspaces() = %#v, want only ordinary server", servers)
+	}
+}
+
+func TestVMCPComponentsAreExcludedFromUnauthenticatedRegistryServers(t *testing.T) {
+	storage := newRegistryTestStorage(
+		registryOrdinaryServer("ms1ordinary", v1.MCPServerSpec{MCPCatalogID: system.DefaultCatalog}),
+		registryVMCPComponent("ms1shared", true, v1.MCPServerSpec{MCPCatalogID: system.DefaultCatalog}),
+		registryVMCPComponent("ms1dedicated", false, v1.MCPServerSpec{MCPCatalogID: system.DefaultCatalog}),
+	)
+
+	h, ctx := registryTestHandlerAndContext(t, storage)
+	servers, err := h.collectAccessibleServersNoAuth(ctx, "com.example.obot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 || servers[0].Server.Name != "com.example.obot/ms1ordinary" {
+		t.Fatalf("collectAccessibleServersNoAuth() = %#v, want only ordinary server", servers)
+	}
+}
+
+func TestRegistryDirectLookupExcludesVMCPComponents(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		shared bool
+	}{
+		{
+			name:   "shared",
+			shared: true,
+		},
+		{
+			name: "dedicated",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := registryVMCPComponent("ms1"+tc.name, tc.shared, v1.MCPServerSpec{MCPCatalogID: system.DefaultCatalog})
+			h, ctx := registryTestHandlerAndContext(t, newRegistryTestStorage(server))
+			_, err := h.findMCPServer(ctx, server.Name, "com.example.obot")
+			if err == nil {
+				t.Fatal("findMCPServer() found a vMCP component")
+			}
+		})
+	}
+}
+
+func TestRegistryDirectLookupIncludesOrdinaryServer(t *testing.T) {
+	server := registryOrdinaryServer("ms1ordinary", v1.MCPServerSpec{UserID: "user-1"})
+	h, ctx := registryTestHandlerAndContext(t, newRegistryTestStorage(server))
+
+	got, err := h.findMCPServer(ctx, server.Name, "com.example.obot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Server.Name != "com.example.obot/ms1ordinary" {
+		t.Fatalf("findMCPServer() returned %q, want ordinary server", got.Server.Name)
+	}
+}
+
+func registryTestHandlerAndContext(t *testing.T, storage *registryTestStorage) (*Handler, api.Context) {
+	t.Helper()
+	services, err := storageservices.New(storageservices.Config{DSN: "sqlite://:memory:"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	database, err := gatewaydb.New(services.DB.DB, services.DB.SQLDB, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.AutoMigrate(); err != nil {
+		t.Fatal(err)
+	}
+	client := gateway.New(t.Context(), database, nil, nil, nil, nil, nil, time.Hour, 10, 0, 0, 0, false)
+	t.Cleanup(func() { _ = client.Close() })
+
+	indexer := gocache.NewIndexer(gocache.MetaNamespaceKeyFunc, gocache.Indexers{
+		"selectors": func(any) ([]string, error) { return []string{"*"}, nil },
+	})
+	if err := indexer.Add(&v1.AccessControlRule{
+		ObjectMeta: registryObjectMeta("acr1allow"),
+		Spec: v1.AccessControlRuleSpec{
+			MCPCatalogID: system.DefaultCatalog,
+			Manifest:     types.AccessControlRuleManifest{Subjects: []types.Subject{{Type: types.SubjectTypeSelector, ID: "*"}}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return NewHandler(accesscontrolrule.NewAccessControlRuleHelper(indexer, storage), "https://obot.example.com", false, ""), registryTestContext(storage, client)
+}
+
+func registryTestContext(storage *registryTestStorage, gatewayClient *gateway.Client) api.Context {
+	return api.Context{
+		Request:       httptest.NewRequest(http.MethodGet, "/v0.1/servers", nil),
+		Storage:       storage,
+		GatewayClient: gatewayClient,
+		User:          &user.DefaultInfo{UID: "user-1"},
+	}
+}
+
+func newRegistryTestStorage(objects ...kclient.Object) *registryTestStorage {
+	return &registryTestStorage{WithWatch: clientfake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(objects...).
+		WithIndex(&v1.MCPServerCatalogEntry{}, "spec.mcpCatalogName", func(object kclient.Object) []string {
+			return []string{object.(*v1.MCPServerCatalogEntry).Spec.MCPCatalogName}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.userID", func(object kclient.Object) []string {
+			return []string{object.(*v1.MCPServer).Spec.UserID}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.mcpCatalogID", func(object kclient.Object) []string {
+			return []string{object.(*v1.MCPServer).Spec.MCPCatalogID}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.powerUserWorkspaceID", func(object kclient.Object) []string {
+			return []string{object.(*v1.MCPServer).Spec.PowerUserWorkspaceID}
+		}).
+		Build()}
+}
+
+func registryVMCPComponent(name string, shared bool, spec v1.MCPServerSpec) *v1.MCPServer {
+	spec.VMCPComponentID = "component-1"
+	if shared {
+		spec.VMCPID = "vmcp1shared"
+	} else {
+		spec.VMCPInstanceID = "vmcpi1dedicated"
+	}
+	return &v1.MCPServer{ObjectMeta: registryObjectMeta(name), Spec: spec}
+}
+
+func registryOrdinaryServer(name string, spec v1.MCPServerSpec) *v1.MCPServer {
+	return &v1.MCPServer{ObjectMeta: registryObjectMeta(name), Spec: spec}
+}
+
+func registryObjectMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name, Namespace: system.DefaultNamespace}
+}

--- a/pkg/api/handlers/serverinstances.go
+++ b/pkg/api/handlers/serverinstances.go
@@ -169,6 +169,15 @@ func (h *ServerInstancesHandler) CreateServerInstance(req api.Context) error {
 }
 
 func (h *ServerInstancesHandler) DeleteServerInstance(req api.Context) error {
+	var mcpServerInstance v1.MCPServerInstance
+	if err := kclient.IgnoreNotFound(req.Get(&mcpServerInstance, req.PathValue("mcp_server_instance_id"))); err != nil {
+		return fmt.Errorf("failed to get MCP server instance: %v", err)
+	}
+
+	if mcpServerInstance.Spec.CompositeName != "" {
+		return types.NewErrBadRequest("cannot delete MCP server instance with associated to composite %q; delete the composite instead", mcpServerInstance.Spec.CompositeName)
+	}
+
 	return req.Delete(&v1.MCPServerInstance{
 		Name:      req.PathValue("mcp_server_instance_id"),
 		Namespace: req.Namespace(),

--- a/pkg/api/handlers/vmcp.go
+++ b/pkg/api/handlers/vmcp.go
@@ -88,8 +88,9 @@ func (h *VMCPHandler) Create(req api.Context) error {
 		GenerateName: system.VMCPPrefix,
 		Namespace:    req.Namespace(),
 		Spec: v1.VMCPSpec{
-			Manifest: manifest,
-			UserID:   userID,
+			Manifest:      manifest,
+			UserID:        userID,
+			CreatorUserID: req.User.GetUID(),
 		},
 	}
 	if err := req.Create(&vmcp); err != nil {

--- a/pkg/api/handlers/vmcp_test.go
+++ b/pkg/api/handlers/vmcp_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -33,6 +34,62 @@ type vmcpTestStorage struct {
 	onCreate  func(kclient.Object)
 	onUpdate  func(kclient.Object)
 	updateErr error
+}
+
+func TestVMCPHandlerRejectsProhibitedRequiredConfiguration(t *testing.T) {
+	for _, operation := range []string{"create", "update", "trigger update"} {
+		t.Run(operation, func(t *testing.T) {
+			entry := vmcpCatalogEntryForTest("entry")
+			entry.Spec.Manifest.Config = []types.MCPConfig{{
+				Key:      "TOKEN",
+				Required: true,
+			}}
+			manifest := testVMCPManifest()
+			manifest.Components[0].Configuration = []types.VMCPConfigurationPolicy{{
+				Key:    "TOKEN",
+				Policy: types.VMCPConfigurationPolicyProhibited,
+			}}
+			storage := newVMCPTestStorage(entry)
+			if operation != "create" {
+				manifest.Components[0].ID = "component-id"
+				manifest.Components[0].CatalogEntry.Manifest = entry.Spec.Manifest
+				if err := storage.Create(t.Context(), &v1.VMCP{
+					Name:      "vmcp1test",
+					Namespace: system.DefaultNamespace,
+					Spec:      v1.VMCPSpec{Manifest: manifest},
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			storage.onCreate = func(kclient.Object) { t.Fatal("rejected request created a resource") }
+			storage.onUpdate = func(kclient.Object) { t.Fatal("rejected request updated a resource") }
+			body, err := json.Marshal(manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := httptest.NewRequest(http.MethodPost, "/api/vmcps", bytes.NewReader(body))
+			request.SetPathValue("vmcp_id", "vmcp1test")
+			ctx := api.Context{
+				Request:       request,
+				Storage:       storage,
+				GatewayClient: newHandlerTestGateway(t),
+				User:          &user.DefaultInfo{UID: "admin", Groups: []string{types.GroupAdmin}},
+			}
+			handler := NewVMCPHandler(nil)
+			switch operation {
+			case "create":
+				err = handler.Create(ctx)
+			case "update":
+				err = handler.Update(ctx)
+			case "trigger update":
+				err = handler.TriggerUpdate(ctx)
+			}
+			var httpErr *types.ErrHTTP
+			if !errors.As(err, &httpErr) || httpErr.Code != http.StatusBadRequest || !strings.Contains(httpErr.Message, `required configuration "TOKEN" cannot be prohibited`) {
+				t.Fatalf("expected 400 for prohibited required configuration, got %v", err)
+			}
+		})
+	}
 }
 
 func (s *vmcpTestStorage) Create(ctx context.Context, obj kclient.Object, opts ...kclient.CreateOption) error {
@@ -200,8 +257,35 @@ func TestVMCPHandlerCreateAppliesScopeAndDefaults(t *testing.T) {
 	if personal.UserID != "user-1" {
 		t.Fatalf("administrator-created personal VMCP userID = %q, want user-1", personal.UserID)
 	}
+
 	if len(personal.Profiles) != 0 {
 		t.Fatalf("administrator-created personal VMCP profiles = %#v, want none", personal.Profiles)
+	}
+
+	for _, tc := range []struct {
+		vmcpID  string
+		creator string
+	}{
+		{
+			vmcpID:  created.ID,
+			creator: "user-1",
+		},
+		{
+			vmcpID:  shared.ID,
+			creator: "admin",
+		},
+		{
+			vmcpID:  personal.ID,
+			creator: "user-1",
+		},
+	} {
+		var persisted v1.VMCP
+		if err := storage.Get(t.Context(), kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: tc.vmcpID}, &persisted); err != nil {
+			t.Fatal(err)
+		}
+		if persisted.Spec.CreatorUserID != tc.creator {
+			t.Fatalf("VMCP %q creator = %q, want %q", tc.vmcpID, persisted.Spec.CreatorUserID, tc.creator)
+		}
 	}
 }
 

--- a/pkg/controller/handlers/cleanup/credentials.go
+++ b/pkg/controller/handlers/cleanup/credentials.go
@@ -33,17 +33,8 @@ func (c *Credentials) RemoveMCPCredentials(req router.Request, _ router.Response
 		return err
 	}
 
-	var credCtx string
-	if mcpServer.Spec.IsCatalogServer() {
-		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.MCPCatalogID, mcpServer.Name)
-	} else if mcpServer.Spec.IsPowerUserWorkspaceServer() {
-		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.PowerUserWorkspaceID, mcpServer.Name)
-	} else {
-		credCtx = fmt.Sprintf("%s-%s", mcpServer.Spec.UserID, mcpServer.Name)
-	}
-
 	creds, err := c.gatewayClient.ListCredentials(req.Ctx, gateway.ListCredentialsOptions{
-		CredentialContexts: []string{credCtx},
+		CredentialContexts: []string{mcpServer.CredentialContext(mcpServer.Spec.UserID)},
 	})
 	if err != nil {
 		return err

--- a/pkg/controller/handlers/compositemigration/migration.go
+++ b/pkg/controller/handlers/compositemigration/migration.go
@@ -228,7 +228,7 @@ func (h *Handler) buildVMCP(req router.Request, entry *v1.MCPServerCatalogEntry,
 			}
 			id = old.MCPServerID
 			catalogID = shared.Spec.MCPCatalogID
-			values, err = h.read(req.Ctx, serverCredentialContext(*shared), shared.Name)
+			values, err = h.read(req.Ctx, shared.CredentialContext(shared.Spec.UserID), shared.Name)
 			if err != nil {
 				return target, nil, nil, err
 			}
@@ -298,16 +298,6 @@ func (h *Handler) buildVMCP(req router.Request, entry *v1.MCPServerCatalogEntry,
 func flattenServer(server types.MCPServerManifest) (types.MCPServerCatalogEntryManifest, error) {
 	// Startup has already flattened stored server manifests.
 	return server.ConvertToCatalogEntry(), nil
-}
-
-func serverCredentialContext(server v1.MCPServer) string {
-	owner := server.Spec.UserID
-	if server.Spec.MCPCatalogID != "" {
-		owner = server.Spec.MCPCatalogID
-	} else if server.Spec.PowerUserWorkspaceID != "" {
-		owner = server.Spec.PowerUserWorkspaceID
-	}
-	return owner + "-" + server.Name
 }
 
 func (h *Handler) read(ctx context.Context, scope, name string) (map[string]string, error) {
@@ -397,7 +387,7 @@ func (h *Handler) migrateInstance(req router.Request, target v1.VMCP, parent *v1
 			if child.Spec.MCPServerCatalogEntryName != id {
 				continue
 			}
-			secret, err := h.read(req.Ctx, serverCredentialContext(child), child.Name)
+			secret, err := h.read(req.Ctx, child.CredentialContext(child.Spec.UserID), child.Name)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/handlers/mcpcatalog/usergroupchange.go
+++ b/pkg/controller/handlers/mcpcatalog/usergroupchange.go
@@ -57,9 +57,8 @@ func (h *Handler) deleteUnauthorizedServersForUser(ctx context.Context, client k
 			continue
 		}
 
-		// Skip composite servers that don't need access checks
-		if server.Spec.CompositeName != "" {
-			// Legacy project-scoped servers, anonymous servers, and composite servers
+		// Components are owned by their composite or vMCP instance, not live catalog access.
+		if server.Spec.CompositeName != "" || server.Spec.VMCPComponentID != "" {
 			continue
 		}
 

--- a/pkg/controller/handlers/mcpcatalog/usergroupchange_test.go
+++ b/pkg/controller/handlers/mcpcatalog/usergroupchange_test.go
@@ -1,0 +1,53 @@
+package mcpcatalog
+
+import (
+	"testing"
+
+	"github.com/obot-platform/obot/pkg/accesscontrolrule"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
+	"github.com/obot-platform/obot/pkg/storage/scheme"
+	"github.com/obot-platform/obot/pkg/system"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/tools/cache"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDeleteUnauthorizedServersForUserPreservesVMCPComponents(t *testing.T) {
+	entry := &v1.MCPServerCatalogEntry{
+		Name:      "entry",
+		Namespace: system.DefaultNamespace,
+		Spec: v1.MCPServerCatalogEntrySpec{
+			MCPCatalogName: system.DefaultCatalog,
+		},
+	}
+	standalone := &v1.MCPServer{
+		Name:      "standalone",
+		Namespace: system.DefaultNamespace,
+		Spec: v1.MCPServerSpec{
+			UserID:                    "1",
+			MCPServerCatalogEntryName: entry.Name,
+		},
+	}
+	component := standalone.DeepCopy()
+	component.Name = "component"
+	component.Spec.VMCPInstanceID = "vmcpi1dedicated"
+	component.Spec.VMCPComponentID = "one"
+	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+		WithIndex(&v1.MCPServer{}, "spec.userID", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.UserID}
+		}).WithObjects(entry, standalone, component).Build()
+	// No remaining ACR grants access to the live catalog entry.
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		"selectors":           cache.MetaNamespaceIndexFunc,
+		"catalog-entry-names": cache.MetaNamespaceIndexFunc,
+	})
+	h := &Handler{accessControlRuleHelper: accesscontrolrule.NewAccessControlRuleHelper(indexer, client)}
+	user := &userInfo{Info: &kuser.DefaultInfo{UID: "1"}}
+
+	require.NoError(t, h.deleteUnauthorizedServersForUser(t.Context(), client, system.DefaultNamespace, "1", user))
+	require.NoError(t, client.Get(t.Context(), kclient.ObjectKeyFromObject(component), &v1.MCPServer{}))
+	require.True(t, apierrors.IsNotFound(client.Get(t.Context(), kclient.ObjectKeyFromObject(standalone), &v1.MCPServer{})))
+}

--- a/pkg/controller/handlers/mcpserver/mcpserver.go
+++ b/pkg/controller/handlers/mcpserver/mcpserver.go
@@ -269,14 +269,7 @@ func ConfigurationHasDrifted(ctx context.Context, gatewayClient *gateway.Client,
 
 	serverManifest := server.Spec.Manifest
 	if len(staticKeys) > 0 {
-		credentialContext := server.Spec.UserID
-		if server.Spec.MCPCatalogID != "" {
-			credentialContext = server.Spec.MCPCatalogID
-		} else if server.Spec.PowerUserWorkspaceID != "" {
-			credentialContext = server.Spec.PowerUserWorkspaceID
-		}
-
-		credential, err := gatewayClient.RevealCredential(ctx, []string{fmt.Sprintf("%s-%s", credentialContext, server.Name)}, server.Name)
+		credential, err := gatewayClient.RevealCredential(ctx, []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 		if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 			return false, err
 		}
@@ -649,15 +642,7 @@ func (h *Handler) SyncOAuthMetadata(req router.Request, _ router.Response) error
 		return nil
 	}
 
-	var credCtxs []string
-	if server.Spec.IsCatalogServer() {
-		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)}
-	} else if server.Spec.IsPowerUserWorkspaceServer() {
-		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)}
-	} else {
-		credCtxs = []string{fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)}
-	}
-	cred, err := h.gatewayClient.RevealCredential(req.Ctx, credCtxs, server.Name)
+	cred, err := h.gatewayClient.RevealCredential(req.Ctx, []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 		return fmt.Errorf("failed to reveal credential: %w", err)
 	}

--- a/pkg/controller/handlers/mcpserver/vmcp.go
+++ b/pkg/controller/handlers/mcpserver/vmcp.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SyncVMCPConfiguration copies the configuration for a VMCP component into
-// the backward-compatible credential consumed by its MCPServer.
+// the configuration credential consumed by its MCPServer.
 func (h *Handler) SyncVMCPConfiguration(req router.Request, _ router.Response) error {
 	server := req.Object.(*v1.MCPServer)
 	if server.Spec.VMCPInstanceID == "" && server.Spec.VMCPID == "" {
@@ -80,7 +80,7 @@ func (h *Handler) SyncVMCPConfiguration(req router.Request, _ router.Response) e
 	}
 
 	if err := h.gatewayClient.UpsertCredential(req.Ctx, gatewaytypes.Credential{
-		Context: fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name),
+		Context: server.CredentialContext(server.Spec.UserID),
 		Name:    server.Name,
 		Secrets: mcpServerConfiguration(*component, staticConfiguration, userConfiguration),
 	}); err != nil {

--- a/pkg/controller/handlers/mcpserver/vmcp_test.go
+++ b/pkg/controller/handlers/mcpserver/vmcp_test.go
@@ -48,14 +48,14 @@ func TestMigratedConfigurationAndFixedValueRotation(t *testing.T) {
 	handler := &Handler{gatewayClient: gw}
 	req := router.Request{Ctx: t.Context(), Client: storage, Object: server}
 	require.NoError(t, handler.SyncVMCPConfiguration(req, nil))
-	credential, err := gw.RevealCredential(t.Context(), []string{"user-" + server.Name}, server.Name)
+	credential, err := gw.RevealCredential(t.Context(), []string{instance.Name + "-" + server.Name}, server.Name)
 	require.NoError(t, err)
 	require.Equal(t, "legacy-override", credential.Secrets["TOKEN"])
 	vmcp.Spec.StaticConfigurationHash = "rotated"
 	vmcp.Spec.ComponentStaticConfigurationHashes[component.ID] = "rotated"
 	require.NoError(t, storage.Update(t.Context(), vmcp))
 	require.NoError(t, handler.SyncVMCPConfiguration(req, nil))
-	credential, err = gw.RevealCredential(t.Context(), []string{"user-" + server.Name}, server.Name)
+	credential, err = gw.RevealCredential(t.Context(), []string{instance.Name + "-" + server.Name}, server.Name)
 	require.NoError(t, err)
 	require.Equal(t, "admin", credential.Secrets["TOKEN"], "fixed configuration must retire the legacy override")
 }
@@ -222,7 +222,7 @@ func TestSyncVMCPConfigurationCopiesComponentConfiguration(t *testing.T) {
 	}
 
 	credential, err := gatewayClient.RevealCredential(t.Context(),
-		[]string{fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)},
+		[]string{instance.Name + "-" + server.Name},
 		server.Name,
 	)
 	if err != nil {
@@ -298,7 +298,7 @@ func TestSyncVMCPConfigurationSkipsMatchingHashes(t *testing.T) {
 	}
 
 	_, err := gatewayClient.RevealCredential(t.Context(),
-		[]string{fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name)},
+		[]string{instance.Name + "-" + server.Name},
 		server.Name,
 	)
 	if !errors.As(err, &client.CredentialNotFoundError{}) {
@@ -346,7 +346,7 @@ func TestSyncVMCPSharedConfiguration(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	credential, err := gatewayClient.RevealCredential(t.Context(), []string{server.Spec.UserID + "-" + server.Name}, server.Name)
+	credential, err := gatewayClient.RevealCredential(t.Context(), []string{vmcp.Name + "-" + server.Name}, server.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +356,7 @@ func TestSyncVMCPSharedConfiguration(t *testing.T) {
 	if server.Status.VMCPStaticConfigurationHash != "new-hash" || server.Status.VMCPUserConfigurationHash != "" {
 		t.Fatal("wrong shared configuration hashes")
 	}
-	if _, err := gatewayClient.RevealCredential(t.Context(), []string{"1-" + stale.Name}, stale.Name); !errors.As(err, &client.CredentialNotFoundError{}) {
+	if _, err := gatewayClient.RevealCredential(t.Context(), []string{instance.Name + "-" + stale.Name}, stale.Name); !errors.As(err, &client.CredentialNotFoundError{}) {
 		t.Fatalf("obsolete instance credential was written: %v", err)
 	}
 }

--- a/pkg/controller/handlers/nanobotagent/nanobotagent.go
+++ b/pkg/controller/handlers/nanobotagent/nanobotagent.go
@@ -168,7 +168,7 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 		}
 
 		// Ensure credentials are up to date
-		if err := h.ensureCredentials(req.Ctx, req, resp, agent, mcpServerName); err != nil {
+		if err := h.ensureCredentials(req.Ctx, req, resp, agent, &existing); err != nil {
 			return fmt.Errorf("failed to ensure credentials: %w", err)
 		}
 
@@ -223,7 +223,7 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 	slog.Info("Created nanobot agent MCP server", "agent", agent.Name, "mcpServer", mcpServerName)
 
 	// Create credentials for the new server
-	if err := h.ensureCredentials(req.Ctx, req, resp, agent, mcpServerName); err != nil {
+	if err := h.ensureCredentials(req.Ctx, req, resp, agent, mcpServer); err != nil {
 		return fmt.Errorf("failed to create credentials: %w", err)
 	}
 
@@ -232,8 +232,9 @@ func (h *Handler) EnsureMCPServer(req router.Request, resp router.Response) erro
 
 // ensureCredentials ensures that the MCP server has credentials with API keys that are valid
 // and refreshes them when they are close to expiration.
-func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, resp router.Response, agent *v1.NanobotAgent, mcpServerName string) error {
-	credCtx := fmt.Sprintf("%s-%s", agent.Spec.UserID, mcpServerName)
+func (h *Handler) ensureCredentials(ctx context.Context, req router.Request, resp router.Response, agent *v1.NanobotAgent, mcpServer *v1.MCPServer) error {
+	mcpServerName := mcpServer.Name
+	credCtx := mcpServer.CredentialContext(agent.Spec.UserID)
 
 	llmModel, err := resolveModel(ctx, req.Client, req.Namespace, types.DefaultModelAliasTypeLLM)
 	if err != nil {
@@ -587,7 +588,9 @@ func preferredModelsForAlias(aliasName types.DefaultModelAliasType) []string {
 
 // deleteTokens revokes the API key and deletes the MCP token associated with the MCP server.
 func (h *Handler) deleteTokens(ctx context.Context, agent *v1.NanobotAgent, mcpServerName string) error {
-	credCtx := fmt.Sprintf("%s-%s", agent.Spec.UserID, mcpServerName)
+	// Agent servers are user-scoped and may already be deleted during cleanup.
+	mcpServer := v1.MCPServer{Name: mcpServerName}
+	credCtx := mcpServer.CredentialContext(agent.Spec.UserID)
 
 	// Retrieve the credential to get the API key ID
 	cred, err := h.gatewayClient.RevealCredential(ctx, []string{credCtx}, mcpServerName)

--- a/pkg/controller/handlers/secret/nanobotagent.go
+++ b/pkg/controller/handlers/secret/nanobotagent.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/obot-platform/nah/pkg/router"
 	gateway "github.com/obot-platform/obot/pkg/gateway/client"
+	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -34,7 +35,8 @@ func (h *Handler) UpdateNanobotAgentCreds(req router.Request, _ router.Response)
 		return nil
 	}
 
-	cred, err := h.gatewayClient.RevealCredential(req.Ctx, []string{fmt.Sprintf("%s-%s", userID, mcpServerID)}, mcpServerID)
+	mcpServer := v1.MCPServer{Name: mcpServerID}
+	cred, err := h.gatewayClient.RevealCredential(req.Ctx, []string{mcpServer.CredentialContext(userID)}, mcpServerID)
 	if err != nil {
 		if errors.As(err, &gateway.CredentialNotFoundError{}) {
 			return nil

--- a/pkg/controller/handlers/vmcp/vmcp.go
+++ b/pkg/controller/handlers/vmcp/vmcp.go
@@ -41,16 +41,19 @@ func EnsureMCPServers(req router.Request, _ router.Response) error {
 		if err != nil {
 			return err
 		}
+
 		servers = append(servers, v1.MCPServer{
 			Name:        name.SafeConcatName(system.MCPServerPrefix+vmcp.Name, component.ID),
 			Namespace:   vmcp.Namespace,
 			Annotations: map[string]string{v1.VMCPSnapshotDigestAnnotation: utils.Digest(component.CatalogEntry)},
 			Spec: v1.MCPServerSpec{
-				Manifest:         manifest,
-				UnsupportedTools: slices.Clone(component.CatalogEntry.UnsupportedTools),
-				UserID:           vmcp.Spec.UserID,
-				VMCPID:           vmcp.Name,
-				VMCPComponentID:  component.ID,
+				MCPCatalogID:              component.MCPCatalogID,
+				MCPServerCatalogEntryName: component.MCPServerCatalogEntryID,
+				Manifest:                  manifest,
+				UnsupportedTools:          slices.Clone(component.CatalogEntry.UnsupportedTools),
+				UserID:                    vmcp.Spec.CreatorUserID,
+				VMCPID:                    vmcp.Name,
+				VMCPComponentID:           component.ID,
 			},
 		})
 	}
@@ -73,9 +76,15 @@ func EnsureMCPServers(req router.Request, _ router.Response) error {
 			if current.Spec.VMCPID != vmcp.Name || current.Spec.VMCPInstanceID != "" || current.Spec.VMCPComponentID != server.Spec.VMCPComponentID {
 				return fmt.Errorf("MCPServer %q already exists with different VMCP ownership", server.Name)
 			}
-			if current.Annotations[v1.VMCPSnapshotDigestAnnotation] != server.Annotations[v1.VMCPSnapshotDigestAnnotation] {
+			if current.Annotations[v1.VMCPSnapshotDigestAnnotation] != server.Annotations[v1.VMCPSnapshotDigestAnnotation] ||
+				current.Spec.UserID != server.Spec.UserID ||
+				current.Spec.MCPCatalogID != server.Spec.MCPCatalogID ||
+				current.Spec.MCPServerCatalogEntryName != server.Spec.MCPServerCatalogEntryName {
 				current.Spec.Manifest = server.Spec.Manifest
 				current.Spec.UnsupportedTools = server.Spec.UnsupportedTools
+				current.Spec.UserID = server.Spec.UserID
+				current.Spec.MCPCatalogID = server.Spec.MCPCatalogID
+				current.Spec.MCPServerCatalogEntryName = server.Spec.MCPServerCatalogEntryName
 				if current.Annotations == nil {
 					current.Annotations = make(map[string]string, 1)
 				}

--- a/pkg/controller/handlers/vmcp/vmcp_test.go
+++ b/pkg/controller/handlers/vmcp/vmcp_test.go
@@ -14,11 +14,20 @@ import (
 )
 
 func TestSharingTransitions(t *testing.T) {
-	vmcp := &v1.VMCP{Name: "vmcp1shared", Namespace: "default", Spec: v1.VMCPSpec{Manifest: types.VMCPManifest{
-		Components: []types.VMCPComponent{{ID: "one", CatalogEntry: types.MCPServerCatalogEntrySnapshot{Manifest: types.MCPServerCatalogEntryManifest{
-			Name: "cached", Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com/mcp"},
-		}}}},
-	}}}
+	vmcp := &v1.VMCP{Name: "vmcp1shared", Namespace: "default", Spec: v1.VMCPSpec{
+		UserID:        "vmcp-owner",
+		CreatorUserID: "vmcp-creator",
+		Manifest: types.VMCPManifest{
+			Components: []types.VMCPComponent{{
+				ID:                      "one",
+				MCPCatalogID:            "catalog-one",
+				MCPServerCatalogEntryID: "entry-one",
+				CatalogEntry: types.MCPServerCatalogEntrySnapshot{Manifest: types.MCPServerCatalogEntryManifest{
+					Name: "cached", Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com/mcp"},
+				}},
+			}},
+		},
+	}}
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(vmcp).
 		WithIndex(&v1.MCPServer{}, "spec.vmcpID", func(o kclient.Object) []string { return []string{o.(*v1.MCPServer).Spec.VMCPID} }).
 		WithIndex(&v1.MCPServer{}, "spec.vmcpInstanceID", func(o kclient.Object) []string { return []string{o.(*v1.MCPServer).Spec.VMCPInstanceID} }).Build()
@@ -112,6 +121,9 @@ func TestSharingTransitions(t *testing.T) {
 			if server.Spec.Manifest.RemoteConfig.URL != "https://example.com/mcp" {
 				t.Fatal("snapshot not copied")
 			}
+			if server.Spec.VMCPID == vmcp.Name && (server.Spec.UserID != vmcp.Spec.CreatorUserID || server.Spec.MCPCatalogID != "catalog-one" || server.Spec.MCPServerCatalogEntryName != "entry-one") {
+				t.Fatalf("server linkage = %#v", server.Spec)
+			}
 		}
 		vmcp.Spec.Manifest.Components[0].CatalogEntry.Manifest.Name += "-updated"
 		if err := client.Update(t.Context(), vmcp); err != nil {
@@ -134,6 +146,52 @@ func TestSharingTransitions(t *testing.T) {
 				t.Fatal("existing component server did not adopt updated snapshot")
 			}
 		}
+	}
+}
+
+func TestEnsureMCPServersBackfillsComponentLinkage(t *testing.T) {
+	component := types.VMCPComponent{
+		ID:                      "one",
+		MCPCatalogID:            "catalog-one",
+		MCPServerCatalogEntryID: "entry-one",
+		CatalogEntry: types.MCPServerCatalogEntrySnapshot{Manifest: types.MCPServerCatalogEntryManifest{
+			Name: "cached", Runtime: types.RuntimeRemote, RemoteConfig: &types.RemoteCatalogConfig{FixedURL: "https://example.com/mcp"},
+		}},
+	}
+	vmcp := &v1.VMCP{Name: "vmcp1shared", Namespace: "default", Spec: v1.VMCPSpec{
+		UserID:        "vmcp-owner",
+		CreatorUserID: "vmcp-creator",
+		Manifest:      types.VMCPManifest{Components: []types.VMCPComponent{component}},
+	}}
+	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(vmcp).
+		WithIndex(&v1.MCPServer{}, "spec.vmcpID", func(o kclient.Object) []string { return []string{o.(*v1.MCPServer).Spec.VMCPID} }).Build()
+	req := router.Request{Ctx: t.Context(), Client: client, Object: vmcp}
+	if err := vmcphandler.EnsureMCPServers(req, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var servers v1.MCPServerList
+	if err := client.List(t.Context(), &servers); err != nil {
+		t.Fatal(err)
+	}
+	if len(servers.Items) != 1 {
+		t.Fatalf("servers = %#v", servers.Items)
+	}
+	server := servers.Items[0]
+	server.Spec.UserID = "stale-owner"
+	server.Spec.MCPCatalogID = "stale-catalog"
+	server.Spec.MCPServerCatalogEntryName = "stale-entry"
+	if err := client.Update(t.Context(), &server); err != nil {
+		t.Fatal(err)
+	}
+	if err := vmcphandler.EnsureMCPServers(req, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Get(t.Context(), kclient.ObjectKeyFromObject(&server), &server); err != nil {
+		t.Fatal(err)
+	}
+	if server.Spec.UserID != vmcp.Spec.CreatorUserID || server.Spec.MCPCatalogID != component.MCPCatalogID || server.Spec.MCPServerCatalogEntryName != component.MCPServerCatalogEntryID {
+		t.Fatalf("server linkage = %#v", server.Spec)
 	}
 }
 

--- a/pkg/controller/handlers/vmcpinstance/vmcpinstance.go
+++ b/pkg/controller/handlers/vmcpinstance/vmcpinstance.go
@@ -190,9 +190,13 @@ func (*Handler) EnsureMCPServers(req router.Request, _ router.Response) error {
 			if existing.Spec.VMCPInstanceID != instance.Name || existing.Spec.VMCPComponentID != server.Spec.VMCPComponentID {
 				return fmt.Errorf("MCPServer %q already exists with different VMCP ownership", server.Name)
 			}
-			if existing.Annotations[v1.VMCPSnapshotDigestAnnotation] != server.Annotations[v1.VMCPSnapshotDigestAnnotation] {
+			if existing.Annotations[v1.VMCPSnapshotDigestAnnotation] != server.Annotations[v1.VMCPSnapshotDigestAnnotation] ||
+				existing.Spec.UserID != server.Spec.UserID ||
+				existing.Spec.MCPServerCatalogEntryName != server.Spec.MCPServerCatalogEntryName {
 				existing.Spec.Manifest = server.Spec.Manifest
 				existing.Spec.UnsupportedTools = server.Spec.UnsupportedTools
+				existing.Spec.UserID = server.Spec.UserID
+				existing.Spec.MCPServerCatalogEntryName = server.Spec.MCPServerCatalogEntryName
 				if existing.Annotations == nil {
 					existing.Annotations = map[string]string{}
 				}
@@ -232,11 +236,12 @@ func mcpServerForComponent(instance *v1.VMCPInstance, component types.VMCPCompon
 		Namespace:   instance.Namespace,
 		Annotations: map[string]string{v1.VMCPSnapshotDigestAnnotation: utils.Digest(component.CatalogEntry)},
 		Spec: v1.MCPServerSpec{
-			Manifest:         manifest,
-			UnsupportedTools: slices.Clone(component.CatalogEntry.UnsupportedTools),
-			UserID:           instance.Spec.UserID,
-			VMCPInstanceID:   instance.Name,
-			VMCPComponentID:  component.ID,
+			MCPServerCatalogEntryName: component.MCPServerCatalogEntryID,
+			Manifest:                  manifest,
+			UnsupportedTools:          slices.Clone(component.CatalogEntry.UnsupportedTools),
+			UserID:                    instance.Spec.UserID,
+			VMCPInstanceID:            instance.Name,
+			VMCPComponentID:           component.ID,
 		},
 	}, nil
 }

--- a/pkg/controller/handlers/vmcpinstance/vmcpinstance_test.go
+++ b/pkg/controller/handlers/vmcpinstance/vmcpinstance_test.go
@@ -295,8 +295,9 @@ func TestEnsureMCPServersCreatesServersFromCachedComponents(t *testing.T) {
 				DisplayName: "Test VMCP",
 				Components: []types.VMCPComponent{
 					{
-						ID:   "component-one",
-						Name: "one",
+						ID:                      "component-one",
+						Name:                    "one",
+						MCPServerCatalogEntryID: "entry-one",
 						CatalogEntry: types.MCPServerCatalogEntrySnapshot{
 							Manifest: types.MCPServerCatalogEntryManifest{
 								Name:      "cached-npx",
@@ -313,8 +314,9 @@ func TestEnsureMCPServersCreatesServersFromCachedComponents(t *testing.T) {
 						},
 					},
 					{
-						ID:   "component-two",
-						Name: "two",
+						ID:                      "component-two",
+						Name:                    "two",
+						MCPServerCatalogEntryID: "entry-two",
 						CatalogEntry: types.MCPServerCatalogEntrySnapshot{
 							Manifest: types.MCPServerCatalogEntryManifest{
 								Name:    "cached-container",
@@ -378,6 +380,13 @@ func TestEnsureMCPServersCreatesServersFromCachedComponents(t *testing.T) {
 		if server.Spec.UserID != instance.Spec.UserID {
 			t.Errorf("server %q user = %q, want %q", server.Name, server.Spec.UserID, instance.Spec.UserID)
 		}
+		wantEntry := "entry-one"
+		if server.Spec.VMCPComponentID == "component-two" {
+			wantEntry = "entry-two"
+		}
+		if server.Spec.MCPServerCatalogEntryName != wantEntry {
+			t.Errorf("server %q catalog entry = %q, want %q", server.Name, server.Spec.MCPServerCatalogEntryName, wantEntry)
+		}
 	}
 
 	npxServer := serversByComponent["component-one"]
@@ -389,6 +398,19 @@ func TestEnsureMCPServersCreatesServersFromCachedComponents(t *testing.T) {
 	}
 	if len(npxServer.Spec.UnsupportedTools) != 1 || npxServer.Spec.UnsupportedTools[0] != "broken-tool" {
 		t.Fatalf("NPX server did not retain cached unsupported tools: %#v", npxServer.Spec.UnsupportedTools)
+	}
+	npxServer.Spec.MCPServerCatalogEntryName = "stale-entry"
+	if err := client.Update(t.Context(), &npxServer); err != nil {
+		t.Fatal(err)
+	}
+	if err := handler.EnsureMCPServers(req, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Get(t.Context(), kclient.ObjectKeyFromObject(&npxServer), &npxServer); err != nil {
+		t.Fatal(err)
+	}
+	if npxServer.Spec.MCPServerCatalogEntryName != "entry-one" {
+		t.Fatalf("NPX server catalog entry = %q, want entry-one", npxServer.Spec.MCPServerCatalogEntryName)
 	}
 
 	containerServer := serversByComponent["component-two"]

--- a/pkg/controller/migrate.go
+++ b/pkg/controller/migrate.go
@@ -167,14 +167,10 @@ func deleteToolReferenceOwnedModels(ctx context.Context, client kclient.Client) 
 }
 
 func mcpServerCredentialContext(server v1.MCPServer) string {
-	switch {
-	case server.Spec.MCPCatalogID != "":
-		return fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
-	case server.Spec.PowerUserWorkspaceID != "":
-		return fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
-	default:
-		return ""
+	if server.Spec.IsCatalogServer() || server.Spec.IsPowerUserWorkspaceServer() {
+		return server.CredentialContext(server.Spec.UserID)
 	}
+	return ""
 }
 
 func extractAndClearMCPServerConfigValues(manifest *types.MCPServerManifest) (map[string]string, bool) {

--- a/pkg/mcp/action.go
+++ b/pkg/mcp/action.go
@@ -195,6 +195,9 @@ func (sm *SessionManager) serverOrInstanceFromConnectURL(ctx context.Context, id
 		); err != nil {
 			return v1.MCPServer{}, v1.MCPServerInstance{}, err
 		}
+		servers.Items = slices.DeleteFunc(servers.Items, func(server v1.MCPServer) bool {
+			return server.Spec.VMCPID != "" || server.Spec.VMCPInstanceID != ""
+		})
 		if len(servers.Items) == 0 {
 			missingAdminConfig, err := sm.entryMissingAdminConfig(ctx, entry)
 			if err != nil {
@@ -269,19 +272,16 @@ func (sm *SessionManager) serverFromMCPServerInstance(ctx context.Context, insta
 
 	addExtractedEnvVars(&server)
 
-	var credCtx, scope string
+	var scope string
 	if server.Spec.MCPCatalogID != "" {
-		credCtx = fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name)
 		scope = server.Spec.MCPCatalogID
 	} else if server.Spec.PowerUserWorkspaceID != "" {
-		credCtx = fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name)
 		scope = server.Spec.PowerUserWorkspaceID
 	} else {
-		credCtx = fmt.Sprintf("%s-%s", instance.Spec.UserID, server.Name)
 		scope = instance.Spec.UserID
 	}
 
-	cred, err := sm.gatewayClient.RevealCredential(ctx, []string{credCtx}, server.Name)
+	cred, err := sm.gatewayClient.RevealCredential(ctx, []string{server.CredentialContext(instance.Spec.UserID)}, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 		return server, ServerConfig{}, nil, fmt.Errorf("failed to find credential: %w", err)
 	}
@@ -333,27 +333,20 @@ func (sm *SessionManager) serverConfigForAction(ctx context.Context, server v1.M
 		return ServerConfig{}, nil, types.NewErrBadRequest("mcp server %s needs to update its URL", server.Name)
 	}
 
-	var (
-		credCtxs []string
-		scope    string
-	)
+	var scope string
 	if server.Spec.VMCPID != "" {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name))
 		scope = server.Spec.VMCPID
 	} else if server.Spec.MCPCatalogID != "" {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.MCPCatalogID, server.Name))
 		scope = server.Spec.MCPCatalogID
 	} else if server.Spec.PowerUserWorkspaceID != "" {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.PowerUserWorkspaceID, server.Name))
 		scope = server.Spec.PowerUserWorkspaceID
 	} else {
-		credCtxs = append(credCtxs, fmt.Sprintf("%s-%s", server.Spec.UserID, server.Name))
 		scope = server.Spec.UserID
 	}
 
 	addExtractedEnvVars(&server)
 
-	cred, err := sm.gatewayClient.RevealCredential(ctx, credCtxs, server.Name)
+	cred, err := sm.gatewayClient.RevealCredential(ctx, []string{server.CredentialContext(server.Spec.UserID)}, server.Name)
 	if err != nil && !errors.As(err, &gateway.CredentialNotFoundError{}) {
 		return ServerConfig{}, nil, fmt.Errorf("failed to find credential: %w", err)
 	}

--- a/pkg/mcp/action_test.go
+++ b/pkg/mcp/action_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	v1 "github.com/obot-platform/obot/pkg/storage/apis/obot.obot.ai/v1"
@@ -10,6 +11,7 @@ import (
 	"github.com/obot-platform/obot/pkg/system"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -81,6 +83,120 @@ func TestServerOrInstanceFromConnectURLCreatesRemoteServerThatNeedsUserURL(t *te
 	require.NotNil(t, server.Spec.Manifest.RemoteConfig)
 	require.Equal(t, "api.example.com", server.Spec.Manifest.RemoteConfig.Hostname)
 	require.Empty(t, server.Spec.Manifest.RemoteConfig.URL)
+}
+
+func TestServerOrInstanceFromConnectURLIgnoresVMCPComponentServers(t *testing.T) {
+	const (
+		entryID = "catalog-entry"
+		userID  = "user-1"
+	)
+
+	entry := &v1.MCPServerCatalogEntry{
+		Name:      entryID,
+		Namespace: system.DefaultNamespace,
+		Spec: v1.MCPServerCatalogEntrySpec{Manifest: types.MCPServerCatalogEntryManifest{
+			Runtime: types.RuntimeRemote,
+			RemoteConfig: &types.RemoteCatalogConfig{
+				Hostname: "api.example.com",
+			},
+		}},
+	}
+
+	for _, component := range []*v1.MCPServer{
+		{
+			Name:      "ms1-vmcp-component",
+			Namespace: system.DefaultNamespace,
+			Spec: v1.MCPServerSpec{
+				MCPServerCatalogEntryName: entryID,
+				UserID:                    userID,
+				VMCPID:                    "vmcp1-test",
+			},
+		},
+		{
+			Name:      "ms1-vmcp-instance-component",
+			Namespace: system.DefaultNamespace,
+			Spec: v1.MCPServerSpec{
+				MCPServerCatalogEntryName: entryID,
+				UserID:                    userID,
+				VMCPInstanceID:            "vmcpi1-test",
+			},
+		},
+	} {
+		t.Run(component.Name, func(t *testing.T) {
+			storageClient := fake.NewClientBuilder().
+				WithScheme(storagescheme.Scheme).
+				WithObjects(entry.DeepCopy(), component).
+				WithIndex(&v1.MCPServer{}, "spec.mcpServerCatalogEntryName", func(obj kclient.Object) []string {
+					return []string{obj.(*v1.MCPServer).Spec.MCPServerCatalogEntryName}
+				}).
+				WithIndex(&v1.MCPServer{}, "spec.userID", func(obj kclient.Object) []string {
+					return []string{obj.(*v1.MCPServer).Spec.UserID}
+				}).
+				WithIndex(&v1.MCPServer{}, "spec.template", func(obj kclient.Object) []string {
+					return []string{strconv.FormatBool(obj.(*v1.MCPServer).Spec.Template)}
+				}).
+				WithIndex(&v1.MCPServer{}, "spec.compositeName", func(obj kclient.Object) []string {
+					return []string{obj.(*v1.MCPServer).Spec.CompositeName}
+				}).
+				Build()
+
+			server, instance, err := (&SessionManager{storageClient: storageClient}).serverOrInstanceFromConnectURL(t.Context(), entryID, userID)
+			require.NoError(t, err)
+			require.Empty(t, instance.Name)
+			require.NotEqual(t, component.Name, server.Name)
+			require.Empty(t, server.Spec.VMCPID)
+			require.Empty(t, server.Spec.VMCPInstanceID)
+		})
+	}
+}
+
+func TestServerOrInstanceFromConnectURLPrefersStandaloneServerOverVMCPComponent(t *testing.T) {
+	const (
+		entryID = "catalog-entry"
+		userID  = "user-1"
+	)
+
+	entry := &v1.MCPServerCatalogEntry{Name: entryID, Namespace: system.DefaultNamespace}
+	component := &v1.MCPServer{
+		Name:              "ms1-vmcp-component",
+		Namespace:         system.DefaultNamespace,
+		CreationTimestamp: metav1.NewTime(time.Unix(1, 0)),
+		Spec: v1.MCPServerSpec{
+			MCPServerCatalogEntryName: entryID,
+			UserID:                    userID,
+			VMCPID:                    "vmcp1-test",
+		},
+	}
+	standalone := &v1.MCPServer{
+		Name:              "ms1-standalone",
+		Namespace:         system.DefaultNamespace,
+		CreationTimestamp: metav1.NewTime(time.Unix(2, 0)),
+		Spec: v1.MCPServerSpec{
+			MCPServerCatalogEntryName: entryID,
+			UserID:                    userID,
+		},
+	}
+	storageClient := fake.NewClientBuilder().
+		WithScheme(storagescheme.Scheme).
+		WithObjects(entry, component, standalone).
+		WithIndex(&v1.MCPServer{}, "spec.mcpServerCatalogEntryName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.MCPServerCatalogEntryName}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.userID", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.UserID}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.template", func(obj kclient.Object) []string {
+			return []string{strconv.FormatBool(obj.(*v1.MCPServer).Spec.Template)}
+		}).
+		WithIndex(&v1.MCPServer{}, "spec.compositeName", func(obj kclient.Object) []string {
+			return []string{obj.(*v1.MCPServer).Spec.CompositeName}
+		}).
+		Build()
+
+	server, instance, err := (&SessionManager{storageClient: storageClient}).serverOrInstanceFromConnectURL(t.Context(), entryID, userID)
+	require.NoError(t, err)
+	require.Empty(t, instance.Name)
+	require.Equal(t, standalone.Name, server.Name)
 }
 
 func TestServerOrInstanceFromConnectURLRejectsResourcesAbovePersistedMaximum(t *testing.T) {

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver.go
@@ -145,6 +145,26 @@ type MCPServerList struct {
 	Items []MCPServer `json:"items"`
 }
 
+// CredentialContext scopes configuration to the owning vMCP, vMCP instance,
+// catalog, or workspace. Personal servers use the supplied user ID.
+func (in *MCPServer) CredentialContext(userID string) string {
+	var owner string
+	switch {
+	case in.Spec.VMCPID != "":
+		owner = in.Spec.VMCPID
+	case in.Spec.VMCPInstanceID != "":
+		owner = in.Spec.VMCPInstanceID
+	case in.Spec.IsCatalogServer():
+		owner = in.Spec.MCPCatalogID
+	case in.Spec.IsPowerUserWorkspaceServer():
+		owner = in.Spec.PowerUserWorkspaceID
+	default:
+		owner = userID
+	}
+
+	return owner + "-" + in.Name
+}
+
 func (in *MCPServer) Has(field string) (exists bool) {
 	return slices.Contains(in.FieldNames(), field)
 }
@@ -199,8 +219,8 @@ func (in *MCPServer) DeleteRefs() []Ref {
 		{ObjType: &VMCPInstance{}, Name: in.Spec.VMCPInstanceID},
 		{ObjType: &VMCP{}, Name: in.Spec.VMCPID},
 	}
-	if in.Spec.CompositeName == "" {
-		// Only garbage collect an MCP server when the catalog entry is deleted if it's not a component of a composite MCP server.
+	if in.Spec.CompositeName == "" && in.Spec.VMCPComponentID == "" {
+		// Only garbage collect an MCP server when the catalog entry is deleted if it's not a component of a composite or vMCP server.
 		// Component MCP servers get their manifest from the composite catalog entry instead.
 		refs = append(refs, Ref{ObjType: &MCPServerCatalogEntry{}, Name: in.Spec.MCPServerCatalogEntryName})
 	}
@@ -209,7 +229,7 @@ func (in *MCPServer) DeleteRefs() []Ref {
 
 func (in *MCPServer) ValidConnectURLs(base string) []string {
 	var urls []string
-	if in.Spec.IsSingleUser() {
+	if in.Spec.IsSingleUser() && in.Spec.VMCPID == "" && in.Spec.VMCPInstanceID == "" {
 		urls = append(urls, system.MCPConnectURL(base, in.Spec.MCPServerCatalogEntryName))
 	}
 	return append(urls, system.MCPConnectURL(base, in.Name))
@@ -228,7 +248,7 @@ func (s MCPServerSpec) IsOwnedBy(userID string) bool {
 
 // IsCatalogServer returns true if this server is owned by a catalog (admin-deployed multi-user server).
 func (s MCPServerSpec) IsCatalogServer() bool {
-	return s.MCPCatalogID != ""
+	return s.VMCPComponentID == "" && s.MCPCatalogID != ""
 }
 
 // IsPowerUserWorkspaceServer returns true if this server is owned by a PowerUserWorkspace.

--- a/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/mcpserver_test.go
@@ -4,6 +4,149 @@ import (
 	"testing"
 )
 
+func TestMCPServerDeleteRefsProtectsComponentsFromCatalogDeletion(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		spec        MCPServerSpec
+		wantCatalog bool
+	}{
+		{
+			name:        "standalone",
+			wantCatalog: true,
+		},
+		{
+			name: "composite component",
+			spec: MCPServerSpec{CompositeName: "ms1composite"},
+		},
+		{
+			name: "shared vMCP component",
+			spec: MCPServerSpec{
+				VMCPID:          "vmcp1shared",
+				VMCPComponentID: "one",
+			},
+		},
+		{
+			name: "dedicated vMCP component",
+			spec: MCPServerSpec{
+				VMCPInstanceID:  "vmcpi1dedicated",
+				VMCPComponentID: "one",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.spec.MCPServerCatalogEntryName = "mcpce1source"
+			server := MCPServer{Spec: tc.spec}
+			var catalog, composite, vmcp, instance string
+			for _, ref := range server.DeleteRefs() {
+				switch ref.ObjType.(type) {
+				case *MCPServerCatalogEntry:
+					catalog = ref.Name
+				case *MCPServer:
+					composite = ref.Name
+				case *VMCP:
+					vmcp = ref.Name
+				case *VMCPInstance:
+					instance = ref.Name
+				}
+			}
+			wantCatalog := ""
+			if tc.wantCatalog {
+				wantCatalog = tc.spec.MCPServerCatalogEntryName
+			}
+			if catalog != wantCatalog {
+				t.Errorf("catalog deletion reference = %q, want %q", catalog, wantCatalog)
+			}
+			if composite != tc.spec.CompositeName || vmcp != tc.spec.VMCPID || instance != tc.spec.VMCPInstanceID {
+				t.Errorf("component owner references were lost: composite=%q vmcp=%q instance=%q", composite, vmcp, instance)
+			}
+		})
+	}
+}
+
+func TestMCPServerCredentialContext(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		spec   MCPServerSpec
+		userID string
+		want   string
+	}{
+		{
+			name:   "personal uses supplied user",
+			spec:   MCPServerSpec{UserID: "owner"},
+			userID: "requester",
+			want:   "requester-server",
+		},
+		{
+			name: "catalog",
+			spec: MCPServerSpec{
+				UserID:       "owner",
+				MCPCatalogID: "catalog",
+			},
+			userID: "requester",
+			want:   "catalog-server",
+		},
+		{
+			name: "workspace",
+			spec: MCPServerSpec{
+				UserID:               "owner",
+				PowerUserWorkspaceID: "workspace",
+			},
+			userID: "requester",
+			want:   "workspace-server",
+		},
+		{
+			name: "vMCP takes precedence over catalog",
+			spec: MCPServerSpec{
+				UserID:       "owner",
+				MCPCatalogID: "catalog",
+				VMCPID:       "vmcp",
+			},
+			userID: "requester",
+			want:   "vmcp-server",
+		},
+		{
+			name: "vMCP instance takes precedence over workspace",
+			spec: MCPServerSpec{
+				UserID:               "owner",
+				PowerUserWorkspaceID: "workspace",
+				VMCPInstanceID:       "instance",
+			},
+			userID: "requester",
+			want:   "instance-server",
+		},
+		{
+			name: "vMCP instance takes precedence over catalog",
+			spec: MCPServerSpec{
+				MCPCatalogID:   "catalog",
+				VMCPInstanceID: "instance",
+			},
+			userID: "requester",
+			want:   "instance-server",
+		},
+		{
+			name: "vMCP does not require a user",
+			spec: MCPServerSpec{
+				UserID:       "owner",
+				MCPCatalogID: "catalog",
+				VMCPID:       "vmcp",
+			},
+			want: "vmcp-server",
+		},
+		{
+			name: "personal empty user remains empty",
+			spec: MCPServerSpec{UserID: "owner"},
+			want: "-server",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := MCPServer{Name: "server", Spec: tc.spec}
+			if got := server.CredentialContext(tc.userID); got != tc.want {
+				t.Fatalf("CredentialContext(%q) = %q, want %q", tc.userID, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMCPServerSpec_IsCatalogServer(t *testing.T) {
 	if (MCPServerSpec{MCPCatalogID: "default"}).IsCatalogServer() != true {
 		t.Error("expected true for catalog server")

--- a/pkg/storage/apis/obot.obot.ai/v1/vmcp.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/vmcp.go
@@ -33,7 +33,9 @@ type VMCPSpec struct {
 	LegacySlug string             `json:"legacySlug,omitempty"`
 	Manifest   types.VMCPManifest `json:"manifest"`
 	// UserID is set for a personal VMCP and empty for an administrator-created shared VMCP.
-	UserID                  string `json:"userID,omitempty"`
+	UserID string `json:"userID,omitempty"`
+	// CreatorUserID is the user ID of the user who created the VMCP. It is used to determine which admin created a server.
+	CreatorUserID           string `json:"creatorUserID,omitempty"`
 	StaticConfigurationHash string `json:"staticConfigurationHash,omitempty"`
 	// ComponentStaticConfigurationHashes retire migrated overrides only for the changed component.
 	ComponentStaticConfigurationHashes map[string]string `json:"componentStaticConfigurationHashes,omitempty"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -29564,6 +29564,13 @@ func schema_storage_apis_obotobotai_v1_VMCPSpec(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"creatorUserID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CreatorUserID is the user ID of the user who created the VMCP. It is used to determine which admin created a server.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"staticConfigurationHash": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},


### PR DESCRIPTION
These extra fields allow them to be exposed in the Deployments tab in the UI.

Issue: https://github.com/obot-platform/obot/issues/7818