### PR TITLE
fix: disallow basic users for setting profiles on vMCP

### DIFF
--- a/apiclient/types/vmcp.go
+++ b/apiclient/types/vmcp.go
@@ -207,10 +207,12 @@ type VMCPInstanceStatus struct {
 type VMCPInstanceList List[VMCPInstance]
 
 // Default fills secure defaults that are omitted by clients.
-func (m *VMCPManifest) Default() {
+func (m *VMCPManifest) Default(personalServer bool) {
 	m.DefaultConfigurationPolicies()
 
-	if m.Profiles == nil {
+	if personalServer {
+		m.Profiles = nil
+	} else if m.Profiles == nil {
 		m.Profiles = []VMCPProfile{{
 			Name:          "default",
 			Subjects:      []Subject{{Type: SubjectTypeSelector, ID: "*"}},

--- a/apiclient/types/vmcp_test.go
+++ b/apiclient/types/vmcp_test.go
@@ -77,7 +77,7 @@ func TestVMCPManifestDefault(t *testing.T) {
 		}},
 	}
 
-	manifest.Default()
+	manifest.Default(false)
 
 	if got := manifest.Components[0].Configuration[0].Policy; got != VMCPConfigurationPolicyProhibited {
 		t.Fatalf("default configuration policy = %q, want %q", got, VMCPConfigurationPolicyProhibited)
@@ -97,10 +97,30 @@ func TestVMCPManifestDefault(t *testing.T) {
 func TestVMCPManifestDefaultPreservesExplicitEmptyProfiles(t *testing.T) {
 	manifest := VMCPManifest{Profiles: []VMCPProfile{}}
 
-	manifest.Default()
+	manifest.Default(false)
 
 	if manifest.Profiles == nil || len(manifest.Profiles) != 0 {
 		t.Fatalf("explicit empty profiles changed to %#v", manifest.Profiles)
+	}
+}
+
+func TestVMCPManifestDefaultPersonalServer(t *testing.T) {
+	for _, profiles := range [][]VMCPProfile{nil, {}, {{Name: "existing", AllowAllTools: true}}} {
+		manifest := VMCPManifest{
+			Profiles: profiles,
+			Components: []VMCPComponent{{
+				Configuration: []VMCPConfigurationPolicy{{Key: "TOKEN"}},
+			}},
+		}
+
+		manifest.Default(true)
+
+		if manifest.Profiles != nil {
+			t.Fatalf("personal server profiles = %#v, want nil", manifest.Profiles)
+		}
+		if got := manifest.Components[0].Configuration[0].Policy; got != VMCPConfigurationPolicyProhibited {
+			t.Fatalf("default configuration policy = %q, want %q", got, VMCPConfigurationPolicyProhibited)
+		}
 	}
 }
 

--- a/pkg/api/authz/vmcp_test.go
+++ b/pkg/api/authz/vmcp_test.go
@@ -25,7 +25,7 @@ func TestEmptyVMCPIsReadableButNotConnectable(t *testing.T) {
 			Manifest: types.VMCPManifest{DisplayName: "Empty draft"},
 		},
 	}
-	vmcp.Spec.Manifest.Default()
+	vmcp.Spec.Manifest.Default(true)
 	if err := vmcp.Spec.Manifest.Validate(); err != nil {
 		t.Fatalf("empty draft should be valid: %v", err)
 	}

--- a/pkg/api/handlers/vmcp.go
+++ b/pkg/api/handlers/vmcp.go
@@ -55,13 +55,16 @@ func (h *VMCPHandler) Create(req api.Context) error {
 	if err := req.Read(&manifest); err != nil {
 		return types.NewErrBadRequest("failed to read VMCP manifest: %v", err)
 	}
-	manifest.Default()
+
+	personalServer := !req.UserIsAdmin() || req.URL.Query().Get("scope") == "personal"
+
+	manifest.Default(personalServer)
 	if err := authz.CheckVMCPForceSingleUser(req.User, false, manifest.ForceSingleUser); err != nil {
 		return err
 	}
 
 	var userID string
-	if !req.UserIsAdmin() || req.URL.Query().Get("scope") == "personal" {
+	if personalServer {
 		userID = req.User.GetUID()
 	}
 
@@ -112,7 +115,10 @@ func (h *VMCPHandler) Update(req api.Context) error {
 	if err := req.Read(&manifest); err != nil {
 		return types.NewErrBadRequest("failed to read VMCP manifest: %v", err)
 	}
-	manifest.DefaultConfigurationPolicies()
+
+	personalServer := !req.UserIsAdmin() || req.URL.Query().Get("scope") == "personal"
+	manifest.Default(personalServer)
+
 	var vmcp v1.VMCP
 	if err := req.Get(&vmcp, req.PathValue("vmcp_id")); err != nil {
 		return fmt.Errorf("failed to get VMCP: %w", err)

--- a/pkg/api/handlers/vmcp_test.go
+++ b/pkg/api/handlers/vmcp_test.go
@@ -177,18 +177,21 @@ func TestVMCPHandlerCreateAppliesScopeAndDefaults(t *testing.T) {
 	if created.UserID != "user-1" {
 		t.Fatalf("personal VMCP userID = %q, want user-1", created.UserID)
 	}
-	if len(created.Profiles) != 1 || !created.Profiles[0].AllowAllTools {
-		t.Fatalf("unexpected default profiles: %#v", created.Profiles)
+	if len(created.Profiles) != 0 {
+		t.Fatalf("personal VMCP profiles = %#v, want none", created.Profiles)
 	}
 	if got := created.Components[0].Configuration[0].Policy; got != types.VMCPConfigurationPolicyProhibited {
 		t.Fatalf("default configuration policy = %q, want prohibited", got)
 	}
 
-	shared := callVMCPCreate(t, storage, gatewayClient, handler, testVMCPManifest(), &user.DefaultInfo{
+	shared := callVMCPCreate(t, storage, gatewayClient, handler, manifest, &user.DefaultInfo{
 		Name: "admin", UID: "admin", Groups: []string{types.GroupAdmin},
 	})
 	if shared.UserID != "" {
 		t.Fatalf("administrator-created VMCP userID = %q, want shared VMCP", shared.UserID)
+	}
+	if len(shared.Profiles) != 1 || !shared.Profiles[0].AllowAllTools {
+		t.Fatalf("unexpected shared default profiles: %#v", shared.Profiles)
 	}
 
 	personal := callVMCPCreate(t, storage, gatewayClient, handler, testVMCPManifest(), &user.DefaultInfo{
@@ -196,6 +199,9 @@ func TestVMCPHandlerCreateAppliesScopeAndDefaults(t *testing.T) {
 	}, "?scope=personal")
 	if personal.UserID != "user-1" {
 		t.Fatalf("administrator-created personal VMCP userID = %q, want user-1", personal.UserID)
+	}
+	if len(personal.Profiles) != 0 {
+		t.Fatalf("administrator-created personal VMCP profiles = %#v, want none", personal.Profiles)
 	}
 }
 
@@ -911,7 +917,7 @@ func TestVMCPRemovalPrunesProfileComponents(t *testing.T) {
 	storage := newVMCPTestStorage(vmcpCatalogEntryForTest("entry"))
 	handler := vmcpHandlerForTest(t, storage)
 	gatewayClient := newHandlerTestGateway(t)
-	u := &user.DefaultInfo{UID: "user-1"}
+	u := &user.DefaultInfo{UID: "user-1", Groups: []string{types.GroupAdmin}}
 	manifest := testVMCPManifest()
 	second := manifest.Components[0]
 	second.Name = "second"


### PR DESCRIPTION
Issue: https://github.com/obot-platform/obot/issues/7820