### PR TITLE
fix: hide device unique user counts from dashboards

### DIFF
--- a/ui/user/src/routes/dashboard/+page.svelte
+++ b/ui/user/src/routes/dashboard/+page.svelte
@@ -265,13 +265,6 @@
 			seeMore: '/inventory?view=devices'
 		},
 		{
-			id: 'device-users',
-			label: 'Unique Users',
-			loading: loadingDeviceScanStats,
-			value: deviceScanStats?.userCount ?? 0,
-			icon: Users
-		},
-		{
 			id: 'device-clients',
 			label: 'Unique Clients',
 			loading: loadingDeviceScanStats,
@@ -330,7 +323,7 @@
 							<h4 class="flex items-center font-light text-xs uppercase">Device Scans</h4>
 						</div>
 						<div class="@container min-w-0 w-full max-w-full">
-							<div class="grid w-full grid-cols-2 gap-0 @md:grid-cols-12 @3xl:grid-cols-5">
+							<div class="grid w-full grid-cols-2 gap-0 @md:grid-cols-12 @3xl:grid-cols-4">
 								{#each deviceScanTiles as deviceScanStat (deviceScanStat.id)}
 									{@render deviceScanStatCell(deviceScanStat)}
 								{/each}
@@ -641,7 +634,7 @@
 {#snippet deviceScanStatCell(deviceScanStat: (typeof deviceScanTiles)[number])}
 	{@const defaultClasses = 'p-2 flex gap-2 items-center justify-between w-full'}
 	<div
-		class="col-span-2 @sm:col-span-1 min-w-0 flex @sm:border-r @sm:not-odd:border-r-0 px-2 my-2 @md:col-span-6 @min-[545px]:col-span-4 @md:last:border-r-0 @md:not-last:border-base-300 @3xl:col-span-1 @3xl:not-odd:border-r"
+		class="col-span-2 @sm:col-span-1 min-w-0 flex @sm:border-r @sm:not-odd:border-r-0 px-2 my-2 @md:col-span-6 @md:last:border-r-0 @md:not-last:border-base-300 @3xl:col-span-1 @3xl:not-odd:not-last:border-r"
 	>
 		{#if deviceScanStat.seeMore}
 			<a

--- a/ui/user/src/routes/inventory/OverviewView.svelte
+++ b/ui/user/src/routes/inventory/OverviewView.svelte
@@ -21,8 +21,7 @@
 		MonitorCheck,
 		PencilRuler,
 		ScanLine,
-		Server,
-		Users
+		Server
 	} from '@lucide/svelte';
 	import { onMount, untrack } from 'svelte';
 
@@ -147,12 +146,6 @@
 			seeMore: '/inventory?view=devices'
 		},
 		{
-			key: 'users',
-			label: 'Unique Users',
-			value: stats?.userCount ?? 0,
-			icon: Users
-		},
-		{
 			key: 'clients',
 			label: 'Unique Clients',
 			value: totalClientGroups,
@@ -194,9 +187,7 @@
 		</p>
 	</div>
 {:else}
-	<div
-		class="paper dark:divide-base-400 divide-base-300 grid grid-cols-2 divide-x sm:grid-cols-3 lg:grid-cols-5"
-	>
+	<div class="paper dark:divide-base-400 divide-base-300 grid grid-cols-2 divide-x lg:grid-cols-4">
 		{#each tiles as tile (tile.key)}
 			{@render statCell(tile)}
 		{/each}


### PR DESCRIPTION
The unique user counts on the primary and inventory dashboards
are driven from the the device scans `submitted_by` column.
It hasn't been possible to populate this column since we switched
to unattended authentication, so they will always show zero unique
users.

Remove them from the UI dashboards.
