### PR TITLE
fix: allow connections to multi-user MCP servers

### DIFF
--- a/pkg/api/handlers/mcpgateway/oauth/authorize.go
+++ b/pkg/api/handlers/mcpgateway/oauth/authorize.go
@@ -273,11 +273,11 @@ func (h *handler) callback(req api.Context) error {
 		}
 
 		mcpID = serverOrInstanceID
-		audience = "/" + audience
-		if !strings.HasSuffix(oauthAppAuthRequest.Spec.Resource, audience) || oauthAppAuthRequest.Spec.MCPID != mcpID {
+		if !strings.HasSuffix(oauthAppAuthRequest.Spec.Resource, "/"+audience) || oauthAppAuthRequest.Spec.MCPID != mcpID {
 			// Ensure the audience is what the server expects.
-			oauthAppAuthRequest.Spec.Resource = fmt.Sprintf("%s/mcp-connect%s", h.baseURL, audience)
+			oauthAppAuthRequest.Spec.Resource = fmt.Sprintf("%s/mcp-connect/%s", h.baseURL, audience)
 			oauthAppAuthRequest.Spec.MCPID = mcpID
+			oauthAppAuthRequest.Spec.Audience = audience
 			if err = req.Update(&oauthAppAuthRequest); err != nil {
 				redirectWithAuthorizeError(req, oauthAppAuthRequest.Spec.RedirectURI, newOAuthError(ErrServerError, fmt.Sprintf("failed to update OAuth app auth request: %v", err), oauthAppAuthRequest.Spec.State))
 				return nil

--- a/pkg/api/handlers/mcpgateway/oauth/token.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token.go
@@ -193,6 +193,11 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 		AuthProviderUserID:    oauthAuthRequest.Spec.AuthProviderUserID,
 		MCPID:                 oauthAuthRequest.Spec.MCPID,
 	}
+
+	if oauthAuthRequest.Spec.Audience != "" && oauthAuthRequest.Spec.MCPID != oauthAuthRequest.Spec.Audience {
+		tknCtx.AuthorizedMCPIDs = []string{oauthAuthRequest.Spec.Audience}
+	}
+
 	_, tkn, err := h.tokenService.NewToken(req.Context(), tknCtx)
 	if err != nil {
 		return fmt.Errorf("failed to create auth token: %w", err)
@@ -212,6 +217,7 @@ func (h *handler) doAuthorizationCode(req api.Context, oauthClient v1.OAuthClien
 			AuthProviderName:      oauthAuthRequest.Spec.AuthProviderName,
 			AuthProviderUserID:    oauthAuthRequest.Spec.AuthProviderUserID,
 			MCPID:                 oauthAuthRequest.Spec.MCPID,
+			Audience:              oauthAuthRequest.Spec.Audience,
 		},
 	}
 
@@ -279,6 +285,11 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 		return fmt.Errorf("failed to refresh oauth token: %w", err)
 	}
 
+	// For backwards compatibility, if the Audience field isn't set on the oauthToken, then set it from the Resource field.
+	if oauthToken.Spec.Audience == "" {
+		oauthToken.Spec.Audience, _ = strings.CutPrefix(oauthToken.Spec.Resource, h.baseURL+"/mcp-connect/")
+	}
+
 	now := time.Now()
 	tknCtx := persistent.TokenContext{
 		OAuthScope:            oauthToken.Spec.Scope,
@@ -294,6 +305,11 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 		AuthProviderUserID:    oauthToken.Spec.AuthProviderUserID,
 		MCPID:                 oauthToken.Spec.MCPID,
 	}
+
+	if oauthToken.Spec.Audience != "" && oauthToken.Spec.MCPID != oauthToken.Spec.Audience {
+		tknCtx.AuthorizedMCPIDs = []string{oauthToken.Spec.Audience}
+	}
+
 	_, tkn, err := h.tokenService.NewToken(req.Context(), tknCtx)
 	if err != nil {
 		return fmt.Errorf("failed to create auth token: %w", err)
@@ -313,6 +329,7 @@ func (h *handler) doRefreshToken(req api.Context, oauthClient v1.OAuthClient, re
 			AuthProviderName:      oauthToken.Spec.AuthProviderName,
 			AuthProviderUserID:    oauthToken.Spec.AuthProviderUserID,
 			MCPID:                 oauthToken.Spec.MCPID,
+			Audience:              oauthToken.Spec.Audience,
 		},
 	}
 

--- a/pkg/api/handlers/mcpgateway/oauth/token_test.go
+++ b/pkg/api/handlers/mcpgateway/oauth/token_test.go
@@ -44,21 +44,18 @@ func (s *consumeOAuthTokenAfterGetStorage) Get(ctx context.Context, key kclient.
 	return nil
 }
 
-func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
-	const (
-		baseURL      = "https://obot.example.com"
-		clientName   = "oauth-client"
-		mcpID        = system.SystemMCPServerPrefix + "test"
-		refreshToken = "old-refresh-token"
-	)
+func newOAuthTokenTestServices(t *testing.T, objects ...kclient.Object) (storage.Client, *gatewayclient.Client, *persistent.TokenService) {
+	t.Helper()
 
+	objects = append(objects, &v1.SystemMCPServer{
+		Namespace: system.DefaultNamespace,
+		Name:      system.SystemMCPServerPrefix + "test",
+	})
 	storage := clientfake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
 		WithIndex(&v1.VMCPInstance{}, "spec.legacySlug", func(obj kclient.Object) []string { return []string{obj.(*v1.VMCPInstance).Spec.LegacySlug} }).
-		WithObjects(&v1.SystemMCPServer{
-			Namespace: system.DefaultNamespace,
-			Name:      mcpID,
-		}).
+		WithIndex(&v1.OAuthAuthRequest{}, "spec.hashedAuthCode", func(obj kclient.Object) []string { return []string{obj.(*v1.OAuthAuthRequest).Spec.HashedAuthCode} }).
+		WithObjects(objects...).
 		Build()
 
 	services, err := sservices.New(sservices.Config{DSN: "sqlite://:memory:"})
@@ -69,7 +66,6 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 
 	gatewayClient := gatewayclient.New(t.Context(), db, storage, nil, nil, nil, nil, time.Hour, 10, 90, 90, 90, true)
 	t.Cleanup(func() { require.NoError(t, gatewayClient.Close()) })
-
 	require.NoError(t, db.WithContext(t.Context()).Create(&gatewaytypes.User{
 		ID:       42,
 		Username: "alice",
@@ -86,6 +82,86 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 			"JWK_KEY": base64.StdEncoding.EncodeToString(privateKey),
 		},
 	}))
+	tokenService, err := persistent.NewTokenService("https://obot.example.com", gatewayClient)
+	require.NoError(t, err)
+
+	return storage, gatewayClient, tokenService
+}
+
+func TestDoAuthorizationCodeScopesTokenToAudience(t *testing.T) {
+	const (
+		baseURL    = "https://obot.example.com"
+		clientName = "oauth-client"
+		mcpID      = system.SystemMCPServerPrefix + "test"
+		code       = "authorization-code"
+	)
+
+	tests := []struct {
+		name           string
+		audience       string
+		wantAuthorized persistent.StringSlice
+	}{
+		{
+			name:           "distinct audience",
+			audience:       "multi-user-server",
+			wantAuthorized: persistent.StringSlice{"multi-user-server"},
+		},
+		{
+			name: "empty audience",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authRequest := &v1.OAuthAuthRequest{
+				Namespace: system.DefaultNamespace,
+				Name:      "oauth-request",
+				Spec: v1.OAuthAuthRequestSpec{
+					ClientID:       clientName,
+					Resource:       baseURL + "/mcp-connect/" + tt.audience,
+					Scope:          "profile email",
+					HashedAuthCode: fmt.Sprintf("%x", sha256.Sum256([]byte(code))),
+					UserID:         42,
+					MCPID:          mcpID,
+					Audience:       tt.audience,
+				},
+			}
+			storage, gatewayClient, tokenService := newOAuthTokenTestServices(t, authRequest)
+			recorder := httptest.NewRecorder()
+			h := &handler{tokenService: tokenService}
+			err := h.doAuthorizationCode(api.Context{
+				ResponseWriter: recorder,
+				Request:        httptest.NewRequest(http.MethodPost, "/oauth/token", nil),
+				Storage:        storage,
+				GatewayClient:  gatewayClient,
+			}, v1.OAuthClient{Namespace: system.DefaultNamespace, Name: clientName}, code, "")
+			require.NoError(t, err)
+
+			var response types.OAuthToken
+			require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+			claims, err := tokenService.DecodeToken(t.Context(), response.AccessToken)
+			require.NoError(t, err)
+			assert.Equal(t, mcpID, claims.MCPID)
+			assert.Equal(t, tt.wantAuthorized, claims.AuthorizedMCPIDs)
+
+			var refreshToken v1.OAuthToken
+			require.NoError(t, storage.Get(t.Context(), kclient.ObjectKey{
+				Namespace: system.DefaultNamespace,
+				Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(response.RefreshToken))),
+			}, &refreshToken))
+			assert.Equal(t, tt.audience, refreshToken.Spec.Audience)
+		})
+	}
+}
+
+func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
+	const (
+		baseURL      = "https://obot.example.com"
+		clientName   = "oauth-client"
+		mcpID        = system.SystemMCPServerPrefix + "test"
+		audience     = "multi-user-server"
+		refreshToken = "old-refresh-token"
+	)
 
 	tokenName := fmt.Sprintf("%x", sha256.Sum256([]byte(refreshToken)))
 	storageToken := &v1.OAuthToken{
@@ -93,16 +169,14 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 		Name:      tokenName,
 		Spec: v1.OAuthTokenSpec{
 			ClientID: clientName,
-			Resource: baseURL,
+			Resource: baseURL + "/mcp-connect/" + audience,
 			Scope:    "profile email",
 			UserID:   42,
 			MCPID:    mcpID,
+			Audience: audience,
 		},
 	}
