### PR TITLE
fix: use user API endpiont for catalog entry

### DIFF
--- a/ui/user/src/lib/components/vmcps/ViewModifyCatalogEntry.svelte
+++ b/ui/user/src/lib/components/vmcps/ViewModifyCatalogEntry.svelte
@@ -175,6 +175,9 @@
 		if (entryWorkspaceId && !isAdmin) {
 			return UserService.getWorkspaceMCPCatalogEntry(entryWorkspaceId, id, opts);
 		}
+		if (!profile.current.hasAdminAccess?.()) {
+			return UserService.getMCP(id, opts);
+		}
 		return AdminService.getMCPCatalogEntry(DEFAULT_MCP_CATALOG_ID, id, opts);
 	}
 

--- a/ui/user/src/lib/components/vmcps/ViewModifyCatalogEntry.svelte.spec.ts
+++ b/ui/user/src/lib/components/vmcps/ViewModifyCatalogEntry.svelte.spec.ts
@@ -1,0 +1,36 @@
+import { Group } from '$lib/services';
+import { createMCPCatalogEntry } from '../../../tests/helpers/mcp';
+import { createMockProfile, preparePageData } from '../../../tests/helpers/pageData';
+import { worker } from '../../../tests/mocks/worker';
+import ViewModifyCatalogEntry from './ViewModifyCatalogEntry.svelte';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+describe('catalog entry hydration', () => {
+	it.each([
+		{ role: 'user', groups: [], endpoint: '/api/all-mcps/entries' },
+		{ role: 'admin', groups: [Group.ADMIN], endpoint: '/api/mcp-catalogs/default/entries' },
+		{ role: 'auditor', groups: [Group.AUDITOR], endpoint: '/api/mcp-catalogs/default/entries' }
+	])('loads details through the $role endpoint', async ({ groups, endpoint }) => {
+		const entry = createMCPCatalogEntry({ id: 'entry-hydration', name: 'Initial entry' });
+		const requested = vi.fn();
+		worker.use(
+			http.get(`${endpoint}/${entry.id}`, () => {
+				requested();
+				return HttpResponse.json({
+					...entry,
+					manifest: { ...entry.manifest, name: 'Hydrated entry' }
+				});
+			})
+		);
+		await preparePageData({ profile: createMockProfile(groups) });
+		const { component } = await render(ViewModifyCatalogEntry);
+		await component.open(entry);
+		expect(requested).toHaveBeenCalledOnce();
+		await expect
+			.element(page.getByRole('heading', { name: 'Hydrated entry', exact: true }).first())
+			.toBeVisible();
+	});
+});

--- a/ui/user/src/lib/services/user/operations.ts
+++ b/ui/user/src/lib/services/user/operations.ts
@@ -218,7 +218,10 @@ export async function listMCPs(opts?: {
 	);
 }
 
-export async function getMCP(id: string, opts?: { fetch?: Fetcher }): Promise<MCPCatalogEntry> {
+export async function getMCP(
+	id: string,
+	opts?: { fetch?: Fetcher; signal?: AbortSignal }
+): Promise<MCPCatalogEntry> {
 	const response = (await doGet(`/all-mcps/entries/${id}`, opts)) as MCPCatalogEntry;
 	return {
 		...response,


### PR DESCRIPTION
Basic users aren't able to use the admin endpoint for getting a catalog entry because that endpoint doesn't do access checks. This change ensures that basic users use the correct endpoint.

Issue: https://github.com/obot-platform/obot/issues/7819