### PR TITLE
fix(vmcp): remove static configuration from vMCP setup

### DIFF
--- a/pkg/api/handlers/vmcp.go
+++ b/pkg/api/handlers/vmcp.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/obot-platform/obot/apiclient/types"
 	"github.com/obot-platform/obot/pkg/accesscontrolrule"
@@ -253,21 +254,28 @@ func (h *VMCPHandler) loadComponentSnapshots(req api.Context, manifest *types.VM
 			if component.Name == "" {
 				component.Name = previous.Name
 			}
-			continue
-		}
-		component.MCPCatalogID = entry.Spec.MCPCatalogName
-		component.CatalogEntry = types.MCPServerCatalogEntrySnapshot{
-			Manifest:         entry.Spec.Manifest,
-			UnsupportedTools: entry.Spec.UnsupportedTools,
-		}
-		component.SourceDigest = utils.Digest(component.CatalogEntry)
-		component.OAuthCredentialID = vmcpconfig.StaticOAuthCredentialReference(entry.Spec.Manifest, entry.Name)
-		if component.Name == "" {
-			component.Name = entry.Spec.Manifest.Name
+		} else {
+			component.MCPCatalogID = entry.Spec.MCPCatalogName
+			component.CatalogEntry = types.MCPServerCatalogEntrySnapshot{
+				Manifest:         entry.Spec.Manifest,
+				UnsupportedTools: entry.Spec.UnsupportedTools,
+			}
+			component.SourceDigest = utils.Digest(component.CatalogEntry)
+			component.OAuthCredentialID = vmcpconfig.StaticOAuthCredentialReference(entry.Spec.Manifest, entry.Name)
 			if component.Name == "" {
-				component.Name = entry.Name
+				component.Name = entry.Spec.Manifest.Name
+				if component.Name == "" {
+					component.Name = entry.Name
+				}
 			}
 		}
+		static := map[string]bool{}
+		for _, field := range component.CatalogEntry.Manifest.Config {
+			static[field.Key] = field.Value != ""
+		}
+		component.Configuration = slices.DeleteFunc(component.Configuration, func(policy types.VMCPConfigurationPolicy) bool {
+			return static[policy.Key]
+		})
 	}
 	return nil
 }