-	require.NoError(t, storage.Create(t.Context(), storageToken))
-
-	tokenService, err := persistent.NewTokenService(baseURL, gatewayClient)
-	require.NoError(t, err)
+	storage, gatewayClient, tokenService := newOAuthTokenTestServices(t, storageToken)
 	recorder := httptest.NewRecorder()
 	req := api.Context{
 		ResponseWriter: recorder,
@@ -114,18 +188,52 @@ func TestDoRefreshTokenRotatesTokenAndPreservesScope(t *testing.T) {
 		Namespace: system.DefaultNamespace,
 		Name:      clientName,
 	}
-	h := &handler{tokenService: tokenService}
-	err = h.doRefreshToken(req, oauthClient, refreshToken)
+	h := &handler{baseURL: baseURL, tokenService: tokenService}
+	err := h.doRefreshToken(req, oauthClient, refreshToken)
 	require.NoError(t, err)
 
 	var response types.OAuthToken
 	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
 	require.NotEmpty(t, response.RefreshToken)
+	claims, err := tokenService.DecodeToken(t.Context(), response.AccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, mcpID, claims.MCPID)
+	assert.Equal(t, persistent.StringSlice{audience}, claims.AuthorizedMCPIDs)
 
 	var refreshed v1.OAuthToken
 	refreshedName := fmt.Sprintf("%x", sha256.Sum256([]byte(response.RefreshToken)))
 	require.NoError(t, storage.Get(t.Context(), kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: refreshedName}, &refreshed))
 	assert.Equal(t, "profile email", refreshed.Spec.Scope)
