### PR TITLE
fix(audit): preserve commas in MCP server filters

### DIFF
--- a/pkg/api/handlers/mcpgateway/auditlog.go
+++ b/pkg/api/handlers/mcpgateway/auditlog.go
@@ -123,7 +123,7 @@ func getOwnServerMCPIDs(req api.Context) ([]string, error) {
 }
 
 // parseMultiValueParam parses query parameters that can have multiple values
-// Supports both comma-separated values in single parameter and repeated parameters
+// Supports JSON string arrays, comma-separated values, and repeated parameters.
 func parseMultiValueParam(queryValues map[string][]string, key string) []string {
 	values := queryValues[key]
 	if len(values) == 0 {
@@ -133,6 +133,15 @@ func parseMultiValueParam(queryValues map[string][]string, key string) []string 
 	var result []string
 	for _, value := range values {
 		if value == "" {
+			continue
+		}
+		var items []string
+		if strings.HasPrefix(strings.TrimSpace(value), "[") && json.Unmarshal([]byte(value), &items) == nil {
+			for _, item := range items {
+				if item != "" {
+					result = append(result, item)
+				}
+			}
 			continue
 		}
 		// Split by comma to support comma-separated values

--- a/pkg/api/handlers/mcpgateway/auditlog_filter_values_test.go
+++ b/pkg/api/handlers/mcpgateway/auditlog_filter_values_test.go
@@ -1,0 +1,41 @@
+package mcpgateway
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseAuditLogServerNames(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		values []string
+		want   []string
+	}{
+		{
+			name:   "commas and escaped characters",
+			values: []string{`["Outlook, Calendar","A \"quoted\" \\ server"," spaced "]`},
+			want:   []string{"Outlook, Calendar", `A "quoted" \ server`, " spaced "},
+		},
+		{
+			name:   "legacy and repeated parameters",
+			values: []string{"one, two", "three", `["Outlook, Calendar"]`},
+			want:   []string{"one", "two", "three", "Outlook, Calendar"},
+		},
+		{
+			name:   "empty selections",
+			values: []string{"", "[]", `[""]`},
+		},
+		{
+			name:   "non JSON names",
+			values: []string{"[server]", "123", "null"},
+			want:   []string{"[server]", "123", "null"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAuditLogOpts(map[string][]string{"mcp_server": tt.values}).MCPServer
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("MCPServer = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/ui/user/src/lib/components/Select.svelte
+++ b/ui/user/src/lib/components/Select.svelte
@@ -7,6 +7,7 @@
 		query?: string;
 		selected?: string | number;
 		multiple?: boolean;
+		valueFormat?: 'comma-separated' | 'json';
 		onSelect?: (option: T, value?: string | number) => void;
 		class?: string;
 		classes?: {
@@ -34,6 +35,7 @@
 </script>
 
 <script lang="ts" generics="T extends { id: string | number; label: string; disabled?: boolean }">
+	import { parseMultiValue, serializeMultiValue } from '$lib/multiValue';
 	import { ChevronDown, X, Check, SearchIcon } from '@lucide/svelte';
 	import { tick, type Snippet } from 'svelte';
 	import { flip } from 'svelte/animate';
@@ -49,6 +51,7 @@
 		selected = $bindable(),
 		query = $bindable(),
 		multiple = false,
+		valueFormat = 'comma-separated',
 		class: klass,
 		classes,
 		position = 'bottom',
@@ -71,6 +74,7 @@
 	const selectedValues = $derived.by(() => {
 		if (multiple) {
 			if (typeof selected === 'string') {
+				if (valueFormat === 'json') return parseMultiValue(selected);
 				const values =
 					selected
 						.split(',')
@@ -127,6 +131,10 @@
 		query = (e.target as HTMLInputElement).value;
 	}
 
+	function serializeValues(values: (string | number)[]) {
+		return valueFormat === 'json' ? serializeMultiValue(values) : values.join(',');
+	}
+
 	function handleSelect(option: T) {
 		if (option.disabled) return;
 
@@ -135,9 +143,9 @@
 
 		if (multiple) {
 			if (isSelected) {
-				selected = selectedValues.filter((d) => d !== key).join(',');
+				selected = serializeValues(selectedValues.filter((d) => d !== key));
 			} else {
-				selected = [key, ...selectedValues].join(',');
+				selected = serializeValues([key, ...selectedValues]);
 			}
 		} else if (!isSelected) {
 			selected = key;
@@ -242,7 +250,7 @@
 
 											const filteredValues = selectedValues.filter((d) => d !== selectedOption.id);
 
-											selected = filteredValues.join(',');
+											selected = serializeValues(filteredValues);
 
 											onClear?.(selectedOption, selected);
 										}}
@@ -409,7 +417,7 @@
 				selectedValues.length > 0 &&
 				(query ?? '')?.length === 0
 			) {
-				selected = selectedValues.slice(0, -1).join(',');
+				selected = serializeValues(selectedValues.slice(0, -1));
 			}
 
 			if (e.key === 'Enter') {

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte
@@ -16,6 +16,7 @@
 	} from '$lib/components/admin/audit-log-exports/filterFields';
 	import AuditLogCalendar from '$lib/components/admin/audit-logs/AuditLogCalendar.svelte';
 	import Loading from '$lib/icons/Loading.svelte';
+	import { parseMultiValue, serializeMultiValue } from '$lib/multiValue';
 	import {
 		AdminService,
 		Group,
@@ -396,7 +397,7 @@
 					api_key_id: join(filters.apiKeyIDs),
 					actor: join(filters.actors),
 					operation: join(filters.operations),
-					mcp_server: join(filters.mcpServers),
+					mcp_server: serializeMultiValue(filters.mcpServers ?? []),
 					tool: join(filters.tools),
 					outcome: join(filters.outcomes),
 					client: join(filters.clients),
@@ -621,7 +622,7 @@
 					sourceTypes: normalizeSourceTypes(form.sourceTypes),
 					actors: split(form.filters.actor),
 					operations: split(form.filters.operation),
-					mcpServers: split(form.filters.mcp_server),
+					mcpServers: parseMultiValue(form.filters.mcp_server),
 					tools: split(form.filters.tool),
 					outcomes: split(form.filters.outcome),
 					clients: split(form.filters.client),
@@ -875,6 +876,7 @@
 								disabled={isViewMode}
 								readonly={isViewMode}
 								multiple
+								valueFormat={filterKey === 'mcp_server' ? 'json' : 'comma-separated'}
 							/>
 							{#if (isViewMode && form.filters[filterKey]) || !isViewMode}
 								<p class="text-muted-content text-xs">{description}</p>

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateAuditLogExportForm.svelte.spec.ts
@@ -1,0 +1,42 @@
+import { page as appPage } from '$app/state';
+import type { AuditLogExport } from '$lib/services';
+import { preparePageData } from '../../../../tests/helpers/pageData';
+import { worker } from '../../../../tests/mocks/worker';
+import CreateAuditLogExportForm from './CreateAuditLogExportForm.svelte';
+import { http, HttpResponse } from 'msw';
+import { afterEach, expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+afterEach(() => appPage.url.searchParams.delete('mcp_server'));
+
+test('preserves comma-containing server names when creating and viewing exports', async () => {
+	const name = 'Outlook, Calendar';
+	appPage.url.searchParams.set('mcp_server', JSON.stringify([name]));
+	const onSubmit = vi.fn();
+	worker.use(
+		http.get('/api/mcp-audit-logs/filter-options/:filter', () =>
+			HttpResponse.json({ options: [name] })
+		),
+		http.post('/api/audit-log-exports', async ({ request }) =>
+			HttpResponse.json(await request.json())
+		)
+	);
+	await preparePageData();
+	const view = await render(CreateAuditLogExportForm, { onCancel: vi.fn(), onSubmit });
+	await expect.element(page.getByCSS('#mcp_server')).toHaveTextContent(name);
+	await page.getByLabelText('Export Name').fill('Comma names');
+	await page.getByLabelText('Bucket Name').fill('audit-logs');
+	await page.getByRole('button', { name: 'Create Export', exact: true }).click();
+	await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+	const exported = onSubmit.mock.calls[0][0] as AuditLogExport;
+	expect(exported.filters?.mcpServers).toEqual([name]);
+	await view.unmount();
+	await render(CreateAuditLogExportForm, {
+		onCancel: vi.fn(),
+		onSubmit: vi.fn(),
+		mode: 'view',
+		initialData: exported
+	});
+	await expect.element(page.getByCSS('#mcp_server')).toHaveTextContent(name);
+});

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte
@@ -14,6 +14,7 @@
 		sourceTypesFromEventTypeParam
 	} from '$lib/components/admin/audit-log-exports/filterFields';
 	import Loading from '$lib/icons/Loading.svelte';
+	import { parseMultiValue, serializeMultiValue } from '$lib/multiValue';
 	import {
 		type LLMAuditLogURLFilters,
 		type AuditLogFilterOption,
@@ -153,7 +154,7 @@
 					api_key_id: filters.apiKeyIDs?.join(',') ?? '',
 					actor: filters.actors?.join(',') ?? '',
 					operation: filters.operations?.join(',') ?? '',
-					mcp_server: filters.mcpServers?.join(',') ?? '',
+					mcp_server: serializeMultiValue(filters.mcpServers ?? []),
 					tool: filters.tools?.join(',') ?? '',
 					outcome: filters.outcomes?.join(',') ?? '',
 					client: filters.clients?.join(',') ?? '',
@@ -684,7 +685,7 @@
 					sourceTypes: normalizeSourceTypes(form.sourceTypes),
 					actors: split(form.filters.actor),
 					operations: split(form.filters.operation),
-					mcpServers: split(form.filters.mcp_server),
+					mcpServers: parseMultiValue(form.filters.mcp_server),
 					tools: split(form.filters.tool),
 					outcomes: split(form.filters.outcome),
 					clients: split(form.filters.client),
@@ -1137,6 +1138,7 @@
 								}
 								disabled={isViewMode}
 								multiple
+								valueFormat={row.filterKey === 'mcp_server' ? 'json' : 'comma-separated'}
 							/>
 							<p class="text-muted-content text-xs">{row.description}</p>
 						</div>

--- a/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/audit-log-exports/CreateScheduleForm.svelte.spec.ts
@@ -1,0 +1,56 @@
+import { page as appPage } from '$app/state';
+import type { ScheduledAuditLogExport } from '$lib/services';
+import { preparePageData } from '../../../../tests/helpers/pageData';
+import { worker } from '../../../../tests/mocks/worker';
+import CreateScheduleForm from './CreateScheduleForm.svelte';
+import { http, HttpResponse } from 'msw';
+import { afterEach, expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+
+afterEach(() => appPage.url.searchParams.delete('mcp_server'));
+
+test('preserves comma-containing server names when creating, editing and viewing schedules', async () => {
+	const name = 'Outlook, Calendar';
+	appPage.url.searchParams.set('mcp_server', JSON.stringify([name]));
+	const onSubmit = vi.fn();
+	worker.use(
+		http.get('/api/mcp-audit-logs/filter-options/:filter', () =>
+			HttpResponse.json({ options: [name] })
+		),
+		http.post('/api/scheduled-audit-log-exports', async ({ request }) =>
+			HttpResponse.json({ ...((await request.json()) as object), id: 'schedule-1' })
+		),
+		http.patch('/api/scheduled-audit-log-exports/schedule-1', async ({ request }) =>
+			HttpResponse.json(await request.json())
+		)
+	);
+	await preparePageData();
+	const view = await render(CreateScheduleForm, { onCancel: vi.fn(), onSubmit });
+	await expect.element(page.getByCSS('#mcp_server')).toHaveTextContent(name);
+	await page.getByLabelText('Schedule Name').fill('Comma names');
+	await page.getByLabelText('Bucket Name').fill('audit-logs');
+	await page.getByRole('button', { name: 'Create Schedule', exact: true }).click();
+	await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+	const exported = onSubmit.mock.calls[0][0] as ScheduledAuditLogExport;
+	expect(exported.filters?.mcpServers).toEqual([name]);
+	await view.unmount();
+	const edit = await render(CreateScheduleForm, {
+		onCancel: vi.fn(),
+		onSubmit,
+		mode: 'edit',
+		initialData: exported
+	});
+	await expect.element(page.getByCSS('#mcp_server')).toHaveTextContent(name);
+	await page.getByRole('button', { name: 'Save Changes', exact: true }).click();
+	await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2));
+	expect(onSubmit.mock.calls[1][0].filters.mcpServers).toEqual([name]);
+	await edit.unmount();
+	await render(CreateScheduleForm, {
+		onCancel: vi.fn(),
+		onSubmit: vi.fn(),
+		mode: 'view',
+		initialData: exported
+	});
+	await expect.element(page.getByCSS('#mcp_server')).toHaveTextContent(name);
+});

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogFilterPills.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogFilterPills.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" generics="T">
 	import { page } from '$app/state';
+	import { parseMultiValue } from '$lib/multiValue';
 	import { goto } from '$lib/url';
 	import { X } from '@lucide/svelte';
 	import { flip } from 'svelte/animate';
@@ -31,7 +32,7 @@
 	>
 		{#each entries as [filterKey, filterValues] (filterKey)}
 			{@const displayLabel = getFilterDisplayLabel(filterKey)}
-			{@const values = filterValues?.toString().split(',').filter(Boolean) ?? []}
+			{@const values = parseMultiValue(filterValues)}
 			{@const isClearable = isFilterClearable?.(filterKey) ?? true}
 
 			<div class="filter-primary" animate:flip={{ duration: 100 }}>

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte
@@ -14,6 +14,7 @@
 	import StackedTimeline from '$lib/components/graph/StackedTimeline.svelte';
 	import { setVirtualPageData } from '$lib/components/ui/virtual-page/context';
 	import Loading from '$lib/icons/Loading.svelte';
+	import { parseMultiValue } from '$lib/multiValue';
 	import { localState } from '$lib/runes/localState.svelte';
 	import {
 		type OrgUser,
@@ -475,10 +476,7 @@
 	// getFilterDisplayValue renders a full (possibly comma-joined) filter value; used by the export
 	// confirmation dialog. Pills call getFilterValue per single value instead.
 	function getFilterDisplayValue(key: string, value: string | number) {
-		return String(value)
-			.split(',')
-			.map((part) => part.trim())
-			.filter(Boolean)
+		return parseMultiValue(value)
 			.map((part) => formatSingleFilterValue(key, part))
 			.join(', ');
 	}

--- a/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/audit-logs/AuditLogsPageContent.svelte.spec.ts
@@ -47,10 +47,25 @@ async function filterOptionsParams(requests: { filterOptions: string[] }) {
 afterEach(() => {
 	appPage.url.searchParams.delete('mcp_id');
 	appPage.url.searchParams.delete('mcp_server_display_name');
+	appPage.url.searchParams.delete('mcp_server');
 	vi.restoreAllMocks();
 });
 
 describe('AuditLogsPageContent server scoping', () => {
+	it('preserves comma-containing server names in requests and filter pills', async () => {
+		const name = 'Outlook, Calendar';
+		const value = JSON.stringify([name]);
+		appPage.url.searchParams.set('mcp_server', value);
+
+		const requests = await renderAuditLogs();
+		expect((await auditLogParams(requests)).get('mcp_server')).toBe(value);
+		await expect.element(page.getByText(name, { exact: true })).toBeVisible();
+		const serverPill = page
+			.getByCSS('.filter-primary')
+			.filter({ hasText: 'Identifier – MCP Server' });
+		await expect.element(serverPill.getByText('OR', { exact: true })).not.toBeInTheDocument();
+	});
+
 	it('applies mcp_id from the URL and pins the source to MCP', async () => {
 		appPage.url.searchParams.set('mcp_id', 'server-1');
 

--- a/ui/user/src/lib/components/admin/filters-drawer/FilterField.svelte
+++ b/ui/user/src/lib/components/admin/filters-drawer/FilterField.svelte
@@ -19,6 +19,7 @@
 <script lang="ts">
 	import InfoTooltip from '$lib/components/InfoTooltip.svelte';
 	import Select, { type SelectProps } from '$lib/components/Select.svelte';
+	import { parseMultiValue } from '$lib/multiValue';
 	import { flip } from 'svelte/animate';
 	import { slide } from 'svelte/transition';
 	import { twMerge } from 'tailwind-merge';
@@ -69,7 +70,7 @@
 			shouldShowClearButton
 				? {
 						id: 'clear',
-						label: ['Clear', value?.toString()?.includes?.(',') ? 'All' : '']
+						label: ['Clear', parseMultiValue(value).length > 1 ? 'All' : '']
 							.filter(Boolean)
 							.join(' '),
 						onclick: () => onClearAll?.(),
@@ -131,6 +132,7 @@
 			}
 		}
 		multiple={filter.multiple ?? true}
+		valueFormat={filter.property === 'mcp_server' ? 'json' : 'comma-separated'}
 		{onSelect}
 	/>
 </div>

--- a/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.commas.svelte.spec.ts
+++ b/ui/user/src/lib/components/admin/filters-drawer/FiltersDrawer.commas.svelte.spec.ts
@@ -1,0 +1,53 @@
+import { goto } from '$lib/url';
+import FiltersDrawer from './FiltersDrawer.svelte';
+import { expect, test, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page, userEvent } from 'vitest/browser';
+
+vi.mock('$lib/url', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/url')>()),
+	goto: vi.fn().mockResolvedValue(undefined)
+}));
+
+test('selects, applies, restores and removes server names containing commas', async () => {
+	const name = 'Outlook, Calendar';
+	const props = {
+		filters: { mcp_server: '' },
+		onClose: vi.fn(),
+		getUserDisplayName: (id: string) => id,
+		endpoint: async () => ({ options: [name, 'Other server'] })
+	};
+	const view = await render(FiltersDrawer, props);
+	const select = page.getByRole('combobox');
+	await select.click({ position: { x: 5, y: 5 } });
+	await page.getByRole('button', { name, exact: true }).click();
+	await expect.element(select).toHaveTextContent(name);
+	await expect.element(page.getByRole('button', { name: 'Clear', exact: true })).toBeVisible();
+	await select.click({ position: { x: 5, y: 5 } });
+	await page.getByRole('button', { name: 'Other server', exact: true }).click();
+	await expect.element(select).toHaveTextContent('Other server');
+	await page.getByRole('button', { name: 'Apply Filters' }).click();
+	const applied = new URL(vi.mocked(goto).mock.calls[0][0].toString());
+	expect(JSON.parse(applied.searchParams.get('mcp_server')!)).toEqual(['Other server', name]);
+	expect(props.onClose).toHaveBeenCalledOnce();
+
+	await view.unmount();
+	await render(FiltersDrawer, {
+		...props,
+		filters: { mcp_server: applied.searchParams.get('mcp_server')! }
+	});
+	await expect.element(select).toHaveTextContent(name);
+	await expect.element(select).toHaveTextContent('Other server');
+	await select.click({ position: { x: 5, y: 5 } });
+	await page.getByRole('button', { name, exact: true }).click();
+	await expect.element(select).not.toHaveTextContent(name);
+	await expect.element(select).toHaveTextContent('Other server');
+	await select.click({ position: { x: 5, y: 5 } });
+	await page.getByRole('button', { name, exact: true }).click();
+	await select.getByRole('textbox').click();
+	await userEvent.keyboard('{Backspace}');
+	await expect.element(select).not.toHaveTextContent('Other server');
+	await expect.element(select).toHaveTextContent(name);
+	await select.getByRole('button').click();
+	await expect.element(select).not.toHaveTextContent(name);
+});

--- a/ui/user/src/lib/multiValue.spec.ts
+++ b/ui/user/src/lib/multiValue.spec.ts
@@ -1,0 +1,15 @@
+import { parseMultiValue, serializeMultiValue } from './multiValue';
+import { expect, test } from 'vitest';
+
+test('round trips names without treating punctuation or whitespace as separators', () => {
+	const values = ['Outlook, Calendar', 'A "quoted" \\ server', ' spaced ', '[server]'];
+	expect(parseMultiValue(serializeMultiValue(values))).toEqual(values);
+	expect(parseMultiValue(serializeMultiValue([]))).toEqual([]);
+});
+
+test('keeps existing comma-separated URLs and malformed JSON readable', () => {
+	expect(parseMultiValue('one, two,,three')).toEqual(['one', 'two', 'three']);
+	expect(parseMultiValue('[server]')).toEqual(['[server]']);
+	expect(parseMultiValue('[123]')).toEqual(['[123]']);
+	expect(parseMultiValue(null)).toEqual([]);
+});

--- a/ui/user/src/lib/multiValue.ts
+++ b/ui/user/src/lib/multiValue.ts
@@ -1,0 +1,20 @@
+// Accept existing comma-separated URLs as well as lossless JSON string arrays.
+export function parseMultiValue(value: string | number | null | undefined): string[] {
+	const text = String(value ?? '');
+	try {
+		const values: unknown = JSON.parse(text);
+		if (Array.isArray(values) && values.every((item) => typeof item === 'string')) {
+			return values.filter(Boolean);
+		}
+	} catch {
+		// Existing URLs use comma-separated values.
+	}
+	return text
+		.split(',')
+		.map((item) => item.trim())
+		.filter(Boolean);
+}
+
+export function serializeMultiValue(values: (string | number)[]): string {
+	return values.length ? JSON.stringify(values.map(String)) : '';
+}


### PR DESCRIPTION
Preserve complete MCP server names across audit log selection, filtering, and exports so names such as Outlook, Calendar match the intended logs. Accept JSON arrays alongside existing comma-separated filter URLs.

Issue: https://github.com/obot-platform/obot/issues/7851