@@ -301,6 +309,28 @@ func vmcpConfiguration(components []types.VMCPComponent, secrets map[string]stri
 }
 
 func convertVMCP(vmcp v1.VMCP) types.VMCP {
+	manifest := vmcp.Spec.Manifest
+	manifest.Components = slices.Clone(manifest.Components)
+	for i := range manifest.Components {
+		component := &manifest.Components[i]
+		component.CatalogEntry.Manifest.Config = slices.Clone(component.CatalogEntry.Manifest.Config)
+		sensitive := map[string]bool{}
+		for i := range component.CatalogEntry.Manifest.Config {
+			field := &component.CatalogEntry.Manifest.Config[i]
+			sensitive[field.Key] = field.Sensitive
+			if field.Sensitive && field.Value != "" {
+				field.Value = "******"
+			}
+		}
+		component.Configuration = slices.Clone(component.Configuration)
+		for i := range component.Configuration {
+			policy := &component.Configuration[i]
+			if sensitive[policy.Key] && policy.Value != "" {
+				policy.Value = "******"
+			}
+		}
+	}
+
 	componentStatuses := make([]types.VMCPComponentStatus, 0, len(vmcp.Status.Components))
 	for _, status := range vmcp.Status.Components {
 		componentStatuses = append(componentStatuses, types.VMCPComponentStatus{
@@ -314,7 +344,7 @@ func convertVMCP(vmcp v1.VMCP) types.VMCP {
 	return types.VMCP{
 		LegacySlug:              vmcp.Spec.LegacySlug,
 		Metadata:                MetadataFrom(&vmcp),
-		VMCPManifest:            vmcp.Spec.Manifest,
+		VMCPManifest:            manifest,
 		UserID:                  vmcp.Spec.UserID,
 		StaticConfigurationHash: vmcp.Spec.StaticConfigurationHash,
 		Status: types.VMCPStatus{

--- a/pkg/api/handlers/vmcp.go
+++ b/pkg/api/handlers/vmcp.go
@@ -271,7 +271,7 @@ func (h *VMCPHandler) loadComponentSnapshots(req api.Context, manifest *types.VM
 		}
 		static := map[string]bool{}
 		for _, field := range component.CatalogEntry.Manifest.Config {
-			static[field.Key] = field.Value != ""
+			static[field.Key] = field.Value != "" || field.SecretBinding != nil
 		}
 		component.Configuration = slices.DeleteFunc(component.Configuration, func(policy types.VMCPConfigurationPolicy) bool {
 			return static[policy.Key]

--- a/pkg/api/handlers/vmcp_test.go
+++ b/pkg/api/handlers/vmcp_test.go
@@ -358,6 +358,33 @@ func TestVMCPHandlerCreateStoresStaticConfigurationInCredential(t *testing.T) {
 	}
 }
 
+func TestConvertVMCPRedactsSensitiveConfigurationValues(t *testing.T) {
+	vmcp := v1.VMCP{Spec: v1.VMCPSpec{Manifest: types.VMCPManifest{Components: []types.VMCPComponent{{
+		Configuration: []types.VMCPConfigurationPolicy{
+			{Key: "SECRET", Value: "policy-secret"},
+			{Key: "REGION", Value: "policy-value"},
+		},
+		CatalogEntry: types.MCPServerCatalogEntrySnapshot{Manifest: types.MCPServerCatalogEntryManifest{
+			Config: []types.MCPConfig{
+				{Key: "SECRET", Sensitive: true, Value: "catalog-secret"},
+				{Key: "REGION", Value: "catalog-value"},
+			},
+		}},
+	}}}}}
+
+	converted := convertVMCP(vmcp)
+	if converted.Components[0].Configuration[0].Value != "******" ||
+		converted.Components[0].Configuration[1].Value != "policy-value" ||
+		converted.Components[0].CatalogEntry.Manifest.Config[0].Value != "******" ||
+		converted.Components[0].CatalogEntry.Manifest.Config[1].Value != "catalog-value" {
+		t.Fatal("configuration values were not filtered correctly")
+	}
+	if vmcp.Spec.Manifest.Components[0].Configuration[0].Value != "policy-secret" ||
+		vmcp.Spec.Manifest.Components[0].CatalogEntry.Manifest.Config[0].Value != "catalog-secret" {
+		t.Fatal("source VMCP was mutated")
+	}
+}
+
 func TestVMCPHandlerUpdatePreservesStaticConfiguration(t *testing.T) {
 	storage := newVMCPTestStorage(vmcpCatalogEntryForTest("entry"))
 	gatewayClient := newHandlerTestGateway(t)
@@ -905,6 +932,7 @@ func vmcpHandlerForTest(t *testing.T, storage kclient.Client) *VMCPHandler {
 func TestVMCPComponentSnapshots(t *testing.T) {
 	entry := vmcpCatalogEntryForTest("entry")
 	entry.Spec.Manifest.RemoteConfig = &types.RemoteCatalogConfig{StaticOAuthRequired: true, FixedURL: "https://example.com/mcp"}
+	entry.Spec.Manifest.Config = []types.MCPConfig{{Key: "STATIC", Value: "catalog-value", Usage: types.Env}}
 	storage := newVMCPTestStorage(entry)
 	handler := vmcpHandlerForTest(t, storage)
 	gatewayClient := newHandlerTestGateway(t)
@@ -914,8 +942,12 @@ func TestVMCPComponentSnapshots(t *testing.T) {
 	manifest.Components[0].CatalogEntry.Manifest.Name = "forged-snapshot"
 	manifest.Components[0].SourceDigest = "forged-digest"
 	manifest.Components[0].OAuthCredentialID = "forged-credential"
+	manifest.Components[0].Configuration = []types.VMCPConfigurationPolicy{{Key: "STATIC", Policy: types.VMCPConfigurationPolicyFixed, Value: "override"}}
 	created := callVMCPCreate(t, storage, gatewayClient, handler, manifest, u)
 	component := created.Components[0]
+	if len(component.Configuration) != 0 || component.CatalogEntry.Manifest.Config[0].Value != "catalog-value" {
+		t.Fatalf("catalog static configuration was overridden: %#v", component)
+	}
 	if component.OAuthCredentialID != system.MCPOAuthCredentialName(entry.Name) {
 		t.Fatalf("incorrect OAuth reference: %q", component.OAuthCredentialID)
 	}
@@ -930,7 +962,10 @@ func TestVMCPComponentSnapshots(t *testing.T) {
 		t.Fatal(err)
 	}
 	// An update needs only the entry ID and the stable component identity, not a snapshot or catalog ID.
-	manifest.Components[0] = types.VMCPComponent{ID: component.ID, MCPServerCatalogEntryID: entry.Name}
+	manifest.Components[0] = types.VMCPComponent{
+		ID: component.ID, MCPServerCatalogEntryID: entry.Name,
+		Configuration: []types.VMCPConfigurationPolicy{{Key: "STATIC", Policy: types.VMCPConfigurationPolicyUserAllowed}},
+	}
 	body, err := json.Marshal(manifest)
 	if err != nil {
 		t.Fatal(err)
@@ -951,6 +986,9 @@ func TestVMCPComponentSnapshots(t *testing.T) {
 		t.Fatal(err)
 	}
 	updated := stored.Spec.Manifest.Components[0]
+	if len(updated.Configuration) != 0 || updated.CatalogEntry.Manifest.Config[0].Value != "catalog-value" {
+		t.Fatalf("catalog static configuration was overridden during update: %#v", updated)
+	}
 	if updated.SourceDigest != component.SourceDigest || updated.CatalogEntry.Manifest.Name != component.CatalogEntry.Manifest.Name || updated.OAuthCredentialID != component.OAuthCredentialID {
 		t.Fatalf("ordinary update refreshed the snapshot: %#v", updated)
 	}

--- a/pkg/api/handlers/vmcp_test.go
+++ b/pkg/api/handlers/vmcp_test.go
@@ -932,7 +932,10 @@ func vmcpHandlerForTest(t *testing.T, storage kclient.Client) *VMCPHandler {
 func TestVMCPComponentSnapshots(t *testing.T) {
 	entry := vmcpCatalogEntryForTest("entry")
 	entry.Spec.Manifest.RemoteConfig = &types.RemoteCatalogConfig{StaticOAuthRequired: true, FixedURL: "https://example.com/mcp"}
-	entry.Spec.Manifest.Config = []types.MCPConfig{{Key: "STATIC", Value: "catalog-value", Usage: types.Env}}
+	entry.Spec.Manifest.Config = []types.MCPConfig{
+		{Key: "STATIC", Value: "catalog-value", Usage: types.Env},
+		{Key: "BOUND", SecretBinding: &types.MCPSecretBinding{Name: "config", Key: "token"}, Usage: types.Env},
+	}
 	storage := newVMCPTestStorage(entry)
 	handler := vmcpHandlerForTest(t, storage)
 	gatewayClient := newHandlerTestGateway(t)
@@ -942,7 +945,10 @@ func TestVMCPComponentSnapshots(t *testing.T) {
 	manifest.Components[0].CatalogEntry.Manifest.Name = "forged-snapshot"
 	manifest.Components[0].SourceDigest = "forged-digest"
 	manifest.Components[0].OAuthCredentialID = "forged-credential"
-	manifest.Components[0].Configuration = []types.VMCPConfigurationPolicy{{Key: "STATIC", Policy: types.VMCPConfigurationPolicyFixed, Value: "override"}}
+	manifest.Components[0].Configuration = []types.VMCPConfigurationPolicy{
+		{Key: "STATIC", Policy: types.VMCPConfigurationPolicyFixed, Value: "override"},
+		{Key: "BOUND", Policy: types.VMCPConfigurationPolicyUserAllowed},
+	}
 	created := callVMCPCreate(t, storage, gatewayClient, handler, manifest, u)
 	component := created.Components[0]
 	if len(component.Configuration) != 0 || component.CatalogEntry.Manifest.Config[0].Value != "catalog-value" {
@@ -964,7 +970,10 @@ func TestVMCPComponentSnapshots(t *testing.T) {
 	// An update needs only the entry ID and the stable component identity, not a snapshot or catalog ID.
 	manifest.Components[0] = types.VMCPComponent{
 		ID: component.ID, MCPServerCatalogEntryID: entry.Name,
-		Configuration: []types.VMCPConfigurationPolicy{{Key: "STATIC", Policy: types.VMCPConfigurationPolicyUserAllowed}},
+		Configuration: []types.VMCPConfigurationPolicy{
+			{Key: "STATIC", Policy: types.VMCPConfigurationPolicyUserAllowed},
+			{Key: "BOUND", Policy: types.VMCPConfigurationPolicyFixed, Value: "override"},
+		},
 	}
 	body, err := json.Marshal(manifest)
 	if err != nil {

--- a/ui/user/src/lib/components/vmcps/VMcpComponentConfigurationDialog.svelte
+++ b/ui/user/src/lib/components/vmcps/VMcpComponentConfigurationDialog.svelte
@@ -84,7 +84,7 @@
 		entry = target;
 		const existing = new Map((options?.configuration ?? []).map((policy) => [policy.key, policy]));
 		drafts = catalogConfigurationFields(target)
-			.filter((field) => !field.value)
+			.filter((field) => !field.value && !field.secretBinding)
 			.toSorted((a, b) => Number(Boolean(b.required)) - Number(Boolean(a.required)))
 			.map((field) => {
 				const policy = existing.get(field.key);

--- a/ui/user/src/lib/components/vmcps/VMcpComponentConfigurationDialog.svelte
+++ b/ui/user/src/lib/components/vmcps/VMcpComponentConfigurationDialog.svelte
@@ -84,6 +84,7 @@
 		entry = target;
 		const existing = new Map((options?.configuration ?? []).map((policy) => [policy.key, policy]));
 		drafts = catalogConfigurationFields(target)
+			.filter((field) => !field.value)
 			.toSorted((a, b) => Number(Boolean(b.required)) - Number(Boolean(a.required)))
 			.map((field) => {
 				const policy = existing.get(field.key);

--- a/ui/user/src/lib/components/vmcps/VMcpComponentConfigurationDialog.svelte.spec.ts
+++ b/ui/user/src/lib/components/vmcps/VMcpComponentConfigurationDialog.svelte.spec.ts
@@ -82,7 +82,12 @@ describe('VMcpComponentConfigurationDialog.svelte', () => {
 			configurableEntry({
 				config: [
 					field({ key: 'SECRET', name: 'Secret', sensitive: true, value: '******' }),
-					field({ key: 'REGION', name: 'Region', value: 'us-east-1' })
+					field({ key: 'REGION', name: 'Region', value: 'us-east-1' }),
+					field({
+						key: 'BOUND',
+						name: 'Bound',
+						secretBinding: { name: 'config', key: 'token' }
+					})
 				]
 			})
 		);
@@ -92,6 +97,9 @@ describe('VMcpComponentConfigurationDialog.svelte', () => {
 			.not.toBeInTheDocument();
 		await expect
 			.element(page.getByRole('combobox', { name: 'Region policy' }))
+			.not.toBeInTheDocument();
+		await expect
+			.element(page.getByRole('combobox', { name: 'Bound policy' }))
 			.not.toBeInTheDocument();
 		await page.getByRole('button', { name: 'Next' }).click();
 		expect(onNext).toHaveBeenCalledWith([], false);

--- a/ui/user/src/lib/components/vmcps/VMcpComponentConfigurationDialog.svelte.spec.ts
+++ b/ui/user/src/lib/components/vmcps/VMcpComponentConfigurationDialog.svelte.spec.ts
@@ -74,6 +74,29 @@ describe('VMcpComponentConfigurationDialog.svelte', () => {
 		expect(onNext).not.toHaveBeenCalled();
 	});
 
+	it('hides configuration with static values', async () => {
+		await preparePageData();
+		const onNext = vi.fn();
+		const result = await render(VMcpComponentConfigurationDialog, { onNext });
+		result.component.open(
+			configurableEntry({
+				config: [
+					field({ key: 'SECRET', name: 'Secret', sensitive: true, value: '******' }),
+					field({ key: 'REGION', name: 'Region', value: 'us-east-1' })
+				]
+			})
+		);
+
+		await expect
+			.element(page.getByRole('combobox', { name: 'Secret policy' }))
+			.not.toBeInTheDocument();
+		await expect
+			.element(page.getByRole('combobox', { name: 'Region policy' }))
+			.not.toBeInTheDocument();
+		await page.getByRole('button', { name: 'Next' }).click();
+		expect(onNext).toHaveBeenCalledWith([], false);
+	});
+
 	it('shows a value field when Fixed is selected and submits policies on Next', async () => {
 		await preparePageData();
 		const onNext = vi.fn();


### PR DESCRIPTION
If a catalog entry has static configuration, then a user create a vMCP shouldn't have the ability to set that configuration. This change ensures that is the case.

Issue: https://github.com/obot-platform/security-issues/issues/78