+	assert.Equal(t, audience, refreshed.Spec.Audience)
+
+	emptyAudienceRefreshToken := "empty-audience-refresh-token"
+	require.NoError(t, storage.Create(t.Context(), &v1.OAuthToken{
+		Namespace: system.DefaultNamespace,
+		Name:      fmt.Sprintf("%x", sha256.Sum256([]byte(emptyAudienceRefreshToken))),
+		Spec: v1.OAuthTokenSpec{
+			ClientID: clientName,
+			Resource: baseURL + "/mcp-connect/" + audience,
+			UserID:   42,
+			MCPID:    mcpID,
+		},
+	}))
+	emptyAudienceRecorder := httptest.NewRecorder()
+	err = h.doRefreshToken(api.Context{
+		ResponseWriter: emptyAudienceRecorder,
+		Request:        httptest.NewRequest(http.MethodPost, "/oauth/token", nil),
+		Storage:        storage,
+		GatewayClient:  gatewayClient,
+	}, oauthClient, emptyAudienceRefreshToken)
+	require.NoError(t, err)
+	require.NoError(t, json.NewDecoder(emptyAudienceRecorder.Body).Decode(&response))
+	claims, err = tokenService.DecodeToken(t.Context(), response.AccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, persistent.StringSlice{audience}, claims.AuthorizedMCPIDs)
+
+	var legacyRefreshed v1.OAuthToken
+	legacyRefreshedName := fmt.Sprintf("%x", sha256.Sum256([]byte(response.RefreshToken)))
+	require.NoError(t, storage.Get(t.Context(), kclient.ObjectKey{Namespace: system.DefaultNamespace, Name: legacyRefreshedName}, &legacyRefreshed))
+	assert.Equal(t, audience, legacyRefreshed.Spec.Audience)
 
 	err = h.doRefreshToken(api.Context{
 		ResponseWriter: httptest.NewRecorder(),

--- a/pkg/storage/apis/obot.obot.ai/v1/oauthauthrequest.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/oauthauthrequest.go
@@ -31,6 +31,7 @@ type OAuthAuthRequestSpec struct {
 	HashedAuthCode            string `json:"hashedAuthCode"`
 	UserID                    uint   `json:"userID"`
 	MCPID                     string `json:"mcpID"`
+	Audience                  string `json:"audience"`
 	AuthProviderUserID        string `json:"authProviderUserID"`
 	AuthProviderNamespace     string `json:"authProviderNamespace"`
 	AuthProviderName          string `json:"authProviderName"`

--- a/pkg/storage/apis/obot.obot.ai/v1/oauthtoken.go
+++ b/pkg/storage/apis/obot.obot.ai/v1/oauthtoken.go
@@ -23,6 +23,7 @@ type OAuthTokenSpec struct {
 	ClientID              string `json:"clientID"`
 	UserID                uint   `json:"userID"`
 	MCPID                 string `json:"mcpID"`
+	Audience              string `json:"audience"`
 	AuthProviderUserID    string `json:"authProviderUserID"`
 	AuthProviderName      string `json:"authProviderName"`
 	AuthProviderNamespace string `json:"authProviderNamespace"`

--- a/pkg/storage/openapi/generated/openapi_generated.go
+++ b/pkg/storage/openapi/generated/openapi_generated.go
@@ -25915,6 +25915,13 @@ func schema_storage_apis_obotobotai_v1_OAuthAuthRequestSpec(ref common.Reference
 							Format:  "",
 						},
 					},
+					"audience": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"authProviderUserID": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -25993,7 +26000,7 @@ func schema_storage_apis_obotobotai_v1_OAuthAuthRequestSpec(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"redirectURI", "state", "clientID", "codeChallenge", "scope", "codeChallengeMethod", "grantType", "resource", "hashedAuthCode", "userID", "mcpID", "authProviderUserID", "authProviderNamespace", "authProviderName", "consentPrepared", "consentMCPConfigRequired", "consentApproved", "consentMCPAuthRequired", "consentMCPAuthURL", "userHasSecondLevelOAuthed", "consentMCPServerName", "consentMCPServerURL"},
+				Required: []string{"redirectURI", "state", "clientID", "codeChallenge", "scope", "codeChallengeMethod", "grantType", "resource", "hashedAuthCode", "userID", "mcpID", "audience", "authProviderUserID", "authProviderNamespace", "authProviderName", "consentPrepared", "consentMCPConfigRequired", "consentApproved", "consentMCPAuthRequired", "consentMCPAuthURL", "userHasSecondLevelOAuthed", "consentMCPServerName", "consentMCPServerURL"},
 			},
 		},
 	}
@@ -26402,6 +26409,13 @@ func schema_storage_apis_obotobotai_v1_OAuthTokenSpec(ref common.ReferenceCallba
 							Format:  "",
 						},
 					},
+					"audience": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 					"authProviderUserID": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -26424,7 +26438,7 @@ func schema_storage_apis_obotobotai_v1_OAuthTokenSpec(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"scope", "resource", "clientID", "userID", "mcpID", "authProviderUserID", "authProviderName", "authProviderNamespace"},
+				Required: []string{"scope", "resource", "clientID", "userID", "mcpID", "audience", "authProviderUserID", "authProviderName", "authProviderNamespace"},
 			},
 		},
 	}


### PR DESCRIPTION
A previous change simplified the token flow for MCP connections. However, it simplified too aggressively and broke multi-user connections. This fixes it by ensure the proper MCP server ID is allowed.

Issue: https://github.com/obot-platform/obot/issues/7842