### PR TITLE
fix: skip hidden catalog directories and support include paths

### DIFF
--- a/docs/docs/configuration/mcp-server-gitops.md
+++ b/docs/docs/configuration/mcp-server-gitops.md
@@ -55,6 +55,54 @@ To pull from a private repository, enter a **Personal access token** in the opti
 
 If no per-URL token is configured, Obot falls back to the `GITHUB_AUTH_TOKEN` environment variable.
 
+## Selecting Catalog Files
+
+Obot recursively scans for `*.json`, `*.yaml`, and `*.yml` files. Hidden child directories such as `.git` and `.github` are always skipped, so GitHub Actions workflows can live alongside catalog entries. Keep catalog entries outside hidden directories.
+
+To customize discovery, add these files at the catalog repository root. Both accept one pattern per line, ignoring blank lines and `#` comments.
+
+### `.obotcatalogs`: include files
+
+A nonempty pattern list replaces the defaults. Patterns without `/` match filenames at any depth; patterns with `/` match paths relative to the catalog root:
+
+```text
+# Matching filenames anywhere in the repository
+*.mcp.yaml
+
+# YAML files directly inside servers/
+servers/*.yaml
+```
+
+### `.ignoreobotcatalogs`: exclude files or directories
+
+Patterns match root-relative paths and override includes. Matching a directory excludes its entire subtree:
+
+```text
+scripts
+renovate.json
+.pre-commit-config.yaml
+```
+
+Wildcards do not cross `/`, and `**` is not recursive. To exclude a whole directory tree, list the directory itself. Include patterns must match files; a bare directory does not include its contents.
+
+## Validating Catalog Entries
+
+With the `obot` CLI installed, run this from your catalog repository root before pushing changes:
+
+```sh
+obot mcp validate-catalog-yaml .
+```
+
+Directory validation uses the same file-selection rules as catalog sync, including both pattern files and hidden-directory skipping. It checks the selected catalog entries and exits with an error if validation fails, making it suitable for CI.
+
+You can also validate individual files:
+
+```sh
+obot mcp validate-catalog-yaml servers/github.yaml
+```
+
+Explicit file arguments are validated directly, without applying directory filters.
+
 ## Configuration Format
 
 MCP server configurations consist of individual YAML files, each defining a single MCP server. These files contain comprehensive metadata including:

--- a/pkg/cli/mcp_convert_test.go
+++ b/pkg/cli/mcp_convert_test.go
@@ -159,7 +159,7 @@ remoteConfig:
 func TestMCPConvertCatalogDirectory(t *testing.T) {
 	dir := t.TempDir()
 	legacy := []byte("name: Example\nruntime: npx\nserverUserType: singleUser\nenv:\n  - key: TOKEN\n")
-	for _, name := range []string{"entry.yaml", "nested/entry.yml", "ignored/entry.yaml", "skip.yaml", ".git/entry.yaml", "other.yaml", "entry.json"} {
+	for _, name := range []string{"entry.yaml", "nested/entry.yml", "ignored/entry.yaml", "skip.yaml", ".git/entry.yaml", ".github/workflows/entry.yaml", "other.yaml", "entry.json"} {
 		path := filepath.Join(dir, name)
 		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
 		require.NoError(t, os.WriteFile(path, legacy, 0o600))
@@ -175,7 +175,7 @@ func TestMCPConvertCatalogDirectory(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, string(data), "usage: env")
 	}
-	for _, name := range []string{"ignored/entry.yaml", "skip.yaml", ".git/entry.yaml", "other.yaml", "entry.json", "nested/entry.yaml"} {
+	for _, name := range []string{"ignored/entry.yaml", "skip.yaml", ".git/entry.yaml", ".github/workflows/entry.yaml", "other.yaml", "entry.json", "nested/entry.yaml"} {
 		data, err := os.ReadFile(filepath.Join(dir, name))
 		require.NoError(t, err)
 		require.Equal(t, legacy, data, name)

--- a/pkg/cli/mcp_test.go
+++ b/pkg/cli/mcp_test.go
@@ -207,6 +207,14 @@ remoteConfig:
 		t.Fatal(err)
 	}
 
+	workflowDir := filepath.Join(dir, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowDir, "ci.yml"), []byte("name: Validate catalog\non: push\njobs: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
 	stdout, err := executeMCPTestCommand(t, mcpTestRoot("http://unused.example"), "validate-catalog-yaml", dir, path)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/controller/handlers/mcpcatalog/strict_decode_test.go
+++ b/pkg/controller/handlers/mcpcatalog/strict_decode_test.go
@@ -99,3 +99,25 @@ npxConfig:
 	require.ErrorContains(t, err, "legacy.yaml")
 	require.Len(t, objects, 1)
 }
+
+func TestReadMCPCatalogSkipsGitHubWorkflows(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "valid.yaml"), []byte(`name: Valid
+entryKey: valid
+shortDescription: Test
+description: Test
+icon: icon
+runtime: npx
+npxConfig:
+  package: test
+`), 0o600))
+
+	workflowDir := filepath.Join(dir, ".github", "workflows")
+	require.NoError(t, os.MkdirAll(workflowDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(workflowDir, "ci.yml"), []byte("name: Validate catalog\non: push\njobs: {}\n"), 0o600))
+
+	h := &Handler{}
+	objects, err := h.readMCPCatalog(t.Context(), "default", dir, "")
+	require.NoError(t, err)
+	require.Len(t, objects, 1)
+}

