### PR TITLE
fix: propagate proxy and CA settings to provider processes

### DIFF
--- a/pkg/gateway/server/dispatcher/daemon.go
+++ b/pkg/gateway/server/dispatcher/daemon.go
@@ -235,7 +235,7 @@ func (d *Dispatcher) newCommand(ctx context.Context, envMap map[string]string, c
 	}
 	envMap["OBOT_SERVER_PUBLIC_URL"] = d.serverURL
 	envMap["OBOT_SERVER_URL"] = d.sessionManager.TransformObotHostname(d.internalServerURL)
-	cmd.Env = envAsSlice(envMap)
+	cmd.Env = append(inheritedEnv(os.LookupEnv, envMap), envAsSlice(envMap)...)
 
 	r, w, err := os.Pipe()
 	if err != nil {
@@ -256,6 +256,47 @@ func (d *Dispatcher) newCommand(ctx context.Context, envMap map[string]string, c
 	}
 
 	return cmd, stop, nil
+}
+
+// inheritedEnvVars are the only variables copied from Obot's own environment into
+// provider processes. A provider is given an explicit environment rather than
+// inheriting Obot's, which holds secrets such as the database DSN and the
+// encryption configuration, so anything a provider legitimately needs has to be
+// listed here. Both spellings of the proxy variables are listed because the HTTP
+// clients providers are written against disagree about which one they read.
+var inheritedEnvVars = []string{
+	"HTTP_PROXY", "http_proxy",
+	"HTTPS_PROXY", "https_proxy",
+	"ALL_PROXY", "all_proxy",
+	"NO_PROXY", "no_proxy",
+	// A proxy that terminates TLS presents its own certificate, so the CA bundle
+	// that makes it trusted has to travel with the proxy settings.
+	"SSL_CERT_FILE", "SSL_CERT_DIR",
+	"REQUESTS_CA_BUNDLE", "NODE_EXTRA_CA_CERTS",
+}
+
+// inheritedEnv returns the allowlisted variables from Obot's environment, keeping
+// the spelling of each name so that providers reading only the lowercase form
+// still see it. A variable the provider sets itself is skipped, because envAsSlice
+// uppercases its keys and would otherwise leave the lowercase copy behind to
+// compete with it.
+func inheritedEnv(lookupEnv func(string) (string, bool), providerEnv map[string]string) []string {
+	overridden := make(map[string]struct{}, len(providerEnv))
+	for key := range providerEnv {
+		overridden[toEnvLike(key)] = struct{}{}
+	}
+
+	env := make([]string, 0, len(inheritedEnvVars))
+	for _, name := range inheritedEnvVars {
+		if _, ok := overridden[strings.ToUpper(name)]; ok {
+			continue
+		}
+		if value, ok := lookupEnv(name); ok {
+			env = append(env, name+"="+value)
+		}
+	}
+
+	return env
 }
 
 func envAsSlice(env map[string]string) []string {

--- a/pkg/gateway/server/dispatcher/daemon_test.go
+++ b/pkg/gateway/server/dispatcher/daemon_test.go
@@ -1,0 +1,102 @@
+package dispatcher
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestInheritedEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment map[string]string
+		providerEnv map[string]string
+		expected    []string
+	}{
+		{
+			name: "copies proxy settings from Obot's environment",
+			environment: map[string]string{
+				"HTTP_PROXY":  "http://proxy.example.com:3128",
+				"HTTPS_PROXY": "http://proxy.example.com:3128",
+				"NO_PROXY":    "localhost,127.0.0.1",
+			},
+			providerEnv: nil,
+			expected: []string{
+				"HTTP_PROXY=http://proxy.example.com:3128",
+				"HTTPS_PROXY=http://proxy.example.com:3128",
+				"NO_PROXY=localhost,127.0.0.1",
+			},
+		},
+		{
+			name: "keeps the spelling of each variable",
+			environment: map[string]string{
+				"HTTP_PROXY": "http://upper.example.com:3128",
+				"http_proxy": "http://lower.example.com:3128",
+			},
+			providerEnv: nil,
+			expected: []string{
+				"HTTP_PROXY=http://upper.example.com:3128",
+				"http_proxy=http://lower.example.com:3128",
+			},
+		},
+		{
+			name: "copies the CA bundle a TLS-terminating proxy needs",
+			environment: map[string]string{
+				"SSL_CERT_FILE":      "/etc/ssl/corp.pem",
+				"REQUESTS_CA_BUNDLE": "/etc/ssl/corp.pem",
+			},
+			providerEnv: nil,
+			expected: []string{
+				"SSL_CERT_FILE=/etc/ssl/corp.pem",
+				"REQUESTS_CA_BUNDLE=/etc/ssl/corp.pem",
+			},
+		},
+		{
+			name: "omits variables that are not set",
+			environment: map[string]string{
+				"HTTP_PROXY": "http://proxy.example.com:3128",
+			},
+			providerEnv: nil,
+			expected:    []string{"HTTP_PROXY=http://proxy.example.com:3128"},
+		},
+		{
+			name: "never copies anything outside the allowlist",
+			environment: map[string]string{
+				"OBOT_SERVER_DSN": "postgres://obot:secret@localhost/obot",
+				"OPENAI_API_KEY":  "sk-secret",
+			},
+			providerEnv: nil,
+			expected:    nil,
+		},
+		{
+			name: "skips variables the provider sets itself, in either spelling",
+			environment: map[string]string{
+				"HTTP_PROXY":  "http://obot.example.com:3128",
+				"http_proxy":  "http://obot.example.com:3128",
+				"HTTPS_PROXY": "http://obot.example.com:3128",
+			},
+			providerEnv: map[string]string{
+				"HTTP_PROXY": "http://provider.example.com:3128",
+			},
+			expected: []string{"HTTPS_PROXY=http://obot.example.com:3128"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookupEnv := func(name string) (string, bool) {
+				value, ok := tt.environment[name]
+				return value, ok
+			}
+
+			got := inheritedEnv(lookupEnv, tt.providerEnv)
+
+			slices.Sort(got)
+			expected := slices.Clone(tt.expected)
+			slices.Sort(expected)
+
+			if !slices.Equal(got, expected) {
+				t.Fatalf("inheritedEnv() = %v, want %v", got, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Model and auth providers run as child processes started by the dispatcher, which sets `cmd.Env` outright. A non-empty `cmd.Env` replaces the parent environment rather than adding to it, so a provider received only its credential values, `LOG_LEVEL`, `PORT` and the two `OBOT_SERVER_*` URLs. `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` set on Obot never reached it.

### Why it matters

Behind a proxy, a provider's traffic splits in two:

| Path | Where it runs | Honored proxy settings |
| --- | --- | --- |
| Chat/inference through the LLM gateway | In the Obot process | Yes |
| Model listing and credential validation | In the provider process | No |

So an administrator whose upstream is only reachable through the proxy sees models fail to list for a provider whose chat requests work. The reverse also happens: with `HTTP_PROXY` set and `NO_PROXY` not covering the upstream host, listing works (it connects directly) while chat is sent through the proxy and fails. This came up with Ollama, which is reached through the Generic Responses Compatible provider, but it affects every provider equally.

### The change

`newCommand` now prepends an allowlist copied from Obot's own environment, so both the long-lived daemon and the short-lived validation command are covered:

- `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, in both upper and lower case
- `SSL_CERT_FILE`, `SSL_CERT_DIR`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`

Three decisions worth reviewing:

- **An allowlist rather than the whole environment.** Obot's environment holds the database DSN, the encryption configuration and provider API keys. The existing code already passes the Postgres DSN to auth providers narrowly and deliberately; inheriting everything would undo that.
- **Both spellings, keeping the case.** Some HTTP clients read only `http_proxy`. A variable the provider sets itself is skipped, so an uppercase provider value can't be shadowed by an inherited lowercase copy.
- **CA bundle variables travel with the proxy settings.** A proxy that terminates TLS presents its own certificate, so proxy settings without a trusted bundle usually still fail.

### Testing

Unit test on the env-building helper covers the allowlist, case preservation, unset variables, provider overrides, and that non-allowlisted variables are never copied.

Verified at runtime by running the server against a fake provider registry whose provider records the environment it was launched with. With the fix, the provider process receives the proxy and CA variables; built from `main`, the same run gives it only `LOG_LEVEL`, `PORT` and the two `OBOT_SERVER_*` URLs. A `SECRET_CANARY` variable and `OBOT_SERVER_DSN` were present in the server's environment and absent from the provider's in both runs.

### Note for reviewers

If the host environment sets `HTTP_PROXY` and `http_proxy` to *different* values, both are passed through and the effective one depends on the provider's language — Go reads the uppercase form first, while Python's `getproxies_environment` lets the later environment entry win. Normalizing to a single value is a small follow-up if that is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTsLnPKKHaR867k4eCfovz
