### PR TITLE
fix(vmcp): set "fixed" for required config on create

### DIFF
--- a/ui/user/src/lib/components/vmcps/CreateEditVMcp.svelte.spec.ts
+++ b/ui/user/src/lib/components/vmcps/CreateEditVMcp.svelte.spec.ts
@@ -1,0 +1,65 @@
+import type { VMCPManifest } from '$lib/services';
+import { catalogEntryToVMCPComponent } from '$lib/services/vmcps/utils';
+import { createMCPCatalogEntry, createVMCP } from '../../../tests/helpers/mcp';
+import { preparePageData } from '../../../tests/helpers/pageData';
+import { worker } from '../../../tests/mocks/worker';
+import CreateEditVMcp from './CreateEditVMcp.svelte';
+import { http, HttpResponse } from 'msw';
+import { expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+it('sends required configuration as fixed when creating a vMCP', async () => {
+	await preparePageData();
+	const entry = createMCPCatalogEntry({
+		id: 'entry-configurable',
+		name: 'Configurable server',
+		manifest: {
+			config: [
+				{
+					key: 'TOKEN',
+					name: 'Token',
+					description: '',
+					required: true,
+					sensitive: true,
+					value: '',
+					usage: 'env'
+				},
+				{
+					key: 'REGION',
+					name: 'Region',
+					description: '',
+					required: true,
+					sensitive: false,
+					value: 'us-east-1',
+					usage: 'header'
+				},
+				{
+					key: 'OPTIONAL',
+					name: 'Optional',
+					description: '',
+					required: false,
+					sensitive: false,
+					value: '',
+					usage: 'env'
+				}
+			]
+		}
+	});
+	const create = vi.fn();
+	worker.use(
+		http.post('/api/vmcps', async ({ request }) => {
+			const manifest = (await request.json()) as VMCPManifest;
+			create(manifest);
+			return HttpResponse.json(createVMCP(manifest));
+		})
+	);
+	const result = await render(CreateEditVMcp);
+	result.component.openCreate([catalogEntryToVMCPComponent(entry)]);
+	await page.getByRole('button', { name: 'Create', exact: true }).click();
+	await vi.waitFor(() => expect(create).toHaveBeenCalledOnce());
+	expect(create.mock.calls[0][0].components[0].configuration).toEqual([
+		{ key: 'TOKEN', policy: 'fixed', value: '' },
+		{ key: 'REGION', policy: 'fixed', value: 'us-east-1' }
+	]);
+});

--- a/ui/user/src/lib/components/vmcps/VMcpDesigner.svelte.spec.ts
+++ b/ui/user/src/lib/components/vmcps/VMcpDesigner.svelte.spec.ts
@@ -10,6 +10,7 @@ import {
 	type VMCP,
 	type VMCPManifest
 } from '$lib/services';
+import { catalogEntryToVMCPComponent } from '$lib/services/vmcps/utils';
 import { mcpServersAndEntries } from '$lib/stores';
 import { createMCPCatalogEntry, createVMCP, createVMCPComponent } from '../../../tests/helpers/mcp';
 import { createMockProfile, preparePageData } from '../../../tests/helpers/pageData';
@@ -961,6 +962,29 @@ describe('VMcpDesigner.svelte', () => {
 			await expect
 				.element(page.getByRole('heading', { name: 'Add Tools' }))
 				.not.toBeInTheDocument();
+		});
+
+		it('opens configuration after creation even when required policies are already fixed', async () => {
+			const entry = configurableGithub();
+			const vmcp = createVMCP({
+				components: [catalogEntryToVMCPComponent(entry)]
+			});
+			const update = vi.fn();
+			mockUpdateVMcp(vmcp, update);
+			queueToolSetupForCreatedVMcp(vmcp.id);
+
+			await renderDesigner([entry], vmcp);
+
+			await expect.element(page.getByRole('heading', { name: /Configure GitHub/ })).toBeVisible();
+			await expect.element(addToolsDialog()).not.toBeInTheDocument();
+			await page.getByCSS('#fixed-API_TOKEN').fill('secret');
+			await page.getByRole('button', { name: 'Next' }).click();
+
+			await vi.waitFor(() => expect(update).toHaveBeenCalledOnce());
+			expect(componentsFrom(update.mock.calls[0][0])[0]).toMatchObject({
+				configuration: [{ key: 'API_TOKEN', policy: 'fixed', value: 'secret' }]
+			});
+			await expect.element(addToolsDialog()).toBeVisible();
 		});
 
 		it('offers tool selection after post-create configuration when no policy is user-supplied', async () => {

--- a/ui/user/src/lib/runes/vmcps/vmcpToolFlow.svelte.ts
+++ b/ui/user/src/lib/runes/vmcps/vmcpToolFlow.svelte.ts
@@ -228,11 +228,6 @@ export function createVMcpToolFlow() {
 		dialog = 'added-create';
 	}
 
-	function needsComponentConfiguration(component: VMCPComponent, entry?: MCPCatalogEntry) {
-		if (component.configuration?.length) return false;
-		return Boolean(entry && catalogConfigurationFields(entry).length > 0);
-	}
-
 	function offerToolsAfterCreate(vmcp: VMCP, component: VMCPComponent, entry?: MCPCatalogEntry) {
 		if (component.configuration?.some((field) => field.policy === 'userAllowed')) return;
 		if (entry) {
@@ -247,7 +242,8 @@ export function createVMcpToolFlow() {
 		if (!firstComponent) return;
 		const entry = catalogEntryForComponent(firstComponent);
 		if (
-			needsComponentConfiguration(firstComponent, entry) &&
+			entry &&
+			catalogConfigurationFields(entry).length > 0 &&
 			configure(vmcp, firstComponent, false)
 		) {
 			postCreateConfiguration = true;

--- a/ui/user/src/lib/services/vmcps/utils.ts
+++ b/ui/user/src/lib/services/vmcps/utils.ts
@@ -89,6 +89,9 @@ export function catalogEntryToVMCPComponent(entry: MCPCatalogEntry): VMCPCompone
 		name: entry.manifest.name ?? entry.id,
 		mcpCatalogID: DEFAULT_MCP_CATALOG_ID,
 		mcpServerCatalogEntryID: entry.id,
+		configuration: catalogConfigurationFields(entry)
+			.filter((field) => field.required)
+			.map((field) => ({ key: field.key, policy: 'fixed', value: field.value })),
 		catalogEntry: {
 			manifest: entry.manifest,
 			unsupportedTools: entry.unsupportedTools


### PR DESCRIPTION
Required configuration cannot be set to "prohibited" for vMCPs because this would put the vMCP into a bad state. This change automatically sets such configuration as fixed and the UI will give the admin the opportunity to change that.

Issue: https://github.com/obot-platform/obot/issues/7850