--- a/pkg/mcpcatalog/walker.go
+++ b/pkg/mcpcatalog/walker.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -133,9 +134,11 @@ func readCatalogPatterns(path string, defaults []string) ([]string, bool) {
 	return patterns, true
 }
 
-func matchesCatalogPattern(patterns []string, path string) bool {
+func matchesCatalogPattern(patterns []string, candidate string) bool {
+	// Catalog patterns use forward slashes on every platform.
+	candidate = filepath.ToSlash(candidate)
 	for _, pattern := range patterns {
-		if matched, _ := filepath.Match(pattern, path); matched {
+		if matched, _ := path.Match(pattern, candidate); matched {
 			return true
 		}
 	}

--- a/pkg/mcpcatalog/walker.go
+++ b/pkg/mcpcatalog/walker.go
@@ -18,7 +18,8 @@ const (
 )
 
 // WalkCatalogFiles returns catalog manifest paths selected by .obotcatalogs and
-// .ignoreobotcatalogs. Traversal errors are yielded in the second value.
+// .ignoreobotcatalogs, skipping hidden child directories. Traversal errors are
+// yielded in the second value.
 func WalkCatalogFiles(root string) (iter.Seq2[string, error], bool, error) {
 	patterns, usingObotCatalogsFile := catalogPatterns(root)
 	ignorePatterns, _ := readCatalogPatterns(filepath.Join(root, ".ignoreobotcatalogs"), nil)
@@ -33,14 +34,19 @@ func WalkCatalogFiles(root string) (iter.Seq2[string, error], bool, error) {
 				return err
 			}
 			if entry.IsDir() {
-				if relPath == ".git" || strings.HasPrefix(relPath, ".git"+string(filepath.Separator)) || matchesCatalogPattern(ignorePatterns, relPath) {
+				if relPath != "." && strings.HasPrefix(entry.Name(), ".") || matchesCatalogPattern(ignorePatterns, relPath) {
 					return filepath.SkipDir
 				}
+
 				return nil
 			}
-			if !matchesCatalogPattern(patterns, filepath.Base(relPath)) || matchesCatalogPattern(ignorePatterns, relPath) {
+
+			// Basename patterns apply at any depth; path patterns are relative to root.
+			included := matchesCatalogPattern(patterns, filepath.Base(relPath)) || matchesCatalogPattern(patterns, relPath)
+			if !included || matchesCatalogPattern(ignorePatterns, relPath) {
 				return nil
 			}
+
 			info, err := os.Lstat(path)
 			if err != nil {
 				slog.Warn("Skipping unsafe file, failed to get file info", "path", relPath, "error", err)

--- a/pkg/mcpcatalog/walker_test.go
+++ b/pkg/mcpcatalog/walker_test.go
@@ -2,6 +2,7 @@ package mcpcatalog
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +28,124 @@ func TestWalkCatalogFilesSkipsSymlinksAndIgnoredFiles(t *testing.T) {
 		paths = append(paths, path)
 	}
 	require.Equal(t, []string{validPath}, paths)
+}
+
+func TestWalkCatalogFilesSkipsHiddenDirectories(t *testing.T) {
+	for _, customPatterns := range []bool{false, true} {
+		t.Run(fmt.Sprintf("customPatterns=%t", customPatterns), func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), ".catalog")
+			for _, name := range []string{
+				"valid.yaml", "nested/valid.yml", "nested/deeper/valid.json",
+				".github/workflows/ci.yml", ".git/config.yaml", ".config/entry.json",
+				"nested/.hidden/entry.yaml", ".pre-commit-config.yaml",
+			} {
+				path := filepath.Join(dir, name)
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+				require.NoError(t, os.WriteFile(path, []byte("name: Test\n"), 0o600))
+			}
+
+			if customPatterns {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, ".obotcatalogs"), []byte("*.yaml\n*.yml\n*.json\n"), 0o600))
+			}
+
+			t.Chdir(dir)
+			for _, root := range []string{dir, "."} {
+				files, usingPatterns, err := WalkCatalogFiles(root)
+				require.NoError(t, err)
+				require.Equal(t, customPatterns, usingPatterns)
+
+				var paths []string
+				for path, err := range files {
+					require.NoError(t, err)
+
+					rel, err := filepath.Rel(root, path)
+					require.NoError(t, err)
+					paths = append(paths, filepath.ToSlash(rel))
+				}
+
+				require.ElementsMatch(t, []string{"valid.yaml", "nested/valid.yml", "nested/deeper/valid.json", ".pre-commit-config.yaml"}, paths)
+			}
+		})
+	}
+}
+
+func TestWalkCatalogFilesPatternSemantics(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		includes string
+		ignores  string
+		want     []string
+	}{
+		{
+			name:    "default patterns and directory exclusions",
+			ignores: "# Repository metadata\n\n scripts \nrenovate.json\n.pre-commit-config.yaml\n",
+			want:    []string{"entry.mcp.yaml", "nested/entry.mcp.yaml", "other.yml"},
+		},
+		{
+			name:     "includes replace defaults and match basenames",
+			includes: "# Catalog manifests\n\n *.mcp.yaml \n",
+			ignores:  "scripts\nnested/entry.mcp.yaml\n",
+			want:     []string{"entry.mcp.yaml"},
+		},
+		{
+			name:     "root-relative directory glob",
+			includes: "nested/*.yaml\n",
+			want:     []string{"nested/entry.mcp.yaml"},
+		},
+		{
+			name:     "exact nested file",
+			includes: "scripts/deep/more/entry.mcp.yaml\n",
+			want:     []string{"scripts/deep/more/entry.mcp.yaml"},
+		},
+		{
+			name:     "mixed basename and path patterns",
+			includes: "*.yml\nnested/*.yaml\n",
+			want:     []string{"other.yml", "nested/entry.mcp.yaml"},
+		},
+		{
+			name:     "exclusions override path includes",
+			includes: "nested/*.yaml\nscripts/deep/more/*.yaml\n",
+			ignores:  "nested/entry.mcp.yaml\nscripts\n",
+		},
+		{
+			name:     "include wildcards do not cross separators",
+			includes: "scripts/*.yaml\nscripts/**/entry.mcp.yaml\n",
+		},
+		{
+			name:     "double star does not cross separators",
+			includes: "*.mcp.yaml\n",
+			ignores:  "scripts/**/entry.mcp.yaml\n",
+			want:     []string{"entry.mcp.yaml", "nested/entry.mcp.yaml", "scripts/deep/more/entry.mcp.yaml"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, name := range []string{"entry.mcp.yaml", "nested/entry.mcp.yaml", "scripts/deep/more/entry.mcp.yaml", "other.yml", "renovate.json", ".pre-commit-config.yaml"} {
+				path := filepath.Join(dir, name)
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+				require.NoError(t, os.WriteFile(path, nil, 0o600))
+			}
+
+			if tt.includes != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, ".obotcatalogs"), []byte(tt.includes), 0o600))
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(dir, ".ignoreobotcatalogs"), []byte(tt.ignores), 0o600))
+
+			files, _, err := WalkCatalogFiles(dir)
+			require.NoError(t, err)
+
+			var paths []string
+			for path, err := range files {
+				require.NoError(t, err)
+
+				rel, err := filepath.Rel(dir, path)
+				require.NoError(t, err)
+				paths = append(paths, filepath.ToSlash(rel))
+			}
+
+			require.ElementsMatch(t, tt.want, paths)
+		})
+	}
 }
 
 func TestWalkCatalogFilesFallsBackWhenPatternFilesCannotBeRead(t *testing.T) {

--- a/pkg/mcpcatalog/walker_test.go
+++ b/pkg/mcpcatalog/walker_test.go
@@ -108,6 +108,18 @@ func TestWalkCatalogFilesPatternSemantics(t *testing.T) {
 			ignores:  "nested/entry.mcp.yaml\nscripts\n",
 		},
 		{
+			name:     "root-relative directory exclusion",
+			includes: "*.mcp.yaml\n",
+			ignores:  "scripts/deep\n",
+			want:     []string{"entry.mcp.yaml", "nested/entry.mcp.yaml"},
+		},
+		{
+			name:     "root-relative file glob exclusion",
+			includes: "*.mcp.yaml\n",
+			ignores:  "nested/*.yaml\nscripts/deep/more/*.yaml\n",
+			want:     []string{"entry.mcp.yaml"},
+		},
+		{
 			name:     "include wildcards do not cross separators",
 			includes: "scripts/*.yaml\nscripts/**/entry.mcp.yaml\n",
 		},


### PR DESCRIPTION
GitHub Actions workflows could be selected as catalog entries and cause catalog source errors. Skip hidden child directories during catalog discovery, and support root-relative include patterns such as `servers/*.yaml` in `.obotcatalogs` while preserving basename matching at any depth.

Document include/exclude patterns and CLI validation, with regression coverage for catalog loading, validation, and conversion.

addresses #7549
